### PR TITLE
fix(ui): suppress duplicate error toast when turn error is in transcript

### DIFF
--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -679,6 +679,11 @@ pub struct App {
     pub is_loading: bool,
     /// Degraded connectivity mode; new user inputs are queued for later retry.
     pub offline_mode: bool,
+    /// Whether an `EngineEvent::Error` has already been posted for the
+    /// current turn. Suppresses the redundant "Turn failed:" status line
+    /// that `TurnComplete { error: .. }` would otherwise emit on top of
+    /// the in-transcript error cell.
+    pub turn_error_posted: bool,
     /// Legacy status text sink retained for compatibility with existing call sites.
     pub status_message: Option<String>,
     /// Recent status toasts (ephemeral, newest at back).
@@ -1289,6 +1294,7 @@ impl App {
             api_messages: Vec::new(),
             is_loading: false,
             offline_mode: false,
+            turn_error_posted: false,
             status_message: None,
             status_toasts: VecDeque::new(),
             sticky_status: None,

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -845,6 +845,7 @@ async fn run_event_loop(
                     EngineEvent::TurnStarted { turn_id } => {
                         app.is_loading = true;
                         app.offline_mode = false;
+                        app.turn_error_posted = false;
                         app.dispatch_started_at = None;
                         current_streaming_text.clear();
                         app.streaming_state.reset();
@@ -941,7 +942,14 @@ async fn run_event_loop(
                             recorded_at: Instant::now(),
                         });
                         if let Some(error) = error {
-                            app.status_message = Some(format!("Turn failed: {error}"));
+                            // Only show "Turn failed:" in the composer status
+                            // area when an EngineEvent::Error has NOT already
+                            // posted the same message into the transcript.
+                            // Otherwise the error appears twice: once in a
+                            // HistoryCell and again as a redundant status line.
+                            if !app.turn_error_posted {
+                                app.status_message = Some(format!("Turn failed: {error}"));
+                            }
                         }
 
                         // Update session cost
@@ -3172,6 +3180,7 @@ pub(crate) fn apply_engine_error_to_app(
     });
     app.is_loading = false;
     app.dispatch_started_at = None;
+    app.turn_error_posted = true;
     if matches!(
         envelope.category,
         crate::error_taxonomy::ErrorCategory::Authentication
@@ -3185,14 +3194,12 @@ pub(crate) fn apply_engine_error_to_app(
         );
         return;
     }
-    if recoverable {
-        app.status_message = Some(format!("Connection interrupted: {message}"));
-    } else {
+    if !recoverable {
         app.offline_mode = true;
-        app.status_message = Some(format!(
-            "Engine error; queued messages stay pending: {message}"
-        ));
     }
+    // Error is already in the transcript as HistoryCell::Error above;
+    // don't emit a redundant status_message that would become a sticky
+    // toast in the footer — that duplicates the transcript entry.
 }
 
 fn persist_offline_queue_state(app: &App) {

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -3865,13 +3865,10 @@ fn recoverable_engine_error_does_not_enter_offline_mode() {
         "recoverable error must keep the session online so the user can retry"
     );
     assert!(!app.is_loading);
-    let status = app
-        .status_message
-        .as_deref()
-        .expect("recoverable errors must set a status message");
+    assert!(app.turn_error_posted, "turn_error_posted must be set");
     assert!(
-        status.starts_with("Connection interrupted"),
-        "expected interrupt-style status, got {status:?}"
+        app.status_message.is_none(),
+        "recoverable error should NOT set status_message — already in transcript as HistoryCell::Error"
     );
 
     // Sanity: the rendered cell is the categorized Error variant, not a plain System note.
@@ -3905,13 +3902,10 @@ fn non_recoverable_engine_error_enters_offline_mode() {
         "non-recoverable error must enter offline mode"
     );
     assert!(!app.is_loading);
-    let status = app
-        .status_message
-        .as_deref()
-        .expect("non-recoverable errors must set a status message");
+    assert!(app.turn_error_posted, "turn_error_posted must be set");
     assert!(
-        status.starts_with("Engine error"),
-        "expected engine-error status, got {status:?}"
+        app.status_message.is_none(),
+        "non-recoverable error should NOT set status_message — already in transcript as HistoryCell::Error"
     );
 }
 
@@ -3935,6 +3929,7 @@ fn env_only_auth_failure_reopens_api_key_onboarding() {
         "env-only auth failures should prompt for a saved config key"
     );
     assert!(app.onboarding_needs_api_key);
+    assert!(app.turn_error_posted, "turn_error_posted must be set");
     let status = app
         .status_message
         .as_deref()


### PR DESCRIPTION
## Problem

When an engine error occurs (e.g. `Refusing insecure base URL`), the same error message appears twice:
1. Once in the transcript as `HistoryCell::Error` (permanent)
2. Once as a sticky toast in the footer/composer area (TTL 15s, then auto-dismisses)

The duplicate comes from `apply_engine_error_to_app` setting `status_message`, which `sync_status_message_to_toasts()` converts into a sticky toast because the text contains "error" or "failed".

## Fix

Add `turn_error_posted` flag to `App`:
- Set to `true` in `apply_engine_error_to_app` after the error is posted to the transcript
- Reset to `false` on `TurnStarted`
- Both `TurnComplete` error handler and `apply_engine_error_to_app` skip setting `status_message` when the flag is set

The auth+env_only onboarding path in `apply_engine_error_to_app` retains its `status_message` since that flow relies on it to prompt the user for a saved API key.

## Changed files

- `crates/tui/src/tui/app.rs` — add `turn_error_posted` field + init
- `crates/tui/src/tui/ui.rs` — flag lifecycle + suppress duplicate status_message
- `crates/tui/src/tui/ui/tests.rs` — update error handling tests

before:

<img width="3807" height="314" alt="image" src="https://github.com/user-attachments/assets/27e35600-fdbb-418c-ab2d-b29f2402b5fc" />

after:

<img width="3818" height="279" alt="image" src="https://github.com/user-attachments/assets/61c5a6cb-a477-4761-bdff-3178b1c453ba" />
