### PR TITLE
Cache file mention popup completions

### DIFF
--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -466,6 +466,17 @@ impl VimMode {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MentionCompletionCache {
+    pub input: String,
+    pub workspace: PathBuf,
+    pub cwd: Option<PathBuf>,
+    pub token_start_byte: usize,
+    pub partial: String,
+    pub limit: usize,
+    pub entries: Vec<String>,
+}
+
 /// Composer input state — grouped fields for the text input area.
 pub struct ComposerState {
     /// Current composer text content.
@@ -485,6 +496,9 @@ pub struct ComposerState {
     pub slash_menu_hidden: bool,
     pub mention_menu_selected: usize,
     pub mention_menu_hidden: bool,
+    /// Last resolved `@path` popup entries. Cursor-only movement within the
+    /// same mention token reuses this instead of walking the workspace again.
+    pub(crate) mention_completion_cache: Option<MentionCompletionCache>,
     /// Whether vim modal editing is enabled for this composer.
     /// Sourced from `Settings::composer_vim_mode` at startup.
     pub vim_enabled: bool,
@@ -513,6 +527,7 @@ impl Default for ComposerState {
             slash_menu_hidden: false,
             mention_menu_selected: 0,
             mention_menu_hidden: false,
+            mention_completion_cache: None,
             vim_enabled: false,
             vim_mode: VimMode::Normal,
             vim_pending_d: false,
@@ -1186,6 +1201,7 @@ impl App {
                 slash_menu_hidden: false,
                 mention_menu_selected: 0,
                 mention_menu_hidden: false,
+                mention_completion_cache: None,
                 vim_enabled: composer_vim_enabled,
                 vim_mode: VimMode::Normal,
                 vim_pending_d: false,

--- a/crates/tui/src/tui/file_mention.rs
+++ b/crates/tui/src/tui/file_mention.rs
@@ -27,7 +27,7 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
-use crate::tui::app::App;
+use crate::tui::app::{App, MentionCompletionCache};
 use crate::working_set::Workspace;
 
 /// Maximum number of `@`-mentions whose contents are inlined into one user
@@ -166,7 +166,11 @@ pub fn find_file_mention_completions(
 /// captures the process CWD so the resolver and completion walker honor the
 /// user's launch directory when it differs from `--workspace`.
 fn workspace_for_app(app: &App) -> Workspace {
-    Workspace::with_cwd(app.workspace.clone(), std::env::current_dir().ok())
+    workspace_for_app_with_cwd(app, std::env::current_dir().ok())
+}
+
+fn workspace_for_app_with_cwd(app: &App, cwd: Option<PathBuf>) -> Workspace {
+    Workspace::with_cwd(app.workspace.clone(), cwd)
 }
 
 /// Resolve the `@`-mention completion popup contents for the current
@@ -182,11 +186,11 @@ fn workspace_for_app(app: &App) -> Workspace {
 /// Once the composer widget is extended to render this as a popup, it will
 /// pair with `apply_mention_menu_selection` for the Up/Down/Enter flow.
 #[must_use]
-pub fn visible_mention_menu_entries(app: &App, limit: usize) -> Vec<String> {
+pub fn visible_mention_menu_entries(app: &mut App, limit: usize) -> Vec<String> {
     if app.mention_menu_hidden {
         return Vec::new();
     }
-    let Some((_byte_start, partial)) =
+    let Some((token_start_byte, partial)) =
         partial_file_mention_at_cursor(&app.input, app.cursor_position)
     else {
         return Vec::new();
@@ -194,8 +198,32 @@ pub fn visible_mention_menu_entries(app: &App, limit: usize) -> Vec<String> {
     if limit == 0 {
         return Vec::new();
     }
-    let ws = workspace_for_app(app);
-    find_file_mention_completions(&ws, &partial, limit)
+    let cwd = std::env::current_dir().ok();
+    let workspace = app.workspace.clone();
+
+    if let Some(cache) = app.composer.mention_completion_cache.as_ref()
+        && cache.input == app.input
+        && cache.workspace == workspace
+        && cache.cwd == cwd
+        && cache.token_start_byte == token_start_byte
+        && cache.partial == partial
+        && cache.limit == limit
+    {
+        return cache.entries.clone();
+    }
+
+    let ws = workspace_for_app_with_cwd(app, cwd.clone());
+    let entries = find_file_mention_completions(&ws, &partial, limit);
+    app.composer.mention_completion_cache = Some(MentionCompletionCache {
+        input: app.input.clone(),
+        workspace,
+        cwd,
+        token_start_byte,
+        partial,
+        limit,
+        entries: entries.clone(),
+    });
+    entries
 }
 
 /// Apply the currently selected `@`-mention popup entry to the composer

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -1990,7 +1990,7 @@ fn mention_popup_is_empty_when_cursor_is_not_in_a_mention() {
     let mut app = create_test_app();
     app.input = "no mention here".to_string();
     app.cursor_position = app.input.chars().count();
-    assert!(visible_mention_menu_entries(&app, 6).is_empty());
+    assert!(visible_mention_menu_entries(&mut app, 6).is_empty());
 }
 
 #[test]
@@ -2006,11 +2006,63 @@ fn mention_popup_lists_workspace_matches_for_cursor_partial() {
     app.input = "look at @docs/".to_string();
     app.cursor_position = app.input.chars().count();
 
-    let entries = visible_mention_menu_entries(&app, 6);
+    let entries = visible_mention_menu_entries(&mut app, 6);
     assert!(!entries.is_empty(), "popup should surface docs/ entries");
     assert!(entries.iter().any(|e| e.starts_with("docs/")));
     // README.md doesn't match `docs/` — confirm we didn't dump every file.
     assert!(!entries.iter().any(|e| e == "README.md"));
+}
+
+#[test]
+fn mention_popup_reuses_cache_when_cursor_moves_inside_same_token() {
+    let tmpdir = TempDir::new().expect("tempdir");
+    std::fs::create_dir_all(tmpdir.path().join("docs")).unwrap();
+    let target = tmpdir.path().join("docs/target.md");
+    std::fs::write(&target, "x").unwrap();
+
+    let mut app = create_test_app();
+    app.workspace = tmpdir.path().to_path_buf();
+    app.input = "open @docs/target.md please".to_string();
+    app.cursor_position = "open @docs/target.md".chars().count();
+
+    let entries = visible_mention_menu_entries(&mut app, 6);
+    assert_eq!(entries, vec!["docs/target.md".to_string()]);
+    assert!(app.composer.mention_completion_cache.is_some());
+
+    std::fs::remove_file(target).unwrap();
+    app.move_cursor_left();
+
+    let cached = visible_mention_menu_entries(&mut app, 6);
+    assert_eq!(
+        cached, entries,
+        "cursor-only movement inside the same mention token should not walk the workspace again"
+    );
+}
+
+#[test]
+fn mention_popup_cache_misses_after_input_changes() {
+    let tmpdir = TempDir::new().expect("tempdir");
+    std::fs::create_dir_all(tmpdir.path().join("docs")).unwrap();
+    let target = tmpdir.path().join("docs/target.md");
+    std::fs::write(&target, "x").unwrap();
+
+    let mut app = create_test_app();
+    app.workspace = tmpdir.path().to_path_buf();
+    app.input = "open @docs/target.md please".to_string();
+    app.cursor_position = "open @docs/target.md".chars().count();
+
+    let entries = visible_mention_menu_entries(&mut app, 6);
+    assert_eq!(entries, vec!["docs/target.md".to_string()]);
+
+    std::fs::remove_file(target).unwrap();
+    app.move_cursor_left();
+    app.insert_char('x');
+
+    let recomputed = visible_mention_menu_entries(&mut app, 6);
+    assert!(
+        recomputed.is_empty(),
+        "input mutation should miss the mention completion cache and recompute"
+    );
 }
 
 #[test]
@@ -2025,7 +2077,7 @@ fn mention_popup_respects_hidden_flag() {
     app.mention_menu_hidden = true;
 
     assert!(
-        visible_mention_menu_entries(&app, 6).is_empty(),
+        visible_mention_menu_entries(&mut app, 6).is_empty(),
         "Esc-hidden popup must not surface entries until next input edit",
     );
 }
@@ -2042,7 +2094,7 @@ fn apply_mention_menu_selection_splices_selected_entry() {
     app.input = "open @crates/tui/m".to_string();
     app.cursor_position = app.input.chars().count();
 
-    let entries = visible_mention_menu_entries(&app, 6);
+    let entries = visible_mention_menu_entries(&mut app, 6);
     assert!(!entries.is_empty(), "expected entries for @crates/tui/m");
     // Pick whichever entry appears at index 0; it's deterministic given the
     // workspace setup. Apply it.


### PR DESCRIPTION
## Summary
- cache visible `@file` mention popup entries in composer state
- reuse cached entries when the cursor moves inside the same mention token
- miss the cache when input, workspace, cwd, partial, or limit changes
- add regression coverage for cursor-only movement and input mutation

## Root cause
Moving the cursor within an existing `@<path>` token caused the popup path to recompute completions repeatedly. That recomputation walks the workspace, so large workspaces could pause for noticeable time on each Left/Right keypress.

## Validation
- `cargo test -p deepseek-tui file_mention`
- `cargo test -p deepseek-tui mention`
- `cargo test -p deepseek-tui`
- `cargo clippy -p deepseek-tui --all-targets --all-features`
- `cargo build`

Closes #792