### PR TITLE
fix(ui): drain active thinking entry on MessageComplete (#861 RC3)

### DIFF
--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -698,6 +698,24 @@ async fn run_event_loop(
                         }
                     }
                     EngineEvent::MessageComplete { .. } => {
+                        // #861 RC3: defensive drain of a still-active thinking
+                        // entry. Normally `ThinkingComplete` arrives first and
+                        // populates `last_reasoning` before we get here, but
+                        // when the engine bursts events the channel can
+                        // deliver `MessageComplete` first, in which case
+                        // `last_reasoning.take()` below would be `None` and
+                        // the thinking block would be dropped from
+                        // `api_messages` — causing a DeepSeek HTTP 400 on the
+                        // next turn (V4 thinking-mode requires
+                        // `reasoning_content` replay). Inline-finalize the
+                        // thinking entry here so this branch is order-
+                        // independent.
+                        if app.streaming_thinking_active_entry.is_some() {
+                            if finalize_current_streaming_thinking(app) {
+                                transcript_batch_updated = true;
+                            }
+                            stash_reasoning_buffer_into_last_reasoning(app);
+                        }
                         if let Some(index) = app.streaming_message_index.take() {
                             let remaining = app.streaming_state.finalize_block_text(0);
                             if !remaining.is_empty() {

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -3861,6 +3861,57 @@ fn engine_error_finalizes_active_thinking_block() {
 }
 
 #[test]
+fn message_complete_drain_preserves_thinking_when_thinking_complete_lost() {
+    // #861 RC3: when the engine bursts events, `MessageComplete` can be
+    // dispatched ahead of `ThinkingComplete`. Without the defensive drain,
+    // `app.last_reasoning` would be `None` at `last_reasoning.take()` time
+    // and the thinking block would be dropped from `api_messages`,
+    // causing a DeepSeek HTTP 400 on the next turn (V4 thinking-mode
+    // requires `reasoning_content` replay).
+    //
+    // This test exercises the head-of-handler drain in isolation: with a
+    // thinking entry still active and `last_reasoning` empty, the drain
+    // must transfer `reasoning_buffer` into `last_reasoning` before the
+    // remainder of `MessageComplete` reads it.
+    let mut app = create_test_app();
+
+    let _ = ensure_streaming_thinking_active_entry(&mut app);
+    app.thinking_started_at = Some(Instant::now());
+    app.streaming_state.start_thinking(0, None);
+    app.streaming_state.push_content(0, "deep reasoning text");
+    let _ = app.streaming_state.commit_text(0);
+    app.reasoning_buffer.push_str("deep reasoning text");
+
+    assert!(
+        app.last_reasoning.is_none(),
+        "precondition: ThinkingComplete has NOT fired"
+    );
+    assert!(
+        app.streaming_thinking_active_entry.is_some(),
+        "precondition: thinking entry is still active"
+    );
+
+    // Mirror the head of `EngineEvent::MessageComplete` — the new defensive
+    // drain installed by the #861 RC3 fix.
+    if app.streaming_thinking_active_entry.is_some() {
+        let _ = finalize_current_streaming_thinking(&mut app);
+        stash_reasoning_buffer_into_last_reasoning(&mut app);
+    }
+
+    assert!(
+        app.last_reasoning
+            .as_deref()
+            .is_some_and(|s| s.contains("deep reasoning text")),
+        "defensive drain must move reasoning into last_reasoning so the\
+         downstream `last_reasoning.take()` produces a Thinking block"
+    );
+    assert!(
+        app.streaming_thinking_active_entry.is_none(),
+        "thinking entry must be cleared after the drain"
+    );
+}
+
+#[test]
 fn second_thinking_block_appends_new_entry_in_same_active_cell() {
     // Real V4 turns can emit Thinking → Tool → Thinking → Tool before any
     // prose; the second thinking block should land as a fresh entry inside


### PR DESCRIPTION
## Summary

Closes [#861](https://github.com/Hmbown/DeepSeek-TUI/issues/861) **root cause 3** — the order-of-events race that drops thinking content from \`api_messages\` and triggers DeepSeek HTTP 400 on the next turn.

The reporter's analysis nailed it:

> If \`MessageComplete\` is processed **before** \`ThinkingComplete\` (possible when the engine channel drains events in burst order), \`last_reasoning\` is \`None\` at \`MessageComplete\` time, and the thinking block is **not included** in the API message history.
> 
> **Impact:** Thinking content is stripped from \`api_messages\`. On the next turn, DeepSeek V4 returns HTTP 400 (missing \`reasoning_content\`), or the model loses continuity of its own reasoning chain.

## What changed

In \`crates/tui/src/tui/ui.rs\`, the head of the \`EngineEvent::MessageComplete\` arm now does a defensive drain when a thinking entry is still active:

```rust
EngineEvent::MessageComplete { .. } => {
    // #861 RC3: defensive drain of a still-active thinking entry.
    if app.streaming_thinking_active_entry.is_some() {
        if finalize_current_streaming_thinking(app) {
            transcript_batch_updated = true;
        }
        stash_reasoning_buffer_into_last_reasoning(app);
    }
    if let Some(index) = app.streaming_message_index.take() { /* … */ }
    // …
    let thinking = app.last_reasoning.take();   // now non-None even if
                                                 // ThinkingComplete was lost
    if let Some(thinking) = thinking {
        blocks.push(ContentBlock::Thinking { thinking });
    }
    // …
}
```

The drain is a **no-op** in the normal case where \`ThinkingComplete\` arrived first (\`streaming_thinking_active_entry\` is already \`None\` and the helpers early-return), so this branch is order-independent.

## Why only RC3 in this PR

The other three root causes from #861 are already (or partially) addressed:

| RC | Status | Where |
|---|---|---|
| **RC1** (apply_engine_error_to_app frozen spinner) | **Already fixed** | \`apply_engine_error_to_app\` line 3198 calls \`finalize_current_streaming_thinking\` before clearing the pointer; covered by \`engine_error_finalizes_active_thinking_block\` test |
| **RC2** (ThinkingStarted drops buffered tail) | **Already fixed** | \`start_streaming_thinking_block\` flushes the previous block via \`finalize_current_streaming_thinking\` + stashes the reasoning buffer before \`streaming_state.reset()\` |
| **RC3** (this PR) | Fixed here | \`MessageComplete\` defensive drain |
| **RC4** (streaming-time truncation affordance) | **Out of scope** | UX improvement; data-loss path is the urgent one |

I split RC4 out so this PR stays narrow on the data-loss path. Happy to follow up with a separate UX PR for RC4 if reviewers want.

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo build --workspace\`
- [x] \`cargo test -p deepseek-tui -- message_complete_drain\` — **1/1 passing**

The new test (\`message_complete_drain_preserves_thinking_when_thinking_complete_lost\`) sets up the precise pre-state the bug requires (thinking entry active, \`last_reasoning\` empty), runs the head-of-handler drain in isolation, and asserts that \`last_reasoning\` carries the text afterwards.

The pre-existing \`engine_error_finalizes_active_thinking_block\` (RC1 coverage) and \`flush_active_cell_finalizes_unclosed_thinking_block\` tests still pass — no behaviour shift in the normal flow.

Refs #861