### PR TITLE
feat: distinct user message body color (green)

### DIFF
--- a/crates/tui/src/palette.rs
+++ b/crates/tui/src/palette.rs
@@ -119,6 +119,8 @@ pub const TEXT_REASONING: Color = Color::Rgb(211, 170, 112); // #D3AA70
 pub const TEXT_PRIMARY: Color = TEXT_BODY;
 pub const TEXT_MUTED: Color = TEXT_SECONDARY;
 pub const TEXT_DIM: Color = TEXT_HINT;
+pub const USER_BODY: Color = Color::Rgb(74, 222, 128); // #4ADE80 green
+pub const LIGHT_USER_BODY: Color = Color::Rgb(21, 128, 61); // #15803D green
 
 // New semantic colors for UI theming
 pub const BORDER_COLOR: Color =
@@ -349,6 +351,8 @@ pub fn adapt_fg_for_palette_mode(color: Color, _bg: Color, mode: PaletteMode) ->
         Color::Rgb(159, 18, 57)
     } else if color == DIFF_ADDED {
         Color::Rgb(22, 101, 52)
+    } else if color == USER_BODY {
+        LIGHT_USER_BODY
     } else {
         color
     }

--- a/crates/tui/src/tui/history.rs
+++ b/crates/tui/src/tui/history.rs
@@ -181,7 +181,7 @@ impl HistoryCell {
             HistoryCell::User { content } => render_message(
                 USER_GLYPH,
                 user_label_style(),
-                message_body_style(),
+                user_body_style(),
                 content,
                 width,
             ),
@@ -268,7 +268,7 @@ impl HistoryCell {
             HistoryCell::User { content } => render_message(
                 USER_GLYPH,
                 user_label_style(),
-                message_body_style(),
+                user_body_style(),
                 content,
                 width,
             ),
@@ -300,7 +300,7 @@ impl HistoryCell {
             HistoryCell::User { content } => render_message(
                 USER_GLYPH,
                 user_label_style(),
-                message_body_style(),
+                user_body_style(),
                 content,
                 width,
             ),
@@ -2636,6 +2636,10 @@ fn truncate_text(text: &str, max_len: usize) -> String {
 
 fn user_label_style() -> Style {
     Style::default().fg(palette::TEXT_MUTED)
+}
+
+fn user_body_style() -> Style {
+    Style::default().fg(palette::USER_BODY)
 }
 
 /// Style for the assistant glyph (`●`). When the cell is streaming and


### PR DESCRIPTION
Use a dedicated user_body_style() with a green (#4ADE80 / #15803D) foreground color for user messages instead of sharing the message_body_style() (TEXT_PRIMARY) used by assistant messages.

This makes user input visually distinguishable from assistant responses in the transcript.

Changes:
- palette.rs: add USER_BODY and LIGHT_USER_BODY color constants
- palette.rs: adapt_fg_for_palette_mode entry for light-mode mapping
- history.rs: add user_body_style() function
- history.rs: replace message_body_style() with user_body_style() in all three User render paths (lines / lines_with_options / transcript_lines)

## Summary

## Testing

- [ ] `cargo test --all-features`
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
