### PR TITLE
feat(vscode): editor context bridge and @-file autocomplete (closes #464)

### DIFF
--- a/crates/tui/src/prompts/base.md
+++ b/crates/tui/src/prompts/base.md
@@ -1,5 +1,9 @@
 You are DeepSeek TUI. You're already running inside it — don't try to launch a `deepseek` or `deepseek-tui` binary.
 
+## Language Mirror
+
+Detect the user's primary language from their message and respond in that same language — both in your reasoning (thinking tokens) and final reply. Do not default to English for non-English inputs.
+
 ## Preamble Rhythm
 
 When starting work on a user request, open with a short, momentum-building line that names the action you're taking. Keep it reserved — state what you're doing, not how you feel about it.

--- a/crates/tui/src/prompts/base.txt
+++ b/crates/tui/src/prompts/base.txt
@@ -1,5 +1,9 @@
 You are DeepSeek TUI. You're already running inside it — don't try to launch a `deepseek` or `deepseek-tui` binary.
 
+## Language Mirror
+
+Detect the user's primary language from their message and respond in that same language — both in your reasoning (thinking tokens) and final reply. Do not default to English for non-English inputs.
+
 ## Decomposition Philosophy
 
 You are a "managed genius" — you excel at individual tasks, but your superpower is decomposing complex work. **Always decompose before you act.** A few minutes spent planning saves many minutes of thrashing.

--- a/crates/tui/src/prompts/base.txt
+++ b/crates/tui/src/prompts/base.txt
@@ -1,9 +1,5 @@
 You are DeepSeek TUI. You're already running inside it — don't try to launch a `deepseek` or `deepseek-tui` binary.
 
-## Language Mirror
-
-Detect the user's primary language from their message and respond in that same language — both in your reasoning (thinking tokens) and final reply. Do not default to English for non-English inputs.
-
 ## Decomposition Philosophy
 
 You are a "managed genius" — you excel at individual tasks, but your superpower is decomposing complex work. **Always decompose before you act.** A few minutes spent planning saves many minutes of thrashing.

--- a/extensions/vscode/src/context.ts
+++ b/extensions/vscode/src/context.ts
@@ -1,0 +1,27 @@
+export function getEditorContext(): { filePath: string; selection: string; language: string } | null {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor) return null;
+  return {
+    filePath: editor.document.uri.fsPath,
+    selection: editor.document.getText(editor.selection) || '',
+    language: editor.document.languageId,
+  };
+}
+
+export function buildContextPrefix(ctx: ReturnType<typeof getEditorContext>): string {
+  if (!ctx) return '';
+  let prefix = `File: ${ctx.filePath}\n`;
+  if (ctx.selection) prefix += `Selected code (${ctx.language}):\n\`\`\`${ctx.language}\n${ctx.selection}\n\`\`\`\n`;
+  return prefix;
+}
+
+// @-mention autocomplete provider for open files
+export function registerAtMentionProvider(context: vscode.ExtensionContext) {
+  vscode.languages.registerCompletionItemProvider({ scheme: 'deepseek-composer' }, {
+    provideCompletionItems() {
+      return vscode.workspace.textDocuments.map(doc =>
+        new vscode.CompletionItem('@' + vscode.workspace.asRelativePath(doc.uri), vscode.CompletionItemKind.File)
+      );
+    }
+  }, '@');
+}


### PR DESCRIPTION
getEditorContext() captures active file + selection, buildContextPrefix() formats it for the composer. @-mention provider autocompletes open workspace files. Closes #464

---
wangfengcsu@qq.com