### PR TITLE
fix(client): unique fallback id for parallel streaming tool calls

### DIFF
--- a/crates/tui/src/client/chat.rs
+++ b/crates/tui/src/client/chat.rs
@@ -1178,11 +1178,21 @@ pub(super) fn parse_sse_chunk(
                                 *thinking_started = false;
                             }
 
+                            let block_index = *content_index;
                             let id = tc
                                 .get("id")
                                 .and_then(Value::as_str)
-                                .unwrap_or("tool_call")
-                                .to_string();
+                                .map(str::to_string)
+                                // Some upstream gateways (and the responses-API
+                                // bridge) elide the `id` on the first chunk of a
+                                // tool call. Falling back to a constant string
+                                // collides when the model emits parallel tool
+                                // calls in the same delta — every call ended up
+                                // with the same id and downstream tool-result
+                                // routing matched the first one twice. Index by
+                                // the content-block position to keep the
+                                // fallback unique within the response.
+                                .unwrap_or_else(|| format!("call_{block_index}"));
                             let name = tc
                                 .get("function")
                                 .and_then(|f| f.get("name"))
@@ -1201,7 +1211,6 @@ pub(super) fn parse_sse_chunk(
                                 })
                             });
 
-                            let block_index = *content_index;
                             events.push(StreamEvent::ContentBlockStart {
                                 index: block_index,
                                 content_block: ContentBlockStart::ToolUse {
@@ -1470,5 +1479,65 @@ mod stream_decoder_tests {
             )),
             "should yield InputJsonDelta carrying the tool args; got {events:?}"
         );
+    }
+
+    /// Regression for the parallel-tool-calls-without-id collision (audit
+    /// Finding 8): when the upstream chunk omits the `id` field, the
+    /// fallback used to be the literal string `"tool_call"` for every
+    /// parallel call, so two tool calls in one delta ended up sharing an
+    /// id. Downstream routing then matched the first call's tool_result
+    /// twice and the second call hung. The fallback is now indexed by the
+    /// content-block position, keeping each call unique within the
+    /// response.
+    #[test]
+    fn decoder_assigns_unique_fallback_ids_to_parallel_tool_calls_missing_id() {
+        let events = decode_chunk(
+            r#"{"choices":[{"delta":{"tool_calls":[
+                {"index":0,"function":{"name":"grep_files","arguments":"{\"pattern\":\"a\"}"}},
+                {"index":1,"function":{"name":"read_file","arguments":"{\"path\":\"x\"}"}}
+            ]}}]}"#,
+        );
+
+        let ids: Vec<&str> = events
+            .iter()
+            .filter_map(|e| match e {
+                StreamEvent::ContentBlockStart {
+                    content_block: ContentBlockStart::ToolUse { id, .. },
+                    ..
+                } => Some(id.as_str()),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(
+            ids.len(),
+            2,
+            "expected two tool-use blocks for parallel tool calls; got {events:?}"
+        );
+        assert_ne!(
+            ids[0], ids[1],
+            "parallel tool calls without upstream `id` must get distinct fallback ids; got {ids:?}"
+        );
+    }
+
+    #[test]
+    fn decoder_preserves_upstream_tool_call_id_when_present() {
+        // Counter-test to the fallback regression: when the upstream chunk
+        // does include `id`, we forward it verbatim — we shouldn't quietly
+        // rewrite ids the API gave us just because we have a fallback path.
+        let events = decode_chunk(
+            r#"{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_xyz","function":{"name":"grep_files","arguments":"{}"}}]}}]}"#,
+        );
+        let id = events
+            .iter()
+            .find_map(|e| match e {
+                StreamEvent::ContentBlockStart {
+                    content_block: ContentBlockStart::ToolUse { id, .. },
+                    ..
+                } => Some(id.as_str()),
+                _ => None,
+            })
+            .expect("tool-use block present");
+        assert_eq!(id, "call_xyz");
     }
 }


### PR DESCRIPTION
## Summary

Closes Finding 8 from the prior agent's audit. \`crates/tui/src/client/chat.rs\` (lines ~1181-1185 in the pre-fix code) used the literal string \`"tool_call"\` as the fallback id when a streamed \`tool_call\` chunk omitted the upstream \`id\` field:

\`\`\`rust
let id = tc
    .get(\"id\")
    .and_then(Value::as_str)
    .unwrap_or(\"tool_call\")  // ← collides for parallel calls
    .to_string();
\`\`\`

DeepSeek V4 emits native parallel tool calls (multiple entries in a single \`tool_calls\` array). When an upstream gateway or the responses-API bridge elides the \`id\` on the first chunk of each call — which is allowed under the OpenAI-compatible streaming spec, since the spec only requires \`id\` somewhere in the stream — every parallel call ended up with the same fallback id. Downstream tool-result routing then matched the first call's result twice and the second call hung waiting for an answer that would never arrive.

The fallback is now indexed by the \`content_block\` position the decoder is about to assign anyway:

\`\`\`rust
let block_index = *content_index;
let id = tc
    .get(\"id\")
    .and_then(Value::as_str)
    .map(str::to_string)
    .unwrap_or_else(|| format!(\"call_{block_index}\"));
\`\`\`

So two parallel calls in one delta become \`call_0\` and \`call_1\` instead of two \`tool_call\`s. Upstream-supplied ids are still forwarded verbatim — the fallback path only kicks in when the upstream chunk genuinely omits \`id\`.

## Test plan

Both tests are in \`stream_decoder_tests\`, which exercises \`parse_sse_chunk\` directly via the existing \`decode_chunk\` helper:

- [x] \`decoder_assigns_unique_fallback_ids_to_parallel_tool_calls_missing_id\` — feeds a chunk with two parallel \`tool_calls\` (\`index: 0\`, \`index: 1\`), neither carrying an \`id\`, and asserts the resulting \`ContentBlockStart::ToolUse\` blocks have distinct ids.
- [x] \`decoder_preserves_upstream_tool_call_id_when_present\` — keeps the forward-as-is path honest by feeding a chunk with \`id: \"call_xyz\"\` and asserting the decoder doesn't quietly rewrite it.
- [x] Existing \`decoder_emits_tool_use_block_for_tool_call_delta\` still passes — the upstream-id case is unchanged.
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace --all-targets --all-features --locked -- -D warnings\`
- [x] \`cargo test --workspace --all-features --locked\` (1942 / 1942 across the workspace, +2 from the new tests)