### PR TITLE
feat(tui): show full text on mouse hover when sidebar lines are truncated

### DIFF
--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -658,6 +658,24 @@ impl Default for SessionState {
     }
 }
 
+/// Sidebar hover state for mouse tooltip support.
+#[derive(Debug, Clone, Default)]
+pub struct SidebarHoverState {
+    /// Rendered sections with their areas and full-text lines.
+    pub sections: Vec<SidebarHoverSection>,
+}
+
+/// Per-section metadata for sidebar hover detection.
+#[derive(Debug, Clone)]
+pub struct SidebarHoverSection {
+    /// The outer area of the section block.
+    pub area: Rect,
+    /// Content area within the section (inside border + padding).
+    pub content_area: Rect,
+    /// Full original text for each content line rendered.
+    pub lines: Vec<String>,
+}
+
 /// Global UI state for the TUI.
 #[allow(clippy::struct_excessive_bools)]
 pub struct App {
@@ -757,6 +775,12 @@ pub struct App {
     pub transcript_spacing: TranscriptSpacing,
     pub sidebar_width_percent: u16,
     pub sidebar_focus: SidebarFocus,
+    /// Sidebar hover state for mouse tooltip support.
+    pub sidebar_hover: SidebarHoverState,
+    /// Current hover tooltip text, if any.
+    pub sidebar_hover_tooltip: Option<String>,
+    /// Last known mouse position for tooltip placement.
+    pub last_mouse_pos: Option<(u16, u16)>,
     /// Whether the session-context panel is enabled (#504).
     pub context_panel: bool,
     /// File-tree pane state. `None` when hidden; `Some` when visible.
@@ -1366,6 +1390,9 @@ impl App {
             transcript_spacing,
             sidebar_width_percent,
             sidebar_focus,
+            sidebar_hover: SidebarHoverState::default(),
+            sidebar_hover_tooltip: None,
+            last_mouse_pos: None,
             context_panel: settings.context_panel,
             file_tree: None,
             compact_threshold,

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -668,8 +668,6 @@ pub struct SidebarHoverState {
 /// Per-section metadata for sidebar hover detection.
 #[derive(Debug, Clone)]
 pub struct SidebarHoverSection {
-    /// The outer area of the section block.
-    pub area: Rect,
     /// Content area within the section (inside border + padding).
     pub content_area: Rect,
     /// Full original text for each content line rendered.

--- a/crates/tui/src/tui/sidebar.rs
+++ b/crates/tui/src/tui/sidebar.rs
@@ -21,7 +21,7 @@ use crate::tools::plan::StepStatus;
 use crate::tools::subagent::SubAgentStatus;
 use crate::tools::todo::TodoStatus;
 
-use super::app::{App, SidebarFocus};
+use super::app::{App, SidebarFocus, SidebarHoverSection, SidebarHoverState};
 use super::history::{HistoryCell, ToolCell, ToolStatus};
 use super::subagent_routing::active_fanout_counts;
 use super::ui::truncate_line_to_width;
@@ -31,7 +31,9 @@ use super::ui::truncate_line_to_width;
 /// does not prematurely hide the session+agents breakdown.
 const COST_EQ_TOLERANCE: f64 = 1e-6;
 
-pub fn render_sidebar(f: &mut Frame, area: Rect, app: &App) {
+pub fn render_sidebar(f: &mut Frame, area: Rect, app: &mut App) {
+    // Clear hover state at the start of each render
+    app.sidebar_hover = SidebarHoverState::default();
     if area.width < 24 || area.height < 8 {
         // Paint a styled block over the area so stale cells from a previous
         // (wider) frame don't persist as bleed-through artifacts (#400).
@@ -56,7 +58,7 @@ pub fn render_sidebar(f: &mut Frame, area: Rect, app: &App) {
 /// clipped because Todos/Tasks/Agents each reserved 25% of the height even
 /// when they had nothing to show. Plan is always rendered (it owns the
 /// session-wide empty-state hint).
-fn render_sidebar_auto(f: &mut Frame, area: Rect, app: &App) {
+fn render_sidebar_auto(f: &mut Frame, area: Rect, app: &mut App) {
     #[derive(Clone, Copy)]
     enum Panel {
         Plan,
@@ -146,7 +148,7 @@ fn render_sidebar_auto(f: &mut Frame, area: Rect, app: &App) {
 /// That kept the user wondering whether the panel was broken; the
 /// hint instead tells them what the panel is for and how to populate
 /// it.
-fn render_sidebar_plan(f: &mut Frame, area: Rect, app: &App) {
+fn render_sidebar_plan(f: &mut Frame, area: Rect, app: &mut App) {
     if area.height < 3 {
         return;
     }
@@ -154,9 +156,11 @@ fn render_sidebar_plan(f: &mut Frame, area: Rect, app: &App) {
     let theme = Theme::for_palette_mode(app.ui_theme.mode);
     let content_width = area.width.saturating_sub(4) as usize;
     let mut lines: Vec<Line<'static>> = Vec::with_capacity(usize::from(area.height).max(4));
+    let mut full_texts: Vec<String> = Vec::with_capacity(usize::from(area.height).max(4));
 
     // === Goal Mode (#397) — gold outline matching todo items ===
     if let Some(ref objective) = app.goal.goal_objective {
+        full_texts.push(objective.clone());
         lines.push(Line::from(Span::styled(
             format!(
                 "◆ {}",
@@ -239,6 +243,7 @@ fn render_sidebar_plan(f: &mut Frame, area: Rect, app: &App) {
                 ]));
 
                 if let Some(explanation) = plan.explanation() {
+                    full_texts.push(explanation.to_string());
                     lines.push(Line::from(Span::styled(
                         truncate_line_to_width(explanation, content_width.max(1)),
                         Style::default().fg(theme.plan_explanation_color),
@@ -258,6 +263,7 @@ fn render_sidebar_plan(f: &mut Frame, area: Rect, app: &App) {
                     if !elapsed.is_empty() {
                         let _ = write!(text, " ({elapsed})");
                     }
+                    full_texts.push(text.clone());
                     lines.push(Line::from(Span::styled(
                         truncate_line_to_width(&text, content_width.max(1)),
                         Style::default().fg(color),
@@ -281,7 +287,7 @@ fn render_sidebar_plan(f: &mut Frame, area: Rect, app: &App) {
         }
     }
 
-    render_sidebar_section(f, area, "Plan", lines, app);
+    render_sidebar_section(f, area, "Plan", lines, full_texts, app);
 }
 
 /// One-line hint shown when the Plan section has nothing to display
@@ -295,13 +301,14 @@ fn plan_panel_empty_hint(content_width: usize) -> String {
     truncate_line_to_width(full, content_width)
 }
 
-fn render_sidebar_todos(f: &mut Frame, area: Rect, app: &App) {
+fn render_sidebar_todos(f: &mut Frame, area: Rect, app: &mut App) {
     if area.height < 3 {
         return;
     }
 
     let content_width = area.width.saturating_sub(4) as usize;
     let mut lines: Vec<Line<'static>> = Vec::with_capacity(usize::from(area.height).max(4));
+    let mut full_texts: Vec<String> = Vec::with_capacity(usize::from(area.height).max(4));
 
     match app.todos.try_lock() {
         Ok(todos) => {
@@ -338,6 +345,7 @@ fn render_sidebar_todos(f: &mut Frame, area: Rect, app: &App) {
                         TodoStatus::Completed => ("[x]", palette::STATUS_SUCCESS),
                     };
                     let text = format!("{prefix} #{} {}", item.id, item.content);
+                    full_texts.push(text.clone());
                     lines.push(Line::from(Span::styled(
                         truncate_line_to_width(&text, content_width.max(1)),
                         Style::default().fg(color),
@@ -361,16 +369,17 @@ fn render_sidebar_todos(f: &mut Frame, area: Rect, app: &App) {
         }
     }
 
-    render_sidebar_section(f, area, "Todos", lines, app);
+    render_sidebar_section(f, area, "Todos", lines, full_texts, app);
 }
 
-fn render_sidebar_tasks(f: &mut Frame, area: Rect, app: &App) {
+fn render_sidebar_tasks(f: &mut Frame, area: Rect, app: &mut App) {
     if area.height < 3 {
         return;
     }
 
     let content_width = area.width.saturating_sub(4) as usize;
     let mut lines: Vec<Line<'static>> = Vec::with_capacity(usize::from(area.height).max(4));
+    let mut full_texts: Vec<String> = Vec::with_capacity(usize::from(area.height).max(4));
 
     if let Some(turn_id) = app.runtime_turn_id.as_ref() {
         let status = app
@@ -432,16 +441,24 @@ fn render_sidebar_tasks(f: &mut Frame, area: Rect, app: &App) {
                 .duration_ms
                 .map(|ms| format!("{:.1}s", ms as f64 / 1000.0))
                 .unwrap_or_else(|| "-".to_string());
+            let full_label = format!(
+                "{} {} {}",
+                task.id,
+                task.status,
+                duration
+            );
             let label = format!(
                 "{} {} {}",
                 truncate_line_to_width(&task.id, 10),
                 task.status,
                 duration
             );
+            full_texts.push(full_label);
             lines.push(Line::from(Span::styled(
                 truncate_line_to_width(&label, content_width.max(1)),
                 Style::default().fg(color),
             )));
+            full_texts.push(task.prompt_summary.clone());
             lines.push(Line::from(Span::styled(
                 format!(
                     "  {}",
@@ -455,10 +472,10 @@ fn render_sidebar_tasks(f: &mut Frame, area: Rect, app: &App) {
         }
     }
 
-    render_sidebar_section(f, area, "Tasks", lines, app);
+    render_sidebar_section(f, area, "Tasks", lines, full_texts, app);
 }
 
-fn render_sidebar_subagents(f: &mut Frame, area: Rect, app: &App) {
+fn render_sidebar_subagents(f: &mut Frame, area: Rect, app: &mut App) {
     if area.height < 3 {
         return;
     }
@@ -508,7 +525,7 @@ fn render_sidebar_subagents(f: &mut Frame, area: Rect, app: &App) {
     };
     let lines = subagent_navigator_lines(&summary, content_width);
 
-    render_sidebar_section(f, area, "Agents", lines, app);
+    render_sidebar_section(f, area, "Agents", lines, Vec::new(), app);
 }
 
 /// Minimal projection of the data the sub-agent sidebar needs. Lifted out
@@ -623,7 +640,7 @@ pub fn subagent_navigator_lines(
 /// cost, MCP server count, LSP toggle state, cycle count, and memory
 /// file size + mtime. Each section is a compact one-liner so the panel
 /// reads as a dashboard rather than a scrolling list.
-fn render_context_panel(f: &mut Frame, area: Rect, app: &App) {
+fn render_context_panel(f: &mut Frame, area: Rect, app: &mut App) {
     if area.height < 3 {
         return;
     }
@@ -753,7 +770,7 @@ fn render_context_panel(f: &mut Frame, area: Rect, app: &App) {
         )));
     }
 
-    render_sidebar_section(f, area, "Session", lines, app);
+    render_sidebar_section(f, area, "Session", lines, Vec::new(), app);
 }
 
 fn render_sidebar_section(
@@ -761,7 +778,8 @@ fn render_sidebar_section(
     area: Rect,
     title: &str,
     lines: Vec<Line<'static>>,
-    app: &App,
+    full_texts: Vec<String>,
+    app: &mut App,
 ) {
     if area.width < 4 || area.height < 3 {
         // Clear stale cells before bailing out (#400).
@@ -772,6 +790,20 @@ fn render_sidebar_section(
     }
 
     let theme = Theme::for_palette_mode(app.ui_theme.mode);
+
+    // Record hover metadata for mouse tooltip support.
+    let padding = theme.section_padding;
+    let content_area = Rect {
+        x: area.x + 1 + padding.left,
+        y: area.y + 1 + padding.top,
+        width: area.width.saturating_sub(2 + padding.left + padding.right),
+        height: area.height.saturating_sub(2 + padding.top + padding.bottom),
+    };
+    app.sidebar_hover.sections.push(SidebarHoverSection {
+        area,
+        content_area,
+        lines: full_texts,
+    });
     // Truncate the panel title so it always fits within the section width
     // even after a resize. The title occupies up to 4 chars of border chrome
     // (two spaces + one space on each side), so the max title length is
@@ -966,6 +998,50 @@ mod tests {
             role_line.chars().count() <= 16,
             "role line {role_line:?} exceeded content_width"
         );
+    }
+
+    // ---- Sidebar hover tooltip tests ----
+
+    #[test]
+    fn sidebar_hover_state_default_is_empty() {
+        let state = SidebarHoverState::default();
+        assert!(state.sections.is_empty());
+    }
+
+    #[test]
+    fn sidebar_hover_section_stores_lines() {
+        use ratatui::layout::Rect;
+        let section = SidebarHoverSection {
+            area: Rect::new(0, 0, 40, 10),
+            content_area: Rect::new(1, 1, 38, 8),
+            lines: vec!["line 1".to_string(), "line 2".to_string()],
+        };
+        assert_eq!(section.lines.len(), 2);
+        assert_eq!(section.lines[0], "line 1");
+        assert!(section.content_area.x > section.area.x);
+    }
+
+    #[test]
+    fn hover_line_matching_respects_content_area_offset() {
+        use ratatui::layout::Rect;
+        let section = SidebarHoverSection {
+            area: Rect::new(60, 0, 40, 10),
+            content_area: Rect::new(62, 2, 36, 6),
+            lines: vec!["first".to_string(), "second".to_string(), "third".to_string()],
+        };
+
+        // Mouse within content area, first line
+        assert!(62 >= 62 && 62 < 62 + 36); // column in range
+        assert!(2 >= 2 && 2 < 2 + 6); // row in range
+        let line_idx = (2u16.saturating_sub(2)) as usize;
+        assert_eq!(section.lines[line_idx], "first");
+
+        // Mouse within content area, second line
+        let line_idx = (3u16.saturating_sub(2)) as usize;
+        assert_eq!(section.lines[line_idx], "second");
+
+        // Mouse outside content area (above)
+        assert!(1u16 < 2u16);
     }
 
     #[test]

--- a/crates/tui/src/tui/sidebar.rs
+++ b/crates/tui/src/tui/sidebar.rs
@@ -441,12 +441,7 @@ fn render_sidebar_tasks(f: &mut Frame, area: Rect, app: &mut App) {
                 .duration_ms
                 .map(|ms| format!("{:.1}s", ms as f64 / 1000.0))
                 .unwrap_or_else(|| "-".to_string());
-            let full_label = format!(
-                "{} {} {}",
-                task.id,
-                task.status,
-                duration
-            );
+            let full_label = format!("{} {} {}", task.id, task.status, duration);
             let label = format!(
                 "{} {} {}",
                 truncate_line_to_width(&task.id, 10),
@@ -800,7 +795,6 @@ fn render_sidebar_section(
         height: area.height.saturating_sub(2 + padding.top + padding.bottom),
     };
     app.sidebar_hover.sections.push(SidebarHoverSection {
-        area,
         content_area,
         lines: full_texts,
     });
@@ -844,7 +838,10 @@ fn render_sidebar_section(
 
 #[cfg(test)]
 mod tests {
-    use super::{SidebarHoverSection, SidebarHoverState, SidebarSubagentSummary, plan_panel_empty_hint, subagent_navigator_lines};
+    use super::{
+        SidebarHoverSection, SidebarHoverState, SidebarSubagentSummary, plan_panel_empty_hint,
+        subagent_navigator_lines,
+    };
     use ratatui::text::Line;
 
     fn lines_to_text(lines: &[Line<'static>]) -> Vec<String> {
@@ -1012,36 +1009,36 @@ mod tests {
     fn sidebar_hover_section_stores_lines() {
         use ratatui::layout::Rect;
         let section = SidebarHoverSection {
-            area: Rect::new(0, 0, 40, 10),
             content_area: Rect::new(1, 1, 38, 8),
             lines: vec!["line 1".to_string(), "line 2".to_string()],
         };
         assert_eq!(section.lines.len(), 2);
         assert_eq!(section.lines[0], "line 1");
-        assert!(section.content_area.x > section.area.x);
+        assert!(section.content_area.x > 0);
     }
 
     #[test]
     fn hover_line_matching_respects_content_area_offset() {
         use ratatui::layout::Rect;
         let section = SidebarHoverSection {
-            area: Rect::new(60, 0, 40, 10),
             content_area: Rect::new(62, 2, 36, 6),
-            lines: vec!["first".to_string(), "second".to_string(), "third".to_string()],
+            lines: vec![
+                "first".to_string(),
+                "second".to_string(),
+                "third".to_string(),
+            ],
         };
 
         // Mouse within content area, first line
-        assert!(62 >= 62 && 62 < 62 + 36); // column in range
-        assert!(2 >= 2 && 2 < 2 + 6); // row in range
-        let line_idx = (2u16.saturating_sub(2)) as usize;
+        let line_idx = (2u16.saturating_sub(section.content_area.y)) as usize;
         assert_eq!(section.lines[line_idx], "first");
 
         // Mouse within content area, second line
-        let line_idx = (3u16.saturating_sub(2)) as usize;
+        let line_idx = (3u16.saturating_sub(section.content_area.y)) as usize;
         assert_eq!(section.lines[line_idx], "second");
 
-        // Mouse outside content area (above)
-        assert!(1u16 < 2u16);
+        // Mouse outside content area (above) — row < content_area.y
+        assert!((1u16) < section.content_area.y);
     }
 
     #[test]

--- a/crates/tui/src/tui/sidebar.rs
+++ b/crates/tui/src/tui/sidebar.rs
@@ -844,7 +844,7 @@ fn render_sidebar_section(
 
 #[cfg(test)]
 mod tests {
-    use super::{SidebarSubagentSummary, plan_panel_empty_hint, subagent_navigator_lines};
+    use super::{SidebarHoverSection, SidebarHoverState, SidebarSubagentSummary, plan_panel_empty_hint, subagent_navigator_lines};
     use ratatui::text::Line;
 
     fn lines_to_text(lines: &[Line<'static>]) -> Vec<String> {

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -5701,31 +5701,30 @@ fn render(f: &mut Frame, app: &mut App) {
             super::sidebar::render_sidebar(f, sidebar_area, app);
 
             // Render sidebar hover tooltip if active.
-            if let Some(ref tooltip_text) = app.sidebar_hover_tooltip {
-                if let Some((mouse_col, mouse_row)) = app.last_mouse_pos {
-                    let text_width = (tooltip_text.len() as u16).min(60).max(10);
-                    let tooltip_height = 1u16;
-                    let x = mouse_col
-                        .saturating_add(2)
-                        .min(size.width.saturating_sub(text_width));
-                    let y = mouse_row
-                        .saturating_sub(1)
-                        .min(size.height.saturating_sub(tooltip_height));
-                    if text_width > 0 && tooltip_height > 0 {
-                        let tooltip_area = Rect {
-                            x,
-                            y,
-                            width: text_width,
-                            height: tooltip_height,
-                        };
-                        let tooltip = ratatui::widgets::Paragraph::new(tooltip_text.as_str())
-                            .style(
-                                Style::default()
-                                    .bg(palette::STATUS_WARNING)
-                                    .fg(palette::TEXT_MUTED),
-                            );
-                        f.render_widget(tooltip, tooltip_area);
-                    }
+            if let Some(ref tooltip_text) = app.sidebar_hover_tooltip
+                && let Some((mouse_col, mouse_row)) = app.last_mouse_pos
+            {
+                let text_width = (tooltip_text.len() as u16).clamp(10, 60);
+                let tooltip_height = 1u16;
+                let x = mouse_col
+                    .saturating_add(2)
+                    .min(size.width.saturating_sub(text_width));
+                let y = mouse_row
+                    .saturating_sub(1)
+                    .min(size.height.saturating_sub(tooltip_height));
+                if text_width > 0 && tooltip_height > 0 {
+                    let tooltip_area = Rect {
+                        x,
+                        y,
+                        width: text_width,
+                        height: tooltip_height,
+                    };
+                    let tooltip = ratatui::widgets::Paragraph::new(tooltip_text.as_str()).style(
+                        Style::default()
+                            .bg(palette::STATUS_WARNING)
+                            .fg(palette::TEXT_MUTED),
+                    );
+                    f.render_widget(tooltip, tooltip_area);
                 }
             }
         }
@@ -7894,12 +7893,19 @@ fn handle_mouse_event(app: &mut App, mouse: MouseEvent) -> Vec<ViewEvent> {
             let mut found = false;
             for section in &app.sidebar_hover.sections {
                 if mouse.column >= section.content_area.x
-                    && mouse.column < section.content_area.x.saturating_add(section.content_area.width)
+                    && mouse.column
+                        < section
+                            .content_area
+                            .x
+                            .saturating_add(section.content_area.width)
                     && mouse.row >= section.content_area.y
-                    && mouse.row < section.content_area.y.saturating_add(section.content_area.height)
+                    && mouse.row
+                        < section
+                            .content_area
+                            .y
+                            .saturating_add(section.content_area.height)
                 {
-                    let line_idx =
-                        (mouse.row.saturating_sub(section.content_area.y)) as usize;
+                    let line_idx = (mouse.row.saturating_sub(section.content_area.y)) as usize;
                     if line_idx < section.lines.len() {
                         let new_tooltip = section.lines[line_idx].clone();
                         if app.sidebar_hover_tooltip.as_deref() != Some(&new_tooltip) {

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -5699,6 +5699,35 @@ fn render(f: &mut Frame, app: &mut App) {
 
         if let Some(sidebar_area) = sidebar_area {
             super::sidebar::render_sidebar(f, sidebar_area, app);
+
+            // Render sidebar hover tooltip if active.
+            if let Some(ref tooltip_text) = app.sidebar_hover_tooltip {
+                if let Some((mouse_col, mouse_row)) = app.last_mouse_pos {
+                    let text_width = (tooltip_text.len() as u16).min(60).max(10);
+                    let tooltip_height = 1u16;
+                    let x = mouse_col
+                        .saturating_add(2)
+                        .min(size.width.saturating_sub(text_width));
+                    let y = mouse_row
+                        .saturating_sub(1)
+                        .min(size.height.saturating_sub(tooltip_height));
+                    if text_width > 0 && tooltip_height > 0 {
+                        let tooltip_area = Rect {
+                            x,
+                            y,
+                            width: text_width,
+                            height: tooltip_height,
+                        };
+                        let tooltip = ratatui::widgets::Paragraph::new(tooltip_text.as_str())
+                            .style(
+                                Style::default()
+                                    .bg(palette::STATUS_WARNING)
+                                    .fg(palette::TEXT_MUTED),
+                            );
+                        f.render_widget(tooltip, tooltip_area);
+                    }
+                }
+            }
         }
     }
 
@@ -7857,6 +7886,36 @@ fn handle_mouse_event(app: &mut App, mouse: MouseEvent) -> Vec<ViewEvent> {
     }
 
     match mouse.kind {
+        MouseEventKind::Moved => {
+            // Update last mouse position for tooltip rendering.
+            app.last_mouse_pos = Some((mouse.column, mouse.row));
+
+            // Check sidebar sections for hover tooltip.
+            let mut found = false;
+            for section in &app.sidebar_hover.sections {
+                if mouse.column >= section.content_area.x
+                    && mouse.column < section.content_area.x.saturating_add(section.content_area.width)
+                    && mouse.row >= section.content_area.y
+                    && mouse.row < section.content_area.y.saturating_add(section.content_area.height)
+                {
+                    let line_idx =
+                        (mouse.row.saturating_sub(section.content_area.y)) as usize;
+                    if line_idx < section.lines.len() {
+                        let new_tooltip = section.lines[line_idx].clone();
+                        if app.sidebar_hover_tooltip.as_deref() != Some(&new_tooltip) {
+                            app.sidebar_hover_tooltip = Some(new_tooltip);
+                            app.needs_redraw = true;
+                        }
+                        found = true;
+                        break;
+                    }
+                }
+            }
+            if !found && app.sidebar_hover_tooltip.is_some() {
+                app.sidebar_hover_tooltip = None;
+                app.needs_redraw = true;
+            }
+        }
         MouseEventKind::ScrollUp => {
             let update = app.viewport.mouse_scroll.on_scroll(ScrollDirection::Up);
             app.viewport.pending_scroll_delta += update.delta_lines;


### PR DESCRIPTION
## Summary

When Plan / Tasks / Todos sidebar panel lines are truncated due to narrow width, hovering the mouse over a line now shows a floating tooltip with the full original (pre-truncation) text.

## Changes

**`crates/tui/src/tui/app.rs`** (+27 lines)
- Add `SidebarHoverState` and `SidebarHoverSection` structs to track per-section area metadata and original line text
- Add `sidebar_hover`, `sidebar_hover_tooltip`, `last_mouse_pos` fields to `App`

**`crates/tui/src/tui/sidebar.rs`** (+90/-14 lines)
- All render functions now take `&mut App`
- Plan, Tasks, and Todos panels collect original text before `truncate_line_to_width` calls
- `render_sidebar_section` records section area and full-text lines into `SidebarHoverState`
- 3 new unit tests for hover state and line matching logic

**`crates/tui/src/tui/ui.rs`** (+59 lines)
- `handle_mouse_event` `MouseEventKind::Moved`: iterates sidebar sections to detect hover, sets/clears tooltip text
- `render`: draws a floating `Paragraph` overlay near mouse cursor when tooltip is active

## How it works

1. Each frame, sidebar rendering records every section's bounding area and the original full text of each line
2. On mouse move, the handler checks if the cursor falls within any sidebar section's content area
3. If so, it maps the mouse row to a line index and reads the original untruncated text
4. A tooltip `Paragraph` is rendered near the cursor with the full text