### PR TITLE
fix(session): skip turn_meta block when deriving session title

### DIFF
--- a/crates/tui/src/session_manager.rs
+++ b/crates/tui/src/session_manager.rs
@@ -674,7 +674,9 @@ pub fn create_saved_session_with_id_and_mode(
         .find(|m| m.role == "user")
         .and_then(|m| {
             m.content.iter().find_map(|block| match block {
-                ContentBlock::Text { text, .. } => Some(truncate_title(text, 50)),
+                ContentBlock::Text { text, .. } if !text.starts_with("<turn_meta>") => {
+                    Some(truncate_title(text, 50))
+                }
                 _ => None,
             })
         })


### PR DESCRIPTION
## Summary

- `/sessions` command was displaying internal `<turn_meta>` metadata as the session name instead of the user's actual input
- Root cause: `create_saved_session_with_id_and_mode` in `session_manager.rs` uses `find_map` to pick the first `ContentBlock::Text` from the user message, but the engine prepends a `<turn_meta>` block (Block 0) before the real user text (Block 1)
- Fix: add a guard `if !text.starts_with("<turn_meta>")` to skip the metadata block

## Test plan

- [x] Start a new conversation, send a message, then run `/sessions` — session name shows the user's input correctly
- [x] Existing sessions without `<turn_meta>` blocks are unaffected (guard is a no-op when no metadata block is present)
- [x] Very long user input is still truncated correctly via `truncate_title`