### PR TITLE
 fix(tui): remove intermediate flush() after TERMINAL_ORIGIN_RESET to reduce flicker

### DIFF
--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -6239,7 +6239,6 @@ fn draw_app_frame_inner(
     let result = (|| -> Result<()> {
         if full_repaint {
             terminal.backend_mut().write_all(TERMINAL_ORIGIN_RESET)?;
-            terminal.backend_mut().flush()?;
             terminal.clear()?;
         }
         terminal.draw(|f| render(f, app))?;
@@ -7166,7 +7165,6 @@ fn reset_terminal_viewport(terminal: &mut AppTerminal, sync_output_enabled: bool
 
     let result = (|| -> Result<()> {
         terminal.backend_mut().write_all(TERMINAL_ORIGIN_RESET)?;
-        terminal.backend_mut().flush()?;
         terminal.clear()?;
         Ok(())
     })();


### PR DESCRIPTION
### Problem
    On terminals that do not support DEC 2026 synchronized output (xterm-256color
    on Ubuntu, slow SSH connections, legacy terminal emulators), every redraw
    causes visible flicker. The intermediate `flush()` between
    `TERMINAL_ORIGIN_RESET` and `terminal.clear()` sends the reset sequence to
    the terminal before ratatui repaints, producing a blank flash each cycle.
    
    ### Root cause
write(TERMINALORIGINRESET)  → reset scroll region + cursor
flush()                       → ← terminal renders BLANK
terminal.clear()              → clear buffer
terminal.draw(ratatui)        → repaint content
    
    The `flush()` at step 2 is redundant — `terminal.clear()` handles its own
    flush internally (comment at line 7152 confirms this: "the
    immediately-following ratatui `terminal.clear()` flushes a single clear").
    By removing the intermediate flush, the reset + clear are batched into a
    single write before ratatui renders.
    
    ### Changes
    - Remove `terminal.backend_mut().flush()?` from `draw_frame` (line 6242)
    - Remove `terminal.backend_mut().flush()?` from `reset_terminal_viewport`
      (line 7169)
    
    1 file changed, 2 deletions. No change to `TERMINAL_ORIGIN_RESET` (existing
    flicker regression test still passes).
    
    Closes #1557