### PR TITLE
fix: count reasoning tokens in cost, auto CNY on zh-Hans

### DIFF
--- a/crates/tui/src/commands/debug.rs
+++ b/crates/tui/src/commands/debug.rs
@@ -450,6 +450,7 @@ mod tests {
         };
         let mut app = App::new(options, &Config::default());
         app.ui_locale = crate::localization::Locale::En;
+        app.cost_currency = crate::pricing::CostCurrency::Usd;
         app.api_provider = crate::config::ApiProvider::Deepseek;
         app
     }

--- a/crates/tui/src/pricing.rs
+++ b/crates/tui/src/pricing.rs
@@ -195,7 +195,9 @@ fn calculate_turn_cost_from_usage_with_pricing(pricing: CurrencyPricing, usage: 
     let hit_cost = (hit_tokens as f64 / 1_000_000.0) * pricing.input_cache_hit_per_million;
     let miss_cost = ((miss_tokens.saturating_add(uncategorized_input)) as f64 / 1_000_000.0)
         * pricing.input_cache_miss_per_million;
-    let output_cost = (usage.output_tokens as f64 / 1_000_000.0) * pricing.output_per_million;
+    let reasoning = usage.reasoning_tokens.unwrap_or(0);
+    let effective_output = usage.output_tokens.saturating_add(reasoning);
+    let output_cost = (effective_output as f64 / 1_000_000.0) * pricing.output_per_million;
     hit_cost + miss_cost + output_cost
 }
 

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -1245,8 +1245,10 @@ impl App {
         let show_thinking = settings.show_thinking;
         let show_tool_details = settings.show_tool_details;
         let ui_locale = resolve_locale(&settings.locale);
-        let cost_currency =
-            CostCurrency::from_setting(&settings.cost_currency).unwrap_or(CostCurrency::Usd);
+        let cost_currency = match (settings.cost_currency.as_str(), ui_locale.tag()) {
+            ("usd", "zh-Hans") => CostCurrency::Cny,
+            _ => CostCurrency::from_setting(&settings.cost_currency).unwrap_or(CostCurrency::Usd),
+        };
         let composer_density = ComposerDensity::from_setting(&settings.composer_density);
         let composer_border = settings.composer_border;
         let composer_vim_enabled = settings

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -1059,7 +1059,11 @@ fn create_test_app() -> App {
         resume_session_id: None,
         initial_input: None,
     };
-    App::new(options, &Config::default())
+    let mut app = App::new(options, &Config::default());
+    // Pin locale and currency for deterministic tests regardless of host locale.
+    app.cost_currency = crate::pricing::CostCurrency::Usd;
+    app.ui_locale = crate::localization::Locale::En;
+    app
 }
 
 fn create_test_options() -> TuiOptions {


### PR DESCRIPTION
Two fixes: (1) Add reasoning_tokens to output cost calculation in pricing.rs. V4 thinking mode reasoning tokens are billed at output rate but were excluded, causing significant under-estimate. (2) Auto-detect CNY currency when ui_locale is zh-Hans and cost_currency is at default usd. Also pin test locale/currency for determinism. All 2782+ tests pass, fmt and clippy clean.