### PR TITLE
feat(web-search): support native DeepSeek web_search_20260209 server tool (closes #708)

### DIFF
--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -935,6 +935,7 @@ pub(super) fn parse_usage(usage: Option<&Value>) -> Usage {
         ServerToolUsage {
             code_execution_requests,
             tool_search_requests,
+            web_search_requests: None,
         }
     });
 

--- a/crates/tui/src/client/chat.rs
+++ b/crates/tui/src/client/chat.rs
@@ -440,6 +440,7 @@ fn build_chat_messages_with_reasoning(
                 ContentBlock::ServerToolUse { .. }
                 | ContentBlock::ToolSearchToolResult { .. }
                 | ContentBlock::CodeExecutionToolResult { .. } => {}
+                        ContentBlock::WebSearchToolResult { .. } => {}
             }
         }
 
@@ -1037,6 +1038,7 @@ fn build_stream_events(response: &MessageResponse) -> Vec<StreamEvent> {
             }
             ContentBlock::ToolSearchToolResult { .. }
             | ContentBlock::CodeExecutionToolResult { .. } => {}
+                    ContentBlock::WebSearchToolResult { .. } => {}
         }
         index = index.saturating_add(1);
     }

--- a/crates/tui/src/client/responses.rs
+++ b/crates/tui/src/client/responses.rs
@@ -169,6 +169,7 @@ fn build_responses_input(messages: &[Message]) -> Vec<Value> {
                         "content": content,
                     }));
                 }
+                        ContentBlock::WebSearchToolResult { .. } => {}
             }
         }
     }

--- a/crates/tui/src/compaction.rs
+++ b/crates/tui/src/compaction.rs
@@ -250,6 +250,7 @@ fn message_text(msg: &Message) -> String {
             ContentBlock::ServerToolUse { .. }
             | ContentBlock::ToolSearchToolResult { .. }
             | ContentBlock::CodeExecutionToolResult { .. } => {}
+                    ContentBlock::WebSearchToolResult { .. } => {}
         }
     }
     text
@@ -265,7 +266,8 @@ fn extract_paths_from_message(message: &Message, workspace: Option<&Path>) -> Ve
             ContentBlock::Thinking { .. } => Vec::new(),
             ContentBlock::ServerToolUse { .. }
             | ContentBlock::ToolSearchToolResult { .. }
-            | ContentBlock::CodeExecutionToolResult { .. } => Vec::new(),
+            | ContentBlock::CodeExecutionToolResult { .. }
+            | ContentBlock::WebSearchToolResult { .. } => Vec::new()
         };
         paths.extend(candidates);
     }
@@ -524,6 +526,7 @@ fn estimate_tokens_for_message(message: &Message, include_thinking: bool) -> usi
             ContentBlock::ServerToolUse { .. }
             | ContentBlock::ToolSearchToolResult { .. }
             | ContentBlock::CodeExecutionToolResult { .. } => 0,
+            ContentBlock::WebSearchToolResult { .. } => 0
         })
         .sum::<usize>()
 }
@@ -933,6 +936,7 @@ fn build_formatted_summary_request(
                 ContentBlock::ServerToolUse { .. }
                 | ContentBlock::ToolSearchToolResult { .. }
                 | ContentBlock::CodeExecutionToolResult { .. } => {}
+                        ContentBlock::WebSearchToolResult { .. } => {}
             }
         }
     }

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -343,6 +343,12 @@ pub struct TuiConfig {
     /// label and ignore the escape. Defaults to `true`; set `false` for
     /// terminals that misrender the sequence.
     pub osc8_links: Option<bool>,
+    /// Enable the native DeepSeek web search tool (`web_search_20260209`).
+    /// Only works with the DeepSeek Anthropic-compatible endpoint
+    /// (`https://api.deepseek.com/anthropic/v1/messages`). When `true` the
+    /// tool is injected into every API request; the model calls it server-side
+    /// and results arrive as `web_search_tool_result` content blocks.
+    pub native_web_search: Option<bool>,
 }
 
 /// Notification delivery method (mirrors `tui::notifications::Method`).

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -140,6 +140,8 @@ pub struct EngineConfig {
     /// consulted when `memory_enabled` is `true`.
     pub memory_path: PathBuf,
     pub goal_objective: Option<String>,
+    /// Whether to inject the native DeepSeek web_search_20260209 server tool.
+    pub native_web_search: bool,
 }
 
 impl Default for EngineConfig {
@@ -170,6 +172,7 @@ impl Default for EngineConfig {
             memory_enabled: false,
             memory_path: PathBuf::from("./memory.md"),
             goal_objective: None,
+            native_web_search: false,
         }
     }
 }
@@ -883,9 +886,34 @@ impl Engine {
         } else {
             Vec::new()
         };
-        let tools = tool_registry
+        let mut tools = tool_registry
             .as_ref()
             .map(|registry| build_model_tool_catalog(registry.to_api_tools(), mcp_tools, mode));
+
+        // Inject the native DeepSeek web search server tool when enabled.
+        // It is a server-side tool (type "web_search_20260209") — the model
+        // calls it autonomously; the client only needs to declare it.
+        if self.config.native_web_search {
+            let web_search_tool = crate::models::Tool {
+                tool_type: Some("web_search_20260209".to_string()),
+                name: "web_search".to_string(),
+                description: "Search the web for current information.".to_string(),
+                input_schema: serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string", "description": "The search query"}
+                    },
+                    "required": ["query"]
+                }),
+                allowed_callers: None,
+                defer_loading: None,
+                input_examples: None,
+                strict: None,
+                cache_control: None,
+            };
+            let entry = tools.get_or_insert_with(Vec::new);
+            entry.insert(0, web_search_tool);
+        }
 
         // Main turn loop
         let (status, error) = self

--- a/crates/tui/src/core/engine/capacity_flow.rs
+++ b/crates/tui/src/core/engine/capacity_flow.rs
@@ -226,6 +226,7 @@ impl Engine {
                     | ContentBlock::ServerToolUse { .. }
                     | ContentBlock::ToolSearchToolResult { .. }
                     | ContentBlock::CodeExecutionToolResult { .. } => {}
+                            ContentBlock::WebSearchToolResult { .. } => {}
                 }
             }
         }

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -3725,6 +3725,11 @@ async fn run_exec_agent(
         memory_enabled: config.memory_enabled(),
         memory_path: config.memory_path(),
         goal_objective: None,
+        native_web_search: config
+            .tui
+            .as_ref()
+            .and_then(|t| t.native_web_search)
+            .unwrap_or(false),
     };
 
     let engine_handle = spawn_engine(engine_config, config);

--- a/crates/tui/src/models.rs
+++ b/crates/tui/src/models.rs
@@ -68,6 +68,7 @@ pub struct Message {
 /// A single content block inside a message.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum ContentBlock {
     #[serde(rename = "text")]
     Text {
@@ -110,6 +111,25 @@ pub enum ContentBlock {
         tool_use_id: String,
         content: serde_json::Value,
     },
+    /// Results from a native DeepSeek web_search server tool call.
+    #[serde(rename = "web_search_tool_result")]
+    WebSearchToolResult {
+        tool_use_id: String,
+        content: Vec<WebSearchResult>,
+    },
+}
+
+/// A single result entry from a web_search_tool_result block.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct WebSearchResult {
+    #[serde(rename = "type")]
+    pub result_type: String,
+    pub title: String,
+    pub url: String,
+    #[serde(default)]
+    pub encrypted_content: Option<String>,
+    #[serde(default)]
+    pub page_age: Option<String>,
 }
 
 /// Cache control metadata for tool definitions and blocks.
@@ -163,6 +183,8 @@ pub struct ServerToolUsage {
     pub code_execution_requests: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_search_requests: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub web_search_requests: Option<u32>,
 }
 
 /// Response payload for a message request.

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -1812,6 +1812,7 @@ impl RuntimeThreadManager {
             memory_enabled: self.config.memory_enabled(),
             memory_path: self.config.memory_path(),
             goal_objective: None,
+            native_web_search: self.config.tui.as_ref().and_then(|t| t.native_web_search).unwrap_or(false),
         };
 
         let engine = spawn_engine(engine_cfg, &self.config);

--- a/crates/tui/src/seam_manager.rs
+++ b/crates/tui/src/seam_manager.rs
@@ -479,6 +479,7 @@ impl SeamManager {
                     ContentBlock::ServerToolUse { .. }
                     | ContentBlock::ToolSearchToolResult { .. }
                     | ContentBlock::CodeExecutionToolResult { .. } => {}
+                            ContentBlock::WebSearchToolResult { .. } => {}
                 }
             }
         }

--- a/crates/tui/src/tools/recall_archive.rs
+++ b/crates/tui/src/tools/recall_archive.rs
@@ -260,6 +260,7 @@ fn message_text(message: &Message) -> String {
             ContentBlock::CodeExecutionToolResult { content, .. } => {
                 push(&format!("[code_execution_result] {content}"));
             }
+                    ContentBlock::WebSearchToolResult { .. } => {}
         }
     }
     out

--- a/crates/tui/src/tui/history.rs
+++ b/crates/tui/src/tui/history.rs
@@ -563,6 +563,18 @@ pub fn history_cells_from_message(msg: &Message) -> Vec<HistoryCell> {
                     });
                 }
             }
+            ContentBlock::WebSearchToolResult { tool_use_id: _, content } => {
+                let summary = content
+                    .iter()
+                    .enumerate()
+                    .map(|(i, r)| format!("{}. [{}]({})", i + 1, r.title, r.url))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                cells.push(HistoryCell::Assistant {
+                    content: format!("🔍 **Web Search Results**\n{summary}"),
+                    streaming: false,
+                });
+            }
             _ => {}
         }
     }

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -542,6 +542,7 @@ fn build_engine_config(app: &App, config: &Config) -> EngineConfig {
         memory_enabled: config.memory_enabled(),
         memory_path: config.memory_path(),
         goal_objective: app.goal.goal_objective.clone(),
+        native_web_search: config.tui.as_ref().and_then(|t| t.native_web_search).unwrap_or(false),
     }
 }
 

--- a/crates/tui/src/utils.rs
+++ b/crates/tui/src/utils.rs
@@ -400,6 +400,7 @@ pub fn estimate_message_chars(messages: &[Message]) -> usize {
                 ContentBlock::ServerToolUse { .. }
                 | ContentBlock::ToolSearchToolResult { .. }
                 | ContentBlock::CodeExecutionToolResult { .. } => {}
+                        ContentBlock::WebSearchToolResult { .. } => {}
             }
         }
     }

--- a/crates/tui/src/working_set.rs
+++ b/crates/tui/src/working_set.rs
@@ -665,6 +665,7 @@ fn extract_paths_from_message(message: &Message) -> Vec<String> {
             | ContentBlock::ServerToolUse { .. }
             | ContentBlock::ToolSearchToolResult { .. }
             | ContentBlock::CodeExecutionToolResult { .. } => {}
+                    ContentBlock::WebSearchToolResult { .. } => {}
         }
     }
     paths
@@ -830,6 +831,7 @@ fn message_mentions_any_path(message: &Message, needles: &[String], max_scan_cha
             | ContentBlock::ServerToolUse { .. }
             | ContentBlock::ToolSearchToolResult { .. }
             | ContentBlock::CodeExecutionToolResult { .. } => {}
+                    ContentBlock::WebSearchToolResult { .. } => {}
         }
     }
     false


### PR DESCRIPTION
## Summary

DeepSeek's Anthropic-compatible endpoint (`https://api.deepseek.com/anthropic/v1/messages`) now supports a server-side web search tool. This PR wires it into DeepSeek-TUI end-to-end.

### Changes

- **`models.rs`**: add `WebSearchToolResult` content block + `WebSearchResult` struct; `web_search_requests` counter on `ServerToolUsage`; `#[non_exhaustive]` on `ContentBlock`
- **`config.rs`**: add `TuiConfig.native_web_search: Option<bool>`
- **`engine.rs` / `EngineConfig`**: `native_web_search: bool` field; when `true`, injects `{"type":"web_search_20260209","name":"web_search"}` at the front of every API tools array
- **`history.rs`**: render `web_search_tool_result` blocks as an `Assistant` cell showing a numbered list of titles + URLs
- **`runtime_threads.rs`, `ui.rs`**: propagate `native_web_search` through all `EngineConfig` construction sites

### Usage

```toml
# ~/.deepseek/config.toml
[tui]
native_web_search = true
```

The model then calls web search autonomously as a server tool — no extra API key required.

## Test plan
- [ ] Set `native_web_search = true`, ask "what happened today?" — model uses web search
- [ ] Web search results render in the transcript as a numbered list
- [ ] `native_web_search = false` (default) — no tool injected, existing behavior unchanged
- [ ] `cargo test -p deepseek-tui` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)