### PR TITLE
fix(fetch_url): add proxy DNS opt-in

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -250,6 +250,10 @@ pub struct NetworkPolicyToml {
     /// Hosts that are always denied. Deny entries win over allow entries.
     #[serde(default)]
     pub deny: Vec<String>,
+    /// Hostnames whose DNS may resolve to fake-IP/private proxy ranges in an
+    /// explicitly trusted proxy setup. Literal IP URLs remain blocked.
+    #[serde(default)]
+    pub proxy: Vec<String>,
     /// Whether to record one audit-log line per outbound network call.
     #[serde(default = "default_network_audit")]
     pub audit: bool,
@@ -269,6 +273,7 @@ impl Default for NetworkPolicyToml {
             default: default_network_decision(),
             allow: Vec::new(),
             deny: Vec::new(),
+            proxy: Vec::new(),
             audit: default_network_audit(),
         }
     }
@@ -1402,6 +1407,21 @@ mod tests {
     fn env_lock() -> std::sync::MutexGuard<'static, ()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+    }
+
+    #[test]
+    fn network_policy_toml_deserializes_proxy_hosts() {
+        let policy: NetworkPolicyToml = toml::from_str(
+            r#"
+            default = "allow"
+            proxy = ["github.com", ".githubusercontent.com"]
+            "#,
+        )
+        .expect("network policy toml");
+
+        assert_eq!(policy.default, "allow");
+        assert_eq!(policy.proxy, ["github.com", ".githubusercontent.com"]);
+        assert!(policy.audit);
     }
 
     struct EnvGuard {

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -919,6 +919,10 @@ pub struct NetworkPolicyToml {
     /// Hosts that are always denied. Deny entries win over allow entries.
     #[serde(default)]
     pub deny: Vec<String>,
+    /// Hostnames whose DNS may resolve to fake-IP/private proxy ranges in an
+    /// explicitly trusted proxy setup. Literal IP URLs remain blocked.
+    #[serde(default)]
+    pub proxy: Vec<String>,
     /// Whether to record one audit-log line per outbound network call.
     #[serde(default = "default_network_audit")]
     pub audit: bool,
@@ -938,6 +942,7 @@ impl Default for NetworkPolicyToml {
             default: default_network_decision(),
             allow: Vec::new(),
             deny: Vec::new(),
+            proxy: Vec::new(),
             audit: default_network_audit(),
         }
     }
@@ -952,6 +957,7 @@ impl NetworkPolicyToml {
             default: crate::network_policy::Decision::parse(&self.default).into(),
             allow: self.allow,
             deny: self.deny,
+            proxy: self.proxy,
             audit: self.audit,
         }
     }
@@ -3129,6 +3135,23 @@ mod tests {
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn network_policy_toml_maps_proxy_hosts_to_runtime_policy() {
+        let policy: NetworkPolicyToml = toml::from_str(
+            r#"
+            default = "allow"
+            proxy = ["github.com", ".githubusercontent.com"]
+            "#,
+        )
+        .expect("network policy toml");
+
+        let runtime = policy.into_runtime();
+
+        assert_eq!(runtime.proxy, ["github.com", ".githubusercontent.com"]);
+        assert!(runtime.trusts_proxy_fakeip_host("github.com"));
+        assert!(runtime.trusts_proxy_fakeip_host("raw.githubusercontent.com"));
+    }
 
     struct EnvGuard {
         home: Option<OsString>,

--- a/crates/tui/src/network_policy.rs
+++ b/crates/tui/src/network_policy.rs
@@ -33,7 +33,7 @@
 //! # Audit-log format
 //!
 //! ```text
-//! <RFC3339-timestamp> network <host> <tool> <Allow|Deny|Prompt-Approved|Prompt-Denied>
+//! <RFC3339-timestamp> network <host> <tool> <Allow|Deny|Prompt-Approved|Prompt-Denied|TrustedProxyFakeIp-Allow>
 //! ```
 //!
 //! Plaintext, one line per call, appended to `<audit_path>` (defaults to
@@ -98,6 +98,10 @@ pub struct NetworkPolicy {
     /// Hosts that should always be denied.
     #[serde(default)]
     pub deny: Vec<String>,
+    /// Hostnames whose DNS may resolve to fake-IP/private proxy ranges in an
+    /// explicitly trusted proxy setup. This does not affect literal IP URLs.
+    #[serde(default)]
+    pub proxy: Vec<String>,
     /// Whether to record one audit-log line per network call. Defaults to true.
     #[serde(default = "default_audit")]
     pub audit: bool,
@@ -117,6 +121,7 @@ impl Default for NetworkPolicy {
             default: DecisionToml::Prompt,
             allow: Vec::new(),
             deny: Vec::new(),
+            proxy: Vec::new(),
             audit: true,
         }
     }
@@ -204,6 +209,26 @@ impl NetworkPolicy {
     #[must_use]
     pub fn audit_enabled(&self) -> bool {
         self.audit
+    }
+
+    /// Whether `host` is explicitly trusted to resolve through a local
+    /// fake-IP proxy. Deny entries still win over this list.
+    #[must_use]
+    pub fn trusts_proxy_fakeip_host(&self, host: &str) -> bool {
+        let normalized = normalize_host(host);
+        if normalized.is_empty() {
+            return false;
+        }
+        if self
+            .deny
+            .iter()
+            .any(|entry| host_matches(entry, &normalized))
+        {
+            return false;
+        }
+        self.proxy
+            .iter()
+            .any(|entry| host_matches(entry, &normalized))
     }
 }
 
@@ -471,6 +496,19 @@ impl NetworkPolicyDecider {
         &self.policy
     }
 
+    /// Whether this host is explicitly configured for trusted proxy fake-IP
+    /// DNS handling.
+    #[must_use]
+    pub fn trusts_proxy_fakeip_host(&self, host: &str) -> bool {
+        self.policy.trusts_proxy_fakeip_host(host)
+    }
+
+    /// Record that a restricted DNS result was allowed because the host is in
+    /// the trusted proxy fake-IP list.
+    pub fn record_trusted_proxy_fakeip_allow(&self, host: &str, tool: &str) {
+        self.audit_record(host, tool, "TrustedProxyFakeIp-Allow");
+    }
+
     fn audit_record(&self, host: &str, tool: &str, label: &str) {
         if let Some(auditor) = self.auditor.as_ref() {
             auditor.record(host, tool, label);
@@ -496,6 +534,7 @@ mod tests {
             default: default.into(),
             allow: allow.iter().map(|s| (*s).to_string()).collect(),
             deny: deny.iter().map(|s| (*s).to_string()).collect(),
+            proxy: Vec::new(),
             audit: false,
         }
     }
@@ -571,6 +610,29 @@ mod tests {
         p.add_allow("example.com");
         assert_eq!(p.allow.len(), 1);
         assert_eq!(p.allow[0], "example.com");
+    }
+
+    #[test]
+    fn trusted_proxy_fakeip_hosts_match_exact_and_subdomains() {
+        let mut p = mk(Decision::Deny, &[], &[]);
+        p.proxy = vec![
+            "github.com".to_string(),
+            ".githubusercontent.com".to_string(),
+        ];
+
+        assert!(p.trusts_proxy_fakeip_host("github.com"));
+        assert!(p.trusts_proxy_fakeip_host("raw.githubusercontent.com"));
+        assert!(!p.trusts_proxy_fakeip_host("githubusercontent.com"));
+        assert!(!p.trusts_proxy_fakeip_host("example.com"));
+    }
+
+    #[test]
+    fn trusted_proxy_fakeip_hosts_respect_deny_precedence() {
+        let mut p = mk(Decision::Allow, &[], &["raw.githubusercontent.com"]);
+        p.proxy = vec![".githubusercontent.com".to_string()];
+
+        assert!(!p.trusts_proxy_fakeip_host("raw.githubusercontent.com"));
+        assert!(p.trusts_proxy_fakeip_host("avatars.githubusercontent.com"));
     }
 
     #[test]

--- a/crates/tui/src/tools/fetch_url.rs
+++ b/crates/tui/src/tools/fetch_url.rs
@@ -10,7 +10,7 @@
 use super::spec::{
     ApprovalRequirement, ToolCapability, ToolContext, ToolError, ToolResult, ToolSpec, optional_u64,
 };
-use crate::network_policy::{Decision, host_from_url};
+use crate::network_policy::{Decision, NetworkPolicyDecider, host_from_url};
 use async_trait::async_trait;
 use regex::Regex;
 use serde::Serialize;
@@ -187,12 +187,7 @@ impl ToolSpec for FetchUrlTool {
             } else if let Ok(addrs) = tokio::net::lookup_host((&**host, 0u16)).await {
                 let mut first_valid: Option<std::net::IpAddr> = None;
                 for addr in addrs {
-                    if is_restricted_ip(&addr.ip()) {
-                        return Err(ToolError::permission_denied(format!(
-                            "resolved IP {} is a restricted address (private/loopback/link-local)",
-                            addr.ip()
-                        )));
-                    }
+                    validate_dns_resolved_ip(host, &addr.ip(), context.network_policy.as_ref())?;
                     if first_valid.is_none() {
                         first_valid = Some(addr.ip());
                     }
@@ -330,6 +325,27 @@ fn is_restricted_ip(ip: &std::net::IpAddr) -> bool {
                 || matches!(v6.segments(), [0xfe80..=0xfebf, ..]) // Link-local fe80::/10
         }
     }
+}
+
+fn validate_dns_resolved_ip(
+    host: &str,
+    ip: &std::net::IpAddr,
+    decider: Option<&NetworkPolicyDecider>,
+) -> Result<(), ToolError> {
+    if !is_restricted_ip(ip) {
+        return Ok(());
+    }
+
+    if let Some(decider) = decider
+        && decider.trusts_proxy_fakeip_host(host)
+    {
+        decider.record_trusted_proxy_fakeip_allow(host, "fetch_url");
+        return Ok(());
+    }
+
+    Err(ToolError::permission_denied(format!(
+        "resolved IP {ip} is a restricted address (private/loopback/link-local)"
+    )))
 }
 
 /// Strip `<script>` / `<style>` blocks, drop remaining tags, and collapse
@@ -495,6 +511,7 @@ mod tests {
             default: Decision::Deny.into(),
             allow: vec!["api.deepseek.com".to_string()],
             deny: vec![],
+            proxy: Vec::new(),
             audit: false,
         };
         let decider = NetworkPolicyDecider::new(policy, None);
@@ -505,5 +522,102 @@ mod tests {
             .await;
         let err = res.expect_err("blocked host should fail");
         assert!(format!("{err}").contains("blocked"));
+    }
+
+    #[test]
+    fn restricted_dns_result_is_denied_without_proxy_opt_in() {
+        let ip = "198.18.0.1".parse().unwrap();
+
+        let err = validate_dns_resolved_ip("github.com", &ip, None)
+            .expect_err("fake-IP DNS result must be denied by default");
+
+        assert!(format!("{err}").contains("resolved IP 198.18.0.1 is a restricted address"));
+    }
+
+    #[test]
+    fn proxy_opt_in_allows_restricted_dns_for_matching_host() {
+        use crate::network_policy::{Decision, NetworkPolicy, NetworkPolicyDecider};
+
+        let policy = NetworkPolicy {
+            default: Decision::Allow.into(),
+            allow: Vec::new(),
+            deny: Vec::new(),
+            proxy: vec!["github.com".to_string()],
+            audit: false,
+        };
+        let decider = NetworkPolicyDecider::new(policy, None);
+        let ip = "198.18.0.1".parse().unwrap();
+
+        validate_dns_resolved_ip("github.com", &ip, Some(&decider))
+            .expect("proxy opt-in should allow fake-IP DNS for matching host");
+    }
+
+    #[test]
+    fn proxy_opt_in_does_not_allow_unlisted_host() {
+        use crate::network_policy::{Decision, NetworkPolicy, NetworkPolicyDecider};
+
+        let policy = NetworkPolicy {
+            default: Decision::Allow.into(),
+            allow: Vec::new(),
+            deny: Vec::new(),
+            proxy: vec!["github.com".to_string()],
+            audit: false,
+        };
+        let decider = NetworkPolicyDecider::new(policy, None);
+        let ip = "198.18.0.1".parse().unwrap();
+
+        let err = validate_dns_resolved_ip("example.com", &ip, Some(&decider))
+            .expect_err("proxy opt-in must be scoped to configured hosts");
+
+        assert!(format!("{err}").contains("resolved IP 198.18.0.1 is a restricted address"));
+    }
+
+    #[tokio::test]
+    async fn proxy_opt_in_does_not_allow_restricted_ip_literal() {
+        use crate::network_policy::{Decision, NetworkPolicy, NetworkPolicyDecider};
+
+        let policy = NetworkPolicy {
+            default: Decision::Allow.into(),
+            allow: Vec::new(),
+            deny: Vec::new(),
+            proxy: vec!["198.18.0.1".to_string()],
+            audit: false,
+        };
+        let decider = NetworkPolicyDecider::new(policy, None);
+        let ctx = ToolContext::new(PathBuf::from(".")).with_network_policy(decider);
+        let tool = FetchUrlTool;
+
+        let err = tool
+            .execute(json!({"url": "http://198.18.0.1/status"}), &ctx)
+            .await
+            .expect_err("literal restricted IP URLs must stay blocked");
+
+        assert!(format!("{err}").contains("IP 198.18.0.1 is a restricted address"));
+    }
+
+    #[test]
+    fn proxy_dns_allow_is_audited() {
+        use crate::network_policy::{
+            Decision, NetworkAuditor, NetworkPolicy, NetworkPolicyDecider,
+        };
+        use tempfile::tempdir;
+
+        let dir = tempdir().expect("tempdir");
+        let auditor = NetworkAuditor::new(dir.path().join("audit.log"), true);
+        let policy = NetworkPolicy {
+            default: Decision::Allow.into(),
+            allow: Vec::new(),
+            deny: Vec::new(),
+            proxy: vec!["github.com".to_string()],
+            audit: true,
+        };
+        let decider = NetworkPolicyDecider::new(policy, Some(auditor));
+        let ip = "198.18.0.1".parse().unwrap();
+
+        validate_dns_resolved_ip("github.com", &ip, Some(&decider)).expect("proxy DNS allow");
+
+        let body = std::fs::read_to_string(dir.path().join("audit.log")).expect("audit log");
+        assert!(body.contains("github.com"));
+        assert!(body.contains("TrustedProxyFakeIp-Allow"));
     }
 }

--- a/crates/tui/src/tools/web_run.rs
+++ b/crates/tui/src/tools/web_run.rs
@@ -1814,6 +1814,7 @@ mod tests {
             default: Decision::Deny.into(),
             allow: vec!["api.deepseek.com".to_string()],
             deny: vec![],
+            proxy: Vec::new(),
             audit: false,
         };
         let decider = NetworkPolicyDecider::new(policy, None);

--- a/crates/tui/tests/skill_install.rs
+++ b/crates/tui/tests/skill_install.rs
@@ -61,6 +61,7 @@ fn allow_all_policy() -> NetworkPolicy {
         default: DecisionToml::Allow,
         allow: Vec::new(),
         deny: Vec::new(),
+        proxy: Vec::new(),
         audit: false,
     }
 }
@@ -70,6 +71,7 @@ fn deny_all_policy() -> NetworkPolicy {
         default: DecisionToml::Deny,
         allow: Vec::new(),
         deny: Vec::new(),
+        proxy: Vec::new(),
         audit: false,
     }
 }
@@ -79,6 +81,7 @@ fn prompt_all_policy() -> NetworkPolicy {
         default: DecisionToml::Prompt,
         allow: Vec::new(),
         deny: Vec::new(),
+        proxy: Vec::new(),
         audit: false,
     }
 }


### PR DESCRIPTION
  ## Summary

  Adds an explicit `[network] proxy = [...]` opt-in for fake-IP proxy DNS setups.

  This keeps the default SSRF behavior strict:
  - restricted DNS results are denied unless the hostname is explicitly configured in `network.proxy`
  - literal restricted IP URLs remain blocked even when `network.proxy` is configured
  - `localhost` remains blocked
  - `network.deny` takes precedence over `network.proxy`
  - trusted proxy DNS allowances are audit logged as `TrustedProxyFakeIp-Allow`

  Related to #1071.

  ## Testing

  - [x] `cargo test --all-features`
  - [x] `cargo fmt --all -- --check`
  - [x] `cargo clippy --all-targets --all-features`

  ## Checklist

  - [x] Updated docs or comments as needed
  - [x] Added or updated tests where relevant
  - [x] Verified TUI behavior manually if UI changes (N/A: no UI changes)