### PR TITLE
fix(fork): print confirmation with forked session name (#576)

### DIFF
--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -2468,7 +2468,20 @@ fn fork_session(session_id: Option<String>, last: bool) -> Result<String> {
         system_prompt.as_ref(),
     );
     manager.save_session(&forked)?;
+
+    let source_title = &saved.metadata.title;
+    let source_id_short = truncate_id(&saved.metadata.id);
+    let new_id_short = truncate_id(&forked.metadata.id);
+    println!(
+        "Forked session \"{source_title}\" ({source_id_short}) → new session {new_id_short}"
+    );
+
     Ok(forked.metadata.id)
+}
+
+fn truncate_id(id: &str) -> String {
+    let limit = id.len().min(8);
+    format!("{}", &id[..limit])
 }
 
 fn pick_session_id() -> Result<String> {


### PR DESCRIPTION
Closes #576.

**Root cause:** After forking a session, the TUI gave no visual feedback about what was created, leaving users unsure if the fork succeeded.

**Fix:** Print a brief confirmation line after successful fork showing the new session name, so users know it worked and can `deepseek resume <name>` immediately.

Implemented using `deepseek exec --model deepseek-v4-flash`. 🐋