### PR TITLE
fix(tui): enable reqwest gzip/brotli decompression for SSE responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "allocative"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,6 +247,18 @@ dependencies = [
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -536,6 +563,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
+name = "brotli"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,6 +844,24 @@ dependencies = [
  "ryu",
  "static_assertions",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "brotli",
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "concurrent-queue"
@@ -5066,13 +5132,18 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "async-compression",
  "bitflags 2.10.0",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "iri-string",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -38,7 +38,7 @@ fd-lock = "4.0.4"
 futures-util = "0.3.31"
 ratatui = "0.29"
 regex = "1.11"
-reqwest = { version = "0.13.1", default-features = false, features = ["blocking", "json", "stream", "multipart", "rustls", "http2"] }
+reqwest = { version = "0.13.1", default-features = false, features = ["blocking", "json", "stream", "multipart", "rustls", "http2", "gzip", "brotli"] }
 similar = "2"
 rustyline = "15.0.0"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/crates/tui/src/snapshot/repo.rs
+++ b/crates/tui/src/snapshot/repo.rs
@@ -72,6 +72,20 @@ __pycache__/
 .m2/
 .local/
 .DS_Store
+# Compilation / build output
+*.img
+*.bin
+*.elf
+*.hex
+*.o
+*.out
+out/
+obj/
+# Large binary blobs
+*.iso
+*.img
+*.vdi
+*.vmdk
 ";
 
 impl SnapshotRepo {

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -357,11 +357,14 @@ fn remove_char_at(text: &mut String, char_index: usize) -> bool {
 }
 
 fn normalize_paste_text(text: &str) -> String {
-    if text.contains('\r') {
+    let normalized = if text.contains('\r') {
         text.replace("\r\n", "\n").replace('\r', "")
     } else {
         text.to_string()
-    }
+    };
+    // Strip trailing newlines to prevent accidental submit when pasting
+    // text that ends with a trailing newline (#1073)
+    normalized.trim_end_matches('\n').to_string()
 }
 
 fn sanitize_api_key_text(text: &str) -> String {


### PR DESCRIPTION
## Summary
- Add `gzip` and `brotli` features to reqwest to enable automatic content encoding decompression
- Fixes garbled Chinese text (乱码) appearing during model's thinking/reasoning phase with deepseek-v4-pro model
- Add common binary build artifacts (*.img, *.bin, *.elf, *.hex, *.o, *.out, out/, obj/) to BUILTIN_EXCLUDES in snapshot repo
- Fixes extremely large snapshot storage (100GB+) when compiling large binary images like ARM firmware
- Strip trailing newlines from pasted text to prevent accidental submit when pasting multi-line content with trailing newline

## Root Causes
1. **Issue #954**: DeepSeek API returns gzip/brotli compressed SSE responses. Without auto-decompression enabled, reqwest's rustls backend passed compressed bytes directly to UTF-8 parsing, causing replacement characters.
2. **Issue #1020**: `git add -A` in snapshots stages all files including massive build outputs (ARM .img files). BUILTIN_EXCLUDES didn't filter these binary blobs, causing 100GB+ snapshot storage.
3. **Issue #1073**: When pasting text with a trailing newline, the paste-burst heuristic may fail to detect paste on Windows (8ms interval too short), causing Enter to trigger submission instead of being handled as paste buffer. The trailing newline in the buffer was then interpreted as a submit trigger.

## Test Plan
- [x] Build succeeded with new dependencies
- [x] 7 stream decoder tests passed
- [x] 47 network/install tests passed
- [x] Snapshot tests passed

Fixes #954
Fixes #1020
Fixes #1073