### PR TITLE
feat: session token breakdown in footer and /status

### DIFF
--- a/crates/tui/src/commands/core.rs
+++ b/crates/tui/src/commands/core.rs
@@ -55,6 +55,10 @@ pub fn clear(app: &mut App) -> CommandResult {
     app.queued_draft = None;
     app.session.total_tokens = 0;
     app.session.total_conversation_tokens = 0;
+    app.session.total_input_tokens = 0;
+    app.session.total_cache_hit_tokens = 0;
+    app.session.total_cache_miss_tokens = 0;
+    app.session.total_output_tokens = 0;
     app.session.session_cost = 0.0;
     app.session.session_cost_cny = 0.0;
     let todos_cleared = app.clear_todos();

--- a/crates/tui/src/commands/session.rs
+++ b/crates/tui/src/commands/session.rs
@@ -99,6 +99,11 @@ pub fn load(app: &mut App, path: Option<&str>) -> CommandResult {
     app.workspace.clone_from(&session.metadata.workspace);
     app.session.total_tokens = u32::try_from(session.metadata.total_tokens).unwrap_or(u32::MAX);
     app.session.total_conversation_tokens = app.session.total_tokens;
+    // Accumulated token breakdown is per-runtime-session; zero on load.
+    app.session.total_input_tokens = 0;
+    app.session.total_cache_hit_tokens = 0;
+    app.session.total_cache_miss_tokens = 0;
+    app.session.total_output_tokens = 0;
     app.session.session_cost = 0.0;
     app.session.session_cost_cny = 0.0;
     app.session.subagent_cost = 0.0;

--- a/crates/tui/src/commands/status.rs
+++ b/crates/tui/src/commands/status.rs
@@ -66,6 +66,24 @@ fn format_status(app: &App) -> String {
     push_row(&mut out, "Cache hit/miss:", &cache_summary(app));
     push_row(
         &mut out,
+        "Session input:",
+        &app.session.total_input_tokens.to_string(),
+    );
+    push_row(
+        &mut out,
+        "Session cache:",
+        &format!(
+            "{} hit / {} miss",
+            app.session.total_cache_hit_tokens, app.session.total_cache_miss_tokens
+        ),
+    );
+    push_row(
+        &mut out,
+        "Session output:",
+        &app.session.total_output_tokens.to_string(),
+    );
+    push_row(
+        &mut out,
         "Total tokens:",
         &app.session.total_tokens.to_string(),
     );

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -660,6 +660,8 @@ pub enum StatusItem {
     LastToolElapsed,
     /// Remaining rate-limit budget (placeholder until wired).
     RateLimit,
+    /// Session token usage: input / cache-hit / output.
+    Tokens,
 }
 
 impl StatusItem {
@@ -678,6 +680,7 @@ impl StatusItem {
             StatusItem::Agents,
             StatusItem::ReasoningReplay,
             StatusItem::Cache,
+            StatusItem::Tokens,
         ]
     }
 
@@ -698,6 +701,7 @@ impl StatusItem {
             StatusItem::GitBranch => "git_branch",
             StatusItem::LastToolElapsed => "last_tool_elapsed",
             StatusItem::RateLimit => "rate_limit",
+            StatusItem::Tokens => "tokens",
         }
     }
 
@@ -718,6 +722,7 @@ impl StatusItem {
             StatusItem::GitBranch => "Git branch",
             StatusItem::LastToolElapsed => "Last tool elapsed",
             StatusItem::RateLimit => "Rate-limit remaining",
+            StatusItem::Tokens => "Session tokens",
         }
     }
 
@@ -739,6 +744,7 @@ impl StatusItem {
             StatusItem::GitBranch => "current workspace branch",
             StatusItem::LastToolElapsed => "ms of the most recent tool call (placeholder)",
             StatusItem::RateLimit => "remaining requests in the budget (placeholder)",
+            StatusItem::Tokens => "input / cache-hit / output token totals",
         }
     }
 
@@ -759,6 +765,7 @@ impl StatusItem {
             StatusItem::GitBranch,
             StatusItem::LastToolElapsed,
             StatusItem::RateLimit,
+            StatusItem::Tokens,
         ]
     }
 

--- a/crates/tui/src/config_ui.rs
+++ b/crates/tui/src/config_ui.rs
@@ -278,6 +278,7 @@ pub enum StatusItemValue {
     GitBranch,
     LastToolElapsed,
     RateLimit,
+    Tokens,
 }
 
 pub fn parse_mode(arg: Option<&str>) -> Result<ConfigUiMode, String> {
@@ -996,6 +997,7 @@ impl From<StatusItem> for StatusItemValue {
             StatusItem::GitBranch => Self::GitBranch,
             StatusItem::LastToolElapsed => Self::LastToolElapsed,
             StatusItem::RateLimit => Self::RateLimit,
+            StatusItem::Tokens => Self::Tokens,
         }
     }
 }
@@ -1016,6 +1018,7 @@ impl From<StatusItemValue> for StatusItem {
             StatusItemValue::GitBranch => Self::GitBranch,
             StatusItemValue::LastToolElapsed => Self::LastToolElapsed,
             StatusItemValue::RateLimit => Self::RateLimit,
+            StatusItemValue::Tokens => Self::Tokens,
         }
     }
 }

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -727,6 +727,11 @@ pub struct SessionState {
     pub last_reasoning_replay_tokens: Option<u32>,
     pub total_tokens: u32,
     pub total_conversation_tokens: u32,
+    /// Accumulated token breakdown for the session.
+    pub total_input_tokens: u32,
+    pub total_cache_hit_tokens: u32,
+    pub total_cache_miss_tokens: u32,
+    pub total_output_tokens: u32,
     pub turn_cache_history: VecDeque<TurnCacheRecord>,
     pub last_cache_inspection: Option<PromptInspection>,
 }
@@ -748,6 +753,10 @@ impl Default for SessionState {
             last_reasoning_replay_tokens: None,
             total_tokens: 0,
             total_conversation_tokens: 0,
+            total_input_tokens: 0,
+            total_cache_hit_tokens: 0,
+            total_cache_miss_tokens: 0,
+            total_output_tokens: 0,
             turn_cache_history: VecDeque::new(),
             last_cache_inspection: None,
         }

--- a/crates/tui/src/tui/footer_ui.rs
+++ b/crates/tui/src/tui/footer_ui.rs
@@ -413,6 +413,7 @@ pub(crate) fn render_footer_from(
         let chip = match *item {
             S::PrefixStability => prefix_stability.clone(),
             S::Cache => cache_chip.clone(),
+            S::Tokens => footer_session_tokens_spans(app),
             S::ContextPercent => footer_context_percent_spans(app),
             S::GitBranch => footer_git_branch_spans(app),
             S::LastToolElapsed | S::RateLimit => Vec::new(),
@@ -489,6 +490,25 @@ pub(crate) fn footer_cost_spans(app: &App) -> Vec<Span<'static>> {
 
 pub(crate) fn should_show_footer_cost(displayed_cost: f64) -> bool {
     displayed_cost.is_finite() && displayed_cost > 0.0
+}
+
+/// Session token-usage chip for the footer right cluster.
+///
+/// Renders the accumulated input / cache-hit / output token breakdown
+/// since the current runtime session started (not persisted across
+/// restarts). Returns empty when no tokens have been recorded yet.
+pub(crate) fn footer_session_tokens_spans(app: &App) -> Vec<Span<'static>> {
+    let session = &app.session;
+    if session.total_input_tokens == 0 && session.total_output_tokens == 0 {
+        return Vec::new();
+    }
+    let in_str = format_token_count_compact(u64::from(session.total_input_tokens));
+    let cache_str = format_token_count_compact(u64::from(session.total_cache_hit_tokens));
+    let out_str = format_token_count_compact(u64::from(session.total_output_tokens));
+    vec![Span::styled(
+        format!("{in_str} in · {cache_str} cch · {out_str} out"),
+        Style::default().fg(palette::TEXT_MUTED),
+    )]
 }
 
 /// Test-only helper retained as a parity reference for `FooterWidget`'s

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -1331,6 +1331,22 @@ async fn run_event_loop(
                             .session
                             .total_conversation_tokens
                             .saturating_add(turn_tokens);
+                        app.session.total_input_tokens = app
+                            .session
+                            .total_input_tokens
+                            .saturating_add(usage.input_tokens);
+                        app.session.total_output_tokens = app
+                            .session
+                            .total_output_tokens
+                            .saturating_add(usage.output_tokens);
+                        app.session.total_cache_hit_tokens = app
+                            .session
+                            .total_cache_hit_tokens
+                            .saturating_add(usage.prompt_cache_hit_tokens.unwrap_or(0));
+                        app.session.total_cache_miss_tokens = app
+                            .session
+                            .total_cache_miss_tokens
+                            .saturating_add(usage.prompt_cache_miss_tokens.unwrap_or(0));
                         app.session.last_prompt_tokens = Some(usage.input_tokens);
                         app.session.last_completion_tokens = Some(usage.output_tokens);
                         app.session.last_prompt_cache_hit_tokens = usage.prompt_cache_hit_tokens;
@@ -6239,6 +6255,11 @@ fn apply_loaded_session(app: &mut App, config: &Config, session: &SavedSession) 
     app.session.last_prompt_cache_hit_tokens = None;
     app.session.last_prompt_cache_miss_tokens = None;
     app.session.last_reasoning_replay_tokens = None;
+    // Accumulated token breakdown is per-runtime-session; reset on load.
+    app.session.total_input_tokens = 0;
+    app.session.total_cache_hit_tokens = 0;
+    app.session.total_cache_miss_tokens = 0;
+    app.session.total_output_tokens = 0;
     app.session.turn_cache_history.clear();
     app.current_session_id = Some(session.metadata.id.clone());
     app.session_artifacts = session.artifacts.clone();

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -1343,10 +1343,15 @@ async fn run_event_loop(
                             .session
                             .total_cache_hit_tokens
                             .saturating_add(usage.prompt_cache_hit_tokens.unwrap_or(0));
+                        let cache_miss = usage.prompt_cache_miss_tokens.unwrap_or_else(|| {
+                            usage
+                                .input_tokens
+                                .saturating_sub(usage.prompt_cache_hit_tokens.unwrap_or(0))
+                        });
                         app.session.total_cache_miss_tokens = app
                             .session
                             .total_cache_miss_tokens
-                            .saturating_add(usage.prompt_cache_miss_tokens.unwrap_or(0));
+                            .saturating_add(cache_miss);
                         app.session.last_prompt_tokens = Some(usage.input_tokens);
                         app.session.last_completion_tokens = Some(usage.output_tokens);
                         app.session.last_prompt_cache_hit_tokens = usage.prompt_cache_hit_tokens;


### PR DESCRIPTION
Add accumulated session token tracking with input / cache-hit / output breakdown.

### Changes
- SessionState: new total_input_tokens, etc.
- Turn outcome handler: accumulate per-turn token breakdown
- StatusItem::Tokens: new footer chip, enabled by default
- Footer chip: 12K in / 8.1K cch / 2.5K out
- /status: expanded with session input/cache/output rows

### Note
Cost in CNY via cost_currency = cny config.

### Verified
- cargo check/fmt/clippy/test pass (3113 passed)
