### PR TITLE
fix(release): make package-channel docs truthful

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,6 +139,10 @@ jobs:
   docker:
     needs: build
     if: ${{ !cancelled() && needs.build.result == 'success' }}
+    # Docker/GHCR is experimental and not a supported release channel yet.
+    # Keep binary GitHub Releases publishable while the arm64 image build path
+    # is hardened separately.
+    continue-on-error: true
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/README.md
+++ b/README.md
@@ -153,8 +153,19 @@ Prebuilt binaries can also be downloaded from [GitHub Releases](https://github.c
 
 ### Windows (Scoop)
 
-A Scoop manifest has not been published yet. For now, use npm, Cargo, or the
-prebuilt Windows binaries from [GitHub Releases](https://github.com/Hmbown/DeepSeek-TUI/releases).
+[Scoop](https://scoop.sh) is a Windows package manager. DeepSeek TUI is listed
+in Scoop's main bucket, but that manifest updates independently and can lag the
+GitHub/npm/Cargo release. Run `scoop update` first, then verify the installed
+version with `deepseek --version`:
+
+```bash
+scoop update
+scoop install deepseek-tui
+deepseek --version
+```
+
+Use npm or direct GitHub release downloads when you need the newest release
+before Scoop's manifest catches up.
 
 
 <details id="install-from-source">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -128,8 +128,17 @@ deepseek --version
 
 ### Windows (Scoop)
 
-Scoop manifest 还没有正式发布。现在请先使用 npm、Cargo，或者从
-[GitHub Releases](https://github.com/Hmbown/DeepSeek-TUI/releases) 下载 Windows 预编译二进制。
+[Scoop](https://scoop.sh) 是一个 Windows 软件包管理器。DeepSeek TUI 已进入
+Scoop main bucket，但该 manifest 独立更新，可能滞后于 GitHub/npm/Cargo
+release。先运行 `scoop update`，安装后用 `deepseek --version` 核对版本：
+
+```bash
+scoop update
+scoop install deepseek-tui
+deepseek --version
+```
+
+如果需要最新版本，请优先使用 npm 或直接下载 GitHub Release 资产。
 
 
 <details id="install-from-source">

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -1,20 +1,28 @@
 # Docker
 
-DeepSeek TUI ships an official multi-arch Docker image (amd64 + arm64) on
-[GitHub Container Registry](https://github.com/Hmbown/DeepSeek-TUI/pkgs/container/deepseek-tui).
+Docker support is currently a local-build/devcontainer path, not a supported
+release channel. The release workflow may try an experimental GHCR publish, but
+no public `ghcr.io/hmbown/deepseek-tui` image should be treated as available
+until this page says so.
 
-## Quick start
+## Local quick start
+
+Build the image locally from a checkout:
+
+```bash
+docker build -t deepseek-tui .
+```
+
+Then run it with your existing config directory mounted:
 
 ```bash
 docker run --rm -it \
   -e DEEPSEEK_API_KEY="$DEEPSEEK_API_KEY" \
   -v ~/.deepseek:/home/deepseek/.deepseek \
-  ghcr.io/hmbown/deepseek-tui:latest
+  deepseek-tui
 ```
 
-Images are published to GitHub Container Registry (GHCR) only. Docker Hub
-publishing is not currently configured — add a `docker/login-action` step
-with Hub credentials to the release workflow if needed.
+Docker Hub publishing is not configured.
 
 ## Environment variables
 
@@ -42,7 +50,7 @@ When stdin is not a TTY, `deepseek` drops to the dispatcher's one-shot mode
 
 ```bash
 echo "Explain the Cargo.toml in structured English." | \
-  docker run --rm -i -e DEEPSEEK_API_KEY ghcr.io/hmbown/deepseek-tui:latest
+  docker run --rm -i -e DEEPSEEK_API_KEY deepseek-tui
 ```
 
 ## Building locally
@@ -63,13 +71,8 @@ configuration for VS Code / GitHub Codespaces. It pre-installs the Rust toolchai
 rust-analyzer, and the `deepseek` binary. Open the repo in a devcontainer to get a
 ready-to-use development environment.
 
-## Tags
+## Release status
 
-| Tag        | Meaning                  |
-|------------|--------------------------|
-| `latest`   | Latest stable release    |
-| `v0`       | Latest v0.x release      |
-| `0.8.9`    | Specific release version |
-
-Docker images are built and pushed automatically when a release tag is pushed
-(see [release.yml](../.github/workflows/release.yml)).
+Docker image publishing is experimental and non-blocking for releases. The
+supported distribution channels are npm, Cargo, Homebrew, GitHub Release
+assets, and Scoop's independently maintained main-bucket manifest.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -156,6 +156,20 @@ curl -L -o /tmp/deepseek-artifacts-sha256.txt \
 
 (Use `shasum -a 256 -c` instead of `sha256sum` on macOS.)
 
+### Windows Scoop
+
+DeepSeek TUI is listed in Scoop's main bucket:
+
+```powershell
+scoop update
+scoop install deepseek-tui
+deepseek --version
+```
+
+Scoop manifests are maintained outside this repository's release workflow and
+can lag GitHub/npm/Cargo releases. Use npm or manual GitHub release downloads
+when you need the newest version immediately.
+
 ---
 
 ## 5. Build from source


### PR DESCRIPTION
Closes #944.

Supersedes #946, which was closed when the branch was moved out of the v0.8.16 namespace for the hotfix lane.

## Summary
- Document Scoop as a real but independently-updated Windows package channel that can lag GitHub/npm/Cargo releases.
- Stop presenting GHCR Docker images as an official supported release channel until publishing is working and public.
- Make the Docker release job non-blocking while Docker/GHCR remains experimental.

## Live evidence
- npm: `npm view deepseek-tui version --json` returned `0.8.16` on May 7, 2026.
- Scoop main bucket: `bucket/deepseek-tui.json` returned `0.8.16` on May 7, 2026.
- GHCR: `docker manifest inspect ghcr.io/hmbown/deepseek-tui:latest` returned `denied` on May 7, 2026.

## Test plan
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release.yml ok"'
- cargo test -p deepseek-tui-cli update::tests::test_asset_matching_accepts_binary_assets_and_rejects_checksums --locked
- cargo fmt --all -- --check