### PR TITLE
fix(cli): restore top-level prompt forwarding

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -79,6 +79,15 @@ struct Cli {
     mouse_capture: bool,
     #[arg(long = "no-mouse-capture", conflicts_with = "mouse_capture")]
     no_mouse_capture: bool,
+    #[arg(long = "skip-onboarding")]
+    skip_onboarding: bool,
+    #[arg(
+        short = 'p',
+        long = "prompt",
+        value_name = "PROMPT",
+        conflicts_with = "prompt"
+    )]
+    prompt_flag: Option<String>,
     #[arg(value_name = "PROMPT")]
     prompt: Option<String>,
     #[command(subcommand)]
@@ -440,7 +449,7 @@ fn run() -> Result<()> {
         Some(Commands::Metrics(args)) => run_metrics_command(args),
         None => {
             let mut forwarded = Vec::new();
-            if let Some(prompt) = cli.prompt.clone() {
+            if let Some(prompt) = cli.prompt_flag.clone().or_else(|| cli.prompt.clone()) {
                 forwarded.push("--prompt".to_string());
                 forwarded.push(prompt);
             }
@@ -1005,6 +1014,9 @@ fn delegate_to_tui(
     }
     if cli.no_mouse_capture {
         cmd.arg("--no-mouse-capture");
+    }
+    if cli.skip_onboarding {
+        cmd.arg("--skip-onboarding");
     }
     cmd.args(passthrough);
 
@@ -1694,6 +1706,7 @@ mod tests {
             "sk-test",
             "--no-alt-screen",
             "--no-mouse-capture",
+            "--skip-onboarding",
             "model",
             "resolve",
             "gpt-4.1",
@@ -1713,6 +1726,15 @@ mod tests {
         assert!(cli.no_alt_screen);
         assert!(cli.no_mouse_capture);
         assert!(!cli.mouse_capture);
+        assert!(cli.skip_onboarding);
+    }
+
+    #[test]
+    fn parses_top_level_prompt_flag_for_canonical_one_shot() {
+        let cli = parse_ok(&["deepseek", "-p", "Reply with exactly OK."]);
+
+        assert_eq!(cli.prompt_flag.as_deref(), Some("Reply with exactly OK."));
+        assert_eq!(cli.prompt, None);
     }
 
     #[test]
@@ -1751,6 +1773,8 @@ mod tests {
             "--no-alt-screen",
             "--mouse-capture",
             "--no-mouse-capture",
+            "--skip-onboarding",
+            "--prompt",
         ] {
             assert!(
                 rendered.contains(token),


### PR DESCRIPTION
## Summary
- restore top-level `deepseek -p/--prompt` forwarding to the TUI `--prompt` path
- forward top-level `--skip-onboarding` to the TUI so canonical dispatcher launches match the TUI surface
- add CLI parser/help coverage for the restored flags

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p deepseek-tui-cli --locked`
- `cargo check --workspace --all-targets --locked`
- global reinstall from this hotfix worktree: `cargo install --path crates/cli --locked --force` and `cargo install --path crates/tui --locked --force`
- `deepseek -p "Reply with exactly OK."` -> `OK`
- PTY smoke: `deepseek --no-alt-screen --skip-onboarding`, type `Reply with exactly OK.`, press Enter -> `OK`

This is the emergency dispatcher repair for the shipped v0.7.8 local/global entrypoint; npm/release artifacts still need a follow-up patch release if this should ship beyond the local rebuild.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hmbown/deepseek-tui/pull/252" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
