### PR TITLE
fix(fetch_url): add allow_private_ip_hosts to skip DNS-resolved IP check

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -230,6 +230,9 @@ max_subagents = 10 # optional (1-20)
 # allow = ["api.deepseek.com", "github.com", ".githubusercontent.com"]
 # deny = []
 # audit = true            # one line per call to ~/.deepseek/audit.log
+# allow_private_ip_hosts = false  # set true when a trusted transparent proxy controls DNS
+#                                 # and returns virtual private-range IPs for external domains.
+#                                 # Direct private-IP literals in URLs remain blocked regardless.
 
 # ─────────────────────────────────────────────────────────────────────────────────
 # Skills (#140)

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -925,6 +925,12 @@ pub struct NetworkPolicyToml {
     /// Whether to record one audit-log line per outbound network call.
     #[serde(default = "default_network_audit")]
     pub audit: bool,
+    /// Allow `fetch_url` to proceed when a hostname resolves to a private/reserved
+    /// IP address. Off by default. Enable when a trusted transparent proxy
+    /// controls DNS and returns virtual private-range IPs for external domains.
+    /// Direct private-IP literals in URLs remain blocked regardless.
+    #[serde(default)]
+    pub allow_private_ip_hosts: bool,
 }
 
 fn default_network_decision() -> String {
@@ -942,6 +948,7 @@ impl Default for NetworkPolicyToml {
             allow: Vec::new(),
             deny: Vec::new(),
             audit: default_network_audit(),
+            allow_private_ip_hosts: false,
         }
     }
 }
@@ -956,6 +963,7 @@ impl NetworkPolicyToml {
             allow: self.allow,
             deny: self.deny,
             audit: self.audit,
+            allow_private_ip_hosts: self.allow_private_ip_hosts,
         }
     }
 }

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -4111,6 +4111,21 @@ api_key = "old-openrouter-key"
     }
 
     #[test]
+    fn deepseek_cn_legacy_alias_routes_to_beta_endpoint() {
+        let config = Config {
+            provider: Some("deepseek-cn".to_string()),
+            ..Default::default()
+        };
+
+        assert_eq!(config.api_provider(), ApiProvider::DeepseekCN);
+        assert_eq!(
+            config.deepseek_base_url(),
+            DEFAULT_DEEPSEEK_BASE_URL,
+            "deepseek-cn legacy alias must use the beta endpoint, not https://api.deepseek.com"
+        );
+    }
+
+    #[test]
     fn explicit_deepseek_base_url_overrides_beta_default() {
         let config = Config {
             base_url: Some("https://api.deepseek.com".to_string()),

--- a/crates/tui/src/network_policy.rs
+++ b/crates/tui/src/network_policy.rs
@@ -101,6 +101,13 @@ pub struct NetworkPolicy {
     /// Whether to record one audit-log line per network call. Defaults to true.
     #[serde(default = "default_audit")]
     pub audit: bool,
+    /// Allow `fetch_url` to proceed when a hostname resolves to a private/reserved
+    /// IP address. Off by default (SSRF protection). Enable only when DNS is
+    /// handled by a trusted transparent proxy that returns virtual private-range
+    /// IPs for external domains. Direct private-IP literals in URLs are always
+    /// blocked regardless of this setting.
+    #[serde(default)]
+    pub allow_private_ip_hosts: bool,
 }
 
 fn default_decision() -> DecisionToml {
@@ -118,6 +125,7 @@ impl Default for NetworkPolicy {
             allow: Vec::new(),
             deny: Vec::new(),
             audit: true,
+            allow_private_ip_hosts: false,
         }
     }
 }
@@ -448,6 +456,13 @@ impl NetworkPolicyDecider {
         decision
     }
 
+    /// Whether DNS-resolved private IPs are allowed by this policy.
+    /// See [`NetworkPolicy::allow_private_ip_hosts`].
+    #[must_use]
+    pub fn allows_private_ip_hosts(&self) -> bool {
+        self.policy.allow_private_ip_hosts
+    }
+
     /// Approve `host` for the rest of the session (one-shot). Audit log gets
     /// `Prompt-Approved`.
     pub fn approve_session(&self, host: &str, tool: &str) {
@@ -497,6 +512,7 @@ mod tests {
             allow: allow.iter().map(|s| (*s).to_string()).collect(),
             deny: deny.iter().map(|s| (*s).to_string()).collect(),
             audit: false,
+            allow_private_ip_hosts: false,
         }
     }
 

--- a/crates/tui/src/tools/fetch_url.rs
+++ b/crates/tui/src/tools/fetch_url.rs
@@ -171,6 +171,15 @@ impl ToolSpec for FetchUrlTool {
         // localhost services, and internal networks.
         // Pin the validated IP via ClientBuilder::resolve() to close the DNS rebinding
         // TOCTOU window — reqwest will use the pinned IP instead of re-resolving.
+        //
+        // Exception: when `network.allow_private_ip_hosts = true`, the DNS-resolved
+        // IP check is skipped. This accommodates transparent-proxy setups where
+        // DNS returns virtual private-range IPs for external domains.
+        // Direct private-IP literals in URLs are always blocked.
+        let allow_private_ip_hosts = context
+            .network_policy
+            .as_ref()
+            .map_or(false, |p| p.allows_private_ip_hosts());
         let mut dns_pinning = None; // (hostname, validated_ip)
         if let Some(host) = &url_host {
             if host == "localhost" || host == "localhost.localdomain" {
@@ -179,6 +188,7 @@ impl ToolSpec for FetchUrlTool {
                 ));
             }
             if let Ok(ip) = host.parse::<std::net::IpAddr>() {
+                // Always block literal private-IP URLs regardless of proxy config.
                 if is_restricted_ip(&ip) {
                     return Err(ToolError::permission_denied(format!(
                         "IP {ip} is a restricted address (private/loopback/link-local)"
@@ -187,9 +197,11 @@ impl ToolSpec for FetchUrlTool {
             } else if let Ok(addrs) = tokio::net::lookup_host((&**host, 0u16)).await {
                 let mut first_valid: Option<std::net::IpAddr> = None;
                 for addr in addrs {
-                    if is_restricted_ip(&addr.ip()) {
+                    if !allow_private_ip_hosts && is_restricted_ip(&addr.ip()) {
                         return Err(ToolError::permission_denied(format!(
-                            "resolved IP {} is a restricted address (private/loopback/link-local)",
+                            "resolved IP {} is a restricted address (private/loopback/link-local); \
+                             if your DNS is managed by a transparent proxy, set \
+                             allow_private_ip_hosts = true under [network] in config.toml",
                             addr.ip()
                         )));
                     }
@@ -496,6 +508,7 @@ mod tests {
             allow: vec!["api.deepseek.com".to_string()],
             deny: vec![],
             audit: false,
+            allow_private_ip_hosts: false,
         };
         let decider = NetworkPolicyDecider::new(policy, None);
         let ctx = ToolContext::new(PathBuf::from(".")).with_network_policy(decider);

--- a/crates/tui/src/tools/web_run.rs
+++ b/crates/tui/src/tools/web_run.rs
@@ -1815,6 +1815,7 @@ mod tests {
             allow: vec!["api.deepseek.com".to_string()],
             deny: vec![],
             audit: false,
+            allow_private_ip_hosts: false,
         };
         let decider = NetworkPolicyDecider::new(policy, None);
         let ctx = ToolContext::new(PathBuf::from(".")).with_network_policy(decider);

--- a/crates/tui/tests/skill_install.rs
+++ b/crates/tui/tests/skill_install.rs
@@ -62,6 +62,7 @@ fn allow_all_policy() -> NetworkPolicy {
         allow: Vec::new(),
         deny: Vec::new(),
         audit: false,
+        allow_private_ip_hosts: false,
     }
 }
 
@@ -71,6 +72,7 @@ fn deny_all_policy() -> NetworkPolicy {
         allow: Vec::new(),
         deny: Vec::new(),
         audit: false,
+        allow_private_ip_hosts: false,
     }
 }
 
@@ -80,6 +82,7 @@ fn prompt_all_policy() -> NetworkPolicy {
         allow: Vec::new(),
         deny: Vec::new(),
         audit: false,
+        allow_private_ip_hosts: false,
     }
 }
 


### PR DESCRIPTION
## Problem

`fetch_url` unconditionally rejects requests when a hostname resolves to a private/reserved IP address. This breaks users whose DNS is managed by a transparent proxy that returns virtual private-range addresses for all external domains — every outbound request fails with `resolved IP x.x.x.x is a restricted address`, and there is no way to override it. Fixes #1071.

## Solution

Add `allow_private_ip_hosts = false` to the `[network]` config table. When set to `true`, the SSRF guard skips the check on **DNS-resolved** IPs, allowing the request to proceed through the proxy. Literal private-IP addresses typed directly into a URL (e.g. `http://10.0.0.1/admin`) are **always** blocked regardless of this setting, preserving the core SSRF protection.

The error message when a resolved IP is rejected now mentions the new option so users know how to unblock their setup.

## Changes

- `crates/tui/src/network_policy.rs` — add `allow_private_ip_hosts: bool` field to `NetworkPolicy`; expose `allows_private_ip_hosts()` on `NetworkPolicyDecider`
- `crates/tui/src/config.rs` — add `allow_private_ip_hosts` to `NetworkPolicyToml` and propagate through `into_runtime()`
- `crates/tui/src/tools/fetch_url.rs` — consult the flag before rejecting DNS-resolved private IPs; improve error message
- `config.example.toml` — document the new option
- `crates/tui/src/tools/web_run.rs`, `crates/tui/tests/skill_install.rs` — fill new field in existing `NetworkPolicy` literals

## Testing

All existing tests pass (`cargo test --package deepseek-tui`).