### PR TITLE
fix: skip pandoc_convert test when pandoc binary is missing

### DIFF
--- a/crates/tui/src/tools/pandoc.rs
+++ b/crates/tui/src/tools/pandoc.rs
@@ -265,6 +265,9 @@ mod tests {
 
     #[tokio::test]
     async fn pandoc_convert_rejects_inline_request_for_binary_format() {
+        if !pandoc_present() {
+            return;
+        }
         let tmp = tempdir().expect("tempdir");
         let src = tmp.path().join("in.md");
         fs::write(&src, "# hi").unwrap();


### PR DESCRIPTION
## Summary

## Testing

- [x] `cargo test --all-features`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes

`pandoc_convert_rejects_inline_request_for_binary_format` was missing a
`pandoc_present()` guard, causing the test to panic when pandoc isn't
installed on the system (the tool's error message about missing binary
didn't match the test's `expect_err` assertion).