### PR TITLE
fix: resolve three UI issues - underscore display, approval popup, th…

### DIFF
--- a/crates/tui/src/prompts/base.md
+++ b/crates/tui/src/prompts/base.md
@@ -1,5 +1,17 @@
 You are DeepSeek TUI. You're already running inside it — don't try to launch a `deepseek` or `deepseek-tui` binary.
 
+## 思考语言 (Reasoning Language)
+
+**重要：你的思考过程（reasoning_content / thinking tokens）必须与用户使用的语言保持一致。**
+
+当用户使用简体中文提问时，你必须用中文进行推理和思考——包括分析问题、拆解任务、评估方案、权衡利弊等所有内部推理环节。不要因为系统提示词是英文就切换到英文思维。请以中文母语者的语言习惯和逻辑方式来组织你的思考过程。
+
+具体规则：
+- 用户消息为中文 → 思考过程用中文
+- 用户消息为英文 → 思考过程用英文
+- 用户中途切换语言 → 跟随切换
+- 代码、路径、标识符、命令等保持原样，仅自然语言部分跟随用户语言
+
 ## Language
 
 Choose the natural language for each turn from the latest user message first — both for `reasoning_content` and for the final reply. If the latest user message is Simplified Chinese (简体中文), your `reasoning_content` and final reply must both be in Simplified Chinese, even when the `lang` field in `## Environment` is `en`. If the user switches languages mid-session, switch with them. Use the `lang` field only when the latest user message is missing, mostly code/logs, or otherwise ambiguous.

--- a/crates/tui/src/tui/approval.rs
+++ b/crates/tui/src/tui/approval.rs
@@ -504,6 +504,8 @@ pub struct ApprovalView {
     pending_confirm: Option<ApprovalOption>,
     timeout: Option<Duration>,
     requested_at: Instant,
+    /// Whether the approval card is collapsed to a single-line banner.
+    pub(crate) collapsed: bool,
 }
 
 impl ApprovalView {
@@ -520,6 +522,7 @@ impl ApprovalView {
             pending_confirm: None,
             timeout: None,
             requested_at: Instant::now(),
+            collapsed: false,
         }
     }
 
@@ -625,6 +628,10 @@ impl ModalView for ApprovalView {
 
     fn handle_key(&mut self, key: KeyEvent) -> ViewAction {
         match key.code {
+            KeyCode::Tab => {
+                self.collapsed = !self.collapsed;
+                ViewAction::None
+            }
             KeyCode::Up | KeyCode::Char('k') => {
                 self.select_prev();
                 ViewAction::None

--- a/crates/tui/src/tui/markdown_render.rs
+++ b/crates/tui/src/tui/markdown_render.rs
@@ -566,9 +566,15 @@ fn parse_inline_spans(line: &str, base_style: Style, link_style: Style) -> Vec<(
             && let Some(end) = rest[1..].find('*')
         {
             let inner = &rest[1..1 + end];
-            out.push((inner.to_string(), italic_style));
-            rest = &rest[1 + end + 1..];
-            continue;
+            let after = &rest[1 + end + 1..];
+            // Closing delimiter must not be immediately followed by a
+            // letter, digit, or underscore (otherwise it's part of an
+            // identifier like `deepseek_tui`, not italic markup).
+            if !after.starts_with(|c: char| c.is_alphanumeric() || c == '_') {
+                out.push((inner.to_string(), italic_style));
+                rest = after;
+                continue;
+            }
         }
         // _italic_
         if rest.starts_with('_')
@@ -576,9 +582,14 @@ fn parse_inline_spans(line: &str, base_style: Style, link_style: Style) -> Vec<(
             && let Some(end) = rest[1..].find('_')
         {
             let inner = &rest[1..1 + end];
-            out.push((inner.to_string(), italic_style));
-            rest = &rest[1 + end + 1..];
-            continue;
+            let after = &rest[1 + end + 1..];
+            // Closing delimiter must not be immediately followed by a
+            // letter, digit, or underscore.
+            if !after.starts_with(|c: char| c.is_alphanumeric() || c == '_') {
+                out.push((inner.to_string(), italic_style));
+                rest = after;
+                continue;
+            }
         }
         // `inline code`
         if let Some(end) = rest.strip_prefix('`').and_then(|s| s.find('`')) {

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -1010,6 +1010,28 @@ impl Renderable for ApprovalWidget<'_> {
             return;
         }
 
+        // Collapsed mode: a single-line banner at the bottom of the area
+        // so the user can still see the transcript behind it.
+        if self.view.collapsed {
+            let bar_y = area.y.saturating_add(area.height.saturating_sub(1));
+            let bar_area = Rect::new(area.x, bar_y, area.width, 1);
+            Clear.render(bar_area, buf);
+
+            let risk = self.request.risk;
+            let palette_colors = approval_palette(risk);
+            let summary = format!(
+                " {} — {}  [Tab to expand] ",
+                self.request.tool_name,
+                risk_badge_text(risk, self.view.locale()),
+            );
+            let line = Line::from(Span::styled(
+                summary,
+                Style::default().fg(palette::DEEPSEEK_INK).bg(palette_colors.accent).add_modifier(Modifier::BOLD),
+            ));
+            Paragraph::new(line).render(bar_area, buf);
+            return;
+        }
+
         let card_area = compute_takeover_area(area);
         Clear.render(card_area, buf);
 


### PR DESCRIPTION
…inking language

Problem 1: Underscore characters in identifiers like deepseek_tui were incorrectly consumed by the markdown inline parser's _italic_ handler. Added CommonMark boundary checks to both _italic_ and *italic* parsing in parse_inline_spans() so that closing delimiters immediately followed by a letter/digit/underscore are treated as literal text.

Problem 2: The approval modal rendered as a full-screen takeover that blocked the transcript behind it. Added a collapsible mode: press Tab to toggle between the full takeover card and a single-line banner at the bottom, so users can inspect the conversation while deciding.

Problem 3: The system prompt's language directive was written entirely in English, which biased the model toward English reasoning tokens. Added a Chinese-language preamble at the top of base.md explicitly instructing the model to use Chinese for reasoning_content when the user writes in Chinese.

## Summary

## Testing

- [ ] `cargo test --all-features`
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
