### PR TITLE
fix(tools): add FALLBACK_GH_PATHS for cross-platform gh CLI discovery

### DIFF
--- a/crates/tui/src/tools/github.rs
+++ b/crates/tui/src/tools/github.rs
@@ -15,6 +15,12 @@ use crate::tools::spec::{
 };
 
 const DEFAULT_GH: &str = "/opt/homebrew/bin/gh";
+const FALLBACK_GH_PATHS: &[&str] = &[
+    "/usr/bin/gh",                       // Linux system package manager
+    "/usr/local/bin/gh",                 // macOS Intel Homebrew / manual install
+    "/home/linuxbrew/.linuxbrew/bin/gh", // Linux Homebrew (official prefix)
+    "/opt/homebrew/bin/gh",              // macOS Apple Silicon Homebrew
+];
 const BODY_ARTIFACT_THRESHOLD: usize = 4_000;
 const DIFF_ARTIFACT_THRESHOLD: usize = 8_000;
 
@@ -300,7 +306,15 @@ impl ToolSpec for GithubCloseIssueTool {
 }
 
 fn gh_bin() -> String {
-    std::env::var("DEEPSEEK_GH_BIN").unwrap_or_else(|_| DEFAULT_GH.to_string())
+    if let Ok(bin) = std::env::var("DEEPSEEK_GH_BIN") {
+        return bin;
+    }
+    for path in FALLBACK_GH_PATHS {
+        if std::path::Path::new(path).is_file() {
+            return path.to_string();
+        }
+    }
+    DEFAULT_GH.to_string()
 }
 
 fn run_gh_text(context: &ToolContext, args: &[&str]) -> Result<String, ToolError> {
@@ -310,7 +324,7 @@ fn run_gh_text(context: &ToolContext, args: &[&str]) -> Result<String, ToolError
         .output()
         .map_err(|e| {
             if e.kind() == std::io::ErrorKind::NotFound {
-                ToolError::not_available("gh CLI is not installed at /opt/homebrew/bin/gh")
+                ToolError::not_available("gh CLI not found; install it or set DEEPSEEK_GH_BIN")
             } else {
                 ToolError::execution_failed(format!("failed to run gh: {e}"))
             }


### PR DESCRIPTION
## Summary

- Hardcoded `DEFAULT_GH = /opt/homebrew/bin/gh` causes `github_issue_context` and related tools to fail on Linux
- Add `FALLBACK_GH_PATHS` list to probe common installation paths before falling back to `DEFAULT_GH`
- Update error message to remove hardcoded path reference

## Path resolution order

1. `DEEPSEEK_GH_BIN` environment variable (existing, highest priority)
2. `FALLBACK_GH_PATHS` — probed in order:
   - `/usr/bin/gh` — Linux system package manager
   - `/usr/local/bin/gh` — macOS Intel Homebrew / manual install
   - `/home/linuxbrew/.linuxbrew/bin/gh` — Linux Homebrew (official prefix per install.sh)
   - `/opt/homebrew/bin/gh` — macOS Apple Silicon Homebrew
3. `DEFAULT_GH` (`/opt/homebrew/bin/gh`) — original fallback, unchanged

## Test plan

- [x] Built on Linux x86_64 (Debian 12, glibc 2.36)
- [x] Verified `github_issue_context` tool failed with "gh CLI is not installed at /opt/homebrew/bin/gh" on `main`
- [x] Verified `github_issue_context` tool successfully invokes `gh` on `feat/gh-path-fallback` (gh found at `/usr/bin/gh`)