### PR TITLE
fix(npm): show install hint on first ETIMEDOUT and fix broken doc anchor

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -439,6 +439,40 @@ target/debug/build/libsqlite3-sys-*/build-script-build
 # fine — the AV is blocking Cargo's process-spawning path specifically.
 ```
 
+### npm binary download times out
+
+If `deepseek` hangs for several seconds and prints `connect ETIMEDOUT`
+or `EAI_AGAIN` when fetching from `github.com`, the prebuilt binary download
+is being blocked on your network. The npm package downloads binaries from
+GitHub Releases; this is separate from the npm registry download.
+
+**Solutions (pick one):**
+
+1. **Use a proxy** — set the standard `HTTPS_PROXY` / `HTTP_PROXY` environment
+   variables and re-run `deepseek`:
+   ```bash
+   export HTTPS_PROXY=http://your-proxy:port
+   deepseek
+   ```
+
+2. **Mirror the release assets** — host the binary assets on an internal server
+   and set `DEEPSEEK_TUI_RELEASE_BASE_URL`:
+   ```bash
+   export DEEPSEEK_TUI_RELEASE_BASE_URL=https://your-mirror.example.com/DeepSeek-TUI/
+   deepseek
+   ```
+   The directory must contain `deepseek-artifacts-sha256.txt` and the platform
+   binaries from the [GitHub Releases](https://github.com/Hmbown/DeepSeek-TUI/releases) page.
+
+3. **Install via Cargo** — Cargo bypasses the GitHub Releases download entirely.
+   See [Section 3](#3-install-via-cargo-any-tier-1-rust-target) for instructions,
+   including China-friendly mirror config.
+
+4. **Manual download** — download both binaries from the
+   [Releases page](https://github.com/Hmbown/DeepSeek-TUI/releases) and place
+   them in your `~/.local/bin` (or any directory on `PATH`). See
+   [Section 4](#4-manual-download-from-github-releases).
+
 ---
 
 ## 7. Verifying your install

--- a/npm/deepseek-tui/scripts/install.js
+++ b/npm/deepseek-tui/scripts/install.js
@@ -195,7 +195,7 @@ function installFailureHint(error) {
     "  If GitHub is unavailable on this network, mirror the release assets and set:",
     "    DEEPSEEK_TUI_RELEASE_BASE_URL=https://<mirror>/<release-asset-directory>/",
     "  The directory must contain deepseek-artifacts-sha256.txt and the platform binaries.",
-    "  See docs/INSTALL.md#npm-download-is-slow-or-times-out-from-mainland-china.",
+    "  See docs/INSTALL.md#npm-binary-download-times-out.",
   ].join("\n");
 }
 
@@ -790,6 +790,14 @@ async function withRetry(label, fn, context = "runtime") {
       logInfo(
         `${label} failed (attempt ${attempt}/${attemptLimit}): ${err.message}; retrying in ${wait} ms`,
       );
+      // Show the install hint on the first retryable failure so users
+      // don't have to wait through all attempts before seeing solutions.
+      if (attempt === 1) {
+        const hint = installFailureHint(err);
+        if (hint) {
+          process.stderr.write(`${hint}\n`);
+        }
+      }
       await sleep(wait);
     }
   }


### PR DESCRIPTION
### Problem
    When GitHub Releases is unreachable (ETIMEDOUT), the npm wrapper retries
    5 times before showing any hint — users wait 10+ seconds with no guidance.
    The hint also references a non-existent doc section.
    
    ### Changes
    - Show `installFailureHint` on the first retryable download failure
      instead of waiting until all retries are exhausted
    - Fix broken anchor: `#npm-download-is-slow-or-times-out-from-mainland-china`
      → `#npm-binary-download-times-out`
    - Add "npm binary download times out" troubleshooting section to
      `docs/INSTALL.md` with 4 solutions: proxy, mirror, Cargo, manual download
    
    Closes #1532