### PR TITLE
release: deepseek-tui 0.4.7 + Devin .env empty-key fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@
 
 # DeepSeek API (default provider)
 # Get an API key from DeepSeek, then keep it local in `.env`.
-DEEPSEEK_API_KEY=
+# DEEPSEEK_API_KEY=
 
 # Global endpoint:
 # DEEPSEEK_BASE_URL=https://api.deepseek.com

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,7 +806,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-agent"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "deepseek-config",
  "serde",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-app-server"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "axum",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-config"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "dirs",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-core"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-execpolicy"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "deepseek-protocol",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-hooks"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-mcp"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "deepseek-protocol",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-protocol"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "serde",
  "serde_json",
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-state"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-tools"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -933,7 +933,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-tui"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "arboard",
@@ -987,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-tui-cli"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-tui-core"
-version = "0.4.6"
+version = "0.4.7"
 
 [[package]]
 name = "deranged"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ default-members = ["crates/cli", "crates/app-server", "crates/tui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.6"
+version = "0.4.7"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/Hmbown/DeepSeek-TUI"

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -728,7 +728,9 @@ fn apply_env_overrides(config: &mut Config) {
     if let Ok(value) = std::env::var("DEEPSEEK_PROVIDER") {
         config.provider = Some(value);
     }
-    if let Ok(value) = std::env::var("DEEPSEEK_API_KEY") {
+    if let Ok(value) = std::env::var("DEEPSEEK_API_KEY")
+        && !value.trim().is_empty()
+    {
         config.api_key = Some(value);
     }
     if let Ok(value) = std::env::var("DEEPSEEK_BASE_URL") {
@@ -1550,6 +1552,39 @@ mod tests {
     #[test]
     fn test_missing_api_key_allowed() -> Result<()> {
         let config = Config::default();
+        config.validate()?;
+        Ok(())
+    }
+
+    #[test]
+    fn apply_env_overrides_ignores_empty_api_key() -> Result<()> {
+        let _lock = lock_test_env();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let temp_root = env::temp_dir().join(format!(
+            "deepseek-tui-empty-key-{}-{}",
+            std::process::id(),
+            nanos
+        ));
+        fs::create_dir_all(&temp_root)?;
+        let _guard = EnvGuard::new(&temp_root);
+
+        // Simulate a fresh user who copied .env.example to .env without
+        // filling in DEEPSEEK_API_KEY: dotenv loads it as the empty string.
+        // Safety: test-only environment mutation guarded by a global mutex.
+        unsafe {
+            env::set_var("DEEPSEEK_API_KEY", "");
+        }
+
+        let mut config = Config {
+            api_key: Some("from-config-file".to_string()),
+            ..Default::default()
+        };
+        apply_env_overrides(&mut config);
+
+        assert_eq!(config.api_key.as_deref(), Some("from-config-file"));
         config.validate()?;
         Ok(())
     }

--- a/npm/deepseek-tui/package.json
+++ b/npm/deepseek-tui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-tui",
-  "version": "0.4.6",
-  "deepseekBinaryVersion": "0.4.6",
+  "version": "0.4.7",
+  "deepseekBinaryVersion": "0.4.7",
   "description": "Install and run deepseek and deepseek-tui binaries from GitHub release artifacts.",
   "author": "Hmbown",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bumps workspace + npm wrapper version `0.4.6` → `0.4.7` so the release workflow can ship a fresh tag (the prior `v0.4.6` release run failed at the parity gate; that tag is intentionally left in place).
- Fixes the `.env.example` / `apply_env_overrides` bug Devin flagged on [PR #18](https://github.com/Hmbown/DeepSeek-TUI/pull/18#discussion).

## Bug fix
A new user following `setup --status` guidance (`cp .env.example .env`) would hit a startup crash:

1. `.env.example:7` had an uncommented `DEEPSEEK_API_KEY=` placeholder.
2. `dotenvy::dotenv()` loaded the empty value into the process env.
3. `apply_env_overrides` (`crates/tui/src/config.rs`) unconditionally set `config.api_key = Some("")`.
4. `Config::validate()` then bailed with `api_key cannot be empty string`.

The facade crate (`crates/config/src/lib.rs:557-559`) already filters empty values; the TUI's override path did not. This PR aligns the two and comments out the placeholder.

## Changes
- `.env.example`: `DEEPSEEK_API_KEY=` → `# DEEPSEEK_API_KEY=`.
- `crates/tui/src/config.rs::apply_env_overrides`: only override `config.api_key` when the env value is non-empty after trim.
- New regression test `apply_env_overrides_ignores_empty_api_key`.
- `Cargo.toml`, `Cargo.lock`, `npm/deepseek-tui/package.json` (`version` + `deepseekBinaryVersion`) bumped to `0.4.7`.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- [x] `cargo test --workspace --all-features --locked` — 781 passed (one new regression test)
- [x] Release gate workflow expected to pass on the resulting `v0.4.7` tag (parity broke previously on fmt; main HEAD is fmt-clean since #18).

After merge, push tag `v0.4.7` to trigger the release workflow which builds platform binaries, creates a GH release, and publishes the npm wrapper via OIDC Trusted Publishing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hmbown/deepseek-tui/pull/19" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
