### PR TITLE
feat(skills): add opt-in v4-best-practices skill

### DIFF
--- a/crates/tui/assets/skills/v4-best-practices/SKILL.md
+++ b/crates/tui/assets/skills/v4-best-practices/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: v4-best-practices
+description: Use when working with deepseek-v4-pro or deepseek-v4-flash in thinking mode on multi-step or plan-driven tasks. Provides rules to prevent stale references, unverified plan assumptions, and vague plan output.
+---
+
+# V4 Best Practices
+
+Rules for multi-step V4 thinking-mode workflows. Each rule prevents a
+specific, observable failure class.
+
+## 1. Verify references before writing
+
+Before referencing a file path, function, or type in code or plan output,
+call `grep_files` or `read_file` to confirm it exists in the workspace.
+
+```
+# Bad:  edit_file path="src/config/loader.rs" (assumed from memory)
+# Good: grep_files pattern="pub fn load_config" → confirms src/config/mod.rs:42
+#        then reference src/config/mod.rs:42
+```
+
+Failure avoided: `edit_file` errors on non-existent paths; LSP diagnostics
+on hallucinated symbols.
+
+## 2. Spawn a verifier sub-agent before multi-file execution
+
+Before executing a plan that touches 3+ files, spawn a `deepseek-v4-flash`
+sub-agent (thinking off) to read the target files and confirm path/symbol
+assumptions still hold.
+
+```
+agent_spawn role="verifier" model="deepseek-v4-flash" thinking="off"
+  prompt: "Read these files and confirm: [list assumptions]. Report mismatches."
+```
+
+Failure avoided: multi-step edits fail partway because file structure
+changed since the plan was drafted.
+
+## 3. Plan output must use confirmed path:line references
+
+In plan-mode output, replace vague location pointers with `path:line`
+references drawn from a prior `grep_files` result.
+
+```
+# Bad:  "Update the retry logic in the client module"
+# Good: "Update retry loop at crates/tui/src/client.rs:187"
+```
+
+Failure avoided: agent-mode execution cannot locate the intended edit
+target when plan directions are imprecise.


### PR DESCRIPTION
## Summary

Adds a single opt-in community skill encoding three V4-specific workflow
rules for multi-step thinking-mode tasks. Each rule maps to a concrete,
observable failure class. Not enabled by default — loaded only when the
user opts in via the existing skills discovery mechanism.

## What this changes

- adds `crates/tui/assets/skills/v4-best-practices/SKILL.md` (one file, 50 lines)
- zero Rust changes, zero new dependencies, zero config schema changes
- not enabled by default; loaded only when users opt in via existing
  skills discovery

## What this is NOT

- not a benchmark-driven claim
- not a new module, dependency, or architectural change
- not a duplicate of AGENTS.md guidance — each rule was grep-checked
  against AGENTS.md before inclusion

## Testing

- placed file at `crates/tui/assets/skills/v4-best-practices/SKILL.md`
- ran `cargo build --release`; confirmed the skill appears in `/skills`
  output
- ran a sample plan-mode task with the skill active; confirmed skill
  content is injected per the existing bundled-skill mechanism

## Notes

Follows the existing bundled-skill convention
(`crates/tui/assets/skills/skill-creator/`). Diff is one new file;
fully reversible by deleting the directory.