### PR TITLE
fix(tui): scroll transcript when composer has text (#1677)

### DIFF
--- a/crates/tui/src/tui/composer_ui.rs
+++ b/crates/tui/src/tui/composer_ui.rs
@@ -56,15 +56,17 @@ pub(crate) fn handle_composer_history_arrow(
         return false;
     }
 
-    // When `composer_arrows_scroll` is enabled and the composer is empty,
-    // plain Up/Down scroll the transcript.  This helps terminals that map
-    // trackpad gestures to arrow keys.  Otherwise arrows always navigate
-    // input history regardless of composer state (#1117).
-    let scroll_on_empty = app.composer_arrows_scroll && app.input.trim().is_empty();
+    // When `composer_arrows_scroll` is enabled, plain Up/Down always
+    // scroll the transcript regardless of whether the composer has text.
+    // Terminals without mouse capture (e.g. legacy conhost, warp on
+    // Windows) convert mouse-wheel events to arrow keys; without this
+    // guard the wheel would navigate input history instead of scrolling
+    // the transcript when the composer is non-empty (#1677).
+    let scroll_transcript = app.composer_arrows_scroll;
 
     match key.code {
         KeyCode::Up => {
-            if scroll_on_empty {
+            if scroll_transcript {
                 app.scroll_up(COMPOSER_ARROW_SCROLL_LINES);
             } else {
                 app.history_up();
@@ -72,7 +74,7 @@ pub(crate) fn handle_composer_history_arrow(
             true
         }
         KeyCode::Down => {
-            if scroll_on_empty {
+            if scroll_transcript {
                 app.scroll_down(COMPOSER_ARROW_SCROLL_LINES);
             } else {
                 app.history_down();

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -5330,6 +5330,9 @@ fn history_arrow_handles_whitespace_input() {
 #[test]
 fn history_arrow_handles_nonempty_input() {
     let mut app = create_test_app();
+    // Explicitly disable arrows-scroll so this test covers the
+    // history-navigation path regardless of the mouse-capture default.
+    app.composer_arrows_scroll = false;
     app.input = "hello".to_string();
     app.cursor_position = app.input.chars().count();
     app.input_history.push("previous prompt".to_string());
@@ -5375,21 +5378,25 @@ fn composer_arrows_scroll_empty_down() {
 }
 
 #[test]
-fn composer_arrows_scroll_nonempty_still_navigates_history() {
+fn composer_arrows_scroll_nonempty_also_scrolls() {
     let mut app = create_test_app();
     app.composer_arrows_scroll = true;
     app.input = "hello".to_string();
     app.cursor_position = app.input.chars().count();
     app.input_history.push("previous prompt".to_string());
 
-    // Even with the option on, non-empty composer still navigates history.
+    // #1677: with arrows-scroll on, non-empty composer also scrolls the
+    // transcript instead of navigating input history.  This ensures
+    // terminals that convert mouse-wheel to arrow keys scroll the
+    // transcript even when the user is mid-typing.
     assert!(handle_composer_history_arrow(
         &mut app,
         KeyEvent::new(KeyCode::Up, KeyModifiers::NONE),
         false,
         false,
     ));
-    assert_eq!(app.input, "previous prompt");
+    assert_eq!(app.viewport.pending_scroll_delta, -3);
+    assert_eq!(app.input, "hello");
 }
 
 // #1443: when mouse capture is off (e.g. Windows CMD), arrow-scroll


### PR DESCRIPTION
## Summary

- When `composer_arrows_scroll` is enabled, Up/Down keys now always scroll the transcript, regardless of whether the composer has text.
- Previously, arrows only scrolled when the composer was empty. With text in the composer, mouse wheel events (sent as arrow keys by terminals without mouse capture) navigated input history instead of scrolling the transcript, making it impossible to review earlier conversation while mid-typing.

## Problem

On terminals without mouse capture (e.g. Warp on Windows, legacy conhost), mouse wheel events are converted to Up/Down arrow keys by the terminal. When `composer_arrows_scroll = true`, these arrow keys only triggered transcript scrolling when the composer was empty. If the user had text in the input field, the arrow keys navigated input history instead, preventing scrolling while typing.

Users had to manually add `mouse_capture = true` to their config to work around this, which isn't obvious.

## Fix

Removed the `app.input.trim().is_empty()` guard in `handle_composer_history_arrow`. When `composer_arrows_scroll` is enabled, arrows always scroll the transcript. When disabled (the default on non-Windows with mouse capture), behavior is unchanged.

## Test plan

- [x] Updated `history_arrow_handles_nonempty_input` to explicitly set `composer_arrows_scroll = false`
- [x] Updated `composer_arrows_scroll_nonempty_still_navigates_history` → `composer_arrows_scroll_nonempty_also_scrolls` to verify new behavior
- [x] All 3119 existing tests pass