### PR TITLE
fix: Ctrl+Enter content lost when engine is idle (#1331)

### DIFF
--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -2549,15 +2549,23 @@ async fn run_event_loop(
                             } else {
                                 build_queued_message(app, input)
                             };
-                            // Force steer: bypass decide_submit_disposition.
-                            if let Err(err) =
-                                steer_user_message(app, &engine_handle, queued.clone()).await
-                            {
-                                app.queue_message(queued);
-                                app.status_message = Some(format!(
-                                    "Steer failed ({err}); queued {} message(s)",
-                                    app.queued_message_count()
-                                ));
+                            if app.is_loading {
+                                // Engine is busy — steer into the current turn.
+                                if let Err(err) =
+                                    steer_user_message(app, &engine_handle, queued.clone()).await
+                                {
+                                    app.queue_message(queued);
+                                    app.status_message = Some(format!(
+                                        "Steer failed ({err}); queued {} message(s)",
+                                        app.queued_message_count()
+                                    ));
+                                }
+                            } else {
+                                // Engine is idle — send as a regular message
+                                // so the content is not lost to rx_steer's
+                                // stale-drain in handle_send_message (#1331).
+                                submit_or_steer_message(app, config, &engine_handle, queued)
+                                    .await?;
                             }
                         }
                     }


### PR DESCRIPTION
## Summary

Fixes #1331 (Ctrl+Enter submission issue).

When the engine is idle (no active turn), Ctrl+Enter sent the message to `rx_steer`, which is only monitored inside `handle_deepseek_turn`. The message appeared in the transcript (via the local mirror in `steer_user_message`) but the LLM never received it. The next regular Enter would drain it as a "stale steer" in `handle_send_message`.

## Root cause

`rx_steer` is only polled inside `handle_deepseek_turn` ([turn_loop.rs:50](https://github.com/Hmbown/DeepSeek-TUI/blob/v0.8.25/crates/tui/src/core/engine/turn_loop.rs#L50), [turn_loop.rs:872](https://github.com/Hmbown/DeepSeek-TUI/blob/v0.8.25/crates/tui/src/core/engine/turn_loop.rs#L872)). The engine's main event loop ([engine.rs:574](https://github.com/Hmbown/DeepSeek-TUI/blob/v0.8.25/crates/tui/src/core/engine.rs#L574)) only handles `Op` variants — steers sent while idle are orphaned.

When the next `Op::SendMessage` arrives, `handle_send_message` drains `rx_steer` as "stale" at [engine.rs:891](https://github.com/Hmbown/DeepSeek-TUI/blob/v0.8.25/crates/tui/src/core/engine.rs#L891), discarding the message permanently.

## Fix

Check `app.is_loading` in the Ctrl+Enter handler:

- **Engine busy** (already generating): steer into current turn as before
- **Engine idle**: send via `submit_or_steer_message` → `Op::SendMessage` so the content goes through the regular submission path

## Files changed

| File | Change |
|------|--------|
| `crates/tui/src/tui/ui.rs` | Conditional steer vs. regular send in Ctrl+Enter handler |

## Test plan

- [x] `cargo check -p deepseek-tui` passes
- [x] `cargo test -p deepseek-tui -- tui::app` — 124 passed
- [x] All pre-existing non-Python-related tests pass (2485/2504)
