### PR TITLE
fix: long text clipped instead of wrapping (#1344)

### DIFF
--- a/crates/tui/src/tui/markdown_render.rs
+++ b/crates/tui/src/tui/markdown_render.rs
@@ -29,6 +29,7 @@ use std::cell::Cell;
 
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
+use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::palette;
@@ -481,8 +482,26 @@ fn render_line_with_links(
             current_spans = Vec::new();
             current_width = 0;
         }
-        current_spans.push(Span::styled(word, style));
+        current_spans.push(Span::styled(word.clone(), style));
         current_width += ww;
+
+        // Hard-wrap at grapheme boundaries when a single word exceeds width
+        // (e.g. long URLs, code tokens, or base64 strings).
+        if ww > width {
+            // Remove the full word and re-add in width-limited grapheme chunks.
+            current_spans.pop();
+            current_width = current_width.saturating_sub(ww);
+            for grapheme in word.graphemes(true) {
+                let gw = grapheme.width();
+                if current_width + gw > width && !current_spans.is_empty() {
+                    lines.push(Line::from(current_spans));
+                    current_spans = Vec::new();
+                    current_width = 0;
+                }
+                current_spans.push(Span::styled(grapheme.to_string(), style));
+                current_width += gw;
+            }
+        }
     }
 
     if !current_spans.is_empty() {
@@ -907,6 +926,23 @@ fn wrap_text(text: &str, width: usize) -> Vec<String> {
             }
             current.push_str(word);
             current_width += word_width;
+        }
+
+        // Hard-wrap at grapheme boundaries when a single word exceeds width
+        // (e.g. long URLs, code tokens, or base64 strings).
+        if current_width > width {
+            let remaining = std::mem::take(&mut current);
+            current_width = 0;
+            for grapheme in remaining.graphemes(true) {
+                let gw = grapheme.width();
+                if current_width + gw > width && !current.is_empty() {
+                    lines.push(current);
+                    current = String::new();
+                    current_width = 0;
+                }
+                current.push_str(grapheme);
+                current_width += gw;
+            }
         }
     }
 

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -326,8 +326,9 @@ impl Renderable for ChatWidget {
             .style(Style::default().bg(self.background))
             .render(area, buf);
 
-        let paragraph =
-            Paragraph::new(self.lines.clone()).style(Style::default().bg(self.background));
+        let paragraph = Paragraph::new(self.lines.clone())
+            .wrap(Wrap { trim: false })
+            .style(Style::default().bg(self.background));
         paragraph.render(area, buf);
 
         if let Some(scrollbar) = self.scrollbar {


### PR DESCRIPTION
## Summary

## Summary

This PR fixes both problems reported in issue #1344 and #1351:

**Grapheme-level hard break for long words** — when a single word (URL, code token, base64 string) exceeds the available width, it is now broken at grapheme cluster boundaries instead of overflowing. This applies to both plain-text paragraphs (`wrap_text`) and inline-styled text with links/markup (`render_line_with_links`).

**Paragraph safety net** — `ChatWidget`'s `Paragraph` now has `.wrap(Wrap { trim: false })` enabled. If any pre-wrapped line still exceeds the area width, ratatui will wrap it at render time instead of silently clipping.

Fixes #1344
Fixes #1351


## Root cause

The markdown renderer's word-level wrapping (`wrap_text` / `render_line_with_links`) does not break long individual words — a URL, code token, or base64 string wider than the available width would overflow. Additionally, `ChatWidget`'s `Paragraph` had no `.wrap()` safety net, so any overflowing line was silently clipped by ratatui at the render stage.

The composer (`wrap_input_lines`) already used grapheme-level wrapping and was unaffected.

## Changes

| File | Change |
|------|--------|
| `crates/tui/src/tui/widgets/mod.rs` | Added `.wrap(Wrap { trim: false })` to `ChatWidget`'s `Paragraph` as a safety net |
| `crates/tui/src/tui/markdown_render.rs` | Added hard grapheme-level wrapping in `wrap_text` and `render_line_with_links` when a single word exceeds the available width |

## Fix details

**Paragraph safety net** — if any pre-wrapped line still exceeds the area width (e.g. due to width-miscalculation edge cases), ratatui will wrap it at render time instead of clipping.

**Grapheme-level hard break** — when a word is wider than the available width, it is now broken at grapheme cluster boundaries. This applies to both plain-text paragraphs (`wrap_text`) and inline-styled text with links/markup (`render_line_with_links`). The break only triggers when necessary — normal text still uses word-level wrapping.

## Test plan

- [x] `cargo check -p deepseek-tui` passes
- [x] `cargo clippy -p deepseek-tui --all-targets --all-features --locked -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo test -p deepseek-tui -- tui::markdown_render` — 21 passed
- [x] `cargo test -p deepseek-tui -- tui::widgets::tests::long_tool_result_lines_fit_requested_width` — passed
- [x] `cargo test -p deepseek-tui -- "tui::"` — 797 passed