### PR TITLE
docs(release): add install + dual-binary template to GitHub Release page

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,53 @@ jobs:
         with:
           files: artifacts/*/*
           prerelease: false
+          body: |
+            ## Install
+
+            ### Recommended — npm (one command, both binaries)
+
+            ```bash
+            npm install -g deepseek-tui
+            ```
+
+            The wrapper downloads both binaries from this Release and places them in the same directory.
+
+            ### Cargo (Linux / macOS)
+
+            ```bash
+            cargo install deepseek-tui-cli deepseek-tui --locked
+            ```
+
+            Both crates are required — `deepseek-tui-cli` produces the `deepseek` dispatcher and `deepseek-tui` produces the interactive runtime that the dispatcher delegates to. Installing only one binary will fail at runtime with a `MISSING_COMPANION_BINARY` error.
+
+            ### Manual download
+
+            **Both** binaries below must be downloaded for your platform and dropped into the same directory (e.g. `~/.local/bin/`):
+
+            | Platform | Dispatcher | TUI runtime |
+            |---|---|---|
+            | Linux x64 | `deepseek-linux-x64` | `deepseek-tui-linux-x64` |
+            | macOS x64 | `deepseek-macos-x64` | `deepseek-tui-macos-x64` |
+            | macOS ARM | `deepseek-macos-arm64` | `deepseek-tui-macos-arm64` |
+            | Windows x64 | `deepseek-windows-x64.exe` | `deepseek-tui-windows-x64.exe` |
+
+            Then `chmod +x` both (Unix) and run `./deepseek`.
+
+            ### Verify (recommended)
+
+            Download `deepseek-artifacts-sha256.txt` from this Release and verify:
+
+            ```bash
+            # Linux
+            sha256sum -c deepseek-artifacts-sha256.txt
+
+            # macOS
+            shasum -a 256 -c deepseek-artifacts-sha256.txt
+            ```
+
+            ## Changelog
+
+            See [CHANGELOG.md](https://github.com/Hmbown/DeepSeek-TUI/blob/main/CHANGELOG.md) for the full notes for this release.
 
 # npm publish is intentionally not automated. The npm account requires 2FA OTP
 # on every publish, and a granular automation token that bypasses 2FA has not


### PR DESCRIPTION
## Summary

Closes #265.

The Release page currently uses the auto-generated commit-title body. Adds a curated body template to the existing \`softprops/action-gh-release@v1\` step covering:

- **npm** (recommended) — \`npm install -g deepseek-tui\`
- **cargo** — \`cargo install deepseek-tui-cli deepseek-tui --locked\` (both crates required, with a one-line note on why)
- **Manual download** — per-platform table mapping the dispatcher and TUI artifacts so users grab both
- **sha256 verify** using the existing \`deepseek-artifacts-sha256.txt\` manifest the workflow already generates
- Pointer to \`CHANGELOG.md\`

The cargo line lists both crates rather than \`cargo install deepseek\`. The meta-crate work in #264 turns out to have a workspace-build collision (commented on the issue with the trade-offs); when that lands, this body just needs a one-line update.

## Test plan

- [x] Workflow YAML syntax check (the \`gh\` CLI exits 0 on parse during \`gh workflow view\`)
- [ ] First v0.8.4 Release renders the body correctly. (Can't verify ahead of release; the template is plain Markdown that GitHub renders natively, no expression substitutions inside.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hmbown/deepseek-tui/pull/275" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
