### PR TITLE
fix(cache): reduce DeepSeek tool-result replay tail

### DIFF
--- a/crates/tui/src/client/chat.rs
+++ b/crates/tui/src/client/chat.rs
@@ -494,6 +494,13 @@ pub(crate) const CACHE_WARMUP_USER_TAIL: &str = "请只回复 OK";
 const TOOL_RESULT_SENT_CHAR_BUDGET: usize = 12_000;
 const TOOL_RESULT_HEAD_CHARS: usize = 4_000;
 const TOOL_RESULT_TAIL_CHARS: usize = 4_000;
+const STALE_TOOL_RESULT_HISTORY_WINDOW: usize = 1;
+const STALE_TOOL_RESULT_SENT_CHAR_BUDGET: usize = 4_000;
+const STALE_TOOL_RESULT_HEAD_CHARS: usize = 1_500;
+const STALE_TOOL_RESULT_TAIL_CHARS: usize = 900;
+const STALE_READ_FILE_TOOL_RESULT_SENT_CHAR_BUDGET: usize = 2_500;
+const STALE_READ_FILE_TOOL_RESULT_HEAD_CHARS: usize = 1_200;
+const STALE_READ_FILE_TOOL_RESULT_TAIL_CHARS: usize = 400;
 /// Tool results shorter than this stay inline even when repeated. The
 /// extra prompt bytes are cheaper than forcing the model through an
 /// unnecessary retrieval hop for tiny command outputs.
@@ -834,6 +841,58 @@ struct WireToolResult {
     deduplicated: bool,
 }
 
+#[derive(Clone, Copy)]
+struct ToolReplayLimits {
+    sent_char_budget: usize,
+    head_chars: usize,
+    tail_chars: usize,
+}
+
+fn tool_result_replay_limits(tool_name: &str, age_from_end: usize) -> ToolReplayLimits {
+    let is_stale = age_from_end >= STALE_TOOL_RESULT_HISTORY_WINDOW;
+    if !is_stale {
+        return ToolReplayLimits {
+            sent_char_budget: TOOL_RESULT_SENT_CHAR_BUDGET,
+            head_chars: TOOL_RESULT_HEAD_CHARS,
+            tail_chars: TOOL_RESULT_TAIL_CHARS,
+        };
+    }
+
+    if matches!(tool_name, "read_file") {
+        return ToolReplayLimits {
+            sent_char_budget: STALE_READ_FILE_TOOL_RESULT_SENT_CHAR_BUDGET,
+            head_chars: STALE_READ_FILE_TOOL_RESULT_HEAD_CHARS,
+            tail_chars: STALE_READ_FILE_TOOL_RESULT_TAIL_CHARS,
+        };
+    }
+
+    if matches!(
+        tool_name,
+        "shell_command"
+            | "exec_shell"
+            | "exec_shell_wait"
+            | "exec_shell_interact"
+            | "exec_wait"
+            | "exec_interact"
+            | "run_tests"
+            | "fetch_url"
+            | "multi_tool_use.parallel"
+            | "web_search"
+    ) {
+        return ToolReplayLimits {
+            sent_char_budget: STALE_TOOL_RESULT_SENT_CHAR_BUDGET,
+            head_chars: STALE_TOOL_RESULT_HEAD_CHARS,
+            tail_chars: STALE_TOOL_RESULT_TAIL_CHARS,
+        };
+    }
+
+    ToolReplayLimits {
+        sent_char_budget: TOOL_RESULT_SENT_CHAR_BUDGET,
+        head_chars: TOOL_RESULT_HEAD_CHARS,
+        tail_chars: TOOL_RESULT_TAIL_CHARS,
+    }
+}
+
 #[derive(Clone)]
 struct TurnMetaBudget {
     original_chars: usize,
@@ -901,6 +960,7 @@ fn compact_tool_result_for_wire(
     input: &Value,
     content: &str,
     message_label: &str,
+    age_from_end: usize,
     seen_tool_results: &mut HashMap<String, SeenToolResult>,
 ) -> WireToolResult {
     let original_chars = content.chars().count();
@@ -955,7 +1015,9 @@ fn compact_tool_result_for_wire(
         }
     }
 
-    if original_chars <= TOOL_RESULT_SENT_CHAR_BUDGET {
+    let limits = tool_result_replay_limits(tool_name, age_from_end);
+
+    if original_chars <= limits.sent_char_budget {
         return WireToolResult {
             content: content.to_string(),
             original_chars,
@@ -965,8 +1027,8 @@ fn compact_tool_result_for_wire(
         };
     }
 
-    let head = first_chars(content, TOOL_RESULT_HEAD_CHARS);
-    let tail = last_chars(content, TOOL_RESULT_TAIL_CHARS);
+    let head = first_chars(content, limits.head_chars);
+    let tail = last_chars(content, limits.tail_chars);
     let kept = head.chars().count() + tail.chars().count();
     let omitted = original_chars.saturating_sub(kept);
     let compacted = format!(
@@ -1056,6 +1118,17 @@ fn build_chat_messages_with_reasoning(
     let mut pending_tool_calls: HashMap<String, PendingToolCallInfo> = HashMap::new();
     let mut seen_tool_results: HashMap<String, SeenToolResult> = HashMap::new();
     let mut last_full_turn_meta: Option<LastFullTurnMeta> = None;
+    let total_tool_results: usize = messages
+        .iter()
+        .map(|message| {
+            message
+                .content
+                .iter()
+                .filter(|block| matches!(block, ContentBlock::ToolResult { .. }))
+                .count()
+        })
+        .sum();
+    let mut emitted_tool_results: usize = 0;
 
     if let Some(instructions) = system_to_instructions(system.cloned())
         && !instructions.trim().is_empty()
@@ -1218,13 +1291,17 @@ fn build_chat_messages_with_reasoning(
             } else {
                 for (tool_id, content, message_label) in tool_results {
                     if let Some(tool_info) = pending_tool_calls.remove(&tool_id) {
+                        let age_from_end = total_tool_results
+                            .saturating_sub(emitted_tool_results.saturating_add(1));
                         let wire_result = compact_tool_result_for_wire(
                             &tool_info.tool_name,
                             &tool_info.input,
                             &content,
                             &message_label,
+                            age_from_end,
                             &mut seen_tool_results,
                         );
+                        emitted_tool_results = emitted_tool_results.saturating_add(1);
                         let mut tool_msg = json!({
                             "role": "tool",
                             "tool_call_id": tool_id,
@@ -2666,6 +2743,112 @@ mod stream_decoder_tests {
             ContentBlock::ToolResult { content, .. } => assert_eq!(content, &long_output),
             other => panic!("expected tool result, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn request_builder_compacts_stale_read_file_replays_more_than_recent_ones() {
+        let old_output = format!(
+            "<file path=\"src/old.rs\" total_lines=\"800\" shown_lines=\"1-200\" truncated=\"true\" next_start_line=\"201\">\n{}\n[TRUNCATED] Showing lines 1-200 of 800. To continue, call read_file with path=\"src/old.rs\" start_line=201 max_lines=200\n</file>",
+            "A".repeat(14_000)
+        );
+        let recent_output = format!(
+            "<file path=\"src/new.rs\" total_lines=\"800\" shown_lines=\"1-200\" truncated=\"true\" next_start_line=\"201\">\n{}\n[TRUNCATED] Showing lines 1-200 of 800. To continue, call read_file with path=\"src/new.rs\" start_line=201 max_lines=200\n</file>",
+            "B".repeat(14_000)
+        );
+        let messages = vec![
+            tool_use_message("tool-old", "read_file", json!({"path": "src/old.rs"})),
+            tool_result_message("tool-old", &old_output),
+            Message {
+                role: "assistant".to_string(),
+                content: vec![ContentBlock::Text {
+                    text: "Observed old file window".to_string(),
+                    cache_control: None,
+                }],
+            },
+            Message {
+                role: "user".to_string(),
+                content: vec![ContentBlock::Text {
+                    text: "Open the current file now".to_string(),
+                    cache_control: None,
+                }],
+            },
+            tool_use_message("tool-new", "read_file", json!({"path": "src/new.rs"})),
+            tool_result_message("tool-new", &recent_output),
+        ];
+
+        let built = build_chat_messages(None, &messages, "deepseek-v4-flash");
+        let stale_sent = tool_message_content(&built, 0);
+        let recent_sent = tool_message_content(&built, 1);
+
+        assert!(
+            stale_sent.len() < recent_sent.len(),
+            "stale read_file replay should be slimmer than the recent one\nstale={}\nrecent={}",
+            stale_sent.len(),
+            recent_sent.len()
+        );
+        assert!(
+            stale_sent.contains("src/old.rs"),
+            "stale replay should still keep the file identity: {stale_sent}"
+        );
+    }
+
+    #[test]
+    fn request_builder_compacts_stale_shell_replays_more_than_recent_ones() {
+        let old_output = format!(
+            "{}\n{}\n{}",
+            "A".repeat(7_000),
+            "mid".repeat(800),
+            "Z".repeat(7_000)
+        );
+        let recent_output = format!(
+            "{}\n{}\n{}",
+            "B".repeat(7_000),
+            "new".repeat(800),
+            "Y".repeat(7_000)
+        );
+        let messages = vec![
+            tool_use_message(
+                "tool-old",
+                "shell_command",
+                json!({"command": "cargo test --lib"}),
+            ),
+            tool_result_message("tool-old", &old_output),
+            Message {
+                role: "assistant".to_string(),
+                content: vec![ContentBlock::Text {
+                    text: "Older test output noted".to_string(),
+                    cache_control: None,
+                }],
+            },
+            Message {
+                role: "user".to_string(),
+                content: vec![ContentBlock::Text {
+                    text: "Run the tests again".to_string(),
+                    cache_control: None,
+                }],
+            },
+            tool_use_message(
+                "tool-new",
+                "shell_command",
+                json!({"command": "cargo test --lib"}),
+            ),
+            tool_result_message("tool-new", &recent_output),
+        ];
+
+        let built = build_chat_messages(None, &messages, "deepseek-v4-flash");
+        let stale_sent = tool_message_content(&built, 0);
+        let recent_sent = tool_message_content(&built, 1);
+
+        assert!(
+            stale_sent.len() < recent_sent.len(),
+            "stale shell replay should be slimmer than the recent one\nstale={}\nrecent={}",
+            stale_sent.len(),
+            recent_sent.len()
+        );
+        assert!(
+            stale_sent.contains("cargo test --lib"),
+            "stale shell replay should still keep the command: {stale_sent}"
+        );
     }
 
     #[test]

--- a/crates/tui/src/client/chat.rs
+++ b/crates/tui/src/client/chat.rs
@@ -494,7 +494,6 @@ pub(crate) const CACHE_WARMUP_USER_TAIL: &str = "请只回复 OK";
 const TOOL_RESULT_SENT_CHAR_BUDGET: usize = 12_000;
 const TOOL_RESULT_HEAD_CHARS: usize = 4_000;
 const TOOL_RESULT_TAIL_CHARS: usize = 4_000;
-const STALE_TOOL_RESULT_HISTORY_WINDOW: usize = 1;
 const STALE_TOOL_RESULT_SENT_CHAR_BUDGET: usize = 4_000;
 const STALE_TOOL_RESULT_HEAD_CHARS: usize = 1_500;
 const STALE_TOOL_RESULT_TAIL_CHARS: usize = 900;
@@ -848,8 +847,7 @@ struct ToolReplayLimits {
     tail_chars: usize,
 }
 
-fn tool_result_replay_limits(tool_name: &str, age_from_end: usize) -> ToolReplayLimits {
-    let is_stale = age_from_end >= STALE_TOOL_RESULT_HISTORY_WINDOW;
+fn tool_result_replay_limits(tool_name: &str, is_stale: bool) -> ToolReplayLimits {
     if !is_stale {
         return ToolReplayLimits {
             sent_char_budget: TOOL_RESULT_SENT_CHAR_BUDGET,
@@ -866,30 +864,10 @@ fn tool_result_replay_limits(tool_name: &str, age_from_end: usize) -> ToolReplay
         };
     }
 
-    if matches!(
-        tool_name,
-        "shell_command"
-            | "exec_shell"
-            | "exec_shell_wait"
-            | "exec_shell_interact"
-            | "exec_wait"
-            | "exec_interact"
-            | "run_tests"
-            | "fetch_url"
-            | "multi_tool_use.parallel"
-            | "web_search"
-    ) {
-        return ToolReplayLimits {
-            sent_char_budget: STALE_TOOL_RESULT_SENT_CHAR_BUDGET,
-            head_chars: STALE_TOOL_RESULT_HEAD_CHARS,
-            tail_chars: STALE_TOOL_RESULT_TAIL_CHARS,
-        };
-    }
-
     ToolReplayLimits {
-        sent_char_budget: TOOL_RESULT_SENT_CHAR_BUDGET,
-        head_chars: TOOL_RESULT_HEAD_CHARS,
-        tail_chars: TOOL_RESULT_TAIL_CHARS,
+        sent_char_budget: STALE_TOOL_RESULT_SENT_CHAR_BUDGET,
+        head_chars: STALE_TOOL_RESULT_HEAD_CHARS,
+        tail_chars: STALE_TOOL_RESULT_TAIL_CHARS,
     }
 }
 
@@ -960,7 +938,7 @@ fn compact_tool_result_for_wire(
     input: &Value,
     content: &str,
     message_label: &str,
-    age_from_end: usize,
+    is_stale: bool,
     seen_tool_results: &mut HashMap<String, SeenToolResult>,
 ) -> WireToolResult {
     let original_chars = content.chars().count();
@@ -1015,7 +993,7 @@ fn compact_tool_result_for_wire(
         }
     }
 
-    let limits = tool_result_replay_limits(tool_name, age_from_end);
+    let limits = tool_result_replay_limits(tool_name, is_stale);
 
     if original_chars <= limits.sent_char_budget {
         return WireToolResult {
@@ -1118,17 +1096,9 @@ fn build_chat_messages_with_reasoning(
     let mut pending_tool_calls: HashMap<String, PendingToolCallInfo> = HashMap::new();
     let mut seen_tool_results: HashMap<String, SeenToolResult> = HashMap::new();
     let mut last_full_turn_meta: Option<LastFullTurnMeta> = None;
-    let total_tool_results: usize = messages
+    let last_assistant_index = messages
         .iter()
-        .map(|message| {
-            message
-                .content
-                .iter()
-                .filter(|block| matches!(block, ContentBlock::ToolResult { .. }))
-                .count()
-        })
-        .sum();
-    let mut emitted_tool_results: usize = 0;
+        .rposition(|message| message.role.as_str() == "assistant");
 
     if let Some(instructions) = system_to_instructions(system.cloned())
         && !instructions.trim().is_empty()
@@ -1291,17 +1261,16 @@ fn build_chat_messages_with_reasoning(
             } else {
                 for (tool_id, content, message_label) in tool_results {
                     if let Some(tool_info) = pending_tool_calls.remove(&tool_id) {
-                        let age_from_end = total_tool_results
-                            .saturating_sub(emitted_tool_results.saturating_add(1));
+                        let is_stale =
+                            last_assistant_index.is_some_and(|last_idx| message_index < last_idx);
                         let wire_result = compact_tool_result_for_wire(
                             &tool_info.tool_name,
                             &tool_info.input,
                             &content,
                             &message_label,
-                            age_from_end,
+                            is_stale,
                             &mut seen_tool_results,
                         );
-                        emitted_tool_results = emitted_tool_results.saturating_add(1);
                         let mut tool_msg = json!({
                             "role": "tool",
                             "tool_call_id": tool_id,
@@ -2849,6 +2818,68 @@ mod stream_decoder_tests {
             stale_sent.contains("cargo test --lib"),
             "stale shell replay should still keep the command: {stale_sent}"
         );
+    }
+
+    #[test]
+    fn request_builder_keeps_parallel_current_turn_tool_results_fresh() {
+        let first_output = format!(
+            "{}\n{}\n{}",
+            "A".repeat(7_000),
+            "mid".repeat(800),
+            "Z".repeat(7_000)
+        );
+        let second_output = format!(
+            "{}\n{}\n{}",
+            "B".repeat(7_000),
+            "new".repeat(800),
+            "Y".repeat(7_000)
+        );
+        let messages = vec![
+            Message {
+                role: "assistant".to_string(),
+                content: vec![
+                    ContentBlock::ToolUse {
+                        id: "tool-1".to_string(),
+                        name: "shell_command".to_string(),
+                        input: json!({"command": "cargo test --lib"}),
+                        caller: None,
+                    },
+                    ContentBlock::ToolUse {
+                        id: "tool-2".to_string(),
+                        name: "shell_command".to_string(),
+                        input: json!({"command": "cargo test --lib"}),
+                        caller: None,
+                    },
+                ],
+            },
+            tool_result_message("tool-1", &first_output),
+            tool_result_message("tool-2", &second_output),
+        ];
+
+        let built = build_chat_messages(None, &messages, "deepseek-v4-flash");
+        let first_sent = tool_message_content(&built, 0);
+        let second_sent = tool_message_content(&built, 1);
+
+        assert_eq!(
+            first_sent.len(),
+            second_sent.len(),
+            "parallel tool results in the active turn should stay on the same fresh replay budget\nfirst={}\nsecond={}",
+            first_sent.len(),
+            second_sent.len()
+        );
+        assert!(
+            first_sent.len() > STALE_TOOL_RESULT_SENT_CHAR_BUDGET,
+            "active-turn tool result unexpectedly fell onto stale compaction budget: {}",
+            first_sent.len()
+        );
+    }
+
+    #[test]
+    fn stale_unknown_tool_results_use_compact_default_budget() {
+        let limits = tool_result_replay_limits("custom_large_output_tool", true);
+        assert_eq!(limits.sent_char_budget, STALE_TOOL_RESULT_SENT_CHAR_BUDGET);
+        assert_eq!(limits.head_chars, STALE_TOOL_RESULT_HEAD_CHARS);
+        assert_eq!(limits.tail_chars, STALE_TOOL_RESULT_TAIL_CHARS);
     }
 
     #[test]

--- a/crates/tui/src/core/engine/context.rs
+++ b/crates/tui/src/core/engine/context.rs
@@ -53,11 +53,11 @@ const TOOL_RESULT_CONTEXT_SOFT_LIMIT_CHARS: usize = 2_000;
 /// Snippet length kept when compacting tool output for model context.
 const TOOL_RESULT_CONTEXT_SNIPPET_CHARS: usize = 900;
 /// Hard cap for tool output inserted into a large-context model.
-const LARGE_CONTEXT_TOOL_RESULT_HARD_LIMIT_CHARS: usize = 180_000;
+const LARGE_CONTEXT_TOOL_RESULT_HARD_LIMIT_CHARS: usize = 96_000;
 /// Soft cap for known noisy tools inserted into a large-context model.
-const LARGE_CONTEXT_TOOL_RESULT_SOFT_LIMIT_CHARS: usize = 60_000;
+const LARGE_CONTEXT_TOOL_RESULT_SOFT_LIMIT_CHARS: usize = 24_000;
 /// Snippet length kept when compacting large-context tool output.
-const LARGE_CONTEXT_TOOL_RESULT_SNIPPET_CHARS: usize = 40_000;
+const LARGE_CONTEXT_TOOL_RESULT_SNIPPET_CHARS: usize = 12_000;
 /// Context window size at which tool output limits can be relaxed.
 const LARGE_CONTEXT_WINDOW_TOKENS: u32 = 500_000;
 /// Max chars to keep from metadata-provided output summaries.
@@ -109,9 +109,11 @@ fn summarize_text_head_tail(text: &str, limit: usize) -> String {
 fn tool_result_is_noisy(tool_name: &str) -> bool {
     matches!(
         tool_name,
-        "exec_shell"
+        "read_file"
+            | "exec_shell"
             | "exec_shell_wait"
             | "exec_shell_interact"
+            | "fetch_url"
             | "multi_tool_use.parallel"
             | "web_search"
     )

--- a/crates/tui/src/core/engine/context.rs
+++ b/crates/tui/src/core/engine/context.rs
@@ -110,9 +110,13 @@ fn tool_result_is_noisy(tool_name: &str) -> bool {
     matches!(
         tool_name,
         "read_file"
+            | "shell_command"
             | "exec_shell"
             | "exec_shell_wait"
             | "exec_shell_interact"
+            | "exec_wait"
+            | "exec_interact"
+            | "run_tests"
             | "fetch_url"
             | "multi_tool_use.parallel"
             | "web_search"

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -810,6 +810,20 @@ fn v4_large_tool_outputs_are_compacted_before_they_bloat_tail() {
 }
 
 #[test]
+fn v4_large_shell_outputs_use_noisy_compaction_limits() {
+    let content = "0123456789abcdef\n".repeat(1_800);
+    let output = ToolResult::success(content.clone());
+
+    let v4_context = compact_tool_result_for_context("deepseek-v4-pro", "shell_command", &output);
+    assert!(
+        v4_context.contains("output compacted to protect context"),
+        "large shell output should be compacted with noisy-tool limits: {}",
+        &v4_context[..v4_context.len().min(300)]
+    );
+    assert!(v4_context.len() < content.len());
+}
+
+#[test]
 fn subagent_results_are_summarized_before_parent_context_insertion() {
     let long_result = "verified detail\n".repeat(1_000);
     let output = ToolResult::success(

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -796,17 +796,17 @@ fn internal_context_budget_unaffected_by_api_request_cap() {
 }
 
 #[test]
-fn v4_tool_outputs_keep_large_file_reads_in_context() {
-    let content = "0123456789abcdef\n".repeat(2_000);
+fn v4_large_tool_outputs_are_compacted_before_they_bloat_tail() {
+    let content = "0123456789abcdef\n".repeat(5_000);
     let output = ToolResult::success(content.clone());
 
-    let v4_context = compact_tool_result_for_context("deepseek-v4-pro", "exec_shell", &output);
-    assert_eq!(v4_context, content.trim());
-
-    let legacy_context =
-        compact_tool_result_for_context("deepseek-v3.2-128k", "exec_shell", &output);
-    assert!(legacy_context.contains("output compacted to protect context"));
-    assert!(legacy_context.len() < v4_context.len());
+    let v4_context = compact_tool_result_for_context("deepseek-v4-pro", "read_file", &output);
+    assert!(
+        v4_context.contains("output compacted to protect context"),
+        "large V4 tool output should now be compacted: {}",
+        &v4_context[..v4_context.len().min(300)]
+    );
+    assert!(v4_context.len() < content.len());
 }
 
 #[test]

--- a/crates/tui/src/tools/file.rs
+++ b/crates/tui/src/tools/file.rs
@@ -100,7 +100,16 @@ impl ToolSpec for ReadFileTool {
         // explicit range — otherwise an explicit `start_line = 5` on a
         // tiny file would silently ignore the request.
         if !explicit_range && total_lines <= SMALL_FILE_LINES && total_bytes <= SMALL_FILE_BYTES {
-            return Ok(ToolResult::success(contents));
+            return Ok(
+                ToolResult::success(contents).with_metadata(read_file_result_metadata(
+                    path_str,
+                    total_lines,
+                    (total_lines > 0).then_some((1, total_lines)),
+                    false,
+                    None,
+                    format!("Read {path_str} (full file, {total_lines} lines)"),
+                )),
+            );
         }
 
         let start_line = match input.get("start_line").and_then(Value::as_u64) {
@@ -133,7 +142,16 @@ impl ToolSpec for ReadFileTool {
                  [NO CONTENT] start_line {start_line} is beyond total_lines {total_lines}.\n\
                  </file>"
             );
-            return Ok(ToolResult::success(output));
+            return Ok(ToolResult::success(output).with_metadata(read_file_result_metadata(
+                path_str,
+                total_lines,
+                None,
+                false,
+                None,
+                format!(
+                    "Read {path_str}: start_line {start_line} is beyond total_lines {total_lines}"
+                ),
+            )));
         }
 
         let lines: Vec<&str> = contents.lines().collect();
@@ -184,8 +202,51 @@ impl ToolSpec for ReadFileTool {
         }
         output.push_str("</file>");
 
-        Ok(ToolResult::success(output))
+        let summary = if truncated_by_lines {
+            format!(
+                "Read {path_str} lines {shown_first}-{shown_last} of {total_lines}; next_start_line={next_start}"
+            )
+        } else {
+            format!("Read {path_str} lines {shown_first}-{shown_last} of {total_lines}")
+        };
+
+        Ok(
+            ToolResult::success(output).with_metadata(read_file_result_metadata(
+                path_str,
+                total_lines,
+                Some((shown_first, shown_last)),
+                truncated,
+                truncated_by_lines.then_some(next_start),
+                summary,
+            )),
+        )
     }
+}
+
+fn read_file_result_metadata(
+    path: &str,
+    total_lines: usize,
+    shown_lines: Option<(usize, usize)>,
+    truncated: bool,
+    next_start_line: Option<usize>,
+    summary: String,
+) -> Value {
+    let mut obj = serde_json::Map::new();
+    obj.insert("summary".to_string(), Value::String(summary));
+    obj.insert("path".to_string(), Value::String(path.to_string()));
+    obj.insert("total_lines".to_string(), json!(total_lines));
+    obj.insert(
+        "shown_lines".to_string(),
+        Value::String(match shown_lines {
+            Some((start, end)) => format!("{start}-{end}"),
+            None => "none".to_string(),
+        }),
+    );
+    obj.insert("truncated".to_string(), json!(truncated));
+    if let Some(next_start_line) = next_start_line {
+        obj.insert("next_start_line".to_string(), json!(next_start_line));
+    }
+    Value::Object(obj)
 }
 
 /// Detect a PDF by extension OR by sniffing the `%PDF-` magic bytes.
@@ -862,6 +923,22 @@ mod tests {
             "lines past max_lines must be excluded"
         );
         assert!(result.content.contains("truncated=\"true\""));
+        let metadata = result
+            .metadata
+            .as_ref()
+            .expect("range results should stamp replay metadata");
+        assert_eq!(
+            metadata.get("path").and_then(Value::as_str),
+            Some("ranged.txt")
+        );
+        assert_eq!(
+            metadata.get("shown_lines").and_then(Value::as_str),
+            Some("3-6")
+        );
+        assert_eq!(
+            metadata.get("truncated").and_then(Value::as_bool),
+            Some(true)
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

DeepSeek's prompt cache helps only on the repeated prefix. Once that prefix hits, a large stale tool-result tail still lands in `prompt_cache_miss_tokens` and can dominate prompt cost. DeepSeek-TUI was replaying older `read_file`, shell, parallel, and web tool results with the same broad wire budget used for fresh results, so later turns kept carrying unnecessarily large uncached tails.

This patch makes stale tool-result replay tool-aware:

- keep the most recent tool result readable
- replay older `read_file` results with a much smaller window
- replay older shell / parallel / web results with a smaller budget than fresh ones
- stamp `read_file` outputs with stable replay metadata
- tighten large-context compaction thresholds for noisy, re-readable tool outputs

## What changed

- `crates/tui/src/client/chat.rs`
  - add stale-vs-fresh replay budgets
  - make `read_file` the tightest stale replay profile
  - keep the existing larger budget for fresh tool results
- `crates/tui/src/core/engine/context.rs`
  - lower large-context hard/soft/snippet limits
  - classify `read_file`, `fetch_url`, `web_search`, and `multi_tool_use.parallel` as noisy
- `crates/tui/src/tools/file.rs`
  - add replay metadata (`path`, `shown_lines`, `truncated`, etc.) to `read_file`

## Why

DeepSeek's official KV cache docs say:

- prompt caching is enabled by default
- responses report `prompt_cache_hit_tokens` and `prompt_cache_miss_tokens`
- later requests hit only when they reuse a repeated prefix
- matching happens on complete cache prefix units

Source:
- <https://api-docs.deepseek.com/zh-cn/guides/kv_cache>

Claude Code's official docs point at the same principle from the other side:

- tool definitions are deferred or loaded on demand
- users are encouraged to manage context proactively

Sources:
- <https://code.claude.com/docs/en/how-claude-code-works>
- <https://code.claude.com/docs/en/costs>

The practical implication for DeepSeek-TUI is that even if prefix hit rate is good, stale replay width still matters because it shows up in the uncached tail.

## Validation

### Rust verification

- `cargo fmt --all`
- `cargo test -p deepseek-tui --bin deepseek-tui request_builder_compacts_stale_ -- --nocapture`
- `cargo test -p deepseek-tui --bin deepseek-tui read_file_explicit_range_wraps_in_file_tag_with_one_based_lines -- --nocapture`
- `cargo test -p deepseek-tui --bin deepseek-tui v4_large_tool_outputs_are_compacted_before_they_bloat_tail -- --nocapture`
- `cargo test -p deepseek-tui --bin deepseek-tui request_builder_truncates_large_tool_result_for_wire -- --nocapture`
- `cargo test -p deepseek-tui --bin deepseek-tui cache_inspect_reports_tool_result_budget_metadata -- --nocapture`
- `cargo test -p deepseek-tui --bin deepseek-tui read_file_large_file_without_range_uses_default_window -- --nocapture`
- `cargo build -p deepseek-tui`

### DeepSeek API cache reproduction

Using the official Chat Completions API with the same warmed prefix in both cases:

- Old wide stale tail
  - `prompt_tokens = 15273`
  - `cached_tokens = 10240`
  - `prompt_cache_hit_tokens = 10240`
  - `prompt_cache_miss_tokens = 5033`
- New slim stale tail
  - `prompt_tokens = 11349`
  - `cached_tokens = 10240`
  - `prompt_cache_hit_tokens = 10240`
  - `prompt_cache_miss_tokens = 1109`

Delta on the repeated request:

- `3924` fewer prompt tokens
- `3924` fewer miss tokens
- identical cached prefix reuse in both cases

## Notes

- This is a focused replay-tail fix, not a full history-compaction redesign.
- It does not try to solve MCP churn, reasoning replay cost, or every long-session context problem in one PR.