### PR TITLE
fix: add DEC 2026 synchronized updates to prevent flickering on GPU terminals

### DIFF
--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -5574,15 +5574,25 @@ fn draw_app_frame_inner(
 ) -> Result<()> {
     terminal.backend_mut().set_palette_mode(app.ui_theme.mode);
     let _ = terminal.backend_mut().write_all(BEGIN_SYNC_UPDATE);
-    if full_repaint {
-        terminal.backend_mut().write_all(TERMINAL_ORIGIN_RESET)?;
-        terminal.backend_mut().flush()?;
-        terminal.clear()?;
-    }
-    terminal.draw(|f| render(f, app))?;
+
+    // Run fallible draw operations in a closure so END_SYNC_UPDATE is
+    // always sent even if an intermediate step fails. Without this, a
+    // failing `?` would return early and leave the terminal stuck in
+    // synchronized-update mode (screen frozen).
+    let result = (|| -> Result<()> {
+        if full_repaint {
+            terminal.backend_mut().write_all(TERMINAL_ORIGIN_RESET)?;
+            terminal.backend_mut().flush()?;
+            terminal.clear()?;
+        }
+        terminal.draw(|f| render(f, app))?;
+        Ok(())
+    })();
+
+    // Always end the synchronized update, regardless of success or failure.
     let _ = terminal.backend_mut().write_all(END_SYNC_UPDATE);
     let _ = terminal.backend_mut().flush();
-    Ok(())
+    result
 }
 
 fn draw_app_frame(terminal: &mut AppTerminal, app: &mut App) -> Result<()> {
@@ -6454,12 +6464,18 @@ fn reset_terminal_viewport(terminal: &mut AppTerminal) -> Result<()> {
     // erases saved scrollback so a focus/resize recapture cannot leave the
     // host terminal's scrollbar above the live TUI.
     let _ = terminal.backend_mut().write_all(BEGIN_SYNC_UPDATE);
-    terminal.backend_mut().write_all(TERMINAL_ORIGIN_RESET)?;
-    terminal.backend_mut().flush()?;
-    terminal.clear()?;
+
+    let result = (|| -> Result<()> {
+        terminal.backend_mut().write_all(TERMINAL_ORIGIN_RESET)?;
+        terminal.backend_mut().flush()?;
+        terminal.clear()?;
+        Ok(())
+    })();
+
+    // Always end the synchronized update, regardless of success or failure.
     let _ = terminal.backend_mut().write_all(END_SYNC_UPDATE);
-    terminal.backend_mut().flush()?;
-    Ok(())
+    let _ = terminal.backend_mut().flush();
+    result
 }
 
 fn push_keyboard_enhancement_flags<W: Write>(writer: &mut W) {

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -140,6 +140,13 @@ const DEFAULT_TERMINAL_PROBE_TIMEOUT_MS: u64 = 500;
 
 type AppTerminal = Terminal<ColorCompatBackend<Stdout>>;
 const TERMINAL_ORIGIN_RESET: &[u8] = b"\x1b[r\x1b[?6l\x1b[H\x1b[2J\x1b[3J";
+/// Begin synchronized update (DEC 2026): tell the terminal to defer
+/// rendering until END_SYNC_UPDATE is received. Best-effort —
+/// terminals that don't support this silently ignore the sequence.
+const BEGIN_SYNC_UPDATE: &[u8] = b"\x1b[?2026h";
+/// End synchronized update (DEC 2026): tell the terminal to render
+/// the complete frame now.
+const END_SYNC_UPDATE: &[u8] = b"\x1b[?2026l";
 
 /// Run the interactive TUI event loop.
 ///
@@ -1519,11 +1526,8 @@ async fn run_event_loop(
             None
         };
         if app.needs_redraw && draw_wait.is_none() {
-            if force_terminal_repaint {
-                reset_terminal_viewport(terminal)?;
-                force_terminal_repaint = false;
-            }
-            draw_app_frame(terminal, app)?;
+            draw_app_frame_inner(terminal, app, force_terminal_repaint)?;
+            force_terminal_repaint = false;
             frame_rate_limiter.mark_emitted(Instant::now());
             app.needs_redraw = false;
         }
@@ -5553,10 +5557,36 @@ fn render(f: &mut Frame, app: &mut App) {
     }
 }
 
-fn draw_app_frame(terminal: &mut AppTerminal, app: &mut App) -> Result<()> {
+/// Draw a complete application frame, optionally with a full viewport reset.
+///
+/// When `full_repaint` is true, the terminal scroll margins and origin mode
+/// are reset, the screen is cleared, ratatui's buffer is emptied, and then
+/// the full UI is drawn — all within a single DEC 2026 synchronized-update
+/// batch so GPU-accelerated terminals (Ghostty, VS Code, Kitty) render one
+/// complete frame instead of a blank intermediate frame followed by the UI.
+///
+/// When `full_repaint` is false, only the diff from the previous draw is
+/// written (normal incremental update path).
+fn draw_app_frame_inner(
+    terminal: &mut AppTerminal,
+    app: &mut App,
+    full_repaint: bool,
+) -> Result<()> {
     terminal.backend_mut().set_palette_mode(app.ui_theme.mode);
+    let _ = terminal.backend_mut().write_all(BEGIN_SYNC_UPDATE);
+    if full_repaint {
+        terminal.backend_mut().write_all(TERMINAL_ORIGIN_RESET)?;
+        terminal.backend_mut().flush()?;
+        terminal.clear()?;
+    }
     terminal.draw(|f| render(f, app))?;
+    let _ = terminal.backend_mut().write_all(END_SYNC_UPDATE);
+    let _ = terminal.backend_mut().flush();
     Ok(())
+}
+
+fn draw_app_frame(terminal: &mut AppTerminal, app: &mut App) -> Result<()> {
+    draw_app_frame_inner(terminal, app, false)
 }
 
 /// Pull the latest snapshot of cells / revisions / render options into the
@@ -6423,9 +6453,12 @@ fn reset_terminal_viewport(terminal: &mut AppTerminal) -> Result<()> {
     // scroll region and the whole viewport appears shifted down. CSI 3J also
     // erases saved scrollback so a focus/resize recapture cannot leave the
     // host terminal's scrollbar above the live TUI.
+    let _ = terminal.backend_mut().write_all(BEGIN_SYNC_UPDATE);
     terminal.backend_mut().write_all(TERMINAL_ORIGIN_RESET)?;
     terminal.backend_mut().flush()?;
     terminal.clear()?;
+    let _ = terminal.backend_mut().write_all(END_SYNC_UPDATE);
+    terminal.backend_mut().flush()?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Add DEC 2026 synchronized update escape sequences (`ESC[?2026h` / `ESC[?2026l`) around terminal drawing to prevent flickering on GPU-accelerated terminals (Ghostty, VS Code Terminal, Kitty, etc.).

## Problem

GPU-accelerated terminals render each batch of escape sequences as it arrives. Without synchronized updates, ratatui's incremental diff writing produces visible intermediate frames, causing rapid flickering and elevated CPU usage when the AI model streams output at high speed (up to 120 FPS).

Related issues:
- #1352 (flickering in Ghostty)
- #1356 (flickering in VS Code Terminal)

## Root Cause

Two issues working together:

1. **No synchronized updates around draws** — ratatui's `terminal.draw()` writes a diff of changed cells to stdout. GPU terminals render partial batches as they arrive, making intermediate states visible.

2. **Separate sync batches for viewport reset and draw** — the `force_terminal_repaint` path called `reset_terminal_viewport()` and `draw_app_frame()` in separate synchronized update blocks, producing a visible blank intermediate frame between the clear and the redraw.

## Fix

- Add `BEGIN_SYNC_UPDATE` / `END_SYNC_UPDATE` constants (`ESC[?2026h` / `ESC[?2026l`)
- Wrap `terminal.draw()` in synchronized updates so terminals render complete frames only
- Wrap `reset_terminal_viewport()` in synchronized updates
- Introduce `draw_app_frame_inner(terminal, app, full_repaint)` that merges viewport-reset + draw into a **single synchronized update batch**, eliminating the blank intermediate frame
- `draw_app_frame()` becomes a thin wrapper calling `draw_app_frame_inner(terminal, app, false)`

All sequences are best-effort — terminals that don't support DEC 2026 silently discard them.

## Test plan

- [ ] Run in Ghostty — no flickering during streaming
- [ ] Run in Konsole — no regression
- [ ] Run in VS Code Terminal — no flickering
- [ ] Run in older terminals (Windows ConHost) — no crash
- [ ] `cargo test -p deepseek-tui` passes with no regressions
