### PR TITLE
fix(working-set): cap file-index walk to bound first-turn latency (#697)

### DIFF
--- a/crates/tui/src/working_set.rs
+++ b/crates/tui/src/working_set.rs
@@ -93,9 +93,18 @@ impl Workspace {
 
     fn build_file_index(&self) -> HashMap<String, Vec<PathBuf>> {
         let mut index: HashMap<String, Vec<PathBuf>> = HashMap::new();
+        let mut total: usize = 0;
         let builder = discovery_walk_builder(&self.root, Some(6));
 
         for entry in builder.build().flatten() {
+            if total >= FILE_INDEX_MAX_ENTRIES {
+                tracing::warn!(
+                    target: "working_set",
+                    limit = FILE_INDEX_MAX_ENTRIES,
+                    "file-index discovery hit the entry cap; truncating to keep first-turn latency bounded (#697)"
+                );
+                return index;
+            }
             if entry
                 .file_type()
                 .is_some_and(|ft| ft.is_file() || ft.is_dir())
@@ -105,11 +114,15 @@ impl Workspace {
                     .entry(name)
                     .or_default()
                     .push(entry.path().to_path_buf());
+                total += 1;
             }
         }
 
         // Also index AI-tool dot-directories with gitignore disabled.
         for dir_name in DISCOVERY_ALWAYS_DIRS {
+            if total >= FILE_INDEX_MAX_ENTRIES {
+                break;
+            }
             let dot_dir = self.root.join(dir_name);
             if !dot_dir.is_dir() {
                 continue;
@@ -122,6 +135,9 @@ impl Workspace {
                 .ignore(false)
                 .max_depth(Some(5));
             for entry in dot_builder.build().flatten() {
+                if total >= FILE_INDEX_MAX_ENTRIES {
+                    break;
+                }
                 // Exclude machine-generated bulk (e.g. .deepseek/snapshots/).
                 if path_is_excluded_from_discovery(&self.root, entry.path()) {
                     continue;
@@ -135,6 +151,7 @@ impl Workspace {
                         .entry(name)
                         .or_default()
                         .push(entry.path().to_path_buf());
+                    total += 1;
                 }
             }
         }
@@ -206,6 +223,15 @@ impl Workspace {
 /// Mirrors the existing `project_tree` cutoff and keeps Tab snappy in deep
 /// monorepos.
 const COMPLETIONS_WALK_DEPTH: usize = 6;
+
+/// Hard cap on the number of `(file or directory)` entries indexed by
+/// [`WorkingSet::build_file_index`]. The fuzzy-resolve index is a
+/// convenience for [`WorkingSet::fuzzy_resolve`]; missing entries fall
+/// back to literal-path resolution. Capping here keeps the first
+/// `fuzzy_resolve` call bounded on huge workspaces (#697 reported a
+/// ~10s hang on the first turn). For typical projects 50K is well
+/// above the actual entry count and the cap is a no-op.
+const FILE_INDEX_MAX_ENTRIES: usize = 50_000;
 
 /// Directories that must remain discoverable for `@`-mention completion and
 /// fuzzy file resolution even when excluded by `.gitignore`. AI-tool


### PR DESCRIPTION
## Summary

[#697](https://github.com/Hmbown/DeepSeek-TUI/issues/697) reports a ~10-second \`Working...\` hang on the **first** command in directories with many files; subsequent commands are instant. This is a fingerprint match for a one-shot lazy-init that gates the first turn — there's exactly one such path in `working_set.rs`:

```
WorkingSet::fuzzy_resolve  →  file_index.get_or_init(self.build_file_index)
```

`build_file_index` walks the workspace at depth 6 plus every entry under `DISCOVERY_ALWAYS_DIRS` (`.deepseek`, `.cursor`, `.claude`, `.agents`) at depth 5, with **no entry-count bound**. On a workspace with tens of thousands of files within those depth caps, the walk dominates the first-turn wall clock.

## Fix

Adds a defensive entry-count cap:

```rust
const FILE_INDEX_MAX_ENTRIES: usize = 50_000;
```

When the cap is hit during the walk, the function returns early with a `tracing::warn!` line. A surplus entry simply isn't fuzzy-resolvable — literal-path resolution (the path the user actually typed) still works through the existing fallback in `WorkingSet::resolve`.

## Why this is a defensive upper bound

50K is comfortably above any realistic project's depth-6 entry count. Audit data points:

- `deepseek-tui` itself: ~3K entries within depth 6 even with `target/` + `.git/` walked
- A typical Node monorepo: 5–15K (gitignored `node_modules` is excluded by `discovery_walk_builder`)
- The reporter's case: probably 10–30K with `.git/` indexed (#697 says "10+ subdirectories, hundreds of files" but that's the *visible* subset)
- A worst-case mistake (someone runs `deepseek` in `~/`): hundreds of thousands → previously unbounded, now stops at 50K

So for ordinary users the cap is a no-op. For pathological cases it gives an upper bound on first-turn latency.

## Notes

- I can't verify the exact 10-second number from inside the repo — that needs a live TUI run on the reporter's workspace. But the unbounded walk is a real exposure regardless of whether it accounts for the full 10s. Treating this as a **partial-but-defensive** fix; if the maintainer's runtime profiling later points elsewhere, this cap stays correct.
- Function-shape change is minimal: same return type, same call sites, same behaviour for typical workspaces.

## Acceptance gates

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build --workspace`
- [x] `cargo test -p deepseek-tui -- working_set` — **26/26 passing, 2 ignored** (no behaviour change on typical workspaces)

Refs #697