### PR TITLE
fix(ui): render error cells without markdown to preserve env-var underscores

### DIFF
--- a/crates/tui/src/tui/history.rs
+++ b/crates/tui/src/tui/history.rs
@@ -207,13 +207,30 @@ impl HistoryCell {
                     )
                 }
             }
-            HistoryCell::Error { message, severity } => render_message(
-                error_label_text(*severity),
-                error_label_style(*severity),
-                error_body_style(*severity),
-                message,
-                width,
-            ),
+            HistoryCell::Error { message, severity } => {
+                // Error messages are machine-generated and should not be run
+                // through markdown rendering, which would mangle env-var names
+                // containing underscores (e.g. DEEPSEEK_ALLOW_INSECURE_HTTP
+                // would lose its underscores as italic markers).
+                let label = error_label_text(*severity);
+                let label_style = error_label_style(*severity);
+                let body_style = error_body_style(*severity);
+                let prefix_width = UnicodeWidthStr::width(label);
+                let content_width = width.saturating_sub(2 + prefix_width as u16).max(1);
+                let mut lines = wrap_plain_line(message, body_style, content_width);
+                // Add the label prefix to the first line
+                if let Some(first) = lines.get_mut(0) {
+                    first.spans.insert(0, Span::raw(" "));
+                    first.spans.insert(0, Span::styled(label, label_style));
+                }
+                // Continuation rail for subsequent lines
+                let rail = format!("{}{}", '\u{258F}', " ".repeat(prefix_width));
+                let rail_style = Style::default().fg(palette::TEXT_DIM);
+                for line in lines.iter_mut().skip(1) {
+                    line.spans.insert(0, Span::styled(rail.clone(), rail_style));
+                }
+                lines
+            }
             HistoryCell::Thinking {
                 content,
                 streaming,


### PR DESCRIPTION
## Summary

Error messages containing environment variable names like `DEEPSEEK_ALLOW_INSECURE_HTTP` were mangled by markdown rendering: the inline `_italic_` parser consumed underscored segments (`_ALLOW_` → italic "ALLOW" without underscores), resulting in the illegible `DEEPSEEKALLOWINSECURE_HTTP` displayed to the user.

## Root Cause

`HistoryCell::Error` was rendered through `render_message` → `markdown_render::render_markdown_tagged` → `parse_inline_spans`, which treats `_text_` as italic and strips the underscores.

## Fix

Switch `HistoryCell::Error` from `render_message` to `wrap_plain_line`, which renders the message body verbatim. The existing severity label, bold prefix, and continuation-rail layout are preserved via manual Span assembly matching the original output structure.

## Verification

- `cargo check` — clean (existing warnings only)
- `cargo test -p deepseek-tui -- history` — 87 passed (1 unrelated pre-existing failure in `model_reset_same_model_keeps_turn_cache_history`)
- Error cell rendering tests: `error_severity_cell_renders_in_red` ✓, `warning_severity_cell_renders_in_amber` ✓, `critical_severity_cell_renders_in_red` ✓, `info_severity_cell_renders_in_dim` ✓

## Before / After

| Before | After |
|--------|-------|
| `DEEPSEEKALLOWINSECURE_HTTP` | `DEEPSEEK_ALLOW_INSECURE_HTTP` |

Closes #1303

<img width="2743" height="242" alt="image" src="https://github.com/user-attachments/assets/c8deac6e-9fb1-4b4c-8db4-3054a8986285" />
