### PR TITLE
feat(tui): /statusline picker for configurable footer (#95)

### DIFF
--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -221,6 +221,12 @@ pub const COMMANDS: &[CommandInfo] = &[
         usage: "/config",
     },
     CommandInfo {
+        name: "statusline",
+        aliases: &["status-line", "footer"],
+        description: "Pick which items appear in the footer status line",
+        usage: "/statusline",
+    },
+    CommandInfo {
         name: "yolo",
         aliases: &[],
         description: "Enable YOLO mode (shell + trust + auto-approve)",
@@ -354,6 +360,9 @@ pub fn execute(cmd: &str, app: &mut App) -> CommandResult {
 
         // Config commands
         "config" => config::show_config(app),
+        "statusline" | "status-line" | "footer" => {
+            CommandResult::action(AppAction::OpenStatusPicker)
+        }
         "settings" => config::show_settings(app),
         "yolo" => config::yolo(app),
         "agent" => config::agent_mode(app),

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -45,6 +45,14 @@ pub struct Settings {
     pub max_input_history: usize,
     /// Default model to use
     pub default_model: Option<String>,
+    /// Footer/header status items to render, ordered.
+    ///
+    /// Each entry is a stable id from [`crate::tui::widgets::StatusItem`]
+    /// (see `status_items.rs`). Toggle the set via the `/statusline`
+    /// picker. `mode` and `model` are forced on at resolve time so the
+    /// footer can never drop the always-on items even if the file is
+    /// hand-edited.
+    pub status_items: Vec<String>,
 }
 
 impl Default for Settings {
@@ -65,6 +73,7 @@ impl Default for Settings {
             sidebar_focus: "auto".to_string(),
             max_input_history: 100,
             default_model: None,
+            status_items: crate::tui::widgets::status_items::StatusItem::default_ids(),
         }
     }
 }

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -428,6 +428,10 @@ pub struct App {
     /// until the footer widget consumes it.
     #[allow(dead_code)]
     pub fancy_animations: bool,
+    /// Configurable footer/header items resolved from `Settings::status_items`
+    /// (#95). The `/statusline` picker mutates this in place; the footer
+    /// renderer reads it on every redraw.
+    pub status_items: Vec<crate::tui::widgets::StatusItem>,
     pub show_thinking: bool,
     pub show_tool_details: bool,
     pub composer_density: ComposerDensity,
@@ -679,6 +683,7 @@ impl App {
         let calm_mode = settings.calm_mode;
         let low_motion = settings.low_motion;
         let fancy_animations = settings.fancy_animations;
+        let status_items = crate::tui::widgets::resolve_status_item_ids(&settings.status_items);
         let show_thinking = settings.show_thinking;
         let show_tool_details = settings.show_tool_details;
         let composer_density = ComposerDensity::from_setting(&settings.composer_density);
@@ -776,6 +781,7 @@ impl App {
             calm_mode,
             low_motion,
             fancy_animations,
+            status_items,
             show_thinking,
             show_tool_details,
             composer_density,
@@ -1866,6 +1872,8 @@ pub enum AppAction {
     OpenConfigView,
     /// Open the `/model` two-pane picker (Pro/Flash + Off/High/Max).
     OpenModelPicker,
+    /// Open the `/statusline` configurable footer picker (#95).
+    OpenStatusPicker,
     SendMessage(String),
     ListSubAgents,
     FetchModels,

--- a/crates/tui/src/tui/mod.rs
+++ b/crates/tui/src/tui/mod.rs
@@ -23,6 +23,7 @@ pub mod selection;
 pub mod session_picker;
 pub mod sidebar;
 pub mod slash_menu;
+pub mod status_picker;
 pub mod streaming;
 pub mod transcript;
 pub mod ui;

--- a/crates/tui/src/tui/status_picker.rs
+++ b/crates/tui/src/tui/status_picker.rs
@@ -1,0 +1,346 @@
+//! `/statusline` modal: multi-select picker for footer status items (#95).
+//!
+//! The picker is a single-pane checklist over [`StatusItem::all`]. The user
+//! navigates with `↑↓`, toggles with `Space`, picks all/none with `a` / `n`,
+//! and confirms with `Enter` (or `Esc` to cancel). On apply we emit a
+//! [`ViewEvent::StatusItemsApplied`] carrying the new ordered selection;
+//! the UI handler updates `App.status_items`, persists to
+//! `~/.config/deepseek/settings.toml`, and the next redraw picks up the
+//! new footer composition.
+//!
+//! `Mode` and `Model` are listed so users can see them, but their
+//! checkmarks are locked — toggling them would silently drop information
+//! every footer needs.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::{
+    buffer::Buffer,
+    layout::Rect,
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph, Widget},
+};
+
+use crate::palette;
+use crate::tui::views::{ModalKind, ModalView, ViewAction, ViewEvent};
+use crate::tui::widgets::StatusItem;
+
+pub struct StatusPickerView {
+    /// Every selectable row in fixed order. The picker doesn't reorder
+    /// items — toggling preserves the user's perception of "this list is
+    /// the catalog of available chips."
+    rows: Vec<StatusItem>,
+    /// `selected[i]` is true when `rows[i]` is enabled. Locked rows
+    /// (Mode/Model) are always true and can't be toggled off.
+    selected: Vec<bool>,
+    cursor: usize,
+}
+
+impl StatusPickerView {
+    /// Build a picker pre-populated with the user's current selection.
+    /// Items not in `current` start unchecked; locked items are always on.
+    #[must_use]
+    pub fn new(current: &[StatusItem]) -> Self {
+        let rows: Vec<StatusItem> = StatusItem::all().to_vec();
+        let selected = rows
+            .iter()
+            .map(|item| item.always_on() || current.contains(item))
+            .collect();
+        Self {
+            rows,
+            selected,
+            cursor: 0,
+        }
+    }
+
+    /// Resolve the picker state into the ordered list of enabled items
+    /// (in canonical [`StatusItem::all`] order).
+    #[must_use]
+    pub fn enabled_items(&self) -> Vec<StatusItem> {
+        self.rows
+            .iter()
+            .zip(&self.selected)
+            .filter_map(|(item, on)| if *on { Some(*item) } else { None })
+            .collect()
+    }
+
+    fn move_up(&mut self) {
+        if self.cursor > 0 {
+            self.cursor -= 1;
+        }
+    }
+
+    fn move_down(&mut self) {
+        let max = self.rows.len().saturating_sub(1);
+        if self.cursor < max {
+            self.cursor += 1;
+        }
+    }
+
+    fn toggle(&mut self) {
+        if let Some(item) = self.rows.get(self.cursor)
+            && !item.always_on()
+            && let Some(slot) = self.selected.get_mut(self.cursor)
+        {
+            *slot = !*slot;
+        }
+    }
+
+    fn select_all(&mut self) {
+        for slot in &mut self.selected {
+            *slot = true;
+        }
+    }
+
+    fn select_none(&mut self) {
+        for (item, slot) in self.rows.iter().zip(self.selected.iter_mut()) {
+            *slot = item.always_on();
+        }
+    }
+
+    fn build_event(&self) -> ViewEvent {
+        ViewEvent::StatusItemsApplied {
+            items: self.enabled_items(),
+        }
+    }
+}
+
+impl ModalView for StatusPickerView {
+    fn kind(&self) -> ModalKind {
+        ModalKind::StatusPicker
+    }
+
+    fn handle_key(&mut self, key: KeyEvent) -> ViewAction {
+        // Ctrl+C / Ctrl+D act as cancel mirrors of Esc — terminal users
+        // tend to reach for Ctrl+C first.
+        if (key.code == KeyCode::Char('c') || key.code == KeyCode::Char('d'))
+            && key.modifiers.contains(KeyModifiers::CONTROL)
+        {
+            return ViewAction::Close;
+        }
+
+        match key.code {
+            KeyCode::Esc => ViewAction::Close,
+            KeyCode::Up => {
+                self.move_up();
+                ViewAction::None
+            }
+            KeyCode::Down => {
+                self.move_down();
+                ViewAction::None
+            }
+            KeyCode::Char(' ') => {
+                self.toggle();
+                ViewAction::None
+            }
+            KeyCode::Enter => {
+                // Enter confirms — toggle behaviour was overloaded onto
+                // Space alone so confirm works from any row, including
+                // locked ones. Codex's status_line_setup follows the same
+                // convention.
+                ViewAction::EmitAndClose(self.build_event())
+            }
+            KeyCode::Char('a') | KeyCode::Char('A') => {
+                self.select_all();
+                ViewAction::None
+            }
+            KeyCode::Char('n') | KeyCode::Char('N') => {
+                self.select_none();
+                ViewAction::None
+            }
+            _ => ViewAction::None,
+        }
+    }
+
+    fn render(&self, area: Rect, buf: &mut Buffer) {
+        let popup_width = 64.min(area.width.saturating_sub(4)).max(40);
+        let popup_height = (self.rows.len() as u16 + 6)
+            .min(area.height.saturating_sub(4))
+            .max(10);
+        let popup_area = Rect {
+            x: area.x + (area.width.saturating_sub(popup_width)) / 2,
+            y: area.y + (area.height.saturating_sub(popup_height)) / 2,
+            width: popup_width,
+            height: popup_height,
+        };
+
+        Clear.render(popup_area, buf);
+
+        let outer = Block::default()
+            .title(Line::from(Span::styled(
+                " Status line ",
+                Style::default()
+                    .fg(palette::DEEPSEEK_SKY)
+                    .add_modifier(Modifier::BOLD),
+            )))
+            .title_bottom(Line::from(vec![
+                Span::styled(
+                    " \u{2191}\u{2193} ",
+                    Style::default().fg(palette::TEXT_MUTED),
+                ),
+                Span::raw("move "),
+                Span::styled(" Space ", Style::default().fg(palette::TEXT_MUTED)),
+                Span::raw("toggle "),
+                Span::styled(" a/n ", Style::default().fg(palette::TEXT_MUTED)),
+                Span::raw("all/none "),
+                Span::styled(" Enter ", Style::default().fg(palette::TEXT_MUTED)),
+                Span::raw("apply "),
+                Span::styled(" Esc ", Style::default().fg(palette::TEXT_MUTED)),
+                Span::raw("cancel"),
+            ]))
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(palette::DEEPSEEK_SKY))
+            .style(Style::default().bg(palette::DEEPSEEK_INK));
+        let inner = outer.inner(popup_area);
+        outer.render(popup_area, buf);
+
+        let mut lines: Vec<Line<'static>> = Vec::with_capacity(self.rows.len());
+        for (idx, item) in self.rows.iter().enumerate() {
+            let is_selected_row = idx == self.cursor;
+            let on = self.selected[idx];
+            let locked = item.always_on();
+
+            let checkbox = if on { "[x]" } else { "[ ]" };
+            let checkbox_color = if locked {
+                palette::TEXT_DIM
+            } else if on {
+                palette::DEEPSEEK_SKY
+            } else {
+                palette::TEXT_MUTED
+            };
+
+            let label_style = if is_selected_row {
+                Style::default()
+                    .fg(palette::SELECTION_TEXT)
+                    .bg(palette::SELECTION_BG)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(palette::TEXT_PRIMARY)
+            };
+            let desc_style = if is_selected_row {
+                Style::default()
+                    .fg(palette::SELECTION_TEXT)
+                    .bg(palette::SELECTION_BG)
+            } else {
+                Style::default().fg(palette::TEXT_MUTED)
+            };
+
+            let marker = if is_selected_row { "▸" } else { " " };
+            let mut spans = vec![
+                Span::raw(" "),
+                Span::styled(marker, label_style),
+                Span::raw(" "),
+                Span::styled(checkbox.to_string(), Style::default().fg(checkbox_color)),
+                Span::raw(" "),
+                Span::styled(item.label().to_string(), label_style),
+            ];
+            if locked {
+                spans.push(Span::raw(" "));
+                spans.push(Span::styled(
+                    "(locked)".to_string(),
+                    Style::default().fg(palette::TEXT_DIM),
+                ));
+            }
+            spans.push(Span::raw("  "));
+            spans.push(Span::styled(item.description().to_string(), desc_style));
+            lines.push(Line::from(spans));
+        }
+
+        Paragraph::new(lines).render(inner, buf);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    fn key_char(c: char) -> KeyEvent {
+        KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn new_picker_seeds_from_current_selection() {
+        let current = vec![StatusItem::SessionCost, StatusItem::Agents];
+        let picker = StatusPickerView::new(&current);
+        let enabled = picker.enabled_items();
+        // Locked rows are always present even if they weren't in `current`.
+        assert!(enabled.contains(&StatusItem::Mode));
+        assert!(enabled.contains(&StatusItem::Model));
+        assert!(enabled.contains(&StatusItem::SessionCost));
+        assert!(enabled.contains(&StatusItem::Agents));
+        assert!(!enabled.contains(&StatusItem::GitBranch));
+    }
+
+    #[test]
+    fn space_toggles_unlocked_row() {
+        let mut picker = StatusPickerView::new(&[]);
+        // Cursor starts on row 0 (Mode — locked). Move past locked rows.
+        picker.handle_key(key(KeyCode::Down));
+        picker.handle_key(key(KeyCode::Down));
+        let item_at_cursor = picker.rows[picker.cursor];
+        assert!(!item_at_cursor.always_on(), "row 2 should be unlocked");
+        let was_on = picker.selected[picker.cursor];
+        picker.handle_key(key_char(' '));
+        assert_ne!(picker.selected[picker.cursor], was_on);
+    }
+
+    #[test]
+    fn space_does_not_toggle_locked_row() {
+        let mut picker = StatusPickerView::new(&[]);
+        // Find a locked row.
+        let locked_idx = picker
+            .rows
+            .iter()
+            .position(|i| i.always_on())
+            .expect("at least one locked row");
+        picker.cursor = locked_idx;
+        picker.handle_key(key_char(' '));
+        assert!(
+            picker.selected[locked_idx],
+            "locked rows must remain enabled"
+        );
+    }
+
+    #[test]
+    fn select_all_then_none_keeps_locked_on() {
+        let mut picker = StatusPickerView::new(&[]);
+        picker.handle_key(key_char('a'));
+        assert!(picker.selected.iter().all(|on| *on));
+        picker.handle_key(key_char('n'));
+        for (item, on) in picker.rows.iter().zip(&picker.selected) {
+            if item.always_on() {
+                assert!(*on, "{} must remain on after 'n'", item.id());
+            } else {
+                assert!(!*on, "{} must be off after 'n'", item.id());
+            }
+        }
+    }
+
+    #[test]
+    fn enter_emits_apply_event_with_current_state() {
+        let mut picker = StatusPickerView::new(&[StatusItem::SessionCost]);
+        let action = picker.handle_key(key(KeyCode::Enter));
+        match action {
+            ViewAction::EmitAndClose(ViewEvent::StatusItemsApplied { items }) => {
+                assert!(items.contains(&StatusItem::Mode));
+                assert!(items.contains(&StatusItem::Model));
+                assert!(items.contains(&StatusItem::SessionCost));
+            }
+            other => panic!("expected EmitAndClose with StatusItemsApplied, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn esc_closes_without_emitting() {
+        let mut picker = StatusPickerView::new(&[]);
+        match picker.handle_key(key(KeyCode::Esc)) {
+            ViewAction::Close => {}
+            other => panic!("expected Close, got {other:?}"),
+        }
+    }
+}

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -2298,6 +2298,12 @@ async fn apply_command_result(
                         .push(crate::tui::model_picker::ModelPickerView::new(app));
                 }
             }
+            AppAction::OpenStatusPicker => {
+                if app.view_stack.top_kind() != Some(ModalKind::StatusPicker) {
+                    let view = crate::tui::status_picker::StatusPickerView::new(&app.status_items);
+                    app.view_stack.push(view);
+                }
+            }
             AppAction::CompactContext => {
                 app.status_message = Some("Compacting context...".to_string());
                 let _ = engine_handle.send(Op::CompactContext).await;
@@ -2947,6 +2953,30 @@ async fn handle_view_events(
                 )
                 .await;
             }
+            ViewEvent::StatusItemsApplied { items } => {
+                // Update App state immediately so the next frame reflects
+                // the new chip set. Persist via Settings so the choice
+                // sticks across sessions; surface a toast on persist
+                // failure so the user knows the chosen footer is
+                // session-only (#95).
+                app.status_items = items.clone();
+                let ids: Vec<String> = items.iter().map(|item| item.id().to_string()).collect();
+                match crate::settings::Settings::load() {
+                    Ok(mut settings) => {
+                        settings.status_items = ids;
+                        if let Err(err) = settings.save() {
+                            app.status_message =
+                                Some(format!("Status line saved (session only): {err}"));
+                        } else {
+                            app.status_message = Some("Status line saved.".to_string());
+                        }
+                    }
+                    Err(err) => {
+                        app.status_message =
+                            Some(format!("Status line saved (session only): {err}"));
+                    }
+                }
+            }
         }
     }
 
@@ -3197,6 +3227,15 @@ fn render_footer(f: &mut Frame, area: Rect, app: &mut App) {
         Vec::new()
     };
 
+    // Optional chips opt-in via `/statusline` (#95). Each helper returns
+    // an empty Vec when its source data isn't available so the
+    // configurable footer never displays an empty placeholder.
+    let last_prompt_tokens_spans = footer_last_prompt_tokens_spans(app);
+    let context_percent_spans = footer_context_percent_spans(app);
+    let git_branch_spans = footer_git_branch_spans(app);
+    let workspace_path_spans = footer_workspace_path_spans(app);
+    let rate_limit_spans = footer_rate_limit_spans(app);
+
     let mut props = FooterProps::from_app(
         app,
         toast,
@@ -3207,7 +3246,13 @@ fn render_footer(f: &mut Frame, area: Rect, app: &mut App) {
         reasoning_replay,
         cache,
         cost,
-    );
+    )
+    .with_enabled_items(app.status_items.clone())
+    .with_last_prompt_tokens(last_prompt_tokens_spans)
+    .with_context_percent(context_percent_spans)
+    .with_git_branch(git_branch_spans)
+    .with_workspace_path(workspace_path_spans)
+    .with_rate_limit_remaining(rate_limit_spans);
 
     // Animate the spacer between the left status line and the right-hand
     // chips whenever a turn is live: model loading/streaming, compacting, or
@@ -3304,6 +3349,93 @@ fn footer_auxiliary_spans(app: &App, max_width: usize) -> Vec<Span<'static>> {
             return combined;
         }
     }
+    Vec::new()
+}
+
+/// `in <N>` chip for the most recent prompt's input-token count. Empty when
+/// the engine hasn't reported usage yet (first turn) so the configurable
+/// footer doesn't show stale zeros (#95).
+fn footer_last_prompt_tokens_spans(app: &App) -> Vec<Span<'static>> {
+    let Some(tokens) = app.last_prompt_tokens else {
+        return Vec::new();
+    };
+    if tokens == 0 {
+        return Vec::new();
+    }
+    vec![Span::styled(
+        format!("in {}", format_token_count_compact(u64::from(tokens))),
+        Style::default().fg(palette::TEXT_MUTED),
+    )]
+}
+
+/// `<N>%` chip for context-window utilisation. Reuses the same helper the
+/// header uses so the two stay in sync (#95).
+fn footer_context_percent_spans(app: &App) -> Vec<Span<'static>> {
+    let Some((_used, _max, percent)) = context_usage_snapshot(app) else {
+        return Vec::new();
+    };
+    let color = if percent >= 90.0 {
+        palette::STATUS_ERROR
+    } else if percent >= 75.0 {
+        palette::STATUS_WARNING
+    } else {
+        palette::TEXT_MUTED
+    };
+    vec![Span::styled(
+        format!("ctx {percent:.0}%"),
+        Style::default().fg(color),
+    )]
+}
+
+/// `⎇ <branch>` chip for the workspace's current git branch. Reads
+/// `.git/HEAD` directly (cheaper than spawning a subprocess on every
+/// redraw) and falls back to empty when the workspace isn't a git repo or
+/// HEAD is in a detached state we can't resolve cheaply (#95).
+fn footer_git_branch_spans(app: &App) -> Vec<Span<'static>> {
+    let head = app.workspace.join(".git").join("HEAD");
+    let Ok(contents) = std::fs::read_to_string(&head) else {
+        return Vec::new();
+    };
+    let trimmed = contents.trim();
+    let branch = trimmed
+        .strip_prefix("ref: refs/heads/")
+        .map(str::to_string)
+        .unwrap_or_else(|| {
+            // Detached HEAD — surface a short SHA so the footer still
+            // tells the user something useful.
+            let short = trimmed.chars().take(7).collect::<String>();
+            format!("({short})")
+        });
+    if branch.is_empty() {
+        return Vec::new();
+    }
+    vec![Span::styled(
+        format!("\u{2387} {branch}"),
+        Style::default().fg(palette::TEXT_MUTED),
+    )]
+}
+
+/// `<dirname>` chip for the workspace path. Truncates to the basename so
+/// it fits next to the other chips (#95).
+fn footer_workspace_path_spans(app: &App) -> Vec<Span<'static>> {
+    let label = app
+        .workspace
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| app.workspace.display().to_string());
+    if label.is_empty() {
+        return Vec::new();
+    }
+    vec![Span::styled(
+        label,
+        Style::default().fg(palette::TEXT_MUTED),
+    )]
+}
+
+/// Rate-limit budget chip. Stub today — DeepSeek's API doesn't expose
+/// `X-RateLimit-Remaining` to the client, so this is wired through but
+/// returns nothing until the engine surfaces a real value (#95).
+fn footer_rate_limit_spans(_app: &App) -> Vec<Span<'static>> {
     Vec::new()
 }
 

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -27,6 +27,8 @@ pub enum ModalKind {
     SessionPicker,
     Config,
     ModelPicker,
+    /// `/statusline` configurable footer picker (#95).
+    StatusPicker,
 }
 
 #[derive(Debug, Clone)]
@@ -90,6 +92,12 @@ pub enum ViewEvent {
         effort: crate::tui::app::ReasoningEffort,
         previous_model: String,
         previous_effort: crate::tui::app::ReasoningEffort,
+    },
+    /// Emitted by the `/statusline` picker on Enter — carries the new
+    /// ordered list of enabled footer/header items. The UI handler
+    /// updates `App.status_items` and persists via `Settings` (#95).
+    StatusItemsApplied {
+        items: Vec<crate::tui::widgets::StatusItem>,
     },
 }
 

--- a/crates/tui/src/tui/widgets/footer.rs
+++ b/crates/tui/src/tui/widgets/footer.rs
@@ -19,6 +19,7 @@ use crate::palette;
 use crate::tui::app::{App, AppMode};
 
 use super::Renderable;
+use super::StatusItem;
 
 /// Pre-computed data the footer needs to render.
 ///
@@ -47,6 +48,21 @@ pub struct FooterProps {
     pub cache: Vec<Span<'static>>,
     /// Session-cost chip spans (empty when below the display threshold).
     pub cost: Vec<Span<'static>>,
+    /// Last-prompt token count chip (#95 — opt-in via `/statusline`).
+    pub last_prompt_tokens: Vec<Span<'static>>,
+    /// Context-window utilisation chip (#95 — opt-in).
+    pub context_percent: Vec<Span<'static>>,
+    /// Git branch chip (#95 — opt-in).
+    pub git_branch: Vec<Span<'static>>,
+    /// Workspace path chip (#95 — opt-in).
+    pub workspace_path: Vec<Span<'static>>,
+    /// Rate-limit remaining chip (#95 — opt-in; stub today).
+    pub rate_limit_remaining: Vec<Span<'static>>,
+    /// Items the user has enabled via `/statusline`. The footer renders
+    /// matching chips in this order; unselected chips are dropped even if
+    /// their span vec was populated. `Mode` and `Model` are honoured by
+    /// the left status line only — they're not part of the chip cluster.
+    pub enabled_items: Vec<StatusItem>,
     /// Optional toast that, when present, replaces the left status line.
     pub toast: Option<FooterToast>,
     /// When `Some(frame_idx)`, the gap between the left status line and the
@@ -193,9 +209,61 @@ impl FooterProps {
             reasoning_replay,
             cache,
             cost,
+            last_prompt_tokens: Vec::new(),
+            context_percent: Vec::new(),
+            git_branch: Vec::new(),
+            workspace_path: Vec::new(),
+            rate_limit_remaining: Vec::new(),
+            // Default to the pre-#95 chip set so existing call sites (and
+            // tests) get the legacy footer until they wire in
+            // `Settings::status_items`. Mode/Model live in the left status
+            // line and are honoured separately.
+            enabled_items: StatusItem::defaults(),
             toast,
             working_strip_frame: None,
         }
+    }
+
+    /// Replace the configurable status item set (from `/statusline`).
+    #[must_use]
+    pub fn with_enabled_items(mut self, items: Vec<StatusItem>) -> Self {
+        self.enabled_items = items;
+        self
+    }
+
+    /// Attach the optional chip for `last_prompt_tokens`.
+    #[must_use]
+    pub fn with_last_prompt_tokens(mut self, spans: Vec<Span<'static>>) -> Self {
+        self.last_prompt_tokens = spans;
+        self
+    }
+
+    /// Attach the optional chip for `context_percent`.
+    #[must_use]
+    pub fn with_context_percent(mut self, spans: Vec<Span<'static>>) -> Self {
+        self.context_percent = spans;
+        self
+    }
+
+    /// Attach the optional chip for `git_branch`.
+    #[must_use]
+    pub fn with_git_branch(mut self, spans: Vec<Span<'static>>) -> Self {
+        self.git_branch = spans;
+        self
+    }
+
+    /// Attach the optional chip for `workspace_path`.
+    #[must_use]
+    pub fn with_workspace_path(mut self, spans: Vec<Span<'static>>) -> Self {
+        self.workspace_path = spans;
+        self
+    }
+
+    /// Attach the optional chip for `rate_limit_remaining`.
+    #[must_use]
+    pub fn with_rate_limit_remaining(mut self, spans: Vec<Span<'static>>) -> Self {
+        self.rate_limit_remaining = spans;
+        self
     }
 }
 
@@ -225,16 +293,31 @@ impl FooterWidget {
     }
 
     fn auxiliary_spans(&self, max_width: usize) -> Vec<Span<'static>> {
-        let parts: Vec<&Vec<Span<'static>>> = [
-            &self.props.coherence,
-            &self.props.agents,
-            &self.props.reasoning_replay,
-            &self.props.cache,
-            &self.props.cost,
-        ]
-        .into_iter()
-        .filter(|spans| !spans.is_empty())
-        .collect();
+        // Walk `enabled_items` in user-chosen order so the picker doubles
+        // as a chip-ordering tool. Mode/Model live in the left status line
+        // and are intentionally skipped here. Each variant maps to its
+        // pre-built span vec; empty vecs (chip "doesn't apply" — e.g. zero
+        // agents in flight, no usage, no git branch) drop out automatically
+        // so configuring an item never adds blank space.
+        let parts: Vec<&Vec<Span<'static>>> = self
+            .props
+            .enabled_items
+            .iter()
+            .filter_map(|item| match item {
+                StatusItem::Mode | StatusItem::Model => None,
+                StatusItem::Coherence => Some(&self.props.coherence),
+                StatusItem::Agents => Some(&self.props.agents),
+                StatusItem::ReasoningReplay => Some(&self.props.reasoning_replay),
+                StatusItem::CacheHitRate => Some(&self.props.cache),
+                StatusItem::SessionCost => Some(&self.props.cost),
+                StatusItem::LastPromptTokens => Some(&self.props.last_prompt_tokens),
+                StatusItem::ContextPercent => Some(&self.props.context_percent),
+                StatusItem::GitBranch => Some(&self.props.git_branch),
+                StatusItem::WorkspacePath => Some(&self.props.workspace_path),
+                StatusItem::RateLimitRemaining => Some(&self.props.rate_limit_remaining),
+            })
+            .filter(|spans| !spans.is_empty())
+            .collect();
 
         // Try to fit as many parts as possible, dropping from the end.
         for end in (0..=parts.len()).rev() {
@@ -495,6 +578,99 @@ mod tests {
         let chip = super::footer_agents_chip(3);
         assert_eq!(chip.len(), 1);
         assert_eq!(chip[0].content.as_ref(), "3 agents");
+    }
+
+    #[test]
+    fn enabled_items_filters_chip_cluster_in_render() {
+        // The footer must honour the `enabled_items` selection: chips
+        // whose StatusItem variant isn't enabled drop out even when their
+        // span vec carries content, matching the `/statusline` contract.
+        let app = make_app();
+        let agents = super::footer_agents_chip(2);
+        let cost = vec![Span::styled(
+            "$1.23".to_string(),
+            ratatui::style::Style::default(),
+        )];
+        // Selection deliberately excludes Agents but includes SessionCost.
+        let props = FooterProps::from_app(
+            &app,
+            None,
+            "ready",
+            palette::TEXT_MUTED,
+            Vec::<Span<'static>>::new(),
+            agents,
+            Vec::<Span<'static>>::new(),
+            Vec::<Span<'static>>::new(),
+            cost,
+        )
+        .with_enabled_items(vec![
+            super::StatusItem::Mode,
+            super::StatusItem::Model,
+            super::StatusItem::SessionCost,
+        ]);
+
+        let widget = FooterWidget::new(props);
+        let area = ratatui::layout::Rect::new(0, 0, 80, 1);
+        let mut buf = ratatui::buffer::Buffer::empty(area);
+        widget.render(area, &mut buf);
+        let rendered: String = (0..area.width).map(|x| buf[(x, 0)].symbol()).collect();
+        assert!(
+            rendered.contains("$1.23"),
+            "session cost chip must render when enabled: {rendered:?}",
+        );
+        assert!(
+            !rendered.contains("2 agents"),
+            "agents chip must NOT render when toggled off: {rendered:?}",
+        );
+    }
+
+    #[test]
+    fn enabled_items_renders_optional_chips_when_present() {
+        // Items added in #95 (context %, git branch, workspace path,
+        // last-prompt tokens) must surface in the chip cluster when
+        // listed in `enabled_items` and given non-empty span vecs.
+        let app = make_app();
+        let ctx = vec![Span::styled(
+            "ctx 42%".to_string(),
+            ratatui::style::Style::default(),
+        )];
+        let branch = vec![Span::styled(
+            "\u{2387} main".to_string(),
+            ratatui::style::Style::default(),
+        )];
+        let props = FooterProps::from_app(
+            &app,
+            None,
+            "ready",
+            palette::TEXT_MUTED,
+            Vec::<Span<'static>>::new(),
+            Vec::<Span<'static>>::new(),
+            Vec::<Span<'static>>::new(),
+            Vec::<Span<'static>>::new(),
+            Vec::<Span<'static>>::new(),
+        )
+        .with_context_percent(ctx)
+        .with_git_branch(branch)
+        .with_enabled_items(vec![
+            super::StatusItem::Mode,
+            super::StatusItem::Model,
+            super::StatusItem::ContextPercent,
+            super::StatusItem::GitBranch,
+        ]);
+
+        let widget = FooterWidget::new(props);
+        let area = ratatui::layout::Rect::new(0, 0, 80, 1);
+        let mut buf = ratatui::buffer::Buffer::empty(area);
+        widget.render(area, &mut buf);
+        let rendered: String = (0..area.width).map(|x| buf[(x, 0)].symbol()).collect();
+        assert!(
+            rendered.contains("ctx 42%"),
+            "context chip must render when enabled: {rendered:?}",
+        );
+        assert!(
+            rendered.contains("main"),
+            "git branch chip must render when enabled: {rendered:?}",
+        );
     }
 
     #[test]

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -1,12 +1,14 @@
 mod footer;
 mod header;
 mod renderable;
+pub mod status_items;
 
 pub use footer::{
     FooterProps, FooterToast, FooterWidget, footer_agents_chip, footer_working_label,
 };
 pub use header::{HeaderData, HeaderWidget};
 pub use renderable::Renderable;
+pub use status_items::{StatusItem, resolve_ids as resolve_status_item_ids};
 
 use std::time::Duration;
 

--- a/crates/tui/src/tui/widgets/status_items.rs
+++ b/crates/tui/src/tui/widgets/status_items.rs
@@ -1,0 +1,329 @@
+//! Configurable status-line items (#95).
+//!
+//! `StatusItem` is the canonical enum of footer/header chips the user can
+//! show or hide via the `/statusline` picker. The footer renderer reads from
+//! [`crate::settings::Settings::status_items`] (a `Vec<String>` of variant
+//! IDs) and uses [`StatusItem`] to compose the right-hand chip cluster — so
+//! toggling persists across sessions without changing the widget API.
+//!
+//! `Mode` and `Model` are always-on: they live in the footer's left status
+//! line and aren't part of the configurable cluster, so the footer can
+//! never become anonymous about which agent / which model is talking.
+
+use std::fmt;
+
+/// One configurable item that can appear on the footer/header.
+///
+/// `Mode` and `Model` are intentionally listed here — they appear in the
+/// picker as locked rows so users can see them — but the footer renders
+/// them unconditionally (they belong to the left status line, not the
+/// auxiliary chip cluster).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum StatusItem {
+    /// Current TUI mode chip (agent / yolo / plan). Always-on.
+    Mode,
+    /// Current model id (e.g. `deepseek-v4-pro`). Always-on.
+    Model,
+    /// Active coherence intervention chip (refresh / verify / reset).
+    Coherence,
+    /// In-flight sub-agent count (`N agents`).
+    Agents,
+    /// `rsn <tokens>` — replayed `reasoning_content` size.
+    ReasoningReplay,
+    /// `cache <pct>%` — prompt-cache hit rate.
+    CacheHitRate,
+    /// `$X.YZ` — running session cost.
+    SessionCost,
+    /// Last prompt token count (`in <N>`).
+    LastPromptTokens,
+    /// Context-window utilisation percentage (`<N>%`).
+    ContextPercent,
+    /// Current git branch (`⎇ main`). Read directly from `.git/HEAD`.
+    GitBranch,
+    /// Workspace directory basename (`~/proj`).
+    WorkspacePath,
+    /// API rate-limit budget remaining. Stub today — surfaces nothing
+    /// when the engine doesn't expose it.
+    RateLimitRemaining,
+}
+
+impl StatusItem {
+    /// Stable string id used in `settings.toml`. Round-trips through
+    /// [`StatusItem::from_id`].
+    #[must_use]
+    pub fn id(self) -> &'static str {
+        match self {
+            StatusItem::Mode => "mode",
+            StatusItem::Model => "model",
+            StatusItem::Coherence => "coherence",
+            StatusItem::Agents => "agents",
+            StatusItem::ReasoningReplay => "reasoning_replay",
+            StatusItem::CacheHitRate => "cache_hit_rate",
+            StatusItem::SessionCost => "session_cost",
+            StatusItem::LastPromptTokens => "last_prompt_tokens",
+            StatusItem::ContextPercent => "context_percent",
+            StatusItem::GitBranch => "git_branch",
+            StatusItem::WorkspacePath => "workspace_path",
+            StatusItem::RateLimitRemaining => "rate_limit_remaining",
+        }
+    }
+
+    /// Human-readable label shown in the picker.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            StatusItem::Mode => "Mode",
+            StatusItem::Model => "Model",
+            StatusItem::Coherence => "Coherence",
+            StatusItem::Agents => "Sub-agents",
+            StatusItem::ReasoningReplay => "Reasoning replay",
+            StatusItem::CacheHitRate => "Cache hit rate",
+            StatusItem::SessionCost => "Session cost",
+            StatusItem::LastPromptTokens => "Last prompt tokens",
+            StatusItem::ContextPercent => "Context %",
+            StatusItem::GitBranch => "Git branch",
+            StatusItem::WorkspacePath => "Workspace path",
+            StatusItem::RateLimitRemaining => "Rate-limit remaining",
+        }
+    }
+
+    /// One-line description shown alongside the label.
+    #[must_use]
+    pub fn description(self) -> &'static str {
+        match self {
+            StatusItem::Mode => "agent / yolo / plan (always on)",
+            StatusItem::Model => "active model id (always on)",
+            StatusItem::Coherence => "active intervention (refresh / verify)",
+            StatusItem::Agents => "in-flight sub-agent count",
+            StatusItem::ReasoningReplay => "replayed reasoning_content size",
+            StatusItem::CacheHitRate => "prompt-cache hit percentage",
+            StatusItem::SessionCost => "running USD cost for this session",
+            StatusItem::LastPromptTokens => "tokens sent on the last prompt",
+            StatusItem::ContextPercent => "context-window utilisation",
+            StatusItem::GitBranch => "current git branch",
+            StatusItem::WorkspacePath => "workspace directory",
+            StatusItem::RateLimitRemaining => "remaining rate-limit budget",
+        }
+    }
+
+    /// Whether the picker should treat this item as always-on (locked).
+    /// Locked items can't be toggled off — `Mode` and `Model` carry
+    /// information no terminal user wants to lose silently.
+    #[must_use]
+    pub fn always_on(self) -> bool {
+        matches!(self, StatusItem::Mode | StatusItem::Model)
+    }
+
+    /// Parse a stable id back into a variant. Unknown ids return `None` so
+    /// callers can drop forward-compat entries without crashing.
+    #[must_use]
+    pub fn from_id(id: &str) -> Option<Self> {
+        Self::all().iter().copied().find(|item| item.id() == id)
+    }
+
+    /// Every variant in canonical picker order.
+    #[must_use]
+    pub fn all() -> &'static [StatusItem] {
+        &[
+            StatusItem::Mode,
+            StatusItem::Model,
+            StatusItem::ContextPercent,
+            StatusItem::SessionCost,
+            StatusItem::LastPromptTokens,
+            StatusItem::CacheHitRate,
+            StatusItem::ReasoningReplay,
+            StatusItem::Coherence,
+            StatusItem::Agents,
+            StatusItem::GitBranch,
+            StatusItem::WorkspacePath,
+            StatusItem::RateLimitRemaining,
+        ]
+    }
+
+    /// Default selection — chosen so an upgrading user sees the same
+    /// footer they had before the picker landed (mode/model + coherence,
+    /// agents, reasoning replay, cache, cost). New items default off so
+    /// the chip cluster doesn't grow without consent.
+    #[must_use]
+    pub fn defaults() -> Vec<StatusItem> {
+        vec![
+            StatusItem::Mode,
+            StatusItem::Model,
+            StatusItem::Coherence,
+            StatusItem::Agents,
+            StatusItem::ReasoningReplay,
+            StatusItem::CacheHitRate,
+            StatusItem::SessionCost,
+        ]
+    }
+
+    /// Return the default selection encoded as the string ids that go in
+    /// `settings.toml`.
+    #[must_use]
+    pub fn default_ids() -> Vec<String> {
+        Self::defaults()
+            .into_iter()
+            .map(|item| item.id().to_string())
+            .collect()
+    }
+}
+
+impl fmt::Display for StatusItem {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.label())
+    }
+}
+
+/// Resolve a list of stable ids (as stored in `settings.toml`) into the
+/// matching `StatusItem` variants, preserving order and silently dropping
+/// unknown ids. `Mode` and `Model` are forced into the resolved set even
+/// when missing from the persisted list — they're always-on.
+#[must_use]
+pub fn resolve_ids(ids: &[String]) -> Vec<StatusItem> {
+    let mut resolved: Vec<StatusItem> = ids.iter().filter_map(|s| StatusItem::from_id(s)).collect();
+    for locked in [StatusItem::Mode, StatusItem::Model] {
+        if !resolved.contains(&locked) {
+            resolved.insert(0, locked);
+        }
+    }
+    resolved
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_variants_have_unique_ids() {
+        let mut ids: Vec<&str> = StatusItem::all().iter().map(|i| i.id()).collect();
+        ids.sort_unstable();
+        let len = ids.len();
+        ids.dedup();
+        assert_eq!(ids.len(), len, "duplicate StatusItem ids");
+    }
+
+    #[test]
+    fn id_round_trips() {
+        for item in StatusItem::all() {
+            let id = item.id();
+            assert_eq!(StatusItem::from_id(id), Some(*item), "id {id} round-trip");
+        }
+    }
+
+    #[test]
+    fn unknown_id_is_none() {
+        assert_eq!(StatusItem::from_id("wat"), None);
+        assert_eq!(StatusItem::from_id(""), None);
+    }
+
+    #[test]
+    fn mode_and_model_are_always_on() {
+        assert!(StatusItem::Mode.always_on());
+        assert!(StatusItem::Model.always_on());
+        for item in StatusItem::all() {
+            if !matches!(item, StatusItem::Mode | StatusItem::Model) {
+                assert!(!item.always_on(), "{} unexpectedly always-on", item.id());
+            }
+        }
+    }
+
+    #[test]
+    fn defaults_include_locked_items() {
+        let defaults = StatusItem::defaults();
+        assert!(defaults.contains(&StatusItem::Mode));
+        assert!(defaults.contains(&StatusItem::Model));
+    }
+
+    #[test]
+    fn defaults_match_pre_picker_footer() {
+        // The pre-picker footer surfaced these chips on the right; locking
+        // the default to that set means an upgrade doesn't silently lose
+        // any signal the user had before.
+        let defaults: Vec<&str> = StatusItem::defaults().iter().map(|i| i.id()).collect();
+        assert!(defaults.contains(&"mode"));
+        assert!(defaults.contains(&"model"));
+        assert!(defaults.contains(&"coherence"));
+        assert!(defaults.contains(&"agents"));
+        assert!(defaults.contains(&"reasoning_replay"));
+        assert!(defaults.contains(&"cache_hit_rate"));
+        assert!(defaults.contains(&"session_cost"));
+    }
+
+    #[test]
+    fn resolve_drops_unknown_and_keeps_locked() {
+        let ids = vec![
+            "session_cost".to_string(),
+            "wat".to_string(),
+            "agents".to_string(),
+        ];
+        let resolved = resolve_ids(&ids);
+        assert!(resolved.contains(&StatusItem::SessionCost));
+        assert!(resolved.contains(&StatusItem::Agents));
+        assert!(resolved.contains(&StatusItem::Mode));
+        assert!(resolved.contains(&StatusItem::Model));
+    }
+
+    #[test]
+    fn resolve_empty_yields_locked_only() {
+        let resolved = resolve_ids(&[]);
+        assert_eq!(resolved.len(), 2);
+        assert!(resolved.contains(&StatusItem::Mode));
+        assert!(resolved.contains(&StatusItem::Model));
+    }
+
+    #[test]
+    fn default_ids_round_trip_through_resolve() {
+        let ids = StatusItem::default_ids();
+        let resolved = resolve_ids(&ids);
+        assert_eq!(resolved, StatusItem::defaults());
+    }
+
+    #[test]
+    fn settings_persistence_round_trips_status_items() {
+        // Persistence path: pick a non-default selection, write it
+        // through the same Settings codepath the picker uses, reload it,
+        // and confirm `resolve_ids` recovers the same StatusItem set.
+        // This locks in the contract `/statusline` depends on.
+        use crate::settings::Settings;
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cfg_path = tmp.path().join("config.toml");
+        // Marker file: Settings reads DEEPSEEK_CONFIG_PATH and places
+        // settings.toml beside it.
+        std::fs::write(&cfg_path, "").expect("write config marker");
+        let prior = std::env::var("DEEPSEEK_CONFIG_PATH").ok();
+        // SAFETY: this test serializes on the env var via the
+        // sequential test infra; Rust requires an `unsafe` block for
+        // env mutation since 1.85 because it isn't thread-safe across
+        // OS APIs. The env is restored at the end of the test.
+        unsafe {
+            std::env::set_var("DEEPSEEK_CONFIG_PATH", &cfg_path);
+        }
+
+        let settings = Settings {
+            status_items: vec![
+                StatusItem::Mode.id().to_string(),
+                StatusItem::Model.id().to_string(),
+                StatusItem::ContextPercent.id().to_string(),
+                StatusItem::SessionCost.id().to_string(),
+            ],
+            ..Settings::default()
+        };
+        settings.save().expect("save");
+
+        let loaded = Settings::load().expect("load");
+        let resolved = resolve_ids(&loaded.status_items);
+        assert!(resolved.contains(&StatusItem::ContextPercent));
+        assert!(resolved.contains(&StatusItem::SessionCost));
+        assert!(resolved.contains(&StatusItem::Mode));
+        assert!(resolved.contains(&StatusItem::Model));
+        assert!(!resolved.contains(&StatusItem::GitBranch));
+
+        // Restore env so other tests aren't disturbed.
+        unsafe {
+            match prior {
+                Some(v) => std::env::set_var("DEEPSEEK_CONFIG_PATH", v),
+                None => std::env::remove_var("DEEPSEEK_CONFIG_PATH"),
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a `StatusItem` enum (Mode, Model, ContextPercent, SessionCost, LastPromptTokens, CacheHitRate, ReasoningReplay, Coherence, Agents, GitBranch, WorkspacePath, RateLimitRemaining) and threads it through the footer renderer so the right-hand chip cluster honors the user's selection.
- New `/statusline` modal (`tui/status_picker.rs`) with arrow / Space / a / n / Enter / Esc bindings. Mode and Model are locked rows — they live in the left status line and can't be toggled off so the footer never goes anonymous.
- Persists the chosen ids to `~/.config/deepseek/settings.toml` (`Settings::status_items: Vec<String>`); resolves missing-locked items at load time so a hand-edited file can't drop Mode/Model.
- Default selection matches the pre-picker footer (mode, model, coherence, agents, reasoning replay, cache, session cost), so upgrades surface no change until the user picks something new.
- New optional chips wired through with empty-vec safe behavior: `in <N>` last-prompt tokens, `ctx <N>%` context utilisation, `⎇ <branch>` (read directly from `.git/HEAD`, no shell-out), workspace basename, plus a no-op rate-limit stub for when the engine starts surfacing it.

Fixes #95

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p deepseek-tui --all-targets --all-features --locked -- -D warnings`
- [x] `cargo test -p deepseek-tui --bin deepseek-tui --locked` (1015 passed)
- [x] Picker tests: enter/esc/space/a/n behavior; locked rows can't be toggled off
- [x] Footer tests: `enabled_items` filter drops disabled chips; new opt-in chips render when enabled
- [x] StatusItem round-trip (id ↔ enum) and settings persistence round-trip via tempdir + `DEEPSEEK_CONFIG_PATH`
- [ ] Manual smoke: `/statusline`, toggle a few items, confirm the footer redraws live and the choice survives a restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hmbown/deepseek-tui/pull/119" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
