### PR TITLE
  fix: show resume hint after TUI exit

### DIFF
--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -447,8 +447,25 @@ pub async fn run_tui(config: &Config, options: TuiOptions) -> Result<()> {
         execute!(terminal.backend_mut(), DisableBracketedPaste)?;
     }
     terminal.show_cursor()?;
+    drop(terminal);
+
+    if result.is_ok()
+        && let Some(hint) = format_resume_hint(app.current_session_id.as_deref())
+    {
+        println!("{hint}");
+    }
 
     result
+}
+
+fn format_resume_hint(session_id: Option<&str>) -> Option<String> {
+    let session_id = session_id?.trim();
+    if session_id.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "To continue this session, run deepseek resume {session_id}"
+    ))
 }
 
 fn terminal_probe_timeout(config: &Config) -> Duration {

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -17,6 +17,23 @@ use std::time::{Duration, Instant};
 use tempfile::TempDir;
 
 #[test]
+fn format_resume_hint_uses_canonical_resume_command() {
+    assert_eq!(
+        format_resume_hint(Some("019dd9d6-4f44-7c83-9863-59674a12b827")),
+        Some(
+            "To continue this session, run deepseek resume 019dd9d6-4f44-7c83-9863-59674a12b827"
+                .to_string()
+        )
+    );
+}
+
+#[test]
+fn format_resume_hint_omits_missing_session_id() {
+    assert_eq!(format_resume_hint(None), None);
+    assert_eq!(format_resume_hint(Some("   ")), None);
+}
+
+#[test]
 fn composer_newline_shortcuts_do_not_steal_ctrl_enter() {
     assert!(is_composer_newline_key(KeyEvent::new(
         KeyCode::Char('j'),


### PR DESCRIPTION

## Summary

  - Print a resume command after successful TUI exit when a session id is available
  - Use the canonical `deepseek resume <SESSION_ID>` command
  - Add focused tests for resume hint formatting

fixes: https://github.com/Hmbown/DeepSeek-TUI/issues/682#issuecomment-4377747777

```
To continue this session, run deepseek resume 1ec096ab-37b4-428b-8883-66ad716d2a47
```

## Testing

- [x] `cargo test --all-features`
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
