### PR TITLE
fix(config): accept provider-prefixed DeepSeek model IDs

### DIFF
--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -237,7 +237,7 @@ pub fn normalize_model_name(model: &str) -> Option<String> {
     }
 
     let normalized = trimmed.to_ascii_lowercase();
-    if !normalized.starts_with("deepseek") {
+    if !normalized.starts_with("deepseek") && !normalized.contains("/deepseek") {
         return None;
     }
 
@@ -3436,6 +3436,18 @@ api_key = "old-openrouter-key"
         assert!(normalize_model_name("gpt-4o").is_none());
         assert!(normalize_model_name("deepseek v4").is_none());
         assert!(normalize_model_name("").is_none());
+    }
+
+    #[test]
+    fn normalize_model_name_accepts_provider_prefixed_deepseek_ids() {
+        assert_eq!(
+            normalize_model_name("accounts/fireworks/models/deepseek-v4-flash").as_deref(),
+            Some("accounts/fireworks/models/deepseek-v4-flash")
+        );
+        assert_eq!(
+            normalize_model_name("provider/deepseek-ai/deepseek-v4-pro").as_deref(),
+            Some("provider/deepseek-ai/deepseek-v4-pro")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

When using `--provider fireworks` with a provider-prefixed model ID like `accounts/fireworks/models/deepseek-v4-flash`, the config validation rejects it with:

```
Invalid default_text_model 'accounts/fireworks/models/deepseek-v4-flash': expected a DeepSeek model ID
```

The `normalize_model_name` function only checked if the model ID **starts with** `deepseek`, which rejects valid provider-prefixed IDs that contain `deepseek` but don't start with it.

## Fix

Changed the validation to also accept model IDs that contain `/deepseek` (path-separated), covering both bare DeepSeek model IDs and provider-prefixed ones:

- `deepseek-v4-flash` ✅ (starts with "deepseek")
- `accounts/fireworks/models/deepseek-v4-flash` ✅ (contains "/deepseek")
- `gpt-4o` ❌ (still rejected)

## Testing

Added unit test `normalize_model_name_accepts_provider_prefixed_deepseek_ids` verifying both `accounts/fireworks/models/deepseek-v4-flash` and `provider/deepseek-ai/deepseek-v4-pro` are accepted.

Fixes #753
