### PR TITLE
fix(tui): debounce FocusGained terminal recovery

### DIFF
--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -744,6 +744,10 @@ async fn run_event_loop(
     let mut web_config_session: Option<WebConfigSession> = None;
     let mut terminal_paused_at: Option<Instant> = None;
     let mut force_terminal_repaint = false;
+    const FOCUS_RECOVERY_DEBOUNCE: Duration = Duration::from_millis(200);
+    let mut last_focus_recovery = Instant::now()
+        .checked_sub(FOCUS_RECOVERY_DEBOUNCE)
+        .unwrap_or_else(Instant::now);
     let mut draws_since_last_full_repaint: u64 = 0;
 
     loop {
@@ -1954,13 +1958,18 @@ async fn run_event_loop(
             // bracketed-paste modes — recover_terminal_modes() is the
             // canonical place those flags live.
             if terminal_event_needs_viewport_recapture(&evt) {
-                recover_terminal_modes(
-                    terminal.backend_mut(),
-                    app.use_mouse_capture,
-                    app.use_bracketed_paste,
-                );
+                let now = Instant::now();
+
+                if now.duration_since(last_focus_recovery) >= FOCUS_RECOVERY_DEBOUNCE {
+                    recover_terminal_modes(
+                        terminal.backend_mut(),
+                        app.use_mouse_capture,
+                        app.use_bracketed_paste,
+                    );
+                    last_focus_recovery = now;
+                }
+
                 force_terminal_repaint = true;
-                app.needs_redraw = true;
             }
             if let Event::Resize(width, height) = evt {
                 tracing::debug!(


### PR DESCRIPTION
## Summary

This PR debounces terminal mode recovery triggered by `FocusGained` events in the TUI event loop.

Currently, when a `F
[cinnamon-2026-05-15T153329+1200.webm](https://github.com/user-attachments/assets/f155ba49-366d-4634-8edd-dac304905a0f)
ocusGained` event is received, the TUI may call `recover_terminal_modes()` and then force a terminal repaint. On some terminals, re-emitting terminal mode escape sequences during focus handling can cause another focus/repaint cycle, leading to visible flickering and high CPU usage.

This patch keeps the repaint behavior, but prevents `recover_terminal_modes()` from running repeatedly within a short interval.

## Problem

On Linux Mint Terminal, I observed persistent flickering when `deepseek-tui` had focus. CPU usage increased while the terminal window was focused, and the flickering stopped when focus moved to another application.

This appears similar to the FocusGained loop reported for Tabby/xterm.js:

## Testing

- [ ] `cargo test --all-features`
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes

