### PR TITLE
docs(memory): rephrase imperative example as declarative

### DIFF
--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -4,7 +4,7 @@ The user-memory feature gives the model a small persistent note file
 that's injected into the system prompt on every turn. It's the place
 to put preferences and conventions that should survive across
 sessions — "I prefer pytest over unittest", "this codebase uses
-4-space indentation", "always run `cargo fmt` before committing" —
+4-space indentation", "this repo runs `cargo fmt` before commits" —
 without having to repeat them in every conversation.
 
 Memory is **opt-in**. When disabled (the default), nothing is loaded,


### PR DESCRIPTION
## Summary

`docs/MEMORY.md` opens by listing three sample memory entries; two are declarative facts ("I prefer pytest over unittest", "this codebase uses 4-space indentation") and one is imperative ("always run \`cargo fmt\` before committing"). The imperative shape is exactly what the new `MEMORY_GUIDANCE` system-prompt fragment (proposed in [#1381](https://github.com/Hmbown/DeepSeek-TUI/pull/1381) for [#725](https://github.com/Hmbown/DeepSeek-TUI/issues/725)) tells the model to *avoid*, since imperatives get re-read as directives in later sessions and can override the user's current request.

This PR rewords that one example so the docs and the system-prompt guidance speak with the same voice.

## Diff

```diff
- 4-space indentation", "always run `cargo fmt` before committing" —
+ 4-space indentation", "this repo runs `cargo fmt` before commits" —
```

`1 file changed, 1 insertion(+), 1 deletion(-).` Pure docs.

## Why now

Even without [#1381](https://github.com/Hmbown/DeepSeek-TUI/pull/1381) landing, the change is consistent with the existing declarative tone of the surrounding two examples — and the rest of the file (the `## File format` sample, "What stays out of memory", etc.) already uses declarative phrasing throughout. So this is just a leftover imperative.

## Test plan

- [x] `git diff` reviewed — single-line wording change
- [x] No code touched, so build/clippy/test untouched