### PR TITLE
docs(tools): add V4 steering sentences to tool descriptions

### DIFF
--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -157,8 +157,6 @@ pub const COMPACT_TEMPLATE: &str = include_str!("prompts/compact.md");
 /// Legacy base prompt (agent.txt — now decomposed into base.md + overlays).
 /// Still available for callers that haven't migrated to the layered API.
 pub const AGENT_PROMPT: &str = include_str!("prompts/agent.txt");
-pub const YOLO_PROMPT: &str = include_str!("prompts/yolo.txt");
-pub const PLAN_PROMPT: &str = include_str!("prompts/plan.txt");
 
 // ── Personality selection ─────────────────────────────────────────────
 
@@ -939,10 +937,8 @@ mod tests {
 
     #[test]
     fn legacy_constants_still_available() {
-        // Verify the old .txt constants still compile and contain expected content
+        // Verify the legacy .txt constant still compiles and contains expected content
         assert!(!AGENT_PROMPT.is_empty());
-        assert!(!YOLO_PROMPT.is_empty());
-        assert!(!PLAN_PROMPT.is_empty());
     }
 
     // ── Cache-prefix stability harness (#263 step 2) ───────────────────────

--- a/crates/tui/src/prompts/normal.txt
+++ b/crates/tui/src/prompts/normal.txt
@@ -1,6 +1,0 @@
-## Mode: normal
-
-Reads and `rlm` run silently. Writes, patches, and shell commands ask for approval.
-
-Before requesting writes, use `checklist_write` to outline your approach — visible plans build trust.
-For complex work, layer `update_plan` (strategy) above `checklist_write` (tactics).

--- a/crates/tui/src/prompts/plan.txt
+++ b/crates/tui/src/prompts/plan.txt
@@ -1,8 +1,0 @@
-## Mode: plan
-
-Investigate first, act later. Use `update_plan` to lay out high-level strategy and `checklist_write` for
-granular, verifiable steps. All writes and patches are blocked — you can read the world but you
-can't change it. Shell and code execution are unavailable.
-
-Use this mode to build a thorough plan. Spawn read-only sub-agents for parallel investigation.
-When the plan is solid, the user will switch modes so you can execute.

--- a/crates/tui/src/prompts/yolo.txt
+++ b/crates/tui/src/prompts/yolo.txt
@@ -1,8 +1,0 @@
-## Mode: yolo
-
-All actions auto-approved. Move fast, but think before you write. If you're about to delete files,
-overwrite user work, or run destructive commands, pause and double-check. The undo button is the user's Git history.
-
-Even with auto-approval, create a `checklist_write` first so your work is visible and trackable in the
-sidebar. Decomposition is not red tape — it's how you organize complex work and demonstrate thoroughness.
-For multi-step initiatives, use `update_plan` + `checklist_write` together.

--- a/crates/tui/src/tools/apply_patch.rs
+++ b/crates/tui/src/tools/apply_patch.rs
@@ -153,7 +153,7 @@ impl ToolSpec for ApplyPatchTool {
     }
 
     fn description(&self) -> &'static str {
-        "Apply a unified diff patch to a file. Supports multi-hunk patches with fuzzy matching."
+        "Apply a unified-diff patch (multi-hunk, multi-file). Use this instead of `git apply`, `patch`, or repeated `edit_file` calls in `exec_shell` — single transactional change with fuzzy matching and a rendered diff."
     }
 
     fn input_schema(&self) -> Value {

--- a/crates/tui/src/tools/fetch_url.rs
+++ b/crates/tui/src/tools/fetch_url.rs
@@ -87,7 +87,7 @@ impl ToolSpec for FetchUrlTool {
     }
 
     fn description(&self) -> &'static str {
-        "Fetch a known URL directly (HTTP GET) and return its content. Use this when the user gives a URL or you already know the canonical link — it's faster and more reliable than web_search for known pages."
+        "Fetch a known URL directly (HTTP GET) and return its content. Use this instead of `curl` in `exec_shell` — sandboxed, network-policy aware, and properly decoded. Plain-text endpoints (`.md`, `.txt`, `.json`, `.yaml`, `raw.githubusercontent.com`, public APIs) prefer this over the browser/automation stack. For unknown queries, use `web_search` first."
     }
 
     fn input_schema(&self) -> Value {

--- a/crates/tui/src/tools/file.rs
+++ b/crates/tui/src/tools/file.rs
@@ -26,7 +26,7 @@ impl ToolSpec for ReadFileTool {
     }
 
     fn description(&self) -> &'static str {
-        "Read a file from the workspace. Plain text is returned as-is; PDFs are auto-extracted via `pdftotext` (poppler) when available."
+        "Read a UTF-8 file from the workspace. Use this instead of `cat`, `head`, `tail`, or `sed -n '..p'` in `exec_shell` — it's faster, sandbox-aware, and skips the approval prompt. Plain text is returned as-is; PDFs are auto-extracted via `pdftotext` (poppler) when available. Cannot read images or non-PDF binaries."
     }
 
     fn input_schema(&self) -> Value {
@@ -191,7 +191,7 @@ impl ToolSpec for WriteFileTool {
     }
 
     fn description(&self) -> &'static str {
-        "Write content to a UTF-8 file in the workspace."
+        "Write content to a UTF-8 file in the workspace. Use this instead of heredocs (`cat <<EOF > file`) or `echo > file` in `exec_shell` — diffs render inline and approval is handled cleanly. Creates or overwrites; parent directories are auto-created."
     }
 
     fn input_schema(&self) -> Value {
@@ -290,7 +290,7 @@ impl ToolSpec for EditFileTool {
     }
 
     fn description(&self) -> &'static str {
-        "Replace text in a file using search/replace. Required: 'path' (file to edit), 'search' (exact text to find), 'replace' (text to substitute)."
+        "Replace text in a single file via exact search/replace. Use this instead of `sed -i` in `exec_shell` for in-place edits. For multi-hunk or cross-file changes, use `apply_patch` instead. Required: 'path', 'search' (exact text to find), 'replace' (text to substitute)."
     }
 
     fn input_schema(&self) -> Value {
@@ -384,7 +384,7 @@ impl ToolSpec for ListDirTool {
     }
 
     fn description(&self) -> &'static str {
-        "List entries in a directory relative to the workspace."
+        "List entries in a directory relative to the workspace. Use this instead of `ls`, `ls -la`, or `find . -maxdepth 1` in `exec_shell` for directory listings."
     }
 
     fn input_schema(&self) -> Value {

--- a/crates/tui/src/tools/file_search.rs
+++ b/crates/tui/src/tools/file_search.rs
@@ -29,7 +29,7 @@ impl ToolSpec for FileSearchTool {
     }
 
     fn description(&self) -> &'static str {
-        "Search for files using fuzzy matching with score-based ranking."
+        "Find files by name using fuzzy matching with score-based ranking. Use this instead of `find -name` or `fd` in `exec_shell` for filename search. Pass `extensions` to filter by suffix."
     }
 
     fn input_schema(&self) -> Value {

--- a/crates/tui/src/tools/search.rs
+++ b/crates/tui/src/tools/search.rs
@@ -40,7 +40,7 @@ impl ToolSpec for GrepFilesTool {
     }
 
     fn description(&self) -> &'static str {
-        "Search for a regex pattern in files within the workspace. Returns matching lines with context."
+        "Search for a regex pattern in workspace files. Use this instead of `grep -r`, `rg`, or `find ... -exec grep` in `exec_shell` — pure-Rust, faster, and respects `.gitignore`. Returns matching lines with context (default: 2 lines before/after each match)."
     }
 
     fn input_schema(&self) -> Value {

--- a/crates/tui/src/tools/web_search.rs
+++ b/crates/tui/src/tools/web_search.rs
@@ -115,7 +115,7 @@ impl ToolSpec for WebSearchTool {
     }
 
     fn description(&self) -> &'static str {
-        "Search the web using DuckDuckGo or Bing and return structured results with URLs and snippets."
+        "Search the web (DuckDuckGo or Bing) and return ranked results with URLs and snippets. Use this instead of scraping search engines with `curl` in `exec_shell`. For a known canonical URL, prefer `fetch_url` directly."
     }
 
     fn input_schema(&self) -> Value {


### PR DESCRIPTION
## Summary

Implements [#711](https://github.com/Hmbown/DeepSeek-TUI/issues/711) — rewrites every model-visible tool's `description()` so it actively herds V4 toward the typed tool instead of reaching for `exec_shell` for the same job.

## What changed

**9 tool descriptions, each gains:**
- a short *"use this instead of X in `exec_shell`"* steering line
- the return shape (where useful)
- the relevant limits

| Tool | Steers away from |
|---|---|
| `read_file` | `cat` / `head` / `tail` / `sed -n '..p'` |
| `write_file` | `cat <<EOF > file` / `echo > file` |
| `edit_file` | `sed -i` |
| `list_dir` | `ls` / `ls -la` / `find . -maxdepth 1` |
| `grep_files` | `grep -r` / `rg` / `find ... -exec grep` |
| `file_search` | `find -name` / `fd` |
| `apply_patch` | `git apply` / `patch` / repeated `edit_file` calls |
| `web_search` | scraping with `curl` |
| `fetch_url` | `curl` for known URLs |

**Dead prompt templates removed:**
- `crates/tui/src/prompts/normal.txt` — fully orphaned (no `include_str!` reference anywhere)
- `crates/tui/src/prompts/plan.txt` + `PLAN_PROMPT` constant — only self-test referenced it
- `crates/tui/src/prompts/yolo.txt` + `YOLO_PROMPT` constant — same
- `legacy_constants_still_available` test trimmed to the surviving `AGENT_PROMPT`

`AGENT_PROMPT` / `agent.txt` are preserved on purpose (they are flagged for a separate issue per the #711 body).

## Diff stat

```
10 files changed, 10 insertions(+), 36 deletions(-)
```

Net **−26 LOC** — within the issue's *+40/−30* target direction.

## Description-quality checks

| Tool | chars | newlines? | markdown header? |
|---|---:|---|---|
| read_file | 311 | no | no |
| write_file | 245 | no | no |
| edit_file | 266 | no | no |
| list_dir | 154 | no | no |
| grep_files | 252 | no | no |
| file_search | 182 | no | no |
| web_search | 214 | no | no |
| apply_patch | 211 | no | no |
| fetch_url | 350 | no | no |

All under the 1024-char acceptance gate; no embedded `\n` or `#` headers — keeps the cached tool catalogue prefix-stable for V4's KV cache.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo build --workspace` — clean
- [x] `cargo test --workspace -- --test-threads=1` — **2557 passed, 0 failed, 2 ignored**

> **Heads-up on a flaky pre-existing test:** `config::tests::test_save_api_key_doesnt_match_similar_keys` intermittently fails on `cargo test --workspace` (parallel) but passes when run alone or single-threaded. The behaviour reproduces on a clean `main` checkout with this branch stashed away, so it is not introduced by these changes. Worth filing as a separate issue if it isn't already tracked.

Closes #711