### PR TITLE
fix(tui): context-usage % no longer drops after multi-round turns (#115)

### DIFF
--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -3660,28 +3660,22 @@ fn context_usage_snapshot(app: &App) -> Option<(i64, u32, f64)> {
         .map(|tokens| tokens.max(0));
     let estimated = estimated_context_tokens(app).map(|tokens| tokens.max(0));
 
-    let used = if app.is_loading {
-        match (estimated, reported) {
-            (Some(estimated), _) => estimated,
-            (None, Some(reported)) => reported,
-            (None, None) => return None,
-        }
-    } else {
-        match (reported, estimated) {
-            (Some(reported), Some(estimated))
-                if reported > max_i64 && estimated > 0 && estimated <= max_i64 =>
-            {
-                estimated
-            }
-            (Some(reported), Some(estimated))
-                if is_reported_context_inflated(reported, estimated) =>
-            {
-                estimated
-            }
-            (Some(reported), _) => reported,
-            (None, Some(estimated)) => estimated,
-            (None, None) => return None,
-        }
+    // Always prefer the estimated current-context size (computed from
+    // `app.api_messages`) when we have it. Reported `last_prompt_tokens`
+    // comes from `Event::TurnComplete.usage`, which the engine builds with
+    // `turn.add_usage` — that SUMS input_tokens across every round in the
+    // turn, so a multi-round tool-call turn reports a value much larger
+    // than the actual context window state, then the next single-round
+    // turn drops back to a single round's input_tokens. User-visible %
+    // was bouncing 31% → 9% (#115) because of this. The estimate is
+    // monotonic wrt conversation growth, which is what a "context filling
+    // up" indicator should show. We still consult `reported` only as a
+    // fallback when no estimate is available (e.g., immediately after a
+    // session restore before the api_messages are populated).
+    let used = match (estimated, reported) {
+        (Some(estimated), _) => estimated.min(max_i64),
+        (None, Some(reported)) => reported.min(max_i64),
+        (None, None) => return None,
     };
 
     let max_f64 = f64::from(max);
@@ -3690,6 +3684,11 @@ fn context_usage_snapshot(app: &App) -> Option<(i64, u32, f64)> {
     Some((used, max, percent))
 }
 
+/// Retained as a callable utility — `context_usage_snapshot` no longer uses
+/// it directly (#115 makes the estimate the primary signal), but tests in
+/// `ui/tests.rs` still exercise it and a future heuristic may want to
+/// distinguish "obviously inflated reported tokens" from healthy reports.
+#[allow(dead_code)]
 fn is_reported_context_inflated(reported: i64, estimated: i64) -> bool {
     const MIN_ABSOLUTE_GAP: i64 = 4_096;
     if estimated <= 0 || reported <= estimated {

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -542,6 +542,47 @@ fn context_usage_snapshot_prefers_estimate_when_reported_is_inflated_by_old_reas
     assert!(percent < 2.0);
 }
 
+/// Regression for #115. The engine sums `input_tokens` across every round
+/// of a turn (`turn.add_usage` does `+=`), so a multi-round tool-call turn
+/// reports a value much larger than the actual context window state, then
+/// the next single-round turn drops back to a single round's input_tokens.
+/// User-visible % was bouncing 31% → 9% because of this. The fix is to
+/// prefer the estimated current-context size, which is monotonic wrt
+/// conversation growth.
+#[test]
+fn context_usage_does_not_drop_when_reported_shrinks_after_multi_round_turn() {
+    let mut app = create_test_app();
+    app.api_messages = vec![Message {
+        role: "user".to_string(),
+        content: vec![ContentBlock::Text {
+            text: "context ".repeat(2_000), // ~14k tokens estimated
+            cache_control: None,
+        }],
+    }];
+
+    // Simulate a multi-round turn that summed two rounds' input_tokens
+    // (e.g., 200k + 210k from a long thinking + tool-call sequence).
+    app.last_prompt_tokens = Some(410_000);
+    let (_, _, percent_after_multi_round) =
+        context_usage_snapshot(&app).expect("usage available");
+
+    // Now the next turn is a single round on the same conversation —
+    // reported drops to one round's worth even though the actual context
+    // hasn't shrunk.
+    app.last_prompt_tokens = Some(15_000);
+    let (_, _, percent_after_single_round) =
+        context_usage_snapshot(&app).expect("usage available");
+
+    // The displayed % should reflect the conversation size (estimated
+    // from api_messages), NOT the wildly variable reported value.
+    let drift = (percent_after_multi_round - percent_after_single_round).abs();
+    assert!(
+        drift < 1.0,
+        "displayed % should not jump because reported tokens varied across rounds; \
+         after-multi-round={percent_after_multi_round:.2} after-single-round={percent_after_single_round:.2}"
+    );
+}
+
 #[test]
 fn context_usage_snapshot_prefers_live_estimate_while_loading() {
     let mut app = create_test_app();

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -606,19 +606,35 @@ fn context_usage_snapshot_prefers_live_estimate_while_loading() {
 #[test]
 fn should_auto_compact_before_send_respects_threshold_and_setting() {
     let mut app = create_test_app();
-    app.api_messages = vec![Message {
+    let big_buffer = vec![Message {
         role: "user".to_string(),
         content: vec![ContentBlock::Text {
             text: "context ".repeat(400_000),
             cache_control: None,
         }],
     }];
+
+    // High estimated context + auto_compact ON → auto-compact triggers.
+    app.api_messages = big_buffer.clone();
     app.auto_compact = true;
     assert!(should_auto_compact_before_send(&app));
 
+    // Same high context but auto_compact OFF → never triggers.
     app.auto_compact = false;
     assert!(!should_auto_compact_before_send(&app));
 
+    // Small estimated context + auto_compact ON → does NOT trigger,
+    // regardless of what `last_prompt_tokens` reports. This matches the
+    // #115 fix: the estimate is the primary signal, not the engine's
+    // turn-cumulative reported value (which used to rule the displayed
+    // % and could spuriously trigger / suppress auto-compact).
+    app.api_messages = vec![Message {
+        role: "user".to_string(),
+        content: vec![ContentBlock::Text {
+            text: "small".to_string(),
+            cache_control: None,
+        }],
+    }];
     app.auto_compact = true;
     app.last_prompt_tokens = Some(10_000);
     assert!(!should_auto_compact_before_send(&app));

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -563,15 +563,13 @@ fn context_usage_does_not_drop_when_reported_shrinks_after_multi_round_turn() {
     // Simulate a multi-round turn that summed two rounds' input_tokens
     // (e.g., 200k + 210k from a long thinking + tool-call sequence).
     app.last_prompt_tokens = Some(410_000);
-    let (_, _, percent_after_multi_round) =
-        context_usage_snapshot(&app).expect("usage available");
+    let (_, _, percent_after_multi_round) = context_usage_snapshot(&app).expect("usage available");
 
     // Now the next turn is a single round on the same conversation —
     // reported drops to one round's worth even though the actual context
     // hasn't shrunk.
     app.last_prompt_tokens = Some(15_000);
-    let (_, _, percent_after_single_round) =
-        context_usage_snapshot(&app).expect("usage available");
+    let (_, _, percent_after_single_round) = context_usage_snapshot(&app).expect("usage available");
 
     // The displayed % should reflect the conversation size (estimated
     // from api_messages), NOT the wildly variable reported value.


### PR DESCRIPTION
Fixes #115. User-visible context % was bouncing 31% → 9% across consecutive turns; root cause is that the engine sums \`input_tokens\` across rounds in a turn, so the post-turn reported value reflects how MANY rounds happened, not the actual context window state.

## Root cause

\`context_usage_snapshot\` preferred \`app.last_prompt_tokens\` (reported by the engine in \`Event::TurnComplete.usage\`). That usage object is built by \`turn.add_usage\` which SUMS input_tokens across every round in a turn. A multi-round tool-call turn reports a value much larger than the actual context window state (200k + 210k from a 2-round thinking-and-tool turn = 410k displayed as 31%); the next single-round turn drops back to a single round's input_tokens (90k displayed as 9%).

## Fix

Prefer the **estimate** computed from \`app.api_messages\`. The estimate is monotonic wrt conversation growth, which is what a "context filling up" indicator should display. Reported tokens fall back only when no estimate is available (e.g., immediately after a session restore before \`api_messages\` is populated). Clamp \`used\` to the model's context window so the ratio never exceeds 100%.

\`is_reported_context_inflated\` is no longer in the primary path; gated behind \`#[allow(dead_code)]\` because existing tests still exercise it and a future heuristic may want to distinguish "obviously inflated reported tokens" from healthy reports.

## Regression test

\`context_usage_does_not_drop_when_reported_shrinks_after_multi_round_turn\` simulates the user's exact scenario:

1. Multi-round turn → \`last_prompt_tokens = 410_000\` → snapshot %.
2. Single-round turn on same conversation → \`last_prompt_tokens = 15_000\` → snapshot %.
3. Assert the displayed % drift between the two is < 1.0pp (since the underlying conversation hasn't changed).

## Verification

- 4/4 \`context_usage*\` tests pass on this branch.
- \`cargo build -p deepseek-tui\` clean.

Fixes #115.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hmbown/deepseek-tui/pull/118" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
