### PR TITLE
fix: replace unreachable!() with proper error returns for DeepSeek providers

### DIFF
--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -2528,7 +2528,11 @@ pub fn save_api_key_for(provider: ApiProvider, api_key: &str) -> Result<PathBuf>
     ensure_parent_dir(&config_path)?;
 
     let table_name = match provider {
-        ApiProvider::Deepseek | ApiProvider::DeepseekCN => unreachable!(),
+        ApiProvider::Deepseek | ApiProvider::DeepseekCN => {
+            return Err(anyhow::anyhow!(
+                "save_api_key_for: DeepSeek variants must use the root api_key field, not provider-specific storage"
+            ));
+        }
         ApiProvider::NvidiaNim => "providers.nvidia_nim",
         ApiProvider::Openrouter => "providers.openrouter",
         ApiProvider::Novita => "providers.novita",
@@ -2556,7 +2560,11 @@ pub fn save_api_key_for(provider: ApiProvider, api_key: &str) -> Result<PathBuf>
         .as_table_mut()
         .context("`providers` must be a table.")?;
     let key_inside = match provider {
-        ApiProvider::Deepseek | ApiProvider::DeepseekCN => unreachable!(),
+        ApiProvider::Deepseek | ApiProvider::DeepseekCN => {
+            return Err(anyhow::anyhow!(
+                "save_api_key_for: DeepSeek variants must use the root api_key field, not provider-specific storage"
+            ));
+        }
         ApiProvider::NvidiaNim => "nvidia_nim",
         ApiProvider::Openrouter => "openrouter",
         ApiProvider::Novita => "novita",

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -5520,7 +5520,10 @@ async fn apply_provider_picker_api_key(
             .providers
             .get_or_insert_with(ProvidersConfig::default);
         let entry: &mut ProviderConfig = match provider {
-            ApiProvider::Deepseek | ApiProvider::DeepseekCN => unreachable!(),
+            ApiProvider::Deepseek | ApiProvider::DeepseekCN => {
+                // Guarded by the outer `if` above; safety net against refactors.
+                return;
+            }
             ApiProvider::NvidiaNim => &mut providers.nvidia_nim,
             ApiProvider::Openrouter => &mut providers.openrouter,
             ApiProvider::Novita => &mut providers.novita,


### PR DESCRIPTION
## Summary
Replace three `unreachable!()` calls that would panic if `ApiProvider::Deepseek` or `ApiProvider::DeepseekCN` ever reached code paths past the early-return guards in `save_api_key_for` and the API key apply path.

The early returns correctly handle these variants, but if a future refactor inadvertently breaks the guard, a panic is a poor failure mode. The replacements return `Err` instead, producing a recoverable error that surfaces the invariant violation without crashing the process.

## Changes
- `crates/tui/src/config.rs`: Two match arms in `save_api_key_for` — convert `unreachable!()` to `return Err(anyhow!(...))`
- `crates/tui/src/tui/ui.rs`: One match arm in the API key apply path — convert `unreachable!()` to an early `return`

## Test plan
- [x] `cargo check -p deepseek-tui` — clean compilation
- [x] `cargo test -p deepseek-tui -- "save_api_key"` — 5 tests pass