### PR TITLE
fix(clear): reset session telemetry

### DIFF
--- a/crates/tui/src/commands/core.rs
+++ b/crates/tui/src/commands/core.rs
@@ -52,7 +52,10 @@ pub fn clear(app: &mut App) -> CommandResult {
     app.viewport.transcript_selection.clear();
     app.queued_messages.clear();
     app.queued_draft = None;
+    app.session.total_tokens = 0;
     app.session.total_conversation_tokens = 0;
+    app.session.session_cost = 0.0;
+    app.session.session_cost_cny = 0.0;
     let todos_cleared = app.clear_todos();
     app.tool_log.clear();
     app.tool_cells.clear();
@@ -63,6 +66,9 @@ pub fn clear(app: &mut App) -> CommandResult {
     app.last_exec_wait_command = None;
     app.session.last_prompt_tokens = None;
     app.session.last_completion_tokens = None;
+    app.session.last_prompt_cache_hit_tokens = None;
+    app.session.last_prompt_cache_miss_tokens = None;
+    app.session.turn_cache_history.clear();
     app.current_session_id = None;
     let locale = app.ui_locale;
     let message = if todos_cleared {
@@ -295,9 +301,10 @@ mod tests {
     use super::*;
     use crate::config::Config;
     use crate::models::Message;
-    use crate::tui::app::{App, AppMode, TuiOptions};
+    use crate::tui::app::{App, AppMode, TuiOptions, TurnCacheRecord};
     use crate::tui::history::HistoryCell;
     use std::path::PathBuf;
+    use std::time::Instant;
 
     fn create_test_app() -> App {
         let options = TuiOptions {
@@ -422,6 +429,35 @@ mod tests {
         assert!(app.tool_details_by_cell.is_empty());
         assert!(app.current_session_id.is_none());
         assert!(matches!(result.action, Some(AppAction::SyncSession { .. })));
+    }
+
+    #[test]
+    fn clear_resets_session_telemetry() {
+        let mut app = create_test_app();
+        app.session.total_tokens = 234;
+        app.session.total_conversation_tokens = 123;
+        app.session.session_cost = 0.42;
+        app.session.session_cost_cny = 3.05;
+        app.session.last_prompt_cache_hit_tokens = Some(70);
+        app.session.last_prompt_cache_miss_tokens = Some(30);
+        app.push_turn_cache_record(TurnCacheRecord {
+            input_tokens: 100,
+            output_tokens: 25,
+            cache_hit_tokens: Some(70),
+            cache_miss_tokens: Some(30),
+            reasoning_replay_tokens: Some(12),
+            recorded_at: Instant::now(),
+        });
+
+        clear(&mut app);
+
+        assert_eq!(app.session.total_tokens, 0);
+        assert_eq!(app.session.total_conversation_tokens, 0);
+        assert_eq!(app.session.session_cost, 0.0);
+        assert_eq!(app.session.session_cost_cny, 0.0);
+        assert_eq!(app.session.last_prompt_cache_hit_tokens, None);
+        assert_eq!(app.session.last_prompt_cache_miss_tokens, None);
+        assert!(app.session.turn_cache_history.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Reset session token totals and session cost counters when `/clear` runs.
- Clear last-turn cache telemetry and the per-turn cache history ring.
- Add a regression test covering the stale `/tokens`, `/cost`, and `/cache` state from the issue.

## Linked Issue / Scope
Fixes #999.

This is intentionally limited to conversation/session telemetry owned by `/clear`; it does not change sub-agent cost accounting or command behavior outside the clear reset.

## AI-use disclosure
Assisted by AI.

## Human-owner statement
I have reviewed the diff and can explain every changed file.

## Verification
- `cargo test -p deepseek-tui clear_resets_session_telemetry --locked`
- `cargo fmt --all -- --check`
- `cargo test -p deepseek-tui --locked`
- `cargo clippy -p deepseek-tui --all-targets --all-features --locked -- -D warnings`