### PR TITLE
fix(prompts): mirror user's language in reasoning + reply (#588)

### DIFF
--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -608,7 +608,12 @@ mod tests {
 
     /// #588: language-mirroring directive must ship in every mode so
     /// DeepSeek's `reasoning_content` and final reply follow the user's
-    /// language. Structural test — wording is not a test concern.
+    /// language. Structural test — wording is not a test concern, but
+    /// the cross-cutting commitment of #588 is specifically that the
+    /// `reasoning_content` field tracks the user's language (not just
+    /// the visible reply); pin that anchor token so a future edit
+    /// can't silently weaken the section to a generic "respond in the
+    /// user's language" directive while keeping the heading.
     #[test]
     fn language_mirroring_section_present_in_all_modes() {
         for mode in [AppMode::Agent, AppMode::Yolo, AppMode::Plan] {
@@ -616,6 +621,12 @@ mod tests {
             assert!(
                 prompt.contains("## Language"),
                 "## Language section missing from mode {mode:?}"
+            );
+            assert!(
+                prompt.contains("reasoning_content"),
+                "## Language section in {mode:?} must mention `reasoning_content` — \
+                 that field name is the structural anchor for the #588 commitment that \
+                 internal reasoning, not just the visible reply, follows the user's language"
             );
         }
     }

--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -606,6 +606,20 @@ mod tests {
         assert!(prompt.contains("### `rlm`"));
     }
 
+    /// #588: language-mirroring directive must ship in every mode so
+    /// DeepSeek's `reasoning_content` and final reply follow the user's
+    /// language. Structural test — wording is not a test concern.
+    #[test]
+    fn language_mirroring_section_present_in_all_modes() {
+        for mode in [AppMode::Agent, AppMode::Yolo, AppMode::Plan] {
+            let prompt = compose_prompt(mode, Personality::Calm);
+            assert!(
+                prompt.contains("## Language"),
+                "## Language section missing from mode {mode:?}"
+            );
+        }
+    }
+
     /// #358: rlm guidance was reframed from "first-class" to "specialty
     /// tool" — verify the structural markers are present so a future
     /// change doesn't silently remove the RLM section entirely.

--- a/crates/tui/src/prompts/base.md
+++ b/crates/tui/src/prompts/base.md
@@ -4,7 +4,7 @@ You are DeepSeek TUI. You're already running inside it — don't try to launch a
 
 Detect the language the user writes in and respond in that same language — including your internal reasoning. If the user writes in Simplified Chinese (简体中文), your `reasoning_content` and final reply must both be in Simplified Chinese. If they switch languages mid-conversation, switch with them. The default when no clear signal is present is English.
 
-Code, file paths, identifiers, tool names, and log lines stay in their original form — translating `read_file` to `读取文件` would break tool calls. Only natural-language prose mirrors the user.
+Code, file paths, identifiers, tool names, environment variables, command-line flags, URLs, and log lines stay in their original form — translating `read_file` to `读取文件` would break tool calls. Only natural-language prose mirrors the user.
 
 ## Preamble Rhythm
 

--- a/crates/tui/src/prompts/base.md
+++ b/crates/tui/src/prompts/base.md
@@ -1,5 +1,11 @@
 You are DeepSeek TUI. You're already running inside it — don't try to launch a `deepseek` or `deepseek-tui` binary.
 
+## Language
+
+Detect the language the user writes in and respond in that same language — including your internal reasoning. If the user writes in Simplified Chinese (简体中文), your `reasoning_content` and final reply must both be in Simplified Chinese. If they switch languages mid-conversation, switch with them. The default when no clear signal is present is English.
+
+Code, file paths, identifiers, tool names, and log lines stay in their original form — translating `read_file` to `读取文件` would break tool calls. Only natural-language prose mirrors the user.
+
 ## Preamble Rhythm
 
 When starting work on a user request, open with a short, momentum-building line that names the action you're taking. Keep it reserved — state what you're doing, not how you feel about it.


### PR DESCRIPTION
## Summary

- Adds a `## Language` section to `crates/tui/src/prompts/base.md` directing the model to mirror the user's language in **both** `reasoning_content` and the visible reply.
- Carve-out so code, file paths, identifiers, tool names, and log lines stay in their original form — translating `read_file` to `读取文件` would break tool calls.
- Default remains English when no clear input signal is present, so existing English-language behaviour is preserved.
- Structural test in `prompts.rs` asserts the section ships in every mode (Agent / Yolo / Plan). Wording is intentionally not asserted on per the test module's existing "don't fail on prose" comment.

## The new section

```markdown
## Language

Detect the language the user writes in and respond in that same language — including your internal reasoning. If the user writes in Simplified Chinese (简体中文), your `reasoning_content` and final reply must both be in Simplified Chinese. If they switch languages mid-conversation, switch with them. The default when no clear signal is present is English.

Code, file paths, identifiers, tool names, and log lines stay in their original form — translating `read_file` to `读取文件` would break tool calls. Only natural-language prose mirrors the user.
```

## Placement

Inserted at the top of `base.md`, immediately after the identity line and before `## Preamble Rhythm`. This puts the directive before any other guidance so the model reads it first — language affects every response on every turn, so prominence matters more than thematic grouping with `## Output formatting` further down.

Cache-prefix impact: a one-time miss on rollout (the static prefix shifts by ~6 lines), then the new prefix is byte-stable turn-over-turn (verified by the existing `compose_prompt_is_byte_stable_across_calls` test, which still passes).

## Notes for the reviewer

- **`base.txt` is orphaned.** The issue body references `base.md` and `base.txt` as though both load, but `prompts.rs` only `include_str!`s `base.md`; a workspace-wide grep for `base.txt` returns no hits. I left it untouched here so this PR stays scoped to the behaviour fix — it's a reasonable follow-up cleanup either as a `chore:` removal or to wire it into a real load path if you'd prefer.
- **Optional `[ui] language` config knob deferred.** The issue mentions an opt-in lock-to-language config as a complementary piece. I kept this PR tight to the cross-cutting fix that ships immediately for every Chinese-speaking user. Happy to follow up in a separate PR if you want it in v0.8.11.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- [x] `cargo test --workspace --all-features --locked` — 2200+ tests, all pass
- [x] `cargo test -p deepseek-tui-core --test snapshot --locked` (parity gate)
- [x] `cargo test -p deepseek-protocol --test parity_protocol --locked`
- [x] `cargo test -p deepseek-state --test parity_state --locked`
- [x] New test `prompts::tests::language_mirroring_section_present_in_all_modes` passes
- [x] `Cargo.lock` clean (`git diff --exit-code -- Cargo.lock`)
- [ ] Manual eval before release: a Chinese-input turn on `deepseek-v4-pro` produces Chinese `reasoning_content` and Chinese reply.

Closes #588.

🤖 Generated with [Claude Code](https://claude.com/claude-code)