### PR TITLE
feat(npm): glibc preflight check on Linux postinstall (#560)

### DIFF
--- a/npm/deepseek-tui/scripts/install.js
+++ b/npm/deepseek-tui/scripts/install.js
@@ -13,6 +13,7 @@ const {
   releaseAssetUrl,
   releaseBinaryDirectory,
 } = require("./artifacts");
+const { preflightGlibc } = require("./preflight-glibc");
 const pkg = require("../package.json");
 
 function resolvePackageVersion() {
@@ -154,6 +155,7 @@ async function ensureBinary(targetPath, assetName, version, repo, getChecksums) 
   await download(url, destination);
   try {
     await verifyChecksum(destination, assetName, checksums);
+    preflightGlibc(destination);
   } catch (error) {
     await unlink(destination).catch(() => {});
     throw error;

--- a/npm/deepseek-tui/scripts/preflight-glibc.js
+++ b/npm/deepseek-tui/scripts/preflight-glibc.js
@@ -1,0 +1,135 @@
+const fs = require("fs");
+const { execFileSync } = require("child_process");
+
+const GLIBC_VERSION_RE = /GLIBC_(\d+)\.(\d+)(?:\.(\d+))?/g;
+
+function isLinux() {
+  return process.platform === "linux";
+}
+
+function parseVersion(text) {
+  const match = String(text || "").match(/(\d+)\.(\d+)(?:\.(\d+))?/);
+  if (!match) return null;
+  return [Number(match[1]), Number(match[2]), Number(match[3] || 0)];
+}
+
+function compareVersion(a, b) {
+  for (let i = 0; i < 3; i += 1) {
+    if (a[i] !== b[i]) return a[i] - b[i];
+  }
+  return 0;
+}
+
+function formatVersion(version) {
+  return version[2] ? `${version[0]}.${version[1]}.${version[2]}` : `${version[0]}.${version[1]}`;
+}
+
+function detectHostGlibc() {
+  try {
+    const out = execFileSync("getconf", ["GNU_LIBC_VERSION"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const version = parseVersion(out);
+    if (version) return version;
+  } catch {
+    // fall through to ldd
+  }
+  try {
+    const out = execFileSync("ldd", ["--version"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const firstLine = out.split("\n", 1)[0];
+    const version = parseVersion(firstLine);
+    if (version) return version;
+  } catch {
+    // glibc not present (e.g. musl / Alpine)
+  }
+  return null;
+}
+
+function detectBinaryRequiredGlibc(filePath) {
+  const buf = fs.readFileSync(filePath);
+  const text = buf.toString("latin1");
+  let highest = null;
+  GLIBC_VERSION_RE.lastIndex = 0;
+  let match;
+  while ((match = GLIBC_VERSION_RE.exec(text)) !== null) {
+    const version = [Number(match[1]), Number(match[2]), Number(match[3] || 0)];
+    if (!highest || compareVersion(version, highest) > 0) {
+      highest = version;
+    }
+  }
+  return highest;
+}
+
+function buildFromSourceHint() {
+  return [
+    "You can still run DeepSeek TUI by building from source with Cargo:",
+    "",
+    "  # Requires Rust 1.85+ (https://rustup.rs)",
+    "  cargo install deepseek-tui-cli --locked   # provides `deepseek`",
+    "  cargo install deepseek-tui     --locked   # provides `deepseek-tui`",
+    "",
+    "Or build from a checkout:",
+    "",
+    "  git clone https://github.com/Hmbown/DeepSeek-TUI.git",
+    "  cd DeepSeek-TUI",
+    "  cargo install --path crates/cli --locked",
+    "  cargo install --path crates/tui --locked",
+    "",
+    "See https://github.com/Hmbown/DeepSeek-TUI/blob/main/docs/INSTALL.md",
+  ].join("\n");
+}
+
+function preflightGlibc(filePath) {
+  if (!isLinux()) return;
+  if (
+    process.env.DEEPSEEK_TUI_SKIP_GLIBC_CHECK === "1" ||
+    process.env.DEEPSEEK_SKIP_GLIBC_CHECK === "1"
+  ) {
+    return;
+  }
+
+  const required = detectBinaryRequiredGlibc(filePath);
+  if (!required) {
+    // Statically linked / musl binary, or no GLIBC_* version dependencies present.
+    return;
+  }
+
+  const host = detectHostGlibc();
+  if (!host) {
+    throw new Error(
+      [
+        `The prebuilt binary requires GLIBC_${formatVersion(required)}, but no GNU libc was detected on this host.`,
+        "This usually means you're on a musl-based distro such as Alpine.",
+        "",
+        buildFromSourceHint(),
+        "",
+        "Set DEEPSEEK_TUI_SKIP_GLIBC_CHECK=1 to bypass this check at your own risk.",
+      ].join("\n"),
+    );
+  }
+
+  if (compareVersion(host, required) < 0) {
+    throw new Error(
+      [
+        `Prebuilt DeepSeek TUI binary requires GLIBC_${formatVersion(required)} but this system has glibc ${formatVersion(host)}.`,
+        "Older distros (CentOS 7/8, RHEL 7/8, Debian 10, etc.) ship an older glibc that is not compatible with the prebuilt artifact.",
+        "",
+        buildFromSourceHint(),
+        "",
+        "Set DEEPSEEK_TUI_SKIP_GLIBC_CHECK=1 to bypass this check at your own risk.",
+      ].join("\n"),
+    );
+  }
+}
+
+module.exports = {
+  preflightGlibc,
+  detectHostGlibc,
+  detectBinaryRequiredGlibc,
+  // exported for tests
+  _internal: { parseVersion, compareVersion, formatVersion },
+};


### PR DESCRIPTION
## Summary
- Closes #560.
- Adds a Linux-only preflight to the npm postinstall that fails fast with a clear, actionable error when the host glibc is older than what the prebuilt binary requires — instead of installing successfully and then dying at runtime with `GLIBC_2.XX not found`.

## What changed
- New module `npm/deepseek-tui/scripts/preflight-glibc.js`:
  - **Required version**: scans the downloaded binary for the highest `GLIBC_X.Y` symbol (no `readelf` runtime dependency — pure Node).
  - **Host version**: `getconf GNU_LIBC_VERSION`, falling back to `ldd --version`.
  - **Comparison**: throws with build-from-source guidance (cargo install / git clone) if host < required, or if no glibc is detected at all (musl/Alpine).
  - **Escape hatch**: `DEEPSEEK_TUI_SKIP_GLIBC_CHECK=1` (or legacy `DEEPSEEK_SKIP_GLIBC_CHECK=1`) bypasses the check.
- `npm/deepseek-tui/scripts/install.js`: invoke `preflightGlibc(destination)` immediately after `verifyChecksum`, inside the same `try`/`catch` that unlinks the partial download on failure. So a failed preflight leaves nothing behind and npm exits non-zero.

## Behavior
- **macOS / Windows**: no-op.
- **Linux, host glibc >= required**: silent pass (current behavior).
- **Linux, host glibc < required**: clear error message naming both versions, pointing at `cargo install ... --locked` and `docs/INSTALL.md`, and noting the skip env var. npm marks the install failed.
- **Statically linked / musl-built artifact** (no `GLIBC_*` symbols in the binary): silent pass — preflight does not block.

## Why scan bytes instead of `readelf`
`readelf` is in `binutils` and is not guaranteed to be installed on minimal containers. The `GLIBC_X.Y` symbol versions live in `.gnu.version_r` as plain ASCII, so a regex scan over the file is reliable and dependency-free. If a future binary is statically linked, the scan returns `null` and the preflight no-ops.

## Test plan
- [x] Unit-tested the version helpers and `detectBinaryRequiredGlibc` against a fixture buffer containing `GLIBC_2.17`, `GLIBC_2.28`, `GLIBC_2.39` — picks `2.39`.
- [x] Confirmed `detectBinaryRequiredGlibc` returns `null` on a binary with no `GLIBC_*` markers.
- [x] Confirmed `preflightGlibc` is a no-op on non-Linux even when given a doctored fixture with `GLIBC_99.99`.
- [ ] Maintainer to verify: actual install on a glibc 2.28 host (e.g. CentOS 8) against a binary built for 2.39 produces the new error and `npm install` exits non-zero.
- [ ] Maintainer to verify: actual install on glibc 2.39+ host still succeeds.

## Related
- Composes cleanly with #555 / #556: even after the build target is lowered, the preflight still protects users on truly old distros (CentOS 7 @ glibc 2.17).