### PR TITLE
fix(tui): let ctrl-alt-0 restore hidden sidebar

### DIFF
--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -3384,8 +3384,13 @@ fn apply_alt_4_shortcut(app: &mut App, _modifiers: KeyModifiers) {
 
 fn apply_alt_0_shortcut(app: &mut App, modifiers: KeyModifiers) {
     if modifiers.contains(KeyModifiers::CONTROL) {
-        app.set_sidebar_focus(SidebarFocus::Hidden);
-        app.status_message = Some("Sidebar hidden".to_string());
+        if app.sidebar_focus == SidebarFocus::Hidden {
+            app.set_sidebar_focus(SidebarFocus::Auto);
+            app.status_message = Some("Sidebar focus: auto".to_string());
+        } else {
+            app.set_sidebar_focus(SidebarFocus::Hidden);
+            app.status_message = Some("Sidebar hidden".to_string());
+        }
     } else {
         app.set_sidebar_focus(SidebarFocus::Auto);
         app.status_message = Some("Sidebar focus: auto".to_string());

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -1880,6 +1880,17 @@ fn ctrl_alt_0_hides_sidebar() {
 }
 
 #[test]
+fn ctrl_alt_0_restores_auto_sidebar_when_already_hidden() {
+    let mut app = create_test_app();
+    app.sidebar_focus = SidebarFocus::Hidden;
+
+    apply_alt_0_shortcut(&mut app, KeyModifiers::ALT | KeyModifiers::CONTROL);
+
+    assert_eq!(app.sidebar_focus, SidebarFocus::Auto);
+    assert_eq!(app.status_message.as_deref(), Some("Sidebar focus: auto"));
+}
+
+#[test]
 fn hidden_sidebar_focus_suppresses_sidebar_split_even_when_wide() {
     let mut app = create_test_app();
     app.sidebar_width_percent = 28;


### PR DESCRIPTION
Fixes #1614.

## Summary
- make `Ctrl+Alt+0` restore `auto` focus when the right sidebar is already hidden
- preserve the existing `Ctrl+Alt+0` hide behavior from visible sidebar states
- add a regression test for the hidden-to-auto toggle path

## Verification
- RED: cargo test -p deepseek-tui --bin deepseek-tui --locked ctrl_alt_0_restores_auto_sidebar_when_already_hidden
- cargo fmt --all -- --check
- cargo test -p deepseek-tui --bin deepseek-tui --locked ctrl_alt_0 - 2 tests passed
- cargo clippy -p deepseek-tui --all-targets --all-features --locked -- -D warnings
- git diff --check

## Release Safety
- Review PR only.
- No merge, tag, publish, force-push, or issue closure performed.
