### PR TITLE
fix(shell): avoid O(total_bytes) buffer clone on every TUI refresh (fixes #1299)

### DIFF
--- a/crates/tui/src/tools/shell.rs
+++ b/crates/tui/src/tools/shell.rs
@@ -469,7 +469,17 @@ impl BackgroundShell {
     }
 
     fn job_snapshot(&self) -> ShellJobSnapshot {
-        let (stdout_full, stderr_full, stdout_len, stderr_len) = self.full_output();
+        // Use tail_from_buffer instead of full_output so we never clone the
+        // entire accumulated stdout/stderr for display purposes.  full_output
+        // is O(total_bytes_written), which caused the ShellManager mutex to be
+        // held for an arbitrarily long time during list_jobs() calls from the
+        // TUI event loop — freezing input handling on long automation runs.
+        let (stdout_len, stdout_tail) = tail_from_buffer(&self.stdout_buffer, 1200);
+        let (stderr_len, stderr_tail) = self
+            .stderr_buffer
+            .as_ref()
+            .map(|buf| tail_from_buffer(buf, 1200))
+            .unwrap_or((0, String::new()));
         ShellJobSnapshot {
             id: self.id.clone(),
             job_id: self.id.clone(),
@@ -478,8 +488,8 @@ impl BackgroundShell {
             status: self.status.clone(),
             exit_code: self.exit_code,
             elapsed_ms: u64::try_from(self.started_at.elapsed().as_millis()).unwrap_or(u64::MAX),
-            stdout_tail: tail_text(&stdout_full, 1200),
-            stderr_tail: tail_text(&stderr_full, 1200),
+            stdout_tail,
+            stderr_tail,
             stdout_len,
             stderr_len,
             stdin_available: self.stdin.is_some() && self.status == ShellStatus::Running,
@@ -1370,11 +1380,30 @@ impl ShellManager {
 }
 
 fn take_delta_from_buffer(buffer: &Arc<Mutex<Vec<u8>>>, cursor: &mut usize) -> (Vec<u8>, usize) {
-    let data = buffer.lock().map(|d| d.clone()).unwrap_or_default();
-    let start = (*cursor).min(data.len());
-    let delta = data[start..].to_vec();
-    *cursor = data.len();
-    (delta, data.len())
+    let guard = buffer.lock().unwrap_or_else(|e| e.into_inner());
+    let total = guard.len();
+    let start = (*cursor).min(total);
+    // Clone only the unread portion (the delta), not the entire accumulated buffer.
+    // Long-running processes can produce megabytes of output; cloning the full
+    // buffer on every poll held the ShellManager mutex for O(total_bytes) time.
+    let delta = guard[start..].to_vec();
+    *cursor = total;
+    (delta, total)
+}
+
+/// Read only the tail of a byte buffer and return (total_len, tail_string).
+///
+/// Avoids cloning the full buffer when only a trailing excerpt is needed
+/// (e.g. for the job-panel display).  `max_tail_chars` is in Unicode scalar
+/// values; we read at most `max_tail_chars * 4` bytes from the end to account
+/// for multi-byte UTF-8 sequences.
+fn tail_from_buffer(buffer: &Arc<Mutex<Vec<u8>>>, max_tail_chars: usize) -> (usize, String) {
+    let guard = buffer.lock().unwrap_or_else(|e| e.into_inner());
+    let total = guard.len();
+    // Over-estimate byte count (4 bytes per char worst case for UTF-8).
+    let tail_start = total.saturating_sub(max_tail_chars.saturating_mul(4));
+    let tail_str = String::from_utf8_lossy(&guard[tail_start..]).into_owned();
+    (total, tail_text(&tail_str, max_tail_chars))
 }
 
 fn tail_text(text: &str, max_chars: usize) -> String {

--- a/crates/tui/src/tools/shell.rs
+++ b/crates/tui/src/tools/shell.rs
@@ -1401,7 +1401,13 @@ fn tail_from_buffer(buffer: &Arc<Mutex<Vec<u8>>>, max_tail_chars: usize) -> (usi
     let guard = buffer.lock().unwrap_or_else(|e| e.into_inner());
     let total = guard.len();
     // Over-estimate byte count (4 bytes per char worst case for UTF-8).
-    let tail_start = total.saturating_sub(max_tail_chars.saturating_mul(4));
+    let mut tail_start = total.saturating_sub(max_tail_chars.saturating_mul(4));
+    // Snap forward to the next valid UTF-8 codepoint boundary so we don't
+    // pass a slice beginning with continuation bytes (0x80–0xBF) to
+    // from_utf8_lossy, which would emit a leading U+FFFD replacement char.
+    while tail_start < total && (guard[tail_start] & 0xC0) == 0x80 {
+        tail_start += 1;
+    }
     let tail_str = String::from_utf8_lossy(&guard[tail_start..]).into_owned();
     (total, tail_text(&tail_str, max_tail_chars))
 }


### PR DESCRIPTION
## Root cause

`job_snapshot()` called `full_output()` which clones the **entire** accumulated stdout/stderr buffer under `std::sync::Mutex<ShellManager>`. For long-running tasks (browser automation, large builds) this buffer grows unboundedly; cloning it on the 2.5-second panel-refresh path held the mutex for O(total_bytes) time, starving the `crossterm::event::poll` loop and causing the input freeze reported in #1299.

Reproduction: start a shell job that produces continuous output, wait ~30 seconds, try to type — input locks up until the next `list_jobs()` call finishes cloning the buffer.

## Fix (two commits)

**`crates/tui/src/tools/shell.rs`**

1. **`job_snapshot()` → `tail_from_buffer()`**: instead of cloning the entire buffer, read only the last `max_tail_chars * 4` bytes under the lock and decode. Lock hold time is now O(1) regardless of total output volume.  `stdout_len` / `stderr_len` still return the true total byte count (not the tail size) so no caller invariant is broken.

2. **`take_delta_from_buffer()` clone reduction**: the old code did `buffer.lock().map(|d| d.clone())` — eagerly cloning the full buffer before slicing out the delta. New code slices `[cursor..total]` inside the lock guard so only the unread bytes are allocated.

3. **UTF-8 boundary safety** (second commit): `tail_start` can land mid-codepoint. Before slicing, the code now skips any continuation bytes (`& 0xC0 == 0x80`) so `from_utf8_lossy` never sees an invalid leading byte and never emits a leading U+FFFD in the job panel.

## What this does NOT fix

The `collect_output()` blocking-`join()` path (orphaned grandchildren keeping the pipe write-end open) is already addressed on Unix by the existing `kill_child_process_group` call in `main`. A corresponding fix for Windows would be a separate PR.

`job_detail()` (user-initiated detail view) still calls `full_output()` — this is intentional since detail views are rare and user-triggered, not on the hot refresh path.

## Testing

```
# Start a job that floods stdout:
task_shell_start "seq 1 1000000 | while read i; do echo $i; done"
# Watch the job panel — input should remain responsive
# Previously this would freeze every 2.5 s for ~100–500 ms after ~30 s of output
```

---

> This contribution was written with AI assistance (Claude Sonnet 4.6 via AutoGHClaw). The logic, root-cause analysis, and fix were verified by code review before submission.

Fixes #1299