### PR TITLE
fix(compaction): default off + raise unknown-model floor to 80% (#664, v0.8.11)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ apps/
 # Local-only Claude / ralph notes
 .claude/*.local.md
 .claude/*.local.json
+
+# Maintainer-internal design notes (trade-secret material, never published)
+.private/

--- a/crates/tui/src/models.rs
+++ b/crates/tui/src/models.rs
@@ -4,7 +4,14 @@ use serde::{Deserialize, Serialize};
 
 pub const DEFAULT_CONTEXT_WINDOW_TOKENS: u32 = 128_000;
 pub const DEEPSEEK_V4_CONTEXT_WINDOW_TOKENS: u32 = 1_000_000;
-pub const DEFAULT_COMPACTION_TOKEN_THRESHOLD: usize = 50_000;
+/// Last-resort compaction trigger when [`context_window_for_model`] returns
+/// `None` (an unrecognised model id). v0.8.11 raised this from `50_000` to
+/// `102_400` (80% of [`DEFAULT_CONTEXT_WINDOW_TOKENS`]) so unknown models
+/// inherit the same late-trigger discipline as V4 instead of paying the
+/// prefix-cache hit at 5% of the V4 window. Known DeepSeek / Claude models
+/// resolve to their own scaled value via [`compaction_threshold_for_model`]
+/// (#664).
+pub const DEFAULT_COMPACTION_TOKEN_THRESHOLD: usize = 102_400;
 pub const DEFAULT_COMPACTION_MESSAGE_THRESHOLD: usize = 50;
 const COMPACTION_THRESHOLD_PERCENT: u32 = 80;
 const COMPACTION_MESSAGE_DIVISOR: u32 = 500;
@@ -450,7 +457,13 @@ mod tests {
             compaction_threshold_for_model("deepseek-v3.2-128k"),
             102_400
         );
-        assert_eq!(compaction_threshold_for_model("unknown-model"), 50_000);
+        // v0.8.11 (#664): unknown-model fallback also resolves to 80% of
+        // `DEFAULT_CONTEXT_WINDOW_TOKENS` (128k) — same late-trigger
+        // discipline as the V4 path. Was `50_000` pre-v0.8.11; that
+        // hardcoded value compacted at ~5% of a 1M window when the model
+        // detection silently fell through, which is exactly the
+        // prefix-cache-burning behaviour we're getting away from.
+        assert_eq!(compaction_threshold_for_model("unknown-model"), 102_400);
     }
 
     #[test]
@@ -495,9 +508,13 @@ mod tests {
             compaction_threshold_for_model_and_effort("deepseek-v3.2-128k", Some("max")),
             102_400
         );
+        // v0.8.11 (#664): unknown-model fallback also lands on the
+        // 80%-of-128K floor instead of the legacy hardcoded 50K, so
+        // model-detection-fall-through doesn't quietly burn V4 prefix
+        // cache at 5%-of-window.
         assert_eq!(
             compaction_threshold_for_model_and_effort("unknown-model", Some("max")),
-            50_000
+            102_400
         );
     }
 

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -59,7 +59,16 @@ pub struct Settings {
 impl Default for Settings {
     fn default() -> Self {
         Self {
-            auto_compact: true,
+            // v0.8.11: default flipped to `false` to stop the engine from
+            // routinely rewriting the prompt prefix, which breaks DeepSeek
+            // V4's prefix cache (~90% discount on cached prefix tokens) and
+            // ends up costing more than the compaction itself saves. With
+            // V4's 1M-token window the user has plenty of headroom to run
+            // long sessions without auto-trimming, and the explicit
+            // `/compact` slash command + `auto_compact = on` opt-in remain
+            // available for users / agents that decide compaction is
+            // worth the cache hit on their workload (#664).
+            auto_compact: false,
             calm_mode: false,
             low_motion: false,
             fancy_animations: false,
@@ -451,11 +460,15 @@ mod tests {
     use super::*;
 
     #[test]
-    fn default_settings_enable_auto_compact_for_session_survivability() {
+    fn default_settings_disable_auto_compact_to_protect_v4_prefix_cache() {
         let settings = Settings::default();
-        // #402 P0: auto-compaction is on by default so long-running
-        // sessions stay within the model's context budget.
-        assert!(settings.auto_compact);
+        // v0.8.11: default is `false` to stop the engine from routinely
+        // rewriting the prompt prefix, which breaks V4's prefix-cache
+        // discount. The explicit `/compact` command and the
+        // `auto_compact = on` opt-in stay available; the default is
+        // flipped so the cache-friendly path is the one users get
+        // without configuring anything (#664).
+        assert!(!settings.auto_compact);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Stops the engine from routinely rewriting the prompt prefix, which burns DeepSeek V4's prefix-cache discount and is the dominant cost-spike vector in long sessions. Two coordinated changes for v0.8.11.

## Change 1 — `auto_compact` default flips to `false`

`crates/tui/src/settings.rs`. Pre-v0.8.11 default was `true` (#402 P0 "session survivability"); under V4 the same default behaviour costs ~10× per post-compaction turn because the rewritten prefix invalidates the cache. With V4's 1M-token window the user has enough headroom to run long sessions without auto-trimming, and the explicit `/compact` command + `auto_compact = on` opt-in remain available for workloads that prefer compaction over cache stability.

## Change 2 — `DEFAULT_COMPACTION_TOKEN_THRESHOLD` raised from `50_000` to `102_400`

`crates/tui/src/models.rs`. This is the last-resort threshold when `context_window_for_model` returns `None` (unrecognised model id). The legacy `50_000` value was set when 128K was the headline window — under V4 it works out to compacting at ~5% of the actual context budget when model detection falls through, which is exactly the prefix-cache-burning behaviour we're getting away from. The new floor is 80% of `DEFAULT_CONTEXT_WINDOW_TOKENS = 128_000`, matching the discipline applied to all known model paths.

## What this is NOT

- Not the agent-aware-handoff pattern in #664 (that's a much larger design surface — out of v0.8.11 scope; this PR closes the immediate cache cost while #664 stays open as the long-term fix).
- Not removing compaction entirely. The `/compact` slash command, the `auto_compact = on` opt-in, and the runtime-thread / capacity-flow / cycle-manager auto-compaction paths all remain functional. We're just changing the default for the in-TUI session.

## Test plan

- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy -p deepseek-tui --bin deepseek-tui --all-features --locked -- -D warnings` clean.
- [x] `cargo test -p deepseek-tui --bin deepseek-tui --locked` → 2028 passed, 2 ignored.
- [x] Updated test names + inline comments explain the new defaults so a future maintainer doesn't accidentally restore the old values without reading the rationale.
- [ ] Manual: launch a long session on V4, confirm no auto-compaction fires until the user invokes `/compact` explicitly. (Verify `RUST_LOG=compaction=debug` shows zero `Auto-compacting context...` events on default config.)
- [ ] Manual: set `auto_compact = on` in `~/.deepseek/settings.toml`, confirm the old auto-trigger behaviour still works for users who opt in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)