### PR TITLE
fix(client): TCP/HTTP2 keepalives + stream-error diagnostics (#103 Phase 1+2)

### DIFF
--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -444,7 +444,13 @@ impl DeepSeekClient {
         reqwest::Client::builder()
             .default_headers(headers)
             .connect_timeout(Duration::from_secs(30))
-            .timeout(Duration::from_secs(300))
+            // The blanket 300s request timeout was incompatible with V4-pro
+            // thinking turns that legitimately exceed that wall-clock window
+            // (see #103). Drop it; per-chunk and per-stream guards in
+            // engine.rs already bound how long we'll wait without progress.
+            .tcp_keepalive(Some(Duration::from_secs(30)))
+            .http2_keep_alive_interval(Some(Duration::from_secs(15)))
+            .http2_keep_alive_timeout(Duration::from_secs(20))
             .min_tls_version(reqwest::tls::Version::TLS_1_2)
             .build()
             .map_err(Into::into)

--- a/crates/tui/src/client/chat.rs
+++ b/crates/tui/src/client/chat.rs
@@ -196,6 +196,15 @@ impl DeepSeekClient {
             let mut byte_stream = std::pin::pin!(byte_stream);
             let idle = stream_idle_timeout();
 
+            // Telemetry for #103 stream-decode diagnostics: bytes received
+            // since the start of this stream and last successful event time.
+            // Surfaces in the error log when reqwest yields a chunk error so
+            // we can tell HTTP/2 RST_STREAM from chunk-decode-failure from
+            // gzip-corruption when investigating a flaky session.
+            let stream_start = std::time::Instant::now();
+            let mut last_event_at = std::time::Instant::now();
+            let mut bytes_received: usize = 0;
+
             loop {
                 let chunk_result = match tokio_timeout(idle, byte_stream.next()).await {
                     Ok(Some(result)) => result,
@@ -211,11 +220,31 @@ impl DeepSeekClient {
                 let chunk = match chunk_result {
                     Ok(bytes) => bytes,
                     Err(e) => {
+                        // Walk the error source chain so reqwest's underlying
+                        // hyper / h2 / io error is visible — without this the
+                        // outer "error decoding response body" message tells
+                        // us nothing about WHY the stream died.
+                        let mut error_chain = format!("{e}");
+                        let mut current: Option<&(dyn std::error::Error + 'static)> =
+                            std::error::Error::source(&e);
+                        while let Some(source) = current {
+                            error_chain.push_str(&format!(" -> {source}"));
+                            current = std::error::Error::source(source);
+                        }
+                        crate::logging::warn(format!(
+                            "Stream read error: {error_chain} \
+                             (elapsed: {}ms, bytes_received: {}, ms_since_last_event: {})",
+                            stream_start.elapsed().as_millis(),
+                            bytes_received,
+                            last_event_at.elapsed().as_millis(),
+                        ));
                         yield Err(anyhow::anyhow!("Stream read error: {e}"));
                         break;
                     }
                 };
 
+                bytes_received = bytes_received.saturating_add(chunk.len());
+                last_event_at = std::time::Instant::now();
                 byte_buf.extend_from_slice(&chunk);
 
                 // Guard against unbounded buffer growth (e.g., malformed stream without newlines)


### PR DESCRIPTION
Phase 1 + 2 of #103. The transparent-retry / prefix-continuation work (Phase 3) is intentionally split off so this PR can ship the diagnostic-and-resilience floor independently.

## What this PR does

### Transport tuning (`client.rs`)
- Drop the blanket 300s request timeout (long V4-pro thinking turns legitimately exceed it; per-chunk and per-stream guards in `engine.rs` already bound how long we wait without progress).
- Add `tcp_keepalive(30s)` so dead-peer detection happens at the TCP layer.
- Add `http2_keep_alive_interval(15s)` + `http2_keep_alive_timeout(20s)` so HTTP/2 connections don't go silent and get killed by upstream proxies mid-thinking.

### Stream-error diagnostics (`client/chat.rs`)
- Walk \`std::error::Error::source()\` recursively when reqwest yields a chunk error, so the underlying hyper / h2 / io error is logged.
- Track \`bytes_received\`, \`stream_start.elapsed()\`, and \`ms_since_last_event\`; log alongside the error chain. Lets us distinguish HTTP/2 RST_STREAM mid-idle from chunk-decode-failure on a short stream from gzip-corruption mid-burst.

## What's NOT in this PR

Phase 3 — transparent retry with DeepSeek's prefix-continuation API. That requires:
- A \`prefix: Option<bool>\` flag plumbed through \`MessageRequest\` (or the assistant Message — DeepSeek's beta endpoint puts it on the message).
- Wire-format support in \`chat.rs\` to set \`\"prefix\": true\` on the last assistant message when the flag is set.
- Engine retry loop that flips the flag on stream error outside a tool block, restarts the request, and resumes from the partial assistant content.

Each of those is a meaningful review surface and worth its own PR. This PR keeps the diagnostic-and-resilience improvements unblocked.

## Acceptance

- 995 tests pass on the tui crate.
- Workspace clippy clean with \`-D warnings\`.
- A 30-minute heavy-tool session should surface \"Stream read error\" less often (TCP/HTTP2 keepalives prevent silent connection death). When it does surface, the log line shows the full error chain + transport stats so the next investigation has data to work with.

Refs #103.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hmbown/deepseek-tui/pull/106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
