### PR TITLE
Fix npm wrapper verbose flag handling

### DIFF
--- a/npm/deepseek-tui/package.json
+++ b/npm/deepseek-tui/package.json
@@ -30,7 +30,8 @@
     "release:check": "node scripts/verify-release-assets.js",
     "postinstall": "node scripts/install.js",
     "prepublishOnly": "node scripts/verify-release-assets.js",
-    "prepack": "node scripts/install.js"
+    "prepack": "node scripts/install.js",
+    "test": "node --test test/*.test.js"
   },
   "engines": {
     "node": ">=18"
@@ -42,6 +43,7 @@
   "files": [
     "bin/*.js",
     "scripts/*.js",
+    "test/*.js",
     "README.md",
     "package.json"
   ]

--- a/npm/deepseek-tui/scripts/run.js
+++ b/npm/deepseek-tui/scripts/run.js
@@ -3,9 +3,8 @@ const { getBinaryPath } = require("./install");
 
 const pkg = require("../package.json");
 
-function isVersionFlag() {
-  const args = process.argv.slice(2);
-  return args.includes("--version") || args.includes("-v") || args.includes("-V");
+function isVersionFlag(args = process.argv.slice(2)) {
+  return args.includes("--version") || args.includes("-V");
 }
 
 function handleVersionFallback(binaryName) {
@@ -46,6 +45,7 @@ module.exports = {
   run,
   runDeepseek,
   runDeepseekTui,
+  _internal: { isVersionFlag },
 };
 
 if (require.main === module) {

--- a/npm/deepseek-tui/test/run.test.js
+++ b/npm/deepseek-tui/test/run.test.js
@@ -1,0 +1,11 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { _internal } = require("../scripts/run");
+
+test("version fallback handles only version flags", () => {
+  assert.equal(_internal.isVersionFlag(["--version"]), true);
+  assert.equal(_internal.isVersionFlag(["-V"]), true);
+  assert.equal(_internal.isVersionFlag(["-v"]), false);
+  assert.equal(_internal.isVersionFlag(["--verbose"]), false);
+});


### PR DESCRIPTION
## Summary
- stop treating `-v` as an npm wrapper version fallback
- keep wrapper fallback for `--version` and Clap's `-V`
- add a small Node test for version flag detection

## Tests
- npm test