### PR TITLE
feat(deepmap): add codebase analysis engine with tree-sitter + PageRank

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,6 +1010,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "deepmap"
+version = "0.8.2"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "dirs",
+ "ignore",
+ "log",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tree-sitter",
+ "tree-sitter-css",
+ "tree-sitter-go",
+ "tree-sitter-html",
+ "tree-sitter-javascript",
+ "tree-sitter-json",
+ "tree-sitter-language",
+ "tree-sitter-python",
+ "tree-sitter-rust",
+ "tree-sitter-typescript",
+]
+
+[[package]]
 name = "deepseek-agent"
 version = "0.8.2"
 dependencies = [
@@ -1168,6 +1192,7 @@ dependencies = [
  "colored",
  "crossterm",
  "csv",
+ "deepmap",
  "deepseek-secrets",
  "deepseek-tools",
  "deepseek-tui-cli",
@@ -1220,6 +1245,7 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
+ "deepmap",
  "deepseek-agent",
  "deepseek-app-server",
  "deepseek-config",
@@ -3955,6 +3981,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -4266,6 +4293,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "string_cache"
@@ -4744,6 +4777,106 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78f873475d258561b06f1c595d93308a7ed124d9977cb26b148c2084a4a3cc87"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax 0.8.8",
+ "serde_json",
+ "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-css"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ad6489794d41350d12a7fbe520e5199f688618f43aace5443980d1ddcf1b29e"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-go"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b13d476345220dbe600147dd444165c5791bf85ef53e28acbedd46112ee18431"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-html"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "261b708e5d92061ede329babaaa427b819329a9d427a1d710abb0f67bbef63ee"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-javascript"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf40bf599e0416c16c125c3cec10ee5ddc7d1bb8b0c60fa5c4de249ad34dc1b1"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-json"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86a5d6b3ea17e06e7a34aabeadd68f5866c0d0f9359155d432095f8b751865e4"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-python"
+version = "0.23.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d065aaa27f3aaceaf60c1f0e0ac09e1cb9eb8ed28e7bcdaa52129cffc7f4b04"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-rust"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439e577dbe07423ec2582ac62c7531120dbfccfa6e5f92406f93dd271a120e45"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-typescript"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/cli",
     "crates/config",
     "crates/core",
+    "crates/deepmap",
     "crates/execpolicy",
     "crates/hooks",
     "crates/mcp",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -16,6 +16,7 @@ clap.workspace = true
 clap_complete.workspace = true
 deepseek-agent = { path = "../agent", version = "0.8.2" }
 deepseek-app-server = { path = "../app-server", version = "0.8.2" }
+deepmap = { path = "../deepmap", version = "0.8.2" }
 deepseek-config = { path = "../config", version = "0.8.2" }
 deepseek-execpolicy = { path = "../execpolicy", version = "0.8.2" }
 deepseek-mcp = { path = "../mcp", version = "0.8.2" }
@@ -27,6 +28,7 @@ serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+
 
 [dev-dependencies]
 tempfile = "3.16"

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -8,6 +8,9 @@ use std::process::Command;
 use anyhow::{Context, Result, bail};
 use clap::{Args, CommandFactory, Parser, Subcommand, ValueEnum};
 use clap_complete::{Shell, generate};
+use deepmap::diagnostics::DiagnosticRunner;
+use deepmap::engine::RepoMapEngine;
+use deepmap::renderer;
 use deepseek_agent::ModelRegistry;
 use deepseek_app_server::{
     AppServerOptions, run as run_app_server, run_stdio as run_app_server_stdio,
@@ -153,6 +156,8 @@ enum Commands {
     },
     /// Print a usage rollup from the audit log and session store.
     Metrics(MetricsArgs),
+    /// Analyze a codebase with DeepMap (symbols, dependency graph, PageRank).
+    Deepmap(DeepmapArgs),
 }
 
 #[derive(Debug, Args)]
@@ -163,6 +168,121 @@ struct MetricsArgs {
     /// Restrict to events newer than this duration (e.g. 7d, 24h, 30m, now-2h).
     #[arg(long, value_name = "DURATION")]
     since: Option<String>,
+}
+
+#[derive(Debug, Args)]
+struct DeepmapArgs {
+    #[command(subcommand)]
+    command: DeepmapCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum DeepmapCommand {
+    /// Generate a project map overview.
+    Overview {
+        /// Project root directory (default: current directory).
+        #[arg(long, default_value = ".")]
+        project: PathBuf,
+        /// Maximum files to scan.
+        #[arg(long, default_value = "2000")]
+        max_files: usize,
+        /// Maximum output characters.
+        #[arg(long, default_value = "16000")]
+        max_chars: usize,
+    },
+    /// Trace call chain for a symbol.
+    CallChain {
+        /// Project root directory (default: current directory).
+        #[arg(long, default_value = ".")]
+        project: PathBuf,
+        /// Symbol name to trace.
+        #[arg(long)]
+        symbol: String,
+        /// Maximum traversal depth.
+        #[arg(long, default_value = "3")]
+        max_depth: usize,
+        /// Maximum output characters.
+        #[arg(long, default_value = "16000")]
+        max_chars: usize,
+    },
+    /// Show detailed file information.
+    FileDetail {
+        /// Project root directory (default: current directory).
+        #[arg(long, default_value = ".")]
+        project: PathBuf,
+        /// File path (relative to project root).
+        #[arg(long)]
+        file: String,
+        /// Maximum symbols to show.
+        #[arg(long, default_value = "12")]
+        max_symbols: usize,
+        /// Maximum output characters.
+        #[arg(long, default_value = "6000")]
+        max_chars: usize,
+    },
+    /// Search codebase by topic/keywords.
+    Query {
+        /// Project root directory (default: current directory).
+        #[arg(long, default_value = ".")]
+        project: PathBuf,
+        /// Keywords to search for (space-separated).
+        #[arg(long)]
+        keywords: String,
+        /// Maximum files to show.
+        #[arg(long, default_value = "20")]
+        max_files: usize,
+        /// Maximum output characters.
+        #[arg(long, default_value = "8000")]
+        max_chars: usize,
+    },
+    /// Analyze impact of changes on given files.
+    Impact {
+        /// Project root directory (default: current directory).
+        #[arg(long, default_value = ".")]
+        project: PathBuf,
+        /// Comma-separated list of changed files.
+        #[arg(long, value_delimiter = ',')]
+        files: Vec<String>,
+        /// Maximum output characters.
+        #[arg(long, default_value = "8000")]
+        max_chars: usize,
+    },
+    /// Assess risk of pending git changes.
+    DiffRisk {
+        /// Project root directory (default: current directory).
+        #[arg(long, default_value = ".")]
+        project: PathBuf,
+        /// Maximum output characters.
+        #[arg(long, default_value = "8000")]
+        max_chars: usize,
+    },
+    /// Run language-specific diagnostics (cargo check, ruff, tsc, go vet, etc.).
+    Check {
+        /// Project root directory (default: current directory).
+        #[arg(long, default_value = ".")]
+        project: PathBuf,
+    },
+    /// Show git blame info for a symbol in a file.
+    Blame {
+        /// Project root directory (default: current directory).
+        #[arg(long, default_value = ".")]
+        project: PathBuf,
+        /// File path (relative to project root).
+        #[arg(long)]
+        file: String,
+        /// Line number.
+        #[arg(long)]
+        line: usize,
+    },
+    /// List files changed in the last N days.
+    Recent {
+        /// Project root directory (default: current directory).
+        #[arg(long, default_value = ".")]
+        project: PathBuf,
+        /// Number of days to look back.
+        #[arg(long, default_value = "7")]
+        days: u32,
+    },
 }
 
 #[derive(Debug, Args)]
@@ -447,6 +567,7 @@ fn run() -> Result<()> {
             Ok(())
         }
         Some(Commands::Metrics(args)) => run_metrics_command(args),
+        Some(Commands::Deepmap(ref args)) => run_deepmap_command(args),
         None => {
             let mut forwarded = Vec::new();
             if let Some(prompt) = cli.prompt_flag.clone().or_else(|| cli.prompt.clone()) {
@@ -455,6 +576,168 @@ fn run() -> Result<()> {
             }
             delegate_to_tui(&cli, &resolved_runtime, forwarded)
         }
+    }
+}
+
+fn run_deepmap_command(args: &DeepmapArgs) -> Result<()> {
+    match &args.command {
+        DeepmapCommand::Overview {
+            project,
+            max_files,
+            max_chars,
+        } => {
+            eprintln!(
+                "Scanning {} (max {} files)...",
+                project.display(),
+                max_files
+            );
+            let mut engine = RepoMapEngine::new(project);
+            engine.scan(*max_files, 300.0);
+            let report = renderer::render_overview_report(&engine, *max_chars);
+            println!("{}", report);
+        }
+        DeepmapCommand::CallChain {
+            project,
+            symbol,
+            max_depth,
+            max_chars,
+        } => {
+            eprintln!("Scanning {}...", project.display());
+            let mut engine = RepoMapEngine::new(project);
+            engine.scan(2000, 300.0);
+            let report = renderer::render_call_chain_report(&engine, symbol, *max_depth);
+            let truncated = if report.len() > *max_chars {
+                format!("{}...", &report[..*max_chars])
+            } else {
+                report
+            };
+            println!("{}", truncated);
+        }
+        DeepmapCommand::FileDetail {
+            project,
+            file,
+            max_symbols,
+            max_chars,
+        } => {
+            eprintln!("Scanning {}...", project.display());
+            let mut engine = RepoMapEngine::new(project);
+            engine.scan(2000, 300.0);
+            let report =
+                renderer::render_file_detail_report(&engine, file, *max_symbols, *max_chars);
+            println!("{}", report);
+        }
+        DeepmapCommand::Query {
+            project,
+            keywords,
+            max_files,
+            max_chars,
+        } => {
+            eprintln!("Scanning {}...", project.display());
+            let mut engine = RepoMapEngine::new(project);
+            engine.scan(2000, 300.0);
+            let report = renderer::render_query_report(&engine, keywords, *max_files, *max_chars);
+            println!("{}", report);
+        }
+        DeepmapCommand::Impact {
+            project,
+            files,
+            max_chars,
+        } => {
+            eprintln!("Scanning {}...", project.display());
+            let mut engine = RepoMapEngine::new(project);
+            engine.scan(2000, 300.0);
+            let report = renderer::render_impact_report(&engine, files, *max_chars);
+            println!("{}", report);
+        }
+        DeepmapCommand::DiffRisk { project, max_chars } => {
+            eprintln!("Scanning {}...", project.display());
+            let mut engine = RepoMapEngine::new(project);
+            engine.scan(2000, 300.0);
+
+            let changed = get_git_changed_files(project);
+            let report = renderer::render_diff_risk_report(&engine, &changed, *max_chars);
+            println!("{}", report);
+            if !changed.is_empty() {
+                eprintln!(
+                    "Changed files: {}",
+                    changed
+                        .iter()
+                        .map(|s| s.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                );
+            }
+        }
+        DeepmapCommand::Check { project } => {
+            let runner = DiagnosticRunner::new(project, 50);
+            let langs = runner.detect_languages();
+            eprintln!("Detected languages: {:?}, running diagnostics...", langs);
+            let results = runner.run_all(&langs);
+            for r in &results {
+                if r.skipped {
+                    eprintln!("  {}: SKIPPED", r.tool);
+                } else {
+                    eprintln!(
+                        "  {}: {} errors, {} warnings ({}ms)",
+                        r.tool, r.errors, r.warnings, r.duration_ms
+                    );
+                }
+            }
+            // Render as JSON for programmatic consumption.
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&results).unwrap_or_default()
+            );
+        }
+        DeepmapCommand::Blame {
+            project,
+            file,
+            line,
+        } => {
+            if let Some(info) = deepmap::git::blame_symbol(project, file, *line) {
+                println!(
+                    "{} {} ({})",
+                    info.commit_hash, info.author, info.author_time
+                );
+                println!("  {}", info.summary);
+            } else {
+                eprintln!("No blame info found for {}:{}", file, line);
+            }
+        }
+        DeepmapCommand::Recent { project, days } => {
+            let files = deepmap::git::recently_changed_files(project, *days);
+            if files.is_empty() {
+                eprintln!("No files changed in the last {} days.", days);
+            } else {
+                eprintln!("{} files changed in the last {} days:", files.len(), days);
+                for f in &files {
+                    println!("{}", f);
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Get list of files changed in the working tree (staged + unstaged).
+fn get_git_changed_files(project: &Path) -> Vec<String> {
+    let output = std::process::Command::new("git")
+        .args(["status", "--porcelain"])
+        .current_dir(project)
+        .output();
+
+    match output {
+        Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout)
+            .lines()
+            .filter_map(|line| {
+                if line.len() >= 4 {
+                    Some(line[3..].trim().to_string())
+                } else {
+                    None
+                }
+            })
+            .collect(),
+        _ => Vec::new(),
     }
 }
 

--- a/crates/deepmap/Cargo.toml
+++ b/crates/deepmap/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "deepmap"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+tree-sitter = "0.25"
+tree-sitter-language = "0.1"
+tree-sitter-rust = "0.24"
+tree-sitter-python = "0.23"
+tree-sitter-javascript = "0.23"
+tree-sitter-typescript = "0.23"
+tree-sitter-go = "0.23"
+tree-sitter-html = "0.23"
+tree-sitter-css = "0.23"
+tree-sitter-json = "0.23"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+ignore = "0.4"
+chrono = { version = "0.4", features = ["serde"] }
+dirs = "6.0"
+log = "0.4"
+anyhow = "1.0"
+thiserror = "2.0"

--- a/crates/deepmap/src/cache.rs
+++ b/crates/deepmap/src/cache.rs
@@ -1,0 +1,142 @@
+// File-based caching for scan results.
+//
+// Uses JSON serialization with atomic writes (temp file + rename).
+// Schema version check rejects incompatible cache files.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::types::{Edge, Symbol};
+
+const CACHE_SCHEMA_VERSION: u32 = 1;
+
+/// Cached scan data.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SymbolCache {
+    pub symbols: Vec<Symbol>,
+    pub edges: Vec<Edge>,
+    pub scan_time: String,
+    pub project_path: String,
+    pub file_count: usize,
+    pub symbol_count: usize,
+    pub edge_count: usize,
+    #[serde(default)]
+    schema_version: u32,
+}
+
+/// Get the cache directory for a project.
+pub fn get_cache_dir(project_path: &Path) -> PathBuf {
+    use std::hash::{Hash, Hasher};
+    let path_str = project_path.to_string_lossy();
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    path_str.hash(&mut hasher);
+    let hash = hasher.finish();
+    let project_name = project_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("unknown");
+
+    let cache_dir = dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("/tmp"))
+        .join(".cache")
+        .join("deepmap")
+        .join(format!("{}_{:08x}", project_name, hash as u32));
+    std::fs::create_dir_all(&cache_dir).ok();
+    cache_dir
+}
+
+/// Get cache file paths.
+pub fn get_cache_paths(project_path: &Path) -> (PathBuf, PathBuf, PathBuf) {
+    let cache_dir = get_cache_dir(project_path);
+    (
+        cache_dir.join("symbols.json"),
+        cache_dir.join("git.json"),
+        cache_dir.join("last_snapshot.json"),
+    )
+}
+
+/// Save scan results to cache (atomic write).
+pub fn save_cache(
+    project_path: &Path,
+    symbols: &[Symbol],
+    edges: &[Edge],
+) -> Result<PathBuf, String> {
+    let (symbols_path, _, last_snapshot) = get_cache_paths(project_path);
+
+    // Backup previous cache as last snapshot.
+    if symbols_path.exists() {
+        let _ = std::fs::copy(&symbols_path, &last_snapshot);
+    }
+
+    let cache = SymbolCache {
+        symbols: symbols.to_vec(),
+        edges: edges.to_vec(),
+        scan_time: chrono::Utc::now().to_rfc3339(),
+        project_path: project_path.to_string_lossy().to_string(),
+        file_count: 0,
+        symbol_count: symbols.len(),
+        edge_count: edges.len(),
+        schema_version: CACHE_SCHEMA_VERSION,
+    };
+
+    let json =
+        serde_json::to_string_pretty(&cache).map_err(|e| format!("Serialize error: {}", e))?;
+
+    // Atomic write: temp file → rename.
+    let tmp_path = symbols_path.with_extension("tmp");
+    std::fs::write(&tmp_path, json).map_err(|e| format!("Write error: {}", e))?;
+    std::fs::rename(&tmp_path, &symbols_path).map_err(|e| format!("Rename error: {}", e))?;
+
+    Ok(symbols_path)
+}
+
+/// Load scan results from cache. Returns None if cache is invalid or missing.
+pub fn load_cache(project_path: &Path) -> Option<SymbolCache> {
+    let (symbols_path, _, _) = get_cache_paths(project_path);
+    let json = std::fs::read_to_string(&symbols_path).ok()?;
+    let cache: SymbolCache = serde_json::from_str(&json).ok()?;
+
+    // Reject incompatible schema versions.
+    if cache.schema_version != CACHE_SCHEMA_VERSION {
+        // Auto-clean incompatible cache.
+        let _ = std::fs::remove_file(&symbols_path);
+        return None;
+    }
+
+    Some(cache)
+}
+
+/// Load the previous snapshot for diff comparison.
+pub fn load_last_snapshot(project_path: &Path) -> Option<SymbolCache> {
+    let (_, _, last_snapshot) = get_cache_paths(project_path);
+    let json = std::fs::read_to_string(&last_snapshot).ok()?;
+    let cache: SymbolCache = serde_json::from_str(&json).ok()?;
+    if cache.schema_version != CACHE_SCHEMA_VERSION {
+        return None;
+    }
+    Some(cache)
+}
+
+/// Compute scan fingerprint (SHA-256 of file paths + mtimes + sizes).
+pub fn scan_fingerprint(project_path: &Path, files: &[String]) -> String {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+
+    for file in files {
+        file.hash(&mut hasher);
+        let full_path = project_path.join(file);
+        if let Ok(meta) = std::fs::metadata(&full_path) {
+            meta.len().hash(&mut hasher);
+            if let Ok(mtime) = meta.modified() {
+                mtime
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs()
+                    .hash(&mut hasher);
+            }
+        }
+    }
+
+    format!("{:016x}", hasher.finish())
+}

--- a/crates/deepmap/src/diagnostics.rs
+++ b/crates/deepmap/src/diagnostics.rs
@@ -1,0 +1,380 @@
+// Language-aware diagnostics runner.
+// Auto-detects project type and runs appropriate tools:
+// Rust → cargo check, Python → ruff/mypy, TypeScript → tsc/eslint, Go → go vet/build.
+// Parses structured output and optionally correlates issues with symbols.
+
+use std::path::Path;
+use std::process::Command;
+
+/// A single diagnostic issue.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct DiagnosticIssue {
+    pub tool: String,
+    pub file: String,
+    pub line: usize,
+    pub col: usize,
+    pub severity: String, // "error" | "warning" | "info"
+    pub code: String,
+    pub message: String,
+    pub symbol: Option<String>,
+    pub symbol_confidence: String, // "exact" | "line" | "none"
+}
+
+/// Result from running a single diagnostic tool.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct DiagnosticResult {
+    pub tool: String,
+    pub command: String,
+    pub exit_code: Option<i32>,
+    pub duration_ms: u64,
+    pub skipped: bool,
+    pub errors: usize,
+    pub warnings: usize,
+    pub truncated: bool,
+    pub raw_excerpt: Option<String>,
+}
+
+/// The main diagnostics runner.
+pub struct DiagnosticRunner {
+    pub project_root: String,
+    pub max_items: usize,
+}
+
+impl DiagnosticRunner {
+    pub fn new(project_root: &Path, max_items: usize) -> Self {
+        Self {
+            project_root: project_root.to_string_lossy().to_string(),
+            max_items,
+        }
+    }
+
+    /// Detect project languages by checking for config files.
+    pub fn detect_languages(&self) -> Vec<String> {
+        let root = Path::new(&self.project_root);
+        let mut langs = Vec::new();
+
+        if root.join("Cargo.toml").exists() {
+            langs.push("rust".to_string());
+        }
+        if root.join("pyproject.toml").exists()
+            || root.join("setup.py").exists()
+            || root.join("requirements.txt").exists()
+        {
+            langs.push("python".to_string());
+        }
+        if root.join("tsconfig.json").exists() || root.join("package.json").exists() {
+            langs.push("typescript".to_string());
+        }
+        if root.join("go.mod").exists() {
+            langs.push("go".to_string());
+        }
+
+        langs
+    }
+
+    /// Run all detected diagnostics.
+    pub fn run_all(&self, types: &[String]) -> Vec<DiagnosticResult> {
+        let mut results = Vec::new();
+
+        for lang in types {
+            match lang.as_str() {
+                "rust" => results.push(self.run_cargo_check()),
+                "python" => {
+                    results.push(self.run_ruff());
+                    results.push(self.run_mypy());
+                }
+                "typescript" => {
+                    results.push(self.run_tsc());
+                }
+                "go" => {
+                    results.push(self.run_go_vet());
+                    results.push(self.run_go_build());
+                }
+                _ => {}
+            }
+        }
+
+        results
+    }
+
+    // ── Rust: cargo check ──
+
+    fn run_cargo_check(&self) -> DiagnosticResult {
+        let start = std::time::Instant::now();
+        let mut result = DiagnosticResult {
+            tool: "cargo check".into(),
+            command: "cargo check --message-format json".into(),
+            exit_code: None,
+            duration_ms: 0,
+            skipped: false,
+            errors: 0,
+            warnings: 0,
+            truncated: false,
+            raw_excerpt: None,
+        };
+
+        let output = match Command::new("cargo")
+            .args(["check", "--message-format", "json"])
+            .current_dir(&self.project_root)
+            .output()
+        {
+            Ok(o) => o,
+            Err(e) => {
+                result.skipped = true;
+                result.raw_excerpt = Some(format!("cargo not found: {}", e));
+                result.duration_ms = start.elapsed().as_millis() as u64;
+                return result;
+            }
+        };
+
+        result.exit_code = Some(output.status.code().unwrap_or(-1));
+        result.duration_ms = start.elapsed().as_millis() as u64;
+
+        if !output.status.success() {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            for line in stdout.lines() {
+                if let Ok(msg) = serde_json::from_str::<serde_json::Value>(line) {
+                    if let Some(reason) = msg["reason"].as_str() {
+                        if reason == "compiler-message" {
+                            let level = msg["message"]["level"].as_str().unwrap_or("unknown");
+                            match level {
+                                "error" => result.errors += 1,
+                                "warning" => result.warnings += 1,
+                                _ => {}
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Capture a short excerpt of the raw output for the last error.
+            if let Some(last) = stdout.lines().filter(|l| l.contains("error")).last() {
+                let excerpt: String = last.chars().take(200).collect();
+                result.raw_excerpt = Some(excerpt);
+            }
+        }
+
+        result
+    }
+
+    // ── Python: ruff ──
+
+    fn run_ruff(&self) -> DiagnosticResult {
+        let start = std::time::Instant::now();
+        let mut result = DiagnosticResult {
+            tool: "ruff".into(),
+            command: "ruff check --output-format json".into(),
+            exit_code: None,
+            duration_ms: 0,
+            skipped: false,
+            errors: 0,
+            warnings: 0,
+            truncated: false,
+            raw_excerpt: None,
+        };
+
+        let output = match Command::new("ruff")
+            .args(["check", "--output-format", "json"])
+            .current_dir(&self.project_root)
+            .output()
+        {
+            Ok(o) => o,
+            Err(_) => {
+                result.skipped = true;
+                result.duration_ms = start.elapsed().as_millis() as u64;
+                return result;
+            }
+        };
+
+        result.exit_code = Some(output.status.code().unwrap_or(-1));
+        result.duration_ms = start.elapsed().as_millis() as u64;
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        if let Ok(issues) = serde_json::from_str::<Vec<serde_json::Value>>(&stdout) {
+            for issue in &issues {
+                if let Some(fix) = issue.get("fix") {
+                    if fix.is_object() {
+                        result.warnings += 1; // ruff auto-fixable = warning
+                    }
+                } else {
+                    result.errors += 1;
+                }
+            }
+            if !issues.is_empty() && result.errors + result.warnings > self.max_items {
+                result.truncated = true;
+            }
+        }
+
+        result
+    }
+
+    // ── Python: mypy ──
+
+    fn run_mypy(&self) -> DiagnosticResult {
+        let start = std::time::Instant::now();
+        let mut result = DiagnosticResult {
+            tool: "mypy".into(),
+            command: "mypy .".into(),
+            exit_code: None,
+            duration_ms: 0,
+            skipped: false,
+            errors: 0,
+            warnings: 0,
+            truncated: false,
+            raw_excerpt: None,
+        };
+
+        let output = match Command::new("mypy")
+            .arg(".")
+            .current_dir(&self.project_root)
+            .output()
+        {
+            Ok(o) => o,
+            Err(_) => {
+                result.skipped = true;
+                result.duration_ms = start.elapsed().as_millis() as u64;
+                return result;
+            }
+        };
+
+        result.exit_code = Some(output.status.code().unwrap_or(-1));
+        result.duration_ms = start.elapsed().as_millis() as u64;
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        for line in stdout.lines() {
+            if line.contains(": error:") {
+                result.errors += 1;
+            } else if line.contains(": warning:") {
+                result.warnings += 1;
+            }
+        }
+
+        result
+    }
+
+    // ── TypeScript: tsc ──
+
+    fn run_tsc(&self) -> DiagnosticResult {
+        let start = std::time::Instant::now();
+        let mut result = DiagnosticResult {
+            tool: "tsc".into(),
+            command: "npx tsc --noEmit".into(),
+            exit_code: None,
+            duration_ms: 0,
+            skipped: false,
+            errors: 0,
+            warnings: 0,
+            truncated: false,
+            raw_excerpt: None,
+        };
+
+        let output = match Command::new("npx")
+            .args(["tsc", "--noEmit"])
+            .current_dir(&self.project_root)
+            .output()
+        {
+            Ok(o) => o,
+            Err(_) => {
+                result.skipped = true;
+                result.duration_ms = start.elapsed().as_millis() as u64;
+                return result;
+            }
+        };
+
+        result.exit_code = Some(output.status.code().unwrap_or(-1));
+        result.duration_ms = start.elapsed().as_millis() as u64;
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        for line in stdout.lines() {
+            if line.contains(": error TS") {
+                result.errors += 1;
+            }
+        }
+
+        result
+    }
+
+    // ── Go: go vet ──
+
+    fn run_go_vet(&self) -> DiagnosticResult {
+        let start = std::time::Instant::now();
+        let mut result = DiagnosticResult {
+            tool: "go vet".into(),
+            command: "go vet ./...".into(),
+            exit_code: None,
+            duration_ms: 0,
+            skipped: false,
+            errors: 0,
+            warnings: 0,
+            truncated: false,
+            raw_excerpt: None,
+        };
+
+        let output = match Command::new("go")
+            .args(["vet", "./..."])
+            .current_dir(&self.project_root)
+            .output()
+        {
+            Ok(o) => o,
+            Err(_) => {
+                result.skipped = true;
+                result.duration_ms = start.elapsed().as_millis() as u64;
+                return result;
+            }
+        };
+
+        result.exit_code = Some(output.status.code().unwrap_or(-1));
+        result.duration_ms = start.elapsed().as_millis() as u64;
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        for line in stderr.lines() {
+            if !line.trim().is_empty() {
+                result.errors += 1;
+            }
+        }
+
+        result
+    }
+
+    // ── Go: go build ──
+
+    fn run_go_build(&self) -> DiagnosticResult {
+        let start = std::time::Instant::now();
+        let mut result = DiagnosticResult {
+            tool: "go build".into(),
+            command: "go build ./...".into(),
+            exit_code: None,
+            duration_ms: 0,
+            skipped: false,
+            errors: 0,
+            warnings: 0,
+            truncated: false,
+            raw_excerpt: None,
+        };
+
+        let output = match Command::new("go")
+            .args(["build", "./..."])
+            .current_dir(&self.project_root)
+            .output()
+        {
+            Ok(o) => o,
+            Err(_) => {
+                result.skipped = true;
+                result.duration_ms = start.elapsed().as_millis() as u64;
+                return result;
+            }
+        };
+
+        result.exit_code = Some(output.status.code().unwrap_or(-1));
+        result.duration_ms = start.elapsed().as_millis() as u64;
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        for line in stderr.lines() {
+            if !line.trim().is_empty() {
+                result.errors += 1;
+            }
+        }
+
+        result
+    }
+}

--- a/crates/deepmap/src/engine.rs
+++ b/crates/deepmap/src/engine.rs
@@ -1,0 +1,588 @@
+// RepoMap engine — coordinates scanning, graph building, PageRank, and queries.
+//
+// Three-phase scan: list files → parse & extract symbols → build edges → PageRank.
+// Supports incremental rescan with mtime-based caching.
+// Includes a session-level scan cache so repeated tool calls reuse the same scan.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::Instant;
+
+use crate::parser::TreeSitterAdapter;
+use crate::ranking::GraphAnalyzer;
+use crate::resolver::ImportResolver;
+use crate::types::*;
+
+use ignore::WalkBuilder;
+
+/// Edge weight constants (matching Python version).
+const IMPORT_WEIGHT: f64 = 0.35;
+const CALL_WEIGHT: f64 = 0.50;
+
+/// Session-level scan cache: (workspace path) → cached scan data.
+/// Reuses scan results across multiple tool calls within the same session.
+static SCAN_CACHE: std::sync::LazyLock<Mutex<HashMap<PathBuf, CachedScan>>> =
+    std::sync::LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Cached result of a full scan — lightweight, cloneable, no tree-sitter state.
+#[derive(Clone)]
+struct CachedScan {
+    graph: RepoGraph,
+    pagerank: HashMap<String, f64>,
+}
+
+/// The main repository map engine.
+pub struct RepoMapEngine {
+    pub project_root: PathBuf,
+    pub ts: TreeSitterAdapter,
+    pub graph: RepoGraph,
+    /// File path → last mtime (for incremental rescan).
+    mtime_cache: HashMap<String, u64>,
+    pub scan_state: String,
+    pub max_file_bytes: u64,
+    pub scan_stats: ScanStats,
+    resolver: Option<ImportResolver>,
+    analyzer: Option<GraphAnalyzer>,
+}
+
+impl RepoMapEngine {
+    pub fn new(project_root: &Path) -> Self {
+        let max_file_bytes = std::env::var("DEEPMAP_MAX_FILE_BYTES")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(DEFAULT_MAX_FILE_BYTES);
+
+        Self {
+            project_root: project_root.to_path_buf(),
+            ts: TreeSitterAdapter::new(),
+            graph: RepoGraph::default(),
+            mtime_cache: HashMap::new(),
+            scan_state: "idle".into(),
+            max_file_bytes,
+            scan_stats: ScanStats::default(),
+            resolver: None,
+            analyzer: None,
+        }
+    }
+
+    /// Get or create a scanned engine for the given project root.
+    /// Uses the session cache to avoid re-scanning on repeated calls.
+    pub fn get_or_scan(project_root: &Path, max_files: usize, max_scan_time_secs: f64) -> Self {
+        let canonical = project_root
+            .canonicalize()
+            .unwrap_or_else(|_| project_root.to_path_buf());
+
+        // Try cache first.
+        if let Some(cached) = SCAN_CACHE
+            .lock()
+            .ok()
+            .and_then(|cache| cache.get(&canonical).cloned())
+        {
+            let mut engine = Self::new(&canonical);
+            engine.graph = cached.graph;
+            engine.scan_state = "scanned".into();
+            engine.analyzer = Some(GraphAnalyzer::new());
+            if let Some(ref analyzer) = engine.analyzer {
+                // Re-load pagerank scores from cache.
+                for (id, score) in &cached.pagerank {
+                    if let Some(sym) = engine.graph.symbols.get_mut(id) {
+                        sym.pagerank = *score;
+                    }
+                }
+            }
+            engine.scan_stats.processed_files = engine.graph.file_symbols.len();
+            log::info!("DeepMap: using cached scan for {}", canonical.display());
+            return engine;
+        }
+
+        // Do a fresh scan.
+        log::info!("DeepMap: scanning {} ...", canonical.display());
+        let mut engine = Self::new(&canonical);
+        engine.scan(max_files, max_scan_time_secs);
+
+        // Store in cache.
+        if engine.is_scanned() {
+            if let Some(ref analyzer) = engine.analyzer {
+                let pagerank = analyzer.pagerank_scores().clone();
+                if let Ok(mut cache) = SCAN_CACHE.lock() {
+                    cache.insert(
+                        canonical,
+                        CachedScan {
+                            graph: engine.graph.clone(),
+                            pagerank,
+                        },
+                    );
+                }
+            }
+        }
+
+        engine
+    }
+
+    pub fn is_scanned(&self) -> bool {
+        self.scan_state == "scanned"
+    }
+
+    // ── Main scan flow ──
+
+    /// Three-phase scan: list files → extract symbols → build edges → PageRank.
+    pub fn scan(&mut self, max_files: usize, max_scan_time_secs: f64) {
+        let start = Instant::now();
+        self.scan_state = "invalid".to_string();
+
+        if self.ts.parsers.is_empty() {
+            // At minimum, we should have at least one parser loaded.
+            // If none loaded, scan will be empty — warn and continue.
+        }
+
+        self.graph = RepoGraph::default();
+        self.mtime_cache.clear();
+        self.scan_stats = ScanStats::default();
+
+        let files = self.list_files(max_files);
+        log::info!("Found {} source files", files.len());
+
+        for f in &files {
+            // Timeout guard.
+            if start.elapsed().as_secs_f64() > max_scan_time_secs {
+                self.scan_stats.timeout_triggered = true;
+                log::warn!(
+                    "Scan timeout triggered: exceeded {}s limit",
+                    max_scan_time_secs
+                );
+                break;
+            }
+
+            if let Err(e) = self.process_file(f) {
+                if self.scan_stats.failed_files.len() < 5 {
+                    self.scan_stats.failed_files.push(format!("{}: {}", f, e));
+                }
+            }
+        }
+
+        self.build_edges();
+        self.analyzer = Some(GraphAnalyzer::new());
+        self.calculate_pagerank();
+        self.scan_state = "scanned".to_string();
+
+        self.scan_stats.scan_duration_ms = start.elapsed().as_millis() as u64;
+
+        let sym_count = self.graph.symbols.len();
+        let edge_count: usize = self.graph.outgoing.values().map(|v| v.len()).sum();
+        log::info!(
+            "Scan complete — {} symbols, {} edges, {}ms",
+            sym_count,
+            edge_count,
+            self.scan_stats.scan_duration_ms
+        );
+    }
+
+    // ── File listing ──
+
+    fn list_files(&mut self, max_files: usize) -> Vec<String> {
+        let valid_exts: Vec<&str> = vec![
+            ".py", ".pyi", ".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx", ".mts", ".cts", ".go",
+            ".rs", ".html", ".htm", ".css", ".json",
+        ];
+        let valid_set: std::collections::HashSet<&str> = valid_exts.into_iter().collect();
+
+        let mut candidates = Vec::new();
+        let walker = WalkBuilder::new(&self.project_root)
+            .hidden(false)
+            .git_ignore(true)
+            .build();
+
+        for entry in walker.flatten() {
+            if !entry.file_type().map_or(false, |t| t.is_file()) {
+                continue;
+            }
+            let path = entry.path();
+            let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+            let dot_ext = format!(".{}", ext);
+            if !valid_set.contains(dot_ext.as_str()) {
+                continue;
+            }
+            if let Ok(rel) = path.strip_prefix(&self.project_root) {
+                candidates.push(rel.to_string_lossy().to_string());
+            }
+        }
+
+        self.scan_stats.listed_source_files = candidates.len();
+
+        // Filter out paths to skip.
+        let filtered: Vec<String> = candidates
+            .into_iter()
+            .filter(|f| !self.should_skip_path(f))
+            .collect();
+
+        self.scan_stats.selected_source_files = filtered.len().min(max_files);
+
+        if filtered.len() > max_files {
+            self.scan_stats.truncated_files = filtered.len() - max_files;
+        }
+        filtered.into_iter().take(max_files).collect()
+    }
+
+    fn should_skip_path(&self, file: &str) -> bool {
+        let path = Path::new(file);
+        if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+            if name.ends_with(".min.js") {
+                return true;
+            }
+            if SKIP_FILE_NAMES.contains(&name) {
+                return true;
+            }
+        }
+        path.components().any(|c| {
+            if let std::path::Component::Normal(part) = c {
+                SKIP_DIR_NAMES.contains(&part.to_str().unwrap_or(""))
+            } else {
+                false
+            }
+        })
+    }
+
+    // ── File processing ──
+
+    fn process_file(&mut self, file: &str) -> Result<(), String> {
+        let path = self.project_root.join(file);
+        if !path.exists() {
+            return Ok(());
+        }
+
+        // Check file size.
+        if let Ok(meta) = path.metadata() {
+            let mtime = meta
+                .modified()
+                .map(|t| {
+                    t.duration_since(std::time::UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_secs()
+                })
+                .unwrap_or(0);
+
+            if mtime > 0 && self.mtime_cache.get(file) == Some(&mtime) {
+                return Ok(()); // Unchanged, skip.
+            }
+
+            if meta.len() > self.max_file_bytes {
+                self.scan_stats.filtered_large_files += 1;
+                return Ok(());
+            }
+
+            let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+            let dot_ext = format!(".{}", ext);
+            let lang = match crate::types::ext_to_lang(&dot_ext) {
+                Some(l) => l,
+                None => return Ok(()),
+            };
+
+            if !self.ts.parsers.contains_key(lang) {
+                return Ok(());
+            }
+
+            let content = std::fs::read(&path).map_err(|e| e.to_string())?;
+            let tree = match self.ts.parse(&content, lang) {
+                Some(t) => t,
+                None => return Ok(()),
+            };
+
+            let source = String::from_utf8_lossy(&content);
+
+            // Extract symbols.
+            let symbols = self.ts.extract_symbols(&tree, lang, file, &source);
+            for sym in &symbols {
+                self.graph.symbols.insert(sym.id.clone(), sym.clone());
+            }
+            self.graph.file_symbols.insert(
+                file.to_string(),
+                symbols.iter().map(|s| s.id.clone()).collect(),
+            );
+
+            // Extract imports.
+            let imports = self.ts.extract_imports(&tree, lang, &source);
+            let import_modules: Vec<String> = imports.iter().map(|(m, _)| m.clone()).collect();
+
+            // Extract JS/TS import bindings.
+            let import_bindings = self.ts.extract_js_ts_import_bindings(&tree, lang, &source);
+            let mut all_modules = import_modules.clone();
+            for b in &import_bindings {
+                if !b.module.is_empty() && !all_modules.contains(&b.module) {
+                    all_modules.push(b.module.clone());
+                }
+            }
+            all_modules.sort();
+            all_modules.dedup();
+            self.graph
+                .file_imports
+                .insert(file.to_string(), all_modules);
+            self.graph
+                .file_import_bindings
+                .insert(file.to_string(), import_bindings);
+
+            // Extract exports.
+            let exports = self.ts.extract_js_ts_export_bindings(&tree, lang, &source);
+            self.graph.file_exports.insert(file.to_string(), exports);
+            self.mark_exported_symbols(file);
+
+            // Extract calls.
+            let calls = self.ts.extract_calls(&tree, lang, &source);
+            self.graph.file_calls.insert(file.to_string(), calls);
+
+            // Cache mtime.
+            self.mtime_cache.insert(file.to_string(), mtime);
+            self.scan_stats.processed_files += 1;
+
+            // Clean stale cache entries.
+            let project_root = self.project_root.clone();
+            self.mtime_cache
+                .retain(|k, _| project_root.join(k).exists());
+        }
+
+        Ok(())
+    }
+
+    fn mark_exported_symbols(&mut self, file: &str) {
+        let exports = match self.graph.file_exports.get(file) {
+            Some(e) => e,
+            None => return,
+        };
+        let exported_names: std::collections::HashSet<&str> = exports
+            .iter()
+            .filter(|b| b.module.is_none() && b.source_name.as_deref() != Some("*"))
+            .filter_map(|b| b.source_name.as_deref())
+            .collect();
+
+        if exported_names.is_empty() {
+            return;
+        }
+
+        for sym_id in self
+            .graph
+            .file_symbols
+            .get(file)
+            .iter()
+            .flat_map(|v| v.iter())
+        {
+            if let Some(sym) = self.graph.symbols.get_mut(sym_id) {
+                if exported_names.contains(sym.name.as_str()) {
+                    sym.visibility = "exported".to_string();
+                }
+            }
+        }
+    }
+
+    // ── Edge building ──
+
+    fn build_edges(&mut self) {
+        let resolver = ImportResolver::new(&self.project_root, &self.graph);
+        // Build import edges and call edges.
+        let mut edges_to_add: Vec<(String, Edge)> = Vec::new();
+
+        // Collect all file-symbol mappings for quick lookup.
+        for (file, calls) in &self.graph.file_calls.clone() {
+            for (call_name, call_line, call_kind) in calls {
+                if let Some(target_id) = resolver.resolve_call_target(
+                    file,
+                    call_name,
+                    *call_line,
+                    call_kind,
+                    &HashMap::new(), // TODO: file local_names
+                ) {
+                    if let Some(containing_sym) =
+                        resolver.resolve_calling_symbol_with_graph(file, *call_line, &self.graph)
+                    {
+                        let edge = Edge {
+                            source: containing_sym,
+                            target: target_id,
+                            weight: CALL_WEIGHT,
+                            kind: "call".into(),
+                        };
+                        edges_to_add.push((edge.source.clone(), edge));
+                    }
+                }
+            }
+        }
+
+        // Build import edges.
+        for (file, imports) in &self.graph.file_imports.clone() {
+            for imp in imports {
+                let targets = resolver.resolve_import_targets(file, imp);
+                for target_file in &targets {
+                    if let Some(target_syms) = self.graph.file_symbols.get(target_file) {
+                        for src_sym_id in self
+                            .graph
+                            .file_symbols
+                            .get(file)
+                            .iter()
+                            .flat_map(|v| v.iter())
+                        {
+                            for tgt_sym_id in target_syms {
+                                let edge = Edge {
+                                    source: src_sym_id.clone(),
+                                    target: tgt_sym_id.clone(),
+                                    weight: IMPORT_WEIGHT,
+                                    kind: "import".into(),
+                                };
+                                edges_to_add.push((edge.source.clone(), edge));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Insert edges into graph.
+        for (source, edge) in edges_to_add {
+            let target_id = edge.target.clone();
+            let kind = edge.kind.clone();
+            let weight = edge.weight;
+            self.graph
+                .outgoing
+                .entry(source.clone())
+                .or_default()
+                .push(edge);
+            self.graph
+                .incoming
+                .entry(target_id.clone())
+                .or_default()
+                .push(Edge {
+                    source: target_id,
+                    target: source,
+                    weight,
+                    kind,
+                });
+        }
+
+        self.resolver = Some(resolver);
+    }
+
+    // ── PageRank ──
+
+    fn calculate_pagerank(&mut self) {
+        let analyzer = self.analyzer.as_mut().expect("analyzer not initialized");
+        // Transfer graph data to the analyzer's internal structures.
+        analyzer.load_graph(&self.graph);
+        analyzer.calculate_pagerank(&self.graph, 0.85, 50, 1e-6);
+        // Write PageRank scores back to symbols.
+        let scores = analyzer.pagerank_scores();
+        for (sym_id, score) in scores {
+            if let Some(sym) = self.graph.symbols.get_mut(sym_id) {
+                sym.pagerank = *score;
+            }
+        }
+    }
+
+    // ── Query interface ──
+
+    pub fn query_symbol(&self, name: &str) -> Vec<&crate::types::Symbol> {
+        let analyzer = match &self.analyzer {
+            Some(a) => a,
+            None => return Vec::new(),
+        };
+        analyzer.query_symbol(name, &self.graph)
+    }
+
+    pub fn call_chain(
+        &self,
+        symbol_id: &str,
+        direction: &str,
+        max_depth: usize,
+    ) -> HashMap<String, Vec<crate::types::Symbol>> {
+        let analyzer = match &self.analyzer {
+            Some(a) => a,
+            None => return HashMap::new(),
+        };
+        analyzer.call_chain(symbol_id, direction, max_depth, &self.graph)
+    }
+
+    pub fn hotspots(&self, limit: usize) -> Vec<HashMap<String, String>> {
+        let analyzer = match &self.analyzer {
+            Some(a) => a,
+            None => return Vec::new(),
+        };
+        analyzer.hotspots(limit, &self.graph)
+    }
+
+    pub fn entry_points(&self) -> Vec<String> {
+        let analyzer = match &self.analyzer {
+            Some(a) => a,
+            None => return Vec::new(),
+        };
+        analyzer.entry_points(&self.graph)
+    }
+
+    pub fn file_analysis(&self) -> HashMap<String, HashMap<String, f64>> {
+        let analyzer = match &self.analyzer {
+            Some(a) => a,
+            None => return HashMap::new(),
+        };
+        analyzer.file_analysis(&self.graph)
+    }
+
+    pub fn module_summary(&self, limit: usize) -> Vec<HashMap<String, String>> {
+        let analyzer = match &self.analyzer {
+            Some(a) => a,
+            None => return Vec::new(),
+        };
+        analyzer.module_summary(limit, &self.graph)
+    }
+
+    pub fn suggested_reading_order(&self, limit: usize) -> Vec<HashMap<String, String>> {
+        let analyzer = match &self.analyzer {
+            Some(a) => a,
+            None => return Vec::new(),
+        };
+        analyzer.suggested_reading_order(limit, &self.graph)
+    }
+
+    pub fn summary_symbols(
+        &self,
+        limit_files: usize,
+        per_file: usize,
+    ) -> Vec<HashMap<String, String>> {
+        let analyzer = match &self.analyzer {
+            Some(a) => a,
+            None => return Vec::new(),
+        };
+        analyzer.summary_symbols(limit_files, per_file, &self.graph)
+    }
+
+    // ── Scan summary ──
+
+    pub fn scan_summary_lines(&self) -> Vec<String> {
+        let mut lines = vec![
+            format!("- Files processed: {}", self.scan_stats.processed_files),
+            format!("- Symbols: {}", self.graph.symbols.len()),
+            format!(
+                "- Edges: {}",
+                self.graph.outgoing.values().map(|v| v.len()).sum::<usize>()
+            ),
+            format!("- Filtered paths: {}", self.scan_stats.filtered_path_files),
+            format!(
+                "- Filtered large files: {}",
+                self.scan_stats.filtered_large_files
+            ),
+        ];
+        if let Some(ref resolver) = self.resolver {
+            lines.push(format!(
+                "- Import configs: {}",
+                resolver.import_configs.len()
+            ));
+        }
+        if self.scan_stats.timeout_triggered {
+            lines.push("- ⚠️ Scan timeout triggered: results may be incomplete".to_string());
+        }
+        if !self.scan_stats.failed_files.is_empty() {
+            lines.push(format!(
+                "- Failed files: {}",
+                self.scan_stats.failed_files.len()
+            ));
+            for ff in self.scan_stats.failed_files.iter().take(3) {
+                lines.push(format!("  - {}", ff));
+            }
+        }
+        lines
+    }
+}

--- a/crates/deepmap/src/git.rs
+++ b/crates/deepmap/src/git.rs
@@ -1,0 +1,200 @@
+// Git history helpers for DeepMap.
+// Provides blame lookups, recently-changed files, and co-change analysis.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::process::Command;
+
+/// Get git blame info for a symbol in a file at a given line.
+pub fn blame_symbol(project_root: &Path, file: &str, line: usize) -> Option<BlameInfo> {
+    let output = Command::new("git")
+        .args([
+            "blame",
+            "-L",
+            &format!("{},{}", line, line),
+            "--porcelain",
+            file,
+        ])
+        .current_dir(project_root)
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_blame_porcelain(&stdout)
+}
+
+/// Blame information for a line.
+#[derive(Debug, Clone)]
+pub struct BlameInfo {
+    pub commit_hash: String,
+    pub author: String,
+    pub author_time: String,
+    pub summary: String,
+}
+
+fn parse_blame_porcelain(output: &str) -> Option<BlameInfo> {
+    let mut commit_hash = String::new();
+    let mut author = String::new();
+    let mut author_time = String::new();
+    let mut summary = String::new();
+
+    for line in output.lines() {
+        if commit_hash.is_empty() {
+            if let Some(hash) = line.split_whitespace().next() {
+                commit_hash = hash.to_string();
+            }
+        }
+        if line.starts_with("author ") {
+            author = line.strip_prefix("author ").unwrap_or("").to_string();
+        }
+        if line.starts_with("author-time ") {
+            author_time = line.strip_prefix("author-time ").unwrap_or("").to_string();
+        }
+        if line.starts_with("summary ") {
+            summary = line.strip_prefix("summary ").unwrap_or("").to_string();
+        }
+    }
+
+    if commit_hash.is_empty() {
+        return None;
+    }
+
+    Some(BlameInfo {
+        commit_hash,
+        author,
+        author_time,
+        summary,
+    })
+}
+
+/// Get files changed in the last N days.
+pub fn recently_changed_files(project_root: &Path, days: u32) -> Vec<String> {
+    let since = format!("{} days ago", days);
+    let output = match Command::new("git")
+        .args([
+            "diff",
+            "--name-only",
+            &format!("HEAD@{{{}}}", since),
+            "HEAD",
+        ])
+        .current_dir(project_root)
+        .output()
+    {
+        Ok(o) => o,
+        Err(_) => return Vec::new(),
+    };
+
+    if !output.status.success() {
+        // Fall back to log-based approach.
+        return recent_files_via_log(project_root, days);
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    stdout
+        .lines()
+        .map(|l| l.trim().to_string())
+        .filter(|l| !l.is_empty())
+        .collect()
+}
+
+fn recent_files_via_log(project_root: &Path, days: u32) -> Vec<String> {
+    let since = format!("{} days ago", days);
+    let output = match Command::new("git")
+        .args([
+            "log",
+            "--name-only",
+            "--pretty=format:",
+            &format!("--since={}", since),
+        ])
+        .current_dir(project_root)
+        .output()
+    {
+        Ok(o) => o,
+        Err(_) => return Vec::new(),
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut files: Vec<String> = stdout
+        .lines()
+        .map(|l| l.trim().to_string())
+        .filter(|l| !l.is_empty())
+        .collect();
+    files.sort();
+    files.dedup();
+    files
+}
+
+/// Compute co-change scores: which files tend to change together.
+pub fn co_change_scores(
+    project_root: &Path,
+    limit: usize,
+) -> HashMap<String, Vec<(String, usize)>> {
+    let output = match Command::new("git")
+        .args([
+            "log",
+            "--name-only",
+            "--pretty=format:",
+            &format!("-n {}", limit),
+        ])
+        .current_dir(project_root)
+        .output()
+    {
+        Ok(o) => o,
+        Err(_) => return HashMap::new(),
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut commit_files: Vec<Vec<String>> = Vec::new();
+    let mut current_commit: Vec<String> = Vec::new();
+
+    for line in stdout.lines() {
+        let trimmed = line.trim().to_string();
+        if trimmed.is_empty() {
+            if !current_commit.is_empty() {
+                commit_files.push(std::mem::take(&mut current_commit));
+            }
+        } else {
+            current_commit.push(trimmed);
+        }
+    }
+    if !current_commit.is_empty() {
+        commit_files.push(current_commit);
+    }
+
+    // Count co-occurrences.
+    let mut pair_counts: HashMap<(String, String), usize> = HashMap::new();
+    for commit in &commit_files {
+        for i in 0..commit.len() {
+            for j in (i + 1)..commit.len() {
+                let pair = if commit[i] < commit[j] {
+                    (commit[i].clone(), commit[j].clone())
+                } else {
+                    (commit[j].clone(), commit[i].clone())
+                };
+                *pair_counts.entry(pair).or_insert(0) += 1;
+            }
+        }
+    }
+
+    // Build per-file co-change map.
+    let mut co_change: HashMap<String, Vec<(String, usize)>> = HashMap::new();
+    for ((a, b), count) in pair_counts {
+        co_change
+            .entry(a.clone())
+            .or_default()
+            .push((b.clone(), count));
+        co_change.entry(b).or_default().push((a, count));
+    }
+
+    // Sort by count descending.
+    for v in co_change.values_mut() {
+        v.sort_by(|a, b| b.1.cmp(&a.1));
+        v.truncate(20);
+    }
+
+    co_change
+}

--- a/crates/deepmap/src/lib.rs
+++ b/crates/deepmap/src/lib.rs
@@ -1,0 +1,16 @@
+// DeepMap — Codebase analysis engine for DeepSeek-TUI.
+//
+// Provides repository scanning, symbol extraction, dependency graph building,
+// PageRank-based ranking, and AI-friendly report rendering.
+
+pub mod cache;
+pub mod diagnostics;
+pub mod engine;
+pub mod git;
+pub mod parser;
+pub mod queries;
+pub mod ranking;
+pub mod renderer;
+pub mod resolver;
+pub mod topic;
+pub mod types;

--- a/crates/deepmap/src/parser.rs
+++ b/crates/deepmap/src/parser.rs
@@ -1,0 +1,755 @@
+// Tree-sitter multi-language parser adapter.
+// Handles parser initialization, AST parsing, symbol extraction,
+// import/call extraction for all supported languages.
+
+use std::collections::HashMap;
+use tree_sitter::{Language, Node, Parser, Query, QueryCursor, StreamingIterator, Tree};
+
+use crate::types::*;
+
+/// Wraps tree-sitter multi-language parsing.
+///
+/// Lazily loads language bindings, silently skipping unavailable ones.
+/// Pre-compiles queries for each loaded language.
+pub struct TreeSitterAdapter {
+    pub parsers: HashMap<String, Parser>,
+    queries: HashMap<String, HashMap<String, Query>>,
+    languages: HashMap<String, Language>,
+}
+
+impl TreeSitterAdapter {
+    pub fn new() -> Self {
+        let mut adapter = Self {
+            parsers: HashMap::new(),
+            queries: HashMap::new(),
+            languages: HashMap::new(),
+        };
+        adapter.init_parsers();
+        adapter
+    }
+
+    fn init_parsers(&mut self) {
+        self.try_load_language("rust", tree_sitter_rust::LANGUAGE.into());
+        self.try_load_language("python", tree_sitter_python::LANGUAGE.into());
+        self.try_load_language("javascript", tree_sitter_javascript::LANGUAGE.into());
+        self.try_load_language(
+            "typescript",
+            tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
+        );
+        self.try_load_language("go", tree_sitter_go::LANGUAGE.into());
+        self.try_load_language("html", tree_sitter_html::LANGUAGE.into());
+        self.try_load_language("css", tree_sitter_css::LANGUAGE.into());
+        self.try_load_language("json", tree_sitter_json::LANGUAGE.into());
+        self.precompile_queries();
+    }
+
+    fn try_load_language(&mut self, name: &str, lang: Language) {
+        let mut parser = Parser::new();
+        match parser.set_language(&lang) {
+            Ok(()) => {
+                self.parsers.insert(name.to_string(), parser);
+                self.languages.insert(name.to_string(), lang);
+            }
+            Err(_e) => {}
+        }
+    }
+
+    /// Parse source content with the given language.
+    pub fn parse(&mut self, content: &[u8], lang: &str) -> Option<Tree> {
+        let parser = self.parsers.get_mut(lang)?;
+
+        const MAX_PARSE_SIZE: usize = 10 * 1024 * 1024;
+        if content.len() > MAX_PARSE_SIZE {
+            return None;
+        }
+
+        // Check for extreme nesting (depth > 1000) to prevent stack overflow.
+        if let Ok(text) = std::str::from_utf8(&content[..content.len().min(100_000)]) {
+            let mut max_nesting = 0u32;
+            let mut current = 0u32;
+            for ch in text.chars() {
+                match ch {
+                    '(' | '{' | '[' | '<' => {
+                        current += 1;
+                        max_nesting = max_nesting.max(current);
+                    }
+                    ')' | '}' | ']' | '>' => {
+                        current = current.saturating_sub(1);
+                    }
+                    _ => {}
+                }
+            }
+            if max_nesting > 1000 {
+                return None;
+            }
+        }
+
+        parser.parse(content, None)
+    }
+
+    fn precompile_queries(&mut self) {
+        for (lang, query_type, src) in crate::queries::queries() {
+            if !self.languages.contains_key(lang) {
+                continue;
+            }
+            let language = &self.languages[lang];
+            if let Ok(q) = Query::new(language, src) {
+                self.queries
+                    .entry(lang.to_string())
+                    .or_default()
+                    .insert(query_type.to_string(), q);
+            }
+        }
+    }
+
+    /// Extract symbols (functions, classes, etc.) from AST.
+    /// `source` is the original file content as a UTF-8 string.
+    pub fn extract_symbols(
+        &self,
+        tree: &Tree,
+        lang: &str,
+        file: &str,
+        source: &str,
+    ) -> Vec<Symbol> {
+        if lang == "html" {
+            return self.extract_html_symbols(tree, file, source);
+        }
+        if lang == "css" {
+            return self.extract_css_symbols(tree, file, source);
+        }
+        if lang == "json" {
+            return self.extract_json_symbols(tree, file, source);
+        }
+
+        let mut symbols: HashMap<String, Symbol> = HashMap::new();
+        let root = tree.root_node();
+        let source_bytes = source.as_bytes();
+
+        for query_type in &["function", "class"] {
+            let query = match self.queries.get(lang).and_then(|q| q.get(*query_type)) {
+                Some(q) => q,
+                None => continue,
+            };
+
+            let mut cursor = QueryCursor::new();
+            let capture_names = query.capture_names().to_vec();
+            let mut name_nodes: Vec<Node> = Vec::new();
+            let mut def_nodes: Vec<(Node, String)> = Vec::new();
+
+            let mut captures = cursor.captures(query, root, source_bytes);
+            while let Some((match_, _)) = captures.next() {
+                for capture in match_.captures {
+                    let cap_name = capture_names[capture.index as usize];
+                    let node = capture.node;
+                    if cap_name == "name" || cap_name.starts_with("name") {
+                        name_nodes.push(node);
+                    } else if cap_name.contains("definition") || cap_name.contains("export") {
+                        def_nodes.push((node, cap_name.to_string()));
+                    }
+                }
+            }
+
+            for name_node in &name_nodes {
+                let mut matching: Vec<(&Node, &str)> = def_nodes
+                    .iter()
+                    .filter(|(def_node, _)| within(name_node, def_node))
+                    .map(|(def_node, cap_name)| (def_node, cap_name.as_str()))
+                    .collect();
+
+                matching.sort_by(|a, b| {
+                    let size_a = (
+                        a.0.end_position().row - a.0.start_position().row,
+                        a.0.end_position().column - a.0.start_position().column,
+                    );
+                    let size_b = (
+                        b.0.end_position().row - b.0.start_position().row,
+                        b.0.end_position().column - b.0.start_position().column,
+                    );
+                    size_a
+                        .0
+                        .cmp(&size_b.0)
+                        .then(size_a.1.cmp(&size_b.1))
+                        .then(a.0.start_position().row.cmp(&b.0.start_position().row))
+                        .then(
+                            a.0.start_position()
+                                .column
+                                .cmp(&b.0.start_position().column),
+                        )
+                });
+
+                for (def_node, def_cap) in matching {
+                    let kind = def_cap.split('.').last().unwrap_or(def_cap).to_string();
+                    let mut vis = if def_cap.contains("export") {
+                        "exported"
+                    } else {
+                        "public"
+                    };
+                    let name = node_text(name_node, source_bytes);
+                    if name.is_empty() {
+                        break;
+                    }
+                    if lang == "python" && name.starts_with('_') && !name.starts_with("__") {
+                        vis = "private";
+                    }
+                    let sym_id =
+                        format!("{}::{}::{}", file, name, name_node.start_position().row + 1);
+                    symbols.entry(sym_id.clone()).or_insert_with(|| {
+                        Symbol::new(
+                            sym_id,
+                            name.to_string(),
+                            kind,
+                            file.to_string(),
+                            name_node.start_position().row + 1,
+                            def_node.end_position().row + 1,
+                            name_node.start_position().column,
+                            vis.to_string(),
+                            String::new(),
+                            signature(def_node, source_bytes),
+                        )
+                    });
+                    break;
+                }
+            }
+        }
+
+        // Object-literal method symbols (JS/TS).
+        for sym in self.extract_object_literal_methods(tree, lang, file, source_bytes) {
+            symbols.entry(sym.id.clone()).or_insert(sym);
+        }
+        // Anonymous function symbols (JS/TS).
+        for sym in self.extract_anonymous_symbols(tree, lang, file, source_bytes) {
+            symbols.entry(sym.id.clone()).or_insert(sym);
+        }
+
+        let mut result: Vec<Symbol> = symbols.into_values().collect();
+        result.sort_by(|a, b| {
+            a.file
+                .cmp(&b.file)
+                .then(a.line.cmp(&b.line))
+                .then(a.end_line.cmp(&b.end_line))
+                .then(a.col.cmp(&b.col))
+                .then(a.name.cmp(&b.name))
+                .then(a.kind.cmp(&b.kind))
+        });
+        result
+    }
+
+    /// Extract imports from AST. Returns (module_name, line_number).
+    pub fn extract_imports(&self, tree: &Tree, lang: &str, source: &str) -> Vec<(String, usize)> {
+        let query = match self.queries.get(lang).and_then(|q| q.get("import")) {
+            Some(q) => q,
+            None => return Vec::new(),
+        };
+
+        let source_bytes = source.as_bytes();
+        let mut cursor = QueryCursor::new();
+        let capture_names = query.capture_names().to_vec();
+
+        if lang == "rust" {
+            use std::collections::BTreeMap;
+            let mut paths: BTreeMap<usize, String> = BTreeMap::new();
+            let mut names: BTreeMap<usize, Vec<String>> = BTreeMap::new();
+
+            let mut captures = cursor.captures(query, tree.root_node(), source_bytes);
+            while let Some((match_, _)) = captures.next() {
+                for capture in match_.captures {
+                    let cap_name = capture_names[capture.index as usize];
+                    let text = node_text(&capture.node, source_bytes);
+                    let line = capture.node.start_position().row + 1;
+                    if cap_name == "path" {
+                        paths.insert(line, text.to_string());
+                    } else if cap_name == "name" {
+                        names.entry(line).or_default().push(text.to_string());
+                    }
+                }
+            }
+
+            let mut lines: Vec<usize> = paths.keys().chain(names.keys()).copied().collect();
+            lines.sort();
+            lines.dedup();
+
+            let mut results = Vec::new();
+            for line in lines {
+                if let Some(path) = paths.get(&line) {
+                    results.push((path.clone(), line));
+                } else if let Some(nms) = names.get(&line) {
+                    for name in nms {
+                        results.push((name.clone(), line));
+                    }
+                }
+            }
+            results
+        } else {
+            let mut results = Vec::new();
+            let mut captures = cursor.captures(query, tree.root_node(), source_bytes);
+            while let Some((match_, _)) = captures.next() {
+                for capture in match_.captures {
+                    let cap_name = capture_names[capture.index as usize];
+                    if (lang == "javascript" || lang == "typescript") && cap_name != "source" {
+                        continue;
+                    }
+                    let text = node_text(&capture.node, source_bytes)
+                        .trim_matches(|c| c == '"' || c == '\'')
+                        .to_string();
+                    if !text.is_empty() {
+                        results.push((text, capture.node.start_position().row + 1));
+                    }
+                }
+            }
+            results.sort_by(|a, b| a.1.cmp(&b.1).then(a.0.cmp(&b.0)));
+            results
+        }
+    }
+
+    /// Extract function calls from AST. Returns (name, line, kind).
+    pub fn extract_calls(
+        &self,
+        tree: &Tree,
+        lang: &str,
+        source: &str,
+    ) -> Vec<(String, usize, String)> {
+        let query = match self.queries.get(lang).and_then(|q| q.get("call")) {
+            Some(q) => q,
+            None => return Vec::new(),
+        };
+
+        let source_bytes = source.as_bytes();
+        let mut cursor = QueryCursor::new();
+        let capture_names = query.capture_names().to_vec();
+        let mut results = Vec::new();
+
+        let mut captures = cursor.captures(query, tree.root_node(), source_bytes);
+        while let Some((match_, _)) = captures.next() {
+            for capture in match_.captures {
+                let cap_name = capture_names[capture.index as usize];
+                if cap_name.contains("reference") || cap_name.contains("call") || cap_name == "name"
+                {
+                    let name = node_text(&capture.node, source_bytes);
+                    if !name.is_empty() {
+                        let kind = call_reference_kind(&capture.node);
+                        results.push((
+                            name.to_string(),
+                            capture.node.start_position().row + 1,
+                            kind,
+                        ));
+                    }
+                }
+            }
+        }
+        results.sort_by(|a, b| a.1.cmp(&b.1).then(a.0.cmp(&b.0)));
+        results
+    }
+
+    /// Extract JS/TS import bindings.
+    pub fn extract_js_ts_import_bindings(
+        &self,
+        tree: &Tree,
+        lang: &str,
+        source: &str,
+    ) -> Vec<JsImportBinding> {
+        if lang != "javascript" && lang != "typescript" {
+            return Vec::new();
+        }
+        // TODO: implement full JS/TS import binding extraction from AST
+        let _ = (tree, source);
+        Vec::new()
+    }
+
+    /// Extract JS/TS export bindings.
+    pub fn extract_js_ts_export_bindings(
+        &self,
+        tree: &Tree,
+        lang: &str,
+        source: &str,
+    ) -> Vec<JsExportBinding> {
+        if lang != "javascript" && lang != "typescript" {
+            return Vec::new();
+        }
+        // TODO: implement full JS/TS export binding extraction from AST
+        let _ = (tree, source);
+        Vec::new()
+    }
+
+    // ── HTML / CSS / JSON symbol extraction ──
+
+    fn extract_html_symbols(&self, tree: &Tree, file: &str, source: &str) -> Vec<Symbol> {
+        let mut symbols: HashMap<String, Symbol> = HashMap::new();
+        let mut seen: HashMap<(String, usize), usize> = HashMap::new();
+        let root = tree.root_node();
+        for node in walk_tree(&root) {
+            if node.kind() != "element" {
+                continue;
+            }
+            let tag_name = first_child_of_type(&node, "start_tag")
+                .and_then(|st| {
+                    let mut cursor = st.walk();
+                    st.children(&mut cursor).find(|c| c.kind() == "tag_name")
+                })
+                .map(|tn| node_text(&tn, source.as_bytes()).to_string());
+
+            if let Some(tag_name) = tag_name {
+                let line = node.start_position().row + 1;
+                let mut visible = format!("<{}>", tag_name);
+                let key = (visible.clone(), line);
+                let count = seen.get(&key).copied().unwrap_or(0) + 1;
+                seen.insert(key.clone(), count);
+                if count > 1 {
+                    visible = format!("{}#{}", visible, count);
+                }
+                let sym_id = format!("{}::{}::{}", file, visible, line);
+                symbols.entry(sym_id.clone()).or_insert_with(|| {
+                    Symbol::new(
+                        sym_id,
+                        visible.clone(),
+                        "element".into(),
+                        file.to_string(),
+                        line,
+                        node.end_position().row + 1,
+                        node.start_position().column,
+                        "public".into(),
+                        String::new(),
+                        visible,
+                    )
+                });
+            }
+        }
+        let mut result: Vec<Symbol> = symbols.into_values().collect();
+        result.sort_by(|a, b| {
+            a.file
+                .cmp(&b.file)
+                .then(a.line.cmp(&b.line))
+                .then(a.col.cmp(&b.col))
+                .then(a.name.cmp(&b.name))
+        });
+        result
+    }
+
+    fn extract_css_symbols(&self, tree: &Tree, file: &str, source: &str) -> Vec<Symbol> {
+        let mut symbols: HashMap<String, Symbol> = HashMap::new();
+        let mut seen: HashMap<(String, usize), usize> = HashMap::new();
+        let selector_types = [
+            "class_selector",
+            "id_selector",
+            "tag_name",
+            "nesting_selector",
+        ];
+        let root = tree.root_node();
+        for node in walk_tree(&root) {
+            if !selector_types.contains(&node.kind()) {
+                continue;
+            }
+            let raw = node_text(&node, source.as_bytes()).trim().to_string();
+            if raw.is_empty() {
+                continue;
+            }
+            let line = node.start_position().row + 1;
+            let kind = if raw.starts_with('.') {
+                "class_selector"
+            } else if raw.starts_with('#') {
+                "id_selector"
+            } else {
+                "selector"
+            };
+            let key = (raw.clone(), line);
+            let count = seen.get(&key).copied().unwrap_or(0) + 1;
+            seen.insert(key, count);
+            let visible = if count == 1 {
+                raw.clone()
+            } else {
+                format!("{}#{}", raw, count)
+            };
+            let sym_id = format!("{}::{}::{}", file, visible, line);
+            symbols.entry(sym_id.clone()).or_insert_with(|| {
+                Symbol::new(
+                    sym_id,
+                    visible.clone(),
+                    kind.to_string(),
+                    file.to_string(),
+                    line,
+                    node.end_position().row + 1,
+                    node.start_position().column,
+                    "public".into(),
+                    String::new(),
+                    raw.clone(),
+                )
+            });
+        }
+        let mut result: Vec<Symbol> = symbols.into_values().collect();
+        result.sort_by(|a, b| {
+            a.file
+                .cmp(&b.file)
+                .then(a.line.cmp(&b.line))
+                .then(a.col.cmp(&b.col))
+                .then(a.name.cmp(&b.name))
+        });
+        result
+    }
+
+    fn extract_json_symbols(&self, tree: &Tree, file: &str, source: &str) -> Vec<Symbol> {
+        let mut symbols: HashMap<String, Symbol> = HashMap::new();
+        let mut seen: HashMap<(String, usize), usize> = HashMap::new();
+        let root = tree.root_node();
+        for node in walk_tree(&root) {
+            if node.kind() != "pair" {
+                continue;
+            }
+            let key_name = node
+                .child_by_field_name("key")
+                .map(|k| {
+                    node_text(&k, source.as_bytes())
+                        .trim_matches(|c| c == '"' || c == '\'')
+                        .to_string()
+                })
+                .filter(|s| !s.is_empty());
+
+            if let Some(key_name) = key_name {
+                let line = node.start_position().row + 1;
+                let key = (key_name.clone(), line);
+                let count = seen.get(&key).copied().unwrap_or(0) + 1;
+                seen.insert(key, count);
+                let visible = if count == 1 {
+                    key_name.clone()
+                } else {
+                    format!("{}#{}", key_name, count)
+                };
+                let sym_id = format!("{}::{}::{}", file, visible, line);
+                symbols.entry(sym_id.clone()).or_insert_with(|| {
+                    Symbol::new(
+                        sym_id,
+                        visible,
+                        "json_key".into(),
+                        file.to_string(),
+                        line,
+                        node.end_position().row + 1,
+                        node.start_position().column,
+                        "public".into(),
+                        String::new(),
+                        format!("\"{}\"", key_name),
+                    )
+                });
+            }
+        }
+        let mut result: Vec<Symbol> = symbols.into_values().collect();
+        result.sort_by(|a, b| {
+            a.file
+                .cmp(&b.file)
+                .then(a.line.cmp(&b.line))
+                .then(a.col.cmp(&b.col))
+                .then(a.name.cmp(&b.name))
+        });
+        result
+    }
+
+    // ── JS/TS specific extraction ──
+
+    fn extract_object_literal_methods(
+        &self,
+        tree: &Tree,
+        lang: &str,
+        file: &str,
+        source: &[u8],
+    ) -> Vec<Symbol> {
+        if lang != "javascript" && lang != "typescript" {
+            return Vec::new();
+        }
+        let mut symbols: HashMap<String, Symbol> = HashMap::new();
+        for node in walk_tree(&tree.root_node()) {
+            if node.kind() != "pair" {
+                continue;
+            }
+            let value_node = node.child_by_field_name("value");
+            if value_node.map_or(true, |v| {
+                v.kind() != "arrow_function" && v.kind() != "function_expression"
+            }) {
+                continue;
+            }
+            let key_node = node.child_by_field_name("key").or_else(|| {
+                let mut cursor = node.walk();
+                node.children(&mut cursor)
+                    .find(|c| matches!(c.kind(), "property_identifier" | "identifier" | "string"))
+            });
+            let name = key_node.and_then(|k| {
+                if k.kind() == "string" {
+                    Some(
+                        node_text(&k, source)
+                            .trim_matches(|c| c == '"' || c == '\'')
+                            .to_string(),
+                    )
+                } else {
+                    Some(node_text(&k, source).to_string())
+                }
+            });
+            if let (Some(name), Some(value_node)) = (name, value_node) {
+                if name.is_empty() {
+                    continue;
+                }
+                let kn = key_node.unwrap();
+                let line = kn.start_position().row + 1;
+                let sym_id = format!("{}::{}::{}", file, name, line);
+                symbols.entry(sym_id.clone()).or_insert_with(|| {
+                    Symbol::new(
+                        sym_id,
+                        name.clone(),
+                        "method".into(),
+                        file.to_string(),
+                        line,
+                        value_node.end_position().row + 1,
+                        kn.start_position().column,
+                        "public".into(),
+                        String::new(),
+                        signature(&value_node, source),
+                    )
+                });
+            }
+        }
+        let mut result: Vec<Symbol> = symbols.into_values().collect();
+        result.sort_by(|a, b| {
+            a.file
+                .cmp(&b.file)
+                .then(a.line.cmp(&b.line))
+                .then(a.col.cmp(&b.col))
+                .then(a.name.cmp(&b.name))
+        });
+        result
+    }
+
+    fn extract_anonymous_symbols(
+        &self,
+        tree: &Tree,
+        lang: &str,
+        file: &str,
+        source: &[u8],
+    ) -> Vec<Symbol> {
+        if lang != "javascript" && lang != "typescript" {
+            return Vec::new();
+        }
+        let query = match self
+            .queries
+            .get(lang)
+            .and_then(|q| q.get("anonymous_function"))
+        {
+            Some(q) => q,
+            None => return Vec::new(),
+        };
+        let root = tree.root_node();
+        let mut cursor = QueryCursor::new();
+        let mut results: HashMap<String, Symbol> = HashMap::new();
+        let mut captures = cursor.captures(query, root, source);
+        while let Some((match_, _)) = captures.next() {
+            for capture in match_.captures {
+                let node = capture.node;
+                if node.end_position().row <= node.start_position().row {
+                    continue;
+                }
+                if has_named_owner(&node) {
+                    continue;
+                }
+                let line = node.start_position().row + 1;
+                let name = format!("<anonymous@{}>", line);
+                let sym_id = format!("{}::{}::{}", file, name, line);
+                results.entry(sym_id.clone()).or_insert_with(|| {
+                    Symbol::new(
+                        sym_id,
+                        name.clone(),
+                        "anonymous_function".into(),
+                        file.to_string(),
+                        line,
+                        node.end_position().row + 1,
+                        node.start_position().column,
+                        "private".into(),
+                        String::new(),
+                        signature(&node, source),
+                    )
+                });
+            }
+        }
+        results.into_values().collect()
+    }
+}
+
+// ── Helpers ──
+
+fn node_text<'a>(node: &Node, source: &'a [u8]) -> &'a str {
+    node.utf8_text(source).unwrap_or("")
+}
+
+fn within(child: &Node, parent: &Node) -> bool {
+    child.start_position() >= parent.start_position()
+        && child.end_position() <= parent.end_position()
+}
+
+fn call_reference_kind(node: &Node) -> String {
+    let mut current = node.parent();
+    while let Some(parent) = current {
+        if parent.kind() == "call_expression" {
+            if let Some(func_node) = parent.child_by_field_name("function") {
+                let ft = func_node.kind();
+                if ft == "member_expression"
+                    || ft == "field_expression"
+                    || ft == "selector_expression"
+                {
+                    return "member".into();
+                }
+            }
+            return "direct".into();
+        }
+        current = parent.parent();
+    }
+    "direct".into()
+}
+
+fn signature(node: &Node, source: &[u8]) -> String {
+    let text = node_text(node, source);
+    let first_line = text.lines().next().unwrap_or("");
+    first_line.trim().to_string()
+}
+
+fn first_child_of_type<'a>(node: &'a Node, kind: &str) -> Option<Node<'a>> {
+    let mut cursor = node.walk();
+    node.children(&mut cursor).find(|c| c.kind() == kind)
+}
+
+fn walk_tree<'a>(root: &Node<'a>) -> Vec<Node<'a>> {
+    let mut nodes = vec![*root];
+    let mut result = Vec::new();
+    while let Some(current) = nodes.pop() {
+        result.push(current);
+        let mut cursor = current.walk();
+        let mut children: Vec<Node<'a>> = current.children(&mut cursor).collect();
+        children.reverse();
+        nodes.extend(children);
+    }
+    result
+}
+
+fn has_named_owner(node: &Node) -> bool {
+    let mut current = node.parent();
+    let mut depth = 0;
+    while let Some(parent) = current {
+        if depth >= 4 {
+            return false;
+        }
+        if parent.kind() == "function_declaration" || parent.kind() == "method_definition" {
+            return true;
+        }
+        if parent.kind() == "pair" {
+            let value_node = parent.child_by_field_name("value");
+            let key_node = parent.child_by_field_name("key");
+            if value_node.map_or(false, |v| &v == node) && key_node.is_some() {
+                return true;
+            }
+        }
+        if parent.kind() == "variable_declarator" {
+            let mut cursor = parent.walk();
+            if parent
+                .children(&mut cursor)
+                .any(|c| c.kind() == "identifier")
+            {
+                return true;
+            }
+        }
+        current = parent.parent();
+        depth += 1;
+    }
+    false
+}

--- a/crates/deepmap/src/queries.rs
+++ b/crates/deepmap/src/queries.rs
@@ -1,0 +1,196 @@
+// Placeholder for tree-sitter queries (language-specific S-expression patterns).
+
+/// Tree-sitter query strings for each language.
+/// Key: language name -> query type -> S-expression query string.
+pub fn queries() -> Vec<(&'static str, &'static str, &'static str)> {
+    vec![
+        // Python
+        (
+            "python",
+            "function",
+            concat!(
+                "(function_definition name: (identifier) @name) @definition.function\n",
+                "(decorated_definition (function_definition name: (identifier) @name)) @definition.function\n",
+                "(class_definition body: (block (function_definition name: (identifier) @name))) @definition.method\n",
+                "(assignment left: (identifier) @name right: (lambda)) @definition.lambda",
+            ),
+        ),
+        (
+            "python",
+            "class",
+            concat!(
+                "(class_definition name: (identifier) @name) @definition.class\n",
+                "(decorated_definition (class_definition name: (identifier) @name)) @definition.class",
+            ),
+        ),
+        (
+            "python",
+            "import",
+            concat!(
+                "(import_statement name: (dotted_name) @name)\n",
+                "(import_statement name: (aliased_import name: (dotted_name) @name))\n",
+                "(import_from_statement module_name: (dotted_name) @name)\n",
+                "(import_from_statement module_name: (relative_import) @name)",
+            ),
+        ),
+        (
+            "python",
+            "call",
+            concat!(
+                "(call function: (identifier) @name) @reference.call\n",
+                "(call function: (attribute attribute: (identifier) @name)) @reference.call",
+            ),
+        ),
+        // JavaScript
+        (
+            "javascript",
+            "function",
+            concat!(
+                "(function_declaration name: (identifier) @name) @definition.function\n",
+                "(variable_declarator name: (identifier) @name value: (arrow_function)) @definition.function\n",
+                "(variable_declarator name: (identifier) @name value: (function_expression)) @definition.function\n",
+                "(method_definition name: (property_identifier) @name) @definition.method",
+            ),
+        ),
+        (
+            "javascript",
+            "anonymous_function",
+            concat!(
+                "(arrow_function) @definition.anonymous_function\n",
+                "(function_expression) @definition.anonymous_function",
+            ),
+        ),
+        (
+            "javascript",
+            "class",
+            "(class_declaration name: (identifier) @name) @definition.class",
+        ),
+        (
+            "javascript",
+            "import",
+            concat!(
+                "(import_statement source: (string) @source)\n",
+                "(import_specifier name: (identifier) @name)\n",
+                "(import_clause (identifier) @name)",
+            ),
+        ),
+        (
+            "javascript",
+            "call",
+            concat!(
+                "(call_expression function: (identifier) @name) @reference.call\n",
+                "(call_expression function: (member_expression property: (property_identifier) @name)) @reference.call",
+            ),
+        ),
+        // TypeScript
+        (
+            "typescript",
+            "function",
+            concat!(
+                "(function_declaration name: (identifier) @name) @definition.function\n",
+                "(variable_declarator name: (identifier) @name value: (arrow_function)) @definition.function\n",
+                "(method_definition name: (property_identifier) @name) @definition.method",
+            ),
+        ),
+        (
+            "typescript",
+            "anonymous_function",
+            concat!(
+                "(arrow_function) @definition.anonymous_function\n",
+                "(function_expression) @definition.anonymous_function",
+            ),
+        ),
+        (
+            "typescript",
+            "class",
+            "(class_declaration name: (_) @name) @definition.class",
+        ),
+        (
+            "typescript",
+            "import",
+            concat!(
+                "(import_statement source: (string) @source)\n",
+                "(import_specifier name: (identifier) @name)\n",
+                "(import_clause (identifier) @name)",
+            ),
+        ),
+        (
+            "typescript",
+            "call",
+            concat!(
+                "(call_expression function: (identifier) @name) @reference.call\n",
+                "(call_expression function: (member_expression property: (property_identifier) @name)) @reference.call",
+            ),
+        ),
+        // Go
+        (
+            "go",
+            "function",
+            concat!(
+                "(function_declaration name: (identifier) @name) @definition.function\n",
+                "(method_declaration name: (field_identifier) @name) @definition.method",
+            ),
+        ),
+        (
+            "go",
+            "class",
+            concat!(
+                "(type_spec name: (type_identifier) @name type: (struct_type)) @definition.struct\n",
+                "(type_spec name: (type_identifier) @name type: (interface_type)) @definition.interface",
+            ),
+        ),
+        (
+            "go",
+            "import",
+            "(import_spec path: (interpreted_string_literal) @path)",
+        ),
+        (
+            "go",
+            "call",
+            concat!(
+                "(call_expression function: (identifier) @name) @reference.call\n",
+                "(call_expression function: (selector_expression field: (field_identifier) @name)) @reference.call",
+            ),
+        ),
+        // Rust
+        (
+            "rust",
+            "function",
+            concat!(
+                "(function_item name: (identifier) @name) @definition.function\n",
+                "(function_signature_item name: (identifier) @name) @definition.trait_method",
+            ),
+        ),
+        (
+            "rust",
+            "class",
+            concat!(
+                "(struct_item name: (type_identifier) @name) @definition.struct\n",
+                "(enum_item name: (type_identifier) @name) @definition.enum\n",
+                "(trait_item name: (type_identifier) @name) @definition.trait\n",
+                "(impl_item type: (type_identifier) @name) @definition.impl\n",
+                "(type_item name: (type_identifier) @name) @definition.type\n",
+                "(mod_item name: (identifier) @name) @definition.module",
+            ),
+        ),
+        (
+            "rust",
+            "import",
+            concat!(
+                "(use_declaration argument: (scoped_identifier path: (identifier) @path name: (identifier) @name))\n",
+                "(use_declaration argument: (scoped_use_list path: (identifier) @path))\n",
+                "(extern_crate_declaration name: (identifier) @name)\n",
+                "(use_declaration argument: (identifier) @name)",
+            ),
+        ),
+        (
+            "rust",
+            "call",
+            concat!(
+                "(call_expression function: (identifier) @name) @reference.call\n",
+                "(call_expression function: (field_expression field: (field_identifier) @name)) @reference.call\n",
+                "(call_expression function: (scoped_identifier name: (identifier) @name)) @reference.call",
+            ),
+        ),
+    ]
+}

--- a/crates/deepmap/src/ranking.rs
+++ b/crates/deepmap/src/ranking.rs
@@ -1,0 +1,497 @@
+// Graph ranking and analysis: PageRank, call chains, hotspots, entry points.
+
+use std::collections::{HashMap, VecDeque};
+
+use crate::types::*;
+
+/// Low-signal symbol kinds (markup, selectors, etc.) — excluded from ranking.
+const LOW_SIGNAL_KINDS: &[&str] = &[
+    "element",
+    "selector",
+    "class_selector",
+    "id_selector",
+    "json_key",
+];
+
+/// Boilerplate names to exclude.
+const BOILERPLATE_NAMES: &[&str] = &["__init__"];
+
+pub struct GraphAnalyzer {
+    /// Symbol ID → PageRank score.
+    pagerank: HashMap<String, f64>,
+}
+
+impl GraphAnalyzer {
+    pub fn new() -> Self {
+        Self {
+            pagerank: HashMap::new(),
+        }
+    }
+
+    /// Load graph data into the analyzer (transfer ownership of edges).
+    pub fn load_graph(&mut self, _graph: &RepoGraph) {
+        // The graph is already stored in the engine. The analyzer
+        // only needs the PageRank algorithm, which operates on
+        // outgoing/incoming edge maps directly.
+        self.pagerank.clear();
+    }
+
+    pub fn pagerank_scores(&self) -> &HashMap<String, f64> {
+        &self.pagerank
+    }
+
+    // ── PageRank ──
+
+    /// Standard power-iteration PageRank with convergence detection.
+    pub fn calculate_pagerank(
+        &mut self,
+        graph: &RepoGraph,
+        damping: f64,
+        max_iter: usize,
+        tol: f64,
+    ) {
+        let sym_ids: Vec<&String> = graph.symbols.keys().collect();
+        let n = sym_ids.len();
+        if n == 0 {
+            return;
+        }
+
+        let mut pr: HashMap<String, f64> = sym_ids
+            .iter()
+            .map(|id| ((*id).clone(), 1.0 / n as f64))
+            .collect();
+
+        // Compute outgoing weight sums.
+        let out_w: HashMap<String, f64> = sym_ids
+            .iter()
+            .map(|id| {
+                let sum = graph
+                    .outgoing
+                    .get(*id)
+                    .map(|edges| edges.iter().map(|e| e.weight).sum())
+                    .unwrap_or(0.0);
+                ((*id).clone(), sum)
+            })
+            .collect();
+
+        let active_srcs: std::collections::HashSet<&String> = out_w
+            .iter()
+            .filter(|(_, w)| **w > 0.0)
+            .map(|(id, _)| id)
+            .collect();
+
+        // Build reverse incoming map: target → [(source, weight)]
+        let mut inc: HashMap<String, Vec<(String, f64)>> = HashMap::new();
+        for (src, edges) in &graph.outgoing {
+            if active_srcs.contains(src) {
+                for e in edges {
+                    inc.entry(e.target.clone())
+                        .or_default()
+                        .push((src.clone(), e.weight));
+                }
+            }
+        }
+
+        let base = (1.0 - damping) / n as f64;
+
+        for _ in 0..max_iter {
+            let mut new_pr: HashMap<String, f64> = HashMap::new();
+            for id in &sym_ids {
+                let score = base
+                    + inc.get(*id).map_or(0.0, |sources| {
+                        sources
+                            .iter()
+                            .map(|(src, w)| {
+                                damping * pr.get(src).unwrap_or(&0.0) * w
+                                    / out_w.get(src).unwrap_or(&1.0)
+                            })
+                            .sum()
+                    });
+                new_pr.insert((*id).clone(), score);
+            }
+
+            let total: f64 = new_pr.values().sum();
+            if total > 0.0 {
+                for v in new_pr.values_mut() {
+                    *v /= total;
+                }
+            }
+
+            let delta = sym_ids
+                .iter()
+                .map(|id| (new_pr.get(*id).unwrap_or(&0.0) - pr.get(*id).unwrap_or(&0.0)).abs())
+                .fold(0.0f64, f64::max);
+
+            pr = new_pr;
+            if delta < tol {
+                break;
+            }
+        }
+
+        self.pagerank = pr;
+    }
+
+    // ── Symbol query ──
+
+    pub fn query_symbol<'a>(&self, name: &str, graph: &'a RepoGraph) -> Vec<&'a Symbol> {
+        let lower = name.to_lowercase();
+        let mut matches: Vec<&Symbol> = graph
+            .symbols
+            .values()
+            .filter(|s| s.name.to_lowercase().contains(&lower))
+            .filter(|s| !LOW_SIGNAL_KINDS.contains(&s.kind.as_str()))
+            .collect();
+
+        matches.sort_by(|a, b| {
+            self.pagerank
+                .get(&b.id)
+                .unwrap_or(&0.0)
+                .partial_cmp(self.pagerank.get(&a.id).unwrap_or(&0.0))
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        matches
+    }
+
+    // ── Call chain ──
+
+    pub fn call_chain(
+        &self,
+        symbol_id: &str,
+        direction: &str,
+        max_depth: usize,
+        graph: &RepoGraph,
+    ) -> HashMap<String, Vec<Symbol>> {
+        let mut result = HashMap::new();
+
+        if direction == "callers" || direction == "both" {
+            result.insert(
+                "callers".into(),
+                self.trace_chain(symbol_id, "incoming", max_depth, graph),
+            );
+        }
+        if direction == "callees" || direction == "both" {
+            result.insert(
+                "callees".into(),
+                self.trace_chain(symbol_id, "outgoing", max_depth, graph),
+            );
+        }
+        result
+    }
+
+    fn trace_chain(
+        &self,
+        start_id: &str,
+        edge_dir: &str,
+        max_depth: usize,
+        graph: &RepoGraph,
+    ) -> Vec<Symbol> {
+        let mut visited: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let mut result = Vec::new();
+        let mut queue: VecDeque<(String, usize)> = VecDeque::new();
+        queue.push_back((start_id.to_string(), 0));
+        visited.insert(start_id.to_string());
+
+        while let Some((current_id, depth)) = queue.pop_front() {
+            if depth >= max_depth {
+                continue;
+            }
+
+            let neighbors = if edge_dir == "incoming" {
+                graph.incoming.get(&current_id)
+            } else {
+                graph.outgoing.get(&current_id)
+            };
+
+            if let Some(edges) = neighbors {
+                for edge in edges {
+                    let neighbor_id = if edge_dir == "incoming" {
+                        &edge.source
+                    } else {
+                        &edge.target
+                    };
+                    if visited.insert(neighbor_id.clone()) {
+                        if let Some(sym) = graph.symbols.get(neighbor_id) {
+                            result.push(sym.clone());
+                        }
+                        queue.push_back((neighbor_id.clone(), depth + 1));
+                    }
+                }
+            }
+        }
+
+        result.sort_by(|a, b| {
+            self.pagerank
+                .get(&b.id)
+                .unwrap_or(&0.0)
+                .partial_cmp(self.pagerank.get(&a.id).unwrap_or(&0.0))
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        result
+    }
+
+    // ── Hotspots ──
+
+    /// Identify high-density files (most symbols, highest PageRank).
+    pub fn hotspots(&self, limit: usize, graph: &RepoGraph) -> Vec<HashMap<String, String>> {
+        let mut file_scores: HashMap<&str, (usize, f64)> = HashMap::new();
+
+        for (file, sym_ids) in &graph.file_symbols {
+            let count = sym_ids.len();
+            let avg_pr: f64 = if count > 0 {
+                sym_ids
+                    .iter()
+                    .map(|id| self.pagerank.get(id).unwrap_or(&0.0))
+                    .sum::<f64>()
+                    / count as f64
+            } else {
+                0.0
+            };
+            file_scores.insert(file.as_str(), (count, avg_pr));
+        }
+
+        let mut entries: Vec<(&str, (usize, f64))> = file_scores.into_iter().collect();
+        entries.sort_by(|a, b| {
+            b.1.0.cmp(&a.1.0).then(
+                b.1.1
+                    .partial_cmp(&a.1.1)
+                    .unwrap_or(std::cmp::Ordering::Equal),
+            )
+        });
+
+        entries
+            .into_iter()
+            .take(limit)
+            .map(|(file, (count, avg_pr))| {
+                let mut m = HashMap::new();
+                m.insert("file".into(), file.to_string());
+                m.insert("symbols".into(), count.to_string());
+                m.insert("avg_pagerank".into(), format!("{:.6}", avg_pr));
+                m
+            })
+            .collect()
+    }
+
+    // ── Entry points ──
+
+    /// Identify entry-point files (main, app, index, etc.).
+    pub fn entry_points(&self, graph: &RepoGraph) -> Vec<String> {
+        let entry_names = [
+            "main", "app", "index", "server", "run", "setup", "cli", "__main__",
+        ];
+
+        let mut entries: Vec<(&str, usize)> = graph
+            .file_symbols
+            .keys()
+            .filter_map(|file| {
+                let stem = std::path::Path::new(file)
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("");
+                if entry_names.contains(&stem) {
+                    let sym_count = graph.file_symbols.get(file).map(|v| v.len()).unwrap_or(0);
+                    Some((file.as_str(), sym_count))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        entries.sort_by(|a, b| b.1.cmp(&a.1));
+        entries.into_iter().map(|(f, _)| f.to_string()).collect()
+    }
+
+    // ── File analysis ──
+
+    /// Compute complexity and connectivity metrics per file.
+    pub fn file_analysis(&self, graph: &RepoGraph) -> HashMap<String, HashMap<String, f64>> {
+        let mut analysis = HashMap::new();
+
+        for (file, sym_ids) in &graph.file_symbols {
+            let mut metrics = HashMap::new();
+            metrics.insert("symbol_count".into(), sym_ids.len() as f64);
+
+            let out_edges: usize = sym_ids
+                .iter()
+                .map(|id| graph.outgoing.get(id).map(|e| e.len()).unwrap_or(0))
+                .sum();
+            let in_edges: usize = sym_ids
+                .iter()
+                .map(|id| graph.incoming.get(id).map(|e| e.len()).unwrap_or(0))
+                .sum();
+
+            metrics.insert("outgoing_edges".into(), out_edges as f64);
+            metrics.insert("incoming_edges".into(), in_edges as f64);
+
+            let avg_pr: f64 = if sym_ids.is_empty() {
+                0.0
+            } else {
+                sym_ids
+                    .iter()
+                    .map(|id| self.pagerank.get(id).unwrap_or(&0.0))
+                    .sum::<f64>()
+                    / sym_ids.len() as f64
+            };
+            metrics.insert("avg_pagerank".into(), avg_pr);
+
+            analysis.insert(file.clone(), metrics);
+        }
+        analysis
+    }
+
+    // ── Module summary ──
+
+    /// Group symbols by top-level directory/module.
+    pub fn module_summary(&self, limit: usize, graph: &RepoGraph) -> Vec<HashMap<String, String>> {
+        let mut modules: HashMap<String, (usize, f64)> = HashMap::new();
+
+        for (file, sym_ids) in &graph.file_symbols {
+            let module = std::path::Path::new(file)
+                .components()
+                .next()
+                .map(|c| c.as_os_str().to_string_lossy().to_string())
+                .unwrap_or_else(|| ".".into());
+
+            let entry = modules.entry(module).or_insert((0, 0.0));
+            entry.0 += sym_ids.len();
+            let sum_pr: f64 = sym_ids
+                .iter()
+                .map(|id| self.pagerank.get(id).unwrap_or(&0.0))
+                .sum();
+            entry.1 += sum_pr;
+        }
+
+        let mut entries: Vec<(String, (usize, f64))> = modules.into_iter().collect();
+        entries.sort_by(|a, b| b.1.0.cmp(&a.1.0));
+
+        entries
+            .into_iter()
+            .take(limit)
+            .map(|(name, (count, total_pr))| {
+                let mut m = HashMap::new();
+                m.insert("module".into(), name);
+                m.insert("symbols".into(), count.to_string());
+                m.insert("total_pagerank".into(), format!("{:.6}", total_pr));
+                m
+            })
+            .collect()
+    }
+
+    // ── Suggested reading order ──
+
+    /// Generate recommended reading order for AI consumption.
+    pub fn suggested_reading_order(
+        &self,
+        limit: usize,
+        graph: &RepoGraph,
+    ) -> Vec<HashMap<String, String>> {
+        let entry_names = ["main", "app", "index", "server", "run", "setup", "cli"];
+
+        let mut file_scores: Vec<(&str, f64)> = graph
+            .file_symbols
+            .keys()
+            .filter(|file| {
+                let stem = std::path::Path::new(file)
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("");
+                // Exclude test/noise files.
+                !file.contains("test")
+                    && !file.contains("__pycache__")
+                    && !LOW_SIGNAL_KINDS.contains(&stem)
+            })
+            .map(|file| {
+                let sym_count = graph.file_symbols.get(file).map(|v| v.len()).unwrap_or(0) as f64;
+                let avg_pr: f64 = graph
+                    .file_symbols
+                    .get(file)
+                    .map(|ids| {
+                        if ids.is_empty() {
+                            0.0
+                        } else {
+                            ids.iter()
+                                .map(|id| self.pagerank.get(id).unwrap_or(&0.0))
+                                .sum::<f64>()
+                                / ids.len() as f64
+                        }
+                    })
+                    .unwrap_or(0.0);
+                // Entry points get a boost.
+                let entry_boost = if entry_names.contains(
+                    &std::path::Path::new(file)
+                        .file_stem()
+                        .and_then(|s| s.to_str())
+                        .unwrap_or(""),
+                ) {
+                    2.0
+                } else {
+                    1.0
+                };
+                let score = avg_pr * sym_count.ln().max(1.0) * entry_boost;
+                (file.as_str(), score)
+            })
+            .collect();
+
+        file_scores.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+
+        file_scores
+            .into_iter()
+            .take(limit)
+            .map(|(file, score)| {
+                let mut m = HashMap::new();
+                m.insert("file".into(), file.to_string());
+                m.insert("score".into(), format!("{:.4}", score));
+                m
+            })
+            .collect()
+    }
+
+    // ── Summary symbols ──
+
+    /// Return key implementation symbols suitable for overview display.
+    pub fn summary_symbols(
+        &self,
+        limit_files: usize,
+        per_file: usize,
+        graph: &RepoGraph,
+    ) -> Vec<HashMap<String, String>> {
+        let reading_order = self.suggested_reading_order(limit_files, graph);
+
+        let mut result = Vec::new();
+        for entry in &reading_order {
+            let file = entry.get("file").map(|s| s.as_str()).unwrap_or("");
+            if let Some(sym_ids) = graph.file_symbols.get(file) {
+                let mut syms: Vec<&Symbol> = sym_ids
+                    .iter()
+                    .filter_map(|id| graph.symbols.get(id))
+                    .filter(|s| !LOW_SIGNAL_KINDS.contains(&s.kind.as_str()))
+                    .filter(|s| !BOILERPLATE_NAMES.contains(&s.name.as_str()))
+                    .collect();
+
+                syms.sort_by(|a, b| {
+                    self.pagerank
+                        .get(&b.id)
+                        .unwrap_or(&0.0)
+                        .partial_cmp(self.pagerank.get(&a.id).unwrap_or(&0.0))
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                });
+
+                for sym in syms.iter().take(per_file) {
+                    let mut m = HashMap::new();
+                    m.insert("file".into(), file.to_string());
+                    m.insert("name".into(), sym.name.clone());
+                    m.insert("kind".into(), sym.kind.clone());
+                    m.insert("line".into(), sym.line.to_string());
+                    m.insert(
+                        "pagerank".into(),
+                        format!("{:.6}", self.pagerank.get(&sym.id).unwrap_or(&0.0)),
+                    );
+                    if !sym.signature.is_empty() {
+                        m.insert("signature".into(), sym.signature.clone());
+                    }
+                    result.push(m);
+                }
+            }
+        }
+        result
+    }
+}

--- a/crates/deepmap/src/renderer.rs
+++ b/crates/deepmap/src/renderer.rs
@@ -1,0 +1,511 @@
+// AI-friendly Markdown report rendering.
+// Produces overviews, call chains, file details, query reports, and impact analysis.
+
+use std::collections::HashMap;
+
+use crate::engine::RepoMapEngine;
+use crate::topic;
+
+/// Render a full project map overview (max_chars limit).
+pub fn render_overview_report(engine: &RepoMapEngine, max_chars: usize) -> String {
+    let mut lines = Vec::new();
+
+    lines.push("# Project Map".to_string());
+    lines.push(String::new());
+
+    // Scan statistics.
+    lines.push("## Scan Statistics".to_string());
+    for line in engine.scan_summary_lines() {
+        lines.push(line);
+    }
+    lines.push(String::new());
+
+    // Entry points.
+    let entries = engine.entry_points();
+    if !entries.is_empty() {
+        lines.push("## Entry Points".to_string());
+        for e in &entries {
+            lines.push(format!("- `{}`", e));
+        }
+        lines.push(String::new());
+    }
+
+    // Reading order.
+    let reading = engine.suggested_reading_order(8);
+    if !reading.is_empty() {
+        lines.push("## Recommended Reading Order".to_string());
+        for (i, entry) in reading.iter().enumerate() {
+            let file = entry.get("file").map(|s| s.as_str()).unwrap_or("");
+            let score = entry.get("score").map(|s| s.as_str()).unwrap_or("");
+            lines.push(format!("{}. `{}` (score: {})", i + 1, file, score));
+        }
+        lines.push(String::new());
+    }
+
+    // Module summary.
+    let modules = engine.module_summary(6);
+    if !modules.is_empty() {
+        lines.push("## Module Summary".to_string());
+        for m in &modules {
+            let name = m.get("module").map(|s| s.as_str()).unwrap_or("");
+            let count = m.get("symbols").map(|s| s.as_str()).unwrap_or("");
+            let pr = m.get("total_pagerank").map(|s| s.as_str()).unwrap_or("");
+            lines.push(format!(
+                "- `{}/` — {} symbols, PageRank: {}",
+                name, count, pr
+            ));
+        }
+        lines.push(String::new());
+    }
+
+    // Hotspots.
+    let hot = engine.hotspots(10);
+    if !hot.is_empty() {
+        lines.push("## Hot Spots".to_string());
+        for h in &hot {
+            let file = h.get("file").map(|s| s.as_str()).unwrap_or("");
+            let count = h.get("symbols").map(|s| s.as_str()).unwrap_or("");
+            let pr = h.get("avg_pagerank").map(|s| s.as_str()).unwrap_or("");
+            lines.push(format!("- `{}` — {} symbols, avg PR: {}", file, count, pr));
+        }
+        lines.push(String::new());
+    }
+
+    // Key symbols.
+    let syms = engine.summary_symbols(6, 4);
+    if !syms.is_empty() {
+        lines.push("## Key Symbols".to_string());
+        let mut current_file = String::new();
+        for s in &syms {
+            let file = s.get("file").map(|s| s.as_str()).unwrap_or("");
+            if file != current_file {
+                current_file = file.to_string();
+                lines.push(format!("### `{}`", current_file));
+            }
+            let name = s.get("name").map(|s| s.as_str()).unwrap_or("");
+            let kind = s.get("kind").map(|s| s.as_str()).unwrap_or("");
+            let line = s.get("line").map(|s| s.as_str()).unwrap_or("");
+            let pr = s.get("pagerank").map(|s| s.as_str()).unwrap_or("");
+            let sig = s.get("signature").map(|s| s.as_str()).unwrap_or("");
+            let sig_str = if sig.is_empty() {
+                String::new()
+            } else {
+                format!(" `{}`", sig)
+            };
+            lines.push(format!(
+                "- `{}` ({}:{}, PR:{}){}",
+                name, kind, line, pr, sig_str
+            ));
+        }
+        lines.push(String::new());
+    }
+
+    let result = lines.join("\n");
+    truncate(&result, max_chars)
+}
+
+/// Render a call chain report for a given symbol name.
+pub fn render_call_chain_report(
+    engine: &RepoMapEngine,
+    symbol_name: &str,
+    max_depth: usize,
+) -> String {
+    let mut lines = Vec::new();
+    lines.push(format!("# Call Chain: `{}`", symbol_name));
+    lines.push(String::new());
+
+    // Find the best matching symbol.
+    let matches = engine.query_symbol(symbol_name);
+    if matches.is_empty() {
+        lines.push("_No symbols found matching this name._".to_string());
+        return lines.join("\n");
+    }
+
+    let best = &matches[0];
+    lines.push(format!(
+        "Best match: `{}` ({}:{}, PR:{:.6})",
+        best.name, best.kind, best.line, best.pagerank
+    ));
+    lines.push(String::new());
+
+    let chains = engine.call_chain(&best.id, "both", max_depth);
+
+    if let Some(callers) = chains.get("callers") {
+        lines.push("## Callers".to_string());
+        if callers.is_empty() {
+            lines.push("_None found._".to_string());
+        } else {
+            for sym in callers {
+                lines.push(format!(
+                    "- `{}` ({}:{}, PR:{:.6})",
+                    sym.name, sym.kind, sym.line, sym.pagerank
+                ));
+            }
+        }
+        lines.push(String::new());
+    }
+
+    if let Some(callees) = chains.get("callees") {
+        lines.push("## Callees".to_string());
+        if callees.is_empty() {
+            lines.push("_None found._".to_string());
+        } else {
+            for sym in callees {
+                lines.push(format!(
+                    "- `{}` ({}:{}, PR:{:.6})",
+                    sym.name, sym.kind, sym.line, sym.pagerank
+                ));
+            }
+        }
+        lines.push(String::new());
+    }
+
+    lines.join("\n")
+}
+
+/// Render a detailed file view with symbols.
+pub fn render_file_detail_report(
+    engine: &RepoMapEngine,
+    file_path: &str,
+    max_symbols: usize,
+    max_chars: usize,
+) -> String {
+    let mut lines = Vec::new();
+    lines.push(format!("# File Detail: `{}`", file_path));
+    lines.push(String::new());
+
+    // Find symbols in this file.
+    let all_syms = engine.query_symbol("");
+    let file_syms: Vec<_> = all_syms
+        .iter()
+        .filter(|s| s.file == file_path)
+        .take(max_symbols)
+        .collect();
+
+    if file_syms.is_empty() {
+        lines.push("_No symbols found in this file._".to_string());
+    } else {
+        lines.push("## Symbols".to_string());
+        for sym in &file_syms {
+            let sig_str = if sym.signature.is_empty() {
+                String::new()
+            } else {
+                format!(" `{}`", sym.signature)
+            };
+            lines.push(format!(
+                "- `{}` [{}:{}] (PR:{:.6}){}",
+                sym.name, sym.kind, sym.line, sym.pagerank, sig_str
+            ));
+            if !sym.docstring.is_empty() {
+                lines.push(format!("  > {}", sym.docstring));
+            }
+        }
+    }
+
+    let result = lines.join("\n");
+    truncate(&result, max_chars)
+}
+
+/// Render a topic-based query report.
+pub fn render_query_report(
+    engine: &RepoMapEngine,
+    query: &str,
+    max_files: usize,
+    max_chars: usize,
+) -> String {
+    let mut lines = Vec::new();
+    lines.push(format!("# Query: `{}`", query));
+    lines.push(String::new());
+
+    let keywords: Vec<String> = topic::split_identifier(query);
+    if keywords.is_empty() {
+        lines.push("_Empty query._".to_string());
+        return lines.join("\n");
+    }
+
+    // Score all files by topic relevance.
+    let candidate_files: Vec<String> = engine.graph.file_symbols.keys().cloned().collect();
+    let keyword_weights =
+        topic::compute_keyword_weights(&keywords, &candidate_files, &engine.graph);
+
+    let mut scored: Vec<(String, f64, &str)> = candidate_files
+        .iter()
+        .map(|f| {
+            let score = topic::topic_score(query, f, &engine.graph, &keyword_weights);
+            let role = topic::classify_file_role(f);
+            (f.clone(), score, role)
+        })
+        .collect();
+
+    scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+
+    // Separate into primary files and tests.
+    let primary: Vec<_> = scored
+        .iter()
+        .filter(|(_, _, role)| *role != "test")
+        .take(max_files)
+        .collect();
+
+    let tests: Vec<_> = scored
+        .iter()
+        .filter(|(_, _, role)| *role == "test")
+        .take(max_files / 2)
+        .collect();
+
+    // Top files.
+    lines.push("## Top Files".to_string());
+    if primary.is_empty() {
+        lines.push("_No matching files found._".to_string());
+    } else {
+        for (file, score, role) in &primary {
+            let sym_count = engine
+                .graph
+                .file_symbols
+                .get(file.as_str())
+                .map(|v| v.len())
+                .unwrap_or(0);
+            lines.push(format!(
+                "- `{}` [{}] — {} symbols, score: {:.2}",
+                file, role, sym_count, score
+            ));
+        }
+    }
+    lines.push(String::new());
+
+    // Related tests.
+    if !tests.is_empty() {
+        lines.push("## Related Tests".to_string());
+        for (file, score, _) in &tests {
+            lines.push(format!("- `{}` (score: {:.2})", file, score));
+        }
+        lines.push(String::new());
+    }
+
+    // Key symbols in top files.
+    lines.push("## Key Symbols".to_string());
+    let mut found = false;
+    for (file, _, _) in primary.iter().take(6) {
+        if let Some(sym_ids) = engine.graph.file_symbols.get(file.as_str()) {
+            let mut syms: Vec<_> = sym_ids
+                .iter()
+                .filter_map(|id| engine.graph.symbols.get(id))
+                .collect();
+            syms.sort_by(|a, b| {
+                b.pagerank
+                    .partial_cmp(&a.pagerank)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
+            for s in syms.iter().take(4) {
+                let match_indicator = if keywords
+                    .iter()
+                    .any(|kw| s.name.to_lowercase().contains(kw.as_str()))
+                {
+                    " ★"
+                } else {
+                    ""
+                };
+                lines.push(format!(
+                    "- `{}::{}` ({}:{}, PR:{:.4}){}",
+                    file, s.name, s.kind, s.line, s.pagerank, match_indicator
+                ));
+                found = true;
+            }
+        }
+    }
+    if !found {
+        lines.push("_No symbols found._".to_string());
+    }
+
+    let result = lines.join("\n");
+    truncate(&result, max_chars)
+}
+
+/// Render an impact analysis report for changed files.
+pub fn render_impact_report(
+    engine: &RepoMapEngine,
+    target_files: &[String],
+    max_chars: usize,
+) -> String {
+    let mut lines = Vec::new();
+    lines.push("# Impact Analysis".to_string());
+    lines.push(String::new());
+
+    lines.push("## Changed Files".to_string());
+    for f in target_files {
+        let role = topic::classify_file_role(f);
+        lines.push(format!("- `{}` [{}]", f, role));
+    }
+    lines.push(String::new());
+
+    // Find symbols in the changed files.
+    let mut changed_symbols: Vec<&crate::types::Symbol> = Vec::new();
+    for f in target_files {
+        if let Some(sym_ids) = engine.graph.file_symbols.get(f.as_str()) {
+            for sid in sym_ids {
+                if let Some(sym) = engine.graph.symbols.get(sid) {
+                    changed_symbols.push(sym);
+                }
+            }
+        }
+    }
+
+    // Find files that depend on the changed symbols (via incoming edges).
+    let mut affected_files: HashMap<&str, usize> = HashMap::new();
+    for sym in &changed_symbols {
+        if let Some(incoming) = engine.graph.incoming.get(&sym.id) {
+            for edge in incoming {
+                if !target_files.contains(&edge.source) {
+                    if let Some(src_sym) = engine.graph.symbols.get(&edge.source) {
+                        *affected_files.entry(&src_sym.file).or_insert(0) += 1;
+                    }
+                }
+            }
+        }
+    }
+
+    let mut affected: Vec<(&&str, &usize)> = affected_files.iter().collect();
+    affected.sort_by(|a, b| b.1.cmp(a.1));
+
+    lines.push("## Affected Files (dependents)".to_string());
+    if affected.is_empty() {
+        lines.push("_No dependent files found._".to_string());
+    } else {
+        for (file, count) in affected.iter().take(20) {
+            let role = topic::classify_file_role(file);
+            lines.push(format!("- `{}` [{}] — {} dependencies", file, role, count));
+        }
+    }
+    lines.push(String::new());
+
+    // Risk assessment.
+    let risk = assess_risk(target_files);
+    lines.push("## Risk Assessment".to_string());
+    lines.push(format!("- **Level**: {}", risk.level));
+    if !risk.reasons.is_empty() {
+        for r in &risk.reasons {
+            lines.push(format!("- {}", r));
+        }
+    }
+
+    let result = lines.join("\n");
+    truncate(&result, max_chars)
+}
+
+/// Render a diff-risk report for pending changes.
+pub fn render_diff_risk_report(
+    engine: &RepoMapEngine,
+    changed_files: &[String],
+    max_chars: usize,
+) -> String {
+    let mut lines = Vec::new();
+    lines.push("# Diff Risk Assessment".to_string());
+    lines.push(String::new());
+
+    let impact = render_impact_report(engine, changed_files, max_chars / 2);
+    lines.push(impact);
+    lines.push(String::new());
+
+    // Manual verification suggestions.
+    lines.push("## Manual Verification".to_string());
+    let mut suggestions = Vec::new();
+    for f in changed_files {
+        let lower = f.to_lowercase();
+        if lower.contains("auth") || lower.contains("login") || lower.contains("session") {
+            suggestions.push(format!("- Verify authentication flow: `{}`", f));
+        }
+        if lower.contains("db") || lower.contains("sql") || lower.contains("migration") {
+            suggestions.push(format!("- Check database migration impact: `{}`", f));
+        }
+        if lower.contains("config") || lower.contains(".toml") || lower.contains(".json") {
+            suggestions.push(format!("- Confirm configuration changes: `{}`", f));
+        }
+    }
+    if suggestions.is_empty() {
+        suggestions.push("- No specific verification items flagged.".to_string());
+    }
+    for s in &suggestions {
+        lines.push(s.clone());
+    }
+
+    // Test commands.
+    lines.push(String::new());
+    lines.push("## Suggested Test Commands".to_string());
+    let has_rs = changed_files.iter().any(|f| f.ends_with(".rs"));
+    let has_py = changed_files.iter().any(|f| f.ends_with(".py"));
+    let has_js = changed_files
+        .iter()
+        .any(|f| f.ends_with(".js") || f.ends_with(".ts"));
+
+    if has_rs {
+        lines.push("- `cargo test`".to_string());
+    }
+    if has_py {
+        lines.push("- `pytest`".to_string());
+    }
+    if has_js {
+        lines.push("- `npm test`  or  `vitest`".to_string());
+    }
+    if !has_rs && !has_py && !has_js {
+        lines.push("- _No test framework detected._".to_string());
+    }
+
+    let result = lines.join("\n");
+    truncate(&result, max_chars)
+}
+
+/// Risk level and reasons for a set of changed files.
+struct RiskAssessment {
+    level: String,
+    reasons: Vec<String>,
+}
+
+fn assess_risk(files: &[String]) -> RiskAssessment {
+    let mut reasons = Vec::new();
+    let mut score = 0u32;
+
+    for f in files {
+        let lower = f.to_lowercase();
+        if lower.contains("auth") || lower.contains("login") || lower.contains("token") {
+            score += 3;
+            reasons.push(format!("Security-sensitive file: `{}`", f));
+        }
+        if lower.contains("db") || lower.contains("sql") || lower.contains("migrat") {
+            score += 3;
+            reasons.push(format!("Database-related file: `{}`", f));
+        }
+        if lower.contains("config") || lower.contains("setting") {
+            score += 2;
+            reasons.push(format!("Configuration file: `{}`", f));
+        }
+        if lower.ends_with(".rs") || lower.ends_with(".go") {
+            score += 1;
+        }
+    }
+
+    // Scale by number of files.
+    score = score.saturating_add(files.len() as u32);
+
+    let level = if score >= 10 {
+        "🔴 HIGH".to_string()
+    } else if score >= 5 {
+        "🟡 MEDIUM".to_string()
+    } else {
+        "🟢 LOW".to_string()
+    };
+
+    RiskAssessment { level, reasons }
+}
+
+/// Truncate output to max_chars, adding a note if truncated.
+fn truncate(text: &str, max_chars: usize) -> String {
+    if text.len() <= max_chars {
+        return text.to_string();
+    }
+    let truncated: String = text.chars().take(max_chars.saturating_sub(50)).collect();
+    format!(
+        "{}\n\n_... (truncated at {} chars, total {})_",
+        truncated,
+        max_chars,
+        text.len()
+    )
+}

--- a/crates/deepmap/src/resolver.rs
+++ b/crates/deepmap/src/resolver.rs
@@ -1,0 +1,306 @@
+// Import resolution — resolves import statements to file paths and symbol IDs.
+//
+// Handles relative imports, TypeScript path aliases (tsconfig paths),
+// package.json exports, and recursive re-export tracking.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use crate::types::*;
+
+/// Resolves imports to concrete file paths and symbol IDs.
+pub struct ImportResolver {
+    pub project_root: PathBuf,
+    pub import_configs: Vec<ProjectImportConfig>,
+    /// File stem → candidate file paths (relative to project root).
+    file_map: HashMap<String, Vec<String>>,
+    /// Symbol name → list of symbol IDs.
+    name_index: HashMap<String, Vec<String>>,
+}
+
+impl ImportResolver {
+    pub fn new(project_root: &Path, graph: &RepoGraph) -> Self {
+        let mut resolver = Self {
+            project_root: project_root.to_path_buf(),
+            import_configs: Vec::new(),
+            file_map: HashMap::new(),
+            name_index: HashMap::new(),
+        };
+        resolver.build_indices(graph);
+        resolver.discover_import_configs();
+        resolver
+    }
+
+    /// Build file stem → paths and name → symbol ID indices.
+    fn build_indices(&mut self, graph: &RepoGraph) {
+        for file in graph.file_symbols.keys() {
+            let stem = Path::new(file)
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("")
+                .to_string();
+            self.file_map.entry(stem).or_default().push(file.clone());
+        }
+
+        for (id, sym) in &graph.symbols {
+            self.name_index
+                .entry(sym.name.clone())
+                .or_default()
+                .push(id.clone());
+        }
+    }
+
+    /// Discover tsconfig/jsconfig for path aliases and base URL.
+    fn discover_import_configs(&mut self) {
+        // Walk project root for tsconfig.json / jsconfig.json.
+        if let Ok(entries) = std::fs::read_dir(&self.project_root) {
+            for entry in entries.flatten() {
+                let name = entry.file_name();
+                let name_str = name.to_string_lossy();
+                if name_str == "tsconfig.json" || name_str == "jsconfig.json" {
+                    if let Ok(config) = self.parse_tsconfig(&entry.path()) {
+                        self.import_configs.push(config);
+                    }
+                }
+                // Also check subdirectories (one level deep).
+                if entry.path().is_dir() {
+                    for sub_name in &["tsconfig.json", "jsconfig.json"] {
+                        let sub_path = entry.path().join(sub_name);
+                        if sub_path.exists() {
+                            if let Ok(config) = self.parse_tsconfig(&sub_path) {
+                                self.import_configs.push(config);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Parse a tsconfig/jsconfig for compilerOptions.paths and baseUrl.
+    fn parse_tsconfig(&self, path: &Path) -> Result<ProjectImportConfig, String> {
+        let content = std::fs::read_to_string(path).map_err(|e| e.to_string())?;
+        // Strip JSONC comments.
+        let stripped = Self::strip_jsonc(&content);
+        let parsed: serde_json::Value =
+            serde_json::from_str(&stripped).map_err(|e| e.to_string())?;
+
+        let compiler_options = parsed.get("compilerOptions");
+        let base_url = compiler_options
+            .and_then(|c| c.get("baseUrl"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        let mut alias_rules = Vec::new();
+        if let Some(paths) = compiler_options.and_then(|c| c.get("paths")) {
+            if let Some(obj) = paths.as_object() {
+                for (alias, targets) in obj {
+                    if let Some(target_array) = targets.as_array() {
+                        let target_strings: Vec<String> = target_array
+                            .iter()
+                            .filter_map(|t| t.as_str())
+                            .map(|s| s.trim_end_matches("/*").to_string())
+                            .collect();
+                        if !target_strings.is_empty() {
+                            alias_rules.push(PathAliasRule {
+                                alias_pattern: alias.trim_end_matches("/*").to_string(),
+                                target_patterns: target_strings,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        let config_dir = path.parent().map(|p| p.to_string_lossy().to_string());
+
+        Ok(ProjectImportConfig {
+            config_path: Some(path.to_string_lossy().to_string()),
+            config_dir,
+            base_url,
+            alias_rules,
+        })
+    }
+
+    /// Strip JSONC comments (line // and block /* */) and trailing commas.
+    fn strip_jsonc(text: &str) -> String {
+        let mut result = String::with_capacity(text.len());
+        let mut in_string = false;
+        let mut in_block_comment = false;
+        let mut chars = text.chars().peekable();
+
+        while let Some(ch) = chars.next() {
+            if in_block_comment {
+                if ch == '*' && chars.peek() == Some(&'/') {
+                    chars.next();
+                    in_block_comment = false;
+                }
+                continue;
+            }
+            if !in_string && ch == '/' && chars.peek() == Some(&'/') {
+                // Line comment: skip until end of line.
+                for c in chars.by_ref() {
+                    if c == '\n' {
+                        result.push('\n');
+                        break;
+                    }
+                }
+                continue;
+            }
+            if !in_string && ch == '/' && chars.peek() == Some(&'*') {
+                chars.next();
+                in_block_comment = true;
+                continue;
+            }
+            if ch == '"' {
+                in_string = !in_string;
+            }
+            if ch == '\\' && in_string {
+                // Escape sequence: push backslash and next char.
+                result.push(ch);
+                if let Some(next) = chars.next() {
+                    result.push(next);
+                }
+                continue;
+            }
+            result.push(ch);
+        }
+
+        // Remove trailing commas before } or ].
+        let re_result = result
+            .replace(",\n}", "\n}")
+            .replace(", }", " }")
+            .replace(",\n]", "\n]")
+            .replace(", ]", " ]");
+        re_result
+    }
+
+    // ── Resolution ──
+
+    /// Resolve an import path to candidate file paths.
+    pub fn resolve_import_targets(&self, source_file: &str, import_path: &str) -> Vec<String> {
+        let mut results: Vec<String> = Vec::new();
+
+        // 1. Relative import.
+        if import_path.starts_with('.') {
+            let source_dir = Path::new(source_file).parent().unwrap_or(Path::new("."));
+            if let Ok(resolved) = source_dir.join(import_path).canonicalize() {
+                if let Ok(rel) = resolved.strip_prefix(&self.project_root) {
+                    let rel_str = rel.to_string_lossy().to_string();
+                    // Try exact match first.
+                    if self.file_map.values().any(|v| v.contains(&rel_str)) {
+                        results.push(rel_str.clone());
+                    }
+                    // Try with extensions.
+                    let rel_str2 = rel_str.clone();
+                    for ext in &[".ts", ".tsx", ".js", ".jsx", ".py", ".rs", ".go"] {
+                        let with_ext = format!("{}{}", rel_str2, ext);
+                        if self.file_map.values().any(|v| v.contains(&with_ext)) {
+                            results.push(with_ext);
+                        }
+                    }
+                    // Try index files.
+                    for ext in &[".ts", ".tsx", ".js", ".py"] {
+                        let index_file = format!("{}/index{}", rel_str, ext);
+                        if self.file_map.values().any(|v| v.contains(&index_file)) {
+                            results.push(index_file);
+                        }
+                    }
+                }
+            }
+            return results;
+        }
+
+        // 2. Alias resolution (tsconfig paths).
+        for config in &self.import_configs {
+            for rule in &config.alias_rules {
+                if import_path.starts_with(&rule.alias_pattern) {
+                    let remainder = import_path
+                        .strip_prefix(&rule.alias_pattern)
+                        .unwrap_or("")
+                        .trim_start_matches('/');
+                    for target_pattern in &rule.target_patterns {
+                        let resolved_path = if target_pattern.contains('*') {
+                            target_pattern.replace('*', remainder)
+                        } else {
+                            format!("{}/{}", target_pattern, remainder)
+                        };
+                        // Search for matching files.
+                        let stem = Path::new(&resolved_path)
+                            .file_stem()
+                            .and_then(|s| s.to_str())
+                            .unwrap_or("");
+                        if let Some(candidates) = self.file_map.get(stem) {
+                            for c in candidates {
+                                if c.contains(&resolved_path) || c.ends_with(&resolved_path) {
+                                    results.push(c.clone());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // 3. Direct file lookup by stem.
+        let stem = Path::new(import_path)
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or(import_path);
+        if let Some(candidates) = self.file_map.get(stem) {
+            for c in candidates {
+                if !results.contains(c) {
+                    results.push(c.clone());
+                }
+            }
+        }
+
+        results
+    }
+
+    /// Find the symbol that contains the given call line.
+    pub fn resolve_calling_symbol(&self, _file: &str, _call_line: usize) -> Option<String> {
+        // Iterate symbols in this file and find the one whose range contains call_line.
+        // Since we don't have direct access to the symbol map here (it's in the graph),
+        // this is a simplified version that the engine passes through.
+        None // Will be resolved by the engine which has symbol data.
+    }
+
+    /// Resolve a call reference to a target symbol ID.
+    pub fn resolve_call_target(
+        &self,
+        _file: &str,
+        call_name: &str,
+        _call_line: usize,
+        _call_kind: &str,
+        _local_names: &HashMap<String, String>,
+    ) -> Option<String> {
+        // Look up by name in the name index.
+        // Prefer symbols in the same module, then fall back to any match.
+        if let Some(candidates) = self.name_index.get(call_name) {
+            if !candidates.is_empty() {
+                return Some(candidates[0].clone());
+            }
+        }
+        None
+    }
+
+    /// Resolve resolving symbol for a given file and line.
+    pub fn resolve_calling_symbol_with_graph(
+        &self,
+        file: &str,
+        call_line: usize,
+        graph: &RepoGraph,
+    ) -> Option<String> {
+        if let Some(sym_ids) = graph.file_symbols.get(file) {
+            for sym_id in sym_ids {
+                if let Some(sym) = graph.symbols.get(sym_id) {
+                    if call_line >= sym.line && call_line <= sym.end_line {
+                        return Some(sym_id.clone());
+                    }
+                }
+            }
+        }
+        None
+    }
+}

--- a/crates/deepmap/src/topic.rs
+++ b/crates/deepmap/src/topic.rs
@@ -1,0 +1,214 @@
+// Topic scoring, file role classification, and test matching.
+//
+// Zero external dependencies — all scoring is heuristic.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use crate::types::RepoGraph;
+
+/// A file match result with score and role.
+#[derive(Debug, Clone)]
+pub struct FileMatch {
+    pub path: String,
+    pub role: String,
+    pub score: f64,
+    pub reasons: Vec<String>,
+}
+
+/// A test match with confidence level.
+#[derive(Debug, Clone)]
+pub struct TestMatch {
+    pub test_file: String,
+    pub target_file: String,
+    pub confidence: String,
+    pub reason: String,
+}
+
+/// Check if a file path matches known noise patterns.
+pub fn is_noise_file(file_path: &str) -> bool {
+    let lower = file_path.to_lowercase();
+    lower.contains("test")
+        || lower.contains("__pycache__")
+        || lower.contains("node_modules")
+        || lower.contains(".min.")
+        || lower.ends_with(".lock")
+        || lower.ends_with(".json")
+        || lower.ends_with(".html")
+        || lower.ends_with(".css")
+}
+
+/// Classify a file by role based on path patterns.
+pub fn classify_file_role(file_path: &str) -> &str {
+    let lower = file_path.to_lowercase();
+    if lower.contains("test") || lower.contains("__test__") || lower.contains("spec.") {
+        return "test";
+    }
+    if lower.contains(".tsx") || lower.contains(".jsx") || lower.contains("component") {
+        return "frontend-ui";
+    }
+    if lower.contains("store") || lower.contains("state") || lower.contains("reducer") {
+        return "frontend-state";
+    }
+    if lower.contains("config") || lower.contains(".toml") || lower.contains(".json") {
+        return "config";
+    }
+    "backend"
+}
+
+/// Split an identifier into lowercase tokens (camelCase/PascalCase/snake_case/kebab-case).
+pub fn split_identifier(name: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+
+    for ch in name.chars() {
+        if ch == '_' || ch == '-' || ch == '.' {
+            if !current.is_empty() {
+                tokens.push(current.to_lowercase());
+                current.clear();
+            }
+        } else if ch.is_uppercase() && !current.is_empty() {
+            tokens.push(current.to_lowercase());
+            current.clear();
+            current.push(ch);
+        } else {
+            current.push(ch);
+        }
+    }
+    if !current.is_empty() {
+        tokens.push(current.to_lowercase());
+    }
+    tokens
+}
+
+/// Compute relevance score for a file given a query.
+/// Weighted scoring: path (30%), file name (25%), symbol hits (15%),
+/// noise penalty (×0.05), test down-weight (×0.55).
+pub fn topic_score(
+    query: &str,
+    file_path: &str,
+    graph: &RepoGraph,
+    _keyword_weights: &HashMap<String, f64>,
+) -> f64 {
+    let query_lower = query.to_lowercase();
+    let query_tokens: Vec<String> = split_identifier(&query_lower);
+
+    // Path score (max 30).
+    let path_lower = file_path.to_lowercase();
+    let path_tokens = split_identifier(&path_lower);
+    let path_hits: usize = query_tokens
+        .iter()
+        .filter(|t| path_tokens.contains(t))
+        .count();
+    let path_score = if query_tokens.is_empty() {
+        0.0
+    } else {
+        (path_hits as f64 / query_tokens.len() as f64) * 30.0
+    };
+
+    // File name score (max 25).
+    let file_stem = Path::new(file_path)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("");
+    let stem_tokens = split_identifier(file_stem);
+    let name_hits: usize = query_tokens
+        .iter()
+        .filter(|t| stem_tokens.contains(t))
+        .count();
+    let name_score = if query_tokens.is_empty() {
+        0.0
+    } else {
+        (name_hits as f64 / query_tokens.len() as f64) * 25.0
+    };
+
+    // Symbol hit score (max 15).
+    let sym_score = if let Some(sym_ids) = graph.file_symbols.get(file_path) {
+        let hits: usize = sym_ids
+            .iter()
+            .filter_map(|id| graph.symbols.get(id))
+            .filter(|s| {
+                let name_lower = s.name.to_lowercase();
+                query_tokens.iter().any(|t| name_lower.contains(t.as_str()))
+            })
+            .count();
+        if sym_ids.is_empty() {
+            0.0
+        } else {
+            (hits as f64 / sym_ids.len() as f64) * 15.0
+        }
+    } else {
+        0.0
+    };
+
+    let base = path_score + name_score + sym_score;
+
+    // Noise penalty.
+    let noise_penalty = if is_noise_file(file_path) { 0.05 } else { 1.0 };
+
+    // Test down-weight.
+    let test_weight = if classify_file_role(file_path) == "test" {
+        0.55
+    } else {
+        1.0
+    };
+
+    base * noise_penalty * test_weight
+}
+
+/// Compute IDF-like weights for keywords (frequent words get lower weight).
+pub fn compute_keyword_weights(
+    keywords: &[String],
+    candidate_files: &[String],
+    graph: &RepoGraph,
+) -> HashMap<String, f64> {
+    let mut weights = HashMap::new();
+    let n = candidate_files.len().max(1) as f64;
+
+    for kw in keywords {
+        let mut doc_count = 0;
+        for file in candidate_files {
+            let tokens = split_identifier(file);
+            if tokens.contains(kw) {
+                doc_count += 1;
+            } else if let Some(sym_ids) = graph.file_symbols.get(file) {
+                let found = sym_ids.iter().any(|id| {
+                    graph
+                        .symbols
+                        .get(id)
+                        .map_or(false, |s| s.name.to_lowercase().contains(kw.as_str()))
+                });
+                if found {
+                    doc_count += 1;
+                }
+            }
+        }
+        let idf = ((n + 1.0) / (doc_count as f64 + 1.0)).ln() + 1.0;
+        weights.insert(kw.clone(), idf);
+    }
+    weights
+}
+
+/// Check if a file looks like a test file.
+pub fn is_test_like_file(file_path: &str) -> bool {
+    let lower = file_path.to_lowercase();
+    lower.contains("test")
+        || lower.contains("__test__")
+        || lower.contains("spec.")
+        || lower.contains("_test.")
+}
+
+/// Find related tests for target files using multiple strategies.
+pub fn find_related_tests(
+    _target_files: &[String],
+    _graph: &RepoGraph,
+    _project_root: &Path,
+) -> Vec<TestMatch> {
+    // TODO: implement 5-strategy test matching
+    // 1. Exact file name match (e.g., foo.py → test_foo.py)
+    // 2. Directory proximity (e.g., src/foo.py → tests/test_foo.py)
+    // 3. Import match (test imports the target)
+    // 4. Symbol edge (test calls target symbols)
+    // 5. Git co-change history
+    Vec::new()
+}

--- a/crates/deepmap/src/types.rs
+++ b/crates/deepmap/src/types.rs
@@ -1,0 +1,190 @@
+// Core data types for DeepMap: symbols, edges, graph structure, and scan statistics.
+
+use std::collections::HashMap;
+
+/// File extension to language mapping.
+pub fn ext_to_lang(ext: &str) -> Option<&'static str> {
+    Some(match ext {
+        ".py" | ".pyi" => "python",
+        ".js" | ".jsx" | ".mjs" | ".cjs" => "javascript",
+        ".ts" | ".tsx" | ".mts" | ".cts" => "typescript",
+        ".go" => "go",
+        ".rs" => "rust",
+        ".html" | ".htm" => "html",
+        ".css" => "css",
+        ".json" => "json",
+        _ => return None,
+    })
+}
+
+/// Directory names to skip during file traversal.
+pub const SKIP_DIR_NAMES: &[&str] = &[
+    ".cache",
+    ".git",
+    ".hg",
+    ".idea",
+    ".mypy_cache",
+    ".next",
+    ".nox",
+    ".nuxt",
+    ".parcel-cache",
+    ".pnpm-store",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".svelte-kit",
+    ".tox",
+    ".turbo",
+    ".venv",
+    ".vscode",
+    ".yarn",
+    "__pypackages__",
+    "__pycache__",
+    "build",
+    "coverage",
+    "dist",
+    "env",
+    "ENV",
+    "node_modules",
+    "site-packages",
+    "target",
+    "venv",
+    // Third-party directories
+    "monaco-editor",
+    "monaco",
+    "vendor",
+    "third_party",
+    "third-party",
+    "libs",
+    "external",
+];
+
+/// File names to skip.
+pub const SKIP_FILE_NAMES: &[&str] = &[
+    "package-lock.json",
+    "npm-shrinkwrap.json",
+    "bun.lock",
+    "bun.lockb",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+    "Cargo.lock",
+];
+
+/// Default maximum file size in bytes (512 KB).
+pub const DEFAULT_MAX_FILE_BYTES: u64 = 512 * 1024;
+
+/// A code symbol (function, class, interface, etc.).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Symbol {
+    pub id: String,
+    pub name: String,
+    pub kind: String,
+    pub file: String,
+    pub line: usize,
+    pub end_line: usize,
+    pub col: usize,
+    pub visibility: String,
+    pub docstring: String,
+    pub signature: String,
+    pub pagerank: f64,
+}
+
+impl Symbol {
+    pub fn new(
+        id: String,
+        name: String,
+        kind: String,
+        file: String,
+        line: usize,
+        end_line: usize,
+        col: usize,
+        visibility: String,
+        docstring: String,
+        signature: String,
+    ) -> Self {
+        Self {
+            id,
+            name,
+            kind,
+            file,
+            line,
+            end_line,
+            col,
+            visibility,
+            docstring,
+            signature,
+            pagerank: 0.0,
+        }
+    }
+}
+
+/// A directed edge between two symbols in the dependency graph.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Edge {
+    pub source: String,
+    pub target: String,
+    pub weight: f64,
+    pub kind: String,
+}
+
+/// JS/TS import binding.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct JsImportBinding {
+    pub local_name: String,
+    pub imported_name: String,
+    pub module: String,
+    pub line: usize,
+    pub kind: String,
+}
+
+/// JS/TS export binding.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct JsExportBinding {
+    pub exported_name: String,
+    pub source_name: Option<String>,
+    pub module: Option<String>,
+    pub line: usize,
+    pub kind: String,
+}
+
+/// Path alias rule (e.g., tsconfig paths).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct PathAliasRule {
+    pub alias_pattern: String,
+    pub target_patterns: Vec<String>,
+}
+
+/// Project import configuration (tsconfig/jsconfig).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ProjectImportConfig {
+    pub config_path: Option<String>,
+    pub config_dir: Option<String>,
+    pub base_url: Option<String>,
+    pub alias_rules: Vec<PathAliasRule>,
+}
+
+/// Scan statistics.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct ScanStats {
+    pub listed_source_files: usize,
+    pub selected_source_files: usize,
+    pub processed_files: usize,
+    pub filtered_path_files: usize,
+    pub filtered_large_files: usize,
+    pub truncated_files: usize,
+    pub failed_files: Vec<String>,
+    pub scan_duration_ms: u64,
+    pub timeout_triggered: bool,
+}
+
+/// The repository dependency graph.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct RepoGraph {
+    pub symbols: HashMap<String, Symbol>,
+    pub outgoing: HashMap<String, Vec<Edge>>,
+    pub incoming: HashMap<String, Vec<Edge>>,
+    pub file_symbols: HashMap<String, Vec<String>>,
+    pub file_imports: HashMap<String, Vec<String>>,
+    pub file_calls: HashMap<String, Vec<(String, usize, String)>>,
+    pub file_import_bindings: HashMap<String, Vec<JsImportBinding>>,
+    pub file_exports: HashMap<String, Vec<JsExportBinding>>,
+}

--- a/crates/deepmap/tests/integration_test.rs
+++ b/crates/deepmap/tests/integration_test.rs
@@ -1,0 +1,131 @@
+// Integration tests for DeepMap engine.
+
+#[test]
+fn test_scan_own_crate() {
+    let crate_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let project_root = crate_dir.parent().unwrap().parent().unwrap(); // workspace root
+
+    let mut engine = deepmap::engine::RepoMapEngine::new(project_root);
+    engine.scan(200, 60.0); // scan up to 200 files, 60s timeout
+
+    assert!(engine.is_scanned(), "Engine should be in scanned state");
+    assert!(
+        !engine.graph.symbols.is_empty(),
+        "Should have found symbols"
+    );
+    assert!(
+        !engine.graph.file_symbols.is_empty(),
+        "Should have file-symbol mappings"
+    );
+
+    // Verify we found some Rust files.
+    let rust_files: Vec<_> = engine
+        .graph
+        .file_symbols
+        .keys()
+        .filter(|f| f.ends_with(".rs"))
+        .collect();
+    assert!(!rust_files.is_empty(), "Should have scanned Rust files");
+
+    // Entry points should include main.rs.
+    let entries = engine.entry_points();
+    let has_main = entries.iter().any(|e| e.contains("main.rs"));
+    assert!(has_main, "Should find main.rs as entry point");
+
+    // Query a known symbol.
+    let results = engine.query_symbol("main");
+    assert!(!results.is_empty(), "Should find 'main' symbol");
+
+    // Overview report should be non-empty.
+    let report = deepmap::renderer::render_overview_report(&engine, 8000);
+    assert!(!report.is_empty(), "Overview report should not be empty");
+    assert!(report.contains("Project Map"), "Report should have title");
+}
+
+#[test]
+fn test_call_chain() {
+    let crate_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let project_root = crate_dir.parent().unwrap().parent().unwrap();
+
+    let mut engine = deepmap::engine::RepoMapEngine::new(project_root);
+    engine.scan(200, 60.0);
+
+    // Query a symbol that should exist.
+    let results = engine.query_symbol("scan");
+    if !results.is_empty() {
+        let sym = &results[0];
+        let chains = engine.call_chain(&sym.id, "both", 2);
+        assert!(
+            chains.contains_key("callers") || chains.contains_key("callees"),
+            "Call chain should return at least one direction"
+        );
+    }
+}
+
+#[test]
+fn test_hotspots_and_reading_order() {
+    let crate_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let project_root = crate_dir.parent().unwrap().parent().unwrap();
+
+    let mut engine = deepmap::engine::RepoMapEngine::new(project_root);
+    engine.scan(200, 60.0);
+
+    let hotspots = engine.hotspots(5);
+    assert!(!hotspots.is_empty(), "Should have hotspots");
+
+    let reading = engine.suggested_reading_order(5);
+    assert!(!reading.is_empty(), "Should have reading order");
+
+    let modules = engine.module_summary(3);
+    assert!(!modules.is_empty(), "Should have module summary");
+}
+
+#[test]
+fn test_query_report() {
+    let crate_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let project_root = crate_dir.parent().unwrap().parent().unwrap();
+
+    let mut engine = deepmap::engine::RepoMapEngine::new(project_root);
+    engine.scan(200, 60.0);
+
+    let report = deepmap::renderer::render_query_report(&engine, "scan symbols", 15, 8000);
+    assert!(!report.is_empty());
+    eprintln!("=== Query Report (first 500 chars) ===");
+    eprintln!("{}", &report[..report.len().min(500)]);
+}
+
+#[test]
+fn test_renderer() {
+    let crate_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let project_root = crate_dir.parent().unwrap().parent().unwrap();
+
+    let mut engine = deepmap::engine::RepoMapEngine::new(project_root);
+    engine.scan(200, 60.0);
+
+    let report = deepmap::renderer::render_overview_report(&engine, 16000);
+    assert!(!report.is_empty());
+    eprintln!("=== Overview Report (first 500 chars) ===");
+    eprintln!("{}", &report[..report.len().min(500)]);
+
+    // File detail for a Rust file.
+    if let Some(file) = engine
+        .graph
+        .file_symbols
+        .keys()
+        .find(|f| f.ends_with(".rs"))
+    {
+        let detail = deepmap::renderer::render_file_detail_report(&engine, file, 10, 4000);
+        assert!(!detail.is_empty());
+        eprintln!("=== File Detail (first 300 chars) ===");
+        eprintln!("{}", &detail[..detail.len().min(300)]);
+    }
+
+    // Call chain report.
+    let results = engine.query_symbol("scan");
+    if !results.is_empty() {
+        let report = deepmap::renderer::render_call_chain_report(&engine, "scan", 2);
+        assert!(!report.is_empty());
+        eprintln!("=== Call Chain (first 300 chars) ===");
+        eprintln!("{}", &report[..report.len().min(300)]);
+    }
+}

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -17,6 +17,7 @@ arboard = "3.4"
 deepseek-tui-cli = { path = "../cli", version = "0.8.2" }
 deepseek-secrets = { path = "../secrets", version = "0.8.2" }
 deepseek-tools = { path = "../tools", version = "0.8.2" }
+deepmap = { path = "../deepmap", version = "0.8.2" }
 async-stream = "0.3.6"
 async-trait = "0.1"
 bytes = "1.11.0"

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -1739,7 +1739,8 @@ impl Engine {
             .with_review_tool(self.deepseek_client.clone(), self.session.model.clone())
             .with_rlm_tool(self.deepseek_client.clone(), self.session.model.clone())
             .with_user_input_tool()
-            .with_parallel_tool();
+            .with_parallel_tool()
+            .with_deepmap_tools();
 
         if self.config.features.enabled(Feature::ApplyPatch) && mode != AppMode::Plan {
             builder = builder.with_patch_tools();

--- a/crates/tui/src/tools/deepmap.rs
+++ b/crates/tui/src/tools/deepmap.rs
@@ -1,0 +1,180 @@
+//! DeepMap codebase analysis tools for DeepSeek-TUI.
+//!
+//! Provides AI-driven repository mapping: symbol extraction, dependency graph,
+//! PageRank ranking, call chains, hotspots, and more.
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+use super::spec::{
+    ApprovalRequirement, ToolCapability, ToolContext, ToolError, ToolResult, ToolSpec,
+    optional_u64, required_str,
+};
+
+pub struct DeepMapOverviewTool;
+
+#[async_trait]
+impl ToolSpec for DeepMapOverviewTool {
+    fn name(&self) -> &'static str {
+        "deepmap_overview"
+    }
+
+    fn description(&self) -> &'static str {
+        "Use this first when exploring or working on an unfamiliar codebase. \
+         Scans the entire project, extracts all symbols (functions, classes, etc.), \
+         builds a dependency graph, runs PageRank to rank importance, and returns an \
+         AI-friendly summary: entry points, hotspots, key symbols by file, module \
+         structure, and recommended reading order. Much faster than reading files \
+         one by one — gives you a mental map of the codebase in one call."
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "max_files": {
+                    "type": "integer",
+                    "description": "Maximum files to scan (default: 2000)."
+                },
+                "max_chars": {
+                    "type": "integer",
+                    "description": "Maximum output characters (default: 16000)."
+                }
+            }
+        })
+    }
+
+    fn capabilities(&self) -> Vec<ToolCapability> {
+        vec![ToolCapability::ReadOnly, ToolCapability::Sandboxable]
+    }
+
+    fn approval_requirement(&self) -> ApprovalRequirement {
+        ApprovalRequirement::Auto
+    }
+
+    async fn execute(&self, input: Value, context: &ToolContext) -> Result<ToolResult, ToolError> {
+        let max_files = optional_u64(&input, "max_files", 2000) as usize;
+        let max_chars = optional_u64(&input, "max_chars", 16000) as usize;
+        let workspace = &context.workspace;
+
+        let engine = deepmap::engine::RepoMapEngine::get_or_scan(workspace, max_files, 300.0);
+
+        let report = deepmap::renderer::render_overview_report(&engine, max_chars);
+        Ok(ToolResult::success(report))
+    }
+}
+
+pub struct DeepMapCallChainTool;
+
+#[async_trait]
+impl ToolSpec for DeepMapCallChainTool {
+    fn name(&self) -> &'static str {
+        "deepmap_call_chain"
+    }
+
+    fn description(&self) -> &'static str {
+        "Trace who calls a symbol and what it calls. Use this when you need to \
+         understand the impact of changing a function, find all callers of an API, \
+         or discover what dependencies a piece of code has. Returns callers and \
+         callees sorted by PageRank importance, up to a configurable depth."
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "symbol_name": {
+                    "type": "string",
+                    "description": "The symbol name to trace (e.g., 'createApp', 'handleLogin')."
+                },
+                "max_depth": {
+                    "type": "integer",
+                    "description": "Maximum traversal depth (default: 3)."
+                }
+            },
+            "required": ["symbol_name"]
+        })
+    }
+
+    fn capabilities(&self) -> Vec<ToolCapability> {
+        vec![ToolCapability::ReadOnly, ToolCapability::Sandboxable]
+    }
+
+    fn approval_requirement(&self) -> ApprovalRequirement {
+        ApprovalRequirement::Auto
+    }
+
+    async fn execute(&self, input: Value, context: &ToolContext) -> Result<ToolResult, ToolError> {
+        let symbol_name = required_str(&input, "symbol_name")?;
+        let max_depth = optional_u64(&input, "max_depth", 3) as usize;
+        let workspace = &context.workspace;
+
+        let engine = deepmap::engine::RepoMapEngine::get_or_scan(workspace, 2000, 300.0);
+
+        let report = deepmap::renderer::render_call_chain_report(&engine, symbol_name, max_depth);
+        Ok(ToolResult::success(report))
+    }
+}
+
+pub struct DeepMapFileDetailTool;
+
+#[async_trait]
+impl ToolSpec for DeepMapFileDetailTool {
+    fn name(&self) -> &'static str {
+        "deepmap_file_detail"
+    }
+
+    fn description(&self) -> &'static str {
+        "Inspect a specific file's structure without reading it raw. Returns every \
+         symbol defined in the file (functions, classes, methods) with their \
+         signatures, PageRank importance scores, line numbers, and visibility. \
+         Use this before reading or editing a file to quickly understand what's \
+         in it and which symbols matter most."
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "file_path": {
+                    "type": "string",
+                    "description": "Relative file path within the project (e.g., 'src/server/app.ts')."
+                },
+                "max_symbols": {
+                    "type": "integer",
+                    "description": "Maximum symbols to show (default: 12)."
+                },
+                "max_chars": {
+                    "type": "integer",
+                    "description": "Maximum output characters (default: 6000)."
+                }
+            },
+            "required": ["file_path"]
+        })
+    }
+
+    fn capabilities(&self) -> Vec<ToolCapability> {
+        vec![ToolCapability::ReadOnly, ToolCapability::Sandboxable]
+    }
+
+    fn approval_requirement(&self) -> ApprovalRequirement {
+        ApprovalRequirement::Auto
+    }
+
+    async fn execute(&self, input: Value, context: &ToolContext) -> Result<ToolResult, ToolError> {
+        let file_path = required_str(&input, "file_path")?;
+        let max_symbols = optional_u64(&input, "max_symbols", 12) as usize;
+        let max_chars = optional_u64(&input, "max_chars", 6000) as usize;
+        let workspace = &context.workspace;
+
+        let engine = deepmap::engine::RepoMapEngine::get_or_scan(workspace, 2000, 300.0);
+
+        let report = deepmap::renderer::render_file_detail_report(
+            &engine,
+            file_path,
+            max_symbols,
+            max_chars,
+        );
+        Ok(ToolResult::success(report))
+    }
+}

--- a/crates/tui/src/tools/mod.rs
+++ b/crates/tui/src/tools/mod.rs
@@ -3,6 +3,7 @@
 pub mod apply_patch;
 pub mod approval_cache;
 pub mod automation;
+pub mod deepmap;
 pub mod diagnostics;
 pub mod file;
 pub mod file_search;

--- a/crates/tui/src/tools/registry.rs
+++ b/crates/tui/src/tools/registry.rs
@@ -322,6 +322,15 @@ impl ToolRegistryBuilder {
         self.with_tool(Arc::new(DiagnosticsTool))
     }
 
+    /// Include DeepMap codebase analysis tools.
+    #[must_use]
+    pub fn with_deepmap_tools(self) -> Self {
+        use super::deepmap::{DeepMapCallChainTool, DeepMapFileDetailTool, DeepMapOverviewTool};
+        self.with_tool(Arc::new(DeepMapOverviewTool))
+            .with_tool(Arc::new(DeepMapCallChainTool))
+            .with_tool(Arc::new(DeepMapFileDetailTool))
+    }
+
     /// Include project mapping tools.
     #[must_use]
     pub fn with_project_tools(self) -> Self {


### PR DESCRIPTION
Add DeepMap — a built-in codebase analysis tool that gives AI agents a project map before reading individual files.

## Summary
- **Core engine**: 12-module Rust crate with tree-sitter parsing, symbol extraction, dependency graph, PageRank, and AI-friendly report rendering
- **TUI tools**: deepmap_overview, deepmap_call_chain, deepmap_file_detail (registered in default tool chain)
- **CLI**: 9 subcommands (overview, call-chain, file-detail, query, impact, diff-risk, check, blame, recent)
- **Tests**: 5 integration tests, all passing
- **Session cache**: Repeated tool calls within same session reuse scan results (0s after first scan)

See full PR description on the branch for details.