### PR TITLE
feat(config): localized hints, enum cycling, and example values in /config

### DIFF
--- a/crates/tui/src/config_ui.rs
+++ b/crates/tui/src/config_ui.rs
@@ -42,46 +42,88 @@ pub struct ConfigUiDocument {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub struct RuntimeSection {
-    #[schemars(title = "Current model")]
+    #[schemars(
+        title = "Current model",
+        description = "The model used for this session. Set to `auto` for automatic model selection based on request complexity."
+    )]
     pub model: String,
+    #[schemars(
+        description = "When tools are called, how approval is handled: auto (auto-approve), suggest (ask first), or never (deny tool use)."
+    )]
     pub approval_mode: ApprovalModeValue,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub struct SettingsSection {
+    #[schemars(
+        description = "Automatically compact long conversation context when approaching the token limit."
+    )]
     pub auto_compact: bool,
+    #[schemars(description = "Calm mode: more concise, less verbose output style.")]
     pub calm_mode: bool,
+    #[schemars(description = "Reduce terminal animations for a quieter feel.")]
     pub low_motion: bool,
+    #[schemars(description = "Enable fancy terminal animations (smooth scrolling, etc.).")]
     pub fancy_animations: bool,
+    #[schemars(
+        description = "Detect multi-line pastes to avoid accidentally submitting incomplete input."
+    )]
     pub paste_burst_detection: bool,
+    #[schemars(description = "Display the model's thinking/reasoning tokens in the transcript.")]
     pub show_thinking: bool,
+    #[schemars(description = "Show full tool-call input/output details instead of summaries.")]
     pub show_tool_details: bool,
+    #[schemars(description = "UI display language. Auto detects from the system locale.")]
     pub locale: UiLocale,
     #[schemars(
         title = "Background color",
-        description = "Main TUI background color as #RRGGBB"
+        description = "Main TUI background color as #RRGGBB hex string. Leave empty for terminal default."
     )]
     pub background_color: Option<String>,
+    #[schemars(description = "How dense the input area should be.")]
     pub composer_density: ComposerDensityValue,
+    #[schemars(description = "Draw a border around the composer input area.")]
     pub composer_border: bool,
+    #[schemars(description = "Spacing between consecutive transcript messages.")]
     pub transcript_spacing: TranscriptSpacingValue,
+    #[schemars(
+        description = "Which mode new sessions start in: Agent (autonomous with approvals), Plan (read-only investigation first), or Yolo (auto-approved)."
+    )]
     pub default_mode: DefaultModeValue,
-    #[schemars(range(min = 10, max = 50))]
+    #[schemars(
+        range(min = 10, max = 50),
+        description = "Sidebar panel width as a percentage of the terminal width."
+    )]
     pub sidebar_width: u16,
+    #[schemars(description = "Which sidebar panel to focus by default when opening.")]
     pub sidebar_focus: SidebarFocusValue,
-    #[schemars(range(min = 0))]
+    #[schemars(
+        range(min = 0),
+        description = "Maximum number of input history entries to keep. 0 means no limit."
+    )]
     pub max_history: usize,
+    #[schemars(description = "Currency used for session cost display.")]
     pub cost_currency: CostCurrencyValue,
+    #[schemars(
+        description = "Model to use for new sessions when not overridden. Leave empty for the built-in default."
+    )]
     pub default_model: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub struct ConfigSection {
+    #[schemars(description = "Filesystem path to the MCP server configuration file.")]
     pub mcp_config_path: String,
+    #[schemars(
+        description = "Model reasoning/thinking effort tier: Off (no thinking), Low, Medium, High, Auto, or Max (deepest reasoning)."
+    )]
     pub reasoning_effort: ReasoningEffortValue,
-    #[schemars(title = "Status line items")]
+    #[schemars(
+        title = "Status line items",
+        description = "Which status chips to show in the footer bar. Order is preserved."
+    )]
     pub status_items: Vec<StatusItemValue>,
 }
 

--- a/crates/tui/src/localization.rs
+++ b/crates/tui/src/localization.rs
@@ -1400,7 +1400,9 @@ fn chinese_simplified(id: MessageId) -> Option<&'static str> {
         MessageId::ConfigNoMatchesPrefix => "  没有匹配设置: ",
         MessageId::ConfigFilteredSettings => "  已筛选设置",
         MessageId::ConfigShowing => "  显示",
-        MessageId::ConfigFooterDefault => " 输入=筛选, Up/Down=选择, -/+=切换, Enter/e=编辑, Esc/q=关闭 ",
+        MessageId::ConfigFooterDefault => {
+            " 输入=筛选, Up/Down=选择, -/+=切换, Enter/e=编辑, Esc/q=关闭 "
+        }
         MessageId::ConfigFooterScrollable => {
             " 输入=筛选, Up/Down=选择, -/+=切换, Enter/e=编辑, PgUp/PgDn=滚动, Esc/q=关闭 "
         }

--- a/crates/tui/src/localization.rs
+++ b/crates/tui/src/localization.rs
@@ -375,6 +375,26 @@ pub enum MessageId {
     HomeYoloModeCaution,
     HomePlanModeTip,
     HomePlanModeChecklistTip,
+    // ── Config hint messages (displayed in /config when a row is highlighted) ──
+    ConfigHintModel,
+    ConfigHintDefaultModel,
+    ConfigHintApprovalMode,
+    ConfigHintAutoCompact,
+    ConfigHintCalmMode,
+    ConfigHintLowMotion,
+    ConfigHintShowThinking,
+    ConfigHintShowToolDetails,
+    ConfigHintTranscriptSpacing,
+    ConfigHintComposerDensity,
+    ConfigHintComposerBorder,
+    ConfigHintPasteBurst,
+    ConfigHintSidebarWidth,
+    ConfigHintSidebarFocus,
+    ConfigHintLocale,
+    ConfigHintBackgroundColor,
+    ConfigHintDefaultMode,
+    ConfigHintMaxHistory,
+    ConfigHintMcpConfigPath,
 }
 
 #[allow(dead_code)]
@@ -565,6 +585,25 @@ pub const ALL_MESSAGE_IDS: &[MessageId] = &[
     MessageId::HomeYoloModeCaution,
     MessageId::HomePlanModeTip,
     MessageId::HomePlanModeChecklistTip,
+    MessageId::ConfigHintModel,
+    MessageId::ConfigHintDefaultModel,
+    MessageId::ConfigHintApprovalMode,
+    MessageId::ConfigHintAutoCompact,
+    MessageId::ConfigHintCalmMode,
+    MessageId::ConfigHintLowMotion,
+    MessageId::ConfigHintShowThinking,
+    MessageId::ConfigHintShowToolDetails,
+    MessageId::ConfigHintTranscriptSpacing,
+    MessageId::ConfigHintComposerDensity,
+    MessageId::ConfigHintComposerBorder,
+    MessageId::ConfigHintPasteBurst,
+    MessageId::ConfigHintSidebarWidth,
+    MessageId::ConfigHintSidebarFocus,
+    MessageId::ConfigHintLocale,
+    MessageId::ConfigHintBackgroundColor,
+    MessageId::ConfigHintDefaultMode,
+    MessageId::ConfigHintMaxHistory,
+    MessageId::ConfigHintMcpConfigPath,
 ];
 
 pub fn tr(locale: Locale, id: MessageId) -> &'static str {
@@ -698,13 +737,13 @@ fn english(id: MessageId) -> &'static str {
         MessageId::ConfigFilteredSettings => "  Filtered settings",
         MessageId::ConfigShowing => "  Showing",
         MessageId::ConfigFooterDefault => {
-            " type=filter, Up/Down=select, Enter/e=edit, Esc/q=close "
+            " type=filter, Up/Down=select, -/+=cycle, Enter/e=edit, Esc/q=close "
         }
         MessageId::ConfigFooterScrollable => {
-            " type=filter, Up/Down=select, Enter/e=edit, PgUp/PgDn=scroll, Esc/q=close "
+            " type=filter, Up/Down=select, -/+=cycle, Enter/e=edit, PgUp/PgDn=scroll, Esc/q=close "
         }
         MessageId::ConfigFooterFiltered => {
-            " type=filter, Backspace=delete, Ctrl+U/Esc=clear, Enter=edit "
+            " type=filter, Backspace=delete, Ctrl+U/Esc=clear, -/+=cycle, Enter=edit "
         }
         MessageId::HelpTitle => "Help",
         MessageId::HelpFilterPlaceholder => "Type to filter",
@@ -953,6 +992,62 @@ fn english(id: MessageId) -> &'static str {
         MessageId::HomeYoloModeCaution => "  Be careful with destructive operations!",
         MessageId::HomePlanModeTip => "Plan mode - Design before implementing",
         MessageId::HomePlanModeChecklistTip => "  Use /plan to create structured checklists",
+        // ── Config hints ──
+        MessageId::ConfigHintModel => {
+            "The model used for this session. Set to \'auto\' for automatic selection based on request complexity."
+        }
+        MessageId::ConfigHintDefaultModel => {
+            "Default model for new sessions. Leave empty to use the built-in default."
+        }
+        MessageId::ConfigHintApprovalMode => {
+            "Controls tool-call approval: \'auto\' auto-approves, \'suggest\' asks first, \'never\' denies all tool use."
+        }
+        MessageId::ConfigHintAutoCompact => {
+            "Automatically compress conversation history when approaching the token limit."
+        }
+        MessageId::ConfigHintCalmMode => {
+            "Calm mode: the assistant gives shorter, more concise responses."
+        }
+        MessageId::ConfigHintLowMotion => "Reduce terminal animations for less visual noise.",
+        MessageId::ConfigHintShowThinking => {
+            "Display the model\'s internal reasoning tokens in the transcript."
+        }
+        MessageId::ConfigHintShowToolDetails => {
+            "Show full tool input/output instead of abbreviated summaries."
+        }
+        MessageId::ConfigHintTranscriptSpacing => {
+            "Vertical spacing between transcript messages: compact, comfortable, or spacious."
+        }
+        MessageId::ConfigHintComposerDensity => {
+            "Layout density of the input area: compact, comfortable, or spacious."
+        }
+        MessageId::ConfigHintComposerBorder => {
+            "Draw a visible border around the composer input area."
+        }
+        MessageId::ConfigHintPasteBurst => {
+            "Detect multi-line pastes to prevent accidentally submitting incomplete input."
+        }
+        MessageId::ConfigHintSidebarWidth => {
+            "Sidebar panel width as a percentage of terminal width (10–50)."
+        }
+        MessageId::ConfigHintSidebarFocus => {
+            "Default sidebar panel: auto, plan, todos, tasks, agents, or context."
+        }
+        MessageId::ConfigHintLocale => {
+            "UI display language. \'auto\' detects from the system locale."
+        }
+        MessageId::ConfigHintBackgroundColor => {
+            "TUI background color as #RRGGBB hex. Leave empty for terminal default."
+        }
+        MessageId::ConfigHintDefaultMode => {
+            "Default mode for new sessions: agent (autonomous with approvals), plan (plan before acting), or yolo (auto-approved)."
+        }
+        MessageId::ConfigHintMaxHistory => {
+            "Maximum number of input history entries. 0 means unlimited."
+        }
+        MessageId::ConfigHintMcpConfigPath => {
+            "Filesystem path to the MCP server configuration file."
+        }
     }
 }
 
@@ -982,13 +1077,13 @@ fn japanese(id: MessageId) -> Option<&'static str> {
         MessageId::ConfigFilteredSettings => "  絞り込み後の設定",
         MessageId::ConfigShowing => "  表示",
         MessageId::ConfigFooterDefault => {
-            " 入力=絞り込み, Up/Down=選択, Enter/e=編集, Esc/q=閉じる "
+            " 入力=絞り込み, Up/Down=選択, -/+=切替, Enter/e=編集, Esc/q=閉じる "
         }
         MessageId::ConfigFooterScrollable => {
-            " 入力=絞り込み, Up/Down=選択, Enter/e=編集, PgUp/PgDn=スクロール, Esc/q=閉じる "
+            " 入力=絞り込み, Up/Down=選択, -/+=切替, Enter/e=編集, PgUp/PgDn=スクロール, Esc/q=閉じる "
         }
         MessageId::ConfigFooterFiltered => {
-            " 入力=絞り込み, Backspace=削除, Ctrl+U/Esc=クリア, Enter=編集 "
+            " 入力=絞り込み, Backspace=削除, Ctrl+U/Esc=クリア, -/+=切替, Enter=編集 "
         }
         MessageId::HelpTitle => "ヘルプ",
         MessageId::HelpFilterPlaceholder => "入力して絞り込み",
@@ -1240,6 +1335,52 @@ fn japanese(id: MessageId) -> Option<&'static str> {
         MessageId::HomeYoloModeCaution => "  破壊的な操作には注意してください！",
         MessageId::HomePlanModeTip => "Plan モード - 実装前に設計",
         MessageId::HomePlanModeChecklistTip => "  /plan を使って構造化されたチェックリストを作成",
+        // ── 設定項目の説明 ──
+        MessageId::ConfigHintModel => {
+            "このセッションで使用するモデル。auto にするとリクエストの複雑さに応じて自動選択されます。"
+        }
+        MessageId::ConfigHintDefaultModel => {
+            "新規セッションのデフォルトモデル。空欄の場合は組み込みのデフォルトを使用。"
+        }
+        MessageId::ConfigHintApprovalMode => {
+            "ツール呼び出しの承認方法：auto 自動承認、suggest 都度確認、never ツール使用不可。"
+        }
+        MessageId::ConfigHintAutoCompact => {
+            "トークン上限に近づいたら会話履歴を自動圧縮し、コンテキスト容量を確保します。"
+        }
+        MessageId::ConfigHintCalmMode => "落ち着きモード：アシスタントの返答がより簡潔になります。",
+        MessageId::ConfigHintLowMotion => "端末アニメーションを抑え、視覚的なノイズを減らします。",
+        MessageId::ConfigHintShowThinking => {
+            "モデルの内部推論プロセス（思考トークン）を会話に表示します。"
+        }
+        MessageId::ConfigHintShowToolDetails => {
+            "ツール呼び出しの入出力を省略せずに全文表示します。"
+        }
+        MessageId::ConfigHintTranscriptSpacing => {
+            "メッセージ間の垂直スペース：compact 狭く、comfortable 標準、spacious 広く。"
+        }
+        MessageId::ConfigHintComposerDensity => {
+            "入力エリアのレイアウト密度：compact 狭く、comfortable 標準、spacious 広く。"
+        }
+        MessageId::ConfigHintComposerBorder => "入力エリアの周囲に枠線を描画します。",
+        MessageId::ConfigHintPasteBurst => {
+            "複数行の貼り付けを検出し、不完全な入力の誤送信を防ぎます。"
+        }
+        MessageId::ConfigHintSidebarWidth => {
+            "サイドバーの幅を端末幅に対するパーセンテージで指定（10～50）。"
+        }
+        MessageId::ConfigHintSidebarFocus => {
+            "デフォルトで開くサイドバーパネル：auto 自動、plan 計画、todos TODO、tasks タスク、agents サブエージェント、context コンテキスト。"
+        }
+        MessageId::ConfigHintLocale => "UI 表示言語。auto はシステムロケールから自動検出します。",
+        MessageId::ConfigHintBackgroundColor => {
+            "TUI 背景色（#RRGGBB 形式）。空欄または default で端末のデフォルトを使用。"
+        }
+        MessageId::ConfigHintDefaultMode => {
+            "新規セッションのデフォルトモード：agent 自律エージェント（承認あり）、plan 計画優先、yolo 完全自動。"
+        }
+        MessageId::ConfigHintMaxHistory => "入力履歴の最大保存数。0 は無制限。",
+        MessageId::ConfigHintMcpConfigPath => "MCP サーバー設定ファイルのファイルシステムパス。",
     })
 }
 
@@ -1259,12 +1400,12 @@ fn chinese_simplified(id: MessageId) -> Option<&'static str> {
         MessageId::ConfigNoMatchesPrefix => "  没有匹配设置: ",
         MessageId::ConfigFilteredSettings => "  已筛选设置",
         MessageId::ConfigShowing => "  显示",
-        MessageId::ConfigFooterDefault => " 输入=筛选, Up/Down=选择, Enter/e=编辑, Esc/q=关闭 ",
+        MessageId::ConfigFooterDefault => " 输入=筛选, Up/Down=选择, -/+=切换, Enter/e=编辑, Esc/q=关闭 ",
         MessageId::ConfigFooterScrollable => {
-            " 输入=筛选, Up/Down=选择, Enter/e=编辑, PgUp/PgDn=滚动, Esc/q=关闭 "
+            " 输入=筛选, Up/Down=选择, -/+=切换, Enter/e=编辑, PgUp/PgDn=滚动, Esc/q=关闭 "
         }
         MessageId::ConfigFooterFiltered => {
-            " 输入=筛选, Backspace=删除, Ctrl+U/Esc=清除, Enter=编辑 "
+            " 输入=筛选, Backspace=删除, Ctrl+U/Esc=清除, -/+=切换, Enter=编辑 "
         }
         MessageId::HelpTitle => "帮助",
         MessageId::HelpFilterPlaceholder => "输入以筛选",
@@ -1482,6 +1623,42 @@ fn chinese_simplified(id: MessageId) -> Option<&'static str> {
         MessageId::HomeYoloModeCaution => "  请小心破坏性操作！",
         MessageId::HomePlanModeTip => "Plan 模式 - 先设计再实现",
         MessageId::HomePlanModeChecklistTip => "  使用 /plan 创建结构化检查清单",
+        // ── 配置项说明 ──
+        MessageId::ConfigHintModel => {
+            "当前会话使用的模型。设为 auto 可由系统根据请求复杂度自动选择模型。"
+        }
+        MessageId::ConfigHintDefaultModel => "新会话的默认模型。留空则使用内置默认值。",
+        MessageId::ConfigHintApprovalMode => {
+            "工具调用审批策略：auto 自动批准，suggest 每次询问，never 拒绝工具调用。"
+        }
+        MessageId::ConfigHintAutoCompact => {
+            "当会话接近令牌上限时自动压缩对话历史，释放上下文空间。"
+        }
+        MessageId::ConfigHintCalmMode => "冷静模式：助手回复更简洁、直截了当。",
+        MessageId::ConfigHintLowMotion => "减少终端动画效果，降低视觉干扰。",
+        MessageId::ConfigHintShowThinking => "在对话中展示模型的内部推理过程（思考令牌）。",
+        MessageId::ConfigHintShowToolDetails => "显示工具调用的完整输入输出内容，而非缩略摘要。",
+        MessageId::ConfigHintTranscriptSpacing => {
+            "消息之间的垂直间距：compact 紧凑、comfortable 适中、spacious 宽松。"
+        }
+        MessageId::ConfigHintComposerDensity => {
+            "输入区域的布局密度：compact 紧凑、comfortable 适中、spacious 宽松。"
+        }
+        MessageId::ConfigHintComposerBorder => "是否在输入区域周围绘制可见边框。",
+        MessageId::ConfigHintPasteBurst => "检测多行粘贴，防止误触发送不完整的输入。",
+        MessageId::ConfigHintSidebarWidth => "侧边栏宽度占终端宽度的百分比（10～50）。",
+        MessageId::ConfigHintSidebarFocus => {
+            "侧边栏默认打开的面板：auto 自动、plan 计划、todos 待办、tasks 任务、agents 子代理、context 上下文。"
+        }
+        MessageId::ConfigHintLocale => "界面显示语言。auto 根据系统语言自动检测。",
+        MessageId::ConfigHintBackgroundColor => {
+            "TUI 背景色（#RRGGBB 格式）。留空或填 default 使用终端默认背景。"
+        }
+        MessageId::ConfigHintDefaultMode => {
+            "新会话的默认模式：agent 自主代理（需审批）、plan 先规划再执行、yolo 全自动。"
+        }
+        MessageId::ConfigHintMaxHistory => "输入历史的最大保存条数。0 表示不限制。",
+        MessageId::ConfigHintMcpConfigPath => "MCP 服务器配置文件的文件系统路径。",
     })
 }
 
@@ -1502,13 +1679,13 @@ fn portuguese_brazil(id: MessageId) -> Option<&'static str> {
         MessageId::ConfigFilteredSettings => "  Configurações filtradas",
         MessageId::ConfigShowing => "  Mostrando",
         MessageId::ConfigFooterDefault => {
-            " digite=filtrar, Up/Down=selecionar, Enter/e=editar, Esc/q=fechar "
+            " digite=filtrar, Up/Down=selecionar, -/+=alternar, Enter/e=editar, Esc/q=fechar "
         }
         MessageId::ConfigFooterScrollable => {
-            " digite=filtrar, Up/Down=selecionar, Enter/e=editar, PgUp/PgDn=rolar, Esc/q=fechar "
+            " digite=filtrar, Up/Down=selecionar, -/+=alternar, Enter/e=editar, PgUp/PgDn=rolar, Esc/q=fechar "
         }
         MessageId::ConfigFooterFiltered => {
-            " digite=filtrar, Backspace=apagar, Ctrl+U/Esc=limpar, Enter=editar "
+            " digite=filtrar, Backspace=apagar, Ctrl+U/Esc=limpar, -/+=alternar, Enter=editar "
         }
         MessageId::HelpTitle => "Ajuda",
         MessageId::HelpFilterPlaceholder => "Digite para filtrar",
@@ -1782,6 +1959,62 @@ fn portuguese_brazil(id: MessageId) -> Option<&'static str> {
         MessageId::HomeYoloModeCaution => "  Tenha cuidado com operações destrutivas!",
         MessageId::HomePlanModeTip => "Modo Plan - Planeje antes de implementar",
         MessageId::HomePlanModeChecklistTip => "  Use /plan para criar checklists estruturados",
+        // ── Dicas de configuração ──
+        MessageId::ConfigHintModel => {
+            "Modelo usado nesta sessão. Use \'auto\' para seleção automática (Pro ou Flash) conforme a complexidade."
+        }
+        MessageId::ConfigHintDefaultModel => {
+            "Modelo padrão para novas sessões. Deixe vazio para usar o padrão do sistema."
+        }
+        MessageId::ConfigHintApprovalMode => {
+            "Controle de aprovação de ferramentas: \'auto\' aprova tudo, \'suggest\' pergunta, \'never\' recusa."
+        }
+        MessageId::ConfigHintAutoCompact => {
+            "Compacta automaticamente o histórico ao se aproximar do limite de tokens."
+        }
+        MessageId::ConfigHintCalmMode => {
+            "Modo calmo: respostas mais curtas e diretas do assistente."
+        }
+        MessageId::ConfigHintLowMotion => "Reduz animações do terminal para menos ruído visual.",
+        MessageId::ConfigHintShowThinking => {
+            "Exibe os tokens de raciocínio interno do modelo na transcrição."
+        }
+        MessageId::ConfigHintShowToolDetails => {
+            "Mostra a entrada/saída completa das ferramentas em vez de resumos."
+        }
+        MessageId::ConfigHintTranscriptSpacing => {
+            "Espaçamento vertical entre mensagens: compact, comfortable ou spacious."
+        }
+        MessageId::ConfigHintComposerDensity => {
+            "Densidade do layout da área de entrada: compact, comfortable ou spacious."
+        }
+        MessageId::ConfigHintComposerBorder => {
+            "Desenha uma borda visível ao redor da área de entrada."
+        }
+        MessageId::ConfigHintPasteBurst => {
+            "Detecta colagens multilinha para evitar envios acidentais de entrada incompleta."
+        }
+        MessageId::ConfigHintSidebarWidth => {
+            "Largura do painel lateral em porcentagem da largura do terminal (10–50)."
+        }
+        MessageId::ConfigHintSidebarFocus => {
+            "Painel lateral padrão: auto, plan, todos, tasks, agents ou context."
+        }
+        MessageId::ConfigHintLocale => {
+            "Idioma da interface. \'auto\' detecta pelo locale do sistema."
+        }
+        MessageId::ConfigHintBackgroundColor => {
+            "Cor de fundo do TUI em #RRGGBB. Deixe vazio para o padrão do terminal."
+        }
+        MessageId::ConfigHintDefaultMode => {
+            "Modo padrão para novas sessões: agent (autônomo com aprovações), plan (planejar antes) ou yolo (automático)."
+        }
+        MessageId::ConfigHintMaxHistory => {
+            "Número máximo de entradas no histórico. 0 significa ilimitado."
+        }
+        MessageId::ConfigHintMcpConfigPath => {
+            "Caminho no sistema de arquivos para o arquivo de configuração do servidor MCP."
+        }
     })
 }
 

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -5637,9 +5637,7 @@ async fn handle_view_events(
                     // Refresh rows in-place instead of rebuilding the view,
                     // so the selected index stays put.
                     if let Some(mut boxed) = app.view_stack.pop() {
-                        if let Some(config_view) =
-                            boxed.as_any_mut().downcast_mut::<ConfigView>()
-                        {
+                        if let Some(config_view) = boxed.as_any_mut().downcast_mut::<ConfigView>() {
                             config_view.refresh_rows(app);
                         }
                         app.view_stack.push_boxed(boxed);

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -5634,8 +5634,16 @@ async fn handle_view_events(
                 }
 
                 if app.view_stack.top_kind() == Some(ModalKind::Config) {
-                    app.view_stack.pop();
-                    app.view_stack.push(ConfigView::new_for_app(app));
+                    // Refresh rows in-place instead of rebuilding the view,
+                    // so the selected index stays put.
+                    if let Some(mut boxed) = app.view_stack.pop() {
+                        if let Some(config_view) =
+                            boxed.as_any_mut().downcast_mut::<ConfigView>()
+                        {
+                            config_view.refresh_rows(app);
+                        }
+                        app.view_stack.push_boxed(boxed);
+                    }
                 }
             }
             ViewEvent::StatusItemsUpdated { items, final_save } => {

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -542,6 +542,10 @@ struct ConfigEdit {
     cursor: usize,
     select_all: bool,
     scope: ConfigScope,
+    /// Set to true once the user manually edits the buffer; -/+/= cycling
+    /// is disabled when dirty so values containing hyphens (e.g. zh-Hans)
+    /// can be typed normally.
+    dirty: bool,
 }
 
 pub struct ConfigView {
@@ -864,7 +868,7 @@ impl ConfigView {
                 if self
                     .editing
                     .as_ref()
-                    .is_some_and(|e| config_enum_values(&e.key).is_some()) =>
+                    .is_some_and(|e| config_enum_values(&e.key).is_some() && !e.dirty) =>
             {
                 if let Some(edit) = self.editing.as_mut() {
                     if let Some(values) = config_enum_values(&edit.key) {
@@ -899,6 +903,7 @@ impl ConfigView {
             }
             KeyCode::Backspace => {
                 if let Some(edit) = self.editing.as_mut() {
+                    edit.dirty = true;
                     if edit.select_all {
                         edit.buffer.clear();
                         edit.cursor = 0;
@@ -912,6 +917,7 @@ impl ConfigView {
             }
             KeyCode::Delete => {
                 if let Some(edit) = self.editing.as_mut() {
+                    edit.dirty = true;
                     if edit.select_all {
                         edit.buffer.clear();
                         edit.cursor = 0;
@@ -924,6 +930,7 @@ impl ConfigView {
             }
             KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                 if let Some(edit) = self.editing.as_mut() {
+                    edit.dirty = true;
                     edit.buffer.clear();
                     edit.cursor = 0;
                     edit.select_all = false;
@@ -977,6 +984,7 @@ impl ConfigView {
                 if !key.modifiers.contains(KeyModifiers::CONTROL) && !ch.is_control() =>
             {
                 if let Some(edit) = self.editing.as_mut() {
+                    edit.dirty = true;
                     if edit.select_all {
                         edit.buffer.clear();
                         edit.cursor = 0;
@@ -1014,6 +1022,7 @@ impl ConfigView {
             buffer,
             select_all: true,
             scope: row.scope,
+            dirty: false,
         });
         self.status = None;
     }

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -871,22 +871,22 @@ impl ConfigView {
                     .as_ref()
                     .is_some_and(|e| config_enum_values(&e.key).is_some() && !e.dirty) =>
             {
-                if let Some(edit) = self.editing.as_mut() {
-                    if let Some(values) = config_enum_values(&edit.key) {
-                        let current: String = edit.buffer.iter().collect();
-                        let pos = values
-                            .iter()
-                            .position(|v| v.eq_ignore_ascii_case(&current))
-                            .unwrap_or(0);
-                        let next = if key.code == KeyCode::Char('-') {
-                            pos.wrapping_sub(1).rem_euclid(values.len())
-                        } else {
-                            (pos + 1) % values.len()
-                        };
-                        edit.buffer = values[next].chars().collect();
-                        edit.cursor = edit.buffer.len();
-                        edit.select_all = false;
-                    }
+                if let Some(edit) = self.editing.as_mut()
+                    && let Some(values) = config_enum_values(&edit.key)
+                {
+                    let current: String = edit.buffer.iter().collect();
+                    let pos = values
+                        .iter()
+                        .position(|v| v.eq_ignore_ascii_case(&current))
+                        .unwrap_or(0);
+                    let next = if key.code == KeyCode::Char('-') {
+                        pos.wrapping_sub(1).rem_euclid(values.len())
+                    } else {
+                        (pos + 1) % values.len()
+                    };
+                    edit.buffer = values[next].chars().collect();
+                    edit.cursor = edit.buffer.len();
+                    edit.select_all = false;
                 }
                 ViewAction::None
             }

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -860,6 +860,31 @@ impl ConfigView {
                 self.status = Some("Edit cancelled".to_string());
                 ViewAction::None
             }
+            KeyCode::Char('-') | KeyCode::Char('+') | KeyCode::Char('=')
+                if self
+                    .editing
+                    .as_ref()
+                    .is_some_and(|e| config_enum_values(&e.key).is_some()) =>
+            {
+                if let Some(edit) = self.editing.as_mut() {
+                    if let Some(values) = config_enum_values(&edit.key) {
+                        let current: String = edit.buffer.iter().collect();
+                        let pos = values
+                            .iter()
+                            .position(|v| v.eq_ignore_ascii_case(&current))
+                            .unwrap_or(0);
+                        let next = if key.code == KeyCode::Char('-') {
+                            pos.wrapping_sub(1) % values.len()
+                        } else {
+                            (pos + 1) % values.len()
+                        };
+                        edit.buffer = values[next].chars().collect();
+                        edit.cursor = edit.buffer.len();
+                        edit.select_all = false;
+                    }
+                }
+                ViewAction::None
+            }
             KeyCode::Enter => {
                 let Some(edit) = self.editing.take() else {
                     return ViewAction::None;
@@ -1000,28 +1025,112 @@ impl ConfigView {
 
         self.update_filter(|filter| filter.clear());
     }
+
+    /// Refresh row values from the current app/settings state without
+    /// resetting the selected index. Called by the ConfigUpdated handler
+    /// so the list stays in place while reflecting the latest values.
+    pub fn refresh_rows(&mut self, app: &App) {
+        let settings = Settings::load().unwrap_or_else(|_| Settings::default());
+        for row in &mut self.rows {
+            match row.key.as_str() {
+                "model" => row.value = app.model.clone(),
+                "default_model" => {
+                    row.value = settings
+                        .default_model
+                        .as_deref()
+                        .unwrap_or("(default)")
+                        .to_string();
+                }
+                "approval_mode" => row.value = app.approval_mode.label().to_string(),
+                "default_mode" => row.value = settings.default_mode.clone(),
+                "locale" => row.value = settings.locale.clone(),
+                "background_color" => {
+                    row.value = settings
+                        .background_color
+                        .clone()
+                        .unwrap_or_else(|| "(default)".to_string());
+                }
+                "calm_mode" => row.value = settings.calm_mode.to_string(),
+                "low_motion" => row.value = settings.low_motion.to_string(),
+                "show_thinking" => row.value = settings.show_thinking.to_string(),
+                "show_tool_details" => row.value = settings.show_tool_details.to_string(),
+                "transcript_spacing" => row.value = settings.transcript_spacing.clone(),
+                "composer_density" => row.value = settings.composer_density.clone(),
+                "composer_border" => row.value = settings.composer_border.to_string(),
+                "paste_burst_detection" => {
+                    row.value = settings.paste_burst_detection.to_string();
+                }
+                "sidebar_width" => row.value = settings.sidebar_width_percent.to_string(),
+                "sidebar_focus" => row.value = settings.sidebar_focus.clone(),
+                "auto_compact" => row.value = settings.auto_compact.to_string(),
+                "max_history" => row.value = settings.max_input_history.to_string(),
+                "mcp_config_path" => {
+                    row.value = app.mcp_config_path.display().to_string();
+                }
+                _ => {}
+            }
+        }
+    }
 }
 
-fn config_hint_for_key(key: &str) -> &'static str {
+fn config_hint_for_key(locale: crate::localization::Locale, key: &str) -> &'static str {
+    use crate::localization::{MessageId, tr};
+    let id = match key {
+        "model" => MessageId::ConfigHintModel,
+        "default_model" => MessageId::ConfigHintDefaultModel,
+        "approval_mode" => MessageId::ConfigHintApprovalMode,
+        "auto_compact" => MessageId::ConfigHintAutoCompact,
+        "calm_mode" => MessageId::ConfigHintCalmMode,
+        "low_motion" => MessageId::ConfigHintLowMotion,
+        "show_thinking" => MessageId::ConfigHintShowThinking,
+        "show_tool_details" => MessageId::ConfigHintShowToolDetails,
+        "transcript_spacing" => MessageId::ConfigHintTranscriptSpacing,
+        "composer_density" => MessageId::ConfigHintComposerDensity,
+        "composer_border" => MessageId::ConfigHintComposerBorder,
+        "paste_burst_detection" => MessageId::ConfigHintPasteBurst,
+        "sidebar_width" => MessageId::ConfigHintSidebarWidth,
+        "sidebar_focus" => MessageId::ConfigHintSidebarFocus,
+        "locale" => MessageId::ConfigHintLocale,
+        "background_color" => MessageId::ConfigHintBackgroundColor,
+        "default_mode" => MessageId::ConfigHintDefaultMode,
+        "max_history" => MessageId::ConfigHintMaxHistory,
+        "mcp_config_path" => MessageId::ConfigHintMcpConfigPath,
+        _ => return "",
+    };
+    tr(locale, id)
+}
+
+/// Valid values for settings that accept a fixed set of options.
+/// Returns `None` for free-text settings.
+fn config_enum_values(key: &str) -> Option<&[&str]> {
     match key {
-        "model" => "deepseek-v4-pro | deepseek-v4-flash | deepseek-*",
-        "approval_mode" => "auto | suggest | never",
+        "approval_mode" => Some(&["auto", "suggest", "never"]),
+        "default_mode" => Some(&["agent", "plan", "yolo"]),
+        "locale" => Some(&["auto", "en", "ja", "zh-Hans", "pt-BR"]),
+        "composer_density" | "transcript_spacing" => {
+            Some(&["compact", "comfortable", "spacious"])
+        }
+        "sidebar_focus" => Some(&["auto", "plan", "todos", "tasks", "agents", "context"]),
         "auto_compact"
         | "calm_mode"
         | "low_motion"
         | "show_thinking"
         | "show_tool_details"
         | "composer_border"
-        | "paste_burst_detection" => "on/off, true/false, yes/no, 1/0",
-        "composer_density" | "transcript_spacing" => "compact | comfortable | spacious",
-        "locale" => "auto | en | ja | zh-Hans | pt-BR",
-        "background_color" => "#RRGGBB | default",
-        "default_mode" => "agent | plan | yolo",
-        "sidebar_width" => "10..=50",
-        "sidebar_focus" => "auto | plan | todos | tasks | agents",
-        "max_history" => "integer (0 allowed)",
-        "default_model" => "deepseek-v4-pro | deepseek-v4-flash | deepseek-* | none/default",
-        "mcp_config_path" => "path to mcp.json",
+        | "paste_burst_detection" => Some(&["true", "false"]),
+        _ => None,
+    }
+}
+
+/// A short example value for free-text settings, shown in the edit UI.
+fn config_example_value(key: &str) -> &str {
+    match key {
+        "model" => "deepseek-v4-pro",
+        "default_model" => "deepseek-v4-flash",
+        "background_color" => "#1A1B26",
+        "sidebar_width" => "20",
+        "max_history" => "1000",
+        "mcp_config_path" => "~/.deepseek/mcp.json",
         _ => "",
     }
 }
@@ -1118,6 +1227,36 @@ impl ModalView for ConfigView {
             }
             KeyCode::PageDown => {
                 self.move_selection(5);
+                ViewAction::None
+            }
+            KeyCode::Char('-') | KeyCode::Char('+') | KeyCode::Char('=')
+                if self.filter.is_empty() =>
+            {
+                if let Some(row_idx) = self.selected_row_index() {
+                    let row = &self.rows[row_idx];
+                    if let Some(values) = config_enum_values(&row.key) {
+                        let current = &row.value;
+                        let pos = values
+                            .iter()
+                            .position(|v| v.eq_ignore_ascii_case(current))
+                            .unwrap_or(0);
+                        let next = if key.code == KeyCode::Char('-') {
+                            pos.wrapping_sub(1) % values.len()
+                        } else {
+                            (pos + 1) % values.len()
+                        };
+                        let new_value = values[next].to_string();
+                        self.status = Some(format!(
+                            "{}: {} \u{2192} {}",
+                            row.key, current, new_value
+                        ));
+                        return ViewAction::Emit(ViewEvent::ConfigUpdated {
+                            key: row.key.clone(),
+                            value: new_value,
+                            persist: row.scope.persist(),
+                        });
+                    }
+                }
                 ViewAction::None
             }
             KeyCode::Backspace => {
@@ -1228,12 +1367,21 @@ impl ModalView for ConfigView {
             lines.push(Line::from(""));
             lines.push(render_config_editor_value_line(edit));
             lines.push(Line::from(""));
-            let hint = config_hint_for_key(&edit.key);
+            let hint = config_hint_for_key(self.locale, &edit.key);
             if !hint.is_empty() {
                 lines.push(Line::from(vec![
                     Span::styled("Hint: ", Style::default().fg(palette::TEXT_MUTED)),
                     Span::raw(hint),
                 ]));
+            }
+            if config_enum_values(&edit.key).is_none() {
+                let example = config_example_value(&edit.key);
+                if !example.is_empty() {
+                    lines.push(Line::from(vec![
+                        Span::styled("Example: ", Style::default().fg(palette::TEXT_MUTED)),
+                        Span::styled(example, Style::default().fg(palette::TEXT_DIM)),
+                    ]));
+                }
             }
             (
                 lines,
@@ -1243,7 +1391,7 @@ impl ModalView for ConfigView {
         } else {
             let content_height = usize::from(inner.height);
             let header_lines = 5usize;
-            let bottom_lines = 1usize;
+            let bottom_lines = 2usize; // +1 for the hint line
             let visible_rows = content_height
                 .saturating_sub(header_lines + bottom_lines)
                 .max(1);
@@ -1315,6 +1463,35 @@ impl ModalView for ConfigView {
                 }
             }
             *self.last_row_hitboxes.borrow_mut() = row_hitboxes;
+
+            // Show hint for the currently highlighted row
+            let hint = self
+                .rows
+                .get(self.selected)
+                .map(|row| config_hint_for_key(self.locale, &row.key))
+                .unwrap_or("");
+            if !hint.is_empty() {
+                let is_enum = self
+                    .rows
+                    .get(self.selected)
+                    .is_some_and(|row| config_enum_values(&row.key).is_some());
+                let mut spans = vec![
+                    Span::styled("  Hint: ", Style::default().fg(palette::TEXT_MUTED)),
+                    Span::styled(hint, Style::default().fg(palette::DEEPSEEK_SKY)),
+                ];
+                if is_enum {
+                    spans.push(Span::styled(
+                        "  [−/+]",
+                        Style::default().fg(palette::DEEPSEEK_SKY).add_modifier(ratatui::style::Modifier::BOLD),
+                    ));
+                }
+                lines.push(Line::from(spans));
+            } else {
+                lines.push(Line::from(vec![Span::styled(
+                    "  Hint: —",
+                    Style::default().fg(palette::TEXT_MUTED),
+                )]));
+            }
 
             if items.is_empty() {
                 let message = if self.filter.is_empty() {

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -878,7 +878,7 @@ impl ConfigView {
                             .position(|v| v.eq_ignore_ascii_case(&current))
                             .unwrap_or(0);
                         let next = if key.code == KeyCode::Char('-') {
-                            pos.wrapping_sub(1) % values.len()
+                            pos.wrapping_sub(1).rem_euclid(values.len())
                         } else {
                             (pos + 1) % values.len()
                         };
@@ -1250,7 +1250,7 @@ impl ModalView for ConfigView {
                             .position(|v| v.eq_ignore_ascii_case(current))
                             .unwrap_or(0);
                         let next = if key.code == KeyCode::Char('-') {
-                            pos.wrapping_sub(1) % values.len()
+                            pos.wrapping_sub(1).rem_euclid(values.len())
                         } else {
                             (pos + 1) % values.len()
                         };

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -1117,9 +1117,7 @@ fn config_enum_values(key: &str) -> Option<&[&str]> {
         "approval_mode" => Some(&["auto", "suggest", "never"]),
         "default_mode" => Some(&["agent", "plan", "yolo"]),
         "locale" => Some(&["auto", "en", "ja", "zh-Hans", "pt-BR"]),
-        "composer_density" | "transcript_spacing" => {
-            Some(&["compact", "comfortable", "spacious"])
-        }
+        "composer_density" | "transcript_spacing" => Some(&["compact", "comfortable", "spacious"]),
         "sidebar_focus" => Some(&["auto", "plan", "todos", "tasks", "agents", "context"]),
         "auto_compact"
         | "calm_mode"
@@ -1256,10 +1254,8 @@ impl ModalView for ConfigView {
                             (pos + 1) % values.len()
                         };
                         let new_value = values[next].to_string();
-                        self.status = Some(format!(
-                            "{}: {} \u{2192} {}",
-                            row.key, current, new_value
-                        ));
+                        self.status =
+                            Some(format!("{}: {} \u{2192} {}", row.key, current, new_value));
                         return ViewAction::Emit(ViewEvent::ConfigUpdated {
                             key: row.key.clone(),
                             value: new_value,
@@ -1516,7 +1512,9 @@ impl ModalView for ConfigView {
                         if i == wrapped.len() - 1 && !suffix.is_empty() {
                             spans.push(Span::styled(
                                 suffix,
-                                Style::default().fg(palette::DEEPSEEK_SKY).add_modifier(ratatui::style::Modifier::BOLD),
+                                Style::default()
+                                    .fg(palette::DEEPSEEK_SKY)
+                                    .add_modifier(ratatui::style::Modifier::BOLD),
                             ));
                         }
                         lines.push(Line::from(spans));
@@ -1529,7 +1527,9 @@ impl ModalView for ConfigView {
                     if !suffix.is_empty() {
                         spans.push(Span::styled(
                             suffix,
-                            Style::default().fg(palette::DEEPSEEK_SKY).add_modifier(ratatui::style::Modifier::BOLD),
+                            Style::default()
+                                .fg(palette::DEEPSEEK_SKY)
+                                .add_modifier(ratatui::style::Modifier::BOLD),
                         ));
                     }
                     lines.push(Line::from(spans));

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -12,6 +12,7 @@ use crate::tui::app::App;
 use crate::tui::approval::{ElevationOption, ReviewDecision};
 use crate::tui::history::{HistoryCell, SubAgentCell, summarize_tool_output};
 use crate::tui::widgets::agent_card::AgentLifecycle;
+use unicode_width::UnicodeWidthStr;
 
 pub mod status_picker;
 
@@ -1378,10 +1379,25 @@ impl ModalView for ConfigView {
             lines.push(Line::from(""));
             let hint = config_hint_for_key(self.locale, &edit.key);
             if !hint.is_empty() {
-                lines.push(Line::from(vec![
-                    Span::styled("Hint: ", Style::default().fg(palette::TEXT_MUTED)),
-                    Span::raw(hint),
-                ]));
+                let label = "Hint: ";
+                let indent = "      ";
+                let available = inner.width as usize;
+                let wrap_width = available.saturating_sub(indent.width());
+                if wrap_width > 0 {
+                    let wrapped = wrap_text(hint, wrap_width);
+                    for (i, chunk) in wrapped.iter().enumerate() {
+                        let prefix = if i == 0 { label } else { indent };
+                        lines.push(Line::from(vec![
+                            Span::styled(prefix, Style::default().fg(palette::TEXT_MUTED)),
+                            Span::raw(chunk.clone()),
+                        ]));
+                    }
+                } else {
+                    lines.push(Line::from(vec![
+                        Span::styled(label, Style::default().fg(palette::TEXT_MUTED)),
+                        Span::raw(hint),
+                    ]));
+                }
             }
             if config_enum_values(&edit.key).is_none() {
                 let example = config_example_value(&edit.key);
@@ -1484,17 +1500,40 @@ impl ModalView for ConfigView {
                     .rows
                     .get(self.selected)
                     .is_some_and(|row| config_enum_values(&row.key).is_some());
-                let mut spans = vec![
-                    Span::styled("  Hint: ", Style::default().fg(palette::TEXT_MUTED)),
-                    Span::styled(hint, Style::default().fg(palette::DEEPSEEK_SKY)),
-                ];
-                if is_enum {
-                    spans.push(Span::styled(
-                        "  [−/+]",
-                        Style::default().fg(palette::DEEPSEEK_SKY).add_modifier(ratatui::style::Modifier::BOLD),
-                    ));
+                let label = "  Hint: ";
+                let indent = "         ";
+                let suffix = if is_enum { "  [−/+]" } else { "" };
+                let available = inner.width as usize;
+                let wrap_width = available.saturating_sub(indent.width());
+                if wrap_width > 0 {
+                    let wrapped = wrap_text(hint, wrap_width);
+                    for (i, chunk) in wrapped.iter().enumerate() {
+                        let prefix = if i == 0 { label } else { indent };
+                        let mut spans = vec![
+                            Span::styled(prefix, Style::default().fg(palette::TEXT_MUTED)),
+                            Span::styled(chunk.clone(), Style::default().fg(palette::DEEPSEEK_SKY)),
+                        ];
+                        if i == wrapped.len() - 1 && !suffix.is_empty() {
+                            spans.push(Span::styled(
+                                suffix,
+                                Style::default().fg(palette::DEEPSEEK_SKY).add_modifier(ratatui::style::Modifier::BOLD),
+                            ));
+                        }
+                        lines.push(Line::from(spans));
+                    }
+                } else {
+                    let mut spans = vec![
+                        Span::styled(label, Style::default().fg(palette::TEXT_MUTED)),
+                        Span::styled(hint, Style::default().fg(palette::DEEPSEEK_SKY)),
+                    ];
+                    if !suffix.is_empty() {
+                        spans.push(Span::styled(
+                            suffix,
+                            Style::default().fg(palette::DEEPSEEK_SKY).add_modifier(ratatui::style::Modifier::BOLD),
+                        ));
+                    }
+                    lines.push(Line::from(spans));
                 }
-                lines.push(Line::from(spans));
             } else {
                 lines.push(Line::from(vec![Span::styled(
                     "  Hint: —",
@@ -2034,6 +2073,46 @@ fn truncate_view_text(text: &str, max_chars: usize) -> String {
         Some((idx, _)) => text[..idx].to_string(),
         None => text.to_string(),
     }
+}
+
+/// Word-wrap text to fit within `max_width` display columns.
+/// Splits on whitespace boundaries using unicode_width for CJK support.
+fn wrap_text(text: &str, max_width: usize) -> Vec<String> {
+    if max_width == 0 {
+        return vec![text.to_string()];
+    }
+    let mut lines = Vec::new();
+    let mut current = String::new();
+    let mut current_width = 0usize;
+
+    for word in text.split_whitespace() {
+        let word_width = word.width();
+        let additional = if current.is_empty() {
+            word_width
+        } else {
+            word_width + 1
+        };
+        if current_width + additional > max_width && !current.is_empty() {
+            lines.push(current);
+            current = word.to_string();
+            current_width = word_width;
+        } else {
+            if !current.is_empty() {
+                current.push(' ');
+                current_width += 1;
+            }
+            current.push_str(word);
+            current_width += word_width;
+        }
+    }
+
+    if current.is_empty() {
+        lines.push(String::new());
+    } else {
+        lines.push(current);
+    }
+
+    lines
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Use <kbd>-</kbd> or <kbd>+</kbd> to cycling enum values in `/config`

- Highlighted rows show localized hint describing each setting's function (zh-Hans/en/ja/pt-BR)
- Enum settings (approval_mode, locale, etc.) can be cycled with -/+/= in both list and edit modes
- Free-text settings show example values in edit mode (model, mcp_config_path, etc.)
- ConfigUpdated handler now updates rows in-place (preserves selection index)
- Footer updated with -/+=cycle hint in all 4 locales
- schemaui descriptions localized with functional explanations

## Testing

- [ ] `cargo test --all-features`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [x] Verified TUI behavior manually if UI changes
