### PR TITLE
Add session budget controls

### DIFF
--- a/crates/config/src/budget.rs
+++ b/crates/config/src/budget.rs
@@ -1,0 +1,40 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct BudgetConfig {
+    #[serde(default, deserialize_with = "zero_as_none")]
+    pub session_usd_soft: Option<f64>,
+    #[serde(default, deserialize_with = "zero_as_none")]
+    pub session_usd_hard: Option<f64>,
+    #[serde(default, deserialize_with = "zero_as_none")]
+    pub session_cny_soft: Option<f64>,
+    #[serde(default, deserialize_with = "zero_as_none")]
+    pub session_cny_hard: Option<f64>,
+    #[serde(default, deserialize_with = "zero_as_none")]
+    pub daily_usd_hard: Option<f64>,
+    #[serde(default)]
+    pub on_exceed: OnExceedStrategy,
+    #[serde(default = "default_include_subagents")]
+    pub include_subagents: bool,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum OnExceedStrategy {
+    #[default]
+    Pause,
+    DowngradeToFlash,
+    Stop,
+}
+
+fn default_include_subagents() -> bool {
+    true
+}
+
+fn zero_as_none<'de, D>(deserializer: D) -> Result<Option<f64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<f64>::deserialize(deserializer)?;
+    Ok(value.filter(|v| *v > 0.0))
+}

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -10,6 +10,9 @@ use deepseek_secrets::SecretSource;
 pub use deepseek_secrets::Secrets;
 use serde::{Deserialize, Serialize};
 
+pub mod budget;
+use budget::BudgetConfig;
+
 #[cfg(unix)]
 use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 
@@ -177,6 +180,8 @@ pub struct ConfigToml {
     /// to a permissive default that mirrors pre-v0.7.0 behavior.
     #[serde(default)]
     pub network: Option<NetworkPolicyToml>,
+    #[serde(default)]
+    pub budget: Option<BudgetConfig>,
     /// Community skill installer settings (#140). Mirrors
     /// [`SkillsToml`] from the TUI side; the dispatcher consults
     /// `registry_url` when running `deepseek skill install`.

--- a/crates/tui/src/budget.rs
+++ b/crates/tui/src/budget.rs
@@ -1,0 +1,121 @@
+use std::fs;
+use std::path::PathBuf;
+
+use chrono::{Local, NaiveDate};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum BudgetState {
+    #[default]
+    Active,
+    SoftWarned,
+    Paused {
+        reason: String,
+    },
+    Stopped,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct BudgetOverrides {
+    pub session_usd_soft: Option<f64>,
+    pub session_usd_hard: Option<f64>,
+    pub released: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DailyBudgetSnapshot {
+    pub date: String,
+    pub usd: f64,
+    pub cny: f64,
+}
+
+#[derive(Debug, Clone)]
+pub struct DailyCostCounter {
+    path: PathBuf,
+    date: NaiveDate,
+    pub usd: f64,
+    pub cny: f64,
+}
+
+impl Default for DailyCostCounter {
+    fn default() -> Self {
+        Self {
+            path: default_daily_budget_path(),
+            date: Local::now().date_naive(),
+            usd: 0.0,
+            cny: 0.0,
+        }
+    }
+}
+
+impl DailyCostCounter {
+    pub fn load_default() -> Self {
+        let path = default_daily_budget_path();
+        Self::load_at(path, Local::now().date_naive())
+    }
+
+    pub fn load_at(path: PathBuf, today: NaiveDate) -> Self {
+        let mut counter = Self {
+            path,
+            date: today,
+            usd: 0.0,
+            cny: 0.0,
+        };
+        let Ok(raw) = fs::read_to_string(&counter.path) else {
+            return counter;
+        };
+        let Ok(snapshot) = serde_json::from_str::<DailyBudgetSnapshot>(&raw) else {
+            return counter;
+        };
+        if snapshot.date == today.to_string() {
+            counter.usd = snapshot.usd.max(0.0);
+            counter.cny = snapshot.cny.max(0.0);
+        } else {
+            let _ = counter.save();
+        }
+        counter
+    }
+
+    pub fn accrue(&mut self, usd: f64, cny: f64) {
+        self.reset_if_needed(Local::now().date_naive());
+        self.usd += usd.max(0.0);
+        self.cny += cny.max(0.0);
+        let _ = self.save();
+    }
+
+    pub fn reset_if_needed(&mut self, today: NaiveDate) {
+        if self.date != today {
+            self.date = today;
+            self.usd = 0.0;
+            self.cny = 0.0;
+            let _ = self.save();
+        }
+    }
+
+    pub fn save(&self) -> std::io::Result<()> {
+        if let Some(parent) = self.path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let snapshot = DailyBudgetSnapshot {
+            date: self.date.to_string(),
+            usd: self.usd,
+            cny: self.cny,
+        };
+        let raw = serde_json::to_string_pretty(&snapshot).map_err(std::io::Error::other)?;
+        fs::write(&self.path, raw)
+    }
+}
+
+fn default_daily_budget_path() -> PathBuf {
+    dirs::home_dir()
+        .map(|home| {
+            home.join(".deepseek")
+                .join("state")
+                .join("daily_budget.json")
+        })
+        .unwrap_or_else(|| {
+            PathBuf::from(".deepseek")
+                .join("state")
+                .join("daily_budget.json")
+        })
+}

--- a/crates/tui/src/commands/budget.rs
+++ b/crates/tui/src/commands/budget.rs
@@ -1,0 +1,185 @@
+use super::CommandResult;
+use crate::budget::BudgetState;
+use crate::pricing::{CostCurrency, format_cost_amount};
+use crate::tui::app::App;
+
+const BUDGET_USAGE: &str = "/budget [set hard <usd>|set soft <usd>|extend <usd>|release|downgrade]";
+
+pub fn budget(app: &mut App, arg: Option<&str>) -> CommandResult {
+    let sub = arg.unwrap_or("").trim();
+    if sub.is_empty() {
+        return CommandResult::message(summary(app));
+    }
+
+    let parts = sub.split_whitespace().collect::<Vec<_>>();
+    match parts.as_slice() {
+        ["set", "hard", amount] => set_hard(app, amount),
+        ["set", "soft", amount] => set_soft(app, amount),
+        ["extend", amount] => extend(app, amount),
+        ["release"] => {
+            app.session.budget_overrides.released = true;
+            app.session.budget_overrides.session_usd_hard = None;
+            app.session.budget_overrides.session_usd_soft = None;
+            app.session.budget_state = BudgetState::Active;
+            CommandResult::message("budget caps released for this session")
+        }
+        ["downgrade"] => super::switch_model(app, "deepseek-v4-flash"),
+        ["help"] => CommandResult::message(BUDGET_USAGE),
+        _ => CommandResult::error(format!("unknown budget command. Usage: {BUDGET_USAGE}")),
+    }
+}
+
+fn set_hard(app: &mut App, amount: &str) -> CommandResult {
+    let Ok(value) = parse_amount(amount) else {
+        return CommandResult::error("hard cap must be a positive USD amount");
+    };
+    app.session.budget_overrides.released = false;
+    app.session.budget_overrides.session_usd_hard = Some(value);
+    app.session.budget_hard_fired_usd = false;
+    CommandResult::message(format!(
+        "session hard budget set to {}",
+        format_cost_amount(value, CostCurrency::Usd)
+    ))
+}
+
+fn set_soft(app: &mut App, amount: &str) -> CommandResult {
+    let Ok(value) = parse_amount(amount) else {
+        return CommandResult::error("soft cap must be a positive USD amount");
+    };
+    app.session.budget_overrides.released = false;
+    app.session.budget_overrides.session_usd_soft = Some(value);
+    app.session.budget_soft_fired_usd = false;
+    CommandResult::message(format!(
+        "session soft budget set to {}",
+        format_cost_amount(value, CostCurrency::Usd)
+    ))
+}
+
+fn extend(app: &mut App, amount: &str) -> CommandResult {
+    let Ok(value) = parse_amount(amount) else {
+        return CommandResult::error("extension must be a positive USD amount");
+    };
+    let current = app.displayed_session_cost_for_currency(CostCurrency::Usd);
+    let base = app
+        .session
+        .budget_overrides
+        .session_usd_hard
+        .or_else(|| {
+            app.budget_config
+                .as_ref()
+                .and_then(|cfg| cfg.session_usd_hard)
+        })
+        .unwrap_or(current);
+    let new_cap = base.max(current) + value;
+    app.session.budget_overrides.released = false;
+    app.session.budget_overrides.session_usd_hard = Some(new_cap);
+    app.session.budget_state = BudgetState::Active;
+    app.session.budget_hard_fired_usd = false;
+    CommandResult::message(format!(
+        "session hard budget extended to {}",
+        format_cost_amount(new_cap, CostCurrency::Usd)
+    ))
+}
+
+fn parse_amount(raw: &str) -> Result<f64, ()> {
+    let value = raw
+        .trim()
+        .trim_start_matches('$')
+        .parse::<f64>()
+        .map_err(|_| ())?;
+    if value > 0.0 && value.is_finite() {
+        Ok(value)
+    } else {
+        Err(())
+    }
+}
+
+fn summary(app: &App) -> String {
+    let config = app.budget_config.as_ref();
+    let soft_usd = app
+        .session
+        .budget_overrides
+        .session_usd_soft
+        .or_else(|| config.and_then(|cfg| cfg.session_usd_soft));
+    let hard_usd = app
+        .session
+        .budget_overrides
+        .session_usd_hard
+        .or_else(|| config.and_then(|cfg| cfg.session_usd_hard));
+    let soft_cny = config.and_then(|cfg| cfg.session_cny_soft);
+    let hard_cny = config.and_then(|cfg| cfg.session_cny_hard);
+    let daily_usd = config.and_then(|cfg| cfg.daily_usd_hard);
+    let strategy = config
+        .map(|cfg| format!("{:?}", cfg.on_exceed))
+        .unwrap_or_else(|| "disabled".to_string());
+
+    format!(
+        "Session: {} / {}\nCaps: soft {} {}, hard {} {}\nDaily: {} accumulated, hard {}\nState: {:?}\nStrategy: {}",
+        format_cost_amount(app.session.session_cost, CostCurrency::Usd),
+        format_cost_amount(app.session.session_cost_cny, CostCurrency::Cny),
+        cap(soft_usd, CostCurrency::Usd),
+        cap(soft_cny, CostCurrency::Cny),
+        cap(hard_usd, CostCurrency::Usd),
+        cap(hard_cny, CostCurrency::Cny),
+        format_cost_amount(app.session.daily_cost.usd, CostCurrency::Usd),
+        cap(daily_usd, CostCurrency::Usd),
+        app.session.budget_state,
+        strategy
+    )
+}
+
+fn cap(value: Option<f64>, currency: CostCurrency) -> String {
+    value
+        .map(|v| format_cost_amount(v, currency))
+        .unwrap_or_else(|| "unset".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+    use crate::tui::app::{App, TuiOptions};
+    use std::path::PathBuf;
+
+    fn test_app() -> App {
+        App::new(
+            TuiOptions {
+                model: "deepseek-v4-pro".to_string(),
+                workspace: PathBuf::from("."),
+                config_path: None,
+                config_profile: None,
+                allow_shell: false,
+                use_alt_screen: true,
+                use_mouse_capture: false,
+                use_bracketed_paste: true,
+                max_subagents: 1,
+                skills_dir: PathBuf::from("."),
+                memory_path: PathBuf::from("memory.md"),
+                notes_path: PathBuf::from("notes.txt"),
+                mcp_config_path: PathBuf::from("mcp.json"),
+                use_memory: false,
+                start_in_agent_mode: false,
+                skip_onboarding: true,
+                yolo: false,
+                resume_session_id: None,
+                initial_input: None,
+            },
+            &Config::default(),
+        )
+    }
+
+    #[test]
+    fn budget_extend_resumes_from_paused() {
+        let mut app = test_app();
+        app.session.budget_state = BudgetState::Paused {
+            reason: "test".to_string(),
+        };
+        app.session.budget_overrides.session_usd_hard = Some(1.0);
+
+        let result = budget(&mut app, Some("extend 2"));
+
+        assert!(!result.is_error);
+        assert_eq!(app.session.budget_state, BudgetState::Active);
+        assert_eq!(app.session.budget_overrides.session_usd_hard, Some(3.0));
+    }
+}

--- a/crates/tui/src/commands/config.rs
+++ b/crates/tui/src/commands/config.rs
@@ -542,8 +542,12 @@ pub fn plan_mode(app: &mut App) -> CommandResult {
 /// Toggle between dark and light theme.
 pub fn theme(app: &mut App) -> CommandResult {
     let new_theme = match app.ui_theme.mode {
-        crate::palette::PaletteMode::Dark => crate::palette::UiTheme::for_mode(crate::palette::PaletteMode::Light),
-        crate::palette::PaletteMode::Light => crate::palette::UiTheme::for_mode(crate::palette::PaletteMode::Dark),
+        crate::palette::PaletteMode::Dark => {
+            crate::palette::UiTheme::for_mode(crate::palette::PaletteMode::Light)
+        }
+        crate::palette::PaletteMode::Light => {
+            crate::palette::UiTheme::for_mode(crate::palette::PaletteMode::Dark)
+        }
     };
     app.ui_theme = new_theme;
     let label = match new_theme.mode {

--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -5,6 +5,7 @@
 
 mod anchor;
 mod attachment;
+mod budget;
 mod config;
 mod core;
 mod cycle;
@@ -224,6 +225,12 @@ pub const COMMANDS: &[CommandInfo] = &[
         aliases: &[],
         usage: "/memory [show|path|clear|edit|help]",
         description_id: MessageId::CmdMemoryDescription,
+    },
+    CommandInfo {
+        name: "budget",
+        aliases: &[],
+        usage: "/budget [set hard <usd>|set soft <usd>|extend <usd>|release|downgrade]",
+        description_id: MessageId::CmdCostDescription,
     },
     CommandInfo {
         name: "attach",
@@ -517,6 +524,7 @@ pub fn execute(cmd: &str, app: &mut App) -> CommandResult {
         "home" | "stats" | "overview" => core::home_dashboard(app),
         "note" => note::note(app, arg),
         "memory" => memory::memory(app, arg),
+        "budget" => budget::budget(app, arg),
         "attach" | "image" | "media" => attachment::attach(app, arg),
         "task" | "tasks" => task::task(app, arg),
         "jobs" | "job" => jobs::jobs(app, arg),
@@ -625,6 +633,10 @@ pub fn execute(cmd: &str, app: &mut App) -> CommandResult {
 /// Update a configuration value programmatically (used by interactive UI views).
 pub fn set_config_value(app: &mut App, key: &str, value: &str, persist: bool) -> CommandResult {
     config::set_config_value(app, key, value, persist)
+}
+
+pub(crate) fn switch_model(app: &mut App, model: &str) -> CommandResult {
+    core::model(app, Some(model))
 }
 
 /// Persist the user's chosen footer items to `~/.deepseek/config.toml` under

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -746,6 +746,45 @@ pub struct PerModelContextConfig {
     pub cycle_threshold: Option<usize>,
 }
 
+#[derive(Debug, Clone, Deserialize, Default, PartialEq)]
+pub struct BudgetConfig {
+    #[serde(default, deserialize_with = "zero_as_none")]
+    pub session_usd_soft: Option<f64>,
+    #[serde(default, deserialize_with = "zero_as_none")]
+    pub session_usd_hard: Option<f64>,
+    #[serde(default, deserialize_with = "zero_as_none")]
+    pub session_cny_soft: Option<f64>,
+    #[serde(default, deserialize_with = "zero_as_none")]
+    pub session_cny_hard: Option<f64>,
+    #[serde(default, deserialize_with = "zero_as_none")]
+    pub daily_usd_hard: Option<f64>,
+    #[serde(default)]
+    pub on_exceed: OnExceedStrategy,
+    #[serde(default = "default_budget_include_subagents")]
+    pub include_subagents: bool,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum OnExceedStrategy {
+    #[default]
+    Pause,
+    DowngradeToFlash,
+    Stop,
+}
+
+fn default_budget_include_subagents() -> bool {
+    true
+}
+
+fn zero_as_none<'de, D>(deserializer: D) -> std::result::Result<Option<f64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<f64>::deserialize(deserializer)?;
+    Ok(value.filter(|v| *v > 0.0))
+}
+
 /// Resolved CLI configuration, including defaults and environment overrides.
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct Config {
@@ -792,6 +831,8 @@ pub struct Config {
     pub max_subagents: Option<usize>,
     pub retry: Option<RetryConfig>,
     pub capacity: Option<CapacityConfig>,
+    #[serde(default)]
+    pub budget: Option<BudgetConfig>,
     pub features: Option<FeaturesToml>,
 
     /// TUI configuration (alternate screen, etc.)
@@ -2372,6 +2413,7 @@ fn merge_config(base: Config, override_cfg: Config) -> Config {
         max_subagents: override_cfg.max_subagents.or(base.max_subagents),
         retry: override_cfg.retry.or(base.retry),
         capacity: override_cfg.capacity.or(base.capacity),
+        budget: override_cfg.budget.or(base.budget),
         tui: override_cfg.tui.or(base.tui),
         hooks: override_cfg.hooks.or(base.hooks),
         providers: merge_providers(base.providers, override_cfg.providers),

--- a/crates/tui/src/core/events.rs
+++ b/crates/tui/src/core/events.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 
 use serde_json::Value;
 
+use crate::config::OnExceedStrategy;
 use crate::core::coherence::CoherenceState;
 use crate::error_taxonomy::ErrorEnvelope;
 use crate::models::{Message, SystemPrompt, Usage};
@@ -177,6 +178,19 @@ pub enum Event {
         label: String,
         description: String,
         reason: String,
+    },
+
+    BudgetSoftReached {
+        currency: crate::pricing::CostCurrency,
+        current: f64,
+        cap: f64,
+    },
+
+    BudgetHardReached {
+        currency: crate::pricing::CostCurrency,
+        current: f64,
+        cap: f64,
+        strategy: OnExceedStrategy,
     },
 
     // === Sub-Agent Events ===

--- a/crates/tui/src/localization.rs
+++ b/crates/tui/src/localization.rs
@@ -761,9 +761,7 @@ fn english(id: MessageId) -> &'static str {
         MessageId::CmdPlanDescription => {
             "Switch to plan mode and review suggested implementation steps"
         }
-        MessageId::CmdThemeDescription => {
-            "Toggle between dark and light theme"
-        }
+        MessageId::CmdThemeDescription => "Toggle between dark and light theme",
         MessageId::CmdProviderDescription => {
             "Switch or view the active LLM backend (deepseek | nvidia-nim | ollama)"
         }
@@ -1577,9 +1575,7 @@ fn portuguese_brazil(id: MessageId) -> Option<&'static str> {
         MessageId::CmdPlanDescription => {
             "Mudar para o modo plan e revisar os passos de implementação sugeridos"
         }
-        MessageId::CmdThemeDescription => {
-            "Alternar entre o tema claro e escuro"
-        }
+        MessageId::CmdThemeDescription => "Alternar entre o tema claro e escuro",
         MessageId::CmdProviderDescription => {
             "Trocar ou exibir o backend LLM ativo (deepseek | nvidia-nim | ollama)"
         }

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -16,6 +16,7 @@ mod acp_server;
 mod audit;
 mod auto_reasoning;
 mod automation_manager;
+mod budget;
 mod client;
 mod command_safety;
 mod commands;

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -8,9 +8,11 @@ use ratatui::layout::Rect;
 use serde_json::Value;
 use thiserror::Error;
 
+use crate::budget::{BudgetOverrides, BudgetState, DailyCostCounter};
 use crate::compaction::CompactionConfig;
 use crate::config::{
-    ApiProvider, Config, DEFAULT_TEXT_MODEL, SavedCredential, has_api_key, save_api_key,
+    ApiProvider, BudgetConfig, Config, DEFAULT_TEXT_MODEL, OnExceedStrategy, SavedCredential,
+    has_api_key, save_api_key,
 };
 use crate::config_ui::ConfigUiMode;
 use crate::core::coherence::CoherenceState;
@@ -619,6 +621,13 @@ pub struct SessionState {
     pub subagent_cost_event_seqs: HashSet<u64>,
     pub displayed_cost_high_water: f64,
     pub displayed_cost_high_water_cny: f64,
+    pub budget_state: BudgetState,
+    pub budget_overrides: BudgetOverrides,
+    pub daily_cost: DailyCostCounter,
+    pub budget_soft_fired_usd: bool,
+    pub budget_soft_fired_cny: bool,
+    pub budget_hard_fired_usd: bool,
+    pub budget_hard_fired_cny: bool,
     pub last_prompt_tokens: Option<u32>,
     pub last_completion_tokens: Option<u32>,
     pub last_prompt_cache_hit_tokens: Option<u32>,
@@ -639,6 +648,13 @@ impl Default for SessionState {
             subagent_cost_event_seqs: HashSet::new(),
             displayed_cost_high_water: 0.0,
             displayed_cost_high_water_cny: 0.0,
+            budget_state: BudgetState::default(),
+            budget_overrides: BudgetOverrides::default(),
+            daily_cost: DailyCostCounter::default(),
+            budget_soft_fired_usd: false,
+            budget_soft_fired_cny: false,
+            budget_hard_fired_usd: false,
+            budget_hard_fired_cny: false,
             last_prompt_tokens: None,
             last_completion_tokens: None,
             last_prompt_cache_hit_tokens: None,
@@ -728,6 +744,7 @@ pub struct App {
     pub show_tool_details: bool,
     pub ui_locale: Locale,
     pub cost_currency: CostCurrency,
+    pub budget_config: Option<BudgetConfig>,
     pub composer_density: ComposerDensity,
     pub composer_border: bool,
     pub transcript_spacing: TranscriptSpacing,
@@ -1249,6 +1266,15 @@ impl App {
         let cached_skills = Self::discover_cached_skills(&workspace);
 
         let input_history = crate::composer_history::load_history();
+        let budget_config = config.budget.clone();
+        let mut session = SessionState::default();
+        if budget_config
+            .as_ref()
+            .and_then(|cfg| cfg.daily_usd_hard)
+            .is_some()
+        {
+            session.daily_cost = DailyCostCounter::load_default();
+        }
         let (initial_input_text, initial_input_cursor) = match initial_input {
             // #451: pre-populate the composer when invoked via
             // `deepseek pr <N>` (or any future caller that wants to
@@ -1284,7 +1310,7 @@ impl App {
             },
             viewport: ViewportState::default(),
             goal: GoalState::default(),
-            session: SessionState::default(),
+            session,
             history: Vec::new(),
             history_version: 0,
             history_revisions: Vec::new(),
@@ -1322,6 +1348,7 @@ impl App {
             show_tool_details,
             ui_locale,
             cost_currency,
+            budget_config,
             composer_density,
             composer_border,
             transcript_spacing,
@@ -1640,6 +1667,8 @@ impl App {
         self.session.session_cost += estimate.usd;
         self.session.session_cost_cny += estimate.cny;
         self.refresh_displayed_cost_high_water();
+        self.accrue_daily_budget_cost(estimate);
+        self.check_budget_after_accrue();
     }
 
     /// Add `delta` to the running sub-agent cost and bump the displayed
@@ -1654,6 +1683,171 @@ impl App {
         self.session.subagent_cost += estimate.usd;
         self.session.subagent_cost_cny += estimate.cny;
         self.refresh_displayed_cost_high_water();
+        if self
+            .budget_config
+            .as_ref()
+            .is_some_and(|cfg| cfg.include_subagents)
+        {
+            self.accrue_daily_budget_cost(estimate);
+            self.check_budget_after_accrue();
+        }
+    }
+
+    fn accrue_daily_budget_cost(&mut self, estimate: CostEstimate) {
+        if self.budget_config.is_some() {
+            self.session.daily_cost.accrue(estimate.usd, estimate.cny);
+        }
+    }
+
+    pub fn check_budget_after_accrue(&mut self) {
+        let Some(config) = self.budget_config.clone() else {
+            return;
+        };
+        if self.session.budget_overrides.released {
+            return;
+        }
+
+        let usd = self.budget_total(CostCurrency::Usd, config.include_subagents);
+        let cny = self.budget_total(CostCurrency::Cny, config.include_subagents);
+        let soft_usd = self
+            .session
+            .budget_overrides
+            .session_usd_soft
+            .or(config.session_usd_soft);
+        let hard_usd = self
+            .session
+            .budget_overrides
+            .session_usd_hard
+            .or(config.session_usd_hard);
+
+        if self.crossed(usd, soft_usd, self.session.budget_soft_fired_usd) {
+            self.session.budget_soft_fired_usd = true;
+            self.emit_budget_soft_message(CostCurrency::Usd, usd, soft_usd.unwrap_or_default());
+        }
+        if self.crossed(
+            cny,
+            config.session_cny_soft,
+            self.session.budget_soft_fired_cny,
+        ) {
+            self.session.budget_soft_fired_cny = true;
+            self.emit_budget_soft_message(
+                CostCurrency::Cny,
+                cny,
+                config.session_cny_soft.unwrap_or_default(),
+            );
+        }
+
+        if self.crossed(usd, hard_usd, self.session.budget_hard_fired_usd) {
+            self.session.budget_hard_fired_usd = true;
+            self.apply_budget_hard(
+                CostCurrency::Usd,
+                usd,
+                hard_usd.unwrap_or_default(),
+                config.on_exceed,
+            );
+            return;
+        }
+        if self.crossed(
+            cny,
+            config.session_cny_hard,
+            self.session.budget_hard_fired_cny,
+        ) {
+            self.session.budget_hard_fired_cny = true;
+            self.apply_budget_hard(
+                CostCurrency::Cny,
+                cny,
+                config.session_cny_hard.unwrap_or_default(),
+                config.on_exceed,
+            );
+            return;
+        }
+        if self.crossed(
+            self.session.daily_cost.usd,
+            config.daily_usd_hard,
+            self.session.budget_hard_fired_usd,
+        ) {
+            self.session.budget_hard_fired_usd = true;
+            self.apply_budget_hard(
+                CostCurrency::Usd,
+                self.session.daily_cost.usd,
+                config.daily_usd_hard.unwrap_or_default(),
+                config.on_exceed,
+            );
+        }
+    }
+
+    fn budget_total(&self, currency: CostCurrency, include_subagents: bool) -> f64 {
+        let base = self.session_cost_for_currency(currency);
+        if include_subagents {
+            base + self.subagent_cost_for_currency(currency)
+        } else {
+            base
+        }
+    }
+
+    fn crossed(&self, current: f64, cap: Option<f64>, fired: bool) -> bool {
+        !fired && cap.is_some_and(|cap| cap > 0.0 && current >= cap)
+    }
+
+    fn emit_budget_soft_message(&mut self, currency: CostCurrency, current: f64, cap: f64) {
+        self.session.budget_state = BudgetState::SoftWarned;
+        self.add_message(HistoryCell::System {
+            content: format!(
+                "⚠ Soft budget {} reached (current {}). /budget to manage.",
+                crate::pricing::format_cost_amount(cap, currency),
+                crate::pricing::format_cost_amount(current, currency)
+            ),
+        });
+    }
+
+    fn apply_budget_hard(
+        &mut self,
+        currency: CostCurrency,
+        current: f64,
+        cap: f64,
+        strategy: OnExceedStrategy,
+    ) {
+        let reason = format!(
+            "Hard budget {} reached (current {}).",
+            crate::pricing::format_cost_amount(cap, currency),
+            crate::pricing::format_cost_amount(current, currency)
+        );
+        match strategy {
+            OnExceedStrategy::Pause => self.pause_for_budget(reason),
+            OnExceedStrategy::DowngradeToFlash => {
+                if self.auto_model || self.model != "deepseek-v4-flash" {
+                    let result = crate::commands::switch_model(self, "deepseek-v4-flash");
+                    if let Some(message) = result.message {
+                        self.add_message(HistoryCell::System {
+                            content: format!("{reason} {message}"),
+                        });
+                    }
+                    self.session.budget_hard_fired_usd = false;
+                    self.session.budget_hard_fired_cny = false;
+                } else {
+                    self.pause_for_budget(reason);
+                }
+            }
+            OnExceedStrategy::Stop => {
+                self.session.budget_state = BudgetState::Stopped;
+                self.add_message(HistoryCell::System {
+                    content: format!(
+                        "{reason} Budget strategy is stop; current turn will be cancelled."
+                    ),
+                });
+            }
+        }
+    }
+
+    fn pause_for_budget(&mut self, reason: String) {
+        self.session.budget_state = BudgetState::Paused {
+            reason: reason.clone(),
+        };
+        self.add_message(HistoryCell::System {
+            content: format!(
+                "{reason} Paused. Use /budget extend <usd>, /budget release, or /budget downgrade."
+            ),
+        });
     }
 
     /// Recompute the displayed cost high-water mark. Called any time a cost
@@ -4041,6 +4235,75 @@ mod tests {
         let app = App::new(test_options(false), &Config::default());
         assert!(app.history.is_empty());
         assert_eq!(app.history_version, 0);
+    }
+
+    #[test]
+    fn budget_soft_threshold_fires_once_on_rising_edge() {
+        let config = Config {
+            budget: Some(BudgetConfig {
+                session_usd_soft: Some(1.0),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let mut app = App::new(test_options(false), &config);
+
+        app.accrue_session_cost_estimate(CostEstimate { usd: 1.1, cny: 0.0 });
+        app.accrue_session_cost_estimate(CostEstimate { usd: 0.1, cny: 0.0 });
+
+        let warnings = app
+            .history
+            .iter()
+            .filter(|cell| match cell {
+                HistoryCell::System { content } => content.contains("Soft budget"),
+                _ => false,
+            })
+            .count();
+        assert_eq!(warnings, 1);
+        assert_eq!(app.session.budget_state, BudgetState::SoftWarned);
+    }
+
+    #[test]
+    fn budget_hard_threshold_pauses_on_pause_strategy() {
+        let config = Config {
+            budget: Some(BudgetConfig {
+                session_usd_hard: Some(1.0),
+                on_exceed: OnExceedStrategy::Pause,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let mut app = App::new(test_options(false), &config);
+
+        app.accrue_session_cost_estimate(CostEstimate { usd: 1.0, cny: 0.0 });
+
+        assert!(matches!(
+            app.session.budget_state,
+            BudgetState::Paused { .. }
+        ));
+    }
+
+    #[test]
+    fn budget_downgrade_to_flash_switches_model_and_does_not_pause() {
+        let config = Config {
+            budget: Some(BudgetConfig {
+                session_usd_hard: Some(1.0),
+                on_exceed: OnExceedStrategy::DowngradeToFlash,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let mut options = test_options(false);
+        options.model = "deepseek-v4-pro".to_string();
+        let mut app = App::new(options, &config);
+
+        app.accrue_session_cost_estimate(CostEstimate { usd: 1.0, cny: 0.0 });
+
+        assert_eq!(app.model, "deepseek-v4-flash");
+        assert!(!matches!(
+            app.session.budget_state,
+            BudgetState::Paused { .. }
+        ));
     }
 
     #[test]

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -29,6 +29,7 @@ use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::audit::log_sensitive_event;
 use crate::automation_manager::{AutomationManager, AutomationSchedulerConfig, spawn_scheduler};
+use crate::budget::BudgetState;
 use crate::client::DeepSeekClient;
 use crate::commands;
 use crate::compaction::estimate_input_tokens_conservative;
@@ -749,6 +750,34 @@ async fn run_event_loop(
                             });
                         }
                     }
+                    EngineEvent::BudgetSoftReached {
+                        currency,
+                        current,
+                        cap,
+                    } => {
+                        app.add_message(HistoryCell::System {
+                            content: format!(
+                                "⚠ Soft budget {} reached (current {}). /budget to manage.",
+                                crate::pricing::format_cost_amount(cap, currency),
+                                crate::pricing::format_cost_amount(current, currency)
+                            ),
+                        });
+                    }
+                    EngineEvent::BudgetHardReached {
+                        currency,
+                        current,
+                        cap,
+                        strategy,
+                    } => {
+                        app.add_message(HistoryCell::System {
+                            content: format!(
+                                "Hard budget {} reached (current {}), strategy {:?}.",
+                                crate::pricing::format_cost_amount(cap, currency),
+                                crate::pricing::format_cost_amount(current, currency),
+                                strategy
+                            ),
+                        });
+                    }
                     EngineEvent::ThinkingStarted { .. } => {
                         // P2.3: thinking lives in the active cell so it groups
                         // visually with the tool calls that follow until the
@@ -959,6 +988,9 @@ async fn run_event_loop(
                         );
                         if let Some(cost) = turn_cost {
                             app.accrue_session_cost_estimate(cost);
+                            if matches!(app.session.budget_state, BudgetState::Stopped) {
+                                engine_handle.cancel();
+                            }
                         }
 
                         // Emit OSC 9 / BEL desktop notification for long turns.
@@ -1484,6 +1516,9 @@ async fn run_event_loop(
         let pending_bg_cost = crate::cost_status::drain();
         if pending_bg_cost.is_positive() {
             app.accrue_subagent_cost_estimate(pending_bg_cost);
+            if matches!(app.session.budget_state, BudgetState::Stopped) {
+                engine_handle.cancel();
+            }
             app.needs_redraw = true;
         }
         // Expire the "Press Ctrl+C again to quit" prompt silently after its
@@ -3590,6 +3625,25 @@ async fn dispatch_user_message(
     engine_handle: &EngineHandle,
     message: QueuedMessage,
 ) -> Result<()> {
+    match app.session.budget_state.clone() {
+        BudgetState::Paused { reason } => {
+            app.add_message(HistoryCell::System {
+                content: format!(
+                    "{reason} Budget paused. Use /budget extend <usd>, /budget release, or /budget downgrade."
+                ),
+            });
+            return Ok(());
+        }
+        BudgetState::Stopped => {
+            app.add_message(HistoryCell::System {
+                content: "Budget stopped. Use /budget release to continue this session."
+                    .to_string(),
+            });
+            return Ok(());
+        }
+        BudgetState::Active | BudgetState::SoftWarned => {}
+    }
+
     // #455 (observer-only): fire `message_submit` hooks before
     // dispatch. Hooks see the user's display text via the
     // `with_message` builder. Read-only — they can log, audit, or
@@ -5941,6 +5995,12 @@ fn apply_loaded_session(app: &mut App, session: &SavedSession) -> bool {
     app.session.subagent_cost_event_seqs.clear();
     app.session.displayed_cost_high_water = 0.0;
     app.session.displayed_cost_high_water_cny = 0.0;
+    app.session.budget_state = BudgetState::Active;
+    app.session.budget_overrides = Default::default();
+    app.session.budget_soft_fired_usd = false;
+    app.session.budget_soft_fired_cny = false;
+    app.session.budget_hard_fired_usd = false;
+    app.session.budget_hard_fired_cny = false;
     app.session.last_prompt_tokens = None;
     app.session.last_completion_tokens = None;
     app.session.last_prompt_cache_hit_tokens = None;
@@ -6758,7 +6818,11 @@ fn footer_cost_spans(app: &App) -> Vec<Span<'static>> {
     }
     vec![Span::styled(
         app.format_cost_amount(displayed_cost),
-        Style::default().fg(palette::TEXT_MUTED),
+        Style::default().fg(match app.session.budget_state {
+            BudgetState::Active => palette::TEXT_MUTED,
+            BudgetState::SoftWarned => palette::STATUS_WARNING,
+            BudgetState::Paused { .. } | BudgetState::Stopped => palette::STATUS_ERROR,
+        }),
     )]
 }
 

--- a/crates/tui/tests/budget.rs
+++ b/crates/tui/tests/budget.rs
@@ -1,0 +1,26 @@
+#[path = "../src/budget.rs"]
+#[allow(dead_code)]
+mod budget;
+
+use budget::DailyCostCounter;
+
+#[test]
+fn daily_counter_persists_and_resets_at_next_local_midnight() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("daily_budget.json");
+    let day = chrono::NaiveDate::from_ymd_opt(2026, 5, 7).expect("date");
+    let next = chrono::NaiveDate::from_ymd_opt(2026, 5, 8).expect("date");
+
+    let mut counter = DailyCostCounter::load_at(path.clone(), day);
+    counter.usd = 12.34;
+    counter.cny = 87.65;
+    counter.save().expect("save");
+
+    let same_day = DailyCostCounter::load_at(path.clone(), day);
+    assert_eq!(same_day.usd, 12.34);
+    assert_eq!(same_day.cny, 87.65);
+
+    let next_day = DailyCostCounter::load_at(path, next);
+    assert_eq!(next_day.usd, 0.0);
+    assert_eq!(next_day.cny, 0.0);
+}


### PR DESCRIPTION
## Summary
- add optional [budget] config for session soft/hard caps, daily USD cap persistence, and on-exceed strategies
- track budget state from the existing session/subagent cost accrual chokepoints
- add /budget controls for inspecting, overriding, extending, releasing, and downgrading budgets
- tint footer cost when budget warning/pause/stop states are active

## Tests
- cargo build --workspace
- cargo test --workspace --all-features
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check

## Notes
- TUI runtime has its own config/module tree, so the runtime budget schema is mirrored in crates/tui/src/config.rs.
- Latest origin/main required cargo fmt changes in commands/config.rs and localization.rs for fmt --check to pass.