### PR TITLE
feat(tui): move todos checklist above the composer

### DIFF
--- a/crates/tui/src/tui/sidebar.rs
+++ b/crates/tui/src/tui/sidebar.rs
@@ -12,7 +12,7 @@ use ratatui::{
     prelude::Widget,
     style::{Style, Stylize},
     text::{Line, Span},
-    widgets::{Block, Paragraph, Wrap},
+    widgets::{Block, Borders, Padding, Paragraph, Wrap},
 };
 
 use crate::deepseek_theme::Theme;
@@ -55,17 +55,11 @@ fn render_sidebar_auto(f: &mut Frame, area: Rect, app: &App) {
     #[derive(Clone, Copy)]
     enum Panel {
         Plan,
-        Todos,
         Tasks,
         Agents,
         Context,
     }
 
-    let todos_empty = app
-        .todos
-        .try_lock()
-        .map(|todos| todos.snapshot().items.is_empty())
-        .unwrap_or(false); // assume non-empty when locked so we don't hide updating data
     let tasks_empty = app.runtime_turn_id.is_none() && app.task_panel.is_empty();
     let agents_empty = app.subagent_cache.is_empty()
         && app.agent_progress.is_empty()
@@ -74,9 +68,8 @@ fn render_sidebar_auto(f: &mut Frame, area: Rect, app: &App) {
 
     let mut visible: Vec<Panel> = Vec::with_capacity(5);
     visible.push(Panel::Plan);
-    if !todos_empty {
-        visible.push(Panel::Todos);
-    }
+    // Todos are shown as a panel above the composer; omitted from the
+    // sidebar to avoid duplication.
     if !tasks_empty {
         visible.push(Panel::Tasks);
     }
@@ -118,7 +111,6 @@ fn render_sidebar_auto(f: &mut Frame, area: Rect, app: &App) {
     for (panel, rect) in visible.iter().zip(sections.iter()) {
         match panel {
             Panel::Plan => render_sidebar_plan(f, *rect, app),
-            Panel::Todos => render_sidebar_todos(f, *rect, app),
             Panel::Tasks => render_sidebar_tasks(f, *rect, app),
             Panel::Agents => render_sidebar_subagents(f, *rect, app),
             Panel::Context => render_context_panel(f, *rect, app),
@@ -740,6 +732,113 @@ fn render_context_panel(f: &mut Frame, area: Rect, app: &App) {
     }
 
     render_sidebar_section(f, area, "Session", lines, app);
+}
+
+/// Maximum visible items in the todos area above the composer.
+const TODOS_PANEL_MAX_ITEMS: usize = 6;
+
+/// Compute the height needed for the todos area above the composer.
+/// Returns 0 when the checklist is empty.
+pub fn todos_panel_height(app: &App) -> u16 {
+    let snapshot = match app.todos.try_lock() {
+        Ok(todos) => todos.snapshot(),
+        Err(_) => return 0,
+    };
+    if snapshot.items.is_empty() {
+        return 0;
+    }
+    // 1 header line + N items (capped) + 2 border rows
+    let items = snapshot.items.len().min(TODOS_PANEL_MAX_ITEMS);
+    1 + items as u16 + 2
+}
+
+/// Render the todos area as a bordered list panel above the composer.
+///
+/// Shows checklist progress with a bordered box: completion summary header
+/// followed by each item on its own line with status markers. Width below
+/// 24 columns silently renders nothing. Items beyond the cap show a
+/// "+N more" footer.
+pub fn render_todos_panel(f: &mut Frame, area: Rect, app: &App) {
+    if area.width < 24 || area.height < 3 {
+        return;
+    }
+
+    let snapshot = match app.todos.try_lock() {
+        Ok(todos) => todos.snapshot(),
+        Err(_) => return,
+    };
+    if snapshot.items.is_empty() {
+        return;
+    }
+
+    let content_width = area.width.saturating_sub(4) as usize;
+    let mut lines: Vec<Line<'static>> = Vec::new();
+
+    // Header: "Todos 33% (2/6)"
+    let total = snapshot.items.len();
+    let completed = snapshot
+        .items
+        .iter()
+        .filter(|item| item.status == TodoStatus::Completed)
+        .count();
+    lines.push(Line::from(vec![
+        Span::styled(
+            "Todos ",
+            Style::default()
+                .fg(palette::TEXT_DIM)
+                .add_modifier(ratatui::style::Modifier::BOLD),
+        ),
+        Span::styled(
+            format!("{:.0}%", snapshot.completion_pct),
+            Style::default()
+                .fg(palette::STATUS_SUCCESS)
+                .add_modifier(ratatui::style::Modifier::BOLD),
+        ),
+        Span::styled(
+            format!(" ({completed}/{total})"),
+            Style::default().fg(palette::TEXT_MUTED),
+        ),
+    ]));
+
+    // Separator
+    lines.push(Line::from(Span::styled(
+        "─".repeat(content_width.min(24)),
+        Style::default().fg(palette::BORDER_COLOR),
+    )));
+
+    // Items
+    let max_items = snapshot.items.len().min(TODOS_PANEL_MAX_ITEMS);
+    for item in snapshot.items.iter().take(max_items) {
+        let (marker, color) = match item.status {
+            TodoStatus::Pending => ("[ ]", palette::TEXT_MUTED),
+            TodoStatus::InProgress => ("[~]", palette::STATUS_WARNING),
+            TodoStatus::Completed => ("[x]", palette::STATUS_SUCCESS),
+        };
+        let label = truncate_line_to_width(
+            &format!("{marker} {}", item.content),
+            content_width.max(1),
+        );
+        lines.push(Line::from(Span::styled(label, Style::default().fg(color))));
+    }
+
+    let remaining = snapshot.items.len().saturating_sub(max_items);
+    if remaining > 0 {
+        lines.push(Line::from(Span::styled(
+            format!("+{remaining} more"),
+            Style::default().fg(palette::TEXT_MUTED),
+        )));
+    }
+
+    let paragraph = Paragraph::new(lines)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(palette::BORDER_COLOR))
+                .padding(Padding::horizontal(1)),
+        )
+        .style(Style::default().bg(app.ui_theme.surface_bg));
+
+    f.render_widget(paragraph, area);
 }
 
 fn render_sidebar_section(

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -5315,14 +5315,17 @@ fn render(f: &mut Frame, app: &mut App) {
     let pending_preview = build_pending_input_preview(app);
     let preview_height = pending_preview.desired_height(size.width);
 
+    let todos_panel_height = super::sidebar::todos_panel_height(app);
+
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(header_height),   // Header
-            Constraint::Min(1),                  // Chat area
-            Constraint::Length(preview_height),  // Pending input preview (0 if empty)
-            Constraint::Length(composer_height), // Composer
-            Constraint::Length(footer_height),   // Footer
+            Constraint::Length(header_height),         // Header
+            Constraint::Min(1),                        // Chat area
+            Constraint::Length(preview_height),        // Pending input preview (0 if empty)
+            Constraint::Length(todos_panel_height),    // Todos panel (0 when empty)
+            Constraint::Length(composer_height),       // Composer
+            Constraint::Length(footer_height),         // Footer
         ])
         .split(size);
 
@@ -5440,6 +5443,11 @@ fn render(f: &mut Frame, app: &mut App) {
         pending_preview.render(chunks[2], buf);
     }
 
+    // Render todos panel above the composer (collapses to 0 height when empty).
+    if todos_panel_height > 0 {
+        super::sidebar::render_todos_panel(f, chunks[3], app);
+    }
+
     // Render composer
     let cursor_pos = {
         let composer_widget = ComposerWidget::new(
@@ -5449,19 +5457,19 @@ fn render(f: &mut Frame, app: &mut App) {
             &mention_menu_entries,
         );
         let buf = f.buffer_mut();
-        composer_widget.render(chunks[3], buf);
-        composer_widget.cursor_pos(chunks[3])
+        composer_widget.render(chunks[4], buf);
+        composer_widget.cursor_pos(chunks[4])
     };
     if let Some(cursor_pos) = cursor_pos {
         f.set_cursor_position(cursor_pos);
     }
 
     // Render footer
-    render_footer(f, chunks[4], app);
+    render_footer(f, chunks[5], app);
     // Toast stack overlay (#439): when multiple status toasts are queued,
     // surface the older ones as a 1-2 line strip above the footer so a
     // burst of events isn't collapsed to a single visible message.
-    render_toast_stack_overlay(f, size, chunks[4], app);
+    render_toast_stack_overlay(f, size, chunks[5], app);
 
     if !app.view_stack.is_empty() {
         // The live transcript overlay snapshots the app's history + active


### PR DESCRIPTION
## Summary

Move the todos/checklist from the sidebar into a bordered panel rendered above the composer.  This keeps todos visible at all times without requiring the sidebar to be open — following Claude Code's pattern.

The panel collapses to zero height when empty, so no screen space is wasted when there are no active checklist items.

## Changes

- `sidebar.rs`:
  - Remove `Todos` from the sidebar `Panel` enum (no duplication)
  - Add `todos_panel_height()` — computes panel height (0 when empty)
  - Add `render_todos_panel()` — renders the bordered list panel with header, items, and "+N more" footer
- `ui.rs`:
  - Wire `todos_panel_height` into the layout constraints
  - Call `render_todos_panel` between the pending-input preview and the composer
  - Update chunk indices (composer 3→4, footer 4→5)

## Screenshots

When active, shows above composer:
```
┌──────────────────────────────┐
│ Todos 33% (2/6)             │
│ ─────────────────────────── │
│ [x] Do the thing            │
│ [ ] Another task            │
│ +4 more                     │
└──────────────────────────────┘
> composer input here
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)