### PR TITLE
  fix: strengthen session picker selection highlight

### DIFF
--- a/crates/tui/src/tui/session_picker.rs
+++ b/crates/tui/src/tui/session_picker.rs
@@ -491,7 +491,8 @@ fn build_list_lines(
         let style = if idx == selected {
             Style::default()
                 .fg(palette::SELECTION_TEXT)
-                .bg(palette::SELECTION_BG)
+                .bg(palette::DEEPSEEK_BLUE)
+                .add_modifier(Modifier::BOLD)
         } else {
             Style::default().fg(palette::TEXT_PRIMARY)
         };
@@ -769,6 +770,32 @@ mod tests {
                 width
             );
         }
+    }
+
+    #[test]
+    fn build_list_lines_selected_row_uses_strong_highlight() {
+        let sessions = vec![
+            test_session(1, "first session"),
+            test_session(2, "second session"),
+        ];
+        let lines = build_list_lines(&sessions, 1, 80, 0, 5, false, "", "recent", false, None);
+
+        let selected_line = lines
+            .iter()
+            .find(|line| {
+                line.spans
+                    .iter()
+                    .any(|span| span.content.contains("second session"))
+            })
+            .expect("selected session should render");
+        let span = selected_line
+            .spans
+            .first()
+            .expect("selected row should have a span");
+
+        assert_eq!(span.style.fg, Some(palette::SELECTION_TEXT));
+        assert_eq!(span.style.bg, Some(palette::DEEPSEEK_BLUE));
+        assert!(span.style.add_modifier.contains(Modifier::BOLD));
     }
 
     #[test]


### PR DESCRIPTION

## Summary

 The selected row in the `/sessions` picker was difficult to distinguish in dark terminals because the highlight background was too subtle.

 This change makes the selected session row use a stronger blue background with bold selected text, so keyboard navigation clearly shows the active row.

<img width="471" height="297" alt="image" src="https://github.com/user-attachments/assets/8826907a-93a8-468b-842a-47b75ddee574" />


## Testing

- [x] `cargo test --all-features`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
