### PR TITLE
fix(pager): G/End overshoot makes k/Up unresponsive after jump to bottom

### DIFF
--- a/crates/tui/src/tui/pager.rs
+++ b/crates/tui/src/tui/pager.rs
@@ -128,7 +128,7 @@ impl PagerView {
         // that G / End land at the actual bottom and k / Up immediately scroll
         // back up by one visible line — over-scrolling would make N consecutive
         // scroll-up presses invisible to the user.
-        self.lines.len().saturating_sub(self.page_height().max(1))
+        self.lines.len().saturating_sub(self.page_height())
     }
 
     fn start_search(&mut self) {

--- a/crates/tui/src/tui/pager.rs
+++ b/crates/tui/src/tui/pager.rs
@@ -124,10 +124,11 @@ impl PagerView {
     }
 
     fn max_scroll(&self) -> usize {
-        // Match the existing 1-line scroll convention used by `j`/`k`. Render
-        // clamps `self.scroll` to `lines.len() - visible_height` for display
-        // purposes, so over-scrolling here is harmless.
-        self.lines.len().saturating_sub(1)
+        // Must match the render-side clamp (lines.len() - visible_height) so
+        // that G / End land at the actual bottom and k / Up immediately scroll
+        // back up by one visible line — over-scrolling would make N consecutive
+        // scroll-up presses invisible to the user.
+        self.lines.len().saturating_sub(self.page_height().max(1))
     }
 
     fn start_search(&mut self) {
@@ -615,6 +616,33 @@ mod tests {
         let mut p = make_pager(50);
         let _ = p.handle_key(key(KeyCode::End));
         assert_eq!(p.scroll, p.max_scroll());
+    }
+
+    /// After G / End jumps to the bottom, pressing k / Up must immediately
+    /// decrease scroll by one line — the scroll value must not overshoot the
+    /// render clamp so far that the first N scroll-up presses are invisible.
+    #[test]
+    fn up_immediately_scrolls_after_shift_g_to_bottom() {
+        let mut p = make_pager(50);
+        prime_layout(&mut p, 22);
+        let bottom = p.max_scroll();
+        let _ = p.handle_key(key(KeyCode::Char('G')));
+        assert_eq!(p.scroll, bottom);
+        let _ = p.handle_key(key(KeyCode::Up));
+        assert_eq!(p.scroll, bottom - 1, "Up should scroll up by 1 after G");
+        let _ = p.handle_key(key(KeyCode::Char('k')));
+        assert_eq!(p.scroll, bottom - 2, "k should scroll up by 1 more");
+    }
+
+    #[test]
+    fn k_immediately_scrolls_after_end_to_bottom() {
+        let mut p = make_pager(50);
+        prime_layout(&mut p, 22);
+        let bottom = p.max_scroll();
+        let _ = p.handle_key(key(KeyCode::End));
+        assert_eq!(p.scroll, bottom);
+        let _ = p.handle_key(key(KeyCode::Char('k')));
+        assert_eq!(p.scroll, bottom - 1, "k should scroll up by 1 after End");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

After pressing `G` or `End` to jump to the bottom of the pager (Ctrl+O reasoning list, tool detail, etc.), pressing `k` / `Up` to scroll back up had no visible effect for many consecutive presses.

## Root cause

`max_scroll()` returned `lines.len() - 1` while `render()` clamped to `lines.len() - visible_height`. The gap meant `G` set `scroll` far above the render clamp. Each `k`/`Up` press decremented `scroll` inside that overshoot gap, producing zero visible movement until the value finally fell below the clamp.

For a 50-line pager with ~18 visible lines, this required **17 consecutive `k` presses** before any content scrolled up.

## Fix

Changed `max_scroll()` to use `page_height()` (the cached `visible_height` from the last render), matching the render-side clamp:

```rust
// Before
self.lines.len().saturating_sub(1)
// After
self.lines.len().saturating_sub(self.page_height().max(1))
```

## Tests

Two regression tests added. All 33 pager tests pass.