### PR TITLE
Fix small UX and configuration docs issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,7 @@ Key environment variables:
 | `DEEPSEEK_PROVIDER` | `deepseek` (default), `nvidia-nim`, `openai`, `openrouter`, `novita`, `fireworks`, `sglang`, `vllm`, `ollama` |
 | `DEEPSEEK_PROFILE` | Config profile name |
 | `DEEPSEEK_MEMORY` | Set to `on` to enable user memory |
+| `DEEPSEEK_ALLOW_INSECURE_HTTP=1` | Allow non-local `http://` API base URLs on trusted networks |
 | `NVIDIA_API_KEY` / `OPENAI_API_KEY` / `OPENROUTER_API_KEY` / `NOVITA_API_KEY` / `FIREWORKS_API_KEY` / `SGLANG_API_KEY` / `VLLM_API_KEY` / `OLLAMA_API_KEY` | Provider auth |
 | `OPENAI_BASE_URL` / `OPENAI_MODEL` | Generic OpenAI-compatible endpoint and model ID |
 | `SGLANG_BASE_URL` | Self-hosted SGLang endpoint |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,10 +17,13 @@ Check the [releases page](https://github.com/Hmbown/DeepSeek-TUI/releases) for t
 
 **Do not open a public GitHub issue for security vulnerabilities.**
 
-Report privately via one of:
+Report privately via:
 
-- **Email**: [hmbown.dev@gmail.com](mailto:hmbown.dev@gmail.com) — include `[SECURITY]` in the subject line
 - **GitHub private advisory**: [github.com/Hmbown/DeepSeek-TUI/security/advisories/new](https://github.com/Hmbown/DeepSeek-TUI/security/advisories/new)
+
+Do not send undisclosed vulnerability details through public issues, discussion
+threads, or personal maintainer email. Use the private advisory flow until a
+project-domain security address is published.
 
 Include in your report:
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -178,7 +178,10 @@ max_subagents = 10 # optional (1-20)
 # base_url = "https://integrate.api.nvidia.com/v1"
 # model = "deepseek-ai/deepseek-v4-pro"     # or deepseek-ai/deepseek-v4-flash
 
-# Generic OpenAI-compatible endpoint
+# Generic OpenAI-compatible endpoint. Use the built-in `openai` provider for
+# third-party gateways; do not invent a custom provider name. For non-local
+# http:// gateways, launch with DEEPSEEK_ALLOW_INSECURE_HTTP=1 only on a
+# trusted network.
 [providers.openai]
 # api_key = "YOUR_OPENAI_COMPATIBLE_API_KEY"
 # base_url = "https://api.openai.com/v1"

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -368,16 +368,12 @@ impl Settings {
             self.low_motion = true;
             self.fancy_animations = false;
         }
-        // VS Code (TERM_PROGRAM=vscode, #1356) and Ghostty (TERM_PROGRAM=ghostty,
-        // #1445) both produce visible flicker at 120 FPS: VS Code's compositor
-        // cannot keep pace; Ghostty's GPU compositor flash-renders each full-screen
-        // repaint. Drop to the 30 FPS low-motion cap for both automatically.
+        // VS Code (TERM_PROGRAM=vscode, #1356), Ghostty (TERM_PROGRAM=ghostty,
+        // #1445), and a few VTE terminals (#1470) produce visible flicker at
+        // 120 FPS. Drop to the 30 FPS low-motion cap for them automatically.
         // Like NO_ANIMATIONS above, this unconditionally overrides any
         // disk-loaded value — consistent precedence: env signals always win.
-        if matches!(
-            std::env::var("TERM_PROGRAM").as_deref(),
-            Ok("vscode") | Ok("ghostty")
-        ) {
+        if terminal_env_forces_low_motion() {
             self.low_motion = true;
             self.fancy_animations = false;
         }
@@ -836,6 +832,21 @@ fn normalize_synchronized_output(value: &str) -> &str {
     }
 }
 
+fn terminal_env_forces_low_motion() -> bool {
+    if matches!(
+        std::env::var("TERM_PROGRAM").as_deref(),
+        Ok("vscode") | Ok("ghostty")
+    ) {
+        return true;
+    }
+
+    // Tilix and Terminator are VTE-based terminals reported with visible
+    // full-screen flicker on redraw-heavy sessions (#1470). Both export
+    // stable session identifiers, while TERM_PROGRAM is often absent.
+    std::env::var_os("TILIX_ID").is_some_and(|v| !v.is_empty())
+        || std::env::var_os("TERMINATOR_UUID").is_some_and(|v| !v.is_empty())
+}
+
 /// Returns `true` when the active terminal is Ptyxis (the new default
 /// terminal on Ubuntu 26.04). Used by [`Settings::apply_env_overrides`]
 /// to flip `synchronized_output` from `auto` to `off` so DEC mode 2026
@@ -1182,6 +1193,8 @@ mod tests {
         let prev = std::env::var_os("TERM_PROGRAM");
         let prev_ssh_client = std::env::var_os("SSH_CLIENT");
         let prev_ssh_tty = std::env::var_os("SSH_TTY");
+        let prev_tilix_id = std::env::var_os("TILIX_ID");
+        let prev_terminator_uuid = std::env::var_os("TERMINATOR_UUID");
         // SAFETY: serialised by the guard. Clear SSH_* so a real
         // SSH session running the test suite doesn't make this
         // assertion trivially fail — the SSH path is exercised
@@ -1189,6 +1202,8 @@ mod tests {
         unsafe {
             std::env::remove_var("SSH_CLIENT");
             std::env::remove_var("SSH_TTY");
+            std::env::remove_var("TILIX_ID");
+            std::env::remove_var("TERMINATOR_UUID");
         }
         for program in ["iTerm.app", "Apple_Terminal", "WezTerm", "xterm-256color"] {
             // SAFETY: serialised by the guard.
@@ -1213,6 +1228,60 @@ mod tests {
             }
             if let Some(v) = prev_ssh_tty {
                 std::env::set_var("SSH_TTY", v);
+            }
+            if let Some(v) = prev_tilix_id {
+                std::env::set_var("TILIX_ID", v);
+            }
+            if let Some(v) = prev_terminator_uuid {
+                std::env::set_var("TERMINATOR_UUID", v);
+            }
+        }
+    }
+
+    #[test]
+    fn tilix_and_terminator_env_force_low_motion_on() {
+        let _g = term_program_test_guard();
+        let prev_term_program = std::env::var_os("TERM_PROGRAM");
+        let prev_tilix_id = std::env::var_os("TILIX_ID");
+        let prev_terminator_uuid = std::env::var_os("TERMINATOR_UUID");
+
+        for (var, val) in [
+            ("TILIX_ID", "d5b5b5d6-tilix-session"),
+            ("TERMINATOR_UUID", "urn:uuid:terminator-session"),
+        ] {
+            // SAFETY: serialised by the guard.
+            unsafe {
+                std::env::remove_var("TERM_PROGRAM");
+                std::env::remove_var("TILIX_ID");
+                std::env::remove_var("TERMINATOR_UUID");
+                std::env::set_var(var, val);
+            }
+            let mut settings = Settings::default();
+            assert!(!settings.low_motion, "default is animated");
+            settings.apply_env_overrides();
+            assert!(
+                settings.low_motion,
+                "{var} must enable low_motion to prevent VTE flicker (#1470)"
+            );
+            assert!(
+                !settings.fancy_animations,
+                "{var} must disable fancy_animations"
+            );
+        }
+
+        // SAFETY: cleanup under the guard.
+        unsafe {
+            match prev_term_program {
+                Some(v) => std::env::set_var("TERM_PROGRAM", v),
+                None => std::env::remove_var("TERM_PROGRAM"),
+            }
+            match prev_tilix_id {
+                Some(v) => std::env::set_var("TILIX_ID", v),
+                None => std::env::remove_var("TILIX_ID"),
+            }
+            match prev_terminator_uuid {
+                Some(v) => std::env::set_var("TERMINATOR_UUID", v),
+                None => std::env::remove_var("TERMINATOR_UUID"),
             }
         }
     }

--- a/crates/tui/src/tools/pandoc.rs
+++ b/crates/tui/src/tools/pandoc.rs
@@ -127,20 +127,6 @@ impl ToolSpec for PandocConvertTool {
             )));
         }
 
-        // Resolve the pandoc binary at execution time too — registration
-        // gated on resolve_pandoc(), but a concurrent uninstall between
-        // catalog build and the model's call should produce a clear
-        // error rather than the cryptic "program not found" from raw
-        // Command::spawn.
-        let pandoc = crate::dependencies::resolve_pandoc().ok_or_else(|| {
-            ToolError::execution_failed(
-                "pandoc_convert: pandoc binary not found on PATH. \
-                 Install pandoc (macOS: `brew install pandoc`; \
-                 Debian/Ubuntu: `apt install pandoc`; \
-                 Windows: `winget install JohnMacFarlane.Pandoc`) and restart deepseek-tui.",
-            )
-        })?;
-
         let resolved_output_path: Option<PathBuf> = match output_path_str {
             Some(p) => Some(context.resolve_path(p)?),
             None => None,
@@ -153,6 +139,22 @@ impl ToolSpec for PandocConvertTool {
                 "target_format `{target_format}` is binary; provide an `output_path` to write the converted file."
             )));
         }
+
+        // Resolve the pandoc binary at execution time too — registration
+        // gated on resolve_pandoc(), but a concurrent uninstall between
+        // catalog build and the model's call should produce a clear
+        // error rather than the cryptic "program not found" from raw
+        // Command::spawn. Keep this after input-only validation so bad
+        // requests get deterministic schema errors even when pandoc is
+        // absent on the host.
+        let pandoc = crate::dependencies::resolve_pandoc().ok_or_else(|| {
+            ToolError::execution_failed(
+                "pandoc_convert: pandoc binary not found on PATH. \
+                 Install pandoc (macOS: `brew install pandoc`; \
+                 Debian/Ubuntu: `apt install pandoc`; \
+                 Windows: `winget install JohnMacFarlane.Pandoc`) and restart deepseek-tui.",
+            )
+        })?;
 
         let mut cmd = Command::new(&pandoc);
         cmd.arg(&source_path);

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -6027,6 +6027,11 @@ fn render(f: &mut Frame, app: &mut App) {
             crate::config::ApiProvider::Vllm => Some("vLLM"),
             crate::config::ApiProvider::Ollama => Some("Ollama"),
         };
+        let status_indicator_started_at = if app.low_motion {
+            None
+        } else {
+            app.turn_started_at
+        };
         let header_data = HeaderData::new(
             app.mode,
             &model_label,
@@ -6043,7 +6048,7 @@ fn render(f: &mut Frame, app: &mut App) {
         .with_reasoning_effort(Some(&effort_label))
         .with_provider(provider_label)
         .with_status_indicator(crate::tui::widgets::header_status_indicator_frame(
-            app.turn_started_at,
+            status_indicator_started_at,
             &app.status_indicator,
         ));
         let header_widget = HeaderWidget::new(header_data);

--- a/crates/tui/src/vision/tools.rs
+++ b/crates/tui/src/vision/tools.rs
@@ -269,8 +269,13 @@ mod tests {
         let tmp = tempdir().expect("tempdir");
         let ctx = ToolContext::new(tmp.path().to_path_buf());
         let tool = ImageAnalyzeTool::new(fake_config());
+        let absolute_path = if cfg!(windows) {
+            r"C:\Windows\win.ini"
+        } else {
+            "/etc/hosts"
+        };
         let err = tool
-            .execute(json!({"image_path": "/etc/hosts"}), &ctx)
+            .execute(json!({"image_path": absolute_path}), &ctx)
             .await
             .expect_err("absolute path must reject");
         assert!(

--- a/docs/ACCESSIBILITY.md
+++ b/docs/ACCESSIBILITY.md
@@ -10,8 +10,9 @@ visual motion and density for screen-reader and low-motion users.
 | Toggle | Default | Effect |
 | --- | --- | --- |
 | `NO_ANIMATIONS=1` env var | unset | At startup, forces `low_motion = true` and `fancy_animations = false`. Overrides whatever's saved in `settings.toml`. |
-| `low_motion` setting | `false` | Suppresses spinners' motion, transcript fade-ins, footer drift, and the active-cell pulse. The frame-rate limiter also slows down idle redraws so the cursor doesn't blink as aggressively. |
+| `low_motion` setting | `false` | Suppresses spinners' motion, transcript fade-ins, footer drift, the header status-indicator cycle, and the active-cell pulse. The frame-rate limiter also slows down idle redraws so the cursor doesn't blink as aggressively. |
 | `fancy_animations` setting | `false` | Footer water-spout strip and pulsing sub-agent counter. Off by default. |
+| `status_indicator` setting | `whale` | Header status chip. Set to `dots` for the compact dot cycle or `off` to hide it. |
 | `calm_mode` setting | `false` | Collapses tool-output details by default and trims status messages. Useful for screen readers that announce every redraw. |
 | `show_thinking` setting | `true` | Set to `false` to hide model `reasoning_content` blocks entirely. |
 | `show_tool_details` setting | `true` | Set to `false` to render tool calls as one-liners without expanded payloads. |
@@ -43,10 +44,16 @@ The same toggles are reachable from the command palette:
 * `/settings set low_motion on`
 * `/settings set fancy_animations off`
 * `/settings set calm_mode on`
+* `/settings set status_indicator off`
 
 Settings written this way persist to `~/.config/deepseek/settings.toml`.
 The `NO_ANIMATIONS` env var still wins at startup if it's set, so
 unsetting the env var is the way to honor your saved choice.
+
+Tilix and Terminator sessions automatically start in low-motion mode because
+those VTE-based terminals have reported visible redraw flicker during active
+turns. You can still override the saved settings after launch if your terminal
+version renders cleanly.
 
 ## Notes for screen-reader users
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -79,6 +79,35 @@ self-hosted and can run without an API key by default. Ollama defaults to
 `http://localhost:11434/v1` and sends model tags such as `deepseek-coder:1.3b`
 or `qwen2.5-coder:7b` unchanged.
 
+### Custom OpenAI-Compatible Gateways
+
+For a third-party service that implements the OpenAI Chat Completions API, use
+the built-in `openai` provider name and point its provider table at the gateway:
+
+```toml
+provider = "openai"
+default_text_model = "your-model-id"
+
+[providers.openai]
+api_key = "YOUR_OPENAI_COMPATIBLE_API_KEY"
+base_url = "https://your-gateway.example/v1"
+```
+
+Do not invent a custom provider name; `provider` must be one of the known
+providers listed above. Put the endpoint under `[providers.openai]`, not the
+legacy top-level `base_url`, so the OpenAI-compatible provider receives it.
+`default_text_model` is the model ID sent to the gateway; if you keep several
+provider tables in one config, `[providers.openai].model` can be used as the
+OpenAI-provider-specific override.
+
+Local HTTP endpoints such as Ollama, SGLang, and vLLM are allowed by default
+when they use localhost or loopback addresses. For a non-local `http://`
+gateway, launch with `DEEPSEEK_ALLOW_INSECURE_HTTP=1` only on a trusted network:
+
+```bash
+DEEPSEEK_ALLOW_INSECURE_HTTP=1 deepseek
+```
+
 Third-party OpenAI-compatible gateways that need extra request headers can set
 `http_headers = { "X-Model-Provider-Id" = "your-model-provider" }` at the top
 level or under a provider table such as `[providers.deepseek]`. When configured,


### PR DESCRIPTION
## Summary
- route security disclosure docs through GitHub private advisories instead of a personal Gmail address
- document custom OpenAI-compatible gateway setup, including provider-table `base_url`, model placement, and `DEEPSEEK_ALLOW_INSECURE_HTTP=1` for trusted non-local HTTP endpoints
- auto-enable low-motion mode for Tilix and Terminator sessions that report VTE redraw flicker
- keep the header status indicator static when low-motion mode is active, and document `status_indicator = off` for users who want no animated chip
- keep pandoc/vision validations deterministic on CI hosts while these fixes are still pending on `main`

## Issues
- Closes #1453
- Closes #1491
- Closes #1105
- Closes #1470
- Addresses #1191

## Validation
- `cargo fmt --all --check`
- `cargo test -p deepseek-tui settings::tests::tilix_and_terminator_env_force_low_motion_on -- --nocapture`
- `cargo test -p deepseek-tui settings::tests::non_vscode_term_program_does_not_force_low_motion -- --nocapture`
- `cargo test -p deepseek-tui tui::widgets::header::tests:: -- --nocapture`
- `cargo test -p deepseek-tui tools::pandoc::tests::pandoc_convert_rejects_inline_request_for_binary_format -- --nocapture`
- `cargo test -p deepseek-tui vision::tools::tests::execute_rejects_absolute_path -- --nocapture`
- `cargo check -p deepseek-tui`