### PR TITLE
fix(settings): auto-enable low_motion in VS Code integrated terminal

### DIFF
--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -311,10 +311,9 @@ impl Settings {
         }
         // VS Code's integrated terminal sets TERM_PROGRAM=vscode. Its
         // compositor cannot keep up with 120 FPS redraws and produces rapid
-        // flickering (#1356). Drop to the 30 FPS low-motion cap automatically
-        // unless the user has explicitly opted out via `low_motion = false` in
-        // their settings file — honoured only when the file exists, otherwise
-        // the default (false) would suppress this useful auto-detection.
+        // flickering (#1356). Drop to the 30 FPS low-motion cap automatically.
+        // Like NO_ANIMATIONS above, this unconditionally overrides any
+        // disk-loaded value — consistent precedence: env signals always win.
         if std::env::var("TERM_PROGRAM").as_deref() == Ok("vscode") {
             self.low_motion = true;
             self.fancy_animations = false;

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -309,6 +309,16 @@ impl Settings {
             self.low_motion = true;
             self.fancy_animations = false;
         }
+        // VS Code's integrated terminal sets TERM_PROGRAM=vscode. Its
+        // compositor cannot keep up with 120 FPS redraws and produces rapid
+        // flickering (#1356). Drop to the 30 FPS low-motion cap automatically
+        // unless the user has explicitly opted out via `low_motion = false` in
+        // their settings file — honoured only when the file exists, otherwise
+        // the default (false) would suppress this useful auto-detection.
+        if std::env::var("TERM_PROGRAM").as_deref() == Ok("vscode") {
+            self.low_motion = true;
+            self.fancy_animations = false;
+        }
     }
 
     /// Save settings to disk
@@ -879,6 +889,65 @@ mod tests {
         // SAFETY: cleanup under the guard.
         unsafe {
             std::env::remove_var("NO_ANIMATIONS");
+        }
+    }
+
+    /// Serialise tests that mutate `TERM_PROGRAM` through this guard.
+    fn term_program_test_guard() -> std::sync::MutexGuard<'static, ()> {
+        static GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        GUARD.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    #[test]
+    fn vscode_term_program_forces_low_motion_on() {
+        let _g = term_program_test_guard();
+        let prev = std::env::var_os("TERM_PROGRAM");
+        // SAFETY: serialised by the guard.
+        unsafe {
+            std::env::set_var("TERM_PROGRAM", "vscode");
+        }
+        let mut settings = Settings::default();
+        assert!(!settings.low_motion, "default is animated");
+        settings.apply_env_overrides();
+        assert!(
+            settings.low_motion,
+            "TERM_PROGRAM=vscode must enable low_motion to prevent flickering (#1356)"
+        );
+        assert!(
+            !settings.fancy_animations,
+            "TERM_PROGRAM=vscode must disable fancy_animations"
+        );
+        // SAFETY: cleanup under the guard.
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("TERM_PROGRAM", v),
+                None => std::env::remove_var("TERM_PROGRAM"),
+            }
+        }
+    }
+
+    #[test]
+    fn non_vscode_term_program_does_not_force_low_motion() {
+        let _g = term_program_test_guard();
+        let prev = std::env::var_os("TERM_PROGRAM");
+        for program in ["iTerm.app", "Apple_Terminal", "WezTerm", "xterm-256color"] {
+            // SAFETY: serialised by the guard.
+            unsafe {
+                std::env::set_var("TERM_PROGRAM", program);
+            }
+            let mut s = Settings::default();
+            s.apply_env_overrides();
+            assert!(
+                !s.low_motion,
+                "TERM_PROGRAM={program:?} should not force low_motion"
+            );
+        }
+        // SAFETY: cleanup under the guard.
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("TERM_PROGRAM", v),
+                None => std::env::remove_var("TERM_PROGRAM"),
+            }
         }
     }
 


### PR DESCRIPTION
## What changed

- `crates/tui/src/settings.rs` — extended `apply_env_overrides()` to detect `TERM_PROGRAM=vscode` and enable `low_motion` + disable `fancy_animations`, matching the existing `NO_ANIMATIONS` env-override pattern.
- Two new tests: `vscode_term_program_forces_low_motion_on` and `non_vscode_term_program_does_not_force_low_motion`, using the same serialised-guard pattern as the existing `NO_ANIMATIONS` tests.

## Why

VS Code's integrated terminal sets `TERM_PROGRAM=vscode`. With the default 120 FPS draw cap, ratatui's diff-and-flush loop overwhelms the compositor on certain hardware (M4 Mac Mini reported in #1356), producing rapid flickering that doesn't occur in Terminal.app, iTerm2, or other CLIs in the same environment.

The `low_motion` path already caps draws at 30 FPS and suppresses animations. Activating it automatically for `TERM_PROGRAM=vscode` fixes the symptom with no user configuration required.

Note: #1361 (open) adds DEC 2026 synchronized-update escapes, which addresses the root rendering cause. These two fixes are complementary: synchronized updates ensure correct frames; the frame-rate reduction lowers CPU overhead during streaming independent of terminal DEC 2026 support. This PR does not conflict with #1361.

## How to verify

```bash
# In VS Code integrated terminal
TERM_PROGRAM=vscode cargo run -- --model auto
# Streaming output should be stable, no rapid flickering

# Confirm low_motion is active
cargo test -p deepseek-tui vscode_term_program_forces_low_motion_on
cargo test -p deepseek-tui non_vscode_term_program_does_not_force_low_motion
```

## Impact scope

- `crates/tui/src/settings.rs` only — one branch added to `apply_env_overrides()`.
- No change to the frame-rate limiter, renderer, or any other subsystem.
- All other terminals unaffected; `TERM_PROGRAM` check is an exact string match.

Fixes #1356