### PR TITLE
fix(tui): preserve prefix cache while pruning tool results

### DIFF
--- a/crates/tui/src/compaction.rs
+++ b/crates/tui/src/compaction.rs
@@ -94,6 +94,7 @@ const LARGE_CONTEXT_SUMMARY_TOOL_RESULT_SNIPPET_CHARS: usize = 4_000;
 const LARGE_CONTEXT_SUMMARY_INPUT_MAX_CHARS: usize = 120_000;
 const LARGE_CONTEXT_SUMMARY_INPUT_HEAD_CHARS: usize = 72_000;
 const LARGE_CONTEXT_SUMMARY_INPUT_TAIL_CHARS: usize = 36_000;
+const TOOL_PRUNE_STOP_CHECK_BYTES: usize = 16 * 1024;
 const LARGE_CONTEXT_SUMMARY_MAX_TOKENS: u32 = 2_048;
 const LARGE_CONTEXT_WINDOW_TOKENS: u32 = 500_000;
 const CACHE_ALIGNED_SUMMARY_CONTEXT_BUDGET_PERCENT: usize = 85;
@@ -749,13 +750,25 @@ struct ToolResultPruneCandidate {
     original_len: usize,
 }
 
+#[cfg(test)]
+fn prune_tool_results(messages: &mut [Message], protected_window: usize) -> usize {
+    prune_tool_results_until(messages, protected_window, |_, _| false)
+}
+
 /// Mechanically prune old verbose tool results before paying for an LLM summary.
 ///
 /// The most recent `protected_window` messages stay byte-for-byte intact. Older
 /// duplicate tool results keep the freshest full body and replace earlier
 /// copies with one-line summaries; non-duplicate old results are summarized only
 /// when they exceed the normal summary snippet size.
-pub fn prune_tool_results(messages: &mut [Message], protected_window: usize) -> usize {
+fn prune_tool_results_until<F>(
+    messages: &mut [Message],
+    protected_window: usize,
+    mut should_stop: F,
+) -> usize
+where
+    F: FnMut(&[Message], usize) -> bool,
+{
     let cutoff = messages.len().saturating_sub(protected_window);
     if cutoff == 0 {
         return 0;
@@ -792,6 +805,12 @@ pub fn prune_tool_results(messages: &mut [Message], protected_window: usize) -> 
         }
     }
 
+    // The maps above are fully populated before pruning starts, so the order below
+    // only changes which message bytes are rewritten first. Pruning from newest to
+    // oldest lets callers stop as soon as enough bytes were saved, preserving the
+    // earlier JSON request prefix for byte-level KV caches.
+    candidates.reverse();
+
     let mut bytes_saved = 0usize;
     for candidate in candidates {
         let duplicate_count = count_by_key.get(&candidate.key).copied().unwrap_or(0);
@@ -821,6 +840,10 @@ pub fn prune_tool_results(messages: &mut [Message], protected_window: usize) -> 
             bytes_saved = bytes_saved.saturating_add(content.len().saturating_sub(summary.len()));
             *content = summary;
             *content_blocks = None;
+
+            if should_stop(messages, bytes_saved) {
+                break;
+            }
         }
     }
 
@@ -875,26 +898,54 @@ pub async fn compact_messages_safe(
     const MAX_RETRIES: u32 = 3;
     const BASE_DELAY_MS: u64 = 1000;
 
+    let was_over_threshold = should_compact(
+        messages,
+        config,
+        workspace,
+        external_pins,
+        external_working_set_paths,
+    );
     let mut pruned_messages = messages.to_vec();
-    let pruned_bytes = prune_tool_results(&mut pruned_messages, KEEP_RECENT_MESSAGES);
-    let compaction_input: &[Message] = if pruned_bytes > 0 {
-        logging::info(format!(
-            "Local tool-result prune saved {pruned_bytes} bytes before LLM compaction"
-        ));
-        let was_over_threshold = should_compact(
-            messages,
-            config,
-            workspace,
-            external_pins,
-            external_working_set_paths,
-        );
-        let now_under_threshold = !should_compact(
+    let mut now_under_threshold = false;
+    let mut next_stop_check_bytes = 0usize;
+    let pruned_bytes = prune_tool_results_until(
+        &mut pruned_messages,
+        KEEP_RECENT_MESSAGES,
+        |candidate_messages, bytes_saved| {
+            if !was_over_threshold || bytes_saved < next_stop_check_bytes {
+                return false;
+            }
+
+            // Stop at the first suffix-side prune check that clears the threshold.
+            // The check itself is a full compaction-plan pass, so bound it by saved
+            // bytes instead of running it after every candidate in huge sessions.
+            next_stop_check_bytes = bytes_saved.saturating_add(TOOL_PRUNE_STOP_CHECK_BYTES);
+            now_under_threshold = !should_compact(
+                candidate_messages,
+                config,
+                workspace,
+                external_pins,
+                external_working_set_paths,
+            );
+            now_under_threshold
+        },
+    );
+    if was_over_threshold && pruned_bytes > 0 && !now_under_threshold {
+        // The throttled in-loop check may skip the exact candidate that clears the
+        // budget. Do one final pass so a successful local prune still avoids LLM compaction.
+        now_under_threshold = !should_compact(
             &pruned_messages,
             config,
             workspace,
             external_pins,
             external_working_set_paths,
         );
+    }
+
+    let compaction_input: &[Message] = if pruned_bytes > 0 {
+        logging::info(format!(
+            "Local tool-result prune saved {pruned_bytes} bytes before LLM compaction"
+        ));
         if was_over_threshold && now_under_threshold {
             return Ok(CompactionResult {
                 messages: pruned_messages,
@@ -1569,6 +1620,60 @@ mod tests {
             panic!("expected tool result");
         };
         assert_eq!(content, &verbose);
+    }
+
+    #[test]
+    fn prune_tool_results_preserves_prefix_bytes_when_reverse_prune_is_enough() {
+        let older_verbose = "old ".repeat(SUMMARY_TOOL_RESULT_SNIPPET_CHARS + 40);
+        let newer_verbose = "new ".repeat(SUMMARY_TOOL_RESULT_SNIPPET_CHARS + 40);
+        let mut messages = vec![
+            tool_use("call-old", "read_file", json!({"path": "old.txt"})),
+            tool_result("call-old", &older_verbose),
+            tool_use("call-new", "read_file", json!({"path": "new.txt"})),
+            tool_result("call-new", &newer_verbose),
+            msg("user", "protected tail"),
+        ];
+        let original = messages.clone();
+
+        // Simulate the caller clearing its token budget after one suffix prune.
+        let saved = prune_tool_results_until(&mut messages, 1, |_, saved| saved > 0);
+
+        assert!(saved > 0);
+        assert_eq!(&messages[..3], &original[..3]);
+        assert_eq!(&messages[4..], &original[4..]);
+        let ContentBlock::ToolResult { content, .. } = &messages[3].content[0] else {
+            panic!("expected pruned tool result");
+        };
+        assert!(content.contains("[read_file] tool result pruned"));
+        assert!(content.contains("new.txt"));
+        assert!(content.len() < newer_verbose.len());
+    }
+
+    #[test]
+    fn prune_tool_results_stops_after_newest_duplicate_prune() {
+        let oldest = "oldest ".repeat(80);
+        let middle = "middle ".repeat(80);
+        let latest = "latest ".repeat(80);
+        let mut messages = vec![
+            tool_use("call-1", "read_file", json!({"path": "Cargo.toml"})),
+            tool_result("call-1", &oldest),
+            tool_use("call-2", "read_file", json!({"path": "Cargo.toml"})),
+            tool_result("call-2", &middle),
+            tool_use("call-3", "read_file", json!({"path": "Cargo.toml"})),
+            tool_result("call-3", &latest),
+            msg("user", "protected tail"),
+        ];
+        let original = messages.clone();
+
+        let saved = prune_tool_results_until(&mut messages, 1, |_, saved| saved > 0);
+
+        assert!(saved > 0);
+        assert_eq!(&messages[..3], &original[..3]);
+        assert_eq!(&messages[4..], &original[4..]);
+        let ContentBlock::ToolResult { content, .. } = &messages[3].content[0] else {
+            panic!("expected middle duplicate to be pruned");
+        };
+        assert!(content.contains("[read_file] tool result pruned"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- improve DeepSeek prefix-cache hit rate by pruning old tool results from newest to oldest
- stop local pruning once it clears the compaction threshold, with throttled threshold checks plus a final check
- add regression coverage for prefix preservation and duplicate-result pruning

## Motivation
DeepSeek's KV cache is byte-prefix sensitive: if the serialized request changes at an earlier byte, all following cached KV state becomes unusable. Tool result pruning previously rewrote older messages first, which can move the first changed byte much closer to the beginning of the request and reduce cache hits.

This PR is specifically aimed at improving cache hit rate for long sessions with local tool-result pruning. It is related to the cache optimization discussion in https://github.com/Hmbown/DeepSeek-TUI/issues/1177#issuecomment-4422049242.

## Technical approach
`compact_messages_safe` now calls a stop-aware pruning helper. The helper builds the complete duplicate-detection maps before mutation, then reverses candidates so the closest-to-cutoff result is considered first. After each bounded saved-byte interval, the caller re-runs the compaction threshold check; if local suffix-side pruning is enough, it returns the pruned messages without rewriting older tool results or invoking LLM compaction. If pruning is not enough, it falls back to sending the pruned history into LLM compaction.

## Why this works
Because cache reuse depends on the longest unchanged request prefix, preserving earlier messages is more valuable than maximizing local byte savings once the request is already under the compaction threshold. Reversing the candidate order moves optional rewrites toward the suffix. Stopping when the threshold is safe prevents unnecessary older rewrites, so more of the serialized JSON request remains byte-identical across turns. The duplicate-result maps are still computed from the full pre-mutation scan, so the latest full duplicate result remains protected.

## Trade-offs
- Some older eligible tool results can remain unpruned when suffix-side pruning already makes the budget safe. This trades maximum byte savings for higher prefix-cache hit probability.
- Threshold checks are throttled by saved bytes to avoid an O(candidates × full compaction plan) pass in very large sessions. This can prune slightly more than the theoretical minimum before noticing the threshold is safe.
- A final threshold check catches cases where the throttled loop skipped the exact clearing point, so successful local pruning still avoids LLM compaction.

## Inspiration
The design follows the prefix-cache-first pruning strategy used by Claude Code and adapted by Boris in OpenClaw PR #58036. This implementation adapts the idea to DeepSeek-TUI's current compaction flow: reverse order alone would not change the final serialized request if every candidate were still pruned, so this patch combines reverse order with a budget-based stop condition.

## Tests
- `cargo fmt --check`
- `cargo test -p deepseek-tui prune_tool_results --all-features`