### PR TITLE
fix(sandbox): elevate Agent-mode shell sandbox to allow network access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Agent-mode shell exec could not reach the network** (#272) — the seatbelt
+  default policy denies all outbound network including DNS, so any
+  `exec_shell` command needing the network (`curl`, `yt-dlp`, package
+  managers, …) failed in Agent mode unless the user dropped to Yolo. The
+  engine now elevates the sandbox policy to `WorkspaceWrite { network_access:
+  true, … }` for both Agent and Yolo. Plan mode is unchanged (read-only
+  investigation never registers the shell tool). The application-level
+  `NetworkPolicy` (`crates/tui/src/network_policy.rs`) remains the only
+  outbound-traffic boundary.
 - **V4 Pro discount expiry extended** (#267) — DeepSeek extended the V4 Pro 75%
   promotional discount from 2026-05-05 15:59 UTC to 2026-05-31 15:59 UTC. Without
   this update the TUI would have started showing 4× the actual billed cost on

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -1195,15 +1195,25 @@ impl Engine {
             ctx = ctx.with_network_policy(decider.clone());
         }
 
-        if mode == AppMode::Yolo {
-            ctx.with_elevated_sandbox_policy(crate::sandbox::SandboxPolicy::WorkspaceWrite {
-                writable_roots: vec![self.session.workspace.clone()],
-                network_access: true,
-                exclude_tmpdir: false,
-                exclude_slash_tmp: false,
-            })
-        } else {
-            ctx
+        match mode {
+            // Plan mode is read-only investigation; the shell tool is not
+            // registered, so leaving the sandbox policy at the seatbelt-strict
+            // default is fine.
+            AppMode::Plan => ctx,
+            // Agent and Yolo both register the shell tool. The sandbox-default
+            // policy denies all outbound network — including DNS — which
+            // breaks ordinary developer commands (cargo fetch, npm install,
+            // curl, yt-dlp, …) without buying the user any safety the
+            // application-level NetworkPolicy / approval flow doesn't already
+            // provide. Elevate to workspace-write + network. (#273)
+            AppMode::Agent | AppMode::Yolo => {
+                ctx.with_elevated_sandbox_policy(crate::sandbox::SandboxPolicy::WorkspaceWrite {
+                    writable_roots: vec![self.session.workspace.clone()],
+                    network_access: true,
+                    exclude_tmpdir: false,
+                    exclude_slash_tmp: false,
+                })
+            }
         }
     }
 

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -290,6 +290,44 @@ fn agent_mode_can_build_auto_approved_tool_context() {
     assert!(engine.build_tool_context(AppMode::Yolo, false).auto_approve);
 }
 
+#[test]
+fn agent_and_yolo_modes_elevate_shell_sandbox_to_allow_network() {
+    // Regression for #273: the seatbelt-default policy denies all outbound
+    // network (including DNS), which broke `curl`, `yt-dlp`, package managers,
+    // and similar shell commands in Agent mode. Elevation must include
+    // network access so the application-level NetworkPolicy stays the only
+    // outbound boundary.
+    let (engine, _handle) = Engine::new(EngineConfig::default(), &Config::default());
+
+    let agent_ctx = engine.build_tool_context(AppMode::Agent, false);
+    let agent_policy = agent_ctx
+        .elevated_sandbox_policy
+        .as_ref()
+        .expect("Agent mode should elevate the sandbox policy");
+    assert!(
+        agent_policy.has_network_access(),
+        "Agent mode must allow shell network access; got {agent_policy:?}",
+    );
+
+    let yolo_ctx = engine.build_tool_context(AppMode::Yolo, false);
+    assert!(
+        yolo_ctx
+            .elevated_sandbox_policy
+            .as_ref()
+            .expect("Yolo mode should elevate the sandbox policy")
+            .has_network_access(),
+    );
+
+    // Plan mode is read-only investigation and does not register the shell
+    // tool, so it intentionally leaves the policy at the strict default.
+    assert!(
+        engine
+            .build_tool_context(AppMode::Plan, false)
+            .elevated_sandbox_policy
+            .is_none(),
+    );
+}
+
 #[tokio::test]
 async fn session_update_preserves_reasoning_tool_only_turn() {
     let (mut engine, handle) = Engine::new(EngineConfig::default(), &Config::default());


### PR DESCRIPTION
**DRAFT — security-relevant default change. Maintainer review requested.**

Closes #272 (independent confirmation from external user @francofang).

## Summary

In Agent mode (the default) every \`exec_shell\` command was wrapped in a seatbelt policy with \`(deny default)\` and no \`(allow network-outbound)\`, so DNS and outbound TCP/UDP failed at the kernel level. Symptom on macOS: \"DNS resolution failed\" for any URL the model tried to reach via \`curl\`, \`yt-dlp\`, package managers, …

External user repro (issue #272 from @francofang):

> Start DeepSeek TUI in Agent mode (default). Ask the agent to fetch external content (e.g. YouTube). DNS fails.
> Switching to YOLO mode resolves it. \`config.toml\` overrides have no effect.

## Root cause

\`engine.rs::build_tool_context\` only set \`elevated_sandbox_policy\` for **Yolo**. Agent fell through to \`ShellManager::sandbox_policy\` = \`SandboxPolicy::default()\` = \`WorkspaceWrite { network_access: false }\`. \`seatbelt::generate_policy\` only emits the network-allow block when \`policy.has_network_access()\` is true — confirmed by the existing test \`test_generate_policy_default\` (\"Default policy has no network\").

## Fix

Three-line shape change: \`if mode == Yolo\` → \`match mode\`, with Agent and Yolo both elevating to \`WorkspaceWrite { network_access: true }\`. Plan mode unchanged (read-only investigation never registers the shell tool).

Adds \`agent_and_yolo_modes_elevate_shell_sandbox_to_allow_network\` regression test so a future revert trips CI.

## Trade-off the maintainer should weigh

This removes the OS-level network block from sandboxed shell commands. The remaining boundary is the application-level \`NetworkPolicy\` (\`crates/tui/src/network_policy.rs\`) plus the per-shell approval flow. **Today \`NetworkPolicy\` only intercepts \`fetch_url\`, not shell commands** — so a model using \`curl\` to reach a denied host could route around the policy. The seatbelt block was kind-of closing that hole on macOS only; it's reopened by this PR.

Options if that residual hole matters:

1. Land this as-is for v0.8.4 — restores parity with Claude Code/Codex; #272 symptom goes away. File a follow-up to teach \`NetworkPolicy\` about shell-level egress.
2. Land this with a narrower policy (e.g. allow DNS + 80/443 only) — partial mitigation, more code.
3. Reject — keep the current behavior and document \"use Yolo for network workflows\".

Drafted (1) since it's the smallest fix that gets the user unstuck and matches what users expect from competitors.

## Test plan

- [x] \`cargo test -p deepseek-tui --bin deepseek-tui --locked sandbox\` (27/27)
- [x] \`cargo test -p deepseek-tui --bin deepseek-tui --locked core::engine\` (62/62, includes new regression)
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy -p deepseek-tui --all-targets --locked -- -D warnings\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)