### PR TITLE
fix(release): switch TUI reqwest from native-tls to rustls (unblock v0.8.10 aarch64)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1790,21 +1790,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2206,22 +2191,6 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
  "tower-service",
 ]
 
@@ -2987,23 +2956,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe 0.1.6",
- "openssl-sys",
- "schannel",
- "security-framework 2.11.1",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3257,54 +3209,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "openssl"
-version = "0.10.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
-dependencies = [
- "bitflags 2.10.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.111"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -3930,12 +3838,10 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime_guess",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -3946,7 +3852,6 @@ dependencies = [
  "serde_json",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -4048,7 +3953,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe 0.2.1",
+ "openssl-probe",
  "rustls-pki-types",
  "schannel",
  "security-framework 3.5.1",
@@ -5038,16 +4943,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -37,7 +37,7 @@ dirs = "6.0.0"
 futures-util = "0.3.31"
 ratatui = "0.29"
 regex = "1.11"
-reqwest = { version = "0.13.1", default-features = false, features = ["blocking", "json", "stream", "multipart", "native-tls", "http2"] }
+reqwest = { version = "0.13.1", default-features = false, features = ["blocking", "json", "stream", "multipart", "rustls", "http2"] }
 similar = "2"
 rustyline = "15.0.0"
 serde = { version = "1.0.228", features = ["derive"] }


### PR DESCRIPTION
## Why

The v0.8.10 GitHub Release was never published because [release.yml run 25327464247](https://github.com/Hmbown/DeepSeek-TUI/actions/runs/25327475634) failed on the aarch64 Linux deepseek-tui build:

```
build (ubuntu-24.04-arm, aarch64-unknown-linux-gnu, deepseek-tui, deepseek-tui-linux-arm64)
  Compiling openssl-sys v0.9.111
  /usr/include/openssl/macros.h:14:10: fatal error: 'openssl/opensslconf.h' file not found
  error: failed to run custom build command for `openssl-sys v0.9.111`
```

One matrix leg failed → fail-fast cancelled the rest → `release` job was skipped → no Release was drafted. End users still see v0.8.9 as Latest on GitHub.

## Root cause

`crates/tui/Cargo.toml:40` was the only crate in the workspace pulling `reqwest` with `native-tls`. Every other crate (including the `deepseek` dispatcher in `crates/cli`) inherits the workspace-default `["json", "rustls"]` from `Cargo.toml:35`.

The aarch64 leg builds with `cargo zigbuild --target aarch64-unknown-linux-gnu.2.28`. Zig's bundled glibc-2.28 sysroot does not ship openssl headers, and the `ubuntu-24.04-arm` runner image's host openssl headers aren't on zigbuild's include path. The v0.8.9 release succeeded against an earlier runner image; the current image no longer satisfies openssl-sys's header probe under zigbuild.

## What changed

One feature swap in `crates/tui/Cargo.toml`:

```diff
-reqwest = { version = "0.13.1", default-features = false, features = ["blocking", "json", "stream", "multipart", "native-tls", "http2"] }
+reqwest = { version = "0.13.1", default-features = false, features = ["blocking", "json", "stream", "multipart", "rustls",     "http2"] }
```

`Cargo.lock` drops nine crates from the build graph (no new additions):

- `openssl` `openssl-sys` `openssl-probe` `openssl-macros`
- `native-tls` `hyper-tls` `tokio-native-tls`
- `foreign-types` `foreign-types-shared`

reqwest 0.13.1 already pulls `rustls-platform-verifier` for OS trust-store integration, so end-user TLS behavior against `api.deepseek.com` remains equivalent. No source code in `crates/` references native-tls or openssl directly (verified by grep).

## Verification

```
cargo clippy --workspace --all-targets --all-features --locked -- -D warnings  # PASS
cargo build --release -p deepseek-tui --locked                                  # PASS
cargo fmt --all -- --check                                                      # PASS
```

CI on this PR will run the full workspace tests across Linux/macOS/Windows.

## Plan after merge

1. Force-update the `v0.8.10` tag to point at this fix's merge commit. The original v0.8.10 tag at `e9b472e9` never produced a published Release, so no consumers exist to break.
2. The tag push fires `release.yml`, the matrix builds across all 10 targets, the `release` job drafts the v0.8.10 GitHub Release with the eight signed binaries plus `deepseek-artifacts-sha256.txt`.
3. After the Release is finalized, the npm wrapper (`npm/deepseek-tui`) can be `npm publish`ed manually per CLAUDE.md.

## Test plan

- [x] Workspace clippy clean locally
- [x] Release build of `deepseek-tui` succeeds locally
- [x] No native-tls / openssl code references in the workspace
- [ ] CI matrix passes (Linux x64, Linux aarch64, macOS x64, macOS aarch64, Windows x64) for both `deepseek` and `deepseek-tui`
- [ ] Re-tagged `v0.8.10` triggers `release.yml` and the GitHub Release is published with all eight binary artifacts + checksum manifest