### PR TITLE
feat(i18n): localize slash command help (Phase 1a, #285)

### DIFF
--- a/crates/tui/src/commands/core.rs
+++ b/crates/tui/src/commands/core.rs
@@ -15,7 +15,9 @@ pub fn help(app: &mut App, topic: Option<&str>) -> CommandResult {
         if let Some(cmd) = super::get_command_info(topic) {
             let mut help = format!(
                 "{}\n\n  {}\n\n  Usage: {}",
-                cmd.name, cmd.description, cmd.usage
+                cmd.name,
+                cmd.description_for(app.ui_locale),
+                cmd.usage
             );
             if !cmd.aliases.is_empty() {
                 let _ = write!(help, "\n  Aliases: {}", cmd.aliases.join(", "));

--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -20,6 +20,7 @@ mod session;
 mod skills;
 mod task;
 
+use crate::localization::{Locale, MessageId, tr};
 use crate::tui::app::{App, AppAction};
 
 /// Result of executing a command
@@ -74,13 +75,16 @@ impl CommandResult {
     }
 }
 
-/// Command metadata for help and autocomplete
+/// Command metadata for help and autocomplete.
+///
+/// The English description string lives in [`crate::localization::english`]
+/// keyed by `description_id`; resolve it with [`CommandInfo::description_for`].
 #[derive(Debug, Clone, Copy)]
 pub struct CommandInfo {
     pub name: &'static str,
     pub aliases: &'static [&'static str],
-    pub description: &'static str,
     pub usage: &'static str,
+    pub description_id: MessageId,
 }
 
 impl CommandInfo {
@@ -96,11 +100,16 @@ impl CommandInfo {
         }
     }
 
-    pub fn palette_description(&self) -> String {
+    pub fn description_for(&self, locale: Locale) -> &'static str {
+        tr(locale, self.description_id)
+    }
+
+    pub fn palette_description_for(&self, locale: Locale) -> String {
+        let desc = self.description_for(locale);
         if self.aliases.is_empty() {
-            self.description.to_string()
+            desc.to_string()
         } else {
-            format!("{}  aliases: {}", self.description, self.aliases.join(", "))
+            format!("{}  aliases: {}", desc, self.aliases.join(", "))
         }
     }
 }
@@ -111,273 +120,273 @@ pub const COMMANDS: &[CommandInfo] = &[
     CommandInfo {
         name: "help",
         aliases: &["?"],
-        description: "Show help information",
         usage: "/help [command]",
+        description_id: MessageId::CmdHelpDescription,
     },
     CommandInfo {
         name: "clear",
         aliases: &[],
-        description: "Clear conversation history",
         usage: "/clear",
+        description_id: MessageId::CmdClearDescription,
     },
     CommandInfo {
         name: "exit",
         aliases: &["quit", "q"],
-        description: "Exit the application",
         usage: "/exit",
+        description_id: MessageId::CmdExitDescription,
     },
     CommandInfo {
         name: "model",
         aliases: &[],
-        description: "Switch or view current model",
         usage: "/model [name]",
+        description_id: MessageId::CmdModelDescription,
     },
     CommandInfo {
         name: "models",
         aliases: &[],
-        description: "List available models from API",
         usage: "/models",
+        description_id: MessageId::CmdModelsDescription,
     },
     CommandInfo {
         name: "provider",
         aliases: &[],
-        description: "Switch or view the active LLM backend (deepseek | nvidia-nim)",
         usage: "/provider [name]",
+        description_id: MessageId::CmdProviderDescription,
     },
     CommandInfo {
         name: "queue",
         aliases: &["queued"],
-        description: "View or edit queued messages",
         usage: "/queue [list|edit <n>|drop <n>|clear]",
+        description_id: MessageId::CmdQueueDescription,
     },
     CommandInfo {
         name: "subagents",
         aliases: &["agents"],
-        description: "List sub-agent status",
         usage: "/subagents",
+        description_id: MessageId::CmdSubagentsDescription,
     },
     CommandInfo {
         name: "links",
         aliases: &["dashboard", "api"],
-        description: "Show DeepSeek dashboard and docs links",
         usage: "/links",
+        description_id: MessageId::CmdLinksDescription,
     },
     CommandInfo {
         name: "home",
         aliases: &["stats", "overview"],
-        description: "Show home dashboard with stats and quick actions",
         usage: "/home",
+        description_id: MessageId::CmdHomeDescription,
     },
     CommandInfo {
         name: "note",
         aliases: &[],
-        description: "Append note to persistent notes file (.deepseek/notes.md)",
         usage: "/note <text>",
+        description_id: MessageId::CmdNoteDescription,
     },
     CommandInfo {
         name: "attach",
         aliases: &["image", "media"],
-        description: "Attach image/video media; use @path for text files or directories",
         usage: "/attach <path>",
+        description_id: MessageId::CmdAttachDescription,
     },
     CommandInfo {
         name: "task",
         aliases: &["tasks"],
-        description: "Manage background tasks",
         usage: "/task [add <prompt>|list|show <id>|cancel <id>]",
+        description_id: MessageId::CmdTaskDescription,
     },
     CommandInfo {
         name: "jobs",
         aliases: &["job"],
-        description: "Inspect and control background shell jobs",
         usage: "/jobs [list|show <id>|poll <id>|wait <id>|stdin <id> <input>|cancel <id>]",
+        description_id: MessageId::CmdJobsDescription,
     },
     CommandInfo {
         name: "mcp",
         aliases: &[],
-        description: "Open or manage MCP servers",
         usage: "/mcp [init|add stdio <name> <command> [args...]|add http <name> <url>|enable <name>|disable <name>|remove <name>|validate|reload]",
+        description_id: MessageId::CmdMcpDescription,
     },
     // Session commands
     CommandInfo {
         name: "save",
         aliases: &[],
-        description: "Save session to file",
         usage: "/save [path]",
+        description_id: MessageId::CmdSaveDescription,
     },
     CommandInfo {
         name: "sessions",
         aliases: &["resume"],
-        description: "Open session picker",
         usage: "/sessions",
+        description_id: MessageId::CmdSessionsDescription,
     },
     CommandInfo {
         name: "load",
         aliases: &[],
-        description: "Load session from file",
         usage: "/load [path]",
+        description_id: MessageId::CmdLoadDescription,
     },
     CommandInfo {
         name: "compact",
         aliases: &[],
-        description: "Trigger context compaction to free up space (legacy; v0.6.6 prefers cycle restart)",
         usage: "/compact",
+        description_id: MessageId::CmdCompactDescription,
     },
     CommandInfo {
         name: "context",
         aliases: &["ctx"],
-        description: "Open compact session context inspector",
         usage: "/context",
+        description_id: MessageId::CmdContextDescription,
     },
     CommandInfo {
         name: "cycles",
         aliases: &[],
-        description: "List checkpoint-restart cycle handoffs in this session",
         usage: "/cycles",
+        description_id: MessageId::CmdCyclesDescription,
     },
     CommandInfo {
         name: "cycle",
         aliases: &[],
-        description: "Show the carry-forward briefing for a specific cycle",
         usage: "/cycle <n>",
+        description_id: MessageId::CmdCycleDescription,
     },
     CommandInfo {
         name: "recall",
         aliases: &[],
-        description: "Search prior cycle archives (BM25 over message text)",
         usage: "/recall <query>",
+        description_id: MessageId::CmdRecallDescription,
     },
     CommandInfo {
         name: "export",
         aliases: &[],
-        description: "Export conversation to markdown",
         usage: "/export [path]",
+        description_id: MessageId::CmdExportDescription,
     },
     // Config commands
     CommandInfo {
         name: "config",
         aliases: &[],
-        description: "Open interactive configuration editor",
         usage: "/config",
+        description_id: MessageId::CmdConfigDescription,
     },
     CommandInfo {
         name: "yolo",
         aliases: &[],
-        description: "Enable YOLO mode (shell + trust + auto-approve)",
         usage: "/yolo",
+        description_id: MessageId::CmdYoloDescription,
     },
     CommandInfo {
         name: "agent",
         aliases: &[],
-        description: "Switch to agent mode",
         usage: "/agent",
+        description_id: MessageId::CmdAgentDescription,
     },
     CommandInfo {
         name: "plan",
         aliases: &[],
-        description: "Switch to plan mode and review suggested implementation steps",
         usage: "/plan",
+        description_id: MessageId::CmdPlanDescription,
     },
     CommandInfo {
         name: "trust",
         aliases: &[],
-        description: "Manage workspace trust and per-path allowlist (`/trust add <path>`, `/trust list`, `/trust on|off`)",
         usage: "/trust [on|off|add <path>|remove <path>|list]",
+        description_id: MessageId::CmdTrustDescription,
     },
     CommandInfo {
         name: "logout",
         aliases: &[],
-        description: "Clear API key and return to setup",
         usage: "/logout",
+        description_id: MessageId::CmdLogoutDescription,
     },
     // Debug commands
     CommandInfo {
         name: "tokens",
         aliases: &[],
-        description: "Show token usage for session",
         usage: "/tokens",
+        description_id: MessageId::CmdTokensDescription,
     },
     CommandInfo {
         name: "system",
         aliases: &[],
-        description: "Show current system prompt",
         usage: "/system",
+        description_id: MessageId::CmdSystemDescription,
     },
     CommandInfo {
         name: "undo",
         aliases: &[],
-        description: "Remove last message pair",
         usage: "/undo",
+        description_id: MessageId::CmdUndoDescription,
     },
     CommandInfo {
         name: "retry",
         aliases: &[],
-        description: "Retry the last request",
         usage: "/retry",
+        description_id: MessageId::CmdRetryDescription,
     },
     CommandInfo {
         name: "init",
         aliases: &[],
-        description: "Generate AGENTS.md for project",
         usage: "/init",
+        description_id: MessageId::CmdInitDescription,
     },
     CommandInfo {
         name: "settings",
         aliases: &[],
-        description: "Show persistent settings",
         usage: "/settings",
+        description_id: MessageId::CmdSettingsDescription,
     },
     CommandInfo {
         name: "statusline",
         aliases: &["status"],
-        description: "Configure which items appear in the footer",
         usage: "/statusline",
+        description_id: MessageId::CmdStatuslineDescription,
     },
     // Skills commands
     CommandInfo {
         name: "skills",
         aliases: &[],
-        description: "List local skills (or --remote to browse the curated registry)",
         usage: "/skills [--remote]",
+        description_id: MessageId::CmdSkillsDescription,
     },
     CommandInfo {
         name: "skill",
         aliases: &[],
-        description: "Activate a skill, or install/update/uninstall/trust a community skill",
         usage: "/skill <name|install <spec>|update <name>|uninstall <name>|trust <name>>",
+        description_id: MessageId::CmdSkillDescription,
     },
     CommandInfo {
         name: "review",
         aliases: &[],
-        description: "Run a structured code review on a file, diff, or PR",
         usage: "/review <target>",
+        description_id: MessageId::CmdReviewDescription,
     },
     CommandInfo {
         name: "restore",
         aliases: &[],
-        description: "Roll back the workspace to a prior pre/post-turn snapshot. With no arg, lists recent snapshots.",
         usage: "/restore [N]",
+        description_id: MessageId::CmdRestoreDescription,
     },
     // RLM command
     CommandInfo {
         name: "rlm",
         aliases: &["recursive"],
-        description: "Recursive Language Model (RLM) turn — store the prompt in a Python REPL and let the model write code to process it, with `llm_query()` / `sub_rlm()` for sub-LLM calls.",
         usage: "/rlm <prompt>",
+        description_id: MessageId::CmdRlmDescription,
     },
     // Debug/cost command
     CommandInfo {
         name: "cost",
         aliases: &[],
-        description: "Show session cost breakdown",
         usage: "/cost",
+        description_id: MessageId::CmdCostDescription,
     },
     // Cache telemetry (#263)
     CommandInfo {
         name: "cache",
         aliases: &[],
-        description: "Show DeepSeek prefix-cache hit/miss stats for the last N turns",
         usage: "/cache [count]",
+        description_id: MessageId::CmdCacheDescription,
     },
 ];
 
@@ -720,7 +729,7 @@ mod tests {
             .find(|cmd| cmd.name == "context")
             .expect("context command should exist");
         assert_eq!(context.aliases, &["ctx"]);
-        assert!(context.description.contains("inspector"));
+        assert!(context.description_for(Locale::En).contains("inspector"));
 
         let mut app = create_test_app();
         let result = execute("/ctx", &mut app);

--- a/crates/tui/src/localization.rs
+++ b/crates/tui/src/localization.rs
@@ -214,6 +214,50 @@ pub enum MessageId {
     HelpFooterMove,
     HelpFooterJump,
     HelpFooterClose,
+    CmdAgentDescription,
+    CmdAttachDescription,
+    CmdCacheDescription,
+    CmdClearDescription,
+    CmdCompactDescription,
+    CmdConfigDescription,
+    CmdContextDescription,
+    CmdCostDescription,
+    CmdCycleDescription,
+    CmdCyclesDescription,
+    CmdExitDescription,
+    CmdExportDescription,
+    CmdHelpDescription,
+    CmdHomeDescription,
+    CmdInitDescription,
+    CmdJobsDescription,
+    CmdLinksDescription,
+    CmdLoadDescription,
+    CmdLogoutDescription,
+    CmdMcpDescription,
+    CmdModelDescription,
+    CmdModelsDescription,
+    CmdNoteDescription,
+    CmdPlanDescription,
+    CmdProviderDescription,
+    CmdQueueDescription,
+    CmdRecallDescription,
+    CmdRestoreDescription,
+    CmdRetryDescription,
+    CmdReviewDescription,
+    CmdRlmDescription,
+    CmdSaveDescription,
+    CmdSessionsDescription,
+    CmdSettingsDescription,
+    CmdSkillDescription,
+    CmdSkillsDescription,
+    CmdStatuslineDescription,
+    CmdSubagentsDescription,
+    CmdSystemDescription,
+    CmdTaskDescription,
+    CmdTokensDescription,
+    CmdTrustDescription,
+    CmdUndoDescription,
+    CmdYoloDescription,
 }
 
 #[allow(dead_code)]
@@ -245,6 +289,50 @@ pub const ALL_MESSAGE_IDS: &[MessageId] = &[
     MessageId::HelpFooterMove,
     MessageId::HelpFooterJump,
     MessageId::HelpFooterClose,
+    MessageId::CmdAgentDescription,
+    MessageId::CmdAttachDescription,
+    MessageId::CmdCacheDescription,
+    MessageId::CmdClearDescription,
+    MessageId::CmdCompactDescription,
+    MessageId::CmdConfigDescription,
+    MessageId::CmdContextDescription,
+    MessageId::CmdCostDescription,
+    MessageId::CmdCycleDescription,
+    MessageId::CmdCyclesDescription,
+    MessageId::CmdExitDescription,
+    MessageId::CmdExportDescription,
+    MessageId::CmdHelpDescription,
+    MessageId::CmdHomeDescription,
+    MessageId::CmdInitDescription,
+    MessageId::CmdJobsDescription,
+    MessageId::CmdLinksDescription,
+    MessageId::CmdLoadDescription,
+    MessageId::CmdLogoutDescription,
+    MessageId::CmdMcpDescription,
+    MessageId::CmdModelDescription,
+    MessageId::CmdModelsDescription,
+    MessageId::CmdNoteDescription,
+    MessageId::CmdPlanDescription,
+    MessageId::CmdProviderDescription,
+    MessageId::CmdQueueDescription,
+    MessageId::CmdRecallDescription,
+    MessageId::CmdRestoreDescription,
+    MessageId::CmdRetryDescription,
+    MessageId::CmdReviewDescription,
+    MessageId::CmdRlmDescription,
+    MessageId::CmdSaveDescription,
+    MessageId::CmdSessionsDescription,
+    MessageId::CmdSettingsDescription,
+    MessageId::CmdSkillDescription,
+    MessageId::CmdSkillsDescription,
+    MessageId::CmdStatuslineDescription,
+    MessageId::CmdSubagentsDescription,
+    MessageId::CmdSystemDescription,
+    MessageId::CmdTaskDescription,
+    MessageId::CmdTokensDescription,
+    MessageId::CmdTrustDescription,
+    MessageId::CmdUndoDescription,
+    MessageId::CmdYoloDescription,
 ];
 
 pub fn tr(locale: Locale, id: MessageId) -> &'static str {
@@ -396,6 +484,72 @@ fn english(id: MessageId) -> &'static str {
         MessageId::HelpFooterMove => "  Up/Down move ",
         MessageId::HelpFooterJump => " PgUp/PgDn jump ",
         MessageId::HelpFooterClose => " Esc close ",
+        MessageId::CmdAgentDescription => "Switch to agent mode",
+        MessageId::CmdAttachDescription => {
+            "Attach image/video media; use @path for text files or directories"
+        }
+        MessageId::CmdCacheDescription => {
+            "Show DeepSeek prefix-cache hit/miss stats for the last N turns"
+        }
+        MessageId::CmdClearDescription => "Clear conversation history",
+        MessageId::CmdCompactDescription => {
+            "Trigger context compaction to free up space (legacy; v0.6.6 prefers cycle restart)"
+        }
+        MessageId::CmdConfigDescription => "Open interactive configuration editor",
+        MessageId::CmdContextDescription => "Open compact session context inspector",
+        MessageId::CmdCostDescription => "Show session cost breakdown",
+        MessageId::CmdCycleDescription => "Show the carry-forward briefing for a specific cycle",
+        MessageId::CmdCyclesDescription => "List checkpoint-restart cycle handoffs in this session",
+        MessageId::CmdExitDescription => "Exit the application",
+        MessageId::CmdExportDescription => "Export conversation to markdown",
+        MessageId::CmdHelpDescription => "Show help information",
+        MessageId::CmdHomeDescription => "Show home dashboard with stats and quick actions",
+        MessageId::CmdInitDescription => "Generate AGENTS.md for project",
+        MessageId::CmdJobsDescription => "Inspect and control background shell jobs",
+        MessageId::CmdLinksDescription => "Show DeepSeek dashboard and docs links",
+        MessageId::CmdLoadDescription => "Load session from file",
+        MessageId::CmdLogoutDescription => "Clear API key and return to setup",
+        MessageId::CmdMcpDescription => "Open or manage MCP servers",
+        MessageId::CmdModelDescription => "Switch or view current model",
+        MessageId::CmdModelsDescription => "List available models from API",
+        MessageId::CmdNoteDescription => {
+            "Append note to persistent notes file (.deepseek/notes.md)"
+        }
+        MessageId::CmdPlanDescription => {
+            "Switch to plan mode and review suggested implementation steps"
+        }
+        MessageId::CmdProviderDescription => {
+            "Switch or view the active LLM backend (deepseek | nvidia-nim)"
+        }
+        MessageId::CmdQueueDescription => "View or edit queued messages",
+        MessageId::CmdRecallDescription => "Search prior cycle archives (BM25 over message text)",
+        MessageId::CmdRestoreDescription => {
+            "Roll back the workspace to a prior pre/post-turn snapshot. With no arg, lists recent snapshots."
+        }
+        MessageId::CmdRetryDescription => "Retry the last request",
+        MessageId::CmdReviewDescription => "Run a structured code review on a file, diff, or PR",
+        MessageId::CmdRlmDescription => {
+            "Recursive Language Model (RLM) turn — store the prompt in a Python REPL and let the model write code to process it, with `llm_query()` / `sub_rlm()` for sub-LLM calls."
+        }
+        MessageId::CmdSaveDescription => "Save session to file",
+        MessageId::CmdSessionsDescription => "Open session picker",
+        MessageId::CmdSettingsDescription => "Show persistent settings",
+        MessageId::CmdSkillDescription => {
+            "Activate a skill, or install/update/uninstall/trust a community skill"
+        }
+        MessageId::CmdSkillsDescription => {
+            "List local skills (or --remote to browse the curated registry)"
+        }
+        MessageId::CmdStatuslineDescription => "Configure which items appear in the footer",
+        MessageId::CmdSubagentsDescription => "List sub-agent status",
+        MessageId::CmdSystemDescription => "Show current system prompt",
+        MessageId::CmdTaskDescription => "Manage background tasks",
+        MessageId::CmdTokensDescription => "Show token usage for session",
+        MessageId::CmdTrustDescription => {
+            "Manage workspace trust and per-path allowlist (`/trust add <path>`, `/trust list`, `/trust on|off`)"
+        }
+        MessageId::CmdUndoDescription => "Remove last message pair",
+        MessageId::CmdYoloDescription => "Enable YOLO mode (shell + trust + auto-approve)",
     }
 }
 
@@ -443,6 +597,72 @@ fn japanese(id: MessageId) -> Option<&'static str> {
         MessageId::HelpFooterMove => "  Up/Down 移動 ",
         MessageId::HelpFooterJump => " PgUp/PgDn ジャンプ ",
         MessageId::HelpFooterClose => " Esc 閉じる ",
+        MessageId::CmdAgentDescription => "Agent モードに切り替え",
+        MessageId::CmdAttachDescription => {
+            "画像・動画メディアを添付（テキストファイルやディレクトリは @path）"
+        }
+        MessageId::CmdCacheDescription => {
+            "直近 N ターンの DeepSeek プレフィックスキャッシュのヒット/ミス統計を表示"
+        }
+        MessageId::CmdClearDescription => "会話履歴をクリア",
+        MessageId::CmdCompactDescription => {
+            "コンテキスト圧縮で容量を確保（旧式：v0.6.6 以降はサイクル再起動を推奨）"
+        }
+        MessageId::CmdConfigDescription => "インタラクティブな設定エディタを開く",
+        MessageId::CmdContextDescription => "コンパクトなセッションコンテキスト検査ツールを開く",
+        MessageId::CmdCostDescription => "セッションのコスト内訳を表示",
+        MessageId::CmdCycleDescription => "指定したサイクルの引き継ぎブリーフィングを表示",
+        MessageId::CmdCyclesDescription => {
+            "セッション内のチェックポイント再起動サイクルの引き継ぎを一覧表示"
+        }
+        MessageId::CmdExitDescription => "アプリを終了",
+        MessageId::CmdExportDescription => "会話を Markdown にエクスポート",
+        MessageId::CmdHelpDescription => "ヘルプを表示",
+        MessageId::CmdHomeDescription => "統計とクイックアクション付きのホームダッシュボードを表示",
+        MessageId::CmdInitDescription => "プロジェクト用に AGENTS.md を生成",
+        MessageId::CmdJobsDescription => "バックグラウンドのシェルジョブを確認・制御",
+        MessageId::CmdLinksDescription => "DeepSeek ダッシュボードとドキュメントへのリンクを表示",
+        MessageId::CmdLoadDescription => "ファイルからセッションを読み込み",
+        MessageId::CmdLogoutDescription => "API キーを消去してセットアップに戻る",
+        MessageId::CmdMcpDescription => "MCP サーバを開く・管理する",
+        MessageId::CmdModelDescription => "現在のモデルを切り替え・確認",
+        MessageId::CmdModelsDescription => "API から利用可能なモデルを一覧表示",
+        MessageId::CmdNoteDescription => "永続ノートファイル（.deepseek/notes.md）に追記",
+        MessageId::CmdPlanDescription => "Plan モードに切り替え、推奨される実装手順を確認",
+        MessageId::CmdProviderDescription => {
+            "現在の LLM バックエンドを切り替え・確認（deepseek | nvidia-nim）"
+        }
+        MessageId::CmdQueueDescription => "キューされたメッセージを確認・編集",
+        MessageId::CmdRecallDescription => {
+            "過去のサイクルアーカイブを検索（メッセージ本文への BM25 検索）"
+        }
+        MessageId::CmdRestoreDescription => {
+            "ワークスペースを以前のターン前/後スナップショットへロールバック。引数なしで最近のスナップショットを一覧表示。"
+        }
+        MessageId::CmdRetryDescription => "直前のリクエストを再試行",
+        MessageId::CmdReviewDescription => "ファイル・diff・PR に対して構造化コードレビューを実行",
+        MessageId::CmdRlmDescription => {
+            "再帰言語モデル（RLM）ターン — プロンプトを Python REPL に格納し、モデルが処理コードを記述。サブ LLM 呼び出しは `llm_query()` / `sub_rlm()`。"
+        }
+        MessageId::CmdSaveDescription => "セッションをファイルに保存",
+        MessageId::CmdSessionsDescription => "セッションピッカーを開く",
+        MessageId::CmdSettingsDescription => "永続化された設定を表示",
+        MessageId::CmdSkillDescription => {
+            "スキルを有効化、またはコミュニティスキルをインストール／更新／アンインストール／信頼"
+        }
+        MessageId::CmdSkillsDescription => {
+            "ローカルスキルを一覧表示（--remote で精選レジストリを参照）"
+        }
+        MessageId::CmdStatuslineDescription => "フッターに表示する項目を設定",
+        MessageId::CmdSubagentsDescription => "サブエージェントの状態を一覧表示",
+        MessageId::CmdSystemDescription => "現在のシステムプロンプトを表示",
+        MessageId::CmdTaskDescription => "バックグラウンドタスクを管理",
+        MessageId::CmdTokensDescription => "セッションのトークン使用量を表示",
+        MessageId::CmdTrustDescription => {
+            "ワークスペースの信頼設定とパス別許可リストを管理（`/trust add <path>`、`/trust list`、`/trust on|off`）"
+        }
+        MessageId::CmdUndoDescription => "最後のメッセージ対を削除",
+        MessageId::CmdYoloDescription => "YOLO モードを有効化（shell + 信頼 + 自動承認）",
     })
 }
 
@@ -479,6 +699,58 @@ fn chinese_simplified(id: MessageId) -> Option<&'static str> {
         MessageId::HelpFooterMove => "  Up/Down 移动 ",
         MessageId::HelpFooterJump => " PgUp/PgDn 跳转 ",
         MessageId::HelpFooterClose => " Esc 关闭 ",
+        MessageId::CmdAgentDescription => "切换到 Agent 模式",
+        MessageId::CmdAttachDescription => "附加图片或视频媒体；文本文件或目录请使用 @path",
+        MessageId::CmdCacheDescription => "显示最近 N 轮的 DeepSeek 前缀缓存命中/未命中统计",
+        MessageId::CmdClearDescription => "清除对话历史",
+        MessageId::CmdCompactDescription => {
+            "触发上下文压缩以释放空间（旧版命令；v0.6.6 起建议改用循环重启）"
+        }
+        MessageId::CmdConfigDescription => "打开交互式配置编辑器",
+        MessageId::CmdContextDescription => "打开紧凑会话上下文检查器",
+        MessageId::CmdCostDescription => "显示本次会话的费用明细",
+        MessageId::CmdCycleDescription => "显示指定循环的延续简报",
+        MessageId::CmdCyclesDescription => "列出本次会话中的检查点重启循环交接",
+        MessageId::CmdExitDescription => "退出应用",
+        MessageId::CmdExportDescription => "将对话导出为 Markdown",
+        MessageId::CmdHelpDescription => "显示帮助信息",
+        MessageId::CmdHomeDescription => "显示主页面板，含统计与快捷操作",
+        MessageId::CmdInitDescription => "为项目生成 AGENTS.md",
+        MessageId::CmdJobsDescription => "查看并管理后台 shell 作业",
+        MessageId::CmdLinksDescription => "显示 DeepSeek 控制台与文档链接",
+        MessageId::CmdLoadDescription => "从文件加载会话",
+        MessageId::CmdLogoutDescription => "清除 API 密钥并返回设置",
+        MessageId::CmdMcpDescription => "打开或管理 MCP 服务器",
+        MessageId::CmdModelDescription => "切换或查看当前模型",
+        MessageId::CmdModelsDescription => "列出 API 中可用的模型",
+        MessageId::CmdNoteDescription => "将笔记追加到持久笔记文件（.deepseek/notes.md）",
+        MessageId::CmdPlanDescription => "切换到 Plan 模式并查看建议的实现步骤",
+        MessageId::CmdProviderDescription => "切换或查看当前 LLM 后端（deepseek | nvidia-nim）",
+        MessageId::CmdQueueDescription => "查看或编辑已排队的消息",
+        MessageId::CmdRecallDescription => "搜索此前的循环归档（基于消息文本的 BM25 检索）",
+        MessageId::CmdRestoreDescription => {
+            "将工作区回滚到此前的轮次前/后快照。不带参数时列出最近的快照。"
+        }
+        MessageId::CmdRetryDescription => "重试上一次请求",
+        MessageId::CmdReviewDescription => "对文件、diff 或 PR 进行结构化代码审查",
+        MessageId::CmdRlmDescription => {
+            "递归语言模型（RLM）轮次 —— 将提示词存入 Python REPL，让模型编写代码进行处理；可用 `llm_query()` / `sub_rlm()` 调用子 LLM。"
+        }
+        MessageId::CmdSaveDescription => "将会话保存到文件",
+        MessageId::CmdSessionsDescription => "打开会话选择器",
+        MessageId::CmdSettingsDescription => "显示持久化设置",
+        MessageId::CmdSkillDescription => "激活技能，或安装/更新/卸载/信任社区技能",
+        MessageId::CmdSkillsDescription => "列出本地技能（或使用 --remote 浏览精选注册表）",
+        MessageId::CmdStatuslineDescription => "配置底栏要显示哪些条目",
+        MessageId::CmdSubagentsDescription => "列出子代理状态",
+        MessageId::CmdSystemDescription => "显示当前系统提示词",
+        MessageId::CmdTaskDescription => "管理后台任务",
+        MessageId::CmdTokensDescription => "显示本次会话的 token 用量",
+        MessageId::CmdTrustDescription => {
+            "管理工作区信任与按路径的白名单（`/trust add <path>`、`/trust list`、`/trust on|off`）"
+        }
+        MessageId::CmdUndoDescription => "移除最后一组消息对",
+        MessageId::CmdYoloDescription => "启用 YOLO 模式（shell + 信任 + 自动批准）",
     })
 }
 
@@ -517,6 +789,82 @@ fn portuguese_brazil(id: MessageId) -> Option<&'static str> {
         MessageId::HelpFooterMove => "  Up/Down move ",
         MessageId::HelpFooterJump => " PgUp/PgDn salta ",
         MessageId::HelpFooterClose => " Esc fecha ",
+        MessageId::CmdAgentDescription => "Mudar para o modo agent",
+        MessageId::CmdAttachDescription => {
+            "Anexar imagem ou vídeo; use @path para arquivos de texto ou diretórios"
+        }
+        MessageId::CmdCacheDescription => {
+            "Exibir estatísticas de hit/miss do cache de prefixo DeepSeek nas últimas N rodadas"
+        }
+        MessageId::CmdClearDescription => "Limpar o histórico da conversa",
+        MessageId::CmdCompactDescription => {
+            "Compactar o contexto para liberar espaço (legado; a v0.6.6 prefere o reinício de ciclo)"
+        }
+        MessageId::CmdConfigDescription => "Abrir o editor interativo de configuração",
+        MessageId::CmdContextDescription => "Abrir o inspetor compacto de contexto da sessão",
+        MessageId::CmdCostDescription => "Exibir o detalhamento de custo da sessão",
+        MessageId::CmdCycleDescription => {
+            "Exibir o briefing de continuidade de um ciclo específico"
+        }
+        MessageId::CmdCyclesDescription => {
+            "Listar as transferências dos ciclos checkpoint-restart desta sessão"
+        }
+        MessageId::CmdExitDescription => "Sair do aplicativo",
+        MessageId::CmdExportDescription => "Exportar a conversa para markdown",
+        MessageId::CmdHelpDescription => "Exibir informações de ajuda",
+        MessageId::CmdHomeDescription => "Exibir o painel inicial com estatísticas e ações rápidas",
+        MessageId::CmdInitDescription => "Gerar AGENTS.md para o projeto",
+        MessageId::CmdJobsDescription => "Inspecionar e controlar jobs de shell em segundo plano",
+        MessageId::CmdLinksDescription => "Exibir links do painel e da documentação do DeepSeek",
+        MessageId::CmdLoadDescription => "Carregar a sessão de um arquivo",
+        MessageId::CmdLogoutDescription => "Limpar a chave de API e voltar à configuração",
+        MessageId::CmdMcpDescription => "Abrir ou gerenciar servidores MCP",
+        MessageId::CmdModelDescription => "Trocar ou exibir o modelo atual",
+        MessageId::CmdModelsDescription => "Listar os modelos disponíveis pela API",
+        MessageId::CmdNoteDescription => {
+            "Adicionar nota ao arquivo persistente (.deepseek/notes.md)"
+        }
+        MessageId::CmdPlanDescription => {
+            "Mudar para o modo plan e revisar os passos de implementação sugeridos"
+        }
+        MessageId::CmdProviderDescription => {
+            "Trocar ou exibir o backend LLM ativo (deepseek | nvidia-nim)"
+        }
+        MessageId::CmdQueueDescription => "Ver ou editar mensagens enfileiradas",
+        MessageId::CmdRecallDescription => {
+            "Buscar arquivos de ciclos anteriores (BM25 sobre o texto das mensagens)"
+        }
+        MessageId::CmdRestoreDescription => {
+            "Reverter o workspace a um snapshot pré/pós-turno anterior. Sem argumento, lista os snapshots recentes."
+        }
+        MessageId::CmdRetryDescription => "Repetir a última requisição",
+        MessageId::CmdReviewDescription => {
+            "Executar uma revisão de código estruturada em um arquivo, diff ou PR"
+        }
+        MessageId::CmdRlmDescription => {
+            "Turno do Recursive Language Model (RLM) — guarda o prompt em um REPL Python e deixa o modelo escrever o código que o processa; use `llm_query()` / `sub_rlm()` para chamadas a sub-LLMs."
+        }
+        MessageId::CmdSaveDescription => "Salvar a sessão em arquivo",
+        MessageId::CmdSessionsDescription => "Abrir o seletor de sessões",
+        MessageId::CmdSettingsDescription => "Exibir as configurações persistidas",
+        MessageId::CmdSkillDescription => {
+            "Ativar uma skill, ou instalar/atualizar/desinstalar/confiar em uma skill da comunidade"
+        }
+        MessageId::CmdSkillsDescription => {
+            "Listar skills locais (ou --remote para navegar pelo registro curado)"
+        }
+        MessageId::CmdStatuslineDescription => "Configurar quais itens aparecem no rodapé",
+        MessageId::CmdSubagentsDescription => "Listar o status dos sub-agentes",
+        MessageId::CmdSystemDescription => "Exibir o prompt de sistema atual",
+        MessageId::CmdTaskDescription => "Gerenciar tarefas em segundo plano",
+        MessageId::CmdTokensDescription => "Exibir o uso de tokens da sessão",
+        MessageId::CmdTrustDescription => {
+            "Gerenciar a confiança do workspace e a allowlist por caminho (`/trust add <path>`, `/trust list`, `/trust on|off`)"
+        }
+        MessageId::CmdUndoDescription => "Remover o último par de mensagens",
+        MessageId::CmdYoloDescription => {
+            "Ativar o modo YOLO (shell + confiança + aprovação automática)"
+        }
     })
 }
 

--- a/crates/tui/src/tui/command_palette.rs
+++ b/crates/tui/src/tui/command_palette.rs
@@ -14,6 +14,7 @@ use ratatui::{
 use unicode_width::UnicodeWidthStr;
 
 use crate::commands;
+use crate::localization::Locale;
 use crate::palette;
 use crate::skills::SkillRegistry;
 use crate::tools::spec::ApprovalRequirement;
@@ -46,6 +47,7 @@ pub struct CommandPaletteView {
 }
 
 pub fn build_entries(
+    locale: Locale,
     skills_dir: &Path,
     workspace: &Path,
     mcp_config_path: &Path,
@@ -54,7 +56,7 @@ pub fn build_entries(
     let mut entries = Vec::new();
 
     for command in commands::COMMANDS {
-        let mut description = command.palette_description();
+        let mut description = command.palette_description_for(locale);
         if command.requires_argument() {
             description.push_str("  ");
             description.push_str(command.usage);
@@ -919,7 +921,13 @@ mod tests {
 
     #[test]
     fn command_palette_command_entries_include_links_and_config_but_not_removed_commands() {
-        let entries = build_entries(Path::new("."), Path::new("."), Path::new("mcp.json"), None);
+        let entries = build_entries(
+            Locale::En,
+            Path::new("."),
+            Path::new("."),
+            Path::new("mcp.json"),
+            None,
+        );
         let command_labels = entries
             .iter()
             .filter(|entry| entry.section == PaletteSection::Command)
@@ -934,7 +942,13 @@ mod tests {
 
     #[test]
     fn command_palette_inserts_model_command_for_argument_entry() {
-        let entries = build_entries(Path::new("."), Path::new("."), Path::new("mcp.json"), None);
+        let entries = build_entries(
+            Locale::En,
+            Path::new("."),
+            Path::new("."),
+            Path::new("mcp.json"),
+            None,
+        );
         let model = entries
             .iter()
             .find(|entry| entry.section == PaletteSection::Command && entry.label == "/model")
@@ -991,6 +1005,7 @@ mod tests {
             ],
         };
         let entries = build_entries(
+            Locale::En,
             Path::new("."),
             Path::new("."),
             Path::new("mcp.json"),
@@ -1044,6 +1059,7 @@ mod tests {
             }],
         };
         let entries = build_entries(
+            Locale::En,
             Path::new("."),
             Path::new("."),
             Path::new("mcp.json"),

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -1430,6 +1430,7 @@ async fn run_event_loop(
                 }
                 app.view_stack
                     .push(CommandPaletteView::new(build_command_palette_entries(
+                        app.ui_locale,
                         &app.skills_dir,
                         &app.workspace,
                         &app.mcp_config_path,
@@ -5721,6 +5722,7 @@ fn handle_context_menu_action(app: &mut App, action: ContextMenuAction) {
         ContextMenuAction::OpenCommandPalette => {
             app.view_stack
                 .push(CommandPaletteView::new(build_command_palette_entries(
+                    app.ui_locale,
                     &app.skills_dir,
                     &app.workspace,
                     &app.mcp_config_path,

--- a/crates/tui/src/tui/views/help.rs
+++ b/crates/tui/src/tui/views/help.rs
@@ -88,7 +88,7 @@ impl HelpView {
     }
 
     pub fn new_for_locale(locale: Locale) -> Self {
-        let entries = build_entries();
+        let entries = build_entries(locale);
         let mut view = Self {
             locale,
             entries,
@@ -144,17 +144,18 @@ impl HelpView {
     }
 }
 
-fn build_entries() -> Vec<HelpEntry> {
+fn build_entries(locale: Locale) -> Vec<HelpEntry> {
     let mut entries = Vec::new();
 
     for command in commands::COMMANDS {
         let label = format!("/{}", command.name);
+        let localized = command.description_for(locale);
         let description = if command.aliases.is_empty() {
-            command.description.to_string()
+            localized.to_string()
         } else {
             format!(
                 "{}  (aliases: {})",
-                command.description,
+                localized,
                 command
                     .aliases
                     .iter()


### PR DESCRIPTION
## Summary

First incremental PR against issue #285 (expand zh-Hans localization).

Adds **44 new `MessageId`s** — one per slash command — and translations to all four shipped locales (en/ja/zh-Hans/pt-BR). Refactors `CommandInfo` so the English description now lives in `localization.rs` (single source of truth) instead of being duplicated on the struct, and threads the active `Locale` through the three render surfaces:

- `crates/tui/src/tui/views/help.rs` — the `?` / `F1` / `Ctrl+/` help overlay (now passes `locale` through `build_entries`)
- `crates/tui/src/tui/command_palette.rs` — the `Ctrl+K` command palette (`build_entries` now takes `Locale` as its first arg; both production callsites in `tui/ui.rs:1432` and `tui/ui.rs:5723` pass `app.ui_locale`)
- `crates/tui/src/commands/core.rs:18` — the text-mode `/help <command>` output (now uses `cmd.description_for(app.ui_locale)`)

### Out of scope by design

- **Tool descriptions sent to the model (`tool.description()`) stay English.** Reasons: training-data alignment, the prefix cache wouldn't fork per-locale anyway, and the model already responds in the user's language because they ask in Chinese — not because the prompt is translated.
- **The base system prompt** (`crates/tui/src/prompts/base.md` and overlays) — same reasoning.
- **Slash-command usage strings** (e.g. `/cache [count]`, `/queue [list|edit <n>|drop <n>|clear]`) stay English. They're placeholder syntax, not natural language; cache stability and copy-pasteability win over translation here.

### How translations were sourced

I (Claude Opus 4.7) wrote each translation by hand rather than machine-translating literally. The Chinese Simplified strings in particular aim for the tone of the existing 27 zh-Hans messages already in `localization.rs` — concise, plain noun-verb-object structure, idiomatic phrasing. Reviewers fluent in any of the four languages: please flag anything that reads as awkward or off-register.

### Test coverage

The existing `shipped_first_pack_has_no_missing_core_messages` test iterates `ALL_MESSAGE_IDS` across `Locale::shipped()` (en/ja/zh-Hans/pt-BR), so all 44 new IDs are automatically required to be present in all four locale arms or CI fails. No new test needed.

The `command.description` field on `CommandInfo` was removed (now strictly redundant with `english(description_id)`); two unit tests that read it were updated to use `command.description_for(Locale::En)`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- [x] `cargo test --workspace --all-features --locked` — 1763 / 1763 in main TUI binary, all parity gates green
- [x] Parity tests: `cargo test -p deepseek-tui-core --test snapshot --locked` (1/1), `cargo test -p deepseek-protocol --test parity_protocol --locked` (3/3), `cargo test -p deepseek-state --test parity_state --locked` (1/1)
- [x] Manual visual check: `LANG=zh_CN.UTF-8 deepseek` then `/help` and `Ctrl+K` show zh-Hans descriptions; `LANG=en_US.UTF-8` shows English; `/help clear` text command shows the localized text.

## Sequel PRs (in flight)

- **Phase 1b** — `/tokens` `/cost` `/cache` debug command output (paste-into-bug-report surfaces).
- **Phase 1c** — footer mode hints (the AGENT/YOLO/PLAN labels stay English; the hint text localizes).
- **Phase 1d** — `deepseek doctor` section headings and verdict lines (paths/env-var-names/version-strings stay English; routes through `display_path` for screenshot-likely surfaces).
- **Phase 2** — setup wizard, `deepseek init`, missing-companion-binary error.
- **Phase 3** — `format_tool_error`, `SandboxManager::denial_message`, `approval_*` messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)