### PR TITLE
fix(docker): pre-create /home/deepseek/.deepseek to avoid permission denied on first run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,8 +75,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Non-root user with explicit UID/GID for filesystem ownership clarity.
 RUN groupadd --gid 1000 deepseek \
     && useradd --create-home --shell /bin/bash --uid 1000 --gid 1000 deepseek \
-    && mkdir -p /home/deepseek/.deepseek \
-    && chown -R deepseek:deepseek /home/deepseek/.deepseek
+    && install -d -m 0700 -o deepseek -g deepseek /home/deepseek/.deepseek
 USER deepseek
 WORKDIR /home/deepseek
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Non-root user with explicit UID/GID for filesystem ownership clarity.
 RUN groupadd --gid 1000 deepseek \
-    && useradd --create-home --shell /bin/bash --uid 1000 --gid 1000 deepseek
+    && useradd --create-home --shell /bin/bash --uid 1000 --gid 1000 deepseek \
+    && mkdir -p /home/deepseek/.deepseek \
+    && chown -R deepseek:deepseek /home/deepseek/.deepseek
 USER deepseek
 WORKDIR /home/deepseek
 


### PR DESCRIPTION
## Summary

The non-root `deepseek` user couldn't write `/home/deepseek/.deepseek/tasks/runtime/threads` on first run inside Docker, failing with `Permission denied (os error 13)`. The Dockerfile created the user and switched to it before any process ever touched the home subdirectory; the runtime then hit a fresh `/home/deepseek` owned by root (because the user's HOME was newly created with default perms but bind-mounted volumes adopted root ownership).

Pre-create `/home/deepseek/.deepseek` with `deepseek:deepseek` ownership in the same `RUN` that adds the user, so any subsequent volume mount or process write lands on a directory the runtime user can write to.

## Why this matters

Reporter @[issue1684_user] in #1684 reported the bridge crashing on first launch in Docker before any thread could be created. The fix is contained to the user-setup section of the Dockerfile (same `RUN` that calls `useradd`), keeps the image layer count unchanged, and doesn't touch the runtime.

Fixes #1684
