### PR TITLE
fix(cache): make tool catalog byte-stable across calls and sessions (#263)

### DIFF
--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -3,6 +3,7 @@ use super::*;
 use super::context::WORKING_SET_SUMMARY_MARKER;
 use crate::models::SystemBlock;
 use serde_json::json;
+use std::collections::HashSet;
 use std::fs;
 use std::path::PathBuf;
 use std::time::Instant;
@@ -256,6 +257,63 @@ fn model_tool_catalog_keeps_everything_loaded_in_yolo_mode() {
     );
 
     assert!(catalog.iter().all(|tool| tool.defer_loading == Some(false)));
+}
+
+#[test]
+fn model_tool_catalog_sorts_each_partition_for_prefix_cache_stability() {
+    // Regression for #263: deterministic byte order of the tools array is a
+    // hard requirement for DeepSeek's KV prefix cache. Built-ins stay as a
+    // contiguous prefix; MCP tools follow. Within each partition: alphabetical.
+    let catalog = build_model_tool_catalog(
+        vec![
+            api_tool("read_file"),
+            api_tool("apply_patch"),
+            api_tool("exec_shell"),
+        ],
+        vec![api_tool("mcp_zoo_b"), api_tool("mcp_aardvark_a")],
+        AppMode::Yolo,
+    );
+
+    let names: Vec<&str> = catalog.iter().map(|t| t.name.as_str()).collect();
+    assert_eq!(
+        names,
+        vec![
+            "apply_patch",
+            "exec_shell",
+            "read_file",
+            "mcp_aardvark_a",
+            "mcp_zoo_b",
+        ],
+        "built-ins must be alphabetical and contiguous; MCP tools follow, alphabetical",
+    );
+}
+
+#[test]
+fn active_tool_list_pushes_deferred_activations_to_the_tail() {
+    // Regression for #263: when ToolSearch activates a deferred tool mid-
+    // session, it must NOT be inserted at its catalog index — that would
+    // shift every later tool's byte offset and bust the cached prefix.
+    // Deferred-but-now-active tools belong at the tail.
+    let mut a = api_tool("a_load_now");
+    a.defer_loading = Some(false);
+    let mut search = api_tool("search_via_toolsearch");
+    search.defer_loading = Some(true);
+    let mut b = api_tool("b_load_now");
+    b.defer_loading = Some(false);
+
+    let catalog = vec![a, search, b];
+    let active: HashSet<String> = ["a_load_now", "search_via_toolsearch", "b_load_now"]
+        .into_iter()
+        .map(String::from)
+        .collect();
+
+    let listed = active_tools_for_step(&catalog, &active, false);
+    let names: Vec<&str> = listed.iter().map(|t| t.name.as_str()).collect();
+    assert_eq!(
+        names,
+        vec!["a_load_now", "b_load_now", "search_via_toolsearch"],
+        "deferred-but-active tools must come after always-loaded tools",
+    );
 }
 
 #[test]

--- a/crates/tui/src/core/engine/tool_catalog.rs
+++ b/crates/tui/src/core/engine/tool_catalog.rs
@@ -105,6 +105,14 @@ pub(super) fn build_model_tool_catalog(
 ) -> Vec<Tool> {
     apply_native_tool_deferral(&mut native_tools, mode);
     apply_mcp_tool_deferral(&mut mcp_tools, mode);
+    // Sort each partition by name for prefix-cache stability (#263). The
+    // upstream `to_api_tools()` already sorts the registry's HashMap output;
+    // this catalog is built from caller-supplied Vecs which the test harness
+    // and (future) caller refactors may not pre-sort. Built-ins stay as a
+    // contiguous prefix ahead of MCP tools so adding/removing an MCP tool
+    // never shifts a built-in's position.
+    native_tools.sort_by(|a, b| a.name.cmp(&b.name));
+    mcp_tools.sort_by(|a, b| a.name.cmp(&b.name));
     native_tools.extend(mcp_tools);
     native_tools
 }
@@ -188,11 +196,25 @@ pub(super) fn initial_active_tools(catalog: &[Tool]) -> HashSet<String> {
 }
 
 fn active_tool_list_from_catalog(catalog: &[Tool], active: &HashSet<String>) -> Vec<Tool> {
-    catalog
-        .iter()
-        .filter(|tool| active.contains(&tool.name))
-        .cloned()
-        .collect()
+    // Two-pass for prefix-cache stability (#263). Always-loaded tools come
+    // first in their stable catalog order; tools that started life deferred
+    // and were activated mid-conversation by ToolSearch get appended at the
+    // tail. Otherwise activating a deferred tool shifts every later tool's
+    // byte offset and busts the cached prefix from that point onwards.
+    let mut head: Vec<Tool> = Vec::new();
+    let mut tail: Vec<Tool> = Vec::new();
+    for tool in catalog {
+        if !active.contains(&tool.name) {
+            continue;
+        }
+        if tool.defer_loading.unwrap_or(false) {
+            tail.push(tool.clone());
+        } else {
+            head.push(tool.clone());
+        }
+    }
+    head.extend(tail);
+    head
 }
 
 pub(super) fn active_tools_for_step(

--- a/crates/tui/src/tools/registry.rs
+++ b/crates/tui/src/tools/registry.rs
@@ -133,10 +133,19 @@ impl ToolRegistry {
     }
 
     /// Convert all tools to API Tool format for sending to the model.
+    ///
+    /// Output is sorted by tool name for **prefix-cache stability** (#263).
+    /// Rust's `HashMap` uses a randomly-seeded hasher per process, so a raw
+    /// `self.tools.values()` iteration emits tools in a different order on
+    /// every `deepseek` launch, invalidating DeepSeek's KV prefix cache for
+    /// every cross-session resume. Sorting here matches the way Claude Code
+    /// stabilises its tool array (`assembleToolPool` in their reference).
     #[must_use]
     pub fn to_api_tools(&self) -> Vec<Tool> {
-        self.tools
-            .values()
+        let mut tools: Vec<&Arc<dyn ToolSpec>> = self.tools.values().collect();
+        tools.sort_by(|a, b| a.name().cmp(b.name()));
+        tools
+            .into_iter()
             .map(|tool| Tool {
                 tool_type: None,
                 name: tool.name().to_string(),
@@ -830,6 +839,44 @@ mod tests {
         assert_eq!(api_tools.len(), 1);
         assert_eq!(api_tools[0].name, "my_tool");
         assert_eq!(api_tools[0].description, "A test tool");
+    }
+
+    #[test]
+    fn to_api_tools_emits_alphabetical_order_regardless_of_registration_order() {
+        // Regression for #263: HashMap iteration is non-deterministic across
+        // process launches, which busts DeepSeek's KV prefix cache for every
+        // cross-session resume. `to_api_tools` must emit by name regardless
+        // of registration order so two consecutive calls (and two distinct
+        // launches) produce byte-identical output.
+        let tmp = tempdir().expect("tempdir");
+        let ctx = ToolContext::new(tmp.path().to_path_buf());
+
+        let order_a = {
+            let mut registry = ToolRegistry::new(ctx.clone());
+            registry.register(make_test_tool("zebra"));
+            registry.register(make_test_tool("alpha"));
+            registry.register(make_test_tool("mango"));
+            registry
+                .to_api_tools()
+                .iter()
+                .map(|t| t.name.clone())
+                .collect::<Vec<_>>()
+        };
+
+        let order_b = {
+            let mut registry = ToolRegistry::new(ctx.clone());
+            registry.register(make_test_tool("alpha"));
+            registry.register(make_test_tool("mango"));
+            registry.register(make_test_tool("zebra"));
+            registry
+                .to_api_tools()
+                .iter()
+                .map(|t| t.name.clone())
+                .collect::<Vec<_>>()
+        };
+
+        assert_eq!(order_a, vec!["alpha", "mango", "zebra"]);
+        assert_eq!(order_a, order_b);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The biggest single cache-prefix-stability win surfaced by the side-by-side comparison with reference-cc (Claude Code source). Refs #263.

The DeepSeek KV cache hits on the longest matching byte prefix of the request. Two places in the tool-array path were silently busting it:

| # | What | Before | After |
|---|---|---|---|
| 1 | \`ToolRegistry::to_api_tools()\` | iterated \`self.tools.values()\` directly. \`HashMap\` uses \`RandomState\` per process → every \`deepseek\` launch produced a different tool order, so cross-session prefix cache never hit. | Sort by tool name before emit. Stable across calls AND across launches. |
| 2 | \`build_model_tool_catalog()\` | took caller-supplied Vecs as-is. | Sort each partition; built-ins stay as a contiguous prefix, MCP tools follow. |
| 3 | \`active_tool_list_from_catalog()\` | filtered the catalog Vec in catalog order. ToolSearch activating a previously-deferred tool mid-conversation shifted every later tool's byte offset, busting the cache from there. | Two-pass: always-loaded tools head, deferred-but-now-active tools tail. |

This mirrors how reference-cc's \`assembleToolPool\` (\`reference-cc/src/tools.ts:345-367\`) handles the same problem. Their comment on it: *\"Sort each partition for prompt-cache stability, keeping built-ins as a contiguous prefix. … a flat sort would interleave MCP tools into built-ins and invalidate all downstream cache keys whenever an MCP tool sorts between existing built-ins.\"*

## Regression tests added

- \`to_api_tools_emits_alphabetical_order_regardless_of_registration_order\` — register the same tools in two different orders, assert the API output is identical
- \`model_tool_catalog_sorts_each_partition_for_prefix_cache_stability\` — pin builtins-then-MCP-each-alphabetical
- \`active_tool_list_pushes_deferred_activations_to_the_tail\` — pin that deferred-tool activation doesn't shift earlier tools

## What this does NOT fix (separate follow-ups, in priority order)

1. **Working-set summary block churn (#280)** — \`age\` and \`touches\` interpolation in the system prompt. Filed; ready for a focused PR.
2. **Handoff block placement** — volatile content in the middle of the system prompt. (Finding 6 in the audit; not yet filed as an issue.)
3. **Tool schema cache** — \`tool.description()\` re-invoked every turn; OK today (descriptions are \`&'static str\`) but no guard against future MCP-reconnect or conditional descriptions. (Finding 4.)

## Test plan

- [x] \`cargo test -p deepseek-tui --bin deepseek-tui --locked\` (1741/1743 — 2 ignored unrelated)
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy -p deepseek-tui --all-targets --locked -- -D warnings\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)