### PR TITLE
[codex] fix Windows PowerShell flicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Plain Windows PowerShell / ConHost rendering is calmer.** When no modern
+  Windows terminal marker is present (`WT_SESSION`, `TERM_PROGRAM`,
+  `ConEmuPID`, WezTerm/Alacritty markers, etc.), startup now treats the host
+  as flicker-sensitive: `low_motion` is enabled, fancy animations are disabled,
+  and `synchronized_output = "auto"` resolves to off. This avoids the rapid
+  repaint path that makes PowerShell appear to flash during streaming and
+  turn completion while leaving Windows Terminal and other marked hosts on
+  their existing rendering path.
+
 ## [0.8.33] - 2026-05-12
 
 A sub-agent and RLM renovation release. The model-facing delegation

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -2336,6 +2336,13 @@ async fn run_doctor(config: &Config, workspace: &Path, config_path_override: Opt
         );
         any_quirk = true;
     }
+    if crate::settings::detected_legacy_windows_console_host() {
+        println!(
+            "  {} legacy Windows console host -> low_motion + fancy_animations=false + synchronized_output=off (auto)",
+            "-".truecolor(sky_r, sky_g, sky_b)
+        );
+        any_quirk = true;
+    }
     if term_program_lc.contains("ptyxis")
         || std::env::var_os("PTYXIS_VERSION").is_some_and(|v| !v.is_empty())
     {

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -405,6 +405,19 @@ impl Settings {
             self.fancy_animations = false;
         }
 
+        // Legacy Windows console hosts (plain PowerShell / cmd.exe under
+        // ConHost) expose none of the modern terminal markers below. They
+        // repaint full-screen TUI diffs much more visibly than Windows
+        // Terminal / VS Code / WezTerm / Alacritty, so use the same calmer
+        // rendering posture as the other flicker-sensitive environments.
+        if detected_legacy_windows_console_host() {
+            self.low_motion = true;
+            self.fancy_animations = false;
+            if self.synchronized_output.eq_ignore_ascii_case("auto") {
+                self.synchronized_output = "off".to_string();
+            }
+        }
+
         // Ptyxis 50.x (the new default terminal on Ubuntu 26.04) ships with
         // VTE 0.84.x which mishandles DEC mode 2026 synchronized output: the
         // begin/end pair is parsed but each wrapped frame still triggers a
@@ -880,6 +893,47 @@ pub fn detected_ptyxis_terminal() -> bool {
     matches!(std::env::var("PTYXIS_VERSION"), Ok(v) if !v.trim().is_empty())
 }
 
+/// Returns `true` for the unmarked Windows console-host path used by plain
+/// PowerShell / cmd.exe. Modern Windows terminals set at least one marker that
+/// lets us keep their richer rendering path.
+pub fn detected_legacy_windows_console_host() -> bool {
+    cfg!(windows)
+        && legacy_windows_console_host_env(
+            std::env::var_os("WT_SESSION").as_deref(),
+            std::env::var_os("ConEmuPID").as_deref(),
+            std::env::var_os("TERM_PROGRAM").as_deref(),
+            std::env::var_os("WEZTERM_EXECUTABLE").as_deref(),
+            std::env::var_os("WEZTERM_PANE").as_deref(),
+            std::env::var_os("ALACRITTY_WINDOW_ID").as_deref(),
+            std::env::var_os("ANSICON").as_deref(),
+            std::env::var_os("TERM").as_deref(),
+        )
+}
+
+fn legacy_windows_console_host_env(
+    wt_session: Option<&std::ffi::OsStr>,
+    conemu_pid: Option<&std::ffi::OsStr>,
+    term_program: Option<&std::ffi::OsStr>,
+    wezterm_executable: Option<&std::ffi::OsStr>,
+    wezterm_pane: Option<&std::ffi::OsStr>,
+    alacritty_window_id: Option<&std::ffi::OsStr>,
+    ansicon: Option<&std::ffi::OsStr>,
+    term: Option<&std::ffi::OsStr>,
+) -> bool {
+    fn has_value(value: Option<&std::ffi::OsStr>) -> bool {
+        value.is_some_and(|v| !v.is_empty())
+    }
+
+    !has_value(wt_session)
+        && !has_value(conemu_pid)
+        && !has_value(term_program)
+        && !has_value(wezterm_executable)
+        && !has_value(wezterm_pane)
+        && !has_value(alacritty_window_id)
+        && !has_value(ansicon)
+        && !has_value(term)
+}
+
 fn normalize_optional_background_color(value: Option<&str>) -> Option<String> {
     value.and_then(|raw| normalize_background_color_setting(raw).ok().flatten())
 }
@@ -1300,6 +1354,99 @@ mod tests {
             match prev {
                 Some(v) => std::env::set_var("TERM_PROGRAM", v),
                 None => std::env::remove_var("TERM_PROGRAM"),
+            }
+        }
+    }
+
+    #[test]
+    fn legacy_windows_console_host_detects_unmarked_shell() {
+        assert!(legacy_windows_console_host_env(
+            None, None, None, None, None, None, None, None
+        ));
+    }
+
+    #[test]
+    fn legacy_windows_console_host_excludes_modern_terminal_markers() {
+        use std::ffi::OsStr;
+
+        let marker = Some(OsStr::new("1"));
+        assert!(!legacy_windows_console_host_env(
+            marker, None, None, None, None, None, None, None
+        ));
+        assert!(!legacy_windows_console_host_env(
+            None, marker, None, None, None, None, None, None
+        ));
+        assert!(!legacy_windows_console_host_env(
+            None, None, Some(OsStr::new("vscode")), None, None, None, None, None
+        ));
+        assert!(!legacy_windows_console_host_env(
+            None, None, None, marker, None, None, None, None
+        ));
+        assert!(!legacy_windows_console_host_env(
+            None, None, None, None, marker, None, None, None
+        ));
+        assert!(!legacy_windows_console_host_env(
+            None, None, None, None, None, marker, None, None
+        ));
+        assert!(!legacy_windows_console_host_env(
+            None, None, None, None, None, None, marker, None
+        ));
+        assert!(!legacy_windows_console_host_env(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(OsStr::new("xterm-256color"))
+        ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn unmarked_windows_console_forces_calm_rendering() {
+        let _g = term_program_test_guard();
+        let vars = [
+            "WT_SESSION",
+            "ConEmuPID",
+            "TERM_PROGRAM",
+            "WEZTERM_EXECUTABLE",
+            "WEZTERM_PANE",
+            "ALACRITTY_WINDOW_ID",
+            "ANSICON",
+            "TERM",
+            "SSH_CLIENT",
+            "SSH_TTY",
+            "NO_ANIMATIONS",
+            "PTYXIS_VERSION",
+        ];
+        let prev: Vec<_> = vars
+            .iter()
+            .map(|name| (*name, std::env::var_os(name)))
+            .collect();
+        // SAFETY: serialised by the guard.
+        unsafe {
+            for name in vars {
+                std::env::remove_var(name);
+            }
+        }
+
+        let mut settings = Settings::default();
+        assert!(!settings.low_motion, "default is animated");
+        assert_eq!(settings.synchronized_output, "auto");
+        settings.apply_env_overrides();
+        assert!(settings.low_motion);
+        assert!(!settings.fancy_animations);
+        assert_eq!(settings.synchronized_output, "off");
+
+        // SAFETY: cleanup under the guard.
+        unsafe {
+            for (name, value) in prev {
+                match value {
+                    Some(value) => std::env::set_var(name, value),
+                    None => std::env::remove_var(name),
+                }
             }
         }
     }

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -305,16 +305,16 @@ pub async fn run_tui(config: &Config, options: TuiOptions) -> Result<()> {
     let backend = ColorCompatBackend::new(stdout, color_depth, palette_mode);
     let mut terminal = Terminal::new(backend)?;
     // At this point Settings hasn't loaded yet, so we can't read the
-    // user's `synchronized_output` knob. Use the same env-based Ptyxis
-    // detection that `Settings::apply_env_overrides` uses, so the
+    // user's `synchronized_output` knob. Use the same env-based terminal
+    // quirk detection that `Settings::apply_env_overrides` uses, so the
     // startup viewport reset matches what every later draw will do on
-    // this terminal. A user who has explicitly set
-    // `synchronized_output = "on"` to override Ptyxis detection will
-    // get sync wrap from the main draw loop onward; the one-time
-    // startup viewport reset stays opt-out for them, which is the safe
-    // default because the cost is at most brief tearing on the first
-    // frame.
-    let sync_output_at_init = !crate::settings::detected_ptyxis_terminal();
+    // flicker-sensitive hosts. A user who has explicitly set
+    // `synchronized_output = "on"` to override detection will get sync wrap
+    // from the main draw loop onward; the one-time startup viewport reset
+    // stays opt-out for them, which is the safe default because the cost is
+    // at most brief tearing on the first frame.
+    let sync_output_at_init = !crate::settings::detected_ptyxis_terminal()
+        && !crate::settings::detected_legacy_windows_console_host();
     reset_terminal_viewport(&mut terminal, sync_output_at_init)?;
     let event_broker = EventBroker::new();
 


### PR DESCRIPTION
Closes #1590

## Summary
- Detect unmarked legacy Windows console hosts used by plain PowerShell/cmd.
- Auto-enable low_motion, disable fancy animations, and turn synchronized_output auto off for that host class.
- Report the terminal quirk in deepseek doctor.

## Validation
- git diff --check
- Not run: cargo fmt/test unavailable in this Windows environment because cargo is not installed.