### PR TITLE
feat(nix): add Nix flake for NixOS/nix-profile installation (closes #701)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,26 @@ deepseek --version
 
 Prebuilt binaries can also be downloaded from [GitHub Releases](https://github.com/Hmbown/DeepSeek-TUI/releases). Use `DEEPSEEK_TUI_RELEASE_BASE_URL` for mirrored release assets.
 
+### NixOS / Nix
+
+```bash
+# Run without installing (nix flakes required)
+nix run github:Hmbown/DeepSeek-TUI
+
+# Install into your profile
+nix profile install github:Hmbown/DeepSeek-TUI
+
+# Enter a dev shell with the full toolchain
+nix develop github:Hmbown/DeepSeek-TUI
+```
+
+Or add to your NixOS / home-manager configuration:
+
+```nix
+inputs.deepseek-tui.url = "github:Hmbown/DeepSeek-TUI";
+# then: environment.systemPackages = [ inputs.deepseek-tui.packages.${system}.default ];
+```
+
 <details id="install-from-source">
 <summary>Install from source</summary>
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,75 @@
+{
+  description = "DeepSeek-TUI — terminal AI coding agent for DeepSeek V4";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, rust-overlay, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs { inherit system overlays; };
+
+        # DeepSeek-TUI requires nightly for `if let` guards and edition 2024.
+        rustToolchain = pkgs.rust-bin.nightly.latest.default;
+
+        nativeBuildInputs = with pkgs; [
+          rustToolchain
+          pkg-config
+        ];
+
+        buildInputs = with pkgs; [
+          dbus
+          openssl
+        ] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
+          pkgs.dbus.dev
+        ];
+
+      in {
+        packages.default = pkgs.rustPlatform.buildRustPackage {
+          pname = "deepseek-tui";
+          version = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).workspace.package.version or "0.8.11";
+
+          src = ./.;
+          cargoLock.lockFile = ./Cargo.lock;
+
+          inherit nativeBuildInputs buildInputs;
+
+          # Build both the CLI dispatcher and the TUI binary.
+          cargoBuildFlags = [ "-p" "deepseek-cli" "-p" "deepseek-tui" ];
+
+          # The nightly toolchain is declared in rust-toolchain.toml;
+          # pass RUSTUP_TOOLCHAIN so rustPlatform picks it up correctly.
+          RUSTUP_TOOLCHAIN = "nightly";
+
+          meta = with pkgs.lib; {
+            description = "Terminal AI coding agent for DeepSeek V4 with 1M-token context";
+            homepage = "https://github.com/Hmbown/DeepSeek-TUI";
+            license = licenses.mit;
+            maintainers = [ ];
+            platforms = platforms.unix;
+            mainProgram = "deepseek-tui";
+          };
+        };
+
+        devShells.default = pkgs.mkShell {
+          inherit buildInputs;
+          nativeBuildInputs = nativeBuildInputs ++ (with pkgs; [
+            rust-analyzer
+            cargo-watch
+            git
+          ]);
+
+          RUST_BACKTRACE = "1";
+          shellHook = ''
+            echo "DeepSeek-TUI dev shell ready. Run: cargo +nightly build"
+          '';
+        };
+      });
+}


### PR DESCRIPTION
## Summary

- Adds `flake.nix` using `rust-overlay` for the nightly toolchain (required for edition 2024 + `if let` guards)
- Builds both `deepseek` (CLI dispatcher) and `deepseek-tui` binaries
- Wires `dbus` and `openssl` system deps (matching the Dockerfile)
- Includes a `devShell` with `rust-analyzer` and `cargo-watch`
- README: adds NixOS section with `nix run`, `nix profile install`, and NixOS module snippet

## Usage

```bash
nix run github:Hmbown/DeepSeek-TUI        # try without installing
nix profile install github:Hmbown/DeepSeek-TUI  # install to profile
nix develop github:Hmbown/DeepSeek-TUI    # dev shell
```

## Test plan

- [ ] `nix flake check` passes (requires nix with flakes enabled)
- [ ] `nix build` produces both binaries
- [ ] README Nix section renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)