### PR TITLE
fix(tui): drag-select auto-scrolls past edge; copy strips all rail decorations

### DIFF
--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -34,7 +34,7 @@ use crate::tui::file_mention::ContextReference;
 use crate::tui::history::{HistoryCell, TranscriptRenderOptions};
 use crate::tui::paste_burst::{FlushResult, PasteBurst};
 use crate::tui::scrolling::{MouseScrollState, TranscriptLineMeta, TranscriptScroll};
-use crate::tui::selection::TranscriptSelection;
+use crate::tui::selection::{SelectionAutoscroll, TranscriptSelection};
 use crate::tui::streaming::StreamingState;
 use crate::tui::transcript::TranscriptViewCache;
 use crate::tui::views::ViewStack;
@@ -574,6 +574,8 @@ pub struct ViewportState {
     pub mouse_scroll: MouseScrollState,
     pub transcript_cache: TranscriptViewCache,
     pub transcript_selection: TranscriptSelection,
+    pub selection_autoscroll: Option<SelectionAutoscroll>,
+    pub transcript_scrollbar_dragging: bool,
     pub last_transcript_area: Option<Rect>,
     pub last_transcript_top: usize,
     pub last_transcript_visible: usize,
@@ -590,6 +592,8 @@ impl Default for ViewportState {
             mouse_scroll: MouseScrollState::new(),
             transcript_cache: TranscriptViewCache::new(),
             transcript_selection: TranscriptSelection::default(),
+            selection_autoscroll: None,
+            transcript_scrollbar_dragging: false,
             last_transcript_area: None,
             last_transcript_top: 0,
             last_transcript_visible: 0,

--- a/crates/tui/src/tui/selection.rs
+++ b/crates/tui/src/tui/selection.rs
@@ -1,5 +1,7 @@
 //! Text selection state for the transcript view.
 
+use std::time::Instant;
+
 // === Types ===
 
 /// A selection endpoint in the transcript (line/column).
@@ -15,6 +17,20 @@ pub struct TranscriptSelection {
     pub anchor: Option<TranscriptSelectionPoint>,
     pub head: Option<TranscriptSelectionPoint>,
     pub dragging: bool,
+}
+
+/// Drag-past-edge auto-scroll state. While the user holds the left button
+/// and the cursor is above or below the transcript rect, the main loop
+/// advances `pending_scroll_delta` and extends the selection head on a
+/// fixed cadence so a long passage can be selected in one drag (#1163).
+#[derive(Debug, Clone, Copy)]
+pub struct SelectionAutoscroll {
+    /// `-1` scrolls up, `+1` scrolls down. Never `0`.
+    pub direction: i32,
+    /// Last in-bounds mouse column, in absolute terminal coordinates.
+    pub column: u16,
+    /// When the next tick is allowed to fire.
+    pub next_tick: Instant,
 }
 
 impl TranscriptSelection {

--- a/crates/tui/src/tui/transcript.rs
+++ b/crates/tui/src/tui/transcript.rs
@@ -73,6 +73,11 @@ pub struct TranscriptViewCache {
     lines: Vec<Line<'static>>,
     /// Per-line metadata aligned with `lines`.
     line_meta: Vec<TranscriptLineMeta>,
+    /// Per-line rail-prefix display-column count (`0` or `2`), aligned with
+    /// `lines`. Populated during flatten so that selection-to-text can shift
+    /// columns past visual-only decoration glyphs without guessing which
+    /// spans are decorative (#1163).
+    rail_prefix_widths: Vec<usize>,
 }
 
 impl TranscriptViewCache {
@@ -85,6 +90,7 @@ impl TranscriptViewCache {
             per_cell: Vec::new(),
             lines: Vec::new(),
             line_meta: Vec::new(),
+            rail_prefix_widths: Vec::new(),
         }
     }
 
@@ -219,6 +225,7 @@ impl TranscriptViewCache {
     fn flatten(&mut self, spacing: TranscriptSpacing) {
         self.lines.clear();
         self.line_meta.clear();
+        self.rail_prefix_widths.clear();
         self.append_flattened_cells(spacing, 0);
     }
 
@@ -243,6 +250,7 @@ impl TranscriptViewCache {
             .unwrap_or(self.lines.len());
         self.lines.truncate(truncate_at);
         self.line_meta.truncate(truncate_at);
+        self.rail_prefix_widths.truncate(truncate_at);
         self.append_flattened_cells(spacing, first_cell);
     }
 
@@ -256,7 +264,7 @@ impl TranscriptViewCache {
             // Deref is zero-cost and gives us &[Line].
             let rendered_line_count = cached.lines.len();
             for (line_in_cell, line) in cached.lines.iter().enumerate() {
-                self.lines.push(line_with_group_rail(
+                let final_line = line_with_group_rail(
                     line,
                     tool_group_rail(
                         self.per_cell.as_slice(),
@@ -265,7 +273,10 @@ impl TranscriptViewCache {
                         rendered_line_count,
                     ),
                     usize::from(self.width),
-                ));
+                );
+                self.rail_prefix_widths
+                    .push(compute_rail_prefix_width(&final_line));
+                self.lines.push(final_line);
                 self.line_meta.push(TranscriptLineMeta::CellLine {
                     cell_index,
                     line_in_cell,
@@ -277,6 +288,7 @@ impl TranscriptViewCache {
                 for _ in 0..spacer_rows {
                     self.lines.push(Line::from(""));
                     self.line_meta.push(TranscriptLineMeta::Spacer);
+                    self.rail_prefix_widths.push(0);
                 }
             }
         }
@@ -298,6 +310,18 @@ impl TranscriptViewCache {
     #[must_use]
     pub fn total_lines(&self) -> usize {
         self.lines.len()
+    }
+
+    /// Return the rail-prefix display-column count for the line at
+    /// `line_index`. Callers use this to shift selection coordinates past
+    /// visual-only decoration glyphs without guessing which spans are
+    /// decorative (#1163).
+    #[must_use]
+    pub fn rail_prefix_width(&self, line_index: usize) -> usize {
+        self.rail_prefix_widths
+            .get(line_index)
+            .copied()
+            .unwrap_or(0)
     }
 }
 
@@ -389,6 +413,75 @@ fn line_with_group_rail(
     spans.extend(rendered.spans);
     rendered.spans = truncate_spans_to_width(spans, max_width);
     rendered
+}
+
+/// Return the display-column count of consecutive visual-only decorative
+/// spans at the start of a rendered transcript line. Iterates through
+/// leading spans matching either of two patterns:
+///
+/// * Pattern A — span is `"<glyph>[<glyph>…]<space>"` where every character
+///   except the trailing space is a rail-drawing character (e.g. `▏ `,
+///   `▶ `, `⋮⋮ `). The entire span width is accumulated.
+/// * Pattern B — span is `"<glyph>"` (1 drawing char) followed by a lone
+///   space span `" "` (e.g. `●` then ` `, `▎` then ` `).
+///
+/// Stops at the first non-matching span. Every decorated glyph used by the
+/// TUI is a single display-column character, so char-count = display width.
+///
+/// Returns `0` for lines whose first span is not a decorative prefix.
+fn compute_rail_prefix_width(line: &Line<'static>) -> usize {
+    let spans = line.spans.as_slice();
+    let mut total = 0;
+    let mut i = 0;
+
+    while i < spans.len() {
+        let content = spans[i].content.as_ref();
+        let n_chars = content.chars().count();
+
+        // Pattern A — span "<glyph>[<glyph>…]<space>" (≥ 2 chars, trailing
+        // space, all preceding chars are drawing chars).
+        if n_chars >= 2
+            && content.ends_with(' ')
+            && content
+                .chars()
+                .take(n_chars.saturating_sub(1))
+                .all(is_rail_drawing_char)
+        {
+            total += n_chars;
+            i += 1;
+            continue;
+        }
+
+        // Pattern B — span "<glyph>" (1 drawing char) + next span " ".
+        if n_chars == 1
+            && content.chars().next().is_some_and(is_rail_drawing_char)
+            && spans.get(i + 1).is_some_and(|s| s.content.as_ref() == " ")
+        {
+            total += 2;
+            i += 2;
+            continue;
+        }
+
+        break;
+    }
+
+    total
+}
+
+/// Characters that serve as decoration glyphs in the TUI left-rail and
+/// tool-header prefix system. All are single display-column characters.
+fn is_rail_drawing_char(ch: char) -> bool {
+    matches!(
+        ch,
+        '\u{2500}'..='\u{257F}'   // Box Drawing (╭ ╮ ╰ ╯ │ ╎ …)
+        | '\u{2580}'..='\u{259F}' // Block Elements (▏ ▎ ▍ ▌ …)
+        | '\u{25A0}'..='\u{25FF}' // Geometric Shapes (● ▶ ▷ ◆ ◐ …)
+        | '\u{2022}'              // • bullet (tool status / generic tool)
+        | '\u{2026}'              // … ellipsis (reasoning opener)
+        | '\u{00B7}'              // · middle dot (tool running symbol)
+        | '\u{2315}'              // ⌕ telephone recorder (find/search tool)
+        | '\u{22EE}'              // ⋮ vertical ellipsis (fanout/rlm tool)
+    )
 }
 
 fn truncate_spans_to_width(spans: Vec<Span<'static>>, max_width: usize) -> Vec<Span<'static>> {

--- a/crates/tui/src/tui/transcript.rs
+++ b/crates/tui/src/tui/transcript.rs
@@ -910,4 +910,66 @@ mod tests {
             );
         }
     }
+
+    /// Simulate a long, complex conversation (thinking + multi-line tool output +
+    /// tool headers with multiple decorative spans) and report the memory
+    /// consumed by `rail_prefix_widths`. This is informational — the assertion
+    /// only fails if the per-line overhead exceeds a generous bound.
+    #[test]
+    fn rail_prefix_widths_memory_overhead_complex_session() {
+        let mut cells: Vec<HistoryCell> = Vec::new();
+        // Build ~60 turns covering the typical deep-reasoning workflow:
+        // user → thinking (5-15 lines) → assistant → tool → tool output →
+        // thinking → assistant → ... repeat.
+        for i in 0..30 {
+            cells.push(user_cell(&format!("complex query {i} about system design")));
+            cells.push(HistoryCell::Thinking {
+                content: format!(
+                    "line A\nline B\nline C\nline D\nline E\nline F\nline G\nline H\nline I\nline J"
+                ),
+                streaming: false,
+                duration_secs: Some(3.5),
+            });
+            cells.push(assistant_cell(
+                &format!("response {i} with multi-line\ntext content spanning\nseveral lines"),
+                false,
+            ));
+            cells.push(exec_tool_cell(&format!(
+                "cargo test --package my_crate -- --nocapture 2>&1 | head -40"
+            )));
+            // Insert a second tool so adjacent tool cells merge into a railed group.
+            cells.push(exec_tool_cell(&format!("git diff --stat HEAD~{i}")));
+        }
+        let revisions: Vec<u64> = (0..cells.len()).map(|i| i as u64 + 1).collect();
+
+        let mut cache = TranscriptViewCache::new();
+        cache.ensure(&cells, &revisions, 80, TranscriptRenderOptions::default());
+
+        let total_lines = cache.total_lines();
+        let pw_len = cache.rail_prefix_widths.len();
+        let pw_cap = cache.rail_prefix_widths.capacity();
+        // The Vec's inlined buffer on most platforms is small; capacity
+        // should be >= len. Both must equal total_lines.
+        assert_eq!(pw_len, total_lines);
+        assert!(pw_cap >= pw_len);
+
+        let memory_bytes = pw_cap * std::mem::size_of::<usize>();
+        let memory_kb = memory_bytes as f64 / 1024.0;
+        // Each usize is 8 bytes on 64-bit. Even with 100k lines this stays
+        // under 1 MB.
+        let kbytes_per_1k_lines = (memory_bytes as f64 / total_lines as f64) * 1000.0 / 1024.0;
+
+        eprintln!("=== rail_prefix_widths memory (complex session) ===");
+        eprintln!("  total_lines:       {total_lines}");
+        eprintln!("  vec len:           {pw_len}");
+        eprintln!("  vec capacity:      {pw_cap}");
+        eprintln!("  memory (bytes):    {memory_bytes}");
+        eprintln!("  memory (KB):       {memory_kb:.2}");
+        eprintln!("  KB per 1k lines:   {kbytes_per_1k_lines:.2}");
+        eprintln!("  lines × 8 bytes:   {} KB", total_lines * 8 / 1024);
+
+        // Sanity: per-line overhead must be reasonable.
+        assert!(memory_kb < 1024.0, "rail_prefix_widths memory unexpectedly large: {memory_kb:.1} KB");
+        eprintln!("  ✓ well under 1 MB even for very long sessions");
+    }
 }

--- a/crates/tui/src/tui/transcript.rs
+++ b/crates/tui/src/tui/transcript.rs
@@ -924,9 +924,8 @@ mod tests {
         for i in 0..30 {
             cells.push(user_cell(&format!("complex query {i} about system design")));
             cells.push(HistoryCell::Thinking {
-                content: format!(
-                    "line A\nline B\nline C\nline D\nline E\nline F\nline G\nline H\nline I\nline J"
-                ),
+                content: "line A\nline B\nline C\nline D\nline E\nline F\nline G\nline H\nline I\nline J"
+                    .to_string(),
                 streaming: false,
                 duration_secs: Some(3.5),
             });
@@ -934,9 +933,9 @@ mod tests {
                 &format!("response {i} with multi-line\ntext content spanning\nseveral lines"),
                 false,
             ));
-            cells.push(exec_tool_cell(&format!(
-                "cargo test --package my_crate -- --nocapture 2>&1 | head -40"
-            )));
+            cells.push(exec_tool_cell(
+                "cargo test --package my_crate -- --nocapture 2>&1 | head -40",
+            ));
             // Insert a second tool so adjacent tool cells merge into a railed group.
             cells.push(exec_tool_cell(&format!("git diff --stat HEAD~{i}")));
         }
@@ -969,7 +968,10 @@ mod tests {
         eprintln!("  lines × 8 bytes:   {} KB", total_lines * 8 / 1024);
 
         // Sanity: per-line overhead must be reasonable.
-        assert!(memory_kb < 1024.0, "rail_prefix_widths memory unexpectedly large: {memory_kb:.1} KB");
+        assert!(
+            memory_kb < 1024.0,
+            "rail_prefix_widths memory unexpectedly large: {memory_kb:.1} KB"
+        );
         eprintln!("  ✓ well under 1 MB even for very long sessions");
     }
 }

--- a/crates/tui/src/tui/transcript.rs
+++ b/crates/tui/src/tui/transcript.rs
@@ -924,8 +924,9 @@ mod tests {
         for i in 0..30 {
             cells.push(user_cell(&format!("complex query {i} about system design")));
             cells.push(HistoryCell::Thinking {
-                content: "line A\nline B\nline C\nline D\nline E\nline F\nline G\nline H\nline I\nline J"
-                    .to_string(),
+                content:
+                    "line A\nline B\nline C\nline D\nline E\nline F\nline G\nline H\nline I\nline J"
+                        .to_string(),
                 streaming: false,
                 duration_secs: Some(3.5),
             });

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -81,9 +81,7 @@ use crate::tui::tool_routing::exploring_label;
 use crate::tui::tool_routing::{
     handle_tool_call_complete, handle_tool_call_started, maybe_add_patch_preview,
 };
-use crate::tui::ui_text::{
-    history_cell_to_text, line_to_plain_for_copy, slice_text, text_display_width,
-};
+use crate::tui::ui_text::{history_cell_to_text, line_to_plain, slice_text, text_display_width};
 use crate::tui::user_input::UserInputView;
 use crate::tui::views::subagent_view_agents;
 
@@ -7999,8 +7997,23 @@ fn selection_to_text(app: &App) -> Option<String> {
     let mut selected_lines = Vec::new();
     #[allow(clippy::needless_range_loop)]
     for line_index in start_index..=end_index {
-        let (line_text, rail_width) = line_to_plain_for_copy(&lines[line_index]);
+        // Rail-prefix decorations are stored as cache metadata rather than
+        // detected from glyphs, so new decoration types are covered without
+        // changes to the copy path (#1163).
+        let rail_width = app.viewport.transcript_cache.rail_prefix_width(line_index);
+        // Convert the rendered line to plain text (strips OSC-8), then
+        // slice off the rail prefix so subsequent column offsets operate
+        // on content-only text.
+        let full_text = line_to_plain(&lines[line_index]);
+        let line_text = if rail_width > 0 {
+            slice_text(&full_text, rail_width, text_display_width(&full_text))
+        } else {
+            full_text
+        };
         let line_width = text_display_width(&line_text);
+        // Selection coordinates are recorded in rendered-column space, which
+        // includes the visual rail prefix. Add rail_width back so the column
+        // window maps correctly into the rail-stripped text.
         let (raw_col_start, raw_col_end) = if start_index == end_index {
             (start.column, end.column)
         } else if line_index == start_index {
@@ -8011,10 +8024,6 @@ fn selection_to_text(app: &App) -> Option<String> {
             (0, line_width.saturating_add(rail_width))
         };
 
-        // The recorded selection columns include the rail prefix because
-        // selection coordinates are taken from the rendered viewport. Shift
-        // them left by the rail width and clamp to the rail-stripped line so
-        // a click that lands on the rail glyph itself collapses to column 0.
         let col_start = raw_col_start.saturating_sub(rail_width).min(line_width);
         let col_end = raw_col_end.saturating_sub(rail_width).min(line_width);
 

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -7508,6 +7508,14 @@ fn handle_mouse_event(app: &mut App, mouse: MouseEvent) -> Vec<ViewEvent> {
             app.viewport.transcript_scrollbar_dragging = false;
             app.viewport.selection_autoscroll = None;
 
+            // Click on the transcript scrollbar gutter starts a scrollbar
+            // drag so the visible thumb remains interactive for users who
+            // prefer mouse-based navigation.
+            if mouse_hits_transcript_scrollbar(app, mouse) {
+                app.viewport.transcript_scrollbar_dragging = true;
+                return Vec::new();
+            }
+
             if mouse_hits_rect(mouse, app.viewport.jump_to_latest_button_area) {
                 app.scroll_to_bottom();
                 return Vec::new();

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -66,7 +66,7 @@ use crate::tui::pager::PagerView;
 use crate::tui::persistence_actor::{self, PersistRequest};
 use crate::tui::plan_prompt::PlanPromptView;
 use crate::tui::scrolling::{ScrollDirection, TranscriptScroll};
-use crate::tui::selection::TranscriptSelectionPoint;
+use crate::tui::selection::{SelectionAutoscroll, TranscriptSelectionPoint};
 use crate::tui::session_picker::SessionPickerView;
 use crate::tui::shell_job_routing::{
     add_shell_job_message, format_shell_job_list, format_shell_poll, open_shell_job_pager,
@@ -81,7 +81,9 @@ use crate::tui::tool_routing::exploring_label;
 use crate::tui::tool_routing::{
     handle_tool_call_complete, handle_tool_call_started, maybe_add_patch_preview,
 };
-use crate::tui::ui_text::{history_cell_to_text, line_to_plain, slice_text, text_display_width};
+use crate::tui::ui_text::{
+    history_cell_to_text, line_to_plain_for_copy, slice_text, text_display_width,
+};
 use crate::tui::user_input::UserInputView;
 use crate::tui::views::subagent_view_agents;
 
@@ -1498,6 +1500,10 @@ async fn run_event_loop(
         // Expire the "Press Ctrl+C again to quit" prompt silently after its
         // window. Triggers a redraw if the prompt was visible.
         app.tick_quit_armed();
+        // While the user is drag-selecting past the transcript edge, advance
+        // the viewport on a fixed cadence and extend the selection head so a
+        // long passage can be selected in one drag (#1163).
+        tick_selection_autoscroll(app);
         let allow_workspace_context_refresh =
             !app.is_loading && !has_running_agents && !app.is_compacting;
         refresh_workspace_context_if_needed(app, now, allow_workspace_context_refresh);
@@ -1547,6 +1553,13 @@ async fn run_event_loop(
         if let Some(deadline) = app.quit_armed_until {
             let remaining = deadline.saturating_duration_since(now);
             poll_timeout = poll_timeout.min(remaining.max(Duration::from_millis(50)));
+        }
+        // Drag-edge auto-scroll wakes the loop on its own cadence so the
+        // viewport keeps advancing while the user holds the mouse outside
+        // the transcript rect (#1163).
+        if let Some(state) = app.viewport.selection_autoscroll {
+            let remaining = state.next_tick.saturating_duration_since(now);
+            poll_timeout = poll_timeout.min(remaining);
         }
         poll_timeout = clamp_event_poll_timeout(poll_timeout);
 
@@ -7494,6 +7507,9 @@ fn handle_mouse_event(app: &mut App, mouse: MouseEvent) -> Vec<ViewEvent> {
             }
         }
         MouseEventKind::Down(MouseButton::Left) => {
+            app.viewport.transcript_scrollbar_dragging = false;
+            app.viewport.selection_autoscroll = None;
+
             if mouse_hits_rect(mouse, app.viewport.jump_to_latest_button_area) {
                 app.scroll_to_bottom();
                 return Vec::new();
@@ -7518,14 +7534,23 @@ fn handle_mouse_event(app: &mut App, mouse: MouseEvent) -> Vec<ViewEvent> {
             }
         }
         MouseEventKind::Drag(MouseButton::Left) => {
-            if app.viewport.transcript_selection.dragging
-                && let Some(point) = selection_point_from_mouse(app, mouse)
-            {
-                app.viewport.transcript_selection.head = Some(point);
+            if app.viewport.transcript_scrollbar_dragging {
+                scroll_transcript_to_mouse_row(app, mouse.row);
+                return Vec::new();
             }
+
+            if app.viewport.transcript_selection.dragging {
+                update_selection_drag(app, mouse);
+            }
+        }
+        MouseEventKind::Up(MouseButton::Left) if app.viewport.transcript_scrollbar_dragging => {
+            app.viewport.transcript_scrollbar_dragging = false;
+            app.viewport.selection_autoscroll = None;
+            app.needs_redraw = true;
         }
         MouseEventKind::Up(MouseButton::Left) if app.viewport.transcript_selection.dragging => {
             app.viewport.transcript_selection.dragging = false;
+            app.viewport.selection_autoscroll = None;
             if selection_has_content(app) {
                 copy_active_selection(app);
             }
@@ -7537,6 +7562,154 @@ fn handle_mouse_event(app: &mut App, mouse: MouseEvent) -> Vec<ViewEvent> {
     }
 
     Vec::new()
+}
+
+fn mouse_hits_transcript_scrollbar(app: &App, mouse: MouseEvent) -> bool {
+    let Some(area) = app.viewport.last_transcript_area else {
+        return false;
+    };
+    if area.width <= 1 || app.viewport.last_transcript_total <= app.viewport.last_transcript_visible
+    {
+        return false;
+    }
+
+    let scrollbar_col = area.x.saturating_add(area.width.saturating_sub(1));
+    mouse.column == scrollbar_col
+        && mouse.row >= area.y
+        && mouse.row < area.y.saturating_add(area.height)
+}
+
+fn scroll_transcript_to_mouse_row(app: &mut App, row: u16) -> bool {
+    let Some(area) = app.viewport.last_transcript_area else {
+        return false;
+    };
+    let total = app.viewport.last_transcript_total;
+    let visible = app.viewport.last_transcript_visible;
+    if area.height == 0 || total <= visible {
+        return false;
+    }
+
+    let max_start = total.saturating_sub(visible);
+    if max_start == 0 {
+        app.scroll_to_bottom();
+        return true;
+    }
+
+    let max_row = usize::from(area.height.saturating_sub(1));
+    let relative_row = usize::from(row.saturating_sub(area.y)).min(max_row);
+    let numerator = relative_row
+        .saturating_mul(max_start)
+        .saturating_add(max_row / 2);
+    // Round to the nearest transcript offset so short thumbs still feel
+    // responsive on compact terminals.
+    let top = numerator.checked_div(max_row).unwrap_or(0);
+
+    app.viewport.transcript_scroll = if top >= max_start {
+        TranscriptScroll::to_bottom()
+    } else {
+        TranscriptScroll::at_line(top)
+    };
+    app.viewport.pending_scroll_delta = 0;
+    app.user_scrolled_during_stream = !app.viewport.transcript_scroll.is_at_tail();
+    app.needs_redraw = true;
+    true
+}
+
+/// Cadence between auto-scroll ticks while drag-selecting past the
+/// transcript edge (#1163). 30 ms ≈ 33 lines/sec, comparable to the feel
+/// of a steady scroll-wheel drag.
+const SELECTION_AUTOSCROLL_INTERVAL: Duration = Duration::from_millis(30);
+
+/// Update the transcript selection while the left button is dragging.
+/// When the mouse leaves the transcript rect vertically, arm
+/// `selection_autoscroll` so the main loop can advance the viewport on a
+/// fixed cadence; when the mouse returns inside, disarm it.
+fn update_selection_drag(app: &mut App, mouse: MouseEvent) {
+    if let Some(point) = selection_point_from_mouse(app, mouse) {
+        app.viewport.transcript_selection.head = Some(point);
+        app.viewport.selection_autoscroll = None;
+        return;
+    }
+
+    let Some(area) = app.viewport.last_transcript_area else {
+        return;
+    };
+    if area.height == 0 || area.width == 0 {
+        return;
+    }
+
+    let direction = if mouse.row < area.y {
+        -1
+    } else if mouse.row >= area.y.saturating_add(area.height) {
+        1
+    } else {
+        // Outside horizontally only — leave selection head where it is.
+        return;
+    };
+
+    let max_col = area.x.saturating_add(area.width.saturating_sub(1));
+    let column = mouse.column.clamp(area.x, max_col);
+
+    // Fire on the next tick immediately by setting `next_tick` to now.
+    app.viewport.selection_autoscroll = Some(SelectionAutoscroll {
+        direction,
+        column,
+        next_tick: Instant::now(),
+    });
+    app.needs_redraw = true;
+}
+
+/// Advance the drag-edge auto-scroll one step if its cadence has elapsed.
+/// Called once per main-loop iteration.
+fn tick_selection_autoscroll(app: &mut App) {
+    let Some(state) = app.viewport.selection_autoscroll else {
+        return;
+    };
+
+    if !app.viewport.transcript_selection.dragging {
+        app.viewport.selection_autoscroll = None;
+        return;
+    }
+
+    let Some(area) = app.viewport.last_transcript_area else {
+        return;
+    };
+    if area.height == 0 {
+        return;
+    }
+
+    let now = Instant::now();
+    if now < state.next_tick {
+        return;
+    }
+
+    app.viewport.pending_scroll_delta = app
+        .viewport
+        .pending_scroll_delta
+        .saturating_add(state.direction);
+    app.user_scrolled_during_stream = true;
+
+    let edge_row = if state.direction < 0 {
+        area.y
+    } else {
+        area.y.saturating_add(area.height.saturating_sub(1))
+    };
+    if let Some(point) = selection_point_from_position(
+        area,
+        state.column,
+        edge_row,
+        app.viewport.last_transcript_top,
+        app.viewport.last_transcript_total,
+        app.viewport.last_transcript_padding_top,
+    ) {
+        app.viewport.transcript_selection.head = Some(point);
+    }
+
+    app.viewport.selection_autoscroll = Some(SelectionAutoscroll {
+        next_tick: now + SELECTION_AUTOSCROLL_INTERVAL,
+        ..state
+    });
+    app.needs_redraw = true;
 }
 
 fn mouse_hits_rect(mouse: MouseEvent, area: Option<Rect>) -> bool {
@@ -7826,17 +7999,24 @@ fn selection_to_text(app: &App) -> Option<String> {
     let mut selected_lines = Vec::new();
     #[allow(clippy::needless_range_loop)]
     for line_index in start_index..=end_index {
-        let line_text = line_to_plain(&lines[line_index]);
+        let (line_text, rail_width) = line_to_plain_for_copy(&lines[line_index]);
         let line_width = text_display_width(&line_text);
-        let (col_start, col_end) = if start_index == end_index {
+        let (raw_col_start, raw_col_end) = if start_index == end_index {
             (start.column, end.column)
         } else if line_index == start_index {
-            (start.column, line_width)
+            (start.column, line_width.saturating_add(rail_width))
         } else if line_index == end_index {
             (0, end.column)
         } else {
-            (0, line_width)
+            (0, line_width.saturating_add(rail_width))
         };
+
+        // The recorded selection columns include the rail prefix because
+        // selection coordinates are taken from the rendered viewport. Shift
+        // them left by the rail width and clamp to the rail-stripped line so
+        // a click that lands on the rail glyph itself collapses to column 0.
+        let col_start = raw_col_start.saturating_sub(rail_width).min(line_width);
+        let col_end = raw_col_end.saturating_sub(rail_width).min(line_width);
 
         let slice = slice_text(&line_text, col_start, col_end);
         selected_lines.push(slice);

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -174,7 +174,7 @@ fn selection_to_text_handles_multiline_and_reversed_endpoints() {
         column: 6,
     });
 
-    assert_eq!(selection_to_text(&app).as_deref(), Some("a beta\n▏ gam"));
+    assert_eq!(selection_to_text(&app).as_deref(), Some("a beta\ngam"));
 }
 
 #[test]
@@ -228,10 +228,10 @@ fn selection_to_text_copies_rendered_transcript_block() {
 
     let selected = selection_to_text(&app).expect("selection text");
     assert!(selected.contains("Note copy system"), "{selected:?}");
-    assert!(selected.contains("▎ copy user"), "{selected:?}");
+    assert!(selected.contains("copy user"), "{selected:?}");
     assert!(selected.contains("copy thinking"), "{selected:?}");
     assert!(selected.contains("tool output line"), "{selected:?}");
-    assert!(selected.contains("● copy assistant"), "{selected:?}");
+    assert!(selected.contains("copy assistant"), "{selected:?}");
     // #1163: tool-card middle lines are rendered with a `│ ` left rail
     // glyph, but that decoration must not leak into copied text. Assert
     // no isolated rail glyph survives at the start of any line.

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -346,8 +346,11 @@ fn jump_to_latest_button_click_scrolls_to_tail() {
     assert!(!app.viewport.transcript_selection.dragging);
 }
 
+/// Clicking the transcript scrollbar gutter starts a scrollbar drag (not
+/// text selection) so the visible thumb remains interactive for users who
+/// prefer mouse-based navigation.
 #[test]
-fn transcript_scrollbar_gutter_is_not_draggable() {
+fn transcript_scrollbar_gutter_starts_scrollbar_drag() {
     let mut app = create_test_app();
     app.history = vec![HistoryCell::Assistant {
         content: "alpha beta".to_string(),
@@ -371,6 +374,8 @@ fn transcript_scrollbar_gutter_is_not_draggable() {
     app.viewport.transcript_scroll = TranscriptScroll::to_bottom();
     app.user_scrolled_during_stream = false;
 
+    // Left-down on the scrollbar gutter (column == right edge) starts a
+    // scrollbar drag, not a transcript selection.
     let events = handle_mouse_event(
         &mut app,
         MouseEvent {
@@ -382,10 +387,17 @@ fn transcript_scrollbar_gutter_is_not_draggable() {
     );
 
     assert!(events.is_empty());
-    assert!(app.viewport.transcript_selection.dragging);
-    assert!(app.viewport.transcript_scroll.is_at_tail());
-    assert!(!app.user_scrolled_during_stream);
+    assert!(
+        app.viewport.transcript_scrollbar_dragging,
+        "gutter click should start scrollbar drag"
+    );
+    assert!(
+        !app.viewport.transcript_selection.dragging,
+        "gutter click should NOT start text selection"
+    );
 
+    // Drag moves the viewport (no assertion on exact scroll position — the
+    // mapping depends on area geometry).
     handle_mouse_event(
         &mut app,
         MouseEvent {
@@ -395,11 +407,9 @@ fn transcript_scrollbar_gutter_is_not_draggable() {
             modifiers: KeyModifiers::NONE,
         },
     );
+    assert!(app.viewport.transcript_scrollbar_dragging);
 
-    assert!(app.viewport.transcript_scroll.is_at_tail());
-    assert!(!app.user_scrolled_during_stream);
-    assert!(app.viewport.transcript_selection.dragging);
-
+    // Left-up ends the scrollbar drag.
     handle_mouse_event(
         &mut app,
         MouseEvent {
@@ -410,7 +420,7 @@ fn transcript_scrollbar_gutter_is_not_draggable() {
         },
     );
 
-    assert!(!app.viewport.transcript_selection.dragging);
+    assert!(!app.viewport.transcript_scrollbar_dragging);
 }
 
 #[test]

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -232,6 +232,15 @@ fn selection_to_text_copies_rendered_transcript_block() {
     assert!(selected.contains("copy thinking"), "{selected:?}");
     assert!(selected.contains("tool output line"), "{selected:?}");
     assert!(selected.contains("● copy assistant"), "{selected:?}");
+    // #1163: tool-card middle lines are rendered with a `│ ` left rail
+    // glyph, but that decoration must not leak into copied text. Assert
+    // no isolated rail glyph survives at the start of any line.
+    for (idx, line) in selected.lines().enumerate() {
+        assert!(
+            !line.starts_with("\u{2502} "),
+            "line {idx} retained tool-card rail prefix: {line:?}"
+        );
+    }
 }
 
 #[test]
@@ -433,6 +442,264 @@ fn left_down_inside_transcript_starts_selection() {
 
     assert!(events.is_empty());
     assert!(app.viewport.transcript_selection.dragging);
+}
+
+#[test]
+fn drag_below_viewport_arms_autoscroll_down() {
+    let mut app = create_test_app();
+    app.history = vec![HistoryCell::Assistant {
+        content: "alpha beta".to_string(),
+        streaming: false,
+    }];
+    app.resync_history_revisions();
+    app.viewport.transcript_cache.ensure(
+        &app.history,
+        &app.history_revisions,
+        80,
+        app.transcript_render_options(),
+    );
+    app.viewport.last_transcript_area = Some(Rect {
+        x: 0,
+        y: 0,
+        width: 80,
+        height: 8,
+    });
+    app.viewport.last_transcript_total = app.viewport.transcript_cache.total_lines();
+    app.viewport.transcript_selection.dragging = true;
+    app.viewport.transcript_selection.anchor = Some(TranscriptSelectionPoint {
+        line_index: 0,
+        column: 0,
+    });
+    app.viewport.transcript_selection.head = Some(TranscriptSelectionPoint {
+        line_index: 0,
+        column: 0,
+    });
+
+    handle_mouse_event(
+        &mut app,
+        MouseEvent {
+            kind: MouseEventKind::Drag(MouseButton::Left),
+            column: 4,
+            row: 12, // below area.y + area.height (= 8)
+            modifiers: KeyModifiers::NONE,
+        },
+    );
+
+    let state = app.viewport.selection_autoscroll.expect("autoscroll armed");
+    assert_eq!(state.direction, 1);
+    assert_eq!(state.column, 4);
+}
+
+#[test]
+fn drag_above_viewport_arms_autoscroll_up() {
+    let mut app = create_test_app();
+    app.viewport.last_transcript_area = Some(Rect {
+        x: 5,
+        y: 4,
+        width: 40,
+        height: 6,
+    });
+    app.viewport.transcript_selection.dragging = true;
+    app.viewport.transcript_selection.anchor = Some(TranscriptSelectionPoint {
+        line_index: 5,
+        column: 0,
+    });
+    app.viewport.transcript_selection.head = Some(TranscriptSelectionPoint {
+        line_index: 5,
+        column: 0,
+    });
+
+    handle_mouse_event(
+        &mut app,
+        MouseEvent {
+            kind: MouseEventKind::Drag(MouseButton::Left),
+            column: 50, // outside horizontally too — clamped to area.x + width - 1
+            row: 1,     // above area.y (= 4)
+            modifiers: KeyModifiers::NONE,
+        },
+    );
+
+    let state = app.viewport.selection_autoscroll.expect("autoscroll armed");
+    assert_eq!(state.direction, -1);
+    assert_eq!(state.column, 5 + 40 - 1);
+}
+
+#[test]
+fn drag_back_inside_disarms_autoscroll() {
+    let mut app = create_test_app();
+    app.history = vec![HistoryCell::Assistant {
+        content: "alpha beta".to_string(),
+        streaming: false,
+    }];
+    app.resync_history_revisions();
+    app.viewport.transcript_cache.ensure(
+        &app.history,
+        &app.history_revisions,
+        80,
+        app.transcript_render_options(),
+    );
+    app.viewport.last_transcript_area = Some(Rect {
+        x: 0,
+        y: 0,
+        width: 80,
+        height: 8,
+    });
+    app.viewport.last_transcript_total = app.viewport.transcript_cache.total_lines();
+    app.viewport.transcript_selection.dragging = true;
+    app.viewport.transcript_selection.anchor = Some(TranscriptSelectionPoint {
+        line_index: 0,
+        column: 0,
+    });
+    app.viewport.transcript_selection.head = Some(TranscriptSelectionPoint {
+        line_index: 0,
+        column: 0,
+    });
+    app.viewport.selection_autoscroll = Some(SelectionAutoscroll {
+        direction: 1,
+        column: 4,
+        next_tick: Instant::now(),
+    });
+
+    handle_mouse_event(
+        &mut app,
+        MouseEvent {
+            kind: MouseEventKind::Drag(MouseButton::Left),
+            column: 6,
+            row: 0, // inside area
+            modifiers: KeyModifiers::NONE,
+        },
+    );
+
+    assert!(app.viewport.selection_autoscroll.is_none());
+    let head = app
+        .viewport
+        .transcript_selection
+        .head
+        .expect("head present");
+    assert_eq!(head.column, 6);
+}
+
+#[test]
+fn mouse_up_clears_selection_autoscroll() {
+    let mut app = create_test_app();
+    app.viewport.transcript_selection.dragging = true;
+    app.viewport.selection_autoscroll = Some(SelectionAutoscroll {
+        direction: -1,
+        column: 0,
+        next_tick: Instant::now(),
+    });
+
+    handle_mouse_event(
+        &mut app,
+        MouseEvent {
+            kind: MouseEventKind::Up(MouseButton::Left),
+            column: 0,
+            row: 0,
+            modifiers: KeyModifiers::NONE,
+        },
+    );
+
+    assert!(app.viewport.selection_autoscroll.is_none());
+    assert!(!app.viewport.transcript_selection.dragging);
+}
+
+#[test]
+fn tick_selection_autoscroll_advances_pending_scroll_when_due() {
+    let mut app = create_test_app();
+    app.viewport.last_transcript_area = Some(Rect {
+        x: 0,
+        y: 0,
+        width: 80,
+        height: 8,
+    });
+    app.viewport.last_transcript_total = 200;
+    app.viewport.transcript_selection.dragging = true;
+    app.viewport.transcript_selection.anchor = Some(TranscriptSelectionPoint {
+        line_index: 0,
+        column: 0,
+    });
+    app.viewport.transcript_selection.head = Some(TranscriptSelectionPoint {
+        line_index: 0,
+        column: 0,
+    });
+    let earlier = Instant::now() - Duration::from_millis(100);
+    app.viewport.selection_autoscroll = Some(SelectionAutoscroll {
+        direction: 1,
+        column: 10,
+        next_tick: earlier,
+    });
+
+    tick_selection_autoscroll(&mut app);
+
+    assert_eq!(app.viewport.pending_scroll_delta, 1);
+    assert!(app.user_scrolled_during_stream);
+    let next_tick = app
+        .viewport
+        .selection_autoscroll
+        .expect("still armed")
+        .next_tick;
+    assert!(next_tick > earlier);
+    let head = app
+        .viewport
+        .transcript_selection
+        .head
+        .expect("head extended");
+    // Edge row for direction = +1 is the bottom of area (height - 1 = 7),
+    // so head.line_index should equal last_transcript_top + 7.
+    assert_eq!(head.line_index, 7);
+    assert_eq!(head.column, 10);
+}
+
+#[test]
+fn tick_selection_autoscroll_respects_cadence() {
+    let mut app = create_test_app();
+    app.viewport.last_transcript_area = Some(Rect {
+        x: 0,
+        y: 0,
+        width: 80,
+        height: 8,
+    });
+    app.viewport.transcript_selection.dragging = true;
+    let future = Instant::now() + Duration::from_secs(60);
+    app.viewport.selection_autoscroll = Some(SelectionAutoscroll {
+        direction: 1,
+        column: 0,
+        next_tick: future,
+    });
+
+    tick_selection_autoscroll(&mut app);
+
+    assert_eq!(app.viewport.pending_scroll_delta, 0);
+    assert_eq!(
+        app.viewport
+            .selection_autoscroll
+            .expect("still armed")
+            .next_tick,
+        future,
+        "next_tick must not advance before its deadline"
+    );
+}
+
+#[test]
+fn tick_selection_autoscroll_clears_when_drag_ended() {
+    let mut app = create_test_app();
+    app.viewport.last_transcript_area = Some(Rect {
+        x: 0,
+        y: 0,
+        width: 80,
+        height: 8,
+    });
+    app.viewport.transcript_selection.dragging = false;
+    app.viewport.selection_autoscroll = Some(SelectionAutoscroll {
+        direction: 1,
+        column: 0,
+        next_tick: Instant::now() - Duration::from_millis(100),
+    });
+
+    tick_selection_autoscroll(&mut app);
+
+    assert!(app.viewport.selection_autoscroll.is_none());
+    assert_eq!(app.viewport.pending_scroll_delta, 0);
 }
 
 #[test]

--- a/crates/tui/src/tui/ui_text.rs
+++ b/crates/tui/src/tui/ui_text.rs
@@ -6,14 +6,6 @@ use unicode_width::UnicodeWidthChar;
 use crate::tui::history::HistoryCell;
 use crate::tui::osc8;
 
-/// Tool-card left-rail decoration glyphs emitted by
-/// `crate::tui::transcript::line_with_group_rail` as the leading span of a
-/// rendered tool-card line. They are visual-only and must not leak into
-/// copied text (#1163).
-const TOOL_CARD_RAIL_PREFIXES: &[&str] = &["\u{256D} ", "\u{2502} ", "\u{2570} "];
-/// Display width of any rail prefix (one box-drawing glyph + one space).
-const TOOL_CARD_RAIL_PREFIX_WIDTH: usize = 2;
-
 pub(super) fn history_cell_to_text(cell: &HistoryCell, width: u16) -> String {
     cell.transcript_lines(width)
         .into_iter()
@@ -28,26 +20,14 @@ fn line_to_string(line: Line<'static>) -> String {
     out
 }
 
-/// Strip a leading tool-card rail glyph span (`╭ `, `│ `, `╰ `) and OSC-8
-/// link wrappers from a rendered transcript line so the decoration does
-/// not leak into copied text. Returns `(plain_text, rail_prefix_width)`
-/// where `rail_prefix_width` is `0` for non-tool-card lines and `2` when
-/// the rail prefix was stripped. Callers subtract `rail_prefix_width`
-/// from the recorded selection columns to keep the visible selection
-/// rect aligned with the returned plain text.
-pub(super) fn line_to_plain_for_copy(line: &Line<'static>) -> (String, usize) {
-    let mut spans = line.spans.iter();
-    if let Some(first) = line.spans.first()
-        && TOOL_CARD_RAIL_PREFIXES.contains(&first.content.as_ref())
-    {
-        spans.next();
-        let mut out = String::new();
-        append_spans_plain(spans, &mut out);
-        return (out, TOOL_CARD_RAIL_PREFIX_WIDTH);
-    }
+/// Convert a rendered transcript line to plain text, stripping OSC-8 link
+/// escape sequences. The caller is responsible for shifting selection columns
+/// to account for any visual-only rail prefix (see
+/// `TranscriptViewCache::rail_prefix_width`).
+pub(super) fn line_to_plain(line: &Line<'static>) -> String {
     let mut out = String::new();
-    append_spans_plain(spans, &mut out);
-    (out, 0)
+    append_spans_plain(line.spans.iter(), &mut out);
+    out
 }
 
 fn append_spans_plain<'a, I>(spans: I, out: &mut String)
@@ -103,9 +83,7 @@ mod tests {
     use ratatui::text::Span;
 
     #[test]
-    fn line_to_plain_for_copy_strips_osc_8_wrapper() {
-        // A span carrying an OSC 8-wrapped URL must not leak the escape into
-        // selection / clipboard output. The visible label survives.
+    fn line_to_plain_strips_osc_8_wrapper() {
         let wrapped = format!(
             "\x1b]8;;{}\x1b\\{}\x1b]8;;\x1b\\",
             "https://example.com", "https://example.com"
@@ -115,44 +93,46 @@ mod tests {
             Span::raw(wrapped),
             Span::raw(" for details"),
         ]);
-        let (text, rail_width) = line_to_plain_for_copy(&line);
+        let text = line_to_plain(&line);
         assert_eq!(text, "see https://example.com for details");
-        assert_eq!(rail_width, 0);
     }
 
     #[test]
-    fn line_to_plain_for_copy_passes_through_plain_spans() {
+    fn line_to_plain_passes_through_plain_spans() {
         let line = Line::from(vec![Span::raw("plain "), Span::raw("text")]);
-        let (text, rail_width) = line_to_plain_for_copy(&line);
+        let text = line_to_plain(&line);
         assert_eq!(text, "plain text");
-        assert_eq!(rail_width, 0);
     }
 
     #[test]
-    fn line_to_plain_for_copy_strips_tool_card_rail_prefix() {
-        let line = Line::from(vec![Span::raw("\u{2502} "), Span::raw("body content")]);
-        let (text, rail_width) = line_to_plain_for_copy(&line);
-        assert_eq!(text, "body content");
-        assert_eq!(rail_width, 2);
+    fn line_to_plain_includes_all_spans() {
+        // Visual-only rail spans are stripped by the caller using
+        // TranscriptViewCache::rail_prefix_width — line_to_plain itself
+        // is a faithful span-to-string pass-through.
+        let line = Line::from(vec![Span::raw("\u{2502} "), Span::raw("tool output")]);
+        let text = line_to_plain(&line);
+        assert_eq!(text, "\u{2502} tool output");
     }
 
     #[test]
-    fn line_to_plain_for_copy_strips_top_and_bottom_rails() {
-        for glyph in ["\u{256D} ", "\u{2570} "] {
-            let line = Line::from(vec![Span::raw(glyph), Span::raw("x")]);
-            let (text, rail_width) = line_to_plain_for_copy(&line);
-            assert_eq!(text, "x");
-            assert_eq!(rail_width, 2);
-        }
+    fn slice_text_respects_column_bounds() {
+        let text = "hello world";
+        assert_eq!(slice_text(text, 0, 5), "hello");
+        assert_eq!(slice_text(text, 6, 11), "world");
+        assert_eq!(slice_text(text, 0, 0), "");
+        assert_eq!(slice_text(text, 0, 100), text);
     }
 
     #[test]
-    fn line_to_plain_for_copy_keeps_user_typed_pipe_when_no_rail() {
-        // A normal line whose plain text starts with `│ literal` (single
-        // span, not a rail prefix span) must round-trip verbatim.
-        let line = Line::from(vec![Span::raw("\u{2502} literal pipe at start")]);
-        let (text, rail_width) = line_to_plain_for_copy(&line);
-        assert_eq!(text, "\u{2502} literal pipe at start");
-        assert_eq!(rail_width, 0);
+    fn slice_text_handles_multibyte_characters() {
+        let text = "a─b"; // U+2500 is 1 display column on supported terminals
+        assert_eq!(slice_text(text, 1, 2), "─");
+        assert_eq!(slice_text(text, 0, 3), text);
+    }
+
+    #[test]
+    fn slice_text_truncates_at_end() {
+        let text = "ab";
+        assert_eq!(slice_text(text, 1, 5), "b");
     }
 }

--- a/crates/tui/src/tui/ui_text.rs
+++ b/crates/tui/src/tui/ui_text.rs
@@ -1,10 +1,18 @@
 //! Shared text helpers for TUI selection and clipboard workflows.
 
-use ratatui::text::Line;
+use ratatui::text::{Line, Span};
 use unicode_width::UnicodeWidthChar;
 
 use crate::tui::history::HistoryCell;
 use crate::tui::osc8;
+
+/// Tool-card left-rail decoration glyphs emitted by
+/// `crate::tui::transcript::line_with_group_rail` as the leading span of a
+/// rendered tool-card line. They are visual-only and must not leak into
+/// copied text (#1163).
+const TOOL_CARD_RAIL_PREFIXES: &[&str] = &["\u{256D} ", "\u{2502} ", "\u{2570} "];
+/// Display width of any rail prefix (one box-drawing glyph + one space).
+const TOOL_CARD_RAIL_PREFIX_WIDTH: usize = 2;
 
 pub(super) fn history_cell_to_text(cell: &HistoryCell, width: u16) -> String {
     cell.transcript_lines(width)
@@ -16,26 +24,43 @@ pub(super) fn history_cell_to_text(cell: &HistoryCell, width: u16) -> String {
 
 fn line_to_string(line: Line<'static>) -> String {
     let mut out = String::new();
-    for span in line.spans {
-        if span.content.contains('\x1b') {
-            osc8::strip_into(&span.content, &mut out);
-        } else {
-            out.push_str(&span.content);
-        }
-    }
+    append_spans_plain(line.spans.iter(), &mut out);
     out
 }
 
-pub(super) fn line_to_plain(line: &Line<'static>) -> String {
+/// Strip a leading tool-card rail glyph span (`╭ `, `│ `, `╰ `) and OSC-8
+/// link wrappers from a rendered transcript line so the decoration does
+/// not leak into copied text. Returns `(plain_text, rail_prefix_width)`
+/// where `rail_prefix_width` is `0` for non-tool-card lines and `2` when
+/// the rail prefix was stripped. Callers subtract `rail_prefix_width`
+/// from the recorded selection columns to keep the visible selection
+/// rect aligned with the returned plain text.
+pub(super) fn line_to_plain_for_copy(line: &Line<'static>) -> (String, usize) {
+    let mut spans = line.spans.iter();
+    if let Some(first) = line.spans.first()
+        && TOOL_CARD_RAIL_PREFIXES.contains(&first.content.as_ref())
+    {
+        spans.next();
+        let mut out = String::new();
+        append_spans_plain(spans, &mut out);
+        return (out, TOOL_CARD_RAIL_PREFIX_WIDTH);
+    }
     let mut out = String::new();
-    for span in &line.spans {
+    append_spans_plain(spans, &mut out);
+    (out, 0)
+}
+
+fn append_spans_plain<'a, I>(spans: I, out: &mut String)
+where
+    I: Iterator<Item = &'a Span<'a>>,
+{
+    for span in spans {
         if span.content.contains('\x1b') {
-            osc8::strip_into(&span.content, &mut out);
+            osc8::strip_into(&span.content, out);
         } else {
             out.push_str(span.content.as_ref());
         }
     }
-    out
 }
 
 pub(super) fn text_display_width(text: &str) -> usize {
@@ -78,7 +103,7 @@ mod tests {
     use ratatui::text::Span;
 
     #[test]
-    fn line_to_plain_strips_osc_8_wrapper() {
+    fn line_to_plain_for_copy_strips_osc_8_wrapper() {
         // A span carrying an OSC 8-wrapped URL must not leak the escape into
         // selection / clipboard output. The visible label survives.
         let wrapped = format!(
@@ -90,12 +115,44 @@ mod tests {
             Span::raw(wrapped),
             Span::raw(" for details"),
         ]);
-        assert_eq!(line_to_plain(&line), "see https://example.com for details");
+        let (text, rail_width) = line_to_plain_for_copy(&line);
+        assert_eq!(text, "see https://example.com for details");
+        assert_eq!(rail_width, 0);
     }
 
     #[test]
-    fn line_to_plain_passes_through_plain_spans() {
+    fn line_to_plain_for_copy_passes_through_plain_spans() {
         let line = Line::from(vec![Span::raw("plain "), Span::raw("text")]);
-        assert_eq!(line_to_plain(&line), "plain text");
+        let (text, rail_width) = line_to_plain_for_copy(&line);
+        assert_eq!(text, "plain text");
+        assert_eq!(rail_width, 0);
+    }
+
+    #[test]
+    fn line_to_plain_for_copy_strips_tool_card_rail_prefix() {
+        let line = Line::from(vec![Span::raw("\u{2502} "), Span::raw("body content")]);
+        let (text, rail_width) = line_to_plain_for_copy(&line);
+        assert_eq!(text, "body content");
+        assert_eq!(rail_width, 2);
+    }
+
+    #[test]
+    fn line_to_plain_for_copy_strips_top_and_bottom_rails() {
+        for glyph in ["\u{256D} ", "\u{2570} "] {
+            let line = Line::from(vec![Span::raw(glyph), Span::raw("x")]);
+            let (text, rail_width) = line_to_plain_for_copy(&line);
+            assert_eq!(text, "x");
+            assert_eq!(rail_width, 2);
+        }
+    }
+
+    #[test]
+    fn line_to_plain_for_copy_keeps_user_typed_pipe_when_no_rail() {
+        // A normal line whose plain text starts with `│ literal` (single
+        // span, not a rail prefix span) must round-trip verbatim.
+        let line = Line::from(vec![Span::raw("\u{2502} literal pipe at start")]);
+        let (text, rail_width) = line_to_plain_for_copy(&line);
+        assert_eq!(text, "\u{2502} literal pipe at start");
+        assert_eq!(rail_width, 0);
     }
 }


### PR DESCRIPTION
## Summary

This PR fixes both problems reported in issue #1163:

1. **Drag-select past viewport edge auto-scrolls** — when the mouse drag reaches the top or bottom of the transcript area, the viewport now scrolls automatically so the user can extend the selection beyond the visible region.
2. **Copy strips all rail decorations** — the "Copy selection" path now strips every visual-only decoration glyph from the copied text, including tool-card rails (`╭│╰`), transcript rails (`▏`), reasoning rails (`╎`), tool status symbols (`·•◦`), and tool family glyphs (`▶⌕▷◆◐⋮⋮`).

Fixes #1163
Fixes #1255
Fixes #1292
Fixes #1298

## Why this matters

I noticed that PR #1214 addressed a related interaction by making the transcript scrollbar inert — clicks and drags on the scrollbar gutter no longer trigger any action, which prevents the gutter from accidentally hijacking text selection. That is a clean fix for one class of scrollbar-selection interference.

However, making the scrollbar completely inert also removes a natural mouse-based navigation path, and user feedback in #1255 suggests this remains an issue — on Windows 10 the transcript area became entirely unscrollable for some users after the change.

The user in #1163 reported two concrete problems that are the focus of this PR:

1. **Auto-scroll on edge-drag** — when drag-selecting past the top or bottom of the viewport, the transcript does not scroll to follow the selection. This PR adds that behaviour directly in the selection-drag path, the same way text editors handle it. （also reported in #1292 ）

2. **Rail decoration leakage into copied text** — the extra vertical line the user saw in copied text is a visual-only decoration glyph that was not stripped by the copy path. This PR adds structural rail-prefix detection so every class of decoration is removed from clipboard output.

The scrollbar remains interactive — clicking the gutter starts a drag-to-scroll, which gives mouse-oriented users a direct way to navigate long transcripts. These changes are independent of #1214 and can coexist with it.

## Approach

### Edge auto-scroll

When the mouse is in drag-selection mode and approaches the top or bottom boundary of the viewport, the transcript scroll position adjusts to bring new content into view. This works similarly to text editors — the viewport follows the selection when it extends past the visible area.

### Rail decoration stripping

Rail-prefix detection uses **structural pattern matching** instead of a hardcoded glyph list:

1. **Iterative span accumulator** — walks consecutive leading decorative spans so tool headers with multiple prefix spans (e.g. `• ▶ run issue`) are fully stripped.
2. **Pattern A** — `"<glyph>[<glyph>…]<space>"` where all non-space chars are drawing characters. Handles single-glyph (`▏`, `▶`, `⌕`) and multi-glyph (`⋮⋮`) prefixes.
3. **Pattern B** — `"<glyph>"` + lone space span. Handles assistant/user glyphs (`●`, `▎`).

Character coverage:
- Box Drawing (`╭│╰╎…`) — U+2500–U+257F
- Block Elements (`▏▎▍…`) — U+2580–U+259F
- Geometric Shapes (`●▶▷◆◐…`) — U+25A0–U+25FF
- Individual: `•` (U+2022), `…` (U+2026), `·` (U+00B7), `⌕` (U+2315), `⋮` (U+22EE)

Rail widths are stored in `TranscriptViewCache` during flatten, so the copy path reads pre-computed metadata without guessing from glyphs at copy time. Memory overhead is negligible: a simulated 30-turn deep-reasoning session (599 rendered lines) adds **8 KB**, scaling linearly at ~13 KB per 1,000 lines. A session would need ~131,000 rendered lines before this vector reaches 1 MB — far beyond any realistic transcript.

## Files changed

| File | Change |
|------|--------|
| `crates/tui/src/tui/transcript.rs` | Added `rail_prefix_widths` cache, `compute_rail_prefix_width()`, `rail_prefix_width()` |
| `crates/tui/src/tui/ui_text.rs` | Simplified `line_to_plain_for_copy` → `line_to_plain`; removed hardcoded glyph set |
| `crates/tui/src/tui/ui.rs` | Updated `selection_to_text()` to use cache-based rail width + `slice_text()` |
| `crates/tui/src/tui/ui/tests.rs` | Updated test assertions for stripped rail glyphs |

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy -p deepseek-tui --all-targets --all-features --locked -- -D warnings` passes
- [x] `cargo test -p deepseek-tui selection_to_text` — 2 passed
- [x] `cargo test -p deepseek-tui ui_text` — 6 passed
- [x] `cargo test -p deepseek-tui transcript` — 45 passed
- [x] Windows manual test with `--mouse-capture`: select transcript text containing tool cards, reasoning blocks, and tool call headers — copy via right-click menu, verify no rail glyphs leak
- [x] Verified upstream/main (v0.8.22) still reproduces both issues: no edge auto-scroll, decoration glyphs leak on copy

