### PR TITLE
fix: handle Home and End in composer input

### DIFF
--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -2696,6 +2696,9 @@ async fn run_event_loop(
                     app.move_cursor_right();
                 }
                 KeyCode::Home if key.modifiers.is_empty() => {
+                    if handle_plain_home_end(app, key.code) {
+                        continue;
+                    }
                     if let Some(anchor) =
                         TranscriptScroll::anchor_for(app.viewport.transcript_cache.line_meta(), 0)
                     {
@@ -2703,6 +2706,9 @@ async fn run_event_loop(
                     }
                 }
                 KeyCode::End if key.modifiers.is_empty() => {
+                    if handle_plain_home_end(app, key.code) {
+                        continue;
+                    }
                     app.scroll_to_bottom();
                 }
                 KeyCode::Home | KeyCode::Char('a')
@@ -2963,6 +2969,18 @@ fn handle_vim_normal_key(app: &mut App, c: char) {
             // Unknown normal-mode key — silently ignored in Normal mode.
         }
     }
+}
+
+fn handle_plain_home_end(app: &mut App, code: KeyCode) -> bool {
+    if app.input.is_empty() {
+        return false;
+    }
+    match code {
+        KeyCode::Home => app.move_cursor_start(),
+        KeyCode::End => app.move_cursor_end(),
+        _ => return false,
+    }
+    true
 }
 
 fn apply_alt_4_shortcut(app: &mut App, _modifiers: KeyModifiers) {

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -94,6 +94,27 @@ fn word_cursor_modifier_accepts_control_and_alt() {
 }
 
 #[test]
+fn plain_home_end_edit_non_empty_composer() {
+    let mut app = create_test_app();
+    app.input = "alpha beta".to_string();
+    app.cursor_position = app.input.chars().count();
+
+    assert!(handle_plain_home_end(&mut app, KeyCode::Home));
+    assert_eq!(app.cursor_position, 0);
+
+    assert!(handle_plain_home_end(&mut app, KeyCode::End));
+    assert_eq!(app.cursor_position, app.input.chars().count());
+}
+
+#[test]
+fn plain_home_end_falls_through_when_composer_empty() {
+    let mut app = create_test_app();
+
+    assert!(!handle_plain_home_end(&mut app, KeyCode::Home));
+    assert!(!handle_plain_home_end(&mut app, KeyCode::End));
+}
+
+#[test]
 fn selection_point_from_position_ignores_top_padding() {
     let area = Rect {
         x: 10,


### PR DESCRIPTION
## Why

The composer currently reserves plain Home/End for transcript navigation before checking whether the user is editing text. That makes the common editing action from #1234/#1263 surprising: pressing Home or End while a draft has focus should move the composer cursor to the start or end of that draft.

This keeps the existing transcript behavior when the composer is empty, so plain Home/End still jump to the top/bottom of the transcript in browsing mode.

Fixes #1234.
Refs #1263.

## Validation

- `git diff --check`
- Not run: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, `cargo test --workspace --all-features --locked` because this machine does not currently have `cargo`/`rustc`; two Homebrew Rust install attempts stalled while downloading Homebrew API metadata.
