### PR TITLE
v0.7.6 TUI input polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ DeepSeek TUI is a coding agent that runs entirely in your terminal. It gives Dee
 - **Session save/resume** — checkpoint and resume long sessions
 - **Workspace rollback** — side-git pre/post-turn snapshots with `/restore` and `revert_turn`, without touching your repo's `.git`
 - **HTTP/SSE runtime API** — `deepseek serve --http` for headless agent workflows
-- **MCP protocol** — connect to Model Context Protocol servers for extended tooling
+- **MCP protocol** — connect to Model Context Protocol servers for extended tooling; see [docs/MCP.md](docs/MCP.md)
 - **Live cost tracking** — per-turn and session-level token usage and cost estimates
 - **Dark theme** — DeepSeek-blue palette
 
@@ -150,23 +150,31 @@ deepseek --model deepseek-v4-flash "summarize" # model override
 deepseek --yolo                               # YOLO mode (auto-approve tools)
 deepseek login --api-key "..."                # save API key
 deepseek doctor                               # check setup & connectivity
+deepseek doctor --json                        # machine-readable diagnostics
+deepseek setup --status                       # read-only setup status
+deepseek setup --tools --plugins              # scaffold local tool/plugin dirs
 deepseek models                               # list live API models
 deepseek sessions                             # list saved sessions
 deepseek resume --last                        # resume latest session
 deepseek serve --http                         # HTTP/SSE API server
+deepseek mcp list                             # list configured MCP servers
+deepseek mcp validate                         # validate MCP config/connectivity
+deepseek mcp-server                           # run dispatcher MCP stdio server
 ```
 
 ### Keyboard shortcuts
 
 | Key | Action |
 |---|---|
-| `Tab` | Cycle mode: Plan → Agent → YOLO |
+| `Tab` | Complete `/` or `@` entries; while a turn is running, queue the draft as a follow-up; otherwise cycle mode |
 | `Shift+Tab` | Cycle reasoning-effort: off → high → max |
 | `F1` | Help |
 | `Esc` | Back / dismiss |
 | `Ctrl+K` | Command palette |
+| `Ctrl+R` | Resume an earlier session |
+| `Alt+R` | Search prompt history and recover cleared drafts |
 | `@path` | Attach file/directory context in composer |
-| `/attach <path>` | Attach image/video media references |
+| `/attach <path>` | Attach image/video media references; select the row with `↑` at composer start and remove with `Backspace`/`Delete` |
 
 ---
 
@@ -198,17 +206,13 @@ Key environment overrides:
 | `SGLANG_BASE_URL` | Self-hosted SGLang endpoint |
 | `SGLANG_API_KEY` | Optional SGLang bearer token |
 
-Quick diagnostics:
-
-```bash
-deepseek-tui setup --status    # read-only status check (API key, MCP, sandbox, .env)
-deepseek-tui doctor --json     # machine-readable doctor output for CI
-deepseek-tui setup --tools --plugins  # scaffold tools/ and plugins/ directories
-```
+Quick diagnostics: `deepseek setup --status` checks API key, MCP, sandbox, and
+`.env` state without network calls; `deepseek doctor --json` is suitable for CI;
+`deepseek setup --tools --plugins` scaffolds local tool and plugin directories.
 
 DeepSeek context caching is automatic — when the API returns cache hit/miss token fields, the TUI includes them in usage and cost tracking.
 
-Full reference: [docs/CONFIGURATION.md](docs/CONFIGURATION.md)
+Full reference: [docs/CONFIGURATION.md](docs/CONFIGURATION.md) and [docs/MCP.md](docs/MCP.md).
 
 ---
 

--- a/crates/tui/src/commands/config.rs
+++ b/crates/tui/src/commands/config.rs
@@ -225,6 +225,12 @@ pub fn set_config_value(app: &mut App, key: &str, value: &str, persist: bool) ->
             app.composer_border = settings.composer_border;
             app.needs_redraw = true;
         }
+        "paste_burst_detection" | "paste_burst" => {
+            app.use_paste_burst_detection = settings.paste_burst_detection;
+            if !app.use_paste_burst_detection {
+                app.paste_burst.clear_after_explicit_paste();
+            }
+        }
         "transcript_spacing" | "spacing" => {
             app.transcript_spacing =
                 crate::tui::app::TranscriptSpacing::from_setting(&settings.transcript_spacing);

--- a/crates/tui/src/seam_manager.rs
+++ b/crates/tui/src/seam_manager.rs
@@ -197,11 +197,12 @@ impl SeamManager {
         // Use compaction pinning heuristics to identify which messages to
         // exclude from summarization. Pinned messages stay verbatim; the
         // seam summary covers everything else.
+        let local_pins = local_pins_for_range(pinned_indices, start_idx, end_idx, messages.len());
         let plan = plan_compaction(
             range,
             workspace,
             KEEP_RECENT_MESSAGES.min(range.len().saturating_sub(1)),
-            Some(pinned_indices),
+            Some(&local_pins),
             None,
         );
 
@@ -597,6 +598,21 @@ fn truncate_chars(text: &str, max_chars: usize) -> String {
     text.chars().take(max_chars).collect()
 }
 
+fn local_pins_for_range(
+    pinned_indices: &[usize],
+    start_idx: usize,
+    end_idx: usize,
+    message_count: usize,
+) -> Vec<usize> {
+    let end_idx = end_idx.min(message_count);
+    pinned_indices
+        .iter()
+        .copied()
+        .filter(|idx| *idx >= start_idx && *idx < end_idx)
+        .map(|idx| idx - start_idx)
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -662,6 +678,15 @@ mod tests {
         assert_eq!(truncate_chars("abc😀é", 4), "abc😀".to_string());
         assert_eq!(truncate_chars("abc😀é", 10), "abc😀é".to_string());
         assert_eq!(truncate_chars("", 5), "".to_string());
+    }
+
+    #[test]
+    fn global_pins_are_mapped_to_soft_seam_slice_indices() {
+        let pins = vec![1, 4, 5, 8, 12];
+
+        let local = local_pins_for_range(&pins, 4, 9, 10);
+
+        assert_eq!(local, vec![0, 1, 4]);
     }
 
     #[test]

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -25,6 +25,9 @@ pub struct Settings {
     /// terminal mishandles the `\e[?2004h` escape (rare; some legacy
     /// terminals over SSH+screen multiplex without the cap).
     pub bracketed_paste: bool,
+    /// Enable rapid-key paste-burst detection for terminals that do not emit
+    /// bracketed-paste events. Independent from `bracketed_paste`.
+    pub paste_burst_detection: bool,
     /// Show thinking blocks from the model
     pub show_thinking: bool,
     /// Show detailed tool output
@@ -55,6 +58,7 @@ impl Default for Settings {
             low_motion: false,
             fancy_animations: false,
             bracketed_paste: true,
+            paste_burst_detection: true,
             show_thinking: true,
             show_tool_details: true,
             composer_density: "comfortable".to_string(),
@@ -149,6 +153,9 @@ impl Settings {
             }
             "bracketed_paste" | "paste" => {
                 self.bracketed_paste = parse_bool(value)?;
+            }
+            "paste_burst_detection" | "paste_burst" => {
+                self.paste_burst_detection = parse_bool(value)?;
             }
             "show_thinking" | "thinking" => {
                 self.show_thinking = parse_bool(value)?;
@@ -260,6 +267,10 @@ impl Settings {
         lines.push(format!("  low_motion:         {}", self.low_motion));
         lines.push(format!("  fancy_animations:   {}", self.fancy_animations));
         lines.push(format!("  bracketed_paste:    {}", self.bracketed_paste));
+        lines.push(format!(
+            "  paste_burst_detect: {}",
+            self.paste_burst_detection
+        ));
         lines.push(format!("  show_thinking:      {}", self.show_thinking));
         lines.push(format!("  show_tool_details:  {}", self.show_tool_details));
         lines.push(format!("  composer_density:   {}", self.composer_density));
@@ -301,6 +312,10 @@ impl Settings {
             (
                 "bracketed_paste",
                 "Terminal bracketed-paste mode: on/off (rare to disable)",
+            ),
+            (
+                "paste_burst_detection",
+                "Fallback rapid-key paste detection: on/off",
             ),
             ("show_thinking", "Show model thinking: on/off"),
             ("show_tool_details", "Show detailed tool output: on/off"),
@@ -398,5 +413,24 @@ mod tests {
         assert!(settings.auto_compact);
         settings.set("auto_compact", "off").expect("disable");
         assert!(!settings.auto_compact);
+    }
+
+    #[test]
+    fn paste_burst_detection_is_configurable_independent_of_bracketed_paste() {
+        let mut settings = Settings::default();
+        assert!(settings.bracketed_paste);
+        assert!(settings.paste_burst_detection);
+
+        settings
+            .set("paste_burst_detection", "off")
+            .expect("disable paste burst fallback");
+        assert!(settings.bracketed_paste);
+        assert!(!settings.paste_burst_detection);
+
+        settings
+            .set("bracketed_paste", "off")
+            .expect("disable bracketed paste");
+        assert!(!settings.bracketed_paste);
+        assert!(!settings.paste_burst_detection);
     }
 }

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -237,6 +237,25 @@ impl StatusToast {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ComposerHistorySearch {
+    pre_search_input: String,
+    pre_search_cursor: usize,
+    query: String,
+    selected: usize,
+}
+
+impl ComposerHistorySearch {
+    fn new(pre_search_input: String, pre_search_cursor: usize) -> Self {
+        Self {
+            pre_search_input,
+            pre_search_cursor,
+            query: String::new(),
+            selected: 0,
+        }
+    }
+}
+
 fn char_count(text: &str) -> usize {
     text.chars().count()
 }
@@ -275,6 +294,7 @@ fn sanitize_api_key_text(text: &str) -> String {
 }
 
 const MAX_SUBMITTED_INPUT_CHARS: usize = 16_000;
+const MAX_DRAFT_HISTORY: usize = 50;
 
 impl AppMode {
     #[must_use]
@@ -423,10 +443,14 @@ pub struct App {
     pub use_alt_screen: bool,
     pub use_mouse_capture: bool,
     pub use_bracketed_paste: bool,
+    pub use_paste_burst_detection: bool,
     #[allow(dead_code)]
     pub system_prompt: Option<SystemPrompt>,
     pub input_history: Vec<String>,
+    pub draft_history: Vec<String>,
     pub history_index: Option<usize>,
+    pub composer_history_search: Option<ComposerHistorySearch>,
+    pub selected_attachment_index: Option<usize>,
     pub auto_compact: bool,
     pub calm_mode: bool,
     pub low_motion: bool,
@@ -589,11 +613,9 @@ pub struct App {
     pub queued_messages: VecDeque<QueuedMessage>,
     /// Draft queued message being edited
     pub queued_draft: Option<QueuedMessage>,
-    /// Composer inputs the user steered with Esc during a running turn. Held
-    /// here until the in-flight turn aborts; then merged into a single fresh
-    /// turn (#122). Not the same channel as the engine's mid-turn steer
-    /// (`EngineHandle::steer`) — those flow through `queued_messages`/`Steer`
-    /// disposition and never abort the current turn.
+    /// Legacy pending-steer bucket retained for session compatibility. New
+    /// in-flight input uses Enter for same-turn steering and Tab for queued
+    /// follow-ups; Esc only cancels the active turn.
     pub pending_steers: VecDeque<QueuedMessage>,
     /// Engine-rejected steers (e.g. a tool was already running and couldn't be
     /// cancelled cleanly). Surfaced in the pending-input preview so the user
@@ -601,10 +623,7 @@ pub struct App {
     /// produces these; the field is scaffolding for a future signalling
     /// channel and the bucket renders identically when populated.
     pub rejected_steers: VecDeque<String>,
-    /// Set when the user pressed Esc with non-empty input. The next
-    /// `TurnComplete::Interrupted` event drains `pending_steers`, merges them
-    /// into one user message, and dispatches a fresh turn. Cleared on drain
-    /// (or whenever the queue empties out).
+    /// Legacy resend flag for pending steer recovery.
     pub submit_pending_steers_after_interrupt: bool,
     /// Start time for current turn
     pub turn_started_at: Option<Instant>,
@@ -677,13 +696,12 @@ pub struct QueuedMessage {
 /// How a freshly-typed user input should be sent.
 ///
 /// Picked by [`App::decide_submit_disposition`] when the user hits Enter on a
-/// non-empty composer. The Esc-to-steer path (typed input + Esc during a
-/// running turn) is separate — see [`App::push_pending_steer`].
+/// non-empty composer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SubmitDisposition {
-    /// Engine idle (or offline mode without a busy turn): send immediately.
+    /// Engine idle and online: send immediately.
     Immediate,
-    /// Engine busy and offline: park on `queued_messages` for end-of-turn drain.
+    /// Offline mode: park on `queued_messages`.
     Queue,
     /// Engine busy and online: forward as a mid-turn steer.
     Steer,
@@ -781,6 +799,7 @@ impl App {
         let sidebar_width_percent = settings.sidebar_width_percent;
         let sidebar_focus = SidebarFocus::from_setting(&settings.sidebar_focus);
         let max_input_history = settings.max_input_history;
+        let use_paste_burst_detection = settings.paste_burst_detection;
         let ui_theme = palette::UI_THEME;
         let model = settings.default_model.clone().unwrap_or(model);
         let compact_threshold =
@@ -865,9 +884,13 @@ impl App {
             use_alt_screen,
             use_mouse_capture,
             use_bracketed_paste,
+            use_paste_burst_detection,
             system_prompt: None,
             input_history: Vec::new(),
+            draft_history: Vec::new(),
             history_index: None,
+            composer_history_search: None,
+            selected_attachment_index: None,
             auto_compact,
             calm_mode,
             low_motion,
@@ -1771,6 +1794,7 @@ impl App {
         if text.is_empty() {
             return;
         }
+        self.selected_attachment_index = None;
         let cursor = self.cursor_position.min(char_count(&self.input));
         let byte_index = byte_index_at_char(&self.input, cursor);
         self.input.insert_str(byte_index, text);
@@ -1782,6 +1806,9 @@ impl App {
     }
 
     pub fn insert_paste_text(&mut self, text: &str) {
+        if let Some(pending) = self.paste_burst.flush_before_modified_input() {
+            self.insert_str(&pending);
+        }
         let normalized = normalize_paste_text(text);
         if !normalized.is_empty() {
             self.insert_str(&normalized);
@@ -1812,6 +1839,98 @@ impl App {
         }
         self.insert_str(&inserted);
         self.paste_burst.clear_after_explicit_paste();
+    }
+
+    pub fn composer_attachment_count(&self) -> usize {
+        crate::tui::file_mention::media_attachment_references(&self.input).len()
+    }
+
+    pub fn selected_composer_attachment_index(&self) -> Option<usize> {
+        let count = self.composer_attachment_count();
+        self.selected_attachment_index
+            .filter(|index| *index < count)
+    }
+
+    pub fn select_previous_composer_attachment(&mut self) -> bool {
+        let count = self.composer_attachment_count();
+        if count == 0 {
+            self.selected_attachment_index = None;
+            return false;
+        }
+
+        let next = self
+            .selected_composer_attachment_index()
+            .map_or(count.saturating_sub(1), |index| index.saturating_sub(1));
+        self.selected_attachment_index = Some(next);
+        self.cursor_position = 0;
+        self.status_message = Some("Attachment selected - Backspace/Delete removes it".to_string());
+        self.needs_redraw = true;
+        true
+    }
+
+    pub fn select_next_composer_attachment(&mut self) -> bool {
+        let count = self.composer_attachment_count();
+        let Some(index) = self.selected_composer_attachment_index() else {
+            return false;
+        };
+        if index + 1 < count {
+            self.selected_attachment_index = Some(index + 1);
+            self.status_message =
+                Some("Attachment selected - Backspace/Delete removes it".to_string());
+        } else {
+            self.selected_attachment_index = None;
+            self.status_message = Some("Composer focused".to_string());
+        }
+        self.needs_redraw = true;
+        true
+    }
+
+    pub fn clear_composer_attachment_selection(&mut self) -> bool {
+        if self.selected_attachment_index.take().is_some() {
+            self.status_message = Some("Composer focused".to_string());
+            self.needs_redraw = true;
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn remove_selected_composer_attachment(&mut self) -> bool {
+        let references = crate::tui::file_mention::media_attachment_references(&self.input);
+        let Some(index) = self
+            .selected_composer_attachment_index()
+            .filter(|index| *index < references.len())
+        else {
+            self.selected_attachment_index = None;
+            return false;
+        };
+        let reference = references[index].clone();
+        let cursor_byte = byte_index_at_char(&self.input, self.cursor_position);
+        let new_cursor_byte = if cursor_byte <= reference.start_byte {
+            cursor_byte
+        } else if cursor_byte >= reference.end_byte {
+            cursor_byte.saturating_sub(reference.end_byte - reference.start_byte)
+        } else {
+            reference.start_byte
+        };
+
+        self.input
+            .replace_range(reference.start_byte..reference.end_byte, "");
+        self.cursor_position = self.input[..new_cursor_byte.min(self.input.len())]
+            .chars()
+            .count();
+        let remaining = self.composer_attachment_count();
+        self.selected_attachment_index = if remaining == 0 {
+            None
+        } else {
+            Some(index.min(remaining.saturating_sub(1)))
+        };
+        self.slash_menu_hidden = false;
+        self.mention_menu_hidden = false;
+        self.mention_menu_selected = 0;
+        self.status_message = Some(format!("Removed attachment: {}", reference.path));
+        self.needs_redraw = true;
+        true
     }
 
     pub fn flush_paste_burst_if_due(&mut self, now: Instant) -> bool {
@@ -1859,23 +1978,19 @@ impl App {
     /// Paste from clipboard into input
     pub fn paste_from_clipboard(&mut self) {
         if let Some(content) = self.clipboard.read(self.workspace.as_path()) {
-            if let Some(pending) = self.paste_burst.flush_before_modified_input() {
-                self.insert_str(&pending);
+            self.apply_clipboard_content(content);
+        }
+    }
+
+    pub fn apply_clipboard_content(&mut self, content: ClipboardContent) {
+        match content {
+            ClipboardContent::Text(text) => {
+                self.insert_paste_text(&text);
             }
-            match content {
-                ClipboardContent::Text(text) => {
-                    self.insert_paste_text(&text);
-                }
-                ClipboardContent::Image(pasted) => {
-                    let description = format!("{} ({})", pasted.short_label(), pasted.size_label());
-                    self.insert_media_attachment("image", &pasted.path, Some(&description));
-                    self.status_message = Some(format!(
-                        "Pasted {} image ({}) -> {}",
-                        pasted.short_label(),
-                        pasted.size_label(),
-                        pasted.path.display()
-                    ));
-                }
+            ClipboardContent::Image(pasted) => {
+                let description = format!("{} ({})", pasted.short_label(), pasted.size_label());
+                self.insert_media_attachment("image", &pasted.path, Some(&description));
+                self.status_message = Some(format!("Attached image: {description}"));
             }
         }
     }
@@ -1913,6 +2028,7 @@ impl App {
     }
 
     pub fn insert_char(&mut self, c: char) {
+        self.selected_attachment_index = None;
         let cursor = self.cursor_position.min(char_count(&self.input));
         let byte_index = byte_index_at_char(&self.input, cursor);
         self.input.insert(byte_index, c);
@@ -1924,6 +2040,7 @@ impl App {
     }
 
     pub fn delete_char(&mut self) {
+        self.selected_attachment_index = None;
         if self.cursor_position == 0 {
             return;
         }
@@ -1939,6 +2056,7 @@ impl App {
     }
 
     pub fn delete_char_forward(&mut self) {
+        self.selected_attachment_index = None;
         if self.input.is_empty() {
             return;
         }
@@ -2042,9 +2160,205 @@ impl App {
     pub fn clear_input(&mut self) {
         self.input.clear();
         self.cursor_position = 0;
+        self.selected_attachment_index = None;
         self.slash_menu_selected = 0;
         self.slash_menu_hidden = false;
         self.paste_burst.clear_after_explicit_paste();
+        self.needs_redraw = true;
+    }
+
+    pub fn clear_input_recoverable(&mut self) {
+        self.stash_current_input_for_recovery();
+        self.clear_input();
+    }
+
+    pub fn stash_current_input_for_recovery(&mut self) {
+        let draft = self.input.clone();
+        self.remember_draft_for_recovery(draft);
+    }
+
+    fn remember_draft_for_recovery(&mut self, draft: String) {
+        if draft.trim().is_empty() {
+            return;
+        }
+        self.draft_history.retain(|existing| existing != &draft);
+        self.draft_history.push(draft);
+        if self.draft_history.len() > MAX_DRAFT_HISTORY {
+            let excess = self.draft_history.len() - MAX_DRAFT_HISTORY;
+            self.draft_history.drain(0..excess);
+        }
+    }
+
+    pub fn start_history_search(&mut self) {
+        if self.composer_history_search.is_some() {
+            return;
+        }
+        self.composer_history_search = Some(ComposerHistorySearch::new(
+            self.input.clone(),
+            self.cursor_position,
+        ));
+        self.slash_menu_hidden = true;
+        self.mention_menu_hidden = true;
+        self.paste_burst.clear_after_explicit_paste();
+        self.status_message = Some("History search: type to filter, Enter accepts".to_string());
+        self.needs_redraw = true;
+    }
+
+    pub fn is_history_search_active(&self) -> bool {
+        self.composer_history_search.is_some()
+    }
+
+    pub fn history_search_query(&self) -> Option<&str> {
+        self.composer_history_search
+            .as_ref()
+            .map(|search| search.query.as_str())
+    }
+
+    pub fn history_search_selected_index(&self) -> usize {
+        self.composer_history_search
+            .as_ref()
+            .map_or(0, |search| search.selected)
+    }
+
+    pub fn composer_display_input(&self) -> &str {
+        self.history_search_query().unwrap_or(&self.input)
+    }
+
+    pub fn composer_display_cursor(&self) -> usize {
+        self.composer_history_search
+            .as_ref()
+            .map_or(self.cursor_position, |search| char_count(&search.query))
+    }
+
+    pub fn history_search_matches(&self) -> Vec<String> {
+        let Some(query) = self.history_search_query() else {
+            return Vec::new();
+        };
+        self.history_search_matches_for_query(query)
+    }
+
+    fn history_search_matches_for_query(&self, query: &str) -> Vec<String> {
+        let normalized_query = query.trim().to_ascii_lowercase();
+        let mut seen = HashSet::new();
+        let mut matches = Vec::new();
+
+        for candidate in self
+            .draft_history
+            .iter()
+            .rev()
+            .chain(self.input_history.iter().rev())
+        {
+            if candidate.trim().is_empty() || !seen.insert(candidate.clone()) {
+                continue;
+            }
+            if normalized_query.is_empty()
+                || candidate.to_ascii_lowercase().contains(&normalized_query)
+            {
+                matches.push(candidate.clone());
+            }
+        }
+
+        matches
+    }
+
+    fn clamp_history_search_selection(&mut self) {
+        let Some(search) = self.composer_history_search.as_ref() else {
+            return;
+        };
+        let selected = search.selected;
+        let query = search.query.clone();
+        let match_count = self.history_search_matches_for_query(&query).len();
+        if let Some(search) = self.composer_history_search.as_mut() {
+            search.selected = if match_count == 0 {
+                0
+            } else {
+                selected.min(match_count.saturating_sub(1))
+            };
+        }
+    }
+
+    pub fn history_search_insert_char(&mut self, ch: char) {
+        if let Some(search) = self.composer_history_search.as_mut() {
+            search.query.push(ch);
+            search.selected = 0;
+            self.status_message = Some("History search: Enter accepts, Esc restores".to_string());
+            self.needs_redraw = true;
+        }
+    }
+
+    pub fn history_search_insert_str(&mut self, text: &str) {
+        if text.is_empty() {
+            return;
+        }
+        if let Some(search) = self.composer_history_search.as_mut() {
+            search.query.push_str(&normalize_paste_text(text));
+            search.selected = 0;
+            self.status_message = Some("History search: Enter accepts, Esc restores".to_string());
+            self.needs_redraw = true;
+        }
+    }
+
+    pub fn history_search_backspace(&mut self) {
+        if let Some(search) = self.composer_history_search.as_mut() {
+            search.query.pop();
+            search.selected = 0;
+            self.needs_redraw = true;
+        }
+        self.clamp_history_search_selection();
+    }
+
+    pub fn history_search_select_previous(&mut self) {
+        if let Some(search) = self.composer_history_search.as_mut() {
+            search.selected = search.selected.saturating_sub(1);
+            self.needs_redraw = true;
+        }
+    }
+
+    pub fn history_search_select_next(&mut self) {
+        let Some(search) = self.composer_history_search.as_ref() else {
+            return;
+        };
+        let query = search.query.clone();
+        let selected = search.selected;
+        let match_count = self.history_search_matches_for_query(&query).len();
+        if let Some(search) = self.composer_history_search.as_mut()
+            && match_count > 0
+        {
+            search.selected = (selected + 1).min(match_count.saturating_sub(1));
+            self.needs_redraw = true;
+        }
+    }
+
+    pub fn accept_history_search(&mut self) -> bool {
+        let Some(search) = self.composer_history_search.take() else {
+            return false;
+        };
+        let matches = self.history_search_matches_for_query(&search.query);
+        if let Some(selected) = matches
+            .get(search.selected.min(matches.len().saturating_sub(1)))
+            .cloned()
+        {
+            self.input = selected;
+            self.cursor_position = char_count(&self.input);
+            self.history_index = None;
+            self.status_message = Some("History match inserted into composer".to_string());
+            self.needs_redraw = true;
+            true
+        } else {
+            self.composer_history_search = Some(search);
+            self.status_message = Some("No history matches".to_string());
+            self.needs_redraw = true;
+            false
+        }
+    }
+
+    pub fn cancel_history_search(&mut self) {
+        let Some(search) = self.composer_history_search.take() else {
+            return;
+        };
+        self.input = search.pre_search_input;
+        self.cursor_position = search.pre_search_cursor.min(char_count(&self.input));
+        self.status_message = Some("History search canceled".to_string());
         self.needs_redraw = true;
     }
 
@@ -2108,13 +2422,15 @@ impl App {
         };
         self.input = msg.display.clone();
         self.cursor_position = char_count(&self.input);
+        self.selected_attachment_index = None;
         self.queued_draft = Some(msg);
         self.needs_redraw = true;
         true
     }
 
-    /// Park a composer input the user steered with Esc. Re-armed each call so
-    /// rapid Esc taps accumulate rather than overwriting each other.
+    /// Park a legacy pending steer. New keyboard handling routes running-turn
+    /// drafts through Enter (same-turn steer) or Tab (next-turn follow-up).
+    #[allow(dead_code)]
     pub fn push_pending_steer(&mut self, message: QueuedMessage) {
         self.pending_steers.push_back(message);
         self.submit_pending_steers_after_interrupt = true;
@@ -2132,21 +2448,19 @@ impl App {
         self.pending_steers.drain(..).collect()
     }
 
-    /// Decide how to route a fresh composer submit. Esc-to-steer goes through
-    /// [`Self::push_pending_steer`] instead; this is the Enter path.
+    /// Decide how to route a fresh composer submit.
     ///
-    /// Truth table (preserves the pre-refactor behaviour):
+    /// Truth table:
     ///   offline=F, busy=F → Immediate
     ///   offline=F, busy=T → Steer
     ///   offline=T, busy=F → Queue
-    ///   offline=T, busy=T → Steer (in-flight turn still owns the wire; the
-    ///     steer attempt falls back to queueing on send failure)
+    ///   offline=T, busy=T → Queue
     #[must_use]
     pub fn decide_submit_disposition(&self) -> SubmitDisposition {
-        if self.is_loading {
-            SubmitDisposition::Steer
-        } else if self.offline_mode {
+        if self.offline_mode {
             SubmitDisposition::Queue
+        } else if self.is_loading {
+            SubmitDisposition::Steer
         } else {
             SubmitDisposition::Immediate
         }
@@ -2186,6 +2500,7 @@ impl App {
         self.history_index = Some(new_index);
         self.input = self.input_history[new_index].clone();
         self.cursor_position = char_count(&self.input);
+        self.selected_attachment_index = None;
         self.slash_menu_hidden = false;
         self.paste_burst.clear_after_explicit_paste();
     }
@@ -2201,6 +2516,7 @@ impl App {
                     self.history_index = Some(i + 1);
                     self.input = self.input_history[i + 1].clone();
                     self.cursor_position = char_count(&self.input);
+                    self.selected_attachment_index = None;
                     self.slash_menu_hidden = false;
                     self.paste_burst.clear_after_explicit_paste();
                 } else {
@@ -2375,6 +2691,7 @@ mod tests {
     use super::*;
     use crate::config::Config;
     use crate::tools::plan::{PlanItemArg, StepStatus, UpdatePlanArgs};
+    use crate::tui::clipboard::PastedImage;
 
     fn test_options(yolo: bool) -> TuiOptions {
         TuiOptions {
@@ -2644,6 +2961,185 @@ mod tests {
     }
 
     #[test]
+    fn history_search_filters_matches_and_skips_duplicates() {
+        let mut app = App::new(test_options(false), &Config::default());
+        app.input_history.push("alpha one".to_string());
+        app.input_history.push("beta two".to_string());
+        app.input_history.push("alpha one".to_string());
+        app.draft_history.push("draft alpha".to_string());
+
+        app.start_history_search();
+        app.history_search_insert_str("alpha");
+
+        assert_eq!(
+            app.history_search_matches(),
+            vec!["draft alpha".to_string(), "alpha one".to_string()]
+        );
+    }
+
+    #[test]
+    fn history_search_accepts_match_without_submitting() {
+        let mut app = App::new(test_options(false), &Config::default());
+        app.input_history.push("older prompt".to_string());
+
+        app.start_history_search();
+        app.history_search_insert_str("older");
+
+        assert!(app.accept_history_search());
+        assert_eq!(app.input, "older prompt");
+        assert_eq!(app.cursor_position, "older prompt".chars().count());
+        assert!(app.composer_history_search.is_none());
+    }
+
+    #[test]
+    fn history_search_cancel_restores_pre_search_draft() {
+        let mut app = App::new(test_options(false), &Config::default());
+        app.input = "current draft".to_string();
+        app.cursor_position = 7;
+        app.input_history.push("older prompt".to_string());
+
+        app.start_history_search();
+        app.history_search_insert_str("older");
+        app.cancel_history_search();
+
+        assert_eq!(app.input, "current draft");
+        assert_eq!(app.cursor_position, 7);
+        assert!(app.composer_history_search.is_none());
+    }
+
+    #[test]
+    fn recoverable_clear_stashes_nonempty_draft() {
+        let mut app = App::new(test_options(false), &Config::default());
+        app.input = "recover this".to_string();
+        app.cursor_position = app.input.chars().count();
+
+        app.clear_input_recoverable();
+        app.start_history_search();
+        app.history_search_insert_str("recover");
+
+        assert_eq!(
+            app.history_search_matches(),
+            vec!["recover this".to_string()]
+        );
+    }
+
+    #[test]
+    fn composer_paste_flushes_pending_burst_and_normalizes_crlf() {
+        let mut app = App::new(test_options(false), &Config::default());
+        app.use_paste_burst_detection = true;
+        let now = Instant::now();
+        let key = crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char('x'),
+            crossterm::event::KeyModifiers::NONE,
+        );
+
+        assert!(crate::tui::paste::handle_paste_burst_key(
+            &mut app, &key, now
+        ));
+        assert!(
+            app.input.is_empty(),
+            "first burst char should stay buffered"
+        );
+
+        app.insert_paste_text("a\r\nb\rc");
+
+        assert_eq!(app.input, "xa\nbc");
+        assert_eq!(app.cursor_position, "xa\nbc".chars().count());
+        assert!(!app.paste_burst.is_active());
+    }
+
+    #[test]
+    fn clipboard_text_paste_matches_bracketed_paste_state() {
+        let text = "alpha\r\nbeta";
+        let mut bracketed = App::new(test_options(false), &Config::default());
+        let mut clipboard = App::new(test_options(false), &Config::default());
+
+        bracketed.insert_paste_text(text);
+        clipboard.apply_clipboard_content(ClipboardContent::Text(text.to_string()));
+
+        assert_eq!(clipboard.input, bracketed.input);
+        assert_eq!(clipboard.cursor_position, bracketed.cursor_position);
+        assert_eq!(clipboard.slash_menu_hidden, bracketed.slash_menu_hidden);
+        assert_eq!(clipboard.mention_menu_hidden, bracketed.mention_menu_hidden);
+    }
+
+    #[test]
+    fn clipboard_image_paste_keeps_adjacent_text_and_concise_status() {
+        let mut app = App::new(test_options(false), &Config::default());
+        app.input = "before after".to_string();
+        app.cursor_position = "before".chars().count();
+
+        app.apply_clipboard_content(ClipboardContent::Image(PastedImage {
+            path: PathBuf::from("/tmp/pasted.png"),
+            width: 8,
+            height: 4,
+            byte_len: 2048,
+        }));
+
+        assert!(
+            app.input
+                .contains("before\n[Attached image: 8x4 PNG (2KB) at /tmp/pasted.png]")
+        );
+        assert!(app.input.contains("] after"));
+        let status = app.status_message.as_deref().expect("status message");
+        assert_eq!(status, "Attached image: 8x4 PNG (2KB)");
+    }
+
+    #[test]
+    fn pasted_text_and_image_placeholders_survive_history_and_queue_paths() {
+        let mut app = App::new(test_options(false), &Config::default());
+        app.insert_paste_text("line 1\r\nline 2");
+        app.insert_media_attachment("image", Path::new("/tmp/pasted.png"), Some("8x4 PNG (2KB)"));
+
+        let submitted = app.submit_input().expect("submitted input");
+        assert!(submitted.contains("line 1\nline 2"));
+        assert!(submitted.contains("[Attached image: 8x4 PNG (2KB) at /tmp/pasted.png]"));
+
+        app.history_up();
+        assert_eq!(app.input, submitted);
+        assert_eq!(app.composer_attachment_count(), 1);
+
+        app.clear_input();
+        app.queue_message(QueuedMessage::new(
+            submitted.clone(),
+            Some("Use this skill".to_string()),
+        ));
+        assert!(app.pop_last_queued_into_draft());
+        assert_eq!(app.input, submitted);
+        assert_eq!(app.composer_attachment_count(), 1);
+        assert_eq!(
+            app.queued_draft
+                .as_ref()
+                .and_then(|draft| draft.skill_instruction.as_deref()),
+            Some("Use this skill")
+        );
+
+        app.push_pending_steer(QueuedMessage::new(submitted.clone(), None));
+        let steers = app.drain_pending_steers();
+        assert_eq!(steers[0].display, submitted);
+    }
+
+    #[test]
+    fn selected_attachment_row_removes_placeholder_without_manual_editing() {
+        let mut app = App::new(test_options(false), &Config::default());
+        app.input = "before".to_string();
+        app.cursor_position = "before".chars().count();
+        app.insert_media_attachment("image", Path::new("/tmp/pasted.png"), Some("8x4 PNG"));
+        app.insert_str("after");
+
+        app.move_cursor_start();
+        assert!(app.select_previous_composer_attachment());
+        assert_eq!(app.selected_composer_attachment_index(), Some(0));
+        assert!(app.remove_selected_composer_attachment());
+
+        assert!(!app.input.contains("[Attached image:"));
+        assert!(app.input.contains("before"));
+        assert!(app.input.contains("after"));
+        assert_eq!(app.composer_attachment_count(), 0);
+        assert!(app.selected_composer_attachment_index().is_none());
+    }
+
+    #[test]
     fn kill_to_end_of_line_cuts_from_middle_of_word() {
         let mut app = App::new(test_options(false), &Config::default());
         app.input = "hello world".to_string();
@@ -2780,7 +3276,7 @@ mod tests {
         assert!(deadline > Instant::now(), "fresh deadline in the future");
     }
 
-    // ---- Issue #122: Esc-to-steer + queue visibility ----
+    // ---- Issue #208: in-flight input routing ----
 
     #[test]
     fn submit_disposition_immediate_when_idle_and_online() {
@@ -2810,13 +3306,11 @@ mod tests {
     }
 
     #[test]
-    fn submit_disposition_offline_busy_still_steers() {
-        // In-flight turn owns the wire even in offline mode; steer attempt
-        // catches the send error and falls back to the queue.
+    fn submit_disposition_offline_busy_queues() {
         let mut app = App::new(test_options(false), &Config::default());
         app.is_loading = true;
         app.offline_mode = true;
-        assert_eq!(app.decide_submit_disposition(), SubmitDisposition::Steer);
+        assert_eq!(app.decide_submit_disposition(), SubmitDisposition::Queue);
     }
 
     #[test]

--- a/crates/tui/src/tui/file_mention.rs
+++ b/crates/tui/src/tui/file_mention.rs
@@ -51,6 +51,7 @@ pub struct FileMentionPreview {
     pub label: String,
     pub detail: Option<String>,
     pub included: bool,
+    pub removable: bool,
 }
 
 /// Durable, compact metadata for a user-visible context reference.
@@ -338,6 +339,7 @@ pub fn pending_context_previews(
             label: reference.label,
             detail: reference.detail,
             included: reference.included,
+            removable: reference.source == ContextReferenceSource::Attachment,
         })
         .collect()
 }
@@ -477,15 +479,21 @@ fn context_reference_for_mention(
     }
 }
 
-#[derive(Debug, Clone)]
-struct MediaAttachmentReference {
-    kind: String,
-    path: String,
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MediaAttachmentReference {
+    pub kind: String,
+    pub path: String,
+    pub start_byte: usize,
+    pub end_byte: usize,
 }
 
-fn extract_media_attachment_references(input: &str) -> Vec<MediaAttachmentReference> {
+pub fn media_attachment_references(input: &str) -> Vec<MediaAttachmentReference> {
     let mut out = Vec::new();
-    for line in input.lines() {
+    let mut offset = 0usize;
+    for line in input.split_inclusive('\n') {
+        let start_byte = offset;
+        let end_byte = offset + line.len();
+        offset = end_byte;
         let trimmed = line.trim();
         let Some(body) = trimmed
             .strip_prefix("[Attached ")
@@ -504,10 +512,16 @@ fn extract_media_attachment_references(input: &str) -> Vec<MediaAttachmentRefere
             out.push(MediaAttachmentReference {
                 kind: kind.trim().to_string(),
                 path: path.to_string(),
+                start_byte,
+                end_byte,
             });
         }
     }
     out
+}
+
+fn extract_media_attachment_references(input: &str) -> Vec<MediaAttachmentReference> {
+    media_attachment_references(input)
 }
 
 fn local_context_from_file_mentions(
@@ -916,6 +930,22 @@ mod tests {
                 .iter()
                 .any(|item| item.kind == "image" && item.included),
             "/attach media should be included: {previews:?}"
+        );
+    }
+
+    #[test]
+    fn media_attachment_references_include_removable_line_ranges() {
+        let input = "before\n[Attached image: 8x4 PNG at /tmp/pasted.png]\nafter";
+
+        let references = media_attachment_references(input);
+
+        assert_eq!(references.len(), 1);
+        let reference = &references[0];
+        assert_eq!(reference.kind, "image");
+        assert_eq!(reference.path, "/tmp/pasted.png");
+        assert_eq!(
+            &input[reference.start_byte..reference.end_byte],
+            "[Attached image: 8x4 PNG at /tmp/pasted.png]\n"
         );
     }
 

--- a/crates/tui/src/tui/keybindings.rs
+++ b/crates/tui/src/tui/keybindings.rs
@@ -78,7 +78,7 @@ pub const KEYBINDINGS: &[KeybindingEntry] = &[
     // --- Navigation ---
     KeybindingEntry {
         chord: "↑ / ↓",
-        description: "Scroll transcript or navigate input history",
+        description: "Scroll transcript, navigate input history, or select composer attachments",
         section: KeybindingSection::Navigation,
     },
     KeybindingEntry {
@@ -124,12 +124,17 @@ pub const KEYBINDINGS: &[KeybindingEntry] = &[
     },
     KeybindingEntry {
         chord: "Backspace / Delete",
-        description: "Delete character before / after the cursor",
+        description: "Delete character before / after the cursor, or remove selected attachment",
         section: KeybindingSection::Editing,
     },
     KeybindingEntry {
         chord: "Ctrl+U",
         description: "Clear the current draft",
+        section: KeybindingSection::Editing,
+    },
+    KeybindingEntry {
+        chord: "Alt+R",
+        description: "Search prompt history and recover local drafts",
         section: KeybindingSection::Editing,
     },
     KeybindingEntry {
@@ -206,7 +211,7 @@ pub const KEYBINDINGS: &[KeybindingEntry] = &[
     // --- Modes ---
     KeybindingEntry {
         chord: "Tab / Shift+Tab",
-        description: "Complete /command or cycle modes (Shift+Tab cycles reasoning effort)",
+        description: "Complete /command, queue running-turn follow-up, or cycle modes",
         section: KeybindingSection::Modes,
     },
     KeybindingEntry {

--- a/crates/tui/src/tui/paste.rs
+++ b/crates/tui/src/tui/paste.rs
@@ -17,6 +17,10 @@ use super::paste_burst::CharDecision;
 /// further input handling); `false` when the key still needs the normal
 /// composer path.
 pub fn handle_paste_burst_key(app: &mut App, key: &KeyEvent, now: Instant) -> bool {
+    if !app.use_paste_burst_detection {
+        return false;
+    }
+
     let has_ctrl_alt_or_super = key.modifiers.contains(KeyModifiers::CONTROL)
         || key.modifiers.contains(KeyModifiers::ALT)
         || key.modifiers.contains(KeyModifiers::SUPER);
@@ -109,4 +113,104 @@ fn apply_paste_burst_retro_capture(
 
 fn in_command_context(app: &App) -> bool {
     app.input.starts_with('/')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+    use crate::tui::app::TuiOptions;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    use std::path::PathBuf;
+    use std::time::{Duration, Instant};
+
+    fn test_app() -> App {
+        let options = TuiOptions {
+            model: "deepseek-v4-pro".to_string(),
+            workspace: PathBuf::from("."),
+            allow_shell: false,
+            use_alt_screen: true,
+            use_mouse_capture: false,
+            use_bracketed_paste: true,
+            max_subagents: 1,
+            skills_dir: PathBuf::from("."),
+            memory_path: PathBuf::from("memory.md"),
+            notes_path: PathBuf::from("notes.txt"),
+            mcp_config_path: PathBuf::from("mcp.json"),
+            use_memory: false,
+            start_in_agent_mode: false,
+            skip_onboarding: true,
+            yolo: false,
+            resume_session_id: None,
+        };
+        let mut app = App::new(options, &Config::default());
+        app.use_paste_burst_detection = true;
+        app
+    }
+
+    fn plain(ch: char) -> KeyEvent {
+        KeyEvent::new(KeyCode::Char(ch), KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn raw_multiline_paste_buffers_enter_instead_of_submitting() {
+        let mut app = test_app();
+        let t0 = Instant::now();
+
+        assert!(handle_paste_burst_key(&mut app, &plain('a'), t0));
+        assert!(handle_paste_burst_key(
+            &mut app,
+            &plain('b'),
+            t0 + Duration::from_millis(1)
+        ));
+        assert!(handle_paste_burst_key(
+            &mut app,
+            &plain('c'),
+            t0 + Duration::from_millis(2)
+        ));
+        assert!(handle_paste_burst_key(
+            &mut app,
+            &KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+            t0 + Duration::from_millis(3)
+        ));
+
+        assert!(app.input.is_empty(), "paste remains buffered until idle");
+        assert!(app.flush_paste_burst_if_due(
+            t0 + Duration::from_millis(3)
+                + crate::tui::paste_burst::PasteBurst::recommended_active_flush_delay()
+        ));
+        assert_eq!(app.input, "abc\n");
+    }
+
+    #[test]
+    fn paste_buffered_question_mark_does_not_fall_through_to_help_shortcut() {
+        let mut app = test_app();
+        let t0 = Instant::now();
+
+        assert!(handle_paste_burst_key(&mut app, &plain('?'), t0));
+
+        assert!(app.input.is_empty(), "shortcut char stays buffered first");
+        assert!(app.view_stack.is_empty(), "help modal must not open");
+        assert!(app.flush_paste_burst_if_due(
+            t0 + crate::tui::paste_burst::PasteBurst::recommended_flush_delay()
+        ));
+        assert_eq!(app.input, "?");
+    }
+
+    #[test]
+    fn paste_burst_detection_can_be_disabled_without_disabling_bracketed_paste() {
+        let mut app = test_app();
+        app.use_paste_burst_detection = false;
+
+        assert!(!handle_paste_burst_key(
+            &mut app,
+            &plain('a'),
+            Instant::now()
+        ));
+        assert!(app.input.is_empty());
+
+        app.insert_paste_text("line 1\r\nline 2");
+        assert_eq!(app.input, "line 1\nline 2");
+        assert!(app.use_bracketed_paste);
+    }
 }

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -750,9 +750,9 @@ async fn run_event_loop(
                         }
                         app.plan_tool_used_in_turn = false;
 
-                        // Esc-to-steer (#122): the user interrupted with input
-                        // pending. Merge every steered message into one fresh
-                        // turn so the model sees a single coherent prompt.
+                        // Legacy pending-steer recovery. Current keyboard
+                        // handling keeps Esc as cancel-only, but older saved
+                        // state may still carry pending steers.
                         if status == crate::core::events::TurnOutcomeStatus::Interrupted
                             && app.submit_pending_steers_after_interrupt
                         {
@@ -1098,7 +1098,9 @@ async fn run_event_loop(
         }
 
         let now = Instant::now();
-        app.flush_paste_burst_if_due(now);
+        if app.use_paste_burst_detection {
+            app.flush_paste_burst_if_due(now);
+        }
         app.sync_status_message_to_toasts();
         // Expire the "Press Ctrl+C again to quit" prompt silently after its
         // window. Triggers a redraw if the prompt was visible.
@@ -1134,7 +1136,9 @@ async fn run_event_loop(
         } else {
             Duration::from_millis(idle_poll_ms(app))
         };
-        if let Some(until_flush) = app.paste_burst.next_flush_delay(now) {
+        if app.use_paste_burst_detection
+            && let Some(until_flush) = app.paste_burst.next_flush_delay(now)
+        {
             poll_timeout = poll_timeout.min(until_flush);
         }
         if let Some(until_draw) = draw_wait {
@@ -1161,11 +1165,10 @@ async fn run_event_loop(
                     // Paste into API key input
                     app.insert_api_key_str(text);
                     sync_api_key_validation_status(app, false);
+                } else if app.is_history_search_active() {
+                    app.history_search_insert_str(text);
                 } else {
                     // Paste into main input
-                    if let Some(pending) = app.paste_burst.flush_before_modified_input() {
-                        app.insert_str(&pending);
-                    }
                     app.insert_paste_text(text);
                 }
                 continue;
@@ -1407,8 +1410,24 @@ async fn run_event_loop(
                 continue;
             }
 
+            if app.is_history_search_active() {
+                handle_history_search_key(app, key);
+                continue;
+            }
+
+            if matches!(key.code, KeyCode::Char('r') | KeyCode::Char('R'))
+                && key.modifiers.contains(KeyModifiers::ALT)
+                && !key.modifiers.contains(KeyModifiers::CONTROL)
+                && !key.modifiers.contains(KeyModifiers::SUPER)
+            {
+                app.start_history_search();
+                continue;
+            }
+
             let now = Instant::now();
-            app.flush_paste_burst_if_due(now);
+            if app.use_paste_burst_detection {
+                app.flush_paste_burst_if_due(now);
+            }
 
             // On Windows, AltGr is delivered as `Ctrl+Alt`; treat
             // AltGr-typed chars (e.g. European layouts producing `@`, `\`,
@@ -1419,7 +1438,8 @@ async fn run_event_loop(
             let is_plain_char = matches!(key.code, KeyCode::Char(_)) && !has_ctrl_alt_or_super;
             let is_enter = matches!(key.code, KeyCode::Enter);
 
-            if !is_plain_char
+            if app.use_paste_burst_detection
+                && !is_plain_char
                 && !is_enter
                 && let Some(pending) = app.paste_burst.flush_before_modified_input()
             {
@@ -1599,6 +1619,9 @@ async fn run_event_loop(
                     let _ = engine_handle.send(Op::Shutdown).await;
                     return Ok(());
                 }
+                KeyCode::Esc if app.clear_composer_attachment_selection() => {
+                    continue;
+                }
                 KeyCode::Esc if mention_menu_open => {
                     app.mention_menu_hidden = true;
                     app.mention_menu_selected = 0;
@@ -1623,24 +1646,6 @@ async fn run_event_loop(
                         app.finalize_streaming_assistant_as_interrupted();
                         app.status_message = Some("Request cancelled".to_string());
                     }
-                    EscapeAction::SteerAndAbort => {
-                        app.backtrack.reset();
-                        if let Some(input) = app.submit_input() {
-                            let queued = build_queued_message(app, input);
-                            app.push_pending_steer(queued);
-                            engine_handle.cancel();
-                            app.is_loading = false;
-                            app.streaming_state.reset();
-                            app.runtime_turn_status = None;
-                            app.finalize_streaming_assistant_as_interrupted();
-                            let count = app.pending_steers.len();
-                            app.status_message = Some(if count == 1 {
-                                "Steering: aborting turn and resending input".to_string()
-                            } else {
-                                format!("Steering: aborting turn and resending {count} input(s)")
-                            });
-                        }
-                    }
                     EscapeAction::DiscardQueuedDraft => {
                         app.backtrack.reset();
                         app.queued_draft = None;
@@ -1648,7 +1653,7 @@ async fn run_event_loop(
                     }
                     EscapeAction::ClearInput => {
                         app.backtrack.reset();
-                        app.clear_input();
+                        app.clear_input_recoverable();
                     }
                     EscapeAction::Noop => {
                         // Nothing else cares about this Esc — route it
@@ -1709,6 +1714,22 @@ async fn run_event_loop(
                 {
                     app.slash_menu_selected = app.slash_menu_selected.saturating_sub(1);
                 }
+                KeyCode::Up
+                    if key.modifiers.is_empty()
+                        && app.selected_composer_attachment_index().is_some() =>
+                {
+                    let _ = app.select_previous_composer_attachment();
+                }
+                KeyCode::Up
+                    if key.modifiers.is_empty()
+                        && app.cursor_position == 0
+                        && !mention_menu_open
+                        && !slash_menu_open
+                        && app.composer_attachment_count() > 0 =>
+                {
+                    let _ = app.select_previous_composer_attachment();
+                    continue;
+                }
                 KeyCode::Down if key.modifiers.contains(KeyModifiers::ALT) => {
                     app.scroll_down(3);
                 }
@@ -1719,6 +1740,12 @@ async fn run_event_loop(
                 KeyCode::Down if key.modifiers.is_empty() && slash_menu_open => {
                     app.slash_menu_selected = (app.slash_menu_selected + 1)
                         .min(slash_menu_entries.len().saturating_sub(1));
+                }
+                KeyCode::Down
+                    if key.modifiers.is_empty()
+                        && app.selected_composer_attachment_index().is_some() =>
+                {
+                    let _ = app.select_next_composer_attachment();
                 }
                 KeyCode::PageUp => {
                     let page = app.last_transcript_visible.max(1);
@@ -1745,6 +1772,9 @@ async fn run_event_loop(
                         continue;
                     }
                     if crate::tui::file_mention::try_autocomplete_file_mention(app) {
+                        continue;
+                    }
+                    if app.is_loading && queue_current_draft_for_next_turn(app) {
                         continue;
                     }
                     let prior_model = app.model.clone();
@@ -1852,10 +1882,14 @@ async fn run_event_loop(
                     }
                 }
                 KeyCode::Backspace => {
-                    app.delete_char();
+                    if !app.remove_selected_composer_attachment() {
+                        app.delete_char();
+                    }
                 }
                 KeyCode::Delete => {
-                    app.delete_char_forward();
+                    if !app.remove_selected_composer_attachment() {
+                        app.delete_char_forward();
+                    }
                 }
                 KeyCode::Left => {
                     app.move_cursor_left();
@@ -1941,7 +1975,7 @@ async fn run_event_loop(
                     }
                 }
                 KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                    app.clear_input();
+                    app.clear_input_recoverable();
                 }
                 KeyCode::Char('y') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                     // Emacs-style yank from the kill buffer at the cursor.
@@ -2269,9 +2303,6 @@ fn finalize_streaming_thinking_active_entry(
 enum EscapeAction {
     CloseSlashMenu,
     CancelRequest,
-    /// Composer non-empty during a running turn — capture the input as a
-    /// pending steer, abort the turn, and re-submit on TurnComplete (#122).
-    SteerAndAbort,
     DiscardQueuedDraft,
     ClearInput,
     Noop,
@@ -2281,17 +2312,54 @@ fn next_escape_action(app: &App, slash_menu_open: bool) -> EscapeAction {
     if slash_menu_open {
         EscapeAction::CloseSlashMenu
     } else if app.is_loading {
-        if app.input.trim().is_empty() {
-            EscapeAction::CancelRequest
-        } else {
-            EscapeAction::SteerAndAbort
-        }
+        EscapeAction::CancelRequest
     } else if app.queued_draft.is_some() && app.input.is_empty() {
         EscapeAction::DiscardQueuedDraft
     } else if !app.input.is_empty() {
         EscapeAction::ClearInput
     } else {
         EscapeAction::Noop
+    }
+}
+
+fn handle_history_search_key(app: &mut App, key: KeyEvent) {
+    match key.code {
+        KeyCode::Enter => {
+            let _ = app.accept_history_search();
+        }
+        KeyCode::Esc => {
+            app.cancel_history_search();
+        }
+        KeyCode::Char('c') | KeyCode::Char('C')
+            if key.modifiers.contains(KeyModifiers::CONTROL) =>
+        {
+            app.cancel_history_search();
+        }
+        KeyCode::Backspace => {
+            app.history_search_backspace();
+        }
+        KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            while app
+                .history_search_query()
+                .is_some_and(|query| !query.is_empty())
+            {
+                app.history_search_backspace();
+            }
+        }
+        KeyCode::Up => {
+            app.history_search_select_previous();
+        }
+        KeyCode::Down => {
+            app.history_search_select_next();
+        }
+        KeyCode::Char(ch)
+            if key.modifiers.is_empty()
+                || key.modifiers == KeyModifiers::SHIFT
+                || key.modifiers == KeyModifiers::NONE =>
+        {
+            app.history_search_insert_char(ch);
+        }
+        _ => {}
     }
 }
 
@@ -2348,6 +2416,24 @@ fn sync_api_key_validation_status(app: &mut App, show_empty_error: bool) {
 fn build_queued_message(app: &mut App, input: String) -> QueuedMessage {
     let skill_instruction = app.active_skill.take();
     QueuedMessage::new(input, skill_instruction)
+}
+
+fn queue_current_draft_for_next_turn(app: &mut App) -> bool {
+    let Some(input) = app.submit_input() else {
+        return false;
+    };
+    let queued = if let Some(mut draft) = app.queued_draft.take() {
+        draft.display = input;
+        draft
+    } else {
+        build_queued_message(app, input)
+    };
+    app.queue_message(queued);
+    app.status_message = Some(format!(
+        "Queued follow-up for next turn ({} queued) - /queue to review",
+        app.queued_message_count()
+    ));
+    true
 }
 
 fn queued_message_content_for_app(
@@ -3261,6 +3347,8 @@ async fn steer_user_message(
     let content = queued_message_content_for_app(app, &message, cwd);
     let message_index = app.api_messages.len();
 
+    engine_handle.steer(content.clone()).await?;
+
     // Mirror steer input in local transcript/session state.
     app.add_message(HistoryCell::User {
         content: format!("+ {}", message.display),
@@ -3275,7 +3363,6 @@ async fn steer_user_message(
         }],
     });
 
-    engine_handle.steer(content).await?;
     app.status_message = Some("Steering current turn...".to_string());
     Ok(())
 }
@@ -3459,17 +3546,30 @@ async fn handle_plan_choice(
 ///   end-of-turn.
 fn build_pending_input_preview(app: &App) -> PendingInputPreview {
     let mut preview = PendingInputPreview::new();
+    let selected_attachment = app.selected_composer_attachment_index();
+    let mut attachment_index = 0usize;
     preview.context_items = crate::tui::file_mention::pending_context_previews(
         &app.input,
         &app.workspace,
         std::env::current_dir().ok(),
     )
     .into_iter()
-    .map(|item| ContextPreviewItem {
-        kind: item.kind,
-        label: item.label,
-        detail: item.detail,
-        included: item.included,
+    .map(|item| {
+        let selected = if item.removable {
+            let selected = selected_attachment == Some(attachment_index);
+            attachment_index += 1;
+            selected
+        } else {
+            false
+        };
+        ContextPreviewItem {
+            kind: item.kind,
+            label: item.label,
+            detail: item.detail,
+            included: item.included,
+            removable: item.removable,
+            selected,
+        }
     })
     .collect();
     preview.pending_steers = app
@@ -5261,7 +5361,8 @@ fn handle_mouse_event(app: &mut App, mouse: MouseEvent) {
         MouseEventKind::Up(MouseButton::Left) if app.transcript_selection.dragging => {
             app.transcript_selection.dragging = false;
             if selection_has_content(app) {
-                copy_active_selection(app);
+                app.status_message =
+                    Some("Selection ready - press Cmd+C or Ctrl+Shift+C to copy".to_string());
             }
         }
         _ => {}
@@ -5327,12 +5428,15 @@ fn copy_active_selection(app: &mut App) {
     if !app.transcript_selection.is_active() {
         return;
     }
-    if let Some(text) = selection_to_text(app) {
+    if let Some(text) = selection_to_text(app).filter(|text| !text.is_empty()) {
         if app.clipboard.write_text(&text).is_ok() {
             app.status_message = Some("Selection copied".to_string());
         } else {
             app.status_message = Some("Copy failed".to_string());
         }
+    } else {
+        app.transcript_selection.clear();
+        app.status_message = Some("No selection to copy".to_string());
     }
 }
 

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -69,6 +69,62 @@ fn selection_point_from_position_ignores_top_padding() {
 }
 
 #[test]
+fn selection_to_text_handles_multiline_and_reversed_endpoints() {
+    let mut app = create_test_app();
+    app.history = vec![HistoryCell::Assistant {
+        content: "alpha beta\ngamma delta".to_string(),
+        streaming: false,
+    }];
+    app.resync_history_revisions();
+    app.transcript_cache.ensure(
+        &app.history,
+        &app.history_revisions,
+        80,
+        app.transcript_render_options(),
+    );
+
+    app.transcript_selection.anchor = Some(TranscriptSelectionPoint {
+        line_index: 1,
+        column: 5,
+    });
+    app.transcript_selection.head = Some(TranscriptSelectionPoint {
+        line_index: 0,
+        column: 6,
+    });
+
+    assert_eq!(selection_to_text(&app).as_deref(), Some("a beta\n  gam"));
+}
+
+#[test]
+fn selection_has_content_rejects_zero_width_selection() {
+    let mut app = create_test_app();
+    let point = TranscriptSelectionPoint {
+        line_index: 0,
+        column: 3,
+    };
+    app.transcript_selection.anchor = Some(point);
+    app.transcript_selection.head = Some(point);
+
+    assert!(!selection_has_content(&app));
+}
+
+#[test]
+fn copy_shortcut_accepts_cmd_and_ctrl_shift_only() {
+    assert!(is_copy_shortcut(&KeyEvent::new(
+        KeyCode::Char('c'),
+        KeyModifiers::SUPER,
+    )));
+    assert!(is_copy_shortcut(&KeyEvent::new(
+        KeyCode::Char('c'),
+        KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+    )));
+    assert!(!is_copy_shortcut(&KeyEvent::new(
+        KeyCode::Char('c'),
+        KeyModifiers::CONTROL,
+    )));
+}
+
+#[test]
 fn parse_plan_choice_accepts_numbers() {
     assert_eq!(parse_plan_choice("1"), Some(PlanChoice::AcceptAgent));
     assert_eq!(parse_plan_choice("2"), Some(PlanChoice::AcceptYolo));
@@ -184,6 +240,38 @@ fn create_test_app() -> App {
         resume_session_id: None,
     };
     App::new(options, &Config::default())
+}
+
+#[test]
+fn backtrack_prefill_rehydrates_attachment_rows() {
+    let mut app = create_test_app();
+    let user_text = "inspect this\n[Attached image: /tmp/pasted.png]";
+    app.add_message(HistoryCell::User {
+        content: user_text.to_string(),
+    });
+    app.api_messages.push(Message {
+        role: "user".to_string(),
+        content: vec![ContentBlock::Text {
+            text: user_text.to_string(),
+            cache_control: None,
+        }],
+    });
+    app.add_message(HistoryCell::Assistant {
+        content: "done".to_string(),
+        streaming: false,
+    });
+    app.api_messages.push(Message {
+        role: "assistant".to_string(),
+        content: vec![ContentBlock::Text {
+            text: "done".to_string(),
+            cache_control: None,
+        }],
+    });
+
+    apply_backtrack(&mut app, 0);
+
+    assert_eq!(app.input, user_text);
+    assert_eq!(app.composer_attachment_count(), 1);
 }
 
 #[test]
@@ -887,8 +975,7 @@ fn test_esc_priority_order_matches_cancel_stack() {
     app.is_loading = true;
     app.input = "draft".to_string();
     app.mode = AppMode::Yolo;
-    // #122: typing during a running turn now steers instead of cancelling.
-    assert_eq!(next_escape_action(&app, false), EscapeAction::SteerAndAbort);
+    assert_eq!(next_escape_action(&app, false), EscapeAction::CancelRequest);
 
     app.input.clear();
     assert_eq!(next_escape_action(&app, false), EscapeAction::CancelRequest);
@@ -2216,7 +2303,7 @@ fn non_recoverable_engine_error_enters_offline_mode() {
     );
 }
 
-// ---- Issue #122: Esc-to-steer routing + steer merge ----
+// ---- Issue #208: in-flight input routing ----
 
 #[test]
 fn next_escape_action_cancels_when_loading_with_empty_input() {
@@ -2227,11 +2314,11 @@ fn next_escape_action_cancels_when_loading_with_empty_input() {
 }
 
 #[test]
-fn next_escape_action_steers_when_loading_with_input() {
+fn next_escape_action_cancels_when_loading_with_input() {
     let mut app = create_test_app();
     app.is_loading = true;
     app.input = "hold on, look at this instead".to_string();
-    assert_eq!(next_escape_action(&app, false), EscapeAction::SteerAndAbort);
+    assert_eq!(next_escape_action(&app, false), EscapeAction::CancelRequest);
 }
 
 #[test]
@@ -2264,6 +2351,47 @@ fn next_escape_action_slash_menu_takes_priority() {
     app.is_loading = true;
     app.input = "anything".to_string();
     assert_eq!(next_escape_action(&app, true), EscapeAction::CloseSlashMenu);
+}
+
+#[test]
+fn tab_queues_running_turn_draft_for_next_turn() {
+    let mut app = create_test_app();
+    app.is_loading = true;
+    app.input = "follow up next".to_string();
+    app.cursor_position = app.input.chars().count();
+
+    assert!(queue_current_draft_for_next_turn(&mut app));
+
+    assert!(app.input.is_empty());
+    assert_eq!(app.queued_message_count(), 1);
+    assert_eq!(
+        app.queued_messages.front().map(|msg| msg.display.as_str()),
+        Some("follow up next")
+    );
+    assert!(
+        app.status_message
+            .as_deref()
+            .is_some_and(|msg| msg.contains("Queued follow-up"))
+    );
+}
+
+#[test]
+fn tab_queue_preserves_queued_draft_skill_instruction() {
+    let mut app = create_test_app();
+    app.is_loading = true;
+    app.input = "edited queued follow-up".to_string();
+    app.cursor_position = app.input.chars().count();
+    app.queued_draft = Some(QueuedMessage::new(
+        "original".to_string(),
+        Some("skill body".to_string()),
+    ));
+
+    assert!(queue_current_draft_for_next_turn(&mut app));
+
+    let queued = app.queued_messages.front().expect("queued message");
+    assert_eq!(queued.display, "edited queued follow-up");
+    assert_eq!(queued.skill_instruction.as_deref(), Some("skill body"));
+    assert!(app.queued_draft.is_none());
 }
 
 #[test]

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -279,10 +279,42 @@ impl ConfigScope {
 
 #[derive(Debug, Clone)]
 struct ConfigRow {
+    section: ConfigSection,
     key: String,
     value: String,
     editable: bool,
     scope: ConfigScope,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConfigSection {
+    Model,
+    Permissions,
+    Display,
+    Composer,
+    Sidebar,
+    History,
+    Mcp,
+}
+
+impl ConfigSection {
+    fn label(self) -> &'static str {
+        match self {
+            ConfigSection::Model => "Model",
+            ConfigSection::Permissions => "Permissions",
+            ConfigSection::Display => "Display",
+            ConfigSection::Composer => "Composer",
+            ConfigSection::Sidebar => "Sidebar",
+            ConfigSection::History => "History",
+            ConfigSection::Mcp => "MCP",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConfigListItem {
+    Section(ConfigSection),
+    Row(usize),
 }
 
 #[derive(Debug, Clone)]
@@ -300,6 +332,7 @@ pub struct ConfigView {
     selected: usize,
     scroll: usize,
     editing: Option<ConfigEdit>,
+    filter: String,
     status: Option<String>,
     last_visible_rows: Cell<usize>,
 }
@@ -309,90 +342,14 @@ impl ConfigView {
         let settings = Settings::load().unwrap_or_else(|_| Settings::default());
         let rows = vec![
             ConfigRow {
+                section: ConfigSection::Model,
                 key: "model".to_string(),
                 value: app.model.clone(),
                 editable: true,
                 scope: ConfigScope::Session,
             },
             ConfigRow {
-                key: "approval_mode".to_string(),
-                value: app.approval_mode.label().to_string(),
-                editable: true,
-                scope: ConfigScope::Session,
-            },
-            ConfigRow {
-                key: "auto_compact".to_string(),
-                value: settings.auto_compact.to_string(),
-                editable: true,
-                scope: ConfigScope::Saved,
-            },
-            ConfigRow {
-                key: "calm_mode".to_string(),
-                value: settings.calm_mode.to_string(),
-                editable: true,
-                scope: ConfigScope::Saved,
-            },
-            ConfigRow {
-                key: "low_motion".to_string(),
-                value: settings.low_motion.to_string(),
-                editable: true,
-                scope: ConfigScope::Saved,
-            },
-            ConfigRow {
-                key: "show_thinking".to_string(),
-                value: settings.show_thinking.to_string(),
-                editable: true,
-                scope: ConfigScope::Saved,
-            },
-            ConfigRow {
-                key: "show_tool_details".to_string(),
-                value: settings.show_tool_details.to_string(),
-                editable: true,
-                scope: ConfigScope::Saved,
-            },
-            ConfigRow {
-                key: "composer_density".to_string(),
-                value: settings.composer_density.clone(),
-                editable: true,
-                scope: ConfigScope::Saved,
-            },
-            ConfigRow {
-                key: "composer_border".to_string(),
-                value: settings.composer_border.to_string(),
-                editable: true,
-                scope: ConfigScope::Saved,
-            },
-            ConfigRow {
-                key: "transcript_spacing".to_string(),
-                value: settings.transcript_spacing.clone(),
-                editable: true,
-                scope: ConfigScope::Saved,
-            },
-            ConfigRow {
-                key: "default_mode".to_string(),
-                value: settings.default_mode.clone(),
-                editable: true,
-                scope: ConfigScope::Saved,
-            },
-            ConfigRow {
-                key: "sidebar_width".to_string(),
-                value: settings.sidebar_width_percent.to_string(),
-                editable: true,
-                scope: ConfigScope::Saved,
-            },
-            ConfigRow {
-                key: "sidebar_focus".to_string(),
-                value: settings.sidebar_focus.clone(),
-                editable: true,
-                scope: ConfigScope::Saved,
-            },
-            ConfigRow {
-                key: "max_history".to_string(),
-                value: settings.max_input_history.to_string(),
-                editable: true,
-                scope: ConfigScope::Saved,
-            },
-            ConfigRow {
+                section: ConfigSection::Model,
                 key: "default_model".to_string(),
                 value: settings
                     .default_model
@@ -403,6 +360,105 @@ impl ConfigView {
                 scope: ConfigScope::Saved,
             },
             ConfigRow {
+                section: ConfigSection::Permissions,
+                key: "approval_mode".to_string(),
+                value: app.approval_mode.label().to_string(),
+                editable: true,
+                scope: ConfigScope::Session,
+            },
+            ConfigRow {
+                section: ConfigSection::Permissions,
+                key: "default_mode".to_string(),
+                value: settings.default_mode.clone(),
+                editable: true,
+                scope: ConfigScope::Saved,
+            },
+            ConfigRow {
+                section: ConfigSection::Display,
+                key: "calm_mode".to_string(),
+                value: settings.calm_mode.to_string(),
+                editable: true,
+                scope: ConfigScope::Saved,
+            },
+            ConfigRow {
+                section: ConfigSection::Display,
+                key: "low_motion".to_string(),
+                value: settings.low_motion.to_string(),
+                editable: true,
+                scope: ConfigScope::Saved,
+            },
+            ConfigRow {
+                section: ConfigSection::Display,
+                key: "show_thinking".to_string(),
+                value: settings.show_thinking.to_string(),
+                editable: true,
+                scope: ConfigScope::Saved,
+            },
+            ConfigRow {
+                section: ConfigSection::Display,
+                key: "show_tool_details".to_string(),
+                value: settings.show_tool_details.to_string(),
+                editable: true,
+                scope: ConfigScope::Saved,
+            },
+            ConfigRow {
+                section: ConfigSection::Display,
+                key: "transcript_spacing".to_string(),
+                value: settings.transcript_spacing.clone(),
+                editable: true,
+                scope: ConfigScope::Saved,
+            },
+            ConfigRow {
+                section: ConfigSection::Composer,
+                key: "composer_density".to_string(),
+                value: settings.composer_density.clone(),
+                editable: true,
+                scope: ConfigScope::Saved,
+            },
+            ConfigRow {
+                section: ConfigSection::Composer,
+                key: "composer_border".to_string(),
+                value: settings.composer_border.to_string(),
+                editable: true,
+                scope: ConfigScope::Saved,
+            },
+            ConfigRow {
+                section: ConfigSection::Composer,
+                key: "paste_burst_detection".to_string(),
+                value: settings.paste_burst_detection.to_string(),
+                editable: true,
+                scope: ConfigScope::Saved,
+            },
+            ConfigRow {
+                section: ConfigSection::Sidebar,
+                key: "sidebar_width".to_string(),
+                value: settings.sidebar_width_percent.to_string(),
+                editable: true,
+                scope: ConfigScope::Saved,
+            },
+            ConfigRow {
+                section: ConfigSection::Sidebar,
+                key: "sidebar_focus".to_string(),
+                value: settings.sidebar_focus.clone(),
+                editable: true,
+                scope: ConfigScope::Saved,
+            },
+            ConfigRow {
+                section: ConfigSection::History,
+                key: "auto_compact".to_string(),
+                value: settings.auto_compact.to_string(),
+                editable: true,
+                scope: ConfigScope::Saved,
+            },
+            ConfigRow {
+                section: ConfigSection::History,
+                key: "max_history".to_string(),
+                value: settings.max_input_history.to_string(),
+                editable: true,
+                scope: ConfigScope::Saved,
+            },
+            ConfigRow {
+                section: ConfigSection::Mcp,
                 key: "mcp_config_path".to_string(),
                 value: app.mcp_config_path.display().to_string(),
                 editable: true,
@@ -415,6 +471,7 @@ impl ConfigView {
             selected: 0,
             scroll: 0,
             editing: None,
+            filter: String::new(),
             status: None,
             last_visible_rows: Cell::new(0),
         }
@@ -425,39 +482,132 @@ impl ConfigView {
         if cached == 0 { 8 } else { cached }
     }
 
-    fn adjust_scroll(&mut self, visible_rows: usize) {
-        if self.rows.is_empty() {
+    fn row_matches_filter(&self, row: &ConfigRow) -> bool {
+        let filter = self.filter.trim().to_ascii_lowercase();
+        if filter.is_empty() {
+            return true;
+        }
+
+        let haystack = format!(
+            "{} {} {} {}",
+            row.section.label(),
+            row.key,
+            row.value,
+            row.scope.label()
+        )
+        .to_ascii_lowercase();
+
+        filter
+            .split_whitespace()
+            .all(|term| haystack.contains(term))
+    }
+
+    fn matching_row_indices(&self) -> Vec<usize> {
+        self.rows
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, row)| self.row_matches_filter(row).then_some(idx))
+            .collect()
+    }
+
+    fn visible_items(&self) -> Vec<ConfigListItem> {
+        let mut items = Vec::new();
+        let mut current_section = None;
+
+        for (idx, row) in self.rows.iter().enumerate() {
+            if !self.row_matches_filter(row) {
+                continue;
+            }
+
+            if current_section != Some(row.section) {
+                current_section = Some(row.section);
+                items.push(ConfigListItem::Section(row.section));
+            }
+            items.push(ConfigListItem::Row(idx));
+        }
+
+        items
+    }
+
+    fn selected_row_index(&self) -> Option<usize> {
+        let selected = self.selected;
+        self.matching_row_indices()
+            .into_iter()
+            .any(|idx| idx == selected)
+            .then_some(selected)
+    }
+
+    fn selected_display_position(&self, items: &[ConfigListItem]) -> Option<usize> {
+        items
+            .iter()
+            .position(|item| matches!(item, ConfigListItem::Row(idx) if *idx == self.selected))
+    }
+
+    fn sync_selection_to_filter(&mut self) {
+        let matches = self.matching_row_indices();
+        if matches.is_empty() {
             self.selected = 0;
             self.scroll = 0;
             return;
         }
 
-        let max = self.rows.len().saturating_sub(1);
-        self.selected = self.selected.min(max);
+        if !matches.iter().any(|idx| *idx == self.selected) {
+            self.selected = matches[0];
+        }
+    }
 
-        if self.selected < self.scroll {
-            self.scroll = self.selected;
+    fn update_filter(&mut self, update: impl FnOnce(&mut String)) {
+        update(&mut self.filter);
+        self.status = None;
+        self.sync_selection_to_filter();
+        self.adjust_scroll(self.visible_rows_cached());
+    }
+
+    fn adjust_scroll(&mut self, visible_rows: usize) {
+        self.sync_selection_to_filter();
+
+        let items = self.visible_items();
+        if items.is_empty() {
+            self.scroll = 0;
+            return;
         }
 
         let visible_rows = visible_rows.max(1);
-        if self.selected >= self.scroll + visible_rows {
-            self.scroll = self.selected.saturating_sub(visible_rows.saturating_sub(1));
+        let max_scroll = items.len().saturating_sub(visible_rows);
+        self.scroll = self.scroll.min(max_scroll);
+
+        let Some(selected_pos) = self.selected_display_position(&items) else {
+            self.scroll = 0;
+            return;
+        };
+
+        if selected_pos < self.scroll {
+            self.scroll = selected_pos;
+        }
+
+        if selected_pos >= self.scroll + visible_rows {
+            self.scroll = selected_pos.saturating_sub(visible_rows.saturating_sub(1));
         }
     }
 
     fn move_selection(&mut self, delta: isize) {
-        if self.rows.is_empty() {
+        let matches = self.matching_row_indices();
+        if matches.is_empty() {
             return;
         }
 
-        let max = self.rows.len().saturating_sub(1);
+        let current = matches
+            .iter()
+            .position(|idx| *idx == self.selected)
+            .unwrap_or(0);
+        let max = matches.len().saturating_sub(1);
         let next = if delta.is_negative() {
-            self.selected.saturating_sub(delta.unsigned_abs())
+            current.saturating_sub(delta.unsigned_abs())
         } else {
-            (self.selected + delta as usize).min(max)
+            (current + delta as usize).min(max)
         };
 
-        self.selected = next;
+        self.selected = matches[next];
         let visible_rows = self.visible_rows_cached();
         self.adjust_scroll(visible_rows);
     }
@@ -576,7 +726,10 @@ impl ConfigView {
     }
 
     fn start_edit(&mut self) {
-        let Some(row) = self.rows.get(self.selected) else {
+        let Some(row_idx) = self.selected_row_index() else {
+            return;
+        };
+        let Some(row) = self.rows.get(row_idx) else {
             return;
         };
         let key = row.key.clone();
@@ -598,20 +751,34 @@ impl ConfigView {
         });
         self.status = None;
     }
+
+    fn clear_filter(&mut self) {
+        if self.filter.is_empty() {
+            return;
+        }
+
+        self.update_filter(|filter| filter.clear());
+    }
 }
 
 fn config_hint_for_key(key: &str) -> &'static str {
     match key {
         "model" => "deepseek-v4-pro | deepseek-v4-flash | deepseek-*",
         "approval_mode" => "auto | suggest | never",
-        "auto_compact" | "calm_mode" | "low_motion" | "show_thinking" | "show_tool_details"
-        | "composer_border" => "on/off, true/false, yes/no, 1/0",
+        "auto_compact"
+        | "calm_mode"
+        | "low_motion"
+        | "show_thinking"
+        | "show_tool_details"
+        | "composer_border"
+        | "paste_burst_detection" => "on/off, true/false, yes/no, 1/0",
         "composer_density" | "transcript_spacing" => "compact | comfortable | spacious",
         "default_mode" => "agent | plan | yolo",
         "sidebar_width" => "10..=50",
         "sidebar_focus" => "auto | plan | todos | tasks | agents",
         "max_history" => "integer (0 allowed)",
         "default_model" => "deepseek-v4-pro | deepseek-v4-flash | deepseek-* | none/default",
+        "mcp_config_path" => "path to mcp.json",
         _ => "",
     }
 }
@@ -677,7 +844,15 @@ impl ModalView for ConfigView {
         }
 
         match key.code {
-            KeyCode::Esc | KeyCode::Char('q') => ViewAction::Close,
+            KeyCode::Esc => {
+                if self.filter.is_empty() {
+                    ViewAction::Close
+                } else {
+                    self.clear_filter();
+                    ViewAction::None
+                }
+            }
+            KeyCode::Char('q') if self.filter.is_empty() => ViewAction::Close,
             KeyCode::Up | KeyCode::Char('k') => {
                 self.move_selection(-1);
                 ViewAction::None
@@ -694,10 +869,42 @@ impl ModalView for ConfigView {
                 self.move_selection(5);
                 ViewAction::None
             }
-            KeyCode::Char('e') | KeyCode::Char('E') | KeyCode::Enter => {
-                if self.rows.get(self.selected).is_some_and(|row| row.editable) {
+            KeyCode::Backspace => {
+                if !self.filter.is_empty() {
+                    self.update_filter(|filter| {
+                        filter.pop();
+                    });
+                }
+                ViewAction::None
+            }
+            KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.clear_filter();
+                ViewAction::None
+            }
+            KeyCode::Char('e') | KeyCode::Char('E') if self.filter.is_empty() => {
+                if self
+                    .selected_row_index()
+                    .and_then(|idx| self.rows.get(idx))
+                    .is_some_and(|row| row.editable)
+                {
                     self.start_edit();
                 }
+                ViewAction::None
+            }
+            KeyCode::Enter => {
+                if self
+                    .selected_row_index()
+                    .and_then(|idx| self.rows.get(idx))
+                    .is_some_and(|row| row.editable)
+                {
+                    self.start_edit();
+                }
+                ViewAction::None
+            }
+            KeyCode::Char(ch)
+                if !key.modifiers.contains(KeyModifiers::CONTROL) && !ch.is_control() =>
+            {
+                self.update_filter(|filter| filter.push(ch));
                 ViewAction::None
             }
             _ => ViewAction::None,
@@ -763,59 +970,97 @@ impl ModalView for ConfigView {
             )
         } else {
             let content_height = usize::from(inner.height);
-            let header_lines = 4usize;
+            let header_lines = 5usize;
             let bottom_lines = 1usize;
             let visible_rows = content_height
                 .saturating_sub(header_lines + bottom_lines)
                 .max(1);
             self.last_visible_rows.set(visible_rows);
 
-            let start = self.scroll.min(self.rows.len());
-            let end = (start + visible_rows).min(self.rows.len());
-            let scrollable = self.rows.len() > visible_rows;
+            let items = self.visible_items();
+            let match_count = self.matching_row_indices().len();
+            let start = self.scroll.min(items.len());
+            let end = (start + visible_rows).min(items.len());
+            let scrollable = items.len() > visible_rows;
+            let search_value = if self.filter.is_empty() {
+                "type to filter".to_string()
+            } else {
+                self.filter.clone()
+            };
 
             let mut lines: Vec<Line> = vec![
                 Line::from(vec![Span::styled(
                     "Session Configuration",
                     Style::default().fg(palette::DEEPSEEK_BLUE).bold(),
                 )]),
+                Line::from(vec![
+                    Span::styled("  Search: ", Style::default().fg(palette::TEXT_MUTED)),
+                    Span::raw(search_value),
+                    Span::styled(
+                        format!("  ({match_count}/{})", self.rows.len()),
+                        Style::default().fg(palette::TEXT_MUTED),
+                    ),
+                ]),
                 Line::from(""),
-                Line::from("  Key               Value                                    Scope"),
-                Line::from("  ─────────────────────────────────────────────────────────────────"),
+                Line::from("  Key                 Value                                    Scope"),
+                Line::from("  ----------------------------------------------------------------"),
             ];
 
-            for (idx, row) in self.rows.iter().enumerate().skip(start).take(visible_rows) {
-                let selected = idx == self.selected;
-                let style = if selected {
-                    Style::default()
-                        .fg(palette::SELECTION_TEXT)
-                        .bg(palette::SELECTION_BG)
-                } else {
-                    Style::default().fg(palette::TEXT_PRIMARY)
-                };
-                let value = truncate_view_text(&row.value, 44);
-                let mut line = Line::from(format!(
-                    "  {:<17} {:<44} {}",
-                    row.key,
-                    value,
-                    row.scope.label()
-                ));
-                line.style = style;
-                lines.push(line);
+            for item in items.iter().skip(start).take(visible_rows) {
+                match item {
+                    ConfigListItem::Section(section) => {
+                        lines.push(Line::from(Span::styled(
+                            format!("  {}", section.label()),
+                            Style::default().fg(palette::DEEPSEEK_SKY).bold(),
+                        )));
+                    }
+                    ConfigListItem::Row(idx) => {
+                        let Some(row) = self.rows.get(*idx) else {
+                            continue;
+                        };
+                        let selected = *idx == self.selected;
+                        let style = if selected {
+                            Style::default()
+                                .fg(palette::SELECTION_TEXT)
+                                .bg(palette::SELECTION_BG)
+                        } else {
+                            Style::default().fg(palette::TEXT_PRIMARY)
+                        };
+                        let value = truncate_view_text(&row.value, 44);
+                        let mut line = Line::from(format!(
+                            "  {:<19} {:<44} {}",
+                            row.key,
+                            value,
+                            row.scope.label()
+                        ));
+                        line.style = style;
+                        lines.push(line);
+                    }
+                }
             }
 
-            if self.rows.is_empty() {
-                lines.push(Line::from("  No settings available."));
+            if items.is_empty() {
+                let message = if self.filter.is_empty() {
+                    "  No settings available.".to_string()
+                } else {
+                    format!("  No settings match \"{}\".", self.filter)
+                };
+                lines.push(Line::from(Span::styled(
+                    message,
+                    Style::default().fg(palette::TEXT_MUTED),
+                )));
             }
 
             let bottom_text = if let Some(status) = self.status.as_ref() {
                 status.clone()
-            } else if scrollable && !self.rows.is_empty() {
+            } else if !self.filter.is_empty() {
+                format!("  Filtered settings: {match_count}")
+            } else if scrollable && !items.is_empty() {
                 format!(
                     "  Showing {}-{} / {}",
                     self.scroll.saturating_add(1),
                     end,
-                    self.rows.len()
+                    items.len()
                 )
             } else {
                 String::new()
@@ -825,10 +1070,12 @@ impl ModalView for ConfigView {
                 Style::default().fg(palette::TEXT_MUTED),
             )));
 
-            let footer = if scrollable {
-                " ↑/↓=select, Enter=edit, PgUp/PgDn=scroll, Esc=close "
+            let footer = if !self.filter.is_empty() {
+                " type=filter, Backspace=delete, Ctrl+U/Esc=clear, Enter=edit "
+            } else if scrollable {
+                " type=filter, Up/Down=select, Enter/e=edit, PgUp/PgDn=scroll, Esc/q=close "
             } else {
-                " ↑/↓=select, Enter=edit, Esc=close "
+                " type=filter, Up/Down=select, Enter/e=edit, Esc/q=close "
             };
             (lines, footer.to_string())
         };
@@ -1223,7 +1470,10 @@ fn truncate_view_text(text: &str, max_chars: usize) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{ConfigView, ModalView, ViewAction, ViewEvent, truncate_view_text};
+    use super::{
+        ConfigListItem, ConfigSection, ConfigView, ModalView, ViewAction, ViewEvent,
+        truncate_view_text,
+    };
     use crate::config::Config;
     use crate::tui::app::{App, TuiOptions};
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
@@ -1251,6 +1501,33 @@ mod tests {
         App::new(options, &Config::default())
     }
 
+    fn type_filter(view: &mut ConfigView, text: &str) {
+        for ch in text.chars() {
+            let action = view.handle_key(KeyEvent::new(KeyCode::Char(ch), KeyModifiers::NONE));
+            assert!(matches!(action, ViewAction::None));
+        }
+    }
+
+    fn visible_section_labels(view: &ConfigView) -> Vec<&'static str> {
+        view.visible_items()
+            .into_iter()
+            .filter_map(|item| match item {
+                ConfigListItem::Section(section) => Some(section.label()),
+                ConfigListItem::Row(_) => None,
+            })
+            .collect()
+    }
+
+    fn visible_row_keys(view: &ConfigView) -> Vec<&str> {
+        view.visible_items()
+            .into_iter()
+            .filter_map(|item| match item {
+                ConfigListItem::Row(idx) => Some(view.rows[idx].key.as_str()),
+                ConfigListItem::Section(_) => None,
+            })
+            .collect()
+    }
+
     #[test]
     fn truncate_view_text_handles_unicode() {
         let text = "abc😀é";
@@ -1259,6 +1536,24 @@ mod tests {
         assert_eq!(truncate_view_text(text, 3), "abc");
         assert_eq!(truncate_view_text(text, 4), "abc😀");
         assert_eq!(truncate_view_text(text, 5), "abc😀é");
+    }
+
+    #[test]
+    fn config_view_groups_rows_by_expected_sections() {
+        let app = create_test_app();
+        let view = ConfigView::new_for_app(&app);
+        assert_eq!(
+            visible_section_labels(&view),
+            vec![
+                ConfigSection::Model.label(),
+                ConfigSection::Permissions.label(),
+                ConfigSection::Display.label(),
+                ConfigSection::Composer.label(),
+                ConfigSection::Sidebar.label(),
+                ConfigSection::History.label(),
+                ConfigSection::Mcp.label(),
+            ]
+        );
     }
 
     #[test]
@@ -1274,7 +1569,73 @@ mod tests {
         assert!(keys.contains(&"approval_mode"));
         assert!(keys.contains(&"auto_compact"));
         assert!(keys.contains(&"composer_border"));
+        assert!(keys.contains(&"mcp_config_path"));
         assert!(view.rows.iter().all(|row| row.editable));
+    }
+
+    #[test]
+    fn config_view_filter_matches_group_and_rows() {
+        let app = create_test_app();
+        let mut view = ConfigView::new_for_app(&app);
+
+        type_filter(&mut view, "side");
+
+        assert_eq!(view.filter, "side");
+        assert_eq!(visible_section_labels(&view), vec!["Sidebar"]);
+        assert_eq!(
+            visible_row_keys(&view),
+            vec!["sidebar_width", "sidebar_focus"]
+        );
+        assert_eq!(view.rows[view.selected].key, "sidebar_width");
+    }
+
+    #[test]
+    fn config_view_filter_no_match_does_not_edit_hidden_row() {
+        let app = create_test_app();
+        let mut view = ConfigView::new_for_app(&app);
+
+        type_filter(&mut view, "zzzz");
+        assert!(visible_row_keys(&view).is_empty());
+
+        let action = view.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert!(matches!(action, ViewAction::None));
+        assert!(view.editing.is_none());
+
+        let clear = view.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        assert!(matches!(clear, ViewAction::None));
+        assert!(view.filter.is_empty());
+        assert!(!visible_row_keys(&view).is_empty());
+    }
+
+    #[test]
+    fn config_view_can_edit_filtered_row() {
+        let app = create_test_app();
+        let mut view = ConfigView::new_for_app(&app);
+
+        type_filter(&mut view, "mcp");
+        assert_eq!(visible_row_keys(&view), vec!["mcp_config_path"]);
+
+        let start = view.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert!(matches!(start, ViewAction::None));
+        assert!(view.editing.is_some());
+
+        let clear = view.handle_key(KeyEvent::new(KeyCode::Char('u'), KeyModifiers::CONTROL));
+        assert!(matches!(clear, ViewAction::None));
+        type_filter(&mut view, "servers.json");
+
+        let submit = view.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        match submit {
+            ViewAction::Emit(ViewEvent::ConfigUpdated {
+                key,
+                value,
+                persist,
+            }) => {
+                assert_eq!(key, "mcp_config_path");
+                assert_eq!(value, "servers.json");
+                assert!(persist);
+            }
+            other => panic!("expected config update emit, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -277,6 +277,14 @@ impl<'a> ComposerWidget<'a> {
         }
     }
 
+    fn active_menu_row_count(&self) -> usize {
+        if self.app.is_history_search_active() {
+            self.app.history_search_matches().len().max(1)
+        } else {
+            self.active_menu_entries().len()
+        }
+    }
+
     fn has_panel(&self, area: Rect) -> bool {
         self.app.composer_border && area.height >= 3 && area.width >= 12
     }
@@ -307,24 +315,37 @@ impl Renderable for ComposerWidget<'_> {
         let background = Style::default().bg(self.app.ui_theme.composer_bg);
         let has_panel = self.has_panel(area);
         let inner_area = self.inner_area(area);
+        let input_text = self.app.composer_display_input();
+        let input_cursor = self.app.composer_display_cursor();
+        let history_search_matches = if self.app.is_history_search_active() {
+            self.app.history_search_matches()
+        } else {
+            Vec::new()
+        };
         let menu_entries = self.active_menu_entries();
-        let menu_lines = menu_entries.len();
+        let menu_lines = if self.app.is_history_search_active() {
+            history_search_matches.len().max(1)
+        } else {
+            menu_entries.len()
+        };
         let input_rows_budget = composer_input_rows_budget(inner_area.height, menu_lines);
         let content_width = usize::from(inner_area.width.max(1));
-        let (visible_lines, _cursor_row, _cursor_col) = layout_input(
-            &self.app.input,
-            self.app.cursor_position,
-            content_width,
-            input_rows_budget,
-        );
-        let is_draft_mode = self.app.input.contains('\n') || visible_lines.len() > 1;
+        let (visible_lines, _cursor_row, _cursor_col) =
+            layout_input(input_text, input_cursor, content_width, input_rows_budget);
+        let is_draft_mode = input_text.contains('\n') || visible_lines.len() > 1;
         if has_panel {
-            let border_color = if self.app.input.trim().is_empty() {
+            let border_color = if input_text.trim().is_empty() {
                 palette::BORDER_COLOR
             } else {
                 self.mode_color()
             };
-            let hint_line = if self.slash_menu_entries.is_empty() {
+            let hint_line = if self.app.is_history_search_active() {
+                Some(Line::from(vec![
+                    Span::styled(" Up/Down move  ", Style::default().fg(palette::TEXT_MUTED)),
+                    Span::styled("Enter accept  ", Style::default().fg(palette::TEXT_MUTED)),
+                    Span::styled("Esc restore", Style::default().fg(palette::TEXT_MUTED)),
+                ]))
+            } else if self.slash_menu_entries.is_empty() {
                 None
             } else {
                 Some(Line::from(vec![
@@ -336,7 +357,13 @@ impl Renderable for ComposerWidget<'_> {
 
             let mut block = Block::default()
                 .title(Line::from(Span::styled(
-                    if is_draft_mode { "Draft" } else { "Composer" },
+                    if self.app.is_history_search_active() {
+                        "History Search"
+                    } else if is_draft_mode {
+                        "Draft"
+                    } else {
+                        "Composer"
+                    },
                     Style::default().fg(palette::TEXT_MUTED),
                 )))
                 .borders(Borders::ALL)
@@ -351,9 +378,14 @@ impl Renderable for ComposerWidget<'_> {
         }
 
         let mut input_lines = Vec::new();
-        if self.app.input.is_empty() {
+        if input_text.is_empty() {
+            let placeholder = if self.app.is_history_search_active() {
+                "Search prompt history..."
+            } else {
+                COMPOSER_PLACEHOLDER
+            };
             input_lines.push(Line::from(Span::styled(
-                COMPOSER_PLACEHOLDER,
+                placeholder,
                 Style::default().fg(palette::TEXT_MUTED).italic(),
             )));
         } else {
@@ -369,7 +401,7 @@ impl Renderable for ComposerWidget<'_> {
         // layout_input.  For the empty-input placeholder, Paragraph::wrap will
         // wrap the single Line at render time, so we must estimate the wrapped
         // row count ourselves to keep padding accurate on narrow widths.
-        let visual_rows = if self.app.input.is_empty() {
+        let visual_rows = if input_text.is_empty() {
             placeholder_visual_lines(content_width)
         } else {
             input_lines.len()
@@ -381,7 +413,62 @@ impl Renderable for ComposerWidget<'_> {
         }
         lines.extend(input_lines);
 
-        if !menu_entries.is_empty() {
+        if self.app.is_history_search_active() {
+            if history_search_matches.is_empty() {
+                lines.push(Line::from(Span::styled(
+                    "  No matches",
+                    Style::default().fg(palette::TEXT_MUTED),
+                )));
+            } else {
+                let selected = self
+                    .app
+                    .history_search_selected_index()
+                    .min(history_search_matches.len().saturating_sub(1));
+                let menu_visible_rows = inner_area
+                    .height
+                    .saturating_sub(visual_rows as u16)
+                    .saturating_sub(top_padding as u16)
+                    .saturating_sub(1)
+                    .max(1) as usize;
+                let menu_total = history_search_matches.len();
+                let menu_top = if menu_total <= menu_visible_rows {
+                    0
+                } else {
+                    let half = menu_visible_rows / 2;
+                    if selected <= half {
+                        0
+                    } else if selected + half >= menu_total {
+                        menu_total.saturating_sub(menu_visible_rows)
+                    } else {
+                        selected.saturating_sub(half)
+                    }
+                };
+                let menu_bottom = (menu_top + menu_visible_rows).min(menu_total);
+
+                for (idx, entry) in history_search_matches
+                    .iter()
+                    .enumerate()
+                    .take(menu_bottom)
+                    .skip(menu_top)
+                {
+                    let is_selected = idx == selected;
+                    let style = if is_selected {
+                        Style::default()
+                            .fg(palette::SELECTION_TEXT)
+                            .bg(palette::SELECTION_BG)
+                    } else {
+                        Style::default().fg(palette::TEXT_MUTED)
+                    };
+                    let marker = if is_selected { "▸" } else { " " };
+                    lines.push(Line::from(vec![
+                        Span::styled(" ", Style::default()),
+                        Span::styled(marker, style),
+                        Span::styled(" ", style),
+                        Span::styled(entry.clone(), style),
+                    ]));
+                }
+            }
+        } else if !menu_entries.is_empty() {
             let selected = self
                 .active_menu_selected()
                 .min(menu_entries.len().saturating_sub(1));
@@ -450,10 +537,10 @@ impl Renderable for ComposerWidget<'_> {
 
     fn desired_height(&self, width: u16) -> u16 {
         composer_height(
-            &self.app.input,
+            self.app.composer_display_input(),
             width,
             self.max_height.min(self.max_height_cap()),
-            self.active_menu_entries().len(),
+            self.active_menu_row_count(),
             self.app.composer_density,
             self.app.composer_border,
         )
@@ -461,17 +548,15 @@ impl Renderable for ComposerWidget<'_> {
 
     fn cursor_pos(&self, area: Rect) -> Option<(u16, u16)> {
         let inner_area = self.inner_area(area);
+        let input_text = self.app.composer_display_input();
+        let input_cursor = self.app.composer_display_cursor();
         let content_width = usize::from(inner_area.width.max(1));
         let input_rows_budget =
-            composer_input_rows_budget(inner_area.height, self.active_menu_entries().len());
+            composer_input_rows_budget(inner_area.height, self.active_menu_row_count());
 
-        let (visible_lines, cursor_row, cursor_col) = layout_input(
-            &self.app.input,
-            self.app.cursor_position,
-            content_width,
-            input_rows_budget,
-        );
-        let visual_rows = if self.app.input.is_empty() {
+        let (visible_lines, cursor_row, cursor_col) =
+            layout_input(input_text, input_cursor, content_width, input_rows_budget);
+        let visual_rows = if input_text.is_empty() {
             placeholder_visual_lines(content_width)
         } else {
             visible_lines.len()

--- a/crates/tui/src/tui/widgets/pending_input_preview.rs
+++ b/crates/tui/src/tui/widgets/pending_input_preview.rs
@@ -3,21 +3,14 @@
 //! Port of `codex-rs/tui/src/bottom_pane/pending_input_preview.rs` for
 //! issue #85. Renders queued/steered messages above the composer when a
 //! turn is in flight, so user input typed during a running turn doesn't
-//! disappear silently. Three buckets:
-//!
-//! 1. **Pending steers** — messages submitted *during* a tool call boundary
-//!    (next round-trip), with hint that Esc force-sends them now.
-//! 2. **Rejected steers** — engine declined the steer (e.g., tool already
-//!    running); will be replayed at end-of-turn.
-//! 3. **Queued follow-ups** — ordinary messages held until the turn ends.
+//! disappear silently. The backing state still distinguishes queue/steer
+//! origins, but the UI renders one coherent pending-input list.
 //!
 //! Empty state renders zero rows so the composer doesn't gain wasted height
 //! when there's nothing to show.
 //!
-//! Wired into `ui.rs::render` between the chat area and the composer in
-//! v0.6.6 (Phase 2 of #85). The full Esc-to-steer flow is a follow-up
-//! (TODO_BACKEND.md §4); v0.6.6 ships the visibility half (`queued_messages`)
-//! which is the larger UX win — the user can see their input was captured.
+//! Wired into `ui.rs::render` between the chat area and the composer; the user
+//! can see when typed input has been captured for later delivery.
 
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
@@ -45,8 +38,7 @@ impl EditBinding {
     pub const ALT_UP: EditBinding = EditBinding { label: "Alt+↑" };
 }
 
-/// Widget showing pending steers + rejected steers + queued follow-up
-/// messages while a turn is in progress.
+/// Widget showing pending input while a turn is in progress.
 #[derive(Debug, Clone)]
 pub struct PendingInputPreview {
     pub context_items: Vec<ContextPreviewItem>,
@@ -65,6 +57,8 @@ pub struct ContextPreviewItem {
     pub label: String,
     pub detail: Option<String>,
     pub included: bool,
+    pub removable: bool,
+    pub selected: bool,
 }
 
 impl PendingInputPreview {
@@ -108,57 +102,32 @@ impl PendingInputPreview {
             }
         }
 
-        if !self.pending_steers.is_empty() {
+        if !self.pending_steers.is_empty()
+            || !self.rejected_steers.is_empty()
+            || !self.queued_messages.is_empty()
+        {
             if !lines.is_empty() {
                 lines.push(Line::from(""));
             }
             push_section_header(
                 &mut lines,
-                Line::from(vec![
-                    Span::raw("• "),
-                    Span::raw("Messages to be submitted after next tool call"),
-                    Span::styled(" (press Esc to send now)", dim),
-                ]),
+                Line::from(vec![Span::raw("• "), Span::raw("Pending inputs")]),
             );
             for steer in &self.pending_steers {
                 push_truncated_item(&mut lines, steer, width, dim, "  ↳ ", "    ");
             }
-        }
-
-        if !self.rejected_steers.is_empty() {
-            if !lines.is_empty() {
-                lines.push(Line::from(""));
-            }
-            push_section_header(
-                &mut lines,
-                Line::from(vec![
-                    Span::raw("• "),
-                    Span::raw("Messages to be submitted at end of turn"),
-                ]),
-            );
             for steer in &self.rejected_steers {
                 push_truncated_item(&mut lines, steer, width, dim, "  ↳ ", "    ");
             }
-        }
-
-        if !self.queued_messages.is_empty() {
-            if !lines.is_empty() {
-                lines.push(Line::from(""));
-            }
-            push_section_header(
-                &mut lines,
-                Line::from(vec![Span::raw("• "), Span::raw("Queued follow-up inputs")]),
-            );
             for message in &self.queued_messages {
                 push_truncated_item(&mut lines, message, width, dim_italic, "  ↳ ", "    ");
             }
-            // Edit-last-queued hint only when there's actually something to
-            // pop — pending steers don't get an Alt+↑ hint because the engine
-            // owns when they get sent.
-            lines.push(Line::from(vec![Span::styled(
-                format!("    {} edit last queued message", self.edit_binding.label),
-                dim,
-            )]));
+            if !self.queued_messages.is_empty() {
+                lines.push(Line::from(vec![Span::styled(
+                    format!("    {} edit last queued message", self.edit_binding.label),
+                    dim,
+                )]));
+            }
         }
 
         lines
@@ -194,12 +163,21 @@ fn push_section_header(lines: &mut Vec<Line<'static>>, header: Line<'static>) {
 }
 
 fn push_context_item(lines: &mut Vec<Line<'static>>, item: &ContextPreviewItem, width: u16) {
-    let status_style = if item.included {
+    let status_style = if item.selected {
+        Style::default()
+            .fg(palette::SELECTION_TEXT)
+            .bg(palette::SELECTION_BG)
+            .add_modifier(Modifier::BOLD)
+    } else if item.included {
         Style::default().fg(palette::TEXT_MUTED)
     } else {
         Style::default().fg(palette::STATUS_WARNING)
     };
-    let label_style = if item.included {
+    let label_style = if item.selected {
+        Style::default()
+            .fg(palette::SELECTION_TEXT)
+            .bg(palette::SELECTION_BG)
+    } else if item.included {
         Style::default().fg(palette::TEXT_PRIMARY)
     } else {
         Style::default().fg(palette::TEXT_MUTED)
@@ -210,10 +188,21 @@ fn push_context_item(lines: &mut Vec<Line<'static>>, item: &ContextPreviewItem, 
         .filter(|detail| !detail.trim().is_empty())
         .map(|detail| format!(" · {detail}"))
         .unwrap_or_default();
-    let body = format!("[{}] {}{}", item.kind, item.label, detail);
+    let action = if item.selected {
+        " · Backspace/Delete removes"
+    } else if item.removable {
+        " · removable"
+    } else {
+        ""
+    };
+    let body = format!("[{}] {}{}{}", item.kind, item.label, detail, action);
     let body_width = width.saturating_sub(4).max(1) as usize;
     for (idx, segment) in wrap_to_width(&body, body_width).into_iter().enumerate() {
-        let prefix = if idx == 0 { "  ↳ " } else { "    " };
+        let prefix = if idx == 0 {
+            if item.selected { "  ▸ " } else { "  ↳ " }
+        } else {
+            "    "
+        };
         lines.push(Line::from(vec![
             Span::styled(prefix.to_string(), status_style),
             Span::styled(segment, label_style),
@@ -350,7 +339,7 @@ mod tests {
         let rows = render_to_string(&preview, 40);
         // Expect: header line, message line, hint line.
         assert_eq!(rows.len(), 3, "got rows: {rows:?}");
-        assert!(rows[0].contains("Queued follow-up inputs"));
+        assert!(rows[0].contains("Pending inputs"));
         assert!(rows[1].contains("Hello, world!"));
         assert!(rows[2].contains("edit last queued message"));
     }
@@ -363,12 +352,16 @@ mod tests {
             label: "src/main.rs".to_string(),
             detail: Some("included".to_string()),
             included: true,
+            removable: false,
+            selected: false,
         });
         preview.context_items.push(ContextPreviewItem {
             kind: "missing".to_string(),
             label: "nope.txt".to_string(),
             detail: Some("not found".to_string()),
             included: false,
+            removable: false,
+            selected: false,
         });
         let rows = render_to_string(&preview, 64);
         assert!(rows[0].contains("Context for next send"));
@@ -377,20 +370,38 @@ mod tests {
     }
 
     #[test]
-    fn pending_steer_shows_esc_hint_no_alt_up_hint() {
+    fn selected_removable_attachment_renders_delete_hint() {
+        let mut preview = PendingInputPreview::new();
+        preview.context_items.push(ContextPreviewItem {
+            kind: "image".to_string(),
+            label: "/tmp/pasted.png".to_string(),
+            detail: Some("attached media".to_string()),
+            included: true,
+            removable: true,
+            selected: true,
+        });
+
+        let rows = render_to_string(&preview, 96);
+
+        assert!(
+            rows.iter()
+                .any(|row| row.contains("Backspace/Delete removes"))
+        );
+        assert!(rows.iter().any(|row| row.contains("▸")));
+    }
+
+    #[test]
+    fn pending_steer_renders_without_esc_or_alt_up_hint() {
         let mut preview = PendingInputPreview::new();
         preview.pending_steers.push("Please continue.".to_string());
-        // Use a wide-enough column budget that the section header does not
-        // wrap — keeps the assertions targeted at content rather than at
-        // wrap boundaries.
         let rows = render_to_string(&preview, 80);
         assert!(
-            rows.iter().any(|r| r.contains("after next tool call")),
-            "missing pending-steer header: {rows:?}"
+            rows.iter().any(|r| r.contains("Pending inputs")),
+            "missing pending input header: {rows:?}"
         );
         assert!(
-            rows.iter().any(|r| r.contains("Esc")),
-            "missing Esc hint: {rows:?}"
+            !rows.iter().any(|r| r.contains("Esc")),
+            "unexpected Esc hint: {rows:?}"
         );
         assert!(
             !rows.iter().any(|r| r.contains("Alt+↑")),
@@ -399,16 +410,20 @@ mod tests {
     }
 
     #[test]
-    fn three_sections_render_with_blank_line_separators() {
+    fn all_pending_inputs_render_as_one_list() {
         let mut preview = PendingInputPreview::new();
         preview.pending_steers.push("steer".to_string());
         preview.rejected_steers.push("rejected".to_string());
         preview.queued_messages.push("queued".to_string());
         let rows = render_to_string(&preview, 60);
-        // Sections are separated by blank lines + headers + items + final hint.
-        assert!(rows.iter().any(|r| r.contains("after next tool call")));
-        assert!(rows.iter().any(|r| r.contains("end of turn")));
-        assert!(rows.iter().any(|r| r.contains("Queued follow-up")));
+        assert!(rows[0].contains("Pending inputs"));
+        assert_eq!(
+            rows.iter().filter(|r| r.contains("Pending inputs")).count(),
+            1
+        );
+        assert!(rows.iter().any(|r| r.contains("steer")));
+        assert!(rows.iter().any(|r| r.contains("rejected")));
+        assert!(rows.iter().any(|r| r.contains("queued")));
         assert!(rows.iter().any(|r| r.contains("Alt+↑")));
     }
 
@@ -421,7 +436,7 @@ mod tests {
         let rows = render_to_string(&preview, 40);
         // Header + 3 visible lines + ellipsis row + hint = 6 rows.
         assert_eq!(rows.len(), 6, "got rows: {rows:?}");
-        assert!(rows[0].contains("Queued follow-up"));
+        assert!(rows[0].contains("Pending inputs"));
         assert!(rows[1].contains("line1"));
         assert!(rows[2].contains("line2"));
         assert!(rows[3].contains("line3"));

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -138,10 +138,14 @@ Common settings keys:
 
 - `theme` (default, dark, light, whale)
 - `auto_compact` (on/off, default off)
+- `paste_burst_detection` (on/off, default on): fallback rapid-key paste
+  detection for terminals that do not emit bracketed-paste events. This is
+  independent of terminal bracketed-paste mode.
 - `show_thinking` (on/off)
 - `show_tool_details` (on/off)
 - `default_mode` (agent, plan, yolo; legacy `normal` is accepted and normalized to `agent`)
-- `max_history` (number of input history entries)
+- `max_history` (number of submitted input history entries; cleared drafts are
+  also kept locally for composer history search)
 - `default_model` (model name override)
 
 Only `agent`, `plan`, and `yolo` are visible modes in the UI. For compatibility,
@@ -290,6 +294,9 @@ to the next message. Use `/attach <path>` for local image/video media paths, or
 `Ctrl+V` to attach an image from the clipboard. DeepSeek's public Chat
 Completions API currently accepts text message content, so media attachments are
 sent as explicit local path references instead of native image/video payloads.
+Attachment rows appear above the composer before submit; move to the start of
+the composer, press `↑` to select an attachment row, then press `Backspace` or
+`Delete` to remove it without editing the placeholder text by hand.
 
 ## Managed Configuration and Requirements
 

--- a/docs/MODES.md
+++ b/docs/MODES.md
@@ -7,7 +7,9 @@ DeepSeek TUI has two related concepts:
 
 ## TUI Modes
 
-Press `Tab` to cycle through the visible modes: **Plan → Agent → YOLO → Plan**.
+Press `Tab` to complete composer menus, queue a draft as a next-turn follow-up
+while a turn is running, or cycle through the visible modes when the composer is
+otherwise idle: **Plan → Agent → YOLO → Plan**.
 Press `Shift+Tab` to cycle reasoning effort.
 
 - **Plan**: design-first prompting. Read-only investigation tools stay available; shell and patch execution stay off. Use this when you want to think out loud and produce a plan to hand to a human (yourself later, or a reviewer).


### PR DESCRIPTION
## Summary

- Adds grouped/searchable `/config` plus README/MCP command cleanup.
- Improves composer paste, clipboard image attach, history search, recoverable draft clearing, queued follow-ups, Esc/Tab behavior, pending-input preview, and transcript selection copy behavior.
- Adds removable composer attachment rows for `/attach` and clipboard image paste while keeping DeepSeek payload reality explicit: media is still sent as local path text references, not native media payloads.
- Fixes soft-seam pin preservation by mapping global working-set pin indices into the local message slice before `plan_compaction`.

## Verified

- `cargo fmt --all`
- `git diff --check`
- `cargo test -p deepseek-tui --bin deepseek-tui`
- `cargo test --workspace --all-features`
- `cargo run --bin deepseek -- --help`
- `cargo run -p deepseek-tui --bin deepseek-tui -- --help`

## Issues

Closes #198.
Closes #199.
Closes #206.
Closes #207.
Closes #208.
Closes #209.
Closes #210.

Left open intentionally: #195, #196, #197, #205, #159, #162, and #200-#204. Their acceptance requires broader background-job/MCP/context-token work or empirical calibration not completed by this PR.

New v0.7.6 follow-up issues created separately: #212, #213, #214, #215, #216.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hmbown/deepseek-tui/pull/217" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
