### PR TITLE
chore(release): bump version to 0.8.11 + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   whose install through a CN npm mirror took 18 minutes — the bottleneck
   was the GitHub fetch, which CN npm mirrors do not proxy.
 
+### Docs
+- **README clarity pass** (#685) — title-cased section headings, an explicit
+  Node + npm prerequisites block before the `npm install -g` snippet, a
+  China-friendly `--registry=https://registry.npmmirror.com` install
+  variant, a DeepWiki badge for AI-assisted repo browsing, and a 🐳 mark
+  on the title. *Thanks to [@Agent-Skill-007](https://github.com/Agent-Skill-007)
+  for this PR.*
+
 ## [0.8.10] - 2026-05-04
 
 A patch release: hotfixes, small UX polish, and four whalescale-unblocking

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-agent"
-version = "0.8.10"
+version = "0.8.11"
 dependencies = [
  "deepseek-config",
  "serde",
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-app-server"
-version = "0.8.10"
+version = "0.8.11"
 dependencies = [
  "anyhow",
  "axum",
@@ -1110,7 +1110,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-config"
-version = "0.8.10"
+version = "0.8.11"
 dependencies = [
  "anyhow",
  "deepseek-secrets",
@@ -1122,7 +1122,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-core"
-version = "0.8.10"
+version = "0.8.11"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1140,7 +1140,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-execpolicy"
-version = "0.8.10"
+version = "0.8.11"
 dependencies = [
  "anyhow",
  "deepseek-protocol",
@@ -1149,7 +1149,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-hooks"
-version = "0.8.10"
+version = "0.8.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-mcp"
-version = "0.8.10"
+version = "0.8.11"
 dependencies = [
  "anyhow",
  "serde",
@@ -1172,7 +1172,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-protocol"
-version = "0.8.10"
+version = "0.8.11"
 dependencies = [
  "serde",
  "serde_json",
@@ -1180,7 +1180,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-secrets"
-version = "0.8.10"
+version = "0.8.11"
 dependencies = [
  "dirs",
  "keyring",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-state"
-version = "0.8.10"
+version = "0.8.11"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1205,7 +1205,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-tools"
-version = "0.8.10"
+version = "0.8.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1218,7 +1218,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-tui"
-version = "0.8.10"
+version = "0.8.11"
 dependencies = [
  "anyhow",
  "arboard",
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-tui-cli"
-version = "0.8.10"
+version = "0.8.11"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1301,7 +1301,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-tui-core"
-version = "0.8.10"
+version = "0.8.11"
 
 [[package]]
 name = "deranged"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = ["crates/cli", "crates/app-server", "crates/tui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.8.10"
+version = "0.8.11"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/Hmbown/DeepSeek-TUI"

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -7,5 +7,5 @@ repository.workspace = true
 description = "Model/provider registry and fallback strategy for DeepSeek workspace architecture"
 
 [dependencies]
-deepseek-config = { path = "../config", version = "0.8.10" }
+deepseek-config = { path = "../config", version = "0.8.11" }
 serde.workspace = true

--- a/crates/app-server/Cargo.toml
+++ b/crates/app-server/Cargo.toml
@@ -10,15 +10,15 @@ description = "Codex-style app-server transport for DeepSeek workspace architect
 anyhow.workspace = true
 axum.workspace = true
 clap.workspace = true
-deepseek-agent = { path = "../agent", version = "0.8.10" }
-deepseek-config = { path = "../config", version = "0.8.10" }
-deepseek-core = { path = "../core", version = "0.8.10" }
-deepseek-execpolicy = { path = "../execpolicy", version = "0.8.10" }
-deepseek-hooks = { path = "../hooks", version = "0.8.10" }
-deepseek-mcp = { path = "../mcp", version = "0.8.10" }
-deepseek-protocol = { path = "../protocol", version = "0.8.10" }
-deepseek-state = { path = "../state", version = "0.8.10" }
-deepseek-tools = { path = "../tools", version = "0.8.10" }
+deepseek-agent = { path = "../agent", version = "0.8.11" }
+deepseek-config = { path = "../config", version = "0.8.11" }
+deepseek-core = { path = "../core", version = "0.8.11" }
+deepseek-execpolicy = { path = "../execpolicy", version = "0.8.11" }
+deepseek-hooks = { path = "../hooks", version = "0.8.11" }
+deepseek-mcp = { path = "../mcp", version = "0.8.11" }
+deepseek-protocol = { path = "../protocol", version = "0.8.11" }
+deepseek-state = { path = "../state", version = "0.8.11" }
+deepseek-tools = { path = "../tools", version = "0.8.11" }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -14,13 +14,13 @@ path = "src/main.rs"
 anyhow.workspace = true
 clap.workspace = true
 clap_complete.workspace = true
-deepseek-agent = { path = "../agent", version = "0.8.10" }
-deepseek-app-server = { path = "../app-server", version = "0.8.10" }
-deepseek-config = { path = "../config", version = "0.8.10" }
-deepseek-execpolicy = { path = "../execpolicy", version = "0.8.10" }
-deepseek-mcp = { path = "../mcp", version = "0.8.10" }
-deepseek-secrets = { path = "../secrets", version = "0.8.10" }
-deepseek-state = { path = "../state", version = "0.8.10" }
+deepseek-agent = { path = "../agent", version = "0.8.11" }
+deepseek-app-server = { path = "../app-server", version = "0.8.11" }
+deepseek-config = { path = "../config", version = "0.8.11" }
+deepseek-execpolicy = { path = "../execpolicy", version = "0.8.11" }
+deepseek-mcp = { path = "../mcp", version = "0.8.11" }
+deepseek-secrets = { path = "../secrets", version = "0.8.11" }
+deepseek-state = { path = "../state", version = "0.8.11" }
 chrono.workspace = true
 dirs.workspace = true
 serde.workspace = true

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -8,7 +8,7 @@ description = "Config schema and precedence model for DeepSeek workspace archite
 
 [dependencies]
 anyhow.workspace = true
-deepseek-secrets = { path = "../secrets", version = "0.8.10" }
+deepseek-secrets = { path = "../secrets", version = "0.8.11" }
 dirs.workspace = true
 serde.workspace = true
 toml.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -9,13 +9,13 @@ description = "Core runtime boundaries for DeepSeek workspace architecture"
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true
-deepseek-agent = { path = "../agent", version = "0.8.10" }
-deepseek-config = { path = "../config", version = "0.8.10" }
-deepseek-execpolicy = { path = "../execpolicy", version = "0.8.10" }
-deepseek-hooks = { path = "../hooks", version = "0.8.10" }
-deepseek-mcp = { path = "../mcp", version = "0.8.10" }
-deepseek-protocol = { path = "../protocol", version = "0.8.10" }
-deepseek-state = { path = "../state", version = "0.8.10" }
-deepseek-tools = { path = "../tools", version = "0.8.10" }
+deepseek-agent = { path = "../agent", version = "0.8.11" }
+deepseek-config = { path = "../config", version = "0.8.11" }
+deepseek-execpolicy = { path = "../execpolicy", version = "0.8.11" }
+deepseek-hooks = { path = "../hooks", version = "0.8.11" }
+deepseek-mcp = { path = "../mcp", version = "0.8.11" }
+deepseek-protocol = { path = "../protocol", version = "0.8.11" }
+deepseek-state = { path = "../state", version = "0.8.11" }
+deepseek-tools = { path = "../tools", version = "0.8.11" }
 serde_json.workspace = true
 uuid.workspace = true

--- a/crates/execpolicy/Cargo.toml
+++ b/crates/execpolicy/Cargo.toml
@@ -8,5 +8,5 @@ description = "Execution policy and approval model parity for DeepSeek workspace
 
 [dependencies]
 anyhow.workspace = true
-deepseek-protocol = { path = "../protocol", version = "0.8.10" }
+deepseek-protocol = { path = "../protocol", version = "0.8.11" }
 serde.workspace = true

--- a/crates/hooks/Cargo.toml
+++ b/crates/hooks/Cargo.toml
@@ -10,7 +10,7 @@ description = "Hook dispatch and notifications parity for DeepSeek workspace arc
 anyhow.workspace = true
 async-trait.workspace = true
 chrono.workspace = true
-deepseek-protocol = { path = "../protocol", version = "0.8.10" }
+deepseek-protocol = { path = "../protocol", version = "0.8.11" }
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -9,7 +9,7 @@ description = "Tool invocation lifecycle, schema validation, and scheduler paral
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
-deepseek-protocol = { path = "../protocol", version = "0.8.10" }
+deepseek-protocol = { path = "../protocol", version = "0.8.11" }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -21,8 +21,8 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0.100"
 arboard = "3.4"
-deepseek-secrets = { path = "../secrets", version = "0.8.10" }
-deepseek-tools = { path = "../tools", version = "0.8.10" }
+deepseek-secrets = { path = "../secrets", version = "0.8.11" }
+deepseek-tools = { path = "../tools", version = "0.8.11" }
 schemaui = { version = "0.12.0", default-features = false, optional = true }
 async-stream = "0.3.6"
 async-trait = "0.1"

--- a/npm/deepseek-tui/package.json
+++ b/npm/deepseek-tui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-tui",
-  "version": "0.8.10",
-  "deepseekBinaryVersion": "0.8.10",
+  "version": "0.8.11",
+  "deepseekBinaryVersion": "0.8.11",
   "description": "Install and run deepseek and deepseek-tui binaries from GitHub release artifacts.",
   "author": "Hmbown",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Final step in the v0.8.11 patch release. Bumps workspace `Cargo.toml`, all 9 internal path-dep version pins, and `npm/deepseek-tui/package.json` to **0.8.11**. `Cargo.lock` regenerated alongside. New CHANGELOG section covers the merged PRs only.

## What landed in v0.8.11

| Area | PRs | Behavior |
|---|---|---|
| **Compaction defaults** | #664, #665 | Off by default; unknown-model floor 80% |
| **Windows BEL fallback** | #583, #591 | Default Off, not BEL |
| **API-key onboarding** | #593, #594 | Dual-write to keyring + config; `doctor` flags mismatches |
| **Language mirroring** | #588, #590 | Reasoning + reply mirror the user's language; thinking-mode `reasoning_content` anchor pinned |
| **Compaction telemetry** | #584, #592 | `RUST_LOG=deepseek_tui::compaction=debug` shows framing fork + cache-hit denominator |
| **`view_stack` tracing** | #670 | `RUST_LOG=deepseek_tui::view_stack=debug` shows push/pop kind + depth (diagnostic for rare sub-agent black-screen symptom) |
| **CN / IME regression tests** | #599 | Composer single-char IME + bracketed-paste CJK pinned |

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — clean
- [x] `cargo test --workspace --all-features --locked` — 2033 passed in TUI bin (2 ignored), all other crates green
- [x] Parity gates: `cargo test -p deepseek-tui-core --test snapshot --locked` ✓ / `cargo test -p deepseek-protocol --test parity_protocol --locked` ✓ / `cargo test -p deepseek-state --test parity_state --locked` ✓
- [x] `bash scripts/release/check-versions.sh` — `workspace=0.8.11, npm=0.8.11, lockfile in sync`
- [x] `git diff --exit-code -- Cargo.lock` — staged only as part of this PR (regenerated for the bump)

## Release pipeline reminder

* When this PR merges to `main`, `auto-tag.yml` will create the `v0.8.11` tag using `RELEASE_TAG_PAT` (assumed configured), which fires `release.yml` to build the matrix, draft the GitHub Release, and upload the eight signed binaries plus the SHA256 manifest. **Don't push the tag manually unless `auto-tag` falls back.**
* **The npm publish is manual** because the npm account requires 2FA OTP on every publish. After the GitHub Release goes live, run from a developer machine:

  ```
  cd npm/deepseek-tui
  npm publish --access public
  ```

  The `prepublishOnly` hook checks all eight binaries plus the checksum manifest are present on the GitHub Release before letting `npm publish` proceed, so don't try to publish before the GitHub Release is finalized.