### PR TITLE
  Support mutable submit hooks and turn-end hooks

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -447,11 +447,23 @@ default_text_model = "deepseek-ai/deepseek-v4-pro"
 # ─────────────────────────────────────────────────────────────────────────────────
 # Hooks (optional)
 # ─────────────────────────────────────────────────────────────────────────────────
-# Hooks run shell commands on lifecycle events (session start/end, tool calls, etc.).
+# Hooks run shell commands on lifecycle events (session start/end, user submit,
+# turn end, tool calls, etc.).
 # Configure as `[[hooks.hooks]]` under a `[hooks]` table.
 #
-# Available events: session_start, session_end, message_submit,
+# Available events: session_start, session_end, message_submit, turn_end,
 # tool_call_before, tool_call_after, mode_change, on_error, shell_env.
+#
+# `message_submit` runs before a user message is sent. Hooks receive the current
+# context as JSON on stdin and compatibility env vars such as DEEPSEEK_MESSAGE.
+# Exit 0 with stdout JSON `{"text":"replacement"}` to replace the submitted
+# text. Exit 2 to block the submission; stdout JSON `{"reason":"..."}` or
+# stderr's first line is shown to the user. Empty/non-JSON stdout keeps the
+# original text, preserving observer-only hooks.
+#
+# `turn_end` runs after a turn completes and the TUI returns to idle. It receives
+# turn metadata as JSON on stdin plus env vars such as DEEPSEEK_TURN_STATUS and
+# DEEPSEEK_TURN_DURATION_MS. Prefer `background = true` for long-running hooks.
 #
 # `shell_env` (#456) is special: the hook runs immediately before each
 # `exec_shell` invocation and its stdout is parsed as `KEY=VALUE\n` lines.
@@ -469,6 +481,15 @@ default_text_model = "deepseek-ai/deepseek-v4-pro"
 # [[hooks.hooks]]
 # event = "session_start"
 # command = "echo 'DeepSeek TUI session started'"
+#
+# [[hooks.hooks]]
+# event = "message_submit"
+# command = "~/.deepseek/hooks/enrich-message"
+#
+# [[hooks.hooks]]
+# event = "turn_end"
+# command = "~/.deepseek/hooks/after-turn"
+# background = true
 #
 # # Inject ephemeral creds into every shell call. Output one
 # # KEY=VALUE per line on stdout (export prefix optional).

--- a/crates/tui/src/commands/hooks.rs
+++ b/crates/tui/src/commands/hooks.rs
@@ -45,7 +45,11 @@ fn events() -> CommandResult {
         (HookEvent::SessionEnd, "fires once on graceful shutdown"),
         (
             HookEvent::MessageSubmit,
-            "fires when the user submits a turn (before model dispatch)",
+            "fires when the user submits a turn; stdout JSON `{ \"text\": \"...\" }` may replace it, exit 2 blocks",
+        ),
+        (
+            HookEvent::TurnEnd,
+            "fires when the model turn completes and the TUI returns to idle",
         ),
         (
             HookEvent::ToolCallBefore,
@@ -134,6 +138,7 @@ fn event_label(event: HookEvent) -> &'static str {
         HookEvent::SessionStart => "session_start",
         HookEvent::SessionEnd => "session_end",
         HookEvent::MessageSubmit => "message_submit",
+        HookEvent::TurnEnd => "turn_end",
         HookEvent::ToolCallBefore => "tool_call_before",
         HookEvent::ToolCallAfter => "tool_call_after",
         HookEvent::ModeChange => "mode_change",
@@ -257,6 +262,7 @@ mod tests {
             "session_start",
             "session_end",
             "message_submit",
+            "turn_end",
             "tool_call_before",
             "tool_call_after",
             "mode_change",
@@ -296,6 +302,7 @@ mod tests {
         assert_eq!(event_label(HookEvent::ToolCallBefore), "tool_call_before");
         assert_eq!(event_label(HookEvent::ToolCallAfter), "tool_call_after");
         assert_eq!(event_label(HookEvent::MessageSubmit), "message_submit");
+        assert_eq!(event_label(HookEvent::TurnEnd), "turn_end");
         assert_eq!(event_label(HookEvent::ModeChange), "mode_change");
         assert_eq!(event_label(HookEvent::OnError), "on_error");
     }

--- a/crates/tui/src/hooks.rs
+++ b/crates/tui/src/hooks.rs
@@ -14,8 +14,9 @@
 #[allow(unused_imports)]
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 use std::collections::HashMap;
-use std::io::Read;
+use std::io::{Read, Write};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
@@ -31,6 +32,8 @@ pub enum HookEvent {
     SessionEnd,
     /// Triggered before a user message is sent to the LLM
     MessageSubmit,
+    /// Triggered when a model turn completes and the TUI returns to idle
+    TurnEnd,
     /// Triggered before a tool is executed
     ToolCallBefore,
     /// Triggered after a tool completes (success or failure)
@@ -56,6 +59,7 @@ impl HookEvent {
             HookEvent::SessionStart => "session_start",
             HookEvent::SessionEnd => "session_end",
             HookEvent::MessageSubmit => "message_submit",
+            HookEvent::TurnEnd => "turn_end",
             HookEvent::ToolCallBefore => "tool_call_before",
             HookEvent::ToolCallAfter => "tool_call_after",
             HookEvent::ModeChange => "mode_change",
@@ -251,6 +255,10 @@ pub struct HookContext {
     pub total_tokens: Option<u32>,
     /// Session cost in USD
     pub session_cost: Option<f64>,
+    /// Final turn status (for `TurnEnd`)
+    pub turn_status: Option<String>,
+    /// Turn duration in milliseconds (for `TurnEnd`)
+    pub turn_duration_ms: Option<u64>,
 }
 
 impl HookContext {
@@ -328,6 +336,38 @@ impl HookContext {
         self
     }
 
+    pub fn with_turn_status(mut self, status: &str) -> Self {
+        self.turn_status = Some(status.to_string());
+        self
+    }
+
+    pub fn with_turn_duration_ms(mut self, duration_ms: u64) -> Self {
+        self.turn_duration_ms = Some(duration_ms);
+        self
+    }
+
+    pub fn to_json_payload(&self, event: HookEvent) -> serde_json::Value {
+        json!({
+            "event": event.as_str(),
+            "tool_name": self.tool_name,
+            "tool_args": self.tool_args,
+            "tool_result": self.tool_result,
+            "tool_exit_code": self.tool_exit_code,
+            "tool_success": self.tool_success,
+            "mode": self.mode,
+            "previous_mode": self.previous_mode,
+            "session_id": self.session_id,
+            "message": self.message,
+            "error": self.error_message,
+            "workspace": self.workspace.as_ref().map(|path| path.display().to_string()),
+            "model": self.model,
+            "total_tokens": self.total_tokens,
+            "session_cost": self.session_cost,
+            "turn_status": self.turn_status,
+            "turn_duration_ms": self.turn_duration_ms,
+        })
+    }
+
     /// Convert to environment variables
     pub fn to_env_vars(&self) -> HashMap<String, String> {
         let mut env = HashMap::new();
@@ -398,9 +438,24 @@ impl HookContext {
         if let Some(cost) = self.session_cost {
             env.insert("DEEPSEEK_SESSION_COST".to_string(), format!("{cost:.6}"));
         }
+        if let Some(ref status) = self.turn_status {
+            env.insert("DEEPSEEK_TURN_STATUS".to_string(), status.clone());
+        }
+        if let Some(duration_ms) = self.turn_duration_ms {
+            env.insert(
+                "DEEPSEEK_TURN_DURATION_MS".to_string(),
+                duration_ms.to_string(),
+            );
+        }
 
         env
     }
+}
+
+#[derive(Debug, Clone)]
+pub enum MessageSubmitOutcome {
+    Continue { text: String },
+    Block { reason: String },
 }
 
 /// Result of a hook execution
@@ -557,6 +612,85 @@ impl HookExecutor {
 
     /// Execute all hooks for an event
     pub fn execute(&self, event: HookEvent, context: &HookContext) -> Vec<HookResult> {
+        self.execute_with_optional_stdin(event, context, None)
+    }
+
+    /// Execute hooks with a JSON stdin payload. The payload is additive:
+    /// existing environment variables stay populated for compatibility.
+    pub fn execute_json(
+        &self,
+        event: HookEvent,
+        context: &HookContext,
+        payload: &serde_json::Value,
+    ) -> Vec<HookResult> {
+        let stdin = serde_json::to_string(payload).unwrap_or_else(|_| "{}".to_string());
+        self.execute_with_optional_stdin(event, context, Some(&stdin))
+    }
+
+    pub fn execute_message_submit(
+        &self,
+        context: &HookContext,
+        original_text: &str,
+    ) -> MessageSubmitOutcome {
+        if !self.config.enabled {
+            return MessageSubmitOutcome::Continue {
+                text: original_text.to_string(),
+            };
+        }
+
+        let hooks = self.config.hooks_for_event(HookEvent::MessageSubmit);
+        if hooks.is_empty() {
+            return MessageSubmitOutcome::Continue {
+                text: original_text.to_string(),
+            };
+        }
+
+        let mut current_text = original_text.to_string();
+
+        for hook in hooks {
+            if !self.matches_condition(hook, context) {
+                continue;
+            }
+
+            let hook_context = context.clone().with_message(&current_text);
+            let env_vars = hook_context.to_env_vars();
+            let mut payload = hook_context.to_json_payload(HookEvent::MessageSubmit);
+            if let Some(obj) = payload.as_object_mut() {
+                obj.insert("text".to_string(), json!(current_text));
+            }
+            let stdin = serde_json::to_string(&payload).unwrap_or_else(|_| "{}".to_string());
+            let result = if hook.background {
+                self.execute_background_with_stdin(hook, &env_vars, Some(stdin))
+            } else {
+                self.execute_sync_with_stdin(hook, &env_vars, Some(&stdin))
+            };
+
+            if result.exit_code == Some(2) {
+                let reason = message_submit_block_reason(&result);
+                return MessageSubmitOutcome::Block { reason };
+            }
+
+            if !result.success {
+                self.log_hook_failure(HookEvent::MessageSubmit, &result);
+            } else if let Some(text) = message_submit_text_from_stdout(&result.stdout) {
+                current_text = text;
+            }
+
+            let should_continue = result.success || hook.continue_on_error;
+            if !should_continue {
+                break;
+            }
+        }
+
+        MessageSubmitOutcome::Continue { text: current_text }
+    }
+
+    fn execute_with_optional_stdin(
+        &self,
+        event: HookEvent,
+        context: &HookContext,
+        stdin: Option<&str>,
+    ) -> Vec<HookResult> {
         if !self.config.enabled {
             return Vec::new();
         }
@@ -579,9 +713,13 @@ impl HookExecutor {
             }
 
             let result = if hook.background {
-                self.execute_background(hook, &env_vars)
+                self.execute_background_with_stdin(
+                    hook,
+                    &env_vars,
+                    stdin.map(std::string::ToString::to_string),
+                )
             } else {
-                self.execute_sync(hook, &env_vars)
+                self.execute_sync_with_stdin(hook, &env_vars, stdin)
             };
 
             // Log failures via tracing so operators tailing
@@ -589,17 +727,7 @@ impl HookExecutor {
             // without instrumenting each call site. Successful runs
             // log nothing (would be too noisy on per-tool events).
             if !result.success {
-                let label = result.name.as_deref().unwrap_or("(unnamed)");
-                tracing::warn!(
-                    target: "hooks",
-                    hook = label,
-                    event = event.as_str(),
-                    exit_code = ?result.exit_code,
-                    duration_ms = result.duration.as_millis() as u64,
-                    error = result.error.as_deref().unwrap_or(""),
-                    stderr_head = %result.stderr.lines().next().unwrap_or(""),
-                    "hook failed"
-                );
+                self.log_hook_failure(event, &result);
             }
 
             let should_continue = result.success || hook.continue_on_error;
@@ -611,6 +739,20 @@ impl HookExecutor {
         }
 
         results
+    }
+
+    fn log_hook_failure(&self, event: HookEvent, result: &HookResult) {
+        let label = result.name.as_deref().unwrap_or("(unnamed)");
+        tracing::warn!(
+            target: "hooks",
+            hook = label,
+            event = event.as_str(),
+            exit_code = ?result.exit_code,
+            duration_ms = result.duration.as_millis() as u64,
+            error = result.error.as_deref().unwrap_or(""),
+            stderr_head = %result.stderr.lines().next().unwrap_or(""),
+            "hook failed"
+        );
     }
 
     /// Check if a hook's condition matches the context
@@ -659,6 +801,15 @@ impl HookExecutor {
 
     /// Execute a hook synchronously
     fn execute_sync(&self, hook: &Hook, env_vars: &HashMap<String, String>) -> HookResult {
+        self.execute_sync_with_stdin(hook, env_vars, None)
+    }
+
+    fn execute_sync_with_stdin(
+        &self,
+        hook: &Hook,
+        env_vars: &HashMap<String, String>,
+        stdin_payload: Option<&str>,
+    ) -> HookResult {
         let started = Instant::now();
         let working_dir = self
             .config
@@ -672,13 +823,17 @@ impl HookExecutor {
             .unwrap_or(hook.timeout_secs);
         let timeout = Duration::from_secs(timeout_secs);
 
-        let mut child = match Self::build_shell_command(&hook.command)
+        let mut command = Self::build_shell_command(&hook.command);
+        command
             .current_dir(&working_dir)
             .envs(env_vars)
             .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-        {
+            .stderr(Stdio::piped());
+        if stdin_payload.is_some() {
+            command.stdin(Stdio::piped());
+        }
+
+        let mut child = match command.spawn() {
             Ok(child) => child,
             Err(e) => {
                 return HookResult {
@@ -692,6 +847,12 @@ impl HookExecutor {
                 };
             }
         };
+
+        if let Some(payload) = stdin_payload
+            && let Some(mut stdin) = child.stdin.take()
+        {
+            let _ = stdin.write_all(payload.as_bytes());
+        }
 
         fn read_pipe(mut pipe: impl Read) -> String {
             let mut buf = String::new();
@@ -734,8 +895,12 @@ impl HookExecutor {
         }
     }
 
-    /// Execute a hook in the background (non-blocking)
-    fn execute_background(&self, hook: &Hook, env_vars: &HashMap<String, String>) -> HookResult {
+    fn execute_background_with_stdin(
+        &self,
+        hook: &Hook,
+        env_vars: &HashMap<String, String>,
+        stdin_payload: Option<String>,
+    ) -> HookResult {
         let started = Instant::now();
         let working_dir = self
             .config
@@ -749,10 +914,24 @@ impl HookExecutor {
 
         // Spawn in a detached thread
         std::thread::spawn(move || {
-            let _ = HookExecutor::build_shell_command(&cmd)
+            let mut command = HookExecutor::build_shell_command(&cmd);
+            command
                 .current_dir(&wd)
                 .envs(&env)
-                .output();
+                .stdout(Stdio::null())
+                .stderr(Stdio::null());
+            if stdin_payload.is_some() {
+                command.stdin(Stdio::piped());
+            }
+            let Ok(mut child) = command.spawn() else {
+                return;
+            };
+            if let Some(payload) = stdin_payload
+                && let Some(mut stdin) = child.stdin.take()
+            {
+                let _ = stdin.write_all(payload.as_bytes());
+            }
+            let _ = child.wait();
         });
 
         // Return immediately with success (background execution is fire-and-forget)
@@ -766,6 +945,36 @@ impl HookExecutor {
             error: None,
         }
     }
+}
+
+fn message_submit_text_from_stdout(stdout: &str) -> Option<String> {
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let value: serde_json::Value = serde_json::from_str(trimmed).ok()?;
+    value
+        .get("text")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+}
+
+fn message_submit_block_reason(result: &HookResult) -> String {
+    let trimmed = result.stdout.trim();
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(trimmed)
+        && let Some(reason) = value
+            .get("reason")
+            .or_else(|| value.get("message"))
+            .and_then(serde_json::Value::as_str)
+        && !reason.trim().is_empty()
+    {
+        return reason.to_string();
+    }
+    let stderr_head = result.stderr.lines().next().unwrap_or("").trim();
+    if !stderr_head.is_empty() {
+        return stderr_head.to_string();
+    }
+    "message_submit hook blocked the submission".to_string()
 }
 
 /// Parse `KEY=VALUE\n` lines from a `shell_env` hook's stdout into a map.
@@ -853,6 +1062,8 @@ NOEQUAL line dropped
     #[test]
     fn test_hook_event_as_str() {
         assert_eq!(HookEvent::SessionStart.as_str(), "session_start");
+        assert_eq!(HookEvent::MessageSubmit.as_str(), "message_submit");
+        assert_eq!(HookEvent::TurnEnd.as_str(), "turn_end");
         assert_eq!(HookEvent::ToolCallAfter.as_str(), "tool_call_after");
         assert_eq!(HookEvent::ModeChange.as_str(), "mode_change");
     }
@@ -1003,6 +1214,7 @@ NOEQUAL line dropped
             HookEvent::SessionStart,
             HookEvent::SessionEnd,
             HookEvent::MessageSubmit,
+            HookEvent::TurnEnd,
             HookEvent::ToolCallBefore,
             HookEvent::ToolCallAfter,
             HookEvent::ModeChange,
@@ -1047,5 +1259,103 @@ NOEQUAL line dropped
         assert!(!executor.has_hooks_for_event(HookEvent::ToolCallAfter));
         assert!(!executor.has_hooks_for_event(HookEvent::OnError));
         assert!(!executor.has_hooks_for_event(HookEvent::ModeChange));
+    }
+
+    #[cfg(not(windows))]
+    fn shell_quote(input: &str) -> String {
+        format!("'{}'", input.replace('\'', "'\"'\"'"))
+    }
+
+    #[cfg(not(windows))]
+    fn printf_command(output: &str) -> String {
+        format!("printf %s {}", shell_quote(output))
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn message_submit_hook_replaces_text_from_json_stdout() {
+        let command = printf_command(r#"{"text":"changed"}"#);
+        let config = HooksConfig {
+            enabled: true,
+            hooks: vec![Hook::new(HookEvent::MessageSubmit, &command)],
+            ..HooksConfig::default()
+        };
+        let executor = HookExecutor::new(config, PathBuf::from("."));
+        let context = HookContext::new().with_message("original");
+
+        let outcome = executor.execute_message_submit(&context, "original");
+
+        match outcome {
+            MessageSubmitOutcome::Continue { text } => assert_eq!(text, "changed"),
+            MessageSubmitOutcome::Block { reason, .. } => {
+                panic!("unexpected block: {reason}");
+            }
+        }
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn message_submit_hook_blocks_on_exit_two() {
+        let command = format!("{}; exit 2", printf_command(r#"{"reason":"nope"}"#));
+        let config = HooksConfig {
+            enabled: true,
+            hooks: vec![Hook::new(HookEvent::MessageSubmit, &command)],
+            ..HooksConfig::default()
+        };
+        let executor = HookExecutor::new(config, PathBuf::from("."));
+        let context = HookContext::new().with_message("original");
+
+        let outcome = executor.execute_message_submit(&context, "original");
+
+        match outcome {
+            MessageSubmitOutcome::Block { reason } => assert_eq!(reason, "nope"),
+            MessageSubmitOutcome::Continue { text, .. } => {
+                panic!("unexpected continue: {text}");
+            }
+        }
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn message_submit_hook_preserves_text_for_legacy_stdout() {
+        let command = printf_command("legacy observer output");
+        let config = HooksConfig {
+            enabled: true,
+            hooks: vec![Hook::new(HookEvent::MessageSubmit, &command)],
+            ..HooksConfig::default()
+        };
+        let executor = HookExecutor::new(config, PathBuf::from("."));
+        let context = HookContext::new().with_message("original");
+
+        let outcome = executor.execute_message_submit(&context, "original");
+
+        match outcome {
+            MessageSubmitOutcome::Continue { text, .. } => assert_eq!(text, "original"),
+            MessageSubmitOutcome::Block { reason, .. } => {
+                panic!("unexpected block: {reason}");
+            }
+        }
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn json_hook_stdin_contains_event_context() {
+        let command = "grep -q '\"event\":\"turn_end\"' && printf %s ok";
+        let config = HooksConfig {
+            enabled: true,
+            hooks: vec![Hook::new(HookEvent::TurnEnd, command)],
+            ..HooksConfig::default()
+        };
+        let executor = HookExecutor::new(config, PathBuf::from("."));
+        let context = HookContext::new()
+            .with_turn_status("completed")
+            .with_turn_duration_ms(123);
+        let payload = context.to_json_payload(HookEvent::TurnEnd);
+
+        let results = executor.execute_json(HookEvent::TurnEnd, &context, &payload);
+
+        assert_eq!(results.len(), 1);
+        assert!(results[0].success);
+        assert_eq!(results[0].stdout, "ok");
     }
 }

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -39,7 +39,7 @@ use crate::core::coherence::CoherenceState;
 use crate::core::engine::{EngineConfig, EngineHandle, spawn_engine};
 use crate::core::events::Event as EngineEvent;
 use crate::core::ops::Op;
-use crate::hooks::HookEvent;
+use crate::hooks::{HookEvent, MessageSubmitOutcome};
 use crate::llm_client::LlmClient;
 use crate::models::{
     ContentBlock, Message, MessageRequest, SystemPrompt, Usage, context_window_for_model,
@@ -940,7 +940,7 @@ async fn run_event_loop(
                             reasoning_replay_tokens: usage.reasoning_replay_tokens,
                             recorded_at: Instant::now(),
                         });
-                        if let Some(error) = error {
+                        if let Some(error) = error.as_deref() {
                             app.status_message = Some(format!("Turn failed: {error}"));
                         }
 
@@ -957,6 +957,8 @@ async fn run_event_loop(
                         if let Some(cost) = turn_cost {
                             app.accrue_session_cost_estimate(cost);
                         }
+
+                        execute_turn_end_hooks(app, &usage, status, error.as_deref(), turn_elapsed);
 
                         // Emit OSC 9 / BEL desktop notification for long turns.
                         if status == crate::core::events::TurnOutcomeStatus::Completed
@@ -3755,19 +3757,29 @@ async fn dispatch_user_message(
     app: &mut App,
     config: &Config,
     engine_handle: &EngineHandle,
-    message: QueuedMessage,
+    mut message: QueuedMessage,
 ) -> Result<()> {
-    // #455 (observer-only): fire `message_submit` hooks before
-    // dispatch. Hooks see the user's display text via the
-    // `with_message` builder. Read-only — they can log, audit, or
-    // notify but cannot mutate the message that goes to the engine.
-    // Fast-path skip when no hooks configured.
+    // Fire `message_submit` before dispatch. Synchronous hooks may return
+    // `{"text":"..."}` on stdout to replace the message, or exit 2 to block.
+    // Non-JSON stdout preserves the old observer-only behavior.
     if app
         .hooks
         .has_hooks_for_event(crate::hooks::HookEvent::MessageSubmit)
     {
         let context = app.base_hook_context().with_message(&message.display);
-        let _ = app.execute_hooks(crate::hooks::HookEvent::MessageSubmit, &context);
+        match app.hooks.execute_message_submit(&context, &message.display) {
+            MessageSubmitOutcome::Continue { text, .. } => {
+                message.display = text;
+            }
+            MessageSubmitOutcome::Block { reason, .. } => {
+                restore_blocked_message_to_composer(app, &message.display);
+                app.status_message = Some(format!("Submission blocked by hook: {reason}"));
+                app.is_loading = false;
+                app.dispatch_started_at = None;
+                app.last_send_at = None;
+                return Ok(());
+            }
+        }
     }
 
     // Set immediately to prevent double-dispatch before TurnStarted event arrives.
@@ -3899,6 +3911,58 @@ async fn dispatch_user_message(
     }
 
     Ok(())
+}
+
+fn restore_blocked_message_to_composer(app: &mut App, message: &str) {
+    if app.input.trim().is_empty() {
+        app.input = message.to_string();
+        app.cursor_position = app.input.chars().count();
+        app.selected_attachment_index = None;
+        app.needs_redraw = true;
+    }
+}
+
+fn execute_turn_end_hooks(
+    app: &App,
+    usage: &Usage,
+    status: crate::core::events::TurnOutcomeStatus,
+    error: Option<&str>,
+    turn_elapsed: Duration,
+) {
+    if !app.hooks.has_hooks_for_event(HookEvent::TurnEnd) {
+        return;
+    }
+
+    let status_label = match status {
+        crate::core::events::TurnOutcomeStatus::Completed => "completed",
+        crate::core::events::TurnOutcomeStatus::Interrupted => "interrupted",
+        crate::core::events::TurnOutcomeStatus::Failed => "failed",
+    };
+    let duration_ms = u64::try_from(turn_elapsed.as_millis()).unwrap_or(u64::MAX);
+    let mut context = app
+        .base_hook_context()
+        .with_turn_status(status_label)
+        .with_turn_duration_ms(duration_ms)
+        .with_cost(app.session.session_cost + app.session.subagent_cost);
+    if let Some(error) = error {
+        context = context.with_error(error);
+    }
+    let mut payload = context.to_json_payload(HookEvent::TurnEnd);
+    if let Some(obj) = payload.as_object_mut() {
+        obj.insert(
+            "usage".to_string(),
+            serde_json::json!({
+                "input_tokens": usage.input_tokens,
+                "output_tokens": usage.output_tokens,
+                "prompt_cache_hit_tokens": usage.prompt_cache_hit_tokens,
+                "prompt_cache_miss_tokens": usage.prompt_cache_miss_tokens,
+                "reasoning_replay_tokens": usage.reasoning_replay_tokens,
+            }),
+        );
+    }
+    let _ = app
+        .hooks
+        .execute_json(HookEvent::TurnEnd, &context, &payload);
 }
 
 fn should_resolve_auto_model_selection(app: &App) -> bool {

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::config::{ApiProvider, Config};
 use crate::config_ui::{self, WebConfigSession, WebConfigSessionEvent};
 use crate::core::engine::mock_engine_handle;
+use crate::hooks::{Hook, HookEvent, HookExecutor, HooksConfig};
 use crate::tui::file_mention::{
     apply_mention_menu_selection, find_file_mention_completions, partial_file_mention_at_cursor,
     try_autocomplete_file_mention, user_request_with_file_mentions, visible_mention_menu_entries,
@@ -15,6 +16,16 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::time::{Duration, Instant};
 use tempfile::TempDir;
+
+#[cfg(not(windows))]
+fn shell_quote(input: &str) -> String {
+    format!("'{}'", input.replace('\'', "'\"'\"'"))
+}
+
+#[cfg(not(windows))]
+fn printf_command(output: &str) -> String {
+    format!("printf %s {}", shell_quote(output))
+}
 
 #[test]
 fn format_resume_hint_uses_canonical_resume_command() {
@@ -2385,6 +2396,100 @@ async fn dismissed_plan_prompt_leaves_non_numeric_input_for_normal_send_path() {
         app.status_message.as_deref(),
         Some("Offline: 1 queued — ↑ to edit, /queue list")
     );
+}
+
+#[cfg(not(windows))]
+#[tokio::test]
+async fn message_submit_hook_mutates_dispatched_content() {
+    let mut app = create_test_app();
+    let command = printf_command(r#"{"text":"changed by hook"}"#);
+    app.hooks = HookExecutor::new(
+        HooksConfig {
+            enabled: true,
+            hooks: vec![Hook::new(HookEvent::MessageSubmit, &command)],
+            ..HooksConfig::default()
+        },
+        app.workspace.clone(),
+    );
+    let mut engine = mock_engine_handle();
+    let config = Config::default();
+
+    let queued = build_queued_message(&mut app, "original".to_string());
+    submit_or_steer_message(&mut app, &config, &engine.handle, queued)
+        .await
+        .expect("submit");
+
+    let op = engine.rx_op.recv().await.expect("send op");
+    match op {
+        Op::SendMessage { content, .. } => assert_eq!(content, "changed by hook"),
+        other => panic!("expected SendMessage, got {other:?}"),
+    }
+}
+
+#[cfg(not(windows))]
+#[tokio::test]
+async fn message_submit_hook_exit_two_blocks_submission_and_restores_input() {
+    let mut app = create_test_app();
+    let command = format!("{}; exit 2", printf_command(r#"{"reason":"blocked"}"#));
+    app.hooks = HookExecutor::new(
+        HooksConfig {
+            enabled: true,
+            hooks: vec![Hook::new(HookEvent::MessageSubmit, &command)],
+            ..HooksConfig::default()
+        },
+        app.workspace.clone(),
+    );
+    let mut engine = mock_engine_handle();
+    let config = Config::default();
+
+    let queued = build_queued_message(&mut app, "do not send".to_string());
+    submit_or_steer_message(&mut app, &config, &engine.handle, queued)
+        .await
+        .expect("blocked submit still returns ok");
+
+    assert!(engine.rx_op.try_recv().is_err());
+    assert_eq!(app.input, "do not send");
+    assert_eq!(
+        app.status_message.as_deref(),
+        Some("Submission blocked by hook: blocked")
+    );
+}
+
+#[cfg(not(windows))]
+#[test]
+fn turn_end_hook_receives_status_duration_and_token_context() {
+    let dir = TempDir::new().expect("tempdir");
+    let output = dir.path().join("turn-end.txt");
+    let command = format!(
+        "printf %s \"$DEEPSEEK_TURN_STATUS:$DEEPSEEK_TURN_DURATION_MS:$DEEPSEEK_TOTAL_TOKENS\" > {}",
+        shell_quote(&output.display().to_string())
+    );
+    let mut app = create_test_app();
+    app.session.total_tokens = 42;
+    app.hooks = HookExecutor::new(
+        HooksConfig {
+            enabled: true,
+            hooks: vec![Hook::new(HookEvent::TurnEnd, &command)],
+            ..HooksConfig::default()
+        },
+        app.workspace.clone(),
+    );
+    let usage = Usage {
+        input_tokens: 1,
+        output_tokens: 2,
+        ..Usage::default()
+    };
+
+    execute_turn_end_hooks(
+        &app,
+        &usage,
+        crate::core::events::TurnOutcomeStatus::Completed,
+        None,
+        Duration::from_millis(123),
+    );
+
+    let written = std::fs::read_to_string(output).expect("hook output");
+    assert_eq!(written, "completed:123:42");
 }
 
 #[tokio::test]

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::config::{ApiProvider, Config};
 use crate::config_ui::{self, WebConfigSession, WebConfigSessionEvent};
 use crate::core::engine::mock_engine_handle;
+#[cfg(not(windows))]
 use crate::hooks::{Hook, HookEvent, HookExecutor, HooksConfig};
 use crate::tui::file_mention::{
     apply_mention_menu_selection, find_file_mention_completions, partial_file_mention_at_cursor,

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -258,6 +258,18 @@ obvious when hooks are globally suppressed. Hooks are
 configured under `[[hooks.hooks]]` entries — see the existing
 hook-system documentation for the full schema.
 
+`message_submit` hooks run before a user message is dispatched. They receive
+context JSON on stdin and the usual `DEEPSEEK_*` environment variables. A
+synchronous hook may print `{"text":"replacement"}` to stdout to replace the
+submitted text, or exit with code `2` to block the submission. Empty or
+non-JSON stdout leaves the original text unchanged for compatibility with
+observer-only hooks.
+
+`turn_end` hooks run after a model turn completes and the TUI is idle again.
+They receive turn metadata on stdin and environment variables such as
+`DEEPSEEK_TURN_STATUS` and `DEEPSEEK_TURN_DURATION_MS`. Use `background = true`
+for hooks that do slow follow-up work.
+
 ### Composer stash (`/stash`, Ctrl+S)
 
 Press **Ctrl+S** in the composer to park the current draft to


### PR DESCRIPTION

## Summary

  Implements the hook behavior requested in #1364.

 Previously, `message_submit` hooks were observer-only: they could see a submitted message, but could not change or block it. This adds a minimal mutation/block contract:

  - `message_submit` hooks receive context JSON on stdin.
  - stdout JSON `{ "text": "..." }` replaces the submitted message.
  - exit code `2` blocks submission and shows a reason from `{ "reason": "..." }` or stderr.
  - empty or non-JSON stdout keeps the original message for compatibility.

 This also adds a `turn_end` observe hook that fires after a model turn completes and the TUI returns to idle. It includes turn
  status, duration, usage, token, cost, session, workspace, model, and error context.

  ## Changes

  - Added `turn_end` as a supported hook event.
  - Added JSON stdin payload support for hook execution.
  - Added `message_submit` mutation and blocking behavior.
  - Wired `message_submit` into the pre-dispatch path.
  - Wired `turn_end` into the turn completion path.
  - Updated `/hooks events` output.
  - Updated `config.example.toml` and configuration docs.
  - Added focused hook executor and TUI dispatch tests.

## Testing

- [x] `cargo test --all-features`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features`

## Checklist

  - [x] Updated docs or comments as needed
  - [x] Added or updated tests where relevant
  - [x] Verified TUI behavior manually
