### PR TITLE
feat(fork): print confirmation with new session id

### DIFF
--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -75,7 +75,7 @@ use crate::features::{Feature, render_feature_table};
 use crate::llm_client::LlmClient;
 use crate::mcp::{McpConfig, McpPool, McpServerConfig};
 use crate::models::{ContentBlock, Message, MessageRequest, SystemPrompt};
-use crate::session_manager::{SessionManager, create_saved_session};
+use crate::session_manager::{SessionManager, create_saved_session, truncate_id};
 use crate::tui::history::{summarize_tool_args, summarize_tool_output};
 
 #[cfg(windows)]
@@ -2660,6 +2660,19 @@ fn fork_session(session_id: Option<String>, last: bool, workspace: &Path) -> Res
         system_prompt.as_ref(),
     );
     manager.save_session(&forked)?;
+
+    let source_title = saved.metadata.title.trim();
+    let source_label = if source_title.is_empty() {
+        "session".to_string()
+    } else {
+        format!("\"{source_title}\"")
+    };
+    println!(
+        "Forked {source_label} ({source_id}) → new session {new_id}",
+        source_id = truncate_id(&saved.metadata.id),
+        new_id = truncate_id(&forked.metadata.id),
+    );
+
     Ok(forked.metadata.id)
 }
 


### PR DESCRIPTION
## Summary

After `deepseek fork` saves the forked session, surface the source
session title and the truncated source/new session ids so the user
sees what was created before the TUI takes over the screen.

```
$ deepseek fork --last
Forked "Refactor exec policy" (5b3c1a2f) → new session 9e0d4f12
```

## Differences from upstream

- Reuses the existing `session_manager::truncate_id` helper instead
  of defining a second `truncate_id` in `main.rs` (the original PR
  duplicated it).
- Guards against an empty saved-title string so the line stays
  readable for unnamed sessions.

This is a UX-only addition that does not address the broader
`/fork` workflow request from #576; that one is asking for an
in-TUI fork picker, which is out of scope for v0.8.15.

Integrates #600.

## Test plan

- [x] `cargo build -p deepseek-tui --tests`
- [x] `cargo clippy -p deepseek-tui --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`

Co-authored-by: macworkers <Mann_Juarezxgs@cash4u.com>