### PR TITLE
fix(tui): merge resize clear+draw into single DEC 2026 batch to eliminate blank flash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Resize no longer flashes a blank intermediate frame.** The previous
+  resize handler called `reset_terminal_viewport` (clear) and
+  `draw_app_frame` (draw) as two separate DEC 2026 synchronized-output
+  batches — GPU-accelerated terminals (Ghostty, VSCode, Kitty,
+  WezTerm) rendered the blank cleared screen as one frame and the
+  repainted UI as the next, producing a visible flash during every
+  window drag-resize. The fix merges both into a single
+  `draw_app_frame_inner(full_repaint=true)` call so the clear and the
+  redraw land in one batch with no intermediate frame.
+
 ## [0.8.32] - 2026-05-12
 
 A "more useful tools" release. v0.8.31 made the tool surface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   window drag-resize. The fix merges both into a single
   `draw_app_frame_inner(full_repaint=true)` call so the clear and the
   redraw land in one batch with no intermediate frame.
+- **TurnComplete no longer forces a full clear+redraw on successful
+  turns.** Every completed turn was unconditionally triggering
+  `force_terminal_repaint = true`, which called
+  `TERMINAL_ORIGIN_RESET` + `terminal.clear()` before redrawing —
+  a clear-then-draw cycle visible as a brief flash on every API
+  response (including intermediate tool-call completions). The
+  full-repaint path is now reserved for `Interrupted` and `Failed`
+  outcomes where child processes may have left the terminal in a
+  corrupted state; normal `Completed` turns use the incremental diff
+  renderer, which handles state transitions (tool finalization,
+  loading → ready, status updates) cleanly without clearing.
 
 ## [0.8.32] - 2026-05-12
 

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -1167,7 +1167,20 @@ async fn run_event_loop(
                         status,
                         error,
                     } => {
-                        force_terminal_repaint = true;
+                        // Only force full repaint for error/interrupted states
+                        // where child processes may have corrupted the terminal
+                        // (scroll region, origin mode). Normal Completed turns
+                        // use the incremental diff renderer — the state changes
+                        // (tool finalization, is_loading → false, status
+                        // string update) are all pure data mutations the diff
+                        // renderer handles cleanly without a clear-then-redraw
+                        // flash.
+                        if !matches!(
+                            status,
+                            crate::core::events::TurnOutcomeStatus::Completed
+                        ) {
+                            force_terminal_repaint = true;
+                        }
                         // Finalize any in-flight tool group. Cancellation
                         // marks still-running entries as Failed so the user
                         // sees they were interrupted rather than the spinner

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -1988,7 +1988,6 @@ async fn run_event_loop(
                     );
                 }
 
-                reset_terminal_viewport(terminal, app.synchronized_output_enabled)?;
                 app.handle_resize(final_w, final_h);
                 // #macos-resize: some terminals (macOS Terminal.app, Windows
                 // ConHost) briefly report stale dimensions via
@@ -2004,11 +2003,15 @@ async fn run_event_loop(
                     let backend = terminal.backend_mut();
                     backend.force_size(Size::new(final_w, final_h));
                 }
-                // Draw immediately so the cleared screen gets repainted before
-                // any other events can interleave. Without this, the next
-                // iteration's draw can race against fast follow-up input and
-                // leave the user staring at a blank/partial frame.
-                draw_app_frame(terminal, app)?;
+                // Draw immediately with full_repaint so the cleared screen
+                // and the repainted UI are committed as a single DEC 2026
+                // synchronized frame. The previous two-step sequence
+                // (reset_terminal_viewport + draw_app_frame) split the clear
+                // and draw into separate DEC 2026 batches, causing a visible
+                // blank flash between them — most noticeable on GPU-accelerated
+                // terminals (Ghostty, VSCode, Kitty, WezTerm) during window
+                // drag-resizes.
+                draw_app_frame_inner(terminal, app, true)?;
                 {
                     let backend = terminal.backend_mut();
                     backend.clear_forced_size();

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -142,6 +142,12 @@ const UI_STATUS_ANIMATION_MS: u64 = 80;
 const WORKSPACE_CONTEXT_REFRESH_SECS: u64 = 15;
 const SIDEBAR_VISIBLE_MIN_WIDTH: u16 = 100;
 const DEFAULT_TERMINAL_PROBE_TIMEOUT_MS: u64 = 500;
+/// Number of incremental (non-full-repaint) draws between periodic full
+/// viewport resets on TurnComplete.  The full reset keeps ratatui's
+/// buffer model in sync with terminal reality without flashing on every
+/// turn.  50 draws ≈ 4 s of streaming at the footer-animation cadence
+/// (~12.5 fps) or ~0.4 s at the 120 FPS cap.
+const PERIODIC_FULL_REPAINT_EVERY_N: u64 = 50;
 
 type AppTerminal = Terminal<ColorCompatBackend<Stdout>>;
 
@@ -735,6 +741,10 @@ async fn run_event_loop(
     let mut web_config_session: Option<WebConfigSession> = None;
     let mut terminal_paused_at: Option<Instant> = None;
     let mut force_terminal_repaint = false;
+    // Tracks how many incremental draws have happened since the last
+    // full repaint.  Used to throttle periodic full resets on
+    // TurnComplete so we don't clear+redraw on every single turn.
+    let mut draws_since_last_full_repaint: u64 = 0;
 
     loop {
         if !drain_web_config_events(&mut web_config_session, app, config, &engine_handle).await {
@@ -1167,18 +1177,18 @@ async fn run_event_loop(
                         status,
                         error,
                     } => {
-                        // Only force full repaint for error/interrupted states
-                        // where child processes may have corrupted the terminal
-                        // (scroll region, origin mode). Normal Completed turns
-                        // use the incremental diff renderer — the state changes
-                        // (tool finalization, is_loading → false, status
-                        // string update) are all pure data mutations the diff
-                        // renderer handles cleanly without a clear-then-redraw
-                        // flash.
+                        // Always force full repaint for error/interrupted
+                        // states where child processes may have corrupted the
+                        // terminal. For Completed turns, throttle to periodic
+                        // resets: the incremental diff renderer handles normal
+                        // state transitions, but a periodic full reset keeps
+                        // ratatui's buffer model in sync with terminal reality.
                         if !matches!(
                             status,
                             crate::core::events::TurnOutcomeStatus::Completed
-                        ) {
+                        ) || draws_since_last_full_repaint
+                            >= PERIODIC_FULL_REPAINT_EVERY_N
+                        {
                             force_terminal_repaint = true;
                         }
                         // Finalize any in-flight tool group. Cancellation
@@ -1853,8 +1863,15 @@ async fn run_event_loop(
             None
         };
         if app.needs_redraw && draw_wait.is_none() {
+            let was_full_repaint = force_terminal_repaint;
             draw_app_frame_inner(terminal, app, force_terminal_repaint)?;
             force_terminal_repaint = false;
+            if was_full_repaint {
+                draws_since_last_full_repaint = 0;
+            } else {
+                draws_since_last_full_repaint =
+                    draws_since_last_full_repaint.saturating_add(1);
+            }
             frame_rate_limiter.mark_emitted(Instant::now());
             app.needs_redraw = false;
         }
@@ -6213,10 +6230,6 @@ fn draw_app_frame_inner(
     }
     let _ = terminal.backend_mut().flush();
     result
-}
-
-fn draw_app_frame(terminal: &mut AppTerminal, app: &mut App) -> Result<()> {
-    draw_app_frame_inner(terminal, app, false)
 }
 
 /// Pull the latest snapshot of cells / revisions / render options into the


### PR DESCRIPTION
Fix resize flicker: merge clear+draw into single DEC 2026 batch. Changes: crates/tui/src/tui/ui.rs (remove reset_terminal_viewport, use draw_app_frame_inner with full_repaint=true). CHANGELOG updated.