### PR TITLE
fix(web_run): decode percent-encoded UTF-8 bytes correctly

### DIFF
--- a/crates/tui/src/tools/web_run.rs
+++ b/crates/tui/src/tools/web_run.rs
@@ -1580,7 +1580,7 @@ fn extract_query_param(url: &str, key: &str) -> Option<String> {
 }
 
 fn percent_decode(input: &str) -> String {
-    let mut out = String::new();
+    let mut out = Vec::with_capacity(input.len());
     let bytes = input.as_bytes();
     let mut idx = 0;
     while idx < bytes.len() {
@@ -1589,14 +1589,14 @@ fn percent_decode(input: &str) -> String {
             && let Ok(hex) = std::str::from_utf8(&bytes[idx + 1..idx + 3])
             && let Ok(val) = u8::from_str_radix(hex, 16)
         {
-            out.push(val as char);
+            out.push(val);
             idx += 3;
             continue;
         }
-        out.push(bytes[idx] as char);
+        out.push(bytes[idx]);
         idx += 1;
     }
-    out
+    String::from_utf8_lossy(&out).into_owned()
 }
 
 fn url_encode(input: &str) -> String {
@@ -1680,6 +1680,22 @@ mod tests {
         assert_eq!(results[0].title, "Example & Result");
         assert_eq!(results[0].url, "https://example.com/path?q=1");
         assert_eq!(results[0].snippet.as_deref(), Some("A useful snippet."));
+    }
+
+    #[test]
+    fn percent_decode_handles_utf8_multibyte_sequences() {
+        // Percent-encoded CJK: %E4%B8%AA%E4%BA%BA = 个人 (each glyph is 3 UTF-8 bytes).
+        assert_eq!(percent_decode("Hello %E4%B8%AA%E4%BA%BA"), "Hello 个人");
+        assert_eq!(percent_decode("%E7%B4%A0%E6%9D%90"), "素材");
+        // Percent-encoded UTF-8 inside a URL path (DuckDuckGo `uddg=` redirect shape).
+        assert_eq!(
+            percent_decode("https://example.com/%E9%A1%B5%E9%9D%A2"),
+            "https://example.com/页面"
+        );
+        // Raw UTF-8 in the input passes through unchanged.
+        assert_eq!(percent_decode("查询 keyword"), "查询 keyword");
+        // ASCII-only inputs preserve existing behavior; `+` stays literal.
+        assert_eq!(percent_decode("foo+bar%20baz"), "foo+bar baz");
     }
 
     #[test]


### PR DESCRIPTION
 ## Summary

  `percent_decode` in `web_run.rs` mangles percent-encoded multi-byte UTF-8 sequences by treating each decoded byte as
  a Latin-1 codepoint:

  ```rust
  out.push(val as char);    // 0xE4 becomes U+00E4 (ä), not part of `个`

  For %E4%B8%AA (which represents 个), this produces ä¸ª instead of 个. This corrupts URLs in DuckDuckGo search results
   before they reach the model and the user.

  The sister module web_search.rs::percent_decode (line 490) already uses the correct pattern — collect raw bytes into
  Vec<u8>, finalize with String::from_utf8_lossy(&out). This PR aligns web_run.rs with that implementation.

  Empirical verification

  input:  Hello %E4%B8%AA   (means "Hello 个")
  before: Hello ä¸ª         ← Latin-1 mojibake
  after:  Hello 个

  input:  %E7%B4%A0%E6%9D%90  (means "素材")
  before: ç´ æ                ← Latin-1 mojibake
  after:  素材

  Test plan

  - New unit test percent_decode_handles_utf8_multibyte_sequences covers percent-encoded CJK, raw UTF-8 input, and
  mixed ASCII+UTF-8.
  - Existing parses_bing_results_and_decodes_redirect_url continues to pass — its ASCII-only URLs are unaffected.
  - cargo test --release --locked --package deepseek-tui 'web_run::tests::' (10/10 pass)
  - cargo fmt --check
  - cargo clippy --workspace --all-targets --all-features (clean)

  Out of scope

  - Unifying percent_decode across web_run.rs and web_search.rs into a shared helper — left for follow-up to keep this
  change focused.
  - A separate code path can produce similar mojibake symptoms in tool-output previews; that lives in a different
  rendering path and is not addressed here.