### PR TITLE
  fix(tui): ignore leaked mouse reports in composer

### DIFF
--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -369,6 +369,90 @@ fn sanitize_api_key_text(text: &str) -> String {
     text.chars().filter(|c| !c.is_control()).collect()
 }
 
+fn strip_raw_mouse_report_runs(input: &str, cursor: usize) -> Option<(String, usize)> {
+    let chars: Vec<char> = input.chars().collect();
+    let mut output = String::with_capacity(input.len());
+    let mut new_cursor = 0usize;
+    let mut changed = false;
+    let mut index = 0usize;
+
+    while index < chars.len() {
+        if is_raw_mouse_report_run_char(chars[index]) {
+            let start = index;
+            while index < chars.len() && is_raw_mouse_report_run_char(chars[index]) {
+                index += 1;
+            }
+            let run = &chars[start..index];
+            if looks_like_raw_mouse_report_run(run) {
+                changed = true;
+                continue;
+            }
+            for (offset, ch) in run.iter().copied().enumerate() {
+                if start + offset < cursor {
+                    new_cursor += 1;
+                }
+                output.push(ch);
+            }
+            continue;
+        }
+
+        if index < cursor {
+            new_cursor += 1;
+        }
+        output.push(chars[index]);
+        index += 1;
+    }
+
+    changed.then(|| {
+        let cursor = new_cursor.min(char_count(&output));
+        (output, cursor)
+    })
+}
+
+fn is_raw_mouse_report_run_char(ch: char) -> bool {
+    matches!(ch, '\x1b' | '[' | '<' | ';' | ':' | 'M' | 'm') || ch.is_ascii_digit()
+}
+
+fn looks_like_raw_mouse_report_run(run: &[char]) -> bool {
+    if run.len() < 5 {
+        return false;
+    }
+    let has_separator = run.iter().any(|ch| matches!(ch, ';' | ':'));
+    let terminators = run.iter().filter(|ch| matches!(ch, 'M' | 'm')).count();
+    if !has_separator || terminators == 0 {
+        return false;
+    }
+    has_sgr_mouse_marker(run) || terminators >= 2 || is_truncated_mouse_report(run)
+}
+
+fn has_sgr_mouse_marker(run: &[char]) -> bool {
+    run.windows(2).any(|window| window == ['[', '<'])
+}
+
+fn is_truncated_mouse_report(run: &[char]) -> bool {
+    let mut index = 0usize;
+    if !consume_mouse_report_number(run, &mut index) {
+        return false;
+    }
+    let mut fields = 1usize;
+    while index < run.len() && matches!(run[index], ';' | ':') {
+        index += 1;
+        if !consume_mouse_report_number(run, &mut index) {
+            return false;
+        }
+        fields += 1;
+    }
+    fields >= 2 && index + 1 == run.len() && matches!(run[index], 'M' | 'm')
+}
+
+fn consume_mouse_report_number(run: &[char], index: &mut usize) -> bool {
+    let start = *index;
+    while *index < run.len() && run[*index].is_ascii_digit() {
+        *index += 1;
+    }
+    *index > start
+}
+
 const MAX_SUBMITTED_INPUT_CHARS: usize = 16_000;
 const MAX_DRAFT_HISTORY: usize = 50;
 
@@ -2537,6 +2621,7 @@ impl App {
         let byte_index = byte_index_at_char(&self.input, cursor);
         self.input.insert_str(byte_index, text);
         self.cursor_position = cursor + char_count(text);
+        self.strip_raw_mouse_reports_from_input();
         self.slash_menu_hidden = false;
         self.mention_menu_hidden = false;
         self.mention_menu_selected = 0;
@@ -2798,10 +2883,23 @@ impl App {
         let byte_index = byte_index_at_char(&self.input, cursor);
         self.input.insert(byte_index, c);
         self.cursor_position = cursor + 1;
+        self.strip_raw_mouse_reports_from_input();
         self.slash_menu_hidden = false;
         self.mention_menu_hidden = false;
         self.mention_menu_selected = 0;
         self.needs_redraw = true;
+    }
+
+    fn strip_raw_mouse_reports_from_input(&mut self) {
+        if !self.use_mouse_capture {
+            return;
+        }
+        if let Some((input, cursor_position)) =
+            strip_raw_mouse_report_runs(&self.input, self.cursor_position)
+        {
+            self.input = input;
+            self.cursor_position = cursor_position;
+        }
     }
 
     pub fn delete_char(&mut self) {
@@ -4039,6 +4137,49 @@ mod tests {
     fn test_trust_mode_follows_yolo_on_startup() {
         let app = App::new(test_options(true), &Config::default());
         assert!(app.trust_mode);
+    }
+
+    #[test]
+    fn composer_strips_raw_sgr_mouse_report_when_mouse_capture_is_enabled() {
+        let mut app = App::new(test_options(false), &Config::default());
+        app.use_mouse_capture = true;
+
+        app.insert_str("[<35;44;18M");
+
+        assert_eq!(app.input, "");
+        assert_eq!(app.cursor_position, 0);
+    }
+
+    #[test]
+    fn composer_strips_corrupted_mouse_report_burst() {
+        let mut app = App::new(test_options(false), &Config::default());
+        app.use_mouse_capture = true;
+        app.insert_str("draft ");
+        let leaked = "43;19M[<35;44;18M[<35;45;18M5;46;18M;48;18M";
+
+        app.insert_str(leaked);
+
+        assert_eq!(app.input, "draft ");
+        assert_eq!(app.cursor_position, "draft ".chars().count());
+    }
+
+    #[test]
+    fn composer_keeps_mouse_like_text_when_mouse_capture_is_disabled() {
+        let mut app = App::new(test_options(false), &Config::default());
+
+        app.insert_str("[<35;44;18M");
+
+        assert_eq!(app.input, "[<35;44;18M");
+    }
+
+    #[test]
+    fn composer_keeps_normal_bracket_text_with_mouse_capture_enabled() {
+        let mut app = App::new(test_options(false), &Config::default());
+        app.use_mouse_capture = true;
+
+        app.insert_str("Use [<tag>] normally");
+
+        assert_eq!(app.input, "Use [<tag>] normally");
     }
 
     #[test]


### PR DESCRIPTION

## Summary

  Fixes #1418.

  Some terminals or SSH/IDE terminal chains can leak SGR mouse report bytes such as `[<35;44;18M` into stdin while mouse capture is enabled. When that happens, the composer treats those bytes as normal typed text, fills the input area, and the footer appears to switch to draft state.

 This change filters raw mouse report fragments at the composer insertion boundary when mouse capture is enabled. Normal text input is preserved, and mouse-like text is still accepted when mouse capture is disabled.

## Testing

- [x] `cargo test --all-features`
- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
