### PR TITLE
fix(build): rerun build script when .git/HEAD moves

### DIFF
--- a/crates/cli/build.rs
+++ b/crates/cli/build.rs
@@ -1,8 +1,12 @@
-use std::{path::PathBuf, process::Command};
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 fn main() {
     println!("cargo:rerun-if-env-changed=DEEPSEEK_BUILD_SHA");
     println!("cargo:rerun-if-env-changed=GITHUB_SHA");
+    declare_git_head_rerun();
 
     let package_version = env!("CARGO_PKG_VERSION");
     let build_version = build_sha()
@@ -10,6 +14,36 @@ fn main() {
         .unwrap_or_else(|| package_version.to_string());
 
     println!("cargo:rustc-env=DEEPSEEK_BUILD_VERSION={build_version}");
+}
+
+/// Tell Cargo to invalidate the cached build script output when `HEAD`
+/// moves, so the embedded short-SHA stays in sync with the checkout. With
+/// only `rerun-if-env-changed` lines, Cargo otherwise caches the script
+/// across commits and the SHA goes stale.
+fn declare_git_head_rerun() {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let workspace_root = manifest_dir.join("..").join("..");
+    let git_meta = workspace_root.join(".git");
+    if git_meta.is_dir() {
+        println!("cargo:rerun-if-changed={}", git_meta.join("HEAD").display());
+    } else if git_meta.is_file() {
+        // Worktree checkout: `.git` is a pointer file with `gitdir: <path>`.
+        println!("cargo:rerun-if-changed={}", git_meta.display());
+        if let Ok(contents) = std::fs::read_to_string(&git_meta) {
+            for line in contents.lines() {
+                if let Some(rest) = line.strip_prefix("gitdir:") {
+                    let trimmed = rest.trim();
+                    let gitdir = if Path::new(trimmed).is_absolute() {
+                        PathBuf::from(trimmed)
+                    } else {
+                        workspace_root.join(trimmed)
+                    };
+                    println!("cargo:rerun-if-changed={}", gitdir.join("HEAD").display());
+                    break;
+                }
+            }
+        }
+    }
 }
 
 fn build_sha() -> Option<String> {

--- a/crates/tui/build.rs
+++ b/crates/tui/build.rs
@@ -1,8 +1,12 @@
-use std::{path::PathBuf, process::Command};
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 fn main() {
     println!("cargo:rerun-if-env-changed=DEEPSEEK_BUILD_SHA");
     println!("cargo:rerun-if-env-changed=GITHUB_SHA");
+    declare_git_head_rerun();
     configure_windows_stack();
 
     let package_version = env!("CARGO_PKG_VERSION");
@@ -11,6 +15,36 @@ fn main() {
         .unwrap_or_else(|| package_version.to_string());
 
     println!("cargo:rustc-env=DEEPSEEK_BUILD_VERSION={build_version}");
+}
+
+/// Tell Cargo to invalidate the cached build script output when `HEAD`
+/// moves, so the embedded short-SHA stays in sync with the checkout. With
+/// only `rerun-if-env-changed` lines, Cargo otherwise caches the script
+/// across commits and the SHA goes stale.
+fn declare_git_head_rerun() {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let workspace_root = manifest_dir.join("..").join("..");
+    let git_meta = workspace_root.join(".git");
+    if git_meta.is_dir() {
+        println!("cargo:rerun-if-changed={}", git_meta.join("HEAD").display());
+    } else if git_meta.is_file() {
+        // Worktree checkout: `.git` is a pointer file with `gitdir: <path>`.
+        println!("cargo:rerun-if-changed={}", git_meta.display());
+        if let Ok(contents) = std::fs::read_to_string(&git_meta) {
+            for line in contents.lines() {
+                if let Some(rest) = line.strip_prefix("gitdir:") {
+                    let trimmed = rest.trim();
+                    let gitdir = if Path::new(trimmed).is_absolute() {
+                        PathBuf::from(trimmed)
+                    } else {
+                        workspace_root.join(trimmed)
+                    };
+                    println!("cargo:rerun-if-changed={}", gitdir.join("HEAD").display());
+                    break;
+                }
+            }
+        }
+    }
 }
 
 fn configure_windows_stack() {


### PR DESCRIPTION
## Summary

`build.rs` only declared `rerun-if-env-changed` for two env vars and no `rerun-if-changed` for any file. Cargo therefore cached the build-script output across commits, and the embedded short-SHA in `DEEPSEEK_BUILD_VERSION` (visible in `deepseek --version`) went stale until the next `cargo clean`.

This adds `cargo:rerun-if-changed=<workspace>/.git/HEAD` to both `crates/cli/build.rs` and `crates/tui/build.rs`. The helper handles two layouts:

- Regular checkout: `.git` is a directory; we watch `<workspace>/.git/HEAD`.
- Worktree: `.git` is a pointer file containing `gitdir: <path>`; we watch the pointer file and follow the pointer to the real `HEAD` so per-worktree checkouts also trigger.

## Verification

```bash
$ cargo fmt --all -- --check                                # clean
$ cargo clippy --workspace --all-targets --all-features --locked -- -D warnings  # clean
$ touch crates/cli/build.rs && cargo build -p deepseek-tui-cli --locked -vv | grep rerun-if-changed
[deepseek-tui-cli 0.8.25] cargo:rerun-if-changed=/.../crates/cli/../../.git/HEAD
$ touch .git/HEAD && cargo build -p deepseek-tui-cli --locked
   Compiling deepseek-tui-cli v0.8.25 ...
```

Touching `.git/HEAD` now triggers a recompile and the `--version` output reflects the current commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)