### PR TITLE
ci: add issue auto-labeler + spam guard workflow (closes #688)

### DIFF
--- a/.github/issue-labeler.yml
+++ b/.github/issue-labeler.yml
@@ -1,0 +1,51 @@
+# Auto-label rules for issues and PRs.
+# Matches against title + body text.
+
+bug:
+  - any:
+    - '(title|body) contains: bug'
+    - '(title|body) contains: crash'
+    - '(title|body) contains: error'
+    - '(title|body) contains: broken'
+    - '(title|body) contains: fix'
+    - '(title|body) contains: regression'
+
+enhancement:
+  - any:
+    - '(title|body) contains: feature'
+    - '(title|body) contains: request'
+    - '(title|body) contains: add'
+    - '(title|body) contains: support'
+    - '(title|body) contains: improve'
+    - '(title|body) contains: enhancement'
+
+question:
+  - any:
+    - '(title|body) contains: how'
+    - '(title|body) contains: why'
+    - '(title|body) contains: help'
+    - '(title|body) contains: question'
+    - '(title|body) contains: ?'
+
+documentation:
+  - any:
+    - '(title|body) contains: docs'
+    - '(title|body) contains: readme'
+    - '(title|body) contains: documentation'
+    - '(title|body) contains: guide'
+
+localization:
+  - any:
+    - '(title|body) contains: chinese'
+    - '(title|body) contains: 中文'
+    - '(title|body) contains: locale'
+    - '(title|body) contains: language'
+    - '(title|body) contains: i18n'
+
+performance:
+  - any:
+    - '(title|body) contains: slow'
+    - '(title|body) contains: performance'
+    - '(title|body) contains: memory'
+    - '(title|body) contains: cpu'
+    - '(title|body) contains: latency'

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,0 +1,56 @@
+name: Issue Auto-Labeler
+
+on:
+  issues:
+    types: [opened, edited]
+  pull_request:
+    types: [opened, edited]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/issue-labeler.yml
+          sync-labels: false
+
+  auto-close-spam:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'issues' && github.event.action == 'opened'
+    steps:
+      - name: Close obvious spam
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.issue.body || '';
+            const title = context.payload.issue.title || '';
+            const combined = (title + ' ' + body).toLowerCase();
+
+            // Spam signals: pure promotional links, no code/log content
+            const spamPatterns = [
+              /\b(buy|sell|cheap|discount|offer|promo|click here|visit now)\b/i,
+              /https?:\/\/[^\s]+\.(xyz|top|click|bid|loan|win)\b/i,
+            ];
+
+            const isSpam = spamPatterns.some(p => p.test(combined));
+            if (isSpam) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: 'This issue appears to be spam and has been automatically closed. If this is a mistake, please reopen with a proper bug report or feature request.'
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                state: 'closed',
+                labels: ['invalid']
+              });
+            }


### PR DESCRIPTION
## Summary

- **Auto-labeler**: uses `actions/labeler@v5` to tag issues/PRs with `bug`, `enhancement`, `question`, `documentation`, `localization`, `performance` based on keyword matching in title+body
- **Spam guard**: script job closes issues matching obvious promotional patterns (`.xyz/.top` domains, buy/sell/promo keywords) and applies `invalid` label with a polite comment
- Labels are additive (`sync-labels: false`) — hand-applied labels are preserved

## Test plan
- [ ] Open a test issue with "feature request" in title → gets `enhancement` label
- [ ] Open test issue with spam URL → auto-closes with comment
- [ ] Existing labels on open issues are not removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)