### PR TITLE
fix(cache): drop volatile fields from working_set summary block (#280)

### DIFF
--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -433,41 +433,7 @@ mod tests {
     // in the cached prefix must produce identical bytes given identical
     // inputs across calls.
 
-    /// Find the byte position of the first divergence between two strings,
-    /// returning a windowed view (`±32 bytes` around the divergence) for
-    /// human-readable failure output.
-    fn first_divergence(a: &str, b: &str) -> Option<(usize, String, String)> {
-        let a_bytes = a.as_bytes();
-        let b_bytes = b.as_bytes();
-        let max = a_bytes.len().min(b_bytes.len());
-        for i in 0..max {
-            if a_bytes[i] != b_bytes[i] {
-                let lo = i.saturating_sub(32);
-                let a_hi = (i + 32).min(a_bytes.len());
-                let b_hi = (i + 32).min(b_bytes.len());
-                let a_ctx = String::from_utf8_lossy(&a_bytes[lo..a_hi]).into_owned();
-                let b_ctx = String::from_utf8_lossy(&b_bytes[lo..b_hi]).into_owned();
-                return Some((i, a_ctx, b_ctx));
-            }
-        }
-        if a_bytes.len() != b_bytes.len() {
-            return Some((
-                max,
-                format!("(len={})", a_bytes.len()),
-                format!("(len={})", b_bytes.len()),
-            ));
-        }
-        None
-    }
-
-    fn assert_byte_identical(label: &str, a: &str, b: &str) {
-        if let Some((pos, a_ctx, b_ctx)) = first_divergence(a, b) {
-            panic!(
-                "{label}: prompt construction is non-deterministic — first diff at byte {pos}\n\
-                 ── side A (±32B) ──\n{a_ctx:?}\n── side B (±32B) ──\n{b_ctx:?}",
-            );
-        }
-    }
+    use crate::test_support::assert_byte_identical;
 
     #[test]
     fn compose_prompt_is_byte_stable_across_calls() {

--- a/crates/tui/src/test_support.rs
+++ b/crates/tui/src/test_support.rs
@@ -17,3 +17,45 @@ pub(crate) fn lock_test_env() -> MutexGuard<'static, ()> {
         Err(poisoned) => poisoned.into_inner(),
     }
 }
+
+/// Find the byte position of the first divergence between two strings,
+/// returning a windowed view (`±32 bytes` around the divergence) so failures
+/// in cache-prefix-stability tests show *which* bytes drifted, not just that
+/// they did. Returns `None` when the strings are byte-identical.
+pub(crate) fn first_divergence(a: &str, b: &str) -> Option<(usize, String, String)> {
+    let a_bytes = a.as_bytes();
+    let b_bytes = b.as_bytes();
+    let max = a_bytes.len().min(b_bytes.len());
+    for i in 0..max {
+        if a_bytes[i] != b_bytes[i] {
+            let lo = i.saturating_sub(32);
+            let a_hi = (i + 32).min(a_bytes.len());
+            let b_hi = (i + 32).min(b_bytes.len());
+            let a_ctx = String::from_utf8_lossy(&a_bytes[lo..a_hi]).into_owned();
+            let b_ctx = String::from_utf8_lossy(&b_bytes[lo..b_hi]).into_owned();
+            return Some((i, a_ctx, b_ctx));
+        }
+    }
+    if a_bytes.len() != b_bytes.len() {
+        return Some((
+            max,
+            format!("(len={})", a_bytes.len()),
+            format!("(len={})", b_bytes.len()),
+        ));
+    }
+    None
+}
+
+/// Assert two strings are byte-identical, panicking with a windowed diff
+/// around the first divergence when they aren't. Used by the prefix-cache
+/// stability harness (#263, #280) to pin construction surfaces that land in
+/// DeepSeek's KV cache prefix.
+#[track_caller]
+pub(crate) fn assert_byte_identical(label: &str, a: &str, b: &str) {
+    if let Some((pos, a_ctx, b_ctx)) = first_divergence(a, b) {
+        panic!(
+            "{label}: prompt construction is non-deterministic — first diff at byte {pos}\n\
+             ── side A (±32B) ──\n{a_ctx:?}\n── side B (±32B) ──\n{b_ctx:?}",
+        );
+    }
+}

--- a/crates/tui/src/working_set.rs
+++ b/crates/tui/src/working_set.rs
@@ -380,9 +380,17 @@ impl WorkingSet {
     }
 
     /// Render a compact working-set block for the system prompt.
+    ///
+    /// Byte-stable across `next_turn()` calls when no new paths are observed
+    /// (#280): the rendered lines drop the turn-relative `touches` and
+    /// `last seen N turn(s) ago` fields, and the order is taken from
+    /// `sorted_for_prompt` (turn-agnostic) instead of `sorted_entries`.
+    /// The block lands in the system prompt before the historical
+    /// conversation; any byte that drifts here cache-misses everything that
+    /// follows in DeepSeek's KV prefix cache.
     pub fn summary_block(&self, workspace: &Path) -> Option<String> {
-        let entries = self.sorted_entries();
-        let prompt_entries: Vec<&WorkingSetEntry> = entries
+        let prompt_entries: Vec<&WorkingSetEntry> = self
+            .sorted_for_prompt()
             .into_iter()
             .take(self.config.max_prompt_entries)
             .collect();
@@ -404,12 +412,8 @@ impl WorkingSet {
         if !prompt_entries.is_empty() {
             lines.push("Active paths (prioritize these):".to_string());
             for entry in prompt_entries {
-                let age = self.turn.saturating_sub(entry.last_turn);
                 let kind = if entry.is_dir { "dir" } else { "file" };
-                lines.push(format!(
-                    "- {} ({kind}, touches: {}, last seen: {} turn(s) ago)",
-                    entry.path, entry.touches, age
-                ));
+                lines.push(format!("- {} ({kind})", entry.path));
             }
         }
 
@@ -529,6 +533,18 @@ impl WorkingSet {
             let sa = score_entry(a, self.turn);
             sb.cmp(&sa).then_with(|| a.path.cmp(&b.path))
         });
+        entries
+    }
+
+    /// Turn-agnostic ordering used when rendering the prompt summary block.
+    /// `sorted_entries` mixes in a recency bonus from `self.turn`, so its
+    /// output reorders as turns advance even when no new paths are touched —
+    /// that movement would cross `max_prompt_entries` boundaries and bust the
+    /// KV prefix cache (#280). Compaction pinning still uses the recency-aware
+    /// `sorted_entries`; only the prompt-facing surface is stabilised here.
+    fn sorted_for_prompt(&self) -> Vec<&WorkingSetEntry> {
+        let mut entries: Vec<&WorkingSetEntry> = self.entries.values().collect();
+        entries.sort_by(|a, b| b.touches.cmp(&a.touches).then_with(|| a.path.cmp(&b.path)));
         entries
     }
 }
@@ -984,6 +1000,62 @@ mod tests {
         assert!(block.contains("Cargo.toml"));
         assert!(block.contains("src"));
         assert!(block.contains("src/lib.rs"));
+    }
+
+    /// #280 regression: `summary_block` must produce byte-identical output
+    /// across `next_turn()` advances when no new paths are touched. Prior to
+    /// the fix, the rendered lines interpolated `entry.touches` and
+    /// `self.turn - entry.last_turn`, both of which drift turn-over-turn even
+    /// when the path set is unchanged. The drift busted DeepSeek's KV prefix
+    /// cache on every user message because the working-set block lands in the
+    /// system prompt before the historical conversation.
+    #[test]
+    fn summary_block_is_byte_stable_across_next_turn_when_no_new_paths_observed() {
+        use crate::test_support::assert_byte_identical;
+
+        let tmp = TempDir::new().expect("tempdir");
+        fs::write(tmp.path().join("Cargo.toml"), "[package]\nname = \"x\"").expect("write");
+        let src = tmp.path().join("src");
+        fs::create_dir_all(&src).expect("mkdir");
+        fs::write(src.join("a.rs"), "a").expect("write");
+        fs::write(src.join("b.rs"), "b").expect("write");
+
+        let mut ws = WorkingSet::default();
+        ws.observe_user_message("Edit src/a.rs and src/b.rs", tmp.path());
+
+        let before = ws.summary_block(tmp.path()).expect("block before");
+        ws.next_turn();
+        let after = ws.summary_block(tmp.path()).expect("block after");
+
+        assert_byte_identical(
+            "summary_block must be stable across next_turn when no new paths touched",
+            &before,
+            &after,
+        );
+    }
+
+    /// Companion to the byte-stability test: a fresh path *should* invalidate
+    /// the block (the KV cache is allowed to miss when there's genuinely new
+    /// signal), so the model still sees newly touched paths after the block
+    /// stabilises across no-op turns.
+    #[test]
+    fn summary_block_changes_when_a_new_path_is_observed() {
+        let tmp = TempDir::new().expect("tempdir");
+        fs::write(tmp.path().join("Cargo.toml"), "[package]\nname = \"x\"").expect("write");
+        let src = tmp.path().join("src");
+        fs::create_dir_all(&src).expect("mkdir");
+        fs::write(src.join("a.rs"), "a").expect("write");
+        fs::write(src.join("c.rs"), "c").expect("write");
+
+        let mut ws = WorkingSet::default();
+        ws.observe_user_message("src/a.rs", tmp.path());
+        let before = ws.summary_block(tmp.path()).expect("block before");
+
+        ws.observe_user_message("src/c.rs", tmp.path());
+        let after = ws.summary_block(tmp.path()).expect("block after");
+
+        assert_ne!(before, after, "new path must update the rendered summary");
+        assert!(after.contains("src/c.rs"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #280. The working-set summary is interpolated into the system prompt before the historical conversation; anything that drifts in those bytes cache-misses every byte of conversation that follows in DeepSeek's KV prefix cache.

Two sources of turn-over-turn drift removed:

- **Rendered line**: now `- {path} ({kind})`. The previous form interpolated `entry.touches` and `self.turn - entry.last_turn`, both of which advance every user message even when no new paths are observed.
- **Sort order**: new `sorted_for_prompt` helper sorts by `(touches DESC, path ASC)` instead of the turn-aware `sorted_entries`. The recency bonus in `score_entry` crosses bucket boundaries as turns advance, so even without rendering `last seen` the order — and which entries crossed the `max_prompt_entries` cutoff — drifted. Compaction pinning (`pinned_message_indices`) still uses `sorted_entries` because it genuinely wants recency.

Adopts option 1 from #280's repair menu (drop volatile fields). Option 2 (move the block out of the system prompt entirely) is a larger architectural change that would land later if we want to claim the bytes back as ephemeral context — option 1 already restores prefix-cache stability.

## Test plan

- [x] New regression test `summary_block_is_byte_stable_across_next_turn_when_no_new_paths_observed` constructs a `WorkingSet`, observes one user message touching two paths, calls `summary_block` once, advances `next_turn()`, and asserts the next call is byte-identical via `assert_byte_identical` (lifted to `test_support` so it's reachable from both `prompts::tests` and `working_set::tests`).
- [x] Companion test `summary_block_changes_when_a_new_path_is_observed` keeps the surface honest: a freshly observed path *must* still update the rendered block, otherwise the model never sees new signal.
- [x] Existing `summary_block_includes_repo_and_working_set` still asserts the block contains `Repo Working Set`, the workspace key files, and the active path — the user-visible content didn't shrink in any way the model can act on.
- [x] `cargo test --workspace --all-features --locked`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`