### PR TITLE
fix(tui): treat absolute paths as prompts

### DIFF
--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -528,6 +528,18 @@ pub const COMMANDS: &[CommandInfo] = &[
     },
 ];
 
+/// Return true when composer input should be routed through slash-command
+/// dispatch. This is intentionally syntactic: unknown command-shaped inputs
+/// such as `/modle` still reach dispatch so the user gets suggestions, while
+/// absolute paths like `/usr/lib/...` remain normal prompt text (#1568).
+pub fn is_command_shaped_input(input: &str) -> bool {
+    let Some(stripped) = input.strip_prefix('/') else {
+        return false;
+    };
+    let command = stripped.split_whitespace().next().unwrap_or("");
+    !command.is_empty() && !command.contains('/') && !command.contains('\\')
+}
+
 /// Execute a slash command
 pub fn execute(cmd: &str, app: &mut App) -> CommandResult {
     let parts: Vec<&str> = cmd.trim().splitn(2, ' ').collect();
@@ -1501,5 +1513,22 @@ mod tests {
             .expect("unknown command should return an error message");
         assert!(msg.contains("Unknown command: /zzzzzz"));
         assert!(msg.contains("Type /help for available commands."));
+    }
+
+    #[test]
+    fn command_shape_keeps_unknown_command_typos_dispatchable() {
+        assert!(is_command_shaped_input("/modle"));
+        assert!(is_command_shaped_input("/help config"));
+        assert!(is_command_shaped_input("/?"));
+        assert!(!is_command_shaped_input(" /help"));
+    }
+
+    #[test]
+    fn command_shape_treats_absolute_paths_as_prompt_text() {
+        assert!(!is_command_shaped_input(
+            "/usr/lib/x86_64-linux-gnu/ is this a standard path?"
+        ));
+        assert!(!is_command_shaped_input("/mnt/c/Users/PC"));
+        assert!(!is_command_shaped_input(r"/mnt\c\Users\PC"));
     }
 }

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -3650,7 +3650,7 @@ impl App {
         // sees the @mention in the composer before submission.
         self.consolidate_large_input_if_oversized();
         let input = self.input.clone();
-        if !input.starts_with('/') {
+        if !crate::commands::is_command_shaped_input(&input) {
             self.input_history.push(input.clone());
             if self.max_input_history == 0 {
                 self.input_history.clear();
@@ -4783,6 +4783,33 @@ mod tests {
 
         // Navigate down
         app.history_down();
+    }
+
+    #[test]
+    fn submit_input_records_absolute_path_prompt_in_history() {
+        let mut app = App::new(test_options(false), &Config::default());
+        app.input_history.clear();
+        let input = "/usr/lib/x86_64-linux-gnu/ is this a standard path?".to_string();
+        app.input = input.clone();
+        app.cursor_position = app.input.chars().count();
+
+        let submitted = app.submit_input().expect("submitted input");
+
+        assert_eq!(submitted, input);
+        assert_eq!(app.input_history, vec![input]);
+    }
+
+    #[test]
+    fn submit_input_keeps_command_shaped_input_out_of_history() {
+        let mut app = App::new(test_options(false), &Config::default());
+        app.input_history.clear();
+        app.input = "/help".to_string();
+        app.cursor_position = app.input.chars().count();
+
+        let submitted = app.submit_input().expect("submitted input");
+
+        assert_eq!(submitted, "/help");
+        assert!(app.input_history.is_empty());
     }
 
     #[test]

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -2956,7 +2956,7 @@ async fn run_event_loop(
                         && !key.modifiers.contains(KeyModifiers::ALT) =>
                 {
                     if let Some(input) = app.submit_input() {
-                        if input.starts_with('/') {
+                        if commands::is_command_shaped_input(&input) {
                             if execute_command_input(
                                 terminal,
                                 app,
@@ -3005,7 +3005,7 @@ async fn run_event_loop(
                 // #382: Ctrl+Enter forces a steer into the current turn.
                 KeyCode::Enter if key.modifiers.contains(KeyModifiers::CONTROL) => {
                     if let Some(input) = app.submit_input() {
-                        if input.starts_with('/') {
+                        if commands::is_command_shaped_input(&input) {
                             if execute_command_input(
                                 terminal,
                                 app,
@@ -3076,7 +3076,7 @@ async fn run_event_loop(
                             handle_memory_quick_add(app, &input, config);
                             continue;
                         }
-                        if input.starts_with('/') {
+                        if commands::is_command_shaped_input(&input) {
                             if execute_command_input(
                                 terminal,
                                 app,


### PR DESCRIPTION
## Summary
- route slash-prefixed inputs with path separators, like `/usr/lib/...`, through the normal prompt path instead of slash-command dispatch
- keep command-shaped unknown inputs like `/modle` dispatchable so the existing suggestion/help flow remains intact
- record absolute-path prompts in composer history while keeping real slash commands out of prompt history

Fixes #1568.

## Validation
- `cargo fmt`
- `cargo test -p deepseek-tui --bin deepseek-tui command_shape --locked`
- `cargo test -p deepseek-tui --bin deepseek-tui submit_input_records_absolute_path_prompt_in_history --locked`
- `cargo test -p deepseek-tui --bin deepseek-tui unknown_command --locked`