### PR TITLE
fix: save config with restrictive permissions and improve secret redaction

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::fs;
+#[cfg(unix)]
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
@@ -9,7 +10,7 @@ pub use deepseek_secrets::Secrets;
 use serde::{Deserialize, Serialize};
 
 #[cfg(unix)]
-use std::os::unix::fs::OpenOptionsExt;
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 
 pub const CONFIG_FILE_NAME: &str = "config.toml";
 const DEFAULT_DEEPSEEK_MODEL: &str = "deepseek-v4-pro";
@@ -948,6 +949,13 @@ impl ConfigStore {
                 .with_context(|| format!("failed to write config at {}", self.path.display()))?;
             file.write_all(body.as_bytes())
                 .with_context(|| format!("failed to write config at {}", self.path.display()))?;
+            file.set_permissions(fs::Permissions::from_mode(0o600))
+                .with_context(|| {
+                    format!(
+                        "failed to set config permissions at {}",
+                        self.path.display()
+                    )
+                })?;
         }
         #[cfg(not(unix))]
         {
@@ -1378,6 +1386,51 @@ mod tests {
             values.get("api_key").map(String::as_str),
             Some("sk-d***cret")
         );
+    }
+
+    #[test]
+    fn list_values_fully_redacts_short_api_key() {
+        let config = ConfigToml {
+            api_key: Some("short-key".to_string()),
+            ..ConfigToml::default()
+        };
+
+        let values = config.list_values();
+
+        assert_eq!(values.get("api_key").map(String::as_str), Some("********"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn save_clamps_existing_config_permissions() {
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "deepseek-config-perms-{}-{unique}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&dir).expect("mkdir");
+        let path = dir.join(CONFIG_FILE_NAME);
+        fs::write(&path, "api_key = \"old\"\n").expect("seed config");
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).expect("chmod seed");
+
+        let store = ConfigStore {
+            path: path.clone(),
+            config: ConfigToml {
+                api_key: Some("new-secret".to_string()),
+                ..ConfigToml::default()
+            },
+        };
+        store.save().expect("save");
+
+        let mode = fs::metadata(&path).expect("metadata").permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+
+        let _ = fs::remove_dir_all(dir);
     }
 
     #[test]

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1,11 +1,15 @@
 use std::collections::BTreeMap;
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 use anyhow::{Context, Result, bail};
 pub use deepseek_secrets::Secrets;
 use serde::{Deserialize, Serialize};
+
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
 
 pub const CONFIG_FILE_NAME: &str = "config.toml";
 const DEFAULT_DEEPSEEK_MODEL: &str = "deepseek-v4-pro";
@@ -933,8 +937,23 @@ impl ConfigStore {
             })?;
         }
         let body = toml::to_string_pretty(&self.config).context("failed to serialize config")?;
-        fs::write(&self.path, body)
-            .with_context(|| format!("failed to write config at {}", self.path.display()))?;
+        #[cfg(unix)]
+        {
+            let mut file = fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .mode(0o600)
+                .open(&self.path)
+                .with_context(|| format!("failed to write config at {}", self.path.display()))?;
+            file.write_all(body.as_bytes())
+                .with_context(|| format!("failed to write config at {}", self.path.display()))?;
+        }
+        #[cfg(not(unix))]
+        {
+            fs::write(&self.path, body)
+                .with_context(|| format!("failed to write config at {}", self.path.display()))?;
+        }
         Ok(())
     }
 
@@ -995,7 +1014,7 @@ fn parse_bool(raw: &str) -> Result<bool> {
 }
 
 fn redact_secret(secret: &str) -> String {
-    if secret.len() <= 8 {
+    if secret.len() <= 16 {
         return "********".to_string();
     }
     format!("{}***{}", &secret[..4], &secret[secret.len() - 4..])


### PR DESCRIPTION
## Summary
Two security improvements to config handling:

1. **Restrictive file permissions on config save** — Config files containing API keys were written via `fs::write()` with default permissions (typically `0644`), making them world-readable. On Unix, the `save()` method now uses `OpenOptions` with `mode(0o600)` so only the file owner can read the config.

2. **Improve `redact_secret` threshold** — The minimum length for partial redaction was 8 characters, meaning a 9-character secret would leak 8 of its 9 characters (`XXXX***YYYY`). Raised the threshold to 16 so secrets up to that length are fully masked with `"********"`.

## Why
- `config.toml` often contains plaintext API keys — it should never be world-readable
- The `redact_secret` function is used when displaying config values in logs, error messages, and the TUI config viewer — short secrets were effectively unmasked

## Test plan
- [x] `cargo test -p deepseek-config` — 27 tests pass
- [x] `cargo check -p deepseek-config` — clean compilation