### PR TITLE
Support Linux arm64 npm/release artifacts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,18 @@
 # NVIDIA_BASE_URL=https://integrate.api.nvidia.com/v1
 # NVIDIA_NIM_MODEL=deepseek-ai/deepseek-v4-pro
 
+# Fireworks-hosted DeepSeek V4
+# DEEPSEEK_PROVIDER=fireworks
+# FIREWORKS_API_KEY=
+# FIREWORKS_BASE_URL=https://api.fireworks.ai/inference/v1
+# FIREWORKS_MODEL=accounts/fireworks/models/deepseek-v4-pro
+
+# Self-hosted SGLang OpenAI-compatible endpoint
+# DEEPSEEK_PROVIDER=sglang
+# SGLANG_API_KEY=
+# SGLANG_BASE_URL=http://localhost:30000/v1
+# SGLANG_MODEL=deepseek-ai/DeepSeek-V4-Pro
+
 # Logging
 # `DEEPSEEK_LOG_LEVEL` is forwarded by the facade; `RUST_LOG` enables the
 # TUI's lightweight verbose logs for info/debug/trace directives.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Install Linux system dependencies
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev libssl-dev pkg-config
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -36,7 +36,7 @@ jobs:
           components: clippy, rustfmt
       - name: Install Linux system dependencies
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev libssl-dev pkg-config
       - uses: Swatinem/rust-cache@v2
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -58,7 +58,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Install Linux system dependencies
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev libssl-dev pkg-config
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
         run: cargo test --workspace --all-features --locked
@@ -78,7 +78,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Install Linux system dependencies
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev libssl-dev pkg-config
       - uses: Swatinem/rust-cache@v2
       - name: Build
         run: cargo build --release
@@ -88,13 +88,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Install Linux system dependencies
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev libssl-dev pkg-config
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -140,7 +140,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Install Linux system dependencies
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev libssl-dev pkg-config
       - uses: Swatinem/rust-cache@v2
       - name: Build docs
         run: cargo doc --workspace --no-deps

--- a/.github/workflows/crates-publish.yml
+++ b/.github/workflows/crates-publish.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Install Linux system dependencies
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev libssl-dev pkg-config
       - uses: Swatinem/rust-cache@v2
 
       - name: Verify version matches tag

--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install Linux system dependencies
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev libssl-dev pkg-config
 
       - name: Cache Cargo registry
         uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           components: clippy, rustfmt
       - name: Install Linux system dependencies
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev libssl-dev pkg-config
       - uses: Swatinem/rust-cache@v2
       - name: Format check
         run: cargo fmt --all -- --check
@@ -54,6 +54,10 @@ jobs:
             target: x86_64-unknown-linux-gnu
             binary: deepseek
             artifact_name: deepseek-linux-x64
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            binary: deepseek
+            artifact_name: deepseek-linux-arm64
           - os: macos-latest
             target: x86_64-apple-darwin
             binary: deepseek
@@ -71,6 +75,10 @@ jobs:
             target: x86_64-unknown-linux-gnu
             binary: deepseek-tui
             artifact_name: deepseek-tui-linux-x64
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            binary: deepseek-tui
+            artifact_name: deepseek-tui-linux-arm64
           - os: macos-latest
             target: x86_64-apple-darwin
             binary: deepseek-tui
@@ -91,7 +99,7 @@ jobs:
           targets: ${{ matrix.target }}
       - name: Install Linux system dependencies
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev libssl-dev pkg-config
       - run: cargo build --release --locked --target ${{ matrix.target }}
       - name: Rename binary
         shell: bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ Thank you for your interest in contributing to DeepSeek TUI! This document provi
 - Rust 1.85 or later (edition 2024)
 - Cargo package manager
 - Git
+- Linux: `libdbus-1-dev`, `libssl-dev`, and `pkg-config`
 
 ### Setting Up Development Environment
 

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -131,6 +131,50 @@ impl Default for ModelRegistry {
                 supports_tools: true,
                 supports_reasoning: true,
             },
+            ModelInfo {
+                id: "accounts/fireworks/models/deepseek-v4-pro".to_string(),
+                provider: ProviderKind::Fireworks,
+                aliases: vec![
+                    "deepseek-v4-pro".to_string(),
+                    "fireworks-deepseek-v4-pro".to_string(),
+                ],
+                supports_tools: true,
+                supports_reasoning: true,
+            },
+            ModelInfo {
+                id: "accounts/fireworks/models/deepseek-v4-flash".to_string(),
+                provider: ProviderKind::Fireworks,
+                aliases: vec![
+                    "deepseek-v4-flash".to_string(),
+                    "deepseek-chat".to_string(),
+                    "deepseek-reasoner".to_string(),
+                    "fireworks-deepseek-v4-flash".to_string(),
+                ],
+                supports_tools: true,
+                supports_reasoning: true,
+            },
+            ModelInfo {
+                id: "deepseek-ai/DeepSeek-V4-Pro".to_string(),
+                provider: ProviderKind::Sglang,
+                aliases: vec![
+                    "deepseek-v4-pro".to_string(),
+                    "sglang-deepseek-v4-pro".to_string(),
+                ],
+                supports_tools: true,
+                supports_reasoning: true,
+            },
+            ModelInfo {
+                id: "deepseek-ai/DeepSeek-V4-Flash".to_string(),
+                provider: ProviderKind::Sglang,
+                aliases: vec![
+                    "deepseek-v4-flash".to_string(),
+                    "deepseek-chat".to_string(),
+                    "deepseek-reasoner".to_string(),
+                    "sglang-deepseek-v4-flash".to_string(),
+                ],
+                supports_tools: true,
+                supports_reasoning: true,
+            },
         ];
         Self::new(models)
     }
@@ -303,5 +347,26 @@ mod tests {
 
         assert_eq!(resolved.resolved.provider, ProviderKind::Novita);
         assert_eq!(resolved.resolved.id, "deepseek/deepseek-v4-flash");
+    }
+
+    #[test]
+    fn fireworks_default_uses_namespaced_model_id() {
+        let registry = ModelRegistry::default();
+        let resolved = registry.resolve(None, Some(ProviderKind::Fireworks));
+
+        assert_eq!(resolved.resolved.provider, ProviderKind::Fireworks);
+        assert_eq!(
+            resolved.resolved.id,
+            "accounts/fireworks/models/deepseek-v4-pro"
+        );
+    }
+
+    #[test]
+    fn sglang_default_uses_catalog_model_id() {
+        let registry = ModelRegistry::default();
+        let resolved = registry.resolve(None, Some(ProviderKind::Sglang));
+
+        assert_eq!(resolved.resolved.provider, ProviderKind::Sglang);
+        assert_eq!(resolved.resolved.id, "deepseek-ai/DeepSeek-V4-Pro");
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -25,6 +25,8 @@ enum ProviderArg {
     Openai,
     Openrouter,
     Novita,
+    Fireworks,
+    Sglang,
 }
 
 impl From<ProviderArg> for ProviderKind {
@@ -35,6 +37,8 @@ impl From<ProviderArg> for ProviderKind {
             ProviderArg::Openai => ProviderKind::Openai,
             ProviderArg::Openrouter => ProviderKind::Openrouter,
             ProviderArg::Novita => ProviderKind::Novita,
+            ProviderArg::Fireworks => ProviderKind::Fireworks,
+            ProviderArg::Sglang => ProviderKind::Sglang,
         }
     }
 }
@@ -525,6 +529,10 @@ fn run_logout_command(store: &mut ConfigStore) -> Result<()> {
     store.config.providers.deepseek.api_key = None;
     store.config.providers.nvidia_nim.api_key = None;
     store.config.providers.openai.api_key = None;
+    store.config.providers.openrouter.api_key = None;
+    store.config.providers.novita.api_key = None;
+    store.config.providers.fireworks.api_key = None;
+    store.config.providers.sglang.api_key = None;
     store.config.auth_mode = None;
     store.config.chatgpt_access_token = None;
     store.config.device_code_session = None;
@@ -542,15 +550,19 @@ fn keyring_slot(provider: ProviderKind) -> &'static str {
         ProviderKind::Openai => "openai",
         ProviderKind::Openrouter => "openrouter",
         ProviderKind::Novita => "novita",
+        ProviderKind::Fireworks => "fireworks",
+        ProviderKind::Sglang => "sglang",
     }
 }
 
 /// Provider order used by the `auth list` and `auth status` outputs.
-const PROVIDER_LIST: [ProviderKind; 5] = [
+const PROVIDER_LIST: [ProviderKind; 7] = [
     ProviderKind::Deepseek,
     ProviderKind::NvidiaNim,
     ProviderKind::Openrouter,
     ProviderKind::Novita,
+    ProviderKind::Fireworks,
+    ProviderKind::Sglang,
     ProviderKind::Openai,
 ];
 
@@ -1021,9 +1033,11 @@ fn delegate_to_tui(
             | ProviderKind::NvidiaNim
             | ProviderKind::Openrouter
             | ProviderKind::Novita
+            | ProviderKind::Fireworks
+            | ProviderKind::Sglang
     ) {
         bail!(
-            "The interactive TUI supports DeepSeek, NVIDIA NIM, OpenRouter, and Novita providers. Remove --provider {} or use `deepseek model ...` for provider registry inspection.",
+            "The interactive TUI supports DeepSeek, NVIDIA NIM, OpenRouter, Novita, Fireworks, and SGLang providers. Remove --provider {} or use `deepseek model ...` for provider registry inspection.",
             resolved_runtime.provider.as_str()
         );
     }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -21,6 +21,12 @@ const DEFAULT_NOVITA_MODEL: &str = "deepseek/deepseek-v4-pro";
 const DEFAULT_NOVITA_FLASH_MODEL: &str = "deepseek/deepseek-v4-flash";
 const DEFAULT_OPENROUTER_BASE_URL: &str = "https://openrouter.ai/api/v1";
 const DEFAULT_NOVITA_BASE_URL: &str = "https://api.novita.ai/v1";
+const DEFAULT_FIREWORKS_MODEL: &str = "accounts/fireworks/models/deepseek-v4-pro";
+const DEFAULT_FIREWORKS_FLASH_MODEL: &str = "accounts/fireworks/models/deepseek-v4-flash";
+const DEFAULT_FIREWORKS_BASE_URL: &str = "https://api.fireworks.ai/inference/v1";
+const DEFAULT_SGLANG_MODEL: &str = "deepseek-ai/DeepSeek-V4-Pro";
+const DEFAULT_SGLANG_FLASH_MODEL: &str = "deepseek-ai/DeepSeek-V4-Flash";
+const DEFAULT_SGLANG_BASE_URL: &str = "http://localhost:30000/v1";
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "kebab-case")]
@@ -31,6 +37,8 @@ pub enum ProviderKind {
     Openai,
     Openrouter,
     Novita,
+    Fireworks,
+    Sglang,
 }
 
 impl ProviderKind {
@@ -42,6 +50,8 @@ impl ProviderKind {
             Self::Openai => "openai",
             Self::Openrouter => "openrouter",
             Self::Novita => "novita",
+            Self::Fireworks => "fireworks",
+            Self::Sglang => "sglang",
         }
     }
 
@@ -53,6 +63,8 @@ impl ProviderKind {
             "openai" | "open-ai" => Some(Self::Openai),
             "openrouter" | "open_router" => Some(Self::Openrouter),
             "novita" => Some(Self::Novita),
+            "fireworks" | "fireworks-ai" => Some(Self::Fireworks),
+            "sglang" | "sg-lang" => Some(Self::Sglang),
             _ => None,
         }
     }
@@ -77,6 +89,10 @@ pub struct ProvidersToml {
     pub openrouter: ProviderConfigToml,
     #[serde(default)]
     pub novita: ProviderConfigToml,
+    #[serde(default)]
+    pub fireworks: ProviderConfigToml,
+    #[serde(default)]
+    pub sglang: ProviderConfigToml,
 }
 
 impl ProvidersToml {
@@ -88,6 +104,8 @@ impl ProvidersToml {
             ProviderKind::Openai => &self.openai,
             ProviderKind::Openrouter => &self.openrouter,
             ProviderKind::Novita => &self.novita,
+            ProviderKind::Fireworks => &self.fireworks,
+            ProviderKind::Sglang => &self.sglang,
         }
     }
 
@@ -98,6 +116,8 @@ impl ProvidersToml {
             ProviderKind::Openai => &mut self.openai,
             ProviderKind::Openrouter => &mut self.openrouter,
             ProviderKind::Novita => &mut self.novita,
+            ProviderKind::Fireworks => &mut self.fireworks,
+            ProviderKind::Sglang => &mut self.sglang,
         }
     }
 }
@@ -274,6 +294,12 @@ impl ConfigToml {
             "providers.novita.api_key" => self.providers.novita.api_key.clone(),
             "providers.novita.base_url" => self.providers.novita.base_url.clone(),
             "providers.novita.model" => self.providers.novita.model.clone(),
+            "providers.fireworks.api_key" => self.providers.fireworks.api_key.clone(),
+            "providers.fireworks.base_url" => self.providers.fireworks.base_url.clone(),
+            "providers.fireworks.model" => self.providers.fireworks.model.clone(),
+            "providers.sglang.api_key" => self.providers.sglang.api_key.clone(),
+            "providers.sglang.base_url" => self.providers.sglang.base_url.clone(),
+            "providers.sglang.model" => self.providers.sglang.model.clone(),
             _ => self.extras.get(key).map(toml::Value::to_string),
         }
     }
@@ -343,6 +369,24 @@ impl ConfigToml {
             "providers.novita.model" => {
                 self.providers.novita.model = Some(value.to_string());
             }
+            "providers.fireworks.api_key" => {
+                self.providers.fireworks.api_key = Some(value.to_string());
+            }
+            "providers.fireworks.base_url" => {
+                self.providers.fireworks.base_url = Some(value.to_string());
+            }
+            "providers.fireworks.model" => {
+                self.providers.fireworks.model = Some(value.to_string());
+            }
+            "providers.sglang.api_key" => {
+                self.providers.sglang.api_key = Some(value.to_string());
+            }
+            "providers.sglang.base_url" => {
+                self.providers.sglang.base_url = Some(value.to_string());
+            }
+            "providers.sglang.model" => {
+                self.providers.sglang.model = Some(value.to_string());
+            }
             _ => {
                 self.extras
                     .insert(key.to_string(), toml::Value::String(value.to_string()));
@@ -390,6 +434,12 @@ impl ConfigToml {
             "providers.novita.api_key" => self.providers.novita.api_key = None,
             "providers.novita.base_url" => self.providers.novita.base_url = None,
             "providers.novita.model" => self.providers.novita.model = None,
+            "providers.fireworks.api_key" => self.providers.fireworks.api_key = None,
+            "providers.fireworks.base_url" => self.providers.fireworks.base_url = None,
+            "providers.fireworks.model" => self.providers.fireworks.model = None,
+            "providers.sglang.api_key" => self.providers.sglang.api_key = None,
+            "providers.sglang.base_url" => self.providers.sglang.base_url = None,
+            "providers.sglang.model" => self.providers.sglang.model = None,
             _ => {
                 self.extras.remove(key);
             }
@@ -483,6 +533,24 @@ impl ConfigToml {
         if let Some(v) = self.providers.novita.model.as_ref() {
             out.insert("providers.novita.model".to_string(), v.clone());
         }
+        if let Some(v) = self.providers.fireworks.api_key.as_ref() {
+            out.insert("providers.fireworks.api_key".to_string(), redact_secret(v));
+        }
+        if let Some(v) = self.providers.fireworks.base_url.as_ref() {
+            out.insert("providers.fireworks.base_url".to_string(), v.clone());
+        }
+        if let Some(v) = self.providers.fireworks.model.as_ref() {
+            out.insert("providers.fireworks.model".to_string(), v.clone());
+        }
+        if let Some(v) = self.providers.sglang.api_key.as_ref() {
+            out.insert("providers.sglang.api_key".to_string(), redact_secret(v));
+        }
+        if let Some(v) = self.providers.sglang.base_url.as_ref() {
+            out.insert("providers.sglang.base_url".to_string(), v.clone());
+        }
+        if let Some(v) = self.providers.sglang.model.as_ref() {
+            out.insert("providers.sglang.model".to_string(), v.clone());
+        }
 
         for (k, v) in &self.extras {
             out.insert(k.clone(), v.to_string());
@@ -547,12 +615,14 @@ impl ConfigToml {
                 ProviderKind::Openai => DEFAULT_OPENAI_BASE_URL.to_string(),
                 ProviderKind::Openrouter => DEFAULT_OPENROUTER_BASE_URL.to_string(),
                 ProviderKind::Novita => DEFAULT_NOVITA_BASE_URL.to_string(),
+                ProviderKind::Fireworks => DEFAULT_FIREWORKS_BASE_URL.to_string(),
+                ProviderKind::Sglang => DEFAULT_SGLANG_BASE_URL.to_string(),
             });
 
         let model = cli
             .model
             .clone()
-            .or_else(|| env.model.clone())
+            .or_else(|| env.model_for(provider))
             .or_else(|| provider_cfg.model.clone())
             .or(root_deepseek_model)
             .or_else(|| self.model.clone())
@@ -562,6 +632,8 @@ impl ConfigToml {
                 ProviderKind::Openai => DEFAULT_OPENAI_MODEL.to_string(),
                 ProviderKind::Openrouter => DEFAULT_OPENROUTER_MODEL.to_string(),
                 ProviderKind::Novita => DEFAULT_NOVITA_MODEL.to_string(),
+                ProviderKind::Fireworks => DEFAULT_FIREWORKS_MODEL.to_string(),
+                ProviderKind::Sglang => DEFAULT_SGLANG_MODEL.to_string(),
             });
         let model = normalize_model_for_provider(provider, &model);
 
@@ -638,6 +710,22 @@ fn normalize_model_for_provider(provider: ProviderKind, model: &str) -> String {
             "deepseek-v4-flash" | "deepseek-v4flash" | "deepseek-chat" | "deepseek-reasoner"
             | "deepseek-r1" | "deepseek-v3" | "deepseek-v3.2",
         ) => DEFAULT_NOVITA_FLASH_MODEL.to_string(),
+        (ProviderKind::Fireworks, "deepseek-v4-pro" | "deepseek-v4pro") => {
+            DEFAULT_FIREWORKS_MODEL.to_string()
+        }
+        (
+            ProviderKind::Fireworks,
+            "deepseek-v4-flash" | "deepseek-v4flash" | "deepseek-chat" | "deepseek-reasoner"
+            | "deepseek-r1" | "deepseek-v3" | "deepseek-v3.2",
+        ) => DEFAULT_FIREWORKS_FLASH_MODEL.to_string(),
+        (ProviderKind::Sglang, "deepseek-v4-pro" | "deepseek-v4pro") => {
+            DEFAULT_SGLANG_MODEL.to_string()
+        }
+        (
+            ProviderKind::Sglang,
+            "deepseek-v4-flash" | "deepseek-v4flash" | "deepseek-chat" | "deepseek-reasoner"
+            | "deepseek-r1" | "deepseek-v3" | "deepseek-v3.2",
+        ) => DEFAULT_SGLANG_FLASH_MODEL.to_string(),
         _ => model.to_string(),
     }
 }
@@ -791,6 +879,11 @@ fn redact_secret(secret: &str) -> String {
 struct EnvRuntimeOverrides {
     provider: Option<ProviderKind>,
     model: Option<String>,
+    nvidia_model: Option<String>,
+    openrouter_model: Option<String>,
+    novita_model: Option<String>,
+    fireworks_model: Option<String>,
+    sglang_model: Option<String>,
     output_mode: Option<String>,
     auth_mode: Option<String>,
     log_level: Option<String>,
@@ -802,6 +895,8 @@ struct EnvRuntimeOverrides {
     openai_base_url: Option<String>,
     openrouter_base_url: Option<String>,
     novita_base_url: Option<String>,
+    fireworks_base_url: Option<String>,
+    sglang_base_url: Option<String>,
 }
 
 impl EnvRuntimeOverrides {
@@ -811,6 +906,11 @@ impl EnvRuntimeOverrides {
                 .ok()
                 .and_then(|v| ProviderKind::parse(&v)),
             model: std::env::var("DEEPSEEK_MODEL").ok(),
+            nvidia_model: std::env::var("NVIDIA_NIM_MODEL").ok(),
+            openrouter_model: std::env::var("OPENROUTER_MODEL").ok(),
+            novita_model: std::env::var("NOVITA_MODEL").ok(),
+            fireworks_model: std::env::var("FIREWORKS_MODEL").ok(),
+            sglang_model: std::env::var("SGLANG_MODEL").ok(),
             output_mode: std::env::var("DEEPSEEK_OUTPUT_MODE").ok(),
             auth_mode: std::env::var("DEEPSEEK_AUTH_MODE").ok(),
             log_level: std::env::var("DEEPSEEK_LOG_LEVEL").ok(),
@@ -836,6 +936,12 @@ impl EnvRuntimeOverrides {
             novita_base_url: std::env::var("NOVITA_BASE_URL")
                 .ok()
                 .filter(|v| !v.trim().is_empty()),
+            fireworks_base_url: std::env::var("FIREWORKS_BASE_URL")
+                .ok()
+                .filter(|v| !v.trim().is_empty()),
+            sglang_base_url: std::env::var("SGLANG_BASE_URL")
+                .ok()
+                .filter(|v| !v.trim().is_empty()),
         }
     }
 
@@ -848,7 +954,20 @@ impl EnvRuntimeOverrides {
             ProviderKind::Openai => self.openai_base_url.clone(),
             ProviderKind::Openrouter => self.openrouter_base_url.clone(),
             ProviderKind::Novita => self.novita_base_url.clone(),
+            ProviderKind::Fireworks => self.fireworks_base_url.clone(),
+            ProviderKind::Sglang => self.sglang_base_url.clone(),
         }
+    }
+
+    fn model_for(&self, provider: ProviderKind) -> Option<String> {
+        self.model.clone().or_else(|| match provider {
+            ProviderKind::Deepseek | ProviderKind::Openai => None,
+            ProviderKind::NvidiaNim => self.nvidia_model.clone(),
+            ProviderKind::Openrouter => self.openrouter_model.clone(),
+            ProviderKind::Novita => self.novita_model.clone(),
+            ProviderKind::Fireworks => self.fireworks_model.clone(),
+            ProviderKind::Sglang => self.sglang_model.clone(),
+        })
     }
 }
 
@@ -871,13 +990,22 @@ mod tests {
         deepseek_provider: Option<OsString>,
         nvidia_api_key: Option<OsString>,
         nvidia_nim_api_key: Option<OsString>,
+        nvidia_nim_model: Option<OsString>,
         nim_base_url: Option<OsString>,
         nvidia_base_url: Option<OsString>,
         nvidia_nim_base_url: Option<OsString>,
         openrouter_api_key: Option<OsString>,
         openrouter_base_url: Option<OsString>,
+        openrouter_model: Option<OsString>,
         novita_api_key: Option<OsString>,
         novita_base_url: Option<OsString>,
+        novita_model: Option<OsString>,
+        fireworks_api_key: Option<OsString>,
+        fireworks_base_url: Option<OsString>,
+        fireworks_model: Option<OsString>,
+        sglang_api_key: Option<OsString>,
+        sglang_base_url: Option<OsString>,
+        sglang_model: Option<OsString>,
     }
 
     impl EnvGuard {
@@ -889,13 +1017,22 @@ mod tests {
                 deepseek_provider: env::var_os("DEEPSEEK_PROVIDER"),
                 nvidia_api_key: env::var_os("NVIDIA_API_KEY"),
                 nvidia_nim_api_key: env::var_os("NVIDIA_NIM_API_KEY"),
+                nvidia_nim_model: env::var_os("NVIDIA_NIM_MODEL"),
                 nim_base_url: env::var_os("NIM_BASE_URL"),
                 nvidia_base_url: env::var_os("NVIDIA_BASE_URL"),
                 nvidia_nim_base_url: env::var_os("NVIDIA_NIM_BASE_URL"),
                 openrouter_api_key: env::var_os("OPENROUTER_API_KEY"),
                 openrouter_base_url: env::var_os("OPENROUTER_BASE_URL"),
+                openrouter_model: env::var_os("OPENROUTER_MODEL"),
                 novita_api_key: env::var_os("NOVITA_API_KEY"),
                 novita_base_url: env::var_os("NOVITA_BASE_URL"),
+                novita_model: env::var_os("NOVITA_MODEL"),
+                fireworks_api_key: env::var_os("FIREWORKS_API_KEY"),
+                fireworks_base_url: env::var_os("FIREWORKS_BASE_URL"),
+                fireworks_model: env::var_os("FIREWORKS_MODEL"),
+                sglang_api_key: env::var_os("SGLANG_API_KEY"),
+                sglang_base_url: env::var_os("SGLANG_BASE_URL"),
+                sglang_model: env::var_os("SGLANG_MODEL"),
             };
             // Safety: test-only environment mutation guarded by a module mutex.
             unsafe {
@@ -905,13 +1042,22 @@ mod tests {
                 env::remove_var("DEEPSEEK_PROVIDER");
                 env::remove_var("NVIDIA_API_KEY");
                 env::remove_var("NVIDIA_NIM_API_KEY");
+                env::remove_var("NVIDIA_NIM_MODEL");
                 env::remove_var("NIM_BASE_URL");
                 env::remove_var("NVIDIA_BASE_URL");
                 env::remove_var("NVIDIA_NIM_BASE_URL");
                 env::remove_var("OPENROUTER_API_KEY");
                 env::remove_var("OPENROUTER_BASE_URL");
+                env::remove_var("OPENROUTER_MODEL");
                 env::remove_var("NOVITA_API_KEY");
                 env::remove_var("NOVITA_BASE_URL");
+                env::remove_var("NOVITA_MODEL");
+                env::remove_var("FIREWORKS_API_KEY");
+                env::remove_var("FIREWORKS_BASE_URL");
+                env::remove_var("FIREWORKS_MODEL");
+                env::remove_var("SGLANG_API_KEY");
+                env::remove_var("SGLANG_BASE_URL");
+                env::remove_var("SGLANG_MODEL");
             }
             guard
         }
@@ -935,13 +1081,22 @@ mod tests {
                 Self::restore_var("DEEPSEEK_PROVIDER", self.deepseek_provider.take());
                 Self::restore_var("NVIDIA_API_KEY", self.nvidia_api_key.take());
                 Self::restore_var("NVIDIA_NIM_API_KEY", self.nvidia_nim_api_key.take());
+                Self::restore_var("NVIDIA_NIM_MODEL", self.nvidia_nim_model.take());
                 Self::restore_var("NIM_BASE_URL", self.nim_base_url.take());
                 Self::restore_var("NVIDIA_BASE_URL", self.nvidia_base_url.take());
                 Self::restore_var("NVIDIA_NIM_BASE_URL", self.nvidia_nim_base_url.take());
                 Self::restore_var("OPENROUTER_API_KEY", self.openrouter_api_key.take());
                 Self::restore_var("OPENROUTER_BASE_URL", self.openrouter_base_url.take());
+                Self::restore_var("OPENROUTER_MODEL", self.openrouter_model.take());
                 Self::restore_var("NOVITA_API_KEY", self.novita_api_key.take());
                 Self::restore_var("NOVITA_BASE_URL", self.novita_base_url.take());
+                Self::restore_var("NOVITA_MODEL", self.novita_model.take());
+                Self::restore_var("FIREWORKS_API_KEY", self.fireworks_api_key.take());
+                Self::restore_var("FIREWORKS_BASE_URL", self.fireworks_base_url.take());
+                Self::restore_var("FIREWORKS_MODEL", self.fireworks_model.take());
+                Self::restore_var("SGLANG_API_KEY", self.sglang_api_key.take());
+                Self::restore_var("SGLANG_BASE_URL", self.sglang_base_url.take());
+                Self::restore_var("SGLANG_MODEL", self.sglang_model.take());
             }
         }
     }
@@ -1120,6 +1275,11 @@ mod tests {
         );
         assert_eq!(ProviderKind::parse("novita"), Some(ProviderKind::Novita));
         assert_eq!(ProviderKind::parse("Novita"), Some(ProviderKind::Novita));
+        assert_eq!(
+            ProviderKind::parse("fireworks-ai"),
+            Some(ProviderKind::Fireworks)
+        );
+        assert_eq!(ProviderKind::parse("sg-lang"), Some(ProviderKind::Sglang));
     }
 
     #[test]
@@ -1152,6 +1312,38 @@ mod tests {
         assert_eq!(resolved.provider, ProviderKind::Novita);
         assert_eq!(resolved.base_url, DEFAULT_NOVITA_BASE_URL);
         assert_eq!(resolved.model, DEFAULT_NOVITA_MODEL);
+    }
+
+    #[test]
+    fn fireworks_provider_defaults_to_canonical_endpoint_and_model() {
+        let _lock = env_lock();
+        let _env = EnvGuard::without_deepseek_runtime_overrides();
+        let config = ConfigToml {
+            provider: ProviderKind::Fireworks,
+            ..ConfigToml::default()
+        };
+
+        let resolved = config.resolve_runtime_options(&CliRuntimeOverrides::default());
+
+        assert_eq!(resolved.provider, ProviderKind::Fireworks);
+        assert_eq!(resolved.base_url, DEFAULT_FIREWORKS_BASE_URL);
+        assert_eq!(resolved.model, DEFAULT_FIREWORKS_MODEL);
+    }
+
+    #[test]
+    fn sglang_provider_defaults_to_canonical_endpoint_and_model() {
+        let _lock = env_lock();
+        let _env = EnvGuard::without_deepseek_runtime_overrides();
+        let config = ConfigToml {
+            provider: ProviderKind::Sglang,
+            ..ConfigToml::default()
+        };
+
+        let resolved = config.resolve_runtime_options(&CliRuntimeOverrides::default());
+
+        assert_eq!(resolved.provider, ProviderKind::Sglang);
+        assert_eq!(resolved.base_url, DEFAULT_SGLANG_BASE_URL);
+        assert_eq!(resolved.model, DEFAULT_SGLANG_MODEL);
     }
 
     #[test]
@@ -1191,6 +1383,24 @@ mod tests {
     }
 
     #[test]
+    fn fireworks_env_api_key_falls_back_when_config_missing() {
+        let _lock = env_lock();
+        let _env = EnvGuard::without_deepseek_runtime_overrides();
+        // Safety: test-only environment mutation guarded by a module mutex.
+        unsafe {
+            env::set_var("DEEPSEEK_PROVIDER", "fireworks");
+            env::set_var("FIREWORKS_API_KEY", "fireworks-env-key");
+        }
+
+        let resolved =
+            ConfigToml::default().resolve_runtime_options(&CliRuntimeOverrides::default());
+
+        assert_eq!(resolved.provider, ProviderKind::Fireworks);
+        assert_eq!(resolved.api_key.as_deref(), Some("fireworks-env-key"));
+        assert_eq!(resolved.base_url, DEFAULT_FIREWORKS_BASE_URL);
+    }
+
+    #[test]
     fn openrouter_provider_normalizes_flash_aliases() {
         let _lock = env_lock();
         let _env = EnvGuard::without_deepseek_runtime_overrides();
@@ -1220,6 +1430,38 @@ mod tests {
 
         assert_eq!(resolved.provider, ProviderKind::Novita);
         assert_eq!(resolved.model, DEFAULT_NOVITA_FLASH_MODEL);
+    }
+
+    #[test]
+    fn fireworks_provider_normalizes_flash_aliases() {
+        let _lock = env_lock();
+        let _env = EnvGuard::without_deepseek_runtime_overrides();
+        let cli = CliRuntimeOverrides {
+            provider: Some(ProviderKind::Fireworks),
+            model: Some("deepseek-v4-flash".to_string()),
+            ..CliRuntimeOverrides::default()
+        };
+
+        let resolved = ConfigToml::default().resolve_runtime_options(&cli);
+
+        assert_eq!(resolved.provider, ProviderKind::Fireworks);
+        assert_eq!(resolved.model, DEFAULT_FIREWORKS_FLASH_MODEL);
+    }
+
+    #[test]
+    fn sglang_provider_normalizes_flash_aliases() {
+        let _lock = env_lock();
+        let _env = EnvGuard::without_deepseek_runtime_overrides();
+        let cli = CliRuntimeOverrides {
+            provider: Some(ProviderKind::Sglang),
+            model: Some("deepseek-v4-flash".to_string()),
+            ..CliRuntimeOverrides::default()
+        };
+
+        let resolved = ConfigToml::default().resolve_runtime_options(&cli);
+
+        assert_eq!(resolved.provider, ProviderKind::Sglang);
+        assert_eq!(resolved.model, DEFAULT_SGLANG_FLASH_MODEL);
     }
 
     #[test]

--- a/crates/secrets/src/lib.rs
+++ b/crates/secrets/src/lib.rs
@@ -388,6 +388,8 @@ pub fn env_for(name: &str) -> Option<String> {
         "deepseek" => &["DEEPSEEK_API_KEY"],
         "openrouter" => &["OPENROUTER_API_KEY"],
         "novita" => &["NOVITA_API_KEY"],
+        "fireworks" => &["FIREWORKS_API_KEY"],
+        "sglang" => &["SGLANG_API_KEY"],
         // NVIDIA NIM falls back to `DEEPSEEK_API_KEY` last because the
         // catalog endpoint accepts the same DeepSeek-issued key when no
         // dedicated NVIDIA token is set. This mirrors pre-v0.7 behaviour.
@@ -426,6 +428,8 @@ mod tests {
             "DEEPSEEK_API_KEY",
             "OPENROUTER_API_KEY",
             "NOVITA_API_KEY",
+            "FIREWORKS_API_KEY",
+            "SGLANG_API_KEY",
             "NVIDIA_API_KEY",
             "NVIDIA_NIM_API_KEY",
             "OPENAI_API_KEY",

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -26,6 +26,7 @@ pub const DEFAULT_NOVITA_MODEL: &str = "deepseek/deepseek-v4-pro";
 pub const DEFAULT_NOVITA_FLASH_MODEL: &str = "deepseek/deepseek-v4-flash";
 pub const DEFAULT_NOVITA_BASE_URL: &str = "https://api.novita.ai/v1";
 pub const DEFAULT_FIREWORKS_MODEL: &str = "accounts/fireworks/models/deepseek-v4-pro";
+pub const DEFAULT_FIREWORKS_FLASH_MODEL: &str = "accounts/fireworks/models/deepseek-v4-flash";
 pub const DEFAULT_FIREWORKS_BASE_URL: &str = "https://api.fireworks.ai/inference/v1";
 pub const DEFAULT_SGLANG_MODEL: &str = "deepseek-ai/DeepSeek-V4-Pro";
 pub const DEFAULT_SGLANG_FLASH_MODEL: &str = "deepseek-ai/DeepSeek-V4-Flash";
@@ -1363,6 +1364,11 @@ fn apply_env_overrides(config: &mut Config) {
     {
         config.default_text_model = Some(value);
     }
+    if matches!(config.api_provider(), ApiProvider::Fireworks)
+        && let Ok(value) = std::env::var("FIREWORKS_MODEL")
+    {
+        config.default_text_model = Some(value);
+    }
     if let Ok(value) =
         std::env::var("DEEPSEEK_MODEL").or_else(|_| std::env::var("DEEPSEEK_DEFAULT_TEXT_MODEL"))
     {
@@ -1576,10 +1582,7 @@ fn model_for_provider(provider: ApiProvider, normalized: String) -> String {
         (ApiProvider::Novita, "deepseek-v4-pro") => DEFAULT_NOVITA_MODEL.to_string(),
         (ApiProvider::Novita, "deepseek-v4-flash") => DEFAULT_NOVITA_FLASH_MODEL.to_string(),
         (ApiProvider::Fireworks, "deepseek-v4-pro") => DEFAULT_FIREWORKS_MODEL.to_string(),
-        (ApiProvider::Fireworks, "deepseek-v4-flash") => {
-            // Flash not yet available on Fireworks; fall through to normalized name
-            "accounts/fireworks/models/deepseek-v4-flash".to_string()
-        }
+        (ApiProvider::Fireworks, "deepseek-v4-flash") => DEFAULT_FIREWORKS_FLASH_MODEL.to_string(),
         (ApiProvider::Sglang, "deepseek-v4-pro") => DEFAULT_SGLANG_MODEL.to_string(),
         (ApiProvider::Sglang, "deepseek-v4-flash") => DEFAULT_SGLANG_FLASH_MODEL.to_string(),
         _ => normalized,
@@ -2093,6 +2096,7 @@ mod tests {
         novita_base_url: Option<OsString>,
         fireworks_api_key: Option<OsString>,
         fireworks_base_url: Option<OsString>,
+        fireworks_model: Option<OsString>,
         sglang_api_key: Option<OsString>,
         sglang_base_url: Option<OsString>,
         sglang_model: Option<OsString>,
@@ -2123,6 +2127,7 @@ mod tests {
             let novita_base_url_prev = env::var_os("NOVITA_BASE_URL");
             let fireworks_api_key_prev = env::var_os("FIREWORKS_API_KEY");
             let fireworks_base_url_prev = env::var_os("FIREWORKS_BASE_URL");
+            let fireworks_model_prev = env::var_os("FIREWORKS_MODEL");
             let sglang_api_key_prev = env::var_os("SGLANG_API_KEY");
             let sglang_base_url_prev = env::var_os("SGLANG_BASE_URL");
             let sglang_model_prev = env::var_os("SGLANG_MODEL");
@@ -2148,6 +2153,7 @@ mod tests {
                 env::remove_var("NOVITA_BASE_URL");
                 env::remove_var("FIREWORKS_API_KEY");
                 env::remove_var("FIREWORKS_BASE_URL");
+                env::remove_var("FIREWORKS_MODEL");
                 env::remove_var("SGLANG_API_KEY");
                 env::remove_var("SGLANG_BASE_URL");
                 env::remove_var("SGLANG_MODEL");
@@ -2173,6 +2179,7 @@ mod tests {
                 novita_base_url: novita_base_url_prev,
                 fireworks_api_key: fireworks_api_key_prev,
                 fireworks_base_url: fireworks_base_url_prev,
+                fireworks_model: fireworks_model_prev,
                 sglang_api_key: sglang_api_key_prev,
                 sglang_base_url: sglang_base_url_prev,
                 sglang_model: sglang_model_prev,
@@ -2207,6 +2214,7 @@ mod tests {
                 Self::restore_var("NOVITA_BASE_URL", self.novita_base_url.take());
                 Self::restore_var("FIREWORKS_API_KEY", self.fireworks_api_key.take());
                 Self::restore_var("FIREWORKS_BASE_URL", self.fireworks_base_url.take());
+                Self::restore_var("FIREWORKS_MODEL", self.fireworks_model.take());
                 Self::restore_var("SGLANG_API_KEY", self.sglang_api_key.take());
                 Self::restore_var("SGLANG_BASE_URL", self.sglang_base_url.take());
                 Self::restore_var("SGLANG_MODEL", self.sglang_model.take());

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -89,6 +89,7 @@ These override config values:
 - `NVIDIA_NIM_MODEL`
 - `FIREWORKS_API_KEY`
 - `FIREWORKS_BASE_URL`
+- `FIREWORKS_MODEL`
 - `SGLANG_BASE_URL`
 - `SGLANG_MODEL`
 - `SGLANG_API_KEY` (optional; many localhost SGLang servers do not require auth)

--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -125,10 +125,12 @@ The publish helper is idempotent for reruns: already-published crate versions ar
 `.github/workflows/release.yml` builds these binaries:
 
 - `deepseek-linux-x64`
+- `deepseek-linux-arm64`
 - `deepseek-macos-x64`
 - `deepseek-macos-arm64`
 - `deepseek-windows-x64.exe`
 - `deepseek-tui-linux-x64`
+- `deepseek-tui-linux-arm64`
 - `deepseek-tui-macos-x64`
 - `deepseek-tui-macos-arm64`
 - `deepseek-tui-windows-x64.exe`
@@ -149,7 +151,7 @@ on a workstation with `npm login` and an authenticator app.
 1. Set the npm package version in [npm/deepseek-tui/package.json](../npm/deepseek-tui/package.json) to match the workspace `Cargo.toml`. CI's version-drift guard will catch mismatches before tag.
 2. Set `deepseekBinaryVersion` to the GitHub release tag that should supply binaries.
 3. Push the version bump to `main`. `auto-tag.yml` creates the matching `vX.Y.Z` tag, and `release.yml` builds the binary matrix and drafts the GitHub Release.
-4. **Wait for the GitHub Release to finalize** with all eight signed binaries plus `deepseek-artifacts-sha256.txt`. The npm `prepublishOnly` hook (`scripts/verify-release-assets.js`) requires every asset to be present.
+4. **Wait for the GitHub Release to finalize** with all ten signed binaries plus `deepseek-artifacts-sha256.txt`. The npm `prepublishOnly` hook (`scripts/verify-release-assets.js`) requires every asset to be present.
 5. From a developer machine, publish the npm wrapper manually:
 
 ```bash

--- a/npm/deepseek-tui/README.md
+++ b/npm/deepseek-tui/README.md
@@ -52,7 +52,7 @@ is `https://integrate.api.nvidia.com/v1`. With `--provider nvidia-nim`,
 
 ## Supported platforms
 
-- Linux x64
+- Linux x64 / arm64
 - macOS x64 / arm64
 - Windows x64
 

--- a/npm/deepseek-tui/scripts/artifacts.js
+++ b/npm/deepseek-tui/scripts/artifacts.js
@@ -6,7 +6,7 @@ const CHECKSUM_MANIFEST = "deepseek-artifacts-sha256.txt";
 const ASSET_MATRIX = {
   linux: {
     x64: ["deepseek-linux-x64", "deepseek-tui-linux-x64"],
-    // arm64: ["deepseek-linux-arm64", "deepseek-tui-linux-arm64"], // Uncomment when binaries are available
+    arm64: ["deepseek-linux-arm64", "deepseek-tui-linux-arm64"],
   },
   darwin: {
     x64: ["deepseek-macos-x64", "deepseek-tui-macos-x64"],


### PR DESCRIPTION
## Summary
- add Linux arm64 release artifacts and npm installer detection
- run npm wrapper smoke CI on ubuntu-24.04-arm
- align Fireworks/SGLang provider handling across config, secrets, CLI, TUI env, and model registry
- make Linux CI dependencies explicit for OpenSSL-backed TUI builds

## Verification
- node artifact detection returns deepseek-linux-arm64 and deepseek-tui-linux-arm64 on Linux arm64
- cargo fmt --all -- --check
- cargo test -p deepseek-config -p deepseek-secrets -p deepseek-agent -p deepseek-tui-cli --locked
- cargo test -p deepseek-tui config --locked
- cargo check --workspace --all-targets --locked