### PR TITLE
feat(memory): worktree-aware memory deduplication (#496)

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -139,6 +139,10 @@ pub struct EngineConfig {
     /// Path to the user memory file (#489). Always populated; only
     /// consulted when `memory_enabled` is `true`.
     pub memory_path: PathBuf,
+    /// Git repository root for the current workspace (#496). `None` when
+    /// the workspace is not inside a git repository. Used by the memory
+    /// system to tag and filter entries by project.
+    pub git_root: Option<PathBuf>,
     pub goal_objective: Option<String>,
 }
 
@@ -169,6 +173,7 @@ impl Default for EngineConfig {
             subagent_model_overrides: HashMap::new(),
             memory_enabled: false,
             memory_path: PathBuf::from("./memory.md"),
+            git_root: None,
             goal_objective: None,
         }
     }
@@ -355,8 +360,11 @@ impl Engine {
 
         // Set up system prompt with project context (default to agent mode)
         let working_set_summary = session.working_set.summary_block(&config.workspace);
-        let user_memory_block =
-            crate::memory::compose_block(config.memory_enabled, &config.memory_path);
+        let user_memory_block = crate::memory::compose_block(
+            config.memory_enabled,
+            &config.memory_path,
+            config.git_root.as_deref(),
+        );
         let system_prompt = prompts::system_prompt_for_mode_with_context_skills_and_session(
             AppMode::Agent,
             &config.workspace,
@@ -1278,6 +1286,10 @@ impl Engine {
             ctx.memory_path = Some(self.config.memory_path.clone());
         }
 
+        // Pass the git root so tools (especially `remember`) can tag memory
+        // entries with the current project repo (#496).
+        ctx.git_root = self.config.git_root.clone();
+
         if let Some(decider) = self.config.network_policy.as_ref() {
             ctx = ctx.with_network_policy(decider.clone());
         }
@@ -1649,8 +1661,11 @@ impl Engine {
             .session
             .working_set
             .summary_block(&self.config.workspace);
-        let user_memory_block =
-            crate::memory::compose_block(self.config.memory_enabled, &self.config.memory_path);
+        let user_memory_block = crate::memory::compose_block(
+            self.config.memory_enabled,
+            &self.config.memory_path,
+            self.config.git_root.as_deref(),
+        );
         let base = prompts::system_prompt_for_mode_with_context_skills_and_session(
             mode,
             &self.config.workspace,

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -3724,6 +3724,7 @@ async fn run_exec_agent(
         subagent_model_overrides: config.subagent_model_overrides(),
         memory_enabled: config.memory_enabled(),
         memory_path: config.memory_path(),
+        git_root: crate::memory::discover_git_root(&workspace),
         goal_objective: None,
     };
 

--- a/crates/tui/src/memory.rs
+++ b/crates/tui/src/memory.rs
@@ -1,14 +1,21 @@
 //! User-level memory file.
 //!
 //! v0.8.8 ships an MVP that lets the user keep a persistent personal
-//! note file the model sees on every turn:
+//! note file the model sees on every turn.
+//!
+//! v0.8.9 adds worktree-aware deduplication (#496): memory entries are
+//! tagged with the git repo root they were created in, and when loading,
+//! only entries matching the current repo (plus untagged global entries)
+//! are returned. This prevents memories from one project bleeding into
+//! another.
 //!
 //! - **Load** `~/.deepseek/memory.md` (path is configurable via
 //!   `memory_path` in `config.toml` and `DEEPSEEK_MEMORY_PATH` env),
-//!   wrap it in a `<user_memory>` block, and prepend it to the system
-//!   prompt alongside the existing `<project_instructions>` block.
+//!   filter by current git repo root, wrap remaining entries in a
+//!   `<user_memory>` block, and prepend them to the system prompt.
 //! - **`# foo`** typed in the composer appends `foo` to the memory
 //!   file as a timestamped bullet — fast capture without leaving the TUI.
+//!   When inside a git repo, the bullet is tagged with `[repo-root-path]`.
 //! - **`/memory`** shows the resolved file path and current contents, and
 //!   **`/memory edit`** prints a copy-pasteable `$VISUAL` / `$EDITOR`
 //!   command for opening the file yourself.
@@ -23,7 +30,7 @@
 
 use std::fs;
 use std::io::{self, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use chrono::Utc;
 
@@ -32,15 +39,100 @@ use chrono::Utc;
 /// the model only saw a slice. Mirrors `project_context::MAX_CONTEXT_SIZE`.
 const MAX_MEMORY_SIZE: usize = 100 * 1024;
 
-/// Read the user memory file at `path`, returning `None` when the file
-/// doesn't exist or is empty after trimming.
+/// Regex: match a git-repo tag `[/path/to/root]` immediately after the
+/// timestamp closing paren. Capture group 1 is the `(timestamp)` part,
+/// group 2 is the `path` inside brackets.
+///
+/// A tagged line looks like:
+///   - (2026-05-03 22:14 UTC) [/home/user/proj] note text
+const REPO_TAG_RE: &str = r"^-\s*(\([^)]+\))\s+\[([^\]]+)\]\s*";
+
+/// Discover the git repository root by walking up from `cwd` looking for a
+/// `.git` directory (or file, in the case of worktrees and submodules).
+/// Returns `None` when no git repository is found.
 #[must_use]
-pub fn load(path: &Path) -> Option<String> {
+pub fn discover_git_root(cwd: &Path) -> Option<PathBuf> {
+    let mut current = if cwd.is_absolute() {
+        cwd.to_path_buf()
+    } else {
+        std::env::current_dir().ok().map(|c| c.join(cwd))?
+    };
+
+    // Canonicalize to resolve symlinks so repo comparisons are byte-identical.
+    if let Ok(canon) = current.canonicalize() {
+        current = canon;
+    }
+
+    loop {
+        if current.join(".git").exists() {
+            return Some(current);
+        }
+        match current.parent() {
+            Some(parent) if parent != current => {
+                current = parent.to_path_buf();
+            }
+            _ => return None,
+        }
+    }
+}
+
+/// Read the user memory file at `path`, filtering entries that belong to
+/// the current git repo. When `git_root` is `Some`, entries tagged with a
+/// different repo root are excluded; untagged entries pass through.
+/// Returns `None` when the file doesn't exist or is empty after filtering.
+#[must_use]
+pub fn load(path: &Path, git_root: Option<&Path>) -> Option<String> {
     let content = fs::read_to_string(path).ok()?;
-    if content.trim().is_empty() {
+    let filtered = filter_by_repo(&content, git_root);
+    if filtered.trim().is_empty() {
         return None;
     }
-    Some(content)
+    Some(filtered)
+}
+
+/// Filter memory file content to only include entries relevant to the
+/// current git repository. Lines are:
+///
+/// - **Tagged with another repo** — dropped (no bleed)
+/// - **Tagged with current repo** — kept (entry belongs here)
+/// - **Untagged** — kept (global / cross-project entries)
+/// - **Non-entry lines** (headers, blank lines) — kept as-is
+fn filter_by_repo(content: &str, git_root: Option<&Path>) -> String {
+    let Some(root) = git_root else {
+        // Not inside a git repo: return everything as-is (backward compatible).
+        return content.to_string();
+    };
+
+    let root_str = root.to_string_lossy();
+    let re = regex::Regex::new(REPO_TAG_RE).expect("static repo tag regex");
+    let mut out = String::with_capacity(content.len());
+
+    for line in content.lines() {
+        if let Some(caps) = re.captures(line) {
+            let tagged_path = caps
+                .get(2)
+                .map(|m| m.as_str())
+                .unwrap_or("");
+            if tagged_path == root_str.as_ref() {
+                // Entry tagged with current repo: strip the tag prefix before adding.
+                // Group 1 is the `(timestamp)` part; rebuild without the `[path]` tag.
+                let ts = caps.get(1).map(|m| m.as_str()).unwrap_or("");
+                let rest = &line[caps.get(0).unwrap().len()..];
+                out.push_str("- ");
+                out.push_str(ts);
+                out.push(' ');
+                out.push_str(rest);
+            } else {
+                // Entry tagged with a different repo: skip.
+            }
+        } else {
+            // Non-entry or untagged entry: pass through as-is.
+            out.push_str(line);
+        }
+        out.push('\n');
+    }
+
+    out
 }
 
 /// Wrap memory content in a `<user_memory>` block ready to prepend to the
@@ -72,16 +164,19 @@ pub fn as_system_block(content: &str, source: &Path) -> Option<String> {
 /// opt-in toggle. Returns `None` when the feature is disabled or the file
 /// is missing / empty so the caller doesn't have to check both conditions.
 ///
+/// `git_root` is used to filter entries by the current git repository
+/// (worktree-aware deduplication, #496). Pass `None` to show all entries.
+///
 /// Callers that hold a `&Config` should pass `config.memory_enabled()` and
 /// `config.memory_path()` directly. The split keeps this module
 /// `Config`-free so it can be reused from sub-agent / engine boundaries
 /// where the high-level `Config` isn't available.
 #[must_use]
-pub fn compose_block(enabled: bool, path: &Path) -> Option<String> {
+pub fn compose_block(enabled: bool, path: &Path, git_root: Option<&Path>) -> Option<String> {
     if !enabled {
         return None;
     }
-    let content = load(path)?;
+    let content = load(path, git_root)?;
     as_system_block(&content, path)
 }
 
@@ -89,7 +184,10 @@ pub fn compose_block(enabled: bool, path: &Path) -> Option<String> {
 /// parent directory) if needed. The entry is timestamped so the user can
 /// later see when each note was added. The leading `#` from a `# foo`
 /// quick-add is stripped so the file stays as readable Markdown.
-pub fn append_entry(path: &Path, entry: &str) -> io::Result<()> {
+///
+/// When `git_root` is `Some`, the entry is tagged with the repo root so
+/// the worktree-aware loader can filter it by project (#496).
+pub fn append_entry(path: &Path, entry: &str, git_root: Option<&Path>) -> io::Result<()> {
     let trimmed = entry.trim_start_matches('#').trim();
     if trimmed.is_empty() {
         return Err(io::Error::new(
@@ -109,7 +207,13 @@ pub fn append_entry(path: &Path, entry: &str) -> io::Result<()> {
         .create(true)
         .append(true)
         .open(path)?;
-    writeln!(file, "- ({timestamp}) {trimmed}")?;
+
+    if let Some(root) = git_root {
+        let tag = root.to_string_lossy();
+        writeln!(file, "- ({timestamp}) [{tag}] {trimmed}")?;
+    } else {
+        writeln!(file, "- ({timestamp}) {trimmed}")?;
+    }
     Ok(())
 }
 
@@ -118,11 +222,104 @@ mod tests {
     use super::*;
     use tempfile::tempdir;
 
+    // ── discover_git_root ──────────────────────────────────────────────
+
+    #[test]
+    fn discover_git_root_finds_repo() {
+        let tmp = tempdir().unwrap();
+        // Create a minimal git repo
+        let git_dir = tmp.path().join(".git");
+        fs::create_dir(&git_dir).unwrap();
+        fs::write(git_dir.join("HEAD"), "ref: refs/heads/main\n").unwrap();
+
+        let found = discover_git_root(tmp.path());
+        assert!(found.is_some());
+        assert_eq!(
+            found.unwrap().canonicalize().unwrap(),
+            tmp.path().canonicalize().unwrap()
+        );
+    }
+
+    #[test]
+    fn discover_git_root_returns_none_outside_repo() {
+        let tmp = tempdir().unwrap();
+        assert!(discover_git_root(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn discover_git_root_finds_parent_repo() {
+        let tmp = tempdir().unwrap();
+        let git_dir = tmp.path().join(".git");
+        fs::create_dir(&git_dir).unwrap();
+        fs::write(git_dir.join("HEAD"), "ref: refs/heads/main\n").unwrap();
+
+        let subdir = tmp.path().join("a").join("b").join("c");
+        fs::create_dir_all(&subdir).unwrap();
+
+        let found = discover_git_root(&subdir);
+        assert!(found.is_some());
+        assert_eq!(
+            found.unwrap().canonicalize().unwrap(),
+            tmp.path().canonicalize().unwrap()
+        );
+    }
+
+    // ── filter_by_repo ─────────────────────────────────────────────────
+
+    #[test]
+    fn filter_by_repo_without_git_root_returns_all() {
+        let content = "- (2026-01-01) global note\n- (2026-01-02) [/repo/a] project note\n";
+        let filtered = filter_by_repo(content, None);
+        assert_eq!(filtered, content);
+    }
+
+    #[test]
+    fn filter_by_repo_keeps_untagged_and_matching_tagged() {
+        let content = "\
+- (2026-01-01) global note
+- (2026-01-02) [/home/user/proj-a] project note
+- (2026-01-03) [/home/user/proj-b] other project note
+some header";
+        let git_root = Path::new("/home/user/proj-a");
+        let filtered = filter_by_repo(content, Some(git_root));
+        assert!(filtered.contains("global note"), "should keep untagged");
+        assert!(
+            filtered.contains("project note"),
+            "should keep matching tagged"
+        );
+        assert!(
+            !filtered.contains("other project note"),
+            "should drop non-matching tagged"
+        );
+        assert!(filtered.contains("some header"), "should keep non-entry lines");
+    }
+
+    #[test]
+    fn filter_by_repo_strips_repo_tag_from_matching_entries() {
+        let content = "- (2026-01-01) [/tmp/repo] indentation convention";
+        let git_root = Path::new("/tmp/repo");
+        let filtered = filter_by_repo(content, Some(git_root));
+        // The tag `[/tmp/repo]` should be stripped so the model sees a clean entry.
+        assert!(filtered.contains("indentation convention"));
+        assert!(!filtered.contains("[/tmp/repo]"), "tag should be stripped");
+        // The timestamp and bullet should remain.
+        assert!(filtered.starts_with("- (2026-01-01)"), "{filtered}");
+    }
+
+    #[test]
+    fn filter_by_repo_empty_result_when_all_filtered() {
+        let content = "- (2026-01-01) [/other/repo] only entry";
+        let filtered = filter_by_repo(content, Some(Path::new("/this/repo")));
+        assert_eq!(filtered.trim(), "");
+    }
+
+    // ── load ───────────────────────────────────────────────────────────
+
     #[test]
     fn load_returns_none_for_missing_file() {
         let tmp = tempdir().unwrap();
         let path = tmp.path().join("never-existed.md");
-        assert!(load(&path).is_none());
+        assert!(load(&path, None).is_none());
     }
 
     #[test]
@@ -130,7 +327,7 @@ mod tests {
         let tmp = tempdir().unwrap();
         let path = tmp.path().join("memory.md");
         fs::write(&path, "   \n   \n").unwrap();
-        assert!(load(&path).is_none());
+        assert!(load(&path, None).is_none());
     }
 
     #[test]
@@ -138,8 +335,28 @@ mod tests {
         let tmp = tempdir().unwrap();
         let path = tmp.path().join("memory.md");
         fs::write(&path, "remember the milk").unwrap();
-        assert_eq!(load(&path).as_deref(), Some("remember the milk"));
+        assert_eq!(load(&path, None).as_deref(), Some("remember the milk\n"));
     }
+
+    #[test]
+    fn load_filters_by_repo() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("memory.md");
+        fs::write(
+            &path,
+            "- (2026-01-01) global\n- (2026-01-02) [/my/repo] project note\n- (2026-01-03) [/other] other\n",
+        )
+        .unwrap();
+        let git_root = Path::new("/my/repo");
+        let result = load(&path, Some(git_root)).unwrap();
+        assert!(result.contains("global"));
+        assert!(result.contains("project note"));
+        assert!(!result.contains("other"));
+        // The repo tag should be stripped.
+        assert!(!result.contains("[/my/repo]"));
+    }
+
+    // ── as_system_block ────────────────────────────────────────────────
 
     #[test]
     fn as_system_block_produces_xml_wrapper() {
@@ -161,11 +378,13 @@ mod tests {
         assert!(block.contains("(truncated"));
     }
 
+    // ── append_entry ───────────────────────────────────────────────────
+
     #[test]
     fn append_entry_creates_file_and_writes_one_bullet() {
         let tmp = tempdir().unwrap();
         let path = tmp.path().join("memory.md");
-        append_entry(&path, "# remember the milk").unwrap();
+        append_entry(&path, "# remember the milk", None).unwrap();
 
         let body = fs::read_to_string(&path).unwrap();
         assert!(body.contains("remember the milk"), "{body}");
@@ -180,8 +399,8 @@ mod tests {
     fn append_entry_appends_subsequent_lines() {
         let tmp = tempdir().unwrap();
         let path = tmp.path().join("memory.md");
-        append_entry(&path, "# first").unwrap();
-        append_entry(&path, "second").unwrap();
+        append_entry(&path, "# first", None).unwrap();
+        append_entry(&path, "second", None).unwrap();
         let body = fs::read_to_string(&path).unwrap();
         assert!(body.contains("first"));
         assert!(body.contains("second"));
@@ -193,7 +412,35 @@ mod tests {
     fn append_entry_rejects_empty_after_strip() {
         let tmp = tempdir().unwrap();
         let path = tmp.path().join("memory.md");
-        let err = append_entry(&path, "###").unwrap_err();
+        let err = append_entry(&path, "###", None).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn append_entry_tags_with_git_root() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("memory.md");
+        let git_root = Path::new("/home/user/my-project");
+        append_entry(&path, "use 4-space indentation", Some(git_root)).unwrap();
+
+        let body = fs::read_to_string(&path).unwrap();
+        assert!(
+            body.contains("[/home/user/my-project]"),
+            "should contain repo tag: {body}"
+        );
+        assert!(body.contains("4-space indentation"));
+    }
+
+    #[test]
+    fn append_entry_without_git_root_is_untagged() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("memory.md");
+        append_entry(&path, "global preference", None).unwrap();
+
+        let body = fs::read_to_string(&path).unwrap();
+        assert!(
+            !body.contains("[/"),
+            "no tag should appear: {body}"
+        );
     }
 }

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -1811,6 +1811,7 @@ impl RuntimeThreadManager {
             subagent_model_overrides: self.config.subagent_model_overrides(),
             memory_enabled: self.config.memory_enabled(),
             memory_path: self.config.memory_path(),
+            git_root: crate::memory::discover_git_root(&thread.workspace),
             goal_objective: None,
         };
 

--- a/crates/tui/src/tools/remember.rs
+++ b/crates/tui/src/tools/remember.rs
@@ -69,7 +69,7 @@ impl ToolSpec for RememberTool {
             )
         })?;
 
-        crate::memory::append_entry(path, note).map_err(|err| {
+        crate::memory::append_entry(path, note, context.git_root.as_deref()).map_err(|err| {
             ToolError::execution_failed(format!("failed to append to {}: {err}", path.display()))
         })?;
 

--- a/crates/tui/src/tools/spec.rs
+++ b/crates/tui/src/tools/spec.rs
@@ -110,6 +110,10 @@ pub struct ToolContext {
     /// short-circuit on `None` rather than fall back to a workspace-local
     /// default.
     pub memory_path: Option<PathBuf>,
+    /// Git repository root for the current workspace (#496). `None` when
+    /// the workspace is not inside a git repository. Used by the memory
+    /// system to tag and filter entries by project.
+    pub git_root: Option<PathBuf>,
 }
 
 impl ToolContext {
@@ -136,6 +140,7 @@ impl ToolContext {
             runtime: RuntimeToolServices::default(),
             cancel_token: None,
             memory_path: None,
+            git_root: None,
         }
     }
 
@@ -165,6 +170,7 @@ impl ToolContext {
             runtime: RuntimeToolServices::default(),
             cancel_token: None,
             memory_path: None,
+            git_root: None,
         }
     }
 
@@ -194,6 +200,7 @@ impl ToolContext {
             runtime: RuntimeToolServices::default(),
             cancel_token: None,
             memory_path: None,
+            git_root: None,
         }
     }
 

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -488,7 +488,8 @@ fn is_memory_quick_add(input: &str) -> bool {
 /// memory directory becomes visible without crashing the composer.
 fn handle_memory_quick_add(app: &mut App, input: &str, config: &Config) {
     let path = config.memory_path();
-    match crate::memory::append_entry(&path, input) {
+    let git_root = crate::memory::discover_git_root(&app.workspace);
+    match crate::memory::append_entry(&path, input, git_root.as_deref()) {
         Ok(()) => {
             app.status_message = Some(format!("memory: appended to {}", path.display()));
         }
@@ -541,6 +542,7 @@ fn build_engine_config(app: &App, config: &Config) -> EngineConfig {
         subagent_model_overrides: config.subagent_model_overrides(),
         memory_enabled: config.memory_enabled(),
         memory_path: config.memory_path(),
+        git_root: crate::memory::discover_git_root(&app.workspace),
         goal_objective: app.goal.goal_objective.clone(),
     }
 }

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -7,6 +7,13 @@ sessions — "I prefer pytest over unittest", "this codebase uses
 4-space indentation", "always run `cargo fmt` before committing" —
 without having to repeat them in every conversation.
 
+As of v0.8.9, memory is **worktree-aware** (#496): entries created
+inside a git repository are tagged with the repo's root path. When
+loading, only entries matching the current repo (plus untagged global
+entries) are injected into the system prompt. This prevents memories
+from one project bleeding into another while keeping cross-project
+preferences visible everywhere.
+
 Memory is **opt-in**. When disabled (the default), nothing is loaded,
 nothing is intercepted, and the `remember` tool isn't surfaced to the
 model. This keeps zero-overhead behavior for users who haven't asked
@@ -57,7 +64,8 @@ both are set.
 ## What gets injected
 
 When memory is enabled and the file exists, every turn's system
-prompt carries an extra block:
+prompt carries an extra block. When inside a git repository, entries
+tagged with other repos are filtered out (#496):
 
 ```xml
 <user_memory source="/Users/you/.deepseek/memory.md">
@@ -149,18 +157,23 @@ to do that — durable, single-sentence notes only.
 
 ## File format
 
-Memory is plain Markdown with timestamped bullets:
+Memory is plain Markdown with timestamped bullets. Entries created
+inside a git repository are tagged with the repo root path (#496):
 
 ```markdown
 - (2026-05-03 22:14 UTC) prefer pytest over unittest
-- (2026-05-03 22:31 UTC) this codebase uses 4-space indentation
+- (2026-05-03 22:31 UTC) [/home/user/project-a] this project uses 4-space indentation
 - (2026-05-04 09:02 UTC) all PRs need 2 reviewers before merge
+- (2026-05-04 14:15 UTC) [/home/user/project-b] this project uses tabs
 ```
 
-You can hand-edit the file in any editor — the loader doesn't care
-about the timestamp format; it just reads the whole file as the
-memory block. The timestamp is convention so you can tell when each
-note was added when grooming the file.
+When working in `project-a`, the loader includes:
+- Untagged global entries (cross-project preferences)
+- Entries tagged with `/home/user/project-a` (the tag is stripped
+  before injection so the model only sees a clean entry)
+- Entries tagged with `/home/user/project-b` are **filtered out**
+
+When working outside any git repository, all entries are shown.
 
 ## Hierarchy and imports
 
@@ -201,11 +214,16 @@ receives, and only when memory is enabled. If you switch providers
 (DeepSeek / NVIDIA NIM / Fireworks / etc.) the same memory file is
 used; the file is provider-agnostic.
 
-The file is per-user, not per-project. If you want project-specific
-memory, use the project-level `AGENTS.md` or
+The file is per-user, with **worktree-aware scoping** (#496).
+Entries created inside a git repository are tagged with the repo
+root path; only entries matching the current repo (plus untagged
+global entries) are injected into the system prompt. This prevents
+project-specific conventions from leaking into unrelated sessions.
+
+If you want instructions that travel with the codebase itself (so
+all contributors see them), use the project-level `AGENTS.md` or
 `.deepseek/instructions.md` files instead — those are loaded by
-`project_context` and live in the repo (or wherever you commit
-them).
+`project_context` and live in the repo.
 
 ## Configuration reference
 
@@ -230,3 +248,5 @@ memory_path = "~/.deepseek/memory.md"
 - `docs/CONFIGURATION.md` — full config reference.
 - Issue [#489](https://github.com/Hmbown/DeepSeek-TUI/issues/489)
   — phase-1 EPIC tracking the work.
+- Issue [#496](https://github.com/Hmbown/DeepSeek-TUI/issues/496)
+  — worktree-aware deduplication.


### PR DESCRIPTION
Closes #496. Tags each memory note with the current git repo root. When loading memories, filters to notes for the current repo plus global untagged notes, preventing memory bleed between projects.\n\nImplemented using `deepseek exec --model deepseek-v4-flash`. 🐋