### PR TITLE
fix(tui): debounce FocusGained recovery to prevent flicker loop on Tabby

### DIFF
--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -745,6 +745,14 @@ async fn run_event_loop(
     let mut terminal_paused_at: Option<Instant> = None;
     let mut force_terminal_repaint = false;
     let mut draws_since_last_full_repaint: u64 = 0;
+    // FocusGained debounce: some terminal emulators (e.g. Tabby) re-trigger
+    // FocusGained when we re-arm focus-change reporting inside
+    // recover_terminal_modes, creating a tight repaint loop. Skip
+    // mode recovery (but still mark a repaint) within the debounce window.
+    const FOCUS_RECOVERY_DEBOUNCE: Duration = Duration::from_millis(200);
+    let mut last_focus_recovery = Instant::now()
+        .checked_sub(Duration::from_secs(60))
+        .unwrap_or_else(Instant::now);
 
     loop {
         if !drain_web_config_events(&mut web_config_session, app, config, &engine_handle).await {
@@ -1954,11 +1962,15 @@ async fn run_event_loop(
             // bracketed-paste modes — recover_terminal_modes() is the
             // canonical place those flags live.
             if terminal_event_needs_viewport_recapture(&evt) {
-                recover_terminal_modes(
-                    terminal.backend_mut(),
-                    app.use_mouse_capture,
-                    app.use_bracketed_paste,
-                );
+                let now = Instant::now();
+                if now.duration_since(last_focus_recovery) >= FOCUS_RECOVERY_DEBOUNCE {
+                    recover_terminal_modes(
+                        terminal.backend_mut(),
+                        app.use_mouse_capture,
+                        app.use_bracketed_paste,
+                    );
+                    last_focus_recovery = now;
+                }
                 force_terminal_repaint = true;
                 app.needs_redraw = true;
             }


### PR DESCRIPTION
## PR 描述 / Description

### 问题现象 / Problem

在 **Tabby** 终端模拟器（基于 xterm.js）中运行 `deepseek-tui` 时，当 Tabby 窗口获得焦点，deepseek-tui 终端界面会出现**持续闪烁**（flickering），CPU 占用飙升。当焦点切换到其他程序（如浏览器、IDE）后，闪烁立即消失，恢复正常。

**复现条件**：
- 终端模拟器：Tabby（macOS，xterm.js 底层）
- deepseek-tui 版本：0.8.32
- 系统：macOS

### 根因分析 / Root Cause

问题链如下：

```
FocusGained 事件 → recover_terminal_modes() → EnableFocusChange(\e[?1004h)
      ↑                                                      ↓
      └──── Tabby 收到 \e[?1004h 后重新触发 FocusGained ←─────┘
```

`recover_terminal_modes()` 在每次收到 `FocusGained` 事件时都会执行 `EnableFocusChange`（发送 `\e[?1004h` 启用焦点报告）。Tabby 的 xterm.js 实现在收到该序列后会重新发送一个 `FocusGained` 事件，形成**事件→恢复→焦点报告→新事件**的死循环。每次循环都触发 `force_terminal_repaint = true`，导致持续全屏重绘 → 肉眼看到的闪烁。

焦点离开 Tabby 时，不再触发 `FocusGained`，循环终止，恢复正常。

### 修复方案 / Fix

在 `FocusGained` 事件处理中加入 **200ms 防抖（debounce）**：

```rust
// 新增常量
const FOCUS_RECOVERY_DEBOUNCE: Duration = Duration::from_millis(200);

// FocusGained 处理逻辑
if terminal_event_needs_viewport_recapture(&evt) {
    let now = Instant::now();
    if now.duration_since(last_focus_recovery) >= FOCUS_RECOVERY_DEBOUNCE {
        recover_terminal_modes(...);  // 只在超过 200ms 间隔时才恢复
        last_focus_recovery = now;
    }
    force_terminal_repaint = true;  // 但始终标记需要重绘
}
```

**为什么 200ms 是合理的**：
- 正常的应用切换产生的 FocusGained 事件间隔远超 200ms，不受影响
- Tabby 的循环触发事件间隔 < 1ms，会被 debounce 拦截
- 即使 debounce 跳过了 `recover_terminal_modes`，`force_terminal_repaint` 仍然会被设置，显示不受影响

### 修改文件 / Changes

- `crates/tui/src/tui/ui.rs`：+17 / -5 行

### 测试 / Verified

- ✅ `cargo check` 通过
- ✅ `cargo build --release` 通过
- ✅ 替换本地二进制后在 Tabby 中测试，闪烁消除

---

> 🧠 **本修复由 DeepSeek V4 Pro 分析、定位并实施。**
> This fix was analyzed, diagnosed, and implemented by **DeepSeek V4 Pro**.