### PR TITLE
fix: resolve session telemetry, symlink, windows shell, and npm bugs

### DIFF
--- a/crates/tui/src/commands/core.rs
+++ b/crates/tui/src/commands/core.rs
@@ -52,6 +52,7 @@ pub fn clear(app: &mut App) -> CommandResult {
     app.viewport.transcript_selection.clear();
     app.queued_messages.clear();
     app.queued_draft = None;
+    app.session.total_tokens = 0;
     app.session.total_conversation_tokens = 0;
     let todos_cleared = app.clear_todos();
     app.tool_log.clear();
@@ -63,6 +64,15 @@ pub fn clear(app: &mut App) -> CommandResult {
     app.last_exec_wait_command = None;
     app.session.last_prompt_tokens = None;
     app.session.last_completion_tokens = None;
+    app.session.last_prompt_cache_hit_tokens = None;
+    app.session.last_prompt_cache_miss_tokens = None;
+    app.session.last_reasoning_replay_tokens = None;
+    app.session.turn_cache_history.clear();
+    app.session.session_cost = 0.0;
+    app.session.session_cost_cny = 0.0;
+    app.session.subagent_cost = 0.0;
+    app.session.subagent_cost_cny = 0.0;
+    app.session.subagent_cost_event_seqs.clear();
     app.current_session_id = None;
     let locale = app.ui_locale;
     let message = if todos_cleared {
@@ -408,7 +418,23 @@ mod tests {
             role: "user".to_string(),
             content: vec![],
         });
+        app.session.total_tokens = 500;
         app.session.total_conversation_tokens = 100;
+        app.session.session_cost = 1.23;
+        app.session.session_cost_cny = 8.76;
+        app.session.subagent_cost = 0.50;
+        app.session.subagent_cost_cny = 3.55;
+        app.session.last_prompt_cache_hit_tokens = Some(10_000);
+        app.session.last_prompt_cache_miss_tokens = Some(2_000);
+        app.session.last_reasoning_replay_tokens = Some(500);
+        app.push_turn_cache_record(crate::tui::app::TurnCacheRecord {
+            input_tokens: 12_000,
+            output_tokens: 300,
+            cache_hit_tokens: Some(10_000),
+            cache_miss_tokens: Some(2_000),
+            reasoning_replay_tokens: Some(500),
+            recorded_at: std::time::Instant::now(),
+        });
         app.tool_log.push("test".to_string());
         app.current_session_id = Some("existing-session".to_string());
 
@@ -416,7 +442,16 @@ mod tests {
         assert!(result.message.is_some());
         assert!(app.history.is_empty());
         assert!(app.api_messages.is_empty());
+        assert_eq!(app.session.total_tokens, 0, "total_tokens must be zeroed");
         assert_eq!(app.session.total_conversation_tokens, 0);
+        assert_eq!(app.session.session_cost, 0.0, "session_cost must be zeroed");
+        assert_eq!(app.session.session_cost_cny, 0.0);
+        assert_eq!(app.session.subagent_cost, 0.0, "subagent_cost must be zeroed");
+        assert_eq!(app.session.subagent_cost_cny, 0.0);
+        assert!(app.session.last_prompt_cache_hit_tokens.is_none(), "cache hit tokens must be cleared");
+        assert!(app.session.last_prompt_cache_miss_tokens.is_none(), "cache miss tokens must be cleared");
+        assert!(app.session.last_reasoning_replay_tokens.is_none(), "reasoning replay tokens must be cleared");
+        assert!(app.session.turn_cache_history.is_empty(), "turn_cache_history must be cleared");
         assert!(app.tool_log.is_empty());
         assert!(app.tool_cells.is_empty());
         assert!(app.tool_details_by_cell.is_empty());

--- a/crates/tui/src/commands/session.rs
+++ b/crates/tui/src/commands/session.rs
@@ -99,6 +99,18 @@ pub fn load(app: &mut App, path: Option<&str>) -> CommandResult {
     app.session.total_conversation_tokens = app.session.total_tokens;
     app.session.last_prompt_tokens = None;
     app.session.last_completion_tokens = None;
+    // Clear per-session telemetry so the loaded session starts with a
+    // clean slate — stale cache-chip data and cost counters from the
+    // previous in-memory session must not bleed into the restored one.
+    app.session.last_prompt_cache_hit_tokens = None;
+    app.session.last_prompt_cache_miss_tokens = None;
+    app.session.last_reasoning_replay_tokens = None;
+    app.session.turn_cache_history.clear();
+    app.session.session_cost = 0.0;
+    app.session.session_cost_cny = 0.0;
+    app.session.subagent_cost = 0.0;
+    app.session.subagent_cost_cny = 0.0;
+    app.session.subagent_cost_event_seqs.clear();
     app.current_session_id = Some(session.metadata.id.clone());
     if let Some(sp) = session.system_prompt {
         app.system_prompt = Some(crate::models::SystemPrompt::Text(sp));
@@ -404,6 +416,68 @@ mod tests {
         assert_eq!(app2.session.total_tokens, 500);
         assert!(app2.current_session_id.is_some());
         assert!(matches!(result.action, Some(AppAction::SyncSession { .. })));
+    }
+
+    #[test]
+    fn test_load_clears_prior_session_telemetry() {
+        // Regression test: /load must not inherit the in-memory session's
+        // cache chip data, turn_cache_history, or cost counters.
+        let tmpdir = TempDir::new().unwrap();
+
+        // Save a session from app1.
+        let mut app1 = create_test_app_with_tmpdir(&tmpdir);
+        app1.api_messages.push(crate::models::Message {
+            role: "user".to_string(),
+            content: vec![crate::models::ContentBlock::Text {
+                text: "hello".to_string(),
+                cache_control: None,
+            }],
+        });
+        let save_path = tmpdir.path().join("telem_test.json");
+        save(&mut app1, Some(save_path.to_str().unwrap()));
+
+        // Populate app2 with stale telemetry that must be cleared by /load.
+        let mut app2 = create_test_app_with_tmpdir(&tmpdir);
+        app2.session.session_cost = 9.99;
+        app2.session.session_cost_cny = 72.0;
+        app2.session.subagent_cost = 1.23;
+        app2.session.subagent_cost_cny = 8.8;
+        app2.session.last_prompt_cache_hit_tokens = Some(50_000);
+        app2.session.last_prompt_cache_miss_tokens = Some(5_000);
+        app2.session.last_reasoning_replay_tokens = Some(1_000);
+        app2.push_turn_cache_record(crate::tui::app::TurnCacheRecord {
+            input_tokens: 55_000,
+            output_tokens: 800,
+            cache_hit_tokens: Some(50_000),
+            cache_miss_tokens: Some(5_000),
+            reasoning_replay_tokens: Some(1_000),
+            recorded_at: std::time::Instant::now(),
+        });
+
+        let result = load(&mut app2, Some(save_path.to_str().unwrap()));
+        assert!(result.message.as_deref().unwrap_or("").contains("Session loaded"));
+
+        // All stale telemetry must be gone after the load.
+        assert_eq!(app2.session.session_cost, 0.0, "session_cost must be zeroed on load");
+        assert_eq!(app2.session.session_cost_cny, 0.0);
+        assert_eq!(app2.session.subagent_cost, 0.0, "subagent_cost must be zeroed on load");
+        assert_eq!(app2.session.subagent_cost_cny, 0.0);
+        assert!(
+            app2.session.last_prompt_cache_hit_tokens.is_none(),
+            "cache hit tokens must be cleared on load"
+        );
+        assert!(
+            app2.session.last_prompt_cache_miss_tokens.is_none(),
+            "cache miss tokens must be cleared on load"
+        );
+        assert!(
+            app2.session.last_reasoning_replay_tokens.is_none(),
+            "reasoning replay tokens must be cleared on load"
+        );
+        assert!(
+            app2.session.turn_cache_history.is_empty(),
+            "turn_cache_history must be empty after load"
+        );
     }
 
     #[test]

--- a/crates/tui/src/sandbox/mod.rs
+++ b/crates/tui/src/sandbox/mod.rs
@@ -80,7 +80,7 @@ impl CommandSpec {
         #[cfg(windows)]
         let (program, args) = (
             "cmd".to_string(),
-            vec!["/C".to_string(), command.to_string()],
+            vec!["/C".to_string(), format!("chcp 65001 >NUL & {command}")],
         );
         #[cfg(not(windows))]
         let (program, args) = (
@@ -145,7 +145,11 @@ impl CommandSpec {
             && self.args.len() == 2
             && self.args[0].eq_ignore_ascii_case("/C")
         {
-            self.args[1].clone()
+            if let Some(stripped) = self.args[1].strip_prefix("chcp 65001 >NUL & ") {
+                stripped.to_string()
+            } else {
+                self.args[1].clone()
+            }
         } else {
             // For other commands, join program and args
             let mut parts = vec![self.program.clone()];
@@ -530,7 +534,7 @@ mod tests {
     fn expected_shell_command(command: &str) -> Vec<String> {
         #[cfg(windows)]
         {
-            vec!["cmd".to_string(), "/C".to_string(), command.to_string()]
+            vec!["cmd".to_string(), "/C".to_string(), format!("chcp 65001 >NUL & {}", command)]
         }
         #[cfg(not(windows))]
         {
@@ -545,7 +549,7 @@ mod tests {
         #[cfg(windows)]
         {
             assert_eq!(spec.program, "cmd");
-            assert_eq!(spec.args, vec!["/C", "echo hello"]);
+            assert_eq!(spec.args, vec!["/C", "chcp 65001 >NUL & echo hello"]);
         }
         #[cfg(not(windows))]
         {

--- a/crates/tui/src/skills/mod.rs
+++ b/crates/tui/src/skills/mod.rs
@@ -97,9 +97,11 @@ impl SkillRegistry {
     /// are skipped to avoid descending into VCS / cache trees like
     /// `.git/`. The provided `dir` itself is always honored, even if
     /// hidden — that's what the user explicitly configured.
-    /// Symlinked directories are not followed, which keeps the walk
-    /// finite when a skills layout contains symlinks. The depth is also
-    /// capped at [`Self::MAX_DISCOVERY_DEPTH`].
+    /// Symlinked directories are followed so users can organise skill
+    /// packs via symlinks (e.g. `ln -s ~/my-skills skills/my-skills`). The
+    /// depth cap at [`Self::MAX_DISCOVERY_DEPTH`] and the hidden-dir filter
+    /// together prevent infinite traversal even when a symlink creates a
+    /// cycle.
     #[must_use]
     pub fn discover(dir: &Path) -> Self {
         let mut registry = Self::default();
@@ -134,11 +136,20 @@ impl SkillRegistry {
         };
 
         for entry in entries.flatten() {
-            // Use `file_type()` (which on Unix returns symlink metadata
-            // without following) so we don't traverse into symlinked
-            // directories — that closes the door on cycles.
+            // `file_type()` returns the type of the directory entry itself
+            // (i.e. symlink metadata, not the target). We also accept
+            // symlinks so users can organise skill packs via `ln -s`.
+            // Infinite-loop protection comes from the depth cap and the
+            // hidden-dir filter (which drops `.`-prefixed names like
+            // common targets of accidental cycles).
             let Ok(ft) = entry.file_type() else { continue };
-            if !ft.is_dir() {
+            let is_dir_or_symlink = ft.is_dir() || ft.is_symlink();
+            if !is_dir_or_symlink {
+                continue;
+            }
+            // For symlinks: verify the target actually is a directory before
+            // recursing. If the symlink is broken or points to a file, skip.
+            if ft.is_symlink() && !entry.path().is_dir() {
                 continue;
             }
 
@@ -524,7 +535,9 @@ pub fn list(skills_dir: &Path) -> Result<()> {
     let mut entries = Vec::new();
     for entry in fs::read_dir(skills_dir)? {
         let entry = entry?;
-        if entry.file_type()?.is_dir() {
+        // Follow symlinks so `list` sees symlinked skill directories.
+        let ft = entry.file_type()?;
+        if ft.is_dir() || (ft.is_symlink() && entry.path().is_dir()) {
             entries.push(entry.file_name().to_string_lossy().to_string());
         }
     }

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -4009,8 +4009,19 @@ async fn switch_provider(
     app.api_provider = target;
     app.model = new_model.clone();
     app.update_model_compaction_budget();
+    // Clear all per-session telemetry so stale cache-chip data and cost
+    // counters from the previous provider don't bleed into the new session.
     app.session.last_prompt_tokens = None;
     app.session.last_completion_tokens = None;
+    app.session.last_prompt_cache_hit_tokens = None;
+    app.session.last_prompt_cache_miss_tokens = None;
+    app.session.last_reasoning_replay_tokens = None;
+    app.session.turn_cache_history.clear();
+    app.session.session_cost = 0.0;
+    app.session.session_cost_cny = 0.0;
+    app.session.subagent_cost = 0.0;
+    app.session.subagent_cost_cny = 0.0;
+    app.session.subagent_cost_event_seqs.clear();
 
     let _ = engine_handle.send(Op::Shutdown).await;
     let engine_config = build_engine_config(app, config);

--- a/npm/deepseek-tui/scripts/install.js
+++ b/npm/deepseek-tui/scripts/install.js
@@ -355,8 +355,8 @@ function connectThroughProxy(proxy, targetHost, targetPort, timeoutMs) {
 // ────────────────────────────────────────────────────────────────────────────
 
 function httpRequest(rawUrl, opts = {}) {
-  const totalTimeoutMs = opts.totalTimeoutMs ?? downloadTimeoutMs();
-  const stallMs = opts.stallMs ?? downloadStallMs();
+  const totalTimeoutMs = opts.totalTimeoutMs !== undefined ? opts.totalTimeoutMs : downloadTimeoutMs();
+  const stallMs = opts.stallMs !== undefined ? opts.stallMs : downloadStallMs();
 
   return new Promise((resolve, reject) => {
     let url;

--- a/npm/deepseek-tui/scripts/run.js
+++ b/npm/deepseek-tui/scripts/run.js
@@ -30,7 +30,7 @@ async function run(binaryName) {
     handleVersionFallback(binaryName);
     throw result.error;
   }
-  process.exit(result.status ?? 1);
+  process.exit(result.status != null ? result.status : 1);
 }
 
 async function runDeepseek() {


### PR DESCRIPTION
Summary
#982 — Windows shell UTF-8: Prepends chcp 65001 >NUL & to every
cmd.exe invocation so non-ASCII characters are not garbled in shell output
#1001 — Session telemetry reset: Clears cache-chip data and cost counters
on /clear, /load, and provider switch so stale stats don't bleed through
#1002 — Skills symlink support: SkillRegistry::discover now follows
symlinked directories; depth cap + hidden-dir filter prevents infinite loops
#1016 — npm Node < 18 compatibility: Replaces ?? with ternary in
run.js and install.js to fix crash on Node 14/16

Test plan
 
Windows: ask model to echo 你好世界 via shell — no garbled output
 Switch provider after a conversation — session cost resets to 0
 /clear mid-session — cost and cache stats reset to 0
 Symlinked skill dir appears in /skills list
 node scripts/run.js --version works on Node 14/16 without crashing