### PR TITLE
fix(web): increase scroll-margin-top to prevent sticky nav from obscu…

### DIFF
--- a/web/app/[locale]/docs/page.tsx
+++ b/web/app/[locale]/docs/page.tsx
@@ -79,7 +79,7 @@ export default async function DocsPage({ params }: { params: Promise<{ locale: s
             <article className="lg:col-span-9 space-y-14 min-w-0">
 
               {/* 模式 */}
-              <section id="modes" className="scroll-mt-32">
+              <section id="modes">
                 <h2 className="font-display text-3xl mb-1">
                   模式 <span className="font-cjk text-indigo text-2xl ml-2">Modes</span>
                 </h2>
@@ -104,7 +104,7 @@ export default async function DocsPage({ params }: { params: Promise<{ locale: s
               </section>
 
               {/* 工具 */}
-              <section id="tools" className="scroll-mt-32">
+              <section id="tools">
                 <h2 className="font-display text-3xl mb-1">
                   工具 <span className="font-cjk text-indigo text-2xl ml-2">Tools</span>
                 </h2>
@@ -130,7 +130,7 @@ export default async function DocsPage({ params }: { params: Promise<{ locale: s
               </section>
 
               {/* 审批 */}
-              <section id="approval" className="scroll-mt-32">
+              <section id="approval">
                 <h2 className="font-display text-3xl mb-1">
                   审批与沙箱 <span className="font-cjk text-indigo text-2xl ml-2">Approval</span>
                 </h2>
@@ -156,7 +156,7 @@ export default async function DocsPage({ params }: { params: Promise<{ locale: s
               </section>
 
               {/* 配置 */}
-              <section id="config" className="scroll-mt-32">
+              <section id="config">
                 <h2 className="font-display text-3xl mb-1">
                   配置 <span className="font-cjk text-indigo text-2xl ml-2">Configuration</span>
                 </h2>
@@ -186,7 +186,7 @@ command = "~/.deepseek/hooks/pre.sh"        # / message_submit / mode_change / o
               </section>
 
               {/* MCP */}
-              <section id="mcp" className="scroll-mt-32">
+              <section id="mcp">
                 <h2 className="font-display text-3xl mb-1">
                   MCP 服务器 <span className="font-cjk text-indigo text-2xl ml-2">MCP</span>
                 </h2>
@@ -212,7 +212,7 @@ command = "~/.deepseek/hooks/pre.sh"        # / message_submit / mode_change / o
               </section>
 
               {/* 技能 */}
-              <section id="skills" className="scroll-mt-32">
+              <section id="skills">
                 <h2 className="font-display text-3xl mb-1">
                   技能 <span className="font-cjk text-indigo text-2xl ml-2">Skills</span>
                 </h2>
@@ -224,7 +224,7 @@ command = "~/.deepseek/hooks/pre.sh"        # / message_submit / mode_change / o
               </section>
 
               {/* 提供商 */}
-              <section id="providers" className="scroll-mt-32">
+              <section id="providers">
                 <h2 className="font-display text-3xl mb-1">
                   提供商 <span className="font-cjk text-indigo text-2xl ml-2">Providers</span>
                 </h2>
@@ -245,7 +245,7 @@ command = "~/.deepseek/hooks/pre.sh"        # / message_submit / mode_change / o
               </section>
 
               {/* 快捷键 */}
-              <section id="shortcuts" className="scroll-mt-32">
+              <section id="shortcuts">
                 <h2 className="font-display text-3xl mb-1">
                   快捷键 <span className="font-cjk text-indigo text-2xl ml-2">Shortcuts</span>
                 </h2>
@@ -307,7 +307,7 @@ command = "~/.deepseek/hooks/pre.sh"        # / message_submit / mode_change / o
 
             <article className="lg:col-span-9 space-y-14 min-w-0">
 
-              <section id="modes" className="scroll-mt-32">
+              <section id="modes">
                 <h2 className="font-display text-3xl mb-1">
                   Modes <span className="font-cjk text-indigo text-2xl ml-2">模式</span>
                 </h2>
@@ -331,7 +331,7 @@ command = "~/.deepseek/hooks/pre.sh"        # / message_submit / mode_change / o
                 </div>
               </section>
 
-              <section id="tools" className="scroll-mt-32">
+              <section id="tools">
                 <h2 className="font-display text-3xl mb-1">
                   Tools <span className="font-cjk text-indigo text-2xl ml-2">工具</span>
                 </h2>
@@ -356,7 +356,7 @@ command = "~/.deepseek/hooks/pre.sh"        # / message_submit / mode_change / o
                 </div>
               </section>
 
-              <section id="approval" className="scroll-mt-32">
+              <section id="approval">
                 <h2 className="font-display text-3xl mb-1">
                   Approval & Sandbox <span className="font-cjk text-indigo text-2xl ml-2">审批</span>
                 </h2>
@@ -381,7 +381,7 @@ command = "~/.deepseek/hooks/pre.sh"        # / message_submit / mode_change / o
                 </p>
               </section>
 
-              <section id="config" className="scroll-mt-32">
+              <section id="config">
                 <h2 className="font-display text-3xl mb-1">
                   Configuration <span className="font-cjk text-indigo text-2xl ml-2">配置</span>
                 </h2>
@@ -410,7 +410,7 @@ command = "~/.deepseek/hooks/pre.sh"        # / message_submit / mode_change / o
                 </p>
               </section>
 
-              <section id="mcp" className="scroll-mt-32">
+              <section id="mcp">
                 <h2 className="font-display text-3xl mb-1">
                   MCP Servers <span className="font-cjk text-indigo text-2xl ml-2">MCP</span>
                 </h2>
@@ -435,7 +435,7 @@ command = "~/.deepseek/hooks/pre.sh"        # / message_submit / mode_change / o
                 </pre>
               </section>
 
-              <section id="skills" className="scroll-mt-32">
+              <section id="skills">
                 <h2 className="font-display text-3xl mb-1">
                   Skills <span className="font-cjk text-indigo text-2xl ml-2">技能</span>
                 </h2>
@@ -446,7 +446,7 @@ command = "~/.deepseek/hooks/pre.sh"        # / message_submit / mode_change / o
                 </p>
               </section>
 
-              <section id="providers" className="scroll-mt-32">
+              <section id="providers">
                 <h2 className="font-display text-3xl mb-1">
                   Providers <span className="font-cjk text-indigo text-2xl ml-2">提供商</span>
                 </h2>
@@ -466,7 +466,7 @@ command = "~/.deepseek/hooks/pre.sh"        # / message_submit / mode_change / o
                 </div>
               </section>
 
-              <section id="shortcuts" className="scroll-mt-32">
+              <section id="shortcuts">
                 <h2 className="font-display text-3xl mb-1">
                   Shortcuts <span className="font-cjk text-indigo text-2xl ml-2">快捷键</span>
                 </h2>

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -340,4 +340,7 @@ a.body-link:hover { background-size: 100% 6px; color: var(--ink); }
 }
 
 /* Anchor scroll-margin so deep links land below the sticky nav. */
-[id] { scroll-margin-top: 8rem; }
+@layer base {
+  [id] { scroll-margin-top: 8rem; }
+}
+

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -340,4 +340,4 @@ a.body-link:hover { background-size: 100% 6px; color: var(--ink); }
 }
 
 /* Anchor scroll-margin so deep links land below the sticky nav. */
-[id] { scroll-margin-top: 5rem; }
+[id] { scroll-margin-top: 8rem; }

--- a/web/lib/facts.generated.ts
+++ b/web/lib/facts.generated.ts
@@ -18,8 +18,8 @@ export interface RepoFacts {
 }
 
 export const FACTS: RepoFacts = {
-  "generatedAt": "2026-05-08T19:10:07.269Z",
-  "version": "0.8.22",
+  "generatedAt": "2026-05-09T07:19:24.744Z",
+  "version": "0.8.23",
   "crates": [
     "agent",
     "app-server",


### PR DESCRIPTION
修复 Docs 页面侧边栏点击锚点链接跳转后，目标 section 顶部被 sticky nav header 遮挡的问题
- `globals.css` 中 `[id] { scroll-margin-top }` 从 `5rem` 提高到 `8rem`
- 移除 docs 页面中 16 个被全局规则覆盖的无效 `scroll-mt-32` 类名
## Root Cause
`[id]` 选择器为非 layered 样式，优先级高于 Tailwind `@layer utilities` 中的 `.scroll-mt-32`，导致 Tailwind 的 scroll-margin 工具类在 该项目全局失效。原值 `5rem` 不足以清除双行 sticky header。
## Test Plan
- 访问 `/docs` 或 `/zh/docs`，点击侧边栏各锚点链接，验证目标 section 顶部不再被 header 遮挡