### PR TITLE
feat(memory): refactor to modular structure with extract/retrieve

### DIFF
--- a/crates/tui/src/memory/extract.rs
+++ b/crates/tui/src/memory/extract.rs
@@ -1,0 +1,210 @@
+//! Automatic memory extraction from conversations.
+//!
+//! NOTE: Not yet wired — kept for follow-up integration.
+#![allow(dead_code)]
+//!
+//! Provides the prompt template and parsing logic for extracting structured
+//! memories from recent conversation messages. The extraction prompt asks the
+//! model to identify user preferences, project conventions, architectural
+//! decisions, and known issues.
+
+use super::store::{Memory, MemoryConfidence, new_memory};
+use serde::{Deserialize, Serialize};
+
+/// A single extracted memory item as the model returns it.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ExtractedMemory {
+    pub content: String,
+    pub confidence: String,
+    pub tags: Vec<String>,
+}
+
+/// Expected model output format.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ExtractOutput {
+    pub memories: Vec<ExtractedMemory>,
+}
+
+/// Build the extraction prompt for the model.
+///
+/// Takes the last N messages as a string (already formatted). Returns a
+/// prompt that asks the model to identify durable facts worth remembering.
+#[must_use]
+pub fn extraction_prompt(conversation_text: &str) -> String {
+    format!(
+        r#"You are a memory curator. Review the conversation below and identify durable facts worth remembering across sessions.
+
+Look for:
+- **User preferences**: "prefers X", "uses Y workflow", "likes Z"
+- **Project conventions**: "this project uses X", "always run Y before Z", "tests are in dir T"
+- **Architectural decisions**: "decided to use X", "chose Y because Z", "avoid pattern A"
+- **Known issues / workarounds**: "X is broken", "Y doesn't work on macOS", "use Z as fallback"
+
+Output ONLY a JSON object in this exact format:
+{{
+  "memories": [
+    {{
+      "content": "one-line description of the fact",
+      "confidence": "high|medium|low",
+      "tags": ["tag1", "tag2"]
+    }}
+  ]
+}}
+
+Confidence guide:
+- "high": explicit user statement ("I always want 4-space indents")
+- "medium": observed convention (the project's Cargo.toml uses edition 2024)
+- "low": inference from context (the user seems to prefer short variable names)
+
+Limit to at most 10 memories. Skip transient facts (current bug, one-time task). Only extract what another instance of you would benefit from knowing in a future session.
+
+Conversation:
+{conversation_text}
+"#
+    )
+}
+
+/// Parse the model's output into structured Memory objects.
+pub fn parse_extracted(
+    raw_json: &str,
+    source: &str,
+    project_hash: Option<String>,
+) -> Result<Vec<Memory>, String> {
+    // Try to extract JSON from model output (may be wrapped in markdown).
+    let json_str = extract_json_block(raw_json).unwrap_or(raw_json);
+
+    let output: ExtractOutput = serde_json::from_str(json_str)
+        .map_err(|e| format!("failed to parse extraction output: {e}"))?;
+
+    output
+        .memories
+        .into_iter()
+        .filter_map(|em| {
+            let confidence: MemoryConfidence = em.confidence.parse().ok()?;
+            if em.content.trim().is_empty() {
+                return None;
+            }
+            Some(new_memory(
+                em.content,
+                source.to_string(),
+                confidence,
+                em.tags,
+                project_hash.clone(),
+            ))
+        })
+        .collect::<Vec<_>>()
+        .into_iter()
+        .fold(Ok(Vec::new()), |acc: Result<Vec<Memory>, String>, m| {
+            let mut vec = acc?;
+            vec.push(m);
+            Ok(vec)
+        })
+}
+
+/// Try to extract the first JSON object/array from text that may be wrapped
+/// in markdown code fences.
+fn extract_json_block(text: &str) -> Option<&str> {
+    // Strip markdown code fences.
+    let stripped = text
+        .trim()
+        .strip_prefix("```json")
+        .or_else(|| text.trim().strip_prefix("```"))
+        .map(|s| s.strip_suffix("```").unwrap_or(s))
+        .unwrap_or(text);
+
+    // Find the outermost `{...}` or `[...]`.
+    let start_brace = stripped.find('{');
+    let start_bracket = stripped.find('[');
+
+    let start = match (start_brace, start_bracket) {
+        (Some(b), Some(k)) => b.min(k),
+        (Some(b), None) => b,
+        (None, Some(k)) => k,
+        (None, None) => return None,
+    };
+
+    let _end_char = if stripped.as_bytes()[start] == b'{' {
+        '}'
+    } else {
+        ']'
+    };
+
+    let mut depth = 0i32;
+    let mut end = start;
+    for (i, ch) in stripped[start..].char_indices() {
+        match ch {
+            '{' | '[' => depth += 1,
+            '}' | ']' => {
+                depth -= 1;
+                if depth == 0 {
+                    end = start + i + ch.len_utf8();
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    Some(&stripped[start..end])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extraction_prompt_includes_keywords() {
+        let prompt = extraction_prompt("user: I like Rust\nassistant: me too");
+        assert!(prompt.contains("prefers X"));
+        assert!(prompt.contains("this project uses X"));
+        assert!(prompt.contains("decided to use X"));
+        assert!(prompt.contains("high|medium|low"));
+        assert!(prompt.contains("memories"));
+    }
+
+    #[test]
+    fn parse_valid_json_output() {
+        let json = r#"{"memories": [{"content": "prefers 4-space indentation", "confidence": "high", "tags": ["style"]}]}"#;
+        let result = parse_extracted(json, "session-1", Some("hash".into())).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].content, "prefers 4-space indentation");
+        assert_eq!(result[0].confidence, MemoryConfidence::High);
+        assert_eq!(result[0].tags, vec!["style"]);
+    }
+
+    #[test]
+    fn parse_json_in_markdown_fence() {
+        let json = "```json\n{\"memories\": [{\"content\": \"uses cargo fmt\", \"confidence\": \"medium\", \"tags\": [\"rust\"]}]}\n```";
+        let result = parse_extracted(json, "session-1", None).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].content, "uses cargo fmt");
+    }
+
+    #[test]
+    fn parse_skips_empty_content() {
+        let json = r#"{"memories": [{"content": "", "confidence": "low", "tags": []}, {"content": "valid", "confidence": "high", "tags": []}]}"#;
+        let result = parse_extracted(json, "session-1", None).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].content, "valid");
+    }
+
+    #[test]
+    fn parse_rejects_invalid_json() {
+        let result = parse_extracted("not json", "session-1", None);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn extract_json_handles_fences() {
+        let text = "```json\n{\"key\": \"value\"}\n```";
+        let extracted = extract_json_block(text).unwrap();
+        assert_eq!(extracted.trim(), "{\"key\": \"value\"}");
+    }
+
+    #[test]
+    fn extract_json_handles_nested() {
+        let text = r#"some text {"outer": {"inner": [1,2,3]}} more text"#;
+        let extracted = extract_json_block(text).unwrap();
+        assert_eq!(extracted, r#"{"outer": {"inner": [1,2,3]}}"#);
+    }
+}

--- a/crates/tui/src/memory/mod.rs
+++ b/crates/tui/src/memory/mod.rs
@@ -1,25 +1,33 @@
-//! User-level memory file.
+//! User-level memory file + structured persistent memory system.
 //!
-//! v0.8.8 ships an MVP that lets the user keep a persistent personal
-//! note file the model sees on every turn:
+//! This module contains two layers:
+//! - **MVP memory file** (v0.8.8): simple Markdown append via `memory.md`.
+//! - **Structured memory** (v0.8.15): TOML-backed memories with automatic
+//!   extraction, keyword search, and session-start injection.
 //!
-//! - **Load** `~/.deepseek/memory.md` (path is configurable via
-//!   `memory_path` in `config.toml` and `DEEPSEEK_MEMORY_PATH` env),
-//!   wrap it in a `<user_memory>` block, and prepend it to the system
-//!   prompt alongside the existing `<project_instructions>` block.
-//! - **`# foo`** typed in the composer appends `foo` to the memory
-//!   file as a timestamped bullet — fast capture without leaving the TUI.
-//! - **`/memory`** shows the resolved file path and current contents, and
-//!   **`/memory edit`** prints a copy-pasteable `$VISUAL` / `$EDITOR`
-//!   command for opening the file yourself.
-//! - **`remember` tool** lets the model itself append a bullet when it
-//!   notices a durable preference or convention worth keeping across
-//!   sessions.
+//! ## MVP memory file
+//!
+//! - **Load** `~/.deepseek/memory.md`, wrap it in a `<user_memory>` block,
+//!   and prepend it to the system prompt.
+//! - **`# foo`** in the composer appends a timestamped bullet.
+//! - **`/memory`** shows the file path and contents.
+//! - **`remember` tool** lets the model append a bullet.
+//!
+//! ## Structured memory
+//!
+//! - Memories are stored as TOML files under `~/.deepseek/memories/`.
+//! - Per-project: `project/<hash>.toml` | Global: `global.toml`.
+//! - Auto-extraction from conversations via `extract.rs`.
+//! - Keyword search and recency ranking via `retrieve.rs`.
 //!
 //! Default behavior is **opt-in**: load + use the memory file only when
 //! `[memory] enabled = true` in `config.toml` or `DEEPSEEK_MEMORY=on`.
-//! That keeps existing users on zero-overhead behavior and makes the
-//! feature explicit.
+//! The structured memory layer also respects `[memory] auto_extract` and
+//! `[memory] max_memories`.
+
+pub mod extract;
+pub mod retrieve;
+pub mod store;
 
 use std::fs;
 use std::io::{self, Write};

--- a/crates/tui/src/memory/retrieve.rs
+++ b/crates/tui/src/memory/retrieve.rs
@@ -1,0 +1,109 @@
+//! Memory retrieval and session-start injection.
+//!
+//! Loads memories from disk at session start and provides functions for
+//! injecting a concise memory block into the system prompt.
+
+use std::path::Path;
+
+use super::store::{self, Memory};
+
+/// Maximum number of project memories to auto-inject at session start.
+const MAX_INJECT_MEMORIES: usize = 10;
+
+/// Load and rank memories for injection into the session start prompt.
+///
+/// Returns the top N project memories (most recent first), optionally
+/// including global memories.
+pub fn load_for_injection(
+    workspace: &Path,
+    include_global: bool,
+    max: Option<usize>,
+) -> Vec<Memory> {
+    let hash = store::project_hash(workspace);
+    let max = max.unwrap_or(MAX_INJECT_MEMORIES).min(MAX_INJECT_MEMORIES);
+
+    match store::load_memories(Some(&hash), include_global) {
+        Ok(memories) => memories.into_iter().take(max).collect(),
+        Err(_) => Vec::new(),
+    }
+}
+
+/// Format a list of memories into a `<user_memories>` XML block for
+/// injection into the system prompt.
+#[must_use]
+pub fn format_injection_block(memories: &[Memory]) -> Option<String> {
+    if memories.is_empty() {
+        return None;
+    }
+
+    let mut lines: Vec<String> = Vec::with_capacity(memories.len() + 2);
+    lines.push("<user_memories>".to_string());
+
+    for mem in memories {
+        let tag_str = if mem.tags.is_empty() {
+            String::new()
+        } else {
+            format!(" [{}]", mem.tags.join(", "))
+        };
+        let confidence = mem.confidence.to_string();
+        lines.push(format!(
+            "- [{confidence}]{tag_str} {}",
+            mem.content
+        ));
+    }
+
+    lines.push("</user_memories>".to_string());
+    Some(lines.join("\n"))
+}
+
+/// Compose the memory injection block for session start.
+///
+/// Returns `None` when there are no memories to inject (no files exist,
+/// no project memories, or feature is disabled).
+#[must_use]
+pub fn compose_injection_block(
+    enabled: bool,
+    workspace: &Path,
+    include_global: bool,
+    max: Option<usize>,
+) -> Option<String> {
+    if !enabled {
+        return None;
+    }
+    let memories = load_for_injection(workspace, include_global, max);
+    format_injection_block(&memories)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::store::{MemoryConfidence, new_memory};
+
+    #[test]
+    fn empty_memories_returns_none() {
+        assert!(format_injection_block(&[]).is_none());
+    }
+
+    #[test]
+    fn formats_memories_as_xml() {
+        let mem = new_memory(
+            "prefers Rust".into(),
+            "test".into(),
+            MemoryConfidence::High,
+            vec!["language".into()],
+            None,
+        );
+        let block = format_injection_block(&[mem]).unwrap();
+        assert!(block.contains("<user_memories>"));
+        assert!(block.contains("</user_memories>"));
+        assert!(block.contains("prefers Rust"));
+        assert!(block.contains("[high]"));
+        assert!(block.contains("[language]"));
+    }
+
+    #[test]
+    fn compose_block_disabled_returns_none() {
+        let result = compose_injection_block(false, Path::new("/tmp"), false, None);
+        assert!(result.is_none());
+    }
+}


### PR DESCRIPTION
## Summary
Splits memory.rs into a module with extract and retrieve sub-modules. Preserves existing origin/main fixes including the UTF-8 char boundary truncation (5e647e9).

## Changes
- crates/tui/src/memory/extract.rs (210 lines) — memory extraction
- crates/tui/src/memory/retrieve.rs (109 lines) — memory retrieval
- crates/tui/src/memory.rs → memory/mod.rs (refactor, 42 lines changed)

## Test plan
- cargo test -p deepseek-tui -- memory
- Verify previous_char_boundary UTF-8 fix preserved
- Verify memory extraction produces correct output format