### PR TITLE
feat(tui): add /theme command to toggle dark/light theme

### DIFF
--- a/crates/tui/src/commands/config.rs
+++ b/crates/tui/src/commands/config.rs
@@ -539,6 +539,20 @@ pub fn plan_mode(app: &mut App) -> CommandResult {
     )
 }
 
+/// Toggle between dark and light theme.
+pub fn theme(app: &mut App) -> CommandResult {
+    let new_theme = match app.ui_theme.mode {
+        crate::palette::PaletteMode::Dark => crate::palette::UiTheme::for_mode(crate::palette::PaletteMode::Light),
+        crate::palette::PaletteMode::Light => crate::palette::UiTheme::for_mode(crate::palette::PaletteMode::Dark),
+    };
+    app.ui_theme = new_theme;
+    let label = match new_theme.mode {
+        crate::palette::PaletteMode::Dark => "dark",
+        crate::palette::PaletteMode::Light => "light",
+    };
+    CommandResult::message(format!("Theme switched to {label}."))
+}
+
 /// Manage workspace-level trust and the per-path allowlist.
 ///
 /// Subcommands:

--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -342,6 +342,12 @@ pub const COMMANDS: &[CommandInfo] = &[
         description_id: MessageId::CmdPlanDescription,
     },
     CommandInfo {
+        name: "theme",
+        aliases: &[],
+        usage: "/theme",
+        description_id: MessageId::CmdThemeDescription,
+    },
+    CommandInfo {
         name: "trust",
         aliases: &[],
         usage: "/trust [on|off|add <path>|remove <path>|list]",
@@ -535,6 +541,7 @@ pub fn execute(cmd: &str, app: &mut App) -> CommandResult {
         "yolo" => config::yolo(app),
         "agent" => config::agent_mode(app),
         "plan" => config::plan_mode(app),
+        "theme" => config::theme(app),
         "trust" => config::trust(app, arg),
         "logout" => config::logout(app),
 

--- a/crates/tui/src/localization.rs
+++ b/crates/tui/src/localization.rs
@@ -245,6 +245,7 @@ pub enum MessageId {
     CmdNetworkDescription,
     CmdNoteDescription,
     CmdPlanDescription,
+    CmdThemeDescription,
     CmdProviderDescription,
     CmdQueueDescription,
     CmdRecallDescription,
@@ -760,6 +761,9 @@ fn english(id: MessageId) -> &'static str {
         MessageId::CmdPlanDescription => {
             "Switch to plan mode and review suggested implementation steps"
         }
+        MessageId::CmdThemeDescription => {
+            "Toggle between dark and light theme"
+        }
         MessageId::CmdProviderDescription => {
             "Switch or view the active LLM backend (deepseek | nvidia-nim | ollama)"
         }
@@ -1043,6 +1047,7 @@ fn japanese(id: MessageId) -> Option<&'static str> {
         MessageId::CmdNetworkDescription => "ネットワーク許可・拒否ルールを管理",
         MessageId::CmdNoteDescription => "永続ノートファイル（.deepseek/notes.md）に追記",
         MessageId::CmdPlanDescription => "Plan モードに切り替え、推奨される実装手順を確認",
+        MessageId::CmdThemeDescription => "テーマ（ダーク/ライト）を切り替え",
         MessageId::CmdProviderDescription => {
             "現在の LLM バックエンドを切り替え・確認（deepseek | nvidia-nim | ollama）"
         }
@@ -1308,6 +1313,7 @@ fn chinese_simplified(id: MessageId) -> Option<&'static str> {
         MessageId::CmdNetworkDescription => "管理网络允许和拒绝规则",
         MessageId::CmdNoteDescription => "将笔记追加到持久笔记文件（.deepseek/notes.md）",
         MessageId::CmdPlanDescription => "切换到 Plan 模式并查看建议的实现步骤",
+        MessageId::CmdThemeDescription => "在浅色和深色主题之间切换",
         MessageId::CmdProviderDescription => {
             "切换或查看当前 LLM 后端（deepseek | nvidia-nim | ollama）"
         }
@@ -1570,6 +1576,9 @@ fn portuguese_brazil(id: MessageId) -> Option<&'static str> {
         }
         MessageId::CmdPlanDescription => {
             "Mudar para o modo plan e revisar os passos de implementação sugeridos"
+        }
+        MessageId::CmdThemeDescription => {
+            "Alternar entre o tema claro e escuro"
         }
         MessageId::CmdProviderDescription => {
             "Trocar ou exibir o backend LLM ativo (deepseek | nvidia-nim | ollama)"


### PR DESCRIPTION
## Summary
Minimal `/theme` command that toggles between dark and light themes using the existing `UiTheme` system — no new theme state, no thread_local, no persistence layer.

## Linked Issue
Follows up on [PR #992 comment](https://github.com/Hmbown/DeepSeek-TUI/pull/992#issuecomment-1467652940) where maintainer requested a focused smaller PR.

## AI-Use Disclosure
`assisted` — Claude Code used for implementation; all changes reviewed line-by-line by human.

## Human-Owner Statement
I have read the diff and can explain every changed file:
- `commands/config.rs`: `theme()` function toggles `app.ui_theme` via `UiTheme::for_mode()` — delegates to existing system
- `commands/mod.rs`: CommandInfo entry and dispatch match for `/theme`
- `localization.rs`: `CmdThemeDescription` added in en/zh/ja/pt locales

## Changes (3 files, 30 lines)
| File | Lines | Change |
|------|-------|--------|
| `commands/config.rs` | +14 | `theme()` toggles `app.ui_theme` |
| `commands/mod.rs` | +7 | CommandInfo + dispatch |
| `localization.rs` | +9 | `CmdThemeDescription` (en/zh/ja/pt) |

## Test Plan
- [x] `cargo build -p deepseek-tui` ✓
- [ ] `/theme` toggles theme and shows confirmation
- [ ] Theme persists within session (runtime toggle)

## Verification Commands Run
```bash
cargo build -p deepseek-tui  # ✓ Passed
```