### PR TITLE
fix(config): repair first-run auth and settings selection

### DIFF
--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -1511,6 +1511,43 @@ fn resolve_load_config_path(path: Option<PathBuf>) -> Option<PathBuf> {
     home_config_path()
 }
 
+/// Create an inspectable config file on first interactive launch.
+///
+/// The file intentionally omits `api_key`; onboarding or `deepseek auth set`
+/// writes that field after the user supplies a key.
+pub fn ensure_config_file_exists(path: Option<PathBuf>) -> Result<Option<PathBuf>> {
+    let config_path = path
+        .map(expand_pathbuf)
+        .or_else(default_config_path)
+        .context("Failed to resolve config path: home directory not found.")?;
+    if config_path.exists() {
+        return Ok(None);
+    }
+
+    ensure_parent_dir(&config_path)?;
+    let content = format!(
+        r#"# DeepSeek TUI Configuration
+# Get your API key from https://platform.deepseek.com
+# Save it with: deepseek auth set --provider deepseek
+
+# Base URL (default: https://api.deepseek.com)
+# base_url = "https://api.deepseek.com"
+
+# Default model
+default_text_model = "{default_model}"
+
+# Thinking mode (DeepSeek V4 reasoning effort):
+# "auto" | "off" | "low" | "medium" | "high" | "max"
+# Shift+Tab in the TUI cycles between off / high / max.
+reasoning_effort = "auto"
+"#,
+        default_model = DEFAULT_TEXT_MODEL
+    );
+    fs::write(&config_path, content)
+        .with_context(|| format!("Failed to write config to {}", config_path.display()))?;
+    Ok(Some(config_path))
+}
+
 fn default_managed_config_path() -> Option<PathBuf> {
     #[cfg(unix)]
     {
@@ -2336,6 +2373,51 @@ pub fn has_api_key(config: &Config) -> bool {
     false
 }
 
+#[must_use]
+pub fn active_provider_has_config_api_key(config: &Config) -> bool {
+    let provider = config.api_provider();
+
+    if config
+        .provider_config_for(provider)
+        .and_then(|entry| entry.api_key.as_ref())
+        .is_some_and(|k| !k.trim().is_empty() && k != API_KEYRING_SENTINEL)
+    {
+        return true;
+    }
+
+    matches!(provider, ApiProvider::Deepseek | ApiProvider::DeepseekCN)
+        && config
+            .api_key
+            .as_ref()
+            .is_some_and(|k| !k.trim().is_empty() && k != API_KEYRING_SENTINEL)
+}
+
+#[must_use]
+pub fn active_provider_has_env_api_key(config: &Config) -> bool {
+    match config.api_provider() {
+        ApiProvider::Deepseek | ApiProvider::DeepseekCN => {
+            std::env::var("DEEPSEEK_API_KEY").is_ok_and(|k| !k.trim().is_empty())
+        }
+        ApiProvider::NvidiaNim => {
+            std::env::var("NVIDIA_API_KEY").is_ok_and(|k| !k.trim().is_empty())
+                || std::env::var("NVIDIA_NIM_API_KEY").is_ok_and(|k| !k.trim().is_empty())
+        }
+        ApiProvider::Openrouter => {
+            std::env::var("OPENROUTER_API_KEY").is_ok_and(|k| !k.trim().is_empty())
+        }
+        ApiProvider::Novita => std::env::var("NOVITA_API_KEY").is_ok_and(|k| !k.trim().is_empty()),
+        ApiProvider::Fireworks => {
+            std::env::var("FIREWORKS_API_KEY").is_ok_and(|k| !k.trim().is_empty())
+        }
+        ApiProvider::Sglang => std::env::var("SGLANG_API_KEY").is_ok_and(|k| !k.trim().is_empty()),
+    }
+}
+
+#[must_use]
+pub fn active_provider_uses_env_only_api_key(config: &Config) -> bool {
+    active_provider_has_env_api_key(config) && !active_provider_has_config_api_key(config)
+}
+
 /// Check whether the given provider has any usable API key — via env var,
 /// provider/root config. Used by the `/provider` picker to decide whether to
 /// prompt for a key inline.
@@ -2748,6 +2830,32 @@ mod tests {
     }
 
     #[test]
+    fn ensure_config_file_exists_creates_first_run_template() -> Result<()> {
+        let _lock = lock_test_env();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let temp_root = env::temp_dir().join(format!(
+            "deepseek-tui-first-run-config-{}-{}",
+            std::process::id(),
+            nanos
+        ));
+        fs::create_dir_all(&temp_root)?;
+        let _guard = EnvGuard::new(&temp_root);
+
+        let created = ensure_config_file_exists(None)?.expect("should create config");
+        let content = fs::read_to_string(&created)?;
+
+        assert_eq!(created, temp_root.join(".deepseek").join("config.toml"));
+        assert!(content.contains("default_text_model = \"deepseek-v4-pro\""));
+        assert!(content.contains("reasoning_effort = \"auto\""));
+        assert!(!content.contains("api_key ="));
+        assert!(ensure_config_file_exists(None)?.is_none());
+        Ok(())
+    }
+
+    #[test]
     fn save_api_key_rejects_empty_input() {
         let _lock = lock_test_env();
         let err = save_api_key("   ").expect_err("empty should bail");
@@ -2920,6 +3028,32 @@ api_key = "old-openrouter-key"
             ..Config::default()
         };
         assert_eq!(config.deepseek_api_key()?, "fresh-config-key");
+        unsafe {
+            env::remove_var("DEEPSEEK_API_KEY");
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn active_provider_detects_env_only_api_key() -> Result<()> {
+        let _lock = lock_test_env();
+        let temp_root =
+            env::temp_dir().join(format!("deepseek-tui-env-only-key-{}", std::process::id()));
+        fs::create_dir_all(&temp_root)?;
+        let _guard = EnvGuard::new(&temp_root);
+
+        unsafe {
+            env::set_var("DEEPSEEK_API_KEY", "env-only-key");
+        }
+        let mut config = Config::default();
+        assert!(active_provider_has_env_api_key(&config));
+        assert!(!active_provider_has_config_api_key(&config));
+        assert!(active_provider_uses_env_only_api_key(&config));
+
+        config.api_key = Some("config-key".to_string());
+        assert!(active_provider_has_config_api_key(&config));
+        assert!(!active_provider_uses_env_only_api_key(&config));
+
         unsafe {
             env::remove_var("DEEPSEEK_API_KEY");
         }

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -1572,11 +1572,17 @@ async fn run_doctor(config: &Config, workspace: &Path, config_path_override: Opt
             if in_config { "yes" } else { "no" }
         );
     }
-    println!("  · credential sources: env, ~/.deepseek/config.toml");
+    println!("  · credential precedence: ~/.deepseek/config.toml, then env");
 
+    let api_key_source = resolve_api_key_source(config);
     let has_api_key = if config.deepseek_api_key().is_ok() {
+        let source_label = match api_key_source {
+            ApiKeySource::Config => "config.toml",
+            ApiKeySource::Env => "environment",
+            ApiKeySource::Missing => "unknown source",
+        };
         println!(
-            "  {} active provider key resolved",
+            "  {} active provider key resolved from {source_label}",
             "✓".truecolor(aqua_r, aqua_g, aqua_b)
         );
         true
@@ -1615,6 +1621,14 @@ async fn run_doctor(config: &Config, workspace: &Path, config_path_override: Opt
                 );
                 if error_msg.contains("401") || error_msg.contains("Unauthorized") {
                     println!("    Invalid API key. Check your DEEPSEEK_API_KEY or config.toml");
+                    if matches!(api_key_source, ApiKeySource::Env) {
+                        println!(
+                            "    The rejected key came from DEEPSEEK_API_KEY; no saved config key is present."
+                        );
+                        println!(
+                            "    Run `deepseek auth set --provider deepseek` to save a config key that overrides stale env."
+                        );
+                    }
                 } else if error_msg.contains("403") || error_msg.contains("Forbidden") {
                     println!(
                         "    API key lacks permissions. Verify key is active at platform.deepseek.com"
@@ -3523,6 +3537,17 @@ async fn run_interactive(
         merge_project_config(&mut merged_config, &workspace);
     }
     let config = &merged_config;
+
+    if !cli.skip_onboarding {
+        match crate::config::ensure_config_file_exists(cli.config.clone()) {
+            Ok(Some(path)) => logging::info(format!(
+                "Created first-run config file at {}",
+                path.display()
+            )),
+            Ok(None) => {}
+            Err(err) => logging::warn(format!("Failed to create first-run config file: {err}")),
+        }
+    }
 
     let model = config.default_model();
     let max_subagents = cli.max_subagents.map_or_else(

--- a/crates/tui/src/palette.rs
+++ b/crates/tui/src/palette.rs
@@ -167,17 +167,32 @@ impl ColorDepth {
                 return Self::TrueColor;
             }
         }
+        if std::env::var_os("WT_SESSION").is_some() {
+            return Self::TrueColor;
+        }
+        if let Ok(term_program) = std::env::var("TERM_PROGRAM") {
+            let term_program = term_program.to_ascii_lowercase();
+            if term_program.contains("iterm")
+                || term_program.contains("wezterm")
+                || term_program.contains("vscode")
+                || term_program.contains("warp")
+            {
+                return Self::TrueColor;
+            }
+        }
         let term = std::env::var("TERM").unwrap_or_default();
         let term = term.to_ascii_lowercase();
-        if term.contains("256") {
+        if term.contains("truecolor") || term.contains("24bit") {
+            Self::TrueColor
+        } else if term.contains("256") {
             Self::Ansi256
         } else if term.is_empty() || term == "dumb" {
             Self::Ansi16
         } else {
-            // Conservative default for unknown TERM strings — most modern
-            // terminals advertise truecolor, but if we're wrong here, dropping
-            // bg tints is the safe failure mode.
-            Self::TrueColor
+            // Unknown TERM strings should not receive 24-bit SGR by default.
+            // Older macOS/remote terminals can render truecolor backgrounds as
+            // bright cyan blocks; 256-color output is the safer compromise.
+            Self::Ansi256
         }
     }
 }
@@ -314,13 +329,13 @@ fn nearest_ansi16(r: u8, g: u8, b: u8) -> Color {
         } else {
             Color::Green
         }
-    } else if r > g + 24 {
+    } else if r.saturating_add(48) >= b && r > g + 24 {
         if bright {
             Color::LightMagenta
         } else {
             Color::Magenta
         }
-    } else if g > r + 24 {
+    } else if g.saturating_add(48) >= b && g > r + 24 {
         if bright {
             Color::LightCyan
         } else {
@@ -414,10 +429,10 @@ mod tests {
 
     #[test]
     fn adapt_color_drops_to_named_on_ansi16() {
-        // Sky: light blue with strong blue dominance and lum>144 → LightCyan.
+        // Sky: blue-dominant and bright → LightBlue, not terminal cyan.
         assert_eq!(
             adapt_color(DEEPSEEK_SKY, ColorDepth::Ansi16),
-            Color::LightCyan
+            Color::LightBlue
         );
         // Red: red-dominant, mid lum → Red (not the bright variant).
         assert_eq!(adapt_color(DEEPSEEK_RED, ColorDepth::Ansi16), Color::Red);
@@ -489,10 +504,12 @@ mod tests {
 
     #[test]
     fn nearest_ansi16_routes_known_brand_colors() {
-        // Blue at lum 134 with strong b-dominance lands on Cyan (pure named
-        // Blue is too dark to read as the brand colour at this lightness).
-        assert_eq!(nearest_ansi16(53, 120, 229), Color::Cyan);
-        assert_eq!(nearest_ansi16(106, 174, 242), Color::LightCyan);
+        // Blue-dominant brand colors should stay blue rather than collapsing
+        // to the user's terminal cyan, which is often much louder.
+        assert_eq!(nearest_ansi16(53, 120, 229), Color::Blue);
+        assert_eq!(nearest_ansi16(106, 174, 242), Color::LightBlue);
+        assert_eq!(nearest_ansi16(42, 74, 127), Color::Blue);
+        assert_eq!(nearest_ansi16(54, 187, 212), Color::LightCyan);
         assert_eq!(nearest_ansi16(226, 80, 96), Color::Red);
         assert_eq!(nearest_ansi16(11, 21, 38), Color::Black);
     }

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -701,6 +701,7 @@ pub struct App {
     // Onboarding
     pub onboarding: OnboardingState,
     pub onboarding_needs_api_key: bool,
+    pub api_key_env_only: bool,
     pub api_key_input: String,
     pub api_key_cursor: usize,
     // Hooks system
@@ -1055,6 +1056,7 @@ impl App {
 
         // Check if API key exists
         let needs_api_key = !has_api_key(config);
+        let api_key_env_only = crate::config::active_provider_uses_env_only_api_key(config);
         let was_onboarded = crate::tui::onboarding::is_onboarded();
         let needs_onboarding = !skip_onboarding && (!was_onboarded || needs_api_key);
         let settings = Settings::load().unwrap_or_else(|_| Settings::default());
@@ -1222,6 +1224,7 @@ impl App {
                 OnboardingState::None
             },
             onboarding_needs_api_key: needs_api_key,
+            api_key_env_only,
             api_key_input: String::new(),
             api_key_cursor: 0,
             hooks,
@@ -1324,6 +1327,7 @@ impl App {
                 self.api_key_input.clear();
                 self.api_key_cursor = 0;
                 self.onboarding_needs_api_key = false;
+                self.api_key_env_only = false;
                 Ok(saved)
             }
             Err(source) => Err(ApiKeyError::SaveFailed { source }),

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -1842,6 +1842,24 @@ async fn run_event_loop(
                 continue;
             }
 
+            if !app.view_stack.is_empty() {
+                let events = app.view_stack.handle_key(key);
+                if handle_view_events(
+                    terminal,
+                    app,
+                    config,
+                    &task_manager,
+                    &mut engine_handle,
+                    &mut web_config_session,
+                    events,
+                )
+                .await?
+                {
+                    return Ok(());
+                }
+                continue;
+            }
+
             // File-tree navigation: intercept keys when the file-tree pane is
             // visible so Up/Down/Enter/Esc operate on the tree rather than
             // falling through to composer or modal handlers.
@@ -1883,24 +1901,6 @@ async fn run_event_loop(
                     }
                     _ => {}
                 }
-            }
-
-            if !app.view_stack.is_empty() {
-                let events = app.view_stack.handle_key(key);
-                if handle_view_events(
-                    terminal,
-                    app,
-                    config,
-                    &task_manager,
-                    &mut engine_handle,
-                    &mut web_config_session,
-                    events,
-                )
-                .await?
-                {
-                    return Ok(());
-                }
-                continue;
             }
 
             if app.is_history_search_active() {
@@ -6692,7 +6692,8 @@ fn handle_mouse_event(app: &mut App, mouse: MouseEvent) -> Vec<ViewEvent> {
     }
 
     if !app.view_stack.is_empty() {
-        return Vec::new();
+        app.needs_redraw = true;
+        return app.view_stack.handle_mouse(mouse);
     }
 
     match mouse.kind {

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -1677,6 +1677,8 @@ async fn run_event_loop(
                                     refreshed_config.api_key = Some(key);
                                     let engine_config = build_engine_config(app, &refreshed_config);
                                     engine_handle = spawn_engine(engine_config, &refreshed_config);
+                                    app.offline_mode = false;
+                                    app.api_key_env_only = false;
 
                                     if !app.api_messages.is_empty() {
                                         let _ = engine_handle
@@ -2916,6 +2918,19 @@ pub(crate) fn apply_engine_error_to_app(
         severity,
     });
     app.is_loading = false;
+    if matches!(
+        envelope.category,
+        crate::error_taxonomy::ErrorCategory::Authentication
+    ) && app.api_key_env_only
+    {
+        app.offline_mode = true;
+        app.onboarding_needs_api_key = true;
+        app.onboarding = OnboardingState::ApiKey;
+        app.status_message = Some(
+            "The API key from DEEPSEEK_API_KEY was rejected. Paste a valid key to save it to ~/.deepseek/config.toml, or update the environment variable.".to_string(),
+        );
+        return;
+    }
     if recoverable {
         app.status_message = Some(format!("Connection interrupted: {message}"));
     } else {
@@ -4338,6 +4353,7 @@ async fn execute_command_input(
             providers.fireworks.api_key = None;
             providers.sglang.api_key = None;
         }
+        app.api_key_env_only = crate::config::active_provider_uses_env_only_api_key(config);
     }
     apply_command_result(
         terminal,
@@ -5304,6 +5320,7 @@ async fn apply_provider_picker_api_key(
                 provider.as_str(),
                 path.display()
             ));
+            app.api_key_env_only = false;
         }
         Err(err) => {
             app.add_message(HistoryCell::System {

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -2805,6 +2805,36 @@ fn non_recoverable_engine_error_enters_offline_mode() {
     );
 }
 
+#[test]
+fn env_only_auth_failure_reopens_api_key_onboarding() {
+    use crate::error_taxonomy::ErrorEnvelope;
+    let mut app = create_test_app();
+    app.api_key_env_only = true;
+    app.onboarding = crate::tui::app::OnboardingState::None;
+    app.onboarding_needs_api_key = false;
+
+    apply_engine_error_to_app(
+        &mut app,
+        ErrorEnvelope::fatal_auth("Authentication failed: invalid API key"),
+    );
+
+    assert!(app.offline_mode);
+    assert_eq!(
+        app.onboarding,
+        crate::tui::app::OnboardingState::ApiKey,
+        "env-only auth failures should prompt for a saved config key"
+    );
+    assert!(app.onboarding_needs_api_key);
+    let status = app
+        .status_message
+        .as_deref()
+        .expect("auth recovery should explain the env key source");
+    assert!(
+        status.contains("DEEPSEEK_API_KEY"),
+        "expected env-specific recovery hint, got {status:?}"
+    );
+}
+
 // ---- Issue #208: in-flight input routing ----
 
 #[test]

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -1,6 +1,6 @@
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use ratatui::{buffer::Buffer, layout::Rect};
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use std::fmt;
 
 use crate::localization::{Locale, MessageId, tr};
@@ -551,6 +551,7 @@ pub struct ConfigView {
     status: Option<String>,
     locale: Locale,
     last_visible_rows: Cell<usize>,
+    last_row_hitboxes: RefCell<Vec<(u16, usize)>>,
 }
 
 impl ConfigView {
@@ -698,6 +699,7 @@ impl ConfigView {
             status: None,
             locale: app.ui_locale,
             last_visible_rows: Cell::new(0),
+            last_row_hitboxes: RefCell::new(Vec::new()),
         }
     }
 
@@ -1147,6 +1149,27 @@ impl ModalView for ConfigView {
         }
     }
 
+    fn handle_mouse(&mut self, mouse: MouseEvent) -> ViewAction {
+        if self.editing.is_some() {
+            return ViewAction::None;
+        }
+        if !matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left)) {
+            return ViewAction::None;
+        }
+
+        let selected = self
+            .last_row_hitboxes
+            .borrow()
+            .iter()
+            .find_map(|(y, row_idx)| (*y == mouse.row).then_some(*row_idx));
+        if let Some(row_idx) = selected {
+            self.selected = row_idx;
+            self.status = None;
+            self.adjust_scroll(self.visible_rows_cached());
+        }
+        ViewAction::None
+    }
+
     fn render(&self, area: Rect, buf: &mut Buffer) {
         use ratatui::{
             prelude::Stylize,
@@ -1241,6 +1264,7 @@ impl ModalView for ConfigView {
                 Line::from("  Key                 Value                                    Scope"),
                 Line::from("  ----------------------------------------------------------------"),
             ];
+            let mut row_hitboxes = Vec::new();
 
             for item in items.iter().skip(start).take(visible_rows) {
                 match item {
@@ -1254,11 +1278,14 @@ impl ModalView for ConfigView {
                         let Some(row) = self.rows.get(*idx) else {
                             continue;
                         };
+                        let line_y = inner.y.saturating_add(lines.len() as u16);
+                        row_hitboxes.push((line_y, *idx));
                         let selected = *idx == self.selected;
                         let style = if selected {
                             Style::default()
-                                .fg(palette::SELECTION_TEXT)
-                                .bg(palette::SELECTION_BG)
+                                .fg(ratatui::style::Color::White)
+                                .bg(palette::DEEPSEEK_BLUE)
+                                .add_modifier(ratatui::style::Modifier::BOLD)
                         } else {
                             Style::default().fg(palette::TEXT_PRIMARY)
                         };
@@ -1274,6 +1301,7 @@ impl ModalView for ConfigView {
                     }
                 }
             }
+            *self.last_row_hitboxes.borrow_mut() = row_hitboxes;
 
             if items.is_empty() {
                 let message = if self.filter.is_empty() {
@@ -1719,7 +1747,9 @@ mod tests {
     use crate::config::Config;
     use crate::localization::Locale;
     use crate::tui::app::{App, TuiOptions};
-    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    use crossterm::event::{
+        KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
+    };
     use ratatui::{buffer::Buffer, layout::Rect};
     use std::path::PathBuf;
 
@@ -1957,6 +1987,40 @@ mod tests {
             other => panic!("expected config update emit, got {other:?}"),
         }
         assert!(view.editing.is_none());
+    }
+
+    #[test]
+    fn config_view_mouse_click_selects_row() {
+        let app = create_test_app();
+        let mut view = ConfigView::new_for_app(&app);
+        let area = Rect::new(0, 0, 100, 30);
+        let mut buf = Buffer::empty(area);
+        view.render(area, &mut buf);
+
+        let hitboxes = view.last_row_hitboxes.borrow().clone();
+        let (_, row_idx) = hitboxes
+            .iter()
+            .find(|(_, idx)| {
+                view.rows
+                    .get(*idx)
+                    .is_some_and(|row| row.key == "default_model")
+            })
+            .copied()
+            .expect("default_model row should have a hitbox");
+        let y = hitboxes
+            .iter()
+            .find_map(|(y, idx)| (*idx == row_idx).then_some(*y))
+            .expect("selected row should have a y coordinate");
+
+        let action = view.handle_mouse(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: 20,
+            row: y,
+            modifiers: KeyModifiers::NONE,
+        });
+
+        assert!(matches!(action, ViewAction::None));
+        assert_eq!(view.selected, row_idx);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- create the first-run config scaffold even when an env API key is present
- track when auth is env-only and reopen API-key onboarding after an auth failure
- make doctor report whether the active key came from config or environment, with an env-specific 401 recovery hint
- let config/settings modals receive arrow keys and mouse clicks before the file tree intercepts input
- make selected config rows render with a blue background instead of invisible foreground-only styling
- promote the terminal color-depth/ANSI fallback fix from the v0.8.15 branch for Windows/older terminal rendering

Refs #759.

## Test plan
- cargo fmt --all --check
- cargo check -p deepseek-tui
- cargo test -p deepseek-tui
- cargo test -p deepseek-tui active_provider_detects_env_only_api_key
- cargo test -p deepseek-tui ensure_config_file_exists_creates_first_run_template
- cargo test -p deepseek-tui env_only_auth_failure_reopens_api_key_onboarding
- cargo test -p deepseek-tui config_view_mouse_click_selects_row
- cargo test -p deepseek-tui nearest_ansi16_routes_known_brand_colors
- cargo test -p deepseek-tui adapt_color_drops_to_named_on_ansi16
- DEEPSEEK_CONFIG_PATH=<temp>/config.toml DEEPSEEK_API_KEY=<invalid> cargo run -q -p deepseek-tui -- doctor