### PR TITLE
fix(tests): pin test app locale and provider to deterministic values

### DIFF
--- a/crates/tui/src/commands/core.rs
+++ b/crates/tui/src/commands/core.rs
@@ -321,7 +321,10 @@ mod tests {
             resume_session_id: None,
             initial_input: None,
         };
-        App::new(options, &Config::default())
+        let mut app = App::new(options, &Config::default());
+        app.ui_locale = crate::localization::Locale::En;
+        app.api_provider = crate::config::ApiProvider::Deepseek;
+        app
     }
 
     #[test]

--- a/crates/tui/src/commands/debug.rs
+++ b/crates/tui/src/commands/debug.rs
@@ -296,7 +296,10 @@ mod tests {
             resume_session_id: None,
             initial_input: None,
         };
-        App::new(options, &Config::default())
+        let mut app = App::new(options, &Config::default());
+        app.ui_locale = crate::localization::Locale::En;
+        app.api_provider = crate::config::ApiProvider::Deepseek;
+        app
     }
 
     #[test]

--- a/crates/tui/src/commands/provider.rs
+++ b/crates/tui/src/commands/provider.rs
@@ -90,7 +90,10 @@ mod tests {
             resume_session_id: None,
             initial_input: None,
         };
-        App::new(options, &Config::default())
+        let mut app = App::new(options, &Config::default());
+        app.ui_locale = crate::localization::Locale::En;
+        app.api_provider = crate::config::ApiProvider::Deepseek;
+        app
     }
 
     #[test]


### PR DESCRIPTION
create_test_app() in commands/{core,debug,provider}.rs constructs App via App::new, which reads system LANG. On a Chinese host this auto-selects ZhHans for ui_locale (translating asserted strings) and DeepseekCN for api_provider (which then differs from the ApiProvider::Deepseek that tests pass to provider()).

Pin both fields after construction, matching the existing pattern in home_dashboard_localizes_in_zh_hans which already sets app.ui_locale to test Chinese rendering.

All 17 tests listed in the issue now pass on a host with LANG=zh_CN.UTF-8.

Closes #791.

## Summary

## Testing

- [x] `cargo test --all-features`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features`

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [x] Verified TUI behavior manually if UI changes
