### PR TITLE
feat(install): add Homebrew formula for macOS and Linux

### DIFF
--- a/Formula/deepseek-tui.rb
+++ b/Formula/deepseek-tui.rb
@@ -1,0 +1,63 @@
+class DeepseekTui < Formula
+  desc "Coding agent for DeepSeek models that runs in your terminal"
+  homepage "https://github.com/Hmbown/DeepSeek-TUI"
+  version "0.8.12"
+  license "MIT"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/Hmbown/DeepSeek-TUI/releases/download/v0.8.12/deepseek-macos-arm64"
+      sha256 "573b11d2da67927f29faf518baa772347f07c291f6cefd68d5bef550d5ce794c"
+
+      resource "deepseek-tui-bin" do
+        url "https://github.com/Hmbown/DeepSeek-TUI/releases/download/v0.8.12/deepseek-tui-macos-arm64"
+        sha256 "8cfa9085807be9a3808fe23db56321f620291ab0ea22a004c31aae0da678438b"
+      end
+    end
+
+    on_intel do
+      url "https://github.com/Hmbown/DeepSeek-TUI/releases/download/v0.8.12/deepseek-macos-x64"
+      sha256 "d865fe32d44a8c067d10b23046b02e8fc7cb0943c2bf7e84a2b433c226e496ed"
+
+      resource "deepseek-tui-bin" do
+        url "https://github.com/Hmbown/DeepSeek-TUI/releases/download/v0.8.12/deepseek-tui-macos-x64"
+        sha256 "eaf03d8d96ce9454147bd7e651b731592957babe376c4404d820c6da380ed8f8"
+      end
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/Hmbown/DeepSeek-TUI/releases/download/v0.8.12/deepseek-linux-arm64"
+      sha256 "a97d2b292788b862d2b56b8c8c44385d196cc18048ce13690d97d4f5fa190ac6"
+
+      resource "deepseek-tui-bin" do
+        url "https://github.com/Hmbown/DeepSeek-TUI/releases/download/v0.8.12/deepseek-tui-linux-arm64"
+        sha256 "9fa08253673f675a59882f2dc1a10582fb9da91616cd664382843de244fd0bb4"
+      end
+    end
+
+    on_intel do
+      url "https://github.com/Hmbown/DeepSeek-TUI/releases/download/v0.8.12/deepseek-linux-x64"
+      sha256 "052236ba569e908c516a760502c0b94da4bb22a61a31df9a6624ee9dd3b96a78"
+
+      resource "deepseek-tui-bin" do
+        url "https://github.com/Hmbown/DeepSeek-TUI/releases/download/v0.8.12/deepseek-tui-linux-x64"
+        sha256 "77e4e991d80aab09244a726232fb84145b81cb3a28c588d2a55a2a0807277861"
+      end
+    end
+  end
+
+  def install
+    bin.install Dir["*"].first => "deepseek"
+
+    resource("deepseek-tui-bin").stage do
+      bin.install Dir["*"].first => "deepseek-tui"
+    end
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/deepseek --version")
+    assert_match version.to_s, shell_output("#{bin}/deepseek-tui --version")
+  end
+end

--- a/README.md
+++ b/README.md
@@ -135,6 +135,20 @@ Prebuilt binaries can also be downloaded from [GitHub Releases](https://github.c
 scoop install deepseek-tui
 ```
 
+### macOS / Linux (Homebrew)
+
+[Homebrew](https://brew.sh) users can install both binaries from the in-repo
+formula:
+
+```bash
+brew install --formula https://raw.githubusercontent.com/Hmbown/DeepSeek-TUI/main/Formula/deepseek-tui.rb
+deepseek --version
+```
+
+The formula installs the matching prebuilt release binary for your platform
+(macOS arm64/x64, Linux arm64/x64) and exposes both `deepseek` and
+`deepseek-tui` on `PATH`.
+
 
 <details id="install-from-source">
 <summary>Install from source</summary>


### PR DESCRIPTION
## Summary

Closes #736.

- Adds `Formula/deepseek-tui.rb` — a Homebrew binary-install formula targeting the v0.8.12 release artifacts for macOS (arm64/x64) and Linux (arm64/x64). Installs both `deepseek` (dispatcher) and `deepseek-tui` (TUI) since both are required at runtime per the existing install docs.
- Adds a "macOS / Linux (Homebrew)" subsection to the README's Install section, mirroring the style of the existing Scoop entry.

Users can then install with:

```bash
brew install --formula https://raw.githubusercontent.com/Hmbown/DeepSeek-TUI/main/Formula/deepseek-tui.rb
```

The sha256 values are taken verbatim from `deepseek-artifacts-sha256.txt` published with the v0.8.12 release.

## Notes for the maintainer

- This in-repo formula is the smallest path to satisfying #736 without requiring a separate `homebrew-tap` repo. Once you're happy with the UX, a follow-up could promote the formula to `Hmbown/homebrew-tap` (enabling `brew install hmbown/tap/deepseek-tui`) and/or submit to homebrew-core.
- I did not wire up an auto-bump on release — happy to add a small workflow that updates `version` + `sha256` on tag push if you want it in a follow-up PR. Kept this PR scoped to just unblocking #736.
- I don't have a Mac to run `brew audit --strict --new` / `brew install --formula ./Formula/deepseek-tui.rb` against — would appreciate a sanity check from a Homebrew user before merge. The formula uses standard `on_macos`/`on_linux` + `on_arm`/`on_intel` blocks with `resource` for the second binary.

## Test plan

- [ ] `brew install --formula ./Formula/deepseek-tui.rb` on macOS arm64 — `deepseek --version` and `deepseek-tui --version` both report `0.8.12`
- [ ] Same on macOS x64
- [ ] Same on Linux arm64 / x64
- [ ] `brew audit --strict --new ./Formula/deepseek-tui.rb` is clean (or surfaces only acceptable warnings for an in-repo formula)
- [ ] README renders the new subsection correctly