### PR TITLE
feat: serve-centered local API bridge for Playwright/Tauri integration

### DIFF
--- a/core/api/server.py
+++ b/core/api/server.py
@@ -1,0 +1,191 @@
+import os
+from typing import Any
+
+from aiohttp import web
+from loguru import logger
+
+
+EXTENSION_HOST = os.getenv("DEEPSEEK_EXTENSION_HOST", "127.0.0.1")
+EXTENSION_PORT = int(os.getenv("DEEPSEEK_EXTENSION_PORT", "3000"))
+
+
+class ExtensionServer:
+    def __init__(self, process_manager, playwright_wrapper):
+        self._pm = process_manager
+        self._pw = playwright_wrapper
+        self._runner: web.AppRunner | None = None
+        self._site: web.TCPSite | None = None
+        self._app = web.Application()
+        self._app.add_routes(
+            [
+                web.get("/health", self.health),
+                web.get("/v1/status", self.status),
+                web.get("/v1/capabilities", self.capabilities),
+                web.get("/v1/browser/state", self.browser_state),
+                web.get("/v1/browser/summary", self.browser_summary),
+                web.post("/v1/chat", self.chat),
+                web.post("/v1/chat/stream", self.chat_stream),
+                web.post("/v1/browser/dom", self.browser_dom),
+                web.post("/v1/browser/element", self.browser_element),
+                web.post("/v1/browser/navigate", self.browser_navigate),
+                web.post("/v1/browser/evaluate", self.browser_evaluate),
+                web.post("/v1/browser/screenshot", self.browser_screenshot),
+                web.post("/v1/browser/ui", self.browser_ui),
+                web.post("/v1/browser/reload-console", self.browser_reload_console),
+                web.post("/v1/browser/mcp-task", self.browser_mcp_task),
+                web.post("/control/start", self.start_runtime),
+                web.post("/control/restart", self.restart),
+                web.post("/control/stop", self.stop_runtime),
+                web.get("/ui/host", self.ui_host),
+            ]
+        )
+
+    async def start(self):
+        self._runner = web.AppRunner(self._app)
+        await self._runner.setup()
+        self._site = web.TCPSite(self._runner, EXTENSION_HOST, EXTENSION_PORT)
+        await self._site.start()
+        logger.info(f"Extension API listening on http://{EXTENSION_HOST}:{EXTENSION_PORT}")
+
+    async def stop(self):
+        if self._runner:
+            await self._runner.cleanup()
+            self._runner = None
+            self._site = None
+
+    async def health(self, _request: web.Request):
+        return web.json_response({"status": "ok", "service": "deepseek-extension-api"})
+
+    async def status(self, _request: web.Request):
+        return web.json_response(await self._pw.get_status())
+
+    async def capabilities(self, _request: web.Request):
+        return web.json_response(await self._pw.get_capabilities())
+
+    async def browser_state(self, _request: web.Request):
+        return web.json_response(await self._pw.get_browser_state())
+
+    async def browser_summary(self, _request: web.Request):
+        return web.json_response(await self._pw.get_page_summary())
+
+    async def chat(self, request: web.Request):
+        payload = await request.json()
+        message = (payload.get("message") or "").strip()
+        if not message:
+            return web.json_response({"error": "message is required"}, status=400)
+
+        content = await self._pw.send_message(message)
+        return web.json_response({"content": content})
+
+    async def chat_stream(self, request: web.Request):
+        payload = await request.json()
+        message = (payload.get("message") or "").strip()
+        if not message:
+            return web.Response(status=400, text="message is required")
+
+        content = await self._pw.send_message(message)
+        return web.Response(text=content, content_type="text/plain")
+
+    async def browser_navigate(self, request: web.Request):
+        payload = await self._read_json(request)
+        url = (payload.get("url") or "").strip()
+        if not url:
+            return web.json_response({"error": "url is required"}, status=400)
+        return web.json_response(await self._pw.navigate(url))
+
+    async def browser_dom(self, request: web.Request):
+        payload = await self._read_json(request)
+        selector = (payload.get("selector") or "").strip()
+        if not selector:
+            return web.json_response({"error": "selector is required"}, status=400)
+        return web.json_response(await self._pw.inspect_dom(selector))
+
+    async def browser_element(self, request: web.Request):
+        payload = await self._read_json(request)
+        selector = (payload.get("selector") or "").strip()
+        action = (payload.get("action") or "").strip()
+        if not selector or not action:
+            return web.json_response({"error": "selector and action are required"}, status=400)
+        return web.json_response(
+            await self._pw.operate_element(selector, action, payload.get("value"))
+        )
+
+    async def browser_evaluate(self, request: web.Request):
+        payload = await self._read_json(request)
+        expression = (payload.get("expression") or "").strip()
+        if not expression:
+            return web.json_response({"error": "expression is required"}, status=400)
+        return web.json_response({"result": await self._pw.evaluate(expression)})
+
+    async def browser_screenshot(self, request: web.Request):
+        payload = await self._read_json(request)
+        return web.json_response(await self._pw.screenshot(payload.get("path")))
+
+    async def browser_ui(self, request: web.Request):
+        payload = await self._read_json(request)
+        return web.json_response(
+            await self._pw.update_ui(
+                viewport_width=payload.get("viewport_width"),
+                viewport_height=payload.get("viewport_height"),
+                zoom=payload.get("zoom"),
+                css=payload.get("css"),
+                js=payload.get("js"),
+                reset_injections=bool(payload.get("reset_injections", False)),
+            )
+        )
+
+    async def browser_reload_console(self, _request: web.Request):
+        return web.json_response(await self._pw.reload_console())
+
+    async def browser_mcp_task(self, request: web.Request):
+        payload = await self._read_json(request)
+        prompt = (payload.get("prompt") or "").strip()
+        if not prompt:
+            return web.json_response({"error": "prompt is required"}, status=400)
+        return web.json_response(await self._pw.run_mcp_browser_task(prompt))
+
+    async def start_runtime(self, _request: web.Request):
+        await self._pm.ensure_started()
+        return web.json_response({"ok": True, "desired_running": self._pm.desired_running})
+
+    async def restart(self, _request: web.Request):
+        await self._pm.restart()
+        return web.json_response({"ok": True})
+
+    async def stop_runtime(self, _request: web.Request):
+        await self._pm.stop()
+        return web.json_response({"ok": True})
+
+    async def _read_json(self, request: web.Request) -> dict[str, Any]:
+        if request.can_read_body:
+            try:
+                return await request.json()
+            except Exception:
+                return {}
+        return {}
+
+    async def ui_host(self, _request: web.Request):
+        return web.Response(
+            text="""
+<!DOCTYPE html>
+<html lang=\"zh-CN\">
+<head>
+  <meta charset=\"utf-8\" />
+  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />
+  <title>DeepSeek Control Console</title>
+  <style>
+    html, body {
+      margin: 0;
+      width: 100%;
+      height: 100%;
+      background: radial-gradient(circle at top, #182334 0%, #0b1017 58%, #06080d 100%);
+      overflow: hidden;
+    }
+  </style>
+</head>
+<body>
+</body>
+</html>
+            """.strip(),
+            content_type="text/html",
+        )

--- a/core/main.py
+++ b/core/main.py
@@ -1,0 +1,66 @@
+﻿"""
+DeepSeek IDE - Extension Layer Entry Point
+Starts ProcessManager + PlaywrightWrapper in parallel.
+This process is launched as a Tauri sidecar.
+"""
+
+import asyncio
+import sys
+from loguru import logger
+from process_manager import ProcessManager
+from playwright_wrapper import PlaywrightWrapper
+from api.server import ExtensionServer
+
+# Pretty log format
+logger.remove()
+logger.add(
+    sys.stderr,
+    format="<green>{time:HH:mm:ss}</green> | <level>{level: <8}</level> | {message}",
+    colorize=True,
+)
+logger.add(
+    "logs/extension.log",
+    rotation="10 MB",
+    retention="7 days",
+    encoding="utf-8",
+)
+
+
+async def main():
+    pm = ProcessManager()
+    pw = PlaywrightWrapper(pm)
+    server = ExtensionServer(pm, pw)
+
+    logger.info("=== DeepSeek IDE Extension Layer Starting ===")
+
+    # Start TUI process in background
+    tui_task = asyncio.create_task(pm.start())
+
+    # Give TUI a moment to bind its port
+    await asyncio.sleep(2.0)
+
+    await server.start()
+
+    # Start Playwright layer (waits for TUI to be ready)
+    await pw.start()
+
+    logger.info("All components ready. Listening...")
+
+    try:
+        # Keep running until TUI exits or Ctrl+C
+        await tui_task
+    except asyncio.CancelledError:
+        pass
+    except KeyboardInterrupt:
+        logger.info("Shutdown signal received.")
+    finally:
+        logger.info("Shutting down...")
+        await server.stop()
+        await pw.stop()
+        await pm.shutdown()
+        logger.info("=== Extension Layer Stopped ===")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+

--- a/core/playwright_wrapper.py
+++ b/core/playwright_wrapper.py
@@ -1,0 +1,417 @@
+﻿import os
+import asyncio
+import json
+import pathlib
+from typing import Any
+import aiohttp
+from loguru import logger
+from process_manager import ProcessManager
+from playwright.async_api import Browser, BrowserContext, Page, Playwright, async_playwright
+
+
+
+
+RUNTIME_PORT  = int(os.getenv("DEEPSEEK_RUNTIME_PORT", "7878"))
+RUNTIME_TOKEN = os.getenv("DEEPSEEK_RUNTIME_TOKEN", "")
+RUNTIME_BASE  = f"http://127.0.0.1:{RUNTIME_PORT}"
+EXTENSION_PORT = int(os.getenv("DEEPSEEK_EXTENSION_PORT", "3000"))
+EXTENSION_BASE = f"http://127.0.0.1:{EXTENSION_PORT}"
+CONTROL_PANEL_SCRIPT = pathlib.Path(__file__).resolve().parent / "ui" / "control_panel.js"
+DEFAULT_VIEWPORT = {"width": 1440, "height": 960}
+
+
+class PlaywrightWrapper:
+    def __init__(self, process_manager: ProcessManager):
+        self._pm = process_manager
+        self._session: aiohttp.ClientSession | None = None
+        self._playwright: Playwright | None = None
+        self._browser: Browser | None = None
+        self._context: BrowserContext | None = None
+        self._page: Page | None = None
+        self._injected_css: list[str] = []
+        self._injected_js: list[str] = []
+        self._ui_config = {
+            "viewport": dict(DEFAULT_VIEWPORT),
+            "zoom": 1.0,
+            "host_url": f"{EXTENSION_BASE}/ui/host",
+            "console_injected": False,
+        }
+        self._pm.on_restart(self._on_tui_restart)
+
+    async def start(self):
+        headers = {}
+        if RUNTIME_TOKEN:
+            headers["Authorization"] = f"Bearer {RUNTIME_TOKEN}"
+        self._session = aiohttp.ClientSession(headers=headers)
+        await self._wait_for_runtime(timeout=600.0)
+        await self._launch_browser()
+        logger.info("Extension layer connected to TUI.")
+
+    async def stop(self):
+        if self._session:
+            await self._session.close()
+        if self._browser:
+            await self._browser.close()
+        if self._playwright:
+            await self._playwright.stop()
+
+    async def _wait_for_runtime(self, timeout: float = 600.0):
+        logger.info(f"Waiting for runtime at {RUNTIME_BASE}  (first run compiles Rust, may take minutes...)")
+        deadline = asyncio.get_event_loop().time() + timeout
+        attempt = 0
+        while asyncio.get_event_loop().time() < deadline:
+            try:
+                async with self._session.get(
+                    f"{RUNTIME_BASE}/health",
+                    timeout=aiohttp.ClientTimeout(total=2),
+                ) as resp:
+                    if resp.status == 200:
+                        logger.info(f"TUI alive! (attempt #{attempt})")
+                        return
+            except Exception:
+                pass
+            attempt += 1
+            if attempt % 30 == 0:
+                elapsed = int(timeout - (deadline - asyncio.get_event_loop().time()))
+                logger.info(f"Still compiling... ({elapsed}s elapsed)")
+            await asyncio.sleep(1.0)
+        raise TimeoutError("TUI did not start within 600s")
+
+    async def _on_tui_restart(self):
+        await self._wait_for_runtime(timeout=120.0)
+        await self._ensure_control_console()
+
+    async def _launch_browser(self):
+        self._playwright = await async_playwright().start()
+        self._browser = await self._playwright.chromium.launch(headless=False)
+        self._context = await self._browser.new_context(viewport=dict(DEFAULT_VIEWPORT))
+        self._page = await self._context.new_page()
+        await self._page.goto(self._ui_config["host_url"], wait_until="domcontentloaded")
+        await self._ensure_control_console()
+
+    async def _ensure_control_console(self):
+        if not self._page:
+            return
+        if self._page.url != self._ui_config["host_url"]:
+            await self._page.goto(self._ui_config["host_url"], wait_until="domcontentloaded")
+
+        script = CONTROL_PANEL_SCRIPT.read_text(encoding="utf-8")
+        bootstrap = (
+            "window.__DEEPSEEK_CONTROL_CONFIG = {"
+            f"runtimeBase: '{RUNTIME_BASE}',"
+            f"extensionBase: '{EXTENSION_BASE}',"
+            f"runtimeToken: '{RUNTIME_TOKEN}'"
+            "};"
+        )
+        await self._page.add_script_tag(content=bootstrap + script)
+        self._ui_config["console_injected"] = True
+        await self._apply_ui_state()
+
+    async def _require_page(self) -> Page:
+        if not self._page:
+            raise RuntimeError("Playwright page is not initialized")
+        return self._page
+
+    async def _apply_ui_state(self):
+        page = await self._require_page()
+        await page.set_viewport_size(self._ui_config["viewport"])
+        zoom = float(self._ui_config.get("zoom", 1.0))
+        await page.evaluate(
+            """
+            (zoom) => {
+                document.documentElement.style.zoom = String(zoom);
+                document.body.dataset.deepseekZoom = String(zoom);
+            }
+            """,
+            zoom,
+        )
+        for css in self._injected_css:
+            await page.add_style_tag(content=css)
+        for js in self._injected_js:
+            await page.add_script_tag(content=js)
+
+    async def get_capabilities(self) -> dict[str, Any]:
+        return {
+            "process_management": {
+                "status": True,
+                "start": True,
+                "stop": True,
+                "restart": True,
+                "auto_restart": True,
+            },
+            "ui_injection": {
+                "viewport": True,
+                "zoom": True,
+                "css": True,
+                "javascript": True,
+                "reload_console": True,
+            },
+            "extension_api": {
+                "status": "/v1/status",
+                "capabilities": "/v1/capabilities",
+                "browser_state": "/v1/browser/state",
+                "browser_summary": "/v1/browser/summary",
+                "browser_dom": "/v1/browser/dom",
+                "browser_element": "/v1/browser/element",
+                "browser_navigate": "/v1/browser/navigate",
+                "browser_screenshot": "/v1/browser/screenshot",
+                "browser_evaluate": "/v1/browser/evaluate",
+                "browser_ui": "/v1/browser/ui",
+                "browser_mcp_task": "/v1/browser/mcp-task",
+            },
+            "browser_ai_native": {
+                "navigate": True,
+                "evaluate": True,
+                "screenshot": True,
+                "dom_injection": True,
+                "page_summary": True,
+                "dom_inspect": True,
+                "element_actions": ["click", "fill", "focus", "highlight"],
+                "mcp_browser_task": True,
+            },
+        }
+
+    async def get_browser_state(self) -> dict[str, Any]:
+        page = await self._require_page()
+        title = await page.title()
+        return {
+            "url": page.url,
+            "title": title,
+            "viewport": dict(self._ui_config["viewport"]),
+            "zoom": self._ui_config["zoom"],
+            "console_injected": self._ui_config["console_injected"],
+            "injected_css_count": len(self._injected_css),
+            "injected_js_count": len(self._injected_js),
+        }
+
+    async def navigate(self, url: str) -> dict[str, Any]:
+        page = await self._require_page()
+        await page.goto(url, wait_until="domcontentloaded")
+        self._ui_config["host_url"] = url
+        await self._apply_ui_state()
+        return await self.get_browser_state()
+
+    async def reload_console(self) -> dict[str, Any]:
+        self._ui_config["host_url"] = f"{EXTENSION_BASE}/ui/host"
+        await self._ensure_control_console()
+        return await self.get_browser_state()
+
+    async def update_ui(
+        self,
+        viewport_width: int | None = None,
+        viewport_height: int | None = None,
+        zoom: float | None = None,
+        css: str | None = None,
+        js: str | None = None,
+        reset_injections: bool = False,
+    ) -> dict[str, Any]:
+        if viewport_width is not None or viewport_height is not None:
+            width = int(viewport_width or self._ui_config["viewport"]["width"])
+            height = int(viewport_height or self._ui_config["viewport"]["height"])
+            self._ui_config["viewport"] = {"width": max(width, 320), "height": max(height, 240)}
+
+        if zoom is not None:
+            self._ui_config["zoom"] = max(float(zoom), 0.25)
+
+        if reset_injections:
+            self._injected_css.clear()
+            self._injected_js.clear()
+
+        if css:
+            self._injected_css.append(css)
+        if js:
+            self._injected_js.append(js)
+
+        await self._apply_ui_state()
+        return await self.get_browser_state()
+
+    async def evaluate(self, expression: str) -> Any:
+        page = await self._require_page()
+        return await page.evaluate(expression)
+
+    async def screenshot(self, path: str | None = None) -> dict[str, Any]:
+        page = await self._require_page()
+        output = pathlib.Path(path) if path else (pathlib.Path(__file__).resolve().parent / "logs" / "playwright-console.png")
+        output.parent.mkdir(parents=True, exist_ok=True)
+        await page.screenshot(path=str(output), full_page=True)
+        return {"path": str(output), "url": page.url}
+
+    async def get_page_summary(self) -> dict[str, Any]:
+        page = await self._require_page()
+        summary = await page.evaluate(
+            """
+            () => {
+                const text = (document.body?.innerText || "").replace(/\s+/g, " ").trim();
+                const headings = Array.from(document.querySelectorAll("h1, h2, h3"))
+                    .map((node) => node.textContent?.trim())
+                    .filter(Boolean)
+                    .slice(0, 8);
+                const links = Array.from(document.querySelectorAll("a[href]"))
+                    .map((node) => ({
+                        text: (node.textContent || "").replace(/\s+/g, " ").trim().slice(0, 80),
+                        href: node.getAttribute("href") || ""
+                    }))
+                    .filter((entry) => entry.text || entry.href)
+                    .slice(0, 8);
+                return {
+                    title: document.title,
+                    text_excerpt: text.slice(0, 1200),
+                    text_length: text.length,
+                    headings,
+                    links,
+                    forms: document.forms.length,
+                    buttons: document.querySelectorAll("button,[role='button']").length,
+                    inputs: document.querySelectorAll("input, textarea, select").length,
+                };
+            }
+            """
+        )
+        return {"url": page.url, **summary}
+
+    async def inspect_dom(self, selector: str) -> dict[str, Any]:
+        page = await self._require_page()
+        selector = selector.strip()
+        if not selector:
+            raise RuntimeError("selector is required")
+        return await page.evaluate(
+            """
+            (selector) => {
+                const allNodes = Array.from(document.querySelectorAll(selector));
+                const nodes = allNodes.slice(0, 12);
+                return {
+                    selector,
+                    count: allNodes.length,
+                    matches: nodes.map((node, index) => ({
+                        index,
+                        tag: node.tagName.toLowerCase(),
+                        id: node.id || null,
+                        classes: Array.from(node.classList).slice(0, 6),
+                        text: (node.textContent || "").replace(/\s+/g, " ").trim().slice(0, 160),
+                        value: "value" in node ? String(node.value).slice(0, 160) : null,
+                        visible: !!(node.offsetWidth || node.offsetHeight || node.getClientRects().length),
+                    })),
+                };
+            }
+            """,
+            selector,
+        )
+
+    async def operate_element(self, selector: str, action: str, value: str | None = None) -> dict[str, Any]:
+        page = await self._require_page()
+        selector = selector.strip()
+        action = action.strip().lower()
+        if not selector:
+            raise RuntimeError("selector is required")
+
+        locator = page.locator(selector).first
+        await locator.wait_for(timeout=5000)
+
+        if action == "click":
+            await locator.click()
+        elif action == "fill":
+            await locator.fill(value or "")
+        elif action == "focus":
+            await locator.focus()
+        elif action == "highlight":
+            await page.evaluate(
+                """
+                (selector) => {
+                    const node = document.querySelector(selector);
+                    if (!node) {
+                        throw new Error("selector not found");
+                    }
+                    node.scrollIntoView({ behavior: "smooth", block: "center" });
+                    node.dataset.deepseekPreviousOutline = node.style.outline || "";
+                    node.style.outline = "3px solid #67e8f9";
+                    setTimeout(() => {
+                        node.style.outline = node.dataset.deepseekPreviousOutline || "";
+                    }, 1800);
+                }
+                """,
+                selector,
+            )
+        else:
+            raise RuntimeError(f"unsupported action: {action}")
+
+        return {
+            "ok": True,
+            "selector": selector,
+            "action": action,
+            "value": value,
+            "url": page.url,
+        }
+
+    async def run_mcp_browser_task(self, prompt: str) -> dict[str, Any]:
+        task_prompt = prompt.strip()
+        if not task_prompt:
+            raise RuntimeError("prompt is required")
+        content = await self.send_message(
+            "请优先使用当前可用的浏览器 / Playwright / MCP 能力完成以下浏览器任务，必要时先检查页面状态，再执行操作，并返回简洁结果：\n\n"
+            f"{task_prompt}"
+        )
+        return {"ok": True, "prompt": task_prompt, "content": content}
+
+    async def send_message(self, content: str) -> str:
+        async with self._session.post(
+            f"{RUNTIME_BASE}/v1/stream",
+            json={"prompt": content},
+            timeout=aiohttp.ClientTimeout(total=300),
+        ) as resp:
+            resp.raise_for_status()
+            event_name = "message"
+            chunks: list[str] = []
+            async for raw_line in resp.content:
+                line = raw_line.decode(errors="replace").strip()
+                if not line:
+                    continue
+                if line.startswith("event:"):
+                    event_name = line[6:].strip()
+                    continue
+                if not line.startswith("data:"):
+                    continue
+
+                data = line[5:].strip()
+                if event_name == "message.delta":
+                    try:
+                        parsed = json.loads(data)
+                    except Exception:
+                        continue
+                    delta = parsed.get("content", "")
+                    if delta:
+                        chunks.append(delta)
+                elif event_name == "error":
+                    try:
+                        parsed = json.loads(data)
+                    except Exception:
+                        parsed = {"message": data}
+                    raise RuntimeError(parsed.get("message", "runtime stream failed"))
+            return "".join(chunks).strip()
+
+    async def get_status(self) -> dict:
+        async with self._session.get(
+            f"{RUNTIME_BASE}/v1/runtime/info",
+            timeout=aiohttp.ClientTimeout(total=5),
+        ) as runtime_resp:
+            runtime = await runtime_resp.json()
+
+        async with self._session.get(
+            f"{RUNTIME_BASE}/v1/workspace/status",
+            timeout=aiohttp.ClientTimeout(total=5),
+        ) as workspace_resp:
+            workspace = await workspace_resp.json()
+
+        return {
+            "runtime": runtime,
+            "workspace": workspace,
+            "process": {
+                "app_server_running": self._pm.is_alive,
+                "app_server_base_url": self._pm.base_url,
+                "pid": self._pm.pid,
+                "desired_running": self._pm.desired_running,
+                "supervising": self._pm.supervising,
+                "retry_count": self._pm.retry_count,
+            },
+            "console": {
+                **(await self.get_browser_state() if self._page else {"url": None}),
+            },
+        }

--- a/core/process_manager.py
+++ b/core/process_manager.py
@@ -1,0 +1,262 @@
+﻿import asyncio
+import os
+import pathlib
+from loguru import logger
+from dotenv import load_dotenv
+
+load_dotenv()
+
+DEEPSEEK_API_KEY   = os.getenv("DEEPSEEK_API_KEY", "")
+DEEPSEEK_HTTP_PORT = int(os.getenv("DEEPSEEK_HTTP_PORT", "3000"))
+MAX_RETRIES        = int(os.getenv("MAX_RETRIES", "5"))
+RETRY_BASE_DELAY   = float(os.getenv("RETRY_BASE_DELAY", "2.0"))
+DEV_MODE           = os.getenv("DEEPSEEK_DEV_MODE", "false").lower() == "true"
+
+_HERE = pathlib.Path(__file__).resolve().parent       # .../core/
+_env_dir = os.getenv("DEEPSEEK_TUI_DIR", "").strip()
+TUI_DIR = pathlib.Path(_env_dir).resolve() if _env_dir else (_HERE.parent / "DeepSeek-TUI").resolve()
+DEEPSEEK_BIN = os.getenv("DEEPSEEK_BIN", str(TUI_DIR / "target" / "release" / "deepseek.exe"))
+
+
+class ProcessManager:
+    def __init__(self):
+        self._process = None
+        self._supervising = False
+        self._desired_running = False
+        self._retry_count = 0
+        self._manual_restart = False
+        self._attached_pid: int | None = None
+        self._restart_callbacks = []
+
+    def on_restart(self, callback):
+        self._restart_callbacks.append(callback)
+
+    async def start(self):
+        self._supervising = True
+        self._desired_running = True
+        self._retry_count = 0
+        await self._launch_loop()
+
+    async def shutdown(self):
+        self._supervising = False
+        self._desired_running = False
+        if self._process and self.is_alive:
+            try:
+                self._process.terminate()
+                await asyncio.wait_for(self._process.wait(), timeout=5.0)
+            except (asyncio.TimeoutError, ProcessLookupError):
+                self._process.kill()
+        elif self._attached_pid is not None:
+            await self._terminate_pid(self._attached_pid)
+            self._attached_pid = None
+        logger.info("DeepSeek-TUI supervisor stopped.")
+
+    async def stop(self):
+        self._desired_running = False
+        if self._process and self.is_alive:
+            try:
+                self._process.terminate()
+                await asyncio.wait_for(self._process.wait(), timeout=5.0)
+            except (asyncio.TimeoutError, ProcessLookupError):
+                self._process.kill()
+        elif self._attached_pid is not None:
+            await self._terminate_pid(self._attached_pid)
+            self._attached_pid = None
+        logger.info("DeepSeek-TUI runtime stopped.")
+
+    async def ensure_started(self):
+        self._desired_running = True
+        self._manual_restart = False
+        logger.info("DeepSeek-TUI runtime marked as desired-running.")
+
+    async def restart(self):
+        self._desired_running = True
+        if not self.is_alive:
+            if self._attached_pid is not None:
+                await self._terminate_pid(self._attached_pid)
+                self._attached_pid = None
+            logger.info("Restart requested while app-server is stopped; launch loop will start it.")
+            return
+
+        if self._attached_pid is not None and (self._process is None or self._process.returncode is not None):
+            await self._terminate_pid(self._attached_pid)
+            self._attached_pid = None
+            logger.info("DeepSeek-TUI attached runtime restart requested.")
+            return
+
+        self._manual_restart = True
+        try:
+            self._process.terminate()
+            await asyncio.wait_for(self._process.wait(), timeout=5.0)
+        except (asyncio.TimeoutError, ProcessLookupError):
+            self._process.kill()
+        logger.info("DeepSeek-TUI restart requested.")
+
+    @property
+    def is_alive(self):
+        return (self._process is not None and self._process.returncode is None) or (
+            self._attached_pid is not None and self._is_pid_running(self._attached_pid)
+        )
+
+    @property
+    def pid(self):
+        if self._process and self._process.returncode is None:
+            return self._process.pid
+        if self._attached_pid is not None and self._is_pid_running(self._attached_pid):
+            return self._attached_pid
+        return None
+
+    @property
+    def desired_running(self):
+        return self._desired_running
+
+    @property
+    def supervising(self):
+        return self._supervising
+
+    @property
+    def retry_count(self):
+        return self._retry_count
+
+    @property
+    def attached_pid(self):
+        return self._attached_pid
+
+    @property
+    def base_url(self):
+        return f"http://localhost:{DEEPSEEK_HTTP_PORT}"
+
+    def _build_cmd(self):
+        env = {**os.environ, "DEEPSEEK_API_KEY": DEEPSEEK_API_KEY}
+        if DEV_MODE:
+            logger.info(f"DEV_MODE: cargo run in {TUI_DIR}")
+            cmd = ["cargo", "run", "--bin", "deepseek", "--",
+               "app-server", "--port", str(DEEPSEEK_HTTP_PORT)]
+            kwargs = dict(cwd=str(TUI_DIR), env=env,
+                          stdout=asyncio.subprocess.PIPE,
+                          stderr=asyncio.subprocess.PIPE)
+        else:
+            logger.info(f"PROD_MODE: {DEEPSEEK_BIN}")
+            cmd = [DEEPSEEK_BIN, "app-server", "--port", str(DEEPSEEK_HTTP_PORT)]
+            kwargs = dict(env=env,
+                          stdout=asyncio.subprocess.PIPE,
+                          stderr=asyncio.subprocess.PIPE)
+        return cmd, kwargs
+
+    def _is_pid_running(self, pid: int) -> bool:
+        try:
+            os.kill(pid, 0)
+            return True
+        except PermissionError:
+            return True
+        except ProcessLookupError:
+            return False
+        except OSError:
+            return False
+
+    async def _probe_runtime_pid(self) -> int | None:
+        command = (
+            f"$conn = Get-NetTCPConnection -LocalPort {DEEPSEEK_HTTP_PORT} -State Listen "
+            "-ErrorAction SilentlyContinue | Select-Object -First 1; "
+            "if ($null -ne $conn) { $conn.OwningProcess }"
+        )
+        proc = await asyncio.create_subprocess_exec(
+            "powershell",
+            "-NoProfile",
+            "-Command",
+            command,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        stdout, _ = await proc.communicate()
+        raw = stdout.decode(errors="replace").strip()
+        if not raw:
+            return None
+        try:
+            return int(raw.splitlines()[-1].strip())
+        except ValueError:
+            return None
+
+    async def _terminate_pid(self, pid: int):
+        logger.info(f"Terminating existing runtime on port {DEEPSEEK_HTTP_PORT} (pid={pid})")
+        proc = await asyncio.create_subprocess_exec(
+            "taskkill",
+            "/PID",
+            str(pid),
+            "/T",
+            "/F",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        await proc.communicate()
+
+    async def _launch_loop(self):
+        while self._supervising:
+            if not self._desired_running:
+                await asyncio.sleep(0.25)
+                continue
+
+            if self._attached_pid is not None and not self._is_pid_running(self._attached_pid):
+                logger.info(f"Attached pid={self._attached_pid} is no longer running; clearing attachment.")
+                self._attached_pid = None
+
+            if self._attached_pid is None:
+                existing_pid = await self._probe_runtime_pid()
+                if existing_pid is not None:
+                    self._attached_pid = existing_pid
+                    logger.warning(
+                        f"Port {DEEPSEEK_HTTP_PORT} is already in use by pid={existing_pid}; skipping duplicate launch."
+                    )
+                    await asyncio.sleep(2.0)
+                    continue
+
+            logger.info(f"Launching (attempt {self._retry_count + 1}/{MAX_RETRIES}) | TUI_DIR={TUI_DIR}")
+            try:
+                cmd, kwargs = self._build_cmd()
+                self._process = await asyncio.create_subprocess_exec(*cmd, **kwargs)
+                stdout, stderr = await self._process.communicate()
+                code = self._process.returncode
+                if not self._supervising:
+                    break
+                if not self._desired_running:
+                    logger.info("Runtime exited after explicit stop request.")
+                    self._process = None
+                    self._manual_restart = False
+                    continue
+                if stderr:
+                    error_text = stderr.decode(errors='replace')
+                    if "os error 10048" in error_text or "Only one usage of each socket address" in error_text:
+                        self._attached_pid = await self._probe_runtime_pid()
+                        logger.warning(
+                            f"Runtime port {DEEPSEEK_HTTP_PORT} is already occupied; attaching instead of retrying."
+                        )
+                        self._retry_count = 0
+                        await asyncio.sleep(2.0)
+                        continue
+                logger.warning(f"Exited (code={code}), restarting...")
+                if stderr:
+                    logger.debug(f"stderr: {error_text[:500]}")
+                if self._manual_restart:
+                    self._retry_count = 0
+                    self._manual_restart = False
+                else:
+                    self._retry_count += 1
+                if self._retry_count >= MAX_RETRIES:
+                    logger.error("Max retries reached.")
+                    self._desired_running = False
+                    break
+                await asyncio.sleep(RETRY_BASE_DELAY ** self._retry_count)
+                for cb in self._restart_callbacks:
+                    asyncio.create_task(cb())
+            except FileNotFoundError as e:
+                logger.error(f"Not found: {e} | TUI_DIR={TUI_DIR} DEV_MODE={DEV_MODE}")
+                self._desired_running = False
+                break
+            except PermissionError as e:
+                logger.error(f"Permission denied: {e}")
+                self._desired_running = False
+                break
+            except Exception as exc:
+                logger.exception(f"Unexpected: {exc}")
+                self._desired_running = False
+                break

--- a/core/ui/control_panel.js
+++ b/core/ui/control_panel.js
@@ -1,0 +1,644 @@
+(function () {
+    if (window.__deepseekControlConsoleMounted) {
+        return;
+    }
+    window.__deepseekControlConsoleMounted = true;
+
+    const extensionBase = (window.__DEEPSEEK_CONTROL_CONFIG || {}).extensionBase || "http://127.0.0.1:3000";
+    let currentZoom = 1;
+
+    const style = document.createElement("style");
+    style.textContent = `
+        :root {
+            color-scheme: dark;
+            --panel-bg: rgba(8, 12, 18, 0.82);
+            --panel-border: rgba(124, 156, 197, 0.18);
+            --panel-shadow: 0 18px 50px rgba(0, 0, 0, 0.38);
+            --text-main: #eff6ff;
+            --text-muted: #91a4bb;
+            --accent: #67e8f9;
+            --accent-strong: #22c55e;
+            --danger: #fb7185;
+            --surface: rgba(15, 23, 34, 0.92);
+        }
+
+        body {
+            font-family: "Segoe UI Variable Text", "Segoe UI", sans-serif;
+            color: var(--text-main);
+        }
+
+        #deepseek-control-root {
+            position: fixed;
+            inset: 0;
+            padding: 24px;
+            display: grid;
+            grid-template-columns: minmax(320px, 380px) minmax(420px, 1fr);
+            gap: 20px;
+        }
+
+        .ds-card {
+            background: var(--panel-bg);
+            border: 1px solid var(--panel-border);
+            box-shadow: var(--panel-shadow);
+            backdrop-filter: blur(18px);
+            border-radius: 22px;
+        }
+
+        .ds-sidebar {
+            padding: 22px;
+            display: flex;
+            flex-direction: column;
+            gap: 18px;
+            overflow-y: auto;
+        }
+
+        .ds-title {
+            font-size: 28px;
+            font-weight: 700;
+            letter-spacing: 0.02em;
+        }
+
+        .ds-subtitle {
+            color: var(--text-muted);
+            font-size: 13px;
+            line-height: 1.6;
+        }
+
+        .ds-badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            padding: 8px 12px;
+            border-radius: 999px;
+            background: rgba(103, 232, 249, 0.1);
+            color: var(--accent);
+            font-size: 12px;
+            font-weight: 600;
+        }
+
+        .ds-meta {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 12px;
+        }
+
+        .ds-meta-item {
+            padding: 12px 14px;
+            border-radius: 16px;
+            background: var(--surface);
+            min-height: 78px;
+        }
+
+        .ds-meta-label {
+            color: var(--text-muted);
+            font-size: 12px;
+            margin-bottom: 6px;
+        }
+
+        .ds-meta-value {
+            font-size: 15px;
+            line-height: 1.5;
+            word-break: break-word;
+        }
+
+        .ds-meta-value.code {
+            font-family: "Cascadia Code", "Consolas", monospace;
+            font-size: 13px;
+        }
+
+        .ds-actions {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+        }
+
+        .ds-section {
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+
+        .ds-section-title {
+            font-size: 12px;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            color: var(--text-muted);
+        }
+
+        .ds-inline-form {
+            display: grid;
+            grid-template-columns: 1fr auto;
+            gap: 10px;
+        }
+
+        .ds-inline-input {
+            width: 100%;
+            border-radius: 14px;
+            border: 1px solid rgba(124, 156, 197, 0.18);
+            background: rgba(6, 9, 14, 0.86);
+            color: var(--text-main);
+            padding: 11px 12px;
+            font: inherit;
+        }
+
+        .ds-inline-input,
+        .ds-input,
+        .ds-select {
+            box-sizing: border-box;
+        }
+
+        .ds-select {
+            width: 100%;
+            border-radius: 14px;
+            border: 1px solid rgba(124, 156, 197, 0.18);
+            background: rgba(6, 9, 14, 0.86);
+            color: var(--text-main);
+            padding: 11px 12px;
+            font: inherit;
+        }
+
+        .ds-mini-textarea {
+            min-height: 88px;
+            resize: vertical;
+        }
+
+        .ds-pre {
+            margin: 0;
+            padding: 12px;
+            border-radius: 14px;
+            background: rgba(6, 9, 14, 0.72);
+            border: 1px solid rgba(124, 156, 197, 0.14);
+            color: #cfe8ff;
+            font-family: "Cascadia Code", "Consolas", monospace;
+            font-size: 12px;
+            line-height: 1.6;
+            overflow: auto;
+            white-space: pre-wrap;
+            max-height: 220px;
+        }
+
+        .ds-tiny-grid {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 10px;
+        }
+
+        .ds-button {
+            border: 0;
+            border-radius: 14px;
+            padding: 11px 14px;
+            font-size: 13px;
+            font-weight: 700;
+            cursor: pointer;
+            color: #041019;
+            background: linear-gradient(135deg, #67e8f9, #a7f3d0);
+        }
+
+        .ds-button.danger {
+            background: linear-gradient(135deg, #fb7185, #fda4af);
+            color: #22070b;
+        }
+
+        .ds-chat {
+            padding: 18px;
+            display: grid;
+            grid-template-rows: 1fr auto;
+            min-height: 0;
+        }
+
+        .ds-log {
+            overflow: auto;
+            padding-right: 6px;
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+
+        .ds-message {
+            max-width: 86%;
+            padding: 14px 16px;
+            border-radius: 18px;
+            line-height: 1.65;
+            white-space: pre-wrap;
+            background: rgba(15, 23, 34, 0.92);
+            border: 1px solid rgba(124, 156, 197, 0.14);
+        }
+
+        .ds-message.user {
+            align-self: flex-end;
+            background: linear-gradient(135deg, rgba(34, 197, 94, 0.22), rgba(103, 232, 249, 0.18));
+        }
+
+        .ds-message.assistant {
+            align-self: flex-start;
+        }
+
+        .ds-composer {
+            display: grid;
+            grid-template-columns: 1fr auto;
+            gap: 12px;
+            margin-top: 18px;
+        }
+
+        .ds-input {
+            min-height: 120px;
+            resize: vertical;
+            border-radius: 18px;
+            border: 1px solid rgba(124, 156, 197, 0.18);
+            background: rgba(6, 9, 14, 0.86);
+            color: var(--text-main);
+            padding: 16px;
+            font: inherit;
+            line-height: 1.6;
+        }
+
+        .ds-input:focus {
+            outline: 1px solid rgba(103, 232, 249, 0.5);
+        }
+
+        @media (max-width: 980px) {
+            #deepseek-control-root {
+                grid-template-columns: 1fr;
+                grid-template-rows: auto 1fr;
+                padding: 14px;
+            }
+        }
+    `;
+    document.head.appendChild(style);
+
+    const root = document.createElement("div");
+    root.id = "deepseek-control-root";
+    root.innerHTML = `
+        <aside class="ds-card ds-sidebar">
+            <div>
+                <div class="ds-badge" id="ds-status-chip">Connecting</div>
+            </div>
+            <div>
+                <div class="ds-title">AI Native Console</div>
+                <div class="ds-subtitle">Playwright 注入控制台。统一承接 runtime 状态、扩展层 API 和后续浏览器能力。</div>
+            </div>
+            <div class="ds-meta">
+                <div class="ds-meta-item">
+                    <div class="ds-meta-label">Runtime</div>
+                    <div class="ds-meta-value" id="ds-runtime">Loading...</div>
+                </div>
+                <div class="ds-meta-item">
+                    <div class="ds-meta-label">Workspace</div>
+                    <div class="ds-meta-value" id="ds-workspace">Loading...</div>
+                </div>
+                <div class="ds-meta-item">
+                    <div class="ds-meta-label">Git</div>
+                    <div class="ds-meta-value" id="ds-git">Loading...</div>
+                </div>
+                <div class="ds-meta-item">
+                    <div class="ds-meta-label">Managed Process</div>
+                    <div class="ds-meta-value" id="ds-app-server">Loading...</div>
+                </div>
+                <div class="ds-meta-item">
+                    <div class="ds-meta-label">Browser</div>
+                    <div class="ds-meta-value" id="ds-browser">Loading...</div>
+                </div>
+                <div class="ds-meta-item">
+                    <div class="ds-meta-label">Viewport / Zoom</div>
+                    <div class="ds-meta-value" id="ds-viewport">Loading...</div>
+                </div>
+            </div>
+            <div class="ds-section">
+                <div class="ds-section-title">Managed App-Server Process</div>
+                <div class="ds-subtitle">这组按钮控制的是 Python 扩展层托管的 DeepSeek-TUI app-server，地址是 8787；不是上面单独启动的 7878 runtime API。</div>
+                <div class="ds-actions">
+                    <button class="ds-button" id="ds-refresh">Refresh</button>
+                    <button class="ds-button" id="ds-start">Start</button>
+                    <button class="ds-button" id="ds-restart">Restart</button>
+                    <button class="ds-button danger" id="ds-stop">Stop</button>
+                </div>
+            </div>
+            <div class="ds-section">
+                <div class="ds-section-title">Browser Controls</div>
+                <div class="ds-inline-form">
+                    <input class="ds-inline-input" id="ds-url" placeholder="https://example.com 或 http://127.0.0.1:3000/ui/host" />
+                    <button class="ds-button" id="ds-go">Go</button>
+                </div>
+                <div class="ds-actions">
+                    <button class="ds-button" id="ds-console">Console</button>
+                    <button class="ds-button" id="ds-shot">Screenshot</button>
+                    <button class="ds-button" id="ds-zoom-in">Zoom +</button>
+                    <button class="ds-button" id="ds-zoom-out">Zoom -</button>
+                </div>
+                <div class="ds-tiny-grid">
+                    <input class="ds-inline-input" id="ds-width" placeholder="Width" value="1440" />
+                    <input class="ds-inline-input" id="ds-height" placeholder="Height" value="960" />
+                </div>
+                <div class="ds-actions">
+                    <button class="ds-button" id="ds-viewport-apply">Apply Viewport</button>
+                </div>
+            </div>
+            <div class="ds-section">
+                <div class="ds-section-title">Browser AI Native</div>
+                <div class="ds-actions">
+                    <button class="ds-button" id="ds-summary">Page Summary</button>
+                </div>
+                <pre class="ds-pre" id="ds-summary-output">Summary output will appear here.</pre>
+                <div class="ds-inline-form">
+                    <input class="ds-inline-input" id="ds-selector" placeholder="CSS selector，例如 button, input[name='q'], a[href]" />
+                    <button class="ds-button" id="ds-inspect">Inspect DOM</button>
+                </div>
+                <pre class="ds-pre" id="ds-dom-output">DOM inspection output will appear here.</pre>
+                <div class="ds-tiny-grid">
+                    <select class="ds-select" id="ds-element-action">
+                        <option value="highlight">highlight</option>
+                        <option value="click">click</option>
+                        <option value="focus">focus</option>
+                        <option value="fill">fill</option>
+                    </select>
+                    <input class="ds-inline-input" id="ds-element-value" placeholder="fill 时输入内容，其余可留空" />
+                </div>
+                <div class="ds-actions">
+                    <button class="ds-button" id="ds-element-run">Run Element Action</button>
+                </div>
+                <div class="ds-section-title">MCP Browser Task</div>
+                <textarea class="ds-input ds-mini-textarea" id="ds-mcp-task" placeholder="例如：检查当前页面的主要 CTA，并总结是否可点击"></textarea>
+                <div class="ds-actions">
+                    <button class="ds-button" id="ds-mcp-run">Run MCP Task</button>
+                </div>
+            </div>
+        </aside>
+        <section class="ds-card ds-chat">
+            <div class="ds-log" id="ds-log"></div>
+            <div class="ds-composer">
+                <textarea class="ds-input" id="ds-input" placeholder="输入消息，直接走 Python 扩展层转发到 DeepSeek runtime"></textarea>
+                <button class="ds-button" id="ds-send">Send</button>
+            </div>
+        </section>
+    `;
+    document.body.appendChild(root);
+
+    const statusChip = document.getElementById("ds-status-chip");
+    const runtimeNode = document.getElementById("ds-runtime");
+    const workspaceNode = document.getElementById("ds-workspace");
+    const gitNode = document.getElementById("ds-git");
+    const appServerNode = document.getElementById("ds-app-server");
+    const browserNode = document.getElementById("ds-browser");
+    const viewportNode = document.getElementById("ds-viewport");
+    const logNode = document.getElementById("ds-log");
+    const inputNode = document.getElementById("ds-input");
+    const sendNode = document.getElementById("ds-send");
+    const urlNode = document.getElementById("ds-url");
+    const widthNode = document.getElementById("ds-width");
+    const heightNode = document.getElementById("ds-height");
+    const selectorNode = document.getElementById("ds-selector");
+    const summaryOutputNode = document.getElementById("ds-summary-output");
+    const domOutputNode = document.getElementById("ds-dom-output");
+    const elementActionNode = document.getElementById("ds-element-action");
+    const elementValueNode = document.getElementById("ds-element-value");
+    const mcpTaskNode = document.getElementById("ds-mcp-task");
+    const refreshNode = document.getElementById("ds-refresh");
+    const startNode = document.getElementById("ds-start");
+    const restartNode = document.getElementById("ds-restart");
+    const stopNode = document.getElementById("ds-stop");
+
+    function renderJson(node, value) {
+        node.textContent = typeof value === "string" ? value : JSON.stringify(value, null, 2);
+    }
+
+    function addMessage(role, text) {
+        const node = document.createElement("div");
+        node.className = `ds-message ${role}`;
+        node.textContent = text;
+        logNode.appendChild(node);
+        logNode.scrollTop = logNode.scrollHeight;
+        return node;
+    }
+
+    function setProcessButtonsDisabled(disabled) {
+        refreshNode.disabled = disabled;
+        startNode.disabled = disabled;
+        restartNode.disabled = disabled;
+        stopNode.disabled = disabled;
+    }
+
+    async function loadStatus() {
+        const response = await fetch(`${extensionBase}/v1/status`);
+        if (!response.ok) {
+            throw new Error(`status ${response.status}`);
+        }
+        const status = await response.json();
+        const runtime = status.runtime || {};
+        const workspace = status.workspace || {};
+        const process = status.process || {};
+        const consoleState = status.console || {};
+
+        statusChip.textContent = runtime.auth_required ? "Runtime Ready / Auth" : "Runtime Ready";
+        statusChip.style.color = runtime.auth_required ? "#67e8f9" : "#22c55e";
+        runtimeNode.textContent = `${runtime.bind_host || "127.0.0.1"}:${runtime.port || "?"}\nversion ${runtime.version || "unknown"}`;
+        workspaceNode.textContent = workspace.workspace || "Unknown workspace";
+        gitNode.textContent = workspace.git_repo
+            ? `${workspace.branch || "detached"}\nstaged ${workspace.staged} / unstaged ${workspace.unstaged} / untracked ${workspace.untracked}`
+            : "No git repository";
+        appServerNode.textContent = process.app_server_running
+            ? `running\npid ${process.pid || "?"}\n${process.app_server_base_url || "http://localhost:8787"}`
+            : `stopped\ndesired ${String(process.desired_running)}\n${process.app_server_base_url || "http://localhost:8787"}`;
+        appServerNode.classList.add("code");
+        browserNode.textContent = `${consoleState.title || "Untitled"}\n${consoleState.url || "No page"}`;
+        viewportNode.textContent = `${(consoleState.viewport || {}).width || "?"} x ${(consoleState.viewport || {}).height || "?"}\nzoom ${consoleState.zoom || 1}`;
+        currentZoom = Number(consoleState.zoom || 1);
+        widthNode.value = String((consoleState.viewport || {}).width || 1440);
+        heightNode.value = String((consoleState.viewport || {}).height || 960);
+        urlNode.value = consoleState.url || urlNode.value;
+    }
+
+    async function sendMessage() {
+        const message = inputNode.value.trim();
+        if (!message) {
+            return;
+        }
+
+        inputNode.value = "";
+        sendNode.disabled = true;
+        addMessage("user", message);
+        const replyNode = addMessage("assistant", "Thinking...");
+
+        try {
+            const response = await fetch(`${extensionBase}/v1/chat`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ message })
+            });
+
+            if (!response.ok) {
+                throw new Error(`chat ${response.status}`);
+            }
+
+            const payload = await response.json();
+            replyNode.textContent = payload.content || "";
+        } catch (error) {
+            replyNode.textContent = `Error: ${error}`;
+        } finally {
+            sendNode.disabled = false;
+            inputNode.focus();
+        }
+    }
+
+    async function postAction(path) {
+        setProcessButtonsDisabled(true);
+        const response = await fetch(`${extensionBase}${path}`, { method: "POST" });
+        try {
+            if (!response.ok) {
+                throw new Error(`${path} ${response.status}`);
+            }
+            await loadStatus();
+        } finally {
+            setProcessButtonsDisabled(false);
+        }
+    }
+
+    async function postJson(path, payload) {
+        const response = await fetch(`${extensionBase}${path}`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(payload || {})
+        });
+        if (!response.ok) {
+            throw new Error(`${path} ${response.status}`);
+        }
+        return await response.json();
+    }
+
+    document.getElementById("ds-refresh").addEventListener("click", () => {
+        setProcessButtonsDisabled(true);
+        loadStatus()
+            .then(() => addMessage("assistant", "Managed app-server status refreshed."))
+            .catch((error) => addMessage("assistant", `Status error: ${error}`))
+            .finally(() => setProcessButtonsDisabled(false));
+    });
+    document.getElementById("ds-start").addEventListener("click", () => {
+        postAction("/control/start")
+            .then(() => addMessage("assistant", "Managed app-server start requested."))
+            .catch((error) => addMessage("assistant", `Start error: ${error}`));
+    });
+    document.getElementById("ds-restart").addEventListener("click", () => {
+        postAction("/control/restart")
+            .then(() => addMessage("assistant", "Managed app-server restart requested."))
+            .catch((error) => addMessage("assistant", `Restart error: ${error}`));
+    });
+    document.getElementById("ds-stop").addEventListener("click", () => {
+        postAction("/control/stop")
+            .then(() => addMessage("assistant", "Managed app-server stop requested."))
+            .catch((error) => addMessage("assistant", `Stop error: ${error}`));
+    });
+    document.getElementById("ds-go").addEventListener("click", async () => {
+        try {
+            const state = await postJson("/v1/browser/navigate", { url: urlNode.value.trim() });
+            addMessage("assistant", `Navigated to ${state.url}`);
+            await loadStatus();
+        } catch (error) {
+            addMessage("assistant", `Navigate error: ${error}`);
+        }
+    });
+    document.getElementById("ds-console").addEventListener("click", async () => {
+        try {
+            await postJson("/v1/browser/reload-console", {});
+            addMessage("assistant", "Control console reloaded.");
+            await loadStatus();
+        } catch (error) {
+            addMessage("assistant", `Reload error: ${error}`);
+        }
+    });
+    document.getElementById("ds-shot").addEventListener("click", async () => {
+        try {
+            const shot = await postJson("/v1/browser/screenshot", {});
+            addMessage("assistant", `Screenshot saved to ${shot.path}`);
+        } catch (error) {
+            addMessage("assistant", `Screenshot error: ${error}`);
+        }
+    });
+    document.getElementById("ds-zoom-in").addEventListener("click", async () => {
+        try {
+            currentZoom = Number((currentZoom + 0.1).toFixed(2));
+            await postJson("/v1/browser/ui", { zoom: currentZoom });
+            await loadStatus();
+        } catch (error) {
+            addMessage("assistant", `Zoom error: ${error}`);
+        }
+    });
+    document.getElementById("ds-zoom-out").addEventListener("click", async () => {
+        try {
+            currentZoom = Number(Math.max(0.25, currentZoom - 0.1).toFixed(2));
+            await postJson("/v1/browser/ui", { zoom: currentZoom });
+            await loadStatus();
+        } catch (error) {
+            addMessage("assistant", `Zoom error: ${error}`);
+        }
+    });
+    document.getElementById("ds-viewport-apply").addEventListener("click", async () => {
+        try {
+            await postJson("/v1/browser/ui", {
+                viewport_width: Number(widthNode.value || 1440),
+                viewport_height: Number(heightNode.value || 960)
+            });
+            addMessage("assistant", "Viewport updated.");
+            await loadStatus();
+        } catch (error) {
+            addMessage("assistant", `Viewport error: ${error}`);
+        }
+    });
+    document.getElementById("ds-summary").addEventListener("click", async () => {
+        try {
+            const summary = await fetch(`${extensionBase}/v1/browser/summary`).then((response) => {
+                if (!response.ok) {
+                    throw new Error(`/v1/browser/summary ${response.status}`);
+                }
+                return response.json();
+            });
+            renderJson(summaryOutputNode, summary);
+            addMessage("assistant", "Page summary captured.");
+        } catch (error) {
+            addMessage("assistant", `Summary error: ${error}`);
+        }
+    });
+    document.getElementById("ds-inspect").addEventListener("click", async () => {
+        try {
+            const result = await postJson("/v1/browser/dom", { selector: selectorNode.value.trim() });
+            renderJson(domOutputNode, result);
+            addMessage("assistant", `DOM inspected for selector: ${result.selector}`);
+        } catch (error) {
+            addMessage("assistant", `DOM inspect error: ${error}`);
+        }
+    });
+    document.getElementById("ds-element-run").addEventListener("click", async () => {
+        try {
+            const result = await postJson("/v1/browser/element", {
+                selector: selectorNode.value.trim(),
+                action: elementActionNode.value,
+                value: elementValueNode.value,
+            });
+            renderJson(domOutputNode, result);
+            addMessage("assistant", `Element action executed: ${result.action}`);
+            await loadStatus();
+        } catch (error) {
+            addMessage("assistant", `Element action error: ${error}`);
+        }
+    });
+    document.getElementById("ds-mcp-run").addEventListener("click", async () => {
+        try {
+            const result = await postJson("/v1/browser/mcp-task", { prompt: mcpTaskNode.value.trim() });
+            addMessage("assistant", result.content || "MCP browser task completed.");
+        } catch (error) {
+            addMessage("assistant", `MCP task error: ${error}`);
+        }
+    });
+    sendNode.addEventListener("click", sendMessage);
+    inputNode.addEventListener("keydown", (event) => {
+        if (event.key === "Enter" && !event.shiftKey) {
+            event.preventDefault();
+            sendMessage();
+        }
+    });
+
+    addMessage("assistant", "Control console attached through Playwright injection.");
+    loadStatus().catch((error) => {
+        statusChip.textContent = "Runtime Unavailable";
+        statusChip.style.color = "#fb7185";
+        addMessage("assistant", `Status error: ${error}`);
+    });
+})();

--- a/tauri-shell/src-tauri/src/ipc.rs
+++ b/tauri-shell/src-tauri/src/ipc.rs
@@ -1,0 +1,159 @@
+﻿// IPC commands exposed to the frontend (JS/HTML side)
+// All calls proxy through to the Python extension layer HTTP API
+
+use reqwest::Method;
+use serde_json::{json, Value};
+use tauri::command;
+
+const CORE_URL: &str = "http://localhost:3000";
+
+async fn send_json(method: Method, path: &str, body: Option<Value>) -> Result<Value, String> {
+    let client = reqwest::Client::new();
+    let mut request = client.request(method, format!("{}{}", CORE_URL, path));
+    if let Some(payload) = body {
+        request = request.json(&payload);
+    }
+    let resp = request.send().await.map_err(|e| e.to_string())?;
+    let resp = resp.error_for_status().map_err(|e| e.to_string())?;
+    resp.json::<Value>().await.map_err(|e| e.to_string())
+}
+
+#[command]
+pub async fn send_message(message: String) -> Result<String, String> {
+    let body = send_json(Method::POST, "/v1/chat", Some(json!({ "message": message }))).await?;
+    Ok(body["content"].as_str().unwrap_or("").to_string())
+}
+
+#[command]
+pub async fn get_status() -> Result<Value, String> {
+    send_json(Method::GET, "/v1/status", None).await
+}
+
+#[command]
+pub async fn stream_message(message: String) -> Result<String, String> {
+    // Simplified: returns full streamed content at once
+    // TODO: replace with SSE streaming via Tauri events
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{}/v1/chat/stream", CORE_URL))
+        .json(&serde_json::json!({ "message": message }))
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let text = resp.text().await.map_err(|e| e.to_string())?;
+    Ok(text)
+}
+
+#[command]
+pub async fn get_capabilities() -> Result<Value, String> {
+    send_json(Method::GET, "/v1/capabilities", None).await
+}
+
+#[command]
+pub async fn get_browser_state() -> Result<Value, String> {
+    send_json(Method::GET, "/v1/browser/state", None).await
+}
+
+#[command]
+pub async fn get_browser_summary() -> Result<Value, String> {
+    send_json(Method::GET, "/v1/browser/summary", None).await
+}
+
+#[command]
+pub async fn start_managed_process() -> Result<Value, String> {
+    send_json(Method::POST, "/control/start", None).await
+}
+
+#[command]
+pub async fn restart_managed_process() -> Result<Value, String> {
+    send_json(Method::POST, "/control/restart", None).await
+}
+
+#[command]
+pub async fn stop_managed_process() -> Result<Value, String> {
+    send_json(Method::POST, "/control/stop", None).await
+}
+
+#[command]
+pub async fn navigate_browser(url: String) -> Result<Value, String> {
+    send_json(Method::POST, "/v1/browser/navigate", Some(json!({ "url": url }))).await
+}
+
+#[command]
+pub async fn reload_browser_console() -> Result<Value, String> {
+    send_json(Method::POST, "/v1/browser/reload-console", Some(json!({}))).await
+}
+
+#[command]
+pub async fn update_browser_ui(
+    viewport_width: Option<u32>,
+    viewport_height: Option<u32>,
+    zoom: Option<f64>,
+    css: Option<String>,
+    js: Option<String>,
+    reset_injections: Option<bool>,
+) -> Result<Value, String> {
+    send_json(
+        Method::POST,
+        "/v1/browser/ui",
+        Some(json!({
+            "viewport_width": viewport_width,
+            "viewport_height": viewport_height,
+            "zoom": zoom,
+            "css": css,
+            "js": js,
+            "reset_injections": reset_injections.unwrap_or(false),
+        })),
+    )
+    .await
+}
+
+#[command]
+pub async fn evaluate_browser(expression: String) -> Result<Value, String> {
+    send_json(
+        Method::POST,
+        "/v1/browser/evaluate",
+        Some(json!({ "expression": expression })),
+    )
+    .await
+}
+
+#[command]
+pub async fn screenshot_browser(path: Option<String>) -> Result<Value, String> {
+    send_json(Method::POST, "/v1/browser/screenshot", Some(json!({ "path": path }))).await
+}
+
+#[command]
+pub async fn inspect_browser_dom(selector: String) -> Result<Value, String> {
+    send_json(Method::POST, "/v1/browser/dom", Some(json!({ "selector": selector }))).await
+}
+
+#[command]
+pub async fn operate_browser_element(
+    selector: String,
+    action: String,
+    value: Option<String>,
+) -> Result<Value, String> {
+    send_json(
+        Method::POST,
+        "/v1/browser/element",
+        Some(json!({
+            "selector": selector,
+            "action": action,
+            "value": value,
+        })),
+    )
+    .await
+}
+
+#[command]
+pub async fn run_mcp_browser_task(prompt: String) -> Result<Value, String> {
+    send_json(
+        Method::POST,
+        "/v1/browser/mcp-task",
+        Some(json!({ "prompt": prompt })),
+    )
+    .await
+}
+

--- a/tauri-shell/src-tauri/src/lib.rs
+++ b/tauri-shell/src-tauri/src/lib.rs
@@ -1,0 +1,27 @@
+﻿pub fn run() {
+    tauri::Builder::default()
+        .plugin(tauri_plugin_shell::init())
+        .plugin(tauri_plugin_process::init())
+        .invoke_handler(tauri::generate_handler![
+            crate::ipc::send_message,
+            crate::ipc::stream_message,
+            crate::ipc::get_status,
+            crate::ipc::get_capabilities,
+            crate::ipc::get_browser_state,
+            crate::ipc::get_browser_summary,
+            crate::ipc::start_managed_process,
+            crate::ipc::restart_managed_process,
+            crate::ipc::stop_managed_process,
+            crate::ipc::navigate_browser,
+            crate::ipc::reload_browser_console,
+            crate::ipc::update_browser_ui,
+            crate::ipc::evaluate_browser,
+            crate::ipc::screenshot_browser,
+            crate::ipc::inspect_browser_dom,
+            crate::ipc::operate_browser_element,
+            crate::ipc::run_mcp_browser_task,
+        ])
+        .run(tauri::generate_context!())
+        .expect("Tauri runtime error");
+}
+

--- a/tauri-shell/src-tauri/src/main.rs
+++ b/tauri-shell/src-tauri/src/main.rs
@@ -1,0 +1,59 @@
+﻿// DeepSeek IDE - Tauri Shell
+// Responsibilities:
+//   - Native window management
+//   - Launch Python extension layer as sidecar
+//   - IPC bridge between frontend and extension layer
+
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
+mod ipc;
+
+use tauri::Manager;
+use tauri_plugin_shell::ShellExt;
+
+fn main() {
+    tauri::Builder::default()
+        .plugin(tauri_plugin_shell::init())
+        .plugin(tauri_plugin_process::init())
+        .setup(|app| {
+            // Launch Python extension layer sidecar
+            let shell = app.shell();
+            let sidecar = shell
+                .sidecar("core")
+                .expect("core sidecar not found in tauri.conf.json");
+            let (_rx, _child) = sidecar
+                .spawn()
+                .expect("Failed to launch Python extension layer");
+
+            // Open devtools in debug builds
+            #[cfg(debug_assertions)]
+            {
+                let window = app.get_webview_window("main").unwrap();
+                window.open_devtools();
+            }
+
+            Ok(())
+        })
+        .invoke_handler(tauri::generate_handler![
+            ipc::send_message,
+            ipc::stream_message,
+            ipc::get_status,
+            ipc::get_capabilities,
+            ipc::get_browser_state,
+            ipc::get_browser_summary,
+            ipc::start_managed_process,
+            ipc::restart_managed_process,
+            ipc::stop_managed_process,
+            ipc::navigate_browser,
+            ipc::reload_browser_console,
+            ipc::update_browser_ui,
+            ipc::evaluate_browser,
+            ipc::screenshot_browser,
+            ipc::inspect_browser_dom,
+            ipc::operate_browser_element,
+            ipc::run_mcp_browser_task,
+        ])
+        .run(tauri::generate_context!())
+        .expect("Tauri runtime error");
+}
+


### PR DESCRIPTION
Summary | 概述
This PR introduces a minimal, serve-centered integration loop that unifies:

DeepSeek runtime API ([deepseek serve --http], port 7878)
Python extension API (port 3000)
Playwright-injected control console
Tauri IPC bridge
本 PR 实现了一个以 [serve]为中心的最小闭环，统一了：

DeepSeek runtime API（[deepseek serve --http]，7878）
Python 扩展层 API（3000）
Playwright 注入控制台
Tauri IPC 桥接层
What’s Included | 变更内容
1) Serve-centered extension layer | 以 serve 为中心的扩展层
Added local extension API endpoints for status/chat/process/browser operations.
新增本地扩展 API，覆盖状态、聊天、进程控制、浏览器操作。
2) Playwright control console | Playwright 控制台
Added injected UI for:
runtime/process status
page summary
DOM inspection
element actions ([highlight/click/fill/focus]
MCP browser task entry
新增注入式控制台，支持：
runtime/进程状态
页面摘要
DOM 检视
元素动作（[highlight/click/fill/focus]
MCP 浏览器任务入口
3) Tauri IPC expansion | Tauri IPC 扩展
Extended IPC commands to proxy the same extension API surface:
capabilities, browser state/summary
process start/stop/restart
navigate/reload UI/evaluate/screenshot
DOM inspect/element action/MCP task
扩展 Tauri IPC，统一代理上述扩展 API 能力面。
4) Process manager hardening | 进程管理增强
Added duplicate-launch guard for app-server port conflicts.
Detects existing listener and avoids blind relaunch loops ([os error 10048]).
Improved attached-process lifecycle behavior for stop/restart/shutdown paths.
增加端口冲突保护，检测已占用实例并跳过重复拉起，避免 10048 重试风暴；并修复附着进程下的 stop/restart/shutdown 边界行为。
Why | 背景与动机
Current integration requires a stable local API contract for UI, IPC, and browser automation features.
This PR aligns all upper layers to one local API surface instead of scattered direct calls.

当前架构需要一个稳定的本地 API 契约来承接 UI、IPC 与浏览器自动化能力。
本 PR 将上层调用统一到本地 API，避免多入口直连导致的语义分裂。

Validation | 验证
Static checks passed for modified Python/Rust/JS files.

Local health/status endpoints returned expected responses.

Capability endpoints exposed new browser-native fields.

Process control ([start/stop/restart])verified through extension API.

Port-occupied scenario observed and handled via duplicate-launch guard.

修改文件静态检查通过（Python/Rust/JS）。

本地 health/status 接口返回正常。

capabilities 接口已返回新增浏览器能力字段。

进程控制接口（start/stop/restart）行为已验证。

8787 端口占用场景已通过防重复拉起逻辑处理。

Notes | 备注
This is a minimal closed-loop implementation focused on architecture convergence.

Future improvements can include:

clearer 7878 vs 8787 control semantics in UI
contract tests for extension API
richer Tauri-native workbench UX
这是面向架构收敛的最小闭环实现。

后续可继续增强：
UI 中更明确区分 7878 与 8787 控制语义
扩展 API 契约测试
更完整的 Tauri 原生工作台体验