### PR TITLE
fix(npm): add --version fallback in wrapper

### DIFF
--- a/npm/deepseek-tui/scripts/run.js
+++ b/npm/deepseek-tui/scripts/run.js
@@ -1,12 +1,34 @@
 const { spawnSync } = require("child_process");
 const { getBinaryPath } = require("./install");
 
+const pkg = require("../package.json");
+
+function isVersionFlag() {
+  const args = process.argv.slice(2);
+  return args.includes("--version") || args.includes("-v") || args.includes("-V");
+}
+
+function handleVersionFallback(binaryName) {
+  if (isVersionFlag()) {
+    const binVersion = pkg.deepseekBinaryVersion || pkg.version;
+    console.log(`${binaryName} (npm wrapper) v${pkg.version}`);
+    console.log(`binary version: v${binVersion}`);
+    console.log(`repo: ${pkg.repository?.url || "N/A"}`);
+    process.exit(0);
+  }
+}
+
 async function run(binaryName) {
+  // Intercept --version before attempting binary download/launch
+  handleVersionFallback(binaryName);
+
   const binaryPath = await getBinaryPath(binaryName);
   const result = spawnSync(binaryPath, process.argv.slice(2), {
     stdio: "inherit",
   });
   if (result.error) {
+    // If binary fails and user asked for --version, show npm version instead
+    handleVersionFallback(binaryName);
     throw result.error;
   }
   process.exit(result.status ?? 1);


### PR DESCRIPTION
## Summary

- Add `--version`/`-v`/`-V` fallback in the npm wrapper so `deepseek --version` works even when the downloaded binary is missing
- Only touches `npm/deepseek-tui/scripts/run.js` — no other files changed

## Test plan

Manually tested:
```bash
node npm/deepseek-tui/bin/deepseek.js --version
node npm/deepseek-tui/bin/deepseek-tui.js --version
node npm/deepseek-tui/bin/deepseek.js -v
```

Output:
```
deepseek (npm wrapper) v0.8.12
binary version: v0.8.12
repo: git+https://github.com/Hmbown/DeepSeek-TUI.git
```

Replaces #728 (which had encoding damage). The uninstall cleanup can be a follow-up PR.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>