### PR TITLE
refactor(tui): share hard-wrap helper across renderers

### DIFF
--- a/crates/tui/src/tui/diff_render.rs
+++ b/crates/tui/src/tui/diff_render.rs
@@ -2,9 +2,10 @@
 
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
-use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+use unicode_width::UnicodeWidthStr;
 
 use crate::palette;
+use crate::tui::ui_text::push_word_breaking_chars;
 
 const LINE_NUMBER_WIDTH: usize = 4;
 
@@ -392,25 +393,6 @@ fn wrap_text(text: &str, width: usize) -> Vec<String> {
 
     lines
 }
-
-fn push_word_breaking_chars(
-    word: &str,
-    width: usize,
-    current: &mut String,
-    current_width: &mut usize,
-    lines: &mut Vec<String>,
-) {
-    for ch in word.chars() {
-        let char_width = ch.width().unwrap_or(1);
-        if *current_width + char_width > width && *current_width > 0 {
-            lines.push(std::mem::take(current));
-            *current_width = 0;
-        }
-        current.push(ch);
-        *current_width += char_width;
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/tui/src/tui/markdown_render.rs
+++ b/crates/tui/src/tui/markdown_render.rs
@@ -33,6 +33,7 @@ use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::palette;
 use crate::tui::osc8;
+use crate::tui::ui_text::push_word_breaking_chars;
 
 // Thread-local counter incremented every time `parse` runs. Used by tests to
 // prove that width-only changes hit the cached-AST path and skip parsing.
@@ -1014,29 +1015,6 @@ fn wrap_text(text: &str, width: usize) -> Vec<String> {
     }
 
     lines
-}
-
-/// Push characters from `word` into `current`, flushing to `lines` when the
-/// running display width would exceed `width`. Width is computed at the
-/// `unicode-width` char level, matching the rest of the rendering pipeline.
-/// Used by `wrap_text` and `wrap_cell_text` so a word longer than the
-/// allotted width never silently overflows the right edge.
-fn push_word_breaking_chars(
-    word: &str,
-    width: usize,
-    current: &mut String,
-    current_width: &mut usize,
-    lines: &mut Vec<String>,
-) {
-    for ch in word.chars() {
-        let cw = ch.width().unwrap_or(1);
-        if *current_width + cw > width && *current_width > 0 {
-            lines.push(std::mem::take(current));
-            *current_width = 0;
-        }
-        current.push(ch);
-        *current_width += cw;
-    }
 }
 
 #[cfg(test)]

--- a/crates/tui/src/tui/pager.rs
+++ b/crates/tui/src/tui/pager.rs
@@ -23,9 +23,10 @@ use ratatui::{
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Padding, Paragraph, Widget, Wrap},
 };
-use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+use unicode_width::UnicodeWidthStr;
 
 use crate::palette;
+use crate::tui::ui_text::push_word_breaking_chars;
 use crate::tui::views::{ModalKind, ModalView, ViewAction, ViewEvent};
 
 /// Footer hint shown along the bottom border of the pager. Kept short so it
@@ -517,25 +518,6 @@ fn wrap_text(text: &str, width: usize) -> Vec<String> {
 
     lines
 }
-
-fn push_word_breaking_chars(
-    word: &str,
-    width: usize,
-    current: &mut String,
-    current_width: &mut usize,
-    lines: &mut Vec<String>,
-) {
-    for ch in word.chars() {
-        let char_width = ch.width().unwrap_or(1);
-        if *current_width + char_width > width && *current_width > 0 {
-            lines.push(std::mem::take(current));
-            *current_width = 0;
-        }
-        current.push(ch);
-        *current_width += char_width;
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/tui/src/tui/ui_text.rs
+++ b/crates/tui/src/tui/ui_text.rs
@@ -163,6 +163,29 @@ pub(super) fn text_display_width(text: &str) -> usize {
     text.chars().map(char_display_width).sum()
 }
 
+/// Push characters from `word` into `current`, flushing to `lines` when the
+/// running display width would exceed `width`. Width is computed at the
+/// `unicode-width` char level, matching the rest of the rendering pipeline.
+/// Used by multiple TUI renderers so a word longer than the allotted width
+/// never silently overflows the right edge.
+pub(crate) fn push_word_breaking_chars(
+    word: &str,
+    width: usize,
+    current: &mut String,
+    current_width: &mut usize,
+    lines: &mut Vec<String>,
+) {
+    for ch in word.chars() {
+        let char_width = UnicodeWidthChar::width(ch).unwrap_or(1);
+        if *current_width + char_width > width && *current_width > 0 {
+            lines.push(std::mem::take(current));
+            *current_width = 0;
+        }
+        current.push(ch);
+        *current_width += char_width;
+    }
+}
+
 pub(super) fn slice_text(text: &str, start: usize, end: usize) -> String {
     if end <= start {
         return String::new();


### PR DESCRIPTION
## Summary

- move the character-level hard-wrap helper into `crates/tui/src/tui/ui_text.rs`
- reuse that shared helper from `markdown_render`, `diff_render`, and `pager`
- remove duplicated implementations while keeping existing wrapping behavior and regression coverage intact

## Why

A follow-up to the merged CJK wrapping fix in #1622. This addresses review feedback about duplicated hard-wrap helpers across TUI renderers without broadening the original bug-fix scope.

## Validation

- `cargo fmt --all --check`
- `cargo test -p deepseek-tui --bin deepseek-tui wrap_text_breaks_overlong_cjk_runs --locked`
- `cargo test -p deepseek-tui --bin deepseek-tui render_diff_prepends_summary_and_gutter_markers --locked`
- `cargo test -p deepseek-tui --bin deepseek-tui footer_hint_is_rendered_in_buffer --locked`
