### PR TITLE
fix(rlm): enforce child model for RLM fanout

### DIFF
--- a/crates/tui/src/repl/runtime.rs
+++ b/crates/tui/src/repl/runtime.rs
@@ -52,7 +52,8 @@ pub struct ReplRound {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum RpcRequest {
-    /// `llm_query(prompt, model=None, max_tokens=None, system=None)`
+    /// `llm_query(prompt, model=None, max_tokens=None, system=None)`.
+    /// The bridge enforces the configured child model and ignores `model`.
     Llm {
         prompt: String,
         #[serde(default)]
@@ -62,19 +63,22 @@ pub enum RpcRequest {
         #[serde(default)]
         system: Option<String>,
     },
-    /// `llm_query_batched(prompts, model=None)`
+    /// `llm_query_batched(prompts, model=None)`.
+    /// The bridge enforces the configured child model and ignores `model`.
     LlmBatch {
         prompts: Vec<String>,
         #[serde(default)]
         model: Option<String>,
     },
     /// `rlm_query(prompt, model=None)` — recursive sub-RLM (paper's `sub_RLM`).
+    /// The bridge enforces the configured child model and ignores `model`.
     Rlm {
         prompt: String,
         #[serde(default)]
         model: Option<String>,
     },
-    /// `rlm_query_batched(prompts, model=None)`
+    /// `rlm_query_batched(prompts, model=None)`.
+    /// The bridge enforces the configured child model and ignores `model`.
     RlmBatch {
         prompts: Vec<String>,
         #[serde(default)]
@@ -495,7 +499,7 @@ def _rpc(req):
     return {"error": f"unexpected protocol line: {line[:120]!r}"}
 
 def llm_query(prompt, model=None, max_tokens=None, system=None):
-    """One-shot sub-LLM call. Returns the completion text as a string."""
+    """One-shot sub-LLM call. The Rust bridge enforces the child model."""
     resp = _rpc({"type":"llm","prompt":str(prompt),"model":model,
                  "max_tokens":max_tokens,"system":system})
     if isinstance(resp, dict) and resp.get("error"):
@@ -505,7 +509,7 @@ def llm_query(prompt, model=None, max_tokens=None, system=None):
     return str(resp)
 
 def llm_query_batched(prompts, model=None):
-    """Run multiple sub-LLM calls concurrently. Returns a list of strings."""
+    """Run sub-LLM calls concurrently. The Rust bridge enforces the child model."""
     if not isinstance(prompts, (list, tuple)):
         return ["[llm_query_batched: prompts must be a list]"]
     resp = _rpc({"type":"llm_batch","prompts":[str(p) for p in prompts],"model":model})
@@ -523,7 +527,7 @@ def llm_query_batched(prompts, model=None):
     return out
 
 def rlm_query(prompt, model=None):
-    """Recursive sub-RLM (paper's `sub_RLM`). Each call gets its own REPL."""
+    """Recursive sub-RLM. The Rust bridge enforces the child model."""
     resp = _rpc({"type":"rlm","prompt":str(prompt),"model":model})
     if isinstance(resp, dict) and resp.get("error"):
         return f"[rlm_query error: {resp['error']}]"
@@ -532,7 +536,7 @@ def rlm_query(prompt, model=None):
     return str(resp)
 
 def rlm_query_batched(prompts, model=None):
-    """Run multiple recursive sub-RLMs in parallel."""
+    """Run recursive sub-RLMs in parallel. The Rust bridge enforces the child model."""
     if not isinstance(prompts, (list, tuple)):
         return ["[rlm_query_batched: prompts must be a list]"]
     resp = _rpc({"type":"rlm_batch","prompts":[str(p) for p in prompts],"model":model})

--- a/crates/tui/src/rlm/bridge.rs
+++ b/crates/tui/src/rlm/bridge.rs
@@ -83,6 +83,13 @@ impl RlmBridge {
         Arc::clone(&self.usage)
     }
 
+    fn enforced_child_model(&self, _requested: Option<String>) -> String {
+        // RLM child calls are background LLM work that can fan out quickly.
+        // Keep REPL-generated model arguments from silently upgrading the
+        // billed model away from the child model selected by the outer tool.
+        self.child_model.clone()
+    }
+
     async fn dispatch_llm(
         &self,
         prompt: String,
@@ -91,9 +98,7 @@ impl RlmBridge {
         system: Option<String>,
     ) -> SingleResp {
         let request = MessageRequest {
-            model: model
-                .filter(|m| !m.is_empty())
-                .unwrap_or_else(|| self.child_model.clone()),
+            model: self.enforced_child_model(model),
             messages: vec![Message {
                 role: "user".to_string(),
                 content: vec![ContentBlock::Text {
@@ -155,11 +160,7 @@ impl RlmBridge {
             return resp;
         }
 
-        let model = Arc::new(
-            model
-                .filter(|m| !m.is_empty())
-                .unwrap_or_else(|| self.child_model.clone()),
-        );
+        let model = Arc::new(self.enforced_child_model(model));
 
         let futures = prompts.into_iter().map(|prompt| {
             let model = Arc::clone(&model);
@@ -192,9 +193,7 @@ impl RlmBridge {
             async move { while rx.recv().await.is_some() {} },
         );
 
-        let child_model = model
-            .filter(|m| !m.is_empty())
-            .unwrap_or_else(|| self.child_model.clone());
+        let child_model = self.enforced_child_model(model);
 
         // Recursive call. The dyn-erasure on `run_rlm_turn_inner` breaks
         // the `bridge → turn → bridge` opaque-future cycle.
@@ -228,10 +227,10 @@ impl RlmBridge {
             return resp;
         }
 
-        let model = Arc::new(model);
+        let model = Arc::new(self.enforced_child_model(model));
         let futures = prompts.into_iter().map(|p| {
             let model = Arc::clone(&model);
-            async move { self.dispatch_rlm(p, (*model).clone()).await }
+            async move { self.dispatch_rlm(p, Some((*model).clone())).await }
         });
         BatchResp {
             results: join_all(futures).await,
@@ -341,7 +340,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn llm_dispatch_uses_trait_backed_mock_client() {
+    async fn llm_dispatch_uses_enforced_child_model() {
         let mock = Arc::new(MockLlmClient::new(Vec::new()));
         mock.push_message_response(mock_response("child answer", 7, 11));
         let bridge = bridge_for(Arc::clone(&mock), 1);
@@ -365,7 +364,7 @@ mod tests {
 
         let captured = mock.captured_requests();
         assert_eq!(captured.len(), 1);
-        assert_eq!(captured[0].model, "override-model");
+        assert_eq!(captured[0].model, "child-model");
         assert_eq!(captured[0].max_tokens, 123);
         assert_eq!(
             captured[0].system,
@@ -375,6 +374,34 @@ mod tests {
         let usage = bridge.usage.lock().await;
         assert_eq!(usage.input_tokens, 7);
         assert_eq!(usage.output_tokens, 11);
+    }
+
+    #[tokio::test]
+    async fn llm_dispatch_ignores_pro_override_for_child_calls() {
+        let mock = Arc::new(MockLlmClient::new(Vec::new()));
+        mock.push_message_response(mock_response("child answer", 7, 11));
+        let bridge = bridge_for(Arc::clone(&mock), 1);
+
+        let response = bridge
+            .dispatch(RpcRequest::Llm {
+                prompt: "child prompt".to_string(),
+                model: Some("deepseek-v4-pro".to_string()),
+                max_tokens: None,
+                system: None,
+            })
+            .await;
+
+        match response {
+            RpcResponse::Single(single) => {
+                assert_eq!(single.text, "child answer");
+                assert!(single.error.is_none());
+            }
+            other => panic!("expected single response, got {other:?}"),
+        }
+
+        let captured = mock.captured_requests();
+        assert_eq!(captured.len(), 1);
+        assert_eq!(captured[0].model, "child-model");
     }
 
     #[tokio::test]
@@ -410,7 +437,7 @@ mod tests {
         assert!(
             captured
                 .iter()
-                .all(|request| request.model == "batch-model")
+                .all(|request| request.model == "child-model")
         );
 
         let usage = bridge.usage.lock().await;
@@ -445,6 +472,6 @@ mod tests {
 
         let captured = mock.captured_requests();
         assert_eq!(captured.len(), 1);
-        assert_eq!(captured[0].model, "override-model");
+        assert_eq!(captured[0].model, "child-model");
     }
 }

--- a/crates/tui/src/rlm/prompt.rs
+++ b/crates/tui/src/rlm/prompt.rs
@@ -15,10 +15,10 @@ const RLM_SYSTEM_PROMPT: &str = r#"You are the root of a Recursive Language Mode
 
 The REPL exposes:
 - `context` (alias `ctx`) — the full input string. Often huge — never `print(context)` in full.
-- `llm_query(prompt, model=None, max_tokens=None, system=None)` — one-shot child LLM. Cheap. Use for chunk-level work.
-- `llm_query_batched(prompts, model=None)` — concurrent fan-out. Returns `list[str]` in input order.
-- `rlm_query(prompt, model=None)` — recursive sub-RLM. Use when a sub-task itself needs decomposition.
-- `rlm_query_batched(prompts, model=None)` — concurrent recursive sub-RLMs.
+- `llm_query(prompt, max_tokens=None, system=None)` — one-shot child LLM. Cheap. Use for chunk-level work.
+- `llm_query_batched(prompts)` — concurrent fan-out. Returns `list[str]` in input order.
+- `rlm_query(prompt)` — recursive sub-RLM. Use when a sub-task itself needs decomposition.
+- `rlm_query_batched(prompts)` — concurrent recursive sub-RLMs.
 - `SHOW_VARS()` — list user variables and their types.
 - `repl_set(name, value)` / `repl_get(name)` — explicit cross-round storage.
 - `print(...)` — diagnostic output. The driver feeds you a truncated preview next round.
@@ -73,6 +73,7 @@ Rules
 - Never `print(context)` or otherwise dump it whole — slice, sample, or chunk.
 - You MUST call `llm_query` / `llm_query_batched` / `rlm_query` at least once before `FINAL(...)`. Calling FINAL from a top-level prose answer (without ever running a `repl` block that touched `context` via a sub-LLM) is REJECTED — the driver will discard the FINAL and ask you to actually use the REPL.
 - Sub-LLMs are powerful — feed them generous chunks (tens of thousands of chars), not tiny windows.
+- Do not pass `model=` to helper calls. Child model selection is enforced by the driver so RLM fan-out stays on the configured low-cost child model.
 - Do NOT pad your output with prose like "Here is what I'll do:" — just emit the next ```repl block.
 "#;
 

--- a/crates/tui/src/rlm/turn.rs
+++ b/crates/tui/src/rlm/turn.rs
@@ -588,11 +588,14 @@ fn build_metadata_message(
     parts.push("**REPL helpers** (use inside ```repl blocks)".to_string());
     parts.push("- `context` / `ctx`                       — the full input string".to_string());
     parts.push("- `len(context)` / `context[a:b]` / `context.splitlines()` — slice it".to_string());
-    parts.push("- `llm_query(prompt, model=None)`        — one-shot child LLM".to_string());
+    parts.push("- `llm_query(prompt)`                    — one-shot child LLM".to_string());
     parts.push("- `llm_query_batched([p1, p2, ...])`     — concurrent fan-out".to_string());
-    parts.push("- `rlm_query(prompt, model=None)`        — recursive sub-RLM".to_string());
+    parts.push("- `rlm_query(prompt)`                    — recursive sub-RLM".to_string());
     parts.push(
         "- `rlm_query_batched([p1, p2, ...])`     — concurrent recursive sub-RLMs".to_string(),
+    );
+    parts.push(
+        "- Child model selection is enforced by the driver; do not pass `model=`".to_string(),
     );
     parts.push("- `SHOW_VARS()`                          — list user variables".to_string());
     parts.push("- `repl_set(name, value)` / `repl_get(name)` — explicit store".to_string());


### PR DESCRIPTION
## Summary

Fixes #829 by enforcing the configured RLM child model for all REPL-driven child calls.

RLM child helpers can fan out many background LLM requests. Before this change, the bridge accepted the `model` field emitted by REPL helper RPCs, which allowed root-generated Python code to silently upgrade child calls away from the intended low-cost child model.

## Changes

- Route `llm_query`, `llm_query_batched`, `rlm_query`, and `rlm_query_batched` through a single enforced child model policy in the RLM bridge.
- Ignore REPL RPC `model` overrides so child calls cannot silently use `deepseek-v4-pro` when the parent/root model is Pro.
- Add a regression test covering a `deepseek-v4-pro` override attempt.
- Update RLM prompt/runtime helper docs to tell the root model not to pass `model=` because the driver enforces child model selection.

## Validation

- `cargo fmt --all`
- `cargo test -p deepseek-tui rlm::bridge`
- `cargo test -p deepseek-tui rlm`
- `cargo clippy -p deepseek-tui --all-targets --all-features`
- `cargo build`
