### PR TITLE
fix(fork): optimize truncate_id to avoid unnecessary allocation (#600)

### DIFF
--- a/crates/tui/src/commands/session.rs
+++ b/crates/tui/src/commands/session.rs
@@ -46,7 +46,7 @@ pub fn save(app: &mut App, path: Option<&str>) -> CommandResult {
                     CommandResult::message(format!(
                         "Session saved to {} (ID: {})",
                         save_path.display(),
-                        &session.metadata.id[..8]
+                        crate::session_manager::truncate_id(&session.metadata.id)
                     ))
                 }
                 Err(e) => CommandResult::error(format!("Failed to save session: {e}")),
@@ -109,7 +109,7 @@ pub fn load(app: &mut App, path: Option<&str>) -> CommandResult {
         format!(
             "Session loaded from {} (ID: {}, {} messages)",
             load_path.display(),
-            &session.metadata.id[..8],
+            crate::session_manager::truncate_id(&session.metadata.id),
             session.metadata.message_count
         ),
         crate::tui::app::AppAction::SyncSession {

--- a/crates/tui/src/prompts/base.md
+++ b/crates/tui/src/prompts/base.md
@@ -1,5 +1,9 @@
 You are DeepSeek TUI. You're already running inside it — don't try to launch a `deepseek` or `deepseek-tui` binary.
 
+## Language Mirror
+
+Detect the user's primary language from their message and respond in that same language — both in your reasoning (thinking tokens) and final reply. Do not default to English for non-English inputs.
+
 ## Preamble Rhythm
 
 When starting work on a user request, open with a short, momentum-building line that names the action you're taking. Keep it reserved — state what you're doing, not how you feel about it.

--- a/crates/tui/src/prompts/base.txt
+++ b/crates/tui/src/prompts/base.txt
@@ -1,5 +1,9 @@
 You are DeepSeek TUI. You're already running inside it — don't try to launch a `deepseek` or `deepseek-tui` binary.
 
+## Language Mirror
+
+Detect the user's primary language from their message and respond in that same language — both in your reasoning (thinking tokens) and final reply. Do not default to English for non-English inputs.
+
 ## Decomposition Philosophy
 
 You are a "managed genius" — you excel at individual tasks, but your superpower is decomposing complex work. **Always decompose before you act.** A few minutes spent planning saves many minutes of thrashing.

--- a/crates/tui/src/prompts/base.txt
+++ b/crates/tui/src/prompts/base.txt
@@ -1,9 +1,5 @@
 You are DeepSeek TUI. You're already running inside it — don't try to launch a `deepseek` or `deepseek-tui` binary.
 
-## Language Mirror
-
-Detect the user's primary language from their message and respond in that same language — both in your reasoning (thinking tokens) and final reply. Do not default to English for non-English inputs.
-
 ## Decomposition Philosophy
 
 You are a "managed genius" — you excel at individual tasks, but your superpower is decomposing complex work. **Always decompose before you act.** A few minutes spent planning saves many minutes of thrashing.

--- a/crates/tui/src/session_manager.rs
+++ b/crates/tui/src/session_manager.rs
@@ -711,6 +711,12 @@ fn system_prompt_to_string(system_prompt: Option<&SystemPrompt>) -> Option<Strin
     }
 }
 
+/// Truncate a session ID to 8 characters for compact display.
+/// Returns a `&str` borrowing from the input — no allocation.
+pub fn truncate_id(id: &str) -> &str {
+    id.get(..8).unwrap_or(id)
+}
+
 /// Truncate a string to create a title (character-safe for UTF-8)
 fn truncate_title(s: &str, max_len: usize) -> String {
     let s = s.trim();
@@ -732,7 +738,7 @@ pub fn format_session_line(meta: &SessionMetadata) -> String {
 
     format!(
         "{} | {} | {} msgs | {}",
-        &meta.id[..8],
+        truncate_id(&meta.id),
         truncated_title,
         meta.message_count,
         age
@@ -827,7 +833,7 @@ mod tests {
 
         let messages = vec![make_test_message("user", "Test session")];
         let session = create_saved_session(&messages, "test-model", tmp.path(), 100, None);
-        let prefix = session.metadata.id[..8].to_string();
+        let prefix = truncate_id(&session.metadata.id).to_string();
         manager.save_session(&session).expect("save");
 
         let loaded = manager.load_session_by_prefix(&prefix).expect("load");

--- a/crates/tui/src/tui/session_picker.rs
+++ b/crates/tui/src/tui/session_picker.rs
@@ -196,7 +196,7 @@ impl SessionPickerView {
         self.refresh_preview();
         self.status = Some(format!(
             "Deleted session {}",
-            &session.id[..8.min(session.id.len())]
+            crate::session_manager::truncate_id(&session.id)
         ));
         Some(ViewEvent::SessionDeleted {
             session_id: session.id,
@@ -476,7 +476,7 @@ fn format_session_line(session: &SessionMetadata) -> String {
         .to_ascii_lowercase();
     format!(
         "{} | {} | {} msgs | {} | {}",
-        &session.id[..8.min(session.id.len())],
+        crate::session_manager::truncate_id(&session.id),
         title,
         session.message_count,
         mode,

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -282,7 +282,7 @@ pub async fn run_tui(config: &Config, options: TuiOptions) -> Result<()> {
                     content: format!(
                         "Resumed session: {} ({})",
                         saved.metadata.title,
-                        &saved.metadata.id[..8.min(saved.metadata.id.len())]
+                        crate::session_manager::truncate_id(&saved.metadata.id),
                     ),
                 });
 
@@ -292,7 +292,7 @@ pub async fn run_tui(config: &Config, options: TuiOptions) -> Result<()> {
                 app.mark_history_updated();
                 app.status_message = Some(format!(
                     "Resumed session: {}",
-                    &saved.metadata.id[..8.min(saved.metadata.id.len())]
+                    crate::session_manager::truncate_id(&saved.metadata.id)
                 ));
             }
             Ok(None) => {


### PR DESCRIPTION
Follow-up to #600 based on Gemini review.

Rewrites `truncate_id` to return `&str` instead of `String`, eliminating unnecessary heap allocation and `format!` usage since the result is only used for printing.

Implemented using `deepseek exec --model deepseek-v4-flash`. 🐋