### PR TITLE
fix(engine): include current date in turn metadata

### DIFF
--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -656,6 +656,36 @@ fn working_set_reaches_model_as_turn_metadata() {
     assert!(text.contains("src/lib.rs"));
 }
 
+#[test]
+fn turn_metadata_includes_current_local_date_without_working_set() {
+    let tmp = tempdir().expect("tempdir");
+    let config = EngineConfig {
+        workspace: tmp.path().to_path_buf(),
+        ..Default::default()
+    };
+    let (mut engine, _handle) = Engine::new(config, &Config::default());
+    engine.session.add_message(Message {
+        role: "user".to_string(),
+        content: vec![ContentBlock::Text {
+            text: "what is today's date?".to_string(),
+            cache_control: None,
+        }],
+    });
+
+    let messages = engine.messages_with_turn_metadata();
+    let first_block = messages
+        .last()
+        .and_then(|message| message.content.first())
+        .expect("turn metadata block");
+    let ContentBlock::Text { text, .. } = first_block else {
+        panic!("expected text metadata block");
+    };
+
+    let today = chrono::Local::now().format("%Y-%m-%d").to_string();
+    assert!(text.starts_with("<turn_meta>\n"));
+    assert!(text.contains(&format!("Current local date: {today}")));
+}
+
 /// v0.8.11 regression: tool-result messages serialize to role="tool" on
 /// the wire but are stored as role="user" internally. Prepending
 /// `<turn_meta>` text onto a tool-result message broke the

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -1713,14 +1713,18 @@ impl Engine {
     }
 
     pub(super) fn messages_with_turn_metadata(&self) -> Vec<Message> {
-        let Some(summary) = self
+        let today = chrono::Local::now().format("%Y-%m-%d").to_string();
+        let working_set_summary = self
             .session
             .working_set
             .summary_block(&self.config.workspace)
             .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty())
-        else {
-            return self.session.messages.clone();
+            .filter(|s| !s.is_empty());
+
+        let summary = if let Some(working_set_summary) = working_set_summary {
+            format!("Current local date: {today}\n{working_set_summary}")
+        } else {
+            format!("Current local date: {today}")
         };
 
         let mut messages = self.session.messages.clone();


### PR DESCRIPTION
## Summary
- prepend the current local date to per-turn metadata on real user turns
- keep the stable system prompt unchanged so prompt cache behavior stays intact
- preserve existing working-set metadata in the same turn_meta block

Closes #865

## Test plan
- cargo test -p deepseek-tui turn_metadata_includes_current_local_date_without_working_set --all-features
- cargo test -p deepseek-tui turn_metadata --all-features
- cargo fmt --all -- --check
- git diff --check
- cargo clippy -p deepseek-tui --all-targets --all-features -- -D warnings