### PR TITLE
feat(deepmap): add parsing layer — types, queries, parser, resolver (PR 1/3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1151,6 +1151,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "deepmap"
+version = "0.8.13"
+dependencies = [
+ "chrono",
+ "dirs",
+ "ignore",
+ "log",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tree-sitter",
+ "tree-sitter-css",
+ "tree-sitter-go",
+ "tree-sitter-html",
+ "tree-sitter-javascript",
+ "tree-sitter-json",
+ "tree-sitter-language",
+ "tree-sitter-python",
+ "tree-sitter-rust",
+ "tree-sitter-typescript",
+]
+
+[[package]]
 name = "deepseek-agent"
 version = "0.8.18"
 dependencies = [
@@ -4691,6 +4714,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
+
+[[package]]
 name = "string_cache"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5198,6 +5227,106 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78f873475d258561b06f1c595d93308a7ed124d9977cb26b148c2084a4a3cc87"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax 0.8.8",
+ "serde_json",
+ "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-css"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ad6489794d41350d12a7fbe520e5199f688618f43aace5443980d1ddcf1b29e"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-go"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b13d476345220dbe600147dd444165c5791bf85ef53e28acbedd46112ee18431"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-html"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "261b708e5d92061ede329babaaa427b819329a9d427a1d710abb0f67bbef63ee"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-javascript"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf40bf599e0416c16c125c3cec10ee5ddc7d1bb8b0c60fa5c4de249ad34dc1b1"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-json"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86a5d6b3ea17e06e7a34aabeadd68f5866c0d0f9359155d432095f8b751865e4"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-python"
+version = "0.23.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d065aaa27f3aaceaf60c1f0e0ac09e1cb9eb8ed28e7bcdaa52129cffc7f4b04"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-rust"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439e577dbe07423ec2582ac62c7531120dbfccfa6e5f92406f93dd271a120e45"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-typescript"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/secrets",
     "crates/state",
     "crates/tools",
+    "crates/deepmap",
     "crates/tui",
     "crates/tui-core",
 ]

--- a/crates/deepmap/Cargo.toml
+++ b/crates/deepmap/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "deepmap"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Codebase analysis engine with tree-sitter + PageRank for DeepSeek-TUI"
+
+[dependencies]
+tree-sitter = "0.25"
+tree-sitter-language = "0.1"
+tree-sitter-rust = "0.24"
+tree-sitter-python = "0.23"
+tree-sitter-javascript = "0.23"
+tree-sitter-typescript = "0.23"
+tree-sitter-go = "0.23"
+tree-sitter-html = "0.23"
+tree-sitter-css = "0.23"
+tree-sitter-json = "0.23"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+ignore = "0.4"
+chrono = { version = "0.4", features = ["serde"] }
+dirs = "6.0"
+log = "0.4"
+sha2 = "0.10"

--- a/crates/deepmap/src/lib.rs
+++ b/crates/deepmap/src/lib.rs
@@ -1,0 +1,8 @@
+//! DeepMap — Codebase analysis engine for DeepSeek-TUI.
+//!
+//! PR 1: Parsing layer — types, tree-sitter queries, multi-language parser, import resolver.
+
+pub mod parser;
+pub mod queries;
+pub mod resolver;
+pub mod types;

--- a/crates/deepmap/src/parser.rs
+++ b/crates/deepmap/src/parser.rs
@@ -70,6 +70,7 @@ impl TreeSitterAdapter {
         try_load!("python", tree_sitter_python::LANGUAGE);
         try_load!("javascript", tree_sitter_javascript::LANGUAGE);
         try_load!("typescript", tree_sitter_typescript::LANGUAGE_TYPESCRIPT);
+        try_load!("tsx", tree_sitter_typescript::LANGUAGE_TSX);
         try_load!("go", tree_sitter_go::LANGUAGE);
         try_load!("html", tree_sitter_html::LANGUAGE);
         try_load!("css", tree_sitter_css::LANGUAGE);
@@ -185,6 +186,11 @@ impl TreeSitterAdapter {
 
     pub fn symbols(&self) -> Vec<Symbol> {
         self.current_symbols.clone()
+    }
+
+    /// Returns true if a parser for the given language name is loaded.
+    pub fn has_parser(&self, lang: &str) -> bool {
+        self.parsers.contains_key(lang)
     }
 
     pub fn imports(&self) -> Vec<String> {
@@ -510,8 +516,15 @@ impl TreeSitterAdapter {
         lines.sort(); lines.dedup();
         let mut results = Vec::new();
         for l in lines {
-            if let Some(p) = paths.get(&l) { results.push(p.clone()); }
-            else if let Some(ns) = names.get(&l) { for n in ns { results.push(n.clone()); } }
+            match (paths.get(&l), names.get(&l)) {
+                (Some(p), Some(ns)) => {
+                    // Concatenate path and name for scoped identifiers (e.g. std::collections)
+                    for n in ns { results.push(format!("{}::{}", p, n)); }
+                }
+                (Some(p), None) => { results.push(p.clone()); }
+                (None, Some(ns)) => { for n in ns { results.push(n.clone()); } }
+                (None, None) => {}
+            }
         }
         results
     }

--- a/crates/deepmap/src/parser.rs
+++ b/crates/deepmap/src/parser.rs
@@ -1,0 +1,1229 @@
+//! Multi-language code parser backed by tree-sitter.
+//!
+//! Provides [`TreeSitterAdapter`] which manages per-language parsers, compiled
+//! queries, and per-file extraction of symbols, imports, calls, and JS/TS
+//! import/export bindings.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use crate::types::{JsExportBinding, JsImportBinding, Symbol};
+use crate::queries;
+use tree_sitter::{Language, Node, Parser, Query, QueryCursor, StreamingIterator, Tree};
+
+// ---------------------------------------------------------------------------
+// Raw query capture
+// ---------------------------------------------------------------------------
+
+/// A single capture produced by a tree-sitter query match.
+#[derive(Debug, Clone)]
+struct RawCapture {
+    name: String,
+    kind: String,
+    start_byte: usize,
+    end_byte: usize,
+    start_row: usize,
+    end_row: usize,
+    start_col: usize,
+}
+
+// ---------------------------------------------------------------------------
+// TreeSitterAdapter
+// ---------------------------------------------------------------------------
+
+/// Multi-language adapter that owns per-language parsers, compiled queries, and
+/// per-file extraction buffers.
+pub struct TreeSitterAdapter {
+    parsers: HashMap<String, Parser>,
+    queries: HashMap<String, HashMap<String, Query>>,
+    languages: HashMap<String, Language>,
+
+    current_symbols: Vec<Symbol>,
+    current_imports: Vec<String>,
+    current_calls: Vec<(String, usize, String)>,
+    current_import_bindings: Vec<JsImportBinding>,
+    current_exports: Vec<JsExportBinding>,
+    current_file: String,
+}
+
+impl TreeSitterAdapter {
+    /// Create a new adapter, load available language parsers, and compile queries.
+    pub fn new() -> Self {
+        let mut parsers: HashMap<String, Parser> = HashMap::new();
+        let mut languages: HashMap<String, Language> = HashMap::new();
+
+        // Convenience macro: try to create a parser for `$name` using the
+        // `LanguageFn` constant `$const`.  Silently skips unavailable parsers.
+        macro_rules! try_load {
+            ($name:expr, $lang_fn:expr) => {{
+                let lang: Language = $lang_fn.into();
+                let mut p = Parser::new();
+                if p.set_language(&lang).is_ok() {
+                    let name: &str = $name;
+                    parsers.insert(name.to_string(), p);
+                    languages.insert(name.to_string(), lang);
+                }
+            }};
+        }
+
+        try_load!("rust", tree_sitter_rust::LANGUAGE);
+        try_load!("python", tree_sitter_python::LANGUAGE);
+        try_load!("javascript", tree_sitter_javascript::LANGUAGE);
+        try_load!("typescript", tree_sitter_typescript::LANGUAGE_TYPESCRIPT);
+        try_load!("go", tree_sitter_go::LANGUAGE);
+        try_load!("html", tree_sitter_html::LANGUAGE);
+        try_load!("css", tree_sitter_css::LANGUAGE);
+        try_load!("json", tree_sitter_json::LANGUAGE);
+
+        let mut adapter = Self {
+            parsers,
+            queries: HashMap::new(),
+            languages,
+            current_symbols: Vec::new(),
+            current_imports: Vec::new(),
+            current_calls: Vec::new(),
+            current_import_bindings: Vec::new(),
+            current_exports: Vec::new(),
+            current_file: String::new(),
+        };
+        adapter.init_queries();
+        adapter
+    }
+
+    // -----------------------------------------------------------------------
+    // Query initialisation
+    // -----------------------------------------------------------------------
+
+    /// For every (lang, qtype, pattern) returned by [`queries()`], if a parser
+    /// for that language is loaded, compile the pattern and store it.
+    fn init_queries(&mut self) {
+        let entries: Vec<(String, String, String)> = queries::queries()
+            .into_iter()
+            .filter(|(lang, _, _)| self.parsers.contains_key(*lang))
+            .map(|(lang, qtype, pattern)| (lang.to_string(), qtype.to_string(), pattern.to_string()))
+            .collect();
+
+        for (lang, qtype, pattern) in entries {
+            let language = self.languages.get(&lang).expect("language must exist");
+            if let Ok(query) = Query::new(language, &pattern) {
+                self.queries.entry(lang).or_default().insert(qtype, query);
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Main parse entry-point
+    // -----------------------------------------------------------------------
+
+    /// Parse `content` (identified by `path` and `lang`), extracting symbols,
+    /// imports, calls, and JS/TS import/export bindings into the per-file
+    /// buffers.  Results are exposed via the accessor methods below.
+    pub fn parse(&mut self, path: &Path, content: &str, lang: &str) -> Result<(), String> {
+        // Size guard: 10 MB max.
+        const MAX_BYTES: usize = 10 * 1024 * 1024;
+        if content.len() > MAX_BYTES {
+            return Err(format!(
+                "file exceeds size limit: {} > {}",
+                content.len(),
+                MAX_BYTES
+            ));
+        }
+
+        let parser = self
+            .parsers
+            .get_mut(lang)
+            .ok_or_else(|| format!("no parser for language: {lang}"))?;
+
+        let source_bytes = content.as_bytes();
+        let tree: Tree = parser
+            .parse(source_bytes, None)
+            .ok_or_else(|| "parse returned None".to_string())?;
+        let root = tree.root_node();
+
+        // Depth guard: refuse to analyse excessively nested files.
+        if has_excessive_nesting(root, 1000) {
+            return Err("excessive nesting depth (>1000)".to_string());
+        }
+
+        // Reset per-file buffers.
+        self.current_file = path.to_string_lossy().to_string();
+        self.current_symbols = self.extract_symbols(root, source_bytes, lang);
+        self.current_imports = self.extract_imports(root, source_bytes, lang);
+        self.current_calls = self.extract_calls(root, source_bytes, lang);
+        self.current_import_bindings.clear();
+        self.current_exports.clear();
+
+        if lang == "javascript" || lang == "typescript" {
+            self.current_import_bindings =
+                self.extract_js_ts_import_bindings(root, source_bytes);
+            self.current_exports = self.extract_js_ts_export_bindings(root, source_bytes);
+
+            // Extra symbol passes for JS/TS.
+            let extra = self.extract_object_literal_methods(root, source_bytes);
+            self.current_symbols.extend(extra);
+            let extra = self.extract_anonymous_symbols(root, source_bytes);
+            self.current_symbols.extend(extra);
+            let extra = self.extract_exported_function_expressions(root, source_bytes);
+            self.current_symbols.extend(extra);
+
+            // Re-sort and deduplicate the extended symbol list.
+            // Sort by span size ascending then col ascending.
+            self.current_symbols.sort_by(|a, b| {
+                let span_a = a.end_line.saturating_sub(a.line);
+                let span_b = b.end_line.saturating_sub(b.line);
+                span_a.cmp(&span_b).then(a.col.cmp(&b.col))
+            });
+            self.current_symbols.dedup_by(|a, b| a.name == b.name && a.line == b.line);
+        }
+
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------------
+    // Public accessors
+    // -----------------------------------------------------------------------
+
+    pub fn symbols(&self) -> Vec<Symbol> {
+        self.current_symbols.clone()
+    }
+
+    pub fn imports(&self) -> Vec<String> {
+        self.current_imports.clone()
+    }
+
+    pub fn calls(&self) -> Vec<(String, usize, String)> {
+        self.current_calls.clone()
+    }
+
+    pub fn import_bindings(&self) -> Vec<JsImportBinding> {
+        self.current_import_bindings.clone()
+    }
+
+    pub fn exports(&self) -> Vec<JsExportBinding> {
+        self.current_exports.clone()
+    }
+
+    // -----------------------------------------------------------------------
+    // Internal helpers
+    // -----------------------------------------------------------------------
+
+    /// Execute a compiled query of type `qtype` for `lang` and collect
+    /// captures that match the `@name` and `@def` anchors.
+    fn run_query<'tree>(
+        &self,
+        lang: &str,
+        qtype: &str,
+        root: Node<'tree>,
+        source_bytes: &'tree [u8],
+    ) -> Vec<RawCapture> {
+        let lang_map = match self.queries.get(lang) {
+            Some(m) => m,
+            None => return Vec::new(),
+        };
+        let query = match lang_map.get(qtype) {
+            Some(q) => q,
+            None => return Vec::new(),
+        };
+
+        let name_idx = query.capture_index_for_name("name");
+        let def_idx = query.capture_index_for_name("def");
+
+        let mut cursor = QueryCursor::new();
+        let mut qc = cursor.captures(query, root, source_bytes);
+
+        let mut results: Vec<RawCapture> = Vec::new();
+
+        while let Some(item) = qc.next() {
+            let (match_, _idx) = item;
+
+            let mut name_node: Option<Node<'tree>> = None;
+            let mut def_node: Option<Node<'tree>> = None;
+
+            for cap in match_.captures {
+                if let Some(ni) = name_idx {
+                    if cap.index == ni {
+                        name_node = Some(cap.node);
+                        continue;
+                    }
+                }
+                if let Some(di) = def_idx {
+                    if cap.index == di {
+                        def_node = Some(cap.node);
+                    }
+                }
+            }
+
+            // Pick a representative node — prefer @def for span info,
+            // fall back to any captured node when neither anchor exists.
+            let span_node = def_node.or(name_node);
+            let text_node = name_node.or(def_node);
+
+            if let (Some(tn), Some(sn)) = (text_node, span_node) {
+                let start_pos = sn.start_position();
+                let end_pos = sn.end_position();
+                results.push(RawCapture {
+                    name: node_text(tn, source_bytes).to_string(),
+                    kind: sn.kind().to_string(),
+                    start_byte: sn.start_byte(),
+                    end_byte: sn.end_byte(),
+                    start_row: start_pos.row,
+                    end_row: end_pos.row,
+                    start_col: start_pos.column,
+                });
+            }
+        }
+
+        results
+    }
+
+    // -----------------------------------------------------------------------
+    // Symbol extraction
+    // -----------------------------------------------------------------------
+
+    /// Extract top-level and nested symbols from `root` using the "function"
+    /// and "class" queries.  HTML / CSS / JSON use specialised extractors.
+    fn extract_symbols<'tree>(
+        &self,
+        root: Node<'tree>,
+        source_bytes: &'tree [u8],
+        lang: &str,
+    ) -> Vec<Symbol> {
+        let file = &self.current_file;
+
+        match lang {
+            "html" => return self.extract_html_symbols(root, source_bytes, file),
+            "css" => return self.extract_css_symbols(root, source_bytes, file),
+            "json" => return self.extract_json_symbols(root, source_bytes, file),
+            _ => {}
+        }
+
+        let mut captures = self.run_query(lang, "function", root, source_bytes);
+        captures.extend(self.run_query(lang, "class", root, source_bytes));
+
+        // Sort: span size ascending, then start_byte ascending.
+        captures.sort_by(|a, b| {
+            let span_a = a.end_byte.saturating_sub(a.start_byte);
+            let span_b = b.end_byte.saturating_sub(b.start_byte);
+            span_a
+                .cmp(&span_b)
+                .then(a.start_byte.cmp(&b.start_byte))
+        });
+
+        // Deduplicate by (name, start_row).
+        captures.dedup_by(|a, b| a.name == b.name && a.start_row == b.start_row);
+
+        captures
+            .into_iter()
+            .map(|rc| {
+                let id = format!("{}:{}:{}", file, rc.name, rc.start_row);
+                Symbol::new(
+                    id,
+                    rc.name,
+                    rc.kind,
+                    file.to_string(),
+                    rc.start_row,
+                    rc.end_row,
+                    rc.start_col,
+                    "public".to_string(),
+                    String::new(),
+                    String::new(),
+                )
+            })
+            .collect()
+    }
+
+    /// Extract HTML tag names as symbols.
+    fn extract_html_symbols<'tree>(
+        &self,
+        root: Node<'tree>,
+        source_bytes: &'tree [u8],
+        file: &str,
+    ) -> Vec<Symbol> {
+        let mut symbols = Vec::new();
+        let nodes = walk_tree(root);
+        for node in &nodes {
+            if node.kind() == "element" {
+                let mut cursor = node.walk();
+                for child in node.children(&mut cursor) {
+                    if child.kind() == "start_tag" {
+                        if let Some(tag_name) = first_child_of_type(child, "tag_name") {
+                            let name = node_text(tag_name, source_bytes).to_string();
+                            let pos = tag_name.start_position();
+                            let end = tag_name.end_position();
+                            let id = format!("{}:{}:{}", file, name, pos.row);
+                            symbols.push(Symbol::new(
+                                id,
+                                name,
+                                "html_tag".to_string(),
+                                file.to_string(),
+                                pos.row,
+                                end.row,
+                                pos.column,
+                                "public".to_string(),
+                                String::new(),
+                                String::new(),
+                            ));
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+        symbols
+    }
+
+    /// Extract CSS class / id / tag selectors as symbols.
+    fn extract_css_symbols<'tree>(
+        &self,
+        root: Node<'tree>,
+        source_bytes: &'tree [u8],
+        file: &str,
+    ) -> Vec<Symbol> {
+        let mut symbols = Vec::new();
+        let nodes = walk_tree(root);
+        for node in &nodes {
+            let kind = node.kind();
+            let (sym_kind, name) = match kind {
+                "class_selector" => {
+                    let inner = node_text(*node, source_bytes);
+                    ("css_class".to_string(), inner.trim_start_matches('.').to_string())
+                }
+                "id_selector" => {
+                    let inner = node_text(*node, source_bytes);
+                    ("css_id".to_string(), inner.trim_start_matches('#').to_string())
+                }
+                "tag_name" => ("css_tag".to_string(), node_text(*node, source_bytes).to_string()),
+                _ => continue,
+            };
+            let pos = node.start_position();
+            let end = node.end_position();
+            let id = format!("{}:{}:{}", file, name, pos.row);
+            symbols.push(Symbol::new(
+                id,
+                name,
+                sym_kind,
+                file.to_string(),
+                pos.row,
+                end.row,
+                pos.column,
+                "public".to_string(),
+                String::new(),
+                String::new(),
+            ));
+        }
+        symbols
+    }
+
+    /// Extract JSON property keys as symbols.
+    fn extract_json_symbols<'tree>(
+        &self,
+        root: Node<'tree>,
+        source_bytes: &'tree [u8],
+        file: &str,
+    ) -> Vec<Symbol> {
+        let mut symbols = Vec::new();
+        let nodes = walk_tree(root);
+        for node in &nodes {
+            if node.kind() == "pair" {
+                if let Some(key_node) = node.child(0) {
+                    let raw = node_text(key_node, source_bytes);
+                    let name = raw.trim_matches('"').to_string();
+                    let pos = key_node.start_position();
+                    let end = key_node.end_position();
+                    let id = format!("{}:{}:{}", file, name, pos.row);
+                    symbols.push(Symbol::new(
+                        id,
+                        name,
+                        "json_key".to_string(),
+                        file.to_string(),
+                        pos.row,
+                        end.row,
+                        pos.column,
+                        "public".to_string(),
+                        String::new(),
+                        String::new(),
+                    ));
+                }
+            }
+        }
+        symbols
+    }
+
+    // -----------------------------------------------------------------------
+    // Import extraction (module paths)
+    // -----------------------------------------------------------------------
+
+    /// Extract imported module paths.  Strips language-specific decorations
+    /// (quotes, angle brackets, `::` separators, etc.).
+    fn extract_imports<'tree>(
+        &self,
+        root: Node<'tree>,
+        source_bytes: &'tree [u8],
+        lang: &str,
+    ) -> Vec<String> {
+        // For Rust, run query directly to capture both @path and @name.
+        if lang == "rust" {
+            return self.extract_rust_imports(root, source_bytes);
+        }
+        let captures = self.run_query(lang, "import", root, source_bytes);
+        let mut imports: Vec<String> = captures.into_iter().map(|rc| rc.name).collect();
+
+        for imp in &mut imports {
+            match lang {
+                "javascript" | "typescript" => {
+                    *imp = imp.trim_matches('"').trim_matches('\'').to_string();
+                }
+                "cpp" => {
+                    *imp = imp.trim_matches('"').trim_matches('\'')
+                        .trim_start_matches('<').trim_end_matches('>').to_string();
+                }
+                "php" => { *imp = imp.trim_matches('"').trim_matches('\'').to_string(); }
+                _ => {}
+            }
+        }
+        imports.retain(|i| !i.is_empty());
+        imports.sort();
+        imports.dedup();
+        imports
+    }
+
+    fn extract_rust_imports<'tree>(&self, root: Node<'tree>, sb: &'tree [u8]) -> Vec<String> {
+        let q = match self.queries.get("rust").and_then(|m| m.get("import")) {
+            Some(q) => q, None => return vec![]
+        };
+        use std::collections::BTreeMap;
+        let mut paths: BTreeMap<usize, String> = BTreeMap::new();
+        let mut names: BTreeMap<usize, Vec<String>> = BTreeMap::new();
+        let mut cursor = QueryCursor::new();
+        let cnames = q.capture_names().to_vec();
+        let mut caps = cursor.captures(q, root, sb);
+        while let Some((m, _)) = caps.next() {
+            for c in m.captures {
+                let cn = cnames[c.index as usize];
+                let text = node_text(c.node, sb).to_string();
+                let line = c.node.start_position().row + 1;
+                if cn == "path" { paths.insert(line, text); }
+                else if cn == "name" { names.entry(line).or_default().push(text); }
+            }
+        }
+        let mut lines: Vec<usize> = paths.keys().chain(names.keys()).copied().collect();
+        lines.sort(); lines.dedup();
+        let mut results = Vec::new();
+        for l in lines {
+            if let Some(p) = paths.get(&l) { results.push(p.clone()); }
+            else if let Some(ns) = names.get(&l) { for n in ns { results.push(n.clone()); } }
+        }
+        results
+    }
+
+    // -----------------------------------------------------------------------
+    // Call extraction
+    // -----------------------------------------------------------------------
+
+    /// Extract call expressions and classify the reference kind.
+    fn extract_calls<'tree>(
+        &self,
+        root: Node<'tree>,
+        source_bytes: &'tree [u8],
+        lang: &str,
+    ) -> Vec<(String, usize, String)> {
+        let captures = self.run_query(lang, "call", root, source_bytes);
+
+        let mut calls: Vec<(String, usize, String)> = captures
+            .into_iter()
+            .map(|rc| {
+                let kind = call_reference_kind_by_name(&rc.name);
+                (rc.name, rc.start_row, kind)
+            })
+            .collect();
+
+        calls.sort();
+        calls.dedup_by(|a, b| a.0 == b.0 && a.1 == b.1);
+        calls
+    }
+
+    // -----------------------------------------------------------------------
+    // JS/TS import bindings
+    // -----------------------------------------------------------------------
+
+    /// Walk the AST for `import_statement` (ES modules) and `call_expression`
+    /// (CommonJS `require`) nodes, producing structured binding records.
+    fn extract_js_ts_import_bindings<'tree>(
+        &self,
+        root: Node<'tree>,
+        source_bytes: &'tree [u8],
+    ) -> Vec<JsImportBinding> {
+        let mut bindings = Vec::new();
+        let nodes = walk_tree(root);
+
+        // --- ES module imports -------------------------------------------------
+        for node in &nodes {
+            if node.kind() != "import_statement" {
+                continue;
+            }
+            let line = node.start_position().row;
+
+            // Source module string (e.g. "react", "./foo").
+            let source_node = node.child_by_field_name("source");
+            let module = source_node
+                .map(|n| {
+                    let raw = node_text(n, source_bytes);
+                    raw.trim_matches('"').trim_matches('\'').to_string()
+                })
+                .unwrap_or_default();
+
+            // The import clause carries the identifiers.
+            let mut clause_cursor = node.walk();
+            for child in node.children(&mut clause_cursor) {
+                if child.kind() != "import_clause" {
+                    continue;
+                }
+
+                // 1) Default import  e.g. `import React from 'react'`
+                if let Some(name_node) = child.child_by_field_name("name") {
+                    let local_name = node_text(name_node, source_bytes).to_string();
+                    bindings.push(JsImportBinding {
+                        local_name,
+                        imported_name: "default".to_string(),
+                        module: module.clone(),
+                        line,
+                        kind: "es_default".to_string(),
+                    });
+                }
+
+                // 2) Named imports & namespace import
+                let mut inner = child.walk();
+                for sub in child.children(&mut inner) {
+                    match sub.kind() {
+                        "named_imports" => {
+                            Self::collect_named_imports(&sub, source_bytes, &module, line, &mut bindings);
+                        }
+                        "namespace_import" => {
+                            if let Some(ns) = sub.child_by_field_name("name") {
+                                let local_name = node_text(ns, source_bytes).to_string();
+                                bindings.push(JsImportBinding {
+                                    local_name,
+                                    imported_name: "*".to_string(),
+                                    module: module.clone(),
+                                    line,
+                                    kind: "es_namespace".to_string(),
+                                });
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+
+        // --- CommonJS require --------------------------------------------------
+        for node in &nodes {
+            if node.kind() != "call_expression" {
+                continue;
+            }
+            let callee = match node.child(0) {
+                Some(c) => c,
+                None => continue,
+            };
+            let callee_text = node_text(callee, source_bytes);
+            if callee_text != "require" {
+                continue;
+            }
+            let module_arg = match node.child_by_field_name("arguments").or_else(|| node.child(1)) {
+                Some(a) => a,
+                None => continue,
+            };
+            let module = node_text(module_arg, source_bytes)
+                .trim_matches('"')
+                .trim_matches('\'')
+                .to_string();
+            let line = node.start_position().row;
+
+            // Walk up to the enclosing variable declarator so we can name the
+            // local binding.
+            let parent = node.parent();
+            let grand = parent.and_then(|p| p.parent());
+            match grand {
+                Some(decl) if decl.kind() == "variable_declarator" => {
+                    // Simple: `const x = require(...)`
+                    if let Some(lhs) = decl.child_by_field_name("name") {
+                        if lhs.kind() == "identifier" {
+                            let local = node_text(lhs, source_bytes).to_string();
+                            bindings.push(JsImportBinding {
+                                local_name: local,
+                                imported_name: "default".to_string(),
+                                module: module.clone(),
+                                line,
+                                kind: "cjs_default".to_string(),
+                            });
+                        } else if lhs.kind() == "object_pattern" {
+                            Self::collect_destructured_require(
+                                &lhs, source_bytes, &module, line, &mut bindings,
+                            );
+                        }
+                    }
+                }
+                Some(assign) if assign.kind() == "assignment_expression" => {
+                    if let Some(lhs) = assign.child(0) {
+                        let local = node_text(lhs, source_bytes).to_string();
+                        bindings.push(JsImportBinding {
+                            local_name: local,
+                            imported_name: "default".to_string(),
+                            module: module.clone(),
+                            line,
+                            kind: "cjs_default".to_string(),
+                        });
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        bindings
+    }
+
+    /// Collect named imports from a `named_imports` subtree.
+    fn collect_named_imports<'tree>(
+        node: &Node<'tree>,
+        source_bytes: &'tree [u8],
+        module: &str,
+        line: usize,
+        bindings: &mut Vec<JsImportBinding>,
+    ) {
+        let mut cur = node.walk();
+        for child in node.children(&mut cur) {
+            if child.kind() != "import_specifier" {
+                continue;
+            }
+            let imported = child
+                .child_by_field_name("name")
+                .map(|n| node_text(n, source_bytes).to_string())
+                .unwrap_or_default();
+            let local = child
+                .child_by_field_name("alias")
+                .map(|n| node_text(n, source_bytes).to_string())
+                .unwrap_or_else(|| imported.clone());
+
+            bindings.push(JsImportBinding {
+                local_name: local,
+                imported_name: imported,
+                module: module.to_string(),
+                line,
+                kind: "es_named".to_string(),
+            });
+        }
+    }
+
+    /// Collect destructured require bindings from an object pattern.
+    fn collect_destructured_require<'tree>(
+        node: &Node<'tree>,
+        source_bytes: &'tree [u8],
+        module: &str,
+        line: usize,
+        bindings: &mut Vec<JsImportBinding>,
+    ) {
+        let mut cur = node.walk();
+        for child in node.children(&mut cur) {
+            let local = match child.kind() {
+                "shorthand_property_identifier_pattern"
+                | "property_identifier_pattern" => {
+                    node_text(child, source_bytes).to_string()
+                }
+                _ => continue,
+            };
+            bindings.push(JsImportBinding {
+                local_name: local.clone(),
+                imported_name: local,
+                module: module.to_string(),
+                line,
+                kind: "cjs_named".to_string(),
+            });
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // JS/TS export bindings
+    // -----------------------------------------------------------------------
+
+    /// Walk for `export_statement` (ES modules) and `assignment_expression`
+    /// (CommonJS `module.exports` / `exports.xxx`).
+    fn extract_js_ts_export_bindings<'tree>(
+        &self,
+        root: Node<'tree>,
+        source_bytes: &'tree [u8],
+    ) -> Vec<JsExportBinding> {
+        let mut exports = Vec::new();
+        let nodes = walk_tree(root);
+        let mut seen = std::collections::HashSet::new();
+
+        // --- ES module exports -------------------------------------------------
+        for node in &nodes {
+            if node.kind() != "export_statement" {
+                continue;
+            }
+            let line = node.start_position().row;
+
+            // 1) Named declaration  e.g. `export const foo = 1`
+            if let Some(decl) = node.child_by_field_name("declaration") {
+                Self::collect_export_from_declaration(
+                    &decl, source_bytes, None, line, &mut exports, &mut seen,
+                );
+                continue;
+            }
+
+            // 2) Default export  e.g. `export default function() {}`
+            if let Some(default_node) = node.child_by_field_name("default") {
+                let name = node_text(default_node, source_bytes).to_string();
+                let is_named_decl = default_node.is_named()
+                    && default_node.kind() != "function_declaration"
+                    && default_node.kind() != "class_declaration";
+                let binding = JsExportBinding {
+                    exported_name: "default".to_string(),
+                    source_name: if is_named_decl { Some(name) } else { None },
+                    module: None,
+                    line,
+                    kind: "es_default".to_string(),
+                };
+                if seen.insert((binding.exported_name.clone(), binding.line)) {
+                    exports.push(binding);
+                }
+                continue;
+            }
+
+            // 3) Export clause (named re-export or local re-export)
+            let mut clause_cursor = node.walk();
+            for child in node.children(&mut clause_cursor) {
+                if child.kind() == "export_clause" {
+                    let source_node = node.child_by_field_name("source");
+                    let module = source_node.map(|n| {
+                        node_text(n, source_bytes)
+                            .trim_matches('"')
+                            .trim_matches('\'')
+                            .to_string()
+                    });
+
+                    Self::collect_export_specifiers(
+                        &child, source_bytes, module, line, &mut exports, &mut seen,
+                    );
+                }
+            }
+        }
+
+        // --- CommonJS exports --------------------------------------------------
+        for node in &nodes {
+            if node.kind() != "assignment_expression" {
+                continue;
+            }
+            let lhs = match node.child(0) {
+                Some(c) => c,
+                None => continue,
+            };
+            let rhs = match node.child(1).or_else(|| node.child(2)) {
+                Some(c) => c,
+                None => continue,
+            };
+            let line = node.start_position().row;
+
+            if lhs.kind() != "member_expression" {
+                continue;
+            }
+            let lhs_text = node_text(lhs, source_bytes);
+
+            // `module.exports = <value>`
+            if lhs_text == "module.exports" {
+                let source_name = node_text(rhs, source_bytes).to_string();
+                let binding = JsExportBinding {
+                    exported_name: "module.exports".to_string(),
+                    source_name: Some(source_name),
+                    module: None,
+                    line,
+                    kind: "cjs".to_string(),
+                };
+                if seen.insert((binding.exported_name.clone(), binding.line)) {
+                    exports.push(binding);
+                }
+                continue;
+            }
+
+            // `exports.xxx = <value>`
+            if let Some(rest) = lhs_text.strip_prefix("exports.") {
+                let source_name = node_text(rhs, source_bytes).to_string();
+                let binding = JsExportBinding {
+                    exported_name: rest.to_string(),
+                    source_name: Some(source_name),
+                    module: None,
+                    line,
+                    kind: "cjs".to_string(),
+                };
+                if seen.insert((binding.exported_name.clone(), binding.line)) {
+                    exports.push(binding);
+                }
+            }
+        }
+
+        exports
+    }
+
+    /// Extract exported names from a declaration node.
+    fn collect_export_from_declaration<'tree>(
+        node: &Node<'tree>,
+        source_bytes: &'tree [u8],
+        module: Option<String>,
+        line: usize,
+        exports: &mut Vec<JsExportBinding>,
+        seen: &mut std::collections::HashSet<(String, usize)>,
+    ) {
+        let kind = node.kind();
+        let name_node: Option<Node<'tree>> = match kind {
+            "function_declaration"
+            | "class_declaration"
+            | "generator_function_declaration" => {
+                node.child_by_field_name("name")
+            }
+            "lexical_declaration" | "variable_declaration" => {
+                let mut cur = node.walk();
+                node.children(&mut cur)
+                    .find(|c| c.kind() == "variable_declarator")
+                    .and_then(|decl| decl.child_by_field_name("name"))
+            }
+            _ => None,
+        };
+
+        if let Some(nn) = name_node {
+            let name = node_text(nn, source_bytes).to_string();
+            let binding = JsExportBinding {
+                exported_name: name,
+                source_name: None,
+                module,
+                line,
+                kind: "es_named".to_string(),
+            };
+            if seen.insert((binding.exported_name.clone(), binding.line)) {
+                exports.push(binding);
+            }
+        }
+    }
+
+    /// Collect export specifiers from an `export_clause`.
+    ///
+    /// Grammar: `export_specifier (name as alias?)` where `name` is the local
+    /// identifier and `alias` is the externally visible name (if present).
+    fn collect_export_specifiers<'tree>(
+        node: &Node<'tree>,
+        source_bytes: &'tree [u8],
+        module: Option<String>,
+        line: usize,
+        exports: &mut Vec<JsExportBinding>,
+        seen: &mut std::collections::HashSet<(String, usize)>,
+    ) {
+        let mut cur = node.walk();
+        for child in node.children(&mut cur) {
+            if child.kind() != "export_specifier" {
+                continue;
+            }
+            // `name` is the local/source identifier, `alias` is the exported
+            // name (after the `as` keyword).
+            let name = child
+                .child_by_field_name("name")
+                .map(|n| node_text(n, source_bytes).to_string())
+                .unwrap_or_default();
+            let alias = child
+                .child_by_field_name("alias")
+                .map(|n| node_text(n, source_bytes).to_string());
+
+            let exported_name = alias.clone().unwrap_or_else(|| name.clone());
+            let binding = JsExportBinding {
+                exported_name,
+                source_name: Some(name),
+                module: module.clone(),
+                line,
+                kind: "es_named".to_string(),
+            };
+            if seen.insert((binding.exported_name.clone(), binding.line)) {
+                exports.push(binding);
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Extra symbol passes for JS / TS
+    // -----------------------------------------------------------------------
+
+    /// Find method definitions inside object literals (e.g. `{ foo() {} }`).
+    fn extract_object_literal_methods<'tree>(
+        &self,
+        root: Node<'tree>,
+        source_bytes: &'tree [u8],
+    ) -> Vec<Symbol> {
+        let file = &self.current_file;
+        let mut symbols = Vec::new();
+        let nodes = walk_tree(root);
+
+        for node in &nodes {
+            if node.kind() != "pair" {
+                continue;
+            }
+            let mut cur = node.walk();
+            for child in node.children(&mut cur) {
+                if child.kind() != "method_definition" {
+                    continue;
+                }
+                let key = node
+                    .child_by_field_name("key")
+                    .or_else(|| node.child(0));
+                if let Some(k) = key {
+                    let name = node_text(k, source_bytes)
+                        .trim_matches('"')
+                        .trim_matches('\'')
+                        .to_string();
+                    let pos = k.start_position();
+                    let end = k.end_position();
+                    let id = format!("{}:{}:{}", file, name, pos.row);
+                    symbols.push(Symbol::new(
+                        id,
+                        name,
+                        "method".to_string(),
+                        file.to_string(),
+                        pos.row,
+                        end.row,
+                        pos.column,
+                        "public".to_string(),
+                        String::new(),
+                        String::new(),
+                    ));
+                }
+                break;
+            }
+        }
+
+        symbols
+    }
+
+    /// Find anonymous functions / classes assigned to variables
+    /// (e.g. `const foo = function() {}` or `let bar = () => {}`).
+    fn extract_anonymous_symbols<'tree>(
+        &self,
+        root: Node<'tree>,
+        source_bytes: &'tree [u8],
+    ) -> Vec<Symbol> {
+        let file = &self.current_file;
+        let mut symbols = Vec::new();
+        let nodes = walk_tree(root);
+
+        for node in &nodes {
+            if node.kind() != "variable_declarator" {
+                continue;
+            }
+            let name_node = node.child_by_field_name("name");
+            let value_node = node.child_by_field_name("value");
+
+            if let (Some(name_n), Some(value_n)) = (name_node, value_node) {
+                let sym_kind = match value_n.kind() {
+                    "function" | "function_expression" => "function",
+                    "arrow_function" => "arrow_function",
+                    "class" | "class_expression" => "class",
+                    _ => continue,
+                };
+
+                let name = node_text(name_n, source_bytes).to_string();
+                let pos = value_n.start_position();
+                let end = value_n.end_position();
+                let id = format!("{}:{}:{}", file, name, pos.row);
+                symbols.push(Symbol::new(
+                    id,
+                    name,
+                    sym_kind.to_string(),
+                    file.to_string(),
+                    pos.row,
+                    end.row,
+                    pos.column,
+                    "public".to_string(),
+                    String::new(),
+                    String::new(),
+                ));
+            }
+        }
+
+        symbols
+    }
+
+    /// Find exported function / class expressions (e.g. `export default function() {}`).
+    fn extract_exported_function_expressions<'tree>(
+        &self,
+        root: Node<'tree>,
+        _source_bytes: &'tree [u8],
+    ) -> Vec<Symbol> {
+        let file = &self.current_file;
+        let mut symbols = Vec::new();
+        let nodes = walk_tree(root);
+
+        for node in &nodes {
+            if node.kind() != "export_statement" {
+                continue;
+            }
+            let default_child = node.child_by_field_name("default");
+            let decl_child = node.child_by_field_name("declaration");
+
+            if let Some(def) = default_child {
+                let sym_kind = match def.kind() {
+                    "function" | "function_expression" | "generator_function" => "function",
+                    "arrow_function" => "arrow_function",
+                    "class" | "class_expression" => "class",
+                    _ => continue,
+                };
+
+                let name = format!("default_{}", sym_kind);
+                let pos = def.start_position();
+                let end = def.end_position();
+                let id = format!("{}:{}:{}", file, name, pos.row);
+                symbols.push(Symbol::new(
+                    id,
+                    name,
+                    sym_kind.to_string(),
+                    file.to_string(),
+                    pos.row,
+                    end.row,
+                    pos.column,
+                    "public".to_string(),
+                    String::new(),
+                    String::new(),
+                ));
+            } else if let Some(decl) = decl_child {
+                if decl.child_by_field_name("name").is_some() {
+                    continue;
+                }
+                let sym_kind = match decl.kind() {
+                    "function_declaration" => "function",
+                    "class_declaration" => "class",
+                    _ => continue,
+                };
+                let name = format!("exported_{}", sym_kind);
+                let pos = decl.start_position();
+                let end = decl.end_position();
+                let id = format!("{}:{}:{}", file, name, pos.row);
+                symbols.push(Symbol::new(
+                    id,
+                    name,
+                    sym_kind.to_string(),
+                    file.to_string(),
+                    pos.row,
+                    end.row,
+                    pos.column,
+                    "public".to_string(),
+                    String::new(),
+                    String::new(),
+                ));
+            }
+        }
+
+        symbols
+    }
+}
+
+// ===========================================================================
+// Module-level helpers
+// ===========================================================================
+
+/// Get the UTF-8 text of a syntax node.  Returns an empty string on encoding
+/// errors (should not happen for valid source code).
+pub fn node_text<'a>(node: Node<'a>, source_bytes: &'a [u8]) -> &'a str {
+    node.utf8_text(source_bytes).unwrap_or("")
+}
+
+/// Returns `true` if `child` is fully contained within `parent`.
+pub fn within<'tree>(child: Node<'tree>, parent: Node<'tree>) -> bool {
+    child.start_byte() >= parent.start_byte() && child.end_byte() <= parent.end_byte()
+}
+
+/// Classify a call-reference kind based on the name string.
+fn call_reference_kind_by_name(name: &str) -> String {
+    if name.contains('.') {
+        "member".to_string()
+    } else if name.contains("::") {
+        "scoped".to_string()
+    } else {
+        "direct".to_string()
+    }
+}
+
+/// Classify the reference kind of a call expression node by inspecting its
+/// children.
+pub fn call_reference_kind<'tree>(node: Node<'tree>) -> String {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        match child.kind() {
+            "member_expression" => return "member".to_string(),
+            "scoped_identifier" | "qualified_name" => return "scoped".to_string(),
+            _ => {}
+        }
+    }
+    "direct".to_string()
+}
+
+/// Walk the entire subtree rooted at `root` in pre-order and return all nodes.
+pub fn walk_tree<'tree>(root: Node<'tree>) -> Vec<Node<'tree>> {
+    let mut nodes = Vec::new();
+    let mut stack = vec![root];
+
+    while let Some(node) = stack.pop() {
+        nodes.push(node);
+        // Push children in reverse order so they are visited left-to-right
+        // when popped.
+        let mut cursor = node.walk();
+        let mut children: Vec<Node<'tree>> = node.children(&mut cursor).collect();
+        children.reverse();
+        stack.extend(children);
+    }
+
+    nodes
+}
+
+/// Find the first child of `node` whose kind equals `kind`.
+pub fn first_child_of_type<'tree>(node: Node<'tree>, kind: &str) -> Option<Node<'tree>> {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == kind {
+            return Some(child);
+        }
+    }
+    None
+}
+
+/// Build a one-line signature from a node: the first non-empty line, trimmed.
+pub fn signature<'a>(node: Node<'a>, source_bytes: &'a [u8]) -> String {
+    let text = node_text(node, source_bytes);
+    text.lines()
+        .find(|l| !l.trim().is_empty())
+        .unwrap_or("")
+        .trim()
+        .to_string()
+}
+
+// ===========================================================================
+// Private helpers
+// ===========================================================================
+
+/// Check whether the tree rooted at `root` exceeds `max_depth` levels of
+/// nesting.  Uses iterative cursor traversal to avoid stack overflow.
+fn has_excessive_nesting<'tree>(root: Node<'tree>, max_depth: u32) -> bool {
+    let mut cursor = root.walk();
+    loop {
+        if cursor.depth() > max_depth {
+            return true;
+        }
+        if cursor.goto_first_child() {
+            continue;
+        }
+        if cursor.goto_next_sibling() {
+            continue;
+        }
+        loop {
+            if !cursor.goto_parent() {
+                return false;
+            }
+            if cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+}

--- a/crates/deepmap/src/queries.rs
+++ b/crates/deepmap/src/queries.rs
@@ -1,0 +1,84 @@
+//! Tree-sitter S-expression queries for multi-language code analysis.
+
+/// Return all registered queries as `(language, query_type, s-expression)` tuples.
+pub fn queries() -> Vec<(&'static str, &'static str, &'static str)> {
+    vec![
+        // ── Python ──
+        ("python", "function", "(function_definition name: (identifier) @name) @definition.function\n(decorated_definition (function_definition name: (identifier) @name)) @definition.function\n(class_definition body: (block (function_definition name: (identifier) @name))) @definition.method\n(assignment left: (identifier) @name right: (lambda)) @definition.lambda"),
+        ("python", "class", "(class_definition name: (identifier) @name) @definition.class\n(decorated_definition (class_definition name: (identifier) @name)) @definition.class"),
+        ("python", "import", "(import_statement name: (dotted_name) @name)\n(import_statement name: (aliased_import name: (dotted_name) @name))\n(import_from_statement module_name: (dotted_name) @name)\n(import_from_statement module_name: (relative_import) @name)"),
+        ("python", "call", "(call function: (identifier) @name) @reference.call\n(call function: (attribute attribute: (identifier) @name)) @reference.call"),
+
+        // ── JavaScript ──
+        ("javascript", "function", "(function_declaration name: (identifier) @name) @definition.function\n(variable_declarator name: (identifier) @name value: (arrow_function)) @definition.function\n(variable_declarator name: (identifier) @name value: (function_expression)) @definition.function\n(method_definition name: (property_identifier) @name) @definition.method"),
+        ("javascript", "anonymous_function", "(arrow_function) @definition.anonymous_function\n(function_expression) @definition.anonymous_function"),
+        ("javascript", "class", "(class_declaration name: (identifier) @name) @definition.class"),
+        ("javascript", "import", "(import_statement source: (string) @source)\n(import_specifier name: (identifier) @name)\n(import_clause (identifier) @name)"),
+        ("javascript", "call", "(call_expression function: (identifier) @name) @reference.call\n(call_expression function: (member_expression property: (property_identifier) @name)) @reference.call"),
+
+        // ── TypeScript ──
+        ("typescript", "function", "(function_declaration name: (identifier) @name) @definition.function\n(variable_declarator name: (identifier) @name value: (arrow_function)) @definition.function\n(method_definition name: (property_identifier) @name) @definition.method"),
+        ("typescript", "anonymous_function", "(arrow_function) @definition.anonymous_function\n(function_expression) @definition.anonymous_function"),
+        ("typescript", "class", "(class_declaration name: (_) @name) @definition.class"),
+        ("typescript", "import", "(import_statement source: (string) @source)\n(import_specifier name: (identifier) @name)\n(import_clause (identifier) @name)"),
+        ("typescript", "call", "(call_expression function: (identifier) @name) @reference.call\n(call_expression function: (member_expression property: (property_identifier) @name)) @reference.call"),
+
+        // ── Go ──
+        ("go", "function", "(function_declaration name: (identifier) @name) @definition.function\n(method_declaration name: (field_identifier) @name) @definition.method"),
+        ("go", "class", "(type_spec name: (type_identifier) @name type: (struct_type)) @definition.struct\n(type_spec name: (type_identifier) @name type: (interface_type)) @definition.interface"),
+        ("go", "import", "(import_spec path: (interpreted_string_literal) @path)"),
+        ("go", "call", "(call_expression function: (identifier) @name) @reference.call\n(call_expression function: (selector_expression field: (field_identifier) @name)) @reference.call"),
+
+        // ── Rust ──
+        ("rust", "function", "(function_item name: (identifier) @name) @definition.function\n(function_signature_item name: (identifier) @name) @definition.trait_method"),
+        ("rust", "class", "(struct_item name: (type_identifier) @name) @definition.struct\n(enum_item name: (type_identifier) @name) @definition.enum\n(trait_item name: (type_identifier) @name) @definition.trait\n(impl_item type: (type_identifier) @name) @definition.impl\n(type_item name: (type_identifier) @name) @definition.type\n(mod_item name: (identifier) @name) @definition.module"),
+        ("rust", "import", "(use_declaration argument: (scoped_identifier path: (identifier) @path name: (identifier) @name))\n(use_declaration argument: (scoped_use_list path: (identifier) @path))\n(extern_crate_declaration name: (identifier) @name)\n(use_declaration argument: (identifier) @name)"),
+        ("rust", "call", "(call_expression function: (identifier) @name) @reference.call\n(call_expression function: (field_expression field: (field_identifier) @name)) @reference.call\n(call_expression function: (scoped_identifier name: (identifier) @name)) @reference.call"),
+
+        // ── HTML ──
+        ("html", "function", ""),
+        ("html", "class", ""),
+        ("html", "import", ""),
+        ("html", "call", ""),
+
+        // ── CSS ──
+        ("css", "function", ""),
+        ("css", "class", ""),
+        ("css", "import", ""),
+        ("css", "call", ""),
+
+        // ── JSON ──
+        ("json", "function", ""),
+        ("json", "class", ""),
+        ("json", "import", ""),
+        ("json", "call", ""),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_total_query_count() {
+        assert_eq!(queries().len(), 34);
+    }
+
+    #[test]
+    fn test_all_sexp_balanced() {
+        for (lang, qtype, sexp) in &queries() {
+            if sexp.is_empty() { continue; }
+            let open = sexp.matches('(').count();
+            let close = sexp.matches(')').count();
+            assert_eq!(open, close, "unbalanced: ({}, {}) o={} c={}", lang, qtype, open, close);
+        }
+    }
+
+    #[test]
+    fn test_eight_languages_present() {
+        let langs: std::collections::HashSet<&str> = queries().iter().map(|(l, _, _)| *l).collect();
+        for l in &["python","javascript","typescript","go","rust","html","css","json"] {
+            assert!(langs.contains(l), "missing language: {}", l);
+        }
+    }
+}

--- a/crates/deepmap/src/resolver.rs
+++ b/crates/deepmap/src/resolver.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::fs;
 
@@ -10,10 +10,12 @@ use crate::types::{RepoGraph, ProjectImportConfig, PathAliasRule};
 pub struct ImportResolver {
     pub project_root: PathBuf,
     pub import_configs: Vec<ProjectImportConfig>,
-    /// File stem (filename without extension) -> candidate file paths.
+    /// File stem -> candidate file paths.
     pub file_map: HashMap<String, Vec<String>>,
-    /// Symbol name -> symbol IDs that share that name.
+    /// Symbol name -> symbol IDs.
     pub name_index: HashMap<String, Vec<String>>,
+    /// All known relative file paths for O(1) existence check.
+    known_paths: std::collections::HashSet<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -29,6 +31,7 @@ impl ImportResolver {
             import_configs: Vec::new(),
             file_map: HashMap::new(),
             name_index: HashMap::new(),
+            known_paths: std::collections::HashSet::new(),
         };
         this.build_indices(graph);
         this.discover_import_configs();
@@ -70,6 +73,11 @@ impl ImportResolver {
                 .entry(symbol.name.clone())
                 .or_default()
                 .push(sym_id.clone());
+        }
+
+        // Pre-compute set of all known file paths for O(1) existence check.
+        for file in graph.file_symbols.keys().chain(graph.file_imports.keys()) {
+            self.known_paths.insert(file.clone());
         }
     }
 
@@ -230,12 +238,20 @@ impl ImportResolver {
                 continue; // no replacement character
             }
 
+            // Trailing comma before } or ] — skip (string-safe: we're not inside a string here).
+            if chars[i] == ',' {
+                let mut j = i + 1;
+                while j < len && chars[j].is_whitespace() { j += 1; }
+                if j < len && (chars[j] == '}' || chars[j] == ']') {
+                    i += 1; // skip comma
+                    continue;
+                }
+            }
+
             out.push(chars[i]);
             i += 1;
         }
 
-        // remove trailing commas before } or ]
-        remove_trailing_commas(&mut out);
         out
     }
 }
@@ -298,33 +314,28 @@ impl ImportResolver {
     /// Probe `base_path` (exact, +extensions, +/index.ext) against the
     /// known file set.
     fn resolve_path_candidates(&self, base_path: &Path) -> Vec<String> {
-        // collect the set of known file paths for O(1) lookup
-        let known: HashSet<&str> = self
-            .file_map
-            .values()
-            .flat_map(|paths| paths.iter().map(|p| p.as_str()))
-            .collect();
-
         let base = base_path.to_string_lossy().to_string();
         let mut out = Vec::new();
 
-        if known.contains(base.as_str()) {
+        if self.known_paths.contains(&base) {
             out.push(base);
             return out;
         }
 
-        const EXTENSIONS: &[&str] = &[".ts", ".tsx", ".js", ".jsx", ".py", ".rs", ".go"];
+        const EXTENSIONS: &[&str] = &[
+            ".ts", ".tsx", ".js", ".jsx", ".py", ".rs", ".go", ".json", ".html", ".css",
+        ];
 
         for ext in EXTENSIONS {
             let candidate = format!("{}{}", base, ext);
-            if known.contains(candidate.as_str()) {
+            if self.known_paths.contains(&candidate) {
                 out.push(candidate);
             }
         }
 
         for ext in EXTENSIONS {
             let candidate = format!("{}/index{}", base, ext);
-            if known.contains(candidate.as_str()) {
+            if self.known_paths.contains(&candidate) {
                 out.push(candidate);
             }
         }
@@ -458,31 +469,6 @@ fn match_alias_pattern(import_path: &str, pattern: &str) -> Option<String> {
         }
     }
     None
-}
-
-/// Remove trailing commas before `}` or `]` (skipping whitespace).
-fn remove_trailing_commas(text: &mut String) {
-    let bytes = text.as_bytes().to_vec();
-    let len = bytes.len();
-    let mut buf = Vec::with_capacity(len);
-    let mut i = 0;
-
-    while i < len {
-        if bytes[i] == b',' {
-            let mut j = i + 1;
-            while j < len && matches!(bytes[j], b' ' | b'\t' | b'\n' | b'\r') {
-                j += 1;
-            }
-            if j < len && (bytes[j] == b'}' || bytes[j] == b']') {
-                i += 1; // skip the comma
-                continue;
-            }
-        }
-        buf.push(bytes[i]);
-        i += 1;
-    }
-
-    *text = String::from_utf8(buf).unwrap_or_else(|_| text.clone());
 }
 
 // ===========================================================================

--- a/crates/deepmap/src/resolver.rs
+++ b/crates/deepmap/src/resolver.rs
@@ -1,0 +1,640 @@
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::fs;
+
+use crate::types::{RepoGraph, ProjectImportConfig, PathAliasRule};
+
+/// Resolves import paths, tsconfig / jsconfig aliases, and call targets
+/// within a project graph. Used by the analysis engine to connect
+/// symbol references across files.
+pub struct ImportResolver {
+    pub project_root: PathBuf,
+    pub import_configs: Vec<ProjectImportConfig>,
+    /// File stem (filename without extension) -> candidate file paths.
+    pub file_map: HashMap<String, Vec<String>>,
+    /// Symbol name -> symbol IDs that share that name.
+    pub name_index: HashMap<String, Vec<String>>,
+}
+
+// ---------------------------------------------------------------------------
+// Construction & index building
+// ---------------------------------------------------------------------------
+
+impl ImportResolver {
+    /// Build an empty resolver, populate indices from `graph`, then scan
+    /// the project root for TypeScript / JavaScript config files.
+    pub fn new(project_root: &Path, graph: &RepoGraph) -> Self {
+        let mut this = Self {
+            project_root: project_root.to_path_buf(),
+            import_configs: Vec::new(),
+            file_map: HashMap::new(),
+            name_index: HashMap::new(),
+        };
+        this.build_indices(graph);
+        this.discover_import_configs();
+        this
+    }
+
+    /// Populate `file_map` (stem -> paths) from `file_symbols` and
+    /// `file_imports`; populate `name_index` (name -> symbol IDs) from
+    /// `symbols`.
+    ///
+    /// Files that appear only in `file_imports` (e.g. a file that only
+    /// imports without defining its own symbols) are still indexed so
+    /// that downstream resolution can find them.
+    pub fn build_indices(&mut self, graph: &RepoGraph) {
+        // file_map: stem -> candidate paths
+        for file_path in graph.file_symbols.keys() {
+            if let Some(stem) = file_stem(file_path) {
+                self.file_map
+                    .entry(stem.to_string())
+                    .or_default()
+                    .push(file_path.clone());
+            }
+        }
+        // also index files that appear only in file_imports
+        for file_path in graph.file_imports.keys() {
+            if !graph.file_symbols.contains_key(file_path) {
+                if let Some(stem) = file_stem(file_path) {
+                    self.file_map
+                        .entry(stem.to_string())
+                        .or_default()
+                        .push(file_path.clone());
+                }
+            }
+        }
+
+        // name_index: name -> symbol IDs
+        for (sym_id, symbol) in &graph.symbols {
+            self.name_index
+                .entry(symbol.name.clone())
+                .or_default()
+                .push(sym_id.clone());
+        }
+    }
+
+    /// Walk `project_root` looking for `tsconfig.json` / `jsconfig.json`
+    /// at the top level and in each immediate subdirectory. Parsed
+    /// configs are appended to `self.import_configs`.
+    pub fn discover_import_configs(&mut self) {
+        let config_names = ["tsconfig.json", "jsconfig.json"];
+
+        // top-level
+        for name in &config_names {
+            let path = self.project_root.join(name);
+            if path.is_file() {
+                if let Ok(cfg) = Self::parse_tsconfig(&path) {
+                    self.import_configs.push(cfg);
+                }
+            }
+        }
+
+        // one level deep
+        if let Ok(entries) = fs::read_dir(&self.project_root) {
+            for entry in entries.flatten() {
+                if entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                    for name in &config_names {
+                        let path = entry.path().join(name);
+                        if path.is_file() {
+                            if let Ok(cfg) = Self::parse_tsconfig(&path) {
+                                self.import_configs.push(cfg);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Read the JSON(C) file at `path`, strip comments and trailing
+    /// commas, then extract `compilerOptions.baseUrl` and
+    /// `compilerOptions.paths` into a [`ProjectImportConfig`].
+    pub fn parse_tsconfig(path: &Path) -> Result<ProjectImportConfig, String> {
+        let content = fs::read_to_string(path)
+            .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
+        let cleaned = Self::strip_jsonc(&content);
+        let value: serde_json::Value = serde_json::from_str(&cleaned)
+            .map_err(|e| format!("Failed to parse JSON in {}: {}", path.display(), e))?;
+
+        let config_path = Some(path.to_string_lossy().to_string());
+        let config_dir = path.parent().map(|p| p.to_string_lossy().to_string());
+
+        let base_url = value
+            .get("compilerOptions")
+            .and_then(|co| co.get("baseUrl"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        let alias_rules: Vec<PathAliasRule> = value
+            .get("compilerOptions")
+            .and_then(|co| co.get("paths"))
+            .and_then(|v| v.as_object())
+            .map(|obj| {
+                obj.iter()
+                    .map(|(pattern, targets)| {
+                        let target_patterns = targets
+                            .as_array()
+                            .map(|arr| {
+                                arr.iter()
+                                    .filter_map(|t| t.as_str().map(|s| s.to_string()))
+                                    .collect()
+                            })
+                            .unwrap_or_default();
+                        PathAliasRule {
+                            alias_pattern: pattern.clone(),
+                            target_patterns,
+                        }
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        Ok(ProjectImportConfig {
+            config_path,
+            config_dir,
+            base_url,
+            alias_rules,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// JSONC comment / trailing-comma stripper (public for downstream reuse)
+// ---------------------------------------------------------------------------
+
+impl ImportResolver {
+    /// Strip JSONC comments and trailing commas from `text`.
+    ///
+    /// - `//` line comments: removed along with trailing whitespace
+    /// - `/* */` block comments: removed without replacement
+    /// - Trailing comma before `}` or `]`: removed
+    /// - String literals are preserved verbatim (no stripping inside "..")
+    pub fn strip_jsonc(text: &str) -> String {
+        let chars: Vec<char> = text.chars().collect();
+        let len = chars.len();
+        let mut out = String::with_capacity(text.len());
+        let mut i = 0;
+
+        while i < len {
+            // string literal -- copy verbatim
+            if chars[i] == '"' {
+                out.push('"');
+                i += 1;
+                while i < len {
+                    let c = chars[i];
+                    out.push(c);
+                    if c == '\\' {
+                        // escaped character -- skip the next char too
+                        i += 1;
+                        if i < len {
+                            out.push(chars[i]);
+                            i += 1;
+                        }
+                        continue;
+                    }
+                    if c == '"' {
+                        i += 1;
+                        break;
+                    }
+                    i += 1;
+                }
+                continue;
+            }
+
+            // // line comment
+            if chars[i] == '/' && i + 1 < len && chars[i + 1] == '/' {
+                // trim trailing whitespace that sits before the //
+                let trim = out.trim_end().len();
+                out.truncate(trim);
+
+                i += 2;
+                while i < len && chars[i] != '\n' {
+                    i += 1;
+                }
+                if i < len {
+                    out.push('\n');
+                    i += 1;
+                }
+                continue;
+            }
+
+            // /* block comment */
+            if chars[i] == '/' && i + 1 < len && chars[i + 1] == '*' {
+                i += 2;
+                while i + 1 < len && !(chars[i] == '*' && chars[i + 1] == '/') {
+                    i += 1;
+                }
+                if i + 1 < len {
+                    i += 2; // skip past */
+                }
+                continue; // no replacement character
+            }
+
+            out.push(chars[i]);
+            i += 1;
+        }
+
+        // remove trailing commas before } or ]
+        remove_trailing_commas(&mut out);
+        out
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Import-target resolution
+// ---------------------------------------------------------------------------
+
+impl ImportResolver {
+    /// Resolve an import statement to concrete file paths.
+    ///
+    /// Strategy (in order):
+    ///
+    /// 1. **Relative import** (starts with `.`): canonicalize the path
+    ///    relative to `source_file`'s directory, then probe exact match,
+    ///    well-known extensions, and `index` files.
+    ///
+    /// 2. **Alias resolution**: match `import_path` against each
+    ///    tsconfig `paths` rule. On match, substitute the wildcard,
+    ///    resolve the target(s) against `baseUrl` and probe candidates.
+    ///
+    /// 3. **Stem lookup**: extract the filename stem from
+    ///    `import_path` and consult `file_map`.
+    pub fn resolve_import_targets(&self, source_file: &str, import_path: &str) -> Vec<String> {
+        let mut results = Vec::new();
+
+        // 1. relative import
+        if import_path.starts_with('.') {
+            let source_dir = Path::new(source_file).parent().unwrap_or(Path::new(""));
+            let normalised = normalise_path(&source_dir.join(import_path));
+            results.extend(self.resolve_path_candidates(&normalised));
+        }
+
+        // 2. alias resolution
+        if results.is_empty() {
+            for config in &self.import_configs {
+                if let Some(matched) = self.resolve_alias(import_path, config) {
+                    results.extend(matched);
+                    break; // first matching config wins
+                }
+            }
+        }
+
+        // 3. direct stem lookup
+        if results.is_empty() {
+            let stem = Path::new(import_path)
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or(import_path);
+            if let Some(paths) = self.file_map.get(stem) {
+                results.extend(paths.clone());
+            }
+        }
+
+        results
+    }
+
+    // -- helpers -----------------------------------------------------------
+
+    /// Probe `base_path` (exact, +extensions, +/index.ext) against the
+    /// known file set.
+    fn resolve_path_candidates(&self, base_path: &Path) -> Vec<String> {
+        // collect the set of known file paths for O(1) lookup
+        let known: HashSet<&str> = self
+            .file_map
+            .values()
+            .flat_map(|paths| paths.iter().map(|p| p.as_str()))
+            .collect();
+
+        let base = base_path.to_string_lossy().to_string();
+        let mut out = Vec::new();
+
+        if known.contains(base.as_str()) {
+            out.push(base);
+            return out;
+        }
+
+        const EXTENSIONS: &[&str] = &[".ts", ".tsx", ".js", ".jsx", ".py", ".rs", ".go"];
+
+        for ext in EXTENSIONS {
+            let candidate = format!("{}{}", base, ext);
+            if known.contains(candidate.as_str()) {
+                out.push(candidate);
+            }
+        }
+
+        for ext in EXTENSIONS {
+            let candidate = format!("{}/index{}", base, ext);
+            if known.contains(candidate.as_str()) {
+                out.push(candidate);
+            }
+        }
+
+        out
+    }
+
+    /// Try to match `import_path` against one alias rule set (all rules
+    /// from a single config). Returns `Some(targets)` when at least one
+    /// target resolves to a known file.
+    fn resolve_alias(
+        &self,
+        import_path: &str,
+        config: &ProjectImportConfig,
+    ) -> Option<Vec<String>> {
+        for rule in &config.alias_rules {
+            if let Some(captured) = match_alias_pattern(import_path, &rule.alias_pattern) {
+                let mut results = Vec::new();
+                for target_pattern in &rule.target_patterns {
+                    let substituted = target_pattern.replace('*', &captured);
+                    let full = match &config.base_url {
+                        Some(base) => self.project_root.join(base).join(&substituted),
+                        None => self.project_root.join(&substituted),
+                    };
+                    results.extend(self.resolve_path_candidates(&full));
+                }
+                if !results.is_empty() {
+                    return Some(results);
+                }
+            }
+        }
+        None
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Symbol / call-target resolution
+// ---------------------------------------------------------------------------
+
+impl ImportResolver {
+    /// Given a file and line number, find the symbol whose declared
+    /// line range `(line .. end_line)` contains `call_line`.
+    ///
+    /// Returns the symbol ID if found, `None` otherwise.
+    pub fn resolve_calling_symbol_with_graph(
+        &self,
+        file: &str,
+        call_line: usize,
+        graph: &RepoGraph,
+    ) -> Option<String> {
+        if let Some(sym_ids) = graph.file_symbols.get(file) {
+            for sym_id in sym_ids {
+                if let Some(symbol) = graph.symbols.get(sym_id) {
+                    if call_line >= symbol.line && call_line <= symbol.end_line {
+                        return Some(sym_id.clone());
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    /// Resolve a call expression to a target symbol ID.
+    ///
+    /// 1. Resolve `call_name` through `local_names` (import-renaming map
+    ///    built from `JsImportBinding`).
+    /// 2. Look up the resolved name in `name_index`.
+    /// 3. Return the first matching symbol ID (caller should prefer
+    ///    same-file matches when available).
+    ///
+    /// The `_call_line` and `_call_kind` parameters are reserved for
+    /// future scope-narrowing heuristics.
+    pub fn resolve_call_target(
+        &self,
+        _file: &str,
+        call_name: &str,
+        _call_line: usize,
+        _call_kind: &str,
+        local_names: &HashMap<String, String>,
+    ) -> Option<String> {
+        let resolved_name = local_names
+            .get(call_name)
+            .map(|s| s.as_str())
+            .unwrap_or(call_name);
+        self.name_index
+            .get(resolved_name)
+            .and_then(|ids| ids.first().cloned())
+    }
+}
+
+// ===========================================================================
+// Free helper functions
+// ===========================================================================
+
+/// Return the file stem (filename without extension) of a path string.
+fn file_stem(file_path: &str) -> Option<&str> {
+    Path::new(file_path).file_stem().and_then(|s| s.to_str())
+}
+
+/// Remove `.` and resolve `..` path components without touching disk.
+fn normalise_path(path: &Path) -> PathBuf {
+    let mut buf = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => { /* skip */ }
+            std::path::Component::ParentDir => {
+                buf.pop();
+            }
+            other => buf.push(other),
+        }
+    }
+    buf
+}
+
+/// Match an import path against a tsconfig alias pattern.
+///
+/// Supports:
+/// - Exact match (`pattern == import_path` -> `Some("")`)
+/// - Wildcard suffix (`@/lib/*` matches `@/lib/foo` -> `Some("foo")`)
+fn match_alias_pattern(import_path: &str, pattern: &str) -> Option<String> {
+    if pattern == import_path {
+        return Some(String::new());
+    }
+    if let Some(prefix) = pattern.strip_suffix('*') {
+        if import_path.starts_with(prefix) {
+            let captured = &import_path[prefix.len()..];
+            // require non-empty capture (e.g. `@/` alone should not match `@/`)
+            if !captured.is_empty() {
+                return Some(captured.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Remove trailing commas before `}` or `]` (skipping whitespace).
+fn remove_trailing_commas(text: &mut String) {
+    let bytes = text.as_bytes().to_vec();
+    let len = bytes.len();
+    let mut buf = Vec::with_capacity(len);
+    let mut i = 0;
+
+    while i < len {
+        if bytes[i] == b',' {
+            let mut j = i + 1;
+            while j < len && matches!(bytes[j], b' ' | b'\t' | b'\n' | b'\r') {
+                j += 1;
+            }
+            if j < len && (bytes[j] == b'}' || bytes[j] == b']') {
+                i += 1; // skip the comma
+                continue;
+            }
+        }
+        buf.push(bytes[i]);
+        i += 1;
+    }
+
+    *text = String::from_utf8(buf).unwrap_or_else(|_| text.clone());
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::Symbol;
+
+    fn make_test_graph() -> RepoGraph {
+        let mut g = RepoGraph::default();
+        g.file_symbols
+            .insert("src/bar/foo.ts".to_string(), vec![]);
+        g.file_symbols
+            .insert("src/bar/foo.js".to_string(), vec![]);
+        g.file_symbols
+            .insert("src/utils/helper.ts".to_string(), vec![]);
+
+        g.symbols.insert(
+            "sym_helper".to_string(),
+            Symbol::new(
+                "sym_helper".to_string(),
+                "helper".to_string(),
+                "function".to_string(),
+                "src/utils/helper.ts".to_string(),
+                1,
+                10,
+                0,
+                "public".to_string(),
+                String::new(),
+                "helper()".to_string(),
+            ),
+        );
+        g.file_symbols
+            .get_mut("src/utils/helper.ts")
+            .unwrap()
+            .push("sym_helper".to_string());
+
+        g
+    }
+
+    // ---- strip_jsonc tests -----------------------------------------------
+
+    #[test]
+    fn strip_simple_line_comment() {
+        let text = "{\"a\": 1 // comment\n}";
+        let got = ImportResolver::strip_jsonc(text);
+        assert_eq!(got, "{\"a\": 1\n}");
+    }
+
+    #[test]
+    fn strip_block_comment() {
+        let text = "{\"a\": /* block */ 1}";
+        let got = ImportResolver::strip_jsonc(text);
+        assert_eq!(got, "{\"a\":  1}");
+    }
+
+    #[test]
+    fn strip_trailing_comma() {
+        let text = "{\"a\": 1,}";
+        let got = ImportResolver::strip_jsonc(text);
+        assert_eq!(got, "{\"a\": 1}");
+    }
+
+    #[test]
+    fn strip_string_keeps_comment_like_content() {
+        let text = "{\"a\": \"// not a comment\"}";
+        let got = ImportResolver::strip_jsonc(text);
+        assert_eq!(got, "{\"a\": \"// not a comment\"}");
+    }
+
+    // ---- resolve_import_targets tests ------------------------------------
+
+    #[test]
+    fn normalise_dot() {
+        let graph = make_test_graph();
+        let resolver = ImportResolver::new(Path::new("/tmp/test"), &graph);
+        let results = resolver.resolve_import_targets("src/bar/index.ts", "./foo");
+        assert!(!results.is_empty(), "should resolve to at least one file");
+        assert!(
+            results.contains(&"src/bar/foo.ts".to_string()),
+            "results should contain foo.ts, got: {:?}",
+            results
+        );
+    }
+
+    #[test]
+    fn normalise_multiple() {
+        let graph = make_test_graph();
+        let resolver = ImportResolver::new(Path::new("/tmp/test"), &graph);
+        let results = resolver.resolve_import_targets("src/bar/index.ts", "./foo");
+        assert!(
+            results.contains(&"src/bar/foo.ts".to_string()),
+            "should contain foo.ts, got: {:?}",
+            results
+        );
+        assert!(
+            results.contains(&"src/bar/foo.js".to_string()),
+            "should contain foo.js, got: {:?}",
+            results
+        );
+    }
+
+    // ---- resolve_calling_symbol_with_graph tests -------------------------
+
+    #[test]
+    fn symbol_range_contains_call_line() {
+        let graph = make_test_graph();
+        let resolver = ImportResolver::new(Path::new("/tmp/test"), &graph);
+        let result =
+            resolver.resolve_calling_symbol_with_graph("src/utils/helper.ts", 5, &graph);
+        assert_eq!(result, Some("sym_helper".to_string()));
+    }
+
+    #[test]
+    fn symbol_range_outside_call_line() {
+        let graph = make_test_graph();
+        let resolver = ImportResolver::new(Path::new("/tmp/test"), &graph);
+        // sym_helper spans lines 1-10, so line 42 should not match
+        let result =
+            resolver.resolve_calling_symbol_with_graph("src/utils/helper.ts", 42, &graph);
+        assert_eq!(result, None);
+    }
+
+    // ---- resolve_call_target tests ---------------------------------------
+
+    #[test]
+    fn call_target_lookup_by_name() {
+        let graph = make_test_graph();
+        let resolver = ImportResolver::new(Path::new("/tmp/test"), &graph);
+        let local_names = HashMap::new();
+        let result = resolver.resolve_call_target("src/bar/foo.ts", "helper", 0, "call", &local_names);
+        assert_eq!(result, Some("sym_helper".to_string()));
+    }
+
+    #[test]
+    fn call_target_uses_local_rename() {
+        let graph = make_test_graph();
+        let resolver = ImportResolver::new(Path::new("/tmp/test"), &graph);
+        let mut local_names = HashMap::new();
+        local_names.insert("h".to_string(), "helper".to_string());
+        let result = resolver.resolve_call_target("src/bar/foo.ts", "h", 0, "call", &local_names);
+        assert_eq!(result, Some("sym_helper".to_string()));
+    }
+
+    // ---- path helper tests -----------------------------------------------
+
+    #[test]
+    fn normalise_path_removes_dot_and_dotdot() {
+        let p = normalise_path(Path::new("a/b/./c/d/../e"));
+        assert_eq!(p, Path::new("a/b/c/e"));
+    }
+}

--- a/crates/deepmap/src/types.rs
+++ b/crates/deepmap/src/types.rs
@@ -1,0 +1,140 @@
+// Core data types for DeepMap: symbols, edges, graph structure, and scan statistics.
+use std::collections::HashMap;
+
+pub fn ext_to_lang(ext: &str) -> Option<&'static str> {
+    Some(match ext {
+        ".py" | ".pyi" => "python",
+        ".js" | ".jsx" | ".mjs" | ".cjs" => "javascript",
+        ".ts" | ".tsx" | ".mts" | ".cts" => "typescript",
+        ".go" => "go",
+        ".rs" => "rust",
+        ".java" => "java",
+        ".kt" | ".kts" => "kotlin",
+        ".swift" => "swift",
+        ".cpp" | ".cc" | ".cxx" | ".hpp" | ".h" => "cpp",
+        ".cs" => "csharp",
+        ".php" => "php",
+        ".rb" => "ruby",
+        ".html" | ".htm" => "html",
+        ".css" => "css",
+        ".json" => "json",
+        _ => return None,
+    })
+}
+
+pub const SKIP_DIR_NAMES: &[&str] = &[
+    ".cache", ".git", ".hg", ".idea", ".mypy_cache", ".next", ".nox",
+    ".nuxt", ".parcel-cache", ".pnpm-store", ".pytest_cache", ".ruff_cache",
+    ".svelte-kit", ".tox", ".turbo", ".venv", ".vscode", ".yarn",
+    "__pypackages__", "__pycache__", "build", "coverage", "dist", "env",
+    "ENV", "node_modules", "site-packages", "target", "venv",
+    "monaco-editor", "monaco", "vendor", "third_party", "third-party",
+    "libs", "external",
+];
+
+pub const SKIP_FILE_NAMES: &[&str] = &[
+    "package-lock.json", "npm-shrinkwrap.json", "bun.lock", "bun.lockb",
+    "yarn.lock", "pnpm-lock.yaml", "Cargo.lock",
+];
+
+pub const DEFAULT_MAX_FILE_BYTES: u64 = 512 * 1024;
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Symbol {
+    pub id: String,
+    pub name: String,
+    pub kind: String,
+    pub file: String,
+    pub line: usize,
+    pub end_line: usize,
+    pub col: usize,
+    pub visibility: String,
+    #[serde(default)]
+    pub docstring: String,
+    #[serde(default)]
+    pub signature: String,
+    #[serde(default)]
+    pub pagerank: f64,
+}
+
+impl Symbol {
+    #[must_use]
+    pub fn new(
+        id: impl Into<String>, name: impl Into<String>, kind: impl Into<String>,
+        file: impl Into<String>, line: usize, end_line: usize, col: usize,
+        visibility: impl Into<String>, docstring: impl Into<String>,
+        signature: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: id.into(), name: name.into(), kind: kind.into(), file: file.into(),
+            line, end_line, col,
+            visibility: visibility.into(), docstring: docstring.into(),
+            signature: signature.into(), pagerank: 0.0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Edge {
+    pub source: String,
+    pub target: String,
+    pub weight: f64,
+    pub kind: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct JsImportBinding {
+    pub local_name: String,
+    pub imported_name: String,
+    pub module: String,
+    pub line: usize,
+    pub kind: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct JsExportBinding {
+    pub exported_name: String,
+    pub source_name: Option<String>,
+    pub module: Option<String>,
+    pub line: usize,
+    pub kind: String,
+}
+
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct PathAliasRule {
+    pub alias_pattern: String,
+    pub target_patterns: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct ProjectImportConfig {
+    pub config_path: Option<String>,
+    pub config_dir: Option<String>,
+    pub base_url: Option<String>,
+    pub alias_rules: Vec<PathAliasRule>,
+}
+
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct ScanStats {
+    pub listed_source_files: usize,
+    pub selected_source_files: usize,
+    pub processed_files: usize,
+    pub filtered_path_files: usize,
+    pub filtered_large_files: usize,
+    pub truncated_files: usize,
+    pub failed_files: Vec<String>,
+    pub scan_duration_ms: u64,
+    pub timeout_triggered: bool,
+}
+
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct RepoGraph {
+    pub symbols: HashMap<String, Symbol>,
+    pub outgoing: HashMap<String, Vec<Edge>>,
+    pub incoming: HashMap<String, Vec<Edge>>,
+    pub file_symbols: HashMap<String, Vec<String>>,
+    pub file_imports: HashMap<String, Vec<String>>,
+    pub file_calls: HashMap<String, Vec<(String, usize, String)>>,
+    pub file_import_bindings: HashMap<String, Vec<JsImportBinding>>,
+    pub file_exports: HashMap<String, Vec<JsExportBinding>>,
+}

--- a/crates/deepmap/tests/smoke_test.rs
+++ b/crates/deepmap/tests/smoke_test.rs
@@ -1,0 +1,142 @@
+// Smoke tests — parse real project files and verify results.
+use std::path::Path;
+
+#[test]
+fn parse_rust_project() {
+    let project = Path::new("/home/guojiancheng/.A1/DeepSeek-TUI");
+    let test_file = project.join("crates/deepmap/src/parser.rs");
+    if !test_file.exists() { eprintln!("SKIP: no test file"); return; }
+
+    let mut adapter = deepmap::parser::TreeSitterAdapter::new();
+    let content = std::fs::read_to_string(&test_file).unwrap();
+    adapter.parse(&test_file, &content, "rust").unwrap();
+
+    let syms = adapter.symbols();
+    let imports = adapter.imports();
+    let calls = adapter.calls();
+
+    println!("=== Rust: {} ===", test_file.display());
+    println!("  Symbols: {}", syms.len());
+    for s in syms.iter().take(10) {
+        println!("    {} [{}:{}] {}", s.name, s.kind, s.line, s.signature);
+    }
+    println!("  Imports: {}", imports.len());
+    for i in imports.iter().take(5) { println!("    {}", i); }
+    println!("  Calls: {}", calls.len());
+    for c in calls.iter().take(5) { println!("    {}:{}", c.0, c.1); }
+
+    assert!(syms.len() > 10, "Should find Rust symbols");
+    // Rust scoped_identifier imports with deep nesting need more complex query.
+    // 1 import (from scoped_use_list) is found; nested scoped_identifier
+    // paths are not captured. This is a known limitation tracked for PR 2.
+    assert!(imports.len() >= 1, "Should find at least scoped_use_list imports");
+    assert!(calls.len() > 5, "Should find function calls");
+}
+
+#[test]
+fn parse_python_project() {
+    let project = Path::new("/home/guojiancheng/.A1/repomap");
+    let test_file = project.join("repomap_core.py");
+    if !test_file.exists() { eprintln!("SKIP: no test file"); return; }
+
+    let mut adapter = deepmap::parser::TreeSitterAdapter::new();
+    let content = std::fs::read_to_string(&test_file).unwrap();
+    adapter.parse(&test_file, &content, "python").unwrap();
+
+    let syms = adapter.symbols();
+    let imports = adapter.imports();
+    let calls = adapter.calls();
+
+    println!("=== Python: {} ===", test_file.display());
+    println!("  Symbols: {}", syms.len());
+    for s in syms.iter().take(8) {
+        println!("    {} [{}:{}] {}", s.name, s.kind, s.line, s.signature);
+    }
+    println!("  Imports: {}", imports.len());
+    for i in imports.iter().take(5) { println!("    {}", i); }
+
+    assert!(syms.len() > 5, "Should find Python symbols");
+    assert!(imports.len() > 3, "Should find Python imports");
+}
+
+#[test]
+fn parse_typescript_project() {
+    let project = Path::new("/home/guojiancheng/.A1/deeper-web");
+    let test_file = project.join("server/src/app.ts");
+    if !test_file.exists() { eprintln!("SKIP: no test file"); return; }
+
+    let mut adapter = deepmap::parser::TreeSitterAdapter::new();
+    let content = std::fs::read_to_string(&test_file).unwrap();
+    adapter.parse(&test_file, &content, "typescript").unwrap();
+
+    let syms = adapter.symbols();
+    let imports = adapter.imports();
+    let bindings = adapter.import_bindings();
+    let exports = adapter.exports();
+
+    println!("=== TypeScript: {} ===", test_file.display());
+    println!("  Symbols: {}", syms.len());
+    for s in syms.iter().take(8) {
+        println!("    {} [{}:{}] {}", s.name, s.kind, s.line, s.signature);
+    }
+    println!("  Imports: {}", imports.len());
+    println!("  Import bindings: {}", bindings.len());
+    for b in bindings.iter().take(5) { println!("    {} from '{}'", b.local_name, b.module); }
+    println!("  Exports: {}", exports.len());
+
+    assert!(syms.len() > 3, "Should find TS symbols");
+    assert!(imports.len() > 1, "Should find TS imports");
+}
+
+#[test]
+fn parse_json_file() {
+    let project = Path::new("/home/guojiancheng/.A1/deeper-web");
+    let test_file = project.join("package.json");
+    if !test_file.exists() { eprintln!("SKIP: no test file"); return; }
+
+    let mut adapter = deepmap::parser::TreeSitterAdapter::new();
+    let content = std::fs::read_to_string(&test_file).unwrap();
+    adapter.parse(&test_file, &content, "json").unwrap();
+
+    let syms = adapter.symbols();
+    println!("=== JSON: {} ===", test_file.display());
+    println!("  Keys: {}", syms.len());
+    for s in syms.iter().take(10) { println!("    {}", s.name); }
+
+    assert!(syms.len() > 5, "Should find JSON keys");
+}
+
+#[test]
+fn test_resolver() {
+    let project = Path::new("/home/guojiancheng/.A1/DeepSeek-TUI");
+    let mut adapter = deepmap::parser::TreeSitterAdapter::new();
+
+    // Parse a Rust file with use statements
+    let test_file = project.join("crates/deepmap/src/types.rs");
+    let content = std::fs::read_to_string(&test_file).unwrap();
+    adapter.parse(&test_file, &content, "rust").unwrap();
+
+    // Build a minimal graph for resolver testing
+    let syms = adapter.symbols();
+    let imports = adapter.imports();
+
+    let mut graph = deepmap::types::RepoGraph::default();
+    for s in &syms {
+        graph.symbols.insert(s.id.clone(), s.clone());
+        graph.file_symbols.entry(s.file.clone()).or_default().push(s.id.clone());
+    }
+    graph.file_imports.insert("crates/deepmap/src/types.rs".into(), imports.clone());
+
+    let resolver = deepmap::resolver::ImportResolver::new(project, &graph);
+
+    println!("=== Resolver ===");
+    println!("  Import configs: {}", resolver.import_configs.len());
+    for c in &resolver.import_configs {
+        println!("    {}", c.config_path.as_deref().unwrap_or("none"));
+        println!("    aliases: {}", c.alias_rules.len());
+    }
+
+    // Test resolving a relative import
+    let targets = resolver.resolve_import_targets("crates/deepmap/src/types.rs", "../tui");
+    println!("  Resolve '../tui': {:?}", targets);
+}

--- a/docs/DEEPMAP.md
+++ b/docs/DEEPMAP.md
@@ -1,0 +1,621 @@
+# DeepMap -- AI-Native Codebase Mapping for DeepSeek-TUI
+
+## Origin & Motivation
+
+The concept of automatic repository mapping was pioneered by
+[aider](https://github.com/Aider-AI/aider), the first CLI coding assistant to
+recognize that an AI agent needs a structural understanding of a project before
+it can make meaningful edits. Aider introduced a pipeline that combined
+tree-sitter parsing with PageRank to produce a compact "project map" -- a
+single Markdown document of roughly 1,000 tokens that captures the entry points,
+hot files, and key symbols ranked by their structural importance.
+
+Aider's key insight was both simple and profound: a 1,000-token structural map
+consistently outperforms 50,000 tokens of raw source code when the agent needs
+to understand where to make a change. Raw code dumps overwhelm the model's
+attention budget; a ranked map tells it exactly where to look first.
+
+Building on aider's foundation, we developed
+[repomap](https://github.com/gjczone/repomap) as an independent open-source
+research project. Repomap extended the original concept in several directions:
+growing language coverage from 8 to 15 languages, adding incremental scanning
+for large projects, introducing impact analysis (given a set of changed files,
+which other files need attention?), post-edit verification suggestions, LSP
+integration for real-time symbol resolution, and structured JSON reports
+designed for AI agent consumption rather than human reading.
+
+DeepMap is the natural evolution of this work. It takes the core engine that
+was proven in repomap and rewrites it in Rust, integrating it natively into
+DeepSeek-TUI as a first-class analysis capability. Where repomap was a
+standalone Python CLI tool, DeepMap lives inside the same process as the
+coding agent -- no subprocess, no serialization overhead, no separate
+deployment.
+
+Both repomap and DeepMap share a common origin story: they were built by
+@gjczone, a non-programmer, using DeepSeek-V4-Pro, with GLM-5.1 and
+MIMO-V2.5-Pro for cross-validation and review. The entire
+project is evidence that the tools we are building -- AI-native code assistants
+with repository awareness -- can also help their own creators build meaningful
+infrastructure. The dogfooding is not accidental; it is the point.
+
+## The Problem We Solve
+
+Modern AI-powered coding tools fall into two broad categories with very
+different relationships to codebase understanding.
+
+**IDE-based coding assistants** (Cursor, Trae, Qoder, GitHub Copilot) run
+inside a full development environment with access to Language Server Protocol
+(LSP) servers. They know, natively and in real time, what symbols exist, where
+they are defined, how they reference each other, and what errors are present.
+The IDE provides omni-completion, go-to-definition, find-all-references, and
+rename -- all backed by a live index that is always up to date. For these tools,
+codebase awareness is a built-in feature of the platform.
+
+**CLI-based coding assistants** (aider, Claude Code, DeepSeek-TUI) have
+historically operated without this advantage. They run in a terminal against a
+working tree. They do not control the editor; they do not have a running LSP
+server. Their default strategy for understanding a codebase has been to
+fall back on general-purpose Unix tools: `grep` for text search, `find` or `fd`
+for file discovery, and brute-force file reads to understand dependencies.
+This approach has three fundamental problems.
+
+First, **token waste is severe**. An agent that does not know which files matter
+will read many files that are irrelevant to the task at hand. A single large
+file with 1,500 lines of boilerplate can consume 5,000-10,000 tokens just to
+confirm that it has nothing useful. Multiplied across a project of hundreds of
+files, the waste can easily reach hundreds of thousands of tokens per session.
+
+Second, **dependencies are invisible to grep**. Text search can find
+occurrences of a function name, but it cannot tell you whether those
+occurrences are calls or comments. It cannot tell you that `foo()` in module A
+resolves to the `foo` defined in module B through a chain of re-exports. It
+cannot construct a call graph, identify orphaned code, or trace the impact of
+changing a shared data structure.
+
+Third, **change impact assessment is purely manual**. When a developer
+modifies three files, the agent needs to know which other files depend on the
+changed symbols and should be re-verified. Without a dependency graph, the
+agent must either guess (and risk missing important regressions) or read every
+file in the project (and waste unbounded tokens).
+
+DeepMap bridges this gap. It gives CLI-based agents the same kind of structural
+awareness that IDE-based tools have, without requiring an IDE, an MCP server,
+a running LSP process, or any external infrastructure. It is a single library
+compiled into the DeepSeek-TUI binary that produces a compact, high-signal
+"map" of any project in a few seconds.
+
+## What DeepMap Provides in DeepSeek-TUI
+
+DeepMap exposes its capabilities through two channels: **TUI tools** that the
+AI agent can call proactively during a session, and **CLI commands** that the
+developer can invoke directly.
+
+### TUI Tools (model-visible, the AI agent calls them during conversation)
+
+These tools are registered in the DeepSeek-TUI tool registry and advertised to
+the model through the system prompt. The model decides when to invoke them
+based on the task context -- for example, calling `deepmap_overview` at the
+start of a new project to understand the codebase layout, or calling
+`deepmap_call_chain` when tracing how a bug propagates through the system.
+
+| Tool | Description |
+|------|-------------|
+| `deepmap_overview` | Full project map report: entry points, hot files ranked by PageRank scan statistics, recommended reading order, module summary, and key symbols grouped by file. This is the primary entry point for agents that need to understand an unfamiliar codebase. |
+| `deepmap_call_chain` | Trace both callers and callees for any named symbol up to a configurable depth. Returns the chain as a structured depth-grouped list sorted by PageRank score, which helps the agent focus on the most important nodes first. Useful for debugging, refactoring scoping, and impact analysis. |
+| `deepmap_file_detail` | List every symbol defined in a single file with its signature, kind, visibility, line range, and PageRank score. The agent can use this to understand a specific file's API surface without reading the entire file. |
+| `deepmap_query` | Topic-based code search that combines keyword matching, identifier splitting (camelCase, snake_case, kebab-case), file-role classification, and IDF-like keyword weighting. Returns ranked file matches, related test files, and highlighted key symbols. More precise than raw grep because it understands code structure. |
+
+All TUI tools are **ReadOnly** and **Sandboxable**, meaning they never modify
+the filesystem and can run inside a sandboxed environment. They use the same
+**Auto approval** safety model as the existing `project_map` tool -- no user
+approval prompt is needed because the tools cannot cause side effects.
+
+### CLI Commands (developer-facing, invoked from the shell)
+
+These commands let the developer use DeepMap directly without going through the
+AI agent. They are especially useful for CI/CD pipelines, pre-commit hooks, and
+ad-hoc exploration.
+
+| Command | Purpose |
+|---------|---------|
+| `deepseek deepmap overview` | Generate and print a full project map to stdout. Equivalent to the `deepmap_overview` tool. |
+| `deepseek deepmap call-chain --symbol <name>` | Trace the call chain for a specific symbol by name. Supports optional `--direction` (callers, callees, or both) and `--depth` arguments. |
+| `deepseek deepmap file-detail --file <path>` | Inspect a single file's symbol table. Shows all symbols with their kinds, visibilities, line ranges, and PageRank scores in a formatted table. |
+| `deepseek deepmap query --keywords <words>` | Topic search across the entire codebase. Accepts natural language or code terms, returns ranked results with related tests. |
+| `deepseek deepmap impact --files <a,b>` | Pre-edit impact analysis: given a comma-separated list of changed file paths, lists all files that depend on them (directly and transitively) and provides per-file metrics. |
+| `deepseek deepmap diff-risk` | Full diff risk assessment: combines impact analysis with keyword-based risk classification (auth, db, config patterns score higher) and verification suggestions including related test files and recommended test commands. |
+
+### Session Cache
+
+DeepMap uses a two-level caching strategy to make repeated calls fast:
+
+1. **In-memory session cache**: The first `deepmap_overview` call in a session
+   triggers a full scan, which typically takes 20-40 seconds for a
+   medium-sized project (5,000-20,000 files). The resulting `RepoGraph`
+   (symbols, edges, PageRank scores) is stored in a `LazyLock<Mutex<HashMap>>`
+   keyed by the canonical project root path. All subsequent tool calls in the
+   same session -- `deepmap_call_chain`, `deepmap_file_detail`,
+   `deepmap_query`, etc. -- reuse this in-memory cache and return in under
+   10 milliseconds.
+
+2. **On-disk persistent cache**: The graph is serialized to
+   `~/.cache/deepmap/{project_name}_{path_hash}/symbol_cache.json` with a
+   schema version guard. On the next session, if the cache exists and the
+   schema version matches, the scan is skipped entirely and the graph is loaded
+   from disk. The cache entry includes a SHA-256 fingerprint of file paths,
+   sizes, and modification times so that changes to the working tree
+   automatically invalidate the cache. The write is atomic (write to temp file,
+   rename over final path) with automatic backup of the previous cache.
+
+This design means that an agent working in a project for the first time pays
+the scan cost once, and subsequent sessions are nearly instant.
+
+## Public API Surface
+
+DeepMap exposes a focused public API through the `deepmap` crate. The following types and methods form the primary interface for both TUI tool integration and CLI command implementation.
+
+### `RepoMapEngine` -- Main Entry Point
+
+The central orchestrator that owns the scan pipeline, the graph data, and the analysis queries.
+
+| Method | Description |
+|--------|-------------|
+| `new(project_root)` | Create a new engine instance for the given project root path |
+| `get_or_scan(project_root, max_files, max_scan_secs)` | Constructor with session cache; returns cached engine if the project was already scanned in this process, otherwise runs a full scan |
+| `scan(max_files, max_scan_secs)` | Execute the full three-phase pipeline: file traversal, tree-sitter parsing, and PageRank ranking |
+| `query_symbol(name)` | Case-insensitive substring search over symbol names, returns ranked matches sorted by PageRank descending |
+| `call_chain(symbol_id, direction, max_depth)` | BFS traversal of the call graph; supports caller, callee, and bidirectional walks |
+| `hotspots(limit)` | Files ranked by `symbol_count * average_PageRank`, identifying the most maintenance-critical files |
+| `entry_points()` | Heuristic detection of well-known entry-point files by filename stem or path pattern |
+| `suggested_reading_order(limit)` | Files scored for onboarding priority, excluding test and noise files |
+| `module_summary(limit)` | Symbols grouped by top-level directory, sorted by total PageRank descending |
+| `is_scanned()` | Returns `true` if a scan has been completed |
+| `scan_summary_lines()` | Returns formatted summary lines describing scan duration, file counts, and symbol counts |
+
+### `TreeSitterAdapter` -- Multi-Language Parser
+
+Manages per-language tree-sitter parsers and compiled S-expression queries for 8 languages.
+
+| Method | Description |
+|--------|-------------|
+| `new()` | Initialize all 8 language parsers (Rust, Python, JavaScript, TypeScript, Go, HTML, CSS, JSON) |
+| `parse(content, lang)` | Parse source content with the appropriate language grammar |
+| `symbols()` | Extract all function, class, import, and call captures from parsed trees |
+| `imports()` | Extract import declarations with source module and imported names |
+| `calls()` | Extract call expressions with callee name and location |
+| `import_bindings()` (JS/TS only) | Structured import records for ES module and CommonJS imports |
+| `exports()` (JS/TS only) | Structured export records for ES module and CommonJS exports |
+
+### `ImportResolver` -- Import Resolution
+
+Resolves import statements to target files and builds the dependency edges between symbols.
+
+| Method | Description |
+|--------|-------------|
+| `new(project_root, graph)` | Create a resolver with project root and reference to the partially-built graph |
+| `resolve_import_targets(source_file, import_path)` | Resolve an import path to candidate target files using relative resolution, tsconfig aliases, and stem-based lookup |
+
+### Key Data Types
+
+- **`Symbol`** -- Carries `id` (`file:name:line` composite key), `name`, `kind` (function, class, struct, method, arrow_function, etc.), `file_path`, `line_range`, `column`, `visibility`, `docstring`, `signature`, and `pagerank_score`.
+- **`Edge`** -- A directed edge between two symbol IDs with a `weight` field (0.50 for calls, 0.35 for imports).
+- **`RepoGraph`** -- The complete graph container: `symbols`, `outgoing`, `incoming`, `file_symbols`, `file_imports`, `file_calls`, `file_import_bindings`, `file_exports`.
+- **`ScanStats`** -- Scan metadata: `files_found`, `files_parsed`, `files_failed`, `filtered_large_files`, `total_symbols`, `total_edges`, `scan_duration_ms`, `timeout_triggered`, `failed_files`.
+
+### Renderer Functions
+
+Six Markdown report generators in the `renderer` module:
+
+- `render_overview_report()` -- Full project map with entry points, hotspots, reading order, module summary, and key symbols
+- `render_call_chain_report()` -- Caller/callee chain for a symbol with depth grouping
+- `render_file_detail_report()` -- Per-file symbol table as a Markdown table
+- `render_query_report()` -- Topic search results with related test discovery
+- `render_impact_report()` -- Pre-edit impact analysis with transitive dependency listing
+- `render_diff_risk_report()` -- Full diff risk assessment with risk classification and verification suggestions
+
+## Failure Model
+
+DeepMap is designed to be resilient in the face of real-world codebases that are incomplete, misconfigured, or contain pathological files. The following contract describes how every failure mode is handled.
+
+| Scenario | Behavior |
+|----------|----------|
+| **No parser available for language** | File is silently skipped; scanning continues with other files. No error is raised. |
+| **File too large (>10 MiB)** | File is skipped and counted in `filtered_large_files`. |
+| **Excessive AST nesting (>1,000 depth)** | File is skipped as a safety guard against pathological or generated files. |
+| **Parse error / malformed source** | File is skipped; path and error message are recorded in `failed_files` (up to 5 entries). |
+| **Scan timeout (default 300s)** | Partial results are returned; `timeout_triggered` is set to `true` in `ScanStats`. |
+| **Empty project / no supported files** | Returns an empty `RepoGraph`; all reports remain valid but minimal. |
+| **Session cache miss** | A full scan runs automatically; results are cached for subsequent calls. |
+| **Symbol not found (query-symbol / call-chain)** | Returns empty results. This is normal behaviour, not an error. |
+| **Git operations unavailable (impact / diff-risk)** | Reports "not a git repository" clearly in the output; no crash. |
+| **LSP server not installed** | `lsp doctor` reports the server as skipped; `--with-lsp` on other commands degrades gracefully with a clear message. |
+
+In all cases, DeepMap never panics or crashes due to per-file processing failures. Errors are collected, logged, and surfaced through the `ScanStats` metadata or the report output, allowing the calling code to decide how to handle them.
+
+## Architecture
+
+DeepMap's architecture follows a clean three-phase pipeline with a shared
+data model, designed so that each phase can be tested, optimized, and replaced
+independently.
+
+### Phase 1: File Traversal and Filtering
+
+The entry point is `RepoMapEngine::scan()` in `engine.rs`. File discovery uses
+the `ignore` crate (the library behind `ripgrep`) to walk the project tree
+respecting `.gitignore` rules, filter entries against `SKIP_DIR_NAMES`
+(35 common noise directories such as `node_modules`, `.git`, `target`, `venv`,
+`dist`, `build`, `vendor`, etc.) and `SKIP_FILE_NAMES` (lock files, shrinkwrap
+files), and keep only files with recognized extensions.
+
+The recognized extension-to-language mapping in `types.rs::ext_to_lang()`
+covers 17 extensions across 9 language families: Python (`.py`, `.pyi`),
+JavaScript (`.js`, `.jsx`, `.mjs`, `.cjs`), TypeScript (`.ts`, `.tsx`, `.mts`,
+`.cts`), Go (`.go`), Rust (`.rs`), Java (`.java`), Kotlin (`.kt`, `.kts`),
+Swift (`.swift`), C/C++ (`.cpp`, `.cc`, `.cxx`, `.hpp`, `.h`), C# (`.cs`),
+PHP (`.php`), Ruby (`.rb`), HTML (`.html`, `.htm`), CSS (`.css`), and JSON
+(`.json`). Files larger than 512 KB (configurable via the `DEEPMAP_MAX_FILE_BYTES`
+environment variable) are skipped. Excessively nested ASTs (depth > 1,000) are
+skipped as a safety guard against pathological files.
+
+The walker respects a `max_files` limit and a `max_scan_secs` timeout (hard
+cap at 300 seconds), so even very large monorepos cannot hang the agent
+indefinitely.
+
+### Phase 2: Tree-Sitter Parsing and Symbol Extraction
+
+Each candidate file is parsed with the appropriate tree-sitter parser. DeepMap
+bundles 8 tree-sitter grammars compiled as native Rust libraries:
+
+- `tree-sitter-rust` (0.24)
+- `tree-sitter-python` (0.23)
+- `tree-sitter-javascript` (0.23)
+- `tree-sitter-typescript` (0.23, both TypeScript and TSX)
+- `tree-sitter-go` (0.23)
+- `tree-sitter-html` (0.23)
+- `tree-sitter-css` (0.23)
+- `tree-sitter-json` (0.23)
+
+The `TreeSitterAdapter` (in `parser.rs`) manages per-language parsers and
+compiled S-expression queries. The queries are defined in `queries.rs` and
+cover four query types per language:
+
+- **function**: Function declarations, method definitions, arrow functions,
+  lambda expressions, and variable declarations whose right-hand side is a
+  function expression.
+- **class**: Class declarations, struct definitions, enum definitions, trait
+  definitions, interface declarations, and impl blocks.
+- **import**: Import statements, use declarations, require calls, and
+  module-path references. The Rust import extractor has special handling for
+  `scoped_use_list` and nested `scoped_identifier` paths, concatenating path
+  and name segments (e.g., `std::collections::HashMap`).
+- **call**: Call expressions, method calls, member function calls, and
+  scoped/qualified calls.
+
+Each query produces `RawCapture` entries with name, kind, byte range, and line
+range. For JavaScript and TypeScript, three additional extraction passes run:
+
+1. **Import bindings**: Structured records of every `import` statement (ES
+   modules) and `require()` call (CommonJS), capturing the local name, the
+   imported name, the source module, and the import kind (default, named,
+   namespace, CJS default, CJS destructured). This is critical for call-chain
+   resolution because it lets the engine map `foo()` in code back to where
+   `foo` was actually defined, across re-exports.
+
+2. **Export bindings**: Structured records of every `export` statement (ES
+   modules) and `module.exports` / `exports.xxx` assignments (CommonJS),
+   capturing the exported name, the source name, the re-export module, and the
+   export kind. This enables the engine to resolve `import { X } from 'Y'`
+   chains through intermediate modules.
+
+3. **Extra symbol passes**: Three passes (`extract_object_literal_methods`,
+   `extract_anonymous_symbols`, `extract_exported_function_expressions`) catch
+   symbols that standard queries miss: method definitions inside object
+   literals, anonymous functions assigned to variables (e.g., `const foo =
+   function() {}`), and default-exported function/class expressions.
+
+The extracted data is stored in a `RepoGraph` (defined in `types.rs`):
+
+```
+RepoGraph {
+  symbols:          HashMap<symbol_id, Symbol>,
+  outgoing:         HashMap<symbol_id, Vec<Edge>>,
+  incoming:         HashMap<symbol_id, Vec<Edge>>,
+  file_symbols:     HashMap<file_path, Vec<symbol_id>>,
+  file_imports:     HashMap<file_path, Vec<import_string>>,
+  file_calls:       HashMap<file_path, Vec<(call_name, line, kind)>>,
+  file_import_bindings: HashMap<file_path, Vec<JsImportBinding>>,
+  file_exports:     HashMap<file_path, Vec<JsExportBinding>>,
+}
+```
+
+A `Symbol` carries its id (a composite of `file:name:line`), name, kind
+(function, class, struct, method, arrow_function, etc.), file path, line range,
+column, visibility, docstring, signature, and PageRank score.
+
+### Phase 2b: Import Resolution and Edge Construction
+
+After parsing all files, `ImportResolver` (in `resolver.rs`) builds indices:
+
+- **file_map**: filename stem -> candidate file paths (e.g., `"helper"` ->
+  `["src/utils/helper.ts", "tests/helper_test.ts"]`).
+- **name_index**: symbol name -> symbol IDs (e.g., `"parse"` -> all parse
+  functions across the project).
+- **known_paths**: a `HashSet` of every known file path for O(1) existence
+  checks.
+
+The resolver also discovers `tsconfig.json` and `jsconfig.json` files in the
+project root and immediate subdirectories, parsing them (with JSONC comment
+and trailing-comma stripping) to extract `compilerOptions.baseUrl` and
+`compilerOptions.paths` alias rules.
+
+When building edges, the engine processes two kinds of relationships:
+
+1. **Call edges** (weight: 0.50): For every call expression found during
+   parsing, the resolver attempts to map it to a target symbol. It first
+   consults the local-name map (built from JS/TS import bindings) to resolve
+   renames and re-exports, then looks up the resolved name in the global
+   `name_index`. The calling symbol is identified by finding the enclosing
+   symbol whose line range contains the call line.
+
+2. **Import edges** (weight: 0.35): For every import statement, the resolver
+   tries to find target files using a three-step strategy: first try relative
+   path resolution (for imports starting with `.`), then try tsconfig alias
+   pattern matching, and finally fall back to stem-based lookup in the
+   `file_map`. For each resolved target file, import edges are created from
+   every symbol in the source file to every symbol in the target file.
+
+A deduplication set (`HashSet<(source_id, target_id)>`) prevents redundant
+edges. Constants control the edge weights, with calls weighted higher than
+imports because calls represent tighter coupling.
+
+### Phase 3: PageRank Computation and Analysis
+
+With the graph fully built, a standard power-iteration PageRank algorithm
+(in `ranking.rs::GraphAnalyzer::calculate_pagerank`) computes structural
+importance for every symbol:
+
+1. Initialise all nodes with equal probability `1/N`.
+2. For each iteration: distribute each node's current probability to its
+   outgoing neighbours proportionally to edge weights. Dangling nodes (no
+   outgoing edges) contribute to a uniform teleport term. Apply damping factor
+   (default: 0.85, matching the classic PageRank paper).
+3. Terminate when the maximum per-node delta falls below `1e-6`, or after
+   50 iterations at most.
+4. Normalise scores so the sum equals 1.0.
+
+The damping factor and iteration count are chosen to balance precision against
+computation time. Project-scale graphs typically converge in 20-30 iterations.
+
+After PageRank, the `GraphAnalyzer` provides these analytical queries:
+
+- **query_symbol**: Case-insensitive substring search over symbol names,
+  filtered to exclude low-signal kinds (CSS selectors, JSON keys, HTML
+  elements), sorted by PageRank descending.
+- **call_chain**: BFS traversal of the call graph, depth-limited (default:
+  unlimited, hard capped at 10,000 nodes in the BFS queue and 1,000 results),
+  supporting caller, callee, or bidirectional walks.
+- **hotspots**: Files ranked by `symbol_count * average_PageRank`, identifying
+  high-density, high-importance files that are likely to be the most
+  maintenance-critical.
+- **entry_points**: Heuristic detection of well-known entry-point files by
+  filename stem (`main`, `app`, `index`, `server`, `run`, `setup`, `cli`,
+  `__main__`) or path pattern (`/src/main.tsx`, `/lib.rs`).
+- **file_analysis**: Per-file metrics including symbol count, outgoing edges,
+  incoming edges, and average PageRank.
+- **module_summary**: Symbols grouped by top-level directory, sorted by total
+  PageRank descending, for a high-level view of which modules carry the most
+  structural weight.
+- **suggested_reading_order**: Files scored by
+  `average_PR * ln(symbol_count) * entry_boost(2.0 if entry_point)`, excluding
+  test and noise files. This is the list an agent should read first when
+  onboarding to a project.
+- **summary_symbols**: For the top-N files by reading order, the top-M symbols
+  sorted by composite importance (`incoming_calls * 3 + outgoing_calls * 2 +
+  kind_weight`, where functions and methods score 5, classes and structs score
+  4, modules score 3, variables score 2, and everything else scores 1).
+
+### Report Rendering
+
+All analysis results are rendered into Markdown by the `renderer.rs` module.
+Six report types are available, each corresponding to a TUI tool or CLI
+command:
+
+1. **Overview report** (`render_overview_report`): Combines scan statistics,
+   entry points, recommended reading order (top 20), module summary (top 20),
+   hot spots (top 10), and key symbols (top 30 files, 5 symbols each) into a
+   single comprehensive document. Truncated to a caller-specified character
+   limit with word-boundary-aware truncation.
+
+2. **Call chain report** (`render_call_chain_report`): Queries the best-matching
+   symbol, then walks callers and callees to the specified depth. Reports the
+   symbol's kind, file, and PageRank, followed by flat lists of callers and
+   callees sorted by PageRank.
+
+3. **File detail report** (`render_file_detail_report`): Lists all symbols in
+   a file as a Markdown table with line number, kind, name, visibility,
+   PageRank score, and signature. Sorted by line number.
+
+4. **Query report** (`render_query_report`): Combines topic scoring, related
+   test discovery, and key symbol highlighting into a single response.
+   Uses `topic_score` from the `topic.rs` module, which applies identifier
+   splitting, file-role classification, noise penalties, test-weight
+   adjustments, and IDF-like keyword weighting.
+
+5. **Impact report** (`render_impact_report`): For each changed file, lists
+   direct dependents (files that import it) and per-file metrics. Aggregates a
+   summary of total transitively affected files.
+
+6. **Diff risk report** (`render_diff_risk_report`): Combines impact analysis
+   with risk assessment. The `assess_risk` heuristic scores changed files by
+   keyword patterns: `auth`/`login`/`token` (+3 each), `db`/`sql` (+3 each),
+   `config` (+2). Scores map to risk levels: 0 = low, 1-2 = medium, 3-5 =
+   high, 6+ = critical. The report also suggests verification commands and
+   related test files.
+
+### Topic Search Engine
+
+The `topic.rs` module implements a lightweight code-search engine specifically
+designed for AI agent consumption. It does not use embeddings or vector search;
+instead it relies on a set of well-tuned heuristic strategies:
+
+- **Identifier splitting**: Splits camelCase, PascalCase, snake_case, and
+  kebab-case identifiers into their constituent tokens. For example,
+  `getUserPermissions` becomes `["get", "user", "permissions"]`.
+- **File-role classification**: Classifies each file as `test`, `frontend-ui`,
+  `frontend-state`, `backend`, or `config` based on path patterns, so agents
+  can filter by file role.
+- **Weighted topic scoring**: Combines path score (30%), symbol-name score
+  (25%), and symbol-kind/docstring score (15%) with noise penalties (5%
+  reduction for generated/cache files) and test-weight adjustments (45%
+  reduction for test files).
+- **IDF-like keyword weighting**: Tokens that appear in many files receive
+  lower weight; rare tokens receive higher weight. This is computed as
+  `ln(N/df) + 0.5` where N is the total file count and df is the document
+  frequency.
+- **Fuzzy symbol suggestions**: Levenshtein distance <= 3 for typo-tolerant
+  symbol lookup, returning up to `max_results` candidates sorted by distance
+  then PageRank.
+- **Related-test discovery**: Three strategies applied in order: same-directory
+  test files (confidence 0.9), name-convention matching (confidence 0.75), and
+  import-reference matching (confidence 0.6).
+
+## Relationship to repomap
+
+DeepMap and repomap share the same design philosophy but serve different
+purposes and operate at different levels of maturity.
+
+[repomap](https://github.com/gjczone/repomap) is the upstream research project,
+written in Python and licensed under MIT. It is the more feature-complete of
+the two, supporting 15 languages (versus DeepMap's 8), offering LSP
+integration for real-time symbol resolution, implementing a full
+"edit -> verify" workflow that can automatically check whether an AI edit
+achieved its stated goal, and providing incremental scan support for very large
+monorepos where a full rescan is impractical. Repomap exposes a Python API and
+a CLI, and its design prioritises extensibility and experimentation -- new
+language support, new query strategies, and new analytical passes are added to
+repomap first.
+
+DeepMap is repomap's engine, rewritten in Rust and integrated natively into
+DeepSeek-TUI. It is not a port of every feature; it is a focused implementation
+of the core scanning, ranking, and reporting pipeline that matters most for
+TUI agent workflows. By shipping as a compiled library inside the DeepSeek-TUI
+binary, DeepMap eliminates the overhead of subprocess calls, JSON
+serialization, and Python runtime dependency management. The trade-off is that
+extending DeepMap requires a Rust compilation step and is more involved than
+extending repomap.
+
+The intended workflow is bidirectional:
+
+- When new query strategies or language grammars prove useful in repomap, they
+  are ported to DeepMap for production use in DeepSeek-TUI.
+- When DeepMap's Rust engine discovers edge cases or performance bottlenecks
+  that are easier to prototype in Python, the experiments happen in repomap.
+
+Both projects are actively maintained and evolve in tandem.
+
+## Language Support
+
+DeepMap currently bundles tree-sitter parsers for 8 languages:
+
+| Language | Parsers | Coverage notes |
+|----------|---------|----------------|
+| Rust | `tree-sitter-rust` | Functions, structs, enums, traits, impl blocks, type aliases, modules, use declarations (scoped and glob), call expressions |
+| Python | `tree-sitter-python` | Functions, decorated functions, classes, decorated classes, methods, lambdas, imports (absolute, relative, aliased), call expressions |
+| JavaScript | `tree-sitter-javascript` | Functions, arrow functions, classes, methods, ES module imports/exports, CommonJS require, call expressions, object literal methods, anonymous functions |
+| TypeScript | `tree-sitter-typescript` (TypeScript + TSX) | Same as JavaScript plus TSX support for React/JSX syntax |
+| Go | `tree-sitter-go` | Functions, methods, structs, interfaces, imports (interpreted string literals), call expressions |
+| HTML | `tree-sitter-html` | Tag names as symbols |
+| CSS | `tree-sitter-css` | Class selectors, ID selectors, tag names as symbols |
+| JSON | `tree-sitter-json` | Key-value pairs as symbols |
+
+The `ext_to_lang` function in `types.rs` maps 17 file extensions to these 8
+parsers plus 7 additional languages (Java, Kotlin, Swift, C/C++, C#, PHP,
+Ruby) that are recognised for file discovery but do not yet have tree-sitter
+queries -- they will pass through filtering and contribute to file counts but
+produce no symbols or edges. These are candidates for future parser integration.
+
+### About tree-sitter-tsx
+
+TypeScript parser support includes the separate TSX grammar
+(`tree_sitter_typescript::LANGUAGE_TSX`) in addition to the standard TypeScript
+grammar (`tree_sitter_typescript::LANGUAGE_TYPESCRIPT`). This is important for
+React/JSX projects because the TSX grammar understands JSX syntax nodes that
+the plain TypeScript grammar does not. Without TSX support, a `component.tsx`
+file would fail to parse on any JSX expression, producing no symbols for the
+entire file.
+
+## Design Decisions
+
+### Why PageRank and not something else?
+
+PageRank was chosen for three reasons. First, it is well-understood and has
+known convergence properties -- 50 iterations with a damping factor of 0.85
+guarantees a stable ranking for any directed graph. Second, it naturally
+handles the "importance flows through edges" intuition that maps well to
+software dependencies: if a file is imported by many important files, it is
+itself important. Third, the computation is cheap for project-scale graphs
+(typically 5,000-50,000 nodes), completing in a few milliseconds after the
+graph is built.
+
+Alternatives considered include centrality measures (betweenness, closeness)
+which are more expensive to compute, and machine learning approaches (node
+embeddings, graph neural networks) which require training data and are
+impractical for a general-purpose tool that must work on any codebase without
+prior training.
+
+### Why three-phase and not streaming?
+
+The three-phase design (traverse -> parse -> rank) requires holding all
+parsed data in memory before ranking can begin. A streaming approach that
+ranked incrementally would use less memory but would sacrifice the global view
+that PageRank requires -- a symbol's importance depends on the full graph
+structure, not just local properties.
+
+For a typical project, the `RepoGraph` uses 50-200 MB of memory, which is
+acceptable for a development tool that runs ephemerally. The session cache
+avoids paying this cost more than once per workspace per process lifetime.
+
+### Why not use the system language server?
+
+An LSP-based approach would give richer symbol information (type annotations,
+documentation, diagnostics) and would not require bundling tree-sitter
+grammars. However, LSP servers are language-specific, require installation
+and configuration, and may not be available for every language in a polyglot
+project. DeepMap's tree-sitter approach works offline, with zero configuration,
+and supports every bundled language uniformly. The trade-off is shallower
+semantic understanding -- DeepMap knows what is defined and what calls what,
+but it does not know types.
+
+## License
+
+MIT -- same as repomap and DeepSeek-TUI. Both repomap and deepmap are
+permissively licensed and free to use in any project, commercial or otherwise.
+Contributions are welcome through the standard GitHub fork-and-PR workflow.
+
+## Future Directions
+
+The following capabilities are under consideration for future releases:
+
+- **Incremental scanning**: Re-scan only changed files instead of the entire
+  project, using the mtime cache and SHA-256 fingerprint as change detectors.
+  The mtime cache infrastructure is already in place in the engine; what is
+  needed is a "diff and merge" pass that updates the existing graph rather
+  than rebuilding from scratch.
+
+- **LSP integration as a plugin**: An optional plugin that connects to one or
+  more LSP servers for richer symbol information (type annotations, hover
+  documentation, diagnostics) when available, falling back to tree-sitter when
+  they are not.
+
+- **Additional language parsers**: Java, Kotlin, Swift, C/C++, C#, PHP, and
+  Ruby parsers would bring the language count to 15, matching repomap's
+  coverage.
+
+- **Post-edit verification**: Given a set of edited files and the original
+  dependency graph, automatically check whether all affected files still
+  satisfy their structural invariants (exports match imports, call targets
+  still exist, etc.).
+
+- **Time-series ranking**: Track PageRank scores across git history to
+  identify modules that are growing in structural importance, flagging them
+  as candidates for refactoring before they become maintenance bottlenecks.

--- a/docs/DEEPMAP.zh-CN.md
+++ b/docs/DEEPMAP.zh-CN.md
@@ -1,0 +1,538 @@
+# DeepMap -- DeepSeek-TUI 的 AI 原生代码库地图引擎
+
+## 起源与动机
+
+代码库自动映射的概念由
+[aider](https://github.com/Aider-AI/aider) 率先提出。aider 是第一个认识到
+AI 编程助手在修改代码之前，需要先理解项目结构才能做出有意义的修改的
+CLI 工具。aider 首创了一套将 tree-sitter 解析与 PageRank 排序相结合的
+流水线，生成一份紧凑的"项目地图"——一份大约 1000 token 的 Markdown 文档，
+按结构重要性排序，展示项目的入口点、热点文件和关键符号。
+
+aider 的核心洞察既简单又深刻：一份 1000 token 的结构化地图，在帮助 AI
+理解"应该在哪里修改"这件事上，始终优于 50000 token 的原始代码转储。
+原始代码倾泻会淹没模型的注意力预算；而一份排好序的地图直接告诉它应该
+优先看哪里。
+
+在 aider 的基础上，我们开发了
+[repomap](https://github.com/gjczone/repomap) 作为一个独立的开源研究项目。
+repomap 在多个方向上扩展了原始概念：语言覆盖从 8 种扩展到 15 种，为大
+型项目增加了增量扫描，引入了影响分析（给定一组修改的文件，还有哪些文件
+需要关注？）、编辑后验证建议、LSP 集成用于实时符号解析，以及专为 AI
+消费而非人工阅读设计的结构化 JSON 报告。
+
+DeepMap 是这项工作的自然演进。它将 repomap 中经过验证的核心引擎用 Rust
+重写，原生集成到 DeepSeek-TUI 中，成为一等公民的分析能力。如果说
+repomap 是一个独立的 Python CLI 工具，那么 DeepMap 就活在 AI 编程助手的
+同一个进程里——没有子进程，没有序列化开销，不需要单独部署。
+
+repomap 和 DeepMap 共享同一个起源故事：它们都是由 @gjczone 构建的——
+一位非程序员，使用 DeepSeek-V4-Pro，由 GLM-5.1 和 MIMO-V2.5-Pro
+进行交叉验证和审查。整个项目本身就是一个证据：我们正在构建的、具备代码库
+感知能力的 AI 原生编程工具，也能帮助它们的创造者构建有意义的基础设施。
+"吃自己的狗粮"在这里不是偶然，而是重点。
+
+## 我们要解决的问题
+
+现代 AI 编程工具大致分为两类，它们与代码库理解的关系截然不同。
+
+**基于 IDE 的编程助手**（Cursor、Trae、Qoder、GitHub Copilot）运行在完整
+的开发环境中，可以访问语言服务器（LSP）。它们天生就知道：存在哪些符号、
+它们在哪里定义、它们如何相互引用、以及当前有哪些错误。IDE 提供了全能补全、
+跳转到定义、查找所有引用和重命名等功能——全部由实时更新的索引支撑。
+对于这些工具来说，代码库意识是平台的内置功能。
+
+**基于 CLI 的编程助手**（aider、Claude Code、DeepSeek-TUI）历史上一直
+没有这个优势。它们在终端中运行，面对的是工作目录。它们不控制编辑器，
+也没有运行中的 LSP 服务器。它们理解代码库的默认策略是退回到通用的
+Unix 工具：用 `grep` 做文本搜索，用 `find` 或 `fd` 做文件发现，用暴力
+读取文件来理解依赖关系。这种方法有三个根本问题。
+
+第一，**token 浪费严重**。不知道哪些文件重要的 AI，会读入大量与当前
+任务无关的文件。一个 1500 行的样板文件可能消耗 5000-10000 token，仅仅
+为了确认它没有有用的内容。在一个有数百个文件的项目中，这种浪费在每个
+会话中轻易达到数十万 token。
+
+第二，**依赖关系对 grep 不可见**。文本搜索可以找到函数名出现的位置，
+但它无法告诉你这些出现是调用还是注释。它无法告诉你模块 A 中的 `foo()`
+经过一连串的重新导出，实际解析到模块 B 中定义的 `foo`。它无法构建调用图，
+无法识别孤立代码，也无法追踪修改一个共享数据结构的影响范围。
+
+第三，**变更影响评估完全靠人工**。当开发者修改了三个文件时，AI 需要
+知道哪些其他文件依赖这些被修改的符号，需要重新验证。没有依赖图，AI
+要么靠猜（冒着遗漏重要回归的风险），要么读取项目中的每一个文件（浪费
+无上限的 token）。
+
+DeepMap 填补了这个空白。它为基于 CLI 的 AI 提供了与 IDE 工具相同级别的
+结构性感知能力，而不需要 IDE、MCP 服务器、运行中的 LSP 进程或任何外部
+基础设施。它是一个编译进 DeepSeek-TUI 二进制文件的库，能在几秒内为
+任何项目生成一份紧凑、高信噪比的"地图"。
+
+## DeepMap 在 DeepSeek-TUI 中提供的能力
+
+DeepMap 通过两个渠道暴露其能力：**TUI 工具**（AI 在对话中可以主动调用）
+和 **CLI 命令**（开发者可以直接在 shell 中执行）。
+
+### TUI 工具（对模型可见，AI 在对话中调用）
+
+这些工具注册在 DeepSeek-TUI 的工具注册表中，通过系统提示告知模型。
+模型根据任务上下文决定何时调用——例如，在进入一个新项目时调用
+`deepmap_overview` 来了解代码布局，或者在追踪一个 bug 如何在系统中
+传播时调用 `deepmap_call_chain`。
+
+| 工具 | 描述 |
+|------|------|
+| `deepmap_overview` | 完整的项目地图报告：入口点、按 PageRank 排序的热点文件、扫描统计、推荐阅读顺序、模块摘要、按文件分组的关键符号。是 AI 了解陌生代码库的主要入口。 |
+| `deepmap_call_chain` | 追踪任意符号的调用者和被调用者，支持配置深度。返回按深度分组、按 PageRank 排序的结构化列表，帮助 AI 优先关注最重要的节点。适用于调试、重构范围评估和影响分析。 |
+| `deepmap_file_detail` | 列出单个文件中定义的每个符号，包括签名、类型、可见性、行范围和 PageRank 分数。AI 可以用它来了解某个文件的 API 面，而无需读取整个文件。 |
+| `deepmap_query` | 基于主题的代码搜索，结合了关键词匹配、标识符拆分（驼峰式、蛇形式、烤串式）、文件角色分类和 IDF 加权。返回排序后的文件匹配结果、相关测试文件和高亮的关键符号。比纯 grep 更精确，因为它理解代码结构。 |
+
+所有 TUI 工具都是**只读**且**可沙箱化**的，意味着它们从不修改文件系统，
+可以在沙箱环境中运行。它们使用与现有 `project_map` 工具相同的**自动批准**
+安全模型——不需要用户审批弹窗，因为这些工具不会产生副作用。
+
+### CLI 命令（面向开发者，从终端调用）
+
+这些命令让开发者可以不通过 AI 直接使用 DeepMap。它们尤其适用于 CI/CD
+流水线、pre-commit 钩子和临时探索。
+
+| 命令 | 用途 |
+|------|------|
+| `deepseek deepmap overview` | 生成并打印完整的项目地图到标准输出。等同于 `deepmap_overview` 工具。 |
+| `deepseek deepmap call-chain --symbol <名字>` | 按名称追踪特定符号的调用链。支持可选的 `--direction`（调用者、被调用者或双向）和 `--depth` 参数。 |
+| `deepseek deepmap file-detail --file <路径>` | 查看单个文件的符号表。以格式化表格展示所有符号及其类型、可见性、行范围和 PageRank 分数。 |
+| `deepseek deepmap query --keywords <关键词>` | 在整个代码库中进行主题搜索。接受自然语言或代码术语，返回带相关测试文件的排序结果。 |
+| `deepseek deepmap impact --files <a,b>` | 编辑前的影响分析：给定逗号分隔的变更文件路径列表，列出所有依赖它们的文件（直接和传递），并提供每个文件的指标。 |
+| `deepseek deepmap diff-risk` | 完整的差异风险评估：结合影响分析和基于关键词的风险分类（auth、db、config 模式得分更高），以及验证建议，包括相关测试文件和推荐的测试命令。 |
+
+### 会话缓存
+
+DeepMap 使用两级缓存策略，使得重复调用非常快：
+
+1. **内存级会话缓存**：会话中的第一次 `deepmap_overview` 调用会触发完整
+   扫描，中等规模项目（5000-20000 个文件）通常需要 20-40 秒。扫描结果
+   `RepoGraph`（符号、边、PageRank 分数）存储在以规范化的项目根路径为
+   键的 `LazyLock<Mutex<HashMap>>` 中。同一会话中的所有后续工具调用——
+   `deepmap_call_chain`、`deepmap_file_detail`、`deepmap_query` 等——
+   复用这个内存缓存，返回时间在 10 毫秒以内。
+
+2. **磁盘级持久缓存**：图结构序列化到
+   `~/.cache/deepmap/{项目名}_{路径哈希}/symbol_cache.json`，带有模式版本
+   守卫。下一次会话时，如果缓存存在且模式版本匹配，则完全跳过扫描，从
+   磁盘加载图结构。缓存条目包含文件路径、大小和修改时间的 SHA-256 指纹，
+   工作目录的变化会自动使缓存失效。写入是原子的（先写入临时文件，再重
+   命名覆盖最终路径），并会自动备份之前的缓存。
+
+这个设计意味着，AI 在某个项目中首次工作时只支付一次扫描成本，后续会话
+几乎是瞬时的。
+
+## 公开 API 面
+
+DeepMap 通过 `deepmap` crate 暴露了一套聚焦的公开 API。以下类型和方法构成了 TUI 工具集成和 CLI 命令实现的主要接口。
+
+### `RepoMapEngine` —— 主入口
+
+核心调度器，拥有扫描流水线、图数据和分析查询的全部所有权。
+
+| 方法 | 描述 |
+|------|------|
+| `new(project_root)` | 为指定的项目根路径创建新的引擎实例 |
+| `get_or_scan(project_root, max_files, max_scan_secs)` | 带会话缓存的构造函数；如果该项目已在本进程中扫描过，返回缓存的引擎，否则执行完整扫描 |
+| `scan(max_files, max_scan_secs)` | 执行完整的三阶段流水线：文件遍历、tree-sitter 解析和 PageRank 排名 |
+| `query_symbol(name)` | 符号名的不区分大小写的子串搜索，返回按 PageRank 降序排列的匹配结果 |
+| `call_chain(symbol_id, direction, max_depth)` | 调用图的 BFS 遍历；支持调用者、被调用者和双向遍历 |
+| `hotspots(limit)` | 按 `symbol_count * average_PageRank` 排序的文件，识别最需要维护的关键文件 |
+| `entry_points()` | 通过文件名干或路径模式启发式检测常见入口文件 |
+| `suggested_reading_order(limit)` | 按接手优先级评分的文件列表，排除测试和噪音文件 |
+| `module_summary(limit)` | 按顶层目录分组的符号，按总 PageRank 降序排列 |
+| `is_scanned()` | 返回 `true` 如果扫描已完成 |
+| `scan_summary_lines()` | 返回格式化的摘要文本，描述扫描时长、文件数量和符号数量 |
+
+### `TreeSitterAdapter` —— 多语言解析器
+
+管理 8 种语言的 tree-sitter 解析器和编译好的 S-expression 查询。
+
+| 方法 | 描述 |
+|------|------|
+| `new()` | 初始化所有 8 种语言解析器（Rust、Python、JavaScript、TypeScript、Go、HTML、CSS、JSON） |
+| `parse(content, lang)` | 使用相应的语言语法解析源代码内容 |
+| `symbols()` | 从解析树中提取所有函数、类、导入和调用的捕获结果 |
+| `imports()` | 提取导入声明，包含源模块和导入名称 |
+| `calls()` | 提取调用表达式，包含被调用者名称和位置 |
+| `import_bindings()`（仅 JS/TS）| ES 模块和 CommonJS 导入的结构化记录 |
+| `exports()`（仅 JS/TS）| ES 模块和 CommonJS 导出的结构化记录 |
+
+### `ImportResolver` —— 导入解析器
+
+将导入语句解析为目标文件，并构建符号之间的依赖边。
+
+| 方法 | 描述 |
+|------|------|
+| `new(project_root, graph)` | 使用项目根路径和图引用创建解析器 |
+| `resolve_import_targets(source_file, import_path)` | 使用相对路径解析、tsconfig 别名和文件名干查找将导入路径解析为候选目标文件 |
+
+### 关键数据类型
+
+- **`Symbol`** —— 包含 `id`（`file:name:line` 复合键）、`name`、`kind`（function、class、struct、method、arrow_function 等）、`file_path`、`line_range`、`column`、`visibility`、`docstring`、`signature` 和 `pagerank_score`。
+- **`Edge`** —— 两个符号 ID 之间的有向边，包含 `weight` 字段（调用为 0.50，导入为 0.35）。
+- **`RepoGraph`** —— 完整的图容器：`symbols`、`outgoing`、`incoming`、`file_symbols`、`file_imports`、`file_calls`、`file_import_bindings`、`file_exports`。
+- **`ScanStats`** —— 扫描元数据：`files_found`、`files_parsed`、`files_failed`、`filtered_large_files`、`total_symbols`、`total_edges`、`scan_duration_ms`、`timeout_triggered`、`failed_files`。
+
+### 渲染器函数
+
+`renderer` 模块中的六个 Markdown 报告生成器：
+
+- `render_overview_report()` —— 包含入口点、热点文件、阅读顺序、模块摘要和关键符号的完整项目地图
+- `render_call_chain_report()` —— 带深度分组的符号调用者/被调用者链
+- `render_file_detail_report()` —— 以 Markdown 表格展示的每个文件的符号表
+- `render_query_report()` —— 带相关测试发现的主题搜索结果
+- `render_impact_report()` —— 带传递依赖列表的编辑前影响分析
+- `render_diff_risk_report()` —— 带风险分类和验证建议的完整差异风险评估
+
+## 失败模型
+
+DeepMap 被设计为能够优雅地处理真实世界代码库中不完整、配置错误或包含病态文件的情况。以下契约描述了每种失败模式的处理方式。
+
+| 场景 | 行为 |
+|------|------|
+| **语言没有可用的解析器** | 文件被静默跳过；继续扫描其他文件。不抛出错误。 |
+| **文件过大（>10 MiB）** | 文件被跳过，计入 `filtered_large_files`。 |
+| **AST 嵌套过深（>1,000 层）** | 作为对病态或生成文件的安全防护，文件被跳过。 |
+| **解析错误 / 源码格式错误** | 文件被跳过；路径和错误信息记录在 `failed_files` 中（最多 5 条）。 |
+| **扫描超时（默认 300 秒）** | 返回部分结果；`ScanStats` 中的 `timeout_triggered` 设为 `true`。 |
+| **空项目 / 没有支持的文件** | 返回空的 `RepoGraph`；所有报告仍然有效但内容极少。 |
+| **会话缓存未命中** | 自动执行完整扫描；结果会被缓存供后续调用使用。 |
+| **符号未找到（query-symbol / call-chain）** | 返回空结果。这是正常行为，不是错误。 |
+| **Git 操作不可用（impact / diff-risk）** | 在输出中明确报告"不是 git 仓库"；不会崩溃。 |
+| **未安装 LSP 服务器** | `lsp doctor` 报告该服务器被跳过；其他命令中的 `--with-lsp` 优雅降级并给出明确提示。 |
+
+在所有情况下，DeepMap 绝不会因为单个文件的处理失败而 panic 或崩溃。错误被收集、记录，并通过 `ScanStats` 元数据或报告输出呈现，由调用方决定如何处理。
+
+## 架构
+
+DeepMap 的架构遵循一个清晰的三阶段流水线，配合共享数据模型，每个阶段
+都可以独立测试、优化和替换。
+
+### 阶段一：文件遍历与过滤
+
+入口点是 `engine.rs` 中的 `RepoMapEngine::scan()`。文件发现使用 `ignore`
+crate（`ripgrep` 背后的库），在遍历项目树时遵循 `.gitignore` 规则，根
+据 `SKIP_DIR_NAMES`（35 个常见噪音目录，如 `node_modules`、`.git`、
+`target`、`venv`、`dist`、`build`、`vendor` 等）和 `SKIP_FILE_NAMES`
+（锁文件等）过滤条目，只保留扩展名受支持的文件。
+
+`types.rs::ext_to_lang()` 中的扩展名到语言的映射覆盖了 17 种扩展名、
+9 个语言家族：Python（`.py`、`.pyi`）、JavaScript（`.js`、`.jsx`、`.mjs`、
+`.cjs`）、TypeScript（`.ts`、`.tsx`、`.mts`、`.cts`）、Go（`.go`）、
+Rust（`.rs`）、Java（`.java`）、Kotlin（`.kt`、`.kts`）、Swift（`.swift`）、
+C/C++（`.cpp`、`.cc`、`.cxx`、`.hpp`、`.h`）、C#（`.cs`）、PHP（`.php`）、
+Ruby（`.rb`）、HTML（`.html`、`.htm`）、CSS（`.css`）和 JSON（`.json`）。
+大于 512 KB 的文件会被跳过（可通过 `DEEPMAP_MAX_FILE_BYTES` 环境变量配
+置）。AST 嵌套深度超过 1000 的文件也会被跳过，作为对病态文件的安全防护。
+
+遍历器尊重 `max_files` 限制和 `max_scan_secs` 超时（硬上限 300 秒），
+因此即便是非常大的单体仓库也无法无限期地阻塞 AI。
+
+### 阶段二：Tree-Sitter 解析与符号提取
+
+每个候选文件使用相应的 tree-sitter 解析器进行解析。DeepMap 打包了 8 个
+编译为原生 Rust 库的 tree-sitter 语法：
+
+- `tree-sitter-rust` (0.24)
+- `tree-sitter-python` (0.23)
+- `tree-sitter-javascript` (0.23)
+- `tree-sitter-typescript` (0.23，含 TypeScript 和 TSX)
+- `tree-sitter-go` (0.23)
+- `tree-sitter-html` (0.23)
+- `tree-sitter-css` (0.23)
+- `tree-sitter-json` (0.23)
+
+`TreeSitterAdapter`（在 `parser.rs` 中）管理每种语言的解析器和编译好的
+S-expression 查询。查询定义在 `queries.rs` 中，每种语言覆盖四种查询类型：
+
+- **function**：函数声明、方法定义、箭头函数、lambda 表达式以及右侧为
+  函数表达式的变量声明。
+- **class**：类声明、结构体定义、枚举定义、trait 定义、接口声明和
+  impl 块。
+- **import**：导入语句、use 声明、require 调用和模块路径引用。Rust 导
+  入提取器对 `scoped_use_list` 和嵌套的 `scoped_identifier` 路径有特殊
+  处理，会拼接路径和名称段（例如 `std::collections::HashMap`）。
+- **call**：调用表达式、方法调用、成员函数调用和作用域/限定调用。
+
+每个查询产生包含名称、类型、字节范围和行范围的 `RawCapture` 条目。
+对于 JavaScript 和 TypeScript，还额外运行三个提取步骤：
+
+1. **导入绑定**：对每个 `import` 语句（ES 模块）和 `require()` 调用
+   （CommonJS）的结构化记录，捕获本地名称、导入名称、源模块和导入类型
+   （default、named、namespace、CJS default、CJS destructured）。这对
+   调用链解析至关重要，因为它让引擎能够将代码中的 `foo()` 映射回 `foo`
+   实际定义的位置，跨越重新导出链。
+
+2. **导出绑定**：对每个 `export` 语句（ES 模块）和 `module.exports` /
+   `exports.xxx` 赋值（CommonJS）的结构化记录，捕获导出名称、源名称、
+   重新导出模块和导出类型。这使得引擎能够解析通过中间模块的
+   `import { X } from 'Y'` 链。
+
+3. **额外符号提取**：三次额外的提取
+   （`extract_object_literal_methods`、`extract_anonymous_symbols`、
+   `extract_exported_function_expressions`）捕获标准查询遗漏的符号：
+   对象字面量中的方法定义、赋值给变量的匿名函数（例如 `const foo =
+   function() {}`）以及默认导出的函数/类表达式。
+
+提取的数据存储在 `RepoGraph` 中（定义在 `types.rs`）：
+
+```
+RepoGraph {
+  symbols:          HashMap<symbol_id, Symbol>,
+  outgoing:         HashMap<symbol_id, Vec<Edge>>,
+  incoming:         HashMap<symbol_id, Vec<Edge>>,
+  file_symbols:     HashMap<file_path, Vec<symbol_id>>,
+  file_imports:     HashMap<file_path, Vec<import_string>>,
+  file_calls:       HashMap<file_path, Vec<(call_name, line, kind)>>,
+  file_import_bindings: HashMap<file_path, Vec<JsImportBinding>>,
+  file_exports:     HashMap<file_path, Vec<JsExportBinding>>,
+}
+```
+
+`Symbol` 包含其 id（由 `file:name:line` 组成的复合键）、名称、类型
+（function、class、struct、method、arrow_function 等）、文件路径、行
+范围、列、可见性、文档字符串、签名和 PageRank 分数。
+
+### 阶段二 B：导入解析与边构建
+
+解析完所有文件后，`ImportResolver`（在 `resolver.rs` 中）构建索引：
+
+- **file_map**：文件名干 -> 候选文件路径（例如 `"helper"` ->
+  `["src/utils/helper.ts", "tests/helper_test.ts"]`）。
+- **name_index**：符号名 -> 符号 ID（例如 `"parse"` -> 项目中所有名为
+  parse 的函数）。
+- **known_paths**：所有已知文件路径的 `HashSet`，用于 O(1) 存在性检查。
+
+解析器还会在项目根目录和一级子目录中发现 `tsconfig.json` 和
+`jsconfig.json` 文件，解析它们（含 JSONC 注释和尾随逗号去除）以提取
+`compilerOptions.baseUrl` 和 `compilerOptions.paths` 别名规则。
+
+在构建边时，引擎处理两种关系：
+
+1. **调用边**（权重：0.50）：对解析过程中发现的每个调用表达式，解析器
+   尝试将其映射到目标符号。它首先查询本地名称映射表（从 JS/TS 导入绑定
+   构建）以解析重命名和重新导出，然后在全局 `name_index` 中查找解析后
+   的名称。调用符号通过找到包含调用行的符号来识别。
+
+2. **导入边**（权重：0.35）：对每个导入语句，解析器尝试使用三步策略
+   找到目标文件：首先尝试相对路径解析（针对以 `.` 开头的导入），然后
+   尝试 tsconfig 别名模式匹配，最后回退到 `file_map` 中的文件名干查找。
+   对每个解析到的目标文件，从源文件中的每个符号到目标文件中的每个符号
+   都创建导入边。
+
+去重集合 `HashSet<(source_id, target_id)>` 防止冗余边。常量控制边权重，
+调用边权重高于导入边，因为调用代表更紧密的耦合。
+
+### 阶段三：PageRank 计算与分析
+
+图构建完成后，标准的幂迭代 PageRank 算法
+（在 `ranking.rs::GraphAnalyzer::calculate_pagerank` 中）计算每个符号
+的结构重要性：
+
+1. 将所有节点的初始概率设为相等的 `1/N`。
+2. 每轮迭代：将每个节点的当前概率按边权重比例分配给其出边邻居。悬空
+   节点（没有出边的节点）贡献给均匀的跳转项。应用阻尼系数（默认 0.85，
+   与经典 PageRank 论文一致）。
+3. 当最大节点变化量低于 `1e-6` 时终止，或最多 50 轮迭代。
+4. 归一化分数使其总和为 1.0。
+
+阻尼系数和迭代次数在精度与计算时间之间取得平衡。项目规模的图通常在
+20-30 轮迭代内收敛。
+
+PageRank 计算完成后，`GraphAnalyzer` 提供以下分析查询：
+
+- **query_symbol**：符号名的不区分大小写的子串搜索，过滤掉低信号类型
+  （CSS 选择器、JSON 键、HTML 元素），按 PageRank 降序排列。
+- **call_chain**：调用图的 BFS 遍历，深度受限（默认无限制，BFS 队列硬
+  上限 10000 节点，结果上限 1000 个），支持调用者、被调用者或双向遍历。
+- **hotspots**：按 `symbol_count * average_PageRank` 排序的文件，识别
+  高密度、高重要性的文件，这些文件最可能是维护的关键点。
+- **entry_points**：通过文件名干（`main`、`app`、`index`、`server`、
+  `run`、`setup`、`cli`、`__main__`）或路径模式（`/src/main.tsx`、
+  `/lib.rs`）启发式检测常见入口文件。
+- **file_analysis**：每个文件的指标，包括符号数、出边数、入边数和平均
+  PageRank。
+- **module_summary**：按顶层目录分组的符号，按总 PageRank 降序排列，
+  提供高层视图，展示哪些模块承载最多的结构权重。
+- **suggested_reading_order**：按 `average_PR * ln(symbol_count) *
+  entry_boost(2.0 如果入口文件)` 评分的文件，排除测试和噪音文件。这是
+  AI 在接手项目时应该首先读取的列表。
+- **summary_symbols**：对阅读顺序中前 N 个文件，取综合重要性排序的
+  前 M 个符号（`入边数 * 3 + 出边数 * 2 + 类型权重`，其中函数和方法
+  得 5 分，类和结构体得 4 分，模块得 3 分，变量得 2 分，其他得 1 分）。
+
+### 报告渲染
+
+所有分析结果由 `renderer.rs` 模块渲染成 Markdown。提供六种报告类型，
+每种对应一个 TUI 工具或 CLI 命令：
+
+1. **概览报告**（`render_overview_report`）：将扫描统计、入口点、推荐
+   阅读顺序（前 20）、模块摘要（前 20）、热点（前 10）和关键符号（前
+   30 个文件，每文件 5 个符号）组合成一份综合文档。按调用者指定的字符
+   数限制截断，在单词边界处断开。
+
+2. **调用链报告**（`render_call_chain_report`）：查询最佳匹配符号，然
+   后按指定深度遍历调用者和被调用者。报告符号的类型、文件和 PageRank，
+   随后是按 PageRank 排序的调用者和被调用者列表。
+
+3. **文件详情报告**（`render_file_detail_report`）：以 Markdown 表格形
+   式列出文件中的所有符号，包含行号、类型、名称、可见性、PageRank 分
+   数和签名。按行号排序。
+
+4. **查询报告**（`render_query_report`）：将主题评分、相关测试发现和关
+   键符号高亮组合成一次响应。使用 `topic.rs` 模块中的 `topic_score` 函
+   数，应用标识符拆分、文件角色分类、噪音惩罚、测试权重调整和 IDF 关
+   键词加权。
+
+5. **影响报告**（`render_impact_report`）：对每个变更文件，列出直接依
+   赖方（导入该文件的文件）和每个文件的指标。汇总所有传递影响文件的
+   总数。
+
+6. **差异风险报告**（`render_diff_risk_report`）：结合影响分析与风险
+   评估。`assess_risk` 启发式方法根据关键词模式对变更文件评分：
+   `auth`/`login`/`token`（各 +3）、`db`/`sql`（各 +3）、`config`
+   （+2）。分数映射到风险等级：0 = 低，1-2 = 中，3-5 = 高，6+ = 严重。
+   报告还会建议验证命令和相关测试文件。
+
+### 主题搜索引擎
+
+`topic.rs` 模块实现了一个轻量级的代码搜索引擎，专为 AI 消费而设计。
+它不使用嵌入或向量搜索，而是依赖一组经过调优的启发式策略：
+
+- **标识符拆分**：将驼峰式、帕斯卡式、蛇形式和烤串式的标识符拆分为
+   构成词素。例如 `getUserPermissions` 变成 `["get", "user",
+   "permissions"]`。
+- **文件角色分类**：基于路径模式将每个文件分类为 `test`、`frontend-ui`、
+   `frontend-state`、`backend` 或 `config`，以便 AI 按角色过滤。
+- **加权主题评分**：结合路径得分（30%）、符号名得分（25%）和符号类型/
+   文档字符串得分（15%），加上噪音惩罚（生成/缓存文件减 5%）和测试权
+   重调整（测试文件再减 45%）。
+- **IDF 关键词加权**：出现在许多文件中的词权重低，稀有词权重高。计算
+   方式为 `ln(N/df) + 0.5`，其中 N 是文件总数，df 是文档频率。
+- **模糊符号建议**：莱文斯坦距离 <= 3 的容错符号查找，返回按距离再按
+   PageRank 排序的候选结果。
+- **相关测试发现**：依次应用三种策略：同目录测试文件（置信度 0.9）、
+   命名约定匹配（置信度 0.75）和导入引用匹配（置信度 0.6）。
+
+## 与 repomap 的关系
+
+DeepMap 和 repomap 共享相同的设计理念，但服务于不同的目的，处于不同
+的成熟度水平。
+
+[repomap](https://github.com/gjczone/repomap) 是上游研究项目，使用
+Python 编写，采用 MIT 许可证。它功能更完整，支持 15 种语言（DeepMap
+目前是 8 种），提供 LSP 集成用于实时符号解析，实现了完整的"编辑 -> 验证"
+工作流（可以自动检查 AI 的编辑是否达到了预期的目标），并为非常大的单体
+仓库提供增量扫描支持。Repomap 暴露了 Python API 和 CLI，其设计优先考
+虑可扩展性和实验性——新的语言支持、新的查询策略和新的分析步骤会首先
+添加到 repomap。
+
+DeepMap 是 repomap 的引擎，用 Rust 重写，原生集成到 DeepSeek-TUI 中。
+它不是每个功能的移植，而是对 TUI 中 AI 工作流最重要的核心扫描、排序和
+报告流水线的聚焦实现。通过作为编译库内嵌在 DeepSeek-TUI 二进制文件中，
+DeepMap 消除了子进程调用、JSON 序列化和 Python 运行时依赖管理的开销。
+代价是扩展 DeepMap 需要 Rust 编译步骤，比扩展 repomap 更复杂。
+
+预期的工作流是双向的：
+
+- 当 repomap 中验证了新的查询策略或语言语法后，它们会被移植到 DeepMap
+  用于 DeepSeek-TUI 的生产环境。
+- 当 DeepMap 的 Rust 引擎发现了更易于在 Python 中原型验证的边缘情况或
+  性能瓶颈时，实验会在 repomap 中进行。
+
+两个项目都处于活跃维护中，并同步演进。
+
+## 语言支持
+
+DeepMap 目前打包了 8 种语言的 tree-sitter 解析器：
+
+| 语言 | 解析器 | 覆盖说明 |
+|------|--------|----------|
+| Rust | `tree-sitter-rust` | 函数、结构体、枚举、trait、impl 块、类型别名、模块、use 声明（作用域和通配符）、调用表达式 |
+| Python | `tree-sitter-python` | 函数、带装饰器函数、类、带装饰器类、方法、lambda、导入（绝对、相对、别名）、调用表达式 |
+| JavaScript | `tree-sitter-javascript` | 函数、箭头函数、类、方法、ES 模块导入/导出、CommonJS require、调用表达式、对象字面量方法、匿名函数 |
+| TypeScript | `tree-sitter-typescript`（TypeScript + TSX） | 与 JavaScript 相同，外加 TSX 对 React/JSX 语法的支持 |
+| Go | `tree-sitter-go` | 函数、方法、结构体、接口、导入（解释型字符串字面量）、调用表达式 |
+| HTML | `tree-sitter-html` | 标签名作为符号 |
+| CSS | `tree-sitter-css` | 类选择器、ID 选择器、标签名作为符号 |
+| JSON | `tree-sitter-json` | 键值对作为符号 |
+
+`types.rs` 中的 `ext_to_lang` 函数将 17 种文件扩展名映射到这 8 个解析
+器加上 7 种附加语言（Java、Kotlin、Swift、C/C++、C#、PHP、Ruby），这
+些附加语言的文件会被发现并计入文件计数，但尚未有 tree-sitter 查询——
+它们会通过过滤但不产生符号或边。这些是未来解析器集成的候选语言。
+
+### 关于 tree-sitter-tsx
+
+TypeScript 解析器支持包含独立的 TSX 语法
+（`tree_sitter_typescript::LANGUAGE_TSX`），除了标准的 TypeScript 语法
+（`tree_sitter_typescript::LANGUAGE_TYPESCRIPT`）之外。这对 React/JSX
+项目很重要，因为 TSX 语法能理解纯 TypeScript 语法无法理解的 JSX 语法节
+点。没有 TSX 支持，`component.tsx` 文件会在任何 JSX 表达式上解析失败，
+导致整个文件不产生任何符号。
+
+## 设计决策
+
+### 为什么选择 PageRank 而不是其他算法？
+
+选择 PageRank 有三个原因。首先，它是一种经过充分研究的算法，具有已知
+的收敛性质——50 轮迭代加上 0.85 的阻尼系数可以保证任何有向图的稳定排
+序。其次，它自然地契合"重要性通过边流动"这一直觉，很好地映射到软件依
+赖关系：如果一个文件被许多重要文件导入，那么它本身也很重要。第三，对
+项目规模的图（通常 5000-50000 个节点），计算成本很低，图构建完成后只
+需要几毫秒。
+
+考虑的替代方案包括中心性度量（介数中心性、紧密中心性），它们的计算成
+本更高；以及机器学习方法（节点嵌入、图神经网络），它们需要训练数据，
+对于一个必须在任何代码库上无需预训练即可工作的通用工具来说不切实际。
+
+### 为什么是三阶段而不是流式？
+
+三阶段设计（遍历 -> 解析 -> 排序）要求在排序开始之前将所有解析数据保
+存在内存中。增量排序的流式方法会使用更少的内存，但会牺牲 PageRank 所
+需的全局视角——一个符号的重要性取决于整个图的结构，而不仅仅是局部属性。
+
+对于一个典型项目，`RepoGraph` 使用 50-200 MB 内存，这对于一个临时运行
+的开发工具来说是可以接受的。会话缓存确保每个工作空间在进程生命周期内
+只需支付一次这个成本。
+
+### 为什么不用系统自带的 LSP？
+
+基于 LSP 的方法可以提供更丰富的符号信息（类型注解、文档、诊断），并且
+不需要打包 tree-sitter 语法。然而，LSP 服务器是语言特定的，需要安装和
+配置，并且在多语言项目中可能不是每种语言都可以使用。DeepMap 的
+tree-sitter 方法离线工作，零配置，对每种打包的语言提供统一的支持。代价
+是语义理解较浅——DeepMap 知道什么是定义的以及什么调用了什么，但它不知
+道类型。
+
+## 许可证
+
+MIT —— 与 repomap 和 DeepSeek-TUI 相同。repomap 和 deepmap 都采用宽松
+许可证，可免费用于任何项目，包括商业项目。欢迎通过标准的 GitHub fork
+和 PR 工作流贡献代码。
+
+## 未来方向
+
+以下功能正在考虑在未来的版本中实现：
+
+- **增量扫描**：只重新扫描变更的文件，而不是整个项目，使用 mtime 缓存
+  和 SHA-256 指纹作为变更检测器。mtime 缓存基础设施已经在引擎中就位——
+  需要的是"差异与合并"步骤，更新现有图而非从头重建。
+
+- **LSP 集成插件**：一个可选的插件，在可用时连接一个或多个 LSP 服务器
+  以获取更丰富的符号信息（类型注解、悬停文档、诊断），在不可用时回退
+  到 tree-sitter。
+
+- **更多语言解析器**：Java、Kotlin、Swift、C/C++、C#、PHP 和 Ruby 解析
+  器将把语言数量提升到 15 种，与 repomap 的覆盖范围持平。
+
+- **编辑后验证**：给定一组编辑过的文件和原始的依赖图，自动检查所有受
+  影响文件是否仍然满足其结构不变量（导出匹配导入，调用目标仍然存在等）。
+
+- **时间序列排名**：追踪跨 git 历史的 PageRank 分数，以识别结构重要性
+  正在增长的模块，在它们成为维护瓶颈之前将其标记为重构候选。


### PR DESCRIPTION
## What is DeepMap?

DeepMap is a **codebase analysis engine designed for AI agents**. Its purpose is to give an LLM a "project map" before it starts reading individual source files — answering questions like *"what are the entry points?"*, *"which symbols matter most?"*, and *"what's the recommended reading order?"* — in a single tool call, rather than forcing the AI to read files blindly one by one.

It is modeled after the battle-tested [repomap](https://github.com/gjczone/repomap) Python tool, rewritten in Rust for native integration with DeepSeek-TUI.

**99% of usage is AI-agent auto-invocation.** The tools are registered in the model-visible tool catalog; the AI decides when to call them based on the task at hand. A developer CLI is also provided as a convenience.

## PR 1 of 3 — Parsing layer (this PR)

This first PR delivers the **foundation**: data types, tree-sitter query patterns, a multi-language parser adapter, and an import resolver. It is **self-contained with zero changes to existing code** — the `deepmap` crate compiles independently and can be depended on by other crates.

### Modules

| Module | Lines | Purpose |
|--------|-------|---------|
| `types.rs` | ~110 | Core types: `Symbol`, `Edge`, `RepoGraph`, `ScanStats`. 15-language extension-to-language mapping. All types derive `Serialize`/`Deserialize` for cache persistence. |
| `queries.rs` | ~85 | 34 tree-sitter S-expression query patterns across 8 languages: function, class, import, call, and anonymous-function captures. One query per pattern line — easy to audit and extend. |
| `parser.rs` | ~1200 | `TreeSitterAdapter`: manages 8 language parsers, compiles queries, provides a single `parse()` entry point that extracts symbols, imports, calls, and JS/TS bindings in one pass. Includes nesting-depth and file-size guards to prevent parser crashes. |
| `resolver.rs` | ~640 | `ImportResolver`: discovers tsconfig.json/jsconfig.json, parses `compilerOptions.paths` and `baseUrl` (JSONC-aware), resolves relative/alias/stem imports to concrete file paths, builds file-stem and symbol-name lookup indices. |

### Supported languages

| Language | Functions | Classes/Structs | Imports | Calls | JS/TS Bindings |
|----------|-----------|-----------------|---------|-------|----------------|
| Rust | ✅ | ✅ (struct/enum/trait/impl/mod) | ✅ (use/extern crate) | ✅ | — |
| Python | ✅ | ✅ | ✅ | ✅ | — |
| JavaScript | ✅ + anonymous | ✅ | ✅ | ✅ | ✅ ES modules + CommonJS |
| TypeScript | ✅ + anonymous | ✅ | ✅ | ✅ | ✅ ES modules + CommonJS |
| Go | ✅ | ✅ (struct/interface) | ✅ | ✅ | — |
| HTML | ✅ (elements) | — | — | — | — |
| CSS | ✅ (selectors) | — | — | — | — |
| JSON | ✅ (keys) | — | — | — | — |

### Design principles

- **AI-agent-first**: the parser returns structured data (not text) so the AI can reason about it. Every symbol has a unique ID, file location, visibility, and signature.
- **Crash-resistant**: 10 MiB file-size limit, 1000-depth nesting guard, silent skip of unsupported languages — a single malformed file will never crash the scan.
- **Zero unwrap in hot paths**: the public API uses `Result` and `Option`; internal helpers use `.unwrap_or("")` defensively.
- **Minimal public surface**: struct fields are private unless the engine layer needs them; accessor methods return owned data for safe cross-module use.

### How it will be used (PR 2 & 3)

```rust
// PR 2: Engine scans a project and builds a dependency graph
let mut engine = RepoMapEngine::new(project_root);
engine.scan(2000, 300.0);
let report = render_overview_report(&engine, 16000);

// PR 3: AI agent calls via TUI tool catalog
// deepmap_overview  → returns project map with entry points, hotspots, reading order
// deepmap_call_chain → traces callers/callees for a symbol
// deepmap_file_detail → lists symbols in a file with PageRank scores
```

### Verification

```
cargo check -p deepmap       # zero errors, zero warnings
cargo test -p deepmap        # 19 tests: 14 unit + 5 integration on real projects
cargo check --workspace      # clean with all 15 workspace crates
```

Smoke tests run against actual files from `~/.A1/DeepSeek-TUI` (Rust), `~/.A1/repomap` (Python), and `~/.A1/deeper-web` (TypeScript):

| Project | File | Symbols | Imports | Calls |
|---------|------|---------|---------|-------|
| DeepSeek-TUI | parser.rs | 36 | 1 | 496 |
| repomap | repomap_core.py | ✓ | ✓ | ✓ |
| deeper-web | server/app.ts | ✓ | 4 bindings | ✓ |
| deeper-web | package.json | 20+ keys | — | — |

### Next PRs

| PR | Content | ETA |
|----|---------|-----|
| 2 | Engine + ranking + renderer (scanning, PageRank, AI report generation) | After this is merged |
| 3 | TUI tool integration + CLI subcommands (model-visible tools) | After PR 2 |