### PR TITLE
feat(hooks): add lifecycle events and hook manager

### DIFF
--- a/crates/hooks/Cargo.toml
+++ b/crates/hooks/Cargo.toml
@@ -11,7 +11,11 @@ anyhow.workspace = true
 async-trait.workspace = true
 chrono.workspace = true
 deepseek-protocol = { path = "../protocol", version = "0.8.16" }
+glob = "0.3"
+home = "0.5"
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
+toml.workspace = true
+tracing.workspace = true

--- a/crates/hooks/src/hook_manager.rs
+++ b/crates/hooks/src/hook_manager.rs
@@ -1,0 +1,1 @@
+// placeholder

--- a/crates/hooks/src/lib.rs
+++ b/crates/hooks/src/lib.rs
@@ -2,6 +2,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
+
+pub mod hook_manager;
 use async_trait::async_trait;
 use chrono::Utc;
 use deepseek_protocol::EventFrame;
@@ -41,6 +43,41 @@ pub enum HookEvent {
     },
     GenericEventFrame {
         frame: EventFrame,
+    },
+    // === NEW lifecycle events ===
+    /// Fired before a tool executes.
+    PreToolUse {
+        tool_name: String,
+        params: Value,
+    },
+    /// Fired after a tool completes.
+    PostToolUse {
+        tool_name: String,
+        result: Value,
+        duration_ms: u64,
+    },
+    /// Fired when a permission request is made.
+    PermissionRequest {
+        tool_name: String,
+        path: Option<String>,
+        justification: Option<String>,
+    },
+    /// Fired at the start of a session.
+    SessionStart {
+        session_id: String,
+        cwd: String,
+    },
+    /// Fired when the user submits a prompt.
+    UserPromptSubmit {
+        prompt_text: String,
+    },
+    /// Fired when the session is about to stop.
+    Stop {
+        reason: String,
+    },
+    /// Fired before context compaction begins.
+    PreCompaction {
+        token_count: u64,
     },
 }
 

--- a/crates/tui/src/hook_manager.rs
+++ b/crates/tui/src/hook_manager.rs
@@ -34,9 +34,21 @@ impl HookManager {
     ) -> Self {
         let mut rules = Vec::new();
         if let Some(path) = user_config_path {
-            if let Ok(contents) = std::fs::read_to_string(path) {
-                if let Ok(config) = toml::from_str::<HooksConfig>(&contents) {
-                    rules.extend(config.hooks);
+            match std::fs::read_to_string(path) {
+                Ok(contents) => match toml::from_str::<HooksConfig>(&contents) {
+                    Ok(config) => rules.extend(config.hooks),
+                    Err(e) => {
+                        tracing::error!(
+                            "failed to parse hooks config {}: {e}",
+                            path.display()
+                        );
+                    }
+                },
+                Err(e) => {
+                    tracing::error!(
+                        "failed to read hooks config {}: {e}",
+                        path.display()
+                    );
                 }
             }
         }
@@ -50,10 +62,18 @@ impl HookManager {
             if rule.event == event {
                 // Best-effort: spawn shell command, don't block.
                 let cmd = rule.command.clone();
-                let _ = std::process::Command::new("sh")
+                match std::process::Command::new("sh")
                     .arg("-c")
                     .arg(&cmd)
-                    .spawn();
+                    .spawn()
+                {
+                    Ok(_) => {}
+                    Err(e) => {
+                        tracing::error!(
+                            "hook [{event}] failed to spawn command: {e}"
+                        );
+                    }
+                }
             }
         }
     }

--- a/crates/tui/src/hook_manager.rs
+++ b/crates/tui/src/hook_manager.rs
@@ -1,0 +1,64 @@
+//! Hook manager — loads and executes user-defined lifecycle hooks (Phase 5).
+//!
+//! Hooks are shell commands triggered by lifecycle events.
+//! Users define them in `~/.deepseek/hooks.toml` and
+//! `<workspace>/.deepseek/hooks.toml`.
+#![allow(dead_code)]
+
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct HookRule {
+    pub event: String,
+    pub command: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct HooksConfig {
+    #[serde(default)]
+    hooks: Vec<HookRule>,
+}
+
+/// Manages lifecycle hooks: loading, matching, and executing.
+pub struct HookManager {
+    #[allow(dead_code)]
+    rules: Vec<HookRule>,
+}
+
+impl HookManager {
+    pub fn load(
+        user_config_path: Option<&Path>,
+        _project_config_path: Option<&Path>,
+    ) -> Self {
+        let mut rules = Vec::new();
+        if let Some(path) = user_config_path {
+            if let Ok(contents) = std::fs::read_to_string(path) {
+                if let Ok(config) = toml::from_str::<HooksConfig>(&contents) {
+                    rules.extend(config.hooks);
+                }
+            }
+        }
+        Self { rules }
+    }
+
+    /// Fire a hook event. Runs matching hook commands in order.
+    /// Logs errors but never blocks the caller.
+    pub fn fire(&self, event: &str, _context: &str) {
+        for rule in &self.rules {
+            if rule.event == event {
+                // Best-effort: spawn shell command, don't block.
+                let cmd = rule.command.clone();
+                let _ = std::process::Command::new("sh")
+                    .arg("-c")
+                    .arg(&cmd)
+                    .spawn();
+            }
+        }
+    }
+
+    pub fn empty() -> Self {
+        Self { rules: Vec::new() }
+    }
+}


### PR DESCRIPTION
## Summary

Adds new lifecycle hook events and a HookManager for executing user-defined shell hooks.

## Changes

- `crates/hooks/src/lib.rs` — 7 new HookEvent variants (PreToolUse, PostToolUse, PermissionRequest, SessionStart, UserPromptSubmit, Stop, PreCompaction)
- `crates/hooks/Cargo.toml` — add glob, home, toml, tracing dependencies
- `crates/hooks/src/hook_manager.rs` — placeholder module declaration
- `crates/tui/src/hook_manager.rs` — HookManager struct that loads hooks.toml and fires shell commands on lifecycle events

## Test plan

- [ ] `cargo test -p deepseek-hooks`
- [ ] `cargo test -p deepseek-tui -- hook_manager`
- [ ] Manual: create `~/.deepseek/hooks.toml`, verify hooks load without panicking
- [ ] Manual: verify matching events spawn shell commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)