### PR TITLE
fix(tui): skip project-scope config merge when workspace is home directory

### DIFF
--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -4159,6 +4159,20 @@ fn preserve_interrupted_checkpoint_for_explicit_resume(launch_workspace: &Path) 
 /// Only explicitly set fields in the project file are applied; everything
 /// else falls back to the global value.
 fn merge_project_config(config: &mut Config, workspace: &Path) {
+    // When the workspace is the user's home directory, the project-scope
+    // config file is also the global config file.  Skip the merge to avoid
+    // redundant processing and a misleading “project-scope config key
+    // ignored” warning on every launch from ~.
+    if let Some(home) = dirs::home_dir()
+        && let (Ok(w), Ok(h)) = (
+            std::fs::canonicalize(workspace),
+            std::fs::canonicalize(&home),
+        )
+        && w == h
+    {
+        return;
+    }
+
     let path = workspace.join(".deepseek").join("config.toml");
     let raw = match std::fs::read_to_string(&path) {
         Ok(r) => r,


### PR DESCRIPTION
## Summary
- skip project-scope config merge when the workspace root resolves to the user home directory
- when `cwd == $HOME`, the project file (`~/.deepseek/config.toml`) is also the global config file — merge is redundant and the warning is noise
- guard early in `merge_project_config` via `dirs::home_dir()` + `std::fs::canonicalize`

The #417 deny-list correctly refuses dangerous keys at project scope, but the warning fires even when the project file is the same file as the global config.

## Tests
- `cargo fmt --all -- --check`
- `cargo check -p deepseek-tui --locked`
- `cargo clippy -p deepseek-tui --all-targets --all-features --locked -- -D warnings`
- `cargo test -p deepseek-tui -- merge_project_config project_overlay --locked` (15/15 passed)
- `git diff --check`

### Reproduce (main)
```bash
tmux -S /tmp/claude.sock new -d -s repro -n shell
tmux -S /tmp/claude.sock send-keys -t repro:1.1 -- \
  'cd ~ && deepseek-tui 2>/tmp/repro.log' Enter
sleep 4
tmux -S /tmp/claude.sock send-keys -t repro:1.1 C-c  # first Ctrl+C
sleep 1
tmux -S /tmp/claude.sock send-keys -t repro:1.1 C-c  # second Ctrl+C
sleep 2
cat /tmp/repro.log
# Output: warning: project-scope config key `api_key` is ignored …
```

### Verify (this branch)
Same steps produce **no** `project-scope config key … ignored` warning.

Environment: macOS, `~/.deepseek/config.toml` contains `api_key`. TUI started from `~`.
