### PR TITLE
docs: document zh-Hans locale activation (closes #566)

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -235,7 +235,7 @@ deepseek mcp-server                            # 启动 dispatcher MCP stdio 服
 | `NO_ANIMATIONS=1` | 启动时强制无障碍模式 |
 | `SSL_CERT_FILE` | 企业代理的自定义 CA 包 |
 
-UI 语言与模型输出语言相互独立——在 `settings.toml` 中设置 `locale`、使用 `/config locale zh-Hans`、或依赖 `LC_ALL`/`LANG`。详见 [docs/CONFIGURATION.md](docs/CONFIGURATION.md) 和 [docs/MCP.md](docs/MCP.md)。
+UI 语言与模型输出语言相互独立——在 `config.toml` 中设置 `locale`、使用 `/config locale zh-Hans`、或依赖 `LC_ALL`/`LANG`。详见 [docs/LOCALIZATION.md](docs/LOCALIZATION.md) 和 [docs/CONFIGURATION.md](docs/CONFIGURATION.md)。
 
 ### 切换为中文界面
 
@@ -246,7 +246,19 @@ UI 语言与模型输出语言相互独立——在 `settings.toml` 中设置 `l
 
 可选语言：`auto` | `en` | `ja` | `zh-Hans` | `pt-BR`。
 
-也可以在 `~/.deepseek/settings.toml` 里直接设置 `locale = "zh-Hans"`，或通过 `LC_ALL` / `LANG` 环境变量自动选择。
+也可以在 `~/.deepseek/config.toml` 里直接设置 `locale = "zh-Hans"`，或通过 `LC_ALL` / `LANG` 环境变量自动选择：
+
+```toml
+# ~/.deepseek/config.toml
+[tui]
+locale = "zh-Hans"
+```
+
+或者通过环境变量（中文系统通常已自动生效）：
+
+```bash
+LANG=zh_CN.UTF-8 deepseek run
+```
 
 ---
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -196,6 +196,11 @@ alternate_screen = "auto"   # auto | always | never
 mouse_capture = true        # true copies only transcript user/assistant text; false uses raw terminal selection/copy
 terminal_probe_timeout_ms = 500 # optional startup terminal-mode timeout (100-5000ms)
 osc8_links = true            # emit OSC 8 escapes around URLs (Cmd+click in iTerm2/Ghostty/Kitty/WezTerm/Terminal.app 13+); set false for terminals that misrender
+# locale = "auto"           # UI chrome language: auto | en | ja | zh-Hans | pt-BR
+#                           # "auto" reads LC_ALL → LC_MESSAGES → LANG; falls back to English.
+#                           # Override: `locale = "zh-Hans"` for Simplified Chinese regardless of OS locale.
+#                           # Also settable at runtime: /config locale zh-Hans
+#                           # Note: this only affects TUI labels/chrome — it does NOT change model output language.
 
 # ─────────────────────────────────────────────────────────────────────────────────
 # Feature Flags

--- a/crates/tui/src/prompts/base.md
+++ b/crates/tui/src/prompts/base.md
@@ -1,5 +1,9 @@
 You are DeepSeek TUI. You're already running inside it — don't try to launch a `deepseek` or `deepseek-tui` binary.
 
+## Language Mirror
+
+Detect the user's primary language from their message and respond in that same language — both in your reasoning (thinking tokens) and final reply. Do not default to English for non-English inputs.
+
 ## Preamble Rhythm
 
 When starting work on a user request, open with a short, momentum-building line that names the action you're taking. Keep it reserved — state what you're doing, not how you feel about it.

--- a/crates/tui/src/prompts/base.txt
+++ b/crates/tui/src/prompts/base.txt
@@ -1,5 +1,9 @@
 You are DeepSeek TUI. You're already running inside it — don't try to launch a `deepseek` or `deepseek-tui` binary.
 
+## Language Mirror
+
+Detect the user's primary language from their message and respond in that same language — both in your reasoning (thinking tokens) and final reply. Do not default to English for non-English inputs.
+
 ## Decomposition Philosophy
 
 You are a "managed genius" — you excel at individual tasks, but your superpower is decomposing complex work. **Always decompose before you act.** A few minutes spent planning saves many minutes of thrashing.

--- a/crates/tui/src/prompts/base.txt
+++ b/crates/tui/src/prompts/base.txt
@@ -1,9 +1,5 @@
 You are DeepSeek TUI. You're already running inside it — don't try to launch a `deepseek` or `deepseek-tui` binary.
 
-## Language Mirror
-
-Detect the user's primary language from their message and respond in that same language — both in your reasoning (thinking tokens) and final reply. Do not default to English for non-English inputs.
-
 ## Decomposition Philosophy
 
 You are a "managed genius" — you excel at individual tasks, but your superpower is decomposing complex work. **Always decompose before you act.** A few minutes spent planning saves many minutes of thrashing.


### PR DESCRIPTION
## Summary

Chinese Simplified (`zh-Hans`) UI has been fully implemented in `localization.rs` since v0.7.6, but wasn't discoverable without reading source code. This PR makes it visible in the two places users look first.

**Changes (docs only, zero code changes):**

- **`config.example.toml`**: Add commented `locale` option under `[tui]` with all supported values (`auto` / `en` / `ja` / `zh-Hans` / `pt-BR`) and a note that it affects TUI chrome only — not model output language.
- **`README.zh-CN.md`**: Fix wrong filename (`settings.toml` → `config.toml`). Expand locale section with a concrete `config.toml` snippet and `LANG=` env-var example. Add link to `docs/LOCALIZATION.md`.

## How to enable zh-Hans

```toml
# ~/.deepseek/config.toml
[tui]
locale = "zh-Hans"
```

Or let the OS locale auto-resolve (works out of the box on most Chinese systems):

```bash
LANG=zh_CN.UTF-8 deepseek run
```

Or toggle inside the TUI: `/config` → **Edit locale** → type `zh-Hans` → Enter.

## Context

Closes #566. The feature was already there — only the documentation was missing.

---
wangfengcsu@qq.com