### PR TITLE
test(web-search): cover optional_search_max_results precedence + edge cases

### DIFF
--- a/crates/tui/src/tools/web_search.rs
+++ b/crates/tui/src/tools/web_search.rs
@@ -633,4 +633,78 @@ mod tests {
             .expect_err("missing query should fail");
         assert!(format!("{err}").contains("missing required field 'query'"));
     }
+
+    #[test]
+    fn optional_max_results_prefers_top_level_value() {
+        // Top-level `max_results` wins over the array-form sibling
+        // because callers using the array form usually copy-paste it
+        // wholesale and then tweak the outer max_results afterwards.
+        assert_eq!(
+            optional_search_max_results(
+                &json!({"query": "x", "max_results": 8, "search_query": [{"q": "y", "max_results": 2}]})
+            ),
+            8,
+        );
+    }
+
+    #[test]
+    fn optional_max_results_falls_back_to_array_form() {
+        // When only the array form sets max_results, that value is the
+        // one that should reach the caller. This is the path V4 uses
+        // when it emits the structured `search_query: [{…}]` shape.
+        assert_eq!(
+            optional_search_max_results(&json!({"search_query": [{"q": "y", "max_results": 3}]})),
+            3,
+        );
+    }
+
+    #[test]
+    fn optional_max_results_uses_default_when_neither_set() {
+        // No explicit bound anywhere → the DEFAULT (currently 5)
+        // applies, so the model can't accidentally pull MAX_RESULTS
+        // worth of bandwidth just by omitting the field.
+        assert_eq!(optional_search_max_results(&json!({"query": "x"})), 5);
+        assert_eq!(
+            optional_search_max_results(&json!({"search_query": [{"q": "y"}]})),
+            5,
+        );
+    }
+
+    #[test]
+    fn optional_max_results_only_reads_first_array_entry() {
+        // Sub-search support is a future feature; for now the array
+        // entries beyond the first are ignored. Pin so a future
+        // multi-query implementation has to update this test
+        // intentionally rather than silently start fanning out.
+        assert_eq!(
+            optional_search_max_results(
+                &json!({"search_query": [{"q": "first", "max_results": 1}, {"q": "second", "max_results": 9}]})
+            ),
+            1,
+        );
+    }
+
+    #[test]
+    fn extract_search_query_trims_whitespace_from_array_form_q_alias() {
+        // The "trimmed" contract is part of the helper's invariant —
+        // a model sometimes pads `q` with newlines from a heredoc.
+        let q = extract_search_query(&json!({"search_query": [{"q": "  deepseek tui  "}]}))
+            .expect("array form should parse with trim");
+        assert_eq!(q, "deepseek tui");
+    }
+
+    #[test]
+    fn extract_search_query_rejects_empty_query() {
+        // A "" query lands in extract_search_query → propagates as
+        // missing_field rather than a confusing engine error a few
+        // layers down. Lock the failure mode.
+        for body in [json!({"query": ""}), json!({"q": "   "}), json!({})] {
+            let err = extract_search_query(&body).expect_err("empty query must reject");
+            let msg = format!("{err}");
+            assert!(
+                msg.contains("missing required field 'query'") || msg.contains("Query"),
+                "expected query-missing error, got `{msg}`"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary

\`optional_search_max_results\` is the silent gatekeeper on how many results \`web_search\` pulls down — too high wastes bandwidth, too low misses what the model wants. The function has three precedence branches (top-level \`max_results\` → \`search_query[0].max_results\` → \`DEFAULT_MAX_RESULTS\`), **none of which are tested today**.

Companion: \`extract_search_query\` already has four tests covering the basic shapes; this PR adds the two edge cases that aren't pinned yet.

**No behaviour change.** Six new tests lock the contract.

## What's pinned

| Test | Locks |
|---|---|
| \`optional_max_results_prefers_top_level_value\` | outer \`max_results\` wins over sibling in the array form |
| \`optional_max_results_falls_back_to_array_form\` | inner-only \`max_results\` (V4's structured shape) reaches the caller |
| \`optional_max_results_uses_default_when_neither_set\` | DEFAULT applies for both shapes, so the model can't burn MAX_RESULTS by omission |
| \`optional_max_results_only_reads_first_array_entry\` | sub-search fan-out is a future feature; today's behaviour ignores entries past the first |
| \`extract_search_query_trims_whitespace_from_array_form_q_alias\` | pad/newlines from heredoc copy-paste don't reach the URL |
| \`extract_search_query_rejects_empty_query\` | empty / whitespace-only / missing query each surface the same missing-field error |

## Tests

\`\`\`
$ cargo test -p deepseek-tui -- web_search::tests
…
test result: ok. 15 passed; 0 failed
\`\`\`

## Acceptance gates

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo build --workspace\`
- [x] \`cargo test -p deepseek-tui -- web_search::tests\` — 15/15