### PR TITLE
Improve file-edit guardrails and shell output truncation

### DIFF
--- a/crates/tui/src/prompts/base.md
+++ b/crates/tui/src/prompts/base.md
@@ -170,10 +170,10 @@ Multiple `tool_calls` in one turn run in parallel. `web_search` returns `ref_id`
 ## Tool Selection Guide
 
 ### `apply_patch`
-Use `apply_patch` for structural edits, coordinated changes, or cases where line context matters. Use `write_file` for brand-new files or full-file rewrites. Use `edit_file` for a single unambiguous replacement.
+Use `apply_patch` for structural edits, coordinated changes, or cases where line context matters. Use `write_file` for brand-new files, full-file rewrites, or large-scope modifications to existing files where multiple intertwined changes make local replacement unreliable. Use `edit_file` for a single unambiguous replacement.
 
 ### `edit_file`
-Use `edit_file` for one clear replacement in one file. Use `apply_patch` when the edit changes whole blocks, touches multiple files, or needs surrounding line context.
+Use `edit_file` for one clear replacement in one file. Do not use `edit_file` for multi-block structural deletions, cross-cutting refactors, or changes that touch more than one logical unit; those require `apply_patch` or `write_file`.
 
 ### `exec_shell`
 Use `exec_shell` for shell-native diagnostics, pipelines, and bounded commands. Use structured tools for structured operations when they map directly (`grep_files`, `git_diff`, `read_file`). For long commands, servers, full test suites, or release computations, start background work with `task_shell_start` or `exec_shell` using `background: true`, then poll with `task_shell_wait` or `exec_shell_wait`.

--- a/crates/tui/src/tools/file.rs
+++ b/crates/tui/src/tools/file.rs
@@ -473,7 +473,7 @@ impl ToolSpec for EditFileTool {
     }
 
     fn description(&self) -> &'static str {
-        "Replace text in a single file via exact search/replace. Use this instead of `sed -i` in `exec_shell` for in-place edits. For multi-hunk or cross-file changes, use `apply_patch` instead. Required: 'path', 'search' (exact text to find), 'replace' (text to substitute)."
+        "Replace text in a single file via exact search/replace. Required: 'path', 'search' (exact text to find; whitespace, indentation, and newlines must match precisely), 'replace' (text to substitute). Use this for a single unambiguous replacement only; it returns a unified diff with three lines of context, not the full file. For multi-block structural edits, cross-cutting refactors, or large-scope existing-file changes, use apply_patch or write_file instead."
     }
 
     fn input_schema(&self) -> Value {
@@ -486,11 +486,11 @@ impl ToolSpec for EditFileTool {
                 },
                 "search": {
                     "type": "string",
-                    "description": "Text to search for"
+                    "description": "Text to search for; must match exactly, including whitespace, indentation, and newlines"
                 },
                 "replace": {
                     "type": "string",
-                    "description": "Text to replace with"
+                    "description": "Replacement text; keep structural replacements syntactically complete"
                 }
             },
             "required": ["path", "search", "replace"]
@@ -542,7 +542,15 @@ impl ToolSpec for EditFileTool {
 
         let display = file_path.display().to_string();
         let diff = make_unified_diff(&display, &contents, &updated);
-        let summary = format!("Replaced {count} occurrence(s) in {display}");
+        let summary = if count > 1 {
+            format!(
+                "Replaced {count} occurrence(s) in {display}\n\
+                 Warning: multiple matches were replaced with the same substitution. \
+                 Verify the result with read_file before proceeding."
+            )
+        } else {
+            format!("Replaced 1 occurrence in {display}")
+        };
         let body = if diff.is_empty() {
             format!("{summary}\n(no textual changes)")
         } else {
@@ -1151,6 +1159,11 @@ mod tests {
 
         assert!(result.success);
         assert!(result.content.contains("2 occurrence(s)"));
+        assert!(
+            result.content.contains("Warning: multiple matches"),
+            "multi-match edits should nudge the agent to inspect the result: {}",
+            result.content
+        );
         // Inline diff (#505) — the unified diff lands above the summary
         // line so the TUI's diff-aware renderer kicks in.
         assert!(result.content.contains("--- a/"), "{}", result.content);
@@ -1168,6 +1181,30 @@ mod tests {
         // Verify edit was applied
         let edited = fs::read_to_string(&test_file).expect("read");
         assert_eq!(edited, "hi world hi");
+    }
+
+    #[tokio::test]
+    async fn edit_file_single_match_does_not_warn_about_multiple_matches() {
+        let tmp = tempdir().expect("tempdir");
+        let ctx = ToolContext::new(tmp.path().to_path_buf());
+        let test_file = tmp.path().join("single.txt");
+        fs::write(&test_file, "alpha beta gamma").expect("write");
+
+        let result = EditFileTool
+            .execute(
+                json!({"path": "single.txt", "search": "beta", "replace": "BETA"}),
+                &ctx,
+            )
+            .await
+            .expect("execute");
+
+        assert!(result.success);
+        assert!(result.content.contains("Replaced 1 occurrence"));
+        assert!(
+            !result.content.contains("Warning: multiple matches"),
+            "single-match edit should stay quiet: {}",
+            result.content
+        );
     }
 
     #[tokio::test]
@@ -1363,6 +1400,15 @@ mod tests {
             .and_then(|value| value.as_array())
             .expect("edit schema should include required array");
         assert_eq!(required.len(), 3);
+        let search_description = edit_schema["properties"]["search"]["description"]
+            .as_str()
+            .expect("search description should be a string");
+        assert!(
+            search_description.contains("whitespace")
+                && search_description.contains("indentation")
+                && search_description.contains("newlines"),
+            "search schema should state exact-match boundaries: {search_description}"
+        );
 
         let list_schema = ListDirTool.input_schema();
         let required = list_schema

--- a/crates/tui/src/tools/pandoc.rs
+++ b/crates/tui/src/tools/pandoc.rs
@@ -127,20 +127,6 @@ impl ToolSpec for PandocConvertTool {
             )));
         }
 
-        // Resolve the pandoc binary at execution time too — registration
-        // gated on resolve_pandoc(), but a concurrent uninstall between
-        // catalog build and the model's call should produce a clear
-        // error rather than the cryptic "program not found" from raw
-        // Command::spawn.
-        let pandoc = crate::dependencies::resolve_pandoc().ok_or_else(|| {
-            ToolError::execution_failed(
-                "pandoc_convert: pandoc binary not found on PATH. \
-                 Install pandoc (macOS: `brew install pandoc`; \
-                 Debian/Ubuntu: `apt install pandoc`; \
-                 Windows: `winget install JohnMacFarlane.Pandoc`) and restart deepseek-tui.",
-            )
-        })?;
-
         let resolved_output_path: Option<PathBuf> = match output_path_str {
             Some(p) => Some(context.resolve_path(p)?),
             None => None,
@@ -153,6 +139,22 @@ impl ToolSpec for PandocConvertTool {
                 "target_format `{target_format}` is binary; provide an `output_path` to write the converted file."
             )));
         }
+
+        // Resolve the pandoc binary at execution time too — registration
+        // gated on resolve_pandoc(), but a concurrent uninstall between
+        // catalog build and the model's call should produce a clear
+        // error rather than the cryptic "program not found" from raw
+        // Command::spawn. Keep this after input-only validation so bad
+        // requests get deterministic schema errors even when pandoc is
+        // absent on the host.
+        let pandoc = crate::dependencies::resolve_pandoc().ok_or_else(|| {
+            ToolError::execution_failed(
+                "pandoc_convert: pandoc binary not found on PATH. \
+                 Install pandoc (macOS: `brew install pandoc`; \
+                 Debian/Ubuntu: `apt install pandoc`; \
+                 Windows: `winget install JohnMacFarlane.Pandoc`) and restart deepseek-tui.",
+            )
+        })?;
 
         let mut cmd = Command::new(&pandoc);
         cmd.arg(&source_path);

--- a/crates/tui/src/tools/shell_output.rs
+++ b/crates/tui/src/tools/shell_output.rs
@@ -2,6 +2,10 @@
 
 /// Maximum output size before truncation (30KB like Claude Code).
 const MAX_OUTPUT_SIZE: usize = 30_000;
+/// Head bytes preserved for large shell/test output. The matching tail budget
+/// keeps final errors and test summaries visible without a second command.
+const TRUNCATED_HEAD_BYTES: usize = 22_000;
+const TRUNCATED_TAIL_BYTES: usize = MAX_OUTPUT_SIZE - TRUNCATED_HEAD_BYTES;
 /// Limits for summary strings in tool metadata.
 const SUMMARY_MAX_LINES: usize = 3;
 const SUMMARY_MAX_CHARS: usize = 240;
@@ -30,22 +34,31 @@ pub(crate) fn truncate_with_meta(output: &str) -> (String, TruncationMeta) {
         );
     }
 
-    let cut_index = char_boundary_at_or_before(output, MAX_OUTPUT_SIZE);
-    let head = &output[..cut_index];
-    let tail = &output[cut_index..];
-    let omitted = original_len.saturating_sub(cut_index);
-    let note =
-        format!("...\n\n[Output truncated at {MAX_OUTPUT_SIZE} bytes. {omitted} bytes omitted.]");
+    let head_end = char_boundary_at_or_before(output, TRUNCATED_HEAD_BYTES);
+    let tail_start =
+        char_boundary_at_or_after(output, original_len.saturating_sub(TRUNCATED_TAIL_BYTES));
+    let head = &output[..head_end];
+    let omitted_middle = &output[head_end..tail_start];
+    let tail = &output[tail_start..];
+    let omitted = omitted_middle.len();
+    let note = format!(
+        "...\n\n[Output truncated: showing first {head_bytes} bytes and last {tail_bytes} bytes. {omitted} bytes omitted.]",
+        head_bytes = head.len(),
+        tail_bytes = tail.len(),
+    );
 
-    // Preserve high-signal summary lines from the tail (cargo test results,
-    // rustc errors, panics, completion markers). Without this the agent
-    // re-runs `cargo test | tail` repeatedly to find pass/fail (#242).
+    // Preserve high-signal summary lines from the omitted middle (cargo test
+    // results, rustc errors, panics, completion markers). The raw tail is
+    // already included below; these middle snippets keep earlier failures
+    // visible without re-running `cargo test | tail` repeatedly (#242/#1450).
     let mut combined = format!("{head}{note}");
-    let preserved = collect_summary_lines(tail);
+    let preserved = collect_summary_lines(omitted_middle);
     if !preserved.is_empty() {
-        combined.push_str("\n\n[Preserved summary lines from omitted tail]\n");
+        combined.push_str("\n\n[Preserved summary lines from omitted middle]\n");
         combined.push_str(&preserved.join("\n"));
     }
+    combined.push_str("\n\n[Output tail]\n");
+    combined.push_str(tail);
 
     (
         combined,
@@ -147,8 +160,21 @@ fn char_boundary_at_or_before(text: &str, max_bytes: usize) -> usize {
     last_end.min(text.len())
 }
 
+fn char_boundary_at_or_after(text: &str, min_bytes: usize) -> usize {
+    if min_bytes >= text.len() {
+        return text.len();
+    }
+    if text.is_char_boundary(min_bytes) {
+        return min_bytes;
+    }
+    text.char_indices()
+        .map(|(idx, _)| idx)
+        .find(|&idx| idx > min_bytes)
+        .unwrap_or(text.len())
+}
+
 fn strip_truncation_note(text: &str) -> &str {
-    text.split_once("\n\n[Output truncated at")
+    text.split_once("\n\n[Output truncated")
         .map_or(text, |(prefix, _)| prefix)
 }
 
@@ -228,6 +254,27 @@ mod tests {
         let (truncated, _meta) = truncate_with_meta(&head);
         assert!(truncated.contains("failures:"), "must preserve failures:");
         assert!(truncated.contains("FAILED"), "must preserve FAILED");
+    }
+
+    #[test]
+    fn truncation_includes_raw_tail_for_shell_output() {
+        let mut output = String::new();
+        output.push_str("head-marker\n");
+        output.push_str(&"middle noise\n".repeat(3_000));
+        output.push_str("tail-marker: final compiler error\n");
+
+        let (truncated, meta) = truncate_with_meta(&output);
+
+        assert!(meta.truncated, "expected truncation");
+        assert!(truncated.contains("head-marker"));
+        assert!(
+            truncated.contains("[Output tail]"),
+            "tail section should be explicit: {truncated}"
+        );
+        assert!(
+            truncated.contains("tail-marker: final compiler error"),
+            "raw tail must remain visible"
+        );
     }
 
     #[test]

--- a/crates/tui/src/vision/tools.rs
+++ b/crates/tui/src/vision/tools.rs
@@ -269,8 +269,13 @@ mod tests {
         let tmp = tempdir().expect("tempdir");
         let ctx = ToolContext::new(tmp.path().to_path_buf());
         let tool = ImageAnalyzeTool::new(fake_config());
+        let absolute_path = if cfg!(windows) {
+            r"C:\Windows\win.ini"
+        } else {
+            "/etc/hosts"
+        };
         let err = tool
-            .execute(json!({"image_path": "/etc/hosts"}), &ctx)
+            .execute(json!({"image_path": absolute_path}), &ctx)
             .await
             .expect_err("absolute path must reject");
         assert!(


### PR DESCRIPTION
## Summary
- tighten `edit_file` tool guidance around exact matching, structural-edit boundaries, and single unambiguous replacements
- add a multi-match `edit_file` warning while preserving valid repeated replacements
- switch large shell/test output truncation to keep a bounded head plus raw tail, with high-signal lines from the omitted middle
- keep `pandoc_convert` input-only validation ahead of pandoc binary lookup, so missing `output_path` errors are deterministic on CI hosts without pandoc
- make the vision absolute-path rejection test platform-aware for Windows CI

## Notes
- Current `main` already includes the `read_file(start_line, max_lines)` bounded-read path for #1450, so this PR focuses on the remaining shell/test output budget failure mode from that issue.
- Closes #1516
- Addresses #1450

## Validation
- `cargo fmt --all --check`
- `cargo test -p deepseek-tui tools::file::tests:: -- --nocapture`
- `cargo test -p deepseek-tui tools::shell_output::tests:: -- --nocapture`
- `cargo test -p deepseek-tui tools::pandoc::tests::pandoc_convert_rejects_inline_request_for_binary_format -- --nocapture`
- `cargo test -p deepseek-tui vision::tools::tests::execute_rejects_absolute_path -- --nocapture`
- `cargo check -p deepseek-tui`