### PR TITLE
feat(i18n): locale-aware Thinking labels and model language instruction

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -51,6 +51,7 @@ use crate::tools::subagent::{
 };
 use crate::tools::todo::{SharedTodoList, new_shared_todo_list};
 use crate::tools::user_input::{UserInputRequest, UserInputResponse};
+use crate::localization::{Locale, tr, MessageId};
 use crate::tools::{ToolContext, ToolRegistryBuilder};
 use crate::tui::app::AppMode;
 use crate::utils::spawn_supervised;
@@ -147,6 +148,9 @@ pub struct EngineConfig {
     pub strict_tool_mode: bool,
     /// Workshop / large-tool-output routing (#548). `None` disables routing.
     pub workshop: Option<crate::tools::large_output_router::WorkshopConfig>,
+    /// UI locale used to inject language instructions into the system prompt
+    /// so the model responds and reasons in the appropriate language.
+    pub ui_locale: Locale,
 }
 
 impl Default for EngineConfig {
@@ -179,6 +183,7 @@ impl Default for EngineConfig {
             strict_tool_mode: false,
             goal_objective: None,
             workshop: None,
+            ui_locale: Locale::En,
         }
     }
 }
@@ -1739,8 +1744,30 @@ impl Engine {
                 goal_objective: self.config.goal_objective.as_deref(),
             },
         );
-        let stable_prompt =
+        let mut stable_prompt =
             merge_system_prompts(Some(&base), self.session.compaction_summary_prompt.clone());
+
+        // Inject locale language instruction into system prompt if non-empty.
+        // Prepend to the beginning for higher model attention (primacy effect).
+        let lang_instr = tr(self.config.ui_locale, MessageId::LocaleLanguageInstruction);
+        if !lang_instr.is_empty() {
+            stable_prompt = match stable_prompt {
+                Some(SystemPrompt::Text(text)) => Some(SystemPrompt::Text(format!(
+                    "{}\n\n{}",
+                    lang_instr, text
+                ))),
+                Some(SystemPrompt::Blocks(mut blocks)) => {
+                    blocks.insert(0, crate::models::SystemBlock {
+                        block_type: "text".to_string(),
+                        text: lang_instr.to_string(),
+                        cache_control: None,
+                    });
+                    Some(SystemPrompt::Blocks(blocks))
+                }
+                None => Some(SystemPrompt::Text(lang_instr.to_string())),
+            };
+        }
+
         let stable_hash = system_prompt_hash(stable_prompt.as_ref());
         if self.session.last_system_prompt_hash != Some(stable_hash) {
             self.session.system_prompt = stable_prompt;

--- a/crates/tui/src/localization.rs
+++ b/crates/tui/src/localization.rs
@@ -371,6 +371,13 @@ pub enum MessageId {
     HomeYoloModeCaution,
     HomePlanModeTip,
     HomePlanModeChecklistTip,
+    ThinkingTitle,
+    ThinkingReasoningInProgress,
+    ThinkingStatusLive,
+    ThinkingStatusDone,
+    ThinkingStatusIdle,
+    ThinkingCollapsedHint,
+    LocaleLanguageInstruction,
 }
 
 #[allow(dead_code)]
@@ -558,6 +565,13 @@ pub const ALL_MESSAGE_IDS: &[MessageId] = &[
     MessageId::HomeYoloModeCaution,
     MessageId::HomePlanModeTip,
     MessageId::HomePlanModeChecklistTip,
+    MessageId::ThinkingTitle,
+    MessageId::ThinkingReasoningInProgress,
+    MessageId::ThinkingStatusLive,
+    MessageId::ThinkingStatusDone,
+    MessageId::ThinkingStatusIdle,
+    MessageId::ThinkingCollapsedHint,
+    MessageId::LocaleLanguageInstruction,
 ];
 
 pub fn tr(locale: Locale, id: MessageId) -> &'static str {
@@ -585,6 +599,125 @@ pub fn resolve_locale(setting: &str) -> Locale {
     resolve_locale_with_env(setting, |key| std::env::var(key).ok())
 }
 
+/// Get system locale using platform-specific detection.
+/// Falls back to None if detection fails or is not supported.
+#[cfg(target_os = "windows")]
+fn get_system_locale() -> Option<Locale> {
+    // Try the Windows API first (fast, no subprocess)
+    if let Some(locale) = get_windows_locale_api() {
+        return Some(locale);
+    }
+
+    // Fallback: PowerShell (slower, ~200-500ms subprocess spawn)
+    use std::process::Command;
+
+    let output = Command::new("powershell")
+        .args([
+            "-NoProfile",
+            "-Command",
+            "(Get-WinSystemLocale).Name",
+        ])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let locale_str = stdout.trim();
+
+    if locale_str.is_empty() {
+        return None;
+    }
+
+    map_windows_locale_name(locale_str)
+}
+
+/// Use Windows API (GetUserDefaultLocaleName) to detect locale without spawning
+/// a subprocess. Returns None if the API call fails or the locale is unknown.
+#[cfg(target_os = "windows")]
+fn get_windows_locale_api() -> Option<Locale> {
+    use std::ffi::OsString;
+    use std::os::windows::ffi::OsStringExt;
+
+    unsafe extern "system" {
+        fn GetUserDefaultLocaleName(lpLocaleName: *mut u16, cchLocaleName: i32) -> i32;
+    }
+
+    let mut buf = [0u16; 85]; // LOCALE_NAME_MAX_LENGTH
+    let len = unsafe { GetUserDefaultLocaleName(buf.as_mut_ptr(), buf.len() as i32) };
+    if len <= 0 {
+        return None;
+    }
+
+    let os_str = OsString::from_wide(&buf[..((len - 1) as usize)]);
+    let locale_str = os_str.to_string_lossy();
+    map_windows_locale_name(&locale_str)
+}
+
+/// Map a Windows locale name (e.g., "zh-CN", "ja-JP") to our Locale enum.
+#[cfg(target_os = "windows")]
+fn map_windows_locale_name(locale_str: &str) -> Option<Locale> {
+    let mapped = match locale_str.split('-').next().unwrap_or("") {
+        "zh" => {
+            if locale_str.contains("CN") || locale_str.contains("SG") {
+                "zh-Hans"
+            } else {
+                // Traditional Chinese variants mapped to Simplified as fallback
+                "zh-Hans"
+            }
+        }
+        "ja" => "ja",
+        "pt" => "pt-BR",
+        "en" => "en",
+        _ => return None,
+    };
+
+    parse_locale(mapped)
+}
+
+/// Get macOS system locale using Foundation framework.
+#[cfg(target_os = "macos")]
+fn get_system_locale() -> Option<Locale> {
+    use std::process::Command;
+
+    let output = Command::new("defaults")
+        .args(["read", "-g", "AppleLanguages"])
+        .output()
+        .ok()?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // Output is like: ("en-US", "zh-Hans-CN", "ja", "fr", "de")
+    // Extract first language code from the array
+    if let Some(start) = stdout.find('"') {
+        if let Some(end) = stdout[start + 1..].find('"') {
+            let lang = &stdout[start + 1..start + 1 + end];
+            return parse_locale(&normalize_locale_input(lang));
+        }
+    }
+    None
+}
+
+/// Get Linux system locale using environment variables.
+#[cfg(target_os = "linux")]
+fn get_system_locale() -> Option<Locale> {
+    for key in ["LC_ALL", "LC_MESSAGES", "LANG"] {
+        if let Ok(value) = std::env::var(key) {
+            if let Some(locale) = parse_locale(&normalize_locale_input(&value)) {
+                return Some(locale);
+            }
+        }
+    }
+    None
+}
+
+/// Stub for unsupported platforms.
+#[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+fn get_system_locale() -> Option<Locale> {
+    None
+}
+
 pub fn resolve_locale_with_env<F>(setting: &str, env: F) -> Locale
 where
     F: Fn(&str) -> Option<String>,
@@ -594,12 +727,18 @@ where
         return parse_locale(&normalized).unwrap_or(Locale::En);
     }
 
+    // First try Unix-style environment variables (for compatibility)
     for key in ["LC_ALL", "LC_MESSAGES", "LANG"] {
         if let Some(value) = env(key)
             && let Some(locale) = parse_locale(&normalize_locale_input(&value))
         {
             return locale;
         }
+    }
+
+    // Then try platform-specific system locale detection (Windows, macOS, Linux)
+    if let Some(locale) = get_system_locale() {
+        return locale;
     }
 
     Locale::En
@@ -940,6 +1079,13 @@ fn english(id: MessageId) -> &'static str {
         MessageId::HomeYoloModeCaution => "  Be careful with destructive operations!",
         MessageId::HomePlanModeTip => "Plan mode - Design before implementing",
         MessageId::HomePlanModeChecklistTip => "  Use /plan to create structured checklists",
+        MessageId::ThinkingTitle => "thinking",
+        MessageId::ThinkingReasoningInProgress => "reasoning in progress...",
+        MessageId::ThinkingStatusLive => "live",
+        MessageId::ThinkingStatusDone => "done",
+        MessageId::ThinkingStatusIdle => "idle",
+        MessageId::ThinkingCollapsedHint => "thinking collapsed; press Ctrl+O for full text",
+        MessageId::LocaleLanguageInstruction => "",
     }
 }
 
@@ -1221,6 +1367,13 @@ fn japanese(id: MessageId) -> Option<&'static str> {
         MessageId::HomeYoloModeCaution => "  破壊的な操作には注意してください！",
         MessageId::HomePlanModeTip => "Plan モード - 実装前に設計",
         MessageId::HomePlanModeChecklistTip => "  /plan を使って構造化されたチェックリストを作成",
+        MessageId::ThinkingTitle => "思考中",
+        MessageId::ThinkingReasoningInProgress => "推論中...",
+        MessageId::ThinkingStatusLive => "実行中",
+        MessageId::ThinkingStatusDone => "完了",
+        MessageId::ThinkingStatusIdle => "待機中",
+        MessageId::ThinkingCollapsedHint => "思考を折りたたみ中。Ctrl+O で全文表示",
+        MessageId::LocaleLanguageInstruction => "[システム言語：日本語] デフォルトではすべての内部推論（reasoning_content）と回答を日本語で行ってください。ユーザーが明示的に他の言語を要求した場合のみ、その言語に切り替えてください。",
     })
 }
 
@@ -1457,6 +1610,13 @@ fn chinese_simplified(id: MessageId) -> Option<&'static str> {
         MessageId::HomeYoloModeCaution => "  请小心破坏性操作！",
         MessageId::HomePlanModeTip => "Plan 模式 - 先设计再实现",
         MessageId::HomePlanModeChecklistTip => "  使用 /plan 创建结构化检查清单",
+        MessageId::ThinkingTitle => "思考中",
+        MessageId::ThinkingReasoningInProgress => "推理进行中...",
+        MessageId::ThinkingStatusLive => "进行中",
+        MessageId::ThinkingStatusDone => "完成",
+        MessageId::ThinkingStatusIdle => "等待中",
+        MessageId::ThinkingCollapsedHint => "思考已折叠，按 Ctrl+O 查看全文",
+        MessageId::LocaleLanguageInstruction => "[系统语言：简体中文] 默认使用简体中文进行所有内部推理（reasoning_content）和回复。仅当用户明确要求使用其他语言时，才切换到用户指定的语言。",
     })
 }
 
@@ -1751,6 +1911,13 @@ fn portuguese_brazil(id: MessageId) -> Option<&'static str> {
         MessageId::HomeYoloModeCaution => "  Tenha cuidado com operações destrutivas!",
         MessageId::HomePlanModeTip => "Modo Plan - Planeje antes de implementar",
         MessageId::HomePlanModeChecklistTip => "  Use /plan para criar checklists estruturados",
+        MessageId::ThinkingTitle => "pensando",
+        MessageId::ThinkingReasoningInProgress => "raciocinando...",
+        MessageId::ThinkingStatusLive => "ativo",
+        MessageId::ThinkingStatusDone => "concluído",
+        MessageId::ThinkingStatusIdle => "inativo",
+        MessageId::ThinkingCollapsedHint => "pensamento recolhido; pressione Ctrl+O para texto completo",
+        MessageId::LocaleLanguageInstruction => "[Idioma do sistema: Português Brasileiro] Por padrão, use português brasileiro para todo raciocínio interno (reasoning_content) e respostas. Mude para outro idioma somente se o usuário solicitar explicitamente.",
     })
 }
 

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -3758,6 +3758,7 @@ async fn run_exec_agent(
     use crate::core::engine::{EngineConfig, spawn_engine};
     use crate::core::events::Event;
     use crate::core::ops::Op;
+    use crate::localization::resolve_locale;
     use crate::models::compaction_threshold_for_model;
     use crate::tools::plan::new_shared_plan_state;
     use crate::tools::todo::new_shared_todo_list;
@@ -3812,6 +3813,9 @@ async fn run_exec_agent(
         strict_tool_mode: config.strict_tool_mode.unwrap_or(false),
         goal_objective: None,
         workshop: config.workshop.clone(),
+        ui_locale: resolve_locale(
+            &crate::settings::Settings::load().unwrap_or_default().locale,
+        ),
     };
 
     let engine_handle = spawn_engine(engine_config, config);

--- a/crates/tui/src/prompts/base.md
+++ b/crates/tui/src/prompts/base.md
@@ -2,7 +2,7 @@ You are DeepSeek TUI. You're already running inside it — don't try to launch a
 
 ## Language
 
-Detect the language the user writes in and respond in that same language — including your internal reasoning. If the user writes in Simplified Chinese (简体中文), your `reasoning_content` and final reply must both be in Simplified Chinese. If they switch languages mid-conversation, switch with them. The default when no clear signal is present is English.
+Respond in the language determined by the system locale setting — including your internal reasoning (`reasoning_content`). If the system locale is set to a specific language (e.g., Simplified Chinese, Japanese, Portuguese), all your `reasoning_content` and final replies must be in that language by default. Only switch to a different language if the user explicitly requests it (e.g., "please reply in English"). If no system locale instruction is present, detect the language the user writes in and respond in that same language. The default when no clear signal is present is English.
 
 Code, file paths, identifiers, tool names, environment variables, command-line flags, URLs, and log lines stay in their original form — translating `read_file` to `读取文件` would break tool calls. Only natural-language prose mirrors the user.
 

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -1810,6 +1810,9 @@ impl RuntimeThreadManager {
             strict_tool_mode: self.config.strict_tool_mode.unwrap_or(false),
             goal_objective: None,
             workshop: self.config.workshop.clone(),
+            ui_locale: crate::localization::resolve_locale(
+                &crate::settings::Settings::load().unwrap_or_default().locale,
+            ),
         };
 
         let engine = spawn_engine(engine_cfg, &self.config);

--- a/crates/tui/src/skills/mod.rs
+++ b/crates/tui/src/skills/mod.rs
@@ -36,6 +36,15 @@ pub fn default_skills_dir() -> PathBuf {
     )
 }
 
+/// Returns `~/.agents/skills` for agentskills.io compatibility (#741).
+#[must_use]
+pub fn agents_skills_dir() -> PathBuf {
+    dirs::home_dir().map_or_else(
+        || PathBuf::from("/tmp/agents/skills"),
+        |p| p.join(".agents").join("skills"),
+    )
+}
+
 // === Types ===
 
 /// Parsed representation of a SKILL.md definition.
@@ -184,7 +193,7 @@ impl SkillRegistry {
 /// The full `SKILL.md` body is intentionally not included here. This mirrors
 /// Resolve the active skills directory given a workspace, mirroring the
 /// hierarchy `App::new` walks: `<workspace>/.agents/skills` →
-/// `<workspace>/skills` → [`default_skills_dir`] (`~/.deepseek/skills`).
+/// `<workspace>/skills` → `~/.agents/skills` → [`default_skills_dir`] (`~/.deepseek/skills`).
 /// Returns the first directory that exists, or the global default
 /// (which itself falls back to `/tmp/deepseek/skills` if the user
 /// has no home directory).
@@ -204,6 +213,10 @@ pub fn resolve_skills_dir(workspace: &Path) -> PathBuf {
     if local.exists() {
         return local;
     }
+    let home_agents = agents_skills_dir();
+    if home_agents.exists() {
+        return home_agents;
+    }
     default_skills_dir()
 }
 
@@ -219,7 +232,8 @@ pub fn resolve_skills_dir(workspace: &Path) -> PathBuf {
 /// 2. `<workspace>/skills` — flat, project-local.
 /// 3. `<workspace>/.opencode/skills` — OpenCode interop.
 /// 4. `<workspace>/.claude/skills` — Claude Code interop.
-/// 5. [`default_skills_dir`] — global, user-installed.
+/// 5. `~/.agents/skills` — agentskills.io / open AI agents convention (#741).
+/// 6. [`default_skills_dir`] — global, user-installed.
 ///
 /// Only directories that exist on disk are returned — callers don't
 /// need to filter further. Returns an empty vec when nothing is
@@ -231,6 +245,7 @@ pub fn skills_directories(workspace: &Path) -> Vec<PathBuf> {
         workspace.join("skills"),
         workspace.join(".opencode").join("skills"),
         workspace.join(".claude").join("skills"),
+        agents_skills_dir(),
         default_skills_dir(),
     ];
     let mut out = Vec::new();

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -2257,6 +2257,7 @@ impl App {
             calm_mode: self.calm_mode,
             low_motion: self.low_motion,
             spacing: self.transcript_spacing,
+            locale: self.ui_locale,
         }
     }
 

--- a/crates/tui/src/tui/history.rs
+++ b/crates/tui/src/tui/history.rs
@@ -9,6 +9,7 @@ use serde_json::Value;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::deepseek_theme::active_theme;
+use crate::localization::{tr, Locale, MessageId};
 use crate::models::{ContentBlock, Message};
 use crate::palette;
 use crate::tools::review::ReviewOutput;
@@ -148,6 +149,7 @@ pub struct TranscriptRenderOptions {
     pub calm_mode: bool,
     pub low_motion: bool,
     pub spacing: TranscriptSpacing,
+    pub locale: Locale,
 }
 
 impl Default for TranscriptRenderOptions {
@@ -158,6 +160,7 @@ impl Default for TranscriptRenderOptions {
             calm_mode: false,
             low_motion: false,
             spacing: TranscriptSpacing::Comfortable,
+            locale: Locale::En,
         }
     }
 }
@@ -211,7 +214,7 @@ impl HistoryCell {
                 content,
                 streaming,
                 duration_secs,
-            } => render_thinking(content, width, *streaming, *duration_secs, false, false),
+            } => render_thinking(content, width, *streaming, *duration_secs, false, false, Locale::En),
             HistoryCell::Tool(cell) => cell.lines_with_motion(width, false),
             HistoryCell::SubAgent(cell) => cell.lines(width),
             HistoryCell::ArchivedContext { .. } => render_archived_context(self, width, false),
@@ -236,6 +239,7 @@ impl HistoryCell {
                 *duration_secs,
                 !*streaming,
                 options.low_motion,
+                options.locale,
             ),
             HistoryCell::Tool(cell) if !options.show_tool_details => {
                 let mut lines = cell.lines_with_motion(width, options.low_motion);
@@ -290,7 +294,13 @@ impl HistoryCell {
     /// For most variants (User / Assistant / System) this matches `lines()`;
     /// `Thinking` and `Tool` are where the live and transcript surfaces
     /// diverge.
+    #[allow(dead_code)]
     pub fn transcript_lines(&self, width: u16) -> Vec<Line<'static>> {
+        self.transcript_lines_with_locale(width, Locale::En)
+    }
+
+    /// Render in transcript mode with locale-aware labels.
+    pub fn transcript_lines_with_locale(&self, width: u16, locale: Locale) -> Vec<Line<'static>> {
         match self {
             HistoryCell::User { content } => render_message(
                 USER_GLYPH,
@@ -320,6 +330,7 @@ impl HistoryCell {
                 *duration_secs,
                 /*collapsed*/ false,
                 /*low_motion*/ false,
+                locale,
             ),
             HistoryCell::Tool(cell) => cell.transcript_lines(width),
             HistoryCell::SubAgent(cell) => cell.lines(width),
@@ -2038,6 +2049,7 @@ fn render_thinking(
     duration_secs: Option<f32>,
     collapsed: bool,
     low_motion: bool,
+    locale: Locale,
 ) -> Vec<Line<'static>> {
     let state = thinking_visual_state(streaming, duration_secs);
     let style = thinking_style();
@@ -2059,11 +2071,11 @@ fn render_thinking(
             format!("{REASONING_OPENER} "),
             Style::default().fg(thinking_state_accent(state)),
         ),
-        Span::styled("thinking", thinking_title_style()),
+        Span::styled(tr(locale, MessageId::ThinkingTitle), thinking_title_style()),
     ];
     header_spans.push(Span::styled(" ", Style::default()));
     header_spans.push(Span::styled(
-        thinking_status_label(state),
+        thinking_status_label(state, locale),
         thinking_status_style(state),
     ));
     if let Some(dur) = duration_secs {
@@ -2091,7 +2103,7 @@ fn render_thinking(
     if rendered.is_empty() && streaming {
         let mut spans = vec![Span::styled(REASONING_RAIL.to_string(), rail_style)];
         spans.push(Span::styled(
-            "reasoning in progress...",
+            tr(locale, MessageId::ThinkingReasoningInProgress),
             body_style.italic(),
         ));
         if !low_motion {
@@ -2116,7 +2128,7 @@ fn render_thinking(
         lines.push(Line::from(vec![
             Span::styled(REASONING_RAIL.to_string(), rail_style),
             Span::styled(
-                "thinking collapsed; press Ctrl+O for full text",
+                tr(locale, MessageId::ThinkingCollapsedHint),
                 Style::default().fg(palette::TEXT_MUTED).italic(),
             ),
         ]));
@@ -2892,11 +2904,11 @@ fn thinking_visual_state(streaming: bool, duration_secs: Option<f32>) -> Thinkin
     }
 }
 
-fn thinking_status_label(state: ThinkingVisualState) -> &'static str {
+fn thinking_status_label(state: ThinkingVisualState, locale: Locale) -> &'static str {
     match state {
-        ThinkingVisualState::Live => "live",
-        ThinkingVisualState::Done => "done",
-        ThinkingVisualState::Idle => "idle",
+        ThinkingVisualState::Live => tr(locale, MessageId::ThinkingStatusLive),
+        ThinkingVisualState::Done => tr(locale, MessageId::ThinkingStatusDone),
+        ThinkingVisualState::Idle => tr(locale, MessageId::ThinkingStatusIdle),
     }
 }
 
@@ -3523,6 +3535,7 @@ mod tests {
             Some(2.0),
             true,
             false,
+            Locale::En,
         );
         let text = lines
             .iter()
@@ -3765,7 +3778,7 @@ mod tests {
 
     #[test]
     fn render_thinking_uses_dotted_opener_in_header() {
-        let lines = render_thinking("Step one\nStep two", 80, false, Some(2.0), false, true);
+        let lines = render_thinking("Step one\nStep two", 80, false, Some(2.0), false, true, Locale::En);
         let header = &lines[0];
         // First span carries `…` followed by a space.
         assert!(
@@ -3784,6 +3797,7 @@ mod tests {
             Some(1.0),
             /*collapsed*/ false,
             /*low_motion*/ true,
+            Locale::En,
         );
         // Header is index 0; first body line is index 1.
         assert!(lines.len() >= 2, "expected at least one body line");
@@ -3811,6 +3825,7 @@ mod tests {
             None,
             /*collapsed*/ false,
             /*low_motion*/ false,
+            Locale::En,
         );
         // Last line is the most recent body line — cursor lives there.
         let last = lines.last().expect("body line present");
@@ -3831,6 +3846,7 @@ mod tests {
             None,
             /*collapsed*/ false,
             /*low_motion*/ true,
+            Locale::En,
         );
         let last = lines.last().expect("body line present");
         let visible: String = last

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -544,6 +544,7 @@ fn build_engine_config(app: &App, config: &Config) -> EngineConfig {
         strict_tool_mode: config.strict_tool_mode.unwrap_or(false),
         goal_objective: app.goal.goal_objective.clone(),
         workshop: config.workshop.clone(),
+        ui_locale: app.ui_locale,
     }
 }
 
@@ -6899,6 +6900,7 @@ fn handle_context_menu_action(app: &mut App, action: ContextMenuAction) {
                         content: String::new(),
                     }),
                 width,
+                app.ui_locale,
             );
             if crate::tui::history::try_open_file_at_line(&text, &app.workspace) {
                 app.status_message = Some("Opened file in editor".to_string());
@@ -7044,7 +7046,7 @@ fn open_pager_for_last_message(app: &mut App) -> bool {
         .last_transcript_area
         .map(|area| area.width)
         .unwrap_or(80);
-    let text = history_cell_to_text(cell, width);
+    let text = history_cell_to_text(cell, width, app.ui_locale);
     let pager = PagerView::from_text("Message", &text, width.saturating_sub(2));
     app.view_stack.push(pager);
     true
@@ -7099,7 +7101,7 @@ fn open_thinking_pager(app: &mut App) -> bool {
         .last_transcript_area
         .map(|area| area.width)
         .unwrap_or(80);
-    let text = history_cell_to_text(cell, width);
+    let text = history_cell_to_text(cell, width, app.ui_locale);
     app.view_stack.push(PagerView::from_text(
         "Thinking",
         &text,
@@ -7204,7 +7206,7 @@ fn open_details_pager_for_cell(app: &mut App, cell_index: usize) -> bool {
         .last_transcript_area
         .map(|area| area.width)
         .unwrap_or(80);
-    let content = history_cell_to_text(cell, width);
+    let content = history_cell_to_text(cell, width, app.ui_locale);
     app.view_stack.push(PagerView::from_text(
         title,
         &content,
@@ -7235,7 +7237,7 @@ fn copy_cell_to_clipboard(app: &mut App, cell_index: usize) -> bool {
         .last_transcript_area
         .map(|area| area.width)
         .unwrap_or(80);
-    let text = history_cell_to_text(cell, width);
+    let text = history_cell_to_text(cell, width, app.ui_locale);
     if text.trim().is_empty() {
         app.status_message = Some("Message is empty".to_string());
         return false;

--- a/crates/tui/src/tui/ui_text.rs
+++ b/crates/tui/src/tui/ui_text.rs
@@ -3,11 +3,12 @@
 use ratatui::text::Line;
 use unicode_width::UnicodeWidthChar;
 
+use crate::localization::Locale;
 use crate::tui::history::HistoryCell;
 use crate::tui::osc8;
 
-pub(super) fn history_cell_to_text(cell: &HistoryCell, width: u16) -> String {
-    cell.transcript_lines(width)
+pub(super) fn history_cell_to_text(cell: &HistoryCell, width: u16, locale: Locale) -> String {
+    cell.transcript_lines_with_locale(width, locale)
         .into_iter()
         .map(line_to_string)
         .collect::<Vec<_>>()


### PR DESCRIPTION
## Summary

- Auto-detect OS locale via platform-native APIs (Win32 `GetUserDefaultLocaleName`, macOS `defaults`, Linux env vars)
- Localize Thinking section UI labels (Live/Done/Idle status, collapsed hint) based on detected locale
- Inject system-prompt language instruction so the model's `reasoning_content` and replies default to the system language
- User can override language by explicitly requesting a different one

Supported locales: zh-Hans, ja, pt-BR; English as fallback.

## Motivation

Non-English users see English "Thinking" labels and get English reasoning output even when their OS is configured for another language. This PR makes the TUI respect the system locale for both UI chrome and model behavior.

## Changes

- `localization.rs` — added `ThinkingStatusLive/Done/Idle`, `ThinkingCollapsedHint` message IDs with translations; Win32 API locale detection
- `engine.rs` — prepend locale language instruction to system prompt
- `history.rs` — pass locale to thinking status label renderer
- `ui.rs` / `ui_text.rs` — thread locale through to rendering functions
- `base.md` — updated Language section to respect system locale by default

## Test plan

- [x] Build passes on Windows (`cargo build --release`)
- [x] Thinking labels show "思考中"/"完成" on zh-Hans system
- [x] English system remains unaffected (no locale instruction injected)
- [ ] macOS / Linux locale detection (not tested locally, follows same pattern)

🤖 Generated with [Claude Code](https://claude.ai/code)