### PR TITLE
  refactor: unify mode switching under /mode

### DIFF
--- a/crates/tui/src/commands/config.rs
+++ b/crates/tui/src/commands/config.rs
@@ -538,30 +538,40 @@ pub fn set_config(app: &mut App, args: Option<&str>) -> CommandResult {
     set_config_value(app, &key, value, should_save)
 }
 
-/// Enable YOLO mode (shell + trust + auto-approve)
-pub fn yolo(app: &mut App) -> CommandResult {
-    app.set_mode(AppMode::Yolo);
-    CommandResult::message("YOLO mode enabled - shell + trust + auto-approve!")
+/// Select the TUI operating mode.
+pub fn mode(app: &mut App, arg: Option<&str>) -> CommandResult {
+    let Some(arg) = arg.filter(|value| !value.trim().is_empty()) else {
+        return CommandResult::action(AppAction::OpenModePicker);
+    };
+    match parse_mode_arg(arg) {
+        Some(mode) => CommandResult::message(switch_mode(app, mode)),
+        None => CommandResult::error("Usage: /mode [agent|plan|yolo|1|2|3]"),
+    }
 }
 
-/// Legacy alias for the removed normal mode.
-pub fn normal_mode(app: &mut App) -> CommandResult {
-    app.set_mode(AppMode::Agent);
-    CommandResult::message("Normal mode was removed. Switched to Agent mode.")
+pub fn switch_mode(app: &mut App, mode: AppMode) -> String {
+    if app.set_mode(mode) {
+        format!("Switched to {} mode.", mode_display_name(mode))
+    } else {
+        format!("Already in {} mode.", mode_display_name(mode))
+    }
 }
 
-/// Enable agent mode (autonomous tool use with approvals)
-pub fn agent_mode(app: &mut App) -> CommandResult {
-    app.set_mode(AppMode::Agent);
-    CommandResult::message("Agent mode enabled.")
+fn parse_mode_arg(arg: &str) -> Option<AppMode> {
+    match arg.trim().to_ascii_lowercase().as_str() {
+        "agent" | "1" => Some(AppMode::Agent),
+        "plan" | "2" => Some(AppMode::Plan),
+        "yolo" | "3" => Some(AppMode::Yolo),
+        _ => None,
+    }
 }
 
-/// Enable plan mode (tool planning, then choose execution route)
-pub fn plan_mode(app: &mut App) -> CommandResult {
-    app.set_mode(AppMode::Plan);
-    CommandResult::message(
-        "Plan mode enabled. Describe your goal and I will create a plan before execution.",
-    )
+fn mode_display_name(mode: AppMode) -> &'static str {
+    match mode {
+        AppMode::Agent => "Agent",
+        AppMode::Plan => "Plan",
+        AppMode::Yolo => "YOLO",
+    }
 }
 
 /// Toggle between dark and light theme.
@@ -1122,9 +1132,10 @@ mod tests {
     }
 
     #[test]
-    fn test_yolo_command_sets_all_flags() {
+    fn test_mode_yolo_sets_all_flags() {
         let mut app = create_test_app();
-        let _ = yolo(&mut app);
+        let result = mode(&mut app, Some("yolo"));
+        assert!(result.message.unwrap().contains("Switched to YOLO mode"));
         assert!(app.allow_shell);
         assert!(app.trust_mode);
         assert!(app.yolo);
@@ -1133,14 +1144,30 @@ mod tests {
     }
 
     #[test]
-    fn test_mode_switch_commands() {
+    fn test_mode_switch_command_accepts_names_and_numbers() {
         let mut app = create_test_app();
-        let _ = normal_mode(&mut app);
+        let _ = mode(&mut app, Some("agent"));
         assert_eq!(app.mode, AppMode::Agent);
-        let _ = agent_mode(&mut app);
-        assert_eq!(app.mode, AppMode::Agent);
-        let _ = plan_mode(&mut app);
+        let _ = mode(&mut app, Some("2"));
         assert_eq!(app.mode, AppMode::Plan);
+        let _ = mode(&mut app, Some("3"));
+        assert_eq!(app.mode, AppMode::Yolo);
+    }
+
+    #[test]
+    fn test_mode_without_arg_opens_picker() {
+        let mut app = create_test_app();
+        let result = mode(&mut app, None);
+        assert!(result.message.is_none());
+        assert!(matches!(result.action, Some(AppAction::OpenModePicker)));
+    }
+
+    #[test]
+    fn test_mode_rejects_unknown_value() {
+        let mut app = create_test_app();
+        let result = mode(&mut app, Some("fast"));
+        assert!(result.is_error);
+        assert!(result.message.unwrap().contains("Usage: /mode"));
     }
 
     #[test]

--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -324,22 +324,10 @@ pub const COMMANDS: &[CommandInfo] = &[
         description_id: MessageId::CmdConfigDescription,
     },
     CommandInfo {
-        name: "yolo",
+        name: "mode",
         aliases: &[],
-        usage: "/yolo",
-        description_id: MessageId::CmdYoloDescription,
-    },
-    CommandInfo {
-        name: "agent",
-        aliases: &[],
-        usage: "/agent",
-        description_id: MessageId::CmdAgentDescription,
-    },
-    CommandInfo {
-        name: "plan",
-        aliases: &[],
-        usage: "/plan",
-        description_id: MessageId::CmdPlanDescription,
+        usage: "/mode [agent|plan|yolo|1|2|3]",
+        description_id: MessageId::CmdModeDescription,
     },
     CommandInfo {
         name: "theme",
@@ -544,9 +532,7 @@ pub fn execute(cmd: &str, app: &mut App) -> CommandResult {
         "config" => config::config_command(app, arg),
         "settings" => config::show_settings(app),
         "statusline" | "status" => config::status_line(app),
-        "yolo" => config::yolo(app),
-        "agent" => config::agent_mode(app),
-        "plan" => config::plan_mode(app),
+        "mode" => config::mode(app, arg),
         "theme" => config::theme(app),
         "verbose" => config::verbose(app, arg),
         "trust" => config::trust(app, arg),
@@ -599,7 +585,6 @@ pub fn execute(cmd: &str, app: &mut App) -> CommandResult {
         "set" => CommandResult::error(
             "The /set command was retired. Use /config to edit settings and /settings to inspect current values.",
         ),
-        "normal" => config::normal_mode(app),
         "deepseek" => CommandResult::error(
             "The /deepseek command was renamed. Use /links (aliases: /dashboard, /api).",
         ),
@@ -645,6 +630,10 @@ pub fn persist_status_items(
 /// Persist a root-level string key in `config.toml`.
 pub fn persist_root_string_key(key: &str, value: &str) -> anyhow::Result<std::path::PathBuf> {
     config::persist_root_string_key(key, value)
+}
+
+pub fn switch_mode(app: &mut App, mode: crate::tui::app::AppMode) -> String {
+    config::switch_mode(app, mode)
 }
 
 /// Auto-select a model based on request complexity.

--- a/crates/tui/src/commands/restore.rs
+++ b/crates/tui/src/commands/restore.rs
@@ -64,7 +64,7 @@ pub fn restore(app: &mut App, arg: Option<&str>) -> CommandResult {
     if !(app.yolo || app.trust_mode) {
         return CommandResult::message(format!(
             "Refusing to restore snapshot #{n} ('{}') outside trusted mode.\n\
-             Run `/trust on` or `/yolo` first, then re-run `/restore {n}`.",
+             Run `/trust on` or `/mode yolo` first, then re-run `/restore {n}`.",
             snapshots[n - 1].label,
         ));
     }

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -1504,7 +1504,7 @@ impl Engine {
         let mut ctx = ctx.with_elevated_sandbox_policy(policy);
         if matches!(mode, AppMode::Plan) {
             ctx = ctx.with_shell_network_denied_hint(
-                "Shell command blocked: Plan mode runs shell commands in a read-only sandbox — no writes, no network. Use Agent mode (`/agent`) for any command that creates or modifies files, or that needs network access.",
+                "Shell command blocked: Plan mode runs shell commands in a read-only sandbox — no writes, no network. Use Agent mode (`/mode agent`) for any command that creates or modifies files, or that needs network access.",
             );
         }
         ctx

--- a/crates/tui/src/localization.rs
+++ b/crates/tui/src/localization.rs
@@ -214,7 +214,6 @@ pub enum MessageId {
     HelpFooterMove,
     HelpFooterJump,
     HelpFooterClose,
-    CmdAgentDescription,
     CmdAttachDescription,
     CmdAnchorDescription,
     CmdCacheDescription,
@@ -240,11 +239,11 @@ pub enum MessageId {
     CmdLogoutDescription,
     CmdMcpDescription,
     CmdMemoryDescription,
+    CmdModeDescription,
     CmdModelDescription,
     CmdModelsDescription,
     CmdNetworkDescription,
     CmdNoteDescription,
-    CmdPlanDescription,
     CmdThemeDescription,
     CmdProviderDescription,
     CmdQueueDescription,
@@ -271,7 +270,6 @@ pub enum MessageId {
     CmdShareDescription,
     CmdUndoDescription,
     CmdVerboseDescription,
-    CmdYoloDescription,
     CmdCacheAdvice,
     CmdCacheFootnote,
     CmdCacheHeader,
@@ -407,7 +405,6 @@ pub const ALL_MESSAGE_IDS: &[MessageId] = &[
     MessageId::HelpFooterMove,
     MessageId::HelpFooterJump,
     MessageId::HelpFooterClose,
-    MessageId::CmdAgentDescription,
     MessageId::CmdAnchorDescription,
     MessageId::CmdAttachDescription,
     MessageId::CmdCacheDescription,
@@ -432,11 +429,11 @@ pub const ALL_MESSAGE_IDS: &[MessageId] = &[
     MessageId::CmdLogoutDescription,
     MessageId::CmdMcpDescription,
     MessageId::CmdMemoryDescription,
+    MessageId::CmdModeDescription,
     MessageId::CmdModelDescription,
     MessageId::CmdModelsDescription,
     MessageId::CmdNetworkDescription,
     MessageId::CmdNoteDescription,
-    MessageId::CmdPlanDescription,
     MessageId::CmdProviderDescription,
     MessageId::CmdQueueDescription,
     MessageId::CmdRecallDescription,
@@ -462,7 +459,6 @@ pub const ALL_MESSAGE_IDS: &[MessageId] = &[
     MessageId::CmdShareDescription,
     MessageId::CmdUndoDescription,
     MessageId::CmdVerboseDescription,
-    MessageId::CmdYoloDescription,
     MessageId::CmdCacheAdvice,
     MessageId::CmdCacheFootnote,
     MessageId::CmdCacheHeader,
@@ -718,7 +714,6 @@ fn english(id: MessageId) -> &'static str {
         MessageId::HelpFooterMove => "  Up/Down move ",
         MessageId::HelpFooterJump => " PgUp/PgDn jump ",
         MessageId::HelpFooterClose => " Esc close ",
-        MessageId::CmdAgentDescription => "Switch to agent mode",
         MessageId::CmdAnchorDescription => {
             "Pin a fact that survives compaction (auto-injected into context)"
         }
@@ -754,14 +749,14 @@ fn english(id: MessageId) -> &'static str {
         MessageId::CmdLogoutDescription => "Clear API key and return to setup",
         MessageId::CmdMcpDescription => "Open or manage MCP servers",
         MessageId::CmdMemoryDescription => "Inspect or manage the persistent user-memory file",
+        MessageId::CmdModeDescription => {
+            "Switch mode or open picker: /mode [agent|plan|yolo|1|2|3]"
+        }
         MessageId::CmdModelDescription => "Switch or view current model",
         MessageId::CmdModelsDescription => "List available models from API",
         MessageId::CmdNetworkDescription => "Manage network allow and deny rules",
         MessageId::CmdNoteDescription => {
             "Append note to persistent notes file (.deepseek/notes.md)"
-        }
-        MessageId::CmdPlanDescription => {
-            "Switch to plan mode and review suggested implementation steps"
         }
         MessageId::CmdThemeDescription => "Toggle between dark and light theme",
         MessageId::CmdProviderDescription => {
@@ -803,7 +798,6 @@ fn english(id: MessageId) -> &'static str {
         }
         MessageId::CmdUndoDescription => "Remove last message pair",
         MessageId::CmdVerboseDescription => "Toggle full live thinking in the transcript",
-        MessageId::CmdYoloDescription => "Enable YOLO mode (shell + trust + auto-approve)",
         MessageId::CmdCacheAdvice => {
             "Hit/miss ratios over ~70% after the third turn indicate a stable cache prefix; \n\
              lower than that on long sessions suggests prefix churn worth investigating (#263)."
@@ -951,11 +945,11 @@ fn english(id: MessageId) -> &'static str {
         MessageId::HomeModeTips => "Mode Tips",
         MessageId::HomeAgentModeTip => "Agent mode - Use tools for autonomous tasks",
         MessageId::HomeAgentModeReviewTip => "  Use Ctrl+X to review in Plan mode before executing",
-        MessageId::HomeAgentModeYoloTip => "  Type /yolo to enable full tool access",
+        MessageId::HomeAgentModeYoloTip => "  Type /mode yolo to enable full tool access",
         MessageId::HomeYoloModeTip => "YOLO mode - Full tool access, no approvals",
         MessageId::HomeYoloModeCaution => "  Be careful with destructive operations!",
         MessageId::HomePlanModeTip => "Plan mode - Design before implementing",
-        MessageId::HomePlanModeChecklistTip => "  Use /plan to create structured checklists",
+        MessageId::HomePlanModeChecklistTip => "  Use /mode plan to create structured checklists",
     }
 }
 
@@ -1003,7 +997,6 @@ fn japanese(id: MessageId) -> Option<&'static str> {
         MessageId::HelpFooterMove => "  Up/Down 移動 ",
         MessageId::HelpFooterJump => " PgUp/PgDn ジャンプ ",
         MessageId::HelpFooterClose => " Esc 閉じる ",
-        MessageId::CmdAgentDescription => "Agent モードに切り替え",
         MessageId::CmdAnchorDescription => {
             "コンパクション後も保持される重要な事実をピン留め（コンテキストに自動注入）"
         }
@@ -1043,11 +1036,13 @@ fn japanese(id: MessageId) -> Option<&'static str> {
         MessageId::CmdLogoutDescription => "API キーを消去してセットアップに戻る",
         MessageId::CmdMcpDescription => "MCP サーバを開く・管理する",
         MessageId::CmdMemoryDescription => "永続ユーザーメモリファイルを確認・管理",
+        MessageId::CmdModeDescription => {
+            "動作モードを切り替え、または選択画面を開く: /mode [agent|plan|yolo|1|2|3]"
+        }
         MessageId::CmdModelDescription => "現在のモデルを切り替え・確認",
         MessageId::CmdModelsDescription => "API から利用可能なモデルを一覧表示",
         MessageId::CmdNetworkDescription => "ネットワーク許可・拒否ルールを管理",
         MessageId::CmdNoteDescription => "永続ノートファイル（.deepseek/notes.md）に追記",
-        MessageId::CmdPlanDescription => "Plan モードに切り替え、推奨される実装手順を確認",
         MessageId::CmdThemeDescription => "テーマ（ダーク/ライト）を切り替え",
         MessageId::CmdProviderDescription => {
             "現在の LLM バックエンドを切り替え・確認（deepseek | nvidia-nim | ollama）"
@@ -1090,7 +1085,6 @@ fn japanese(id: MessageId) -> Option<&'static str> {
         }
         MessageId::CmdUndoDescription => "最後のメッセージ対を削除",
         MessageId::CmdVerboseDescription => "ライブ思考表示の詳細モードを切り替え",
-        MessageId::CmdYoloDescription => "YOLO モードを有効化（shell + 信頼 + 自動承認）",
         MessageId::CmdCacheAdvice => {
             "3 ターン目以降にヒット率が ~70% 以上で安定していれば、プレフィックスキャッシュは健全。\n\
              長いセッションでこれを下回る場合はプレフィックスのドリフトの可能性あり (#263)。"
@@ -1239,11 +1233,13 @@ fn japanese(id: MessageId) -> Option<&'static str> {
         MessageId::HomeModeTips => "モードヒント",
         MessageId::HomeAgentModeTip => "Agent モード - ツールを使って自律的なタスクを実行",
         MessageId::HomeAgentModeReviewTip => "  実行前に Ctrl+X で Plan モードでレビュー",
-        MessageId::HomeAgentModeYoloTip => "  /yolo と入力して完全なツールアクセスを有効化",
+        MessageId::HomeAgentModeYoloTip => "  /mode yolo と入力して完全なツールアクセスを有効化",
         MessageId::HomeYoloModeTip => "YOLO モード - 完全なツールアクセス、承認なし",
         MessageId::HomeYoloModeCaution => "  破壊的な操作には注意してください！",
         MessageId::HomePlanModeTip => "Plan モード - 実装前に設計",
-        MessageId::HomePlanModeChecklistTip => "  /plan を使って構造化されたチェックリストを作成",
+        MessageId::HomePlanModeChecklistTip => {
+            "  /mode plan を使って構造化されたチェックリストを作成"
+        }
     })
 }
 
@@ -1280,7 +1276,6 @@ fn chinese_simplified(id: MessageId) -> Option<&'static str> {
         MessageId::HelpFooterMove => "  Up/Down 移动 ",
         MessageId::HelpFooterJump => " PgUp/PgDn 跳转 ",
         MessageId::HelpFooterClose => " Esc 关闭 ",
-        MessageId::CmdAgentDescription => "切换到 Agent 模式",
         MessageId::CmdAnchorDescription => "钉选关键事实，在压缩后自动注入上下文",
         MessageId::CmdAttachDescription => "附加图片或视频媒体；文本文件或目录请使用 @path",
         MessageId::CmdCacheDescription => "显示最近 N 轮的 DeepSeek 前缀缓存命中/未命中统计",
@@ -1310,11 +1305,11 @@ fn chinese_simplified(id: MessageId) -> Option<&'static str> {
         MessageId::CmdLogoutDescription => "清除 API 密钥并返回设置",
         MessageId::CmdMcpDescription => "打开或管理 MCP 服务器",
         MessageId::CmdMemoryDescription => "查看或管理持久用户记忆文件",
+        MessageId::CmdModeDescription => "切换运行模式或打开选择器：/mode [agent|plan|yolo|1|2|3]",
         MessageId::CmdModelDescription => "切换或查看当前模型",
         MessageId::CmdModelsDescription => "列出 API 中可用的模型",
         MessageId::CmdNetworkDescription => "管理网络允许和拒绝规则",
         MessageId::CmdNoteDescription => "将笔记追加到持久笔记文件（.deepseek/notes.md）",
-        MessageId::CmdPlanDescription => "切换到 Plan 模式并查看建议的实现步骤",
         MessageId::CmdThemeDescription => "在浅色和深色主题之间切换",
         MessageId::CmdProviderDescription => {
             "切换或查看当前 LLM 后端（deepseek | nvidia-nim | ollama）"
@@ -1349,7 +1344,6 @@ fn chinese_simplified(id: MessageId) -> Option<&'static str> {
         }
         MessageId::CmdUndoDescription => "移除最后一组消息对",
         MessageId::CmdVerboseDescription => "切换实时思考内容的完整显示",
-        MessageId::CmdYoloDescription => "启用 YOLO 模式（shell + 信任 + 自动批准）",
         MessageId::CmdCacheAdvice => {
             "第 3 轮起命中率稳定在 ~70% 以上即表示前缀缓存稳定；\n\
              长会话中明显偏低则意味着前缀有抖动，值得排查（#263）。"
@@ -1482,11 +1476,11 @@ fn chinese_simplified(id: MessageId) -> Option<&'static str> {
         MessageId::HomeModeTips => "模式提示",
         MessageId::HomeAgentModeTip => "Agent 模式 - 使用工具执行自主任务",
         MessageId::HomeAgentModeReviewTip => "  按 Ctrl+X 可在 Plan 模式下审查后再执行",
-        MessageId::HomeAgentModeYoloTip => "  输入 /yolo 启用完整工具访问",
+        MessageId::HomeAgentModeYoloTip => "  输入 /mode yolo 启用完整工具访问",
         MessageId::HomeYoloModeTip => "YOLO 模式 - 完整工具访问，无需审批",
         MessageId::HomeYoloModeCaution => "  请小心破坏性操作！",
         MessageId::HomePlanModeTip => "Plan 模式 - 先设计再实现",
-        MessageId::HomePlanModeChecklistTip => "  使用 /plan 创建结构化检查清单",
+        MessageId::HomePlanModeChecklistTip => "  使用 /mode plan 创建结构化检查清单",
     })
 }
 
@@ -1525,7 +1519,6 @@ fn portuguese_brazil(id: MessageId) -> Option<&'static str> {
         MessageId::HelpFooterMove => "  Up/Down move ",
         MessageId::HelpFooterJump => " PgUp/PgDn salta ",
         MessageId::HelpFooterClose => " Esc fecha ",
-        MessageId::CmdAgentDescription => "Mudar para o modo agent",
         MessageId::CmdAnchorDescription => {
             "Fixar um fato que sobrevive à compactação (injetado automaticamente no contexto)"
         }
@@ -1571,14 +1564,14 @@ fn portuguese_brazil(id: MessageId) -> Option<&'static str> {
         MessageId::CmdMemoryDescription => {
             "Inspecionar ou gerenciar o arquivo persistente de memória do usuário"
         }
+        MessageId::CmdModeDescription => {
+            "Alternar modo ou abrir seletor: /mode [agent|plan|yolo|1|2|3]"
+        }
         MessageId::CmdModelDescription => "Trocar ou exibir o modelo atual",
         MessageId::CmdModelsDescription => "Listar os modelos disponíveis pela API",
         MessageId::CmdNetworkDescription => "Gerenciar regras de rede permitidas e bloqueadas",
         MessageId::CmdNoteDescription => {
             "Adicionar nota ao arquivo persistente (.deepseek/notes.md)"
-        }
-        MessageId::CmdPlanDescription => {
-            "Mudar para o modo plan e revisar os passos de implementação sugeridos"
         }
         MessageId::CmdThemeDescription => "Alternar entre o tema claro e escuro",
         MessageId::CmdProviderDescription => {
@@ -1624,9 +1617,6 @@ fn portuguese_brazil(id: MessageId) -> Option<&'static str> {
         }
         MessageId::CmdUndoDescription => "Remover o último par de mensagens",
         MessageId::CmdVerboseDescription => "Alternar pensamento ao vivo completo no transcript",
-        MessageId::CmdYoloDescription => {
-            "Ativar o modo YOLO (shell + confiança + aprovação automática)"
-        }
         MessageId::CmdCacheAdvice => {
             "Taxas de hit/miss acima de ~70% a partir do terceiro turno indicam um prefixo de cache estável;\n\
              valores menores em sessões longas sugerem instabilidade no prefixo, vale investigar (#263)."
@@ -1782,12 +1772,14 @@ fn portuguese_brazil(id: MessageId) -> Option<&'static str> {
             "  Use Ctrl+X para revisar no modo Plan antes de executar"
         }
         MessageId::HomeAgentModeYoloTip => {
-            "  Digite /yolo para habilitar acesso total às ferramentas"
+            "  Digite /mode yolo para habilitar acesso total às ferramentas"
         }
         MessageId::HomeYoloModeTip => "Modo YOLO - Acesso total a ferramentas, sem aprovações",
         MessageId::HomeYoloModeCaution => "  Tenha cuidado com operações destrutivas!",
         MessageId::HomePlanModeTip => "Modo Plan - Planeje antes de implementar",
-        MessageId::HomePlanModeChecklistTip => "  Use /plan para criar checklists estruturados",
+        MessageId::HomePlanModeChecklistTip => {
+            "  Use /mode plan para criar checklists estruturados"
+        }
     })
 }
 

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -3790,6 +3790,8 @@ pub enum AppAction {
     /// Open the `/provider` picker modal — DeepSeek / NVIDIA NIM / OpenRouter
     /// / Novita with inline API-key prompt for un-configured providers (#52).
     OpenProviderPicker,
+    /// Open the `/mode` picker modal for Agent / Plan / YOLO.
+    OpenModePicker,
     /// Open the `/statusline` multi-select picker for footer items.
     OpenStatusPicker,
     /// Send a message to the AI (normal chat mode).

--- a/crates/tui/src/tui/command_palette.rs
+++ b/crates/tui/src/tui/command_palette.rs
@@ -818,7 +818,7 @@ mod tests {
     #[test]
     fn command_palette_filters_with_section_shortcuts() {
         let entries = vec![
-            palette_entry(PaletteSection::Command, "/agent", "agent command", "/agent"),
+            palette_entry(PaletteSection::Command, "/mode", "mode command", "/mode"),
             palette_entry(
                 PaletteSection::Skill,
                 "skill:search",
@@ -836,7 +836,7 @@ mod tests {
         ];
         let mut view = CommandPaletteView::new(entries);
 
-        view.query = "c:agent".to_string();
+        view.query = "c:mode".to_string();
         view.refilter();
         assert_eq!(view.filtered, vec![0]);
 

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -4646,6 +4646,14 @@ async fn apply_command_result(
                         ));
                 }
             }
+            AppAction::OpenModePicker => {
+                if app.view_stack.top_kind() != Some(ModalKind::ModePicker) {
+                    app.view_stack
+                        .push(crate::tui::views::mode_picker::ModePickerView::new(
+                            app.mode,
+                        ));
+                }
+            }
             AppAction::OpenStatusPicker => {
                 if app.view_stack.top_kind() != Some(ModalKind::StatusPicker) {
                     app.view_stack
@@ -5805,6 +5813,10 @@ async fn handle_view_events(
             }
             ViewEvent::ProviderPickerApiKeySubmitted { provider, api_key } => {
                 apply_provider_picker_api_key(app, engine_handle, config, provider, api_key).await;
+            }
+            ViewEvent::ModeSelected { mode } => {
+                let msg = commands::switch_mode(app, mode);
+                app.add_message(HistoryCell::System { content: msg });
             }
             ViewEvent::BacktrackStep { direction } => {
                 app.backtrack.step(direction);

--- a/crates/tui/src/tui/views/help.rs
+++ b/crates/tui/src/tui/views/help.rs
@@ -483,24 +483,24 @@ mod tests {
     #[test]
     fn substring_filter_narrows_to_command() {
         let mut view = HelpView::new();
-        type_filter(&mut view, "yolo");
+        type_filter(&mut view, "mode yolo");
         assert!(!view.filtered.is_empty());
         // Every filtered entry should genuinely contain the query in its
         // searchable haystack — no false positives slipped past.
         for idx in &view.filtered {
             assert!(
                 view.entries[*idx].haystack.contains("yolo"),
-                "entry {:?} leaked through `yolo` filter",
+                "entry {:?} leaked through `mode yolo` filter",
                 view.entries[*idx]
             );
         }
-        // The `/yolo` command must survive the filter; it's the canonical
-        // single-term match.
+        // The unified `/mode` command must surface when filtering for a
+        // concrete mode value.
         assert!(
             view.filtered
                 .iter()
-                .any(|idx| view.entries[*idx].label == "/yolo"),
-            "/yolo should match the `yolo` filter"
+                .any(|idx| view.entries[*idx].label == "/mode"),
+            "/mode should match the `mode yolo` filter"
         );
     }
 
@@ -618,14 +618,14 @@ mod tests {
     #[test]
     fn render_with_filter_shows_only_matching_section_and_status() {
         let mut view = HelpView::new();
-        type_filter(&mut view, "yolo");
+        type_filter(&mut view, "mode yolo");
         let area = Rect::new(0, 0, 96, 24);
         let mut buf = Buffer::empty(area);
         view.render(area, &mut buf);
 
         let dump = buffer_text(&buf, area);
         assert!(
-            dump.contains("Filter: yolo"),
+            dump.contains("Filter: mode yolo"),
             "filter echo missing:\n{dump}"
         );
         assert!(
@@ -633,12 +633,12 @@ mod tests {
             "match counter missing in dump:\n{dump}"
         );
         assert!(
-            dump.contains("/yolo"),
-            "expected /yolo command in filtered render:\n{dump}"
+            dump.contains("/mode"),
+            "expected /mode command in filtered render:\n{dump}"
         );
         assert!(
-            !dump.contains("/agent"),
-            "non-matching commands should not render under a `yolo` filter:\n{dump}"
+            !dump.contains("/model"),
+            "non-matching commands should not render under a `mode yolo` filter:\n{dump}"
         );
     }
 

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -13,6 +13,7 @@ use crate::tui::approval::{ElevationOption, ReviewDecision};
 use crate::tui::history::{HistoryCell, SubAgentCell, summarize_tool_output};
 use crate::tui::widgets::agent_card::AgentLifecycle;
 
+pub mod mode_picker;
 pub mod status_picker;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -30,6 +31,7 @@ pub enum ModalKind {
     Config,
     ModelPicker,
     ProviderPicker,
+    ModePicker,
     FilePicker,
     StatusPicker,
     ContextMenu,
@@ -149,6 +151,10 @@ pub enum ViewEvent {
     ProviderPickerApiKeySubmitted {
         provider: crate::config::ApiProvider,
         api_key: String,
+    },
+    /// Emitted by the `/mode` picker when the user chooses a mode.
+    ModeSelected {
+        mode: crate::tui::app::AppMode,
     },
     /// Emitted by the `/statusline` picker every time the user toggles an
     /// item (live preview) and once more on Enter (final). The handler

--- a/crates/tui/src/tui/views/mode_picker.rs
+++ b/crates/tui/src/tui/views/mode_picker.rs
@@ -1,0 +1,223 @@
+//! `/mode` picker for Agent / Plan / YOLO.
+
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::{
+    buffer::Buffer,
+    layout::Rect,
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Padding, Paragraph, Widget},
+};
+
+use crate::palette;
+use crate::tui::app::AppMode;
+use crate::tui::views::{ModalKind, ModalView, ViewAction, ViewEvent};
+
+#[derive(Debug, Clone, Copy)]
+struct ModeRow {
+    mode: AppMode,
+    number: char,
+    name: &'static str,
+    hint: &'static str,
+}
+
+const MODE_ROWS: &[ModeRow] = &[
+    ModeRow {
+        mode: AppMode::Agent,
+        number: '1',
+        name: "Agent",
+        hint: "Normal execution with approvals",
+    },
+    ModeRow {
+        mode: AppMode::Plan,
+        number: '2',
+        name: "Plan",
+        hint: "Plan first before execution",
+    },
+    ModeRow {
+        mode: AppMode::Yolo,
+        number: '3',
+        name: "YOLO",
+        hint: "Shell + trust + auto-approve",
+    },
+];
+
+pub struct ModePickerView {
+    cursor: usize,
+}
+
+impl ModePickerView {
+    #[must_use]
+    pub fn new(current: AppMode) -> Self {
+        let cursor = MODE_ROWS
+            .iter()
+            .position(|row| row.mode == current)
+            .unwrap_or(0);
+        Self { cursor }
+    }
+
+    fn selected_mode(&self) -> AppMode {
+        MODE_ROWS
+            .get(self.cursor)
+            .map_or(AppMode::Agent, |row| row.mode)
+    }
+
+    fn move_up(&mut self) {
+        if self.cursor > 0 {
+            self.cursor -= 1;
+        }
+    }
+
+    fn move_down(&mut self) {
+        let max = MODE_ROWS.len().saturating_sub(1);
+        if self.cursor < max {
+            self.cursor += 1;
+        }
+    }
+
+    fn select_by_number(&mut self, number: char) -> Option<ViewAction> {
+        let idx = MODE_ROWS.iter().position(|row| row.number == number)?;
+        self.cursor = idx;
+        Some(ViewAction::EmitAndClose(ViewEvent::ModeSelected {
+            mode: self.selected_mode(),
+        }))
+    }
+}
+
+impl ModalView for ModePickerView {
+    fn kind(&self) -> ModalKind {
+        ModalKind::ModePicker
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    fn handle_key(&mut self, key: KeyEvent) -> ViewAction {
+        match key.code {
+            KeyCode::Esc => ViewAction::Close,
+            KeyCode::Enter => ViewAction::EmitAndClose(ViewEvent::ModeSelected {
+                mode: self.selected_mode(),
+            }),
+            KeyCode::Up | KeyCode::Char('k') => {
+                self.move_up();
+                ViewAction::None
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                self.move_down();
+                ViewAction::None
+            }
+            KeyCode::Char(number) => self.select_by_number(number).unwrap_or(ViewAction::None),
+            _ => ViewAction::None,
+        }
+    }
+
+    fn render(&self, area: Rect, buf: &mut Buffer) {
+        let popup_width = 68.min(area.width.saturating_sub(4)).max(44);
+        let popup_height = 9.min(area.height.saturating_sub(4)).max(7);
+        let popup_area = Rect {
+            x: area.x + (area.width.saturating_sub(popup_width)) / 2,
+            y: area.y + (area.height.saturating_sub(popup_height)) / 2,
+            width: popup_width,
+            height: popup_height,
+        };
+
+        Clear.render(popup_area, buf);
+
+        let block = Block::default()
+            .title(Line::from(Span::styled(
+                " Mode ",
+                Style::default()
+                    .fg(palette::DEEPSEEK_SKY)
+                    .add_modifier(Modifier::BOLD),
+            )))
+            .title_bottom(Line::from(vec![
+                Span::styled(" Up/Down ", Style::default().fg(palette::TEXT_MUTED)),
+                Span::raw("move "),
+                Span::styled(" Enter ", Style::default().fg(palette::TEXT_MUTED)),
+                Span::raw("select "),
+                Span::styled(" Esc ", Style::default().fg(palette::TEXT_MUTED)),
+                Span::raw("cancel "),
+            ]))
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(palette::BORDER_COLOR))
+            .style(Style::default().bg(palette::DEEPSEEK_INK))
+            .padding(Padding::uniform(1));
+
+        let inner = block.inner(popup_area);
+        block.render(popup_area, buf);
+
+        let mut lines = Vec::with_capacity(MODE_ROWS.len() + 1);
+        lines.push(Line::from(Span::styled(
+            "Choose how DeepSeek TUI should operate:",
+            Style::default().fg(palette::TEXT_MUTED),
+        )));
+
+        for (idx, row) in MODE_ROWS.iter().enumerate() {
+            let is_cursor = idx == self.cursor;
+            let row_style = if is_cursor {
+                Style::default()
+                    .fg(palette::SELECTION_TEXT)
+                    .bg(palette::SELECTION_BG)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(palette::TEXT_PRIMARY)
+            };
+            let hint_style = if is_cursor {
+                Style::default()
+                    .fg(palette::SELECTION_TEXT)
+                    .bg(palette::SELECTION_BG)
+            } else {
+                Style::default().fg(palette::TEXT_MUTED)
+            };
+            let pointer = if is_cursor { ">" } else { " " };
+
+            lines.push(Line::from(vec![
+                Span::styled(
+                    format!("{pointer} {}. {:<7}", row.number, row.name),
+                    row_style,
+                ),
+                Span::styled(row.hint, hint_style),
+            ]));
+        }
+
+        Paragraph::new(lines).render(inner, buf);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::KeyModifiers;
+
+    #[test]
+    fn opens_on_current_mode() {
+        let view = ModePickerView::new(AppMode::Plan);
+        assert_eq!(view.selected_mode(), AppMode::Plan);
+    }
+
+    #[test]
+    fn enter_emits_selected_mode() {
+        let mut view = ModePickerView::new(AppMode::Agent);
+        view.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        let action = view.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        match action {
+            ViewAction::EmitAndClose(ViewEvent::ModeSelected { mode }) => {
+                assert_eq!(mode, AppMode::Plan);
+            }
+            other => panic!("expected ModeSelected, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn number_keys_select_modes() {
+        let mut view = ModePickerView::new(AppMode::Agent);
+        let action = view.handle_key(KeyEvent::new(KeyCode::Char('3'), KeyModifiers::NONE));
+        match action {
+            ViewAction::EmitAndClose(ViewEvent::ModeSelected { mode }) => {
+                assert_eq!(mode, AppMode::Yolo);
+            }
+            other => panic!("expected ModeSelected, got {other:?}"),
+        }
+    }
+}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -307,9 +307,9 @@ Common settings keys:
   also kept locally for composer history search)
 - `default_model` (model name override)
 
-Only `agent`, `plan`, and `yolo` are visible modes in the UI. For compatibility,
-older settings files with `default_mode = "normal"` still load as `agent`, and
-the hidden `/normal` slash command switches to `Agent`.
+Only `agent`, `plan`, and `yolo` are visible modes in the UI. Switch between
+them with `/mode`. For compatibility, older settings files with
+`default_mode = "normal"` still load as `agent`.
 
 Localization scope is tracked in [LOCALIZATION.md](LOCALIZATION.md). The v0.7.6
 core pack covers high-visibility TUI chrome only; provider/tool schemas,

--- a/docs/MODES.md
+++ b/docs/MODES.md
@@ -11,6 +11,8 @@ Press `Tab` to complete composer menus, queue a draft as a next-turn follow-up
 while a turn is running, or cycle through the visible modes when the composer is
 otherwise idle: **Plan → Agent → YOLO → Plan**.
 Press `Shift+Tab` to cycle reasoning effort.
+Run `/mode` to open the mode picker, or switch directly with `/mode agent`,
+`/mode plan`, `/mode yolo`, `/mode 1`, `/mode 2`, or `/mode 3`.
 
 - **Plan**: design-first prompting. Read-only investigation tools stay available; shell and patch execution stay off. Use this when you want to think out loud and produce a plan to hand to a human (yourself later, or a reviewer).
 - **Agent**: multi-step tool use. Approvals for shell and paid tools (file writes are allowed without a prompt).
@@ -20,7 +22,6 @@ All three modes have access to the `rlm` tool. Inside its Python REPL, `llm_quer
 
 ## Compatibility Notes
 
-- `/normal` is a hidden compatibility alias that switches to `Agent`.
 - Older settings files with `default_mode = "normal"` still load as `agent`; saving rewrites the normalized value.
 
 ## Escape Key Behavior


### PR DESCRIPTION


## Summary

  This PR unifies the mode-switching commands into a single `/mode` command.

  Previously, `/agent`, `/plan`, and `/yolo` were separate commands, but they all did the same kind of operation: switch
  DeepSeek TUI into a different operating mode. Keeping those as separate top-level commands makes the command surface
  more scattered and repeats similar behavior across multiple entries.

  Now `/mode` is the single place for mode switching:

  - `/mode` opens a picker for Agent, Plan, and YOLO
  - `/mode agent` or `/mode 1` switches to Agent mode
  - `/mode plan` or `/mode 2` switches to Plan mode
  - `/mode yolo` or `/mode 3` switches to YOLO mode

  This makes the behavior easier to understand as switching between modes, instead of treating each mode as a separate
  command.

## Testing

- [x] `cargo test --all-features`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features`

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [x] Verified TUI behavior manually if UI changes
