### PR TITLE
fix: write all config files with restrictive permissions (0o600)

### DIFF
--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -3,9 +3,13 @@
 use std::collections::HashMap;
 use std::fmt::Write;
 use std::fs;
+use std::io::Write as _;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
+
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
@@ -1564,7 +1568,7 @@ reasoning_effort = "auto"
 "#,
         default_model = DEFAULT_TEXT_MODEL
     );
-    fs::write(&config_path, content)
+    write_config_file_secure(&config_path, &content)
         .with_context(|| format!("Failed to write config to {}", config_path.display()))?;
     Ok(Some(config_path))
 }
@@ -2206,6 +2210,38 @@ pub fn ensure_parent_dir(path: &Path) -> Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)
             .with_context(|| format!("Failed to create directory: {}", parent.display()))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(parent)
+                .with_context(|| format!("Failed to read metadata for {}", parent.display()))?
+                .permissions();
+            if perms.mode() & 0o077 != 0 {
+                perms.set_mode(perms.mode() & !0o077);
+                fs::set_permissions(parent, perms)
+                    .with_context(|| format!("Failed to set permissions on {}", parent.display()))?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Write content to a config file with restrictive permissions (owner-only read/write).
+/// On Unix this sets mode 0o600 before writing.
+fn write_config_file_secure(path: &Path, content: &str) -> Result<()> {
+    #[cfg(unix)]
+    {
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)?;
+        file.write_all(content.as_bytes())?;
+    }
+    #[cfg(not(unix))]
+    {
+        fs::write(path, content)?;
     }
     Ok(())
 }
@@ -2373,7 +2409,7 @@ reasoning_effort = "max"
         )
     };
 
-    fs::write(&config_path, content)
+    write_config_file_secure(&config_path, &content)
         .with_context(|| format!("Failed to write config to {}", config_path.display()))?;
     log_sensitive_event(
         "credential.save",
@@ -2583,7 +2619,7 @@ pub fn save_api_key_for(provider: ApiProvider, api_key: &str) -> Result<PathBuf>
     );
 
     let serialized = toml::to_string_pretty(&doc).context("failed to serialize updated config")?;
-    fs::write(&config_path, serialized)
+    write_config_file_secure(&config_path, &serialized)
         .with_context(|| format!("Failed to write config to {}", config_path.display()))?;
     log_sensitive_event(
         "credential.save",
@@ -2637,7 +2673,7 @@ pub fn clear_api_key() -> Result<()> {
         result.push('\n');
     }
 
-    fs::write(&config_path, result)
+    write_config_file_secure(&config_path, &result)
         .with_context(|| format!("Failed to write config to {}", config_path.display()))?;
     log_sensitive_event(
         "credential.clear",

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -3,15 +3,15 @@
 use std::collections::HashMap;
 use std::fmt::Write;
 use std::fs;
+#[cfg(unix)]
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
-
-#[cfg(unix)]
-use std::os::unix::fs::OpenOptionsExt;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+#[cfg(unix)]
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 
 use crate::audit::log_sensitive_event;
 use crate::features::{Features, FeaturesToml, is_known_feature_key};
@@ -2212,14 +2212,14 @@ pub fn ensure_parent_dir(path: &Path) -> Result<()> {
             .with_context(|| format!("Failed to create directory: {}", parent.display()))?;
         #[cfg(unix)]
         {
-            use std::os::unix::fs::PermissionsExt;
             let mut perms = fs::metadata(parent)
                 .with_context(|| format!("Failed to read metadata for {}", parent.display()))?
                 .permissions();
             if perms.mode() & 0o077 != 0 {
                 perms.set_mode(perms.mode() & !0o077);
-                fs::set_permissions(parent, perms)
-                    .with_context(|| format!("Failed to set permissions on {}", parent.display()))?;
+                fs::set_permissions(parent, perms).with_context(|| {
+                    format!("Failed to set permissions on {}", parent.display())
+                })?;
             }
         }
     }
@@ -2238,6 +2238,7 @@ fn write_config_file_secure(path: &Path, content: &str) -> Result<()> {
             .mode(0o600)
             .open(path)?;
         file.write_all(content.as_bytes())?;
+        file.set_permissions(fs::Permissions::from_mode(0o600))?;
     }
     #[cfg(not(unix))]
     {
@@ -2694,6 +2695,8 @@ mod tests {
     use std::collections::HashMap;
     use std::env;
     use std::ffi::OsString;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     struct EnvGuard {
@@ -2933,6 +2936,17 @@ mod tests {
 
         let contents = fs::read_to_string(&expected)?;
         assert!(contents.contains("api_key = \""));
+
+        #[cfg(unix)]
+        {
+            assert_eq!(fs::metadata(&expected)?.permissions().mode() & 0o777, 0o600);
+            let parent = expected.parent().expect("config has parent dir");
+            assert_eq!(fs::metadata(parent)?.permissions().mode() & 0o077, 0);
+
+            fs::set_permissions(&expected, fs::Permissions::from_mode(0o644))?;
+            save_api_key("second-test-key")?;
+            assert_eq!(fs::metadata(&expected)?.permissions().mode() & 0o777, 0o600);
+        }
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
Three config-file write paths in the TUI crate used `fs::write()` with default permissions (typically `0644` on Unix), leaving API keys in `~/.deepseek/config.toml` world-readable:

- `save_api_key_to_config_file` — initial API key storage during `/login`
- `save_api_key_for` — provider-specific key writes (NvidiaNim, OpenRouter, etc.)
- `clear_api_keys_from_config_file` — credential wipe during `/logout`

## Changes
- Add `write_config_file_secure` helper that uses `OpenOptions` with `mode(0o600)` on Unix
- Route all three config write paths through this helper
- Harden `ensure_parent_dir` to strip group/other permissions from the `~/.deepseek` directory after creation

## Why
API keys are stored in plaintext in `config.toml`. The file should never be readable by other users on the system. The `Config::save()` path (in the `deepseek-config` crate) was fixed separately; this PR covers the remaining write paths in the TUI crate.

## Test plan
- [x] `cargo check -p deepseek-tui` — clean compilation
- [x] `cargo test -p deepseek-tui -- "save_api_key"` — 5 tests pass