### PR TITLE
Release v0.8.28

### DIFF
--- a/.claude/HANDOFF_v0.8.28_user_issues.md
+++ b/.claude/HANDOFF_v0.8.28_user_issues.md
@@ -193,6 +193,9 @@ v0.9.0** — out of scope for a polish release.
 Recurring request. v0.9.x territory at the earliest. Comment with
 roadmap status if not already.
 
+### #1394 Prompt-level reliability guidance
+Feature/enhancement for prompting (PR #1393). Defer to future release.
+
 ---
 
 ## Workflow

--- a/.github/workflows/sync-cnb.yml
+++ b/.github/workflows/sync-cnb.yml
@@ -1,0 +1,20 @@
+name: Sync to CNB
+
+on: [push]
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      
+      - name: Sync to CNB Repository
+        uses: docker://tencentcom/git-sync
+        env:
+          PLUGIN_TARGET_URL: "https://cnb.cool/deepseek-tui.com/DeepSeek-TUI"
+          PLUGIN_AUTH_TYPE: "https"
+          PLUGIN_USERNAME: "cnb"
+          PLUGIN_PASSWORD: ${{ secrets.CNB_GIT_TOKEN }}
+          PLUGIN_SYNC_MODE: "rebase"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,59 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.28] - 2026-05-10
+
+A maintenance release with four focused bug-fix cherry-picks plus
+test-suite stabilization for parallel-test environment races.
+
+### Fixed
+
+- **Cache usage shows 0 when API omits cache data** (#1391, PR #1392
+  from **@Oliver-ZPLiu**) — `SessionUsage.cache_creation_input_tokens` /
+  `cache_read_input_tokens` are now `Option<u64>` instead of `u64`
+  defaulting to 0. When the upstream API doesn't report cache
+  hit/miss, the model sees `null` instead of misleading zeros, and
+  reasoning about cache utilization is accurate. Includes a
+  truthful-reporting addition to `prompts/base.md` so the model
+  doesn't confidently claim "0% cache hits" from absent data.
+- **Deny of one tool call no longer blocks all future calls of the
+  same tool** (#1377, PR #1388 from **@Oliver-ZPLiu**) — denying a
+  tool call now only caches the per-call `approval_key`, not the
+  tool type. Subsequent invocations of the same tool prompt for
+  approval again instead of being silently auto-denied.
+- **Streaming thinking blocks no longer drop their tail on
+  MessageComplete** (#861 RC3, PR #1389 from **@linzhiqin2003**) —
+  the active streaming entry is now drained into the finalized
+  cell on `MessageComplete`, eliminating a data-loss path where
+  the last chunk(s) of a streaming "thinking" reply could be
+  discarded when `MessageComplete` arrived ahead of
+  `ThinkingComplete` in a bursty event stream. Also closes a
+  related HTTP 400 on the next turn (DeepSeek V4 requires
+  `reasoning_content` replay for assistant messages that carry
+  tool calls).
+- **Streaming thinking renders live in collapsed view** (#861 RC4,
+  #1324, PR #1390 from **@linzhiqin2003**) — collapsed thinking
+  cells now stream their content as it arrives instead of staying
+  at a static "thinking..." placeholder until streaming ends. When
+  the live body exceeds the collapsed budget, the truncation
+  affordance ("thinking continues; press Ctrl+O for full text")
+  now fires during streaming with head lines dropped so the
+  visible window tracks the live cursor at the bottom.
+
+### Internal
+
+- Test-suite parallelism stabilization (see commit
+  `test: stabilize parallel test execution`). Folds three local
+  test-mutex implementations into the process-wide
+  `test_support::lock_test_env`, eliminating a class of
+  intermittent failures (`refresh_system_prompt_is_noop_when_unchanged`,
+  `save_api_key_for_openrouter_writes_provider_table`,
+  `list_archives_sorts_by_cycle_number`) observed during the
+  v0.8.27 release cycle.
+- Windows `task_manager` timeout bumped 3s → 10s on four tests
+  exercising durable task recovery, addressing an intermittent
+  CI timeout on Windows under file-I/O load.
+
 ## [0.8.27] - 2026-05-10
 
 A polish release bundling 17 community PRs plus a focused user-issue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.8.28] - 2026-05-10
 
 A maintenance release bundling four streaming / approvals / cache
-bug-fix cherry-picks, three smaller community fixes, a Cmux
-notification probe, a CNB mirror workflow, and test-suite
+bug-fix cherry-picks, six smaller community fixes, a Cmux
+notification probe, GPU-terminal flicker hardening via DEC 2026
+synchronized output, VS Code low-motion auto-detection, a CNB
+mirror workflow, V4-steered tool descriptions, and test-suite
 stabilization for parallel-test environment races.
 
 ### Added
@@ -30,6 +32,25 @@ stabilization for parallel-test environment races.
   Cmux and WezTerm `LC_TERMINAL` paths; the existing
   unknown-terminal-on-Unix test now clears `LC_TERMINAL` before
   asserting fallback so it doesn't flake on CI hosts that set it.
+- **DEC 2026 synchronized output around terminal repaints** (PR
+  #1361 from **@xuezhaoyu**) — the viewport-reset path now wraps
+  `terminal.clear()` in `\x1b[?2026h` / `\x1b[?2026l` so
+  GPU-accelerated terminals (Ghostty, VSCode Terminal, Kitty,
+  WezTerm) defer rendering until the whole frame is staged,
+  eliminating mid-frame flicker on resize / focus / TurnComplete.
+  The earlier "drop destructive 2J/3J" fix from v0.8.27 stays;
+  this PR is complementary, batching the same lighter reset
+  sequence into a single synchronized frame. Terminals without
+  DEC 2026 support silently ignore the sequence.
+- **`low_motion` auto-enables under VS Code integrated terminal**
+  (PR #1365 from **@CrepuscularIRIS**) — `apply_env_overrides()`
+  now treats `TERM_PROGRAM=vscode` the same way it treats
+  `NO_ANIMATIONS=1`: force `low_motion = true` and
+  `fancy_animations = false`. The VS Code terminal compositor
+  cannot keep up with 120 fps redraws and produces rapid flicker
+  (#1356); the 30 fps low-motion cap is the right default there.
+  Env overlays always win over the disk-loaded value, matching
+  the existing precedence for `NO_ANIMATIONS`.
 
 ### Fixed
 
@@ -75,6 +96,25 @@ stabilization for parallel-test environment races.
 - **Clearer continue tip on idle prompts** (PR #1370 from
   **@nightfallsad**) — the "press Tab to continue" affordance now
   uses concrete language instead of a vague hint.
+- **Ctrl+Enter content lost when engine is idle** (#1331, PR #1347
+  from **@Oliver-ZPLiu**) — when no turn was active, `Ctrl+Enter`
+  routed the message to `rx_steer` (only monitored inside
+  `handle_deepseek_turn`), so the user saw their message in the
+  transcript via the local mirror but the LLM never received it —
+  the next regular Enter would drain it as a "stale steer". The
+  idle path now sends through the standard `handle_send_message`
+  flow so the submission reaches the engine.
+- **Explicit hidden / ignored `@`-mention completions work**
+  (#1270 follow-up) — PR #1270 from **@SamhandsomeLee** landed
+  the `add_local_reference_completions` helper and tests in
+  v0.8.27 but never wired it into `Workspace::completions()` or
+  `build_file_index`. The two regression tests were ignored with
+  a "v0.8.28 follow-up" marker. This release wires the helper
+  into both entry points so `@.deepseek/commands/start-task.md`
+  and `@.generated/specs/device-layout.md` (and the basename
+  fuzzy-resolve equivalent) now surface from gitignored
+  user-folders while `.deepseekignore` entries stay blocked.
+  Both tests un-ignored.
 
 ### Changed
 
@@ -85,6 +125,19 @@ stabilization for parallel-test environment races.
   inspect errors before retrying. Combined with the truthful-
   reporting addition from #1392, the model is less likely to claim
   unverified successes or repeat the identical failing tool call.
+- **V4-steered tool descriptions** (#711, PR #1379 from
+  **@linzhiqin2003**) — every model-visible tool description
+  (`read_file`, `write_file`, `edit_file`, `list_dir`,
+  `grep_files`, `file_search`, `web_search`, `apply_patch`,
+  `fetch_url`) now opens with a short *"use this instead of X
+  in exec_shell"* steering line, the return shape, and the
+  limits. Routes V4 toward our typed tools and away from
+  shell footguns. All description strings stay under 1024
+  chars (max: 350) with no embedded newlines so the cached
+  tool catalogue stays prefix-stable for V4's KV cache.
+  Removes the unused legacy `normal.txt` / `plan.txt` /
+  `yolo.txt` prompt templates (referenced only by their own
+  self-tests).
 
 ### Internal
 
@@ -106,6 +159,15 @@ stabilization for parallel-test environment races.
   on every run, which then contaminated parallel-running picker
   tests because Ollama is a pass-through provider that hides the
   DeepSeek model rows.
+- `settings::tests::no_animations_test_guard` and
+  `term_program_test_guard` both now return
+  `crate::test_support::lock_test_env()` instead of their own
+  module-local mutexes — folding them into the same
+  process-wide test env lock the v0.8.27 EnvGuard family was
+  migrated to. Without this, a `NO_ANIMATIONS=1` write from one
+  test family could race a `TERM_PROGRAM=iTerm.app` write from
+  the other through the shared `apply_env_overrides` path and
+  flip `low_motion` to `true` on the assertion side.
 
 ## [0.8.27] - 2026-05-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.8.28] - 2026-05-10
 
-A maintenance release with four focused bug-fix cherry-picks plus
-test-suite stabilization for parallel-test environment races.
+A maintenance release bundling four streaming / approvals / cache
+bug-fix cherry-picks, three smaller community fixes, a Cmux
+notification probe, a CNB mirror workflow, and test-suite
+stabilization for parallel-test environment races.
+
+### Added
+
+- **CNB mirror workflow** (PR #1373 from **@Anyexyz**) — a
+  GitHub Actions workflow (`sync-cnb.yml`) mirrors every push to
+  the `cnb.cool/deepseek-tui.com/DeepSeek-TUI` repository,
+  closing out the long-standing China-mirror request. Requires the
+  `CNB_GIT_TOKEN` repo secret.
+- **Cmux desktop notification support via `LC_TERMINAL`** (#1281,
+  PR #1340 from **@CrepuscularIRIS**) — Cmux sets
+  `LC_TERMINAL=Cmux` rather than `TERM_PROGRAM`, so the previous
+  notification probe fell back to `BEL` instead of using OSC 9.
+  `resolve_method()` now checks `LC_TERMINAL` as a secondary probe
+  and adds Cmux to the OSC 9 allowlist. Terminals that set
+  neither env var can still force OSC 9 via
+  `[notifications].method = "osc9"`. Two regression tests pin the
+  Cmux and WezTerm `LC_TERMINAL` paths; the existing
+  unknown-terminal-on-Unix test now clears `LC_TERMINAL` before
+  asserting fallback so it doesn't flake on CI hosts that set it.
 
 ### Fixed
 
@@ -17,9 +38,7 @@ test-suite stabilization for parallel-test environment races.
   `cache_read_input_tokens` are now `Option<u64>` instead of `u64`
   defaulting to 0. When the upstream API doesn't report cache
   hit/miss, the model sees `null` instead of misleading zeros, and
-  reasoning about cache utilization is accurate. Includes a
-  truthful-reporting addition to `prompts/base.md` so the model
-  doesn't confidently claim "0% cache hits" from absent data.
+  reasoning about cache utilization is accurate.
 - **Deny of one tool call no longer blocks all future calls of the
   same tool** (#1377, PR #1388 from **@Oliver-ZPLiu**) — denying a
   tool call now only caches the per-call `approval_key`, not the
@@ -43,10 +62,33 @@ test-suite stabilization for parallel-test environment races.
   affordance ("thinking continues; press Ctrl+O for full text")
   now fires during streaming with head lines dropped so the
   visible window tracks the live cursor at the bottom.
+- **First-turn latency bounded on large workspaces** (#697, PR #1386
+  from **@linzhiqin2003**) — the working-set file walker now caps
+  the number of entries it visits during initial indexing, so
+  starting a session in a workspace with a deep `node_modules`,
+  `target`, or `.venv` no longer stalls the first response on
+  filesystem traversal.
+- **Duplicate error toast on transcript-rendered turn errors** (PR
+  #1368 from **@douglarek**) — when a turn error is already in the
+  transcript as a system/error cell, the status-line toast is
+  suppressed so the user doesn't see the same failure twice.
+- **Clearer continue tip on idle prompts** (PR #1370 from
+  **@nightfallsad**) — the "press Tab to continue" affordance now
+  uses concrete language instead of a vague hint.
+
+### Changed
+
+- **Prompt-side reliability guidance** (PR #1393 from
+  **@Oliver-ZPLiu**) — `prompts/base.md` gains three Verification
+  Principle bullets steering the model to verify before reporting
+  complete, preserve only key facts from tool results, and
+  inspect errors before retrying. Combined with the truthful-
+  reporting addition from #1392, the model is less likely to claim
+  unverified successes or repeat the identical failing tool call.
 
 ### Internal
 
-- Test-suite parallelism stabilization (see commit
+- Test-suite parallelism stabilization (commit
   `test: stabilize parallel test execution`). Folds three local
   test-mutex implementations into the process-wide
   `test_support::lock_test_env`, eliminating a class of
@@ -57,6 +99,13 @@ test-suite stabilization for parallel-test environment races.
 - Windows `task_manager` timeout bumped 3s → 10s on four tests
   exercising durable task recovery, addressing an intermittent
   CI timeout on Windows under file-I/O load.
+- `provider_switch_clears_turn_cache_history` now isolates
+  `HOME` / `USERPROFILE` to a tempdir for its lifetime. The test
+  was silently writing `default_provider = "ollama"` to the
+  developer's real `~/Library/Application Support/deepseek/settings.toml`
+  on every run, which then contaminated parallel-running picker
+  tests because Ollama is a pass-through provider that hides the
+  DeepSeek model rows.
 
 ## [0.8.27] - 2026-05-10
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1151,7 +1151,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-agent"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "deepseek-config",
  "serde",
@@ -1159,7 +1159,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-app-server"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "axum",
@@ -1181,7 +1181,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-config"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "deepseek-secrets",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-core"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-execpolicy"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "deepseek-protocol",
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-hooks"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1234,7 +1234,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-mcp"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "serde",
@@ -1243,7 +1243,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-protocol"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "serde",
  "serde_json",
@@ -1251,7 +1251,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-secrets"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "dirs",
  "keyring",
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-state"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1276,7 +1276,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-tools"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1289,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-tui"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "arboard",
@@ -1350,7 +1350,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-tui-cli"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1375,7 +1375,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-tui-core"
-version = "0.8.27"
+version = "0.8.28"
 
 [[package]]
 name = "deltae"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = ["crates/cli", "crates/app-server", "crates/tui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.8.27"
+version = "0.8.28"
 edition = "2024"
 # Rust 1.88 stabilized `let_chains` in `if`/`while` conditions, which the
 # codebase relies on extensively. Cargo enforces this so users on older

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -7,5 +7,5 @@ repository.workspace = true
 description = "Model/provider registry and fallback strategy for DeepSeek workspace architecture"
 
 [dependencies]
-deepseek-config = { path = "../config", version = "0.8.27" }
+deepseek-config = { path = "../config", version = "0.8.28" }
 serde.workspace = true

--- a/crates/app-server/Cargo.toml
+++ b/crates/app-server/Cargo.toml
@@ -10,15 +10,15 @@ description = "Codex-style app-server transport for DeepSeek workspace architect
 anyhow.workspace = true
 axum.workspace = true
 clap.workspace = true
-deepseek-agent = { path = "../agent", version = "0.8.27" }
-deepseek-config = { path = "../config", version = "0.8.27" }
-deepseek-core = { path = "../core", version = "0.8.27" }
-deepseek-execpolicy = { path = "../execpolicy", version = "0.8.27" }
-deepseek-hooks = { path = "../hooks", version = "0.8.27" }
-deepseek-mcp = { path = "../mcp", version = "0.8.27" }
-deepseek-protocol = { path = "../protocol", version = "0.8.27" }
-deepseek-state = { path = "../state", version = "0.8.27" }
-deepseek-tools = { path = "../tools", version = "0.8.27" }
+deepseek-agent = { path = "../agent", version = "0.8.28" }
+deepseek-config = { path = "../config", version = "0.8.28" }
+deepseek-core = { path = "../core", version = "0.8.28" }
+deepseek-execpolicy = { path = "../execpolicy", version = "0.8.28" }
+deepseek-hooks = { path = "../hooks", version = "0.8.28" }
+deepseek-mcp = { path = "../mcp", version = "0.8.28" }
+deepseek-protocol = { path = "../protocol", version = "0.8.28" }
+deepseek-state = { path = "../state", version = "0.8.28" }
+deepseek-tools = { path = "../tools", version = "0.8.28" }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -14,13 +14,13 @@ path = "src/main.rs"
 anyhow.workspace = true
 clap.workspace = true
 clap_complete.workspace = true
-deepseek-agent = { path = "../agent", version = "0.8.27" }
-deepseek-app-server = { path = "../app-server", version = "0.8.27" }
-deepseek-config = { path = "../config", version = "0.8.27" }
-deepseek-execpolicy = { path = "../execpolicy", version = "0.8.27" }
-deepseek-mcp = { path = "../mcp", version = "0.8.27" }
-deepseek-secrets = { path = "../secrets", version = "0.8.27" }
-deepseek-state = { path = "../state", version = "0.8.27" }
+deepseek-agent = { path = "../agent", version = "0.8.28" }
+deepseek-app-server = { path = "../app-server", version = "0.8.28" }
+deepseek-config = { path = "../config", version = "0.8.28" }
+deepseek-execpolicy = { path = "../execpolicy", version = "0.8.28" }
+deepseek-mcp = { path = "../mcp", version = "0.8.28" }
+deepseek-secrets = { path = "../secrets", version = "0.8.28" }
+deepseek-state = { path = "../state", version = "0.8.28" }
 chrono.workspace = true
 dirs.workspace = true
 serde.workspace = true

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -8,7 +8,7 @@ description = "Config schema and precedence model for DeepSeek workspace archite
 
 [dependencies]
 anyhow.workspace = true
-deepseek-secrets = { path = "../secrets", version = "0.8.27" }
+deepseek-secrets = { path = "../secrets", version = "0.8.28" }
 dirs.workspace = true
 serde.workspace = true
 toml.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -9,13 +9,13 @@ description = "Core runtime boundaries for DeepSeek workspace architecture"
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true
-deepseek-agent = { path = "../agent", version = "0.8.27" }
-deepseek-config = { path = "../config", version = "0.8.27" }
-deepseek-execpolicy = { path = "../execpolicy", version = "0.8.27" }
-deepseek-hooks = { path = "../hooks", version = "0.8.27" }
-deepseek-mcp = { path = "../mcp", version = "0.8.27" }
-deepseek-protocol = { path = "../protocol", version = "0.8.27" }
-deepseek-state = { path = "../state", version = "0.8.27" }
-deepseek-tools = { path = "../tools", version = "0.8.27" }
+deepseek-agent = { path = "../agent", version = "0.8.28" }
+deepseek-config = { path = "../config", version = "0.8.28" }
+deepseek-execpolicy = { path = "../execpolicy", version = "0.8.28" }
+deepseek-hooks = { path = "../hooks", version = "0.8.28" }
+deepseek-mcp = { path = "../mcp", version = "0.8.28" }
+deepseek-protocol = { path = "../protocol", version = "0.8.28" }
+deepseek-state = { path = "../state", version = "0.8.28" }
+deepseek-tools = { path = "../tools", version = "0.8.28" }
 serde_json.workspace = true
 uuid.workspace = true

--- a/crates/execpolicy/Cargo.toml
+++ b/crates/execpolicy/Cargo.toml
@@ -8,5 +8,5 @@ description = "Execution policy and approval model parity for DeepSeek workspace
 
 [dependencies]
 anyhow.workspace = true
-deepseek-protocol = { path = "../protocol", version = "0.8.27" }
+deepseek-protocol = { path = "../protocol", version = "0.8.28" }
 serde.workspace = true

--- a/crates/hooks/Cargo.toml
+++ b/crates/hooks/Cargo.toml
@@ -10,7 +10,7 @@ description = "Hook dispatch and notifications parity for DeepSeek workspace arc
 anyhow.workspace = true
 async-trait.workspace = true
 chrono.workspace = true
-deepseek-protocol = { path = "../protocol", version = "0.8.27" }
+deepseek-protocol = { path = "../protocol", version = "0.8.28" }
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -9,7 +9,7 @@ description = "Tool invocation lifecycle, schema validation, and scheduler paral
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
-deepseek-protocol = { path = "../protocol", version = "0.8.27" }
+deepseek-protocol = { path = "../protocol", version = "0.8.28" }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -21,8 +21,8 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0.100"
 arboard = "3.4"
-deepseek-secrets = { path = "../secrets", version = "0.8.27" }
-deepseek-tools = { path = "../tools", version = "0.8.27" }
+deepseek-secrets = { path = "../secrets", version = "0.8.28" }
+deepseek-tools = { path = "../tools", version = "0.8.28" }
 schemaui = { version = "0.12.0", default-features = false, optional = true }
 async-stream = "0.3.6"
 async-trait = "0.1"

--- a/crates/tui/src/commands/config.rs
+++ b/crates/tui/src/commands/config.rs
@@ -1040,10 +1040,12 @@ mod tests {
         home: Option<OsString>,
         userprofile: Option<OsString>,
         deepseek_config_path: Option<OsString>,
+        _lock: std::sync::MutexGuard<'static, ()>,
     }
 
     impl EnvGuard {
         fn new(home: &Path) -> Self {
+            let lock = crate::test_support::lock_test_env();
             let home_str = OsString::from(home.as_os_str());
             let config_path = home.join(".deepseek").join("config.toml");
             let config_str = OsString::from(config_path.as_os_str());
@@ -1051,7 +1053,7 @@ mod tests {
             let userprofile_prev = env::var_os("USERPROFILE");
             let deepseek_config_prev = env::var_os("DEEPSEEK_CONFIG_PATH");
 
-            // Safety: test-only environment mutation guarded by a global mutex.
+            // Safety: test-only environment mutation guarded by process-wide mutex.
             unsafe {
                 env::set_var("HOME", &home_str);
                 env::set_var("USERPROFILE", &home_str);
@@ -1062,6 +1064,7 @@ mod tests {
                 home: home_prev,
                 userprofile: userprofile_prev,
                 deepseek_config_path: deepseek_config_prev,
+                _lock: lock,
             }
         }
     }
@@ -1296,7 +1299,6 @@ mod tests {
 
     #[test]
     fn test_set_default_mode_normal_save_reports_normalized_value() {
-        let _lock = lock_test_env();
         let nanos = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
@@ -1322,7 +1324,6 @@ mod tests {
 
     #[test]
     fn config_command_cost_currency_save_persists_value() {
-        let _lock = lock_test_env();
         let nanos = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
@@ -1426,7 +1427,6 @@ mod tests {
 
     #[test]
     fn test_logout_clears_api_key_state() {
-        let _lock = lock_test_env();
         let nanos = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
@@ -1476,7 +1476,6 @@ mod tests {
 
     #[test]
     fn persist_status_items_writes_tui_section_to_config_toml() {
-        let _lock = lock_test_env();
         let nanos = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
@@ -1508,7 +1507,6 @@ mod tests {
 
     #[test]
     fn persist_status_items_preserves_existing_unrelated_keys() {
-        let _lock = lock_test_env();
         let nanos = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()

--- a/crates/tui/src/commands/network.rs
+++ b/crates/tui/src/commands/network.rs
@@ -269,7 +269,6 @@ fn display_list(values: &[String]) -> String {
 mod tests {
     use super::*;
     use crate::config::Config;
-    use crate::test_support::lock_test_env;
     use crate::tui::app::{App, TuiOptions};
     use std::env;
     use std::ffi::OsString;
@@ -280,10 +279,12 @@ mod tests {
         home: Option<OsString>,
         userprofile: Option<OsString>,
         deepseek_config_path: Option<OsString>,
+        _lock: std::sync::MutexGuard<'static, ()>,
     }
 
     impl EnvGuard {
         fn new(home: &Path) -> Self {
+            let lock = crate::test_support::lock_test_env();
             let config_path = home.join(".deepseek").join("config.toml");
             let home_prev = env::var_os("HOME");
             let userprofile_prev = env::var_os("USERPROFILE");
@@ -300,6 +301,7 @@ mod tests {
                 home: home_prev,
                 userprofile: userprofile_prev,
                 deepseek_config_path: deepseek_config_prev,
+                _lock: lock,
             }
         }
     }
@@ -363,7 +365,6 @@ mod tests {
 
     #[test]
     fn network_allow_persists_host_and_removes_exact_deny() {
-        let _lock = lock_test_env();
         let home = temp_home("allow");
         let _guard = EnvGuard::new(&home);
         let config_path = home.join(".deepseek").join("config.toml");
@@ -385,7 +386,6 @@ mod tests {
 
     #[test]
     fn network_allow_extracts_host_from_url() {
-        let _lock = lock_test_env();
         let home = temp_home("url");
         let _guard = EnvGuard::new(&home);
 
@@ -399,7 +399,6 @@ mod tests {
 
     #[test]
     fn network_default_rejects_unknown_value() {
-        let _lock = lock_test_env();
         let home = temp_home("default");
         let _guard = EnvGuard::new(&home);
 

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -5287,6 +5287,7 @@ api_key = "novita-table-key"
         ));
         fs::create_dir_all(&temp_root)?;
         let _guard = EnvGuard::new(&temp_root);
+        unsafe { std::env::set_var("DEEPSEEK_SECRET_BACKEND", "local") };
 
         let path = save_api_key_for(ApiProvider::Openrouter, "or-saved-key")?;
         let contents = fs::read_to_string(&path)?;
@@ -5365,6 +5366,7 @@ api_key = "novita-table-key"
         ));
         fs::create_dir_all(&temp_root)?;
         let _guard = EnvGuard::new(&temp_root);
+        unsafe { std::env::set_var("DEEPSEEK_SECRET_BACKEND", "local") };
 
         let path = save_api_key_for(ApiProvider::DeepseekCN, "cn-saved-key")?;
         let contents = fs::read_to_string(&path)?;

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -432,10 +432,12 @@ fn default_threshold_secs() -> u64 {
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct NotificationsConfig {
     /// Delivery method: `auto` | `osc9` | `bel` | `off`. Default: `auto`.
-    /// `auto` resolves to OSC 9 in iTerm.app / Ghostty / WezTerm; on
-    /// macOS / Linux it falls back to BEL, and on Windows it falls
-    /// back to `Off` so the post-turn notification doesn't ring the
-    /// system error chime (#583).
+    /// `auto` resolves to OSC 9 for iTerm.app / Ghostty / WezTerm / Cmux
+    /// (detected via `$TERM_PROGRAM` then `$LC_TERMINAL`); on macOS / Linux
+    /// it falls back to BEL, and on Windows it falls back to `Off` so the
+    /// post-turn notification doesn't ring the system error chime (#583).
+    /// Use `method = "osc9"` explicitly when your terminal is OSC-9 capable
+    /// but sets neither env var (e.g. Cmux without `LC_TERMINAL`).
     #[serde(default)]
     pub method: NotificationMethod,
     /// Only notify when the turn took at least this many seconds. Default: 30.

--- a/crates/tui/src/core/session.rs
+++ b/crates/tui/src/core/session.rs
@@ -90,10 +90,12 @@ pub struct Session {
 pub struct SessionUsage {
     pub input_tokens: u64,
     pub output_tokens: u64,
-    #[allow(dead_code)]
-    pub cache_creation_input_tokens: u64,
-    #[allow(dead_code)]
-    pub cache_read_input_tokens: u64,
+    /// Cache creation (miss) tokens. `None` when never observed by the API —
+    /// do NOT display as 0, which would be indistinguishable from "no misses".
+    pub cache_creation_input_tokens: Option<u64>,
+    /// Cache read (hit) tokens. `None` when never observed by the API —
+    /// do NOT display as 0, which would be indistinguishable from "no hits".
+    pub cache_read_input_tokens: Option<u64>,
 }
 
 impl SessionUsage {
@@ -102,10 +104,12 @@ impl SessionUsage {
         self.input_tokens += u64::from(usage.input_tokens);
         self.output_tokens += u64::from(usage.output_tokens);
         if let Some(tokens) = usage.prompt_cache_miss_tokens {
-            self.cache_creation_input_tokens += u64::from(tokens);
+            self.cache_creation_input_tokens =
+                Some(self.cache_creation_input_tokens.unwrap_or(0) + u64::from(tokens));
         }
         if let Some(tokens) = usage.prompt_cache_hit_tokens {
-            self.cache_read_input_tokens += u64::from(tokens);
+            self.cache_read_input_tokens =
+                Some(self.cache_read_input_tokens.unwrap_or(0) + u64::from(tokens));
         }
     }
 }
@@ -163,5 +167,72 @@ impl Session {
     pub fn rebuild_working_set(&mut self) {
         self.working_set
             .rebuild_from_messages(&self.messages, &self.workspace);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_usage_cache_starts_none() {
+        let usage = SessionUsage::default();
+        assert!(usage.cache_creation_input_tokens.is_none());
+        assert!(usage.cache_read_input_tokens.is_none());
+    }
+
+    #[test]
+    fn session_usage_cache_remains_none_when_api_omits_cache() {
+        let mut usage = SessionUsage::default();
+        let api_usage = Usage {
+            input_tokens: 100,
+            output_tokens: 50,
+            prompt_cache_hit_tokens: None,
+            prompt_cache_miss_tokens: None,
+            reasoning_tokens: None,
+            reasoning_replay_tokens: None,
+            server_tool_use: None,
+        };
+        usage.add(&api_usage);
+        assert!(usage.cache_creation_input_tokens.is_none());
+        assert!(usage.cache_read_input_tokens.is_none());
+    }
+
+    #[test]
+    fn session_usage_cache_accumulates_when_reported() {
+        let mut usage = SessionUsage::default();
+        let api_usage = Usage {
+            input_tokens: 100,
+            output_tokens: 50,
+            prompt_cache_hit_tokens: Some(30),
+            prompt_cache_miss_tokens: Some(70),
+            reasoning_tokens: None,
+            reasoning_replay_tokens: None,
+            server_tool_use: None,
+        };
+        usage.add(&api_usage);
+        assert_eq!(usage.cache_read_input_tokens, Some(30));
+        assert_eq!(usage.cache_creation_input_tokens, Some(70));
+        usage.add(&api_usage);
+        assert_eq!(usage.cache_read_input_tokens, Some(60));
+        assert_eq!(usage.cache_creation_input_tokens, Some(140));
+    }
+
+    #[test]
+    fn session_usage_cache_preserves_explicit_zero() {
+        let mut usage = SessionUsage::default();
+        let api_usage = Usage {
+            input_tokens: 100,
+            output_tokens: 50,
+            prompt_cache_hit_tokens: Some(0), // explicit zero from provider
+            prompt_cache_miss_tokens: Some(1234),
+            reasoning_tokens: None,
+            reasoning_replay_tokens: None,
+            server_tool_use: None,
+        };
+        usage.add(&api_usage);
+        // 0 is a valid observed value, must NOT be converted to None
+        assert_eq!(usage.cache_read_input_tokens, Some(0));
+        assert_eq!(usage.cache_creation_input_tokens, Some(1234));
     }
 }

--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -157,8 +157,6 @@ pub const COMPACT_TEMPLATE: &str = include_str!("prompts/compact.md");
 /// Legacy base prompt (agent.txt — now decomposed into base.md + overlays).
 /// Still available for callers that haven't migrated to the layered API.
 pub const AGENT_PROMPT: &str = include_str!("prompts/agent.txt");
-pub const YOLO_PROMPT: &str = include_str!("prompts/yolo.txt");
-pub const PLAN_PROMPT: &str = include_str!("prompts/plan.txt");
 
 // ── Personality selection ─────────────────────────────────────────────
 
@@ -939,10 +937,8 @@ mod tests {
 
     #[test]
     fn legacy_constants_still_available() {
-        // Verify the old .txt constants still compile and contain expected content
+        // Verify the legacy .txt constant still compiles and contains expected content
         assert!(!AGENT_PROMPT.is_empty());
-        assert!(!YOLO_PROMPT.is_empty());
-        assert!(!PLAN_PROMPT.is_empty());
     }
 
     // ── Cache-prefix stability harness (#263 step 2) ───────────────────────

--- a/crates/tui/src/prompts/base.md
+++ b/crates/tui/src/prompts/base.md
@@ -60,6 +60,10 @@ After every tool call that produces a result you'll act on, verify before procee
 
 Don't claim a change worked until you've observed evidence. Don't trust memory over live tool output.
 
+**Report outcomes faithfully.** If a tool call fails or returns no data, say so. If you did not run a verification step, say that — don't imply it succeeded. Never claim "all tests pass" when output shows failures. State what actually happened, not what you expected.
+
+When the API does not report cache usage (`prompt_cache_hit_tokens` or `prompt_cache_miss_tokens` are absent/`null`), treat cache status as **unknown** — not zero. Do not report "cache miss" or "cache hit rate 0%" for unobserved metrics.
+
 ## Composition Pattern for Multi-Step Work
 
 For any task estimated to take 5+ steps:

--- a/crates/tui/src/prompts/base.md
+++ b/crates/tui/src/prompts/base.md
@@ -60,9 +60,15 @@ After every tool call that produces a result you'll act on, verify before procee
 
 Don't claim a change worked until you've observed evidence. Don't trust memory over live tool output.
 
-**Report outcomes faithfully.** If a tool call fails or returns no data, say so. If you did not run a verification step, say that — don't imply it succeeded. Never claim "all tests pass" when output shows failures. State what actually happened, not what you expected.
+Before reporting a task as complete, verify the result when practical: run the relevant test or command, inspect the output, or confirm the expected file or change exists. If verification was not performed or could not be performed, say so explicitly instead of implying success.
+
+**Report outcomes faithfully.** If a tool call fails or returns no data, say so. Never claim "all tests pass" when output shows failures. State what actually happened, not what you expected.
 
 When the API does not report cache usage (`prompt_cache_hit_tokens` or `prompt_cache_miss_tokens` are absent/`null`), treat cache status as **unknown** — not zero. Do not report "cache miss" or "cache hit rate 0%" for unobserved metrics.
+
+When using tool results, preserve only the key facts needed for later reasoning or the final answer, such as file paths, error messages, command exit status, relevant line numbers, and cache usage values. Do not copy large raw outputs unless the user asks for them.
+
+If a tool call fails, inspect the error before retrying. Do not repeat the identical action blindly. Adjust the command, inputs, or approach based on the failure, and do not abandon a viable approach after a single recoverable failure.
 
 ## Composition Pattern for Multi-Step Work
 

--- a/crates/tui/src/prompts/normal.txt
+++ b/crates/tui/src/prompts/normal.txt
@@ -1,6 +1,0 @@
-## Mode: normal
-
-Reads and `rlm` run silently. Writes, patches, and shell commands ask for approval.
-
-Before requesting writes, use `checklist_write` to outline your approach — visible plans build trust.
-For complex work, layer `update_plan` (strategy) above `checklist_write` (tactics).

--- a/crates/tui/src/prompts/plan.txt
+++ b/crates/tui/src/prompts/plan.txt
@@ -1,8 +1,0 @@
-## Mode: plan
-
-Investigate first, act later. Use `update_plan` to lay out high-level strategy and `checklist_write` for
-granular, verifiable steps. All writes and patches are blocked — you can read the world but you
-can't change it. Shell and code execution are unavailable.
-
-Use this mode to build a thorough plan. Spawn read-only sub-agents for parallel investigation.
-When the plan is solid, the user will switch modes so you can execute.

--- a/crates/tui/src/prompts/yolo.txt
+++ b/crates/tui/src/prompts/yolo.txt
@@ -1,8 +1,0 @@
-## Mode: yolo
-
-All actions auto-approved. Move fast, but think before you write. If you're about to delete files,
-overwrite user work, or run destructive commands, pause and double-check. The undo button is the user's Git history.
-
-Even with auto-approval, create a `checklist_write` first so your work is visible and trackable in the
-sidebar. Decomposition is not red tape — it's how you organize complex work and demonstrate thoroughness.
-For multi-step initiatives, use `update_plan` + `checklist_write` together.

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -903,8 +903,7 @@ mod tests {
     /// Serialise tests that mutate `DEEPSEEK_CONFIG_PATH` through this guard
     /// so the parallel test runner doesn't observe interleaved env values.
     fn config_path_test_guard() -> std::sync::MutexGuard<'static, ()> {
-        static GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
-        GUARD.lock().unwrap_or_else(|e| e.into_inner())
+        crate::test_support::lock_test_env()
     }
 
     #[test]

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -316,6 +316,16 @@ impl Settings {
             self.low_motion = true;
             self.fancy_animations = false;
         }
+        // VS Code's integrated terminal sets TERM_PROGRAM=vscode. Its
+        // compositor cannot keep up with 120 FPS redraws and produces rapid
+        // flickering (#1356). Drop to the 30 FPS low-motion cap automatically
+        // unless the user has explicitly opted out via `low_motion = false` in
+        // their settings file — honoured only when the file exists, otherwise
+        // the default (false) would suppress this useful auto-detection.
+        if std::env::var("TERM_PROGRAM").as_deref() == Ok("vscode") {
+            self.low_motion = true;
+            self.fancy_animations = false;
+        }
     }
 
     /// Save settings to disk
@@ -893,6 +903,65 @@ mod tests {
         // SAFETY: cleanup under the guard.
         unsafe {
             std::env::remove_var("NO_ANIMATIONS");
+        }
+    }
+
+    /// Serialise tests that mutate `TERM_PROGRAM` through this guard.
+    fn term_program_test_guard() -> std::sync::MutexGuard<'static, ()> {
+        static GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        GUARD.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    #[test]
+    fn vscode_term_program_forces_low_motion_on() {
+        let _g = term_program_test_guard();
+        let prev = std::env::var_os("TERM_PROGRAM");
+        // SAFETY: serialised by the guard.
+        unsafe {
+            std::env::set_var("TERM_PROGRAM", "vscode");
+        }
+        let mut settings = Settings::default();
+        assert!(!settings.low_motion, "default is animated");
+        settings.apply_env_overrides();
+        assert!(
+            settings.low_motion,
+            "TERM_PROGRAM=vscode must enable low_motion to prevent flickering (#1356)"
+        );
+        assert!(
+            !settings.fancy_animations,
+            "TERM_PROGRAM=vscode must disable fancy_animations"
+        );
+        // SAFETY: cleanup under the guard.
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("TERM_PROGRAM", v),
+                None => std::env::remove_var("TERM_PROGRAM"),
+            }
+        }
+    }
+
+    #[test]
+    fn non_vscode_term_program_does_not_force_low_motion() {
+        let _g = term_program_test_guard();
+        let prev = std::env::var_os("TERM_PROGRAM");
+        for program in ["iTerm.app", "Apple_Terminal", "WezTerm", "xterm-256color"] {
+            // SAFETY: serialised by the guard.
+            unsafe {
+                std::env::set_var("TERM_PROGRAM", program);
+            }
+            let mut s = Settings::default();
+            s.apply_env_overrides();
+            assert!(
+                !s.low_motion,
+                "TERM_PROGRAM={program:?} should not force low_motion"
+            );
+        }
+        // SAFETY: cleanup under the guard.
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("TERM_PROGRAM", v),
+                None => std::env::remove_var("TERM_PROGRAM"),
+            }
         }
     }
 

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -826,10 +826,13 @@ mod tests {
 
     /// Tests that mutate process-global `NO_ANIMATIONS` serialise
     /// through this guard so the cargo parallel runner doesn't
-    /// observe interleaved overrides.
+    /// observe interleaved overrides. Uses the process-wide test env
+    /// lock so this serializes with the TERM_PROGRAM tests too —
+    /// otherwise a `NO_ANIMATIONS=1` leak from this test family can
+    /// flip a concurrent `TERM_PROGRAM=iTerm` test's `low_motion`
+    /// assertion through the shared `apply_env_overrides` path.
     fn no_animations_test_guard() -> std::sync::MutexGuard<'static, ()> {
-        static GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
-        GUARD.lock().unwrap_or_else(|e| e.into_inner())
+        crate::test_support::lock_test_env()
     }
 
     #[test]
@@ -906,9 +909,13 @@ mod tests {
     }
 
     /// Serialise tests that mutate `TERM_PROGRAM` through this guard.
+    /// Uses the process-wide test env lock so this serializes not just
+    /// with itself but with every other env-mutating test in the suite
+    /// — otherwise a concurrent test that calls `Settings::default()`
+    /// can read whatever value our two `set_var`s have raced into the
+    /// env at that instant.
     fn term_program_test_guard() -> std::sync::MutexGuard<'static, ()> {
-        static GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
-        GUARD.lock().unwrap_or_else(|e| e.into_inner())
+        crate::test_support::lock_test_env()
     }
 
     #[test]

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -318,10 +318,9 @@ impl Settings {
         }
         // VS Code's integrated terminal sets TERM_PROGRAM=vscode. Its
         // compositor cannot keep up with 120 FPS redraws and produces rapid
-        // flickering (#1356). Drop to the 30 FPS low-motion cap automatically
-        // unless the user has explicitly opted out via `low_motion = false` in
-        // their settings file — honoured only when the file exists, otherwise
-        // the default (false) would suppress this useful auto-detection.
+        // flickering (#1356). Drop to the 30 FPS low-motion cap automatically.
+        // Like NO_ANIMATIONS above, this unconditionally overrides any
+        // disk-loaded value — consistent precedence: env signals always win.
         if std::env::var("TERM_PROGRAM").as_deref() == Ok("vscode") {
             self.low_motion = true;
             self.fancy_animations = false;

--- a/crates/tui/src/task_manager.rs
+++ b/crates/tui/src/task_manager.rs
@@ -1746,7 +1746,7 @@ mod tests {
         let task = manager
             .add_task(NewTaskRequest::from_prompt("test persistence"))
             .await?;
-        let finished = wait_for_terminal_state(&manager, &task.id, Duration::from_secs(3)).await?;
+        let finished = wait_for_terminal_state(&manager, &task.id, Duration::from_secs(10)).await?;
         assert_eq!(finished.status, TaskStatus::Completed);
         assert_eq!(finished.thread_id.as_deref(), Some("thr_test"));
         assert_eq!(finished.turn_id.as_deref(), Some("turn_test"));
@@ -1774,7 +1774,7 @@ mod tests {
         let task = manager
             .add_task(NewTaskRequest::from_prompt("test metadata"))
             .await?;
-        let finished = wait_for_terminal_state(&manager, &task.id, Duration::from_secs(3)).await?;
+        let finished = wait_for_terminal_state(&manager, &task.id, Duration::from_secs(10)).await?;
         let updated = manager
             .record_tool_metadata(
                 &finished.id,
@@ -1815,7 +1815,7 @@ mod tests {
 
         sleep(Duration::from_millis(10)).await;
         let _ = manager.cancel_task(&task.id).await?;
-        let finished = wait_for_terminal_state(&manager, &task.id, Duration::from_secs(3)).await?;
+        let finished = wait_for_terminal_state(&manager, &task.id, Duration::from_secs(10)).await?;
         assert_eq!(finished.status, TaskStatus::Canceled);
         Ok(())
     }
@@ -1865,7 +1865,7 @@ mod tests {
         let task = manager
             .add_task(NewTaskRequest::from_prompt("test schema gate"))
             .await?;
-        let _ = wait_for_terminal_state(&manager, &task.id, Duration::from_secs(3)).await?;
+        let _ = wait_for_terminal_state(&manager, &task.id, Duration::from_secs(10)).await?;
         drop(manager);
 
         let task_path = root.join("tasks").join(format!("{}.json", task.id));

--- a/crates/tui/src/tools/apply_patch.rs
+++ b/crates/tui/src/tools/apply_patch.rs
@@ -153,7 +153,7 @@ impl ToolSpec for ApplyPatchTool {
     }
 
     fn description(&self) -> &'static str {
-        "Apply a unified diff patch to a file. Supports multi-hunk patches with fuzzy matching."
+        "Apply a unified-diff patch (multi-hunk, multi-file). Use this instead of `git apply`, `patch`, or repeated `edit_file` calls in `exec_shell` — single transactional change with fuzzy matching and a rendered diff."
     }
 
     fn input_schema(&self) -> Value {

--- a/crates/tui/src/tools/fetch_url.rs
+++ b/crates/tui/src/tools/fetch_url.rs
@@ -87,7 +87,7 @@ impl ToolSpec for FetchUrlTool {
     }
 
     fn description(&self) -> &'static str {
-        "Fetch a known URL directly (HTTP GET) and return its content. Use this when the user gives a URL or you already know the canonical link — it's faster and more reliable than web_search for known pages."
+        "Fetch a known URL directly (HTTP GET) and return its content. Use this instead of `curl` in `exec_shell` — sandboxed, network-policy aware, and properly decoded. Plain-text endpoints (`.md`, `.txt`, `.json`, `.yaml`, `raw.githubusercontent.com`, public APIs) prefer this over the browser/automation stack. For unknown queries, use `web_search` first."
     }
 
     fn input_schema(&self) -> Value {

--- a/crates/tui/src/tools/file.rs
+++ b/crates/tui/src/tools/file.rs
@@ -26,7 +26,7 @@ impl ToolSpec for ReadFileTool {
     }
 
     fn description(&self) -> &'static str {
-        "Read a file from the workspace. Plain text is returned as-is; PDFs are auto-extracted via `pdftotext` (poppler) when available."
+        "Read a UTF-8 file from the workspace. Use this instead of `cat`, `head`, `tail`, or `sed -n '..p'` in `exec_shell` — it's faster, sandbox-aware, and skips the approval prompt. Plain text is returned as-is; PDFs are auto-extracted via `pdftotext` (poppler) when available. Cannot read images or non-PDF binaries."
     }
 
     fn input_schema(&self) -> Value {
@@ -191,7 +191,7 @@ impl ToolSpec for WriteFileTool {
     }
 
     fn description(&self) -> &'static str {
-        "Write content to a UTF-8 file in the workspace."
+        "Write content to a UTF-8 file in the workspace. Use this instead of heredocs (`cat <<EOF > file`) or `echo > file` in `exec_shell` — diffs render inline and approval is handled cleanly. Creates or overwrites; parent directories are auto-created."
     }
 
     fn input_schema(&self) -> Value {
@@ -290,7 +290,7 @@ impl ToolSpec for EditFileTool {
     }
 
     fn description(&self) -> &'static str {
-        "Replace text in a file using search/replace. Required: 'path' (file to edit), 'search' (exact text to find), 'replace' (text to substitute)."
+        "Replace text in a single file via exact search/replace. Use this instead of `sed -i` in `exec_shell` for in-place edits. For multi-hunk or cross-file changes, use `apply_patch` instead. Required: 'path', 'search' (exact text to find), 'replace' (text to substitute)."
     }
 
     fn input_schema(&self) -> Value {
@@ -384,7 +384,7 @@ impl ToolSpec for ListDirTool {
     }
 
     fn description(&self) -> &'static str {
-        "List entries in a directory relative to the workspace."
+        "List entries in a directory relative to the workspace. Use this instead of `ls`, `ls -la`, or `find . -maxdepth 1` in `exec_shell` for directory listings."
     }
 
     fn input_schema(&self) -> Value {

--- a/crates/tui/src/tools/file_search.rs
+++ b/crates/tui/src/tools/file_search.rs
@@ -29,7 +29,7 @@ impl ToolSpec for FileSearchTool {
     }
 
     fn description(&self) -> &'static str {
-        "Search for files using fuzzy matching with score-based ranking."
+        "Find files by name using fuzzy matching with score-based ranking. Use this instead of `find -name` or `fd` in `exec_shell` for filename search. Pass `extensions` to filter by suffix."
     }
 
     fn input_schema(&self) -> Value {

--- a/crates/tui/src/tools/recall_archive.rs
+++ b/crates/tui/src/tools/recall_archive.rs
@@ -428,14 +428,10 @@ mod tests {
         }
     }
 
-    /// Serializes home-redirecting tests since cargo runs tests in parallel
-    /// by default. Held for the full test (no `.await` while holding it).
-    static HOME_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
     /// Guard that points `dirs::home_dir()` at a tempdir for the test's
     /// lifetime and restores the original on drop. On Unix this means
     /// `HOME`; on Windows it means `USERPROFILE`. We set both so the same
-    /// guard works portably. Holds `HOME_LOCK` to serialize.
+    /// guard works portably. Holds process-wide lock to serialize.
     struct HomeGuard {
         _tmp: TempDir,
         original_home: Option<String>,
@@ -444,11 +440,11 @@ mod tests {
     }
     impl HomeGuard {
         fn new() -> Self {
-            let lock = HOME_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+            let lock = crate::test_support::lock_test_env();
             let tmp = TempDir::new().expect("tempdir");
             let original_home = std::env::var("HOME").ok();
             let original_userprofile = std::env::var("USERPROFILE").ok();
-            // SAFETY: serialized by HOME_LOCK; only this thread mutates the
+            // SAFETY: serialized by process-wide lock; only this thread mutates the
             // env vars for the duration of the guard.
             unsafe {
                 std::env::set_var("HOME", tmp.path());

--- a/crates/tui/src/tools/search.rs
+++ b/crates/tui/src/tools/search.rs
@@ -40,7 +40,7 @@ impl ToolSpec for GrepFilesTool {
     }
 
     fn description(&self) -> &'static str {
-        "Search for a regex pattern in files within the workspace. Returns matching lines with context."
+        "Search for a regex pattern in workspace files. Use this instead of `grep -r`, `rg`, or `find ... -exec grep` in `exec_shell` — pure-Rust, faster, and respects `.gitignore`. Returns matching lines with context (default: 2 lines before/after each match)."
     }
 
     fn input_schema(&self) -> Value {

--- a/crates/tui/src/tools/web_search.rs
+++ b/crates/tui/src/tools/web_search.rs
@@ -115,7 +115,7 @@ impl ToolSpec for WebSearchTool {
     }
 
     fn description(&self) -> &'static str {
-        "Search the web using DuckDuckGo or Bing and return structured results with URLs and snippets."
+        "Search the web (DuckDuckGo or Bing) and return ranked results with URLs and snippets. Use this instead of scraping search engines with `curl` in `exec_shell`. For a known canonical URL, prefer `fetch_url` directly."
     }
 
     fn input_schema(&self) -> Value {

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -680,6 +680,11 @@ pub struct App {
     pub is_loading: bool,
     /// Degraded connectivity mode; new user inputs are queued for later retry.
     pub offline_mode: bool,
+    /// Whether an `EngineEvent::Error` has already been posted for the
+    /// current turn. Suppresses the redundant "Turn failed:" status line
+    /// that `TurnComplete { error: .. }` would otherwise emit on top of
+    /// the in-transcript error cell.
+    pub turn_error_posted: bool,
     /// Legacy status text sink retained for compatibility with existing call sites.
     pub status_message: Option<String>,
     /// Recent status toasts (ephemeral, newest at back).
@@ -1323,6 +1328,7 @@ impl App {
             api_messages: Vec::new(),
             is_loading: false,
             offline_mode: false,
+            turn_error_posted: false,
             status_message: None,
             status_toasts: VecDeque::new(),
             sticky_status: None,

--- a/crates/tui/src/tui/history.rs
+++ b/crates/tui/src/tui/history.rs
@@ -4128,38 +4128,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn streaming_thinking_live_collapses_unless_verbose() {
-        let cell = HistoryCell::Thinking {
-            content: "private step one\nprivate step two".to_string(),
-            streaming: true,
-            duration_secs: None,
-        };
-
-        let compact = cell.lines_with_options(
-            80,
-            TranscriptRenderOptions {
-                low_motion: true,
-                ..TranscriptRenderOptions::default()
-            },
-        );
-        let compact_text = lines_text(&compact);
-        assert!(compact_text.contains("thinking..."));
-        assert!(!compact_text.contains("private step one"));
-
-        let verbose = cell.lines_with_options(
-            80,
-            TranscriptRenderOptions {
-                verbose: true,
-                low_motion: true,
-                ..TranscriptRenderOptions::default()
-            },
-        );
-        let verbose_text = lines_text(&verbose);
-        assert!(verbose_text.contains("private step one"));
-        assert!(verbose_text.contains("private step two"));
-    }
-
     // === Theme parity tests ===
     //
     // These lock the visible color/style choices for one plan cell and one

--- a/crates/tui/src/tui/history.rs
+++ b/crates/tui/src/tui/history.rs
@@ -2092,10 +2092,18 @@ fn render_thinking(
     lines.push(Line::from(header_spans));
 
     let content_width = width.saturating_sub(3).max(1);
-    let body_text = if collapsed && streaming {
-        String::new()
-    } else if collapsed {
-        extract_reasoning_summary(content).unwrap_or_else(|| content.trim().to_string())
+    let body_text = if collapsed {
+        if streaming {
+            // #861 RC4 / #1324: during streaming we don't yet have a
+            // completed reasoning block, so `extract_reasoning_summary`
+            // is meaningless. Show the raw content and let the
+            // truncation logic below keep the *last* `LIMIT` lines so
+            // the user sees the model's most recent thinking instead of
+            // staring at an empty placeholder.
+            content.to_string()
+        } else {
+            extract_reasoning_summary(content).unwrap_or_else(|| content.trim().to_string())
+        }
     } else {
         content.to_string()
     };
@@ -2106,7 +2114,14 @@ fn render_thinking(
     };
     let mut truncated = false;
     if collapsed && rendered.len() > THINKING_SUMMARY_LINE_LIMIT {
-        rendered.truncate(THINKING_SUMMARY_LINE_LIMIT);
+        if streaming {
+            // Drop the *head* during streaming so the visible window
+            // tracks the live cursor at the bottom.
+            let drop = rendered.len() - THINKING_SUMMARY_LINE_LIMIT;
+            rendered.drain(0..drop);
+        } else {
+            rendered.truncate(THINKING_SUMMARY_LINE_LIMIT);
+        }
         truncated = true;
     }
 
@@ -2134,13 +2149,24 @@ fn render_thinking(
         lines.push(Line::from(spans));
     }
 
-    if collapsed && (!streaming && (truncated || body_text.trim() != content.trim())) {
+    let needs_affordance = collapsed
+        && if streaming {
+            // #861 RC4 / #1324: during streaming, surface the affordance
+            // whenever any head lines have been clipped so the user
+            // knows there's more above and how to reach it.
+            truncated
+        } else {
+            truncated || body_text.trim() != content.trim()
+        };
+    if needs_affordance {
+        let label = if streaming {
+            "thinking continues; press Ctrl+O for full text"
+        } else {
+            "thinking collapsed; press Ctrl+O for full text"
+        };
         lines.push(Line::from(vec![
             Span::styled(REASONING_RAIL.to_string(), rail_style),
-            Span::styled(
-                "thinking collapsed; press Ctrl+O for full text",
-                Style::default().fg(palette::TEXT_MUTED).italic(),
-            ),
+            Span::styled(label, Style::default().fg(palette::TEXT_MUTED).italic()),
         ]));
     }
 
@@ -3622,6 +3648,64 @@ mod tests {
             .collect::<String>();
         assert!(text.contains("thinking collapsed; press Ctrl+O for full text"));
         assert!(text.contains("thinking"));
+    }
+
+    #[test]
+    fn render_thinking_streaming_collapsed_shows_live_content() {
+        // #861 RC4 / #1324: during a live thinking block in collapsed view,
+        // the body must NOT be blanked out. Users want to watch the model
+        // think; the previous behaviour stalled on a "thinking..." spinner
+        // until ThinkingComplete fired.
+        let lines = render_thinking(
+            "Step 1: read the code\nStep 2: trace the call\nStep 3: form a hypothesis",
+            80,
+            true, // streaming
+            None, // no duration yet
+            true, // collapsed
+            true, // low_motion (no cursor noise to grep)
+        );
+        let text = lines
+            .iter()
+            .flat_map(|line| line.spans.iter().map(|span| span.content.as_ref()))
+            .collect::<String>();
+        assert!(
+            text.contains("Step 3: form a hypothesis"),
+            "the most recent thinking line must be visible during streaming, got: {text}"
+        );
+        // "thinking..." placeholder must not be the only thing rendered.
+        assert!(
+            !text.contains("thinking..."),
+            "raw content present means the placeholder line should not be drawn, got: {text}"
+        );
+    }
+
+    #[test]
+    fn render_thinking_streaming_truncated_shows_continues_affordance() {
+        // #861 RC4: when a streaming thinking block exceeds the line cap,
+        // surface a live affordance pointing at Ctrl+O. The earlier code
+        // suppressed the affordance unless `!streaming`.
+        let long = (1..=10)
+            .map(|i| format!("Reasoning line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let lines = render_thinking(&long, 80, true, None, true, true);
+        let text = lines
+            .iter()
+            .flat_map(|line| line.spans.iter().map(|span| span.content.as_ref()))
+            .collect::<String>();
+        assert!(
+            text.contains("thinking continues; press Ctrl+O for full text"),
+            "streaming-truncation affordance missing, got: {text}"
+        );
+        // The most recent line must be the visible tail (head dropped).
+        assert!(
+            text.contains("Reasoning line 10"),
+            "tail line missing, got: {text}"
+        );
+        assert!(
+            !text.contains("Reasoning line 1\n"),
+            "head should be clipped, got: {text}"
+        );
     }
 
     #[test]

--- a/crates/tui/src/tui/model_picker.rs
+++ b/crates/tui/src/tui/model_picker.rs
@@ -376,7 +376,8 @@ mod tests {
     use crate::tui::app::{App, TuiOptions};
     use std::path::PathBuf;
 
-    fn create_test_app() -> App {
+    fn create_test_app() -> (App, std::sync::MutexGuard<'static, ()>) {
+        let lock = crate::test_support::lock_test_env();
         let options = TuiOptions {
             model: "deepseek-v4-pro".to_string(),
             workspace: PathBuf::from("."),
@@ -406,12 +407,12 @@ mod tests {
         // exercise the picker logic, not the user's environment.
         app.model = "deepseek-v4-pro".to_string();
         app.reasoning_effort = ReasoningEffort::Max;
-        app
+        (app, lock)
     }
 
     #[test]
     fn picker_initial_selection_matches_app_state() {
-        let mut app = create_test_app();
+        let (mut app, _lock) = create_test_app();
         app.model = "deepseek-v4-flash".to_string();
         app.reasoning_effort = ReasoningEffort::Max;
         let view = ModelPickerView::new(&app);
@@ -421,7 +422,7 @@ mod tests {
 
     #[test]
     fn picker_initial_selection_matches_auto_state() {
-        let mut app = create_test_app();
+        let (mut app, _lock) = create_test_app();
         app.model = "auto".to_string();
         app.auto_model = true;
         app.reasoning_effort = ReasoningEffort::Auto;
@@ -434,7 +435,7 @@ mod tests {
 
     #[test]
     fn picker_auto_model_forces_auto_effort_on_apply() {
-        let mut app = create_test_app();
+        let (mut app, _lock) = create_test_app();
         app.model = "auto".to_string();
         app.auto_model = true;
         app.reasoning_effort = ReasoningEffort::Off;
@@ -452,7 +453,7 @@ mod tests {
 
     #[test]
     fn picker_normalizes_low_medium_to_high() {
-        let mut app = create_test_app();
+        let (mut app, _lock) = create_test_app();
         app.reasoning_effort = ReasoningEffort::Medium;
         let view = ModelPickerView::new(&app);
         assert_eq!(
@@ -479,7 +480,7 @@ mod tests {
 
     #[test]
     fn picker_preserves_unknown_model_via_custom_row() {
-        let mut app = create_test_app();
+        let (mut app, _lock) = create_test_app();
         app.model = "deepseek-v4-pro-2026-04-XX".to_string();
         let view = ModelPickerView::new(&app);
         assert!(view.show_custom_model_row);
@@ -488,7 +489,7 @@ mod tests {
 
     #[test]
     fn arrow_keys_move_within_focused_pane() {
-        let app = create_test_app();
+        let (app, _lock) = create_test_app();
         let mut view = ModelPickerView::new(&app);
         // Default focus is Model; move down then up.
         let initial = view.selected_model_idx;
@@ -506,7 +507,7 @@ mod tests {
 
     #[test]
     fn tab_switches_focus_and_arrow_now_moves_effort() {
-        let mut app = create_test_app();
+        let (mut app, _lock) = create_test_app();
         // Default is Max; pin to Off so the Down arrow has
         // somewhere to go.
         app.reasoning_effort = ReasoningEffort::Off;
@@ -526,7 +527,7 @@ mod tests {
 
     #[test]
     fn enter_emits_apply_event_with_selection() {
-        let mut app = create_test_app();
+        let (mut app, _lock) = create_test_app();
         app.reasoning_effort = ReasoningEffort::High;
         let mut view = ModelPickerView::new(&app);
         view.handle_key(KeyEvent::new(
@@ -558,7 +559,7 @@ mod tests {
 
     #[test]
     fn esc_closes_without_emitting() {
-        let app = create_test_app();
+        let (app, _lock) = create_test_app();
         let mut view = ModelPickerView::new(&app);
         let action = view.handle_key(KeyEvent::new(
             KeyCode::Esc,

--- a/crates/tui/src/tui/model_picker.rs
+++ b/crates/tui/src/tui/model_picker.rs
@@ -402,11 +402,15 @@ mod tests {
         let mut app = App::new(options, &Config::default());
         // App::new merges in `~/.config/deepseek/settings.toml` /
         // `Application Support/deepseek/settings.toml`, which can override
-        // the model and effort with whatever the developer happens to have
-        // saved. Pin both back to known values so the picker tests below
-        // exercise the picker logic, not the user's environment.
+        // the model, effort, and provider with whatever the developer
+        // happens to have saved. Pin all three back to known values so
+        // the picker tests below exercise the picker logic, not the
+        // user's environment. In particular `api_provider` matters because
+        // pass-through providers (Ollama, OpenAI) hide the DeepSeek model
+        // rows and leave only `auto` + custom — Down has nowhere to go.
         app.model = "deepseek-v4-pro".to_string();
         app.reasoning_effort = ReasoningEffort::Max;
+        app.api_provider = crate::config::ApiProvider::Deepseek;
         (app, lock)
     }
 

--- a/crates/tui/src/tui/notifications.rs
+++ b/crates/tui/src/tui/notifications.rs
@@ -49,13 +49,17 @@ fn windows_bell() {
     }
 }
 
-/// Resolve `Auto` to a concrete method by inspecting `$TERM_PROGRAM`.
+/// Resolve `Auto` to a concrete method by inspecting `$TERM_PROGRAM` and
+/// `$LC_TERMINAL`.
 ///
-/// Known OSC-9 capable programs: `iTerm.app`, `Ghostty`, `WezTerm`
+/// Known OSC-9 capable programs: `iTerm.app`, `Ghostty`, `WezTerm`, `Cmux`
 /// (these resolve to `Osc9` on every platform, including Windows
 /// when running inside WezTerm).
 ///
-/// Otherwise the fallback is platform-dependent:
+/// The probe order is: `$TERM_PROGRAM` first, then `$LC_TERMINAL` as a
+/// fallback for terminals (e.g. Cmux) that set `LC_TERMINAL` instead of
+/// `TERM_PROGRAM`. If neither env var matches a known OSC-9 capable terminal,
+/// the fallback is platform-dependent:
 /// - **macOS / Linux / other Unix:** `Bel` (a single `\x07` byte).
 /// - **Windows:** `Off`. BEL is mapped by the Windows audio stack
 ///   to `SystemAsterisk` / `MB_OK`, the same chime used by
@@ -63,13 +67,27 @@ fn windows_bell() {
 ///   notification even though the turn completed successfully (#583).
 ///   Users can opt back in with `[notifications].method = "bel"` or
 ///   pick a known OSC-9 terminal.
+///
+/// Terminals that set neither env var (e.g. Cmux in some configurations)
+/// can force OSC 9 with `[notifications].method = "osc9"` in the config file.
 #[must_use]
 fn resolve_method() -> Method {
+    const OSC9_TERMINALS: &[&str] = &["iTerm.app", "Ghostty", "WezTerm", "Cmux"];
+
     let term_program = std::env::var("TERM_PROGRAM").unwrap_or_default();
-    match term_program.as_str() {
-        "iTerm.app" | "Ghostty" | "WezTerm" => Method::Osc9,
-        _ if cfg!(target_os = "windows") => Method::Off,
-        _ => Method::Bel,
+    if OSC9_TERMINALS.contains(&term_program.as_str()) {
+        return Method::Osc9;
+    }
+
+    let lc_terminal = std::env::var("LC_TERMINAL").unwrap_or_default();
+    if OSC9_TERMINALS.contains(&lc_terminal.as_str()) {
+        return Method::Osc9;
+    }
+
+    if cfg!(target_os = "windows") {
+        Method::Off
+    } else {
+        Method::Bel
     }
 }
 
@@ -309,19 +327,85 @@ mod tests {
         assert_eq!(resolved, Method::Osc9);
     }
 
+    /// Cmux in typical configurations does not set `TERM_PROGRAM`; it sets
+    /// `LC_TERMINAL=Cmux` instead. Verify the `LC_TERMINAL` fallback probe
+    /// correctly resolves to `Osc9`.
+    #[test]
+    fn auto_detect_picks_osc9_for_cmux_via_lc_terminal() {
+        let _lock = env_lock();
+        let prev_tp = std::env::var_os("TERM_PROGRAM");
+        let prev_lc = std::env::var_os("LC_TERMINAL");
+        // SAFETY: test-only; serialised by env_lock().
+        unsafe {
+            std::env::remove_var("TERM_PROGRAM");
+            std::env::set_var("LC_TERMINAL", "Cmux");
+        }
+        let resolved = resolve_method();
+        // SAFETY: test-only; serialised by env_lock().
+        unsafe {
+            match prev_tp {
+                Some(v) => std::env::set_var("TERM_PROGRAM", v),
+                None => std::env::remove_var("TERM_PROGRAM"),
+            }
+            match prev_lc {
+                Some(v) => std::env::set_var("LC_TERMINAL", v),
+                None => std::env::remove_var("LC_TERMINAL"),
+            }
+        }
+        assert_eq!(resolved, Method::Osc9);
+    }
+
+    /// `LC_TERMINAL` should also match other OSC-9 capable terminals in case
+    /// they set it in addition to or instead of `TERM_PROGRAM`.
+    #[test]
+    fn auto_detect_picks_osc9_for_wezterm_via_lc_terminal() {
+        let _lock = env_lock();
+        let prev_tp = std::env::var_os("TERM_PROGRAM");
+        let prev_lc = std::env::var_os("LC_TERMINAL");
+        // SAFETY: test-only; serialised by env_lock().
+        unsafe {
+            std::env::remove_var("TERM_PROGRAM");
+            std::env::set_var("LC_TERMINAL", "WezTerm");
+        }
+        let resolved = resolve_method();
+        // SAFETY: test-only; serialised by env_lock().
+        unsafe {
+            match prev_tp {
+                Some(v) => std::env::set_var("TERM_PROGRAM", v),
+                None => std::env::remove_var("TERM_PROGRAM"),
+            }
+            match prev_lc {
+                Some(v) => std::env::set_var("LC_TERMINAL", v),
+                None => std::env::remove_var("LC_TERMINAL"),
+            }
+        }
+        assert_eq!(resolved, Method::Osc9);
+    }
+
     #[test]
     #[cfg(not(target_os = "windows"))]
     fn auto_detect_picks_bel_for_unknown_on_unix() {
         let _lock = env_lock();
-        let prev = std::env::var_os("TERM_PROGRAM");
+        let prev_tp = std::env::var_os("TERM_PROGRAM");
+        let prev_lc = std::env::var_os("LC_TERMINAL");
         // SAFETY: test-only; serialised by env_lock().
-        unsafe { std::env::set_var("TERM_PROGRAM", "xterm-256color") };
+        // Clear LC_TERMINAL so the LC_TERMINAL fallback probe does not
+        // accidentally pick up an OSC-9 capable terminal from the test runner
+        // environment and shadow the Bel fallback we're trying to verify.
+        unsafe {
+            std::env::set_var("TERM_PROGRAM", "xterm-256color");
+            std::env::remove_var("LC_TERMINAL");
+        }
         let resolved = resolve_method();
         // SAFETY: test-only; serialised by env_lock().
         unsafe {
-            match prev {
+            match prev_tp {
                 Some(v) => std::env::set_var("TERM_PROGRAM", v),
                 None => std::env::remove_var("TERM_PROGRAM"),
+            }
+            match prev_lc {
+                Some(v) => std::env::set_var("LC_TERMINAL", v),
+                None => std::env::remove_var("LC_TERMINAL"),
             }
         }
         assert_eq!(resolved, Method::Bel);

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -872,6 +872,7 @@ async fn run_event_loop(
                     EngineEvent::TurnStarted { turn_id } => {
                         app.is_loading = true;
                         app.offline_mode = false;
+                        app.turn_error_posted = false;
                         app.dispatch_started_at = None;
                         current_streaming_text.clear();
                         app.streaming_state.reset();
@@ -978,7 +979,14 @@ async fn run_event_loop(
                             recorded_at: Instant::now(),
                         });
                         if let Some(error) = error {
-                            app.status_message = Some(format!("Turn failed: {error}"));
+                            // Only show "Turn failed:" in the composer status
+                            // area when an EngineEvent::Error has NOT already
+                            // posted the same message into the transcript.
+                            // Otherwise the error appears twice: once in a
+                            // HistoryCell and again as a redundant status line.
+                            if !app.turn_error_posted {
+                                app.status_message = Some(format!("Turn failed: {error}"));
+                            }
                         }
 
                         // Update session cost
@@ -3237,6 +3245,7 @@ pub(crate) fn apply_engine_error_to_app(
     });
     app.is_loading = false;
     app.dispatch_started_at = None;
+    app.turn_error_posted = true;
     if matches!(
         envelope.category,
         crate::error_taxonomy::ErrorCategory::Authentication
@@ -3250,14 +3259,12 @@ pub(crate) fn apply_engine_error_to_app(
         );
         return;
     }
-    if recoverable {
-        app.status_message = Some(format!("Connection interrupted: {message}"));
-    } else {
+    if !recoverable {
         app.offline_mode = true;
-        app.status_message = Some(format!(
-            "Engine error; queued messages stay pending: {message}"
-        ));
     }
+    // Error is already in the transcript as HistoryCell::Error above;
+    // don't emit a redundant status_message that would become a sticky
+    // toast in the footer — that duplicates the transcript entry.
 }
 
 fn persist_offline_queue_state(app: &App) {

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -698,6 +698,24 @@ async fn run_event_loop(
                         }
                     }
                     EngineEvent::MessageComplete { .. } => {
+                        // #861 RC3: defensive drain of a still-active thinking
+                        // entry. Normally `ThinkingComplete` arrives first and
+                        // populates `last_reasoning` before we get here, but
+                        // when the engine bursts events the channel can
+                        // deliver `MessageComplete` first, in which case
+                        // `last_reasoning.take()` below would be `None` and
+                        // the thinking block would be dropped from
+                        // `api_messages` — causing a DeepSeek HTTP 400 on the
+                        // next turn (V4 thinking-mode requires
+                        // `reasoning_content` replay). Inline-finalize the
+                        // thinking entry here so this branch is order-
+                        // independent.
+                        if app.streaming_thinking_active_entry.is_some() {
+                            if finalize_current_streaming_thinking(app) {
+                                transcript_batch_updated = true;
+                            }
+                            stash_reasoning_buffer_into_last_reasoning(app);
+                        }
                         if let Some(index) = app.streaming_message_index.take() {
                             let remaining = app.streaming_state.finalize_block_text(0);
                             if !remaining.is_empty() {

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -148,6 +148,16 @@ type AppTerminal = Terminal<ColorCompatBackend<Stdout>>;
 // TurnComplete / focus-gain / resize. The alt-screen buffer's double-buffering
 // plus ratatui's `terminal.clear()` are sufficient to repaint cleanly.
 const TERMINAL_ORIGIN_RESET: &[u8] = b"\x1b[r\x1b[?6l\x1b[H";
+/// Begin synchronized update (DEC 2026): tell the terminal to defer
+/// rendering until END_SYNC_UPDATE is received. Best-effort —
+/// terminals that don't support this silently ignore the sequence.
+/// Reduces flicker on GPU-accelerated terminals (Ghostty, VSCode
+/// Terminal, Kitty, WezTerm) by batching ratatui's incremental
+/// diff writes into a single frame.
+const BEGIN_SYNC_UPDATE: &[u8] = b"\x1b[?2026h";
+/// End synchronized update (DEC 2026): tell the terminal to render
+/// the complete frame now.
+const END_SYNC_UPDATE: &[u8] = b"\x1b[?2026l";
 
 /// Run the interactive TUI event loop.
 ///
@@ -1566,11 +1576,8 @@ async fn run_event_loop(
             None
         };
         if app.needs_redraw && draw_wait.is_none() {
-            if force_terminal_repaint {
-                reset_terminal_viewport(terminal)?;
-                force_terminal_repaint = false;
-            }
-            draw_app_frame(terminal, app)?;
+            draw_app_frame_inner(terminal, app, force_terminal_repaint)?;
+            force_terminal_repaint = false;
             frame_rate_limiter.mark_emitted(Instant::now());
             app.needs_redraw = false;
         }
@@ -5728,10 +5735,36 @@ fn render(f: &mut Frame, app: &mut App) {
     }
 }
 
-fn draw_app_frame(terminal: &mut AppTerminal, app: &mut App) -> Result<()> {
+/// Draw a complete application frame, optionally with a full viewport reset.
+///
+/// When `full_repaint` is true, the terminal scroll margins and origin mode
+/// are reset, the screen is cleared, ratatui's buffer is emptied, and then
+/// the full UI is drawn — all within a single DEC 2026 synchronized-update
+/// batch so GPU-accelerated terminals (Ghostty, VS Code, Kitty) render one
+/// complete frame instead of a blank intermediate frame followed by the UI.
+///
+/// When `full_repaint` is false, only the diff from the previous draw is
+/// written (normal incremental update path).
+fn draw_app_frame_inner(
+    terminal: &mut AppTerminal,
+    app: &mut App,
+    full_repaint: bool,
+) -> Result<()> {
     terminal.backend_mut().set_palette_mode(app.ui_theme.mode);
+    let _ = terminal.backend_mut().write_all(BEGIN_SYNC_UPDATE);
+    if full_repaint {
+        terminal.backend_mut().write_all(TERMINAL_ORIGIN_RESET)?;
+        terminal.backend_mut().flush()?;
+        terminal.clear()?;
+    }
     terminal.draw(|f| render(f, app))?;
+    let _ = terminal.backend_mut().write_all(END_SYNC_UPDATE);
+    let _ = terminal.backend_mut().flush();
     Ok(())
+}
+
+fn draw_app_frame(terminal: &mut AppTerminal, app: &mut App) -> Result<()> {
+    draw_app_frame_inner(terminal, app, false)
 }
 
 /// Pull the latest snapshot of cells / revisions / render options into the
@@ -6630,9 +6663,17 @@ fn reset_terminal_viewport(terminal: &mut AppTerminal) -> Result<()> {
     // for why; the immediately-following ratatui `terminal.clear()` flushes a
     // single clear via the diff renderer, which the alt-screen buffer absorbs
     // without visible flicker on the affected terminals.
+    //
+    // Wrap the reset+clear sequence in DEC 2026 synchronized-output mode
+    // (`\x1b[?2026h` … `\x1b[?2026l`) so GPU-accelerated terminals
+    // (Ghostty, VSCode, Kitty, WezTerm) defer rendering until the whole
+    // frame is staged. Terminals that don't support it silently ignore.
+    let _ = terminal.backend_mut().write_all(BEGIN_SYNC_UPDATE);
     terminal.backend_mut().write_all(TERMINAL_ORIGIN_RESET)?;
     terminal.backend_mut().flush()?;
     terminal.clear()?;
+    let _ = terminal.backend_mut().write_all(END_SYNC_UPDATE);
+    terminal.backend_mut().flush()?;
     Ok(())
 }
 

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -2625,15 +2625,23 @@ async fn run_event_loop(
                             } else {
                                 build_queued_message(app, input)
                             };
-                            // Force steer: bypass decide_submit_disposition.
-                            if let Err(err) =
-                                steer_user_message(app, &engine_handle, queued.clone()).await
-                            {
-                                app.queue_message(queued);
-                                app.status_message = Some(format!(
-                                    "Steer failed ({err}); queued {} message(s)",
-                                    app.queued_message_count()
-                                ));
+                            if app.is_loading {
+                                // Engine is busy — steer into the current turn.
+                                if let Err(err) =
+                                    steer_user_message(app, &engine_handle, queued.clone()).await
+                                {
+                                    app.queue_message(queued);
+                                    app.status_message = Some(format!(
+                                        "Steer failed ({err}); queued {} message(s)",
+                                        app.queued_message_count()
+                                    ));
+                                }
+                            } else {
+                                // Engine is idle — send as a regular message
+                                // so the content is not lost to rx_steer's
+                                // stale-drain in handle_send_message (#1331).
+                                submit_or_steer_message(app, config, &engine_handle, queued)
+                                    .await?;
                             }
                         }
                     }

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -448,7 +448,7 @@ fn format_resume_hint(session_id: Option<&str>) -> Option<String> {
     if session_id.is_empty() {
         return None;
     }
-    Some("To continue this session, run deepseek --continue".to_string())
+    Some("To continue this session, execute deepseek run --continue".to_string())
 }
 
 fn terminal_probe_timeout(config: &Config) -> Duration {

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -5752,15 +5752,25 @@ fn draw_app_frame_inner(
 ) -> Result<()> {
     terminal.backend_mut().set_palette_mode(app.ui_theme.mode);
     let _ = terminal.backend_mut().write_all(BEGIN_SYNC_UPDATE);
-    if full_repaint {
-        terminal.backend_mut().write_all(TERMINAL_ORIGIN_RESET)?;
-        terminal.backend_mut().flush()?;
-        terminal.clear()?;
-    }
-    terminal.draw(|f| render(f, app))?;
+
+    // Run fallible draw operations in a closure so END_SYNC_UPDATE is
+    // always sent even if an intermediate step fails. Without this, a
+    // failing `?` would return early and leave the terminal stuck in
+    // synchronized-update mode (screen frozen).
+    let result = (|| -> Result<()> {
+        if full_repaint {
+            terminal.backend_mut().write_all(TERMINAL_ORIGIN_RESET)?;
+            terminal.backend_mut().flush()?;
+            terminal.clear()?;
+        }
+        terminal.draw(|f| render(f, app))?;
+        Ok(())
+    })();
+
+    // Always end the synchronized update, regardless of success or failure.
     let _ = terminal.backend_mut().write_all(END_SYNC_UPDATE);
     let _ = terminal.backend_mut().flush();
-    Ok(())
+    result
 }
 
 fn draw_app_frame(terminal: &mut AppTerminal, app: &mut App) -> Result<()> {
@@ -6669,12 +6679,18 @@ fn reset_terminal_viewport(terminal: &mut AppTerminal) -> Result<()> {
     // (Ghostty, VSCode, Kitty, WezTerm) defer rendering until the whole
     // frame is staged. Terminals that don't support it silently ignore.
     let _ = terminal.backend_mut().write_all(BEGIN_SYNC_UPDATE);
-    terminal.backend_mut().write_all(TERMINAL_ORIGIN_RESET)?;
-    terminal.backend_mut().flush()?;
-    terminal.clear()?;
+
+    let result = (|| -> Result<()> {
+        terminal.backend_mut().write_all(TERMINAL_ORIGIN_RESET)?;
+        terminal.backend_mut().flush()?;
+        terminal.clear()?;
+        Ok(())
+    })();
+
+    // Always end the synchronized update, regardless of success or failure.
     let _ = terminal.backend_mut().write_all(END_SYNC_UPDATE);
-    terminal.backend_mut().flush()?;
-    Ok(())
+    let _ = terminal.backend_mut().flush();
+    result
 }
 
 fn push_keyboard_enhancement_flags<W: Write>(writer: &mut W) {

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -5825,12 +5825,11 @@ async fn handle_view_events(
                     }
                     ReviewDecision::Denied | ReviewDecision::Abort => {
                         // Cache the denial so the model retry-loop doesn't
-                        // re-prompt for the same command (#360). Only when
-                        // the user actively denied (not when the timeout
-                        // fired) — a timeout might mean the user stepped
-                        // away rather than refused.
+                        // re-prompt for the exact same approval_key (#360).
+                        // Only the key (per-call unique) is stored — NOT
+                        // the tool_name, which would block all future
+                        // invocations of the same tool type (#1377).
                         if !timed_out {
-                            app.approval_session_denied.insert(tool_name.clone());
                             app.approval_session_denied.insert(approval_key);
                         }
                         let _ = engine_handle.deny_tool_call(tool_id).await;

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -1380,6 +1380,56 @@ async fn model_change_update_syncs_engine_model_before_compaction() {
 
 #[tokio::test]
 async fn provider_switch_clears_turn_cache_history() {
+    // `switch_provider` persists the new provider to `Settings`, which
+    // writes through `dirs::data_dir()` (`~/Library/Application
+    // Support/deepseek/settings.toml` on macOS). Without redirecting
+    // HOME / USERPROFILE we would clobber the developer's real
+    // preferences and leave `default_provider = "ollama"` behind —
+    // which then leaks into any subsequent test that constructs an
+    // `App`. Hold the process-wide env lock for the duration so we
+    // serialize with other tests that mutate the same env vars.
+    // Wrap the lock inside a guard struct so clippy's
+    // `await_holding_lock` doesn't fire on the `.await` below; the
+    // pattern matches `tools::recall_archive::HomeGuard`.
+    struct HomeGuard {
+        _tmp: tempfile::TempDir,
+        prev_home: Option<std::ffi::OsString>,
+        prev_userprofile: Option<std::ffi::OsString>,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            // SAFETY: still holding the process-wide env lock.
+            unsafe {
+                match self.prev_home.take() {
+                    Some(v) => std::env::set_var("HOME", v),
+                    None => std::env::remove_var("HOME"),
+                }
+                match self.prev_userprofile.take() {
+                    Some(v) => std::env::set_var("USERPROFILE", v),
+                    None => std::env::remove_var("USERPROFILE"),
+                }
+            }
+        }
+    }
+    let _home = {
+        let lock = crate::test_support::lock_test_env();
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let prev_home = std::env::var_os("HOME");
+        let prev_userprofile = std::env::var_os("USERPROFILE");
+        // SAFETY: serialized by the process-wide test env lock.
+        unsafe {
+            std::env::set_var("HOME", tmp.path());
+            std::env::set_var("USERPROFILE", tmp.path());
+        }
+        HomeGuard {
+            _tmp: tmp,
+            prev_home,
+            prev_userprofile,
+            _lock: lock,
+        }
+    };
+
     let mut app = create_test_app();
     app.push_turn_cache_record(crate::tui::app::TurnCacheRecord {
         input_tokens: 100,

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -4080,13 +4080,10 @@ fn recoverable_engine_error_does_not_enter_offline_mode() {
         "recoverable error must keep the session online so the user can retry"
     );
     assert!(!app.is_loading);
-    let status = app
-        .status_message
-        .as_deref()
-        .expect("recoverable errors must set a status message");
+    assert!(app.turn_error_posted, "turn_error_posted must be set");
     assert!(
-        status.starts_with("Connection interrupted"),
-        "expected interrupt-style status, got {status:?}"
+        app.status_message.is_none(),
+        "recoverable error should NOT set status_message — already in transcript as HistoryCell::Error"
     );
 
     // Sanity: the rendered cell is the categorized Error variant, not a plain System note.
@@ -4120,13 +4117,10 @@ fn non_recoverable_engine_error_enters_offline_mode() {
         "non-recoverable error must enter offline mode"
     );
     assert!(!app.is_loading);
-    let status = app
-        .status_message
-        .as_deref()
-        .expect("non-recoverable errors must set a status message");
+    assert!(app.turn_error_posted, "turn_error_posted must be set");
     assert!(
-        status.starts_with("Engine error"),
-        "expected engine-error status, got {status:?}"
+        app.status_message.is_none(),
+        "non-recoverable error should NOT set status_message — already in transcript as HistoryCell::Error"
     );
 }
 
@@ -4150,6 +4144,7 @@ fn env_only_auth_failure_reopens_api_key_onboarding() {
         "env-only auth failures should prompt for a saved config key"
     );
     assert!(app.onboarding_needs_api_key);
+    assert!(app.turn_error_posted, "turn_error_posted must be set");
     let status = app
         .status_message
         .as_deref()

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -3861,6 +3861,57 @@ fn engine_error_finalizes_active_thinking_block() {
 }
 
 #[test]
+fn message_complete_drain_preserves_thinking_when_thinking_complete_lost() {
+    // #861 RC3: when the engine bursts events, `MessageComplete` can be
+    // dispatched ahead of `ThinkingComplete`. Without the defensive drain,
+    // `app.last_reasoning` would be `None` at `last_reasoning.take()` time
+    // and the thinking block would be dropped from `api_messages`,
+    // causing a DeepSeek HTTP 400 on the next turn (V4 thinking-mode
+    // requires `reasoning_content` replay).
+    //
+    // This test exercises the head-of-handler drain in isolation: with a
+    // thinking entry still active and `last_reasoning` empty, the drain
+    // must transfer `reasoning_buffer` into `last_reasoning` before the
+    // remainder of `MessageComplete` reads it.
+    let mut app = create_test_app();
+
+    let _ = ensure_streaming_thinking_active_entry(&mut app);
+    app.thinking_started_at = Some(Instant::now());
+    app.streaming_state.start_thinking(0, None);
+    app.streaming_state.push_content(0, "deep reasoning text");
+    let _ = app.streaming_state.commit_text(0);
+    app.reasoning_buffer.push_str("deep reasoning text");
+
+    assert!(
+        app.last_reasoning.is_none(),
+        "precondition: ThinkingComplete has NOT fired"
+    );
+    assert!(
+        app.streaming_thinking_active_entry.is_some(),
+        "precondition: thinking entry is still active"
+    );
+
+    // Mirror the head of `EngineEvent::MessageComplete` — the new defensive
+    // drain installed by the #861 RC3 fix.
+    if app.streaming_thinking_active_entry.is_some() {
+        let _ = finalize_current_streaming_thinking(&mut app);
+        stash_reasoning_buffer_into_last_reasoning(&mut app);
+    }
+
+    assert!(
+        app.last_reasoning
+            .as_deref()
+            .is_some_and(|s| s.contains("deep reasoning text")),
+        "defensive drain must move reasoning into last_reasoning so the\
+         downstream `last_reasoning.take()` produces a Thinking block"
+    );
+    assert!(
+        app.streaming_thinking_active_entry.is_none(),
+        "thinking entry must be cleared after the drain"
+    );
+}
+
+#[test]
 fn second_thinking_block_appends_new_entry_in_same_active_cell() {
     // Real V4 turns can emit Thinking → Tool → Thinking → Tool before any
     // prose; the second thinking block should land as a fresh entry inside

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -20,7 +20,7 @@ use tempfile::TempDir;
 fn format_resume_hint_uses_canonical_resume_command() {
     assert_eq!(
         format_resume_hint(Some("019dd9d6-4f44-7c83-9863-59674a12b827")),
-        Some("To continue this session, run deepseek --continue".to_string())
+        Some("To continue this session, execute deepseek run --continue".to_string())
     );
 }
 

--- a/crates/tui/src/working_set.rs
+++ b/crates/tui/src/working_set.rs
@@ -155,6 +155,24 @@ impl Workspace {
                 }
             }
         }
+
+        // Beyond the curated dot-dir whitelist above, also index any explicit
+        // hidden/ignored path the user might `@`-mention (e.g. a project's
+        // own `.generated/specs/`). `local_reference_paths` walks with
+        // gitignore disabled but still honors `.deepseekignore`.
+        for path in local_reference_paths(&self.root, LOCAL_REFERENCE_SCAN_LIMIT) {
+            if total >= FILE_INDEX_MAX_ENTRIES {
+                break;
+            }
+            let Some(name) = path
+                .file_name()
+                .map(|name| name.to_string_lossy().to_lowercase())
+            else {
+                continue;
+            };
+            index.entry(name).or_default().push(path);
+            total += 1;
+        }
         index
     }
 
@@ -200,8 +218,26 @@ impl Workspace {
                 &mut substring_hits,
                 &mut seen,
             );
+            add_local_reference_completions(
+                cwd,
+                cwd,
+                &needle,
+                limit,
+                &mut prefix_hits,
+                &mut substring_hits,
+                &mut seen,
+            );
         }
         walk_for_completions(
+            &self.root,
+            &self.root,
+            &needle,
+            limit,
+            &mut prefix_hits,
+            &mut substring_hits,
+            &mut seen,
+        );
+        add_local_reference_completions(
             &self.root,
             &self.root,
             &needle,
@@ -396,10 +432,8 @@ fn walk_for_completions(
     );
 }
 
-#[allow(dead_code)]
 const LOCAL_REFERENCE_SCAN_LIMIT: usize = 4096;
 
-#[allow(dead_code)]
 #[allow(clippy::too_many_arguments)]
 fn add_local_reference_completions(
     root: &Path,
@@ -434,12 +468,10 @@ fn add_local_reference_completions(
     }
 }
 
-#[allow(dead_code)]
 fn should_try_local_reference_completion(needle: &str) -> bool {
     !needle.is_empty() && (needle.starts_with('.') || needle.contains('/') || needle.contains('\\'))
 }
 
-#[allow(dead_code)]
 fn local_reference_paths(root: &Path, limit: usize) -> Vec<PathBuf> {
     let mut out = Vec::new();
     let mut builder = WalkBuilder::new(root);
@@ -471,7 +503,6 @@ fn local_reference_paths(root: &Path, limit: usize) -> Vec<PathBuf> {
     out
 }
 
-#[allow(dead_code)]
 fn should_skip_local_reference_dir(path: &Path) -> bool {
     let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
         return false;
@@ -1440,7 +1471,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "wiring incomplete — add_local_reference_completions not yet called from completions()"]
     fn workspace_completions_surface_explicit_hidden_and_ignored_paths() {
         let tmp = TempDir::new().unwrap();
         std::fs::write(tmp.path().join(".gitignore"), ".deepseek/\n.generated/\n").unwrap();
@@ -1483,7 +1513,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "wiring incomplete — needs add_local_reference_completions integration"]
     fn fuzzy_index_resolves_hidden_and_ignored_files_except_deepseekignored() {
         let tmp = TempDir::new().unwrap();
         std::fs::write(tmp.path().join(".gitignore"), ".generated/\n").unwrap();

--- a/crates/tui/src/working_set.rs
+++ b/crates/tui/src/working_set.rs
@@ -93,9 +93,18 @@ impl Workspace {
 
     fn build_file_index(&self) -> HashMap<String, Vec<PathBuf>> {
         let mut index: HashMap<String, Vec<PathBuf>> = HashMap::new();
+        let mut total: usize = 0;
         let builder = discovery_walk_builder(&self.root, Some(6));
 
         for entry in builder.build().flatten() {
+            if total >= FILE_INDEX_MAX_ENTRIES {
+                tracing::warn!(
+                    target: "working_set",
+                    limit = FILE_INDEX_MAX_ENTRIES,
+                    "file-index discovery hit the entry cap; truncating to keep first-turn latency bounded (#697)"
+                );
+                return index;
+            }
             if entry
                 .file_type()
                 .is_some_and(|ft| ft.is_file() || ft.is_dir())
@@ -105,11 +114,15 @@ impl Workspace {
                     .entry(name)
                     .or_default()
                     .push(entry.path().to_path_buf());
+                total += 1;
             }
         }
 
         // Also index AI-tool dot-directories with gitignore disabled.
         for dir_name in DISCOVERY_ALWAYS_DIRS {
+            if total >= FILE_INDEX_MAX_ENTRIES {
+                break;
+            }
             let dot_dir = self.root.join(dir_name);
             if !dot_dir.is_dir() {
                 continue;
@@ -122,6 +135,9 @@ impl Workspace {
                 .ignore(false)
                 .max_depth(Some(5));
             for entry in dot_builder.build().flatten() {
+                if total >= FILE_INDEX_MAX_ENTRIES {
+                    break;
+                }
                 // Exclude machine-generated bulk (e.g. .deepseek/snapshots/).
                 if path_is_excluded_from_discovery(&self.root, entry.path()) {
                     continue;
@@ -135,6 +151,7 @@ impl Workspace {
                         .entry(name)
                         .or_default()
                         .push(entry.path().to_path_buf());
+                    total += 1;
                 }
             }
         }
@@ -206,6 +223,15 @@ impl Workspace {
 /// Mirrors the existing `project_tree` cutoff and keeps Tab snappy in deep
 /// monorepos.
 const COMPLETIONS_WALK_DEPTH: usize = 6;
+
+/// Hard cap on the number of `(file or directory)` entries indexed by
+/// [`WorkingSet::build_file_index`]. The fuzzy-resolve index is a
+/// convenience for [`WorkingSet::fuzzy_resolve`]; missing entries fall
+/// back to literal-path resolution. Capping here keeps the first
+/// `fuzzy_resolve` call bounded on huge workspaces (#697 reported a
+/// ~10s hang on the first turn). For typical projects 50K is well
+/// above the actual entry count and the cap is a no-op.
+const FILE_INDEX_MAX_ENTRIES: usize = 50_000;
 
 /// Directories that must remain discoverable for `@`-mention completion and
 /// fuzzy file resolution even when excluded by `.gitignore`. AI-tool

--- a/npm/deepseek-tui/package.json
+++ b/npm/deepseek-tui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-tui",
-  "version": "0.8.27",
-  "deepseekBinaryVersion": "0.8.27",
+  "version": "0.8.28",
+  "deepseekBinaryVersion": "0.8.28",
   "description": "Install and run deepseek and deepseek-tui binaries from GitHub release artifacts.",
   "author": "Hmbown",
   "license": "MIT",


### PR DESCRIPTION
## v0.8.28 — maintenance release

Preflight (all clean):
- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — clean
- `cargo test --workspace --all-features --locked` — 2645 passed, 2 flaky-under-parallel-load (both pass in isolation)
- `cargo build --release --locked -p deepseek-tui-cli -p deepseek-tui` — clean
- `scripts/release/check-versions.sh` — workspace=0.8.28, npm=0.8.28, lockfile in sync

Highlights from CHANGELOG:
- **Streaming fixes**: V4-pro thinking streams live in collapsed view, tail no longer drops (#1389, #1390)
- **Ctrl+Enter while idle**: message now reaches the engine (#1347)
- **VS Code terminal**: low_motion auto-on (#1365)
- **Cmux/WezTerm**: OSC 9 notifications via LC_TERMINAL probe (#1340)
- **DEC 2026 sync**: GPU terminal flicker hardening (#1361)
- **Cache reporting**: null → null (no fake 0%) (#1392)
- **Tool deny fix**: deny one call → next call re-prompts (#1377)
- **Completions**: @.deepseek/commands/ and @.generated/specs/ surface hidden paths (#1270)
- **CNB mirror**: sync-cnb.yml workflow from @Anyexyz (#1373)
- **Test stabilization**: parallel-test environment race fixes

Commits: `61f40420a..5bededf77` (27 commits since last tag)