### PR TITLE
Retry quota errors returned as HTTP 400

### DIFF
--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -648,10 +648,6 @@ impl DeepSeekClient {
                     if status.is_success() {
                         return Ok(response);
                     }
-                    let retryable = status.as_u16() == 429 || status.is_server_error();
-                    if !retryable {
-                        return Ok(response);
-                    }
                     let retry_after = extract_retry_after(response.headers());
                     let body = bounded_error_text(response, ERROR_BODY_MAX_BYTES).await;
                     Err(LlmError::from_http_response_with_retry_after(

--- a/crates/tui/src/llm_client/mod.rs
+++ b/crates/tui/src/llm_client/mod.rs
@@ -202,7 +202,16 @@ impl LlmError {
             400 => {
                 // Classify 400 errors by examining the response body
                 let body_lower = body.to_lowercase();
-                if body_lower.contains("context_length")
+                if body_lower.contains("insufficientquota")
+                    || body_lower.contains("insufficient_quota")
+                    || body_lower.contains("exceeded your current quota")
+                    || body_lower.contains("quota exceeded")
+                {
+                    LlmError::RateLimited {
+                        message: body.to_string(),
+                        retry_after: None,
+                    }
+                } else if body_lower.contains("context_length")
                     || body_lower.contains("token")
                     || body_lower.contains("too long")
                     || body_lower.contains("maximum")
@@ -845,6 +854,14 @@ mod tests {
         // Context length
         let err = LlmError::from_http_response(400, "context_length_exceeded");
         assert!(matches!(err, LlmError::ContextLengthError(_)));
+
+        // Some OpenAI-compatible gateways return quota/rate-limit errors as HTTP 400.
+        let err = LlmError::from_http_response(
+            400,
+            r#"{"error":{"code":"insufficientquota","message":"You exceeded your current quota"}}"#,
+        );
+        assert!(matches!(err, LlmError::RateLimited { .. }));
+        assert!(err.is_retryable());
 
         // Content policy
         let err = LlmError::from_http_response(400, "content_policy_violation");


### PR DESCRIPTION
## Summary
- classify HTTP 400 quota/rate-limit gateway responses as `LlmError::RateLimited`
- let `send_with_retry()` route all non-success responses through unified `LlmError` classification
- add regression coverage for `400 + insufficientquota` being retryable

## Verification
- `git diff --check` ok
-  build and check on Mac OS，it's OK

User-provided verification notes report the equivalent patch passed `cargo fmt --all`, `cargo test -p deepseek-tui test_llm_error_from_http_response`, and `git diff --check` locally.