### PR TITLE
fix(tui): set Windows console to UTF-8

### DIFF
--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -81,4 +81,4 @@ libc = "0.2"
 libc = "0.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.60", features = ["Win32_Foundation", "Win32_UI_WindowsAndMessaging", "Win32_System_Diagnostics_Debug"] }
+windows = { version = "0.60", features = ["Win32_Foundation", "Win32_System_Console", "Win32_UI_WindowsAndMessaging", "Win32_System_Diagnostics_Debug"] }

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -78,6 +78,20 @@ use crate::models::{ContentBlock, Message, MessageRequest, SystemPrompt};
 use crate::session_manager::{SessionManager, create_saved_session};
 use crate::tui::history::{summarize_tool_args, summarize_tool_output};
 
+#[cfg(windows)]
+fn configure_windows_console_utf8() {
+    use windows::Win32::System::Console::{SetConsoleCP, SetConsoleOutputCP};
+
+    const CP_UTF8: u32 = 65001;
+    unsafe {
+        let _ = SetConsoleCP(CP_UTF8);
+        let _ = SetConsoleOutputCP(CP_UTF8);
+    }
+}
+
+#[cfg(not(windows))]
+fn configure_windows_console_utf8() {}
+
 #[derive(Parser, Debug)]
 #[command(
     name = "deepseek",
@@ -543,6 +557,8 @@ enum SandboxCommand {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    configure_windows_console_utf8();
+
     // Set up process panic hook before anything else — writes crash dumps
     // to ~/.deepseek/crashes/ even if the panic happens before tokio is up,
     // and restores the terminal so a panicked TUI doesn't leave the user's


### PR DESCRIPTION
## Summary
- set the Windows console input/output code pages to UTF-8 at process startup
- add the Windows console API feature to the existing `windows` crate dependency

Closes #872

## Test plan
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p deepseek-tui --all-features`
- `cargo clippy -p deepseek-tui --all-targets --all-features -- -D warnings`

Note: `cargo check -p deepseek-tui --target x86_64-pc-windows-gnu --all-features` was attempted locally but this macOS host is missing `x86_64-w64-mingw32-gcc`, so Windows CI is the platform compile check.