### PR TITLE
fix(docker): remove misleading ENV, add explicit UID/GID, add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 # Build artifacts
-/target
+/target/
 *.pdb
 *.dll
 *.so
@@ -11,21 +11,21 @@
 .env.*
 
 # Development
-node_modules/
-.vscode/
-.idea/
+/node_modules/
+/.vscode/
+/.idea/
 *.swp
 *.swo
 *~
 .DS_Store
 
 # Git
-.git
-.gitignore
-.gitattributes
+/.git/
+/.gitignore
+/.gitattributes
 
 # CI/CD
-.github/
+/.github/
 
 # Python
 __pycache__/
@@ -38,28 +38,28 @@ venv/
 *.log
 
 # Generated
-outputs/
-tmp/
+/outputs/
+/tmp/
 
 # Local runtime state
-.deepseek/
+/.deepseek/
 
 # Claude Code artifacts
-.claude/
-.ace-tool/
+/.claude/
+/.ace-tool/
 
 # Documentation (not needed at runtime)
-docs/
-website/
-*.md
-!README.md
+/docs/
+/website/
+/*.md
+!/README.md
 
 # Assets (screenshots, etc.)
-assets/
+/assets/
 
 # Scripts
-scripts/
+/scripts/
 
 # Development configs
-.devcontainer/
-config.example.toml
+/.devcontainer/
+/config.example.toml

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,65 @@
+# Build artifacts
+/target
+*.pdb
+*.dll
+*.so
+*.dylib
+*.rlib
+
+# Sensitive environment files
+.env
+.env.*
+
+# Development
+node_modules/
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.DS_Store
+
+# Git
+.git
+.gitignore
+.gitattributes
+
+# CI/CD
+.github/
+
+# Python
+__pycache__/
+*.py[cod]
+.pytest_cache/
+venv/
+.venv/
+
+# Logs
+*.log
+
+# Generated
+outputs/
+tmp/
+
+# Local runtime state
+.deepseek/
+
+# Claude Code artifacts
+.claude/
+.ace-tool/
+
+# Documentation (not needed at runtime)
+docs/
+website/
+*.md
+!README.md
+
+# Assets (screenshots, etc.)
+assets/
+
+# Scripts
+scripts/
+
+# Development configs
+.devcontainer/
+config.example.toml

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,11 @@
 # The image ships both binaries (deepseek dispatcher + deepseek-tui runtime)
 # in a minimal runtime layer. No MCP servers or heavy toolchains are included
 # — keep it slim.
+#
+# API keys MUST be passed at runtime (never baked into the image):
+#   docker run --rm -it -e DEEPSEEK_API_KEY deepseek-tui
+# Or mount an env file:
+#   docker run --rm -it --env-file .env deepseek-tui
 
 ARG RUST_VERSION=1.88
 
@@ -50,8 +55,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libdbus-1-3 \
     && rm -rf /var/lib/apt/lists/*
 
-# Non-root user.
-RUN useradd --create-home --shell /bin/bash deepseek
+# Non-root user with explicit UID/GID for filesystem ownership clarity.
+RUN groupadd --gid 1000 deepseek \
+    && useradd --create-home --shell /bin/bash --uid 1000 --gid 1000 deepseek
 USER deepseek
 WORKDIR /home/deepseek
 
@@ -60,9 +66,6 @@ COPY --from=builder --chown=deepseek:deepseek /out/deepseek-tui /usr/local/bin/d
 
 # The dispatcher expects to find its companion binary next to it.
 # Both are in /usr/local/bin — no further path setup needed.
-
-ENV DEEPSEEK_API_KEY=""
-ENV DEEPSEEK_NO_COLOR=""
 
 ENTRYPOINT ["deepseek"]
 CMD []


### PR DESCRIPTION
## Summary
Three Docker improvements for security and reproducibility:

1. **Remove `ENV DEEPSEEK_API_KEY=""` and `ENV DEEPSEEK_NO_COLOR=""`**: API keys should never be baked into image layers, even as empty strings. The Docker run examples already document passing `-e DEEPSEEK_API_KEY` at runtime. Added comments documenting env-file usage as an alternative.

2. **Add explicit UID/GID (1000:1000)** for the `deepseek` user: Makes filesystem ownership unambiguous when mounting volumes (`-v ~/.deepseek:/home/deepseek/.deepseek`), avoiding permission issues when the auto-assigned UID differs between hosts.

3. **Add `.dockerignore`**: Prevents accidental inclusion of `.env` files, local runtime state (`.deepseek/`), Claude Code artifacts (`.claude/`), documentation, dev configs, and build artifacts into the build context. This both shrinks the image and eliminates a vector for secret leaks via `COPY .`.

## Test plan
- [x] Dockerfile still specifies a valid `useradd` command
- [x] `.dockerignore` excludes `.env*` (prevents API key leaks)
- [x] `.dockerignore` excludes `target/` (prevents stale builds)
- [x] Image entrypoint and CMD unchanged