### PR TITLE
ci(deploy-web): bump Node to 22 for wrangler@4

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -41,7 +41,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          # wrangler@4 requires Node 22+
+          node-version: 22
           cache: npm
           cache-dependency-path: web/package-lock.json
 


### PR DESCRIPTION
## Summary
- Deploy of #1108 failed at the wrangler step: `Wrangler requires at least Node.js v22.0.0. You are using v20.20.2.`
- Bumps `actions/setup-node` to `node-version: 22`. No other changes.

Once merged, manually trigger `deploy-web` (Actions → deploy-web → Run workflow) so the site reflects the mobile/color refresh + #1104 docs fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)