### PR TITLE
fix(prompts): strengthen language directive so thinking matches user (#1118)

### DIFF
--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -542,6 +542,44 @@ mod tests {
     }
 
     #[test]
+    fn language_section_carries_reasoning_content_directives_for_1118() {
+        // #1118 ("Language has been configured to Chinese, but thinking
+        // outputs are still in English"): the base prompt's language
+        // section is the only knob that steers V4's `reasoning_content`
+        // language. Pin the load-bearing phrases so a future innocuous
+        // edit can't quietly drop them.
+        let lang = BASE_PROMPT;
+        assert!(
+            lang.contains("reasoning_content"),
+            "language section must explicitly call out reasoning_content"
+        );
+        // Bold "must both be in Simplified Chinese" anchor — strong
+        // emphasis aimed at the failure mode V4 falls into where it
+        // mirrors the user message for the final reply but defaults to
+        // English for thinking.
+        assert!(
+            lang.contains("must both be in Simplified Chinese"),
+            "expected the bold Simplified Chinese requirement"
+        );
+        // "overwhelmingly English" — addresses the specific trigger
+        // where a Chinese question lands on a codebase whose system
+        // prompt and context are English-heavy.
+        assert!(
+            lang.contains("overwhelmingly English"),
+            "expected the context-is-English caveat"
+        );
+        // Explicit-user-override clause keeps the prompt useful for the
+        // opposite preference (#1118 commenters who want English
+        // thinking for token-cost reasons).
+        for phrase in ["think in English", "\u{7528}\u{82F1}\u{6587}\u{601D}\u{8003}"] {
+            assert!(
+                lang.contains(phrase),
+                "expected the user-override example `{phrase}`"
+            );
+        }
+    }
+
+    #[test]
     fn environment_block_is_inserted_into_system_prompt() {
         let tmp = tempdir().expect("tempdir");
         let prompt = match system_prompt_for_mode_with_context_skills_and_session(

--- a/crates/tui/src/prompts/base.md
+++ b/crates/tui/src/prompts/base.md
@@ -2,7 +2,11 @@ You are DeepSeek TUI. You're already running inside it — don't try to launch a
 
 ## Language
 
-Choose the natural language for each turn from the latest user message first — both for `reasoning_content` and for the final reply. If the latest user message is Simplified Chinese (简体中文), your `reasoning_content` and final reply must both be in Simplified Chinese, even when the `lang` field in `## Environment` is `en`. If the user switches languages mid-session, switch with them. Use the `lang` field only when the latest user message is missing, mostly code/logs, or otherwise ambiguous.
+Choose the natural language for each turn from the latest user message first — both for `reasoning_content` (your internal thinking) and for the final reply. If the latest user message is Simplified Chinese (简体中文), **your `reasoning_content` and your final reply must both be in Simplified Chinese** — even when the `lang` field in `## Environment` is `en`, even when the surrounding system prompt is in English, and even when the task context (source code, error logs, README excerpts) is overwhelmingly English. Thinking in a different language than the user just wrote in creates a jarring read-back when they expand the thinking block; match the user end-to-end.
+
+If the user switches languages mid-session, switch with them on the very next turn — including in `reasoning_content`. Don't carry the previous turn's language forward. Use the `lang` field only when the latest user message is missing, is mostly code/logs, or is otherwise ambiguous; the `lang` field is a fallback, not an override.
+
+The user can explicitly override the default at any time. Phrases like "think in English", "用英文思考", "reason in Chinese", or "你用中文思考" change the `reasoning_content` language until the next explicit override. Their explicit request wins over their message language — but only for thinking; the final reply still mirrors whatever language they're writing in.
 
 Code, file paths, identifiers, tool names, environment variables, command-line flags, URLs, and log lines stay in their original form — translating `read_file` to `读取文件` would break tool calls. Only natural-language prose mirrors the user.
 


### PR DESCRIPTION
## Summary

[#1118](https://github.com/Hmbown/DeepSeek-TUI/issues/1118): \"Language has been configured to Chinese, but thinking outputs are still in English.\" Maintainer's reply:

> thank you so much - will work on editing the prompt file to make this correct!

This PR is that edit. The existing language directive already said \"both for `reasoning_content` and for the final reply\", but V4 falls into a failure mode where it mirrors the user message for the **final answer** while quietly defaulting to English for **thinking** when the surrounding context (system prompt, code, error logs) is English-heavy.

## Three changes to \`prompts/base.md\`

1. **Bold the requirement and name the failure mode.** The line that used to say \"your `reasoning_content` and final reply must both be in Simplified Chinese, even when the `lang` field is `en`\" now adds \"even when the surrounding system prompt is in English, and even when the task context (source code, error logs, README excerpts) is overwhelmingly English.\" That second clause is exactly the trigger #1118 reports.

2. **Mid-session-switch rule covers thinking too.** Today the prompt says \"switch with them\" but doesn't reinforce that this includes `reasoning_content` — V4 sometimes carries the previous turn's reasoning language forward when the new turn is a single-word follow-up. Added \"on the very next turn — including in `reasoning_content`. Don't carry the previous turn's language forward.\"

3. **Explicit-override clause.** Issue commenter @pmsleepcheck prefers English thinking for token-cost reasons; the prompt now respects \"think in English\" / \"用英文思考\" as a per-session override. Only thinking is overridable — the final reply still mirrors message language.

## Test

\`\`\`
$ cargo test -p deepseek-tui -- language_section_carries
test prompts::tests::language_section_carries_reasoning_content_directives_for_1118 ... ok
test result: ok. 1 passed; 0 failed
\`\`\`

The test pins four load-bearing phrases:
- \`reasoning_content\` (the section must call it out by name)
- \`must both be in Simplified Chinese\` (the bold requirement)
- \`overwhelmingly English\` (the context-is-English caveat)
- both \`think in English\` and \`用英文思考\` (the user-override examples)

The existing \`system_prompt_for_mode_with_context_is_byte_stable_for_unchanged_workspace\` invariant test still passes, so the cached prefix for unchanged sessions remains byte-stable.

## Why prompt-only and not a config option

A prompt fix matches the maintainer's stated direction (\"will work on editing the prompt file\"), is testable today, and ships without surface-area expansion. A future \`[language] reasoning = \"english\"|\"match_user\"\` config could replace the explicit-override paragraph if reviewers want a more structured opt-out — happy to follow up.

## Acceptance gates

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo build --workspace\`
- [x] \`cargo test -p deepseek-tui -- prompts\` — passing (including byte-stability invariants)

Refs #1118