### PR TITLE
fix(settings): enable low-motion for Termius and SSH sessions (#1433)

### DIFF
--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -325,6 +325,21 @@ impl Settings {
             self.low_motion = true;
             self.fancy_animations = false;
         }
+        // Termius and SSH sessions exhibit the same 120 FPS flickering as
+        // vscode: the SSH round-trip latency means rapid cursor repositioning
+        // races ahead of what the remote renderer can flush, producing the
+        // cursor-cycling flicker reported in #1433. Enable low-motion
+        // automatically when:
+        //   • TERM_PROGRAM=Termius  (Termius desktop client sets this on connect)
+        //   • SSH_CLIENT is set     (sshd exports client IP:port for all sessions)
+        //   • SSH_TTY is set        (sshd exports PTY path for interactive logins)
+        if std::env::var("TERM_PROGRAM").as_deref() == Ok("Termius")
+            || std::env::var_os("SSH_CLIENT").map_or(false, |v| !v.is_empty())
+            || std::env::var_os("SSH_TTY").map_or(false, |v| !v.is_empty())
+        {
+            self.low_motion = true;
+            self.fancy_animations = false;
+        }
     }
 
     /// Save settings to disk
@@ -967,6 +982,69 @@ mod tests {
             match prev {
                 Some(v) => std::env::set_var("TERM_PROGRAM", v),
                 None => std::env::remove_var("TERM_PROGRAM"),
+            }
+        }
+    }
+
+    #[test]
+    fn termius_term_program_forces_low_motion_on() {
+        let _g = term_program_test_guard();
+        let prev = std::env::var_os("TERM_PROGRAM");
+        // SAFETY: serialised by the guard.
+        unsafe {
+            std::env::set_var("TERM_PROGRAM", "Termius");
+        }
+        let mut settings = Settings::default();
+        assert!(!settings.low_motion, "default is animated");
+        settings.apply_env_overrides();
+        assert!(
+            settings.low_motion,
+            "TERM_PROGRAM=Termius must enable low_motion to prevent flickering (#1433)"
+        );
+        assert!(
+            !settings.fancy_animations,
+            "TERM_PROGRAM=Termius must disable fancy_animations"
+        );
+        // SAFETY: cleanup under the guard.
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("TERM_PROGRAM", v),
+                None => std::env::remove_var("TERM_PROGRAM"),
+            }
+        }
+    }
+
+    #[test]
+    fn ssh_session_forces_low_motion_on() {
+        let _g = term_program_test_guard();
+        let prev_client = std::env::var_os("SSH_CLIENT");
+        let prev_tty = std::env::var_os("SSH_TTY");
+        for (var, val) in [
+            ("SSH_CLIENT", "192.168.1.100 50000 22"),
+            ("SSH_TTY", "/dev/pts/0"),
+        ] {
+            // SAFETY: serialised by the guard.
+            unsafe {
+                std::env::remove_var("SSH_CLIENT");
+                std::env::remove_var("SSH_TTY");
+                std::env::set_var(var, val);
+            }
+            let mut s = Settings::default();
+            s.apply_env_overrides();
+            assert!(
+                s.low_motion,
+                "{var}={val:?} must enable low_motion to prevent flickering in SSH sessions (#1433)"
+            );
+        }
+        // SAFETY: cleanup under the guard.
+        unsafe {
+            std::env::remove_var("SSH_CLIENT");
+            std::env::remove_var("SSH_TTY");
+            if let Some(v) = prev_client {
+                std::env::set_var("SSH_CLIENT", v);
+            }
+            if let Some(v) = prev_tty {
+                std::env::set_var("SSH_TTY", v);
             }
         }
     }

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -1035,6 +1035,10 @@ mod tests {
                 s.low_motion,
                 "{var}={val:?} must enable low_motion to prevent flickering in SSH sessions (#1433)"
             );
+            assert!(
+                !s.fancy_animations,
+                "{var}={val:?} must disable fancy_animations in SSH sessions (#1433)"
+            );
         }
         // SAFETY: cleanup under the guard.
         unsafe {


### PR DESCRIPTION
## Problem

Users connecting to DeepSeek TUI over SSH via Termius experience screen
flickering: the cursor cycles through input boxes and the display corrupts
intermittently.

**Root cause**: The default 120 FPS redraw rate issues rapid
cursor-repositioning escape sequences (`ESC[H`, `ESC[?25l/h`, etc.) faster
than the SSH round-trip can flush them. The remote renderer falls behind and
races → flicker. This is the same class of issue fixed for VS Code in #1356
(`TERM_PROGRAM=vscode` → 30 FPS cap).

## Fix

Extend `apply_env_overrides()` with three new triggers that mirror the
existing `vscode` block:

| Env var | Set by | Meaning |
|---|---|---|
| `TERM_PROGRAM=Termius` | Termius desktop client | Termius-specific identifier |
| `SSH_CLIENT` (non-empty) | sshd | All TCP SSH sessions |
| `SSH_TTY` (non-empty) | sshd | Interactive PTY logins |

Any of the three enables `low_motion = true` and `fancy_animations = false`,
capping the frame rate at 30 FPS and eliminating the flicker.

The change is 15 lines of production code; `cargo fmt` passes. The same env
precedence contract applies: env signals always override disk-loaded config.

## Tests

Two new tests added to `mod tests` in `settings.rs`, using the established
`term_program_test_guard()` / `lock_test_env()` pattern (Bug-128 compliant):

- `termius_term_program_forces_low_motion_on` — verifies `TERM_PROGRAM=Termius` path
- `ssh_session_forces_low_motion_on` — verifies `SSH_CLIENT` and `SSH_TTY` paths independently; asserts both `low_motion` and `!fancy_animations`

## Testing instructions

```bash
# Run the new tests
cargo test -p deepseek-tui -- settings::tests::termius_term_program_forces_low_motion_on
cargo test -p deepseek-tui -- settings::tests::ssh_session_forces_low_motion_on

# Or run the full settings test suite
cargo test -p deepseek-tui -- settings::tests

# Manual: connect via Termius or any SSH client and observe no flicker
SSH_TTY=/dev/pts/0 cargo run -p deepseek-tui
```

Fixes #1433.