### PR TITLE
feat: add y (yank) keybinding to pager for clipboard copy

### DIFF
--- a/crates/tui/src/tui/pager.rs
+++ b/crates/tui/src/tui/pager.rs
@@ -10,6 +10,7 @@
 //! - `Ctrl+F` / PageDown / Space — full page down
 //! - `Ctrl+B` / PageUp / Shift+Space — full page up
 //! - `/` — start search; `n` / `N` — next / previous match
+//! - `y` — yank all content to clipboard
 //! - `q` / Esc — close pager
 
 use std::cell::Cell;
@@ -29,7 +30,8 @@ use crate::tui::views::{ModalKind, ModalView, ViewAction};
 
 /// Footer hint shown along the bottom border of the pager. Kept short so it
 /// fits on narrow terminals; full reference lives in the module docs.
-const FOOTER_HINT_NAV: &str = " j/k scroll  Space page  Ctrl+D/U half  g/G top/bottom  / search";
+const FOOTER_HINT_NAV: &str =
+    " j/k scroll  Space page  Ctrl+D/U half  g/G top/bottom  / search  y yank";
 const FOOTER_HINT_EXIT: &str = " q/Esc close ";
 
 pub struct PagerView {
@@ -305,6 +307,11 @@ impl ModalView for PagerView {
                 self.scroll_to_bottom(max_scroll);
                 self.pending_g = false;
                 ViewAction::None
+            }
+            KeyCode::Char('y') => {
+                self.pending_g = false;
+                let text = self.plain_lines.join("\n");
+                ViewAction::Emit(crate::tui::views::ViewEvent::CopyToClipboard { text })
             }
             KeyCode::Char('/') => {
                 self.start_search();
@@ -663,7 +670,15 @@ mod tests {
     fn footer_hint_includes_new_bindings() {
         // The rendered pager must surface the new vim-style bindings to
         // the user; check the footer hint covers the headline keys.
-        for needle in &["j/k", "g/G", "Space", "Ctrl+D", "/ search", "q/Esc close"] {
+        for needle in &[
+            "j/k",
+            "g/G",
+            "Space",
+            "Ctrl+D",
+            "/ search",
+            "y yank",
+            "q/Esc close",
+        ] {
             let full_hint = format!("{FOOTER_HINT_EXIT}{FOOTER_HINT_NAV}");
             assert!(
                 full_hint.contains(needle),

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -5911,6 +5911,15 @@ async fn handle_view_events(
                 app.finalize_streaming_assistant_as_interrupted();
                 app.status_message = Some("Request cancelled".to_string());
             }
+            ViewEvent::CopyToClipboard { text } => {
+                let _ = app.clipboard.write_text(&text);
+                let preview = if text.len() > 80 {
+                    format!("{}… ({} chars)", &text[..80], text.len())
+                } else {
+                    text.clone()
+                };
+                app.status_message = Some(format!("Copied: {preview}"));
+            }
         }
     }
 

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -103,6 +103,9 @@ pub enum ViewEvent {
     UserInputCancelled {
         tool_id: String,
     },
+    CopyToClipboard {
+        text: String,
+    },
     ConfigUpdated {
         key: String,
         value: String,


### PR DESCRIPTION
## Summary

The PagerView (used by `Alt+V` for tool details, `Ctrl+O` for thinking content, and other detail views) had no way to copy content to the clipboard. Users had to close the pager and attempt to select truncated text in the transcript, which was often impossible.

This PR adds a `y` (yank) keybinding following vim convention, consistent with the pager's existing vim-style navigation keys (`j`/`k`, `gg`/`G`).

Fixes #1354

## Changes

| File | Change |
|------|--------|
| `crates/tui/src/tui/views/mod.rs` | Added `ViewEvent::CopyToClipboard { text }` variant |
| `crates/tui/src/tui/pager.rs` | Added `y` keybinding → emits `CopyToClipboard` with full plain text; added `y yank` to footer hint and module docs |
| `crates/tui/src/tui/ui.rs` | Handle `ViewEvent::CopyToClipboard` → write to `app.clipboard.write_text()` with status message |

## Usage

While any pager is open (tool details, thinking content, context inspector, etc.), press `y` to copy the entire content to the system clipboard. A status message shows a preview of the copied text.

## Test plan

- [x] `cargo check -p deepseek-tui` passes
- [x] `cargo clippy -p deepseek-tui --all-targets --all-features --locked -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo test -p deepseek-tui -- pager` — 26 passed