### PR TITLE
  fix: simplify approval confirmation flow

### DIFF
--- a/crates/tui/src/tui/approval.rs
+++ b/crates/tui/src/tui/approval.rs
@@ -16,10 +16,9 @@
 //!   `2` / `a` approves for the session.
 //! - **Destructive** (`RiskLevel::Destructive`) — file writes, shell,
 //!   patches, MCP actions, unclassified tools, and any "fetch arbitrary
-//!   content" surface. The first approve press *stages* a decision and
-//!   the second matching press commits — muscle-memory `Enter` cannot
-//!   accidentally land on an approval. Any non-approve key clears the
-//!   staging and keeps the user in selection mode.
+//!   content" surface. The takeover itself is the warning; once it is
+//!   visible, `Enter` commits the highlighted option and direct shortcut
+//!   keys (`y`/`a`/`d`/`Esc`) commit their matching option.
 //!
 //! The decision events emitted upstream are unchanged
 //! (`ViewEvent::ApprovalDecision`), so `ui.rs` and the engine handle
@@ -222,13 +221,12 @@ pub fn get_tool_category(name: &str) -> ToolCategory {
 /// The bias is conservative: a category we don't recognise routes to
 /// `Destructive`, and any shell command that `command_safety` flags as
 /// `Dangerous` is forced to `Destructive` even when the rest of the
-/// request looks calm. The split lets the modal swap muscle-memory
-/// approval for an explicit two-key confirmation on anything that can
-/// touch state outside this turn.
+/// request looks calm. The split lets the modal make risk visible without
+/// changing the core "select an option, then confirm once" interaction.
 #[must_use]
 pub fn classify_risk(tool_name: &str, category: ToolCategory, params: &Value) -> RiskLevel {
     match category {
-        // Read paths and discovery — never staged.
+        // Read paths and discovery stay in the calmer benign variant.
         ToolCategory::Safe | ToolCategory::McpRead => RiskLevel::Benign,
         // Query-only network is benign; opening a URL pulls arbitrary
         // remote content, so it stays destructive.
@@ -442,9 +440,7 @@ fn build_impact_summary_zh_hans(
     }
 }
 
-/// Indices into the option list shared by both variants. Visible to
-/// the widget module so it can render the staged-confirmation banner
-/// without re-deriving the variant from the request.
+/// Indices into the option list shared by both variants.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ApprovalOption {
     ApproveOnce,
@@ -480,16 +476,6 @@ impl ApprovalOption {
             ApprovalOption::Abort => ReviewDecision::Abort,
         }
     }
-
-    /// Whether this option needs an explicit second-key confirmation in
-    /// the destructive variant. Deny/Abort are never staged.
-    fn requires_confirm(self, risk: RiskLevel) -> bool {
-        matches!(risk, RiskLevel::Destructive)
-            && matches!(
-                self,
-                ApprovalOption::ApproveOnce | ApprovalOption::ApproveAlways
-            )
-    }
 }
 
 /// Approval overlay state managed by the modal view stack
@@ -498,10 +484,6 @@ pub struct ApprovalView {
     request: ApprovalRequest,
     selected: usize,
     locale: Locale,
-    /// When `Some`, the destructive variant has staged this approval and
-    /// is waiting for the user to press the same key (or `Enter`) again.
-    /// Any other key clears the staging.
-    pending_confirm: Option<ApprovalOption>,
     timeout: Option<Duration>,
     requested_at: Instant,
 }
@@ -517,7 +499,6 @@ impl ApprovalView {
             request,
             selected: 0,
             locale,
-            pending_confirm: None,
             timeout: None,
             requested_at: Instant::now(),
         }
@@ -525,22 +506,17 @@ impl ApprovalView {
 
     fn select_prev(&mut self) {
         self.selected = self.selected.saturating_sub(1);
-        // Moving the selection abandons any staged confirmation; the
-        // user is reconsidering.
-        self.pending_confirm = None;
     }
 
     fn select_next(&mut self) {
         self.selected = (self.selected + 1).min(ApprovalOption::ORDER.len() - 1);
-        self.pending_confirm = None;
     }
 
     fn current_option(&self) -> ApprovalOption {
         ApprovalOption::from_index(self.selected)
     }
 
-    /// Test-only accessor — the widget reads decisions through
-    /// `commit_or_stage` instead of polling.
+    /// Test-only accessor for the currently highlighted decision.
     #[cfg(test)]
     fn current_decision(&self) -> ReviewDecision {
         self.current_option().decision()
@@ -557,33 +533,15 @@ impl ApprovalView {
         self.request.risk
     }
 
-    /// The staged option, if any. `None` in the benign variant or when
-    /// no approve key has been pressed yet.
-    pub(crate) fn pending_confirm(&self) -> Option<ApprovalOption> {
-        self.pending_confirm
-    }
-
     pub(crate) fn locale(&self) -> Locale {
         self.locale
     }
 
-    /// Try to commit (or stage) the given option respecting the
-    /// variant's confirmation policy. Returns the action the modal
-    /// stack should apply.
-    fn commit_or_stage(&mut self, option: ApprovalOption) -> ViewAction {
-        if option.requires_confirm(self.request.risk) {
-            // Two-step destructive flow: first press stages, second
-            // press of the same option commits.
-            if self.pending_confirm == Some(option) {
-                self.pending_confirm = None;
-                return self.emit_decision(option.decision(), false);
-            }
-            self.pending_confirm = Some(option);
-            self.selected = option.index();
-            return ViewAction::None;
-        }
-        // Benign variant or non-approve options commit immediately.
-        self.pending_confirm = None;
+    /// Commit the given option. The approval modal itself is the warning;
+    /// once visible, Enter or a direct shortcut should perform exactly
+    /// the selected action.
+    fn commit_option(&mut self, option: ApprovalOption) -> ViewAction {
+        self.selected = option.index();
         self.emit_decision(option.decision(), false)
     }
 
@@ -633,31 +591,23 @@ impl ModalView for ApprovalView {
                 self.select_next();
                 ViewAction::None
             }
-            KeyCode::Enter => self.commit_or_stage(self.current_option()),
+            KeyCode::Enter => self.commit_option(self.current_option()),
             // Direct shortcuts; '1' / '2' map to the first two options
             // so a numeric pad still works for benign approve flows.
             KeyCode::Char('y') | KeyCode::Char('Y') | KeyCode::Char('1') => {
-                self.commit_or_stage(ApprovalOption::ApproveOnce)
+                self.commit_option(ApprovalOption::ApproveOnce)
             }
             KeyCode::Char('a') | KeyCode::Char('A') | KeyCode::Char('2') => {
-                self.commit_or_stage(ApprovalOption::ApproveAlways)
+                self.commit_option(ApprovalOption::ApproveAlways)
             }
             KeyCode::Char('n')
             | KeyCode::Char('N')
             | KeyCode::Char('d')
             | KeyCode::Char('D')
-            | KeyCode::Char('3') => self.commit_or_stage(ApprovalOption::Deny),
-            KeyCode::Char('v') | KeyCode::Char('V') => {
-                self.pending_confirm = None;
-                self.emit_params_pager()
-            }
+            | KeyCode::Char('3') => self.commit_option(ApprovalOption::Deny),
+            KeyCode::Char('v') | KeyCode::Char('V') => self.emit_params_pager(),
             KeyCode::Esc => self.emit_decision(ReviewDecision::Abort, false),
-            _ => {
-                // Any unrecognised key cancels a staged confirmation —
-                // the user is no longer aiming at "approve".
-                self.pending_confirm = None;
-                ViewAction::None
-            }
+            _ => ViewAction::None,
         }
     }
 
@@ -1016,13 +966,13 @@ mod tests {
 
     #[test]
     fn risk_query_only_network_is_benign_but_fetch_is_destructive() {
-        // web_search is read-only enough to skip the two-key dance.
+        // web_search is read-only enough to use the calmer benign variant.
         let cat = ToolCategory::Network;
         assert_eq!(
             classify_risk("web_search", cat, &json!({"q": "rust"})),
             RiskLevel::Benign
         );
-        // fetch_url pulls arbitrary remote content; never staged.
+        // fetch_url pulls arbitrary remote content, so it stays destructive.
         assert_eq!(
             classify_risk("fetch_url", cat, &json!({"url": "https://example.com"})),
             RiskLevel::Destructive
@@ -1149,7 +1099,6 @@ mod tests {
         let view = ApprovalView::new(benign_request());
         assert_eq!(view.selected, 0);
         assert!(view.timeout.is_none());
-        assert_eq!(view.pending_confirm(), None);
         assert_eq!(view.risk(), RiskLevel::Benign);
     }
 
@@ -1340,7 +1289,7 @@ mod tests {
     }
 
     // ========================================================================
-    // ApprovalView Tests — Destructive Variant (two-key confirm)
+    // ApprovalView Tests — Destructive Variant
     // ========================================================================
 
     #[test]
@@ -1350,16 +1299,10 @@ mod tests {
     }
 
     #[test]
-    fn destructive_y_first_press_stages_then_second_commits() {
+    fn destructive_y_first_press_approves_once() {
         for code in [KeyCode::Char('y'), KeyCode::Char('Y')] {
             let mut view = ApprovalView::new(destructive_request());
 
-            // First press stages — no decision emitted yet.
-            let action = view.handle_key(create_key_event(code));
-            assert!(matches!(action, ViewAction::None));
-            assert_eq!(view.pending_confirm(), Some(ApprovalOption::ApproveOnce));
-
-            // Second press of the same key commits.
             let action = view.handle_key(create_key_event(code));
             assert!(
                 matches!(
@@ -1375,15 +1318,10 @@ mod tests {
     }
 
     #[test]
-    fn destructive_enter_first_press_stages_then_second_commits() {
+    fn destructive_enter_approves_selected_option() {
         let mut view = ApprovalView::new(destructive_request());
 
-        // Selection starts at ApproveOnce — Enter stages.
-        let action = view.handle_key(create_key_event(KeyCode::Enter));
-        assert!(matches!(action, ViewAction::None));
-        assert_eq!(view.pending_confirm(), Some(ApprovalOption::ApproveOnce));
-
-        // Second Enter on the same selection commits.
+        // Selection starts at ApproveOnce, so Enter approves once.
         let action = view.handle_key(create_key_event(KeyCode::Enter));
         assert!(matches!(
             action,
@@ -1395,38 +1333,24 @@ mod tests {
     }
 
     #[test]
-    fn destructive_navigation_clears_staged_confirmation() {
+    fn destructive_navigation_then_enter_commits_highlighted_option() {
         let mut view = ApprovalView::new(destructive_request());
 
-        view.handle_key(create_key_event(KeyCode::Char('y')));
-        assert_eq!(view.pending_confirm(), Some(ApprovalOption::ApproveOnce));
-
-        // Moving the selection abandons the staging.
         view.handle_key(create_key_event(KeyCode::Down));
-        assert_eq!(view.pending_confirm(), None);
+        let action = view.handle_key(create_key_event(KeyCode::Enter));
+        assert!(matches!(
+            action,
+            ViewAction::EmitAndClose(ViewEvent::ApprovalDecision {
+                decision: ReviewDecision::ApprovedForSession,
+                ..
+            })
+        ));
     }
 
     #[test]
-    fn destructive_unrelated_key_clears_staged_confirmation() {
-        let mut view = ApprovalView::new(destructive_request());
-
-        view.handle_key(create_key_event(KeyCode::Char('y')));
-        assert_eq!(view.pending_confirm(), Some(ApprovalOption::ApproveOnce));
-
-        // A key with no mapped action clears the staging.
-        let action = view.handle_key(create_key_event(KeyCode::Char('q')));
-        assert!(matches!(action, ViewAction::None));
-        assert_eq!(view.pending_confirm(), None);
-    }
-
-    #[test]
-    fn destructive_a_first_press_stages_then_second_commits_session() {
+    fn destructive_a_first_press_approves_for_session() {
         for code in [KeyCode::Char('a'), KeyCode::Char('A')] {
             let mut view = ApprovalView::new(destructive_request());
-
-            let action = view.handle_key(create_key_event(code));
-            assert!(matches!(action, ViewAction::None));
-            assert_eq!(view.pending_confirm(), Some(ApprovalOption::ApproveAlways));
 
             let action = view.handle_key(create_key_event(code));
             assert!(
@@ -1443,23 +1367,15 @@ mod tests {
     }
 
     #[test]
-    fn destructive_y_then_a_does_not_commit_either() {
-        // Pressing 'y' then 'a' must NOT commit ApproveAlways — the
-        // second key is a different option, so it re-stages instead.
+    fn destructive_unrelated_key_keeps_modal_open() {
         let mut view = ApprovalView::new(destructive_request());
 
-        let action = view.handle_key(create_key_event(KeyCode::Char('y')));
+        let action = view.handle_key(create_key_event(KeyCode::Char('q')));
         assert!(matches!(action, ViewAction::None));
-        assert_eq!(view.pending_confirm(), Some(ApprovalOption::ApproveOnce));
-
-        let action = view.handle_key(create_key_event(KeyCode::Char('a')));
-        assert!(matches!(action, ViewAction::None));
-        assert_eq!(view.pending_confirm(), Some(ApprovalOption::ApproveAlways));
     }
 
     #[test]
-    fn destructive_deny_does_not_require_confirmation() {
-        // Deny / Abort skip the two-key dance — the user is bailing.
+    fn destructive_deny_commits_immediately() {
         for code in [
             KeyCode::Char('n'),
             KeyCode::Char('N'),
@@ -1484,9 +1400,6 @@ mod tests {
     #[test]
     fn destructive_esc_aborts_immediately() {
         let mut view = ApprovalView::new(destructive_request());
-        // Stage something first.
-        view.handle_key(create_key_event(KeyCode::Char('y')));
-        // Esc still aborts in one press.
         let action = view.handle_key(create_key_event(KeyCode::Esc));
         assert!(matches!(
             action,
@@ -1527,14 +1440,14 @@ mod tests {
         let joined = lines.join("\n");
         assert!(joined.contains("REVIEW"), "missing REVIEW badge:\n{joined}");
         assert!(
-            joined.contains("Single key approves"),
-            "benign hint missing:\n{joined}"
+            joined.contains("Enter selected option"),
+            "selection hint missing:\n{joined}"
         );
         assert!(joined.contains("read_file"));
     }
 
     #[test]
-    fn render_destructive_shows_warning_badge_and_two_step_hint() {
+    fn render_destructive_shows_warning_badge_and_one_step_hint() {
         let view = ApprovalView::new(destructive_request());
         let lines = render_lines(&view, 100, 40);
         let joined = lines.join("\n");
@@ -1543,31 +1456,15 @@ mod tests {
             "missing DESTRUCTIVE badge:\n{joined}"
         );
         assert!(
-            joined.contains("Two keys to approve"),
+            joined.contains("Enter selected option"),
             "destructive hint missing:\n{joined}"
         );
         assert!(joined.contains("write_file"));
     }
 
     #[test]
-    fn render_destructive_after_stage_shows_confirm_banner() {
-        let mut view = ApprovalView::new(destructive_request());
-        view.handle_key(create_key_event(KeyCode::Char('y')));
-        let lines = render_lines(&view, 100, 40);
-        let joined = lines.join("\n");
-        assert!(
-            joined.contains("Confirm destructive action"),
-            "confirm banner missing:\n{joined}"
-        );
-        assert!(
-            joined.contains("(staged)"),
-            "stage marker missing:\n{joined}"
-        );
-    }
-
-    #[test]
     fn render_destructive_zh_hans_localizes_security_copy() {
-        let mut view = ApprovalView::new_for_locale(destructive_request(), Locale::ZhHans);
+        let view = ApprovalView::new_for_locale(destructive_request(), Locale::ZhHans);
         let lines = render_lines(&view, 100, 40);
         let joined = compact_rendered_text(&lines);
         assert!(
@@ -1575,8 +1472,12 @@ mod tests {
             "missing zh risk badge:\n{joined}"
         );
         assert!(
-            joined.contains("两次按键确认"),
-            "missing zh two-step hint:\n{joined}"
+            joined.contains("选择："),
+            "missing zh selection hint:\n{joined}"
+        );
+        assert!(
+            joined.contains("Enter执行选中项，或直接按y/a/d"),
+            "missing zh direct selection hint:\n{joined}"
         );
         assert!(
             joined.contains("文件写入"),
@@ -1593,22 +1494,6 @@ mod tests {
         assert!(
             joined.contains("仅本次批准"),
             "missing zh approve option:\n{joined}"
-        );
-
-        view.handle_key(create_key_event(KeyCode::Char('y')));
-        let lines = render_lines(&view, 100, 40);
-        let joined = compact_rendered_text(&lines);
-        assert!(
-            joined.contains("确认破坏性操作"),
-            "missing zh confirm banner:\n{joined}"
-        );
-        assert!(
-            joined.contains("(待确认)"),
-            "missing zh staged marker:\n{joined}"
-        );
-        assert!(
-            joined.contains("Enter或y"),
-            "missing zh confirm key:\n{joined}"
         );
     }
 

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -969,13 +969,11 @@ impl Renderable for ComposerWidget<'_> {
 
 /// Codex-style full-screen approval takeover (#129).
 ///
-/// The widget reads its mutable state (selected option, staged
-/// confirmation) directly from the [`ApprovalView`] so the destructive
-/// variant can render its "Press Y again to confirm" banner without
-/// touching internal fields. Rendering reflows to fill most of the
-/// transcript area instead of a centered popup; on small terminals it
-/// falls back to a 65×22 card so existing snapshot tests still see a
-/// coherent layout.
+/// The widget reads its mutable state (selected option and locale)
+/// directly from the [`ApprovalView`]. Rendering reflows to fill most
+/// of the transcript area instead of a centered popup; on small
+/// terminals it falls back to a 65×22 card so existing snapshot tests
+/// still see a coherent layout.
 pub struct ApprovalWidget<'a> {
     request: &'a ApprovalRequest,
     view: &'a ApprovalView,
@@ -1093,120 +1091,49 @@ impl Renderable for ApprovalWidget<'_> {
         lines.push(Line::from(""));
 
         let options = approval_options_for(risk, locale);
-        let pending = self.view.pending_confirm();
 
         for (i, opt) in options.iter().enumerate() {
             let is_selected = i == self.view.selected();
-            let staged = pending.is_some_and(|p| p == opt.option);
             let label_color = if opt.dangerous {
                 palette_colors.accent
             } else {
                 palette::TEXT_BODY
             };
 
-            let row_style = if is_selected {
-                Style::default()
-                    .fg(palette::SELECTION_TEXT)
-                    .bg(palette::SELECTION_BG)
-            } else {
-                Style::default()
-            };
+            let option_style = approval_option_style(is_selected, label_color);
+            let shortcut_style = approval_option_style(is_selected, palette_colors.shortcut);
 
-            let mut spans = vec![
+            lines.push(Line::from(vec![
                 Span::raw("  "),
                 Span::styled(
                     format!("[{}] ", opt.key_hint),
-                    Style::default()
-                        .fg(palette_colors.shortcut)
-                        .add_modifier(Modifier::BOLD),
+                    shortcut_style.add_modifier(Modifier::BOLD),
                 ),
-                Span::styled(opt.label.to_string(), row_style.fg(label_color)),
-            ];
-            if staged {
-                spans.push(Span::raw("  "));
-                spans.push(Span::styled(
-                    staged_marker(locale),
-                    Style::default()
-                        .fg(palette_colors.accent)
-                        .add_modifier(Modifier::BOLD),
-                ));
-            }
-            lines.push(Line::from(spans));
+                Span::styled(opt.label.to_string(), option_style),
+            ]));
         }
 
-        // Variant-specific footer: benign nudges single-key approve;
-        // destructive shows either the standing prompt or the
-        // confirmation banner when an approve key has been staged.
+        // The takeover itself is the confirmation prompt. Enter commits
+        // the highlighted row; direct shortcuts commit their matching
+        // option immediately.
         lines.push(Line::from(""));
-        match (risk, pending) {
-            (RiskLevel::Benign, _) => {
-                lines.push(Line::from(vec![
-                    Span::raw("  "),
-                    Span::styled(
-                        single_key_prefix(locale),
-                        Style::default().fg(palette::TEXT_HINT),
-                    ),
-                    Span::styled(
-                        single_key_value(locale),
-                        Style::default()
-                            .fg(palette_colors.accent)
-                            .add_modifier(Modifier::BOLD),
-                    ),
-                    Span::styled(
-                        footer_controls(locale),
-                        Style::default().fg(palette::TEXT_HINT),
-                    ),
-                ]));
-            }
-            (RiskLevel::Destructive, Some(opt)) => {
-                let again_key = match opt {
-                    crate::tui::approval::ApprovalOption::ApproveOnce => confirm_key_once(locale),
-                    crate::tui::approval::ApprovalOption::ApproveAlways => {
-                        confirm_key_always(locale)
-                    }
-                    _ => "Enter",
-                };
-                lines.push(Line::from(vec![
-                    Span::raw("  "),
-                    Span::styled(
-                        destructive_confirm_prefix(locale),
-                        Style::default()
-                            .fg(palette_colors.accent)
-                            .add_modifier(Modifier::BOLD),
-                    ),
-                    Span::styled(
-                        again_key.to_string(),
-                        Style::default()
-                            .fg(palette::DEEPSEEK_INK)
-                            .bg(palette_colors.accent)
-                            .add_modifier(Modifier::BOLD),
-                    ),
-                    Span::styled(
-                        destructive_confirm_suffix(locale),
-                        Style::default().fg(palette::TEXT_HINT),
-                    ),
-                ]));
-            }
-            (RiskLevel::Destructive, None) => {
-                lines.push(Line::from(vec![
-                    Span::raw("  "),
-                    Span::styled(
-                        two_key_prefix(locale),
-                        Style::default().fg(palette::TEXT_HINT),
-                    ),
-                    Span::styled(
-                        two_key_value(locale),
-                        Style::default()
-                            .fg(palette_colors.accent)
-                            .add_modifier(Modifier::BOLD),
-                    ),
-                    Span::styled(
-                        footer_controls(locale),
-                        Style::default().fg(palette::TEXT_HINT),
-                    ),
-                ]));
-            }
-        }
+        lines.push(Line::from(vec![
+            Span::raw("  "),
+            Span::styled(
+                selection_hint_prefix(locale),
+                Style::default().fg(palette::TEXT_HINT),
+            ),
+            Span::styled(
+                selection_hint_value(locale),
+                Style::default()
+                    .fg(palette_colors.accent)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                footer_controls(locale),
+                Style::default().fg(palette::TEXT_HINT),
+            ),
+        ]));
 
         let title = format!(
             " {} {} — {} ",
@@ -1304,6 +1231,21 @@ fn approval_palette(risk: RiskLevel) -> ApprovalColors {
     }
 }
 
+fn approval_selected_style() -> Style {
+    Style::default()
+        .fg(palette::SELECTION_TEXT)
+        .bg(palette::DEEPSEEK_BLUE)
+        .add_modifier(Modifier::BOLD)
+}
+
+fn approval_option_style(is_selected: bool, color: Color) -> Style {
+    if is_selected {
+        approval_selected_style()
+    } else {
+        Style::default().fg(color)
+    }
+}
+
 fn risk_badge_text(risk: RiskLevel, locale: Locale) -> &'static str {
     match (locale, risk) {
         (Locale::ZhHans, RiskLevel::Benign) => "审查",
@@ -1367,22 +1309,18 @@ fn label_params(locale: Locale) -> &'static str {
     }
 }
 
-fn staged_marker(locale: Locale) -> &'static str {
+fn selection_hint_prefix(locale: Locale) -> &'static str {
     match locale {
-        Locale::ZhHans => "(待确认)",
-        _ => "(staged)",
+        Locale::ZhHans => "选择：",
+        _ => "Choose: ",
     }
 }
 
-fn single_key_prefix(locale: Locale) -> &'static str {
+fn selection_hint_value(locale: Locale) -> &'static str {
     match locale {
-        Locale::ZhHans => "单键批准：",
-        _ => "Single key approves: ",
+        Locale::ZhHans => "Enter 执行选中项，或直接按 y/a/d",
+        _ => "Enter selected option, or press y/a/d directly",
     }
-}
-
-fn single_key_value(_locale: Locale) -> &'static str {
-    "Enter / 1 / y"
 }
 
 fn footer_controls(locale: Locale) -> &'static str {
@@ -1392,79 +1330,31 @@ fn footer_controls(locale: Locale) -> &'static str {
     }
 }
 
-fn destructive_confirm_prefix(locale: Locale) -> &'static str {
-    match locale {
-        Locale::ZhHans => "确认破坏性操作：再次按 ",
-        _ => "Confirm destructive action — press ",
-    }
-}
-
-fn destructive_confirm_suffix(locale: Locale) -> &'static str {
-    match locale {
-        Locale::ZhHans => " 执行；按其他键取消。",
-        _ => " again to commit, anything else cancels.",
-    }
-}
-
-fn confirm_key_once(locale: Locale) -> &'static str {
-    match locale {
-        Locale::ZhHans => "Enter 或 y",
-        _ => "Enter or y",
-    }
-}
-
-fn confirm_key_always(locale: Locale) -> &'static str {
-    match locale {
-        Locale::ZhHans => "Enter 或 a",
-        _ => "Enter or a",
-    }
-}
-
-fn two_key_prefix(locale: Locale) -> &'static str {
-    match locale {
-        Locale::ZhHans => "两次按键确认：",
-        _ => "Two keys to approve: ",
-    }
-}
-
-fn two_key_value(locale: Locale) -> &'static str {
-    match locale {
-        Locale::ZhHans => "先按 y/a，再按一次 y/a",
-        _ => "y/a then y/a again",
-    }
-}
-
 struct ApprovalOptionRow {
-    option: crate::tui::approval::ApprovalOption,
     label: &'static str,
     key_hint: &'static str,
     dangerous: bool,
 }
 
 fn approval_options_for(risk: RiskLevel, locale: Locale) -> [ApprovalOptionRow; 4] {
-    use crate::tui::approval::ApprovalOption as O;
     let dangerous = matches!(risk, RiskLevel::Destructive);
     [
         ApprovalOptionRow {
-            option: O::ApproveOnce,
             label: option_approve_once(locale),
             key_hint: "1 / y",
             dangerous,
         },
         ApprovalOptionRow {
-            option: O::ApproveAlways,
             label: option_approve_always(locale),
             key_hint: "2 / a",
             dangerous,
         },
         ApprovalOptionRow {
-            option: O::Deny,
             label: option_deny(locale),
             key_hint: "3 / d / n",
             dangerous: false,
         },
         ApprovalOptionRow {
-            option: O::Abort,
             label: option_abort(locale),
             key_hint: "Esc",
             dangerous: false,
@@ -3000,6 +2890,54 @@ mod tests {
             let mut buf = Buffer::empty(area);
             widget.render(area, &mut buf);
         }
+    }
+
+    #[test]
+    fn approval_selected_destructive_option_uses_contrasting_highlight() {
+        let request = crate::tui::approval::ApprovalRequest::new(
+            "approval-1",
+            "task_shell_start",
+            "Run unclassified tool",
+            &serde_json::json!({}),
+            "task_shell_start",
+        );
+        let view =
+            crate::tui::approval::ApprovalView::new_for_locale(request.clone(), Locale::ZhHans);
+        let widget = ApprovalWidget::new(&request, &view);
+        let area = Rect::new(0, 0, 80, 24);
+        let mut buf = Buffer::empty(area);
+
+        widget.render(area, &mut buf);
+
+        let selected_row = (0..area.height)
+            .find(|&y| {
+                let row = (0..area.width)
+                    .map(|x| buf[(x, y)].symbol())
+                    .collect::<String>();
+                row.contains("仅")
+            })
+            .expect("selected approval row should render");
+
+        let mut highlighted_cells = 0usize;
+        for x in 0..area.width {
+            let cell = &buf[(x, selected_row)];
+            if cell.symbol().trim().is_empty() {
+                continue;
+            }
+            if cell.bg == palette::DEEPSEEK_BLUE {
+                assert_eq!(
+                    cell.fg,
+                    palette::SELECTION_TEXT,
+                    "selected option highlight should use white foreground"
+                );
+                highlighted_cells += 1;
+            }
+        }
+
+        assert!(
+            highlighted_cells >= 4,
+            "selected row should have a visible blue/white highlight"
+        );
     }
 
     /// Regression for issue #65: after `App::handle_resize`, the chat widget


### PR DESCRIPTION

## Summary

  This simplifies the approval prompt interaction and improves selected-row visibility.

 Previously, destructive approval prompts required a two-step flow: press `y` / `a` / `Enter` once to stage the action, then press again to confirm. That made approval feel heavier than necessary because the user had already passed through multiple explicit signals:

  1. The blocking approval modal is the first warning.
  2. The highlighted selection is the second indication of the chosen action.
  3. Pressing `Enter` or a direct shortcut is the final confirmation.

 This is also closer to the interaction model used by other coding agents: once an approval modal is shown, users can move the highlighted choice and confirm it once, or press the corresponding shortcut directly. Keeping the flow consistent with that pattern makes the prompt easier to understand and less repetitive during normal coding sessions.

  The new flow is:

  - Up/Down selects an option, then one `Enter` confirms the highlighted choice.
  - `y` / `1` approves once directly.
  - `a` / `2` approves the same kind for the session directly.
  - `d` / `n` / `3` denies directly.
  - `Esc` aborts the turn.

  The selected approval row now also uses a clearer blue/white highlight so users can see the active choice more reliably,
  especially for destructive prompts where red risk coloring previously competed with the selection state.

<img width="838" height="405" alt="image" src="https://github.com/user-attachments/assets/0bd42a85-11c4-4101-919c-6ed32cb822a9" />


  Closes #1257.

## Testing

- [ ] `cargo test --all-features`
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
