### PR TITLE
fix(client): use chat_template_kwargs for Vllm provider instead of An…

### DIFF
--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -833,9 +833,21 @@ pub(super) fn apply_reasoning_effort(
             | ApiProvider::Openrouter
             | ApiProvider::Novita
             | ApiProvider::Fireworks
-            | ApiProvider::Sglang
-            | ApiProvider::Vllm => {
+            | ApiProvider::Sglang => {
                 body["thinking"] = json!({ "type": "disabled" });
+            }
+            // vLLM is an OpenAI-protocol server, not an Anthropic-protocol one.
+            // For Qwen3 / DeepSeek-R1 / other reasoning models hosted via vLLM,
+            // the canonical OpenAI extension to disable thinking is
+            // `chat_template_kwargs.enable_thinking`. The old `thinking:
+            // {type: disabled}` field is Anthropic-native and silently ignored
+            // by vLLM — the model still emits a full reasoning trace into the
+            // `reasoning` field (which this client doesn't surface), causing
+            // 10+ seconds of perceived "freeze" before the first content token.
+            ApiProvider::Vllm => {
+                body["chat_template_kwargs"] = json!({
+                    "enable_thinking": false,
+                });
             }
             ApiProvider::Openai | ApiProvider::Ollama => {}
             ApiProvider::NvidiaNim => {
@@ -850,10 +862,15 @@ pub(super) fn apply_reasoning_effort(
             | ApiProvider::Openrouter
             | ApiProvider::Novita
             | ApiProvider::Fireworks
-            | ApiProvider::Sglang
-            | ApiProvider::Vllm => {
+            | ApiProvider::Sglang => {
                 body["reasoning_effort"] = json!("high");
                 body["thinking"] = json!({ "type": "enabled" });
+            }
+            ApiProvider::Vllm => {
+                body["chat_template_kwargs"] = json!({
+                    "enable_thinking": true,
+                });
+                body["reasoning_effort"] = json!("high");
             }
             ApiProvider::Openai | ApiProvider::Ollama => {}
             ApiProvider::NvidiaNim => {
@@ -869,10 +886,15 @@ pub(super) fn apply_reasoning_effort(
             | ApiProvider::Openrouter
             | ApiProvider::Novita
             | ApiProvider::Fireworks
-            | ApiProvider::Sglang
-            | ApiProvider::Vllm => {
+            | ApiProvider::Sglang => {
                 body["reasoning_effort"] = json!("max");
                 body["thinking"] = json!({ "type": "enabled" });
+            }
+            ApiProvider::Vllm => {
+                body["chat_template_kwargs"] = json!({
+                    "enable_thinking": true,
+                });
+                body["reasoning_effort"] = json!("max");
             }
             ApiProvider::Openai | ApiProvider::Ollama => {}
             ApiProvider::NvidiaNim => {


### PR DESCRIPTION
…thropic-style thinking field

vLLM is an OpenAI-compatible server, so it speaks OpenAI's chat completions protocol and does not understand Anthropic-native extension fields. The Vllm branch of apply_reasoning_effort was previously injecting `thinking: {type: "disabled" | "enabled"}` at the top level of the request body — but vLLM silently ignores this unknown field.

For Qwen3 (and other reasoning-capable models hosted via vLLM), the canonical way to toggle thinking is the OpenAI-protocol extension `chat_template_kwargs.enable_thinking`, which vLLM forwards into the model's chat template. See the vLLM docs on chat templating + Qwen3 official template's `enable_thinking` parameter.

Symptom before this fix
-----------------------
With reasoning_effort="off" against a Qwen3 deployment, the model still generated 10+ seconds of reasoning tokens, which vLLM placed into the non-OpenAI-standard `reasoning` field. This client does not consume `reasoning`, so the user observes a ~13s "freeze" before any content delta arrives. Manual curl reproduction:

    $ curl http://vllm-host:8000/v1/chat/completions -d '{
        "model": "...", "messages":[{"role":"user","content":"hi"}],
        "max_tokens": 100
      }'
    -> reasoning: "Thinking Process: 1. Analyze the User's Input..."
    -> content: null   (max_tokens spent in reasoning)

    $ curl http://vllm-host:8000/v1/chat/completions -d '{
        "model": "...", "messages":[{"role":"user","content":"hi"}],
        "max_tokens": 100,
        "chat_template_kwargs": {"enable_thinking": false}
      }'
    -> reasoning: null
    -> content: "你好！我是 Qwen…"   (full answer, < 5s)

After this fix
--------------
Vllm branch now mirrors NvidiaNim (which already uses chat_template_kwargs, but with the NVIDIA-specific `thinking` key rather than the Qwen-standard `enable_thinking`).

End-to-end measurement against vLLM hosting Qwen3.6-35B-A3B-FP8:
- TTFT (time-to-first-text-delta): 13039ms -> 274ms
- Total LLM call: 13s -> 5.7s
- Effective output rate: 3 chars/s (most time in hidden reasoning) -> 46 chars/s

Note: Sglang and other OpenAI-compatible servers (Fireworks, Novita) likely have the same issue but I have not verified the right field for each. They are left unchanged in this PR; the Vllm branch is the minimal, verified fix.

## Summary

## Testing

- [ ] `cargo test --all-features`
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
