### PR TITLE
docs(readme): sync zh-CN with run pr dispatcher path

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -232,7 +232,7 @@ deepseek resume --last                         # 恢复最近会话
 deepseek resume <SESSION_ID>                   # 按 UUID 恢复指定会话
 deepseek fork <SESSION_ID>                     # 在指定轮次分叉会话
 deepseek serve --http                          # HTTP/SSE API 服务
-deepseek pr <N>                                # 获取 PR 并预填审查提示
+deepseek run pr <N>                            # 获取 PR 并预填审查提示
 deepseek mcp list                              # 列出已配置 MCP 服务器
 deepseek mcp validate                          # 校验 MCP 配置和连接
 deepseek mcp-server                            # 启动 dispatcher MCP stdio 服务器


### PR DESCRIPTION
## Summary

Mirror PR #1227 in `README.zh-CN.md`: the usage example still shows `deepseek pr <N>`, which fails after the dispatcher rename. Updated to `deepseek run pr <N>` so the Chinese README matches the current CLI.

## Testing

Markdown-only change; no build/test impact.

- [x] Verified `deepseek run pr <N>` matches the EN README (line 285)
- [x] Visual diff: only one line in `README.zh-CN.md`, comment alignment preserved
- [ ] `cargo test` / `cargo clippy` — N/A for docs-only change

## Checklist

- [x] Updated docs or comments as needed
- [ ] Added or updated tests where relevant — N/A
- [ ] Verified TUI behavior manually if UI changes — N/A

> Drafted with AI assistance; verified by author before publishing.