### PR TITLE
fix: stabilize MCP tool ordering prefix-cache stability fix

### DIFF
--- a/crates/tui/src/mcp.rs
+++ b/crates/tui/src/mcp.rs
@@ -2251,7 +2251,8 @@ mod tests {
         }
     }
 
-    fn test_connection(name: &str, tools: Vec<McpTool>) -> McpConnection {
+    fn test_connection(name: &str, mut tools: Vec<McpTool>) -> McpConnection {
+        tools.sort_by(|a, b| a.name.cmp(&b.name));
         McpConnection {
             name: name.to_string(),
             transport: Box::new(MockTransport {

--- a/crates/tui/src/mcp.rs
+++ b/crates/tui/src/mcp.rs
@@ -1735,7 +1735,6 @@ impl McpPool {
             });
         }
 
-        api_tools.sort_by(|a, b| a.name.cmp(&b.name));
         api_tools
     }
 
@@ -2500,7 +2499,7 @@ mod tests {
     }
 
     #[test]
-    fn mcp_pool_tool_exports_are_sorted_by_final_api_name() {
+    fn mcp_pool_tool_exports_sort_only_regular_mcp_block() {
         let mut config = McpConfig::default();
         config
             .servers
@@ -2510,10 +2509,19 @@ mod tests {
             .insert("aserver".to_string(), test_server_config());
 
         let mut pool = McpPool::new(config);
-        pool.connections.insert(
-            "zserver".to_string(),
-            test_connection("zserver", vec![test_tool("zeta"), test_tool("alpha")]),
-        );
+        let mut zserver = test_connection("zserver", vec![test_tool("zeta"), test_tool("alpha")]);
+        zserver.resources.push(McpResource {
+            uri: "file:///tmp/example".to_string(),
+            name: "Example".to_string(),
+            description: None,
+            mime_type: None,
+        });
+        zserver.prompts.push(McpPrompt {
+            name: "summarize".to_string(),
+            description: None,
+            arguments: Vec::new(),
+        });
+        pool.connections.insert("zserver".to_string(), zserver);
         pool.connections.insert(
             "aserver".to_string(),
             test_connection("aserver", vec![test_tool("middle")]),
@@ -2535,9 +2543,19 @@ mod tests {
             .into_iter()
             .map(|tool| tool.name)
             .collect();
-        let mut sorted_api_tool_names = api_tool_names.clone();
-        sorted_api_tool_names.sort();
-        assert_eq!(api_tool_names, sorted_api_tool_names);
+        assert_eq!(
+            api_tool_names,
+            vec![
+                "mcp_aserver_middle".to_string(),
+                "mcp_zserver_alpha".to_string(),
+                "mcp_zserver_zeta".to_string(),
+                "list_mcp_resources".to_string(),
+                "list_mcp_resource_templates".to_string(),
+                "mcp_read_resource".to_string(),
+                "read_mcp_resource".to_string(),
+                "mcp_get_prompt".to_string(),
+            ]
+        );
     }
 
     /// #1244: when an MCP stdio server fails to spawn, the underlying OS

--- a/crates/tui/src/mcp.rs
+++ b/crates/tui/src/mcp.rs
@@ -1029,6 +1029,7 @@ impl McpConnection {
                 break;
             }
         }
+        self.tools.sort_by(|a, b| a.name.cmp(&b.name));
         Ok(())
     }
 
@@ -1458,6 +1459,7 @@ impl McpPool {
                 tools.push((format!("mcp_{}_{}", server, tool.name), tool));
             }
         }
+        tools.sort_by(|a, b| a.0.cmp(&b.0));
         tools
     }
 
@@ -1733,6 +1735,7 @@ impl McpPool {
             });
         }
 
+        api_tools.sort_by(|a, b| a.name.cmp(&b.name));
         api_tools
     }
 
@@ -2215,6 +2218,65 @@ pub fn format_tool_result(result: &serde_json::Value) -> String {
 mod tests {
     use super::*;
 
+    struct MockTransport {
+        responses: VecDeque<serde_json::Value>,
+    }
+
+    #[async_trait::async_trait]
+    impl McpTransport for MockTransport {
+        async fn send(&mut self, _msg: serde_json::Value) -> Result<()> {
+            Ok(())
+        }
+
+        async fn recv(&mut self) -> Result<serde_json::Value> {
+            self.responses
+                .pop_front()
+                .context("mock MCP response queue is empty")
+        }
+    }
+
+    fn test_server_config() -> McpServerConfig {
+        McpServerConfig {
+            command: Some("test".to_string()),
+            args: Vec::new(),
+            env: HashMap::new(),
+            url: None,
+            connect_timeout: None,
+            execute_timeout: None,
+            read_timeout: None,
+            disabled: false,
+            enabled: true,
+            required: false,
+            enabled_tools: Vec::new(),
+            disabled_tools: Vec::new(),
+        }
+    }
+
+    fn test_connection(name: &str, tools: Vec<McpTool>) -> McpConnection {
+        McpConnection {
+            name: name.to_string(),
+            transport: Box::new(MockTransport {
+                responses: VecDeque::new(),
+            }),
+            tools,
+            resources: Vec::new(),
+            resource_templates: Vec::new(),
+            prompts: Vec::new(),
+            request_id: AtomicU64::new(1),
+            state: ConnectionState::Ready,
+            config: test_server_config(),
+            cancel_token: tokio_util::sync::CancellationToken::new(),
+        }
+    }
+
+    fn test_tool(name: &str) -> McpTool {
+        McpTool {
+            name: name.to_string(),
+            description: None,
+            input_schema: serde_json::json!({}),
+        }
+    }
+
     #[test]
     fn test_mcp_config_defaults() {
         let config = McpConfig::default();
@@ -2398,6 +2460,84 @@ mod tests {
         let pool = McpPool::new(McpConfig::default());
         assert!(pool.server_names().is_empty());
         assert!(pool.all_tools().is_empty());
+    }
+
+    #[tokio::test]
+    async fn discover_tools_sorts_paginated_results_by_name() {
+        let mut conn = McpConnection {
+            name: "test".to_string(),
+            transport: Box::new(MockTransport {
+                responses: VecDeque::from([
+                    serde_json::json!({
+                        "id": 1,
+                        "result": {
+                            "tools": [{ "name": "zeta" }, { "name": "alpha" }],
+                            "nextCursor": "page-2"
+                        }
+                    }),
+                    serde_json::json!({
+                        "id": 2,
+                        "result": {
+                            "tools": [{ "name": "middle" }]
+                        }
+                    }),
+                ]),
+            }),
+            tools: Vec::new(),
+            resources: Vec::new(),
+            resource_templates: Vec::new(),
+            prompts: Vec::new(),
+            request_id: AtomicU64::new(1),
+            state: ConnectionState::Ready,
+            config: test_server_config(),
+            cancel_token: tokio_util::sync::CancellationToken::new(),
+        };
+
+        conn.discover_tools().await.unwrap();
+
+        let names: Vec<&str> = conn.tools().iter().map(|tool| tool.name.as_str()).collect();
+        assert_eq!(names, vec!["alpha", "middle", "zeta"]);
+    }
+
+    #[test]
+    fn mcp_pool_tool_exports_are_sorted_by_final_api_name() {
+        let mut config = McpConfig::default();
+        config
+            .servers
+            .insert("zserver".to_string(), test_server_config());
+        config
+            .servers
+            .insert("aserver".to_string(), test_server_config());
+
+        let mut pool = McpPool::new(config);
+        pool.connections.insert(
+            "zserver".to_string(),
+            test_connection("zserver", vec![test_tool("zeta"), test_tool("alpha")]),
+        );
+        pool.connections.insert(
+            "aserver".to_string(),
+            test_connection("aserver", vec![test_tool("middle")]),
+        );
+
+        let all_tool_names: Vec<String> =
+            pool.all_tools().into_iter().map(|(name, _)| name).collect();
+        assert_eq!(
+            all_tool_names,
+            vec![
+                "mcp_aserver_middle".to_string(),
+                "mcp_zserver_alpha".to_string(),
+                "mcp_zserver_zeta".to_string(),
+            ]
+        );
+
+        let api_tool_names: Vec<String> = pool
+            .to_api_tools()
+            .into_iter()
+            .map(|tool| tool.name)
+            .collect();
+        let mut sorted_api_tool_names = api_tool_names.clone();
+        sorted_api_tool_names.sort();
+        assert_eq!(api_tool_names, sorted_api_tool_names);
     }
 
     /// #1244: when an MCP stdio server fails to spawn, the underlying OS


### PR DESCRIPTION
## Summary

This is an incremental prefix-cache stability fix for MCP tool ordering. It removes non-deterministic ordering from MCP tool discovery and aggregation without changing the existing `to_api_tools()` block layout.

## Background

DeepSeek's prefix KV cache depends on byte-identical request prefixes. Reordering tool entries changes subsequent byte offsets and can invalidate the cached prefix from the first changed tool onward.

The main model request path is already protected by `build_model_tool_catalog()`, which sorts native and MCP tool partitions before sending tools to the model. This PR adds lower-level defensive ordering so MCP consumers get deterministic tool lists before they reach that catalog layer.

## Changes

### 1. Sort tools after MCP discovery

`McpConnection::discover_tools()` now sorts the merged paginated `tools/list` result by tool name after discovery completes.

This makes `conn.tools()` deterministic even if an MCP server returns tools in a different order after reconnect or pagination.

### 2. Sort aggregated MCP tools by fully-qualified name

`McpPool::all_tools()` now sorts by the final exported MCP tool name:

```rust
mcp_{server}_{tool}
```

This controls the previous `HashMap<String, McpConnection>` iteration-order dependency when aggregating tools across servers.

### 3. Preserve `to_api_tools()` block ordering

`McpPool::to_api_tools()` intentionally does **not** apply a flat global sort. It keeps the historical block structure:

```text
[MCP regular tools — sorted by all_tools()]
  → [list_mcp_resources + list_mcp_resource_templates]
  → [mcp_read_resource + read_mcp_resource]
  → [mcp_get_prompt]
```

This keeps the ordering change scoped to the regular MCP tool block instead of interleaving helper tools such as `list_mcp_resources` with `mcp_*` tools.

## Tests

- `discover_tools_sorts_paginated_results_by_name` verifies observable discovery behavior: paginated server responses are merged and exposed in deterministic name order.
- `mcp_pool_tool_exports_sort_only_regular_mcp_block` verifies exported behavior: regular MCP tools are sorted by fully-qualified name while `to_api_tools()` preserves helper-tool block order.

The test helper for constructing `McpConnection` sorts its tools to mirror production discovery behavior, so tests that do not specifically exercise discovery start from a representative connection state.

## Scope boundary

This PR addresses deterministic ordering only. It does not attempt to solve:

- Conditional helper-tool presence:
  - `list_mcp_resources` / `list_mcp_resource_templates` are present when MCP servers are configured.
  - `mcp_read_resource` / `read_mcp_resource` are present when resources exist.
  - `mcp_get_prompt` is present when prompts exist.
- MCP tool metadata drift after reconnect, such as changed descriptions or schemas.
- UI-level cache hit reporting.

Those are separate follow-ups from this ordering fix.

## Verification

- [x] `cargo fmt -p deepseek-tui --manifest-path /data/code/DeepSeek-TUI/lane1/Cargo.toml`
- [x] `cargo test -q -p deepseek-tui --manifest-path /data/code/DeepSeek-TUI/lane1/Cargo.toml discover_tools_sorts_paginated_results_by_name`
- [x] `cargo test -q -p deepseek-tui --manifest-path /data/code/DeepSeek-TUI/lane1/Cargo.toml mcp_pool_tool_exports_sort_only_regular_mcp_block`
- [x] `cargo test -q -p deepseek-tui --manifest-path /data/code/DeepSeek-TUI/lane1/Cargo.toml model_tool_catalog_sorts_each_partition_for_prefix_cache_stability`
