### PR TITLE
fix(engine): transparent retry on stream death with no content (#103 Phase 3)

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -2022,6 +2022,16 @@ impl Engine {
         }
         let mut active_tool_names = initial_active_tools(&tool_catalog);
 
+        // Transparent stream-retry counter: when the chunked-transfer
+        // connection dies mid-stream and we got nothing useful out of it
+        // (no tool calls, no completed text), we silently re-issue the
+        // SAME request up to MAX_STREAM_RETRIES times before surfacing
+        // the failure to the user. This is the #103 Phase 3 retry that
+        // keeps long V4 thinking turns from being killed by transient
+        // proxy disconnects.
+        const MAX_STREAM_RETRIES: u32 = 3;
+        let mut stream_retry_attempts: u32 = 0;
+
         loop {
             if self.cancel_token.is_cancelled() {
                 let _ = self.tx_event.send(Event::status("Request cancelled")).await;
@@ -2564,6 +2574,49 @@ impl Engine {
                     }
                     StreamEvent::MessageStop | StreamEvent::Ping => {}
                 }
+            }
+
+            // #103 Phase 3 — transparent retry. The inner loop above bails
+            // when reqwest yields chunk decode errors three times in a row;
+            // most of the time those are recoverable proxy / HTTP/2 issues
+            // and the request can simply be re-issued. Re-issue silently up
+            // to MAX_STREAM_RETRIES, but only when the stream produced
+            // nothing actionable — if any tool call landed or text was
+            // streamed, ship the partial state to the rest of the turn
+            // pipeline so we don't double-bill the user by re-running it.
+            let stream_died_with_nothing = stream_errors > 0
+                && tool_uses.is_empty()
+                && current_text_visible.trim().is_empty()
+                && current_thinking.trim().is_empty()
+                && !pending_message_complete;
+            if stream_died_with_nothing {
+                if stream_retry_attempts < MAX_STREAM_RETRIES {
+                    stream_retry_attempts = stream_retry_attempts.saturating_add(1);
+                    crate::logging::warn(format!(
+                        "Stream died with no content (attempt {}/{}); retrying request",
+                        stream_retry_attempts, MAX_STREAM_RETRIES
+                    ));
+                    let _ = self
+                        .tx_event
+                        .send(Event::status(format!(
+                            "Connection interrupted; retrying ({}/{})",
+                            stream_retry_attempts, MAX_STREAM_RETRIES
+                        )))
+                        .await;
+                    // Don't preserve the per-stream `turn_error` — we're
+                    // about to retry, and a successful retry should not
+                    // surface the transient error as the turn outcome.
+                    turn_error = None;
+                    continue;
+                }
+                crate::logging::warn(format!(
+                    "Stream retry budget exhausted ({} attempts); failing turn",
+                    stream_retry_attempts
+                ));
+            } else if stream_errors == 0 {
+                // Healthy round → reset retry budget so we don't carry over
+                // state from a previous bad round.
+                stream_retry_attempts = 0;
             }
 
             // Update turn usage


### PR DESCRIPTION
Phase 3 of #103 — closes the user-visible loop. When the chunked-transfer connection to DeepSeek dies mid-stream and we got nothing useful out of it, the engine now silently re-issues the same request up to 3 times before surfacing a failure.

## What changed

`crates/tui/src/core/engine.rs` — after the inner stream-consumption loop, detect "stream died with nothing actionable":

| Condition | Why |
|---|---|
| \`stream_errors > 0\` | Stream errored at some point |
| \`tool_uses.is_empty()\` | No tool call landed |
| \`current_text_visible\` whitespace | No visible text emitted |
| \`current_thinking\` whitespace | No reasoning content emitted |
| \`!pending_message_complete\` | No completed text block |

If all hold AND \`stream_retry_attempts < MAX_STREAM_RETRIES\` (3), silently re-issue the same outer-loop iteration. Surface a \`Connection interrupted; retrying (N/3)\` status to the user but DON'T trip the engine-level Error event.

Healthy rounds (\`stream_errors == 0\`) reset the retry budget.

If we got ANY partial output (a tool call, visible text, or reasoning), we DON'T retry — re-running the request would double-bill. Ship the partial state to the rest of the turn pipeline.

## Why this matters

Before this PR: user sees \`Turn failed: Stream read error: error decoding response body\` and has to manually re-send.

After this PR: the engine retries silently up to 3 times. Most flaky-proxy cases recover invisibly. Only persistent failures surface as a turn failure.

Combined with #103 Phase 1+2 (TCP/HTTP2 keepalives + diagnostic logging) the floor is now: keepalives prevent dead-peer detection lag → diagnostics light up the underlying error chain → retry transparently recovers from transient closures.

## Verification

- \`cargo fmt --all -- --check\` ✓
- \`cargo clippy -p deepseek-tui --all-targets --all-features --locked -- -D warnings\` ✓
- \`cargo test -p deepseek-tui --bin deepseek-tui --locked\` 995/995 ✓

## Manual smoke

Hard to deterministically reproduce a chunked-transfer corruption locally, but the retry budget tracking + status events are observable in \`RUST_LOG=deepseek_tui::core::engine=warn deepseek\` — kicked-off long V4-pro thinking turn, watched for \"Stream died with no content (attempt N/3); retrying request\" in logs.

Refs #103.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hmbown/deepseek-tui/pull/114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
