### PR TITLE
fix(tui): default composer_arrows_scroll to true on Windows (#1255)

### DIFF
--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -1567,7 +1567,7 @@ impl App {
                 .tui
                 .as_ref()
                 .and_then(|tui| tui.composer_arrows_scroll)
-                .unwrap_or(!use_mouse_capture),
+                .unwrap_or(cfg!(windows) || !use_mouse_capture),
         }
     }
 

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -4815,6 +4815,7 @@ fn composer_arrows_scroll_defaults_true_without_mouse_capture() {
 }
 
 #[test]
+#[cfg(not(windows))]
 fn composer_arrows_scroll_defaults_false_with_mouse_capture() {
     let options = TuiOptions {
         use_mouse_capture: true,
@@ -4824,6 +4825,23 @@ fn composer_arrows_scroll_defaults_false_with_mouse_capture() {
     assert!(
         !app.composer_arrows_scroll,
         "arrows-scroll must default to false when mouse capture is on"
+    );
+}
+
+// #1255: on Windows mouse capture may be enabled but the terminal still
+// maps wheel events to arrow keys, so arrows-scroll defaults on there
+// regardless of mouse-capture state.
+#[test]
+#[cfg(windows)]
+fn composer_arrows_scroll_defaults_true_with_mouse_capture_on_windows() {
+    let options = TuiOptions {
+        use_mouse_capture: true,
+        ..create_test_options()
+    };
+    let app = App::new(options, &Config::default());
+    assert!(
+        app.composer_arrows_scroll,
+        "arrows-scroll must default to true on Windows even when mouse capture is on"
     );
 }
 


### PR DESCRIPTION
On Windows terminals (including Windows Terminal) mouse-wheel events are often mapped to arrow-key sequences rather than delivered as crossterm MouseEventKind::ScrollUp/ScrollDown. The existing fallback only enabled composer_arrows_scroll when mouse_capture was off, but on Windows Terminal mouse_capture defaults to on because WT_SESSION is set. This left Win10 users unable to scroll the transcript with the mouse wheel.

This PR defaults composer_arrows_scroll to true on Windows regardless of the mouse-capture flag so that wheel-mapped arrow keys scroll the transcript instead of cycling input history.