### PR TITLE
Fix fixed-model auto thinking router stalls

### DIFF
--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -3390,7 +3390,7 @@ pub(crate) async fn resolve_subagent_assignment_route(
     let explicit_model = configured_model.is_some();
     let mut route = fallback_subagent_assignment_route(runtime, configured_model, prompt);
 
-    if (runtime.auto_model || runtime.reasoning_effort_auto)
+    if should_use_subagent_flash_router(runtime)
         && let Ok(Some(recommendation)) = subagent_flash_router(runtime, prompt).await
     {
         if runtime.auto_model && !explicit_model {
@@ -3405,6 +3405,10 @@ pub(crate) async fn resolve_subagent_assignment_route(
     }
 
     route
+}
+
+fn should_use_subagent_flash_router(runtime: &SubAgentRuntime) -> bool {
+    runtime.auto_model
 }
 
 fn fallback_subagent_assignment_route(

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -443,6 +443,26 @@ fn subagent_auto_reasoning_resolves_to_distinct_v4_tiers() {
 }
 
 #[test]
+fn fixed_model_subagent_auto_reasoning_skips_flash_router() {
+    let runtime = stub_runtime().with_reasoning_effort(Some("high".to_string()), true);
+
+    assert!(
+        !should_use_subagent_flash_router(&runtime),
+        "fixed-model auto thinking should resolve locally without a hidden router request"
+    );
+}
+
+#[test]
+fn auto_model_subagent_assignments_still_use_flash_router() {
+    let runtime = stub_runtime().with_auto_model(true);
+
+    assert!(
+        should_use_subagent_flash_router(&runtime),
+        "auto-model sub-agent assignments still need router guidance"
+    );
+}
+
+#[test]
 fn subagent_router_prompt_frames_assignment_as_auto_routing() {
     let runtime = stub_runtime()
         .with_auto_model(true)

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -3628,7 +3628,7 @@ async fn dispatch_user_message(
         persistence_actor::persist(PersistRequest::Checkpoint(session));
     }
 
-    let auto_selection = if app.auto_model || app.reasoning_effort == ReasoningEffort::Auto {
+    let auto_selection = if should_resolve_auto_model_selection(app) {
         Some(resolve_auto_model_selection(app, config, &message, &content).await)
     } else {
         None
@@ -3696,6 +3696,10 @@ async fn dispatch_user_message(
     }
 
     Ok(())
+}
+
+fn should_resolve_auto_model_selection(app: &App) -> bool {
+    app.auto_model
 }
 
 async fn resolve_auto_model_selection(

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -787,6 +787,31 @@ async fn dispatch_user_message_failed_send_clears_loading_state() {
     assert!(app.last_send_at.is_none());
 }
 
+#[test]
+fn fixed_model_auto_thinking_skips_auto_model_router() {
+    let mut app = create_test_app();
+    app.auto_model = false;
+    app.model = "deepseek-v4-pro".to_string();
+    app.reasoning_effort = ReasoningEffort::Auto;
+
+    assert!(
+        !should_resolve_auto_model_selection(&app),
+        "fixed-model auto thinking must stay local instead of starting a hidden router request"
+    );
+}
+
+#[test]
+fn auto_model_still_uses_auto_model_router() {
+    let mut app = create_test_app();
+    app.auto_model = true;
+    app.reasoning_effort = ReasoningEffort::Auto;
+
+    assert!(
+        should_resolve_auto_model_selection(&app),
+        "auto model still needs the router to choose the concrete model"
+    );
+}
+
 fn init_git_repo() -> TempDir {
     let dir = tempfile::tempdir().expect("tempdir");
 


### PR DESCRIPTION
Closes #973

## Summary
- keep fixed-model auto thinking on the local reasoning selector instead of making a hidden Flash router request before the real turn
- apply the same policy to sub-agent assignment routing so fixed-model auto thinking does not trigger an extra router call there either
- preserve router usage for true auto-model mode

## Test plan
- cargo test -p deepseek-tui fixed_model_auto_thinking_skips_auto_model_router --locked
- cargo test -p deepseek-tui fixed_model_subagent_auto_reasoning_skips_flash_router --locked
- cargo test -p deepseek-tui auto_model_still_uses_auto_model_router --locked
- cargo test -p deepseek-tui auto_model_subagent_assignments_still_use_flash_router --locked
- cargo fmt --all -- --check
- cargo test -p deepseek-tui tui::ui::tests --locked
- cargo test -p deepseek-tui tools::subagent::tests --locked
- git diff --check
- cargo test -p deepseek-tui --locked
- cargo clippy -p deepseek-tui --all-targets --all-features --locked -- -D warnings