### PR TITLE
feat(prompts): add reliability guidance for verification and tool failure handling

### DIFF
--- a/crates/tui/src/prompts/base.md
+++ b/crates/tui/src/prompts/base.md
@@ -60,6 +60,12 @@ After every tool call that produces a result you'll act on, verify before procee
 
 Don't claim a change worked until you've observed evidence. Don't trust memory over live tool output.
 
+Before reporting a task as complete, verify the result when practical: run the relevant test or command, inspect the output, or confirm the expected file or change exists. If verification was not performed or could not be performed, say so explicitly instead of implying success.
+
+When using tool results, preserve only the key facts needed for later reasoning or the final answer, such as file paths, error messages, command exit status, relevant line numbers, and cache usage values. Do not copy large raw outputs unless the user asks for them.
+
+If a tool call fails, inspect the error before retrying. Do not repeat the identical action blindly. Adjust the command, inputs, or approach based on the failure, and do not abandon a viable approach after a single recoverable failure.
+
 ## Composition Pattern for Multi-Step Work
 
 For any task estimated to take 5+ steps:


### PR DESCRIPTION
## Summary

This PR adds three short guidance rules to the existing `Verification Principle` section in `base.md`. It improves agent behavior around task completion, tool-result handling, and failure recovery — without adding runtime verification or extra model calls.

Fixes issue #1394

## Why it matters

Coding agents commonly exhibit three reliability gaps that prompt guidance can reduce:

1. **Claiming completion without verification** — the model reports a task as done based on expected outcome rather than actual result.
2. **Losing critical context after tool-result cleanup** — compaction clears old tool outputs and the model forgets key facts or fabricates replacements.
3. **Blind retries on tool failure** — the model repeats the identical failing command instead of reading the error and adjusting.

These are all soft failures that don't crash the TUI but erode user trust. Prompt-level rules are a low-risk first step before any runtime mechanism.

## Changes

**Before reporting a task as complete, verify when practical.** If verification was not performed, say so explicitly instead of implying success.

**Preserve only key facts from tool results** (file paths, error messages, exit status, relevant line numbers, cache values). Do not copy large raw outputs unless the user asks.

**If a tool call fails, inspect the error before retrying.** Do not repeat the identical action blindly. Adjust based on the failure, and do not abandon a viable approach after a single recoverable failure.

| File | Change |
|------|--------|
| `crates/tui/src/prompts/base.md` | Added 6 lines to Verification Principle section |

## Non-goals

This PR does not add:
- Runtime claim checking
- Tool Status Guard
- Independent verifier agents
- Additional model calls
- Cache usage schema changes