### PR TITLE
fix(edit_file): reject identical search and replace values

### DIFF
--- a/crates/tui/src/tools/file.rs
+++ b/crates/tui/src/tools/file.rs
@@ -331,6 +331,12 @@ impl ToolSpec for EditFileTool {
         let search = required_str(&input, "search")?;
         let replace = required_str(&input, "replace")?;
 
+        if search == replace {
+            return Err(ToolError::invalid_input(
+                "edit_file: search and replace are identical, no change intended",
+            ));
+        }
+
         let file_path = context.resolve_path(path_str)?;
 
         let contents = fs::read_to_string(&file_path).map_err(|e| {


### PR DESCRIPTION
## Summary

Adds a guard clause in `EditFileTool::execute` that rejects calls where `search == replace` with a clear error message.

## Why it matters

When `edit_file` is called with identical search and replace values, the tool currently returns `(no textual changes)` without error. Agents frequently copy the search value into the replace parameter and forget to mutate it, then retry with the same mistake, causing 3-4 serial failures before a successful edit. In one reported session, ~40% of edit_file calls required retries due to this issue.

The guard clause breaks the retry loop on the first attempt by returning an explicit error: `edit_file: search and replace are identical, no change intended`.

## Files changed

| File | Change |
|------|--------|
| `crates/tui/src/tools/file.rs` | +5 lines: guard clause after param parsing |

Fixes #1457.
