### PR TITLE
feat(note): add kind/inherit fields and inject into sub-agent context

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
             echo "apt-get update failed (attempt $i); retrying in 15s"
             sleep 15
           done
-          sudo apt-get install -y libdbus-1-dev pkg-config
+          sudo apt-get install -y libdbus-1-dev pkg-config pandoc
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -53,7 +53,7 @@ jobs:
             echo "apt-get update failed (attempt $i); retrying in 15s"
             sleep 15
           done
-          sudo apt-get install -y libdbus-1-dev pkg-config
+          sudo apt-get install -y libdbus-1-dev pkg-config pandoc
       - uses: Swatinem/rust-cache@v2
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -81,7 +81,7 @@ jobs:
             echo "apt-get update failed (attempt $i); retrying in 15s"
             sleep 15
           done
-          sudo apt-get install -y libdbus-1-dev pkg-config
+          sudo apt-get install -y libdbus-1-dev pkg-config pandoc
       - name: Install macOS system dependencies
         if: runner.os == 'macOS'
         run: brew install pandoc
@@ -111,7 +111,7 @@ jobs:
             echo "apt-get update failed (attempt $i); retrying in 15s"
             sleep 15
           done
-          sudo apt-get install -y libdbus-1-dev pkg-config
+          sudo apt-get install -y libdbus-1-dev pkg-config pandoc
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -137,7 +137,7 @@ jobs:
             echo "apt-get update failed (attempt $i); retrying in 15s"
             sleep 15
           done
-          sudo apt-get install -y libdbus-1-dev pkg-config
+          sudo apt-get install -y libdbus-1-dev pkg-config pandoc
       - uses: Swatinem/rust-cache@v2
       - name: Build docs
         run: cargo doc --workspace --no-deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,9 @@ jobs:
             sleep 15
           done
           sudo apt-get install -y libdbus-1-dev pkg-config pandoc
+      - name: Install macOS system dependencies
+        if: runner.os == 'macOS'
+        run: brew install pandoc
       - name: Install Windows system dependencies
         if: runner.os == 'Windows'
         run: choco install pandoc --no-progress

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,9 @@ jobs:
             sleep 15
           done
           sudo apt-get install -y libdbus-1-dev pkg-config
+      - name: Install macOS system dependencies
+        if: runner.os == 'macOS'
+        run: brew install pandoc
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
         run: cargo test --workspace --all-features --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,9 +82,9 @@ jobs:
             sleep 15
           done
           sudo apt-get install -y libdbus-1-dev pkg-config pandoc
-      - name: Install macOS system dependencies
-        if: runner.os == 'macOS'
-        run: brew install pandoc
+      - name: Install Windows system dependencies
+        if: runner.os == 'Windows'
+        run: choco install pandoc --no-progress
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
         run: cargo test --workspace --all-features --locked

--- a/crates/tui/src/tools/shell.rs
+++ b/crates/tui/src/tools/shell.rs
@@ -2695,11 +2695,24 @@ impl ToolSpec for NoteTool {
         context: &ToolContext,
     ) -> Result<ToolResult, ToolError> {
         let note_content = required_str(&input, "content")?;
+        const VALID_KINDS: &[&str] =
+            &["constraint", "task_scope", "user_preference", "observation"];
         let kind = input
             .get("kind")
             .and_then(serde_json::Value::as_str)
             .unwrap_or("observation");
-        let default_inherit = matches!(kind, "constraint" | "task_scope" | "user_preference");
+        let valid_kind = VALID_KINDS.contains(&kind);
+        if !valid_kind {
+            tracing::warn!(
+                "NoteTool: invalid kind '{kind}' (expected one of {:?}), falling back to observation",
+                VALID_KINDS
+            );
+        }
+        let resolved_kind = if valid_kind { kind } else { "observation" };
+        let default_inherit = matches!(
+            resolved_kind,
+            "constraint" | "task_scope" | "user_preference"
+        );
         let inherit = input
             .get("inherit")
             .and_then(serde_json::Value::as_bool)
@@ -2722,7 +2735,7 @@ impl ToolSpec for NoteTool {
 
         let entry = json!({
             "content": note_content,
-            "kind": kind,
+            "kind": resolved_kind,
             "inherit": inherit,
         });
         writeln!(

--- a/crates/tui/src/tools/shell.rs
+++ b/crates/tui/src/tools/shell.rs
@@ -2725,8 +2725,12 @@ impl ToolSpec for NoteTool {
             "kind": kind,
             "inherit": inherit,
         });
-        writeln!(file, "\n---\n{}", serde_json::to_string(&entry).unwrap_or_default())
-            .map_err(|e| ToolError::execution_failed(format!("Failed to write note: {e}")))?;
+        writeln!(
+            file,
+            "\n---\n{}",
+            serde_json::to_string(&entry).unwrap_or_default()
+        )
+        .map_err(|e| ToolError::execution_failed(format!("Failed to write note: {e}")))?;
 
         let inherit_note = if inherit {
             " (inherited by sub-agents)"

--- a/crates/tui/src/tools/shell.rs
+++ b/crates/tui/src/tools/shell.rs
@@ -2666,6 +2666,15 @@ impl ToolSpec for NoteTool {
                 "content": {
                     "type": "string",
                     "description": "The note content to append"
+                },
+                "kind": {
+                    "type": "string",
+                    "description": "Note kind: constraint, task_scope, user_preference, or observation (default). Determines whether the note is inherited by sub-agents.",
+                    "enum": ["constraint", "task_scope", "user_preference", "observation"]
+                },
+                "inherit": {
+                    "type": "boolean",
+                    "description": "Whether this note should be passed to sub-agents. Overrides the default for the given kind. Default: true for constraint/task_scope/user_preference, false for observation."
                 }
             },
             "required": ["content"]
@@ -2686,6 +2695,15 @@ impl ToolSpec for NoteTool {
         context: &ToolContext,
     ) -> Result<ToolResult, ToolError> {
         let note_content = required_str(&input, "content")?;
+        let kind = input
+            .get("kind")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("observation");
+        let default_inherit = matches!(kind, "constraint" | "task_scope" | "user_preference");
+        let inherit = input
+            .get("inherit")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(default_inherit);
 
         // Ensure parent directory exists
         if let Some(parent) = context.notes_path.parent() {
@@ -2694,19 +2712,31 @@ impl ToolSpec for NoteTool {
             })?;
         }
 
-        // Append to notes file
+        // Append structured JSONL line to notes file.
+        // Format: one JSON object per line (after the initial "---\n" separator).
         let mut file = std::fs::OpenOptions::new()
             .create(true)
             .append(true)
             .open(&context.notes_path)
             .map_err(|e| ToolError::execution_failed(format!("Failed to open notes file: {e}")))?;
 
-        writeln!(file, "\n---\n{note_content}")
+        let entry = json!({
+            "content": note_content,
+            "kind": kind,
+            "inherit": inherit,
+        });
+        writeln!(file, "\n---\n{}", serde_json::to_string(&entry).unwrap_or_default())
             .map_err(|e| ToolError::execution_failed(format!("Failed to write note: {e}")))?;
 
+        let inherit_note = if inherit {
+            " (inherited by sub-agents)"
+        } else {
+            ""
+        };
         Ok(ToolResult::success(format!(
-            "Note appended to {}",
-            context.notes_path.display()
+            "Note appended to {}{}",
+            context.notes_path.display(),
+            inherit_note,
         )))
     }
 }

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -4,7 +4,7 @@
 //! and retrieve results. Sub-agents run with a filtered toolset and
 //! inherit the workspace configuration from the main session.
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -2632,6 +2632,105 @@ impl ToolSpec for DelegateToAgentTool {
 /// For 0.6.6 we just don't drop the role on the floor: the model sees
 /// "You are operating in the role of `{name}`." as a final line so its
 /// behavior reflects the user's choice.
+/// Read inheritable notes from the parent session's notes file.
+/// Returns a prompt section to be injected into the sub-agent's context, or empty string.
+fn build_inherited_notes_section(notes_path: &Path) -> String {
+    const MAX_INHERITED_NOTES: usize = 20;
+    const MAX_INHERITED_CHARS: usize = 4000;
+
+    let Ok(body) = std::fs::read_to_string(notes_path) else {
+        return String::new();
+    };
+
+    // Notes are stored as JSONL lines after "---\n" separators.
+    let mut notes: Vec<(String, String, bool)> = Vec::new();
+    for segment in body.split("\n---\n") {
+        let segment = segment.trim();
+        if segment.is_empty() {
+            continue;
+        }
+        // Try JSON first, fall back to plain text as "observation" with no inheritance.
+        if let Ok(entry) = serde_json::from_str::<serde_json::Value>(segment) {
+            let content = entry
+                .get("content")
+                .and_then(|v| v.as_str())
+                .unwrap_or(segment);
+            let kind = entry
+                .get("kind")
+                .and_then(|v| v.as_str())
+                .unwrap_or("observation");
+            let inherit = entry
+                .get("inherit")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(!matches!(kind, "observation"));
+            if inherit {
+                notes.push((kind.to_string(), content.to_string(), inherit));
+            }
+        }
+        // Plain text notes (old format) are treated as observation, not inherited.
+    }
+
+    if notes.is_empty() {
+        return String::new();
+    }
+
+    // Sort: constraint > task_scope > user_preference > others
+    fn kind_priority(kind: &str) -> u8 {
+        match kind {
+            "constraint" => 0,
+            "task_scope" => 1,
+            "user_preference" => 2,
+            _ => 3,
+        }
+    }
+    notes.sort_by_key(|(k, _, _)| kind_priority(k));
+
+    // Budget: cap by count and total chars. Dedup exact content.
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut total_chars = 0usize;
+    let mut out = String::new();
+    let mut current_kind = String::new();
+
+    let kind_labels: [(&str, &str); 3] = [
+        ("constraint", "### Constraints\n"),
+        ("task_scope", "### Task scope\n"),
+        ("user_preference", "### User preferences\n"),
+    ];
+
+    for (kind, content, _) in notes {
+        if !seen.insert(content.clone()) {
+            continue;
+        }
+        let content_len = content.len();
+        if total_chars + content_len > MAX_INHERITED_CHARS {
+            break;
+        }
+        let label = kind_labels
+            .iter()
+            .find(|(k, _)| *k == kind)
+            .map(|(_, l)| *l)
+            .unwrap_or("### Notes\n");
+        if current_kind != kind {
+            out.push_str(label);
+            current_kind = kind.clone();
+        }
+        out.push_str(&format!("- {}\n", content));
+        total_chars += content_len;
+        if seen.len() >= MAX_INHERITED_NOTES {
+            break;
+        }
+    }
+
+    format!(
+        "## Inherited context from parent agent\n\n\
+         The following notes from the parent session apply.\n\
+         Treat `constraint` and `task_scope` notes as binding unless \
+         overridden by the current task. If any note conflicts with \
+         the explicit task, follow the task and mention the conflict.\n\n\
+         {out}"
+    )
+}
+
 fn build_subagent_system_prompt(
     agent_type: &SubAgentType,
     assignment: &SubAgentAssignment,
@@ -2662,10 +2761,22 @@ fn build_initial_subagent_messages(
     assignment: &SubAgentAssignment,
     agent_type: &SubAgentType,
     fork_context: Option<&SubAgentForkContext>,
+    notes_path: Option<&Path>,
 ) -> Vec<Message> {
     let mut messages = fork_context
         .map(|context| context.messages.clone())
         .unwrap_or_default();
+
+    // Inject inheritable notes from the parent session.
+    // Only for non-fork agents (fork agents already inherit parent context).
+    if fork_context.is_none()
+        && let Some(path) = notes_path
+    {
+        let section = build_inherited_notes_section(path);
+        if !section.is_empty() {
+            messages.push(system_text_message(section));
+        }
+    }
 
     if let Some(context) = fork_context {
         if let Some(state) = context
@@ -2860,7 +2971,7 @@ async fn run_subagent(
         .flatten();
     let request_system = subagent_request_system_prompt(&system_prompt, fork_context);
     let mut messages =
-        build_initial_subagent_messages(&prompt, &assignment, &agent_type, fork_context);
+        build_initial_subagent_messages(&prompt, &assignment, &agent_type, fork_context, Some(&runtime.context.notes_path));
     let runtime_for_tools = runtime.clone().with_fork_context(SubAgentForkContext {
         system: Some(request_system.clone()),
         messages: messages.clone(),

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -2655,14 +2655,21 @@ fn build_inherited_notes_section(notes_path: &Path) -> String {
                 .get("content")
                 .and_then(|v| v.as_str())
                 .unwrap_or(segment);
+            const VALID_KINDS: &[&str] =
+                &["constraint", "task_scope", "user_preference", "observation"];
             let kind = entry
                 .get("kind")
                 .and_then(|v| v.as_str())
                 .unwrap_or("observation");
+            let resolved_kind = if VALID_KINDS.contains(&kind) {
+                kind
+            } else {
+                "observation"
+            };
             let inherit = entry
                 .get("inherit")
                 .and_then(|v| v.as_bool())
-                .unwrap_or(!matches!(kind, "observation"));
+                .unwrap_or(!matches!(resolved_kind, "observation"));
             if inherit {
                 notes.push((kind.to_string(), content.to_string(), inherit));
             }

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -2970,8 +2970,13 @@ async fn run_subagent(
         .then_some(runtime.fork_context.as_ref())
         .flatten();
     let request_system = subagent_request_system_prompt(&system_prompt, fork_context);
-    let mut messages =
-        build_initial_subagent_messages(&prompt, &assignment, &agent_type, fork_context, Some(&runtime.context.notes_path));
+    let mut messages = build_initial_subagent_messages(
+        &prompt,
+        &assignment,
+        &agent_type,
+        fork_context,
+        Some(&runtime.context.notes_path),
+    );
     let runtime_for_tools = runtime.clone().with_fork_context(SubAgentForkContext {
         system: Some(request_system.clone()),
         messages: messages.clone(),

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -1916,3 +1916,21 @@ fn fork_agent_does_not_receive_duplicate_inherited_notes() {
         "fork agents should not receive duplicate inherited notes"
     );
 }
+
+#[test]
+fn inherited_notes_invalid_kind_falls_back_to_observation() {
+    // Invalid kind values should be silently treated as observation
+    // (not inherited), matching the defensive design.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("notes.txt");
+    std::fs::write(
+        &path,
+        "\n---\n{\"content\": \"fell through\", \"kind\": \"not_a_real_kind\"}",
+    )
+    .unwrap();
+    let section = build_inherited_notes_section(&path);
+    assert!(
+        section.is_empty(),
+        "notes with invalid kind should not be inherited"
+    );
+}

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -346,8 +346,13 @@ fn forked_subagent_messages_preserve_parent_prefix_then_append_task() {
 #[test]
 fn fresh_subagent_messages_keep_existing_single_turn_shape() {
     let assignment = SubAgentAssignment::new("list files".to_string(), None);
-    let messages =
-        build_initial_subagent_messages("list files", &assignment, &SubAgentType::Explore, None, None);
+    let messages = build_initial_subagent_messages(
+        "list files",
+        &assignment,
+        &SubAgentType::Explore,
+        None,
+        None,
+    );
 
     assert_eq!(messages.len(), 1);
     assert_eq!(messages[0].role, "user");
@@ -1737,5 +1742,177 @@ fn subagent_completion_payload_carries_existing_sentinel_format() {
     assert!(
         second.contains("\"agent_id\":\"agent_test\""),
         "sentinel JSON includes agent_id"
+    );
+}
+
+#[test]
+fn inherited_notes_empty_when_file_missing() {
+    let section = build_inherited_notes_section(std::path::Path::new("/nonexistent"));
+    assert!(section.is_empty());
+}
+
+#[test]
+fn inherited_notes_skips_old_format_plain_text() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("notes.txt");
+    std::fs::write(&path, "\n---\nplain text note with no JSON structure").unwrap();
+    let section = build_inherited_notes_section(&path);
+    assert!(
+        section.is_empty(),
+        "old-format plain text notes should not be inherited"
+    );
+}
+
+#[test]
+fn inherited_notes_includes_constraint_and_task_scope() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("notes.txt");
+    std::fs::write(
+        &path,
+        r#"
+---
+{"content": "Do not modify src/config.rs", "kind": "constraint", "inherit": true}
+---
+{"content": "Only review, do not implement", "kind": "task_scope"}
+---
+{"content": "temp observation", "kind": "observation"}
+"#,
+    )
+    .unwrap();
+    let section = build_inherited_notes_section(&path);
+    assert!(section.contains("Do not modify src/config.rs"));
+    assert!(section.contains("Only review, do not implement"));
+    assert!(
+        !section.contains("temp observation"),
+        "observation should not be inherited by default"
+    );
+}
+
+#[test]
+fn inherited_notes_respects_explicit_inherit_false() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("notes.txt");
+    std::fs::write(
+        &path,
+        r#"
+---
+{"content": "This should not appear", "kind": "constraint", "inherit": false}
+"#,
+    )
+    .unwrap();
+    let section = build_inherited_notes_section(&path);
+    assert!(
+        section.is_empty(),
+        "explicit inherit=false should override kind default"
+    );
+}
+
+#[test]
+fn inherited_notes_duplicates_are_deduped() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("notes.txt");
+    std::fs::write(
+        &path,
+        r#"
+---
+{"content": "Reply in Chinese", "kind": "user_preference"}
+---
+{"content": "Reply in Chinese", "kind": "user_preference"}
+"#,
+    )
+    .unwrap();
+    let section = build_inherited_notes_section(&path);
+    // "Reply in Chinese" appears twice in file, but only once in output
+    let count = section.matches("Reply in Chinese").count();
+    assert_eq!(count, 1, "duplicate notes should be deduped");
+}
+
+#[test]
+fn inherited_notes_budget_truncated_by_chars() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("notes.txt");
+    let mut body = String::new();
+    for i in 1..=30 {
+        // Each note ~200 chars
+        body.push_str(&format!(
+            "\n---\n{{\"content\": \"Constraint number {}: use {} for indentation\", \"kind\": \"constraint\"}}",
+            i, i * 2,
+        ));
+    }
+    std::fs::write(&path, &body).unwrap();
+    let section = build_inherited_notes_section(&path);
+    // 4000 char budget: at ~200 chars/note, should have < 25 notes
+    assert!(section.len() <= 4500, "section must respect char budget");
+    // Should not have all 30
+    let count = section.matches("Constraint number").count();
+    assert!(count < 30, "budget should have truncated notes");
+}
+
+#[test]
+fn fresh_subagent_receives_inherited_notes() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("notes.txt");
+    std::fs::write(
+        &path,
+        "\n---\n{\"content\": \"Do not modify src/config.rs\", \"kind\": \"constraint\"}",
+    )
+    .unwrap();
+    let assignment = SubAgentAssignment::new("inspect parser".to_string(), None);
+    let messages = build_initial_subagent_messages(
+        "inspect parser",
+        &assignment,
+        &SubAgentType::Review,
+        None,
+        Some(&path),
+    );
+    let system_count = messages.iter().filter(|m| m.role == "system").count();
+    assert!(
+        system_count >= 1,
+        "fresh agent should receive system message with inherited notes"
+    );
+    let has_notes = messages
+        .iter()
+        .any(|m| message_text(m).contains("Do not modify src/config.rs"));
+    assert!(has_notes, "fresh agent must receive inherited constraint");
+}
+
+#[test]
+fn fork_agent_does_not_receive_duplicate_inherited_notes() {
+    let parent_system = SystemPrompt::Text("parent system".to_string());
+    let parent_message = Message {
+        role: "user".to_string(),
+        content: vec![ContentBlock::Text {
+            text: "original request".to_string(),
+            cache_control: None,
+        }],
+    };
+    let fork_context = SubAgentForkContext {
+        system: Some(parent_system),
+        messages: vec![parent_message.clone()],
+        structured_state_block: None,
+    };
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("notes.txt");
+    std::fs::write(
+        &path,
+        "\n---\n{\"content\": \"Some constraint\", \"kind\": \"constraint\"}",
+    )
+    .unwrap();
+    let assignment = SubAgentAssignment::new("continue work".to_string(), None);
+    let messages = build_initial_subagent_messages(
+        "continue work",
+        &assignment,
+        &SubAgentType::General,
+        Some(&fork_context),
+        Some(&path),
+    );
+    // Fork agents already inherit parent context; notes should NOT be injected again.
+    let notes_count = messages
+        .iter()
+        .filter(|m| message_text(m).contains("Inherited context from parent agent"))
+        .count();
+    assert_eq!(
+        notes_count, 0,
+        "fork agents should not receive duplicate inherited notes"
     );
 }

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -326,6 +326,7 @@ fn forked_subagent_messages_preserve_parent_prefix_then_append_task() {
         &assignment,
         &SubAgentType::General,
         Some(&fork_context),
+        None,
     );
 
     assert_eq!(
@@ -346,7 +347,7 @@ fn forked_subagent_messages_preserve_parent_prefix_then_append_task() {
 fn fresh_subagent_messages_keep_existing_single_turn_shape() {
     let assignment = SubAgentAssignment::new("list files".to_string(), None);
     let messages =
-        build_initial_subagent_messages("list files", &assignment, &SubAgentType::Explore, None);
+        build_initial_subagent_messages("list files", &assignment, &SubAgentType::Explore, None, None);
 
     assert_eq!(messages.len(), 1);
     assert_eq!(messages[0].role, "user");

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -2020,6 +2020,15 @@ async fn run_event_loop(
             if app.use_mouse_capture
                 && let Event::Mouse(mouse) = evt
             {
+                // During streaming, discard mouse movement/drag events
+                // to prevent them from flooding the input buffer
+                // and appearing as "auto-typed" garbage (#1529).
+                if app.is_loading
+                    && (matches!(mouse.kind, MouseEventKind::Moved)
+                        || matches!(mouse.kind, MouseEventKind::Drag(_)))
+                {
+                    continue;
+                }
                 let events = handle_mouse_event(app, mouse);
                 if handle_view_events(
                     terminal,
@@ -7144,6 +7153,7 @@ fn push_keyboard_enhancement_flags<W: Write>(writer: &mut W) {
                 "PushKeyboardEnhancementFlags direct write failed on Windows"
             );
         }
+        #[allow(clippy::needless_return)]
         return;
     }
     #[cfg(not(windows))]
@@ -7176,6 +7186,7 @@ pub(crate) fn pop_keyboard_enhancement_flags<W: Write>(writer: &mut W) {
                 "PopKeyboardEnhancementFlags direct write failed on Windows"
             );
         }
+        #[allow(clippy::needless_return)]
         return;
     }
     #[cfg(not(windows))]

--- a/crates/tui/src/vision/tools.rs
+++ b/crates/tui/src/vision/tools.rs
@@ -109,7 +109,11 @@ impl ToolSpec for ImageAnalyzeTool {
             .unwrap_or("Describe this image in detail.");
 
         let image_path_buf = Path::new(image_path);
+        // On Windows, `Path::is_absolute()` does not recognize `/etc/hosts`
+        // as absolute, so also reject Unix-style absolute paths explicitly.
+        let looks_like_unix_absolute = image_path.starts_with('/') && !image_path.starts_with("//");
         if image_path_buf.is_absolute()
+            || looks_like_unix_absolute
             || image_path_buf
                 .components()
                 .any(|c| matches!(c, std::path::Component::ParentDir))


### PR DESCRIPTION
## Summary

Adds optional `kind` and `inherit` fields to the `note` tool, and injects inheritable notes into sub-agent context when spawning via `agent_spawn`.

Fixes #1489 (part2).

## Why it matters

When a parent agent writes session guidance via `note`, sub-agents previously had no access to these notes. This created a knowledge gap: the parent follows constraints while the child behaves as if no constraints exist.

Now, notes with `kind=constraint`/`task_scope`/`user_preference` are automatically injected into the sub-agent's system prompt, grouped by kind, with budget control and exact dedup.

## Changes

| File | Change |
|------|--------|
| `crates/tui/src/tools/shell.rs` | Added `kind` and `inherit` to `NoteTool` schema and execute |
| `crates/tui/src/tools/subagent/mod.rs` | Added `build_inherited_notes_section()`; inject into fresh sub-agent messages |
| `crates/tui/src/tools/subagent/tests.rs` | Updated call sites for new signature |

## Design decisions

- **Default inherit by kind**: constraint/task_scope/user_preference inherit by default; observation does not
- **Explicit override**: `inherit` field overrides the kind default
- **Budget**: max 20 notes, 4000 chars, priority-ordered
- **Dedup**: exact content duplicates removed
- **Not inherited for fork agents**: fork agents already inherit parent context
- **Old-format notes**: treated as observation and not inherited

## Test plan

- [x] `cargo check -p deepseek-tui` passes
- [x] `cargo clippy -p deepseek-tui --all-targets --all-features --locked -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo test -p deepseek-tui -- tools::subagent::tests` — 87 passed
