### PR TITLE
fix(subagent): prevent review agents from spawning sub-agents

### DIFF
--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -2879,7 +2879,7 @@ async fn run_subagent(
             unavailable_tools.join(", ")
         ));
     }
-    let tools = tool_registry.tools_for_model();
+    let tools = tool_registry.tools_for_model(&agent_type);
     if let Some(mb) = runtime.mailbox.as_ref() {
         let _ = mb.send(MailboxMessage::started(&agent_id, agent_type.clone()));
     }
@@ -3838,14 +3838,27 @@ impl SubAgentToolRegistry {
         }
     }
 
-    fn tools_for_model(&self) -> Vec<Tool> {
+    fn tools_for_model(&self, agent_type: &SubAgentType) -> Vec<Tool> {
+        let disallowed = match agent_type {
+            // Review agents should not spawn sub-agents (#1489).
+            SubAgentType::Review => &["agent_spawn"][..],
+            _ => &[][..],
+        };
         let api_tools = self.registry.to_api_tools();
-        match &self.allowed_tools {
+        let filtered = match &self.allowed_tools {
             None => api_tools,
             Some(list) => api_tools
                 .into_iter()
                 .filter(|tool| list.contains(&tool.name))
-                .collect(),
+                .collect::<Vec<_>>(),
+        };
+        if disallowed.is_empty() {
+            filtered
+        } else {
+            filtered
+                .into_iter()
+                .filter(|tool| !disallowed.contains(&tool.name.as_str()))
+                .collect()
         }
     }
 

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -638,6 +638,26 @@ fn test_subagent_tool_registry_reports_unavailable_tools() {
     );
 }
 
+#[test]
+fn test_review_agent_tools_exclude_agent_spawn() {
+    let tmp = tempdir().expect("tempdir");
+    let mut runtime = stub_runtime();
+    runtime.context = ToolContext::new(tmp.path().to_path_buf());
+    // None = full parent tool inheritance (the default for builtin types).
+    let registry = SubAgentToolRegistry::new(
+        runtime,
+        None,
+        Arc::new(Mutex::new(TodoList::new())),
+        Arc::new(Mutex::new(PlanState::default())),
+    );
+    let tools = registry.tools_for_model(&SubAgentType::Review);
+    let names: Vec<_> = tools.iter().map(|t| t.name.as_str()).collect();
+    assert!(
+        !names.contains(&"agent_spawn"),
+        "Review agent must not have agent_spawn; tools: {names:?}"
+    );
+}
+
 #[tokio::test]
 async fn test_wait_for_result_reports_timeout_when_still_running() {
     let manager = Arc::new(RwLock::new(SubAgentManager::new(PathBuf::from("."), 2)));


### PR DESCRIPTION
## Summary

Adds a disallowed-tools filter to `SubAgentToolRegistry::tools_for_model()` so that Review-type agents cannot call `agent_spawn`.

## Why it matters

When a review sub-agent is spawned, it can reinterpret itself as a coordinator and spawn further sub-agents instead of performing the review directly. This multiplies work, increases runtime and token use, and the parent receives an incomplete synthesized review because child outputs are not merged.

The existing `allowed_tools()` function already excludes `agent_spawn` for Review agents, but it was deprecated (maintainer's design: default sub-agents inherit full parent registry). The missing piece was a `disallowed_tools` filter that operates after full parent inheritance.

## Changes

| File | Change |
|------|--------|
| `crates/tui/src/tools/subagent/mod.rs` | Added `disallowed_tools` filter; Review agent blocked from `agent_spawn` |

Fixes #1489.

## Test plan

- [x] `cargo check -p deepseek-tui` passes
- [x] `cargo clippy -p deepseek-tui --all-targets --all-features --locked -- -D warnings` passes
- [x] `cargo test -p deepseek-tui -- subagent` — 118 passed