### PR TITLE
fix(statusline): wire GitBranch to footer rendering

### DIFF
--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -6652,7 +6652,8 @@ fn render_footer_from(
     for item in items {
         let chip = match *item {
             S::ContextPercent => footer_context_percent_spans(app),
-            S::GitBranch | S::LastToolElapsed | S::RateLimit => Vec::new(),
+            S::GitBranch => footer_git_branch_spans(app),
+            S::LastToolElapsed | S::RateLimit => Vec::new(),
             _ => continue,
         };
         if chip.is_empty() {
@@ -6693,6 +6694,17 @@ fn footer_context_percent_spans(app: &App) -> Vec<Span<'static>> {
     vec![Span::styled(
         format!("active ctx {percent:.0}%"),
         Style::default().fg(color),
+    )]
+}
+
+fn footer_git_branch_spans(app: &App) -> Vec<Span<'static>> {
+    let workspace = app.workspace.as_path();
+    let Some(branch) = workspace_git_branch(workspace) else {
+        return Vec::new();
+    };
+    vec![Span::styled(
+        format!("git:{branch}"),
+        Style::default().fg(app.ui_theme.text_muted),
     )]
 }
 


### PR DESCRIPTION
Previously S::GitBranch was exposed in /statusline picker and persisted to config, but the footer render path always returned Vec::new(). Wire it up by:

- Adding S::GitBranch => footer_git_branch_spans(app) in the match
- Adding footer_git_branch_spans() that calls the already-implemented workspace_git_branch() and formats as "git:{branch}"

Fixes #1217

## Summary

## Testing

- [ ] `cargo test --all-features`
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
