### PR TITLE
fix(shell): validate cwd parameter against workspace boundary

### DIFF
--- a/crates/tui/src/tools/shell.rs
+++ b/crates/tui/src/tools/shell.rs
@@ -1560,11 +1560,18 @@ impl ToolSpec for ExecShellTool {
         }
 
         let policy_override = context.elevated_sandbox_policy.clone();
-        let working_dir = input
+        let working_dir = match input
             .get("cwd")
             .or_else(|| input.get("working_dir"))
             .and_then(serde_json::Value::as_str)
-            .map(str::to_string);
+        {
+            Some(dir) => {
+                // Validate cwd against workspace boundary (same as file tools)
+                let resolved = context.resolve_path(dir)?;
+                Some(resolved.to_string_lossy().to_string())
+            }
+            None => None,
+        };
 
         let result = if interactive {
             let mut manager = context


### PR DESCRIPTION
  The shell tool's `cwd` / `working_dir` JSON parameter was accepted as-is
  without workspace boundary validation. All file tools (`read_file`,
  `write_file`, `list_dir`, etc.) already go through `ToolContext::resolve_path()`
  to enforce workspace boundaries, but `exec_shell` skipped this check entirely.
  This meant the AI model could run shell commands from arbitrary directories
  outside the user's workspace.

  This PR adds a single `resolve_path()` call on the `cwd` parameter, bringing
  the shell tool in line with the existing file tool security model:

  - Paths outside the workspace root are rejected with `ToolError::PathEscape`
  - `trust_mode = true` still bypasses the check (consistent with file tools)
  - `trusted_external_paths` entries are respected automatically
  - Default behavior (no `cwd` argument → use workspace root) is unchanged
  - OS-level sandboxing (Seatbelt/Landlock) remains a separate, orthogonal layer

  ## Changes

  - `crates/tui/src/tools/shell.rs` — Replace raw string extraction of `cwd`
    with a `context.resolve_path(dir)?` validated version (+9 / -2 lines)
