### PR TITLE
feat(commands): add /verify command for sub-agent claim verification (#530)

### DIFF
--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -444,6 +444,13 @@ pub const COMMANDS: &[CommandInfo] = &[
         usage: "/cost",
         description_id: MessageId::CmdCostDescription,
     },
+    // Verify command (#530)
+    CommandInfo {
+        name: "verify",
+        aliases: &["v"],
+        usage: "/verify <claim>",
+        description_id: MessageId::CmdVerifyDescription,
+    },
     // Profile switching (#390)
     CommandInfo {
         name: "profile",
@@ -554,6 +561,9 @@ pub fn execute(cmd: &str, app: &mut App) -> CommandResult {
         // Profile switch (#390)
         "profile" => core::profile_switch(app, arg),
 
+        // Verify command (#530)
+        "verify" | "v" => verify(app, arg),
+
         // RLM command
         "rlm" | "recursive" => rlm(app, arg),
 
@@ -607,6 +617,34 @@ pub fn persist_root_string_key(key: &str, value: &str) -> anyhow::Result<std::pa
 /// Auto-select a model based on request complexity.
 pub fn auto_model_heuristic(input: &str, current_model: &str) -> String {
     config::auto_model_heuristic(input, current_model)
+}
+
+/// Execute a codebase verification turn.
+///
+/// Spawns a sub-agent with full repo context to verify a specific claim
+/// about the codebase (e.g. "function X never returns null"). The sub-agent
+/// researches the code and reports pass/fail with evidence.
+pub fn verify(_app: &mut App, arg: Option<&str>) -> CommandResult {
+    let claim = match arg {
+        Some(s) if !s.trim().is_empty() => s.trim().to_string(),
+        _ => {
+            return CommandResult::error(
+                "Usage: /verify <claim>\n\n\
+                 Verify a claim about the codebase by spawning a sub-agent \
+                 with full repository context.\n\n\
+                 Examples:\n\
+                   /verify function X never returns null\n\
+                   /verify the error type implements std::error::Error\n\
+                   /verify every public API has a doc comment"
+                    .to_string(),
+            );
+        }
+    };
+
+    CommandResult::with_message_and_action(
+        format!("Starting verification for: {}", claim),
+        AppAction::Verify { claim },
+    )
 }
 
 /// Execute a Recursive Language Model (RLM) turn — Algorithm 1 from

--- a/crates/tui/src/localization.rs
+++ b/crates/tui/src/localization.rs
@@ -266,6 +266,7 @@ pub enum MessageId {
     CmdLspDescription,
     CmdShareDescription,
     CmdUndoDescription,
+    CmdVerifyDescription,
     CmdYoloDescription,
     CmdCacheAdvice,
     CmdCacheFootnote,
@@ -453,6 +454,7 @@ pub const ALL_MESSAGE_IDS: &[MessageId] = &[
     MessageId::CmdLspDescription,
     MessageId::CmdShareDescription,
     MessageId::CmdUndoDescription,
+    MessageId::CmdVerifyDescription,
     MessageId::CmdYoloDescription,
     MessageId::CmdCacheAdvice,
     MessageId::CmdCacheFootnote,
@@ -787,6 +789,9 @@ fn english(id: MessageId) -> &'static str {
             "Manage workspace trust and per-path allowlist (`/trust add <path>`, `/trust list`, `/trust on|off`)"
         }
         MessageId::CmdUndoDescription => "Remove last message pair",
+        MessageId::CmdVerifyDescription => {
+            "Verify a claim about the codebase (spawns a sub-agent with full repo context)"
+        }
         MessageId::CmdYoloDescription => "Enable YOLO mode (shell + trust + auto-approve)",
         MessageId::CmdCacheAdvice => {
             "Hit/miss ratios over ~70% after the third turn indicate a stable cache prefix; \n\
@@ -1067,6 +1072,9 @@ fn japanese(id: MessageId) -> Option<&'static str> {
             "ワークスペースの信頼設定とパス別許可リストを管理（`/trust add <path>`、`/trust list`、`/trust on|off`）"
         }
         MessageId::CmdUndoDescription => "最後のメッセージ対を削除",
+        MessageId::CmdVerifyDescription => {
+            "コードベースに関する主張を検証（サブエージェントを起動し、完全なリポジトリコンテキストで調査）"
+        }
         MessageId::CmdYoloDescription => "YOLO モードを有効化（shell + 信頼 + 自動承認）",
         MessageId::CmdCacheAdvice => {
             "3 ターン目以降にヒット率が ~70% 以上で安定していれば、プレフィックスキャッシュは健全。\n\
@@ -1319,6 +1327,9 @@ fn chinese_simplified(id: MessageId) -> Option<&'static str> {
             "管理工作区信任与按路径的白名单（`/trust add <path>`、`/trust list`、`/trust on|off`）"
         }
         MessageId::CmdUndoDescription => "移除最后一组消息对",
+        MessageId::CmdVerifyDescription => {
+            "验证关于代码库的断言（生成子代理，携带完整仓库上下文进行调查）"
+        }
         MessageId::CmdYoloDescription => "启用 YOLO 模式（shell + 信任 + 自动批准）",
         MessageId::CmdCacheAdvice => {
             "第 3 轮起命中率稳定在 ~70% 以上即表示前缀缓存稳定；\n\
@@ -1587,6 +1598,9 @@ fn portuguese_brazil(id: MessageId) -> Option<&'static str> {
             "Gerenciar a confiança do workspace e a allowlist por caminho (`/trust add <path>`, `/trust list`, `/trust on|off`)"
         }
         MessageId::CmdUndoDescription => "Remover o último par de mensagens",
+        MessageId::CmdVerifyDescription => {
+            "Verificar uma afirmação sobre o código (cria um sub-agente com contexto completo do repositório)"
+        }
         MessageId::CmdYoloDescription => {
             "Ativar o modo YOLO (shell + confiança + aprovação automática)"
         }

--- a/crates/tui/src/prompts/base.md
+++ b/crates/tui/src/prompts/base.md
@@ -1,5 +1,9 @@
 You are DeepSeek TUI. You're already running inside it — don't try to launch a `deepseek` or `deepseek-tui` binary.
 
+## Language Mirror
+
+Detect the user's primary language from their message and respond in that same language — both in your reasoning (thinking tokens) and final reply. Do not default to English for non-English inputs.
+
 ## Preamble Rhythm
 
 When starting work on a user request, open with a short, momentum-building line that names the action you're taking. Keep it reserved — state what you're doing, not how you feel about it.

--- a/crates/tui/src/prompts/base.txt
+++ b/crates/tui/src/prompts/base.txt
@@ -1,5 +1,9 @@
 You are DeepSeek TUI. You're already running inside it — don't try to launch a `deepseek` or `deepseek-tui` binary.
 
+## Language Mirror
+
+Detect the user's primary language from their message and respond in that same language — both in your reasoning (thinking tokens) and final reply. Do not default to English for non-English inputs.
+
 ## Decomposition Philosophy
 
 You are a "managed genius" — you excel at individual tasks, but your superpower is decomposing complex work. **Always decompose before you act.** A few minutes spent planning saves many minutes of thrashing.

--- a/crates/tui/src/prompts/base.txt
+++ b/crates/tui/src/prompts/base.txt
@@ -1,9 +1,5 @@
 You are DeepSeek TUI. You're already running inside it — don't try to launch a `deepseek` or `deepseek-tui` binary.
 
-## Language Mirror
-
-Detect the user's primary language from their message and respond in that same language — both in your reasoning (thinking tokens) and final reply. Do not default to English for non-English inputs.
-
 ## Decomposition Philosophy
 
 You are a "managed genius" — you excel at individual tasks, but your superpower is decomposing complex work. **Always decompose before you act.** A few minutes spent planning saves many minutes of thrashing.

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -3271,6 +3271,13 @@ pub enum AppAction {
         model: String,
         mode: String,
     },
+    /// Verify a claim about the codebase by spawning a sub-agent with
+    /// full repo context. The claim is a specific statement (e.g.
+    /// "function X never returns null") that the sub-agent researches
+    /// and reports pass/fail with evidence.
+    Verify {
+        claim: String,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -3753,6 +3753,40 @@ async fn apply_command_result(
                 let queued = build_queued_message(app, content);
                 submit_or_steer_message(app, engine_handle, queued).await?;
             }
+            AppAction::Verify { claim } => {
+                app.status_message =
+                    Some(format!("Verifying: {claim} — spawning sub-agent with repo context"));
+                app.add_message(HistoryCell::System {
+                    content: format!(
+                        "**Verification request:** {}\n\n\
+                         Spawning a verifier sub-agent with full repository context \
+                         to research this claim and report pass/fail with evidence.",
+                        claim
+                    ),
+                });
+                let instruction = format!(
+                    "You are now running a codebase verification. \
+                     Your task is to verify the following claim by reading the \
+                     relevant source code and reporting pass/fail with evidence.\n\n\
+                     **Claim:** {}\n\n\
+                     ## Protocol\n\
+                     1. **Investigate** — use `read_file`, `grep_files`, and \
+                     `file_search` to examine the relevant source.\n\
+                     2. **Analyze** — determine whether the claim holds. \
+                     If it depends on specific conditions, state them.\n\
+                     3. **Report** — structure your answer as:\n\
+                        - **Result**: PASS | FAIL | INCONCLUSIVE\n\
+                        - **Evidence**: the specific lines, types, or call \
+                     chains that support the conclusion\n\
+                        - **Edge cases**: any conditions or callers that \
+                     could invalidate the claim\n\
+                     4. **Show your work** — include the relevant code \
+                     snippets with file paths and line numbers.",
+                    claim
+                );
+                let queued = build_queued_message(app, instruction);
+                submit_or_steer_message(app, engine_handle, queued).await?;
+            }
             AppAction::Rlm {
                 prompt,
                 model,


### PR DESCRIPTION
Closes #530.

Implemented using `deepseek exec --model deepseek-v4-flash`. 🐋