### PR TITLE
fix: /clear now resets the Todos sidebar panel

### DIFF
--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -3695,18 +3695,28 @@ impl App {
     }
 
     pub fn clear_todos(&mut self) -> bool {
-        // Clear the todo list (the sidebar checklist). Uses try_lock so the
-        // UI thread doesn't block if the engine briefly holds the mutex
-        // during tool execution; the caller can retry or show a busy message.
-        let todos_cleared = if let Ok(mut todos) = self.todos.try_lock() {
-            todos.clear();
-            true
-        } else {
-            false
+        // Clear the todo list (the sidebar checklist). Retry with try_lock
+        // so /clear always resets todos even when the engine briefly holds
+        // the mutex during tool execution.
+        let todos_cleared = {
+            let mut cleared = false;
+            for _ in 0..100 {
+                if let Ok(mut todos) = self.todos.try_lock() {
+                    todos.clear();
+                    cleared = true;
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(1));
+            }
+            cleared
         };
         // Also clear the plan state — /clear means a full reset.
-        if let Ok(mut plan) = self.plan_state.try_lock() {
-            *plan = crate::tools::plan::PlanState::default();
+        for _ in 0..100 {
+            if let Ok(mut plan) = self.plan_state.try_lock() {
+                *plan = crate::tools::plan::PlanState::default();
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(1));
         }
         todos_cleared
     }
@@ -3911,6 +3921,7 @@ mod tests {
     use super::*;
     use crate::config::Config;
     use crate::tools::plan::{PlanItemArg, StepStatus, UpdatePlanArgs};
+    use crate::tools::todo::TodoStatus;
     use crate::tui::clipboard::PastedImage;
 
     fn test_options(yolo: bool) -> TuiOptions {
@@ -4059,6 +4070,24 @@ mod tests {
         let app = App::new(test_options(false), &Config::default());
         assert!(app.history.is_empty());
         assert_eq!(app.history_version, 0);
+    }
+
+    #[test]
+    fn clear_todos_resets_todos_list() {
+        let mut app = App::new(test_options(false), &Config::default());
+
+        // Seed some todos.
+        {
+            let mut todos = app.todos.try_lock().expect("todos lock");
+            todos.add("buy milk".to_string(), TodoStatus::Pending);
+            todos.add("write code".to_string(), TodoStatus::InProgress);
+            assert_eq!(todos.snapshot().items.len(), 2);
+        }
+
+        assert!(app.clear_todos());
+
+        let todos = app.todos.try_lock().expect("todos lock");
+        assert!(todos.snapshot().items.is_empty());
     }
 
     #[test]

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -3694,29 +3694,32 @@ impl App {
         self.history_navigation_draft = None;
     }
 
+    /// Retry a `try_lock` up to `retries` times with a 1ms pause between
+    /// attempts. Returns `Some(guard)` on success, `None` if the lock
+    /// remains contended after all retries.
+    fn retry_lock<T>(mutex: &tokio::sync::Mutex<T>, retries: u32) -> Option<tokio::sync::MutexGuard<'_, T>> {
+        for _ in 0..retries {
+            if let Ok(guard) = mutex.try_lock() {
+                return Some(guard);
+            }
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+        None
+    }
+
     pub fn clear_todos(&mut self) -> bool {
         // Clear the todo list (the sidebar checklist). Retry with try_lock
         // so /clear always resets todos even when the engine briefly holds
         // the mutex during tool execution.
-        let todos_cleared = {
-            let mut cleared = false;
-            for _ in 0..100 {
-                if let Ok(mut todos) = self.todos.try_lock() {
-                    todos.clear();
-                    cleared = true;
-                    break;
-                }
-                std::thread::sleep(std::time::Duration::from_millis(1));
-            }
-            cleared
+        let todos_cleared = if let Some(mut todos) = Self::retry_lock(&self.todos, 100) {
+            todos.clear();
+            true
+        } else {
+            false
         };
         // Also clear the plan state — /clear means a full reset.
-        for _ in 0..100 {
-            if let Ok(mut plan) = self.plan_state.try_lock() {
-                *plan = crate::tools::plan::PlanState::default();
-                break;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(1));
+        if let Some(mut plan) = Self::retry_lock(&self.plan_state, 100) {
+            *plan = crate::tools::plan::PlanState::default();
         }
         todos_cleared
     }


### PR DESCRIPTION
## Problem

Running `/clear` does not reliably clear the Todos sidebar. When the engine holds the todos mutex during tool execution, `clear_todos()` fails because it uses a single `try_lock()` attempt. The todos persist across `/clear` commands until the app is restarted.

## Root Cause

`clear_todos()` in `crates/tui/src/tui/app.rs` uses `try_lock()` which is non-blocking. If the mutex is held by the engine, the method returns `false` and shows a busy message instead of clearing the todos.

## Fix

Replace the single `try_lock()` attempt with a retry loop (up to 100 attempts, 1ms apart). This gives the engine up to 100ms to release the mutex while keeping the UI responsive.

## Testing

Added a regression test `clear_todos_resets_todos_list` that:
1. Seeds todos into the list
2. Calls `clear_todos()`
3. Asserts the todos list is empty

Fixes #1258