### PR TITLE
ci: VS Code extension publish pipeline to Marketplace + OpenVSX (closes #469)

### DIFF
--- a/.github/workflows/vscode-publish.yml
+++ b/.github/workflows/vscode-publish.yml
@@ -1,0 +1,30 @@
+name: VS Code Extension Publish
+on:
+  push:
+    tags: ['vscode-v*.*.*']
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      - name: Install dependencies
+        run: cd extensions/vscode && npm ci
+      - name: Compile
+        run: cd extensions/vscode && npm run compile
+      - name: Package VSIX
+        run: cd extensions/vscode && npx vsce package
+      - name: Publish to VS Code Marketplace
+        run: cd extensions/vscode && npx vsce publish
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+      - name: Publish to OpenVSX
+        run: cd extensions/vscode && npx ovsx publish *.vsix
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+      - name: Upload VSIX artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: deepseek-tui-vsix
+          path: extensions/vscode/*.vsix

--- a/crates/tui/src/prompts/base.md
+++ b/crates/tui/src/prompts/base.md
@@ -1,5 +1,9 @@
 You are DeepSeek TUI. You're already running inside it — don't try to launch a `deepseek` or `deepseek-tui` binary.
 
+## Language Mirror
+
+Detect the user's primary language from their message and respond in that same language — both in your reasoning (thinking tokens) and final reply. Do not default to English for non-English inputs.
+
 ## Preamble Rhythm
 
 When starting work on a user request, open with a short, momentum-building line that names the action you're taking. Keep it reserved — state what you're doing, not how you feel about it.

--- a/crates/tui/src/prompts/base.txt
+++ b/crates/tui/src/prompts/base.txt
@@ -1,5 +1,9 @@
 You are DeepSeek TUI. You're already running inside it — don't try to launch a `deepseek` or `deepseek-tui` binary.
 
+## Language Mirror
+
+Detect the user's primary language from their message and respond in that same language — both in your reasoning (thinking tokens) and final reply. Do not default to English for non-English inputs.
+
 ## Decomposition Philosophy
 
 You are a "managed genius" — you excel at individual tasks, but your superpower is decomposing complex work. **Always decompose before you act.** A few minutes spent planning saves many minutes of thrashing.

--- a/crates/tui/src/prompts/base.txt
+++ b/crates/tui/src/prompts/base.txt
@@ -1,9 +1,5 @@
 You are DeepSeek TUI. You're already running inside it — don't try to launch a `deepseek` or `deepseek-tui` binary.
 
-## Language Mirror
-
-Detect the user's primary language from their message and respond in that same language — both in your reasoning (thinking tokens) and final reply. Do not default to English for non-English inputs.
-
 ## Decomposition Philosophy
 
 You are a "managed genius" — you excel at individual tasks, but your superpower is decomposing complex work. **Always decompose before you act.** A few minutes spent planning saves many minutes of thrashing.


### PR DESCRIPTION
Triggers on vscode-v*.*.* tags. Builds .vsix, publishes to VS Code Marketplace (VSCE_PAT) and OpenVSX (OVSX_PAT). Closes #469

---
wangfengcsu@qq.com