### PR TITLE
fix: replace std::thread::sleep with tokio::time::sleep in async context

### DIFF
--- a/crates/tui/src/tools/shell.rs
+++ b/crates/tui/src/tools/shell.rs
@@ -2438,7 +2438,7 @@ impl ToolSpec for ShellInteractTool {
                 return Ok(build_shell_delta_tool_result(delta));
             }
 
-            std::thread::sleep(Duration::from_millis(50));
+            tokio::time::sleep(Duration::from_millis(50)).await;
             elapsed = elapsed.saturating_add(50);
         }
     }


### PR DESCRIPTION
## Summary
- `ShellWaitTool::execute` is an `async fn` but used `std::thread::sleep(Duration::from_millis(50))` in its polling loop, which blocks the tokio worker thread for the full 50ms
- Replace with `tokio::time::sleep(Duration::from_millis(50)).await` so the runtime can schedule other tasks during the poll interval

## Why
Blocking a tokio worker thread in an async context prevents other futures from making progress. During shell wait operations (which can last seconds to minutes), this blocking sleep compounds — every 50ms poll cycle blocks the worker, effectively serializing all async tasks on that worker.

## Test plan
- [x] `cargo check -p deepseek-tui` passes
- [ ] Shell wait operations continue to function with correct timing