### PR TITLE
feat(memory): learn from repeated tool failures (#546)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -80,6 +80,12 @@ memory_path = "~/.deepseek/memory.md"
 # enabled = true            # turn the feature on (default: false)
 # Override the env-var equivalent: `DEEPSEEK_MEMORY=on`
 
+# learn_from_tool_failures = true  # #546: when true, the engine detects
+                                  # repeated tool failures within a turn
+                                  # (same tool fails 2+ times) and writes
+                                  # a learning-signal note to the memory
+                                  # file. Default: false (opt-in).
+
 # Parsed but currently unused (reserved for future versions):
 # tools_file = "./tools.json"
 

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -419,6 +419,11 @@ pub struct MemoryConfig {
     /// `# foo` typed in the composer to append to that file. Default `false`.
     #[serde(default)]
     pub enabled: Option<bool>,
+    /// When `true`, the engine detects repeated tool failures within a turn
+    /// and writes a learning-signal note to the memory file. Default `false`
+    /// (opt-in).
+    #[serde(default)]
+    pub learn_from_tool_failures: Option<bool>,
 }
 
 impl SnapshotsConfig {
@@ -1344,6 +1349,16 @@ impl Config {
         self.memory
             .as_ref()
             .and_then(|m| m.enabled)
+            .unwrap_or(false)
+    }
+
+    /// Whether the tool-failure learning-signal feature is enabled (#546).
+    /// Opt-in; defaults to `false`.
+    #[must_use]
+    pub fn learn_from_tool_failures(&self) -> bool {
+        self.memory
+            .as_ref()
+            .and_then(|m| m.learn_from_tool_failures)
             .unwrap_or(false)
     }
 

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -139,6 +139,10 @@ pub struct EngineConfig {
     /// Path to the user memory file (#489). Always populated; only
     /// consulted when `memory_enabled` is `true`.
     pub memory_path: PathBuf,
+    /// When `true`, the engine detects repeated tool failures within a turn
+    /// and writes a learning-signal note to the memory file. Default is `false`
+    /// (opt-in). Gated behind `[memory] learn_from_tool_failures` in config.
+    pub learn_from_tool_failures: bool,
     pub goal_objective: Option<String>,
 }
 
@@ -169,6 +173,7 @@ impl Default for EngineConfig {
             subagent_model_overrides: HashMap::new(),
             memory_enabled: false,
             memory_path: PathBuf::from("./memory.md"),
+            learn_from_tool_failures: false,
             goal_objective: None,
         }
     }

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -1425,6 +1425,9 @@ impl Engine {
             // (e.g.) a Tool failure that should escalate from a permission
             // denial that should not.
             let mut step_error_categories: Vec<ErrorCategory> = Vec::new();
+            // #546: per-tool failure frequency for learning-signal notes.
+            let mut tool_failures: std::collections::HashMap<String, (usize, String)> =
+                std::collections::HashMap::new();
             let mut stop_after_plan_tool = false;
 
             for outcome in outcomes.into_iter().flatten() {
@@ -1493,6 +1496,14 @@ impl Engine {
                         step_error_count += 1;
                         step_error_categories.push(envelope.category);
                         let error = format_tool_error(&e, &outcome.name);
+                        // #546: count repeated tool failures for learning signal.
+                        let entry = tool_failures
+                            .entry(outcome.name.clone())
+                            .or_insert_with(|| (0, String::new()));
+                        entry.0 += 1;
+                        if entry.1.is_empty() {
+                            entry.1 = error.clone();
+                        }
                         tool_call.set_error(error.clone(), duration);
                         self.session.working_set.observe_tool_call(
                             &tool_name_for_ws,
@@ -1515,6 +1526,27 @@ impl Engine {
 
                 turn.record_tool_call(tool_call);
                 stop_after_plan_tool |= should_stop_this_turn;
+            }
+
+            // #546: tool-failure learning signal — when the same tool fails
+            // 2+ times in this step and the feature is enabled, write a
+            // durable memory note so future sessions can avoid the pattern.
+            if self.config.learn_from_tool_failures {
+                for (tool_name, (count, error_msg)) in &tool_failures {
+                    if *count >= 2 {
+                        let note = format!(
+                            "Tool '{}' failed {} times with error: {} — avoid this pattern",
+                            tool_name, count, error_msg
+                        );
+                        let _ = crate::memory::append_entry(&self.config.memory_path, &note);
+                        let _ = self
+                            .tx_event
+                            .send(Event::status(format!(
+                                "🧠 learned: tool '{tool_name}' failure pattern written to memory"
+                            )))
+                            .await;
+                    }
+                }
             }
 
             if stop_after_plan_tool {

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -3724,6 +3724,7 @@ async fn run_exec_agent(
         subagent_model_overrides: config.subagent_model_overrides(),
         memory_enabled: config.memory_enabled(),
         memory_path: config.memory_path(),
+        learn_from_tool_failures: config.learn_from_tool_failures(),
         goal_objective: None,
     };
 

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -1811,6 +1811,7 @@ impl RuntimeThreadManager {
             subagent_model_overrides: self.config.subagent_model_overrides(),
             memory_enabled: self.config.memory_enabled(),
             memory_path: self.config.memory_path(),
+            learn_from_tool_failures: self.config.learn_from_tool_failures(),
             goal_objective: None,
         };
 

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -541,6 +541,7 @@ fn build_engine_config(app: &App, config: &Config) -> EngineConfig {
         subagent_model_overrides: config.subagent_model_overrides(),
         memory_enabled: config.memory_enabled(),
         memory_path: config.memory_path(),
+        learn_from_tool_failures: config.learn_from_tool_failures(),
         goal_objective: app.goal.goal_objective.clone(),
     }
 }


### PR DESCRIPTION
Closes #546. When the same tool fails 2+ times in a turn, stores a memory note: 'Tool X failed with Y — avoid pattern Z'. Gated behind `learn_from_tool_failures = false` (opt-in).\n\nImplemented using `deepseek exec --model deepseek-v4-flash`. 🐋