### PR TITLE
chore: remove stale TODO(integrate) markers from already-integrated modules

### DIFF
--- a/crates/tui/src/command_safety.rs
+++ b/crates/tui/src/command_safety.rs
@@ -1,4 +1,3 @@
-// TODO(integrate): Wire command safety analysis into shell tool approval flow
 #![allow(dead_code)]
 
 //! Command safety analysis for shell execution

--- a/crates/tui/src/execpolicy/mod.rs
+++ b/crates/tui/src/execpolicy/mod.rs
@@ -1,4 +1,3 @@
-// TODO(integrate): Wire exec-policy into shell tool — tracked as future work
 #![allow(dead_code)]
 #![allow(unused_imports)]
 

--- a/crates/tui/src/sandbox/mod.rs
+++ b/crates/tui/src/sandbox/mod.rs
@@ -1,9 +1,6 @@
-// TODO(integrate): Wire sandbox into shell tool — tracked as future security feature
 #![allow(dead_code)]
 
 //! Sandbox module for secure command execution.
-//! NOTE: Not yet integrated into shell tool - planned security feature.
-
 //!
 //! This module provides sandboxing capabilities for shell commands executed by
 //! DeepSeek TUI. Sandboxing restricts what system resources a command can access,

--- a/crates/tui/src/sandbox/policy.rs
+++ b/crates/tui/src/sandbox/policy.rs
@@ -1,4 +1,3 @@
-// TODO(integrate): Wire sandbox policy into shell tool — tracked as future work
 #![allow(dead_code)]
 
 //! Sandbox policy definitions for command execution restrictions.

--- a/crates/tui/src/tui/streaming/mod.rs
+++ b/crates/tui/src/tui/streaming/mod.rs
@@ -1,4 +1,3 @@
-// TODO(integrate): Wire streaming collector into TUI rendering pipeline
 #![allow(dead_code)]
 
 //! Markdown stream collector for newline-gated rendering.


### PR DESCRIPTION
## Summary

Five `// TODO(integrate)` comments at the top of source files claimed their modules were "not yet integrated" — every one of them is actually wired up in the live build. They were actively misleading anyone grepping the tree for integration work.

| File | Verified call site |
|---|---|
| `crates/tui/src/execpolicy/mod.rs` | `tools/shell.rs:1322` (`load_default_policy`, `ExecPolicyDecision`) |
| `crates/tui/src/sandbox/mod.rs` | `tools/shell.rs:28-33`, `main.rs:2647`, `tui/approval.rs:30` |
| `crates/tui/src/sandbox/policy.rs` | `main.rs:2752`, `tui/approval.rs:30` (`SandboxPolicy`) |
| `crates/tui/src/command_safety.rs` | `tools/shell.rs:1321`, `tools/tasks.rs:13`, `tools/approval_cache.rs:26` |
| `crates/tui/src/tui/streaming/mod.rs` | `tui/app.rs:38` (`StreamingState`) |

Also dropped the matching `//! NOTE: Not yet integrated` line from `sandbox/mod.rs` so the doc-comment doesn't disagree with the call sites.

`mcp.rs:1771` (`Wire legacy sync API into CLI subcommands or remove`) is left alone — it covers an unresolved keep-or-delete decision rather than a stale tracking note.

Closes #266.

## Test plan

- [x] `grep -rn 'TODO(integrate)' crates/` now only matches `mcp.rs:1771`
- [x] `cargo check -p deepseek-tui --locked` clean
- [x] `cargo fmt --all -- --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hmbown/deepseek-tui/pull/271" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
