### PR TITLE
fix(cache): place handoff and working_set after static prompt blocks

### DIFF
--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -177,6 +177,22 @@ pub fn system_prompt_for_mode_with_context(
 }
 
 /// Get the system prompt for a specific mode with project and skills context.
+///
+/// **Volatile-content-last invariant.** Blocks are appended in order from
+/// most-static to most-volatile so DeepSeek's KV prefix cache hits the
+/// longest possible byte prefix turn-over-turn:
+///
+///   1. mode prompt (compile-time constant)
+///   2. project context / fallback (workspace-static)
+///   3. skills block (skills-dir-static)
+///   4. `## Context Management` (compile-time constant, Agent/Yolo only)
+///   5. compaction handoff template (compile-time constant)
+///   6. handoff block — file-backed; rewritten by `/compact` and on exit
+///   7. working-set summary — drifts when a new path is observed
+///
+/// Anything appended after a volatile block forfeits the cache for the rest
+/// of the request. New blocks belong above the handoff/working-set boundary
+/// unless they themselves are turn-volatile.
 pub fn system_prompt_for_mode_with_context_and_skills(
     mode: AppMode,
     workspace: &Path,
@@ -188,7 +204,7 @@ pub fn system_prompt_for_mode_with_context_and_skills(
     // Load project context from workspace
     let project_context = load_project_context_with_parents(workspace);
 
-    // Combine base prompt with project context
+    // 1–2. Mode prompt + project context (or fallback automap).
     let mut full_prompt = if let Some(project_block) = project_context.as_system_block() {
         format!("{}\n\n{}", mode_prompt, project_block)
     } else {
@@ -201,22 +217,13 @@ pub fn system_prompt_for_mode_with_context_and_skills(
         )
     };
 
-    if let Some(summary) = working_set_summary
-        && !summary.trim().is_empty()
-    {
-        full_prompt = format!("{full_prompt}\n\n{summary}");
-    }
-
+    // 3. Skills block.
     if let Some(skills_block) = skills_dir.and_then(crate::skills::render_available_skills_context)
     {
         full_prompt = format!("{full_prompt}\n\n{skills_block}");
     }
 
-    if let Some(handoff_block) = load_handoff_block(workspace) {
-        full_prompt = format!("{full_prompt}\n\n{handoff_block}");
-    }
-
-    // Add compaction instruction for agent modes
+    // 4. Context Management (Agent / Yolo only).
     if matches!(mode, AppMode::Agent | AppMode::Yolo) {
         full_prompt.push_str(
             "\n\n## Context Management\n\n\
@@ -228,10 +235,26 @@ pub fn system_prompt_for_mode_with_context_and_skills(
         );
     }
 
-    // Append the compaction handoff template so the model knows the format
-    // to use when writing `.deepseek/handoff.md` on exit / `/compact`.
+    // 5. Compaction handoff template — so the model knows the format to use
+    //    when writing `.deepseek/handoff.md` on exit / `/compact`.
     full_prompt.push_str("\n\n");
     full_prompt.push_str(COMPACT_TEMPLATE);
+
+    // ── Volatile-content boundary ─────────────────────────────────────────
+    // Everything below drifts mid-session and busts the prefix cache for
+    // bytes that follow. Keep new static blocks above this comment.
+
+    // 6. Previous-session handoff (file-backed, rewritten by `/compact`).
+    if let Some(handoff_block) = load_handoff_block(workspace) {
+        full_prompt = format!("{full_prompt}\n\n{handoff_block}");
+    }
+
+    // 7. Working-set summary (drifts when a new path is observed).
+    if let Some(summary) = working_set_summary
+        && !summary.trim().is_empty()
+    {
+        full_prompt = format!("{full_prompt}\n\n{summary}");
+    }
 
     SystemPrompt::Text(full_prompt)
 }
@@ -506,5 +529,88 @@ mod tests {
             &b,
         );
         assert!(a.contains(summary), "summary must be embedded as-is");
+    }
+
+    #[test]
+    fn system_prompt_with_handoff_file_is_byte_stable_when_file_is_unchanged() {
+        // Companion to the working-set stability test: if `.deepseek/handoff.md`
+        // hasn't moved between two builds, the rendered prompt must produce
+        // identical bytes. The handoff block is the second volatile surface
+        // (the first is the working-set summary) — both land below the static
+        // boundary in `system_prompt_for_mode_with_context_and_skills`.
+        let tmp = tempdir().expect("tempdir");
+        let workspace = tmp.path();
+        let handoff_dir = workspace.join(".deepseek");
+        std::fs::create_dir_all(&handoff_dir).unwrap();
+        std::fs::write(
+            handoff_dir.join("handoff.md"),
+            "# Session handoff\n\n## Active task\nFinish #280.\n\n## Open blockers\n- [ ] none\n",
+        )
+        .unwrap();
+
+        let a = match system_prompt_for_mode_with_context(AppMode::Agent, workspace, None) {
+            SystemPrompt::Text(text) => text,
+            SystemPrompt::Blocks(_) => panic!("expected text system prompt"),
+        };
+        let b = match system_prompt_for_mode_with_context(AppMode::Agent, workspace, None) {
+            SystemPrompt::Text(text) => text,
+            SystemPrompt::Blocks(_) => panic!("expected text system prompt"),
+        };
+        assert_byte_identical(
+            "system_prompt_for_mode_with_context with constant handoff file",
+            &a,
+            &b,
+        );
+        assert!(a.contains(HANDOFF_BLOCK_MARKER), "handoff must be embedded");
+        assert!(a.contains("Finish #280."), "handoff body must be present");
+    }
+
+    #[test]
+    fn handoff_and_working_set_appear_after_static_blocks() {
+        // Cache-prefix invariant: the volatile blocks (handoff, working_set)
+        // must come *after* the static `## Context Management` and the
+        // compaction handoff template (`## Compaction Handoff`) so a churn
+        // in either volatile section doesn't drag the static blocks out of
+        // the cached prefix. Pre-fix ordering placed handoff between the
+        // skills block and `## Context Management`, which busted the cache
+        // every time `/compact` rewrote the file.
+        let tmp = tempdir().expect("tempdir");
+        let workspace = tmp.path();
+        let handoff_dir = workspace.join(".deepseek");
+        std::fs::create_dir_all(&handoff_dir).unwrap();
+        std::fs::write(handoff_dir.join("handoff.md"), "# handoff body\n").unwrap();
+
+        let summary = "## Repo Working Set\nWorkspace: /tmp/x\n";
+        let prompt =
+            match system_prompt_for_mode_with_context(AppMode::Agent, workspace, Some(summary)) {
+                SystemPrompt::Text(text) => text,
+                SystemPrompt::Blocks(_) => panic!("expected text system prompt"),
+            };
+
+        let context_pos = prompt
+            .find("## Context Management")
+            .expect("Context Management section present in Agent mode");
+        let compact_pos = prompt
+            .find("## Compaction Handoff")
+            .expect("compaction handoff template present");
+        let handoff_pos = prompt
+            .find(HANDOFF_BLOCK_MARKER)
+            .expect("handoff block present when fixture file exists");
+        let working_set_pos = prompt
+            .find("## Repo Working Set")
+            .expect("working-set summary present when supplied");
+
+        assert!(
+            context_pos < handoff_pos,
+            "## Context Management must precede the handoff block"
+        );
+        assert!(
+            compact_pos < handoff_pos,
+            "## Compaction Handoff must precede the handoff block"
+        );
+        assert!(
+            handoff_pos < working_set_pos,
+            "handoff block must precede the working-set summary (most-volatile last)"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Stacked on top of #287 (the test_support helpers it reuses live there). When #287 lands the diff against \`feat/v0.8.4\` collapses to just the prompt-ordering change.

The system prompt previously interleaved volatile content (working-set summary, handoff block) with static content (\`## Context Management\`, \`COMPACT_TEMPLATE\`):

| step | block                  | static? |
|------|------------------------|---------|
| 1    | mode prompt            | yes     |
| 2    | project context        | yes     |
| 3    | working-set summary    | **no**  |
| 4    | skills block           | yes     |
| 5    | handoff block          | **no**  |
| 6    | \`## Context Management\` | yes     |
| 7    | \`COMPACT_TEMPLATE\`     | yes     |

Anything past step 3 cache-missed any time the working-set or handoff drifted — which means the static \`## Context Management\` and compaction-template bytes spent the session in the volatile zone for no reason.

New order keeps the static prefix together and puts the two volatile blocks at the tail:

| step | block                  | static?      |
|------|------------------------|--------------|
| 1    | mode prompt            | yes          |
| 2    | project context        | yes          |
| 3    | skills block           | yes          |
| 4    | \`## Context Management\` | yes (A/Y)    |
| 5    | \`COMPACT_TEMPLATE\`     | yes          |
| —    | **volatile boundary**  |              |
| 6    | handoff block          | file-backed  |
| 7    | working-set summary    | turn-volatile |

Reference: Claude Code's own builder draws the same line with a \`SYSTEM_PROMPT_DYNAMIC_BOUNDARY\` constant. I didn't introduce the abstraction (one call site, no need yet) but the function-level doc comment names the invariant so a future reorder doesn't quietly break it.

## Test plan

- [x] \`system_prompt_with_handoff_file_is_byte_stable_when_file_is_unchanged\` — writes a fixture handoff file, builds the prompt twice, asserts byte-identical via \`assert_byte_identical\`.
- [x] \`handoff_and_working_set_appear_after_static_blocks\` — asserts \`## Context Management\` < \`## Compaction Handoff\` < handoff < working-set in the rendered string. A future reorder that violates the invariant fails this test loudly.
- [x] Existing \`handoff_artifact_is_prepended_…\`, \`compact_template_is_included_in_full_prompt\`, and the byte-stability suite from #279 keep passing — the user-visible contents still appear, just in a different order.
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace --all-targets --all-features --locked -- -D warnings\`
- [x] \`cargo test --workspace --all-features --locked\` (1756 / 1756 in the main TUI binary, +2 from the new tests)