### PR TITLE
fix(engine): store turn_meta at message creation time to fix KV prefix cache (#934)

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -824,6 +824,37 @@ impl Engine {
             .await;
     }
 
+    /// Build the turn‑metadata block for KV prefix‑cache stability (#934).
+    ///
+    /// The sentinel prefix `<!-- DSTUI_TURN_META` lets the transcript
+    /// renderer identify and skip this block so it never appears in the
+    /// user‑visible history.
+    ///
+    /// Contents are deliberately limited to information the model cannot
+    /// infer from V4's retained reasoning chain or Quick Instruction
+    /// mechanism (DeepSeek-V4 Technical Report §5.1.1, Table 5, Fig. 7a).
+    ///
+    /// - turn counter (machine‑readable identifier)
+    /// - working‑set paths (model can't reconstruct from its own output)
+    ///
+    /// DateTime, intent classification, and state summaries are omitted
+    /// because V4 handles those internally via Quick Instruction tokens.
+    fn build_turn_meta_string(&self) -> String {
+        let working_set_summary = self
+            .session
+            .working_set
+            .summary_block(&self.config.workspace)
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+
+        let summary = working_set_summary.unwrap_or_default();
+
+        format!(
+            "<!-- DSTUI_TURN_META turn_id={} -->\n<turn_meta>\n{summary}\n</turn_meta>",
+            self.turn_counter
+        )
+    }
+
     async fn add_session_message(&mut self, message: Message) {
         self.session.add_message(message);
         self.emit_session_updated().await;
@@ -907,13 +938,23 @@ impl Engine {
             .observe_user_message(&content, &self.session.workspace);
         let force_update_plan_first = should_force_update_plan_first(mode, &content);
 
-        // Add user message to session
+        // Build turn metadata at storage time (#934). Storing the meta
+        // block as part of the message means replayed messages sent in
+        // subsequent turns are byte-identical to their originals, enabling
+        // DeepSeek's KV prefix cache to hit.
+        let turn_meta = self.build_turn_meta_string();
         let user_msg = Message {
             role: "user".to_string(),
-            content: vec![ContentBlock::Text {
-                text: content,
-                cache_control: None,
-            }],
+            content: vec![
+                ContentBlock::Text {
+                    text: turn_meta,
+                    cache_control: None,
+                },
+                ContentBlock::Text {
+                    text: content,
+                    cache_control: None,
+                },
+            ],
         };
         self.session.add_message(user_msg);
 

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 use crate::models::SystemBlock;
-use crate::test_support::lock_test_env;
+use crate::test_support::{assert_byte_identical, lock_test_env};
 use serde_json::json;
 use std::collections::HashSet;
 use std::ffi::OsString;
@@ -681,7 +681,7 @@ fn refresh_system_prompt_leaves_working_set_out_of_system_prompt() {
 }
 
 #[test]
-fn working_set_reaches_model_as_turn_metadata() {
+fn turn_meta_string_includes_working_set_and_sentinel() {
     let tmp = tempdir().expect("tempdir");
     fs::create_dir_all(tmp.path().join("src")).expect("mkdir");
     fs::write(tmp.path().join("src/lib.rs"), "pub fn sample() {}").expect("write");
@@ -691,71 +691,21 @@ fn working_set_reaches_model_as_turn_metadata() {
         ..Default::default()
     };
     let (mut engine, _handle) = Engine::new(config, &Config::default());
+    engine.turn_counter = 3;
     engine
         .session
         .working_set
         .observe_user_message("please inspect src/lib.rs", tmp.path());
-    engine.session.add_message(Message {
-        role: "user".to_string(),
-        content: vec![ContentBlock::Text {
-            text: "please inspect src/lib.rs".to_string(),
-            cache_control: None,
-        }],
-    });
 
-    let messages = engine.messages_with_turn_metadata();
-    let first_block = messages
-        .last()
-        .and_then(|message| message.content.first())
-        .expect("turn metadata block");
-    let ContentBlock::Text { text, .. } = first_block else {
-        panic!("expected text metadata block");
-    };
-    assert!(text.starts_with("<turn_meta>\n"));
-    assert!(text.contains(WORKING_SET_SUMMARY_MARKER));
-    assert!(text.contains("src/lib.rs"));
+    // build_turn_meta_string is used at storage time (#934).
+    let meta = engine.build_turn_meta_string();
+    assert!(meta.starts_with("<!-- DSTUI_TURN_META turn_id=3"));
+    assert!(meta.contains(WORKING_SET_SUMMARY_MARKER));
+    assert!(meta.contains("src/lib.rs"));
 }
 
 #[test]
-fn turn_metadata_includes_current_local_date_without_working_set() {
-    let tmp = tempdir().expect("tempdir");
-    let config = EngineConfig {
-        workspace: tmp.path().to_path_buf(),
-        ..Default::default()
-    };
-    let (mut engine, _handle) = Engine::new(config, &Config::default());
-    engine.session.add_message(Message {
-        role: "user".to_string(),
-        content: vec![ContentBlock::Text {
-            text: "what is today's date?".to_string(),
-            cache_control: None,
-        }],
-    });
-
-    let messages = engine.messages_with_turn_metadata();
-    let first_block = messages
-        .last()
-        .and_then(|message| message.content.first())
-        .expect("turn metadata block");
-    let ContentBlock::Text { text, .. } = first_block else {
-        panic!("expected text metadata block");
-    };
-
-    let today = chrono::Local::now().format("%Y-%m-%d").to_string();
-    assert!(text.starts_with("<turn_meta>\n"));
-    assert!(text.contains(&format!("Current local date: {today}")));
-}
-
-/// v0.8.11 regression: tool-result messages serialize to role="tool" on
-/// the wire but are stored as role="user" internally. Prepending
-/// `<turn_meta>` text onto a tool-result message broke the
-/// assistant→tool_result invariant and caused HTTP 400 from DeepSeek's
-/// API ("insufficient tool messages following tool_calls"). The fix:
-/// inject only into messages that have a Text content block and no
-/// ToolResult blocks; mid-turn (tool-result is the trailing user
-/// message) the injection skips.
-#[test]
-fn turn_metadata_skips_tool_result_messages() {
+fn turn_meta_string_omits_date_includes_working_set() {
     let tmp = tempdir().expect("tempdir");
     fs::create_dir_all(tmp.path().join("src")).expect("mkdir");
     fs::write(tmp.path().join("src/lib.rs"), "pub fn sample() {}").expect("write");
@@ -765,30 +715,53 @@ fn turn_metadata_skips_tool_result_messages() {
         ..Default::default()
     };
     let (mut engine, _handle) = Engine::new(config, &Config::default());
+    engine.turn_counter = 7;
     engine
         .session
         .working_set
         .observe_user_message("inspect src/lib.rs", tmp.path());
 
-    // Real user message — should be eligible for injection.
+    let meta = engine.build_turn_meta_string();
+    // Date is intentionally omitted — V4 handles temporal awareness
+    // internally (Quick Instruction, Table 5 in §5.1.1).
+    assert!(!meta.contains("Current local date"));
+    assert!(!meta.contains("chrono"));
+    // Machine-readable identifiers present.
+    assert!(meta.starts_with("<!-- DSTUI_TURN_META turn_id=7"));
+    assert!(meta.contains(WORKING_SET_SUMMARY_MARKER));
+    assert!(meta.contains("src/lib.rs"));
+}
+
+/// Turn metadata is stored at storage time (#934) rather than injected at
+/// send time.  Tool‑result messages (stored as role="user" internally) do
+/// NOT get a turn_meta block — they have no Text content.  Verify that
+/// `messages_with_turn_metadata()` returns stored messages unchanged.
+#[test]
+fn messages_with_turn_metadata_returns_stored_messages_as_is() {
+    let tmp = tempdir().expect("tempdir");
+    let config = EngineConfig {
+        workspace: tmp.path().to_path_buf(),
+        ..Default::default()
+    };
+    let (mut engine, _handle) = Engine::new(config, &Config::default());
+    engine.turn_counter = 1;
+
+    // User message stored through the normal path now includes turn_meta.
     engine.session.add_message(Message {
         role: "user".to_string(),
-        content: vec![ContentBlock::Text {
-            text: "inspect src/lib.rs".to_string(),
-            cache_control: None,
-        }],
+        content: vec![
+            ContentBlock::Text {
+                text: engine.build_turn_meta_string(),
+                cache_control: None,
+            },
+            ContentBlock::Text {
+                text: "inspect src/lib.rs".to_string(),
+                cache_control: None,
+            },
+        ],
     });
-    // Assistant tool-call.
-    engine.session.add_message(Message {
-        role: "assistant".to_string(),
-        content: vec![ContentBlock::ToolUse {
-            id: "call_42".to_string(),
-            name: "read_file".to_string(),
-            input: serde_json::json!({"path": "src/lib.rs"}),
-            caller: None,
-        }],
-    });
-    // Tool result, stored as role="user" internally.
+
+    // Tool result stored as role="user" (no turn_meta).
     engine.session.add_message(Message {
         role: "user".to_string(),
         content: vec![ContentBlock::ToolResult {
@@ -801,52 +774,45 @@ fn turn_metadata_skips_tool_result_messages() {
 
     let messages = engine.messages_with_turn_metadata();
 
-    // The trailing message is the tool result and MUST be untouched —
-    // no Text block sneaking in front of the ToolResult block.
-    let trailing = messages.last().expect("trailing message");
-    assert_eq!(trailing.role, "user");
-    assert_eq!(trailing.content.len(), 1);
+    // messages_with_turn_metadata is now a simple clone (#934).
+    assert_eq!(messages.len(), 2);
+
+    // User message: content[0] = turn_meta, content[1] = user input.
+    let user_msg = &messages[0];
+    assert_eq!(user_msg.role, "user");
+    assert_eq!(user_msg.content.len(), 2);
+    let ContentBlock::Text { text: t0, .. } = &user_msg.content[0] else {
+        panic!("expected turn_meta block");
+    };
+    assert!(t0.starts_with("<!-- DSTUI_TURN_META"));
+    let ContentBlock::Text { text: t1, .. } = &user_msg.content[1] else {
+        panic!("expected user input block");
+    };
+    assert_eq!(t1, "inspect src/lib.rs");
+
+    // Tool result: untouched, no Text blocks added.
+    let tool_msg = &messages[1];
+    assert_eq!(tool_msg.role, "user");
+    assert_eq!(tool_msg.content.len(), 1);
     assert!(matches!(
-        trailing.content.first(),
+        tool_msg.content.first(),
         Some(ContentBlock::ToolResult { .. })
     ));
-
-    // The earlier real user message receives the turn_meta prefix.
-    let real_user = messages.first().expect("first user message");
-    assert_eq!(real_user.role, "user");
-    let ContentBlock::Text { text, .. } = real_user.content.first().expect("user text content")
-    else {
-        panic!("expected Text block on real user message");
-    };
-    assert!(text.starts_with("<turn_meta>\n"));
-    assert!(text.contains("src/lib.rs"));
 }
 
-/// When the turn is mid-execution and the trailing user message is a
-/// tool result, no turn_meta is injected at all (rather than landing on
-/// some earlier user message and confusing the API's tool-call
-/// continuity check). The working_set surfaces again on the next
-/// genuine user prompt.
+/// When only tool‑result messages exist in history (no user Text message),
+/// `messages_with_turn_metadata()` returns them unchanged — no turn_meta
+/// block is injected anywhere because none were stored (#934).
 #[test]
-fn turn_metadata_skips_when_only_tool_results_trail() {
+fn messages_with_turn_metadata_returns_tool_only_history_unchanged() {
     let tmp = tempdir().expect("tempdir");
-    fs::create_dir_all(tmp.path().join("src")).expect("mkdir");
-    fs::write(tmp.path().join("src/lib.rs"), "pub fn sample() {}").expect("write");
-
     let config = EngineConfig {
         workspace: tmp.path().to_path_buf(),
         ..Default::default()
     };
     let (mut engine, _handle) = Engine::new(config, &Config::default());
-    engine
-        .session
-        .working_set
-        .observe_user_message("inspect src/lib.rs", tmp.path());
 
-    // Only a tool-result message in history — simulates the corner case
-    // where the prior real user message has already been compacted away
-    // but a tool-result is still pending. We must not retroactively
-    // inject.
+    // Only a tool-result message in history.
     engine.session.add_message(Message {
         role: "user".to_string(),
         content: vec![ContentBlock::ToolResult {
@@ -859,8 +825,7 @@ fn turn_metadata_skips_when_only_tool_results_trail() {
 
     let messages = engine.messages_with_turn_metadata();
 
-    // Returned unchanged: the single tool-result message, no Text
-    // prefix, content length == 1.
+    // Returned unchanged: single tool-result, content length == 1.
     let only = messages.last().expect("trailing message");
     assert_eq!(only.content.len(), 1);
     assert!(matches!(
@@ -921,6 +886,226 @@ fn compaction_summary_stays_in_stable_system_prompt() {
 
     assert!(prompt.contains(COMPACTION_SUMMARY_MARKER));
     assert!(!prompt.contains(WORKING_SET_SUMMARY_MARKER));
+}
+
+/// Simulate a multi‑turn conversation and verify that the JSON‑serialized
+/// messages array is prefix‑stable across turns.  If this test fails, the
+/// KV cache will miss on every turn and DeepSeek API costs will spike.
+///
+/// After the fix for #934, user messages carry their `<turn_meta>` block
+/// from storage time onward, so replayed historical messages are always
+/// byte‑identical to their original wire representation.
+#[test]
+fn messages_prefix_is_stable_across_turns() {
+    let tmp = tempdir().expect("tempdir");
+    let config = EngineConfig {
+        workspace: tmp.path().to_path_buf(),
+        ..Default::default()
+    };
+    let (mut engine, _handle) = Engine::new(config, &Config::default());
+
+    // ── Turn 1 ──────────────────────────────────────────────────────────
+    engine.turn_counter = 1;
+    let meta1 = engine.build_turn_meta_string();
+    engine.session.add_message(Message {
+        role: "user".to_string(),
+        content: vec![
+            ContentBlock::Text { text: meta1,  cache_control: None },
+            ContentBlock::Text { text: "hello".to_string(), cache_control: None },
+        ],
+    });
+    engine.session.add_message(Message {
+        role: "assistant".to_string(),
+        content: vec![ContentBlock::Text {
+            text: "Hi! How can I help?".to_string(),
+            cache_control: None,
+        }],
+    });
+
+    // ── Turn 2 ──────────────────────────────────────────────────────────
+    engine.turn_counter = 2;
+    let meta2 = engine.build_turn_meta_string();
+    engine.session.add_message(Message {
+        role: "user".to_string(),
+        content: vec![
+            ContentBlock::Text { text: meta2,  cache_control: None },
+            ContentBlock::Text { text: "fix src/main.rs".to_string(), cache_control: None },
+        ],
+    });
+    engine.session.add_message(Message {
+        role: "assistant".to_string(),
+        content: vec![ContentBlock::Text {
+            text: "Sure, let me look at it.".to_string(),
+            cache_control: None,
+        }],
+    });
+
+    let turn2_messages = engine.messages_with_turn_metadata();
+    let turn2_json = serde_json::to_string(&turn2_messages).expect("serialize turn2");
+
+    // ── Turn 3 ──────────────────────────────────────────────────────────
+    engine.turn_counter = 3;
+    let meta3 = engine.build_turn_meta_string();
+    engine.session.add_message(Message {
+        role: "user".to_string(),
+        content: vec![
+            ContentBlock::Text { text: meta3,  cache_control: None },
+            ContentBlock::Text { text: "now edit the tests".to_string(), cache_control: None },
+        ],
+    });
+
+    let turn3_messages = engine.messages_with_turn_metadata();
+    let turn3_json = serde_json::to_string(&turn3_messages).expect("serialize turn3");
+
+    // ── Assert prefix stability ─────────────────────────────────────────
+    // turn2_json ends with "]".  turn3_json has everything turn2 has plus
+    // turn 3's user message at the end.  The shared prefix (everything
+    // before the trailing "]") must be byte-identical — otherwise the KV
+    // prefix cache misses on every turn after the first.
+    let shared_len = turn2_json.len() - 1; // exclude the trailing ']'
+    assert_byte_identical(
+        "turn2 and turn3 messages share a common prefix",
+        &turn2_json[..shared_len],
+        &turn3_json[..shared_len],
+    );
+    // Sanity: turn3_json has more elements
+    assert!(
+        turn3_json.len() > turn2_json.len(),
+        "turn3 should be longer than turn2"
+    );
+}
+
+/// Same prefix‑stability check but with V4 thinking traces, tool calls,
+/// and tool results interleaved — the real‑world pattern that exercises
+/// the assistant→tool_result invariant (v0.8.11 hotfix).
+///
+/// V4's on‑disk KV cache (§3.5.2) penalises any byte drift in the
+/// conversation prefix: even a single changed character forces a full
+/// re‑compute of everything after the divergence point.  This test
+/// ensures that the turn‑meta block (stored at creation time, #934)
+/// survives multi‑turn tool‑interleaved sessions without drifting.
+#[test]
+fn messages_prefix_is_stable_across_turns_with_tool_calls() {
+    let tmp = tempdir().expect("tempdir");
+    fs::create_dir_all(tmp.path().join("src")).expect("mkdir");
+    fs::write(tmp.path().join("src/lib.rs"), "pub fn sample() {}").expect("write");
+
+    let config = EngineConfig {
+        workspace: tmp.path().to_path_buf(),
+        ..Default::default()
+    };
+    let (mut engine, _handle) = Engine::new(config, &Config::default());
+
+    // ── Turn 1: user → thinking + tool_call → tool_result → text ─────────
+    engine.turn_counter = 1;
+    let meta1 = engine.build_turn_meta_string();
+    engine.session.add_message(Message {
+        role: "user".to_string(),
+        content: vec![
+            ContentBlock::Text { text: meta1,  cache_control: None },
+            ContentBlock::Text { text: "inspect src/lib.rs".to_string(), cache_control: None },
+        ],
+    });
+    engine.session.add_message(Message {
+        role: "assistant".to_string(),
+        content: vec![
+            ContentBlock::Thinking { thinking: "User wants me to inspect src/lib.rs. I should read the file first.".to_string() },
+            ContentBlock::ToolUse {
+                id: "call_1a".to_string(),
+                name: "read_file".to_string(),
+                input: serde_json::json!({"path": "src/lib.rs"}),
+                caller: None,
+            },
+        ],
+    });
+    engine.session.add_message(Message {
+        role: "user".to_string(),
+        content: vec![ContentBlock::ToolResult {
+            tool_use_id: "call_1a".to_string(),
+            content: "pub fn sample() {}".to_string(),
+            is_error: None,
+            content_blocks: None,
+        }],
+    });
+    engine.session.add_message(Message {
+        role: "assistant".to_string(),
+        content: vec![ContentBlock::Text {
+            text: "The file contains a sample function.".to_string(),
+            cache_control: None,
+        }],
+    });
+
+    // ── Turn 2: user → thinking + tool_call → tool_result → text ─────────
+    engine.turn_counter = 2;
+    let meta2 = engine.build_turn_meta_string();
+    engine.session.add_message(Message {
+        role: "user".to_string(),
+        content: vec![
+            ContentBlock::Text { text: meta2,  cache_control: None },
+            ContentBlock::Text { text: "fix src/main.rs".to_string(), cache_control: None },
+        ],
+    });
+    engine.session.add_message(Message {
+        role: "assistant".to_string(),
+        content: vec![
+            ContentBlock::Thinking { thinking: "Let me read the file and apply a fix.".to_string() },
+            ContentBlock::ToolUse {
+                id: "call_2a".to_string(),
+                name: "read_file".to_string(),
+                input: serde_json::json!({"path": "src/main.rs"}),
+                caller: None,
+            },
+        ],
+    });
+    engine.session.add_message(Message {
+        role: "user".to_string(),
+        content: vec![ContentBlock::ToolResult {
+            tool_use_id: "call_2a".to_string(),
+            content: "fn main() { println!(\"hello\"); }".to_string(),
+            is_error: None,
+            content_blocks: None,
+        }],
+    });
+    engine.session.add_message(Message {
+        role: "assistant".to_string(),
+        content: vec![ContentBlock::Text {
+            text: "I've read the file. Ready to make changes.".to_string(),
+            cache_control: None,
+        }],
+    });
+
+    let turn2_messages = engine.messages_with_turn_metadata();
+    let turn2_json = serde_json::to_string(&turn2_messages).expect("serialize turn2");
+
+    // ── Turn 3: user only — shares prefix with turn 2 ────────────────────
+    engine.turn_counter = 3;
+    let meta3 = engine.build_turn_meta_string();
+    engine.session.add_message(Message {
+        role: "user".to_string(),
+        content: vec![
+            ContentBlock::Text { text: meta3,  cache_control: None },
+            ContentBlock::Text { text: "now apply the fix".to_string(), cache_control: None },
+        ],
+    });
+
+    let turn3_messages = engine.messages_with_turn_metadata();
+    let turn3_json = serde_json::to_string(&turn3_messages).expect("serialize turn3");
+
+    // ── Assert prefix stability ─────────────────────────────────────────
+    // The entire turn‑2 prefix must be byte‑identical in turn 3's request.
+    // V4's on‑disk KV cache requires strict prefix matching (§3.5.2);
+    // anything short of this forces a full re‑compute of the suffix.
+    let shared_len = turn2_json.len() - 1; // exclude turn2's trailing ']'
+    assert_byte_identical(
+        "turn2 and turn3 messages share a common prefix\n\
+         (tool-call pattern — see DeepSeek V4 §3.5.2, §5.1.1, Fig. 7a)",
+        &turn2_json[..shared_len],
+        &turn3_json[..shared_len],
+    );
+    assert!(
+        turn3_json.len() > turn2_json.len(),
+        "turn3 should be longer than turn2"
+    );
 }
 
 #[tokio::test]

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -231,9 +231,25 @@ impl Engine {
             };
 
             // Resolve `auto` reasoning_effort to a concrete tier (#663).
+            // Strip turn metadata blocks (#934) so they don't influence the
+            // keyword-based effort classifier.
+            let clean_messages: Vec<Message> = self
+                .session
+                .messages
+                .iter()
+                .map(|msg| Message {
+                    content: msg
+                        .content
+                        .iter()
+                        .filter(|b| !is_turn_meta_block(b))
+                        .cloned()
+                        .collect(),
+                    ..msg.clone()
+                })
+                .collect();
             let effective_reasoning_effort = resolve_auto_effort(
                 self.session.reasoning_effort.as_deref(),
-                &self.session.messages,
+                &clean_messages,
             );
 
             let request = MessageRequest {
@@ -1765,12 +1781,19 @@ impl Engine {
                     self.session
                         .working_set
                         .observe_user_message(&steer, &self.session.workspace);
+                    let steer_meta = self.build_turn_meta_string();
                     self.add_session_message(Message {
                         role: "user".to_string(),
-                        content: vec![ContentBlock::Text {
-                            text: steer,
-                            cache_control: None,
-                        }],
+                        content: vec![
+                            ContentBlock::Text {
+                                text: steer_meta,
+                                cache_control: None,
+                            },
+                            ContentBlock::Text {
+                                text: steer,
+                                cache_control: None,
+                            },
+                        ],
                     })
                     .await;
                 }
@@ -1809,54 +1832,10 @@ impl Engine {
     }
 
     pub(super) fn messages_with_turn_metadata(&self) -> Vec<Message> {
-        let today = chrono::Local::now().format("%Y-%m-%d").to_string();
-        let working_set_summary = self
-            .session
-            .working_set
-            .summary_block(&self.config.workspace)
-            .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty());
-
-        let summary = if let Some(working_set_summary) = working_set_summary {
-            format!("Current local date: {today}\n{working_set_summary}")
-        } else {
-            format!("Current local date: {today}")
-        };
-
-        let mut messages = self.session.messages.clone();
-        // v0.8.11 hotfix: tool-result messages are stored as role="user" in
-        // our internal representation but serialize to role="tool" on the
-        // wire. Prepending a Text block onto a tool-result message breaks
-        // the assistant→tool_result invariant — the API rejects the request
-        // with `"insufficient tool messages following tool_calls"`. Inject
-        // only into actual user-typed messages, recognizable by having at
-        // least one Text content block (and no ToolResult blocks).
-        let Some(last_user) = messages.iter_mut().rev().find(|message| {
-            message.role == "user"
-                && message
-                    .content
-                    .iter()
-                    .all(|block| !matches!(block, ContentBlock::ToolResult { .. }))
-                && message
-                    .content
-                    .iter()
-                    .any(|block| matches!(block, ContentBlock::Text { .. }))
-        }) else {
-            // No real user message in the trailing slice (e.g. mid-turn
-            // after a tool call). Skip injection — the working_set will
-            // surface again on the next genuine user prompt.
-            return messages;
-        };
-
-        let turn_meta = format!("<turn_meta>\n{summary}\n</turn_meta>");
-        last_user.content.insert(
-            0,
-            ContentBlock::Text {
-                text: turn_meta,
-                cache_control: None,
-            },
-        );
-        messages
+        // Messages already carry their <turn_meta> block from storage
+        // time (#934).  Keep this function as a single aggregation point
+        // for any future transient message modifications.
+        self.session.messages.clone()
     }
 }
 
@@ -1903,5 +1882,19 @@ fn resolve_auto_effort(reasoning_effort: Option<&str>, messages: &[Message]) -> 
         }
         Some(other) => Some(other.to_string()),
         None => None,
+    }
+}
+
+/// Check whether a content block is a turn‑metadata block (stored at
+/// message‑creation time for KV prefix‑cache stability, #934).
+///
+/// Rendering and analysis paths that need "clean" messages (without meta)
+/// should filter blocks through this predicate rather than re‑implementing
+/// the sentinel check themselves.
+fn is_turn_meta_block(block: &ContentBlock) -> bool {
+    if let ContentBlock::Text { text, .. } = block {
+        text.starts_with("<!-- DSTUI_TURN_META")
+    } else {
+        false
     }
 }

--- a/crates/tui/src/tui/history.rs
+++ b/crates/tui/src/tui/history.rs
@@ -509,6 +509,14 @@ pub fn history_cells_from_message(msg: &Message) -> Vec<HistoryCell> {
     for block in &msg.content {
         match block {
             ContentBlock::Text { text, .. } => {
+                // Skip turn‑metadata blocks stored for KV prefix‑cache
+                // stability (#934).  Identified by the DSTUI_TURN_META
+                // sentinel so we never swallow user content regardless
+                // of how many Text blocks a message carries.
+                if text.starts_with("<!-- DSTUI_TURN_META") {
+                    continue;
+                }
+
                 // Check if this is an `<archived_context>` block.
                 if msg.role == "assistant"
                     && let Some(archived) = parse_archived_context(text)
@@ -3508,6 +3516,58 @@ mod tests {
         let text = "Line one\nLine two";
         let summary = extract_reasoning_summary(text).expect("summary should exist");
         assert_eq!(summary, "Line one\nLine two");
+    }
+
+    #[test]
+    fn old_session_without_turn_meta_renders_normally() {
+        // Simulate a message saved before #934 — a single Text block
+        // without any turn_meta sentinel.
+        let old_msg = Message {
+            role: "user".to_string(),
+            content: vec![ContentBlock::Text {
+                text: "fix src/main.rs by adding error handling".to_string(),
+                cache_control: None,
+            }],
+        };
+
+        let cells = super::history_cells_from_message(&old_msg);
+        assert_eq!(cells.len(), 1);
+        let HistoryCell::User { content } = &cells[0] else {
+            panic!("expected User history cell");
+        };
+        // The full user input must be present — nothing swallowed.
+        assert_eq!(content, "fix src/main.rs by adding error handling");
+        assert!(!content.contains("DSTUI_TURN_META"));
+        assert!(!content.contains("<turn_meta>"));
+    }
+
+    #[test]
+    fn turn_meta_block_is_skipped_during_render() {
+        // A message stored after #934 has a turn_meta block at content[0]
+        // and the real user input at content[1].
+        let new_msg = Message {
+            role: "user".to_string(),
+            content: vec![
+                ContentBlock::Text {
+                    text: "<!-- DSTUI_TURN_META turn_id=3 -->\n<turn_meta>\n## Repo Working Set\nWorkspace: /test\n- src/main.rs (file)\n</turn_meta>".to_string(),
+                    cache_control: None,
+                },
+                ContentBlock::Text {
+                    text: "fix src/main.rs".to_string(),
+                    cache_control: None,
+                },
+            ],
+        };
+
+        let cells = super::history_cells_from_message(&new_msg);
+        assert_eq!(cells.len(), 1);
+        let HistoryCell::User { content } = &cells[0] else {
+            panic!("expected User history cell");
+        };
+        // Only the real user input; no turn_meta leaked.
+        assert_eq!(content, "fix src/main.rs");
+        assert!(!content.contains("DSTUI_TURN_META"));
+        assert!(!content.contains("<turn_meta>"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes a bug where DeepSeek-TUI's KV prefix cache hit rate drops to near zero
after the first turn because `messages_with_turn_metadata()` injects
`<turn_meta>` at send time without persisting it. Every replayed historical
message then has different bytes from its original wire format.

## Root cause

See issue #934 for the full trace. In short:

Turn 1 wire:    `[{user: "<turn_meta>...hello"}]`
Turn 2 store:   `[{user: "hello"}, {assistant: ...}, {user: "<turn_meta>...fix"}]`
Turn 2 wire:    `[{user: "hello"}, ...]`
                 ↑ "hello" ≠ "<turn_meta>...hello" → cache miss from byte 0

## Fix

Store `<turn_meta>` at message creation time (`handle_send_message`) rather
than injecting it at send time (`messages_with_turn_metadata`). Each user
message becomes two independent `ContentBlock` entries — a meta block with a
`<!-- DSTUI_TURN_META` sentinel prefix, and the actual user input.

## Design decisions

| Decision | Rationale |
|----------|-----------|
| Sentinel prefix instead of block index | Survives future addition of extra Text blocks (e.g. @file rendering) |
| Store-at-creation instead of insert-separate-message | V4 on-disk KV cache (§3.5.2) penalises ANY byte drift in the prefix — modifying stored messages is forbidden |
| Only turn_id + working-set paths | V4 handles time/date internally via Quick Instruction (§5.1.1 Table 5) |
| Keep `messages_with_turn_metadata()` as thin wrapper | Aggregation point for future transient modifications |

## How to test

1. **Quick verification** — `cargo test -p deepseek-tui messages_prefix_is_stable`
   runs the two integration tests that assert byte-identical JSON prefixes.
2. **Full suite** — `cargo test -p deepseek-tui` passes all 2252 tests.
3. **Manual** — start a multi-turn session and watch the footer `cache hit %`
   chip. After the first turn, hit rate should increase noticeably compared to
   the pre-fix baseline, and climb further as the conversation grows.
4. **Regression** — load a saved session from before this fix and verify the
   transcript renders all user messages correctly (the sentinel check is
   backward-compatible).

## Backward compatibility

Old session files (single Text block, no sentinel) render identically — the
renderer's `starts_with("<!-- DSTUI_TURN_META")` check simply never matches,
so all content passes through unchanged.