### PR TITLE
Direction Check Reasoning

### DIFF
--- a/crates/tui/src/commands/config.rs
+++ b/crates/tui/src/commands/config.rs
@@ -329,8 +329,19 @@ pub fn set_config_value(app: &mut App, key: &str, value: &str, persist: bool) ->
             app.update_model_compaction_budget();
             app.session.last_prompt_tokens = None;
             app.session.last_completion_tokens = None;
+            let message = if persist {
+                match persist_root_string_key("default_text_model", &model) {
+                    Ok(path) => format!(
+                        "model = {model} (saved to {}; takes effect as default on next start)",
+                        path.display()
+                    ),
+                    Err(e) => return CommandResult::error(format!("Failed to save model: {e}")),
+                }
+            } else {
+                format!("model = {model} (session only, add --save to persist)")
+            };
             return CommandResult::with_message_and_action(
-                format!("model = {model}"),
+                message,
                 AppAction::UpdateCompaction(app.compaction_config()),
             );
         }
@@ -1292,10 +1303,29 @@ mod tests {
     #[test]
     fn test_set_model_with_save_flag() {
         let mut app = create_test_app();
-        let _result = set_config(&mut app, Some("model deepseek-v4-flash --save"));
-        // Note: This test may fail in environments where settings can't be saved
-        // The important thing is that the model is updated
+        let result = set_config(&mut app, Some("model deepseek-v4-flash --save"));
         assert_eq!(app.model, "deepseek-v4-flash");
+        let msg = result.message.unwrap_or_default();
+        assert!(
+            !msg.contains("session only"),
+            "expected no 'session only' hint when --save is used, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_set_model_without_save_shows_session_only_hint() {
+        let mut app = create_test_app();
+        let result = set_config(&mut app, Some("model deepseek-v4-flash"));
+        assert_eq!(app.model, "deepseek-v4-flash");
+        let msg = result.message.unwrap_or_default();
+        assert!(
+            msg.contains("session only"),
+            "expected 'session only' hint when --save not used, got: {msg}"
+        );
+        assert!(
+            msg.contains("--save"),
+            "expected '--save' hint in message, got: {msg}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Direction Check Reasoning
**Issue summary**: User on Windows 10 reports that every time DeepSeek TUI starts, the model resets to `gpt-4.1` instead of persisting the previously selected `deepseek` model. Labeled `bug` + `enhancement`.
---
### Gate 1 — AI policy
CONTRIBUTING.md (decoded) is a standard Rust contribution guide covering `cargo fmt`, `cargo clippy`, commit conventions, and the harvest-vs-direct-merge model. There is **no mention of AI-generated code being forbidden, discouraged, or requiring special approval**. Silence = permitted by default.
→ **CLEAR**
---
### Gate 2 — Maintainer dispute
Zero comments on the issue. No OWNER/MEMBER/COLLABORATOR has weighed in at all, let alone disputed the premise. The `bug` label was applied (label assignment is a light acceptance signal).
→ **CLEAR**
---
### Gate 3 — Prior claims
No comments of any kind. No `/assign`, no "I'll work on this". No stale claim to defer to.
→ **CLEAR**
---
### Gate 4 — Duplicate PR
No related open PRs provided. Python preflight passed this through, meaning no `Fixes #1434` grep hit in open PRs.
→ **CLEAR**
---
### Gate 5 — Direction alignment
- The report is specific and actionable: model selection is not being persisted across sessions, falling back to a hardcoded or default value (`gpt-4.1`).
- This is a classic config-persistence bug — the fix scope is narrow (read/write the selected model to config/state on exit/startup).
- Dual labels `bug + enhancement` are consistent with "this is broken AND we want persistent selection".
- No "proposal / RFC / discussion" framing — it is a concrete bug report.
- Issue is recent; no staleness concern.
→ **CLEAR**
---
DIRECTION_VERDICT: proceed | Bug-labeled issue with no maintainer dispute, no prior claims, no duplicate PRs, and no AI-policy restriction; model selection not persisting across sessions is an actionable scoped fix.