### PR TITLE
fix: accept SSE data without trailing space, and relax model validation

### DIFF
--- a/crates/tui/src/client/chat.rs
+++ b/crates/tui/src/client/chat.rs
@@ -134,6 +134,17 @@ impl DeepSeekClient {
         }
 
         let response_text = response.text().await.unwrap_or_default();
+        // Some OpenAI-compatible APIs return HTTP 200 with a JSON error body
+        // (e.g. {"success": false, "message": "service busy"}).
+        if let Ok(json) = serde_json::from_str::<Value>(&response_text)
+            && json.get("success").and_then(Value::as_bool) == Some(false)
+        {
+            let msg = json
+                .get("message")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown error");
+            anyhow::bail!("API error: {msg}");
+        }
         let value: Value =
             serde_json::from_str(&response_text).context("Failed to parse Chat API JSON")?;
         parse_chat_message(&value)
@@ -203,6 +214,7 @@ impl DeepSeekClient {
             .await?;
 
         let status = response.status();
+        let response_headers = format_stream_headers(response.headers());
         if !status.is_success() {
             let error_text = bounded_error_text(response, ERROR_BODY_MAX_BYTES).await;
             // If DeepSeek rejected for missing reasoning_content despite the
@@ -214,14 +226,33 @@ impl DeepSeekClient {
             anyhow::bail!("SSE stream request failed: HTTP {status}: {error_text}");
         }
 
+        // Some OpenAI-compatible APIs return HTTP 200 with a JSON error body
+        // (e.g. {"success": false, "message": "service busy"}) using
+        // Content-Type: text/event-stream. Inspect the first byte: '{' means
+        // JSON error, 'd' (for "data:") means valid SSE.
         let model = request.model.clone();
+        let full_body = response.bytes().await.unwrap_or_default();
+        if full_body
+            .iter()
+            .find(|b| !b.is_ascii_whitespace())
+            .copied()
+            == Some(b'{')
+        {
+            let text = String::from_utf8_lossy(&full_body);
+            if let Ok(json) = serde_json::from_str::<Value>(&text)
+                && json.get("success").and_then(Value::as_bool) == Some(false)
+            {
+                let msg = json
+                    .get("message")
+                    .and_then(Value::as_str)
+                    .unwrap_or("unknown error");
+                anyhow::bail!("API error: {msg}");
+            }
+        }
 
-        // Capture transport-shape headers before we consume `response` into
-        // `bytes_stream()`. They are surfaced in the decode-error log path so
-        // we can tell HTTP/2 RST_STREAM from chunked-encoding corruption from
-        // gzip-compressor failure when investigating #103.
-        let response_headers = format_stream_headers(response.headers());
-        let byte_stream = response.bytes_stream();
+        let byte_stream = futures_util::stream::once(async move {
+            Ok::<_, reqwest::Error>(full_body)
+        });
 
         let stream = async_stream::stream! {
             use futures_util::StreamExt;
@@ -366,6 +397,9 @@ impl DeepSeekClient {
                     }
 
                     if let Some(data) = line.strip_prefix("data: ") {
+                        line_buf.push_str(data);
+                    } else if let Some(data) = line.strip_prefix("data:") {
+                        // Some OpenAI-compatible APIs omit the space after the colon
                         line_buf.push_str(data);
                     }
                     // Ignore other SSE fields (event:, id:, retry:)

--- a/crates/tui/src/commands/config.rs
+++ b/crates/tui/src/commands/config.rs
@@ -5,7 +5,9 @@ use std::time::Duration;
 
 use super::CommandResult;
 use crate::client::DeepSeekClient;
-use crate::config::{COMMON_DEEPSEEK_MODELS, clear_api_key, normalize_model_name_for_provider};
+use crate::config::{
+    clear_api_key, model_completion_names_for_provider, normalize_model_name_for_provider,
+};
 use crate::config_ui::{ConfigUiMode, parse_mode};
 use crate::llm_client::LlmClient;
 use crate::localization::resolve_locale;
@@ -387,9 +389,10 @@ pub fn set_config_value(app: &mut App, key: &str, value: &str, persist: bool) ->
             app.auto_model = false;
             app.last_effective_model = None;
             let Some(model) = normalize_model_name_for_provider(app.api_provider, value) else {
+                let models = model_completion_names_for_provider(app.api_provider);
                 return CommandResult::error(format!(
-                    "Invalid model '{value}'. Expected a DeepSeek model ID. Common models: {}",
-                    COMMON_DEEPSEEK_MODELS.join(", ")
+                    "Invalid model '{value}'. Try: auto, {}",
+                    models.join(", ")
                 ));
             };
             app.model = model.clone();

--- a/crates/tui/src/commands/core.rs
+++ b/crates/tui/src/commands/core.rs
@@ -3,7 +3,9 @@
 use std::fmt::Write;
 use std::path::PathBuf;
 
-use crate::config::{COMMON_DEEPSEEK_MODELS, normalize_model_name_for_provider};
+use crate::config::{
+    model_completion_names_for_provider, normalize_model_name_for_provider,
+};
 use crate::localization::{MessageId, tr};
 use crate::tui::app::{App, AppAction, AppMode, ReasoningEffort};
 use crate::tui::views::{HelpView, ModalKind, SubAgentsView, subagent_view_agents};
@@ -122,9 +124,10 @@ pub fn model(app: &mut App, model_name: Option<&str>) -> CommandResult {
             );
         }
         let Some(model_id) = normalize_model_name_for_provider(app.api_provider, name) else {
+            let models = model_completion_names_for_provider(app.api_provider);
             return CommandResult::error(format!(
-                "Invalid model '{name}'. Expected auto or a DeepSeek model ID. Common models: {}",
-                COMMON_DEEPSEEK_MODELS.join(", ")
+                "Invalid model '{name}'. Try: auto, {}",
+                models.join(", ")
             ));
         };
         let old_model = app.model_display_label();

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -378,6 +378,21 @@ fn canonical_official_deepseek_model_id(model: &str) -> Option<&'static str> {
 /// config/back-compat, and canonicalize only when the active provider is known.
 #[must_use]
 pub fn normalize_model_name_for_provider(provider: ApiProvider, model: &str) -> Option<String> {
+    // Pass-through providers (OpenAI, AtlasCloud, Ollama) accept any valid
+    // model name the user types — they are not limited to DeepSeek IDs.
+    if provider_passes_model_through(provider) {
+        let trimmed = model.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+        if !trimmed
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | ':' | '/'))
+        {
+            return None;
+        }
+        return Some(trimmed.to_string());
+    }
     let normalized = normalize_model_name(model)?;
     if matches!(provider, ApiProvider::Deepseek | ApiProvider::DeepseekCN)
         && let Some(canonical) = canonical_official_deepseek_model_id(&normalized)


### PR DESCRIPTION
Three improvements for OpenAI-compatible API providers:

1. SSE parser: accept "data:" without trailing space. The SSE spec allows both "data: " and "data:"; many OpenAI-compatible APIs (including jiarongai and self-hosted gateways) omit the space. Previously only "data: " was recognized, causing SSE events to be silently dropped.

2. Model name validation: relax for pass-through providers (OpenAI, AtlasCloud, Ollama). These providers accept arbitrary model IDs, not just "deepseek-*" prefixed names. Previously normalize_model_name_for_provider would reject any model name not starting with "deepseek".

3. Dynamic model lists in error messages: when /model rejects an invalid name, show the current provider's available models instead of a hardcoded DeepSeek list.

4. Detect JSON error responses in streaming mode: some OpenAI-compatible APIs return HTTP 200 with a JSON error body when the service is busy, which the SSE parser would hang on. Detect this by inspecting the first response byte.

## Summary

## Testing

- [ ] `cargo test --all-features`
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
