### PR TITLE
feat(prompts): inject deterministic Environment block in system prompt

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -143,6 +143,11 @@ pub struct EngineConfig {
     /// consulted when `memory_enabled` is `true`.
     pub memory_path: PathBuf,
     pub goal_objective: Option<String>,
+    /// Resolved BCP-47 locale tag (e.g. `"en"`, `"zh-Hans"`, `"ja"`)
+    /// for the `## Environment` block in the system prompt. The
+    /// caller resolves this from `Settings` once at engine
+    /// construction; the engine never touches disk for it.
+    pub locale_tag: String,
     /// When true, force `tool_choice: "required"` so the model always calls
     /// a tool on every turn step (V4 strict tool-following mode).
     pub strict_tool_mode: bool,
@@ -179,6 +184,7 @@ impl Default for EngineConfig {
             memory_path: PathBuf::from("./memory.md"),
             strict_tool_mode: false,
             goal_objective: None,
+            locale_tag: "en".to_string(),
             workshop: None,
         }
     }
@@ -433,6 +439,7 @@ impl Engine {
                 prompts::PromptSessionContext {
                     user_memory_block: user_memory_block.as_deref(),
                     goal_objective: config.goal_objective.as_deref(),
+                    locale_tag: &config.locale_tag,
                 },
                 session.approval_mode,
             );
@@ -1825,6 +1832,7 @@ impl Engine {
             prompts::PromptSessionContext {
                 user_memory_block: user_memory_block.as_deref(),
                 goal_objective: self.config.goal_objective.as_deref(),
+                locale_tag: &self.config.locale_tag,
             },
             self.session.approval_mode,
         );

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -4045,6 +4045,11 @@ async fn run_exec_agent(
         memory_path: config.memory_path(),
         strict_tool_mode: config.strict_tool_mode.unwrap_or(false),
         goal_objective: None,
+        locale_tag: crate::localization::resolve_locale(
+            &crate::settings::Settings::load().unwrap_or_default().locale,
+        )
+        .tag()
+        .to_string(),
         workshop: config.workshop.clone(),
     };
 

--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -17,6 +17,12 @@ use std::path::{Path, PathBuf};
 pub struct PromptSessionContext<'a> {
     pub user_memory_block: Option<&'a str>,
     pub goal_objective: Option<&'a str>,
+    /// Resolved BCP-47 locale tag for the `## Environment` block in
+    /// the system prompt (e.g. `"en"`, `"zh-Hans"`, `"ja"`). The
+    /// caller is responsible for resolving this from `Settings`; no
+    /// disk I/O happens inside the prompt builder, so the workspace-
+    /// static portion of the system prompt stays cache-friendly.
+    pub locale_tag: &'a str,
 }
 
 /// Conventional location for the structured session-handoff artifact (#32).
@@ -31,6 +37,30 @@ pub const HANDOFF_RELATIVE_PATH: &str = ".deepseek/handoff.md";
 /// its own. Files larger than this are truncated with an `[…elided]`
 /// marker rather than skipped entirely so the model still sees the head.
 const INSTRUCTIONS_FILE_MAX_BYTES: usize = 100 * 1024;
+
+/// Render a `## Environment` block listing the resolved locale tag,
+/// host platform, login shell, and current working directory.
+///
+/// The block is appended to the workspace-static portion of the
+/// system prompt (after mode prompt + project context, before
+/// configured instructions / skills) so the `## Language` directive
+/// in `prompts/base.md` can reference it without the model having to
+/// guess from the user's first message. `locale_tag` is resolved by
+/// the caller from `Settings` so this function stays I/O-free.
+fn render_environment_block(workspace: &Path, locale_tag: &str) -> String {
+    let platform = std::env::consts::OS;
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| "unknown".to_string());
+    let pwd = workspace.display();
+
+    format!(
+        "## Environment\n\
+         \n\
+         - lang: {locale_tag}\n\
+         - platform: {platform}\n\
+         - shell: {shell}\n\
+         - pwd: {pwd}"
+    )
+}
 
 /// Render the `instructions = [...]` config array as a single
 /// system-prompt block (#454). Each path is loaded in declared order;
@@ -301,6 +331,7 @@ pub fn system_prompt_for_mode_with_context_and_skills(
         PromptSessionContext {
             user_memory_block,
             goal_objective: None,
+            locale_tag: "en",
         },
     )
 }
@@ -350,6 +381,17 @@ pub fn system_prompt_for_mode_with_context_skills_session_and_approval(
             mode_prompt, summary, tree
         )
     };
+
+    // 2.25. Environment block — locale, platform, shell, pwd. All
+    // four inputs are session-stable (workspace path is fixed for
+    // the run; locale is loaded once by the caller; platform/shell
+    // come from process env). Inserted above instructions/skills so
+    // it remains in the workspace-static cache layer alongside the
+    // mode prompt and project context.
+    full_prompt = format!(
+        "{full_prompt}\n\n{}",
+        render_environment_block(workspace, session_context.locale_tag),
+    );
 
     // 2.5a. Configured `instructions = [...]` files (#454). Loaded
     // and concatenated in declared order. Lives above the skills
@@ -474,6 +516,39 @@ mod tests {
     /// Discriminator unique to the injected handoff block (not present in the
     /// agent prompt's own discussion of the convention).
     const HANDOFF_BLOCK_MARKER: &str = "left a handoff at `.deepseek/handoff.md`";
+
+    #[test]
+    fn render_environment_block_lists_supplied_locale_and_workspace() {
+        let tmp = tempdir().expect("tempdir");
+        let block = render_environment_block(tmp.path(), "zh-Hans");
+        assert!(block.starts_with("## Environment"));
+        assert!(block.contains("- lang: zh-Hans"));
+        assert!(block.contains(&format!("- pwd: {}", tmp.path().display())));
+        assert!(block.contains("- platform:"));
+        assert!(block.contains("- shell:"));
+    }
+
+    #[test]
+    fn environment_block_is_inserted_into_system_prompt() {
+        let tmp = tempdir().expect("tempdir");
+        let prompt = match system_prompt_for_mode_with_context_skills_and_session(
+            AppMode::Agent,
+            tmp.path(),
+            None,
+            None,
+            None,
+            PromptSessionContext {
+                user_memory_block: None,
+                goal_objective: None,
+                locale_tag: "ja",
+            },
+        ) {
+            SystemPrompt::Text(text) => text,
+            SystemPrompt::Blocks(_) => panic!("expected text system prompt"),
+        };
+        assert!(prompt.contains("## Environment"));
+        assert!(prompt.contains("- lang: ja"));
+    }
 
     #[test]
     fn handoff_artifact_is_prepended_to_system_prompt_when_present() {
@@ -607,6 +682,7 @@ mod tests {
             PromptSessionContext {
                 user_memory_block: None,
                 goal_objective: Some("Fix transcript corruption"),
+                locale_tag: "en",
             },
         ) {
             SystemPrompt::Text(text) => text,
@@ -633,6 +709,7 @@ mod tests {
             PromptSessionContext {
                 user_memory_block: None,
                 goal_objective: Some("   "),
+                locale_tag: "en",
             },
         ) {
             SystemPrompt::Text(text) => text,

--- a/crates/tui/src/prompts/base.md
+++ b/crates/tui/src/prompts/base.md
@@ -2,7 +2,7 @@ You are DeepSeek TUI. You're already running inside it — don't try to launch a
 
 ## Language
 
-Detect the language the user writes in and respond in that same language — including your internal reasoning. If the user writes in Simplified Chinese (简体中文), your `reasoning_content` and final reply must both be in Simplified Chinese. If they switch languages mid-conversation, switch with them. The default when no clear signal is present is English.
+Use the language indicated by the `lang` field in the `## Environment` section as your default — both for `reasoning_content` and for the final reply. For example, when `lang` resolves to a Simplified Chinese tag (`zh-Hans`, `zh-CN`, …) reason and reply in Simplified Chinese; when it is `ja` use Japanese. If the user writes in a different language during the session, switch with them. When `lang` is missing or ambiguous, fall back to detecting the user's writing.
 
 Code, file paths, identifiers, tool names, environment variables, command-line flags, URLs, and log lines stay in their original form — translating `read_file` to `读取文件` would break tool calls. Only natural-language prose mirrors the user.
 

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -1836,6 +1836,11 @@ impl RuntimeThreadManager {
             memory_path: self.config.memory_path(),
             strict_tool_mode: self.config.strict_tool_mode.unwrap_or(false),
             goal_objective: None,
+            locale_tag: crate::localization::resolve_locale(
+                &crate::settings::Settings::load().unwrap_or_default().locale,
+            )
+            .tag()
+            .to_string(),
             workshop: self.config.workshop.clone(),
         };
 

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -564,6 +564,7 @@ fn build_engine_config(app: &App, config: &Config) -> EngineConfig {
         memory_path: config.memory_path(),
         strict_tool_mode: config.strict_tool_mode.unwrap_or(false),
         goal_objective: app.goal.goal_objective.clone(),
+        locale_tag: app.ui_locale.tag().to_string(),
         workshop: config.workshop.clone(),
     }
 }
@@ -3357,6 +3358,7 @@ async fn dispatch_user_message(
             prompts::PromptSessionContext {
                 user_memory_block: None,
                 goal_objective: app.goal.goal_objective.as_deref(),
+                locale_tag: app.ui_locale.tag(),
             },
         ),
     );


### PR DESCRIPTION
## Summary

Replace the model's first-message language detection with a
deterministic `## Environment` block at the top of the workspace-
static portion of the system prompt. The block lists:

- `lang`     — resolved BCP-47 tag (`en`, `zh-Hans`, `ja`, `pt-BR`)
- `platform` — `std::env::consts::OS`
- `shell`    — `\$SHELL` (or `unknown`)
- `pwd`      — workspace path

`base.md`'s `## Language` directive now points the model at the
`lang` field instead of asking it to guess from the user's first
turn. When `lang` is missing or ambiguous the existing detect-from-
writing fallback still applies.

## Cache safety

The block is injected at \"step 2.25\" — after mode prompt + project
context, before the configured `instructions` files and the skills
section — so it lives in the same workspace-static cache layer as
the surrounding blocks. All four inputs (locale tag, platform,
shell, pwd) are resolved once per session and stay byte-stable
across turns, preserving prefix-cache hits.

`render_environment_block` is I/O-free: callers pass the resolved
locale tag in `PromptSessionContext.locale_tag` /
`EngineConfig.locale_tag`. `resolve_locale(...)` is invoked once
when constructing the engine config in `tui::ui`,
`runtime_threads`, and `run_exec_agent`.

Integrates #813.

## Test plan

- [x] `cargo test -p deepseek-tui --bin deepseek-tui` (2224 passed, 2 ignored)
- [x] `cargo test -p deepseek-tui-core --test snapshot --locked`
- [x] `cargo clippy -p deepseek-tui --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- New tests:
  - `render_environment_block_lists_supplied_locale_and_workspace`
  - `environment_block_is_inserted_into_system_prompt`

Co-authored-by: lloydzhou <lloydzhou@qq.com>