### PR TITLE
feat(providers): add openai-compatible provider with custom URL and API key

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -26,6 +26,7 @@ enum ProviderArg {
     Deepseek,
     NvidiaNim,
     Openai,
+    OpenaiCompatible,
     Openrouter,
     Novita,
     Fireworks,
@@ -40,6 +41,7 @@ impl From<ProviderArg> for ProviderKind {
             ProviderArg::Deepseek => ProviderKind::Deepseek,
             ProviderArg::NvidiaNim => ProviderKind::NvidiaNim,
             ProviderArg::Openai => ProviderKind::Openai,
+            ProviderArg::OpenaiCompatible => ProviderKind::OpenaiCompatible,
             ProviderArg::Openrouter => ProviderKind::Openrouter,
             ProviderArg::Novita => ProviderKind::Novita,
             ProviderArg::Fireworks => ProviderKind::Fireworks,
@@ -249,6 +251,9 @@ enum AuthCommand {
         /// Read the key from stdin instead of prompting.
         #[arg(long = "api-key-stdin", default_value_t = false)]
         api_key_stdin: bool,
+        /// Base URL for the provider's API (required for openai-compatible).
+        #[arg(long)]
+        url: Option<String>,
     },
     /// Report whether a provider has a key configured. Never prints
     /// the value; just `set` / `not set` plus the source layer.
@@ -669,6 +674,7 @@ fn provider_slot(provider: ProviderKind) -> &'static str {
         ProviderKind::Deepseek => "deepseek",
         ProviderKind::NvidiaNim => "nvidia-nim",
         ProviderKind::Openai => "openai",
+        ProviderKind::OpenaiCompatible => "openai-compatible",
         ProviderKind::Openrouter => "openrouter",
         ProviderKind::Novita => "novita",
         ProviderKind::Fireworks => "fireworks",
@@ -679,9 +685,10 @@ fn provider_slot(provider: ProviderKind) -> &'static str {
 }
 
 /// Provider order used by the `auth list` and `auth status` outputs.
-const PROVIDER_LIST: [ProviderKind; 9] = [
+const PROVIDER_LIST: [ProviderKind; 10] = [
     ProviderKind::Deepseek,
     ProviderKind::NvidiaNim,
+    ProviderKind::OpenaiCompatible,
     ProviderKind::Openrouter,
     ProviderKind::Novita,
     ProviderKind::Fireworks,
@@ -744,6 +751,7 @@ fn provider_env_vars(provider: ProviderKind) -> &'static [&'static str] {
         ProviderKind::Vllm => &["VLLM_API_KEY"],
         ProviderKind::Ollama => &["OLLAMA_API_KEY"],
         ProviderKind::Openai => &["OPENAI_API_KEY"],
+        ProviderKind::OpenaiCompatible => &["OPENAI_COMPATIBLE_API_KEY"],
     }
 }
 
@@ -883,9 +891,25 @@ fn run_auth_command_with_secrets(
             provider,
             api_key,
             api_key_stdin,
+            url,
         } => {
             let provider: ProviderKind = provider.into();
             let slot = provider_slot(provider);
+
+            // openai-compatible requires a base URL.
+            if provider == ProviderKind::OpenaiCompatible {
+                let provider_cfg = store.config.providers.for_provider_mut(provider);
+                if let Some(url) = url.clone() {
+                    provider_cfg.base_url = Some(url);
+                } else if provider_cfg.base_url.is_none() {
+                    let entered = prompt_base_url(slot)?;
+                    provider_cfg.base_url = Some(entered);
+                }
+            } else if let Some(url) = url.clone() {
+                let provider_cfg = store.config.providers.for_provider_mut(provider);
+                provider_cfg.base_url = Some(url);
+            }
+
             if provider == ProviderKind::Ollama && api_key.is_none() && !api_key_stdin {
                 store.config.provider = provider;
                 let provider_cfg = store.config.providers.for_provider_mut(provider);
@@ -897,6 +921,34 @@ fn run_auth_command_with_secrets(
                     "configured {slot} provider in {} (API key optional)",
                     store.path().display()
                 );
+                return Ok(());
+            }
+            // For openai-compatible, API key is also optional (local servers may not need one).
+            if provider == ProviderKind::OpenaiCompatible && api_key.is_none() && !api_key_stdin {
+                let entered = prompt_api_key_optional(slot)?;
+                if !entered.is_empty() {
+                    write_provider_api_key_to_config(store, provider, &entered);
+                    let keyring_saved =
+                        write_provider_api_key_to_keyring(secrets, provider, &entered);
+                    store.config.provider = provider;
+                    store.save()?;
+                    if keyring_saved {
+                        println!(
+                            "saved API key for {slot} to {} and {}",
+                            store.path().display(),
+                            secrets.backend_name()
+                        );
+                    } else {
+                        println!("saved API key for {slot} to {}", store.path().display());
+                    }
+                } else {
+                    store.config.provider = provider;
+                    store.save()?;
+                    println!(
+                        "configured {slot} provider in {} (API key optional, no key set)",
+                        store.path().display()
+                    );
+                }
                 return Ok(());
             }
             let api_key = match (api_key, api_key_stdin) {
@@ -1010,6 +1062,40 @@ fn prompt_api_key(slot: &str) -> Result<String> {
         bail!("empty API key provided");
     }
     Ok(key)
+}
+
+fn prompt_api_key_optional(slot: &str) -> Result<String> {
+    use std::io::{IsTerminal, Write};
+    eprint!("Enter API key for {slot} (press Enter to skip): ");
+    io::stderr().flush().ok();
+    if !io::stdin().is_terminal() {
+        // Non-interactive: read directly without prompting twice.
+        return read_api_key_from_stdin();
+    }
+    let mut buf = String::new();
+    io::stdin()
+        .read_line(&mut buf)
+        .context("failed to read API key from stdin")?;
+    Ok(buf.trim().to_string())
+}
+
+fn prompt_base_url(slot: &str) -> Result<String> {
+    use std::io::{IsTerminal, Write};
+    eprint!("Enter base URL for {slot}: ");
+    io::stderr().flush().ok();
+    if !io::stdin().is_terminal() {
+        // Non-interactive: read directly without prompting twice.
+        return read_api_key_from_stdin();
+    }
+    let mut buf = String::new();
+    io::stdin()
+        .read_line(&mut buf)
+        .context("failed to read base URL from stdin")?;
+    let url = buf.trim().to_string();
+    if url.is_empty() {
+        bail!("empty base URL provided — openai-compatible requires a base URL");
+    }
+    Ok(url)
 }
 
 /// Move plaintext keys from config.toml into the configured secret store.

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -896,18 +896,14 @@ fn run_auth_command_with_secrets(
             let provider: ProviderKind = provider.into();
             let slot = provider_slot(provider);
 
-            // openai-compatible requires a base URL.
-            if provider == ProviderKind::OpenaiCompatible {
-                let provider_cfg = store.config.providers.for_provider_mut(provider);
-                if let Some(url) = url.clone() {
-                    provider_cfg.base_url = Some(url);
-                } else if provider_cfg.base_url.is_none() {
-                    let entered = prompt_base_url(slot)?;
-                    provider_cfg.base_url = Some(entered);
-                }
-            } else if let Some(url) = url.clone() {
-                let provider_cfg = store.config.providers.for_provider_mut(provider);
-                provider_cfg.base_url = Some(url);
+            // Apply --url when present, or prompt for openai-compatible.
+            let provider_cfg = store.config.providers.for_provider_mut(provider);
+            if let Some(u) = url {
+                provider_cfg.base_url = Some(validate_openai_compatible_url(&u)?);
+            } else if provider == ProviderKind::OpenaiCompatible && provider_cfg.base_url.is_none()
+            {
+                let entered = prompt_base_url(slot)?;
+                provider_cfg.base_url = Some(entered);
             }
 
             if provider == ProviderKind::Ollama && api_key.is_none() && !api_key_stdin {
@@ -1083,19 +1079,67 @@ fn prompt_base_url(slot: &str) -> Result<String> {
     use std::io::{IsTerminal, Write};
     eprint!("Enter base URL for {slot}: ");
     io::stderr().flush().ok();
-    if !io::stdin().is_terminal() {
-        // Non-interactive: read directly without prompting twice.
-        return read_api_key_from_stdin();
+    let url = if !io::stdin().is_terminal() {
+        // Non-interactive: read a single line without prompting twice.
+        read_line_from_stdin()?
+    } else {
+        let mut buf = String::new();
+        io::stdin()
+            .read_line(&mut buf)
+            .context("failed to read base URL from stdin")?;
+        buf.trim().to_string()
+    };
+    validate_openai_compatible_url(&url)
+}
+
+/// Validate and sanitise a user-supplied base URL for the openai-compatible
+/// provider.  Rejects empty strings, whitespace-only values, and URLs whose
+/// scheme is not `http` or `https`.  Strips any embedded credentials from the
+/// userinfo portion so they never end up in config files or error messages.
+fn validate_openai_compatible_url(url: &str) -> Result<String> {
+    if url.trim().is_empty() {
+        bail!("empty base URL provided — openai-compatible requires a base URL");
     }
+
+    // Quick sanity: only accept http/https schemes.
+    let lower = url.trim().to_ascii_lowercase();
+    if !lower.starts_with("https://") && !lower.starts_with("http://") {
+        let scheme = lower.split("://").next().unwrap_or(&lower);
+        bail!(
+            "unsupported URL scheme '{scheme}://' — only http and https are allowed for openai-compatible"
+        );
+    }
+
+    // Strip userinfo (user:password@) so credentials are never persisted or
+    // logged.  The user should pass secrets via api_key instead.
+    if let Some(rest) = lower
+        .strip_prefix("https://")
+        .or_else(|| lower.strip_prefix("http://"))
+    {
+        if let Some(at_pos) = rest.find('@') {
+            let host_and_path = &rest[at_pos + 1..];
+            if host_and_path.is_empty() {
+                bail!("invalid base URL — host is empty after stripping credentials");
+            }
+            let scheme = if lower.starts_with("https") {
+                "https"
+            } else {
+                "http"
+            };
+            return Ok(format!("{scheme}://***:***@{host_and_path}"));
+        }
+    }
+
+    Ok(url.trim().to_string())
+}
+
+/// Read exactly one line from stdin (trimmed).
+fn read_line_from_stdin() -> Result<String> {
     let mut buf = String::new();
     io::stdin()
         .read_line(&mut buf)
-        .context("failed to read base URL from stdin")?;
-    let url = buf.trim().to_string();
-    if url.is_empty() {
-        bail!("empty base URL provided — openai-compatible requires a base URL");
-    }
-    Ok(url)
+        .context("failed to read from stdin")?;
+    Ok(buf.trim().to_string())
 }
 
 /// Move plaintext keys from config.toml into the configured secret store.
@@ -2823,5 +2867,58 @@ mod tests {
 
         let resolved = locate_sibling_tui_binary().expect("override must resolve");
         assert_eq!(resolved, custom);
+    }
+
+    // --- validate_openai_compatible_url ---
+
+    #[test]
+    fn validate_url_rejects_empty() {
+        assert!(validate_openai_compatible_url("").is_err());
+        assert!(validate_openai_compatible_url("   ").is_err());
+    }
+
+    #[test]
+    fn validate_url_rejects_non_http_schemes() {
+        assert!(validate_openai_compatible_url("file:///etc/passwd").is_err());
+        assert!(validate_openai_compatible_url("ftp://example.com").is_err());
+        assert!(
+            validate_openai_compatible_url("javascript:alert(1)").is_err(),
+            "javascript: URIs must be rejected at config time"
+        );
+    }
+
+    #[test]
+    fn validate_url_accepts_http_and_https() {
+        assert!(validate_openai_compatible_url("https://api.openai.com/v1").is_ok());
+        assert!(validate_openai_compatible_url("http://localhost:8000/v1").is_ok());
+        assert!(validate_openai_compatible_url("https://example.com").is_ok());
+    }
+
+    #[test]
+    fn validate_url_strips_userinfo() {
+        let sanitized =
+            validate_openai_compatible_url("https://user:secret@api.example.com/v1").unwrap();
+        assert!(
+            !sanitized.contains("user"),
+            "username must be stripped: {sanitized}"
+        );
+        assert!(
+            !sanitized.contains("secret"),
+            "password must be stripped: {sanitized}"
+        );
+        assert!(
+            sanitized.contains("***"),
+            "credentials replaced with ***: {sanitized}"
+        );
+        assert!(
+            sanitized.ends_with("api.example.com/v1"),
+            "host+path preserved: {sanitized}"
+        );
+    }
+
+    #[test]
+    fn validate_url_trims_whitespace() {
+        let result = validate_openai_compatible_url("  https://api.example.com/v1  ").unwrap();
+        assert_eq!(result, "https://api.example.com/v1");
     }
 }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1017,7 +1017,10 @@ pub fn load_project_config(workspace: &Path) -> Option<ConfigToml> {
 }
 
 fn normalize_model_for_provider(provider: ProviderKind, model: &str) -> String {
-    if matches!(provider, ProviderKind::Ollama | ProviderKind::OpenaiCompatible) {
+    if matches!(
+        provider,
+        ProviderKind::Ollama | ProviderKind::OpenaiCompatible
+    ) {
         return model.to_string();
     }
 

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -45,6 +45,7 @@ pub enum ProviderKind {
     Deepseek,
     NvidiaNim,
     Openai,
+    OpenaiCompatible,
     Openrouter,
     Novita,
     Fireworks,
@@ -60,6 +61,7 @@ impl ProviderKind {
             Self::Deepseek => "deepseek",
             Self::NvidiaNim => "nvidia-nim",
             Self::Openai => "openai",
+            Self::OpenaiCompatible => "openai-compatible",
             Self::Openrouter => "openrouter",
             Self::Novita => "novita",
             Self::Fireworks => "fireworks",
@@ -75,6 +77,9 @@ impl ProviderKind {
             "deepseek" | "deep-seek" => Some(Self::Deepseek),
             "nvidia" | "nvidia-nim" | "nvidia_nim" | "nim" => Some(Self::NvidiaNim),
             "openai" | "open-ai" => Some(Self::Openai),
+            "openai-compatible" | "openai_compatible" | "openai-compat" => {
+                Some(Self::OpenaiCompatible)
+            }
             "openrouter" | "open_router" => Some(Self::Openrouter),
             "novita" => Some(Self::Novita),
             "fireworks" | "fireworks-ai" => Some(Self::Fireworks),
@@ -104,6 +109,8 @@ pub struct ProvidersToml {
     #[serde(default)]
     pub openai: ProviderConfigToml,
     #[serde(default)]
+    pub openai_compatible: ProviderConfigToml,
+    #[serde(default)]
     pub openrouter: ProviderConfigToml,
     #[serde(default)]
     pub novita: ProviderConfigToml,
@@ -124,6 +131,7 @@ impl ProvidersToml {
             ProviderKind::Deepseek => &self.deepseek,
             ProviderKind::NvidiaNim => &self.nvidia_nim,
             ProviderKind::Openai => &self.openai,
+            ProviderKind::OpenaiCompatible => &self.openai_compatible,
             ProviderKind::Openrouter => &self.openrouter,
             ProviderKind::Novita => &self.novita,
             ProviderKind::Fireworks => &self.fireworks,
@@ -138,6 +146,7 @@ impl ProvidersToml {
             ProviderKind::Deepseek => &mut self.deepseek,
             ProviderKind::NvidiaNim => &mut self.nvidia_nim,
             ProviderKind::Openai => &mut self.openai,
+            ProviderKind::OpenaiCompatible => &mut self.openai_compatible,
             ProviderKind::Openrouter => &mut self.openrouter,
             ProviderKind::Novita => &mut self.novita,
             ProviderKind::Fireworks => &mut self.fireworks,
@@ -897,6 +906,7 @@ impl ConfigToml {
                 ProviderKind::Deepseek => DEFAULT_DEEPSEEK_BASE_URL.to_string(),
                 ProviderKind::NvidiaNim => DEFAULT_NVIDIA_NIM_BASE_URL.to_string(),
                 ProviderKind::Openai => DEFAULT_OPENAI_BASE_URL.to_string(),
+                ProviderKind::OpenaiCompatible => String::new(),
                 ProviderKind::Openrouter => DEFAULT_OPENROUTER_BASE_URL.to_string(),
                 ProviderKind::Novita => DEFAULT_NOVITA_BASE_URL.to_string(),
                 ProviderKind::Fireworks => DEFAULT_FIREWORKS_BASE_URL.to_string(),
@@ -1007,7 +1017,7 @@ pub fn load_project_config(workspace: &Path) -> Option<ConfigToml> {
 }
 
 fn normalize_model_for_provider(provider: ProviderKind, model: &str) -> String {
-    if matches!(provider, ProviderKind::Ollama) {
+    if matches!(provider, ProviderKind::Ollama | ProviderKind::OpenaiCompatible) {
         return model.to_string();
     }
 
@@ -1065,6 +1075,7 @@ fn default_model_for_provider(provider: ProviderKind) -> &'static str {
         ProviderKind::Deepseek => DEFAULT_DEEPSEEK_MODEL,
         ProviderKind::NvidiaNim => DEFAULT_NVIDIA_NIM_MODEL,
         ProviderKind::Openai => DEFAULT_OPENAI_MODEL,
+        ProviderKind::OpenaiCompatible => "",
         ProviderKind::Openrouter => DEFAULT_OPENROUTER_MODEL,
         ProviderKind::Novita => DEFAULT_NOVITA_MODEL,
         ProviderKind::Fireworks => DEFAULT_FIREWORKS_MODEL,
@@ -1079,6 +1090,7 @@ fn default_base_url_for_provider(provider: ProviderKind) -> &'static str {
         ProviderKind::Deepseek => DEFAULT_DEEPSEEK_BASE_URL,
         ProviderKind::NvidiaNim => DEFAULT_NVIDIA_NIM_BASE_URL,
         ProviderKind::Openai => DEFAULT_OPENAI_BASE_URL,
+        ProviderKind::OpenaiCompatible => "",
         ProviderKind::Openrouter => DEFAULT_OPENROUTER_BASE_URL,
         ProviderKind::Novita => DEFAULT_NOVITA_BASE_URL,
         ProviderKind::Fireworks => DEFAULT_FIREWORKS_BASE_URL,
@@ -1095,8 +1107,10 @@ fn base_url_is_custom_for_provider(provider: ProviderKind, base_url: &str) -> bo
 }
 
 fn provider_preserves_custom_base_url_model(provider: ProviderKind, base_url: &str) -> bool {
-    matches!(provider, ProviderKind::Openrouter)
-        && base_url_is_custom_for_provider(provider, base_url)
+    matches!(
+        provider,
+        ProviderKind::Openrouter | ProviderKind::OpenaiCompatible
+    ) && base_url_is_custom_for_provider(provider, base_url)
 }
 
 #[derive(Debug, Clone, Default)]
@@ -1365,6 +1379,7 @@ struct EnvRuntimeOverrides {
     deepseek_base_url: Option<String>,
     nvidia_base_url: Option<String>,
     openai_base_url: Option<String>,
+    openai_compatible_base_url: Option<String>,
     openrouter_base_url: Option<String>,
     novita_base_url: Option<String>,
     fireworks_base_url: Option<String>,
@@ -1403,6 +1418,9 @@ impl EnvRuntimeOverrides {
             openai_base_url: std::env::var("OPENAI_BASE_URL")
                 .ok()
                 .filter(|v| !v.trim().is_empty()),
+            openai_compatible_base_url: std::env::var("OPENAI_COMPATIBLE_BASE_URL")
+                .ok()
+                .filter(|v| !v.trim().is_empty()),
             openrouter_base_url: std::env::var("OPENROUTER_BASE_URL")
                 .ok()
                 .filter(|v| !v.trim().is_empty()),
@@ -1431,6 +1449,7 @@ impl EnvRuntimeOverrides {
             ProviderKind::Deepseek => self.deepseek_base_url.clone(),
             ProviderKind::NvidiaNim => self.nvidia_base_url.clone(),
             ProviderKind::Openai => self.openai_base_url.clone(),
+            ProviderKind::OpenaiCompatible => self.openai_compatible_base_url.clone(),
             ProviderKind::Openrouter => self.openrouter_base_url.clone(),
             ProviderKind::Novita => self.novita_base_url.clone(),
             ProviderKind::Fireworks => self.fireworks_base_url.clone(),

--- a/crates/secrets/src/lib.rs
+++ b/crates/secrets/src/lib.rs
@@ -532,6 +532,9 @@ pub fn env_for(name: &str) -> Option<String> {
         "vllm" | "v-llm" => &["VLLM_API_KEY"],
         "ollama" | "ollama-local" => &["OLLAMA_API_KEY"],
         "openai" => &["OPENAI_API_KEY"],
+        "openai-compatible" | "openai_compatible" | "openai-compat" => {
+            &["OPENAI_COMPATIBLE_API_KEY"]
+        }
         _ => return None,
     };
     for var in candidates {

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -830,7 +830,7 @@ pub(super) fn apply_reasoning_effort(
             | ApiProvider::Vllm => {
                 body["thinking"] = json!({ "type": "disabled" });
             }
-            ApiProvider::Openai | ApiProvider::Ollama => {}
+            ApiProvider::Openai | ApiProvider::OpenaiCompatible | ApiProvider::Ollama => {}
             ApiProvider::NvidiaNim => {
                 body["chat_template_kwargs"] = json!({
                     "thinking": false,
@@ -848,7 +848,7 @@ pub(super) fn apply_reasoning_effort(
                 body["reasoning_effort"] = json!("high");
                 body["thinking"] = json!({ "type": "enabled" });
             }
-            ApiProvider::Openai | ApiProvider::Ollama => {}
+            ApiProvider::Openai | ApiProvider::OpenaiCompatible | ApiProvider::Ollama => {}
             ApiProvider::NvidiaNim => {
                 body["chat_template_kwargs"] = json!({
                     "thinking": true,
@@ -867,7 +867,7 @@ pub(super) fn apply_reasoning_effort(
                 body["reasoning_effort"] = json!("max");
                 body["thinking"] = json!({ "type": "enabled" });
             }
-            ApiProvider::Openai | ApiProvider::Ollama => {}
+            ApiProvider::Openai | ApiProvider::OpenaiCompatible | ApiProvider::Ollama => {}
             ApiProvider::NvidiaNim => {
                 body["chat_template_kwargs"] = json!({
                     "thinking": true,

--- a/crates/tui/src/commands/provider.rs
+++ b/crates/tui/src/commands/provider.rs
@@ -27,7 +27,7 @@ pub fn provider(app: &mut App, args: Option<&str>) -> CommandResult {
 
     let Some(target) = ApiProvider::parse(name) else {
         return CommandResult::error(format!(
-            "Unknown provider '{name}'. Expected: deepseek, nvidia-nim, openrouter, novita, fireworks, sglang, vllm, or ollama."
+            "Unknown provider '{name}'. Expected: deepseek, nvidia-nim, openai-compatible, openai, openrouter, novita, fireworks, sglang, vllm, or ollama."
         ));
     };
 

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -66,6 +66,7 @@ pub enum ApiProvider {
     DeepseekCN,
     NvidiaNim,
     Openai,
+    OpenaiCompatible,
     Openrouter,
     Novita,
     Fireworks,
@@ -84,6 +85,9 @@ impl ApiProvider {
             }
             "nvidia" | "nvidia-nim" | "nvidia_nim" | "nim" => Some(Self::NvidiaNim),
             "openai" | "open-ai" => Some(Self::Openai),
+            "openai-compatible" | "openai_compatible" | "openai-compat" => {
+                Some(Self::OpenaiCompatible)
+            }
             "openrouter" | "open_router" => Some(Self::Openrouter),
             "novita" => Some(Self::Novita),
             "fireworks" | "fireworks-ai" => Some(Self::Fireworks),
@@ -101,6 +105,7 @@ impl ApiProvider {
             Self::DeepseekCN => "deepseek-cn",
             Self::NvidiaNim => "nvidia-nim",
             Self::Openai => "openai",
+            Self::OpenaiCompatible => "openai-compatible",
             Self::Openrouter => "openrouter",
             Self::Novita => "novita",
             Self::Fireworks => "fireworks",
@@ -117,7 +122,8 @@ impl ApiProvider {
             Self::Deepseek => "DeepSeek",
             Self::DeepseekCN => "DeepSeek (legacy alias)",
             Self::NvidiaNim => "NVIDIA NIM",
-            Self::Openai => "OpenAI-compatible",
+            Self::Openai => "OpenAI",
+            Self::OpenaiCompatible => "OpenAI Compatible",
             Self::Openrouter => "OpenRouter",
             Self::Novita => "Novita AI",
             Self::Fireworks => "Fireworks AI",
@@ -133,6 +139,7 @@ impl ApiProvider {
         &[
             Self::Deepseek,
             Self::NvidiaNim,
+            Self::OpenaiCompatible,
             Self::Openai,
             Self::Openrouter,
             Self::Novita,
@@ -205,7 +212,7 @@ pub enum RequestPayloadMode {
 /// in the API payload (after normalization / provider-specific mapping).
 #[must_use]
 pub fn provider_capability(provider: ApiProvider, resolved_model: &str) -> ProviderCapability {
-    if matches!(provider, ApiProvider::Openai) {
+    if matches!(provider, ApiProvider::Openai | ApiProvider::OpenaiCompatible) {
         return ProviderCapability {
             provider,
             resolved_model: resolved_model.to_string(),
@@ -1029,6 +1036,8 @@ pub struct ProvidersConfig {
     #[serde(default)]
     pub openai: ProviderConfig,
     #[serde(default)]
+    pub openai_compatible: ProviderConfig,
+    #[serde(default)]
     pub openrouter: ProviderConfig,
     #[serde(default)]
     pub novita: ProviderConfig,
@@ -1099,7 +1108,7 @@ impl Config {
             && ApiProvider::parse(provider).is_none()
         {
             anyhow::bail!(
-                "Invalid provider '{provider}': expected deepseek, deepseek-cn, nvidia-nim, openai, openrouter, novita, fireworks, sglang, vllm, or ollama."
+                "Invalid provider '{provider}': expected deepseek, deepseek-cn, nvidia-nim, openai, openai-compatible, openrouter, novita, fireworks, sglang, vllm, or ollama."
             );
         }
         if let Some(ref key) = self.api_key
@@ -1216,6 +1225,7 @@ impl Config {
             ApiProvider::DeepseekCN => &providers.deepseek_cn,
             ApiProvider::NvidiaNim => &providers.nvidia_nim,
             ApiProvider::Openai => &providers.openai,
+            ApiProvider::OpenaiCompatible => &providers.openai_compatible,
             ApiProvider::Openrouter => &providers.openrouter,
             ApiProvider::Novita => &providers.novita,
             ApiProvider::Fireworks => &providers.fireworks,
@@ -1279,6 +1289,7 @@ impl Config {
             ApiProvider::Deepseek | ApiProvider::DeepseekCN => DEFAULT_TEXT_MODEL,
             ApiProvider::NvidiaNim => DEFAULT_NVIDIA_NIM_MODEL,
             ApiProvider::Openai => DEFAULT_OPENAI_MODEL,
+            ApiProvider::OpenaiCompatible => "",
             ApiProvider::Openrouter => DEFAULT_OPENROUTER_MODEL,
             ApiProvider::Novita => DEFAULT_NOVITA_MODEL,
             ApiProvider::Fireworks => DEFAULT_FIREWORKS_MODEL,
@@ -1308,6 +1319,7 @@ impl Config {
                 .filter(|base| base.contains("integrate.api.nvidia.com"))
                 .cloned(),
             ApiProvider::Openai
+            | ApiProvider::OpenaiCompatible
             | ApiProvider::Openrouter
             | ApiProvider::Novita
             | ApiProvider::Fireworks
@@ -1321,6 +1333,7 @@ impl Config {
                 ApiProvider::DeepseekCN => DEFAULT_DEEPSEEKCN_BASE_URL,
                 ApiProvider::NvidiaNim => DEFAULT_NVIDIA_NIM_BASE_URL,
                 ApiProvider::Openai => DEFAULT_OPENAI_BASE_URL,
+                ApiProvider::OpenaiCompatible => "",
                 ApiProvider::Openrouter => DEFAULT_OPENROUTER_BASE_URL,
                 ApiProvider::Novita => DEFAULT_NOVITA_BASE_URL,
                 ApiProvider::Fireworks => DEFAULT_FIREWORKS_BASE_URL,
@@ -1352,6 +1365,7 @@ impl Config {
             ApiProvider::Deepseek | ApiProvider::DeepseekCN => "deepseek",
             ApiProvider::NvidiaNim => "nvidia-nim",
             ApiProvider::Openai => "openai",
+            ApiProvider::OpenaiCompatible => "openai-compatible",
             ApiProvider::Openrouter => "openrouter",
             ApiProvider::Novita => "novita",
             ApiProvider::Fireworks => "fireworks",
@@ -1409,8 +1423,14 @@ impl Config {
                  with provider = \"nvidia-nim\"."
             ),
             ApiProvider::Openai => anyhow::bail!(
-                "OpenAI-compatible API key not found. Run 'deepseek auth set --provider openai', \
+                "OpenAI API key not found. Run 'deepseek auth set --provider openai', \
                  set OPENAI_API_KEY, or add [providers.openai] api_key in ~/.deepseek/config.toml."
+            ),
+            ApiProvider::OpenaiCompatible => anyhow::bail!(
+                "OpenAI-compatible API key and base URL not found. \
+                 Run 'deepseek auth set --provider openai-compatible --url <BASE_URL>', \
+                 set OPENAI_COMPATIBLE_API_KEY and OPENAI_COMPATIBLE_BASE_URL, \
+                 or add [providers.openai_compatible] api_key and base_url in ~/.deepseek/config.toml."
             ),
             ApiProvider::Openrouter => anyhow::bail!(
                 "OpenRouter API key not found. Run 'deepseek auth set --provider openrouter', \
@@ -1898,6 +1918,13 @@ fn apply_env_overrides(config: &mut Config) {
                     .openai
                     .base_url = Some(value);
             }
+            ApiProvider::OpenaiCompatible => {
+                config
+                    .providers
+                    .get_or_insert_with(ProvidersConfig::default)
+                    .openai_compatible
+                    .base_url = Some(value);
+            }
             _ => {
                 config.base_url = Some(value);
             }
@@ -1925,6 +1952,16 @@ fn apply_env_overrides(config: &mut Config) {
             .providers
             .get_or_insert_with(ProvidersConfig::default)
             .openai
+            .base_url = Some(value);
+    }
+    if matches!(config.api_provider(), ApiProvider::OpenaiCompatible)
+        && let Ok(value) = std::env::var("OPENAI_COMPATIBLE_BASE_URL")
+        && !value.trim().is_empty()
+    {
+        config
+            .providers
+            .get_or_insert_with(ProvidersConfig::default)
+            .openai_compatible
             .base_url = Some(value);
     }
     if matches!(config.api_provider(), ApiProvider::Openrouter)
@@ -1994,6 +2031,7 @@ fn apply_env_overrides(config: &mut Config) {
             ApiProvider::DeepseekCN => &mut providers.deepseek_cn,
             ApiProvider::NvidiaNim => &mut providers.nvidia_nim,
             ApiProvider::Openai => &mut providers.openai,
+            ApiProvider::OpenaiCompatible => &mut providers.openai_compatible,
             ApiProvider::Openrouter => &mut providers.openrouter,
             ApiProvider::Novita => &mut providers.novita,
             ApiProvider::Fireworks => &mut providers.fireworks,
@@ -2032,6 +2070,11 @@ fn apply_env_overrides(config: &mut Config) {
     }
     if matches!(config.api_provider(), ApiProvider::Openai)
         && let Ok(value) = std::env::var("OPENAI_MODEL")
+    {
+        config.default_text_model = Some(value);
+    }
+    if matches!(config.api_provider(), ApiProvider::OpenaiCompatible)
+        && let Ok(value) = std::env::var("OPENAI_COMPATIBLE_MODEL")
     {
         config.default_text_model = Some(value);
     }
@@ -2280,7 +2323,10 @@ fn normalize_model_for_provider(provider: ApiProvider, model: &str) -> Option<St
 }
 
 fn provider_passes_model_through(provider: ApiProvider) -> bool {
-    matches!(provider, ApiProvider::Openai | ApiProvider::Ollama)
+    matches!(
+        provider,
+        ApiProvider::Openai | ApiProvider::OpenaiCompatible | ApiProvider::Ollama
+    )
 }
 
 fn provider_entry_uses_custom_base_url(provider: ApiProvider, entry: &ProviderConfig) -> bool {
@@ -2296,6 +2342,7 @@ fn default_base_url_for_provider(provider: ApiProvider) -> &'static str {
         ApiProvider::DeepseekCN => DEFAULT_DEEPSEEKCN_BASE_URL,
         ApiProvider::NvidiaNim => DEFAULT_NVIDIA_NIM_BASE_URL,
         ApiProvider::Openai => DEFAULT_OPENAI_BASE_URL,
+        ApiProvider::OpenaiCompatible => "",
         ApiProvider::Openrouter => DEFAULT_OPENROUTER_BASE_URL,
         ApiProvider::Novita => DEFAULT_NOVITA_BASE_URL,
         ApiProvider::Fireworks => DEFAULT_FIREWORKS_BASE_URL,
@@ -2310,8 +2357,10 @@ fn base_url_is_custom_for_provider(provider: ApiProvider, base_url: &str) -> boo
 }
 
 fn provider_preserves_custom_base_url_model(provider: ApiProvider, base_url: &str) -> bool {
-    matches!(provider, ApiProvider::Openrouter)
-        && base_url_is_custom_for_provider(provider, base_url)
+    matches!(
+        provider,
+        ApiProvider::Openrouter | ApiProvider::OpenaiCompatible
+    ) && base_url_is_custom_for_provider(provider, base_url)
 }
 
 fn model_for_provider(provider: ApiProvider, normalized: String) -> String {
@@ -2496,6 +2545,10 @@ fn merge_providers(
             deepseek_cn: merge_provider_config(base.deepseek_cn, override_cfg.deepseek_cn),
             nvidia_nim: merge_provider_config(base.nvidia_nim, override_cfg.nvidia_nim),
             openai: merge_provider_config(base.openai, override_cfg.openai),
+            openai_compatible: merge_provider_config(
+                base.openai_compatible,
+                override_cfg.openai_compatible,
+            ),
             openrouter: merge_provider_config(base.openrouter, override_cfg.openrouter),
             novita: merge_provider_config(base.novita, override_cfg.novita),
             fireworks: merge_provider_config(base.fireworks, override_cfg.fireworks),
@@ -2913,6 +2966,9 @@ pub fn active_provider_has_env_api_key(config: &Config) -> bool {
                 || std::env::var("NVIDIA_NIM_API_KEY").is_ok_and(|k| !k.trim().is_empty())
         }
         ApiProvider::Openai => std::env::var("OPENAI_API_KEY").is_ok_and(|k| !k.trim().is_empty()),
+        ApiProvider::OpenaiCompatible => {
+            std::env::var("OPENAI_COMPATIBLE_API_KEY").is_ok_and(|k| !k.trim().is_empty())
+        }
         ApiProvider::Openrouter => {
             std::env::var("OPENROUTER_API_KEY").is_ok_and(|k| !k.trim().is_empty())
         }
@@ -2940,6 +2996,7 @@ pub fn has_api_key_for(config: &Config, provider: ApiProvider) -> bool {
         ApiProvider::Deepseek | ApiProvider::DeepseekCN => "DEEPSEEK_API_KEY",
         ApiProvider::NvidiaNim => "NVIDIA_API_KEY",
         ApiProvider::Openai => "OPENAI_API_KEY",
+        ApiProvider::OpenaiCompatible => "OPENAI_COMPATIBLE_API_KEY",
         ApiProvider::Openrouter => "OPENROUTER_API_KEY",
         ApiProvider::Novita => "NOVITA_API_KEY",
         ApiProvider::Fireworks => "FIREWORKS_API_KEY",
@@ -3008,6 +3065,7 @@ pub fn save_api_key_for(provider: ApiProvider, api_key: &str) -> Result<PathBuf>
         }
         ApiProvider::NvidiaNim => "providers.nvidia_nim",
         ApiProvider::Openai => "providers.openai",
+        ApiProvider::OpenaiCompatible => "providers.openai_compatible",
         ApiProvider::Openrouter => "providers.openrouter",
         ApiProvider::Novita => "providers.novita",
         ApiProvider::Fireworks => "providers.fireworks",
@@ -3042,6 +3100,7 @@ pub fn save_api_key_for(provider: ApiProvider, api_key: &str) -> Result<PathBuf>
         }
         ApiProvider::NvidiaNim => "nvidia_nim",
         ApiProvider::Openai => "openai",
+        ApiProvider::OpenaiCompatible => "openai_compatible",
         ApiProvider::Openrouter => "openrouter",
         ApiProvider::Novita => "novita",
         ApiProvider::Fireworks => "fireworks",
@@ -3175,6 +3234,9 @@ mod tests {
         openai_api_key: Option<OsString>,
         openai_base_url: Option<OsString>,
         openai_model: Option<OsString>,
+        openai_compatible_api_key: Option<OsString>,
+        openai_compatible_base_url: Option<OsString>,
+        openai_compatible_model: Option<OsString>,
         openrouter_api_key: Option<OsString>,
         openrouter_base_url: Option<OsString>,
         novita_api_key: Option<OsString>,
@@ -3215,6 +3277,9 @@ mod tests {
             let openai_api_key_prev = env::var_os("OPENAI_API_KEY");
             let openai_base_url_prev = env::var_os("OPENAI_BASE_URL");
             let openai_model_prev = env::var_os("OPENAI_MODEL");
+            let openai_compatible_api_key_prev = env::var_os("OPENAI_COMPATIBLE_API_KEY");
+            let openai_compatible_base_url_prev = env::var_os("OPENAI_COMPATIBLE_BASE_URL");
+            let openai_compatible_model_prev = env::var_os("OPENAI_COMPATIBLE_MODEL");
             let openrouter_api_key_prev = env::var_os("OPENROUTER_API_KEY");
             let openrouter_base_url_prev = env::var_os("OPENROUTER_BASE_URL");
             let novita_api_key_prev = env::var_os("NOVITA_API_KEY");
@@ -3250,6 +3315,9 @@ mod tests {
                 env::remove_var("OPENAI_API_KEY");
                 env::remove_var("OPENAI_BASE_URL");
                 env::remove_var("OPENAI_MODEL");
+                env::remove_var("OPENAI_COMPATIBLE_API_KEY");
+                env::remove_var("OPENAI_COMPATIBLE_BASE_URL");
+                env::remove_var("OPENAI_COMPATIBLE_MODEL");
                 env::remove_var("OPENROUTER_API_KEY");
                 env::remove_var("OPENROUTER_BASE_URL");
                 env::remove_var("NOVITA_API_KEY");
@@ -3285,6 +3353,9 @@ mod tests {
                 openai_api_key: openai_api_key_prev,
                 openai_base_url: openai_base_url_prev,
                 openai_model: openai_model_prev,
+                openai_compatible_api_key: openai_compatible_api_key_prev,
+                openai_compatible_base_url: openai_compatible_base_url_prev,
+                openai_compatible_model: openai_compatible_model_prev,
                 openrouter_api_key: openrouter_api_key_prev,
                 openrouter_base_url: openrouter_base_url_prev,
                 novita_api_key: novita_api_key_prev,
@@ -3329,6 +3400,18 @@ mod tests {
                 Self::restore_var("OPENAI_API_KEY", self.openai_api_key.take());
                 Self::restore_var("OPENAI_BASE_URL", self.openai_base_url.take());
                 Self::restore_var("OPENAI_MODEL", self.openai_model.take());
+                Self::restore_var(
+                    "OPENAI_COMPATIBLE_API_KEY",
+                    self.openai_compatible_api_key.take(),
+                );
+                Self::restore_var(
+                    "OPENAI_COMPATIBLE_BASE_URL",
+                    self.openai_compatible_base_url.take(),
+                );
+                Self::restore_var(
+                    "OPENAI_COMPATIBLE_MODEL",
+                    self.openai_compatible_model.take(),
+                );
                 Self::restore_var("OPENROUTER_API_KEY", self.openrouter_api_key.take());
                 Self::restore_var("OPENROUTER_BASE_URL", self.openrouter_base_url.take());
                 Self::restore_var("NOVITA_API_KEY", self.novita_api_key.take());

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -212,7 +212,10 @@ pub enum RequestPayloadMode {
 /// in the API payload (after normalization / provider-specific mapping).
 #[must_use]
 pub fn provider_capability(provider: ApiProvider, resolved_model: &str) -> ProviderCapability {
-    if matches!(provider, ApiProvider::Openai | ApiProvider::OpenaiCompatible) {
+    if matches!(
+        provider,
+        ApiProvider::Openai | ApiProvider::OpenaiCompatible
+    ) {
         return ProviderCapability {
             provider,
             resolved_model: resolved_model.to_string(),
@@ -3024,9 +3027,7 @@ pub fn has_api_key_for(config: &Config, provider: ApiProvider) -> bool {
     // openai-compatible: key is optional, but a configured base URL means the
     // provider is usable (the picker shows "(configured)" instead of prompting).
     if provider == ApiProvider::OpenaiCompatible {
-        if std::env::var("OPENAI_COMPATIBLE_BASE_URL")
-            .is_ok_and(|v| !v.trim().is_empty())
-        {
+        if std::env::var("OPENAI_COMPATIBLE_BASE_URL").is_ok_and(|v| !v.trim().is_empty()) {
             return true;
         }
         if config

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -1426,12 +1426,12 @@ impl Config {
                 "OpenAI API key not found. Run 'deepseek auth set --provider openai', \
                  set OPENAI_API_KEY, or add [providers.openai] api_key in ~/.deepseek/config.toml."
             ),
-            ApiProvider::OpenaiCompatible => anyhow::bail!(
-                "OpenAI-compatible API key and base URL not found. \
-                 Run 'deepseek auth set --provider openai-compatible --url <BASE_URL>', \
-                 set OPENAI_COMPATIBLE_API_KEY and OPENAI_COMPATIBLE_BASE_URL, \
-                 or add [providers.openai_compatible] api_key and base_url in ~/.deepseek/config.toml."
-            ),
+            ApiProvider::OpenaiCompatible => {
+                // Key is optional for openai-compatible (local servers may not
+                // need auth). Return empty string so the client sends no
+                // Authorization header.
+                return Ok(String::new());
+            }
             ApiProvider::Openrouter => anyhow::bail!(
                 "OpenRouter API key not found. Run 'deepseek auth set --provider openrouter', \
                  set OPENROUTER_API_KEY, or add [providers.openrouter] api_key in ~/.deepseek/config.toml."
@@ -3019,6 +3019,23 @@ pub fn has_api_key_for(config: &Config, provider: ApiProvider) -> bool {
         ApiProvider::Sglang | ApiProvider::Vllm | ApiProvider::Ollama
     ) {
         return true;
+    }
+
+    // openai-compatible: key is optional, but a configured base URL means the
+    // provider is usable (the picker shows "(configured)" instead of prompting).
+    if provider == ApiProvider::OpenaiCompatible {
+        if std::env::var("OPENAI_COMPATIBLE_BASE_URL")
+            .is_ok_and(|v| !v.trim().is_empty())
+        {
+            return true;
+        }
+        if config
+            .provider_config_for(provider)
+            .and_then(|entry| entry.base_url.as_ref())
+            .is_some_and(|v| !v.trim().is_empty())
+        {
+            return true;
+        }
     }
 
     if config

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -4644,6 +4644,43 @@ model = "glm-5"
     }
 
     #[test]
+    fn openai_compatible_env_overrides_provider_base_url_and_model() -> Result<()> {
+        let _lock = lock_test_env();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let temp_root = env::temp_dir().join(format!(
+            "deepseek-tui-openai-compat-env-test-{}-{}",
+            std::process::id(),
+            nanos
+        ));
+        fs::create_dir_all(&temp_root)?;
+        let _guard = EnvGuard::new(&temp_root);
+
+        // Safety: test-only environment mutation guarded by a global mutex.
+        unsafe {
+            env::set_var("DEEPSEEK_PROVIDER", "openai-compatible");
+            env::set_var("OPENAI_COMPATIBLE_API_KEY", "openai-compat-key");
+            env::set_var(
+                "OPENAI_COMPATIBLE_BASE_URL",
+                "https://custom-llm.example.com/v1",
+            );
+            env::set_var("OPENAI_COMPATIBLE_MODEL", "llama-4");
+        }
+
+        let config = Config::load(None, None)?;
+        assert_eq!(config.api_provider(), ApiProvider::OpenaiCompatible);
+        assert_eq!(config.deepseek_api_key()?, "openai-compat-key");
+        assert_eq!(
+            config.deepseek_base_url(),
+            "https://custom-llm.example.com/v1"
+        );
+        assert_eq!(config.default_model(), "llama-4");
+        Ok(())
+    }
+
+    #[test]
     fn openrouter_provider_uses_canonical_defaults() -> Result<()> {
         let _lock = lock_test_env();
         let nanos = SystemTime::now()

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -371,6 +371,7 @@ impl Engine {
             ApiProvider::Deepseek | ApiProvider::DeepseekCN => "DEEPSEEK_API_KEY",
             ApiProvider::NvidiaNim => "NVIDIA_API_KEY/NVIDIA_NIM_API_KEY",
             ApiProvider::Openai => "OPENAI_API_KEY",
+            ApiProvider::OpenaiCompatible => "OPENAI_COMPATIBLE_API_KEY",
             ApiProvider::Openrouter => "OPENROUTER_API_KEY",
             ApiProvider::Novita => "NOVITA_API_KEY",
             ApiProvider::Fireworks => "FIREWORKS_API_KEY",

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -1361,6 +1361,10 @@ fn run_setup_status(config: &Config, workspace: &Path) -> Result<()> {
                     "OPENAI_API_KEY",
                     "deepseek auth set --provider openai --api-key \"...\"",
                 ),
+                crate::config::ApiProvider::OpenaiCompatible => (
+                    "OPENAI_COMPATIBLE_API_KEY",
+                    "deepseek auth set --provider openai-compatible --url <BASE_URL> --api-key \"...\"",
+                ),
                 crate::config::ApiProvider::Openrouter => (
                     "OPENROUTER_API_KEY",
                     "deepseek auth set --provider openrouter --api-key \"...\"",
@@ -1394,6 +1398,7 @@ fn run_setup_status(config: &Config, workspace: &Path) -> Result<()> {
                 match config.api_provider() {
                     crate::config::ApiProvider::NvidiaNim => "nvidia_nim",
                     crate::config::ApiProvider::Openai => "openai",
+                    crate::config::ApiProvider::OpenaiCompatible => "openai_compatible",
                     crate::config::ApiProvider::Openrouter => "openrouter",
                     crate::config::ApiProvider::Novita => "novita",
                     crate::config::ApiProvider::Fireworks => "fireworks",

--- a/crates/tui/src/tui/provider_picker.rs
+++ b/crates/tui/src/tui/provider_picker.rs
@@ -89,6 +89,7 @@ impl ProviderPickerView {
             ApiProvider::Deepseek | ApiProvider::DeepseekCN => "DEEPSEEK_API_KEY",
             ApiProvider::NvidiaNim => "NVIDIA_API_KEY",
             ApiProvider::Openai => "OPENAI_API_KEY",
+            ApiProvider::OpenaiCompatible => "OPENAI_COMPATIBLE_API_KEY",
             ApiProvider::Openrouter => "OPENROUTER_API_KEY",
             ApiProvider::Novita => "NOVITA_API_KEY",
             ApiProvider::Fireworks => "FIREWORKS_API_KEY",
@@ -392,7 +393,8 @@ mod tests {
             vec![
                 "DeepSeek",
                 "NVIDIA NIM",
-                "OpenAI-compatible",
+                "OpenAI Compatible",
+                "OpenAI",
                 "OpenRouter",
                 "Novita AI",
                 "Fireworks AI",

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -5351,6 +5351,7 @@ fn render(f: &mut Frame, app: &mut App) {
             crate::config::ApiProvider::DeepseekCN => None,
             crate::config::ApiProvider::NvidiaNim => Some("NIM"),
             crate::config::ApiProvider::Openai => Some("OpenAI"),
+            crate::config::ApiProvider::OpenaiCompatible => Some("Compat"),
             crate::config::ApiProvider::Openrouter => Some("OR"),
             crate::config::ApiProvider::Novita => Some("Novita"),
             crate::config::ApiProvider::Fireworks => Some("Fireworks"),
@@ -6002,6 +6003,7 @@ async fn apply_provider_picker_api_key(
             }
             ApiProvider::NvidiaNim => &mut providers.nvidia_nim,
             ApiProvider::Openai => &mut providers.openai,
+            ApiProvider::OpenaiCompatible => &mut providers.openai_compatible,
             ApiProvider::Openrouter => &mut providers.openrouter,
             ApiProvider::Novita => &mut providers.novita,
             ApiProvider::Fireworks => &mut providers.fireworks,


### PR DESCRIPTION
  ## Summary

  Add a new `openai-compatible` provider type that allows users to connect to any
  OpenAI-compatible API endpoint by providing a custom base URL and optional API key.
  This covers self-hosted LLM servers (e.g. vLLM, SGLang), third-party API proxies, and the official OpenAI API.

  - `deepseek auth set --provider openai-compatible --url <BASE_URL> [--api-key <KEY>]`
  - URL is **required** (interactive prompt if omitted); API key is **optional**
  - Env vars: `OPENAI_COMPATIBLE_API_KEY`, `OPENAI_COMPATIBLE_BASE_URL`, `OPENAI_COMPATIBLE_MODEL`
  - Config: `[providers.openai_compatible]` with `api_key`, `base_url`, `model`
  - TUI `/provider` picker shows "OpenAI Compatible" with "(configured)" when URL is set
  - No model name normalization — passes through whatever the user configures

  ## Changes
  10 files, +238 / -16 lines:

  | File | Change |
  |---|---|
  | `crates/config/src/lib.rs` | `OpenaiCompatible` in `ProviderKind`, `ProvidersToml`, env forwarding, skip model normalization |
  | `crates/cli/src/lib.rs` | `OpenaiCompatible` in `ProviderArg`, `--url` on `auth set`, optional-key prompt, env vars |
  | `crates/secrets/src/lib.rs` | `OPENAI_COMPATIBLE_API_KEY` env mapping |
  | `crates/tui/src/config.rs` | `OpenaiCompatible` in `ApiProvider`, picker, env forwarding, empty key allowed |
  | `crates/tui/src/client.rs` | `OpenaiCompatible` in reasoning-effort match arms (no-op, like Ollama) |
  | `crates/tui/src/commands/provider.rs` | Error message updated |
  | `crates/tui/src/tui/provider_picker.rs` | Env var label + picker ordering |
  | `crates/tui/src/tui/ui.rs` | Provider label "Compat" for status bar |
  | `crates/tui/src/core/engine.rs` | Env var reference for error recovery |
  | `crates/tui/src/main.rs` | Doctor/status match arms |

  ## Test plan

  - [x] `cargo fmt --check` — clean
  - [x] `cargo clippy --workspace --all-targets --all-features` — clean
  - [x] `cargo test --workspace` — all tests pass
  - [x] Manual: test against a real OpenAI-compatible endpoint