### PR TITLE
docs: align Rust MSRV references with workspace

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "dockerFile": "../Dockerfile",
   "build": {
     "args": {
-      "RUST_VERSION": "1.85"
+      "RUST_VERSION": "1.88"
     }
   },
   "customizations": {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to DeepSeek TUI! This document provi
 
 ### Prerequisites
 
-- Rust 1.85 or later (edition 2024)
+- Rust 1.88 or later (edition 2024)
 - Cargo package manager
 - Git
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # in a minimal runtime layer. No MCP servers or heavy toolchains are included
 # — keep it slim.
 
-ARG RUST_VERSION=1.85
+ARG RUST_VERSION=1.88
 
 # ── Stage 1: Build ────────────────────────────────────────────────────
 FROM --platform=$BUILDPLATFORM rust:${RUST_VERSION}-slim-bookworm AS builder

--- a/crates/tui/src/tui/markdown_render.rs
+++ b/crates/tui/src/tui/markdown_render.rs
@@ -749,7 +749,7 @@ mod tests {
     #[test]
     fn table_separator_row_is_dropped() {
         // "|---|---|" must not appear in output
-        let src = "| 项目属性 | 详情 |\n|----------|------|\n| **语言** | Rust 1.85+ |\n";
+        let src = "| 项目属性 | 详情 |\n|----------|------|\n| **语言** | Rust 1.88+ |\n";
         let parsed = parse(src);
         let blocks: Vec<_> = parsed.blocks.iter().collect();
         // Should have 2 TableRow blocks (header + data), no separator

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -79,7 +79,7 @@ install from crates.io directly. Both crates are required — the dispatcher
 delegates to the TUI runtime at runtime.
 
 ```bash
-# Requires Rust 1.85+ (https://rustup.rs)
+# Requires Rust 1.88+ (https://rustup.rs)
 cargo install deepseek-tui-cli --locked   # provides `deepseek`
 cargo install deepseek-tui     --locked   # provides `deepseek-tui`
 deepseek --version
@@ -165,7 +165,7 @@ LoongArch, FreeBSD, and pre-2024 ARM64 distros.
 
 ### Prerequisites
 
-- **Rust** 1.85 or later — install with [rustup](https://rustup.rs).
+- **Rust** 1.88 or later — install with [rustup](https://rustup.rs).
 - **Linux build-time deps** (Debian/Ubuntu/openEuler/Kylin):
   ```bash
   sudo apt-get install -y build-essential pkg-config libdbus-1-dev
@@ -240,7 +240,7 @@ Building on Windows requires the **MSVC C toolchain** from
 
 1. Install Visual Studio 2022 Build Tools — select the **"Desktop development
    with C++"** workload.
-2. Install [Rust](https://rustup.rs) 1.85+ (see the
+2. Install [Rust](https://rustup.rs) 1.88+ (see the
    [China mirror instructions](#china--mirror-friendly-install) above if
    downloading from mainland China).
 3. Install [Git for Windows](https://git-scm.com/download/win) (provides `git`

--- a/npm/deepseek-tui/scripts/artifacts.js
+++ b/npm/deepseek-tui/scripts/artifacts.js
@@ -50,7 +50,7 @@ function unsupportedBuildHint() {
     "No prebuilt binary is available for this platform/architecture combo.",
     "You can still run DeepSeek TUI by building from source with Cargo:",
     "",
-    "  # Requires Rust 1.85+ (https://rustup.rs)",
+    "  # Requires Rust 1.88+ (https://rustup.rs)",
     "  cargo install deepseek-tui-cli --locked   # provides `deepseek`",
     "  cargo install deepseek-tui     --locked   # provides `deepseek-tui`",
     "",

--- a/npm/deepseek-tui/scripts/preflight-glibc.js
+++ b/npm/deepseek-tui/scripts/preflight-glibc.js
@@ -68,7 +68,7 @@ function buildFromSourceHint() {
   return [
     "You can still run DeepSeek TUI by building from source with Cargo:",
     "",
-    "  # Requires Rust 1.85+ (https://rustup.rs)",
+    "  # Requires Rust 1.88+ (https://rustup.rs)",
     "  cargo install deepseek-tui-cli --locked   # provides `deepseek`",
     "  cargo install deepseek-tui     --locked   # provides `deepseek-tui`",
     "",


### PR DESCRIPTION
## Summary
- Update install and contribution docs from Rust 1.85+ to Rust 1.88+
- Update Docker/devcontainer Rust build args to match the workspace rust-version
- Update npm fallback build hints and the markdown renderer fixture so stale 1.85 references do not remain

## Rationale
The workspace now declares rust-version = 1.88 because it relies on stabilized let_chains. Some install/build entry points still pointed users at Rust 1.85, which would fail before compilation.

## Checks
- git grep for Rust 1.85 references returns no matches outside vendor
- git diff --check
- .devcontainer/devcontainer.json parses with PowerShell ConvertFrom-Json
- node --check npm/deepseek-tui/scripts/artifacts.js
- node --check npm/deepseek-tui/scripts/preflight-glibc.js

Rust checks were not run locally because this Windows environment does not have rustc/cargo installed.