### PR TITLE
fix(tui): detect macOS light mode for system theme

### DIFF
--- a/crates/tui/src/palette.rs
+++ b/crates/tui/src/palette.rs
@@ -304,12 +304,7 @@ fn detect_macos_palette_mode() -> Option<PaletteMode> {
         ));
     }
 
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    if stderr.contains("does not exist") {
-        Some(PaletteMode::Light)
-    } else {
-        None
-    }
+    Some(PaletteMode::Light)
 }
 
 #[cfg(not(target_os = "macos"))]

--- a/crates/tui/src/palette.rs
+++ b/crates/tui/src/palette.rs
@@ -1,6 +1,8 @@
 //! DeepSeek color palette and semantic roles.
 
 use ratatui::style::Color;
+#[cfg(target_os = "macos")]
+use std::process::Command;
 
 pub const DEEPSEEK_BLUE_RGB: (u8, u8, u8) = (53, 120, 229); // #3578E5
 pub const DEEPSEEK_SKY_RGB: (u8, u8, u8) = (106, 174, 242);
@@ -264,14 +266,62 @@ impl PaletteMode {
         Some(if bg >= 8 { Self::Light } else { Self::Dark })
     }
 
-    /// Detect whether the terminal profile is light. Missing or unparsable
-    /// values default to dark so existing terminal setups keep the tuned theme.
+    /// Detect the active palette mode.
+    ///
+    /// Prefer the terminal's `COLORFGBG` hint when present. On macOS,
+    /// terminals such as Ghostty may omit that variable even when the
+    /// terminal is following the system appearance, so we fall back to
+    /// `defaults read -g AppleInterfaceStyle`. If neither source yields a
+    /// result, default to dark so existing terminal setups keep the tuned
+    /// theme.
     #[must_use]
     pub fn detect() -> Self {
-        std::env::var("COLORFGBG")
-            .ok()
-            .and_then(|value| Self::from_colorfgbg(&value))
+        Self::detect_from_sources(
+            std::env::var("COLORFGBG").ok().as_deref(),
+            detect_macos_palette_mode(),
+        )
+    }
+
+    #[must_use]
+    fn detect_from_sources(colorfgbg: Option<&str>, macos_fallback: Option<Self>) -> Self {
+        colorfgbg
+            .and_then(Self::from_colorfgbg)
+            .or(macos_fallback)
             .unwrap_or(Self::Dark)
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn detect_macos_palette_mode() -> Option<PaletteMode> {
+    let output = Command::new("defaults")
+        .args(["read", "-g", "AppleInterfaceStyle"])
+        .output()
+        .ok()?;
+
+    if output.status.success() {
+        return Some(palette_mode_from_apple_interface_style(
+            &String::from_utf8_lossy(&output.stdout),
+        ));
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if stderr.contains("does not exist") {
+        Some(PaletteMode::Light)
+    } else {
+        None
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn detect_macos_palette_mode() -> Option<PaletteMode> {
+    None
+}
+
+fn palette_mode_from_apple_interface_style(value: &str) -> PaletteMode {
+    if value.trim().eq_ignore_ascii_case("dark") {
+        PaletteMode::Dark
+    } else {
+        PaletteMode::Light
     }
 }
 
@@ -540,7 +590,7 @@ impl ThemeId {
     #[must_use]
     pub const fn tagline(self) -> &'static str {
         match self {
-            Self::System => "Follow terminal background (COLORFGBG)",
+            Self::System => "Follow terminal background (COLORFGBG / macOS appearance)",
             Self::Whale => "Default DeepSeek dark blue",
             Self::WhaleLight => "DeepSeek light, paper-ish",
             Self::Grayscale => "Color-minimal high contrast",
@@ -1331,6 +1381,50 @@ mod tests {
             Some(PaletteMode::Light)
         );
         assert_eq!(PaletteMode::from_colorfgbg("not-a-color"), None);
+    }
+
+    #[test]
+    fn palette_mode_detect_prefers_colorfgbg_over_macos_fallback() {
+        assert_eq!(
+            PaletteMode::detect_from_sources(Some("0;15"), Some(PaletteMode::Dark)),
+            PaletteMode::Light
+        );
+        assert_eq!(
+            PaletteMode::detect_from_sources(Some("15;0"), Some(PaletteMode::Light)),
+            PaletteMode::Dark
+        );
+    }
+
+    #[test]
+    fn palette_mode_detect_uses_macos_fallback_when_colorfgbg_missing_or_invalid() {
+        assert_eq!(
+            PaletteMode::detect_from_sources(None, Some(PaletteMode::Light)),
+            PaletteMode::Light
+        );
+        assert_eq!(
+            PaletteMode::detect_from_sources(Some("not-a-color"), Some(PaletteMode::Light)),
+            PaletteMode::Light
+        );
+        assert_eq!(
+            PaletteMode::detect_from_sources(None, None),
+            PaletteMode::Dark
+        );
+    }
+
+    #[test]
+    fn apple_interface_style_maps_dark_and_missing_key_to_expected_modes() {
+        assert_eq!(
+            super::palette_mode_from_apple_interface_style("Dark\n"),
+            PaletteMode::Dark
+        );
+        assert_eq!(
+            super::palette_mode_from_apple_interface_style("Light\n"),
+            PaletteMode::Light
+        );
+        assert_eq!(
+            super::palette_mode_from_apple_interface_style(""),
+            PaletteMode::Light
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- fall back to macOS appearance detection when `theme = "system"` cannot infer light/dark mode from `COLORFGBG`
- treat a missing `AppleInterfaceStyle` key as Light mode, matching macOS defaults
- add regression tests covering source precedence and the macOS fallback mapping

## Testing

- [x] `cargo fmt --all --check`
- [ ] `cargo test --all-features`
- [ ] `cargo clippy --all-targets --all-features`
- [x] `cargo test -p deepseek-tui --bin deepseek-tui palette_mode_ --locked`
- [x] `cargo test -p deepseek-tui --bin deepseek-tui apple_interface_style_maps_dark_and_missing_key_to_expected_modes --locked`
- [x] `cargo test -p deepseek-tui --bin deepseek-tui ui_theme_selects_light_variant --locked`

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes

Fixes #1670.