### PR TITLE
fix(shell): kill process group before joining reader threads to prevent UI freeze on orphaned subprocesses (#828)

### DIFF
--- a/crates/tui/src/tools/shell.rs
+++ b/crates/tui/src/tools/shell.rs
@@ -329,6 +329,15 @@ impl BackgroundShell {
 
     /// Collect output from the background threads
     fn collect_output(&mut self) {
+        // Kill the whole process group before joining reader threads.
+        // When the shell spawned persistent background jobs (e.g. `nohup curl`),
+        // those subprocesses keep the pipe write-ends open after the shell exits.
+        // Without this kill, handle.join() blocks indefinitely, freezing the UI
+        // event loop that calls list_jobs() → poll() → collect_output().
+        #[cfg(unix)]
+        if let Some(ShellChild::Process(ref mut proc)) = self.child {
+            let _ = kill_child_process_group(proc);
+        }
         if let Some(handle) = self.stdout_thread.take() {
             let _ = handle.join();
         }
@@ -1299,6 +1308,8 @@ impl ShellManager {
         for shell in self.processes.values_mut() {
             shell.poll();
         }
+        // Evict completed processes older than 1 hour to bound memory growth.
+        self.cleanup(Duration::from_secs(3600));
 
         let mut jobs = self
             .processes
@@ -1346,7 +1357,6 @@ impl ShellManager {
     }
 
     /// Clean up completed processes older than the given duration
-    #[allow(dead_code)]
     pub fn cleanup(&mut self, max_age: Duration) {
         let _now = Instant::now();
         self.processes.retain(|_, shell| {

--- a/crates/tui/src/tools/shell/tests.rs
+++ b/crates/tui/src/tools/shell/tests.rs
@@ -689,3 +689,49 @@ async fn test_exec_shell_cancel_tool_can_kill_all_running_processes() {
     assert_eq!(first_job.snapshot.status, ShellStatus::Killed);
     assert_eq!(second_job.snapshot.status, ShellStatus::Killed);
 }
+
+// Regression test for #828: shell spawns an orphaned background subprocess
+// (simulating `nohup curl`) that keeps the pipe write-end open after the shell
+// exits. collect_output() must not block indefinitely — it kills the whole
+// process group first, allowing reader threads to get EOF and exit.
+#[cfg(unix)]
+#[test]
+fn test_orphaned_subprocess_does_not_block_collect_output() {
+    let tmp = tempdir().expect("tempdir");
+    let mut manager = ShellManager::new(tmp.path().to_path_buf());
+
+    // sh spawns `sleep 100 &` and exits; the sleep subprocess inherits the
+    // pipe write-ends and would keep reader threads blocked without the fix.
+    let result = manager
+        .execute("sh -c 'sleep 100 &'", None, 5000, true)
+        .expect("execute");
+    let task_id = result.task_id.expect("task id");
+
+    // Drive to completion with a tight timeout — must not hang.
+    let done = manager
+        .get_output(&task_id, true, 3000)
+        .expect("get_output must complete, not hang");
+    assert_eq!(done.status, ShellStatus::Completed);
+}
+
+#[test]
+fn test_list_jobs_cleans_up_completed_old_processes() {
+    let tmp = tempdir().expect("tempdir");
+    let mut manager = ShellManager::new(tmp.path().to_path_buf());
+
+    let bg = manager
+        .execute(&echo_command("bg"), None, 5000, true)
+        .expect("execute bg");
+    let bg_id = bg.task_id.expect("bg task id");
+    manager.get_output(&bg_id, true, 3000).expect("bg done");
+
+    // Both the completed job and any tracking state should be present.
+    assert!(!manager.processes.is_empty());
+
+    // cleanup(ZERO) removes all completed processes immediately.
+    manager.cleanup(Duration::ZERO);
+    assert!(
+        manager.processes.is_empty(),
+        "completed processes should be evicted by cleanup"
+    );
+}


### PR DESCRIPTION
## Problem

When a shell command spawns background subprocesses (e.g. `nohup curl …`, `sleep 100 &`, long-running daemons), those subprocesses inherit the pipe write-ends from the shell. After the shell exits, the subprocesses remain alive and keep those write-ends open. `collect_output()` then calls `handle.join()` on the reader threads — but those threads are blocked in `read()` waiting for EOF that never comes because the orphaned subprocesses still hold the write-end open.

`list_jobs()` calls `poll()` → `collect_output()` on every TUI render tick, so the entire UI event loop blocks indefinitely.

A second latent issue: `ShellManager::cleanup()` was annotated `#[allow(dead_code)]` and never called, causing the `processes` `HashMap` to grow without bound over a long session.

## Fix

**`collect_output()` — kill the process group before joining reader threads**

Each child shell is already spawned with `cmd.process_group(0)` (PGID = child PID), so `kill(-pgid, SIGKILL)` targets only the child's process group, not the TUI's own process group. The existing `kill_child_process_group()` helper already handles `ESRCH` gracefully (child already gone). This is gated `#[cfg(unix)]` and only applies to `ShellChild::Process` (not PTY paths).

```rust
#[cfg(unix)]
if let Some(ShellChild::Process(ref mut proc)) = self.child {
    let _ = kill_child_process_group(proc);
}
```

**`list_jobs()` — evict completed processes after 1 hour**

```rust
self.cleanup(Duration::from_secs(3600));
```

Removes the `#[allow(dead_code)]` annotation from `cleanup()` and wires it into `list_jobs()` so completed job state is bounded.

## Tests

Two new regression tests in `crates/tui/src/tools/shell/tests.rs`:

- `test_orphaned_subprocess_does_not_block_collect_output` — spawns `sh -c 'sleep 100 &'`, drives to completion with a 3 s timeout; would hang indefinitely without the fix.
- `test_list_jobs_cleans_up_completed_old_processes` — verifies `cleanup(Duration::ZERO)` evicts all completed entries.

All 20+ pre-existing shell tests pass. The 3 pre-existing failing tests (`no_animations_env_recognises_truthy_spellings_only`, `plain_launch_preserves_checkpoint_but_starts_fresh`, `thinking_delta_emits_agent_reasoning_item`) are unrelated to this change and were already failing on upstream `main`.

Fixes #828.

Signed-off-by: lingxufeng <anjun.lyu@gmail.com>