### PR TITLE
"fix-session-picker-display-clean-titles-preview"

### DIFF
--- a/crates/tui/src/session_manager.rs
+++ b/crates/tui/src/session_manager.rs
@@ -907,7 +907,11 @@ pub(crate) fn extract_title(raw: &str) -> &str {
 }
 
 /// Strip common thinking/reasoning XML tags from assistant text.
+/// Short-circuits if no thinking markers are present to avoid allocation.
 pub(crate) fn strip_thinking_tags(text: &str) -> String {
+    if !text.contains("<think") && !text.contains("<thinking") && !text.contains("<reasoning") {
+        return text.to_string();
+    }
     let tags = ["think", "thinking", "reasoning"];
     let mut result = text.to_string();
     for tag in &tags {

--- a/crates/tui/src/session_manager.rs
+++ b/crates/tui/src/session_manager.rs
@@ -674,8 +674,13 @@ pub fn create_saved_session_with_id_and_mode(
         .find(|m| m.role == "user")
         .and_then(|m| {
             m.content.iter().find_map(|block| match block {
-                ContentBlock::Text { text, .. } if !text.starts_with("<turn_meta>") => {
-                    Some(truncate_title(text, 50))
+                ContentBlock::Text { text, .. } => {
+                    let t = extract_user_prompt(text);
+                    if !t.is_empty() {
+                        Some(truncate_title(t, 50))
+                    } else {
+                        None
+                    }
                 }
                 _ => None,
             })
@@ -879,6 +884,43 @@ fn system_prompt_to_string(system_prompt: Option<&SystemPrompt>) -> Option<Strin
 /// Returns a `&str` borrowing from the input — no allocation.
 pub fn truncate_id(id: &str) -> &str {
     id.get(..8).unwrap_or(id)
+}
+
+/// Strip `<turn_meta>...</turn_meta>` prefix from a message text to
+/// extract the user's actual prompt. Returns trimmed text unchanged if
+/// no turn-meta block is present.
+pub(crate) fn extract_user_prompt(raw: &str) -> &str {
+    let trimmed = raw.trim_start();
+    let Some(after_open) = trimmed.strip_prefix("<turn_meta>") else {
+        return trimmed;
+    };
+    if let Some(close_pos) = after_open.find("</turn_meta>") {
+        return after_open[close_pos + "</turn_meta>".len()..].trim_start();
+    }
+    after_open.trim_start()
+}
+
+/// Like extract_user_prompt but returns "Session" as fallback for empty results.
+pub(crate) fn extract_title(raw: &str) -> &str {
+    let result = extract_user_prompt(raw);
+    if result.is_empty() { "Session" } else { result }
+}
+
+/// Strip common thinking/reasoning XML tags from assistant text.
+pub(crate) fn strip_thinking_tags(text: &str) -> String {
+    let tags = ["think", "thinking", "reasoning"];
+    let mut result = text.to_string();
+    for tag in &tags {
+        let open = format!("<{tag}>");
+        let close = format!("</{tag}>");
+        loop {
+            let Some(start) = result.find(&open) else { break };
+            let Some(end) = result[start..].find(&close) else { break };
+            let end_abs = start + end + close.len();
+            result.replace_range(start..end_abs, "");
+        }
+    }
+    result
 }
 
 /// Truncate a string to create a title (character-safe for UTF-8)

--- a/crates/tui/src/tui/session_picker.rs
+++ b/crates/tui/src/tui/session_picker.rs
@@ -560,8 +560,8 @@ fn build_preview_lines(session: &SavedSession) -> Vec<String> {
     }
     out.push("".to_string());
 
-    const MAX_MESSAGES: usize = 50;
-    const MAX_DIALOGUE: usize = 20;
+    const MAX_MESSAGES: usize = 6;
+    const MAX_DIALOGUE: usize = 6;
     let mut dialogue_lines: Vec<String> = Vec::new();
     for message in session.messages.iter().take(MAX_MESSAGES) {
         let role = message.role.to_ascii_uppercase();

--- a/crates/tui/src/tui/session_picker.rs
+++ b/crates/tui/src/tui/session_picker.rs
@@ -16,7 +16,7 @@ use ratatui::{
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::palette;
-use crate::session_manager::{SavedSession, SessionManager, SessionMetadata};
+use crate::session_manager::{extract_title, SavedSession, SessionManager, SessionMetadata};
 use crate::tui::views::{ModalKind, ModalView, ViewAction, ViewEvent};
 
 fn modal_block(title: &str) -> Block<'static> {
@@ -534,7 +534,10 @@ fn format_session_line(session: &SessionMetadata) -> String {
 
 fn build_preview_lines(session: &SavedSession) -> Vec<String> {
     let mut out = Vec::new();
-    out.push(format!("Title: {}", session.metadata.title));
+    out.push(format!(
+        "Title: {}",
+        extract_title(&session.metadata.title)
+    ));
     out.push(format!(
         "Updated: {}",
         session
@@ -552,17 +555,34 @@ fn build_preview_lines(session: &SavedSession) -> Vec<String> {
     }
     out.push("".to_string());
 
-    for message in session.messages.iter().take(6) {
+    let mut dialogue_lines: Vec<String> = Vec::new();
+    for message in &session.messages {
         let role = message.role.to_ascii_uppercase();
         let mut text = String::new();
         for block in &message.content {
-            if let crate::models::ContentBlock::Text { text: body, .. } = block {
-                text.push_str(body);
+            match block {
+                crate::models::ContentBlock::Text { text: body, .. } => {
+                    let cleaned = if role == "USER" {
+                        crate::session_manager::extract_user_prompt(body).to_string()
+                    } else {
+                        crate::session_manager::strip_thinking_tags(body)
+                    };
+                    if !cleaned.trim().is_empty() {
+                        if !text.is_empty() { text.push(' '); }
+                        text.push_str(&cleaned);
+                    }
+                }
+                crate::models::ContentBlock::Thinking { .. } => {}
+                _ => {}
             }
         }
-        let preview = truncate(&text.replace('\n', " "), 120);
-        out.push(format!("{role}: {preview}"));
+        let trimmed = text.trim().to_string();
+        if !trimmed.is_empty() {
+            let preview = truncate(&trimmed.replace('\n', " "), 120);
+            dialogue_lines.push(format!("{role}: {preview}"));
+        }
     }
+    out.extend(dialogue_lines);
     out
 }
 

--- a/crates/tui/src/tui/session_picker.rs
+++ b/crates/tui/src/tui/session_picker.rs
@@ -516,7 +516,12 @@ fn build_list_lines(
 
 fn format_session_line(session: &SessionMetadata) -> String {
     let updated = format_relative_time(&session.updated_at);
-    let title = truncate(&session.title, 32);
+    let raw_title = extract_title(&session.title);
+    let title = if raw_title == "Session" {
+        truncate(crate::session_manager::truncate_id(&session.id), 32)
+    } else {
+        truncate(raw_title, 32)
+    };
     let mode = session
         .mode
         .as_deref()
@@ -555,8 +560,10 @@ fn build_preview_lines(session: &SavedSession) -> Vec<String> {
     }
     out.push("".to_string());
 
+    const MAX_MESSAGES: usize = 50;
+    const MAX_DIALOGUE: usize = 20;
     let mut dialogue_lines: Vec<String> = Vec::new();
-    for message in &session.messages {
+    for message in session.messages.iter().take(MAX_MESSAGES) {
         let role = message.role.to_ascii_uppercase();
         let mut text = String::new();
         for block in &message.content {
@@ -582,6 +589,7 @@ fn build_preview_lines(session: &SavedSession) -> Vec<String> {
             dialogue_lines.push(format!("{role}: {preview}"));
         }
     }
+    dialogue_lines.truncate(MAX_DIALOGUE);
     out.extend(dialogue_lines);
     out
 }


### PR DESCRIPTION
Fix three display issues in the Ctrl+R session resumption screen:

1. Session titles show clean user prompt instead of <turn_meta>
2. First user message in preview no longer leaks system prefix
3. Empty USER/ASSISTANT entries and thinking blocks are filtered

Implementation:
- extract_user_prompt(): strips <turn_meta> prefix from message text
- extract_title(): wraps extract_user_prompt with fallback for empty titles
- strip_thinking_tags(): removes thinking XML tags from assistant text
- format_session_line + build_preview_lines: apply extraction at display time

Tests: cargo check passes. Verified on Windows with existing session files.
7/7 extract_user_prompt unit tests pass (on development branch).

Developed with AI assistance. Ref: REQ-20260511-001
