### PR TITLE
fix(ci): use cargo-zigbuild to lower Linux glibc requirement to 2.28

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,10 +58,12 @@ jobs:
           # --- deepseek (cli) ---
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
+            target_zig: x86_64-unknown-linux-gnu.2.28
             binary: deepseek
             artifact_name: deepseek-linux-x64
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
+            target_zig: aarch64-unknown-linux-gnu.2.28
             binary: deepseek
             artifact_name: deepseek-linux-arm64
           - os: macos-latest
@@ -79,10 +81,12 @@ jobs:
           # --- deepseek-tui (TUI) ---
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
+            target_zig: x86_64-unknown-linux-gnu.2.28
             binary: deepseek-tui
             artifact_name: deepseek-tui-linux-x64
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
+            target_zig: aarch64-unknown-linux-gnu.2.28
             binary: deepseek-tui
             artifact_name: deepseek-tui-linux-arm64
           - os: macos-latest
@@ -103,14 +107,31 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
       - name: Install Linux system dependencies
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
-      - run: cargo build --release --locked --target ${{ matrix.target }}
+      - name: Install zig
+        if: runner.os == 'Linux'
+        uses: goto-bus-stop/setup-zig@v2
+        with:
+          version: '0.13.0'
+      - name: Install cargo-zigbuild
+        if: runner.os == 'Linux'
+        run: cargo install cargo-zigbuild --locked
+      - name: Build
+        shell: bash
+        run: |
+          if [ -n "${{ matrix.target_zig }}" ]; then
+            cargo zigbuild --release --locked --target ${{ matrix.target_zig }}
+          else
+            cargo build --release --locked --target ${{ matrix.target }}
+          fi
       - name: Rename binary
         shell: bash
         run: |
-          cp target/${{ matrix.target }}/release/${{ matrix.binary }} ${{ matrix.artifact_name }}
+          TARGET_DIR="${{ matrix.target_zig || matrix.target }}"
+          cp "target/${TARGET_DIR}/release/${{ matrix.binary }}" ${{ matrix.artifact_name }}
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact_name }}


### PR DESCRIPTION
## Summary

Replace `cargo build` with `cargo zigbuild` for Linux release binaries, targeting `x86_64-unknown-linux-gnu.2.28` and `aarch64-unknown-linux-gnu.2.28` so prebuilt binaries run on distributions with glibc ≥ 2.28 instead of requiring glibc ≥ 2.39.

## What changed

- **4 Linux matrix entries**: added `target_zig` field (`.2.28` zig target)
- **Build steps**: added zig + cargo-zigbuild install (Linux only), conditional build logic
- **Added `rust-cache`** to build job to speed up compilation and cargo-zigbuild install

## What didn't change

- macOS / Windows builds — untouched
- Asset names — identical
- npm wrapper — no changes needed
- glibc coverage table:

| Distribution | Before (glibc ≥ 2.39) | After (glibc ≥ 2.28) |
|---|---|---|
| RHEL 8 / CentOS 8 / TencentOS 3 | ❌ | ✅ |
| Debian 10 (buster) | ❌ | ✅ |
| Debian 11 (bullseye) | ❌ | ✅ |
| Ubuntu 20.04 | ❌ | ✅ |
| Ubuntu 22.04 | ❌ | ✅ |
| Ubuntu 24.04 | ✅ | ✅ |

## Test plan

- [ ] CI: Release workflow passes on push to `fix/glibc-compat` (can be triggered via `workflow_dispatch` on the fork)
- [ ] Verify built Linux x64 binary with `readelf -V` shows `GLIBC_2.28` as the highest required version
- [ ] Smoke test binary on a glibc 2.28 system (e.g. TencentOS 3.2 / CentOS 8 container)

Fixes #555.

🤖 Generated with [Claude Code](https://claude.com/claude-code)