### PR TITLE
feat(config): add context_mode field for cache-maximal default (#541)

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -40,6 +40,41 @@ pub enum ProviderKind {
     Sglang,
 }
 
+/// Context management strategy: how the TUI handles growing conversation context.
+///
+/// `CacheMaximal` (default) prefers appending new content over summarizing old
+/// context, keeping the KV prefix cache hot by avoiding rewrites. Routine
+/// auto-compaction is skipped. Users can still trigger `/compact` manually.
+///
+/// `Compact` enables the legacy summarization-based compaction path, which
+/// periodically summarizes older messages to stay within a token budget.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum ContextMode {
+    #[default]
+    CacheMaximal,
+    Compact,
+}
+
+impl ContextMode {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::CacheMaximal => "cache-maximal",
+            Self::Compact => "compact",
+        }
+    }
+
+    #[must_use]
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "cache-maximal" | "cache_maximal" | "cache" => Some(Self::CacheMaximal),
+            "compact" => Some(Self::Compact),
+            _ => None,
+        }
+    }
+}
+
 impl ProviderKind {
     #[must_use]
     pub fn as_str(self) -> &'static str {
@@ -143,6 +178,12 @@ pub struct ConfigToml {
     pub sandbox_mode: Option<String>,
     #[serde(default)]
     pub providers: ProvidersToml,
+    /// Context management mode: `cache-maximal` (default) or `compact`.
+    /// Cache-maximal mode skips routine auto-compaction and prefers appending
+    /// new context, keeping the KV prefix cache hot. Set to `compact` to
+    /// re-enable legacy summarization-based compaction.
+    #[serde(default)]
+    pub context_mode: Option<ContextMode>,
     /// Per-domain network policy (#135). When absent, network tools fall back
     /// to a permissive default that mirrors pre-v0.7.0 behavior.
     #[serde(default)]
@@ -304,6 +345,10 @@ impl ConfigToml {
             self.provider = project.provider;
         }
 
+        if project.context_mode.is_some() {
+            self.context_mode = project.context_mode;
+        }
+
         // Merge provider sub-tables field-by-field.
         merge_provider_config(&mut self.providers.deepseek, &project.providers.deepseek);
         merge_provider_config(
@@ -350,6 +395,7 @@ impl ConfigToml {
             "output_mode" => self.output_mode.clone(),
             "log_level" => self.log_level.clone(),
             "telemetry" => self.telemetry.map(|v| v.to_string()),
+            "context_mode" => self.context_mode.map(|v| v.as_str().to_string()),
             "approval_policy" => self.approval_policy.clone(),
             "sandbox_mode" => self.sandbox_mode.clone(),
             "providers.deepseek.api_key" => self.providers.deepseek.api_key.clone(),
@@ -394,6 +440,12 @@ impl ConfigToml {
             "log_level" => self.log_level = Some(value.to_string()),
             "telemetry" => {
                 self.telemetry = Some(parse_bool(value)?);
+            }
+            "context_mode" => {
+                self.context_mode = Some(
+                    ContextMode::parse(value)
+                        .with_context(|| format!("invalid context_mode '{value}'; expected 'cache-maximal' or 'compact'"))?,
+                );
             }
             "approval_policy" => self.approval_policy = Some(value.to_string()),
             "sandbox_mode" => self.sandbox_mode = Some(value.to_string()),
@@ -481,6 +533,7 @@ impl ConfigToml {
             "output_mode" => self.output_mode = None,
             "log_level" => self.log_level = None,
             "telemetry" => self.telemetry = None,
+            "context_mode" => self.context_mode = None,
             "approval_policy" => self.approval_policy = None,
             "sandbox_mode" => self.sandbox_mode = None,
             "providers.deepseek.api_key" => {
@@ -560,6 +613,9 @@ impl ConfigToml {
         }
         if let Some(v) = self.sandbox_mode.as_ref() {
             out.insert("sandbox_mode".to_string(), v.clone());
+        }
+        if let Some(v) = self.context_mode {
+            out.insert("context_mode".to_string(), v.as_str().to_string());
         }
         if let Some(v) = self.providers.deepseek.api_key.as_ref() {
             out.insert("providers.deepseek.api_key".to_string(), redact_secret(v));

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -577,6 +577,41 @@ impl StatusItem {
     }
 }
 
+/// Context management strategy: how the TUI handles growing conversation context.
+///
+/// `CacheMaximal` (default) prefers appending new content over summarizing old
+/// context, keeping the KV prefix cache hot by avoiding rewrites. Routine
+/// auto-compaction is skipped. Users can still trigger `/compact` manually.
+///
+/// `Compact` enables the legacy summarization-based compaction path, which
+/// periodically summarizes older messages to stay within a token budget.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum ContextMode {
+    #[default]
+    CacheMaximal,
+    Compact,
+}
+
+impl ContextMode {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::CacheMaximal => "cache-maximal",
+            Self::Compact => "compact",
+        }
+    }
+
+    #[must_use]
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "cache-maximal" | "cache_maximal" | "cache" => Some(Self::CacheMaximal),
+            "compact" => Some(Self::Compact),
+            _ => None,
+        }
+    }
+}
+
 /// Resolved retry policy with defaults applied.
 #[derive(Debug, Clone)]
 pub struct RetryPolicy {
@@ -767,6 +802,13 @@ pub struct Config {
     /// Append-only layered context management with Flash seam manager (#159).
     #[serde(default)]
     pub context: ContextConfig,
+
+    /// Context management mode: `cache-maximal` (default) or `compact`.
+    /// Cache-maximal mode skips routine auto-compaction and prefers appending
+    /// new context, keeping the KV prefix cache hot. Set to `compact` to
+    /// re-enable legacy summarization-based compaction.
+    #[serde(default)]
+    pub context_mode: Option<ContextMode>,
 
     /// Sub-agent model overrides.
     #[serde(default)]
@@ -2024,6 +2066,7 @@ fn merge_config(base: Config, override_cfg: Config) -> Config {
             seam_model: override_cfg.context.seam_model.or(base.context.seam_model),
             per_model: override_cfg.context.per_model.or(base.context.per_model),
         },
+        context_mode: override_cfg.context_mode.or(base.context_mode),
         subagents: override_cfg.subagents.or(base.subagents),
         runtime_api: override_cfg.runtime_api.or(base.runtime_api),
     }


### PR DESCRIPTION
Closes #541.

Implemented using `deepseek exec --model deepseek-v4-flash`. 🐋