### PR TITLE
docs: document four undocumented environment variables

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -158,6 +158,7 @@ fallbacks after saved config and keyring credentials:
 - `DEEPSEEK_PROVIDER` (`deepseek|nvidia-nim|openai|openrouter|novita|fireworks|sglang|vllm|ollama`)
 - `DEEPSEEK_MODEL` or `DEEPSEEK_DEFAULT_TEXT_MODEL`
 - `DEEPSEEK_STREAM_IDLE_TIMEOUT_SECS` (stream idle timeout in seconds; default `300`, clamped to `1..=3600`)
+- `DEEPSEEK_STREAM_OPEN_TIMEOUT_SECS` (connection setup + response-header wait in seconds; default `45`, clamped to `5..=300`; distinct from the per-chunk idle timeout)
 - `NVIDIA_API_KEY` or `NVIDIA_NIM_API_KEY` (preferred when provider is `nvidia-nim`; falls back to `DEEPSEEK_API_KEY`)
 - `NVIDIA_NIM_BASE_URL`, `NIM_BASE_URL`, or `NVIDIA_BASE_URL`
 - `NVIDIA_NIM_MODEL`
@@ -193,6 +194,9 @@ fallbacks after saved config and keyring credentials:
 - `DEEPSEEK_MAX_SUBAGENTS` (clamped to `1..=20`)
 - `DEEPSEEK_TASKS_DIR` (runtime task queue/artifact storage, default `~/.deepseek/tasks`)
 - `DEEPSEEK_ALLOW_INSECURE_HTTP` (`1`/`true` allows non-local `http://` base URLs; default is reject)
+- `DEEPSEEK_FORCE_HTTP1` (`1|true|yes|on` pins the HTTP client to HTTP/1.1, disabling HTTP/2; useful on Windows or behind proxies that mishandle long-lived H2 streams)
+- `DEEPSEEK_HOME` (override the base data directory; defaults to `~/.deepseek`)
+- `DEEPSEEK_AUTOMATIONS_DIR` (override the automations storage directory; defaults to `~/.deepseek/automations`)
 - `DEEPSEEK_CAPACITY_ENABLED`
 - `DEEPSEEK_CAPACITY_LOW_RISK_MAX`
 - `DEEPSEEK_CAPACITY_MEDIUM_RISK_MAX`


### PR DESCRIPTION
## Summary

Four environment variables are implemented and checked in the source but were absent from the public reference in `docs/CONFIGURATION.md`:

| Variable | Default | Notes |
|---|---|---|
| `DEEPSEEK_STREAM_OPEN_TIMEOUT_SECS` | `45` | Connection setup + response-header wait (clamped `5..=300`); sibling of the already-documented idle timeout |
| `DEEPSEEK_FORCE_HTTP1` | off | Pins HTTP client to HTTP/1.1; the error message in `client/chat.rs` already tells users to try this on Windows / proxy environments |
| `DEEPSEEK_HOME` | `~/.deepseek` | Overrides the base data directory |
| `DEEPSEEK_AUTOMATIONS_DIR` | `~/.deepseek/automations` | Overrides the automations storage directory |

No code changes — documentation only.

## Test plan

- [ ] Verify each variable name and description matches the source (`client/chat.rs`, `client.rs`, `cli/src/metrics.rs`, `automation_manager.rs`)