### PR TITLE
fix(mcp): paginate tools/resources/prompts discovery via nextCursor

### DIFF
--- a/crates/tui/src/mcp.rs
+++ b/crates/tui/src/mcp.rs
@@ -1095,9 +1095,12 @@ impl McpConnection {
                 break;
             };
 
-            if let Some(tools) = result.get("tools") {
-                let page: Vec<McpTool> = serde_json::from_value(tools.clone()).unwrap_or_default();
-                self.tools.extend(page);
+            if let Some(arr) = result.get("tools").and_then(|v| v.as_array()) {
+                for item in arr {
+                    if let Ok(tool) = serde_json::from_value::<McpTool>(item.clone()) {
+                        self.tools.push(tool);
+                    }
+                }
             }
 
             cursor = result
@@ -1137,10 +1140,12 @@ impl McpConnection {
                 break;
             };
 
-            if let Some(resources) = result.get("resources") {
-                let page: Vec<McpResource> =
-                    serde_json::from_value(resources.clone()).unwrap_or_default();
-                self.resources.extend(page);
+            if let Some(arr) = result.get("resources").and_then(|v| v.as_array()) {
+                for item in arr {
+                    if let Ok(resource) = serde_json::from_value::<McpResource>(item.clone()) {
+                        self.resources.push(resource);
+                    }
+                }
             }
 
             cursor = result
@@ -1180,10 +1185,12 @@ impl McpConnection {
                 .get("resourceTemplates")
                 .or_else(|| result.get("templates"))
                 .or_else(|| result.get("resource_templates"));
-            if let Some(templates) = templates {
-                let page: Vec<McpResourceTemplate> =
-                    serde_json::from_value(templates.clone()).unwrap_or_default();
-                self.resource_templates.extend(page);
+            if let Some(arr) = templates.and_then(|v| v.as_array()) {
+                for item in arr {
+                    if let Ok(tmpl) = serde_json::from_value::<McpResourceTemplate>(item.clone()) {
+                        self.resource_templates.push(tmpl);
+                    }
+                }
             }
 
             cursor = result
@@ -1219,10 +1226,12 @@ impl McpConnection {
                 break;
             };
 
-            if let Some(prompts) = result.get("prompts") {
-                let page: Vec<McpPrompt> =
-                    serde_json::from_value(prompts.clone()).unwrap_or_default();
-                self.prompts.extend(page);
+            if let Some(arr) = result.get("prompts").and_then(|v| v.as_array()) {
+                for item in arr {
+                    if let Ok(prompt) = serde_json::from_value::<McpPrompt>(item.clone()) {
+                        self.prompts.push(prompt);
+                    }
+                }
             }
 
             cursor = result


### PR DESCRIPTION
## Problem

MCP servers are allowed by spec to paginate `tools/list`, `resources/list`, `resources/templates/list`, and `prompts/list` responses. When a server paginates at N items per page (e.g. gbrain paginates at 5), the previous implementation would silently stop after the first page, making it appear as if only those N tools existed.

This caused the symptom reported in #1250: only the first 5 alphabetically-sorted tools were loaded, regardless of how many the server actually exposed.

## Fix

All four discovery methods now follow `nextCursor` until the server signals no more pages, accumulating results across all pages before completing.

The non-paginating path (servers that return all results in one response with no `nextCursor`) is unchanged in behavior.

## Testing

- Servers that don't paginate: unaffected — they return no `nextCursor`, the loop exits after the first response exactly as before.
- Servers that paginate: all pages are now fetched and merged.

Fixes #1250