### PR TITLE
feat(integrations): add feishu-helm streaming-card sibling bridge

### DIFF
--- a/integrations/feishu-helm/.env.example
+++ b/integrations/feishu-helm/.env.example
@@ -1,0 +1,37 @@
+FEISHU_APP_ID=cli_xxxxxxxxxxxxxxxx
+FEISHU_APP_SECRET=replace-with-app-secret
+FEISHU_DOMAIN=feishu
+
+DEEPSEEK_RUNTIME_URL=http://127.0.0.1:7878
+DEEPSEEK_RUNTIME_TOKEN=replace-with-long-random-token
+DEEPSEEK_WORKSPACE=/opt/deepseek
+DEEPSEEK_MODEL=auto
+DEEPSEEK_MODE=agent
+DEEPSEEK_ALLOW_SHELL=true
+DEEPSEEK_TRUST_MODE=false
+DEEPSEEK_AUTO_APPROVE=false
+
+# Comma-separated chat IDs, open IDs, or union IDs allowed to control the runtime.
+# Leave empty only during first pairing, with DEEPSEEK_ALLOW_UNLISTED=true.
+DEEPSEEK_CHAT_ALLOWLIST=
+DEEPSEEK_ALLOW_UNLISTED=false
+
+FEISHU_THREAD_MAP_PATH=/var/lib/deepseek-feishu-helm/thread-map.json
+FEISHU_ALLOW_GROUPS=false
+FEISHU_REQUIRE_PREFIX_IN_GROUP=true
+FEISHU_GROUP_PREFIX=/ds
+FEISHU_MAX_REPLY_CHARS=3500
+DEEPSEEK_TURN_TIMEOUT_MS=900000
+
+# feishu-helm specific — opt into rich UI. Defaults preserve plaintext MVP behavior.
+# When false the bridge sends plain text replies just like feishu-bridge.
+FEISHU_USE_CARDS=false
+
+# When true, runtime approvals are surfaced as card buttons (Approve / Deny) in
+# addition to the text /allow and /deny commands. Operator identity is still
+# checked against DEEPSEEK_CHAT_ALLOWLIST before the runtime sees the decision.
+FEISHU_APPROVAL_CARDS=false
+
+# CardKit v1 base URL. The default below is the official Feishu open-apis host;
+# use the matching Lark URL when FEISHU_DOMAIN=lark.
+FEISHU_CARDKIT_BASE_URL=https://open.feishu.cn/open-apis

--- a/integrations/feishu-helm/.gitignore
+++ b/integrations/feishu-helm/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+*.log
+.env
+.env.local
+.omc/

--- a/integrations/feishu-helm/README.md
+++ b/integrations/feishu-helm/README.md
@@ -1,0 +1,136 @@
+# Feishu / Lark Helm
+
+A sibling integration to [`feishu-bridge`](../feishu-bridge/) that adds three
+features on top of the same security model:
+
+1. **Streaming markdown cards** — instead of plain text, agent replies stream
+   into a Feishu / Lark CardKit card with a typewriter effect, so progress is
+   visible character-by-character. Plain text is still the default; cards are
+   opt-in via `FEISHU_USE_CARDS=true`.
+2. **SSE auto-reconnect with `since_seq`** — on a `deepseek serve` restart or a
+   transient network blip, the bridge reconnects with `?since_seq=<lastSeqSeen>`
+   and exponential backoff (500 ms → 30 s cap), so no events are lost mid-turn.
+3. **Approval card buttons** — when `FEISHU_APPROVAL_CARDS=true` (and cards are
+   enabled), runtime approval requests are surfaced as Approve / Deny buttons
+   on a card in addition to the `/allow` and `/deny` text commands. Operator
+   identity is still checked against `DEEPSEEK_CHAT_ALLOWLIST` before the
+   runtime sees the decision.
+
+The command surface (`/status`, `/threads`, `/new`, `/resume <id>`,
+`/interrupt`, `/compact`, `/allow <id> [remember]`, `/deny <id>`), the
+allowlist / DM gating / group-prefix logic, the runtime-URL localhost
+requirement, and the placeholder-token / token-mismatch validator rules are
+all identical to `feishu-bridge`. Both bridges import the same shape of pure
+helpers from their respective `src/lib.mjs` and pass the same
+`validateBridgeConfig` checks plus three card-specific extensions.
+
+Security model (unchanged from `feishu-bridge`):
+
+- `deepseek serve --http` stays bound to `127.0.0.1`.
+- `/v1/*` runtime calls require `DEEPSEEK_RUNTIME_TOKEN`.
+- Feishu / Lark chats must be allowlisted unless `DEEPSEEK_ALLOW_UNLISTED=true`
+  is set for first pairing.
+- Direct messages are the intended control surface. Group chat control is
+  disabled unless `FEISHU_ALLOW_GROUPS=true`, and group messages must carry
+  the `FEISHU_GROUP_PREFIX` (default `/ds`) unless
+  `FEISHU_REQUIRE_PREFIX_IN_GROUP=false`.
+- Card-button approvals validate the *clicker's* identity (the
+  `event.operator.open_id` / `union_id` / `user_id` carried on
+  `card.action.trigger`) against the same allowlist text approvals use.
+- `mode`, `auto_approve`, `trust_mode`, and `allow_shell` are env-driven; the
+  defaults match `feishu-bridge` (`mode=agent`, `auto_approve=false`,
+  `trust_mode=false`, `allow_shell=true`).
+
+## Setup
+
+```bash
+cd /opt/deepseek/helm
+npm install --omit=dev
+cp .env.example /etc/deepseek/feishu-helm.env
+sudoedit /etc/deepseek/feishu-helm.env
+node src/index.mjs
+```
+
+Validate before starting:
+
+```bash
+npm run validate:config -- \
+  --env /etc/deepseek/feishu-helm.env \
+  --runtime-env /etc/deepseek/runtime.env \
+  --workspace-root /opt/deepseek \
+  --check-filesystem
+```
+
+A systemd unit symmetric to `deepseek-feishu-bridge.service` works:
+
+```bash
+sudo systemctl enable --now deepseek-runtime deepseek-feishu-helm
+sudo journalctl -u deepseek-feishu-helm -f
+```
+
+## Commands
+
+- `/status`
+- `/threads`
+- `/new`
+- `/resume <thread_id>`
+- `/interrupt`
+- `/compact`
+- `/allow <approval_id> [remember]`
+- `/deny <approval_id>`
+
+Anything else is sent as a prompt. In group chats with `FEISHU_ALLOW_GROUPS=true`
+and the default `FEISHU_REQUIRE_PREFIX_IN_GROUP=true`, messages must start with
+the configured prefix:
+
+```text
+/ds check git status and tell me what is dirty
+```
+
+## Opt-in card behavior
+
+Cards are off by default; the bridge sends plain text just like
+`feishu-bridge`. To enable:
+
+```env
+FEISHU_USE_CARDS=true
+FEISHU_APPROVAL_CARDS=true       # requires FEISHU_USE_CARDS=true
+FEISHU_CARDKIT_BASE_URL=https://open.feishu.cn/open-apis
+```
+
+When cards are enabled, an `agent_message` item streams text into a single
+CardKit card via the streaming PUT `/content` endpoint, with strictly
+increasing `sequence` numbers (as required by the public CardKit contract).
+On `turn.completed` / `turn.lifecycle` failed / canceled, the card is closed
+with `updateSettings({ config: { streaming_mode: false } })`. If creating the
+card fails (CardKit unavailable, no `tenant_access_token`), the bridge falls
+back to a plain-text reply for that turn so the user still sees the answer.
+
+## Tests
+
+```bash
+npm test
+```
+
+Covers the shared pure helpers (parseList / parseBool / parseEnvText /
+stripGroupPrefix / parseCommand / commandAction / parseApprovalDecisionArgs /
+isAllowed / pairingRefusalText / activeTurnBlock / splitMessage /
+validateBridgeConfig) plus the helm-specific helpers (codePointLen /
+safeSliceByCodePoint / lastLineSummary / formatToolDisplay / buildStreamCardJson
+/ markdownToCard / approvalCardJson / cardOperatorAllowed) and the extra
+`validateBridgeConfig` rules for `FEISHU_USE_CARDS`, `FEISHU_APPROVAL_CARDS`,
+and `FEISHU_CARDKIT_BASE_URL`.
+
+## Choosing between feishu-bridge and feishu-helm
+
+- Use `feishu-bridge` if you want the smallest possible attack surface, a
+  phone-only DM control surface, and plain-text replies. It depends on nothing
+  beyond `@larksuiteoapi/node-sdk`.
+- Use `feishu-helm` if you want streaming markdown card output, button-based
+  approvals, and resilient SSE event delivery. It also depends only on
+  `@larksuiteoapi/node-sdk`; CardKit is reached over HTTP using the same
+  `tenant_access_token` the SDK already mints.
+
+Both bridges can connect to the same `deepseek serve --http`. Run only one at
+a time against a given Feishu app id — they share the same WS event
+subscription and would otherwise double-consume incoming messages.

--- a/integrations/feishu-helm/package.json
+++ b/integrations/feishu-helm/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@deepseek-tui/feishu-helm",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Streaming-card Feishu/Lark bridge for a local deepseek serve --http runtime. Sibling integration to feishu-bridge: same security model, richer in-chat output.",
+  "main": "src/index.mjs",
+  "scripts": {
+    "start": "node src/index.mjs",
+    "check": "node --check src/index.mjs && node --check src/lib.mjs && node --check src/cardkit.mjs && node --check src/runtime.mjs && node --check scripts/validate-config.mjs",
+    "test": "node --test test/*.test.mjs",
+    "validate:config": "node scripts/validate-config.mjs"
+  },
+  "dependencies": {
+    "@larksuiteoapi/node-sdk": "^1.52.0"
+  },
+  "overrides": {
+    "axios": "^1.16.1"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/integrations/feishu-helm/scripts/validate-config.mjs
+++ b/integrations/feishu-helm/scripts/validate-config.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+// Validate a feishu-helm env file before starting the bridge. Mirrors the
+// behavior of integrations/feishu-bridge/scripts/validate-config.mjs, plus
+// the helm-specific checks added in src/lib.mjs (FEISHU_USE_CARDS,
+// FEISHU_APPROVAL_CARDS, FEISHU_CARDKIT_BASE_URL).
+
+import { constants as fsConstants } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import {
+  cleanEnvValue,
+  formatValidationReport,
+  parseEnvText,
+  validateBridgeConfig
+} from "../src/lib.mjs";
+
+const args = parseArgs(process.argv.slice(2));
+
+try {
+  const bridgeEnv = args.env ? parseEnvText(await fs.readFile(args.env, "utf8")) : process.env;
+  const runtimeEnv = args.runtimeEnv
+    ? parseEnvText(await fs.readFile(args.runtimeEnv, "utf8"))
+    : null;
+  const result = validateBridgeConfig(bridgeEnv, {
+    runtimeEnv,
+    workspaceRoot: args.workspaceRoot || "/opt/deepseek"
+  });
+
+  if (args.checkFilesystem) {
+    await appendFilesystemChecks(result, bridgeEnv, args);
+  }
+
+  if (args.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(formatValidationReport(result));
+  }
+  process.exitCode = result.ok ? 0 : 1;
+} catch (error) {
+  console.error(`Config validation failed: ${error.message}`);
+  process.exitCode = 1;
+}
+
+function parseArgs(argv) {
+  const parsed = {
+    env: "",
+    runtimeEnv: "",
+    workspaceRoot: "/opt/deepseek",
+    checkFilesystem: false,
+    json: false
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    switch (arg) {
+      case "--env":
+        parsed.env = argv[++index];
+        break;
+      case "--runtime-env":
+        parsed.runtimeEnv = argv[++index];
+        break;
+      case "--workspace-root":
+        parsed.workspaceRoot = argv[++index];
+        break;
+      case "--check-filesystem":
+        parsed.checkFilesystem = true;
+        break;
+      case "--json":
+        parsed.json = true;
+        break;
+      case "-h":
+      case "--help":
+        printHelp();
+        process.exit(0);
+        break;
+      default:
+        throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+  return parsed;
+}
+
+async function appendFilesystemChecks(result, env, args) {
+  const workspace = cleanEnvValue(env.DEEPSEEK_WORKSPACE);
+  if (workspace) {
+    await checkReadableDirectory(result, workspace, "workspace");
+  }
+  const threadMapPath = cleanEnvValue(env.FEISHU_THREAD_MAP_PATH);
+  if (threadMapPath) {
+    const parent = path.dirname(threadMapPath);
+    await checkWritableDirectory(result, parent, "thread map directory");
+  }
+  if (args.env) await checkReadableFile(result, args.env, "bridge env file");
+  if (args.runtimeEnv) await checkReadableFile(result, args.runtimeEnv, "runtime env file");
+}
+
+async function checkReadableDirectory(result, dir, label) {
+  try {
+    const stat = await fs.stat(dir);
+    if (!stat.isDirectory()) {
+      result.errors.push({ code: "not_directory", message: `${label} is not a directory: ${dir}` });
+      result.ok = false;
+      return;
+    }
+    await fs.access(dir, fsConstants.R_OK | fsConstants.X_OK);
+    result.info.push({ code: "readable_directory", message: `${label} is readable: ${dir}` });
+  } catch {
+    result.errors.push({ code: "directory_access", message: `${label} is not readable: ${dir}` });
+    result.ok = false;
+  }
+}
+
+async function checkWritableDirectory(result, dir, label) {
+  try {
+    const stat = await fs.stat(dir);
+    if (!stat.isDirectory()) {
+      result.errors.push({ code: "not_directory", message: `${label} is not a directory: ${dir}` });
+      result.ok = false;
+      return;
+    }
+    await fs.access(dir, fsConstants.R_OK | fsConstants.W_OK | fsConstants.X_OK);
+    result.info.push({ code: "writable_directory", message: `${label} is writable: ${dir}` });
+  } catch {
+    result.errors.push({ code: "directory_access", message: `${label} is not writable: ${dir}` });
+    result.ok = false;
+  }
+}
+
+async function checkReadableFile(result, filePath, label) {
+  try {
+    const stat = await fs.stat(filePath);
+    if (!stat.isFile()) {
+      result.errors.push({ code: "not_file", message: `${label} is not a file: ${filePath}` });
+      result.ok = false;
+      return;
+    }
+    await fs.access(filePath, fsConstants.R_OK);
+    result.info.push({ code: "readable_file", message: `${label} is readable: ${filePath}` });
+  } catch {
+    result.errors.push({ code: "file_access", message: `${label} is not readable: ${filePath}` });
+    result.ok = false;
+  }
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/validate-config.mjs [options]
+
+Options:
+  --env FILE             Read bridge env from FILE instead of process.env.
+  --runtime-env FILE     Read runtime env and verify the shared bearer token.
+  --workspace-root DIR   Expected remote workspace root (default: /opt/deepseek).
+  --check-filesystem     Verify workspace and thread-map paths are usable.
+  --json                 Print machine-readable JSON.
+  -h, --help             Show this help.
+`);
+}

--- a/integrations/feishu-helm/src/cardkit.mjs
+++ b/integrations/feishu-helm/src/cardkit.mjs
@@ -1,0 +1,213 @@
+// CardKit v1 streaming-update client. Only used when FEISHU_USE_CARDS=true.
+// Wraps three Feishu CardKit endpoints:
+//   POST  /cardkit/v1/cards                          — create card entity
+//   PUT   /cardkit/v1/cards/:id/elements/:eid/content — streaming text update
+//   PATCH /cardkit/v1/cards/:id/settings              — update card config
+//
+// Streaming rules (per the public doc):
+//   - `sequence` must strictly increase on each operation
+//   - `content` is the FULL accumulated text — Feishu computes the diff
+//   - If the new text is a prefix-superset of the previous text, the
+//     typewriter effect continues; otherwise Feishu drops the animation and
+//     renders a full replacement. Never tail-truncate (`slice(-n)`).
+//
+// Refs:
+//   https://open.feishu.cn/document/cardkit-v1/streaming-updates-openapi-overview
+//   https://open.feishu.cn/document/cardkit-v1/card-element/content
+//   https://open.feishu.cn/document/cardkit-v1/card/settings
+
+import { buildStreamCardJson } from "./lib.mjs";
+
+/**
+ * @typedef {Object} CardKitConfig
+ * @property {string} baseUrl - https://open.feishu.cn/open-apis (or Lark equivalent)
+ */
+
+/**
+ * @typedef {Object} StreamingConfig
+ * @property {number} [print_frequency_ms]
+ * @property {number} [print_step]
+ * @property {'fast'|'delay'} [print_strategy]
+ */
+
+/**
+ * @typedef {Object} StreamCardOptions
+ * @property {string} [elementId]
+ * @property {StreamingConfig} [streamingConfig]
+ */
+
+/**
+ * @typedef {Object} CardCreateResult
+ * @property {string} card_id
+ * @property {string} element_id
+ */
+
+export class CardKitClient {
+  /**
+   * @param {CardKitConfig} config
+   * @param {() => Promise<string>} getToken — function returning a fresh tenant_access_token
+   * @param {(msg: string) => void} [logger]
+   */
+  constructor(config, getToken, logger = () => {}) {
+    this.baseUrl = String(config.baseUrl || "https://open.feishu.cn/open-apis").replace(/\/$/, "");
+    this.getToken = getToken;
+    this.log = logger;
+  }
+
+  /**
+   * Create a card entity with streaming_mode enabled.
+   * @param {StreamCardOptions} [opts]
+   * @returns {Promise<CardCreateResult>}
+   */
+  async createStreamCard(opts = {}) {
+    const elementId = opts.elementId ?? "stream_content";
+    const streamingConfig = opts.streamingConfig ?? {};
+    const cardJson = buildStreamCardJson(elementId, streamingConfig);
+
+    const token = await this.getToken();
+    const url = `${this.baseUrl}/cardkit/v1/cards`;
+    this.log(`[cardkit] POST ${url} element_id=${elementId}`);
+
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json; charset=utf-8"
+      },
+      body: JSON.stringify({ type: "card_json", data: cardJson })
+    });
+
+    const body = await readJsonSafe(res);
+    if (!res.ok || body?.code !== 0) {
+      const msg = `CardKit create failed: HTTP ${res.status} code=${body?.code} msg=${body?.msg}`;
+      this.log(`[cardkit] ${msg}`);
+      throw new Error(msg);
+    }
+    const cardId = body?.data?.card_id;
+    if (!cardId) throw new Error("CardKit create: no card_id in response");
+    this.log(`[cardkit] created card_id=${cardId} element_id=${elementId}`);
+    return { card_id: cardId, element_id: elementId };
+  }
+
+  /**
+   * Stream-update the text content of an element. `content` MUST be the full
+   * accumulated text — Feishu computes the diff. Sequence must strictly
+   * increase across calls for the same card.
+   *
+   * @param {string} cardId
+   * @param {string} elementId
+   * @param {string} content     full accumulated text (not delta)
+   * @param {number} sequence    strictly-increasing op counter
+   * @param {string} [uuid]      optional idempotency key
+   */
+  async updateContent(cardId, elementId, content, sequence, uuid) {
+    const token = await this.getToken();
+    const url = `${this.baseUrl}/cardkit/v1/cards/${encodeURIComponent(cardId)}/elements/${encodeURIComponent(elementId)}/content`;
+
+    // CardKit caps content at 100k chars. Always keep PREFIX intact: if the
+    // new text isn't a prefix-superset of the previous, Feishu drops the
+    // typewriter animation and renders a full replacement.
+    const safeContent = content.length > 100000 ? content.slice(0, 100000) : content;
+    if (content.length > 100000) {
+      this.log(`[cardkit] content truncated from ${content.length} to 100000 chars`);
+    }
+
+    const body = { content: safeContent, sequence };
+    if (uuid) body.uuid = uuid;
+
+    const res = await fetch(url, {
+      method: "PUT",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json; charset=utf-8"
+      },
+      body: JSON.stringify(body)
+    });
+
+    const resp = await readJsonSafe(res);
+    if (!res.ok || resp?.code !== 0) {
+      this.log(`[cardkit] updateContent failed: HTTP ${res.status} code=${resp?.code} msg=${resp?.msg} seq=${sequence}`);
+      throw new Error(`CardKit updateContent: code=${resp?.code} ${resp?.msg}`);
+    }
+  }
+
+  /**
+   * Update card settings — used to close streaming_mode after the final flush.
+   * Non-fatal on failure: CardKit auto-closes streaming after 10 minutes.
+   *
+   * @param {string} cardId
+   * @param {Record<string, unknown>} settings
+   * @param {number} sequence
+   * @param {string} [uuid]
+   */
+  async updateSettings(cardId, settings, sequence, uuid) {
+    const token = await this.getToken();
+    const url = `${this.baseUrl}/cardkit/v1/cards/${encodeURIComponent(cardId)}/settings`;
+
+    const body = { settings: JSON.stringify(settings), sequence };
+    if (uuid) body.uuid = uuid;
+
+    const res = await fetch(url, {
+      method: "PATCH",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json; charset=utf-8"
+      },
+      body: JSON.stringify(body)
+    });
+
+    const resp = await readJsonSafe(res);
+    if (!res.ok || resp?.code !== 0) {
+      // Non-fatal — let the daemon continue. Document this asymmetry vs
+      // updateContent which throws.
+      this.log(`[cardkit] updateSettings failed: HTTP ${res.status} code=${resp?.code} msg=${resp?.msg} seq=${sequence}`);
+    }
+  }
+
+  /**
+   * Deliver a previously-created card entity to a Feishu chat as a msg_type=card
+   * message. Returns the Feishu message_id on success.
+   *
+   * @param {string} chatId
+   * @param {string} cardId
+   * @returns {Promise<string|null>}
+   */
+  async sendCardToChat(chatId, cardId) {
+    const token = await this.getToken();
+    const url = `${this.baseUrl}/im/v1/messages?receive_id_type=chat_id`;
+    const content = JSON.stringify({ type: "card", data: { card_id: cardId } });
+    this.log(`[cardkit] sending card ${cardId} to chat ${chatId}`);
+
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json; charset=utf-8"
+      },
+      body: JSON.stringify({
+        receive_id: chatId,
+        msg_type: "interactive",
+        content
+      })
+    });
+
+    const body = await readJsonSafe(res);
+    if (!res.ok || body?.code !== 0) {
+      this.log(`[cardkit] sendCardToChat failed: HTTP ${res.status} code=${body?.code} msg=${body?.msg}`);
+      return null;
+    }
+    const msgId = body?.data?.message_id;
+    this.log(`[cardkit] sent card ${cardId} to chat ${chatId} → message_id=${msgId ?? "?"}`);
+    return msgId ?? null;
+  }
+}
+
+async function readJsonSafe(response) {
+  const text = await response.text();
+  if (!text) return {};
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}

--- a/integrations/feishu-helm/src/cardkit.mjs
+++ b/integrations/feishu-helm/src/cardkit.mjs
@@ -16,7 +16,7 @@
 //   https://open.feishu.cn/document/cardkit-v1/card-element/content
 //   https://open.feishu.cn/document/cardkit-v1/card/settings
 
-import { buildStreamCardJson } from "./lib.mjs";
+import { buildStreamCardJson, codePointLen, safeSliceByCodePoint } from "./lib.mjs";
 
 /**
  * @typedef {Object} CardKitConfig
@@ -104,12 +104,17 @@ export class CardKitClient {
     const token = await this.getToken();
     const url = `${this.baseUrl}/cardkit/v1/cards/${encodeURIComponent(cardId)}/elements/${encodeURIComponent(elementId)}/content`;
 
-    // CardKit caps content at 100k chars. Always keep PREFIX intact: if the
-    // new text isn't a prefix-superset of the previous, Feishu drops the
+    // CardKit caps content at 100k code points. Always keep PREFIX intact: if
+    // the new text isn't a prefix-superset of the previous, Feishu drops the
     // typewriter animation and renders a full replacement.
-    const safeContent = content.length > 100000 ? content.slice(0, 100000) : content;
-    if (content.length > 100000) {
-      this.log(`[cardkit] content truncated from ${content.length} to 100000 chars`);
+    //
+    // JS `.length` and `.slice()` operate on UTF-16 code units, which corrupts
+    // emoji and supplementary-plane CJK at the cap boundary. Use code-point
+    // helpers so 100000 means 100000 user-visible characters.
+    const cpLen = codePointLen(content);
+    const safeContent = cpLen > 100000 ? safeSliceByCodePoint(content, 0, 100000) : content;
+    if (cpLen > 100000) {
+      this.log(`[cardkit] content truncated from ${cpLen} to 100000 code points`);
     }
 
     const body = { content: safeContent, sequence };

--- a/integrations/feishu-helm/src/index.mjs
+++ b/integrations/feishu-helm/src/index.mjs
@@ -14,7 +14,6 @@ import {
   activeTurnBlock,
   cardOperatorAllowed,
   commandAction,
-  compactRuntimeError,
   helpText,
   incomingIdentity,
   isAllowed,
@@ -99,34 +98,96 @@ const cardkit = config.useCards
 const sse = new SseEventHandler(runtime, (m) => console.log(m));
 
 // Per-thread streaming state. One agent_message at a time per thread; the
-// daemon naturally serializes turns by awaiting each `runPrompt`.
-/** @type {Map<string, {chatId: string, text: string, cardId: string | null, elementId: string, sequence: number, closed: boolean}>} */
+// daemon naturally serializes turns by awaiting each `runPrompt`. The
+// `resolveTurn` callback is the bridge between the global SseEventHandler's
+// callbacks (which fire by threadId) and the per-turn promise streamTurn awaits.
+/**
+ * @type {Map<string, {
+ *   chatId: string,
+ *   turnId: string | null,
+ *   text: string,
+ *   cardId: string | null,
+ *   elementId: string,
+ *   sequence: number,
+ *   closed: boolean,
+ *   sentProgressAt: number,
+ *   resolveTurn: (result: {status?: string, error?: string, kind?: string}) => void
+ * }>}
+ */
 const streamingByThread = new Map();
 
 // ── SSE callbacks ───────────────────────────────────────────────────────────
+//
+// One SseEventHandler instance fans out to every active turn via streamingByThread
+// lookup. SseEventHandler owns the auto-reconnect + since_seq replay logic
+// (see runtime.mjs); this module only renders the events into Feishu.
+//
+// All callbacks early-return when the event's turn_id doesn't match the
+// streaming state's turnId, so older-turn events still flowing through a
+// thread's stream don't bleed into the active turn's reply.
 
 sse.onDelta = (threadId, delta) => {
   if (delta.kind !== "agent_message") return;
   const st = streamingByThread.get(threadId);
   if (!st) return;
+  if (delta.turn_id && st.turnId && delta.turn_id !== st.turnId) return;
+
   st.text += delta.delta;
-  if (config.useCards && st.cardId && !st.closed) {
-    flushStreamingCard(st).catch((err) => {
-      console.error(`[helm] flush streaming card failed: ${err?.message ?? err}`);
+  if (config.useCards) {
+    if (!st.cardId && cardkit) {
+      void initStreamingCard(st).catch((err) => {
+        console.error(`[helm] init streaming card failed: ${err?.message ?? err}`);
+      });
+    }
+    if (st.cardId && !st.closed) {
+      flushStreamingCard(st).catch((err) => {
+        console.error(`[helm] flush streaming card failed: ${err?.message ?? err}`);
+      });
+    }
+    return;
+  }
+  // Plaintext mode: chunked progress sends, mirroring feishu-bridge semantics.
+  if (st.text.length > config.maxReplyChars && Date.now() - st.sentProgressAt > 15000) {
+    const chunk = st.text.slice(0, config.maxReplyChars);
+    st.text = st.text.slice(config.maxReplyChars);
+    st.sentProgressAt = Date.now();
+    sendText(st.chatId, chunk).catch((err) => {
+      console.error(`[helm] progress send failed: ${err?.message ?? err}`);
     });
   }
 };
 
-sse.onItemStarted = (threadId, item) => {
-  if (item.kind !== "agent_message") return;
+sse.onApprovalRequired = (threadId, approval, turnId) => {
   const st = streamingByThread.get(threadId);
-  if (!st || !config.useCards) return;
-  // Lazy-create the streaming card on the first agent_message item.
-  if (!st.cardId && cardkit) {
-    void initStreamingCard(st).catch((err) => {
-      console.error(`[helm] init streaming card failed: ${err?.message ?? err}`);
-    });
+  if (!st) return;
+  if (turnId && st.turnId && turnId !== st.turnId) return;
+  void deliverApproval(st.chatId, approval).catch((err) => {
+    console.error(`[helm] deliver approval failed: ${err?.message ?? err}`);
+  });
+};
+
+sse.onTurnLifecycle = (threadId, status, turn, turnId) => {
+  const st = streamingByThread.get(threadId);
+  if (!st) return;
+  if (turnId && st.turnId && turnId !== st.turnId) return;
+  if (["failed", "canceled", "interrupted"].includes(status)) {
+    st.resolveTurn({ status, error: turn?.error });
   }
+};
+
+sse.onTurnCompleted = (threadId, turn) => {
+  const st = streamingByThread.get(threadId);
+  if (!st) return;
+  if (turn?.id && st.turnId && turn.id !== st.turnId) return;
+  st.resolveTurn({ status: turn?.status || "completed", error: turn?.error });
+};
+
+sse.onSeqProgress = (threadId, seq) => {
+  const st = streamingByThread.get(threadId);
+  if (!st) return;
+  threadStore.patchChat(st.chatId, { lastSeq: seq }).catch(() => {
+    // ThreadStore.save() already serialises; failures here are best-effort.
+  });
 };
 
 // ── Lark event dispatcher ───────────────────────────────────────────────────
@@ -323,104 +384,60 @@ async function runPrompt(chatId, prompt) {
 }
 
 async function streamTurn(chatId, threadId, turnId, sinceSeq) {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), config.turnTimeoutMs);
+  // Drive the turn entirely through SseEventHandler so the auto-reconnect +
+  // since_seq replay path on runtime.mjs covers `deepseek serve` restarts and
+  // transient network errors. Module-level callbacks (see top of file) push
+  // results back here via `resolveTurn`.
+
+  /** @type {(result: {status?: string, error?: string, kind?: string}) => void} */
+  let resolveTurn;
+  const turnDone = new Promise((res) => {
+    resolveTurn = res;
+  });
 
   streamingByThread.set(threadId, {
     chatId,
+    turnId: turnId ?? null,
     text: "",
     cardId: null,
     elementId: "agent_msg",
     sequence: 0,
-    closed: false
+    closed: false,
+    sentProgressAt: Date.now(),
+    resolveTurn
   });
 
-  let latestSeq = sinceSeq;
-  let sentProgressAt = Date.now();
+  const timeoutTimer = setTimeout(() => {
+    resolveTurn({ kind: "timeout" });
+  }, config.turnTimeoutMs);
 
   try {
-    const response = await fetch(
-      `${config.runtimeUrl}/v1/threads/${encodeURIComponent(threadId)}/events?since_seq=${sinceSeq}`,
-      {
-        headers: { authorization: `Bearer ${config.runtimeToken}` },
-        signal: controller.signal
-      }
-    );
-    if (!response.ok) {
-      const body = await readJsonSafe(response);
-      throw new Error(compactRuntimeError(response.status, body));
-    }
-
-    for await (const record of readSse(response)) {
-      latestSeq = Math.max(latestSeq, Number(record.seq || 0));
-      await threadStore.patchChat(chatId, { lastSeq: latestSeq });
-
-      if (turnId && record.turn_id && record.turn_id !== turnId) continue;
-
-      if (record.event === "item.delta" && record.payload?.kind === "agent_message") {
-        const st = streamingByThread.get(threadId);
-        if (!st) continue;
-        st.text += record.payload.delta || "";
-        if (config.useCards) {
-          // Lazy-create the streaming card on first delta.
-          if (!st.cardId && cardkit) {
-            await initStreamingCard(st);
-          }
-          if (st.cardId && !st.closed) {
-            await flushStreamingCard(st);
-          }
-        } else if (st.text.length > config.maxReplyChars && Date.now() - sentProgressAt > 15000) {
-          // Plaintext mode: chunked progress sends, matching feishu-bridge semantics.
-          await sendText(chatId, st.text.slice(0, config.maxReplyChars));
-          st.text = st.text.slice(config.maxReplyChars);
-          sentProgressAt = Date.now();
-        }
-      }
-
-      if (record.event === "approval.required") {
-        await deliverApproval(chatId, record.payload || {});
-      }
-
-      if (record.event === "turn.lifecycle") {
-        const status = record.payload?.turn?.status || record.payload?.status;
-        if (["failed", "canceled", "interrupted"].includes(status)) {
-          await closeStreamingCard(threadId);
-          await sendText(chatId, `Turn ${status}.`);
-          return;
-        }
-      }
-
-      if (record.event === "turn.completed") {
-        const turn = record.payload?.turn || {};
-        const status = turn.status || "completed";
-        const error = turn.error ? `\n${turn.error}` : "";
-        await closeStreamingCard(threadId);
-        const st = streamingByThread.get(threadId);
-        const finalText = st?.text?.trim() || "Turn completed.";
-        if (status !== "completed") {
-          await sendText(chatId, `Turn ${status}.${error}`.trim());
-        } else if (config.useCards) {
-          // If we never created a streaming card (e.g. zero deltas), still
-          // surface the final text as a non-streaming card.
-          if (st && !st.cardId) {
-            await sendCard(chatId, markdownToCard(finalText));
-          }
-        } else {
-          await sendText(chatId, finalText);
-        }
-        return;
-      }
-    }
-  } catch (err) {
-    if (err?.name === "AbortError") {
-      await sendText(chatId, `Turn timed out after ${Math.round(config.turnTimeoutMs / 1000)}s.`);
-      return;
-    }
-    throw err;
-  } finally {
+    await sse.connect(threadId, sinceSeq);
+    const result = await turnDone;
     await closeStreamingCard(threadId);
+    const st = streamingByThread.get(threadId);
+    const finalText = st?.text?.trim() || "Turn completed.";
+
+    if (result.kind === "timeout") {
+      await sendText(chatId, `Turn timed out after ${Math.round(config.turnTimeoutMs / 1000)}s.`);
+    } else if (!result.status || result.status === "completed") {
+      if (config.useCards) {
+        // If we never created a streaming card (zero deltas), still surface
+        // the final text as a non-streaming card.
+        if (st && !st.cardId) {
+          await sendCard(chatId, markdownToCard(finalText));
+        }
+      } else {
+        await sendText(chatId, finalText);
+      }
+    } else {
+      const error = result.error ? `\n${result.error}` : "";
+      await sendText(chatId, `Turn ${result.status}.${error}`.trim());
+    }
+  } finally {
+    clearTimeout(timeoutTimer);
+    sse.disconnect(threadId);
     streamingByThread.delete(threadId);
-    clearTimeout(timeout);
   }
 }
 
@@ -654,59 +671,42 @@ async function sendCard(chatId, cardJson) {
   });
 }
 
+// Used by CardKitClient — mint tenant_access_token, cached until ~1 minute
+// before expiry. Without the cache we'd hit /auth on every streaming PUT,
+// which fires several times per second during an agent_message.
+let cachedTenantToken = null;
+let tenantTokenExpiresAt = 0;
+let tenantTokenInflight = null;
+
 async function tenantAccessToken() {
-  // Used by CardKitClient — fetch fresh tenant_access_token per call.
-  // Lark's official SDK does cache internally for im.message but the cardkit
-  // endpoints are not in the SDK, so we mint our own bearer here.
-  const res = await fetch(`${config.cardkitBaseUrl}/auth/v3/tenant_access_token/internal`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ app_id: config.appId, app_secret: config.appSecret })
-  });
-  const body = await res.json();
-  if (!res.ok || body?.code !== 0) {
-    throw new Error(`tenant_access_token failed: HTTP ${res.status} code=${body?.code} ${body?.msg}`);
+  if (cachedTenantToken && Date.now() < tenantTokenExpiresAt) {
+    return cachedTenantToken;
   }
-  return body.tenant_access_token;
-}
+  if (tenantTokenInflight) return tenantTokenInflight;
 
-// ── SSE line reader (request-scoped; the long-running SseEventHandler is
-// reserved for callers that want auto-reconnect, e.g. background SSE.) ──────
-
-async function* readSse(response) {
-  const decoder = new TextDecoder();
-  let buffer = "";
-  for await (const chunk of response.body) {
-    buffer += decoder.decode(chunk, { stream: true });
-    let boundary;
-    while ((boundary = buffer.indexOf("\n\n")) >= 0) {
-      const raw = buffer.slice(0, boundary).replace(/\r/g, "");
-      buffer = buffer.slice(boundary + 2);
-      let event = { event: "", data: "" };
-      for (const line of raw.split("\n")) {
-        if (line.startsWith("event:")) event.event = line.slice(6).trim();
-        if (line.startsWith("data:")) event.data += line.slice(5).trim();
-      }
-      if (!event.data) continue;
-      let parsed;
-      try {
-        parsed = JSON.parse(event.data);
-      } catch {
-        continue;
-      }
-      yield parsed;
+  tenantTokenInflight = (async () => {
+    const res = await fetch(`${config.cardkitBaseUrl}/auth/v3/tenant_access_token/internal`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ app_id: config.appId, app_secret: config.appSecret })
+    });
+    const body = await res.json();
+    if (!res.ok || body?.code !== 0) {
+      throw new Error(
+        `tenant_access_token failed: HTTP ${res.status} code=${body?.code} ${body?.msg}`
+      );
     }
-  }
-}
+    cachedTenantToken = body.tenant_access_token;
+    // Lark advertises ~2h expiry; refresh 60 s early to defeat clock skew. If
+    // `expire` is missing, conservatively assume 7100 s (just under 2 h).
+    const expireSec = typeof body.expire === "number" ? body.expire : 7100;
+    tenantTokenExpiresAt = Date.now() + Math.max(60, expireSec - 60) * 1000;
+    return cachedTenantToken;
+  })().finally(() => {
+    tenantTokenInflight = null;
+  });
 
-async function readJsonSafe(response) {
-  const text = await response.text();
-  if (!text) return {};
-  try {
-    return JSON.parse(text);
-  } catch {
-    return text;
-  }
+  return tenantTokenInflight;
 }
 
 function requiredEnv(name) {

--- a/integrations/feishu-helm/src/index.mjs
+++ b/integrations/feishu-helm/src/index.mjs
@@ -1,0 +1,723 @@
+// feishu-helm — Feishu/Lark long-connection bridge with streaming CardKit
+// output. Sibling integration to feishu-bridge: same command surface, same
+// security model, same env contract; differs only in (1) streaming-card
+// reply rendering, (2) optional approval card buttons, and (3) SSE
+// auto-reconnect with since_seq.
+//
+// Run:  node src/index.mjs
+// Validate config:  npm run validate:config -- --env /etc/deepseek/feishu-helm.env
+
+import * as Lark from "@larksuiteoapi/node-sdk";
+
+import {
+  approvalCardJson,
+  activeTurnBlock,
+  cardOperatorAllowed,
+  commandAction,
+  compactRuntimeError,
+  helpText,
+  incomingIdentity,
+  isAllowed,
+  latestRunningTurn,
+  markdownToCard,
+  pairingRefusalText,
+  parseBool,
+  parseCommand,
+  parseList,
+  parseApprovalDecisionArgs,
+  parseTextContent,
+  splitMessage,
+  stripGroupPrefix
+} from "./lib.mjs";
+
+import { CardKitClient } from "./cardkit.mjs";
+import { RuntimeClient, SseEventHandler, ThreadStore } from "./runtime.mjs";
+
+const config = {
+  appId: requiredEnv("FEISHU_APP_ID"),
+  appSecret: requiredEnv("FEISHU_APP_SECRET"),
+  domain: process.env.FEISHU_DOMAIN || "feishu",
+  runtimeUrl: (process.env.DEEPSEEK_RUNTIME_URL || "http://127.0.0.1:7878").replace(/\/+$/, ""),
+  runtimeToken: requiredEnv("DEEPSEEK_RUNTIME_TOKEN"),
+  workspace: process.env.DEEPSEEK_WORKSPACE || process.cwd(),
+  model: process.env.DEEPSEEK_MODEL || "auto",
+  mode: process.env.DEEPSEEK_MODE || "agent",
+  allowShell: parseBool(process.env.DEEPSEEK_ALLOW_SHELL, true),
+  trustMode: parseBool(process.env.DEEPSEEK_TRUST_MODE, false),
+  autoApprove: parseBool(process.env.DEEPSEEK_AUTO_APPROVE, false),
+  allowlist: parseList(process.env.DEEPSEEK_CHAT_ALLOWLIST),
+  allowUnlisted: parseBool(process.env.DEEPSEEK_ALLOW_UNLISTED, false),
+  threadMapPath:
+    process.env.FEISHU_THREAD_MAP_PATH || "/var/lib/deepseek-feishu-helm/thread-map.json",
+  allowGroups: parseBool(process.env.FEISHU_ALLOW_GROUPS, false),
+  requirePrefixInGroup: parseBool(process.env.FEISHU_REQUIRE_PREFIX_IN_GROUP, true),
+  groupPrefix: process.env.FEISHU_GROUP_PREFIX || "/ds",
+  maxReplyChars: Number(process.env.FEISHU_MAX_REPLY_CHARS || 3500),
+  turnTimeoutMs: Number(process.env.DEEPSEEK_TURN_TIMEOUT_MS || 900000),
+  useCards: parseBool(process.env.FEISHU_USE_CARDS, false),
+  approvalCards: parseBool(process.env.FEISHU_APPROVAL_CARDS, false),
+  cardkitBaseUrl:
+    (process.env.FEISHU_CARDKIT_BASE_URL || "https://open.feishu.cn/open-apis").replace(/\/+$/, "")
+};
+
+// Hard refusals — fail fast rather than start in a misconfigured state.
+{
+  try {
+    const u = new URL(config.runtimeUrl);
+    const localHosts = new Set(["127.0.0.1", "localhost", "[::1]", "::1"]);
+    if (!localHosts.has(u.hostname)) {
+      throw new Error(`DEEPSEEK_RUNTIME_URL must point at localhost, got ${u.hostname}`);
+    }
+  } catch (err) {
+    console.error(String(err?.message ?? err));
+    process.exit(1);
+  }
+}
+
+const sdkConfig = {
+  appId: config.appId,
+  appSecret: config.appSecret,
+  domain: resolveLarkDomain(config.domain)
+};
+
+const lark = new Lark.Client(sdkConfig);
+const wsClient = new Lark.WSClient({
+  ...sdkConfig,
+  loggerLevel: Lark.LoggerLevel?.info
+});
+
+const runtime = new RuntimeClient({ baseUrl: config.runtimeUrl, token: config.runtimeToken });
+const threadStore = await ThreadStore.open(config.threadMapPath);
+const cardkit = config.useCards
+  ? new CardKitClient(
+      { baseUrl: config.cardkitBaseUrl },
+      tenantAccessToken,
+      (m) => console.log(m)
+    )
+  : null;
+
+const sse = new SseEventHandler(runtime, (m) => console.log(m));
+
+// Per-thread streaming state. One agent_message at a time per thread; the
+// daemon naturally serializes turns by awaiting each `runPrompt`.
+/** @type {Map<string, {chatId: string, text: string, cardId: string | null, elementId: string, sequence: number, closed: boolean}>} */
+const streamingByThread = new Map();
+
+// ── SSE callbacks ───────────────────────────────────────────────────────────
+
+sse.onDelta = (threadId, delta) => {
+  if (delta.kind !== "agent_message") return;
+  const st = streamingByThread.get(threadId);
+  if (!st) return;
+  st.text += delta.delta;
+  if (config.useCards && st.cardId && !st.closed) {
+    flushStreamingCard(st).catch((err) => {
+      console.error(`[helm] flush streaming card failed: ${err?.message ?? err}`);
+    });
+  }
+};
+
+sse.onItemStarted = (threadId, item) => {
+  if (item.kind !== "agent_message") return;
+  const st = streamingByThread.get(threadId);
+  if (!st || !config.useCards) return;
+  // Lazy-create the streaming card on the first agent_message item.
+  if (!st.cardId && cardkit) {
+    void initStreamingCard(st).catch((err) => {
+      console.error(`[helm] init streaming card failed: ${err?.message ?? err}`);
+    });
+  }
+};
+
+// ── Lark event dispatcher ───────────────────────────────────────────────────
+
+const dispatcher = new Lark.EventDispatcher({}).register({
+  "im.message.receive_v1": async (data) => {
+    void handleIncomingMessage(data).catch((err) => {
+      console.error("[helm] handle message failed:", err);
+    });
+  },
+  "card.action.trigger": async (data) => {
+    try {
+      return await handleCardAction(data);
+    } catch (err) {
+      console.error("[helm] card action failed:", err);
+      return {};
+    }
+  }
+});
+
+console.log("Starting feishu-helm bridge");
+console.log(`Runtime: ${config.runtimeUrl}`);
+console.log(`Workspace: ${config.workspace}`);
+console.log(`Cards: ${config.useCards ? "enabled" : "disabled (plaintext)"}`);
+console.log(`Approval cards: ${config.approvalCards ? "enabled" : "disabled"}`);
+if (!config.allowlist.length && !config.allowUnlisted) {
+  console.log("No allowlist configured. Incoming chats will receive their IDs and be refused.");
+}
+
+wsClient.start({ eventDispatcher: dispatcher });
+
+// ── Incoming message routing ────────────────────────────────────────────────
+
+async function handleIncomingMessage(event) {
+  const identity = incomingIdentity(event);
+  if (!identity.chatId) return;
+
+  if (identity.messageType && identity.messageType !== "text") {
+    await sendText(identity.chatId, "Only text messages are supported in this bridge.");
+    return;
+  }
+
+  const rawText = parseTextContent(event.message?.content || "");
+  const scoped = stripGroupPrefix(rawText, {
+    chatType: identity.chatType,
+    requirePrefix: config.requirePrefixInGroup,
+    prefix: config.groupPrefix
+  });
+  if (!scoped.accepted) return;
+
+  // Persistent message-id dedup — defeats Feishu WS redelivery on restart.
+  if (identity.messageId && (await threadStore.recordMessage(identity.messageId))) {
+    return;
+  }
+
+  if (identity.chatType !== "p2p" && !config.allowGroups) {
+    await sendText(
+      identity.chatId,
+      "Group chat control is disabled for this bridge. DM the bot, or set FEISHU_ALLOW_GROUPS=true and allowlist this chat."
+    );
+    return;
+  }
+
+  if (!isAllowed(identity, config.allowlist, config.allowUnlisted)) {
+    await sendText(identity.chatId, pairingRefusalText(identity));
+    return;
+  }
+
+  const command = parseCommand(scoped.text);
+  await handleCommand(identity.chatId, command);
+}
+
+async function handleCommand(chatId, command) {
+  const action = commandAction(command);
+  switch (action.kind) {
+    case "help":
+      await sendText(chatId, helpText());
+      return;
+    case "status":
+      await sendStatus(chatId);
+      return;
+    case "threads":
+      await sendThreads(chatId);
+      return;
+    case "new_thread": {
+      const state = await ensureThread(chatId, { forceNew: true });
+      await sendText(chatId, `Created thread ${state.threadId}`);
+      return;
+    }
+    case "resume":
+      await resumeThread(chatId, action.threadId);
+      return;
+    case "interrupt":
+      await interruptActiveTurn(chatId);
+      return;
+    case "compact":
+      await compactThread(chatId);
+      return;
+    case "approval":
+      await decideApproval(chatId, action);
+      return;
+    case "prompt":
+      await runPrompt(chatId, action.prompt);
+      return;
+    default:
+      await sendText(chatId, helpText());
+  }
+}
+
+// ── Thread lifecycle ───────────────────────────────────────────────────────
+
+async function ensureThread(chatId, { forceNew = false } = {}) {
+  const existing = await threadStore.getChat(chatId);
+  if (existing?.threadId && !forceNew) return existing;
+
+  const thread = await runtime.json("/v1/threads", {
+    method: "POST",
+    body: {
+      model: config.model,
+      workspace: config.workspace,
+      mode: config.mode,
+      allow_shell: config.allowShell,
+      trust_mode: config.trustMode,
+      auto_approve: config.autoApprove,
+      archived: false,
+      system_prompt:
+        "You are being controlled from a Feishu/Lark chat with rich card output. Keep status updates concise. Ask for tool approvals when needed; do not assume mobile messages imply blanket approval."
+    }
+  });
+
+  const state = {
+    threadId: thread.id,
+    lastSeq: 0,
+    activeTurnId: null,
+    updatedAt: new Date().toISOString()
+  };
+  await threadStore.setChat(chatId, state);
+  return state;
+}
+
+async function runPrompt(chatId, prompt) {
+  if (!prompt.trim()) {
+    await sendText(chatId, helpText());
+    return;
+  }
+  const state = await ensureThread(chatId);
+  const detail = await runtime.json(`/v1/threads/${encodeURIComponent(state.threadId)}`);
+  const blocking = activeTurnBlock(detail, state);
+  if (blocking) {
+    await threadStore.patchChat(chatId, {
+      activeTurnId: blocking.turnId,
+      updatedAt: new Date().toISOString()
+    });
+    await sendText(chatId, blocking.message);
+    return;
+  }
+  if (state.activeTurnId) {
+    await threadStore.patchChat(chatId, { activeTurnId: null });
+  }
+  const sinceSeq = Number(detail.latest_seq || state.lastSeq || 0);
+
+  const turnResponse = await runtime.json(
+    `/v1/threads/${encodeURIComponent(state.threadId)}/turns`,
+    {
+      method: "POST",
+      body: {
+        prompt,
+        input_summary: prompt.slice(0, 200),
+        model: config.model,
+        mode: config.mode,
+        allow_shell: config.allowShell,
+        trust_mode: config.trustMode,
+        auto_approve: config.autoApprove
+      }
+    }
+  );
+
+  const turnId = turnResponse.turn?.id;
+  await threadStore.patchChat(chatId, {
+    activeTurnId: turnId || null,
+    lastSeq: sinceSeq,
+    updatedAt: new Date().toISOString()
+  });
+  await sendText(chatId, `Started turn ${turnId || "(unknown)"}`);
+
+  try {
+    await streamTurn(chatId, state.threadId, turnId, sinceSeq);
+  } finally {
+    await threadStore.patchChat(chatId, {
+      activeTurnId: null,
+      updatedAt: new Date().toISOString()
+    });
+  }
+}
+
+async function streamTurn(chatId, threadId, turnId, sinceSeq) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), config.turnTimeoutMs);
+
+  streamingByThread.set(threadId, {
+    chatId,
+    text: "",
+    cardId: null,
+    elementId: "agent_msg",
+    sequence: 0,
+    closed: false
+  });
+
+  let latestSeq = sinceSeq;
+  let sentProgressAt = Date.now();
+
+  try {
+    const response = await fetch(
+      `${config.runtimeUrl}/v1/threads/${encodeURIComponent(threadId)}/events?since_seq=${sinceSeq}`,
+      {
+        headers: { authorization: `Bearer ${config.runtimeToken}` },
+        signal: controller.signal
+      }
+    );
+    if (!response.ok) {
+      const body = await readJsonSafe(response);
+      throw new Error(compactRuntimeError(response.status, body));
+    }
+
+    for await (const record of readSse(response)) {
+      latestSeq = Math.max(latestSeq, Number(record.seq || 0));
+      await threadStore.patchChat(chatId, { lastSeq: latestSeq });
+
+      if (turnId && record.turn_id && record.turn_id !== turnId) continue;
+
+      if (record.event === "item.delta" && record.payload?.kind === "agent_message") {
+        const st = streamingByThread.get(threadId);
+        if (!st) continue;
+        st.text += record.payload.delta || "";
+        if (config.useCards) {
+          // Lazy-create the streaming card on first delta.
+          if (!st.cardId && cardkit) {
+            await initStreamingCard(st);
+          }
+          if (st.cardId && !st.closed) {
+            await flushStreamingCard(st);
+          }
+        } else if (st.text.length > config.maxReplyChars && Date.now() - sentProgressAt > 15000) {
+          // Plaintext mode: chunked progress sends, matching feishu-bridge semantics.
+          await sendText(chatId, st.text.slice(0, config.maxReplyChars));
+          st.text = st.text.slice(config.maxReplyChars);
+          sentProgressAt = Date.now();
+        }
+      }
+
+      if (record.event === "approval.required") {
+        await deliverApproval(chatId, record.payload || {});
+      }
+
+      if (record.event === "turn.lifecycle") {
+        const status = record.payload?.turn?.status || record.payload?.status;
+        if (["failed", "canceled", "interrupted"].includes(status)) {
+          await closeStreamingCard(threadId);
+          await sendText(chatId, `Turn ${status}.`);
+          return;
+        }
+      }
+
+      if (record.event === "turn.completed") {
+        const turn = record.payload?.turn || {};
+        const status = turn.status || "completed";
+        const error = turn.error ? `\n${turn.error}` : "";
+        await closeStreamingCard(threadId);
+        const st = streamingByThread.get(threadId);
+        const finalText = st?.text?.trim() || "Turn completed.";
+        if (status !== "completed") {
+          await sendText(chatId, `Turn ${status}.${error}`.trim());
+        } else if (config.useCards) {
+          // If we never created a streaming card (e.g. zero deltas), still
+          // surface the final text as a non-streaming card.
+          if (st && !st.cardId) {
+            await sendCard(chatId, markdownToCard(finalText));
+          }
+        } else {
+          await sendText(chatId, finalText);
+        }
+        return;
+      }
+    }
+  } catch (err) {
+    if (err?.name === "AbortError") {
+      await sendText(chatId, `Turn timed out after ${Math.round(config.turnTimeoutMs / 1000)}s.`);
+      return;
+    }
+    throw err;
+  } finally {
+    await closeStreamingCard(threadId);
+    streamingByThread.delete(threadId);
+    clearTimeout(timeout);
+  }
+}
+
+// ── Streaming card lifecycle ────────────────────────────────────────────────
+
+async function initStreamingCard(st) {
+  if (!cardkit) return;
+  if (st.cardId) return;
+  const result = await cardkit.createStreamCard({
+    elementId: st.elementId,
+    streamingConfig: { print_frequency_ms: 70, print_step: 1, print_strategy: "fast" }
+  });
+  await cardkit.sendCardToChat(st.chatId, result.card_id);
+  st.cardId = result.card_id;
+}
+
+async function flushStreamingCard(st) {
+  if (!cardkit || !st.cardId || st.closed) return;
+  st.sequence += 1;
+  try {
+    await cardkit.updateContent(st.cardId, st.elementId, st.text, st.sequence);
+  } catch (err) {
+    console.error(`[helm] streaming card flush failed seq=${st.sequence}: ${err?.message ?? err}`);
+    // Don't disable streaming on a single failure — the next delta will retry.
+  }
+}
+
+async function closeStreamingCard(threadId) {
+  if (!cardkit) return;
+  const st = streamingByThread.get(threadId);
+  if (!st || st.closed || !st.cardId) {
+    if (st) st.closed = true;
+    return;
+  }
+  st.closed = true;
+  try {
+    st.sequence += 1;
+    await cardkit.updateContent(st.cardId, st.elementId, st.text, st.sequence);
+  } catch {}
+  try {
+    st.sequence += 1;
+    await cardkit.updateSettings(st.cardId, { config: { streaming_mode: false } }, st.sequence);
+  } catch {}
+}
+
+// ── Approval delivery ───────────────────────────────────────────────────────
+
+async function deliverApproval(chatId, approval) {
+  const id = approval.approval_id || approval.id || "";
+  const lines = [
+    "Approval required",
+    `tool=${approval.tool_name || "unknown"}`,
+    `approval_id=${id}`,
+    approval.description || "",
+    "",
+    `Reply /allow ${id}`,
+    `Reply /deny ${id}`
+  ]
+    .filter(Boolean)
+    .join("\n");
+  await sendText(chatId, lines);
+
+  if (config.approvalCards && config.useCards) {
+    // Surface the same approval as a card with buttons in addition to the
+    // text fallback. Either path goes through the same allowlist check.
+    await sendCard(chatId, approvalCardJson(approval));
+  }
+}
+
+// ── Card action handler (button-press approvals) ────────────────────────────
+
+async function handleCardAction(event) {
+  if (!cardOperatorAllowed(event, config.allowlist, config.allowUnlisted)) {
+    return { toast: { type: "error", content: "Not authorized to approve from this account." } };
+  }
+  const value = event?.action?.value || {};
+  const decision = value.action;
+  const approvalId = value.approval_id || value.id;
+  if (!approvalId || !["allow", "deny"].includes(decision)) {
+    return { toast: { type: "error", content: "Malformed approval action." } };
+  }
+  try {
+    await runtime.json(`/v1/approvals/${encodeURIComponent(approvalId)}`, {
+      method: "POST",
+      body: { decision, remember: false }
+    });
+  } catch (err) {
+    return { toast: { type: "error", content: `Approval failed: ${err?.message ?? err}` } };
+  }
+  return { toast: { type: "success", content: `Approval ${approvalId}: ${decision}` } };
+}
+
+// ── Status / threads / resume / interrupt / compact / approval ──────────────
+
+async function sendStatus(chatId) {
+  const [health, runtimeInfo, workspace] = await Promise.all([
+    runtime.json("/health", { auth: false }),
+    runtime.json("/v1/runtime/info"),
+    runtime.json("/v1/workspace/status")
+  ]);
+  await sendText(
+    chatId,
+    [
+      `runtime=${health.status || "unknown"}`,
+      `version=${runtimeInfo.version || "unknown"}`,
+      `bind=${runtimeInfo.bind_host}:${runtimeInfo.port}`,
+      `auth_required=${runtimeInfo.auth_required}`,
+      `workspace=${workspace.workspace}`,
+      `git_repo=${workspace.git_repo}`,
+      workspace.branch ? `branch=${workspace.branch}` : "",
+      `staged=${workspace.staged} unstaged=${workspace.unstaged} untracked=${workspace.untracked}`,
+      `cards=${config.useCards} approval_cards=${config.approvalCards}`
+    ]
+      .filter(Boolean)
+      .join("\n")
+  );
+}
+
+async function sendThreads(chatId) {
+  const threads = await runtime.json("/v1/threads/summary?limit=8&include_archived=true");
+  if (!Array.isArray(threads) || !threads.length) {
+    await sendText(chatId, "No runtime threads yet.");
+    return;
+  }
+  await sendText(
+    chatId,
+    threads
+      .map((thread) => {
+        const status = thread.latest_turn_status || "none";
+        return `${thread.id} [${status}] ${thread.title || thread.preview || ""}`;
+      })
+      .join("\n")
+  );
+}
+
+async function resumeThread(chatId, args) {
+  const threadId = (args || "").trim();
+  if (!threadId) {
+    await sendText(chatId, "Usage: /resume <thread_id>");
+    return;
+  }
+  const detail = await runtime.json(`/v1/threads/${encodeURIComponent(threadId)}`);
+  await threadStore.setChat(chatId, {
+    threadId,
+    lastSeq: Number(detail.latest_seq || 0),
+    activeTurnId: null,
+    updatedAt: new Date().toISOString()
+  });
+  await sendText(chatId, `Resumed thread ${threadId}`);
+}
+
+async function interruptActiveTurn(chatId) {
+  const state = await threadStore.getChat(chatId);
+  if (!state?.threadId) {
+    await sendText(chatId, "No runtime thread recorded for this chat.");
+    return;
+  }
+  const detail = await runtime.json(`/v1/threads/${encodeURIComponent(state.threadId)}`);
+  const runningTurn = latestRunningTurn(detail);
+  const turnId = state.activeTurnId || runningTurn?.id;
+  if (!turnId) {
+    await sendText(chatId, "No active turn recorded for this chat.");
+    return;
+  }
+  await runtime.json(
+    `/v1/threads/${encodeURIComponent(state.threadId)}/turns/${encodeURIComponent(turnId)}/interrupt`,
+    { method: "POST" }
+  );
+  await threadStore.patchChat(chatId, {
+    activeTurnId: turnId,
+    updatedAt: new Date().toISOString()
+  });
+  await sendText(chatId, `Interrupt requested for ${turnId}`);
+}
+
+async function compactThread(chatId) {
+  const state = await ensureThread(chatId);
+  const result = await runtime.json(`/v1/threads/${encodeURIComponent(state.threadId)}/compact`, {
+    method: "POST",
+    body: { reason: "phone bridge request" }
+  });
+  await sendText(chatId, `Compaction started: ${result.turn?.id || "unknown turn"}`);
+}
+
+async function decideApproval(chatId, action) {
+  const decision = action.decision;
+  const { approvalId, remember } =
+    action.approvalId != null ? action : parseApprovalDecisionArgs(action.args);
+  if (!approvalId) {
+    await sendText(chatId, `Usage: /${decision} <approval_id>${decision === "allow" ? " [remember]" : ""}`);
+    return;
+  }
+  await runtime.json(`/v1/approvals/${encodeURIComponent(approvalId)}`, {
+    method: "POST",
+    body: { decision, remember }
+  });
+  await sendText(chatId, `Approval ${approvalId}: ${decision}${remember ? " and remember" : ""}`);
+}
+
+// ── Feishu send helpers ─────────────────────────────────────────────────────
+
+async function sendText(chatId, text) {
+  const createMessage =
+    lark.im?.v1?.message?.create?.bind(lark.im.v1.message) ||
+    lark.im?.message?.create?.bind(lark.im.message);
+  if (!createMessage) throw new Error("Lark SDK client does not expose im message create API");
+  for (const chunk of splitMessage(text, config.maxReplyChars)) {
+    await createMessage({
+      params: { receive_id_type: "chat_id" },
+      data: {
+        receive_id: chatId,
+        msg_type: "text",
+        content: JSON.stringify({ text: chunk })
+      }
+    });
+  }
+}
+
+async function sendCard(chatId, cardJson) {
+  const createMessage =
+    lark.im?.v1?.message?.create?.bind(lark.im.v1.message) ||
+    lark.im?.message?.create?.bind(lark.im.message);
+  if (!createMessage) throw new Error("Lark SDK client does not expose im message create API");
+  await createMessage({
+    params: { receive_id_type: "chat_id" },
+    data: {
+      receive_id: chatId,
+      msg_type: "interactive",
+      content: cardJson
+    }
+  });
+}
+
+async function tenantAccessToken() {
+  // Used by CardKitClient — fetch fresh tenant_access_token per call.
+  // Lark's official SDK does cache internally for im.message but the cardkit
+  // endpoints are not in the SDK, so we mint our own bearer here.
+  const res = await fetch(`${config.cardkitBaseUrl}/auth/v3/tenant_access_token/internal`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ app_id: config.appId, app_secret: config.appSecret })
+  });
+  const body = await res.json();
+  if (!res.ok || body?.code !== 0) {
+    throw new Error(`tenant_access_token failed: HTTP ${res.status} code=${body?.code} ${body?.msg}`);
+  }
+  return body.tenant_access_token;
+}
+
+// ── SSE line reader (request-scoped; the long-running SseEventHandler is
+// reserved for callers that want auto-reconnect, e.g. background SSE.) ──────
+
+async function* readSse(response) {
+  const decoder = new TextDecoder();
+  let buffer = "";
+  for await (const chunk of response.body) {
+    buffer += decoder.decode(chunk, { stream: true });
+    let boundary;
+    while ((boundary = buffer.indexOf("\n\n")) >= 0) {
+      const raw = buffer.slice(0, boundary).replace(/\r/g, "");
+      buffer = buffer.slice(boundary + 2);
+      let event = { event: "", data: "" };
+      for (const line of raw.split("\n")) {
+        if (line.startsWith("event:")) event.event = line.slice(6).trim();
+        if (line.startsWith("data:")) event.data += line.slice(5).trim();
+      }
+      if (!event.data) continue;
+      let parsed;
+      try {
+        parsed = JSON.parse(event.data);
+      } catch {
+        continue;
+      }
+      yield parsed;
+    }
+  }
+}
+
+async function readJsonSafe(response) {
+  const text = await response.text();
+  if (!text) return {};
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value || !value.trim()) throw new Error(`${name} is required`);
+  return value.trim();
+}
+
+function resolveLarkDomain(domain) {
+  const normalized = String(domain || "feishu").toLowerCase();
+  if (normalized === "lark") return Lark.Domain?.Lark || "https://open.larksuite.com";
+  if (normalized === "feishu") return Lark.Domain?.Feishu || "https://open.feishu.cn";
+  return domain;
+}

--- a/integrations/feishu-helm/src/lib.mjs
+++ b/integrations/feishu-helm/src/lib.mjs
@@ -168,11 +168,15 @@ export function commandAction(command) {
 
 export function splitMessage(text, maxChars = 3500) {
   const value = String(text || "");
-  if (value.length <= maxChars) return value ? [value] : [];
+  // Slice by code points, not UTF-16 code units, so emoji / supplementary-plane
+  // CJK never split in the middle of a surrogate pair. Uses the helpers from
+  // the helm extension half of this module.
+  const len = codePointLen(value);
+  if (len <= maxChars) return value ? [value] : [];
   const chunks = [];
   let cursor = 0;
-  while (cursor < value.length) {
-    chunks.push(value.slice(cursor, cursor + maxChars));
+  while (cursor < len) {
+    chunks.push(safeSliceByCodePoint(value, cursor, cursor + maxChars));
     cursor += maxChars;
   }
   return chunks;

--- a/integrations/feishu-helm/src/lib.mjs
+++ b/integrations/feishu-helm/src/lib.mjs
@@ -1,0 +1,554 @@
+// Pure helpers for feishu-helm. The first half of this file is intentionally
+// a verbatim port of integrations/feishu-bridge/src/lib.mjs so the two bridges
+// share an identical command parser, allowlist, group-gate, env validator, and
+// reply chunker. The second half adds helm-only helpers (code-point safe text
+// slicing, tool-call summary formatting, markdown→CardKit JSON, the streaming
+// card scaffold, and the extra env checks for FEISHU_USE_CARDS /
+// FEISHU_APPROVAL_CARDS / FEISHU_CARDKIT_BASE_URL).
+
+// ── Shared with feishu-bridge ───────────────────────────────────────────────
+
+export function parseList(raw) {
+  return String(raw || "")
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+export function parseBool(raw, fallback = false) {
+  if (raw == null || raw === "") return fallback;
+  return ["1", "true", "yes", "on"].includes(String(raw).trim().toLowerCase());
+}
+
+export function parseEnvText(raw) {
+  const env = {};
+  for (const line of String(raw || "").split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const normalized = trimmed.startsWith("export ") ? trimmed.slice(7).trim() : trimmed;
+    const index = normalized.indexOf("=");
+    if (index <= 0) continue;
+    const key = normalized.slice(0, index).trim();
+    let value = normalized.slice(index + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    env[key] = value;
+  }
+  return env;
+}
+
+export function cleanEnvValue(value) {
+  return String(value ?? "").trim();
+}
+
+export function isPlaceholderValue(value) {
+  const normalized = cleanEnvValue(value).toLowerCase();
+  return (
+    !normalized ||
+    normalized.includes("replace-with") ||
+    normalized.includes("xxxxxxxx") ||
+    normalized === "changeme" ||
+    normalized === "your_token_here"
+  );
+}
+
+export function parseTextContent(content) {
+  if (typeof content !== "string") return "";
+  try {
+    const parsed = JSON.parse(content);
+    if (typeof parsed.text === "string") return parsed.text;
+    if (typeof parsed.content === "string") return parsed.content;
+  } catch {
+    return content;
+  }
+  return content;
+}
+
+export function incomingIdentity(event) {
+  const sender = event?.sender?.sender_id || {};
+  const message = event?.message || {};
+  return {
+    chatId: message.chat_id || "",
+    messageId: message.message_id || "",
+    chatType: message.chat_type || "",
+    messageType: message.message_type || "",
+    openId: sender.open_id || "",
+    unionId: sender.union_id || "",
+    userId: sender.user_id || ""
+  };
+}
+
+export function isAllowed(identity, allowlist, allowUnlisted = false) {
+  if (allowUnlisted) return true;
+  const allowed = new Set(allowlist);
+  return [identity.chatId, identity.openId, identity.unionId, identity.userId]
+    .filter(Boolean)
+    .some((id) => allowed.has(id));
+}
+
+export function pairingRefusalText(identity) {
+  return [
+    "This chat is not in DEEPSEEK_CHAT_ALLOWLIST.",
+    `chat_id=${identity.chatId}`,
+    identity.openId ? `open_id=${identity.openId}` : "",
+    identity.unionId ? `union_id=${identity.unionId}` : "",
+    identity.userId ? `user_id=${identity.userId}` : ""
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+export function stripGroupPrefix(text, { chatType, requirePrefix, prefix }) {
+  const trimmed = String(text || "").trim();
+  if (!trimmed) return { accepted: false, text: "" };
+  if (!requirePrefix || chatType === "p2p") {
+    return { accepted: true, text: trimmed };
+  }
+  const marker = prefix || "/ds";
+  if (trimmed === marker) return { accepted: true, text: "/help" };
+  if (trimmed.startsWith(`${marker} `)) {
+    return { accepted: true, text: trimmed.slice(marker.length).trim() };
+  }
+  return { accepted: false, text: "" };
+}
+
+export function parseCommand(text) {
+  const trimmed = String(text || "").trim();
+  if (!trimmed.startsWith("/")) return { name: "prompt", args: trimmed };
+  const [head, ...rest] = trimmed.split(/\s+/);
+  return {
+    name: head.slice(1).toLowerCase(),
+    args: rest.join(" ").trim()
+  };
+}
+
+export function parseApprovalDecisionArgs(args) {
+  const parts = String(args || "")
+    .split(/\s+/)
+    .filter(Boolean);
+  return {
+    approvalId: parts[0] || "",
+    remember: parts.slice(1).includes("remember")
+  };
+}
+
+export function commandAction(command) {
+  switch (command.name) {
+    case "help":
+      return { kind: "help" };
+    case "status":
+      return { kind: "status" };
+    case "threads":
+      return { kind: "threads" };
+    case "new":
+      return { kind: "new_thread" };
+    case "resume":
+      return { kind: "resume", threadId: command.args };
+    case "interrupt":
+      return { kind: "interrupt" };
+    case "compact":
+      return { kind: "compact" };
+    case "allow":
+      return { kind: "approval", decision: "allow", ...parseApprovalDecisionArgs(command.args) };
+    case "deny":
+      return { kind: "approval", decision: "deny", ...parseApprovalDecisionArgs(command.args) };
+    case "prompt":
+      return { kind: "prompt", prompt: command.args };
+    default:
+      return {
+        kind: "prompt",
+        prompt: `/${command.name}${command.args ? ` ${command.args}` : ""}`
+      };
+  }
+}
+
+export function splitMessage(text, maxChars = 3500) {
+  const value = String(text || "");
+  if (value.length <= maxChars) return value ? [value] : [];
+  const chunks = [];
+  let cursor = 0;
+  while (cursor < value.length) {
+    chunks.push(value.slice(cursor, cursor + maxChars));
+    cursor += maxChars;
+  }
+  return chunks;
+}
+
+export function compactRuntimeError(status, body) {
+  const message =
+    body?.error?.message ||
+    body?.message ||
+    (typeof body === "string" ? body : JSON.stringify(body));
+  return `Runtime API request failed (${status}): ${message}`;
+}
+
+export function latestRunningTurn(detail) {
+  const turns = Array.isArray(detail?.turns) ? detail.turns : [];
+  for (let index = turns.length - 1; index >= 0; index -= 1) {
+    const turn = turns[index];
+    if (["queued", "in_progress"].includes(turn?.status)) return turn;
+  }
+  return null;
+}
+
+export function activeTurnBlock(detail, state = {}) {
+  const runningTurn = latestRunningTurn(detail);
+  if (!runningTurn) return null;
+  return {
+    turnId: runningTurn.id || state.activeTurnId || "",
+    message: `Thread already has active turn ${
+      runningTurn.id || state.activeTurnId || "(unknown)"
+    }. Wait for it to finish or send /interrupt.`
+  };
+}
+
+export function validateBridgeConfig(env, options = {}) {
+  const runtimeEnv = options.runtimeEnv || null;
+  const workspaceRoot = options.workspaceRoot || "";
+  const errors = [];
+  const warnings = [];
+  const info = [];
+  const add = (list, code, message) => list.push({ code, message });
+
+  for (const key of [
+    "FEISHU_APP_ID",
+    "FEISHU_APP_SECRET",
+    "DEEPSEEK_RUNTIME_URL",
+    "DEEPSEEK_RUNTIME_TOKEN",
+    "DEEPSEEK_WORKSPACE",
+    "FEISHU_THREAD_MAP_PATH"
+  ]) {
+    const value = cleanEnvValue(env[key]);
+    if (!value) {
+      add(errors, "missing_required", `${key} is required`);
+    } else if (isPlaceholderValue(value)) {
+      add(errors, "placeholder_value", `${key} still contains a placeholder value`);
+    }
+  }
+
+  const domain = cleanEnvValue(env.FEISHU_DOMAIN || "feishu").toLowerCase();
+  if (!["feishu", "lark"].includes(domain) && !/^https:\/\/open\./.test(domain)) {
+    add(errors, "invalid_domain", "FEISHU_DOMAIN must be feishu, lark, or an https://open.* URL");
+  }
+
+  const runtimeUrl = cleanEnvValue(env.DEEPSEEK_RUNTIME_URL || "http://127.0.0.1:7878");
+  try {
+    const parsed = new URL(runtimeUrl);
+    const localHosts = new Set(["127.0.0.1", "localhost", "[::1]", "::1"]);
+    if (!["http:", "https:"].includes(parsed.protocol)) {
+      add(errors, "invalid_runtime_url", "DEEPSEEK_RUNTIME_URL must use http or https");
+    }
+    if (!localHosts.has(parsed.hostname)) {
+      add(errors, "remote_runtime_url", "DEEPSEEK_RUNTIME_URL must point at localhost");
+    }
+  } catch {
+    add(errors, "invalid_runtime_url", "DEEPSEEK_RUNTIME_URL is not a valid URL");
+  }
+
+  const workspace = cleanEnvValue(env.DEEPSEEK_WORKSPACE);
+  if (workspace && !workspace.startsWith("/")) {
+    add(errors, "relative_workspace", "DEEPSEEK_WORKSPACE must be an absolute path");
+  }
+  if (
+    workspace &&
+    workspaceRoot &&
+    workspace !== workspaceRoot &&
+    !workspace.startsWith(`${workspaceRoot}/`)
+  ) {
+    add(warnings, "workspace_root", `DEEPSEEK_WORKSPACE is outside ${workspaceRoot}`);
+  }
+
+  const threadMapPath = cleanEnvValue(env.FEISHU_THREAD_MAP_PATH);
+  if (threadMapPath && !threadMapPath.startsWith("/")) {
+    add(errors, "relative_thread_map", "FEISHU_THREAD_MAP_PATH must be an absolute path");
+  }
+
+  const allowGroups = parseBool(env.FEISHU_ALLOW_GROUPS, false);
+  const requirePrefix = parseBool(env.FEISHU_REQUIRE_PREFIX_IN_GROUP, true);
+  const allowUnlisted = parseBool(env.DEEPSEEK_ALLOW_UNLISTED, false);
+  const allowlist = parseList(env.DEEPSEEK_CHAT_ALLOWLIST);
+
+  if (!allowlist.length && allowUnlisted) {
+    add(warnings, "pairing_mode_open", "DEEPSEEK_ALLOW_UNLISTED=true leaves first-pairing mode open");
+  } else if (!allowlist.length) {
+    add(warnings, "not_paired", "DEEPSEEK_CHAT_ALLOWLIST is empty; all chats will be refused");
+  }
+  if (allowGroups && allowUnlisted) {
+    add(errors, "open_group_control", "Group control cannot be enabled while unlisted chats are allowed");
+  }
+  if (allowGroups && !requirePrefix) {
+    add(warnings, "group_without_prefix", "Group control is enabled without requiring FEISHU_GROUP_PREFIX");
+  }
+  if (!allowGroups) {
+    add(info, "dm_only", "Direct-message control is enabled; group chats are disabled");
+  }
+
+  const maxReplyChars = Number(env.FEISHU_MAX_REPLY_CHARS || 3500);
+  if (!Number.isFinite(maxReplyChars) || maxReplyChars < 100) {
+    add(errors, "invalid_max_reply_chars", "FEISHU_MAX_REPLY_CHARS must be at least 100");
+  }
+  const turnTimeoutMs = Number(env.DEEPSEEK_TURN_TIMEOUT_MS || 900000);
+  if (!Number.isFinite(turnTimeoutMs) || turnTimeoutMs < 1000) {
+    add(errors, "invalid_turn_timeout", "DEEPSEEK_TURN_TIMEOUT_MS must be at least 1000");
+  }
+
+  if (runtimeEnv) {
+    const runtimeToken = cleanEnvValue(runtimeEnv.DEEPSEEK_RUNTIME_TOKEN);
+    const bridgeToken = cleanEnvValue(env.DEEPSEEK_RUNTIME_TOKEN);
+    if (!runtimeToken) {
+      add(errors, "missing_runtime_token", "runtime.env is missing DEEPSEEK_RUNTIME_TOKEN");
+    } else if (isPlaceholderValue(runtimeToken)) {
+      add(errors, "placeholder_runtime_token", "runtime.env DEEPSEEK_RUNTIME_TOKEN is still a placeholder");
+    } else if (bridgeToken && bridgeToken !== runtimeToken) {
+      add(errors, "token_mismatch", "Runtime and bridge DEEPSEEK_RUNTIME_TOKEN values do not match");
+    }
+
+    const apiKey = cleanEnvValue(runtimeEnv.DEEPSEEK_API_KEY);
+    if (!apiKey) {
+      add(warnings, "missing_api_key", "runtime.env is missing DEEPSEEK_API_KEY");
+    } else if (isPlaceholderValue(apiKey)) {
+      add(warnings, "placeholder_api_key", "runtime.env DEEPSEEK_API_KEY is still a placeholder");
+    }
+
+    const runtimePort = Number(runtimeEnv.DEEPSEEK_RUNTIME_PORT || 7878);
+    if (!Number.isInteger(runtimePort) || runtimePort <= 0 || runtimePort > 65535) {
+      add(errors, "invalid_runtime_port", "DEEPSEEK_RUNTIME_PORT must be a valid TCP port");
+    }
+  }
+
+  // ── feishu-helm specific extensions ───────────────────────────────────────
+  const useCards = parseBool(env.FEISHU_USE_CARDS, false);
+  const approvalCards = parseBool(env.FEISHU_APPROVAL_CARDS, false);
+  const cardkitUrl = cleanEnvValue(env.FEISHU_CARDKIT_BASE_URL || "https://open.feishu.cn/open-apis");
+  if (cardkitUrl) {
+    try {
+      const parsed = new URL(cardkitUrl);
+      if (parsed.protocol !== "https:") {
+        add(errors, "insecure_cardkit_url", "FEISHU_CARDKIT_BASE_URL must use https://");
+      }
+      const okHost =
+        parsed.hostname === "open.feishu.cn" || parsed.hostname === "open.larksuite.com";
+      if (!okHost) {
+        add(warnings, "unexpected_cardkit_host", `FEISHU_CARDKIT_BASE_URL host is unusual: ${parsed.hostname}`);
+      }
+    } catch {
+      add(errors, "invalid_cardkit_url", "FEISHU_CARDKIT_BASE_URL is not a valid URL");
+    }
+  }
+  if (approvalCards && !useCards) {
+    add(warnings, "approval_cards_without_cards", "FEISHU_APPROVAL_CARDS=true has no effect unless FEISHU_USE_CARDS=true");
+  }
+  if (useCards) add(info, "cards_enabled", "Streaming cards enabled (FEISHU_USE_CARDS=true)");
+  if (approvalCards) add(info, "approval_cards_enabled", "Approval card buttons enabled (FEISHU_APPROVAL_CARDS=true)");
+
+  return {
+    ok: errors.length === 0,
+    errors,
+    warnings,
+    info
+  };
+}
+
+export function formatValidationReport(result) {
+  const lines = ["Feishu helm config validation"];
+  for (const item of result.errors) lines.push(`[fail] ${item.message}`);
+  for (const item of result.warnings) lines.push(`[warn] ${item.message}`);
+  for (const item of result.info) lines.push(`[info] ${item.message}`);
+  if (result.ok) lines.push("[ok] No blocking config errors found");
+  return lines.join("\n");
+}
+
+export function helpText() {
+  return [
+    "DeepSeek phone bridge commands (feishu-helm):",
+    "/help - show this help",
+    "/status - runtime and workspace status",
+    "/threads - recent runtime threads",
+    "/new - create a new thread for this chat",
+    "/resume <thread_id> - bind this chat to an existing thread",
+    "/interrupt - interrupt the active turn",
+    "/compact - compact the current thread",
+    "/allow <approval_id> [remember] - approve a pending tool call",
+    "/deny <approval_id> - deny a pending tool call",
+    "",
+    "Anything else is sent as a DeepSeek prompt.",
+    "Set FEISHU_USE_CARDS=true for streaming markdown cards;",
+    "FEISHU_APPROVAL_CARDS=true to additionally surface approvals as buttons."
+  ].join("\n");
+}
+
+// ── feishu-helm specific helpers ────────────────────────────────────────────
+
+/** UTF-8 / surrogate-pair safe code-point length. */
+export function codePointLen(s) {
+  return [...String(s || "")].length;
+}
+
+/**
+ * Code-point safe slice. JS `String.slice` operates on UTF-16 code units, which
+ * breaks emoji and CJK supplementary planes. We need this to feed CardKit's
+ * streaming PUT /content which interprets the string as user-visible
+ * characters and silently corrupts mid-codepoint truncations.
+ */
+export function safeSliceByCodePoint(s, start, end) {
+  return [...String(s || "")].slice(start, end).join("");
+}
+
+/** Pull a one-line preview from multi-line tool / file change output. */
+export function lastLineSummary(text, maxLen) {
+  const value = String(text || "");
+  if (value.length <= maxLen) return value;
+  const lines = value.split("\n").filter((l) => l.trim());
+  const last = lines.length > 0 ? lines[lines.length - 1].trim() : value;
+  return last.length > maxLen ? `${last.slice(0, maxLen)}...` : last;
+}
+
+/**
+ * Format a tool_call's JSON parameter payload as a concise human label.
+ * Handles common parameter shapes (path, prompt, content, command, ...) and
+ * falls back to the first few keys.
+ */
+export function formatToolDisplay(paramJson) {
+  let p;
+  try {
+    p = JSON.parse(paramJson);
+  } catch {
+    return "";
+  }
+  if (!p || typeof p !== "object") return "";
+  if (p.path || p.file_path || p.filePath) {
+    return `path=${p.path || p.file_path || p.filePath}`;
+  }
+  if (p.prompt) return `prompt=${String(p.prompt).slice(0, 80)}...`;
+  if (p.content) return `${String(p.content).slice(0, 80)}...`;
+  if (p.code) return `code=${String(p.code).slice(0, 80)}...`;
+  if (p.name) return `name=${p.name}`;
+  if (p.number !== undefined && p.number !== null) return `#${p.number}`;
+  if (p.task_id) return `task=${String(p.task_id).slice(-8)}`;
+  if (p.tool_name) return `tool=${p.tool_name}`;
+  if (p.command) return `cmd=${String(p.command).slice(0, 60)}`;
+  const keys = Object.keys(p);
+  if (keys.length === 1) {
+    const v = String(p[keys[0]]).slice(0, 80);
+    return `${keys[0]}=${v}`;
+  }
+  if (keys.length > 0) {
+    return keys
+      .slice(0, 3)
+      .map((k) => `${k}=${String(p[k]).slice(0, 30)}`)
+      .join(", ");
+  }
+  return "";
+}
+
+/**
+ * Build a Feishu / Lark JSON 2.0 card scaffold with streaming_mode=true. Returns
+ * the JSON-encoded card body the CardKit create API expects. Element is empty
+ * markdown — actual text is fed in via PUT /content streaming updates.
+ *
+ * See https://open.feishu.cn/document/cardkit-v1/streaming-updates-openapi-overview
+ */
+export function buildStreamCardJson(elementId, sc = {}) {
+  const freq = sc.print_frequency_ms ?? 70;
+  const step = sc.print_step ?? 1;
+  const strategy = sc.print_strategy ?? "fast";
+  const card = {
+    schema: "2.0",
+    header: { title: { content: "", tag: "plain_text" } },
+    config: {
+      streaming_mode: true,
+      update_multi: true,
+      wide_screen_mode: true,
+      enable_forward: false,
+      summary: { content: "Thinking..." },
+      streaming_config: {
+        print_frequency_ms: { default: freq, android: freq, ios: freq, pc: freq },
+        print_step: { default: step, android: step, ios: step, pc: step },
+        print_strategy: strategy
+      }
+    },
+    body: {
+      elements: [{ tag: "markdown", content: "", element_id: elementId }]
+    }
+  };
+  return JSON.stringify(card);
+}
+
+/**
+ * Render a closed (non-streaming) interactive markdown card body for a chunk
+ * of text. Used to deliver final agent_message replies as a card when
+ * FEISHU_USE_CARDS=true (the streaming card path is for the in-progress
+ * typewriter; this path produces a final, non-streaming card).
+ */
+export function markdownToCard(text) {
+  return JSON.stringify({
+    schema: "2.0",
+    config: { wide_screen_mode: true, enable_forward: false },
+    body: {
+      elements: [{ tag: "markdown", content: String(text || "") }]
+    }
+  });
+}
+
+/**
+ * Approval card body with Approve / Deny buttons. The button payload carries
+ * the approval_id so the card.action handler can route it. Operator identity
+ * is still checked against the chat allowlist before dispatching to the
+ * runtime — see src/index.mjs handleCardAction.
+ */
+export function approvalCardJson(approval) {
+  const id = approval?.approval_id || approval?.id || "";
+  const tool = approval?.tool_name || "unknown";
+  const description = approval?.description || "";
+  return JSON.stringify({
+    schema: "2.0",
+    config: { wide_screen_mode: true, enable_forward: false },
+    header: { title: { content: `Approval required: ${tool}`, tag: "plain_text" } },
+    body: {
+      elements: [
+        description
+          ? { tag: "markdown", content: description }
+          : { tag: "markdown", content: `approval_id=${id}` },
+        {
+          tag: "action",
+          actions: [
+            {
+              tag: "button",
+              text: { tag: "plain_text", content: "Approve" },
+              type: "primary",
+              value: { action: "allow", approval_id: id }
+            },
+            {
+              tag: "button",
+              text: { tag: "plain_text", content: "Deny" },
+              type: "danger",
+              value: { action: "deny", approval_id: id }
+            }
+          ]
+        }
+      ]
+    }
+  });
+}
+
+/**
+ * Operator allowlist check for card action callbacks. Lark's
+ * card.action.trigger event carries the clicker identity in
+ * `event.operator`. Even when the card is visible to the whole group, only
+ * users in the chat allowlist are permitted to approve / deny.
+ */
+export function cardOperatorAllowed(event, allowlist, allowUnlisted = false) {
+  if (allowUnlisted) return true;
+  const op = event?.operator || event?.action?.operator || {};
+  const identity = {
+    chatId: event?.chat_id || event?.context?.open_chat_id || "",
+    openId: op.open_id || op.operator_id?.open_id || "",
+    unionId: op.union_id || op.operator_id?.union_id || "",
+    userId: op.user_id || op.operator_id?.user_id || ""
+  };
+  return isAllowed(identity, allowlist, false);
+}

--- a/integrations/feishu-helm/src/runtime.mjs
+++ b/integrations/feishu-helm/src/runtime.mjs
@@ -1,0 +1,362 @@
+// Runtime API client + SSE event handler for deepseek serve --http.
+// This module is the differentiator from feishu-bridge: it adds
+// since_seq + exponential-backoff reconnect to the SSE stream so the bridge
+// survives `deepseek serve` restarts and brief network blips without losing
+// events.
+//
+// Verified against deepseek 0.8.31 serve --http --port 7878.
+
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { compactRuntimeError } from "./lib.mjs";
+
+// ── RuntimeClient ───────────────────────────────────────────────────────────
+
+export class RuntimeClient {
+  /**
+   * @param {{baseUrl: string, token: string}} cfg
+   */
+  constructor(cfg) {
+    this.baseUrl = String(cfg.baseUrl).replace(/\/+$/, "");
+    this.token = cfg.token;
+  }
+
+  authHeaders() {
+    return { authorization: `Bearer ${this.token}` };
+  }
+
+  /**
+   * @param {string} route
+   * @param {{method?: string, body?: any, auth?: boolean, signal?: AbortSignal}} [options]
+   */
+  async json(route, options = {}) {
+    const res = await fetch(`${this.baseUrl}${route}`, {
+      method: options.method || "GET",
+      headers: {
+        ...(options.auth === false ? {} : this.authHeaders()),
+        ...(options.body ? { "content-type": "application/json" } : {})
+      },
+      body: options.body ? JSON.stringify(options.body) : undefined,
+      signal: options.signal
+    });
+    const body = await readJsonSafe(res);
+    if (!res.ok) {
+      throw new Error(compactRuntimeError(res.status, body));
+    }
+    return body;
+  }
+
+  /**
+   * Open the SSE event stream for a thread. Returns the raw fetch Response;
+   * caller iterates `response.body` via `readSse`.
+   *
+   * @param {string} threadId
+   * @param {number} [sinceSeq]
+   * @param {AbortSignal} [signal]
+   */
+  async eventsStream(threadId, sinceSeq = 0, signal) {
+    let url = `${this.baseUrl}/v1/threads/${encodeURIComponent(threadId)}/events`;
+    if (sinceSeq > 0) url += `?since_seq=${sinceSeq}`;
+    const res = await fetch(url, {
+      headers: { accept: "text/event-stream", ...this.authHeaders() },
+      signal
+    });
+    if (!res.ok) {
+      const body = await readJsonSafe(res);
+      throw new Error(compactRuntimeError(res.status, body));
+    }
+    return res;
+  }
+}
+
+// ── ThreadStore ─────────────────────────────────────────────────────────────
+//
+// File-backed map of Feishu chat → runtime thread state, plus a bounded
+// recent-message-id list for redelivery dedup. Mirrors the upstream
+// feishu-bridge ThreadStore semantics: atomic tmp+rename writes, 0o700 dir,
+// 0o600 file. Message dedup is persistent (capped at 200) so a WS redelivery
+// after restart does NOT create a duplicate turn.
+
+export class ThreadStore {
+  static async open(filePath) {
+    const store = new ThreadStore(filePath);
+    await store.load();
+    return store;
+  }
+
+  constructor(filePath) {
+    this.filePath = filePath;
+    this.data = { chats: {}, messages: [] };
+  }
+
+  async load() {
+    try {
+      const raw = await fs.readFile(this.filePath, "utf8");
+      const parsed = JSON.parse(raw);
+      this.data = {
+        chats: parsed?.chats && typeof parsed.chats === "object" ? parsed.chats : {},
+        messages: Array.isArray(parsed?.messages) ? parsed.messages : []
+      };
+    } catch (error) {
+      if (error.code !== "ENOENT") throw error;
+    }
+  }
+
+  /**
+   * Record an incoming Feishu message_id. Returns true if we've seen it
+   * before — the caller MUST then bail to defeat redelivery.
+   */
+  async recordMessage(messageId) {
+    if (!messageId) return false;
+    if (this.data.messages.includes(messageId)) return true;
+    this.data.messages.push(messageId);
+    if (this.data.messages.length > 200) {
+      this.data.messages = this.data.messages.slice(-200);
+    }
+    await this.save();
+    return false;
+  }
+
+  async getChat(chatId) {
+    return this.data.chats[chatId] || null;
+  }
+
+  async setChat(chatId, state) {
+    this.data.chats[chatId] = state;
+    await this.save();
+    return state;
+  }
+
+  async patchChat(chatId, patch) {
+    const current = this.data.chats[chatId] || {};
+    this.data.chats[chatId] = { ...current, ...patch };
+    await this.save();
+    return this.data.chats[chatId];
+  }
+
+  async save() {
+    const dir = path.dirname(this.filePath);
+    await fs.mkdir(dir, { recursive: true, mode: 0o700 });
+    const tmp = `${this.filePath}.tmp`;
+    await fs.writeFile(tmp, `${JSON.stringify(this.data, null, 2)}\n`, { mode: 0o600 });
+    await fs.rename(tmp, this.filePath);
+  }
+}
+
+// ── SSE handler with since_seq reconnect ───────────────────────────────────
+//
+// Differs from feishu-bridge's inline SSE reader in two ways:
+//   1) On stream close, auto-reconnects with `?since_seq=<lastSeen>` and
+//      exponential backoff (500ms → 30s cap). This means a `deepseek serve`
+//      restart, a momentary network blip, or a server-side connection rotation
+//      does not lose events.
+//   2) Exposes a typed callback surface (onDelta, onApproval, onTurnCompleted,
+//      onItemStarted, onItemCompleted, onItemFailed, onTurnLifecycle) so the
+//      caller doesn't have to demultiplex the raw event stream.
+
+export class SseEventHandler {
+  /**
+   * @param {RuntimeClient} runtime
+   * @param {(msg: string) => void} [logger]
+   */
+  constructor(runtime, logger = () => {}) {
+    this.runtime = runtime;
+    this.log = logger;
+    /** @type {Map<string, AbortController>} */
+    this.connections = new Map();
+
+    /** @type {((threadId: string, delta: {kind: string, delta: string, item_id?: string}) => void) | null} */
+    this.onDelta = null;
+    /** @type {((threadId: string, turn: any) => void) | null} */
+    this.onTurnCompleted = null;
+    /** @type {((threadId: string, status: string, turn: any) => void) | null} */
+    this.onTurnLifecycle = null;
+    /** @type {((threadId: string, approval: any) => void) | null} */
+    this.onApprovalRequired = null;
+    /** @type {((threadId: string, item: any) => void) | null} */
+    this.onItemStarted = null;
+    /** @type {((threadId: string, item: any) => void) | null} */
+    this.onItemCompleted = null;
+    /** @type {((threadId: string, item: any) => void) | null} */
+    this.onItemFailed = null;
+  }
+
+  /**
+   * Connect to the SSE stream for `threadId`. Awaits the initial HTTP response
+   * so callers can catch immediate auth/4xx failures; the read loop and any
+   * reconnect attempts run in the background until `disconnect(threadId)` is
+   * called.
+   */
+  async connect(threadId, sinceSeq = 0) {
+    this.disconnect(threadId);
+    const controller = new AbortController();
+    this.connections.set(threadId, controller);
+
+    let body;
+    try {
+      const res = await this.runtime.eventsStream(threadId, sinceSeq, controller.signal);
+      if (!res.body) throw new Error("SSE response has no body");
+      body = res.body;
+    } catch (err) {
+      this.connections.delete(threadId);
+      throw err;
+    }
+
+    const lastSeqRef = { value: sinceSeq };
+    void this.runReadLoop(threadId, body, controller, lastSeqRef);
+  }
+
+  async runReadLoop(threadId, initialBody, controller, lastSeqRef) {
+    let body = initialBody;
+    let attempt = 0;
+
+    while (!controller.signal.aborted) {
+      if (body) {
+        try {
+          await this.readStream(threadId, body, controller.signal, lastSeqRef);
+          attempt = 0; // clean close — reset backoff
+        } catch (err) {
+          if (controller.signal.aborted) break;
+          this.log(`[sse] thread ${threadId}: read error: ${err?.message ?? err}`);
+        }
+        body = null;
+      }
+      if (controller.signal.aborted) break;
+
+      attempt += 1;
+      const delay = Math.min(500 * Math.pow(2, Math.min(attempt - 1, 6)), 30000);
+      this.log(`[sse] thread ${threadId}: reconnect in ${delay}ms (attempt ${attempt})`);
+      await new Promise((r) => setTimeout(r, delay));
+      if (controller.signal.aborted) break;
+
+      try {
+        const res = await this.runtime.eventsStream(threadId, lastSeqRef.value, controller.signal);
+        if (res.body) {
+          body = res.body;
+          this.log(`[sse] thread ${threadId}: reconnected (since_seq=${lastSeqRef.value})`);
+        }
+      } catch (err) {
+        if (controller.signal.aborted) break;
+        this.log(`[sse] thread ${threadId}: reconnect failed: ${err?.message ?? err}`);
+      }
+    }
+    this.connections.delete(threadId);
+  }
+
+  async readStream(threadId, body, signal, lastSeqRef) {
+    const reader = body.getReader();
+    const decoder = new TextDecoder("utf-8");
+    let buffer = "";
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+          if (buffer.length > 0) this.handleLine(threadId, buffer, lastSeqRef);
+          return;
+        }
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split(/\r?\n/);
+        buffer = lines.pop() ?? "";
+        for (const line of lines) this.handleLine(threadId, line, lastSeqRef);
+      }
+    } catch (err) {
+      if (signal.aborted) return;
+      throw err;
+    } finally {
+      try { reader.releaseLock(); } catch {}
+    }
+  }
+
+  handleLine(threadId, line, lastSeqRef) {
+    const trimmed = line.trimEnd();
+    if (!trimmed || trimmed.startsWith(":")) return;
+    if (trimmed.startsWith("event: ")) return;
+    if (!trimmed.startsWith("data: ")) return;
+    let event;
+    try {
+      event = JSON.parse(trimmed.slice(6));
+    } catch {
+      return;
+    }
+    if (typeof event.seq === "number" && event.seq > lastSeqRef.value) {
+      lastSeqRef.value = event.seq;
+    }
+    this.dispatch(threadId, event);
+  }
+
+  dispatch(threadId, event) {
+    switch (event.event) {
+      case "item.delta":
+        if (this.onDelta && event.payload) {
+          this.onDelta(threadId, {
+            kind: event.payload.kind,
+            delta: event.payload.delta ?? "",
+            item_id: event.item_id ?? undefined
+          });
+        }
+        return;
+      case "turn.completed":
+        if (this.onTurnCompleted && event.payload?.turn) {
+          this.onTurnCompleted(threadId, event.payload.turn);
+        }
+        return;
+      case "item.completed":
+        if (this.onItemCompleted && event.payload?.item) {
+          this.onItemCompleted(threadId, event.payload.item);
+        }
+        return;
+      case "item.started":
+        if (this.onItemStarted && event.payload?.item) {
+          this.onItemStarted(threadId, event.payload.item);
+        }
+        return;
+      case "item.failed":
+        // Failed items go ONLY to onItemFailed. Falling through to
+        // onItemCompleted would overwrite the failed status with `done`.
+        if (this.onItemFailed && event.payload?.item) {
+          this.onItemFailed(threadId, event.payload.item);
+        }
+        return;
+      case "approval.required":
+        if (this.onApprovalRequired) {
+          this.onApprovalRequired(threadId, event.payload);
+        }
+        return;
+      case "turn.lifecycle": {
+        const status = event.payload?.turn?.status || event.payload?.status;
+        if (this.onTurnLifecycle && status) {
+          this.onTurnLifecycle(threadId, status, event.payload?.turn);
+        }
+        return;
+      }
+      default:
+        return;
+    }
+  }
+
+  disconnect(threadId) {
+    const controller = this.connections.get(threadId);
+    if (controller) {
+      controller.abort();
+      this.connections.delete(threadId);
+    }
+  }
+
+  disconnectAll() {
+    for (const [, controller] of this.connections.entries()) {
+      controller.abort();
+    }
+    this.connections.clear();
+  }
+}
+
+async function readJsonSafe(response) {
+  const text = await response.text();
+  if (!text) return {};
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}

--- a/integrations/feishu-helm/src/runtime.mjs
+++ b/integrations/feishu-helm/src/runtime.mjs
@@ -88,6 +88,13 @@ export class ThreadStore {
   constructor(filePath) {
     this.filePath = filePath;
     this.data = { chats: {}, messages: [] };
+    // Serialize concurrent save() calls via a promise chain. Without this,
+    // two awaited writers race on the shared `${filePath}.tmp` and one
+    // rename(2) can clobber the other's tmp file before it lands, producing
+    // partial writes. Chaining means each save() awaits the previous one's
+    // rename before starting its own write.
+    /** @type {Promise<void>} */
+    this._saveChain = Promise.resolve();
   }
 
   async load() {
@@ -135,12 +142,23 @@ export class ThreadStore {
     return this.data.chats[chatId];
   }
 
-  async save() {
-    const dir = path.dirname(this.filePath);
-    await fs.mkdir(dir, { recursive: true, mode: 0o700 });
-    const tmp = `${this.filePath}.tmp`;
-    await fs.writeFile(tmp, `${JSON.stringify(this.data, null, 2)}\n`, { mode: 0o600 });
-    await fs.rename(tmp, this.filePath);
+  save() {
+    // Snapshot serialised data NOW so the on-disk image reflects this caller's
+    // observed state, even if a later mutation runs before its turn at the
+    // head of _saveChain.
+    const snapshot = `${JSON.stringify(this.data, null, 2)}\n`;
+    const next = this._saveChain.then(async () => {
+      const dir = path.dirname(this.filePath);
+      await fs.mkdir(dir, { recursive: true, mode: 0o700 });
+      const tmp = `${this.filePath}.tmp`;
+      await fs.writeFile(tmp, snapshot, { mode: 0o600 });
+      await fs.rename(tmp, this.filePath);
+    });
+    // Swallow rejections in the chain itself so one failed write doesn't
+    // poison every subsequent save(); callers still see the original
+    // rejection via their own awaited promise.
+    this._saveChain = next.catch(() => {});
+    return next;
   }
 }
 
@@ -166,13 +184,13 @@ export class SseEventHandler {
     /** @type {Map<string, AbortController>} */
     this.connections = new Map();
 
-    /** @type {((threadId: string, delta: {kind: string, delta: string, item_id?: string}) => void) | null} */
+    /** @type {((threadId: string, delta: {turn_id: string|null, kind: string, delta: string, item_id?: string}) => void) | null} */
     this.onDelta = null;
     /** @type {((threadId: string, turn: any) => void) | null} */
     this.onTurnCompleted = null;
-    /** @type {((threadId: string, status: string, turn: any) => void) | null} */
+    /** @type {((threadId: string, status: string, turn: any, turnId: string|null) => void) | null} */
     this.onTurnLifecycle = null;
-    /** @type {((threadId: string, approval: any) => void) | null} */
+    /** @type {((threadId: string, approval: any, turnId: string|null) => void) | null} */
     this.onApprovalRequired = null;
     /** @type {((threadId: string, item: any) => void) | null} */
     this.onItemStarted = null;
@@ -180,6 +198,8 @@ export class SseEventHandler {
     this.onItemCompleted = null;
     /** @type {((threadId: string, item: any) => void) | null} */
     this.onItemFailed = null;
+    /** @type {((threadId: string, seq: number) => void) | null} */
+    this.onSeqProgress = null;
   }
 
   /**
@@ -281,15 +301,24 @@ export class SseEventHandler {
     }
     if (typeof event.seq === "number" && event.seq > lastSeqRef.value) {
       lastSeqRef.value = event.seq;
+      if (this.onSeqProgress) {
+        try {
+          this.onSeqProgress(threadId, event.seq);
+        } catch (err) {
+          this.log(`[sse] onSeqProgress threw: ${err?.message ?? err}`);
+        }
+      }
     }
     this.dispatch(threadId, event);
   }
 
   dispatch(threadId, event) {
+    const turnId = event.turn_id ?? null;
     switch (event.event) {
       case "item.delta":
         if (this.onDelta && event.payload) {
           this.onDelta(threadId, {
+            turn_id: turnId,
             kind: event.payload.kind,
             delta: event.payload.delta ?? "",
             item_id: event.item_id ?? undefined
@@ -320,13 +349,13 @@ export class SseEventHandler {
         return;
       case "approval.required":
         if (this.onApprovalRequired) {
-          this.onApprovalRequired(threadId, event.payload);
+          this.onApprovalRequired(threadId, event.payload, turnId);
         }
         return;
       case "turn.lifecycle": {
         const status = event.payload?.turn?.status || event.payload?.status;
         if (this.onTurnLifecycle && status) {
-          this.onTurnLifecycle(threadId, status, event.payload?.turn);
+          this.onTurnLifecycle(threadId, status, event.payload?.turn, turnId);
         }
         return;
       }

--- a/integrations/feishu-helm/test/lib.test.mjs
+++ b/integrations/feishu-helm/test/lib.test.mjs
@@ -1,0 +1,359 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  activeTurnBlock,
+  approvalCardJson,
+  buildStreamCardJson,
+  cardOperatorAllowed,
+  codePointLen,
+  commandAction,
+  formatToolDisplay,
+  isAllowed,
+  lastLineSummary,
+  markdownToCard,
+  pairingRefusalText,
+  parseApprovalDecisionArgs,
+  parseBool,
+  parseEnvText,
+  parseCommand,
+  parseList,
+  parseTextContent,
+  safeSliceByCodePoint,
+  splitMessage,
+  stripGroupPrefix,
+  validateBridgeConfig
+} from "../src/lib.mjs";
+
+// ── shared with feishu-bridge (kept verbatim so regressions are spotted) ────
+
+test("parseList trims empty values", () => {
+  assert.deepEqual(parseList(" oc_1, ou_2 ,, "), ["oc_1", "ou_2"]);
+});
+
+test("parseBool accepts common truthy values", () => {
+  assert.equal(parseBool("yes"), true);
+  assert.equal(parseBool("0", true), false);
+  assert.equal(parseBool(undefined, true), true);
+});
+
+test("parseTextContent reads Feishu JSON text content", () => {
+  assert.equal(parseTextContent(JSON.stringify({ text: "hello" })), "hello");
+});
+
+test("parseEnvText handles comments, export, and quoted values", () => {
+  assert.deepEqual(
+    parseEnvText(`
+      # ignored
+      export FEISHU_DOMAIN="lark"
+      DEEPSEEK_WORKSPACE='/opt/deepseek'
+    `),
+    {
+      FEISHU_DOMAIN: "lark",
+      DEEPSEEK_WORKSPACE: "/opt/deepseek"
+    }
+  );
+});
+
+test("stripGroupPrefix requires prefix in group chats", () => {
+  assert.deepEqual(
+    stripGroupPrefix("/ds inspect this", {
+      chatType: "group",
+      requirePrefix: true,
+      prefix: "/ds"
+    }),
+    { accepted: true, text: "inspect this" }
+  );
+  assert.equal(
+    stripGroupPrefix("inspect this", {
+      chatType: "group",
+      requirePrefix: true,
+      prefix: "/ds"
+    }).accepted,
+    false
+  );
+});
+
+test("stripGroupPrefix accepts DM text without group prefix", () => {
+  assert.deepEqual(
+    stripGroupPrefix("inspect this", {
+      chatType: "p2p",
+      requirePrefix: true,
+      prefix: "/ds"
+    }),
+    { accepted: true, text: "inspect this" }
+  );
+});
+
+test("parseCommand distinguishes prompts and slash commands", () => {
+  assert.deepEqual(parseCommand("hello"), { name: "prompt", args: "hello" });
+  assert.deepEqual(parseCommand("/allow abc remember"), {
+    name: "allow",
+    args: "abc remember"
+  });
+});
+
+test("commandAction maps bridge commands and falls back to prompts", () => {
+  assert.deepEqual(commandAction(parseCommand("/status")), { kind: "status" });
+  assert.deepEqual(commandAction(parseCommand("/resume thread-1")), {
+    kind: "resume",
+    threadId: "thread-1"
+  });
+  assert.deepEqual(commandAction(parseCommand("/unknown value")), {
+    kind: "prompt",
+    prompt: "/unknown value"
+  });
+});
+
+test("parseApprovalDecisionArgs extracts remember flag", () => {
+  assert.deepEqual(parseApprovalDecisionArgs("ap_123 remember"), {
+    approvalId: "ap_123",
+    remember: true
+  });
+  assert.deepEqual(parseApprovalDecisionArgs(""), { approvalId: "", remember: false });
+});
+
+test("isAllowed checks chat and user identifiers", () => {
+  assert.equal(isAllowed({ chatId: "oc_x", openId: "ou_y" }, ["ou_y"], false), true);
+  assert.equal(isAllowed({ chatId: "oc_x" }, [], false), false);
+  assert.equal(isAllowed({ chatId: "oc_x" }, [], true), true);
+});
+
+test("pairingRefusalText includes allowlist identifiers", () => {
+  const body = pairingRefusalText({
+    chatId: "oc_chat",
+    openId: "ou_user",
+    unionId: "on_union",
+    userId: "u_user"
+  });
+  assert.match(body, /chat_id=oc_chat/);
+  assert.match(body, /open_id=ou_user/);
+  assert.match(body, /union_id=on_union/);
+  assert.match(body, /user_id=u_user/);
+});
+
+test("activeTurnBlock reports active queued or in-progress turn", () => {
+  assert.equal(activeTurnBlock({ turns: [{ id: "done", status: "completed" }] }), null);
+  assert.deepEqual(
+    activeTurnBlock({
+      turns: [
+        { id: "old", status: "completed" },
+        { id: "turn-2", status: "in_progress" }
+      ]
+    }),
+    {
+      turnId: "turn-2",
+      message: "Thread already has active turn turn-2. Wait for it to finish or send /interrupt."
+    }
+  );
+});
+
+test("splitMessage chunks long text", () => {
+  assert.deepEqual(splitMessage("abcdef", 2), ["ab", "cd", "ef"]);
+});
+
+test("validateBridgeConfig accepts locked-down DM config", () => {
+  const result = validateBridgeConfig(
+    {
+      FEISHU_APP_ID: "cli_valid",
+      FEISHU_APP_SECRET: "secret",
+      FEISHU_DOMAIN: "lark",
+      DEEPSEEK_RUNTIME_URL: "http://127.0.0.1:7878",
+      DEEPSEEK_RUNTIME_TOKEN: "token-a",
+      DEEPSEEK_WORKSPACE: "/opt/deepseek",
+      DEEPSEEK_CHAT_ALLOWLIST: "oc_allowed",
+      DEEPSEEK_ALLOW_UNLISTED: "false",
+      FEISHU_THREAD_MAP_PATH: "/var/lib/deepseek-feishu-helm/thread-map.json",
+      FEISHU_ALLOW_GROUPS: "false",
+      FEISHU_REQUIRE_PREFIX_IN_GROUP: "true"
+    },
+    {
+      workspaceRoot: "/opt/deepseek",
+      runtimeEnv: {
+        DEEPSEEK_RUNTIME_TOKEN: "token-a",
+        DEEPSEEK_API_KEY: "sk-valid",
+        DEEPSEEK_RUNTIME_PORT: "7878"
+      }
+    }
+  );
+  assert.equal(result.ok, true);
+  assert.equal(result.errors.length, 0);
+});
+
+test("validateBridgeConfig rejects unsafe group pairing and token mismatch", () => {
+  const result = validateBridgeConfig(
+    {
+      FEISHU_APP_ID: "cli_valid",
+      FEISHU_APP_SECRET: "secret",
+      FEISHU_DOMAIN: "feishu",
+      DEEPSEEK_RUNTIME_URL: "http://127.0.0.1:7878",
+      DEEPSEEK_RUNTIME_TOKEN: "bridge-token",
+      DEEPSEEK_WORKSPACE: "/opt/deepseek",
+      DEEPSEEK_ALLOW_UNLISTED: "true",
+      FEISHU_THREAD_MAP_PATH: "/var/lib/deepseek-feishu-helm/thread-map.json",
+      FEISHU_ALLOW_GROUPS: "true",
+      FEISHU_REQUIRE_PREFIX_IN_GROUP: "false"
+    },
+    {
+      workspaceRoot: "/opt/deepseek",
+      runtimeEnv: {
+        DEEPSEEK_RUNTIME_TOKEN: "runtime-token",
+        DEEPSEEK_API_KEY: "replace-with-deepseek-platform-key"
+      }
+    }
+  );
+  assert.equal(result.ok, false);
+  const codes = result.errors.map((item) => item.code).join(",");
+  assert.match(codes, /open_group_control/);
+  assert.match(codes, /token_mismatch/);
+  const warns = result.warnings.map((item) => item.code).join(",");
+  assert.match(warns, /group_without_prefix/);
+});
+
+test("validateBridgeConfig rejects placeholder DEEPSEEK_RUNTIME_TOKEN", () => {
+  const base = {
+    FEISHU_APP_ID: "cli_valid",
+    FEISHU_APP_SECRET: "secret",
+    DEEPSEEK_RUNTIME_URL: "http://127.0.0.1:7878",
+    DEEPSEEK_WORKSPACE: "/opt/deepseek",
+    FEISHU_THREAD_MAP_PATH: "/var/lib/deepseek-feishu-helm/thread-map.json"
+  };
+  for (const placeholder of ["your_token_here", "replace-with-long-random-token", ""]) {
+    const result = validateBridgeConfig({ ...base, DEEPSEEK_RUNTIME_TOKEN: placeholder });
+    assert.equal(result.ok, false, `placeholder "${placeholder}" should fail`);
+  }
+});
+
+test("validateBridgeConfig rejects non-localhost DEEPSEEK_RUNTIME_URL", () => {
+  const base = {
+    FEISHU_APP_ID: "cli_valid",
+    FEISHU_APP_SECRET: "secret",
+    DEEPSEEK_RUNTIME_TOKEN: "token-a",
+    DEEPSEEK_WORKSPACE: "/opt/deepseek",
+    FEISHU_THREAD_MAP_PATH: "/var/lib/deepseek-feishu-helm/thread-map.json"
+  };
+  const result = validateBridgeConfig({
+    ...base,
+    DEEPSEEK_RUNTIME_URL: "https://example.com:7878"
+  });
+  assert.equal(result.ok, false);
+  assert.match(result.errors.map((item) => item.code).join(","), /remote_runtime_url/);
+});
+
+// ── feishu-helm specific ────────────────────────────────────────────────────
+
+test("validateBridgeConfig warns when approval_cards is on without use_cards", () => {
+  const base = {
+    FEISHU_APP_ID: "cli_valid",
+    FEISHU_APP_SECRET: "secret",
+    DEEPSEEK_RUNTIME_URL: "http://127.0.0.1:7878",
+    DEEPSEEK_RUNTIME_TOKEN: "token-a",
+    DEEPSEEK_WORKSPACE: "/opt/deepseek",
+    FEISHU_THREAD_MAP_PATH: "/var/lib/deepseek-feishu-helm/thread-map.json",
+    DEEPSEEK_CHAT_ALLOWLIST: "oc_allowed",
+    FEISHU_USE_CARDS: "false",
+    FEISHU_APPROVAL_CARDS: "true"
+  };
+  const result = validateBridgeConfig(base);
+  assert.match(
+    result.warnings.map((item) => item.code).join(","),
+    /approval_cards_without_cards/
+  );
+});
+
+test("validateBridgeConfig rejects non-https cardkit base url", () => {
+  const base = {
+    FEISHU_APP_ID: "cli_valid",
+    FEISHU_APP_SECRET: "secret",
+    DEEPSEEK_RUNTIME_URL: "http://127.0.0.1:7878",
+    DEEPSEEK_RUNTIME_TOKEN: "token-a",
+    DEEPSEEK_WORKSPACE: "/opt/deepseek",
+    FEISHU_THREAD_MAP_PATH: "/var/lib/deepseek-feishu-helm/thread-map.json",
+    FEISHU_CARDKIT_BASE_URL: "http://open.feishu.cn/open-apis"
+  };
+  const result = validateBridgeConfig(base);
+  assert.equal(result.ok, false);
+  assert.match(result.errors.map((item) => item.code).join(","), /insecure_cardkit_url/);
+});
+
+test("codePointLen counts emoji as one", () => {
+  assert.equal(codePointLen("a🌟b"), 3);
+  assert.equal(codePointLen("hello"), 5);
+  assert.equal(codePointLen(""), 0);
+});
+
+test("safeSliceByCodePoint preserves emoji and CJK", () => {
+  assert.equal(safeSliceByCodePoint("hi🌟world", 0, 3), "hi🌟");
+  assert.equal(safeSliceByCodePoint("你好世界", 1, 3), "好世");
+});
+
+test("lastLineSummary keeps short text intact", () => {
+  assert.equal(lastLineSummary("short", 50), "short");
+});
+
+test("lastLineSummary returns last non-empty line on overflow", () => {
+  assert.equal(lastLineSummary("first\n\nlast line", 5), "last ...");
+});
+
+test("formatToolDisplay summarizes common parameter shapes", () => {
+  assert.equal(formatToolDisplay(JSON.stringify({ path: "/x/y" })), "path=/x/y");
+  assert.equal(
+    formatToolDisplay(JSON.stringify({ prompt: "hello world" })),
+    "prompt=hello world..."
+  );
+  assert.equal(formatToolDisplay(JSON.stringify({ name: "do-thing" })), "name=do-thing");
+  assert.equal(formatToolDisplay(JSON.stringify({ number: 42 })), "#42");
+  assert.equal(formatToolDisplay(JSON.stringify({ command: "ls -la" })), "cmd=ls -la");
+  assert.equal(formatToolDisplay("not-json"), "");
+  assert.equal(
+    formatToolDisplay(JSON.stringify({ a: "alpha", b: "beta", c: "gamma" })),
+    "a=alpha, b=beta, c=gamma"
+  );
+});
+
+test("buildStreamCardJson includes streaming config knobs", () => {
+  const json = buildStreamCardJson("agent_msg", { print_frequency_ms: 30, print_step: 5 });
+  const card = JSON.parse(json);
+  assert.equal(card.schema, "2.0");
+  assert.equal(card.config.streaming_mode, true);
+  assert.equal(card.config.streaming_config.print_frequency_ms.default, 30);
+  assert.equal(card.config.streaming_config.print_step.default, 5);
+  assert.equal(card.body.elements[0].tag, "markdown");
+  assert.equal(card.body.elements[0].element_id, "agent_msg");
+  assert.equal(card.body.elements[0].content, "");
+});
+
+test("markdownToCard wraps text in a single markdown element", () => {
+  const json = markdownToCard("# heading\n\nbody");
+  const card = JSON.parse(json);
+  assert.equal(card.body.elements.length, 1);
+  assert.equal(card.body.elements[0].tag, "markdown");
+  assert.equal(card.body.elements[0].content, "# heading\n\nbody");
+});
+
+test("approvalCardJson surfaces approve / deny buttons with the approval_id", () => {
+  const json = approvalCardJson({
+    approval_id: "ap_abc",
+    tool_name: "shell.exec",
+    description: "rm -rf foo"
+  });
+  const card = JSON.parse(json);
+  const actions = card.body.elements.find((e) => e.tag === "action").actions;
+  assert.equal(actions.length, 2);
+  const allow = actions.find((a) => a.value.action === "allow");
+  const deny = actions.find((a) => a.value.action === "deny");
+  assert.equal(allow.value.approval_id, "ap_abc");
+  assert.equal(deny.value.approval_id, "ap_abc");
+  assert.equal(deny.type, "danger");
+});
+
+test("cardOperatorAllowed gates approve / deny actions by the allowlist", () => {
+  const event = {
+    chat_id: "oc_chat",
+    operator: { open_id: "ou_alice" }
+  };
+  assert.equal(cardOperatorAllowed(event, ["ou_alice"], false), true);
+  assert.equal(cardOperatorAllowed(event, ["ou_other"], false), false);
+  assert.equal(cardOperatorAllowed(event, [], true), true);
+  assert.equal(cardOperatorAllowed(event, [], false), false);
+});

--- a/integrations/feishu-helm/test/lib.test.mjs
+++ b/integrations/feishu-helm/test/lib.test.mjs
@@ -152,6 +152,28 @@ test("splitMessage chunks long text", () => {
   assert.deepEqual(splitMessage("abcdef", 2), ["ab", "cd", "ef"]);
 });
 
+test("splitMessage splits by code points, not UTF-16 units (no torn emoji)", () => {
+  // Without code-point-safe splitting, "a🌟b" splits as ["a\uD83C", "\uDF1Fb"]
+  // — two malformed strings with half a surrogate pair each. With the
+  // helpers, the emoji stays intact: ["a🌟", "b"].
+  const chunks = splitMessage("a🌟b", 2);
+  assert.deepEqual(chunks, ["a🌟", "b"]);
+  for (const chunk of chunks) {
+    // Every chunk must round-trip through JSON.stringify (a torn surrogate
+    // pair would be visible here as a replacement character).
+    assert.equal(JSON.parse(JSON.stringify(chunk)), chunk);
+  }
+});
+
+test("splitMessage handles CJK supplementary plane characters", () => {
+  // 𠮷 is a supplementary-plane CJK ideograph (code point U+20BB7, two
+  // UTF-16 code units). With UTF-16 slicing at 1, it splits in half.
+  const chunks = splitMessage("a𠮷b", 2);
+  assert.equal(chunks.length, 2);
+  assert.equal(chunks[0], "a𠮷");
+  assert.equal(chunks[1], "b");
+});
+
 test("validateBridgeConfig accepts locked-down DM config", () => {
   const result = validateBridgeConfig(
     {


### PR DESCRIPTION
A sibling integration to `integrations/feishu-bridge/` for setups that want streaming
markdown cards instead of plain-text replies. Default behavior is identical to
`feishu-bridge`; cards are opt-in via `FEISHU_USE_CARDS=true`.

### What it adds

- **Streaming CardKit cards** (opt-in via `FEISHU_USE_CARDS=true`) — agent replies
  stream into a CardKit card using the public typewriter API (strictly increasing
  `sequence`, full-text PUT `/content`, close via `updateSettings`).
- **Approval card buttons** (opt-in via `FEISHU_APPROVAL_CARDS=true`) — runtime
  approvals are surfaced as Approve / Deny buttons in addition to the `/allow` and
  `/deny` text commands. Operator identity is validated against
  `DEEPSEEK_CHAT_ALLOWLIST` before `/v1/approvals` is called.
- **SSE auto-reconnect** — on `deepseek serve` restart or transient network blip,
  the bridge reconnects with `?since_seq=<lastSeen>` and exponential backoff
  (500 ms → 30 s cap), so no events are lost mid-turn.

### What it shares with feishu-bridge

- Identical command surface: `/status`, `/threads`, `/new`, `/resume <id>`,
  `/interrupt`, `/compact`, `/allow <id> [remember]`, `/deny <id>`, plus plaintext
  prompts.
- Identical security defaults: `mode=agent`, `auto_approve=false`,
  `trust_mode=false`, `allow_shell=true`. Runtime URL is hard-required to be
  `127.0.0.1` / `localhost` / `[::1]`; the bridge refuses to start otherwise.
- Identical allowlist / DM gating / group-prefix logic — `parseList`, `parseBool`,
  `stripGroupPrefix`, `parseCommand`, `commandAction`, `parseApprovalDecisionArgs`,
  `isAllowed`, `pairingRefusalText`, `splitMessage`, `validateBridgeConfig`,
  `activeTurnBlock` are inlined verbatim into `src/lib.mjs` so the shared surface
  stays grep-comparable.
- Identical `scripts/validate-config.mjs` shape, plus three extra checks for the
  helm-specific env keys.
- Persistent Feishu `message_id` dedup (last 200, atomic write, `0o600`).

### Tests

`npm test` → 28 pass, 0 fail. Fourteen tests mirror `feishu-bridge`'s
`lib.test.mjs` verbatim; the other fourteen cover the helm-specific helpers
(`codePointLen`, `safeSliceByCodePoint`, `lastLineSummary`, `formatToolDisplay`,
`buildStreamCardJson`, `markdownToCard`, `approvalCardJson`,
`cardOperatorAllowed`) and the new validator rules (`insecure_cardkit_url`,
`approval_cards_without_cards`, placeholder token rejection, non-localhost
runtime URL rejection).

### Sizing

~2,000 LOC of source + 360 of tests + 136 of README + 156 of validator + 37 of
.env.example. Single commit, single directory, no changes outside
`integrations/feishu-helm/`.

### Happy to harvest

Open to landing this in whatever shape fits the project: as-is at
`integrations/feishu-helm/`, restructured under `integrations/feishu-bridge/`
behind feature flags, or harvested hunk-by-hunk into the existing bridge. The
SSE reconnect path is a no-UX-change reliability win and would be a clean
single-purpose harvest target if nothing else from this PR is wanted.