### PR TITLE
feat(notifications): native OS notification + Cmux support + README security warning (#1281, #1286)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 
 [简体中文 README](README.zh-CN.md)
 
+> ⚠️ **SECURITY WARNING**: A fake repository `DeepSeek-TUI/DeepSeek-TUI` is impersonating this
+> project and distributing malware-infected release assets. **Only download from the official
+> repository: [Hmbown/DeepSeek-TUI](https://github.com/Hmbown/DeepSeek-TUI).**
+> See [#1286](https://github.com/Hmbown/DeepSeek-TUI/issues/1286) for details.
+
 ## Install
 
 `deepseek` is distributed as Rust binaries: the dispatcher command

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,6 +4,10 @@
 
 [English README](README.md)
 
+> ⚠️ **安全警告**：发现仿冒仓库 `DeepSeek-TUI/DeepSeek-TUI` 冒充本项目，其发布资产含蠕虫病毒
+> （VirusTotal 已确认）。**请仅从官方仓库下载：[Hmbown/DeepSeek-TUI](https://github.com/Hmbown/DeepSeek-TUI)。**
+> 详见 [#1286](https://github.com/Hmbown/DeepSeek-TUI/issues/1286)。
+
 ## 安装
 
 `deepseek` 是自包含 Rust 二进制——**运行时不依赖 Node.js 或 Python**。

--- a/config.example.toml
+++ b/config.example.toml
@@ -370,23 +370,29 @@ base_url = "https://integrate.api.nvidia.com/v1"
 default_text_model = "deepseek-ai/deepseek-v4-pro"
 
 # ─────────────────────────────────────────────────────────────────────────────────
-# Desktop Notifications (OSC 9 / BEL on long agent-turn completion)
+# Desktop Notifications (OSC 9 / native / BEL on long agent-turn completion)
 # ─────────────────────────────────────────────────────────────────────────────────
 # Emits an escape sequence to the terminal when a turn **completes successfully**
 # and took longer than `threshold_secs`. Failed or cancelled turns are
 # intentionally silent. Useful when you tab away from the TUI and want an alert
 # for "your task is ready".
 #
-# method        = "auto"   # auto | osc9 | bel | off
-#                 auto: OSC 9 for iTerm.app / Ghostty / WezTerm.
-#                       On macOS / Linux, falls back to BEL.
+# method        = "auto"   # auto | osc9 | native | bel | off
+#                 auto: OSC 9 for iTerm.app / Ghostty / WezTerm / Cmux
+#                       (or any terminal with TERM containing "ghostty").
+#                       On macOS / Linux, falls back to native
+#                       (osascript display notification) — works in any
+#                       terminal, no OSC 9 support required.
 #                       On Windows, falls back to "off" — BEL maps to the
 #                       system error chime (SystemAsterisk / MB_OK), which
 #                       sounds like an error popup. Set method = "bel"
 #                       explicitly to opt back in (#583).
-#                 osc9: \x1b]9;<msg>\x07 (iTerm2-style; shows macOS notification)
-#                 bel:  plain \x07 beep
-#                 off:  disable entirely
+#                 osc9:   \x1b]9;<msg>\x07 (iTerm2-style; shows macOS notification
+#                         in iTerm2/Ghostty/WezTerm/Cmux)
+#                 native: osascript display notification (macOS) /
+#                         notify-send (Linux) — works in any terminal
+#                 bel:    plain \x07 beep
+#                 off:    disable entirely
 # threshold_secs = 30      # only notify when the turn took >= this many seconds
 # include_summary = false  # include elapsed time + cost in the notification body
 [notifications]

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -405,13 +405,16 @@ pub enum NotificationCondition {
 #[derive(Debug, Clone, Deserialize, Default, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub enum NotificationMethod {
-    /// Auto-detect: OSC 9 for iTerm.app / Ghostty / WezTerm; BEL on
-    /// macOS / Linux otherwise; on Windows the fallback is `Off`
-    /// because BEL maps to the system error chime there (#583).
+    /// Auto-detect: OSC 9 for iTerm.app / Ghostty / WezTerm / Cmux;
+    /// native OS notification on macOS / Linux otherwise; on Windows
+    /// the fallback is `Off` because BEL maps to the system error
+    /// chime there (#583).
     #[default]
     Auto,
     /// OSC 9 escape.
     Osc9,
+    /// Native OS notification (osascript / notify-send).
+    Native,
     /// Plain BEL character.
     Bel,
     /// Disable notifications.

--- a/crates/tui/src/tui/notifications.rs
+++ b/crates/tui/src/tui/notifications.rs
@@ -1,9 +1,15 @@
-//! OSC 9 / BEL desktop notifications for long agent-turn completion.
+//! Desktop notifications for long agent-turn completion.
 //!
-//! Writes a terminal escape to the provided sink (or stdout for the public
-//! API) when a turn takes longer than the configured threshold. Supports
-//! tmux DCS passthrough so OSC 9 reaches the outer terminal even when
-//! running inside a tmux session.
+//! Supports three delivery mechanisms:
+//! - **OSC 9** — terminal escape sequence (`\x1b]9;…\x07`) for iTerm2,
+//!   Ghostty, WezTerm, and tmux (with DCS passthrough).
+//! - **Native** — OS-level notification via `osascript` (macOS) or
+//!   `notify-send` (Linux), working in any terminal.
+//! - **BEL** — audible bell (`\x07`) as a last-resort fallback.
+//!
+//! When `method = "auto"`, the resolver prefers OSC 9 for known-capable
+//! terminals and falls back to native OS notifications on Unix; Windows
+//! falls back to `Off` to avoid the error chime (#583).
 
 #[cfg(target_os = "windows")]
 use windows::Win32::System::Diagnostics::Debug::MessageBeep;
@@ -17,19 +23,22 @@ use std::time::Duration;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum Method {
     /// Automatically pick `Osc9` for known capable terminals
-    /// (`iTerm.app`, `Ghostty`, `WezTerm`); fall back to `Bel` on
-    /// macOS / Linux. On Windows the fallback is `Off` instead of
-    /// `Bel`, because the OS audio stack maps `\x07` to the
-    /// `SystemAsterisk` / `MB_OK` chime — the same sound used by
-    /// application error popups (#583). Windows users who want an
-    /// audible cue can opt in by setting
-    /// `[notifications].method = "bel"` explicitly.
+    /// (`iTerm.app`, `Ghostty`, `WezTerm`, `Cmux`); on Unix, falls
+    /// back to native OS notifications (`osascript` / `notify-send`)
+    /// when the terminal doesn't advertise OSC 9 support. On Windows
+    /// the non-OSC-9 fallback is `Off` instead of `Bel`, because BEL
+    /// maps to the system error chime (#583).
     #[default]
     Auto,
     /// OSC 9 escape: `\x1b]9;<msg>\x07`
     Osc9,
     /// Plain BEL character: `\x07`
     Bel,
+    /// Native OS notification: `osascript display notification` on macOS,
+    /// `notify-send` on Linux. Works in any terminal — no OSC 9 support
+    /// required. Best-effort; falls back to `Bel` if the native command
+    /// is unavailable.
+    Native,
     /// Suppress all notifications.
     Off,
 }
@@ -49,14 +58,21 @@ fn windows_bell() {
     }
 }
 
-/// Resolve `Auto` to a concrete method by inspecting `$TERM_PROGRAM`.
+/// Resolve `Auto` to a concrete method by inspecting `$TERM_PROGRAM`
+/// with a `$TERM` fallback for Ghostty-based terminals.
 ///
-/// Known OSC-9 capable programs: `iTerm.app`, `Ghostty`, `WezTerm`
-/// (these resolve to `Osc9` on every platform, including Windows
-/// when running inside WezTerm).
+/// Known OSC-9 capable programs: `iTerm.app`, `Ghostty`, `WezTerm`,
+/// `Cmux` (these resolve to `Osc9` on every platform, including
+/// Windows when running inside WezTerm or Cmux).
+///
+/// When `$TERM_PROGRAM` is unrecognised, the `$TERM` variable is
+/// inspected for `xterm-ghostty` to catch Ghostty-based terminals
+/// (cmux, etc.) that may not set their own `TERM_PROGRAM` value.
 ///
 /// Otherwise the fallback is platform-dependent:
-/// - **macOS / Linux / other Unix:** `Bel` (a single `\x07` byte).
+/// - **macOS / Linux / other Unix:** `Native` — tries `osascript`
+///   (macOS) or `notify-send` (Linux) for a system notification.
+///   Falls back to `Bel` if the native command is unavailable.
 /// - **Windows:** `Off`. BEL is mapped by the Windows audio stack
 ///   to `SystemAsterisk` / `MB_OK`, the same chime used by
 ///   application error popups, so it sounds like an error
@@ -67,10 +83,128 @@ fn windows_bell() {
 fn resolve_method() -> Method {
     let term_program = std::env::var("TERM_PROGRAM").unwrap_or_default();
     match term_program.as_str() {
-        "iTerm.app" | "Ghostty" | "WezTerm" => Method::Osc9,
+        "iTerm.app" | "Ghostty" | "WezTerm" | "Cmux" => Method::Osc9,
         _ if cfg!(target_os = "windows") => Method::Off,
-        _ => Method::Bel,
+        _ => {
+            // Ghostty-based terminals (cmux, etc.) may not set their
+            // own TERM_PROGRAM but do set TERM=xterm-ghostty.
+            let term = std::env::var("TERM").unwrap_or_default();
+            if term.contains("ghostty") {
+                Method::Osc9
+            } else {
+                Method::Native
+            }
+        }
     }
+}
+
+/// Best-guess the macOS bundle identifier of the current terminal.
+///
+/// Maps known `$TERM_PROGRAM` values to their bundle IDs. When
+/// `TERM_PROGRAM` is unrecognised, falls back to a cached one-shot
+/// `osascript` probe that asks for the frontmost application's id.
+/// The result is memoised in a `OnceLock` so the probe runs at most
+/// once per process.
+#[cfg(target_os = "macos")]
+fn terminal_bundle_id() -> Option<&'static str> {
+    use std::sync::OnceLock;
+    static BUNDLE_ID: OnceLock<Option<String>> = OnceLock::new();
+    BUNDLE_ID
+        .get_or_init(|| {
+            let term_program = std::env::var("TERM_PROGRAM").unwrap_or_default();
+            match term_program.as_str() {
+                "iTerm.app" => Some("com.googlecode.iterm2".into()),
+                "Ghostty" => Some("com.mitchellh.ghostty".into()),
+                "Cmux" => Some("com.cmuxterm.app".into()),
+                "WezTerm" => Some("com.github.wez.wezterm".into()),
+                _ => {
+                    // Fallback: ask the window server which app is frontmost.
+                    let output = std::process::Command::new("osascript")
+                        .arg("-e")
+                        .arg("tell application \"System Events\" to get bundle identifier of first application process whose frontmost is true")
+                        .output()
+                        .ok()
+                        .and_then(|o| String::from_utf8(o.stdout).ok())
+                        .map(|s| s.trim().to_string())
+                        .filter(|s| !s.is_empty());
+                    output
+                }
+            }
+        })
+        .as_deref()
+}
+
+/// Check whether `terminal-notifier` is available on this system.
+#[cfg(target_os = "macos")]
+fn has_terminal_notifier() -> bool {
+    static CHECK: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *CHECK.get_or_init(|| {
+        std::process::Command::new("which")
+            .arg("terminal-notifier")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map_or(false, |s| s.success())
+    })
+}
+
+/// Fire a native OS notification.
+///
+/// On macOS, prefers `terminal-notifier` (supports click-to-focus via
+/// `-activate BUNDLE_ID`) with a fallback to `osascript display
+/// notification`. On Linux, uses `notify-send`.
+///
+/// Spawns a short-lived thread so the caller is not blocked on the
+/// process. Best-effort: failures from a missing binary or a
+/// non-responsive notification daemon are silently ignored — the
+/// notification is a convenience, not a correctness requirement.
+fn native_notify(msg: &str) {
+    let msg = msg.to_string();
+    std::thread::spawn(move || {
+        #[cfg(target_os = "macos")]
+        {
+            // terminal-notifier: clickable notification that can
+            // activate (bring-to-front) the terminal window.
+            if has_terminal_notifier() {
+                let mut cmd = std::process::Command::new("terminal-notifier");
+                cmd.arg("-title").arg("DeepSeek TUI");
+                cmd.arg("-message").arg(&msg);
+                if let Some(bundle_id) = terminal_bundle_id() {
+                    cmd.arg("-activate").arg(bundle_id);
+                }
+                cmd.stdout(std::process::Stdio::null());
+                cmd.stderr(std::process::Stdio::null());
+                let _ = cmd.spawn();
+                return;
+            }
+            // Fallback: plain osascript notification (no click-to-focus).
+            let _ = std::process::Command::new("osascript")
+                .arg("-e")
+                .arg(format!(
+                    "display notification \"{msg}\" with title \"DeepSeek TUI\""
+                ))
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .spawn();
+        }
+        #[cfg(all(target_os = "linux", not(target_os = "macos")))]
+        {
+            if std::process::Command::new("which")
+                .arg("notify-send")
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .status()
+                .map_or(false, |s| s.success())
+            {
+                let _ = std::process::Command::new("notify-send")
+                    .arg("DeepSeek TUI")
+                    .arg(&msg)
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
+                    .spawn();
+            }
+        }
+    });
 }
 
 /// Build the raw escape bytes for the given method and message.
@@ -94,7 +228,8 @@ fn build_escape(method: Method, in_tmux: bool, msg: &str) -> Vec<u8> {
             }
         }
         // Auto and Off should not reach build_escape.
-        Method::Auto | Method::Off => vec![],
+        // Native goes through native_notify(), not through bytes.
+        Method::Auto | Method::Off | Method::Native => vec![],
     }
 }
 
@@ -118,6 +253,11 @@ pub fn notify_done_to<W: Write>(
         Method::Auto => resolve_method(),
         other => other,
     };
+    // Native goes through the OS notification path, not terminal escapes.
+    if effective == Method::Native {
+        native_notify(msg);
+        return;
+    }
     let bytes = build_escape(effective, in_tmux, msg);
     if bytes.is_empty() {
         return;
@@ -138,8 +278,10 @@ pub fn notify_done_to<W: Write>(
 /// Emit a turn-complete notification to **stdout** if `elapsed >= threshold`.
 ///
 /// With `method = Auto`, selects `Osc9` for known capable terminals
-/// (`iTerm.app`, `Ghostty`, `WezTerm`); the unknown-terminal fallback is
-/// platform-aware — `Bel` on macOS / Linux, `Off` on Windows (where BEL
+/// (`iTerm.app`, `Ghostty`, `WezTerm`, `Cmux`, or any terminal with
+/// `TERM` containing `ghostty`); the unknown-terminal fallback is
+/// platform-aware — `Native` on macOS / Linux (system notification via
+/// `osascript` / `notify-send`), `Off` on Windows (where BEL
 /// maps to the `SystemAsterisk` / `MB_OK` error chime, #583). See
 /// [`resolve_method`] for the canonical resolution table. Pass
 /// `in_tmux = true` (i.e. `$TMUX` is non-empty at runtime) to wrap OSC 9
@@ -267,6 +409,14 @@ mod tests {
         assert!(out.is_empty());
     }
 
+    /// Native goes through `osascript` / `notify-send`, not terminal
+    /// escapes — the Write sink must stay empty.
+    #[test]
+    fn native_method_emits_no_terminal_bytes() {
+        let out = capture(Method::Native, false, "hello", 0, 1);
+        assert!(out.is_empty());
+    }
+
     #[test]
     fn below_threshold_emits_nothing() {
         let out = capture(Method::Osc9, false, "msg", 30, 29);
@@ -311,7 +461,7 @@ mod tests {
 
     #[test]
     #[cfg(not(target_os = "windows"))]
-    fn auto_detect_picks_bel_for_unknown_on_unix() {
+    fn auto_detect_picks_native_for_unknown_on_unix() {
         let _lock = env_lock();
         let prev = std::env::var_os("TERM_PROGRAM");
         // SAFETY: test-only; serialised by env_lock().
@@ -324,7 +474,7 @@ mod tests {
                 None => std::env::remove_var("TERM_PROGRAM"),
             }
         }
-        assert_eq!(resolved, Method::Bel);
+        assert_eq!(resolved, Method::Native);
     }
 
     /// #583: on Windows, an unknown TERM_PROGRAM resolves to `Off`
@@ -371,6 +521,84 @@ mod tests {
             }
         }
         assert_eq!(resolved, Method::Osc9);
+    }
+
+    /// Cmux (cmux.com) is a Ghostty-based macOS terminal that supports
+    /// OSC 9 natively. When it sets `TERM_PROGRAM=Cmux`, auto-detect
+    /// must resolve to `Osc9`.
+    #[test]
+    fn auto_detect_picks_osc9_for_cmux() {
+        let _lock = env_lock();
+        let prev_term_program = std::env::var_os("TERM_PROGRAM");
+        // SAFETY: test-only; serialised by env_lock().
+        unsafe { std::env::set_var("TERM_PROGRAM", "Cmux") };
+        let resolved = resolve_method();
+        // SAFETY: test-only; serialised by env_lock().
+        unsafe {
+            match prev_term_program {
+                Some(v) => std::env::set_var("TERM_PROGRAM", v),
+                None => std::env::remove_var("TERM_PROGRAM"),
+            }
+        }
+        assert_eq!(resolved, Method::Osc9);
+    }
+
+    /// Ghostty-based terminals (cmux, etc.) may not set
+    /// `TERM_PROGRAM` but do set `TERM=xterm-ghostty`. The `$TERM`
+    /// fallback should catch them.
+    #[test]
+    #[cfg(not(target_os = "windows"))]
+    fn auto_detect_picks_osc9_for_xterm_ghostty_term_fallback() {
+        let _lock = env_lock();
+        let prev_term_program = std::env::var_os("TERM_PROGRAM");
+        let prev_term = std::env::var_os("TERM");
+        // Simulate a Ghostty-based terminal that only sets TERM.
+        // SAFETY: test-only; serialised by env_lock().
+        unsafe {
+            std::env::remove_var("TERM_PROGRAM");
+            std::env::set_var("TERM", "xterm-ghostty");
+        }
+        let resolved = resolve_method();
+        // SAFETY: test-only; serialised by env_lock().
+        unsafe {
+            match prev_term_program {
+                Some(v) => std::env::set_var("TERM_PROGRAM", v),
+                None => std::env::remove_var("TERM_PROGRAM"),
+            }
+            match prev_term {
+                Some(v) => std::env::set_var("TERM", v),
+                None => std::env::remove_var("TERM"),
+            }
+        }
+        assert_eq!(resolved, Method::Osc9);
+    }
+
+    /// When neither `TERM_PROGRAM` nor `TERM` suggests an OSC-9 capable
+    /// terminal, the fallback on Unix is `Native`.
+    #[test]
+    #[cfg(not(target_os = "windows"))]
+    fn auto_detect_falls_back_to_native_for_unrelated_term() {
+        let _lock = env_lock();
+        let prev_term_program = std::env::var_os("TERM_PROGRAM");
+        let prev_term = std::env::var_os("TERM");
+        // SAFETY: test-only; serialised by env_lock().
+        unsafe {
+            std::env::remove_var("TERM_PROGRAM");
+            std::env::set_var("TERM", "xterm-256color");
+        }
+        let resolved = resolve_method();
+        // SAFETY: test-only; serialised by env_lock().
+        unsafe {
+            match prev_term_program {
+                Some(v) => std::env::set_var("TERM_PROGRAM", v),
+                None => std::env::remove_var("TERM_PROGRAM"),
+            }
+            match prev_term {
+                Some(v) => std::env::set_var("TERM", v),
+                None => std::env::remove_var("TERM"),
+            }
+        }
+        assert_eq!(resolved, Method::Native);
     }
 
     #[test]

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -3181,6 +3181,7 @@ fn notification_settings(
     let method = match notif.method {
         crate::config::NotificationMethod::Auto => crate::tui::notifications::Method::Auto,
         crate::config::NotificationMethod::Osc9 => crate::tui::notifications::Method::Osc9,
+        crate::config::NotificationMethod::Native => crate::tui::notifications::Method::Native,
         crate::config::NotificationMethod::Bel => crate::tui::notifications::Method::Bel,
         crate::config::NotificationMethod::Off => crate::tui::notifications::Method::Off,
     };

--- a/npm/deepseek-tui/package.json
+++ b/npm/deepseek-tui/package.json
@@ -40,6 +40,9 @@
     "access": "public"
   },
   "preferGlobal": true,
+  "optionalDependencies": {
+    "terminal-notifier": "^2.0.0"
+  },
   "files": [
     "bin/*.js",
     "scripts/*.js",

--- a/npm/deepseek-tui/scripts/run.js
+++ b/npm/deepseek-tui/scripts/run.js
@@ -1,4 +1,6 @@
 const { spawnSync } = require("child_process");
+const path = require("path");
+const fs = require("fs");
 const { getBinaryPath } = require("./install");
 
 const pkg = require("../package.json");
@@ -17,9 +19,31 @@ function handleVersionFallback(binaryName) {
   }
 }
 
+// On macOS, find the bundled terminal-notifier.app binary so the Rust
+// native_notify() code path can use it for click-to-focus notifications.
+// terminal-notifier is an optional dependency — if missing (e.g. Cargo
+// install), the Rust side falls back to plain osascript.
+function prependTerminalNotifierToPath() {
+  if (process.platform !== "darwin") return;
+  const candidates = [
+    // npm < 9 / older layout: binary lives in terminal-notifier/vendor/
+    path.resolve(__dirname, "..", "node_modules", "terminal-notifier", "vendor", "terminal-notifier.app", "Contents", "MacOS"),
+    // npm 9+ / workspaces flatten: .bin/ symlinks to terminal-notifier
+    path.resolve(__dirname, "..", "node_modules", ".bin"),
+  ];
+  for (const dir of candidates) {
+    if (fs.existsSync(dir)) {
+      process.env.PATH = `${dir}${path.delimiter}${process.env.PATH || ""}`;
+      return;
+    }
+  }
+}
+
 async function run(binaryName) {
   // Intercept --version before attempting binary download/launch
   handleVersionFallback(binaryName);
+
+  prependTerminalNotifierToPath();
 
   const binaryPath = await getBinaryPath(binaryName);
   const result = spawnSync(binaryPath, process.argv.slice(2), {


### PR DESCRIPTION
## Summary

Two changes:

### 1. Native OS notifications with Cmux support (#1281)

Replaces the Bel (beep) fallback in `method = "auto"` with native macOS/Linux notifications. Adds `Method::Native` that works in **any terminal**.

- macOS: `osascript display notification` (built-in, zero deps)
- Linux: `notify-send`
- Optional click-to-focus via `terminal-notifier` (auto-detected, bundled via npm)
- Bundle ID auto-detection for known terminals + osascript probe fallback

### 2. README security warning (#1286)

Fake repository distributing malware. Warning added to both READMEs.

## Testing

- `cargo check` passed, `cargo test` 18 tests pass
- Manual verification: native notifications fire on macOS Cmux