### PR TITLE
Fix cargo fmt formatting issues

### DIFF
--- a/src/commands/note.rs
+++ b/src/commands/note.rs
@@ -1,8 +1,8 @@
 //! Note command: append to persistent notes file
 
+use crate::tui::app::App;
 use std::fs;
 use std::io::Write;
-use crate::tui::app::App;
 
 use super::CommandResult;
 
@@ -25,9 +25,7 @@ pub fn note(app: &mut App, content: Option<&str>) -> CommandResult {
     // Ensure parent directory exists
     if let Some(parent) = notes_path.parent() {
         if let Err(e) = fs::create_dir_all(parent) {
-            return CommandResult::error(format!(
-                "Failed to create notes directory: {e}"
-            ));
+            return CommandResult::error(format!("Failed to create notes directory: {e}"));
         }
     }
 
@@ -39,21 +37,14 @@ pub fn note(app: &mut App, content: Option<&str>) -> CommandResult {
     {
         Ok(f) => f,
         Err(e) => {
-            return CommandResult::error(format!(
-                "Failed to open notes file: {e}"
-            ));
+            return CommandResult::error(format!("Failed to open notes file: {e}"));
         }
     };
 
     // Write separator and note content
     if let Err(e) = writeln!(file, "\n---\n{}", note_content) {
-        return CommandResult::error(format!(
-            "Failed to write note: {e}"
-        ));
+        return CommandResult::error(format!("Failed to write note: {e}"));
     }
 
-    CommandResult::message(format!(
-        "Note appended to {}",
-        notes_path.display()
-    ))
+    CommandResult::message(format!("Note appended to {}", notes_path.display()))
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -186,7 +186,10 @@ impl Settings {
         vec![
             ("theme", "Color theme: default, dark, light"),
             ("auto_compact", "Auto-compact conversations: on/off"),
-            ("auto_rlm", "Auto-switch to RLM mode for large inputs: on/off"),
+            (
+                "auto_rlm",
+                "Auto-switch to RLM mode for large inputs: on/off",
+            ),
             ("show_thinking", "Show model thinking: on/off"),
             ("show_tool_details", "Show detailed tool output: on/off"),
             ("default_mode", "Default mode: agent, plan, yolo, rlm, duo"),


### PR DESCRIPTION
## Summary
- Fix cargo fmt CI failure in src/commands/note.rs and src/settings.rs

## Test plan
- [x] `cargo fmt --all -- --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)