### PR TITLE
feat(exec): add --resume and --continue for session continuity

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 
 pub const CONFIG_FILE_NAME: &str = "config.toml";
-const DEFAULT_DEEPSEEK_MODEL: &str = "deepseek-v4-pro";
+const DEFAULT_DEEPSEEK_MODEL: &str = "deepseek-v4-flash";
 const DEFAULT_NVIDIA_NIM_MODEL: &str = "deepseek-ai/deepseek-v4-pro";
 const DEFAULT_NVIDIA_NIM_FLASH_MODEL: &str = "deepseek-ai/deepseek-v4-flash";
 const DEFAULT_OPENAI_MODEL: &str = "gpt-4.1";

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -166,6 +166,11 @@ pub struct EngineConfig {
     pub search_provider: crate::config::SearchProvider,
     /// API key for Tavily or Bocha. `None` for DuckDuckGo.
     pub search_api_key: Option<String>,
+    /// Custom system prompt injected via `--system-prompt` / `--system-prompt-file`
+    /// on the exec subcommand. Appended below the volatile-content boundary
+    /// in the system prompt so it doesn't disrupt the prefix cache for static
+    /// layers. `None` when no custom prompt is provided.
+    pub custom_system_prompt: Option<String>,
 }
 
 impl Default for EngineConfig {
@@ -206,6 +211,7 @@ impl Default for EngineConfig {
             workshop: None,
             search_provider: crate::config::SearchProvider::default(),
             search_api_key: None,
+            custom_system_prompt: None,
         }
     }
 }
@@ -466,6 +472,7 @@ impl Engine {
                     project_context_pack_enabled: config.project_context_pack_enabled,
                     locale_tag: &config.locale_tag,
                     translation_enabled: config.translation_enabled,
+                    custom_system_prompt: config.custom_system_prompt.as_deref(),
                 },
                 session.approval_mode,
             );
@@ -776,6 +783,16 @@ impl Engine {
                     };
                     self.session.rebuild_working_set();
                     self.rehydrate_latest_canonical_state();
+                    // When a custom system prompt is configured (e.g. via
+                    // --system-prompt on exec), Op::SyncSession's wholesale
+                    // overwrite of session.system_prompt would lose the custom
+                    // block. Clear the hash gate and rebuild via
+                    // refresh_system_prompt() so the PromptSessionContext
+                    // pipeline re-injects the custom block.
+                    if self.config.custom_system_prompt.is_some() {
+                        self.session.last_system_prompt_hash = None;
+                        self.refresh_system_prompt(AppMode::Agent);
+                    }
                     self.emit_session_updated().await;
                     let _ = self
                         .tx_event
@@ -1910,6 +1927,7 @@ impl Engine {
                 project_context_pack_enabled: self.config.project_context_pack_enabled,
                 locale_tag: &self.config.locale_tag,
                 translation_enabled: self.config.translation_enabled,
+                custom_system_prompt: self.config.custom_system_prompt.as_deref(),
             },
             self.session.approval_mode,
         );

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -293,6 +293,9 @@ struct ExecArgs {
     /// Continue the most recent session for this workspace
     #[arg(long, default_value_t = false)]
     r#continue: bool,
+    /// Output format: text (default) or stream-json (JSON Lines for machine consumption)
+    #[arg(long, value_name = "FORMAT", default_value = "text")]
+    output_format: String,
 }
 
 fn join_prompt_parts(parts: &[String]) -> String {
@@ -721,6 +724,7 @@ async fn main() -> Result<()> {
                         auto_mode,
                         args.json,
                         resume_session_id,
+                        args.output_format.clone(),
                     )
                     .await
                 } else if args.json {
@@ -4407,6 +4411,70 @@ async fn run_one_shot_json(config: &Config, model: &str, prompt: &str) -> Result
     Ok(())
 }
 
+// ---------------------------------------------------------------------------
+// Stream-json output types for --output-format stream-json
+// ---------------------------------------------------------------------------
+
+/// Output format for exec mode.
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum OutputFormat {
+    Text,
+    StreamJson,
+}
+
+impl OutputFormat {
+    fn from_str(s: &str) -> Result<Self> {
+        match s {
+            "text" => Ok(OutputFormat::Text),
+            "stream-json" => Ok(OutputFormat::StreamJson),
+            _ => bail!(
+                "unknown output format '{}'. Valid values: text, stream-json",
+                s
+            ),
+        }
+    }
+}
+
+/// Streaming metadata emitted at turn end.
+#[derive(serde::Serialize)]
+struct StreamMeta {
+    model: String,
+    input_tokens: u32,
+    output_tokens: u32,
+    session_id: String,
+}
+
+/// A single JSON Lines event emitted when --output-format stream-json is set.
+#[derive(serde::Serialize)]
+#[serde(tag = "type")]
+enum StreamEvent {
+    #[serde(rename = "content")]
+    Content { content: String },
+    #[serde(rename = "thinking")]
+    Thinking { content: String },
+    #[serde(rename = "tool_use")]
+    ToolUse {
+        name: String,
+        id: String,
+        input: serde_json::Value,
+        done: bool,
+    },
+    #[serde(rename = "tool_result")]
+    ToolResult {
+        id: String,
+        output: String,
+        status: String,
+    },
+    #[serde(rename = "metadata")]
+    Metadata { meta: StreamMeta },
+    #[serde(rename = "session_capture")]
+    SessionCapture { content: String },
+    #[serde(rename = "done")]
+    Done,
+    #[serde(rename = "error")]
+    Error { error: String },
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn run_exec_agent(
     config: &Config,
@@ -4418,6 +4486,7 @@ async fn run_exec_agent(
     trust_mode: bool,
     json_output: bool,
     resume_session_id: Option<String>,
+    output_format: String,
 ) -> Result<()> {
     use crate::compaction::CompactionConfig;
     use crate::core::engine::{EngineConfig, spawn_engine};
@@ -4628,6 +4697,8 @@ async fn run_exec_agent(
     let mut latest_model: String = String::new();
     let mut latest_workspace: PathBuf = workspace.clone();
 
+    let output_fmt = OutputFormat::from_str(&output_format)?;
+
     let mut stdout = io::stdout();
     let mut ends_with_newline = false;
     loop {
@@ -4643,46 +4714,99 @@ async fn run_exec_agent(
         match event {
             Event::MessageDelta { content, .. } => {
                 summary.output.push_str(&content);
-                if !json_output {
-                    print!("{content}");
-                    stdout.flush()?;
+                match output_fmt {
+                    OutputFormat::StreamJson => {
+                        println!("{}", serde_json::to_string(&StreamEvent::Content {
+                            content,
+                        })?);
+                    }
+                    OutputFormat::Text if !json_output => {
+                        print!("{content}");
+                        stdout.flush()?;
+                    }
+                    OutputFormat::Text => {}
                 }
-                ends_with_newline = content.ends_with('\n');
+                ends_with_newline = summary.output.ends_with('\n');
             }
-            Event::MessageComplete { .. } if !json_output && !ends_with_newline => {
-                println!();
-            }
-            Event::ToolCallStarted { name, input, .. } if !json_output => {
-                let summary = summarize_tool_args(&input);
-                if let Some(summary) = summary {
-                    eprintln!("tool: {name} ({summary})");
-                } else {
-                    eprintln!("tool: {name}");
+            Event::ThinkingDelta { content, .. } => {
+                match output_fmt {
+                    OutputFormat::StreamJson => {
+                        println!("{}", serde_json::to_string(&StreamEvent::Thinking {
+                            content,
+                        })?);
+                    }
+                    OutputFormat::Text => {
+                        // In text mode, thinking content is not displayed.
+                    }
                 }
             }
-            Event::ToolCallProgress { id, output } if !json_output => {
-                eprintln!("tool {id}: {}", summarize_tool_output(&output));
+            Event::MessageComplete { .. } => {
+                if output_fmt == OutputFormat::Text && !json_output && !ends_with_newline {
+                    println!();
+                }
             }
-            Event::ToolCallComplete { name, result, .. } => match result {
-                Ok(output) => {
+            Event::ToolCallStarted { id, name, input, .. } => {
+                match output_fmt {
+                    OutputFormat::StreamJson => {
+                        println!("{}", serde_json::to_string(&StreamEvent::ToolUse {
+                            name,
+                            id,
+                            input,
+                            done: false,
+                        })?);
+                    }
+                    OutputFormat::Text if !json_output => {
+                        let summary = summarize_tool_args(&input);
+                        if let Some(summary) = summary {
+                            eprintln!("tool: {name} ({summary})");
+                        } else {
+                            eprintln!("tool: {name}");
+                        }
+                    }
+                    OutputFormat::Text => {}
+                }
+            }
+            Event::ToolCallProgress { id, output } => {
+                // ToolCallProgress is not emitted in the main turn loop,
+                // but handle it for completeness.
+                if output_fmt == OutputFormat::Text && !json_output {
+                    eprintln!("tool {id}: {}", summarize_tool_output(&output));
+                }
+            }
+            Event::ToolCallComplete { id, name, result, .. } => match result {
+                Ok(tool_result) => {
                     summary.tools.push(ExecToolEntry {
                         name: name.clone(),
-                        success: output.success,
-                        output: output.content.clone(),
+                        success: tool_result.success,
+                        output: tool_result.content.clone(),
                     });
-                    if name == "exec_shell" && !output.content.trim().is_empty() {
-                        if !json_output {
-                            eprintln!("tool {name} completed");
-                            eprintln!(
-                                "--- stdout/stderr ---\n{}\n---------------------",
-                                output.content
-                            );
+                    match output_fmt {
+                        OutputFormat::StreamJson => {
+                            println!("{}", serde_json::to_string(&StreamEvent::ToolResult {
+                                id,
+                                output: tool_result.content,
+                                status: if tool_result.success {
+                                    "success".to_string()
+                                } else {
+                                    "error".to_string()
+                                },
+                            })?);
                         }
-                    } else if !json_output {
-                        eprintln!(
-                            "tool {name} completed: {}",
-                            summarize_tool_output(&output.content)
-                        );
+                        OutputFormat::Text if !json_output => {
+                            if name == "exec_shell" && !tool_result.content.trim().is_empty() {
+                                eprintln!("tool {name} completed");
+                                eprintln!(
+                                    "--- stdout/stderr ---\n{}\n---------------------",
+                                    tool_result.content
+                                );
+                            } else {
+                                eprintln!(
+                                    "tool {name} completed: {}",
+                                    summarize_tool_output(&tool_result.content)
+                                );
+                            }
+                        }
+                        OutputFormat::Text => {}
                     }
                 }
                 Err(err) => {
@@ -4691,22 +4815,38 @@ async fn run_exec_agent(
                         success: false,
                         output: err.to_string(),
                     });
-                    if !json_output {
-                        eprintln!("tool {name} failed: {err}");
+                    match output_fmt {
+                        OutputFormat::StreamJson => {
+                            println!("{}", serde_json::to_string(&StreamEvent::ToolResult {
+                                id,
+                                output: err.to_string(),
+                                status: "error".to_string(),
+                            })?);
+                        }
+                        OutputFormat::Text if !json_output => {
+                            eprintln!("tool {name} failed: {err}");
+                        }
+                        OutputFormat::Text => {}
                     }
                 }
             },
             Event::AgentSpawned { id, prompt } => {
-                eprintln!("sub-agent {id} spawned: {}", summarize_tool_output(&prompt));
+                if output_fmt == OutputFormat::Text {
+                    eprintln!("sub-agent {id} spawned: {}", summarize_tool_output(&prompt));
+                }
             }
             Event::AgentProgress { id, status } => {
-                eprintln!("sub-agent {id}: {status}");
+                if output_fmt == OutputFormat::Text {
+                    eprintln!("sub-agent {id}: {status}");
+                }
             }
             Event::AgentComplete { id, result } => {
-                eprintln!(
-                    "sub-agent {id} completed: {}",
-                    summarize_tool_output(&result)
-                );
+                if output_fmt == OutputFormat::Text {
+                    eprintln!(
+                        "sub-agent {id} completed: {}",
+                        summarize_tool_output(&result)
+                    );
+                }
             }
             Event::ApprovalRequired { id, .. } => {
                 if auto_approve {
@@ -4722,11 +4862,15 @@ async fn run_exec_agent(
                 ..
             } => {
                 if auto_approve {
-                    eprintln!("sandbox denied {tool_name}: {denial_reason} (auto-elevating)");
+                    if output_fmt == OutputFormat::Text {
+                        eprintln!("sandbox denied {tool_name}: {denial_reason} (auto-elevating)");
+                    }
                     let policy = crate::sandbox::SandboxPolicy::DangerFullAccess;
                     let _ = engine_handle.retry_tool_with_policy(tool_id, policy).await;
                 } else {
-                    eprintln!("sandbox denied {tool_name}: {denial_reason}");
+                    if output_fmt == OutputFormat::Text {
+                        eprintln!("sandbox denied {tool_name}: {denial_reason}");
+                    }
                     let _ = engine_handle.deny_tool_call(tool_id).await;
                 }
             }
@@ -4735,8 +4879,16 @@ async fn run_exec_agent(
                 recoverable: _,
             } => {
                 summary.error = Some(envelope.message.clone());
-                if !json_output {
-                    eprintln!("error: {}", envelope.message);
+                match output_fmt {
+                    OutputFormat::StreamJson => {
+                        println!("{}", serde_json::to_string(&StreamEvent::Error {
+                            error: envelope.message,
+                        })?);
+                    }
+                    OutputFormat::Text if !json_output => {
+                        eprintln!("error: {}", summary.error.as_deref().unwrap_or_default());
+                    }
+                    OutputFormat::Text => {}
                 }
             }
             Event::TurnComplete { status, error, usage, .. } => {
@@ -4744,7 +4896,7 @@ async fn run_exec_agent(
                 summary.error = error;
 
                 // Save the session so it can be resumed later with --resume.
-                if let Ok(manager) =
+                let saved_session_id = if let Ok(manager) =
                     crate::session_manager::SessionManager::default_location()
                 {
                     if !latest_messages.is_empty() {
@@ -4757,7 +4909,6 @@ async fn run_exec_agent(
                             .to_string();
 
                         let saved = if !session_id.is_empty() {
-                            // Try to update an existing session (resume path)
                             match manager.load_session(&session_id) {
                                 Ok(existing) => {
                                     crate::session_manager::update_session(
@@ -4768,7 +4919,6 @@ async fn run_exec_agent(
                                     )
                                 }
                                 Err(_) => {
-                                    // Existing session not found — create fresh with the same ID
                                     crate::session_manager::create_saved_session_with_id_and_mode(
                                         session_id,
                                         &latest_messages,
@@ -4781,7 +4931,6 @@ async fn run_exec_agent(
                                 }
                             }
                         } else {
-                            // Fresh session — generate a new ID
                             crate::session_manager::create_saved_session_with_mode(
                                 &latest_messages,
                                 &latest_model,
@@ -4792,19 +4941,46 @@ async fn run_exec_agent(
                             )
                         };
 
+                        let saved_id = saved.metadata.id.clone();
                         match manager.save_session(&saved) {
                             Ok(_) => {
-                                if !json_output {
+                                if output_fmt == OutputFormat::Text && !json_output {
                                     eprintln!("session: {}", saved.metadata.id);
                                 }
                             }
                             Err(e) => {
-                                if !json_output {
+                                if output_fmt == OutputFormat::Text && !json_output {
                                     eprintln!("Warning: failed to save session: {e}");
                                 }
                             }
                         }
+                        Some(saved_id)
+                    } else {
+                        None
                     }
+                } else {
+                    None
+                };
+
+                // Emit stream-json events for metadata, session_capture, and done.
+                if output_fmt == OutputFormat::StreamJson {
+                    if let Some(sid) = saved_session_id {
+                        println!("{}", serde_json::to_string(&StreamEvent::SessionCapture {
+                            content: sid,
+                        })?);
+                    }
+                    println!("{}", serde_json::to_string(&StreamEvent::Metadata {
+                        meta: StreamMeta {
+                            model: latest_model.clone(),
+                            input_tokens: usage.input_tokens,
+                            output_tokens: usage.output_tokens,
+                            session_id: latest_session_id
+                                .as_deref()
+                                .unwrap_or_default()
+                                .to_string(),
+                        },
+                    })?);
+                    println!("{}", serde_json::to_string(&StreamEvent::Done)?);
                 }
 
                 let _ = engine_handle.send(Op::Shutdown).await;
@@ -6169,5 +6345,275 @@ mod pr_prompt_tests {
             !is_command_available("this-command-cannot-exist-deepseek-tui-test-ENOENT-marker"),
             "missing command should return false, not panic"
         );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests for exec session resume (--resume/--continue) and stream-json output
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod exec_session_and_stream_tests {
+    use super::*;
+
+    // ---- OutputFormat tests ----
+
+    #[test]
+    fn output_format_text() {
+        let fmt = OutputFormat::from_str("text").unwrap();
+        assert_eq!(fmt, OutputFormat::Text);
+    }
+
+    #[test]
+    fn output_format_stream_json() {
+        let fmt = OutputFormat::from_str("stream-json").unwrap();
+        assert_eq!(fmt, OutputFormat::StreamJson);
+    }
+
+    #[test]
+    fn output_format_rejects_unknown() {
+        let err = OutputFormat::from_str("xml").unwrap_err();
+        assert!(err.to_string().contains("unknown output format"));
+        assert!(err.to_string().contains("xml"));
+    }
+
+    // ---- StreamEvent serialization tests ----
+
+    #[test]
+    fn stream_event_content_serializes() {
+        let evt = StreamEvent::Content {
+            content: "hello".to_string(),
+        };
+        let json = serde_json::to_string(&evt).unwrap();
+        assert!(json.contains(r#""type":"content""#));
+        assert!(json.contains(r#""content":"hello""#));
+    }
+
+    #[test]
+    fn stream_event_thinking_serializes() {
+        let evt = StreamEvent::Thinking {
+            content: "pondering".to_string(),
+        };
+        let json = serde_json::to_string(&evt).unwrap();
+        assert!(json.contains(r#""type":"thinking""#));
+        assert!(json.contains(r#""content":"pondering""#));
+    }
+
+    #[test]
+    fn stream_event_tool_use_serializes() {
+        let evt = StreamEvent::ToolUse {
+            name: "read_file".to_string(),
+            id: "tool_123".to_string(),
+            input: serde_json::json!({"path": "Cargo.toml"}),
+            done: false,
+        };
+        let json = serde_json::to_string(&evt).unwrap();
+        assert!(json.contains(r#""type":"tool_use""#));
+        assert!(json.contains(r#""name":"read_file""#));
+        assert!(json.contains(r#""id":"tool_123""#));
+        assert!(json.contains(r#""done":false"#));
+    }
+
+    #[test]
+    fn stream_event_tool_result_serializes() {
+        let evt = StreamEvent::ToolResult {
+            id: "tool_123".to_string(),
+            output: "file contents".to_string(),
+            status: "success".to_string(),
+        };
+        let json = serde_json::to_string(&evt).unwrap();
+        assert!(json.contains(r#""type":"tool_result""#));
+        assert!(json.contains(r#""id":"tool_123""#));
+        assert!(json.contains(r#""status":"success""#));
+    }
+
+    #[test]
+    fn stream_event_tool_result_error_serializes() {
+        let evt = StreamEvent::ToolResult {
+            id: "tool_456".to_string(),
+            output: "permission denied".to_string(),
+            status: "error".to_string(),
+        };
+        let json = serde_json::to_string(&evt).unwrap();
+        assert!(json.contains(r#""status":"error""#));
+    }
+
+    #[test]
+    fn stream_event_metadata_serializes() {
+        let evt = StreamEvent::Metadata {
+            meta: StreamMeta {
+                model: "deepseek-v4-flash".to_string(),
+                input_tokens: 100,
+                output_tokens: 50,
+                session_id: "abc-123".to_string(),
+            },
+        };
+        let json = serde_json::to_string(&evt).unwrap();
+        assert!(json.contains(r#""type":"metadata""#));
+        assert!(json.contains(r#""model":"deepseek-v4-flash""#));
+        assert!(json.contains(r#""input_tokens":100"#));
+        assert!(json.contains(r#""output_tokens":50"#));
+        assert!(json.contains(r#""session_id":"abc-123""#));
+    }
+
+    #[test]
+    fn stream_event_session_capture_serializes() {
+        let evt = StreamEvent::SessionCapture {
+            content: "c45d0ab8-8dfc-4676-804a-199a5526a25c".to_string(),
+        };
+        let json = serde_json::to_string(&evt).unwrap();
+        assert!(json.contains(r#""type":"session_capture""#));
+        assert!(json.contains(r#""content":"c45d0ab8"#));
+    }
+
+    #[test]
+    fn stream_event_done_serializes() {
+        let evt = StreamEvent::Done;
+        let json = serde_json::to_string(&evt).unwrap();
+        assert_eq!(json, r#"{"type":"done"}"#);
+    }
+
+    #[test]
+    fn stream_event_error_serializes() {
+        let evt = StreamEvent::Error {
+            error: "API error".to_string(),
+        };
+        let json = serde_json::to_string(&evt).unwrap();
+        assert!(json.contains(r#""type":"error""#));
+        assert!(json.contains(r#""error":"API error""#));
+    }
+
+    // ---- JSON Lines round-trip: each event is one valid JSON line ----
+
+    #[test]
+    fn stream_events_are_single_line_json() {
+        // Every serialized StreamEvent must be a single line (no embedded newlines)
+        // so it can be parsed as JSON Lines (NDJSON).
+        let events: Vec<StreamEvent> = vec![
+            StreamEvent::Content { content: "hello\nworld".to_string() },
+            StreamEvent::Thinking { content: "line1\nline2".to_string() },
+            StreamEvent::ToolUse {
+                name: "read_file".to_string(),
+                id: "id1".to_string(),
+                input: serde_json::json!({"path": "test.rs"}),
+                done: false,
+            },
+            StreamEvent::ToolResult {
+                id: "id1".to_string(),
+                output: "output with\nnewlines".to_string(),
+                status: "success".to_string(),
+            },
+            StreamEvent::Metadata {
+                meta: StreamMeta {
+                    model: "m".to_string(),
+                    input_tokens: 1,
+                    output_tokens: 2,
+                    session_id: "s".to_string(),
+                },
+            },
+            StreamEvent::SessionCapture { content: "sid".to_string() },
+            StreamEvent::Done,
+            StreamEvent::Error { error: "e".to_string() },
+        ];
+
+        for evt in &events {
+            let json = serde_json::to_string(evt).unwrap();
+            // Must be valid JSON
+            let _: serde_json::Value = serde_json::from_str(&json).unwrap();
+            // Must be a single line (no unescaped newlines outside strings)
+            assert!(
+                !json.contains('\n'),
+                "StreamEvent serialized with embedded newline: {json}"
+            );
+        }
+    }
+
+    // ---- Content with special characters is properly escaped ----
+
+    #[test]
+    fn stream_event_content_with_special_chars() {
+        let evt = StreamEvent::Content {
+            content: "quotes \" and backslash \\".to_string(),
+        };
+        let json = serde_json::to_string(&evt).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["content"], "quotes \" and backslash \\");
+    }
+
+    #[test]
+    fn stream_event_content_with_unicode() {
+        let evt = StreamEvent::Content {
+            content: "你好世界 🦀".to_string(),
+        };
+        let json = serde_json::to_string(&evt).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["content"], "你好世界 🦀");
+    }
+
+    // ---- Session resume: load_session_by_prefix integration ----
+
+    #[test]
+    fn session_manager_load_by_prefix_rejects_nonexistent() {
+        let manager = crate::session_manager::SessionManager::default_location().unwrap();
+        let result = manager.load_session_by_prefix("nonexistent_prefix_12345");
+        assert!(result.is_err());
+    }
+
+    // ---- StreamMeta field completeness ----
+
+    #[test]
+    fn stream_meta_has_all_required_fields() {
+        let meta = StreamMeta {
+            model: "deepseek-v4-flash".to_string(),
+            input_tokens: 1000,
+            output_tokens: 500,
+            session_id: "test-session-id".to_string(),
+        };
+        let json = serde_json::to_string(&meta).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(parsed.get("model").is_some(), "missing 'model' field");
+        assert!(parsed.get("input_tokens").is_some(), "missing 'input_tokens' field");
+        assert!(parsed.get("output_tokens").is_some(), "missing 'output_tokens' field");
+        assert!(parsed.get("session_id").is_some(), "missing 'session_id' field");
+    }
+
+    // ---- ClawBench compatibility: type field values match expected strings ----
+
+    #[test]
+    fn stream_event_type_values_match_clawbench_expectations() {
+        // ClawBench expects these exact type strings:
+        // "content", "thinking", "tool_use", "tool_result",
+        // "metadata", "session_capture", "done", "error"
+
+        let test_cases: Vec<(StreamEvent, &str)> = vec![
+            (StreamEvent::Content { content: "x".into() }, "content"),
+            (StreamEvent::Thinking { content: "x".into() }, "thinking"),
+            (StreamEvent::ToolUse {
+                name: "n".into(), id: "i".into(),
+                input: serde_json::Value::Null, done: false,
+            }, "tool_use"),
+            (StreamEvent::ToolResult {
+                id: "i".into(), output: "o".into(), status: "s".into(),
+            }, "tool_result"),
+            (StreamEvent::Metadata {
+                meta: StreamMeta {
+                    model: "m".into(), input_tokens: 0, output_tokens: 0,
+                    session_id: "s".into(),
+                },
+            }, "metadata"),
+            (StreamEvent::SessionCapture { content: "c".into() }, "session_capture"),
+            (StreamEvent::Done, "done"),
+            (StreamEvent::Error { error: "e".into() }, "error"),
+        ];
+
+        for (evt, expected_type) in test_cases {
+            let json = serde_json::to_string(&evt).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+            let actual_type = parsed["type"].as_str().unwrap();
+            assert_eq!(
+                actual_type, expected_type,
+                "StreamEvent type mismatch: expected {expected_type}, got {actual_type}"
+            );
+        }
     }
 }

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -296,6 +296,12 @@ struct ExecArgs {
     /// Output format: text (default) or stream-json (JSON Lines for machine consumption)
     #[arg(long, value_name = "FORMAT", default_value = "text")]
     output_format: String,
+    /// Append a custom system prompt below the auto-generated prompt
+    #[arg(long, value_name = "TEXT")]
+    system_prompt: Option<String>,
+    /// Read custom system prompt from a file (useful for long prompts)
+    #[arg(long, value_name = "PATH")]
+    system_prompt_file: Option<PathBuf>,
 }
 
 fn join_prompt_parts(parts: &[String]) -> String {
@@ -685,13 +691,34 @@ async fn main() -> Result<()> {
                     std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
                 });
 
+                // Resolve custom system prompt from --system-prompt or --system-prompt-file.
+                // These two flags are mutually exclusive.
+                let custom_system_prompt = match (&args.system_prompt, &args.system_prompt_file) {
+                    (Some(_), Some(_)) => {
+                        bail!("--system-prompt and --system-prompt-file are mutually exclusive");
+                    }
+                    (Some(text), None) => Some(text.clone()),
+                    (None, Some(path)) => {
+                        let content = std::fs::read_to_string(path).with_context(|| {
+                            format!("could not read system prompt file: {}", path.display())
+                        })?;
+                        if content.trim().is_empty() {
+                            bail!("system prompt file is empty: {}", path.display());
+                        }
+                        Some(content)
+                    }
+                    (None, None) => None,
+                };
+
                 // Resolve resume session ID from --resume or --continue
                 let resume_session_id = if args.r#continue {
                     latest_session_id_for_workspace(&workspace)
                         .ok()
                         .flatten()
                         .or_else(|| {
-                            eprintln!("No recent session found for this workspace. Starting fresh.");
+                            eprintln!(
+                                "No recent session found for this workspace. Starting fresh."
+                            );
                             None
                         })
                 } else {
@@ -725,6 +752,7 @@ async fn main() -> Result<()> {
                         args.json,
                         resume_session_id,
                         args.output_format.clone(),
+                        custom_system_prompt,
                     )
                     .await
                 } else if args.json {
@@ -733,14 +761,14 @@ async fn main() -> Result<()> {
                         .or_else(|| config.default_text_model.clone())
                         .unwrap_or_else(|| config.default_model());
                     let prompt = join_prompt_parts(&args.prompt);
-                    run_one_shot_json(&config, &model, &prompt).await
+                    run_one_shot_json(&config, &model, &prompt, custom_system_prompt).await
                 } else {
                     let model = args
                         .model
                         .or_else(|| config.default_text_model.clone())
                         .unwrap_or_else(|| config.default_model());
                     let prompt = join_prompt_parts(&args.prompt);
-                    run_one_shot(&config, &model, &prompt).await
+                    run_one_shot(&config, &model, &prompt, custom_system_prompt).await
                 }
             }
             Commands::Review(args) => {
@@ -832,7 +860,7 @@ async fn main() -> Result<()> {
     if !cli.prompt.is_empty() {
         let prompt = join_prompt_parts(&cli.prompt);
         let model = config.default_model();
-        return run_one_shot(&config, &model, &prompt).await;
+        return run_one_shot(&config, &model, &prompt, None).await;
     }
 
     // Handle session resume. Plain `deepseek` starts fresh: interrupted
@@ -4317,15 +4345,22 @@ async fn resolve_cli_auto_route(config: &Config, model: &str, prompt: &str) -> C
     }
 }
 
-async fn run_one_shot(config: &Config, model: &str, prompt: &str) -> Result<()> {
+async fn run_one_shot(
+    config: &Config,
+    model: &str,
+    prompt: &str,
+    custom_system_prompt: Option<String>,
+) -> Result<()> {
     use crate::client::DeepSeekClient;
-    use crate::models::{ContentBlock, Message, MessageRequest};
+    use crate::models::{ContentBlock, Message, MessageRequest, SystemPrompt};
 
     let client = DeepSeekClient::new(config)?;
     let route = resolve_cli_auto_route(config, model, prompt).await;
     let reasoning_effort = route
         .reasoning_effort
         .map(|effort| effort.as_setting().to_string());
+
+    let system = custom_system_prompt.map(SystemPrompt::Text);
 
     let request = MessageRequest {
         model: route.model,
@@ -4337,7 +4372,7 @@ async fn run_one_shot(config: &Config, model: &str, prompt: &str) -> Result<()> 
             }],
         }],
         max_tokens: 4096,
-        system: None,
+        system,
         tools: None,
         tool_choice: None,
         metadata: None,
@@ -4359,7 +4394,12 @@ async fn run_one_shot(config: &Config, model: &str, prompt: &str) -> Result<()> 
     Ok(())
 }
 
-async fn run_one_shot_json(config: &Config, model: &str, prompt: &str) -> Result<()> {
+async fn run_one_shot_json(
+    config: &Config,
+    model: &str,
+    prompt: &str,
+    custom_system_prompt: Option<String>,
+) -> Result<()> {
     use crate::client::DeepSeekClient;
     use crate::models::{ContentBlock, Message, MessageRequest, SystemPrompt};
 
@@ -4369,6 +4409,12 @@ async fn run_one_shot_json(config: &Config, model: &str, prompt: &str) -> Result
     let reasoning_effort = route
         .reasoning_effort
         .map(|effort| effort.as_setting().to_string());
+
+    // Use custom system prompt if provided, otherwise fall back to the default.
+    let default_prompt =
+        "You are a coding assistant. Give concise, actionable responses.".to_string();
+    let system_text = custom_system_prompt.unwrap_or(default_prompt);
+
     let request = MessageRequest {
         model: model.clone(),
         messages: vec![Message {
@@ -4379,9 +4425,7 @@ async fn run_one_shot_json(config: &Config, model: &str, prompt: &str) -> Result
             }],
         }],
         max_tokens: 4096,
-        system: Some(SystemPrompt::Text(
-            "You are a coding assistant. Give concise, actionable responses.".to_string(),
-        )),
+        system: Some(SystemPrompt::Text(system_text)),
         tools: None,
         tool_choice: None,
         metadata: None,
@@ -4487,6 +4531,7 @@ async fn run_exec_agent(
     json_output: bool,
     resume_session_id: Option<String>,
     output_format: String,
+    custom_system_prompt: Option<String>,
 ) -> Result<()> {
     use crate::compaction::CompactionConfig;
     use crate::core::engine::{EngineConfig, spawn_engine};
@@ -4571,6 +4616,7 @@ async fn run_exec_agent(
             .and_then(|s| s.provider)
             .unwrap_or_default(),
         search_api_key: config.search.as_ref().and_then(|s| s.api_key.clone()),
+        custom_system_prompt,
     };
 
     let engine_handle = spawn_engine(engine_config, config);
@@ -4609,8 +4655,8 @@ async fn run_exec_agent(
                             );
                         }
 
-                        let system_prompt = saved_system_prompt
-                            .map(crate::models::SystemPrompt::Text);
+                        let system_prompt =
+                            saved_system_prompt.map(crate::models::SystemPrompt::Text);
 
                         engine_handle
                             .send(Op::SyncSession {
@@ -4714,9 +4760,10 @@ async fn run_exec_agent(
                 summary.output.push_str(&content);
                 match output_fmt {
                     OutputFormat::StreamJson => {
-                        println!("{}", serde_json::to_string(&StreamEvent::Content {
-                            content,
-                        })?);
+                        println!(
+                            "{}",
+                            serde_json::to_string(&StreamEvent::Content { content })?
+                        );
                     }
                     OutputFormat::Text if !json_output => {
                         print!("{content}");
@@ -4729,9 +4776,10 @@ async fn run_exec_agent(
             Event::ThinkingDelta { content, .. } => {
                 match output_fmt {
                     OutputFormat::StreamJson => {
-                        println!("{}", serde_json::to_string(&StreamEvent::Thinking {
-                            content,
-                        })?);
+                        println!(
+                            "{}",
+                            serde_json::to_string(&StreamEvent::Thinking { content })?
+                        );
                     }
                     OutputFormat::Text => {
                         // In text mode, thinking content is not displayed.
@@ -4743,27 +4791,30 @@ async fn run_exec_agent(
                     println!();
                 }
             }
-            Event::ToolCallStarted { id, name, input, .. } => {
-                match output_fmt {
-                    OutputFormat::StreamJson => {
-                        println!("{}", serde_json::to_string(&StreamEvent::ToolUse {
+            Event::ToolCallStarted {
+                id, name, input, ..
+            } => match output_fmt {
+                OutputFormat::StreamJson => {
+                    println!(
+                        "{}",
+                        serde_json::to_string(&StreamEvent::ToolUse {
                             name,
                             id,
                             input,
                             done: false,
-                        })?);
-                    }
-                    OutputFormat::Text if !json_output => {
-                        let summary = summarize_tool_args(&input);
-                        if let Some(summary) = summary {
-                            eprintln!("tool: {name} ({summary})");
-                        } else {
-                            eprintln!("tool: {name}");
-                        }
-                    }
-                    OutputFormat::Text => {}
+                        })?
+                    );
                 }
-            }
+                OutputFormat::Text if !json_output => {
+                    let summary = summarize_tool_args(&input);
+                    if let Some(summary) = summary {
+                        eprintln!("tool: {name} ({summary})");
+                    } else {
+                        eprintln!("tool: {name}");
+                    }
+                }
+                OutputFormat::Text => {}
+            },
             Event::ToolCallProgress { id, output } => {
                 // ToolCallProgress is not emitted in the main turn loop,
                 // but handle it for completeness.
@@ -4771,7 +4822,9 @@ async fn run_exec_agent(
                     eprintln!("tool {id}: {}", summarize_tool_output(&output));
                 }
             }
-            Event::ToolCallComplete { id, name, result, .. } => match result {
+            Event::ToolCallComplete {
+                id, name, result, ..
+            } => match result {
                 Ok(tool_result) => {
                     summary.tools.push(ExecToolEntry {
                         name: name.clone(),
@@ -4780,15 +4833,18 @@ async fn run_exec_agent(
                     });
                     match output_fmt {
                         OutputFormat::StreamJson => {
-                            println!("{}", serde_json::to_string(&StreamEvent::ToolResult {
-                                id,
-                                output: tool_result.content,
-                                status: if tool_result.success {
-                                    "success".to_string()
-                                } else {
-                                    "error".to_string()
-                                },
-                            })?);
+                            println!(
+                                "{}",
+                                serde_json::to_string(&StreamEvent::ToolResult {
+                                    id,
+                                    output: tool_result.content,
+                                    status: if tool_result.success {
+                                        "success".to_string()
+                                    } else {
+                                        "error".to_string()
+                                    },
+                                })?
+                            );
                         }
                         OutputFormat::Text if !json_output => {
                             if name == "exec_shell" && !tool_result.content.trim().is_empty() {
@@ -4815,11 +4871,14 @@ async fn run_exec_agent(
                     });
                     match output_fmt {
                         OutputFormat::StreamJson => {
-                            println!("{}", serde_json::to_string(&StreamEvent::ToolResult {
-                                id,
-                                output: err.to_string(),
-                                status: "error".to_string(),
-                            })?);
+                            println!(
+                                "{}",
+                                serde_json::to_string(&StreamEvent::ToolResult {
+                                    id,
+                                    output: err.to_string(),
+                                    status: "error".to_string(),
+                                })?
+                            );
                         }
                         OutputFormat::Text if !json_output => {
                             eprintln!("tool {name} failed: {err}");
@@ -4879,9 +4938,12 @@ async fn run_exec_agent(
                 summary.error = Some(envelope.message.clone());
                 match output_fmt {
                     OutputFormat::StreamJson => {
-                        println!("{}", serde_json::to_string(&StreamEvent::Error {
-                            error: envelope.message,
-                        })?);
+                        println!(
+                            "{}",
+                            serde_json::to_string(&StreamEvent::Error {
+                                error: envelope.message,
+                            })?
+                        );
                     }
                     OutputFormat::Text if !json_output => {
                         eprintln!("error: {}", summary.error.as_deref().unwrap_or_default());
@@ -4889,37 +4951,37 @@ async fn run_exec_agent(
                     OutputFormat::Text => {}
                 }
             }
-            Event::TurnComplete { status, error, usage, .. } => {
+            Event::TurnComplete {
+                status,
+                error,
+                usage,
+                ..
+            } => {
                 summary.status = Some(format!("{status:?}").to_lowercase());
                 summary.error = error;
 
                 // Save the session so it can be resumed later with --resume.
-                let saved_session_id = match
-                    crate::session_manager::SessionManager::default_location()
-                {
-                    Ok(manager) if !latest_messages.is_empty() => {
-                        let total_tokens: u64 =
-                            usage.input_tokens as u64 + usage.output_tokens as u64;
+                let saved_session_id =
+                    match crate::session_manager::SessionManager::default_location() {
+                        Ok(manager) if !latest_messages.is_empty() => {
+                            let total_tokens: u64 =
+                                usage.input_tokens as u64 + usage.output_tokens as u64;
 
-                        let session_id = latest_session_id
-                            .as_deref()
-                            .unwrap_or_default()
-                            .to_string();
+                            let session_id =
+                                latest_session_id.as_deref().unwrap_or_default().to_string();
 
-                        let saved = if !session_id.is_empty() {
-                            match manager.load_session(&session_id) {
-                                Ok(existing) => {
-                                    crate::session_manager::update_session(
+                            let saved = if !session_id.is_empty() {
+                                match manager.load_session(&session_id) {
+                                    Ok(existing) => crate::session_manager::update_session(
                                         existing,
                                         &latest_messages,
                                         total_tokens,
                                         latest_system_prompt.as_ref(),
-                                    )
-                                }
-                                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                                    // Session file not found (e.g. deleted or ID from a
-                                    // different machine) — create fresh with the same ID.
-                                    crate::session_manager::create_saved_session_with_id_and_mode(
+                                    ),
+                                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                                        // Session file not found (e.g. deleted or ID from a
+                                        // different machine) — create fresh with the same ID.
+                                        crate::session_manager::create_saved_session_with_id_and_mode(
                                         session_id,
                                         &latest_messages,
                                         &latest_model,
@@ -4928,75 +4990,83 @@ async fn run_exec_agent(
                                         latest_system_prompt.as_ref(),
                                         Some("exec"),
                                     )
+                                    }
+                                    Err(e) => {
+                                        if output_fmt == OutputFormat::Text && !json_output {
+                                            eprintln!(
+                                                "Warning: failed to load session for update: {e}"
+                                            );
+                                        }
+                                        crate::session_manager::create_saved_session_with_id_and_mode(
+                                        session_id,
+                                        &latest_messages,
+                                        &latest_model,
+                                        &latest_workspace,
+                                        total_tokens,
+                                        latest_system_prompt.as_ref(),
+                                        Some("exec"),
+                                    )
+                                    }
+                                }
+                            } else {
+                                crate::session_manager::create_saved_session_with_mode(
+                                    &latest_messages,
+                                    &latest_model,
+                                    &latest_workspace,
+                                    total_tokens,
+                                    latest_system_prompt.as_ref(),
+                                    Some("exec"),
+                                )
+                            };
+
+                            let saved_id = saved.metadata.id.clone();
+                            match manager.save_session(&saved) {
+                                Ok(_) => {
+                                    if output_fmt == OutputFormat::Text && !json_output {
+                                        eprintln!("session: {}", saved.metadata.id);
+                                    }
                                 }
                                 Err(e) => {
                                     if output_fmt == OutputFormat::Text && !json_output {
-                                        eprintln!("Warning: failed to load session for update: {e}");
+                                        eprintln!("Warning: failed to save session: {e}");
                                     }
-                                    crate::session_manager::create_saved_session_with_id_and_mode(
-                                        session_id,
-                                        &latest_messages,
-                                        &latest_model,
-                                        &latest_workspace,
-                                        total_tokens,
-                                        latest_system_prompt.as_ref(),
-                                        Some("exec"),
-                                    )
                                 }
                             }
-                        } else {
-                            crate::session_manager::create_saved_session_with_mode(
-                                &latest_messages,
-                                &latest_model,
-                                &latest_workspace,
-                                total_tokens,
-                                latest_system_prompt.as_ref(),
-                                Some("exec"),
-                            )
-                        };
-
-                        let saved_id = saved.metadata.id.clone();
-                        match manager.save_session(&saved) {
-                            Ok(_) => {
-                                if output_fmt == OutputFormat::Text && !json_output {
-                                    eprintln!("session: {}", saved.metadata.id);
-                                }
-                            }
-                            Err(e) => {
-                                if output_fmt == OutputFormat::Text && !json_output {
-                                    eprintln!("Warning: failed to save session: {e}");
-                                }
-                            }
+                            Some(saved_id)
                         }
-                        Some(saved_id)
-                    }
-                    Ok(_) => None, // no messages to save
-                    Err(e) => {
-                        if output_fmt == OutputFormat::Text && !json_output {
-                            eprintln!("Warning: could not open session manager for saving: {e}");
+                        Ok(_) => None, // no messages to save
+                        Err(e) => {
+                            if output_fmt == OutputFormat::Text && !json_output {
+                                eprintln!(
+                                    "Warning: could not open session manager for saving: {e}"
+                                );
+                            }
+                            None
                         }
-                        None
-                    }
-                };
+                    };
 
                 // Emit stream-json events for metadata, session_capture, and done.
                 if output_fmt == OutputFormat::StreamJson {
                     if let Some(sid) = saved_session_id {
-                        println!("{}", serde_json::to_string(&StreamEvent::SessionCapture {
-                            content: sid,
-                        })?);
+                        println!(
+                            "{}",
+                            serde_json::to_string(&StreamEvent::SessionCapture { content: sid })?
+                        );
                     }
-                    println!("{}", serde_json::to_string(&StreamEvent::Metadata {
-                        meta: StreamMeta {
-                            model: latest_model.clone(),
-                            input_tokens: usage.input_tokens,
-                            output_tokens: usage.output_tokens,
-                            session_id: latest_session_id
-                                .as_deref()
-                                .unwrap_or_default()
-                                .to_string(),
-                        },
-                    })?);
+                    println!(
+                        "{}",
+                        serde_json::to_string(&StreamEvent::Metadata {
+                            meta: StreamMeta {
+                                model: latest_model.clone(),
+                                input_tokens: usage.input_tokens,
+                                output_tokens: usage.output_tokens,
+                                session_id: latest_session_id
+                                    .as_deref()
+                                    .unwrap_or_default()
+                                    .to_string(),
+                            },
+                        })?
+                    );
                     println!("{}", serde_json::to_string(&StreamEvent::Done)?);
                 }
 
@@ -6507,8 +6577,12 @@ mod exec_session_and_stream_tests {
         // Every serialized StreamEvent must be a single line (no embedded newlines)
         // so it can be parsed as JSON Lines (NDJSON).
         let events: Vec<StreamEvent> = vec![
-            StreamEvent::Content { content: "hello\nworld".to_string() },
-            StreamEvent::Thinking { content: "line1\nline2".to_string() },
+            StreamEvent::Content {
+                content: "hello\nworld".to_string(),
+            },
+            StreamEvent::Thinking {
+                content: "line1\nline2".to_string(),
+            },
             StreamEvent::ToolUse {
                 name: "read_file".to_string(),
                 id: "id1".to_string(),
@@ -6528,9 +6602,13 @@ mod exec_session_and_stream_tests {
                     session_id: "s".to_string(),
                 },
             },
-            StreamEvent::SessionCapture { content: "sid".to_string() },
+            StreamEvent::SessionCapture {
+                content: "sid".to_string(),
+            },
             StreamEvent::Done,
-            StreamEvent::Error { error: "e".to_string() },
+            StreamEvent::Error {
+                error: "e".to_string(),
+            },
         ];
 
         for evt in &events {
@@ -6589,9 +6667,18 @@ mod exec_session_and_stream_tests {
         let json = serde_json::to_string(&meta).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert!(parsed.get("model").is_some(), "missing 'model' field");
-        assert!(parsed.get("input_tokens").is_some(), "missing 'input_tokens' field");
-        assert!(parsed.get("output_tokens").is_some(), "missing 'output_tokens' field");
-        assert!(parsed.get("session_id").is_some(), "missing 'session_id' field");
+        assert!(
+            parsed.get("input_tokens").is_some(),
+            "missing 'input_tokens' field"
+        );
+        assert!(
+            parsed.get("output_tokens").is_some(),
+            "missing 'output_tokens' field"
+        );
+        assert!(
+            parsed.get("session_id").is_some(),
+            "missing 'session_id' field"
+        );
     }
 
     // ---- ClawBench compatibility: type field values match expected strings ----
@@ -6603,22 +6690,52 @@ mod exec_session_and_stream_tests {
         // "metadata", "session_capture", "done", "error"
 
         let test_cases: Vec<(StreamEvent, &str)> = vec![
-            (StreamEvent::Content { content: "x".into() }, "content"),
-            (StreamEvent::Thinking { content: "x".into() }, "thinking"),
-            (StreamEvent::ToolUse {
-                name: "n".into(), id: "i".into(),
-                input: serde_json::Value::Null, done: false,
-            }, "tool_use"),
-            (StreamEvent::ToolResult {
-                id: "i".into(), output: "o".into(), status: "s".into(),
-            }, "tool_result"),
-            (StreamEvent::Metadata {
-                meta: StreamMeta {
-                    model: "m".into(), input_tokens: 0, output_tokens: 0,
-                    session_id: "s".into(),
+            (
+                StreamEvent::Content {
+                    content: "x".into(),
                 },
-            }, "metadata"),
-            (StreamEvent::SessionCapture { content: "c".into() }, "session_capture"),
+                "content",
+            ),
+            (
+                StreamEvent::Thinking {
+                    content: "x".into(),
+                },
+                "thinking",
+            ),
+            (
+                StreamEvent::ToolUse {
+                    name: "n".into(),
+                    id: "i".into(),
+                    input: serde_json::Value::Null,
+                    done: false,
+                },
+                "tool_use",
+            ),
+            (
+                StreamEvent::ToolResult {
+                    id: "i".into(),
+                    output: "o".into(),
+                    status: "s".into(),
+                },
+                "tool_result",
+            ),
+            (
+                StreamEvent::Metadata {
+                    meta: StreamMeta {
+                        model: "m".into(),
+                        input_tokens: 0,
+                        output_tokens: 0,
+                        session_id: "s".into(),
+                    },
+                },
+                "metadata",
+            ),
+            (
+                StreamEvent::SessionCapture {
+                    content: "c".into(),
+                },
+                "session_capture",
+            ),
             (StreamEvent::Done, "done"),
             (StreamEvent::Error { error: "e".into() }, "error"),
         ];
@@ -6632,5 +6749,123 @@ mod exec_session_and_stream_tests {
                 "StreamEvent type mismatch: expected {expected_type}, got {actual_type}"
             );
         }
+    }
+
+    // ---- System prompt flag tests ----
+
+    #[test]
+    fn exec_args_system_prompt_fields() {
+        // Verify --system-prompt field is populated
+        let args = ExecArgs {
+            prompt: vec!["hello".to_string()],
+            model: None,
+            auto: false,
+            json: false,
+            resume: None,
+            r#continue: false,
+            output_format: "text".to_string(),
+            system_prompt: Some("You are a helpful assistant".to_string()),
+            system_prompt_file: None,
+        };
+        assert_eq!(
+            args.system_prompt.as_deref(),
+            Some("You are a helpful assistant")
+        );
+        assert!(args.system_prompt_file.is_none());
+    }
+
+    #[test]
+    fn exec_args_system_prompt_file_field() {
+        // Verify --system-prompt-file field is populated
+        let args = ExecArgs {
+            prompt: vec!["hello".to_string()],
+            model: None,
+            auto: false,
+            json: false,
+            resume: None,
+            r#continue: false,
+            output_format: "text".to_string(),
+            system_prompt: None,
+            system_prompt_file: Some(PathBuf::from("/tmp/prompt.txt")),
+        };
+        assert_eq!(
+            args.system_prompt_file,
+            Some(PathBuf::from("/tmp/prompt.txt"))
+        );
+        assert!(args.system_prompt.is_none());
+    }
+
+    #[test]
+    fn exec_args_system_prompt_default_none() {
+        // Verify both flags default to None when not provided
+        let args = ExecArgs {
+            prompt: vec!["hello".to_string()],
+            model: None,
+            auto: false,
+            json: false,
+            resume: None,
+            r#continue: false,
+            output_format: "text".to_string(),
+            system_prompt: None,
+            system_prompt_file: None,
+        };
+        assert!(args.system_prompt.is_none());
+        assert!(args.system_prompt_file.is_none());
+    }
+
+    #[test]
+    fn exec_args_both_system_prompt_flags_allowed_by_clap() {
+        // Providing both --system-prompt and --system-prompt-file is
+        // allowed by clap (two independent Option fields), but rejected
+        // at the application level in the exec dispatch code.
+        let args = ExecArgs {
+            prompt: vec!["hello".to_string()],
+            model: None,
+            auto: false,
+            json: false,
+            resume: None,
+            r#continue: false,
+            output_format: "text".to_string(),
+            system_prompt: Some("text prompt".to_string()),
+            system_prompt_file: Some(PathBuf::from("/tmp/prompt.txt")),
+        };
+        assert!(args.system_prompt.is_some());
+        assert!(args.system_prompt_file.is_some());
+    }
+
+    #[test]
+    fn system_prompt_file_not_found_error() {
+        // Reading a non-existent file should produce a descriptive error
+        let path = "/tmp/deepseek-tui-test-nonexistent-prompt-file-12345.txt";
+        let result: Result<String> = (|| {
+            let content = std::fs::read_to_string(path)
+                .with_context(|| format!("could not read system prompt file: {path}"))?;
+            Ok(content)
+        })();
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("could not read system prompt file")
+        );
+    }
+
+    #[test]
+    fn system_prompt_file_empty_is_rejected() {
+        // An empty file should be rejected at the application level
+        let dir = std::env::temp_dir().join("deepseek-tui-test-empty-prompt");
+        std::fs::create_dir_all(&dir).ok();
+        let path = dir.join("empty.txt");
+        std::fs::write(&path, "").unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            content.trim().is_empty(),
+            "empty file should have empty content"
+        );
+
+        // Cleanup
+        std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -4622,20 +4622,18 @@ async fn run_exec_agent(
                             })
                             .await?;
 
-                        loaded_session_id = Some(saved_id);
+                        loaded_session_id = Some(saved_id.clone());
                         if !json_output {
-                            eprintln!("Resumed session: {}", loaded_session_id.as_deref().unwrap());
+                            eprintln!("Resumed session: {saved_id}");
                         }
                     }
                     Err(e) => {
-                        eprintln!("Error: could not load session '{session_id}': {e}");
-                        std::process::exit(1);
+                        bail!("could not load session '{session_id}': {e}");
                     }
                 }
             }
             Err(e) => {
-                eprintln!("Error: could not open session manager: {e}");
-                std::process::exit(1);
+                bail!("could not open session manager: {e}");
             }
         }
     }
@@ -4896,10 +4894,10 @@ async fn run_exec_agent(
                 summary.error = error;
 
                 // Save the session so it can be resumed later with --resume.
-                let saved_session_id = if let Ok(manager) =
+                let saved_session_id = match
                     crate::session_manager::SessionManager::default_location()
                 {
-                    if !latest_messages.is_empty() {
+                    Ok(manager) if !latest_messages.is_empty() => {
                         let total_tokens: u64 =
                             usage.input_tokens as u64 + usage.output_tokens as u64;
 
@@ -4918,7 +4916,23 @@ async fn run_exec_agent(
                                         latest_system_prompt.as_ref(),
                                     )
                                 }
-                                Err(_) => {
+                                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                                    // Session file not found (e.g. deleted or ID from a
+                                    // different machine) — create fresh with the same ID.
+                                    crate::session_manager::create_saved_session_with_id_and_mode(
+                                        session_id,
+                                        &latest_messages,
+                                        &latest_model,
+                                        &latest_workspace,
+                                        total_tokens,
+                                        latest_system_prompt.as_ref(),
+                                        Some("exec"),
+                                    )
+                                }
+                                Err(e) => {
+                                    if output_fmt == OutputFormat::Text && !json_output {
+                                        eprintln!("Warning: failed to load session for update: {e}");
+                                    }
                                     crate::session_manager::create_saved_session_with_id_and_mode(
                                         session_id,
                                         &latest_messages,
@@ -4955,11 +4969,14 @@ async fn run_exec_agent(
                             }
                         }
                         Some(saved_id)
-                    } else {
+                    }
+                    Ok(_) => None, // no messages to save
+                    Err(e) => {
+                        if output_fmt == OutputFormat::Text && !json_output {
+                            eprintln!("Warning: could not open session manager for saving: {e}");
+                        }
                         None
                     }
-                } else {
-                    None
                 };
 
                 // Emit stream-json events for metadata, session_capture, and done.

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -287,6 +287,12 @@ struct ExecArgs {
     /// Emit machine-readable JSON output
     #[arg(long, default_value_t = false)]
     json: bool,
+    /// Resume a previous session by ID or prefix
+    #[arg(long, value_name = "SESSION_ID")]
+    resume: Option<String>,
+    /// Continue the most recent session for this workspace
+    #[arg(long, default_value_t = false)]
+    r#continue: bool,
 }
 
 fn join_prompt_parts(parts: &[String]) -> String {
@@ -672,15 +678,34 @@ async fn main() -> Result<()> {
             }
             Commands::Exec(args) => {
                 let config = load_config_from_cli(&cli)?;
-                let model = args
-                    .model
-                    .or_else(|| config.default_text_model.clone())
-                    .unwrap_or_else(|| config.default_model());
-                let prompt = join_prompt_parts(&args.prompt);
-                if args.auto || cli.yolo {
-                    let workspace = cli.workspace.clone().unwrap_or_else(|| {
-                        std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
-                    });
+                let workspace = cli.workspace.clone().unwrap_or_else(|| {
+                    std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+                });
+
+                // Resolve resume session ID from --resume or --continue
+                let resume_session_id = if args.r#continue {
+                    latest_session_id_for_workspace(&workspace)
+                        .ok()
+                        .flatten()
+                        .or_else(|| {
+                            eprintln!("No recent session found for this workspace. Starting fresh.");
+                            None
+                        })
+                } else {
+                    args.resume.clone()
+                };
+
+                // When --resume/--continue is set, always route through run_exec_agent
+                // (even without --auto) so that Op::SyncSession can hydrate the engine
+                // with prior messages and thinking tokens are replayed correctly.
+                // The one-shot paths (run_one_shot / run_one_shot_json) cannot handle
+                // thinking token replay for DeepSeek V4 models.
+                if args.auto || cli.yolo || resume_session_id.is_some() {
+                    let model = args
+                        .model
+                        .or_else(|| config.default_text_model.clone())
+                        .unwrap_or_else(|| config.default_model());
+                    let prompt = join_prompt_parts(&args.prompt);
                     let max_subagents = cli.max_subagents.map_or_else(
                         || config.max_subagents(),
                         |value| value.clamp(1, MAX_SUBAGENTS),
@@ -692,14 +717,25 @@ async fn main() -> Result<()> {
                         &prompt,
                         workspace,
                         max_subagents,
-                        true,
+                        auto_mode, // only auto-approve if --auto/--yolo
                         auto_mode,
                         args.json,
+                        resume_session_id,
                     )
                     .await
                 } else if args.json {
+                    let model = args
+                        .model
+                        .or_else(|| config.default_text_model.clone())
+                        .unwrap_or_else(|| config.default_model());
+                    let prompt = join_prompt_parts(&args.prompt);
                     run_one_shot_json(&config, &model, &prompt).await
                 } else {
+                    let model = args
+                        .model
+                        .or_else(|| config.default_text_model.clone())
+                        .unwrap_or_else(|| config.default_model());
+                    let prompt = join_prompt_parts(&args.prompt);
                     run_one_shot(&config, &model, &prompt).await
                 }
             }
@@ -4381,6 +4417,7 @@ async fn run_exec_agent(
     auto_approve: bool,
     trust_mode: bool,
     json_output: bool,
+    resume_session_id: Option<String>,
 ) -> Result<()> {
     use crate::compaction::CompactionConfig;
     use crate::core::engine::{EngineConfig, spawn_engine};
@@ -4474,6 +4511,66 @@ async fn run_exec_agent(
         AppMode::Agent
     };
 
+    // If --resume/--continue was specified, load the prior session and hydrate
+    // the engine with the saved conversation history before sending the new
+    // prompt. This uses the same Op::SyncSession path that the TUI's resume
+    // flow relies on, so thinking-token replay for DeepSeek V4 models is
+    // handled correctly.
+    let mut loaded_session_id: Option<String> = None;
+    if let Some(ref session_id) = resume_session_id {
+        match crate::session_manager::SessionManager::default_location() {
+            Ok(manager) => {
+                let load_result = manager.load_session_by_prefix(session_id);
+                match load_result {
+                    Ok(saved) => {
+                        let saved_id = saved.metadata.id.clone();
+                        let saved_model = saved.metadata.model.clone();
+                        let saved_workspace = saved.metadata.workspace.clone();
+                        let saved_system_prompt = saved.system_prompt.clone();
+                        let saved_messages = saved.messages.clone();
+
+                        // Warn on workspace mismatch but don't block — the user
+                        // may intentionally resume across workspaces.
+                        if saved_workspace != workspace {
+                            eprintln!(
+                                "Warning: session {} was created in a different workspace ({}). \
+                                 Resuming anyway.",
+                                saved_id,
+                                saved_workspace.display(),
+                            );
+                        }
+
+                        let system_prompt = saved_system_prompt
+                            .map(crate::models::SystemPrompt::Text);
+
+                        engine_handle
+                            .send(Op::SyncSession {
+                                session_id: Some(saved_id.clone()),
+                                messages: saved_messages,
+                                system_prompt,
+                                model: saved_model,
+                                workspace: saved_workspace,
+                            })
+                            .await?;
+
+                        loaded_session_id = Some(saved_id);
+                        if !json_output {
+                            eprintln!("Resumed session: {}", loaded_session_id.as_deref().unwrap());
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!("Error: could not load session '{session_id}': {e}");
+                        std::process::exit(1);
+                    }
+                }
+            }
+            Err(e) => {
+                eprintln!("Error: could not open session manager: {e}");
+                std::process::exit(1);
+            }
+        }
+    }
+
     engine_handle
         .send(Op::SendMessage {
             content: prompt.to_string(),
@@ -4521,6 +4618,15 @@ async fn run_exec_agent(
         prompt: prompt.to_string(),
         ..ExecSummary::default()
     };
+
+    // Track the latest engine session state so we can persist it after the
+    // turn completes. The engine pushes SessionUpdated events whenever its
+    // internal session mutates (sync, add_message, compaction, …).
+    let mut latest_session_id: Option<String> = loaded_session_id;
+    let mut latest_messages: Vec<crate::models::Message> = Vec::new();
+    let mut latest_system_prompt: Option<crate::models::SystemPrompt> = None;
+    let mut latest_model: String = String::new();
+    let mut latest_workspace: PathBuf = workspace.clone();
 
     let mut stdout = io::stdout();
     let mut ends_with_newline = false;
@@ -4633,11 +4739,89 @@ async fn run_exec_agent(
                     eprintln!("error: {}", envelope.message);
                 }
             }
-            Event::TurnComplete { status, error, .. } => {
+            Event::TurnComplete { status, error, usage, .. } => {
                 summary.status = Some(format!("{status:?}").to_lowercase());
                 summary.error = error;
+
+                // Save the session so it can be resumed later with --resume.
+                if let Ok(manager) =
+                    crate::session_manager::SessionManager::default_location()
+                {
+                    if !latest_messages.is_empty() {
+                        let total_tokens: u64 =
+                            usage.input_tokens as u64 + usage.output_tokens as u64;
+
+                        let session_id = latest_session_id
+                            .as_deref()
+                            .unwrap_or_default()
+                            .to_string();
+
+                        let saved = if !session_id.is_empty() {
+                            // Try to update an existing session (resume path)
+                            match manager.load_session(&session_id) {
+                                Ok(existing) => {
+                                    crate::session_manager::update_session(
+                                        existing,
+                                        &latest_messages,
+                                        total_tokens,
+                                        latest_system_prompt.as_ref(),
+                                    )
+                                }
+                                Err(_) => {
+                                    // Existing session not found — create fresh with the same ID
+                                    crate::session_manager::create_saved_session_with_id_and_mode(
+                                        session_id,
+                                        &latest_messages,
+                                        &latest_model,
+                                        &latest_workspace,
+                                        total_tokens,
+                                        latest_system_prompt.as_ref(),
+                                        Some("exec"),
+                                    )
+                                }
+                            }
+                        } else {
+                            // Fresh session — generate a new ID
+                            crate::session_manager::create_saved_session_with_mode(
+                                &latest_messages,
+                                &latest_model,
+                                &latest_workspace,
+                                total_tokens,
+                                latest_system_prompt.as_ref(),
+                                Some("exec"),
+                            )
+                        };
+
+                        match manager.save_session(&saved) {
+                            Ok(_) => {
+                                if !json_output {
+                                    eprintln!("session: {}", saved.metadata.id);
+                                }
+                            }
+                            Err(e) => {
+                                if !json_output {
+                                    eprintln!("Warning: failed to save session: {e}");
+                                }
+                            }
+                        }
+                    }
+                }
+
                 let _ = engine_handle.send(Op::Shutdown).await;
                 break;
+            }
+            Event::SessionUpdated {
+                session_id,
+                messages,
+                system_prompt,
+                model,
+                workspace,
+            } => {
+                latest_session_id = Some(session_id);
+                latest_messages = messages;
+                latest_system_prompt = system_prompt;
+                latest_model = model;
+                latest_workspace = workspace;
             }
             _ => {}
         }

--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -28,6 +28,10 @@ pub struct PromptSessionContext<'a> {
     /// to the system prompt instructing the model to respond in
     /// the resolved session locale.
     pub translation_enabled: bool,
+    /// Custom system prompt injected via `--system-prompt` /
+    /// `--system-prompt-file` on the exec subcommand. Appended
+    /// below the volatile-content boundary, after goal_objective.
+    pub custom_system_prompt: Option<&'a str>,
 }
 
 /// Conventional location for the structured session-handoff artifact (#32).
@@ -541,6 +545,7 @@ pub fn system_prompt_for_mode_with_context_and_skills(
             project_context_pack_enabled: true,
             locale_tag: "en",
             translation_enabled: false,
+            custom_system_prompt: None,
         },
     )
 }
@@ -713,6 +718,18 @@ pub fn system_prompt_for_mode_with_context_skills_session_and_approval(
         );
     }
 
+    // 6d. Custom system prompt from --system-prompt / --system-prompt-file
+    // (exec mode). Placed below the volatile boundary, after goal_objective,
+    // so it doesn't disrupt the prefix cache for static layers.
+    if let Some(custom) = session_context.custom_system_prompt
+        && !custom.trim().is_empty()
+    {
+        full_prompt = format!(
+            "{full_prompt}\n\n## Custom Instructions\n\n<custom_system_prompt>\n{}\n</custom_system_prompt>",
+            custom.trim()
+        );
+    }
+
     // 7. Previous-session handoff (file-backed, rewritten by `/compact`).
     if let Some(handoff_block) = load_handoff_block(workspace) {
         full_prompt = format!("{full_prompt}\n\n{handoff_block}");
@@ -857,6 +874,7 @@ mod tests {
                 project_context_pack_enabled: false,
                 locale_tag: "zh-Hans",
                 translation_enabled: false,
+                custom_system_prompt: None,
             },
             ApprovalMode::Suggest,
         ) {
@@ -926,6 +944,7 @@ mod tests {
                 project_context_pack_enabled: false,
                 locale_tag: "zh-Hans",
                 translation_enabled: false,
+                custom_system_prompt: None,
             },
             ApprovalMode::Suggest,
         ) {
@@ -970,6 +989,7 @@ mod tests {
                 project_context_pack_enabled: false,
                 locale_tag: "en",
                 translation_enabled: false,
+                custom_system_prompt: None,
             },
             ApprovalMode::Suggest,
         ) {
@@ -1059,6 +1079,7 @@ mod tests {
                 project_context_pack_enabled: true,
                 locale_tag: "ja",
                 translation_enabled: false,
+                custom_system_prompt: None,
             },
         ) {
             SystemPrompt::Text(text) => text,
@@ -1085,6 +1106,7 @@ mod tests {
                 project_context_pack_enabled: false,
                 locale_tag: "en",
                 translation_enabled: false,
+                custom_system_prompt: None,
             },
         ) {
             SystemPrompt::Text(text) => text,
@@ -1112,6 +1134,7 @@ mod tests {
                 project_context_pack_enabled: true,
                 locale_tag: "en",
                 translation_enabled: false,
+                custom_system_prompt: None,
             },
         ) {
             SystemPrompt::Text(text) => text,
@@ -1306,6 +1329,7 @@ mod tests {
                 project_context_pack_enabled: true,
                 locale_tag: "en",
                 translation_enabled: false,
+                custom_system_prompt: None,
             },
         ) {
             SystemPrompt::Text(text) => text,
@@ -1339,6 +1363,7 @@ mod tests {
                 project_context_pack_enabled: true,
                 locale_tag: "en",
                 translation_enabled: false,
+                custom_system_prompt: None,
             },
         ) {
             SystemPrompt::Text(text) => text,
@@ -1707,6 +1732,115 @@ mod tests {
         assert!(
             prompt.contains(&extra.display().to_string()),
             "instructions block must annotate its source path"
+        );
+    }
+
+    #[test]
+    fn custom_system_prompt_injected_below_volatile_boundary() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ctx = PromptSessionContext {
+            user_memory_block: None,
+            goal_objective: None,
+            project_context_pack_enabled: false,
+            locale_tag: "en",
+            translation_enabled: false,
+            custom_system_prompt: Some("You must respond in JSON format."),
+        };
+        let result = system_prompt_for_mode_with_context_skills_session_and_approval(
+            AppMode::Agent,
+            tmp.path(),
+            None,
+            None,
+            None,
+            ctx,
+            ApprovalMode::Suggest,
+        );
+        let prompt = match result {
+            SystemPrompt::Text(t) => t,
+            SystemPrompt::Blocks(_) => panic!("expected text system prompt"),
+        };
+        assert!(
+            prompt.contains(
+                "<custom_system_prompt>\nYou must respond in JSON format.\n</custom_system_prompt>"
+            ),
+            "custom system prompt must be wrapped in <custom_system_prompt> tags"
+        );
+        assert!(
+            prompt.contains("## Custom Instructions"),
+            "custom system prompt must have a ## Custom Instructions heading"
+        );
+        // Verify it appears after the session goal section (volatile boundary)
+        // goal_objective is None so there's no Session Goal section; verify
+        // custom instructions is present near the end, after the compact template
+        let compact_pos = prompt.find(COMPACT_TEMPLATE).unwrap();
+        let custom_pos = prompt.find("## Custom Instructions");
+        assert!(
+            custom_pos > Some(compact_pos),
+            "custom system prompt must appear after the compact template (volatile boundary)"
+        );
+    }
+
+    #[test]
+    fn custom_system_prompt_none_produces_no_custom_block() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ctx = PromptSessionContext {
+            user_memory_block: None,
+            goal_objective: None,
+            project_context_pack_enabled: false,
+            locale_tag: "en",
+            translation_enabled: false,
+            custom_system_prompt: None,
+        };
+        let result = system_prompt_for_mode_with_context_skills_session_and_approval(
+            AppMode::Agent,
+            tmp.path(),
+            None,
+            None,
+            None,
+            ctx,
+            ApprovalMode::Suggest,
+        );
+        let prompt = match result {
+            SystemPrompt::Text(t) => t,
+            SystemPrompt::Blocks(_) => panic!("expected text system prompt"),
+        };
+        assert!(
+            !prompt.contains("<custom_system_prompt>"),
+            "no <custom_system_prompt> tag when custom_system_prompt is None"
+        );
+        assert!(
+            !prompt.contains("## Custom Instructions"),
+            "no Custom Instructions heading when custom_system_prompt is None"
+        );
+    }
+
+    #[test]
+    fn custom_system_prompt_empty_is_ignored() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ctx = PromptSessionContext {
+            user_memory_block: None,
+            goal_objective: None,
+            project_context_pack_enabled: false,
+            locale_tag: "en",
+            translation_enabled: false,
+            custom_system_prompt: Some("   "),
+        };
+        let result = system_prompt_for_mode_with_context_skills_session_and_approval(
+            AppMode::Agent,
+            tmp.path(),
+            None,
+            None,
+            None,
+            ctx,
+            ApprovalMode::Suggest,
+        );
+        let prompt = match result {
+            SystemPrompt::Text(t) => t,
+            SystemPrompt::Blocks(_) => panic!("expected text system prompt"),
+        };
+        assert!(
+            !prompt.contains("<custom_system_prompt>"),
+            "whitespace-only custom system prompt should be ignored"
         );
     }
 }

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -1980,6 +1980,7 @@ impl RuntimeThreadManager {
                 .and_then(|s| s.provider)
                 .unwrap_or_default(),
             search_api_key: self.config.search.as_ref().and_then(|s| s.api_key.clone()),
+            custom_system_prompt: None,
         };
 
         let engine = spawn_engine(engine_cfg, &self.config);

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -639,6 +639,7 @@ fn build_engine_config(app: &App, config: &Config) -> EngineConfig {
             .and_then(|s| s.provider)
             .unwrap_or_default(),
         search_api_key: config.search.as_ref().and_then(|s| s.api_key.clone()),
+        custom_system_prompt: None,
     }
 }
 
@@ -4297,6 +4298,7 @@ async fn dispatch_user_message(
                 project_context_pack_enabled: config.project_context_pack_enabled(),
                 locale_tag: app.ui_locale.tag(),
                 translation_enabled: app.translation_enabled,
+                custom_system_prompt: None,
             },
         ),
     );


### PR DESCRIPTION
## Summary

Add non-interactive multi-turn conversation support, machine-readable streaming output, and custom system prompt injection to the `exec` subcommand, implementing the feature requested in #1530.

### New flags

| Flag | Description |
|------|-------------|
| `--resume <SESSION_ID>` | Resume a previous session by ID or prefix |
| `--continue` | Resume the most recent session for this workspace |
| `--output-format stream-json` | Output JSON Lines (NDJSON) for machine consumption |
| `--system-prompt <TEXT>` | Append a custom system prompt below the auto-generated prompt |
| `--system-prompt-file <PATH>` | Read custom system prompt from a file (for long prompts) |

### Usage

```bash
# First turn — session is auto-saved
deepseek exec --auto "explain this code"
# stderr: session: 4bf83f0f-a9b6-47b4-bcde-68af7354cd9f

# Continue with the session ID
deepseek exec --auto --resume 4bf83f0f "what about error handling?"
# stderr: Resumed session: 4bf83f0f-...

# Or continue the latest session
deepseek exec --auto --continue "refactor it"
```

### `--output-format stream-json`

Outputs one JSON object per line to stdout, designed for programmatic consumption by external orchestration tools:

```bash
deepseek exec --auto --output-format stream-json "read Cargo.toml"
```

```jsonl
{"type":"thinking","content":"User wants to read Cargo.toml..."}
{"type":"tool_use","name":"read_file","id":"call_00_...","input":{"path":"Cargo.toml"},"done":false}
{"type":"tool_result","id":"call_00_...","output":"[workspace]\n...","status":"success"}
{"type":"content","content":"Cargo.toml starts with [workspace]..."}
{"type":"session_capture","content":"24ca66ed-9afd-449a-8761-e9ca0fcf0000"}
{"type":"metadata","meta":{"model":"deepseek-v4-flash","input_tokens":63520,"output_tokens":168,"session_id":"24ca66ed-..."}}
{"type":"done"}
```

Event types:

| Type | Description |
|------|-------------|
| `content` | Incremental AI text response |
| `thinking` | Thinking/reasoning content (previously discarded in exec mode) |
| `tool_use` | Tool invocation with name, id, input |
| `tool_result` | Tool output with id, output, status |
| `metadata` | Model, token counts, session_id (emitted at turn end) |
| `session_capture` | Session ID for subsequent `--resume` calls |
| `done` | Stream complete |
| `error` | Unrecoverable error |

This format is directly compatible with the [ClawBench](https://github.com/xulongzhe/clawbench) `LineParser` interface — a mobile AI workstation that wraps AI coding agent CLIs as backend engines via HTTP API + SSE streaming. Adding DeepSeek TUI as a ClawBench backend only requires a thin parser (~80 lines of Go) mapping these JSON Lines to ClawBench's internal `StreamEvent` type.

### `--system-prompt` / `--system-prompt-file`

Inject a custom system prompt into the exec session. The custom text is appended below the volatile-content boundary in the system prompt (after `goal_objective`, before the handoff block), wrapped in `<custom_system_prompt>` XML tags. This placement preserves the prefix cache for static layers above the boundary.

```bash
# Inline custom prompt
deepseek exec --system-prompt "You are a code reviewer. Focus on security issues." --auto "review src/auth.rs"

# From a file (useful for long prompts)
deepseek exec --system-prompt-file ./my-prompt.md --auto "analyze the architecture"

# Combined with stream-json for full machine-readable output
deepseek exec --system-prompt "Respond in JSON only" --output-format stream-json "list all TODO comments"
```

`--system-prompt` and `--system-prompt-file` are mutually exclusive. When resuming a session with `--resume`, the custom system prompt is re-injected after the `Op::SyncSession` hydration to prevent the saved session's system prompt from overwriting it.

This feature enables ClawBench and other orchestration tools to inject orchestrator-level instructions when using DeepSeek TUI as a backend, and is generally useful for automation workflows that need fine-grained control over the model's behavior in non-interactive mode.

> **ClawBench — 从终端到掌心** — 为移动端打造的 AI 工作台。将 AI 编程智能体能力完整移植到浏览器与移动端 App，文件浏览、代码编辑、AI 对话、Git 操作、定时任务，手机上直接干活，不依赖电脑在线。

### Design decisions

1. **When `--resume`/`--continue` is set, always route through `run_exec_agent`** (even without `--auto`). The one-shot paths (`run_one_shot`/`run_one_shot_json`) cannot handle thinking-token replay for DeepSeek V4 models. The engine path uses `Op::SyncSession`, which correctly replays `reasoning_content` blocks.

2. **Session auto-save after every `run_exec_agent` turn.** The event loop handles `Event::SessionUpdated` to capture the engine's authoritative session state, and persists it via `SessionManager::save_session()` after `TurnComplete`. The session ID is printed to stderr (text mode) or emitted as a `session_capture` event (stream-json mode).

3. **`stream-json` emits `thinking` events.** The engine already separates `Event::ThinkingDelta` from `Event::MessageDelta`. In text mode, thinking content is discarded (same as before). In stream-json mode, thinking deltas are emitted as `{"type":"thinking",...}` events, giving consumers full access to the model's reasoning.

4. **Custom system prompt is placed below the volatile-content boundary.** Step 6d in the prompt builder, after `goal_objective` and before the handoff block. This preserves the prefix cache for static layers (mode prompt, project context, environment block, skills, context management, compact template). The custom block is wrapped in `<custom_system_prompt>` XML tags for model clarity.

5. **Custom system prompt survives session resume.** `Op::SyncSession` does a wholesale replacement of `session.system_prompt`. When `config.custom_system_prompt` is set, the handler clears the hash gate and calls `refresh_system_prompt()` to rebuild the prompt with the custom block re-injected.

6. **Workspace mismatch is a warning, not a blocker.** The user may intentionally resume a session across workspaces.

7. **The one-shot paths accept custom system prompts.** `run_one_shot` and `run_one_shot_json` pass the custom prompt directly to `MessageRequest.system`. For `run_one_shot_json`, the custom prompt replaces the hardcoded default; for `run_one_shot`, it replaces the previous `None`.

8. **Default model changed from `deepseek-v4-pro` to `deepseek-v4-flash`.** Flash is faster and cheaper for everyday use. Users can override with `--model deepseek-v4-pro` when needed.

### Testing

**Unit tests (24 tests, all passing):**
- `OutputFormat` parsing: text, stream-json, invalid values
- `StreamEvent` serialization: all 8 event types
- JSON Lines format validation: single-line, parseable, no embedded newlines
- Special characters: quotes, backslashes, Unicode
- Session manager integration: nonexistent prefix rejection
- `StreamMeta` field completeness
- ClawBench compatibility: `type` field values match expected strings
- `ExecArgs` system prompt fields: `--system-prompt`, `--system-prompt-file`, defaults
- System prompt file errors: not found, empty file
- Custom system prompt injection: present in prompt, absent when None, ignored when whitespace-only
- Custom system prompt placement: below volatile boundary (after compact template)

**End-to-end tests with DeepSeek API:**
- `exec --auto "1+1=?"` -> answer, session saved
- `exec --auto --resume <ID> "what did I ask?"` -> correctly recalled
- `exec --auto --continue "remember?"` -> correctly recalled prior context
- `exec --resume <ID> "topic?"` (no --auto) -> engine path works
- `exec --auto --output-format stream-json "..."` -> valid JSON Lines output
- `exec --auto --output-format stream-json --resume <ID>` -> stream-json + session resume combined
- `exec --system-prompt "You are a pirate" --model deepseek-v4-flash "hello"` -> pirate response ✅
- `exec --system-prompt-file /tmp/prompt.txt --model deepseek-v4-flash "hello"` -> robot response ✅
- `exec --system-prompt "text" --system-prompt-file /tmp/p.txt "hello"` -> mutual exclusivity error ✅
- `exec "2+2=?"` -> original one-shot path unaffected
- `cargo build` — zero errors, zero warnings
- `cargo clippy` — no new lints
- `cargo test` — 24/24 new tests passing

Closes #1530