### PR TITLE
fix(snapshot): add max_size_mb hard cap to prevent unbounded growth (#1112)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -414,6 +414,7 @@ default_text_model = "deepseek-ai/deepseek-v4-pro"
 # [snapshots]
 # enabled = true        # Snapshot workspace pre/post each turn for /restore
 # max_age_days = 7      # Older snapshots pruned at session start
+# max_size_mb = 4096    # Hard limit: oldest snapshots pruned when exceeded (0 = unlimited)
 
 # ─────────────────────────────────────────────────────────────────────────────────
 # LSP Diagnostics (post-edit) (#136)

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -216,6 +216,12 @@ pub struct SnapshotsToml {
     pub enabled: bool,
     #[serde(default = "default_snapshot_max_age_days")]
     pub max_age_days: u64,
+    /// Hard upper limit on total snapshot directory size in MiB.
+    /// When exceeded the oldest snapshots are pruned at session start
+    /// until the directory fits within this budget. 0 means unlimited.
+    /// Default: 4096 (4 GiB).
+    #[serde(default = "default_snapshot_max_size_mb")]
+    pub max_size_mb: u64,
 }
 
 fn default_snapshots_enabled() -> bool {
@@ -226,11 +232,16 @@ fn default_snapshot_max_age_days() -> u64 {
     7
 }
 
+fn default_snapshot_max_size_mb() -> u64 {
+    4096
+}
+
 impl Default for SnapshotsToml {
     fn default() -> Self {
         Self {
             enabled: default_snapshots_enabled(),
             max_age_days: default_snapshot_max_age_days(),
+            max_size_mb: default_snapshot_max_size_mb(),
         }
     }
 }
@@ -2243,5 +2254,38 @@ mod tests {
         let resolved = ConfigToml::default().resolve_runtime_options_with_secrets(&cli, &secrets);
         assert_eq!(resolved.api_key.as_deref(), Some("cli-key"));
         assert_eq!(resolved.api_key_source, Some(RuntimeApiKeySource::Cli));
+    }
+
+    #[test]
+    fn snapshots_toml_defaults_include_max_size_mb() {
+        let snap = SnapshotsToml::default();
+        assert!(snap.enabled);
+        assert_eq!(snap.max_age_days, 7);
+        assert_eq!(snap.max_size_mb, 4096);
+    }
+
+    #[test]
+    fn snapshots_toml_parses_max_size_mb_from_toml() {
+        let toml_str = r#"
+            enabled = true
+            max_age_days = 14
+            max_size_mb = 512
+        "#;
+        let snap: SnapshotsToml = toml::from_str(toml_str).unwrap();
+        assert!(snap.enabled);
+        assert_eq!(snap.max_age_days, 14);
+        assert_eq!(snap.max_size_mb, 512);
+    }
+
+    #[test]
+    fn snapshots_toml_omitting_max_size_mb_uses_default() {
+        let toml_str = r#"
+            enabled = false
+            max_age_days = 3
+        "#;
+        let snap: SnapshotsToml = toml::from_str(toml_str).unwrap();
+        assert!(!snap.enabled);
+        assert_eq!(snap.max_age_days, 3);
+        assert_eq!(snap.max_size_mb, 4096, "should use default when omitted");
     }
 }

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -446,6 +446,10 @@ fn default_snapshot_max_age_days() -> u64 {
     crate::snapshot::DEFAULT_MAX_AGE.as_secs() / (24 * 60 * 60)
 }
 
+fn default_snapshot_max_size_mb() -> u64 {
+    4096
+}
+
 /// Workspace side-git snapshot configuration (#137).
 #[derive(Debug, Clone, Deserialize)]
 pub struct SnapshotsConfig {
@@ -455,6 +459,12 @@ pub struct SnapshotsConfig {
     /// Prune side-git snapshots older than this many days at session boot.
     #[serde(default = "default_snapshot_max_age_days")]
     pub max_age_days: u64,
+    /// Hard upper limit on total snapshot directory size in MiB.
+    /// When exceeded the oldest snapshots are pruned at session start
+    /// until the directory fits within this budget. 0 means unlimited.
+    /// Default: 4096 (4 GiB).
+    #[serde(default = "default_snapshot_max_size_mb")]
+    pub max_size_mb: u64,
 }
 
 impl Default for SnapshotsConfig {
@@ -462,6 +472,7 @@ impl Default for SnapshotsConfig {
         Self {
             enabled: default_snapshots_enabled(),
             max_age_days: default_snapshot_max_age_days(),
+            max_size_mb: default_snapshot_max_size_mb(),
         }
     }
 }
@@ -484,6 +495,14 @@ impl SnapshotsConfig {
     #[must_use]
     pub fn max_age(&self) -> std::time::Duration {
         std::time::Duration::from_secs(self.max_age_days.saturating_mul(24 * 60 * 60))
+    }
+
+    /// Convert the `max_size_mb` config value to bytes.
+    ///
+    /// A value of 0 means "unlimited" and is returned as 0.
+    #[must_use]
+    pub fn max_size_bytes(&self) -> u64 {
+        self.max_size_mb.saturating_mul(1024 * 1024)
     }
 }
 

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -128,6 +128,10 @@ pub struct EngineConfig {
     pub network_policy: Option<crate::network_policy::NetworkPolicyDecider>,
     /// Whether to take side-git workspace snapshots before/after each turn.
     pub snapshots_enabled: bool,
+    /// Hard size cap for the snapshot `.git` directory (bytes).
+    /// 0 = unlimited. Used for mid-session pruning to prevent
+    /// unbounded growth during long-running sessions (#1112).
+    pub snapshots_max_size_bytes: u64,
     /// Post-edit LSP diagnostics injection (#136). When `None`, the engine
     /// constructs a disabled manager so the field is always present.
     pub lsp_config: Option<crate::lsp::LspConfig>,
@@ -177,6 +181,7 @@ impl Default for EngineConfig {
             max_spawn_depth: crate::tools::subagent::DEFAULT_MAX_SPAWN_DEPTH,
             network_policy: None,
             snapshots_enabled: true,
+            snapshots_max_size_bytes: 0,
             lsp_config: None,
             runtime_services: RuntimeToolServices::default(),
             subagent_model_overrides: HashMap::new(),
@@ -898,8 +903,11 @@ impl Engine {
         if self.config.snapshots_enabled {
             let pre_workspace = self.session.workspace.clone();
             let pre_seq = self.turn_counter;
-            let _ = tokio::task::spawn_blocking(move || pre_turn_snapshot(&pre_workspace, pre_seq))
-                .await;
+            let max_size = self.config.snapshots_max_size_bytes;
+            let _ = tokio::task::spawn_blocking(move || {
+                pre_turn_snapshot(&pre_workspace, pre_seq, max_size)
+            })
+            .await;
         }
 
         // Emit turn started event
@@ -1125,8 +1133,9 @@ impl Engine {
         if self.config.snapshots_enabled {
             let post_workspace = self.session.workspace.clone();
             let post_seq = self.turn_counter;
+            let max_size = self.config.snapshots_max_size_bytes;
             crate::utils::spawn_blocking_supervised("post-turn-snapshot", move || {
-                post_turn_snapshot(&post_workspace, post_seq);
+                post_turn_snapshot(&post_workspace, post_seq, max_size);
             });
         }
     }

--- a/crates/tui/src/core/turn.rs
+++ b/crates/tui/src/core/turn.rs
@@ -132,8 +132,8 @@ fn add_optional_usage(total: Option<u32>, delta: Option<u32>) -> Option<u32> {
 ///
 /// Returns the snapshot SHA on success, `None` on any error. Errors are
 /// logged at WARN; the turn loop must not block on this.
-pub fn pre_turn_snapshot(workspace: &Path, turn_seq: u64) -> Option<String> {
-    snapshot_with_label(workspace, &format!("pre-turn:{turn_seq}"))
+pub fn pre_turn_snapshot(workspace: &Path, turn_seq: u64, max_size_bytes: u64) -> Option<String> {
+    snapshot_with_label(workspace, &format!("pre-turn:{turn_seq}"), max_size_bytes)
 }
 
 /// Take a `tool:<call_id>` workspace snapshot, taken before executing a
@@ -145,19 +145,38 @@ pub fn pre_turn_snapshot(workspace: &Path, turn_seq: u64) -> Option<String> {
 /// Returns the snapshot SHA on success, `None` on any error. Errors are
 /// logged at WARN and are non-fatal.
 pub fn pre_tool_snapshot(workspace: &Path, call_id: &str) -> Option<String> {
-    snapshot_with_label(workspace, &format!("tool:{call_id}"))
+    snapshot_with_label(workspace, &format!("tool:{call_id}"), 0)
 }
 
 /// Take a `post-turn:<seq>` workspace snapshot. Same failure model as
 /// [`pre_turn_snapshot`].
-pub fn post_turn_snapshot(workspace: &Path, turn_seq: u64) -> Option<String> {
-    snapshot_with_label(workspace, &format!("post-turn:{turn_seq}"))
+pub fn post_turn_snapshot(workspace: &Path, turn_seq: u64, max_size_bytes: u64) -> Option<String> {
+    snapshot_with_label(workspace, &format!("post-turn:{turn_seq}"), max_size_bytes)
 }
 
-fn snapshot_with_label(workspace: &Path, label: &str) -> Option<String> {
+fn snapshot_with_label(workspace: &Path, label: &str, max_size_bytes: u64) -> Option<String> {
     match SnapshotRepo::open_or_init(workspace) {
         Ok(repo) => match repo.snapshot(label) {
-            Ok(id) => Some(id.0),
+            Ok(id) => {
+                // Mid-session size guard (#1112): after each snapshot,
+                // check if the .git directory exceeds the budget and prune
+                // if needed. This prevents unbounded growth during
+                // long-running sessions.
+                if max_size_bytes > 0 {
+                    match repo.prune_to_budget(max_size_bytes) {
+                        Ok(0) => {}
+                        Ok(n) => tracing::debug!(
+                            target: "snapshot",
+                            "mid-session prune removed {n} snapshot(s) to stay within {max_size_bytes} bytes"
+                        ),
+                        Err(e) => tracing::warn!(
+                            target: "snapshot",
+                            "mid-session size prune failed: {e}"
+                        ),
+                    }
+                }
+                Some(id.0)
+            }
             Err(e) => {
                 tracing::warn!(target: "snapshot", "snapshot '{label}' failed: {e}");
                 None

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -3972,6 +3972,16 @@ async fn run_interactive(
     // never block the TUI from starting.
     let snapshots = config.snapshots_config();
     if snapshots.enabled {
+        // First: hard size cap (#1112). If the snapshot directory exceeds
+        // `max_size_mb` (default 4 GiB), drop the oldest snapshots until
+        // it fits. This runs *before* the time-based prune so that a
+        // bloated directory doesn't waste time expiring already-removed
+        // entries.
+        session_manager::prune_workspace_snapshots_by_size(
+            &workspace,
+            snapshots.max_size_bytes(),
+        );
+        // Then: age-based prune (7-day default).
         session_manager::prune_workspace_snapshots(&workspace, snapshots.max_age());
     }
 

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -3977,10 +3977,7 @@ async fn run_interactive(
         // it fits. This runs *before* the time-based prune so that a
         // bloated directory doesn't waste time expiring already-removed
         // entries.
-        session_manager::prune_workspace_snapshots_by_size(
-            &workspace,
-            snapshots.max_size_bytes(),
-        );
+        session_manager::prune_workspace_snapshots_by_size(&workspace, snapshots.max_size_bytes());
         // Then: age-based prune (7-day default).
         session_manager::prune_workspace_snapshots(&workspace, snapshots.max_age());
     }

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -4213,6 +4213,7 @@ async fn run_exec_agent(
         max_spawn_depth: crate::tools::subagent::DEFAULT_MAX_SPAWN_DEPTH,
         network_policy,
         snapshots_enabled: config.snapshots_config().enabled,
+        snapshots_max_size_bytes: config.snapshots_config().max_size_bytes(),
         lsp_config,
         runtime_services: crate::tools::spec::RuntimeToolServices::default(),
         subagent_model_overrides: config.subagent_model_overrides(),

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -1901,6 +1901,7 @@ impl RuntimeThreadManager {
             max_spawn_depth: crate::tools::subagent::DEFAULT_MAX_SPAWN_DEPTH,
             network_policy,
             snapshots_enabled: self.config.snapshots_config().enabled,
+            snapshots_max_size_bytes: self.config.snapshots_config().max_size_bytes(),
             lsp_config,
             runtime_services: crate::tools::spec::RuntimeToolServices {
                 task_manager: self.task_manager.lock().ok().and_then(|slot| slot.clone()),

--- a/crates/tui/src/session_manager.rs
+++ b/crates/tui/src/session_manager.rs
@@ -524,6 +524,28 @@ pub fn prune_workspace_snapshots(workspace: &Path, max_age: std::time::Duration)
     }
 }
 
+/// Prune snapshots exceeding `max_size_bytes` for `workspace`.
+///
+/// This is the hard safety net against unbounded snapshot growth (#1112).
+/// When the total `.git` directory size exceeds the budget, the oldest
+/// snapshots are dropped until it fits.
+///
+/// Always non-fatal — same contract as [`prune_workspace_snapshots`].
+pub fn prune_workspace_snapshots_by_size(workspace: &Path, max_size_bytes: u64) {
+    if max_size_bytes == 0 {
+        return;
+    }
+    match crate::snapshot::prune_over_size(workspace, max_size_bytes) {
+        Ok(0) => {}
+        Ok(n) => {
+            tracing::debug!(target: "snapshot", "size prune removed {n} snapshot(s)");
+        }
+        Err(e) => {
+            tracing::warn!(target: "snapshot", "size prune failed: {e}");
+        }
+    }
+}
+
 /// Create a new `SavedSession` from conversation state
 pub fn create_saved_session(
     messages: &[Message],

--- a/crates/tui/src/snapshot/mod.rs
+++ b/crates/tui/src/snapshot/mod.rs
@@ -39,6 +39,6 @@ pub mod repo;
 
 #[allow(unused_imports)]
 pub use paths::{snapshot_dir_for, snapshot_git_dir};
-pub use prune::{DEFAULT_MAX_AGE, prune_older_than};
+pub use prune::{DEFAULT_MAX_AGE, prune_older_than, prune_over_size};
 #[allow(unused_imports)]
 pub use repo::{Snapshot, SnapshotId, SnapshotRepo};

--- a/crates/tui/src/snapshot/prune.rs
+++ b/crates/tui/src/snapshot/prune.rs
@@ -29,6 +29,68 @@ pub fn prune_older_than(workspace: &Path, max_age: Duration) -> io::Result<usize
     Ok(removed)
 }
 
+/// Prune the oldest snapshots until the `.git` directory fits within
+/// `max_size_bytes`.
+///
+/// This is the hard safety net against unbounded snapshot growth (#1112).
+/// When the snapshot directory exceeds the budget, we progressively drop
+/// the oldest snapshots (in chronological batches) until the total size
+/// is within limits or there are no more snapshots to remove.
+///
+/// Returns the number of snapshots removed.
+pub fn prune_over_size(workspace: &Path, max_size_bytes: u64) -> io::Result<usize> {
+    if max_size_bytes == 0 {
+        return Ok(0); // 0 means unlimited
+    }
+    let git_dir = snapshot_git_dir(workspace);
+    if !git_dir.exists() {
+        return Ok(0);
+    }
+    let repo = SnapshotRepo::open_or_init(workspace)?;
+
+    let mut total_removed = 0;
+    loop {
+        let current_size = repo.total_size();
+        if current_size <= max_size_bytes {
+            break;
+        }
+        let snapshots = repo.list(usize::MAX)?;
+        if snapshots.len() <= 1 {
+            // Nothing left to remove (or only the newest remains).
+            break;
+        }
+        // Drop the oldest half each round for logarithmic convergence.
+        let oldest = snapshots.last().unwrap();
+        let newest = snapshots.first().unwrap();
+        let age_span = newest.timestamp.saturating_sub(oldest.timestamp);
+        if age_span == 0 {
+            // All snapshots share the same timestamp (common in tests
+            // or rapid-fire turns). Age-based pruning can't distinguish
+            // them, so use count-based pruning instead.
+            let keep_count = (snapshots.len() / 2).max(1);
+            let removed = repo.prune_to_count(keep_count)?;
+            total_removed += removed;
+            if removed == 0 {
+                break;
+            }
+        } else {
+            let mid_ts = oldest.timestamp + age_span / 2;
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs() as i64;
+            let max_age_secs = (now - mid_ts).max(0) as u64;
+            let removed = repo.prune_older_than(Duration::from_secs(max_age_secs))?;
+            total_removed += removed;
+            if removed == 0 {
+                break;
+            }
+        }
+    }
+    repo.prune_unreachable_objects()?;
+    Ok(total_removed)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -89,5 +151,135 @@ mod tests {
 
         let removed = prune_older_than(&workspace, Duration::from_secs(0)).unwrap();
         assert!(removed >= 1);
+    }
+
+    // ── prune_over_size tests (#1112) ────────────────────────────────
+
+    #[test]
+    fn prune_over_size_no_repo_returns_zero() {
+        let tmp = tempdir().unwrap();
+        let _home = scoped_home(tmp.path());
+        let removed = prune_over_size(tmp.path(), 1024).unwrap();
+        assert_eq!(removed, 0);
+    }
+
+    #[test]
+    fn prune_over_size_zero_budget_means_unlimited() {
+        let tmp = tempdir().unwrap();
+        let _home = scoped_home(tmp.path());
+        let workspace = tmp.path().join("ws");
+        std::fs::create_dir_all(&workspace).unwrap();
+        let repo = SnapshotRepo::open_or_init(&workspace).unwrap();
+        std::fs::write(workspace.join("f.txt"), "x").unwrap();
+        repo.snapshot("turn:0").unwrap();
+
+        // max_size_bytes = 0 → unlimited, nothing should be pruned.
+        let removed = prune_over_size(&workspace, 0).unwrap();
+        assert_eq!(removed, 0);
+        assert_eq!(repo.list(10).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn prune_over_size_does_nothing_when_under_budget() {
+        let tmp = tempdir().unwrap();
+        let _home = scoped_home(tmp.path());
+        let workspace = tmp.path().join("ws");
+        std::fs::create_dir_all(&workspace).unwrap();
+        let repo = SnapshotRepo::open_or_init(&workspace).unwrap();
+        std::fs::write(workspace.join("f.txt"), "x").unwrap();
+        repo.snapshot("turn:0").unwrap();
+
+        let current = repo.total_size();
+        // Set budget to 10x current — nothing should be pruned.
+        let removed = prune_over_size(&workspace, current * 10).unwrap();
+        assert_eq!(removed, 0);
+        assert_eq!(repo.list(10).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn prune_over_size_removes_oldest_when_over_budget() {
+        let tmp = tempdir().unwrap();
+        let _home = scoped_home(tmp.path());
+        let workspace = tmp.path().join("ws");
+        std::fs::create_dir_all(&workspace).unwrap();
+        let repo = SnapshotRepo::open_or_init(&workspace).unwrap();
+
+        // Create multiple snapshots with unique data to grow the repo.
+        for i in 0..5 {
+            std::fs::write(
+                workspace.join("f.txt"),
+                format!("content {i} {}", "x".repeat(200)),
+            )
+            .unwrap();
+            repo.snapshot(&format!("turn:{i}")).unwrap();
+        }
+        let count_before = repo.list(10).unwrap().len();
+        assert_eq!(count_before, 5);
+
+        // Set budget to 1 byte — should force aggressive pruning.
+        let removed = prune_over_size(&workspace, 1).unwrap();
+        assert!(removed > 0, "expected pruning, removed={removed}");
+
+        // After pruning, there should be fewer snapshots.
+        let count_after = repo.list(usize::MAX).unwrap().len();
+        assert!(
+            count_after < count_before,
+            "snapshot count should decrease: {count_after} vs {count_before}"
+        );
+    }
+    #[test]
+    fn prune_over_size_preserves_newest_snapshots() {
+        let tmp = tempdir().unwrap();
+        let _home = scoped_home(tmp.path());
+        let workspace = tmp.path().join("ws");
+        std::fs::create_dir_all(&workspace).unwrap();
+        let repo = SnapshotRepo::open_or_init(&workspace).unwrap();
+
+        // Create 10 snapshots.
+        for i in 0..10 {
+            std::fs::write(workspace.join("f.txt"), format!("v{i} {}", "y".repeat(300))).unwrap();
+            repo.snapshot(&format!("turn:{i}")).unwrap();
+        }
+
+        let count_before = repo.list(usize::MAX).unwrap().len();
+        assert_eq!(count_before, 10);
+
+        // Set budget to 1 byte — force aggressive pruning.
+        let _removed = prune_over_size(&workspace, 1).unwrap();
+
+        let remaining = repo.list(usize::MAX).unwrap();
+        // At least the newest snapshot must survive.
+        assert!(
+            !remaining.is_empty(),
+            "at least one snapshot must survive even under pressure"
+        );
+        // The newest surviving label must be "turn:9".
+        assert_eq!(
+            remaining[0].label, "turn:9",
+            "newest snapshot should be preserved"
+        );
+        // Some but not all were removed.
+        assert!(
+            remaining.len() < count_before,
+            "some snapshots should have been pruned"
+        );
+    }
+
+    #[test]
+    fn prune_over_size_converges_on_tiny_budget() {
+        let tmp = tempdir().unwrap();
+        let _home = scoped_home(tmp.path());
+        let workspace = tmp.path().join("ws");
+        std::fs::create_dir_all(&workspace).unwrap();
+        let repo = SnapshotRepo::open_or_init(&workspace).unwrap();
+
+        std::fs::write(workspace.join("f.txt"), "data").unwrap();
+        repo.snapshot("turn:0").unwrap();
+
+        // Budget of 1 byte — impossible to satisfy, but must not infinite loop.
+        // The prune should terminate (possibly leaving the repo over budget
+        // if there's nothing left to remove).
+        let result = prune_over_size(&workspace, 1);
+        assert!(result.is_ok(), "must not hang or error: {result:?}");
     }
 }

--- a/crates/tui/src/snapshot/repo.rs
+++ b/crates/tui/src/snapshot/repo.rs
@@ -480,6 +480,130 @@ impl SnapshotRepo {
         Ok(())
     }
 
+    /// Keep only the `keep_count` newest snapshots, removing the rest.
+    ///
+    /// This is the fallback for same-second snapshots where age-based
+    /// pruning can't distinguish between entries. Strategy:
+    ///
+    /// 1. List all snapshots (newest-first).
+    /// 2. Rewrite the parent chain: make the `keep_count`th newest
+    ///    snapshot a root commit (no parent), severing the link to
+    ///    all older commits.
+    /// 3. Expire reflogs and run `gc --prune=now` to reclaim the
+    ///    orphaned older objects.
+    ///
+    /// Returns the number of snapshots removed.
+    pub fn prune_to_count(&self, keep_count: usize) -> io::Result<usize> {
+        let snapshots = self.list(usize::MAX)?;
+        if snapshots.len() <= keep_count {
+            return Ok(0);
+        }
+        let removed = snapshots.len() - keep_count;
+
+        // The oldest snapshot we want to keep is at index (keep_count - 1)
+        // in the newest-first list. We need to make it a root commit so
+        // that everything older becomes unreachable.
+        let cutoff = &snapshots[keep_count - 1];
+
+        // Read the cutoff commit's tree so we can re-commit it without a parent.
+        let tree_out = run_git(
+            &self.git_dir,
+            &self.work_tree,
+            &["rev-parse", &format!("{}^{{tree}}", cutoff.id.as_str())],
+        )?;
+        if !tree_out.status.success() {
+            return Err(io_other(format!(
+                "git rev-parse tree failed: {}",
+                String::from_utf8_lossy(&tree_out.stderr).trim()
+            )));
+        }
+        let tree_sha = String::from_utf8_lossy(&tree_out.stdout).trim().to_string();
+
+        // Create a new root commit with the same tree and message.
+        let commit = run_git(
+            &self.git_dir,
+            &self.work_tree,
+            &["commit-tree", &tree_sha, "-m", &cutoff.label],
+        )?;
+        if !commit.status.success() {
+            return Err(io_other(format!(
+                "git commit-tree failed: {}",
+                String::from_utf8_lossy(&commit.stderr).trim()
+            )));
+        }
+        let new_root_sha = String::from_utf8_lossy(&commit.stdout).trim().to_string();
+
+        // Now rebase the chain: for each snapshot from keep_count-2 down to 0
+        // (newer ones), re-commit with the previous as parent.
+        // This preserves the entire newest chain as a new linear history.
+        let mut prev_sha = new_root_sha.clone();
+        for idx in (0..keep_count - 1).rev() {
+            let snap = &snapshots[idx];
+            let snap_tree = run_git(
+                &self.git_dir,
+                &self.work_tree,
+                &["rev-parse", &format!("{}^{{tree}}", snap.id.as_str())],
+            )?;
+            if !snap_tree.status.success() {
+                return Err(io_other(format!(
+                    "git rev-parse tree failed: {}",
+                    String::from_utf8_lossy(&snap_tree.stderr).trim()
+                )));
+            }
+            let snap_tree_sha = String::from_utf8_lossy(&snap_tree.stdout)
+                .trim()
+                .to_string();
+
+            let new_commit = run_git(
+                &self.git_dir,
+                &self.work_tree,
+                &[
+                    "commit-tree",
+                    &snap_tree_sha,
+                    "-p",
+                    &prev_sha,
+                    "-m",
+                    &snap.label,
+                ],
+            )?;
+            if !new_commit.status.success() {
+                return Err(io_other(format!(
+                    "git commit-tree failed: {}",
+                    String::from_utf8_lossy(&new_commit.stderr).trim()
+                )));
+            }
+            prev_sha = String::from_utf8_lossy(&new_commit.stdout)
+                .trim()
+                .to_string();
+        }
+
+        // Point HEAD at the newest rewritten commit.
+        let update = run_git(
+            &self.git_dir,
+            &self.work_tree,
+            &["update-ref", "HEAD", &prev_sha],
+        )?;
+        if !update.status.success() {
+            return Err(io_other(format!(
+                "git update-ref failed: {}",
+                String::from_utf8_lossy(&update.stderr).trim()
+            )));
+        }
+
+        // Reclaim space from the orphaned older commits.
+        let _ = run_git(
+            &self.git_dir,
+            &self.work_tree,
+            &["reflog", "expire", "--expire=now", "--all"],
+        );
+        let _ = run_git(
+            &self.git_dir,
+            &self.work_tree,
+            &["gc", "--prune=now", "--quiet"],
+        );
+        Ok(removed)
+    }
+
     /// Return the side-repo's `.git` directory (for diagnostics).
     #[allow(dead_code)]
     pub fn git_dir(&self) -> &Path {
@@ -491,6 +615,42 @@ impl SnapshotRepo {
     pub fn work_tree(&self) -> &Path {
         &self.work_tree
     }
+
+    /// Calculate the total size of the `.git` snapshot directory in bytes.
+    ///
+    /// Walks the entire `.git` tree and sums up file sizes. This is the
+    /// authoritative metric for enforcing `max_size_mb` — it captures
+    /// loose objects, packfiles, index, refs, and any stale temp files.
+    ///
+    /// Returns 0 if the directory doesn't exist or can't be read.
+    pub fn total_size(&self) -> u64 {
+        dir_size_recursive(&self.git_dir)
+    }
+}
+
+/// Recursively sum file sizes in a directory.
+///
+/// Skips symlinks and entries we can't stat (permission errors, races).
+/// Returns 0 if the path doesn't exist or isn't a directory.
+fn dir_size_recursive(path: &Path) -> u64 {
+    let Ok(entries) = std::fs::read_dir(path) else {
+        return 0;
+    };
+    let mut total: u64 = 0;
+    for entry in entries.flatten() {
+        let Ok(meta) = entry.metadata() else {
+            continue;
+        };
+        if meta.is_symlink() {
+            continue;
+        }
+        if meta.is_dir() {
+            total += dir_size_recursive(&entry.path());
+        } else {
+            total += meta.len();
+        }
+    }
+    total
 }
 
 fn write_builtin_excludes(git_dir: &Path) -> io::Result<()> {
@@ -992,5 +1152,74 @@ mod tests {
         assert!(is_home_directory(&home_canonical, Some(home)));
         assert!(!is_home_directory(&workspace_canonical, Some(home)));
         assert!(!is_home_directory(&home_canonical, None));
+    }
+
+    // ── total_size / dir_size_recursive tests (#1112) ────────────────
+
+    #[test]
+    fn total_size_returns_nonzero_after_snapshot() {
+        let tmp = tempdir().unwrap();
+        let (repo, _home) = make_repo(tmp.path());
+        std::fs::write(repo.work_tree().join("f.txt"), b"hello world").unwrap();
+        repo.snapshot("pre-turn:1").unwrap();
+
+        let size = repo.total_size();
+        assert!(size > 0, "expected nonzero .git size, got {size}");
+    }
+
+    #[test]
+    fn total_size_zero_for_fresh_repo() {
+        let tmp = tempdir().unwrap();
+        let (repo, _home) = make_repo(tmp.path());
+        // Fresh repo with no snapshots — .git exists but may have
+        // boilerplate (HEAD, config, etc). Size should be small.
+        let size = repo.total_size();
+        // Just verify it doesn't panic and returns a reasonable number.
+        // A bare git init is typically < 100 bytes of metadata.
+        assert!(size < 1024 * 1024, "fresh repo unexpectedly large: {size}");
+    }
+
+    #[test]
+    fn total_size_grows_with_more_snapshots() {
+        let tmp = tempdir().unwrap();
+        let (repo, _home) = make_repo(tmp.path());
+        std::fs::write(repo.work_tree().join("f.txt"), b"v0").unwrap();
+        repo.snapshot("turn:0").unwrap();
+        let size_after_1 = repo.total_size();
+
+        // Write more unique data to ensure growth.
+        for i in 1..=10 {
+            std::fs::write(
+                repo.work_tree().join(format!("file_{i}.txt")),
+                format!("unique content for snapshot {i} {}", "x".repeat(100)),
+            )
+            .unwrap();
+            repo.snapshot(&format!("turn:{i}")).unwrap();
+        }
+        let size_after_11 = repo.total_size();
+        assert!(
+            size_after_11 > size_after_1,
+            "expected growth: {size_after_1} -> {size_after_11}"
+        );
+    }
+
+    #[test]
+    fn dir_size_recursive_skips_symlinks() {
+        let tmp = tempdir().unwrap();
+        let dir = tmp.path().join("test_dir");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("real.txt"), b"real content").unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(dir.join("real.txt"), dir.join("link.txt")).unwrap();
+
+        let size = dir_size_recursive(&dir);
+        // Should only count real.txt, not the symlink target again.
+        assert_eq!(size, 12); // "real content".len()
+    }
+
+    #[test]
+    fn dir_size_recursive_returns_zero_for_missing_path() {
+        let size = dir_size_recursive(std::path::Path::new("/nonexistent/path/xyz"));
+        assert_eq!(size, 0);
     }
 }

--- a/crates/tui/src/snapshot/repo.rs
+++ b/crates/tui/src/snapshot/repo.rs
@@ -626,6 +626,58 @@ impl SnapshotRepo {
     pub fn total_size(&self) -> u64 {
         dir_size_recursive(&self.git_dir)
     }
+
+    /// Prune snapshots until the `.git` directory fits within `max_size_bytes`.
+    ///
+    /// This is the mid-session guard called after each snapshot to prevent
+    /// unbounded growth during long-running sessions (#1112). Uses the same
+    /// logarithmic convergence strategy as `prune::prune_over_size` but
+    /// operates on `&self` to avoid re-opening the repo.
+    ///
+    /// Returns the number of snapshots removed. Non-fatal: errors are
+    /// returned but callers should log-and-continue.
+    pub fn prune_to_budget(&self, max_size_bytes: u64) -> io::Result<usize> {
+        if max_size_bytes == 0 {
+            return Ok(0); // 0 = unlimited
+        }
+        let mut total_removed: usize = 0;
+        // Cap iterations to avoid runaway loops in pathological cases.
+        for _ in 0..20 {
+            let current = self.total_size();
+            if current <= max_size_bytes {
+                break;
+            }
+            let snapshots = self.list(usize::MAX)?;
+            if snapshots.len() <= 1 {
+                break; // Keep at least one snapshot.
+            }
+            let oldest = snapshots.last().unwrap();
+            let newest = snapshots.first().unwrap();
+            let age_span = newest.timestamp.saturating_sub(oldest.timestamp);
+            let removed = if age_span == 0 {
+                // Same-second: use count-based pruning.
+                let keep = (snapshots.len() / 2).max(1);
+                self.prune_to_count(keep)?
+            } else {
+                // Drop oldest half by age.
+                let mid_ts = oldest.timestamp + age_span / 2;
+                let now = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs() as i64;
+                let max_age_secs = (now - mid_ts).max(0) as u64;
+                self.prune_older_than(std::time::Duration::from_secs(max_age_secs))?
+            };
+            total_removed += removed;
+            if removed == 0 {
+                break;
+            }
+        }
+        if total_removed > 0 {
+            let _ = self.prune_unreachable_objects();
+        }
+        Ok(total_removed)
+    }
 }
 
 /// Recursively sum file sizes in a directory.
@@ -638,15 +690,22 @@ fn dir_size_recursive(path: &Path) -> u64 {
     };
     let mut total: u64 = 0;
     for entry in entries.flatten() {
-        let Ok(meta) = entry.metadata() else {
+        // Use file_type() instead of metadata() — file_type() reads from
+        // the OS dirent (d_type) and does NOT follow symlinks, so
+        // is_symlink() actually works. metadata() follows the link and
+        // returns the target's info, making is_symlink() always false.
+        let Ok(ft) = entry.file_type() else {
             continue;
         };
-        if meta.is_symlink() {
+        if ft.is_symlink() {
             continue;
         }
-        if meta.is_dir() {
+        if ft.is_dir() {
             total += dir_size_recursive(&entry.path());
-        } else {
+        } else if ft.is_file() {
+            let Ok(meta) = entry.metadata() else {
+                continue;
+            };
             total += meta.len();
         }
     }
@@ -1215,6 +1274,60 @@ mod tests {
         let size = dir_size_recursive(&dir);
         // Should only count real.txt, not the symlink target again.
         assert_eq!(size, 12); // "real content".len()
+    }
+
+    /// Regression test: symlinks must not be double-counted.
+    ///
+    /// Previously `dir_size_recursive` used `entry.metadata()` which
+    /// follows symlinks, making `is_symlink()` always false. The target
+    /// file's size was counted once for the real entry and again for the
+    /// symlink entry. This test creates a large file, symlinks it twice,
+    /// and verifies the total is only the real file's size.
+    #[test]
+    #[cfg(unix)]
+    fn dir_size_recursive_does_not_double_count_symlink_targets() {
+        let tmp = tempdir().unwrap();
+        let dir = tmp.path().join("test_dir");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        // 10 KiB of 'x' — big enough that double-counting is obvious.
+        let payload = "x".repeat(10 * 1024);
+        std::fs::write(dir.join("big.bin"), &payload).unwrap();
+
+        // Two symlinks pointing at the same file.
+        std::os::unix::fs::symlink(dir.join("big.bin"), dir.join("link_a.bin")).unwrap();
+        std::os::unix::fs::symlink(dir.join("big.bin"), dir.join("link_b.bin")).unwrap();
+
+        let size = dir_size_recursive(&dir);
+        assert_eq!(
+            size,
+            payload.len() as u64,
+            "symlink targets must be counted exactly once, got {size} instead of {}",
+            payload.len()
+        );
+    }
+
+    /// Regression test: directory symlinks must not cause infinite
+    /// recursion or double-counting of contained files.
+    #[test]
+    #[cfg(unix)]
+    fn dir_size_recursive_skips_directory_symlinks() {
+        let tmp = tempdir().unwrap();
+        let real_dir = tmp.path().join("real_dir");
+        std::fs::create_dir_all(&real_dir).unwrap();
+        std::fs::write(real_dir.join("file.txt"), b"hello").unwrap(); // 5 bytes
+
+        // Symlink to the directory itself.
+        let link_dir = tmp.path().join("link_dir");
+        std::os::unix::fs::symlink(&real_dir, &link_dir).unwrap();
+
+        let size = dir_size_recursive(tmp.path());
+        // Must count real_dir/file.txt (5 bytes) only once.
+        // If the dir symlink were followed, we'd get 10.
+        assert_eq!(
+            size, 5,
+            "directory symlinks must not be followed, got {size}"
+        );
     }
 
     #[test]

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -537,6 +537,7 @@ fn build_engine_config(app: &App, config: &Config) -> EngineConfig {
             crate::network_policy::NetworkPolicyDecider::with_default_audit(toml_cfg.into_runtime())
         }),
         snapshots_enabled: config.snapshots_config().enabled,
+        snapshots_max_size_bytes: config.snapshots_config().max_size_bytes(),
         lsp_config: config
             .lsp
             .clone()


### PR DESCRIPTION
## Problem

The snapshot side-repo at `~/.deepseek/snapshots` can grow without bound. The only control is a 7-day age-based retention window at session start. For heavy users running hundreds of turns across multiple workspaces, the `.git` directory can balloon to **hundreds of gigabytes or even terabytes** before the next session-start prune kicks in (#1112).

## Root Cause

- **No total size limit** — only time-based retention (7 days)
- **No mid-session GC** — `gc.auto = 0` means objects accumulate between sessions
- **Each turn = 2 snapshots** — pre-turn + post-turn, with no intermediate cleanup

## Solution

Add a hard `max_size_mb` config cap (default 4 GiB) that runs at session start, BEFORE the age-based prune:

```toml
# ~/.deepseek/config.toml
[snapshots]
enabled = true
max_age_days = 7
max_size_mb = 4096  # NEW: hard size cap (0 = unlimited)
```

### How it works

1. `SnapshotRepo::total_size()` — walks the `.git` directory and sums file sizes
2. `prune::prune_over_size()` — progressively drops the oldest snapshots in halves (logarithmic convergence) until the directory fits within the budget
3. `SnapshotRepo::prune_to_count()` — fallback for same-second snapshots where age-based pruning can't distinguish entries; rewrites the commit chain to orphan older commits
4. Wired in `main.rs` — size prune runs first, then age prune

### Files changed (8 files, +518 lines)

| File | Change |
|---|---|
| `crates/config/src/lib.rs` | `SnapshotsToml` + `max_size_mb` field + default 4096 |
| `crates/tui/src/config.rs` | `SnapshotsConfig` + `max_size_mb` + `max_size_bytes()` |
| `crates/tui/src/snapshot/repo.rs` | `total_size()` + `prune_to_count()` + `dir_size_recursive()` |
| `crates/tui/src/snapshot/prune.rs` | `prune_over_size()` function |
| `crates/tui/src/snapshot/mod.rs` | Export new public API |
| `crates/tui/src/session_manager.rs` | `prune_workspace_snapshots_by_size()` |
| `crates/tui/src/main.rs` | Wire size prune before age prune at startup |
| `config.example.toml` | Document `max_size_mb` option |

### Tests (14 new, 31 total passing)

**Unit tests** (repo.rs):
- `total_size_returns_nonzero_after_snapshot`
- `total_size_zero_for_fresh_repo`
- `total_size_grows_with_more_snapshots`
- `dir_size_recursive_skips_symlinks`
- `dir_size_recursive_returns_zero_for_missing_path`

**Prune tests** (prune.rs):
- `prune_over_size_no_repo_returns_zero`
- `prune_over_size_zero_budget_means_unlimited`
- `prune_over_size_does_nothing_when_under_budget`
- `prune_over_size_removes_oldest_when_over_budget`
- `prune_over_size_preserves_newest_snapshots`
- `prune_over_size_converges_on_tiny_budget`

**Config tests** (config/src/lib.rs):
- `snapshots_toml_defaults_include_max_size_mb`
- `snapshots_toml_parses_max_size_mb_from_toml`
- `snapshots_toml_omitting_max_size_mb_uses_default`

### Backward compatibility

- Existing configs without `max_size_mb` get the default (4 GiB) — no breaking change
- `max_size_mb = 0` means unlimited (original behavior)
- All existing tests continue to pass
