### PR TITLE
fix(tui): send TurnStarted before snapshot to prevent WSL2 timeout

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -895,6 +895,16 @@ impl Engine {
         self.turn_counter = self.turn_counter.saturating_add(1);
         self.capacity_controller.mark_turn_start(self.turn_counter);
 
+        // Emit turn started event IMMEDIATELY so the UI knows the turn is
+        // active. The snapshot below can take 30+ seconds on slow filesystems
+        // (e.g. WSL2 /mnt/c) and must not delay the TurnStarted event.
+        let _ = self
+            .tx_event
+            .send(Event::TurnStarted {
+                turn_id: turn.id.clone(),
+            })
+            .await;
+
         // Snapshot the workspace BEFORE we touch a single tool. Run the git
         // work on the blocking pool so the async runtime stays responsive;
         // failure is non-fatal (the helper logs at WARN).
@@ -904,14 +914,6 @@ impl Engine {
             let _ = tokio::task::spawn_blocking(move || pre_turn_snapshot(&pre_workspace, pre_seq))
                 .await;
         }
-
-        // Emit turn started event
-        let _ = self
-            .tx_event
-            .send(Event::TurnStarted {
-                turn_id: turn.id.clone(),
-            })
-            .await;
 
         // A new turn means any leftover retry banner (success cleared
         // it, failure pinned it) is no longer relevant — reset to idle


### PR DESCRIPTION
## Problem

On WSL2 with Windows drives mounted at \/mnt\/c, the \/ routine (which runs \/ on the workspace) can take 30+ seconds due to the slow 9P filesystem bridge.

The original code sent \/ *after* the snapshot completed. This caused the UI's 30-second dispatch watchdog to fire with:

> Turn dispatch timed out; the engine may have stopped. Please try again.

...before the turn ever appeared to start, leaving users with a hung\/blank TUI on WSL2 + Windows Terminal.

## Changes

1. **Send \/ immediately** — before the snapshot runs — so the UI shows progress while the snapshot operates in the background.
2. **Increase \/ from 30s → 120s** — more tolerant of slow filesystems.

## Environment

- WSL2 + Windows Terminal
- Workspace on \/mnt\/c\/Users\/... (Windows-mounted drive)

Fixes #— (blank screen\/hang issues on WSL2)