### PR TITLE
fix(CI): stabilize pandoc binary output validation

### DIFF
--- a/crates/tui/src/tools/pandoc.rs
+++ b/crates/tui/src/tools/pandoc.rs
@@ -127,6 +127,19 @@ impl ToolSpec for PandocConvertTool {
             )));
         }
 
+        let resolved_output_path: Option<PathBuf> = match output_path_str {
+            Some(p) => Some(context.resolve_path(p)?),
+            None => None,
+        };
+
+        // Binary formats can't round-trip through stdout reliably —
+        // require an output_path so the bytes survive the trip.
+        if resolved_output_path.is_none() && format_is_binary(&target_format) {
+            return Err(ToolError::invalid_input(format!(
+                "target_format `{target_format}` is binary; provide an `output_path` to write the converted file."
+            )));
+        }
+
         // Resolve the pandoc binary at execution time too — registration
         // gated on resolve_pandoc(), but a concurrent uninstall between
         // catalog build and the model's call should produce a clear
@@ -140,19 +153,6 @@ impl ToolSpec for PandocConvertTool {
                  Windows: `winget install JohnMacFarlane.Pandoc`) and restart deepseek-tui.",
             )
         })?;
-
-        let resolved_output_path: Option<PathBuf> = match output_path_str {
-            Some(p) => Some(context.resolve_path(p)?),
-            None => None,
-        };
-
-        // Binary formats can't round-trip through stdout reliably —
-        // require an output_path so the bytes survive the trip.
-        if resolved_output_path.is_none() && format_is_binary(&target_format) {
-            return Err(ToolError::invalid_input(format!(
-                "target_format `{target_format}` is binary; provide an `output_path` to write the converted file."
-            )));
-        }
 
         let mut cmd = Command::new(&pandoc);
         cmd.arg(&source_path);


### PR DESCRIPTION

## Summary

  - Validate `docx`, `odt`, and `epub` output requirements before probing for the `pandoc` binary
  - Keep missing `output_path` errors stable even when pandoc is not installed
  - Fix the CI failure where the test saw `pandoc binary not found` before the expected input validation error

https://github.com/Hmbown/DeepSeek-TUI/actions/runs/25728223000/job/75546433402?pr=1341
https://github.com/Hmbown/DeepSeek-TUI/actions/runs/25725470275/job/75536985166?pr=1507
https://github.com/Hmbown/DeepSeek-TUI/actions/runs/25725631101/job/75537540251?pr=1513
```
failures:

---- tools::pandoc::tests::pandoc_convert_rejects_inline_request_for_binary_format stdout ----

thread 'tools::pandoc::tests::pandoc_convert_rejects_inline_request_for_binary_format' (13627) panicked at crates/tui/src/tools/pandoc.rs:279:9:
error must explain why output_path is required; got Failed to execute tool: pandoc_convert: pandoc binary not found on PATH. Install pandoc (macOS: `brew install pandoc`; Debian/Ubuntu: `apt install pandoc`; Windows: `winget install JohnMacFarlane.Pandoc`) and restart deepseek-tui.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    tools::pandoc::tests::pandoc_convert_rejects_inline_request_for_binary_format

test result: FAILED. 2842 passed; 1 failed; 2 ignored; 0 measured; 0 filtered out; finished in 8.87s

error: test failed, to rerun pass `-p deepseek-tui --bin deepseek-tui`
Error: Process completed with exit code 101.
```

## Testing

- [x] `cargo test --all-features`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
