### PR TITLE
docs: list `deepseek update` in README command tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ deepseek pr <N>                                  # fetch PR and pre-seed review 
 deepseek mcp list                                # list configured MCP servers
 deepseek mcp validate                            # validate MCP config/connectivity
 deepseek mcp-server                              # run dispatcher MCP stdio server
+deepseek update                                  # check for and apply binary updates
 ```
 
 ### Zed / ACP

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -213,6 +213,7 @@ deepseek pr <N>                                # 获取 PR 并预填审查提示
 deepseek mcp list                              # 列出已配置 MCP 服务器
 deepseek mcp validate                          # 校验 MCP 配置和连接
 deepseek mcp-server                            # 启动 dispatcher MCP stdio 服务器
+deepseek update                                # 检查并应用二进制更新
 ```
 
 ### 常用快捷键


### PR DESCRIPTION
## Summary

Surface the existing `deepseek update` self-update command in the
English and Chinese README command listings so users can discover it
without reading source. The `deepseek update` subcommand has shipped
since the dispatcher gained `crates/cli/src/update.rs`.

This integration takes only the README slice from #838. The startup
GitHub-Releases polling check from the same PR is intentionally
deferred until it can be made opt-in / config-backed, so v0.8.15 does
not ship an unconditional network call or perceptible startup latency.

Integrates #838.

## Test plan

- [x] Docs-only change; no build impact
- [ ] CI: docs lint + workflow checks

Co-authored-by: leo119 <leo.hou0924@gmail.com>