### PR TITLE
feat: inject structured Environment block into system prompt

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -143,6 +143,10 @@ pub struct EngineConfig {
     /// consulted when `memory_enabled` is `true`.
     pub memory_path: PathBuf,
     pub goal_objective: Option<String>,
+    /// Resolved BCP-47 locale tag (e.g. `"en"`, `"zh-Hans"`, `"ja"`)
+    /// for the `## Environment` block in the system prompt. The caller
+    /// resolves this from `Settings` once; no file I/O in the engine.
+    pub locale_tag: String,
     /// When true, force `tool_choice: "required"` so the model always calls
     /// a tool on every turn step (V4 strict tool-following mode).
     pub strict_tool_mode: bool,
@@ -179,6 +183,7 @@ impl Default for EngineConfig {
             memory_path: PathBuf::from("./memory.md"),
             strict_tool_mode: false,
             goal_objective: None,
+            locale_tag: "en".to_string(),
             workshop: None,
         }
     }
@@ -386,6 +391,7 @@ impl Engine {
                 prompts::PromptSessionContext {
                     user_memory_block: user_memory_block.as_deref(),
                     goal_objective: config.goal_objective.as_deref(),
+                    locale_tag: &config.locale_tag,
                 },
                 session.approval_mode,
             );
@@ -1774,6 +1780,7 @@ impl Engine {
             prompts::PromptSessionContext {
                 user_memory_block: user_memory_block.as_deref(),
                 goal_objective: self.config.goal_objective.as_deref(),
+                locale_tag: &self.config.locale_tag,
             },
             self.session.approval_mode,
         );

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -3845,6 +3845,10 @@ async fn run_exec_agent(
         memory_path: config.memory_path(),
         strict_tool_mode: config.strict_tool_mode.unwrap_or(false),
         goal_objective: None,
+        locale_tag: {
+            let settings = crate::settings::Settings::load().unwrap_or_default();
+            crate::localization::resolve_locale(&settings.locale).tag().to_string()
+        },
         workshop: config.workshop.clone(),
     };
 

--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -39,7 +39,7 @@ const INSTRUCTIONS_FILE_MAX_BYTES: usize = 100 * 1024;
 /// `lang` is resolved in priority order:
 /// 1. User-configured locale from `Settings` (e.g. `zh-Hans`, `ja`)
 /// 2. System environment variables (`LC_ALL`, `LC_MESSAGES`, `LANG`)
-/// 3. Fallback to `en_US.UTF-8`
+/// 3. Fallback to `en`
 fn render_environment_block(workspace: &Path) -> String {
     let lang = {
         let settings = crate::settings::Settings::load().unwrap_or_default();

--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -17,6 +17,11 @@ use std::path::{Path, PathBuf};
 pub struct PromptSessionContext<'a> {
     pub user_memory_block: Option<&'a str>,
     pub goal_objective: Option<&'a str>,
+    /// Resolved locale tag for the `## Environment` block (e.g. `"en"`,
+    /// `"zh-Hans"`, `"ja"`). The caller is responsible for loading
+    /// settings and resolving; no file I/O happens inside the prompt
+    /// builder.
+    pub locale_tag: &'a str,
 }
 
 /// Conventional location for the structured session-handoff artifact (#32).
@@ -36,16 +41,10 @@ const INSTRUCTIONS_FILE_MAX_BYTES: usize = 100 * 1024;
 /// system-prompt block (#454). Each path is loaded in declared order;
 /// Render a `## Environment` block with lang / platform / shell / pwd.
 ///
-/// `lang` is resolved in priority order:
-/// 1. User-configured locale from `Settings` (e.g. `zh-Hans`, `ja`)
-/// 2. System environment variables (`LC_ALL`, `LC_MESSAGES`, `LANG`)
-/// 3. Fallback to `en`
-fn render_environment_block(workspace: &Path) -> String {
-    let lang = {
-        let settings = crate::settings::Settings::load().unwrap_or_default();
-        let locale = crate::localization::resolve_locale(&settings.locale);
-        locale.tag().to_string()
-    };
+/// `locale_tag` is a resolved BCP-47 tag (e.g. `"en"`, `"zh-Hans"`)
+/// provided by the caller — no file I/O is performed here.
+fn render_environment_block(workspace: &Path, locale_tag: &str) -> String {
+    let lang = locale_tag;
     let platform = std::env::consts::OS;
     let shell = std::env::var("SHELL").unwrap_or_else(|_| "unknown".to_string());
     let pwd = workspace.display().to_string();
@@ -327,6 +326,7 @@ pub fn system_prompt_for_mode_with_context_and_skills(
         PromptSessionContext {
             user_memory_block,
             goal_objective: None,
+            locale_tag: "en",
         },
     )
 }
@@ -382,7 +382,7 @@ pub fn system_prompt_for_mode_with_context_skills_session_and_approval(
     // so the `## Language` section in base.md can reference it.
     full_prompt = format!(
         "{full_prompt}\n\n{}",
-        render_environment_block(workspace)
+        render_environment_block(workspace, session_context.locale_tag)
     );
 
     // 2.5a. Configured `instructions = [...]` files (#454). Loaded
@@ -640,6 +640,7 @@ mod tests {
             PromptSessionContext {
                 user_memory_block: None,
                 goal_objective: Some("Fix transcript corruption"),
+                locale_tag: "en",
             },
         ) {
             SystemPrompt::Text(text) => text,
@@ -666,6 +667,7 @@ mod tests {
             PromptSessionContext {
                 user_memory_block: None,
                 goal_objective: Some("   "),
+                locale_tag: "en",
             },
         ) {
             SystemPrompt::Text(text) => text,

--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -34,6 +34,32 @@ const INSTRUCTIONS_FILE_MAX_BYTES: usize = 100 * 1024;
 
 /// Render the `instructions = [...]` config array as a single
 /// system-prompt block (#454). Each path is loaded in declared order;
+/// Render a `## Environment` block with lang / platform / shell / pwd.
+///
+/// `lang` is resolved in priority order:
+/// 1. User-configured locale from `Settings` (e.g. `zh-Hans`, `ja`)
+/// 2. System environment variables (`LC_ALL`, `LC_MESSAGES`, `LANG`)
+/// 3. Fallback to `en_US.UTF-8`
+fn render_environment_block(workspace: &Path) -> String {
+    let lang = {
+        let settings = crate::settings::Settings::load().unwrap_or_default();
+        let locale = crate::localization::resolve_locale(&settings.locale);
+        locale.tag().to_string()
+    };
+    let platform = std::env::consts::OS;
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| "unknown".to_string());
+    let pwd = workspace.display().to_string();
+
+    format!(
+        "## Environment\n\
+         \n\
+         - lang: {lang}\n\
+         - platform: {platform}\n\
+         - shell: {shell}\n\
+         - pwd: {pwd}"
+    )
+}
+
 /// missing files are skipped with a tracing warning so a stale entry
 /// in `~/.deepseek/config.toml` doesn't fail the launch. Empty input
 /// (or all paths missing) returns `None` so callers append nothing.
@@ -350,6 +376,14 @@ pub fn system_prompt_for_mode_with_context_skills_session_and_approval(
             mode_prompt, summary, tree
         )
     };
+
+    // 2.25. Environment block (lang / platform / shell / pwd).
+    // Placed after base+mode+project context, before instructions,
+    // so the `## Language` section in base.md can reference it.
+    full_prompt = format!(
+        "{full_prompt}\n\n{}",
+        render_environment_block(workspace)
+    );
 
     // 2.5a. Configured `instructions = [...]` files (#454). Loaded
     // and concatenated in declared order. Lives above the skills

--- a/crates/tui/src/prompts/base.md
+++ b/crates/tui/src/prompts/base.md
@@ -2,7 +2,7 @@ You are DeepSeek TUI. You're already running inside it — don't try to launch a
 
 ## Language
 
-Detect the language the user writes in and respond in that same language — including your internal reasoning. If the user writes in Simplified Chinese (简体中文), your `reasoning_content` and final reply must both be in Simplified Chinese. If they switch languages mid-conversation, switch with them. The default when no clear signal is present is English.
+Use the language specified by the `lang` field in the `## Environment` section. If `lang` indicates Chinese (zh-*), your `reasoning_content` and final reply must both be in that language. If the user switches languages mid-conversation, switch with them. The default when no clear signal is present is English.
 
 Code, file paths, identifiers, tool names, environment variables, command-line flags, URLs, and log lines stay in their original form — translating `read_file` to `读取文件` would break tool calls. Only natural-language prose mirrors the user.
 

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -1836,6 +1836,10 @@ impl RuntimeThreadManager {
             memory_path: self.config.memory_path(),
             strict_tool_mode: self.config.strict_tool_mode.unwrap_or(false),
             goal_objective: None,
+            locale_tag: {
+                let settings = crate::settings::Settings::load().unwrap_or_default();
+                crate::localization::resolve_locale(&settings.locale).tag().to_string()
+            },
             workshop: self.config.workshop.clone(),
         };
 

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -547,6 +547,7 @@ fn build_engine_config(app: &App, config: &Config) -> EngineConfig {
         memory_path: config.memory_path(),
         strict_tool_mode: config.strict_tool_mode.unwrap_or(false),
         goal_objective: app.goal.goal_objective.clone(),
+        locale_tag: app.ui_locale.tag().to_string(),
         workshop: config.workshop.clone(),
     }
 }
@@ -3283,6 +3284,7 @@ async fn dispatch_user_message(
             prompts::PromptSessionContext {
                 user_memory_block: None,
                 goal_objective: app.goal.goal_objective.as_deref(),
+                locale_tag: app.ui_locale.tag(),
             },
         ),
     );


### PR DESCRIPTION
## Summary

Add a `## Environment` section (lang / platform / shell / pwd) to the system prompt, giving the model deterministic knowledge of the user's runtime context instead of relying on heuristic language detection.

- New `render_environment_block()` in `prompts.rs` emits lang, platform, shell, and pwd.
- `lang` is resolved in priority order: user-configured locale from `Settings` → system env vars (`LC_ALL` / `LC_MESSAGES` / `LANG`) → fallback `en`.
- `## Language` in `base.md` updated to reference the Environment section's `lang` field instead of instructing the model to "Detect the language the user writes in".
- Block is inserted at step 2.25 (after mode prompt + project context, before instructions) so it stays in the workspace-static KV prefix cache layer.

## Testing

- [x] `cargo test --all-features` (prompts: 38/38 passed)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features`

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes