### PR TITLE
add frontend import alias resolution tool

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -285,6 +285,7 @@ pub struct Engine {
     session: Session,
     subagent_manager: SharedSubAgentManager,
     shell_manager: SharedShellManager,
+    module_resolver: Arc<crate::module_resolver::ModuleResolver>,
     mcp_pool: Option<Arc<AsyncMutex<McpPool>>>,
     rx_op: mpsc::Receiver<Op>,
     rx_approval: mpsc::Receiver<ApprovalDecision>,
@@ -373,6 +374,9 @@ impl Engine {
             .shell_manager
             .clone()
             .unwrap_or_else(|| new_shared_shell_manager(config.workspace.clone()));
+        let module_resolver = Arc::new(crate::module_resolver::ModuleResolver::new(
+            config.workspace.clone(),
+        ));
         let capacity_controller = CapacityController::new(config.capacity.clone());
 
         // Create Flash seam manager for layered context (#159). v0.7.5 keeps
@@ -422,6 +426,7 @@ impl Engine {
             session,
             subagent_manager,
             shell_manager,
+            module_resolver,
             mcp_pool: None,
             rx_op,
             rx_approval,
@@ -1247,6 +1252,9 @@ impl Engine {
         .with_state_namespace(self.session.id.clone())
         .with_features(self.config.features.clone())
         .with_shell_manager(self.shell_manager.clone())
+        .with_cwd_hint(std::env::current_dir().ok())
+        .with_active_paths(self.session.working_set.top_paths(8))
+        .with_module_resolver(self.module_resolver.clone())
         .with_runtime_services(self.config.runtime_services.clone())
         .with_cancel_token(self.cancel_token.clone())
         .with_trusted_external_paths(trusted.paths().to_vec());

--- a/crates/tui/src/core/engine/tool_catalog.rs
+++ b/crates/tui/src/core/engine/tool_catalog.rs
@@ -55,6 +55,7 @@ pub(super) fn should_default_defer_tool(name: &str, mode: AppMode) -> bool {
             | "list_dir"
             | "grep_files"
             | "file_search"
+            | "resolve_import"
             | "diagnostics"
             | "rlm"
             | "recall_archive"

--- a/crates/tui/src/core/engine/tool_setup.rs
+++ b/crates/tui/src/core/engine/tool_setup.rs
@@ -18,6 +18,7 @@ impl Engine {
                 .with_git_tools()
                 .with_git_history_tools()
                 .with_diagnostics_tool()
+                .with_module_resolve_tool()
                 .with_skill_tools()
                 .with_validation_tools()
                 .with_runtime_task_tools()

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -38,6 +38,7 @@ mod mcp;
 mod mcp_server;
 mod memory;
 mod models;
+mod module_resolver;
 mod network_policy;
 mod palette;
 mod pricing;

--- a/crates/tui/src/module_resolver.rs
+++ b/crates/tui/src/module_resolver.rs
@@ -1,0 +1,1182 @@
+//! Lightweight frontend import resolver for monorepo workspaces.
+//!
+//! This intentionally handles a small, safe subset of TypeScript resolution:
+//! local relative imports, `tsconfig.json` / `jsconfig.json` `baseUrl` and
+//! `paths`, JSONC config files, and local `extends`. It never executes project
+//! JavaScript/TypeScript configuration.
+
+use std::collections::{BTreeMap, HashMap};
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+use std::sync::{Arc, RwLock};
+use std::time::SystemTime;
+
+use serde::Serialize;
+
+const PROBE_EXTENSIONS: [&str; 9] = [
+    "ts", "tsx", "js", "jsx", "mjs", "cjs", "vue", "svelte", "json",
+];
+const INDEX_FILES: [&str; 7] = [
+    "index.ts",
+    "index.tsx",
+    "index.js",
+    "index.jsx",
+    "index.vue",
+    "index.svelte",
+    "index.json",
+];
+const MAX_CONFIG_SCAN_DEPTH: usize = 8;
+
+#[derive(Debug, Clone)]
+pub struct ModuleResolver {
+    workspace: PathBuf,
+    cache: Arc<RwLock<ResolverCache>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ResolveImportRequest {
+    pub specifier: String,
+    pub from: Option<PathBuf>,
+    pub cwd_hint: Option<PathBuf>,
+    pub active_paths: Vec<PathBuf>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ResolveImportOutcome {
+    #[serde(skip_serializing)]
+    pub resolved_path: PathBuf,
+    #[serde(skip_serializing)]
+    pub project_root: PathBuf,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config_path: Option<PathBuf>,
+    pub rule: ResolveRule,
+    #[serde(skip_serializing)]
+    pub tried: Vec<PathBuf>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ResolveRule {
+    Relative,
+    FilePath,
+    TsconfigPaths { pattern: String, target: String },
+    BaseUrl { base_url: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResolveImportError {
+    ExternalPackage,
+    MissingContext,
+    AmbiguousProject { candidates: Vec<PathBuf> },
+    NoMatchingAlias,
+    NotFound { tried: Vec<PathBuf> },
+    PathEscape { path: PathBuf },
+    ConfigError { path: PathBuf, message: String },
+}
+
+impl std::fmt::Display for ResolveImportError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ExternalPackage => write!(
+                f,
+                "specifier appears to be an external package, not a workspace file"
+            ),
+            Self::MissingContext => write!(
+                f,
+                "missing importer context; pass `from` with the file that contains the import"
+            ),
+            Self::AmbiguousProject { candidates } => write!(
+                f,
+                "multiple frontend project configs can resolve this alias: {}",
+                candidates
+                    .iter()
+                    .map(|p| p.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+            Self::NoMatchingAlias => write!(f, "no matching local alias rule was found"),
+            Self::NotFound { tried } => write!(
+                f,
+                "matched local import rules but no file was found; tried {} path(s)",
+                tried.len()
+            ),
+            Self::PathEscape { path } => {
+                write!(f, "resolved path escapes workspace: {}", path.display())
+            }
+            Self::ConfigError { path, message } => {
+                write!(f, "failed to read {}: {message}", path.display())
+            }
+        }
+    }
+}
+
+impl std::error::Error for ResolveImportError {}
+
+#[derive(Debug, Default)]
+struct ResolverCache {
+    raw_configs: HashMap<PathBuf, CachedRawConfig>,
+}
+
+#[derive(Debug, Clone)]
+struct CachedRawConfig {
+    fingerprint: FileFingerprint,
+    raw: Result<RawConfig, ResolveImportError>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FileFingerprint {
+    len: u64,
+    modified: Option<SystemTime>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct RawConfig {
+    extends: Option<String>,
+    base_url: Option<String>,
+    paths: BTreeMap<String, Vec<String>>,
+}
+
+#[derive(Debug, Clone)]
+struct MergedConfig {
+    config_path: PathBuf,
+    config_dir: PathBuf,
+    base_url: Option<PathBuf>,
+    paths: BTreeMap<String, Vec<String>>,
+}
+
+#[derive(Debug, Clone)]
+struct PatternMatch<'a> {
+    pattern: &'a str,
+    targets: &'a [String],
+    capture: String,
+    prefix_len: usize,
+}
+
+impl ModuleResolver {
+    #[must_use]
+    pub fn new(workspace: impl Into<PathBuf>) -> Self {
+        let workspace = workspace.into();
+        let workspace = workspace
+            .canonicalize()
+            .unwrap_or_else(|_| normalize_path(&workspace));
+        Self {
+            workspace,
+            cache: Arc::new(RwLock::new(ResolverCache::default())),
+        }
+    }
+
+    #[must_use]
+    pub fn workspace_relative_path(&self, path: &Path) -> PathBuf {
+        let normalized = normalize_path(path);
+        normalized
+            .strip_prefix(&self.workspace)
+            .map(Path::to_path_buf)
+            .unwrap_or(normalized)
+    }
+
+    pub fn resolve_import(
+        &self,
+        request: ResolveImportRequest,
+    ) -> Result<ResolveImportOutcome, ResolveImportError> {
+        let specifier = request.specifier.trim();
+        if specifier.is_empty() {
+            return Err(ResolveImportError::NoMatchingAlias);
+        }
+
+        if is_relative_specifier(specifier) {
+            return self.resolve_relative(specifier, request.from.as_deref());
+        }
+
+        if Path::new(specifier).is_absolute() {
+            return self.resolve_absolute_file_path(specifier);
+        }
+
+        if let Some(from) = request.from.as_deref() {
+            let importer = self.workspace_path(from)?;
+            let config_path = self
+                .nearest_config_for_path(&importer)
+                .ok_or(ResolveImportError::MissingContext)?;
+            let config = self.load_merged_config(&config_path)?;
+            return self.resolve_with_config(specifier, &config);
+        }
+
+        let hint_configs = self.configs_from_hints(&request);
+        let hint_outcomes = self.resolve_across_configs(specifier, hint_configs)?;
+        if let Some(outcome) = hint_outcomes {
+            return Ok(outcome);
+        }
+
+        let scanned = self.scan_project_configs();
+        match self.resolve_across_configs(specifier, scanned)? {
+            Some(outcome) => Ok(outcome),
+            None if is_probably_external_package(specifier) => {
+                Err(ResolveImportError::ExternalPackage)
+            }
+            None => Err(ResolveImportError::NoMatchingAlias),
+        }
+    }
+
+    fn resolve_relative(
+        &self,
+        specifier: &str,
+        from: Option<&Path>,
+    ) -> Result<ResolveImportOutcome, ResolveImportError> {
+        let from = from.ok_or(ResolveImportError::MissingContext)?;
+        let importer = self.workspace_path(from)?;
+        let base_dir = if importer.exists() && importer.is_dir() {
+            importer.clone()
+        } else {
+            importer
+                .parent()
+                .map(Path::to_path_buf)
+                .ok_or(ResolveImportError::MissingContext)?
+        };
+        let candidate = normalize_path(&base_dir.join(specifier));
+        let mut tried = Vec::new();
+        let resolved = self.probe_candidate(&candidate, &mut tried)?;
+        let config_path = self.nearest_config_for_path(&importer);
+        let project_root = config_path
+            .as_deref()
+            .and_then(Path::parent)
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| self.workspace.clone());
+
+        Ok(ResolveImportOutcome {
+            resolved_path: resolved,
+            project_root,
+            config_path,
+            rule: ResolveRule::Relative,
+            tried,
+        })
+    }
+
+    fn resolve_absolute_file_path(
+        &self,
+        specifier: &str,
+    ) -> Result<ResolveImportOutcome, ResolveImportError> {
+        let candidate = normalize_path(Path::new(specifier));
+        let mut tried = Vec::new();
+        let resolved = self.probe_candidate(&candidate, &mut tried)?;
+        Ok(ResolveImportOutcome {
+            resolved_path: resolved,
+            project_root: self.workspace.clone(),
+            config_path: None,
+            rule: ResolveRule::FilePath,
+            tried,
+        })
+    }
+
+    fn resolve_with_config(
+        &self,
+        specifier: &str,
+        config: &MergedConfig,
+    ) -> Result<ResolveImportOutcome, ResolveImportError> {
+        let mut tried = Vec::new();
+        let mut matches = Vec::new();
+        for (pattern, targets) in &config.paths {
+            if let Some((capture, prefix_len)) = match_paths_pattern(pattern, specifier) {
+                matches.push(PatternMatch {
+                    pattern,
+                    targets,
+                    capture,
+                    prefix_len,
+                });
+            }
+        }
+        matches.sort_by(|a, b| {
+            b.prefix_len
+                .cmp(&a.prefix_len)
+                .then_with(|| b.pattern.len().cmp(&a.pattern.len()))
+        });
+
+        for matched in matches {
+            for target in matched.targets {
+                let replaced = replace_capture(target, &matched.capture);
+                let base = config.base_url.as_ref().unwrap_or(&config.config_dir);
+                let candidate = normalize_path(&base.join(&replaced));
+                match self.probe_candidate(&candidate, &mut tried) {
+                    Ok(resolved_path) => {
+                        return Ok(ResolveImportOutcome {
+                            resolved_path,
+                            project_root: config.config_dir.clone(),
+                            config_path: Some(config.config_path.clone()),
+                            rule: ResolveRule::TsconfigPaths {
+                                pattern: matched.pattern.to_string(),
+                                target: target.clone(),
+                            },
+                            tried,
+                        });
+                    }
+                    Err(ResolveImportError::NotFound { .. }) => {}
+                    Err(err) => return Err(err),
+                }
+            }
+        }
+
+        if !tried.is_empty() {
+            return Err(ResolveImportError::NotFound { tried });
+        }
+
+        if let Some(base_url) = config.base_url.as_ref()
+            && is_base_url_candidate(specifier)
+        {
+            let candidate = normalize_path(&base_url.join(specifier));
+            match self.probe_candidate(&candidate, &mut tried) {
+                Ok(resolved_path) => {
+                    return Ok(ResolveImportOutcome {
+                        resolved_path,
+                        project_root: config.config_dir.clone(),
+                        config_path: Some(config.config_path.clone()),
+                        rule: ResolveRule::BaseUrl {
+                            base_url: self
+                                .workspace_relative_path(base_url)
+                                .to_string_lossy()
+                                .replace('\\', "/"),
+                        },
+                        tried,
+                    });
+                }
+                Err(ResolveImportError::NotFound { .. }) => {}
+                Err(err) => return Err(err),
+            }
+        }
+
+        if !tried.is_empty() {
+            Err(ResolveImportError::NotFound { tried })
+        } else if is_probably_external_package(specifier) {
+            Err(ResolveImportError::ExternalPackage)
+        } else {
+            Err(ResolveImportError::NoMatchingAlias)
+        }
+    }
+
+    fn resolve_across_configs(
+        &self,
+        specifier: &str,
+        configs: Vec<PathBuf>,
+    ) -> Result<Option<ResolveImportOutcome>, ResolveImportError> {
+        let mut outcomes = Vec::new();
+        let mut not_found_tried = Vec::new();
+
+        for config_path in configs {
+            let config = match self.load_merged_config(&config_path) {
+                Ok(config) => config,
+                Err(ResolveImportError::ConfigError { .. }) => continue,
+                Err(err) => return Err(err),
+            };
+            match self.resolve_with_config(specifier, &config) {
+                Ok(outcome) => outcomes.push(outcome),
+                Err(ResolveImportError::NotFound { tried }) => not_found_tried.extend(tried),
+                Err(ResolveImportError::ExternalPackage | ResolveImportError::NoMatchingAlias) => {}
+                Err(err) => return Err(err),
+            }
+        }
+
+        outcomes.sort_by(|a, b| a.config_path.cmp(&b.config_path));
+        outcomes.dedup_by(|a, b| a.config_path == b.config_path);
+        match outcomes.len() {
+            0 if !not_found_tried.is_empty() => Err(ResolveImportError::NotFound {
+                tried: not_found_tried,
+            }),
+            0 => Ok(None),
+            1 => Ok(outcomes.into_iter().next()),
+            _ => Err(ResolveImportError::AmbiguousProject {
+                candidates: outcomes
+                    .into_iter()
+                    .filter_map(|outcome| outcome.config_path)
+                    .collect(),
+            }),
+        }
+    }
+
+    fn configs_from_hints(&self, request: &ResolveImportRequest) -> Vec<PathBuf> {
+        let mut configs = Vec::new();
+        for active in &request.active_paths {
+            if let Ok(path) = self.workspace_path(active)
+                && let Some(config) = self.nearest_config_for_path(&path)
+                && !configs.contains(&config)
+            {
+                configs.push(config);
+            }
+        }
+        if let Some(cwd) = request.cwd_hint.as_deref() {
+            if let Ok(path) = self.workspace_path(cwd)
+                && let Some(config) = self.nearest_config_for_path(&path)
+                && !configs.contains(&config)
+            {
+                configs.push(config);
+            }
+        }
+        configs
+    }
+
+    fn nearest_config_for_path(&self, path: &Path) -> Option<PathBuf> {
+        let normalized = normalize_path(path);
+        let mut dir = if normalized.exists() && normalized.is_dir() {
+            normalized
+        } else {
+            normalized.parent()?.to_path_buf()
+        };
+
+        loop {
+            let tsconfig = dir.join("tsconfig.json");
+            if tsconfig.is_file() {
+                return Some(normalize_path(&tsconfig));
+            }
+            let jsconfig = dir.join("jsconfig.json");
+            if jsconfig.is_file() {
+                return Some(normalize_path(&jsconfig));
+            }
+            if dir == self.workspace {
+                return None;
+            }
+            dir = dir.parent()?.to_path_buf();
+            if !dir.starts_with(&self.workspace) {
+                return None;
+            }
+        }
+    }
+
+    fn scan_project_configs(&self) -> Vec<PathBuf> {
+        let mut by_dir: BTreeMap<PathBuf, PathBuf> = BTreeMap::new();
+        self.scan_project_configs_inner(&self.workspace, 0, &mut by_dir);
+        by_dir.into_values().collect()
+    }
+
+    fn scan_project_configs_inner(
+        &self,
+        dir: &Path,
+        depth: usize,
+        by_dir: &mut BTreeMap<PathBuf, PathBuf>,
+    ) {
+        if depth > MAX_CONFIG_SCAN_DEPTH {
+            return;
+        }
+        let Ok(entries) = fs::read_dir(dir) else {
+            return;
+        };
+
+        let mut child_dirs = Vec::new();
+        let mut found_tsconfig = None;
+        let mut found_jsconfig = None;
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if path.is_dir() {
+                if should_skip_scan_dir(&name) {
+                    continue;
+                }
+                child_dirs.push(path);
+                continue;
+            }
+            match name.as_ref() {
+                "tsconfig.json" => found_tsconfig = Some(path),
+                "jsconfig.json" => found_jsconfig = Some(path),
+                _ => {}
+            }
+        }
+
+        if let Some(config) = found_tsconfig.or(found_jsconfig) {
+            by_dir.insert(normalize_path(dir), normalize_path(&config));
+        }
+
+        for child in child_dirs {
+            self.scan_project_configs_inner(&child, depth + 1, by_dir);
+        }
+    }
+
+    fn load_merged_config(&self, config_path: &Path) -> Result<MergedConfig, ResolveImportError> {
+        let config_path = normalize_path(config_path);
+        self.ensure_inside_workspace(&config_path)?;
+        self.load_merged_config_inner(&config_path, &mut Vec::new())
+    }
+
+    fn load_merged_config_inner(
+        &self,
+        config_path: &Path,
+        stack: &mut Vec<PathBuf>,
+    ) -> Result<MergedConfig, ResolveImportError> {
+        let config_path = normalize_path(config_path);
+        if stack.contains(&config_path) {
+            return Err(ResolveImportError::ConfigError {
+                path: config_path,
+                message: "cyclic extends chain".to_string(),
+            });
+        }
+
+        let config_dir = config_path.parent().map(Path::to_path_buf).ok_or_else(|| {
+            ResolveImportError::ConfigError {
+                path: config_path.clone(),
+                message: "config has no parent directory".to_string(),
+            }
+        })?;
+        let raw = self.read_raw_config(&config_path)?;
+
+        stack.push(config_path.clone());
+        let mut merged = raw
+            .extends
+            .as_deref()
+            .and_then(|extends| resolve_local_extends(&config_dir, extends))
+            .filter(|path| path.is_file())
+            .map(|parent| self.load_merged_config_inner(&parent, stack))
+            .transpose()?
+            .unwrap_or_else(|| MergedConfig {
+                config_path: config_path.clone(),
+                config_dir: config_dir.clone(),
+                base_url: None,
+                paths: BTreeMap::new(),
+            });
+        let _ = stack.pop();
+
+        merged.config_path = config_path.clone();
+        merged.config_dir = config_dir.clone();
+        if let Some(base_url) = raw.base_url {
+            merged.base_url = Some(normalize_path(&config_dir.join(base_url)));
+        }
+        for (pattern, targets) in raw.paths {
+            merged.paths.insert(pattern, targets);
+        }
+        Ok(merged)
+    }
+
+    fn read_raw_config(&self, config_path: &Path) -> Result<RawConfig, ResolveImportError> {
+        let config_path = normalize_path(config_path);
+        let fingerprint =
+            file_fingerprint(&config_path).map_err(|message| ResolveImportError::ConfigError {
+                path: config_path.clone(),
+                message,
+            })?;
+
+        if let Ok(cache) = self.cache.read()
+            && let Some(cached) = cache.raw_configs.get(&config_path)
+            && cached.fingerprint == fingerprint
+        {
+            return cached.raw.clone();
+        }
+
+        let raw = parse_raw_config(&config_path);
+        if let Ok(mut cache) = self.cache.write() {
+            cache.raw_configs.insert(
+                config_path,
+                CachedRawConfig {
+                    fingerprint,
+                    raw: raw.clone(),
+                },
+            );
+        }
+        raw
+    }
+
+    fn probe_candidate(
+        &self,
+        candidate: &Path,
+        tried: &mut Vec<PathBuf>,
+    ) -> Result<PathBuf, ResolveImportError> {
+        let candidate = normalize_path(candidate);
+        self.ensure_inside_workspace(&candidate)?;
+
+        tried.push(candidate.clone());
+        if candidate.is_file() {
+            return Ok(candidate.canonicalize().unwrap_or(candidate));
+        }
+
+        if candidate.extension().is_none() {
+            for ext in PROBE_EXTENSIONS {
+                let mut with_ext = candidate.clone();
+                with_ext.set_extension(ext);
+                self.ensure_inside_workspace(&with_ext)?;
+                tried.push(with_ext.clone());
+                if with_ext.is_file() {
+                    return Ok(with_ext.canonicalize().unwrap_or(with_ext));
+                }
+            }
+        }
+
+        if candidate.is_dir() {
+            for index in INDEX_FILES {
+                let index_path = candidate.join(index);
+                self.ensure_inside_workspace(&index_path)?;
+                tried.push(index_path.clone());
+                if index_path.is_file() {
+                    return Ok(index_path.canonicalize().unwrap_or(index_path));
+                }
+            }
+        }
+
+        Err(ResolveImportError::NotFound {
+            tried: tried.clone(),
+        })
+    }
+
+    fn workspace_path(&self, path: &Path) -> Result<PathBuf, ResolveImportError> {
+        let candidate = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            self.workspace.join(path)
+        };
+        let normalized = normalize_path(&candidate);
+        self.ensure_inside_workspace(&normalized)?;
+        Ok(normalized)
+    }
+
+    fn ensure_inside_workspace(&self, path: &Path) -> Result<(), ResolveImportError> {
+        let normalized = normalize_path(path);
+        if normalized.starts_with(&self.workspace) {
+            Ok(())
+        } else {
+            Err(ResolveImportError::PathEscape { path: normalized })
+        }
+    }
+}
+
+fn parse_raw_config(config_path: &Path) -> Result<RawConfig, ResolveImportError> {
+    let content =
+        fs::read_to_string(config_path).map_err(|err| ResolveImportError::ConfigError {
+            path: config_path.to_path_buf(),
+            message: err.to_string(),
+        })?;
+    let cleaned = remove_trailing_commas(&strip_json_comments(&content));
+    let value: serde_json::Value =
+        serde_json::from_str(&cleaned).map_err(|err| ResolveImportError::ConfigError {
+            path: config_path.to_path_buf(),
+            message: err.to_string(),
+        })?;
+
+    let extends = value
+        .get("extends")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string);
+    let compiler_options = value
+        .get("compilerOptions")
+        .and_then(serde_json::Value::as_object);
+    let base_url = compiler_options
+        .and_then(|options| options.get("baseUrl"))
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string);
+    let mut paths = BTreeMap::new();
+    if let Some(paths_value) = compiler_options
+        .and_then(|options| options.get("paths"))
+        .and_then(serde_json::Value::as_object)
+    {
+        for (pattern, targets) in paths_value {
+            let targets = match targets {
+                serde_json::Value::Array(items) => items
+                    .iter()
+                    .filter_map(serde_json::Value::as_str)
+                    .map(str::to_string)
+                    .collect::<Vec<_>>(),
+                serde_json::Value::String(target) => vec![target.clone()],
+                _ => Vec::new(),
+            };
+            if !targets.is_empty() {
+                paths.insert(pattern.clone(), targets);
+            }
+        }
+    }
+
+    Ok(RawConfig {
+        extends,
+        base_url,
+        paths,
+    })
+}
+
+fn file_fingerprint(path: &Path) -> Result<FileFingerprint, String> {
+    let metadata = fs::metadata(path).map_err(|err| err.to_string())?;
+    Ok(FileFingerprint {
+        len: metadata.len(),
+        modified: metadata.modified().ok(),
+    })
+}
+
+fn resolve_local_extends(config_dir: &Path, extends: &str) -> Option<PathBuf> {
+    let raw = Path::new(extends);
+    if !(raw.is_absolute() || extends.starts_with('.')) {
+        return None;
+    }
+
+    let base = if raw.is_absolute() {
+        raw.to_path_buf()
+    } else {
+        config_dir.join(raw)
+    };
+    let mut candidates = vec![base.clone()];
+    if !extends.ends_with(".json") {
+        candidates.push(append_json_suffix(&base));
+        candidates.push(base.join("tsconfig.json"));
+    }
+    candidates
+        .into_iter()
+        .find(|candidate| candidate.is_file())
+        .map(|path| normalize_path(&path))
+}
+
+fn append_json_suffix(path: &Path) -> PathBuf {
+    let mut value = path.as_os_str().to_os_string();
+    value.push(".json");
+    PathBuf::from(value)
+}
+
+fn match_paths_pattern(pattern: &str, specifier: &str) -> Option<(String, usize)> {
+    let Some((prefix, suffix)) = pattern.split_once('*') else {
+        return (pattern == specifier).then(|| (String::new(), pattern.len()));
+    };
+    if !specifier.starts_with(prefix) || !specifier.ends_with(suffix) {
+        return None;
+    }
+    let capture_start = prefix.len();
+    let capture_end = specifier.len().checked_sub(suffix.len())?;
+    if capture_start > capture_end {
+        return None;
+    }
+    Some((
+        specifier[capture_start..capture_end].to_string(),
+        prefix.len(),
+    ))
+}
+
+fn replace_capture(target: &str, capture: &str) -> String {
+    if target.contains('*') {
+        target.replace('*', capture)
+    } else {
+        target.to_string()
+    }
+}
+
+fn is_relative_specifier(specifier: &str) -> bool {
+    specifier.starts_with("./") || specifier.starts_with("../")
+}
+
+fn is_base_url_candidate(specifier: &str) -> bool {
+    !specifier.starts_with('@') && specifier.contains('/')
+}
+
+fn is_probably_external_package(specifier: &str) -> bool {
+    if specifier.starts_with("@/") || specifier.starts_with("~/") || specifier.starts_with("#/") {
+        return false;
+    }
+    !is_relative_specifier(specifier) && !Path::new(specifier).is_absolute()
+}
+
+fn should_skip_scan_dir(name: &str) -> bool {
+    matches!(
+        name,
+        ".git"
+            | ".hg"
+            | ".svn"
+            | "node_modules"
+            | "target"
+            | "dist"
+            | "build"
+            | "coverage"
+            | ".next"
+            | ".turbo"
+            | ".cache"
+            | "vendor"
+    )
+}
+
+fn strip_json_comments(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+    let mut in_string = false;
+    let mut escaped = false;
+
+    while let Some(ch) = chars.next() {
+        if in_string {
+            out.push(ch);
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+
+        match ch {
+            '"' => {
+                in_string = true;
+                out.push(ch);
+            }
+            '/' if chars.peek() == Some(&'/') => {
+                let _ = chars.next();
+                for next in chars.by_ref() {
+                    if next == '\n' {
+                        out.push('\n');
+                        break;
+                    }
+                }
+            }
+            '/' if chars.peek() == Some(&'*') => {
+                let _ = chars.next();
+                let mut prev = '\0';
+                for next in chars.by_ref() {
+                    if next == '\n' {
+                        out.push('\n');
+                    }
+                    if prev == '*' && next == '/' {
+                        break;
+                    }
+                    prev = next;
+                }
+            }
+            _ => out.push(ch),
+        }
+    }
+
+    out
+}
+
+fn remove_trailing_commas(input: &str) -> String {
+    let chars: Vec<char> = input.chars().collect();
+    let mut out = String::with_capacity(input.len());
+    let mut in_string = false;
+    let mut escaped = false;
+    let mut i = 0;
+
+    while i < chars.len() {
+        let ch = chars[i];
+        if in_string {
+            out.push(ch);
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == '"' {
+                in_string = false;
+            }
+            i += 1;
+            continue;
+        }
+
+        if ch == '"' {
+            in_string = true;
+            out.push(ch);
+            i += 1;
+            continue;
+        }
+
+        if ch == ',' {
+            let mut j = i + 1;
+            while j < chars.len() && chars[j].is_whitespace() {
+                j += 1;
+            }
+            if j < chars.len() && matches!(chars[j], '}' | ']') {
+                i += 1;
+                continue;
+            }
+        }
+
+        out.push(ch);
+        i += 1;
+    }
+
+    out
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    let mut prefix: Option<std::ffi::OsString> = None;
+    let mut is_root = false;
+    let mut stack: Vec<std::ffi::OsString> = Vec::new();
+
+    for component in path.components() {
+        match component {
+            Component::Prefix(prefix_component) => {
+                prefix = Some(prefix_component.as_os_str().to_owned());
+            }
+            Component::RootDir => {
+                is_root = true;
+            }
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if stack.pop().is_none() && !is_root {
+                    stack.push(Component::ParentDir.as_os_str().to_owned());
+                }
+            }
+            Component::Normal(part) => {
+                stack.push(part.to_owned());
+            }
+        }
+    }
+
+    let mut normalized = PathBuf::new();
+    if let Some(prefix) = prefix {
+        normalized.push(prefix);
+    }
+    if is_root {
+        normalized.push(Path::new(std::path::MAIN_SEPARATOR_STR));
+    }
+    for part in stack {
+        normalized.push(part);
+    }
+    normalized
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn write(path: &Path, content: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("mkdir");
+        }
+        fs::write(path, content).expect("write");
+    }
+
+    fn request(specifier: &str, from: Option<&str>) -> ResolveImportRequest {
+        ResolveImportRequest {
+            specifier: specifier.to_string(),
+            from: from.map(PathBuf::from),
+            cwd_hint: None,
+            active_paths: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn resolves_single_project_alias() {
+        let tmp = tempdir().expect("tempdir");
+        write(
+            &tmp.path().join("apps/web/tsconfig.json"),
+            r#"{"compilerOptions":{"baseUrl":".","paths":{"@/*":["src/*"]}}}"#,
+        );
+        write(&tmp.path().join("apps/web/src/lib/api.ts"), "export {};");
+
+        let resolver = ModuleResolver::new(tmp.path());
+        let outcome = resolver
+            .resolve_import(request("@/lib/api", Some("apps/web/src/pages/Home.tsx")))
+            .expect("resolve");
+
+        assert_eq!(
+            resolver.workspace_relative_path(&outcome.resolved_path),
+            PathBuf::from("apps/web/src/lib/api.ts")
+        );
+        assert!(matches!(
+            outcome.rule,
+            ResolveRule::TsconfigPaths { ref pattern, .. } if pattern == "@/*"
+        ));
+    }
+
+    #[test]
+    fn resolves_same_alias_from_different_projects() {
+        let tmp = tempdir().expect("tempdir");
+        for app in ["web", "admin"] {
+            write(
+                &tmp.path().join(format!("apps/{app}/tsconfig.json")),
+                r#"{"compilerOptions":{"baseUrl":".","paths":{"@/*":["src/*"]}}}"#,
+            );
+            write(
+                &tmp.path()
+                    .join(format!("apps/{app}/src/components/Button.tsx")),
+                app,
+            );
+        }
+
+        let resolver = ModuleResolver::new(tmp.path());
+        let web = resolver
+            .resolve_import(request(
+                "@/components/Button",
+                Some("apps/web/src/pages/Home.tsx"),
+            ))
+            .expect("resolve web");
+        let admin = resolver
+            .resolve_import(request(
+                "@/components/Button",
+                Some("apps/admin/src/pages/Home.tsx"),
+            ))
+            .expect("resolve admin");
+
+        assert_eq!(
+            resolver.workspace_relative_path(&web.resolved_path),
+            PathBuf::from("apps/web/src/components/Button.tsx")
+        );
+        assert_eq!(
+            resolver.workspace_relative_path(&admin.resolved_path),
+            PathBuf::from("apps/admin/src/components/Button.tsx")
+        );
+    }
+
+    #[test]
+    fn returns_ambiguous_without_importer_context() {
+        let tmp = tempdir().expect("tempdir");
+        for app in ["web", "admin"] {
+            write(
+                &tmp.path().join(format!("apps/{app}/tsconfig.json")),
+                r#"{"compilerOptions":{"baseUrl":".","paths":{"@/*":["src/*"]}}}"#,
+            );
+            write(
+                &tmp.path()
+                    .join(format!("apps/{app}/src/components/Button.tsx")),
+                app,
+            );
+        }
+
+        let resolver = ModuleResolver::new(tmp.path());
+        let err = resolver
+            .resolve_import(request("@/components/Button", None))
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            ResolveImportError::AmbiguousProject { ref candidates } if candidates.len() == 2
+        ));
+    }
+
+    #[test]
+    fn extends_merges_parent_paths_and_child_overrides() {
+        let tmp = tempdir().expect("tempdir");
+        write(
+            &tmp.path().join("tsconfig.base.json"),
+            r#"{"compilerOptions":{"baseUrl":".","paths":{"@shared/*":["packages/shared/src/*"],"@/*":["root/*"]}}}"#,
+        );
+        write(
+            &tmp.path().join("apps/web/tsconfig.json"),
+            r#"{"extends":"../../tsconfig.base","compilerOptions":{"baseUrl":"../..","paths":{"@/*":["apps/web/src/*"]}}}"#,
+        );
+        write(&tmp.path().join("apps/web/src/lib/api.ts"), "web");
+        write(&tmp.path().join("packages/shared/src/theme.ts"), "shared");
+
+        let resolver = ModuleResolver::new(tmp.path());
+        let child = resolver
+            .resolve_import(request("@/lib/api", Some("apps/web/src/pages/Home.tsx")))
+            .expect("child alias");
+        let parent = resolver
+            .resolve_import(request(
+                "@shared/theme",
+                Some("apps/web/src/pages/Home.tsx"),
+            ))
+            .expect("parent alias");
+
+        assert_eq!(
+            resolver.workspace_relative_path(&child.resolved_path),
+            PathBuf::from("apps/web/src/lib/api.ts")
+        );
+        assert_eq!(
+            resolver.workspace_relative_path(&parent.resolved_path),
+            PathBuf::from("packages/shared/src/theme.ts")
+        );
+    }
+
+    #[test]
+    fn longest_prefix_wins() {
+        let tmp = tempdir().expect("tempdir");
+        write(
+            &tmp.path().join("apps/web/tsconfig.json"),
+            r#"{"compilerOptions":{"baseUrl":".","paths":{"@/*":["src/*"],"@ui/*":["src/ui/*"]}}}"#,
+        );
+        write(&tmp.path().join("apps/web/src/ui/Button.tsx"), "ui");
+
+        let resolver = ModuleResolver::new(tmp.path());
+        let outcome = resolver
+            .resolve_import(request("@ui/Button", Some("apps/web/src/pages/Home.tsx")))
+            .expect("resolve");
+
+        assert_eq!(
+            resolver.workspace_relative_path(&outcome.resolved_path),
+            PathBuf::from("apps/web/src/ui/Button.tsx")
+        );
+        assert!(matches!(
+            outcome.rule,
+            ResolveRule::TsconfigPaths { ref pattern, .. } if pattern == "@ui/*"
+        ));
+    }
+
+    #[test]
+    fn probes_extensions_and_index_files() {
+        let tmp = tempdir().expect("tempdir");
+        write(
+            &tmp.path().join("apps/web/tsconfig.json"),
+            r#"{"compilerOptions":{"baseUrl":".","paths":{"@/*":["src/*"]}}}"#,
+        );
+        write(
+            &tmp.path().join("apps/web/src/components/Button.tsx"),
+            "tsx",
+        );
+        write(&tmp.path().join("apps/web/src/routes/index.ts"), "index");
+
+        let resolver = ModuleResolver::new(tmp.path());
+        let component = resolver
+            .resolve_import(request(
+                "@/components/Button",
+                Some("apps/web/src/pages/Home.tsx"),
+            ))
+            .expect("component");
+        let index = resolver
+            .resolve_import(request("@/routes", Some("apps/web/src/pages/Home.tsx")))
+            .expect("index");
+
+        assert_eq!(
+            resolver.workspace_relative_path(&component.resolved_path),
+            PathBuf::from("apps/web/src/components/Button.tsx")
+        );
+        assert_eq!(
+            resolver.workspace_relative_path(&index.resolved_path),
+            PathBuf::from("apps/web/src/routes/index.ts")
+        );
+    }
+
+    #[test]
+    fn scoped_package_is_external_without_matching_alias() {
+        let tmp = tempdir().expect("tempdir");
+        write(
+            &tmp.path().join("apps/web/tsconfig.json"),
+            r#"{"compilerOptions":{"baseUrl":".","paths":{"@/*":["src/*"]}}}"#,
+        );
+
+        let resolver = ModuleResolver::new(tmp.path());
+        let err = resolver
+            .resolve_import(request("@scope/pkg", Some("apps/web/src/pages/Home.tsx")))
+            .unwrap_err();
+
+        assert_eq!(err, ResolveImportError::ExternalPackage);
+    }
+
+    #[test]
+    fn rejects_alias_targets_that_escape_workspace() {
+        let tmp = tempdir().expect("tempdir");
+        write(
+            &tmp.path().join("apps/web/tsconfig.json"),
+            r#"{"compilerOptions":{"baseUrl":".","paths":{"@/*":["../../../../outside/*"]}}}"#,
+        );
+
+        let resolver = ModuleResolver::new(tmp.path());
+        let err = resolver
+            .resolve_import(request("@/secret", Some("apps/web/src/pages/Home.tsx")))
+            .unwrap_err();
+
+        assert!(matches!(err, ResolveImportError::PathEscape { .. }));
+    }
+
+    #[test]
+    fn parses_jsonc_comments_and_trailing_commas() {
+        let tmp = tempdir().expect("tempdir");
+        write(
+            &tmp.path().join("apps/web/tsconfig.json"),
+            r#"
+            {
+              // comment
+              "compilerOptions": {
+                "baseUrl": ".",
+                "paths": {
+                  "@/*": ["src/*",],
+                },
+              },
+            }
+            "#,
+        );
+        write(&tmp.path().join("apps/web/src/lib/api.ts"), "api");
+
+        let resolver = ModuleResolver::new(tmp.path());
+        let outcome = resolver
+            .resolve_import(request("@/lib/api", Some("apps/web/src/pages/Home.tsx")))
+            .expect("resolve jsonc");
+
+        assert_eq!(
+            resolver.workspace_relative_path(&outcome.resolved_path),
+            PathBuf::from("apps/web/src/lib/api.ts")
+        );
+    }
+}

--- a/crates/tui/src/prompts/base.md
+++ b/crates/tui/src/prompts/base.md
@@ -48,6 +48,10 @@ After every tool call that produces a result you'll act on, verify before procee
 
 Don't claim a change worked until you've observed evidence. Don't trust memory over live tool output.
 
+## Frontend Import Aliases
+
+When reading frontend imports in monorepos, don't pass alias specifiers such as `@/x` directly to `read_file`. First call `resolve_import` with the specifier and the importing file path, then read the returned concrete path. If `resolve_import` reports ambiguity, use the importer path from the working set or ask for it before proceeding.
+
 ## Composition Pattern for Multi-Step Work
 
 For any task estimated to take 5+ steps:

--- a/crates/tui/src/prompts/base.txt
+++ b/crates/tui/src/prompts/base.txt
@@ -14,6 +14,10 @@ Your default workflow for any non-trivial request:
 
 **Key principle**: make your work visible. The sidebar shows Plan / Todos / Tasks / Agents. When these panels are empty, the user has no idea what you're doing. Keep them populated.
 
+## Frontend Import Aliases
+
+When reading frontend imports in monorepos, don't pass alias specifiers such as `@/x` directly to `read_file`. First call `resolve_import` with the specifier and the importing file path, then read the returned concrete path. If `resolve_import` reports ambiguity, use the importer path from the working set or ask for it before proceeding.
+
 ## RLM Is a Specialty Tool
 
 `rlm` is for one specific shape of work: a long input that genuinely does not fit in your context (a whole file > ~50K tokens, a long transcript, a multi-document corpus). Reach for it ONLY when direct reasoning over the input is impossible because of its size. For everything else — short inputs, focused questions, parallel exploration — use `read_file`, `grep_files`, or `agent_spawn` instead.

--- a/crates/tui/src/prompts/subagent_output_format.md
+++ b/crates/tui/src/prompts/subagent_output_format.md
@@ -54,6 +54,8 @@ workspace boundary. Reach for `exec_shell` only for things the typed tools do
 not cover (build, test, format, lint, ad-hoc one-liners).
 
 - Read a file: `read_file` (NOT `exec_shell` with `cat`/`head`/`tail`).
+- Resolve a frontend alias import: `resolve_import` first, then `read_file`
+  the returned concrete path.
 - List a directory: `list_dir` (NOT `exec_shell` with `ls`).
 - Search file contents: `grep_files` (NOT `exec_shell` with `rg`/`grep`).
 - Find files by name: `file_search` (NOT `exec_shell` with `find`).

--- a/crates/tui/src/tools/file.rs
+++ b/crates/tui/src/tools/file.rs
@@ -4,14 +4,16 @@
 //! with path validation to prevent escaping the workspace boundary.
 
 use super::diff_format::make_unified_diff;
+use super::module_resolve::{import_error_message, resolver_for_context};
 use super::spec::{
     ApprovalRequirement, ToolCapability, ToolContext, ToolError, ToolResult, ToolSpec,
     optional_str, required_str,
 };
+use crate::module_resolver::ResolveImportRequest;
 use async_trait::async_trait;
 use serde_json::{Value, json};
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 // === ReadFileTool ===
@@ -40,6 +42,10 @@ impl ToolSpec for ReadFileTool {
                 "pages": {
                     "type": "string",
                     "description": "PDF only: page range to extract, e.g. \"1-5\" or \"10\". Ignored for non-PDF files."
+                },
+                "from": {
+                    "type": "string",
+                    "description": "Optional importer file path used to resolve frontend import aliases such as '@/components/Button'."
                 }
             },
             "required": ["path"]
@@ -56,19 +62,77 @@ impl ToolSpec for ReadFileTool {
 
     async fn execute(&self, input: Value, context: &ToolContext) -> Result<ToolResult, ToolError> {
         let path_str = required_str(&input, "path")?;
-        let file_path = context.resolve_path(path_str)?;
         let pages = optional_str(&input, "pages");
+        let from = optional_str(&input, "from");
+        let direct_path = context.resolve_path(path_str);
 
-        if is_pdf(&file_path)? {
-            return read_pdf(&file_path, pages);
+        if let Ok(file_path) = direct_path.as_ref()
+            && file_path.exists()
+        {
+            return read_file_contents(file_path, pages);
         }
 
-        let contents = fs::read_to_string(&file_path).map_err(|e| {
-            ToolError::execution_failed(format!("Failed to read {}: {}", file_path.display(), e))
-        })?;
+        if should_try_import_fallback(path_str, from, direct_path.as_ref().ok()) {
+            let resolved = resolve_import_for_read(path_str, from, context)?;
+            return read_file_contents(&resolved, pages);
+        }
 
-        Ok(ToolResult::success(contents))
+        let file_path = direct_path?;
+        read_file_contents(&file_path, pages)
     }
+}
+
+fn read_file_contents(file_path: &Path, pages: Option<&str>) -> Result<ToolResult, ToolError> {
+    if is_pdf(file_path)? {
+        return read_pdf(file_path, pages);
+    }
+
+    let contents = fs::read_to_string(file_path).map_err(|e| {
+        ToolError::execution_failed(format!("Failed to read {}: {}", file_path.display(), e))
+    })?;
+
+    Ok(ToolResult::success(contents))
+}
+
+fn resolve_import_for_read(
+    path_str: &str,
+    from: Option<&str>,
+    context: &ToolContext,
+) -> Result<PathBuf, ToolError> {
+    let resolver = resolver_for_context(context);
+    let from_path = from.map(PathBuf::from);
+    let request = ResolveImportRequest {
+        specifier: path_str.to_string(),
+        from: from_path.clone(),
+        cwd_hint: context.cwd_hint.clone(),
+        active_paths: context.active_paths.clone(),
+    };
+
+    match resolver.resolve_import(request) {
+        Ok(outcome) => context.resolve_path(&outcome.resolved_path.to_string_lossy()),
+        Err(err) => Err(ToolError::execution_failed(format!(
+            "Failed to resolve import specifier `{}`: {}",
+            path_str,
+            import_error_message(&resolver, path_str, from_path.as_deref(), &err)
+        ))),
+    }
+}
+
+fn should_try_import_fallback(
+    path_str: &str,
+    from: Option<&str>,
+    direct_path: Option<&PathBuf>,
+) -> bool {
+    if direct_path.is_some_and(|path| path.exists()) || Path::new(path_str).is_absolute() {
+        return false;
+    }
+    if path_str.starts_with("@") || path_str.starts_with("~/") || path_str.starts_with("#/") {
+        return true;
+    }
+    from.is_some()
+        && (path_str.starts_with("./")
+            || path_str.starts_with("../")
+            || (path_str.contains('/') && !path_str.starts_with('/')))
 }
 
 /// Detect a PDF by extension OR by sniffing the `%PDF-` magic bytes.
@@ -455,6 +519,67 @@ mod tests {
         let result = tool.execute(json!({"path": "nonexistent.txt"}), &ctx).await;
 
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn read_file_resolves_frontend_alias_with_from() {
+        let tmp = tempdir().expect("tempdir");
+        let ctx = ToolContext::new(tmp.path().to_path_buf());
+        fs::create_dir_all(tmp.path().join("apps/web/src/components")).expect("mkdir");
+        fs::write(
+            tmp.path().join("apps/web/tsconfig.json"),
+            r#"{"compilerOptions":{"baseUrl":".","paths":{"@/*":["src/*"]}}}"#,
+        )
+        .expect("write config");
+        fs::write(
+            tmp.path().join("apps/web/src/components/Button.tsx"),
+            "export const Button = () => null;",
+        )
+        .expect("write component");
+
+        let result = ReadFileTool
+            .execute(
+                json!({
+                    "path": "@/components/Button",
+                    "from": "apps/web/src/pages/Home.tsx"
+                }),
+                &ctx,
+            )
+            .await
+            .expect("execute");
+
+        assert!(result.success);
+        assert!(result.content.contains("Button"));
+    }
+
+    #[tokio::test]
+    async fn read_file_reports_ambiguous_alias_without_from() {
+        let tmp = tempdir().expect("tempdir");
+        let ctx = ToolContext::new(tmp.path().to_path_buf());
+        for app in ["web", "admin"] {
+            fs::create_dir_all(tmp.path().join(format!("apps/{app}/src/components")))
+                .expect("mkdir");
+            fs::write(
+                tmp.path().join(format!("apps/{app}/tsconfig.json")),
+                r#"{"compilerOptions":{"baseUrl":".","paths":{"@/*":["src/*"]}}}"#,
+            )
+            .expect("write config");
+            fs::write(
+                tmp.path()
+                    .join(format!("apps/{app}/src/components/Button.tsx")),
+                "button",
+            )
+            .expect("write component");
+        }
+
+        let err = ReadFileTool
+            .execute(json!({"path": "@/components/Button"}), &ctx)
+            .await
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("ambiguous_project"), "{err}");
+        assert!(err.contains("Pass `from`"), "{err}");
     }
 
     #[tokio::test]

--- a/crates/tui/src/tools/mod.rs
+++ b/crates/tui/src/tools/mod.rs
@@ -13,6 +13,7 @@ pub mod fetch_url;
 pub mod git;
 pub mod git_history;
 pub mod github;
+pub mod module_resolve;
 pub mod parallel;
 pub mod plan;
 pub mod project;

--- a/crates/tui/src/tools/module_resolve.rs
+++ b/crates/tui/src/tools/module_resolve.rs
@@ -1,0 +1,270 @@
+//! Read-only tool for resolving frontend import specifiers to workspace files.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+use crate::module_resolver::{
+    ModuleResolver, ResolveImportError, ResolveImportOutcome, ResolveImportRequest, ResolveRule,
+};
+
+use super::spec::{
+    ToolCapability, ToolContext, ToolError, ToolResult, ToolSpec, optional_str, required_str,
+};
+
+pub struct ResolveImportTool;
+
+#[async_trait]
+impl ToolSpec for ResolveImportTool {
+    fn name(&self) -> &'static str {
+        "resolve_import"
+    }
+
+    fn description(&self) -> &'static str {
+        "Resolve a frontend import specifier (for example '@/components/Button') to a concrete workspace file using the importing file's tsconfig/jsconfig aliases."
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "specifier": {
+                    "type": "string",
+                    "description": "Import specifier exactly as written in source, e.g. '@/components/Button'."
+                },
+                "from": {
+                    "type": "string",
+                    "description": "Importer file path relative to workspace, e.g. 'apps/web/src/pages/Home.tsx'."
+                }
+            },
+            "required": ["specifier"]
+        })
+    }
+
+    fn capabilities(&self) -> Vec<ToolCapability> {
+        vec![ToolCapability::ReadOnly, ToolCapability::Sandboxable]
+    }
+
+    fn supports_parallel(&self) -> bool {
+        true
+    }
+
+    async fn execute(&self, input: Value, context: &ToolContext) -> Result<ToolResult, ToolError> {
+        let specifier = required_str(&input, "specifier")?.to_string();
+        let from = optional_str(&input, "from").map(PathBuf::from);
+        let resolver = resolver_for_context(context);
+        let request = ResolveImportRequest {
+            specifier: specifier.clone(),
+            from: from.clone(),
+            cwd_hint: context.cwd_hint.clone(),
+            active_paths: context.active_paths.clone(),
+        };
+
+        match resolver.resolve_import(request) {
+            Ok(outcome) => ToolResult::json(&success_json(
+                &resolver,
+                &specifier,
+                from.as_deref(),
+                outcome,
+            ))
+            .map_err(|err| ToolError::execution_failed(format!("serialize result: {err}"))),
+            Err(err) => ToolResult::json(&error_json(&resolver, &specifier, from.as_deref(), &err))
+                .map_err(|err| ToolError::execution_failed(format!("serialize result: {err}"))),
+        }
+    }
+}
+
+pub(crate) fn resolver_for_context(context: &ToolContext) -> Arc<ModuleResolver> {
+    context
+        .module_resolver
+        .clone()
+        .unwrap_or_else(|| Arc::new(ModuleResolver::new(context.workspace.clone())))
+}
+
+pub(crate) fn import_error_message(
+    resolver: &ModuleResolver,
+    specifier: &str,
+    from: Option<&Path>,
+    err: &ResolveImportError,
+) -> String {
+    let value = error_json(resolver, specifier, from, err);
+    value.to_string()
+}
+
+fn success_json(
+    resolver: &ModuleResolver,
+    specifier: &str,
+    from: Option<&Path>,
+    outcome: ResolveImportOutcome,
+) -> Value {
+    json!({
+        "specifier": specifier,
+        "from": from.map(|path| path.to_string_lossy().replace('\\', "/")),
+        "resolved_path": rel_string(resolver, &outcome.resolved_path),
+        "project_root": rel_string(resolver, &outcome.project_root),
+        "config_path": outcome.config_path.as_deref().map(|path| rel_string(resolver, path)),
+        "rule": rule_json(outcome.rule),
+        "tried": outcome
+            .tried
+            .iter()
+            .map(|path| rel_string(resolver, path))
+            .collect::<Vec<_>>(),
+    })
+}
+
+fn error_json(
+    resolver: &ModuleResolver,
+    specifier: &str,
+    from: Option<&Path>,
+    err: &ResolveImportError,
+) -> Value {
+    match err {
+        ResolveImportError::AmbiguousProject { candidates } => json!({
+            "error": "ambiguous_project",
+            "specifier": specifier,
+            "from": from.map(|path| path.to_string_lossy().replace('\\', "/")),
+            "message": "Multiple frontend project configs can resolve this alias. Pass `from`.",
+            "candidates": candidates
+                .iter()
+                .map(|path| rel_string(resolver, path))
+                .collect::<Vec<_>>(),
+        }),
+        ResolveImportError::MissingContext => json!({
+            "error": "missing_context",
+            "specifier": specifier,
+            "from": from.map(|path| path.to_string_lossy().replace('\\', "/")),
+            "message": "Pass `from` with the importer file path so the project alias config can be selected.",
+        }),
+        ResolveImportError::ExternalPackage => json!({
+            "error": "external_package",
+            "specifier": specifier,
+            "from": from.map(|path| path.to_string_lossy().replace('\\', "/")),
+            "message": "This specifier appears to be an external package, not a workspace file.",
+        }),
+        ResolveImportError::NoMatchingAlias => json!({
+            "error": "no_matching_alias",
+            "specifier": specifier,
+            "from": from.map(|path| path.to_string_lossy().replace('\\', "/")),
+            "message": "No local tsconfig/jsconfig alias rule matched this specifier.",
+        }),
+        ResolveImportError::NotFound { tried } => json!({
+            "error": "not_found",
+            "specifier": specifier,
+            "from": from.map(|path| path.to_string_lossy().replace('\\', "/")),
+            "message": "Matched a local import rule, but no file was found after extension/index probing.",
+            "tried": tried
+                .iter()
+                .map(|path| rel_string(resolver, path))
+                .collect::<Vec<_>>(),
+        }),
+        ResolveImportError::PathEscape { path } => json!({
+            "error": "path_escape",
+            "specifier": specifier,
+            "from": from.map(|path| path.to_string_lossy().replace('\\', "/")),
+            "message": "Resolved import path escapes the workspace.",
+            "path": rel_string(resolver, path),
+        }),
+        ResolveImportError::ConfigError { path, message } => json!({
+            "error": "config_error",
+            "specifier": specifier,
+            "from": from.map(|path| path.to_string_lossy().replace('\\', "/")),
+            "message": message,
+            "config_path": rel_string(resolver, path),
+        }),
+    }
+}
+
+fn rule_json(rule: ResolveRule) -> Value {
+    match rule {
+        ResolveRule::Relative => json!({"kind": "relative"}),
+        ResolveRule::FilePath => json!({"kind": "file_path"}),
+        ResolveRule::TsconfigPaths { pattern, target } => {
+            json!({"kind": "tsconfig_paths", "pattern": pattern, "target": target})
+        }
+        ResolveRule::BaseUrl { base_url } => json!({"kind": "base_url", "base_url": base_url}),
+    }
+}
+
+fn rel_string(resolver: &ModuleResolver, path: &Path) -> String {
+    resolver
+        .workspace_relative_path(path)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tools::spec::ToolContext;
+    use tempfile::tempdir;
+
+    fn write(path: &Path, content: &str) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("mkdir");
+        }
+        std::fs::write(path, content).expect("write");
+    }
+
+    #[tokio::test]
+    async fn resolve_import_tool_returns_resolved_json() {
+        let tmp = tempdir().expect("tempdir");
+        write(
+            &tmp.path().join("apps/web/tsconfig.json"),
+            r#"{"compilerOptions":{"baseUrl":".","paths":{"@/*":["src/*"]}}}"#,
+        );
+        write(
+            &tmp.path().join("apps/web/src/components/Button.tsx"),
+            "button",
+        );
+        let ctx = ToolContext::new(tmp.path());
+
+        let result = ResolveImportTool
+            .execute(
+                json!({
+                    "specifier": "@/components/Button",
+                    "from": "apps/web/src/pages/Home.tsx"
+                }),
+                &ctx,
+            )
+            .await
+            .expect("execute");
+
+        assert!(result.success);
+        assert!(result.content.contains("\"resolved_path\""));
+        assert!(
+            result
+                .content
+                .contains("apps/web/src/components/Button.tsx")
+        );
+        assert!(result.content.contains("\"tsconfig_paths\""));
+    }
+
+    #[tokio::test]
+    async fn resolve_import_tool_returns_ambiguous_json() {
+        let tmp = tempdir().expect("tempdir");
+        for app in ["web", "admin"] {
+            write(
+                &tmp.path().join(format!("apps/{app}/tsconfig.json")),
+                r#"{"compilerOptions":{"baseUrl":".","paths":{"@/*":["src/*"]}}}"#,
+            );
+            write(
+                &tmp.path()
+                    .join(format!("apps/{app}/src/components/Button.tsx")),
+                "button",
+            );
+        }
+        let ctx = ToolContext::new(tmp.path());
+
+        let result = ResolveImportTool
+            .execute(json!({"specifier": "@/components/Button"}), &ctx)
+            .await
+            .expect("execute");
+
+        assert!(result.success);
+        assert!(result.content.contains("\"ambiguous_project\""));
+        assert!(result.content.contains("apps/web/tsconfig.json"));
+        assert!(result.content.contains("apps/admin/tsconfig.json"));
+    }
+}

--- a/crates/tui/src/tools/registry.rs
+++ b/crates/tui/src/tools/registry.rs
@@ -315,6 +315,13 @@ impl ToolRegistryBuilder {
             .with_tool(Arc::new(ListDirTool))
     }
 
+    /// Include frontend import alias resolution.
+    #[must_use]
+    pub fn with_module_resolve_tool(self) -> Self {
+        use super::module_resolve::ResolveImportTool;
+        self.with_tool(Arc::new(ResolveImportTool))
+    }
+
     /// Include shell execution tool.
     #[must_use]
     pub fn with_shell_tools(self) -> Self {
@@ -566,6 +573,7 @@ impl ToolRegistryBuilder {
             .with_git_tools()
             .with_git_history_tools()
             .with_diagnostics_tool()
+            .with_module_resolve_tool()
             .with_project_tools()
             .with_skill_tools()
             .with_test_runner_tool()

--- a/crates/tui/src/tools/spec.rs
+++ b/crates/tui/src/tools/spec.rs
@@ -7,12 +7,14 @@
 //! - `ToolCapability`: Capabilities and requirements of tools
 
 use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use serde_json::Value;
 use tokio_util::sync::CancellationToken;
 
 use crate::features::Features;
+use crate::module_resolver::ModuleResolver;
 use crate::network_policy::NetworkPolicyDecider;
 use crate::tools::shell::{SharedShellManager, new_shared_shell_manager};
 #[allow(unused_imports)]
@@ -97,6 +99,15 @@ pub struct ToolContext {
     /// Durable runtime services for task, gate, PR-attempt, GitHub evidence,
     /// and automation tools.
     pub runtime: RuntimeToolServices,
+    /// Hint for resolving frontend import aliases when the importer file is
+    /// not explicitly supplied.
+    pub cwd_hint: Option<PathBuf>,
+    /// High-priority workspace paths recently mentioned or read in the
+    /// session. Used only as importer hints for read-only import resolution.
+    pub active_paths: Vec<PathBuf>,
+    /// Shared frontend module resolver. Kept outside `resolve_path` so the
+    /// filesystem safety boundary stays independent from language semantics.
+    pub module_resolver: Option<Arc<ModuleResolver>>,
     /// Cancellation token for the active engine turn. Tools that may wait on
     /// external work should observe this so UI cancel can interrupt them.
     pub cancel_token: Option<CancellationToken>,
@@ -115,6 +126,7 @@ impl ToolContext {
         let shell_manager = new_shared_shell_manager(workspace.clone());
         let notes_path = workspace.join(".deepseek").join("notes.md");
         let mcp_config_path = workspace.join(".deepseek").join("mcp.json");
+        let module_resolver = Some(Arc::new(ModuleResolver::new(workspace.clone())));
         Self {
             workspace,
             shell_manager,
@@ -129,6 +141,9 @@ impl ToolContext {
             trusted_external_paths: Vec::new(),
             network_policy: None,
             runtime: RuntimeToolServices::default(),
+            cwd_hint: None,
+            active_paths: Vec::new(),
+            module_resolver,
             cancel_token: None,
             memory_path: None,
         }
@@ -144,6 +159,7 @@ impl ToolContext {
     ) -> Self {
         let workspace = workspace.into();
         let shell_manager = new_shared_shell_manager(workspace.clone());
+        let module_resolver = Some(Arc::new(ModuleResolver::new(workspace.clone())));
         Self {
             workspace,
             shell_manager,
@@ -158,6 +174,9 @@ impl ToolContext {
             trusted_external_paths: Vec::new(),
             network_policy: None,
             runtime: RuntimeToolServices::default(),
+            cwd_hint: None,
+            active_paths: Vec::new(),
+            module_resolver,
             cancel_token: None,
             memory_path: None,
         }
@@ -173,6 +192,7 @@ impl ToolContext {
     ) -> Self {
         let workspace = workspace.into();
         let shell_manager = new_shared_shell_manager(workspace.clone());
+        let module_resolver = Some(Arc::new(ModuleResolver::new(workspace.clone())));
         Self {
             workspace,
             shell_manager,
@@ -187,6 +207,9 @@ impl ToolContext {
             trusted_external_paths: Vec::new(),
             network_policy: None,
             runtime: RuntimeToolServices::default(),
+            cwd_hint: None,
+            active_paths: Vec::new(),
+            module_resolver,
             cancel_token: None,
             memory_path: None,
         }
@@ -203,6 +226,29 @@ impl ToolContext {
     #[must_use]
     pub fn with_runtime_services(mut self, runtime: RuntimeToolServices) -> Self {
         self.runtime = runtime;
+        self
+    }
+
+    /// Set the current process or project CWD hint used by `resolve_import`
+    /// when the caller omits `from`.
+    #[must_use]
+    pub fn with_cwd_hint(mut self, cwd: Option<PathBuf>) -> Self {
+        self.cwd_hint = cwd;
+        self
+    }
+
+    /// Attach active working-set paths as importer hints for read-only module
+    /// resolution. Relative paths are interpreted from the workspace root.
+    #[must_use]
+    pub fn with_active_paths(mut self, paths: Vec<String>) -> Self {
+        self.active_paths = paths.into_iter().map(PathBuf::from).collect();
+        self
+    }
+
+    /// Attach a shared module resolver cache.
+    #[must_use]
+    pub fn with_module_resolver(mut self, resolver: Arc<ModuleResolver>) -> Self {
+        self.module_resolver = Some(resolver);
         self
     }
 

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -251,6 +251,7 @@ impl SubAgentType {
             Self::General => vec![
                 "list_dir",
                 "read_file",
+                "resolve_import",
                 "write_file",
                 "edit_file",
                 "apply_patch",
@@ -277,6 +278,7 @@ impl SubAgentType {
             Self::Explore => vec![
                 "list_dir",
                 "read_file",
+                "resolve_import",
                 "grep_files",
                 "file_search",
                 "web.run",
@@ -290,6 +292,7 @@ impl SubAgentType {
             Self::Plan => vec![
                 "list_dir",
                 "read_file",
+                "resolve_import",
                 "grep_files",
                 "file_search",
                 "web.run",
@@ -304,10 +307,18 @@ impl SubAgentType {
                 "todo_update",
                 "todo_list",
             ],
-            Self::Review => vec!["list_dir", "read_file", "grep_files", "file_search", "note"],
+            Self::Review => vec![
+                "list_dir",
+                "read_file",
+                "resolve_import",
+                "grep_files",
+                "file_search",
+                "note",
+            ],
             Self::Implementer => vec![
                 "list_dir",
                 "read_file",
+                "resolve_import",
                 "write_file",
                 "edit_file",
                 "apply_patch",
@@ -332,6 +343,7 @@ impl SubAgentType {
             Self::Verifier => vec![
                 "list_dir",
                 "read_file",
+                "resolve_import",
                 "grep_files",
                 "file_search",
                 "exec_shell",


### PR DESCRIPTION
## Summary

本 PR 为 TUI 工具层新增前端 import alias 解析能力，使模型在阅读前端项目代码时可以通过 `tsconfig.json` / `jsconfig.json` 中的 `baseUrl` 和 `paths` 配置正确定位别名导入文件。

核心变化包括：

- 新增 `ModuleResolver`，支持解析 TypeScript/JavaScript 项目的 import alias。
- 新增 `resolve_import` 工具，用于显式解析 import specifier。
- 扩展 `read_file`，在直接路径不存在时可根据 `from` 上下文自动解析前端别名。
- 将 resolver 注入 Engine 和 ToolContext，并让默认工具集、Plan 模式和子代理提示都能使用该能力。
- 更新系统提示，指导模型在读取别名导入前优先使用 `resolve_import`。

## Motivation

在现代前端项目中，导入路径经常不是普通相对路径，而是类似：

```ts
import Button from "@/components/Button"
import { api } from "~/lib/api"
import Card from "@app/ui/Card"
```

这些路径通常依赖 `tsconfig.json` 或 `jsconfig.json` 中的 `baseUrl` / `paths` 配置。此前工具层只能按文件系统路径读取文件，模型在遇到 alias import 时容易出现以下问题：

- 无法判断 alias 对应的真实文件位置。
- 多个前端子项目拥有相同 alias 时无法区分上下文。
- `read_file` 读取 `@/...`、`~/...` 等路径时直接失败。
- 需要模型手动猜测路径，容易浪费上下文并降低代码导航质量。

本 PR 按 `docs/planer.md` 方案实现了一个受限、只读、可缓存、不会执行项目配置代码的 resolver，用于提升前端代码阅读和工具调用体验。

## Changes

### 1. 新增 `ModuleResolver`

新增 `crates/tui/src/module_resolver.rs`，实现前端模块路径解析器。

支持能力：

- 自动发现 workspace 内的 `tsconfig.json` / `jsconfig.json`。
- 支持 JSONC 风格配置：
  - 行注释
  - 块注释
  - trailing comma
- 支持本地 `extends` 链路合并。
- 支持 `compilerOptions.baseUrl`。
- 支持 `compilerOptions.paths`。
- 支持 longest-prefix alias 匹配。
- 支持扩展名探测：
  - `.ts`
  - `.tsx`
  - `.js`
  - `.jsx`
  - `.mjs`
  - `.cjs`
  - `.json`
- 支持目录 index 探测。
- 支持相对导入、绝对路径和 alias 导入。
- 支持多项目场景下基于 `from`、cwd hint、active paths 选择最近配置。
- 支持配置缓存，基于文件 `mtime` 和 `len` 指纹避免重复解析。
- 跳过常见无关目录，例如：
  - `node_modules`
  - `target`
  - `dist`
  - `build`
  - `.git`
  - `vendor`

安全和边界处理：

- 不执行 JS/TS 配置文件。
- resolver 内部拒绝 path escape。
- 最终读取文件前仍通过 `ToolContext::resolve_path` 做权限校验。
- 将外部 package、缺少上下文、多项目歧义、配置错误、未匹配 alias、文件不存在等情况区分为结构化错误。

### 2. 新增 `resolve_import` 工具

新增 `crates/tui/src/tools/module_resolve.rs`，注册新的只读工具：

```json
{
  "specifier": "@/components/Button",
  "from": "src/pages/Home.tsx"
}
```

成功时返回结构化 JSON，包括：

- 原始 specifier
- from 上下文
- 解析后的真实路径
- project root
- config path
- 命中的 alias rule
- 尝试过的候选路径

失败时返回结构化错误，例如：

- `external_package`
- `missing_context`
- `ambiguous_project`
- `no_matching_alias`
- `not_found`
- `path_escape`
- `config_error`

该工具被标记为：

- `ReadOnly`
- `Sandboxable`
- `supports_parallel`

因此可以安全地在计划、探索和并行工具调用中使用。

### 3. 扩展 `read_file` 的 alias fallback

更新 `crates/tui/src/tools/file.rs`：

- `read_file` schema 新增可选字段 `from`。
- 直接路径存在时保持原有行为不变。
- 当直接路径不存在，且输入看起来像前端 import specifier 时，自动尝试 resolver：
  - `@/...`
  - `~/...`
  - `#/...`
  - 带 `from` 的 `./...` 或 `../...`
  - 其他包含 `/` 的 import-like 路径
- resolver 成功后，仍会通过 `ToolContext::resolve_path` 校验权限，再读取文件。
- resolver 失败时返回更清晰的错误信息，避免静默猜测。

这让模型可以直接执行类似：

```json
{
  "path": "@/components/Button",
  "from": "src/pages/Home.tsx"
}
```

并读取到真实文件。

### 4. 将 resolver 注入 Engine / ToolContext

更新 `ToolContext`：

- 新增 `cwd_hint`
- 新增 `active_paths`
- 新增共享 `module_resolver`

更新 Engine 构建工具上下文时注入：

- 当前工作目录 hint
- session working set 中的活跃路径
- 共享的 `Arc<ModuleResolver>`

这样 resolver 可以在多轮会话中复用缓存，并根据当前编辑/阅读上下文更准确地消除多项目歧义。

### 5. 注册工具并更新默认工具集

更新工具注册和工具目录：

- `crates/tui/src/tools/mod.rs`
- `crates/tui/src/tools/registry.rs`
- `crates/tui/src/core/engine/tool_catalog.rs`
- `crates/tui/src/core/engine/tool_setup.rs`

`resolve_import` 现在会随默认工具集加载，并在 Plan 分支中可用。

### 6. 更新子代理和提示词

更新：

- `crates/tui/src/prompts/base.md`
- `crates/tui/src/prompts/base.txt`
- `crates/tui/src/prompts/subagent_output_format.md`
- `crates/tui/src/tools/subagent/mod.rs`

新增提示约定：

- 遇到前端 alias import 时，优先调用 `resolve_import`。
- 如果 resolver 报告多项目歧义，使用 importer path 重新解析。
- 子代理允许并理解 `resolve_import` 工具。

## Tests

已执行并通过：

```sh
cargo fmt --all --check
cargo check -p deepseek-tui
cargo test -p deepseek-tui module_resolver
cargo test -p deepseek-tui resolve_import_tool
cargo test -p deepseek-tui read_file_resolves_frontend_alias_with_from
cargo test -p deepseek-tui read_file_reports_ambiguous_alias_without_from
cargo test -p deepseek-tui
```

测试覆盖包括：

- 单项目 alias 解析。
- 多项目相同 alias 的上下文解析。
- 无 `from` 时的多项目歧义报告。
- `extends` 配置合并。
- longest-prefix alias 优先级。
- 扩展名和 index 文件探测。
- scoped package 被识别为外部依赖。
- path escape 防护。
- JSONC 配置解析。
- `resolve_import` 成功和失败 JSON 输出。
- `read_file` alias fallback 成功路径。
- `read_file` alias fallback 歧义错误路径。

备注：完整 `cargo test -p deepseek-tui` 在普通沙箱中曾因本地端口绑定权限导致 wiremock 相关测试失败；使用允许本地测试端口绑定的环境重跑后全部通过。

## Compatibility

- 保持 `read_file` 对普通路径的既有行为。
- resolver 只在直接路径不存在且输入像 import specifier 时触发。
- 不执行项目配置文件，因此不会引入额外运行时代码执行风险。
- 对外部 package import 不做文件解析，避免把 npm package 错误当成本地路径。
- 多项目歧义会显式报错，要求提供 `from`，避免错误读取其他子项目文件。

## Risk / Notes

主要风险集中在不同前端项目配置的兼容性上：

- 当前实现覆盖 `baseUrl`、`paths`、本地 `extends`、扩展名探测和 index 探测。
- 不支持执行动态 JS 配置，这是有意的安全限制。
- 对复杂 monorepo 的准确性依赖 `from`、cwd hint 和 active paths；无上下文时会优先返回歧义错误。
- 后续如果需要支持更多构建工具特有 alias，例如 Vite/Webpack 自定义 alias，可以在 `ModuleResolver` 上继续扩展。