### PR TITLE
fix(i18n): localize approval dialog safety copy

### DIFF
--- a/crates/tui/src/tui/approval.rs
+++ b/crates/tui/src/tui/approval.rs
@@ -27,6 +27,7 @@
 //! happen *before* the view is constructed (see `tui/ui.rs`); this
 //! module always assumes the user is being asked.
 
+use crate::localization::Locale;
 use crate::sandbox::SandboxPolicy;
 use crate::tui::views::{ModalKind, ModalView, ViewAction, ViewEvent};
 use crate::tui::widgets::{ApprovalWidget, ElevationWidget, Renderable};
@@ -160,6 +161,22 @@ impl ApprovalRequest {
     pub fn params_display(&self) -> String {
         let truncated = truncate_params_value(&self.params, 200);
         serde_json::to_string(&truncated).unwrap_or_else(|_| truncated.to_string())
+    }
+
+    pub fn description_for_locale(&self, locale: Locale) -> String {
+        match locale {
+            Locale::ZhHans => localized_description_zh_hans(self.category),
+            _ => self.description.clone(),
+        }
+    }
+
+    pub fn impacts_for_locale(&self, locale: Locale) -> Vec<String> {
+        match locale {
+            Locale::ZhHans => {
+                build_impact_summary_zh_hans(&self.tool_name, self.category, &self.params)
+            }
+            _ => self.impacts.clone(),
+        }
     }
 }
 
@@ -346,6 +363,85 @@ fn build_impact_summary(tool_name: &str, category: ToolCategory, params: &Value)
     }
 }
 
+fn localized_description_zh_hans(category: ToolCategory) -> String {
+    match category {
+        ToolCategory::Safe => "请求执行只读操作。".to_string(),
+        ToolCategory::FileWrite => "请求修改文件。请确认路径和内容符合预期。".to_string(),
+        ToolCategory::Shell => "请求执行 shell 命令。请先检查命令和工作目录。".to_string(),
+        ToolCategory::Network => "请求访问网络或远程内容。请确认目标可信。".to_string(),
+        ToolCategory::McpRead => "请求从 MCP 服务器读取信息。".to_string(),
+        ToolCategory::McpAction => "请求调用 MCP 服务器操作，可能产生副作用。".to_string(),
+        ToolCategory::Unknown => "请求运行未分类工具。批准前请仔细检查参数。".to_string(),
+    }
+}
+
+fn build_impact_summary_zh_hans(
+    tool_name: &str,
+    category: ToolCategory,
+    params: &Value,
+) -> Vec<String> {
+    match category {
+        ToolCategory::Safe => {
+            let mut impacts = vec!["只读操作。".to_string()];
+            if let Some(path) = param_preview(params, &["path", "ref_id", "uri"], 72) {
+                impacts.push(format!("读取：{path}"));
+            }
+            impacts
+        }
+        ToolCategory::FileWrite => {
+            let mut impacts = vec!["会写入工作区或已批准写入范围内的文件。".to_string()];
+            if let Some(path) = param_preview(params, &["path", "target", "destination"], 72) {
+                impacts.push(format!("写入：{path}"));
+            }
+            impacts
+        }
+        ToolCategory::Shell => {
+            let mut impacts = vec!["执行 shell 命令。".to_string()];
+            if let Some(command) = param_preview(params, &["cmd", "command"], 96) {
+                impacts.push(format!("命令：{command}"));
+            }
+            if let Some(workdir) = param_preview(params, &["workdir", "cwd"], 72) {
+                impacts.push(format!("工作目录：{workdir}"));
+            }
+            impacts
+        }
+        ToolCategory::Network => {
+            let mut impacts = vec!["可能访问网络服务或远程内容。".to_string()];
+            if let Some(target) =
+                param_preview(params, &["url", "q", "query", "location", "repo"], 96)
+            {
+                impacts.push(format!("目标：{target}"));
+            }
+            impacts
+        }
+        ToolCategory::McpRead => {
+            let mut impacts = vec!["从 MCP 服务器读取信息，不应产生本地写入。".to_string()];
+            if let Some(server) = mcp_server_hint(tool_name) {
+                impacts.push(format!("服务器：{server}"));
+            }
+            impacts
+        }
+        ToolCategory::McpAction => {
+            let mut impacts = vec!["调用可能产生副作用的 MCP 服务器操作。".to_string()];
+            if let Some(server) = mcp_server_hint(tool_name) {
+                impacts.push(format!("服务器：{server}"));
+            }
+            impacts
+        }
+        ToolCategory::Unknown => {
+            let mut impacts = vec!["工具未分类。批准前请仔细检查参数。".to_string()];
+            if let Some(target) = param_preview(
+                params,
+                &["path", "cmd", "command", "url", "q", "query", "ref_id"],
+                96,
+            ) {
+                impacts.push(format!("主要输入：{target}"));
+            }
+            impacts
+        }
+    }
+}
+
 /// Indices into the option list shared by both variants. Visible to
 /// the widget module so it can render the staged-confirmation banner
 /// without re-deriving the variant from the request.
@@ -401,6 +497,7 @@ impl ApprovalOption {
 pub struct ApprovalView {
     request: ApprovalRequest,
     selected: usize,
+    locale: Locale,
     /// When `Some`, the destructive variant has staged this approval and
     /// is waiting for the user to press the same key (or `Enter`) again.
     /// Any other key clears the staging.
@@ -410,10 +507,16 @@ pub struct ApprovalView {
 }
 
 impl ApprovalView {
+    #[cfg(test)]
     pub fn new(request: ApprovalRequest) -> Self {
+        Self::new_for_locale(request, Locale::En)
+    }
+
+    pub fn new_for_locale(request: ApprovalRequest, locale: Locale) -> Self {
         Self {
             request,
             selected: 0,
+            locale,
             pending_confirm: None,
             timeout: None,
             requested_at: Instant::now(),
@@ -458,6 +561,10 @@ impl ApprovalView {
     /// no approve key has been pressed yet.
     pub(crate) fn pending_confirm(&self) -> Option<ApprovalOption> {
         self.pending_confirm
+    }
+
+    pub(crate) fn locale(&self) -> Locale {
+        self.locale
     }
 
     /// Try to commit (or stage) the given option respecting the
@@ -1381,6 +1488,10 @@ mod tests {
             .collect()
     }
 
+    fn compact_rendered_text(lines: &[String]) -> String {
+        lines.join("\n").replace(' ', "")
+    }
+
     #[test]
     fn render_benign_includes_review_badge_and_one_step_hint() {
         let view = ApprovalView::new(benign_request());
@@ -1423,6 +1534,53 @@ mod tests {
         assert!(
             joined.contains("(staged)"),
             "stage marker missing:\n{joined}"
+        );
+    }
+
+    #[test]
+    fn render_destructive_zh_hans_localizes_security_copy() {
+        let mut view = ApprovalView::new_for_locale(destructive_request(), Locale::ZhHans);
+        let lines = render_lines(&view, 100, 40);
+        let joined = compact_rendered_text(&lines);
+        assert!(
+            joined.contains("破坏性"),
+            "missing zh risk badge:\n{joined}"
+        );
+        assert!(
+            joined.contains("两次按键确认"),
+            "missing zh two-step hint:\n{joined}"
+        );
+        assert!(
+            joined.contains("文件写入"),
+            "missing zh category:\n{joined}"
+        );
+        assert!(
+            joined.contains("影响："),
+            "missing zh impact label:\n{joined}"
+        );
+        assert!(
+            joined.contains("写入：src/main.rs"),
+            "missing zh impact path:\n{joined}"
+        );
+        assert!(
+            joined.contains("仅本次批准"),
+            "missing zh approve option:\n{joined}"
+        );
+
+        view.handle_key(create_key_event(KeyCode::Char('y')));
+        let lines = render_lines(&view, 100, 40);
+        let joined = compact_rendered_text(&lines);
+        assert!(
+            joined.contains("确认破坏性操作"),
+            "missing zh confirm banner:\n{joined}"
+        );
+        assert!(
+            joined.contains("(待确认)"),
+            "missing zh staged marker:\n{joined}"
+        );
+        assert!(
+            joined.contains("Enter或y"),
+            "missing zh confirm key:\n{joined}"
         );
     }
 

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -1310,7 +1310,8 @@ async fn run_event_loop(
                                     "mode": app.mode.label(),
                                 }),
                             );
-                            app.view_stack.push(ApprovalView::new(request));
+                            app.view_stack
+                                .push(ApprovalView::new_for_locale(request, app.ui_locale));
                             app.status_message = Some(format!(
                                 "Approval required for '{tool_name}': {description}"
                             ));

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -22,6 +22,7 @@ pub use renderable::Renderable;
 
 use std::time::Duration;
 
+use crate::localization::Locale;
 use crate::palette;
 use crate::tui::app::{App, AppMode, ComposerDensity, VimMode};
 use crate::tui::approval::{
@@ -1014,6 +1015,7 @@ impl Renderable for ApprovalWidget<'_> {
         Clear.render(card_area, buf);
 
         let risk = self.request.risk;
+        let locale = self.view.locale();
         let palette_colors = approval_palette(risk);
         let mut lines: Vec<Line<'static>> = Vec::with_capacity(20);
 
@@ -1023,7 +1025,7 @@ impl Renderable for ApprovalWidget<'_> {
         lines.push(Line::from(vec![
             Span::raw("  "),
             Span::styled(
-                format!(" {} ", risk_badge_text(risk)),
+                format!(" {} ", risk_badge_text(risk, locale)),
                 Style::default()
                     .fg(palette::DEEPSEEK_INK)
                     .bg(palette_colors.accent)
@@ -1038,12 +1040,12 @@ impl Renderable for ApprovalWidget<'_> {
             ),
         ]));
 
-        // Category line — unchanged vocabulary so existing tests still
-        // recognise the rendering.
-        let (cat_label, cat_color) = category_label_for(self.request.category);
+        // Category line — English remains the baseline while localized
+        // sessions get the same risk category in their UI language.
+        let (cat_label, cat_color) = category_label_for(self.request.category, locale);
         lines.push(Line::from(vec![
             Span::raw("  "),
-            Span::styled("Type: ", Style::default().fg(palette::TEXT_HINT)),
+            Span::styled(label_type(locale), Style::default().fg(palette::TEXT_HINT)),
             Span::styled(
                 cat_label,
                 Style::default().fg(cat_color).add_modifier(Modifier::BOLD),
@@ -1055,17 +1057,20 @@ impl Renderable for ApprovalWidget<'_> {
         // they tell the user what will happen.
         lines.push(Line::from(vec![
             Span::raw("  "),
-            Span::styled("About:  ", Style::default().fg(palette::TEXT_HINT)),
+            Span::styled(label_about(locale), Style::default().fg(palette::TEXT_HINT)),
             Span::styled(
-                self.request.description.clone(),
+                self.request.description_for_locale(locale),
                 Style::default().fg(palette::TEXT_BODY),
             ),
         ]));
-        for impact in self.request.impacts.iter().take(4) {
+        for impact in self.request.impacts_for_locale(locale).into_iter().take(4) {
             lines.push(Line::from(vec![
                 Span::raw("  "),
-                Span::styled("Impact: ", Style::default().fg(palette::TEXT_HINT)),
-                Span::styled(impact.clone(), Style::default().fg(palette::TEXT_BODY)),
+                Span::styled(
+                    label_impact(locale),
+                    Style::default().fg(palette::TEXT_HINT),
+                ),
+                Span::styled(impact, Style::default().fg(palette::TEXT_BODY)),
             ]));
         }
 
@@ -1076,7 +1081,10 @@ impl Renderable for ApprovalWidget<'_> {
             crate::utils::truncate_with_ellipsis(&params_str, params_width.max(20), "...");
         lines.push(Line::from(vec![
             Span::raw("  "),
-            Span::styled("Params: ", Style::default().fg(palette::TEXT_HINT)),
+            Span::styled(
+                label_params(locale),
+                Style::default().fg(palette::TEXT_HINT),
+            ),
             Span::styled(
                 params_truncated,
                 Style::default().fg(palette::TEXT_SECONDARY),
@@ -1085,7 +1093,7 @@ impl Renderable for ApprovalWidget<'_> {
 
         lines.push(Line::from(""));
 
-        let options = approval_options_for(risk);
+        let options = approval_options_for(risk, locale);
         let pending = self.view.pending_confirm();
 
         for (i, opt) in options.iter().enumerate() {
@@ -1118,7 +1126,7 @@ impl Renderable for ApprovalWidget<'_> {
             if staged {
                 spans.push(Span::raw("  "));
                 spans.push(Span::styled(
-                    "(staged)",
+                    staged_marker(locale),
                     Style::default()
                         .fg(palette_colors.accent)
                         .add_modifier(Modifier::BOLD),
@@ -1136,31 +1144,33 @@ impl Renderable for ApprovalWidget<'_> {
                 lines.push(Line::from(vec![
                     Span::raw("  "),
                     Span::styled(
-                        "Single key approves: ",
+                        single_key_prefix(locale),
                         Style::default().fg(palette::TEXT_HINT),
                     ),
                     Span::styled(
-                        "Enter / 1 / y",
+                        single_key_value(locale),
                         Style::default()
                             .fg(palette_colors.accent)
                             .add_modifier(Modifier::BOLD),
                     ),
                     Span::styled(
-                        "  ·  v: full params  ·  Esc: abort",
+                        footer_controls(locale),
                         Style::default().fg(palette::TEXT_HINT),
                     ),
                 ]));
             }
             (RiskLevel::Destructive, Some(opt)) => {
                 let again_key = match opt {
-                    crate::tui::approval::ApprovalOption::ApproveOnce => "Enter or y",
-                    crate::tui::approval::ApprovalOption::ApproveAlways => "Enter or a",
+                    crate::tui::approval::ApprovalOption::ApproveOnce => confirm_key_once(locale),
+                    crate::tui::approval::ApprovalOption::ApproveAlways => {
+                        confirm_key_always(locale)
+                    }
                     _ => "Enter",
                 };
                 lines.push(Line::from(vec![
                     Span::raw("  "),
                     Span::styled(
-                        "Confirm destructive action — press ",
+                        destructive_confirm_prefix(locale),
                         Style::default()
                             .fg(palette_colors.accent)
                             .add_modifier(Modifier::BOLD),
@@ -1173,7 +1183,7 @@ impl Renderable for ApprovalWidget<'_> {
                             .add_modifier(Modifier::BOLD),
                     ),
                     Span::styled(
-                        " again to commit, anything else cancels.",
+                        destructive_confirm_suffix(locale),
                         Style::default().fg(palette::TEXT_HINT),
                     ),
                 ]));
@@ -1182,17 +1192,17 @@ impl Renderable for ApprovalWidget<'_> {
                 lines.push(Line::from(vec![
                     Span::raw("  "),
                     Span::styled(
-                        "Two keys to approve: ",
+                        two_key_prefix(locale),
                         Style::default().fg(palette::TEXT_HINT),
                     ),
                     Span::styled(
-                        "y/a then y/a again",
+                        two_key_value(locale),
                         Style::default()
                             .fg(palette_colors.accent)
                             .add_modifier(Modifier::BOLD),
                     ),
                     Span::styled(
-                        "  ·  v: full params  ·  Esc: abort",
+                        footer_controls(locale),
                         Style::default().fg(palette::TEXT_HINT),
                     ),
                 ]));
@@ -1200,8 +1210,9 @@ impl Renderable for ApprovalWidget<'_> {
         }
 
         let title = format!(
-            " {} approval — {} ",
-            risk_badge_text(risk),
+            " {} {} — {} ",
+            risk_badge_text(risk, locale),
+            approval_word(locale),
             self.request.tool_name
         );
         let block = Block::default()
@@ -1294,22 +1305,133 @@ fn approval_palette(risk: RiskLevel) -> ApprovalColors {
     }
 }
 
-fn risk_badge_text(risk: RiskLevel) -> &'static str {
-    match risk {
-        RiskLevel::Benign => "REVIEW",
-        RiskLevel::Destructive => "DESTRUCTIVE",
+fn risk_badge_text(risk: RiskLevel, locale: Locale) -> &'static str {
+    match (locale, risk) {
+        (Locale::ZhHans, RiskLevel::Benign) => "审查",
+        (Locale::ZhHans, RiskLevel::Destructive) => "破坏性",
+        (_, RiskLevel::Benign) => "REVIEW",
+        (_, RiskLevel::Destructive) => "DESTRUCTIVE",
     }
 }
 
-fn category_label_for(category: ToolCategory) -> (&'static str, Color) {
-    match category {
-        ToolCategory::Safe => ("Safe", palette::STATUS_SUCCESS),
-        ToolCategory::FileWrite => ("File Write", palette::STATUS_WARNING),
-        ToolCategory::Shell => ("Shell Command", palette::STATUS_ERROR),
-        ToolCategory::Network => ("Network", palette::STATUS_WARNING),
-        ToolCategory::McpRead => ("MCP Read", palette::DEEPSEEK_SKY),
-        ToolCategory::McpAction => ("MCP Action", palette::STATUS_WARNING),
-        ToolCategory::Unknown => ("Unknown", palette::STATUS_ERROR),
+fn category_label_for(category: ToolCategory, locale: Locale) -> (&'static str, Color) {
+    match (locale, category) {
+        (Locale::ZhHans, ToolCategory::Safe) => ("安全", palette::STATUS_SUCCESS),
+        (Locale::ZhHans, ToolCategory::FileWrite) => ("文件写入", palette::STATUS_WARNING),
+        (Locale::ZhHans, ToolCategory::Shell) => ("Shell 命令", palette::STATUS_ERROR),
+        (Locale::ZhHans, ToolCategory::Network) => ("网络", palette::STATUS_WARNING),
+        (Locale::ZhHans, ToolCategory::McpRead) => ("MCP 读取", palette::DEEPSEEK_SKY),
+        (Locale::ZhHans, ToolCategory::McpAction) => ("MCP 操作", palette::STATUS_WARNING),
+        (Locale::ZhHans, ToolCategory::Unknown) => ("未知", palette::STATUS_ERROR),
+        (_, ToolCategory::Safe) => ("Safe", palette::STATUS_SUCCESS),
+        (_, ToolCategory::FileWrite) => ("File Write", palette::STATUS_WARNING),
+        (_, ToolCategory::Shell) => ("Shell Command", palette::STATUS_ERROR),
+        (_, ToolCategory::Network) => ("Network", palette::STATUS_WARNING),
+        (_, ToolCategory::McpRead) => ("MCP Read", palette::DEEPSEEK_SKY),
+        (_, ToolCategory::McpAction) => ("MCP Action", palette::STATUS_WARNING),
+        (_, ToolCategory::Unknown) => ("Unknown", palette::STATUS_ERROR),
+    }
+}
+
+fn approval_word(locale: Locale) -> &'static str {
+    match locale {
+        Locale::ZhHans => "审批",
+        _ => "approval",
+    }
+}
+
+fn label_type(locale: Locale) -> &'static str {
+    match locale {
+        Locale::ZhHans => "类型：",
+        _ => "Type: ",
+    }
+}
+
+fn label_about(locale: Locale) -> &'static str {
+    match locale {
+        Locale::ZhHans => "说明：",
+        _ => "About:  ",
+    }
+}
+
+fn label_impact(locale: Locale) -> &'static str {
+    match locale {
+        Locale::ZhHans => "影响：",
+        _ => "Impact: ",
+    }
+}
+
+fn label_params(locale: Locale) -> &'static str {
+    match locale {
+        Locale::ZhHans => "参数：",
+        _ => "Params: ",
+    }
+}
+
+fn staged_marker(locale: Locale) -> &'static str {
+    match locale {
+        Locale::ZhHans => "(待确认)",
+        _ => "(staged)",
+    }
+}
+
+fn single_key_prefix(locale: Locale) -> &'static str {
+    match locale {
+        Locale::ZhHans => "单键批准：",
+        _ => "Single key approves: ",
+    }
+}
+
+fn single_key_value(_locale: Locale) -> &'static str {
+    "Enter / 1 / y"
+}
+
+fn footer_controls(locale: Locale) -> &'static str {
+    match locale {
+        Locale::ZhHans => "  ·  v：完整参数  ·  Esc：中止",
+        _ => "  ·  v: full params  ·  Esc: abort",
+    }
+}
+
+fn destructive_confirm_prefix(locale: Locale) -> &'static str {
+    match locale {
+        Locale::ZhHans => "确认破坏性操作：再次按 ",
+        _ => "Confirm destructive action — press ",
+    }
+}
+
+fn destructive_confirm_suffix(locale: Locale) -> &'static str {
+    match locale {
+        Locale::ZhHans => " 执行；按其他键取消。",
+        _ => " again to commit, anything else cancels.",
+    }
+}
+
+fn confirm_key_once(locale: Locale) -> &'static str {
+    match locale {
+        Locale::ZhHans => "Enter 或 y",
+        _ => "Enter or y",
+    }
+}
+
+fn confirm_key_always(locale: Locale) -> &'static str {
+    match locale {
+        Locale::ZhHans => "Enter 或 a",
+        _ => "Enter or a",
+    }
+}
+
+fn two_key_prefix(locale: Locale) -> &'static str {
+    match locale {
+        Locale::ZhHans => "两次按键确认：",
+        _ => "Two keys to approve: ",
+    }
+}
+
+fn two_key_value(locale: Locale) -> &'static str {
+    match locale {
+        Locale::ZhHans => "先按 y/a，再按一次 y/a",
+        _ => "y/a then y/a again",
     }
 }
 
@@ -1320,35 +1442,63 @@ struct ApprovalOptionRow {
     dangerous: bool,
 }
 
-fn approval_options_for(risk: RiskLevel) -> [ApprovalOptionRow; 4] {
+fn approval_options_for(risk: RiskLevel, locale: Locale) -> [ApprovalOptionRow; 4] {
     use crate::tui::approval::ApprovalOption as O;
     let dangerous = matches!(risk, RiskLevel::Destructive);
     [
         ApprovalOptionRow {
             option: O::ApproveOnce,
-            label: "Approve once",
+            label: option_approve_once(locale),
             key_hint: "1 / y",
             dangerous,
         },
         ApprovalOptionRow {
             option: O::ApproveAlways,
-            label: "Approve always for this kind",
+            label: option_approve_always(locale),
             key_hint: "2 / a",
             dangerous,
         },
         ApprovalOptionRow {
             option: O::Deny,
-            label: "Deny this call",
+            label: option_deny(locale),
             key_hint: "3 / d / n",
             dangerous: false,
         },
         ApprovalOptionRow {
             option: O::Abort,
-            label: "Abort the turn",
+            label: option_abort(locale),
             key_hint: "Esc",
             dangerous: false,
         },
     ]
+}
+
+fn option_approve_once(locale: Locale) -> &'static str {
+    match locale {
+        Locale::ZhHans => "仅本次批准",
+        _ => "Approve once",
+    }
+}
+
+fn option_approve_always(locale: Locale) -> &'static str {
+    match locale {
+        Locale::ZhHans => "本会话同类自动批准",
+        _ => "Approve always for this kind",
+    }
+}
+
+fn option_deny(locale: Locale) -> &'static str {
+    match locale {
+        Locale::ZhHans => "拒绝本次调用",
+        _ => "Deny this call",
+    }
+}
+
+fn option_abort(locale: Locale) -> &'static str {
+    match locale {
+        Locale::ZhHans => "中止本轮",
+        _ => "Abort the turn",
+    }
 }
 
 pub struct ElevationWidget<'a> {


### PR DESCRIPTION
## Summary
- Pass the configured UI locale into approval modals.
- Localize Simplified Chinese approval-dialog safety copy: risk badge, category labels, impact summaries, option labels, and destructive two-step confirmation text.
- Preserve English behavior by default and add a zh-Hans render regression test.

Closes #1087

## Tests
- cargo test -p deepseek-tui tui::approval::tests:: -- --nocapture
- cargo check -p deepseek-tui