### PR TITLE
 fix: handle short CJK raw multiline paste

### DIFF
--- a/crates/tui/src/tui/paste.rs
+++ b/crates/tui/src/tui/paste.rs
@@ -187,6 +187,41 @@ mod tests {
     }
 
     #[test]
+    fn raw_short_cjk_multiline_paste_buffers_enter_instead_of_submitting() {
+        let mut app = test_app();
+        let t0 = Instant::now();
+
+        let pasted = "请联网搜索：\nSTM32 商业应用案例";
+        let mut enter_was_handled = false;
+        for (i, ch) in pasted.chars().enumerate() {
+            let key = if ch == '\n' {
+                KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)
+            } else {
+                plain(ch)
+            };
+            let handled =
+                handle_paste_burst_key(&mut app, &key, t0 + Duration::from_millis(i as u64));
+            assert!(
+                handled,
+                "raw paste character {ch:?} should be handled by paste-burst detection"
+            );
+            if ch == '\n' {
+                enter_was_handled = handled;
+            }
+        }
+
+        assert!(
+            enter_was_handled,
+            "raw paste Enter must not fall through to submit"
+        );
+        assert!(app.flush_paste_burst_if_due(
+            t0 + Duration::from_millis(pasted.chars().count() as u64)
+                + crate::tui::paste_burst::PasteBurst::recommended_active_flush_delay()
+        ));
+        assert_eq!(app.input, pasted);
+    }
+
+    #[test]
     fn paste_buffered_question_mark_does_not_fall_through_to_help_shortcut() {
         let mut app = test_app();
         let t0 = Instant::now();

--- a/crates/tui/src/tui/paste_burst.rs
+++ b/crates/tui/src/tui/paste_burst.rs
@@ -193,8 +193,9 @@ impl PasteBurst {
     ) -> Option<RetroGrab> {
         let start_byte = retro_start_index(before, retro_chars);
         let grabbed = before[start_byte..].to_string();
-        let looks_pastey =
-            grabbed.chars().any(char::is_whitespace) || grabbed.chars().count() >= 16;
+        let looks_pastey = grabbed.chars().any(char::is_whitespace)
+            || !grabbed.is_ascii()
+            || grabbed.chars().count() >= 16;
         if looks_pastey {
             self.begin_with_retro_grabbed(grabbed.clone(), now);
             Some(RetroGrab {


### PR DESCRIPTION

## Summary

  Fixes short CJK multiline pastes in terminals that fall back to raw key events instead of bracketed paste.

 Previously, a short first line such as `请联网搜索：` was not recognized as paste-like because it had no whitespace and was under the length threshold. The following pasted newline could then fall through as a normal Enter and submit the first line.

 This change treats fast non-ASCII text as paste-like in the raw paste fallback and adds a regression test for the reported Chinese multiline paste case.

fixes: https://github.com/Hmbown/DeepSeek-TUI/issues/1302

## Testing

- [x] `cargo test --all-features`
- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
