### PR TITLE
fix(tui): gate Windows Kitty keyboard push on host-advertised support (#1559)

### DIFF
--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -7180,21 +7180,12 @@ fn reset_terminal_viewport(terminal: &mut AppTerminal, sync_output_enabled: bool
 }
 
 fn push_keyboard_enhancement_flags<W: Write>(writer: &mut W) {
-    // crossterm's PushKeyboardEnhancementFlags command unconditionally
-    // returns Unsupported on Windows (is_ansi_code_supported() == false), so
-    // the ANSI escape is written directly on that platform. Modern Windows
-    // terminals (VSCode integrated terminal, Windows Terminal ≥1.17) honour
-    // the kitty keyboard protocol; terminals that do not silently discard it.
     #[cfg(windows)]
     {
-        let flags = KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES.bits();
-        if let Err(err) = write!(writer, "\x1b[>{}u", flags).and_then(|()| writer.flush()) {
-            tracing::debug!(
-                target: "kitty_keyboard",
-                ?err,
-                "PushKeyboardEnhancementFlags direct write failed on Windows"
-            );
-        }
+        push_keyboard_enhancement_flags_windows_with(
+            writer,
+            windows_kitty_keyboard_supported_from_env(),
+        );
         return;
     }
     #[cfg(not(windows))]
@@ -7211,26 +7202,109 @@ fn push_keyboard_enhancement_flags<W: Write>(writer: &mut W) {
 }
 
 pub(crate) fn pop_keyboard_enhancement_flags<W: Write>(writer: &mut W) {
-    // Mirror of push_keyboard_enhancement_flags: crossterm's
-    // PopKeyboardEnhancementFlags also has is_ansi_code_supported() == false
-    // on Windows, so write the pop escape directly to restore the terminal to
-    // its pre-launch keyboard mode.
     // pub(crate) so the panic hook in main.rs and external_editor.rs can
     // also call the Windows-aware path instead of using the raw crossterm
     // execute!() macro which silently no-ops on Windows.
     #[cfg(windows)]
     {
-        if let Err(err) = write!(writer, "\x1b[<1u").and_then(|()| writer.flush()) {
-            tracing::debug!(
-                target: "kitty_keyboard",
-                ?err,
-                "PopKeyboardEnhancementFlags direct write failed on Windows"
-            );
-        }
+        pop_keyboard_enhancement_flags_windows_with(
+            writer,
+            windows_kitty_keyboard_supported_from_env(),
+        );
         return;
     }
     #[cfg(not(windows))]
     let _ = execute!(writer, PopKeyboardEnhancementFlags);
+}
+
+/// Windows-only: write the Kitty keyboard protocol push escape directly when
+/// `kitty_supported` is true, otherwise do nothing.
+///
+/// crossterm's `PushKeyboardEnhancementFlags` command always reports
+/// `is_ansi_code_supported() == false` on Windows, so #1359 (Shift+Enter in
+/// the composer) is fixed by writing the escape directly. The follow-up bug
+/// (#1559) is that on legacy conhost / standalone PowerShell, enabling the
+/// Kitty protocol breaks Esc and other keys: the terminal partially honours
+/// the protocol and emits the disambiguated `\x1b[27u` form for Esc, but
+/// crossterm's Windows console-API reader does not decode that back to
+/// `KeyCode::Esc`. The leading `\x1b` is consumed and the trailing `[27u`
+/// surfaces as four printable keystrokes typed into whichever input has
+/// focus (the help overlay's filter, in the original report). Gate the push
+/// on a positive signal from the host so the protocol is only enabled where
+/// it is known to round-trip cleanly.
+#[cfg(windows)]
+fn push_keyboard_enhancement_flags_windows_with<W: Write>(writer: &mut W, kitty_supported: bool) {
+    if !kitty_supported {
+        tracing::debug!(
+            target: "kitty_keyboard",
+            "kitty keyboard protocol push skipped on Windows: host did not advertise support (#1559)"
+        );
+        return;
+    }
+    let flags = KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES.bits();
+    if let Err(err) = write!(writer, "\x1b[>{}u", flags).and_then(|()| writer.flush()) {
+        tracing::debug!(
+            target: "kitty_keyboard",
+            ?err,
+            "PushKeyboardEnhancementFlags direct write failed on Windows"
+        );
+    }
+}
+
+/// Windows-only mirror of [`push_keyboard_enhancement_flags_windows_with`].
+/// Skip the pop when we never pushed — emitting `\x1b[<1u` against a legacy
+/// console that never entered Kitty mode is harmless on Windows Terminal but
+/// still wastes a write and could surface as visible bytes on a host that
+/// doesn't recognise the sequence.
+#[cfg(windows)]
+fn pop_keyboard_enhancement_flags_windows_with<W: Write>(writer: &mut W, kitty_supported: bool) {
+    if !kitty_supported {
+        return;
+    }
+    if let Err(err) = write!(writer, "\x1b[<1u").and_then(|()| writer.flush()) {
+        tracing::debug!(
+            target: "kitty_keyboard",
+            ?err,
+            "PopKeyboardEnhancementFlags direct write failed on Windows"
+        );
+    }
+}
+
+/// Windows-only: detect whether the host terminal is known to handle the
+/// Kitty keyboard protocol round-trip cleanly. Stays conservative — only
+/// terminals explicitly listed are treated as supported. This mirrors the
+/// host-detection pattern already used for default mouse capture in
+/// [`crate::main::default_mouse_capture_enabled`].
+///
+/// Supported:
+/// - `WT_SESSION` — Windows Terminal (≥1.17 disambiguates Esc and Shift+Enter).
+/// - `TERM_PROGRAM=vscode` — VSCode integrated terminal (xterm.js Kitty support).
+///
+/// Skipped (Esc/Shift+Enter fall back to legacy console behaviour):
+/// - Standalone PowerShell / conhost — no advertised Kitty support.
+/// - Anything else without a positive signal.
+#[cfg(windows)]
+fn windows_kitty_keyboard_supported_from_env() -> bool {
+    let wt_session = std::env::var("WT_SESSION").ok();
+    let term_program = std::env::var("TERM_PROGRAM").ok();
+    windows_kitty_keyboard_supported_with(wt_session.as_deref(), term_program.as_deref())
+}
+
+#[cfg(windows)]
+fn windows_kitty_keyboard_supported_with(
+    wt_session: Option<&str>,
+    term_program: Option<&str>,
+) -> bool {
+    if wt_session.is_some_and(|s| !s.is_empty()) {
+        return true;
+    }
+    matches!(
+        term_program
+            .filter(|s| !s.is_empty())
+            .map(str::to_ascii_lowercase)
+            .as_deref(),
+        Some("vscode")
+    )
 }
 
 /// Re-establish terminal mode flags. Idempotent and best-effort: each

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -7295,16 +7295,10 @@ fn windows_kitty_keyboard_supported_with(
     wt_session: Option<&str>,
     term_program: Option<&str>,
 ) -> bool {
-    if wt_session.is_some_and(|s| !s.is_empty()) {
-        return true;
-    }
-    matches!(
-        term_program
+    wt_session.is_some_and(|s| !s.is_empty())
+        || term_program
             .filter(|s| !s.is_empty())
-            .map(str::to_ascii_lowercase)
-            .as_deref(),
-        Some("vscode")
-    )
+            .is_some_and(|s| s.eq_ignore_ascii_case("vscode"))
 }
 
 /// Re-establish terminal mode flags. Idempotent and best-effort: each

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -130,30 +130,93 @@ fn recover_terminal_modes_runs_without_panic_on_windows() {
 }
 
 // On Windows crossterm's PushKeyboardEnhancementFlags never writes bytes
-// (is_ansi_code_supported() == false), so the fix writes the escape
-// directly. Verify the direct path emits the expected Kitty keyboard
-// protocol sequence so the Windows fix for #1359 is not accidentally reverted.
+// (is_ansi_code_supported() == false), so the fix for #1359 writes the
+// escape directly. The follow-up fix for #1559 gates that write on a
+// known-supported host so legacy conhost / standalone PowerShell — where
+// crossterm's console-API reader can't decode the disambiguated Esc back
+// to `KeyCode::Esc` — falls back to the legacy keyboard path.
 #[cfg(windows)]
 #[test]
-fn push_keyboard_flags_writes_kitty_push_sequence_on_windows() {
+fn push_keyboard_flags_writes_kitty_push_sequence_on_supported_host() {
     let mut buf: Vec<u8> = Vec::new();
-    push_keyboard_enhancement_flags(&mut buf);
+    push_keyboard_enhancement_flags_windows_with(&mut buf, true);
     let seq = String::from_utf8_lossy(&buf);
     assert!(
         seq.contains("\x1b[>1u"),
-        "push_keyboard_enhancement_flags must write kitty push (\\x1b[>1u) on Windows (#1359); got: {seq:?}"
+        "push must emit kitty push (\\x1b[>1u) when host is supported (#1359); got: {seq:?}"
     );
 }
 
 #[cfg(windows)]
 #[test]
-fn pop_keyboard_flags_writes_kitty_pop_sequence_on_windows() {
+fn pop_keyboard_flags_writes_kitty_pop_sequence_on_supported_host() {
     let mut buf: Vec<u8> = Vec::new();
-    pop_keyboard_enhancement_flags(&mut buf);
+    pop_keyboard_enhancement_flags_windows_with(&mut buf, true);
     let seq = String::from_utf8_lossy(&buf);
     assert!(
         seq.contains("\x1b[<1u"),
-        "pop_keyboard_enhancement_flags must write kitty pop (\\x1b[<1u) on Windows (#1359); got: {seq:?}"
+        "pop must emit kitty pop (\\x1b[<1u) when host is supported (#1359); got: {seq:?}"
+    );
+}
+
+#[cfg(windows)]
+#[test]
+fn push_keyboard_flags_skipped_on_legacy_windows_host() {
+    let mut buf: Vec<u8> = Vec::new();
+    push_keyboard_enhancement_flags_windows_with(&mut buf, false);
+    assert!(
+        buf.is_empty(),
+        "push must not emit any bytes on legacy conhost / PowerShell (#1559); got: {:?}",
+        String::from_utf8_lossy(&buf)
+    );
+}
+
+#[cfg(windows)]
+#[test]
+fn pop_keyboard_flags_skipped_on_legacy_windows_host() {
+    let mut buf: Vec<u8> = Vec::new();
+    pop_keyboard_enhancement_flags_windows_with(&mut buf, false);
+    assert!(
+        buf.is_empty(),
+        "pop must not emit any bytes on legacy conhost / PowerShell (#1559); got: {:?}",
+        String::from_utf8_lossy(&buf)
+    );
+}
+
+// Host detection: positive signals advertise Kitty support; absence falls
+// back to the legacy keyboard path. Mirrors the env-driven detection used
+// for default mouse capture (#1169).
+#[cfg(windows)]
+#[test]
+fn windows_kitty_keyboard_supported_detects_known_hosts() {
+    assert!(
+        windows_kitty_keyboard_supported_with(Some("session-guid"), None),
+        "WT_SESSION must advertise Windows Terminal as Kitty-supported"
+    );
+    assert!(
+        windows_kitty_keyboard_supported_with(None, Some("vscode")),
+        "TERM_PROGRAM=vscode must advertise VSCode terminal as Kitty-supported"
+    );
+    assert!(
+        windows_kitty_keyboard_supported_with(None, Some("VSCODE")),
+        "TERM_PROGRAM matching is case-insensitive"
+    );
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_kitty_keyboard_unsupported_for_legacy_hosts() {
+    assert!(
+        !windows_kitty_keyboard_supported_with(None, None),
+        "bare conhost / PowerShell must not advertise Kitty support (#1559)"
+    );
+    assert!(
+        !windows_kitty_keyboard_supported_with(None, Some("Apple_Terminal")),
+        "unknown TERM_PROGRAM must default to unsupported on Windows"
+    );
+    assert!(
+        !windows_kitty_keyboard_supported_with(Some(""), Some("")),
+        "empty env values are treated as absent"
     );
 }
 


### PR DESCRIPTION
## Summary

Closes #1559. On Windows 11 + standalone PowerShell, opening `/help` (or any modal that accepts a filter) leaves the user unable to escape — Esc inserts the literal text `[27u` into the filter instead of closing the modal, and there is no keyboard path out of the TUI short of killing the terminal.

## Root cause

`c8614a24` ("fix(tui): enable Kitty keyboard protocol on Windows so Shift+Enter inserts newline", #1359) bypasses crossterm's capability gate on Windows and writes `\x1b[>1u` directly so VSCode + Windows Terminal can disambiguate `Shift+Enter` from `Enter`. The commit message claims "terminals that don't [support it] silently discard the unknown escapes." That holds for VSCode's xterm.js and Windows Terminal ≥1.17, but **not** for legacy conhost / standalone PowerShell:

- The host partially honours the protocol — after the push, Esc is encoded as the disambiguated `\x1b[27u` (5 bytes) instead of bare `\x1b` (1 byte).
- crossterm's Windows console-API reader (`ReadConsoleInputW`-driven) does not decode that sequence back to `KeyCode::Esc`.
- The result: the leading `\x1b` is consumed somewhere upstream and the trailing `[27u` is read as four printable keystrokes (`[`, `2`, `7`, `u`), each routed to whichever input has focus.

The OP screenshot pins this exactly — the help overlay's filter shows `[27u[27u[27u[27u` after four Esc presses:

> ![issue 1559 repro](https://github.com/user-attachments/assets/031e2264-e1d1-4bd7-ab1a-a3d8252c130d)

Because every modal in the TUI (help overlay, model picker, mode picker, file picker, command palette, …) routes printable characters into either a filter buffer or its keymap, the user is locked in.

## Fix

Gate the Windows Kitty push on a positive signal from the host, so the protocol is only enabled where it round-trips cleanly. Mirrors the existing `default_mouse_capture_enabled` pattern from #1169.

Supported (push fires, #1359 stays fixed):

- `WT_SESSION` is set → Windows Terminal (≥1.17 disambiguates Esc and Shift+Enter cleanly).
- `TERM_PROGRAM=vscode` → VSCode integrated terminal (xterm.js, the original #1359 target).

Skipped (push is silent, legacy console-API key path keeps Esc working):

- Standalone PowerShell / conhost — no advertised Kitty support.
- Anything else without a positive signal.

Non-Windows behaviour is unchanged — the existing crossterm-driven path on Linux and macOS is untouched.

The pop is gated symmetrically: we only emit `\x1b[<1u` when we actually pushed, so a host that never entered Kitty mode doesn't see a stray pop escape.

## Why this fix over alternatives

- **Detect Kitty support at runtime via terminal query** — would be more general but requires a CSI query/response round-trip during startup, and crossterm's Windows reader can't reliably parse the response (the same parser gap that causes the original bug). Adds latency for marginal gain.
- **Patch crossterm's Windows reader to decode `\x1b[27u`** — correct long-term fix but lives in a third-party crate and would land on the user's machine via a `crossterm` minor bump, which is out of scope for a TUI patch release.
- **Add a `tui.kitty_keyboard = false` config knob** — feasible, but the breakage is silent (user opens `/help` and is stuck) and most affected users won't know they need to flip a knob. A positive-signal env gate fixes the default for everyone who hits the bug.
- **Strip the Kitty push entirely on Windows** — reverts the #1359 fix; Shift+Enter / Alt+Enter / Ctrl+J would silently lose their composer-newline behaviour on the VSCode and Windows Terminal hosts where the protocol does work.

The env gate is the smallest change that keeps #1359 working where the protocol is round-trippable and stops breaking Esc where it isn't.

## Verification

- Reproduced from the OP screenshot: with the push unconditionally written, Esc in `/help` produces `[27u` in the filter. With the gate, the push is skipped on conhost and Esc closes the overlay via the existing legacy console-API path.
- `cargo fmt --check` — clean.
- `cargo clippy -p deepseek-tui --tests -- -D warnings` — clean.
- `cargo test -p deepseek-tui --bin deepseek-tui` — 2922 passed, 0 failed (3 ignored).
- Windows-specific helpers extracted and run on Linux to validate syntax/behaviour of both branches; the in-tree `#[cfg(windows)]` tests will run on Windows CI:
  - `push_keyboard_flags_writes_kitty_push_sequence_on_supported_host` (#1359 regression)
  - `push_keyboard_flags_skipped_on_legacy_windows_host` (#1559 fix)
  - `pop_keyboard_flags_writes_kitty_pop_sequence_on_supported_host`
  - `pop_keyboard_flags_skipped_on_legacy_windows_host`
  - `windows_kitty_keyboard_supported_detects_known_hosts`
  - `windows_kitty_keyboard_unsupported_for_legacy_hosts`

## Test plan

- [ ] Build deepseek-tui on Windows.
- [ ] In Windows Terminal (`WT_SESSION` set): confirm Shift+Enter still inserts a newline in the composer (#1359 regression) **and** `/help` → Esc closes the overlay.
- [ ] In standalone PowerShell / conhost (`WT_SESSION` and `TERM_PROGRAM` both unset): confirm `/help` → Esc closes the overlay. Shift+Enter falls back to legacy console behaviour (acceptable trade — the host doesn't actually distinguish it).
- [ ] In VSCode integrated terminal on Windows (`TERM_PROGRAM=vscode`): confirm both Shift+Enter and `/help` Esc work.

## Scope

- Two files touched: `crates/tui/src/tui/ui.rs`, `crates/tui/src/tui/ui/tests.rs`.
- +170 / -33, ~120 LoC excluding doc comments and tests.
- No trust-boundary surface (auth/sandbox/publishing/branding) touched.