### PR TITLE
fix(pricing): extend V4 Pro 75% discount expiry to 2026-05-31 15:59 UTC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **V4 Pro discount expiry extended** (#267) — DeepSeek extended the V4 Pro 75%
+  promotional discount from 2026-05-05 15:59 UTC to 2026-05-31 15:59 UTC. Without
+  this update the TUI would have started showing 4× the actual billed cost on
+  May 6 onwards. Verified at https://api-docs.deepseek.com/quick_start/pricing.
+
 ## [0.8.3] - 2026-05-01
 
 ### Fixed

--- a/crates/tui/src/pricing.rs
+++ b/crates/tui/src/pricing.rs
@@ -14,7 +14,7 @@ struct ModelPricing {
 }
 
 fn v4_pro_discount_ends_at() -> DateTime<Utc> {
-    Utc.with_ymd_and_hms(2026, 5, 5, 15, 59, 0)
+    Utc.with_ymd_and_hms(2026, 5, 31, 15, 59, 0)
         .single()
         .expect("valid DeepSeek V4 Pro discount end timestamp")
 }
@@ -37,7 +37,7 @@ fn pricing_for_model_at(model: &str, now: DateTime<Utc>) -> Option<ModelPricing>
     if lower.contains("v4-pro") || lower.contains("v4pro") {
         if now <= v4_pro_discount_ends_at() {
             // DeepSeek lists these as a limited-time 75% discount through
-            // 2026-05-05 15:59 UTC.
+            // 2026-05-31 15:59 UTC.
             return Some(ModelPricing {
                 input_cache_hit_per_million: 0.003625,
                 input_cache_miss_per_million: 0.435,
@@ -131,7 +131,7 @@ mod tests {
     #[test]
     fn v4_pro_uses_limited_time_discount_before_expiry() {
         let before_expiry = Utc
-            .with_ymd_and_hms(2026, 5, 5, 15, 58, 59)
+            .with_ymd_and_hms(2026, 5, 31, 15, 58, 59)
             .single()
             .unwrap();
         let pricing = pricing_for_model_at("deepseek-v4-pro", before_expiry).unwrap();
@@ -143,12 +143,26 @@ mod tests {
 
     #[test]
     fn v4_pro_returns_to_base_rates_after_discount_expiry() {
-        let after_expiry = Utc.with_ymd_and_hms(2026, 5, 5, 16, 0, 0).single().unwrap();
+        let after_expiry = Utc
+            .with_ymd_and_hms(2026, 5, 31, 16, 0, 0)
+            .single()
+            .unwrap();
         let pricing = pricing_for_model_at("deepseek-v4-pro", after_expiry).unwrap();
 
         assert_eq!(pricing.input_cache_hit_per_million, 0.0145);
         assert_eq!(pricing.input_cache_miss_per_million, 1.74);
         assert_eq!(pricing.output_per_million, 3.48);
+    }
+
+    #[test]
+    fn v4_pro_discount_still_applies_just_before_old_may5_expiry() {
+        // Regression for #267: extension to 2026-05-31 15:59 UTC.
+        let after_old_expiry = Utc.with_ymd_and_hms(2026, 5, 6, 0, 0, 0).single().unwrap();
+        let pricing = pricing_for_model_at("deepseek-v4-pro", after_old_expiry).unwrap();
+
+        assert_eq!(pricing.input_cache_hit_per_million, 0.003625);
+        assert_eq!(pricing.input_cache_miss_per_million, 0.435);
+        assert_eq!(pricing.output_per_million, 0.87);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- DeepSeek extended the V4 Pro 75% promotional discount from 2026-05-05 15:59 UTC → 2026-05-31 15:59 UTC. Source: https://api-docs.deepseek.com/quick_start/pricing
- Without this update the TUI would start showing 4× the actual billed cost on May 6 (one-line constant + the comment + two test timestamps).
- Adds a regression test (`v4_pro_discount_still_applies_just_before_old_may5_expiry`) that pins the new active window so a revert to the May 5 date trips the suite immediately.

Closes #267.

## Test plan

- [x] `cargo test -p deepseek-tui --bin deepseek-tui --locked pricing` — 5/5 pass
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p deepseek-tui --all-targets --locked -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hmbown/deepseek-tui/pull/270" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
