### PR TITLE
feat(compaction): add /anchor command to pin facts across compaction

### DIFF
--- a/crates/tui/src/commands/anchor.rs
+++ b/crates/tui/src/commands/anchor.rs
@@ -1,0 +1,280 @@
+//! Anchor command: pin critical facts that survive compaction
+//!
+//! Unlike `/note` (active lookup), anchors are passive — they are automatically
+//! re-injected into the context after every compaction cycle. Use anchors to
+//! preserve invariants like "This API's status field is unreliable" or
+//! ".ssh/ must never be touched".
+
+use crate::tui::app::App;
+use std::fs;
+use std::io::Write;
+
+use super::CommandResult;
+
+/// Handle the `/anchor` command with subcommands:
+///   /anchor <text>       — add a new anchor
+///   /anchor list         — list all anchors
+///   /anchor remove <n>   — remove anchor by 1-based index
+pub fn anchor(app: &mut App, content: Option<&str>) -> CommandResult {
+    let input = match content {
+        Some(c) => c.trim(),
+        None => {
+            return CommandResult::error(
+                "Usage: /anchor <text> | /anchor list | /anchor remove <n>",
+            );
+        }
+    };
+
+    if input.is_empty() {
+        return CommandResult::error("Usage: /anchor <text> | /anchor list | /anchor remove <n>");
+    }
+
+    // Parse subcommands
+    if input.eq_ignore_ascii_case("list") {
+        return list_anchors(app);
+    }
+
+    if let Some(rest) = input
+        .strip_prefix("remove ")
+        .or_else(|| input.strip_prefix("rm "))
+        .or_else(|| input.strip_prefix("delete "))
+    {
+        return remove_anchor(app, rest.trim());
+    }
+
+    // Default: add a new anchor
+    add_anchor(app, input)
+}
+
+fn anchors_path(app: &App) -> std::path::PathBuf {
+    app.workspace.join(".deepseek").join("anchors.md")
+}
+
+/// Read and split anchors from the file. Each anchor is separated by "\n---\n".
+fn read_anchors(app: &App) -> Vec<String> {
+    let path = anchors_path(app);
+    let content = match fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(_) => return Vec::new(),
+    };
+
+    content
+        .split("\n---\n")
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+/// Write anchors back to the file, joined by "\n---\n".
+fn write_anchors(app: &App, anchors: &[String]) -> Result<(), String> {
+    let path = anchors_path(app);
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create anchors directory: {e}"))?;
+    }
+
+    let content = anchors.join("\n---\n");
+    fs::write(&path, content).map_err(|e| format!("Failed to write anchors file: {e}"))
+}
+
+fn add_anchor(app: &mut App, text: &str) -> CommandResult {
+    let path = anchors_path(app);
+
+    // Ensure parent directory exists
+    if let Some(parent) = path.parent()
+        && let Err(e) = fs::create_dir_all(parent)
+    {
+        return CommandResult::error(format!("Failed to create anchors directory: {e}"));
+    }
+
+    // Append to anchors file
+    let mut file = match fs::OpenOptions::new().create(true).append(true).open(&path) {
+        Ok(f) => f,
+        Err(e) => {
+            return CommandResult::error(format!("Failed to open anchors file: {e}"));
+        }
+    };
+
+    // Write separator and anchor content
+    if let Err(e) = writeln!(file, "\n---\n{}", text) {
+        return CommandResult::error(format!("Failed to write anchor: {e}"));
+    }
+
+    CommandResult::message(format!(
+        "Anchor pinned. It will be auto-injected into context after each compaction.\n\
+         Stored in: {}",
+        path.display()
+    ))
+}
+
+fn list_anchors(app: &App) -> CommandResult {
+    let anchors = read_anchors(app);
+
+    if anchors.is_empty() {
+        return CommandResult::message(
+            "No anchors set. Use /anchor <text> to pin a fact that survives compaction.",
+        );
+    }
+
+    let mut output = format!("Pinned anchors ({} total):\n", anchors.len());
+    for (i, anchor) in anchors.iter().enumerate() {
+        output.push_str(&format!("\n  {}. {}", i + 1, anchor));
+    }
+    output.push_str("\n\nUse /anchor remove <n> to remove an anchor.");
+
+    CommandResult::message(output)
+}
+
+fn remove_anchor(app: &mut App, index_str: &str) -> CommandResult {
+    let index: usize = match index_str.parse() {
+        Ok(n) if n >= 1 => n,
+        _ => {
+            return CommandResult::error(
+                "Invalid index. Use /anchor list to see anchor numbers, then /anchor remove <n>.",
+            );
+        }
+    };
+
+    let mut anchors = read_anchors(app);
+
+    if index > anchors.len() {
+        return CommandResult::error(format!(
+            "Anchor #{index} does not exist. You have {} anchor(s). Use /anchor list to see them.",
+            anchors.len()
+        ));
+    }
+
+    let removed = anchors.remove(index - 1);
+    if let Err(e) = write_anchors(app, &anchors) {
+        return CommandResult::error(e);
+    }
+
+    CommandResult::message(format!("Removed anchor #{index}: {removed}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+    use crate::tui::app::{App, TuiOptions};
+    use tempfile::TempDir;
+
+    fn create_test_app_with_tmpdir(tmpdir: &TempDir) -> App {
+        let options = TuiOptions {
+            model: "deepseek-v4-pro".to_string(),
+            workspace: tmpdir.path().to_path_buf(),
+            config_path: None,
+            config_profile: None,
+            allow_shell: false,
+            use_alt_screen: true,
+            use_mouse_capture: false,
+            use_bracketed_paste: true,
+            max_subagents: 1,
+            skills_dir: tmpdir.path().join("skills"),
+            memory_path: tmpdir.path().join("memory.md"),
+            notes_path: tmpdir.path().join("notes.txt"),
+            mcp_config_path: tmpdir.path().join("mcp.json"),
+            use_memory: false,
+            start_in_agent_mode: false,
+            skip_onboarding: true,
+            yolo: false,
+            resume_session_id: None,
+            initial_input: None,
+        };
+        App::new(options, &Config::default())
+    }
+
+    #[test]
+    fn test_anchor_without_content_returns_error() {
+        let tmpdir = TempDir::new().unwrap();
+        let mut app = create_test_app_with_tmpdir(&tmpdir);
+        let result = anchor(&mut app, None);
+        assert!(result.is_error);
+        assert!(result.message.unwrap().contains("Usage:"));
+    }
+
+    #[test]
+    fn test_anchor_with_empty_content_returns_error() {
+        let tmpdir = TempDir::new().unwrap();
+        let mut app = create_test_app_with_tmpdir(&tmpdir);
+        let result = anchor(&mut app, Some("   "));
+        assert!(result.is_error);
+        assert!(result.message.unwrap().contains("Usage:"));
+    }
+
+    #[test]
+    fn test_anchor_add() {
+        let tmpdir = TempDir::new().unwrap();
+        let mut app = create_test_app_with_tmpdir(&tmpdir);
+        let result = anchor(&mut app, Some("API status field is unreliable"));
+        assert!(!result.is_error);
+        assert!(result.message.unwrap().contains("Anchor pinned"));
+
+        let path = tmpdir.path().join(".deepseek").join("anchors.md");
+        assert!(path.exists());
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("API status field is unreliable"));
+    }
+
+    #[test]
+    fn test_anchor_list_empty() {
+        let tmpdir = TempDir::new().unwrap();
+        let mut app = create_test_app_with_tmpdir(&tmpdir);
+        let result = anchor(&mut app, Some("list"));
+        assert!(!result.is_error);
+        assert!(result.message.unwrap().contains("No anchors set"));
+    }
+
+    #[test]
+    fn test_anchor_list_with_items() {
+        let tmpdir = TempDir::new().unwrap();
+        let mut app = create_test_app_with_tmpdir(&tmpdir);
+        anchor(&mut app, Some("First anchor"));
+        anchor(&mut app, Some("Second anchor"));
+
+        let result = anchor(&mut app, Some("list"));
+        let msg = result.message.unwrap();
+        assert!(msg.contains("2 total"));
+        assert!(msg.contains("1. First anchor"));
+        assert!(msg.contains("2. Second anchor"));
+    }
+
+    #[test]
+    fn test_anchor_remove() {
+        let tmpdir = TempDir::new().unwrap();
+        let mut app = create_test_app_with_tmpdir(&tmpdir);
+        anchor(&mut app, Some("First anchor"));
+        anchor(&mut app, Some("Second anchor"));
+
+        let result = anchor(&mut app, Some("remove 1"));
+        assert!(!result.is_error);
+        assert!(result.message.unwrap().contains("Removed anchor #1"));
+
+        let result = anchor(&mut app, Some("list"));
+        let msg = result.message.unwrap();
+        assert!(msg.contains("1 total"));
+        assert!(msg.contains("Second anchor"));
+        assert!(!msg.contains("First anchor"));
+    }
+
+    #[test]
+    fn test_anchor_remove_invalid_index() {
+        let tmpdir = TempDir::new().unwrap();
+        let mut app = create_test_app_with_tmpdir(&tmpdir);
+        anchor(&mut app, Some("Only anchor"));
+
+        let result = anchor(&mut app, Some("remove 5"));
+        assert!(result.is_error);
+        assert!(result.message.unwrap().contains("does not exist"));
+    }
+
+    #[test]
+    fn test_anchor_remove_non_numeric() {
+        let tmpdir = TempDir::new().unwrap();
+        let mut app = create_test_app_with_tmpdir(&tmpdir);
+        let result = anchor(&mut app, Some("remove abc"));
+        assert!(result.is_error);
+        assert!(result.message.unwrap().contains("Invalid index"));
+    }
+}

--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -3,6 +3,7 @@
 //! This module provides a modular command system inspired by Codex-rs.
 //! Commands are organized by category and dispatched through a central registry.
 
+mod anchor;
 mod attachment;
 mod config;
 mod core;
@@ -132,6 +133,12 @@ impl CommandInfo {
 /// All registered commands
 pub const COMMANDS: &[CommandInfo] = &[
     // Core commands
+    CommandInfo {
+        name: "anchor",
+        aliases: &["pin"],
+        usage: "/anchor <text> | /anchor list | /anchor remove <n>",
+        description_id: MessageId::CmdAnchorDescription,
+    },
     CommandInfo {
         name: "help",
         aliases: &["?"],
@@ -475,6 +482,7 @@ pub fn execute(cmd: &str, app: &mut App) -> CommandResult {
     // Match command or alias
     match command {
         // Core commands
+        "anchor" | "pin" => anchor::anchor(app, arg),
         "help" | "?" => core::help(app, arg),
         "clear" => core::clear(app),
         "exit" | "quit" | "q" => core::exit(),

--- a/crates/tui/src/compaction.rs
+++ b/crates/tui/src/compaction.rs
@@ -775,11 +775,31 @@ pub async fn compact_messages(
     // Extract workflow context (files touched, tasks in progress, etc.)
     let workflow_context = extract_workflow_context(&to_summarize, workspace);
 
+    // Read user-anchored facts that must survive compaction
+    let anchors_text = if let Some(ws) = workspace {
+        let anchors_path = ws.join(".deepseek").join("anchors.md");
+        std::fs::read_to_string(&anchors_path).unwrap_or_default()
+    } else {
+        String::new()
+    };
+
+    let anchors_section = if !anchors_text.trim().is_empty() {
+        format!(
+            "## 📌 Pinned Facts (User-Anchored — DO NOT discard)\n\n\
+             The following facts were explicitly pinned by the user. \
+             They MUST be preserved across all compaction cycles.\n\n\
+             {anchors_text}\n\n---\n\n"
+        )
+    } else {
+        String::new()
+    };
+
     // Build new message list with enhanced summary as system block
     let summary_block = SystemBlock {
         block_type: "text".to_string(),
         text: format!(
-            "## 📋 Conversation Summary (Auto-Generated)\n\n\
+            "{anchors_section}\
+             ## 📋 Conversation Summary (Auto-Generated)\n\n\
              {summary}\n\n\
              ---\n\n\
              ## 🔍 Workflow Context\n\n\

--- a/crates/tui/src/localization.rs
+++ b/crates/tui/src/localization.rs
@@ -216,6 +216,7 @@ pub enum MessageId {
     HelpFooterClose,
     CmdAgentDescription,
     CmdAttachDescription,
+    CmdAnchorDescription,
     CmdCacheDescription,
     CmdClearDescription,
     CmdCompactDescription,
@@ -403,6 +404,7 @@ pub const ALL_MESSAGE_IDS: &[MessageId] = &[
     MessageId::HelpFooterJump,
     MessageId::HelpFooterClose,
     MessageId::CmdAgentDescription,
+    MessageId::CmdAnchorDescription,
     MessageId::CmdAttachDescription,
     MessageId::CmdCacheDescription,
     MessageId::CmdClearDescription,
@@ -710,6 +712,9 @@ fn english(id: MessageId) -> &'static str {
         MessageId::HelpFooterJump => " PgUp/PgDn jump ",
         MessageId::HelpFooterClose => " Esc close ",
         MessageId::CmdAgentDescription => "Switch to agent mode",
+        MessageId::CmdAnchorDescription => {
+            "Pin a fact that survives compaction (auto-injected into context)"
+        }
         MessageId::CmdAttachDescription => {
             "Attach image/video media; use @path for text files or directories"
         }
@@ -988,6 +993,9 @@ fn japanese(id: MessageId) -> Option<&'static str> {
         MessageId::HelpFooterJump => " PgUp/PgDn ジャンプ ",
         MessageId::HelpFooterClose => " Esc 閉じる ",
         MessageId::CmdAgentDescription => "Agent モードに切り替え",
+        MessageId::CmdAnchorDescription => {
+            "コンパクション後も保持される重要な事実をピン留め（コンテキストに自動注入）"
+        }
         MessageId::CmdAttachDescription => {
             "画像・動画メディアを添付（テキストファイルやディレクトリは @path）"
         }
@@ -1258,6 +1266,7 @@ fn chinese_simplified(id: MessageId) -> Option<&'static str> {
         MessageId::HelpFooterJump => " PgUp/PgDn 跳转 ",
         MessageId::HelpFooterClose => " Esc 关闭 ",
         MessageId::CmdAgentDescription => "切换到 Agent 模式",
+        MessageId::CmdAnchorDescription => "钉选关键事实，在压缩后自动注入上下文",
         MessageId::CmdAttachDescription => "附加图片或视频媒体；文本文件或目录请使用 @path",
         MessageId::CmdCacheDescription => "显示最近 N 轮的 DeepSeek 前缀缓存命中/未命中统计",
         MessageId::CmdClearDescription => "清除对话历史",
@@ -1496,6 +1505,9 @@ fn portuguese_brazil(id: MessageId) -> Option<&'static str> {
         MessageId::HelpFooterJump => " PgUp/PgDn salta ",
         MessageId::HelpFooterClose => " Esc fecha ",
         MessageId::CmdAgentDescription => "Mudar para o modo agent",
+        MessageId::CmdAnchorDescription => {
+            "Fixar um fato que sobrevive à compactação (injetado automaticamente no contexto)"
+        }
         MessageId::CmdAttachDescription => {
             "Anexar imagem ou vídeo; use @path para arquivos de texto ou diretórios"
         }


### PR DESCRIPTION
 ## Summary

  Context compaction summarizes old messages to free space, but sometimes users
  need certain facts to survive indefinitely — things like "this API's status
  field is unreliable" or ".ssh/ must never be touched". Currently there is no
  mechanism for this; `/note` exists but requires active lookup.

  This PR introduces `/anchor` (alias: `/pin`), a new slash command that lets
  users pin critical facts which are **automatically re-injected** into the
  compaction summary after every compaction cycle — no manual recall needed.

  ## Changes

  - **`crates/tui/src/commands/anchor.rs`** (new, 285 lines) — `/anchor`
    command with `add` / `list` / `remove` subcommands and 7 unit tests
  - **`crates/tui/src/commands/mod.rs`** — Register `anchor` in `COMMANDS`
    array and `execute()` match dispatch (passes the existing
    `every_registered_command_dispatches_to_a_handler` smoke test)
  - **`crates/tui/src/localization.rs`** — Add `CmdAnchorDescription` to the
    `MessageId` enum, `ALL_MESSAGE_IDS`, and all 4 locale functions
    (English, Japanese, Simplified Chinese, Brazilian Portuguese)
  - **`crates/tui/src/compaction.rs`** — Read `.deepseek/anchors.md` during
    compaction and prepend a "Pinned Facts" section to the summary block

  ## Usage

  /anchor The status field from /api/v2/orders is unreliable
  /anchor .ssh/ directory must never be read or modified
  /anchor list          — show all pinned anchors
  /anchor remove 1      — remove anchor #1
  /pin            — alias for /anchor

  Anchors are stored in `.deepseek/anchors.md` (same pattern as `/note` using
  `.deepseek/notes.md`). When compaction runs, any non-empty anchors file is
  read and injected as a "📌 Pinned Facts" section at the top of the compaction
  summary, instructing the model to preserve them.