### PR TITLE
  Fix flaky workspace and env-sensitive tests

### DIFF
--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -5260,13 +5260,6 @@ mod setup_helper_tests {
     use std::collections::BTreeSet;
     use tempfile::TempDir;
 
-    // Serialize tests that mutate process-global env vars. Without this,
-    // `cargo test` runs them in parallel and they race on `DEEPSEEK_API_KEY`,
-    // causing intermittent CI failures (one test reads while another's set
-    // is still active). `unwrap_or_else` recovers from poisoning so a panic
-    // in one test doesn't cascade through the whole module.
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
     #[test]
     fn init_tools_dir_creates_readme_and_example() {
         let tmp = TempDir::new().unwrap();
@@ -5421,7 +5414,7 @@ mod setup_helper_tests {
 
     #[test]
     fn plain_launch_preserves_checkpoint_but_starts_fresh() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = crate::test_support::lock_test_env();
         let tmp = TempDir::new().unwrap();
         let workspace = tmp.path().join("workspace");
         std::fs::create_dir_all(&workspace).unwrap();
@@ -5457,7 +5450,7 @@ mod setup_helper_tests {
 
     #[test]
     fn continue_recovers_same_workspace_checkpoint() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = crate::test_support::lock_test_env();
         let tmp = TempDir::new().unwrap();
         let workspace = tmp.path().join("workspace");
         std::fs::create_dir_all(&workspace).unwrap();
@@ -5567,7 +5560,7 @@ mod setup_helper_tests {
 
     #[test]
     fn resolve_api_key_source_reports_env_when_set() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = crate::test_support::lock_test_env();
         let prev = std::env::var("DEEPSEEK_API_KEY").ok();
         let prev_source = std::env::var("DEEPSEEK_API_KEY_SOURCE").ok();
         unsafe {
@@ -5589,7 +5582,7 @@ mod setup_helper_tests {
 
     #[test]
     fn resolve_api_key_source_reports_dispatcher_keyring() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = crate::test_support::lock_test_env();
         let prev = std::env::var("DEEPSEEK_API_KEY").ok();
         let prev_source = std::env::var("DEEPSEEK_API_KEY_SOURCE").ok();
         unsafe {
@@ -5611,7 +5604,7 @@ mod setup_helper_tests {
 
     #[test]
     fn resolve_api_key_source_prefers_config_over_env() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = crate::test_support::lock_test_env();
         let prev = std::env::var("DEEPSEEK_API_KEY").ok();
         let prev_source = std::env::var("DEEPSEEK_API_KEY_SOURCE").ok();
         unsafe {

--- a/crates/tui/src/mcp.rs
+++ b/crates/tui/src/mcp.rs
@@ -2969,8 +2969,10 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let server = tokio::spawn(async move {
-            for _ in 0..6 {
-                let (mut socket, _) = listener.accept().await.unwrap();
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    break;
+                };
                 tokio::spawn(async move {
                     let request = read_http_request(&mut socket).await;
                     assert!(request.starts_with("POST /mcp "));

--- a/crates/tui/src/sandbox/seatbelt.rs
+++ b/crates/tui/src/sandbox/seatbelt.rs
@@ -365,12 +365,8 @@ pub fn detect_denial(exit_code: i32, stderr: &str) -> bool {
 mod tests {
     use super::*;
 
-    /// Serializes tests that mutate process-global env vars (HOME, CARGO_HOME)
-    /// so they don't race with each other or with sibling tests in this
-    /// crate that read those vars. Mirrors the pattern in main.rs::tests
-    /// (commit d06eaed0).
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
+    // Tests that mutate HOME/CARGO_HOME use crate::test_support::lock_test_env()
+    // so they don't race with sibling tests in this crate that read those vars.
     #[test]
     fn test_is_available() {
         // This test just checks the function doesn't panic
@@ -429,11 +425,11 @@ mod tests {
     /// sandbox-exec refuse to load the profile.
     #[test]
     fn test_cargo_home_paths_emitted_in_policy_and_params_when_home_set() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = crate::test_support::lock_test_env();
 
-        // SAFETY: HOME / CARGO_HOME are process-global. ENV_LOCK serializes
-        // all tests in this module that mutate them, and we always restore
-        // the prior value before returning.
+        // SAFETY: HOME / CARGO_HOME are process-global. lock_test_env
+        // serializes tests that mutate them, and we always restore the
+        // prior value before returning.
         let saved_home = std::env::var_os("HOME");
         let saved_cargo = std::env::var_os("CARGO_HOME");
         unsafe {
@@ -485,11 +481,11 @@ mod tests {
     /// would crash sandbox-exec on profile load.
     #[test]
     fn test_cargo_home_skipped_when_no_env() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = crate::test_support::lock_test_env();
 
         let saved_home = std::env::var_os("HOME");
         let saved_cargo = std::env::var_os("CARGO_HOME");
-        // SAFETY: HOME/CARGO_HOME are process-global; ENV_LOCK serializes
+        // SAFETY: HOME/CARGO_HOME are process-global; lock_test_env serializes
         // mutations here and we restore the prior values before returning.
         unsafe {
             std::env::remove_var("HOME");

--- a/crates/tui/src/session_manager.rs
+++ b/crates/tui/src/session_manager.rs
@@ -574,7 +574,7 @@ fn paths_equivalent(lhs: &Path, rhs: &Path) -> bool {
 fn find_git_root(path: &Path) -> Option<PathBuf> {
     let mut current = fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
     loop {
-        if current.join(".git").exists() {
+        if is_git_metadata_entry(&current.join(".git")) {
             return Some(current);
         }
         match current.parent() {
@@ -582,6 +582,16 @@ fn find_git_root(path: &Path) -> Option<PathBuf> {
             _ => return None,
         }
     }
+}
+
+fn is_git_metadata_entry(path: &Path) -> bool {
+    if path.is_dir() {
+        return path.join("HEAD").is_file();
+    }
+
+    fs::read_to_string(path)
+        .map(|content| content.trim_start().starts_with("gitdir:"))
+        .unwrap_or(false)
 }
 
 /// Resolve the default session directory path (`~/.deepseek/sessions`).
@@ -1067,6 +1077,31 @@ mod tests {
     }
 
     #[test]
+    fn latest_session_for_workspace_ignores_invalid_parent_git_marker() {
+        let tmp = tempdir().expect("tempdir");
+        let manager = SessionManager::new(tmp.path().join("sessions")).expect("new");
+        let workspace_a = tmp.path().join("aa").join("aaa");
+        let workspace_b = tmp.path().join("bb").join("bbb");
+        fs::create_dir_all(&workspace_a).expect("mkdir workspace a");
+        fs::create_dir_all(&workspace_b).expect("mkdir workspace b");
+        fs::create_dir_all(tmp.path().join(".git")).expect("mkdir invalid git marker");
+
+        write_session_record(
+            &manager,
+            "current-workspace",
+            &workspace_a,
+            Utc::now() - chrono::Duration::minutes(10),
+        );
+        write_session_record(&manager, "other-workspace", &workspace_b, Utc::now());
+
+        let scoped = manager
+            .get_latest_session_for_workspace(&workspace_a)
+            .expect("latest for workspace")
+            .expect("scoped latest");
+        assert_eq!(scoped.id, "current-workspace");
+    }
+
+    #[test]
     fn latest_session_for_workspace_matches_same_git_repository() {
         let tmp = tempdir().expect("tempdir");
         let manager = SessionManager::new(tmp.path().join("sessions")).expect("new");
@@ -1075,6 +1110,7 @@ mod tests {
         let repo_crate = repo.join("crates").join("server");
         let other_repo = tmp.path().join("other").join("project");
         fs::create_dir_all(repo.join(".git")).expect("mkdir .git");
+        fs::write(repo.join(".git").join("HEAD"), "ref: refs/heads/main\n").expect("write HEAD");
         fs::create_dir_all(&repo_app).expect("mkdir repo app");
         fs::create_dir_all(&repo_crate).expect("mkdir repo crate");
         fs::create_dir_all(&other_repo).expect("mkdir other repo");


### PR DESCRIPTION

## Summary

  Fixes several flaky test failures that can appear depending on the local test
  environment and parallel test timing.

  The main issue was in session workspace scoping. `find_git_root()` treated any
  parent `.git` path as a valid repository marker. If a stray or invalid `.git`
  directory exists above tempfile workspaces, such as `/tmp/.git`, unrelated
  temporary workspaces can be incorrectly treated as belonging to the same Git
  repository. This made `latest_session_for_workspace` return the newest session
  from the wrong workspace.

  This PR tightens Git root detection so:

  - `.git` directories must contain `HEAD`
  - `.git` files must use the `gitdir:` worktree format

  It also fixes two test isolation issues:

  - Env-mutating tests now share the crate-wide test env lock instead of using
    local locks that can race with sibling tests.
  - The streamable HTTP MCP test mock server now serves until the test ends,
    instead of stopping after a fixed number of accepted connections.


## Testing

- [x] `cargo test --all-features`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
