### PR TITLE
feat(i18n): add Traditional Chinese (zh-Hant) locale support

### DIFF
--- a/crates/tui/src/commands/config.rs
+++ b/crates/tui/src/commands/config.rs
@@ -75,6 +75,7 @@ fn show_single_setting(app: &App, key: &str) -> CommandResult {
         match l {
             crate::localization::Locale::En => "en",
             crate::localization::Locale::ZhHans => "zh-Hans",
+            crate::localization::Locale::ZhHant => "zh-Hant",
             crate::localization::Locale::Ja => "ja",
             crate::localization::Locale::PtBr => "pt-BR",
         }

--- a/crates/tui/src/commands/core.rs
+++ b/crates/tui/src/commands/core.rs
@@ -294,6 +294,7 @@ pub fn home_dashboard(app: &mut App) -> CommandResult {
 mod tests {
     use super::*;
     use crate::config::Config;
+    use crate::localization::Locale;
     use crate::models::Message;
     use crate::tui::app::{App, AppMode, TuiOptions};
     use crate::tui::history::HistoryCell;
@@ -321,7 +322,9 @@ mod tests {
             resume_session_id: None,
             initial_input: None,
         };
-        App::new(options, &Config::default())
+        let mut app = App::new(options, &Config::default());
+        app.ui_locale = Locale::En;
+        app
     }
 
     #[test]

--- a/crates/tui/src/commands/debug.rs
+++ b/crates/tui/src/commands/debug.rs
@@ -291,7 +291,9 @@ mod tests {
             resume_session_id: None,
             initial_input: None,
         };
-        App::new(options, &Config::default())
+        let mut app = App::new(options, &Config::default());
+        app.ui_locale = Locale::En;
+        app
     }
 
     #[test]

--- a/crates/tui/src/config_ui.rs
+++ b/crates/tui/src/config_ui.rs
@@ -152,6 +152,9 @@ pub enum UiLocale {
     #[serde(rename = "zh-Hans")]
     #[schemars(rename = "zh-Hans")]
     ZhHans,
+    #[serde(rename = "zh-Hant")]
+    #[schemars(rename = "zh-Hant")]
+    ZhHant,
     #[serde(rename = "pt-BR")]
     #[schemars(rename = "pt-BR")]
     PtBr,
@@ -617,6 +620,7 @@ impl UiLocale {
             Self::En => "en",
             Self::Ja => "ja",
             Self::ZhHans => "zh-Hans",
+            Self::ZhHant => "zh-Hant",
             Self::PtBr => "pt-BR",
         }
     }
@@ -627,6 +631,7 @@ impl UiLocale {
             Some("en") => Ok(Self::En),
             Some("ja") => Ok(Self::Ja),
             Some("zh-Hans") => Ok(Self::ZhHans),
+            Some("zh-Hant") => Ok(Self::ZhHant),
             Some("pt-BR") => Ok(Self::PtBr),
             Some(other) => bail!("unsupported locale '{other}'"),
             None => bail!("invalid locale '{value}'"),
@@ -870,7 +875,7 @@ mod tests {
         let locale = &schema["$defs"]["UiLocale"]["enum"];
         assert_eq!(
             locale,
-            &serde_json::json!(["auto", "en", "ja", "zh-Hans", "pt-BR"])
+            &serde_json::json!(["auto", "en", "ja", "zh-Hans", "zh-Hant", "pt-BR"])
         );
     }
 

--- a/crates/tui/src/localization.rs
+++ b/crates/tui/src/localization.rs
@@ -1568,7 +1568,7 @@ fn chinese_traditional(id: MessageId) -> Option<&'static str> {
         MessageId::CmdUndoDescription => "移除最後一組訊息對",
         MessageId::CmdYoloDescription => "啟用 YOLO 模式（shell + 信任 + 自動核准）",
         MessageId::CmdCacheAdvice => {
-            "第 3 輪起命中率穩定在 ~70% 以上即表示前綴快取穩定；
+            "第 3 輪起命中率穩定在 ~70% 以上即表示前綴快取穩定；\n\
              長工作階段中明顯偏低則意味著前綴有抖動，值得排查（#263）。"
         }
         MessageId::CmdCacheFootnote => "* 當提供方未單獨回報未命中時，由「輸入 − 命中」推算。\n",

--- a/crates/tui/src/localization.rs
+++ b/crates/tui/src/localization.rs
@@ -36,6 +36,7 @@ pub enum Locale {
     En,
     Ja,
     ZhHans,
+    ZhHant,
     PtBr,
 }
 
@@ -45,6 +46,7 @@ impl Locale {
             Self::En => "en",
             Self::Ja => "ja",
             Self::ZhHans => "zh-Hans",
+            Self::ZhHant => "zh-Hant",
             Self::PtBr => "pt-BR",
         }
     }
@@ -76,6 +78,14 @@ impl Locale {
                 fallback: "en",
                 coverage: LocaleCoverage::V076Core,
             },
+            Self::ZhHant => LocaleSpec {
+                tag: "zh-Hant",
+                display_name: "Chinese Traditional",
+                script: "Hant",
+                direction: TextDirection::Ltr,
+                fallback: "en",
+                coverage: LocaleCoverage::V076Core,
+            },
             Self::PtBr => LocaleSpec {
                 tag: "pt-BR",
                 display_name: "Portuguese (Brazil)",
@@ -89,7 +99,7 @@ impl Locale {
 
     #[allow(dead_code)]
     pub fn shipped() -> &'static [Self] {
-        &[Self::En, Self::Ja, Self::ZhHans, Self::PtBr]
+        &[Self::En, Self::Ja, Self::ZhHans, Self::ZhHant, Self::PtBr]
     }
 }
 
@@ -660,7 +670,7 @@ fn parse_locale(value: &str) -> Option<Locale> {
             || value.contains("-hk")
             || value.contains("-mo")
         {
-            return None;
+            return Some(Locale::ZhHant);
         }
         return Some(Locale::ZhHans);
     }
@@ -948,6 +958,7 @@ fn translation(locale: Locale, id: MessageId) -> Option<&'static str> {
         Locale::En => Some(english(id)),
         Locale::Ja => japanese(id),
         Locale::ZhHans => chinese_simplified(id),
+        Locale::ZhHant => chinese_traditional(id),
         Locale::PtBr => portuguese_brazil(id),
     }
 }
@@ -1460,6 +1471,244 @@ fn chinese_simplified(id: MessageId) -> Option<&'static str> {
     })
 }
 
+fn chinese_traditional(id: MessageId) -> Option<&'static str> {
+    Some(match id {
+        MessageId::ComposerPlaceholder => "撰寫任務或使用 /。",
+        MessageId::HistorySearchPlaceholder => "搜尋提示歷史...",
+        MessageId::HistorySearchTitle => "歷史搜尋",
+        MessageId::HistoryHintMove => "Up/Down 移動",
+        MessageId::HistoryHintAccept => "Enter 接受",
+        MessageId::HistoryHintRestore => "Esc 還原",
+        MessageId::HistoryNoMatches => "  無符合項目",
+        MessageId::ConfigTitle => "工作階段設定",
+        MessageId::ConfigModalTitle => " 設定 ",
+        MessageId::ConfigSearchPlaceholder => "輸入以篩選",
+        MessageId::ConfigNoSettings => "  沒有可用設定。",
+        MessageId::ConfigNoMatchesPrefix => "  沒有符合的設定: ",
+        MessageId::ConfigFilteredSettings => "  已篩選設定",
+        MessageId::ConfigShowing => "  顯示",
+        MessageId::ConfigFooterDefault => " 輸入=篩選, Up/Down=選取, Enter/e=編輯, Esc/q=關閉 ",
+        MessageId::ConfigFooterScrollable => {
+            " 輸入=篩選, Up/Down=選取, Enter/e=編輯, PgUp/PgDn=捲動, Esc/q=關閉 "
+        }
+        MessageId::ConfigFooterFiltered => {
+            " 輸入=篩選, Backspace=刪除, Ctrl+U/Esc=清除, Enter=編輯 "
+        }
+        MessageId::HelpTitle => "說明",
+        MessageId::HelpFilterPlaceholder => "輸入以篩選",
+        MessageId::HelpFilterPrefix => "篩選: ",
+        MessageId::HelpNoMatches => "  無符合項目。",
+        MessageId::HelpSlashCommands => "斜線命令",
+        MessageId::HelpKeybindings => "快捷鍵",
+        MessageId::HelpFooterTypeFilter => " 輸入以篩選 ",
+        MessageId::HelpFooterMove => "  Up/Down 移動 ",
+        MessageId::HelpFooterJump => " PgUp/PgDn 跳轉 ",
+        MessageId::HelpFooterClose => " Esc 關閉 ",
+        MessageId::CmdAgentDescription => "切換到 Agent 模式",
+        MessageId::CmdAttachDescription => "附加圖片或影片媒體；文字檔或目錄請使用 @path",
+        MessageId::CmdCacheDescription => "顯示最近 N 輪的 DeepSeek 前綴快取命中/未命中統計",
+        MessageId::CmdClearDescription => "清除對話歷史",
+        MessageId::CmdCompactDescription => {
+            "觸發上下文壓縮以釋放空間（舊版命令；v0.6.6 起建議改用循環重啟）"
+        }
+        MessageId::CmdConfigDescription => "開啟互動式設定編輯器",
+        MessageId::CmdContextDescription => "開啟精簡工作階段上下文檢查器",
+        MessageId::CmdCostDescription => "顯示本次工作階段的費用明細",
+        MessageId::CmdCycleDescription => "顯示指定循環的延續簡報",
+        MessageId::CmdCyclesDescription => "列出本次工作階段中的檢查點重啟循環交接",
+        MessageId::CmdDiffDescription => "顯示工作階段開始以來的檔案變更",
+        MessageId::CmdEditDescription => "修改並重新提交最後一則訊息",
+        MessageId::CmdExitDescription => "結束應用程式",
+        MessageId::CmdExportDescription => "將對話匯出為 Markdown",
+        MessageId::CmdHelpDescription => "顯示說明資訊",
+        MessageId::CmdHomeDescription => "顯示首頁面板，包含統計與快捷操作",
+        MessageId::CmdHooksDescription => "列出已設定的生命週期 Hook（唯讀）",
+        MessageId::CmdGoalDescription => "設定帶有可選 Token 預算的工作階段目標",
+        MessageId::CmdInitDescription => "為專案產生 AGENTS.md",
+        MessageId::CmdLspDescription => "切換 LSP 診斷的開啟或關閉",
+        MessageId::CmdShareDescription => "將目前工作階段匯出為可分享的 Web URL",
+        MessageId::CmdJobsDescription => "查看並管理背景 shell 作業",
+        MessageId::CmdLinksDescription => "顯示 DeepSeek 控制台與文件連結",
+        MessageId::CmdLoadDescription => "從檔案載入工作階段",
+        MessageId::CmdLogoutDescription => "清除 API 金鑰並返回設定",
+        MessageId::CmdMcpDescription => "開啟或管理 MCP 伺服器",
+        MessageId::CmdMemoryDescription => "查看或管理持久使用者記憶檔案",
+        MessageId::CmdModelDescription => "切換或查看目前模型",
+        MessageId::CmdModelsDescription => "列出 API 中可用的模型",
+        MessageId::CmdNoteDescription => "將筆記追加到持久筆記檔案（.deepseek/notes.md）",
+        MessageId::CmdPlanDescription => "切換到 Plan 模式並查看建議的實作步驟",
+        MessageId::CmdProviderDescription => "切換或查看目前 LLM 後端（deepseek | nvidia-nim）",
+        MessageId::CmdQueueDescription => "查看或編輯已排隊的訊息",
+        MessageId::CmdRecallDescription => "搜尋先前的循環封存（基於訊息文字的 BM25 檢索）",
+        MessageId::CmdRestoreDescription => {
+            "將工作區回復到先前輪次前/後的快照。不帶參數時列出最近的快照。"
+        }
+        MessageId::CmdRetryDescription => "重試上一次請求",
+        MessageId::CmdReviewDescription => "對檔案、diff 或 PR 進行結構化程式碼審查",
+        MessageId::CmdRlmDescription => {
+            "遞迴語言模型（RLM）輪次 —— 將提示詞存入 Python REPL，讓模型編寫程式碼進行處理；可用 `llm_query()` / `sub_rlm()` 呼叫子 LLM。"
+        }
+        MessageId::CmdSaveDescription => "將工作階段儲存到檔案",
+        MessageId::CmdSessionsDescription => "開啟工作階段選擇器",
+        MessageId::CmdSettingsDescription => "顯示持久化設定",
+        MessageId::CmdSkillDescription => "啟用技能，或安裝/更新/解除安裝/信任社群技能",
+        MessageId::CmdSkillsDescription => "列出本機技能（或使用 --remote 瀏覽精選登錄檔）",
+        MessageId::CmdStashDescription => "暫存或還原輸入草稿（Ctrl+S 暫存，/stash list|pop）",
+        MessageId::CmdStatuslineDescription => "設定底列要顯示哪些項目",
+        MessageId::CmdSubagentsDescription => "列出子代理狀態",
+        MessageId::CmdSwarmDescription => {
+            "執行多代理扇出輪次（sequential | mixture | distill | deliberate）"
+        }
+        MessageId::CmdSystemDescription => "顯示目前系統提示詞",
+        MessageId::CmdTaskDescription => "管理背景任務",
+        MessageId::CmdTokensDescription => "顯示本次工作階段的 Token 用量",
+        MessageId::CmdTrustDescription => {
+            "管理工作區信任與按路徑的允許清單（`/trust add <path>`、`/trust list`、`/trust on|off`）"
+        }
+        MessageId::CmdUndoDescription => "移除最後一組訊息對",
+        MessageId::CmdYoloDescription => "啟用 YOLO 模式（shell + 信任 + 自動核准）",
+        MessageId::CmdCacheAdvice => {
+            "第 3 輪起命中率穩定在 ~70% 以上即表示前綴快取穩定；
+             長工作階段中明顯偏低則意味著前綴有抖動，值得排查（#263）。"
+        }
+        MessageId::CmdCacheFootnote => "* 當提供方未單獨回報未命中時，由「輸入 − 命中」推算。\n",
+        MessageId::CmdCacheHeader => "快取遙測 —— 最近 {count} / {total} 輪（模型：{model}）\n",
+        MessageId::CmdCacheNoData => {
+            "快取歷史：尚未記錄任何輪次。\n\n\
+             DeepSeek 在受支援的模型（V4 系列）每個 API 輪次都會回傳 `prompt_cache_hit_tokens` / \
+             `prompt_cache_miss_tokens`。請先執行一個輪次再試 /cache。"
+        }
+        MessageId::CmdCacheTotals => {
+            "Σ 輸入：{sum_in}   Σ 命中：{sum_hit}   Σ 未命中：{sum_miss}   平均命中率：{avg}\n"
+        }
+        MessageId::CmdCostReport => {
+            "工作階段費用：\n\
+             ─────────────────────────────\n\
+             預估累計消耗：${cost}\n\n\
+             費用為估算值；如有提供方用量遙測會優先使用。\n\n\
+             DeepSeek API 計費：\n\
+             ─────────────────────────────\n\
+             此 CLI 中未設定詳細計費規則。"
+        }
+        MessageId::CmdTokensCacheBoth => "命中 {hit} / 未命中 {miss}",
+        MessageId::CmdTokensCacheHitOnly => "命中 {hit} / 未命中未回報",
+        MessageId::CmdTokensCacheMissOnly => "命中未回報 / 未命中 {miss}",
+        MessageId::CmdTokensContextUnknownWindow => "~{estimated} / 視窗未知",
+        MessageId::CmdTokensContextWithWindow => "~{used} / {window}（{percent}%）",
+        MessageId::FooterAgentSingular => "1 個子代理",
+        MessageId::FooterAgentsPlural => "{count} 個子代理",
+        MessageId::FooterPressCtrlCAgain => "再次按 Ctrl+C 結束",
+        MessageId::FooterWorking => "工作中",
+        MessageId::HelpSectionActions => "操作",
+        MessageId::HelpSectionClipboard => "剪貼簿",
+        MessageId::HelpSectionEditing => "輸入編輯",
+        MessageId::HelpSectionHelp => "說明",
+        MessageId::HelpSectionModes => "模式",
+        MessageId::HelpSectionNavigation => "導覽",
+        MessageId::HelpSectionSessions => "工作階段",
+        MessageId::CmdTokensNotReported => "未回報",
+        MessageId::CmdTokensReport => {
+            "Token 用量：\n\
+             ─────────────────────────────\n\
+             活動上下文：       {active}\n\
+             上次 API 輸入：    {input}（來自輪次遙測；多輪工具呼叫中相同前綴可能被重複計入）\n\
+             上次 API 輸出：    {output}\n\
+             快取命中/未命中：  {cache}（僅用於遙測/計費）\n\
+             累計 Token：       {total}（工作階段用量遙測）\n\
+             預估工作階段費用： ${cost}\n\
+             API 訊息數：       {api_messages}\n\
+             聊天訊息數：       {chat_messages}\n\
+             模型：             {model}"
+        }
+        MessageId::KbScrollTranscript => "捲動對話記錄、瀏覽輸入歷史或選取附件",
+        MessageId::KbNavigateHistory => "瀏覽輸入歷史",
+        MessageId::KbScrollTranscriptAlt => "捲動對話記錄",
+        MessageId::KbScrollPage => "按頁捲動對話記錄",
+        MessageId::KbJumpTopBottom => "跳轉到對話頂部/底部",
+        MessageId::KbJumpTopBottomEmpty => "跳轉到頂部/底部（輸入框為空時）",
+        MessageId::KbJumpToolBlocks => "在工具輸出區塊之間跳轉",
+        MessageId::KbMoveCursor => "在輸入框中移動游標",
+        MessageId::KbJumpLineStartEnd => "跳轉到行首/行尾",
+        MessageId::KbDeleteChar => "刪除游標前/後的字元，或移除已選附件",
+        MessageId::KbClearDraft => "清空目前草稿",
+        MessageId::KbStashDraft => "暫存目前草稿（用 `/stash pop` 還原）",
+        MessageId::KbSearchHistory => "搜尋提示歷史並還原本機草稿",
+        MessageId::KbInsertNewline => "在輸入框中插入換行",
+        MessageId::KbSendDraft => "送出目前草稿",
+        MessageId::KbCloseMenu => "關閉選單、取消請求、丟棄草稿或清空輸入",
+        MessageId::KbCancelOrExit => "取消請求，或閒置時結束",
+        MessageId::KbShellControls => "開啟正在執行的前景命令 shell 控制",
+        MessageId::KbExitEmpty => "輸入框為空時結束",
+        MessageId::KbCommandPalette => "開啟命令面板",
+        MessageId::KbFuzzyFilePicker => "開啟模糊檔案選擇器（按 Enter 插入 @path）",
+        MessageId::KbCompactInspector => "開啟精簡工作階段上下文檢查器",
+        MessageId::KbLastMessagePager => "開啟最後一則訊息的分頁器（輸入框為空時）",
+        MessageId::KbSelectedDetails => "開啟已選工具或訊息的詳細資訊（輸入框為空時）",
+        MessageId::KbToolDetailsPager => "開啟工具詳細資訊分頁器",
+        MessageId::KbThinkingPager => "開啟思考內容分頁器",
+        MessageId::KbLiveTranscript => "開啟即時對話覆蓋層（自動捲動尾隨）",
+        MessageId::KbBacktrackMessage => "退回到先前的使用者訊息（左右鍵步進，Enter 回復）",
+        MessageId::KbCompleteCycleModes => {
+            "補全 /command、排隊執行輪次跟進、切換模式；Shift+Tab 切換推理強度"
+        }
+        MessageId::KbJumpPlanAgentYolo => "直接跳轉到 Plan / Agent / YOLO 模式",
+        MessageId::KbAltJumpPlanAgentYolo => "替代快捷鍵跳轉到 Plan / Agent / YOLO 模式",
+        MessageId::KbFocusSidebar => "聚焦 Plan / 待辦 / 任務 / 代理 / 自動側邊欄",
+        MessageId::KbTogglePlanAgent => "在 Plan 和 Agent 模式之間切換",
+        MessageId::KbSessionPicker => "開啟工作階段選擇器",
+        MessageId::KbPasteAttach => "貼上文字或附加剪貼簿圖片",
+        MessageId::KbCopySelection => "複製目前選取內容（macOS 為 Cmd+C）",
+        MessageId::KbContextMenu => {
+            "開啟上下文操作選單，用於貼上、選取、訊息詳細資訊、上下文和說明"
+        }
+        MessageId::KbAttachPath => "新增本機文字檔或目錄到上下文",
+        MessageId::KbHelpOverlay => "開啟此說明覆蓋層（輸入框為空時）",
+        MessageId::KbToggleHelp => "切換說明覆蓋層",
+        MessageId::KbToggleHelpSlash => "切換說明覆蓋層",
+        MessageId::HelpUsageLabel => "用法：",
+        MessageId::HelpAliasesLabel => "別名：",
+        MessageId::SettingsTitle => "設定：",
+        MessageId::SettingsConfigFile => "設定檔：",
+        MessageId::ClearConversation => "對話已清空",
+        MessageId::ClearConversationBusy => {
+            "對話已清空（Plan 狀態忙碌；如需再次清空請執行 /clear）"
+        }
+        MessageId::ModelChanged => "模型已切換：{old} \u{2192} {new}",
+        MessageId::LinksTitle => "DeepSeek 連結：",
+        MessageId::LinksDashboard => "控制台：",
+        MessageId::LinksDocs => "文件：",
+        MessageId::LinksTip => "提示：API 金鑰可在控制台中取得。",
+        MessageId::SubagentsFetching => "正在取得子代理狀態...",
+        MessageId::HelpUnknownCommand => "未知命令：{topic}",
+        MessageId::HomeDashboardTitle => "DeepSeek TUI 首頁面板",
+        MessageId::HomeModel => "模型：",
+        MessageId::HomeMode => "模式：",
+        MessageId::HomeWorkspace => "工作區：",
+        MessageId::HomeHistory => "歷史：",
+        MessageId::HomeTokens => "Token：",
+        MessageId::HomeQueued => "佇列：",
+        MessageId::HomeSubagents => "子代理：",
+        MessageId::HomeSkill => "技能：",
+        MessageId::HomeQuickActions => "快捷操作",
+        MessageId::HomeQuickLinks => "/links      - 控制台與 API 連結",
+        MessageId::HomeQuickSkills => "/skills      - 列出可用技能",
+        MessageId::HomeQuickConfig => "/config      - 開啟互動式設定編輯器",
+        MessageId::HomeQuickSettings => "/settings    - 顯示持久化設定",
+        MessageId::HomeQuickModel => "/model       - 切換或查看模型",
+        MessageId::HomeQuickSubagents => "/subagents   - 列出子代理狀態",
+        MessageId::HomeQuickTaskList => "/task list   - 顯示背景任務佇列",
+        MessageId::HomeQuickHelp => "/help        - 顯示說明",
+        MessageId::HomeModeTips => "模式提示",
+        MessageId::HomeAgentModeTip => "Agent 模式 - 使用工具執行自主任務",
+        MessageId::HomeAgentModeReviewTip => "  按 Ctrl+X 可在 Plan 模式下審查後再執行",
+        MessageId::HomeAgentModeYoloTip => "  輸入 /yolo 啟用完整工具存取",
+        MessageId::HomeYoloModeTip => "YOLO 模式 - 完整工具存取，無需核准",
+        MessageId::HomeYoloModeCaution => "  請小心破壞性操作！",
+        MessageId::HomePlanModeTip => "Plan 模式 - 先設計再實作",
+        MessageId::HomePlanModeChecklistTip => "  使用 /plan 建立結構化檢查清單",
+    })
+}
+
 fn portuguese_brazil(id: MessageId) -> Option<&'static str> {
     Some(match id {
         MessageId::ComposerPlaceholder => "Escreva uma tarefa ou use /.",
@@ -1768,9 +2017,10 @@ mod tests {
         assert_eq!(normalize_configured_locale("auto"), Some("auto"));
         assert_eq!(normalize_configured_locale("ja_JP.UTF-8"), Some("ja"));
         assert_eq!(normalize_configured_locale("zh-CN"), Some("zh-Hans"));
+        assert_eq!(normalize_configured_locale("zh-Hant"), Some("zh-Hant"));
+        assert_eq!(normalize_configured_locale("zh-TW"), Some("zh-Hant"));
         assert_eq!(normalize_configured_locale("pt"), Some("pt-BR"));
         assert_eq!(normalize_configured_locale("pt-PT"), Some("pt-BR"));
-        assert_eq!(normalize_configured_locale("zh-TW"), None);
     }
 
     #[test]
@@ -1784,6 +2034,12 @@ mod tests {
                 (key == "LANG").then(|| "zh_CN.UTF-8".to_string())
             }),
             Locale::ZhHans
+        );
+        assert_eq!(
+            resolve_locale_with_env("auto", |key| {
+                (key == "LANG").then(|| "zh_TW.UTF-8".to_string())
+            }),
+            Locale::ZhHant
         );
         assert_eq!(resolve_locale_with_env("auto", |_| None), Locale::En);
     }
@@ -1820,6 +2076,7 @@ mod tests {
     fn width_truncation_handles_cjk_rtl_indic_and_latin_samples() {
         let samples = [
             ("zh-Hans", "输入以筛选配置"),
+            ("zh-Hant", "輸入以篩選設定"),
             ("ar", "تصفية الإعدادات"),
             ("hi", "सेटिंग खोजें"),
             ("pt-BR", "configurações filtradas"),

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -183,7 +183,7 @@ pub struct Settings {
     pub show_thinking: bool,
     /// Show detailed tool output
     pub show_tool_details: bool,
-    /// UI locale: auto, en, ja, zh-Hans, pt-BR
+    /// UI locale: auto, en, ja, zh-Hans, zh-Hant, pt-BR
     pub locale: String,
     /// Composer layout density: compact, comfortable, spacious
     pub composer_density: String,
@@ -350,7 +350,7 @@ impl Settings {
             "locale" | "language" => {
                 let Some(locale) = normalize_configured_locale(value) else {
                     anyhow::bail!(
-                        "Failed to update setting: invalid locale '{value}'. Expected: auto, en, ja, zh-Hans, pt-BR."
+                        "Failed to update setting: invalid locale '{value}'. Expected: auto, en, ja, zh-Hans, zh-Hant, pt-BR."
                     );
                 };
                 self.locale = locale.to_string();
@@ -526,7 +526,7 @@ impl Settings {
             ("show_tool_details", "Show detailed tool output: on/off"),
             (
                 "locale",
-                "UI locale: auto, en, ja, zh-Hans, pt-BR (model output is unchanged)",
+                "UI locale: auto, en, ja, zh-Hans, zh-Hant, pt-BR (model output is unchanged)",
             ),
             (
                 "composer_density",
@@ -682,6 +682,11 @@ mod tests {
         settings.set("language", "pt-PT").expect("set pt fallback");
         assert_eq!(settings.locale, "pt-BR");
 
+        settings
+            .set("locale", "zh_TW.UTF-8")
+            .expect("set traditional chinese");
+        assert_eq!(settings.locale, "zh-Hant");
+
         let err = settings
             .set("locale", "ar")
             .expect_err("Arabic is planned, not shipped");
@@ -703,6 +708,16 @@ mod tests {
         assert!(
             zh.contains("配置文件"),
             "chinese config label missing:\n{zh}"
+        );
+
+        let zh_hant = settings.display(crate::localization::Locale::ZhHant);
+        assert!(
+            zh_hant.contains("設定"),
+            "traditional chinese header missing:\n{zh_hant}"
+        );
+        assert!(
+            zh_hant.contains("設定檔"),
+            "traditional chinese config label missing:\n{zh_hant}"
         );
     }
 

--- a/crates/tui/src/tui/onboarding/language.rs
+++ b/crates/tui/src/tui/onboarding/language.rs
@@ -12,7 +12,7 @@ use crate::palette;
 use crate::tui::app::App;
 
 /// Locale options shown in the picker. Order matches the keyboard hotkeys
-/// (1-5). Each entry is `(hotkey, settings_tag, native_name, english_label)`.
+/// (1-6). Each entry is `(hotkey, settings_tag, native_name, english_label)`.
 /// `settings_tag` is what `Settings::set("locale", …)` accepts and what
 /// `localization::Locale` resolves on next read.
 pub const LANGUAGE_OPTIONS: &[(char, &str, &str, &str)] = &[
@@ -20,7 +20,8 @@ pub const LANGUAGE_OPTIONS: &[(char, &str, &str, &str)] = &[
     ('2', "en", "English", ""),
     ('3', "ja", "日本語", "(Japanese)"),
     ('4', "zh-Hans", "简体中文", "(Simplified Chinese)"),
-    ('5', "pt-BR", "Português (Brasil)", "(Brazilian Portuguese)"),
+    ('5', "zh-Hant", "繁體中文", "(Traditional Chinese)"),
+    ('6', "pt-BR", "Português (Brasil)", "(Brazilian Portuguese)"),
 ];
 
 pub fn lines(app: &App) -> Vec<Line<'static>> {
@@ -76,7 +77,7 @@ pub fn lines(app: &App) -> Vec<Line<'static>> {
     out.push(Line::from(vec![
         Span::styled("Press ", Style::default().fg(palette::TEXT_MUTED)),
         Span::styled(
-            "1-5",
+            "1-6",
             Style::default()
                 .fg(palette::TEXT_PRIMARY)
                 .add_modifier(Modifier::BOLD),

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -1002,7 +1002,7 @@ fn config_hint_for_key(key: &str) -> &'static str {
         | "composer_border"
         | "paste_burst_detection" => "on/off, true/false, yes/no, 1/0",
         "composer_density" | "transcript_spacing" => "compact | comfortable | spacious",
-        "locale" => "auto | en | ja | zh-Hans | pt-BR",
+        "locale" => "auto | en | ja | zh-Hans | zh-Hant | pt-BR",
         "default_mode" => "agent | plan | yolo",
         "sidebar_width" => "10..=50",
         "sidebar_focus" => "auto | plan | todos | tasks | agents",

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -2186,7 +2186,7 @@ mod tests {
 
     #[test]
     fn localized_composer_placeholders_render_at_narrow_widths() {
-        for locale in [Locale::Ja, Locale::ZhHans, Locale::PtBr] {
+        for locale in [Locale::Ja, Locale::ZhHans, Locale::ZhHant, Locale::PtBr] {
             let mut app = create_test_app();
             app.ui_locale = locale;
             app.composer_density = ComposerDensity::Comfortable;


### PR DESCRIPTION
## Summary

Adds full Traditional Chinese (zh-Hant) locale support to the TUI. Taiwanese/Macau/Hong Kong users can now auto-detect or manually select Traditional Chinese.

## Changes

- **localization.rs**: New `Locale::ZhHant` variant, `chinese_traditional()` translation function (~200 lines), `parse_locale` updated to map `zh-TW`/zh-HK/zh-MO to `ZhHant`
- **config_ui.rs**: `UiLocale` enum extended with `ZhHant`
- **commands/config.rs**: locale match added for `ZhHant`
- **settings.rs**: locale validation & help text updated
- **onboarding/language.rs**: zh-Hant option added (hotkey 5), pt-BR moved to 6
- **views/mod.rs**: locale hint updated
- **widgets/mod.rs**: composer test includes `ZhHant`

Closes #740