### PR TITLE
fix(config): handle empty/corrupted config files gracefully (#767)

### DIFF
--- a/crates/tui/src/commands/network.rs
+++ b/crates/tui/src/commands/network.rs
@@ -154,7 +154,22 @@ fn load_config_doc(path: &Path) -> anyhow::Result<Value> {
     }
     let raw = fs::read_to_string(path)
         .with_context(|| format!("failed to read config at {}", path.display()))?;
-    toml::from_str(&raw).with_context(|| format!("failed to parse config at {}", path.display()))
+
+    // Handle empty or whitespace-only config files gracefully
+    if raw.trim().is_empty() {
+        return Ok(Value::Table(toml::value::Table::new()));
+    }
+
+    toml::from_str(&raw).with_context(|| {
+        format!(
+            "failed to parse config at {}\n\n\
+             The config file may be corrupted. You can:\n\
+             1. Fix the TOML syntax manually\n\
+             2. Delete the file and run `deepseek` again to regenerate it\n\
+             3. Run `deepseek config path` to see the file location",
+            path.display()
+        )
+    })
 }
 
 fn save_config_doc(path: &Path, doc: &Value) -> anyhow::Result<()> {

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -951,9 +951,31 @@ impl Config {
             if path.exists() {
                 let contents = fs::read_to_string(path)
                     .with_context(|| format!("Failed to read config file: {}", path.display()))?;
-                let parsed: ConfigFile = toml::from_str(&contents)
-                    .with_context(|| format!("Failed to parse config file: {}", path.display()))?;
-                apply_profile(parsed, profile)?
+
+                // Handle empty or whitespace-only config files gracefully
+                if contents.trim().is_empty() {
+                    tracing::warn!(
+                        target: "deepseek_tui::config",
+                        path = %path.display(),
+                        "Config file is empty; using defaults"
+                    );
+                    Config::default()
+                } else {
+                    match toml::from_str::<ConfigFile>(&contents) {
+                        Ok(parsed) => apply_profile(parsed, profile)?,
+                        Err(e) => {
+                            let path_display = path.display();
+                            anyhow::bail!(
+                                "Failed to parse config file at {path_display}\n\n\
+                                 Error: {e}\n\n\
+                                 The config file may be corrupted. You can:\n\
+                                 1. Fix the TOML syntax manually\n\
+                                 2. Delete the file and run `deepseek` again to regenerate it\n\
+                                 3. Run `deepseek config path` to see the file location"
+                            );
+                        }
+                    }
+                }
             } else {
                 Config::default()
             }

--- a/crates/tui/src/execpolicy/rules.rs
+++ b/crates/tui/src/execpolicy/rules.rs
@@ -34,11 +34,7 @@ impl ExecPolicyConfig {
     pub fn from_str(contents: &str) -> Result<Self> {
         // Handle empty or whitespace-only config files gracefully
         if contents.trim().is_empty() {
-            return Ok(Self {
-                rules: std::collections::HashMap::new(),
-                allow: Vec::new(),
-                deny: Vec::new(),
-            });
+            return Ok(Self::default());
         }
 
         toml::from_str(contents).context(

--- a/crates/tui/src/execpolicy/rules.rs
+++ b/crates/tui/src/execpolicy/rules.rs
@@ -32,7 +32,21 @@ pub struct RuleSet {
 
 impl ExecPolicyConfig {
     pub fn from_str(contents: &str) -> Result<Self> {
-        toml::from_str(contents).context("failed to parse execpolicy.toml")
+        // Handle empty or whitespace-only config files gracefully
+        if contents.trim().is_empty() {
+            return Ok(Self {
+                rules: std::collections::HashMap::new(),
+                allow: Vec::new(),
+                deny: Vec::new(),
+            });
+        }
+
+        toml::from_str(contents).context(
+            "failed to parse execpolicy.toml\n\n\
+             The config file may be corrupted. You can:\n\
+             1. Fix the TOML syntax manually\n\
+             2. Delete the file to reset to defaults",
+        )
     }
 
     pub fn from_path(path: &Path) -> Result<Self> {

--- a/crates/tui/src/mcp_server.rs
+++ b/crates/tui/src/mcp_server.rs
@@ -43,8 +43,23 @@ impl McpServerSettings {
         if let Some(path) = path.filter(|p| p.exists()) {
             let contents = std::fs::read_to_string(&path)
                 .with_context(|| format!("Failed to read MCP server config: {}", path.display()))?;
+
+            // Handle empty or whitespace-only config files gracefully
+            if contents.trim().is_empty() {
+                return Ok(Self {
+                    expose_tools: default_expose_tools(),
+                    require_approval: false,
+                });
+            }
+
             let config: McpServerConfigFile = toml::from_str(&contents).with_context(|| {
-                format!("Failed to parse MCP server config: {}", path.display())
+                format!(
+                    "Failed to parse MCP server config: {}\n\n\
+                     The config file may be corrupted. You can:\n\
+                     1. Fix the TOML syntax manually\n\
+                     2. Delete the file to reset to defaults",
+                    path.display()
+                )
             })?;
             let expose_tools = config
                 .server

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -122,8 +122,21 @@ impl TuiPrefs {
         }
         let content = std::fs::read_to_string(&path)
             .with_context(|| format!("Failed to read tui.toml from {}", path.display()))?;
-        let prefs: TuiPrefs = toml::from_str(&content)
-            .with_context(|| format!("Failed to parse tui.toml from {}", path.display()))?;
+
+        // Handle empty or whitespace-only config files gracefully
+        if content.trim().is_empty() {
+            return Ok(Self::default());
+        }
+
+        let prefs: TuiPrefs = toml::from_str(&content).with_context(|| {
+            format!(
+                "Failed to parse tui.toml from {}\n\n\
+                 The settings file may be corrupted. You can:\n\
+                 1. Fix the TOML syntax manually\n\
+                 2. Delete the file to reset settings to defaults",
+                path.display()
+            )
+        })?;
         Ok(prefs)
     }
 


### PR DESCRIPTION
## Summary

- Handle empty or whitespace-only config files gracefully by returning defaults
- Improve error messages with recovery instructions when config parsing fails
- Fixes the crash when running `deepseek` after fresh install on Windows

## Problem

After `npm install -g deepseek-tui`, running `deepseek` crashes with:
```
failed to parse config at C:\Users\xxxx\.deepseek\config.toml
```

This happens because:
1. The config file may be empty or contain only whitespace
2. The error message provides no recovery guidance

## Solution

All config file parsers now:
1. Check for empty/whitespace-only content and return defaults
2. Provide helpful error messages with three recovery options:
   - Fix the TOML syntax manually
   - Delete the file to regenerate it
   - Run `deepseek config path` to locate the file

## Changes

| File | Change |
|------|--------|
| `config.rs` | Main config: empty → defaults + warning log |
| `network.rs` | Network config: empty → empty table |
| `settings.rs` | TUI settings: empty → defaults |
| `mcp_server.rs` | MCP config: empty → defaults |
| `execpolicy/rules.rs` | Exec policy: empty → empty config |

Fixes #767
