### PR TITLE
feat(providers): add opencode-go provider support

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -16,7 +16,7 @@
 # `/provider sglang`, `/provider vllm`, `/provider ollama`) toggle without having to
 # re-enter keys. Top-level `api_key` / `base_url` are still read as DeepSeek
 # defaults when `[providers.deepseek]` is absent (backward compatibility).
-provider = "deepseek" # deepseek | deepseek-cn | nvidia-nim | openai | openrouter | novita | fireworks | sglang | vllm | ollama
+provider = "deepseek" # deepseek | deepseek-cn | nvidia-nim | openai | openrouter | novita | fireworks | sglang | vllm | ollama | opencode-go
 api_key = "YOUR_DEEPSEEK_API_KEY" # must be non-empty
 base_url = "https://api.deepseek.com/beta"
 # base_url = "https://api.deepseeki.com"         # China users
@@ -188,6 +188,12 @@ max_subagents = 10 # optional (1-20)
 # api_key = "YOUR_FIREWORKS_API_KEY"
 # base_url = "https://api.fireworks.ai/inference/v1"
 # model = "accounts/fireworks/models/deepseek-v4-pro"
+
+# OpenCode Go — free DeepSeek V4 endpoint via opencode.ai (https://opencode.ai)
+[providers.opencode_go]
+# api_key = "YOUR_OPENCODE_API_KEY"
+# base_url = "https://opencode.ai/zen/go/v1"
+# model = "deepseek-v4-pro"     # or deepseek-v4-flash
 
 # Self-hosted SGLang OpenAI-compatible server
 [providers.sglang]

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -32,6 +32,7 @@ enum ProviderArg {
     Sglang,
     Vllm,
     Ollama,
+    OpencodeGo,
 }
 
 impl From<ProviderArg> for ProviderKind {
@@ -46,6 +47,7 @@ impl From<ProviderArg> for ProviderKind {
             ProviderArg::Sglang => ProviderKind::Sglang,
             ProviderArg::Vllm => ProviderKind::Vllm,
             ProviderArg::Ollama => ProviderKind::Ollama,
+            ProviderArg::OpencodeGo => ProviderKind::OpencodeGo,
         }
     }
 }
@@ -666,11 +668,12 @@ fn provider_slot(provider: ProviderKind) -> &'static str {
         ProviderKind::Sglang => "sglang",
         ProviderKind::Vllm => "vllm",
         ProviderKind::Ollama => "ollama",
+        ProviderKind::OpencodeGo => "opencode-go",
     }
 }
 
 /// Provider order used by the `auth list` and `auth status` outputs.
-const PROVIDER_LIST: [ProviderKind; 9] = [
+const PROVIDER_LIST: [ProviderKind; 10] = [
     ProviderKind::Deepseek,
     ProviderKind::NvidiaNim,
     ProviderKind::Openrouter,
@@ -680,6 +683,7 @@ const PROVIDER_LIST: [ProviderKind; 9] = [
     ProviderKind::Vllm,
     ProviderKind::Ollama,
     ProviderKind::Openai,
+    ProviderKind::OpencodeGo,
 ];
 
 #[cfg(test)]
@@ -735,6 +739,7 @@ fn provider_env_vars(provider: ProviderKind) -> &'static [&'static str] {
         ProviderKind::Vllm => &["VLLM_API_KEY"],
         ProviderKind::Ollama => &["OLLAMA_API_KEY"],
         ProviderKind::Openai => &["OPENAI_API_KEY"],
+        ProviderKind::OpencodeGo => &["OPENCODE_GO_API_KEY"],
     }
 }
 

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -37,6 +37,9 @@ const DEFAULT_VLLM_FLASH_MODEL: &str = "deepseek-ai/DeepSeek-V4-Flash";
 const DEFAULT_VLLM_BASE_URL: &str = "http://localhost:8000/v1";
 const DEFAULT_OLLAMA_MODEL: &str = "deepseek-coder:1.3b";
 const DEFAULT_OLLAMA_BASE_URL: &str = "http://localhost:11434/v1";
+const DEFAULT_OPENCODE_GO_MODEL: &str = "deepseek-v4-pro";
+const DEFAULT_OPENCODE_GO_FLASH_MODEL: &str = "deepseek-v4-flash";
+const DEFAULT_OPENCODE_GO_BASE_URL: &str = "https://opencode.ai/zen/go/v1";
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "kebab-case")]
@@ -51,6 +54,7 @@ pub enum ProviderKind {
     Sglang,
     Vllm,
     Ollama,
+    OpencodeGo,
 }
 
 impl ProviderKind {
@@ -66,6 +70,7 @@ impl ProviderKind {
             Self::Sglang => "sglang",
             Self::Vllm => "vllm",
             Self::Ollama => "ollama",
+            Self::OpencodeGo => "opencode-go",
         }
     }
 
@@ -81,6 +86,7 @@ impl ProviderKind {
             "sglang" | "sg-lang" => Some(Self::Sglang),
             "vllm" | "v-llm" => Some(Self::Vllm),
             "ollama" | "ollama-local" => Some(Self::Ollama),
+            "opencode-go" | "opencode_go" | "opencodego" => Some(Self::OpencodeGo),
             _ => None,
         }
     }
@@ -115,6 +121,8 @@ pub struct ProvidersToml {
     pub vllm: ProviderConfigToml,
     #[serde(default)]
     pub ollama: ProviderConfigToml,
+    #[serde(default)]
+    pub opencode_go: ProviderConfigToml,
 }
 
 impl ProvidersToml {
@@ -130,6 +138,7 @@ impl ProvidersToml {
             ProviderKind::Sglang => &self.sglang,
             ProviderKind::Vllm => &self.vllm,
             ProviderKind::Ollama => &self.ollama,
+            ProviderKind::OpencodeGo => &self.opencode_go,
         }
     }
 
@@ -144,6 +153,7 @@ impl ProvidersToml {
             ProviderKind::Sglang => &mut self.sglang,
             ProviderKind::Vllm => &mut self.vllm,
             ProviderKind::Ollama => &mut self.ollama,
+            ProviderKind::OpencodeGo => &mut self.opencode_go,
         }
     }
 }
@@ -353,6 +363,7 @@ impl ConfigToml {
         merge_provider_config(&mut self.providers.sglang, &project.providers.sglang);
         merge_provider_config(&mut self.providers.vllm, &project.providers.vllm);
         merge_provider_config(&mut self.providers.ollama, &project.providers.ollama);
+        merge_provider_config(&mut self.providers.opencode_go, &project.providers.opencode_go);
 
         if project.network.is_some() {
             self.network = project.network;
@@ -441,6 +452,12 @@ impl ConfigToml {
             "providers.ollama.model" => self.providers.ollama.model.clone(),
             "providers.ollama.http_headers" => {
                 serialize_http_headers(&self.providers.ollama.http_headers)
+            }
+            "providers.opencode_go.api_key" => self.providers.opencode_go.api_key.clone(),
+            "providers.opencode_go.base_url" => self.providers.opencode_go.base_url.clone(),
+            "providers.opencode_go.model" => self.providers.opencode_go.model.clone(),
+            "providers.opencode_go.http_headers" => {
+                serialize_http_headers(&self.providers.opencode_go.http_headers)
             }
             _ => self.extras.get(key).map(toml::Value::to_string),
         }
@@ -577,6 +594,18 @@ impl ConfigToml {
             "providers.ollama.http_headers" => {
                 self.providers.ollama.http_headers = parse_http_headers(value)?;
             }
+            "providers.opencode_go.api_key" => {
+                self.providers.opencode_go.api_key = Some(value.to_string());
+            }
+            "providers.opencode_go.base_url" => {
+                self.providers.opencode_go.base_url = Some(value.to_string());
+            }
+            "providers.opencode_go.model" => {
+                self.providers.opencode_go.model = Some(value.to_string());
+            }
+            "providers.opencode_go.http_headers" => {
+                self.providers.opencode_go.http_headers = parse_http_headers(value)?;
+            }
             _ => {
                 self.extras
                     .insert(key.to_string(), toml::Value::String(value.to_string()));
@@ -649,6 +678,10 @@ impl ConfigToml {
             "providers.ollama.base_url" => self.providers.ollama.base_url = None,
             "providers.ollama.model" => self.providers.ollama.model = None,
             "providers.ollama.http_headers" => self.providers.ollama.http_headers.clear(),
+            "providers.opencode_go.api_key" => self.providers.opencode_go.api_key = None,
+            "providers.opencode_go.base_url" => self.providers.opencode_go.base_url = None,
+            "providers.opencode_go.model" => self.providers.opencode_go.model = None,
+            "providers.opencode_go.http_headers" => self.providers.opencode_go.http_headers.clear(),
             _ => {
                 self.extras.remove(key);
             }
@@ -808,6 +841,18 @@ impl ConfigToml {
         if let Some(v) = serialize_http_headers(&self.providers.ollama.http_headers) {
             out.insert("providers.ollama.http_headers".to_string(), v);
         }
+        if let Some(v) = self.providers.opencode_go.api_key.as_ref() {
+            out.insert("providers.opencode_go.api_key".to_string(), redact_secret(v));
+        }
+        if let Some(v) = self.providers.opencode_go.base_url.as_ref() {
+            out.insert("providers.opencode_go.base_url".to_string(), v.clone());
+        }
+        if let Some(v) = self.providers.opencode_go.model.as_ref() {
+            out.insert("providers.opencode_go.model".to_string(), v.clone());
+        }
+        if let Some(v) = serialize_http_headers(&self.providers.opencode_go.http_headers) {
+            out.insert("providers.opencode_go.http_headers".to_string(), v);
+        }
 
         for (k, v) in &self.extras {
             out.insert(k.clone(), v.to_string());
@@ -886,6 +931,7 @@ impl ConfigToml {
                 ProviderKind::Sglang => DEFAULT_SGLANG_BASE_URL.to_string(),
                 ProviderKind::Vllm => DEFAULT_VLLM_BASE_URL.to_string(),
                 ProviderKind::Ollama => DEFAULT_OLLAMA_BASE_URL.to_string(),
+                ProviderKind::OpencodeGo => DEFAULT_OPENCODE_GO_BASE_URL.to_string(),
             });
 
         let model = cli
@@ -905,6 +951,7 @@ impl ConfigToml {
                 ProviderKind::Sglang => DEFAULT_SGLANG_MODEL.to_string(),
                 ProviderKind::Vllm => DEFAULT_VLLM_MODEL.to_string(),
                 ProviderKind::Ollama => DEFAULT_OLLAMA_MODEL.to_string(),
+                ProviderKind::OpencodeGo => DEFAULT_OPENCODE_GO_MODEL.to_string(),
             });
         let model = normalize_model_for_provider(provider, &model);
 
@@ -1039,6 +1086,14 @@ fn normalize_model_for_provider(provider: ProviderKind, model: &str) -> String {
             "deepseek-v4-flash" | "deepseek-v4flash" | "deepseek-chat" | "deepseek-reasoner"
             | "deepseek-r1" | "deepseek-v3" | "deepseek-v3.2",
         ) => DEFAULT_VLLM_FLASH_MODEL.to_string(),
+        (ProviderKind::OpencodeGo, "deepseek-v4-pro" | "deepseek-v4pro") => {
+            DEFAULT_OPENCODE_GO_MODEL.to_string()
+        }
+        (
+            ProviderKind::OpencodeGo,
+            "deepseek-v4-flash" | "deepseek-v4flash" | "deepseek-chat" | "deepseek-reasoner"
+            | "deepseek-r1" | "deepseek-v3" | "deepseek-v3.2",
+        ) => DEFAULT_OPENCODE_GO_FLASH_MODEL.to_string(),
         _ => model.to_string(),
     }
 }
@@ -1283,6 +1338,7 @@ struct EnvRuntimeOverrides {
     sglang_base_url: Option<String>,
     vllm_base_url: Option<String>,
     ollama_base_url: Option<String>,
+    opencode_go_base_url: Option<String>,
 }
 
 impl EnvRuntimeOverrides {
@@ -1333,6 +1389,9 @@ impl EnvRuntimeOverrides {
             ollama_base_url: std::env::var("OLLAMA_BASE_URL")
                 .ok()
                 .filter(|v| !v.trim().is_empty()),
+            opencode_go_base_url: std::env::var("OPENCODE_GO_BASE_URL")
+                .ok()
+                .filter(|v| !v.trim().is_empty()),
         }
     }
 
@@ -1349,6 +1408,7 @@ impl EnvRuntimeOverrides {
             ProviderKind::Sglang => self.sglang_base_url.clone(),
             ProviderKind::Vllm => self.vllm_base_url.clone(),
             ProviderKind::Ollama => self.ollama_base_url.clone(),
+            ProviderKind::OpencodeGo => self.opencode_go_base_url.clone(),
         }
     }
 }
@@ -1388,6 +1448,8 @@ mod tests {
         vllm_base_url: Option<OsString>,
         ollama_api_key: Option<OsString>,
         ollama_base_url: Option<OsString>,
+        opencode_go_api_key: Option<OsString>,
+        opencode_go_base_url: Option<OsString>,
     }
 
     impl EnvGuard {
@@ -1415,6 +1477,8 @@ mod tests {
                 vllm_base_url: env::var_os("VLLM_BASE_URL"),
                 ollama_api_key: env::var_os("OLLAMA_API_KEY"),
                 ollama_base_url: env::var_os("OLLAMA_BASE_URL"),
+                opencode_go_api_key: env::var_os("OPENCODE_GO_API_KEY"),
+                opencode_go_base_url: env::var_os("OPENCODE_GO_BASE_URL"),
             };
             // Safety: test-only environment mutation guarded by a module mutex.
             unsafe {
@@ -1440,6 +1504,8 @@ mod tests {
                 env::remove_var("VLLM_BASE_URL");
                 env::remove_var("OLLAMA_API_KEY");
                 env::remove_var("OLLAMA_BASE_URL");
+                env::remove_var("OPENCODE_GO_API_KEY");
+                env::remove_var("OPENCODE_GO_BASE_URL");
             }
             guard
         }
@@ -1479,6 +1545,8 @@ mod tests {
                 Self::restore_var("VLLM_BASE_URL", self.vllm_base_url.take());
                 Self::restore_var("OLLAMA_API_KEY", self.ollama_api_key.take());
                 Self::restore_var("OLLAMA_BASE_URL", self.ollama_base_url.take());
+                Self::restore_var("OPENCODE_GO_API_KEY", self.opencode_go_api_key.take());
+                Self::restore_var("OPENCODE_GO_BASE_URL", self.opencode_go_base_url.take());
             }
         }
     }

--- a/crates/secrets/src/lib.rs
+++ b/crates/secrets/src/lib.rs
@@ -434,6 +434,7 @@ pub fn env_for(name: &str) -> Option<String> {
         "vllm" | "v-llm" => &["VLLM_API_KEY"],
         "ollama" | "ollama-local" => &["OLLAMA_API_KEY"],
         "openai" => &["OPENAI_API_KEY"],
+        "opencode-go" | "opencode_go" | "opencodego" => &["OPENCODE_GO_API_KEY"],
         _ => return None,
     };
     for var in candidates {

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -822,7 +822,8 @@ pub(super) fn apply_reasoning_effort(
             | ApiProvider::Novita
             | ApiProvider::Fireworks
             | ApiProvider::Sglang
-            | ApiProvider::Vllm => {
+            | ApiProvider::Vllm
+            | ApiProvider::OpencodeGo => {
                 body["thinking"] = json!({ "type": "disabled" });
             }
             ApiProvider::Openai | ApiProvider::Ollama => {}
@@ -839,7 +840,8 @@ pub(super) fn apply_reasoning_effort(
             | ApiProvider::Novita
             | ApiProvider::Fireworks
             | ApiProvider::Sglang
-            | ApiProvider::Vllm => {
+            | ApiProvider::Vllm
+            | ApiProvider::OpencodeGo => {
                 body["reasoning_effort"] = json!("high");
                 body["thinking"] = json!({ "type": "enabled" });
             }
@@ -858,7 +860,8 @@ pub(super) fn apply_reasoning_effort(
             | ApiProvider::Novita
             | ApiProvider::Fireworks
             | ApiProvider::Sglang
-            | ApiProvider::Vllm => {
+            | ApiProvider::Vllm
+            | ApiProvider::OpencodeGo => {
                 body["reasoning_effort"] = json!("max");
                 body["thinking"] = json!({ "type": "enabled" });
             }

--- a/crates/tui/src/commands/provider.rs
+++ b/crates/tui/src/commands/provider.rs
@@ -27,13 +27,13 @@ pub fn provider(app: &mut App, args: Option<&str>) -> CommandResult {
 
     let Some(target) = ApiProvider::parse(name) else {
         return CommandResult::error(format!(
-            "Unknown provider '{name}'. Expected: deepseek, nvidia-nim, openrouter, novita, fireworks, sglang, vllm, or ollama."
+            "Unknown provider '{name}'. Expected: deepseek, nvidia-nim, openrouter, novita, fireworks, sglang, vllm, ollama, or opencode-go."
         ));
     };
 
     let model = match model_arg {
         None => None,
-        Some(raw) if target == ApiProvider::Ollama => Some(raw.trim().to_string()),
+        Some(raw) if target == ApiProvider::Ollama || target == ApiProvider::OpencodeGo => Some(raw.trim().to_string()),
         Some(raw) => match normalize_model_name(&expand_model_alias(raw)) {
             Some(normalized) => Some(normalized),
             None => {

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -42,6 +42,9 @@ pub const DEFAULT_VLLM_FLASH_MODEL: &str = "deepseek-ai/DeepSeek-V4-Flash";
 pub const DEFAULT_VLLM_BASE_URL: &str = "http://localhost:8000/v1";
 pub const DEFAULT_OLLAMA_MODEL: &str = "deepseek-coder:1.3b";
 pub const DEFAULT_OLLAMA_BASE_URL: &str = "http://localhost:11434/v1";
+pub const DEFAULT_OPENCODE_GO_MODEL: &str = "deepseek-v4-pro";
+pub const DEFAULT_OPENCODE_GO_FLASH_MODEL: &str = "deepseek-v4-flash";
+pub const DEFAULT_OPENCODE_GO_BASE_URL: &str = "https://opencode.ai/zen/go/v1";
 pub const DEFAULT_DEEPSEEKCN_BASE_URL: &str = "https://api.deepseeki.com";
 const API_KEYRING_SENTINEL: &str = "__KEYRING__";
 pub const COMMON_DEEPSEEK_MODELS: &[&str] = &[
@@ -66,6 +69,7 @@ pub enum ApiProvider {
     Sglang,
     Vllm,
     Ollama,
+    OpencodeGo,
 }
 
 impl ApiProvider {
@@ -84,6 +88,7 @@ impl ApiProvider {
             "sglang" | "sg-lang" => Some(Self::Sglang),
             "vllm" | "v-llm" => Some(Self::Vllm),
             "ollama" | "ollama-local" => Some(Self::Ollama),
+            "opencode-go" | "opencode_go" | "opencodego" => Some(Self::OpencodeGo),
             _ => None,
         }
     }
@@ -101,6 +106,7 @@ impl ApiProvider {
             Self::Sglang => "sglang",
             Self::Vllm => "vllm",
             Self::Ollama => "ollama",
+            Self::OpencodeGo => "opencode-go",
         }
     }
 
@@ -118,6 +124,7 @@ impl ApiProvider {
             Self::Sglang => "SGLang",
             Self::Vllm => "vLLM",
             Self::Ollama => "Ollama",
+            Self::OpencodeGo => "OpenCode Go",
         }
     }
 
@@ -135,6 +142,7 @@ impl ApiProvider {
             Self::Sglang,
             Self::Vllm,
             Self::Ollama,
+            Self::OpencodeGo,
         ]
     }
 }
@@ -1029,6 +1037,8 @@ pub struct ProvidersConfig {
     pub vllm: ProviderConfig,
     #[serde(default)]
     pub ollama: ProviderConfig,
+    #[serde(default)]
+    pub opencode_go: ProviderConfig,
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
@@ -1088,7 +1098,7 @@ impl Config {
             && ApiProvider::parse(provider).is_none()
         {
             anyhow::bail!(
-                "Invalid provider '{provider}': expected deepseek, deepseek-cn, nvidia-nim, openai, openrouter, novita, fireworks, sglang, vllm, or ollama."
+                "Invalid provider '{provider}': expected deepseek, deepseek-cn, nvidia-nim, openai, openrouter, novita, fireworks, sglang, vllm, ollama, or opencode-go."
             );
         }
         if let Some(ref key) = self.api_key
@@ -1210,6 +1220,7 @@ impl Config {
             ApiProvider::Sglang => &providers.sglang,
             ApiProvider::Vllm => &providers.vllm,
             ApiProvider::Ollama => &providers.ollama,
+            ApiProvider::OpencodeGo => &providers.opencode_go,
         })
     }
 
@@ -1270,6 +1281,7 @@ impl Config {
             ApiProvider::Sglang => DEFAULT_SGLANG_MODEL,
             ApiProvider::Vllm => DEFAULT_VLLM_MODEL,
             ApiProvider::Ollama => DEFAULT_OLLAMA_MODEL,
+            ApiProvider::OpencodeGo => DEFAULT_OPENCODE_GO_MODEL,
         }
         .to_string()
     }
@@ -1298,7 +1310,8 @@ impl Config {
             | ApiProvider::Fireworks
             | ApiProvider::Sglang
             | ApiProvider::Vllm
-            | ApiProvider::Ollama => None,
+            | ApiProvider::Ollama
+            | ApiProvider::OpencodeGo => None,
         };
         let base = provider_base.or(root_base).unwrap_or_else(|| {
             match provider {
@@ -1312,6 +1325,7 @@ impl Config {
                 ApiProvider::Sglang => DEFAULT_SGLANG_BASE_URL,
                 ApiProvider::Vllm => DEFAULT_VLLM_BASE_URL,
                 ApiProvider::Ollama => DEFAULT_OLLAMA_BASE_URL,
+                ApiProvider::OpencodeGo => DEFAULT_OPENCODE_GO_BASE_URL,
             }
             .to_string()
         });
@@ -1338,6 +1352,7 @@ impl Config {
             ApiProvider::Sglang => "sglang",
             ApiProvider::Vllm => "vllm",
             ApiProvider::Ollama => "ollama",
+            ApiProvider::OpencodeGo => "opencode-go",
         };
 
         // 0. Explicit in-memory override (set by onboarding / provider
@@ -1405,6 +1420,10 @@ impl Config {
             // Self-hosted deployments commonly run without auth on localhost.
             // Return an empty key and let the client omit the Authorization header.
             ApiProvider::Sglang | ApiProvider::Vllm | ApiProvider::Ollama => Ok(String::new()),
+            ApiProvider::OpencodeGo => anyhow::bail!(
+                "OpenCode Go API key not found. Run 'deepseek auth set --provider opencode-go', \
+                 set OPENCODE_GO_API_KEY, or add [providers.opencode_go] api_key in ~/.deepseek/config.toml."
+            ),
         }
     }
 
@@ -1978,6 +1997,7 @@ fn apply_env_overrides(config: &mut Config) {
             ApiProvider::Sglang => &mut providers.sglang,
             ApiProvider::Vllm => &mut providers.vllm,
             ApiProvider::Ollama => &mut providers.ollama,
+            ApiProvider::OpencodeGo => &mut providers.opencode_go,
         };
         let mut provider_headers = entry.http_headers.clone().unwrap_or_default();
         provider_headers.extend(headers);
@@ -1991,6 +2011,16 @@ fn apply_env_overrides(config: &mut Config) {
             .providers
             .get_or_insert_with(ProvidersConfig::default)
             .ollama
+            .base_url = Some(value);
+    }
+    if matches!(config.api_provider(), ApiProvider::OpencodeGo)
+        && let Ok(value) = std::env::var("OPENCODE_GO_BASE_URL")
+        && !value.trim().is_empty()
+    {
+        config
+            .providers
+            .get_or_insert_with(ProvidersConfig::default)
+            .opencode_go
             .base_url = Some(value);
     }
     if matches!(config.api_provider(), ApiProvider::Sglang)
@@ -2238,6 +2268,11 @@ fn normalize_model_config(config: &mut Config) {
         {
             providers.vllm.model = Some(normalized);
         }
+        if let Some(model) = providers.opencode_go.model.as_deref()
+            && let Some(normalized) = normalize_model_for_provider(ApiProvider::OpencodeGo, model)
+        {
+            providers.opencode_go.model = Some(normalized);
+        }
     }
 }
 
@@ -2272,6 +2307,8 @@ fn model_for_provider(provider: ApiProvider, normalized: String) -> String {
         (ApiProvider::Sglang, "deepseek-v4-flash") => DEFAULT_SGLANG_FLASH_MODEL.to_string(),
         (ApiProvider::Vllm, "deepseek-v4-pro") => DEFAULT_VLLM_MODEL.to_string(),
         (ApiProvider::Vllm, "deepseek-v4-flash") => DEFAULT_VLLM_FLASH_MODEL.to_string(),
+        (ApiProvider::OpencodeGo, "deepseek-v4-pro") => DEFAULT_OPENCODE_GO_MODEL.to_string(),
+        (ApiProvider::OpencodeGo, "deepseek-v4-flash") => DEFAULT_OPENCODE_GO_FLASH_MODEL.to_string(),
         _ => normalized,
     }
 }
@@ -2440,6 +2477,7 @@ fn merge_providers(
             sglang: merge_provider_config(base.sglang, override_cfg.sglang),
             vllm: merge_provider_config(base.vllm, override_cfg.vllm),
             ollama: merge_provider_config(base.ollama, override_cfg.ollama),
+            opencode_go: merge_provider_config(base.opencode_go, override_cfg.opencode_go),
         }),
     }
 }
@@ -2861,6 +2899,7 @@ pub fn active_provider_has_env_api_key(config: &Config) -> bool {
         ApiProvider::Sglang => std::env::var("SGLANG_API_KEY").is_ok_and(|k| !k.trim().is_empty()),
         ApiProvider::Vllm => std::env::var("VLLM_API_KEY").is_ok_and(|k| !k.trim().is_empty()),
         ApiProvider::Ollama => std::env::var("OLLAMA_API_KEY").is_ok_and(|k| !k.trim().is_empty()),
+        ApiProvider::OpencodeGo => std::env::var("OPENCODE_GO_API_KEY").is_ok_and(|k| !k.trim().is_empty()),
     }
 }
 
@@ -2884,6 +2923,7 @@ pub fn has_api_key_for(config: &Config, provider: ApiProvider) -> bool {
         ApiProvider::Sglang => "SGLANG_API_KEY",
         ApiProvider::Vllm => "VLLM_API_KEY",
         ApiProvider::Ollama => "OLLAMA_API_KEY",
+        ApiProvider::OpencodeGo => "OPENCODE_GO_API_KEY",
     };
     if std::env::var(env_var).is_ok_and(|k| !k.trim().is_empty()) {
         return true;
@@ -2952,6 +2992,7 @@ pub fn save_api_key_for(provider: ApiProvider, api_key: &str) -> Result<PathBuf>
         ApiProvider::Sglang => "providers.sglang",
         ApiProvider::Vllm => "providers.vllm",
         ApiProvider::Ollama => "providers.ollama",
+        ApiProvider::OpencodeGo => "providers.opencode_go",
     };
 
     // Parse existing TOML (or start fresh) so we can edit the right table
@@ -2986,6 +3027,7 @@ pub fn save_api_key_for(provider: ApiProvider, api_key: &str) -> Result<PathBuf>
         ApiProvider::Sglang => "sglang",
         ApiProvider::Vllm => "vllm",
         ApiProvider::Ollama => "ollama",
+        ApiProvider::OpencodeGo => "opencode_go",
     };
     let entry = providers
         .entry(key_inside.to_string())

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -377,6 +377,7 @@ impl Engine {
             ApiProvider::Sglang => "SGLANG_API_KEY",
             ApiProvider::Vllm => "VLLM_API_KEY",
             ApiProvider::Ollama => "OLLAMA_API_KEY",
+            ApiProvider::OpencodeGo => "OPENCODE_GO_API_KEY",
         };
 
         Some(format!(

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -1363,6 +1363,9 @@ fn run_setup_status(config: &Config, workspace: &Path) -> Result<()> {
                 crate::config::ApiProvider::Ollama => {
                     ("OLLAMA_API_KEY", "deepseek auth set --provider ollama")
                 }
+                crate::config::ApiProvider::OpencodeGo => {
+                    ("OPENCODE_GO_API_KEY", "deepseek auth set --provider opencode-go")
+                }
                 crate::config::ApiProvider::Deepseek | crate::config::ApiProvider::DeepseekCN => {
                     ("DEEPSEEK_API_KEY", "deepseek auth set --provider deepseek")
                 }
@@ -1379,6 +1382,7 @@ fn run_setup_status(config: &Config, workspace: &Path) -> Result<()> {
                     crate::config::ApiProvider::Sglang => "sglang",
                     crate::config::ApiProvider::Vllm => "vllm",
                     crate::config::ApiProvider::Ollama => "ollama",
+                    crate::config::ApiProvider::OpencodeGo => "opencode_go",
                     crate::config::ApiProvider::Deepseek
                     | crate::config::ApiProvider::DeepseekCN => "deepseek",
                 }
@@ -1613,6 +1617,11 @@ async fn run_doctor(config: &Config, workspace: &Path, config_path_override: Opt
             crate::config::ApiProvider::Ollama,
             "ollama",
             &["OLLAMA_API_KEY"][..],
+        ),
+        (
+            crate::config::ApiProvider::OpencodeGo,
+            "opencode-go",
+            &["OPENCODE_GO_API_KEY"][..],
         ),
     ] {
         let in_env = env_names.iter().any(|n| {

--- a/crates/tui/src/tui/provider_picker.rs
+++ b/crates/tui/src/tui/provider_picker.rs
@@ -95,6 +95,7 @@ impl ProviderPickerView {
             ApiProvider::Sglang => "SGLANG_API_KEY",
             ApiProvider::Vllm => "VLLM_API_KEY",
             ApiProvider::Ollama => "OLLAMA_API_KEY",
+            ApiProvider::OpencodeGo => "OPENCODE_GO_API_KEY",
         }
     }
 
@@ -399,7 +400,8 @@ mod tests {
                 "Fireworks AI",
                 "SGLang",
                 "vLLM",
-                "Ollama"
+                "Ollama",
+                "OpenCode Go",
             ]
         );
     }

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -5186,6 +5186,7 @@ fn render(f: &mut Frame, app: &mut App) {
             crate::config::ApiProvider::Sglang => Some("SGLang"),
             crate::config::ApiProvider::Vllm => Some("vLLM"),
             crate::config::ApiProvider::Ollama => Some("Ollama"),
+            crate::config::ApiProvider::OpencodeGo => Some("OC-Go"),
         };
         let header_data = HeaderData::new(
             app.mode,
@@ -5820,6 +5821,7 @@ async fn apply_provider_picker_api_key(
             ApiProvider::Sglang => &mut providers.sglang,
             ApiProvider::Vllm => &mut providers.vllm,
             ApiProvider::Ollama => &mut providers.ollama,
+            ApiProvider::OpencodeGo => &mut providers.opencode_go,
         };
         entry.api_key = Some(api_key);
     }


### PR DESCRIPTION
Adds OpenCode Go (opencode.ai/zen/go/v1) as a new hosted DeepSeek V4 provider alongside the existing roster.

Changes:
- New `ApiProvider::OpencodeGo` / `ProviderKind::OpencodeGo` variants with canonical ID "opencode-go"
- Default base URL: https://opencode.ai/zen/go/v1
- Default models: deepseek-v4-pro (Pro) / deepseek-v4-flash (Flash)
- API key sourced from OPENCODE_GO_API_KEY env var or [providers.opencode_go] api_key in config.toml
- Full integration across all provider-aware surfaces: config loading/merging, CLI auth commands, provider picker TUI, thinking/reasoning-effort payloads, doctor diagnostics, secrets env_for lookup, and the dispatcher runtime resolver
- `config.example.toml` updated with [providers.opencode_go] example
- Provider picker test updated to include "OpenCode Go" in the list

Usage:
  provider = "opencode-go"   # in config.toml
  --provider opencode-go     # CLI flag
  /provider opencode-go      # in-TUI slash command

## Summary

## Testing

- [x] `cargo test --all-features`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features`

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [x] Verified TUI behavior manually if UI changes
