### PR TITLE
chore(release): prepare v0.8.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,96 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.15] - 2026-05-06
+
+An auth, Windows, editor-integration, and setup stabilization release. This
+release keeps the existing DeepSeek V4 architecture intact while landing small
+community fixes that make first-run setup, terminal behavior, skills, cost
+display, and recovery paths easier to trust.
+
+### Added
+- **ACP stdio adapter for Zed/custom agents** (#782) — `deepseek serve --acp`
+  starts a local Agent Client Protocol server over stdio. The first slice
+  supports new sessions and prompt responses through the user's existing
+  DeepSeek config/API key; tool-backed editing and checkpoint replay remain
+  outside the ACP surface for now.
+- **Yuan/CNY cost display** (#806) — `cost_currency = "cny"` (also accepts
+  `yuan` / `rmb`) switches footer, context panel, `/cost`, `/tokens`, and
+  long-turn notification summaries from USD to CNY.
+- **Slash autocomplete for skills** (#808) — installed skills are visible in
+  the slash-command autocomplete menu.
+- **`/rename` session titles** (#836) — sessions can be renamed without
+  editing save files manually.
+
+### Changed
+- **Current local date in turn metadata** (#893, closes #865) — real user turns
+  now include the current local date in `<turn_meta>`, without changing the
+  stable system prompt/cache prefix.
+- **Doctor endpoint diagnostics** (#823) — `deepseek doctor` shows the resolved
+  provider/API endpoint to make proxy, China endpoint, and inherited-env
+  debugging more concrete.
+- **More conservative request sizing** (#826) — API requests cap `max_tokens`
+  against the active model/context budget before dispatch.
+- **Safer config and secret file writes** (#833, #837) — generated config files
+  use restrictive permissions and improved secret redaction.
+
+### Fixed
+- **Env-only API key failure recovery** (#892) — runtime auth failures now say
+  when the rejected key came from inherited `DEEPSEEK_API_KEY` and no saved
+  config key is present, matching the clearer `deepseek doctor` guidance.
+- **Windows Unicode output** (#887, closes #872) — TUI startup now best-effort
+  switches the Windows console input/output codepages to UTF-8, improving
+  Chinese and other non-ASCII rendering.
+- **Windows resume picker** (#886, closes #866) — the dispatcher keeps the
+  resume picker path on Windows instead of bypassing it.
+- **Windows clipboard fallback** (#850) — copy operations have a fallback path
+  when the primary clipboard backend is unavailable.
+- **Workspace trust persistence** (#870) — approval/trust choices persist in
+  global config instead of surprising users on the next launch.
+- **Ctrl+E composer behavior** (#883, closes #876) — plain Ctrl+E moves to the
+  end of the composer again; file-tree toggling moved to the shifted shortcut.
+- **Plain Markdown skills** (#869) — `SKILL.md` files without frontmatter now
+  fall back to the first `# Heading` instead of being ignored.
+- **Workspace-scoped latest resume** (#830, closes #779) — `resume --last`,
+  `--continue`, and fork/resume helpers choose the latest session for the
+  current workspace/repo rather than the newest saved session globally.
+- **Npm wrapper version fallback** (#885) — `deepseek --version` / `-v` can
+  report the package version when the native binary has not been downloaded
+  yet.
+- **TUI exit resume hint** (#863, closes #682) — exiting the TUI now points
+  users toward the relevant resume command.
+- **Startup and terminal reliability** — includes bounded stream-open waits
+  (#847), cursor-lag reduction for `@` mentions (#849), OSC52 clipboard fallback
+  for SSH (#845), legacy Ctrl+V paste recognition (#786), Windows mouse capture
+  defaulting off (#785), and UTF-8-preserving ANSI stripping (#784).
+- **Install and policy reliability** — avoids unstable Rust file-locking APIs
+  (#821), enforces network policy in `web_run` (#800), fixes repeated setup
+  language prompts after API-key setup (#844), and explains dispatcher TUI spawn
+  failures (#853).
+- **Workspace safety** — refuses dangerous snapshots for `$HOME` or unsafe
+  workspaces (#798, #804), fixes path-escape false positives for double-dots in
+  names (#824), scopes snapshot built-in excludes (#854), and replaces provider
+  `unreachable!()` paths with proper errors (#835).
+- **Skills discovery** — recursively reads the skills directory (#811), ignores
+  symlinks outside the selected install root (#814), discovers global Agents
+  skills (#848), and includes `.cursor/skills` (#817).
+- **Provider/model compatibility** — restores auto model routing (#772),
+  completes vLLM provider integration (#737), accepts provider-prefixed DeepSeek
+  model IDs (#794), preserves requested model ID casing (#733), and pins RLM
+  child calls to Flash (#832).
+
+### Thanks
+- Thanks to [@reidliu41](https://github.com/reidliu41) for the resume hint and
+  workspace trust fixes (#863, #870).
+- Thanks to [@Oliver-ZPLiu](https://github.com/Oliver-ZPLiu) for the Windows
+  clipboard fallback (#850).
+- Thanks to [@xieshutao](https://github.com/xieshutao) for the plain Markdown
+  skill fallback (#869).
+- Thanks to [@GK012](https://github.com/GK012) for the npm wrapper version
+  fallback (#885).
+- Thanks to everyone filing Windows, Chinese-language setup, auth, and
+  first-run reports. Those concrete reproductions shaped the release.
+
 ## [0.8.13] - 2026-05-05
 
 A stabilization release for DeepSeek V4 runtime and TUI reliability. The

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-agent"
-version = "0.8.14"
+version = "0.8.15"
 dependencies = [
  "deepseek-config",
  "serde",
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-app-server"
-version = "0.8.14"
+version = "0.8.15"
 dependencies = [
  "anyhow",
  "axum",
@@ -1110,7 +1110,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-config"
-version = "0.8.14"
+version = "0.8.15"
 dependencies = [
  "anyhow",
  "deepseek-secrets",
@@ -1122,7 +1122,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-core"
-version = "0.8.14"
+version = "0.8.15"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1140,7 +1140,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-execpolicy"
-version = "0.8.14"
+version = "0.8.15"
 dependencies = [
  "anyhow",
  "deepseek-protocol",
@@ -1149,7 +1149,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-hooks"
-version = "0.8.14"
+version = "0.8.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-mcp"
-version = "0.8.14"
+version = "0.8.15"
 dependencies = [
  "anyhow",
  "serde",
@@ -1172,7 +1172,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-protocol"
-version = "0.8.14"
+version = "0.8.15"
 dependencies = [
  "serde",
  "serde_json",
@@ -1180,7 +1180,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-secrets"
-version = "0.8.14"
+version = "0.8.15"
 dependencies = [
  "dirs",
  "keyring",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-state"
-version = "0.8.14"
+version = "0.8.15"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1205,7 +1205,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-tools"
-version = "0.8.14"
+version = "0.8.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1218,7 +1218,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-tui"
-version = "0.8.14"
+version = "0.8.15"
 dependencies = [
  "anyhow",
  "arboard",
@@ -1278,7 +1278,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-tui-cli"
-version = "0.8.14"
+version = "0.8.15"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1302,7 +1302,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-tui-core"
-version = "0.8.14"
+version = "0.8.15"
 
 [[package]]
 name = "deranged"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = ["crates/cli", "crates/app-server", "crates/tui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.8.14"
+version = "0.8.15"
 edition = "2024"
 # Rust 1.88 stabilized `let_chains` in `if`/`while` conditions, which the
 # codebase relies on extensively. Cargo enforces this so users on older

--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ deepseek
 deepseek doctor                         # verify setup
 ```
 
+If `deepseek doctor` says the rejected key came from `DEEPSEEK_API_KEY`, remove
+the stale export from your shell startup file, open a fresh shell, then run
+`deepseek auth set --provider deepseek`. Saved config keys take precedence over
+the environment and are easier to rotate.
+
 > To rotate or remove a saved key: `deepseek auth clear --provider deepseek`.
 
 ### Auto Mode
@@ -196,15 +201,18 @@ VLLM_BASE_URL="http://localhost:8000/v1" deepseek --provider vllm --model deepse
 
 ---
 
-## What's New In v0.8.14
+## What's New In v0.8.15
 
-A stabilization release focused on first-run setup, auto model + thinking routing, cost accounting, and provider support. [Full changelog](CHANGELOG.md).
+A community-driven stabilization release focused on auth recovery, Windows
+terminals, Zed/ACP compatibility, setup friction, and clearer cost display.
+[Full changelog](CHANGELOG.md).
 
-- **Auto mode restored** — `--model auto`, `/model auto`, config `default_model = "auto"`, one-shot prompts, and sub-agents resolve to concrete model + thinking routes before calling the API
-- **Per-turn cost accounting fix** — V4 reasoning tokens are counted as billable output when providers report them separately from completion tokens
-- **First-run setup repair** — missing config files now lead users through API key setup and create `~/.deepseek/config.toml`
-- **Settings navigation fix** — arrow-key selection and click highlighting in the config UI work reliably on Windows terminals
-- **vLLM provider support** — self-hosted vLLM endpoints can be used with `--provider vllm` and `VLLM_BASE_URL`
+- **Friendlier auth recovery** — runtime API-key failures now explain when the active key came only from `DEEPSEEK_API_KEY` and no saved config key is present
+- **Zed / ACP adapter** — `deepseek serve --acp` exposes a local stdio Agent Client Protocol server for Zed and other compatible editors
+- **Windows terminal fixes** — UTF-8 console setup, dispatcher resume handling, clipboard fallback, Ctrl+E composer behavior, and safer Windows mouse defaults
+- **Yuan cost display** — set `cost_currency = "cny"` (or `yuan` / `rmb`) to show footer, `/cost`, `/tokens`, and notification summaries in CNY
+- **Setup and skill polish** — workspace trust persists globally, plain Markdown `SKILL.md` files load correctly, global Agents/Cursor skill paths are discovered, and the TUI shows skills in slash autocomplete
+- **Reliability fixes** — workspace-scoped `resume --last`, capped API `max_tokens`, endpoint diagnostics in `deepseek doctor`, npm `--version` fallback, and current-date turn metadata
 
 ---
 
@@ -391,7 +399,10 @@ This project ships with help from a growing community of contributors:
 - **[wangfeng](mailto:wangfengcsu@qq.com)** — Pricing/discount info update (#692)
 - **[zichen0116](https://github.com/zichen0116)** — CODE_OF_CONDUCT.md (#686)
 - **[dfwqdyl-ui](https://github.com/dfwqdyl-ui)** — model ID case-sensitivity compatibility report (#729)
-- **[Oliver-ZPLiu](https://github.com/Oliver-ZPLiu)** — stale `working...` state bug report with detailed reproduction and fix (#738)
+- **[Oliver-ZPLiu](https://github.com/Oliver-ZPLiu)** — stale `working...` state bug report and Windows clipboard fallback (#738, #850)
+- **[reidliu41](https://github.com/reidliu41)** — resume hint and workspace trust persistence fixes (#863, #870)
+- **[xieshutao](https://github.com/xieshutao)** — plain Markdown skill fallback (#869)
+- **[GK012](https://github.com/GK012)** — npm wrapper `--version` fallback (#885)
 - **Hafeez Pizofreude** — SSRF protection in `fetch_url` and Star History chart
 - **Unic (YuniqueUnic)** — Schema-driven config UI (TUI + web)
 - **Jason** — SSRF security hardening

--- a/config.example.toml
+++ b/config.example.toml
@@ -48,6 +48,12 @@ default_text_model = "deepseek-v4-pro"
 reasoning_effort = "max"
 
 # ─────────────────────────────────────────────────────────────────────────────────
+# Cost Display
+# ─────────────────────────────────────────────────────────────────────────────────
+# Display estimated usage in USD or CNY. Aliases `yuan` and `rmb` normalize to `cny`.
+cost_currency = "usd" # usd | cny
+
+# ─────────────────────────────────────────────────────────────────────────────────
 # Paths
 # ─────────────────────────────────────────────────────────────────────────────────
 skills_dir = "~/.deepseek/skills"

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -7,5 +7,5 @@ repository.workspace = true
 description = "Model/provider registry and fallback strategy for DeepSeek workspace architecture"
 
 [dependencies]
-deepseek-config = { path = "../config", version = "0.8.14" }
+deepseek-config = { path = "../config", version = "0.8.15" }
 serde.workspace = true

--- a/crates/app-server/Cargo.toml
+++ b/crates/app-server/Cargo.toml
@@ -10,15 +10,15 @@ description = "Codex-style app-server transport for DeepSeek workspace architect
 anyhow.workspace = true
 axum.workspace = true
 clap.workspace = true
-deepseek-agent = { path = "../agent", version = "0.8.14" }
-deepseek-config = { path = "../config", version = "0.8.14" }
-deepseek-core = { path = "../core", version = "0.8.14" }
-deepseek-execpolicy = { path = "../execpolicy", version = "0.8.14" }
-deepseek-hooks = { path = "../hooks", version = "0.8.14" }
-deepseek-mcp = { path = "../mcp", version = "0.8.14" }
-deepseek-protocol = { path = "../protocol", version = "0.8.14" }
-deepseek-state = { path = "../state", version = "0.8.14" }
-deepseek-tools = { path = "../tools", version = "0.8.14" }
+deepseek-agent = { path = "../agent", version = "0.8.15" }
+deepseek-config = { path = "../config", version = "0.8.15" }
+deepseek-core = { path = "../core", version = "0.8.15" }
+deepseek-execpolicy = { path = "../execpolicy", version = "0.8.15" }
+deepseek-hooks = { path = "../hooks", version = "0.8.15" }
+deepseek-mcp = { path = "../mcp", version = "0.8.15" }
+deepseek-protocol = { path = "../protocol", version = "0.8.15" }
+deepseek-state = { path = "../state", version = "0.8.15" }
+deepseek-tools = { path = "../tools", version = "0.8.15" }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -14,13 +14,13 @@ path = "src/main.rs"
 anyhow.workspace = true
 clap.workspace = true
 clap_complete.workspace = true
-deepseek-agent = { path = "../agent", version = "0.8.14" }
-deepseek-app-server = { path = "../app-server", version = "0.8.14" }
-deepseek-config = { path = "../config", version = "0.8.14" }
-deepseek-execpolicy = { path = "../execpolicy", version = "0.8.14" }
-deepseek-mcp = { path = "../mcp", version = "0.8.14" }
-deepseek-secrets = { path = "../secrets", version = "0.8.14" }
-deepseek-state = { path = "../state", version = "0.8.14" }
+deepseek-agent = { path = "../agent", version = "0.8.15" }
+deepseek-app-server = { path = "../app-server", version = "0.8.15" }
+deepseek-config = { path = "../config", version = "0.8.15" }
+deepseek-execpolicy = { path = "../execpolicy", version = "0.8.15" }
+deepseek-mcp = { path = "../mcp", version = "0.8.15" }
+deepseek-secrets = { path = "../secrets", version = "0.8.15" }
+deepseek-state = { path = "../state", version = "0.8.15" }
 chrono.workspace = true
 dirs.workspace = true
 serde.workspace = true

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -8,7 +8,7 @@ description = "Config schema and precedence model for DeepSeek workspace archite
 
 [dependencies]
 anyhow.workspace = true
-deepseek-secrets = { path = "../secrets", version = "0.8.14" }
+deepseek-secrets = { path = "../secrets", version = "0.8.15" }
 dirs.workspace = true
 serde.workspace = true
 toml.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -9,13 +9,13 @@ description = "Core runtime boundaries for DeepSeek workspace architecture"
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true
-deepseek-agent = { path = "../agent", version = "0.8.14" }
-deepseek-config = { path = "../config", version = "0.8.14" }
-deepseek-execpolicy = { path = "../execpolicy", version = "0.8.14" }
-deepseek-hooks = { path = "../hooks", version = "0.8.14" }
-deepseek-mcp = { path = "../mcp", version = "0.8.14" }
-deepseek-protocol = { path = "../protocol", version = "0.8.14" }
-deepseek-state = { path = "../state", version = "0.8.14" }
-deepseek-tools = { path = "../tools", version = "0.8.14" }
+deepseek-agent = { path = "../agent", version = "0.8.15" }
+deepseek-config = { path = "../config", version = "0.8.15" }
+deepseek-execpolicy = { path = "../execpolicy", version = "0.8.15" }
+deepseek-hooks = { path = "../hooks", version = "0.8.15" }
+deepseek-mcp = { path = "../mcp", version = "0.8.15" }
+deepseek-protocol = { path = "../protocol", version = "0.8.15" }
+deepseek-state = { path = "../state", version = "0.8.15" }
+deepseek-tools = { path = "../tools", version = "0.8.15" }
 serde_json.workspace = true
 uuid.workspace = true

--- a/crates/execpolicy/Cargo.toml
+++ b/crates/execpolicy/Cargo.toml
@@ -8,5 +8,5 @@ description = "Execution policy and approval model parity for DeepSeek workspace
 
 [dependencies]
 anyhow.workspace = true
-deepseek-protocol = { path = "../protocol", version = "0.8.14" }
+deepseek-protocol = { path = "../protocol", version = "0.8.15" }
 serde.workspace = true

--- a/crates/hooks/Cargo.toml
+++ b/crates/hooks/Cargo.toml
@@ -10,7 +10,7 @@ description = "Hook dispatch and notifications parity for DeepSeek workspace arc
 anyhow.workspace = true
 async-trait.workspace = true
 chrono.workspace = true
-deepseek-protocol = { path = "../protocol", version = "0.8.14" }
+deepseek-protocol = { path = "../protocol", version = "0.8.15" }
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -9,7 +9,7 @@ description = "Tool invocation lifecycle, schema validation, and scheduler paral
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
-deepseek-protocol = { path = "../protocol", version = "0.8.14" }
+deepseek-protocol = { path = "../protocol", version = "0.8.15" }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -21,8 +21,8 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0.100"
 arboard = "3.4"
-deepseek-secrets = { path = "../secrets", version = "0.8.14" }
-deepseek-tools = { path = "../tools", version = "0.8.14" }
+deepseek-secrets = { path = "../secrets", version = "0.8.15" }
+deepseek-tools = { path = "../tools", version = "0.8.15" }
 schemaui = { version = "0.12.0", default-features = false, optional = true }
 async-stream = "0.3.6"
 async-trait = "0.1"

--- a/npm/deepseek-tui/package.json
+++ b/npm/deepseek-tui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-tui",
-  "version": "0.8.14",
-  "deepseekBinaryVersion": "0.8.14",
+  "version": "0.8.15",
+  "deepseekBinaryVersion": "0.8.15",
   "description": "Install and run deepseek and deepseek-tui binaries from GitHub release artifacts.",
   "author": "Hmbown",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- bump workspace, internal path dependency pins, Cargo.lock package versions, and npm wrapper metadata to 0.8.15
- update README and CHANGELOG with the 0.8.15 auth, Windows, ACP/Zed, cost-currency, skills, and reliability fixes
- document stale DEEPSEEK_API_KEY recovery and add cost_currency to config.example.toml
- thank the community contributors whose small fixes landed in this release lane

## Test plan
- ./scripts/release/check-versions.sh
- cargo fmt --all -- --check
- git diff --check
- cargo test --workspace --all-features --locked
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- cargo build --release --locked
- node scripts/release/npm-wrapper-smoke.js
- cargo install --path crates/cli --locked --force
- cargo install --path crates/tui --locked --force
- deepseek --version
- deepseek-tui --version
- deepseek doctor

## Notes
- This only prepares 0.8.15. It does not tag, publish crates, publish npm, or create a GitHub release.
- Local doctor confirms the new env-only key guidance: the active key came from DEEPSEEK_API_KEY and no saved config key is present, so the installed 0.8.15 build now points users to deepseek auth set --provider deepseek.