### PR TITLE
docs: fix help keybinding reference

### DIFF
--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -8,7 +8,7 @@ Bindings are not (yet) user-configurable — tracked for a future release (#436,
 
 | Chord                | Action                                                        |
 |----------------------|---------------------------------------------------------------|
-| `F1` or `Ctrl-?`     | Toggle the help overlay                                       |
+| `F1` or `Ctrl-/`     | Toggle the help overlay                                       |
 | `Ctrl-K`             | Open the command palette (slash-command finder)                |
 | `Ctrl-C`             | Cancel current turn / dismiss modal / arm-then-confirm quit    |
 | `Ctrl-D`             | Quit (only when the composer is empty)                         |


### PR DESCRIPTION
## Summary

- Correct `docs/KEYBINDINGS.md` to document `Ctrl-/` for help overlay toggling.
- Aligns the docs with the live `ui.rs` handler and help catalog, which use `Ctrl+/`, not `Ctrl-?`.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets --all-features`
- [x] `cargo check`
- [x] `cargo test --workspace --all-features`

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant (not needed; docs-only correction)
- [ ] Verified TUI behavior manually if UI changes (not needed; no UI behavior change)