### PR TITLE
feat(mcp): global MCP config support for context-mode and claude-mem

### DIFF
--- a/config.example.mcp.json
+++ b/config.example.mcp.json
@@ -1,0 +1,26 @@
+{
+  "_comment": "Example MCP server configuration for DeepSeek TUI. Copy to ~/.deepseek/mcp.json for global use, or .deepseek/mcp.json for per-workspace servers.",
+  "timeouts": {
+    "connect_timeout": 10,
+    "execute_timeout": 60,
+    "read_timeout": 120
+  },
+  "mcpServers": {
+    "claude-mem": {
+      "_comment": "Cross-session memory and search from Claude Code sessions",
+      "command": "bash",
+      "args": [
+        "-c",
+        "exec bun \"$(~/.deepseek/mcp-resolve.sh claude-mem scripts/mcp-server.cjs)\""
+      ]
+    },
+    "context-mode": {
+      "_comment": "Sandboxed execution, FTS5 knowledge base, context savings",
+      "command": "bash",
+      "args": [
+        "-c",
+        "exec node \"$(~/.deepseek/mcp-resolve.sh context-mode start.mjs)\""
+      ]
+    }
+  }
+}

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -1389,8 +1389,9 @@ impl Engine {
         if let Some(pool) = self.mcp_pool.as_ref() {
             return Ok(Arc::clone(pool));
         }
-        let mut pool = McpPool::from_config_path(&self.session.mcp_config_path)
+        let mut pool = McpPool::from_workspace_config(&self.session.mcp_config_path)
             .map_err(|e| ToolError::execution_failed(format!("Failed to load MCP config: {e}")))?;
+        pool = pool.with_workspace(self.session.workspace.clone());
         if let Some(decider) = self.config.network_policy.as_ref() {
             pool = pool.with_network_policy(decider.clone());
         }

--- a/crates/tui/src/mcp.rs
+++ b/crates/tui/src/mcp.rs
@@ -18,7 +18,6 @@ use tokio::process::{Child, ChildStdin, ChildStdout};
 
 use crate::network_policy::{Decision, NetworkPolicyDecider, host_from_url};
 use crate::utils::write_atomic;
-use dirs;
 
 // === Error diagnostics helpers (#71) ===
 
@@ -1002,6 +1001,7 @@ impl McpPool {
     /// Override or set an environment variable on a specific server's config.
     /// The value is only set if the key does not already exist in the server's
     /// env map, preserving any explicit user-configured values.
+    #[allow(dead_code)]
     pub fn with_server_env(mut self, server_name: &str, key: &str, value: &str) -> Self {
         if let Some(server) = self.config.servers.get_mut(server_name) {
             server
@@ -1066,13 +1066,13 @@ impl McpPool {
             .clone();
 
         // Inject workspace directory for context-mode connections
-        if server_name == "context-mode" {
-            if let Some(ref workspace) = self.workspace_dir {
-                server_config
-                    .env
-                    .entry("CONTEXT_MODE_PROJECT_DIR".to_string())
-                    .or_insert_with(|| workspace.display().to_string());
-            }
+        if server_name == "context-mode"
+            && let Some(ref workspace) = self.workspace_dir
+        {
+            server_config
+                .env
+                .entry("CONTEXT_MODE_PROJECT_DIR".to_string())
+                .or_insert_with(|| workspace.display().to_string());
         }
 
         if !server_config.is_enabled() {

--- a/crates/tui/src/mcp.rs
+++ b/crates/tui/src/mcp.rs
@@ -658,7 +658,7 @@ impl McpConnection {
             "id": init_id,
             "method": "initialize",
             "params": {
-                "protocolVersion": "2024-11-05",
+                "protocolVersion": "2025-03-26",
                 "clientInfo": {
                     "name": "deepseek-tui",
                     "version": env!("CARGO_PKG_VERSION")

--- a/crates/tui/src/mcp.rs
+++ b/crates/tui/src/mcp.rs
@@ -2148,7 +2148,78 @@ mod tests {
         let still_alive = unsafe { libc::kill(pid as i32, 0) } == 0;
         assert!(
             !still_alive,
-            "child {pid} survived StdioTransport::shutdown — SIGTERM not delivered"
+            "child {pid} survived StdioTransport::shutdown \u{2014} SIGTERM not delivered"
         );
+    }
+
+    // ── Helper ──────────────────────────────────────────────────────
+
+    fn make_server(command: &str, args: &[&str]) -> McpServerConfig {
+        McpServerConfig {
+            command: Some(command.to_string()),
+            args: args.iter().map(|s| s.to_string()).collect(),
+            env: HashMap::new(),
+            url: None,
+            connect_timeout: None,
+            execute_timeout: None,
+            read_timeout: None,
+            disabled: false,
+            enabled: true,
+            required: false,
+            enabled_tools: Vec::new(),
+            disabled_tools: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn test_workspace_overrides_global() {
+        // from_workspace_config reads ~/.deepseek/mcp.json which varies per
+        // machine, so this tests the merge logic in isolation.
+
+        let mut global = McpConfig::default();
+        global.servers.insert(
+            "claude-mem".to_string(),
+            make_server("bun", &["global-mem.cjs"]),
+        );
+        global.servers.insert(
+            "shared".to_string(),
+            make_server("node", &["global-shared.js"]),
+        );
+
+        let mut workspace = McpConfig::default();
+        workspace.servers.insert(
+            "context-mode".to_string(),
+            make_server("node", &["workspace-ctx.mjs"]),
+        );
+        workspace.servers.insert(
+            "shared".to_string(),
+            make_server("node", &["workspace-shared.js"]),
+        );
+
+        // Merge (same logic as from_workspace_config)
+        for (name, server) in workspace.servers {
+            global.servers.insert(name, server);
+        }
+
+        assert_eq!(global.servers.len(), 3);
+        assert!(global.servers.contains_key("claude-mem"));
+        assert!(global.servers.contains_key("context-mode"));
+        assert!(global.servers.contains_key("shared"));
+        // workspace override wins
+        assert_eq!(global.servers["shared"].args, vec!["workspace-shared.js"]);
+    }
+
+    #[test]
+    fn test_load_config_parses_minimal_server() {
+        let dir = tempfile::tempdir().unwrap();
+        let ws_config = dir.path().join("mcp.json");
+        std::fs::write(
+            &ws_config,
+            r#"{"servers": {"test": {"command": "echo", "args": ["hi"]}}}"#,
+        )
+        .unwrap();
+
+        let pool = McpPool::from_config_path(&ws_config).unwrap();
+        assert!(pool.config.servers.contains_key("test"));
     }
 }

--- a/crates/tui/src/mcp.rs
+++ b/crates/tui/src/mcp.rs
@@ -7,7 +7,7 @@
 
 use std::collections::HashMap;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
@@ -18,6 +18,7 @@ use tokio::process::{Child, ChildStdin, ChildStdout};
 
 use crate::network_policy::{Decision, NetworkPolicyDecider, host_from_url};
 use crate::utils::write_atomic;
+use dirs;
 
 // === Error diagnostics helpers (#71) ===
 
@@ -971,6 +972,7 @@ pub struct McpPool {
     connections: HashMap<String, McpConnection>,
     config: McpConfig,
     network_policy: Option<NetworkPolicyDecider>,
+    workspace_dir: Option<PathBuf>,
 }
 
 impl McpPool {
@@ -980,6 +982,7 @@ impl McpPool {
             connections: HashMap::new(),
             config,
             network_policy: None,
+            workspace_dir: None,
         }
     }
 
@@ -996,10 +999,46 @@ impl McpPool {
         Ok(Self::new(config))
     }
 
+    /// Override or set an environment variable on a specific server's config.
+    /// The value is only set if the key does not already exist in the server's
+    /// env map, preserving any explicit user-configured values.
+    pub fn with_server_env(mut self, server_name: &str, key: &str, value: &str) -> Self {
+        if let Some(server) = self.config.servers.get_mut(server_name) {
+            server
+                .env
+                .entry(key.to_string())
+                .or_insert_with(|| value.to_string());
+        }
+        self
+    }
+
     /// Attach a per-domain network policy (#135). When set, HTTP/SSE
     /// transports are gated through it; STDIO transports are unaffected.
     pub fn with_network_policy(mut self, policy: NetworkPolicyDecider) -> Self {
         self.network_policy = Some(policy);
+        self
+    }
+
+    /// Merge global config (~/.deepseek/mcp.json) with workspace config.
+    /// Workspace entries override global entries with the same server name.
+    pub fn from_workspace_config(workspace_config_path: &std::path::Path) -> Result<Self> {
+        let global_path = dirs::home_dir()
+            .unwrap_or_default()
+            .join(".deepseek")
+            .join("mcp.json");
+        let mut merged = load_config(&global_path).unwrap_or_default();
+        let workspace_cfg = load_config(workspace_config_path)?;
+        // workspace overrides global for same-named servers
+        for (name, server) in workspace_cfg.servers {
+            merged.servers.insert(name, server);
+        }
+        Ok(Self::new(merged))
+    }
+
+    /// Set the workspace directory, used to inject CONTEXT_MODE_PROJECT_DIR
+    /// for context-mode MCP connections.
+    pub fn with_workspace(mut self, workspace: PathBuf) -> Self {
+        self.workspace_dir = Some(workspace);
         self
     }
 
@@ -1019,12 +1058,22 @@ impl McpPool {
 
         self.connections.remove(server_name);
 
-        let server_config = self
+        let mut server_config = self
             .config
             .servers
             .get(server_name)
             .ok_or_else(|| anyhow::anyhow!("Failed to find MCP server: {server_name}"))?
             .clone();
+
+        // Inject workspace directory for context-mode connections
+        if server_name == "context-mode" {
+            if let Some(ref workspace) = self.workspace_dir {
+                server_config
+                    .env
+                    .entry("CONTEXT_MODE_PROJECT_DIR".to_string())
+                    .or_insert_with(|| workspace.display().to_string());
+            }
+        }
 
         if !server_config.is_enabled() {
             anyhow::bail!("Failed to connect MCP server '{server_name}': server is disabled");

--- a/crates/tui/src/mcp.rs
+++ b/crates/tui/src/mcp.rs
@@ -1020,7 +1020,8 @@ impl McpPool {
     }
 
     /// Merge global config (~/.deepseek/mcp.json) with workspace config.
-    /// Workspace entries override global entries with the same server name.
+    /// Workspace entries override global entries with the same server name,
+    /// and workspace timeouts override global timeouts.
     /// Global config is only read when HOME is set and the file exists;
     /// a missing file is fine, but parse errors are propagated.
     pub fn from_workspace_config(workspace_config_path: &std::path::Path) -> Result<Self> {
@@ -1035,6 +1036,8 @@ impl McpPool {
         for (name, server) in workspace_cfg.servers {
             merged.servers.insert(name, server);
         }
+        // workspace timeouts override global timeouts
+        merged.timeouts = workspace_cfg.timeouts;
         Ok(Self::new(merged))
     }
 

--- a/crates/tui/src/mcp.rs
+++ b/crates/tui/src/mcp.rs
@@ -1021,12 +1021,15 @@ impl McpPool {
 
     /// Merge global config (~/.deepseek/mcp.json) with workspace config.
     /// Workspace entries override global entries with the same server name.
+    /// Global config is only read when HOME is set and the file exists;
+    /// a missing file is fine, but parse errors are propagated.
     pub fn from_workspace_config(workspace_config_path: &std::path::Path) -> Result<Self> {
-        let global_path = dirs::home_dir()
-            .unwrap_or_default()
-            .join(".deepseek")
-            .join("mcp.json");
-        let mut merged = load_config(&global_path).unwrap_or_default();
+        let mut merged = if let Some(home) = dirs::home_dir() {
+            let global_path = home.join(".deepseek").join("mcp.json");
+            load_config(&global_path)?
+        } else {
+            McpConfig::default()
+        };
         let workspace_cfg = load_config(workspace_config_path)?;
         // workspace overrides global for same-named servers
         for (name, server) in workspace_cfg.servers {

--- a/docs/superpowers/plans/2026-05-06-mcp-integration-plan.md
+++ b/docs/superpowers/plans/2026-05-06-mcp-integration-plan.md
@@ -10,6 +10,23 @@
 
 ---
 
+## Pre-flight
+
+- [ ] **Step 1: Create feature branch**
+
+```bash
+git checkout -b feat/mcp-integration
+```
+
+- [ ] **Step 2: Verify prerequisites**
+
+```bash
+rustc --version  # must be >= 1.88
+cargo build      # clean baseline
+```
+
+---
+
 ### Task 1: Add `McpPool::from_workspace_config` and workspace injection
 
 **Files:**
@@ -94,9 +111,10 @@ if server_name == "context-mode" {
 }
 ```
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 6: Format and commit**
 
 ```bash
+cargo fmt
 git add crates/tui/src/mcp.rs
 git commit -m "feat(mcp): add from_workspace_config and workspace injection for context-mode"
 ```
@@ -118,9 +136,10 @@ git commit -m "feat(mcp): add from_workspace_config and workspace injection for 
 "protocolVersion": "2025-03-26",
 ```
 
-- [ ] **Step 2: Commit**
+- [ ] **Step 2: Format and commit**
 
 ```bash
+cargo fmt
 git add crates/tui/src/mcp.rs
 git commit -m "fix(mcp): bump protocol version to 2025-03-26"
 ```
@@ -145,9 +164,10 @@ let mut pool = McpPool::from_workspace_config(&self.session.mcp_config_path)
 pool = pool.with_workspace(self.session.workspace.clone());
 ```
 
-- [ ] **Step 2: Commit**
+- [ ] **Step 2: Format and commit**
 
 ```bash
+cargo fmt
 git add crates/tui/src/core/engine.rs
 git commit -m "feat(engine): use from_workspace_config for MCP pool init"
 ```
@@ -352,23 +372,32 @@ Add `use std::collections::HashMap;` at the top of the test module if not alread
 - [ ] **Step 2: Run the tests**
 
 ```bash
-cargo test -p deepseek-tui -- mcp
+cargo test --workspace --all-features
 ```
 
-Expected: all existing MCP tests pass, plus the two new ones.
+Expected: all existing tests pass, plus the two new MCP merge tests.
 
-- [ ] **Step 3: Commit**
+- [ ] **Step 3: Format and commit**
 
 ```bash
+cargo fmt
 git add crates/tui/src/mcp.rs
-git commit -m "test(mcp): add from_workspace_config merge behavior test"
+git commit -m "test(mcp): add workspace-override merge behavior test"
 ```
 
 ---
 
 ### Task 7: Build and verify
 
-- [ ] **Step 1: Build the project**
+- [ ] **Step 1: Format check**
+
+```bash
+cargo fmt --check
+```
+
+Expected: no formatting changes needed.
+
+- [ ] **Step 2: Build**
 
 ```bash
 cargo build
@@ -376,22 +405,22 @@ cargo build
 
 Expected: compile cleanly, no warnings.
 
-- [ ] **Step 2: Run the full MCP test suite**
+- [ ] **Step 3: Run full test suite**
 
 ```bash
-cargo test -p deepseek-tui -- mcp
+cargo test --workspace --all-features
 ```
 
 Expected: all tests pass.
 
-- [ ] **Step 3: Run clippy**
+- [ ] **Step 4: Run clippy**
 
 ```bash
-cargo clippy -p deepseek-tui -- -D warnings
+cargo clippy --workspace --all-targets --all-features -- -D warnings
 ```
 
 Expected: no warnings.
 
-- [ ] **Step 4: Commit any remaining changes**
+- [ ] **Step 5: Commit any remaining changes**
 
 Only if needed for clippy fixes or build tweaks.

--- a/docs/superpowers/plans/2026-05-06-mcp-integration-plan.md
+++ b/docs/superpowers/plans/2026-05-06-mcp-integration-plan.md
@@ -1,0 +1,397 @@
+# MCP Integration: context-mode + claude-mem — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enable DeepSeek TUI to connect to existing context-mode and claude-mem MCP servers by adding global config support, workspace-aware env injection, and a version-independent plugin path resolver.
+
+**Architecture:** Add a `McpPool::from_workspace_config` constructor that merges `~/.deepseek/mcp.json` (global) with workspace-level config. Auto-inject `CONTEXT_MODE_PROJECT_DIR` for context-mode connections. Bump MCP protocol version to 2025-03-26. Ship a shell script that resolves latest plugin versions so config survives upgrades.
+
+**Tech Stack:** Rust (tokio async, serde_json), Bash (plugin path resolver)
+
+---
+
+### Task 1: Add `McpPool::from_workspace_config` and workspace injection
+
+**Files:**
+- Modify: `crates/tui/src/mcp.rs` (McpPool impl, ~line 976-1015)
+
+- [ ] **Step 1: Add `workspace_dir` field to `McpPool`**
+
+```rust
+// In McpPool struct, after `network_policy` field (~line 973):
+pub struct McpPool {
+    connections: HashMap<String, McpConnection>,
+    config: McpConfig,
+    network_policy: Option<NetworkPolicyDecider>,
+    workspace_dir: Option<PathBuf>,
+}
+```
+
+- [ ] **Step 2: Update `McpPool::new` to initialize the new field**
+
+```rust
+// In McpPool::new(), replace the constructor body:
+pub fn new(config: McpConfig) -> Self {
+    Self {
+        connections: HashMap::new(),
+        config,
+        network_policy: None,
+        workspace_dir: None,
+    }
+}
+```
+
+- [ ] **Step 3: Add `McpPool::from_workspace_config` constructor**
+
+```rust
+/// Merge global config (~/.deepseek/mcp.json) with workspace config.
+/// Workspace entries override global entries with the same server name.
+pub fn from_workspace_config(workspace_config_path: &std::path::Path) -> Result<Self> {
+    let global_path = dirs::home_dir()
+        .unwrap_or_default()
+        .join(".deepseek")
+        .join("mcp.json");
+    let mut merged = load_config(&global_path).unwrap_or_default();
+    let workspace_cfg = load_config(workspace_config_path)?;
+    // workspace overrides global for same-named servers
+    for (name, server) in workspace_cfg.servers {
+        merged.servers.insert(name, server);
+    }
+    Ok(Self::new(merged))
+}
+```
+
+Add `use std::path::PathBuf;` if not already imported.
+
+- [ ] **Step 4: Add `McpPool::with_workspace` setter**
+
+```rust
+/// Set the workspace directory, used to inject CONTEXT_MODE_PROJECT_DIR
+/// for context-mode MCP connections.
+pub fn with_workspace(mut self, workspace: PathBuf) -> Self {
+    self.workspace_dir = Some(workspace);
+    self
+}
+```
+
+- [ ] **Step 5: Inject `CONTEXT_MODE_PROJECT_DIR` in `get_or_connect`**
+
+After `server_config` is cloned and before calling `McpConnection::connect_with_policy`, inject the env var if the server is context-mode and a workspace is set:
+
+```rust
+// In get_or_connect(), after the line:
+//   let server_config = self.config.servers.get(server_name)...clone();
+// Add:
+
+let mut server_config = server_config;
+if server_name == "context-mode" {
+    if let Some(ref workspace) = self.workspace_dir {
+        server_config
+            .env
+            .entry("CONTEXT_MODE_PROJECT_DIR".to_string())
+            .or_insert_with(|| workspace.display().to_string());
+    }
+}
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/tui/src/mcp.rs
+git commit -m "feat(mcp): add from_workspace_config and workspace injection for context-mode"
+```
+
+---
+
+### Task 2: Bump MCP protocol version
+
+**Files:**
+- Modify: `crates/tui/src/mcp.rs:660`
+
+- [ ] **Step 1: Change protocol version string**
+
+```rust
+// Line 660, in McpConnection::initialize():
+// Before:
+"protocolVersion": "2024-11-05",
+// After:
+"protocolVersion": "2025-03-26",
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add crates/tui/src/mcp.rs
+git commit -m "fix(mcp): bump protocol version to 2025-03-26"
+```
+
+---
+
+### Task 3: Update engine call site
+
+**Files:**
+- Modify: `crates/tui/src/core/engine.rs` (ensure_mcp_pool, ~line 1392)
+
+- [ ] **Step 1: Replace `from_config_path` with `from_workspace_config`**
+
+```rust
+// Line 1392, in Engine::ensure_mcp_pool():
+// Before:
+let mut pool = McpPool::from_config_path(&self.session.mcp_config_path)
+    .map_err(|e| ToolError::execution_failed(format!("Failed to load MCP config: {e}")))?;
+// After:
+let mut pool = McpPool::from_workspace_config(&self.session.mcp_config_path)
+    .map_err(|e| ToolError::execution_failed(format!("Failed to load MCP config: {e}")))?;
+pool = pool.with_workspace(self.session.workspace.clone());
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add crates/tui/src/core/engine.rs
+git commit -m "feat(engine): use from_workspace_config for MCP pool init"
+```
+
+---
+
+### Task 4: Create plugin path resolver script
+
+**Files:**
+- Create: `scripts/mcp-resolve.sh`
+
+- [ ] **Step 1: Create `scripts/mcp-resolve.sh`**
+
+```bash
+#!/usr/bin/env bash
+# Resolves latest installed version of a claude-mem or context-mode plugin.
+# Usage: mcp-resolve.sh <plugin-name> <relative-script-path>
+#   plugin-name: "claude-mem" | "context-mode"
+#   relative-script-path: path inside the version directory
+#
+# Output: absolute path to the script (trailing newline)
+# Exit: 1 if plugin not found
+
+set -euo pipefail
+
+PLUGIN_CACHE="${HOME}/.claude/plugins/cache"
+PLUGIN_NAME="$1"
+SCRIPT_PATH="$2"
+
+case "${PLUGIN_NAME}" in
+  claude-mem)
+    base="${PLUGIN_CACHE}/thedotmack/claude-mem"
+    ;;
+  context-mode)
+    base="${PLUGIN_CACHE}/context-mode/context-mode"
+    ;;
+  *)
+    echo "mcp-resolve.sh: unknown plugin '${PLUGIN_NAME}'" >&2
+    exit 1
+    ;;
+esac
+
+if [[ ! -d "${base}" ]]; then
+  echo "mcp-resolve.sh: plugin directory not found: ${base}" >&2
+  exit 1
+fi
+
+latest=$(ls -d "${base}"/*/ 2>/dev/null | sort -V | tail -1)
+if [[ -z "${latest}" ]]; then
+  echo "mcp-resolve.sh: no version directories found under ${base}" >&2
+  exit 1
+fi
+
+echo "${latest}${SCRIPT_PATH}"
+```
+
+- [ ] **Step 2: Make it executable**
+
+```bash
+chmod +x scripts/mcp-resolve.sh
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/mcp-resolve.sh
+git commit -m "feat: add mcp-resolve.sh for version-independent plugin paths"
+```
+
+---
+
+### Task 5: Create example MCP config
+
+**Files:**
+- Create: `config.example.mcp.json`
+
+- [ ] **Step 1: Create `config.example.mcp.json`**
+
+```json
+{
+  "_comment": "Example MCP server configuration for DeepSeek TUI. Copy to ~/.deepseek/mcp.json for global use, or .deepseek/mcp.json for per-workspace servers.",
+  "timeouts": {
+    "connect_timeout": 10,
+    "execute_timeout": 60,
+    "read_timeout": 120
+  },
+  "mcpServers": {
+    "claude-mem": {
+      "_comment": "Cross-session memory and search from Claude Code sessions",
+      "command": "bash",
+      "args": [
+        "-c",
+        "exec bun \"$(~/.deepseek/mcp-resolve.sh claude-mem scripts/mcp-server.cjs)\""
+      ]
+    },
+    "context-mode": {
+      "_comment": "Sandboxed execution, FTS5 knowledge base, context savings",
+      "command": "bash",
+      "args": [
+        "-c",
+        "exec node \"$(~/.deepseek/mcp-resolve.sh context-mode start.mjs)\""
+      ]
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add config.example.mcp.json
+git commit -m "docs: add example MCP config for claude-mem and context-mode"
+```
+
+---
+
+### Task 6: Write unit test for config merge
+
+**Files:**
+- Modify: `crates/tui/src/mcp.rs` (tests module, ~line 1859)
+
+- [ ] **Step 1: Add test for `from_workspace_config` merge behavior**
+
+In the `mod tests` block at the end of `mcp.rs`:
+
+```rust
+fn make_server(command: &str, args: &[&str]) -> McpServerConfig {
+    McpServerConfig {
+        command: Some(command.to_string()),
+        args: args.iter().map(|s| s.to_string()).collect(),
+        env: HashMap::new(),
+        url: None,
+        connect_timeout: None,
+        execute_timeout: None,
+        read_timeout: None,
+        disabled: false,
+        enabled: true,
+        required: false,
+        enabled_tools: Vec::new(),
+        disabled_tools: Vec::new(),
+    }
+}
+
+#[test]
+fn test_workspace_overrides_global() {
+    // from_workspace_config reads ~/.deepseek/mcp.json which varies per
+    // machine, so this tests the merge logic in isolation.
+
+    let mut global = McpConfig::default();
+    global.servers.insert(
+        "claude-mem".to_string(),
+        make_server("bun", &["global-mem.cjs"]),
+    );
+    global.servers.insert(
+        "shared".to_string(),
+        make_server("node", &["global-shared.js"]),
+    );
+
+    let mut workspace = McpConfig::default();
+    workspace.servers.insert(
+        "context-mode".to_string(),
+        make_server("node", &["workspace-ctx.mjs"]),
+    );
+    workspace.servers.insert(
+        "shared".to_string(),
+        make_server("node", &["workspace-shared.js"]),
+    );
+
+    // Merge (same logic as from_workspace_config)
+    for (name, server) in workspace.servers {
+        global.servers.insert(name, server);
+    }
+
+    assert_eq!(global.servers.len(), 3);
+    assert!(global.servers.contains_key("claude-mem"));
+    assert!(global.servers.contains_key("context-mode"));
+    assert!(global.servers.contains_key("shared"));
+    // workspace override wins
+    assert_eq!(
+        global.servers["shared"].args,
+        vec!["workspace-shared.js"]
+    );
+}
+
+#[test]
+fn test_load_config_parses_minimal_server() {
+    let dir = tempfile::tempdir().unwrap();
+    let ws_config = dir.path().join("mcp.json");
+    std::fs::write(
+        &ws_config,
+        r#"{"servers": {"test": {"command": "echo", "args": ["hi"]}}}"#,
+    )
+    .unwrap();
+
+    let pool = McpPool::from_config_path(&ws_config).unwrap();
+    assert!(pool.config.servers.contains_key("test"));
+}
+```
+
+Add `use std::collections::HashMap;` at the top of the test module if not already imported.
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+cargo test -p deepseek-tui -- mcp
+```
+
+Expected: all existing MCP tests pass, plus the two new ones.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/tui/src/mcp.rs
+git commit -m "test(mcp): add from_workspace_config merge behavior test"
+```
+
+---
+
+### Task 7: Build and verify
+
+- [ ] **Step 1: Build the project**
+
+```bash
+cargo build
+```
+
+Expected: compile cleanly, no warnings.
+
+- [ ] **Step 2: Run the full MCP test suite**
+
+```bash
+cargo test -p deepseek-tui -- mcp
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Run clippy**
+
+```bash
+cargo clippy -p deepseek-tui -- -D warnings
+```
+
+Expected: no warnings.
+
+- [ ] **Step 4: Commit any remaining changes**
+
+Only if needed for clippy fixes or build tweaks.

--- a/docs/superpowers/specs/2026-05-06-mcp-integration-design.md
+++ b/docs/superpowers/specs/2026-05-06-mcp-integration-design.md
@@ -1,0 +1,266 @@
+# MCP Integration: context-mode + claude-mem + superpowers
+
+**Date:** 2026-05-06
+**Status:** draft
+**Scope:** Enable DeepSeek TUI to connect to existing MCP servers (claude-mem, context-mode, superpowers) via the built-in MCP client.
+
+## Problem
+
+DeepSeek TUI is a Claude Code replacement that talks to DeepSeek models via a full-featured terminal UI. It already has a complete MCP client implementation (`crates/tui/src/mcp.rs`, ~2100 lines) but it only reads MCP server config from a workspace-level file (`.deepseek/mcp.json`). The user has significant context built up in claude-mem (cross-session memory) and context-mode (context savings), and wants those tools available inside DeepSeek TUI sessions — not just Claude Code sessions.
+
+The MCP servers already exist as standalone stdio binaries. The MCP client already exists and is fully spec-compliant. The gap is purely configuration and wiring.
+
+## Architecture
+
+### Current state
+
+```
+┌─────────────────────────────────┐
+│ DeepSeek TUI                    │
+│  ┌───────────────────────────┐  │
+│  │ Engine                    │  │
+│  │  ┌─────────────────────┐  │  │
+│  │  │ McpPool             │  │  │   reads mcp.json from
+│  │  │  McpConnection ──────────►   workspace/.deepseek/mcp.json
+│  │  │  StdioTransport     │  │  │
+│  │  │  SseTransport       │  │  │
+│  │  └─────────────────────┘  │  │
+│  │  ┌─────────────────────┐  │  │
+│  │  │ ToolRegistry        │  │  │
+│  │  │  McpToolAdapter ────┼──┼──► wraps MCP tools as native tools
+│  │  └─────────────────────┘  │  │
+│  └───────────────────────────┘  │
+└─────────────────────────────────┘
+```
+
+The MCP client already supports:
+- `initialize` → `notifications/initialized` handshake
+- `tools/list` with `inputSchema` per spec
+- `tools/call` with `{ content: [...], isError }` per spec
+- `resources/list`, `resources/read`
+- `prompts/list`, `prompts/get`
+- `StdioTransport`: spawns child process, newline-delimited JSON-RPC on stdin/stdout
+- `SseTransport`: HTTP POST + SSE stream for server-to-client messages
+- Per-server timeouts, network policy gating, graceful shutdown
+
+### Target state
+
+```
+┌──────────────────────────────────────┐
+│ ~/.deepseek/mcp.json (global)        │  NEW — fallback/merge with workspace
+│                                        │
+│ "mcpServers": {                       │
+│   "claude-mem": {                     │
+│     "command": "bun",                 │
+│     "args": ["/path/to/mcp-server"]   │
+│   },                                  │
+│   "context-mode": {                   │
+│     "command": "node",                │
+│     "args": ["/path/to/start.mjs"],   │
+│     "env": {                          │
+│       "CONTEXT_MODE_PROJECT_DIR":     │
+│         "${WORKSPACE}"                │  dynamic per workspace
+│     }                                 │
+│   }                                   │
+│ }                                     │
+└──────────────────────────────────────┘
+                │
+                ▼
+┌─────────────────────────────────┐
+│ DeepSeek TUI                    │
+│  ┌───────────────────────────┐  │
+│  │ Engine                    │  │
+│  │  McpPool                  │  │   reads BOTH:
+│  │    ~/.deepseek/mcp.json ──┼──►  1. ~/.deepseek/mcp.json (global)
+│  │    .deepseek/mcp.json ────┼──►  2. workspace/.deepseek/mcp.json
+│  │                           │  │     workspace overrides global
+│  │  ┌─────────────────────┐  │  │
+│  │  │ StdioTransport      │  │  │
+│  │  │  child: node/bun ────────► node /path/to/context-mode/start.mjs
+│  │  │  stdin/stdout pipes │  │  │   bun /path/to/claude-mem/mcp-server.cjs
+│  │  └─────────────────────┘  │  │
+│  └───────────────────────────┘  │
+└─────────────────────────────────┘
+```
+
+## Changes
+
+### 1. Global MCP config support
+
+**File:** `crates/tui/src/mcp.rs` (McpPool)
+
+Add a second config load path. `McpPool::from_config_path` currently takes a single path. Add a new constructor that merges global + workspace configs:
+
+```rust
+impl McpPool {
+    /// Merge global config (if present) with workspace config.
+    /// Workspace entries override global entries with the same server name.
+    pub fn from_workspace_config(workspace_config_path: &Path) -> Result<Self> {
+        let global_path = dirs::home_dir()
+            .unwrap_or_default()
+            .join(".deepseek")
+            .join("mcp.json");
+        let mut merged = if global_path.exists() {
+            McpConfig::from_path(&global_path).unwrap_or_default()
+        } else {
+            McpConfig::default()
+        };
+        if workspace_config_path.exists() {
+            let workspace_cfg = McpConfig::from_path(workspace_config_path)?;
+            merged.servers.extend(workspace_cfg.servers);
+            // workspace overrides
+            for (name, server) in workspace_cfg.servers {
+                merged.servers.insert(name, server);
+            }
+        }
+        Ok(Self::new(merged))
+    }
+}
+```
+
+Call site change in `crates/tui/src/core/engine.rs`:
+
+```rust
+// Before:
+let mut pool = McpPool::from_config_path(&self.session.mcp_config_path)?;
+
+// After:
+let mut pool = McpPool::from_workspace_config(&self.session.mcp_config_path)?;
+```
+
+**Rationale:** Users want memory/context tools in every project. Workspace configs can add project-specific MCP servers (e.g., a database MCP server for a specific repo). Global config ensures claude-mem and context-mode are always available.
+
+### 2. Version-independent wrapper script
+
+Plugin cache paths include version numbers that change on upgrade (e.g., `claude-mem/12.6.5/` → `claude-mem/12.7.0/`). Rather than updating `mcp.json` on every upgrade, ship a small shell script that resolves the latest version:
+
+```bash
+#!/bin/bash
+# ~/.deepseek/mcp-resolve.sh — resolves latest plugin version
+# Usage: mcp-resolve.sh <plugin-name> <script-path>
+#   plugin-name: "claude-mem" or "context-mode"
+#   script-path: relative path inside the version dir
+
+PLUGIN_CACHE="$HOME/.claude/plugins/cache"
+
+case "$1" in
+  claude-mem)
+    latest=$(ls -d "$PLUGIN_CACHE/thedotmack/claude-mem/"*/ 2>/dev/null | sort -V | tail -1)
+    ;;
+  context-mode)
+    latest=$(ls -d "$PLUGIN_CACHE/context-mode/context-mode/"*/ 2>/dev/null | sort -V | tail -1)
+    ;;
+esac
+
+if [ -n "$latest" ]; then
+  echo "${latest}$2"
+else
+  echo "Error: $1 not found" >&2
+  exit 1
+fi
+```
+
+mcp.json entries reference the wrapper:
+
+```json
+{
+  "mcpServers": {
+    "claude-mem": {
+      "command": "bun",
+      "args": ["$(~/.deepseek/mcp-resolve.sh claude-mem scripts/mcp-server.cjs)"]
+    }
+  }
+}
+```
+
+**Alternative considered:** Direct paths with hardcoded versions. Rejected — breaks on every plugin update.
+
+### 3. CONTEXT_MODE_PROJECT_DIR env var
+
+context-mode needs to know which project it operates on (for its FTS5 knowledge base, session DB, etc.). The MCP client already supports per-server env vars in `McpServerConfig`. The config just needs to include it.
+
+For the global config, we need a dynamic value — the current workspace. This requires either:
+- The wrapper script to accept a `--project-dir` argument and set the env var internally
+- Or the MCP client to inject `CONTEXT_MODE_PROJECT_DIR` automatically for context-mode connections
+
+**Decision:** Pass it as an env var pointing at a wrapper. Simpler, no code changes:
+
+```json
+{
+  "context-mode": {
+    "command": "bash",
+    "args": ["-c", "CONTEXT_MODE_PROJECT_DIR=$(pwd) exec node $(~/.deepseek/mcp-resolve.sh context-mode start.mjs)"]
+  }
+}
+```
+
+But this breaks on Windows. **Better approach:** add automatic injection in `StdioTransport` or `McpConnection::connect_with_policy` — if the server name is "context-mode", inject `CONTEXT_MODE_PROJECT_DIR` from the current workspace. This is a single-line change in `mcp.rs` and works cross-platform.
+
+### 4. mcp.json template
+
+Ship `config.example.mcp.json` in the repo root with commented examples:
+
+```json
+{
+  "timeouts": {
+    "connect_timeout": 10,
+    "execute_timeout": 60,
+    "read_timeout": 120
+  },
+  "mcpServers": {
+    "claude-mem": {
+      "command": "bash",
+      "args": ["-c", "exec bun $(~/.deepseek/mcp-resolve.sh claude-mem scripts/mcp-server.cjs)"]
+    },
+    "context-mode": {
+      "command": "bash",
+      "args": ["-c", "exec node $(~/.deepseek/mcp-resolve.sh context-mode start.mjs)"]
+    },
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/path/to/allowed/dir"]
+    }
+  }
+}
+```
+
+### 5. Protocol version bump
+
+The MCP client sends `"protocolVersion": "2024-11-05"`. This should be bumped to `"2025-03-26"` to match the current spec. Both context-mode and claude-mem target 2025-03-26.
+
+**File:** `crates/tui/src/mcp.rs`, line 660
+
+## What does NOT change
+
+- `crates/mcp/` — the legacy stdio MCP server. Unrelated to client-side MCP.
+- `McpConnection::initialize()` — handshake is correct per spec.
+- `McpToolAdapter` — wrapping MCP tools as native ToolSpec impls is correct.
+- `ToolRegistry` registration — MCP tools flow through the existing pipeline.
+- Tool dispatch in `turn_loop.rs` — `mcp__server__tool` qualified dispatch is correct.
+- `McpPool::call_tool()` — the dispatch path is correct.
+- `config.example.toml` — MCP config lives in mcp.json, separate from the main config.
+
+## Files modified
+
+| File | Change | Lines |
+|------|--------|-------|
+| `crates/tui/src/mcp.rs` | Add `from_workspace_config`, auto-inject `CONTEXT_MODE_PROJECT_DIR` for context-mode, bump protocol version | ~30 |
+| `crates/tui/src/core/engine.rs` | Call `from_workspace_config` instead of `from_config_path` | ~3 |
+| `config.example.mcp.json` | New — commented MCP server config template | ~30 |
+| `scripts/mcp-resolve.sh` | New — version-independent plugin path resolver | ~20 |
+
+## Testing
+
+1. **Unit:** `McpPool::from_workspace_config` merges global + workspace correctly (workspace overrides)
+2. **Integration:** Start `deepseek`, verify `mcp__claude_mem__search` and `mcp__context_mode__ctx_search` appear in available tools
+3. **End-to-end:** Call `mcp__claude_mem__search` with a query, verify it returns past observation data
+4. **Upgrade resilience:** Bump a plugin version, verify `mcp-resolve.sh` resolves the new path
+5. **Protocol compat:** Verify handshake succeeds against context-mode and claude-mem MCP servers
+
+## Open questions
+
+1. **superpowers MCP server:** Does superpowers have a standalone stdio MCP server? It may be a collection of skills (markdown files + Skill tool invocations) rather than an MCP server. If not, it may need a thin MCP wrapper or be loaded differently (e.g., as a skill directory).
+
+2. **Windows support:** `mcp-resolve.sh` is bash. On Windows, need a PowerShell equivalent or embed the resolution logic in Rust.
+
+3. **Mixed transport:** context-mode and claude-mem only support stdio. If the user wants to connect to HTTP/SSE MCP servers, those are already supported by the SSE transport — just configure `"url"` instead of `"command"`.

--- a/docs/superpowers/specs/2026-05-06-mcp-integration-design.md
+++ b/docs/superpowers/specs/2026-05-06-mcp-integration-design.md
@@ -1,4 +1,4 @@
-# MCP Integration: context-mode + claude-mem + superpowers
+# MCP Integration: context-mode + claude-mem
 
 **Date:** 2026-05-06
 **Status:** draft
@@ -257,10 +257,15 @@ The MCP client sends `"protocolVersion": "2024-11-05"`. This should be bumped to
 4. **Upgrade resilience:** Bump a plugin version, verify `mcp-resolve.sh` resolves the new path
 5. **Protocol compat:** Verify handshake succeeds against context-mode and claude-mem MCP servers
 
+## Out of scope
+
+**superpowers:** Verified — superpowers is a Claude Code plugin (skills + hooks + agents) with no standalone MCP server. It has no `.mcp.json` and no stdio entry point. Connecting superpowers skills to DeepSeek TUI would require:
+- A separate MCP server wrapper that exposes skills as MCP tools, or
+- Loading skill markdown files directly into DeepSeek TUI's existing skill system (`crates/tui/src/skills/`)
+Either path is independent of this MCP transport work and should be designed separately.
+
 ## Open questions
 
-1. **superpowers MCP server:** Does superpowers have a standalone stdio MCP server? It may be a collection of skills (markdown files + Skill tool invocations) rather than an MCP server. If not, it may need a thin MCP wrapper or be loaded differently (e.g., as a skill directory).
+1. **Windows support:** `mcp-resolve.sh` is bash. On Windows, need a PowerShell equivalent or embed the resolution logic in Rust.
 
-2. **Windows support:** `mcp-resolve.sh` is bash. On Windows, need a PowerShell equivalent or embed the resolution logic in Rust.
-
-3. **Mixed transport:** context-mode and claude-mem only support stdio. If the user wants to connect to HTTP/SSE MCP servers, those are already supported by the SSE transport — just configure `"url"` instead of `"command"`.
+2. **Mixed transport:** context-mode and claude-mem only support stdio. If the user wants to connect to HTTP/SSE MCP servers, those are already supported by the SSE transport — just configure `"url"` instead of `"command"`.

--- a/scripts/mcp-resolve.sh
+++ b/scripts/mcp-resolve.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Resolves latest installed version of a claude-mem or context-mode plugin.
+# Usage: mcp-resolve.sh <plugin-name> <relative-script-path>
+#   plugin-name: "claude-mem" | "context-mode"
+#   relative-script-path: path inside the version directory
+#
+# Output: absolute path to the script (trailing newline)
+# Exit: 1 if plugin not found
+
+set -euo pipefail
+
+PLUGIN_CACHE="${HOME}/.claude/plugins/cache"
+PLUGIN_NAME="$1"
+SCRIPT_PATH="$2"
+
+case "${PLUGIN_NAME}" in
+  claude-mem)
+    base="${PLUGIN_CACHE}/thedotmack/claude-mem"
+    ;;
+  context-mode)
+    base="${PLUGIN_CACHE}/context-mode/context-mode"
+    ;;
+  *)
+    echo "mcp-resolve.sh: unknown plugin '${PLUGIN_NAME}'" >&2
+    exit 1
+    ;;
+esac
+
+if [[ ! -d "${base}" ]]; then
+  echo "mcp-resolve.sh: plugin directory not found: ${base}" >&2
+  exit 1
+fi
+
+latest=$(ls -d "${base}"/*/ 2>/dev/null | sort -V | tail -1)
+if [[ -z "${latest}" ]]; then
+  echo "mcp-resolve.sh: no version directories found under ${base}" >&2
+  exit 1
+fi
+
+echo "${latest}${SCRIPT_PATH}"


### PR DESCRIPTION
## Summary

Users accumulate significant context over time — claude-mem observations span sessions, context-mode FTS5 indexes hold project knowledge, and knowledge corpora capture hard-won debugging insights. When moving from Claude Code to DeepSeek TUI, none of that should be left behind.

DeepSeek TUI already has a complete, spec-compliant MCP client with stdio and SSE transports, full handshake, tool discovery, and dispatch. But it only reads MCP server config from a workspace-level file, so MCP servers must be configured per-project.

This PR adds global MCP config support so claude-mem and context-mode MCP servers can be configured once at `~/.deepseek/mcp.json` and connect in every workspace — bringing existing project context, memory, and session history into DeepSeek TUI sessions.

## Changes

| File | Delta |
|------|-------|
| `crates/tui/src/mcp.rs` | +128 lines |
| `crates/tui/src/core/engine.rs` | +3/-1 lines |
| `scripts/mcp-resolve.sh` | new (+40) |
| `config.example.mcp.json` | new (+26) |

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test --workspace --all-features` — 2337 passed, 6 ignored
- [x] `cargo build` — clean