### PR TITLE
feat(tui): Add background color to all panels and status bar (closes #734)

### DIFF
--- a/crates/tui/src/deepseek_theme.rs
+++ b/crates/tui/src/deepseek_theme.rs
@@ -62,7 +62,7 @@ impl Theme {
             section_borders: Borders::ALL,
             section_border_type: BorderType::Plain,
             section_border_color: palette::BORDER_COLOR,
-            section_bg: Color::Reset,
+            section_bg: palette::DEEPSEEK_INK,
             section_title_color: palette::DEEPSEEK_BLUE,
             // Horizontal padding only. `Padding::uniform(1)` ate two rows of
             // each sidebar panel — for compact terminals where Plan/Todos/Tasks
@@ -147,7 +147,7 @@ mod tests {
         let theme = Theme::dark();
         assert_eq!(theme.variant, Variant::Dark);
         assert_eq!(theme.section_border_color, palette::BORDER_COLOR);
-        assert_eq!(theme.section_bg, ratatui::style::Color::Reset);
+        assert_eq!(theme.section_bg, palette::DEEPSEEK_INK);
         assert_eq!(theme.section_title_color, palette::DEEPSEEK_BLUE);
         assert_eq!(theme.tool_title_color, palette::TEXT_SOFT);
         assert_eq!(theme.tool_value_color, palette::TEXT_MUTED);

--- a/crates/tui/src/tui/widgets/footer.rs
+++ b/crates/tui/src/tui/widgets/footer.rs
@@ -593,6 +593,13 @@ impl Renderable for FooterWidget {
         all_spans.push(spacer_span);
         all_spans.extend(right_spans);
 
+        // Fill the footer area with the deepseek-ink background before
+        // painting the text line, so the status bar reads as part of the
+        // unified dark surface (issue #734).
+        ratatui::widgets::Block::default()
+            .style(ratatui::style::Style::default().bg(palette::DEEPSEEK_INK))
+            .render(area, buf);
+
         let paragraph = Paragraph::new(Line::from(all_spans));
         paragraph.render(area, buf);
     }


### PR DESCRIPTION
## Summary
This PR closes #734. Changes:
- `deepseek_theme.rs`: Set `section_bg` to `palette::DEEPSEEK_INK`, so every sidebar panel and the file-tree pane now shares the same dark background as the chat area.
- `footer.rs`: Added a `Block` fill with `DEEPSEEK_INK` in `FooterWidget::render`, unifying the status bar with the dark surface.

## Testing
- [x] `cargo test --all-features`: 2055 passed; 1 failed; 2 ignored; 0 measured; 0 filtered out.
The failing test is `core::engine::tests::error_escalation_triggers_replan_when_severe_or_repeated_failures`, which fails about half the time. This test also fails occasionally on the current `main` branch, and this PR does not modify any code related to it. Therefore, I believe this failure is not introduced by this PR.
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features`

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [x] Verified TUI behavior manually if UI changes
<img width="3838" height="2064" alt="screenshot_20260505_223344" src="https://github.com/user-attachments/assets/61b08352-3d28-4eaf-ad8a-0d7299d3b04c" />
