### PR TITLE
fix(cli): forward --yolo flag to TUI binary for run command

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,7 @@
 # DEEPSEEK_APPROVAL_POLICY=on-request
 # DEEPSEEK_SANDBOX_MODE=workspace-write
 # DEEPSEEK_ALLOW_SHELL=true
+# DEEPSEEK_YOLO=true
 
 # Optional extension paths
 # DEEPSEEK_SKILLS_DIR=~/.deepseek/skills

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -92,6 +92,9 @@ struct Cli {
     no_mouse_capture: bool,
     #[arg(long = "skip-onboarding")]
     skip_onboarding: bool,
+    /// YOLO mode: auto-approve all tools
+    #[arg(long)]
+    yolo: bool,
     #[arg(short = 'p', long = "prompt", value_name = "PROMPT")]
     prompt_flag: Option<String>,
     #[arg(
@@ -425,6 +428,7 @@ fn run() -> Result<()> {
         telemetry: cli.telemetry,
         approval_policy: cli.approval_policy.clone(),
         sandbox_mode: cli.sandbox_mode.clone(),
+        yolo: Some(cli.yolo),
     };
     let command = cli.command.take();
 
@@ -1438,6 +1442,9 @@ fn build_tui_command(
     }
     if let Some(mode) = cli.sandbox_mode.as_ref() {
         cmd.env("DEEPSEEK_SANDBOX_MODE", mode);
+    }
+    if cli.yolo {
+        cmd.env("DEEPSEEK_YOLO", "true");
     }
     if let Some(api_key) = cli.api_key.as_ref() {
         cmd.env("DEEPSEEK_API_KEY", api_key);

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -950,6 +950,9 @@ impl ConfigToml {
             .clone()
             .or_else(|| env.sandbox_mode.clone())
             .or_else(|| self.sandbox_mode.clone());
+        let yolo = cli
+            .yolo
+            .or(env.yolo);
 
         ResolvedRuntimeOptions {
             provider,
@@ -963,6 +966,7 @@ impl ConfigToml {
             telemetry,
             approval_policy,
             sandbox_mode,
+            yolo,
             http_headers,
         }
     }
@@ -1099,6 +1103,7 @@ pub struct CliRuntimeOverrides {
     pub telemetry: Option<bool>,
     pub approval_policy: Option<String>,
     pub sandbox_mode: Option<String>,
+    pub yolo: Option<bool>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1134,6 +1139,7 @@ pub struct ResolvedRuntimeOptions {
     pub telemetry: bool,
     pub approval_policy: Option<String>,
     pub sandbox_mode: Option<String>,
+    pub yolo: Option<bool>,
     pub http_headers: BTreeMap<String, String>,
 }
 
@@ -1317,6 +1323,7 @@ struct EnvRuntimeOverrides {
     telemetry: Option<bool>,
     approval_policy: Option<String>,
     sandbox_mode: Option<String>,
+    yolo: Option<bool>,
     http_headers: Option<BTreeMap<String, String>>,
     deepseek_base_url: Option<String>,
     nvidia_base_url: Option<String>,
@@ -1344,6 +1351,9 @@ impl EnvRuntimeOverrides {
                 .and_then(|v| parse_bool(&v).ok()),
             approval_policy: std::env::var("DEEPSEEK_APPROVAL_POLICY").ok(),
             sandbox_mode: std::env::var("DEEPSEEK_SANDBOX_MODE").ok(),
+            yolo: std::env::var("DEEPSEEK_YOLO")
+                .ok()
+                .and_then(|v| parse_bool(&v).ok()),
             http_headers: std::env::var("DEEPSEEK_HTTP_HEADERS")
                 .ok()
                 .and_then(|value| parse_http_headers(&value).ok())

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -782,6 +782,7 @@ pub struct Config {
     pub allow_shell: Option<bool>,
     pub approval_policy: Option<String>,
     pub sandbox_mode: Option<String>,
+    pub yolo: Option<bool>,
     /// External sandbox backend: `"none"` or `"opensandbox"`.
     /// When set, exec_shell routes commands through the backend's HTTP API
     /// instead of spawning a local process.
@@ -2076,6 +2077,9 @@ fn apply_env_overrides(config: &mut Config) {
     if let Ok(value) = std::env::var("DEEPSEEK_SANDBOX_MODE") {
         config.sandbox_mode = Some(value);
     }
+    if let Ok(value) = std::env::var("DEEPSEEK_YOLO") {
+        config.yolo = Some(value == "1" || value.eq_ignore_ascii_case("true"));
+    }
     if let Ok(value) = std::env::var("DEEPSEEK_SANDBOX_BACKEND") {
         config.sandbox_backend = Some(value);
     }
@@ -2420,6 +2424,7 @@ fn merge_config(base: Config, override_cfg: Config) -> Config {
         // both — they list `~/global.md` inside the project array.
         instructions: override_cfg.instructions.or(base.instructions),
         allow_shell: override_cfg.allow_shell.or(base.allow_shell),
+        yolo: override_cfg.yolo.or(base.yolo),
         approval_policy: override_cfg.approval_policy.or(base.approval_policy),
         sandbox_mode: override_cfg.sandbox_mode.or(base.sandbox_mode),
         sandbox_backend: override_cfg.sandbox_backend.or(base.sandbox_backend),

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -5465,6 +5465,7 @@ mod setup_helper_tests {
             "RUST_LOG",
             "DEEPSEEK_APPROVAL_POLICY",
             "DEEPSEEK_SANDBOX_MODE",
+            "DEEPSEEK_YOLO",
         ] {
             assert!(
                 keys.contains(required),


### PR DESCRIPTION
## Problem

The  flag only worked when passed through the dispatcher subcommands (e.g., ), but failed silently for the primary  usage shown in README:


This is because  delegates to the TUI binary without forwarding  as an env var. The other subcommands (Exec, Doctor, etc.) pass CLI flags via , which forward everything, but  goes through  which only set env vars for config-level options (model, api_key, sandbox_mode, etc.), not top-level flags like .

## Root cause

In , the  pattern was only applied when invoking the TUI via , not when delegating plain . The  flag on  was never forwarded as an env var to the TUI binary.

## Fix

1. Add  env var in  when  is set
2. TUI  already reads  env (matching the  pattern)
3. Add  field to , , and  to propagate through the full resolve chain
4. Add  to TUI  struct and merge function
5. Add  to 

## Testing

-  passes with no new errors
- The fix follows the existing pattern used for , , and 

## Related

Fixes #1221