### PR TITLE
fix(cache): reduce DeepSeek prefix churn from dynamic tool catalog growth

### DIFF
--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+use crate::core::engine::tool_catalog::AGENT_MODE_PRELOADED_TOOLS;
 use crate::models::SystemBlock;
 use crate::test_support::lock_test_env;
 use crate::tools::spec::ToolCapability;
@@ -342,17 +343,7 @@ fn non_yolo_mode_retains_default_defer_policy() {
 
 #[test]
 fn agent_mode_preloads_core_coding_toolset() {
-    for name in [
-        "write_file",
-        "edit_file",
-        "apply_patch",
-        "git_status",
-        "git_diff",
-        "git_show",
-        "git_log",
-        "git_blame",
-        "run_tests",
-    ] {
+    for &name in AGENT_MODE_PRELOADED_TOOLS {
         assert!(
             !should_default_defer_tool(name, AppMode::Agent),
             "{name} should stay loaded in Agent mode to avoid DeepSeek prefix churn",
@@ -362,35 +353,15 @@ fn agent_mode_preloads_core_coding_toolset() {
 
 #[test]
 fn initial_active_tools_include_core_coding_toolset_in_agent_mode() {
-    let catalog = build_model_tool_catalog(
-        vec![
-            api_tool("write_file"),
-            api_tool("edit_file"),
-            api_tool("apply_patch"),
-            api_tool("git_status"),
-            api_tool("git_diff"),
-            api_tool("git_show"),
-            api_tool("git_log"),
-            api_tool("git_blame"),
-            api_tool("run_tests"),
-            api_tool("project_map"),
-        ],
-        vec![],
-        AppMode::Agent,
-    );
+    let mut native_tools: Vec<Tool> = AGENT_MODE_PRELOADED_TOOLS
+        .iter()
+        .map(|&name| api_tool(name))
+        .collect();
+    native_tools.push(api_tool("project_map"));
+    let catalog = build_model_tool_catalog(native_tools, vec![], AppMode::Agent);
 
     let active = initial_active_tools(&catalog);
-    for name in [
-        "write_file",
-        "edit_file",
-        "apply_patch",
-        "git_status",
-        "git_diff",
-        "git_show",
-        "git_log",
-        "git_blame",
-        "run_tests",
-    ] {
+    for &name in AGENT_MODE_PRELOADED_TOOLS {
         assert!(
             active.contains(name),
             "{name} should be active from turn one in Agent mode",

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -341,6 +341,68 @@ fn non_yolo_mode_retains_default_defer_policy() {
 }
 
 #[test]
+fn agent_mode_preloads_core_coding_toolset() {
+    for name in [
+        "write_file",
+        "edit_file",
+        "apply_patch",
+        "git_status",
+        "git_diff",
+        "git_show",
+        "git_log",
+        "git_blame",
+        "run_tests",
+    ] {
+        assert!(
+            !should_default_defer_tool(name, AppMode::Agent),
+            "{name} should stay loaded in Agent mode to avoid DeepSeek prefix churn",
+        );
+    }
+}
+
+#[test]
+fn initial_active_tools_include_core_coding_toolset_in_agent_mode() {
+    let catalog = build_model_tool_catalog(
+        vec![
+            api_tool("write_file"),
+            api_tool("edit_file"),
+            api_tool("apply_patch"),
+            api_tool("git_status"),
+            api_tool("git_diff"),
+            api_tool("git_show"),
+            api_tool("git_log"),
+            api_tool("git_blame"),
+            api_tool("run_tests"),
+            api_tool("project_map"),
+        ],
+        vec![],
+        AppMode::Agent,
+    );
+
+    let active = initial_active_tools(&catalog);
+    for name in [
+        "write_file",
+        "edit_file",
+        "apply_patch",
+        "git_status",
+        "git_diff",
+        "git_show",
+        "git_log",
+        "git_blame",
+        "run_tests",
+    ] {
+        assert!(
+            active.contains(name),
+            "{name} should be active from turn one in Agent mode",
+        );
+    }
+    assert!(
+        !active.contains("project_map"),
+        "rare tools should remain deferred so the preload set stays scoped",
+    );
+}
+
+#[test]
 fn model_tool_catalog_applies_native_and_mcp_deferral() {
     let catalog = build_model_tool_catalog(
         vec![

--- a/crates/tui/src/core/engine/tool_catalog.rs
+++ b/crates/tui/src/core/engine/tool_catalog.rs
@@ -34,20 +34,30 @@ pub(super) fn should_default_defer_tool(name: &str, mode: AppMode) -> bool {
         return false;
     }
 
-    // Shell exec tools are kept active in Agent so the model can run
-    // verification commands (build/test/git/cargo) without first having to
-    // discover them through ToolSearch. Plan mode does not register shell
-    // execution tools.
-    let always_loaded_in_action_modes = matches!(mode, AppMode::Agent)
+    // DeepSeek cache hits depend on replaying the same full prompt prefix.
+    // In Agent mode, the common coding loop is read -> edit -> diff/test, so
+    // the core edit/git/test surfaces stay loaded from turn one instead of
+    // growing the model-visible tool catalog mid-session. Plan mode remains
+    // read-only and does not register write/exec tools.
+    let always_loaded_in_agent_mode = matches!(mode, AppMode::Agent)
         && matches!(
             name,
-            "exec_shell"
+            "apply_patch"
+                | "edit_file"
+                | "exec_shell"
                 | "exec_shell_wait"
                 | "exec_shell_interact"
                 | "exec_wait"
                 | "exec_interact"
+                | "git_blame"
+                | "git_diff"
+                | "git_log"
+                | "git_show"
+                | "git_status"
+                | "run_tests"
+                | "write_file"
         );
-    if always_loaded_in_action_modes {
+    if always_loaded_in_agent_mode {
         return false;
     }
 

--- a/crates/tui/src/core/engine/tool_catalog.rs
+++ b/crates/tui/src/core/engine/tool_catalog.rs
@@ -24,6 +24,22 @@ const TOOL_SEARCH_REGEX_NAME: &str = "tool_search_tool_regex";
 const TOOL_SEARCH_REGEX_TYPE: &str = "tool_search_tool_regex_20251119";
 pub(super) const TOOL_SEARCH_BM25_NAME: &str = "tool_search_tool_bm25";
 const TOOL_SEARCH_BM25_TYPE: &str = "tool_search_tool_bm25_20251119";
+pub(super) const AGENT_MODE_PRELOADED_TOOLS: &[&str] = &[
+    "apply_patch",
+    "edit_file",
+    "exec_interact",
+    "exec_shell",
+    "exec_shell_interact",
+    "exec_shell_wait",
+    "exec_wait",
+    "git_blame",
+    "git_diff",
+    "git_log",
+    "git_show",
+    "git_status",
+    "run_tests",
+    "write_file",
+];
 
 pub(super) fn is_tool_search_tool(name: &str) -> bool {
     matches!(name, TOOL_SEARCH_REGEX_NAME | TOOL_SEARCH_BM25_NAME)
@@ -39,24 +55,8 @@ pub(super) fn should_default_defer_tool(name: &str, mode: AppMode) -> bool {
     // the core edit/git/test surfaces stay loaded from turn one instead of
     // growing the model-visible tool catalog mid-session. Plan mode remains
     // read-only and does not register write/exec tools.
-    let always_loaded_in_agent_mode = matches!(mode, AppMode::Agent)
-        && matches!(
-            name,
-            "apply_patch"
-                | "edit_file"
-                | "exec_shell"
-                | "exec_shell_wait"
-                | "exec_shell_interact"
-                | "exec_wait"
-                | "exec_interact"
-                | "git_blame"
-                | "git_diff"
-                | "git_log"
-                | "git_show"
-                | "git_status"
-                | "run_tests"
-                | "write_file"
-        );
+    let always_loaded_in_agent_mode =
+        matches!(mode, AppMode::Agent) && AGENT_MODE_PRELOADED_TOOLS.contains(&name);
     if always_loaded_in_agent_mode {
         return false;
     }

--- a/docs/deepseek_cache_prefix_churn.md
+++ b/docs/deepseek_cache_prefix_churn.md
@@ -1,0 +1,193 @@
+# DeepSeek Cache Prefix Churn Analysis
+
+Date: 2026-05-13
+
+## Problem statement
+
+DeepSeek-TUI already includes several cache-stability improvements, but Agent mode
+still allows the model-visible tool catalog to grow during a normal edit/test
+loop. For DeepSeek, that matters because prompt cache reuse depends on repeated
+request prefixes matching complete cache prefix units. When common tools are
+initially deferred and only become active after first use, later requests carry a
+different `tools` array than earlier ones, which reduces prompt-cache reuse.
+
+This document explains why that happens, why users are noticing it, and why a
+targeted Agent-mode preload of the core coding toolset is a good first fix.
+
+## Official DeepSeek cache behavior
+
+DeepSeek's official KV cache guide says:
+
+- Prompt caching is enabled by default.
+- The response includes `prompt_cache_hit_tokens` and
+  `prompt_cache_miss_tokens`.
+- Later requests only hit the cache when they reuse a repeated prefix.
+- Because DeepSeek uses Sliding Window Attention, matching happens on complete
+  cache prefix units, so a later request must fully match a cached unit to hit.
+
+Source:
+- <https://api-docs.deepseek.com/zh-cn/guides/kv_cache>
+
+Practical consequence: if the request body changes near the front of the prompt,
+even for something structurally "small" like the visible tool definitions, the
+cache can miss from that point onward.
+
+## Official Claude Code comparison
+
+Claude Code's official "How Claude Code works" page documents several context
+stability tactics:
+
+- MCP tool definitions are deferred by default and loaded on demand via tool
+  search, so only tool names consume context until Claude uses a specific tool.
+- Skills load on demand.
+- Subagents run with their own fresh context and return summaries.
+
+Source:
+- <https://code.claude.com/docs/en/how-claude-code-works>
+
+That does not mean Claude Code and DeepSeek-TUI have identical architectures.
+It does show a useful principle: keep the stable prefix stable, and push
+late-bound detail to the tail or into separate contexts.
+
+## Repo evidence that the issue is real
+
+Open issues in the upstream repo show repeated user reports that DeepSeek cache
+hit rate is worse than in Claude Code-like tools:
+
+- Issue #1120: "There still seems to be some problems with cache hits缓存命中方面似乎还是有些问题"
+  - <https://github.com/Hmbown/DeepSeek-TUI/issues/1120>
+- Issue #1177: "输入缓存命中率太低了"
+  - <https://github.com/Hmbown/DeepSeek-TUI/issues/1177>
+- Issue #1253: "Feature: DeepSeek cache-aware prompt diagnostics and wire payload optimization"
+  - <https://github.com/Hmbown/DeepSeek-TUI/issues/1253>
+
+These issues are corroborating evidence, not the primary proof. The primary
+proof is the combination of DeepSeek's documented cache behavior and the current
+tool-catalog implementation.
+
+## What the code already gets right
+
+The current engine already contains several good cache-aware decisions:
+
+- `crates/tui/src/core/engine/tool_catalog.rs`
+  - `build_model_tool_catalog(...)` sorts native tools and MCP tools
+    deterministically.
+  - Built-ins stay ahead of MCP tools so MCP changes do not shift built-in tool
+    positions.
+  - `active_tool_list_from_catalog(...)` appends deferred-but-activated tools to
+    the tail, which avoids reindexing always-loaded tools mid-session.
+- Existing tests already guard these properties in
+  `crates/tui/src/core/engine/tests.rs`.
+
+So the cache problem is not "the tools array is random." The remaining issue is
+that the active tool list still grows during normal coding sessions.
+
+## The remaining root cause
+
+Agent mode currently keeps these tools loaded by default:
+
+- file/navigation/search basics such as `read_file`, `list_dir`, `grep_files`,
+  `file_search`
+- diagnostics/planning/task helpers
+- shell execution tools such as `exec_shell`
+
+But many tools that the project's own prompts describe as normal primary coding
+tools are still deferred:
+
+- File editing: `write_file`, `edit_file`, `apply_patch`
+- Git inspection: `git_status`, `git_diff`, `git_show`, `git_log`, `git_blame`
+- Verification: `run_tests`
+
+Relevant prompt references:
+
+- `crates/tui/src/prompts/base.md`
+- `crates/tui/src/prompts/base.txt`
+- `crates/tui/src/prompts/subagent_output_format.md`
+
+That mismatch creates avoidable prefix churn in a common Agent-mode flow:
+
+1. Request 1 starts with the base always-loaded tool set.
+2. The first edit activates `edit_file` or `apply_patch`.
+3. A later verification step activates `run_tests`.
+4. A later inspection step activates `git_diff` or `git_status`.
+
+Each activation changes the model-visible `tools` array for subsequent requests.
+DeepSeek's cache rules make this expensive because later requests no longer
+replay the same full cached prefix unit.
+
+## Why this PR scope is the right first fix
+
+The narrow fix is to preload the core coding toolset in Agent mode, while still
+keeping less common tools deferred.
+
+Why this is a good first step:
+
+- It directly addresses a documented DeepSeek cache requirement: prefix reuse.
+- It matches the repo's own prompts, which already treat these tools as
+  first-class tools for normal coding work.
+- It preserves the existing architecture and the existing tail-append behavior
+  for truly rare tools.
+- It is small, testable, and low-risk compared with a bigger redesign of tool
+  hydration or request serialization.
+
+## Expected effect
+
+This change should not eliminate every cache miss. Other factors still matter:
+
+- changing conversation content
+- dynamic MCP availability
+- compaction boundaries
+- tool results and reasoning content
+
+But it should reduce avoidable misses caused by the tool catalog changing during
+the standard read -> edit -> diff/test loop that most coding tasks follow.
+
+## Controlled API validation
+
+I also ran a controlled reproduction directly against DeepSeek's official Chat
+Completions API using `deepseek-v4-flash` and the documented cache metrics
+fields from the KV cache guide.
+
+Test design:
+
+- Stable case:
+  - Request 1: long repeated prefix + full coding toolset
+  - Request 2: identical long repeated prefix + identical full coding toolset
+- Churn case:
+  - Request 1: identical long repeated prefix + smaller base toolset
+  - Request 2: identical long repeated prefix + expanded coding toolset
+
+The only intentional difference between the two cases was whether the visible
+tool catalog grew between the first and second request.
+
+Observed results:
+
+- Stable repeat:
+  - `prompt_cache_hit_tokens = 4096`
+  - `prompt_cache_miss_tokens = 18`
+  - hit ratio ~= `99.56%`
+- Churn repeat:
+  - `prompt_cache_hit_tokens = 3328`
+  - `prompt_cache_miss_tokens = 791`
+  - hit ratio ~= `80.80%`
+
+Delta on the repeated request:
+
+- `768` fewer cache-hit tokens
+- `773` more cache-miss tokens
+
+This is not a full end-to-end TUI benchmark, but it is strong mechanism-level
+evidence that expanding the model-visible tool definitions between requests
+materially reduces DeepSeek cache reuse.
+
+## Non-goals for this PR
+
+This PR does not attempt to solve:
+
+- MCP tool churn beyond the current partitioning and deferral logic
+- history compaction strategy
+- tool-result payload size
+- request-body diagnostics for cache hit/miss accounting
+
+Those are valid follow-up areas, but they are intentionally out of scope for a
+first targeted fix.


### PR DESCRIPTION
## Summary

DeepSeek's prompt cache only hits when later requests replay the same cached prefix units. In Agent mode, DeepSeek-TUI was still deferring several tools that belong to the normal coding loop, so the model-visible `tools` array kept growing during read -> edit -> diff/test workflows.

This patch preloads the core coding toolset in Agent mode so those tools are present from turn one instead of being appended later after first use.

## What changed

- Keep these tools loaded by default in Agent mode:
  - `write_file`
  - `edit_file`
  - `apply_patch`
  - `git_status`
  - `git_diff`
  - `git_show`
  - `git_log`
  - `git_blame`
  - `run_tests`
- Add regression tests that assert:
  - the core coding toolset is not deferred in Agent mode
  - the core coding toolset is active from the first turn
- Add an analysis document with official links and cache validation:
  - `docs/deepseek_cache_prefix_churn.md`

## Why

DeepSeek's official KV cache docs say prompt caching is enabled by default, and that later requests only hit when they reuse a repeated prefix; because of Sliding Window Attention, matching happens on complete cache prefix units.

- DeepSeek KV cache: https://api-docs.deepseek.com/zh-cn/guides/kv_cache

Claude Code's official docs describe a similar context-stability principle from the opposite direction: tool definitions are deferred and loaded on demand so the stable prefix stays small and stable.

- Claude Code how-it-works: https://code.claude.com/docs/en/how-claude-code-works

DeepSeek-TUI already sorts tool partitions deterministically and appends deferred activations to the tail, which is good. The remaining problem was that many tools the project itself treats as first-class coding tools were still deferred, so a normal Agent session kept mutating the visible tool catalog.

## Validation

### Rust verification

- `cargo fmt --all`
- `cargo test -p deepseek-tui --bin deepseek-tui agent_mode_preloads_core_coding_toolset -- --nocapture`
- `cargo test -p deepseek-tui --bin deepseek-tui initial_active_tools_include_core_coding_toolset_in_agent_mode -- --nocapture`
- `cargo test -p deepseek-tui --bin deepseek-tui non_yolo_mode_retains_default_defer_policy -- --nocapture`
- `cargo test -p deepseek-tui --bin deepseek-tui active_tool_list_pushes_deferred_activations_to_the_tail -- --nocapture`
- `cargo test -p deepseek-tui --bin deepseek-tui deferred_edit_file_first_use_hydrates_schema_without_execution -- --nocapture`
- `cargo test -p deepseek-tui --bin deepseek-tui model_tool_catalog -- --nocapture`
- `cargo build -p deepseek-tui`
- `cargo test --workspace --all-features` (passes for this change set's touched areas, but currently reports two unrelated failures in `commands::skills::*`)

### DeepSeek API cache reproduction

Using the official Chat Completions API with a long repeated prefix:

- Stable tools on repeat:
  - `prompt_cache_hit_tokens = 4096`
  - `prompt_cache_miss_tokens = 18`
- Expanded tool catalog on repeat:
  - `prompt_cache_hit_tokens = 3328`
  - `prompt_cache_miss_tokens = 791`

That is a loss of 768 cache-hit tokens and an increase of 773 miss tokens on the repeated request when the visible tool catalog grows between requests.

## Notes

This is a focused first fix. It does not try to solve MCP churn, compaction strategy, or tool-result payload size.