### PR TITLE
fix: deny of one tool call permanently blocks all future same-tool calls

### DIFF
--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -5825,12 +5825,11 @@ async fn handle_view_events(
                     }
                     ReviewDecision::Denied | ReviewDecision::Abort => {
                         // Cache the denial so the model retry-loop doesn't
-                        // re-prompt for the same command (#360). Only when
-                        // the user actively denied (not when the timeout
-                        // fired) — a timeout might mean the user stepped
-                        // away rather than refused.
+                        // re-prompt for the exact same approval_key (#360).
+                        // Only the key (per-call unique) is stored — NOT
+                        // the tool_name, which would block all future
+                        // invocations of the same tool type (#1377).
                         if !timed_out {
-                            app.approval_session_denied.insert(tool_name.clone());
                             app.approval_session_denied.insert(approval_key);
                         }
                         let _ = engine_handle.deny_tool_call(tool_id).await;


### PR DESCRIPTION
## Summary

Fixes #1377 — denying a tool call (e.g. `edit_file`) once permanently auto-denies every subsequent invocation of the same tool type for the rest of the session.

## Root cause

In `handle_view_events`, when a tool call is denied, both the `tool_name` (e.g. `"edit_file"`) and the `approval_key` (per-call unique) were inserted into `app.approval_session_denied`. The `tool_name` entry caused **all** future calls to `edit_file` to be auto-denied without prompting.

## Fix

Only store the `approval_key` on denial. The `approval_key` is per-call unique, which still prevents the model's retry loop from re-prompting the exact same command (#360), but allows fresh invocations of the same tool type to prompt the user for approval.

## Files changed

| File | Change |
|------|--------|
| `crates/tui/src/tui/ui.rs` | Remove `tool_name` insertion into `approval_session_denied` |

## Test plan

- [x] `cargo check -p deepseek-tui` passes
- [x] `cargo clippy -p deepseek-tui --all-targets --all-features --locked -- -D warnings` passes
- [x] Code only changes denial path; approval path (`ApprovedForSession`) is unchanged
