### PR TITLE
fix(skills): treat bare github.com/<owner>/<repo> URLs as GitHubRepo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   investigation never registers the shell tool). The application-level
   `NetworkPolicy` (`crates/tui/src/network_policy.rs`) remains the only
   outbound-traffic boundary.
+- **`/skill install <github-repo-url>` failed with `invalid gzip header`** (#269)
+  — `https://github.com/<owner>/<repo>` parsed as a raw direct URL, so the
+  installer downloaded the HTML repo page and tried to gzip-decode HTML.
+  Bare GitHub repo URLs (with or without `.git`, with or without `www.`,
+  with or without a trailing slash) now route to the `GitHubRepo` source the
+  same as `github:<owner>/<repo>`. URLs that already point at a specific
+  archive / blob / tree path still go through `DirectUrl`.
 - **V4 Pro discount expiry extended** (#267) — DeepSeek extended the V4 Pro 75%
   promotional discount from 2026-05-05 15:59 UTC to 2026-05-31 15:59 UTC. Without
   this update the TUI would have started showing 4× the actual billed cost on

--- a/crates/tui/src/skills/install.rs
+++ b/crates/tui/src/skills/install.rs
@@ -82,7 +82,9 @@ impl InstallSource {
     /// Parse a user-supplied spec. Empty / whitespace-only input is rejected.
     ///
     /// * `github:owner/repo` → [`InstallSource::GitHubRepo`]
-    /// * `http://` or `https://` prefix → [`InstallSource::DirectUrl`]
+    /// * `https://github.com/owner/repo[.git]` (no path past the repo) →
+    ///   [`InstallSource::GitHubRepo`]
+    /// * any other `http://` or `https://` prefix → [`InstallSource::DirectUrl`]
     /// * anything else → [`InstallSource::Registry`]
     pub fn parse(spec: &str) -> Result<Self> {
         let trimmed = spec.trim();
@@ -107,10 +109,41 @@ impl InstallSource {
             return Ok(Self::GitHubRepo(format!("{owner}/{repo}")));
         }
         if trimmed.starts_with("https://") || trimmed.starts_with("http://") {
+            if let Some(repo) = parse_github_browser_url(trimmed) {
+                return Ok(Self::GitHubRepo(repo));
+            }
             return Ok(Self::DirectUrl(trimmed.to_string()));
         }
         Ok(Self::Registry(trimmed.to_string()))
     }
+}
+
+/// Detect bare `https://github.com/<owner>/<repo>` URLs (with or without a
+/// trailing `.git`) and return `owner/repo`. Returns `None` for any URL that
+/// already points at a specific archive / blob / tree path — those are real
+/// direct URLs and the caller fetches them as-is.
+fn parse_github_browser_url(url: &str) -> Option<String> {
+    let after_scheme = url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("http://"))?;
+    let (host, rest) = after_scheme.split_once('/')?;
+    if !host.eq_ignore_ascii_case("github.com") && !host.eq_ignore_ascii_case("www.github.com") {
+        return None;
+    }
+    let trimmed = rest.trim_end_matches('/');
+    let mut parts = trimmed.splitn(3, '/');
+    let owner = parts.next()?.trim();
+    let repo = parts.next()?.trim().trim_end_matches(".git");
+    if owner.is_empty() || repo.is_empty() {
+        return None;
+    }
+    // If there is a third segment, the URL points at a sub-resource
+    // (`/archive/...`, `/blob/...`, `/tree/...`). Treat that as a real direct
+    // URL — the user explicitly wants whatever lives at that path.
+    if parts.next().is_some() {
+        return None;
+    }
+    Some(format!("{owner}/{repo}"))
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1032,6 +1065,47 @@ mod tests {
             s,
             InstallSource::DirectUrl("http://example.com/skill.tar.gz".to_string())
         );
+    }
+
+    #[test]
+    fn parse_github_browser_url_routes_to_github_repo() {
+        // Regression for #269: `https://github.com/<owner>/<repo>` was being
+        // parsed as a DirectUrl, so the installer downloaded the HTML repo
+        // page and tried to gzip-decode HTML ("invalid gzip header").
+        for spec in [
+            "https://github.com/obra/superpowers",
+            "https://github.com/obra/superpowers/",
+            "https://github.com/obra/superpowers.git",
+            "https://github.com/obra/superpowers.git/",
+            "https://www.github.com/obra/superpowers",
+            "http://github.com/obra/superpowers",
+            "  https://github.com/obra/superpowers  ",
+        ] {
+            let parsed = InstallSource::parse(spec)
+                .unwrap_or_else(|err| panic!("parse({spec}) failed: {err}"));
+            assert_eq!(
+                parsed,
+                InstallSource::GitHubRepo("obra/superpowers".to_string()),
+                "spec {spec} must route to GitHubRepo",
+            );
+        }
+    }
+
+    #[test]
+    fn parse_github_archive_url_stays_direct() {
+        // URLs that point at a specific subresource (archive tarball, blob,
+        // tree) are real direct URLs — the user picked that exact path.
+        for spec in [
+            "https://github.com/obra/superpowers/archive/refs/heads/main.tar.gz",
+            "https://github.com/obra/superpowers/blob/main/README.md",
+            "https://github.com/obra/superpowers/tree/main",
+        ] {
+            let parsed = InstallSource::parse(spec).unwrap();
+            assert!(
+                matches!(parsed, InstallSource::DirectUrl(_)),
+                "spec {spec} must stay DirectUrl, got {parsed:?}",
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #269 (\`安装不了 superpowers\` / \"invalid gzip header\" reported by @bigfoot88).

\`/skill install https://github.com/obra/superpowers\` failed with \`invalid gzip header\` because \`InstallSource::parse\` routed any \`https://\`-prefixed spec to \`DirectUrl\`. The installer downloaded the HTML repo page (200 OK, \`text/html\`) and \`GzDecoder\` choked.

| URL                                                                          | Before              | After (this PR)             |
|------------------------------------------------------------------------------|---------------------|-----------------------------|
| \`github:obra/superpowers\`                                                  | \`GitHubRepo\`      | \`GitHubRepo\` (unchanged)  |
| \`https://github.com/obra/superpowers\`                                      | \`DirectUrl\` (HTML) | \`GitHubRepo\`              |
| \`https://github.com/obra/superpowers/\`                                     | \`DirectUrl\`       | \`GitHubRepo\`              |
| \`https://github.com/obra/superpowers.git\`                                  | \`DirectUrl\`       | \`GitHubRepo\`              |
| \`https://www.github.com/obra/superpowers\`                                  | \`DirectUrl\`       | \`GitHubRepo\`              |
| \`http://github.com/obra/superpowers\`                                       | \`DirectUrl\`       | \`GitHubRepo\`              |
| \`https://github.com/obra/superpowers/archive/refs/heads/main.tar.gz\`       | \`DirectUrl\`       | \`DirectUrl\` (unchanged)   |
| \`https://github.com/obra/superpowers/blob/main/README.md\`                  | \`DirectUrl\`       | \`DirectUrl\` (unchanged)   |
| \`https://example.com/skill.tar.gz\`                                         | \`DirectUrl\`       | \`DirectUrl\` (unchanged)   |

The platform was a red herring: the user reported Win11 + PowerShell + 0.8.1 but the parse path is platform-independent. The macOS happy path was confirmed working pre-fix on \`https://github.com/obra/superpowers/archive/refs/heads/main.tar.gz\` and post-fix on \`https://github.com/obra/superpowers\`.

## Test plan

- [x] \`cargo test -p deepseek-tui --bin deepseek-tui --locked install\` (25/25, includes 2 new regressions)
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy -p deepseek-tui --all-targets --locked -- -D warnings\`
- [ ] Maintainer to confirm \`/skill install https://github.com/obra/superpowers\` succeeds on a release build before closing #269.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hmbown/deepseek-tui/pull/276" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
