### PR TITLE
feat(theme): add configurable background_color in [theme] config (#596)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -189,6 +189,24 @@ max_subagents = 10 # optional (1-20)
 # max_install_size_bytes = 5_242_880
 
 # ─────────────────────────────────────────────────────────────────────────────────
+# Theme (#596)
+# ─────────────────────────────────────────────────────────────────────────────────
+# Custom visual appearance overrides.
+
+[theme]
+# Custom background color for the entire TUI canvas.
+#
+# Accepted formats:
+#   - Hex: `#rrggbb` (e.g. `"#0B1526"` is the default ink color)
+#   - Hex: `#rgb`   (e.g. `"#FFF"` for white)
+#   - Named: black, white, red, green, yellow, blue, magenta, cyan,
+#            gray, darkgray, lightred, lightgreen, lightyellow,
+#            lightblue, lightmagenta, lightcyan, reset
+#
+# When unset the built-in dark palette applies unchanged.
+# background_color = "#0B1526"
+
+# ─────────────────────────────────────────────────────────────────────────────────
 # TUI
 # ─────────────────────────────────────────────────────────────────────────────────
 [tui]

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -772,12 +772,37 @@ pub struct Config {
     #[serde(default)]
     pub subagents: Option<SubagentsConfig>,
 
+    /// Visual appearance overrides (#596). When absent, the built-in dark
+    /// palette applies unchanged.
+    #[serde(default)]
+    pub theme: Option<ThemeConfig>,
+
     /// Runtime API server tuning (`deepseek serve --http`). Currently only
     /// hosts the CORS allow-list extension (whalescale#255 / #561). When the
     /// table is absent, the daemon ships with localhost:3000 / localhost:1420
     /// / tauri://localhost as the only allowed dev origins.
     #[serde(default)]
     pub runtime_api: Option<RuntimeApiConfig>,
+}
+
+/// `[theme]` table — visual appearance overrides for the TUI (#596).
+///
+/// Currently supports only `background_color`. When the table is absent,
+/// the built-in dark palette applies unchanged.
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct ThemeConfig {
+    /// Custom background color for the TUI canvas. Accepted formats:
+    ///
+    ///   - `"#rrggbb"` — hex RGB (e.g. `"#0B1526"` matches the default ink)
+    ///   - Named CSS/terminal colors: `"black"`, `"white"`, `"red"`,
+    ///     `"green"`, `"yellow"`, `"blue"`, `"magenta"`, `"cyan"`, `"gray"`,
+    ///     `"darkgray"`, `"lightred"`, `"lightgreen"`, `"lightyellow"`,
+    ///     `"lightblue"`, `"lightmagenta"`, `"lightcyan"`.
+    ///
+    /// When unset or invalid, the default dark-ink background (`#0B1526`)
+    /// is used with a logged warning.
+    #[serde(default)]
+    pub background_color: Option<String>,
 }
 
 /// `[runtime_api]` table — knobs for the local HTTP/SSE daemon.
@@ -2025,6 +2050,7 @@ fn merge_config(base: Config, override_cfg: Config) -> Config {
             per_model: override_cfg.context.per_model.or(base.context.per_model),
         },
         subagents: override_cfg.subagents.or(base.subagents),
+        theme: override_cfg.theme.or(base.theme),
         runtime_api: override_cfg.runtime_api.or(base.runtime_api),
     }
 }

--- a/crates/tui/src/palette.rs
+++ b/crates/tui/src/palette.rs
@@ -259,6 +259,68 @@ pub fn pulse_brightness(color: Color, now_ms: u64) -> Color {
     }
 }
 
+/// Parse a color string into a `ratatui::style::Color`.
+///
+/// Accepts:
+///   - Hex `#rrggbb` (e.g. `"#0B1526"`)
+///   - Hex `#rgb` (e.g. `"#FFF"` → `"#FFFFFF"`)
+///   - Named CSS/terminal colors: `"black"`, `"white"`, `"red"`, `"green"`,
+///     `"yellow"`, `"blue"`, `"magenta"`, `"cyan"`, `"gray"`, `"darkgray"`,
+///     `"lightred"`, `"lightgreen"`, `"lightyellow"`, `"lightblue"`,
+///     `"lightmagenta"`, `"lightcyan"`.
+///
+/// Returns `None` when the string cannot be parsed.
+#[must_use]
+pub fn parse_color(s: &str) -> Option<Color> {
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    // Hex #rrggbb or #rgb
+    if let Some(hex) = trimmed.strip_prefix('#') {
+        let hex = hex.trim();
+        let rgb = match hex.len() {
+            3 => {
+                let r = u8::from_str_radix(&hex[0..1].repeat(2), 16).ok()?;
+                let g = u8::from_str_radix(&hex[1..2].repeat(2), 16).ok()?;
+                let b = u8::from_str_radix(&hex[2..3].repeat(2), 16).ok()?;
+                (r, g, b)
+            }
+            6 => {
+                let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
+                let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
+                let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
+                (r, g, b)
+            }
+            _ => return None,
+        };
+        return Some(Color::Rgb(rgb.0, rgb.1, rgb.2));
+    }
+
+    // Named colors
+    Some(match trimmed.to_ascii_lowercase().as_str() {
+        "black" => Color::Black,
+        "white" => Color::White,
+        "red" => Color::Red,
+        "green" => Color::Green,
+        "yellow" => Color::Yellow,
+        "blue" => Color::Blue,
+        "magenta" => Color::Magenta,
+        "cyan" => Color::Cyan,
+        "gray" | "grey" => Color::Gray,
+        "darkgray" | "darkgrey" => Color::DarkGray,
+        "lightred" | "light-red" => Color::LightRed,
+        "lightgreen" | "light-green" => Color::LightGreen,
+        "lightyellow" | "light-yellow" => Color::LightYellow,
+        "lightblue" | "light-blue" => Color::LightBlue,
+        "lightmagenta" | "light-magenta" => Color::LightMagenta,
+        "lightcyan" | "light-cyan" => Color::LightCyan,
+        "reset" => Color::Reset,
+        _ => return None,
+    })
+}
+
 /// Map an RGB triple to its closest ANSI-16 named color. Only used by
 /// `adapt_color` on Ansi16 terminals; we lean on hue dominance + lightness so
 /// brand colors land on the obviously-related named entry (sky → cyan, blue →
@@ -331,8 +393,8 @@ fn nearest_ansi16(r: u8, g: u8, b: u8) -> Color {
 mod tests {
     use super::{
         ACCENT_REASONING_LIVE, ColorDepth, DEEPSEEK_INK, DEEPSEEK_RED, DEEPSEEK_SKY,
-        SURFACE_REASONING, adapt_bg, adapt_color, blend, nearest_ansi16, pulse_brightness,
-        reasoning_surface_tint,
+        SURFACE_REASONING, adapt_bg, adapt_color, blend, nearest_ansi16, parse_color,
+        pulse_brightness, reasoning_surface_tint,
     };
     use ratatui::style::Color;
 
@@ -430,5 +492,40 @@ mod tests {
         // exercise the path so a panic would surface.
         let _ = ColorDepth::detect();
         let _ = adapt_color(DEEPSEEK_INK, ColorDepth::detect());
+    }
+
+    #[test]
+    fn parse_color_handles_hex_rrggbb() {
+        assert_eq!(
+            parse_color("#0B1526"),
+            Some(Color::Rgb(11, 21, 38)),
+        );
+        assert_eq!(parse_color("#3578E5"), Some(Color::Rgb(53, 120, 229)));
+    }
+
+    #[test]
+    fn parse_color_handles_hex_rgb() {
+        assert_eq!(parse_color("#FFF"), Some(Color::Rgb(255, 255, 255)));
+        assert_eq!(parse_color("#000"), Some(Color::Rgb(0, 0, 0)));
+        assert_eq!(parse_color("#0B1"), Some(Color::Rgb(0x00, 0xBB, 0x11)));
+    }
+
+    #[test]
+    fn parse_color_handles_named_colors() {
+        assert_eq!(parse_color("black"), Some(Color::Black));
+        assert_eq!(parse_color("white"), Some(Color::White));
+        assert_eq!(parse_color("red"), Some(Color::Red));
+        assert_eq!(parse_color("lightblue"), Some(Color::LightBlue));
+        assert_eq!(parse_color("light-blue"), Some(Color::LightBlue));
+        assert_eq!(parse_color("reset"), Some(Color::Reset));
+    }
+
+    #[test]
+    fn parse_color_rejects_invalid_inputs() {
+        assert_eq!(parse_color(""), None);
+        assert_eq!(parse_color("#XYZ"), None);
+        assert_eq!(parse_color("#1234567"), None);
+        assert_eq!(parse_color("notacolor"), None);
+        assert_eq!(parse_color("  "), None);
     }
 }

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -241,6 +241,23 @@ pub async fn run_tui(config: &Config, options: TuiOptions) -> Result<()> {
     let config = &mut config;
     let mut app = App::new(options.clone(), config);
 
+    // Apply custom background color from [theme] config (#596).
+    if let Some(ref theme_cfg) = config.theme
+        && let Some(ref bg_str) = theme_cfg.background_color
+    {
+        match palette::parse_color(bg_str) {
+            Some(color) => {
+                app.ui_theme.header_bg = color;
+            }
+            None => {
+                tracing::warn!(
+                    target: "theme",
+                    "Ignoring invalid theme.background_color: {bg_str:?} — expected hex #rrggbb or named color"
+                );
+            }
+        }
+    }
+
     // Load existing session if resuming.
     if let Some(ref session_id) = options.resume_session_id
         && let Ok(manager) = SessionManager::default_location()
@@ -4600,12 +4617,12 @@ fn render(f: &mut Frame, app: &mut App) {
 
     // Render chat + sidebar + optional file-tree pane
     {
-        // Defensive backstop (#400): fill the entire body area with ink
-        // background before any sub-widgets render, so cells that end up
-        // uncovered by layout splits (e.g. after file-tree toggle or
+        // Defensive backstop (#400): fill the entire body area with
+        // background color before any sub-widgets render, so cells that end
+        // up uncovered by layout splits (e.g. after file-tree toggle or
         // resize) don't retain stale content from a previous frame.
         Block::default()
-            .style(Style::default().bg(palette::DEEPSEEK_INK))
+            .style(Style::default().bg(app.ui_theme.header_bg))
             .render(chunks[1], f.buffer_mut());
 
         let mut sidebar_area = None;


### PR DESCRIPTION
Closes #596. Adds `[theme]` section to config with `background_color` field supporting hex `#rrggbb` and named colors. Applied to TUI background elements.\n\nImplemented using `deepseek exec --model deepseek-v4-flash`. 🐋