### PR TITLE
fix(tui): preserve upstream stream pacing

### DIFF
--- a/crates/tui/src/tui/streaming/chunking.rs
+++ b/crates/tui/src/tui/streaming/chunking.rs
@@ -7,8 +7,12 @@
 //! # Mental model
 //!
 //! Two gears:
-//! - [`ChunkingMode::Smooth`]: drain one display chunk per commit tick (steady pacing).
-//! - [`ChunkingMode::CatchUp`]: drain a bounded burst while pressure exists.
+//! - [`ChunkingMode::Smooth`]: normal pressure.
+//! - [`ChunkingMode::CatchUp`]: elevated pressure.
+//!
+//! Normal-motion callers drain all currently available chunks so the display
+//! follows the upstream SSE delta cadence. Low-motion callers stay in Smooth
+//! and drain one chunk per tick to reduce visual churn.
 //!
 //! # Hysteresis
 //!
@@ -67,10 +71,10 @@ pub struct QueueSnapshot {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum DrainPlan {
+    /// Emit all queued chunks available at this tick.
+    Available,
     /// Emit exactly one queued line.
     Single,
-    /// Emit up to `usize` queued lines.
-    Batch(usize),
 }
 
 /// Represents one policy decision for a specific queue snapshot.
@@ -145,7 +149,7 @@ impl AdaptiveChunkingPolicy {
             return ChunkingDecision {
                 mode: self.mode,
                 entered_catch_up: false,
-                drain_plan: DrainPlan::Single,
+                drain_plan: DrainPlan::Available,
             };
         }
 
@@ -157,15 +161,10 @@ impl AdaptiveChunkingPolicy {
             }
         };
 
-        let drain_plan = match self.mode {
-            ChunkingMode::Smooth => DrainPlan::Single,
-            ChunkingMode::CatchUp => DrainPlan::Batch(snapshot.queued_lines.max(1)),
-        };
-
         ChunkingDecision {
             mode: self.mode,
             entered_catch_up,
-            drain_plan,
+            drain_plan: DrainPlan::Available,
         }
     }
 
@@ -256,9 +255,10 @@ mod tests {
     }
 
     #[test]
-    fn smooth_only_burst_emits_one_per_tick() {
+    fn smooth_only_burst_drains_available_chunks_in_normal_motion() {
         // Five slowly-arriving lines, each well below enter thresholds, never
-        // flip the policy out of `Smooth`. Each decision should plan a single drain.
+        // flip the policy out of `Smooth`. Normal motion still drains what is
+        // already available so display pacing follows upstream deltas.
         let mut policy = AdaptiveChunkingPolicy::new();
         let t0 = Instant::now();
 
@@ -267,7 +267,7 @@ mod tests {
             let decision = policy.decide(snap(1, 10), t0 + Duration::from_millis(50 * i));
             assert_eq!(decision.mode, ChunkingMode::Smooth);
             assert!(!decision.entered_catch_up);
-            assert_eq!(decision.drain_plan, DrainPlan::Single);
+            assert_eq!(decision.drain_plan, DrainPlan::Available);
         }
     }
 
@@ -276,25 +276,22 @@ mod tests {
         // A burst crossing ENTER_QUEUE_DEPTH_LINES enters CatchUp. With
         // single-grapheme chunks, the threshold stays high enough that
         // ordinary prose still drips in visibly before catch-up engages.
-        // The policy should enter `CatchUp` and request a Batch drain matching
-        // the queue depth.
+        // The policy should enter `CatchUp`, while normal-motion draining still
+        // preserves the already-arrived upstream burst.
         let mut policy = AdaptiveChunkingPolicy::new();
         let now = Instant::now();
 
         let decision = policy.decide(snap(ENTER_QUEUE_DEPTH_LINES, 10), now);
         assert_eq!(decision.mode, ChunkingMode::CatchUp);
         assert!(decision.entered_catch_up);
-        assert_eq!(
-            decision.drain_plan,
-            DrainPlan::Batch(ENTER_QUEUE_DEPTH_LINES)
-        );
+        assert_eq!(decision.drain_plan, DrainPlan::Available);
 
         // Larger backlog requested next tick: still CatchUp, batch grows to match.
         let larger_backlog = ENTER_QUEUE_DEPTH_LINES + 80;
         let decision = policy.decide(snap(larger_backlog, 30), now + Duration::from_millis(10));
         assert_eq!(decision.mode, ChunkingMode::CatchUp);
         assert!(!decision.entered_catch_up, "no second transition signal");
-        assert_eq!(decision.drain_plan, DrainPlan::Batch(larger_backlog));
+        assert_eq!(decision.drain_plan, DrainPlan::Available);
     }
 
     #[test]
@@ -307,7 +304,7 @@ mod tests {
         let decision = policy.decide(snap(2, ENTER_OLDEST_AGE.as_millis() as u64), now);
         assert_eq!(decision.mode, ChunkingMode::CatchUp);
         assert!(decision.entered_catch_up);
-        assert_eq!(decision.drain_plan, DrainPlan::Batch(2));
+        assert_eq!(decision.drain_plan, DrainPlan::Available);
     }
 
     #[test]
@@ -341,7 +338,7 @@ mod tests {
             t0 + Duration::from_millis(320),
         );
         assert_eq!(post_hold.mode, ChunkingMode::Smooth);
-        assert_eq!(post_hold.drain_plan, DrainPlan::Single);
+        assert_eq!(post_hold.drain_plan, DrainPlan::Available);
     }
 
     #[test]
@@ -355,7 +352,7 @@ mod tests {
 
         let decision = policy.decide(empty_snap(), now + Duration::from_millis(10));
         assert_eq!(decision.mode, ChunkingMode::Smooth);
-        assert_eq!(decision.drain_plan, DrainPlan::Single);
+        assert_eq!(decision.drain_plan, DrainPlan::Available);
     }
 
     #[test]
@@ -374,7 +371,7 @@ mod tests {
             t0 + Duration::from_millis(100),
         );
         assert_eq!(held.mode, ChunkingMode::Smooth);
-        assert_eq!(held.drain_plan, DrainPlan::Single);
+        assert_eq!(held.drain_plan, DrainPlan::Available);
 
         // Past the hold: re-entry permitted.
         let reentered = policy.decide(
@@ -382,10 +379,7 @@ mod tests {
             t0 + Duration::from_millis(400),
         );
         assert_eq!(reentered.mode, ChunkingMode::CatchUp);
-        assert_eq!(
-            reentered.drain_plan,
-            DrainPlan::Batch(ENTER_QUEUE_DEPTH_LINES)
-        );
+        assert_eq!(reentered.drain_plan, DrainPlan::Available);
     }
 
     #[test]
@@ -403,10 +397,7 @@ mod tests {
             t0 + Duration::from_millis(100),
         );
         assert_eq!(severe.mode, ChunkingMode::CatchUp);
-        assert_eq!(
-            severe.drain_plan,
-            DrainPlan::Batch(SEVERE_QUEUE_DEPTH_LINES)
-        );
+        assert_eq!(severe.drain_plan, DrainPlan::Available);
     }
 
     #[test]
@@ -460,9 +451,6 @@ mod tests {
         );
         assert_eq!(d2.mode, ChunkingMode::CatchUp);
         assert!(d2.entered_catch_up);
-        assert_eq!(
-            d2.drain_plan,
-            DrainPlan::Batch(ENTER_QUEUE_DEPTH_LINES + 80)
-        );
+        assert_eq!(d2.drain_plan, DrainPlan::Available);
     }
 }

--- a/crates/tui/src/tui/streaming/commit_tick.rs
+++ b/crates/tui/src/tui/streaming/commit_tick.rs
@@ -2,8 +2,10 @@
 //!
 //! Bridges [`AdaptiveChunkingPolicy`] with a concrete [`StreamChunker`] queue.
 //! Callers feed raw text deltas via [`StreamChunker::push_delta`], then call
-//! [`run_commit_tick`] on every commit beat to obtain the next small text
-//! slice to flush to the transcript on this beat.
+//! [`run_commit_tick`] on every commit beat to obtain text to flush to the
+//! transcript on this beat. Normal motion drains all text received since the
+//! prior tick so the display follows the upstream delta cadence. Low-motion
+//! mode keeps the old one-grapheme drip to reduce visual churn.
 //!
 //! The chunker is the unit of streaming — one per active block (assistant /
 //! thinking). Tool output is unbuffered and bypasses this path.
@@ -20,8 +22,6 @@ use super::chunking::DrainPlan;
 use super::chunking::QueueSnapshot;
 
 const GRAPHEMES_PER_MICRO_CHUNK: usize = 1;
-const CATCH_UP_MAX_MICRO_CHUNKS: usize = 12;
-
 /// Buffers raw stream deltas and emits committed text in small display chunks.
 #[derive(Debug, Default)]
 pub struct StreamChunker {
@@ -152,8 +152,8 @@ pub fn run_commit_tick(
     }
 
     let max = match decision.drain_plan {
+        DrainPlan::Available => snapshot.queued_lines,
         DrainPlan::Single => 1,
-        DrainPlan::Batch(n) => n.min(CATCH_UP_MAX_MICRO_CHUNKS),
     };
 
     // Drain through the chunker; an empty queue under Smooth produces "".
@@ -204,35 +204,53 @@ mod tests {
 
         chunker.push_delta("hello world");
         let out = run_commit_tick(&mut policy, &mut chunker, now);
-        assert_eq!(out.committed_text, "h");
-        assert!(!chunker.is_idle(), "remaining prose should keep dripping");
+        assert_eq!(out.committed_text, "hello world");
+        assert!(
+            chunker.is_idle(),
+            "normal motion should preserve upstream pacing"
+        );
 
         let out = run_commit_tick(&mut policy, &mut chunker, now + Duration::from_millis(5));
+        assert_eq!(out.committed_text, "");
+    }
+
+    #[test]
+    fn low_motion_keeps_smooth_micro_chunk_pacing() {
+        let mut chunker = StreamChunker::new();
+        let mut policy = AdaptiveChunkingPolicy::new();
+        policy.set_low_motion(true);
+        let now = Instant::now();
+
+        chunker.push_delta("hello world");
+        let out = run_commit_tick(&mut policy, &mut chunker, now);
+        assert_eq!(out.committed_text, "h");
+        assert!(!chunker.is_idle(), "low motion should keep dripping");
+
+        let out = run_commit_tick(&mut policy, &mut chunker, now + Duration::from_millis(20));
         assert_eq!(out.committed_text, "e");
     }
 
     #[test]
-    fn smooth_burst_emits_one_micro_chunk_per_tick() {
+    fn normal_motion_burst_drains_available_backlog() {
         let mut chunker = StreamChunker::new();
         let mut policy = AdaptiveChunkingPolicy::new();
         let t0 = Instant::now();
 
         chunker.push_delta("abc");
-        // Each tick under Smooth pulls exactly one grapheme.
         let out1 = run_commit_tick(&mut policy, &mut chunker, t0);
         assert_eq!(out1.decision.mode, ChunkingMode::Smooth);
-        assert_eq!(out1.committed_text, "a");
+        assert_eq!(out1.committed_text, "abc");
+        assert!(out1.is_idle);
+
         let out2 = run_commit_tick(&mut policy, &mut chunker, t0 + Duration::from_millis(20));
-        assert_eq!(out2.committed_text, "b");
-        let out3 = run_commit_tick(&mut policy, &mut chunker, t0 + Duration::from_millis(40));
-        assert_eq!(out3.committed_text, "c");
-        assert!(out3.is_idle);
+        assert_eq!(out2.committed_text, "");
     }
 
     #[test]
-    fn smooth_stream_keeps_combining_marks_with_base_letter() {
+    fn low_motion_stream_keeps_combining_marks_with_base_letter() {
         let mut chunker = StreamChunker::new();
         let mut policy = AdaptiveChunkingPolicy::new();
+        policy.set_low_motion(true);
         let t0 = Instant::now();
 
         chunker.push_delta("e\u{301}x");
@@ -243,23 +261,20 @@ mod tests {
     }
 
     #[test]
-    fn large_burst_drains_in_catch_up_without_full_jump() {
-        // A large text burst arriving "at once" must trigger CatchUp on the first
-        // commit tick without dumping the full backlog in one jump.
+    fn large_burst_preserves_upstream_burst_in_normal_motion() {
+        // A large text burst arriving "at once" should be displayed at the
+        // same cadence instead of being synthetically dripped and then flushed
+        // at the end of the turn.
         let mut chunker = StreamChunker::new();
         let mut policy = AdaptiveChunkingPolicy::new();
         let now = Instant::now();
 
         let burst = "abcdefghijklmnopqrstuvwxyz".repeat(8);
-        let expected_prefix: String = burst
-            .chars()
-            .take(CATCH_UP_MAX_MICRO_CHUNKS * GRAPHEMES_PER_MICRO_CHUNK)
-            .collect();
         chunker.push_delta(&burst);
         let out = run_commit_tick(&mut policy, &mut chunker, now);
         assert_eq!(out.decision.mode, ChunkingMode::CatchUp);
-        assert_eq!(out.committed_text, expected_prefix);
-        assert!(!out.is_idle);
+        assert_eq!(out.committed_text, burst);
+        assert!(out.is_idle);
     }
 
     #[test]

--- a/crates/tui/src/tui/streaming/mod.rs
+++ b/crates/tui/src/tui/streaming/mod.rs
@@ -558,9 +558,8 @@ mod tests {
         state.start_text(0, None);
         state.push_content(0, "hello world");
 
-        assert_eq!(state.commit_text(0), "h");
-        assert_eq!(state.commit_text(0), "e");
-        assert!(state.has_pending_chunker_lines(0));
+        assert_eq!(state.commit_text(0), "hello world");
+        assert!(!state.has_pending_chunker_lines(0));
     }
 
     #[test]
@@ -569,15 +568,15 @@ mod tests {
         state.start_thinking(0, None);
         state.push_content(0, "thinking deeply");
 
-        assert_eq!(state.commit_text(0), "t");
-        assert_eq!(state.commit_text(0), "h");
-        assert!(state.has_pending_chunker_lines(0));
+        assert_eq!(state.commit_text(0), "thinking deeply");
+        assert!(!state.has_pending_chunker_lines(0));
     }
 
     #[test]
     fn finalize_preserves_uncommitted_micro_chunks() {
         let mut state = StreamingState::new();
         state.start_text(0, None);
+        state.set_low_motion(true);
         state.push_content(0, "abc");
         assert_eq!(state.commit_text(0), "a");
 


### PR DESCRIPTION
• ## Summary

  Fixes #1200.

  - Preserve upstream SSE delta cadence for normal-motion streaming by draining the text already available on each commit tick.
  - Remove the artificial one-grapheme drip that made output look uniformly throttled and then flush at the end.
  - Keep the previous one-grapheme pacing for low-motion mode to reduce visual churn.

  ## Testing

  - [x] `cargo test --workspace --all-features`
  - [x] `cargo fmt --all -- --check`
  - [x] `cargo clippy --workspace --all-targets --all-features`
  - [x] `cargo test -p deepseek-tui --test qa_pty -- --nocapture`
  - [x] Manual TUI smoke: launched `target/debug/deepseek-tui` with local API key and confirmed a real streamed response completed.

  ## Checklist

  - [x] Updated docs or comments as needed
  - [x] Added or updated tests where relevant
  - [x] Verified TUI behavior manually if UI changes