### PR TITLE
fix(npm): preserve quoted arguments on Windows (#1101)

### DIFF
--- a/npm/deepseek-tui/scripts/run.js
+++ b/npm/deepseek-tui/scripts/run.js
@@ -22,7 +22,29 @@ async function run(binaryName) {
   handleVersionFallback(binaryName);
 
   const binaryPath = await getBinaryPath(binaryName);
-  const result = spawnSync(binaryPath, process.argv.slice(2), {
+  const args = process.argv.slice(2);
+
+  // On Windows, .cmd wrappers strip quotes from arguments. Use execSync
+  // with manual quoting to preserve multi-word prompts. See issue #1101.
+  if (process.platform === "win32") {
+    const { execSync } = require("child_process");
+    const quotedArgs = args.map((arg) => {
+      // Quote arguments that contain spaces and aren't already quoted
+      if (arg.includes(" ") && !arg.startsWith('"') && !arg.startsWith("'")) {
+        return `"${arg.replace(/"/g, '\\"')}"`;
+      }
+      return arg;
+    });
+    const fullCmd = `"${binaryPath}" ${quotedArgs.join(" ")}`;
+    try {
+      execSync(fullCmd, { stdio: "inherit" });
+      process.exit(0);
+    } catch (err) {
+      process.exit(err.status ?? 1);
+    }
+  }
+
+  const result = spawnSync(binaryPath, args, {
     stdio: "inherit",
   });
   if (result.error) {


### PR DESCRIPTION
## Summary

- Fix multi-word prompts failing on Windows npm wrapper
- Preserve quoted arguments when invoking the binary via `.cmd` wrapper

## Problem

On Windows, `deepseek exec "hello world"` fails with:
```
error: unexpected argument 'world' found
Usage: deepseek-tui.exe exec [OPTIONS] <PROMPT>
```

The `.cmd` wrapper created by npm strips quotes, so the binary receives `hello` and `world` as separate arguments instead of a single `hello world` prompt.

## Solution

On Windows, use `execSync` with manual argument quoting instead of `spawnSync`. This preserves the original quoting from the user's command line.

```javascript
// Before
spawnSync(binaryPath, process.argv.slice(2), { stdio: "inherit" });

// After (Windows only)
const quotedArgs = args.map(arg => {
  if (arg.includes(" ") && !arg.startsWith('"')) {
    return `"${arg}"`;
  }
  return arg;
});
execSync(`"${binaryPath}" ${quotedArgs.join(" ")}`, { stdio: "inherit" });
```

## Changes

| File | Change |
|------|--------|
| `npm/deepseek-tui/scripts/run.js` | Use `execSync` with manual quoting on Windows |

## Testing

- `deepseek exec "hello world"` should work on Windows
- `deepseek -p "hello world"` should work on Windows
- Single-word prompts should continue to work
- Unix behavior is unchanged

Fixes #1101
