### PR TITLE
fix(snapshot): refuse to snapshot $HOME directory

### DIFF
--- a/crates/tui/src/snapshot/repo.rs
+++ b/crates/tui/src/snapshot/repo.rs
@@ -440,33 +440,41 @@ mod tests {
     use std::sync::MutexGuard;
     use tempfile::tempdir;
 
-    /// Holds HOME pinned to a tempdir for the lifetime of a test. Also
+    /// Holds the home directory pinned to a tempdir for the lifetime of a test. Also
     /// owns the process-wide env-var mutex so tests across modules
-    /// don't trample each other's `HOME`.
+    /// don't trample each other's home env vars.
     pub(super) struct ScopedHome {
-        prev: Option<std::ffi::OsString>,
+        prev_vars: Vec<(&'static str, Option<std::ffi::OsString>)>,
         _guard: MutexGuard<'static, ()>,
     }
     impl Drop for ScopedHome {
         fn drop(&mut self) {
             // SAFETY: process-wide lock still held.
             unsafe {
-                match self.prev.take() {
-                    Some(v) => std::env::set_var("HOME", v),
-                    None => std::env::remove_var("HOME"),
+                for (key, prev) in self.prev_vars.drain(..) {
+                    match prev {
+                        Some(value) => std::env::set_var(key, value),
+                        None => std::env::remove_var(key),
+                    }
                 }
             }
         }
     }
     pub(super) fn scoped_home(home: &Path) -> ScopedHome {
         let guard = lock_test_env();
-        let prev = std::env::var_os("HOME");
+        let prev_vars = ["HOME", "USERPROFILE", "HOMEDRIVE", "HOMEPATH"]
+            .into_iter()
+            .map(|key| (key, std::env::var_os(key)))
+            .collect();
         // SAFETY: serialised by the global env lock.
         unsafe {
             std::env::set_var("HOME", home);
+            std::env::set_var("USERPROFILE", home);
+            std::env::remove_var("HOMEDRIVE");
+            std::env::remove_var("HOMEPATH");
         }
         ScopedHome {
-            prev,
+            prev_vars,
             _guard: guard,
         }
     }
@@ -680,8 +688,10 @@ mod tests {
 
         // Try to snapshot HOME itself.
         let result = SnapshotRepo::open_or_init(tmp.path());
-        assert!(result.is_err(), "should refuse to snapshot home directory");
-        let err_msg = result.unwrap_err().to_string();
+        let err_msg = match result {
+            Ok(_) => panic!("should refuse to snapshot home directory"),
+            Err(err) => err.to_string(),
+        };
         assert!(
             err_msg.contains("home directory"),
             "error should mention home directory: {err_msg}"

--- a/crates/tui/src/snapshot/repo.rs
+++ b/crates/tui/src/snapshot/repo.rs
@@ -62,6 +62,17 @@ impl SnapshotRepo {
             .canonicalize()
             .unwrap_or_else(|_| workspace.to_path_buf());
 
+        // Refuse to snapshot the user's home directory — `git add -A` on $HOME
+        // can consume unbounded disk/CPU and effectively DoS the TUI (#793).
+        if let Some(home) = dirs::home_dir() {
+            let home_canonical = home.canonicalize().unwrap_or(home);
+            if work_tree == home_canonical {
+                return Err(io_other(
+                    "refusing to snapshot home directory — start deepseek from a project directory instead",
+                ));
+            }
+        }
+
         let _ = ensure_snapshot_dir(&work_tree)?;
         let git_dir = snapshot_git_dir(&work_tree);
 
@@ -660,5 +671,21 @@ mod tests {
         // avoid double-acquiring HOME (the guard would deadlock).
         drop((_r, _h));
         let (_r2, _h2) = make_repo(tmp.path());
+    }
+
+    #[test]
+    fn open_or_init_refuses_home_directory() {
+        let tmp = tempdir().unwrap();
+        let guard = scoped_home(tmp.path());
+
+        // Try to snapshot HOME itself.
+        let result = SnapshotRepo::open_or_init(tmp.path());
+        assert!(result.is_err(), "should refuse to snapshot home directory");
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("home directory"),
+            "error should mention home directory: {err_msg}"
+        );
+        drop(guard);
     }
 }

--- a/crates/tui/src/snapshot/repo.rs
+++ b/crates/tui/src/snapshot/repo.rs
@@ -62,15 +62,12 @@ impl SnapshotRepo {
             .canonicalize()
             .unwrap_or_else(|_| workspace.to_path_buf());
 
-        // Refuse to snapshot the user's home directory — `git add -A` on $HOME
+        // Refuse to snapshot the user's home directory: `git add -A` on $HOME
         // can consume unbounded disk/CPU and effectively DoS the TUI (#793).
-        if let Some(home) = dirs::home_dir() {
-            let home_canonical = home.canonicalize().unwrap_or(home);
-            if work_tree == home_canonical {
-                return Err(io_other(
-                    "refusing to snapshot home directory — start deepseek from a project directory instead",
-                ));
-            }
+        if is_home_directory(&work_tree, dirs::home_dir().as_deref()) {
+            return Err(io_other(
+                "refusing to snapshot home directory - start deepseek from a project directory instead",
+            ));
         }
 
         let _ = ensure_snapshot_dir(&work_tree)?;
@@ -418,6 +415,15 @@ fn io_other(msg: impl Into<String>) -> io::Error {
     io::Error::other(msg.into())
 }
 
+fn is_home_directory(work_tree: &Path, home: Option<&Path>) -> bool {
+    let Some(home) = home else {
+        return false;
+    };
+
+    let home_canonical = home.canonicalize().unwrap_or_else(|_| home.to_path_buf());
+    work_tree == home_canonical
+}
+
 fn parse_nul_paths(bytes: &[u8]) -> HashSet<PathBuf> {
     bytes
         .split(|b| *b == 0)
@@ -682,20 +688,16 @@ mod tests {
     }
 
     #[test]
-    fn open_or_init_refuses_home_directory() {
+    fn home_directory_guard_matches_canonical_paths() {
         let tmp = tempdir().unwrap();
-        let guard = scoped_home(tmp.path());
+        let home = tmp.path();
+        let home_canonical = home.canonicalize().unwrap();
+        let workspace = home.join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap();
+        let workspace_canonical = workspace.canonicalize().unwrap();
 
-        // Try to snapshot HOME itself.
-        let result = SnapshotRepo::open_or_init(tmp.path());
-        let err_msg = match result {
-            Ok(_) => panic!("should refuse to snapshot home directory"),
-            Err(err) => err.to_string(),
-        };
-        assert!(
-            err_msg.contains("home directory"),
-            "error should mention home directory: {err_msg}"
-        );
-        drop(guard);
+        assert!(is_home_directory(&home_canonical, Some(home)));
+        assert!(!is_home_directory(&workspace_canonical, Some(home)));
+        assert!(!is_home_directory(&home_canonical, None));
     }
 }


### PR DESCRIPTION
Fixes #793

When the TUI is launched from `$HOME`, the snapshot system runs `git add -A` on the entire home directory. This spawns a long-running git process that consumes unbounded CPU and disk (tens of GB reported), making the TUI appear frozen.

**Fix:** `SnapshotRepo::open_or_init` now compares the canonical workspace path against `$HOME` and returns an error if they match. Since snapshots are non-fatal (the turn loop continues without them), this cleanly prevents the DoS without affecting normal operation.

The same issue doesn't affect project directories because they're typically bounded in size and often have `.gitignore` rules.