### PR TITLE
test(config): add regression test for deepseek-cn beta endpoint

### DIFF
--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -4111,6 +4111,21 @@ api_key = "old-openrouter-key"
     }
 
     #[test]
+    fn deepseek_cn_legacy_alias_routes_to_beta_endpoint() {
+        let config = Config {
+            provider: Some("deepseek-cn".to_string()),
+            ..Default::default()
+        };
+
+        assert_eq!(config.api_provider(), ApiProvider::DeepseekCN);
+        assert_eq!(
+            config.deepseek_base_url(),
+            DEFAULT_DEEPSEEK_BASE_URL,
+            "deepseek-cn legacy alias must use the beta endpoint, not https://api.deepseek.com"
+        );
+    }
+
+    #[test]
     fn explicit_deepseek_base_url_overrides_beta_default() {
         let config = Config {
             base_url: Some("https://api.deepseek.com".to_string()),


### PR DESCRIPTION
## Summary

- v0.8.19 fixed `deepseek-cn` routing to `https://api.deepseek.com` instead of the beta endpoint (`https://api.deepseek.com/beta`), but no regression test was added to pin that fix.
- This PR adds `deepseek_cn_legacy_alias_routes_to_beta_endpoint` alongside the existing `deepseek_provider_defaults_to_beta_endpoint` test, so any future change that accidentally reverts `DEFAULT_DEEPSEEKCN_BASE_URL` to the non-beta URL will be caught immediately.

## Test plan

- [ ] `cargo test -p deepseek-tui deepseek_cn_legacy_alias_routes_to_beta_endpoint` passes
- [ ] No existing tests broken