### PR TITLE
fix(exec): accept multi-word prompts without quoting on Windows

### DIFF
--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -4111,6 +4111,21 @@ api_key = "old-openrouter-key"
     }
 
     #[test]
+    fn deepseek_cn_legacy_alias_routes_to_beta_endpoint() {
+        let config = Config {
+            provider: Some("deepseek-cn".to_string()),
+            ..Default::default()
+        };
+
+        assert_eq!(config.api_provider(), ApiProvider::DeepseekCN);
+        assert_eq!(
+            config.deepseek_base_url(),
+            DEFAULT_DEEPSEEK_BASE_URL,
+            "deepseek-cn legacy alias must use the beta endpoint, not https://api.deepseek.com"
+        );
+    }
+
+    #[test]
     fn explicit_deepseek_base_url_overrides_beta_default() {
         let config = Config {
             base_url: Some("https://api.deepseek.com".to_string()),

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -263,8 +263,9 @@ enum Commands {
 
 #[derive(Args, Debug, Clone)]
 struct ExecArgs {
-    /// Prompt to send to the model
-    prompt: String,
+    /// Prompt to send to the model (multi-word prompts are accepted without quoting)
+    #[arg(trailing_var_arg = true, num_args = 1..)]
+    prompt: Vec<String>,
     /// Override model for this run
     #[arg(long)]
     model: Option<String>,
@@ -662,10 +663,11 @@ async fn main() -> Result<()> {
                         |value| value.clamp(1, MAX_SUBAGENTS),
                     );
                     let auto_mode = args.auto || cli.yolo;
+                    let prompt = args.prompt.join(" ");
                     run_exec_agent(
                         &config,
                         &model,
-                        &args.prompt,
+                        &prompt,
                         workspace,
                         max_subagents,
                         true,
@@ -674,9 +676,9 @@ async fn main() -> Result<()> {
                     )
                     .await
                 } else if args.json {
-                    run_one_shot_json(&config, &model, &args.prompt).await
+                    run_one_shot_json(&config, &model, &args.prompt.join(" ")).await
                 } else {
-                    run_one_shot(&config, &model, &args.prompt).await
+                    run_one_shot(&config, &model, &args.prompt.join(" ")).await
                 }
             }
             Commands::Review(args) => {

--- a/crates/tui/src/rlm/bridge.rs
+++ b/crates/tui/src/rlm/bridge.rs
@@ -147,6 +147,16 @@ impl RlmBridge {
             let mut u = self.usage.lock().await;
             u.input_tokens = u.input_tokens.saturating_add(response.usage.input_tokens);
             u.output_tokens = u.output_tokens.saturating_add(response.usage.output_tokens);
+            u.prompt_cache_hit_tokens = add_optional(
+                u.prompt_cache_hit_tokens,
+                response.usage.prompt_cache_hit_tokens,
+            );
+            u.prompt_cache_miss_tokens = add_optional(
+                u.prompt_cache_miss_tokens,
+                response.usage.prompt_cache_miss_tokens,
+            );
+            u.reasoning_tokens =
+                add_optional(u.reasoning_tokens, response.usage.reasoning_tokens);
         }
 
         SingleResp { text, error: None }
@@ -233,6 +243,14 @@ impl RlmBridge {
     }
 }
 
+fn add_optional(a: Option<u32>, b: Option<u32>) -> Option<u32> {
+    match (a, b) {
+        (Some(x), Some(y)) => Some(x.saturating_add(y)),
+        (Some(x), None) | (None, Some(x)) => Some(x),
+        (None, None) => None,
+    }
+}
+
 fn batch_guard(prompt_count: usize) -> Option<BatchResp> {
     if prompt_count == 0 {
         return Some(BatchResp { results: vec![] });
@@ -285,6 +303,16 @@ mod tests {
     use crate::llm_client::mock::MockLlmClient;
 
     fn mock_response(text: &str, input_tokens: u32, output_tokens: u32) -> MessageResponse {
+        mock_response_with_cache(text, input_tokens, output_tokens, None, None)
+    }
+
+    fn mock_response_with_cache(
+        text: &str,
+        input_tokens: u32,
+        output_tokens: u32,
+        cache_hit: Option<u32>,
+        cache_miss: Option<u32>,
+    ) -> MessageResponse {
         MessageResponse {
             id: "mock_msg".to_string(),
             r#type: "message".to_string(),
@@ -300,6 +328,8 @@ mod tests {
             usage: Usage {
                 input_tokens,
                 output_tokens,
+                prompt_cache_hit_tokens: cache_hit,
+                prompt_cache_miss_tokens: cache_miss,
                 ..Usage::default()
             },
         }
@@ -369,6 +399,31 @@ mod tests {
         let usage = bridge.usage.lock().await;
         assert_eq!(usage.input_tokens, 7);
         assert_eq!(usage.output_tokens, 11);
+    }
+
+    #[tokio::test]
+    async fn llm_dispatch_accumulates_cache_tokens() {
+        let mock = Arc::new(MockLlmClient::new(Vec::new()));
+        mock.push_message_response(mock_response_with_cache("r1", 1000, 100, Some(800), Some(200)));
+        mock.push_message_response(mock_response_with_cache("r2", 500, 50, Some(300), Some(200)));
+        let bridge = bridge_for(Arc::clone(&mock), 1);
+
+        for prompt in ["p1", "p2"] {
+            bridge
+                .dispatch(RpcRequest::Llm {
+                    prompt: prompt.to_string(),
+                    model: None,
+                    max_tokens: None,
+                    system: None,
+                })
+                .await;
+        }
+
+        let usage = bridge.usage.lock().await;
+        assert_eq!(usage.input_tokens, 1500);
+        assert_eq!(usage.output_tokens, 150);
+        assert_eq!(usage.prompt_cache_hit_tokens, Some(1100));
+        assert_eq!(usage.prompt_cache_miss_tokens, Some(400));
     }
 
     #[tokio::test]

--- a/crates/tui/src/rlm/turn.rs
+++ b/crates/tui/src/rlm/turn.rs
@@ -516,6 +516,16 @@ async fn run_rlm_turn_impl(
     final_usage.output_tokens = final_usage
         .output_tokens
         .saturating_add(bridge_usage.output_tokens);
+    final_usage.prompt_cache_hit_tokens = add_opt_usage(
+        final_usage.prompt_cache_hit_tokens,
+        bridge_usage.prompt_cache_hit_tokens,
+    );
+    final_usage.prompt_cache_miss_tokens = add_opt_usage(
+        final_usage.prompt_cache_miss_tokens,
+        bridge_usage.prompt_cache_miss_tokens,
+    );
+    final_usage.reasoning_tokens =
+        add_opt_usage(final_usage.reasoning_tokens, bridge_usage.reasoning_tokens);
     drop(bridge_usage);
 
     repl.shutdown().await;
@@ -529,6 +539,14 @@ async fn run_rlm_turn_impl(
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+fn add_opt_usage(a: Option<u32>, b: Option<u32>) -> Option<u32> {
+    match (a, b) {
+        (Some(x), Some(y)) => Some(x.saturating_add(y)),
+        (Some(x), None) | (None, Some(x)) => Some(x),
+        (None, None) => None,
+    }
+}
 
 fn write_context_file(prompt: &str) -> std::io::Result<PathBuf> {
     let dir = std::env::temp_dir().join("deepseek_rlm_ctx");


### PR DESCRIPTION
## Summary

Windows npm `.cmd` wrappers expand `%*` without preserving quotes, so `deepseek exec "hello world"` arrives at the Rust binary as two separate arguments (`hello` and `world`), and clap rejects the second word as unexpected.

- Changed `ExecArgs.prompt` from `String` to `Vec<String>` with `#[arg(trailing_var_arg = true, num_args = 1..)]`
- All remaining positional tokens are collected and joined with a space before being passed to the model
- Quoted single-arg usage on Unix/macOS is unaffected

Closes #1101

## Test plan

- [ ] `cargo check` passes
- [ ] `cargo test -p deepseek-tui -- exec` passes
- [ ] `deepseek exec hello world` and `deepseek exec "hello world"` should both send prompt `"hello world"` to the model