### PR TITLE
fix(i18n): use 终止 instead of 中止 in zh-Hans approval dialog

### DIFF
--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -1387,7 +1387,7 @@ fn single_key_value(_locale: Locale) -> &'static str {
 
 fn footer_controls(locale: Locale) -> &'static str {
     match locale {
-        Locale::ZhHans => "  ·  v：完整参数  ·  Esc：中止",
+        Locale::ZhHans => "  ·  v：完整参数  ·  Esc：终止",
         _ => "  ·  v: full params  ·  Esc: abort",
     }
 }
@@ -1495,7 +1495,7 @@ fn option_deny(locale: Locale) -> &'static str {
 
 fn option_abort(locale: Locale) -> &'static str {
     match locale {
-        Locale::ZhHans => "中止本轮",
+        Locale::ZhHans => "终止本轮",
         _ => "Abort the turn",
     }
 }


### PR DESCRIPTION
## Problem

The zh-Hans approval/elevation dialog shows `中止` (and `中止本轮`) for the abort action. As noted in #1273:

- **中止** = temporarily stop; implies the action can be resumed
- **终止** = definitively end; matches the English *"Abort the turn"* / *"abort"* semantics

Since aborting a turn is a permanent, non-recoverable action, `终止` is the correct term.

Fixes #1273

## Changes

`crates/tui/src/tui/widgets/mod.rs`:

| Location | Before | After |
|---|---|---|
| `option_abort()` | `中止本轮` | `终止本轮` |
| `footer_controls()` | `Esc：中止` | `Esc：终止` |