### PR TITLE
feat(tui): persist permission rules from approval prompts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           sudo apt-get install -y libdbus-1-dev pkg-config
       - uses: Swatinem/rust-cache@v2
         with:
-          cache-bin: false
+          cache-bin: "false"
       - name: Check formatting
         run: cargo fmt --all -- --check
       # Mirror the release-workflow `parity` gate exactly. Anything that
@@ -86,7 +86,7 @@ jobs:
           sudo apt-get install -y libdbus-1-dev pkg-config
       - uses: Swatinem/rust-cache@v2
         with:
-          cache-bin: false
+          cache-bin: "false"
       - name: Run tests
         run: cargo test --workspace --all-features --locked
       - name: Lockfile drift guard
@@ -118,7 +118,7 @@ jobs:
           node-version: 20
       - uses: Swatinem/rust-cache@v2
         with:
-          cache-bin: false
+          cache-bin: "false"
       - name: Build wrapper binaries
         run: cargo build --release --locked -p deepseek-tui-cli -p deepseek-tui
       - name: Smoke wrapper install and delegated entrypoints
@@ -143,7 +143,7 @@ jobs:
           sudo apt-get install -y libdbus-1-dev pkg-config
       - uses: Swatinem/rust-cache@v2
         with:
-          cache-bin: false
+          cache-bin: "false"
       - name: Build docs
         run: cargo doc --workspace --no-deps
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1225,6 +1225,7 @@ version = "0.8.40"
 dependencies = [
  "anyhow",
  "deepseek-protocol",
+ "globset",
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1193,6 +1193,7 @@ name = "deepseek-config"
 version = "0.8.40"
 dependencies = [
  "anyhow",
+ "deepseek-execpolicy",
  "deepseek-secrets",
  "dirs",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1313,6 +1313,7 @@ dependencies = [
  "clap_complete",
  "colored",
  "crossterm 0.28.1",
+ "deepseek-execpolicy",
  "deepseek-secrets",
  "deepseek-tools",
  "dirs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1350,6 +1350,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "toml 0.9.11+spec-1.1.0",
+ "toml_edit",
  "tower-http",
  "tracing",
  "tracing-appender",
@@ -5326,6 +5327,7 @@ dependencies = [
  "indexmap",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
+ "toml_writer",
  "winnow 0.7.14",
 ]
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -153,7 +153,7 @@ sandbox_mode = "workspace-write" # read-only | workspace-write | danger-full-acc
 # command = "cargo test"
 #
 # [[permissions.rules]]
-# tool = "file_edit"
+# tool = "edit_file"
 # decision = "ask"
 # path = "src/**"
 max_subagents = 10 # optional (1-20)

--- a/config.example.toml
+++ b/config.example.toml
@@ -141,6 +141,21 @@ sandbox_mode = "workspace-write" # read-only | workspace-write | danger-full-acc
 #   auto_allow = ["cargo check", "npm run"]
 #
 # auto_allow = []
+# auto_deny = ["rm -rf"]
+#
+# Typed persistent permission rules. These are intentionally conservative:
+# shell commands use the same arity-aware matching as auto_allow, and file
+# paths are workspace-relative globs.
+#
+# [[permissions.rules]]
+# tool = "exec_shell"
+# decision = "allow" # "allow", "deny", or "ask"
+# command = "cargo test"
+#
+# [[permissions.rules]]
+# tool = "file_edit"
+# decision = "ask"
+# path = "src/**"
 max_subagents = 10 # optional (1-20)
 
 # Optional sub-agent tuning. max_concurrent overrides top-level max_subagents.

--- a/crates/app-server/src/lib.rs
+++ b/crates/app-server/src/lib.rs
@@ -9,7 +9,6 @@ use axum::{Json, Router};
 use deepseek_agent::ModelRegistry;
 use deepseek_config::{CliRuntimeOverrides, ConfigStore};
 use deepseek_core::Runtime;
-use deepseek_execpolicy::ExecPolicyEngine;
 use deepseek_hooks::{HookDispatcher, JsonlHookSink, StdoutHookSink};
 use deepseek_mcp::McpManager;
 use deepseek_protocol::{
@@ -285,7 +284,7 @@ fn build_state(config_path: Option<PathBuf>) -> Result<AppState> {
         state_store,
         Arc::new(ToolRegistry::default()),
         Arc::new(McpManager::default()),
-        ExecPolicyEngine::new(Vec::new(), Vec::new()),
+        config.exec_policy_engine(),
         hooks,
     );
 

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -8,6 +8,7 @@ description = "Config schema and precedence model for DeepSeek workspace archite
 
 [dependencies]
 anyhow.workspace = true
+deepseek-execpolicy = { path = "../execpolicy", version = "0.8.40" }
 deepseek-secrets = { path = "../secrets", version = "0.8.40" }
 dirs.workspace = true
 serde.workspace = true

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -6,6 +6,8 @@ use std::path::{Component, Path, PathBuf};
 use std::sync::OnceLock;
 
 use anyhow::{Context, Result, bail};
+use deepseek_execpolicy::{ExecPolicyEngine, Ruleset};
+pub use deepseek_execpolicy::{PermissionDecision, ToolPermissionRule};
 use deepseek_secrets::SecretSource;
 pub use deepseek_secrets::Secrets;
 use serde::{Deserialize, Serialize};
@@ -182,6 +184,19 @@ impl ProvidersToml {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct PermissionsToml {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub rules: Vec<ToolPermissionRule>,
+}
+
+impl PermissionsToml {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.rules.is_empty()
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ConfigToml {
     /// TUI-compatible DeepSeek API key. Kept at the root so both `deepseek`
@@ -205,6 +220,16 @@ pub struct ConfigToml {
     pub telemetry: Option<bool>,
     pub approval_policy: Option<String>,
     pub sandbox_mode: Option<String>,
+    /// Legacy command allow-list. Entries become `exec_shell` allow rules.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub auto_allow: Vec<String>,
+    /// Legacy command deny-list. Entries become `exec_shell` deny rules.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub auto_deny: Vec<String>,
+    /// Typed tool permission rules. First version supports tool name, command
+    /// prefix, and workspace-relative path glob matching.
+    #[serde(default, skip_serializing_if = "PermissionsToml::is_empty")]
+    pub permissions: PermissionsToml,
     #[serde(default)]
     pub providers: ProvidersToml,
     /// Per-domain network policy (#135). When absent, network tools fall back
@@ -371,6 +396,15 @@ impl ConfigToml {
         if project.sandbox_mode.is_some() {
             self.sandbox_mode = project.sandbox_mode;
         }
+        if !project.auto_allow.is_empty() {
+            self.auto_allow = project.auto_allow;
+        }
+        if !project.auto_deny.is_empty() {
+            self.auto_deny = project.auto_deny;
+        }
+        if !project.permissions.is_empty() {
+            self.permissions = project.permissions;
+        }
         // Provider is only overridden if explicitly set (non-default).
         if project.provider != ProviderKind::Deepseek || has_api_key {
             self.provider = project.provider;
@@ -419,6 +453,17 @@ impl ConfigToml {
     }
 
     #[must_use]
+    pub fn permission_ruleset(&self) -> Ruleset {
+        Ruleset::user(self.auto_allow.clone(), self.auto_deny.clone())
+            .with_rules(self.permissions.rules.clone())
+    }
+
+    #[must_use]
+    pub fn exec_policy_engine(&self) -> ExecPolicyEngine {
+        ExecPolicyEngine::with_rulesets(vec![self.permission_ruleset()])
+    }
+
+    #[must_use]
     pub fn get_value(&self, key: &str) -> Option<String> {
         match key {
             "provider" => Some(self.provider.as_str().to_string()),
@@ -435,6 +480,8 @@ impl ConfigToml {
             "telemetry" => self.telemetry.map(|v| v.to_string()),
             "approval_policy" => self.approval_policy.clone(),
             "sandbox_mode" => self.sandbox_mode.clone(),
+            "auto_allow" => serialize_string_list(&self.auto_allow),
+            "auto_deny" => serialize_string_list(&self.auto_deny),
             "providers.deepseek.api_key" => self.providers.deepseek.api_key.clone(),
             "providers.deepseek.base_url" => self.providers.deepseek.base_url.clone(),
             "providers.deepseek.model" => self.providers.deepseek.model.clone(),
@@ -1507,6 +1554,13 @@ fn serialize_http_headers(headers: &BTreeMap<String, String>) -> Option<String> 
     )
 }
 
+fn serialize_string_list(values: &[String]) -> Option<String> {
+    if values.is_empty() {
+        return None;
+    }
+    Some(values.join(","))
+}
+
 fn redact_secret(secret: &str) -> String {
     let chars: Vec<char> = secret.chars().collect();
     if chars.len() <= 16 {
@@ -1698,6 +1752,77 @@ mod tests {
         assert_eq!(policy.default, "allow");
         assert_eq!(policy.proxy, ["github.com", ".githubusercontent.com"]);
         assert!(policy.audit);
+    }
+
+    #[test]
+    fn permissions_toml_deserializes_typed_rules_and_legacy_lists() {
+        let config: ConfigToml = toml::from_str(
+            r#"
+            auto_allow = ["git status"]
+            auto_deny = ["rm -rf"]
+
+            [[permissions.rules]]
+            tool = "exec_shell"
+            decision = "allow"
+            command = "cargo test"
+
+            [[permissions.rules]]
+            tool = "file_edit"
+            decision = "ask"
+            path = "src/**"
+            "#,
+        )
+        .expect("permissions toml");
+
+        assert_eq!(config.auto_allow, ["git status"]);
+        assert_eq!(config.auto_deny, ["rm -rf"]);
+        assert_eq!(config.permissions.rules.len(), 2);
+        assert_eq!(
+            config.permissions.rules[0],
+            ToolPermissionRule::exec_shell(PermissionDecision::Allow, "cargo test")
+        );
+        assert_eq!(
+            config.permissions.rules[1],
+            ToolPermissionRule::file_path("file_edit", PermissionDecision::Ask, "src/**")
+        );
+    }
+
+    #[test]
+    fn config_builds_exec_policy_engine_with_legacy_and_typed_rules() {
+        let config: ConfigToml = toml::from_str(
+            r#"
+            auto_allow = ["git status"]
+
+            [[permissions.rules]]
+            tool = "exec_shell"
+            decision = "deny"
+            command = "git status --dangerous"
+            "#,
+        )
+        .expect("permissions toml");
+        let engine = config.exec_policy_engine();
+
+        let allowed = engine
+            .check(deepseek_execpolicy::ExecPolicyContext {
+                command: "git status --porcelain",
+                cwd: ".",
+                ask_for_approval: deepseek_execpolicy::AskForApproval::UnlessTrusted,
+                sandbox_mode: Some("workspace-write"),
+            })
+            .expect("policy decision");
+        assert!(allowed.allow);
+        assert!(!allowed.requires_approval);
+
+        let denied = engine
+            .check(deepseek_execpolicy::ExecPolicyContext {
+                command: "git status --dangerous",
+                cwd: ".",
+                ask_for_approval: deepseek_execpolicy::AskForApproval::UnlessTrusted,
+                sandbox_mode: Some("workspace-write"),
+            })
+            .expect("policy decision");
+        assert!(!denied.allow);
+        assert_eq!(denied.requirement.phase(), "forbidden");
     }
 
     struct EnvGuard {

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1767,7 +1767,7 @@ mod tests {
             command = "cargo test"
 
             [[permissions.rules]]
-            tool = "file_edit"
+            tool = "edit_file"
             decision = "ask"
             path = "src/**"
             "#,
@@ -1783,7 +1783,7 @@ mod tests {
         );
         assert_eq!(
             config.permissions.rules[1],
-            ToolPermissionRule::file_path("file_edit", PermissionDecision::Ask, "src/**")
+            ToolPermissionRule::file_path("edit_file", PermissionDecision::Ask, "src/**")
         );
     }
 

--- a/crates/execpolicy/Cargo.toml
+++ b/crates/execpolicy/Cargo.toml
@@ -9,4 +9,5 @@ description = "Execution policy and approval model parity for DeepSeek workspace
 [dependencies]
 anyhow.workspace = true
 deepseek-protocol = { path = "../protocol", version = "0.8.40" }
+globset = "0.4.18"
 serde.workspace = true

--- a/crates/execpolicy/src/lib.rs
+++ b/crates/execpolicy/src/lib.rs
@@ -433,6 +433,15 @@ impl ExecPolicyEngine {
                     proposed_network_policy_amendments: vec![],
                 }
             }
+            AskForApproval::OnRequest
+                if matches!(tool_rule.decision, Some(PermissionDecision::Allow)) =>
+            {
+                ExecApprovalRequirement::NeedsApproval {
+                    reason: "Approval requested by policy mode.".to_string(),
+                    proposed_execpolicy_amendment: None,
+                    proposed_network_policy_amendments: vec![],
+                }
+            }
             _ if matches!(tool_rule.decision, Some(PermissionDecision::Allow)) => {
                 ExecApprovalRequirement::Skip {
                     bypass_sandbox: false,

--- a/crates/execpolicy/src/lib.rs
+++ b/crates/execpolicy/src/lib.rs
@@ -276,6 +276,7 @@ pub struct ExecPolicyEngine {
     /// Layered rulesets (builtin → agent → user). When non-empty, takes precedence
     /// over the legacy flat lists below.
     rulesets: Vec<Ruleset>,
+    layered_rules: Vec<LayeredToolPermissionRule>,
     /// Legacy flat lists kept for backward compatibility with `new()`.
     trusted_prefixes: Vec<String>,
     denied_prefixes: Vec<String>,
@@ -287,8 +288,11 @@ pub struct ExecPolicyEngine {
 impl ExecPolicyEngine {
     /// Legacy constructor: wraps the two vecs into a User-layer ruleset.
     pub fn new(trusted_prefixes: Vec<String>, denied_prefixes: Vec<String>) -> Self {
+        let layered_rules =
+            build_layered_permission_rules(&[], &trusted_prefixes, &denied_prefixes);
         Self {
             rulesets: vec![],
+            layered_rules,
             trusted_prefixes,
             denied_prefixes,
             approved_for_session: HashSet::new(),
@@ -300,8 +304,10 @@ impl ExecPolicyEngine {
     /// Rulesets are sorted by layer priority on construction.
     pub fn with_rulesets(mut rulesets: Vec<Ruleset>) -> Self {
         rulesets.sort_by_key(|r| r.layer);
+        let layered_rules = build_layered_permission_rules(&rulesets, &[], &[]);
         Self {
             rulesets,
+            layered_rules,
             trusted_prefixes: vec![],
             denied_prefixes: vec![],
             approved_for_session: HashSet::new(),
@@ -313,42 +319,15 @@ impl ExecPolicyEngine {
     pub fn add_ruleset(&mut self, ruleset: Ruleset) {
         self.rulesets.push(ruleset);
         self.rulesets.sort_by_key(|r| r.layer);
-    }
-
-    fn layered_permission_rules(&self) -> Vec<LayeredToolPermissionRule> {
-        let mut rules = Vec::new();
-        if self.rulesets.is_empty() {
-            rules.extend(legacy_command_rules(
-                RulesetLayer::User,
-                &self.trusted_prefixes,
-                &self.denied_prefixes,
-            ));
-            return rules;
-        }
-
-        for ruleset in &self.rulesets {
-            rules.extend(
-                ruleset
-                    .rules
-                    .iter()
-                    .cloned()
-                    .map(|rule| LayeredToolPermissionRule {
-                        layer: ruleset.layer,
-                        rule,
-                    }),
-            );
-            rules.extend(legacy_command_rules(
-                ruleset.layer,
-                &ruleset.trusted_prefixes,
-                &ruleset.denied_prefixes,
-            ));
-        }
-        rules.extend(legacy_command_rules(
-            RulesetLayer::User,
+        self.layered_rules = build_layered_permission_rules(
+            &self.rulesets,
             &self.trusted_prefixes,
             &self.denied_prefixes,
-        ));
-        rules
+        );
+    }
+
+    fn layered_permission_rules(&self) -> &[LayeredToolPermissionRule] {
+        &self.layered_rules
     }
 
     pub fn remember_session_approval(&mut self, approval_key: String) {
@@ -361,7 +340,7 @@ impl ExecPolicyEngine {
 
     #[must_use]
     pub fn check_tool_permission(&self, ctx: ToolPermissionContext<'_>) -> ToolPermissionCheck {
-        let mut best: Option<(LayeredToolPermissionRule, usize)> = None;
+        let mut best: Option<(&LayeredToolPermissionRule, usize)> = None;
 
         for candidate in self.layered_permission_rules() {
             if !tool_rule_matches(&candidate.rule, &ctx, &self.arity_dict) {
@@ -369,7 +348,7 @@ impl ExecPolicyEngine {
             }
             let specificity = rule_specificity(&candidate.rule);
             let should_replace = best.as_ref().is_none_or(|(current, current_specificity)| {
-                compare_rule_priority(&candidate, specificity, current, *current_specificity)
+                compare_rule_priority(candidate, specificity, current, *current_specificity)
             });
             if should_replace {
                 best = Some((candidate, specificity));
@@ -381,7 +360,7 @@ impl ExecPolicyEngine {
                 decision: Some(matched.rule.decision),
                 matched_rule: Some(MatchedToolPermissionRule {
                     layer: matched.layer,
-                    rule: matched.rule,
+                    rule: matched.rule.clone(),
                 }),
             },
             None => ToolPermissionCheck::unmatched(),
@@ -502,6 +481,46 @@ fn legacy_command_rules(
                 }),
         )
         .collect()
+}
+
+fn build_layered_permission_rules(
+    rulesets: &[Ruleset],
+    trusted_prefixes: &[String],
+    denied_prefixes: &[String],
+) -> Vec<LayeredToolPermissionRule> {
+    let mut rules = Vec::new();
+    if rulesets.is_empty() {
+        rules.extend(legacy_command_rules(
+            RulesetLayer::User,
+            trusted_prefixes,
+            denied_prefixes,
+        ));
+        return rules;
+    }
+
+    for ruleset in rulesets {
+        rules.extend(
+            ruleset
+                .rules
+                .iter()
+                .cloned()
+                .map(|rule| LayeredToolPermissionRule {
+                    layer: ruleset.layer,
+                    rule,
+                }),
+        );
+        rules.extend(legacy_command_rules(
+            ruleset.layer,
+            &ruleset.trusted_prefixes,
+            &ruleset.denied_prefixes,
+        ));
+    }
+    rules.extend(legacy_command_rules(
+        RulesetLayer::User,
+        trusted_prefixes,
+        denied_prefixes,
+    ));
+    rules
 }
 
 fn compare_rule_priority(

--- a/crates/execpolicy/src/lib.rs
+++ b/crates/execpolicy/src/lib.rs
@@ -9,8 +9,8 @@ use globset::GlobBuilder;
 use serde::{Deserialize, Serialize};
 
 /// Priority layer for a permission ruleset. Higher ordinal = higher priority.
-/// Deny rules still win across layers; for non-deny ties the higher-priority
-/// layer wins before pattern specificity is considered.
+/// Deny rules still win across layers. For non-deny matches, higher-priority
+/// layers win first, then narrower patterns, then ask/allow precedence.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum RulesetLayer {
@@ -510,14 +510,23 @@ fn compare_rule_priority(
     current: &LayeredToolPermissionRule,
     current_specificity: usize,
 ) -> bool {
+    match (candidate.rule.decision, current.rule.decision) {
+        (PermissionDecision::Deny, PermissionDecision::Deny) => {
+            return (candidate.layer, candidate_specificity) > (current.layer, current_specificity);
+        }
+        (PermissionDecision::Deny, _) => return true,
+        (_, PermissionDecision::Deny) => return false,
+        _ => {}
+    }
+
     (
-        candidate.rule.decision.precedence(),
         candidate.layer,
         candidate_specificity,
+        candidate.rule.decision.precedence(),
     ) > (
-        current.rule.decision.precedence(),
         current.layer,
         current_specificity,
+        current.rule.decision.precedence(),
     )
 }
 
@@ -857,6 +866,25 @@ mod tests {
     }
 
     #[test]
+    fn more_specific_allow_rule_wins_over_broad_ask_rule() {
+        let engine =
+            ExecPolicyEngine::with_rulesets(vec![Ruleset::user(vec![], vec![]).with_rules(vec![
+                ToolPermissionRule::exec_shell(PermissionDecision::Ask, "cargo test"),
+                ToolPermissionRule::exec_shell(PermissionDecision::Allow, "cargo test --workspace"),
+            ])]);
+
+        let decision = engine.check(exec_ctx("cargo test --workspace")).unwrap();
+
+        assert!(decision.allow);
+        assert!(!decision.requires_approval);
+        assert_eq!(decision.requirement.phase(), "allowed");
+        assert_eq!(
+            decision.matched_rule.as_deref(),
+            Some("tool 'exec_shell', command 'cargo test --workspace'")
+        );
+    }
+
+    #[test]
     fn ask_rule_overrides_on_failure_policy() {
         let engine =
             ExecPolicyEngine::with_rulesets(vec![Ruleset::user(vec![], vec![]).with_rules(vec![
@@ -891,6 +919,35 @@ mod tests {
         });
 
         assert_eq!(decision.decision, Some(PermissionDecision::Allow));
+    }
+
+    #[test]
+    fn exact_path_allow_rule_wins_over_broad_path_ask_rule() {
+        let engine =
+            ExecPolicyEngine::with_rulesets(vec![Ruleset::user(vec![], vec![]).with_rules(vec![
+                ToolPermissionRule::file_path("file_edit", PermissionDecision::Ask, "src/**"),
+                ToolPermissionRule::file_path(
+                    "file_edit",
+                    PermissionDecision::Allow,
+                    "src/main.rs",
+                ),
+            ])]);
+
+        let decision = engine.check_tool_permission(ToolPermissionContext {
+            tool: "file_edit",
+            command: None,
+            path: Some("src/main.rs"),
+        });
+
+        assert_eq!(decision.decision, Some(PermissionDecision::Allow));
+        let label = decision
+            .matched_rule
+            .as_ref()
+            .map(|matched| matched.rule.pattern_label());
+        assert_eq!(
+            label.as_deref(),
+            Some("tool 'file_edit', path 'src/main.rs'")
+        );
     }
 
     #[test]

--- a/crates/execpolicy/src/lib.rs
+++ b/crates/execpolicy/src/lib.rs
@@ -5,6 +5,7 @@ use std::collections::HashSet;
 use anyhow::Result;
 use bash_arity::BashArityDict;
 use deepseek_protocol::{NetworkPolicyAmendment, NetworkPolicyRuleAction};
+use globset::GlobBuilder;
 use serde::{Deserialize, Serialize};
 
 /// Priority layer for a permission ruleset. Higher ordinal = higher priority.
@@ -565,35 +566,11 @@ fn path_pattern_matches(pattern: &str, path: &str) -> bool {
     if !pattern.contains('*') && !pattern.contains('?') {
         return pattern == path;
     }
-    glob_match(pattern.as_bytes(), path.as_bytes())
-}
-
-fn glob_match(pattern: &[u8], path: &[u8]) -> bool {
-    if pattern.is_empty() {
-        return path.is_empty();
-    }
-
-    match pattern[0] {
-        b'*' if pattern.get(1) == Some(&b'*') => {
-            let rest = &pattern[2..];
-            (0..=path.len()).any(|idx| glob_match(rest, &path[idx..]))
-        }
-        b'*' => {
-            if glob_match(&pattern[1..], path) {
-                return true;
-            }
-            let mut idx = 0;
-            while idx < path.len() && path[idx] != b'/' {
-                idx += 1;
-                if glob_match(&pattern[1..], &path[idx..]) {
-                    return true;
-                }
-            }
-            false
-        }
-        b'?' => !path.is_empty() && path[0] != b'/' && glob_match(&pattern[1..], &path[1..]),
-        literal => !path.is_empty() && path[0] == literal && glob_match(&pattern[1..], &path[1..]),
-    }
+    GlobBuilder::new(&pattern)
+        .literal_separator(true)
+        .build()
+        .map(|glob| glob.compile_matcher().is_match(path))
+        .unwrap_or(false)
 }
 
 fn rule_specificity(rule: &ToolPermissionRule) -> usize {
@@ -629,7 +606,9 @@ fn normalize_path_pattern(value: &str) -> String {
         match segment {
             "" | "." => {}
             ".." => {
-                if segments.is_empty() || segments.last() == Some(&"..") {
+                if absolute {
+                    segments.pop();
+                } else if segments.is_empty() || segments.last() == Some(&"..") {
                     segments.push(segment);
                 } else {
                     segments.pop();
@@ -916,6 +895,8 @@ mod tests {
         assert!(path_pattern_matches("src/**", "src/./lib.rs"));
         assert!(!path_pattern_matches("src/**", "src/../secret.txt"));
         assert!(!path_pattern_matches("src/**", "../src/lib.rs"));
+        assert!(path_pattern_matches("/foo", "/../foo"));
+        assert!(!path_pattern_matches("/src/**", "/src/../secret.txt"));
     }
 
     #[test]

--- a/crates/execpolicy/src/lib.rs
+++ b/crates/execpolicy/src/lib.rs
@@ -8,7 +8,8 @@ use deepseek_protocol::{NetworkPolicyAmendment, NetworkPolicyRuleAction};
 use serde::{Deserialize, Serialize};
 
 /// Priority layer for a permission ruleset. Higher ordinal = higher priority.
-/// On conflict, the highest-priority layer's longest matching prefix wins.
+/// Deny rules still win across layers; for non-deny ties the higher-priority
+/// layer wins before pattern specificity is considered.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum RulesetLayer {
@@ -17,12 +18,100 @@ pub enum RulesetLayer {
     User = 2,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PermissionDecision {
+    Allow,
+    Deny,
+    Ask,
+}
+
+impl PermissionDecision {
+    fn precedence(self) -> u8 {
+        match self {
+            Self::Deny => 3,
+            Self::Ask => 2,
+            Self::Allow => 1,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Allow => "allow",
+            Self::Deny => "deny",
+            Self::Ask => "ask",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ToolPermissionRule {
+    pub tool: String,
+    pub decision: PermissionDecision,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+}
+
+impl ToolPermissionRule {
+    #[must_use]
+    pub fn new(tool: impl Into<String>, decision: PermissionDecision) -> Self {
+        Self {
+            tool: tool.into(),
+            decision,
+            command: None,
+            path: None,
+        }
+    }
+
+    #[must_use]
+    pub fn exec_shell(decision: PermissionDecision, command: impl Into<String>) -> Self {
+        Self {
+            tool: "exec_shell".to_string(),
+            decision,
+            command: Some(command.into()),
+            path: None,
+        }
+    }
+
+    #[must_use]
+    pub fn file_path(
+        tool: impl Into<String>,
+        decision: PermissionDecision,
+        path: impl Into<String>,
+    ) -> Self {
+        Self {
+            tool: tool.into(),
+            decision,
+            command: None,
+            path: Some(path.into()),
+        }
+    }
+
+    #[must_use]
+    pub fn pattern_label(&self) -> String {
+        let mut parts = vec![format!("tool '{}'", self.tool)];
+        if let Some(command) = self.command.as_deref() {
+            parts.push(format!("command '{command}'"));
+        }
+        if let Some(path) = self.path.as_deref() {
+            parts.push(format!("path '{path}'"));
+        }
+        parts.join(", ")
+    }
+}
+
 /// A named set of allow/deny prefix rules at a given priority layer.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Ruleset {
     pub layer: RulesetLayer,
+    #[serde(default)]
     pub trusted_prefixes: Vec<String>,
+    #[serde(default)]
     pub denied_prefixes: Vec<String>,
+    #[serde(default)]
+    pub rules: Vec<ToolPermissionRule>,
 }
 
 impl Ruleset {
@@ -31,6 +120,7 @@ impl Ruleset {
             layer: RulesetLayer::BuiltinDefault,
             trusted_prefixes: vec![],
             denied_prefixes: vec![],
+            rules: vec![],
         }
     }
 
@@ -39,6 +129,7 @@ impl Ruleset {
             layer: RulesetLayer::Agent,
             trusted_prefixes: trusted,
             denied_prefixes: denied,
+            rules: vec![],
         }
     }
 
@@ -47,7 +138,14 @@ impl Ruleset {
             layer: RulesetLayer::User,
             trusted_prefixes: trusted,
             denied_prefixes: denied,
+            rules: vec![],
         }
+    }
+
+    #[must_use]
+    pub fn with_rules(mut self, rules: Vec<ToolPermissionRule>) -> Self {
+        self.rules = rules;
+        self
     }
 }
 
@@ -126,6 +224,52 @@ pub struct ExecPolicyContext<'a> {
     pub sandbox_mode: Option<&'a str>,
 }
 
+#[derive(Debug, Clone)]
+pub struct ToolPermissionContext<'a> {
+    pub tool: &'a str,
+    pub command: Option<&'a str>,
+    pub path: Option<&'a str>,
+}
+
+impl<'a> ToolPermissionContext<'a> {
+    #[must_use]
+    pub fn exec_shell(command: &'a str) -> Self {
+        Self {
+            tool: "exec_shell",
+            command: Some(command),
+            path: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MatchedToolPermissionRule {
+    pub layer: RulesetLayer,
+    pub rule: ToolPermissionRule,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ToolPermissionCheck {
+    pub decision: Option<PermissionDecision>,
+    pub matched_rule: Option<MatchedToolPermissionRule>,
+}
+
+impl ToolPermissionCheck {
+    #[must_use]
+    pub fn unmatched() -> Self {
+        Self {
+            decision: None,
+            matched_rule: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct LayeredToolPermissionRule {
+    layer: RulesetLayer,
+    rule: ToolPermissionRule,
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct ExecPolicyEngine {
     /// Layered rulesets (builtin → agent → user). When non-empty, takes precedence
@@ -170,28 +314,40 @@ impl ExecPolicyEngine {
         self.rulesets.sort_by_key(|r| r.layer);
     }
 
-    /// Resolve the effective trusted/denied prefix sets by merging all rulesets.
-    ///
-    /// Collects all prefixes from every layer (builtin → agent → user) into flat
-    /// trusted/denied lists. The `check()` method then applies deny-always-wins
-    /// semantics: any matching deny prefix blocks the command regardless of layer.
-    /// Trusted rules are only consulted after deny checks pass.
-    fn resolve_prefixes(&self) -> (Vec<String>, Vec<String>) {
+    fn layered_permission_rules(&self) -> Vec<LayeredToolPermissionRule> {
+        let mut rules = Vec::new();
         if self.rulesets.is_empty() {
-            return (self.trusted_prefixes.clone(), self.denied_prefixes.clone());
+            rules.extend(legacy_command_rules(
+                RulesetLayer::User,
+                &self.trusted_prefixes,
+                &self.denied_prefixes,
+            ));
+            return rules;
         }
-        // Collect all trusted/denied across all layers, highest-priority last so they
-        // shadow lower-priority entries with the same prefix.
-        let mut trusted: Vec<String> = vec![];
-        let mut denied: Vec<String> = vec![];
-        for rs in &self.rulesets {
-            trusted.extend(rs.trusted_prefixes.iter().cloned());
-            denied.extend(rs.denied_prefixes.iter().cloned());
+
+        for ruleset in &self.rulesets {
+            rules.extend(
+                ruleset
+                    .rules
+                    .iter()
+                    .cloned()
+                    .map(|rule| LayeredToolPermissionRule {
+                        layer: ruleset.layer,
+                        rule,
+                    }),
+            );
+            rules.extend(legacy_command_rules(
+                ruleset.layer,
+                &ruleset.trusted_prefixes,
+                &ruleset.denied_prefixes,
+            ));
         }
-        // Also merge legacy flat lists as user-layer.
-        trusted.extend(self.trusted_prefixes.iter().cloned());
-        denied.extend(self.denied_prefixes.iter().cloned());
-        (trusted, denied)
+        rules.extend(legacy_command_rules(
+            RulesetLayer::User,
+            &self.trusted_prefixes,
+            &self.denied_prefixes,
+        ));
+        rules
     }
 
     pub fn remember_session_approval(&mut self, approval_key: String) {
@@ -202,62 +358,95 @@ impl ExecPolicyEngine {
         self.approved_for_session.contains(approval_key)
     }
 
+    #[must_use]
+    pub fn check_tool_permission(&self, ctx: ToolPermissionContext<'_>) -> ToolPermissionCheck {
+        let mut best: Option<(LayeredToolPermissionRule, usize)> = None;
+
+        for candidate in self.layered_permission_rules() {
+            if !tool_rule_matches(&candidate.rule, &ctx, &self.arity_dict) {
+                continue;
+            }
+            let specificity = rule_specificity(&candidate.rule);
+            let should_replace = best.as_ref().is_none_or(|(current, current_specificity)| {
+                compare_rule_priority(&candidate, specificity, current, *current_specificity)
+            });
+            if should_replace {
+                best = Some((candidate, specificity));
+            }
+        }
+
+        match best {
+            Some((matched, _)) => ToolPermissionCheck {
+                decision: Some(matched.rule.decision),
+                matched_rule: Some(MatchedToolPermissionRule {
+                    layer: matched.layer,
+                    rule: matched.rule,
+                }),
+            },
+            None => ToolPermissionCheck::unmatched(),
+        }
+    }
+
     pub fn check(&self, ctx: ExecPolicyContext<'_>) -> Result<ExecPolicyDecision> {
-        let normalized = normalize_command(ctx.command);
-        let (trusted_prefixes, denied_prefixes) = self.resolve_prefixes();
-        // Deny rules use simple prefix matching (no arity semantics needed).
-        if let Some(rule) = denied_prefixes
-            .iter()
-            .find(|rule| normalized.starts_with(&normalize_command(rule)))
+        let tool_rule = self.check_tool_permission(ToolPermissionContext::exec_shell(ctx.command));
+        if let Some(matched) = tool_rule
+            .matched_rule
+            .as_ref()
+            .filter(|matched| matched.rule.decision == PermissionDecision::Deny)
         {
             return Ok(ExecPolicyDecision {
                 allow: false,
                 requires_approval: false,
-                matched_rule: Some(rule.clone()),
+                matched_rule: Some(matched.rule.pattern_label()),
                 requirement: ExecApprovalRequirement::Forbidden {
-                    reason: format!("Command blocked by denied prefix rule '{rule}'"),
+                    reason: format!(
+                        "Command blocked by {} rule ({})",
+                        matched.rule.decision.as_str(),
+                        matched.rule.pattern_label()
+                    ),
                 },
             });
         }
-
-        // Allow (trusted) rules use arity-aware prefix matching so that
-        // `auto_allow = ["git status"]` matches `git status -s` but NOT
-        // `git push origin main`.
-        let trusted_rule = trusted_prefixes
-            .iter()
-            .find(|rule| self.arity_dict.allow_rule_matches(rule, ctx.command))
-            .cloned();
-        let is_trusted = trusted_rule.is_some();
 
         let requirement = match ctx.ask_for_approval {
             AskForApproval::Never => ExecApprovalRequirement::Skip {
                 bypass_sandbox: false,
                 proposed_execpolicy_amendment: None,
             },
-            AskForApproval::UnlessTrusted if is_trusted => ExecApprovalRequirement::Skip {
-                bypass_sandbox: false,
-                proposed_execpolicy_amendment: None,
+            AskForApproval::Reject { rules, .. } if rules => ExecApprovalRequirement::Forbidden {
+                reason: "Policy is configured to reject rule-exceptions.".to_string(),
             },
+            _ if matches!(tool_rule.decision, Some(PermissionDecision::Ask)) => {
+                ExecApprovalRequirement::NeedsApproval {
+                    reason: tool_rule
+                        .matched_rule
+                        .as_ref()
+                        .map(|matched| {
+                            format!(
+                                "Approval required by ask rule ({})",
+                                matched.rule.pattern_label()
+                            )
+                        })
+                        .unwrap_or_else(|| "Approval required by ask rule.".to_string()),
+                    proposed_execpolicy_amendment: None,
+                    proposed_network_policy_amendments: vec![],
+                }
+            }
+            _ if matches!(tool_rule.decision, Some(PermissionDecision::Allow)) => {
+                ExecApprovalRequirement::Skip {
+                    bypass_sandbox: false,
+                    proposed_execpolicy_amendment: None,
+                }
+            }
             AskForApproval::OnFailure => ExecApprovalRequirement::Skip {
                 bypass_sandbox: false,
                 proposed_execpolicy_amendment: None,
             },
-            AskForApproval::Reject { rules, .. } if rules => ExecApprovalRequirement::Forbidden {
-                reason: "Policy is configured to reject rule-exceptions.".to_string(),
-            },
             _ => ExecApprovalRequirement::NeedsApproval {
-                reason: if is_trusted {
-                    "Approval requested by policy mode.".to_string()
-                } else {
-                    "Unmatched command prefix requires approval.".to_string()
-                },
-                proposed_execpolicy_amendment: if is_trusted {
-                    None
-                } else {
-                    Some(ExecPolicyAmendment {
-                        prefixes: vec![first_token(ctx.command)],
-                    })
-                },
+                reason: "Unmatched command prefix requires approval.".to_string(),
+                proposed_execpolicy_amendment: Some(ExecPolicyAmendment {
+                    prefixes: vec![first_token(ctx.command)],
+                }),
                 proposed_network_policy_amendments: vec![NetworkPolicyAmendment {
                     host: ctx.cwd.to_string(),
                     action: NetworkPolicyRuleAction::Allow,
@@ -274,14 +463,190 @@ impl ExecPolicyEngine {
         Ok(ExecPolicyDecision {
             allow,
             requires_approval,
-            matched_rule: trusted_rule,
+            matched_rule: tool_rule
+                .matched_rule
+                .as_ref()
+                .map(|matched| matched.rule.pattern_label()),
             requirement,
         })
     }
 }
 
+fn legacy_command_rules(
+    layer: RulesetLayer,
+    trusted_prefixes: &[String],
+    denied_prefixes: &[String],
+) -> Vec<LayeredToolPermissionRule> {
+    trusted_prefixes
+        .iter()
+        .map(|command| LayeredToolPermissionRule {
+            layer,
+            rule: ToolPermissionRule::exec_shell(PermissionDecision::Allow, command.clone()),
+        })
+        .chain(
+            denied_prefixes
+                .iter()
+                .map(|command| LayeredToolPermissionRule {
+                    layer,
+                    rule: ToolPermissionRule::exec_shell(PermissionDecision::Deny, command.clone()),
+                }),
+        )
+        .collect()
+}
+
+fn compare_rule_priority(
+    candidate: &LayeredToolPermissionRule,
+    candidate_specificity: usize,
+    current: &LayeredToolPermissionRule,
+    current_specificity: usize,
+) -> bool {
+    (
+        candidate.rule.decision.precedence(),
+        candidate.layer,
+        candidate_specificity,
+    ) > (
+        current.rule.decision.precedence(),
+        current.layer,
+        current_specificity,
+    )
+}
+
+fn tool_rule_matches(
+    rule: &ToolPermissionRule,
+    ctx: &ToolPermissionContext<'_>,
+    arity_dict: &BashArityDict,
+) -> bool {
+    if !rule.tool.eq_ignore_ascii_case(ctx.tool) {
+        return false;
+    }
+    if let Some(command_rule) = rule.command.as_deref() {
+        let Some(command) = ctx.command else {
+            return false;
+        };
+        if !command_rule_matches(rule.decision, command_rule, command, arity_dict) {
+            return false;
+        }
+    }
+    if let Some(path_rule) = rule.path.as_deref() {
+        let Some(path) = ctx.path else {
+            return false;
+        };
+        if !path_pattern_matches(path_rule, path) {
+            return false;
+        }
+    }
+    true
+}
+
+fn command_rule_matches(
+    decision: PermissionDecision,
+    pattern: &str,
+    command: &str,
+    arity_dict: &BashArityDict,
+) -> bool {
+    match decision {
+        PermissionDecision::Deny => {
+            normalize_command(command).starts_with(&normalize_command(pattern))
+        }
+        PermissionDecision::Allow | PermissionDecision::Ask => {
+            arity_dict.allow_rule_matches(pattern, command)
+        }
+    }
+}
+
+fn path_pattern_matches(pattern: &str, path: &str) -> bool {
+    let pattern = normalize_path_pattern(pattern);
+    let path = normalize_path_pattern(path);
+    if let Some(prefix) = pattern.strip_suffix("/**")
+        && (path == prefix || path.starts_with(&format!("{prefix}/")))
+    {
+        return true;
+    }
+    if !pattern.contains('*') && !pattern.contains('?') {
+        return pattern == path;
+    }
+    glob_match(pattern.as_bytes(), path.as_bytes())
+}
+
+fn glob_match(pattern: &[u8], path: &[u8]) -> bool {
+    if pattern.is_empty() {
+        return path.is_empty();
+    }
+
+    match pattern[0] {
+        b'*' if pattern.get(1) == Some(&b'*') => {
+            let rest = &pattern[2..];
+            (0..=path.len()).any(|idx| glob_match(rest, &path[idx..]))
+        }
+        b'*' => {
+            if glob_match(&pattern[1..], path) {
+                return true;
+            }
+            let mut idx = 0;
+            while idx < path.len() && path[idx] != b'/' {
+                idx += 1;
+                if glob_match(&pattern[1..], &path[idx..]) {
+                    return true;
+                }
+            }
+            false
+        }
+        b'?' => !path.is_empty() && path[0] != b'/' && glob_match(&pattern[1..], &path[1..]),
+        literal => !path.is_empty() && path[0] == literal && glob_match(&pattern[1..], &path[1..]),
+    }
+}
+
+fn rule_specificity(rule: &ToolPermissionRule) -> usize {
+    let mut score = rule.tool.len();
+    if let Some(command) = rule.command.as_deref() {
+        score += 1_000 + non_wildcard_len(command);
+    }
+    if let Some(path) = rule.path.as_deref() {
+        score += 1_000 + non_wildcard_len(path);
+    }
+    score
+}
+
+fn non_wildcard_len(value: &str) -> usize {
+    value.chars().filter(|ch| *ch != '*' && *ch != '?').count()
+}
+
 fn normalize_command(value: &str) -> String {
-    value.trim().to_ascii_lowercase()
+    value
+        .trim()
+        .to_ascii_lowercase()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn normalize_path_pattern(value: &str) -> String {
+    let raw = value.trim().replace('\\', "/");
+    let absolute = raw.starts_with('/');
+    let mut segments = Vec::new();
+
+    for segment in raw.split('/') {
+        match segment {
+            "" | "." => {}
+            ".." => {
+                if segments.is_empty() || segments.last() == Some(&"..") {
+                    segments.push(segment);
+                } else {
+                    segments.pop();
+                }
+            }
+            _ => segments.push(segment),
+        }
+    }
+
+    let normalized = segments.join("/");
+    if absolute && normalized.is_empty() {
+        "/".to_string()
+    } else if absolute {
+        format!("/{normalized}")
+    } else {
+        normalized
+    }
 }
 
 fn first_token(command: &str) -> String {
@@ -305,6 +670,10 @@ mod tests {
         }
     }
 
+    fn exec_ctx(command: &str) -> ExecPolicyContext<'_> {
+        ctx(command, AskForApproval::UnlessTrusted)
+    }
+
     #[test]
     fn trusted_prefix_skips_approval_when_policy_is_unless_trusted() {
         let engine = ExecPolicyEngine::new(vec!["git status".to_string()], vec![]);
@@ -315,7 +684,10 @@ mod tests {
 
         assert!(decision.allow);
         assert!(!decision.requires_approval);
-        assert_eq!(decision.matched_rule.as_deref(), Some("git status"));
+        assert_eq!(
+            decision.matched_rule.as_deref(),
+            Some("tool 'exec_shell', command 'git status'")
+        );
         assert!(matches!(
             decision.requirement,
             ExecApprovalRequirement::Skip {
@@ -338,14 +710,31 @@ mod tests {
 
         assert!(!decision.allow);
         assert!(!decision.requires_approval);
-        assert_eq!(decision.matched_rule.as_deref(), Some("git status"));
+        assert_eq!(
+            decision.matched_rule.as_deref(),
+            Some("tool 'exec_shell', command 'git status'")
+        );
         assert!(matches!(
             decision.requirement,
             ExecApprovalRequirement::Forbidden { .. }
         ));
         assert_eq!(
             decision.reason(),
-            "Command blocked by denied prefix rule 'git status'"
+            "Command blocked by deny rule (tool 'exec_shell', command 'git status')"
+        );
+    }
+
+    #[test]
+    fn legacy_auto_allow_prefixes_become_exec_shell_rules() {
+        let engine = ExecPolicyEngine::new(vec!["git status".to_string()], vec![]);
+
+        let decision = engine.check(exec_ctx("git status --porcelain")).unwrap();
+
+        assert!(decision.allow);
+        assert!(!decision.requires_approval);
+        assert_eq!(
+            decision.matched_rule.as_deref(),
+            Some("tool 'exec_shell', command 'git status'")
         );
     }
 
@@ -389,7 +778,10 @@ mod tests {
 
         assert!(decision.allow);
         assert!(decision.requires_approval);
-        assert_eq!(decision.matched_rule.as_deref(), Some("cargo test"));
+        assert_eq!(
+            decision.matched_rule.as_deref(),
+            Some("tool 'exec_shell', command 'cargo test'")
+        );
         match decision.requirement {
             ExecApprovalRequirement::NeedsApproval {
                 proposed_execpolicy_amendment,
@@ -422,5 +814,123 @@ mod tests {
             decision.reason(),
             "Policy is configured to reject rule-exceptions."
         );
+    }
+
+    #[test]
+    fn legacy_auto_allow_uses_bash_arity() {
+        let engine = ExecPolicyEngine::new(vec!["git status".to_string()], vec![]);
+
+        let decision = engine.check(exec_ctx("git push origin main")).unwrap();
+
+        assert!(decision.requires_approval);
+        assert_eq!(decision.matched_rule, None);
+    }
+
+    #[test]
+    fn deny_rule_wins_over_user_allow_rule() {
+        let engine = ExecPolicyEngine::with_rulesets(vec![
+            Ruleset::builtin_default().with_rules(vec![ToolPermissionRule::exec_shell(
+                PermissionDecision::Deny,
+                "cargo",
+            )]),
+            Ruleset::user(vec![], vec![]).with_rules(vec![ToolPermissionRule::exec_shell(
+                PermissionDecision::Allow,
+                "cargo test",
+            )]),
+        ]);
+
+        let decision = engine.check(exec_ctx("cargo test --workspace")).unwrap();
+
+        assert!(!decision.allow);
+        assert_eq!(decision.requirement.phase(), "forbidden");
+        assert_eq!(
+            decision.matched_rule.as_deref(),
+            Some("tool 'exec_shell', command 'cargo'")
+        );
+    }
+
+    #[test]
+    fn ask_rule_wins_over_allow_rule() {
+        let engine =
+            ExecPolicyEngine::with_rulesets(vec![Ruleset::user(vec![], vec![]).with_rules(vec![
+                ToolPermissionRule::exec_shell(PermissionDecision::Allow, "cargo"),
+                ToolPermissionRule::exec_shell(PermissionDecision::Ask, "cargo test"),
+            ])]);
+
+        let decision = engine.check(exec_ctx("cargo test --workspace")).unwrap();
+
+        assert!(decision.allow);
+        assert!(decision.requires_approval);
+        assert_eq!(decision.requirement.phase(), "needs_approval");
+        assert_eq!(
+            decision.matched_rule.as_deref(),
+            Some("tool 'exec_shell', command 'cargo test'")
+        );
+    }
+
+    #[test]
+    fn ask_rule_overrides_on_failure_policy() {
+        let engine =
+            ExecPolicyEngine::with_rulesets(vec![Ruleset::user(vec![], vec![]).with_rules(vec![
+                ToolPermissionRule::exec_shell(PermissionDecision::Ask, "cargo test"),
+            ])]);
+
+        let decision = engine
+            .check(ExecPolicyContext {
+                command: "cargo test --workspace",
+                cwd: ".",
+                ask_for_approval: AskForApproval::OnFailure,
+                sandbox_mode: Some("workspace-write"),
+            })
+            .unwrap();
+
+        assert!(decision.allow);
+        assert!(decision.requires_approval);
+        assert_eq!(decision.requirement.phase(), "needs_approval");
+    }
+
+    #[test]
+    fn path_rules_match_workspace_relative_globs() {
+        let engine =
+            ExecPolicyEngine::with_rulesets(vec![Ruleset::user(vec![], vec![]).with_rules(vec![
+                ToolPermissionRule::file_path("file_edit", PermissionDecision::Allow, "docs/**"),
+            ])]);
+
+        let decision = engine.check_tool_permission(ToolPermissionContext {
+            tool: "file_edit",
+            command: None,
+            path: Some("./docs/guide/setup.md"),
+        });
+
+        assert_eq!(decision.decision, Some(PermissionDecision::Allow));
+    }
+
+    #[test]
+    fn path_star_does_not_cross_directory_separator() {
+        assert!(path_pattern_matches("docs/*.md", "docs/readme.md"));
+        assert!(!path_pattern_matches("docs/*.md", "docs/guides/readme.md"));
+    }
+
+    #[test]
+    fn path_rules_normalize_dot_segments() {
+        assert!(path_pattern_matches("src/**", "src/./lib.rs"));
+        assert!(!path_pattern_matches("src/**", "src/../secret.txt"));
+        assert!(!path_pattern_matches("src/**", "../src/lib.rs"));
+    }
+
+    #[test]
+    fn tool_name_only_rule_matches_unknown_tool() {
+        let engine =
+            ExecPolicyEngine::with_rulesets(vec![Ruleset::user(vec![], vec![]).with_rules(vec![
+                ToolPermissionRule::new("agent_spawn", PermissionDecision::Ask),
+            ])]);
+
+        let decision = engine.check_tool_permission(ToolPermissionContext {
+            tool: "agent_spawn",
+            command: None,
+            path: None,
+        });
+
+        assert_eq!(decision.decision, Some(PermissionDecision::Ask));
     }
 }

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -47,6 +47,7 @@ serde_json = { version = "1.0.149", features = ["preserve_order"] }
 schemars = { version = "1.2.1", features = ["derive", "preserve_order"] }
 shellexpand = "3"
 toml = "0.9.7"
+toml_edit = "0.23.10"
 tokio = { version = "1.49.0", features = ["full"] }
 tokio-util = { version = "0.7.16", features = ["io"] }
 unicode-width = "0.2"

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -22,6 +22,7 @@ path = "src/main.rs"
 anyhow = "1.0.100"
 arboard = "3.4"
 deepseek-secrets = { path = "../secrets", version = "0.8.40" }
+deepseek-execpolicy = { path = "../execpolicy", version = "0.8.40" }
 deepseek-tools = { path = "../tools", version = "0.8.40" }
 schemaui = { version = "0.12.0", default-features = false, optional = true }
 async-stream = "0.3.6"

--- a/crates/tui/src/commands/config.rs
+++ b/crates/tui/src/commands/config.rs
@@ -348,6 +348,82 @@ pub fn persist_root_string_key(key: &str, value: &str) -> anyhow::Result<PathBuf
     Ok(path)
 }
 
+pub fn persist_permission_rules(
+    rules: &[deepseek_execpolicy::ToolPermissionRule],
+) -> anyhow::Result<PathBuf> {
+    use anyhow::Context;
+    use std::fs;
+
+    let path = config_toml_path()?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create config directory {}", parent.display()))?;
+    }
+
+    let mut doc: toml::Value = if path.exists() {
+        let raw = fs::read_to_string(&path)
+            .with_context(|| format!("failed to read config at {}", path.display()))?;
+        toml::from_str(&raw)
+            .with_context(|| format!("failed to parse config at {}", path.display()))?
+    } else {
+        toml::Value::Table(toml::value::Table::new())
+    };
+    let table = doc
+        .as_table_mut()
+        .context("config.toml root must be a table")?;
+    let permissions_entry = table
+        .entry("permissions".to_string())
+        .or_insert_with(|| toml::Value::Table(toml::value::Table::new()));
+    let permissions_table = permissions_entry
+        .as_table_mut()
+        .context("`permissions` section in config.toml must be a table")?;
+    let rules_entry = permissions_table
+        .entry("rules".to_string())
+        .or_insert_with(|| toml::Value::Array(Vec::new()));
+    let rules_array = rules_entry
+        .as_array_mut()
+        .context("`permissions.rules` in config.toml must be an array")?;
+
+    for rule in rules {
+        let value = permission_rule_to_toml_value(rule);
+        if !rules_array.iter().any(|existing| existing == &value) {
+            rules_array.push(value);
+        }
+    }
+
+    let body = toml::to_string_pretty(&doc).context("failed to serialize config.toml")?;
+    fs::write(&path, body)
+        .with_context(|| format!("failed to write config at {}", path.display()))?;
+    Ok(path)
+}
+
+fn permission_rule_to_toml_value(rule: &deepseek_execpolicy::ToolPermissionRule) -> toml::Value {
+    let mut table = toml::value::Table::new();
+    table.insert("tool".to_string(), toml::Value::String(rule.tool.clone()));
+    table.insert(
+        "decision".to_string(),
+        toml::Value::String(permission_decision_label(rule.decision).to_string()),
+    );
+    if let Some(command) = rule.command.as_deref() {
+        table.insert(
+            "command".to_string(),
+            toml::Value::String(command.to_string()),
+        );
+    }
+    if let Some(path) = rule.path.as_deref() {
+        table.insert("path".to_string(), toml::Value::String(path.to_string()));
+    }
+    toml::Value::Table(table)
+}
+
+fn permission_decision_label(decision: deepseek_execpolicy::PermissionDecision) -> &'static str {
+    match decision {
+        deepseek_execpolicy::PermissionDecision::Allow => "allow",
+        deepseek_execpolicy::PermissionDecision::Deny => "deny",
+        deepseek_execpolicy::PermissionDecision::Ask => "ask",
+    }
+}
+
 /// Resolve the path to `~/.deepseek/config.toml` (or
 /// `$DEEPSEEK_CONFIG_PATH`). Mirrors what `Config::load` accepts so we
 /// never write to a different file than the one we read.
@@ -1995,5 +2071,54 @@ mod tests {
             body.contains("status_items"),
             "expected status_items in {body}"
         );
+    }
+
+    #[test]
+    fn persist_permission_rules_writes_deduped_rules_and_preserves_config() {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let temp_root = env::temp_dir().join(format!(
+            "deepseek-permission-rules-{}-{}",
+            std::process::id(),
+            nanos
+        ));
+        fs::create_dir_all(&temp_root).unwrap();
+        let _guard = EnvGuard::new(&temp_root);
+
+        let path = temp_root.join(".deepseek").join("config.toml");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(
+            &path,
+            "api_key = \"sentinel-key\"\nmodel = \"deepseek-v4-pro\"\n",
+        )
+        .unwrap();
+
+        let cargo_rule = deepseek_execpolicy::ToolPermissionRule::exec_shell(
+            deepseek_execpolicy::PermissionDecision::Allow,
+            "cargo test",
+        );
+        let docs_rule = deepseek_execpolicy::ToolPermissionRule::file_path(
+            "read_file",
+            deepseek_execpolicy::PermissionDecision::Allow,
+            "docs/README.md",
+        );
+        let written =
+            persist_permission_rules(&[cargo_rule.clone(), cargo_rule.clone(), docs_rule.clone()])
+                .expect("persist should succeed");
+
+        let body = fs::read_to_string(&written).expect("written file should be readable");
+        assert!(
+            body.contains("api_key = \"sentinel-key\""),
+            "round-trip lost api_key: {body}"
+        );
+        assert!(
+            body.contains("model = \"deepseek-v4-pro\""),
+            "round-trip lost model: {body}"
+        );
+
+        let config = Config::load(Some(written), None).expect("written config should load");
+        assert_eq!(config.permissions.rules, vec![cargo_rule, docs_rule]);
     }
 }

--- a/crates/tui/src/commands/config.rs
+++ b/crates/tui/src/commands/config.rs
@@ -353,6 +353,7 @@ pub fn persist_permission_rules(
 ) -> anyhow::Result<PathBuf> {
     use anyhow::Context;
     use std::fs;
+    use toml_edit::{ArrayOfTables, DocumentMut, Item, Table};
 
     let path = config_toml_path()?;
     if let Some(parent) = path.parent() {
@@ -360,60 +361,132 @@ pub fn persist_permission_rules(
             .with_context(|| format!("failed to create config directory {}", parent.display()))?;
     }
 
-    let mut doc: toml::Value = if path.exists() {
+    let mut doc: DocumentMut = if path.exists() {
         let raw = fs::read_to_string(&path)
             .with_context(|| format!("failed to read config at {}", path.display()))?;
-        toml::from_str(&raw)
+        raw.parse()
             .with_context(|| format!("failed to parse config at {}", path.display()))?
     } else {
-        toml::Value::Table(toml::value::Table::new())
+        DocumentMut::new()
     };
-    let table = doc
-        .as_table_mut()
-        .context("config.toml root must be a table")?;
-    let permissions_entry = table
-        .entry("permissions".to_string())
-        .or_insert_with(|| toml::Value::Table(toml::value::Table::new()));
+    let permissions_entry = doc
+        .entry("permissions")
+        .or_insert_with(|| Item::Table(Table::new()));
     let permissions_table = permissions_entry
         .as_table_mut()
         .context("`permissions` section in config.toml must be a table")?;
     let rules_entry = permissions_table
-        .entry("rules".to_string())
-        .or_insert_with(|| toml::Value::Array(Vec::new()));
-    let rules_array = rules_entry
-        .as_array_mut()
-        .context("`permissions.rules` in config.toml must be an array")?;
+        .entry("rules")
+        .or_insert_with(|| Item::ArrayOfTables(ArrayOfTables::new()));
 
-    for rule in rules {
-        let value = permission_rule_to_toml_value(rule);
-        if !rules_array.iter().any(|existing| existing == &value) {
-            rules_array.push(value);
-        }
-    }
+    append_permission_rules(rules_entry, rules)?;
 
-    let body = toml::to_string_pretty(&doc).context("failed to serialize config.toml")?;
+    let body = doc.to_string();
     fs::write(&path, body)
         .with_context(|| format!("failed to write config at {}", path.display()))?;
     Ok(path)
 }
 
-fn permission_rule_to_toml_value(rule: &deepseek_execpolicy::ToolPermissionRule) -> toml::Value {
-    let mut table = toml::value::Table::new();
-    table.insert("tool".to_string(), toml::Value::String(rule.tool.clone()));
-    table.insert(
-        "decision".to_string(),
-        toml::Value::String(permission_decision_label(rule.decision).to_string()),
-    );
+fn append_permission_rules(
+    rules_item: &mut toml_edit::Item,
+    rules: &[deepseek_execpolicy::ToolPermissionRule],
+) -> anyhow::Result<()> {
+    match rules_item {
+        toml_edit::Item::ArrayOfTables(array) => {
+            for rule in rules {
+                if !array
+                    .iter()
+                    .any(|existing| permission_toml_table_matches_rule(existing, rule))
+                {
+                    array.push(permission_rule_to_toml_table(rule));
+                }
+            }
+        }
+        toml_edit::Item::Value(value) => {
+            let Some(array) = value.as_array_mut() else {
+                anyhow::bail!("`permissions.rules` in config.toml must be an array");
+            };
+            for rule in rules {
+                if !array
+                    .iter()
+                    .any(|existing| permission_toml_value_matches_rule(existing, rule))
+                {
+                    array.push(permission_rule_to_toml_inline_table(rule));
+                }
+            }
+        }
+        _ => anyhow::bail!("`permissions.rules` in config.toml must be an array"),
+    }
+    Ok(())
+}
+
+fn permission_rule_to_toml_table(
+    rule: &deepseek_execpolicy::ToolPermissionRule,
+) -> toml_edit::Table {
+    let mut table = toml_edit::Table::new();
+    table["tool"] = toml_edit::value(rule.tool.clone());
+    table["decision"] = toml_edit::value(permission_decision_label(rule.decision));
     if let Some(command) = rule.command.as_deref() {
-        table.insert(
-            "command".to_string(),
-            toml::Value::String(command.to_string()),
-        );
+        table["command"] = toml_edit::value(command);
     }
     if let Some(path) = rule.path.as_deref() {
-        table.insert("path".to_string(), toml::Value::String(path.to_string()));
+        table["path"] = toml_edit::value(path);
     }
-    toml::Value::Table(table)
+    table
+}
+
+fn permission_rule_to_toml_inline_table(
+    rule: &deepseek_execpolicy::ToolPermissionRule,
+) -> toml_edit::Value {
+    let mut table = toml_edit::InlineTable::new();
+    table.insert("tool", toml_edit::Value::from(rule.tool.clone()));
+    table.insert(
+        "decision",
+        toml_edit::Value::from(permission_decision_label(rule.decision)),
+    );
+    if let Some(command) = rule.command.as_deref() {
+        table.insert("command", toml_edit::Value::from(command));
+    }
+    if let Some(path) = rule.path.as_deref() {
+        table.insert("path", toml_edit::Value::from(path));
+    }
+    toml_edit::Value::InlineTable(table)
+}
+
+fn permission_toml_table_matches_rule(
+    table: &toml_edit::Table,
+    rule: &deepseek_execpolicy::ToolPermissionRule,
+) -> bool {
+    table.get("tool").and_then(toml_edit::Item::as_str) == Some(rule.tool.as_str())
+        && table.get("decision").and_then(toml_edit::Item::as_str)
+            == Some(permission_decision_label(rule.decision))
+        && optional_toml_item_str_matches(table.get("command"), rule.command.as_deref())
+        && optional_toml_item_str_matches(table.get("path"), rule.path.as_deref())
+}
+
+fn permission_toml_value_matches_rule(
+    value: &toml_edit::Value,
+    rule: &deepseek_execpolicy::ToolPermissionRule,
+) -> bool {
+    let Some(table) = value.as_inline_table() else {
+        return false;
+    };
+    table.get("tool").and_then(toml_edit::Value::as_str) == Some(rule.tool.as_str())
+        && table.get("decision").and_then(toml_edit::Value::as_str)
+            == Some(permission_decision_label(rule.decision))
+        && optional_toml_value_str_matches(table.get("command"), rule.command.as_deref())
+        && optional_toml_value_str_matches(table.get("path"), rule.path.as_deref())
+}
+
+fn optional_toml_item_str_matches(item: Option<&toml_edit::Item>, expected: Option<&str>) -> bool {
+    item.and_then(toml_edit::Item::as_str) == expected
+}
+
+fn optional_toml_value_str_matches(
+    value: Option<&toml_edit::Value>,
+    expected: Option<&str>,
+) -> bool {
+    value.and_then(toml_edit::Value::as_str) == expected
 }
 
 fn permission_decision_label(decision: deepseek_execpolicy::PermissionDecision) -> &'static str {
@@ -2052,13 +2125,25 @@ mod tests {
         // Seed the config with a sentinel key the picker MUST NOT clobber.
         fs::write(
             &path,
-            "api_key = \"sentinel-key\"\nmodel = \"deepseek-v4-pro\"\n",
+            "# user config header\napi_key = \"sentinel-key\" # keep inline\nmodel = \"deepseek-v4-pro\"\n\n[permissions]\n# user permission notes\n",
         )
         .unwrap();
 
         let written = persist_status_items(&[crate::config::StatusItem::Mode])
             .expect("persist should succeed");
         let body = fs::read_to_string(&written).expect("written file should be readable");
+        assert!(
+            body.contains("# user config header"),
+            "round-trip lost top-level comment: {body}"
+        );
+        assert!(
+            body.contains("# keep inline"),
+            "round-trip lost inline comment: {body}"
+        );
+        assert!(
+            body.contains("# user permission notes"),
+            "round-trip lost permissions comment: {body}"
+        );
         assert!(
             body.contains("api_key = \"sentinel-key\""),
             "round-trip lost api_key: {body}"

--- a/crates/tui/src/commands/config.rs
+++ b/crates/tui/src/commands/config.rs
@@ -2125,25 +2125,13 @@ mod tests {
         // Seed the config with a sentinel key the picker MUST NOT clobber.
         fs::write(
             &path,
-            "# user config header\napi_key = \"sentinel-key\" # keep inline\nmodel = \"deepseek-v4-pro\"\n\n[permissions]\n# user permission notes\n",
+            "api_key = \"sentinel-key\"\nmodel = \"deepseek-v4-pro\"\n",
         )
         .unwrap();
 
         let written = persist_status_items(&[crate::config::StatusItem::Mode])
             .expect("persist should succeed");
         let body = fs::read_to_string(&written).expect("written file should be readable");
-        assert!(
-            body.contains("# user config header"),
-            "round-trip lost top-level comment: {body}"
-        );
-        assert!(
-            body.contains("# keep inline"),
-            "round-trip lost inline comment: {body}"
-        );
-        assert!(
-            body.contains("# user permission notes"),
-            "round-trip lost permissions comment: {body}"
-        );
         assert!(
             body.contains("api_key = \"sentinel-key\""),
             "round-trip lost api_key: {body}"
@@ -2176,7 +2164,7 @@ mod tests {
         fs::create_dir_all(path.parent().unwrap()).unwrap();
         fs::write(
             &path,
-            "api_key = \"sentinel-key\"\nmodel = \"deepseek-v4-pro\"\n",
+            "# user config header\napi_key = \"sentinel-key\" # keep inline\nmodel = \"deepseek-v4-pro\"\n\n[permissions]\n# user permission notes\n",
         )
         .unwrap();
 
@@ -2194,6 +2182,18 @@ mod tests {
                 .expect("persist should succeed");
 
         let body = fs::read_to_string(&written).expect("written file should be readable");
+        assert!(
+            body.contains("# user config header"),
+            "round-trip lost top-level comment: {body}"
+        );
+        assert!(
+            body.contains("# keep inline"),
+            "round-trip lost inline comment: {body}"
+        );
+        assert!(
+            body.contains("# user permission notes"),
+            "round-trip lost permissions comment: {body}"
+        );
         assert!(
             body.contains("api_key = \"sentinel-key\""),
             "round-trip lost api_key: {body}"

--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -697,6 +697,13 @@ pub fn persist_root_string_key(key: &str, value: &str) -> anyhow::Result<std::pa
     config::persist_root_string_key(key, value)
 }
 
+/// Persist generated tool permission rules to `~/.deepseek/config.toml`.
+pub fn persist_permission_rules(
+    rules: &[deepseek_execpolicy::ToolPermissionRule],
+) -> anyhow::Result<std::path::PathBuf> {
+    config::persist_permission_rules(rules)
+}
+
 pub fn switch_mode(app: &mut App, mode: crate::tui::app::AppMode) -> String {
     config::switch_mode(app, mode)
 }

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -8,6 +8,7 @@ use std::io::Write as _;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
+use deepseek_execpolicy::{ExecPolicyEngine, Ruleset, ToolPermissionRule};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 #[cfg(unix)]
@@ -913,6 +914,12 @@ pub struct AutoConfig {
     pub cost_saving: Option<bool>,
 }
 
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct PermissionsConfig {
+    #[serde(default)]
+    pub rules: Vec<ToolPermissionRule>,
+}
+
 /// Resolved CLI configuration, including defaults and environment overrides.
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct Config {
@@ -947,6 +954,15 @@ pub struct Config {
     pub approval_policy: Option<String>,
     pub sandbox_mode: Option<String>,
     pub yolo: Option<bool>,
+    /// Legacy shell command permission rules. These are translated into typed
+    /// `exec_shell` allow/deny rules before tool execution.
+    #[serde(default)]
+    pub auto_allow: Vec<String>,
+    #[serde(default)]
+    pub auto_deny: Vec<String>,
+    /// Typed, persistent tool permission rules.
+    #[serde(default)]
+    pub permissions: PermissionsConfig,
     /// External sandbox backend: `"none"` or `"opensandbox"`.
     /// When set, exec_shell routes commands through the backend's HTTP API
     /// instead of spawning a local process.
@@ -1816,6 +1832,20 @@ impl Config {
     #[must_use]
     pub fn allow_shell(&self) -> bool {
         self.allow_shell.unwrap_or(false)
+    }
+
+    /// Build the user-layer permission ruleset used by the tool execution
+    /// approval path.
+    #[must_use]
+    pub fn permission_ruleset(&self) -> Ruleset {
+        Ruleset::user(self.auto_allow.clone(), self.auto_deny.clone())
+            .with_rules(self.permissions.rules.clone())
+    }
+
+    /// Build the permission engine for shell/file tool approval decisions.
+    #[must_use]
+    pub fn exec_policy_engine(&self) -> ExecPolicyEngine {
+        ExecPolicyEngine::with_rulesets(vec![self.permission_ruleset()])
     }
 
     /// Return the maximum number of concurrent sub-agents.
@@ -2922,6 +2952,9 @@ fn merge_config(base: Config, override_cfg: Config) -> Config {
         yolo: override_cfg.yolo.or(base.yolo),
         approval_policy: override_cfg.approval_policy.or(base.approval_policy),
         sandbox_mode: override_cfg.sandbox_mode.or(base.sandbox_mode),
+        auto_allow: merge_non_empty_vec(base.auto_allow, override_cfg.auto_allow),
+        auto_deny: merge_non_empty_vec(base.auto_deny, override_cfg.auto_deny),
+        permissions: merge_permissions_config(base.permissions, override_cfg.permissions),
         sandbox_backend: override_cfg.sandbox_backend.or(base.sandbox_backend),
         sandbox_url: override_cfg.sandbox_url.or(base.sandbox_url),
         sandbox_api_key: override_cfg.sandbox_api_key.or(base.sandbox_api_key),
@@ -2976,6 +3009,25 @@ fn merge_config(base: Config, override_cfg: Config) -> Config {
         strict_tool_mode: override_cfg.strict_tool_mode.or(base.strict_tool_mode),
         runtime_api: override_cfg.runtime_api.or(base.runtime_api),
         workshop: override_cfg.workshop.or(base.workshop),
+    }
+}
+
+fn merge_non_empty_vec<T>(base: Vec<T>, override_cfg: Vec<T>) -> Vec<T> {
+    if override_cfg.is_empty() {
+        base
+    } else {
+        override_cfg
+    }
+}
+
+fn merge_permissions_config(
+    base: PermissionsConfig,
+    override_cfg: PermissionsConfig,
+) -> PermissionsConfig {
+    if override_cfg.rules.is_empty() {
+        base
+    } else {
+        override_cfg
     }
 }
 
@@ -4050,6 +4102,44 @@ mod tests {
             high.subagent_api_timeout_secs(),
             MAX_SUBAGENT_API_TIMEOUT_SECS
         );
+    }
+
+    #[test]
+    fn config_loads_typed_permission_rules_for_exec_policy_engine() -> Result<()> {
+        let _guard = lock_test_env();
+        let temp = tempfile::tempdir()?;
+        let _env = EnvGuard::new(temp.path());
+        let config_path = temp.path().join("config.toml");
+        fs::write(
+            &config_path,
+            r#"
+auto_allow = ["git status"]
+auto_deny = ["rm -rf"]
+
+[[permissions.rules]]
+tool = "read_file"
+decision = "ask"
+path = "secrets/**"
+"#,
+        )?;
+
+        let config = Config::load(Some(config_path), None)?;
+        assert_eq!(config.auto_allow, ["git status"]);
+        assert_eq!(config.auto_deny, ["rm -rf"]);
+
+        let decision = config.exec_policy_engine().check_tool_permission(
+            deepseek_execpolicy::ToolPermissionContext {
+                tool: "read_file",
+                command: None,
+                path: Some("secrets/token.txt"),
+            },
+        );
+
+        assert_eq!(
+            decision.decision,
+            Some(deepseek_execpolicy::PermissionDecision::Ask)
+        );
+        Ok(())
     }
 
     #[test]

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -1920,7 +1920,7 @@ pub(crate) enum MockApprovalEvent {
 impl MockEngineHandle {
     pub(crate) async fn recv_approval_event(&mut self) -> Option<MockApprovalEvent> {
         match self.rx_approval.recv().await? {
-            ApprovalDecision::Approved { id } => Some(MockApprovalEvent::Approved { id }),
+            ApprovalDecision::Approved { id, .. } => Some(MockApprovalEvent::Approved { id }),
             ApprovalDecision::Denied { id } => Some(MockApprovalEvent::Denied { id }),
             ApprovalDecision::RetryWithPolicy { id, policy } => {
                 Some(MockApprovalEvent::RetryWithPolicy { id, policy })

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -171,6 +171,9 @@ pub struct EngineConfig {
     /// once at engine construction, then threaded onto every
     /// `SubAgentRuntime` the engine builds (#1806, #1808).
     pub subagent_api_timeout: Duration,
+    /// Typed permission rules used before falling back to the legacy approval
+    /// prompt path for shell and file tools.
+    pub exec_policy_engine: deepseek_execpolicy::ExecPolicyEngine,
 }
 
 impl Default for EngineConfig {
@@ -214,6 +217,7 @@ impl Default for EngineConfig {
             subagent_api_timeout: Duration::from_secs(
                 crate::config::DEFAULT_SUBAGENT_API_TIMEOUT_SECS,
             ),
+            exec_policy_engine: deepseek_execpolicy::ExecPolicyEngine::default(),
         }
     }
 }
@@ -1980,10 +1984,11 @@ use self::approval::{ApprovalDecision, ApprovalResult, UserInputDecision};
 use self::dispatch::should_parallelize_tool_batch;
 use self::dispatch::{
     ParallelToolResult, ParallelToolResultEntry, ToolExecGuard, ToolExecOutcome,
-    ToolExecutionBatch, ToolExecutionPlan, caller_allowed_for_tool, caller_type_for_tool_use,
-    final_tool_input, format_tool_error, mcp_tool_approval_description, mcp_tool_is_parallel_safe,
-    mcp_tool_is_read_only, parse_parallel_tool_calls, parse_tool_input,
+    ToolExecutionBatch, ToolExecutionPlan, ToolPermissionOverride, caller_allowed_for_tool,
+    caller_type_for_tool_use, final_tool_input, format_tool_error, mcp_tool_approval_description,
+    mcp_tool_is_parallel_safe, mcp_tool_is_read_only, parse_parallel_tool_calls, parse_tool_input,
     plan_tool_execution_batches, should_force_update_plan_first, should_stop_after_plan_tool,
+    tool_permission_override_for_call,
 };
 use self::loop_guard::{AttemptDecision, LoopGuard, OutcomeDecision};
 #[cfg(test)]

--- a/crates/tui/src/core/engine/approval.rs
+++ b/crates/tui/src/core/engine/approval.rs
@@ -15,6 +15,7 @@ use super::Engine;
 pub(super) enum ApprovalDecision {
     Approved {
         id: String,
+        persistent_rules: Vec<deepseek_execpolicy::ToolPermissionRule>,
     },
     Denied {
         id: String,
@@ -86,7 +87,16 @@ impl Engine {
                         ));
                     };
                     match decision {
-                        ApprovalDecision::Approved { id } if id == tool_id => {
+                        ApprovalDecision::Approved {
+                            id,
+                            persistent_rules,
+                        } if id == tool_id => {
+                            if !persistent_rules.is_empty() {
+                                self.config.exec_policy_engine.add_ruleset(
+                                    deepseek_execpolicy::Ruleset::user(vec![], vec![])
+                                        .with_rules(persistent_rules),
+                                );
+                            }
                             return Ok(ApprovalResult::Approved);
                         }
                         ApprovalDecision::Denied { id } if id == tool_id => {

--- a/crates/tui/src/core/engine/dispatch.rs
+++ b/crates/tui/src/core/engine/dispatch.rs
@@ -358,9 +358,7 @@ fn apply_patch_permission_paths(input: &Value) -> Vec<String> {
             }
         }
     }
-    if paths.is_empty()
-        && let Some(patch) = input.get("patch").and_then(Value::as_str)
-    {
+    if let Some(patch) = input.get("patch").and_then(Value::as_str) {
         for path in parse_unified_diff_permission_paths(patch) {
             push_unique_path(&mut paths, &path);
         }
@@ -390,7 +388,7 @@ fn parse_unified_diff_permission_paths(patch: &str) -> Vec<String> {
 }
 
 fn normalize_diff_permission_path(raw: &str) -> Option<String> {
-    let raw = raw.trim();
+    let raw = raw.split('\t').next()?.trim();
     if raw.is_empty() || raw == "/dev/null" || raw == "dev/null" {
         return None;
     }

--- a/crates/tui/src/core/engine/dispatch.rs
+++ b/crates/tui/src/core/engine/dispatch.rs
@@ -15,13 +15,18 @@
 //! All items are `pub(super)`-only: the public engine surface (Op/Event,
 //! `EngineHandle`, `spawn_engine`) stays in `core/engine.rs`.
 
-use serde_json::json;
+use deepseek_execpolicy::{
+    ExecPolicyEngine, PermissionDecision, ToolPermissionCheck, ToolPermissionContext,
+};
+use serde_json::{Value, json};
+use std::path::{Component, Path, PathBuf};
 
 use crate::models::{Tool, ToolCaller};
 use crate::tools::spec::{ToolError, ToolResult};
 use crate::tui::app::AppMode;
 
 use super::ToolUseState;
+use super::tool_catalog::MULTI_TOOL_PARALLEL_NAME;
 
 // === Types ============================================================
 
@@ -70,6 +75,14 @@ pub(super) struct ParallelToolResult {
     pub(super) results: Vec<ParallelToolResultEntry>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum ToolPermissionOverride {
+    Unmatched,
+    Allow { reason: String },
+    Ask { reason: String },
+    Deny { reason: String },
+}
+
 // Hold the lock guard for the duration of a tool execution.
 // The inner guards are held for RAII purposes (dropped when the guard is dropped).
 pub(super) enum ToolExecGuard<'a> {
@@ -97,6 +110,452 @@ pub(super) fn caller_allowed_for_tool(
         return allowed.iter().any(|item| item == requested);
     }
     requested == "direct"
+}
+
+// === Typed permission rules ==========================================
+
+pub(super) fn tool_permission_override_for_call(
+    engine: &ExecPolicyEngine,
+    tool_name: &str,
+    input: &Value,
+    workspace: &Path,
+) -> ToolPermissionOverride {
+    if tool_name == MULTI_TOOL_PARALLEL_NAME {
+        return permission_override_for_parallel_call(engine, input, workspace);
+    }
+
+    if is_shell_permission_tool(tool_name) {
+        let command = input.get("command").and_then(Value::as_str);
+        return permission_override_for_context(engine, tool_name, command, None);
+    }
+
+    if !is_file_permission_tool(tool_name) {
+        return ToolPermissionOverride::Unmatched;
+    }
+
+    let paths = permission_paths_for_file_tool(tool_name, input);
+    if paths.is_empty() {
+        return permission_override_for_context(engine, tool_name, None, None);
+    }
+
+    let mut saw_allow = false;
+    let mut saw_unmatched = false;
+    let mut ask_reason: Option<String> = None;
+
+    for path in paths {
+        match permission_override_for_path(engine, tool_name, &path, workspace) {
+            ToolPermissionOverride::Deny { reason } => {
+                return ToolPermissionOverride::Deny { reason };
+            }
+            ToolPermissionOverride::Ask { reason } => {
+                ask_reason.get_or_insert(reason);
+            }
+            ToolPermissionOverride::Allow { .. } => {
+                saw_allow = true;
+            }
+            ToolPermissionOverride::Unmatched => {
+                saw_unmatched = true;
+            }
+        }
+    }
+
+    if let Some(reason) = ask_reason {
+        ToolPermissionOverride::Ask { reason }
+    } else if saw_allow && !saw_unmatched {
+        ToolPermissionOverride::Allow {
+            reason: format!("Tool '{tool_name}' allowed by permission rule"),
+        }
+    } else {
+        ToolPermissionOverride::Unmatched
+    }
+}
+
+fn permission_override_for_parallel_call(
+    engine: &ExecPolicyEngine,
+    input: &Value,
+    workspace: &Path,
+) -> ToolPermissionOverride {
+    let Ok(calls) = parse_parallel_tool_calls(input) else {
+        return ToolPermissionOverride::Unmatched;
+    };
+
+    let mut saw_allow = false;
+    let mut saw_unmatched = false;
+    let mut ask_reason: Option<String> = None;
+
+    for (nested_tool_name, nested_input) in calls {
+        match tool_permission_override_for_call(engine, &nested_tool_name, &nested_input, workspace)
+        {
+            ToolPermissionOverride::Deny { reason } => {
+                return ToolPermissionOverride::Deny { reason };
+            }
+            ToolPermissionOverride::Ask { reason } => {
+                ask_reason.get_or_insert(reason);
+            }
+            ToolPermissionOverride::Allow { .. } => {
+                saw_allow = true;
+            }
+            ToolPermissionOverride::Unmatched => {
+                saw_unmatched = true;
+            }
+        }
+    }
+
+    if let Some(reason) = ask_reason {
+        ToolPermissionOverride::Ask { reason }
+    } else if saw_allow && !saw_unmatched {
+        ToolPermissionOverride::Allow {
+            reason: format!("Tool '{MULTI_TOOL_PARALLEL_NAME}' allowed by permission rule"),
+        }
+    } else {
+        ToolPermissionOverride::Unmatched
+    }
+}
+
+fn permission_override_for_path(
+    engine: &ExecPolicyEngine,
+    tool_name: &str,
+    path: &str,
+    workspace: &Path,
+) -> ToolPermissionOverride {
+    let mut override_result = ToolPermissionOverride::Unmatched;
+    for candidate in permission_path_candidates(path, workspace) {
+        let next = permission_override_for_context(engine, tool_name, None, Some(&candidate));
+        override_result = combine_permission_overrides(override_result, next);
+        if matches!(override_result, ToolPermissionOverride::Deny { .. }) {
+            break;
+        }
+    }
+    override_result
+}
+
+fn permission_override_for_context(
+    engine: &ExecPolicyEngine,
+    tool_name: &str,
+    command: Option<&str>,
+    path: Option<&str>,
+) -> ToolPermissionOverride {
+    let mut override_result = ToolPermissionOverride::Unmatched;
+    for policy_tool_name in
+        std::iter::once(tool_name).chain(permission_policy_tool_aliases(tool_name).iter().copied())
+    {
+        let next = permission_override_from_check(
+            tool_name,
+            engine.check_tool_permission(ToolPermissionContext {
+                tool: policy_tool_name,
+                command,
+                path,
+            }),
+        );
+        override_result = combine_permission_overrides(override_result, next);
+        if matches!(override_result, ToolPermissionOverride::Deny { .. }) {
+            break;
+        }
+    }
+    override_result
+}
+
+fn combine_permission_overrides(
+    current: ToolPermissionOverride,
+    next: ToolPermissionOverride,
+) -> ToolPermissionOverride {
+    match (current, next) {
+        (ToolPermissionOverride::Deny { reason }, _) => ToolPermissionOverride::Deny { reason },
+        (_, ToolPermissionOverride::Deny { reason }) => ToolPermissionOverride::Deny { reason },
+        (ToolPermissionOverride::Ask { reason }, _) => ToolPermissionOverride::Ask { reason },
+        (_, ToolPermissionOverride::Ask { reason }) => ToolPermissionOverride::Ask { reason },
+        (ToolPermissionOverride::Allow { reason }, _) => ToolPermissionOverride::Allow { reason },
+        (_, ToolPermissionOverride::Allow { reason }) => ToolPermissionOverride::Allow { reason },
+        (ToolPermissionOverride::Unmatched, ToolPermissionOverride::Unmatched) => {
+            ToolPermissionOverride::Unmatched
+        }
+    }
+}
+
+fn permission_override_from_check(
+    tool_name: &str,
+    check: ToolPermissionCheck,
+) -> ToolPermissionOverride {
+    let Some(decision) = check.decision else {
+        return ToolPermissionOverride::Unmatched;
+    };
+    let label = check
+        .matched_rule
+        .as_ref()
+        .map(|matched| matched.rule.pattern_label())
+        .unwrap_or_else(|| format!("tool '{tool_name}'"));
+    match decision {
+        PermissionDecision::Allow => ToolPermissionOverride::Allow {
+            reason: format!("Tool '{tool_name}' allowed by permission rule ({label})"),
+        },
+        PermissionDecision::Ask => ToolPermissionOverride::Ask {
+            reason: format!("Approval required by permission rule ({label})"),
+        },
+        PermissionDecision::Deny => ToolPermissionOverride::Deny {
+            reason: format!("Tool '{tool_name}' denied by permission rule ({label})"),
+        },
+    }
+}
+
+fn is_shell_permission_tool(tool_name: &str) -> bool {
+    matches!(
+        tool_name,
+        "exec_shell"
+            | "exec_shell_wait"
+            | "exec_shell_interact"
+            | "exec_shell_cancel"
+            | "exec_wait"
+            | "exec_interact"
+    )
+}
+
+fn is_file_permission_tool(tool_name: &str) -> bool {
+    matches!(
+        tool_name,
+        "read_file" | "write_file" | "edit_file" | "list_dir" | "apply_patch"
+    )
+}
+
+fn permission_policy_tool_aliases(tool_name: &str) -> &'static [&'static str] {
+    match tool_name {
+        "read_file" => &["file_read"],
+        "write_file" => &["file_write"],
+        "edit_file" => &["file_edit"],
+        _ => &[],
+    }
+}
+
+fn permission_paths_for_file_tool(tool_name: &str, input: &Value) -> Vec<String> {
+    match tool_name {
+        "read_file" | "write_file" | "edit_file" => input
+            .get("path")
+            .and_then(Value::as_str)
+            .map(|path| vec![path.to_string()])
+            .unwrap_or_default(),
+        "list_dir" => vec![
+            input
+                .get("path")
+                .and_then(Value::as_str)
+                .unwrap_or(".")
+                .to_string(),
+        ],
+        "apply_patch" => apply_patch_permission_paths(input),
+        _ => Vec::new(),
+    }
+}
+
+fn apply_patch_permission_paths(input: &Value) -> Vec<String> {
+    let mut paths = Vec::new();
+    if let Some(path) = input.get("path").and_then(Value::as_str) {
+        push_unique_path(&mut paths, path);
+    }
+    for key in ["changes", "files"] {
+        if let Some(entries) = input.get(key).and_then(Value::as_array) {
+            for entry in entries {
+                if let Some(path) = entry.get("path").and_then(Value::as_str) {
+                    push_unique_path(&mut paths, path);
+                }
+            }
+        }
+    }
+    if paths.is_empty()
+        && let Some(patch) = input.get("patch").and_then(Value::as_str)
+    {
+        for path in parse_unified_diff_permission_paths(patch) {
+            push_unique_path(&mut paths, &path);
+        }
+    }
+    paths
+}
+
+fn parse_unified_diff_permission_paths(patch: &str) -> Vec<String> {
+    let mut paths = Vec::new();
+    let mut old_path: Option<String> = None;
+
+    for line in patch.lines() {
+        if let Some(stripped) = line.strip_prefix("--- ") {
+            old_path = normalize_diff_permission_path(stripped);
+            continue;
+        }
+        if let Some(stripped) = line.strip_prefix("+++ ") {
+            let new_path = normalize_diff_permission_path(stripped);
+            if let Some(path) = new_path.or_else(|| old_path.clone()) {
+                push_unique_path(&mut paths, &path);
+            }
+            old_path = None;
+        }
+    }
+
+    paths
+}
+
+fn normalize_diff_permission_path(raw: &str) -> Option<String> {
+    let raw = raw.trim();
+    if raw.is_empty() || raw == "/dev/null" || raw == "dev/null" {
+        return None;
+    }
+    let raw = raw
+        .strip_prefix("a/")
+        .or_else(|| raw.strip_prefix("b/"))
+        .unwrap_or(raw);
+    Some(raw.to_string())
+}
+
+fn push_unique_path(paths: &mut Vec<String>, path: &str) {
+    if !paths.iter().any(|existing| existing == path) {
+        paths.push(path.to_string());
+    }
+}
+
+fn permission_path_candidates(path: &str, workspace: &Path) -> Vec<String> {
+    let mut candidates = Vec::new();
+    push_unique_path(&mut candidates, path);
+
+    let workspace_bases = permission_workspace_bases(workspace);
+    let workspace_base = workspace_bases
+        .first()
+        .cloned()
+        .unwrap_or_else(|| normalize_permission_path(workspace));
+    let raw_path = Path::new(path);
+    let candidate_path = if raw_path.is_absolute() {
+        raw_path.to_path_buf()
+    } else {
+        workspace_base.join(raw_path)
+    };
+    let candidate_path = normalize_permission_path(&candidate_path);
+
+    for workspace_base in &workspace_bases {
+        if let Some(relative) = workspace_relative_permission_path(&candidate_path, workspace_base)
+        {
+            push_unique_path(&mut candidates, &relative);
+        }
+    }
+
+    if let Some(canonical_path) = canonicalize_permission_path(&candidate_path) {
+        for workspace_base in &workspace_bases {
+            if let Some(relative) =
+                workspace_relative_permission_path(&canonical_path, workspace_base)
+            {
+                push_unique_path(&mut candidates, &relative);
+            }
+        }
+    }
+
+    candidates
+}
+
+fn permission_workspace_bases(workspace: &Path) -> Vec<PathBuf> {
+    let mut bases = Vec::new();
+    let workspace = if workspace.is_absolute() {
+        workspace.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map(|current_dir| current_dir.join(workspace))
+            .unwrap_or_else(|_| workspace.to_path_buf())
+    };
+    push_unique_path_buf(&mut bases, normalize_permission_path(&workspace));
+    if let Ok(canonical) = workspace.canonicalize() {
+        push_unique_path_buf(&mut bases, normalize_permission_path(&canonical));
+    }
+    bases
+}
+
+fn workspace_relative_permission_path(path: &Path, workspace: &Path) -> Option<String> {
+    let normalized_path = normalize_permission_path(path);
+    normalized_path
+        .strip_prefix(workspace)
+        .ok()
+        .map(permission_path_to_string)
+}
+
+fn canonicalize_permission_path(path: &Path) -> Option<PathBuf> {
+    if path.exists() {
+        return path
+            .canonicalize()
+            .ok()
+            .map(|path| normalize_permission_path(&path));
+    }
+
+    let mut existing_ancestor = path.to_path_buf();
+    let mut suffix_parts: Vec<std::ffi::OsString> = Vec::new();
+
+    while !existing_ancestor.exists() {
+        if let Some(file_name) = existing_ancestor.file_name() {
+            suffix_parts.push(file_name.to_owned());
+        }
+        match existing_ancestor.parent() {
+            Some(parent) if !parent.as_os_str().is_empty() => {
+                existing_ancestor = parent.to_path_buf();
+            }
+            _ => return None,
+        }
+    }
+
+    let mut canonical = existing_ancestor
+        .canonicalize()
+        .unwrap_or(existing_ancestor);
+    for part in suffix_parts.into_iter().rev() {
+        canonical.push(part);
+    }
+    Some(normalize_permission_path(&canonical))
+}
+
+fn normalize_permission_path(path: &Path) -> PathBuf {
+    let mut prefix: Option<std::ffi::OsString> = None;
+    let mut is_root = false;
+    let mut stack: Vec<std::ffi::OsString> = Vec::new();
+
+    for component in path.components() {
+        match component {
+            Component::Prefix(prefix_component) => {
+                prefix = Some(prefix_component.as_os_str().to_owned());
+            }
+            Component::RootDir => {
+                is_root = true;
+            }
+            Component::CurDir => {}
+            Component::ParentDir => {
+                let parent = Component::ParentDir.as_os_str();
+                if let Some(last) = stack.pop() {
+                    if last == parent {
+                        stack.push(last);
+                        stack.push(parent.to_owned());
+                    }
+                } else if !is_root {
+                    stack.push(parent.to_owned());
+                }
+            }
+            Component::Normal(part) => {
+                stack.push(part.to_owned());
+            }
+        }
+    }
+
+    let mut normalized = PathBuf::new();
+    if let Some(prefix) = prefix {
+        normalized.push(prefix);
+    }
+    if is_root {
+        normalized.push(Path::new(std::path::MAIN_SEPARATOR_STR));
+    }
+    for part in stack {
+        normalized.push(part);
+    }
+    normalized
+}
+
+fn permission_path_to_string(path: &Path) -> String {
+    if path.as_os_str().is_empty() {
+        ".".to_string()
+    } else {
+        path.to_string_lossy().replace('\\', "/")
+    }
+}
+
+fn push_unique_path_buf(paths: &mut Vec<PathBuf>, path: PathBuf) {
+    if !paths.iter().any(|existing| existing == &path) {
+        paths.push(path);
+    }
 }
 
 pub(super) fn format_tool_error(err: &ToolError, tool_name: &str) -> String {

--- a/crates/tui/src/core/engine/handle.rs
+++ b/crates/tui/src/core/engine/handle.rs
@@ -52,8 +52,21 @@ impl EngineHandle {
 
     /// Approve a pending tool call
     pub async fn approve_tool_call(&self, id: impl Into<String>) -> Result<()> {
+        self.approve_tool_call_with_rules(id, Vec::new()).await
+    }
+
+    /// Approve a pending tool call and add persistent permission rules to the
+    /// live engine policy for the rest of this session.
+    pub async fn approve_tool_call_with_rules(
+        &self,
+        id: impl Into<String>,
+        persistent_rules: Vec<deepseek_execpolicy::ToolPermissionRule>,
+    ) -> Result<()> {
         self.tx_approval
-            .send(ApprovalDecision::Approved { id: id.into() })
+            .send(ApprovalDecision::Approved {
+                id: id.into(),
+                persistent_rules,
+            })
             .await?;
         Ok(())
     }

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -152,6 +152,210 @@ fn make_plan_at(
     }
 }
 
+fn permission_engine_with_rules(
+    rules: Vec<deepseek_execpolicy::ToolPermissionRule>,
+) -> deepseek_execpolicy::ExecPolicyEngine {
+    deepseek_execpolicy::ExecPolicyEngine::with_rulesets(vec![
+        deepseek_execpolicy::Ruleset::user(vec![], vec![]).with_rules(rules),
+    ])
+}
+
+fn permission_test_workspace() -> &'static Path {
+    Path::new(".")
+}
+
+#[test]
+fn typed_permission_allows_shell_command_before_approval_prompt() {
+    let engine =
+        permission_engine_with_rules(vec![deepseek_execpolicy::ToolPermissionRule::exec_shell(
+            deepseek_execpolicy::PermissionDecision::Allow,
+            "cargo test",
+        )]);
+
+    let decision = tool_permission_override_for_call(
+        &engine,
+        "exec_shell",
+        &json!({"command": "cargo test --workspace"}),
+        permission_test_workspace(),
+    );
+
+    assert!(matches!(decision, ToolPermissionOverride::Allow { .. }));
+}
+
+#[test]
+fn typed_permission_can_force_read_file_approval() {
+    let engine =
+        permission_engine_with_rules(vec![deepseek_execpolicy::ToolPermissionRule::file_path(
+            "read_file",
+            deepseek_execpolicy::PermissionDecision::Ask,
+            "secrets/**",
+        )]);
+
+    let decision = tool_permission_override_for_call(
+        &engine,
+        "read_file",
+        &json!({"path": "secrets/a.env"}),
+        permission_test_workspace(),
+    );
+
+    assert!(matches!(decision, ToolPermissionOverride::Ask { .. }));
+}
+
+#[test]
+fn typed_permission_matches_absolute_workspace_file_paths() {
+    let workspace = tempdir().expect("workspace");
+    let absolute_path = workspace.path().join("secrets/a.env");
+    let engine =
+        permission_engine_with_rules(vec![deepseek_execpolicy::ToolPermissionRule::file_path(
+            "read_file",
+            deepseek_execpolicy::PermissionDecision::Deny,
+            "secrets/**",
+        )]);
+
+    let decision = tool_permission_override_for_call(
+        &engine,
+        "read_file",
+        &json!({"path": absolute_path.to_string_lossy()}),
+        workspace.path(),
+    );
+
+    assert!(matches!(decision, ToolPermissionOverride::Deny { .. }));
+}
+
+#[cfg(unix)]
+#[test]
+fn typed_permission_matches_symlink_resolved_workspace_file_paths() {
+    use std::os::unix::fs::symlink;
+
+    let workspace = tempdir().expect("workspace");
+    let secrets_dir = workspace.path().join("secrets");
+    fs::create_dir(&secrets_dir).expect("create secrets dir");
+    fs::write(secrets_dir.join("a.env"), "token").expect("write secret");
+    symlink(&secrets_dir, workspace.path().join("alias")).expect("symlink secrets");
+    let engine =
+        permission_engine_with_rules(vec![deepseek_execpolicy::ToolPermissionRule::file_path(
+            "read_file",
+            deepseek_execpolicy::PermissionDecision::Deny,
+            "secrets/**",
+        )]);
+
+    let decision = tool_permission_override_for_call(
+        &engine,
+        "read_file",
+        &json!({"path": "alias/a.env"}),
+        workspace.path(),
+    );
+
+    assert!(matches!(decision, ToolPermissionOverride::Deny { .. }));
+}
+
+#[test]
+fn typed_permission_checks_nested_parallel_tool_calls() {
+    let engine =
+        permission_engine_with_rules(vec![deepseek_execpolicy::ToolPermissionRule::file_path(
+            "read_file",
+            deepseek_execpolicy::PermissionDecision::Deny,
+            "secrets/**",
+        )]);
+
+    let decision = tool_permission_override_for_call(
+        &engine,
+        "multi_tool_use.parallel",
+        &json!({
+            "tool_uses": [{
+                "recipient_name": "read_file",
+                "parameters": { "path": "secrets/a.env" }
+            }]
+        }),
+        permission_test_workspace(),
+    );
+
+    assert!(matches!(decision, ToolPermissionOverride::Deny { .. }));
+}
+
+#[test]
+fn typed_permission_matches_legacy_file_tool_aliases() {
+    let engine =
+        permission_engine_with_rules(vec![deepseek_execpolicy::ToolPermissionRule::file_path(
+            "file_edit",
+            deepseek_execpolicy::PermissionDecision::Ask,
+            "src/**",
+        )]);
+
+    let decision = tool_permission_override_for_call(
+        &engine,
+        "edit_file",
+        &json!({"path": "src/main.rs"}),
+        permission_test_workspace(),
+    );
+
+    assert!(matches!(decision, ToolPermissionOverride::Ask { .. }));
+}
+
+#[test]
+fn typed_permission_denies_file_path_before_tool_execution() {
+    let engine =
+        permission_engine_with_rules(vec![deepseek_execpolicy::ToolPermissionRule::file_path(
+            "write_file",
+            deepseek_execpolicy::PermissionDecision::Deny,
+            "src/**",
+        )]);
+
+    let decision = tool_permission_override_for_call(
+        &engine,
+        "write_file",
+        &json!({"path": "src/main.rs", "content": "fn main() {}"}),
+        permission_test_workspace(),
+    );
+
+    assert!(matches!(decision, ToolPermissionOverride::Deny { .. }));
+}
+
+#[test]
+fn typed_permission_requires_all_apply_patch_paths_to_be_allowed() {
+    let engine =
+        permission_engine_with_rules(vec![deepseek_execpolicy::ToolPermissionRule::file_path(
+            "apply_patch",
+            deepseek_execpolicy::PermissionDecision::Allow,
+            "docs/**",
+        )]);
+
+    let decision = tool_permission_override_for_call(
+        &engine,
+        "apply_patch",
+        &json!({
+            "changes": [
+                { "path": "docs/a.md", "content": "ok" },
+                { "path": "src/lib.rs", "content": "needs existing approval" }
+            ]
+        }),
+        permission_test_workspace(),
+    );
+
+    assert_eq!(decision, ToolPermissionOverride::Unmatched);
+}
+
+#[test]
+fn typed_permission_allows_apply_patch_when_all_paths_match() {
+    let engine =
+        permission_engine_with_rules(vec![deepseek_execpolicy::ToolPermissionRule::file_path(
+            "apply_patch",
+            deepseek_execpolicy::PermissionDecision::Allow,
+            "docs/**",
+        )]);
+
+    let decision = tool_permission_override_for_call(
+        &engine,
+        "apply_patch",
+        &json!({
+            "patch": "--- a/docs/a.md\n+++ b/docs/a.md\n@@ -1 +1 @@\n-old\n+new\n"
+        }),
+        permission_test_workspace(),
+    );
+
+    assert!(matches!(decision, ToolPermissionOverride::Allow { .. }));
+}
+
 fn api_tool(name: &str) -> Tool {
     Tool {
         tool_type: Some("function".to_string()),

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -366,6 +366,34 @@ fn typed_permission_requires_all_apply_patch_paths_to_be_allowed() {
 }
 
 #[test]
+fn typed_permission_checks_apply_patch_diff_even_when_path_field_is_present() {
+    let engine = permission_engine_with_rules(vec![
+        deepseek_execpolicy::ToolPermissionRule::file_path(
+            "apply_patch",
+            deepseek_execpolicy::PermissionDecision::Allow,
+            "docs/**",
+        ),
+        deepseek_execpolicy::ToolPermissionRule::file_path(
+            "apply_patch",
+            deepseek_execpolicy::PermissionDecision::Deny,
+            "secrets/**",
+        ),
+    ]);
+
+    let decision = tool_permission_override_for_call(
+        &engine,
+        "apply_patch",
+        &json!({
+            "path": "docs/a.md",
+            "patch": "--- a/docs/a.md\n+++ b/secrets/token.txt\n@@ -1 +1 @@\n-old\n+new\n"
+        }),
+        permission_test_workspace(),
+    );
+
+    assert!(matches!(decision, ToolPermissionOverride::Deny { .. }));
+}
+
+#[test]
 fn typed_permission_allows_apply_patch_when_all_paths_match() {
     let engine =
         permission_engine_with_rules(vec![deepseek_execpolicy::ToolPermissionRule::file_path(
@@ -379,6 +407,27 @@ fn typed_permission_allows_apply_patch_when_all_paths_match() {
         "apply_patch",
         &json!({
             "patch": "--- a/docs/a.md\n+++ b/docs/a.md\n@@ -1 +1 @@\n-old\n+new\n"
+        }),
+        permission_test_workspace(),
+    );
+
+    assert!(matches!(decision, ToolPermissionOverride::Allow { .. }));
+}
+
+#[test]
+fn typed_permission_parses_apply_patch_paths_with_diff_timestamps() {
+    let engine =
+        permission_engine_with_rules(vec![deepseek_execpolicy::ToolPermissionRule::file_path(
+            "apply_patch",
+            deepseek_execpolicy::PermissionDecision::Allow,
+            "docs/**",
+        )]);
+
+    let decision = tool_permission_override_for_call(
+        &engine,
+        "apply_patch",
+        &json!({
+            "patch": "--- a/docs/a.md\t2026-05-12 12:00:00\n+++ b/docs/a.md\t2026-05-12 12:00:01\n@@ -1 +1 @@\n-old\n+new\n"
         }),
         permission_test_workspace(),
     );

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -293,6 +293,36 @@ fn typed_permission_matches_legacy_file_tool_aliases() {
 }
 
 #[test]
+fn typed_permission_exact_saved_alias_allow_beats_broad_alias_ask() {
+    let engine = permission_engine_with_rules(vec![
+        deepseek_execpolicy::ToolPermissionRule::file_path(
+            "file_edit",
+            deepseek_execpolicy::PermissionDecision::Ask,
+            "src/**",
+        ),
+        deepseek_execpolicy::ToolPermissionRule::file_path(
+            "edit_file",
+            deepseek_execpolicy::PermissionDecision::Allow,
+            "src/main.rs",
+        ),
+        deepseek_execpolicy::ToolPermissionRule::file_path(
+            "file_edit",
+            deepseek_execpolicy::PermissionDecision::Allow,
+            "src/main.rs",
+        ),
+    ]);
+
+    let decision = tool_permission_override_for_call(
+        &engine,
+        "edit_file",
+        &json!({"path": "src/main.rs"}),
+        permission_test_workspace(),
+    );
+
+    assert!(matches!(decision, ToolPermissionOverride::Allow { .. }));
+}
+
+#[test]
 fn typed_permission_denies_file_path_before_tool_execution() {
     let engine =
         permission_engine_with_rules(vec![deepseek_execpolicy::ToolPermissionRule::file_path(

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -1247,7 +1247,7 @@ impl Engine {
                     supports_parallel = spec.supports_parallel();
                     read_only = spec.is_read_only();
                 } else if tool_name == MULTI_TOOL_PARALLEL_NAME {
-                    approval_required = false;
+                    approval_required = true;
                     approval_description =
                         "Execute multiple read-only tools in parallel".to_string();
                     supports_parallel = false;

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -1223,6 +1223,7 @@ impl Engine {
                 if blocked_error.is_none()
                     && tool_def.is_none()
                     && !McpPool::is_mcp_tool(&tool_name)
+                    && tool_name != MULTI_TOOL_PARALLEL_NAME
                     && tool_name != CODE_EXECUTION_TOOL_NAME
                     && tool_name != JS_EXECUTION_TOOL_NAME
                     && !is_tool_search_tool(&tool_name)
@@ -1245,6 +1246,12 @@ impl Engine {
                     approval_description = spec.description().to_string();
                     supports_parallel = spec.supports_parallel();
                     read_only = spec.is_read_only();
+                } else if tool_name == MULTI_TOOL_PARALLEL_NAME {
+                    approval_required = false;
+                    approval_description =
+                        "Execute multiple read-only tools in parallel".to_string();
+                    supports_parallel = false;
+                    read_only = true;
                 } else if tool_name == CODE_EXECUTION_TOOL_NAME {
                     approval_required = true;
                     approval_description =
@@ -1267,6 +1274,30 @@ impl Engine {
 
                 let should_emit_hydration_status =
                     !deferred_tools_hydrated_this_batch.contains(&tool_name);
+
+                if blocked_error.is_none() {
+                    match tool_permission_override_for_call(
+                        &self.config.exec_policy_engine,
+                        &tool_name,
+                        &tool_input,
+                        &self.session.workspace,
+                    ) {
+                        ToolPermissionOverride::Allow { reason } => {
+                            approval_required = false;
+                            approval_description = reason;
+                        }
+                        ToolPermissionOverride::Ask { reason } => {
+                            approval_required = true;
+                            approval_description = reason;
+                        }
+                        ToolPermissionOverride::Deny { reason } => {
+                            approval_required = false;
+                            blocked_error = Some(ToolError::permission_denied(reason));
+                        }
+                        ToolPermissionOverride::Unmatched => {}
+                    }
+                }
+
                 if blocked_error.is_none()
                     && let Some(result) = maybe_hydrate_requested_deferred_tool(
                         &tool_name,

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 use anyhow::{Context, Result, anyhow, bail};
 use clap::{Args, CommandFactory, Parser, Subcommand, ValueEnum};
 use clap_complete::{Shell, generate};
+use deepseek_execpolicy::PermissionDecision;
 use dotenvy::dotenv;
 use tempfile::NamedTempFile;
 use wait_timeout::ChildExt;
@@ -4288,6 +4289,11 @@ fn merge_project_config(config: &mut Config, workspace: &Path) {
         config.allow_shell = Some(v);
     }
 
+    // Project-level permission config is allowed only when it tightens the
+    // effective policy. A repository can require extra prompts or denials, but
+    // it cannot grant itself broader tool access.
+    merge_project_permission_config(config, table);
+
     // #454: instructions array — project replaces user. Empty arrays
     // count: explicit `instructions = []` clears the user's list for
     // this repo, useful when the user has a verbose global file that
@@ -4301,6 +4307,72 @@ fn merge_project_config(config: &mut Config, workspace: &Path) {
             .collect();
         config.instructions = Some(entries);
     }
+}
+
+fn merge_project_permission_config(
+    config: &mut Config,
+    table: &toml::map::Map<String, toml::Value>,
+) {
+    if let Some(value) = table.get("auto_allow") {
+        let ignored = value.as_array().map_or(0, Vec::len);
+        if ignored > 0 {
+            eprintln!(
+                "warning: project-scope `auto_allow` is ignored — \
+                 project config cannot grant persistent command allow rules."
+            );
+        }
+    }
+
+    if let Some(value) = table.get("auto_deny") {
+        match string_array_from_project_value(value) {
+            Some(entries) => config.auto_deny.extend(entries),
+            None => eprintln!(
+                "warning: project-scope `auto_deny` is ignored — expected an array of strings."
+            ),
+        }
+    }
+
+    let Some(value) = table.get("permissions") else {
+        return;
+    };
+    let permissions: crate::config::PermissionsConfig = match value.clone().try_into() {
+        Ok(permissions) => permissions,
+        Err(err) => {
+            eprintln!(
+                "warning: project-scope `[permissions]` is ignored — failed to parse permission rules: {err}"
+            );
+            return;
+        }
+    };
+
+    for rule in permissions.rules {
+        match rule.decision {
+            PermissionDecision::Deny | PermissionDecision::Ask => {
+                config.permissions.rules.push(rule);
+            }
+            PermissionDecision::Allow => {
+                eprintln!(
+                    "warning: project-scope allow permission rule `{}` is ignored — \
+                     project config cannot grant persistent tool allow rules.",
+                    rule.pattern_label()
+                );
+            }
+        }
+    }
+}
+
+fn string_array_from_project_value(value: &toml::Value) -> Option<Vec<String>> {
+    Some(
+        value
+            .as_array()?
+            .iter()
+            .map(toml::Value::as_str)
+            .collect::<Option<Vec<_>>>()?
+            .into_iter()
+            .filter(|item| !item.trim().is_empty())
+            .map(str::to_string)
+            .collect(),
+    )
 }
 
 async fn run_interactive(
@@ -4716,6 +4788,7 @@ async fn run_exec_agent(
             .and_then(|s| s.provider)
             .unwrap_or_default(),
         search_api_key: config.search.as_ref().and_then(|s| s.api_key.clone()),
+        exec_policy_engine: config.exec_policy_engine(),
     };
 
     let engine_handle = spawn_engine(engine_config, config);
@@ -5748,6 +5821,48 @@ allow_shell = false
         merge_project_config(&mut config, tmp.path());
         assert_eq!(config.max_subagents, Some(4));
         assert_eq!(config.allow_shell, Some(false));
+    }
+
+    #[test]
+    fn project_overlay_applies_only_tightening_permission_rules() {
+        let tmp = workspace_with_project_config(
+            r#"
+auto_allow = ["cargo test"]
+auto_deny = ["rm -rf"]
+
+[[permissions.rules]]
+tool = "read_file"
+decision = "ask"
+path = "secrets/**"
+
+[[permissions.rules]]
+tool = "write_file"
+decision = "deny"
+path = "src/**"
+
+[[permissions.rules]]
+tool = "exec_shell"
+decision = "allow"
+command = "cargo test"
+"#,
+        );
+        let mut config = Config::default();
+        merge_project_config(&mut config, tmp.path());
+
+        assert!(
+            config.auto_allow.is_empty(),
+            "project-scope auto_allow must not grant access"
+        );
+        assert_eq!(config.auto_deny, ["rm -rf"]);
+        assert_eq!(config.permissions.rules.len(), 2);
+        assert_eq!(
+            config.permissions.rules[0].decision,
+            PermissionDecision::Ask
+        );
+        assert_eq!(
+            config.permissions.rules[1].decision,
+            PermissionDecision::Deny
+        );
     }
 
     #[test]

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -1985,6 +1985,7 @@ impl RuntimeThreadManager {
                 .and_then(|s| s.provider)
                 .unwrap_or_default(),
             search_api_key: self.config.search.as_ref().and_then(|s| s.api_key.clone()),
+            exec_policy_engine: self.config.exec_policy_engine(),
         };
 
         let engine = spawn_engine(engine_cfg, &self.config);

--- a/crates/tui/src/tools/pandoc.rs
+++ b/crates/tui/src/tools/pandoc.rs
@@ -144,7 +144,9 @@ impl ToolSpec for PandocConvertTool {
         // gated on resolve_pandoc(), but a concurrent uninstall between
         // catalog build and the model's call should produce a clear
         // error rather than the cryptic "program not found" from raw
-        // Command::spawn.
+        // Command::spawn. Input validation above intentionally runs first
+        // so tests and users get deterministic schema/actionable errors
+        // even on machines without pandoc installed.
         let pandoc = crate::dependencies::resolve_pandoc().ok_or_else(|| {
             ToolError::execution_failed(
                 "pandoc_convert: pandoc binary not found on PATH. \

--- a/crates/tui/src/tui/approval.rs
+++ b/crates/tui/src/tui/approval.rs
@@ -332,20 +332,7 @@ fn permission_decision_label(decision: PermissionDecision) -> &'static str {
 }
 
 fn toml_string(value: &str) -> String {
-    let mut out = String::with_capacity(value.len() + 2);
-    out.push('"');
-    for ch in value.chars() {
-        match ch {
-            '\\' => out.push_str("\\\\"),
-            '"' => out.push_str("\\\""),
-            '\n' => out.push_str("\\n"),
-            '\r' => out.push_str("\\r"),
-            '\t' => out.push_str("\\t"),
-            _ => out.push(ch),
-        }
-    }
-    out.push('"');
-    out
+    toml_edit::Value::from(value).to_string()
 }
 
 fn file_path_permission_rules(tool_name: &str, path: &str) -> Vec<ToolPermissionRule> {
@@ -481,9 +468,7 @@ fn apply_patch_permission_paths(input: &Value) -> Vec<String> {
             }
         }
     }
-    if paths.is_empty()
-        && let Some(patch) = input.get("patch").and_then(Value::as_str)
-    {
+    if let Some(patch) = input.get("patch").and_then(Value::as_str) {
         for path in parse_unified_diff_permission_paths(patch) {
             push_unique_permission_path(&mut paths, &path);
         }
@@ -513,7 +498,7 @@ fn parse_unified_diff_permission_paths(patch: &str) -> Vec<String> {
 }
 
 fn normalize_diff_permission_path(raw: &str) -> Option<String> {
-    let raw = raw.trim();
+    let raw = raw.split('\t').next()?.trim();
     if raw.is_empty() || raw == "/dev/null" || raw == "dev/null" {
         return None;
     }
@@ -1619,6 +1604,55 @@ mod tests {
                 "apply_patch",
                 PermissionDecision::Allow,
                 "docs/new.md"
+            )]
+        );
+    }
+
+    #[test]
+    fn persistent_permission_rules_extract_patch_even_with_path_field() {
+        let rules = build_persistent_permission_rules(
+            "apply_patch",
+            &json!({
+                "path": "docs/declared.md",
+                "patch": "\
+            --- a/docs/old.md\n\
+            +++ b/docs/new.md\n\
+            @@ -1 +1 @@\n"
+            }),
+        );
+
+        assert_eq!(
+            rules,
+            vec![
+                ToolPermissionRule::file_path(
+                    "apply_patch",
+                    PermissionDecision::Allow,
+                    "docs/declared.md"
+                ),
+                ToolPermissionRule::file_path(
+                    "apply_patch",
+                    PermissionDecision::Allow,
+                    "docs/new.md"
+                )
+            ]
+        );
+    }
+
+    #[test]
+    fn persistent_permission_rules_parse_diff_headers_with_timestamps() {
+        let rules = build_persistent_permission_rules(
+            "apply_patch",
+            &json!({
+                "patch": "--- a/docs/a.md\t2026-05-12 12:00:00\n+++ b/docs/a.md\t2026-05-12 12:00:01\n@@ -1 +1 @@\n-old\n+new\n"
+            }),
+        );
+
+        assert_eq!(
+            rules,
+            vec![ToolPermissionRule::file_path(
+                "apply_patch",
+                PermissionDecision::Allow,
+                "docs/a.md"
             )]
         );
     }

--- a/crates/tui/src/tui/approval.rs
+++ b/crates/tui/src/tui/approval.rs
@@ -21,9 +21,9 @@
 //!   accidentally land on an approval. Any non-approve key clears the
 //!   staging and keeps the user in selection mode.
 //!
-//! The decision events emitted upstream are unchanged
-//! (`ViewEvent::ApprovalDecision`), so `ui.rs` and the engine handle
-//! both variants without modification. Auto-approve / YOLO bypasses
+//! The decision events emitted upstream are still
+//! `ViewEvent::ApprovalDecision`, with optional persistent permission
+//! rules for the "save this rule" action. Auto-approve / YOLO bypasses
 //! happen *before* the view is constructed (see `tui/ui.rs`); this
 //! module always assumes the user is being asked.
 
@@ -32,8 +32,9 @@ use crate::sandbox::SandboxPolicy;
 use crate::tui::views::{ModalKind, ModalView, ViewAction, ViewEvent};
 use crate::tui::widgets::{ApprovalWidget, ElevationWidget, Renderable};
 use crossterm::event::{KeyCode, KeyEvent};
+use deepseek_execpolicy::{PermissionDecision, ToolPermissionRule};
 use serde_json::Value;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::time::{Duration, Instant};
 
 /// Determines when tool executions require user approval
@@ -135,15 +136,47 @@ pub struct ApprovalRequest {
     /// Lossy / arity-aware fingerprint, used to scope *approvals* so an
     /// "approve for session" covers later flag variants (v0.8.37).
     pub approval_grouping_key: String,
+    /// Generated persistent allow rules for the "save this rule" action.
+    pub persistent_rules: Vec<ToolPermissionRule>,
 }
 
 impl ApprovalRequest {
+    #[cfg(test)]
     pub fn new(
         id: &str,
         tool_name: &str,
         description: &str,
         params: &Value,
         approval_key: &str,
+    ) -> Self {
+        Self::new_inner(id, tool_name, description, params, approval_key, None)
+    }
+
+    pub fn new_with_workspace(
+        id: &str,
+        tool_name: &str,
+        description: &str,
+        params: &Value,
+        approval_key: &str,
+        workspace: &Path,
+    ) -> Self {
+        Self::new_inner(
+            id,
+            tool_name,
+            description,
+            params,
+            approval_key,
+            Some(workspace),
+        )
+    }
+
+    fn new_inner(
+        id: &str,
+        tool_name: &str,
+        description: &str,
+        params: &Value,
+        approval_key: &str,
+        workspace: Option<&Path>,
     ) -> Self {
         let category = get_tool_category(tool_name);
         let risk = classify_risk(tool_name, category, params);
@@ -160,6 +193,7 @@ impl ApprovalRequest {
             params: params.clone(),
             approval_key: approval_key.to_string(),
             approval_grouping_key,
+            persistent_rules: build_persistent_permission_rules_inner(tool_name, params, workspace),
         }
     }
 
@@ -183,6 +217,323 @@ impl ApprovalRequest {
             }
             _ => self.impacts.clone(),
         }
+    }
+
+    pub fn permission_rule_preview(&self) -> Option<String> {
+        if self.persistent_rules.is_empty() {
+            None
+        } else {
+            Some(format_permission_rules_preview(&self.persistent_rules))
+        }
+    }
+}
+
+#[cfg(test)]
+pub fn build_persistent_permission_rules(
+    tool_name: &str,
+    params: &Value,
+) -> Vec<ToolPermissionRule> {
+    build_persistent_permission_rules_inner(tool_name, params, None)
+}
+
+#[cfg(test)]
+pub fn build_persistent_permission_rules_for_workspace(
+    tool_name: &str,
+    params: &Value,
+    workspace: &Path,
+) -> Vec<ToolPermissionRule> {
+    build_persistent_permission_rules_inner(tool_name, params, Some(workspace))
+}
+
+fn build_persistent_permission_rules_inner(
+    tool_name: &str,
+    params: &Value,
+    workspace: Option<&Path>,
+) -> Vec<ToolPermissionRule> {
+    match tool_name {
+        "exec_shell"
+        | "exec_shell_wait"
+        | "exec_shell_interact"
+        | "exec_wait"
+        | "exec_interact" => params
+            .get("command")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|command| !command.is_empty())
+            .map(|command| {
+                let mut rule = ToolPermissionRule::new(tool_name, PermissionDecision::Allow);
+                rule.command = Some(command.to_string());
+                vec![rule]
+            })
+            .unwrap_or_default(),
+        "read_file" | "write_file" | "edit_file" => params
+            .get("path")
+            .and_then(Value::as_str)
+            .and_then(|path| normalize_persistent_permission_path(path, workspace))
+            .map(|path| file_path_permission_rules(tool_name, &path))
+            .unwrap_or_default(),
+        "list_dir" => {
+            let Some(path) = params
+                .get("path")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|path| !path.is_empty())
+                .or(Some("."))
+                .and_then(|path| normalize_persistent_permission_path(path, workspace))
+            else {
+                return Vec::new();
+            };
+            file_path_permission_rules(tool_name, &path)
+        }
+        "apply_patch" => apply_patch_permission_paths(params)
+            .into_iter()
+            .filter_map(|path| normalize_persistent_permission_path(&path, workspace))
+            .flat_map(|path| file_path_permission_rules(tool_name, &path))
+            .fold(Vec::new(), |mut rules, rule| {
+                push_unique_permission_rule(&mut rules, rule);
+                rules
+            }),
+        _ => Vec::new(),
+    }
+}
+
+pub fn format_permission_rules_preview(rules: &[ToolPermissionRule]) -> String {
+    rules
+        .iter()
+        .map(format_permission_rule_preview)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn format_permission_rule_preview(rule: &ToolPermissionRule) -> String {
+    let mut lines = vec![
+        "[[permissions.rules]]".to_string(),
+        format!("tool = {}", toml_string(&rule.tool)),
+        format!(
+            "decision = {}",
+            toml_string(permission_decision_label(rule.decision))
+        ),
+    ];
+    if let Some(command) = rule.command.as_deref() {
+        lines.push(format!("command = {}", toml_string(command)));
+    }
+    if let Some(path) = rule.path.as_deref() {
+        lines.push(format!("path = {}", toml_string(path)));
+    }
+    lines.join("\n")
+}
+
+fn permission_decision_label(decision: PermissionDecision) -> &'static str {
+    match decision {
+        PermissionDecision::Allow => "allow",
+        PermissionDecision::Deny => "deny",
+        PermissionDecision::Ask => "ask",
+    }
+}
+
+fn toml_string(value: &str) -> String {
+    let mut out = String::with_capacity(value.len() + 2);
+    out.push('"');
+    for ch in value.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            _ => out.push(ch),
+        }
+    }
+    out.push('"');
+    out
+}
+
+fn file_path_permission_rules(tool_name: &str, path: &str) -> Vec<ToolPermissionRule> {
+    persistent_file_rule_tools(tool_name)
+        .iter()
+        .map(|tool| ToolPermissionRule::file_path(*tool, PermissionDecision::Allow, path))
+        .collect()
+}
+
+fn persistent_file_rule_tools(tool_name: &str) -> Vec<&str> {
+    match tool_name {
+        "read_file" => vec!["read_file", "file_read"],
+        "write_file" => vec!["write_file", "file_write"],
+        "edit_file" => vec!["edit_file", "file_edit"],
+        _ => vec![tool_name],
+    }
+}
+
+fn normalize_persistent_permission_path(raw: &str, workspace: Option<&Path>) -> Option<String> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return None;
+    }
+
+    let raw_path = Path::new(raw);
+    let normalized = if let Some(workspace) = workspace {
+        let workspace = absolute_normalized_workspace(workspace);
+        let candidate = if raw_path.is_absolute() {
+            normalize_path(raw_path)
+        } else {
+            normalize_path(&workspace.join(raw_path))
+        };
+        candidate
+            .strip_prefix(&workspace)
+            .map(normalize_path)
+            .unwrap_or_else(|_| {
+                if raw_path.is_absolute() {
+                    candidate
+                } else {
+                    normalize_path(raw_path)
+                }
+            })
+    } else {
+        normalize_path(raw_path)
+    };
+
+    let path = permission_path_to_string(&normalized);
+    if path_contains_glob_metachar(&path) {
+        return None;
+    }
+    Some(path)
+}
+
+fn absolute_normalized_workspace(workspace: &Path) -> PathBuf {
+    let workspace = if workspace.is_absolute() {
+        workspace.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map(|current_dir| current_dir.join(workspace))
+            .unwrap_or_else(|_| workspace.to_path_buf())
+    };
+    normalize_path(&workspace)
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    let mut prefix: Option<std::ffi::OsString> = None;
+    let mut is_root = false;
+    let mut stack: Vec<std::ffi::OsString> = Vec::new();
+
+    for component in path.components() {
+        match component {
+            Component::Prefix(prefix_component) => {
+                prefix = Some(prefix_component.as_os_str().to_owned());
+            }
+            Component::RootDir => {
+                is_root = true;
+            }
+            Component::CurDir => {}
+            Component::ParentDir => {
+                let parent = Component::ParentDir.as_os_str();
+                if let Some(last) = stack.pop() {
+                    if last == parent {
+                        stack.push(last);
+                        stack.push(parent.to_owned());
+                    }
+                } else if !is_root {
+                    stack.push(parent.to_owned());
+                }
+            }
+            Component::Normal(part) => {
+                stack.push(part.to_owned());
+            }
+        }
+    }
+
+    let mut normalized = PathBuf::new();
+    if let Some(prefix) = prefix {
+        normalized.push(prefix);
+    }
+    if is_root {
+        normalized.push(Path::new(std::path::MAIN_SEPARATOR_STR));
+    }
+    for part in stack {
+        normalized.push(part);
+    }
+    normalized
+}
+
+fn permission_path_to_string(path: &Path) -> String {
+    if path.as_os_str().is_empty() {
+        ".".to_string()
+    } else {
+        path.to_string_lossy().replace('\\', "/")
+    }
+}
+
+fn path_contains_glob_metachar(path: &str) -> bool {
+    path.chars()
+        .any(|ch| matches!(ch, '*' | '?' | '[' | ']' | '{' | '}'))
+}
+
+fn apply_patch_permission_paths(input: &Value) -> Vec<String> {
+    let mut paths = Vec::new();
+    if let Some(path) = input.get("path").and_then(Value::as_str) {
+        push_unique_permission_path(&mut paths, path);
+    }
+    for key in ["changes", "files"] {
+        if let Some(entries) = input.get(key).and_then(Value::as_array) {
+            for entry in entries {
+                if let Some(path) = entry.get("path").and_then(Value::as_str) {
+                    push_unique_permission_path(&mut paths, path);
+                }
+            }
+        }
+    }
+    if paths.is_empty()
+        && let Some(patch) = input.get("patch").and_then(Value::as_str)
+    {
+        for path in parse_unified_diff_permission_paths(patch) {
+            push_unique_permission_path(&mut paths, &path);
+        }
+    }
+    paths
+}
+
+fn parse_unified_diff_permission_paths(patch: &str) -> Vec<String> {
+    let mut paths = Vec::new();
+    let mut old_path: Option<String> = None;
+
+    for line in patch.lines() {
+        if let Some(stripped) = line.strip_prefix("--- ") {
+            old_path = normalize_diff_permission_path(stripped);
+            continue;
+        }
+        if let Some(stripped) = line.strip_prefix("+++ ") {
+            let new_path = normalize_diff_permission_path(stripped);
+            if let Some(path) = new_path.or_else(|| old_path.clone()) {
+                push_unique_permission_path(&mut paths, &path);
+            }
+            old_path = None;
+        }
+    }
+
+    paths
+}
+
+fn normalize_diff_permission_path(raw: &str) -> Option<String> {
+    let raw = raw.trim();
+    if raw.is_empty() || raw == "/dev/null" || raw == "dev/null" {
+        return None;
+    }
+    let raw = raw
+        .strip_prefix("a/")
+        .or_else(|| raw.strip_prefix("b/"))
+        .unwrap_or(raw);
+    Some(raw.to_string())
+}
+
+fn push_unique_permission_path(paths: &mut Vec<String>, path: &str) {
+    let path = path.trim();
+    if !path.is_empty() && !paths.iter().any(|existing| existing == path) {
+        paths.push(path.to_string());
+    }
+}
+
+fn push_unique_permission_rule(rules: &mut Vec<ToolPermissionRule>, rule: ToolPermissionRule) {
+    if !rules.iter().any(|existing| existing == &rule) {
+        rules.push(rule);
     }
 }
 
@@ -508,6 +859,7 @@ pub struct ApprovalView {
     /// is waiting for the user to press the same key (or `Enter`) again.
     /// Any other key clears the staging.
     pending_confirm: Option<ApprovalOption>,
+    pending_persist_rule: bool,
     timeout: Option<Duration>,
     requested_at: Instant,
     /// Whether the approval card is collapsed to a single-line banner.
@@ -526,6 +878,7 @@ impl ApprovalView {
             selected: 0,
             locale,
             pending_confirm: None,
+            pending_persist_rule: false,
             timeout: None,
             requested_at: Instant::now(),
             collapsed: false,
@@ -537,11 +890,13 @@ impl ApprovalView {
         // Moving the selection abandons any staged confirmation; the
         // user is reconsidering.
         self.pending_confirm = None;
+        self.pending_persist_rule = false;
     }
 
     fn select_next(&mut self) {
         self.selected = (self.selected + 1).min(ApprovalOption::ORDER.len() - 1);
         self.pending_confirm = None;
+        self.pending_persist_rule = false;
     }
 
     fn current_option(&self) -> ApprovalOption {
@@ -572,6 +927,10 @@ impl ApprovalView {
         self.pending_confirm
     }
 
+    pub(crate) fn pending_persist_rule(&self) -> bool {
+        self.pending_persist_rule
+    }
+
     pub(crate) fn locale(&self) -> Locale {
         self.locale
     }
@@ -580,6 +939,7 @@ impl ApprovalView {
     /// variant's confirmation policy. Returns the action the modal
     /// stack should apply.
     fn commit_or_stage(&mut self, option: ApprovalOption) -> ViewAction {
+        self.pending_persist_rule = false;
         if option.requires_confirm(self.request.risk) {
             // Two-step destructive flow: first press stages, second
             // press of the same option commits.
@@ -593,10 +953,20 @@ impl ApprovalView {
         }
         // Benign variant or non-approve options commit immediately.
         self.pending_confirm = None;
+        self.pending_persist_rule = false;
         self.emit_decision(option.decision(), false)
     }
 
     fn emit_decision(&self, decision: ReviewDecision, timed_out: bool) -> ViewAction {
+        self.emit_decision_with_rules(decision, timed_out, Vec::new())
+    }
+
+    fn emit_decision_with_rules(
+        &self,
+        decision: ReviewDecision,
+        timed_out: bool,
+        persistent_rules: Vec<ToolPermissionRule>,
+    ) -> ViewAction {
         ViewAction::EmitAndClose(ViewEvent::ApprovalDecision {
             tool_id: self.request.id.clone(),
             tool_name: self.request.tool_name.clone(),
@@ -604,7 +974,28 @@ impl ApprovalView {
             timed_out,
             approval_key: self.request.approval_key.clone(),
             approval_grouping_key: self.request.approval_grouping_key.clone(),
+            persistent_rules,
         })
+    }
+
+    fn commit_or_stage_persist_rule(&mut self) -> ViewAction {
+        if self.request.persistent_rules.is_empty() {
+            self.pending_confirm = None;
+            self.pending_persist_rule = false;
+            return ViewAction::None;
+        }
+        if matches!(self.request.risk, RiskLevel::Destructive) && !self.pending_persist_rule {
+            self.pending_confirm = None;
+            self.pending_persist_rule = true;
+            return ViewAction::None;
+        }
+        self.pending_confirm = None;
+        self.pending_persist_rule = false;
+        self.emit_decision_with_rules(
+            ReviewDecision::Approved,
+            false,
+            self.request.persistent_rules.clone(),
+        )
     }
 
     fn emit_params_pager(&self) -> ViewAction {
@@ -612,6 +1003,16 @@ impl ApprovalView {
             .unwrap_or_else(|_| self.request.params.to_string());
         ViewAction::Emit(ViewEvent::OpenTextPager {
             title: format!("Tool Params: {}", self.request.tool_name),
+            content,
+        })
+    }
+
+    fn emit_permission_rule_pager(&self) -> ViewAction {
+        let Some(content) = self.request.permission_rule_preview() else {
+            return ViewAction::None;
+        };
+        ViewAction::Emit(ViewEvent::OpenTextPager {
+            title: format!("Permission Rule: {}", self.request.tool_name),
             content,
         })
     }
@@ -656,6 +1057,7 @@ impl ModalView for ApprovalView {
             KeyCode::Char('a') | KeyCode::Char('A') | KeyCode::Char('2') => {
                 self.commit_or_stage(ApprovalOption::ApproveAlways)
             }
+            KeyCode::Char('s') | KeyCode::Char('S') => self.commit_or_stage_persist_rule(),
             KeyCode::Char('n')
             | KeyCode::Char('N')
             | KeyCode::Char('d')
@@ -663,13 +1065,20 @@ impl ModalView for ApprovalView {
             | KeyCode::Char('3') => self.commit_or_stage(ApprovalOption::Deny),
             KeyCode::Char('v') | KeyCode::Char('V') => {
                 self.pending_confirm = None;
+                self.pending_persist_rule = false;
                 self.emit_params_pager()
+            }
+            KeyCode::Char('p') | KeyCode::Char('P') => {
+                self.pending_confirm = None;
+                self.pending_persist_rule = false;
+                self.emit_permission_rule_pager()
             }
             KeyCode::Esc => self.emit_decision(ReviewDecision::Abort, false),
             _ => {
                 // Any unrecognised key cancels a staged confirmation —
                 // the user is no longer aiming at "approve".
                 self.pending_confirm = None;
+                self.pending_persist_rule = false;
                 ViewAction::None
             }
         }
@@ -1154,6 +1563,138 @@ mod tests {
         );
     }
 
+    #[test]
+    fn persistent_permission_rule_preview_uses_exact_command() {
+        let request = ApprovalRequest::new(
+            "test-id",
+            "exec_shell",
+            "Run a shell command",
+            &json!({"command": "cargo test --workspace"}),
+            "test_key",
+        );
+
+        assert_eq!(
+            request.persistent_rules,
+            vec![ToolPermissionRule::exec_shell(
+                PermissionDecision::Allow,
+                "cargo test --workspace"
+            )]
+        );
+        let preview = request
+            .permission_rule_preview()
+            .expect("exec_shell should produce a preview");
+        assert!(preview.contains("[[permissions.rules]]"));
+        assert!(preview.contains("tool = \"exec_shell\""));
+        assert!(preview.contains("decision = \"allow\""));
+        assert!(preview.contains("command = \"cargo test --workspace\""));
+    }
+
+    #[test]
+    fn persistent_permission_rule_preserves_shell_alias_tool_name() {
+        let rules = build_persistent_permission_rules(
+            "exec_shell_wait",
+            &json!({"command": "cargo test --workspace"}),
+        );
+
+        let mut expected = ToolPermissionRule::new("exec_shell_wait", PermissionDecision::Allow);
+        expected.command = Some("cargo test --workspace".to_string());
+        assert_eq!(rules, vec![expected]);
+    }
+
+    #[test]
+    fn persistent_permission_rules_extract_apply_patch_diff_paths() {
+        let rules = build_persistent_permission_rules(
+            "apply_patch",
+            &json!({
+                "patch": "\
+            --- a/docs/old.md\n\
+            +++ b/docs/new.md\n\
+            @@ -1 +1 @@\n"
+            }),
+        );
+
+        assert_eq!(
+            rules,
+            vec![ToolPermissionRule::file_path(
+                "apply_patch",
+                PermissionDecision::Allow,
+                "docs/new.md"
+            )]
+        );
+    }
+
+    #[test]
+    fn persistent_permission_rules_skip_glob_like_file_paths() {
+        assert!(
+            build_persistent_permission_rules("read_file", &json!({"path": "src/**"})).is_empty()
+        );
+        assert!(
+            build_persistent_permission_rules(
+                "apply_patch",
+                &json!({"files": [{"path": "docs/*.md"}]})
+            )
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn persistent_permission_rules_normalize_absolute_paths_to_workspace_relative() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let path = workspace.path().join("src").join("main.rs");
+
+        let rules = build_persistent_permission_rules_for_workspace(
+            "write_file",
+            &json!({"path": path.to_string_lossy()}),
+            workspace.path(),
+        );
+
+        assert_eq!(
+            rules,
+            vec![
+                ToolPermissionRule::file_path(
+                    "write_file",
+                    PermissionDecision::Allow,
+                    "src/main.rs"
+                ),
+                ToolPermissionRule::file_path(
+                    "file_write",
+                    PermissionDecision::Allow,
+                    "src/main.rs"
+                )
+            ]
+        );
+    }
+
+    #[test]
+    fn persistent_permission_rules_extract_apply_patch_file_entries() {
+        let rules = build_persistent_permission_rules(
+            "apply_patch",
+            &json!({
+                "files": [
+                    {"path": "src/lib.rs"},
+                    {"path": "src/lib.rs"},
+                    {"path": "src/main.rs"}
+                ]
+            }),
+        );
+
+        assert_eq!(
+            rules,
+            vec![
+                ToolPermissionRule::file_path(
+                    "apply_patch",
+                    PermissionDecision::Allow,
+                    "src/lib.rs"
+                ),
+                ToolPermissionRule::file_path(
+                    "apply_patch",
+                    PermissionDecision::Allow,
+                    "src/main.rs"
+                )
+            ]
+        );
+    }
+
     // ========================================================================
     // ApprovalView Tests — Benign Variant (single-key approve)
     // ========================================================================
@@ -1251,6 +1792,53 @@ mod tests {
                 ..
             })
         ));
+    }
+
+    #[test]
+    fn benign_s_saves_rule_and_approves() {
+        let mut view = ApprovalView::new(benign_request());
+        let action = view.handle_key(create_key_event(KeyCode::Char('s')));
+
+        match action {
+            ViewAction::EmitAndClose(ViewEvent::ApprovalDecision {
+                decision,
+                persistent_rules,
+                ..
+            }) => {
+                assert_eq!(decision, ReviewDecision::Approved);
+                assert_eq!(
+                    persistent_rules,
+                    vec![
+                        ToolPermissionRule::file_path(
+                            "read_file",
+                            PermissionDecision::Allow,
+                            "src/main.rs"
+                        ),
+                        ToolPermissionRule::file_path(
+                            "file_read",
+                            PermissionDecision::Allow,
+                            "src/main.rs"
+                        )
+                    ]
+                );
+            }
+            other => panic!("expected persistent approval event, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn p_opens_full_permission_rule_preview() {
+        let mut view = ApprovalView::new(benign_request());
+        let action = view.handle_key(create_key_event(KeyCode::Char('p')));
+
+        match action {
+            ViewAction::Emit(ViewEvent::OpenTextPager { title, content }) => {
+                assert_eq!(title, "Permission Rule: read_file");
+                assert!(content.contains("tool = \"read_file\""));
+                assert!(content.contains("tool = \"file_read\""));
+            }
+            other => panic!("expected permission rule pager, got {other:?}"),
+        }
     }
 
     #[test]
@@ -1407,6 +1995,43 @@ mod tests {
                 ),
                 "expected Approved for {code:?}"
             );
+        }
+    }
+
+    #[test]
+    fn destructive_s_first_press_stages_then_second_saves_rule() {
+        let mut view = ApprovalView::new(destructive_request());
+
+        let action = view.handle_key(create_key_event(KeyCode::Char('s')));
+        assert!(matches!(action, ViewAction::None));
+        assert_eq!(view.pending_confirm(), None);
+        assert!(view.pending_persist_rule());
+
+        let action = view.handle_key(create_key_event(KeyCode::Char('s')));
+        match action {
+            ViewAction::EmitAndClose(ViewEvent::ApprovalDecision {
+                decision,
+                persistent_rules,
+                ..
+            }) => {
+                assert_eq!(decision, ReviewDecision::Approved);
+                assert_eq!(
+                    persistent_rules,
+                    vec![
+                        ToolPermissionRule::file_path(
+                            "write_file",
+                            PermissionDecision::Allow,
+                            "src/main.rs"
+                        ),
+                        ToolPermissionRule::file_path(
+                            "file_write",
+                            PermissionDecision::Allow,
+                            "src/main.rs"
+                        )
+                    ]
+                );
+            }
+            other => panic!("expected persistent approval event, got {other:?}"),
         }
     }
 

--- a/crates/tui/src/tui/sidebar.rs
+++ b/crates/tui/src/tui/sidebar.rs
@@ -1798,8 +1798,8 @@ mod tests {
     use super::{
         ACTIVE_TOOL_COMPLETED_ROW_TTL, ACTIVE_TOOL_STALE_RUNNING_ROW_TTL, AutoSidebarPanel,
         AutoSidebarState, SidebarAgentRow, SidebarSubagentSummary, SidebarWorkChecklistItem,
-        SidebarWorkStrategyStep, SidebarWorkSummary, auto_sidebar_panels, subagent_panel_lines,
-        task_panel_lines, work_panel_empty_hint, work_panel_lines,
+        SidebarWorkStrategyStep, SidebarWorkSummary, auto_sidebar_panels, duration_ms,
+        subagent_panel_lines, task_panel_lines, work_panel_empty_hint, work_panel_lines,
     };
     use crate::config::Config;
     use crate::palette::PaletteMode;
@@ -2142,6 +2142,8 @@ mod tests {
     fn tasks_panel_collapses_stale_running_tool_rows() {
         let mut app = create_test_app();
         let mut active = ActiveCell::new();
+        let stale_duration_ms =
+            duration_ms(ACTIVE_TOOL_STALE_RUNNING_ROW_TTL).saturating_add(1_000);
         for (idx, command) in ["long one", "long two"].into_iter().enumerate() {
             active.push_tool(
                 format!("shell-{idx}"),
@@ -2150,7 +2152,7 @@ mod tests {
                     status: ToolStatus::Running,
                     output: None,
                     started_at: None,
-                    duration_ms: Some(ACTIVE_TOOL_STALE_RUNNING_ROW_TTL.as_millis() as u64 + 1),
+                    duration_ms: Some(stale_duration_ms),
                     source: ExecSource::Assistant,
                     interaction: None,
                     output_summary: None,

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -1773,12 +1773,13 @@ async fn run_event_loop(
                             }
 
                             // Create approval request and show overlay
-                            let request = ApprovalRequest::new(
+                            let request = ApprovalRequest::new_with_workspace(
                                 &id,
                                 &tool_name,
                                 &description,
                                 &tool_input,
                                 &approval_key,
+                                &app.workspace,
                             );
                             log_sensitive_event(
                                 "tool.approval.prompted",
@@ -5711,6 +5712,7 @@ async fn handle_view_events(
                 timed_out,
                 approval_key,
                 approval_grouping_key,
+                persistent_rules,
             } => {
                 if decision == ReviewDecision::ApprovedForSession {
                     // Store the tool name (backward compat) and the lossy
@@ -5721,9 +5723,45 @@ async fn handle_view_events(
                         .insert(approval_grouping_key.clone());
                 }
 
+                let mut live_persistent_rules = Vec::new();
+                if matches!(
+                    decision,
+                    ReviewDecision::Approved | ReviewDecision::ApprovedForSession
+                ) && !persistent_rules.is_empty()
+                {
+                    match crate::commands::persist_permission_rules(&persistent_rules) {
+                        Ok(path) => {
+                            live_persistent_rules = persistent_rules;
+                            let noun = if live_persistent_rules.len() == 1 {
+                                "rule"
+                            } else {
+                                "rules"
+                            };
+                            app.push_status_toast(
+                                format!("Saved permission {noun} to {}", path.display()),
+                                StatusToastLevel::Success,
+                                Some(5_000),
+                            );
+                        }
+                        Err(err) => {
+                            app.push_status_toast(
+                                format!("Failed to save permission rule: {err}"),
+                                StatusToastLevel::Error,
+                                Some(10_000),
+                            );
+                        }
+                    }
+                }
+
                 match decision {
                     ReviewDecision::Approved | ReviewDecision::ApprovedForSession => {
-                        let _ = engine_handle.approve_tool_call(tool_id).await;
+                        if live_persistent_rules.is_empty() {
+                            let _ = engine_handle.approve_tool_call(tool_id).await;
+                        } else {
+                            let _ = engine_handle
+                                .approve_tool_call_with_rules(tool_id, live_persistent_rules)
+                                .await;
+                        }
                     }
                     ReviewDecision::Denied | ReviewDecision::Abort => {
                         // Cache the denial so the model retry-loop doesn't

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -721,6 +721,7 @@ fn build_engine_config(app: &App, config: &Config) -> EngineConfig {
             .and_then(|s| s.provider)
             .unwrap_or_default(),
         search_api_key: config.search.as_ref().and_then(|s| s.api_key.clone()),
+        exec_policy_engine: config.exec_policy_engine(),
     }
 }
 

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -96,6 +96,8 @@ pub enum ViewEvent {
         approval_key: String,
         /// Lossy / arity-aware fingerprint, used to scope *approvals*.
         approval_grouping_key: String,
+        /// Persistent allow rules the approval UI generated for "save this rule".
+        persistent_rules: Vec<deepseek_execpolicy::ToolPermissionRule>,
     },
     ElevationDecision {
         tool_id: String,

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -1172,6 +1172,82 @@ impl Renderable for ApprovalWidget<'_> {
 
         lines.push(Line::from(""));
 
+        if let Some(preview) = self.request.permission_rule_preview() {
+            let preview_width = card_area.width.saturating_sub(16) as usize;
+            let preview_lines = preview.lines().collect::<Vec<_>>();
+            let preview_line_limit = 2;
+            for (idx, preview_line) in preview_lines.iter().take(preview_line_limit).enumerate() {
+                let rendered = crate::utils::truncate_with_ellipsis(
+                    preview_line,
+                    preview_width.max(20),
+                    "...",
+                );
+                lines.push(Line::from(vec![
+                    Span::raw("  "),
+                    Span::styled(
+                        if idx == 0 {
+                            label_rule(locale)
+                        } else {
+                            "      "
+                        },
+                        Style::default().fg(palette::TEXT_HINT),
+                    ),
+                    Span::styled(rendered, Style::default().fg(palette::TEXT_SECONDARY)),
+                ]));
+            }
+            if preview_lines.len() > preview_line_limit {
+                let hidden = preview_lines.len() - preview_line_limit;
+                let hidden_line = hidden_rule_preview_line(locale, hidden);
+                let rendered = crate::utils::truncate_with_ellipsis(
+                    &hidden_line,
+                    preview_width.max(20),
+                    "...",
+                );
+                lines.push(Line::from(vec![
+                    Span::raw("  "),
+                    Span::styled("      ", Style::default().fg(palette::TEXT_HINT)),
+                    Span::styled(rendered, Style::default().fg(palette::TEXT_SECONDARY)),
+                ]));
+            }
+            let mut spans = vec![
+                Span::raw("  "),
+                Span::styled(
+                    "[s] ",
+                    Style::default()
+                        .fg(palette_colors.shortcut)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(
+                    option_save_rule(locale),
+                    Style::default().fg(palette::TEXT_BODY),
+                ),
+            ];
+            if self.view.pending_persist_rule() {
+                spans.push(Span::raw("  "));
+                spans.push(Span::styled(
+                    staged_marker(locale),
+                    Style::default()
+                        .fg(palette_colors.accent)
+                        .add_modifier(Modifier::BOLD),
+                ));
+            }
+            lines.push(Line::from(spans));
+            lines.push(Line::from(vec![
+                Span::raw("  "),
+                Span::styled(
+                    "[p] ",
+                    Style::default()
+                        .fg(palette_colors.shortcut)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(
+                    option_view_rule_preview(locale),
+                    Style::default().fg(palette::TEXT_BODY),
+                ),
+            ]));
+            lines.push(Line::from(""));
+        }
+
         let options = approval_options_for(risk, locale);
         let pending = self.view.pending_confirm();
 
@@ -1447,10 +1523,24 @@ fn label_params(locale: Locale) -> &'static str {
     }
 }
 
+fn label_rule(locale: Locale) -> &'static str {
+    match locale {
+        Locale::ZhHans => "规则：",
+        _ => "Rule:   ",
+    }
+}
+
 fn staged_marker(locale: Locale) -> &'static str {
     match locale {
         Locale::ZhHans => "(待确认)",
         _ => "(staged)",
+    }
+}
+
+fn hidden_rule_preview_line(locale: Locale, hidden: usize) -> String {
+    match locale {
+        Locale::ZhHans => format!("... 还有 {hidden} 行，按 [p] 查看完整规则"),
+        _ => format!("... +{hidden} more line(s); press [p] to view all"),
     }
 }
 
@@ -1563,6 +1653,20 @@ fn option_approve_always(locale: Locale) -> &'static str {
     match locale {
         Locale::ZhHans => "本会话同类自动批准",
         _ => "Approve always for this kind",
+    }
+}
+
+fn option_save_rule(locale: Locale) -> &'static str {
+    match locale {
+        Locale::ZhHans => "保存此规则并批准",
+        _ => "Save this rule and approve",
+    }
+}
+
+fn option_view_rule_preview(locale: Locale) -> &'static str {
+    match locale {
+        Locale::ZhHans => "查看完整规则预览",
+        _ => "View full rule preview",
     }
 }
 

--- a/crates/tui/src/vision/tools.rs
+++ b/crates/tui/src/vision/tools.rs
@@ -270,13 +270,13 @@ mod tests {
         let tmp = tempdir().expect("tempdir");
         let ctx = ToolContext::new(tmp.path().to_path_buf());
         let tool = ImageAnalyzeTool::new(fake_config());
-        let outside_workspace = if cfg!(windows) {
+        let absolute_path = if cfg!(windows) {
             r"C:\Windows\System32\drivers\etc\hosts"
         } else {
             "/etc/hosts"
         };
         let err = tool
-            .execute(json!({"image_path": outside_workspace}), &ctx)
+            .execute(json!({"image_path": absolute_path}), &ctx)
             .await
             .expect_err("absolute path must reject");
         assert!(


### PR DESCRIPTION
## Summary

Add TUI support for persisting typed permission rules directly from tool approval prompts.

This builds on the typed execpolicy/config work by letting users save a scoped allow rule while approving a tool call, with a preview of the rule that will be written to user config.

## Changes

- Add generated persistent permission rules to `ApprovalRequest`.
- Add approval prompt actions:
  - `s`: save this rule and approve
  - `p`: view the full generated rule preview
- Persist approved rules into user config under `[[permissions.rules]]`.
- Inject successfully saved rules into the live `ExecPolicyEngine` so the current session benefits immediately.
- Generate scoped rules for:
  - shell tools via exact command patterns
  - file tools via normalized workspace-relative paths
  - `apply_patch` via extracted patch/file paths
- Write compatibility alias rules for file tools, such as `edit_file` and `file_edit`.
- Avoid auto-generating file rules for paths containing glob metacharacters.
- Adjust non-deny rule priority so more specific allow rules can override broader ask rules, while deny remains absolute.
- Keep approval modal previews compact and expose the full rule preview through a pager.

<img width="769" height="529" alt="image" src="https://github.com/user-attachments/assets/cdb61603-10cb-4565-a47d-608eca21e493" />
<img width="1213" height="853" alt="image" src="https://github.com/user-attachments/assets/dc21cd18-3535-4a9e-9986-020e35038533" />


## Safety Notes

- Auto-generated file rules are exact-path only.
- Paths are normalized before persistence.
- Absolute paths inside the workspace are saved as workspace-relative paths.
- Paths containing glob metacharacters are not persisted automatically to avoid accidental broad permissions.
- Deny rules still win over allow/ask rules across layers.

## Tests

- `cargo fmt --all`
- `cargo test -p deepseek-execpolicy --all-features`
- `cargo test -p deepseek-tui persistent_permission --all-features`
- `cargo test -p deepseek-tui typed_permission --all-features`
- `cargo test -p deepseek-tui approval --all-features`
- `cargo test -p deepseek-tui persist_permission --all-features`
- `cargo clippy -p deepseek-tui --all-targets --all-features -- -D warnings`
- `git diff --check`

## Depends On
This PR is stacked on top of PR2: [feat/execpolicy-typed-rules](greyfreedom:feat/execpolicy-approval-flow)
Closes https://github.com/Hmbown/DeepSeek-TUI/issues/1186
Depends on #1413