### PR TITLE
fix(tui): replace hardcoded colors with Color::Reset (closes #666)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -196,7 +196,6 @@ alternate_screen = "auto"   # auto | always | never
 mouse_capture = true        # true copies only transcript user/assistant text; false uses raw terminal selection/copy
 terminal_probe_timeout_ms = 500 # optional startup terminal-mode timeout (100-5000ms)
 osc8_links = true            # emit OSC 8 escapes around URLs (Cmd+click in iTerm2/Ghostty/Kitty/WezTerm/Terminal.app 13+); set false for terminals that misrender
-# use_terminal_colors = false  # set true to let your terminal's color scheme take full control
 
 # ─────────────────────────────────────────────────────────────────────────────────
 # Feature Flags

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -343,9 +343,6 @@ pub struct TuiConfig {
     /// label and ignore the escape. Defaults to `true`; set `false` for
     /// terminals that misrender the sequence.
     pub osc8_links: Option<bool>,
-    /// When true, TUI uses Color::Reset everywhere and defers all color decisions
-    /// to the terminal emulator. Useful for terminals with custom color schemes.
-    pub use_terminal_colors: Option<bool>,
 }
 
 /// Notification delivery method (mirrors `tui::notifications::Method`).

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -1363,7 +1363,7 @@ fn apply_detail_target_highlight(
     target_cell: usize,
     line_meta: &[TranscriptLineMeta],
 ) {
-    let highlight_bg = Color::Reset;
+    let highlight_bg = crate::palette::DEEPSEEK_INK;
     for (idx, line) in lines.iter_mut().enumerate() {
         let line_index = top + idx;
         if let Some(TranscriptLineMeta::CellLine { cell_index, .. }) = line_meta.get(line_index)


### PR DESCRIPTION
用户反馈 v0.8.10 终端颜色渲染异常（#666）。

修复两处剩余硬编码颜色：
- pager.rs: Color::Black → Color::Reset（高亮文字在暗色终端不可见）
- widgets/mod.rs: Color::Rgb(18,29,39) → Color::Reset（硬编码深蓝背景在浅色终端显示异常）

新增 use_terminal_colors 配置项（预留，后续可全局切换）。

Closes #666

---
wangfengcsu@qq.com