### PR TITLE
fix(v0.8.11): release-day cluster — capacity off + scroll lock + YOLO no sandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.8.11] - Unreleased
+## [0.8.11] - 2026-05-05
 
 ### Changed
 - **Cache-maxing prompt path for DeepSeek V4** — the engine now skips

--- a/crates/tui/src/core/capacity.rs
+++ b/crates/tui/src/core/capacity.rs
@@ -28,16 +28,17 @@ impl Default for CapacityControllerConfig {
         model_priors.insert("deepseek_v4_flash".to_string(), 4.2);
 
         Self {
-            // ON BY DEFAULT since v0.8.6 (#402 P0 survivability). The
-            // capacity controller detects context pressure and triggers
-            // TargetedContextRefresh (compaction) before the model hits its
-            // window limit. Long-running sessions accumulate unbounded
-            // message history that silently crosses the token budget — by
-            // the time the error surfaces the conversation is already
-            // degraded. Running the controller by default catches this
-            // early. Users who prefer the previous behaviour can opt out
-            // via `capacity.enabled = false` in `~/.deepseek/config.toml`.
-            enabled: true,
+            // OFF BY DEFAULT since v0.8.11. The capacity controller's
+            // interventions (TargetedContextRefresh, VerifyAndReplan)
+            // silently rewrite or clear the session message log, which
+            // surprises the user and destroys V4's prefix cache. v0.8.11
+            // committed to "trust the model with the full 1M-token
+            // context, only compact on explicit user `/compact`."
+            // Auto-managing the prefix on the user's behalf works against
+            // that posture. Power users who want the controller can opt
+            // in via `capacity.enabled = true` in
+            // `~/.deepseek/config.toml`.
+            enabled: false,
             // Thresholds retained for the opt-in path; tuning notes live
             // in git history (#63 follow-up).
             low_risk_max: 0.50,
@@ -618,10 +619,12 @@ mod tests {
         assert_eq!(decide_policy(&cfg, &snap), GuardrailAction::VerifyAndReplan);
     }
 
+    /// v0.8.11 flipped the default to `enabled = false`. The controller's
+    /// observe / decide methods early-return when disabled — opt-in only.
     #[test]
-    fn default_controller_is_enabled_and_observes() {
+    fn default_controller_is_disabled_and_skips_observations() {
         let cfg = CapacityControllerConfig::default();
-        assert!(cfg.enabled);
+        assert!(!cfg.enabled);
 
         let mut controller = CapacityController::new(cfg);
         let snapshot = controller.observe_pre_turn(CapacityObservationInput {
@@ -633,7 +636,29 @@ mod tests {
             context_used_ratio: 0.95,
         });
 
-        // With enabled=true, observe_pre_turn returns a snapshot.
+        // With enabled=false, observe_pre_turn returns None.
+        assert!(snapshot.is_none());
+    }
+
+    /// Opting in via `capacity.enabled = true` re-arms the controller —
+    /// observations produce snapshots, decisions can fire interventions.
+    #[test]
+    fn opt_in_controller_observes_and_decides() {
+        let cfg = CapacityControllerConfig {
+            enabled: true,
+            ..Default::default()
+        };
+
+        let mut controller = CapacityController::new(cfg);
+        let snapshot = controller.observe_pre_turn(CapacityObservationInput {
+            turn_index: 1,
+            model: "deepseek-v4-pro".to_string(),
+            action_count_this_turn: 10,
+            tool_calls_recent_window: 10,
+            unique_reference_ids_recent_window: 10,
+            context_used_ratio: 0.95,
+        });
+
         assert!(snapshot.is_some());
         let snap = snapshot.unwrap();
         assert_eq!(snap.turn_index, 1);
@@ -641,11 +666,11 @@ mod tests {
     }
 
     #[test]
-    fn app_config_without_capacity_uses_default_enabled() {
+    fn app_config_without_capacity_uses_default_disabled() {
         let cfg = CapacityControllerConfig::from_app_config(&crate::config::Config::default());
-        // Default is now enabled (#402 P0); no capacity section in config
-        // means the controller starts active with reasonable defaults.
-        assert!(cfg.enabled);
+        // v0.8.11: default is disabled. No capacity section in config
+        // means the controller stays inert; users opt in deliberately.
+        assert!(!cfg.enabled);
         assert_eq!(cfg.low_risk_max, 0.50);
         assert_eq!(cfg.refresh_cooldown_turns, 6);
         assert_eq!(cfg.min_turns_before_guardrail, 4);

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -1294,19 +1294,31 @@ impl Engine {
             // registered, so leaving the sandbox policy at the seatbelt-strict
             // default is fine.
             AppMode::Plan => ctx,
-            // Agent and Yolo both register the shell tool. The sandbox-default
-            // policy denies all outbound network — including DNS — which
-            // breaks ordinary developer commands (cargo fetch, npm install,
-            // curl, yt-dlp, …) without buying the user any safety the
-            // application-level NetworkPolicy / approval flow doesn't already
-            // provide. Elevate to workspace-write + network. (#273)
-            AppMode::Agent | AppMode::Yolo => {
+            // Agent registers the shell tool and runs each command through
+            // the per-mode sandbox + per-tool approval flow. The sandbox
+            // default would deny all outbound network — including DNS —
+            // which breaks ordinary developer commands (cargo fetch, npm
+            // install, curl, yt-dlp, …) without buying the user any safety
+            // the approval flow doesn't already provide. Elevate to
+            // workspace-write + network. (#273)
+            AppMode::Agent => {
                 ctx.with_elevated_sandbox_policy(crate::sandbox::SandboxPolicy::WorkspaceWrite {
                     writable_roots: vec![self.session.workspace.clone()],
                     network_access: true,
                     exclude_tmpdir: false,
                     exclude_slash_tmp: false,
                 })
+            }
+            // YOLO is the explicit "no guardrails" mode — auto-approve all
+            // tools, trust mode on, no sandbox. Workspace-write was still
+            // intercepting commands that wanted to write outside the
+            // workspace (rare but legitimate: pipx install, npm install
+            // -g, brew, package-manager state under ~/.cache, sub-agent
+            // workspaces, …) which forced approval round-trips and
+            // contradicts the YOLO contract. The user opted into YOLO
+            // deliberately; trust them.
+            AppMode::Yolo => {
+                ctx.with_elevated_sandbox_policy(crate::sandbox::SandboxPolicy::DangerFullAccess)
             }
         }
     }

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -957,6 +957,68 @@ async fn error_escalation_triggers_replan_when_severe_or_repeated_failures() {
     }
 }
 
+/// v0.8.11: `CapacityControllerConfig::default()` ships with
+/// `enabled = false`. The capacity controller's destructive
+/// interventions (TargetedContextRefresh silently runs compaction;
+/// VerifyAndReplan clears the session message log) silently rewrote
+/// or nuked the user's transcript ("resetting plan" footer +
+/// black-screen symptom). v0.8.11 commits to "trust the model with
+/// the full 1M-token context, only compact on explicit user
+/// /compact" — auto-managing the prefix contradicts that posture.
+/// Power users can still opt in via `capacity.enabled = true`.
+#[tokio::test]
+async fn capacity_disabled_by_default_keeps_messages_intact() {
+    let tmp = tempdir().expect("tempdir");
+    unsafe {
+        std::env::set_var(
+            "DEEPSEEK_CAPACITY_MEMORY_DIR",
+            tmp.path().to_string_lossy().to_string(),
+        );
+    }
+
+    // Default config — what real users get.
+    let mut engine = build_engine_with_capacity(CapacityControllerConfig::default());
+    assert!(
+        !engine.config.capacity.enabled,
+        "capacity controller must be off by default in v0.8.11+"
+    );
+    engine.turn_counter = 6;
+    engine
+        .capacity_controller
+        .mark_turn_start(engine.turn_counter);
+
+    for i in 0..10 {
+        engine.session.messages.push(Message {
+            role: if i % 2 == 0 { "user" } else { "assistant" }.to_string(),
+            content: vec![ContentBlock::Text {
+                text: format!("noise message {i}"),
+                cache_control: None,
+            }],
+        });
+    }
+    engine.session.messages.push(Message {
+        role: "user".to_string(),
+        content: vec![ContentBlock::Text {
+            text: "Please finish task".to_string(),
+            cache_control: None,
+        }],
+    });
+
+    let before_len = engine.session.messages.len();
+    let turn = TurnContext::new(10);
+    let restarted = engine
+        .run_capacity_error_escalation_checkpoint(&turn, AppMode::Agent, 2, 2, &[])
+        .await;
+
+    // Capacity is disabled → no replan, no message clear.
+    assert!(!restarted);
+    assert_eq!(engine.session.messages.len(), before_len);
+
+    unsafe {
+        std::env::remove_var("DEEPSEEK_CAPACITY_MEMORY_DIR");
+    }
+}
+
 #[tokio::test]
 async fn controller_disabled_keeps_behavior_unchanged() {
     let capacity = CapacityControllerConfig {

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -390,12 +390,20 @@ fn agent_and_yolo_modes_elevate_shell_sandbox_to_allow_network() {
     );
 
     let yolo_ctx = engine.build_tool_context(AppMode::Yolo, false);
+    let yolo_policy = yolo_ctx
+        .elevated_sandbox_policy
+        .as_ref()
+        .expect("Yolo mode should elevate the sandbox policy");
+    assert!(yolo_policy.has_network_access());
+    // v0.8.11: YOLO drops to DangerFullAccess (no sandbox) so the user
+    // is not bounced through approval round-trips for legitimate
+    // outside-workspace writes (package installs, sub-agent
+    // workspaces, ~/.cache mutations, etc.). YOLO is opt-in and
+    // already enables trust mode + auto-approve; the sandbox was the
+    // last guardrail and contradicts the contract.
     assert!(
-        yolo_ctx
-            .elevated_sandbox_policy
-            .as_ref()
-            .expect("Yolo mode should elevate the sandbox policy")
-            .has_network_access(),
+        matches!(yolo_policy, crate::sandbox::SandboxPolicy::DangerFullAccess),
+        "Yolo mode must use DangerFullAccess (no sandbox); got {yolo_policy:?}",
     );
 
     // Plan mode is read-only investigation and does not register the shell

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -195,6 +195,17 @@ impl ChatWidget {
         }
 
         let max_start = total_lines.saturating_sub(visible_lines);
+        // v0.8.11 hotfix: snapshot whether the user's prior scroll state
+        // was *deliberately* tail BEFORE we resolve. `resolve_top` clamps
+        // out-of-range `at_line(N)` to `to_bottom()` (e.g. when content
+        // shrunk so `max_start < N`), and `scrolled_by` returns
+        // `to_bottom()` when the whole transcript fits in one screen
+        // even if the user just scrolled up. Either case would fool a
+        // post-resolve `is_at_tail()` check into thinking the user is
+        // tracking the tail and silently revoke `user_scrolled_during_
+        // stream` — the next stream chunk would then yank them back to
+        // bottom mid-read.
+        let was_explicit_tail = app.viewport.transcript_scroll.is_at_tail();
         let (scroll_state, top) = app
             .viewport
             .transcript_scroll
@@ -205,7 +216,14 @@ impl ChatWidget {
         // again until they explicitly scroll up. Without this clear, content
         // piles up off-screen below the visible area and the view appears
         // frozen at the moment they returned to bottom.
-        if app.viewport.transcript_scroll.is_at_tail() {
+        //
+        // Only clear the lock when the user's INTENT was tail (their
+        // stored state was already `to_bottom()` before resolve), AND
+        // when the transcript actually has scrolling room to talk about
+        // — if everything fits in one screen, "tail" is trivially true
+        // and clearing here would yank the user back to bottom on the
+        // next chunk even though they explicitly scrolled up.
+        if was_explicit_tail && total_lines > visible_lines {
             app.user_scrolled_during_stream = false;
         }
 


### PR DESCRIPTION
## Summary

Three release-day fixes that surfaced after the v0.8.11 cache-maxing PR landed and you started exercising the binary.

### 1. Capacity controller off by default

**Repro:** YOLO at ~5% context briefly showed `resetting plan` in the footer; the transcript above the latest turn went black.

**Cause:** the capacity controller's `VerifyAndReplan` action does `self.session.messages.clear()`. It fires whenever the slack-based `p_fail` crosses high-severe — independently of `auto_compact`. The user opted out of auto-compaction in v0.8.11 (#665) to trust the model with the full 1M V4 window; auto-managing the prefix on their behalf via the capacity controller contradicts that posture and silently destroys the visible transcript + V4's prefix cache.

**Fix:** flip `CapacityControllerConfig::default().enabled` from `true` to `false`. The controller's `observe_*` and `decide` already short-circuit when disabled, so the whole subsystem becomes a no-op for default users — no defensive gating in the call sites needed. Power users opt in via `capacity.enabled = true`. Nothing deleted; the slack heuristics, model priors, intervention paths all remain on the opt-in path.

### 2. Scroll lock preserved across `resolve_top`

**Repro:** in a session with active streaming (sub-agent running), the user mouse-scrolls up to read earlier output. Their scroll position takes effect briefly, then snaps back to the live tail when the next chunk arrives.

**Cause:** `crates/tui/src/tui/widgets/mod.rs:208` cleared `user_scrolled_during_stream` whenever the post-`resolve_top` state was `at_tail`. But `resolve_top` clamps `at_line(N)` to `to_bottom()` whenever `max_start < N` (e.g. transcript briefly shrinks during a sub-agent card transition), and `scrolled_by` returns `to_bottom()` whenever `total_lines <= visible_lines`. Either path silently revoked the user's "leave me alone" intent and the next stream chunk yanked them to bottom mid-read.

**Fix:** snapshot `is_at_tail()` BEFORE `resolve_top` and only clear the lock when (a) the user's prior state was deliberately tail AND (b) `total_lines > visible_lines` (so "tail" is meaningful). Legitimate clear paths (`TurnComplete`, explicit `scroll_to_bottom()`, scrolling DOWN to `max_start`) all still work.

### 3. YOLO mode drops sandbox to `DangerFullAccess`

**Repro:** YOLO mode was supposed to be "no guardrails" but shell commands still routed through the `WorkspaceWrite` sandbox, intercepting legitimate outside-workspace writes (package installs, `~/.cache` mutations, sub-agent workspaces, `brew`, `npm install -g`, `pipx`, …) and forcing approval round-trips.

**Fix:** split the previously-merged `AppMode::Agent | AppMode::Yolo` branch in `Engine::build_tool_context`:

* **Agent** keeps `WorkspaceWrite { writable_roots, network_access: true, … }` — interactive mode; sandbox + approval flow form defense-in-depth.
* **YOLO** uses `DangerFullAccess` — no sandbox. Consistent with the rest of the YOLO contract (auto-approve all + trust mode).

Updated `agent_and_yolo_modes_elevate_shell_sandbox_to_allow_network` to pin the new YOLO contract specifically.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- [x] `cargo test --workspace --all-features --locked` — green
- [x] Parity gates pass

## Release strategy

The `v0.8.11` tag was already pushed and the in-flight `release.yml` was cancelled at the maintainer's request to avoid shipping bug-having binaries. Once this PR lands, the maintainer can:

1. Force-move `v0.8.11` to the new HEAD; re-fire `release.yml`. Nothing has been published to crates.io / npm / GH Release yet.
2. Or bump to v0.8.11.1 and ship as a fast follow.

Recommended: (1) — no consumers have pulled v0.8.11.