### PR TITLE
fix(tui): force ratatui resize on window resize event (#582)

### DIFF
--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -1497,6 +1497,14 @@ async fn run_event_loop(
                 }
                 terminal.clear()?;
                 app.handle_resize(final_w, final_h);
+                // Explicitly resize ratatui's internal buffers to the
+                // dimensions reported by the resize event.  On Windows
+                // PowerShell (ConHost), `crossterm::terminal::size()` can
+                // return stale dimensions during a maximize→windowed
+                // transition, which `terminal.draw()` queries internally via
+                // `backend.size()`. Forwarding the event-reported dimensions
+                // directly avoids the stale-query black screen (#582).
+                terminal.resize(Rect::new(0, 0, final_w, final_h))?;
                 // Draw immediately so the cleared screen gets repainted before
                 // any other events can interleave. Without this, the next
                 // iteration's draw can race against fast follow-up input and


### PR DESCRIPTION
Closes #582. On Windows PowerShell (ConHost), `terminal.draw()` queries stale dimensions during a maximize→windowed transition. Adding `terminal.resize(Rect::new(0, 0, final_w, final_h))` after the existing resize handler forwards the event-reported dimensions directly, preventing the black screen.\n\nImplemented using `deepseek exec --model deepseek-v4-flash`. 🐋