### PR TITLE
chore(release): prepare v0.8.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-agent"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "deepseek-config",
  "serde",
@@ -1160,7 +1160,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-app-server"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "anyhow",
  "axum",
@@ -1182,7 +1182,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-config"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "anyhow",
  "deepseek-secrets",
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-core"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-execpolicy"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "anyhow",
  "deepseek-protocol",
@@ -1221,7 +1221,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-hooks"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1235,7 +1235,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-mcp"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "anyhow",
  "serde",
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-protocol"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "serde",
  "serde_json",
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-secrets"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "dirs",
  "keyring",
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-state"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-tools"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1290,7 +1290,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-tui"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "anyhow",
  "arboard",
@@ -1351,7 +1351,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-tui-cli"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1375,7 +1375,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-tui-core"
-version = "0.8.20"
+version = "0.8.21"
 
 [[package]]
 name = "deranged"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = ["crates/cli", "crates/app-server", "crates/tui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.8.20"
+version = "0.8.21"
 edition = "2024"
 # Rust 1.88 stabilized `let_chains` in `if`/`while` conditions, which the
 # codebase relies on extensively. Cargo enforces this so users on older

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -7,5 +7,5 @@ repository.workspace = true
 description = "Model/provider registry and fallback strategy for DeepSeek workspace architecture"
 
 [dependencies]
-deepseek-config = { path = "../config", version = "0.8.20" }
+deepseek-config = { path = "../config", version = "0.8.21" }
 serde.workspace = true

--- a/crates/app-server/Cargo.toml
+++ b/crates/app-server/Cargo.toml
@@ -10,15 +10,15 @@ description = "Codex-style app-server transport for DeepSeek workspace architect
 anyhow.workspace = true
 axum.workspace = true
 clap.workspace = true
-deepseek-agent = { path = "../agent", version = "0.8.20" }
-deepseek-config = { path = "../config", version = "0.8.20" }
-deepseek-core = { path = "../core", version = "0.8.20" }
-deepseek-execpolicy = { path = "../execpolicy", version = "0.8.20" }
-deepseek-hooks = { path = "../hooks", version = "0.8.20" }
-deepseek-mcp = { path = "../mcp", version = "0.8.20" }
-deepseek-protocol = { path = "../protocol", version = "0.8.20" }
-deepseek-state = { path = "../state", version = "0.8.20" }
-deepseek-tools = { path = "../tools", version = "0.8.20" }
+deepseek-agent = { path = "../agent", version = "0.8.21" }
+deepseek-config = { path = "../config", version = "0.8.21" }
+deepseek-core = { path = "../core", version = "0.8.21" }
+deepseek-execpolicy = { path = "../execpolicy", version = "0.8.21" }
+deepseek-hooks = { path = "../hooks", version = "0.8.21" }
+deepseek-mcp = { path = "../mcp", version = "0.8.21" }
+deepseek-protocol = { path = "../protocol", version = "0.8.21" }
+deepseek-state = { path = "../state", version = "0.8.21" }
+deepseek-tools = { path = "../tools", version = "0.8.21" }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -14,13 +14,13 @@ path = "src/main.rs"
 anyhow.workspace = true
 clap.workspace = true
 clap_complete.workspace = true
-deepseek-agent = { path = "../agent", version = "0.8.20" }
-deepseek-app-server = { path = "../app-server", version = "0.8.20" }
-deepseek-config = { path = "../config", version = "0.8.20" }
-deepseek-execpolicy = { path = "../execpolicy", version = "0.8.20" }
-deepseek-mcp = { path = "../mcp", version = "0.8.20" }
-deepseek-secrets = { path = "../secrets", version = "0.8.20" }
-deepseek-state = { path = "../state", version = "0.8.20" }
+deepseek-agent = { path = "../agent", version = "0.8.21" }
+deepseek-app-server = { path = "../app-server", version = "0.8.21" }
+deepseek-config = { path = "../config", version = "0.8.21" }
+deepseek-execpolicy = { path = "../execpolicy", version = "0.8.21" }
+deepseek-mcp = { path = "../mcp", version = "0.8.21" }
+deepseek-secrets = { path = "../secrets", version = "0.8.21" }
+deepseek-state = { path = "../state", version = "0.8.21" }
 chrono.workspace = true
 dirs.workspace = true
 serde.workspace = true

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -8,7 +8,7 @@ description = "Config schema and precedence model for DeepSeek workspace archite
 
 [dependencies]
 anyhow.workspace = true
-deepseek-secrets = { path = "../secrets", version = "0.8.20" }
+deepseek-secrets = { path = "../secrets", version = "0.8.21" }
 dirs.workspace = true
 serde.workspace = true
 toml.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -9,13 +9,13 @@ description = "Core runtime boundaries for DeepSeek workspace architecture"
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true
-deepseek-agent = { path = "../agent", version = "0.8.20" }
-deepseek-config = { path = "../config", version = "0.8.20" }
-deepseek-execpolicy = { path = "../execpolicy", version = "0.8.20" }
-deepseek-hooks = { path = "../hooks", version = "0.8.20" }
-deepseek-mcp = { path = "../mcp", version = "0.8.20" }
-deepseek-protocol = { path = "../protocol", version = "0.8.20" }
-deepseek-state = { path = "../state", version = "0.8.20" }
-deepseek-tools = { path = "../tools", version = "0.8.20" }
+deepseek-agent = { path = "../agent", version = "0.8.21" }
+deepseek-config = { path = "../config", version = "0.8.21" }
+deepseek-execpolicy = { path = "../execpolicy", version = "0.8.21" }
+deepseek-hooks = { path = "../hooks", version = "0.8.21" }
+deepseek-mcp = { path = "../mcp", version = "0.8.21" }
+deepseek-protocol = { path = "../protocol", version = "0.8.21" }
+deepseek-state = { path = "../state", version = "0.8.21" }
+deepseek-tools = { path = "../tools", version = "0.8.21" }
 serde_json.workspace = true
 uuid.workspace = true

--- a/crates/execpolicy/Cargo.toml
+++ b/crates/execpolicy/Cargo.toml
@@ -8,5 +8,5 @@ description = "Execution policy and approval model parity for DeepSeek workspace
 
 [dependencies]
 anyhow.workspace = true
-deepseek-protocol = { path = "../protocol", version = "0.8.20" }
+deepseek-protocol = { path = "../protocol", version = "0.8.21" }
 serde.workspace = true

--- a/crates/hooks/Cargo.toml
+++ b/crates/hooks/Cargo.toml
@@ -10,7 +10,7 @@ description = "Hook dispatch and notifications parity for DeepSeek workspace arc
 anyhow.workspace = true
 async-trait.workspace = true
 chrono.workspace = true
-deepseek-protocol = { path = "../protocol", version = "0.8.20" }
+deepseek-protocol = { path = "../protocol", version = "0.8.21" }
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -9,7 +9,7 @@ description = "Tool invocation lifecycle, schema validation, and scheduler paral
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
-deepseek-protocol = { path = "../protocol", version = "0.8.20" }
+deepseek-protocol = { path = "../protocol", version = "0.8.21" }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -21,8 +21,8 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0.100"
 arboard = "3.4"
-deepseek-secrets = { path = "../secrets", version = "0.8.20" }
-deepseek-tools = { path = "../tools", version = "0.8.20" }
+deepseek-secrets = { path = "../secrets", version = "0.8.21" }
+deepseek-tools = { path = "../tools", version = "0.8.21" }
 schemaui = { version = "0.12.0", default-features = false, optional = true }
 async-stream = "0.3.6"
 async-trait = "0.1"

--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -618,8 +618,8 @@ mod tests {
     fn package_version_is_current_hotfix_release() {
         assert_eq!(
             env!("CARGO_PKG_VERSION"),
-            "0.8.20",
-            "0.8.20 release branch must report the release version before publishing"
+            "0.8.21",
+            "0.8.21 release branch must report the release version before publishing"
         );
     }
 

--- a/npm/deepseek-tui/package.json
+++ b/npm/deepseek-tui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-tui",
-  "version": "0.8.20",
-  "deepseekBinaryVersion": "0.8.20",
+  "version": "0.8.21",
+  "deepseekBinaryVersion": "0.8.21",
   "description": "Install and run deepseek and deepseek-tui binaries from GitHub release artifacts.",
   "author": "Hmbown",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- bump the Rust workspace and internal path dependency pins to 0.8.21
- update Cargo.lock local package versions for the release bump
- bump the npm wrapper version and deepseekBinaryVersion to 0.8.21
- update the prompt package-version guard for the v0.8.21 release branch

## Test plan
- cargo fmt --all -- --check
- cargo check --workspace --all-targets --locked
- cargo test --workspace --all-features --locked
- ./scripts/release/check-versions.sh