### PR TITLE
fix(cache): place handoff and working_set after static prompt blocks

### DIFF
--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -177,6 +177,22 @@ pub fn system_prompt_for_mode_with_context(
 }
 
 /// Get the system prompt for a specific mode with project and skills context.
+///
+/// **Volatile-content-last invariant.** Blocks are appended in order from
+/// most-static to most-volatile so DeepSeek's KV prefix cache hits the
+/// longest possible byte prefix turn-over-turn:
+///
+///   1. mode prompt (compile-time constant)
+///   2. project context / fallback (workspace-static)
+///   3. skills block (skills-dir-static)
+///   4. `## Context Management` (compile-time constant, Agent/Yolo only)
+///   5. compaction handoff template (compile-time constant)
+///   6. handoff block — file-backed; rewritten by `/compact` and on exit
+///   7. working-set summary — drifts when a new path is observed
+///
+/// Anything appended after a volatile block forfeits the cache for the rest
+/// of the request. New blocks belong above the handoff/working-set boundary
+/// unless they themselves are turn-volatile.
 pub fn system_prompt_for_mode_with_context_and_skills(
     mode: AppMode,
     workspace: &Path,
@@ -188,7 +204,7 @@ pub fn system_prompt_for_mode_with_context_and_skills(
     // Load project context from workspace
     let project_context = load_project_context_with_parents(workspace);
 
-    // Combine base prompt with project context
+    // 1–2. Mode prompt + project context (or fallback automap).
     let mut full_prompt = if let Some(project_block) = project_context.as_system_block() {
         format!("{}\n\n{}", mode_prompt, project_block)
     } else {
@@ -201,22 +217,13 @@ pub fn system_prompt_for_mode_with_context_and_skills(
         )
     };
 
-    if let Some(summary) = working_set_summary
-        && !summary.trim().is_empty()
-    {
-        full_prompt = format!("{full_prompt}\n\n{summary}");
-    }
-
+    // 3. Skills block.
     if let Some(skills_block) = skills_dir.and_then(crate::skills::render_available_skills_context)
     {
         full_prompt = format!("{full_prompt}\n\n{skills_block}");
     }
 
-    if let Some(handoff_block) = load_handoff_block(workspace) {
-        full_prompt = format!("{full_prompt}\n\n{handoff_block}");
-    }
-
-    // Add compaction instruction for agent modes
+    // 4. Context Management (Agent / Yolo only).
     if matches!(mode, AppMode::Agent | AppMode::Yolo) {
         full_prompt.push_str(
             "\n\n## Context Management\n\n\
@@ -228,10 +235,26 @@ pub fn system_prompt_for_mode_with_context_and_skills(
         );
     }
 
-    // Append the compaction handoff template so the model knows the format
-    // to use when writing `.deepseek/handoff.md` on exit / `/compact`.
+    // 5. Compaction handoff template — so the model knows the format to use
+    //    when writing `.deepseek/handoff.md` on exit / `/compact`.
     full_prompt.push_str("\n\n");
     full_prompt.push_str(COMPACT_TEMPLATE);
+
+    // ── Volatile-content boundary ─────────────────────────────────────────
+    // Everything below drifts mid-session and busts the prefix cache for
+    // bytes that follow. Keep new static blocks above this comment.
+
+    // 6. Previous-session handoff (file-backed, rewritten by `/compact`).
+    if let Some(handoff_block) = load_handoff_block(workspace) {
+        full_prompt = format!("{full_prompt}\n\n{handoff_block}");
+    }
+
+    // 7. Working-set summary (drifts when a new path is observed).
+    if let Some(summary) = working_set_summary
+        && !summary.trim().is_empty()
+    {
+        full_prompt = format!("{full_prompt}\n\n{summary}");
+    }
 
     SystemPrompt::Text(full_prompt)
 }
@@ -506,5 +529,88 @@ mod tests {
             &b,
         );
         assert!(a.contains(summary), "summary must be embedded as-is");
+    }
+
+    #[test]
+    fn system_prompt_with_handoff_file_is_byte_stable_when_file_is_unchanged() {
+        // Companion to the working-set stability test: if `.deepseek/handoff.md`
+        // hasn't moved between two builds, the rendered prompt must produce
+        // identical bytes. The handoff block is the second volatile surface
+        // (the first is the working-set summary) — both land below the static
+        // boundary in `system_prompt_for_mode_with_context_and_skills`.
+        let tmp = tempdir().expect("tempdir");
+        let workspace = tmp.path();
+        let handoff_dir = workspace.join(".deepseek");
+        std::fs::create_dir_all(&handoff_dir).unwrap();
+        std::fs::write(
+            handoff_dir.join("handoff.md"),
+            "# Session handoff\n\n## Active task\nFinish #280.\n\n## Open blockers\n- [ ] none\n",
+        )
+        .unwrap();
+
+        let a = match system_prompt_for_mode_with_context(AppMode::Agent, workspace, None) {
+            SystemPrompt::Text(text) => text,
+            SystemPrompt::Blocks(_) => panic!("expected text system prompt"),
+        };
+        let b = match system_prompt_for_mode_with_context(AppMode::Agent, workspace, None) {
+            SystemPrompt::Text(text) => text,
+            SystemPrompt::Blocks(_) => panic!("expected text system prompt"),
+        };
+        assert_byte_identical(
+            "system_prompt_for_mode_with_context with constant handoff file",
+            &a,
+            &b,
+        );
+        assert!(a.contains(HANDOFF_BLOCK_MARKER), "handoff must be embedded");
+        assert!(a.contains("Finish #280."), "handoff body must be present");
+    }
+
+    #[test]
+    fn handoff_and_working_set_appear_after_static_blocks() {
+        // Cache-prefix invariant: the volatile blocks (handoff, working_set)
+        // must come *after* the static `## Context Management` and the
+        // compaction handoff template (`## Compaction Handoff`) so a churn
+        // in either volatile section doesn't drag the static blocks out of
+        // the cached prefix. Pre-fix ordering placed handoff between the
+        // skills block and `## Context Management`, which busted the cache
+        // every time `/compact` rewrote the file.
+        let tmp = tempdir().expect("tempdir");
+        let workspace = tmp.path();
+        let handoff_dir = workspace.join(".deepseek");
+        std::fs::create_dir_all(&handoff_dir).unwrap();
+        std::fs::write(handoff_dir.join("handoff.md"), "# handoff body\n").unwrap();
+
+        let summary = "## Repo Working Set\nWorkspace: /tmp/x\n";
+        let prompt =
+            match system_prompt_for_mode_with_context(AppMode::Agent, workspace, Some(summary)) {
+                SystemPrompt::Text(text) => text,
+                SystemPrompt::Blocks(_) => panic!("expected text system prompt"),
+            };
+
+        let context_pos = prompt
+            .find("## Context Management")
+            .expect("Context Management section present in Agent mode");
+        let compact_pos = prompt
+            .find("## Compaction Handoff")
+            .expect("compaction handoff template present");
+        let handoff_pos = prompt
+            .find(HANDOFF_BLOCK_MARKER)
+            .expect("handoff block present when fixture file exists");
+        let working_set_pos = prompt
+            .find("## Repo Working Set")
+            .expect("working-set summary present when supplied");
+
+        assert!(
+            context_pos < handoff_pos,
+            "## Context Management must precede the handoff block"
+        );
+        assert!(
+            compact_pos < handoff_pos,
+            "## Compaction Handoff must precede the handoff block"
+        );
+        assert!(
+            handoff_pos < working_set_pos,
+            "handoff block must precede the working-set summary (most-volatile last)"
+        );
     }
 }

--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -433,41 +433,7 @@ mod tests {
     // in the cached prefix must produce identical bytes given identical
     // inputs across calls.
 
-    /// Find the byte position of the first divergence between two strings,
-    /// returning a windowed view (`±32 bytes` around the divergence) for
-    /// human-readable failure output.
-    fn first_divergence(a: &str, b: &str) -> Option<(usize, String, String)> {
-        let a_bytes = a.as_bytes();
-        let b_bytes = b.as_bytes();
-        let max = a_bytes.len().min(b_bytes.len());
-        for i in 0..max {
-            if a_bytes[i] != b_bytes[i] {
-                let lo = i.saturating_sub(32);
-                let a_hi = (i + 32).min(a_bytes.len());
-                let b_hi = (i + 32).min(b_bytes.len());
-                let a_ctx = String::from_utf8_lossy(&a_bytes[lo..a_hi]).into_owned();
-                let b_ctx = String::from_utf8_lossy(&b_bytes[lo..b_hi]).into_owned();
-                return Some((i, a_ctx, b_ctx));
-            }
-        }
-        if a_bytes.len() != b_bytes.len() {
-            return Some((
-                max,
-                format!("(len={})", a_bytes.len()),
-                format!("(len={})", b_bytes.len()),
-            ));
-        }
-        None
-    }
-
-    fn assert_byte_identical(label: &str, a: &str, b: &str) {
-        if let Some((pos, a_ctx, b_ctx)) = first_divergence(a, b) {
-            panic!(
-                "{label}: prompt construction is non-deterministic — first diff at byte {pos}\n\
-                 ── side A (±32B) ──\n{a_ctx:?}\n── side B (±32B) ──\n{b_ctx:?}",
-            );
-        }
-    }
+    use crate::test_support::assert_byte_identical;
 
     #[test]
     fn compose_prompt_is_byte_stable_across_calls() {

--- a/crates/tui/src/test_support.rs
+++ b/crates/tui/src/test_support.rs
@@ -17,3 +17,45 @@ pub(crate) fn lock_test_env() -> MutexGuard<'static, ()> {
         Err(poisoned) => poisoned.into_inner(),
     }
 }
+
+/// Find the byte position of the first divergence between two strings,
+/// returning a windowed view (`±32 bytes` around the divergence) so failures
+/// in cache-prefix-stability tests show *which* bytes drifted, not just that
+/// they did. Returns `None` when the strings are byte-identical.
+pub(crate) fn first_divergence(a: &str, b: &str) -> Option<(usize, String, String)> {
+    let a_bytes = a.as_bytes();
+    let b_bytes = b.as_bytes();
+    let max = a_bytes.len().min(b_bytes.len());
+    for i in 0..max {
+        if a_bytes[i] != b_bytes[i] {
+            let lo = i.saturating_sub(32);
+            let a_hi = (i + 32).min(a_bytes.len());
+            let b_hi = (i + 32).min(b_bytes.len());
+            let a_ctx = String::from_utf8_lossy(&a_bytes[lo..a_hi]).into_owned();
+            let b_ctx = String::from_utf8_lossy(&b_bytes[lo..b_hi]).into_owned();
+            return Some((i, a_ctx, b_ctx));
+        }
+    }
+    if a_bytes.len() != b_bytes.len() {
+        return Some((
+            max,
+            format!("(len={})", a_bytes.len()),
+            format!("(len={})", b_bytes.len()),
+        ));
+    }
+    None
+}
+
+/// Assert two strings are byte-identical, panicking with a windowed diff
+/// around the first divergence when they aren't. Used by the prefix-cache
+/// stability harness (#263, #280) to pin construction surfaces that land in
+/// DeepSeek's KV cache prefix.
+#[track_caller]
+pub(crate) fn assert_byte_identical(label: &str, a: &str, b: &str) {
+    if let Some((pos, a_ctx, b_ctx)) = first_divergence(a, b) {
+        panic!(
+            "{label}: prompt construction is non-deterministic — first diff at byte {pos}\n\
+             ── side A (±32B) ──\n{a_ctx:?}\n── side B (±32B) ──\n{b_ctx:?}",
+        );
+    }
+}

--- a/crates/tui/src/working_set.rs
+++ b/crates/tui/src/working_set.rs
@@ -380,9 +380,17 @@ impl WorkingSet {
     }
 
     /// Render a compact working-set block for the system prompt.
+    ///
+    /// Byte-stable across `next_turn()` calls when no new paths are observed
+    /// (#280): the rendered lines drop the turn-relative `touches` and
+    /// `last seen N turn(s) ago` fields, and the order is taken from
+    /// `sorted_for_prompt` (turn-agnostic) instead of `sorted_entries`.
+    /// The block lands in the system prompt before the historical
+    /// conversation; any byte that drifts here cache-misses everything that
+    /// follows in DeepSeek's KV prefix cache.
     pub fn summary_block(&self, workspace: &Path) -> Option<String> {
-        let entries = self.sorted_entries();
-        let prompt_entries: Vec<&WorkingSetEntry> = entries
+        let prompt_entries: Vec<&WorkingSetEntry> = self
+            .sorted_for_prompt()
             .into_iter()
             .take(self.config.max_prompt_entries)
             .collect();
@@ -404,12 +412,8 @@ impl WorkingSet {
         if !prompt_entries.is_empty() {
             lines.push("Active paths (prioritize these):".to_string());
             for entry in prompt_entries {
-                let age = self.turn.saturating_sub(entry.last_turn);
                 let kind = if entry.is_dir { "dir" } else { "file" };
-                lines.push(format!(
-                    "- {} ({kind}, touches: {}, last seen: {} turn(s) ago)",
-                    entry.path, entry.touches, age
-                ));
+                lines.push(format!("- {} ({kind})", entry.path));
             }
         }
 
@@ -529,6 +533,18 @@ impl WorkingSet {
             let sa = score_entry(a, self.turn);
             sb.cmp(&sa).then_with(|| a.path.cmp(&b.path))
         });
+        entries
+    }
+
+    /// Turn-agnostic ordering used when rendering the prompt summary block.
+    /// `sorted_entries` mixes in a recency bonus from `self.turn`, so its
+    /// output reorders as turns advance even when no new paths are touched —
+    /// that movement would cross `max_prompt_entries` boundaries and bust the
+    /// KV prefix cache (#280). Compaction pinning still uses the recency-aware
+    /// `sorted_entries`; only the prompt-facing surface is stabilised here.
+    fn sorted_for_prompt(&self) -> Vec<&WorkingSetEntry> {
+        let mut entries: Vec<&WorkingSetEntry> = self.entries.values().collect();
+        entries.sort_by(|a, b| b.touches.cmp(&a.touches).then_with(|| a.path.cmp(&b.path)));
         entries
     }
 }
@@ -984,6 +1000,62 @@ mod tests {
         assert!(block.contains("Cargo.toml"));
         assert!(block.contains("src"));
         assert!(block.contains("src/lib.rs"));
+    }
+
+    /// #280 regression: `summary_block` must produce byte-identical output
+    /// across `next_turn()` advances when no new paths are touched. Prior to
+    /// the fix, the rendered lines interpolated `entry.touches` and
+    /// `self.turn - entry.last_turn`, both of which drift turn-over-turn even
+    /// when the path set is unchanged. The drift busted DeepSeek's KV prefix
+    /// cache on every user message because the working-set block lands in the
+    /// system prompt before the historical conversation.
+    #[test]
+    fn summary_block_is_byte_stable_across_next_turn_when_no_new_paths_observed() {
+        use crate::test_support::assert_byte_identical;
+
+        let tmp = TempDir::new().expect("tempdir");
+        fs::write(tmp.path().join("Cargo.toml"), "[package]\nname = \"x\"").expect("write");
+        let src = tmp.path().join("src");
+        fs::create_dir_all(&src).expect("mkdir");
+        fs::write(src.join("a.rs"), "a").expect("write");
+        fs::write(src.join("b.rs"), "b").expect("write");
+
+        let mut ws = WorkingSet::default();
+        ws.observe_user_message("Edit src/a.rs and src/b.rs", tmp.path());
+
+        let before = ws.summary_block(tmp.path()).expect("block before");
+        ws.next_turn();
+        let after = ws.summary_block(tmp.path()).expect("block after");
+
+        assert_byte_identical(
+            "summary_block must be stable across next_turn when no new paths touched",
+            &before,
+            &after,
+        );
+    }
+
+    /// Companion to the byte-stability test: a fresh path *should* invalidate
+    /// the block (the KV cache is allowed to miss when there's genuinely new
+    /// signal), so the model still sees newly touched paths after the block
+    /// stabilises across no-op turns.
+    #[test]
+    fn summary_block_changes_when_a_new_path_is_observed() {
+        let tmp = TempDir::new().expect("tempdir");
+        fs::write(tmp.path().join("Cargo.toml"), "[package]\nname = \"x\"").expect("write");
+        let src = tmp.path().join("src");
+        fs::create_dir_all(&src).expect("mkdir");
+        fs::write(src.join("a.rs"), "a").expect("write");
+        fs::write(src.join("c.rs"), "c").expect("write");
+
+        let mut ws = WorkingSet::default();
+        ws.observe_user_message("src/a.rs", tmp.path());
+        let before = ws.summary_block(tmp.path()).expect("block before");
+
+        ws.observe_user_message("src/c.rs", tmp.path());
+        let after = ws.summary_block(tmp.path()).expect("block after");
+
+        assert_ne!(before, after, "new path must update the rendered summary");
+        assert!(after.contains("src/c.rs"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Reopened from #288 — GitHub auto-closed it when the stacked-on parent branch was deleted by the merge of #287.

The system prompt previously interleaved volatile content (working-set summary, handoff block) with static content (`## Context Management`, `COMPACT_TEMPLATE`):

| step | block                  | static? |
|------|------------------------|---------|
| 1    | mode prompt            | yes     |
| 2    | project context        | yes     |
| 3    | working-set summary    | **no**  |
| 4    | skills block           | yes     |
| 5    | handoff block          | **no**  |
| 6    | `## Context Management` | yes     |
| 7    | `COMPACT_TEMPLATE`     | yes     |

Anything past step 3 cache-missed any time the working-set or handoff drifted — which means the static `## Context Management` and compaction-template bytes spent the session in the volatile zone for no reason.

New order keeps the static prefix together and puts the two volatile blocks at the tail:

| step | block                  | static?      |
|------|------------------------|--------------|
| 1    | mode prompt            | yes          |
| 2    | project context        | yes          |
| 3    | skills block           | yes          |
| 4    | `## Context Management` | yes (A/Y)    |
| 5    | `COMPACT_TEMPLATE`     | yes          |
| —    | **volatile boundary**  |              |
| 6    | handoff block          | file-backed  |
| 7    | working-set summary    | turn-volatile |

Reference: Claude Code's own builder draws the same line with a `SYSTEM_PROMPT_DYNAMIC_BOUNDARY` constant. I didn't introduce the abstraction (one call site, no need yet) but the function-level doc comment names the invariant so a future reorder doesn't quietly break it.

## Test plan

- [x] `system_prompt_with_handoff_file_is_byte_stable_when_file_is_unchanged`
- [x] `handoff_and_working_set_appear_after_static_blocks`
- [x] Existing `handoff_artifact_is_prepended_…`, `compact_template_is_included_in_full_prompt`, and the byte-stability suite from #279 keep passing
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- [x] `cargo test --workspace --all-features --locked`

🤖 Generated with [Claude Code](https://claude.com/claude-code)