### PR TITLE
fix(release): bump internal path-dep versions + repair doc link

### DIFF
--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -7,5 +7,5 @@ repository.workspace = true
 description = "Model/provider registry and fallback strategy for DeepSeek workspace architecture"
 
 [dependencies]
-deepseek-config = { path = "../config", version = "0.8.3" }
+deepseek-config = { path = "../config", version = "0.8.4" }
 serde.workspace = true

--- a/crates/app-server/Cargo.toml
+++ b/crates/app-server/Cargo.toml
@@ -10,15 +10,15 @@ description = "Codex-style app-server transport for DeepSeek workspace architect
 anyhow.workspace = true
 axum.workspace = true
 clap.workspace = true
-deepseek-agent = { path = "../agent", version = "0.8.3" }
-deepseek-config = { path = "../config", version = "0.8.3" }
-deepseek-core = { path = "../core", version = "0.8.3" }
-deepseek-execpolicy = { path = "../execpolicy", version = "0.8.3" }
-deepseek-hooks = { path = "../hooks", version = "0.8.3" }
-deepseek-mcp = { path = "../mcp", version = "0.8.3" }
-deepseek-protocol = { path = "../protocol", version = "0.8.3" }
-deepseek-state = { path = "../state", version = "0.8.3" }
-deepseek-tools = { path = "../tools", version = "0.8.3" }
+deepseek-agent = { path = "../agent", version = "0.8.4" }
+deepseek-config = { path = "../config", version = "0.8.4" }
+deepseek-core = { path = "../core", version = "0.8.4" }
+deepseek-execpolicy = { path = "../execpolicy", version = "0.8.4" }
+deepseek-hooks = { path = "../hooks", version = "0.8.4" }
+deepseek-mcp = { path = "../mcp", version = "0.8.4" }
+deepseek-protocol = { path = "../protocol", version = "0.8.4" }
+deepseek-state = { path = "../state", version = "0.8.4" }
+deepseek-tools = { path = "../tools", version = "0.8.4" }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -14,13 +14,13 @@ path = "src/main.rs"
 anyhow.workspace = true
 clap.workspace = true
 clap_complete.workspace = true
-deepseek-agent = { path = "../agent", version = "0.8.3" }
-deepseek-app-server = { path = "../app-server", version = "0.8.3" }
-deepseek-config = { path = "../config", version = "0.8.3" }
-deepseek-execpolicy = { path = "../execpolicy", version = "0.8.3" }
-deepseek-mcp = { path = "../mcp", version = "0.8.3" }
-deepseek-secrets = { path = "../secrets", version = "0.8.3" }
-deepseek-state = { path = "../state", version = "0.8.3" }
+deepseek-agent = { path = "../agent", version = "0.8.4" }
+deepseek-app-server = { path = "../app-server", version = "0.8.4" }
+deepseek-config = { path = "../config", version = "0.8.4" }
+deepseek-execpolicy = { path = "../execpolicy", version = "0.8.4" }
+deepseek-mcp = { path = "../mcp", version = "0.8.4" }
+deepseek-secrets = { path = "../secrets", version = "0.8.4" }
+deepseek-state = { path = "../state", version = "0.8.4" }
 chrono.workspace = true
 dirs.workspace = true
 serde.workspace = true

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -8,7 +8,7 @@ description = "Config schema and precedence model for DeepSeek workspace archite
 
 [dependencies]
 anyhow.workspace = true
-deepseek-secrets = { path = "../secrets", version = "0.8.3" }
+deepseek-secrets = { path = "../secrets", version = "0.8.4" }
 dirs.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -9,14 +9,14 @@ description = "Core runtime boundaries for DeepSeek workspace architecture"
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true
-deepseek-agent = { path = "../agent", version = "0.8.3" }
-deepseek-config = { path = "../config", version = "0.8.3" }
-deepseek-execpolicy = { path = "../execpolicy", version = "0.8.3" }
-deepseek-hooks = { path = "../hooks", version = "0.8.3" }
-deepseek-mcp = { path = "../mcp", version = "0.8.3" }
-deepseek-protocol = { path = "../protocol", version = "0.8.3" }
-deepseek-state = { path = "../state", version = "0.8.3" }
-deepseek-tools = { path = "../tools", version = "0.8.3" }
+deepseek-agent = { path = "../agent", version = "0.8.4" }
+deepseek-config = { path = "../config", version = "0.8.4" }
+deepseek-execpolicy = { path = "../execpolicy", version = "0.8.4" }
+deepseek-hooks = { path = "../hooks", version = "0.8.4" }
+deepseek-mcp = { path = "../mcp", version = "0.8.4" }
+deepseek-protocol = { path = "../protocol", version = "0.8.4" }
+deepseek-state = { path = "../state", version = "0.8.4" }
+deepseek-tools = { path = "../tools", version = "0.8.4" }
 serde_json.workspace = true
 tokio.workspace = true
 uuid.workspace = true

--- a/crates/execpolicy/Cargo.toml
+++ b/crates/execpolicy/Cargo.toml
@@ -8,5 +8,5 @@ description = "Execution policy and approval model parity for DeepSeek workspace
 
 [dependencies]
 anyhow.workspace = true
-deepseek-protocol = { path = "../protocol", version = "0.8.3" }
+deepseek-protocol = { path = "../protocol", version = "0.8.4" }
 serde.workspace = true

--- a/crates/hooks/Cargo.toml
+++ b/crates/hooks/Cargo.toml
@@ -10,7 +10,7 @@ description = "Hook dispatch and notifications parity for DeepSeek workspace arc
 anyhow.workspace = true
 async-trait.workspace = true
 chrono.workspace = true
-deepseek-protocol = { path = "../protocol", version = "0.8.3" }
+deepseek-protocol = { path = "../protocol", version = "0.8.4" }
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -8,6 +8,6 @@ description = "MCP server lifecycle and tool proxy compatibility for DeepSeek wo
 
 [dependencies]
 anyhow.workspace = true
-deepseek-protocol = { path = "../protocol", version = "0.8.3" }
+deepseek-protocol = { path = "../protocol", version = "0.8.4" }
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -9,7 +9,7 @@ description = "Tool invocation lifecycle, schema validation, and scheduler paral
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
-deepseek-protocol = { path = "../protocol", version = "0.8.3" }
+deepseek-protocol = { path = "../protocol", version = "0.8.4" }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -14,9 +14,9 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0.100"
 arboard = "3.4"
-deepseek-tui-cli = { path = "../cli", version = "0.8.3" }
-deepseek-secrets = { path = "../secrets", version = "0.8.3" }
-deepseek-tools = { path = "../tools", version = "0.8.3" }
+deepseek-tui-cli = { path = "../cli", version = "0.8.4" }
+deepseek-secrets = { path = "../secrets", version = "0.8.4" }
+deepseek-tools = { path = "../tools", version = "0.8.4" }
 async-stream = "0.3.6"
 async-trait = "0.1"
 bytes = "1.11.0"

--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -77,8 +77,10 @@ impl CommandResult {
 
 /// Command metadata for help and autocomplete.
 ///
-/// The English description string lives in [`crate::localization::english`]
-/// keyed by `description_id`; resolve it with [`CommandInfo::description_for`].
+/// The English description lives in `localization::english` (private), keyed
+/// by `description_id`. Callers resolve a localized description through
+/// [`CommandInfo::description_for`] which delegates to
+/// [`crate::localization::tr`].
 #[derive(Debug, Clone, Copy)]
 pub struct CommandInfo {
     pub name: &'static str,


### PR DESCRIPTION
## Summary

CI on the release PR (#300, `feat/v0.8.4` → `main`) flagged two regressions introduced by the 0.8.4 version bump in #297:

### 1. Version drift (the `Version drift` job)

The `[workspace.package] version` was bumped to `0.8.4`, but the per-crate `version = "0.8.x"` entries on internal `deepseek-*` path dependencies stayed at `"0.8.3"`. `scripts/release/check-versions.sh` enforces that they match the workspace version (otherwise crates published to crates.io would have mismatched dep specs).

Bumped path deps in 10 Cargo.toml files: `crates/agent`, `crates/app-server`, `crates/cli`, `crates/config`, `crates/core`, `crates/execpolicy`, `crates/hooks`, `crates/mcp`, `crates/tools`, `crates/tui`. (`crates/protocol`, `crates/secrets`, `crates/state`, `crates/tui-core` had no path-dep refs to update.)

### 2. Broken intra-doc-link (the `Documentation` job)

`[crate::localization::english]` resolves to a private function and `RUSTDOCFLAGS=-Dwarnings` makes the broken link a hard error. Rewrote the doc comment to reference the public `CommandInfo::description_for` accessor and `crate::localization::tr` instead.

## Verified locally

- [x] `scripts/release/check-versions.sh` — `Version state OK: workspace=0.8.4, npm=0.8.4, lockfile in sync.`
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps` — green.
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- [x] `cargo test --workspace --all-features --locked`

Once this lands on `feat/v0.8.4`, PR #300 picks up these commits automatically and CI re-runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)