### PR TITLE
docs(readme): use dispatcher path for PR prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ deepseek resume <SESSION_ID>                     # resume a specific session by 
 deepseek fork <SESSION_ID>                       # fork a session at a chosen turn
 deepseek serve --http                            # HTTP/SSE API server
 deepseek serve --acp                             # ACP stdio adapter for Zed/custom agents
-deepseek pr <N>                                  # fetch PR and pre-seed review prompt
+deepseek run pr <N>                              # fetch PR and pre-seed review prompt
 deepseek mcp list                                # list configured MCP servers
 deepseek mcp validate                            # validate MCP config/connectivity
 deepseek mcp-server                              # run dispatcher MCP stdio server


### PR DESCRIPTION
## Summary
- update the README PR prompt example to use the dispatcher-supported `deepseek run pr <N>` path
- verified `deepseek --help` still exposes `--yolo`; the README does not document a CLI reasoning-effort flag

## Test plan
- `deepseek --help`
- `deepseek run pr --help`
- `rg -n "deepseek pr <|deepseek run pr <|--yolo|reasoning-effort" README.md`
- `git diff --check`

Closes #1221.