### PR TITLE
fix(tui): forward Event::Resize size to ratatui viewport (#582 candidate, awaiting Windows confirmation)

### DIFF
--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -1466,7 +1466,13 @@ async fn run_event_loop(
             }
 
             if let Event::Resize(width, height) = evt {
-                tracing::debug!(width, height, "Event::Resize received; clearing terminal");
+                tracing::debug!(
+                    width,
+                    height,
+                    coherence = ?app.coherence_state,
+                    use_alt_screen = app.use_alt_screen,
+                    "Event::Resize received; clearing terminal"
+                );
                 // Drain any further Resize events queued in this poll cycle so we
                 // act on the final size only, then issue a single clear + redraw.
                 // crossterm coalesces some resize events but rapid drag-resizes
@@ -1495,6 +1501,28 @@ async fn run_event_loop(
                         Err(_) => break,
                     }
                 }
+
+                // #582: commit the event-reported size to ratatui's
+                // viewport explicitly before the redraw, instead of
+                // relying on `crossterm::terminal::size()` which gets
+                // queried internally during `terminal.draw`. On
+                // Windows ConHost specifically, `terminal::size()` has
+                // been observed to return stale dimensions briefly
+                // during a maximize→windowed transition; the next
+                // `draw` then paints into a buffer that does not
+                // match the post-restore viewport, producing the
+                // unrecoverable black screen reported by @imakid.
+                // The `Event::Resize` payload itself carries the
+                // authoritative new size, so we forward it.
+                if let Err(err) = terminal.resize(Rect::new(0, 0, final_w, final_h)) {
+                    tracing::warn!(
+                        ?err,
+                        final_w,
+                        final_h,
+                        "terminal.resize during Resize event failed; falling back to clear+draw"
+                    );
+                }
+
                 terminal.clear()?;
                 app.handle_resize(final_w, final_h);
                 // Draw immediately so the cleared screen gets repainted before

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -2341,6 +2341,74 @@ mod tests {
         );
     }
 
+    /// Regression for issue #582: a resize event arriving while the
+    /// engine is in `CoherenceState::RefreshingContext` (i.e. running
+    /// a compaction summary call) must NOT leave the chat widget with
+    /// an empty viewport. The user-reported symptom on Windows
+    /// PowerShell is that the screen turns black on the maximize→
+    /// windowed transition during a long task; the post-resize render
+    /// must produce a populated frame regardless of the active
+    /// coherence intervention. Pins the invariant from the renderer
+    /// side; the actual ConHost size-stale fix lives in
+    /// `tui::ui::run_tui` (the `Event::Resize` handler now forwards
+    /// the event-reported dimensions to ratatui's viewport before the
+    /// redraw).
+    #[test]
+    fn chat_widget_renders_cleanly_after_resize_during_refreshing_context() {
+        use crate::core::coherence::CoherenceState;
+
+        let mut app = create_test_app();
+        for i in 0..30 {
+            app.add_message(HistoryCell::User {
+                content: format!("user message {i} during a long-running task"),
+            });
+        }
+
+        // Pretend the engine is mid-compaction when the resize arrives.
+        app.coherence_state = CoherenceState::RefreshingContext;
+
+        // Drive the same shrink-then-grow cycle that maximize→windowed
+        // transitions produce on Windows.
+        for (width, height) in [(140u16, 40u16), (90, 28), (60, 20), (140, 40)] {
+            app.handle_resize(width, height);
+            let area = Rect {
+                x: 0,
+                y: 0,
+                width,
+                height,
+            };
+            let mut buf = Buffer::empty(area);
+            let widget = ChatWidget::new(&mut app, area);
+            widget.render(area, &mut buf);
+
+            let mut non_empty = 0usize;
+            for y in 0..height {
+                for x in 0..width {
+                    let sym = buf[(x, y)].symbol();
+                    if sym != " " && !sym.is_empty() {
+                        non_empty += 1;
+                    }
+                }
+            }
+            assert!(
+                non_empty > 0,
+                "resize-during-RefreshingContext at {width}x{height} produced an empty buffer; \
+                 render path must not gate on coherence state (#582)"
+            );
+        }
+
+        // The engine's coherence_state must survive a resize — it is
+        // the engine's runtime decision, not a render-loop concern.
+        // A future regression that bounced the state to `Healthy` on
+        // resize would silently drop the "refreshing context" footer
+        // chip while compaction is still in flight.
+        assert_eq!(
+            app.coherence_state,
+            CoherenceState::RefreshingContext,
+            "resize must not mutate engine-owned coherence_state"
+        );
+    }
+
     /// Regression for issue #65: after `App::handle_resize`, the chat widget
     /// must produce a clean render at the new width — no stale wrapping,
     /// no panic, no content exceeding the requested width. Cycling through


### PR DESCRIPTION
## Summary

Speculative candidate fix for #582 (PowerShell resize → black screen). I do not have a Windows dev machine and @imakid has not yet replied to the info-request on the issue, so this PR is **explicitly speculative** — the user-side test plan below asks @imakid to confirm whether this resolves the symptom on their setup before merging.

## Hypothesis

The current resize handler does `terminal.clear()` followed by `terminal.draw()`, and relies on ratatui's internal autoresize, which calls `crossterm::terminal::size()` to query the OS for the current dimensions. On Windows ConHost, that OS query has been observed to return *stale* (still-maximized) dimensions briefly during a maximize→windowed transition, while the `Event::Resize(w, h)` payload itself already carries the correct post-restore size. So we paint a frame sized to the stale dimensions into the post-restore viewport, leaving most of the visible area unpainted — the user-reported black screen.

This PR forwards the event-reported size to ratatui explicitly via `Terminal::resize(Rect)` before the clear+draw, so the viewport commit always uses the OS-truthful new size regardless of whether `crossterm::terminal::size()` has caught up.

## What changed

- **`crates/tui/src/tui/ui.rs`** — the `Event::Resize` handler now calls `terminal.resize(Rect::new(0, 0, final_w, final_h))` after coalescing intermediate resize events and before the clear+draw. Logged via `tracing::warn!` if it fails (best-effort; the existing clear+draw still runs).
- **`crates/tui/src/tui/ui.rs`** — the resize tracing event now also captures `coherence_state` and `use_alt_screen` so the next user bug report comes with the triage context for free.
- **`crates/tui/src/tui/widgets/mod.rs`** — new test `chat_widget_renders_cleanly_after_resize_during_refreshing_context` pins the renderer-side invariant: a resize cycle that arrives while `coherence_state == RefreshingContext` (i.e. mid-compaction) must produce non-empty frames at every cycled width, and must not mutate the engine's coherence_state.

## What this does NOT change

- No platform gating — passing the event-reported size to ratatui is correct on every platform; Windows just happens to be where the bug manifests visibly. If we discover the fix regresses macOS/Linux it can be cfg-gated to Windows in a follow-up.
- The "transcript stops refreshing" symptom is most likely the expected no-stream window during a compaction summary call, not a bug. A UX cue ("compacting context, please hold") would be a separate follow-up.

## Test plan

- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy -p deepseek-tui --bin deepseek-tui --all-features --locked -- -D warnings` clean.
- [x] `cargo test -p deepseek-tui --bin deepseek-tui --locked` → 2029 passed, 2 ignored.
- [x] New test pins resize-during-RefreshingContext invariant (no empty frame, coherence_state preserved).
- [ ] **@imakid confirmation required.** Please install this branch and test:

      cargo install --git https://github.com/Hmbown/DeepSeek-TUI.git \\
          --branch fix/582-powershell-resize

  Then start a long task, click the OS restore button mid-task, and report whether the black-screen symptom is gone. If it still reproduces, please run with `RUST_LOG=deepseek_tui=debug 2>resize.log` and attach the resize lines from `resize.log` so we can see the actual dimensions crossterm/ratatui saw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)