### PR TITLE
fix(npm): hint release mirror on download failures

### DIFF
--- a/npm/deepseek-tui/README.md
+++ b/npm/deepseek-tui/README.md
@@ -70,6 +70,9 @@ build-from-source guide.
 - Default binary version comes from `deepseekBinaryVersion` in `package.json`.
 - Set `DEEPSEEK_TUI_VERSION` or `DEEPSEEK_VERSION` to override the release version.
 - Set `DEEPSEEK_TUI_GITHUB_REPO` or `DEEPSEEK_GITHUB_REPO` to override the source repo (defaults to `Hmbown/DeepSeek-TUI`).
+- Set `DEEPSEEK_TUI_RELEASE_BASE_URL` to use an internal or mirrored
+  release-asset directory when GitHub Releases is unavailable. The directory
+  must contain `deepseek-artifacts-sha256.txt` and the platform binaries.
 - Set `DEEPSEEK_TUI_FORCE_DOWNLOAD=1` to force download even when the cached binary is already present.
 - Set `DEEPSEEK_TUI_DISABLE_INSTALL=1` to skip install-time download.
 - Set `DEEPSEEK_TUI_OPTIONAL_INSTALL=1` to make the `postinstall` step warn and exit `0` on download/extract errors instead of failing `npm install` (useful in CI matrices).
@@ -80,5 +83,3 @@ build-from-source guide.
   exist for the target GitHub release before publishing.
 - Install-time downloads are verified against the release checksum manifest before
   the wrapper marks them executable.
-- Set `DEEPSEEK_TUI_RELEASE_BASE_URL` to point the installer at a local or
-  staged release-asset directory for smoke tests.

--- a/npm/deepseek-tui/scripts/install.js
+++ b/npm/deepseek-tui/scripts/install.js
@@ -120,6 +120,47 @@ function logInfo(message) {
   process.stderr.write(`deepseek-tui: ${message}\n`);
 }
 
+function installFailureHint(error) {
+  const message = error && error.message ? String(error.message) : "";
+  const code = error && error.code ? String(error.code) : "";
+  const releaseBase =
+    process.env.DEEPSEEK_TUI_RELEASE_BASE_URL || process.env.DEEPSEEK_RELEASE_BASE_URL;
+  const networkMarkers = [
+    "github.com",
+    "ENOTFOUND",
+    "EAI_AGAIN",
+    "ETIMEDOUT",
+    "ECONNRESET",
+    "ENETUNREACH",
+    "EHOSTUNREACH",
+    "EDOWNLOADTIMEOUT",
+  ];
+  const looksLikeNetworkDownloadFailure = networkMarkers.some(
+    marker => message.includes(marker) || code === marker,
+  );
+  if (!looksLikeNetworkDownloadFailure) {
+    return "";
+  }
+
+  if (releaseBase) {
+    return [
+      "deepseek-tui install hint:",
+      `  DEEPSEEK_TUI_RELEASE_BASE_URL is set to ${releaseBase}`,
+      "  Verify that this directory contains deepseek-artifacts-sha256.txt",
+      "  plus the deepseek/deepseek-tui binary assets for your platform.",
+    ].join("\n");
+  }
+
+  return [
+    "deepseek-tui install hint:",
+    "  The npm package downloads prebuilt binaries from GitHub Releases.",
+    "  If GitHub is unavailable on this network, mirror the release assets and set:",
+    "    DEEPSEEK_TUI_RELEASE_BASE_URL=https://<mirror>/<release-asset-directory>/",
+    "  The directory must contain deepseek-artifacts-sha256.txt and the platform binaries.",
+    "  See docs/INSTALL.md#npm-download-is-slow-or-times-out-from-mainland-china.",
+  ].join("\n");
+}
+
 function envInt(name, fallback) {
   const raw = process.env[name];
   if (!raw) {
@@ -945,12 +986,17 @@ async function getBinaryPath(name) {
 
 module.exports = {
   getBinaryPath,
+  installFailureHint,
   run,
 };
 
 if (require.main === module) {
   run().catch((error) => {
     console.error("deepseek-tui install failed:", error.message);
+    const hint = installFailureHint(error);
+    if (hint) {
+      console.error(hint);
+    }
     if (process.env.DEEPSEEK_TUI_OPTIONAL_INSTALL === "1") {
       console.error(
         "DEEPSEEK_TUI_OPTIONAL_INSTALL=1 set; continuing without a usable binary.",

--- a/npm/deepseek-tui/test/install.test.js
+++ b/npm/deepseek-tui/test/install.test.js
@@ -7,6 +7,7 @@ const installScript = fs.readFileSync(
   path.join(__dirname, "..", "scripts", "install.js"),
   "utf8",
 );
+const { installFailureHint } = require("../scripts/install");
 
 test("install script checks Node support before loading helpers", () => {
   const guardIndex = installScript.indexOf("assertSupportedNode();");
@@ -20,4 +21,51 @@ test("install script checks Node support before loading helpers", () => {
 test("install script remains parseable before the Node support guard runs", () => {
   assert.equal(installScript.includes("??"), false);
   assert.equal(installScript.includes("?."), false);
+});
+
+test("install failure hint explains release base override for blocked GitHub downloads", () => {
+  const previous = process.env.DEEPSEEK_TUI_RELEASE_BASE_URL;
+  delete process.env.DEEPSEEK_TUI_RELEASE_BASE_URL;
+  try {
+    const error = Object.assign(
+      new Error(
+        "fetch https://github.com/Hmbown/DeepSeek-TUI/releases/download/v0.8.16/deepseek-artifacts-sha256.txt failed after 5 attempts:\ngetaddrinfo ENOTFOUND github.com",
+      ),
+      { code: "ENOTFOUND" },
+    );
+
+    const hint = installFailureHint(error);
+
+    assert.match(hint, /DEEPSEEK_TUI_RELEASE_BASE_URL/);
+    assert.match(hint, /deepseek-artifacts-sha256\.txt/);
+    assert.match(hint, /platform binaries/);
+  } finally {
+    if (previous === undefined) {
+      delete process.env.DEEPSEEK_TUI_RELEASE_BASE_URL;
+    } else {
+      process.env.DEEPSEEK_TUI_RELEASE_BASE_URL = previous;
+    }
+  }
+});
+
+test("install failure hint checks configured release base when override is already set", () => {
+  const previous = process.env.DEEPSEEK_TUI_RELEASE_BASE_URL;
+  process.env.DEEPSEEK_TUI_RELEASE_BASE_URL = "https://mirror.example/deepseek/";
+  try {
+    const error = Object.assign(new Error("download stalled"), {
+      code: "EDOWNLOADTIMEOUT",
+    });
+
+    const hint = installFailureHint(error);
+
+    assert.match(hint, /is set to https:\/\/mirror\.example\/deepseek\//);
+    assert.match(hint, /deepseek-artifacts-sha256\.txt/);
+    assert.doesNotMatch(hint, /If GitHub is unavailable/);
+  } finally {
+    if (previous === undefined) {
+      delete process.env.DEEPSEEK_TUI_RELEASE_BASE_URL;
+    } else {
+      process.env.DEEPSEEK_TUI_RELEASE_BASE_URL = previous;
+    }
+  }
 });


### PR DESCRIPTION
## Summary
- Print an actionable install hint when npm postinstall download failures look like blocked GitHub/network access.
- Point users to the existing `DEEPSEEK_TUI_RELEASE_BASE_URL` mirror override and state the required manifest/binary layout.
- Document the mirror override in the npm package README and cover both unset/set override cases in tests.

## Linked Issue / Scope
Fixes #1051.

This does not hard-code or endorse any third-party mirror. It only documents and surfaces the existing release-base override so users can point at their own internal mirror or release-asset proxy.

## AI-use disclosure
Assisted by AI.

## Human-owner statement
I have reviewed the diff and can explain every changed file.

## Verification
- `npm test` in `npm/deepseek-tui`
- `node --check scripts/install.js` in `npm/deepseek-tui`
- `git diff --check`