### PR TITLE
chore(release): bump version to 0.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.4] - 2026-05-02
+
+### Added
+- **Localization expansion (Phase 1, #285)** — every slash command's help
+  description, the full `/tokens` / `/cost` / `/cache` debug output, the
+  footer state and chip text, and the help-overlay section headings are
+  now translated for all four shipped locales (`en`, `ja`, `zh-Hans`,
+  `pt-BR`). Set the language with `/config locale zh-Hans` (or
+  `LANG=zh_CN.UTF-8` / `LC_ALL=zh_CN.UTF-8` from the shell). Non-Latin
+  scripts render via the same `unicode_width` plumbing the existing 27
+  chrome strings already use; the `shipped_first_pack_has_no_missing_core_messages`
+  test enforces full coverage across all four locales for every new
+  `MessageId`. Tool descriptions sent to the model and the base system
+  prompt intentionally remain English (training-data alignment, prefix
+  cache stability).
+  - Phase 1a (#294): 44 new IDs covering slash commands.
+  - Phase 1b (#295): 13 new IDs covering `/tokens` / `/cost` / `/cache`
+    debug output. Templates use `{placeholder}` substitution so a
+    translator can re-order args freely.
+  - Phase 1c (#296): 11 new IDs covering footer state, sub-agent chip,
+    quit-confirmation toast, and help-overlay section labels.
+- **Stable cache prefix** (#263) — five companion fixes to keep the
+  DeepSeek prefix cache stable across turns: drop volatile fields from
+  the working-set summary block (#280, #287), place handoff and
+  working-set after the static prompt blocks (#288 → #292), memoise the
+  tool catalog so descriptions stay byte-stable (#289), sort
+  `project_tree` and `summarize_project` output (#290), and use a unique
+  fallback id for parallel streaming tool calls so downstream tool-result
+  routing doesn't match the first call twice (#291). The combined effect
+  is a meaningful jump in cache hit rate after the third turn.
+
 ### Fixed
 - **Agent-mode shell exec could not reach the network** (#272) — the seatbelt
   default policy denies all outbound network including DNS, so any

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1011,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-agent"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "deepseek-config",
  "serde",
@@ -1019,7 +1019,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-app-server"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "anyhow",
  "axum",
@@ -1042,7 +1042,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-config"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "anyhow",
  "deepseek-secrets",
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-core"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1074,7 +1074,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-execpolicy"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "anyhow",
  "deepseek-protocol",
@@ -1083,7 +1083,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-hooks"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1097,7 +1097,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-mcp"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "anyhow",
  "deepseek-protocol",
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-protocol"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-secrets"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "dirs",
  "keyring",
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-state"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1140,7 +1140,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-tools"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1153,7 +1153,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-tui"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "anyhow",
  "arboard",
@@ -1214,7 +1214,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-tui-cli"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1237,7 +1237,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-tui-core"
-version = "0.8.3"
+version = "0.8.4"
 
 [[package]]
 name = "deranged"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = ["crates/cli", "crates/app-server", "crates/tui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.8.3"
+version = "0.8.4"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/Hmbown/DeepSeek-TUI"

--- a/npm/deepseek-tui/package.json
+++ b/npm/deepseek-tui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-tui",
-  "version": "0.8.3",
-  "deepseekBinaryVersion": "0.8.3",
+  "version": "0.8.4",
+  "deepseekBinaryVersion": "0.8.4",
   "description": "Install and run deepseek and deepseek-tui binaries from GitHub release artifacts.",
   "author": "Hmbown",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Land the version bump and CHANGELOG entry on `feat/v0.8.4` so the release branch is ready to PR into `main`. Once this merges, `feat/v0.8.4` is the v0.8.4 release candidate.

- `Cargo.toml` workspace version: `0.8.3` → `0.8.4`
- `npm/deepseek-tui/package.json` version + `deepseekBinaryVersion`: `0.8.3` → `0.8.4`
- `Cargo.lock` regenerated

CHANGELOG `[Unreleased]` → `[0.8.4] - 2026-05-02` with two new sections summarizing what's landed:

1. **Localization expansion (Phase 1, #285)** — 68 new `MessageId`s across all four shipped locales (en/ja/zh-Hans/pt-BR) covering:
   - 44 slash-command descriptions (#294)
   - 13 debug-command output blocks (#295)
   - 11 footer state + help-overlay section labels (#296)

2. **Stable cache prefix (#263)** — five companion fixes that keep the DeepSeek prefix cache stable across turns: drop volatile fields from working-set summary block (#280→#287), reorder static/volatile prompt blocks (#288→#292), memoise tool catalog (#289), sort `project_tree` and `summarize_project` output (#290), unique fallback id for parallel streaming tool calls (#291).

Plus the existing `[Unreleased]` items: agent-mode network exec (#272), `/skill` GitHub URL parsing (#269), V4 Pro discount expiry extension (#267).

### Deferred to v0.8.5

- Phase 1d: doctor output (~100 strings, deferred to keep this release scoped).
- Phase 2: setup wizard, `deepseek init`, missing-companion-binary message.
- Phase 3: tool errors, sandbox denial messages, approval surfaces.

The shipped Phase 1 surfaces are the highest-traffic UI paths a new zh-Hans user encounters first; the deferred phases are problem-path surfaces (doctor when things break, errors when tools fail) that lose less by waiting one release.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- [x] `cargo test --workspace --all-features --locked` — 1765 / 1765 in main TUI binary, all parity gates green
- [x] `scripts/release/check-versions.sh` parity (Cargo.toml `0.8.4` matches `npm/deepseek-tui/package.json` `0.8.4`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)