### PR TITLE
  fix(CI): use platform-native absolute path in vision test

### DIFF
--- a/crates/tui/src/vision/tools.rs
+++ b/crates/tui/src/vision/tools.rs
@@ -269,8 +269,13 @@ mod tests {
         let tmp = tempdir().expect("tempdir");
         let ctx = ToolContext::new(tmp.path().to_path_buf());
         let tool = ImageAnalyzeTool::new(fake_config());
+        let outside_workspace = if cfg!(windows) {
+            r"C:\Windows\System32\drivers\etc\hosts"
+        } else {
+            "/etc/hosts"
+        };
         let err = tool
-            .execute(json!({"image_path": "/etc/hosts"}), &ctx)
+            .execute(json!({"image_path": outside_workspace}), &ctx)
             .await
             .expect_err("absolute path must reject");
         assert!(


### PR DESCRIPTION


## Summary

```
test tools::shell::tests::test_exec_shell_wait_cancel_leaves_background_process_running ... ok

failures:

---- vision::tools::tests::execute_rejects_absolute_path stdout ----

thread 'vision::tools::tests::execute_rejects_absolute_path' (3760) panicked at crates\tui\src\vision\tools.rs:276:9:
error must call out the workspace boundary; got Failed to execute tool: Failed to read image file: The system cannot find the path specified. (os error 3)


failures:
    vision::tools::tests::execute_rejects_absolute_path

test result: FAILED. 2828 passed; 1 failed; 2 ignored; 0 measured; 0 filtered out; finished in 70.83s

error: test failed, to rerun pass `-p deepseek-tui --bin deepseek-tui`
Error: Process completed with exit code 1.
```
https://github.com/Hmbown/DeepSeek-TUI/actions/runs/25729176965/job/75549680983?pr=1518

  - Use a platform-native absolute path in the `image_analyze` workspace boundary test
  - Keep the test exercising the intended absolute-path rejection on Windows
  - Fix the Windows CI failure where `/etc/hosts` was treated as a relative workspace path

## Testing

- [x] `cargo test --all-features`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
