### PR TITLE
Direction-Check Reasoning — Hmbown/DeepSeek-TUI#1441

### DIFF
--- a/crates/tui/src/child_env.rs
+++ b/crates/tui/src/child_env.rs
@@ -223,12 +223,7 @@ fn normalize_key(key: &OsStr) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Mutex, OnceLock};
-
-    fn env_lock() -> &'static Mutex<()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-    }
+    use crate::test_support::lock_test_env;
 
     #[test]
     fn mcp_env_allowlist_inherits_base_keys() {
@@ -356,7 +351,7 @@ mod tests {
 
     #[test]
     fn sanitized_mcp_env_passes_through_node_bootstrap() {
-        let _guard = env_lock().lock().expect("env lock");
+        let _guard = lock_test_env();
         let prev = std::env::var_os("NVM_DIR");
         unsafe {
             std::env::set_var("NVM_DIR", "/tmp/test-nvm");
@@ -378,7 +373,7 @@ mod tests {
 
     #[test]
     fn sanitized_mcp_env_drops_unrelated_secret_like_values() {
-        let _guard = env_lock().lock().expect("env lock");
+        let _guard = lock_test_env();
         let prev = std::env::var_os("DEEPSEEK_MCP_TEST_SECRET");
         unsafe {
             std::env::set_var("DEEPSEEK_MCP_TEST_SECRET", "should-not-leak");
@@ -403,7 +398,7 @@ mod tests {
 
     #[test]
     fn sanitized_child_env_drops_parent_secret_like_values() {
-        let _guard = env_lock().lock().expect("env lock");
+        let _guard = lock_test_env();
         let previous = std::env::var_os("DEEPSEEK_CHILD_ENV_TEST_SECRET");
         unsafe {
             std::env::set_var("DEEPSEEK_CHILD_ENV_TEST_SECRET", "parent-secret");
@@ -428,7 +423,7 @@ mod tests {
 
     #[test]
     fn explicit_child_env_values_win_over_parent_allowlist() {
-        let _guard = env_lock().lock().expect("env lock");
+        let _guard = lock_test_env();
         let previous = std::env::var_os("PATH");
         unsafe {
             std::env::set_var("PATH", "/parent/bin");

--- a/crates/tui/src/utils.rs
+++ b/crates/tui/src/utils.rs
@@ -764,3 +764,58 @@ mod project_mapping_tests {
         assert_eq!(suffix, "Makefile, README.md");
     }
 }
+
+#[cfg(test)]
+mod truncate_tests {
+    use super::truncate_with_ellipsis;
+
+    #[test]
+    fn ascii_short_string_is_returned_unchanged() {
+        assert_eq!(truncate_with_ellipsis("hello", 10, "..."), "hello");
+    }
+
+    #[test]
+    fn ascii_string_at_exact_limit_is_returned_unchanged() {
+        assert_eq!(truncate_with_ellipsis("hello", 5, "..."), "hello");
+    }
+
+    #[test]
+    fn ascii_string_over_limit_is_truncated_with_ellipsis() {
+        assert_eq!(truncate_with_ellipsis("hello world", 8, "..."), "hello...");
+    }
+
+    #[test]
+    fn cjk_string_truncates_on_char_boundary_not_byte_boundary() {
+        // "你好世界" is 4 chars × 3 bytes each = 12 bytes.
+        // With max_len=8 and ellipsis="..." (3 bytes), budget=5 bytes.
+        // Byte index of '好' is 3 (≤ 5), byte index of '世' is 6 (> 5), so
+        // exactly one CJK char fits: result is "你...".
+        assert_eq!(truncate_with_ellipsis("你好世界", 8, "..."), "你...");
+    }
+
+    #[test]
+    fn cjk_string_shorter_than_limit_is_returned_unchanged() {
+        assert_eq!(truncate_with_ellipsis("你好", 10, "..."), "你好");
+    }
+
+    #[test]
+    fn mixed_ascii_cjk_truncates_on_char_boundary() {
+        // "hi你好" = 2 + 6 = 8 bytes; max_len=6, ellipsis="…" (3 bytes), budget=3.
+        // Byte indices of chars: h=0, i=1, 你=2, 好=5.
+        // take_while(i <= 3): 0, 1, 2 → last=2, so "hi" + "…"
+        let result = truncate_with_ellipsis("hi你好", 6, "…");
+        assert!(result.starts_with("hi"), "should preserve leading ASCII: {result}");
+        assert!(result.contains('…'), "should contain ellipsis: {result}");
+    }
+
+    #[test]
+    fn empty_string_is_returned_unchanged() {
+        assert_eq!(truncate_with_ellipsis("", 5, "..."), "");
+    }
+
+    #[test]
+    fn string_that_fits_exactly_within_byte_budget_is_unchanged() {
+        // "abc" = 3 bytes, max_len=3 → s.len() == max_len, returned as-is.
+        assert_eq!(truncate_with_ellipsis("abc", 3, "..."), "abc");
+    }
+}


### PR DESCRIPTION
## Direction-Check Reasoning — Hmbown/DeepSeek-TUI#1441
**Issue:** "Text coding error" — intermittent text encoding garbling on Mac OS v0.8.28 with screenshot evidence. Label: `bug`.
**AI-policy scan (CONTRIBUTING.md):** No mention of AI contributions at all. Default = permitted. No block.
**Maintainer-dispute scan:** Zero comments on the issue. No maintainer voice present. No dispute possible.
**Claim scan:** No comments, no `/assign`, no "I'll work on this." No claim.
**Duplicate-PR scan:** 30 open PRs checked. None reference `#1441` or address text encoding. No duplicate.
**Direction-alignment:** `bug` label, fresh report (opened today), screenshot attached showing visible garbling. Vague repro steps are a concern but not a blocker for direction — that's a Phase 3 investigation problem. The issue is within scope of the project (TUI rendering / byte stream handling).
**Summary of gates:**
| Gate | Result |
|---|---|
| forbids_ai | false → clear |
| needs_cla | false → clear |
| policy_fetch_failed | false → clear |
| maintainer_disputed | no comments → clear |
| claimed | no → clear |
| duplicate PR | none found → clear |
| stale/discussion | fresh bug report → clear |
DIRECTION_VERDICT: proceed | no blocks detected — bug label, no maintainer dispute, no duplicate PR, no AI policy, no claim