### PR TITLE
fix(commands): discover project-local .deepseek and .cursor slash commands

### DIFF
--- a/crates/tui/src/commands/user_commands.rs
+++ b/crates/tui/src/commands/user_commands.rs
@@ -1,47 +1,44 @@
-//! User-defined slash commands from `~/.deepseek/commands/<name>.md`.
+//! User-defined slash commands from `~/.deepseek/commands/<name>.md` and
+//! project-local `.deepseek/commands/<name>.md` / `.cursor/commands/<name>.md`.
 //!
-//! Users drop `.md` files into `~/.deepseek/commands/` and the filename
+//! Users drop `.md` files into any of these directories and the filename
 //! (without `.md` extension) becomes a slash command. When invoked via
 //! `/name`, the file contents are sent as a user message.
+//!
+//! Discovery order (later entries override earlier ones):
+//! 1. `~/.deepseek/commands/`  — global user commands
+//! 2. `<cwd>/.deepseek/commands/` — project-local deepseek commands
+//! 3. `<cwd>/.cursor/commands/`   — project-local cursor commands
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::tui::app::{App, AppAction};
 
 use super::CommandResult;
 
-/// Path to the user commands directory: `~/.deepseek/commands/`.
-fn commands_dir() -> PathBuf {
+/// Path to the global user commands directory: `~/.deepseek/commands/`.
+fn global_commands_dir() -> PathBuf {
     let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("~"));
     home.join(".deepseek").join("commands")
 }
 
-/// Scan `~/.deepseek/commands/` for `.md` files and return `(name, content)` pairs.
+/// Scan a single directory for `.md` command files.
 ///
-/// The name is the filename without the `.md` extension, normalized to
-/// lowercase. Files that fail to read are silently skipped. The directory
-/// is re-scanned on every call so newly-added commands show up immediately
-/// without requiring a restart.
-pub fn load_user_commands() -> Vec<(String, String)> {
-    let dir = commands_dir();
-    let mut commands: Vec<(String, String)> = Vec::new();
-
-    if !dir.exists() {
-        return commands;
-    }
-
-    let entries = match std::fs::read_dir(&dir) {
-        Ok(entries) => entries,
+/// Returns `(name, content)` pairs where name is the stem lowercased.
+/// Non-`.md` files and unreadable files are silently skipped.
+fn scan_commands_dir(dir: &Path) -> Vec<(String, String)> {
+    let mut commands = Vec::new();
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
         Err(_) => return commands,
     };
-
     for entry in entries.flatten() {
         let path = entry.path();
         if path.extension().and_then(|e| e.to_str()) != Some("md") {
             continue;
         }
         let stem = match path.file_stem().and_then(|s| s.to_str()) {
-            Some(stem) => stem.to_lowercase(),
+            Some(s) => s.to_lowercase(),
             None => continue,
         };
         let content = match std::fs::read_to_string(&path) {
@@ -50,8 +47,32 @@ pub fn load_user_commands() -> Vec<(String, String)> {
         };
         commands.push((stem, content));
     }
+    commands
+}
 
-    // Sort by name for deterministic ordering.
+/// Collect user-defined commands from all command directories.
+///
+/// Scans the global directory first, then project-local directories.
+/// Project-local commands override global ones with the same name.
+/// The directory is re-scanned on every call so newly-added commands
+/// show up immediately without requiring a restart.
+pub fn load_user_commands() -> Vec<(String, String)> {
+    // Use an ordered map so later (higher-priority) entries overwrite earlier ones.
+    let mut by_name: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+
+    for (name, content) in scan_commands_dir(&global_commands_dir()) {
+        by_name.insert(name, content);
+    }
+
+    if let Ok(cwd) = std::env::current_dir() {
+        for sub in &[".deepseek/commands", ".cursor/commands"] {
+            for (name, content) in scan_commands_dir(&cwd.join(sub)) {
+                by_name.insert(name, content);
+            }
+        }
+    }
+
+    let mut commands: Vec<(String, String)> = by_name.into_iter().collect();
     commands.sort_by(|a, b| a.0.cmp(&b.0));
     commands
 }
@@ -106,10 +127,11 @@ pub fn user_commands_matching(prefix: &str) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
 
     #[test]
-    fn test_commands_dir_contains_deepseek_commands() {
-        let dir = commands_dir();
+    fn test_global_commands_dir_contains_deepseek_commands() {
+        let dir = global_commands_dir();
         let parts: Vec<_> = dir
             .components()
             .filter_map(|component| component.as_os_str().to_str())
@@ -124,14 +146,58 @@ mod tests {
     }
 
     #[test]
+    fn test_scan_commands_dir_absent() {
+        let tmp = std::env::temp_dir().join("deepseek-scan-absent-12345");
+        let cmds = scan_commands_dir(&tmp);
+        assert!(cmds.is_empty());
+    }
+
+    #[test]
+    fn test_scan_commands_dir_reads_md_files() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        fs::write(tmp.path().join("hello.md"), "Hello world!").unwrap();
+        fs::write(tmp.path().join("other.txt"), "ignored").unwrap();
+        let cmds = scan_commands_dir(tmp.path());
+        assert_eq!(cmds.len(), 1);
+        assert_eq!(cmds[0].0, "hello");
+        assert_eq!(cmds[0].1, "Hello world!");
+    }
+
+    #[test]
+    fn test_project_local_commands_override_global() {
+        // Simulate global and project-local dirs.
+        let global_dir = tempfile::tempdir().expect("global dir");
+        let project_dir = tempfile::tempdir().expect("project dir");
+
+        fs::write(global_dir.path().join("shared.md"), "global version").unwrap();
+        fs::write(global_dir.path().join("only-global.md"), "only in global").unwrap();
+        fs::write(project_dir.path().join("shared.md"), "project version").unwrap();
+
+        // Merge: global first, then project-local overrides.
+        let mut by_name: std::collections::HashMap<String, String> =
+            std::collections::HashMap::new();
+        for (name, content) in scan_commands_dir(global_dir.path()) {
+            by_name.insert(name, content);
+        }
+        for (name, content) in scan_commands_dir(project_dir.path()) {
+            by_name.insert(name, content);
+        }
+
+        assert_eq!(
+            by_name.get("shared").map(String::as_str),
+            Some("project version")
+        );
+        assert_eq!(
+            by_name.get("only-global").map(String::as_str),
+            Some("only in global")
+        );
+    }
+
+    #[test]
     fn test_load_user_commands_when_dir_absent() {
-        // Use a temp dir that definitely doesn't have a commands dir.
-        let _tmp = std::env::temp_dir().join("deepseek-test-nonexistent");
-        // Temporarily override the home for this test by checking the
-        // function with a non-existent directory path.
         let cmds = load_user_commands();
-        // Should not panic; returns empty vec when dir doesn't exist.
-        assert!(cmds.is_empty() || !cmds.is_empty());
+        // Should not panic; returns whatever exists (may be empty or not).
+        let _ = cmds;
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Slash commands defined in project-local directories are not discovered.
Only the global `~/.deepseek/commands/` directory is scanned, so files
placed under `<workspace>/.deepseek/commands/` or `<workspace>/.cursor/commands/`
are silently ignored (issue #1259).

## Solution

Extend `load_user_commands()` to also scan two project-local directories
using `std::env::current_dir()` (the same value `main.rs` uses as workspace):

1. `~/.deepseek/commands/` — global (existing behaviour, unchanged)
2. `<cwd>/.deepseek/commands/` — project-local deepseek commands (**new**)
3. `<cwd>/.cursor/commands/` — project-local cursor commands (**new**)

Project-local entries override global ones with the same name, so
per-project customisations take precedence without removing the user's
globals.  No function signatures were changed, so autocomplete
(`user_commands_matching`) and dispatch (`try_dispatch_user_command`)
pick up the new paths automatically.

## Changes

- `crates/tui/src/commands/user_commands.rs`
  - Extracted `scan_commands_dir(dir: &Path)` helper (replaces inline loop)
  - `global_commands_dir()` renamed from `commands_dir()` for clarity
  - `load_user_commands()` now merges global + two project-local dirs
    via a `HashMap` so last-write (highest priority) wins
  - Added tests: `test_scan_commands_dir_absent`, `test_scan_commands_dir_reads_md_files`,
    `test_project_local_commands_override_global`

## Testing

```
cargo test -p deepseek-tui -- user_commands
# 7 tests: ok
cargo fmt -p deepseek-tui && cargo check -p deepseek-tui
# clean
```

Fixes #1259