### PR TITLE
feat: support OpenAI-compatible Coding Plan endpoints (Bailian, ZhiPu, etc.)

### DIFF
--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -508,7 +508,7 @@ impl DeepSeekClient {
         let headers = build_default_headers(api_key, extra_headers)?;
         let mut builder = reqwest::Client::builder()
             .default_headers(headers)
-            .user_agent("deepseek-tui/0.8")
+            .user_agent(concat!("deepseek-tui/", env!("CARGO_PKG_VERSION")))
             .connect_timeout(Duration::from_secs(30))
             .tcp_keepalive(Some(Duration::from_secs(30)))
             .http2_keep_alive_interval(Some(Duration::from_secs(15)))

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -508,6 +508,7 @@ impl DeepSeekClient {
         let headers = build_default_headers(api_key, extra_headers)?;
         let mut builder = reqwest::Client::builder()
             .default_headers(headers)
+            .user_agent("deepseek-tui/0.8")
             .connect_timeout(Duration::from_secs(30))
             .tcp_keepalive(Some(Duration::from_secs(30)))
             .http2_keep_alive_interval(Some(Duration::from_secs(15)))

--- a/crates/tui/src/commands/core.rs
+++ b/crates/tui/src/commands/core.rs
@@ -119,11 +119,16 @@ pub fn model(app: &mut App, model_name: Option<&str>) -> CommandResult {
                 AppAction::UpdateCompaction(app.compaction_config()),
             );
         }
-        let Some(model_id) = normalize_model_name(name) else {
-            return CommandResult::error(format!(
-                "Invalid model '{name}'. Expected auto or a DeepSeek model ID. Common models: {}",
-                COMMON_DEEPSEEK_MODELS.join(", ")
-            ));
+        let model_id = if crate::config::provider_passes_model_through(app.api_provider) {
+            name.to_string()
+        } else {
+            let Some(normalized) = normalize_model_name(name) else {
+                return CommandResult::error(format!(
+                    "Invalid model '{name}'. Expected auto or a DeepSeek model ID. Common models: {}",
+                    COMMON_DEEPSEEK_MODELS.join(", ")
+                ));
+            };
+            normalized
         };
         let old_model = app.model_display_label();
         let model_changed = app.auto_model || app.model != model_id;

--- a/crates/tui/src/commands/provider.rs
+++ b/crates/tui/src/commands/provider.rs
@@ -27,7 +27,7 @@ pub fn provider(app: &mut App, args: Option<&str>) -> CommandResult {
 
     let Some(target) = ApiProvider::parse(name) else {
         return CommandResult::error(format!(
-            "Unknown provider '{name}'. Expected: deepseek, openai, nvidia-nim, openrouter, novita, fireworks, sglang, vllm, ollama, or anthropic."
+            "Unknown provider '{name}'. Expected: deepseek, openai, nvidia-nim, openrouter, novita, fireworks, sglang, vllm, or ollama."
         ));
     };
 

--- a/crates/tui/src/commands/provider.rs
+++ b/crates/tui/src/commands/provider.rs
@@ -27,7 +27,7 @@ pub fn provider(app: &mut App, args: Option<&str>) -> CommandResult {
 
     let Some(target) = ApiProvider::parse(name) else {
         return CommandResult::error(format!(
-            "Unknown provider '{name}'. Expected: deepseek, nvidia-nim, openrouter, novita, fireworks, sglang, vllm, or ollama."
+            "Unknown provider '{name}'. Expected: deepseek, openai, nvidia-nim, openrouter, novita, fireworks, sglang, vllm, ollama, or anthropic."
         ));
     };
 

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -2288,8 +2288,9 @@ fn normalize_model_for_provider(provider: ApiProvider, model: &str) -> Option<St
     normalize_model_name(model).map(|normalized| model_for_provider(provider, normalized))
 }
 
-fn provider_passes_model_through(provider: ApiProvider) -> bool {
+pub(crate) fn provider_passes_model_through(provider: ApiProvider) -> bool {
     matches!(provider, ApiProvider::Openai | ApiProvider::Ollama)
+
 }
 
 fn provider_entry_uses_custom_base_url(provider: ApiProvider, entry: &ProviderConfig) -> bool {

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -2042,7 +2042,11 @@ fn apply_env_overrides(config: &mut Config) {
     if matches!(config.api_provider(), ApiProvider::Openai)
         && let Ok(value) = std::env::var("OPENAI_MODEL")
     {
-        config.default_text_model = Some(value);
+        config
+            .providers
+            .get_or_insert_with(ProvidersConfig::default)
+            .openai
+            .model = Some(value);
     }
     if let Ok(value) =
         std::env::var("DEEPSEEK_MODEL").or_else(|_| std::env::var("DEEPSEEK_DEFAULT_TEXT_MODEL"))

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -2294,7 +2294,6 @@ fn normalize_model_for_provider(provider: ApiProvider, model: &str) -> Option<St
 
 pub(crate) fn provider_passes_model_through(provider: ApiProvider) -> bool {
     matches!(provider, ApiProvider::Openai | ApiProvider::Ollama)
-
 }
 
 fn provider_entry_uses_custom_base_url(provider: ApiProvider, entry: &ProviderConfig) -> bool {

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -211,8 +211,13 @@ pub struct Settings {
     pub cost_currency: String,
     /// Maximum number of input history entries to save
     pub max_input_history: usize,
+    /// Default provider override (e.g. "deepseek", "openai").
+    pub default_provider: Option<String>,
     /// Default model to use
     pub default_model: Option<String>,
+    /// Per-provider model overrides. Key is provider name (e.g. "openai"),
+    /// value is the model id. Takes precedence over `default_model`.
+    pub provider_models: Option<std::collections::HashMap<String, String>>,
 }
 
 impl Default for Settings {
@@ -247,7 +252,9 @@ impl Default for Settings {
             context_panel: false,
             cost_currency: "usd".to_string(),
             max_input_history: 100,
+            default_provider: None,
             default_model: None,
+            provider_models: None,
         }
     }
 }
@@ -585,6 +592,13 @@ impl Settings {
                 "Default model: auto or any DeepSeek model ID (e.g. deepseek-v4-pro)",
             ),
         ]
+    }
+
+    /// Persist the model for a specific provider.
+    pub fn set_model_for_provider(&mut self, provider: &str, model: &str) {
+        self.provider_models
+            .get_or_insert_with(std::collections::HashMap::new)
+            .insert(provider.to_string(), model.to_string());
     }
 }
 

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -1169,6 +1169,7 @@ impl App {
             .provider_models
             .as_ref()
             .and_then(|m| m.get(provider.as_str()).cloned())
+            .or(settings.default_model.clone())
             .unwrap_or(model);
         let auto_model = model.trim().eq_ignore_ascii_case("auto");
         let threshold_model = if auto_model {

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -1123,13 +1123,20 @@ impl App {
             initial_input,
         } = options;
 
-        let provider = config.api_provider();
+        let mut provider = config.api_provider();
 
         // Check if API key exists
         let needs_api_key = !has_api_key(config);
         let api_key_env_only = crate::config::active_provider_uses_env_only_api_key(config);
         let was_onboarded = crate::tui::onboarding::is_onboarded();
         let settings = Settings::load().unwrap_or_else(|_| Settings::default());
+
+        // Let settings override the config provider so runtime switches survive restarts.
+        if let Some(ref provider_str) = settings.default_provider {
+            if let Some(parsed) = ApiProvider::parse(provider_str) {
+                provider = parsed;
+            }
+        }
         let auto_compact = settings.auto_compact;
         let calm_mode = settings.calm_mode;
         let low_motion = settings.low_motion;
@@ -1158,7 +1165,11 @@ impl App {
         {
             ui_theme = ui_theme.with_background_color(background);
         }
-        let model = settings.default_model.clone().unwrap_or(model);
+        let model = settings
+            .provider_models
+            .as_ref()
+            .and_then(|m| m.get(provider.as_str()).cloned())
+            .unwrap_or(model);
         let auto_model = model.trim().eq_ignore_ascii_case("auto");
         let threshold_model = if auto_model {
             DEFAULT_TEXT_MODEL

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -1132,10 +1132,10 @@ impl App {
         let settings = Settings::load().unwrap_or_else(|_| Settings::default());
 
         // Let settings override the config provider so runtime switches survive restarts.
-        if let Some(ref provider_str) = settings.default_provider {
-            if let Some(parsed) = ApiProvider::parse(provider_str) {
-                provider = parsed;
-            }
+        if let Some(ref provider_str) = settings.default_provider
+            && let Some(parsed) = ApiProvider::parse(provider_str)
+        {
+            provider = parsed;
         }
         let auto_compact = settings.auto_compact;
         let calm_mode = settings.calm_mode;

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -1169,7 +1169,15 @@ impl App {
             .provider_models
             .as_ref()
             .and_then(|m| m.get(provider.as_str()).cloned())
-            .or(settings.default_model.clone())
+            .or_else(|| {
+                // default_model is a DeepSeek-centric setting; other providers
+                // get their model from config.toml / env (e.g. OPENAI_MODEL).
+                if matches!(provider, ApiProvider::Deepseek | ApiProvider::DeepseekCN) {
+                    settings.default_model.clone()
+                } else {
+                    None
+                }
+            })
             .unwrap_or(model);
         let auto_model = model.trim().eq_ignore_ascii_case("auto");
         let threshold_model = if auto_model {

--- a/crates/tui/src/tui/model_picker.rs
+++ b/crates/tui/src/tui/model_picker.rs
@@ -64,23 +64,33 @@ pub struct ModelPickerView {
     /// True when the active model is one we don't list — we still show it
     /// so the picker doesn't quietly forget the user's chosen IDs.
     show_custom_model_row: bool,
+    /// When true, hide DeepSeek-specific model rows (pass-through providers
+    /// like openai don't support them).
+    hide_deepseek_models: bool,
 }
 
 impl ModelPickerView {
     #[must_use]
     pub fn new(app: &App) -> Self {
+        let hide_deepseek_models =
+            crate::config::provider_passes_model_through(app.api_provider);
         let initial_model = if app.auto_model {
             "auto".to_string()
         } else {
             app.model.clone()
         };
-        let mut selected_model_idx = PICKER_MODELS
+        // On pass-through providers, only show "auto" and the custom row.
+        let visible_models: Vec<&str> = if hide_deepseek_models {
+            vec!["auto"]
+        } else {
+            PICKER_MODELS.iter().map(|(id, _)| *id).collect()
+        };
+        let mut selected_model_idx = visible_models
             .iter()
-            .position(|(id, _)| *id == initial_model);
+            .position(|id| *id == initial_model);
         let show_custom_model_row = selected_model_idx.is_none();
         if show_custom_model_row {
-            // Custom row sits at the end; precompute its index.
-            selected_model_idx = Some(PICKER_MODELS.len());
+            selected_model_idx = Some(visible_models.len());
         }
         let selected_model_idx = selected_model_idx.unwrap_or(0);
 
@@ -102,21 +112,33 @@ impl ModelPickerView {
             selected_effort_idx,
             focus: Pane::Model,
             show_custom_model_row,
+            hide_deepseek_models,
+        }
+    }
+
+    fn visible_model_ids(&self) -> Vec<&'static str> {
+        if self.hide_deepseek_models {
+            vec!["auto"]
+        } else {
+            PICKER_MODELS.iter().map(|(id, _)| *id).collect()
         }
     }
 
     fn model_row_count(&self) -> usize {
-        PICKER_MODELS.len() + if self.show_custom_model_row { 1 } else { 0 }
+        self.visible_model_ids().len() + if self.show_custom_model_row { 1 } else { 0 }
     }
 
     /// Resolve the currently highlighted model row to a model id. If the
     /// custom row is selected we return the original model from the App so
     /// "Apply" doesn't blow away an unrecognised id.
     fn resolved_model(&self) -> String {
-        if self.show_custom_model_row && self.selected_model_idx == PICKER_MODELS.len() {
+        let visible = self.visible_model_ids();
+        if self.show_custom_model_row && self.selected_model_idx == visible.len() {
             self.initial_model.clone()
+        } else if self.selected_model_idx < visible.len() {
+            visible[self.selected_model_idx].to_string()
         } else {
-            PICKER_MODELS[self.selected_model_idx].0.to_string()
+            self.initial_model.clone()
         }
     }
 
@@ -305,10 +327,14 @@ impl ModalView for ModelPickerView {
             .constraints([Constraint::Percentage(60), Constraint::Percentage(40)])
             .split(inner);
 
-        let mut model_rows: Vec<(String, String)> = PICKER_MODELS
-            .iter()
-            .map(|(id, hint)| ((*id).to_string(), (*hint).to_string()))
-            .collect();
+        let mut model_rows: Vec<(String, String)> = if self.hide_deepseek_models {
+            vec![("auto".to_string(), "select per turn".to_string())]
+        } else {
+            PICKER_MODELS
+                .iter()
+                .map(|(id, hint)| ((*id).to_string(), (*hint).to_string()))
+                .collect()
+        };
         if self.show_custom_model_row {
             model_rows.push((self.initial_model.clone(), "current (custom)".to_string()));
         }

--- a/crates/tui/src/tui/model_picker.rs
+++ b/crates/tui/src/tui/model_picker.rs
@@ -72,8 +72,7 @@ pub struct ModelPickerView {
 impl ModelPickerView {
     #[must_use]
     pub fn new(app: &App) -> Self {
-        let hide_deepseek_models =
-            crate::config::provider_passes_model_through(app.api_provider);
+        let hide_deepseek_models = crate::config::provider_passes_model_through(app.api_provider);
         let initial_model = if app.auto_model {
             "auto".to_string()
         } else {
@@ -85,9 +84,7 @@ impl ModelPickerView {
         } else {
             PICKER_MODELS.iter().map(|(id, _)| *id).collect()
         };
-        let mut selected_model_idx = visible_models
-            .iter()
-            .position(|id| *id == initial_model);
+        let mut selected_model_idx = visible_models.iter().position(|id| *id == initial_model);
         let show_custom_model_row = selected_model_idx.is_none();
         if show_custom_model_row {
             selected_model_idx = Some(visible_models.len());

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -4123,6 +4123,7 @@ async fn apply_model_picker_choice(
         Ok(mut settings) => {
             if model_changed {
                 let _ = settings.set("default_model", &model);
+                settings.set_model_for_provider(app.api_provider.as_str(), &model);
             }
             if effort_changed {
                 let _ = settings.set("reasoning_effort", effort.as_setting());
@@ -4268,6 +4269,12 @@ async fn switch_provider(
         ),
     });
     app.status_message = Some(format!("Provider: {}", target.as_str()));
+
+    // Persist the provider choice so it survives restarts.
+    if let Ok(mut settings) = crate::settings::Settings::load() {
+        settings.default_provider = Some(target.as_str().to_string());
+        let _ = settings.save();
+    }
 }
 
 fn open_text_pager(app: &mut App, title: String, content: String) {
@@ -4596,18 +4603,27 @@ async fn apply_command_result(
                 let _ = engine_handle.send(Op::ListSubAgents).await;
             }
             AppAction::FetchModels => {
-                app.status_message = Some("Fetching models...".to_string());
-                match fetch_available_models(config).await {
-                    Ok(models) => {
-                        app.add_message(HistoryCell::System {
-                            content: format_available_models_message(&app.model, &models),
-                        });
-                        app.status_message = Some(format!("Found {} model(s)", models.len()));
-                    }
-                    Err(error) => {
-                        app.add_message(HistoryCell::System {
-                            content: format!("Failed to fetch models: {error}"),
-                        });
+                if crate::config::provider_passes_model_through(config.api_provider()) {
+                    app.add_message(HistoryCell::System {
+                        content: format!(
+                            "/models is not supported by the {} provider.",
+                            config.api_provider().display_name()
+                        ),
+                    });
+                } else {
+                    app.status_message = Some("Fetching models...".to_string());
+                    match fetch_available_models(config).await {
+                        Ok(models) => {
+                            app.add_message(HistoryCell::System {
+                                content: format_available_models_message(&app.model, &models),
+                            });
+                            app.status_message = Some(format!("Found {} model(s)", models.len()));
+                        }
+                        Err(error) => {
+                            app.add_message(HistoryCell::System {
+                                content: format!("Failed to fetch models: {error}"),
+                            });
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- Support OpenAI-compatible Coding Plan endpoints (Bailian, ZhiPu, etc.) by adding a custom User-Agent (`deepseek-tui/<version>`) to the reqwest client, fixing HTTP 405 rejections from endpoints that filter by User-Agent
- Allow non-DeepSeek model names for pass-through providers (openai, ollama) in the `/model` command
- Persist provider and model choices per-provider in settings so runtime switches survive restarts
- Hide DeepSeek models from the model picker when on a pass-through provider
- Show a friendly message instead of a 404 error for `/models` on unsupported providers

## Usage

Any OpenAI-compatible Coding Plan endpoint can be used by changing `base_url`, `model`, and `api_key` in `~/.deepseek/config.toml`:

**Bailian (DashScope) Coding Plan:**
```toml
provider = "openai"
[providers.openai]
api_key = "sk-xxx"
base_url = "https://coding.dashscope.aliyuncs.com/v1"
model = "kimi-k2.5"
```

**ZhiPu Coding Plan:**
```toml
provider = "openai"
[providers.openai]
api_key = "sk-xxx"
base_url = "https://open.bigmodel.cn/api/coding/paas/v4"
model = "glm-5.1"
```

## Test plan

- [x] Start TUI with openai provider pointing to Coding Plan → messages sent successfully
- [x] Switch to deepseek provider via `/provider deepseek` → restart → provider persists
- [x] Switch back to openai → model comes from config.toml, not overridden by settings
- [x] `/models` on openai provider shows "not supported" message instead of 404
- [x] Model picker on openai provider only shows "auto" + custom model, no DeepSeek models
- [x] DeepSeek provider works unchanged