### PR TITLE
fix: preserve docs anchor offset

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -339,5 +339,5 @@ a.body-link:hover { background-size: 100% 6px; color: var(--ink); }
   .ticker-track { gap: 1.5rem; padding-right: 1.5rem; }
 }
 
-/* Anchor scroll-margin so deep links land below the sticky nav. */
-[id] { scroll-margin-top: 5rem; }
+/* Anchor fallback; page-level scroll-mt utilities should be able to override it. */
+:where([id]) { scroll-margin-top: 5rem; }


### PR DESCRIPTION
## Why

Docs page section anchors used Tailwind scroll-mt-32 so headings should land below the sticky nav, but the global id selector in globals.css has the same specificity and loads later. That reduced the effective scroll margin to 5rem, leaving section titles partially hidden after sidebar anchor navigation.

Fixes #1278.

## What changed

- Lower the global anchor fallback specificity with :where([id]) so page-level Tailwind scroll-margin utilities can override it.
- Keep the existing 5rem fallback for anchors that do not define their own offset.

## Validation

- git diff --check
- Not run: npm run lint, because web/node_modules is not installed in this environment.