### PR TITLE
fix(tui): close /help overlay on Ctrl+C and Ctrl+G (#1559)

### DIFF
--- a/crates/tui/src/tui/views/help.rs
+++ b/crates/tui/src/tui/views/help.rs
@@ -9,8 +9,9 @@
 //! Keys: any printable character extends the filter, `Backspace` (or `Ctrl+H`)
 //! shrinks it,
 //! `↑`/`↓` (or `Ctrl+P`/`Ctrl+N`) move the selection, `PgUp`/`PgDn` jump by
-//! ten rows, `Home`/`End` jump to ends, and `Esc` closes. Pressing `?` again
-//! at the call-site (`tui::ui`) also toggles the overlay closed.
+//! ten rows, `Home`/`End` jump to ends, and `Esc` (or `Ctrl+C` / `Ctrl+G`)
+//! closes. Pressing `?` again at the call-site (`tui::ui`) also toggles the
+//! overlay closed.
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::{
@@ -246,6 +247,15 @@ impl ModalView for HelpView {
     fn handle_key(&mut self, key: KeyEvent) -> ViewAction {
         match key.code {
             KeyCode::Esc => ViewAction::Close,
+            // `Ctrl+C` (universal terminal cancel) and `Ctrl+G` (emacs
+            // "keyboard quit") both close the overlay so users have a
+            // dependable escape hatch when `Esc` is intercepted by their
+            // terminal or input method (#1559). `q` is intentionally not a
+            // close key because `q` is a valid filter character and would
+            // make it impossible to search for commands like `/quit`.
+            KeyCode::Char('c' | 'g') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                ViewAction::Close
+            }
             KeyCode::Up => {
                 self.move_selection(-1);
                 ViewAction::None
@@ -574,6 +584,49 @@ mod tests {
         let mut view = HelpView::new();
         let action = view.handle_key(key(KeyCode::Esc));
         assert!(matches!(action, ViewAction::Close));
+    }
+
+    #[test]
+    fn ctrl_c_closes_overlay() {
+        // #1559: terminals/IMEs occasionally swallow Esc; Ctrl+C is the
+        // universal cancel gesture and must give users a reliable exit.
+        let mut view = HelpView::new();
+        let action = view.handle_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL));
+        assert!(
+            matches!(action, ViewAction::Close),
+            "Ctrl+C must close the help overlay"
+        );
+    }
+
+    #[test]
+    fn ctrl_g_closes_overlay() {
+        // Emacs convention — `Ctrl+G` is "keyboard quit"; matching it keeps
+        // muscle memory consistent for users who reach for it instinctively.
+        let mut view = HelpView::new();
+        let action = view.handle_key(KeyEvent::new(KeyCode::Char('g'), KeyModifiers::CONTROL));
+        assert!(
+            matches!(action, ViewAction::Close),
+            "Ctrl+G must close the help overlay"
+        );
+    }
+
+    #[test]
+    fn plain_c_still_filters_after_ctrl_c_close_binding() {
+        // Regression guard for the close binding above: a bare `c` must keep
+        // typing into the filter so users can search for `/clear`, `/compact`,
+        // etc. — only the Ctrl-modified variant closes.
+        let mut view = HelpView::new();
+        let total = view.filtered.len();
+        let action = view.handle_key(key(KeyCode::Char('c')));
+        assert!(
+            matches!(action, ViewAction::None),
+            "plain `c` must not close the overlay"
+        );
+        assert!(
+            view.filtered.len() <= total,
+            "plain `c` should narrow (or hold) the filtered set, not close"
+        );
+        assert_eq!(view.query, "c", "plain `c` should append to the filter");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #1559.

`/help` previously only closed on `Esc`. The reporter in #1559 (Windows 11 + PowerShell, v0.8.32) got stuck in the overlay because neither `Esc` nor `Ctrl+C` could exit it — every other key was captured as filter input and the only way out was to close the terminal.

Even on platforms where `Esc` is reliable, terminals, key remappers, and IMEs sometimes intercept it (kitty/legacy-console keyboard reporting, tmux `escape-time`, vim-style modal stacks). Other modals in this crate already cover the same risk by accepting multiple close keys — e.g. `ShellControlView` (`Esc | q | Q`), `SubAgentsView` (`Esc | q`).

This change brings `HelpView` in line by adding two universal cancel gestures:

| Key      | Convention                          |
| -------- | ----------------------------------- |
| `Ctrl+C` | terminal "cancel / interrupt"       |
| `Ctrl+G` | emacs "keyboard quit"               |

`q` is intentionally **not** bound — it has to remain a valid filter character. Otherwise typing `/quit` would close the overlay before the search ever reached the `q`. The existing `Esc` handler is unchanged so users who relied on it keep their muscle memory.

## Why this fix specifically

A few alternatives I weighed:

1. **Diagnose the Windows-specific `Esc` swallow.** The reporter's `Esc` should reach `HelpView::handle_key` via the existing dispatch — but the screenshot they attached implies it doesn't. Tracking that down likely involves crossterm key-event normalization on PowerShell + Windows Terminal, which I can't reproduce on a Linux CI runner and warrants a separate platform investigation. Adding `Ctrl+C` is independently correct and unblocks affected users today.
2. **Bind `q` to close.** Breaks the substring filter for any command starting with `q` (`/quit` isn't a current command, but `/quit-and-save` etc. are easy to add).
3. **Add a footer-hint string change.** Would touch every localized chrome message (`en`, `zh-Hans`, `ja`, `pt-BR`) and the localized render tests for marginal benefit. Keeping the change tight; the module doc-comment now lists all three close keys for contributors.

## Implementation

```rust
KeyCode::Char('c' | 'g') if key.modifiers.contains(KeyModifiers::CONTROL) => {
    ViewAction::Close
}
```

Added directly after the existing `KeyCode::Esc` arm. The filter-input guard further down already rejects `c.is_control()`, so this new arm is unreachable from a non-modified `c`.

## Tests

Three new unit tests, alongside the existing `esc_closes_overlay`:

- `ctrl_c_closes_overlay` — `Ctrl+C` returns `ViewAction::Close`.
- `ctrl_g_closes_overlay` — `Ctrl+G` returns `ViewAction::Close`.
- `plain_c_still_filters_after_ctrl_c_close_binding` — bare `c` continues to append to the filter (regression guard for the close binding).

```text
running 16 tests
test tui::views::help::tests::esc_closes_overlay ... ok
test tui::views::help::tests::ctrl_c_closes_overlay ... ok
test tui::views::help::tests::ctrl_g_closes_overlay ... ok
test tui::views::help::tests::plain_c_still_filters_after_ctrl_c_close_binding ... ok
...
test result: ok. 16 passed; 0 failed
```

## Verification

Run locally on Linux (Rust 1.94):

- `cargo fmt --all -- --check` ✓
- `cargo clippy -p deepseek-tui --bin deepseek-tui --tests --no-deps --locked -- -D warnings` ✓
- `cargo test -p deepseek-tui --bin deepseek-tui -- views::help` ✓ (16/16)
- `cargo test -p deepseek-tui --bin deepseek-tui -- keybindings::` ✓ (4/4)
- `git diff --exit-code -- Cargo.lock` ✓ (no lockfile drift)

## Scope

1 file, +55 / -2. No public-API or trust-boundary surface touched.

## Test plan

- [x] `Ctrl+C` while `/help` is open closes the overlay (unit test).
- [x] `Ctrl+G` while `/help` is open closes the overlay (unit test).
- [x] `Esc` still closes the overlay (existing test).
- [x] Bare `c` still narrows the filter (unit test).
- [x] `cargo fmt`, `cargo clippy -D warnings`, full views::help and keybindings test suites pass.