### PR TITLE
fix(config): persist cost_currency setting across sessions

### DIFF
--- a/crates/tui/src/commands/config.rs
+++ b/crates/tui/src/commands/config.rs
@@ -44,7 +44,7 @@ pub fn show_config(_app: &mut App, arg: Option<&str>) -> CommandResult {
 /// - `/config tui` / `/config web` / `/config native` — open a specific
 ///   editor mode (web requires the `web` build feature).
 /// - `/config <key>` — shows the current value of a setting.
-/// - `/config <key> <value>` — sets a runtime value (session only, no --save).
+/// - `/config <key> <value>` — sets a runtime value (session only, add --save to persist).
 pub fn config_command(app: &mut App, arg: Option<&str>) -> CommandResult {
     let raw = arg.map(str::trim).unwrap_or("");
     if raw.is_empty() {
@@ -63,8 +63,18 @@ pub fn config_command(app: &mut App, arg: Option<&str>) -> CommandResult {
         // `/config <key>` — show current value
         show_single_setting(app, token)
     } else {
-        // `/config <key> <value>` — set value
-        set_config_value(app, parts[0], parts[1], false)
+        // `/config <key> <value> [--save|-s]` — set value, optionally persist
+        let raw_value = parts[1];
+        let persist = raw_value.ends_with(" --save") || raw_value.ends_with(" -s");
+        let value = if persist {
+            raw_value
+                .strip_suffix(" --save")
+                .or_else(|| raw_value.strip_suffix(" -s"))
+                .unwrap_or(raw_value)
+        } else {
+            raw_value
+        };
+        set_config_value(app, parts[0], value, persist)
     }
 }
 
@@ -126,6 +136,13 @@ fn show_single_setting(app: &App, key: &str) -> CommandResult {
         }
         "transcript_spacing" | "spacing" => {
             Some(spacing_display(app.transcript_spacing).to_string())
+        }
+        "cost_currency" | "currency" => {
+            Some(match app.cost_currency {
+                crate::pricing::CostCurrency::Usd => "usd",
+                crate::pricing::CostCurrency::Cny => "cny",
+            }
+            .to_string())
         }
         _ => {
             let known = Settings::available_settings()

--- a/crates/tui/src/config_ui.rs
+++ b/crates/tui/src/config_ui.rs
@@ -67,6 +67,7 @@ pub struct SettingsSection {
     pub sidebar_focus: SidebarFocusValue,
     #[schemars(range(min = 0))]
     pub max_history: usize,
+    pub cost_currency: CostCurrencyValue,
     pub default_model: Option<String>,
 }
 
@@ -183,6 +184,13 @@ pub enum DefaultModeValue {
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
+pub enum CostCurrencyValue {
+    Usd,
+    Cny,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
 pub enum SidebarFocusValue {
     Auto,
     Plan,
@@ -267,6 +275,7 @@ pub fn build_document(app: &App, config: &Config) -> Result<ConfigUiDocument> {
             sidebar_width: settings.sidebar_width_percent,
             sidebar_focus: settings.sidebar_focus.as_str().into(),
             max_history: settings.max_input_history,
+            cost_currency: CostCurrencyValue::from_setting(&settings.cost_currency)?,
             default_model,
         },
         config: ConfigSection {
@@ -428,6 +437,7 @@ pub fn apply_document(
         ("sidebar_width", &doc.settings.sidebar_width.to_string()),
         ("sidebar_focus", doc.settings.sidebar_focus.as_setting()),
         ("max_history", &doc.settings.max_history.to_string()),
+        ("cost_currency", doc.settings.cost_currency.as_setting()),
         ("mcp_config_path", doc.config.mcp_config_path.as_str()),
     ] {
         let result = commands::set_config_value(app, key, value, persist);
@@ -660,6 +670,23 @@ impl DefaultModeValue {
             Self::Agent => "agent",
             Self::Plan => "plan",
             Self::Yolo => "yolo",
+        }
+    }
+}
+
+impl CostCurrencyValue {
+    fn from_setting(value: &str) -> Result<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "usd" => Ok(Self::Usd),
+            "cny" | "rmb" | "yuan" => Ok(Self::Cny),
+            other => anyhow::bail!("Invalid cost_currency '{other}': expected usd, cny, rmb, or yuan"),
+        }
+    }
+
+    fn as_setting(self) -> &'static str {
+        match self {
+            Self::Usd => "usd",
+            Self::Cny => "cny",
         }
     }
 }


### PR DESCRIPTION
## Summary
- Support `--save` flag in `/config <key> <value>` so settings can be persisted to settings.toml (e.g. `/config cost_currency cny --save`)
- Add `cost_currency` to `show_single_setting()` so `/config cost_currency` displays the current value
- Add `CostCurrencyValue` enum and wire it into the interactive `/config` TUI editor so users can change it visually

Closes #932

## Test plan
- [x] All 2368 existing tests pass with zero failures
- [x] `cost_currency`-specific tests pass (pricing, settings, UI footer)
- [x] `cargo check` compiles cleanly with no warnings