### PR TITLE
feat: add ShengSuanYun provider support

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -197,6 +197,11 @@ max_subagents = 10 # optional (1-20)
 # base_url = "http://localhost:11434/v1"
 # model = "deepseek-coder:1.3b"             # or any local Ollama tag
 
+[providers.shengsuanyun]
+# api_key = "YOUR_SHENGSUANYUN_API_KEY"
+# base_url = "https://router.shengsuanyun.com/api/v1"
+# model = "deepseek/deepseek-v4-pro"
+
 # ─────────────────────────────────────────────────────────────────────────────────
 # Network Policy (#135)
 # ─────────────────────────────────────────────────────────────────────────────────

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -192,6 +192,28 @@ impl Default for ModelRegistry {
                 supports_tools: true,
                 supports_reasoning: false,
             },
+            ModelInfo {
+                id: "deepseek/deepseek-v4-pro".to_string(),
+                provider: ProviderKind::ShengSuanYun,
+                aliases: vec![
+                    "deepseek-v4-pro".to_string(),
+                    "shengsuanyun-deepseek-v4-pro".to_string(),
+                ],
+                supports_tools: true,
+                supports_reasoning: true,
+            },
+            ModelInfo {
+                id: "deepseek/deepseek-v4-flash".to_string(),
+                provider: ProviderKind::ShengSuanYun,
+                aliases: vec![
+                    "deepseek-v4-flash".to_string(),
+                    "deepseek-chat".to_string(),
+                    "deepseek-reasoner".to_string(),
+                    "shengsuanyun-deepseek-v4-flash".to_string(),
+                ],
+                supports_tools: true,
+                supports_reasoning: true,
+            },
         ];
         Self::new(models)
     }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -32,6 +32,7 @@ enum ProviderArg {
     Sglang,
     Vllm,
     Ollama,
+    Shengsuanyun,
 }
 
 impl From<ProviderArg> for ProviderKind {
@@ -46,6 +47,7 @@ impl From<ProviderArg> for ProviderKind {
             ProviderArg::Sglang => ProviderKind::Sglang,
             ProviderArg::Vllm => ProviderKind::Vllm,
             ProviderArg::Ollama => ProviderKind::Ollama,
+            ProviderArg::Shengsuanyun => ProviderKind::ShengSuanYun,
         }
     }
 }
@@ -666,11 +668,12 @@ fn provider_slot(provider: ProviderKind) -> &'static str {
         ProviderKind::Sglang => "sglang",
         ProviderKind::Vllm => "vllm",
         ProviderKind::Ollama => "ollama",
+        ProviderKind::ShengSuanYun => "shengsuanyun",
     }
 }
 
 /// Provider order used by the `auth list` and `auth status` outputs.
-const PROVIDER_LIST: [ProviderKind; 9] = [
+const PROVIDER_LIST: [ProviderKind; 10] = [
     ProviderKind::Deepseek,
     ProviderKind::NvidiaNim,
     ProviderKind::Openrouter,
@@ -680,6 +683,7 @@ const PROVIDER_LIST: [ProviderKind; 9] = [
     ProviderKind::Vllm,
     ProviderKind::Ollama,
     ProviderKind::Openai,
+    ProviderKind::ShengSuanYun,
 ];
 
 #[cfg(test)]
@@ -1302,9 +1306,10 @@ fn build_tui_command(
             | ProviderKind::Sglang
             | ProviderKind::Vllm
             | ProviderKind::Ollama
+            | ProviderKind::ShengSuanYun
     ) {
         bail!(
-            "The interactive TUI supports DeepSeek, NVIDIA NIM, OpenRouter, Novita, Fireworks, SGLang, vLLM, and Ollama providers. Remove --provider {} or use `deepseek model ...` for provider registry inspection.",
+            "The interactive TUI supports DeepSeek, NVIDIA NIM, OpenRouter, Novita, Fireworks, SGLang, vLLM, Ollama, and ShengSuanYun providers. Remove --provider {} or use `deepseek model ...` for provider registry inspection.",
             resolved_runtime.provider.as_str()
         );
     }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -37,7 +37,8 @@ const DEFAULT_VLLM_FLASH_MODEL: &str = "deepseek-ai/DeepSeek-V4-Flash";
 const DEFAULT_VLLM_BASE_URL: &str = "http://localhost:8000/v1";
 const DEFAULT_OLLAMA_MODEL: &str = "deepseek-coder:1.3b";
 const DEFAULT_OLLAMA_BASE_URL: &str = "http://localhost:11434/v1";
-
+const DEFAULT_SHENGSUANYUN_MODEL: &str = "deepseek/deepseek-v4-pro";
+const DEFAULT_SHENGSUANYUN_BASE_URL: &str = "https://router.shengsuanyun.com/api/v1";
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "kebab-case")]
 pub enum ProviderKind {
@@ -51,6 +52,7 @@ pub enum ProviderKind {
     Sglang,
     Vllm,
     Ollama,
+    ShengSuanYun,
 }
 
 impl ProviderKind {
@@ -66,6 +68,7 @@ impl ProviderKind {
             Self::Sglang => "sglang",
             Self::Vllm => "vllm",
             Self::Ollama => "ollama",
+            Self::ShengSuanYun => "shengsuanyun",
         }
     }
 
@@ -81,6 +84,7 @@ impl ProviderKind {
             "sglang" | "sg-lang" => Some(Self::Sglang),
             "vllm" | "v-llm" => Some(Self::Vllm),
             "ollama" | "ollama-local" => Some(Self::Ollama),
+            "shengsuanyun" | "sheng-suan-yun" => Some(Self::ShengSuanYun),
             _ => None,
         }
     }
@@ -115,6 +119,8 @@ pub struct ProvidersToml {
     pub vllm: ProviderConfigToml,
     #[serde(default)]
     pub ollama: ProviderConfigToml,
+    #[serde(default)]
+    pub shengsuanyun: ProviderConfigToml,
 }
 
 impl ProvidersToml {
@@ -130,6 +136,7 @@ impl ProvidersToml {
             ProviderKind::Sglang => &self.sglang,
             ProviderKind::Vllm => &self.vllm,
             ProviderKind::Ollama => &self.ollama,
+            ProviderKind::ShengSuanYun => &self.shengsuanyun,
         }
     }
 
@@ -144,6 +151,7 @@ impl ProvidersToml {
             ProviderKind::Sglang => &mut self.sglang,
             ProviderKind::Vllm => &mut self.vllm,
             ProviderKind::Ollama => &mut self.ollama,
+            ProviderKind::ShengSuanYun => &mut self.shengsuanyun,
         }
     }
 }
@@ -353,6 +361,10 @@ impl ConfigToml {
         merge_provider_config(&mut self.providers.sglang, &project.providers.sglang);
         merge_provider_config(&mut self.providers.vllm, &project.providers.vllm);
         merge_provider_config(&mut self.providers.ollama, &project.providers.ollama);
+        merge_provider_config(
+            &mut self.providers.shengsuanyun,
+            &project.providers.shengsuanyun,
+        );
 
         if project.network.is_some() {
             self.network = project.network;
@@ -441,6 +453,12 @@ impl ConfigToml {
             "providers.ollama.model" => self.providers.ollama.model.clone(),
             "providers.ollama.http_headers" => {
                 serialize_http_headers(&self.providers.ollama.http_headers)
+            }
+            "providers.shengsuanyun.api_key" => self.providers.shengsuanyun.api_key.clone(),
+            "providers.shengsuanyun.base_url" => self.providers.shengsuanyun.base_url.clone(),
+            "providers.shengsuanyun.model" => self.providers.shengsuanyun.model.clone(),
+            "providers.shengsuanyun.http_headers" => {
+                serialize_http_headers(&self.providers.shengsuanyun.http_headers)
             }
             _ => self.extras.get(key).map(toml::Value::to_string),
         }
@@ -577,6 +595,18 @@ impl ConfigToml {
             "providers.ollama.http_headers" => {
                 self.providers.ollama.http_headers = parse_http_headers(value)?;
             }
+            "providers.shengsuanyun.api_key" => {
+                self.providers.shengsuanyun.api_key = Some(value.to_string());
+            }
+            "providers.shengsuanyun.base_url" => {
+                self.providers.shengsuanyun.base_url = Some(value.to_string());
+            }
+            "providers.shengsuanyun.model" => {
+                self.providers.shengsuanyun.model = Some(value.to_string());
+            }
+            "providers.shengsuanyun.http_headers" => {
+                self.providers.shengsuanyun.http_headers = parse_http_headers(value)?;
+            }
             _ => {
                 self.extras
                     .insert(key.to_string(), toml::Value::String(value.to_string()));
@@ -649,6 +679,12 @@ impl ConfigToml {
             "providers.ollama.base_url" => self.providers.ollama.base_url = None,
             "providers.ollama.model" => self.providers.ollama.model = None,
             "providers.ollama.http_headers" => self.providers.ollama.http_headers.clear(),
+            "providers.shengsuanyun.api_key" => self.providers.shengsuanyun.api_key = None,
+            "providers.shengsuanyun.base_url" => self.providers.shengsuanyun.base_url = None,
+            "providers.shengsuanyun.model" => self.providers.shengsuanyun.model = None,
+            "providers.shengsuanyun.http_headers" => {
+                self.providers.shengsuanyun.http_headers.clear()
+            }
             _ => {
                 self.extras.remove(key);
             }
@@ -886,6 +922,7 @@ impl ConfigToml {
                 ProviderKind::Sglang => DEFAULT_SGLANG_BASE_URL.to_string(),
                 ProviderKind::Vllm => DEFAULT_VLLM_BASE_URL.to_string(),
                 ProviderKind::Ollama => DEFAULT_OLLAMA_BASE_URL.to_string(),
+                ProviderKind::ShengSuanYun => DEFAULT_SHENGSUANYUN_BASE_URL.to_string(),
             });
 
         let model = cli
@@ -905,6 +942,7 @@ impl ConfigToml {
                 ProviderKind::Sglang => DEFAULT_SGLANG_MODEL.to_string(),
                 ProviderKind::Vllm => DEFAULT_VLLM_MODEL.to_string(),
                 ProviderKind::Ollama => DEFAULT_OLLAMA_MODEL.to_string(),
+                ProviderKind::ShengSuanYun => DEFAULT_SHENGSUANYUN_MODEL.to_string(),
             });
         let model = normalize_model_for_provider(provider, &model);
 
@@ -1273,6 +1311,7 @@ struct EnvRuntimeOverrides {
     sglang_base_url: Option<String>,
     vllm_base_url: Option<String>,
     ollama_base_url: Option<String>,
+    shengsuanyun_base_url: Option<String>,
 }
 
 impl EnvRuntimeOverrides {
@@ -1323,6 +1362,9 @@ impl EnvRuntimeOverrides {
             ollama_base_url: std::env::var("OLLAMA_BASE_URL")
                 .ok()
                 .filter(|v| !v.trim().is_empty()),
+            shengsuanyun_base_url: std::env::var("SHENGSUANYUN_BASE_URL")
+                .ok()
+                .filter(|v| !v.trim().is_empty()),
         }
     }
 
@@ -1339,6 +1381,7 @@ impl EnvRuntimeOverrides {
             ProviderKind::Sglang => self.sglang_base_url.clone(),
             ProviderKind::Vllm => self.vllm_base_url.clone(),
             ProviderKind::Ollama => self.ollama_base_url.clone(),
+            ProviderKind::ShengSuanYun => self.shengsuanyun_base_url.clone(),
         }
     }
 }

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -809,7 +809,8 @@ pub(super) fn apply_reasoning_effort(
             | ApiProvider::Novita
             | ApiProvider::Fireworks
             | ApiProvider::Sglang
-            | ApiProvider::Vllm => {
+            | ApiProvider::Vllm
+            | ApiProvider::Shengsuanyun => {
                 body["thinking"] = json!({ "type": "disabled" });
             }
             ApiProvider::Ollama => {}
@@ -826,7 +827,8 @@ pub(super) fn apply_reasoning_effort(
             | ApiProvider::Novita
             | ApiProvider::Fireworks
             | ApiProvider::Sglang
-            | ApiProvider::Vllm => {
+            | ApiProvider::Vllm
+            | ApiProvider::Shengsuanyun => {
                 body["reasoning_effort"] = json!("high");
                 body["thinking"] = json!({ "type": "enabled" });
             }
@@ -845,7 +847,8 @@ pub(super) fn apply_reasoning_effort(
             | ApiProvider::Novita
             | ApiProvider::Fireworks
             | ApiProvider::Sglang
-            | ApiProvider::Vllm => {
+            | ApiProvider::Vllm
+            | ApiProvider::Shengsuanyun => {
                 body["reasoning_effort"] = json!("max");
                 body["thinking"] = json!({ "type": "enabled" });
             }

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -41,6 +41,8 @@ pub const DEFAULT_VLLM_BASE_URL: &str = "http://localhost:8000/v1";
 pub const DEFAULT_OLLAMA_MODEL: &str = "deepseek-coder:1.3b";
 pub const DEFAULT_OLLAMA_BASE_URL: &str = "http://localhost:11434/v1";
 pub const DEFAULT_DEEPSEEKCN_BASE_URL: &str = "https://api.deepseeki.com";
+pub const DEFAULT_SHENGSUANYUN_MODEL: &str = "deepseek/deepseek-v4-pro";
+pub const DEFAULT_SHENGSUANYUN_BASE_URL: &str = "https://router.shengsuanyun.com/api/v1";
 const API_KEYRING_SENTINEL: &str = "__KEYRING__";
 pub const COMMON_DEEPSEEK_MODELS: &[&str] = &[
     "deepseek-v4-pro",
@@ -63,6 +65,7 @@ pub enum ApiProvider {
     Sglang,
     Vllm,
     Ollama,
+    Shengsuanyun,
 }
 
 impl ApiProvider {
@@ -80,6 +83,7 @@ impl ApiProvider {
             "sglang" | "sg-lang" => Some(Self::Sglang),
             "vllm" | "v-llm" => Some(Self::Vllm),
             "ollama" | "ollama-local" => Some(Self::Ollama),
+            "shengsuanyun" | "sheng-suan-yun" => Some(Self::Shengsuanyun),
             _ => None,
         }
     }
@@ -96,6 +100,7 @@ impl ApiProvider {
             Self::Sglang => "sglang",
             Self::Vllm => "vllm",
             Self::Ollama => "ollama",
+            Self::Shengsuanyun => "shengsuanyun",
         }
     }
 
@@ -112,6 +117,7 @@ impl ApiProvider {
             Self::Sglang => "SGLang",
             Self::Vllm => "vLLM",
             Self::Ollama => "Ollama",
+            Self::Shengsuanyun => "ShengSuanYun",
         }
     }
 
@@ -128,6 +134,7 @@ impl ApiProvider {
             Self::Sglang,
             Self::Vllm,
             Self::Ollama,
+            Self::Shengsuanyun,
         ]
     }
 }
@@ -966,6 +973,8 @@ pub struct ProvidersConfig {
     pub vllm: ProviderConfig,
     #[serde(default)]
     pub ollama: ProviderConfig,
+    #[serde(default)]
+    pub shengsuanyun: ProviderConfig,
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
@@ -1146,6 +1155,7 @@ impl Config {
             ApiProvider::Sglang => &providers.sglang,
             ApiProvider::Vllm => &providers.vllm,
             ApiProvider::Ollama => &providers.ollama,
+            ApiProvider::Shengsuanyun => &providers.shengsuanyun,
         })
     }
 
@@ -1205,6 +1215,7 @@ impl Config {
             ApiProvider::Sglang => DEFAULT_SGLANG_MODEL,
             ApiProvider::Vllm => DEFAULT_VLLM_MODEL,
             ApiProvider::Ollama => DEFAULT_OLLAMA_MODEL,
+            ApiProvider::Shengsuanyun => DEFAULT_SHENGSUANYUN_MODEL,
         }
         .to_string()
     }
@@ -1232,7 +1243,8 @@ impl Config {
             | ApiProvider::Fireworks
             | ApiProvider::Sglang
             | ApiProvider::Vllm
-            | ApiProvider::Ollama => None,
+            | ApiProvider::Ollama
+            | ApiProvider::Shengsuanyun => None,
         };
         let base = provider_base.or(root_base).unwrap_or_else(|| {
             match provider {
@@ -1245,6 +1257,7 @@ impl Config {
                 ApiProvider::Sglang => DEFAULT_SGLANG_BASE_URL,
                 ApiProvider::Vllm => DEFAULT_VLLM_BASE_URL,
                 ApiProvider::Ollama => DEFAULT_OLLAMA_BASE_URL,
+                ApiProvider::Shengsuanyun => DEFAULT_SHENGSUANYUN_BASE_URL,
             }
             .to_string()
         });
@@ -1270,6 +1283,7 @@ impl Config {
             ApiProvider::Sglang => "sglang",
             ApiProvider::Vllm => "vllm",
             ApiProvider::Ollama => "ollama",
+            ApiProvider::Shengsuanyun => "shengsuanyun",
         };
 
         // 0. Explicit in-memory override (set by onboarding / provider
@@ -1332,7 +1346,10 @@ impl Config {
             ),
             // Self-hosted deployments commonly run without auth on localhost.
             // Return an empty key and let the client omit the Authorization header.
-            ApiProvider::Sglang | ApiProvider::Vllm | ApiProvider::Ollama => Ok(String::new()),
+            ApiProvider::Sglang
+            | ApiProvider::Vllm
+            | ApiProvider::Ollama
+            | ApiProvider::Shengsuanyun => Ok(String::new()),
         }
     }
 
@@ -1884,6 +1901,7 @@ fn apply_env_overrides(config: &mut Config) {
             ApiProvider::Sglang => &mut providers.sglang,
             ApiProvider::Vllm => &mut providers.vllm,
             ApiProvider::Ollama => &mut providers.ollama,
+            ApiProvider::Shengsuanyun => &mut providers.shengsuanyun,
         };
         let mut provider_headers = entry.http_headers.clone().unwrap_or_default();
         provider_headers.extend(headers);
@@ -2336,6 +2354,7 @@ fn merge_providers(
             sglang: merge_provider_config(base.sglang, override_cfg.sglang),
             vllm: merge_provider_config(base.vllm, override_cfg.vllm),
             ollama: merge_provider_config(base.ollama, override_cfg.ollama),
+            shengsuanyun: merge_provider_config(base.shengsuanyun, override_cfg.shengsuanyun),
         }),
     }
 }
@@ -2756,6 +2775,9 @@ pub fn active_provider_has_env_api_key(config: &Config) -> bool {
         ApiProvider::Sglang => std::env::var("SGLANG_API_KEY").is_ok_and(|k| !k.trim().is_empty()),
         ApiProvider::Vllm => std::env::var("VLLM_API_KEY").is_ok_and(|k| !k.trim().is_empty()),
         ApiProvider::Ollama => std::env::var("OLLAMA_API_KEY").is_ok_and(|k| !k.trim().is_empty()),
+        ApiProvider::Shengsuanyun => {
+            std::env::var("SHENGSUANYUN_API_KEY").is_ok_and(|k| !k.trim().is_empty())
+        }
     }
 }
 
@@ -2778,6 +2800,7 @@ pub fn has_api_key_for(config: &Config, provider: ApiProvider) -> bool {
         ApiProvider::Sglang => "SGLANG_API_KEY",
         ApiProvider::Vllm => "VLLM_API_KEY",
         ApiProvider::Ollama => "OLLAMA_API_KEY",
+        ApiProvider::Shengsuanyun => "SHENGSUANYUN_API_KEY",
     };
     if std::env::var(env_var).is_ok_and(|k| !k.trim().is_empty()) {
         return true;
@@ -2845,6 +2868,7 @@ pub fn save_api_key_for(provider: ApiProvider, api_key: &str) -> Result<PathBuf>
         ApiProvider::Sglang => "providers.sglang",
         ApiProvider::Vllm => "providers.vllm",
         ApiProvider::Ollama => "providers.ollama",
+        ApiProvider::Shengsuanyun => "providers.shengsuanyun",
     };
 
     // Parse existing TOML (or start fresh) so we can edit the right table
@@ -2878,6 +2902,7 @@ pub fn save_api_key_for(provider: ApiProvider, api_key: &str) -> Result<PathBuf>
         ApiProvider::Sglang => "sglang",
         ApiProvider::Vllm => "vllm",
         ApiProvider::Ollama => "ollama",
+        ApiProvider::Shengsuanyun => "shengsuanyun",
     };
     let entry = providers
         .entry(key_inside.to_string())

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -376,6 +376,7 @@ impl Engine {
             ApiProvider::Sglang => "SGLANG_API_KEY",
             ApiProvider::Vllm => "VLLM_API_KEY",
             ApiProvider::Ollama => "OLLAMA_API_KEY",
+            ApiProvider::Shengsuanyun => "SHENGSUANYUN_API_KEY",
         };
 
         Some(format!(

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -1358,6 +1358,10 @@ fn run_setup_status(config: &Config, workspace: &Path) -> Result<()> {
                 crate::config::ApiProvider::Ollama => {
                     ("OLLAMA_API_KEY", "deepseek auth set --provider ollama")
                 }
+                crate::config::ApiProvider::Shengsuanyun => (
+                    "SHENGSUANYUN_API_KEY",
+                    "deepseek auth set --provider shengsuanyun --api-key \"...\"",
+                ),
                 crate::config::ApiProvider::Deepseek | crate::config::ApiProvider::DeepseekCN => {
                     ("DEEPSEEK_API_KEY", "deepseek auth set --provider deepseek")
                 }
@@ -1373,6 +1377,7 @@ fn run_setup_status(config: &Config, workspace: &Path) -> Result<()> {
                     crate::config::ApiProvider::Sglang => "sglang",
                     crate::config::ApiProvider::Vllm => "vllm",
                     crate::config::ApiProvider::Ollama => "ollama",
+                    crate::config::ApiProvider::Shengsuanyun => "shengsuanyun",
                     crate::config::ApiProvider::Deepseek
                     | crate::config::ApiProvider::DeepseekCN => "deepseek",
                 }

--- a/crates/tui/src/tui/provider_picker.rs
+++ b/crates/tui/src/tui/provider_picker.rs
@@ -94,6 +94,7 @@ impl ProviderPickerView {
             ApiProvider::Sglang => "SGLANG_API_KEY",
             ApiProvider::Vllm => "VLLM_API_KEY",
             ApiProvider::Ollama => "OLLAMA_API_KEY",
+            ApiProvider::Shengsuanyun => "SHENGSUANYUN_API_KEY",
         }
     }
 

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -5083,6 +5083,7 @@ fn render(f: &mut Frame, app: &mut App) {
             crate::config::ApiProvider::Sglang => Some("SGLang"),
             crate::config::ApiProvider::Vllm => Some("vLLM"),
             crate::config::ApiProvider::Ollama => Some("Ollama"),
+            crate::config::ApiProvider::Shengsuanyun => Some("ShengSuanYun"),
         };
         let header_data = HeaderData::new(
             app.mode,
@@ -5714,6 +5715,7 @@ async fn apply_provider_picker_api_key(
             ApiProvider::Sglang => &mut providers.sglang,
             ApiProvider::Vllm => &mut providers.vllm,
             ApiProvider::Ollama => &mut providers.ollama,
+            ApiProvider::Shengsuanyun => &mut providers.shengsuanyun,
         };
         entry.api_key = Some(api_key);
     }


### PR DESCRIPTION
## Summary

Add support for ShengSuanYun (算筹云) as a new API provider, following the existing provider pattern used by DeepSeek, NVIDIA NIM, OpenRouter, Ollama, etc.

## Changes

- **Provider Infrastructure**: Add `ShengSuanYun` to `ProviderKind` enum across all crates
- **Configuration**: Add provider defaults (`deepseek/deepseek-v4-pro` model, `https://router.shengsuanyun.com/api/v1` base URL)
- **Model Registry**: Add ShengSuanYun entries for both v4-pro and v4-flash models with appropriate aliases
- **CLI & TUI**: Add provider argument and update all provider match expressions
- **Documentation**: Add example configuration section in `config.example.toml`

## Implementation Details

The provider uses the OpenAI-compatible API pattern with:
- Standard model IDs: `deepseek/deepseek-v4-pro`, `deepseek/deepseek-v4-flash`
- Thinking mode support for reasoning tasks
- Environment variable: `SHENGSUANYUN_API_KEY`, `SHENGSUANYUN_BASE_URL`
- Config section: `[providers.shengsuanyun]`
- CLI flag: `--provider shengsuanyun`

## Testing

- ✅ `cargo fmt --check` passes
- ✅ `cargo clippy` passes (only pre-existing warnings)
- ✅ `cargo build` succeeds
- ✅ Manually tested auth setup: `deepseek auth set --provider shengsuanyun`
- ✅ TUI launches with ShengSuanYun provider

## Related

This follows the same pattern established by existing providers and adheres to the guidelines in CONTRIBUTING.md.