### PR TITLE
fix(update): pass --ssl-no-revoke to curl on Windows

### DIFF
--- a/crates/cli/src/update.rs
+++ b/crates/cli/src/update.rs
@@ -140,10 +140,33 @@ struct Asset {
     browser_download_url: String,
 }
 
+/// Per-OS extra arguments to pass to every `curl` invocation issued from
+/// `deepseek update`. On Windows the system curl is built against Schannel,
+/// which performs mandatory certificate-revocation checks; if the user's
+/// network can't reach the OCSP/CRL responders (corporate firewalls,
+/// captive portals, IPv6 hiccups, some ISPs) the TLS handshake fails with
+/// `CRYPT_E_NO_REVOCATION_CHECK (0x80092012)` and `deepseek update` cannot
+/// proceed. `--ssl-no-revoke` tells Schannel to skip the revocation check
+/// for these one-shot HTTPS GETs against `api.github.com` /
+/// `objects.githubusercontent.com`. Other backends (OpenSSL/LibreSSL) accept
+/// the flag silently as a no-op, so we leave the helper a pure function over
+/// `os` and only consult `std::env::consts::OS` at call sites.
+pub(crate) fn extra_curl_args_for_os(os: &str) -> &'static [&'static str] {
+    match os {
+        "windows" => &["--ssl-no-revoke"],
+        _ => &[],
+    }
+}
+
+fn current_extra_curl_args() -> &'static [&'static str] {
+    extra_curl_args_for_os(std::env::consts::OS)
+}
+
 /// Fetch the latest release metadata from GitHub.
 fn fetch_latest_release() -> Result<Release> {
     let url = "https://api.github.com/repos/Hmbown/DeepSeek-TUI/releases/latest";
     let output = Command::new("curl")
+        .args(current_extra_curl_args())
         .args([
             "-sSfL",
             "-H",
@@ -171,6 +194,7 @@ fn fetch_latest_release() -> Result<Release> {
 /// Download a URL to bytes using curl.
 fn download_url(url: &str) -> Result<Vec<u8>> {
     let output = Command::new("curl")
+        .args(current_extra_curl_args())
         .args(["-sSfL", url])
         .output()
         .with_context(|| format!("failed to download {url}"))?;
@@ -280,6 +304,35 @@ fn backup_path_for(target: &Path) -> std::path::PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Windows curl is built against Schannel and performs mandatory
+    /// certificate-revocation checks. Networks that can't reach OCSP/CRL
+    /// responders trip `CRYPT_E_NO_REVOCATION_CHECK (0x80092012)`. Verify
+    /// we pass `--ssl-no-revoke` so `deepseek update` works in those
+    /// environments.
+    #[test]
+    fn windows_curl_extras_disable_certificate_revocation_check() {
+        let args = extra_curl_args_for_os("windows");
+        assert!(
+            args.contains(&"--ssl-no-revoke"),
+            "Windows curl invocations must include --ssl-no-revoke; got {args:?}"
+        );
+    }
+
+    /// Other OS curl backends (OpenSSL/LibreSSL on macOS/Linux/BSD) do
+    /// not need the Schannel-specific revocation override. Asserting an
+    /// empty extras list pins the behavior — adding new flags should be
+    /// a deliberate change with its own test.
+    #[test]
+    fn non_windows_curl_extras_are_empty() {
+        for os in ["linux", "macos", "freebsd", "openbsd", "netbsd"] {
+            assert!(
+                extra_curl_args_for_os(os).is_empty(),
+                "expected no curl extras for {os}, got {:?}",
+                extra_curl_args_for_os(os)
+            );
+        }
+    }
 
     /// Verify the arch mapping used when constructing asset names.
     /// The mapping must use release-asset naming (arm64/x64), not Rust


### PR DESCRIPTION
## Summary

Pre-tag fix for v0.8.23. Windows users hitting `deepseek update` with the error

```
error: curl failed: curl: (35) schannel: next InitializeSecurityContext failed: CRYPT_E_NO_REVOCATION_CHECK (0x80092012)
```

are blocked because Schannel-backed curl insists on reaching OCSP/CRL responders for revocation checks. Many corporate networks (and some consumer ones) can't reach those servers — the TLS handshake fails before the GitHub Releases API is ever queried.

`--ssl-no-revoke` is the standard Schannel-curl flag that disables this check for one-shot HTTPS GETs. Used by rustup, GitHub CLI, and most self-updaters. Only applied on Windows; non-Windows curl backends are untouched.

## Changes

- `crates/cli/src/update.rs` — extracted `extra_curl_args_for_os(os)` helper, applied to both `fetch_latest_release()` and `download_url()`. Pure function over the OS string so both branches are unit-tested.
- 2 new tests: Windows includes `--ssl-no-revoke`, other platforms get an empty extras list.

## Test plan

- [x] `cargo test -p deepseek-tui-cli windows_curl_extras_disable_certificate_revocation_check` — passes
- [x] `cargo test -p deepseek-tui-cli non_windows_curl_extras_are_empty` — passes
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p deepseek-tui-cli --all-targets --all-features -- -D warnings` — clean
- [ ] CI green
- [ ] Merge before tagging v0.8.23

🤖 Generated with [Claude Code](https://claude.com/claude-code)