### PR TITLE
test(settings): serialize TUI prefs path env test

### DIFF
--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -958,6 +958,7 @@ mod tests {
 
     #[test]
     fn tui_prefs_path_uses_home_deepseek_subdir_by_default() {
+        let _g = config_path_test_guard();
         // Without DEEPSEEK_CONFIG_PATH the path should end with
         // .deepseek/tui.toml relative to the home directory.
         // We skip this check if home_dir() is unavailable (CI without HOME).


### PR DESCRIPTION
## Summary
- serialize the default TUI prefs path test with the existing config-path env guard
- prevents parallel test runs from observing a temporary DEEPSEEK_CONFIG_PATH override

## Test plan
- cargo test -p deepseek-tui tui_prefs --all-features
- cargo fmt --all -- --check
- git diff --check
- cargo clippy -p deepseek-tui --all-targets --all-features -- -D warnings