### PR TITLE
feat(prompts): XML-tagged execution discipline + tool-use enforcement

### DIFF
--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -493,28 +493,6 @@ pub fn build_system_prompt(base: &str, project_context: Option<&ProjectContext>)
     SystemPrompt::Text(full_prompt)
 }
 
-// ── Legacy functions for backwards compatibility ──────────────────────
-
-pub fn base_system_prompt() -> SystemPrompt {
-    SystemPrompt::Text(BASE_PROMPT.trim().to_string())
-}
-
-pub fn normal_system_prompt() -> SystemPrompt {
-    system_prompt_for_mode(AppMode::Agent)
-}
-
-pub fn agent_system_prompt() -> SystemPrompt {
-    system_prompt_for_mode(AppMode::Agent)
-}
-
-pub fn yolo_system_prompt() -> SystemPrompt {
-    system_prompt_for_mode(AppMode::Yolo)
-}
-
-pub fn plan_system_prompt() -> SystemPrompt {
-    system_prompt_for_mode(AppMode::Plan)
-}
-
 #[cfg(test)]
 mod tests {
     // Don't assert on prose. If you wouldn't fail a code review for
@@ -525,6 +503,44 @@ mod tests {
     /// Discriminator unique to the injected handoff block (not present in the
     /// agent prompt's own discussion of the convention).
     const HANDOFF_BLOCK_MARKER: &str = "left a handoff at `.deepseek/handoff.md`";
+
+    #[test]
+    fn base_prompt_carries_execution_discipline_block() {
+        // The XML-tagged execution-discipline block is the contract —
+        // verify each section name is present so reviewers can't quietly
+        // strip the rules that herd V4 toward acting instead of narrating.
+        for tag in [
+            "<tool_persistence>",
+            "<mandatory_tool_use>",
+            "<act_dont_ask>",
+            "<verification>",
+            "<missing_context>",
+        ] {
+            assert!(
+                BASE_PROMPT.contains(tag),
+                "BASE_PROMPT missing required tag {tag}"
+            );
+        }
+        assert!(
+            BASE_PROMPT.contains("Tool-use enforcement"),
+            "BASE_PROMPT missing the tool-use enforcement clause"
+        );
+    }
+
+    #[test]
+    fn execution_discipline_is_at_the_end_for_cache_stability() {
+        // DeepSeek's prefix cache keys on a leading byte-stable run, so
+        // the new sections must be appended, not interleaved earlier.
+        let body = BASE_PROMPT;
+        let persistence_at = body
+            .find("<tool_persistence>")
+            .expect("tool_persistence anchor present");
+        let language_at = body.find("## Language").expect("Language anchor present");
+        assert!(
+            language_at < persistence_at,
+            "execution-discipline block must come after the early sections"
+        );
+    }
 
     #[test]
     fn render_environment_block_lists_supplied_locale_and_workspace() {

--- a/crates/tui/src/prompts/base.md
+++ b/crates/tui/src/prompts/base.md
@@ -201,3 +201,41 @@ You're rendering into a terminal, not a browser. Markdown tables almost never re
 - **Definition-style lists** (`- **Label**: value`) when the user asked for a comparison or summary.
 
 If you genuinely need column-aligned data (e.g. the user asked for a table or for `/cost` style output), keep columns narrow, ASCII-only, and limit to 2–3 columns. Otherwise convert what would be a table into a list of `**Header**: value` pairs.
+
+## Execution discipline
+
+<tool_persistence>
+- Use tools whenever they improve correctness, completeness, or grounding.
+- Do not stop early when another tool call would materially improve the result.
+- If a tool returns empty or partial results, retry with a different query or strategy before giving up.
+- Keep calling tools until: (1) the task is complete, AND (2) you have verified the result.
+</tool_persistence>
+
+<mandatory_tool_use>
+NEVER answer these from memory or mental computation — ALWAYS use a tool:
+- Arithmetic, math, calculations → `exec_shell` (e.g. `python -c '…'`)
+- Hashes, encodings, checksums → `exec_shell` (e.g. `sha256sum`, `base64`)
+- Current time, date, timezone → `exec_shell` (e.g. `date`)
+- System state: OS, CPU, memory, disk, ports, processes → `exec_shell`
+- File contents, sizes, line counts → `read_file` or `grep_files`
+- Symbol or pattern search across the workspace → `grep_files`
+- Filename search → `file_search`
+</mandatory_tool_use>
+
+<act_dont_ask>
+When a question has an obvious default interpretation, act on it immediately instead of asking for clarification. Save clarification for genuinely ambiguous requests.
+</act_dont_ask>
+
+<verification>
+After making changes, verify them: read back the file you wrote, run the test you fixed, fetch the URL you posted to. Don't claim success on faith.
+</verification>
+
+<missing_context>
+If you need context (a file you haven't read, a variable's current value, an external URL), name the gap and fetch it before proceeding.
+</missing_context>
+
+## Tool-use enforcement
+
+You MUST use your tools to take action — do not describe what you would do or plan to do without actually doing it. When you say you will perform an action ("I will run the tests", "Let me check the file", "I will create the project"), you MUST immediately make the corresponding tool call in the same response. Never end your turn with a promise of future action — execute it now.
+
+Every response should either (a) contain tool calls that make progress, or (b) deliver a final result to the user. Responses that only describe intentions without acting are not acceptable.


### PR DESCRIPTION
## Summary

Implements [#718](https://github.com/Hmbown/decision-TUI/issues/718) from the v0.9.0 self-executing-task batch: adds two structured sections to `base.md` that turn V4 (especially V4-Pro thinking mode) from a narrator into an actor.

The two failure modes the issue calls out:
- *"narrates intent without executing"* — `I will run the tests` then ends the turn without calling `exec_shell`
- *"answers from memory or mental computation"* — does arithmetic, hashes, dates, system state in the assistant message instead of using a tool

## What changed

### 1. `crates/tui/src/prompts/base.md` (+38 LOC at the **end**)

Five XML-tagged blocks plus a binary tool-use enforcement clause:

```xml
<tool_persistence>          when to keep iterating
<mandatory_tool_use>        which categories MUST hit a tool
<act_dont_ask>              acting on the obvious default
<verification>              read it back, run it, fetch it
<missing_context>           name the gap before guessing
```

```
## Tool-use enforcement
Every response should either (a) contain tool calls that make progress,
or (b) deliver a final result. Responses that only describe intentions
without acting are not acceptable.
```

Placed at the **end** of the prompt — the `## Language` and `## Output formatting` sections come first, so the static byte prefix that DeepSeek's automatic cache keys on doesn't shift for already-running sessions. Two new tests assert this ordering invariant.

### 2. `crates/tui/src/prompts.rs` (-22 LOC dead code)

Removes the five legacy `*_system_prompt()` facade functions (`base_system_prompt`, `normal_system_prompt`, `agent_system_prompt`, `yolo_system_prompt`, `plan_system_prompt`). Repo-wide grep confirms zero callers outside their own definition.

The companion `.txt` templates (`agent.txt`, `base.txt`, `normal.txt`, `plan.txt`, `yolo.txt`) and `*_PROMPT` constants are intentionally **out of scope** here — they're being retired in [#1379](https://github.com/Hmbown/DeepSeek-TUI/pull/1379) and [#1382](https://github.com/Hmbown/DeepSeek-TUI/pull/1382) so the diffs stay review-friendly and atomic.

## Tests

```
cargo test -p deepseek-tui -- prompts::tests
test result: ok. 36 passed; 0 failed
```

Two new ones:
- `base_prompt_carries_execution_discipline_block` — every required XML tag and the enforcement clause is present
- `execution_discipline_is_at_the_end_for_cache_stability` — block sits after `## Language` so the cached prefix doesn't shift

The existing `system_prompt_for_mode_with_context_is_byte_stable_for_unchanged_workspace` invariant test still passes.

## Acceptance gates

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build --workspace`
- [x] `cargo test -p deepseek-tui -- prompts::tests` — 36/36

Net diff: **+76 / −22 LOC**. The issue plan called for net-negative; we are net-positive here because the paired `.txt` / constant deletions live in #1379 / #1382 to keep PRs single-scope. With those merged this issue's overall delta will be net negative (~-15 LOC) as planned.

Refs #718