### PR TITLE
fix(render): replace SMP emoji with stable BMP glyphs to fix layout on Windows terminals

### DIFF
--- a/crates/tui/src/tui/file_tree.rs
+++ b/crates/tui/src/tui/file_tree.rs
@@ -333,14 +333,12 @@ pub fn render_file_tree(
             } else {
                 "  "
             };
-            let icon = if entry.is_dir {
-                "\u{1F4C1} "
-            } else {
-                "\u{1F4C4} "
-            }; // 📁 / 📄
+            // No separate icon: the ▼/▶ expand marker already signals dirs,
+            // and SMP emoji (📁/📄, U+1F4C1/U+1F4C4) render at inconsistent
+            // column widths across terminals, breaking layout. See issue #1314.
 
             // Build the display text.
-            let raw = format!("{indent}{expand_marker}{icon}{}", entry.name);
+            let raw = format!("{indent}{expand_marker}{}", entry.name);
             let display = truncate_line_to_width(&raw, content_width.max(1));
 
             let style = if is_selected {

--- a/crates/tui/src/tui/widgets/header.rs
+++ b/crates/tui/src/tui/widgets/header.rs
@@ -250,7 +250,10 @@ impl<'a> HeaderWidget<'a> {
         let body = if !include_prefix {
             trimmed.to_string()
         } else if trimmed.eq_ignore_ascii_case("max") || trimmed.eq_ignore_ascii_case("maximum") {
-            format!("\u{1F433} {trimmed}")
+            // Use a non-emoji diamond (U+25C6, always 1 column) instead of an
+            // SMP emoji whose rendered width is inconsistent across terminals
+            // (cmd/PowerShell, WezTerm, Alacritty). See issue #1314.
+            format!("\u{25C6} {trimmed}")
         } else {
             format!("\u{00B7} {trimmed}")
         };


### PR DESCRIPTION
## What changed

- `crates/tui/src/tui/widgets/header.rs`: Replace `\u{1F433}` (🐳 whale, U+1F433) in the
  reasoning-effort "max" chip with `\u{25C6}` (◆ BLACK DIAMOND, U+25C6). The diamond is a BMP
  Geometric Shapes character whose column width (1) is consistent across all terminals.
- `crates/tui/src/tui/file_tree.rs`: Remove the folder (📁, U+1F4C1) and file (📄, U+1F4C4) emoji
  icons from the file tree entry prefix. The ▼/▶ expand markers already distinguish directories
  from files, so the emoji are purely decorative — and their inconsistent widths are the source of
  the misalignment.

## Why

SMP emoji (U+1F000+) have no stable column-width contract across terminal emulators:

- **cmd.exe / PowerShell**: emoji render as 1-column placeholder boxes even though
  `unicode_width` reports 2. The header's right-side layout arithmetic
  (`span_width` → `spacer_width`) therefore computes 1 column too wide, causing a
  shift in the header bar.
- **WezTerm / Alacritty**: font-dependent emoji rendering (Noto Color Emoji, Segoe UI Emoji,
  etc.) can differ from the `unicode_width` value by one column, producing the same
  layout artifact.

Replacing every SMP emoji in the production render paths with BMP symbols eliminates the
ambiguity at its source.

## How to verify

```
# Build and run the TUI on Windows (cmd/PowerShell) or in WezTerm/Alacritty:
cargo run

# Confirm:
# 1. Header bar shows "◆ max" (not a box/garbled character) when reasoning effort is max
# 2. File tree shows "▼  src/" / "▶  lib/" / "  README.md" (no broken emoji prefix)
# 3. Header right-side content is aligned (not overflowing or truncated by 1 col)
```

## Impact scope

- **Changed**: `header.rs` effort chip glyph (cosmetic), `file_tree.rs` entry prefix (cosmetic)
- **Not affected**: all state management, API calls, config, session handling, key bindings

Fixes #1314

---
*AI-assisted: diff reviewed and verified locally before submission.*