### PR TITLE
Fix provider-aware /model picker catalogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **`/model` uses the active provider's model catalog** - opening the picker now
+  fetches live model IDs from the configured provider, falls back to
+  provider-specific defaults when discovery fails, maps short DeepSeek IDs to
+  provider-specific IDs for `/model <id>`, and sizes the picker columns to keep
+  long provider model names and thinking-effort labels readable.
+
 ## [0.8.20] - 2026-05-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fetches live model IDs from the configured provider, falls back to
   provider-specific defaults when discovery fails, maps short DeepSeek IDs to
   provider-specific IDs for `/model <id>`, and sizes the picker columns to keep
-  long provider model names and thinking-effort labels readable.
+  long provider model names and thinking-effort labels readable. Provider-native
+  IDs selected from a live catalog are now accepted by settings persistence so
+  they survive restart.
 
 ## [0.8.20] - 2026-05-08
 

--- a/crates/tui/src/commands/core.rs
+++ b/crates/tui/src/commands/core.rs
@@ -2,7 +2,7 @@
 
 use std::fmt::Write;
 
-use crate::config::{COMMON_DEEPSEEK_MODELS, normalize_model_name};
+use crate::config::{COMMON_DEEPSEEK_MODELS, normalize_model_name_for_provider};
 use crate::localization::{MessageId, tr};
 use crate::tui::app::{App, AppAction, AppMode, ReasoningEffort};
 use crate::tui::views::{HelpView, ModalKind, SubAgentsView, subagent_view_agents};
@@ -119,7 +119,7 @@ pub fn model(app: &mut App, model_name: Option<&str>) -> CommandResult {
                 AppAction::UpdateCompaction(app.compaction_config()),
             );
         }
-        let Some(model_id) = normalize_model_name(name) else {
+        let Some(model_id) = normalize_model_name_for_provider(app.api_provider, name) else {
             return CommandResult::error(format!(
                 "Invalid model '{name}'. Expected auto or a DeepSeek model ID. Common models: {}",
                 COMMON_DEEPSEEK_MODELS.join(", ")
@@ -341,6 +341,8 @@ mod tests {
         let mut app = App::new(options, &Config::default());
         app.ui_locale = crate::localization::Locale::En;
         app.api_provider = crate::config::ApiProvider::Deepseek;
+        app.model = "deepseek-v4-pro".to_string();
+        app.auto_model = false;
         app
     }
 
@@ -558,6 +560,22 @@ mod tests {
             result.action,
             Some(AppAction::UpdateCompaction(_))
         ));
+    }
+
+    #[test]
+    fn model_change_maps_short_id_for_nvidia_nim() {
+        let mut app = create_test_app();
+        app.api_provider = crate::config::ApiProvider::NvidiaNim;
+
+        let result = model(&mut app, Some("deepseek-v4-flash"));
+
+        assert!(
+            result
+                .message
+                .unwrap()
+                .contains("deepseek-ai/deepseek-v4-flash")
+        );
+        assert_eq!(app.model, "deepseek-ai/deepseek-v4-flash");
     }
 
     #[test]

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -2279,6 +2279,24 @@ fn normalize_model_for_provider(provider: ApiProvider, model: &str) -> Option<St
     normalize_model_name(model).map(|normalized| model_for_provider(provider, normalized))
 }
 
+/// Normalize a user-entered model name for the active provider.
+///
+/// DeepSeek-family hosted providers accept the same short user-facing aliases
+/// (`deepseek-v4-pro`, `deepseek-v4-flash`) but send provider-specific IDs on
+/// the wire. Generic OpenAI-compatible and Ollama providers intentionally pass
+/// model IDs through so custom deployments can use their native names.
+#[must_use]
+pub fn normalize_model_name_for_provider(provider: ApiProvider, model: &str) -> Option<String> {
+    let trimmed = model.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if provider_passes_model_through(provider) {
+        return Some(trimmed.to_string());
+    }
+    normalize_model_for_provider(provider, trimmed)
+}
+
 fn provider_passes_model_through(provider: ApiProvider) -> bool {
     matches!(provider, ApiProvider::Openai | ApiProvider::Ollama)
 }

--- a/crates/tui/src/schema_migration.rs
+++ b/crates/tui/src/schema_migration.rs
@@ -205,6 +205,7 @@ pub fn backup_before_migrate(path: &Path, domain: &str) -> PathBuf {
 /// 3. Bump `CURRENT_VERSION` to match.
 /// 4. Wire `<Domain>Migration::migrate(...)` into the load function in
 ///    the owning module.
+#[allow(dead_code)]
 pub mod registry {
     use super::{MigrationFn, SchemaMigration};
 

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -469,7 +469,7 @@ impl Settings {
 
                 let Some(model) = normalize_default_model(trimmed) else {
                     anyhow::bail!(
-                        "Failed to update setting: invalid model '{value}'. Expected: auto, a DeepSeek model ID (for example deepseek-v4-pro, deepseek-v4-flash), or none/default."
+                        "Failed to update setting: invalid model '{value}'. Expected: auto, a DeepSeek or provider-native model ID, or none/default."
                     );
                 };
                 self.default_model = Some(model);
@@ -582,7 +582,7 @@ impl Settings {
             ("max_history", "Max input history entries"),
             (
                 "default_model",
-                "Default model: auto or any DeepSeek model ID (e.g. deepseek-v4-pro)",
+                "Default model: auto or any DeepSeek/provider-native model ID",
             ),
         ]
     }
@@ -590,11 +590,28 @@ impl Settings {
 
 fn normalize_default_model(value: &str) -> Option<String> {
     let trimmed = value.trim();
-    if trimmed.eq_ignore_ascii_case("auto") {
-        Some("auto".to_string())
-    } else {
-        normalize_model_name(trimmed)
+    if trimmed.is_empty()
+        || matches!(
+            trimmed.to_ascii_lowercase().as_str(),
+            "none" | "default" | "(default)"
+        )
+    {
+        return None;
     }
+    if trimmed.eq_ignore_ascii_case("auto") {
+        return Some("auto".to_string());
+    }
+    if let Some(normalized) = normalize_model_name(trimmed) {
+        return Some(normalized);
+    }
+    is_provider_native_model_id(trimmed).then(|| trimmed.to_string())
+}
+
+fn is_provider_native_model_id(model: &str) -> bool {
+    model.chars().any(|ch| ch.is_ascii_alphanumeric())
+        && model
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | ':' | '/'))
 }
 
 /// Parse a boolean value from various formats
@@ -781,6 +798,47 @@ mod tests {
             .set("cost_currency", "eur")
             .expect_err("unsupported currency");
         assert!(err.to_string().contains("invalid cost currency"));
+    }
+
+    #[test]
+    fn default_model_accepts_provider_native_ids() {
+        let mut settings = Settings::default();
+
+        settings
+            .set("default_model", " meta/llama-3.1-405b-instruct ")
+            .expect("hosted provider model IDs should persist");
+        assert_eq!(
+            settings.default_model.as_deref(),
+            Some("meta/llama-3.1-405b-instruct")
+        );
+
+        settings
+            .set("default_model", "ft:gpt-4o-mini:org:custom:suffix")
+            .expect("OpenAI-compatible fine-tuned IDs should persist");
+        assert_eq!(
+            settings.default_model.as_deref(),
+            Some("ft:gpt-4o-mini:org:custom:suffix")
+        );
+    }
+
+    #[test]
+    fn default_model_still_normalizes_deepseek_aliases_and_rejects_unsafe_ids() {
+        let mut settings = Settings::default();
+
+        settings
+            .set("default_model", "deepseek-v4pro")
+            .expect("compact DeepSeek alias should normalize");
+        assert_eq!(settings.default_model.as_deref(), Some("deepseek-v4-pro"));
+
+        let err = settings
+            .set("default_model", "meta/llama 3")
+            .expect_err("model IDs with spaces should fail");
+        assert!(err.to_string().contains("invalid model"));
+
+        settings
+            .set("default_model", "default")
+            .expect("default should reset");
+        assert_eq!(settings.default_model, None);
     }
 
     #[test]

--- a/crates/tui/src/tui/model_picker.rs
+++ b/crates/tui/src/tui/model_picker.rs
@@ -1,4 +1,4 @@
-//! `/model` picker modal: pick a DeepSeek model and a thinking-effort tier
+//! `/model` picker modal: pick a provider-specific model and a thinking-effort tier
 //! and apply both at once (#39).
 //!
 //! Two side-by-side panes — Models on the left, Thinking effort on the
@@ -26,18 +26,144 @@ use ratatui::{
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph, Widget},
 };
+use std::collections::HashSet;
+use unicode_width::UnicodeWidthStr;
 
+use crate::config::{
+    ApiProvider, DEFAULT_FIREWORKS_MODEL, DEFAULT_NOVITA_FLASH_MODEL, DEFAULT_NOVITA_MODEL,
+    DEFAULT_NVIDIA_NIM_FLASH_MODEL, DEFAULT_NVIDIA_NIM_MODEL, DEFAULT_OLLAMA_MODEL,
+    DEFAULT_OPENAI_MODEL, DEFAULT_OPENROUTER_FLASH_MODEL, DEFAULT_OPENROUTER_MODEL,
+    DEFAULT_SGLANG_FLASH_MODEL, DEFAULT_SGLANG_MODEL, DEFAULT_TEXT_MODEL, DEFAULT_VLLM_FLASH_MODEL,
+    DEFAULT_VLLM_MODEL,
+};
 use crate::palette;
 use crate::tui::app::{App, ReasoningEffort};
 use crate::tui::views::{ModalKind, ModalView, ViewAction, ViewEvent};
 
-/// Models the picker exposes by default. Kept short on purpose — power
-/// users can still type `/model <id>` for anything else.
-const PICKER_MODELS: &[(&str, &str)] = &[
-    ("auto", "select per turn"),
-    ("deepseek-v4-pro", "flagship"),
-    ("deepseek-v4-flash", "fast / cheap"),
-];
+/// Built-in fallback rows for providers that cannot return a live catalog.
+fn picker_models_for_provider(provider: ApiProvider) -> Vec<(String, String)> {
+    let mut rows = vec![("auto".to_string(), String::new())];
+    let provider_rows: &[&str] = match provider {
+        ApiProvider::Deepseek | ApiProvider::DeepseekCN => {
+            &[DEFAULT_TEXT_MODEL, "deepseek-v4-flash"]
+        }
+        ApiProvider::NvidiaNim => &[DEFAULT_NVIDIA_NIM_MODEL, DEFAULT_NVIDIA_NIM_FLASH_MODEL],
+        ApiProvider::Openai => &[DEFAULT_OPENAI_MODEL],
+        ApiProvider::Openrouter => &[DEFAULT_OPENROUTER_MODEL, DEFAULT_OPENROUTER_FLASH_MODEL],
+        ApiProvider::Novita => &[DEFAULT_NOVITA_MODEL, DEFAULT_NOVITA_FLASH_MODEL],
+        ApiProvider::Fireworks => &[
+            DEFAULT_FIREWORKS_MODEL,
+            "accounts/fireworks/models/deepseek-v4-flash",
+        ],
+        ApiProvider::Sglang => &[DEFAULT_SGLANG_MODEL, DEFAULT_SGLANG_FLASH_MODEL],
+        ApiProvider::Vllm => &[DEFAULT_VLLM_MODEL, DEFAULT_VLLM_FLASH_MODEL],
+        ApiProvider::Ollama => &[DEFAULT_OLLAMA_MODEL],
+    };
+    rows.extend(
+        provider_rows
+            .iter()
+            .map(|id| ((*id).to_string(), String::new())),
+    );
+    rows
+}
+
+fn picker_rows_from_model_ids(model_ids: Vec<String>) -> Vec<(String, String)> {
+    let mut rows = Vec::with_capacity(model_ids.len() + 1);
+    let mut seen = HashSet::new();
+
+    push_model_row(&mut rows, &mut seen, "auto", "");
+    for model_id in model_ids {
+        let id = model_id.trim();
+        if id.is_empty() {
+            continue;
+        }
+        push_model_row(&mut rows, &mut seen, id, "");
+    }
+
+    rows
+}
+
+fn push_model_row(
+    rows: &mut Vec<(String, String)>,
+    seen: &mut HashSet<String>,
+    id: &str,
+    hint: &str,
+) {
+    let key = if id.eq_ignore_ascii_case("auto") {
+        "auto".to_string()
+    } else {
+        id.to_string()
+    };
+    if seen.insert(key) {
+        rows.push((id.to_string(), hint.to_string()));
+    }
+}
+
+fn effort_rows() -> Vec<(String, String)> {
+    PICKER_EFFORTS
+        .iter()
+        .map(|effort| {
+            let label = effort.short_label().to_string();
+            let hint = match effort {
+                ReasoningEffort::Auto => "auto-select".to_string(),
+                ReasoningEffort::Off => "thinking disabled".to_string(),
+                ReasoningEffort::High => "thinking enabled".to_string(),
+                ReasoningEffort::Max => "max effort".to_string(),
+                _ => String::new(),
+            };
+            (label, hint)
+        })
+        .collect()
+}
+
+fn row_display_width(label: &str, hint: &str) -> usize {
+    // Rendered as: " ▸ {label}  ({hint})"; unselected rows reserve the same
+    // marker width, so focused/unfocused rows need the same pane size.
+    let base = 3 + UnicodeWidthStr::width(label);
+    if hint.is_empty() {
+        base
+    } else {
+        base + 4 + UnicodeWidthStr::width(hint)
+    }
+}
+
+fn pane_required_width(title: &str, rows: &[(String, String)]) -> u16 {
+    let title_width = UnicodeWidthStr::width(title) + 2;
+    let row_width = rows
+        .iter()
+        .map(|(label, hint)| row_display_width(label, hint))
+        .max()
+        .unwrap_or(0);
+    saturating_usize_to_u16(title_width.max(row_width) + 2)
+}
+
+fn picker_layout_widths(
+    available_width: u16,
+    model_title: &str,
+    model_rows: &[(String, String)],
+    effort_rows: &[(String, String)],
+) -> (u16, u16, u16) {
+    let model_width = pane_required_width(model_title, model_rows);
+    let effort_width = pane_required_width("Thinking", effort_rows).saturating_add(1);
+    let desired_inner_width = model_width.saturating_add(effort_width);
+    let popup_width = desired_inner_width
+        .saturating_add(2)
+        .min(available_width)
+        .max(1);
+    let inner_width = popup_width.saturating_sub(2);
+
+    if inner_width >= desired_inner_width {
+        return (popup_width, model_width, effort_width);
+    }
+
+    let effort_width = effort_width.min(inner_width.saturating_sub(1));
+    let model_width = inner_width.saturating_sub(effort_width);
+    (popup_width, model_width, effort_width)
+}
+
+fn saturating_usize_to_u16(value: usize) -> u16 {
+    value.min(u16::MAX as usize) as u16
+}
 
 /// Thinking-effort rows shown in the picker, in the order DeepSeek
 /// behaviorally distinguishes them.
@@ -57,6 +183,7 @@ enum Pane {
 pub struct ModelPickerView {
     initial_model: String,
     initial_effort: ReasoningEffort,
+    model_rows: Vec<(String, String)>,
     /// Working selection (separate from the initial values so we can offer a
     /// clean Esc-to-cancel without mutating App state).
     selected_model_idx: usize,
@@ -70,18 +197,25 @@ pub struct ModelPickerView {
 impl ModelPickerView {
     #[must_use]
     pub fn new(app: &App) -> Self {
+        Self::new_with_rows(app, picker_models_for_provider(app.api_provider))
+    }
+
+    #[must_use]
+    pub fn new_with_models(app: &App, model_ids: Vec<String>) -> Self {
+        Self::new_with_rows(app, picker_rows_from_model_ids(model_ids))
+    }
+
+    fn new_with_rows(app: &App, model_rows: Vec<(String, String)>) -> Self {
         let initial_model = if app.auto_model {
             "auto".to_string()
         } else {
             app.model.clone()
         };
-        let mut selected_model_idx = PICKER_MODELS
-            .iter()
-            .position(|(id, _)| *id == initial_model);
+        let mut selected_model_idx = model_rows.iter().position(|(id, _)| *id == initial_model);
         let show_custom_model_row = selected_model_idx.is_none();
         if show_custom_model_row {
             // Custom row sits at the end; precompute its index.
-            selected_model_idx = Some(PICKER_MODELS.len());
+            selected_model_idx = Some(model_rows.len());
         }
         let selected_model_idx = selected_model_idx.unwrap_or(0);
 
@@ -99,6 +233,7 @@ impl ModelPickerView {
         Self {
             initial_model,
             initial_effort,
+            model_rows,
             selected_model_idx,
             selected_effort_idx,
             focus: Pane::Model,
@@ -107,17 +242,17 @@ impl ModelPickerView {
     }
 
     fn model_row_count(&self) -> usize {
-        PICKER_MODELS.len() + if self.show_custom_model_row { 1 } else { 0 }
+        self.model_rows.len() + if self.show_custom_model_row { 1 } else { 0 }
     }
 
     /// Resolve the currently highlighted model row to a model id. If the
     /// custom row is selected we return the original model from the App so
     /// "Apply" doesn't blow away an unrecognised id.
     fn resolved_model(&self) -> String {
-        if self.show_custom_model_row && self.selected_model_idx == PICKER_MODELS.len() {
+        if self.show_custom_model_row && self.selected_model_idx == self.model_rows.len() {
             self.initial_model.clone()
         } else {
-            PICKER_MODELS[self.selected_model_idx].0.to_string()
+            self.model_rows[self.selected_model_idx].0.clone()
         }
     }
 
@@ -201,8 +336,17 @@ impl ModelPickerView {
         let inner = block.inner(area);
         block.render(area, buf);
 
-        let mut lines = Vec::with_capacity(rows.len());
-        for (idx, (label, hint)) in rows.iter().enumerate() {
+        let visible_capacity = inner.height as usize;
+        let start = if visible_capacity == 0 || selected < visible_capacity {
+            0
+        } else {
+            selected + 1 - visible_capacity
+        };
+        let end = rows.len().min(start + visible_capacity);
+
+        let mut lines = Vec::with_capacity(end.saturating_sub(start));
+        for (offset, (label, hint)) in rows[start..end].iter().enumerate() {
+            let idx = start + offset;
             let is_selected = idx == selected;
             let marker = if is_selected { "▸" } else { " " };
             let label_style = if is_selected {
@@ -266,8 +410,20 @@ impl ModalView for ModelPickerView {
     }
 
     fn render(&self, area: Rect, buf: &mut Buffer) {
-        let popup_width = 64.min(area.width.saturating_sub(4)).max(40);
-        let popup_height = 14.min(area.height.saturating_sub(4)).max(10);
+        let available_width = area.width.saturating_sub(4).max(1);
+        let mut model_rows = self.model_rows.clone();
+        if self.show_custom_model_row {
+            model_rows.push((self.initial_model.clone(), "current (custom)".to_string()));
+        }
+        let model_title = format!("Model ({})", self.model_row_count());
+        let effort_rows = effort_rows();
+        let (popup_width, model_width, effort_width) =
+            picker_layout_widths(available_width, &model_title, &model_rows, &effort_rows);
+        let desired_rows = self.model_row_count().max(PICKER_EFFORTS.len()) as u16;
+        let popup_height = desired_rows
+            .saturating_add(4)
+            .min(area.height.saturating_sub(4))
+            .max(10);
         let popup_area = Rect {
             x: area.x + (area.width.saturating_sub(popup_width)) / 2,
             y: area.y + (area.height.saturating_sub(popup_height)) / 2,
@@ -303,39 +459,21 @@ impl ModalView for ModelPickerView {
 
         let columns = Layout::default()
             .direction(Direction::Horizontal)
-            .constraints([Constraint::Percentage(60), Constraint::Percentage(40)])
+            .constraints([
+                Constraint::Length(model_width),
+                Constraint::Length(effort_width),
+            ])
             .split(inner);
 
-        let mut model_rows: Vec<(String, String)> = PICKER_MODELS
-            .iter()
-            .map(|(id, hint)| ((*id).to_string(), (*hint).to_string()))
-            .collect();
-        if self.show_custom_model_row {
-            model_rows.push((self.initial_model.clone(), "current (custom)".to_string()));
-        }
         self.render_pane(
             columns[0],
             buf,
-            "Model",
+            &model_title,
             model_rows,
             self.selected_model_idx,
             self.focus == Pane::Model,
         );
 
-        let effort_rows: Vec<(String, String)> = PICKER_EFFORTS
-            .iter()
-            .map(|effort| {
-                let label = effort.short_label().to_string();
-                let hint = match effort {
-                    ReasoningEffort::Auto => "auto-select per turn".to_string(),
-                    ReasoningEffort::Off => "thinking disabled".to_string(),
-                    ReasoningEffort::High => "thinking enabled (default)".to_string(),
-                    ReasoningEffort::Max => "thinking enabled, max effort".to_string(),
-                    _ => String::new(),
-                };
-                (label, hint)
-            })
-            .collect();
         self.render_pane(
             columns[1],
             buf,
@@ -442,7 +580,8 @@ mod tests {
 
     #[test]
     fn picker_exposes_auto_and_distinct_thinking_tiers() {
-        let model_labels: Vec<_> = PICKER_MODELS.iter().map(|(id, _)| *id).collect();
+        let deepseek_rows = picker_models_for_provider(crate::config::ApiProvider::Deepseek);
+        let model_labels: Vec<_> = deepseek_rows.iter().map(|(id, _)| id.as_str()).collect();
         assert_eq!(
             model_labels,
             vec!["auto", "deepseek-v4-pro", "deepseek-v4-flash"]
@@ -462,6 +601,90 @@ mod tests {
         let view = ModelPickerView::new(&app);
         assert!(view.show_custom_model_row);
         assert_eq!(view.resolved_model(), "deepseek-v4-pro-2026-04-XX");
+    }
+
+    #[test]
+    fn picker_uses_nvidia_nim_model_ids_for_nvidia_provider() {
+        let mut app = create_test_app();
+        app.api_provider = crate::config::ApiProvider::NvidiaNim;
+        app.model = "deepseek-ai/deepseek-v4-flash".to_string();
+
+        let view = ModelPickerView::new(&app);
+        let model_labels: Vec<_> = view.model_rows.iter().map(|(id, _)| id.as_str()).collect();
+
+        assert_eq!(
+            model_labels,
+            vec![
+                "auto",
+                "deepseek-ai/deepseek-v4-pro",
+                "deepseek-ai/deepseek-v4-flash"
+            ]
+        );
+        assert!(!view.show_custom_model_row);
+        assert_eq!(view.resolved_model(), "deepseek-ai/deepseek-v4-flash");
+    }
+
+    #[test]
+    fn picker_uses_live_provider_model_ids_when_supplied() {
+        let mut app = create_test_app();
+        app.api_provider = crate::config::ApiProvider::NvidiaNim;
+        app.model = "meta/llama-3.1-405b-instruct".to_string();
+
+        let view = ModelPickerView::new_with_models(
+            &app,
+            vec![
+                "deepseek-ai/deepseek-v4-pro".to_string(),
+                "meta/llama-3.1-405b-instruct".to_string(),
+                "nv-mistralai/mistral-nemo-12b-instruct".to_string(),
+            ],
+        );
+        let model_labels: Vec<_> = view.model_rows.iter().map(|(id, _)| id.as_str()).collect();
+
+        assert_eq!(
+            model_labels,
+            vec![
+                "auto",
+                "deepseek-ai/deepseek-v4-pro",
+                "meta/llama-3.1-405b-instruct",
+                "nv-mistralai/mistral-nemo-12b-instruct"
+            ]
+        );
+        assert!(!view.show_custom_model_row);
+        assert_eq!(view.resolved_model(), "meta/llama-3.1-405b-instruct");
+    }
+
+    #[test]
+    fn picker_widths_follow_longest_model_and_effort_text() {
+        let model_rows = vec![
+            ("auto".to_string(), String::new()),
+            ("short".to_string(), String::new()),
+            (
+                "provider/family/very-long-model-name".to_string(),
+                String::new(),
+            ),
+        ];
+        let efforts = effort_rows();
+        let (popup_width, model_width, effort_width) =
+            picker_layout_widths(200, "Model (3)", &model_rows, &efforts);
+
+        assert_eq!(model_width, pane_required_width("Model (3)", &model_rows));
+        assert_eq!(effort_width, pane_required_width("Thinking", &efforts) + 1);
+        assert_eq!(popup_width, model_width + effort_width + 2);
+        assert!(effort_width as usize >= row_display_width("high", "thinking enabled") + 3);
+    }
+
+    #[test]
+    fn picker_widths_keep_effort_readable_when_terminal_is_narrow() {
+        let model_rows = vec![(
+            "provider/family/very-long-model-name".to_string(),
+            String::new(),
+        )];
+        let efforts = effort_rows();
+        let (_popup_width, model_width, effort_width) =
+            picker_layout_widths(60, "Model (1)", &model_rows, &efforts);
+
+        assert!(model_width > 0);
+        assert_eq!(effort_width, pane_required_width("Thinking", &efforts) + 1);
     }
 
     #[test]

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -4630,8 +4630,34 @@ async fn apply_command_result(
             }
             AppAction::OpenModelPicker => {
                 if app.view_stack.top_kind() != Some(ModalKind::ModelPicker) {
-                    app.view_stack
-                        .push(crate::tui::model_picker::ModelPickerView::new(app));
+                    app.status_message =
+                        Some(format!("Fetching {} models...", app.api_provider.as_str()));
+                    let picker = match fetch_available_models(config).await {
+                        Ok(models) if !models.is_empty() => {
+                            let count = models.len();
+                            app.status_message = Some(format!("Found {count} model(s)"));
+                            crate::tui::model_picker::ModelPickerView::new_with_models(app, models)
+                        }
+                        Ok(_) => {
+                            app.status_message = Some(format!(
+                                "{} returned no models; showing defaults",
+                                app.api_provider.as_str()
+                            ));
+                            crate::tui::model_picker::ModelPickerView::new(app)
+                        }
+                        Err(error) => {
+                            app.add_message(HistoryCell::System {
+                                content: format!(
+                                    "Failed to fetch {} models: {error}. Showing built-in defaults.",
+                                    app.api_provider.as_str()
+                                ),
+                            });
+                            app.status_message =
+                                Some("Model fetch failed; showing defaults".to_string());
+                            crate::tui::model_picker::ModelPickerView::new(app)
+                        }
+                    };
+                    app.view_stack.push(picker);
                 }
             }
             AppAction::OpenProviderPicker => {

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -4063,13 +4063,23 @@ async fn apply_model_picker_choice(
     let mut persist_warning: Option<String> = None;
     match crate::settings::Settings::load() {
         Ok(mut settings) => {
+            let mut settings_changed = false;
             if model_changed {
-                let _ = settings.set("default_model", &model);
+                match settings.set("default_model", &model) {
+                    Ok(()) => settings_changed = true,
+                    Err(err) => persist_warning = Some(format!("(model not persisted: {err})")),
+                }
             }
             if effort_changed {
-                let _ = settings.set("reasoning_effort", effort.as_setting());
+                match settings.set("reasoning_effort", effort.as_setting()) {
+                    Ok(()) => settings_changed = true,
+                    Err(err) if persist_warning.is_none() => {
+                        persist_warning = Some(format!("(thinking not persisted: {err})"));
+                    }
+                    Err(_) => {}
+                }
             }
-            if let Err(err) = settings.save() {
+            if settings_changed && let Err(err) = settings.save() {
                 persist_warning = Some(format!("(not persisted: {err})"));
             }
         }

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -1020,7 +1020,7 @@ fn config_hint_for_key(key: &str) -> &'static str {
         "sidebar_width" => "10..=50",
         "sidebar_focus" => "auto | plan | todos | tasks | agents",
         "max_history" => "integer (0 allowed)",
-        "default_model" => "deepseek-v4-pro | deepseek-v4-flash | deepseek-* | none/default",
+        "default_model" => "auto | deepseek-v4-pro | provider/model-id | none/default",
         "mcp_config_path" => "path to mcp.json",
         _ => "",
     }


### PR DESCRIPTION
## Summary

Fixes the `/model` picker so it reflects the currently selected provider instead of always showing the static DeepSeek Pro/Flash list.

Changes:
- fetch live model IDs from the active provider when opening `/model`
- fall back to provider-specific defaults when live discovery fails or returns no models
- normalize `/model <id>` through the active provider, so short DeepSeek IDs map to provider IDs such as `deepseek-ai/deepseek-v4-flash` for NVIDIA NIM
- keep custom/current model IDs visible when they are not present in the picker list
- make the picker scrollable for long model catalogs
- size picker columns from rendered content: the model pane follows the longest model ID, and the thinking pane keeps `high  (thinking enabled)` readable with one trailing cell before the border
- add an Unreleased changelog entry
- silence dead-code warnings for schema migration registry marker structs so strict clippy can pass with `-D warnings`

## Testing

- [x] `cargo test --workspace --all-features --locked`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- [x] `cargo build`

Local environment note:
- `cargo run -p deepseek-tui --all-features -- eval` fails on Windows because the offline eval harness runs `printf`, which is not available under `cmd.exe`.

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [x] Verified TUI behavior manually if UI changes