### PR TITLE
docs(docker): prefer writable named data volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # DeepSeek-TUI multi-arch Docker image (#501)
 #
 # Build:  docker buildx build --platform linux/amd64,linux/arm64 -t deepseek-tui:latest .
-# Run:    docker run --rm -it -e DEEPSEEK_API_KEY -v ~/.deepseek:/home/deepseek/.deepseek deepseek-tui
+# Run:    docker run --rm -it -e DEEPSEEK_API_KEY -v deepseek-tui-home:/home/deepseek/.deepseek deepseek-tui
 #
 # The image ships both binaries (deepseek dispatcher + deepseek-tui runtime)
 # in a minimal runtime layer. No MCP servers or heavy toolchains are included

--- a/README.md
+++ b/README.md
@@ -292,9 +292,11 @@ deepseek update                                  # check for and apply binary up
 Docker images are published to GHCR for release builds:
 
 ```bash
+docker volume create deepseek-tui-home
+
 docker run --rm -it \
   -e DEEPSEEK_API_KEY="$DEEPSEEK_API_KEY" \
-  -v ~/.deepseek:/home/deepseek/.deepseek \
+  -v deepseek-tui-home:/home/deepseek/.deepseek \
   ghcr.io/hmbown/deepseek-tui:latest
 ```
 

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -9,12 +9,14 @@ docker pull ghcr.io/hmbown/deepseek-tui:latest
 
 ## Quick start
 
-Run the published image with your existing config directory mounted:
+Run the published image with a Docker-managed data volume:
 
 ```bash
+docker volume create deepseek-tui-home
+
 docker run --rm -it \
   -e DEEPSEEK_API_KEY="$DEEPSEEK_API_KEY" \
-  -v ~/.deepseek:/home/deepseek/.deepseek \
+  -v deepseek-tui-home:/home/deepseek/.deepseek \
   ghcr.io/hmbown/deepseek-tui:latest
 ```
 
@@ -23,7 +25,7 @@ Use a pinned release tag for reproducible installs:
 ```bash
 docker run --rm -it \
   -e DEEPSEEK_API_KEY="$DEEPSEEK_API_KEY" \
-  -v ~/.deepseek:/home/deepseek/.deepseek \
+  -v deepseek-tui-home:/home/deepseek/.deepseek \
   ghcr.io/hmbown/deepseek-tui:v0.8.20
 ```
 
@@ -35,12 +37,12 @@ Build the image locally from a checkout:
 docker build -t deepseek-tui .
 ```
 
-Then run it with your existing config directory mounted:
+Then run it with the same Docker-managed data volume:
 
 ```bash
 docker run --rm -it \
   -e DEEPSEEK_API_KEY="$DEEPSEEK_API_KEY" \
-  -v ~/.deepseek:/home/deepseek/.deepseek \
+  -v deepseek-tui-home:/home/deepseek/.deepseek \
   deepseek-tui
 ```
 
@@ -57,14 +59,36 @@ registry.
 
 ## Volumes
 
-Mount `~/.deepseek` to persist sessions, config, skills, memory, and the offline queue
-across container restarts:
+Mount `/home/deepseek/.deepseek` to persist sessions, config, skills, memory,
+and the offline queue across container restarts. A Docker-managed named volume
+is the safest default because Docker creates it with ownership the container can
+write:
 
 ```bash
--v ~/.deepseek:/home/deepseek/.deepseek
+-v deepseek-tui-home:/home/deepseek/.deepseek
 ```
 
 Without this mount the container starts fresh each time.
+
+If you bind-mount an existing host directory instead, the image runs as the
+non-root `deepseek` user with UID/GID `1000:1000`. The mounted directory must be
+writable by that user, or startup can fail while creating runtime directories
+under `.deepseek/tasks`. On Linux hosts, either use the named volume above or
+prepare the bind mount explicitly:
+
+```bash
+mkdir -p ~/.deepseek
+sudo chown -R 1000:1000 ~/.deepseek
+
+docker run --rm -it \
+  -e DEEPSEEK_API_KEY="$DEEPSEEK_API_KEY" \
+  -v ~/.deepseek:/home/deepseek/.deepseek \
+  ghcr.io/hmbown/deepseek-tui:latest
+```
+
+That `chown` changes ownership of the host `~/.deepseek` directory. Skip it if
+you do not want the container UID to own your local config, and use a named
+volume instead.
 
 ## Non-interactive / pipeline usage
 


### PR DESCRIPTION
Closes #1204

## Summary
- switch Docker examples from a host bind mount to a Docker-managed named volume for the persisted .deepseek data directory
- document that the runtime runs as UID/GID 1000:1000 and bind-mounted host directories must be writable by that user
- include an explicit Linux bind-mount preparation path plus a warning that chown changes host ownership

## Test plan
- git diff --check