### PR TITLE
feat(tools): CorrectedError reject-with-feedback + subagent perm auto-derivation (#413 #414)

### DIFF
--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -39,6 +39,26 @@ pub enum ApprovalRequirement {
     Required,
 }
 
+/// A corrected error that bundles a human-readable suggestion alongside the
+/// error message. Returned to the model so it can self-correct rather than
+/// retrying the same failing call.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CorrectedError {
+    /// The original error message.
+    pub error: String,
+    /// A human-readable suggestion for how to correct the issue.
+    pub suggestion: String,
+}
+
+impl CorrectedError {
+    pub fn new(error: impl Into<String>, suggestion: impl Into<String>) -> Self {
+        Self {
+            error: error.into(),
+            suggestion: suggestion.into(),
+        }
+    }
+}
+
 /// Errors that can occur during tool execution.
 #[derive(Debug, Clone)]
 pub enum ToolError {
@@ -48,7 +68,7 @@ pub enum ToolError {
     ExecutionFailed { message: String },
     Timeout { seconds: u64 },
     NotAvailable { message: String },
-    PermissionDenied { message: String },
+    PermissionDenied { message: String, suggestion: Option<String> },
 }
 
 impl std::fmt::Display for ToolError {
@@ -82,8 +102,18 @@ impl std::fmt::Display for ToolError {
             Self::NotAvailable { message } => {
                 write!(f, "Failed to locate tool: {message}")
             }
-            Self::PermissionDenied { message } => {
-                write!(f, "Failed to authorize tool execution: {message}")
+            Self::PermissionDenied {
+                message,
+                suggestion,
+            } => {
+                if let Some(suggestion) = suggestion {
+                    write!(
+                        f,
+                        "Failed to authorize tool execution: {message}. Suggestion: {suggestion}"
+                    )
+                } else {
+                    write!(f, "Failed to authorize tool execution: {message}")
+                }
             }
         }
     }
@@ -129,6 +159,18 @@ impl ToolError {
     pub fn permission_denied(msg: impl Into<String>) -> Self {
         Self::PermissionDenied {
             message: msg.into(),
+            suggestion: None,
+        }
+    }
+
+    #[must_use]
+    pub fn permission_denied_with_suggestion(
+        msg: impl Into<String>,
+        suggestion: impl Into<String>,
+    ) -> Self {
+        Self::PermissionDenied {
+            message: msg.into(),
+            suggestion: Some(suggestion.into()),
         }
     }
 }

--- a/crates/tui/src/core/engine/dispatch.rs
+++ b/crates/tui/src/core/engine/dispatch.rs
@@ -119,9 +119,19 @@ pub(super) fn format_tool_error(err: &ToolError, tool_name: &str) -> String {
                 )
             }
         }
-        ToolError::PermissionDenied { message } => format!(
-            "Tool '{tool_name}' was denied: {message}. Adjust approval mode or request permission."
-        ),
+        ToolError::PermissionDenied {
+            message,
+            suggestion,
+        } => {
+            let base = format!(
+                "Tool '{tool_name}' was denied: {message}. Adjust approval mode or request permission."
+            );
+            if let Some(suggestion) = suggestion {
+                format!("{base}\nSuggestion: {suggestion}")
+            } else {
+                base
+            }
+        }
     }
 }
 

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -978,10 +978,13 @@ impl Engine {
                 let tool_def = tool_catalog.iter().find(|def| def.name == tool_name);
 
                 if !caller_allowed_for_tool(tool_caller.as_ref(), tool_def) {
-                    blocked_error = Some(ToolError::permission_denied(format!(
-                        "Tool '{tool_name}' does not allow caller '{}'",
-                        caller_type_for_tool_use(tool_caller.as_ref())
-                    )));
+                    blocked_error = Some(ToolError::permission_denied_with_suggestion(
+                        format!(
+                            "Tool '{tool_name}' does not allow caller '{}'",
+                            caller_type_for_tool_use(tool_caller.as_ref())
+                        ),
+                        "Try asking the user first",
+                    ));
                 }
 
                 if blocked_error.is_none()
@@ -1319,9 +1322,10 @@ impl Engine {
                                     "caller": caller_type_for_tool_use(tool_caller.as_ref()),
                                 }));
                                 (
-                                    Some(Err(ToolError::permission_denied(format!(
-                                        "Tool '{tool_name}' denied by user"
-                                    )))),
+                                    Some(Err(ToolError::permission_denied_with_suggestion(
+                                        format!("Tool '{tool_name}' denied by user"),
+                                        "Try asking the user first",
+                                    ))),
                                     None,
                                 )
                             }

--- a/crates/tui/src/error_taxonomy.rs
+++ b/crates/tui/src/error_taxonomy.rs
@@ -400,7 +400,7 @@ impl From<ToolError> for ErrorEnvelope {
                 "tool_not_available",
                 message,
             ),
-            ToolError::PermissionDenied { message } => Self::new(
+            ToolError::PermissionDenied { message, .. } => Self::new(
                 ErrorCategory::Authorization,
                 ErrorSeverity::Error,
                 false,

--- a/crates/tui/src/tools/spec.rs
+++ b/crates/tui/src/tools/spec.rs
@@ -17,8 +17,8 @@ use crate::network_policy::NetworkPolicyDecider;
 use crate::tools::shell::{SharedShellManager, new_shared_shell_manager};
 #[allow(unused_imports)]
 pub use deepseek_tools::{
-    ApprovalRequirement, ToolCapability, ToolError, ToolResult, optional_bool, optional_str,
-    optional_u64, required_str, required_u64,
+    ApprovalRequirement, CorrectedError, ToolCapability, ToolError, ToolResult, optional_bool,
+    optional_str, optional_u64, required_str, required_u64,
 };
 
 /// Optional durable runtime services made available to model-visible tools.

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -3289,13 +3289,18 @@ fn emit_agent_progress(
 
 /// Per-sub-agent tool registry.
 ///
-/// Two modes:
-/// - **Full inheritance** (`allowed_tools = None`): the child sees the same
-///   tool surface as the parent's Agent mode — every tool family including
-///   `with_subagent_tools` (so it can recurse). This is the v0.6.6 default.
-/// - **Explicit narrow** (`allowed_tools = Some(list)`): legacy / Custom
+/// Three modes:
+/// - **Auto-derived read-only** (`allowed_tools = Some(read_only_list)`):
+///   when the spawner provides no explicit `allowed_tools`, the child
+///   automatically inherits only read-only tools from the parent registry
+///   (#414). Write tools (filesystem mutation, code execution) are excluded
+///   and require explicit grant.
+/// - **Explicit narrow** (`allowed_tools = Some(user_list)`): legacy / Custom
 ///   path. The registry still builds the full surface, but only the listed
 ///   tool names are visible to the model and callable.
+/// - **Full inheritance** (`allowed_tools = None`): the child sees every
+///   tool the parent has. Retained for backward compat in edge paths; the
+///   default Agent-mode spawn now uses auto-derived read-only.
 struct SubAgentToolRegistry {
     /// `None` → full inheritance (no filter applied). `Some(list)` →
     /// only the listed tools are visible to the model and callable.
@@ -3327,14 +3332,36 @@ impl SubAgentToolRegistry {
             )
             .build(context);
 
+        // Feature #414: auto-derive sub-agent permissions.
+        //
+        // When the spawner omits `allowed_tools`, the child does NOT get
+        // full inheritance of every parent tool. Instead, only tools
+        // whose `is_read_only()` returns true are auto-derived. Write
+        // tools (WritesFiles, ExecutesCode capabilities) require explicit
+        // grant via the `allowed_tools` parameter at spawn time.
+        //
+        // The full registry is still built so grandchildren can spawn
+        // through the sub-agent management family, but model-visible
+        // tool listing and execution gating both use the filtered list.
+        let allowed_tools = explicit_allowed_tools.or_else(|| {
+            let read_only: Vec<String> = registry
+                .all()
+                .iter()
+                .filter(|tool| tool.is_read_only())
+                .map(|tool| tool.name().to_string())
+                .collect();
+            Some(read_only)
+        });
+
         Self {
-            allowed_tools: explicit_allowed_tools,
+            allowed_tools,
             registry,
         }
     }
 
     /// Whether a given tool name is permitted under this child's filter.
-    /// `None` filter = everything permitted.
+    /// Always `false` for unknown tools; filtered by the auto-derived or
+    /// explicit list.
     fn is_tool_allowed(&self, name: &str) -> bool {
         match &self.allowed_tools {
             None => true,
@@ -3377,10 +3404,13 @@ impl SubAgentToolRegistry {
 
 /// Resolve the effective allowed-tools list for a child.
 ///
-/// **v0.6.6 default: full inheritance.** Returning `Ok(None)` means the
-/// child sees the same tool surface as the parent's Agent mode — every
-/// family including `with_subagent_tools` so it can recurse. The narrowing
-/// path (`Ok(Some(list))`) is only used by:
+/// Returns `Ok(None)` for the default path, meaning the child's tool
+/// permissions will be auto-derived downstream in
+/// `SubAgentToolRegistry::new()` (#414): only read-only tools from the
+/// parent's surface are inherited; write tools require explicit grant
+/// via the `allowed_tools` parameter.
+///
+/// The narrowing path (`Ok(Some(list))`) is only used by:
 /// - `Custom` agent types (which require an explicit list).
 /// - Callers that pass `explicit_tools` (advanced / legacy use).
 ///


### PR DESCRIPTION
Closes #413. Closes #414.

**#413**: Adds `CorrectedError` type that includes a human-readable suggestion alongside the error. Permission denials now return helpful guidance instead of bare errors.

**#414**: Sub-agents automatically inherit parent read permissions; write permissions require explicit grant at spawn time.

Implemented using `deepseek exec --model deepseek-v4-flash`. 🐋