### PR TITLE
diag(tui): trace view_stack push/pop for post-mortem black-screen repro

### DIFF
--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -235,18 +235,26 @@ impl ViewStack {
     }
 
     pub fn push<V: ModalView + 'static>(&mut self, view: V) {
+        let kind = view.kind();
         self.views.push(Box::new(view));
+        tracing::debug!(target: "deepseek_tui::view_stack", action = "push", kind = ?kind, depth = self.views.len(), "view pushed");
     }
 
     /// Push an already-boxed view back onto the stack. Used by call sites
     /// that pop a view, mutate it externally, and need to restore it without
     /// the generic `push` re-boxing dance.
     pub fn push_boxed(&mut self, view: Box<dyn ModalView>) {
+        let kind = view.kind();
         self.views.push(view);
+        tracing::debug!(target: "deepseek_tui::view_stack", action = "push_boxed", kind = ?kind, depth = self.views.len(), "view pushed");
     }
 
     pub fn pop(&mut self) -> Option<Box<dyn ModalView>> {
-        self.views.pop()
+        let popped = self.views.pop();
+        if let Some(view) = popped.as_ref() {
+            tracing::debug!(target: "deepseek_tui::view_stack", action = "pop", kind = ?view.kind(), depth = self.views.len(), "view popped");
+        }
+        popped
     }
 
     pub fn render(&self, area: Rect, buf: &mut Buffer) {
@@ -301,14 +309,18 @@ impl ViewStack {
         match action {
             ViewAction::None => {}
             ViewAction::Close => {
-                self.views.pop();
+                if let Some(view) = self.views.pop() {
+                    tracing::debug!(target: "deepseek_tui::view_stack", action = "close", kind = ?view.kind(), depth = self.views.len(), "view closed via action");
+                }
             }
             ViewAction::Emit(event) => {
                 events.push(event);
             }
             ViewAction::EmitAndClose(event) => {
                 events.push(event);
-                self.views.pop();
+                if let Some(view) = self.views.pop() {
+                    tracing::debug!(target: "deepseek_tui::view_stack", action = "emit_and_close", kind = ?view.kind(), depth = self.views.len(), "view closed via action");
+                }
             }
         }
         events


### PR DESCRIPTION
## Summary

- Maintainer-reported sub-agent → black-transcript symptom (after `agent_spawn` in YOLO, transcript area renders solid black AND scroll keys go dead while footer + sidebar still render fine).
- Hypothesis from session-3 handoff: a `View` is on the stack that returns empty layout AND intercepts key events at the top level. Unconfirmed without repro.
- This PR ships **diagnostic tracing only** — no behavior change. Adds `tracing::debug!` to every `ViewStack::push` / `push_boxed` / `pop` and to the implicit pops in `apply_action` (`Close`, `EmitAndClose`). Each line carries the `ModalKind` and post-action depth.

## Why now

The handoff explicitly listed *"add `tracing::debug!` on every `view_stack.push`/`pop` so a post-mortem `RUST_LOG=deepseek_tui=debug` log shows which view stayed pushed"* as the first-look diagnostic step. Shipping the diagnostic in v0.8.11 means the next time the symptom hits, the maintainer can capture the bad push from a single `RUST_LOG=deepseek_tui::view_stack=debug` run and we don't need another back-and-forth on the channel.

## How to use

```
RUST_LOG=deepseek_tui::view_stack=debug deepseek
```

…then reproduce the black-screen scenario. The log will show the push/pop sequence ending in the stuck view.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — clean
- [x] `cargo test --workspace --all-features --locked` — 2033 passed in TUI bin (2 ignored), all other crates green
- [x] Parity gates: `cargo test -p deepseek-tui-core --test snapshot --locked` ✓ / `cargo test -p deepseek-protocol --test parity_protocol --locked` ✓ / `cargo test -p deepseek-state --test parity_state --locked` ✓
- [x] `git diff --exit-code -- Cargo.lock` — clean