### PR TITLE
fix(tui): refresh mcp discovery on manager open

### DIFF
--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -4757,10 +4757,7 @@ async fn handle_mcp_ui_action(
     let path = app.mcp_config_path.clone();
     let mut changed = false;
     let mut message = None;
-    let discover = matches!(
-        action,
-        crate::tui::app::McpUiAction::Validate | crate::tui::app::McpUiAction::Reload
-    );
+    let discover = mcp_ui_action_refreshes_discovery(&action);
 
     let action_result = match action {
         crate::tui::app::McpUiAction::Show => Ok(()),
@@ -4856,6 +4853,15 @@ async fn handle_mcp_ui_action(
         }
         Err(err) => add_mcp_message(app, format!("MCP snapshot failed: {err}")),
     }
+}
+
+fn mcp_ui_action_refreshes_discovery(action: &crate::tui::app::McpUiAction) -> bool {
+    matches!(
+        action,
+        crate::tui::app::McpUiAction::Show
+            | crate::tui::app::McpUiAction::Validate
+            | crate::tui::app::McpUiAction::Reload
+    )
 }
 
 fn handle_shell_job_action(app: &mut App, action: crate::tui::app::ShellJobAction) {

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -87,6 +87,18 @@ fn resume_hint_omits_missing_session_id() {
 }
 
 #[test]
+fn plain_mcp_show_refreshes_discovery_counts() {
+    use crate::tui::app::McpUiAction;
+
+    assert!(mcp_ui_action_refreshes_discovery(&McpUiAction::Show));
+    assert!(mcp_ui_action_refreshes_discovery(&McpUiAction::Validate));
+    assert!(mcp_ui_action_refreshes_discovery(&McpUiAction::Reload));
+    assert!(!mcp_ui_action_refreshes_discovery(&McpUiAction::Init {
+        force: false,
+    }));
+}
+
+#[test]
 fn focus_gained_forces_terminal_viewport_recapture() {
     assert!(terminal_event_needs_viewport_recapture(&Event::FocusGained));
     assert!(!terminal_event_needs_viewport_recapture(&Event::FocusLost));


### PR DESCRIPTION
## Summary
- make plain `/mcp` refresh MCP discovery instead of rendering a config-only snapshot
- keep validate/reload discovery behavior unchanged
- add a focused action-policy regression test so the manager keeps showing live discovered counts

Fixes #1613

## Tests
- cargo test -p deepseek-tui --bin deepseek-tui --locked plain_mcp_show_refreshes_discovery_counts
- cargo test -p deepseek-tui --bin deepseek-tui --locked mcp
- cargo fmt --all -- --check
- cargo clippy -p deepseek-tui --all-targets --all-features --locked -- -D warnings
- git diff --check