### PR TITLE
feat(lsp): add 9-operation LSP tool (#427)

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -1269,6 +1269,13 @@ impl Engine {
         .with_shell_manager(self.shell_manager.clone())
         .with_runtime_services(self.config.runtime_services.clone())
         .with_cancel_token(self.cancel_token.clone())
+        // Inject the LSP manager so the LSP tool can call code-intelligence
+        // operations (hover, definition, references, etc.).
+        .map_runtime(|rt| {
+            if rt.lsp_manager.is_none() {
+                rt.lsp_manager = Some(Arc::clone(&self.lsp_manager));
+            }
+        })
         .with_trusted_external_paths(trusted.paths().to_vec());
 
         // Hand the user-memory path to tools so the model-callable

--- a/crates/tui/src/core/engine/tool_setup.rs
+++ b/crates/tui/src/core/engine/tool_setup.rs
@@ -48,6 +48,10 @@ impl Engine {
             builder = builder.with_shell_tools();
         }
 
+        // Register the LSP code-intelligence tool (#427) — available in
+        // both Plan and Agent modes since it's read-only.
+        builder = builder.with_lsp_tool();
+
         // Register the `remember` tool only when the user has opted in to
         // user-memory (#489). Without that opt-in the tool would always
         // fail; surfacing it would just waste catalog slots.

--- a/crates/tui/src/lsp/client.rs
+++ b/crates/tui/src/lsp/client.rs
@@ -57,6 +57,20 @@ pub trait LspTransport: Send + Sync {
         wait: Duration,
     ) -> Result<Vec<Diagnostic>>;
 
+    /// Send a generic JSON-RPC request to the LSP server (e.g.
+    /// `textDocument/hover`, `textDocument/definition`). Returns the
+    /// `result` field of the response, or an error on timeout / LSP
+    /// error response. The caller is responsible for ensuring the
+    /// relevant file is opened (via `ensure_open` or a prior
+    /// `diagnostics_for`) before sending document-scoped requests.
+    async fn request(&self, method: &str, params: Value) -> Result<Value>;
+
+    /// Ensure the file is opened (didOpen) or up-to-date (didChange) in
+    /// the LSP server. Called by `LspManager` before sending
+    /// textDocument-scoped requests for files that may not have been
+    /// seen yet.
+    async fn ensure_open(&self, path: &Path, text: &str) -> Result<()>;
+
     /// Best-effort shutdown. Called via `LspManager::shutdown_all`.
     #[allow(dead_code)]
     async fn shutdown(&self);
@@ -75,14 +89,10 @@ pub struct StdioLspTransport {
     /// Inbound diagnostics queue. We push every `publishDiagnostics`
     /// notification into here and the public API drains the relevant entries.
     diagnostics_rx: AsyncMutex<mpsc::Receiver<(PathBuf, Vec<Diagnostic>)>>,
-    /// Map of in-flight request id -> reply slot. We do not currently call
-    /// methods that need replies after `initialize`, but this is the hook
-    /// for it.
-    #[allow(dead_code)]
+    /// Map of in-flight request id -> reply slot. Used by the `request`
+    /// method for request/response LSP operations (hover, definition, etc.).
     pending: Arc<AsyncMutex<HashMap<i64, oneshot::Sender<Value>>>>,
-    /// Monotonic request id counter. Reserved for future LSP request/reply
-    /// methods (workspace symbol queries, etc.).
-    #[allow(dead_code)]
+    /// Monotonic request id counter. Used by the `request` method.
     next_id: AsyncMutex<i64>,
     /// Language id passed in `textDocument/didOpen` (e.g. "rust").
     language_id: &'static str,
@@ -201,42 +211,9 @@ impl LspTransport for StdioLspTransport {
         wait: Duration,
     ) -> Result<Vec<Diagnostic>> {
         let path_buf = path.to_path_buf();
-        let uri = uri_from_path(&path_buf);
 
-        // Either send didOpen (first time) or didChange (subsequent edits).
-        let mut opened = self.opened.lock().await;
-        let is_new = !opened.contains_key(&path_buf);
-        let new_version = opened.get(&path_buf).copied().unwrap_or(0) + 1;
-        opened.insert(path_buf.clone(), new_version);
-        drop(opened);
-
-        let payload = if is_new {
-            json!({
-                "jsonrpc": "2.0",
-                "method": "textDocument/didOpen",
-                "params": {
-                    "textDocument": {
-                        "uri": uri.clone(),
-                        "languageId": self.language_id,
-                        "version": new_version,
-                        "text": text
-                    }
-                }
-            })
-        } else {
-            json!({
-                "jsonrpc": "2.0",
-                "method": "textDocument/didChange",
-                "params": {
-                    "textDocument": {
-                        "uri": uri.clone(),
-                        "version": new_version
-                    },
-                    "contentChanges": [{ "text": text }]
-                }
-            })
-        };
-        send_message(&self.tx_outbound, &payload).await?;
+        // Ensure the file is opened/updated before waiting for diagnostics.
+        self.ensure_open(path, text).await?;
 
         // Drain matching `publishDiagnostics` notifications until `wait`
         // elapses. Servers typically publish within a few hundred ms; for
@@ -269,6 +246,81 @@ impl LspTransport for StdioLspTransport {
             // opened. Discard and continue waiting.
         }
         Ok(latest.unwrap_or_default())
+    }
+
+    async fn ensure_open(&self, path: &Path, text: &str) -> Result<()> {
+        let path_buf = path.to_path_buf();
+        let uri = uri_from_path(&path_buf);
+
+        let mut opened = self.opened.lock().await;
+        let is_new = !opened.contains_key(&path_buf);
+        let new_version = opened.get(&path_buf).copied().unwrap_or(0) + 1;
+        opened.insert(path_buf.clone(), new_version);
+        drop(opened);
+
+        let payload = if is_new {
+            json!({
+                "jsonrpc": "2.0",
+                "method": "textDocument/didOpen",
+                "params": {
+                    "textDocument": {
+                        "uri": uri,
+                        "languageId": self.language_id,
+                        "version": new_version,
+                        "text": text,
+                    }
+                }
+            })
+        } else {
+            json!({
+                "jsonrpc": "2.0",
+                "method": "textDocument/didChange",
+                "params": {
+                    "textDocument": {
+                        "uri": uri,
+                        "version": new_version,
+                    },
+                    "contentChanges": [{ "text": text }],
+                }
+            })
+        };
+        send_message(&self.tx_outbound, &payload).await?;
+        Ok(())
+    }
+
+    async fn request(&self, method: &str, params: Value) -> Result<Value> {
+        let mut id_lock = self.next_id.lock().await;
+        let id = *id_lock;
+        *id_lock += 1;
+        drop(id_lock);
+
+        let (tx, rx) = oneshot::channel();
+        self.pending.lock().await.insert(id, tx);
+
+        let request_body = json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        });
+        send_message(&self.tx_outbound, &request_body).await?;
+
+        // Wait up to 30 seconds for a response.
+        let response = tokio::time::timeout(Duration::from_secs(30), rx)
+            .await
+            .map_err(|_| anyhow!("LSP {method} timed out after 30s"))?
+            .map_err(|_| anyhow!("LSP {method} response channel closed"))?;
+
+        if let Some(error) = response.get("error") {
+            let code = error.get("code").and_then(|v| v.as_i64()).unwrap_or(-1);
+            let msg = error
+                .get("message")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown error");
+            return Err(anyhow!("LSP {method} error (code {code}): {msg}"));
+        }
+
+        Ok(response.get("result").cloned().unwrap_or(Value::Null))
     }
 
     async fn shutdown(&self) {

--- a/crates/tui/src/lsp/mod.rs
+++ b/crates/tui/src/lsp/mod.rs
@@ -37,6 +37,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use serde::Deserialize;
+use serde_json::Value;
 use tokio::sync::Mutex as AsyncMutex;
 use tokio::time::timeout;
 
@@ -215,6 +216,74 @@ impl LspManager {
         }
     }
 
+    /// Send a generic LSP request for a file (e.g. `textDocument/hover`,
+    /// `textDocument/definition`, `textDocument/references`).
+    ///
+    /// Reads the file, ensures the transport is spawned, opens/updates the
+    /// file in the LSP server via `ensure_open`, then sends the request and
+    /// returns the raw JSON `result`. Returns `None` when the manager is
+    /// disabled, the language is unsupported, or the transport is
+    /// unavailable.
+    ///
+    /// The caller is responsible for passing the correct JSON params for the
+    /// LSP method. For `workspace/symbol`, pass `Path::new("")` as the file
+    /// — it will skip the file-read and open steps.
+    pub async fn request_for(
+        &self,
+        file: &Path,
+        method: &str,
+        params: Value,
+    ) -> Option<Value> {
+        if !self.config.enabled {
+            return None;
+        }
+
+        let is_workspace_request = file.as_os_str().is_empty();
+        let lang = if is_workspace_request {
+            // workspace/symbol doesn't need a file; use a placeholder
+            Language::Other
+        } else {
+            let l = registry::detect_language(file);
+            if l == Language::Other {
+                return None;
+            }
+            l
+        };
+
+        let transport = match self.transport_for(lang).await {
+            Some(t) => t,
+            None => return None,
+        };
+
+        if !is_workspace_request {
+            // Read file content and ensure it's open in the server.
+            let text = match tokio::fs::read_to_string(file).await {
+                Ok(text) => text,
+                Err(err) => {
+                    tracing::debug!(?err, file = %file.display(), "lsp: read file failed for request");
+                    return None;
+                }
+            };
+            if let Err(err) = transport.ensure_open(file, &text).await {
+                tracing::debug!(?err, file = %file.display(), method, "lsp: ensure_open failed");
+                return None;
+            }
+        }
+
+        let wait = Duration::from_secs(30);
+        match timeout(wait, transport.request(method, params)).await {
+            Ok(Ok(value)) => Some(value),
+            Ok(Err(err)) => {
+                tracing::debug!(?err, method, file = %file.display(), "lsp: request failed");
+                None
+            }
+            Err(_) => {
+                tracing::debug!(method, file = %file.display(), "lsp: request timed out");
+                None
+            }
+        }
+    }
+
     /// Resolve (and lazily spawn) the transport for `lang`. Tests can
     /// short-circuit this via `install_test_transport` (cfg-test only).
     async fn transport_for(&self, lang: Language) -> Option<Arc<dyn LspTransport>> {
@@ -298,6 +367,7 @@ impl LspManager {
 pub(crate) mod tests {
     use super::*;
     use async_trait::async_trait;
+    use serde_json::Value;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     /// Fake transport: returns a fixed list of diagnostics. Used by
@@ -330,6 +400,20 @@ pub(crate) mod tests {
         ) -> anyhow::Result<Vec<Diagnostic>> {
             self.calls.fetch_add(1, Ordering::Relaxed);
             Ok(self.items.clone())
+        }
+
+        async fn request(
+            &self,
+            _method: &str,
+            _params: Value,
+        ) -> anyhow::Result<Value> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            Ok(Value::Null)
+        }
+
+        async fn ensure_open(&self, _path: &Path, _text: &str) -> anyhow::Result<()> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            Ok(())
         }
 
         async fn shutdown(&self) {}

--- a/crates/tui/src/prompts/base.md
+++ b/crates/tui/src/prompts/base.md
@@ -1,5 +1,9 @@
 You are DeepSeek TUI. You're already running inside it — don't try to launch a `deepseek` or `deepseek-tui` binary.
 
+## Language Mirror
+
+Detect the user's primary language from their message and respond in that same language — both in your reasoning (thinking tokens) and final reply. Do not default to English for non-English inputs.
+
 ## Preamble Rhythm
 
 When starting work on a user request, open with a short, momentum-building line that names the action you're taking. Keep it reserved — state what you're doing, not how you feel about it.

--- a/crates/tui/src/prompts/base.txt
+++ b/crates/tui/src/prompts/base.txt
@@ -1,5 +1,9 @@
 You are DeepSeek TUI. You're already running inside it — don't try to launch a `deepseek` or `deepseek-tui` binary.
 
+## Language Mirror
+
+Detect the user's primary language from their message and respond in that same language — both in your reasoning (thinking tokens) and final reply. Do not default to English for non-English inputs.
+
 ## Decomposition Philosophy
 
 You are a "managed genius" — you excel at individual tasks, but your superpower is decomposing complex work. **Always decompose before you act.** A few minutes spent planning saves many minutes of thrashing.

--- a/crates/tui/src/prompts/base.txt
+++ b/crates/tui/src/prompts/base.txt
@@ -1,9 +1,5 @@
 You are DeepSeek TUI. You're already running inside it — don't try to launch a `deepseek` or `deepseek-tui` binary.
 
-## Language Mirror
-
-Detect the user's primary language from their message and respond in that same language — both in your reasoning (thinking tokens) and final reply. Do not default to English for non-English inputs.
-
 ## Decomposition Philosophy
 
 You are a "managed genius" — you excel at individual tasks, but your superpower is decomposing complex work. **Always decompose before you act.** A few minutes spent planning saves many minutes of thrashing.

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -1807,6 +1807,7 @@ impl RuntimeThreadManager {
                 active_thread_id: Some(thread.id.clone()),
                 shell_manager: None,
                 hook_executor: None,
+                lsp_manager: None,
             },
             subagent_model_overrides: self.config.subagent_model_overrides(),
             memory_enabled: self.config.memory_enabled(),

--- a/crates/tui/src/tools/lsp.rs
+++ b/crates/tui/src/tools/lsp.rs
@@ -1,0 +1,443 @@
+//! LSP code-intelligence tool: 9 named operations exposed as model-visible
+//! tool calls (hover, definition, references, rename, codeAction,
+//! completion, signatureHelp, documentSymbol, workspaceSymbol).
+//!
+//! The tool accepts a required `operation` string plus operation-specific
+//! parameters. The underlying `LspManager` handles transport lifecycle and
+//! language detection.
+//!
+//! # Operations
+//!
+//! | operation          | LSP method                        | key params                            |
+//! |--------------------|-----------------------------------|---------------------------------------|
+//! | hover              | textDocument/hover                | path, line, character                 |
+//! | definition         | textDocument/definition           | path, line, character                 |
+//! | references         | textDocument/references            | path, line, character                 |
+//! | rename             | textDocument/rename               | path, line, character, newName        |
+//! | codeAction         | textDocument/codeAction           | path, range start/end, context        |
+//! | completion         | textDocument/completion           | path, line, character                 |
+//! | signatureHelp      | textDocument/signatureHelp        | path, line, character                 |
+//! | documentSymbol     | textDocument/documentSymbol       | path                                 |
+//! | workspaceSymbol    | workspace/symbol                  | query                                |
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+use super::spec::{
+    ApprovalRequirement, ToolCapability, ToolContext, ToolError, ToolResult, ToolSpec,
+    optional_u64, required_str,
+};
+
+/// The `lsp` tool — dispatches to one of 9 LSP code-intelligence operations.
+pub struct LspTool;
+
+#[async_trait]
+impl ToolSpec for LspTool {
+    fn name(&self) -> &'static str {
+        "lsp"
+    }
+
+    fn description(&self) -> &'static str {
+        "Execute an LSP code-intelligence operation: hover, definition, references, rename, \
+         codeAction, completion, signatureHelp, documentSymbol, or workspaceSymbol. \
+         Returns the result from the LSP server as JSON."
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "operation": {
+                    "type": "string",
+                    "enum": [
+                        "hover",
+                        "definition",
+                        "references",
+                        "rename",
+                        "codeAction",
+                        "completion",
+                        "signatureHelp",
+                        "documentSymbol",
+                        "workspaceSymbol"
+                    ],
+                    "description": "The LSP operation to perform"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Path to the file (required for all operations except workspaceSymbol)"
+                },
+                "line": {
+                    "type": "integer",
+                    "description": "0-based line number for position-based operations"
+                },
+                "character": {
+                    "type": "integer",
+                    "description": "0-based character offset for position-based operations"
+                },
+                "newName": {
+                    "type": "string",
+                    "description": "New symbol name (required for rename operation)"
+                },
+                "query": {
+                    "type": "string",
+                    "description": "Search query (required for workspaceSymbol)"
+                },
+                "rangeStartLine": {
+                    "type": "integer",
+                    "description": "Range start line (0-based, for codeAction)"
+                },
+                "rangeStartCharacter": {
+                    "type": "integer",
+                    "description": "Range start character (0-based, for codeAction)"
+                },
+                "rangeEndLine": {
+                    "type": "integer",
+                    "description": "Range end line (0-based, for codeAction)"
+                },
+                "rangeEndCharacter": {
+                    "type": "integer",
+                    "description": "Range end character (0-based, for codeAction)"
+                },
+                "context": {
+                    "type": "object",
+                    "description": "Optional extra context JSON for codeAction (e.g. diagnostics)"
+                }
+            },
+            "required": ["operation"]
+        })
+    }
+
+    fn capabilities(&self) -> Vec<ToolCapability> {
+        vec![ToolCapability::ReadOnly]
+    }
+
+    fn approval_requirement(&self) -> ApprovalRequirement {
+        ApprovalRequirement::Auto
+    }
+
+    async fn execute(&self, input: Value, context: &ToolContext) -> Result<ToolResult, ToolError> {
+        let operation = required_str(&input, "operation")?;
+
+        // Grab the LSP manager from runtime services.
+        let lsp_manager = context
+            .runtime
+            .lsp_manager
+            .clone()
+            .ok_or_else(|| ToolError::not_available(
+                "LSP is not available in this context (no LspManager configured)"
+            ))?;
+
+        // Dispatch to the requested operation.
+        let result = match operation {
+            "hover" => op_hover(&input, &lsp_manager, context).await,
+            "definition" => op_definition(&input, &lsp_manager, context).await,
+            "references" => op_references(&input, &lsp_manager, context).await,
+            "rename" => op_rename(&input, &lsp_manager, context).await,
+            "codeAction" => op_code_action(&input, &lsp_manager, context).await,
+            "completion" => op_completion(&input, &lsp_manager, context).await,
+            "signatureHelp" => op_signature_help(&input, &lsp_manager, context).await,
+            "documentSymbol" => op_document_symbol(&input, &lsp_manager, context).await,
+            "workspaceSymbol" => op_workspace_symbol(&input, &lsp_manager, context).await,
+            other => return Err(ToolError::invalid_input(format!(
+                "unknown LSP operation '{other}'; expected one of: \
+                 hover, definition, references, rename, codeAction, \
+                 completion, signatureHelp, documentSymbol, workspaceSymbol"
+            ))),
+        }?;
+
+        Ok(ToolResult::success(result))
+    }
+}
+
+// ── Position helpers ──────────────────────────────────────────────────────
+
+/// Build a LSP Position `{line, character}` from the input (0-based).
+fn position_from_input(input: &Value) -> Result<Value, ToolError> {
+    let line = optional_u64(input, "line", 0);
+    let character = optional_u64(input, "character", 0);
+    Ok(json!({ "line": line, "character": character }))
+}
+
+/// Build a LSP Range from start/end fields in the input.
+fn range_from_input(input: &Value) -> Result<Value, ToolError> {
+    let start_line = optional_u64(input, "rangeStartLine", 0);
+    let start_char = optional_u64(input, "rangeStartCharacter", 0);
+    let end_line = optional_u64(input, "rangeEndLine", 0);
+    let end_char = optional_u64(input, "rangeEndCharacter", 0);
+    Ok(json!({
+        "start": { "line": start_line, "character": start_char },
+        "end":   { "line": end_line,   "character": end_char }
+    }))
+}
+
+/// Resolve the file path from input, relative to the workspace.
+fn resolve_path(input: &Value, context: &ToolContext) -> Result<PathBuf, ToolError> {
+    let raw = required_str(input, "path")?;
+    context.resolve_path(raw)
+}
+
+// ── Operation implementations ─────────────────────────────────────────────
+
+/// `textDocument/hover`
+async fn op_hover(
+    input: &Value,
+    mgr: &Arc<crate::lsp::LspManager>,
+    context: &ToolContext,
+) -> Result<String, ToolError> {
+    let path = resolve_path(input, context)?;
+    let position = position_from_input(input)?;
+    let params = json!({
+        "textDocument": { "uri": uri_from_path(&path) },
+        "position": position,
+    });
+    let result = mgr.request_for(&path, "textDocument/hover", params).await;
+    Ok(format_result("hover", result))
+}
+
+/// `textDocument/definition`
+async fn op_definition(
+    input: &Value,
+    mgr: &Arc<crate::lsp::LspManager>,
+    context: &ToolContext,
+) -> Result<String, ToolError> {
+    let path = resolve_path(input, context)?;
+    let position = position_from_input(input)?;
+    let params = json!({
+        "textDocument": { "uri": uri_from_path(&path) },
+        "position": position,
+    });
+    let result = mgr.request_for(&path, "textDocument/definition", params).await;
+    Ok(format_result("definition", result))
+}
+
+/// `textDocument/references`
+async fn op_references(
+    input: &Value,
+    mgr: &Arc<crate::lsp::LspManager>,
+    context: &ToolContext,
+) -> Result<String, ToolError> {
+    let path = resolve_path(input, context)?;
+    let position = position_from_input(input)?;
+    let params = json!({
+        "textDocument": { "uri": uri_from_path(&path) },
+        "position": position,
+        "context": { "includeDeclaration": true },
+    });
+    let result = mgr.request_for(&path, "textDocument/references", params).await;
+    Ok(format_result("references", result))
+}
+
+/// `textDocument/rename`
+async fn op_rename(
+    input: &Value,
+    mgr: &Arc<crate::lsp::LspManager>,
+    context: &ToolContext,
+) -> Result<String, ToolError> {
+    let path = resolve_path(input, context)?;
+    let position = position_from_input(input)?;
+    let new_name = required_str(input, "newName")?;
+    let params = json!({
+        "textDocument": { "uri": uri_from_path(&path) },
+        "position": position,
+        "newName": new_name,
+    });
+    let result = mgr.request_for(&path, "textDocument/rename", params).await;
+    Ok(format_result("rename", result))
+}
+
+/// `textDocument/codeAction`
+async fn op_code_action(
+    input: &Value,
+    mgr: &Arc<crate::lsp::LspManager>,
+    context: &ToolContext,
+) -> Result<String, ToolError> {
+    let path = resolve_path(input, context)?;
+    let range = range_from_input(input)?;
+    let ctx = input
+        .get("context")
+        .cloned()
+        .unwrap_or(json!({ "diagnostics": [] }));
+    let params = json!({
+        "textDocument": { "uri": uri_from_path(&path) },
+        "range": range,
+        "context": ctx,
+    });
+    let result = mgr.request_for(&path, "textDocument/codeAction", params).await;
+    Ok(format_result("codeAction", result))
+}
+
+/// `textDocument/completion`
+async fn op_completion(
+    input: &Value,
+    mgr: &Arc<crate::lsp::LspManager>,
+    context: &ToolContext,
+) -> Result<String, ToolError> {
+    let path = resolve_path(input, context)?;
+    let position = position_from_input(input)?;
+    let params = json!({
+        "textDocument": { "uri": uri_from_path(&path) },
+        "position": position,
+    });
+    let result = mgr.request_for(&path, "textDocument/completion", params).await;
+    Ok(format_result("completion", result))
+}
+
+/// `textDocument/signatureHelp`
+async fn op_signature_help(
+    input: &Value,
+    mgr: &Arc<crate::lsp::LspManager>,
+    context: &ToolContext,
+) -> Result<String, ToolError> {
+    let path = resolve_path(input, context)?;
+    let position = position_from_input(input)?;
+    let params = json!({
+        "textDocument": { "uri": uri_from_path(&path) },
+        "position": position,
+    });
+    let result = mgr.request_for(&path, "textDocument/signatureHelp", params).await;
+    Ok(format_result("signatureHelp", result))
+}
+
+/// `textDocument/documentSymbol`
+async fn op_document_symbol(
+    input: &Value,
+    mgr: &Arc<crate::lsp::LspManager>,
+    context: &ToolContext,
+) -> Result<String, ToolError> {
+    let path = resolve_path(input, context)?;
+    let params = json!({
+        "textDocument": { "uri": uri_from_path(&path) },
+    });
+    let result = mgr.request_for(&path, "textDocument/documentSymbol", params).await;
+    Ok(format_result("documentSymbol", result))
+}
+
+/// `workspace/symbol`
+async fn op_workspace_symbol(
+    input: &Value,
+    mgr: &Arc<crate::lsp::LspManager>,
+    _context: &ToolContext,
+) -> Result<String, ToolError> {
+    let query = required_str(input, "query")?;
+    let params = json!({ "query": query });
+    // workspace/symbol doesn't need a file path — pass empty path.
+    let empty_path = Path::new("");
+    let result = mgr.request_for(empty_path, "workspace/symbol", params).await;
+    Ok(format_result("workspaceSymbol", result))
+}
+
+// ── Formatting helpers ────────────────────────────────────────────────────
+
+/// Format an LSP response: pretty-print the JSON when Some, or "no result"
+/// when None.
+fn format_result(label: &str, result: Option<Value>) -> String {
+    match result {
+        Some(value) if value != Value::Null => {
+            let pretty = serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string());
+            format!("<lsp_{}>\n{}\n</lsp_{}>", label, pretty, label)
+        }
+        _ => format!("<lsp_{}>\nno result\n</lsp_{}>", label, label),
+    }
+}
+
+/// Convert a filesystem path to a `file://` URI. Reuses the same logic from
+/// the LSP client crate.
+fn uri_from_path(path: &Path) -> String {
+    let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    let s = canonical.to_string_lossy();
+    if s.starts_with('/') {
+        format!("file://{s}")
+    } else {
+        format!("file:///{}", s.trim_start_matches('/'))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn tool_name_and_description() {
+        let tool = LspTool;
+        assert_eq!(tool.name(), "lsp");
+        assert!(!tool.description().is_empty());
+    }
+
+    #[test]
+    fn tool_input_schema_has_required_operation() {
+        let tool = LspTool;
+        let schema = tool.input_schema();
+        let props = schema.get("properties").unwrap();
+        assert!(props.get("operation").is_some());
+        let required = schema.get("required").unwrap().as_array().unwrap();
+        assert!(required.iter().any(|v| v == "operation"));
+    }
+
+    #[test]
+    fn schema_lists_all_nine_operations() {
+        let tool = LspTool;
+        let schema = tool.input_schema();
+        let op_schema = schema.pointer("/properties/operation").unwrap();
+        let variants = op_schema.get("enum").unwrap().as_array().unwrap();
+        let names: Vec<&str> = variants.iter().map(|v| v.as_str().unwrap()).collect();
+        assert_eq!(names.len(), 9);
+        assert!(names.contains(&"hover"));
+        assert!(names.contains(&"definition"));
+        assert!(names.contains(&"references"));
+        assert!(names.contains(&"rename"));
+        assert!(names.contains(&"codeAction"));
+        assert!(names.contains(&"completion"));
+        assert!(names.contains(&"signatureHelp"));
+        assert!(names.contains(&"documentSymbol"));
+        assert!(names.contains(&"workspaceSymbol"));
+    }
+
+    #[test]
+    fn tool_is_read_only() {
+        let tool = LspTool;
+        assert!(tool.is_read_only());
+        assert_eq!(tool.approval_requirement(), ApprovalRequirement::Auto);
+    }
+
+    #[test]
+    fn uri_format() {
+        let path = PathBuf::from("/home/user/project/src/main.rs");
+        let uri = uri_from_path(&path);
+        assert_eq!(uri, "file:///home/user/project/src/main.rs");
+    }
+
+    #[test]
+    fn position_from_input_defaults_to_zero() {
+        let input = json!({});
+        let pos = position_from_input(&input).unwrap();
+        assert_eq!(pos["line"], 0);
+        assert_eq!(pos["character"], 0);
+    }
+
+    #[test]
+    fn position_from_input_uses_supplied_values() {
+        let input = json!({ "line": 10, "character": 5 });
+        let pos = position_from_input(&input).unwrap();
+        assert_eq!(pos["line"], 10);
+        assert_eq!(pos["character"], 5);
+    }
+
+    #[test]
+    fn format_result_some_non_null() {
+        let result = Some(json!({ "key": "value" }));
+        let output = format_result("test", result);
+        assert!(output.starts_with("<lsp_test>"));
+        assert!(output.contains("\"key\""));
+        assert!(output.ends_with("</lsp_test>"));
+    }
+
+    #[test]
+    fn format_result_none_or_null() {
+        assert!(format_result("t", None).contains("no result"));
+        assert!(format_result("t", Some(Value::Null)).contains("no result"));
+    }
+}

--- a/crates/tui/src/tools/mod.rs
+++ b/crates/tui/src/tools/mod.rs
@@ -12,6 +12,7 @@ pub mod finance;
 pub mod fetch_url;
 pub mod git;
 pub mod git_history;
+pub mod lsp;
 pub mod github;
 pub mod parallel;
 pub mod plan;

--- a/crates/tui/src/tools/registry.rs
+++ b/crates/tui/src/tools/registry.rs
@@ -471,6 +471,15 @@ impl ToolRegistryBuilder {
         self.with_tool(Arc::new(ApplyPatchTool))
     }
 
+    /// Include the LSP code-intelligence tool (9 operations: hover,
+    /// definition, references, rename, codeAction, completion,
+    /// signatureHelp, documentSymbol, workspaceSymbol).
+    #[must_use]
+    pub fn with_lsp_tool(self) -> Self {
+        use super::lsp::LspTool;
+        self.with_tool(Arc::new(LspTool))
+    }
+
     /// Include the `revert_turn` tool. Approval-gated since it mutates
     /// the workspace; the model uses it when the user asks to "undo my
     /// last edit". Backed by the per-workspace snapshot side-repo

--- a/crates/tui/src/tools/spec.rs
+++ b/crates/tui/src/tools/spec.rs
@@ -39,6 +39,10 @@ pub struct RuntimeToolServices {
     /// tool-side hook events. `None` outside the live engine — test
     /// contexts that don't care about hooks get a no-op.
     pub hook_executor: Option<std::sync::Arc<crate::hooks::HookExecutor>>,
+    /// LSP manager for code intelligence operations (hover, definition,
+    /// references, completion, etc.). When `None`, the LSP tool degrades
+    /// gracefully with a "LSP unavailable" message.
+    pub lsp_manager: Option<std::sync::Arc<crate::lsp::LspManager>>,
 }
 
 impl std::fmt::Debug for RuntimeToolServices {
@@ -397,6 +401,15 @@ impl ToolContext {
     /// Set the namespace used for session-scoped tool state.
     pub fn with_state_namespace(mut self, namespace: impl Into<String>) -> Self {
         self.state_namespace = namespace.into();
+        self
+    }
+
+    /// Mutate the attached runtime services in place. Returns self for
+    /// chaining. This is a lower-level escape hatch used by the engine to
+    /// inject session-scoped services (like `LspManager`) that aren't known
+    /// when `RuntimeToolServices` is first constructed.
+    pub fn map_runtime(mut self, f: impl FnOnce(&mut RuntimeToolServices)) -> Self {
+        f(&mut self.runtime);
         self
     }
 }

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -376,6 +376,7 @@ pub async fn run_tui(config: &Config, options: TuiOptions) -> Result<()> {
         // #456: plumb the App's HookExecutor so `exec_shell` can surface
         // the configured `shell_env` hooks. Wrapped in Arc once and shared.
         hook_executor: Some(std::sync::Arc::new(app.hooks.clone())),
+        lsp_manager: None,
     };
     refresh_active_task_panel(&mut app, &task_manager).await;
 


### PR DESCRIPTION
Closes #427.

Adds a `lsp` tool exposing 9 named operations backed by the existing LSP client: `hover`, `definition`, `references`, `rename`, `codeAction`, `completion`, `signatureHelp`, `documentSymbol`, `workspaceSymbol`.

Implemented using `deepseek exec --model deepseek-v4-flash`. 🐋