### PR TITLE
fix(npm): guard unsupported node during install

### DIFF
--- a/npm/deepseek-tui/scripts/install.js
+++ b/npm/deepseek-tui/scripts/install.js
@@ -1,3 +1,18 @@
+function assertSupportedNode() {
+  const version = process.versions && process.versions.node ? process.versions.node : "unknown";
+  const major = Number.parseInt(String(version).split(".")[0], 10);
+  if (Number.isNaN(major) || major < 18) {
+    process.stderr.write(
+      "deepseek-tui: Node.js 18 or newer is required for npm installation. " +
+      `Current Node.js version is ${version}. ` +
+      "Please upgrade Node.js and rerun `npm install -g deepseek-tui`.\n",
+    );
+    process.exit(1);
+  }
+}
+
+assertSupportedNode();
+
 const fs = require("fs");
 const https = require("https");
 const http = require("http");
@@ -355,8 +370,14 @@ function connectThroughProxy(proxy, targetHost, targetPort, timeoutMs) {
 // ────────────────────────────────────────────────────────────────────────────
 
 function httpRequest(rawUrl, opts = {}) {
-  const totalTimeoutMs = opts.totalTimeoutMs ?? downloadTimeoutMs();
-  const stallMs = opts.stallMs ?? downloadStallMs();
+  const totalTimeoutMs =
+    opts.totalTimeoutMs === undefined || opts.totalTimeoutMs === null
+      ? downloadTimeoutMs()
+      : opts.totalTimeoutMs;
+  const stallMs =
+    opts.stallMs === undefined || opts.stallMs === null
+      ? downloadStallMs()
+      : opts.stallMs;
 
   return new Promise((resolve, reject) => {
     let url;

--- a/npm/deepseek-tui/test/install.test.js
+++ b/npm/deepseek-tui/test/install.test.js
@@ -1,0 +1,23 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const installScript = fs.readFileSync(
+  path.join(__dirname, "..", "scripts", "install.js"),
+  "utf8",
+);
+
+test("install script checks Node support before loading helpers", () => {
+  const guardIndex = installScript.indexOf("assertSupportedNode();");
+  const firstRequireIndex = installScript.indexOf("require(");
+
+  assert.notEqual(guardIndex, -1);
+  assert.notEqual(firstRequireIndex, -1);
+  assert.ok(guardIndex < firstRequireIndex);
+});
+
+test("install script remains parseable before the Node support guard runs", () => {
+  assert.equal(installScript.includes("??"), false);
+  assert.equal(installScript.includes("?."), false);
+});


### PR DESCRIPTION
## Summary
- Add an early Node.js version guard to the npm install script before local helpers are loaded.
- Replace nullish coalescing in `install.js` so Node 12 can parse far enough to show the supported-version error.
- Add a regression test that keeps the guard before `require()` and blocks `??` / `?.` in the install script.

## Linked Issue / Scope
Fixes #1016.

This keeps the package requirement at Node.js >=18. It improves the failure mode for older Node/npm installations; it does not add Node 12 support.

## AI-use disclosure
Assisted by AI.

## Human-owner statement
I have reviewed the diff and can explain every changed file.

## Verification
- `node --check scripts\\install.js`
- `node --test test\\*.test.js`