### PR TITLE
feat(tui):add jump-to-latest transcript button

### DIFF
--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -580,6 +580,7 @@ pub struct ViewportState {
     pub last_transcript_visible: usize,
     pub last_transcript_total: usize,
     pub last_transcript_padding_top: usize,
+    pub jump_to_latest_button_area: Option<Rect>,
 }
 
 impl Default for ViewportState {
@@ -595,6 +596,7 @@ impl Default for ViewportState {
             last_transcript_visible: 0,
             last_transcript_total: 0,
             last_transcript_padding_top: 0,
+            jump_to_latest_button_area: None,
         }
     }
 }
@@ -2453,6 +2455,7 @@ impl App {
         self.viewport.last_transcript_visible = 0;
         self.viewport.last_transcript_total = 0;
         self.viewport.last_transcript_padding_top = 0;
+        self.viewport.jump_to_latest_button_area = None;
 
         self.mark_history_updated();
     }
@@ -2711,6 +2714,7 @@ impl App {
     pub fn scroll_to_bottom(&mut self) {
         self.viewport.transcript_scroll = TranscriptScroll::to_bottom();
         self.viewport.pending_scroll_delta = 0;
+        self.viewport.jump_to_latest_button_area = None;
         self.user_scrolled_during_stream = false;
         self.needs_redraw = true;
     }

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -7083,6 +7083,11 @@ fn handle_mouse_event(app: &mut App, mouse: MouseEvent) -> Vec<ViewEvent> {
             }
         }
         MouseEventKind::Down(MouseButton::Left) => {
+            if mouse_hits_rect(mouse, app.viewport.jump_to_latest_button_area) {
+                app.scroll_to_bottom();
+                return Vec::new();
+            }
+
             if let Some(point) = selection_point_from_mouse(app, mouse) {
                 app.viewport.transcript_selection.anchor = Some(point);
                 app.viewport.transcript_selection.head = Some(point);
@@ -7121,6 +7126,17 @@ fn handle_mouse_event(app: &mut App, mouse: MouseEvent) -> Vec<ViewEvent> {
     }
 
     Vec::new()
+}
+
+fn mouse_hits_rect(mouse: MouseEvent, area: Option<Rect>) -> bool {
+    let Some(area) = area else {
+        return false;
+    };
+
+    mouse.column >= area.x
+        && mouse.column < area.x.saturating_add(area.width)
+        && mouse.row >= area.y
+        && mouse.row < area.y.saturating_add(area.height)
 }
 
 fn open_context_menu(app: &mut App, mouse: MouseEvent) {

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -274,6 +274,35 @@ fn mouse_selection_autocopies_on_release_without_ctrl_c() {
 }
 
 #[test]
+fn jump_to_latest_button_click_scrolls_to_tail() {
+    let mut app = create_test_app();
+    app.viewport.transcript_scroll = TranscriptScroll::at_line(7);
+    app.viewport.jump_to_latest_button_area = Some(Rect {
+        x: 10,
+        y: 5,
+        width: 3,
+        height: 3,
+    });
+    app.user_scrolled_during_stream = true;
+
+    let events = handle_mouse_event(
+        &mut app,
+        MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: 11,
+            row: 6,
+            modifiers: KeyModifiers::NONE,
+        },
+    );
+
+    assert!(events.is_empty());
+    assert!(app.viewport.transcript_scroll.is_at_tail());
+    assert!(app.viewport.jump_to_latest_button_area.is_none());
+    assert!(!app.user_scrolled_during_stream);
+    assert!(!app.viewport.transcript_selection.dragging);
+}
+
+#[test]
 fn right_click_opens_context_menu() {
     let mut app = create_test_app();
 

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -37,8 +37,8 @@ use ratatui::{
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{
-        Block, Borders, Clear, Padding, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState,
-        StatefulWidget, Widget, Wrap,
+        Block, BorderType, Borders, Clear, Padding, Paragraph, Scrollbar, ScrollbarOrientation,
+        ScrollbarState, StatefulWidget, Widget, Wrap,
     },
 };
 use unicode_segmentation::UnicodeSegmentation;
@@ -46,11 +46,14 @@ use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 const SEND_FLASH_DURATION: Duration = Duration::from_millis(500);
 const COMPOSER_PANEL_HEIGHT: u16 = 2;
+const JUMP_TO_LATEST_BUTTON_WIDTH: u16 = 3;
+const JUMP_TO_LATEST_BUTTON_HEIGHT: u16 = 3;
 
 pub struct ChatWidget {
     content_area: Rect,
     lines: Vec<Line<'static>>,
     scrollbar: Option<TranscriptScrollbar>,
+    jump_to_latest_button: Option<Rect>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -73,10 +76,12 @@ impl ChatWidget {
             app.viewport.last_transcript_visible = visible_lines;
             app.viewport.last_transcript_total = 0;
             app.viewport.last_transcript_padding_top = 0;
+            app.viewport.jump_to_latest_button_area = None;
             return Self {
                 content_area,
                 lines,
                 scrollbar: None,
+                jump_to_latest_button: None,
             };
         }
 
@@ -272,11 +277,19 @@ impl ChatWidget {
                 total: total_lines,
             },
         );
+        let jump_to_latest_button =
+            if app.use_mouse_capture && !app.viewport.transcript_scroll.is_at_tail() {
+                jump_to_latest_button_rect(content_area, scrollbar.is_some())
+            } else {
+                None
+            };
+        app.viewport.jump_to_latest_button_area = jump_to_latest_button;
 
         Self {
             content_area,
             lines,
             scrollbar,
+            jump_to_latest_button,
         }
     }
 }
@@ -327,11 +340,55 @@ impl Renderable for ChatWidget {
                 .thumb_style(Style::default().fg(palette::DEEPSEEK_SKY))
                 .render(area, buf, &mut state);
         }
+
+        if let Some(button_area) = self.jump_to_latest_button {
+            render_jump_to_latest_button(button_area, buf);
+        }
     }
 
     fn desired_height(&self, _width: u16) -> u16 {
         1
     }
+}
+
+fn jump_to_latest_button_rect(area: Rect, has_scrollbar: bool) -> Option<Rect> {
+    if area.width < JUMP_TO_LATEST_BUTTON_WIDTH + u16::from(has_scrollbar)
+        || area.height < JUMP_TO_LATEST_BUTTON_HEIGHT
+    {
+        return None;
+    }
+
+    let scrollbar_gutter = u16::from(has_scrollbar);
+    Some(Rect {
+        x: area
+            .x
+            .saturating_add(area.width)
+            .saturating_sub(scrollbar_gutter)
+            .saturating_sub(JUMP_TO_LATEST_BUTTON_WIDTH),
+        y: area
+            .y
+            .saturating_add(area.height)
+            .saturating_sub(JUMP_TO_LATEST_BUTTON_HEIGHT),
+        width: JUMP_TO_LATEST_BUTTON_WIDTH,
+        height: JUMP_TO_LATEST_BUTTON_HEIGHT,
+    })
+}
+
+fn render_jump_to_latest_button(area: Rect, buf: &mut Buffer) {
+    Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(palette::BORDER_COLOR))
+        .style(Style::default().bg(palette::DEEPSEEK_INK))
+        .render(area, buf);
+
+    let arrow_x = area.x.saturating_add(1);
+    let arrow_y = area.y.saturating_add(1);
+    buf[(arrow_x, arrow_y)].set_symbol("↓").set_style(
+        Style::default()
+            .fg(palette::DEEPSEEK_SKY)
+            .add_modifier(Modifier::BOLD),
+    );
 }
 
 pub struct ComposerWidget<'a> {
@@ -1947,6 +2004,7 @@ mod tests {
     use crate::palette;
     use crate::tui::app::{App, ComposerDensity, TuiOptions};
     use crate::tui::history::{GenericToolCell, HistoryCell, ToolCell, ToolStatus};
+    use crate::tui::scrolling::TranscriptScroll;
     use ratatui::{
         buffer::Buffer,
         layout::Rect,
@@ -2585,6 +2643,61 @@ mod tests {
             scrollbar_seen,
             "scrollbar should be visible for a long history"
         );
+    }
+
+    #[test]
+    fn chat_widget_shows_jump_to_latest_button_when_scrolled_up() {
+        let mut app = create_test_app();
+        app.use_mouse_capture = true;
+        for i in 0..80 {
+            app.add_message(HistoryCell::User {
+                content: format!("user message {i}"),
+            });
+        }
+        app.viewport.transcript_scroll = TranscriptScroll::at_line(0);
+
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 8,
+        };
+        let mut buf = Buffer::empty(area);
+        let widget = ChatWidget::new(&mut app, area);
+        widget.render(area, &mut buf);
+
+        let button = app
+            .viewport
+            .jump_to_latest_button_area
+            .expect("button appears when transcript is not at tail");
+        assert_eq!(button.width, 3);
+        assert_eq!(button.height, 3);
+        assert_eq!(buf[(button.x + 1, button.y + 1)].symbol(), "↓");
+    }
+
+    #[test]
+    fn chat_widget_hides_jump_to_latest_button_at_tail() {
+        let mut app = create_test_app();
+        app.use_mouse_capture = true;
+        for i in 0..80 {
+            app.add_message(HistoryCell::User {
+                content: format!("user message {i}"),
+            });
+        }
+        app.viewport.transcript_scroll = TranscriptScroll::to_bottom();
+
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 8,
+        };
+        let _widget = ChatWidget::new(&mut app, area);
+        assert!(
+            app.viewport.jump_to_latest_button_area.is_none(),
+            "button should hide while following the live tail"
+        );
+        assert!(app.viewport.transcript_scroll.is_at_tail());
     }
 
     /// Regression for issue #582: a resize event arriving while the


### PR DESCRIPTION
## Summary

Adds a jump-to-latest button to the transcript area when the user has scrolled away from the live tail.

- Shows a small `↓` button near the lower-right of the transcript while viewing older content
- Clicking the button scrolls back to the latest transcript content and hides the button
- Keeps the button hidden when mouse capture is disabled, so users do not see a non-clickable control
- Adds tests for button visibility and click behavior

<img width="274" height="175" alt="image" src="https://github.com/user-attachments/assets/e09a7acb-1dca-4fb5-ab95-763b61da61c0" />


## Testing

- [x] `cargo test --workspace --all-features`
- [x] `cargo fmt --all`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features`

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [x] Verified TUI behavior manually if UI changes

## Related Issue

Closes #971