### PR TITLE
feat(prompts): declarative-fact memory hygiene guidance

### DIFF
--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -152,6 +152,14 @@ pub const NEVER_APPROVAL: &str = include_str!("prompts/approvals/never.md");
 /// model knows the format to use when writing `.deepseek/handoff.md`.
 pub const COMPACT_TEMPLATE: &str = include_str!("prompts/compact.md");
 
+/// Memory hygiene guidance — appended to the system prompt only when the
+/// session has a non-empty user-memory block. Steers the model toward
+/// writing durable memories as declarative facts ("User prefers concise
+/// responses") rather than imperatives ("Always respond concisely"),
+/// because imperatives get re-read as directives in later sessions and
+/// can override the user's current request (#725).
+pub const MEMORY_GUIDANCE: &str = include_str!("prompts/memory_guidance.md");
+
 // ── Legacy prompt constants (kept for backwards compatibility) ────────
 
 /// Legacy base prompt (agent.txt — now decomposed into base.md + overlays).
@@ -416,10 +424,16 @@ pub fn system_prompt_for_mode_with_context_skills_session_and_approval(
     // 2.5b. User memory block (#489). Goes above skills/context-management
     // because it's session-stable: the memory file changes when the user
     // edits it via `/memory` or `# foo` quick-add, but not turn-over-turn.
+    //
+    // When memory is active, also append `MEMORY_GUIDANCE` (#725) so the
+    // model writes new memories as declarative facts rather than
+    // imperatives. The guidance is pinned to the memory branch so its
+    // bytes don't enter the prompt for sessions that never use memory —
+    // those sessions stay byte-identical to before.
     if let Some(memory_block) = session_context.user_memory_block
         && !memory_block.trim().is_empty()
     {
-        full_prompt = format!("{full_prompt}\n\n{memory_block}");
+        full_prompt = format!("{full_prompt}\n\n{memory_block}\n\n{MEMORY_GUIDANCE}");
     }
 
     if let Some(goal_objective) = session_context.goal_objective
@@ -563,6 +577,69 @@ mod tests {
         assert!(prompt.contains("## Environment"));
         assert!(prompt.contains("- lang: ja"));
         assert!(prompt.contains("- deepseek_version:"));
+    }
+
+    #[test]
+    fn memory_guidance_carries_paired_examples() {
+        // The fragment is the contract — verify the verbatim ✓ / ✗
+        // pair is present so V4 has both shapes to imitate.
+        assert!(MEMORY_GUIDANCE.contains("declarative facts"));
+        assert!(MEMORY_GUIDANCE.contains(" ✓"));
+        assert!(MEMORY_GUIDANCE.contains(" ✗"));
+        assert!(MEMORY_GUIDANCE.contains("Imperative"));
+    }
+
+    #[test]
+    fn memory_guidance_absent_when_no_memory_block() {
+        let tmp = tempdir().expect("tempdir");
+        let prompt = match system_prompt_for_mode_with_context_skills_and_session(
+            AppMode::Agent,
+            tmp.path(),
+            None,
+            None,
+            None,
+            PromptSessionContext {
+                user_memory_block: None,
+                goal_objective: None,
+                project_context_pack_enabled: false,
+                locale_tag: "en",
+            },
+        ) {
+            SystemPrompt::Text(text) => text,
+            SystemPrompt::Blocks(_) => panic!("expected text system prompt"),
+        };
+        assert!(
+            !prompt.contains("Memory Hygiene"),
+            "memory guidance must not leak into sessions without a memory block"
+        );
+    }
+
+    #[test]
+    fn memory_guidance_appended_after_memory_block() {
+        let tmp = tempdir().expect("tempdir");
+        let block = "## User Memory\n\n- prefers Rust\n";
+        let prompt = match system_prompt_for_mode_with_context_skills_and_session(
+            AppMode::Agent,
+            tmp.path(),
+            None,
+            None,
+            None,
+            PromptSessionContext {
+                user_memory_block: Some(block),
+                goal_objective: None,
+                project_context_pack_enabled: false,
+                locale_tag: "en",
+            },
+        ) {
+            SystemPrompt::Text(text) => text,
+            SystemPrompt::Blocks(_) => panic!("expected text system prompt"),
+        };
+        let mem_at = prompt.find("User Memory").expect("user memory present");
+        let guide_at = prompt.find("Memory Hygiene").expect("guidance present");
+        assert!(
+            mem_at < guide_at,
+            "guidance must come after the user memory block"
+        );
     }
 
     #[test]

--- a/crates/tui/src/prompts/memory_guidance.md
+++ b/crates/tui/src/prompts/memory_guidance.md
@@ -1,0 +1,14 @@
+## Memory Hygiene
+
+When you write durable memories on the user's behalf, phrase them as
+declarative facts about the world or their preferences — not as
+instructions to your future self.
+
+- "User prefers concise responses" ✓ — "Always respond concisely" ✗
+- "Project uses pytest with xdist" ✓ — "Run tests with pytest -n 4" ✗
+- "Repo's main branch is `main`, release branches are `feat/v*`" ✓ —
+  "When committing, target main" ✗
+
+Imperative phrasing gets re-read as a directive in later sessions and
+can override the user's current request in cases where it shouldn't.
+Procedures and workflows belong in skills, not memory.


### PR DESCRIPTION
## Summary

Implements [#725](https://github.com/Hmbown/DeepSeek-TUI/issues/725): adds a small prompt fragment that steers the model toward writing durable memories as **declarative facts** rather than imperatives.

The motivating concern from the issue body:

> Memory writes phrased as imperatives ("Always respond concisely") get re-read as directives in later sessions and conflict with the user's *current* request. Declarative facts ("User prefers concise responses") are stable across sessions.

## What changed

**New file** — `crates/tui/src/prompts/memory_guidance.md` (≈14 lines). Carries the verbatim ✓ / ✗ pairs from the issue body so V4 has both shapes to imitate.

**`crates/tui/src/prompts.rs`**:
- New `pub const MEMORY_GUIDANCE` next to the other prompt-layer constants.
- Conditional injection inside the existing user-memory block in `build_system_prompt`: when `session_context.user_memory_block` is `Some` and non-empty, the guidance is appended right after the memory block.

```rust
if let Some(memory_block) = session_context.user_memory_block
    && !memory_block.trim().is_empty()
{
    full_prompt = format!("{full_prompt}\n\n{memory_block}\n\n{MEMORY_GUIDANCE}");
}
```

## Why pin it to the memory branch (not append at the end)

Sessions that don't use memory should stay byte-identical to today so DeepSeek's KV prefix cache keeps hitting. By gating the guidance on the same condition as the existing memory block, we get:

- **No memory:** prompt unchanged → cache-stable.
- **With memory:** memory + guidance arrive together as a stable section, also cache-stable across turns.

## Stale-prose deletion (issue's "paired delete")

The issue listed swarm/fanout cleanup in `CHANGELOG.md` and `docs/ARCHITECTURE.md` as the paired deletion target, "skip if #13 already cleaned these." The current `docs/ARCHITECTURE.md:10-11` already reads in past tense ("The swarm agent system was removed in v0.8.5…"), and the CHANGELOG entries are historical version notes that should not be rewritten retroactively. So no doc deletions in this PR — happy to add them in a follow-up if reviewers spot something I missed.

## Test plan

All run on this branch, all green:

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p deepseek-tui -- prompts::tests` — **37/37 passing**, including:
  - `memory_guidance_carries_paired_examples` — `MEMORY_GUIDANCE` is non-empty and contains the ✓ / ✗ pairs and the "declarative facts" / "Imperative" anchors
  - `memory_guidance_absent_when_no_memory_block` — `user_memory_block: None` produces a prompt that does **not** mention "Memory Hygiene"
  - `memory_guidance_appended_after_memory_block` — when set, guidance appears strictly after the memory block
  - The existing `system_prompt_for_mode_with_context_is_byte_stable_for_unchanged_workspace` test still passes (prefix cache invariant intact)

Refs #725