### PR TITLE
fix(mcp): skip malformed items during discovery instead of dropping all

### DIFF
--- a/crates/tui/src/mcp.rs
+++ b/crates/tui/src/mcp.rs
@@ -787,8 +787,14 @@ impl McpConnection {
 
         if let Some(result) = response.get("result")
             && let Some(tools) = result.get("tools")
+            && let Some(arr) = tools.as_array()
         {
-            self.tools = serde_json::from_value(tools.clone()).unwrap_or_default();
+            for item in arr {
+                match serde_json::from_value::<McpTool>(item.clone()) {
+                    Ok(tool) => self.tools.push(tool),
+                    Err(_) => {}
+                }
+            }
         }
 
         Ok(())
@@ -809,8 +815,14 @@ impl McpConnection {
 
         if let Some(result) = response.get("result")
             && let Some(resources) = result.get("resources")
+            && let Some(arr) = resources.as_array()
         {
-            self.resources = serde_json::from_value(resources.clone()).unwrap_or_default();
+            for item in arr {
+                match serde_json::from_value::<McpResource>(item.clone()) {
+                    Ok(resource) => self.resources.push(resource),
+                    Err(_) => {}
+                }
+            }
         }
 
         Ok(())
@@ -834,9 +846,13 @@ impl McpConnection {
                 .get("resourceTemplates")
                 .or_else(|| result.get("templates"))
                 .or_else(|| result.get("resource_templates"));
-            if let Some(templates) = templates {
-                self.resource_templates =
-                    serde_json::from_value(templates.clone()).unwrap_or_default();
+            if let Some(arr) = templates.and_then(|t| t.as_array()) {
+                for item in arr {
+                    match serde_json::from_value::<McpResourceTemplate>(item.clone()) {
+                        Ok(tmpl) => self.resource_templates.push(tmpl),
+                        Err(_) => {}
+                    }
+                }
             }
         }
 
@@ -858,8 +874,14 @@ impl McpConnection {
 
         if let Some(result) = response.get("result")
             && let Some(prompts) = result.get("prompts")
+            && let Some(arr) = prompts.as_array()
         {
-            self.prompts = serde_json::from_value(prompts.clone()).unwrap_or_default();
+            for item in arr {
+                match serde_json::from_value::<McpPrompt>(item.clone()) {
+                    Ok(prompt) => self.prompts.push(prompt),
+                    Err(_) => {}
+                }
+            }
         }
 
         Ok(())


### PR DESCRIPTION
## Problem

All four MCP discovery functions (`discover_tools`, `discover_resources`,
`discover_resource_templates`, `discover_prompts`) deserialize the server
response as a `Vec<T>` in a single call:

```rust
self.tools = serde_json::from_value(tools.clone()).unwrap_or_default();
```

If **any** entry in the list fails to deserialize (e.g. a tool missing the
required `name` field, or an unexpected `inputSchema` shape), `serde_json`
returns `Err` for the whole collection and `.unwrap_or_default()` silently
replaces the entire list with an empty `Vec`.  Every valid tool/resource/prompt
in that response is lost.

This was noted in issue #1250 as a possible cause of unexpectedly empty tool
lists when a server returns a non-conformant entry.

## Fix

Switch each discovery function to iterate over the JSON array and
deserialize items one by one, skipping only the entries that fail:

```rust
if let Some(arr) = tools.as_array() {
    for item in arr {
        match serde_json::from_value::<McpTool>(item.clone()) {
            Ok(tool) => self.tools.push(tool),
            Err(_) => {}
        }
    }
}
```

One malformed entry no longer hides the rest of the list.

## Changes

- `crates/tui/src/mcp.rs` — four discovery functions updated:
  `discover_tools`, `discover_resources`, `discover_resource_templates`,
  `discover_prompts`

## Testing

```
cargo check -p deepseek-tui   # clean
cargo fmt -p deepseek-tui     # no changes
```

Related: #1250