### PR TITLE
fix(tui): reflect approval mode in agent prompts

### DIFF
--- a/crates/tui/src/commands/config.rs
+++ b/crates/tui/src/commands/config.rs
@@ -288,19 +288,14 @@ pub fn set_config_value(app: &mut App, key: &str, value: &str, persist: bool) ->
             );
         }
         "approval_mode" | "approval" => {
-            let mode = match value.to_lowercase().as_str() {
-                "auto" => Some(ApprovalMode::Auto),
-                "suggest" | "suggested" | "on-request" | "untrusted" => Some(ApprovalMode::Suggest),
-                "never" => Some(ApprovalMode::Never),
-                _ => None,
-            };
+            let mode = ApprovalMode::from_config_value(value);
             return match mode {
                 Some(m) => {
                     app.approval_mode = m;
                     CommandResult::message(format!("approval_mode = {}", m.label()))
                 }
                 None => CommandResult::error(
-                    "Invalid approval_mode. Use: auto, suggest/on-request/untrusted, never",
+                    "Invalid approval_mode. Use: auto, suggest/on-request/untrusted, never/deny",
                 ),
             };
         }

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -371,23 +371,24 @@ impl Engine {
             config.notes_path.clone(),
             config.mcp_config_path.clone(),
         );
-
         // Set up stable system prompt with project context (default to agent mode).
         // Per-turn working-set metadata is injected into the latest user
         // message at request time so file churn does not rewrite this prefix.
         let user_memory_block =
             crate::memory::compose_block(config.memory_enabled, &config.memory_path);
-        let system_prompt = prompts::system_prompt_for_mode_with_context_skills_and_session(
-            AppMode::Agent,
-            &config.workspace,
-            None,
-            Some(&config.skills_dir),
-            Some(&config.instructions),
-            prompts::PromptSessionContext {
-                user_memory_block: user_memory_block.as_deref(),
-                goal_objective: config.goal_objective.as_deref(),
-            },
-        );
+        let system_prompt =
+            prompts::system_prompt_for_mode_with_context_skills_session_and_approval(
+                AppMode::Agent,
+                &config.workspace,
+                None,
+                Some(&config.skills_dir),
+                Some(&config.instructions),
+                prompts::PromptSessionContext {
+                    user_memory_block: user_memory_block.as_deref(),
+                    goal_objective: config.goal_objective.as_deref(),
+                },
+                session.approval_mode,
+            );
         let stable_prompt = Some(system_prompt);
         session.last_system_prompt_hash = Some(system_prompt_hash(stable_prompt.as_ref()));
         session.system_prompt = stable_prompt;
@@ -521,6 +522,7 @@ impl Engine {
                     allow_shell,
                     trust_mode,
                     auto_approve,
+                    approval_mode,
                 } => {
                     self.handle_send_message(
                         content,
@@ -533,6 +535,7 @@ impl Engine {
                         allow_shell,
                         trust_mode,
                         auto_approve,
+                        approval_mode,
                     )
                     .await;
                 }
@@ -730,6 +733,7 @@ impl Engine {
                         self.session.allow_shell,
                         self.session.trust_mode,
                         self.session.auto_approve,
+                        self.session.approval_mode,
                     )
                     .await;
                 }
@@ -781,6 +785,7 @@ impl Engine {
         allow_shell: bool,
         trust_mode: bool,
         auto_approve: bool,
+        approval_mode: crate::tui::approval::ApprovalMode,
     ) {
         // Reset cancel token for fresh turn (in case previous was cancelled)
         self.reset_cancel_token();
@@ -865,6 +870,11 @@ impl Engine {
         self.session.trust_mode = trust_mode;
         self.config.trust_mode = trust_mode;
         self.session.auto_approve = auto_approve;
+        self.session.approval_mode = if auto_approve {
+            crate::tui::approval::ApprovalMode::Auto
+        } else {
+            approval_mode
+        };
 
         // Update system prompt to match current mode and include persisted compaction context.
         self.refresh_system_prompt(mode);
@@ -1755,7 +1765,7 @@ impl Engine {
     fn refresh_system_prompt(&mut self, mode: AppMode) {
         let user_memory_block =
             crate::memory::compose_block(self.config.memory_enabled, &self.config.memory_path);
-        let base = prompts::system_prompt_for_mode_with_context_skills_and_session(
+        let base = prompts::system_prompt_for_mode_with_context_skills_session_and_approval(
             mode,
             &self.config.workspace,
             None,
@@ -1765,6 +1775,7 @@ impl Engine {
                 user_memory_block: user_memory_block.as_deref(),
                 goal_objective: self.config.goal_objective.as_deref(),
             },
+            self.session.approval_mode,
         );
         let stable_prompt =
             merge_system_prompts(Some(&base), self.session.compaction_summary_prompt.clone());

--- a/crates/tui/src/core/ops.rs
+++ b/crates/tui/src/core/ops.rs
@@ -6,6 +6,7 @@
 use crate::compaction::CompactionConfig;
 use crate::models::{Message, SystemPrompt};
 use crate::tui::app::AppMode;
+use crate::tui::approval::ApprovalMode;
 use std::path::PathBuf;
 
 /// Operations that can be submitted to the engine.
@@ -28,6 +29,7 @@ pub enum Op {
         allow_shell: bool,
         trust_mode: bool,
         auto_approve: bool,
+        approval_mode: ApprovalMode,
     },
 
     /// Cancel the current request

--- a/crates/tui/src/core/session.rs
+++ b/crates/tui/src/core/session.rs
@@ -5,6 +5,7 @@
 use crate::cycle_manager::CycleBriefing;
 use crate::models::{Message, SystemPrompt, Usage};
 use crate::project_context::{ProjectContext, load_project_context_with_parents};
+use crate::tui::approval::ApprovalMode;
 use crate::working_set::WorkingSet;
 use chrono::{DateTime, Utc};
 use std::path::PathBuf;
@@ -50,6 +51,9 @@ pub struct Session {
 
     /// Whether the current session should auto-approve tool safety checks.
     pub auto_approve: bool,
+
+    /// Live UI approval policy used to steer the system prompt.
+    pub approval_mode: ApprovalMode,
 
     /// Notes file path
     pub notes_path: PathBuf,
@@ -133,6 +137,7 @@ impl Session {
             allow_shell,
             trust_mode,
             auto_approve: false,
+            approval_mode: ApprovalMode::Suggest,
             notes_path,
             mcp_config_path,
             id: uuid::Uuid::new_v4().to_string(),

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -3867,6 +3867,15 @@ async fn run_exec_agent(
             allow_shell: auto_approve || config.allow_shell(),
             trust_mode,
             auto_approve,
+            approval_mode: if auto_approve {
+                crate::tui::approval::ApprovalMode::Auto
+            } else {
+                config
+                    .approval_policy
+                    .as_deref()
+                    .and_then(crate::tui::approval::ApprovalMode::from_config_value)
+                    .unwrap_or_default()
+            },
         })
         .await?;
 

--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -10,6 +10,7 @@
 use crate::models::SystemPrompt;
 use crate::project_context::{ProjectContext, load_project_context_with_parents};
 use crate::tui::app::AppMode;
+use crate::tui::approval::ApprovalMode;
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -170,11 +171,23 @@ fn mode_prompt(mode: AppMode) -> &'static str {
     }
 }
 
-fn approval_prompt(mode: AppMode) -> &'static str {
+fn default_approval_mode_for_mode(mode: AppMode) -> ApprovalMode {
     match mode {
-        AppMode::Agent => SUGGEST_APPROVAL,
+        AppMode::Agent => ApprovalMode::Suggest,
+        AppMode::Yolo => ApprovalMode::Auto,
+        AppMode::Plan => ApprovalMode::Never,
+    }
+}
+
+fn approval_prompt_for_mode(mode: AppMode, approval_mode: ApprovalMode) -> &'static str {
+    match mode {
         AppMode::Yolo => AUTO_APPROVAL,
         AppMode::Plan => NEVER_APPROVAL,
+        AppMode::Agent => match approval_mode {
+            ApprovalMode::Auto => AUTO_APPROVAL,
+            ApprovalMode::Suggest => SUGGEST_APPROVAL,
+            ApprovalMode::Never => NEVER_APPROVAL,
+        },
     }
 }
 
@@ -187,11 +200,19 @@ fn approval_prompt(mode: AppMode) -> &'static str {
 /// Each layer is separated by a blank line for readability in the
 /// rendered prompt (the model sees them as contiguous sections).
 pub fn compose_prompt(mode: AppMode, personality: Personality) -> String {
+    compose_prompt_with_approval(mode, personality, default_approval_mode_for_mode(mode))
+}
+
+pub fn compose_prompt_with_approval(
+    mode: AppMode,
+    personality: Personality,
+    approval_mode: ApprovalMode,
+) -> String {
     let parts: [&str; 4] = [
         BASE_PROMPT.trim(),
         personality.prompt().trim(),
         mode_prompt(mode).trim(),
-        approval_prompt(mode).trim(),
+        approval_prompt_for_mode(mode, approval_mode).trim(),
     ];
 
     let mut out =
@@ -209,6 +230,10 @@ pub fn compose_prompt(mode: AppMode, personality: Personality) -> String {
 /// Compose for the default personality (Calm).
 fn compose_mode_prompt(mode: AppMode) -> String {
     compose_prompt(mode, Personality::Calm)
+}
+
+fn compose_mode_prompt_with_approval(mode: AppMode, approval_mode: ApprovalMode) -> String {
+    compose_prompt_with_approval(mode, Personality::Calm, approval_mode)
 }
 
 // ── Public API ────────────────────────────────────────────────────────
@@ -288,7 +313,27 @@ pub fn system_prompt_for_mode_with_context_skills_and_session(
     instructions: Option<&[PathBuf]>,
     session_context: PromptSessionContext<'_>,
 ) -> SystemPrompt {
-    let mode_prompt = compose_mode_prompt(mode);
+    system_prompt_for_mode_with_context_skills_session_and_approval(
+        mode,
+        workspace,
+        _working_set_summary,
+        skills_dir,
+        instructions,
+        session_context,
+        default_approval_mode_for_mode(mode),
+    )
+}
+
+pub fn system_prompt_for_mode_with_context_skills_session_and_approval(
+    mode: AppMode,
+    workspace: &Path,
+    _working_set_summary: Option<&str>,
+    skills_dir: Option<&Path>,
+    instructions: Option<&[PathBuf]>,
+    session_context: PromptSessionContext<'_>,
+    approval_mode: ApprovalMode,
+) -> SystemPrompt {
+    let mode_prompt = compose_mode_prompt_with_approval(mode, approval_mode);
 
     // Load project context from workspace
     let project_context = load_project_context_with_parents(workspace);
@@ -509,6 +554,15 @@ mod tests {
         assert!(
             compose_prompt(AppMode::Plan, Personality::Calm).contains("Approval Policy: Never")
         );
+    }
+
+    #[test]
+    fn agent_prompt_can_reflect_never_approval_policy() {
+        let prompt =
+            compose_prompt_with_approval(AppMode::Agent, Personality::Calm, ApprovalMode::Never);
+        assert!(prompt.contains("Mode: Agent"));
+        assert!(prompt.contains("Approval Policy: Never"));
+        assert!(prompt.contains("/config approval_mode suggest"));
     }
 
     #[test]

--- a/crates/tui/src/prompts/approvals/never.md
+++ b/crates/tui/src/prompts/approvals/never.md
@@ -7,4 +7,4 @@ This is a read-only mode. Use it to:
 - Investigate codebases, trace logic, and gather context.
 - Spawn read-only sub-agents for parallel exploration.
 
-When your plan is solid, the user can switch modes to begin execution. Do not ask to switch — the user knows this mode is read-only.
+If the user asks you to edit files, run shell commands, apply patches, or otherwise change the workspace while this policy is active, do not draft a large implementation first. Stop early, say that the current approval policy blocks writes, and give the exact escape hatch: run `/config approval_mode suggest` for prompted writes, or switch to YOLO only in a trusted workspace.

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -1493,6 +1493,11 @@ impl RuntimeThreadManager {
                 allow_shell,
                 trust_mode,
                 auto_approve,
+                approval_mode: if auto_approve {
+                    crate::tui::approval::ApprovalMode::Auto
+                } else {
+                    crate::tui::approval::ApprovalMode::Suggest
+                },
             })
             .await
             .map_err(|e| anyhow!("Failed to start turn: {e}"))?;

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -1118,7 +1118,11 @@ impl App {
             Some(YoloRestoreState {
                 allow_shell: config.allow_shell(),
                 trust_mode: false,
-                approval_mode: ApprovalMode::Suggest,
+                approval_mode: config
+                    .approval_policy
+                    .as_deref()
+                    .and_then(ApprovalMode::from_config_value)
+                    .unwrap_or_default(),
             })
         } else {
             None
@@ -1255,7 +1259,11 @@ impl App {
             approval_mode: if matches!(initial_mode, AppMode::Yolo) {
                 ApprovalMode::Auto
             } else {
-                ApprovalMode::Suggest
+                config
+                    .approval_policy
+                    .as_deref()
+                    .and_then(ApprovalMode::from_config_value)
+                    .unwrap_or_default()
             },
             view_stack: ViewStack::new(),
             backtrack: crate::tui::backtrack::BacktrackState::new(),
@@ -3922,6 +3930,21 @@ mod tests {
         assert!(!app.allow_shell);
         assert!(!app.trust_mode);
         assert_eq!(app.approval_mode, ApprovalMode::Suggest);
+    }
+
+    #[test]
+    fn configured_approval_policy_initializes_live_approval_mode() {
+        let config = Config {
+            approval_policy: Some("never".to_string()),
+            ..Default::default()
+        };
+        let mut options = test_options(false);
+        options.start_in_agent_mode = true;
+
+        let app = App::new(options, &config);
+
+        assert_eq!(app.mode, AppMode::Agent);
+        assert_eq!(app.approval_mode, ApprovalMode::Never);
     }
 
     #[test]

--- a/crates/tui/src/tui/approval.rs
+++ b/crates/tui/src/tui/approval.rs
@@ -55,6 +55,15 @@ impl ApprovalMode {
             ApprovalMode::Never => "NEVER",
         }
     }
+
+    pub fn from_config_value(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "auto" => Some(ApprovalMode::Auto),
+            "suggest" | "suggested" | "on-request" | "untrusted" => Some(ApprovalMode::Suggest),
+            "never" | "deny" | "denied" => Some(ApprovalMode::Never),
+            _ => None,
+        }
+    }
 }
 
 /// User's decision for a pending approval
@@ -1684,5 +1693,22 @@ mod tests {
         assert_eq!(ApprovalMode::Auto.label(), "AUTO");
         assert_eq!(ApprovalMode::Suggest.label(), "SUGGEST");
         assert_eq!(ApprovalMode::Never.label(), "NEVER");
+    }
+
+    #[test]
+    fn test_approval_mode_from_config_value_accepts_aliases() {
+        assert_eq!(
+            ApprovalMode::from_config_value("auto"),
+            Some(ApprovalMode::Auto)
+        );
+        assert_eq!(
+            ApprovalMode::from_config_value("on-request"),
+            Some(ApprovalMode::Suggest)
+        );
+        assert_eq!(
+            ApprovalMode::from_config_value("deny"),
+            Some(ApprovalMode::Never)
+        );
+        assert_eq!(ApprovalMode::from_config_value("unknown"), None);
     }
 }

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -3368,6 +3368,7 @@ async fn dispatch_user_message(
             allow_shell: app.allow_shell,
             trust_mode: app.trust_mode,
             auto_approve: app.mode == AppMode::Yolo,
+            approval_mode: app.approval_mode,
         })
         .await
     {


### PR DESCRIPTION
## Summary
- pass live approval_mode into engine prompt composition instead of deriving approval policy only from Plan/Agent/YOLO
- initialize live approval mode from configured approval_policy and accept deny/denied aliases for the runtime approval setting
- make the Never approval prompt stop early and point users to /config approval_mode suggest instead of drafting blocked edits first

## Verification
- cargo fmt --all -- --check
- cargo test -p deepseek-tui --bin deepseek-tui approval_mode
- cargo test -p deepseek-tui --bin deepseek-tui agent_prompt_can_reflect_never_approval_policy
- cargo test -p deepseek-tui --bin deepseek-tui prompts::tests::each_mode_gets_correct_approval
- cargo build
