### PR TITLE
fix(cli): honor config.toml reasoning_effort on non-auto exec routes

### DIFF
--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -4050,9 +4050,17 @@ async fn resolve_cli_auto_route(config: &Config, model: &str, prompt: &str) -> C
             auto_model: true,
         }
     } else {
+        // When --model is not `auto`, fall back to the reasoning_effort
+        // declared in the user's config.toml. The previous hard-coded `None`
+        // silently dropped the user's setting on every non-auto-route exec
+        // call, which (for example) prevented vllm + Qwen3 users from
+        // disabling thinking via `reasoning_effort = "off"` and caused
+        // 30+ second SSE idle timeouts on trivial prompts.
         CliAutoRoute {
             model: model.to_string(),
-            reasoning_effort: None,
+            reasoning_effort: config
+                .reasoning_effort()
+                .map(crate::tui::app::ReasoningEffort::from_setting),
             auto_model: false,
         }
     }


### PR DESCRIPTION
## Problem

`resolve_cli_auto_route` in `crates/tui/src/main.rs` was hard-coding `reasoning_effort: None` whenever the user did not pass `--model auto`. That meant the `reasoning_effort` value set in `~/.deepseek/config.toml` (or `<workspace>/.deepseek/config.toml`) was silently dropped on every non-auto-route exec/one-shot call.

For users running a Qwen3 model on a vllm provider with `reasoning_effort = "off"`, thinking was therefore never disabled. The model emitted a long reasoning trace on every prompt, leading to:

- 30–45 second response times on trivial prompts (e.g. "translate this sentence")
- `SSE stream request did not receive response headers after 45s` timeouts on any prompt that needed a non-trivial reply

After this fix, the same prompts return in ~1.5s.

## Repro (before this PR)

```toml
# ~/.deepseek/config.toml
provider           = "vllm"
base_url           = "http://your-vllm-host:8000/v1"
default_text_model = "/model"   # any Qwen3 / DeepSeek-R1 style reasoning model
reasoning_effort   = "off"
```

```
$ deepseek-tui exec "translate to chinese: hello"
Error: SSE stream request did not receive response headers after 45s.
```

After this PR the same command returns in ~1.5s.

## Fix

Route the configured value through `ReasoningEffort::from_setting`, the same parser the TUI already uses for this field elsewhere:

```rust
reasoning_effort: config
    .reasoning_effort()
    .map(crate::tui::app::ReasoningEffort::from_setting),
```

Auto-route behaviour (`--model auto`) is unchanged — it still derives `reasoning_effort` from the auto-route flash selection.

## Verification

Captured outgoing request bodies with `nc -l -p 18000` before and after the patch:

**Before:**
```json
{"model":"/model","messages":[...],"max_tokens":4096}
```

**After:**
```json
{"model":"/model","messages":[...],"max_tokens":4096,"chat_template_kwargs":{"enable_thinking":false}}
```

vLLM logs confirm `enable_thinking=false` is now honored by the Qwen3 chat template, and end-to-end latency for trivial prompts drops from 30–45s (idle timeout) to ~1.5s.

The same fix benefits any provider whose `apply_reasoning_effort` branch needs `reasoning_effort = "off"` to inject a no-thinking marker (e.g. `nvidia-nim`'s `chat_template_kwargs.thinking=false`, Anthropic-style `thinking.type=disabled` for the deepseek provider).

## Scope

- One file changed: `crates/tui/src/main.rs` (+9, −1)
- No behaviour change for the `--model auto` path
- No new dependencies or config fields — just routes an existing config value into an existing parser