### PR TITLE
feat(ux): add /verbose toggle for thinking trace display (#598)

### DIFF
--- a/crates/tui/src/commands/debug.rs
+++ b/crates/tui/src/commands/debug.rs
@@ -250,6 +250,20 @@ fn format_cache_history(app: &App, count: usize, locale: Locale) -> String {
     format!("{header}{body}{footer}")
 }
 
+/// Toggle verbose thinking display.
+///
+/// When enabled, full chain-of-thought (reasoning_content) is shown in the
+/// transcript for completed thinking blocks. When disabled (default), only
+/// a compact summary is shown.
+pub fn verbose_thinking(app: &mut App) -> CommandResult {
+    app.verbose_thinking = !app.verbose_thinking;
+    let state = if app.verbose_thinking { "on" } else { "off" };
+    CommandResult::message(format!(
+        "Verbose thinking display: {state}. Now showing {} chain-of-thought.",
+        if app.verbose_thinking { "full" } else { "compact" }
+    ))
+}
+
 fn humanize_age(d: std::time::Duration) -> String {
     let secs = d.as_secs();
     if secs < 60 {

--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -458,6 +458,12 @@ pub const COMMANDS: &[CommandInfo] = &[
         usage: "/cache [count]",
         description_id: MessageId::CmdCacheDescription,
     },
+    CommandInfo {
+        name: "verbose",
+        aliases: &[],
+        usage: "/verbose",
+        description_id: MessageId::CmdVerboseDescription,
+    },
 ];
 
 /// Execute a slash command
@@ -518,6 +524,7 @@ pub fn execute(cmd: &str, app: &mut App) -> CommandResult {
         "tokens" => debug::tokens(app),
         "cost" => debug::cost(app),
         "cache" => debug::cache(app, arg),
+        "verbose" => debug::verbose_thinking(app),
         "system" => debug::system_prompt(app),
         "context" | "ctx" => debug::context(app),
         "edit" => debug::edit(app),

--- a/crates/tui/src/localization.rs
+++ b/crates/tui/src/localization.rs
@@ -266,6 +266,7 @@ pub enum MessageId {
     CmdLspDescription,
     CmdShareDescription,
     CmdUndoDescription,
+    CmdVerboseDescription,
     CmdYoloDescription,
     CmdCacheAdvice,
     CmdCacheFootnote,
@@ -453,6 +454,7 @@ pub const ALL_MESSAGE_IDS: &[MessageId] = &[
     MessageId::CmdLspDescription,
     MessageId::CmdShareDescription,
     MessageId::CmdUndoDescription,
+    MessageId::CmdVerboseDescription,
     MessageId::CmdYoloDescription,
     MessageId::CmdCacheAdvice,
     MessageId::CmdCacheFootnote,
@@ -787,6 +789,7 @@ fn english(id: MessageId) -> &'static str {
             "Manage workspace trust and per-path allowlist (`/trust add <path>`, `/trust list`, `/trust on|off`)"
         }
         MessageId::CmdUndoDescription => "Remove last message pair",
+        MessageId::CmdVerboseDescription => "Toggle verbose thinking display (full chain-of-thought vs compact summary)",
         MessageId::CmdYoloDescription => "Enable YOLO mode (shell + trust + auto-approve)",
         MessageId::CmdCacheAdvice => {
             "Hit/miss ratios over ~70% after the third turn indicate a stable cache prefix; \n\
@@ -1067,6 +1070,7 @@ fn japanese(id: MessageId) -> Option<&'static str> {
             "ワークスペースの信頼設定とパス別許可リストを管理（`/trust add <path>`、`/trust list`、`/trust on|off`）"
         }
         MessageId::CmdUndoDescription => "最後のメッセージ対を削除",
+        MessageId::CmdVerboseDescription => "推論内容の表示を切り替え（完全な思考連鎖とコンパクト要約の間で切替）",
         MessageId::CmdYoloDescription => "YOLO モードを有効化（shell + 信頼 + 自動承認）",
         MessageId::CmdCacheAdvice => {
             "3 ターン目以降にヒット率が ~70% 以上で安定していれば、プレフィックスキャッシュは健全。\n\
@@ -1319,6 +1323,7 @@ fn chinese_simplified(id: MessageId) -> Option<&'static str> {
             "管理工作区信任与按路径的白名单（`/trust add <path>`、`/trust list`、`/trust on|off`）"
         }
         MessageId::CmdUndoDescription => "移除最后一组消息对",
+        MessageId::CmdVerboseDescription => "切换详细推理显示（完整思考链 vs 紧凑摘要）",
         MessageId::CmdYoloDescription => "启用 YOLO 模式（shell + 信任 + 自动批准）",
         MessageId::CmdCacheAdvice => {
             "第 3 轮起命中率稳定在 ~70% 以上即表示前缀缓存稳定；\n\
@@ -1587,6 +1592,7 @@ fn portuguese_brazil(id: MessageId) -> Option<&'static str> {
             "Gerenciar a confiança do workspace e a allowlist por caminho (`/trust add <path>`, `/trust list`, `/trust on|off`)"
         }
         MessageId::CmdUndoDescription => "Remover o último par de mensagens",
+        MessageId::CmdVerboseDescription => "Alternar exibição detalhada de raciocínio (cadeia de pensamento completa vs resumo compacto)",
         MessageId::CmdYoloDescription => {
             "Ativar o modo YOLO (shell + confiança + aprovação automática)"
         }

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -598,6 +598,7 @@ pub struct App {
     pub fancy_animations: bool,
     pub show_thinking: bool,
     pub show_tool_details: bool,
+    pub verbose_thinking: bool,
     pub ui_locale: Locale,
     pub composer_density: ComposerDensity,
     pub composer_border: bool,
@@ -1121,6 +1122,7 @@ impl App {
             fancy_animations,
             show_thinking,
             show_tool_details,
+            verbose_thinking: false,
             ui_locale,
             composer_density,
             composer_border,
@@ -2182,6 +2184,7 @@ impl App {
         TranscriptRenderOptions {
             show_thinking: self.show_thinking,
             show_tool_details: self.show_tool_details,
+            verbose_thinking: self.verbose_thinking,
             calm_mode: self.calm_mode,
             low_motion: self.low_motion,
             spacing: self.transcript_spacing,

--- a/crates/tui/src/tui/history.rs
+++ b/crates/tui/src/tui/history.rs
@@ -145,6 +145,7 @@ impl SubAgentCell {
 pub struct TranscriptRenderOptions {
     pub show_thinking: bool,
     pub show_tool_details: bool,
+    pub verbose_thinking: bool,
     pub calm_mode: bool,
     pub low_motion: bool,
     pub spacing: TranscriptSpacing,
@@ -155,6 +156,7 @@ impl Default for TranscriptRenderOptions {
         Self {
             show_thinking: true,
             show_tool_details: true,
+            verbose_thinking: false,
             calm_mode: false,
             low_motion: false,
             spacing: TranscriptSpacing::Comfortable,
@@ -234,7 +236,7 @@ impl HistoryCell {
                 width,
                 *streaming,
                 *duration_secs,
-                !*streaming,
+                !*streaming && !options.verbose_thinking,
                 options.low_motion,
             ),
             HistoryCell::Tool(cell) if !options.show_tool_details => {

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -1600,11 +1600,18 @@ async fn run_event_loop(
                     KeyCode::Char(c)
                         if app.onboarding == OnboardingState::Language
                             && c.is_ascii_digit()
-                            && let Some((_, tag, _, _)) =
+                            && matches!(
                                 onboarding::language::LANGUAGE_OPTIONS
                                     .iter()
-                                    .find(|(hotkey, _, _, _)| *hotkey == c) =>
+                                    .find(|(hotkey, _, _, _)| *hotkey == c),
+                                Some((_, _, _, _))
+                            ) =>
                     {
+                        let tag = onboarding::language::LANGUAGE_OPTIONS
+                            .iter()
+                            .find(|(hotkey, _, _, _)| *hotkey == c)
+                            .map(|(_, tag, _, _)| tag)
+                            .expect("digit matched in guard");
                         match app.set_locale_from_onboarding(tag) {
                             Ok(()) => {
                                 app.push_status_toast(


### PR DESCRIPTION
Closes #598. Adds `/verbose` slash command to toggle between compact (summary only) and full (complete chain-of-thought) reasoning display. Defaults to compact.\n\nImplemented using `deepseek exec --model deepseek-v4-flash`. 🐋