### PR TITLE
feat(permissions): external_directory gate + broader-pattern always-allow (#411 #412)

### DIFF
--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -712,6 +712,12 @@ pub struct Config {
     /// missing optional file doesn't fail the launch.
     pub instructions: Option<Vec<String>>,
     pub allow_shell: Option<bool>,
+    /// When false (default), tools that try to write outside the workspace
+    /// directory get a `PermissionDenied` error with a message suggesting
+    /// the user set `allow_external_writes = true` or trust the path.
+    /// When true, external writes proceed with the existing workspace-trust
+    /// and `trust_mode` validation.
+    pub allow_external_writes: Option<bool>,
     pub approval_policy: Option<String>,
     pub sandbox_mode: Option<String>,
     pub managed_config_path: Option<String>,
@@ -1353,6 +1359,12 @@ impl Config {
         self.allow_shell.unwrap_or(true)
     }
 
+    /// Return whether external writes are allowed.
+    #[must_use]
+    pub fn allow_external_writes(&self) -> bool {
+        self.allow_external_writes.unwrap_or(false)
+    }
+
     /// Return the maximum number of concurrent sub-agents.
     /// Checks `[subagents] max_concurrent` first, then top-level `max_subagents`,
     /// then falls back to `DEFAULT_MAX_SUBAGENTS`.
@@ -1980,6 +1992,7 @@ fn merge_config(base: Config, override_cfg: Config) -> Config {
         // both — they list `~/global.md` inside the project array.
         instructions: override_cfg.instructions.or(base.instructions),
         allow_shell: override_cfg.allow_shell.or(base.allow_shell),
+        allow_external_writes: override_cfg.allow_external_writes.or(base.allow_external_writes),
         approval_policy: override_cfg.approval_policy.or(base.approval_policy),
         sandbox_mode: override_cfg.sandbox_mode.or(base.sandbox_mode),
         managed_config_path: override_cfg

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -81,6 +81,10 @@ pub struct EngineConfig {
     pub allow_shell: bool,
     /// Enable trust mode (skip approvals) when true.
     pub trust_mode: bool,
+    /// When false (default), tools that try to write outside the workspace
+    /// get a `PermissionDenied` error. When true, external writes proceed
+    /// with the existing workspace-trust and trust_mode validation.
+    pub allow_external_writes: bool,
     /// Path to the notes file used by the notes tool.
     pub notes_path: PathBuf,
     /// Path to the MCP configuration file.
@@ -149,6 +153,7 @@ impl Default for EngineConfig {
             workspace: PathBuf::from("."),
             allow_shell: true,
             trust_mode: false,
+            allow_external_writes: false,
             notes_path: PathBuf::from("notes.txt"),
             mcp_config_path: PathBuf::from("mcp.json"),
             skills_dir: crate::skills::default_skills_dir(),
@@ -1269,7 +1274,8 @@ impl Engine {
         .with_shell_manager(self.shell_manager.clone())
         .with_runtime_services(self.config.runtime_services.clone())
         .with_cancel_token(self.cancel_token.clone())
-        .with_trusted_external_paths(trusted.paths().to_vec());
+        .with_trusted_external_paths(trusted.paths().to_vec())
+        .with_allow_external_writes(self.config.allow_external_writes);
 
         // Hand the user-memory path to tools so the model-callable
         // `remember` tool can append entries (#489). `None` when the

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -3704,6 +3704,7 @@ async fn run_exec_agent(
         workspace: workspace.clone(),
         allow_shell: auto_approve || config.allow_shell(),
         trust_mode,
+        allow_external_writes: config.allow_external_writes(),
         notes_path: config.notes_path(),
         mcp_config_path: config.mcp_config_path(),
         skills_dir: config.skills_dir(),

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -1781,6 +1781,7 @@ impl RuntimeThreadManager {
             workspace: thread.workspace.clone(),
             allow_shell: thread.allow_shell,
             trust_mode: thread.trust_mode,
+            allow_external_writes: self.config.allow_external_writes(),
             notes_path: self.config.notes_path(),
             mcp_config_path: self.config.mcp_config_path(),
             skills_dir: self.config.skills_dir(),

--- a/crates/tui/src/tools/approval_cache.rs
+++ b/crates/tui/src/tools/approval_cache.rs
@@ -6,14 +6,29 @@
 //! cache keys off a **call fingerprint** — a digest of the tool name and
 //! the semantically‑relevant portion of its arguments.
 //!
-//! ## Fingerprint shape
+//! ## Fingerprint shape (per‑call, [`build_approval_key`])
 //!
 //! | Tool           | Key                                      |
 //! |---------------|------------------------------------------|
 //! | `apply_patch`  | `patch:<hash of file paths>`             |
 //! | `exec_shell`   | `shell:<command prefix (first 3 tokens)>` |
 //! | `fetch_url`    | `net:<hostname>`                         |
+//! | `read_file`    | `"file:<parent_dir_hash>"`               |
+//! | `write_file`   | `"file:<parent_dir_hash>"`               |
+//! | `edit_file`    | `"file:<parent_dir_hash>"`               |
 //! | everything else| `tool:<tool_name>`                       |
+//!
+//! ## Fingerprint shape (session‑broad, [`build_session_approval_key`])
+//!
+//! | Tool           | Key                                      |
+//! |---------------|------------------------------------------|
+//! | `read_file`    | `"read:dir:<parent_dir_hash>"`           |
+//! | `write_file`   | `"write:dir:<parent_dir_hash>"`          |
+//! | `edit_file`    | `"edit:dir:<parent_dir_hash>"`           |
+//! | `apply_patch`  | `"patch:dir:<common_parent_dir_hash>"`   |
+//! | `exec_shell`   | `"shell:<command_prefix>"`               |
+//! | `fetch_url`    | `"net:<hostname>"`                       |
+//! | everything else| `"tool:<tool_name>"`                     |
 //!
 //! The cache is **session‑keyed**: entries carry an
 //! `ApprovedForSession` flag. When true, the approval is reused for the
@@ -111,15 +126,198 @@ impl ApprovalCache {
 
 // ── Fingerprint helpers ────────────────────────────────────────────
 
+/// Derive the parent-directory hash from a path value.
+///
+/// Returns the hash of the parent directory (or the workspace root if
+/// the path has no parent). This is used by the session‑broad key to
+/// match all reads/writes in the same directory tree.
+fn parent_dir_hash(value: &serde_json::Value) -> String {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let path_str = match value {
+        serde_json::Value::String(s) => s.clone(),
+        _ => return "<no_path>".to_string(),
+    };
+    let path = std::path::Path::new(&path_str);
+    let parent = path
+        .parent()
+        .and_then(|p| p.to_str())
+        .unwrap_or(".");
+    let mut hasher = DefaultHasher::new();
+    parent.hash(&mut hasher);
+    format!("{:x}", hasher.finish())
+}
+
+/// Extract a `path` parameter from a JSON input value.
+fn extract_path(input: &serde_json::Value) -> Option<&str> {
+    input
+        .get("path")
+        .and_then(|v| v.as_str())
+        .or_else(|| input.get("target").and_then(|v| v.as_str()))
+        .or_else(|| input.get("destination").and_then(|v| v.as_str()))
+}
+
+/// Build the session‑level approval key — a **broader** fingerprint than
+/// [`build_approval_key`] so that an "always allow" decision generalises
+/// to related operations (e.g. all reads in the same directory).
+///
+/// | Tool                  | Key (session‑broad)                        |
+/// |-----------------------|--------------------------------------------|
+/// | `read_file`           | `"read:dir:<parent_dir_hash>"`             |
+/// | `write_file`          | `"write:dir:<parent_dir_hash>"`            |
+/// | `edit_file`           | `"edit:dir:<parent_dir_hash>"`             |
+/// | `apply_patch`         | `"patch:dir:<common_parent_dir_hash>"`     |
+/// | `exec_shell`          | `"shell:<command_prefix>"` (unchanged)     |
+/// | `fetch_url`           | `"net:<hostname>"` (unchanged)             |
+/// | everything else       | `"tool:<tool_name>"` (unchanged)           |
+///
+/// # Example
+///
+/// ```
+/// # use crate::tools::approval_cache::build_session_approval_key;
+/// # use serde_json::json;
+/// // read_file("src/main.rs") → broad key based on "src/" directory
+/// let key = build_session_approval_key("read_file", &json!({"path": "src/main.rs"}));
+/// assert!(key.0.starts_with("read:dir:"), "expected read:dir: prefix, got {key:?}");
+/// ```
+#[must_use]
+pub fn build_session_approval_key(tool_name: &str, input: &serde_json::Value) -> ApprovalKey {
+    match tool_name {
+        // File read tools — key on parent directory
+        "read_file" => {
+            if let Some(path) = extract_path(input) {
+                let ph = parent_dir_hash(&serde_json::Value::String(path.to_string()));
+                ApprovalKey(format!("read:dir:{ph}"))
+            } else {
+                ApprovalKey(format!("tool:{tool_name}"))
+            }
+        }
+        // File write/edit tools — key on parent directory
+        "write_file" | "edit_file" => {
+            if let Some(path) = extract_path(input) {
+                let ph = parent_dir_hash(&serde_json::Value::String(path.to_string()));
+                ApprovalKey(format!("write:dir:{ph}"))
+            } else {
+                ApprovalKey(format!("tool:{tool_name}"))
+            }
+        }
+        // Patch tool — key on common parent directory of all affected files
+        "apply_patch" => {
+            let paths = collect_patch_paths(input);
+            if paths.is_empty() {
+                return ApprovalKey("patch:no_files".to_string());
+            }
+            // Find the common ancestor directory across all patched files.
+            let common = common_parent_dir(&paths);
+            let ph = parent_dir_hash(&serde_json::Value::String(
+                common.unwrap_or_else(|| ".".to_string()),
+            ));
+            ApprovalKey(format!("patch:dir:{ph}"))
+        }
+        // Shell — reuse the exact prefix (already broad enough)
+        "exec_shell"
+        | "exec_shell_wait"
+        | "exec_shell_interact"
+        | "exec_wait"
+        | "exec_interact" => {
+            let prefix = command_prefix(input);
+            ApprovalKey(format!("shell:{prefix}"))
+        }
+        // Network — reuse host-level key (already broad enough)
+        "fetch_url" | "web.fetch" | "web_fetch" => {
+            let host = parse_host(input);
+            ApprovalKey(format!("net:{host}"))
+        }
+        // Everything else — tool-wide key for session
+        _ => ApprovalKey(format!("tool:{tool_name}")),
+    }
+}
+
+/// Collect file paths referenced by a patch input into a Vec.
+fn collect_patch_paths(input: &serde_json::Value) -> Vec<String> {
+    let mut paths: Vec<String> = Vec::new();
+
+    if let Some(changes) = input.get("changes").and_then(|v| v.as_array()) {
+        for change in changes {
+            if let Some(path) = change.get("path").and_then(|v| v.as_str()) {
+                paths.push(path.to_string());
+            }
+        }
+    } else if let Some(patch_text) = input.get("patch").and_then(|v| v.as_str()) {
+        for line in patch_text.lines() {
+            if let Some(rest) = line.strip_prefix("+++ b/") {
+                paths.push(rest.trim().to_string());
+            }
+        }
+    }
+
+    paths
+}
+
+/// Find the common parent directory for a set of paths.
+/// Returns `None` if the set is empty or paths have no common ancestor.
+fn common_parent_dir(paths: &[String]) -> Option<String> {
+    if paths.is_empty() {
+        return None;
+    }
+    if paths.len() == 1 {
+        return std::path::Path::new(&paths[0])
+            .parent()
+            .and_then(|p| p.to_str())
+            .map(|s| s.to_string());
+    }
+    // Split each path into components and find common prefix.
+    let components: Vec<Vec<std::path::Component>> = paths
+        .iter()
+        .map(|p| std::path::Path::new(p).components().collect::<Vec<_>>())
+        .collect();
+    let first = &components[0];
+    let mut common_len = 0;
+    for i in 0..first.len() {
+        let comp = first[i];
+        if components[1..].iter().all(|c| c.get(i) == Some(&comp)) {
+            common_len = i + 1;
+        } else {
+            break;
+        }
+    }
+    if common_len == 0 {
+        return Some(".".to_string());
+    }
+    let common: std::path::PathBuf = first[..common_len].iter().collect();
+    common.to_str().map(|s| s.to_string())
+}
+
 /// Build the approval‑cache key for a tool call.
 ///
 /// The key incorporates the tool name and a lossy digest of the
 /// arguments so that the cache can distinguish `exec_shell "ls"`
 /// from `exec_shell "rm -rf /"` while still recognising repeated
 /// invocations of the same harmless command.
+///
+/// For file‑based tools (`read_file`, `write_file`, `edit_file`), the
+/// key includes the parent‑directory hash so that repeated reads of
+/// files in the same directory are recognised as the same operation.
 #[must_use]
 pub fn build_approval_key(tool_name: &str, input: &serde_json::Value) -> ApprovalKey {
     let fingerprint = match tool_name {
+        "read_file" => {
+            if let Some(path) = extract_path(input) {
+                let ph = parent_dir_hash(&serde_json::Value::String(path.to_string()));
+                format!("file:{ph}")
+            } else {
+                format!("tool:{tool_name}")
+            }
+        }
+        "write_file" | "edit_file" => {
+            if let Some(path) = extract_path(input) {
+                let ph = parent_dir_hash(&serde_json::Value::String(path.to_string()));
+                format!("file:{ph}")
+            } else {
+                format!("tool:{tool_name}")
+            }
+        }
         "apply_patch" => {
             let paths_hash = hash_patch_paths(input);
             format!("patch:{paths_hash}")
@@ -271,10 +469,107 @@ mod tests {
     }
 
     #[test]
-    fn generic_tool_uses_tool_name() {
-        let key_a = build_approval_key("read_file", &json!({"path": "a.txt"}));
-        let key_b = build_approval_key("read_file", &json!({"path": "b.txt"}));
+    fn file_tools_key_on_parent_dir() {
+        // Same parent dir → same key
+        let key_a = build_approval_key("read_file", &json!({"path": "src/main.rs"}));
+        let key_b = build_approval_key("read_file", &json!({"path": "src/lib.rs"}));
         assert_eq!(key_a, key_b);
-        assert_eq!(key_a.0, "tool:read_file");
+        assert!(
+            key_a.0.starts_with("file:"),
+            "expected file: prefix, got {:?}",
+            key_a.0
+        );
+        // Different parent dir → different key
+        let key_c = build_approval_key("read_file", &json!({"path": "Cargo.toml"}));
+        assert_ne!(key_a, key_c);
+    }
+
+    #[test]
+    fn write_file_uses_same_file_prefix_as_read() {
+        let key = build_approval_key("write_file", &json!({"path": "src/main.rs"}));
+        assert!(
+            key.0.starts_with("file:"),
+            "expected file: prefix for write_file, got {:?}",
+            key.0
+        );
+        let key_edit = build_approval_key("edit_file", &json!({"path": "src/lib.rs"}));
+        assert!(
+            key_edit.0.starts_with("file:"),
+            "expected file: prefix for edit_file, got {:?}",
+            key_edit.0
+        );
+    }
+
+    // ── build_session_approval_key tests ───────────────────────────
+
+    #[test]
+    fn session_key_for_read_file_uses_read_dir_prefix() {
+        let key = build_session_approval_key("read_file", &json!({"path": "src/main.rs"}));
+        assert!(
+            key.0.starts_with("read:dir:"),
+            "expected read:dir: prefix, got {:?}",
+            key.0
+        );
+    }
+
+    #[test]
+    fn session_key_same_dir_reads_match() {
+        let key_a = build_session_approval_key("read_file", &json!({"path": "src/main.rs"}));
+        let key_b = build_session_approval_key("read_file", &json!({"path": "src/lib.rs"}));
+        assert_eq!(key_a, key_b, "same dir should produce same session key");
+    }
+
+    #[test]
+    fn session_key_diff_dir_reads_differ() {
+        let key_a = build_session_approval_key("read_file", &json!({"path": "src/main.rs"}));
+        let key_b = build_session_approval_key("read_file", &json!({"path": "Cargo.toml"}));
+        assert_ne!(key_a, key_b, "different dirs should produce different keys");
+    }
+
+    #[test]
+    fn session_key_write_and_edit_use_write_dir_prefix() {
+        let key_w = build_session_approval_key("write_file", &json!({"path": "src/main.rs"}));
+        assert!(key_w.0.starts_with("write:dir:"), "{:?}", key_w.0);
+        let key_e = build_session_approval_key("edit_file", &json!({"path": "src/lib.rs"}));
+        assert!(key_e.0.starts_with("write:dir:"), "{:?}", key_e.0);
+        // Same dir → same key
+        assert_eq!(key_w, key_e);
+    }
+
+    #[test]
+    fn session_key_apply_patch_uses_patch_dir_prefix() {
+        let key = build_session_approval_key(
+            "apply_patch",
+            &json!({"changes": [{"path": "src/main.rs", "content": "x"}]}),
+        );
+        assert!(
+            key.0.starts_with("patch:dir:"),
+            "expected patch:dir: prefix, got {:?}",
+            key.0
+        );
+        // Same dir → same key
+        let key2 = build_session_approval_key(
+            "apply_patch",
+            &json!({"changes": [{"path": "src/lib.rs", "content": "y"}]}),
+        );
+        assert_eq!(key, key2, "same dir patches should match");
+    }
+
+    #[test]
+    fn session_key_shell_unchanged() {
+        let key = build_session_approval_key("exec_shell", &json!({"command": "cargo build --release"}));
+        assert_eq!(key.0, "shell:cargo build");
+    }
+
+    #[test]
+    fn session_key_network_unchanged() {
+        let key = build_session_approval_key("fetch_url", &json!({"url": "https://example.com/data"}));
+        assert_eq!(key.0, "net:example.com");
+    }
+
+    #[test]
+    fn session_key_generic_tool_uses_tool_prefix() {
+        let key = build_session_approval_key("list_dir", &json!({"path": "src"}));
+        assert_eq!(key.0, "tool:list_dir");
     }
 }

--- a/crates/tui/src/tools/spec.rs
+++ b/crates/tui/src/tools/spec.rs
@@ -110,6 +110,16 @@ pub struct ToolContext {
     /// short-circuit on `None` rather than fall back to a workspace-local
     /// default.
     pub memory_path: Option<PathBuf>,
+
+    /// When false (default), tools that try to write outside the workspace
+    /// directory get a `PermissionDenied` error instead of the usual
+    /// `PathEscape` — the denial carries a message suggesting the user set
+    /// `allow_external_writes = true` in their config or trust the specific
+    /// path via `/trust add <path>`.
+    ///
+    /// When `true`, external writes proceed with the existing workspace-trust
+    /// and `trust_mode` validation.
+    pub allow_external_writes: bool,
 }
 
 impl ToolContext {
@@ -136,6 +146,7 @@ impl ToolContext {
             runtime: RuntimeToolServices::default(),
             cancel_token: None,
             memory_path: None,
+            allow_external_writes: false,
         }
     }
 
@@ -165,6 +176,7 @@ impl ToolContext {
             runtime: RuntimeToolServices::default(),
             cancel_token: None,
             memory_path: None,
+            allow_external_writes: false,
         }
     }
 
@@ -194,6 +206,7 @@ impl ToolContext {
             runtime: RuntimeToolServices::default(),
             cancel_token: None,
             memory_path: None,
+            allow_external_writes: false,
         }
     }
 
@@ -278,9 +291,7 @@ impl ToolContext {
                 && !self.is_trusted_external_path(&candidate_canonical)
                 && !self.is_trusted_external_path(&candidate_normalized)
             {
-                return Err(ToolError::PathEscape {
-                    path: candidate_canonical,
-                });
+                return self.external_path_error(candidate_canonical);
             }
         }
 
@@ -297,7 +308,7 @@ impl ToolContext {
             if !canonical.starts_with(&workspace_canonical)
                 && !self.is_trusted_external_path(&canonical)
             {
-                return Err(ToolError::PathEscape { path: canonical });
+                return self.external_path_error(canonical);
             }
 
             return Ok(canonical);
@@ -345,7 +356,7 @@ impl ToolContext {
             && !canonical.starts_with(&workspace_normalized)
             && !self.is_trusted_external_path(&canonical)
         {
-            return Err(ToolError::PathEscape { path: canonical });
+            return self.external_path_error(canonical);
         }
 
         Ok(canonical)
@@ -357,6 +368,32 @@ impl ToolContext {
         self.trusted_external_paths
             .iter()
             .any(|trusted| path.starts_with(trusted))
+    }
+
+    /// Return a `PermissionDenied` error when `allow_external_writes` is
+    /// false, or a `PathEscape` error when the user has opted in via config.
+    /// The PermissionDenied variant triggers a more actionable UI message
+    /// suggesting the user set `allow_external_writes = true` or trust the
+    /// path.
+    fn external_path_error(&self, path: PathBuf) -> Result<PathBuf, ToolError> {
+        if self.allow_external_writes {
+            Err(ToolError::PathEscape { path })
+        } else {
+            Err(ToolError::permission_denied(format!(
+                "Path '{}' is outside the workspace directory. \
+                 Set `allow_external_writes = true` in config, \
+                 use `/trust add <path>` to trust the directory, \
+                 or use a path within the workspace.",
+                path.display()
+            )))
+        }
+    }
+
+    /// Set the allow_external_writes mode.
+    #[must_use]
+    pub fn with_allow_external_writes(mut self, allow: bool) -> Self {
+        self.allow_external_writes = allow;
+        self
     }
 
     /// Set the trust mode.

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -653,6 +653,12 @@ pub struct App {
     /// dangerous command after being told no, but the user shouldn't
     /// have to keep dismissing the same dialog.
     pub approval_session_denied: HashSet<String>,
+    /// Pre-computed broad approval keys for pending approval requests,
+    /// keyed by tool_id. Set in the `ApprovalRequired` handler so the
+    /// `ApprovalDecision` handler can store the broad key without
+    /// re-deriving it from tool_input (which is not available at that
+    /// point). Used by #412 (always-allow broader-pattern memory).
+    pub pending_approval_broad_keys: HashMap<String, String>,
     pub approval_mode: ApprovalMode,
     // Modal view stack (approval/help/etc.)
     pub view_stack: ViewStack,
@@ -664,6 +670,9 @@ pub struct App {
     pub current_session_id: Option<String>,
     /// Trust mode - allow access outside workspace
     pub trust_mode: bool,
+    /// When false (default), deny external directory writes with a permission
+    /// error. When true, external writes use the existing trust validation.
+    pub allow_external_writes: bool,
     /// Ordered list of footer items the user wants visible. Sourced from
     /// `tui.status_items` in `~/.deepseek/config.toml` at startup; mutated
     /// live by `/statusline`. The renderer iterates this slice; no item is
@@ -1158,6 +1167,7 @@ impl App {
             clipboard: ClipboardHandler::new(),
             approval_session_approved: HashSet::new(),
             approval_session_denied: HashSet::new(),
+            pending_approval_broad_keys: HashMap::new(),
             approval_mode: if matches!(initial_mode, AppMode::Yolo) {
                 ApprovalMode::Auto
             } else {
@@ -1167,6 +1177,7 @@ impl App {
             backtrack: crate::tui::backtrack::BacktrackState::new(),
             current_session_id: None,
             trust_mode: initial_mode == AppMode::Yolo,
+            allow_external_writes: config.allow_external_writes(),
             status_items: config
                 .tui
                 .as_ref()

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -508,6 +508,7 @@ fn build_engine_config(app: &App, config: &Config) -> EngineConfig {
         workspace: app.workspace.clone(),
         allow_shell: app.allow_shell,
         trust_mode: app.trust_mode,
+        allow_external_writes: app.allow_external_writes,
         notes_path: config.notes_path(),
         mcp_config_path: config.mcp_config_path(),
         skills_dir: app.skills_dir.clone(),
@@ -1162,9 +1163,26 @@ async fn run_event_loop(
                         description,
                         approval_key,
                     } => {
+                        // Pre-compute the broad session key so it's available
+                        // for both the approval check here and the decision
+                        // handler later (#412).
+                        let tool_input = app
+                            .pending_tool_uses
+                            .iter()
+                            .find(|(tool_id, _, _)| tool_id == &id)
+                            .map(|(_, _, input)| input.clone())
+                            .unwrap_or_else(|| serde_json::json!({}));
+                        let approval_key_broad = crate::tools::approval_cache::build_session_approval_key(
+                            &tool_name,
+                            &tool_input,
+                        );
+                        app.pending_approval_broad_keys
+                            .insert(id.clone(), approval_key_broad.0.clone());
+
                         let session_approved =
                             app.approval_session_approved.contains(&approval_key)
-                                || app.approval_session_approved.contains(&tool_name);
+                                || app.approval_session_approved.contains(&tool_name)
+                                || app.approval_session_approved.contains(&approval_key_broad.0);
                         let session_denied = app.approval_session_denied.contains(&approval_key)
                             || app.approval_session_denied.contains(&tool_name);
                         if session_denied {
@@ -1205,13 +1223,6 @@ async fn run_event_loop(
                             app.status_message =
                                 Some(format!("Blocked tool '{tool_name}' (approval_mode=never)"));
                         } else {
-                            let tool_input = app
-                                .pending_tool_uses
-                                .iter()
-                                .find(|(tool_id, _, _)| tool_id == &id)
-                                .map(|(_, _, input)| input.clone())
-                                .unwrap_or_else(|| serde_json::json!({}));
-
                             if tool_name == "apply_patch" {
                                 maybe_add_patch_preview(app, &tool_input);
                             }
@@ -4793,11 +4804,19 @@ async fn handle_view_events(
                 approval_key,
             } => {
                 if decision == ReviewDecision::ApprovedForSession {
-                    // Store both the tool name (backward compat) and the
-                    // approval key (fingerprint-based).
-                    app.approval_session_approved.insert(tool_name.clone());
+                    // Store the exact approval key and the broader
+                    // session‑level key so that "always allow" on a
+                    // read_file("src/main.rs") also covers read_file
+                    // operations in the same directory (#412).
                     app.approval_session_approved.insert(approval_key.clone());
+                    if let Some(broad_key) = app.pending_approval_broad_keys.remove(&tool_id) {
+                        app.approval_session_approved.insert(broad_key);
+                    }
                 }
+
+                // Clean up the pending broad key — it's no longer needed
+                // and we don't want unbounded map growth (#412).
+                app.pending_approval_broad_keys.remove(&tool_id);
 
                 match decision {
                     ReviewDecision::Approved | ReviewDecision::ApprovedForSession => {


### PR DESCRIPTION
Closes #411. Closes #412.

**#411**: Adds `external_directory` permission gate — writes outside the current working directory require explicit approval. Gated behind `allow_external_writes = false` config.

**#412**: When user selects 'always allow' for a permission, stores a broader directory-level pattern rather than per-file, reducing repetitive approval prompts.

Implemented using `deepseek exec --model deepseek-v4-flash`. 🐋