### PR TITLE
fix(tui): recognize legacy Ctrl+V paste input

### DIFF
--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -1747,9 +1747,7 @@ async fn run_event_loop(
                         app.delete_api_key_char();
                         sync_api_key_validation_status(app, false);
                     }
-                    KeyCode::Char('v') | KeyCode::Char('V')
-                        if is_paste_shortcut(&key) && app.onboarding == OnboardingState::ApiKey =>
-                    {
+                    _ if is_paste_shortcut(&key) && app.onboarding == OnboardingState::ApiKey => {
                         // Cmd+V / Ctrl+V paste (bracketed paste handled above)
                         app.paste_api_key_from_clipboard();
                         sync_api_key_validation_status(app, false);
@@ -2671,7 +2669,7 @@ async fn run_event_loop(
                     };
                     app.set_mode(new_mode);
                 }
-                KeyCode::Char('v') if is_paste_shortcut(&key) => {
+                _ if is_paste_shortcut(&key) => {
                     app.paste_from_clipboard();
                 }
                 KeyCode::Char('a') if key.modifiers.contains(KeyModifiers::ALT) => {
@@ -7535,8 +7533,13 @@ fn details_shortcut_modifiers(modifiers: KeyModifiers) -> bool {
 
 fn is_paste_shortcut(key: &KeyEvent) -> bool {
     let is_v = matches!(key.code, KeyCode::Char('v') | KeyCode::Char('V'));
-    if !is_v {
+    let is_legacy_ctrl_v = matches!(key.code, KeyCode::Char('\u{16}'));
+    if !is_v && !is_legacy_ctrl_v {
         return false;
+    }
+
+    if is_legacy_ctrl_v {
+        return true;
     }
 
     // Cmd+V on macOS
@@ -7549,6 +7552,10 @@ fn is_paste_shortcut(key: &KeyEvent) -> bool {
 }
 
 fn is_text_input_key(key: &KeyEvent) -> bool {
+    if matches!(key.code, KeyCode::Char(c) if c.is_control()) {
+        return false;
+    }
+
     !key.modifiers.contains(KeyModifiers::CONTROL)
         && !key.modifiers.contains(KeyModifiers::ALT)
         && !key.modifiers.contains(KeyModifiers::SUPER)

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -1555,6 +1555,10 @@ fn api_key_paste_shortcut_is_not_plain_text_input() {
     assert!(is_paste_shortcut(&ctrl_v));
     assert!(!is_text_input_key(&ctrl_v));
 
+    let legacy_ctrl_v = KeyEvent::new(KeyCode::Char('\u{16}'), KeyModifiers::NONE);
+    assert!(is_paste_shortcut(&legacy_ctrl_v));
+    assert!(!is_text_input_key(&legacy_ctrl_v));
+
     let shifted = KeyEvent::new(KeyCode::Char('A'), KeyModifiers::SHIFT);
     assert!(is_text_input_key(&shifted));
 }


### PR DESCRIPTION
Closes #783.\n\n## Summary\n- recognize legacy Ctrl+V input (ASCII SYN / U+0016) as a paste shortcut\n- apply that shortcut in onboarding API-key entry and the main composer\n- reject raw control characters as normal text input so paste shortcuts do not become invisible input\n\n## Test plan\n- `cargo fmt --all -- --check`\n- `cargo test -p deepseek-tui --bin deepseek-tui api_key_paste_shortcut_is_not_plain_text_input`\n- `cargo check -p deepseek-tui`