### PR TITLE
fix: treat deepseek-chat / deepseek-reasoner aliases as reasoning models

### DIFF
--- a/crates/tui/src/client/chat.rs
+++ b/crates/tui/src/client/chat.rs
@@ -1506,7 +1506,16 @@ fn log_thinking_mode_violations(body: &Value) {
 
 fn requires_reasoning_content(model: &str) -> bool {
     let lower = model.to_lowercase();
+    // V4-family direct model IDs.
     lower.contains("deepseek-v4")
+        // Public DeepSeek API aliases routed server-side to the V4 family.
+        // `deepseek-chat` resolves to `deepseek-v4-flash` and `deepseek-reasoner`
+        // resolves to `deepseek-v4-pro`; both have thinking mode enabled by
+        // default, so any assistant message carrying tool_calls must replay
+        // `reasoning_content` on subsequent turns or the API returns 400.
+        || lower.starts_with("deepseek-chat")
+        || lower.starts_with("deepseek-reasoner")
+        // Generic reasoning markers used by custom/proxied deployments.
         || lower.contains("reasoner")
         || lower.contains("-reasoning")
         || lower.contains("-thinking")
@@ -2613,5 +2622,80 @@ mod stream_decoder_tests {
         assert!(tool_layers[1].sent_chars < 200);
         assert!(!tool_layers[1].truncated);
         assert!(tool_layers[1].deduplicated);
+    }
+}
+
+#[cfg(test)]
+mod alias_thinking_detection_tests {
+    //! Regression coverage for the DeepSeek public model aliases.
+    //!
+    //! `deepseek-chat` and `deepseek-reasoner` are the canonical alias names
+    //! published in DeepSeek's API docs. Server-side they resolve to V4-flash
+    //! and V4-pro respectively, both of which have thinking mode enabled by
+    //! default. If the TUI does not classify those aliases as reasoning
+    //! models, the sanitizer skips replaying `reasoning_content` on tool-call
+    //! assistant messages and DeepSeek returns a 400 ("the `reasoning_content`
+    //! in the thinking mode must be passed back to the API") on the second
+    //! turn. See upstream API docs:
+    //! https://api-docs.deepseek.com/guides/thinking_mode
+    use super::{requires_reasoning_content, should_replay_reasoning_content};
+
+    #[test]
+    fn aliases_routed_to_v4_require_reasoning_content() {
+        // Documented public aliases.
+        assert!(requires_reasoning_content("deepseek-chat"));
+        assert!(requires_reasoning_content("deepseek-reasoner"));
+        // Case-insensitive: users sometimes copy/paste with capitalisation.
+        assert!(requires_reasoning_content("DeepSeek-Chat"));
+        assert!(requires_reasoning_content("DEEPSEEK-REASONER"));
+    }
+
+    #[test]
+    fn explicit_v4_ids_still_require_reasoning_content() {
+        // Direct V4 IDs continue to match (regression guard for the existing
+        // `lower.contains("deepseek-v4")` branch).
+        assert!(requires_reasoning_content("deepseek-v4-flash"));
+        assert!(requires_reasoning_content("deepseek-v4-pro"));
+    }
+
+    #[test]
+    fn non_thinking_aliases_remain_excluded() {
+        // Legacy non-thinking IDs and unrelated provider models must not be
+        // misclassified, otherwise we would force a placeholder
+        // `reasoning_content` on providers that reject the field.
+        assert!(!requires_reasoning_content("deepseek-v3"));
+        assert!(!requires_reasoning_content("deepseek-coder"));
+        assert!(!requires_reasoning_content("gpt-4o"));
+        assert!(!requires_reasoning_content("claude-sonnet-4-6"));
+    }
+
+    #[test]
+    fn alias_prefix_handles_suffixed_variants() {
+        // OpenRouter / proxy deployments occasionally suffix the canonical
+        // alias (e.g. `deepseek-chat:free`). Those routes still hit V4
+        // server-side, so they must continue to require reasoning_content.
+        assert!(requires_reasoning_content("deepseek-chat:free"));
+        assert!(requires_reasoning_content("deepseek-reasoner-2025-05"));
+    }
+
+    #[test]
+    fn explicit_reasoning_off_overrides_alias_detection() {
+        // `reasoning_effort = "off"` is the documented escape hatch: even when
+        // the model is in the thinking family, the user can opt out and the
+        // sanitizer must respect that choice.
+        assert!(!should_replay_reasoning_content(
+            "deepseek-chat",
+            Some("off")
+        ));
+        assert!(!should_replay_reasoning_content(
+            "deepseek-reasoner",
+            Some("disabled")
+        ));
+        // Without an explicit override, alias models still trigger replay.
+        assert!(should_replay_reasoning_content("deepseek-chat", None));
+        assert!(should_replay_reasoning_content(
+            "deepseek-reasoner",
+            Some("medium")
+        ));
     }
 }


### PR DESCRIPTION
## Problem

Setting `default_text_model = "deepseek-chat"` (the value `deepseek auth` / onboarding writes) makes the TUI 400 on the **second turn** of any session that involves a tool call:

```
HTTP 400: The `reasoning_content` in the thinking mode must be passed back to the API.
```

(Some users also see this surface as `Authentication failed: Authentication Fails (governor)` when the rejected request is the streaming one.)

### Root cause

`requires_reasoning_content()` in `crates/tui/src/client/chat.rs` only matched literal `deepseek-v4*` model IDs:

```rust
fn requires_reasoning_content(model: &str) -> bool {
    let lower = model.to_lowercase();
    lower.contains("deepseek-v4")
        || lower.contains("reasoner")
        || lower.contains("-reasoning")
        || lower.contains("-thinking")
        || has_deepseek_r_series_marker(&lower)
}
```

But `deepseek-chat` and `deepseek-reasoner` are DeepSeek's **public API aliases** — server-side they resolve to `deepseek-v4-flash` and `deepseek-v4-pro` respectively, and the entire V4 family has thinking mode **enabled by default** ([API docs](https://api-docs.deepseek.com/guides/thinking_mode)). Because the alias names don't contain the substring `deepseek-v4`, `requires_reasoning_content("deepseek-chat")` returns `false`, so:

- `should_replay_reasoning_content()` → `false`
- `build_chat_messages_with_reasoning(..., include_reasoning = false, ...)` skips the placeholder
- `sanitize_thinking_mode_messages()` early-returns
- the tool-call assistant message goes out with no `reasoning_content` → DeepSeek 400

### Repro

1. Fresh `~/.deepseek/config.toml` with `default_text_model = "deepseek-chat"` (or just run `deepseek auth set --provider deepseek` and accept the default model).
2. `deepseek` in any directory.
3. Ask something that triggers one tool call (e.g. "list the files here").
4. Send a second message → 400.

`models` lists only `deepseek-v4-flash` / `deepseek-v4-pro`, so users who pick `deepseek-chat` from docs/onboarding are the affected population.

## Fix

Extend `requires_reasoning_content()` to recognise the `deepseek-chat` and `deepseek-reasoner` alias prefixes, so alias handling matches the explicit V4 IDs. `starts_with` (not `contains`) is used so unrelated names aren't swept in, while suffixed variants used by proxied deployments (`deepseek-chat:free`, `deepseek-reasoner-2025-05`, …) are still covered.

The `reasoning_effort = "off"` escape hatch is unaffected — it's checked in `should_replay_reasoning_content()`, which this PR doesn't touch.

## Tests

New `alias_thinking_detection_tests` module in `chat.rs`:

- aliases (`deepseek-chat`, `deepseek-reasoner`, case-insensitive) require reasoning_content
- explicit V4 IDs still match (regression guard for the existing branch)
- non-thinking IDs (`deepseek-v3`, `deepseek-coder`) and other providers (`gpt-4o`, `claude-sonnet-4-6`) stay excluded
- suffixed alias variants are covered
- `reasoning_effort = "off"` / `"disabled"` overrides alias detection

`cargo fmt --check` passes locally. (I don't have an MSVC toolchain on this machine, so I'm relying on CI for `cargo clippy` / `cargo test` — happy to iterate if anything's red.)

## Environment

- OS: Windows 11
- `deepseek --version`: 0.8.28
- `rustc --version`: 1.95.0