### PR TITLE
fix: first-message 400 error and /model default reset

### DIFF
--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -339,6 +339,10 @@ pub async fn run_tui(config: &Config, options: TuiOptions) -> Result<()> {
     let config = &mut config;
     let mut app = App::new(options.clone(), config);
 
+    // Sync the provider resolved by App::new (which reads settings.default_provider)
+    // back into config so that DeepSeekClient and Engine use the correct provider.
+    config.provider = Some(app.api_provider.as_str().to_string());
+
     // Load existing session if resuming.
     if let Some(ref session_id) = options.resume_session_id
         && let Ok(manager) = SessionManager::default_location()
@@ -5847,7 +5851,14 @@ async fn handle_view_events(
                 .await;
             }
             ViewEvent::ProviderPickerApplied { provider } => {
-                switch_provider(app, engine_handle, config, provider, None).await;
+                // Preserve the current model when re-selecting the same provider
+                // so the model picker choice (e.g. flash) is not lost.
+                let model_override = if app.api_provider == provider {
+                    Some(app.model.clone())
+                } else {
+                    None
+                };
+                switch_provider(app, engine_handle, config, provider, model_override).await;
             }
             ViewEvent::ProviderPickerApiKeySubmitted { provider, api_key } => {
                 apply_provider_picker_api_key(app, engine_handle, config, provider, api_key).await;


### PR DESCRIPTION
## Summary
- Fix 400 error on first message after entering TUI — sync provider from `App::new` back to `config.provider`
- Fix `/model` re-selecting same provider resetting model to default — preserve `model_override` when provider unchanged

## Test plan
- [ ] Start TUI, send first message — should not return 400
- [ ] Switch to deepseek provider, pick a non-default model (e.g. flash), re-select deepseek — model should persist