### PR TITLE
fix(deps): use libc on all Unix targets

### DIFF
--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -75,10 +75,7 @@ wiremock = "0.6"
 pretty_assertions = "1.4"
 vt100 = "0.15"
 
-[target.'cfg(target_os = "macos")'.dependencies]
-libc = "0.2"
-
-[target.'cfg(target_os = "linux")'.dependencies]
+[target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]


### PR DESCRIPTION
## Summary
- broaden the `libc` dependency from macOS/Linux-only to `cfg(unix)`
- fixes FreeBSD builds where Unix-gated code references `libc`
- preserves the original contributor author on the commit; based on #1167 with CI enabled on a maintainer branch

Closes #1143

## Test plan
- `cargo check -p deepseek-tui --locked`
- `git diff --check origin/main...HEAD`
