### PR TITLE
  Add shell completion setup examples

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -156,17 +156,24 @@ enum Commands {
   Bash (current shell only):
     source <(deepseek completion bash)
 
-  Bash (persistent, Ubuntu/bash-completion):
+  Bash (persistent, Linux/bash-completion):
     mkdir -p ~/.local/share/bash-completion/completions
     deepseek completion bash > ~/.local/share/bash-completion/completions/deepseek
+    # Requires bash-completion to be installed and loaded by your shell.
 
   Zsh:
     mkdir -p ~/.zfunc
     deepseek completion zsh > ~/.zfunc/_deepseek
-    # Ensure ~/.zfunc is in fpath from ~/.zshrc.
+    # Add to ~/.zshrc if needed:
+    #   fpath=(~/.zfunc $fpath)
+    #   autoload -Uz compinit && compinit
 
   Fish:
+    mkdir -p ~/.config/fish/completions
     deepseek completion fish > ~/.config/fish/completions/deepseek.fish
+
+  PowerShell (current shell only):
+    deepseek completion powershell | Out-String | Invoke-Expression
 
 The command prints the completion script to stdout; redirect it to a path your shell loads automatically."#)]
     Completion {
@@ -1897,7 +1904,9 @@ mod tests {
                     "bash",
                     "source <(deepseek completion bash)",
                     "~/.local/share/bash-completion/completions/deepseek",
+                    "fpath=(~/.zfunc $fpath)",
                     "deepseek completion fish > ~/.config/fish/completions/deepseek.fish",
+                    "deepseek completion powershell | Out-String | Invoke-Expression",
                 ],
             ),
             ("metrics", vec!["--json", "--since"]),

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -152,6 +152,23 @@ enum Commands {
     /// Run the app-server transport.
     AppServer(AppServerArgs),
     /// Generate shell completions.
+    #[command(after_help = r#"Examples:
+  Bash (current shell only):
+    source <(deepseek completion bash)
+
+  Bash (persistent, Ubuntu/bash-completion):
+    mkdir -p ~/.local/share/bash-completion/completions
+    deepseek completion bash > ~/.local/share/bash-completion/completions/deepseek
+
+  Zsh:
+    mkdir -p ~/.zfunc
+    deepseek completion zsh > ~/.zfunc/_deepseek
+    # Ensure ~/.zfunc is in fpath from ~/.zshrc.
+
+  Fish:
+    deepseek completion fish > ~/.config/fish/completions/deepseek.fish
+
+The command prints the completion script to stdout; redirect it to a path your shell loads automatically."#)]
     Completion {
         #[arg(value_enum)]
         shell: Shell,
@@ -1873,7 +1890,16 @@ mod tests {
                 "app-server",
                 vec!["--host", "--port", "--config", "--stdio"],
             ),
-            ("completion", vec!["<SHELL>", "bash"]),
+            (
+                "completion",
+                vec![
+                    "<SHELL>",
+                    "bash",
+                    "source <(deepseek completion bash)",
+                    "~/.local/share/bash-completion/completions/deepseek",
+                    "deepseek completion fish > ~/.config/fish/completions/deepseek.fish",
+                ],
+            ),
             ("metrics", vec!["--json", "--since"]),
         ];
 


### PR DESCRIPTION


## Summary
  - Add actionable setup examples to `deepseek completion --help`
  - Cover bash, zsh, and fish completion installation guidance
  - Update the CLI help surface test for the new help text

```
Generate shell completions

Usage: deepseek completion <SHELL>

Arguments:
  <SHELL>  [possible values: bash, elvish, fish, powershell, zsh]

Options:
  -h, --help  Print help

Examples:
  Bash (current shell only):
    source <(deepseek completion bash)

  Bash (persistent, Ubuntu/bash-completion):
    mkdir -p ~/.local/share/bash-completion/completions
    deepseek completion bash > ~/.local/share/bash-completion/completions/deepseek

  Zsh:
    mkdir -p ~/.zfunc
    deepseek completion zsh > ~/.zfunc/_deepseek
    # Ensure ~/.zfunc is in fpath from ~/.zshrc.

  Fish:
    deepseek completion fish > ~/.config/fish/completions/deepseek.fish
```

## Testing

 - `cargo test -p deepseek-tui-cli subcommand_help_surfaces_are_stable --all-features --locked`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
