### PR TITLE
fix: validate API key before terminal init to prevent garbled output

### DIFF
--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -4326,6 +4326,12 @@ async fn run_interactive(
         ),
     }
 
+    // Pre-validate the API key *before* entering the TUI (which switches
+    // into alternate screen / raw mode). Failing after terminal init would
+    // leave escape-sequence garbage on the user's screen.  Self-hosted
+    // providers (sglang, vllm, ollama) are allowed to have an empty key.
+    config.deepseek_api_key()?;
+
     tui::run_tui(
         config,
         tui::TuiOptions {

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -310,6 +310,17 @@ pub async fn run_tui(config: &Config, options: TuiOptions) -> Result<()> {
     // sequence is received. Terminals that do not understand it silently
     // ignore it.
     recover_terminal_modes(&mut stdout, use_mouse_capture, use_bracketed_paste);
+
+    // RAII guard: if anything below returns early via `?`, the terminal is
+    // restored automatically so the user's shell isn't left in alt-screen /
+    // raw mode (which manifests as "garbled output").
+    let mut _cleanup_guard = TerminalCleanupGuard {
+        use_alt_screen,
+        use_mouse_capture,
+        use_bracketed_paste,
+        defused: false,
+    };
+
     let color_depth = palette::ColorDepth::detect();
     let palette_mode = palette::PaletteMode::detect();
     tracing::debug!(
@@ -522,6 +533,10 @@ pub async fn run_tui(config: &Config, options: TuiOptions) -> Result<()> {
     persistence_actor::persist(PersistRequest::ClearCheckpoint);
     persistence_actor::persist(PersistRequest::Shutdown);
 
+    // Defuse the RAII guard — we're doing the cleanup manually here so we
+    // can use the terminal backend handle (better than raw stdout).
+    _cleanup_guard.defused = true;
+
     pop_keyboard_enhancement_flags(terminal.backend_mut());
     execute!(terminal.backend_mut(), DisableFocusChange)?;
     disable_raw_mode()?;
@@ -568,6 +583,42 @@ fn terminal_probe_timeout(config: &Config) -> Duration {
         .unwrap_or(DEFAULT_TERMINAL_PROBE_TIMEOUT_MS)
         .clamp(100, 5_000);
     Duration::from_millis(timeout_ms)
+}
+
+/// RAII guard that restores the terminal on drop — ensures we leave
+/// alternate screen, raw mode, mouse capture, etc. even when `run_tui`
+/// returns early via `?`.
+struct TerminalCleanupGuard {
+    use_alt_screen: bool,
+    use_mouse_capture: bool,
+    use_bracketed_paste: bool,
+    /// Set to `true` once the happy-path cleanup runs so we don't double-clean.
+    defused: bool,
+}
+
+impl Drop for TerminalCleanupGuard {
+    fn drop(&mut self) {
+        if self.defused {
+            return;
+        }
+        // Best-effort terminal restoration — same sequence as the panic hook.
+        let mut stdout = io::stdout();
+        pop_keyboard_enhancement_flags(&mut stdout);
+        let _ = execute!(stdout, DisableFocusChange);
+        let _ = disable_raw_mode();
+        if self.use_alt_screen {
+            let _ = execute!(stdout, LeaveAlternateScreen);
+        }
+        if self.use_mouse_capture {
+            let _ = execute!(stdout, DisableMouseCapture);
+        }
+        if self.use_bracketed_paste {
+            let _ = execute!(stdout, DisableBracketedPaste);
+        }
+        // Show cursor best-effort (write the escape directly since we may
+        // not have a Terminal handle here).
+        let _ = execute!(stdout, crossterm::cursor::Show);
+    }
 }
 
 /// Recognise composer input that is a `# foo` memory quick-add (#492).


### PR DESCRIPTION
When the API key was missing, run_tui would initialize the terminal (alternate screen, raw mode, Kitty keyboard protocol, mouse capture) and then bail at DeepSeekClient::new(config)?, skipping the cleanup code. This left escape sequences in stdout, rendering as garbled text.

Two changes:
- Pre-validate the API key in run_interactive() before calling run_tui(), so the error message prints cleanly without entering terminal mode.
- Add a TerminalCleanupGuard (RAII) inside run_tui() as a safety net: if any other early ?-return occurs after terminal init, the guard restores raw mode, alternate screen, mouse capture, and keyboard flags on drop.

## Summary

## Testing

- [ ] `cargo test --all-features`
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
