### PR TITLE
feat(execpolicy): add typed permission rules and config schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           sudo apt-get install -y libdbus-1-dev pkg-config
       - uses: Swatinem/rust-cache@v2
         with:
-          cache-bin: false
+          cache-bin: "false"
       - name: Check formatting
         run: cargo fmt --all -- --check
       # Mirror the release-workflow `parity` gate exactly. Anything that
@@ -86,7 +86,7 @@ jobs:
           sudo apt-get install -y libdbus-1-dev pkg-config
       - uses: Swatinem/rust-cache@v2
         with:
-          cache-bin: false
+          cache-bin: "false"
       - name: Run tests
         run: cargo test --workspace --all-features --locked
       - name: Lockfile drift guard
@@ -118,7 +118,7 @@ jobs:
           node-version: 20
       - uses: Swatinem/rust-cache@v2
         with:
-          cache-bin: false
+          cache-bin: "false"
       - name: Build wrapper binaries
         run: cargo build --release --locked -p deepseek-tui-cli -p deepseek-tui
       - name: Smoke wrapper install and delegated entrypoints
@@ -143,7 +143,7 @@ jobs:
           sudo apt-get install -y libdbus-1-dev pkg-config
       - uses: Swatinem/rust-cache@v2
         with:
-          cache-bin: false
+          cache-bin: "false"
       - name: Build docs
         run: cargo doc --workspace --no-deps
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1225,6 +1225,7 @@ version = "0.8.40"
 dependencies = [
  "anyhow",
  "deepseek-protocol",
+ "globset",
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1193,6 +1193,7 @@ name = "deepseek-config"
 version = "0.8.40"
 dependencies = [
  "anyhow",
+ "deepseek-execpolicy",
  "deepseek-secrets",
  "dirs",
  "serde",

--- a/config.example.toml
+++ b/config.example.toml
@@ -141,6 +141,21 @@ sandbox_mode = "workspace-write" # read-only | workspace-write | danger-full-acc
 #   auto_allow = ["cargo check", "npm run"]
 #
 # auto_allow = []
+# auto_deny = ["rm -rf"]
+#
+# Typed persistent permission rules. These are intentionally conservative:
+# shell commands use the same arity-aware matching as auto_allow, and file
+# paths are workspace-relative globs.
+#
+# [[permissions.rules]]
+# tool = "exec_shell"
+# decision = "allow" # "allow", "deny", or "ask"
+# command = "cargo test"
+#
+# [[permissions.rules]]
+# tool = "file_edit"
+# decision = "ask"
+# path = "src/**"
 max_subagents = 10 # optional (1-20)
 
 # Optional sub-agent tuning. max_concurrent overrides top-level max_subagents.

--- a/crates/app-server/src/lib.rs
+++ b/crates/app-server/src/lib.rs
@@ -9,7 +9,6 @@ use axum::{Json, Router};
 use deepseek_agent::ModelRegistry;
 use deepseek_config::{CliRuntimeOverrides, ConfigStore};
 use deepseek_core::Runtime;
-use deepseek_execpolicy::ExecPolicyEngine;
 use deepseek_hooks::{HookDispatcher, JsonlHookSink, StdoutHookSink};
 use deepseek_mcp::McpManager;
 use deepseek_protocol::{
@@ -285,7 +284,7 @@ fn build_state(config_path: Option<PathBuf>) -> Result<AppState> {
         state_store,
         Arc::new(ToolRegistry::default()),
         Arc::new(McpManager::default()),
-        ExecPolicyEngine::new(Vec::new(), Vec::new()),
+        config.exec_policy_engine(),
         hooks,
     );
 

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -8,6 +8,7 @@ description = "Config schema and precedence model for DeepSeek workspace archite
 
 [dependencies]
 anyhow.workspace = true
+deepseek-execpolicy = { path = "../execpolicy", version = "0.8.40" }
 deepseek-secrets = { path = "../secrets", version = "0.8.40" }
 dirs.workspace = true
 serde.workspace = true

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -6,6 +6,8 @@ use std::path::{Component, Path, PathBuf};
 use std::sync::OnceLock;
 
 use anyhow::{Context, Result, bail};
+use deepseek_execpolicy::{ExecPolicyEngine, Ruleset};
+pub use deepseek_execpolicy::{PermissionDecision, ToolPermissionRule};
 use deepseek_secrets::SecretSource;
 pub use deepseek_secrets::Secrets;
 use serde::{Deserialize, Serialize};
@@ -182,6 +184,19 @@ impl ProvidersToml {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct PermissionsToml {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub rules: Vec<ToolPermissionRule>,
+}
+
+impl PermissionsToml {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.rules.is_empty()
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ConfigToml {
     /// TUI-compatible DeepSeek API key. Kept at the root so both `deepseek`
@@ -205,6 +220,16 @@ pub struct ConfigToml {
     pub telemetry: Option<bool>,
     pub approval_policy: Option<String>,
     pub sandbox_mode: Option<String>,
+    /// Legacy command allow-list. Entries become `exec_shell` allow rules.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub auto_allow: Vec<String>,
+    /// Legacy command deny-list. Entries become `exec_shell` deny rules.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub auto_deny: Vec<String>,
+    /// Typed tool permission rules. First version supports tool name, command
+    /// prefix, and workspace-relative path glob matching.
+    #[serde(default, skip_serializing_if = "PermissionsToml::is_empty")]
+    pub permissions: PermissionsToml,
     #[serde(default)]
     pub providers: ProvidersToml,
     /// Per-domain network policy (#135). When absent, network tools fall back
@@ -371,6 +396,15 @@ impl ConfigToml {
         if project.sandbox_mode.is_some() {
             self.sandbox_mode = project.sandbox_mode;
         }
+        if !project.auto_allow.is_empty() {
+            self.auto_allow = project.auto_allow;
+        }
+        if !project.auto_deny.is_empty() {
+            self.auto_deny = project.auto_deny;
+        }
+        if !project.permissions.is_empty() {
+            self.permissions = project.permissions;
+        }
         // Provider is only overridden if explicitly set (non-default).
         if project.provider != ProviderKind::Deepseek || has_api_key {
             self.provider = project.provider;
@@ -419,6 +453,17 @@ impl ConfigToml {
     }
 
     #[must_use]
+    pub fn permission_ruleset(&self) -> Ruleset {
+        Ruleset::user(self.auto_allow.clone(), self.auto_deny.clone())
+            .with_rules(self.permissions.rules.clone())
+    }
+
+    #[must_use]
+    pub fn exec_policy_engine(&self) -> ExecPolicyEngine {
+        ExecPolicyEngine::with_rulesets(vec![self.permission_ruleset()])
+    }
+
+    #[must_use]
     pub fn get_value(&self, key: &str) -> Option<String> {
         match key {
             "provider" => Some(self.provider.as_str().to_string()),
@@ -435,6 +480,8 @@ impl ConfigToml {
             "telemetry" => self.telemetry.map(|v| v.to_string()),
             "approval_policy" => self.approval_policy.clone(),
             "sandbox_mode" => self.sandbox_mode.clone(),
+            "auto_allow" => serialize_string_list(&self.auto_allow),
+            "auto_deny" => serialize_string_list(&self.auto_deny),
             "providers.deepseek.api_key" => self.providers.deepseek.api_key.clone(),
             "providers.deepseek.base_url" => self.providers.deepseek.base_url.clone(),
             "providers.deepseek.model" => self.providers.deepseek.model.clone(),
@@ -1507,6 +1554,13 @@ fn serialize_http_headers(headers: &BTreeMap<String, String>) -> Option<String> 
     )
 }
 
+fn serialize_string_list(values: &[String]) -> Option<String> {
+    if values.is_empty() {
+        return None;
+    }
+    Some(values.join(","))
+}
+
 fn redact_secret(secret: &str) -> String {
     let chars: Vec<char> = secret.chars().collect();
     if chars.len() <= 16 {
@@ -1698,6 +1752,77 @@ mod tests {
         assert_eq!(policy.default, "allow");
         assert_eq!(policy.proxy, ["github.com", ".githubusercontent.com"]);
         assert!(policy.audit);
+    }
+
+    #[test]
+    fn permissions_toml_deserializes_typed_rules_and_legacy_lists() {
+        let config: ConfigToml = toml::from_str(
+            r#"
+            auto_allow = ["git status"]
+            auto_deny = ["rm -rf"]
+
+            [[permissions.rules]]
+            tool = "exec_shell"
+            decision = "allow"
+            command = "cargo test"
+
+            [[permissions.rules]]
+            tool = "file_edit"
+            decision = "ask"
+            path = "src/**"
+            "#,
+        )
+        .expect("permissions toml");
+
+        assert_eq!(config.auto_allow, ["git status"]);
+        assert_eq!(config.auto_deny, ["rm -rf"]);
+        assert_eq!(config.permissions.rules.len(), 2);
+        assert_eq!(
+            config.permissions.rules[0],
+            ToolPermissionRule::exec_shell(PermissionDecision::Allow, "cargo test")
+        );
+        assert_eq!(
+            config.permissions.rules[1],
+            ToolPermissionRule::file_path("file_edit", PermissionDecision::Ask, "src/**")
+        );
+    }
+
+    #[test]
+    fn config_builds_exec_policy_engine_with_legacy_and_typed_rules() {
+        let config: ConfigToml = toml::from_str(
+            r#"
+            auto_allow = ["git status"]
+
+            [[permissions.rules]]
+            tool = "exec_shell"
+            decision = "deny"
+            command = "git status --dangerous"
+            "#,
+        )
+        .expect("permissions toml");
+        let engine = config.exec_policy_engine();
+
+        let allowed = engine
+            .check(deepseek_execpolicy::ExecPolicyContext {
+                command: "git status --porcelain",
+                cwd: ".",
+                ask_for_approval: deepseek_execpolicy::AskForApproval::UnlessTrusted,
+                sandbox_mode: Some("workspace-write"),
+            })
+            .expect("policy decision");
+        assert!(allowed.allow);
+        assert!(!allowed.requires_approval);
+
+        let denied = engine
+            .check(deepseek_execpolicy::ExecPolicyContext {
+                command: "git status --dangerous",
+                cwd: ".",
+                ask_for_approval: deepseek_execpolicy::AskForApproval::UnlessTrusted,
+                sandbox_mode: Some("workspace-write"),
+            })
+            .expect("policy decision");
+        assert!(!denied.allow);
+        assert_eq!(denied.requirement.phase(), "forbidden");
     }
 
     struct EnvGuard {

--- a/crates/execpolicy/Cargo.toml
+++ b/crates/execpolicy/Cargo.toml
@@ -9,4 +9,5 @@ description = "Execution policy and approval model parity for DeepSeek workspace
 [dependencies]
 anyhow.workspace = true
 deepseek-protocol = { path = "../protocol", version = "0.8.40" }
+globset = "0.4.18"
 serde.workspace = true

--- a/crates/execpolicy/src/lib.rs
+++ b/crates/execpolicy/src/lib.rs
@@ -433,6 +433,15 @@ impl ExecPolicyEngine {
                     proposed_network_policy_amendments: vec![],
                 }
             }
+            AskForApproval::OnRequest
+                if matches!(tool_rule.decision, Some(PermissionDecision::Allow)) =>
+            {
+                ExecApprovalRequirement::NeedsApproval {
+                    reason: "Approval requested by policy mode.".to_string(),
+                    proposed_execpolicy_amendment: None,
+                    proposed_network_policy_amendments: vec![],
+                }
+            }
             _ if matches!(tool_rule.decision, Some(PermissionDecision::Allow)) => {
                 ExecApprovalRequirement::Skip {
                     bypass_sandbox: false,

--- a/crates/execpolicy/src/lib.rs
+++ b/crates/execpolicy/src/lib.rs
@@ -5,6 +5,7 @@ use std::collections::HashSet;
 use anyhow::Result;
 use bash_arity::BashArityDict;
 use deepseek_protocol::{NetworkPolicyAmendment, NetworkPolicyRuleAction};
+use globset::GlobBuilder;
 use serde::{Deserialize, Serialize};
 
 /// Priority layer for a permission ruleset. Higher ordinal = higher priority.
@@ -565,35 +566,11 @@ fn path_pattern_matches(pattern: &str, path: &str) -> bool {
     if !pattern.contains('*') && !pattern.contains('?') {
         return pattern == path;
     }
-    glob_match(pattern.as_bytes(), path.as_bytes())
-}
-
-fn glob_match(pattern: &[u8], path: &[u8]) -> bool {
-    if pattern.is_empty() {
-        return path.is_empty();
-    }
-
-    match pattern[0] {
-        b'*' if pattern.get(1) == Some(&b'*') => {
-            let rest = &pattern[2..];
-            (0..=path.len()).any(|idx| glob_match(rest, &path[idx..]))
-        }
-        b'*' => {
-            if glob_match(&pattern[1..], path) {
-                return true;
-            }
-            let mut idx = 0;
-            while idx < path.len() && path[idx] != b'/' {
-                idx += 1;
-                if glob_match(&pattern[1..], &path[idx..]) {
-                    return true;
-                }
-            }
-            false
-        }
-        b'?' => !path.is_empty() && path[0] != b'/' && glob_match(&pattern[1..], &path[1..]),
-        literal => !path.is_empty() && path[0] == literal && glob_match(&pattern[1..], &path[1..]),
-    }
+    GlobBuilder::new(&pattern)
+        .literal_separator(true)
+        .build()
+        .map(|glob| glob.compile_matcher().is_match(path))
+        .unwrap_or(false)
 }
 
 fn rule_specificity(rule: &ToolPermissionRule) -> usize {
@@ -629,7 +606,9 @@ fn normalize_path_pattern(value: &str) -> String {
         match segment {
             "" | "." => {}
             ".." => {
-                if segments.is_empty() || segments.last() == Some(&"..") {
+                if absolute {
+                    segments.pop();
+                } else if segments.is_empty() || segments.last() == Some(&"..") {
                     segments.push(segment);
                 } else {
                     segments.pop();
@@ -916,6 +895,8 @@ mod tests {
         assert!(path_pattern_matches("src/**", "src/./lib.rs"));
         assert!(!path_pattern_matches("src/**", "src/../secret.txt"));
         assert!(!path_pattern_matches("src/**", "../src/lib.rs"));
+        assert!(path_pattern_matches("/foo", "/../foo"));
+        assert!(!path_pattern_matches("/src/**", "/src/../secret.txt"));
     }
 
     #[test]

--- a/crates/execpolicy/src/lib.rs
+++ b/crates/execpolicy/src/lib.rs
@@ -8,7 +8,8 @@ use deepseek_protocol::{NetworkPolicyAmendment, NetworkPolicyRuleAction};
 use serde::{Deserialize, Serialize};
 
 /// Priority layer for a permission ruleset. Higher ordinal = higher priority.
-/// On conflict, the highest-priority layer's longest matching prefix wins.
+/// Deny rules still win across layers; for non-deny ties the higher-priority
+/// layer wins before pattern specificity is considered.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum RulesetLayer {
@@ -17,12 +18,100 @@ pub enum RulesetLayer {
     User = 2,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PermissionDecision {
+    Allow,
+    Deny,
+    Ask,
+}
+
+impl PermissionDecision {
+    fn precedence(self) -> u8 {
+        match self {
+            Self::Deny => 3,
+            Self::Ask => 2,
+            Self::Allow => 1,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Allow => "allow",
+            Self::Deny => "deny",
+            Self::Ask => "ask",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ToolPermissionRule {
+    pub tool: String,
+    pub decision: PermissionDecision,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+}
+
+impl ToolPermissionRule {
+    #[must_use]
+    pub fn new(tool: impl Into<String>, decision: PermissionDecision) -> Self {
+        Self {
+            tool: tool.into(),
+            decision,
+            command: None,
+            path: None,
+        }
+    }
+
+    #[must_use]
+    pub fn exec_shell(decision: PermissionDecision, command: impl Into<String>) -> Self {
+        Self {
+            tool: "exec_shell".to_string(),
+            decision,
+            command: Some(command.into()),
+            path: None,
+        }
+    }
+
+    #[must_use]
+    pub fn file_path(
+        tool: impl Into<String>,
+        decision: PermissionDecision,
+        path: impl Into<String>,
+    ) -> Self {
+        Self {
+            tool: tool.into(),
+            decision,
+            command: None,
+            path: Some(path.into()),
+        }
+    }
+
+    #[must_use]
+    pub fn pattern_label(&self) -> String {
+        let mut parts = vec![format!("tool '{}'", self.tool)];
+        if let Some(command) = self.command.as_deref() {
+            parts.push(format!("command '{command}'"));
+        }
+        if let Some(path) = self.path.as_deref() {
+            parts.push(format!("path '{path}'"));
+        }
+        parts.join(", ")
+    }
+}
+
 /// A named set of allow/deny prefix rules at a given priority layer.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Ruleset {
     pub layer: RulesetLayer,
+    #[serde(default)]
     pub trusted_prefixes: Vec<String>,
+    #[serde(default)]
     pub denied_prefixes: Vec<String>,
+    #[serde(default)]
+    pub rules: Vec<ToolPermissionRule>,
 }
 
 impl Ruleset {
@@ -31,6 +120,7 @@ impl Ruleset {
             layer: RulesetLayer::BuiltinDefault,
             trusted_prefixes: vec![],
             denied_prefixes: vec![],
+            rules: vec![],
         }
     }
 
@@ -39,6 +129,7 @@ impl Ruleset {
             layer: RulesetLayer::Agent,
             trusted_prefixes: trusted,
             denied_prefixes: denied,
+            rules: vec![],
         }
     }
 
@@ -47,7 +138,14 @@ impl Ruleset {
             layer: RulesetLayer::User,
             trusted_prefixes: trusted,
             denied_prefixes: denied,
+            rules: vec![],
         }
+    }
+
+    #[must_use]
+    pub fn with_rules(mut self, rules: Vec<ToolPermissionRule>) -> Self {
+        self.rules = rules;
+        self
     }
 }
 
@@ -126,6 +224,52 @@ pub struct ExecPolicyContext<'a> {
     pub sandbox_mode: Option<&'a str>,
 }
 
+#[derive(Debug, Clone)]
+pub struct ToolPermissionContext<'a> {
+    pub tool: &'a str,
+    pub command: Option<&'a str>,
+    pub path: Option<&'a str>,
+}
+
+impl<'a> ToolPermissionContext<'a> {
+    #[must_use]
+    pub fn exec_shell(command: &'a str) -> Self {
+        Self {
+            tool: "exec_shell",
+            command: Some(command),
+            path: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MatchedToolPermissionRule {
+    pub layer: RulesetLayer,
+    pub rule: ToolPermissionRule,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ToolPermissionCheck {
+    pub decision: Option<PermissionDecision>,
+    pub matched_rule: Option<MatchedToolPermissionRule>,
+}
+
+impl ToolPermissionCheck {
+    #[must_use]
+    pub fn unmatched() -> Self {
+        Self {
+            decision: None,
+            matched_rule: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct LayeredToolPermissionRule {
+    layer: RulesetLayer,
+    rule: ToolPermissionRule,
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct ExecPolicyEngine {
     /// Layered rulesets (builtin → agent → user). When non-empty, takes precedence
@@ -170,28 +314,40 @@ impl ExecPolicyEngine {
         self.rulesets.sort_by_key(|r| r.layer);
     }
 
-    /// Resolve the effective trusted/denied prefix sets by merging all rulesets.
-    ///
-    /// Collects all prefixes from every layer (builtin → agent → user) into flat
-    /// trusted/denied lists. The `check()` method then applies deny-always-wins
-    /// semantics: any matching deny prefix blocks the command regardless of layer.
-    /// Trusted rules are only consulted after deny checks pass.
-    fn resolve_prefixes(&self) -> (Vec<String>, Vec<String>) {
+    fn layered_permission_rules(&self) -> Vec<LayeredToolPermissionRule> {
+        let mut rules = Vec::new();
         if self.rulesets.is_empty() {
-            return (self.trusted_prefixes.clone(), self.denied_prefixes.clone());
+            rules.extend(legacy_command_rules(
+                RulesetLayer::User,
+                &self.trusted_prefixes,
+                &self.denied_prefixes,
+            ));
+            return rules;
         }
-        // Collect all trusted/denied across all layers, highest-priority last so they
-        // shadow lower-priority entries with the same prefix.
-        let mut trusted: Vec<String> = vec![];
-        let mut denied: Vec<String> = vec![];
-        for rs in &self.rulesets {
-            trusted.extend(rs.trusted_prefixes.iter().cloned());
-            denied.extend(rs.denied_prefixes.iter().cloned());
+
+        for ruleset in &self.rulesets {
+            rules.extend(
+                ruleset
+                    .rules
+                    .iter()
+                    .cloned()
+                    .map(|rule| LayeredToolPermissionRule {
+                        layer: ruleset.layer,
+                        rule,
+                    }),
+            );
+            rules.extend(legacy_command_rules(
+                ruleset.layer,
+                &ruleset.trusted_prefixes,
+                &ruleset.denied_prefixes,
+            ));
         }
-        // Also merge legacy flat lists as user-layer.
-        trusted.extend(self.trusted_prefixes.iter().cloned());
-        denied.extend(self.denied_prefixes.iter().cloned());
-        (trusted, denied)
+        rules.extend(legacy_command_rules(
+            RulesetLayer::User,
+            &self.trusted_prefixes,
+            &self.denied_prefixes,
+        ));
+        rules
     }
 
     pub fn remember_session_approval(&mut self, approval_key: String) {
@@ -202,62 +358,95 @@ impl ExecPolicyEngine {
         self.approved_for_session.contains(approval_key)
     }
 
+    #[must_use]
+    pub fn check_tool_permission(&self, ctx: ToolPermissionContext<'_>) -> ToolPermissionCheck {
+        let mut best: Option<(LayeredToolPermissionRule, usize)> = None;
+
+        for candidate in self.layered_permission_rules() {
+            if !tool_rule_matches(&candidate.rule, &ctx, &self.arity_dict) {
+                continue;
+            }
+            let specificity = rule_specificity(&candidate.rule);
+            let should_replace = best.as_ref().is_none_or(|(current, current_specificity)| {
+                compare_rule_priority(&candidate, specificity, current, *current_specificity)
+            });
+            if should_replace {
+                best = Some((candidate, specificity));
+            }
+        }
+
+        match best {
+            Some((matched, _)) => ToolPermissionCheck {
+                decision: Some(matched.rule.decision),
+                matched_rule: Some(MatchedToolPermissionRule {
+                    layer: matched.layer,
+                    rule: matched.rule,
+                }),
+            },
+            None => ToolPermissionCheck::unmatched(),
+        }
+    }
+
     pub fn check(&self, ctx: ExecPolicyContext<'_>) -> Result<ExecPolicyDecision> {
-        let normalized = normalize_command(ctx.command);
-        let (trusted_prefixes, denied_prefixes) = self.resolve_prefixes();
-        // Deny rules use simple prefix matching (no arity semantics needed).
-        if let Some(rule) = denied_prefixes
-            .iter()
-            .find(|rule| normalized.starts_with(&normalize_command(rule)))
+        let tool_rule = self.check_tool_permission(ToolPermissionContext::exec_shell(ctx.command));
+        if let Some(matched) = tool_rule
+            .matched_rule
+            .as_ref()
+            .filter(|matched| matched.rule.decision == PermissionDecision::Deny)
         {
             return Ok(ExecPolicyDecision {
                 allow: false,
                 requires_approval: false,
-                matched_rule: Some(rule.clone()),
+                matched_rule: Some(matched.rule.pattern_label()),
                 requirement: ExecApprovalRequirement::Forbidden {
-                    reason: format!("Command blocked by denied prefix rule '{rule}'"),
+                    reason: format!(
+                        "Command blocked by {} rule ({})",
+                        matched.rule.decision.as_str(),
+                        matched.rule.pattern_label()
+                    ),
                 },
             });
         }
-
-        // Allow (trusted) rules use arity-aware prefix matching so that
-        // `auto_allow = ["git status"]` matches `git status -s` but NOT
-        // `git push origin main`.
-        let trusted_rule = trusted_prefixes
-            .iter()
-            .find(|rule| self.arity_dict.allow_rule_matches(rule, ctx.command))
-            .cloned();
-        let is_trusted = trusted_rule.is_some();
 
         let requirement = match ctx.ask_for_approval {
             AskForApproval::Never => ExecApprovalRequirement::Skip {
                 bypass_sandbox: false,
                 proposed_execpolicy_amendment: None,
             },
-            AskForApproval::UnlessTrusted if is_trusted => ExecApprovalRequirement::Skip {
-                bypass_sandbox: false,
-                proposed_execpolicy_amendment: None,
+            AskForApproval::Reject { rules, .. } if rules => ExecApprovalRequirement::Forbidden {
+                reason: "Policy is configured to reject rule-exceptions.".to_string(),
             },
+            _ if matches!(tool_rule.decision, Some(PermissionDecision::Ask)) => {
+                ExecApprovalRequirement::NeedsApproval {
+                    reason: tool_rule
+                        .matched_rule
+                        .as_ref()
+                        .map(|matched| {
+                            format!(
+                                "Approval required by ask rule ({})",
+                                matched.rule.pattern_label()
+                            )
+                        })
+                        .unwrap_or_else(|| "Approval required by ask rule.".to_string()),
+                    proposed_execpolicy_amendment: None,
+                    proposed_network_policy_amendments: vec![],
+                }
+            }
+            _ if matches!(tool_rule.decision, Some(PermissionDecision::Allow)) => {
+                ExecApprovalRequirement::Skip {
+                    bypass_sandbox: false,
+                    proposed_execpolicy_amendment: None,
+                }
+            }
             AskForApproval::OnFailure => ExecApprovalRequirement::Skip {
                 bypass_sandbox: false,
                 proposed_execpolicy_amendment: None,
             },
-            AskForApproval::Reject { rules, .. } if rules => ExecApprovalRequirement::Forbidden {
-                reason: "Policy is configured to reject rule-exceptions.".to_string(),
-            },
             _ => ExecApprovalRequirement::NeedsApproval {
-                reason: if is_trusted {
-                    "Approval requested by policy mode.".to_string()
-                } else {
-                    "Unmatched command prefix requires approval.".to_string()
-                },
-                proposed_execpolicy_amendment: if is_trusted {
-                    None
-                } else {
-                    Some(ExecPolicyAmendment {
-                        prefixes: vec![first_token(ctx.command)],
-                    })
-                },
+                reason: "Unmatched command prefix requires approval.".to_string(),
+                proposed_execpolicy_amendment: Some(ExecPolicyAmendment {
+                    prefixes: vec![first_token(ctx.command)],
+                }),
                 proposed_network_policy_amendments: vec![NetworkPolicyAmendment {
                     host: ctx.cwd.to_string(),
                     action: NetworkPolicyRuleAction::Allow,
@@ -274,14 +463,190 @@ impl ExecPolicyEngine {
         Ok(ExecPolicyDecision {
             allow,
             requires_approval,
-            matched_rule: trusted_rule,
+            matched_rule: tool_rule
+                .matched_rule
+                .as_ref()
+                .map(|matched| matched.rule.pattern_label()),
             requirement,
         })
     }
 }
 
+fn legacy_command_rules(
+    layer: RulesetLayer,
+    trusted_prefixes: &[String],
+    denied_prefixes: &[String],
+) -> Vec<LayeredToolPermissionRule> {
+    trusted_prefixes
+        .iter()
+        .map(|command| LayeredToolPermissionRule {
+            layer,
+            rule: ToolPermissionRule::exec_shell(PermissionDecision::Allow, command.clone()),
+        })
+        .chain(
+            denied_prefixes
+                .iter()
+                .map(|command| LayeredToolPermissionRule {
+                    layer,
+                    rule: ToolPermissionRule::exec_shell(PermissionDecision::Deny, command.clone()),
+                }),
+        )
+        .collect()
+}
+
+fn compare_rule_priority(
+    candidate: &LayeredToolPermissionRule,
+    candidate_specificity: usize,
+    current: &LayeredToolPermissionRule,
+    current_specificity: usize,
+) -> bool {
+    (
+        candidate.rule.decision.precedence(),
+        candidate.layer,
+        candidate_specificity,
+    ) > (
+        current.rule.decision.precedence(),
+        current.layer,
+        current_specificity,
+    )
+}
+
+fn tool_rule_matches(
+    rule: &ToolPermissionRule,
+    ctx: &ToolPermissionContext<'_>,
+    arity_dict: &BashArityDict,
+) -> bool {
+    if !rule.tool.eq_ignore_ascii_case(ctx.tool) {
+        return false;
+    }
+    if let Some(command_rule) = rule.command.as_deref() {
+        let Some(command) = ctx.command else {
+            return false;
+        };
+        if !command_rule_matches(rule.decision, command_rule, command, arity_dict) {
+            return false;
+        }
+    }
+    if let Some(path_rule) = rule.path.as_deref() {
+        let Some(path) = ctx.path else {
+            return false;
+        };
+        if !path_pattern_matches(path_rule, path) {
+            return false;
+        }
+    }
+    true
+}
+
+fn command_rule_matches(
+    decision: PermissionDecision,
+    pattern: &str,
+    command: &str,
+    arity_dict: &BashArityDict,
+) -> bool {
+    match decision {
+        PermissionDecision::Deny => {
+            normalize_command(command).starts_with(&normalize_command(pattern))
+        }
+        PermissionDecision::Allow | PermissionDecision::Ask => {
+            arity_dict.allow_rule_matches(pattern, command)
+        }
+    }
+}
+
+fn path_pattern_matches(pattern: &str, path: &str) -> bool {
+    let pattern = normalize_path_pattern(pattern);
+    let path = normalize_path_pattern(path);
+    if let Some(prefix) = pattern.strip_suffix("/**")
+        && (path == prefix || path.starts_with(&format!("{prefix}/")))
+    {
+        return true;
+    }
+    if !pattern.contains('*') && !pattern.contains('?') {
+        return pattern == path;
+    }
+    glob_match(pattern.as_bytes(), path.as_bytes())
+}
+
+fn glob_match(pattern: &[u8], path: &[u8]) -> bool {
+    if pattern.is_empty() {
+        return path.is_empty();
+    }
+
+    match pattern[0] {
+        b'*' if pattern.get(1) == Some(&b'*') => {
+            let rest = &pattern[2..];
+            (0..=path.len()).any(|idx| glob_match(rest, &path[idx..]))
+        }
+        b'*' => {
+            if glob_match(&pattern[1..], path) {
+                return true;
+            }
+            let mut idx = 0;
+            while idx < path.len() && path[idx] != b'/' {
+                idx += 1;
+                if glob_match(&pattern[1..], &path[idx..]) {
+                    return true;
+                }
+            }
+            false
+        }
+        b'?' => !path.is_empty() && path[0] != b'/' && glob_match(&pattern[1..], &path[1..]),
+        literal => !path.is_empty() && path[0] == literal && glob_match(&pattern[1..], &path[1..]),
+    }
+}
+
+fn rule_specificity(rule: &ToolPermissionRule) -> usize {
+    let mut score = rule.tool.len();
+    if let Some(command) = rule.command.as_deref() {
+        score += 1_000 + non_wildcard_len(command);
+    }
+    if let Some(path) = rule.path.as_deref() {
+        score += 1_000 + non_wildcard_len(path);
+    }
+    score
+}
+
+fn non_wildcard_len(value: &str) -> usize {
+    value.chars().filter(|ch| *ch != '*' && *ch != '?').count()
+}
+
 fn normalize_command(value: &str) -> String {
-    value.trim().to_ascii_lowercase()
+    value
+        .trim()
+        .to_ascii_lowercase()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn normalize_path_pattern(value: &str) -> String {
+    let raw = value.trim().replace('\\', "/");
+    let absolute = raw.starts_with('/');
+    let mut segments = Vec::new();
+
+    for segment in raw.split('/') {
+        match segment {
+            "" | "." => {}
+            ".." => {
+                if segments.is_empty() || segments.last() == Some(&"..") {
+                    segments.push(segment);
+                } else {
+                    segments.pop();
+                }
+            }
+            _ => segments.push(segment),
+        }
+    }
+
+    let normalized = segments.join("/");
+    if absolute && normalized.is_empty() {
+        "/".to_string()
+    } else if absolute {
+        format!("/{normalized}")
+    } else {
+        normalized
+    }
 }
 
 fn first_token(command: &str) -> String {
@@ -305,6 +670,10 @@ mod tests {
         }
     }
 
+    fn exec_ctx(command: &str) -> ExecPolicyContext<'_> {
+        ctx(command, AskForApproval::UnlessTrusted)
+    }
+
     #[test]
     fn trusted_prefix_skips_approval_when_policy_is_unless_trusted() {
         let engine = ExecPolicyEngine::new(vec!["git status".to_string()], vec![]);
@@ -315,7 +684,10 @@ mod tests {
 
         assert!(decision.allow);
         assert!(!decision.requires_approval);
-        assert_eq!(decision.matched_rule.as_deref(), Some("git status"));
+        assert_eq!(
+            decision.matched_rule.as_deref(),
+            Some("tool 'exec_shell', command 'git status'")
+        );
         assert!(matches!(
             decision.requirement,
             ExecApprovalRequirement::Skip {
@@ -338,14 +710,31 @@ mod tests {
 
         assert!(!decision.allow);
         assert!(!decision.requires_approval);
-        assert_eq!(decision.matched_rule.as_deref(), Some("git status"));
+        assert_eq!(
+            decision.matched_rule.as_deref(),
+            Some("tool 'exec_shell', command 'git status'")
+        );
         assert!(matches!(
             decision.requirement,
             ExecApprovalRequirement::Forbidden { .. }
         ));
         assert_eq!(
             decision.reason(),
-            "Command blocked by denied prefix rule 'git status'"
+            "Command blocked by deny rule (tool 'exec_shell', command 'git status')"
+        );
+    }
+
+    #[test]
+    fn legacy_auto_allow_prefixes_become_exec_shell_rules() {
+        let engine = ExecPolicyEngine::new(vec!["git status".to_string()], vec![]);
+
+        let decision = engine.check(exec_ctx("git status --porcelain")).unwrap();
+
+        assert!(decision.allow);
+        assert!(!decision.requires_approval);
+        assert_eq!(
+            decision.matched_rule.as_deref(),
+            Some("tool 'exec_shell', command 'git status'")
         );
     }
 
@@ -389,7 +778,10 @@ mod tests {
 
         assert!(decision.allow);
         assert!(decision.requires_approval);
-        assert_eq!(decision.matched_rule.as_deref(), Some("cargo test"));
+        assert_eq!(
+            decision.matched_rule.as_deref(),
+            Some("tool 'exec_shell', command 'cargo test'")
+        );
         match decision.requirement {
             ExecApprovalRequirement::NeedsApproval {
                 proposed_execpolicy_amendment,
@@ -422,5 +814,123 @@ mod tests {
             decision.reason(),
             "Policy is configured to reject rule-exceptions."
         );
+    }
+
+    #[test]
+    fn legacy_auto_allow_uses_bash_arity() {
+        let engine = ExecPolicyEngine::new(vec!["git status".to_string()], vec![]);
+
+        let decision = engine.check(exec_ctx("git push origin main")).unwrap();
+
+        assert!(decision.requires_approval);
+        assert_eq!(decision.matched_rule, None);
+    }
+
+    #[test]
+    fn deny_rule_wins_over_user_allow_rule() {
+        let engine = ExecPolicyEngine::with_rulesets(vec![
+            Ruleset::builtin_default().with_rules(vec![ToolPermissionRule::exec_shell(
+                PermissionDecision::Deny,
+                "cargo",
+            )]),
+            Ruleset::user(vec![], vec![]).with_rules(vec![ToolPermissionRule::exec_shell(
+                PermissionDecision::Allow,
+                "cargo test",
+            )]),
+        ]);
+
+        let decision = engine.check(exec_ctx("cargo test --workspace")).unwrap();
+
+        assert!(!decision.allow);
+        assert_eq!(decision.requirement.phase(), "forbidden");
+        assert_eq!(
+            decision.matched_rule.as_deref(),
+            Some("tool 'exec_shell', command 'cargo'")
+        );
+    }
+
+    #[test]
+    fn ask_rule_wins_over_allow_rule() {
+        let engine =
+            ExecPolicyEngine::with_rulesets(vec![Ruleset::user(vec![], vec![]).with_rules(vec![
+                ToolPermissionRule::exec_shell(PermissionDecision::Allow, "cargo"),
+                ToolPermissionRule::exec_shell(PermissionDecision::Ask, "cargo test"),
+            ])]);
+
+        let decision = engine.check(exec_ctx("cargo test --workspace")).unwrap();
+
+        assert!(decision.allow);
+        assert!(decision.requires_approval);
+        assert_eq!(decision.requirement.phase(), "needs_approval");
+        assert_eq!(
+            decision.matched_rule.as_deref(),
+            Some("tool 'exec_shell', command 'cargo test'")
+        );
+    }
+
+    #[test]
+    fn ask_rule_overrides_on_failure_policy() {
+        let engine =
+            ExecPolicyEngine::with_rulesets(vec![Ruleset::user(vec![], vec![]).with_rules(vec![
+                ToolPermissionRule::exec_shell(PermissionDecision::Ask, "cargo test"),
+            ])]);
+
+        let decision = engine
+            .check(ExecPolicyContext {
+                command: "cargo test --workspace",
+                cwd: ".",
+                ask_for_approval: AskForApproval::OnFailure,
+                sandbox_mode: Some("workspace-write"),
+            })
+            .unwrap();
+
+        assert!(decision.allow);
+        assert!(decision.requires_approval);
+        assert_eq!(decision.requirement.phase(), "needs_approval");
+    }
+
+    #[test]
+    fn path_rules_match_workspace_relative_globs() {
+        let engine =
+            ExecPolicyEngine::with_rulesets(vec![Ruleset::user(vec![], vec![]).with_rules(vec![
+                ToolPermissionRule::file_path("file_edit", PermissionDecision::Allow, "docs/**"),
+            ])]);
+
+        let decision = engine.check_tool_permission(ToolPermissionContext {
+            tool: "file_edit",
+            command: None,
+            path: Some("./docs/guide/setup.md"),
+        });
+
+        assert_eq!(decision.decision, Some(PermissionDecision::Allow));
+    }
+
+    #[test]
+    fn path_star_does_not_cross_directory_separator() {
+        assert!(path_pattern_matches("docs/*.md", "docs/readme.md"));
+        assert!(!path_pattern_matches("docs/*.md", "docs/guides/readme.md"));
+    }
+
+    #[test]
+    fn path_rules_normalize_dot_segments() {
+        assert!(path_pattern_matches("src/**", "src/./lib.rs"));
+        assert!(!path_pattern_matches("src/**", "src/../secret.txt"));
+        assert!(!path_pattern_matches("src/**", "../src/lib.rs"));
+    }
+
+    #[test]
+    fn tool_name_only_rule_matches_unknown_tool() {
+        let engine =
+            ExecPolicyEngine::with_rulesets(vec![Ruleset::user(vec![], vec![]).with_rules(vec![
+                ToolPermissionRule::new("agent_spawn", PermissionDecision::Ask),
+            ])]);
+
+        let decision = engine.check_tool_permission(ToolPermissionContext {
+            tool: "agent_spawn",
+            command: None,
+            path: None,
+        });
+
+        assert_eq!(decision.decision, Some(PermissionDecision::Ask));
     }
 }

--- a/crates/tui/src/tools/pandoc.rs
+++ b/crates/tui/src/tools/pandoc.rs
@@ -144,7 +144,9 @@ impl ToolSpec for PandocConvertTool {
         // gated on resolve_pandoc(), but a concurrent uninstall between
         // catalog build and the model's call should produce a clear
         // error rather than the cryptic "program not found" from raw
-        // Command::spawn.
+        // Command::spawn. Input validation above intentionally runs first
+        // so tests and users get deterministic schema/actionable errors
+        // even on machines without pandoc installed.
         let pandoc = crate::dependencies::resolve_pandoc().ok_or_else(|| {
             ToolError::execution_failed(
                 "pandoc_convert: pandoc binary not found on PATH. \

--- a/crates/tui/src/tui/sidebar.rs
+++ b/crates/tui/src/tui/sidebar.rs
@@ -1798,8 +1798,8 @@ mod tests {
     use super::{
         ACTIVE_TOOL_COMPLETED_ROW_TTL, ACTIVE_TOOL_STALE_RUNNING_ROW_TTL, AutoSidebarPanel,
         AutoSidebarState, SidebarAgentRow, SidebarSubagentSummary, SidebarWorkChecklistItem,
-        SidebarWorkStrategyStep, SidebarWorkSummary, auto_sidebar_panels, subagent_panel_lines,
-        task_panel_lines, work_panel_empty_hint, work_panel_lines,
+        SidebarWorkStrategyStep, SidebarWorkSummary, auto_sidebar_panels, duration_ms,
+        subagent_panel_lines, task_panel_lines, work_panel_empty_hint, work_panel_lines,
     };
     use crate::config::Config;
     use crate::palette::PaletteMode;
@@ -2142,6 +2142,8 @@ mod tests {
     fn tasks_panel_collapses_stale_running_tool_rows() {
         let mut app = create_test_app();
         let mut active = ActiveCell::new();
+        let stale_duration_ms =
+            duration_ms(ACTIVE_TOOL_STALE_RUNNING_ROW_TTL).saturating_add(1_000);
         for (idx, command) in ["long one", "long two"].into_iter().enumerate() {
             active.push_tool(
                 format!("shell-{idx}"),
@@ -2150,7 +2152,7 @@ mod tests {
                     status: ToolStatus::Running,
                     output: None,
                     started_at: None,
-                    duration_ms: Some(ACTIVE_TOOL_STALE_RUNNING_ROW_TTL.as_millis() as u64 + 1),
+                    duration_ms: Some(stale_duration_ms),
                     source: ExecSource::Assistant,
                     interaction: None,
                     output_summary: None,

--- a/crates/tui/src/vision/tools.rs
+++ b/crates/tui/src/vision/tools.rs
@@ -270,13 +270,13 @@ mod tests {
         let tmp = tempdir().expect("tempdir");
         let ctx = ToolContext::new(tmp.path().to_path_buf());
         let tool = ImageAnalyzeTool::new(fake_config());
-        let outside_workspace = if cfg!(windows) {
+        let absolute_path = if cfg!(windows) {
             r"C:\Windows\System32\drivers\etc\hosts"
         } else {
             "/etc/hosts"
         };
         let err = tool
-            .execute(json!({"image_path": outside_workspace}), &ctx)
+            .execute(json!({"image_path": absolute_path}), &ctx)
             .await
             .expect_err("absolute path must reject");
         assert!(


### PR DESCRIPTION
## Summary

This PR adds the first slice of persistent permission rule support at the `execpolicy` and config layers.

It introduces typed permission rules scoped by tool name, optional command prefix, and optional workspace-relative path pattern, with `allow`, `deny`, and `ask` decisions.

This intentionally does not add TUI approval modal persistence yet. It provides the policy/config foundation for that follow-up work.

## Changes

- Added `PermissionDecision`:
  - `allow`
  - `deny`
  - `ask`
- Added `ToolPermissionRule` with:
  - `tool`
  - `decision`
  - optional `command`
  - optional `path`
- Extended `Ruleset` to carry typed permission rules.
- Added `ExecPolicyEngine::check_tool_permission`.
- Kept legacy `auto_allow` / `auto_deny` compatibility by converting them into `exec_shell` typed rules.
- Reused existing bash arity matching for shell allow/ask rules.
- Preserved deny-wins behavior.
- Added workspace-relative path glob matching with `.` / `..` normalization.
- Added config support for:

```toml
auto_allow = ["git status"]
auto_deny = ["rm -rf"]

[[permissions.rules]]
tool = "exec_shell"
decision = "allow"
command = "cargo test"

[[permissions.rules]]
tool = "file_edit"
decision = "ask"
path = "src/**"
```

- Wired app-server startup to build its exec policy engine from config.

## Precedence

When multiple rules match, the engine resolves them by:

1. decision precedence: `deny > ask > allow`
2. ruleset layer
3. rule specificity

This keeps deny rules conservative while allowing narrower `ask` rules to force approval over broader allow rules.

## Compatibility

Existing `auto_allow` and `auto_deny` config entries continue to work. They are treated as legacy shell rules and mapped into typed `exec_shell` permission rules internally.

## Tests

Added coverage for:

- legacy `auto_allow` compatibility
- bash arity behavior for legacy rules
- deny winning over allow
- ask winning over allow
- ask forcing approval under `OnFailure`
- workspace-relative path glob matching
- path normalization for `.` / `..`
- tool-name-only rules for non-shell tools
- config deserialization for `permissions.rules`
- config-to-policy-engine construction

## Verification

```bash
cargo fmt --all
cargo test -p deepseek-execpolicy -p deepseek-config -p deepseek-app-server -p deepseek-tui-cli
cargo clippy -p deepseek-execpolicy -p deepseek-config -p deepseek-app-server -p deepseek-tui-cli --all-targets -- -D warnings
git diff --check
```

## Follow-up Work

- Connect typed permission rules to the full TUI tool invocation approval path.
- Add approval UI actions such as “always allow this pattern”.
- Persist generated rules after user confirmation.
- Add rule preview before saving broad patterns.

## Related Issue

Part of #1186

This is the first PR in the proposed permission-rules implementation plan. It only adds the execpolicy/config typed rule model, matching behavior, precedence tests, and legacy `auto_allow` / `auto_deny` compatibility.