### PR TITLE
feat(debug): add /cache command surfacing per-turn DeepSeek cache hit/miss

### DIFF
--- a/crates/tui/src/commands/debug.rs
+++ b/crates/tui/src/commands/debug.rs
@@ -2,10 +2,12 @@
 
 //! Debug commands: tokens, cost, system, context, undo, retry
 
+use std::time::Instant;
+
 use super::CommandResult;
 use crate::compaction::estimate_input_tokens_conservative;
 use crate::models::{SystemPrompt, context_window_for_model};
-use crate::tui::app::{App, AppAction};
+use crate::tui::app::{App, AppAction, TurnCacheRecord};
 use crate::tui::history::HistoryCell;
 
 fn token_count(value: Option<u32>) -> String {
@@ -119,6 +121,149 @@ pub fn system_prompt(app: &mut App) -> CommandResult {
 /// Show context window usage
 pub fn context(_app: &mut App) -> CommandResult {
     CommandResult::action(AppAction::OpenContextInspector)
+}
+
+/// Show per-turn DeepSeek prefix-cache telemetry for the last N turns (#263).
+///
+/// `arg` is parsed as a count override (default 10, capped at the ring size).
+/// Renders a fixed-width table the user can paste into a bug report.
+pub fn cache(app: &mut App, arg: Option<&str>) -> CommandResult {
+    let want = arg
+        .and_then(|s| s.trim().parse::<usize>().ok())
+        .unwrap_or(10);
+    let cap = app.turn_cache_history.len();
+    let count = want
+        .min(cap)
+        .min(crate::tui::app::App::TURN_CACHE_HISTORY_CAP);
+
+    if cap == 0 {
+        return CommandResult::message(
+            "Cache history: no turns recorded yet.\n\n\
+             DeepSeek surfaces `prompt_cache_hit_tokens` / `prompt_cache_miss_tokens` \
+             on every API turn that the model supports it (V4 family). Run a turn \
+             and try /cache again.",
+        );
+    }
+
+    CommandResult::message(format_cache_history(app, count))
+}
+
+fn format_cache_history(app: &App, count: usize) -> String {
+    let total = app.turn_cache_history.len();
+    let start = total.saturating_sub(count);
+    let rows: Vec<&TurnCacheRecord> = app.turn_cache_history.iter().skip(start).collect();
+
+    let mut totals_input: u64 = 0;
+    let mut totals_hit: u64 = 0;
+    let mut totals_miss: u64 = 0;
+    let mut header = format!(
+        "Cache telemetry — last {} of {} turn(s) (model: {})\n",
+        rows.len(),
+        total,
+        app.model
+    );
+    header.push_str(&"─".repeat(76));
+    header.push('\n');
+    header.push_str("turn   in    out   hit   miss   replay   ratio   age\n");
+    header.push_str(&"─".repeat(76));
+    header.push('\n');
+
+    let now = Instant::now();
+    let mut body = String::new();
+    let absolute_start = total.saturating_sub(rows.len());
+    for (i, rec) in rows.iter().enumerate() {
+        let turn_index = absolute_start + i + 1;
+        totals_input += u64::from(rec.input_tokens);
+
+        let replay_cell = rec
+            .reasoning_replay_tokens
+            .map_or_else(|| "—".to_string(), |t| t.to_string());
+        let age = humanize_age(now.saturating_duration_since(rec.recorded_at));
+
+        // No cache telemetry → render `—` everywhere and don't pollute totals
+        // with inferred zeros. Some providers (and some routes inside DeepSeek)
+        // skip the cache fields; including a synthesized 0/N for those turns
+        // would make every aggregate ratio look broken.
+        let Some(hit) = rec.cache_hit_tokens else {
+            body.push_str(&format!(
+                "{turn:>4}  {input:>5}  {output:>5}  {hit:>5}  {miss:>5}  {replay:>6}   {ratio:>6}   {age}\n",
+                turn = turn_index,
+                input = rec.input_tokens,
+                output = rec.output_tokens,
+                hit = "—",
+                miss = "—",
+                replay = replay_cell,
+                ratio = "—",
+                age = age,
+            ));
+            continue;
+        };
+
+        let miss_reported = rec.cache_miss_tokens;
+        let miss = miss_reported.unwrap_or_else(|| rec.input_tokens.saturating_sub(hit));
+        let accounted = u64::from(hit) + u64::from(miss);
+        let ratio = if accounted == 0 {
+            "    —".to_string()
+        } else {
+            format!("{:>5.1}%", 100.0 * f64::from(hit) / accounted as f64)
+        };
+        totals_hit += u64::from(hit);
+        totals_miss += u64::from(miss);
+
+        let miss_cell = match miss_reported {
+            Some(_) => format!("{miss}"),
+            None => format!("{miss}*"),
+        };
+
+        body.push_str(&format!(
+            "{turn:>4}  {input:>5}  {output:>5}  {hit:>5}  {miss:>5}  {replay:>6}   {ratio}   {age}\n",
+            turn = turn_index,
+            input = rec.input_tokens,
+            output = rec.output_tokens,
+            hit = hit,
+            miss = miss_cell,
+            replay = replay_cell,
+            ratio = ratio,
+            age = age,
+        ));
+    }
+
+    let totals_accounted = totals_hit + totals_miss;
+    let avg_ratio = if totals_accounted == 0 {
+        "—".to_string()
+    } else {
+        format!(
+            "{:.1}%",
+            100.0 * totals_hit as f64 / totals_accounted as f64
+        )
+    };
+
+    let mut footer = String::new();
+    footer.push_str(&"─".repeat(76));
+    footer.push('\n');
+    footer.push_str(&format!(
+        "Σ in: {totals_input}   Σ hit: {totals_hit}   Σ miss: {totals_miss}   avg hit ratio: {avg_ratio}\n",
+    ));
+    footer.push_str(
+        "* miss inferred from input − hit when the provider did not report it explicitly.\n",
+    );
+    footer.push_str(
+        "Hit/miss ratios over ~70% after the third turn indicate a stable cache prefix; \n\
+         lower than that on long sessions suggests prefix churn worth investigating (#263).",
+    );
+
+    format!("{header}{body}{footer}")
+}
+
+fn humanize_age(d: std::time::Duration) -> String {
+    let secs = d.as_secs();
+    if secs < 60 {
+        format!("{secs}s")
+    } else if secs < 3600 {
+        format!("{}m{:02}s", secs / 60, secs % 60)
+    } else {
+        format!("{}h{:02}m", secs / 3600, (secs % 3600) / 60)
+    }
 }
 
 #[cfg(test)]
@@ -254,6 +399,115 @@ mod tests {
         let msg = result.message.unwrap();
         assert!(msg.contains("..."));
         assert!(msg.contains("chars total"));
+    }
+
+    #[test]
+    fn cache_command_reports_no_data_before_first_turn() {
+        let mut app = create_test_app();
+        let result = cache(&mut app, None);
+        let msg = result.message.expect("cache produces a message");
+        assert!(msg.contains("no turns recorded yet"), "got: {msg}");
+    }
+
+    #[test]
+    fn cache_command_renders_recorded_turns_with_ratio() {
+        let mut app = create_test_app();
+        let now = Instant::now();
+        // Three turns: 75% hit, 50% hit, miss-only (provider didn't report hit).
+        app.push_turn_cache_record(TurnCacheRecord {
+            input_tokens: 4_000,
+            output_tokens: 200,
+            cache_hit_tokens: Some(3_000),
+            cache_miss_tokens: Some(1_000),
+            reasoning_replay_tokens: None,
+            recorded_at: now,
+        });
+        app.push_turn_cache_record(TurnCacheRecord {
+            input_tokens: 6_000,
+            output_tokens: 250,
+            cache_hit_tokens: Some(3_000),
+            cache_miss_tokens: Some(3_000),
+            reasoning_replay_tokens: Some(150),
+            recorded_at: now,
+        });
+        // Turn 3: hit reported but provider didn't report miss separately —
+        // infer miss = input − hit and mark with `*`.
+        app.push_turn_cache_record(TurnCacheRecord {
+            input_tokens: 5_000,
+            output_tokens: 100,
+            cache_hit_tokens: Some(2_500),
+            cache_miss_tokens: None,
+            reasoning_replay_tokens: None,
+            recorded_at: now,
+        });
+        // Turn 4: no telemetry at all — must not pollute aggregate ratios.
+        app.push_turn_cache_record(TurnCacheRecord {
+            input_tokens: 1_000,
+            output_tokens: 50,
+            cache_hit_tokens: None,
+            cache_miss_tokens: None,
+            reasoning_replay_tokens: None,
+            recorded_at: now,
+        });
+
+        let result = cache(&mut app, None);
+        let msg = result.message.expect("cache produces a message");
+
+        // Header reflects total rows and model.
+        assert!(msg.contains("last 4 of 4 turn(s)"), "got: {msg}");
+        // Per-turn ratios are rendered.
+        assert!(msg.contains("75.0%"), "got: {msg}");
+        assert!(msg.contains("50.0%"), "got: {msg}");
+        // Turn 3: hit=2500, inferred miss=2500 → 50.0% with `*`-marked miss.
+        assert!(msg.contains("2500*"), "got: {msg}");
+        // Turn 4 (no telemetry) shows em-dashes and is excluded from totals.
+        // Aggregate over turns 1-3: hit=8500, miss=6500 → 56.7%.
+        assert!(msg.contains("avg hit ratio: 56.7%"), "got: {msg}");
+        // Footer guidance is present.
+        assert!(msg.contains("70%"), "got: {msg}");
+    }
+
+    #[test]
+    fn cache_command_count_argument_clamps_to_history() {
+        let mut app = create_test_app();
+        for _ in 0..3 {
+            app.push_turn_cache_record(TurnCacheRecord {
+                input_tokens: 1_000,
+                output_tokens: 100,
+                cache_hit_tokens: Some(500),
+                cache_miss_tokens: Some(500),
+                reasoning_replay_tokens: None,
+                recorded_at: Instant::now(),
+            });
+        }
+        let result = cache(&mut app, Some("100"));
+        let msg = result.message.expect("cache produces a message");
+        // Asked for 100 turns, only 3 exist — should report "last 3 of 3".
+        assert!(msg.contains("last 3 of 3 turn(s)"), "got: {msg}");
+    }
+
+    #[test]
+    fn turn_cache_history_is_capped_at_50() {
+        let mut app = create_test_app();
+        for i in 0..(crate::tui::app::App::TURN_CACHE_HISTORY_CAP + 12) {
+            app.push_turn_cache_record(TurnCacheRecord {
+                input_tokens: i as u32,
+                output_tokens: 1,
+                cache_hit_tokens: Some(i as u32),
+                cache_miss_tokens: Some(0),
+                reasoning_replay_tokens: None,
+                recorded_at: Instant::now(),
+            });
+        }
+        assert_eq!(
+            app.turn_cache_history.len(),
+            crate::tui::app::App::TURN_CACHE_HISTORY_CAP
+        );
+        // Oldest record was evicted; newest record is still at the back.
+        assert_eq!(
+            app.turn_cache_history.back().unwrap().input_tokens,
+            (crate::tui::app::App::TURN_CACHE_HISTORY_CAP + 11) as u32
+        );
     }
 
     #[test]

--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -372,6 +372,13 @@ pub const COMMANDS: &[CommandInfo] = &[
         description: "Show session cost breakdown",
         usage: "/cost",
     },
+    // Cache telemetry (#263)
+    CommandInfo {
+        name: "cache",
+        aliases: &[],
+        description: "Show DeepSeek prefix-cache hit/miss stats for the last N turns",
+        usage: "/cache [count]",
+    },
 ];
 
 /// Execute a slash command
@@ -423,6 +430,7 @@ pub fn execute(cmd: &str, app: &mut App) -> CommandResult {
         // Debug commands
         "tokens" => debug::tokens(app),
         "cost" => debug::cost(app),
+        "cache" => debug::cache(app, arg),
         "system" => debug::system_prompt(app),
         "context" | "ctx" => debug::context(app),
         "undo" => debug::undo(app),

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -59,6 +59,32 @@ pub enum AppMode {
     Plan,
 }
 
+/// One row in the per-turn cache-telemetry ring (`/cache` debug surface, #263).
+#[derive(Debug, Clone)]
+pub struct TurnCacheRecord {
+    /// Provider-reported total input tokens for the turn (cache-hit +
+    ///   cache-miss + uncategorized). Useful for sanity-checking that hits +
+    ///   misses sum back to roughly the prompt size.
+    pub input_tokens: u32,
+    /// Provider-reported output tokens.
+    pub output_tokens: u32,
+    /// `prompt_cache_hit_tokens` from DeepSeek's usage payload. `None` when
+    ///   the model in use does not report cache telemetry (see
+    ///   `Capabilities::cache_telemetry_supported`).
+    pub cache_hit_tokens: Option<u32>,
+    /// `prompt_cache_miss_tokens`. `None` when the provider did not report it
+    ///   — in that case the `/cache` formatter infers the miss as
+    ///   `input_tokens − cache_hit_tokens`.
+    pub cache_miss_tokens: Option<u32>,
+    /// Approximate tokens spent re-sending prior `reasoning_content` on
+    ///   V4-thinking tool-calling turns (chars/3 heuristic). Helps separate
+    ///   cache misses caused by reasoning-replay churn from misses caused by
+    ///   real prefix instability.
+    pub reasoning_replay_tokens: Option<u32>,
+    /// Local timestamp the turn telemetry was recorded.
+    pub recorded_at: Instant,
+}
+
 /// DeepSeek reasoning-effort tier, mirrored on ChatGPT/Claude effort pickers.
 ///
 /// The config file accepts all five string values for forward-compat with
@@ -666,6 +692,9 @@ pub struct App {
     pub last_prompt_cache_hit_tokens: Option<u32>,
     /// DeepSeek context-cache miss tokens from the last API call. Telemetry only.
     pub last_prompt_cache_miss_tokens: Option<u32>,
+    /// Per-turn cache telemetry ring (`/cache` debug surface, #263). Newest
+    /// turn at the back. Capped at [`Self::TURN_CACHE_HISTORY_CAP`].
+    pub turn_cache_history: VecDeque<TurnCacheRecord>,
     /// Approximate input tokens spent re-sending prior `reasoning_content` on
     /// the last thinking-mode tool-calling turn (V4 §5.1.1 "Interleaved
     /// Thinking"). Computed client-side at ~4 chars/token.
@@ -790,6 +819,19 @@ pub enum ApiKeyError {
 // === App State ===
 
 impl App {
+    /// Cap on [`Self::turn_cache_history`]. Holds enough turns to debug a long
+    /// session without being so large the on-screen `/cache` table wraps.
+    pub const TURN_CACHE_HISTORY_CAP: usize = 50;
+
+    /// Append a per-turn cache-telemetry record, trimming the oldest entry once
+    /// the ring exceeds [`Self::TURN_CACHE_HISTORY_CAP`].
+    pub fn push_turn_cache_record(&mut self, record: TurnCacheRecord) {
+        self.turn_cache_history.push_back(record);
+        while self.turn_cache_history.len() > Self::TURN_CACHE_HISTORY_CAP {
+            self.turn_cache_history.pop_front();
+        }
+    }
+
     pub fn tr(&self, id: MessageId) -> &'static str {
         tr(self.ui_locale, id)
     }
@@ -1039,6 +1081,7 @@ impl App {
             last_completion_tokens: None,
             last_prompt_cache_hit_tokens: None,
             last_prompt_cache_miss_tokens: None,
+            turn_cache_history: VecDeque::new(),
             last_reasoning_replay_tokens: None,
             workspace_context: None,
             workspace_context_refreshed_at: None,

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -716,6 +716,14 @@ async fn run_event_loop(
                         app.last_prompt_cache_hit_tokens = usage.prompt_cache_hit_tokens;
                         app.last_prompt_cache_miss_tokens = usage.prompt_cache_miss_tokens;
                         app.last_reasoning_replay_tokens = usage.reasoning_replay_tokens;
+                        app.push_turn_cache_record(crate::tui::app::TurnCacheRecord {
+                            input_tokens: usage.input_tokens,
+                            output_tokens: usage.output_tokens,
+                            cache_hit_tokens: usage.prompt_cache_hit_tokens,
+                            cache_miss_tokens: usage.prompt_cache_miss_tokens,
+                            reasoning_replay_tokens: usage.reasoning_replay_tokens,
+                            recorded_at: Instant::now(),
+                        });
                         if let Some(error) = error {
                             app.status_message = Some(format!("Turn failed: {error}"));
                         }


### PR DESCRIPTION
## Summary

Step 1 of #263 — without per-turn cache telemetry on screen the prefix-cache audit is unfounded speculation. This adds the foundation.

The DeepSeek API already returns \`prompt_cache_hit_tokens\` / \`prompt_cache_miss_tokens\` per turn, and we already store the *latest* values on \`App\`. This adds:

- \`App::turn_cache_history: VecDeque<TurnCacheRecord>\` — 50-turn ring populated at the same site as \`last_prompt_cache_*_tokens\` (\`tui/ui.rs:716\`)
- \`/cache [count]\` slash command (default count 10, clamps to ring size) that renders a fixed-width table the user can paste into a bug report:

\`\`\`
Cache telemetry — last 4 of 4 turn(s) (model: deepseek-v4-pro)
────────────────────────────────────────────────────────────────────────────
turn   in    out   hit   miss   replay   ratio   age
────────────────────────────────────────────────────────────────────────────
   1   4000    200   3000   1000       —    75.0%   0s
   2   6000    250   3000   3000     150    50.0%   0s
   3   5000    100   2500  2500*       —    50.0%   0s
   4   1000     50      —      —       —        —   0s
────────────────────────────────────────────────────────────────────────────
Σ in: 16000   Σ hit: 8500   Σ miss: 6500   avg hit ratio: 56.7%
* miss inferred from input − hit when the provider did not report it explicitly.
Hit/miss ratios over ~70% after the third turn indicate a stable cache prefix; …
\`\`\`

## Edge cases handled by the formatter

- **No telemetry yet** → friendly \"no turns recorded\" message instead of an empty table
- **\`cache_hit_tokens = None\`** (provider didn't report) → row renders em-dashes and is excluded from aggregates, so one missing-telemetry turn can't make the average look broken
- **\`cache_hit_tokens = Some, cache_miss_tokens = None\`** → infer miss as \`input − hit\` and mark with \`*\`; footer documents the asterisk
- **Ring at cap (50)** → push evicts oldest

All four paths are covered by tests; the regression test \`turn_cache_history_is_capped_at_50\` pins the cap.

## What this unlocks

With per-turn telemetry on screen, step 2 of the audit (byte-diff harness) can be measurably driven. Step 3 (suspect-by-suspect bisection) can verify each fix with \`/cache\` showing the ratio jump.

## Test plan

- [x] \`cargo test -p deepseek-tui --bin deepseek-tui --locked\` (1742/1744 — 2 ignored unrelated)
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy -p deepseek-tui --all-targets --locked -- -D warnings\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hmbown/deepseek-tui/pull/278" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
