### PR TITLE
feat(nix): add nix package build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,7 @@ apps/
 
 # Maintainer-internal design notes (trade-secret material, never published)
 .private/
+
+# direnv
+.envrc
+.direnv

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -129,7 +129,62 @@ is fastest from your network.
 
 ---
 
-## 4. Manual download from GitHub Releases
+## 4. Install via Nix
+
+**Try it**
+
+If you already have Nix setup with flake support, you can try out `deepseek-tui` with the nix run command:
+
+```sh
+nix run github:Hmbown/DeepSeek-TUI
+```
+
+Nix will build `deepseek-tui` and run it.
+
+If you want to pass arguments this way, use e.g. `nix run github:Hmbown/DeepSeek-TUI -- --help`.
+
+### Flake
+
+Add inputs to `flake.nix`
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    deepseek-tui.url = "github:Hmbown/DeepSeek-TUI";
+    deepseek-tui.inputs.nixpkgs.follows = "nixpkgs";
+  };
+}
+```
+
+Install into a NixOS Module
+
+```nix
+{
+  outputs = { self, nixpkgs, deepseek-tui }:
+  let
+    # replace system "x86_64-linux" with your system
+    system = "x86_64-linux";
+  in
+  {
+    # change `yourhostname` to your actual hostname
+    nixosConfigurations.yourhostname = nixpkgs.lib.nixosSystem {
+      inherit system;
+      modules = [
+        # ...
+        {
+          environment.systemPackages = [ deepseek-tui.packages.${system}.default ];
+        }
+      ];
+    };
+  };
+}
+```
+
+---
+
+## 5. Manual download from GitHub Releases
 
 Grab the matching pair of binaries for your platform from the
 [Releases page](https://github.com/Hmbown/DeepSeek-TUI/releases) and drop them
@@ -158,7 +213,7 @@ curl -L -o /tmp/deepseek-artifacts-sha256.txt \
 
 ---
 
-## 5. Build from source
+## 6. Build from source
 
 This is the catch-all for any platform we don't ship — including musl, riscv64,
 LoongArch, FreeBSD, and pre-2024 ARM64 distros.
@@ -295,7 +350,7 @@ Both binaries appear in `target\release\deepseek.exe` and
 
 ---
 
-## 6. Troubleshooting
+## 7. Troubleshooting
 
 ### `Unsupported architecture: arm64 on platform linux`
 
@@ -404,7 +459,7 @@ target/debug/build/libsqlite3-sys-*/build-script-build
 
 ---
 
-## 7. Verifying your install
+## 8. Verifying your install
 
 ```bash
 deepseek --version

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,66 @@
+{
+  "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1777884425,
+        "narHash": "sha256-MzIEqXcx2EzJXOqrGETHFlzx6aGP2NhLVLxrM+ej41s=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "18454832b8f5d6cb33910382defc793dd78306f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1777578337,
+        "narHash": "sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM+Z4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "fenix": "fenix",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1777843182,
+        "narHash": "sha256-AO068PumYkLmubBSjlEQKAsnhVdF1Es7NC25X3KmuOw=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "f04c37286472e3687a2d32d3d1fad2772de515a1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,103 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    {
+      self,
+      fenix,
+      ...
+    }@inputs:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+      forEachSystem =
+        f:
+        inputs.nixpkgs.lib.genAttrs systems (
+          system:
+          f {
+            inherit system;
+            pkgs = import inputs.nixpkgs {
+              inherit system;
+              overlays = [
+                inputs.self.overlays.default
+              ];
+            };
+          }
+        );
+      rev = self.shortRev or self.dirtyShortRev or "dirty";
+    in
+    {
+      packages = forEachSystem (
+        { pkgs, system }:
+        {
+          default = self.packages.${system}.deepseek-tui;
+          deepseek-tui = pkgs.callPackage ./nix/package.nix {
+            inherit rev;
+            rustPlatform = pkgs.makeRustPlatform {
+              cargo = pkgs.rustToolchain;
+              rustc = pkgs.rustToolchain;
+            };
+          };
+        }
+      );
+
+      overlays.default = final: prev: {
+        rustToolchain =
+          with fenix.packages.${prev.stdenv.hostPlatform.system};
+          combine (
+            with stable;
+            [
+              rustc
+              cargo
+              clippy
+              rustfmt
+              rust-src
+            ]
+          );
+      };
+
+      devShells = forEachSystem (
+        { pkgs, system }:
+        {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              rustToolchain
+              rust-analyzer
+              lldb
+
+              pkg-config
+              openssl
+              dbus
+              python3
+
+              self.formatter.${system}
+            ];
+
+            env = {
+              # Required by rust-analyzer
+              RUST_SRC_PATH = "${pkgs.rustToolchain}/lib/rustlib/src/rust/library";
+
+              LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath (
+                with pkgs;
+                [
+                  openssl
+                  dbus
+                ]
+              );
+            };
+          };
+        }
+      );
+
+      formatter = forEachSystem ({ pkgs, ... }: pkgs.nixfmt);
+    };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,7 +1,9 @@
 {
   lib,
+  stdenv,
   rustPlatform,
   pkg-config,
+  autoPatchelfHook,
   openssl,
   dbus,
 
@@ -24,12 +26,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   nativeBuildInputs = [
     pkg-config
-    dbus
+    autoPatchelfHook
   ];
 
   buildInputs = [
     openssl
+    dbus.dev
     dbus.lib
+    stdenv.cc.cc.lib
   ];
 
   nativeCheckInputs = [
@@ -44,7 +48,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "--package"
     "deepseek-tui"
   ];
-  cargoTestFlags = finalAttrs.cargoBuildFlags;
+  cargoTestFlags = finalAttrs.cargoBuildFlags ++ [
+    "--lib"
+    "--bins"
+  ];
 
   preCheck = ''
     export SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  rustPlatform,
+  pkg-config,
+  openssl,
+  dbus,
+
+  # for cargo test
+  python3,
+  gitMinimal,
+  cacert,
+
+  rev ? "dirty",
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "deepseek-tui";
+  version = "git-${rev}";
+
+  src = ../.;
+
+  cargoLock = {
+    lockFile = ../Cargo.lock;
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    openssl
+    dbus
+  ];
+
+  nativeCheckInputs = [
+    python3
+    gitMinimal
+    cacert
+  ];
+
+  cargoBuildFlags = [
+    "--package"
+    "deepseek-tui-cli"
+    "--package"
+    "deepseek-tui"
+  ];
+  cargoTestFlags = finalAttrs.cargoBuildFlags;
+
+  preCheck = ''
+    export SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt
+  '';
+
+  meta = {
+    description = "Coding agent for DeepSeek models that runs in your terminal";
+    homepage = "https://github.com/Hmbown/DeepSeek-TUI";
+    license = lib.licenses.mit;
+    mainProgram = "deepseek";
+  };
+})

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -22,11 +22,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
     lockFile = ../Cargo.lock;
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    pkg-config
+    dbus
+  ];
 
   buildInputs = [
     openssl
-    dbus
+    dbus.lib
   ];
 
   nativeCheckInputs = [


### PR DESCRIPTION
## Summary

Add support for building the package with Nix. #701 

---

This change adds a Nix flake for building the package.

- Adds `flake.nix` with package output
- Enables reproducible builds via Nix
- Includes development shell and dependencies

## Testing

- [x] `cargo test --all-features`
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets --all-features`

## Checklist

- [x] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
