### PR TITLE
Release 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-04-28
+
+### Added
+- Grouped active tool-call cards with compact rails and a live working-status row while tools run. (#142, #149)
+- Selected-card-aware Alt+V details so the visible or selected tool card opens the matching detail payload. (#143)
+- Compact terminal-native session context inspector with persisted `@path` and `/attach` reference metadata for resumed transcripts. (#146, #150)
+
+### Changed
+- Polished tool cards, diff summaries, and pending context previews for denser terminal-native scanning. (#141, #144, #145, #148)
+- Ranked Ctrl+P file-picker results with working-set relevance from modified files, recent `@file` mentions, and recent tool paths while keeping fuzzy filtering in memory. (#147)
+
 ## [0.7.0] - 2026-04-28
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1011,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-agent"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "deepseek-config",
  "serde",
@@ -1019,7 +1019,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-app-server"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -1042,7 +1042,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-config"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "deepseek-secrets",
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-core"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1074,7 +1074,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-execpolicy"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "deepseek-protocol",
@@ -1083,7 +1083,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-hooks"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1097,7 +1097,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-mcp"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "deepseek-protocol",
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-protocol"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-secrets"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "dirs",
  "keyring",
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-state"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1140,7 +1140,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-tools"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1153,7 +1153,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-tui"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "arboard",
@@ -1213,7 +1213,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-tui-cli"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1236,7 +1236,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-tui-core"
-version = "0.7.0"
+version = "0.7.1"
 
 [[package]]
 name = "deranged"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = ["crates/cli", "crates/app-server", "crates/tui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/Hmbown/DeepSeek-TUI"

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -7,5 +7,5 @@ repository.workspace = true
 description = "Model/provider registry and fallback strategy for DeepSeek workspace architecture"
 
 [dependencies]
-deepseek-config = { path = "../config", version = "0.7.0" }
+deepseek-config = { path = "../config", version = "0.7.1" }
 serde.workspace = true

--- a/crates/app-server/Cargo.toml
+++ b/crates/app-server/Cargo.toml
@@ -10,15 +10,15 @@ description = "Codex-style app-server transport for DeepSeek workspace architect
 anyhow.workspace = true
 axum.workspace = true
 clap.workspace = true
-deepseek-agent = { path = "../agent", version = "0.7.0" }
-deepseek-config = { path = "../config", version = "0.7.0" }
-deepseek-core = { path = "../core", version = "0.7.0" }
-deepseek-execpolicy = { path = "../execpolicy", version = "0.7.0" }
-deepseek-hooks = { path = "../hooks", version = "0.7.0" }
-deepseek-mcp = { path = "../mcp", version = "0.7.0" }
-deepseek-protocol = { path = "../protocol", version = "0.7.0" }
-deepseek-state = { path = "../state", version = "0.7.0" }
-deepseek-tools = { path = "../tools", version = "0.7.0" }
+deepseek-agent = { path = "../agent", version = "0.7.1" }
+deepseek-config = { path = "../config", version = "0.7.1" }
+deepseek-core = { path = "../core", version = "0.7.1" }
+deepseek-execpolicy = { path = "../execpolicy", version = "0.7.1" }
+deepseek-hooks = { path = "../hooks", version = "0.7.1" }
+deepseek-mcp = { path = "../mcp", version = "0.7.1" }
+deepseek-protocol = { path = "../protocol", version = "0.7.1" }
+deepseek-state = { path = "../state", version = "0.7.1" }
+deepseek-tools = { path = "../tools", version = "0.7.1" }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -14,13 +14,13 @@ path = "src/main.rs"
 anyhow.workspace = true
 clap.workspace = true
 clap_complete.workspace = true
-deepseek-agent = { path = "../agent", version = "0.7.0" }
-deepseek-app-server = { path = "../app-server", version = "0.7.0" }
-deepseek-config = { path = "../config", version = "0.7.0" }
-deepseek-execpolicy = { path = "../execpolicy", version = "0.7.0" }
-deepseek-mcp = { path = "../mcp", version = "0.7.0" }
-deepseek-secrets = { path = "../secrets", version = "0.7.0" }
-deepseek-state = { path = "../state", version = "0.7.0" }
+deepseek-agent = { path = "../agent", version = "0.7.1" }
+deepseek-app-server = { path = "../app-server", version = "0.7.1" }
+deepseek-config = { path = "../config", version = "0.7.1" }
+deepseek-execpolicy = { path = "../execpolicy", version = "0.7.1" }
+deepseek-mcp = { path = "../mcp", version = "0.7.1" }
+deepseek-secrets = { path = "../secrets", version = "0.7.1" }
+deepseek-state = { path = "../state", version = "0.7.1" }
 chrono.workspace = true
 dirs.workspace = true
 serde.workspace = true

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -8,7 +8,7 @@ description = "Config schema and precedence model for DeepSeek workspace archite
 
 [dependencies]
 anyhow.workspace = true
-deepseek-secrets = { path = "../secrets", version = "0.7.0" }
+deepseek-secrets = { path = "../secrets", version = "0.7.1" }
 dirs.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -9,14 +9,14 @@ description = "Core runtime boundaries for DeepSeek workspace architecture"
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true
-deepseek-agent = { path = "../agent", version = "0.7.0" }
-deepseek-config = { path = "../config", version = "0.7.0" }
-deepseek-execpolicy = { path = "../execpolicy", version = "0.7.0" }
-deepseek-hooks = { path = "../hooks", version = "0.7.0" }
-deepseek-mcp = { path = "../mcp", version = "0.7.0" }
-deepseek-protocol = { path = "../protocol", version = "0.7.0" }
-deepseek-state = { path = "../state", version = "0.7.0" }
-deepseek-tools = { path = "../tools", version = "0.7.0" }
+deepseek-agent = { path = "../agent", version = "0.7.1" }
+deepseek-config = { path = "../config", version = "0.7.1" }
+deepseek-execpolicy = { path = "../execpolicy", version = "0.7.1" }
+deepseek-hooks = { path = "../hooks", version = "0.7.1" }
+deepseek-mcp = { path = "../mcp", version = "0.7.1" }
+deepseek-protocol = { path = "../protocol", version = "0.7.1" }
+deepseek-state = { path = "../state", version = "0.7.1" }
+deepseek-tools = { path = "../tools", version = "0.7.1" }
 serde_json.workspace = true
 tokio.workspace = true
 uuid.workspace = true

--- a/crates/execpolicy/Cargo.toml
+++ b/crates/execpolicy/Cargo.toml
@@ -8,5 +8,5 @@ description = "Execution policy and approval model parity for DeepSeek workspace
 
 [dependencies]
 anyhow.workspace = true
-deepseek-protocol = { path = "../protocol", version = "0.7.0" }
+deepseek-protocol = { path = "../protocol", version = "0.7.1" }
 serde.workspace = true

--- a/crates/hooks/Cargo.toml
+++ b/crates/hooks/Cargo.toml
@@ -10,7 +10,7 @@ description = "Hook dispatch and notifications parity for DeepSeek workspace arc
 anyhow.workspace = true
 async-trait.workspace = true
 chrono.workspace = true
-deepseek-protocol = { path = "../protocol", version = "0.7.0" }
+deepseek-protocol = { path = "../protocol", version = "0.7.1" }
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -8,6 +8,6 @@ description = "MCP server lifecycle and tool proxy compatibility for DeepSeek wo
 
 [dependencies]
 anyhow.workspace = true
-deepseek-protocol = { path = "../protocol", version = "0.7.0" }
+deepseek-protocol = { path = "../protocol", version = "0.7.1" }
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -9,7 +9,7 @@ description = "Tool invocation lifecycle, schema validation, and scheduler paral
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
-deepseek-protocol = { path = "../protocol", version = "0.7.0" }
+deepseek-protocol = { path = "../protocol", version = "0.7.1" }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -13,8 +13,8 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0.100"
 arboard = "3.4"
-deepseek-secrets = { path = "../secrets", version = "0.7.0" }
-deepseek-tools = { path = "../tools", version = "0.7.0" }
+deepseek-secrets = { path = "../secrets", version = "0.7.1" }
+deepseek-tools = { path = "../tools", version = "0.7.1" }
 async-stream = "0.3.6"
 async-trait = "0.1"
 bytes = "1.11.0"

--- a/npm/deepseek-tui/package.json
+++ b/npm/deepseek-tui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-tui",
-  "version": "0.7.0",
-  "deepseekBinaryVersion": "0.7.0",
+  "version": "0.7.1",
+  "deepseekBinaryVersion": "0.7.1",
   "description": "Install and run deepseek and deepseek-tui binaries from GitHub release artifacts.",
   "author": "Hmbown",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- bump workspace, internal crate pins, lockfile, and npm wrapper to 0.7.1
- add 0.7.1 changelog entry for the UI/UX polish release

## Release verification
- ./scripts/release/check-versions.sh
- cargo fmt --all -- --check
- cargo check --workspace --all-targets --locked
- cargo test --workspace --all-features --locked
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- cargo build --release --locked -p deepseek-tui-cli -p deepseek-tui
- target/release/deepseek-tui --help
- target/release/deepseek-tui doctor
- target/release/deepseek-tui doctor --json
- target/release/deepseek-tui --no-alt-screen --skip-onboarding, then /exit
- target/release/deepseek exec --model deepseek-v4-flash "Reply with exactly OK."
- ./scripts/release/publish-crates.sh dry-run
- npm pack/install smoke against local release assets
- DEEPSEEK_TUI_VERSION=0.7.1 DEEPSEEK_TUI_RELEASE_BASE_URL=http://127.0.0.1:8123/ npm run release:check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hmbown/deepseek-tui/pull/156" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
