### PR TITLE
fix(shell): force UTF-8 output on Windows via chcp 65001 (#982)

### DIFF
--- a/crates/tui/src/sandbox/mod.rs
+++ b/crates/tui/src/sandbox/mod.rs
@@ -78,10 +78,14 @@ impl CommandSpec {
     /// Create a `CommandSpec` for running a shell command via the platform shell.
     pub fn shell(command: &str, cwd: PathBuf, timeout: Duration) -> Self {
         #[cfg(windows)]
-        let (program, args) = (
-            "cmd".to_string(),
-            vec!["/C".to_string(), command.to_string()],
-        );
+        let (program, args) = {
+            // Force UTF-8 output on Windows by running `chcp 65001` before the
+            // actual command. Without this, subprocesses output in the system's
+            // ANSI code page (e.g. GBK for Chinese locales), causing garbled
+            // text in the shell output panel. See issue #982.
+            let cmd = format!("chcp 65001 >NUL & {command}");
+            ("cmd".to_string(), vec!["/C".to_string(), cmd])
+        };
         #[cfg(not(windows))]
         let (program, args) = (
             "sh".to_string(),

--- a/crates/tui/src/sandbox/mod.rs
+++ b/crates/tui/src/sandbox/mod.rs
@@ -149,7 +149,12 @@ impl CommandSpec {
             && self.args.len() == 2
             && self.args[0].eq_ignore_ascii_case("/C")
         {
-            self.args[1].clone()
+            // Strip the `chcp 65001 >NUL & ` prefix we add on Windows for
+            // UTF-8 output (issue #982).
+            let raw = &self.args[1];
+            raw.strip_prefix("chcp 65001 >NUL & ")
+                .unwrap_or(raw)
+                .to_string()
         } else {
             // For other commands, join program and args
             let mut parts = vec![self.program.clone()];
@@ -534,7 +539,11 @@ mod tests {
     fn expected_shell_command(command: &str) -> Vec<String> {
         #[cfg(windows)]
         {
-            vec!["cmd".to_string(), "/C".to_string(), command.to_string()]
+            vec![
+                "cmd".to_string(),
+                "/C".to_string(),
+                format!("chcp 65001 >NUL & {command}"),
+            ]
         }
         #[cfg(not(windows))]
         {
@@ -549,7 +558,7 @@ mod tests {
         #[cfg(windows)]
         {
             assert_eq!(spec.program, "cmd");
-            assert_eq!(spec.args, vec!["/C", "echo hello"]);
+            assert_eq!(spec.args, vec!["/C", "chcp 65001 >NUL & echo hello"]);
         }
         #[cfg(not(windows))]
         {


### PR DESCRIPTION
## Summary

- Force UTF-8 output on Windows by running `chcp 65001` before each shell command
- Fixes garbled Chinese/CJK text in the shell output panel on Windows

## Problem

On Windows with Chinese locale, the shell output panel displays garbled text (mojibake). For example, `whoami` output shows `缇絓13247` instead of `羽\13247`.

This happens because:
1. Windows subprocesses output in the system's ANSI code page (GBK/CP936 for Chinese)
2. The TUI decodes using `String::from_utf8_lossy` which assumes UTF-8
3. The mismatch causes garbled output

## Solution

Prefix each shell command with `chcp 65001 >NUL &` on Windows to force UTF-8 code page before execution:

```rust
// Before
cmd /C whoami

// After  
cmd /C chcp 65001 >NUL & whoami
```

The `>NUL` suppresses the code page change message so it doesn't appear in the output.

## Changes

| File | Change |
|------|--------|
| `sandbox/mod.rs` | Add `chcp 65001` prefix for Windows shell commands |

## Testing

- Verified on Windows 11 with Chinese Simplified locale
- `whoami` with CJK characters now displays correctly
- No impact on Unix systems (unchanged code path)

Fixes #982
