### PR TITLE
docs: fix memory skill link

### DIFF
--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -189,7 +189,7 @@ Memory is for **durable** signal. Things that should NOT live there:
 - **Conversation snippets** — quote-style notes belong in the notes
   tool (`note`), not memory.
 - **Long instructions** — anything over a few sentences should live
-  in `AGENTS.md` (project-level) or in a [skill](../crates/tui/src/skills.rs)
+  in `AGENTS.md` (project-level) or in a [skill](../crates/tui/src/skills/mod.rs)
   (reusable instruction packs).
 
 ## Privacy and scope


### PR DESCRIPTION
## Summary
- Update the memory documentation's skill link to point at the current skills module path

## Verification
- Confirmed `crates/tui/src/skills/mod.rs` exists
- Checked non-code-fence local Markdown links resolve
- Ran `git diff --check`
- Ran `cargo fmt --all -- --check`