### PR TITLE
fix(tui): make Home/End keys move cursor in input box

### DIFF
--- a/crates/tui/src/tui/keybindings.rs
+++ b/crates/tui/src/tui/keybindings.rs
@@ -99,7 +99,7 @@ pub const KEYBINDINGS: &[KeybindingEntry] = &[
         section: KeybindingSection::Navigation,
     },
     KeybindingEntry {
-        chord: "Home / End",
+        chord: "Ctrl+Home / Ctrl+End",
         description_id: crate::localization::MessageId::KbJumpTopBottom,
         section: KeybindingSection::Navigation,
     },
@@ -117,6 +117,11 @@ pub const KEYBINDINGS: &[KeybindingEntry] = &[
     KeybindingEntry {
         chord: "← / →",
         description_id: crate::localization::MessageId::KbMoveCursor,
+        section: KeybindingSection::Editing,
+    },
+    KeybindingEntry {
+        chord: "Home / End",
+        description_id: crate::localization::MessageId::KbJumpLineStartEnd,
         section: KeybindingSection::Editing,
     },
     KeybindingEntry {

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -2697,19 +2697,22 @@ async fn run_event_loop(
                 KeyCode::Right => {
                     app.move_cursor_right();
                 }
-                KeyCode::Home if key.modifiers.is_empty() => {
+                KeyCode::Home if key.modifiers.contains(KeyModifiers::CONTROL) => {
                     if let Some(anchor) =
                         TranscriptScroll::anchor_for(app.viewport.transcript_cache.line_meta(), 0)
                     {
                         app.viewport.transcript_scroll = anchor;
                     }
                 }
-                KeyCode::End if key.modifiers.is_empty() => {
+                KeyCode::End if key.modifiers.contains(KeyModifiers::CONTROL) => {
                     app.scroll_to_bottom();
                 }
                 KeyCode::Home | KeyCode::Char('a')
                     if key.modifiers.contains(KeyModifiers::CONTROL) =>
                 {
+                    app.move_cursor_start();
+                }
+                KeyCode::Home => {
                     app.move_cursor_start();
                 }
                 KeyCode::End => {


### PR DESCRIPTION
## Summary

- Home/End keys now move the cursor to the start/end of the input line (standard text editing behavior)
- Ctrl+Home/End retains the previous scroll-to-top/bottom functionality
- Updated keybindings help overlay to reflect the new mappings

## Motivation

Closes #1234

When the cursor is in the input box, pressing Home/End should move the cursor to the beginning/end of the input text. Previously, these keys scrolled the transcript instead, which is unexpected for most users.

## Changes

- `crates/tui/src/tui/ui.rs`: Swap Home/End (no modifier) to call `move_cursor_start()`/`move_cursor_end()`, and Ctrl+Home/End to scroll transcript
- `crates/tui/src/tui/keybindings.rs`: Update help overlay — Navigation section shows "Ctrl+Home / Ctrl+End", Editing section adds "Home / End"

## Test plan

- [ ] `cargo build` compiles without errors
- [ ] Press Home/End in input box → cursor jumps to start/end
- [ ] Press Ctrl+Home/End → transcript scrolls to top/bottom
- [ ] Ctrl+A / Ctrl+E still work as before