### PR TITLE
fix(ui): stream thinking content during collapsed view (#861 RC4, #1324)

### DIFF
--- a/crates/tui/src/tui/history.rs
+++ b/crates/tui/src/tui/history.rs
@@ -2092,10 +2092,18 @@ fn render_thinking(
     lines.push(Line::from(header_spans));
 
     let content_width = width.saturating_sub(3).max(1);
-    let body_text = if collapsed && streaming {
-        String::new()
-    } else if collapsed {
-        extract_reasoning_summary(content).unwrap_or_else(|| content.trim().to_string())
+    let body_text = if collapsed {
+        if streaming {
+            // #861 RC4 / #1324: during streaming we don't yet have a
+            // completed reasoning block, so `extract_reasoning_summary`
+            // is meaningless. Show the raw content and let the
+            // truncation logic below keep the *last* `LIMIT` lines so
+            // the user sees the model's most recent thinking instead of
+            // staring at an empty placeholder.
+            content.to_string()
+        } else {
+            extract_reasoning_summary(content).unwrap_or_else(|| content.trim().to_string())
+        }
     } else {
         content.to_string()
     };
@@ -2106,7 +2114,14 @@ fn render_thinking(
     };
     let mut truncated = false;
     if collapsed && rendered.len() > THINKING_SUMMARY_LINE_LIMIT {
-        rendered.truncate(THINKING_SUMMARY_LINE_LIMIT);
+        if streaming {
+            // Drop the *head* during streaming so the visible window
+            // tracks the live cursor at the bottom.
+            let drop = rendered.len() - THINKING_SUMMARY_LINE_LIMIT;
+            rendered.drain(0..drop);
+        } else {
+            rendered.truncate(THINKING_SUMMARY_LINE_LIMIT);
+        }
         truncated = true;
     }
 
@@ -2134,13 +2149,24 @@ fn render_thinking(
         lines.push(Line::from(spans));
     }
 
-    if collapsed && (!streaming && (truncated || body_text.trim() != content.trim())) {
+    let needs_affordance = collapsed
+        && if streaming {
+            // #861 RC4 / #1324: during streaming, surface the affordance
+            // whenever any head lines have been clipped so the user
+            // knows there's more above and how to reach it.
+            truncated
+        } else {
+            truncated || body_text.trim() != content.trim()
+        };
+    if needs_affordance {
+        let label = if streaming {
+            "thinking continues; press Ctrl+O for full text"
+        } else {
+            "thinking collapsed; press Ctrl+O for full text"
+        };
         lines.push(Line::from(vec![
             Span::styled(REASONING_RAIL.to_string(), rail_style),
-            Span::styled(
-                "thinking collapsed; press Ctrl+O for full text",
-                Style::default().fg(palette::TEXT_MUTED).italic(),
-            ),
+            Span::styled(label, Style::default().fg(palette::TEXT_MUTED).italic()),
         ]));
     }
 
@@ -3622,6 +3648,64 @@ mod tests {
             .collect::<String>();
         assert!(text.contains("thinking collapsed; press Ctrl+O for full text"));
         assert!(text.contains("thinking"));
+    }
+
+    #[test]
+    fn render_thinking_streaming_collapsed_shows_live_content() {
+        // #861 RC4 / #1324: during a live thinking block in collapsed view,
+        // the body must NOT be blanked out. Users want to watch the model
+        // think; the previous behaviour stalled on a "thinking..." spinner
+        // until ThinkingComplete fired.
+        let lines = render_thinking(
+            "Step 1: read the code\nStep 2: trace the call\nStep 3: form a hypothesis",
+            80,
+            true, // streaming
+            None, // no duration yet
+            true, // collapsed
+            true, // low_motion (no cursor noise to grep)
+        );
+        let text = lines
+            .iter()
+            .flat_map(|line| line.spans.iter().map(|span| span.content.as_ref()))
+            .collect::<String>();
+        assert!(
+            text.contains("Step 3: form a hypothesis"),
+            "the most recent thinking line must be visible during streaming, got: {text}"
+        );
+        // "thinking..." placeholder must not be the only thing rendered.
+        assert!(
+            !text.contains("thinking..."),
+            "raw content present means the placeholder line should not be drawn, got: {text}"
+        );
+    }
+
+    #[test]
+    fn render_thinking_streaming_truncated_shows_continues_affordance() {
+        // #861 RC4: when a streaming thinking block exceeds the line cap,
+        // surface a live affordance pointing at Ctrl+O. The earlier code
+        // suppressed the affordance unless `!streaming`.
+        let long = (1..=10)
+            .map(|i| format!("Reasoning line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let lines = render_thinking(&long, 80, true, None, true, true);
+        let text = lines
+            .iter()
+            .flat_map(|line| line.spans.iter().map(|span| span.content.as_ref()))
+            .collect::<String>();
+        assert!(
+            text.contains("thinking continues; press Ctrl+O for full text"),
+            "streaming-truncation affordance missing, got: {text}"
+        );
+        // The most recent line must be the visible tail (head dropped).
+        assert!(
+            text.contains("Reasoning line 10"),
+            "tail line missing, got: {text}"
+        );
+        assert!(
+            !text.contains("Reasoning line 1\n"),
+            "head should be clipped, got: {text}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes [#1324](https://github.com/Hmbown/DeepSeek-TUI/issues/1324) (\"Thinking 思考内容不能流式输出, 只能等到完全输出后通过 ctrl+O 查看完整思考内容\") and addresses **root cause 4** of [#861](https://github.com/Hmbown/DeepSeek-TUI/issues/861) — both report the same surface: while V4-Pro is in a long thinking phase, the collapsed transcript view shows a frozen \"thinking...\" placeholder until the block completes, so the user can't tell whether the model is still working or stuck.

## Root cause

\`crates/tui/src/tui/history.rs\` — \`render_thinking\` blanks the body on the streaming branch:

```rust
let body_text = if collapsed && streaming {
    String::new()         // ← nothing renders during streaming
} else if collapsed {
    extract_reasoning_summary(content).unwrap_or_else(|| content.trim().to_string())
} else {
    content.to_string()
};
```

…and the \"press Ctrl+O for full text\" affordance was gated behind \`!streaming\`, so even when content was clipped during streaming, no signpost was shown.

## Fix

Three changes, all in \`render_thinking\`:

1. **Stream the body during \`collapsed && streaming\`.** We can't run \`extract_reasoning_summary\` on an unfinished block, so the streaming branch returns the raw content. Truncation handles the rest.

2. **Drop head lines, not tail, while streaming.** Users want to watch the live cursor at the bottom. Once the block completes, we revert to \`truncate(LIMIT)\` so the existing summary-style snapshot view is unchanged.

3. **Render the affordance during streaming when truncated.** Slightly different label (\`thinking continues; press Ctrl+O for full text\`) to match the live state. Already-completed blocks keep the original \`thinking collapsed; press Ctrl+O for full text\`.

## Behavioural matrix

| State | Before this PR | After this PR |
|---|---|---|
| streaming, collapsed, content fits | \"thinking...\" placeholder | Live content visible |
| streaming, collapsed, content > 4 lines | \"thinking...\" placeholder | Last 4 lines + \"thinking continues; press Ctrl+O…\" |
| streaming, expanded | Full content | Full content (unchanged) |
| completed, collapsed, ≤ 4 summary lines | Summary | Summary (unchanged) |
| completed, collapsed, > 4 summary lines | Truncated + \"thinking collapsed; …\" | Truncated + \"thinking collapsed; …\" (unchanged) |

## Tests

```
$ cargo test -p deepseek-tui -- render_thinking
test tui::history::tests::render_thinking_uses_dotted_opener_in_header ... ok
test tui::history::tests::render_thinking_streaming_appends_cursor_when_motion_allowed ... ok
test tui::history::tests::render_thinking_body_lines_use_dashed_rail_and_italic ... ok
test tui::history::tests::render_thinking_streaming_collapsed_shows_live_content ... ok                  ← new
test tui::history::tests::render_thinking_collapsed_shows_details_affordance ... ok
test tui::history::tests::render_thinking_streaming_omits_cursor_when_low_motion ... ok
test tui::history::tests::render_thinking_streaming_truncated_shows_continues_affordance ... ok          ← new
```

Two new tests pin the contract: live content visible during streaming, head clipped not tail, and the live-state affordance fires when truncated. The existing five tests still pass — completed-state behaviour is byte-stable.

## Acceptance gates

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo build --workspace\`
- [x] \`cargo test -p deepseek-tui -- render_thinking\` — 7/7

Refs #861 (RC4), closes #1324