### PR TITLE
fix(client): stabilize reasoning_content replay for prompt cache

### DIFF
--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -1290,7 +1290,12 @@ mod tests {
     }
 
     #[test]
-    fn chat_messages_omit_prior_non_tool_reasoning_after_new_user_turn() {
+    fn chat_messages_keep_prior_non_tool_reasoning_after_new_user_turn() {
+        // The serialized JSON for a stored assistant message MUST be a pure
+        // function of that message — never of what comes after it. DeepSeek's
+        // prompt cache hashes the leading bytes of every request; flipping
+        // `reasoning_content` on/off across turns rewrites historical bytes
+        // and busts the prefix cache from that message onwards. (#583)
         let messages = vec![
             Message {
                 role: "user".to_string(),
@@ -1330,9 +1335,68 @@ mod tests {
             assistant.get("content").and_then(Value::as_str),
             Some("Final answer")
         );
-        assert!(
-            assistant.get("reasoning_content").is_none(),
-            "non-tool reasoning from previous turns should not be replayed"
+        assert_eq!(
+            assistant.get("reasoning_content").and_then(Value::as_str),
+            Some("Internal explanation plan"),
+            "reasoning_content must be preserved across follow-up user turns to keep DeepSeek's prefix cache warm"
+        );
+    }
+
+    #[test]
+    fn chat_messages_assistant_json_is_byte_stable_across_follow_up_user_turn() {
+        // Direct prefix-cache regression: the JSON for the assistant message
+        // built on turn N must equal the JSON for the same assistant message
+        // built on turn N+1, after a new user message has been appended.
+        let assistant = Message {
+            role: "assistant".to_string(),
+            content: vec![
+                ContentBlock::Thinking {
+                    thinking: "I should explain step by step.".to_string(),
+                },
+                ContentBlock::Text {
+                    text: "Here is the explanation.".to_string(),
+                    cache_control: None,
+                },
+            ],
+        };
+        let user_initial = Message {
+            role: "user".to_string(),
+            content: vec![ContentBlock::Text {
+                text: "Explain it".to_string(),
+                cache_control: None,
+            }],
+        };
+        let user_follow_up = Message {
+            role: "user".to_string(),
+            content: vec![ContentBlock::Text {
+                text: "Next question".to_string(),
+                cache_control: None,
+            }],
+        };
+
+        let turn_n = build_chat_messages(
+            None,
+            &[user_initial.clone(), assistant.clone()],
+            "deepseek-v4-pro",
+        );
+        let turn_n_plus_1 = build_chat_messages(
+            None,
+            &[user_initial, assistant, user_follow_up],
+            "deepseek-v4-pro",
+        );
+
+        let assistant_n = turn_n
+            .iter()
+            .find(|v| v.get("role").and_then(Value::as_str) == Some("assistant"))
+            .expect("assistant present in turn N");
+        let assistant_n1 = turn_n_plus_1
+            .iter()
+            .find(|v| v.get("role").and_then(Value::as_str) == Some("assistant"))
+            .expect("assistant present in turn N+1");
+
+        assert_eq!(
+            assistant_n, assistant_n1,
+            "assistant message JSON must be byte-identical across turns or DeepSeek's prefix cache breaks"
         );
     }
 

--- a/crates/tui/src/client/chat.rs
+++ b/crates/tui/src/client/chat.rs
@@ -1008,9 +1008,6 @@ fn build_chat_messages_with_reasoning(
         let mut tool_call_infos = Vec::new();
         let mut tool_results: Vec<(String, String, String)> = Vec::new();
         let mut turn_meta_budget: Option<TurnMetaBudget> = None;
-        let later_user_turn = messages[message_index + 1..]
-            .iter()
-            .any(message_starts_user_turn);
 
         for block in &message.content {
             match block {
@@ -1075,14 +1072,19 @@ fn build_chat_messages_with_reasoning(
             let mut reasoning_content = thinking_parts.join("\n");
             let has_text = !content.trim().is_empty();
             let has_tool_calls = !tool_calls.is_empty();
-            // DeepSeek thinking-mode tool calls must replay `reasoning_content`
-            // on subsequent requests. Non-tool assistant reasoning can be
-            // omitted once a later real user text message starts a new turn.
-            let include_reasoning_for_turn =
-                include_reasoning && (has_tool_calls || !later_user_turn);
+            // Reasoning replay must be a function of the stored message ONLY,
+            // never of later history. DeepSeek's prefix cache hashes the raw
+            // bytes of every message; flipping `reasoning_content` on/off
+            // depending on whether a follow-up user turn exists rewrites a
+            // historical message between turns and busts the cache from that
+            // point onwards. Always emit `reasoning_content` when the model
+            // requires replay AND the stored message carries thinking text.
+            // Tool-call messages with empty thinking still need a placeholder
+            // (DeepSeek 400s without it), but text-only assistant messages
+            // simply omit the field when there's nothing to replay.
             let mut has_reasoning =
-                include_reasoning_for_turn && !reasoning_content.trim().is_empty();
-            if include_reasoning_for_turn && has_tool_calls && !has_reasoning {
+                include_reasoning && !reasoning_content.trim().is_empty();
+            if include_reasoning && has_tool_calls && !has_reasoning {
                 logging::warn(
                     "Substituting placeholder reasoning_content for DeepSeek tool-call assistant message",
                 );
@@ -1293,14 +1295,6 @@ fn build_chat_messages_with_reasoning(
     }
 
     out
-}
-
-fn message_starts_user_turn(message: &Message) -> bool {
-    message.role == "user"
-        && message.content.iter().any(|block| match block {
-            ContentBlock::Text { text, .. } => !text.trim().is_empty(),
-            _ => false,
-        })
 }
 
 pub(super) fn tool_to_chat(tool: &Tool) -> Value {

--- a/crates/tui/src/client/chat.rs
+++ b/crates/tui/src/client/chat.rs
@@ -1082,8 +1082,7 @@ fn build_chat_messages_with_reasoning(
             // Tool-call messages with empty thinking still need a placeholder
             // (DeepSeek 400s without it), but text-only assistant messages
             // simply omit the field when there's nothing to replay.
-            let mut has_reasoning =
-                include_reasoning && !reasoning_content.trim().is_empty();
+            let mut has_reasoning = include_reasoning && !reasoning_content.trim().is_empty();
             if include_reasoning && has_tool_calls && !has_reasoning {
                 logging::warn(
                     "Substituting placeholder reasoning_content for DeepSeek tool-call assistant message",


### PR DESCRIPTION
## Summary
DeepSeek-V4's prompt cache (paper §3.5.2 On-Disk KV Cache Storage) matches on request byte prefix hashes — cache-hit
  input tokens are billed at roughly 1/100 the price of misses. Earning that discount requires that the bytes of
  already-sent historical messages stay identical across turns of a multi-turn conversation.

  Users reported a consistently low cache hit rate.

  The bug

  In crates/tui/src/client/chat.rs, build_chat_messages_with_reasoning was re-deciding per request whether each
  historical assistant message should carry reasoning_content, gated on later_user_turn — "is there a real user message
  later in the history?"
```rust
  // Old logic
  let later_user_turn = messages[message_index + 1..]
      .iter()
      .any(message_starts_user_turn);
  let include_reasoning_for_turn =
      include_reasoning && (has_tool_calls || !later_user_turn);
```
  Result: the same text-only assistant reply serialized to different bytes on different turns. On the turn it was just
  produced (no later user message yet), it went out as:
```
  {"role":"assistant","content":"answer","reasoning_content":"..."}
```
  On the very next turn, after the user asked a follow-up, that same historical message went out as:
```
  {"role":"assistant","content":"answer"}
```
  The reasoning_content field was silently dropped. Once the historical bytes shifted, the entire prefix from that
  message onward mismatched. Every "user asks → assistant replies in text → user asks again" cycle — the most common
  pattern in multi-turn chat — triggered a cache wipe.

  The codebase already had messages_with_turn_metadata_preserves_stored_messages_for_prefix_cache asserting that
  historical message bytes must be byte-stable across turns, proving the invariant was the intended design. This code
  path just violated it.

  The fix

  In crates/tui/src/client/chat.rs, reasoning_content now depends only on the stored message itself:

```rust
  let mut has_reasoning = include_reasoning && !reasoning_content.trim().is_empty();
  if include_reasoning && has_tool_calls && !has_reasoning {
      // Tool-call messages with empty thinking still need a placeholder
      // (DeepSeek 400s without it).
      reasoning_content = String::from("(reasoning omitted)");
      has_reasoning = true;
  }
```
  When the model requires replay and the message has thinking content, always emit reasoning_content. When the model
  requires replay and the message has tool_calls but empty thinking, emit the (reasoning omitted) placeholder — this
  part is unchanged because DeepSeek thinking-mode tool-call turns return 400 without it. Otherwise the field is
  omitted. The later_user_turn scan and the now-unused message_starts_user_turn helper are removed.

  In crates/tui/src/client.rs, the old test chat_messages_omit_prior_non_tool_reasoning_after_new_user_turn (which
  encoded the bug) was renamed to chat_messages_keep_prior_non_tool_reasoning_after_new_user_turn and updated to assert
  the correct contract. A new dedicated regression test was added:
```rust
  #[test]
  fn chat_messages_assistant_json_is_byte_stable_across_follow_up_user_turn() {
      // ...build the same assistant message as part of turn N and turn N+1...
      assert_eq!(
          assistant_n, assistant_n1,
          "assistant message JSON must be byte-identical across turns \
           or DeepSeek's prefix cache breaks"
      );
  }
```
  Any future attempt to reintroduce "mutate history based on context" will trip this test immediately.

  Scope of impact

  This only affects the request-body builder for DeepSeek chat completions — no UI changes, no config changes. Tool-call
   reasoning replay behavior is unchanged; that path was already cache-safe and DeepSeek-required. Expected outcome: in
  multi-turn conversations, prompt_cache_hit_tokens should rise significantly, and the footer's cache-hit-rate chip
  should stay green (≥ 80%) far more often.
## Testing

- [x] `cargo test --all-features`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features`

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [x] Verified TUI behavior manually if UI changes
