### PR TITLE
feat: add OpenCode Go provider support

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -16,7 +16,7 @@
 # `/provider sglang`, `/provider vllm`, `/provider ollama`) toggle without having to
 # re-enter keys. Top-level `api_key` / `base_url` are still read as DeepSeek
 # defaults when `[providers.deepseek]` is absent (backward compatibility).
-provider = "deepseek" # deepseek | deepseek-cn | nvidia-nim | openai | openrouter | novita | fireworks | sglang | vllm | ollama
+provider = "deepseek" # deepseek | deepseek-cn | nvidia-nim | openai | openrouter | novita | fireworks | sglang | vllm | ollama | opencode-go
 api_key = "YOUR_DEEPSEEK_API_KEY" # must be non-empty
 base_url = "https://api.deepseek.com/beta"
 # provider = "deepseek-cn"                       # mainland China preset (official https://api.deepseek.com)
@@ -163,6 +163,7 @@ max_subagents = 10 # optional (1-20)
 #   SGLang:    SGLANG_BASE_URL, SGLANG_MODEL, optional SGLANG_API_KEY
 #   vLLM:      VLLM_BASE_URL, VLLM_MODEL, optional VLLM_API_KEY
 #   Ollama:    OLLAMA_BASE_URL, OLLAMA_MODEL, optional OLLAMA_API_KEY
+#   OpenCode Go: OPENCODE_GO_API_KEY, OPENCODE_GO_BASE_URL, OPENCODE_GO_MODEL
 
 # DeepSeek Platform (https://platform.deepseek.com)
 [providers.deepseek]
@@ -206,6 +207,12 @@ max_subagents = 10 # optional (1-20)
 # api_key = "OPTIONAL_OLLAMA_TOKEN"
 # base_url = "http://localhost:11434/v1"
 # model = "deepseek-coder:1.3b"             # or any local Ollama tag
+
+# OpenCode Go (https://opencode.ai/go)
+[providers.opencode_go]
+# api_key = "YOUR_OPENCODE_GO_API_KEY"
+# base_url = "https://opencode.ai/zen/go/v1"
+# model = "deepseek-v4-pro"                 # or deepseek-v4-flash
 
 # ─────────────────────────────────────────────────────────────────────────────────
 # Network Policy (#135)

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -192,6 +192,28 @@ impl Default for ModelRegistry {
                 supports_tools: true,
                 supports_reasoning: false,
             },
+            ModelInfo {
+                id: "deepseek-v4-pro".to_string(),
+                provider: ProviderKind::OpencodeGo,
+                aliases: vec![
+                    "deepseek-v4-pro".to_string(),
+                    "opencode-go-deepseek-v4-pro".to_string(),
+                ],
+                supports_tools: true,
+                supports_reasoning: true,
+            },
+            ModelInfo {
+                id: "deepseek-v4-flash".to_string(),
+                provider: ProviderKind::OpencodeGo,
+                aliases: vec![
+                    "deepseek-v4-flash".to_string(),
+                    "deepseek-chat".to_string(),
+                    "deepseek-reasoner".to_string(),
+                    "opencode-go-deepseek-v4-flash".to_string(),
+                ],
+                supports_tools: true,
+                supports_reasoning: true,
+            },
         ];
         Self::new(models)
     }
@@ -489,6 +511,34 @@ mod tests {
         let resolved = registry.resolve(Some("deepseek-reasoner"), None);
 
         assert_eq!(resolved.resolved.provider, ProviderKind::Deepseek);
+    }
+
+    #[test]
+    fn opencode_go_default_uses_deepseek_v4_pro() {
+        let registry = ModelRegistry::default();
+        let resolved = registry.resolve(None, Some(ProviderKind::OpencodeGo));
+
+        assert_eq!(resolved.resolved.provider, ProviderKind::OpencodeGo);
+        assert_eq!(resolved.resolved.id, "deepseek-v4-pro");
+        assert!(resolved.resolved.supports_tools);
+        assert!(resolved.resolved.supports_reasoning);
+    }
+
+    #[test]
+    fn deepseek_v4_pro_resolves_to_opencode_go_when_provider_hinted() {
+        let registry = ModelRegistry::default();
+        let resolved = registry.resolve(Some("deepseek-v4-pro"), Some(ProviderKind::OpencodeGo));
+
+        assert_eq!(resolved.resolved.provider, ProviderKind::OpencodeGo);
+        assert_eq!(resolved.resolved.id, "deepseek-v4-pro");
+    }
+
+    #[test]
+    fn deepseek_v4_flash_resolves_to_opencode_go_when_provider_hinted() {
+        let registry = ModelRegistry::default();
+        let resolved = registry.resolve(Some("deepseek-v4-flash"), Some(ProviderKind::OpencodeGo));
+
+        assert_eq!(resolved.resolved.provider, ProviderKind::OpencodeGo);
         assert_eq!(resolved.resolved.id, "deepseek-v4-flash");
     }
 }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -32,6 +32,7 @@ enum ProviderArg {
     Sglang,
     Vllm,
     Ollama,
+    OpencodeGo,
 }
 
 impl From<ProviderArg> for ProviderKind {
@@ -46,6 +47,7 @@ impl From<ProviderArg> for ProviderKind {
             ProviderArg::Sglang => ProviderKind::Sglang,
             ProviderArg::Vllm => ProviderKind::Vllm,
             ProviderArg::Ollama => ProviderKind::Ollama,
+            ProviderArg::OpencodeGo => ProviderKind::OpencodeGo,
         }
     }
 }
@@ -675,11 +677,12 @@ fn provider_slot(provider: ProviderKind) -> &'static str {
         ProviderKind::Sglang => "sglang",
         ProviderKind::Vllm => "vllm",
         ProviderKind::Ollama => "ollama",
+        ProviderKind::OpencodeGo => "opencode-go",
     }
 }
 
 /// Provider order used by the `auth list` and `auth status` outputs.
-const PROVIDER_LIST: [ProviderKind; 9] = [
+const PROVIDER_LIST: [ProviderKind; 10] = [
     ProviderKind::Deepseek,
     ProviderKind::NvidiaNim,
     ProviderKind::Openrouter,
@@ -688,6 +691,7 @@ const PROVIDER_LIST: [ProviderKind; 9] = [
     ProviderKind::Sglang,
     ProviderKind::Vllm,
     ProviderKind::Ollama,
+    ProviderKind::OpencodeGo,
     ProviderKind::Openai,
 ];
 
@@ -743,6 +747,7 @@ fn provider_env_vars(provider: ProviderKind) -> &'static [&'static str] {
         ProviderKind::Sglang => &["SGLANG_API_KEY"],
         ProviderKind::Vllm => &["VLLM_API_KEY"],
         ProviderKind::Ollama => &["OLLAMA_API_KEY"],
+        ProviderKind::OpencodeGo => &["OPENCODE_GO_API_KEY"],
         ProviderKind::Openai => &["OPENAI_API_KEY"],
     }
 }
@@ -1390,9 +1395,10 @@ fn build_tui_command(
             | ProviderKind::Sglang
             | ProviderKind::Vllm
             | ProviderKind::Ollama
+            | ProviderKind::OpencodeGo
     ) {
         bail!(
-            "The interactive TUI supports DeepSeek, NVIDIA NIM, OpenAI-compatible, OpenRouter, Novita, Fireworks, SGLang, vLLM, and Ollama providers. Remove --provider {} or use `deepseek model ...` for provider registry inspection.",
+            "The interactive TUI supports DeepSeek, NVIDIA NIM, OpenAI-compatible, OpenRouter, Novita, Fireworks, SGLang, vLLM, Ollama, and OpenCode Go providers. Remove --provider {} or use `deepseek model ...` for provider registry inspection.",
             resolved_runtime.provider.as_str()
         );
     }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -37,6 +37,9 @@ const DEFAULT_VLLM_FLASH_MODEL: &str = "deepseek-ai/DeepSeek-V4-Flash";
 const DEFAULT_VLLM_BASE_URL: &str = "http://localhost:8000/v1";
 const DEFAULT_OLLAMA_MODEL: &str = "deepseek-coder:1.3b";
 const DEFAULT_OLLAMA_BASE_URL: &str = "http://localhost:11434/v1";
+const DEFAULT_OPENCODE_GO_MODEL: &str = "deepseek-v4-pro";
+const DEFAULT_OPENCODE_GO_FLASH_MODEL: &str = "deepseek-v4-flash";
+const DEFAULT_OPENCODE_GO_BASE_URL: &str = "https://opencode.ai/zen/go/v1";
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "kebab-case")]
@@ -51,6 +54,7 @@ pub enum ProviderKind {
     Sglang,
     Vllm,
     Ollama,
+    OpencodeGo,
 }
 
 impl ProviderKind {
@@ -66,6 +70,7 @@ impl ProviderKind {
             Self::Sglang => "sglang",
             Self::Vllm => "vllm",
             Self::Ollama => "ollama",
+            Self::OpencodeGo => "opencode-go",
         }
     }
 
@@ -81,6 +86,7 @@ impl ProviderKind {
             "sglang" | "sg-lang" => Some(Self::Sglang),
             "vllm" | "v-llm" => Some(Self::Vllm),
             "ollama" | "ollama-local" => Some(Self::Ollama),
+            "opencode-go" | "opencode_go" | "opencodego" | "go" => Some(Self::OpencodeGo),
             _ => None,
         }
     }
@@ -115,6 +121,8 @@ pub struct ProvidersToml {
     pub vllm: ProviderConfigToml,
     #[serde(default)]
     pub ollama: ProviderConfigToml,
+    #[serde(default)]
+    pub opencode_go: ProviderConfigToml,
 }
 
 impl ProvidersToml {
@@ -130,6 +138,7 @@ impl ProvidersToml {
             ProviderKind::Sglang => &self.sglang,
             ProviderKind::Vllm => &self.vllm,
             ProviderKind::Ollama => &self.ollama,
+            ProviderKind::OpencodeGo => &self.opencode_go,
         }
     }
 
@@ -144,6 +153,7 @@ impl ProvidersToml {
             ProviderKind::Sglang => &mut self.sglang,
             ProviderKind::Vllm => &mut self.vllm,
             ProviderKind::Ollama => &mut self.ollama,
+            ProviderKind::OpencodeGo => &mut self.opencode_go,
         }
     }
 }
@@ -358,6 +368,10 @@ impl ConfigToml {
         merge_provider_config(&mut self.providers.sglang, &project.providers.sglang);
         merge_provider_config(&mut self.providers.vllm, &project.providers.vllm);
         merge_provider_config(&mut self.providers.ollama, &project.providers.ollama);
+        merge_provider_config(
+            &mut self.providers.opencode_go,
+            &project.providers.opencode_go,
+        );
 
         if project.network.is_some() {
             self.network = project.network;
@@ -446,6 +460,12 @@ impl ConfigToml {
             "providers.ollama.model" => self.providers.ollama.model.clone(),
             "providers.ollama.http_headers" => {
                 serialize_http_headers(&self.providers.ollama.http_headers)
+            }
+            "providers.opencode_go.api_key" => self.providers.opencode_go.api_key.clone(),
+            "providers.opencode_go.base_url" => self.providers.opencode_go.base_url.clone(),
+            "providers.opencode_go.model" => self.providers.opencode_go.model.clone(),
+            "providers.opencode_go.http_headers" => {
+                serialize_http_headers(&self.providers.opencode_go.http_headers)
             }
             _ => self.extras.get(key).map(toml::Value::to_string),
         }
@@ -582,6 +602,18 @@ impl ConfigToml {
             "providers.ollama.http_headers" => {
                 self.providers.ollama.http_headers = parse_http_headers(value)?;
             }
+            "providers.opencode_go.api_key" => {
+                self.providers.opencode_go.api_key = Some(value.to_string());
+            }
+            "providers.opencode_go.base_url" => {
+                self.providers.opencode_go.base_url = Some(value.to_string());
+            }
+            "providers.opencode_go.model" => {
+                self.providers.opencode_go.model = Some(value.to_string());
+            }
+            "providers.opencode_go.http_headers" => {
+                self.providers.opencode_go.http_headers = parse_http_headers(value)?;
+            }
             _ => {
                 self.extras
                     .insert(key.to_string(), toml::Value::String(value.to_string()));
@@ -654,6 +686,10 @@ impl ConfigToml {
             "providers.ollama.base_url" => self.providers.ollama.base_url = None,
             "providers.ollama.model" => self.providers.ollama.model = None,
             "providers.ollama.http_headers" => self.providers.ollama.http_headers.clear(),
+            "providers.opencode_go.api_key" => self.providers.opencode_go.api_key = None,
+            "providers.opencode_go.base_url" => self.providers.opencode_go.base_url = None,
+            "providers.opencode_go.model" => self.providers.opencode_go.model = None,
+            "providers.opencode_go.http_headers" => self.providers.opencode_go.http_headers.clear(),
             _ => {
                 self.extras.remove(key);
             }
@@ -813,6 +849,21 @@ impl ConfigToml {
         if let Some(v) = serialize_http_headers(&self.providers.ollama.http_headers) {
             out.insert("providers.ollama.http_headers".to_string(), v);
         }
+        if let Some(v) = self.providers.opencode_go.api_key.as_ref() {
+            out.insert(
+                "providers.opencode_go.api_key".to_string(),
+                redact_secret(v),
+            );
+        }
+        if let Some(v) = self.providers.opencode_go.base_url.as_ref() {
+            out.insert("providers.opencode_go.base_url".to_string(), v.clone());
+        }
+        if let Some(v) = self.providers.opencode_go.model.as_ref() {
+            out.insert("providers.opencode_go.model".to_string(), v.clone());
+        }
+        if let Some(v) = serialize_http_headers(&self.providers.opencode_go.http_headers) {
+            out.insert("providers.opencode_go.http_headers".to_string(), v);
+        }
 
         for (k, v) in &self.extras {
             out.insert(k.clone(), v.to_string());
@@ -891,6 +942,7 @@ impl ConfigToml {
                 ProviderKind::Sglang => DEFAULT_SGLANG_BASE_URL.to_string(),
                 ProviderKind::Vllm => DEFAULT_VLLM_BASE_URL.to_string(),
                 ProviderKind::Ollama => DEFAULT_OLLAMA_BASE_URL.to_string(),
+                ProviderKind::OpencodeGo => DEFAULT_OPENCODE_GO_BASE_URL.to_string(),
             });
 
         let explicit_model = cli.model.is_some()
@@ -1044,6 +1096,14 @@ fn normalize_model_for_provider(provider: ProviderKind, model: &str) -> String {
             "deepseek-v4-flash" | "deepseek-v4flash" | "deepseek-chat" | "deepseek-reasoner"
             | "deepseek-r1" | "deepseek-v3" | "deepseek-v3.2",
         ) => DEFAULT_VLLM_FLASH_MODEL.to_string(),
+        (ProviderKind::OpencodeGo, "deepseek-v4-pro" | "deepseek-v4pro") => {
+            DEFAULT_OPENCODE_GO_MODEL.to_string()
+        }
+        (
+            ProviderKind::OpencodeGo,
+            "deepseek-v4-flash" | "deepseek-v4flash" | "deepseek-chat" | "deepseek-reasoner"
+            | "deepseek-r1" | "deepseek-v3" | "deepseek-v3.2",
+        ) => DEFAULT_OPENCODE_GO_FLASH_MODEL.to_string(),
         _ => model.to_string(),
     }
 }
@@ -1059,6 +1119,7 @@ fn default_model_for_provider(provider: ProviderKind) -> &'static str {
         ProviderKind::Sglang => DEFAULT_SGLANG_MODEL,
         ProviderKind::Vllm => DEFAULT_VLLM_MODEL,
         ProviderKind::Ollama => DEFAULT_OLLAMA_MODEL,
+        ProviderKind::OpencodeGo => DEFAULT_OPENCODE_GO_MODEL,
     }
 }
 
@@ -1073,6 +1134,7 @@ fn default_base_url_for_provider(provider: ProviderKind) -> &'static str {
         ProviderKind::Sglang => DEFAULT_SGLANG_BASE_URL,
         ProviderKind::Vllm => DEFAULT_VLLM_BASE_URL,
         ProviderKind::Ollama => DEFAULT_OLLAMA_BASE_URL,
+        ProviderKind::OpencodeGo => DEFAULT_OPENCODE_GO_BASE_URL,
     }
 }
 
@@ -1327,6 +1389,7 @@ struct EnvRuntimeOverrides {
     sglang_base_url: Option<String>,
     vllm_base_url: Option<String>,
     ollama_base_url: Option<String>,
+    opencode_go_base_url: Option<String>,
 }
 
 impl EnvRuntimeOverrides {
@@ -1377,6 +1440,9 @@ impl EnvRuntimeOverrides {
             ollama_base_url: std::env::var("OLLAMA_BASE_URL")
                 .ok()
                 .filter(|v| !v.trim().is_empty()),
+            opencode_go_base_url: std::env::var("OPENCODE_GO_BASE_URL")
+                .ok()
+                .filter(|v| !v.trim().is_empty()),
         }
     }
 
@@ -1393,6 +1459,7 @@ impl EnvRuntimeOverrides {
             ProviderKind::Sglang => self.sglang_base_url.clone(),
             ProviderKind::Vllm => self.vllm_base_url.clone(),
             ProviderKind::Ollama => self.ollama_base_url.clone(),
+            ProviderKind::OpencodeGo => self.opencode_go_base_url.clone(),
         }
     }
 }
@@ -2120,6 +2187,49 @@ mod tests {
 
         assert_eq!(resolved.provider, ProviderKind::Vllm);
         assert_eq!(resolved.model, DEFAULT_VLLM_FLASH_MODEL);
+    }
+
+    #[test]
+    fn opencode_go_provider_normalizes_pro_aliases() {
+        let _lock = env_lock();
+        let _env = EnvGuard::without_deepseek_runtime_overrides();
+        for alias in ["deepseek-v4-pro", "deepseek-v4pro"] {
+            let cli = CliRuntimeOverrides {
+                provider: Some(ProviderKind::OpencodeGo),
+                model: Some(alias.to_string()),
+                ..CliRuntimeOverrides::default()
+            };
+            let resolved = ConfigToml::default().resolve_runtime_options(&cli);
+            assert_eq!(resolved.provider, ProviderKind::OpencodeGo);
+            assert_eq!(
+                resolved.model, "deepseek-v4-pro",
+                "alias '{alias}' should normalise to deepseek-v4-pro"
+            );
+        }
+    }
+
+    #[test]
+    fn opencode_go_provider_normalizes_flash_aliases() {
+        let _lock = env_lock();
+        let _env = EnvGuard::without_deepseek_runtime_overrides();
+        for alias in [
+            "deepseek-v4-flash",
+            "deepseek-v4flash",
+            "deepseek-chat",
+            "deepseek-reasoner",
+        ] {
+            let cli = CliRuntimeOverrides {
+                provider: Some(ProviderKind::OpencodeGo),
+                model: Some(alias.to_string()),
+                ..CliRuntimeOverrides::default()
+            };
+            let resolved = ConfigToml::default().resolve_runtime_options(&cli);
+            assert_eq!(resolved.provider, ProviderKind::OpencodeGo);
+            assert_eq!(
+                resolved.model, "deepseek-v4-flash",
+                "alias '{alias}' should normalise to deepseek-v4-flash"
+            );
+        }
     }
 
     #[test]

--- a/crates/secrets/src/lib.rs
+++ b/crates/secrets/src/lib.rs
@@ -474,6 +474,7 @@ pub fn env_for(name: &str) -> Option<String> {
         "vllm" | "v-llm" => &["VLLM_API_KEY"],
         "ollama" | "ollama-local" => &["OLLAMA_API_KEY"],
         "openai" => &["OPENAI_API_KEY"],
+        "opencode-go" | "opencode_go" | "opencodego" | "go" => &["OPENCODE_GO_API_KEY"],
         _ => return None,
     };
     for var in candidates {
@@ -512,6 +513,7 @@ mod tests {
             "VLLM_API_KEY",
             "OLLAMA_API_KEY",
             "OPENAI_API_KEY",
+            "OPENCODE_GO_API_KEY",
         ] {
             // Safety: tests serialise on env_lock(); the broader
             // workspace has the same pattern in `crates/config`.
@@ -809,5 +811,26 @@ mod tests {
             "unexpected default path: {}",
             path.display()
         );
+    }
+
+    #[test]
+    fn env_for_opencode_go_reads_opencode_go_api_key() {
+        let _guard = env_lock();
+        clear_known_envs();
+        // Safety: tests serialise on env_lock().
+        unsafe { std::env::set_var("OPENCODE_GO_API_KEY", "sk-opencode-go-test") };
+        assert_eq!(
+            env_for("opencode-go"),
+            Some("sk-opencode-go-test".to_string())
+        );
+        assert_eq!(
+            env_for("opencode_go"),
+            Some("sk-opencode-go-test".to_string())
+        );
+        assert_eq!(
+            env_for("opencodego"),
+            Some("sk-opencode-go-test".to_string())
+        );
+        assert_eq!(env_for("go"), Some("sk-opencode-go-test".to_string()));
     }
 }

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -821,13 +821,15 @@ pub(super) fn apply_reasoning_effort(
     let normalized = effort.trim().to_ascii_lowercase();
     match normalized.as_str() {
         "off" | "disabled" | "none" | "false" => match provider {
+            // OpenCode Go is a DeepSeek API proxy — same thinking/reasoning_effort payload.
             ApiProvider::Deepseek
             | ApiProvider::DeepseekCN
             | ApiProvider::Openrouter
             | ApiProvider::Novita
             | ApiProvider::Fireworks
             | ApiProvider::Sglang
-            | ApiProvider::Vllm => {
+            | ApiProvider::Vllm
+            | ApiProvider::OpencodeGo => {
                 body["thinking"] = json!({ "type": "disabled" });
             }
             ApiProvider::Openai | ApiProvider::Ollama => {}
@@ -844,7 +846,8 @@ pub(super) fn apply_reasoning_effort(
             | ApiProvider::Novita
             | ApiProvider::Fireworks
             | ApiProvider::Sglang
-            | ApiProvider::Vllm => {
+            | ApiProvider::Vllm
+            | ApiProvider::OpencodeGo => {
                 body["reasoning_effort"] = json!("high");
                 body["thinking"] = json!({ "type": "enabled" });
             }
@@ -863,7 +866,8 @@ pub(super) fn apply_reasoning_effort(
             | ApiProvider::Novita
             | ApiProvider::Fireworks
             | ApiProvider::Sglang
-            | ApiProvider::Vllm => {
+            | ApiProvider::Vllm
+            | ApiProvider::OpencodeGo => {
                 body["reasoning_effort"] = json!("max");
                 body["thinking"] = json!({ "type": "enabled" });
             }

--- a/crates/tui/src/commands/provider.rs
+++ b/crates/tui/src/commands/provider.rs
@@ -27,7 +27,7 @@ pub fn provider(app: &mut App, args: Option<&str>) -> CommandResult {
 
     let Some(target) = ApiProvider::parse(name) else {
         return CommandResult::error(format!(
-            "Unknown provider '{name}'. Expected: deepseek, nvidia-nim, openrouter, novita, fireworks, sglang, vllm, or ollama."
+            "Unknown provider '{name}'. Expected: deepseek, nvidia-nim, openrouter, novita, fireworks, sglang, vllm, ollama, or opencode-go."
         ));
     };
 

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -49,6 +49,9 @@ pub const DEFAULT_OLLAMA_BASE_URL: &str = "http://localhost:11434/v1";
 /// Legacy typo hostname `api.deepseeki.com` remains recognized in URL
 /// heuristics for backward compatibility.
 pub const DEFAULT_DEEPSEEKCN_BASE_URL: &str = DEFAULT_DEEPSEEK_BASE_URL;
+pub const DEFAULT_OPENCODE_GO_MODEL: &str = "deepseek-v4-pro";
+pub const DEFAULT_OPENCODE_GO_FLASH_MODEL: &str = "deepseek-v4-flash";
+pub const DEFAULT_OPENCODE_GO_BASE_URL: &str = "https://opencode.ai/zen/go/v1";
 const API_KEYRING_SENTINEL: &str = "__KEYRING__";
 pub const COMMON_DEEPSEEK_MODELS: &[&str] = &[
     "deepseek-v4-pro",
@@ -72,6 +75,7 @@ pub enum ApiProvider {
     Sglang,
     Vllm,
     Ollama,
+    OpencodeGo,
 }
 
 impl ApiProvider {
@@ -90,6 +94,7 @@ impl ApiProvider {
             "sglang" | "sg-lang" => Some(Self::Sglang),
             "vllm" | "v-llm" => Some(Self::Vllm),
             "ollama" | "ollama-local" => Some(Self::Ollama),
+            "opencode-go" | "opencode_go" | "opencodego" | "go" => Some(Self::OpencodeGo),
             _ => None,
         }
     }
@@ -107,6 +112,7 @@ impl ApiProvider {
             Self::Sglang => "sglang",
             Self::Vllm => "vllm",
             Self::Ollama => "ollama",
+            Self::OpencodeGo => "opencode-go",
         }
     }
 
@@ -124,6 +130,7 @@ impl ApiProvider {
             Self::Sglang => "SGLang",
             Self::Vllm => "vLLM",
             Self::Ollama => "Ollama",
+            Self::OpencodeGo => "OpenCode Go",
         }
     }
 
@@ -140,6 +147,7 @@ impl ApiProvider {
             Self::Sglang,
             Self::Vllm,
             Self::Ollama,
+            Self::OpencodeGo,
         ]
     }
 }
@@ -269,6 +277,10 @@ pub fn provider_capability(provider: ApiProvider, resolved_model: &str) -> Provi
         provider,
         ApiProvider::Deepseek | ApiProvider::DeepseekCN | ApiProvider::NvidiaNim
     );
+
+    // OpenCode Go supports thinking for DeepSeek V4 models.
+    let thinking_supported = thinking_supported
+        || (matches!(provider, ApiProvider::OpencodeGo) && (is_v4_pro || is_v4_flash));
 
     // Request payload mode: all current providers use chat completions.
     let request_payload_mode = RequestPayloadMode::ChatCompletions;
@@ -1040,6 +1052,8 @@ pub struct ProvidersConfig {
     pub vllm: ProviderConfig,
     #[serde(default)]
     pub ollama: ProviderConfig,
+    #[serde(default)]
+    pub opencode_go: ProviderConfig,
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
@@ -1099,7 +1113,7 @@ impl Config {
             && ApiProvider::parse(provider).is_none()
         {
             anyhow::bail!(
-                "Invalid provider '{provider}': expected deepseek, deepseek-cn, nvidia-nim, openai, openrouter, novita, fireworks, sglang, vllm, or ollama."
+                "Invalid provider '{provider}': expected deepseek, deepseek-cn, nvidia-nim, openai, openrouter, novita, fireworks, sglang, vllm, ollama, or opencode-go."
             );
         }
         if let Some(ref key) = self.api_key
@@ -1222,6 +1236,7 @@ impl Config {
             ApiProvider::Sglang => &providers.sglang,
             ApiProvider::Vllm => &providers.vllm,
             ApiProvider::Ollama => &providers.ollama,
+            ApiProvider::OpencodeGo => &providers.opencode_go,
         })
     }
 
@@ -1285,6 +1300,7 @@ impl Config {
             ApiProvider::Sglang => DEFAULT_SGLANG_MODEL,
             ApiProvider::Vllm => DEFAULT_VLLM_MODEL,
             ApiProvider::Ollama => DEFAULT_OLLAMA_MODEL,
+            ApiProvider::OpencodeGo => DEFAULT_OPENCODE_GO_MODEL,
         }
         .to_string()
     }
@@ -1313,7 +1329,8 @@ impl Config {
             | ApiProvider::Fireworks
             | ApiProvider::Sglang
             | ApiProvider::Vllm
-            | ApiProvider::Ollama => None,
+            | ApiProvider::Ollama
+            | ApiProvider::OpencodeGo => None,
         };
         let base = provider_base.or(root_base).unwrap_or_else(|| {
             match provider {
@@ -1327,6 +1344,7 @@ impl Config {
                 ApiProvider::Sglang => DEFAULT_SGLANG_BASE_URL,
                 ApiProvider::Vllm => DEFAULT_VLLM_BASE_URL,
                 ApiProvider::Ollama => DEFAULT_OLLAMA_BASE_URL,
+                ApiProvider::OpencodeGo => DEFAULT_OPENCODE_GO_BASE_URL,
             }
             .to_string()
         });
@@ -1358,6 +1376,7 @@ impl Config {
             ApiProvider::Sglang => "sglang",
             ApiProvider::Vllm => "vllm",
             ApiProvider::Ollama => "ollama",
+            ApiProvider::OpencodeGo => "opencode-go",
         };
 
         // 0. DeepSeek compatibility slot. The legacy top-level `api_key`
@@ -1427,6 +1446,10 @@ impl Config {
             // Self-hosted deployments commonly run without auth on localhost.
             // Return an empty key and let the client omit the Authorization header.
             ApiProvider::Sglang | ApiProvider::Vllm | ApiProvider::Ollama => Ok(String::new()),
+            ApiProvider::OpencodeGo => anyhow::bail!(
+                "OpenCode Go API key not found. Run 'deepseek auth set --provider opencode-go', \
+                 set OPENCODE_GO_API_KEY, or add [providers.opencode_go] api_key in ~/.deepseek/config.toml."
+            ),
         }
     }
 
@@ -2000,6 +2023,7 @@ fn apply_env_overrides(config: &mut Config) {
             ApiProvider::Sglang => &mut providers.sglang,
             ApiProvider::Vllm => &mut providers.vllm,
             ApiProvider::Ollama => &mut providers.ollama,
+            ApiProvider::OpencodeGo => &mut providers.opencode_go,
         };
         let mut provider_headers = entry.http_headers.clone().unwrap_or_default();
         provider_headers.extend(headers);
@@ -2015,6 +2039,16 @@ fn apply_env_overrides(config: &mut Config) {
             .ollama
             .base_url = Some(value);
     }
+    if matches!(config.api_provider(), ApiProvider::OpencodeGo)
+        && let Ok(value) = std::env::var("OPENCODE_GO_BASE_URL")
+        && !value.trim().is_empty()
+    {
+        config
+            .providers
+            .get_or_insert_with(ProvidersConfig::default)
+            .opencode_go
+            .base_url = Some(value);
+    }
     if matches!(config.api_provider(), ApiProvider::Sglang)
         && let Ok(value) = std::env::var("SGLANG_MODEL")
     {
@@ -2027,6 +2061,11 @@ fn apply_env_overrides(config: &mut Config) {
     }
     if matches!(config.api_provider(), ApiProvider::Ollama)
         && let Ok(value) = std::env::var("OLLAMA_MODEL")
+    {
+        config.default_text_model = Some(value);
+    }
+    if matches!(config.api_provider(), ApiProvider::OpencodeGo)
+        && let Ok(value) = std::env::var("OPENCODE_GO_MODEL")
     {
         config.default_text_model = Some(value);
     }
@@ -2269,6 +2308,11 @@ fn normalize_model_config(config: &mut Config) {
         {
             providers.vllm.model = Some(normalized);
         }
+        if let Some(model) = providers.opencode_go.model.as_deref()
+            && let Some(normalized) = normalize_model_for_provider(ApiProvider::OpencodeGo, model)
+        {
+            providers.opencode_go.model = Some(normalized);
+        }
     }
 }
 
@@ -2302,6 +2346,7 @@ fn default_base_url_for_provider(provider: ApiProvider) -> &'static str {
         ApiProvider::Sglang => DEFAULT_SGLANG_BASE_URL,
         ApiProvider::Vllm => DEFAULT_VLLM_BASE_URL,
         ApiProvider::Ollama => DEFAULT_OLLAMA_BASE_URL,
+        ApiProvider::OpencodeGo => DEFAULT_OPENCODE_GO_BASE_URL,
     }
 }
 
@@ -2334,6 +2379,11 @@ fn model_for_provider(provider: ApiProvider, normalized: String) -> String {
         (ApiProvider::Sglang, "deepseek-v4-flash") => DEFAULT_SGLANG_FLASH_MODEL.to_string(),
         (ApiProvider::Vllm, "deepseek-v4-pro") => DEFAULT_VLLM_MODEL.to_string(),
         (ApiProvider::Vllm, "deepseek-v4-flash") => DEFAULT_VLLM_FLASH_MODEL.to_string(),
+        (
+            ApiProvider::OpencodeGo,
+            "deepseek-v4-flash" | "deepseek-chat" | "deepseek-reasoner" | "deepseek-r1"
+            | "deepseek-v3" | "deepseek-v3.2",
+        ) => DEFAULT_OPENCODE_GO_FLASH_MODEL.to_string(),
         _ => normalized,
     }
 }
@@ -2502,6 +2552,7 @@ fn merge_providers(
             sglang: merge_provider_config(base.sglang, override_cfg.sglang),
             vllm: merge_provider_config(base.vllm, override_cfg.vllm),
             ollama: merge_provider_config(base.ollama, override_cfg.ollama),
+            opencode_go: merge_provider_config(base.opencode_go, override_cfg.opencode_go),
         }),
     }
 }
@@ -2923,6 +2974,9 @@ pub fn active_provider_has_env_api_key(config: &Config) -> bool {
         ApiProvider::Sglang => std::env::var("SGLANG_API_KEY").is_ok_and(|k| !k.trim().is_empty()),
         ApiProvider::Vllm => std::env::var("VLLM_API_KEY").is_ok_and(|k| !k.trim().is_empty()),
         ApiProvider::Ollama => std::env::var("OLLAMA_API_KEY").is_ok_and(|k| !k.trim().is_empty()),
+        ApiProvider::OpencodeGo => {
+            std::env::var("OPENCODE_GO_API_KEY").is_ok_and(|k| !k.trim().is_empty())
+        }
     }
 }
 
@@ -2946,6 +3000,7 @@ pub fn has_api_key_for(config: &Config, provider: ApiProvider) -> bool {
         ApiProvider::Sglang => "SGLANG_API_KEY",
         ApiProvider::Vllm => "VLLM_API_KEY",
         ApiProvider::Ollama => "OLLAMA_API_KEY",
+        ApiProvider::OpencodeGo => "OPENCODE_GO_API_KEY",
     };
     if std::env::var(env_var).is_ok_and(|k| !k.trim().is_empty()) {
         return true;
@@ -3014,6 +3069,7 @@ pub fn save_api_key_for(provider: ApiProvider, api_key: &str) -> Result<PathBuf>
         ApiProvider::Sglang => "providers.sglang",
         ApiProvider::Vllm => "providers.vllm",
         ApiProvider::Ollama => "providers.ollama",
+        ApiProvider::OpencodeGo => "providers.opencode_go",
     };
 
     // Parse existing TOML (or start fresh) so we can edit the right table
@@ -3048,6 +3104,7 @@ pub fn save_api_key_for(provider: ApiProvider, api_key: &str) -> Result<PathBuf>
         ApiProvider::Sglang => "sglang",
         ApiProvider::Vllm => "vllm",
         ApiProvider::Ollama => "ollama",
+        ApiProvider::OpencodeGo => "opencode_go",
     };
     let entry = providers
         .entry(key_inside.to_string())
@@ -3190,6 +3247,9 @@ mod tests {
         ollama_api_key: Option<OsString>,
         ollama_base_url: Option<OsString>,
         ollama_model: Option<OsString>,
+        opencode_go_api_key: Option<OsString>,
+        opencode_go_base_url: Option<OsString>,
+        opencode_go_model: Option<OsString>,
     }
 
     impl EnvGuard {
@@ -3230,6 +3290,9 @@ mod tests {
             let ollama_api_key_prev = env::var_os("OLLAMA_API_KEY");
             let ollama_base_url_prev = env::var_os("OLLAMA_BASE_URL");
             let ollama_model_prev = env::var_os("OLLAMA_MODEL");
+            let opencode_go_api_key_prev = env::var_os("OPENCODE_GO_API_KEY");
+            let opencode_go_base_url_prev = env::var_os("OPENCODE_GO_BASE_URL");
+            let opencode_go_model_prev = env::var_os("OPENCODE_GO_MODEL");
             // Safety: test-only environment mutation guarded by a global mutex.
             unsafe {
                 env::set_var("HOME", &home_str);
@@ -3265,6 +3328,9 @@ mod tests {
                 env::remove_var("OLLAMA_API_KEY");
                 env::remove_var("OLLAMA_BASE_URL");
                 env::remove_var("OLLAMA_MODEL");
+                env::remove_var("OPENCODE_GO_API_KEY");
+                env::remove_var("OPENCODE_GO_BASE_URL");
+                env::remove_var("OPENCODE_GO_MODEL");
             }
             Self {
                 home: home_prev,
@@ -3300,6 +3366,9 @@ mod tests {
                 ollama_api_key: ollama_api_key_prev,
                 ollama_base_url: ollama_base_url_prev,
                 ollama_model: ollama_model_prev,
+                opencode_go_api_key: opencode_go_api_key_prev,
+                opencode_go_base_url: opencode_go_base_url_prev,
+                opencode_go_model: opencode_go_model_prev,
             }
         }
     }
@@ -3344,6 +3413,9 @@ mod tests {
                 Self::restore_var("OLLAMA_API_KEY", self.ollama_api_key.take());
                 Self::restore_var("OLLAMA_BASE_URL", self.ollama_base_url.take());
                 Self::restore_var("OLLAMA_MODEL", self.ollama_model.take());
+                Self::restore_var("OPENCODE_GO_API_KEY", self.opencode_go_api_key.take());
+                Self::restore_var("OPENCODE_GO_BASE_URL", self.opencode_go_base_url.take());
+                Self::restore_var("OPENCODE_GO_MODEL", self.opencode_go_model.take());
             }
         }
     }
@@ -5381,5 +5453,110 @@ model = "deepseek-ai/deepseek-v4-pro"
         let json = serde_json::to_value(&cap).unwrap();
         let deserialized: ProviderCapability = serde_json::from_value(json).unwrap();
         assert_eq!(cap, deserialized);
+    }
+
+    #[test]
+    fn provider_capability_opencode_go_v4_pro_has_thinking_no_cache() {
+        let cap = provider_capability(ApiProvider::OpencodeGo, "deepseek-v4-pro");
+        assert_eq!(
+            cap.context_window,
+            crate::models::DEEPSEEK_V4_CONTEXT_WINDOW_TOKENS
+        );
+        assert_eq!(cap.max_output, 384_000);
+        assert!(cap.thinking_supported);
+        assert!(!cap.cache_telemetry_supported);
+        assert_eq!(
+            cap.request_payload_mode,
+            RequestPayloadMode::ChatCompletions
+        );
+    }
+
+    #[test]
+    fn api_provider_parse_opencode_go_aliases() {
+        assert_eq!(
+            ApiProvider::parse("opencode-go"),
+            Some(ApiProvider::OpencodeGo)
+        );
+        assert_eq!(
+            ApiProvider::parse("opencode_go"),
+            Some(ApiProvider::OpencodeGo)
+        );
+        assert_eq!(
+            ApiProvider::parse("opencodego"),
+            Some(ApiProvider::OpencodeGo)
+        );
+        assert_eq!(ApiProvider::parse("go"), Some(ApiProvider::OpencodeGo));
+        assert_eq!(
+            ApiProvider::parse("OPENCODE-GO"),
+            Some(ApiProvider::OpencodeGo)
+        );
+    }
+
+    #[test]
+    fn api_provider_opencode_go_as_str_and_display_name() {
+        assert_eq!(ApiProvider::OpencodeGo.as_str(), "opencode-go");
+        assert_eq!(ApiProvider::OpencodeGo.display_name(), "OpenCode Go");
+    }
+
+    #[test]
+    fn default_model_for_opencode_go() {
+        let config = Config {
+            provider: Some("opencode-go".to_string()),
+            ..Config::default()
+        };
+        assert_eq!(config.default_model(), "deepseek-v4-pro");
+    }
+
+    #[test]
+    fn deepseek_base_url_for_opencode_go() {
+        let config = Config {
+            provider: Some("opencode-go".to_string()),
+            ..Config::default()
+        };
+        assert_eq!(config.deepseek_base_url(), DEFAULT_OPENCODE_GO_BASE_URL);
+    }
+
+    #[test]
+    fn model_for_provider_opencode_go_passes_through() {
+        assert_eq!(
+            model_for_provider(ApiProvider::OpencodeGo, "deepseek-v4-pro".to_string()),
+            "deepseek-v4-pro"
+        );
+        assert_eq!(
+            model_for_provider(ApiProvider::OpencodeGo, "deepseek-v4-flash".to_string()),
+            "deepseek-v4-flash"
+        );
+    }
+
+    #[test]
+    fn opencode_go_env_overrides_base_url_and_model() -> Result<()> {
+        let _lock = lock_test_env();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let temp_root = env::temp_dir().join(format!(
+            "deepseek-tui-opencode-go-env-test-{}-{}",
+            std::process::id(),
+            nanos
+        ));
+        fs::create_dir_all(&temp_root)?;
+        let _guard = EnvGuard::new(&temp_root);
+
+        // Safety: test-only environment mutation guarded by a global mutex.
+        unsafe {
+            env::set_var("DEEPSEEK_PROVIDER", "opencode-go");
+            env::set_var("OPENCODE_GO_BASE_URL", "https://custom.opencode.example/v1");
+            env::set_var("OPENCODE_GO_MODEL", "deepseek-v4-flash");
+        }
+
+        let config = Config::load(None, None)?;
+        assert_eq!(config.api_provider(), ApiProvider::OpencodeGo);
+        assert_eq!(
+            config.deepseek_base_url(),
+            "https://custom.opencode.example/v1"
+        );
+        assert_eq!(config.default_model(), "deepseek-v4-flash");
+        Ok(())
     }
 }

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -377,6 +377,7 @@ impl Engine {
             ApiProvider::Sglang => "SGLANG_API_KEY",
             ApiProvider::Vllm => "VLLM_API_KEY",
             ApiProvider::Ollama => "OLLAMA_API_KEY",
+            ApiProvider::OpencodeGo => "OPENCODE_GO_API_KEY",
         };
 
         Some(format!(

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -1379,6 +1379,10 @@ fn run_setup_status(config: &Config, workspace: &Path) -> Result<()> {
                 crate::config::ApiProvider::Ollama => {
                     ("OLLAMA_API_KEY", "deepseek auth set --provider ollama")
                 }
+                crate::config::ApiProvider::OpencodeGo => (
+                    "OPENCODE_GO_API_KEY",
+                    "deepseek auth set --provider opencode-go --api-key \"...\"",
+                ),
                 crate::config::ApiProvider::Deepseek | crate::config::ApiProvider::DeepseekCN => {
                     ("DEEPSEEK_API_KEY", "deepseek auth set --provider deepseek")
                 }
@@ -1395,6 +1399,7 @@ fn run_setup_status(config: &Config, workspace: &Path) -> Result<()> {
                     crate::config::ApiProvider::Sglang => "sglang",
                     crate::config::ApiProvider::Vllm => "vllm",
                     crate::config::ApiProvider::Ollama => "ollama",
+                    crate::config::ApiProvider::OpencodeGo => "opencode_go",
                     crate::config::ApiProvider::Deepseek
                     | crate::config::ApiProvider::DeepseekCN => "deepseek",
                 }

--- a/crates/tui/src/tui/provider_picker.rs
+++ b/crates/tui/src/tui/provider_picker.rs
@@ -95,6 +95,7 @@ impl ProviderPickerView {
             ApiProvider::Sglang => "SGLANG_API_KEY",
             ApiProvider::Vllm => "VLLM_API_KEY",
             ApiProvider::Ollama => "OLLAMA_API_KEY",
+            ApiProvider::OpencodeGo => "OPENCODE_GO_API_KEY",
         }
     }
 
@@ -398,7 +399,8 @@ mod tests {
                 "Fireworks AI",
                 "SGLang",
                 "vLLM",
-                "Ollama"
+                "Ollama",
+                "OpenCode Go"
             ]
         );
     }

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -5359,6 +5359,7 @@ fn render(f: &mut Frame, app: &mut App) {
             crate::config::ApiProvider::Sglang => Some("SGLang"),
             crate::config::ApiProvider::Vllm => Some("vLLM"),
             crate::config::ApiProvider::Ollama => Some("Ollama"),
+            crate::config::ApiProvider::OpencodeGo => Some("OpenCode Go"),
         };
         let header_data = HeaderData::new(
             app.mode,
@@ -6010,6 +6011,7 @@ async fn apply_provider_picker_api_key(
             ApiProvider::Sglang => &mut providers.sglang,
             ApiProvider::Vllm => &mut providers.vllm,
             ApiProvider::Ollama => &mut providers.ollama,
+            ApiProvider::OpencodeGo => &mut providers.opencode_go,
         };
         entry.api_key = Some(api_key);
     }


### PR DESCRIPTION
Users on [OpenCode Go](https://opencode.ai/go)'s $10/month flat plan have been unable to use it without manually overriding `base_url` and losing model alias normalisation, key management, and the provider picker. This adds OpenCode Go as a first-class provider so those users get the same `/provider opencode-go` workflow as every other supported provider — no config hacks needed.

No related issue. OpenCode Go uses the same DeepSeek V4 API, so `thinking`/`reasoning_effort` forwarding works without extra effort.

## Known gap

`pricing.rs` matches on model name without provider context, so OpenCode Go's cache-read pricing (slightly different from DeepSeek Platform) isn't reflected in cost estimates. The same limitation applies to OpenRouter, Novita, and Fireworks — not introduced here.

## Test plan

- `cargo fmt` / `cargo clippy` — clean, no new warnings
- `cargo test` — all tests pass
