### PR TITLE
fix: 添加 DEC 2026 同步更新，修复 GPU 终端上的界面闪烁 (add DEC 2026 synchronized updates to prevent flickering on GPU terminals)

### DIFF
--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -140,6 +140,13 @@ const DEFAULT_TERMINAL_PROBE_TIMEOUT_MS: u64 = 500;
 
 type AppTerminal = Terminal<ColorCompatBackend<Stdout>>;
 const TERMINAL_ORIGIN_RESET: &[u8] = b"\x1b[r\x1b[?6l\x1b[H\x1b[2J\x1b[3J";
+/// Begin synchronized update (DEC 2026): tell the terminal to defer
+/// rendering until END_SYNC_UPDATE is received. Best-effort —
+/// terminals that don't support this silently ignore the sequence.
+const BEGIN_SYNC_UPDATE: &[u8] = b"\x1b[?2026h";
+/// End synchronized update (DEC 2026): tell the terminal to render
+/// the complete frame now.
+const END_SYNC_UPDATE: &[u8] = b"\x1b[?2026l";
 
 /// Run the interactive TUI event loop.
 ///
@@ -1519,11 +1526,8 @@ async fn run_event_loop(
             None
         };
         if app.needs_redraw && draw_wait.is_none() {
-            if force_terminal_repaint {
-                reset_terminal_viewport(terminal)?;
-                force_terminal_repaint = false;
-            }
-            draw_app_frame(terminal, app)?;
+            draw_app_frame_inner(terminal, app, force_terminal_repaint)?;
+            force_terminal_repaint = false;
             frame_rate_limiter.mark_emitted(Instant::now());
             app.needs_redraw = false;
         }
@@ -5553,10 +5557,36 @@ fn render(f: &mut Frame, app: &mut App) {
     }
 }
 
-fn draw_app_frame(terminal: &mut AppTerminal, app: &mut App) -> Result<()> {
+/// Draw a complete application frame, optionally with a full viewport reset.
+///
+/// When `full_repaint` is true, the terminal scroll margins and origin mode
+/// are reset, the screen is cleared, ratatui's buffer is emptied, and then
+/// the full UI is drawn — all within a single DEC 2026 synchronized-update
+/// batch so GPU-accelerated terminals (Ghostty, VS Code, Kitty) render one
+/// complete frame instead of a blank intermediate frame followed by the UI.
+///
+/// When `full_repaint` is false, only the diff from the previous draw is
+/// written (normal incremental update path).
+fn draw_app_frame_inner(
+    terminal: &mut AppTerminal,
+    app: &mut App,
+    full_repaint: bool,
+) -> Result<()> {
     terminal.backend_mut().set_palette_mode(app.ui_theme.mode);
+    let _ = terminal.backend_mut().write_all(BEGIN_SYNC_UPDATE);
+    if full_repaint {
+        terminal.backend_mut().write_all(TERMINAL_ORIGIN_RESET)?;
+        terminal.backend_mut().flush()?;
+        terminal.clear()?;
+    }
     terminal.draw(|f| render(f, app))?;
+    let _ = terminal.backend_mut().write_all(END_SYNC_UPDATE);
+    let _ = terminal.backend_mut().flush();
     Ok(())
+}
+
+fn draw_app_frame(terminal: &mut AppTerminal, app: &mut App) -> Result<()> {
+    draw_app_frame_inner(terminal, app, false)
 }
 
 /// Pull the latest snapshot of cells / revisions / render options into the
@@ -6423,9 +6453,12 @@ fn reset_terminal_viewport(terminal: &mut AppTerminal) -> Result<()> {
     // scroll region and the whole viewport appears shifted down. CSI 3J also
     // erases saved scrollback so a focus/resize recapture cannot leave the
     // host terminal's scrollbar above the live TUI.
+    let _ = terminal.backend_mut().write_all(BEGIN_SYNC_UPDATE);
     terminal.backend_mut().write_all(TERMINAL_ORIGIN_RESET)?;
     terminal.backend_mut().flush()?;
     terminal.clear()?;
+    let _ = terminal.backend_mut().write_all(END_SYNC_UPDATE);
+    terminal.backend_mut().flush()?;
     Ok(())
 }
 


### PR DESCRIPTION
## 概述 | Summary

添加 DEC 2026 同步更新转义序列（ESC[?2026h / ESC[?2026l）包裹终端绘制操作，修复在 GPU 加速终端（Ghostty、VS Code 内置终端、Kitty 等）中 deepseek-tui 界面闪烁的问题。

Add DEC 2026 synchronized update escape sequences (ESC[?2026h / ESC[?2026l) around terminal drawing to prevent flickering on GPU-accelerated terminals (Ghostty, VS Code Terminal, Kitty, etc.).

## 问题描述 | Problem

GPU 加速终端在收到每一批转义序列时立即渲染。deepseek-tui 使用 ratatui 的增量 diff 绘制，每次重绘会分批写入转义序列（移动光标、写文字、设颜色...），GPU 终端在收到部分数据时就渲染一帧，导致不完整的中间状态被显示出来，产生界面闪烁。

当 AI 模型高速流式输出时，这个问题尤为严重 —— 每个 token 都可能触发一次全屏重绘，最高可达 120 FPS，导致持续闪烁 + CPU 占用率暴增。

GPU-accelerated terminals render each batch of escape sequences as it arrives. Without synchronized updates, ratatui's incremental diff writing produces visible intermediate frames, causing rapid flickering and elevated CPU when the AI model streams output at high speed (up to 120 FPS).

相关 issue | Related issues:
- #1352（在 Ghostty 中运行时界面闪烁 | flickering in Ghostty）
- #1356（在 VS Code 终端中快速闪烁 | flickering in VS Code Terminal）

## 根因分析 | Root Cause

两个问题叠加导致 | Two issues working together:

1. **绘制时未使用同步更新** —— `terminal.draw()` 写入转义序列后没有告诉终端"我写完了再一起渲染"，GPU 终端每收到一批数据就渲染一次，中间帧可见。

   **No synchronized updates around draws** — ratatui's `terminal.draw()` writes a diff of changed cells to stdout. GPU terminals render partial batches as they arrive, making intermediate states visible.

2. **清屏和绘制被拆成两个同步块** —— `force_terminal_repaint` 路径中，`reset_terminal_viewport()`（清屏）和 `draw_app_frame()`（绘制 UI）分别处于不同的同步更新块中，导致先渲染一帧白屏，再渲染 UI，用户看到白屏闪烁。

   **Separate sync batches for viewport reset and draw** — the `force_terminal_repaint` path called `reset_terminal_viewport()` and `draw_app_frame()` in separate synchronized update blocks, producing a visible blank intermediate frame between the clear and the redraw.

## 修复内容 | Fix

- 新增 `BEGIN_SYNC_UPDATE` / `END_SYNC_UPDATE` 常量（`ESC[?2026h` / `ESC[?2026l`）
- `terminal.draw()` 用同步更新包裹，确保完整帧才渲染
- `reset_terminal_viewport()` 用同步更新包裹
- 新增 `draw_app_frame_inner(terminal, app, full_repaint)` 函数，在 `full_repaint=true` 时把清屏 + 绘制合并到**同一个同步更新块**中，消除中间白屏帧
- `draw_app_frame()` 改为调用 `draw_app_frame_inner(terminal, app, false)` 的薄包装

所有序列均为 best-effort，不支持的终端（老旧终端）会静默丢弃，不影响正常使用。

- Add `BEGIN_SYNC_UPDATE` / `END_SYNC_UPDATE` constants (`ESC[?2026h` / `ESC[?2026l`)
- Wrap `terminal.draw()` in synchronized updates so terminals render complete frames only
- Wrap `reset_terminal_viewport()` in synchronized updates
- Introduce `draw_app_frame_inner(terminal, app, full_repaint)` that merges viewport-reset + draw into a **single synchronized update batch**, eliminating the blank intermediate frame
- `draw_app_frame()` becomes a thin wrapper calling `draw_app_frame_inner(terminal, app, false)`

All sequences are best-effort — terminals that don't support DEC 2026 silently discard them.

## 测试计划 | Test plan

- [ ] 在 Ghostty 中运行 —— 流式输出时无闪烁 | Run in Ghostty — no flickering during streaming
- [ ] 在 Konsole 中运行 —— 无回归 | Run in Konsole — no regression
- [ ] 在 VS Code 内置终端中运行 —— 无闪烁 | Run in VS Code Terminal — no flickering
- [ ] 在老旧终端（Windows ConHost）中运行 —— 无崩溃 | Run in older terminals — no crash
- [ ] `cargo test -p deepseek-tui` 通过，无回归 | `cargo test -p deepseek-tui` passes with no regressions
