### PR TITLE
[subagents] Add api_timeout_secs config for per-step API call timeout

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -144,6 +144,7 @@ max_subagents = 10 # optional (1-20)
 # Optional sub-agent tuning. max_concurrent overrides top-level max_subagents.
 # [subagents]
 # max_concurrent = 10
+# api_timeout_secs = 120
 
 # Optional managed policy paths (defaults to /etc/deepseek/*.toml on unix):
 # managed_config_path = "/etc/deepseek/managed_config.toml"

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -868,6 +868,9 @@ pub struct SubagentsConfig {
     /// setting. Clamped to [1, MAX_SUBAGENTS].
     #[serde(default)]
     pub max_concurrent: Option<usize>,
+    /// Per-step LLM API call timeout in seconds. Default: 120.
+    #[serde(default)]
+    pub api_timeout_secs: Option<u64>,
 }
 
 /// `[auto]` table — knobs for the `--model auto` / `/model auto` router.

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -166,6 +166,10 @@ pub struct EngineConfig {
     pub search_provider: crate::config::SearchProvider,
     /// API key for Tavily or Bocha. `None` for Bing or DuckDuckGo.
     pub search_api_key: Option<String>,
+    /// Per-step LLM API call timeout for sub-agents, in seconds.
+    /// Resolved once at engine construction from
+    /// `[subagents].api_timeout_secs`. Default: 120.
+    pub subagent_api_timeout_secs: u64,
 }
 
 impl Default for EngineConfig {
@@ -206,6 +210,7 @@ impl Default for EngineConfig {
             workshop: None,
             search_provider: crate::config::SearchProvider::default(),
             search_api_key: None,
+            subagent_api_timeout_secs: 120,
         }
     }
 }
@@ -656,6 +661,7 @@ impl Engine {
                     )
                     .with_max_spawn_depth(self.config.max_spawn_depth)
                     .background_runtime();
+                    runtime.api_timeout_secs = self.config.subagent_api_timeout_secs;
                     let route = resolve_subagent_assignment_route(&runtime, None, &prompt).await;
                     runtime.model = route.model;
                     runtime.reasoning_effort = route.reasoning_effort;
@@ -1060,6 +1066,7 @@ impl Engine {
                         )
                         .with_max_spawn_depth(self.config.max_spawn_depth)
                         .with_parent_completion_tx(self.tx_subagent_completion.clone());
+                        rt.api_timeout_secs = self.config.subagent_api_timeout_secs;
                         if let Some(context) = fork_context_for_runtime.clone() {
                             rt = rt.with_fork_context(context);
                         }

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -4671,6 +4671,11 @@ async fn run_exec_agent(
             .and_then(|s| s.provider)
             .unwrap_or_default(),
         search_api_key: config.search.as_ref().and_then(|s| s.api_key.clone()),
+        subagent_api_timeout_secs: config
+            .subagents
+            .as_ref()
+            .and_then(|s| s.api_timeout_secs)
+            .unwrap_or(120),
     };
 
     let engine_handle = spawn_engine(engine_config, config);

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -1982,6 +1982,12 @@ impl RuntimeThreadManager {
                 .and_then(|s| s.provider)
                 .unwrap_or_default(),
             search_api_key: self.config.search.as_ref().and_then(|s| s.api_key.clone()),
+            subagent_api_timeout_secs: self
+                .config
+                .subagents
+                .as_ref()
+                .and_then(|s| s.api_timeout_secs)
+                .unwrap_or(120),
         };
 
         let engine = spawn_engine(engine_cfg, &self.config);

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -640,6 +640,7 @@ pub struct SubAgentRuntime {
     pub parent_completion_tx: Option<mpsc::UnboundedSender<SubAgentCompletion>>,
     /// Snapshot of the request prefix visible to an opt-in forked child.
     pub fork_context: Option<SubAgentForkContext>,
+    pub api_timeout_secs: u64,
 }
 
 impl SubAgentRuntime {
@@ -673,6 +674,7 @@ impl SubAgentRuntime {
             mailbox: None,
             parent_completion_tx: None,
             fork_context: None,
+            api_timeout_secs: STEP_API_TIMEOUT.as_secs(),
         }
     }
 
@@ -796,6 +798,7 @@ impl SubAgentRuntime {
             mailbox: self.mailbox.clone(),
             parent_completion_tx: self.parent_completion_tx.clone(),
             fork_context: self.fork_context.clone(),
+            api_timeout_secs: self.api_timeout_secs,
         }
     }
 
@@ -3460,8 +3463,8 @@ async fn run_subagent(
                     from_prior_session: false,
                 });
             }
-            api = tokio::time::timeout(STEP_API_TIMEOUT, runtime.client.create_message(request)) => {
-                api.map_err(|_| anyhow!("API call timed out after {}s", STEP_API_TIMEOUT.as_secs()))??
+            api = tokio::time::timeout(Duration::from_secs(runtime.api_timeout_secs), runtime.client.create_message(request)) => {
+                api.map_err(|_| anyhow!("API call timed out after {}s", runtime.api_timeout_secs))??
             }
         };
 

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -1402,6 +1402,7 @@ fn stub_runtime() -> SubAgentRuntime {
         mailbox: None,
         parent_completion_tx: None,
         fork_context: None,
+        api_timeout_secs: super::STEP_API_TIMEOUT.as_secs(),
     }
 }
 

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -710,6 +710,11 @@ fn build_engine_config(app: &App, config: &Config) -> EngineConfig {
             .and_then(|s| s.provider)
             .unwrap_or_default(),
         search_api_key: config.search.as_ref().and_then(|s| s.api_key.clone()),
+        subagent_api_timeout_secs: config
+            .subagents
+            .as_ref()
+            .and_then(|s| s.api_timeout_secs)
+            .unwrap_or(120),
     }
 }
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -439,9 +439,9 @@ If you are upgrading from older releases:
   related persistent sub-agent sessions. Explicit tool `model` values win, then role/type
   overrides, then the parent runtime model. Supported convenience keys are
   `default_model`, `worker_model`, `explorer_model`, `awaiter_model`,
-  `review_model`, `custom_model`, and `max_concurrent`. The
+  `review_model`, `custom_model`, `max_concurrent`, and `api_timeout_secs`. The
   `[subagents] max_concurrent` value overrides top-level `max_subagents` and is
-  also clamped to `1..=20`. `[subagents.models]` accepts lower-case role or type
+  also clamped to `1..=20`. `[subagents] api_timeout_secs` (int, optional, default `120`): per-step LLM API call timeout in seconds. Increase for sub-agents that process large prompts or need deep reasoning. `[subagents.models]` accepts lower-case role or type
   keys such as `worker`, `explorer`, `general`, `explore`, `plan`, and
   `review`. Values must normalize to a supported DeepSeek model id before an
   agent is spawned.

--- a/docs/SUBAGENTS.md
+++ b/docs/SUBAGENTS.md
@@ -99,7 +99,7 @@ the next turn.
 
 The dispatcher caps concurrent sub-agents at 10 by default
 (configurable via `[subagents].max_concurrent` in `~/.deepseek/config.toml`,
-hard ceiling 20). When the parent hits the cap, `agent_open` returns
+hard ceiling 20). Per-step API call timeout defaults to 120 s; override with `[subagents].api_timeout_secs`. When the parent hits the cap, `agent_open` returns
 an error with the cap value; the parent should use `agent_eval` to wait for
 completion or `agent_close` to free a slot before retrying.
 


### PR DESCRIPTION
## Summary
The hardcoded STEP_API_TIMEOUT (120s) is too short for sub-agents that process large prompts or need deep reasoning. 
Expose it as a configurable option.
    
## Changes
- Add `api_timeout_secs: Option<u64>` to `[subagents]` config section
- SubAgentRuntime reads timeout from config; falls back to  `STEP_API_TIMEOUT` (120s) when unset
- Children inherit via `child_runtime()` clone
- No builder — uses direct field assignment, keeps diff minimal

## Testing
- [ ] `cargo test --all-features` — not run (no Rust toolchain available)
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets --all-features`

## Checklist
- [x] Updated docs or comments as needed — CONFIGURATION.md, SUBAGENTS.md, config.example.toml
- [ ] Added or updated tests where relevant — existing tests cover runtime defaults; CI should pass
- [ ] Verified TUI behavior manually if UI changes — no UI changes