### PR TITLE
fix(web): increase anchor scroll-margin to clear sticky header

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -340,4 +340,4 @@ a.body-link:hover { background-size: 100% 6px; color: var(--ink); }
 }
 
 /* Anchor scroll-margin so deep links land below the sticky nav. */
-[id] { scroll-margin-top: 5rem; }
+[id] { scroll-margin-top: 6rem; }


### PR DESCRIPTION
## Problem

Docs 页面侧边栏点击目录锚点链接（如 #modes、#tools）跳转后，目标 section 的顶部内容被 sticky nav header 遮挡。

## Root Cause

 中的全局规则 `[id] { scroll-margin-top: 5rem; }` 覆盖了 docs 页面 `<section>` 上的 Tailwind class `scroll-mt-32`（8rem），因为两者优先级相同（0,1,0），但 globals.css 在 Tailwind utilities 之后加载。

Nav header 实际高度约 5.4rem（date strip ~1.4rem + main bar ~4rem），5rem 不足以完全清除遮挡。

## Fix

Bump `scroll-margin-top` from 5rem to 6rem in globals.css — enough to clear the header with comfortable padding.

Fixes #1278