### PR TITLE
  feat(tui): add bang shell command shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ ACP workflows outside the built-in Zed slice.
 | `Ctrl+R` | Resume an earlier session |
 | `Alt+R` | Search prompt history and recover cleared drafts |
 | `Ctrl+S` | Stash current draft (`/stash list`, `/stash pop` to recover) |
+| `! command` | Run a shell command through normal approval and sandbox handling |
 | `@path` | Attach file/directory context in composer |
 | `↑` (at composer start) | Select attachment row for removal |
 

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -571,6 +571,213 @@ impl Engine {
         (engine, handle)
     }
 
+    async fn handle_run_shell_command(
+        &mut self,
+        command: String,
+        mode: AppMode,
+        _allow_shell: bool,
+        trust_mode: bool,
+        auto_approve: bool,
+        approval_mode: crate::tui::approval::ApprovalMode,
+    ) {
+        self.reset_cancel_token();
+        self.turn_counter = self.turn_counter.saturating_add(1);
+        self.capacity_controller.mark_turn_start(self.turn_counter);
+        let turn_id = format!(
+            "{}{}",
+            super::ops::USER_SHELL_TOOL_ID_PREFIX,
+            self.turn_counter
+        );
+        let tool_id = turn_id.clone();
+        let tool_name = "exec_shell".to_string();
+        let tool_input = json!({ "command": command });
+
+        self.session.trust_mode = trust_mode;
+        self.config.trust_mode = trust_mode;
+        self.session.auto_approve = auto_approve;
+        self.session.approval_mode = if auto_approve {
+            crate::tui::approval::ApprovalMode::Auto
+        } else {
+            approval_mode
+        };
+
+        let _ = self
+            .tx_event
+            .send(Event::TurnStarted {
+                turn_id: turn_id.clone(),
+            })
+            .await;
+
+        if self.config.snapshots_enabled {
+            let pre_workspace = self.session.workspace.clone();
+            let pre_seq = self.turn_counter;
+            let pre_cap = self.config.snapshots_max_workspace_bytes;
+            let _ = tokio::task::spawn_blocking(move || {
+                pre_turn_snapshot(&pre_workspace, pre_seq, pre_cap)
+            })
+            .await;
+        }
+
+        let _ = self
+            .tx_event
+            .send(Event::ToolCallStarted {
+                id: tool_id.clone(),
+                name: tool_name.clone(),
+                input: tool_input.clone(),
+            })
+            .await;
+
+        let tool_context = self.build_tool_context(mode, auto_approve);
+        let registry = ToolRegistryBuilder::new()
+            .with_shell_tools()
+            .build(tool_context);
+
+        let result = if mode == AppMode::Plan {
+            Err(ToolError::permission_denied(
+                "Tool 'exec_shell' is unavailable in Plan mode".to_string(),
+            ))
+        } else if !self.config.features.enabled(Feature::ShellTool) {
+            Err(ToolError::not_available(
+                "Tool 'exec_shell' is disabled by feature flag".to_string(),
+            ))
+        } else if let Some(spec) = registry.get(&tool_name) {
+            let approval_required = spec.approval_requirement() != ApprovalRequirement::Auto;
+            if approval_required {
+                emit_tool_audit(json!({
+                    "event": "tool.approval_required",
+                    "tool_id": tool_id.clone(),
+                    "tool_name": tool_name.clone(),
+                    "source": "composer_bang",
+                }));
+                let approval_key =
+                    crate::tools::approval_cache::build_approval_key(&tool_name, &tool_input).0;
+                let _ = self
+                    .tx_event
+                    .send(Event::ApprovalRequired {
+                        id: tool_id.clone(),
+                        tool_name: tool_name.clone(),
+                        description: spec.description().to_string(),
+                        approval_key,
+                    })
+                    .await;
+
+                match self.await_tool_approval(&tool_id).await {
+                    Ok(ApprovalResult::Approved) => {
+                        emit_tool_audit(json!({
+                            "event": "tool.approval_decision",
+                            "tool_id": tool_id.clone(),
+                            "tool_name": tool_name.clone(),
+                            "decision": "approved",
+                            "source": "composer_bang",
+                        }));
+                        Self::execute_tool_with_lock(
+                            self.tool_exec_lock.clone(),
+                            spec.supports_parallel(),
+                            false,
+                            self.tx_event.clone(),
+                            tool_name.clone(),
+                            tool_input.clone(),
+                            Some(&registry),
+                            None,
+                            None,
+                        )
+                        .await
+                    }
+                    Ok(ApprovalResult::Denied) => {
+                        emit_tool_audit(json!({
+                            "event": "tool.approval_decision",
+                            "tool_id": tool_id.clone(),
+                            "tool_name": tool_name.clone(),
+                            "decision": "denied",
+                            "source": "composer_bang",
+                        }));
+                        Err(ToolError::permission_denied(format!(
+                            "Tool '{tool_name}' denied by user"
+                        )))
+                    }
+                    Ok(ApprovalResult::RetryWithPolicy(policy)) => {
+                        emit_tool_audit(json!({
+                            "event": "tool.approval_decision",
+                            "tool_id": tool_id.clone(),
+                            "tool_name": tool_name.clone(),
+                            "decision": "retry_with_policy",
+                            "policy": format!("{policy:?}"),
+                            "source": "composer_bang",
+                        }));
+                        let elevated_context = registry
+                            .context()
+                            .clone()
+                            .with_elevated_sandbox_policy(policy);
+                        Self::execute_tool_with_lock(
+                            self.tool_exec_lock.clone(),
+                            spec.supports_parallel(),
+                            false,
+                            self.tx_event.clone(),
+                            tool_name.clone(),
+                            tool_input.clone(),
+                            Some(&registry),
+                            None,
+                            Some(elevated_context),
+                        )
+                        .await
+                    }
+                    Err(err) => Err(err),
+                }
+            } else {
+                Self::execute_tool_with_lock(
+                    self.tool_exec_lock.clone(),
+                    spec.supports_parallel(),
+                    false,
+                    self.tx_event.clone(),
+                    tool_name.clone(),
+                    tool_input.clone(),
+                    Some(&registry),
+                    None,
+                    None,
+                )
+                .await
+            }
+        } else {
+            Err(ToolError::not_available(
+                "tool 'exec_shell' is not registered".to_string(),
+            ))
+        };
+
+        let status = if result.is_err() {
+            TurnOutcomeStatus::Failed
+        } else {
+            TurnOutcomeStatus::Completed
+        };
+        let error = result.as_ref().err().map(ToString::to_string);
+
+        let _ = self
+            .tx_event
+            .send(Event::ToolCallComplete {
+                id: tool_id,
+                name: tool_name,
+                result,
+            })
+            .await;
+
+        let _ = self
+            .tx_event
+            .send(Event::TurnComplete {
+                usage: Usage::default(),
+                status,
+                error,
+            })
+            .await;
+
+        if self.config.snapshots_enabled {
+            let post_workspace = self.session.workspace.clone();
+            let post_seq = self.turn_counter;
+            let post_cap = self.config.snapshots_max_workspace_bytes;
+            crate::utils::spawn_blocking_supervised("post-shell-turn-snapshot", move || {
+                post_turn_snapshot(&post_workspace, post_seq, post_cap);
+            });
+        }
+    }
+
     /// Run the engine event loop
     #[allow(clippy::too_many_lines)]
     pub async fn run(mut self) {
@@ -603,6 +810,24 @@ impl Engine {
                         auto_approve,
                         approval_mode,
                         translation_enabled,
+                    )
+                    .await;
+                }
+                Op::RunShellCommand {
+                    command,
+                    mode,
+                    allow_shell,
+                    trust_mode,
+                    auto_approve,
+                    approval_mode,
+                } => {
+                    self.handle_run_shell_command(
+                        command,
+                        mode,
+                        allow_shell,
+                        trust_mode,
+                        auto_approve,
+                        approval_mode,
                     )
                     .await;
                 }

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -900,6 +900,119 @@ async fn session_update_preserves_reasoning_tool_only_turn() {
     assert_eq!(messages, vec![assistant]);
 }
 
+#[tokio::test]
+async fn run_shell_command_op_requests_approval_and_executes_shell() {
+    let (mut engine, handle) = Engine::new(EngineConfig::default(), &Config::default());
+    let handle_for_approval = handle.clone();
+
+    let task = tokio::spawn(async move {
+        engine
+            .handle_run_shell_command(
+                "echo bang-ok".to_string(),
+                AppMode::Agent,
+                false,
+                false,
+                false,
+                crate::tui::approval::ApprovalMode::Suggest,
+            )
+            .await;
+    });
+
+    let mut saw_started = false;
+    let mut saw_approval = false;
+    let mut saw_complete = false;
+    let mut saw_turn_complete = false;
+    let mut rx = handle.rx_event.write().await;
+    while let Some(event) = rx.recv().await {
+        match event {
+            Event::TurnStarted { turn_id } => {
+                assert!(turn_id.starts_with(crate::core::ops::USER_SHELL_TOOL_ID_PREFIX));
+            }
+            Event::ToolCallStarted { id, name, input } => {
+                saw_started = true;
+                assert!(id.starts_with(crate::core::ops::USER_SHELL_TOOL_ID_PREFIX));
+                assert_eq!(name, "exec_shell");
+                assert_eq!(input["command"], json!("echo bang-ok"));
+            }
+            Event::ApprovalRequired { id, tool_name, .. } => {
+                saw_approval = true;
+                assert!(id.starts_with(crate::core::ops::USER_SHELL_TOOL_ID_PREFIX));
+                assert_eq!(tool_name, "exec_shell");
+                handle_for_approval
+                    .approve_tool_call(id)
+                    .await
+                    .expect("approve shell");
+            }
+            Event::ToolCallComplete { id, name, result } => {
+                saw_complete = true;
+                assert!(id.starts_with(crate::core::ops::USER_SHELL_TOOL_ID_PREFIX));
+                assert_eq!(name, "exec_shell");
+                let result = result.expect("shell result");
+                assert!(result.success, "{result:?}");
+                assert!(result.content.contains("bang-ok"), "{result:?}");
+            }
+            Event::TurnComplete { status, .. } => {
+                saw_turn_complete = true;
+                assert_eq!(status, TurnOutcomeStatus::Completed);
+                break;
+            }
+            _ => {}
+        }
+    }
+    drop(rx);
+    task.await.expect("shell op task");
+
+    assert!(saw_started);
+    assert!(saw_approval);
+    assert!(saw_complete);
+    assert!(saw_turn_complete);
+}
+
+#[tokio::test]
+async fn run_shell_command_op_preserves_plan_mode_shell_block() {
+    let (mut engine, handle) = Engine::new(EngineConfig::default(), &Config::default());
+
+    engine
+        .handle_run_shell_command(
+            "echo blocked".to_string(),
+            AppMode::Plan,
+            true,
+            false,
+            false,
+            crate::tui::approval::ApprovalMode::Suggest,
+        )
+        .await;
+
+    let mut saw_complete = false;
+    let mut saw_turn_complete = false;
+    let mut rx = handle.rx_event.write().await;
+    while let Some(event) = rx.recv().await {
+        match event {
+            Event::ApprovalRequired { .. } => {
+                panic!("Plan mode shell should be blocked before approval");
+            }
+            Event::ToolCallComplete { name, result, .. } => {
+                saw_complete = true;
+                assert_eq!(name, "exec_shell");
+                let err = result.expect_err("plan shell should fail");
+                assert!(
+                    err.to_string().contains("unavailable in Plan mode"),
+                    "{err}"
+                );
+            }
+            Event::TurnComplete { status, .. } => {
+                saw_turn_complete = true;
+                assert_eq!(status, TurnOutcomeStatus::Failed);
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    assert!(saw_complete);
+    assert!(saw_turn_complete);
+}
+
 #[test]
 fn detects_context_length_errors_from_provider_payloads() {
     let msg = r#"SSE stream request failed: HTTP 400 Bad Request: {"error":{"message":"This model's maximum context length is 131072 tokens. However, you requested 153056 tokens (148960 in the messages, 4096 in the completion).","type":"invalid_request_error"}}"#;

--- a/crates/tui/src/core/ops.rs
+++ b/crates/tui/src/core/ops.rs
@@ -9,6 +9,9 @@ use crate::tui::app::AppMode;
 use crate::tui::approval::ApprovalMode;
 use std::path::PathBuf;
 
+/// Prefix used for tool-call ids created by local composer shell shortcuts.
+pub const USER_SHELL_TOOL_ID_PREFIX: &str = "user_shell_";
+
 /// Operations that can be submitted to the engine.
 #[derive(Debug, Clone)]
 pub enum Op {
@@ -31,6 +34,18 @@ pub enum Op {
         auto_approve: bool,
         approval_mode: ApprovalMode,
         translation_enabled: bool,
+    },
+
+    /// Execute a user-submitted composer shell command (`! <command>`) without
+    /// sending a model turn. This still routes through `exec_shell`, approval,
+    /// sandbox, and command-safety handling.
+    RunShellCommand {
+        command: String,
+        mode: AppMode,
+        allow_shell: bool,
+        trust_mode: bool,
+        auto_approve: bool,
+        approval_mode: ApprovalMode,
     },
 
     /// Cancel the current request

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -93,6 +93,19 @@ pub(crate) fn looks_like_slash_command_input(input: &str) -> bool {
     !command.contains('/')
 }
 
+pub(crate) fn shell_command_from_bang_input(input: &str) -> Result<Option<&str>, &'static str> {
+    let Some(rest) = input.trim_start().strip_prefix('!') else {
+        return Ok(None);
+    };
+    let command = rest
+        .strip_prefix(|c: char| c.is_whitespace())
+        .unwrap_or(rest);
+    if command.trim().is_empty() {
+        return Err("Usage: ! <shell command>");
+    }
+    Ok(Some(command))
+}
+
 fn initial_onboarding_state(
     skip_onboarding: bool,
     was_onboarded: bool,
@@ -4326,6 +4339,29 @@ mod tests {
         assert!(!looks_like_slash_command_input(
             "/usr/lib/x86_64-linux-gnu/ 是标准路径吗？"
         ));
+    }
+
+    #[test]
+    fn bang_shell_prefix_parses_compact_and_spaced_forms() {
+        assert_eq!(shell_command_from_bang_input("!pwd"), Ok(Some("pwd")));
+        assert_eq!(shell_command_from_bang_input("! pwd"), Ok(Some("pwd")));
+        assert_eq!(
+            shell_command_from_bang_input("  ! cargo test -p deepseek-tui sidebar"),
+            Ok(Some("cargo test -p deepseek-tui sidebar"))
+        );
+        assert_eq!(shell_command_from_bang_input("normal message"), Ok(None));
+    }
+
+    #[test]
+    fn bang_shell_prefix_rejects_empty_command() {
+        assert_eq!(
+            shell_command_from_bang_input("!"),
+            Err("Usage: ! <shell command>")
+        );
+        assert_eq!(
+            shell_command_from_bang_input("!   "),
+            Err("Usage: ! <shell command>")
+        );
     }
 
     #[test]

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -41,7 +41,7 @@ use crate::config::{ApiProvider, Config, DEFAULT_NVIDIA_NIM_BASE_URL};
 use crate::config_ui::{self, ConfigUiMode, WebConfigSession, WebConfigSessionEvent};
 use crate::core::engine::{EngineConfig, EngineHandle, spawn_engine};
 use crate::core::events::Event as EngineEvent;
-use crate::core::ops::Op;
+use crate::core::ops::{Op, USER_SHELL_TOOL_ID_PREFIX};
 use crate::hooks::{HookEvent, HookExecutor};
 use crate::llm_client::LlmClient;
 use crate::models::{
@@ -105,7 +105,7 @@ use crate::tui::workspace_context;
 use super::app::{
     App, AppAction, AppMode, OnboardingState, QueuedMessage, ReasoningEffort, SidebarFocus,
     StatusToastLevel, SubmitDisposition, TaskPanelEntry, TuiOptions,
-    looks_like_slash_command_input,
+    looks_like_slash_command_input, shell_command_from_bang_input,
 };
 use super::approval::{
     ApprovalMode, ApprovalRequest, ApprovalView, ElevationRequest, ElevationView, ReviewDecision,
@@ -1181,23 +1181,28 @@ async fn run_event_loop(
                         if name == "update_plan" {
                             app.plan_tool_used_in_turn = true;
                         }
-                        let tool_content = match &result {
-                            Ok(output) => sanitize_stream_chunk(
-                                &crate::core::engine::compact_tool_result_for_context(
-                                    &app.model, &name, output,
+                        if is_model_visible_tool_call(&id) {
+                            let tool_content = match &result {
+                                Ok(output) => sanitize_stream_chunk(
+                                    &crate::core::engine::compact_tool_result_for_context(
+                                        &app.model, &name, output,
+                                    ),
                                 ),
-                            ),
-                            Err(err) => sanitize_stream_chunk(&format!("Error: {err}")),
-                        };
-                        app.api_messages.push(Message {
-                            role: "user".to_string(),
-                            content: vec![ContentBlock::ToolResult {
-                                tool_use_id: id.clone(),
-                                content: tool_content,
-                                is_error: None,
-                                content_blocks: None,
-                            }],
-                        });
+                                Err(err) => sanitize_stream_chunk(&format!("Error: {err}")),
+                            };
+                            app.api_messages.push(Message {
+                                role: "user".to_string(),
+                                content: vec![ContentBlock::ToolResult {
+                                    tool_use_id: id.clone(),
+                                    content: tool_content,
+                                    is_error: None,
+                                    content_blocks: None,
+                                }],
+                            });
+                        } else {
+                            app.pending_tool_uses
+                                .retain(|(tool_id, _, _)| tool_id != &id);
+                        }
                         handle_tool_call_complete(app, &id, &name, &result);
 
                         // Immediately refresh the task panel sidebar when a
@@ -3134,6 +3139,9 @@ async fn run_event_loop(
                         // behaviour falls through to normal turn submit.
                         if config.memory_enabled() && is_memory_quick_add(&input) {
                             handle_memory_quick_add(app, &input, config);
+                            continue;
+                        }
+                        if handle_bang_shell_input(app, &engine_handle, &input).await? {
                             continue;
                         }
                         if looks_like_slash_command_input(&input) {
@@ -5161,6 +5169,38 @@ async fn submit_or_steer_message(
         }
         SubmitDisposition::QueueFollowUp => queue_follow_up(app, message).await,
     }
+}
+
+async fn handle_bang_shell_input(
+    app: &mut App,
+    engine_handle: &EngineHandle,
+    input: &str,
+) -> Result<bool> {
+    let command = match shell_command_from_bang_input(input) {
+        Ok(Some(command)) => command,
+        Ok(None) => return Ok(false),
+        Err(message) => {
+            app.status_message = Some(format!("Error: {message}"));
+            return Ok(true);
+        }
+    };
+
+    engine_handle
+        .send(Op::RunShellCommand {
+            command: command.to_string(),
+            mode: app.mode,
+            allow_shell: app.allow_shell,
+            trust_mode: app.trust_mode,
+            auto_approve: app.mode == AppMode::Yolo,
+            approval_mode: app.approval_mode,
+        })
+        .await?;
+    app.status_message = Some(format!("Shell command submitted: {command}"));
+    Ok(true)
+}
+
+fn is_model_visible_tool_call(id: &str) -> bool {
+    !id.starts_with(USER_SHELL_TOOL_ID_PREFIX)
 }
 
 /// Drain `app.pending_steers` into a single `QueuedMessage` ready for

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -2944,6 +2944,62 @@ async fn dismissed_plan_prompt_leaves_non_numeric_input_for_normal_send_path() {
 }
 
 #[tokio::test]
+async fn bang_shell_input_dispatches_shell_op_instead_of_model_message() {
+    let mut app = create_test_app();
+    app.mode = AppMode::Agent;
+    app.allow_shell = false;
+    app.trust_mode = false;
+
+    let mut engine = crate::core::engine::mock_engine_handle();
+
+    let handled = handle_bang_shell_input(&mut app, &engine.handle, "! pwd")
+        .await
+        .expect("bang shell handler");
+
+    assert!(handled);
+    assert_eq!(
+        app.status_message.as_deref(),
+        Some("Shell command submitted: pwd")
+    );
+
+    let op = engine.rx_op.recv().await.expect("engine op");
+    match op {
+        Op::RunShellCommand {
+            command,
+            mode,
+            allow_shell,
+            trust_mode,
+            auto_approve,
+            approval_mode,
+        } => {
+            assert_eq!(command, "pwd");
+            assert_eq!(mode, AppMode::Agent);
+            assert!(!allow_shell);
+            assert!(!trust_mode);
+            assert!(!auto_approve);
+            assert_eq!(approval_mode, ApprovalMode::Suggest);
+        }
+        other => panic!("expected RunShellCommand, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn empty_bang_shell_input_is_consumed_with_usage_error() {
+    let mut app = create_test_app();
+    let engine = crate::core::engine::mock_engine_handle();
+
+    let handled = handle_bang_shell_input(&mut app, &engine.handle, "!   ")
+        .await
+        .expect("bang shell handler");
+
+    assert!(handled);
+    assert_eq!(
+        app.status_message.as_deref(),
+        Some("Error: Usage: ! <shell command>")
+    );
+}
+
+#[tokio::test]
 async fn numeric_plan_choice_still_queues_follow_up_when_busy() {
     let mut app = create_test_app();
     app.mode = AppMode::Plan;

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -44,6 +44,7 @@ Editing the message you're about to send.
 | `Alt-R`                    | Search prompt history (Alt-R to exit)                  |
 | `Tab`                       | Slash-command / `@`-mention completion (popup-aware)    |
 | `Ctrl-O`                    | Open external editor for the composer draft when it has focus |
+| `! command`                 | Run a shell command through normal approval, sandbox, and shell output surfaces |
 
 ### `@` mentions
 


### PR DESCRIPTION


## Summary
  Closes #1546.

  Adds composer support for `! <command>` so users can run an explicit shell command directly from the input box.

  The shortcut routes through the existing shell execution path, so it keeps the same approval flow, sandbox policy, command safety checks, hooks, audit events, and tool-card output. It does not turn on model-visible shell access when shell tools are otherwise disabled for the model.

  Also handles empty `!` input with a usage message and keeps Plan mode shell execution blocked.

## Testing

- [x] `cargo test --all-features`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features`

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
