### PR TITLE
[codex] Add configurable theme color overrides

### DIFF
--- a/crates/tui/src/commands/config.rs
+++ b/crates/tui/src/commands/config.rs
@@ -422,9 +422,10 @@ pub fn set_config_value(app: &mut App, key: &str, value: &str, persist: bool) ->
             app.needs_redraw = true;
         }
         "theme" | "ui_theme" | "background_color" | "background" | "bg" => {
-            app.ui_theme = crate::palette::ui_theme_from_settings(
+            app.ui_theme = crate::palette::ui_theme_from_settings_with_overrides(
                 &settings.theme,
                 settings.background_color.as_deref(),
+                &settings.theme_colors.as_overrides(),
             );
             app.needs_redraw = true;
         }
@@ -482,6 +483,14 @@ pub fn set_config_value(app: &mut App, key: &str, value: &str, persist: bool) ->
         "sidebar_focus" | "focus" => {
             app.set_sidebar_focus(SidebarFocus::from_setting(&settings.sidebar_focus));
         }
+        _ if Settings::is_theme_color_key(&key) => {
+            app.ui_theme = crate::palette::ui_theme_from_settings_with_overrides(
+                &settings.theme,
+                settings.background_color.as_deref(),
+                &settings.theme_colors.as_overrides(),
+            );
+            app.needs_redraw = true;
+        }
         _ => {}
     }
 
@@ -493,6 +502,7 @@ pub fn set_config_value(app: &mut App, key: &str, value: &str, persist: bool) ->
             .background_color
             .clone()
             .unwrap_or_else(|| "default".to_string()),
+        _ if Settings::is_theme_color_key(&key) => value.to_string(),
         _ => value.to_string(),
     };
 
@@ -598,10 +608,12 @@ pub fn theme(app: &mut App, arg: Option<&str>) -> CommandResult {
         },
     };
 
-    let background = Settings::load()
-        .ok()
-        .and_then(|settings| settings.background_color);
-    app.ui_theme = crate::palette::ui_theme_from_settings(requested, background.as_deref());
+    let settings = Settings::load().unwrap_or_default();
+    app.ui_theme = crate::palette::ui_theme_from_settings_with_overrides(
+        requested,
+        settings.background_color.as_deref(),
+        &settings.theme_colors.as_overrides(),
+    );
     app.needs_redraw = true;
 
     let label = crate::palette::theme_label_for_mode(app.ui_theme.mode);

--- a/crates/tui/src/config_ui.rs
+++ b/crates/tui/src/config_ui.rs
@@ -13,7 +13,7 @@ use serde_json::Value;
 use crate::commands;
 use crate::config::{Config, StatusItem, normalize_model_name};
 use crate::localization::{normalize_configured_locale, resolve_locale};
-use crate::settings::Settings;
+use crate::settings::{Settings, ThemeColorSettings};
 use crate::tui::app::{
     App, AppMode, ComposerDensity, ReasoningEffort, SidebarFocus, TranscriptSpacing,
 };
@@ -58,11 +58,17 @@ pub struct SettingsSection {
     pub show_thinking: bool,
     pub show_tool_details: bool,
     pub locale: UiLocale,
+    pub theme: ThemeValue,
     #[schemars(
         title = "Background color",
         description = "Main TUI background color as #RRGGBB"
     )]
     pub background_color: Option<String>,
+    #[schemars(
+        title = "Theme color overrides",
+        description = "Optional semantic theme colors as #RRGGBB. Leave empty to use the selected preset."
+    )]
+    pub theme_colors: ThemeColorSettings,
     pub composer_density: ComposerDensityValue,
     pub composer_border: bool,
     pub transcript_spacing: TranscriptSpacingValue,
@@ -162,6 +168,15 @@ pub enum UiLocale {
     #[serde(rename = "pt-BR")]
     #[schemars(rename = "pt-BR")]
     PtBr,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ThemeValue {
+    System,
+    Dark,
+    Light,
+    Grayscale,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -281,7 +296,9 @@ pub fn build_document(app: &App, config: &Config) -> Result<ConfigUiDocument> {
             show_thinking: settings.show_thinking,
             show_tool_details: settings.show_tool_details,
             locale: UiLocale::from_setting(&settings.locale)?,
+            theme: ThemeValue::from_setting(&settings.theme)?,
             background_color: settings.background_color.clone(),
+            theme_colors: settings.theme_colors.clone(),
             composer_density: settings.composer_density.as_str().into(),
             composer_border: settings.composer_border,
             transcript_spacing: settings.transcript_spacing.as_str().into(),
@@ -439,6 +456,7 @@ pub fn apply_document(
             bool_str(doc.settings.show_tool_details),
         ),
         ("locale", doc.settings.locale.as_setting()),
+        ("theme", doc.settings.theme.as_setting()),
         (
             "background_color",
             doc.settings
@@ -473,6 +491,21 @@ pub fn apply_document(
                 result
                     .message
                     .unwrap_or_else(|| "config update failed".to_string())
+            );
+        }
+        if let Some(message) = result.message {
+            notes.push(message);
+        }
+    }
+
+    for (key, value) in theme_color_update_values(&doc.settings.theme_colors) {
+        let result = commands::set_config_value(app, key, value, persist);
+        if result.is_error {
+            bail!(
+                "{}",
+                result
+                    .message
+                    .unwrap_or_else(|| "theme color update failed".to_string())
             );
         }
         if let Some(message) = result.message {
@@ -636,6 +669,60 @@ fn parse_status_items(items: &[StatusItemValue]) -> Vec<StatusItem> {
     items.iter().copied().map(Into::into).collect()
 }
 
+fn theme_color_update_values(colors: &ThemeColorSettings) -> Vec<(&'static str, &str)> {
+    vec![
+        ("theme_colors.surface", colors.surface.as_deref().unwrap_or("default")),
+        ("theme_colors.panel", colors.panel.as_deref().unwrap_or("default")),
+        (
+            "theme_colors.elevated",
+            colors.elevated.as_deref().unwrap_or("default"),
+        ),
+        (
+            "theme_colors.composer",
+            colors.composer.as_deref().unwrap_or("default"),
+        ),
+        (
+            "theme_colors.selection",
+            colors.selection.as_deref().unwrap_or("default"),
+        ),
+        ("theme_colors.header", colors.header.as_deref().unwrap_or("default")),
+        ("theme_colors.footer", colors.footer.as_deref().unwrap_or("default")),
+        (
+            "theme_colors.mode_agent",
+            colors.mode_agent.as_deref().unwrap_or("default"),
+        ),
+        (
+            "theme_colors.mode_yolo",
+            colors.mode_yolo.as_deref().unwrap_or("default"),
+        ),
+        (
+            "theme_colors.mode_plan",
+            colors.mode_plan.as_deref().unwrap_or("default"),
+        ),
+        (
+            "theme_colors.status_ready",
+            colors.status_ready.as_deref().unwrap_or("default"),
+        ),
+        (
+            "theme_colors.status_working",
+            colors.status_working.as_deref().unwrap_or("default"),
+        ),
+        (
+            "theme_colors.status_warning",
+            colors.status_warning.as_deref().unwrap_or("default"),
+        ),
+        ("theme_colors.text_dim", colors.text_dim.as_deref().unwrap_or("default")),
+        ("theme_colors.text_hint", colors.text_hint.as_deref().unwrap_or("default")),
+        (
+            "theme_colors.text_muted",
+            colors.text_muted.as_deref().unwrap_or("default"),
+        ),
+        ("theme_colors.text_body", colors.text_body.as_deref().unwrap_or("default")),
+        ("theme_colors.text_soft", colors.text_soft.as_deref().unwrap_or("default")),
+        ("theme_colors.border", colors.border.as_deref().unwrap_or("default")),
+    ]
+}
+
 impl ApprovalModeValue {
     fn as_setting(self) -> &'static str {
         match self {
@@ -666,6 +753,28 @@ impl UiLocale {
             Some("pt-BR") => Ok(Self::PtBr),
             Some(other) => bail!("unsupported locale '{other}'"),
             None => bail!("invalid locale '{value}'"),
+        }
+    }
+}
+
+impl ThemeValue {
+    fn as_setting(self) -> &'static str {
+        match self {
+            Self::System => "system",
+            Self::Dark => "dark",
+            Self::Light => "light",
+            Self::Grayscale => "grayscale",
+        }
+    }
+
+    fn from_setting(value: &str) -> Result<Self> {
+        match crate::palette::normalize_theme_name(value) {
+            Some("system") => Ok(Self::System),
+            Some("dark") => Ok(Self::Dark),
+            Some("light") => Ok(Self::Light),
+            Some("grayscale") => Ok(Self::Grayscale),
+            Some(other) => bail!("unsupported theme '{other}'"),
+            None => bail!("invalid theme '{value}'"),
         }
     }
 }
@@ -1027,6 +1136,57 @@ background_color = "#1A1B26"
     }
 
     #[test]
+    fn build_document_reflects_theme_and_color_overrides_from_settings() {
+        let _lock = lock_test_env();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let temp_root = std::env::temp_dir().join(format!(
+            "deepseek-config-ui-theme-colors-{}-{}",
+            std::process::id(),
+            nanos
+        ));
+        fs::create_dir_all(temp_root.join(".deepseek")).expect("config dir");
+        let config_path = temp_root.join(".deepseek").join("config.toml");
+        fs::write(&config_path, "").expect("seed config");
+        fs::write(
+            temp_root.join(".deepseek").join("settings.toml"),
+            r##"
+theme = "grayscale"
+
+[theme_colors]
+panel = "#202124"
+text_body = "F8F8F2"
+"##,
+        )
+        .expect("seed settings");
+
+        let old_config_path = std::env::var_os("DEEPSEEK_CONFIG_PATH");
+        unsafe {
+            std::env::set_var("DEEPSEEK_CONFIG_PATH", &config_path);
+        }
+
+        let app = app();
+        let config = Config::default();
+        let doc = build_document(&app, &config).expect("document");
+
+        assert_eq!(doc.settings.theme, ThemeValue::Grayscale);
+        assert_eq!(doc.settings.theme_colors.panel.as_deref(), Some("#202124"));
+        assert_eq!(
+            doc.settings.theme_colors.text_body.as_deref(),
+            Some("#f8f8f2")
+        );
+        unsafe {
+            if let Some(value) = old_config_path {
+                std::env::set_var("DEEPSEEK_CONFIG_PATH", value);
+            } else {
+                std::env::remove_var("DEEPSEEK_CONFIG_PATH");
+            }
+        }
+    }
+
+    #[test]
     fn schema_contains_typed_enums() {
         let schema = build_schema();
         let approval_mode = &schema["$defs"]["ApprovalModeValue"]["enum"];
@@ -1038,6 +1198,11 @@ background_color = "#1A1B26"
         assert_eq!(
             locale,
             &serde_json::json!(["auto", "en", "ja", "zh-Hans", "pt-BR"])
+        );
+        let theme = &schema["$defs"]["ThemeValue"]["enum"];
+        assert_eq!(
+            theme,
+            &serde_json::json!(["system", "dark", "light", "grayscale"])
         );
     }
 

--- a/crates/tui/src/config_ui.rs
+++ b/crates/tui/src/config_ui.rs
@@ -442,46 +442,6 @@ pub fn apply_document(
     for (key, value) in [
         ("model", doc.runtime.model.as_str()),
         ("approval_mode", doc.runtime.approval_mode.as_setting()),
-        ("auto_compact", bool_str(doc.settings.auto_compact)),
-        ("calm_mode", bool_str(doc.settings.calm_mode)),
-        ("low_motion", bool_str(doc.settings.low_motion)),
-        ("fancy_animations", bool_str(doc.settings.fancy_animations)),
-        (
-            "paste_burst_detection",
-            bool_str(doc.settings.paste_burst_detection),
-        ),
-        ("show_thinking", bool_str(doc.settings.show_thinking)),
-        (
-            "show_tool_details",
-            bool_str(doc.settings.show_tool_details),
-        ),
-        ("locale", doc.settings.locale.as_setting()),
-        ("theme", doc.settings.theme.as_setting()),
-        (
-            "background_color",
-            doc.settings
-                .background_color
-                .as_deref()
-                .unwrap_or("default"),
-        ),
-        (
-            "composer_density",
-            doc.settings.composer_density.as_setting(),
-        ),
-        ("composer_border", bool_str(doc.settings.composer_border)),
-        (
-            "transcript_spacing",
-            doc.settings.transcript_spacing.as_setting(),
-        ),
-        (
-            "status_indicator",
-            doc.settings.status_indicator.as_setting(),
-        ),
-        ("default_mode", doc.settings.default_mode.as_setting()),
-        ("sidebar_width", &doc.settings.sidebar_width.to_string()),
-        ("sidebar_focus", doc.settings.sidebar_focus.as_setting()),
-        ("max_history", &doc.settings.max_history.to_string()),
-        ("cost_currency", doc.settings.cost_currency.as_setting()),
         ("mcp_config_path", doc.config.mcp_config_path.as_str()),
     ] {
         let result = commands::set_config_value(app, key, value, persist);
@@ -498,39 +458,7 @@ pub fn apply_document(
         }
     }
 
-    for (key, value) in theme_color_update_values(&doc.settings.theme_colors) {
-        let result = commands::set_config_value(app, key, value, persist);
-        if result.is_error {
-            bail!(
-                "{}",
-                result
-                    .message
-                    .unwrap_or_else(|| "theme color update failed".to_string())
-            );
-        }
-        if let Some(message) = result.message {
-            notes.push(message);
-        }
-    }
-
-    // default_model is only applied when persisting (it controls the model
-    // for future sessions).  Processing it in the main loop would overwrite
-    // the runtime model the user just chose when persist=false (#346-fix).
-    if persist {
-        let default_model_val = doc.settings.default_model.as_deref().unwrap_or("default");
-        let result = commands::set_config_value(app, "default_model", default_model_val, true);
-        if result.is_error {
-            bail!(
-                "{}",
-                result
-                    .message
-                    .unwrap_or_else(|| "default_model update failed".to_string())
-            );
-        }
-        if let Some(message) = result.message {
-            notes.push(message);
-        }
-    }
+    apply_settings_document(&doc, app, persist, &mut notes)?;
 
     apply_reasoning_effort(app, config, doc.config.reasoning_effort, persist)?;
     let requires_engine_sync = app.compaction_config() != previous_compaction
@@ -567,6 +495,143 @@ pub fn apply_document(
         final_message,
         requires_engine_sync,
     })
+}
+
+fn apply_settings_document(
+    doc: &ConfigUiDocument,
+    app: &mut App,
+    persist: bool,
+    notes: &mut Vec<String>,
+) -> Result<()> {
+    let mut settings = match Settings::load() {
+        Ok(settings) => settings,
+        Err(err) if !persist => {
+            app.status_message = Some(format!(
+                "Settings unavailable; applying session-only override ({err})"
+            ));
+            Settings::default()
+        }
+        Err(err) => bail!("Failed to load settings: {err}"),
+    };
+
+    let sidebar_width = doc.settings.sidebar_width.to_string();
+    let max_history = doc.settings.max_history.to_string();
+    for (key, value) in [
+        ("auto_compact", bool_str(doc.settings.auto_compact)),
+        ("calm_mode", bool_str(doc.settings.calm_mode)),
+        ("low_motion", bool_str(doc.settings.low_motion)),
+        ("fancy_animations", bool_str(doc.settings.fancy_animations)),
+        (
+            "paste_burst_detection",
+            bool_str(doc.settings.paste_burst_detection),
+        ),
+        ("show_thinking", bool_str(doc.settings.show_thinking)),
+        (
+            "show_tool_details",
+            bool_str(doc.settings.show_tool_details),
+        ),
+        ("locale", doc.settings.locale.as_setting()),
+        ("theme", doc.settings.theme.as_setting()),
+        (
+            "background_color",
+            doc.settings
+                .background_color
+                .as_deref()
+                .unwrap_or("default"),
+        ),
+        (
+            "composer_density",
+            doc.settings.composer_density.as_setting(),
+        ),
+        ("composer_border", bool_str(doc.settings.composer_border)),
+        (
+            "transcript_spacing",
+            doc.settings.transcript_spacing.as_setting(),
+        ),
+        (
+            "status_indicator",
+            doc.settings.status_indicator.as_setting(),
+        ),
+        ("default_mode", doc.settings.default_mode.as_setting()),
+        ("sidebar_width", sidebar_width.as_str()),
+        ("sidebar_focus", doc.settings.sidebar_focus.as_setting()),
+        ("max_history", max_history.as_str()),
+        ("cost_currency", doc.settings.cost_currency.as_setting()),
+    ] {
+        settings
+            .set(key, value)
+            .with_context(|| format!("config update failed for {key}"))?;
+    }
+
+    for (key, value) in theme_color_update_values(&doc.settings.theme_colors) {
+        settings
+            .set(key, value)
+            .with_context(|| format!("theme color update failed for {key}"))?;
+    }
+
+    // default_model is only applied when persisting (it controls the model
+    // for future sessions). Applying it session-only would overwrite the
+    // runtime model the user just chose when persist=false (#346-fix).
+    if persist {
+        settings
+            .set(
+                "default_model",
+                doc.settings.default_model.as_deref().unwrap_or("default"),
+            )
+            .context("default_model update failed")?;
+        settings.save().context("Failed to save settings")?;
+        notes.push("Settings saved".to_string());
+    } else {
+        notes.push("Settings updated for this session".to_string());
+    }
+
+    sync_app_settings(app, &settings, persist);
+    Ok(())
+}
+
+fn sync_app_settings(app: &mut App, settings: &Settings, include_default_model: bool) {
+    app.auto_compact = settings.auto_compact;
+    app.calm_mode = settings.calm_mode;
+    app.low_motion = settings.low_motion;
+    app.fancy_animations = settings.fancy_animations;
+    app.use_paste_burst_detection = settings.paste_burst_detection;
+    if !app.use_paste_burst_detection {
+        app.paste_burst.clear_after_explicit_paste();
+    }
+    app.show_thinking = settings.show_thinking;
+    app.show_tool_details = settings.show_tool_details;
+    app.ui_locale = resolve_locale(&settings.locale);
+    app.ui_theme = crate::palette::ui_theme_from_settings_with_overrides(
+        &settings.theme,
+        settings.background_color.as_deref(),
+        &settings.theme_colors.as_overrides(),
+    );
+    app.cost_currency = crate::pricing::CostCurrency::from_setting(&settings.cost_currency)
+        .unwrap_or(crate::pricing::CostCurrency::Usd);
+    app.composer_density = ComposerDensity::from_setting(&settings.composer_density);
+    app.composer_border = settings.composer_border;
+    app.transcript_spacing = TranscriptSpacing::from_setting(&settings.transcript_spacing);
+    app.status_indicator = settings.status_indicator.clone();
+    app.set_mode(AppMode::from_setting(&settings.default_mode));
+    app.max_input_history = settings.max_input_history;
+    app.sidebar_width_percent = settings.sidebar_width_percent;
+    app.set_sidebar_focus(SidebarFocus::from_setting(&settings.sidebar_focus));
+
+    if include_default_model && let Some(ref model) = settings.default_model {
+        app.auto_model = model.trim().eq_ignore_ascii_case("auto");
+        app.model.clone_from(model);
+        app.last_effective_model = None;
+        if app.auto_model {
+            app.reasoning_effort = ReasoningEffort::Auto;
+            app.last_effective_reasoning_effort = None;
+        }
+        app.update_model_compaction_budget();
+        app.session.last_prompt_tokens = None;
+        app.session.last_completion_tokens = None;
+    }
+
+    app.mark_history_updated();
+    app.needs_redraw = true;
 }
 
 pub fn parse_document(value: Value) -> Result<ConfigUiDocument> {

--- a/crates/tui/src/palette.rs
+++ b/crates/tui/src/palette.rs
@@ -185,7 +185,7 @@ pub const TEXT_HINT: Color = Color::Rgb(135, 151, 171); // #8797AB
 pub const TEXT_ACCENT: Color = DEEPSEEK_SKY;
 pub const SELECTION_TEXT: Color = Color::White;
 pub const TEXT_SOFT: Color = Color::Rgb(217, 226, 238); // #D9E2EE
-pub const TEXT_REASONING: Color = Color::Rgb(211, 170, 112); // #D3AA70
+pub const TEXT_REASONING: Color = Color::Rgb(186, 199, 215); // #BAC7D7
 
 // Compatibility aliases for existing call sites.
 pub const TEXT_PRIMARY: Color = TEXT_BODY;
@@ -209,10 +209,10 @@ pub const STATUS_NEUTRAL: Color = Color::Rgb(160, 160, 160); // #A0A0A0
 pub const SURFACE_PANEL: Color = Color::Rgb(21, 33, 52); // #152134
 #[allow(dead_code)]
 pub const SURFACE_ELEVATED: Color = Color::Rgb(28, 42, 64); // #1C2A40
-pub const SURFACE_REASONING: Color = Color::Rgb(54, 44, 26); // #362C1A
-pub const SURFACE_REASONING_TINT: Color = Color::Rgb(16, 24, 37); // #101825
+pub const SURFACE_REASONING: Color = Color::Rgb(20, 32, 50); // #142032
+pub const SURFACE_REASONING_TINT: Color = Color::Rgb(12, 22, 39); // #0C1627
 #[allow(dead_code)]
-pub const SURFACE_REASONING_ACTIVE: Color = Color::Rgb(68, 53, 28); // #44351C
+pub const SURFACE_REASONING_ACTIVE: Color = Color::Rgb(29, 48, 73); // #1D3049
 #[allow(dead_code)]
 pub const SURFACE_TOOL: Color = Color::Rgb(24, 39, 60); // #18273C
 #[allow(dead_code)]
@@ -224,7 +224,7 @@ pub const SURFACE_ERROR: Color = Color::Rgb(63, 27, 36); // #3F1B24
 pub const DIFF_ADDED_BG: Color = Color::Rgb(18, 52, 38); // #123426 dark green tint
 pub const DIFF_DELETED_BG: Color = Color::Rgb(52, 22, 28); // #34161C dark red tint
 pub const DIFF_ADDED: Color = Color::Rgb(87, 199, 133); // #57C785
-pub const ACCENT_REASONING_LIVE: Color = Color::Rgb(224, 153, 72); // #E09948
+pub const ACCENT_REASONING_LIVE: Color = Color::Rgb(133, 184, 234); // #85B8EA
 pub const ACCENT_TOOL_LIVE: Color = Color::Rgb(133, 184, 234); // #85B8EA
 pub const ACCENT_TOOL_ISSUE: Color = Color::Rgb(192, 143, 153); // #C08F99
 pub const TEXT_TOOL_OUTPUT: Color = Color::Rgb(191, 205, 220); // #BFCEDC
@@ -301,6 +301,29 @@ pub struct UiTheme {
     pub text_body: Color,
     pub text_soft: Color,
     pub border: Color,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct UiThemeColorOverrides<'a> {
+    pub surface_bg: Option<&'a str>,
+    pub panel_bg: Option<&'a str>,
+    pub elevated_bg: Option<&'a str>,
+    pub composer_bg: Option<&'a str>,
+    pub selection_bg: Option<&'a str>,
+    pub header_bg: Option<&'a str>,
+    pub footer_bg: Option<&'a str>,
+    pub mode_agent: Option<&'a str>,
+    pub mode_yolo: Option<&'a str>,
+    pub mode_plan: Option<&'a str>,
+    pub status_ready: Option<&'a str>,
+    pub status_working: Option<&'a str>,
+    pub status_warning: Option<&'a str>,
+    pub text_dim: Option<&'a str>,
+    pub text_hint: Option<&'a str>,
+    pub text_muted: Option<&'a str>,
+    pub text_body: Option<&'a str>,
+    pub text_soft: Option<&'a str>,
+    pub border: Option<&'a str>,
 }
 
 pub const UI_THEME: UiTheme = UiTheme {
@@ -408,6 +431,30 @@ impl UiTheme {
         self.footer_bg = color;
         self
     }
+
+    #[must_use]
+    pub fn with_color_overrides(mut self, overrides: &UiThemeColorOverrides<'_>) -> Self {
+        apply_optional_color(&mut self.surface_bg, overrides.surface_bg);
+        apply_optional_color(&mut self.panel_bg, overrides.panel_bg);
+        apply_optional_color(&mut self.elevated_bg, overrides.elevated_bg);
+        apply_optional_color(&mut self.composer_bg, overrides.composer_bg);
+        apply_optional_color(&mut self.selection_bg, overrides.selection_bg);
+        apply_optional_color(&mut self.header_bg, overrides.header_bg);
+        apply_optional_color(&mut self.footer_bg, overrides.footer_bg);
+        apply_optional_color(&mut self.mode_agent, overrides.mode_agent);
+        apply_optional_color(&mut self.mode_yolo, overrides.mode_yolo);
+        apply_optional_color(&mut self.mode_plan, overrides.mode_plan);
+        apply_optional_color(&mut self.status_ready, overrides.status_ready);
+        apply_optional_color(&mut self.status_working, overrides.status_working);
+        apply_optional_color(&mut self.status_warning, overrides.status_warning);
+        apply_optional_color(&mut self.text_dim, overrides.text_dim);
+        apply_optional_color(&mut self.text_hint, overrides.text_hint);
+        apply_optional_color(&mut self.text_muted, overrides.text_muted);
+        apply_optional_color(&mut self.text_body, overrides.text_body);
+        apply_optional_color(&mut self.text_soft, overrides.text_soft);
+        apply_optional_color(&mut self.border, overrides.border);
+        self
+    }
 }
 
 #[must_use]
@@ -433,11 +480,26 @@ pub fn theme_label_for_mode(mode: PaletteMode) -> &'static str {
 
 #[must_use]
 pub fn ui_theme_from_settings(theme: &str, background_color: Option<&str>) -> UiTheme {
+    ui_theme_from_settings_with_overrides(theme, background_color, &UiThemeColorOverrides::default())
+}
+
+#[must_use]
+pub fn ui_theme_from_settings_with_overrides(
+    theme: &str,
+    background_color: Option<&str>,
+    overrides: &UiThemeColorOverrides<'_>,
+) -> UiTheme {
     let mut ui_theme = UiTheme::from_setting(theme).unwrap_or_else(UiTheme::detect);
     if let Some(background) = background_color.and_then(parse_hex_rgb_color) {
         ui_theme = ui_theme.with_background_color(background);
     }
-    ui_theme
+    ui_theme.with_color_overrides(overrides)
+}
+
+fn apply_optional_color(slot: &mut Color, value: Option<&str>) {
+    if let Some(color) = value.and_then(parse_hex_rgb_color) {
+        *slot = color;
+    }
 }
 
 #[must_use]
@@ -497,8 +559,10 @@ fn adapt_fg_for_light_palette(color: Color) -> Color {
         LIGHT_BORDER
     } else if color == TEXT_ACCENT || color == DEEPSEEK_SKY || color == ACCENT_TOOL_LIVE {
         DEEPSEEK_BLUE
-    } else if color == TEXT_REASONING || color == ACCENT_REASONING_LIVE {
-        Color::Rgb(146, 64, 14)
+    } else if color == TEXT_REASONING {
+        LIGHT_TEXT_MUTED
+    } else if color == ACCENT_REASONING_LIVE {
+        DEEPSEEK_BLUE
     } else if color == ACCENT_TOOL_ISSUE {
         Color::Rgb(159, 18, 57)
     } else if color == DIFF_ADDED {
@@ -948,10 +1012,11 @@ mod tests {
         GRAYSCALE_UI_THEME, LIGHT_BORDER, LIGHT_ELEVATED, LIGHT_PANEL, LIGHT_REASONING,
         LIGHT_SURFACE, LIGHT_TEXT_BODY, LIGHT_TEXT_HINT, LIGHT_UI_THEME, PaletteMode,
         SURFACE_REASONING, SURFACE_REASONING_TINT, TEXT_BODY, TEXT_HINT, TEXT_REASONING,
-        TEXT_TOOL_OUTPUT, UI_THEME, adapt_bg, adapt_bg_for_palette_mode, adapt_color,
-        adapt_fg_for_palette_mode, blend, nearest_ansi16, normalize_hex_rgb_color,
+        TEXT_TOOL_OUTPUT, UI_THEME, UiThemeColorOverrides, adapt_bg, adapt_bg_for_palette_mode,
+        adapt_color, adapt_fg_for_palette_mode, blend, nearest_ansi16, normalize_hex_rgb_color,
         normalize_theme_name, parse_hex_rgb_color, pulse_brightness, reasoning_surface_tint,
         rgb_to_ansi256, theme_label_for_mode, ui_theme_from_settings,
+        ui_theme_from_settings_with_overrides,
     };
     use ratatui::style::Color;
 
@@ -1008,10 +1073,10 @@ mod tests {
     }
 
     #[test]
-    fn dark_palette_uses_soft_body_text_and_warm_reasoning() {
+    fn dark_palette_uses_soft_body_text_and_calm_reasoning() {
         assert_eq!(TEXT_BODY, Color::Rgb(226, 232, 240));
-        assert_eq!(TEXT_REASONING, Color::Rgb(211, 170, 112));
-        assert_eq!(ACCENT_REASONING_LIVE, Color::Rgb(224, 153, 72));
+        assert_eq!(TEXT_REASONING, Color::Rgb(186, 199, 215));
+        assert_eq!(ACCENT_REASONING_LIVE, Color::Rgb(133, 184, 234));
         assert_ne!(TEXT_REASONING, TEXT_TOOL_OUTPUT);
         assert_ne!(TEXT_BODY, Color::White);
     }
@@ -1100,6 +1165,24 @@ mod tests {
         assert_eq!(theme.panel_bg, GRAYSCALE_PANEL);
         assert_eq!(theme.elevated_bg, GRAYSCALE_ELEVATED);
         assert_eq!(theme.border, GRAYSCALE_BORDER);
+    }
+
+    #[test]
+    fn ui_theme_from_settings_applies_custom_color_overrides() {
+        let overrides = UiThemeColorOverrides {
+            panel_bg: Some("#202124"),
+            text_body: Some("#f8f8f2"),
+            status_warning: Some("#ffb86c"),
+            border: Some("#6272a4"),
+            ..UiThemeColorOverrides::default()
+        };
+        let theme = ui_theme_from_settings_with_overrides("dark", Some("#101010"), &overrides);
+
+        assert_eq!(theme.surface_bg, Color::Rgb(16, 16, 16));
+        assert_eq!(theme.panel_bg, Color::Rgb(32, 33, 36));
+        assert_eq!(theme.text_body, Color::Rgb(248, 248, 242));
+        assert_eq!(theme.status_warning, Color::Rgb(255, 184, 108));
+        assert_eq!(theme.border, Color::Rgb(98, 114, 164));
     }
 
     #[test]

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -8,11 +8,12 @@
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::config::{expand_path, normalize_model_name};
 use crate::localization::normalize_configured_locale;
-use crate::palette::{normalize_hex_rgb_color, normalize_theme_name};
+use crate::palette::{UiThemeColorOverrides, normalize_hex_rgb_color, normalize_theme_name};
 
 // ============================================================================
 // TuiPrefs — ~/.deepseek/tui.toml
@@ -84,6 +85,145 @@ pub struct KeybindPrefs {
     /// Key to toggle the sidebar.
     /// Default: `"ctrl+b"`.
     pub toggle_sidebar: Option<String>,
+}
+
+/// Optional semantic colour overrides for the active TUI theme.
+///
+/// Each value accepts `#RRGGBB`, `RRGGBB`, or `default`/`none` to clear it.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(default)]
+pub struct ThemeColorSettings {
+    pub surface: Option<String>,
+    pub panel: Option<String>,
+    pub elevated: Option<String>,
+    pub composer: Option<String>,
+    pub selection: Option<String>,
+    pub header: Option<String>,
+    pub footer: Option<String>,
+    pub mode_agent: Option<String>,
+    pub mode_yolo: Option<String>,
+    pub mode_plan: Option<String>,
+    pub status_ready: Option<String>,
+    pub status_working: Option<String>,
+    pub status_warning: Option<String>,
+    pub text_dim: Option<String>,
+    pub text_hint: Option<String>,
+    pub text_muted: Option<String>,
+    pub text_body: Option<String>,
+    pub text_soft: Option<String>,
+    pub border: Option<String>,
+}
+
+impl ThemeColorSettings {
+    pub fn normalize(&mut self) {
+        self.surface = normalize_optional_hex_color(self.surface.as_deref());
+        self.panel = normalize_optional_hex_color(self.panel.as_deref());
+        self.elevated = normalize_optional_hex_color(self.elevated.as_deref());
+        self.composer = normalize_optional_hex_color(self.composer.as_deref());
+        self.selection = normalize_optional_hex_color(self.selection.as_deref());
+        self.header = normalize_optional_hex_color(self.header.as_deref());
+        self.footer = normalize_optional_hex_color(self.footer.as_deref());
+        self.mode_agent = normalize_optional_hex_color(self.mode_agent.as_deref());
+        self.mode_yolo = normalize_optional_hex_color(self.mode_yolo.as_deref());
+        self.mode_plan = normalize_optional_hex_color(self.mode_plan.as_deref());
+        self.status_ready = normalize_optional_hex_color(self.status_ready.as_deref());
+        self.status_working = normalize_optional_hex_color(self.status_working.as_deref());
+        self.status_warning = normalize_optional_hex_color(self.status_warning.as_deref());
+        self.text_dim = normalize_optional_hex_color(self.text_dim.as_deref());
+        self.text_hint = normalize_optional_hex_color(self.text_hint.as_deref());
+        self.text_muted = normalize_optional_hex_color(self.text_muted.as_deref());
+        self.text_body = normalize_optional_hex_color(self.text_body.as_deref());
+        self.text_soft = normalize_optional_hex_color(self.text_soft.as_deref());
+        self.border = normalize_optional_hex_color(self.border.as_deref());
+    }
+
+    pub fn as_overrides(&self) -> UiThemeColorOverrides<'_> {
+        UiThemeColorOverrides {
+            surface_bg: self.surface.as_deref(),
+            panel_bg: self.panel.as_deref(),
+            elevated_bg: self.elevated.as_deref(),
+            composer_bg: self.composer.as_deref(),
+            selection_bg: self.selection.as_deref(),
+            header_bg: self.header.as_deref(),
+            footer_bg: self.footer.as_deref(),
+            mode_agent: self.mode_agent.as_deref(),
+            mode_yolo: self.mode_yolo.as_deref(),
+            mode_plan: self.mode_plan.as_deref(),
+            status_ready: self.status_ready.as_deref(),
+            status_working: self.status_working.as_deref(),
+            status_warning: self.status_warning.as_deref(),
+            text_dim: self.text_dim.as_deref(),
+            text_hint: self.text_hint.as_deref(),
+            text_muted: self.text_muted.as_deref(),
+            text_body: self.text_body.as_deref(),
+            text_soft: self.text_soft.as_deref(),
+            border: self.border.as_deref(),
+        }
+    }
+
+    fn set_slot(&mut self, slot: ThemeColorSlot, value: &str) -> Result<()> {
+        let color = normalize_theme_color_setting(slot.setting_name(), value)?;
+        match slot {
+            ThemeColorSlot::Surface => self.surface = color,
+            ThemeColorSlot::Panel => self.panel = color,
+            ThemeColorSlot::Elevated => self.elevated = color,
+            ThemeColorSlot::Composer => self.composer = color,
+            ThemeColorSlot::Selection => self.selection = color,
+            ThemeColorSlot::Header => self.header = color,
+            ThemeColorSlot::Footer => self.footer = color,
+            ThemeColorSlot::ModeAgent => self.mode_agent = color,
+            ThemeColorSlot::ModeYolo => self.mode_yolo = color,
+            ThemeColorSlot::ModePlan => self.mode_plan = color,
+            ThemeColorSlot::StatusReady => self.status_ready = color,
+            ThemeColorSlot::StatusWorking => self.status_working = color,
+            ThemeColorSlot::StatusWarning => self.status_warning = color,
+            ThemeColorSlot::TextDim => self.text_dim = color,
+            ThemeColorSlot::TextHint => self.text_hint = color,
+            ThemeColorSlot::TextMuted => self.text_muted = color,
+            ThemeColorSlot::TextBody => self.text_body = color,
+            ThemeColorSlot::TextSoft => self.text_soft = color,
+            ThemeColorSlot::Border => self.border = color,
+        }
+        Ok(())
+    }
+
+    fn summary(&self) -> String {
+        let mut parts = Vec::new();
+        for slot in ThemeColorSlot::ALL {
+            if let Some(value) = self.slot_value(slot) {
+                parts.push(format!("{}={value}", slot.setting_name()));
+            }
+        }
+        if parts.is_empty() {
+            "(default)".to_string()
+        } else {
+            parts.join(", ")
+        }
+    }
+
+    fn slot_value(&self, slot: ThemeColorSlot) -> Option<&str> {
+        match slot {
+            ThemeColorSlot::Surface => self.surface.as_deref(),
+            ThemeColorSlot::Panel => self.panel.as_deref(),
+            ThemeColorSlot::Elevated => self.elevated.as_deref(),
+            ThemeColorSlot::Composer => self.composer.as_deref(),
+            ThemeColorSlot::Selection => self.selection.as_deref(),
+            ThemeColorSlot::Header => self.header.as_deref(),
+            ThemeColorSlot::Footer => self.footer.as_deref(),
+            ThemeColorSlot::ModeAgent => self.mode_agent.as_deref(),
+            ThemeColorSlot::ModeYolo => self.mode_yolo.as_deref(),
+            ThemeColorSlot::ModePlan => self.mode_plan.as_deref(),
+            ThemeColorSlot::StatusReady => self.status_ready.as_deref(),
+            ThemeColorSlot::StatusWorking => self.status_working.as_deref(),
+            ThemeColorSlot::StatusWarning => self.status_warning.as_deref(),
+            ThemeColorSlot::TextDim => self.text_dim.as_deref(),
+            ThemeColorSlot::TextHint => self.text_hint.as_deref(),
+            ThemeColorSlot::TextMuted => self.text_muted.as_deref(),
+            ThemeColorSlot::TextBody => self.text_body.as_deref(),
+            ThemeColorSlot::TextSoft => self.text_soft.as_deref(),
+            ThemeColorSlot::Border => self.border.as_deref(),
+        }
+    }
 }
 
 #[allow(dead_code)] // see TuiPrefs note above; deferred to a later settings pass (#657).
@@ -199,6 +339,8 @@ pub struct Settings {
     pub theme: String,
     /// Optional main TUI background color as a 6-digit hex RGB value.
     pub background_color: Option<String>,
+    /// Optional semantic color overrides applied on top of the selected theme.
+    pub theme_colors: ThemeColorSettings,
     /// Composer layout density: compact, comfortable, spacious
     pub composer_density: String,
     /// Show a border around the composer input area
@@ -291,6 +433,7 @@ impl Default for Settings {
             locale: "auto".to_string(),
             theme: "system".to_string(),
             background_color: None,
+            theme_colors: ThemeColorSettings::default(),
             composer_density: "comfortable".to_string(),
             composer_border: true,
             composer_vim_mode: "normal".to_string(),
@@ -312,6 +455,10 @@ impl Default for Settings {
 }
 
 impl Settings {
+    pub fn is_theme_color_key(key: &str) -> bool {
+        ThemeColorSlot::from_key(key).is_some()
+    }
+
     /// Get the settings file path
     pub fn path() -> Result<PathBuf> {
         // Allow tests to override the settings directory via the same env var
@@ -355,6 +502,7 @@ impl Settings {
                 .to_string();
             s.theme = normalize_settings_theme(&s.theme).to_string();
             s.background_color = normalize_optional_background_color(s.background_color.as_deref());
+            s.theme_colors.normalize();
             s.default_model = s.default_model.as_deref().and_then(normalize_default_model);
             s
         };
@@ -445,6 +593,11 @@ impl Settings {
 
     /// Set a single setting by key
     pub fn set(&mut self, key: &str, value: &str) -> Result<()> {
+        if let Some(slot) = ThemeColorSlot::from_key(key) {
+            self.theme_colors.set_slot(slot, value)?;
+            return Ok(());
+        }
+
         match key {
             "auto_compact" | "compact" => {
                 self.auto_compact = parse_bool(value)?;
@@ -648,6 +801,10 @@ impl Settings {
             "  background_color:   {}",
             self.background_color.as_deref().unwrap_or("(default)")
         ));
+        lines.push(format!(
+            "  theme_colors:       {}",
+            self.theme_colors.summary()
+        ));
         lines.push(format!("  composer_density:   {}", self.composer_density));
         lines.push(format!("  composer_border:    {}", self.composer_border));
         lines.push(format!("  composer_vim_mode:  {}", self.composer_vim_mode));
@@ -717,6 +874,10 @@ impl Settings {
             (
                 "background_color",
                 "Main TUI background color: #RRGGBB or default",
+            ),
+            (
+                "theme_colors.<role>",
+                "Custom theme color override: #RRGGBB or default (roles: surface, panel, elevated, composer, selection, header, footer, mode_agent, mode_yolo, mode_plan, status_ready, status_working, status_warning, text_dim, text_hint, text_muted, text_body, text_soft, border)",
             ),
             (
                 "composer_density",
@@ -902,6 +1063,131 @@ fn normalize_background_color_setting(value: &str) -> Result<Option<String>> {
     })
 }
 
+fn normalize_optional_hex_color(value: Option<&str>) -> Option<String> {
+    value.and_then(|raw| normalize_theme_color_setting("theme color", raw).ok().flatten())
+}
+
+fn normalize_theme_color_setting(setting: &str, value: &str) -> Result<Option<String>> {
+    let trimmed = value.trim();
+    if trimmed.is_empty()
+        || matches!(
+            trimmed.to_ascii_lowercase().as_str(),
+            "default" | "none" | "reset" | "off"
+        )
+    {
+        return Ok(None);
+    }
+    normalize_hex_rgb_color(trimmed).map(Some).ok_or_else(|| {
+        anyhow::anyhow!(
+            "Failed to update setting: invalid {setting} '{value}'. Expected #RRGGBB, RRGGBB, or default."
+        )
+    })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ThemeColorSlot {
+    Surface,
+    Panel,
+    Elevated,
+    Composer,
+    Selection,
+    Header,
+    Footer,
+    ModeAgent,
+    ModeYolo,
+    ModePlan,
+    StatusReady,
+    StatusWorking,
+    StatusWarning,
+    TextDim,
+    TextHint,
+    TextMuted,
+    TextBody,
+    TextSoft,
+    Border,
+}
+
+impl ThemeColorSlot {
+    const ALL: [Self; 19] = [
+        Self::Surface,
+        Self::Panel,
+        Self::Elevated,
+        Self::Composer,
+        Self::Selection,
+        Self::Header,
+        Self::Footer,
+        Self::ModeAgent,
+        Self::ModeYolo,
+        Self::ModePlan,
+        Self::StatusReady,
+        Self::StatusWorking,
+        Self::StatusWarning,
+        Self::TextDim,
+        Self::TextHint,
+        Self::TextMuted,
+        Self::TextBody,
+        Self::TextSoft,
+        Self::Border,
+    ];
+
+    fn from_key(key: &str) -> Option<Self> {
+        let normalized = key.trim().to_ascii_lowercase().replace('-', "_");
+        let role = normalized
+            .strip_prefix("theme_colors.")
+            .or_else(|| normalized.strip_prefix("theme_color."))
+            .or_else(|| normalized.strip_prefix("theme_colors_"))
+            .or_else(|| normalized.strip_prefix("theme_color_"))
+            .or_else(|| normalized.strip_prefix("theme_"))?;
+        let role = role.strip_suffix("_color").unwrap_or(role);
+        match role {
+            "surface" | "surface_bg" | "background" | "background_color" => Some(Self::Surface),
+            "panel" | "panel_bg" => Some(Self::Panel),
+            "elevated" | "elevated_bg" => Some(Self::Elevated),
+            "composer" | "composer_bg" => Some(Self::Composer),
+            "selection" | "selection_bg" => Some(Self::Selection),
+            "header" | "header_bg" => Some(Self::Header),
+            "footer" | "footer_bg" => Some(Self::Footer),
+            "mode_agent" | "agent" => Some(Self::ModeAgent),
+            "mode_yolo" | "yolo" => Some(Self::ModeYolo),
+            "mode_plan" | "plan" => Some(Self::ModePlan),
+            "status_ready" | "ready" => Some(Self::StatusReady),
+            "status_working" | "working" => Some(Self::StatusWorking),
+            "status_warning" | "warning" => Some(Self::StatusWarning),
+            "text_dim" | "dim" => Some(Self::TextDim),
+            "text_hint" | "hint" => Some(Self::TextHint),
+            "text_muted" | "muted" => Some(Self::TextMuted),
+            "text_body" | "body" => Some(Self::TextBody),
+            "text_soft" | "soft" => Some(Self::TextSoft),
+            "border" => Some(Self::Border),
+            _ => None,
+        }
+    }
+
+    fn setting_name(self) -> &'static str {
+        match self {
+            Self::Surface => "surface",
+            Self::Panel => "panel",
+            Self::Elevated => "elevated",
+            Self::Composer => "composer",
+            Self::Selection => "selection",
+            Self::Header => "header",
+            Self::Footer => "footer",
+            Self::ModeAgent => "mode_agent",
+            Self::ModeYolo => "mode_yolo",
+            Self::ModePlan => "mode_plan",
+            Self::StatusReady => "status_ready",
+            Self::StatusWorking => "status_working",
+            Self::StatusWarning => "status_warning",
+            Self::TextDim => "text_dim",
+            Self::TextHint => "text_hint",
+            Self::TextMuted => "text_muted",
+            Self::TextBody => "text_body",
+            Self::TextSoft => "text_soft",
+            Self::Border => "border",
+        }
+    }
+}
+
 fn normalize_sidebar_focus(value: &str) -> &str {
     match value.trim().to_ascii_lowercase().as_str() {
         "work" | "plan" | "todos" => "work",
@@ -1026,6 +1312,35 @@ mod tests {
             .set("background_color", "#123")
             .expect_err("short hex should fail");
         assert!(err.to_string().contains("invalid background_color"));
+    }
+
+    #[test]
+    fn theme_color_overrides_normalize_and_reset() {
+        let mut settings = Settings::default();
+        settings
+            .set("theme_colors.panel", "#202124")
+            .expect("set panel");
+        settings
+            .set("theme_text_body_color", "F8F8F2")
+            .expect("set body");
+
+        assert_eq!(settings.theme_colors.panel.as_deref(), Some("#202124"));
+        assert_eq!(settings.theme_colors.text_body.as_deref(), Some("#f8f8f2"));
+        assert!(Settings::is_theme_color_key("theme_colors.panel"));
+
+        settings
+            .set("theme_colors.panel", "default")
+            .expect("reset panel");
+        assert_eq!(settings.theme_colors.panel, None);
+    }
+
+    #[test]
+    fn theme_color_overrides_reject_invalid_hex() {
+        let mut settings = Settings::default();
+        let err = settings
+            .set("theme_colors.border", "#12")
+            .expect_err("short hex should fail");
+        assert!(err.to_string().contains("invalid border"));
     }
 
     #[test]

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -1259,8 +1259,11 @@ impl App {
         let sidebar_focus = SidebarFocus::from_setting(&settings.sidebar_focus);
         let max_input_history = settings.max_input_history;
         let use_paste_burst_detection = settings.paste_burst_detection;
-        let ui_theme =
-            palette::ui_theme_from_settings(&settings.theme, settings.background_color.as_deref());
+        let ui_theme = palette::ui_theme_from_settings_with_overrides(
+            &settings.theme,
+            settings.background_color.as_deref(),
+            &settings.theme_colors.as_overrides(),
+        );
         let model = settings
             .provider_models
             .as_ref()

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -318,6 +318,13 @@ Common settings keys:
 - `background_color` (`#RRGGBB`, `RRGGBB`, or `default`): optional main TUI
   background color applied to the root, header, transcript, and footer
   surfaces while preserving panel contrast.
+- `[theme_colors]`: optional per-role color overrides layered on top of the
+  selected preset. Each value accepts `#RRGGBB`, `RRGGBB`, or `default`. Roles
+  include `surface`, `panel`, `elevated`, `composer`, `selection`, `header`,
+  `footer`, `mode_agent`, `mode_yolo`, `mode_plan`, `status_ready`,
+  `status_working`, `status_warning`, `text_dim`, `text_hint`, `text_muted`,
+  `text_body`, `text_soft`, and `border`. The same roles can be changed live
+  with `/set theme_colors.<role> #RRGGBB --save`.
 - `cost_currency` (`usd`, `cny`; default `usd`): currency used by the footer,
   context panel, `/cost`, `/tokens`, and long-turn notification summaries. The
   aliases `rmb` and `yuan` normalize to `cny`.


### PR DESCRIPTION
## Summary
- calm the default dark-mode reasoning colors by replacing the warm yellow reasoning text/accent with cooler gray-blue tones
- add `theme_colors` semantic overrides on top of existing `system`, `dark`, `light`, and `grayscale` presets
- expose theme selection and color overrides through the config UI document and document `/set theme_colors.<role> #RRGGBB --save`

Fixes #1528.

## Validation
- `git diff --check`
- Not run: `cargo fmt` / Rust tests, because this environment does not have `cargo` or `rustc` installed.