### PR TITLE
fix(sandbox): add Windows job object helper

### DIFF
--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -18,6 +18,10 @@ toml = ["schemaui/toml"]
 name = "deepseek-tui"
 path = "src/main.rs"
 
+[[bin]]
+name = "deepseek-windows-sandbox-helper"
+path = "src/bin/deepseek-windows-sandbox-helper.rs"
+
 [dependencies]
 anyhow = "1.0.100"
 arboard = "3.4"
@@ -81,4 +85,12 @@ libc = "0.2"
 libc = "0.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.60", features = ["Win32_Foundation", "Win32_System_Console", "Win32_UI_WindowsAndMessaging", "Win32_System_Diagnostics_Debug"] }
+windows = { version = "0.60", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_System_Console",
+    "Win32_UI_WindowsAndMessaging",
+    "Win32_System_Diagnostics_Debug",
+    "Win32_System_Threading",
+    "Win32_System_JobObjects",
+] }

--- a/crates/tui/src/bin/deepseek-windows-sandbox-helper.rs
+++ b/crates/tui/src/bin/deepseek-windows-sandbox-helper.rs
@@ -1,0 +1,261 @@
+use std::env;
+use std::ffi::OsString;
+use std::path::PathBuf;
+use std::process::{Command, ExitCode};
+use std::time::Duration;
+
+#[cfg(windows)]
+use std::os::windows::io::AsRawHandle;
+
+#[cfg(windows)]
+use wait_timeout::ChildExt;
+
+#[cfg(windows)]
+use windows::Win32::Foundation::{CloseHandle, HANDLE};
+#[cfg(windows)]
+use windows::Win32::System::JobObjects::{
+    AssignProcessToJobObject, CreateJobObjectW, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+    JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectExtendedLimitInformation,
+    SetInformationJobObject, TerminateJobObject,
+};
+#[cfg(windows)]
+use windows::core::PCWSTR;
+
+#[derive(Debug, PartialEq, Eq)]
+enum HelperMode {
+    SelfTest,
+    Contain {
+        cwd: PathBuf,
+        timeout: Duration,
+        program: OsString,
+        args: Vec<OsString>,
+    },
+}
+
+fn main() -> ExitCode {
+    match real_main() {
+        Ok(code) => ExitCode::from(code),
+        Err(err) => {
+            eprintln!("deepseek-windows-sandbox-helper: {err}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+fn real_main() -> anyhow::Result<u8> {
+    match parse_args(env::args_os().skip(1))? {
+        HelperMode::SelfTest => self_test(),
+        HelperMode::Contain {
+            cwd,
+            timeout,
+            program,
+            args,
+        } => run_contained(cwd, timeout, program, args),
+    }
+}
+
+fn parse_args<I>(args: I) -> anyhow::Result<HelperMode>
+where
+    I: IntoIterator<Item = OsString>,
+{
+    let mut args = args.into_iter();
+    let Some(first) = args.next() else {
+        anyhow::bail!("expected --self-test or --contain");
+    };
+
+    if first == "--self-test" {
+        if args.next().is_some() {
+            anyhow::bail!("--self-test does not accept extra arguments");
+        }
+        return Ok(HelperMode::SelfTest);
+    }
+
+    if first != "--contain" {
+        anyhow::bail!("unknown mode: {}", first.to_string_lossy());
+    }
+
+    let mut cwd = env::current_dir()?;
+    let mut timeout = Duration::from_secs(30);
+
+    loop {
+        let Some(arg) = args.next() else {
+            anyhow::bail!("missing -- before command");
+        };
+
+        if arg == "--" {
+            break;
+        }
+
+        if arg == "--cwd" {
+            let Some(value) = args.next() else {
+                anyhow::bail!("--cwd requires a value");
+            };
+            cwd = PathBuf::from(value);
+            continue;
+        }
+
+        if arg == "--timeout-ms" {
+            let Some(value) = args.next() else {
+                anyhow::bail!("--timeout-ms requires a value");
+            };
+            let timeout_ms = value
+                .to_string_lossy()
+                .parse::<u64>()
+                .map_err(|_| anyhow::anyhow!("invalid --timeout-ms value"))?;
+            timeout = Duration::from_millis(timeout_ms);
+            continue;
+        }
+
+        anyhow::bail!("unknown option before command: {}", arg.to_string_lossy());
+    }
+
+    let Some(program) = args.next() else {
+        anyhow::bail!("missing command after --");
+    };
+
+    Ok(HelperMode::Contain {
+        cwd,
+        timeout,
+        program,
+        args: args.collect(),
+    })
+}
+
+#[cfg(windows)]
+fn self_test() -> anyhow::Result<u8> {
+    let _job = JobObject::create_kill_on_close()?;
+    Ok(0)
+}
+
+#[cfg(not(windows))]
+fn self_test() -> anyhow::Result<u8> {
+    anyhow::bail!("Windows sandbox helper is only supported on Windows")
+}
+
+#[cfg(windows)]
+fn run_contained(
+    cwd: PathBuf,
+    timeout: Duration,
+    program: OsString,
+    args: Vec<OsString>,
+) -> anyhow::Result<u8> {
+    let job = JobObject::create_kill_on_close()?;
+    let mut child = Command::new(&program)
+        .args(&args)
+        .current_dir(cwd)
+        .spawn()
+        .map_err(|err| {
+            anyhow::anyhow!(
+                "failed to spawn {}: {err}",
+                PathBuf::from(&program).display()
+            )
+        })?;
+
+    if let Err(err) = job.assign_process(&child) {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err(err);
+    }
+
+    let status = match child.wait_timeout(timeout)? {
+        Some(status) => status,
+        None => {
+            let _ = job.terminate(124);
+            let _ = child.wait();
+            return Ok(124);
+        }
+    };
+
+    Ok(status.code().unwrap_or(1).try_into().unwrap_or(1))
+}
+
+#[cfg(not(windows))]
+fn run_contained(
+    _cwd: PathBuf,
+    _timeout: Duration,
+    _program: OsString,
+    _args: Vec<OsString>,
+) -> anyhow::Result<u8> {
+    anyhow::bail!("Windows sandbox helper is only supported on Windows")
+}
+
+#[cfg(windows)]
+struct JobObject(HANDLE);
+
+#[cfg(windows)]
+impl JobObject {
+    fn create_kill_on_close() -> anyhow::Result<Self> {
+        let job = unsafe { CreateJobObjectW(None, PCWSTR::null()) }?;
+
+        let mut limits = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+        limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+
+        unsafe {
+            SetInformationJobObject(
+                job,
+                JobObjectExtendedLimitInformation,
+                &limits as *const _ as *const _,
+                std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+            )?;
+        }
+
+        Ok(Self(job))
+    }
+
+    fn assign_process(&self, child: &std::process::Child) -> anyhow::Result<()> {
+        let process = HANDLE(child.as_raw_handle());
+        unsafe { AssignProcessToJobObject(self.0, process) }?;
+        Ok(())
+    }
+
+    fn terminate(&self, exit_code: u32) -> anyhow::Result<()> {
+        unsafe { TerminateJobObject(self.0, exit_code) }?;
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+impl Drop for JobObject {
+    fn drop(&mut self) {
+        let _ = unsafe { CloseHandle(self.0) };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_self_test() {
+        assert_eq!(
+            parse_args([OsString::from("--self-test")]).unwrap(),
+            HelperMode::SelfTest
+        );
+    }
+
+    #[test]
+    fn parse_contain_command() {
+        let parsed = parse_args([
+            OsString::from("--contain"),
+            OsString::from("--cwd"),
+            OsString::from("C:\\repo"),
+            OsString::from("--timeout-ms"),
+            OsString::from("1234"),
+            OsString::from("--"),
+            OsString::from("cmd.exe"),
+            OsString::from("/C"),
+            OsString::from("echo hello"),
+        ])
+        .unwrap();
+
+        assert_eq!(
+            parsed,
+            HelperMode::Contain {
+                cwd: PathBuf::from("C:\\repo"),
+                timeout: Duration::from_millis(1234),
+                program: OsString::from("cmd.exe"),
+                args: vec![OsString::from("/C"), OsString::from("echo hello")],
+            }
+        );
+    }
+}

--- a/crates/tui/src/bin/deepseek-windows-sandbox-helper.rs
+++ b/crates/tui/src/bin/deepseek-windows-sandbox-helper.rs
@@ -1,11 +1,14 @@
 use std::env;
 use std::ffi::OsString;
 use std::path::PathBuf;
-use std::process::{Command, ExitCode};
+use std::process::ExitCode;
 use std::time::Duration;
 
 #[cfg(windows)]
 use std::os::windows::io::AsRawHandle;
+
+#[cfg(windows)]
+use std::process::Command;
 
 #[cfg(windows)]
 use wait_timeout::ChildExt;

--- a/crates/tui/src/core/engine/tool_catalog.rs
+++ b/crates/tui/src/core/engine/tool_catalog.rs
@@ -23,6 +23,10 @@ const TOOL_SEARCH_REGEX_NAME: &str = "tool_search_tool_regex";
 const TOOL_SEARCH_REGEX_TYPE: &str = "tool_search_tool_regex_20251119";
 pub(super) const TOOL_SEARCH_BM25_NAME: &str = "tool_search_tool_bm25";
 const TOOL_SEARCH_BM25_TYPE: &str = "tool_search_tool_bm25_20251119";
+#[cfg(windows)]
+const CODE_EXECUTION_PYTHON_BIN: &str = "python";
+#[cfg(not(windows))]
+const CODE_EXECUTION_PYTHON_BIN: &str = "python3";
 
 pub(super) fn is_tool_search_tool(name: &str) -> bool {
     matches!(name, TOOL_SEARCH_REGEX_NAME | TOOL_SEARCH_BM25_NAME)
@@ -445,7 +449,7 @@ pub(super) async fn execute_code_execution_tool(
     workspace: &Path,
 ) -> Result<ToolResult, ToolError> {
     let code = required_str(input, "code")?;
-    let mut cmd = tokio::process::Command::new("python3");
+    let mut cmd = tokio::process::Command::new(CODE_EXECUTION_PYTHON_BIN);
     cmd.arg("-c");
     cmd.arg(code);
     cmd.current_dir(workspace);

--- a/crates/tui/src/repl/runtime.rs
+++ b/crates/tui/src/repl/runtime.rs
@@ -122,6 +122,10 @@ pub trait RpcDispatcher: Send + Sync {
 
 const DEFAULT_STDOUT_LIMIT: usize = 8_192;
 const ROUND_TIMEOUT: Duration = Duration::from_secs(180);
+#[cfg(windows)]
+const PYTHON_BIN: &str = "python";
+#[cfg(not(windows))]
+const PYTHON_BIN: &str = "python3";
 #[cfg(not(windows))]
 const SPAWN_READY_TIMEOUT: Duration = Duration::from_secs(10);
 #[cfg(windows)]
@@ -179,7 +183,7 @@ impl PythonRuntime {
         let session_id = Uuid::new_v4().simple().to_string();
         let bootstrap = render_bootstrap(&session_id);
 
-        let mut cmd = Command::new("python3");
+        let mut cmd = Command::new(PYTHON_BIN);
         cmd.arg("-u")
             .arg("-c")
             .arg(&bootstrap)
@@ -194,16 +198,16 @@ impl PythonRuntime {
 
         let mut child = cmd
             .spawn()
-            .map_err(|e| format!("failed to spawn python3: {e}"))?;
+            .map_err(|e| format!("failed to spawn {PYTHON_BIN}: {e}"))?;
 
         let stdin = child
             .stdin
             .take()
-            .ok_or_else(|| "python3 stdin pipe missing".to_string())?;
+            .ok_or_else(|| format!("{PYTHON_BIN} stdin pipe missing"))?;
         let raw_stdout = child
             .stdout
             .take()
-            .ok_or_else(|| "python3 stdout pipe missing".to_string())?;
+            .ok_or_else(|| format!("{PYTHON_BIN} stdout pipe missing"))?;
         let stdout = BufReader::new(raw_stdout);
 
         let mut rt = Self {
@@ -226,12 +230,12 @@ impl PythonRuntime {
             Ok(Ok(())) => Ok(rt),
             Ok(Err(e)) => {
                 let _ = rt.child.kill().await;
-                Err(format!("python3 bootstrap failed: {e}"))
+                Err(format!("{PYTHON_BIN} bootstrap failed: {e}"))
             }
             Err(_) => {
                 let _ = rt.child.kill().await;
                 Err(format!(
-                    "python3 bootstrap did not signal ready within {}s",
+                    "{PYTHON_BIN} bootstrap did not signal ready within {}s",
                     SPAWN_READY_TIMEOUT.as_secs()
                 ))
             }
@@ -247,7 +251,7 @@ impl PythonRuntime {
                 .await
                 .map_err(|e| format!("stdout read: {e}"))?;
             if n == 0 {
-                return Err("python3 closed stdout before ready signal".to_string());
+                return Err(format!("{PYTHON_BIN} closed stdout before ready signal"));
             }
             let trimmed = line.trim_end_matches(['\n', '\r']);
             if trimmed == ready_sentinel {

--- a/crates/tui/src/sandbox/mod.rs
+++ b/crates/tui/src/sandbox/mod.rs
@@ -10,7 +10,7 @@
 //!
 //! - **macOS**: Uses Seatbelt (sandbox-exec) for mandatory access control
 //! - **Linux**: Uses Landlock (kernel 5.13+) for filesystem access control
-//! - **Windows**: Windows Sandbox/AppContainer/Restricted token (best-effort)
+//! - **Windows**: helper-based Job Object process-tree containment (best-effort)
 //!
 //! # Usage
 //!
@@ -170,7 +170,7 @@ pub enum SandboxType {
     #[cfg(target_os = "linux")]
     LinuxLandlock,
 
-    /// Windows sandboxing (Windows Sandbox/AppContainer/Restricted token).
+    /// Windows Job Object process-tree containment.
     #[cfg(target_os = "windows")]
     Windows,
 }
@@ -184,7 +184,7 @@ impl std::fmt::Display for SandboxType {
             #[cfg(target_os = "linux")]
             SandboxType::LinuxLandlock => write!(f, "linux-landlock"),
             #[cfg(target_os = "windows")]
-            SandboxType::Windows => write!(f, "windows-sandbox"),
+            SandboxType::Windows => write!(f, "windows-job-object"),
         }
     }
 }
@@ -418,17 +418,24 @@ impl SandboxManager {
         }
     }
 
-    /// Prepare a Windows-sandboxed execution environment.
+    /// Prepare a Windows-contained execution environment.
     ///
-    /// Note: Windows sandboxing requires a helper process for full isolation.
-    /// This implementation marks intent and defers enforcement to a helper.
+    /// The current Windows backend is process-tree containment only. It uses a
+    /// helper binary to place the command in a Job Object with kill-on-close
+    /// semantics. It does not enforce filesystem or network access policy.
     #[cfg(target_os = "windows")]
     fn prepare_windows(spec: &CommandSpec) -> ExecEnv {
-        let mut command = vec![spec.program.clone()];
-        command.extend(spec.args.clone());
+        let Some(kind) = windows::select_best_kind(&spec.sandbox_policy, &spec.cwd) else {
+            return Self::prepare_unsandboxed(spec);
+        };
+
+        let Some(command) =
+            windows::build_helper_command(&spec.program, &spec.args, spec.timeout, &spec.cwd)
+        else {
+            return Self::prepare_unsandboxed(spec);
+        };
 
         let mut env = spec.env.clone();
-        let kind = windows::select_best_kind(&spec.sandbox_policy, &spec.cwd);
         env.insert("DEEPSEEK_SANDBOX".to_string(), format!("windows:{kind}"));
         if !spec.sandbox_policy.has_network_access() {
             env.insert(

--- a/crates/tui/src/sandbox/windows.rs
+++ b/crates/tui/src/sandbox/windows.rs
@@ -1,46 +1,69 @@
-//! Windows sandbox implementation (best-effort placeholder).
+//! Windows process-containment helpers.
 //!
-//! Windows sandboxing can be implemented using:
-//! - Windows Sandbox (full isolation)
-//! - AppContainer (process isolation)
-//! - Restricted tokens (reduced privileges)
-//!
-//! This module selects a preferred approach and exposes helpers used by the
-//! sandbox manager. Full enforcement should be implemented in a helper binary.
+//! This module intentionally does **not** claim to implement filesystem or
+//! network sandboxing on Windows. The first Windows backend is a helper-runner
+//! that places the command in a Job Object with kill-on-close semantics. That
+//! prevents leaked child process trees, but it does not enforce ReadOnly or
+//! WorkspaceWrite access policies.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::OnceLock;
+use std::time::Duration;
 
 use super::SandboxPolicy;
 
+const HELPER_BIN_NAME: &str = "deepseek-windows-sandbox-helper.exe";
+static AVAILABLE_HELPER: OnceLock<Option<PathBuf>> = OnceLock::new();
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WindowsSandboxKind {
-    WindowsSandbox,
-    AppContainer,
-    RestrictedToken,
+    /// Process-tree containment via Windows Job Objects.
+    JobObjectContainment,
 }
 
 impl std::fmt::Display for WindowsSandboxKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            WindowsSandboxKind::WindowsSandbox => write!(f, "sandbox"),
-            WindowsSandboxKind::AppContainer => write!(f, "appcontainer"),
-            WindowsSandboxKind::RestrictedToken => write!(f, "restricted-token"),
+            WindowsSandboxKind::JobObjectContainment => write!(f, "job-object-containment"),
         }
     }
 }
 
+/// Check if a usable Windows helper backend is available.
 pub fn is_available() -> bool {
-    windows_sandbox_available() || appcontainer_available() || restricted_token_available()
+    available_helper_path().is_some()
 }
 
-pub fn select_best_kind(_policy: &SandboxPolicy, _cwd: &Path) -> WindowsSandboxKind {
-    if windows_sandbox_available() {
-        WindowsSandboxKind::WindowsSandbox
-    } else if appcontainer_available() {
-        WindowsSandboxKind::AppContainer
+pub fn select_best_kind(_policy: &SandboxPolicy, _cwd: &Path) -> Option<WindowsSandboxKind> {
+    if is_available() {
+        Some(WindowsSandboxKind::JobObjectContainment)
     } else {
-        WindowsSandboxKind::RestrictedToken
+        None
     }
+}
+
+pub fn build_helper_command(
+    spec_program: &str,
+    spec_args: &[String],
+    spec_timeout: Duration,
+    cwd: &Path,
+) -> Option<Vec<String>> {
+    let helper = available_helper_path()?;
+
+    let timeout_ms = spec_timeout.as_millis().min(u128::from(u64::MAX)) as u64;
+    let mut command = vec![
+        helper.to_string_lossy().into_owned(),
+        "--contain".to_string(),
+        "--cwd".to_string(),
+        cwd.to_string_lossy().into_owned(),
+        "--timeout-ms".to_string(),
+        timeout_ms.to_string(),
+        "--".to_string(),
+        spec_program.to_string(),
+    ];
+    command.extend(spec_args.iter().cloned());
+    Some(command)
 }
 
 pub fn detect_denial(exit_code: i32, stderr: &str) -> bool {
@@ -60,20 +83,84 @@ pub fn detect_denial(exit_code: i32, stderr: &str) -> bool {
     patterns.iter().any(|p| stderr.contains(p))
 }
 
-fn windows_sandbox_available() -> bool {
-    let Ok(system_root) = std::env::var("SystemRoot") else {
-        return false;
-    };
-    Path::new(&system_root)
-        .join("System32")
-        .join("WindowsSandbox.exe")
-        .exists()
+fn helper_path() -> Option<PathBuf> {
+    if let Some(path) = helper_path_from_env() {
+        return Some(path);
+    }
+
+    let current = std::env::current_exe().ok()?;
+    helper_candidates(&current)
+        .into_iter()
+        .find(|candidate| candidate.is_file())
 }
 
-fn appcontainer_available() -> bool {
-    true
+fn available_helper_path() -> Option<PathBuf> {
+    AVAILABLE_HELPER
+        .get_or_init(|| {
+            let helper = helper_path()?;
+            helper_self_test(&helper).then_some(helper)
+        })
+        .clone()
 }
 
-fn restricted_token_available() -> bool {
-    true
+fn helper_path_from_env() -> Option<PathBuf> {
+    std::env::var_os("DEEPSEEK_WINDOWS_SANDBOX_HELPER")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .filter(|path| path.is_file())
+}
+
+fn helper_candidates(current_exe: &Path) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+
+    if let Some(dir) = current_exe.parent() {
+        candidates.push(dir.join(HELPER_BIN_NAME));
+
+        // Cargo test binaries live in target/{debug,release}/deps while helper
+        // binaries live one directory up.
+        if dir.file_name().is_some_and(|name| name == "deps")
+            && let Some(parent) = dir.parent()
+        {
+            candidates.push(parent.join(HELPER_BIN_NAME));
+        }
+    }
+
+    candidates
+}
+
+fn helper_self_test(helper: &Path) -> bool {
+    Command::new(helper)
+        .arg("--self-test")
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn helper_candidates_include_current_dir() {
+        let current = Path::new(r"C:\repo\target\debug\deepseek-tui.exe");
+        let candidates = helper_candidates(current);
+        assert_eq!(
+            candidates,
+            vec![PathBuf::from(
+                r"C:\repo\target\debug\deepseek-windows-sandbox-helper.exe"
+            )]
+        );
+    }
+
+    #[test]
+    fn helper_candidates_include_cargo_test_parent_dir() {
+        let current = Path::new(r"C:\repo\target\debug\deps\deepseek_tui-test.exe");
+        let candidates = helper_candidates(current);
+        assert_eq!(
+            candidates,
+            vec![
+                PathBuf::from(r"C:\repo\target\debug\deps\deepseek-windows-sandbox-helper.exe"),
+                PathBuf::from(r"C:\repo\target\debug\deepseek-windows-sandbox-helper.exe"),
+            ]
+        );
+    }
 }

--- a/crates/tui/src/tools/shell.rs
+++ b/crates/tui/src/tools/shell.rs
@@ -305,7 +305,10 @@ impl BackgroundShell {
             match child.try_wait() {
                 Ok(Some(status)) => {
                     self.exit_code = status.code;
-                    self.status = if status.success {
+                    let helper_timed_out = windows_helper_timed_out(self.sandbox_type, status.code);
+                    self.status = if helper_timed_out {
+                        ShellStatus::TimedOut
+                    } else if status.success {
                         ShellStatus::Completed
                     } else {
                         ShellStatus::Failed
@@ -405,6 +408,9 @@ impl BackgroundShell {
 
     fn sandbox_denied(&self) -> bool {
         if matches!(self.status, ShellStatus::Running) {
+            return false;
+        }
+        if windows_helper_timed_out(self.sandbox_type, self.exit_code) {
             return false;
         }
         let (_, stderr_full, _, _) = self.full_output();
@@ -807,15 +813,19 @@ impl ShellManager {
             let stdout_str = String::from_utf8_lossy(&stdout).to_string();
             let stderr_str = String::from_utf8_lossy(&stderr).to_string();
             let exit_code = status.code().unwrap_or(-1);
+            let helper_timed_out = windows_helper_timed_out(sandbox_type, status.code());
 
             // Check if sandbox denied the operation
-            let sandbox_denied = SandboxManager::was_denied(sandbox_type, exit_code, &stderr_str);
+            let sandbox_denied = !helper_timed_out
+                && SandboxManager::was_denied(sandbox_type, exit_code, &stderr_str);
             let (stdout, stdout_meta) = truncate_with_meta(&stdout_str);
             let (stderr, stderr_meta) = truncate_with_meta(&stderr_str);
 
             Ok(ShellResult {
                 task_id: None,
-                status: if status.success() {
+                status: if helper_timed_out {
+                    ShellStatus::TimedOut
+                } else if status.success() {
                     ShellStatus::Completed
                 } else {
                     ShellStatus::Failed
@@ -912,9 +922,12 @@ impl ShellManager {
             .with_context(|| format!("Failed to execute: {original_command}"))?;
 
         if let Some(status) = child.wait_timeout(timeout)? {
+            let helper_timed_out = windows_helper_timed_out(sandbox_type, status.code());
             Ok(ShellResult {
                 task_id: None,
-                status: if status.success() {
+                status: if helper_timed_out {
+                    ShellStatus::TimedOut
+                } else if status.success() {
                     ShellStatus::Completed
                 } else {
                     ShellStatus::Failed
@@ -1405,6 +1418,16 @@ pub type SharedShellManager = Arc<Mutex<ShellManager>>;
 /// Create a new shared shell manager with default sandbox policy.
 pub fn new_shared_shell_manager(workspace: PathBuf) -> SharedShellManager {
     Arc::new(Mutex::new(ShellManager::new(workspace)))
+}
+
+#[cfg(target_os = "windows")]
+fn windows_helper_timed_out(sandbox_type: SandboxType, exit_code: Option<i32>) -> bool {
+    matches!(sandbox_type, SandboxType::Windows) && exit_code == Some(124)
+}
+
+#[cfg(not(target_os = "windows"))]
+fn windows_helper_timed_out(_sandbox_type: SandboxType, _exit_code: Option<i32>) -> bool {
+    false
 }
 
 // === ToolSpec Implementations ===


### PR DESCRIPTION
## Background

The current Windows sandbox path does not provide real process containment. If a shell command spawns child processes and the TUI exits unexpectedly or a timeout is hit, those child processes can remain running outside the TUI lifecycle.

This PR adds a small Windows helper foundation using Job Objects. The goal is to provide reliable process-tree containment first, without claiming full filesystem or network sandbox enforcement.

## Summary

- Add a Windows-only `deepseek-windows-sandbox-helper` binary.
- Run Windows shell commands through a Job Object with kill-on-close semantics when the helper self-test passes.
- Wire the Windows sandbox backend through the helper and label it as `windows-job-object`.
- Keep the boundary explicit: this is process-tree containment only, not ReadOnly / WorkspaceWrite / network policy enforcement.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p deepseek-tui sandbox --all-features`
  - `24 passed; 0 failed`
- `cargo clippy -p deepseek-tui --all-targets --all-features -- -D warnings`

## Notes

This is intended as a small Windows reliability/sandbox foundation PR. Full Windows filesystem and network enforcement should be handled in follow-up work, likely through a stricter helper contract plus Windows-specific enforcement mechanisms such as Restricted Tokens, AppContainer, ACLs, or related APIs.
