### PR TITLE
feat(command-safety): block eval/exec as primary command

### DIFF
--- a/crates/tui/src/command_safety.rs
+++ b/crates/tui/src/command_safety.rs
@@ -622,6 +622,21 @@ pub fn analyze_command(command: &str) -> SafetyAnalysis {
         );
     }
 
+    // Check for eval/exec as the primary command - these can enable dynamic code execution
+    if let Some(primary) = extract_primary_command(command) {
+        let primary_lower = primary.to_lowercase();
+        if primary_lower == "eval" || primary_lower == "exec" {
+            return SafetyAnalysis::dangerous(
+                command,
+                vec![format!(
+                    "Command uses '{}' which can enable dynamic code execution",
+                    primary_lower
+                )],
+                vec!["Avoid using eval/exec in commands".to_string()],
+            );
+        }
+    }
+
     // Check for dangerous patterns first
     for (pattern, reason) in DANGEROUS_PATTERNS {
         if command_lower.contains(&pattern.to_lowercase()) {
@@ -985,6 +1000,32 @@ mod tests {
             evaluator,
             SafetyLevel::Dangerous,
             "running an evaluator script should not be classified as dangerous"
+        );
+    }
+
+    #[test]
+    fn test_eval_exec_as_primary_command_is_blocked() {
+        // eval and exec as the primary command should be blocked
+        // because they can enable dynamic code execution
+        assert_eq!(
+            analyze_command("eval $USER_INPUT").level,
+            SafetyLevel::Dangerous,
+            "eval as primary command should be blocked"
+        );
+        assert_eq!(
+            analyze_command("exec bash -c 'rm -rf /'").level,
+            SafetyLevel::Dangerous,
+            "exec as primary command should be blocked"
+        );
+        assert_eq!(
+            analyze_command("exec>file").level,
+            SafetyLevel::Dangerous,
+            "exec with redirection should be blocked"
+        );
+        assert_eq!(
+            analyze_command("EXEC ./script.sh").level,
+            SafetyLevel::Dangerous,
+            "EXEC uppercase should also be blocked"
         );
     }
 


### PR DESCRIPTION
## Summary

This PR adds detection for `eval` and `exec` when used as the **primary command** (first token), which can enable dynamic code execution attacks.

## Problem

The previous code had no protection against `eval` or `exec` being used as the main command. While the project had some safety checks, these dangerous commands were not blocked.

## Solution

Uses `extract_primary_command()` to check if the first token is `eval` or `exec`:
- Only blocks when `eval` or `exec` is the **primary command**
- Avoids false positives from words like `evaluate`, `evaluator.py`, `cargo run -- eval`

## Changes

**crates/tui/src/command_safety.rs**:
- Added eval/exec detection in `analyze_command()` function
- Added `test_eval_exec_as_primary_command_is_blocked` test

## Test Cases

| Command | Expected | Reason |
|---------|----------|--------|
| `eval $USER_INPUT` | Dangerous | Primary command is eval |
| `exec bash -c '...'` | Dangerous | Primary command is exec |
| `exec>file` | Dangerous | Primary command is exec |
| `cargo run --bin deepseek -- eval` | Safe | eval is an argument, not command |
| `python evaluator.py` | Safe | Different word, not eval |
| `primeval-checker` | Safe | Different word, contains "eval" |

## Compatibility

This fix addresses the concern raised in #706 about the original `command.contains("eval")` approach that was rejected for false positives. By using `extract_primary_command()`, we only block when `eval` or `exec` is truly the command being executed.