### PR TITLE
fix(tui): keep denied approvals scoped to exact calls

### DIFF
--- a/crates/tui/src/tools/approval_cache.rs
+++ b/crates/tui/src/tools/approval_cache.rs
@@ -10,10 +10,10 @@
 //!
 //! | Tool           | Key                                      |
 //! |---------------|------------------------------------------|
-//! | `apply_patch`  | `patch:<hash of file paths>`             |
-//! | `exec_shell`   | `shell:<command prefix (first 3 tokens)>` |
+//! | file writes    | `file:<tool_name>:<hash of args>`        |
+//! | shell tools    | `shell:<tool_name>:<hash of args>`       |
 //! | `fetch_url`    | `net:<hostname>`                         |
-//! | everything else| `tool:<tool_name>:<hash of input>`       |
+//! | everything else| `tool:<tool_name>:<hash of args>`        |
 //!
 //! The cache is **session‑keyed**: entries carry an
 //! `ApprovedForSession` flag. When true, the approval is reused for the
@@ -21,9 +21,11 @@
 //! calls with the same fingerprint still prompt).
 
 use std::collections::HashMap;
+use std::fmt::Write as _;
 use std::time::Instant;
 
-use crate::command_safety::classify_command;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
 
 /// The fingerprint of a tool call — stable enough to match repeated
 /// calls but specific enough to avoid privilege confusion.
@@ -113,95 +115,30 @@ impl ApprovalCache {
 
 /// Build the approval‑cache key for a tool call.
 ///
-/// The key incorporates the tool name and a lossy digest of the
-/// arguments so that the cache can distinguish `exec_shell "ls"`
-/// from `exec_shell "rm -rf /"` while still recognising repeated
-/// invocations of the same harmless command.
+/// The key incorporates the tool name and a canonical digest of the
+/// arguments so that denying one call only suppresses exact retries, not
+/// later invocations of the same tool with different parameters.
 #[must_use]
 pub fn build_approval_key(tool_name: &str, input: &serde_json::Value) -> ApprovalKey {
     let fingerprint = match tool_name {
-        "apply_patch" => {
-            let paths_hash = hash_patch_paths(input);
-            format!("patch:{paths_hash}")
+        "apply_patch" | "write_file" | "edit_file" | "fim_edit" => {
+            format!("file:{tool_name}:{}", hash_json_value(input))
         }
         "exec_shell"
+        | "task_shell_start"
         | "exec_shell_wait"
         | "exec_shell_interact"
         | "exec_wait"
         | "exec_interact" => {
-            let prefix = command_prefix(input);
-            format!("shell:{prefix}")
+            format!("shell:{tool_name}:{}", hash_json_value(input))
         }
         "fetch_url" | "web.fetch" | "web_fetch" => {
             let host = parse_host(input);
             format!("net:{host}")
         }
-        _ => {
-            let input_hash = hash_json_input(input);
-            format!("tool:{tool_name}:{input_hash}")
-        }
+        _ => format!("tool:{tool_name}:{}", hash_json_value(input)),
     };
     ApprovalKey(fingerprint)
-}
-
-/// Return the canonical command prefix for the shell command in `input`.
-///
-/// Uses [`classify_command`] from the arity dictionary so that
-/// `auto_allow = ["git status"]` correctly matches `git status -s` and
-/// `git status --porcelain` without also matching `git push`.
-fn command_prefix(input: &serde_json::Value) -> String {
-    let cmd = input.get("command").and_then(|v| v.as_str()).unwrap_or("");
-    let tokens: Vec<&str> = cmd.split_whitespace().collect();
-    if tokens.is_empty() {
-        return "<empty>".to_string();
-    }
-    classify_command(&tokens)
-}
-
-/// Hash the sorted set of file paths referenced by a patch input.
-fn hash_patch_paths(input: &serde_json::Value) -> String {
-    use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash, Hasher};
-
-    let mut paths: Vec<&str> = Vec::new();
-
-    if let Some(changes) = input.get("changes").and_then(|v| v.as_array()) {
-        for change in changes {
-            if let Some(path) = change.get("path").and_then(|v| v.as_str()) {
-                paths.push(path);
-            }
-        }
-    } else if let Some(patch_text) = input.get("patch").and_then(|v| v.as_str()) {
-        for line in patch_text.lines() {
-            if let Some(rest) = line.strip_prefix("+++ b/") {
-                paths.push(rest.trim());
-            }
-        }
-    }
-
-    paths.sort();
-    paths.dedup();
-
-    if paths.is_empty() {
-        return "no_files".to_string();
-    }
-
-    let mut hasher = DefaultHasher::new();
-    for path in &paths {
-        path.hash(&mut hasher);
-    }
-    format!("{:x}", hasher.finish())
-}
-
-fn hash_json_input(input: &serde_json::Value) -> String {
-    use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash, Hasher};
-
-    let mut hasher = DefaultHasher::new();
-    serde_json::to_string(input)
-        .unwrap_or_default()
-        .hash(&mut hasher);
-    format!("{:x}", hasher.finish())
 }
 
 /// Parse the host portion from a URL input.
@@ -212,6 +149,60 @@ fn parse_host(input: &serde_json::Value) -> String {
         parsed.host_str().unwrap_or(url).to_string()
     } else {
         url.to_string()
+    }
+}
+
+fn hash_json_value(value: &Value) -> String {
+    let mut canonical = String::new();
+    push_canonical_json(value, &mut canonical);
+
+    let digest = Sha256::digest(canonical.as_bytes());
+    let mut short = String::with_capacity(16);
+    for byte in &digest[..8] {
+        write!(&mut short, "{byte:02x}").expect("writing to String cannot fail");
+    }
+    short
+}
+
+fn push_canonical_json(value: &Value, out: &mut String) {
+    match value {
+        Value::Null => out.push_str("null"),
+        Value::Bool(value) => {
+            out.push_str("bool:");
+            out.push_str(if *value { "true" } else { "false" });
+        }
+        Value::Number(value) => {
+            out.push_str("number:");
+            out.push_str(&value.to_string());
+        }
+        Value::String(value) => {
+            out.push_str("string:");
+            let encoded = serde_json::to_string(value).expect("serializing a string cannot fail");
+            out.push_str(&encoded);
+        }
+        Value::Array(items) => {
+            out.push('[');
+            for item in items {
+                push_canonical_json(item, out);
+                out.push(',');
+            }
+            out.push(']');
+        }
+        Value::Object(map) => {
+            let mut entries = map.iter().collect::<Vec<_>>();
+            entries.sort_by_key(|(key, _)| *key);
+
+            out.push('{');
+            for (key, value) in entries {
+                let encoded_key =
+                    serde_json::to_string(key).expect("serializing an object key cannot fail");
+                out.push_str(&encoded_key);
+                out.push(':');
+                push_canonical_json(value, out);
+                out.push(',');
+            }
+            out.push('}');
+        }
     }
 }
 
@@ -258,10 +249,10 @@ mod tests {
     }
 
     #[test]
-    fn command_prefix_drops_flags() {
+    fn shell_keys_include_full_command_arguments() {
         let key_a = build_approval_key("exec_shell", &json!({"command": "cargo build"}));
         let key_b = build_approval_key("exec_shell", &json!({"command": "cargo build --release"}));
-        assert_eq!(key_a, key_b);
+        assert_ne!(key_a, key_b);
     }
 
     #[test]
@@ -278,6 +269,48 @@ mod tests {
     }
 
     #[test]
+    fn patch_keys_differ_by_body_for_same_path() {
+        let key_a = build_approval_key(
+            "apply_patch",
+            &json!({"changes": [{"path": "a.rs", "content": "x"}]}),
+        );
+        let key_b = build_approval_key(
+            "apply_patch",
+            &json!({"changes": [{"path": "a.rs", "content": "y"}]}),
+        );
+        assert_ne!(key_a, key_b);
+    }
+
+    #[test]
+    fn file_write_keys_differ_by_path_and_content() {
+        let key_a = build_approval_key("write_file", &json!({"path": "a.txt", "content": "x"}));
+        let key_b = build_approval_key("write_file", &json!({"path": "b.txt", "content": "x"}));
+        let key_c = build_approval_key("write_file", &json!({"path": "a.txt", "content": "y"}));
+        assert_ne!(key_a, key_b);
+        assert_ne!(key_a, key_c);
+    }
+
+    #[test]
+    fn edit_file_keys_differ_by_replacement() {
+        let key_a = build_approval_key(
+            "edit_file",
+            &json!({"path": "a.txt", "search": "old", "replace": "new"}),
+        );
+        let key_b = build_approval_key(
+            "edit_file",
+            &json!({"path": "a.txt", "search": "old", "replace": "newer"}),
+        );
+        assert_ne!(key_a, key_b);
+    }
+
+    #[test]
+    fn task_shell_keys_differ_by_command() {
+        let key_a = build_approval_key("task_shell_start", &json!({"command": "cargo build"}));
+        let key_b = build_approval_key("task_shell_start", &json!({"command": "cargo test"}));
+        assert_ne!(key_a, key_b);
+    }
+
+    #[test]
     fn net_keys_differ_by_host() {
         let key_a = build_approval_key("fetch_url", &json!({"url": "https://example.com"}));
         let key_b = build_approval_key("fetch_url", &json!({"url": "https://other.org"}));
@@ -285,7 +318,7 @@ mod tests {
     }
 
     #[test]
-    fn generic_tool_keys_include_arguments() {
+    fn generic_tool_uses_tool_name_and_input_hash() {
         let key_a = build_approval_key("read_file", &json!({"path": "a.txt"}));
         let key_b = build_approval_key("read_file", &json!({"path": "b.txt"}));
         assert_ne!(key_a, key_b);
@@ -293,10 +326,9 @@ mod tests {
     }
 
     #[test]
-    fn generic_tool_same_arguments_reuse_key() {
-        let input = json!({"path": "a.txt"});
-        let key_a = build_approval_key("edit_file", &input);
-        let key_b = build_approval_key("edit_file", &input);
+    fn input_hash_is_stable_across_object_key_order() {
+        let key_a = build_approval_key("write_file", &json!({"path": "a.txt", "content": "x"}));
+        let key_b = build_approval_key("write_file", &json!({"content": "x", "path": "a.txt"}));
         assert_eq!(key_a, key_b);
     }
 }

--- a/crates/tui/src/tools/approval_cache.rs
+++ b/crates/tui/src/tools/approval_cache.rs
@@ -182,9 +182,11 @@ fn push_canonical_json(value: &Value, out: &mut String) {
         }
         Value::Array(items) => {
             out.push('[');
-            for item in items {
+            for (index, item) in items.iter().enumerate() {
+                if index > 0 {
+                    out.push(',');
+                }
                 push_canonical_json(item, out);
-                out.push(',');
             }
             out.push(']');
         }
@@ -193,13 +195,15 @@ fn push_canonical_json(value: &Value, out: &mut String) {
             entries.sort_by_key(|(key, _)| *key);
 
             out.push('{');
-            for (key, value) in entries {
+            for (index, (key, value)) in entries.into_iter().enumerate() {
+                if index > 0 {
+                    out.push(',');
+                }
                 let encoded_key =
                     serde_json::to_string(key).expect("serializing an object key cannot fail");
                 out.push_str(&encoded_key);
                 out.push(':');
                 push_canonical_json(value, out);
-                out.push(',');
             }
             out.push('}');
         }
@@ -330,5 +334,18 @@ mod tests {
         let key_a = build_approval_key("write_file", &json!({"path": "a.txt", "content": "x"}));
         let key_b = build_approval_key("write_file", &json!({"content": "x", "path": "a.txt"}));
         assert_eq!(key_a, key_b);
+    }
+
+    #[test]
+    fn canonical_json_omits_trailing_commas() {
+        let mut canonical = String::new();
+        push_canonical_json(&json!({"b": [true, false], "a": {"x": 1}}), &mut canonical);
+
+        assert_eq!(
+            canonical,
+            r#"{"a":{"x":number:1},"b":[bool:true,bool:false]}"#
+        );
+        assert!(!canonical.contains(",]"));
+        assert!(!canonical.contains(",}"));
     }
 }

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -6439,6 +6439,7 @@ fn push_keyboard_enhancement_flags<W: Write>(writer: &mut W) {
                 "PushKeyboardEnhancementFlags direct write failed on Windows"
             );
         }
+        return;
     }
     #[cfg(not(windows))]
     if let Err(err) = execute!(
@@ -6470,6 +6471,7 @@ pub(crate) fn pop_keyboard_enhancement_flags<W: Write>(writer: &mut W) {
                 "PopKeyboardEnhancementFlags direct write failed on Windows"
             );
         }
+        return;
     }
     #[cfg(not(windows))]
     let _ = execute!(writer, PopKeyboardEnhancementFlags);

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -150,6 +150,15 @@ const PERIODIC_FULL_REPAINT_EVERY_N: u64 = 50;
 const TURN_META_PREFIX: &str = "<turn_meta>";
 const SESSION_TITLE_MAX_CHARS: usize = 32;
 
+fn is_session_approved_for_tool(app: &App, tool_name: &str, approval_key: &str) -> bool {
+    app.approval_session_approved.contains(approval_key)
+        || app.approval_session_approved.contains(tool_name)
+}
+
+fn is_session_denied_for_key(app: &App, approval_key: &str) -> bool {
+    app.approval_session_denied.contains(approval_key)
+}
+
 fn sidebar_width_for_chat_area(app: &App, chat_width: u16) -> Option<u16> {
     if app.sidebar_focus == SidebarFocus::Hidden || chat_width < SIDEBAR_VISIBLE_MIN_WIDTH {
         return None;
@@ -1687,10 +1696,8 @@ async fn run_event_loop(
                         approval_key,
                     } => {
                         let session_approved =
-                            app.approval_session_approved.contains(&approval_key)
-                                || app.approval_session_approved.contains(&tool_name);
-                        let session_denied = app.approval_session_denied.contains(&approval_key)
-                            || app.approval_session_denied.contains(&tool_name);
+                            is_session_approved_for_tool(app, &tool_name, &approval_key);
+                        let session_denied = is_session_denied_for_key(app, &approval_key);
                         if session_denied {
                             // The user already said no to this exact tool /
                             // approval key in this session; auto-deny so the
@@ -6432,7 +6439,6 @@ fn push_keyboard_enhancement_flags<W: Write>(writer: &mut W) {
                 "PushKeyboardEnhancementFlags direct write failed on Windows"
             );
         }
-        return;
     }
     #[cfg(not(windows))]
     if let Err(err) = execute!(
@@ -6464,7 +6470,6 @@ pub(crate) fn pop_keyboard_enhancement_flags<W: Write>(writer: &mut W) {
                 "PopKeyboardEnhancementFlags direct write failed on Windows"
             );
         }
-        return;
     }
     #[cfg(not(windows))]
     let _ = execute!(writer, PopKeyboardEnhancementFlags);

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -1203,6 +1203,33 @@ fn create_test_app() -> App {
     app
 }
 
+#[test]
+fn session_denied_cache_matches_only_approval_key() {
+    let mut app = create_test_app();
+    app.approval_session_denied.insert("edit_file".to_string());
+
+    assert!(
+        !is_session_denied_for_key(&app, "file:edit_file:fresh"),
+        "a legacy tool-name entry must not deny a later fresh call"
+    );
+
+    app.approval_session_denied
+        .insert("file:edit_file:retry".to_string());
+    assert!(is_session_denied_for_key(&app, "file:edit_file:retry"));
+}
+
+#[test]
+fn session_approved_cache_keeps_tool_name_session_grants() {
+    let mut app = create_test_app();
+    app.approval_session_approved
+        .insert("edit_file".to_string());
+
+    assert!(
+        is_session_approved_for_tool(&app, "edit_file", "file:edit_file:fresh"),
+        "approve-for-session should still cover future calls of the same tool"
+    );
+}
+
 fn create_test_options() -> TuiOptions {
     TuiOptions {
         model: "deepseek-v4-pro".to_string(),


### PR DESCRIPTION
## Summary

Fixes #1617.

- Key approval denials by a canonical argument hash for file-write tools, shell/task-shell tools, and generic approval-gated tools, so a denial only suppresses exact retries instead of every future call of the same tool.
- Keep approve-for-session behavior tool-wide while making deny auto-cache match only the approval key.
- Omit trailing commas from the canonical argument serialization after review feedback, with a regression test for the exact serialized shape.
- Remove two Windows-only needless returns in `ui.rs` so the repository clippy command passes with warnings denied.

## Root cause

PR #1388 stopped inserting `tool_name` into `approval_session_denied`, but most tools still built fallback approval keys as `tool:<tool_name>`. For tools like `edit_file`, `write_file`, and `task_shell_start`, denying one request therefore cached a key reused by later distinct requests. The UI path also still accepted legacy tool-name deny hits.

## Testing

- [ ] `cargo test --all-features`
  - Ran after the latest commit on this Windows checkout; failed with 3052 passed, 5 failed, 3 ignored.
  - The failing tests are outside this approval-cache change:
    - `session_manager::tests::latest_session_for_workspace_ignores_newer_other_directory` and `session_manager::tests::latest_session_for_workspace_ignores_invalid_parent_git_marker` also fail individually here. This checkout has `C:\.git\HEAD`, so the temp workspaces are detected as sharing the same parent git root.
    - `commands::change::tests::change_in_non_english_without_api_key_uses_explicit_fallback` also fails individually in this environment.
    - `tools::pandoc::tests::pandoc_convert_roundtrips_markdown_to_html_inline` and `tools::pandoc::tests::pandoc_convert_writes_output_path_and_reports_summary` failed during the full run with `pandoc: getXdgDirectory:sHGetFolderPath: illegal operation`, but both passed when rerun individually.
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo build`
- [x] `cargo test -p deepseek-tui approval_cache`
- [x] `cargo test -p deepseek-tui session_denied_cache_matches_only_approval_key`
- [x] `cargo test -p deepseek-tui session_approved_cache_keeps_tool_name_session_grants`

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
  - Covered by focused unit tests; no manual interactive TUI session was run.