### PR TITLE
fix(tui): treat absolute slash paths as messages

### DIFF
--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -82,6 +82,17 @@ pub(crate) fn resolve_skills_dir(
     global_skills_dir.to_path_buf()
 }
 
+pub(crate) fn looks_like_slash_command_input(input: &str) -> bool {
+    let Some(rest) = input.trim_start().strip_prefix('/') else {
+        return false;
+    };
+    let Some(command) = rest.split_whitespace().next() else {
+        return rest.is_empty();
+    };
+
+    !command.contains('/')
+}
+
 fn initial_onboarding_state(
     skip_onboarding: bool,
     was_onboarded: bool,
@@ -3653,7 +3664,7 @@ impl App {
         // sees the @mention in the composer before submission.
         self.consolidate_large_input_if_oversized();
         let input = self.input.clone();
-        if !input.starts_with('/') {
+        if !looks_like_slash_command_input(&input) {
             self.input_history.push(input.clone());
             if self.max_input_history == 0 {
                 self.input_history.clear();
@@ -4282,6 +4293,29 @@ mod tests {
         assert_eq!(SidebarFocus::from_setting("off"), SidebarFocus::Hidden);
         assert_eq!(SidebarFocus::Work.as_setting(), "work");
         assert_eq!(SidebarFocus::Hidden.as_setting(), "hidden");
+    }
+
+    #[test]
+    fn slash_command_classifier_treats_absolute_path_as_message() {
+        assert!(looks_like_slash_command_input("/"));
+        assert!(looks_like_slash_command_input("/help"));
+        assert!(looks_like_slash_command_input("/model deepseek-v4-pro"));
+        assert!(!looks_like_slash_command_input(
+            "/usr/lib/x86_64-linux-gnu/ 是标准路径吗？"
+        ));
+    }
+
+    #[test]
+    fn submit_input_records_absolute_slash_path_as_message_history() {
+        let mut app = App::new(test_options(false), &Config::default());
+        let input = "/usr/lib/x86_64-linux-gnu/ 是标准路径吗？";
+        app.input = input.to_string();
+        app.cursor_position = input.chars().count();
+
+        let submitted = app.submit_input().expect("expected submitted input");
+
+        assert_eq!(submitted, input);
+        assert_eq!(app.input_history.last().map(String::as_str), Some(input));
     }
 
     #[test]

--- a/crates/tui/src/tui/paste.rs
+++ b/crates/tui/src/tui/paste.rs
@@ -9,7 +9,7 @@ use std::time::Instant;
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-use super::app::App;
+use super::app::{App, looks_like_slash_command_input};
 use super::paste_burst::CharDecision;
 
 /// Process a key in the context of paste-burst detection. Returns `true`
@@ -122,7 +122,7 @@ fn apply_paste_burst_retro_capture(
 }
 
 fn in_command_context(app: &App) -> bool {
-    app.input.starts_with('/')
+    looks_like_slash_command_input(&app.input)
 }
 
 #[cfg(test)]

--- a/crates/tui/src/tui/slash_menu.rs
+++ b/crates/tui/src/tui/slash_menu.rs
@@ -10,7 +10,7 @@
 
 use crate::commands;
 
-use super::app::App;
+use super::app::{App, looks_like_slash_command_input};
 use super::widgets::SlashMenuEntry;
 use super::widgets::slash_completion_hints;
 
@@ -66,7 +66,7 @@ pub fn apply_slash_menu_selection(
 /// fully (with trailing space). On ambiguity, posts a status hint listing
 /// up to five candidates. Also considers skill names as completion candidates.
 pub fn try_autocomplete_slash_command(app: &mut App) -> bool {
-    if !app.input.starts_with('/') {
+    if !looks_like_slash_command_input(&app.input) {
         return false;
     }
 

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -103,6 +103,7 @@ use crate::tui::workspace_context;
 use super::app::{
     App, AppAction, AppMode, OnboardingState, QueuedMessage, ReasoningEffort, SidebarFocus,
     StatusToastLevel, SubmitDisposition, TaskPanelEntry, TuiOptions,
+    looks_like_slash_command_input,
 };
 use super::approval::{
     ApprovalMode, ApprovalRequest, ApprovalView, ElevationRequest, ElevationView, ReviewDecision,
@@ -2961,7 +2962,7 @@ async fn run_event_loop(
                         && !key.modifiers.contains(KeyModifiers::ALT) =>
                 {
                     if let Some(input) = app.submit_input() {
-                        if input.starts_with('/') {
+                        if looks_like_slash_command_input(&input) {
                             if execute_command_input(
                                 terminal,
                                 app,
@@ -3010,7 +3011,7 @@ async fn run_event_loop(
                 // #382: Ctrl+Enter forces a steer into the current turn.
                 KeyCode::Enter if key.modifiers.contains(KeyModifiers::CONTROL) => {
                     if let Some(input) = app.submit_input() {
-                        if input.starts_with('/') {
+                        if looks_like_slash_command_input(&input) {
                             if execute_command_input(
                                 terminal,
                                 app,
@@ -3061,7 +3062,7 @@ async fn run_event_loop(
                     // to the legacy submit path.
                     if slash_menu_open
                         && !slash_menu_entries.is_empty()
-                        && app.input.starts_with('/')
+                        && looks_like_slash_command_input(&app.input)
                         && apply_slash_menu_selection(app, &slash_menu_entries, false)
                     {
                         app.close_slash_menu();
@@ -3081,7 +3082,7 @@ async fn run_event_loop(
                             handle_memory_quick_add(app, &input, config);
                             continue;
                         }
-                        if input.starts_with('/') {
+                        if looks_like_slash_command_input(&input) {
                             if execute_command_input(
                                 terminal,
                                 app,

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -2034,7 +2034,7 @@ pub(crate) fn slash_completion_hints(
     locale: crate::localization::Locale,
     workspace: Option<&std::path::Path>,
 ) -> Vec<SlashMenuEntry> {
-    if !input.starts_with('/') {
+    if !super::app::looks_like_slash_command_input(input) {
         return Vec::new();
     }
 


### PR DESCRIPTION
## Summary
- add a shared slash-command classifier that rejects path-like slash tokens
- route Enter/Ctrl+Enter/Shift+Enter, slash autocomplete, and paste context through that classifier
- keep bare `/` and real slash commands working for the slash menu

Fixes #1568

## Tests
- cargo test -p deepseek-tui --bin deepseek-tui --locked absolute
- cargo test -p deepseek-tui --bin deepseek-tui --locked slash
- cargo fmt --all -- --check
- cargo clippy -p deepseek-tui --all-targets --all-features --locked -- -D warnings
- git diff --check