### PR TITLE
fix(deps): extend libc to all Unix targets for FreeBSD compatibility

### DIFF
--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -75,10 +75,7 @@ wiremock = "0.6"
 pretty_assertions = "1.4"
 vt100 = "0.15"
 
-[target.'cfg(target_os = "macos")'.dependencies]
-libc = "0.2"
-
-[target.'cfg(target_os = "linux")'.dependencies]
+[target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]


### PR DESCRIPTION
## Problem

Building `deepseek-tui` on FreeBSD fails with:

```
error[E0433]: cannot find module or crate `libc` in this scope
```

The `libc` crate was declared as a dependency only for `target_os = "macos"` and `target_os = "linux"`, so FreeBSD (and other BSDs) never get it resolved at compile time.

Closes #1143.

## Solution

Replace the two separate OS-specific entries with a single `cfg(unix)` dependency target. All existing call sites that use `libc` are already gated behind `#[cfg(unix)]` or narrower OS-specific guards (`#[cfg(target_os = "linux")]` for `prctl`/landlock, `#[cfg(target_os = "macos")]` for seatbelt), so this change is safe for macOS and Linux and fixes FreeBSD in one line.

## Changes

- `crates/tui/Cargo.toml` — merge `cfg(target_os = "macos")` + `cfg(target_os = "linux")` libc entries into a single `cfg(unix)` entry

## Testing

- Existing `cargo test --package deepseek-tui` passes on macOS/Linux (no behavioural change)
- FreeBSD users should now be able to `cargo install deepseek-tui --locked` without `libc` resolution errors