### PR TITLE
fix(core): sync system prompt hash when overriding via runtime API

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -756,6 +756,7 @@ impl Engine {
                     } else {
                         None
                     };
+                    self.sync_session_system_prompt_hash();
                     self.session.rebuild_working_set();
                     self.rehydrate_latest_canonical_state();
                     self.emit_session_updated().await;
@@ -1773,8 +1774,8 @@ impl Engine {
             .await;
     }
 
-    /// Refresh the system prompt based on current mode and context.
-    fn refresh_system_prompt(&mut self, mode: AppMode) {
+    /// Build the stable system prompt baseline for the current mode and context.
+    fn stable_system_prompt_for_mode(&self, mode: AppMode) -> Option<SystemPrompt> {
         let user_memory_block =
             crate::memory::compose_block(self.config.memory_enabled, &self.config.memory_path);
         let base = prompts::system_prompt_for_mode_with_context_skills_session_and_approval(
@@ -1792,8 +1793,21 @@ impl Engine {
             },
             self.session.approval_mode,
         );
-        let stable_prompt =
-            merge_system_prompts(Some(&base), self.session.compaction_summary_prompt.clone());
+        merge_system_prompts(Some(&base), self.session.compaction_summary_prompt.clone())
+    }
+
+    fn sync_session_system_prompt_hash(&mut self) {
+        self.session.last_system_prompt_hash = if self.session.system_prompt.is_some() {
+            let stable_prompt = self.stable_system_prompt_for_mode(AppMode::Agent);
+            Some(system_prompt_hash(stable_prompt.as_ref()))
+        } else {
+            Some(system_prompt_hash(None))
+        };
+    }
+
+    /// Refresh the system prompt based on current mode and context.
+    fn refresh_system_prompt(&mut self, mode: AppMode) {
+        let stable_prompt = self.stable_system_prompt_for_mode(mode);
         let stable_hash = system_prompt_hash(stable_prompt.as_ref());
         if self.session.last_system_prompt_hash != Some(stable_hash) {
             self.session.system_prompt = stable_prompt;

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -1797,12 +1797,10 @@ impl Engine {
     }
 
     fn sync_session_system_prompt_hash(&mut self) {
-        self.session.last_system_prompt_hash = if self.session.system_prompt.is_some() {
+        self.session.last_system_prompt_hash = self.session.system_prompt.as_ref().map(|_| {
             let stable_prompt = self.stable_system_prompt_for_mode(AppMode::Agent);
-            Some(system_prompt_hash(stable_prompt.as_ref()))
-        } else {
-            Some(system_prompt_hash(None))
-        };
+            system_prompt_hash(stable_prompt.as_ref())
+        });
     }
 
     /// Refresh the system prompt based on current mode and context.

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -1297,6 +1297,55 @@ fn refresh_system_prompt_is_noop_when_unchanged() {
     assert_eq!(engine.session.system_prompt, first_prompt);
 }
 
+fn sync_system_prompt_override(engine: &mut Engine, system_prompt: SystemPrompt) {
+    engine.session.compaction_summary_prompt =
+        extract_compaction_summary_prompt(Some(system_prompt.clone()));
+    engine.session.system_prompt = Some(system_prompt);
+    engine.sync_session_system_prompt_hash();
+}
+
+#[test]
+fn text_system_prompt_override_via_sync_session_survives_refresh() {
+    let tmp = tempdir().expect("tempdir");
+    let config = EngineConfig {
+        workspace: tmp.path().to_path_buf(),
+        ..Default::default()
+    };
+    let (mut engine, _handle) = Engine::new(config, &Config::default());
+    let prompt = SystemPrompt::Text("TANGERINE-7".to_string());
+    let expected = Some(prompt.clone());
+
+    sync_system_prompt_override(&mut engine, prompt);
+    let first_hash = engine.session.last_system_prompt_hash;
+    engine.refresh_system_prompt(AppMode::Agent);
+
+    assert_eq!(engine.session.last_system_prompt_hash, first_hash);
+    assert_eq!(engine.session.system_prompt, expected);
+}
+
+#[test]
+fn blocks_system_prompt_override_via_sync_session_survives_refresh() {
+    let tmp = tempdir().expect("tempdir");
+    let config = EngineConfig {
+        workspace: tmp.path().to_path_buf(),
+        ..Default::default()
+    };
+    let (mut engine, _handle) = Engine::new(config, &Config::default());
+    let prompt = SystemPrompt::Blocks(vec![SystemBlock {
+        block_type: "text".to_string(),
+        text: "TANGERINE-7".to_string(),
+        cache_control: None,
+    }]);
+    let expected = Some(prompt.clone());
+
+    sync_system_prompt_override(&mut engine, prompt);
+    let first_hash = engine.session.last_system_prompt_hash;
+    engine.refresh_system_prompt(AppMode::Agent);
+
+    assert_eq!(engine.session.last_system_prompt_hash, first_hash);
+    assert_eq!(engine.session.system_prompt, expected);
+}
+
 #[test]
 fn compaction_summary_stays_in_stable_system_prompt() {
     let tmp = tempdir().expect("tempdir");


### PR DESCRIPTION
## Summary

`POST /v1/threads` accepts a `system_prompt` field and stores it on the session, but the next `refresh_system_prompt` call rebuilt the stable baseline and overwrote it because `session.last_system_prompt_hash` was still the pre-override value. The model request fired with the rebuilt baseline, not the override.

Add `sync_session_system_prompt_hash` that recomputes `last_system_prompt_hash` after a thread API override, and call it where the override is installed. Now `refresh_system_prompt`'s hash-equality short-circuit fires and the override survives.

Factor the stable-prompt construction into `stable_system_prompt_for_mode` so the sync and the refresh paths share it.

## Why this matters

Reporter quote from #1688: "system_prompt on POST /v1/threads is accepted and stored but discarded before the model request." Root cause: hash drift between session.last_system_prompt_hash (pre-override baseline) and the new override. The new tests (`text_system_prompt_override_via_sync_session_survives_refresh` and the Blocks variant) lock the regression in.

Closes #1688
