### PR TITLE
fix(tui): default Windows composer arrows to scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   default providers sync into the runtime config before the first request, and
   reselecting the active provider from the picker keeps the current model
   instead of falling back to the provider default (#1632).
+- **Windows wheel-as-arrow scrolling works with mouse capture enabled.**
+  `composer_arrows_scroll` now defaults on for Windows terminals even when
+  mouse capture is enabled, so wheel events that arrive as arrow keys scroll the
+  transcript instead of cycling composer history (#1578).
 
 ### Thanks
 
@@ -43,7 +47,9 @@ terminal cleanup-guard idea harvested from #1630, and **imkingjh999
 ([@imkingjh999](https://github.com/imkingjh999))** for the provider/model
 switching fixes harvested from #1642. Thanks to **Photo
 ([@eng2007](https://github.com/eng2007))** for the provider-aware `/model`
-picker catalog work harvested from #1201.
+picker catalog work harvested from #1201. Thanks to
+**[@kunpeng-ai-lab](https://github.com/kunpeng-ai-lab)** for the Windows
+composer scroll fix harvested from #1578.
 
 ## [0.8.37] - 2026-05-14
 

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -35,6 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   default providers sync into the runtime config before the first request, and
   reselecting the active provider from the picker keeps the current model
   instead of falling back to the provider default (#1632).
+- **Windows wheel-as-arrow scrolling works with mouse capture enabled.**
+  `composer_arrows_scroll` now defaults on for Windows terminals even when
+  mouse capture is enabled, so wheel events that arrive as arrow keys scroll the
+  transcript instead of cycling composer history (#1578).
 
 ### Thanks
 
@@ -43,7 +47,9 @@ terminal cleanup-guard idea harvested from #1630, and **imkingjh999
 ([@imkingjh999](https://github.com/imkingjh999))** for the provider/model
 switching fixes harvested from #1642. Thanks to **Photo
 ([@eng2007](https://github.com/eng2007))** for the provider-aware `/model`
-picker catalog work harvested from #1201.
+picker catalog work harvested from #1201. Thanks to
+**[@kunpeng-ai-lab](https://github.com/kunpeng-ai-lab)** for the Windows
+composer scroll fix harvested from #1578.
 
 ## [0.8.37] - 2026-05-14
 

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -1233,6 +1233,14 @@ impl std::ops::DerefMut for App {
 
 // === App State ===
 
+fn default_composer_arrows_scroll(use_mouse_capture: bool) -> bool {
+    default_composer_arrows_scroll_for_platform(use_mouse_capture, cfg!(windows))
+}
+
+fn default_composer_arrows_scroll_for_platform(use_mouse_capture: bool, is_windows: bool) -> bool {
+    is_windows || !use_mouse_capture
+}
+
 impl App {
     /// Cap on the session turn-cache history. Holds enough turns to debug a long
     /// session without being so large the on-screen `/cache` table wraps.
@@ -1629,7 +1637,7 @@ impl App {
                 .tui
                 .as_ref()
                 .and_then(|tui| tui.composer_arrows_scroll)
-                .unwrap_or(!use_mouse_capture),
+                .unwrap_or_else(|| default_composer_arrows_scroll(use_mouse_capture)),
             session_title: None,
         }
     }
@@ -4208,6 +4216,21 @@ mod tests {
             resume_session_id: None,
             initial_input: None,
         }
+    }
+
+    #[test]
+    fn composer_arrows_scroll_default_is_true_without_mouse_capture() {
+        assert!(default_composer_arrows_scroll_for_platform(false, false));
+    }
+
+    #[test]
+    fn composer_arrows_scroll_default_is_false_with_mouse_capture_on_non_windows() {
+        assert!(!default_composer_arrows_scroll_for_platform(true, false));
+    }
+
+    #[test]
+    fn composer_arrows_scroll_default_is_true_on_windows_even_with_mouse_capture() {
+        assert!(default_composer_arrows_scroll_for_platform(true, true));
     }
 
     struct EnvVarGuard {

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -5382,15 +5382,16 @@ fn composer_arrows_scroll_defaults_true_without_mouse_capture() {
 }
 
 #[test]
-fn composer_arrows_scroll_defaults_false_with_mouse_capture() {
+fn composer_arrows_scroll_defaults_follow_platform_with_mouse_capture() {
     let options = TuiOptions {
         use_mouse_capture: true,
         ..create_test_options()
     };
     let app = App::new(options, &Config::default());
-    assert!(
-        !app.composer_arrows_scroll,
-        "arrows-scroll must default to false when mouse capture is on"
+    assert_eq!(
+        app.composer_arrows_scroll,
+        cfg!(windows),
+        "arrows-scroll should default to true on Windows and false on other platforms when mouse capture is on"
     );
 }
 


### PR DESCRIPTION
## Summary
- default `composer_arrows_scroll` on for Windows even when mouse capture is enabled
- keep explicit `tui.composer_arrows_scroll` config overrides authoritative
- add deterministic helper coverage for Windows and non-Windows defaults
- document the v0.8.38 fix and credit the #1578 contribution

Fixes #1578.
Harvests the narrow Windows composer-scroll fix from #1578.

## Tests
- ./scripts/release/check-versions.sh
- cargo fmt --all -- --check
- git diff --check
- cargo test -p deepseek-tui --bin deepseek-tui composer_arrows_scroll --locked
- cargo clippy -p deepseek-tui --bin deepseek-tui --tests --locked -- -D warnings