### PR TITLE
fix: prepare v0.8.38 bug-bash fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Update guidance is clearer on the website.** The homepage and install page
+  now surface `deepseek update` while keeping package-manager update paths
+  visible for Homebrew, npm, and Cargo installs.
+
+### Fixed
+
+- **OpenAI-compatible providers receive stricter request bodies.** Fireworks
+  requests now use `reasoning_effort` without the DeepSeek/Anthropic-style
+  top-level `thinking` field, and chat tool schemas no longer include
+  Anthropic-only metadata such as `allowed_callers`, `defer_loading`, or
+  `input_examples` (#1592).
+- **pnpm global installs no longer hang in optional postinstall.** pnpm
+  postinstall now skips install-time binary downloads and leaves the existing
+  runtime downloader to verify or fetch binaries on first run (#1637).
+- **Terminal modes are restored on early TUI exits.** A cleanup guard now
+  restores raw mode, alternate screen, focus events, mouse capture, bracketed
+  paste, keyboard flags, and cursor visibility if startup returns early after
+  terminal initialization (#1593, #1582).
+- **Wrapped OSC 8 links keep their full target.** Long clickable URLs now
+  reopen the original full link target on each wrapped visual chunk instead of
+  exposing truncated hyperlink targets (#1577).
+
+### Thanks
+
+Thanks to **DC ([@duanchao-lab](https://github.com/duanchao-lab))** for the
+terminal cleanup-guard idea harvested from #1630.
+
 ## [0.8.37] - 2026-05-14
 
 ### Added

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Update guidance is clearer on the website.** The homepage and install page
+  now surface `deepseek update` while keeping package-manager update paths
+  visible for Homebrew, npm, and Cargo installs.
+
+### Fixed
+
+- **OpenAI-compatible providers receive stricter request bodies.** Fireworks
+  requests now use `reasoning_effort` without the DeepSeek/Anthropic-style
+  top-level `thinking` field, and chat tool schemas no longer include
+  Anthropic-only metadata such as `allowed_callers`, `defer_loading`, or
+  `input_examples` (#1592).
+- **pnpm global installs no longer hang in optional postinstall.** pnpm
+  postinstall now skips install-time binary downloads and leaves the existing
+  runtime downloader to verify or fetch binaries on first run (#1637).
+- **Terminal modes are restored on early TUI exits.** A cleanup guard now
+  restores raw mode, alternate screen, focus events, mouse capture, bracketed
+  paste, keyboard flags, and cursor visibility if startup returns early after
+  terminal initialization (#1593, #1582).
+- **Wrapped OSC 8 links keep their full target.** Long clickable URLs now
+  reopen the original full link target on each wrapped visual chunk instead of
+  exposing truncated hyperlink targets (#1577).
+
+### Thanks
+
+Thanks to **DC ([@duanchao-lab](https://github.com/duanchao-lab))** for the
+terminal cleanup-guard idea harvested from #1630.
+
 ## [0.8.37] - 2026-05-14
 
 ### Added

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -887,10 +887,10 @@ pub(super) fn apply_reasoning_effort(
             | ApiProvider::DeepseekCN
             | ApiProvider::Openrouter
             | ApiProvider::Novita
-            | ApiProvider::Fireworks
             | ApiProvider::Sglang => {
                 body["thinking"] = json!({ "type": "disabled" });
             }
+            ApiProvider::Fireworks => {}
             // vLLM is an OpenAI-protocol server, not an Anthropic-protocol one.
             // For Qwen3 / DeepSeek-R1 / other reasoning models hosted via vLLM,
             // the canonical OpenAI extension to disable thinking is
@@ -917,10 +917,12 @@ pub(super) fn apply_reasoning_effort(
             | ApiProvider::DeepseekCN
             | ApiProvider::Openrouter
             | ApiProvider::Novita
-            | ApiProvider::Fireworks
             | ApiProvider::Sglang => {
                 body["reasoning_effort"] = json!("high");
                 body["thinking"] = json!({ "type": "enabled" });
+            }
+            ApiProvider::Fireworks => {
+                body["reasoning_effort"] = json!("high");
             }
             ApiProvider::Vllm => {
                 body["chat_template_kwargs"] = json!({
@@ -941,10 +943,12 @@ pub(super) fn apply_reasoning_effort(
             | ApiProvider::DeepseekCN
             | ApiProvider::Openrouter
             | ApiProvider::Novita
-            | ApiProvider::Fireworks
             | ApiProvider::Sglang => {
                 body["reasoning_effort"] = json!("max");
                 body["thinking"] = json!({ "type": "enabled" });
+            }
+            ApiProvider::Fireworks => {
+                body["reasoning_effort"] = json!("max");
             }
             ApiProvider::Vllm => {
                 body["chat_template_kwargs"] = json!({
@@ -1919,6 +1923,21 @@ mod tests {
     }
 
     #[test]
+    fn reasoning_effort_uses_openai_compatible_shape_for_fireworks() {
+        let mut body = json!({});
+        apply_reasoning_effort(&mut body, Some("max"), ApiProvider::Fireworks);
+
+        assert_eq!(
+            body.get("reasoning_effort").and_then(Value::as_str),
+            Some("max")
+        );
+        assert!(
+            body.get("thinking").is_none(),
+            "Fireworks strict-validates OpenAI-compatible requests and rejects top-level thinking"
+        );
+    }
+
+    #[test]
     fn chat_parser_accepts_nvidia_nim_reasoning_field() -> Result<()> {
         let response = parse_chat_message(&json!({
             "id": "chatcmpl-test",
@@ -2053,6 +2072,27 @@ mod tests {
                 Some(true)
             );
         }
+    }
+
+    #[test]
+    fn chat_tool_wire_shape_omits_anthropic_only_metadata() {
+        let tool = Tool {
+            tool_type: Some("function".to_string()),
+            name: "mcp_read_resource".to_string(),
+            description: "Read resource".to_string(),
+            input_schema: json!({"type": "object", "properties": {}}),
+            allowed_callers: Some(vec!["direct".to_string()]),
+            defer_loading: Some(false),
+            input_examples: Some(vec![json!({"uri": "file://example"})]),
+            strict: None,
+            cache_control: None,
+        };
+
+        let encoded = tool_to_chat_for_base_url(&tool, "https://api.fireworks.ai/inference/v1");
+
+        assert!(encoded.get("allowed_callers").is_none());
+        assert!(encoded.get("defer_loading").is_none());
+        assert!(encoded.get("input_examples").is_none());
     }
 
     #[test]

--- a/crates/tui/src/client/chat.rs
+++ b/crates/tui/src/client/chat.rs
@@ -1396,15 +1396,6 @@ pub(super) fn tool_to_chat(tool: &Tool) -> Value {
             "parameters": tool.input_schema,
         }
     });
-    if let Some(allowed_callers) = &tool.allowed_callers {
-        value["allowed_callers"] = json!(allowed_callers);
-    }
-    if let Some(defer_loading) = tool.defer_loading {
-        value["defer_loading"] = json!(defer_loading);
-    }
-    if let Some(input_examples) = &tool.input_examples {
-        value["input_examples"] = json!(input_examples);
-    }
     if let Some(strict) = tool.strict
         && let Some(function) = value.get_mut("function")
     {

--- a/crates/tui/src/tui/markdown_render.rs
+++ b/crates/tui/src/tui/markdown_render.rs
@@ -497,9 +497,7 @@ fn render_line_with_links(
             for ch in word.text.chars() {
                 let cw = ch.width().unwrap_or(1);
                 if chunk_w + cw > width && chunk_w > 0 {
-                    lines.push(Line::from(vec![word.span_for(std::mem::take(
-                        &mut chunk,
-                    ))]));
+                    lines.push(Line::from(vec![word.span_for(std::mem::take(&mut chunk))]));
                     chunk_w = 0;
                 }
                 chunk.push(ch);
@@ -663,7 +661,11 @@ fn parse_inline_spans(line: &str, base_style: Style, link_style: Style) -> Vec<I
                         Some(url.to_string()),
                     ));
                 } else {
-                    out.push(InlineToken::new(format!("{text} ({url})"), link_style, None));
+                    out.push(InlineToken::new(
+                        format!("{text} ({url})"),
+                        link_style,
+                        None,
+                    ));
                 }
                 rest = &after_bracket[paren_end + 1..];
                 continue;
@@ -1287,7 +1289,9 @@ mod tests {
             "expected each wrapped URL chunk to reopen the full OSC 8 target; got {joined:?}"
         );
         assert!(
-            !joined.contains("\x1b]8;;https://raw.githubusercontent.com/Hmbown/deepseek-skills/main/inde\x1b\\"),
+            !joined.contains(
+                "\x1b]8;;https://raw.githubusercontent.com/Hmbown/deepseek-skills/main/inde\x1b\\"
+            ),
             "wrapped link must not expose a truncated OSC 8 target: {joined:?}"
         );
     }
@@ -1486,7 +1490,9 @@ mod tests {
     }
 
     fn render_paragraph_for_test(text: &str, width: usize) -> Vec<Line<'static>> {
-        with_osc8(false, || render_line_with_links(text, width, Style::default(), Style::default()))
+        with_osc8(false, || {
+            render_line_with_links(text, width, Style::default(), Style::default())
+        })
     }
 
     #[test]

--- a/crates/tui/src/tui/markdown_render.rs
+++ b/crates/tui/src/tui/markdown_render.rs
@@ -438,17 +438,21 @@ fn render_line_with_links(
 
     // Flatten inline tokens into (word, style) pairs preserving inter-token spaces.
     let tokens = parse_inline_spans(line, base_style, link_style);
-    let mut words: Vec<(String, Style)> = Vec::new();
-    for (text, style) in tokens {
+    let mut words: Vec<InlineToken> = Vec::new();
+    for token in tokens {
         let mut first = true;
-        for part in text.split(' ') {
+        for part in token.text.split(' ') {
             if !first {
                 // The space consumed by split — attach as a plain space word
                 // so the wrap loop can decide whether to keep or break it.
-                words.push((" ".to_string(), style));
+                words.push(InlineToken::new(" ".to_string(), token.style, None));
             }
             if !part.is_empty() {
-                words.push((part.to_string(), style));
+                words.push(InlineToken::new(
+                    part.to_string(),
+                    token.style,
+                    token.link_url.clone(),
+                ));
             }
             first = false;
         }
@@ -458,9 +462,9 @@ fn render_line_with_links(
     let mut current_spans: Vec<Span> = Vec::new();
     let mut current_width = 0usize;
 
-    for (word, style) in words {
-        let ww = word.width();
-        if word == " " {
+    for word in words {
+        let ww = word.text.width();
+        if word.text == " " {
             // Space: emit only if we're mid-line and it fits; otherwise drop
             // (it's a potential wrap point, not content).
             if !current_spans.is_empty() && current_width < width {
@@ -490,20 +494,19 @@ fn render_line_with_links(
             // current line so the next word can pack onto it.
             let mut chunk = String::new();
             let mut chunk_w = 0usize;
-            for ch in word.chars() {
+            for ch in word.text.chars() {
                 let cw = ch.width().unwrap_or(1);
                 if chunk_w + cw > width && chunk_w > 0 {
-                    lines.push(Line::from(vec![Span::styled(
-                        std::mem::take(&mut chunk),
-                        style,
-                    )]));
+                    lines.push(Line::from(vec![word.span_for(std::mem::take(
+                        &mut chunk,
+                    ))]));
                     chunk_w = 0;
                 }
                 chunk.push(ch);
                 chunk_w += cw;
             }
             if !chunk.is_empty() {
-                current_spans.push(Span::styled(chunk, style));
+                current_spans.push(word.span_for(chunk));
                 current_width = chunk_w;
             }
             continue;
@@ -520,7 +523,7 @@ fn render_line_with_links(
             current_spans = Vec::new();
             current_width = 0;
         }
-        current_spans.push(Span::styled(word, style));
+        current_spans.push(word.into_span());
         current_width += ww;
     }
 
@@ -533,9 +536,47 @@ fn render_line_with_links(
     lines
 }
 
+#[derive(Clone)]
+struct InlineToken {
+    text: String,
+    style: Style,
+    link_url: Option<String>,
+}
+
+impl InlineToken {
+    fn new(text: String, style: Style, link_url: Option<String>) -> Self {
+        Self {
+            text,
+            style,
+            link_url,
+        }
+    }
+
+    fn span_for(&self, text: String) -> Span<'static> {
+        let content = match &self.link_url {
+            Some(url) if osc8::enabled() => osc8::wrap_link(url, &text),
+            _ => text,
+        };
+        Span::styled(content, self.style)
+    }
+
+    fn into_span(self) -> Span<'static> {
+        let Self {
+            text,
+            style,
+            link_url,
+        } = self;
+        let content = match link_url {
+            Some(url) if osc8::enabled() => osc8::wrap_link(&url, &text),
+            _ => text,
+        };
+        Span::styled(content, style)
+    }
+}
+
 /// Parse an entire line into (text, style) segments, handling **bold**,
 /// *italic*, `code`, ~~strikethrough~~, `[text](url)` links, and bare URLs.
-fn parse_inline_spans(line: &str, base_style: Style, link_style: Style) -> Vec<(String, Style)> {
+fn parse_inline_spans(line: &str, base_style: Style, link_style: Style) -> Vec<InlineToken> {
     let bold_style = base_style.add_modifier(Modifier::BOLD);
     let italic_style = base_style.add_modifier(Modifier::ITALIC);
     let code_style = base_style
@@ -549,14 +590,14 @@ fn parse_inline_spans(line: &str, base_style: Style, link_style: Style) -> Vec<(
         // **bold**
         if let Some(end) = rest.strip_prefix("**").and_then(|s| s.find("**")) {
             let inner = &rest[2..2 + end];
-            out.push((inner.to_string(), bold_style));
+            out.push(InlineToken::new(inner.to_string(), bold_style, None));
             rest = &rest[2 + end + 2..];
             continue;
         }
         // __bold__
         if let Some(end) = rest.strip_prefix("__").and_then(|s| s.find("__")) {
             let inner = &rest[2..2 + end];
-            out.push((inner.to_string(), bold_style));
+            out.push(InlineToken::new(inner.to_string(), bold_style, None));
             rest = &rest[2 + end + 2..];
             continue;
         }
@@ -571,7 +612,7 @@ fn parse_inline_spans(line: &str, base_style: Style, link_style: Style) -> Vec<(
             // letter, digit, or underscore (otherwise it's part of an
             // identifier like `deepseek_tui`, not italic markup).
             if !after.starts_with(|c: char| c.is_alphanumeric() || c == '_') {
-                out.push((inner.to_string(), italic_style));
+                out.push(InlineToken::new(inner.to_string(), italic_style, None));
                 rest = after;
                 continue;
             }
@@ -586,7 +627,7 @@ fn parse_inline_spans(line: &str, base_style: Style, link_style: Style) -> Vec<(
             // Closing delimiter must not be immediately followed by a
             // letter, digit, or underscore.
             if !after.starts_with(|c: char| c.is_alphanumeric() || c == '_') {
-                out.push((inner.to_string(), italic_style));
+                out.push(InlineToken::new(inner.to_string(), italic_style, None));
                 rest = after;
                 continue;
             }
@@ -594,14 +635,14 @@ fn parse_inline_spans(line: &str, base_style: Style, link_style: Style) -> Vec<(
         // `inline code`
         if let Some(end) = rest.strip_prefix('`').and_then(|s| s.find('`')) {
             let inner = &rest[1..1 + end];
-            out.push((inner.to_string(), code_style));
+            out.push(InlineToken::new(inner.to_string(), code_style, None));
             rest = &rest[1 + end + 1..];
             continue;
         }
         // ~~strikethrough~~
         if let Some(end) = rest.strip_prefix("~~").and_then(|s| s.find("~~")) {
             let inner = &rest[2..2 + end];
-            out.push((inner.to_string(), strike_style));
+            out.push(InlineToken::new(inner.to_string(), strike_style, None));
             rest = &rest[2 + end + 2..];
             continue;
         }
@@ -615,12 +656,15 @@ fn parse_inline_spans(line: &str, base_style: Style, link_style: Style) -> Vec<(
                 && let Some(paren_end) = after_bracket.find(')')
             {
                 let url = &after_bracket[1..paren_end];
-                let content = if osc8::enabled() {
-                    osc8::wrap_link(url, text)
+                if osc8::enabled() {
+                    out.push(InlineToken::new(
+                        text.to_string(),
+                        link_style,
+                        Some(url.to_string()),
+                    ));
                 } else {
-                    format!("{text} ({url})")
-                };
-                out.push((content, link_style));
+                    out.push(InlineToken::new(format!("{text} ({url})"), link_style, None));
+                }
                 rest = &after_bracket[paren_end + 1..];
                 continue;
             }
@@ -629,18 +673,21 @@ fn parse_inline_spans(line: &str, base_style: Style, link_style: Style) -> Vec<(
         if rest.starts_with("http://") || rest.starts_with("https://") {
             let end = rest.find(char::is_whitespace).unwrap_or(rest.len());
             let url = &rest[..end];
-            let content = if osc8::enabled() {
-                osc8::wrap_link(url, url)
+            if osc8::enabled() {
+                out.push(InlineToken::new(
+                    url.to_string(),
+                    link_style,
+                    Some(url.to_string()),
+                ));
             } else {
-                url.to_string()
-            };
-            out.push((content, link_style));
+                out.push(InlineToken::new(url.to_string(), link_style, None));
+            }
             rest = &rest[end..];
             continue;
         }
         // Plain text: consume until next marker or URL; always advance at least 1 char.
         let next = find_next_marker(rest).max(rest.chars().next().map_or(1, |c| c.len_utf8()));
-        out.push((rest[..next].to_string(), base_style));
+        out.push(InlineToken::new(rest[..next].to_string(), base_style, None));
         rest = &rest[next..];
     }
     out
@@ -759,12 +806,11 @@ fn render_table_row(cells: &[String], width: usize, base_style: Style) -> Vec<Li
         let mut spans: Vec<Span> = vec![Span::styled("│ ".to_string(), sep_style)];
         for (i, cell_segments) in wrapped.iter().enumerate() {
             let segment = cell_segments.get(row).map(String::as_str).unwrap_or("");
-            let cell_spans: Vec<(String, Style)> =
-                parse_inline_spans(segment, base_style, link_style());
-            let cell_width: usize = cell_spans.iter().map(|(t, _)| t.width()).sum();
+            let cell_spans = parse_inline_spans(segment, base_style, link_style());
+            let cell_width: usize = cell_spans.iter().map(|token| token.text.width()).sum();
             let pad = col_width.saturating_sub(cell_width);
-            for (text, style) in cell_spans {
-                spans.push(Span::styled(text, style));
+            for token in cell_spans {
+                spans.push(token.into_span());
             }
             spans.push(Span::raw(" ".repeat(pad)));
             if i + 1 < cells.len() {
@@ -1198,8 +1244,12 @@ mod tests {
     /// value. We serialize through a static mutex because `osc8::ENABLED` is
     /// process-wide state and other tests touching it would race otherwise.
     fn render_with_osc8(enabled: bool, source: &str) -> String {
+        render_with_osc8_width(enabled, source, 80)
+    }
+
+    fn render_with_osc8_width(enabled: bool, source: &str, width: u16) -> String {
         with_osc8(enabled, || {
-            render_markdown(source, 80, Style::default())
+            render_markdown(source, width, Style::default())
                 .iter()
                 .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
                 .collect::<String>()
@@ -1223,6 +1273,22 @@ mod tests {
         assert!(
             joined.contains("\x1b]8;;https://example.com\x1b\\https://example.com\x1b]8;;\x1b\\"),
             "expected OSC 8 wrapper around URL; got {joined:?}"
+        );
+    }
+
+    #[test]
+    fn wrapped_osc_8_url_chunks_keep_full_link_target() {
+        let url = "https://raw.githubusercontent.com/Hmbown/deepseek-skills/main/index.json";
+        let joined = render_with_osc8_width(true, url, 34);
+        let full_target = format!("\x1b]8;;{url}\x1b\\");
+
+        assert!(
+            joined.matches(&full_target).count() > 1,
+            "expected each wrapped URL chunk to reopen the full OSC 8 target; got {joined:?}"
+        );
+        assert!(
+            !joined.contains("\x1b]8;;https://raw.githubusercontent.com/Hmbown/deepseek-skills/main/inde\x1b\\"),
+            "wrapped link must not expose a truncated OSC 8 target: {joined:?}"
         );
     }
 
@@ -1420,7 +1486,7 @@ mod tests {
     }
 
     fn render_paragraph_for_test(text: &str, width: usize) -> Vec<Line<'static>> {
-        render_line_with_links(text, width, Style::default(), Style::default())
+        with_osc8(false, || render_line_with_links(text, width, Style::default(), Style::default()))
     }
 
     #[test]

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -311,6 +311,12 @@ pub async fn run_tui(config: &Config, options: TuiOptions) -> Result<()> {
     // sequence is received. Terminals that do not understand it silently
     // ignore it.
     recover_terminal_modes(&mut stdout, use_mouse_capture, use_bracketed_paste);
+    let mut cleanup_guard = TerminalCleanupGuard {
+        use_alt_screen,
+        use_mouse_capture,
+        use_bracketed_paste,
+        defused: false,
+    };
     let color_depth = palette::ColorDepth::detect();
     let palette_mode = palette::PaletteMode::detect();
     tracing::debug!(
@@ -523,6 +529,7 @@ pub async fn run_tui(config: &Config, options: TuiOptions) -> Result<()> {
     persistence_actor::persist(PersistRequest::ClearCheckpoint);
     persistence_actor::persist(PersistRequest::Shutdown);
 
+    cleanup_guard.defused = true;
     pop_keyboard_enhancement_flags(terminal.backend_mut());
     execute!(terminal.backend_mut(), DisableFocusChange)?;
     disable_raw_mode()?;
@@ -569,6 +576,36 @@ fn terminal_probe_timeout(config: &Config) -> Duration {
         .unwrap_or(DEFAULT_TERMINAL_PROBE_TIMEOUT_MS)
         .clamp(100, 5_000);
     Duration::from_millis(timeout_ms)
+}
+
+struct TerminalCleanupGuard {
+    use_alt_screen: bool,
+    use_mouse_capture: bool,
+    use_bracketed_paste: bool,
+    defused: bool,
+}
+
+impl Drop for TerminalCleanupGuard {
+    fn drop(&mut self) {
+        if self.defused {
+            return;
+        }
+
+        let mut stdout = io::stdout();
+        pop_keyboard_enhancement_flags(&mut stdout);
+        let _ = execute!(stdout, DisableFocusChange);
+        let _ = disable_raw_mode();
+        if self.use_alt_screen {
+            let _ = execute!(stdout, LeaveAlternateScreen);
+        }
+        if self.use_mouse_capture {
+            let _ = execute!(stdout, DisableMouseCapture);
+        }
+        if self.use_bracketed_paste {
+            let _ = execute!(stdout, DisableBracketedPaste);
+        }
+        let _ = execute!(stdout, crossterm::cursor::Show);
+    }
 }
 
 /// Recognise composer input that is a `# foo` memory quick-add (#492).

--- a/npm/deepseek-tui/scripts/install.js
+++ b/npm/deepseek-tui/scripts/install.js
@@ -103,6 +103,18 @@ function isInstallContext(context) {
   return context === "install";
 }
 
+function isPnpmUserAgent(env = process.env) {
+  return String(env.npm_config_user_agent || "").toLowerCase().includes("pnpm/");
+}
+
+function shouldSkipOptionalPostinstall(
+  context,
+  argv = process.argv.slice(2),
+  env = process.env,
+) {
+  return isInstallContext(context) && isOptionalInstall(argv, env) && isPnpmUserAgent(env);
+}
+
 // Optional install only relaxes npm postinstall behavior. Runtime downloads
 // keep the normal retry/timeout budget so first-run recovery stays resilient.
 function defaultTimeoutMs(context = "runtime", env = process.env) {
@@ -1089,6 +1101,12 @@ async function run(options = {}) {
   if (process.env.DEEPSEEK_TUI_DISABLE_INSTALL === "1" || process.env.DEEPSEEK_DISABLE_INSTALL === "1") {
     return;
   }
+  if (shouldSkipOptionalPostinstall(context)) {
+    logInfo(
+      "pnpm optional postinstall detected; skipping install-time download. The binary will be checked on first run.",
+    );
+    return;
+  }
   const version = resolvePackageVersion();
   const repo = resolveRepo();
   const paths = binaryPaths();
@@ -1129,6 +1147,7 @@ module.exports = {
     isOptionalInstall,
     adoptExistingBinaryIfValid,
     shouldIgnoreInstallFailure,
+    shouldSkipOptionalPostinstall,
     defaultTimeoutMs,
     defaultStallMs,
     ensureBinary,

--- a/npm/deepseek-tui/test/postinstall.test.js
+++ b/npm/deepseek-tui/test/postinstall.test.js
@@ -24,6 +24,33 @@ test("optional mode only changes install-time defaults", () => {
   assert.equal(_internal.defaultStallMs("runtime", { DEEPSEEK_TUI_OPTIONAL_INSTALL: "1" }), 30_000);
 });
 
+test("pnpm optional postinstall skips install-time download", () => {
+  assert.equal(
+    _internal.shouldSkipOptionalPostinstall("install", ["--optional"], {
+      npm_config_user_agent: "pnpm/10.11.0 npm/? node/v22.15.0 win32 x64",
+    }),
+    true,
+  );
+  assert.equal(
+    _internal.shouldSkipOptionalPostinstall("runtime", ["--optional"], {
+      npm_config_user_agent: "pnpm/10.11.0 npm/? node/v22.15.0 win32 x64",
+    }),
+    false,
+  );
+  assert.equal(
+    _internal.shouldSkipOptionalPostinstall("install", [], {
+      npm_config_user_agent: "pnpm/10.11.0 npm/? node/v22.15.0 win32 x64",
+    }),
+    false,
+  );
+  assert.equal(
+    _internal.shouldSkipOptionalPostinstall("install", ["--optional"], {
+      npm_config_user_agent: "npm/11.3.0 node/v22.15.0 win32 x64",
+    }),
+    false,
+  );
+});
+
 test("optional install only swallows retryable download failures", () => {
   const socketHangUp = new Error("socket hang up");
   assert.equal(

--- a/web/app/[locale]/install/page.tsx
+++ b/web/app/[locale]/install/page.tsx
@@ -19,6 +19,8 @@ const FIRST_RUN = `deepseek`;
 const VERIFY = `deepseek --version
 deepseek doctor`;
 
+const UPDATE = `deepseek update`;
+
 const SET_KEY_BASH = `export DEEPSEEK_API_KEY=sk-...`;
 const SET_KEY_AUTH = `deepseek auth set --provider deepseek --api-key sk-...`;
 
@@ -149,11 +151,42 @@ export default async function InstallPage({ params }: { params: Promise<{ locale
         </p>
       </section>
 
-      {/* ③ FIRST RUN */}
+      {/* ③ UPDATE */}
+      <section className="mx-auto max-w-[1100px] px-6 py-10 hairline-t">
+        <div className="flex items-baseline gap-4 mb-5">
+          <Seal char="新" />
+          <div className="eyebrow">{isZh ? "03 · 更新" : "03 · Update"}</div>
+        </div>
+
+        <InstallCodeBlock cmd={UPDATE} copyLabel={copyLabel} copiedLabel={copiedLabel} />
+
+        <p className="mt-4 text-sm text-ink-soft leading-relaxed max-w-2xl">
+          {isZh ? (
+            <>
+              检查 GitHub Releases 是否有新版本并就地替换二进制。
+              通过 Homebrew 或 npm 安装的话，使用包管理器升级更稳：
+              <code className="inline">brew upgrade deepseek-tui</code> 或{" "}
+              <code className="inline">npm update -g deepseek-tui</code>。
+              Cargo 安装的可以重跑{" "}
+              <code className="inline">cargo install deepseek-tui-cli --locked --force</code>。
+            </>
+          ) : (
+            <>
+              Checks GitHub Releases for a newer version and replaces the binary in place. If you
+              installed via Homebrew or npm, prefer the package manager instead:{" "}
+              <code className="inline">brew upgrade deepseek-tui</code> or{" "}
+              <code className="inline">npm update -g deepseek-tui</code>. Cargo users can re-run{" "}
+              <code className="inline">cargo install deepseek-tui-cli --locked --force</code>.
+            </>
+          )}
+        </p>
+      </section>
+
+      {/* ④ FIRST RUN */}
       <section className="mx-auto max-w-[1100px] px-6 py-10 hairline-t">
         <div className="flex items-baseline gap-4 mb-5">
           <Seal char="始" />
-          <div className="eyebrow">{isZh ? "03 · 首次运行" : "03 · First run"}</div>
+          <div className="eyebrow">{isZh ? "04 · 首次运行" : "04 · First run"}</div>
         </div>
 
         <ol className="space-y-6 max-w-2xl">
@@ -220,12 +253,12 @@ export default async function InstallPage({ params }: { params: Promise<{ locale
         </ol>
       </section>
 
-      {/* ④ OTHER WAYS TO INSTALL */}
+      {/* ⑤ OTHER WAYS TO INSTALL */}
       <section id="other-ways" className="bg-paper-deep hairline-t hairline-b">
         <div className="mx-auto max-w-[1100px] px-6 py-12">
           <div className="flex items-baseline gap-4 mb-5">
             <Seal char="备" />
-            <div className="eyebrow">{isZh ? "04 · 其他安装方式" : "04 · Other ways to install"}</div>
+            <div className="eyebrow">{isZh ? "05 · 其他安装方式" : "05 · Other ways to install"}</div>
           </div>
           <h2 className="font-display text-3xl mb-2">
             {isZh ? "其他安装方式" : "Other ways to install"}
@@ -360,12 +393,12 @@ export default async function InstallPage({ params }: { params: Promise<{ locale
         </div>
       </section>
 
-      {/* ⑤ WHERE CONFIG LIVES */}
+      {/* ⑥ WHERE CONFIG LIVES */}
       <section className="mx-auto max-w-[1100px] px-6 py-12">
         <div className="flex items-baseline gap-4 mb-5">
           <Seal char="件" />
           <div className="eyebrow">
-            {isZh ? "05 · 配置文件位置" : "05 · Where config lives"}
+            {isZh ? "06 · 配置文件位置" : "06 · Where config lives"}
           </div>
         </div>
         <h2 className="font-display text-3xl mb-6">

--- a/web/app/[locale]/page.tsx
+++ b/web/app/[locale]/page.tsx
@@ -148,35 +148,31 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
               <pre className="code-block mt-2">
                 {isZh ? (
                   <>
-                    <span className="comment"># macOS / Linux — Cargo</span>{"\n"}
+                    <span className="comment"># 安装</span>{"\n"}
                     <span className="prompt">$</span> cargo install deepseek-tui-cli --locked{"\n"}
                     <span className="prompt">$</span> deepseek{"\n"}
                     <br />
-                    <span className="comment"># 或通过 npm 安装</span>{"\n"}
-                    <span className="prompt">$</span> npm i -g deepseek-tui{"\n"}
+                    <span className="comment"># 已安装？更新到最新版</span>{"\n"}
+                    <span className="prompt">$</span> deepseek update{"\n"}
                     <br />
-                    <span className="comment"># 首次运行会自动创建 <span className="key">~/.deepseek/</span></span>{"\n"}
-                    <br />
-                    <span className="comment"># 国内镜像</span>{"\n"}
-                    <span className="prompt">$</span> npm config set registry https://registry.npmmirror.com{"\n"}
-                    <span className="prompt">$</span> npm i -g deepseek-tui
+                    <span className="comment"># 首次运行会自动创建 <span className="key">~/.deepseek/</span></span>
                   </>
                 ) : (
                   <>
-                    <span className="comment"># macOS / Linux — Cargo</span>{"\n"}
+                    <span className="comment"># install</span>{"\n"}
                     <span className="prompt">$</span> cargo install deepseek-tui-cli --locked{"\n"}
                     <span className="prompt">$</span> deepseek{"\n"}
                     <br />
-                    <span className="comment"># or via npm wrapper</span>{"\n"}
-                    <span className="prompt">$</span> npm i -g deepseek-tui{"\n"}
+                    <span className="comment"># already installed? pull the latest</span>{"\n"}
+                    <span className="prompt">$</span> deepseek update{"\n"}
                     <br />
                     <span className="comment"># first run sets up <span className="key">~/.deepseek/</span></span>
                   </>
                 )}
               </pre>
               <div className="mt-3 flex items-center justify-between text-[0.7rem] font-mono text-ink-mute">
-                <span>{isZh ? `需要 Rust 1.88+ 或 Node ${facts.nodeEngines ?? ">=18"}` : `requires Rust 1.88+ or Node ${facts.nodeEngines ?? ">=18"}`}</span>
-                <Link href={isZh ? "/zh/install" : "/install"} className="text-indigo hover:underline">{isZh ? "其他系统 →" : "other OSes →"}</Link>
+                <span>{isZh ? "需要 Rust 1.88+ · 没有 Rust? 见其他方式" : "requires Rust 1.88+ · no Rust? see other ways"}</span>
+                <Link href={isZh ? "/zh/install" : "/install"} className="text-indigo hover:underline">{isZh ? "其他方式 →" : "other ways →"}</Link>
               </div>
             </div>
           </div>

--- a/web/lib/facts.generated.ts
+++ b/web/lib/facts.generated.ts
@@ -18,7 +18,7 @@ export interface RepoFacts {
 }
 
 export const FACTS: RepoFacts = {
-  "generatedAt": "2026-05-14T19:34:46.542Z",
+  "generatedAt": "2026-05-14T19:43:39.727Z",
   "version": "0.8.37",
   "crates": [
     "agent",


### PR DESCRIPTION
## Summary
- document the current website update path (`deepseek update` plus package-manager fallbacks)
- fix strict OpenAI-compatible provider payloads for Fireworks and tool metadata (#1592)
- avoid pnpm optional postinstall hangs by deferring binary checks to first run (#1637)
- restore terminal modes on early TUI exits, harvesting the safe cleanup-guard idea from #1630 (#1593, #1582)
- keep wrapped OSC 8 links clickable with the full target (#1577)

Fixes #1637.
Fixes #1592.
Fixes #1577.
Fixes #1593.
Fixes #1582.

## Tests
- cargo test -p deepseek-tui --bin deepseek-tui onboarding --locked
- cargo test -p deepseek-tui --bin deepseek-tui reasoning_effort_uses_openai_compatible_shape_for_fireworks --locked
- cargo test -p deepseek-tui --bin deepseek-tui chat_tool_wire_shape_omits_anthropic_only_metadata --locked
- cargo test -p deepseek-tui --bin deepseek-tui reasoning_effort --locked
- cargo test -p deepseek-tui --bin deepseek-tui osc_8 --locked
- cargo test -p deepseek-tui --bin deepseek-tui paragraph_wrap --locked
- node --test npm/deepseek-tui/test/install.test.js npm/deepseek-tui/test/postinstall.test.js npm/deepseek-tui/test/run.test.js
- cargo fmt --all -- --check
- cargo check --workspace --all-targets --locked
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- npm run lint (web)
- npx tsc --noEmit (web)
- git diff --check

## Notes
- No tag or publish action performed.
- PR #1630 was not merged as-is because its unconditional API-key prevalidation would bypass provider-aware onboarding; only the terminal cleanup guard was harvested.
- PR #1580 was not merged because it is mixed-scope and current main already has the absolute-slash-path composer classifier.