### PR TITLE
docs: update thanks and package-manager notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,11 +153,8 @@ Prebuilt binaries can also be downloaded from [GitHub Releases](https://github.c
 
 ### Windows (Scoop)
 
-[Scoop](https://scoop.sh) is a Windows package manager. Once installed, run:
-
-```bash
-scoop install deepseek-tui
-```
+A Scoop manifest has not been published yet. For now, use npm, Cargo, or the
+prebuilt Windows binaries from [GitHub Releases](https://github.com/Hmbown/DeepSeek-TUI/releases).
 
 
 <details id="install-from-source">
@@ -401,16 +398,27 @@ This project ships with help from a growing community of contributors:
 - **[toi500](https://github.com/toi500)** — Windows paste fix report
 - **[xsstomy](https://github.com/xsstomy)** — Terminal startup repaint report
 - **[melody0709](https://github.com/melody0709)** — Slash-prefix Enter activation report
-- **[lloydzhou](https://github.com/lloydzhou)** and **[jeoor](https://github.com/jeoor)** — Compaction cost reports
+- **[lloydzhou](https://github.com/lloydzhou)** and **[jeoor](https://github.com/jeoor)** — Compaction cost reports; lloydzhou also contributed deterministic environment context (#813, #922)
 - **[Agent-Skill-007](https://github.com/Agent-Skill-007)** — README clarity pass (#685)
-- **[woyxiang](https://github.com/woyxiang)** — Windows Scoop install docs (#696)
+- **[woyxiang](https://github.com/woyxiang)** — Windows install documentation (#696)
 - **[wangfeng](mailto:wangfengcsu@qq.com)** — Pricing/discount info update (#692)
 - **[zichen0116](https://github.com/zichen0116)** — CODE_OF_CONDUCT.md (#686)
 - **[dfwqdyl-ui](https://github.com/dfwqdyl-ui)** — model ID case-sensitivity compatibility report (#729)
 - **[Oliver-ZPLiu](https://github.com/Oliver-ZPLiu)** — stale `working...` state bug report and Windows clipboard fallback (#738, #850)
-- **[reidliu41](https://github.com/reidliu41)** — resume hint and workspace trust persistence fixes (#863, #870)
+- **[reidliu41](https://github.com/reidliu41)** — resume hint, workspace trust persistence, and Ollama provider support (#863, #870, #921)
 - **[xieshutao](https://github.com/xieshutao)** — plain Markdown skill fallback (#869)
 - **[GK012](https://github.com/GK012)** — npm wrapper `--version` fallback (#885)
+- **[y0sif](https://github.com/y0sif)** — parent turn-loop wakeup after direct child sub-agent completion (#901)
+- **[mac119](https://github.com/mac119)** and **[leo119](https://github.com/leo119)** — `deepseek update` command documentation (#838, #917)
+- **[dumbjack](https://github.com/dumbjack)** / **浩淼的mac** — command-safety null-byte hardening (#706, #918)
+- **macworkers** — fork confirmation with the new session id (#600, #919)
+- **zero** and **[zerx-lab](https://github.com/zerx-lab)** — notification condition config and richer OSC 9 notification body (#820, #920)
+- **[chnjames](https://github.com/chnjames)** — cached @mention completions and config recovery polish (#849, #927)
+- **[angziii](https://github.com/angziii)** — config safety, async cleanup, Docker hardening, and command-safety fixes (#822, #824, #827, #831, #833, #835, #837)
+- **[elowen53](https://github.com/elowen53)** — UTF-8 decoding and deterministic test coverage (#825, #840)
+- **[wdw8276](https://github.com/wdw8276)** — `/rename` command for custom session titles (#836)
+- **[banqii](https://github.com/banqii)** — `.cursor/skills` discovery path support (#817)
+- **[junskyeed](https://github.com/junskyeed)** — dynamic `max_tokens` calculation for API requests (#826)
 - **Hafeez Pizofreude** — SSRF protection in `fetch_url` and Star History chart
 - **Unic (YuniqueUnic)** — Schema-driven config UI (TUI + web)
 - **Jason** — SSRF security hardening

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -128,11 +128,8 @@ deepseek --version
 
 ### Windows (Scoop)
 
-[Scoop](https://scoop.sh) 是一个 Windows 软件包管理器。安装好 Scoop 后，运行：
-
-```bash
-scoop install deepseek-tui
-```
+Scoop manifest 还没有正式发布。现在请先使用 npm、Cargo，或者从
+[GitHub Releases](https://github.com/Hmbown/DeepSeek-TUI/releases) 下载 Windows 预编译二进制。
 
 
 <details id="install-from-source">
@@ -374,13 +371,27 @@ description: 当 DeepSeek 需要遵循我的自定义工作流时使用这个技
 - **[toi500](https://github.com/toi500)** — Windows 粘贴修复报告
 - **[xsstomy](https://github.com/xsstomy)** — 终端启动重绘报告
 - **[melody0709](https://github.com/melody0709)** — 斜杠前缀回车激活报告
-- **[lloydzhou](https://github.com/lloydzhou)** 和 **[jeoor](https://github.com/jeoor)** — 压缩成本报告
+- **[lloydzhou](https://github.com/lloydzhou)** 和 **[jeoor](https://github.com/jeoor)** — 压缩成本报告；lloydzhou 还贡献了确定性的环境上下文注入 (#813, #922)
 - **[Agent-Skill-007](https://github.com/Agent-Skill-007)** — README 清晰化改进 (#685)
-- **[woyxiang](https://github.com/woyxiang)** — Windows Scoop 安装文档 (#696)
+- **[woyxiang](https://github.com/woyxiang)** — Windows 安装文档 (#696)
 - **[wangfeng](mailto:wangfengcsu@qq.com)** — 价格/折扣信息更新 (#692)
 - **[zichen0116](https://github.com/zichen0116)** — CODE_OF_CONDUCT.md (#686)
 - **[dfwqdyl-ui](https://github.com/dfwqdyl-ui)** — 模型 ID 大小写兼容性报告 (#729)
-- **[Oliver-ZPLiu](https://github.com/Oliver-ZPLiu)** — `working...` 卡死状态 Bug 报告，含详细复现步骤和修复建议 (#738)
+- **[Oliver-ZPLiu](https://github.com/Oliver-ZPLiu)** — `working...` 卡死状态 Bug 报告和 Windows 剪贴板兜底修复 (#738, #850)
+- **[reidliu41](https://github.com/reidliu41)** — 退出后的恢复提示、工作区信任持久化，以及 Ollama provider 支持 (#863, #870, #921)
+- **[xieshutao](https://github.com/xieshutao)** — 纯 Markdown skill 兜底解析 (#869)
+- **[GK012](https://github.com/GK012)** — npm wrapper 的 `--version` 兜底 (#885)
+- **[y0sif](https://github.com/y0sif)** — 直接子智能体完成后唤醒父级 turn loop (#901)
+- **[mac119](https://github.com/mac119)** 和 **[leo119](https://github.com/leo119)** — `deepseek update` 命令文档 (#838, #917)
+- **[dumbjack](https://github.com/dumbjack)** / **浩淼的mac** — shell 命令空字节安全加固 (#706, #918)
+- **macworkers** — fork 完成后显示新 session id (#600, #919)
+- **zero** 和 **[zerx-lab](https://github.com/zerx-lab)** — 通知条件配置和更完整的 OSC 9 通知正文 (#820, #920)
+- **[chnjames](https://github.com/chnjames)** — @mention 补全缓存和配置恢复优化 (#849, #927)
+- **[angziii](https://github.com/angziii)** — 配置安全、异步清理、Docker 加固和命令安全修复 (#822, #824, #827, #831, #833, #835, #837)
+- **[elowen53](https://github.com/elowen53)** — UTF-8 解码和确定性测试覆盖 (#825, #840)
+- **[wdw8276](https://github.com/wdw8276)** — 用于自定义 session 标题的 `/rename` 命令 (#836)
+- **[banqii](https://github.com/banqii)** — `.cursor/skills` 发现路径支持 (#817)
+- **[junskyeed](https://github.com/junskyeed)** — API 请求动态 `max_tokens` 计算 (#826)
 - **Hafeez Pizofreude** — `fetch_url` 的 SSRF 保护和 Star History 图表
 - **Unic (YuniqueUnic)** — 基于 schema 的配置 UI（TUI + web）
 - **Jason** — SSRF 安全加固


### PR DESCRIPTION
## Summary
- add the v0.8.15 contributor wave to the English and Chinese Thanks sections
- keep contributor credit aligned with integration commit Co-authored-by trailers and verified GitHub authors where available
- stop telling Windows users to run `scoop install deepseek-tui` before a Scoop manifest exists

## Test plan
- `git diff --check`
- verified npm global install separately: `deepseek` and `deepseek-tui` wrappers report v0.8.15