### PR TITLE
fix(release): use rust target (not glibc-versioned) path for binary copy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,8 +130,16 @@ jobs:
       - name: Rename binary
         shell: bash
         run: |
-          TARGET_DIR="${{ matrix.target_zig || matrix.target }}"
-          cp "target/${TARGET_DIR}/release/${{ matrix.binary }}" ${{ matrix.artifact_name }}
+          # cargo zigbuild writes binaries to target/<rust-target>/release/ —
+          # the .glibc suffix in matrix.target_zig is consumed by zig as a CC
+          # flag, not by cargo as a target dir. Always use the rust target.
+          BIN_PATH="target/${{ matrix.target }}/release/${{ matrix.binary }}"
+          if [ ! -f "${BIN_PATH}" ]; then
+            echo "Binary not at ${BIN_PATH}; searching target/ for ${{ matrix.binary }}:"
+            find target -name "${{ matrix.binary }}" -type f
+            exit 1
+          fi
+          cp "${BIN_PATH}" "${{ matrix.artifact_name }}"
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact_name }}


### PR DESCRIPTION
## Why

The v0.8.10 aarch64 dispatcher build in [release.yml run 25329602631](https://github.com/Hmbown/DeepSeek-TUI/actions/runs/25329602631) succeeded in 4m 53s but the rename step failed:

```
cp: cannot stat 'target/aarch64-unknown-linux-gnu.2.28/release/deepseek': No such file
```

`cargo zigbuild --target aarch64-unknown-linux-gnu.2.28` passes the rust triple `aarch64-unknown-linux-gnu` to cargo and the glibc minimum (`2.28`) to zig as a CC flag. The cargo output directory is therefore `target/aarch64-unknown-linux-gnu/release/`, never the `.2.28` form.

v0.8.9's release.yml hard-coded the rust triple in the rename and worked. v0.8.10 added `target_zig` to the matrix and switched the rename step to `${{ matrix.target_zig || matrix.target }}`, which silently became wrong for every zigbuild leg.

## Fix

- Always copy from `target/${{ matrix.target }}/release/${{ matrix.binary }}`.
- If the binary isn't there, log a `find target -name <binary>` listing before exiting non-zero, so any future cargo-zigbuild output-dir change is visible in the build log instead of just "No such file or directory".

## After merge

Force-update the `v0.8.10` tag to this fix's merge commit. release.yml will fire and build all 10 matrix legs cleanly, the `release` job will draft the v0.8.10 GitHub Release with the eight signed binaries plus the SHA256 manifest.