### PR TITLE
ci(release): build Linux artifacts natively

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,12 +64,10 @@ jobs:
           # --- deepseek (cli) ---
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            target_zig: x86_64-unknown-linux-gnu.2.28
             binary: deepseek
             artifact_name: deepseek-linux-x64
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
-            target_zig: aarch64-unknown-linux-gnu.2.28
             binary: deepseek
             artifact_name: deepseek-linux-arm64
           - os: macos-latest
@@ -87,12 +85,10 @@ jobs:
           # --- deepseek-tui (TUI) ---
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            target_zig: x86_64-unknown-linux-gnu.2.28
             binary: deepseek-tui
             artifact_name: deepseek-tui-linux-x64
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
-            target_zig: aarch64-unknown-linux-gnu.2.28
             binary: deepseek-tui
             artifact_name: deepseek-tui-linux-arm64
           - os: macos-latest
@@ -123,62 +119,12 @@ jobs:
             sleep 15
           done
           sudo apt-get install -y libdbus-1-dev pkg-config
-      - name: Install zig
-        if: runner.os == 'Linux'
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          case "$(uname -m)" in
-            x86_64) zig_arch="x86_64" ;;
-            aarch64|arm64) zig_arch="aarch64" ;;
-            *)
-              echo "Unsupported Linux architecture for Zig: $(uname -m)" >&2
-              exit 1
-              ;;
-          esac
-
-          zig_version="0.13.0"
-          zig_dir="zig-linux-${zig_arch}-${zig_version}"
-          zig_url="https://ziglang.org/download/${zig_version}/${zig_dir}.tar.xz"
-
-          for attempt in 1 2 3 4 5; do
-            if curl -fsSL \
-              --connect-timeout 20 \
-              --max-time 180 \
-              --speed-limit 1024 \
-              --speed-time 30 \
-              --retry 2 \
-              --retry-delay 5 \
-              --retry-all-errors \
-              "${zig_url}" \
-              -o zig.tar.xz; then
-              break
-            fi
-            echo "Zig download failed (attempt ${attempt}); retrying in 15s"
-            sleep 15
-          done
-
-          tar -xf zig.tar.xz
-          echo "${PWD}/${zig_dir}" >> "${GITHUB_PATH}"
-          "${PWD}/${zig_dir}/zig" version
-      - name: Install cargo-zigbuild
-        if: runner.os == 'Linux'
-        run: cargo install cargo-zigbuild --locked
       - name: Build
         shell: bash
-        run: |
-          if [ -n "${{ matrix.target_zig }}" ]; then
-            cargo zigbuild --release --locked --target ${{ matrix.target_zig }}
-          else
-            cargo build --release --locked --target ${{ matrix.target }}
-          fi
+        run: cargo build --release --locked --target ${{ matrix.target }}
       - name: Rename binary
         shell: bash
         run: |
-          # cargo zigbuild writes binaries to target/<rust-target>/release/ —
-          # the .glibc suffix in matrix.target_zig is consumed by zig as a CC
-          # flag, not by cargo as a target dir. Always use the rust target.
           BIN_PATH="target/${{ matrix.target }}/release/${{ matrix.binary }}"
           if [ ! -f "${BIN_PATH}" ]; then
             echo "Binary not at ${BIN_PATH}; searching target/ for ${{ matrix.binary }}:"


### PR DESCRIPTION
## Summary
- remove Zig/cargo-zigbuild from the release artifact workflow
- build Linux x64 and Linux ARM64 artifacts natively on matching GitHub runners
- keeps v0.8.15 release publishing unblocked after repeated setup-zig download failures and hangs

## Test plan
- ruby YAML parse check for .github/workflows/release.yml
- grep verified no remaining zig/target_zig/cargo-zigbuild references in release.yml

Tradeoff: Linux release artifacts now target the runner glibc instead of Zig's glibc 2.28 target. This is preferable to a blocked release for v0.8.15; we can reintroduce older-glibc builds later through a less flaky path.