### PR TITLE
feat(tools): add question tool — model asks user for clarification (#424)

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -187,6 +187,8 @@ pub struct EngineHandle {
     tx_approval: mpsc::Sender<ApprovalDecision>,
     /// Send user input responses to the engine
     tx_user_input: mpsc::Sender<UserInputDecision>,
+    /// Send question answers to the engine
+    tx_question: mpsc::Sender<QuestionDecision>,
     /// Send steer input for an in-flight turn.
     tx_steer: mpsc::Sender<String>,
 }
@@ -262,6 +264,29 @@ impl EngineHandle {
         Ok(())
     }
 
+    /// Submit a response for the question tool.
+    pub async fn submit_question(
+        &self,
+        id: impl Into<String>,
+        answer: impl Into<String>,
+    ) -> Result<()> {
+        self.tx_question
+            .send(QuestionDecision::Answered {
+                id: id.into(),
+                answer: answer.into(),
+            })
+            .await?;
+        Ok(())
+    }
+
+    /// Cancel a question tool prompt.
+    pub async fn cancel_question(&self, id: impl Into<String>) -> Result<()> {
+        self.tx_question
+            .send(QuestionDecision::Cancelled { id: id.into() })
+            .await?;
+        Ok(())
+    }
+
     /// Cancel a request_user_input prompt.
     pub async fn cancel_user_input(&self, id: impl Into<String>) -> Result<()> {
         self.tx_user_input
@@ -290,6 +315,7 @@ pub struct Engine {
     mcp_pool: Option<Arc<AsyncMutex<McpPool>>>,
     rx_op: mpsc::Receiver<Op>,
     rx_approval: mpsc::Receiver<ApprovalDecision>,
+    rx_question: mpsc::Receiver<QuestionDecision>,
     rx_user_input: mpsc::Receiver<UserInputDecision>,
     rx_steer: mpsc::Receiver<String>,
     tx_event: mpsc::Sender<Event>,
@@ -333,6 +359,7 @@ impl Engine {
         let (tx_event, rx_event) = mpsc::channel(256);
         let (tx_approval, rx_approval) = mpsc::channel(64);
         let (tx_user_input, rx_user_input) = mpsc::channel(32);
+        let (tx_question, rx_question) = mpsc::channel(32);
         let (tx_steer, rx_steer) = mpsc::channel(64);
         let cancel_token = CancellationToken::new();
         let shared_cancel_token = Arc::new(StdMutex::new(cancel_token.clone()));
@@ -430,6 +457,7 @@ impl Engine {
             mcp_pool: None,
             rx_op,
             rx_approval,
+            rx_question,
             rx_user_input,
             rx_steer,
             tx_event,
@@ -451,6 +479,7 @@ impl Engine {
             cancel_token: shared_cancel_token,
             tx_approval,
             tx_user_input,
+            tx_question,
             tx_steer,
         };
 
@@ -1788,7 +1817,7 @@ mod tool_execution;
 mod tool_setup;
 mod turn_loop;
 
-use self::approval::{ApprovalDecision, ApprovalResult, UserInputDecision};
+use self::approval::{ApprovalDecision, ApprovalResult, QuestionDecision, UserInputDecision};
 use self::dispatch::{
     ParallelToolResult, ParallelToolResultEntry, ToolExecGuard, ToolExecOutcome, ToolExecutionPlan,
     caller_allowed_for_tool, caller_type_for_tool_use, final_tool_input, format_tool_error,
@@ -1807,7 +1836,7 @@ use self::streaming::{
     should_transparently_retry_stream,
 };
 use self::tool_catalog::{
-    CODE_EXECUTION_TOOL_NAME, MULTI_TOOL_PARALLEL_NAME, REQUEST_USER_INPUT_NAME,
+    CODE_EXECUTION_TOOL_NAME, MULTI_TOOL_PARALLEL_NAME, QUESTION_TOOL_NAME, REQUEST_USER_INPUT_NAME,
     active_tools_for_step, build_model_tool_catalog, ensure_advanced_tooling,
     execute_code_execution_tool, execute_tool_search, initial_active_tools, is_tool_search_tool,
     maybe_activate_requested_deferred_tool, missing_tool_error_message,

--- a/crates/tui/src/core/engine/approval.rs
+++ b/crates/tui/src/core/engine/approval.rs
@@ -37,6 +37,61 @@ pub(super) enum UserInputDecision {
     },
 }
 
+#[derive(Debug, Clone)]
+pub(super) enum QuestionDecision {
+    Answered {
+        id: String,
+        answer: String,
+    },
+    Cancelled {
+        id: String,
+    },
+}
+
+impl Engine {
+    pub(super) async fn await_question(
+        &mut self,
+        tool_id: &str,
+        question: &str,
+    ) -> Result<String, ToolError> {
+        let _ = self
+            .tx_event
+            .send(Event::QuestionRequired {
+                id: tool_id.to_string(),
+                question: question.to_string(),
+            })
+            .await;
+
+        loop {
+            tokio::select! {
+                _ = self.cancel_token.cancelled() => {
+                    return Err(ToolError::execution_failed(
+                        "Request cancelled while awaiting question answer".to_string(),
+                    ));
+                }
+                decision = self.rx_question.recv() => {
+                    let Some(decision) = decision else {
+                        return Err(ToolError::execution_failed(
+                            "Question channel closed".to_string(),
+                        ));
+                    };
+                    match decision {
+                        QuestionDecision::Answered { id, answer } if id == tool_id => {
+                            return Ok(answer);
+                        }
+                        QuestionDecision::Cancelled { id } if id == tool_id => {
+                            return Err(ToolError::execution_failed(
+                                "Question cancelled by user".to_string(),
+                            ));
+                        }
+                        _ => continue,
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// Result of awaiting tool approval from the user.
 #[derive(Debug)]
 pub(super) enum ApprovalResult {

--- a/crates/tui/src/core/engine/capacity_flow.rs
+++ b/crates/tui/src/core/engine/capacity_flow.rs
@@ -515,7 +515,8 @@ impl Engine {
                 .get("interactive")
                 .and_then(serde_json::Value::as_bool)
                 == Some(true))
-            || candidate.name == REQUEST_USER_INPUT_NAME;
+            || candidate.name == REQUEST_USER_INPUT_NAME
+            || candidate.name == QUESTION_TOOL_NAME;
 
         let replay_result = Self::execute_tool_with_lock(
             tool_exec_lock,
@@ -747,7 +748,10 @@ impl Engine {
         tool_name: &str,
         tool_registry: Option<&crate::tools::ToolRegistry>,
     ) -> bool {
-        if tool_name == MULTI_TOOL_PARALLEL_NAME || tool_name == REQUEST_USER_INPUT_NAME {
+        if tool_name == MULTI_TOOL_PARALLEL_NAME
+            || tool_name == REQUEST_USER_INPUT_NAME
+            || tool_name == QUESTION_TOOL_NAME
+        {
             return false;
         }
         if McpPool::is_mcp_tool(tool_name) {

--- a/crates/tui/src/core/engine/tool_catalog.rs
+++ b/crates/tui/src/core/engine/tool_catalog.rs
@@ -17,6 +17,7 @@ use crate::tui::app::AppMode;
 
 pub(super) const MULTI_TOOL_PARALLEL_NAME: &str = "multi_tool_use.parallel";
 pub(super) const REQUEST_USER_INPUT_NAME: &str = "request_user_input";
+pub(super) const QUESTION_TOOL_NAME: &str = "question";
 pub(super) const CODE_EXECUTION_TOOL_NAME: &str = "code_execution";
 const CODE_EXECUTION_TOOL_TYPE: &str = "code_execution_20250825";
 const TOOL_SEARCH_REGEX_NAME: &str = "tool_search_tool_regex";
@@ -71,6 +72,7 @@ pub(super) fn should_default_defer_tool(name: &str, mode: AppMode) -> bool {
             | "github_issue_context"
             | "github_pr_context"
             | REQUEST_USER_INPUT_NAME
+            | QUESTION_TOOL_NAME
     )
 }
 

--- a/crates/tui/src/core/engine/tool_setup.rs
+++ b/crates/tui/src/core/engine/tool_setup.rs
@@ -33,6 +33,7 @@ impl Engine {
         builder = builder
             .with_review_tool(self.deepseek_client.clone(), self.session.model.clone())
             .with_rlm_tool(self.deepseek_client.clone(), self.session.model.clone())
+            .with_question_tool()
             .with_user_input_tool()
             .with_parallel_tool();
 

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -956,7 +956,8 @@ impl Engine {
                         .get("interactive")
                         .and_then(serde_json::Value::as_bool)
                         == Some(true))
-                    || tool_name == REQUEST_USER_INPUT_NAME;
+                    || tool_name == REQUEST_USER_INPUT_NAME
+                    || tool_name == QUESTION_TOOL_NAME;
 
                 let mut approval_required = false;
                 let mut approval_description = "Tool execution requires approval".to_string();
@@ -1251,6 +1252,48 @@ impl Engine {
                                         .map_err(|e| ToolError::execution_failed(e.to_string()))
                                 },
                             ),
+                            Err(err) => Err(err),
+                        };
+
+                        let _ = self
+                            .tx_event
+                            .send(Event::ToolCallComplete {
+                                id: tool_id.clone(),
+                                name: tool_name.clone(),
+                                result: result.clone(),
+                            })
+                            .await;
+
+                        outcomes[plan.index] = Some(ToolExecOutcome {
+                            index: plan.index,
+                            id: tool_id,
+                            name: tool_name,
+                            input: tool_input,
+                            started_at,
+                            result,
+                        });
+                        continue;
+                    }
+
+                    if tool_name == QUESTION_TOOL_NAME {
+                        let started_at = Instant::now();
+                        let result = match crate::tools::question::QuestionRequest::from_value(&tool_input) {
+                            Ok(request) => {
+                                // In auto-approve mode (YOLO, --auto), skip
+                                // the interactive prompt and return "proceed".
+                                if self.session.auto_approve || mode == AppMode::Yolo {
+                                    tracing::info!(
+                                        "question tool (auto mode): {}",
+                                        request.text
+                                    );
+                                    Ok(ToolResult::success("proceed"))
+                                } else {
+                                    match self.await_question(&tool_id, &request.text).await {
+                                        Ok(answer) => Ok(ToolResult::success(&answer)),
+                                        Err(e) => Err(e),
+                                    }
+                                }
+                            }
                             Err(err) => Err(err),
                         };
 

--- a/crates/tui/src/core/events.rs
+++ b/crates/tui/src/core/events.rs
@@ -217,6 +217,12 @@ pub enum Event {
     /// Resume terminal input events after subprocess completion
     ResumeEvents,
 
+    /// Request user input for the question tool
+    QuestionRequired {
+        id: String,
+        question: String,
+    },
+
     /// Request user approval for a tool call
     ApprovalRequired {
         id: String,

--- a/crates/tui/src/tools/mod.rs
+++ b/crates/tui/src/tools/mod.rs
@@ -15,6 +15,7 @@ pub mod git_history;
 pub mod github;
 pub mod parallel;
 pub mod plan;
+pub mod question;
 pub mod project;
 pub mod recall_archive;
 pub mod registry;

--- a/crates/tui/src/tools/question.rs
+++ b/crates/tui/src/tools/question.rs
@@ -1,0 +1,144 @@
+//! `question` tool — the model asks the user a clarifying question and
+//! waits for a freeform text response.
+//!
+//! In TUI mode the question is displayed in a highlighted modal; the user
+//! types a response and presses Enter. In auto-approve mode (YOLO, `--auto`)
+//! the question is logged at INFO level and the tool returns `"proceed"`
+//! without blocking.
+
+use super::spec::{
+    ApprovalRequirement, ToolCapability, ToolContext, ToolError, ToolResult, ToolSpec,
+};
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+/// Payload for the `question` tool.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QuestionRequest {
+    /// The clarifying question the model wants to ask the user.
+    pub text: String,
+}
+
+impl QuestionRequest {
+    /// Parse and validate a `question` tool input.
+    pub fn from_value(value: &Value) -> Result<Self, ToolError> {
+        let request: QuestionRequest =
+            serde_json::from_value(value.clone()).map_err(|e| {
+                ToolError::invalid_input(format!("Invalid question payload: {e}"))
+            })?;
+        request.validate()?;
+        Ok(request)
+    }
+
+    pub fn validate(&self) -> Result<(), ToolError> {
+        if self.text.trim().is_empty() {
+            return Err(ToolError::invalid_input(
+                "question.text must be non-empty",
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Response type returned to the model.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QuestionResponse {
+    pub answer: String,
+}
+
+impl QuestionResponse {
+    pub fn new(answer: impl Into<String>) -> Self {
+        Self {
+            answer: answer.into(),
+        }
+    }
+}
+
+pub struct QuestionTool;
+
+#[async_trait]
+impl ToolSpec for QuestionTool {
+    fn name(&self) -> &'static str {
+        "question"
+    }
+
+    fn description(&self) -> &'static str {
+        "Ask the user a clarifying question and wait for a freeform text response. \
+         Use this when you need additional context, clarification, or a decision \
+         that cannot be derived from the available information."
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "text": {
+                    "type": "string",
+                    "description": "The clarifying question to ask the user."
+                }
+            },
+            "required": ["text"],
+            "additionalProperties": false
+        })
+    }
+
+    fn capabilities(&self) -> Vec<ToolCapability> {
+        vec![ToolCapability::ReadOnly]
+    }
+
+    fn approval_requirement(&self) -> ApprovalRequirement {
+        ApprovalRequirement::Auto
+    }
+
+    async fn execute(
+        &self,
+        _input: Value,
+        _context: &ToolContext,
+    ) -> Result<ToolResult, ToolError> {
+        Err(ToolError::execution_failed(
+            "question must be handled by the engine",
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_question_request() {
+        let req = QuestionRequest {
+            text: "What port should I use?".to_string(),
+        };
+        assert!(req.validate().is_ok());
+    }
+
+    #[test]
+    fn rejects_empty_text() {
+        let req = QuestionRequest {
+            text: "   ".to_string(),
+        };
+        assert!(req.validate().is_err());
+    }
+
+    #[test]
+    fn deserializes_from_json() {
+        let value = json!({ "text": "Which branch to target?" });
+        let req = QuestionRequest::from_value(&value).unwrap();
+        assert_eq!(req.text, "Which branch to target?");
+    }
+
+    #[test]
+    fn rejects_missing_text() {
+        let value = json!({});
+        assert!(QuestionRequest::from_value(&value).is_err());
+    }
+
+    #[test]
+    fn response_serializes() {
+        let resp = QuestionResponse::new("use port 8080");
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["answer"], "use port 8080");
+    }
+}

--- a/crates/tui/src/tools/registry.rs
+++ b/crates/tui/src/tools/registry.rs
@@ -457,6 +457,14 @@ impl ToolRegistryBuilder {
         self
     }
 
+    /// Include the `question` tool (#424) — the model asks the user
+    /// a clarifying question and waits for a freeform text response.
+    #[must_use]
+    pub fn with_question_tool(self) -> Self {
+        use super::question::QuestionTool;
+        self.with_tool(Arc::new(QuestionTool))
+    }
+
     /// Include request_user_input tool.
     #[must_use]
     pub fn with_user_input_tool(self) -> Self {

--- a/crates/tui/src/tui/mod.rs
+++ b/crates/tui/src/tui/mod.rs
@@ -30,6 +30,7 @@ pub mod osc8;
 pub mod pager;
 pub mod paste;
 pub mod paste_burst;
+pub mod question;
 pub mod persistence_actor;
 pub mod plan_prompt;
 pub mod provider_picker;

--- a/crates/tui/src/tui/question.rs
+++ b/crates/tui/src/tui/question.rs
@@ -1,0 +1,285 @@
+//! Modal for the `question` tool — highlighted prompt with freeform
+//! text input.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::layout::{Alignment, Rect};
+use ratatui::prelude::*;
+use ratatui::widgets::{Block, Borders, Clear, Padding, Paragraph, Widget, Wrap};
+
+use crate::palette;
+use crate::tui::views::{ModalKind, ModalView, ViewAction, ViewEvent};
+
+fn modal_block(title: &str) -> Block<'static> {
+    Block::default()
+        .title(Line::from(vec![Span::styled(
+            title.to_string(),
+            Style::default().fg(palette::DEEPSEEK_BLUE).bold(),
+        )]))
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(palette::BORDER_COLOR))
+        .style(Style::default().bg(palette::DEEPSEEK_INK))
+        .padding(Padding::uniform(1))
+}
+
+fn render_modal_chrome(area: Rect, popup_area: Rect, buf: &mut Buffer) {
+    let shadow_x = popup_area.x.saturating_add(1);
+    let shadow_y = popup_area.y.saturating_add(1);
+    let shadow_right = area.x.saturating_add(area.width);
+    let shadow_bottom = area.y.saturating_add(area.height);
+    let shadow_width = popup_area.width.min(shadow_right.saturating_sub(shadow_x));
+    let shadow_height = popup_area
+        .height
+        .min(shadow_bottom.saturating_sub(shadow_y));
+
+    if shadow_width > 0 && shadow_height > 0 {
+        Block::default()
+            .style(Style::default().bg(palette::DEEPSEEK_NAVY))
+            .render(
+                Rect {
+                    x: shadow_x,
+                    y: shadow_y,
+                    width: shadow_width,
+                    height: shadow_height,
+                },
+                buf,
+            );
+    }
+
+    Clear.render(popup_area, buf);
+}
+
+#[derive(Debug, Clone)]
+pub struct QuestionView {
+    tool_id: String,
+    question: String,
+    input_buffer: String,
+}
+
+impl QuestionView {
+    pub fn new(tool_id: impl Into<String>, question: impl Into<String>) -> Self {
+        Self {
+            tool_id: tool_id.into(),
+            question: question.into(),
+            input_buffer: String::new(),
+        }
+    }
+}
+
+impl ModalView for QuestionView {
+    fn kind(&self) -> ModalKind {
+        ModalKind::Question
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    fn handle_key(&mut self, key: KeyEvent) -> ViewAction {
+        if key.code == KeyCode::Esc {
+            return ViewAction::EmitAndClose(ViewEvent::QuestionCancelled {
+                tool_id: self.tool_id.clone(),
+            });
+        }
+
+        match key.code {
+            KeyCode::Enter => {
+                let answer = if self.input_buffer.trim().is_empty() {
+                    "proceed".to_string()
+                } else {
+                    self.input_buffer.trim().to_string()
+                };
+                ViewAction::EmitAndClose(ViewEvent::QuestionAnswered {
+                    tool_id: self.tool_id.clone(),
+                    answer,
+                })
+            }
+            KeyCode::Backspace => {
+                if key.modifiers.contains(KeyModifiers::CONTROL) {
+                    // Ctrl+Backspace: delete last word
+                    let trimmed = self.input_buffer.trim_end();
+                    if let Some(pos) = trimmed.rfind(|c: char| c.is_whitespace()) {
+                        self.input_buffer.truncate(pos);
+                    } else {
+                        self.input_buffer.clear();
+                    }
+                } else {
+                    self.input_buffer.pop();
+                }
+                ViewAction::None
+            }
+            KeyCode::Char(ch)
+                if !key.modifiers.contains(KeyModifiers::CONTROL) && !ch.is_control() =>
+            {
+                self.input_buffer.push(ch);
+                ViewAction::None
+            }
+            _ => ViewAction::None,
+        }
+    }
+
+    fn render(&self, area: Rect, buf: &mut Buffer) {
+        let mut lines: Vec<Line> = Vec::new();
+
+        // Banner
+        lines.push(Line::from(vec![Span::styled(
+            "The model needs clarification",
+            Style::default().fg(palette::DEEPSEEK_SKY).bold(),
+        )]));
+        lines.push(Line::from(""));
+
+        // Question text — highlighted
+        lines.push(Line::from(vec![Span::styled(
+            &self.question,
+            Style::default()
+                .fg(palette::TEXT_PRIMARY)
+                .bold()
+                .italic(),
+        )]));
+        lines.push(Line::from(""));
+
+        // Separator
+        lines.push(Line::from(vec![Span::styled(
+            "─".repeat(40),
+            Style::default().fg(palette::BORDER_COLOR),
+        )]));
+        lines.push(Line::from(""));
+
+        // Input area
+        let display_text = if self.input_buffer.is_empty() {
+            "(type your response then press Enter)".to_string()
+        } else {
+            self.input_buffer.clone()
+        };
+
+        lines.push(Line::from(vec![
+            Span::styled("> ", Style::default().fg(palette::DEEPSEEK_BLUE).bold()),
+            Span::styled(
+                display_text,
+                if self.input_buffer.is_empty() {
+                    Style::default().fg(palette::TEXT_MUTED)
+                } else {
+                    Style::default().fg(palette::DEEPSEEK_SKY)
+                },
+            ),
+        ]));
+        lines.push(Line::from(""));
+
+        // Footer controls
+        lines.push(Line::from(vec![
+            Span::styled("Enter", Style::default().fg(palette::DEEPSEEK_SKY).bold()),
+            Span::styled(" submit answer  ", Style::default().fg(palette::TEXT_MUTED)),
+            Span::styled("Esc", Style::default().fg(palette::DEEPSEEK_SKY).bold()),
+            Span::styled(" cancel", Style::default().fg(palette::TEXT_MUTED)),
+        ]));
+
+        let paragraph = Paragraph::new(lines)
+            .alignment(Alignment::Left)
+            .wrap(Wrap { trim: true })
+            .block(modal_block(" Question "));
+
+        let popup_area = centered_rect(72, 50, area);
+        render_modal_chrome(area, popup_area, buf);
+        paragraph.render(popup_area, buf);
+    }
+}
+
+fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
+    let popup_layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - percent_y) / 2),
+            Constraint::Percentage(percent_y),
+            Constraint::Percentage((100 - percent_y) / 2),
+        ])
+        .split(r);
+    let horizontal = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(popup_layout[1]);
+    horizontal[1]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn render_view(view: &QuestionView, width: u16, height: u16) -> String {
+        let area = Rect::new(0, 0, width, height);
+        let mut buf = Buffer::empty(area);
+        view.render(area, &mut buf);
+
+        (0..height)
+            .map(|y| {
+                (0..width)
+                    .map(|x| buf[(x, y)].symbol())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn sample_view() -> QuestionView {
+        QuestionView::new("tool-1", "What port should the server listen on?")
+    }
+
+    #[test]
+    fn question_modal_calls_out_clarification() {
+        let rendered = render_view(&sample_view(), 90, 20);
+
+        assert!(rendered.contains("needs clarification"));
+        assert!(rendered.contains("What port should the server listen on?"));
+        assert!(rendered.contains("Enter"));
+        assert!(rendered.contains("submit"));
+    }
+
+    #[test]
+    fn question_modal_renders_input_text() {
+        let mut view = sample_view();
+        view.input_buffer = "8080".to_string();
+
+        let rendered = render_view(&view, 90, 20);
+
+        assert!(rendered.contains("8080"));
+        assert!(!rendered.contains("type your response"));
+    }
+
+    #[test]
+    fn enter_with_empty_input_returns_proceed() {
+        let mut view = sample_view();
+        let key = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
+
+        match view.handle_key(key) {
+            ViewAction::EmitAndClose(ViewEvent::QuestionAnswered { answer, .. }) => {
+                assert_eq!(answer, "proceed");
+            }
+            other => panic!("expected QuestionAnswered with 'proceed', got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn escape_cancels_question() {
+        let mut view = sample_view();
+        let key = KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE);
+
+        match view.handle_key(key) {
+            ViewAction::EmitAndClose(ViewEvent::QuestionCancelled { .. }) => {}
+            other => panic!("expected QuestionCancelled, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn typing_accumulates_in_buffer() {
+        let mut view = sample_view();
+
+        for ch in "hello".chars() {
+            let action = view.handle_key(KeyEvent::new(KeyCode::Char(ch), KeyModifiers::NONE));
+            assert!(matches!(action, ViewAction::None));
+        }
+
+        assert_eq!(view.input_buffer, "hello");
+    }
+}

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -81,6 +81,7 @@ use crate::tui::tool_routing::{
     handle_tool_call_complete, handle_tool_call_started, maybe_add_patch_preview,
 };
 use crate::tui::ui_text::{history_cell_to_text, line_to_plain, slice_text, text_display_width};
+use crate::tui::question::QuestionView;
 use crate::tui::user_input::UserInputView;
 
 use super::active_cell::ActiveCell;
@@ -1238,6 +1239,14 @@ async fn run_event_loop(
                                 "Approval required for '{tool_name}': {description}"
                             ));
                         }
+                    }
+                    EngineEvent::QuestionRequired { id, question } => {
+                        app.view_stack.push(QuestionView::new(id.clone(), question));
+                        app.status_message = Some(
+                            "The model needs clarification — type your answer and press Enter"
+                                .to_string(),
+                        );
+                        app.needs_redraw = true;
                     }
                     EngineEvent::UserInputRequired { id, request } => {
                         app.view_stack.push(UserInputView::new(id.clone(), request));
@@ -4858,6 +4867,17 @@ async fn handle_view_events(
                         let _ = engine_handle.retry_tool_with_policy(tool_id, policy).await;
                     }
                 }
+            }
+            ViewEvent::QuestionAnswered { tool_id, answer } => {
+                let _ = engine_handle.submit_question(tool_id, answer).await;
+            }
+            ViewEvent::QuestionCancelled { tool_id } => {
+                let _ = engine_handle.cancel_question(tool_id).await;
+                app.add_message(HistoryCell::System {
+                    content: "Question cancelled by user".to_string(),
+                });
+                app.status_message = Some("Question cancelled".to_string());
+                app.needs_redraw = true;
             }
             ViewEvent::UserInputSubmitted { tool_id, response } => {
                 let _ = engine_handle.submit_user_input(tool_id, response).await;

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -17,6 +17,7 @@ pub mod status_picker;
 pub enum ModalKind {
     Approval,
     Elevation,
+    Question,
     UserInput,
     PlanPrompt,
     CommandPalette,
@@ -93,6 +94,13 @@ pub enum ViewEvent {
         tool_id: String,
         tool_name: String,
         option: ElevationOption,
+    },
+    QuestionAnswered {
+        tool_id: String,
+        answer: String,
+    },
+    QuestionCancelled {
+        tool_id: String,
     },
     UserInputSubmitted {
         tool_id: String,


### PR DESCRIPTION
Closes #424. Adds a `question` tool: model calls `question(text)` to ask the user a clarifying question and await response. In TUI mode shows a highlighted prompt box; in `--auto` mode logs the question and proceeds with a default response.

Implemented using `deepseek exec --model deepseek-v4-flash`. 🐋