### PR TITLE
  Guard first calls to deferred tools

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -2049,10 +2049,12 @@ use self::tool_catalog::{
     CODE_EXECUTION_TOOL_NAME, MULTI_TOOL_PARALLEL_NAME, REQUEST_USER_INPUT_NAME,
     active_tools_for_step, build_model_tool_catalog, ensure_advanced_tooling,
     execute_code_execution_tool, execute_tool_search, initial_active_tools, is_tool_search_tool,
-    maybe_activate_requested_deferred_tool, missing_tool_error_message,
+    missing_tool_error_message, preflight_requested_deferred_tool,
 };
 #[cfg(test)]
-use self::tool_catalog::{TOOL_SEARCH_BM25_NAME, should_default_defer_tool};
+use self::tool_catalog::{
+    TOOL_SEARCH_BM25_NAME, maybe_activate_requested_deferred_tool, should_default_defer_tool,
+};
 use self::tool_execution::emit_tool_audit;
 use self::tool_setup::sandbox_policy_for_mode;
 

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -435,6 +435,111 @@ fn active_tool_list_pushes_deferred_activations_to_the_tail() {
 }
 
 #[test]
+fn deferred_tool_preflight_loads_edit_schema_without_executing_bad_aliases() {
+    let (engine, _handle) = Engine::new(EngineConfig::default(), &Config::default());
+    let registry = engine
+        .build_turn_tool_registry_builder(
+            AppMode::Agent,
+            engine.config.todos.clone(),
+            engine.config.plan_state.clone(),
+        )
+        .build(engine.build_tool_context(AppMode::Agent, false));
+    let catalog = build_model_tool_catalog(
+        registry.to_api_tools_with_cache(true),
+        vec![],
+        AppMode::Agent,
+    );
+    let mut active = initial_active_tools(&catalog);
+    assert!(!active.contains("edit_file"));
+
+    let result = preflight_requested_deferred_tool(
+        "edit_file",
+        &json!({
+            "path": "src/foo.rs",
+            "old_string": "before",
+            "new_string": "after"
+        }),
+        &catalog,
+        &mut active,
+    )
+    .expect("deferred edit_file should preflight");
+
+    assert!(active.contains("edit_file"));
+    assert!(result.success);
+    assert!(result.content.contains("Tool `edit_file` was deferred"));
+    assert!(result.content.contains("The tool was not executed"));
+    assert!(result.content.contains("path: string required"));
+    assert!(result.content.contains("search: string required"));
+    assert!(result.content.contains("replace: string required"));
+    assert!(result.content.contains("old_string -> search"));
+    assert!(result.content.contains("new_string -> replace"));
+    assert_eq!(
+        result.metadata.as_ref().unwrap()["deferred_tool_loaded"],
+        json!(true)
+    );
+}
+
+#[test]
+fn deferred_tool_preflight_guides_checklist_update_list_replacement() {
+    let (engine, _handle) = Engine::new(EngineConfig::default(), &Config::default());
+    let registry = engine
+        .build_turn_tool_registry_builder(
+            AppMode::Agent,
+            engine.config.todos.clone(),
+            engine.config.plan_state.clone(),
+        )
+        .build(engine.build_tool_context(AppMode::Agent, false));
+    let catalog = build_model_tool_catalog(
+        registry.to_api_tools_with_cache(true),
+        vec![],
+        AppMode::Agent,
+    );
+    let mut active = initial_active_tools(&catalog);
+    assert!(!active.contains("checklist_update"));
+
+    let result = preflight_requested_deferred_tool(
+        "checklist_update",
+        &json!({
+            "todos": [
+                { "content": "wire preflight", "status": "completed" }
+            ]
+        }),
+        &catalog,
+        &mut active,
+    )
+    .expect("deferred checklist_update should preflight");
+
+    assert!(active.contains("checklist_update"));
+    assert!(result.success);
+    assert!(
+        result
+            .content
+            .contains("Tool `checklist_update` was deferred")
+    );
+    assert!(result.content.contains("id: integer required"));
+    assert!(result.content.contains("status: string"));
+    assert!(result.content.contains("Missing required fields:"));
+    assert!(result.content.contains("id, status"));
+    assert!(result.content.contains("Unexpected fields:"));
+    assert!(result.content.contains("todos"));
+    assert!(result.content.contains("Use checklist_write"));
+}
+
+#[test]
+fn deferred_tool_preflight_skips_already_active_tools() {
+    let mut tool = api_tool("deferred_tool");
+    tool.defer_loading = Some(true);
+    let catalog = vec![tool];
+    let mut active = HashSet::from(["deferred_tool".to_string()]);
+
+    assert!(
+        preflight_requested_deferred_tool("deferred_tool", &json!({}), &catalog, &mut active,)
+            .is_none(),
+        "already active tools should execute normally"
+    );
+}
+
+#[test]
 fn turn_tool_registry_builder_keeps_plan_mode_read_only_for_files() {
     let (engine, _handle) = Engine::new(EngineConfig::default(), &Config::default());
     let registry = engine

--- a/crates/tui/src/core/engine/tool_catalog.rs
+++ b/crates/tui/src/core/engine/tool_catalog.rs
@@ -390,6 +390,7 @@ pub(super) fn missing_tool_error_message(tool_name: &str, catalog: &[Tool]) -> S
     )
 }
 
+#[cfg(test)]
 pub(super) fn maybe_activate_requested_deferred_tool(
     tool_name: &str,
     catalog: &[Tool],
@@ -404,6 +405,182 @@ pub(super) fn maybe_activate_requested_deferred_tool(
     }
 
     active_tools.insert(tool_name.to_string())
+}
+
+pub(super) fn preflight_requested_deferred_tool(
+    tool_name: &str,
+    input: &serde_json::Value,
+    catalog: &[Tool],
+    active_tools: &mut HashSet<String>,
+) -> Option<ToolResult> {
+    let def = catalog.iter().find(|def| def.name == tool_name)?;
+    if !def.defer_loading.unwrap_or(false) || active_tools.contains(tool_name) {
+        return None;
+    }
+
+    active_tools.insert(tool_name.to_string());
+    Some(deferred_tool_loaded_result(def, input))
+}
+
+fn deferred_tool_loaded_result(tool: &Tool, input: &serde_json::Value) -> ToolResult {
+    let expected = schema_fields(&tool.input_schema);
+    let required = schema_required_fields(&tool.input_schema);
+    let received = received_fields(input);
+    let missing = required
+        .iter()
+        .filter(|field| !received.contains(field))
+        .cloned()
+        .collect::<Vec<_>>();
+    let unexpected = received
+        .iter()
+        .filter(|field| !expected.iter().any(|expected| &expected.name == *field))
+        .cloned()
+        .collect::<Vec<_>>();
+    let corrections = likely_field_corrections(&received, &expected, &tool.name);
+
+    let mut lines = vec![
+        format!("Tool `{}` was deferred and has now been loaded.", tool.name),
+        String::new(),
+        "The tool was not executed. Retry with the loaded schema.".to_string(),
+        String::new(),
+        "Expected fields:".to_string(),
+    ];
+    if expected.is_empty() {
+        lines.push("  (none)".to_string());
+    } else {
+        for field in &expected {
+            let required_marker = if required.contains(&field.name) {
+                " required"
+            } else {
+                ""
+            };
+            lines.push(format!(
+                "  {}: {}{}",
+                field.name, field.kind, required_marker
+            ));
+        }
+    }
+    lines.push(String::new());
+    lines.push("Received fields:".to_string());
+    if received.is_empty() {
+        lines.push("  (none)".to_string());
+    } else {
+        lines.push(format!("  {}", received.join(", ")));
+    }
+    if !missing.is_empty() {
+        lines.push(String::new());
+        lines.push("Missing required fields:".to_string());
+        lines.push(format!("  {}", missing.join(", ")));
+    }
+    if !unexpected.is_empty() {
+        lines.push(String::new());
+        lines.push("Unexpected fields:".to_string());
+        lines.push(format!("  {}", unexpected.join(", ")));
+    }
+    if !corrections.is_empty() {
+        lines.push(String::new());
+        lines.push("Likely corrections:".to_string());
+        for correction in &corrections {
+            lines.push(format!("  {correction}"));
+        }
+    }
+
+    ToolResult::success(lines.join("\n")).with_metadata(json!({
+        "deferred_tool_loaded": true,
+        "tool_name": tool.name,
+        "expected_fields": expected.iter().map(|field| field.name.clone()).collect::<Vec<_>>(),
+        "received_fields": received,
+        "missing_required_fields": missing,
+        "unexpected_fields": unexpected,
+        "likely_corrections": corrections,
+    }))
+}
+
+#[derive(Debug, Clone)]
+struct SchemaField {
+    name: String,
+    kind: String,
+}
+
+fn schema_fields(schema: &serde_json::Value) -> Vec<SchemaField> {
+    let Some(properties) = schema.get("properties").and_then(|value| value.as_object()) else {
+        return Vec::new();
+    };
+    let mut fields = properties
+        .iter()
+        .map(|(name, spec)| SchemaField {
+            name: name.clone(),
+            kind: schema_type_label(spec),
+        })
+        .collect::<Vec<_>>();
+    fields.sort_by(|a, b| a.name.cmp(&b.name));
+    fields
+}
+
+fn schema_required_fields(schema: &serde_json::Value) -> Vec<String> {
+    let mut required = schema
+        .get("required")
+        .and_then(|value| value.as_array())
+        .into_iter()
+        .flatten()
+        .filter_map(|value| value.as_str().map(str::to_string))
+        .collect::<Vec<_>>();
+    required.sort();
+    required
+}
+
+fn schema_type_label(spec: &serde_json::Value) -> String {
+    let Some(kind) = spec.get("type").and_then(|value| value.as_str()) else {
+        return "value".to_string();
+    };
+    if let Some(values) = spec.get("enum").and_then(|value| value.as_array()) {
+        let labels = values
+            .iter()
+            .filter_map(|value| value.as_str())
+            .collect::<Vec<_>>();
+        if !labels.is_empty() {
+            return format!("{kind} ({})", labels.join(" | "));
+        }
+    }
+    kind.to_string()
+}
+
+fn received_fields(input: &serde_json::Value) -> Vec<String> {
+    let mut fields = input
+        .as_object()
+        .into_iter()
+        .flat_map(|object| object.keys().cloned())
+        .collect::<Vec<_>>();
+    fields.sort();
+    fields
+}
+
+fn likely_field_corrections(
+    received: &[String],
+    expected: &[SchemaField],
+    tool_name: &str,
+) -> Vec<String> {
+    let has_expected = |name: &str| expected.iter().any(|field| field.name == name);
+    let has_received = |name: &str| received.iter().any(|field| field == name);
+    let mut corrections = Vec::new();
+
+    if has_received("old_string") && has_expected("search") {
+        corrections.push("old_string -> search".to_string());
+    }
+    if has_received("new_string") && has_expected("replace") {
+        corrections.push("new_string -> replace".to_string());
+    }
+    if has_received("replacement") && has_expected("replace") {
+        corrections.push("replacement -> replace".to_string());
+    }
+    if tool_name == "checklist_update" && has_received("todos") {
+        corrections.push(
+            "Use checklist_write to replace the full list, or retry checklist_update with id and status."
+                .to_string(),
+        );
+    }
+
+    corrections
 }
 
 pub(super) fn execute_tool_search(

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -1062,8 +1062,9 @@ impl Engine {
                     )));
                 }
 
-                if maybe_activate_requested_deferred_tool(
+                if let Some(result) = preflight_requested_deferred_tool(
                     &tool_name,
+                    &tool_input,
                     &tool_catalog,
                     &mut active_tool_names,
                 ) {
@@ -1073,6 +1074,7 @@ impl Engine {
                             "Auto-loaded deferred tool '{tool_name}' after model request."
                         )))
                         .await;
+                    guard_result = Some(result);
                 }
                 let mut tool_def = tool_catalog.iter().find(|def| def.name == tool_name);
 
@@ -1094,8 +1096,9 @@ impl Engine {
                         tool.name = tool_name.clone();
                         // Re-run the deferred-activation check with the
                         // canonical name.
-                        if maybe_activate_requested_deferred_tool(
+                        if let Some(result) = preflight_requested_deferred_tool(
                             &tool_name,
+                            &tool_input,
                             &tool_catalog,
                             &mut active_tool_names,
                         ) {
@@ -1106,6 +1109,7 @@ impl Engine {
                                     tool_name, tool_name
                                 )))
                                 .await;
+                            guard_result = Some(result);
                         }
                     }
                 }


### PR DESCRIPTION


## Summary

  Fixes the deferred tool first-call flow.

  Some tools, such as `edit_file` and `checklist_update`, are deferred until
  the model asks for them. Before this change, the runtime loaded the deferred
  tool and then continued executing the same call, even if the model had guessed
  the argument names before seeing the real schema.

  This change loads the deferred tool schema but does not execute that first
  call. Instead, it returns a synthetic tool result that tells the model to retry
  with the loaded schema, including expected fields, received fields, missing
  required fields, unexpected fields, and likely corrections.

  Examples covered:
  - `edit_file` guessed with `old_string` / `new_string`
  - `checklist_update` guessed with `todos`

Fixes: https://github.com/Hmbown/DeepSeek-TUI/issues/1419

## Testing

- [x] `cargo test --all-features`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
