### PR TITLE
fix(tui): clear loading state on dispatch failure

### DIFF
--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -3168,7 +3168,7 @@ async fn dispatch_user_message(
         app.model.clone()
     };
 
-    engine_handle
+    if let Err(err) = engine_handle
         .send(Op::SendMessage {
             content,
             mode: app.mode,
@@ -3179,7 +3179,12 @@ async fn dispatch_user_message(
             trust_mode: app.trust_mode,
             auto_approve: app.mode == AppMode::Yolo,
         })
-        .await?;
+        .await
+    {
+        app.is_loading = false;
+        app.last_send_at = None;
+        return Err(err);
+    }
 
     Ok(())
 }

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -1473,6 +1473,28 @@ async fn dismissed_plan_prompt_leaves_non_numeric_input_for_normal_send_path() {
 }
 
 #[tokio::test]
+async fn dispatch_failure_before_turn_started_clears_loading_state() {
+    let mut app = create_test_app();
+    let engine = crate::core::engine::mock_engine_handle();
+    let handle = engine.handle.clone();
+    drop(engine.rx_op);
+
+    let result = dispatch_user_message(
+        &mut app,
+        &handle,
+        crate::tui::app::QueuedMessage::new("hello".to_string(), None),
+    )
+    .await;
+
+    assert!(result.is_err());
+    assert!(
+        !app.is_loading,
+        "failed dispatch must not leave future composer submits queued as if a turn were live"
+    );
+    assert!(app.last_send_at.is_none());
+}
+
+#[tokio::test]
 async fn numeric_plan_choice_still_queues_follow_up_when_busy() {
     let mut app = create_test_app();
     app.mode = AppMode::Plan;


### PR DESCRIPTION
## Summary

Fixes a stale TUI busy-state path where `dispatch_user_message()` sets `app.is_loading = true` before sending `Op::SendMessage`, but did not clear it if dispatch failed before the engine started a turn.

This could leave the UI stuck on `working...`, with later inputs moved to `Pending inputs`, while `/task` reports `No tasks found`.

Fixes #738.

## Changes

- Clear `app.is_loading` and `app.last_send_at` when sending `Op::SendMessage` fails.
- Add a regression test for dispatch failure before turn start.

## Testing

- `cargo test -p deepseek-tui dispatch_failure_before_turn_started_clears_loading_state -- --nocapture`
- `git diff --check`