### PR TITLE
feat(tui): use distinct user message color

### DIFF
--- a/crates/tui/src/palette.rs
+++ b/crates/tui/src/palette.rs
@@ -119,6 +119,8 @@ pub const TEXT_REASONING: Color = Color::Rgb(211, 170, 112); // #D3AA70
 pub const TEXT_PRIMARY: Color = TEXT_BODY;
 pub const TEXT_MUTED: Color = TEXT_SECONDARY;
 pub const TEXT_DIM: Color = TEXT_HINT;
+pub const USER_BODY: Color = Color::Rgb(74, 222, 128); // #4ADE80 green
+pub const LIGHT_USER_BODY: Color = Color::Rgb(21, 128, 61); // #15803D green
 
 // New semantic colors for UI theming
 pub const BORDER_COLOR: Color =
@@ -349,6 +351,8 @@ pub fn adapt_fg_for_palette_mode(color: Color, _bg: Color, mode: PaletteMode) ->
         Color::Rgb(159, 18, 57)
     } else if color == DIFF_ADDED {
         Color::Rgb(22, 101, 52)
+    } else if color == USER_BODY {
+        LIGHT_USER_BODY
     } else {
         color
     }

--- a/crates/tui/src/tui/history.rs
+++ b/crates/tui/src/tui/history.rs
@@ -181,7 +181,7 @@ impl HistoryCell {
             HistoryCell::User { content } => render_message(
                 USER_GLYPH,
                 user_label_style(),
-                message_body_style(),
+                user_body_style(),
                 content,
                 width,
             ),
@@ -268,7 +268,7 @@ impl HistoryCell {
             HistoryCell::User { content } => render_message(
                 USER_GLYPH,
                 user_label_style(),
-                message_body_style(),
+                user_body_style(),
                 content,
                 width,
             ),
@@ -300,7 +300,7 @@ impl HistoryCell {
             HistoryCell::User { content } => render_message(
                 USER_GLYPH,
                 user_label_style(),
-                message_body_style(),
+                user_body_style(),
                 content,
                 width,
             ),
@@ -2636,6 +2636,10 @@ fn truncate_text(text: &str, max_len: usize) -> String {
 
 fn user_label_style() -> Style {
     Style::default().fg(palette::TEXT_MUTED)
+}
+
+fn user_body_style() -> Style {
+    Style::default().fg(palette::USER_BODY)
 }
 
 /// Style for the assistant glyph (`●`). When the cell is streaming and


### PR DESCRIPTION
## Summary
- add a dedicated user message body color for dark and light palettes
- render user transcript body text with that style instead of assistant body text
- preserves the original contributor author on the commit; based on #1154 with formatting cleanup

## Test plan
- `cargo fmt --all -- --check && git diff --check`
- `cargo test -p deepseek-tui palette --locked`
- `cargo clippy -p deepseek-tui --all-targets --all-features --locked -- -D warnings`
