### PR TITLE
feat(commands): add /think off|high|max reasoning dispatcher (#543)

### DIFF
--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -327,6 +327,12 @@ pub const COMMANDS: &[CommandInfo] = &[
         description_id: MessageId::CmdTrustDescription,
     },
     CommandInfo {
+        name: "think",
+        aliases: &[],
+        usage: "/think <off|high|max>",
+        description_id: MessageId::CmdThinkDescription,
+    },
+    CommandInfo {
         name: "logout",
         aliases: &[],
         usage: "/logout",
@@ -512,6 +518,7 @@ pub fn execute(cmd: &str, app: &mut App) -> CommandResult {
         "agent" => config::agent_mode(app),
         "plan" => config::plan_mode(app),
         "trust" => config::trust(app, arg),
+        "think" => think(app, arg),
         "logout" => config::logout(app),
 
         // Debug commands
@@ -607,6 +614,45 @@ pub fn persist_root_string_key(key: &str, value: &str) -> anyhow::Result<std::pa
 /// Auto-select a model based on request complexity.
 pub fn auto_model_heuristic(input: &str, current_model: &str) -> String {
     config::auto_model_heuristic(input, current_model)
+}
+
+/// Set the reasoning-effort tier for DeepSeek thinking mode.
+///
+/// `/think off`  — disable thinking (no reasoning)
+/// `/think high` — enable thinking with high effort (maps to `"high"` /
+///                 `{ "type": "enabled" }`)
+/// `/think max`  — enable thinking with maximum effort (maps to `"max"`)
+pub fn think(app: &mut App, arg: Option<&str>) -> CommandResult {
+    use crate::tui::app::ReasoningEffort;
+
+    let effort = match arg {
+        Some("off" | "none" | "false" | "0") => ReasoningEffort::Off,
+        Some("high" | "on" | "true" | "1") => ReasoningEffort::High,
+        Some("max" | "maximum") => ReasoningEffort::Max,
+        _ => {
+            return CommandResult::error(
+                "Usage: /think <off|high|max>\n\
+                 \n\
+                 Set the reasoning-effort tier for DeepSeek thinking mode:\n\
+                 - off   — disable thinking (no reasoning_content)\n\
+                 - high  — enable thinking with high reasoning effort\n\
+                 - max   — enable thinking with maximum reasoning effort\n\
+                 \n\
+                 Current: {current}\n\
+                 \n\
+                 You can also cycle between Off → High → Max with Shift+Tab."
+                    .replace("{current}", app.reasoning_effort.short_label()),
+            );
+        }
+    };
+
+    app.reasoning_effort = effort;
+    app.needs_redraw = true;
+
+    CommandResult::message(format!(
+        "Reasoning effort set to: {}",
+        app.reasoning_effort.short_label(),
+    ))
 }
 
 /// Execute a Recursive Language Model (RLM) turn — Algorithm 1 from

--- a/crates/tui/src/localization.rs
+++ b/crates/tui/src/localization.rs
@@ -261,6 +261,7 @@ pub enum MessageId {
     CmdSwarmDescription,
     CmdSystemDescription,
     CmdTaskDescription,
+    CmdThinkDescription,
     CmdTokensDescription,
     CmdTrustDescription,
     CmdLspDescription,
@@ -448,6 +449,7 @@ pub const ALL_MESSAGE_IDS: &[MessageId] = &[
     MessageId::CmdSwarmDescription,
     MessageId::CmdSystemDescription,
     MessageId::CmdTaskDescription,
+    MessageId::CmdThinkDescription,
     MessageId::CmdTokensDescription,
     MessageId::CmdTrustDescription,
     MessageId::CmdLspDescription,
@@ -782,6 +784,9 @@ fn english(id: MessageId) -> &'static str {
         }
         MessageId::CmdSystemDescription => "Show current system prompt",
         MessageId::CmdTaskDescription => "Manage background tasks",
+        MessageId::CmdThinkDescription => {
+            "Set reasoning effort: /think off | /think high | /think max"
+        }
         MessageId::CmdTokensDescription => "Show token usage for session",
         MessageId::CmdTrustDescription => {
             "Manage workspace trust and per-path allowlist (`/trust add <path>`, `/trust list`, `/trust on|off`)"
@@ -1062,6 +1067,9 @@ fn japanese(id: MessageId) -> Option<&'static str> {
         }
         MessageId::CmdSystemDescription => "現在のシステムプロンプトを表示",
         MessageId::CmdTaskDescription => "バックグラウンドタスクを管理",
+        MessageId::CmdThinkDescription => {
+            "推論強度を設定: /think off | /think high | /think max"
+        }
         MessageId::CmdTokensDescription => "セッションのトークン使用量を表示",
         MessageId::CmdTrustDescription => {
             "ワークスペースの信頼設定とパス別許可リストを管理（`/trust add <path>`、`/trust list`、`/trust on|off`）"
@@ -1314,6 +1322,9 @@ fn chinese_simplified(id: MessageId) -> Option<&'static str> {
         }
         MessageId::CmdSystemDescription => "显示当前系统提示词",
         MessageId::CmdTaskDescription => "管理后台任务",
+        MessageId::CmdThinkDescription => {
+            "设置推理强度: /think off | /think high | /think max"
+        }
         MessageId::CmdTokensDescription => "显示本次会话的 token 用量",
         MessageId::CmdTrustDescription => {
             "管理工作区信任与按路径的白名单（`/trust add <path>`、`/trust list`、`/trust on|off`）"
@@ -1582,6 +1593,9 @@ fn portuguese_brazil(id: MessageId) -> Option<&'static str> {
         }
         MessageId::CmdSystemDescription => "Exibir o prompt de sistema atual",
         MessageId::CmdTaskDescription => "Gerenciar tarefas em segundo plano",
+        MessageId::CmdThinkDescription => {
+            "Definir esforço de raciocínio: /think off | /think high | /think max"
+        }
         MessageId::CmdTokensDescription => "Exibir o uso de tokens da sessão",
         MessageId::CmdTrustDescription => {
             "Gerenciar a confiança do workspace e a allowlist por caminho (`/trust add <path>`, `/trust list`, `/trust on|off`)"


### PR DESCRIPTION
Closes #543. Adds `/think <off|high|max>` slash command mapping to `ReasoningEffort` enum values. Includes usage help when called without args showing current mode.\n\nImplemented using `deepseek exec --model deepseek-v4-flash`. 🐋