### PR TITLE
  fix(ci): avoid caching cargo binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,8 @@ jobs:
           done
           sudo apt-get install -y libdbus-1-dev pkg-config
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
       - name: Check formatting
         run: cargo fmt --all -- --check
       # Mirror the release-workflow `parity` gate exactly. Anything that
@@ -83,6 +85,8 @@ jobs:
           done
           sudo apt-get install -y libdbus-1-dev pkg-config
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
       - name: Run tests
         run: cargo test --workspace --all-features --locked
       - name: Lockfile drift guard
@@ -113,6 +117,8 @@ jobs:
         with:
           node-version: 20
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
       - name: Build wrapper binaries
         run: cargo build --release --locked -p deepseek-tui-cli -p deepseek-tui
       - name: Smoke wrapper install and delegated entrypoints
@@ -136,6 +142,8 @@ jobs:
           done
           sudo apt-get install -y libdbus-1-dev pkg-config
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
       - name: Build docs
         run: cargo doc --workspace --no-deps
         env:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -71,6 +71,8 @@ jobs:
         with:
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
       - name: Install Linux system dependencies
         if: runner.os == 'Linux'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,8 @@ jobs:
           done
           sudo apt-get install -y libdbus-1-dev pkg-config
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
       - name: Format check
         run: cargo fmt --all -- --check
       - name: Compile check
@@ -149,6 +151,8 @@ jobs:
         with:
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
       - name: Install Linux system dependencies
         if: runner.os == 'Linux'
         run: |


### PR DESCRIPTION


## Summary

  Fixes a CI failure where the macOS test job restored `~/.cargo/bin` from `Swatinem/rust-cache`, then `cargo test` invoked the wrong binary and failed with:

  ```text
  unexpected argument 'test' found
  Usage: rustup-init[EXE] [OPTIONS]
```

https://github.com/Hmbown/DeepSeek-TUI/actions/runs/25837894806/job/75916813979?pr=1601

  The workflows do not need to cache installed cargo binaries. This change disables cache-bin for all Rust cache steps while keeping registry, git, and target caching available.

## Testing

- [ ] `cargo test --all-features`
- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
