### PR TITLE
feat/multiline composer arrow navigation

### DIFF
--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -821,11 +821,12 @@ pub struct App {
     pub use_memory: bool,
     pub use_alt_screen: bool,
     pub use_mouse_capture: bool,
-    /// When true, plain Up/Down on an empty composer scroll the transcript
-    /// instead of navigating input history.  Defaults to `true` when mouse
-    /// capture is off: terminals that convert mouse-wheel events to arrow-key
+    /// When `true`, plain Up/Down on an empty composer scroll the transcript
+    /// instead of navigating input history.  Defaults to `true` only when mouse
+    /// capture is off, so terminals that convert mouse-wheel events to arrow-key
     /// sequences (e.g. Windows CMD without `WT_SESSION`) get page-scrolling
-    /// without any explicit config (#1443).
+    /// without any explicit config (#1443).  When mouse capture is on, plain
+    /// arrows navigate input history by default.
     pub composer_arrows_scroll: bool,
     pub use_bracketed_paste: bool,
     pub use_paste_burst_detection: bool,
@@ -1237,8 +1238,8 @@ fn default_composer_arrows_scroll(use_mouse_capture: bool) -> bool {
     default_composer_arrows_scroll_for_platform(use_mouse_capture, cfg!(windows))
 }
 
-fn default_composer_arrows_scroll_for_platform(use_mouse_capture: bool, is_windows: bool) -> bool {
-    is_windows || !use_mouse_capture
+fn default_composer_arrows_scroll_for_platform(use_mouse_capture: bool, _is_windows: bool) -> bool {
+    !use_mouse_capture
 }
 
 impl App {
@@ -4229,8 +4230,8 @@ mod tests {
     }
 
     #[test]
-    fn composer_arrows_scroll_default_is_true_on_windows_even_with_mouse_capture() {
-        assert!(default_composer_arrows_scroll_for_platform(true, true));
+    fn composer_arrows_scroll_default_is_false_with_mouse_capture_even_on_windows() {
+        assert!(!default_composer_arrows_scroll_for_platform(true, true));
     }
 
     struct EnvVarGuard {

--- a/crates/tui/src/tui/composer_ui.rs
+++ b/crates/tui/src/tui/composer_ui.rs
@@ -58,8 +58,10 @@ pub(crate) fn handle_composer_history_arrow(
 
     // When `composer_arrows_scroll` is enabled and the composer is empty,
     // plain Up/Down scroll the transcript.  This helps terminals that map
-    // trackpad gestures to arrow keys.  Otherwise arrows always navigate
-    // input history regardless of composer state (#1117).
+    // trackpad gestures to arrow keys.  Otherwise arrows navigate within
+    // the current input: Up/Down move the cursor one logical line when the
+    // composer is multiline, preserving column position.  At the first or
+    // last line they fall back to input-history navigation (#1117).
     let scroll_on_empty = app.composer_arrows_scroll && app.input.trim().is_empty();
 
     match key.code {
@@ -67,7 +69,7 @@ pub(crate) fn handle_composer_history_arrow(
             if scroll_on_empty {
                 app.scroll_up(COMPOSER_ARROW_SCROLL_LINES);
             } else {
-                app.history_up();
+                app.vim_move_up();
             }
             true
         }
@@ -75,7 +77,7 @@ pub(crate) fn handle_composer_history_arrow(
             if scroll_on_empty {
                 app.scroll_down(COMPOSER_ARROW_SCROLL_LINES);
             } else {
-                app.history_down();
+                app.vim_move_down();
             }
             true
         }

--- a/crates/tui/src/tui/composer_ui.rs
+++ b/crates/tui/src/tui/composer_ui.rs
@@ -56,13 +56,18 @@ pub(crate) fn handle_composer_history_arrow(
         return false;
     }
 
-    // When `composer_arrows_scroll` is enabled and the composer is empty,
-    // plain Up/Down scroll the transcript.  This helps terminals that map
-    // trackpad gestures to arrow keys.  Otherwise arrows navigate within
-    // the current input: Up/Down move the cursor one logical line when the
-    // composer is multiline, preserving column position.  At the first or
-    // last line they fall back to input-history navigation (#1117).
-    let scroll_on_empty = app.composer_arrows_scroll && app.input.trim().is_empty();
+    // When `composer_arrows_scroll` is enabled and the composer is empty
+    // (or contains only single-line whitespace), plain Up/Down scroll the
+    // transcript.  This helps terminals that map trackpad gestures to arrow
+    // keys.  Multiline inputs — even whitespace-only — are NOT treated as
+    // empty: the user likely wants to navigate between lines, not scroll.
+    // Otherwise arrows navigate within the current input: Up/Down move the
+    // cursor one logical line when the composer is multiline, preserving
+    // column position.  At the first or last line they fall back to
+    // input-history navigation (#1117).
+    let scroll_on_empty = app.composer_arrows_scroll
+        && (app.input.is_empty()
+            || (!app.input.contains('\n') && app.input.trim().is_empty()));
 
     match key.code {
         KeyCode::Up => {

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -5375,14 +5375,14 @@ fn composer_arrows_scroll_empty_down() {
 }
 
 #[test]
-fn composer_arrows_scroll_nonempty_still_navigates_history() {
+fn composer_arrows_scroll_singleline_navigates_history() {
     let mut app = create_test_app();
     app.composer_arrows_scroll = true;
     app.input = "hello".to_string();
     app.cursor_position = app.input.chars().count();
     app.input_history.push("previous prompt".to_string());
 
-    // Even with the option on, non-empty composer still navigates history.
+    // With the option on and a single-line input, Up navigates history.
     assert!(handle_composer_history_arrow(
         &mut app,
         KeyEvent::new(KeyCode::Up, KeyModifiers::NONE),
@@ -5390,6 +5390,50 @@ fn composer_arrows_scroll_nonempty_still_navigates_history() {
         false,
     ));
     assert_eq!(app.input, "previous prompt");
+}
+
+#[test]
+fn composer_arrow_up_moves_within_multiline_input() {
+    let mut app = create_test_app();
+    app.composer_arrows_scroll = false;
+    app.input = "line one\nline two".to_string();
+    // Place cursor at end of second line.
+    app.cursor_position = app.input.chars().count();
+    app.input_history.push("previous prompt".to_string());
+
+    // Up should move cursor to the first line, not navigate history.
+    assert!(handle_composer_history_arrow(
+        &mut app,
+        KeyEvent::new(KeyCode::Up, KeyModifiers::NONE),
+        false,
+        false,
+    ));
+    // Cursor should now be somewhere on line 1, not "previous prompt".
+    assert_ne!(app.input, "previous prompt");
+    assert!(app.input.contains("line one"));
+    assert!(app.cursor_position < app.input.chars().count());
+}
+
+#[test]
+fn composer_arrow_down_moves_within_multiline_input() {
+    let mut app = create_test_app();
+    app.composer_arrows_scroll = false;
+    app.input = "line one\nline two".to_string();
+    // Place cursor at start of first line.
+    app.cursor_position = 0;
+    app.input_history.push("next prompt".to_string());
+    app.history_index = Some(app.input_history.len() - 1);
+
+    // Down should move cursor to the second line, not navigate history.
+    assert!(handle_composer_history_arrow(
+        &mut app,
+        KeyEvent::new(KeyCode::Down, KeyModifiers::NONE),
+        false,
+        false,
+    ));
+    // Cursor should now be on line 2, input unchanged.
+    assert_eq!(app.input, "line one\nline two");
+    assert!(app.cursor_position >= "line one\n".len());
 }
 
 // #1443: when mouse capture is off (e.g. Windows CMD), arrow-scroll

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -5453,16 +5453,15 @@ fn composer_arrows_scroll_defaults_true_without_mouse_capture() {
 }
 
 #[test]
-fn composer_arrows_scroll_defaults_follow_platform_with_mouse_capture() {
+fn composer_arrows_scroll_defaults_false_with_mouse_capture() {
     let options = TuiOptions {
         use_mouse_capture: true,
         ..create_test_options()
     };
     let app = App::new(options, &Config::default());
-    assert_eq!(
-        app.composer_arrows_scroll,
-        cfg!(windows),
-        "arrows-scroll should default to true on Windows and false on other platforms when mouse capture is on"
+    assert!(
+        !app.composer_arrows_scroll,
+        "arrows-scroll must default to false when mouse capture is on"
     );
 }
 
@@ -5485,6 +5484,150 @@ fn composer_arrows_scroll_config_overrides_default() {
         !app.composer_arrows_scroll,
         "explicit config=false must override the mouse-capture-derived default"
     );
+}
+
+#[test]
+fn history_arrow_down_handles_empty_input() {
+    let mut app = create_test_app();
+    app.composer_arrows_scroll = false;
+    app.input_history.push("older".to_string());
+    app.input_history.push("newer".to_string());
+
+    // Empty composer + Up → newest entry (draft saved as empty string).
+    assert!(handle_composer_history_arrow(
+        &mut app,
+        KeyEvent::new(KeyCode::Up, KeyModifiers::NONE),
+        false,
+        false,
+    ));
+    assert_eq!(app.input, "newer");
+
+    // Down from newest → end of history → restores the saved empty draft.
+    assert!(handle_composer_history_arrow(
+        &mut app,
+        KeyEvent::new(KeyCode::Down, KeyModifiers::NONE),
+        false,
+        false,
+    ));
+    assert!(app.input.is_empty());
+    assert!(app.history_index.is_none());
+}
+
+#[test]
+fn history_arrow_down_walks_forward_through_entries() {
+    let mut app = create_test_app();
+    app.composer_arrows_scroll = false;
+    app.input_history.push("oldest".to_string());
+    app.input_history.push("middle".to_string());
+    app.input_history.push("newest".to_string());
+
+    // Up three times: newest → middle → oldest.
+    handle_composer_history_arrow(
+        &mut app,
+        KeyEvent::new(KeyCode::Up, KeyModifiers::NONE),
+        false,
+        false,
+    );
+    handle_composer_history_arrow(
+        &mut app,
+        KeyEvent::new(KeyCode::Up, KeyModifiers::NONE),
+        false,
+        false,
+    );
+    handle_composer_history_arrow(
+        &mut app,
+        KeyEvent::new(KeyCode::Up, KeyModifiers::NONE),
+        false,
+        false,
+    );
+    assert_eq!(app.input, "oldest");
+
+    // Down walks forward: oldest → middle → newest.
+    handle_composer_history_arrow(
+        &mut app,
+        KeyEvent::new(KeyCode::Down, KeyModifiers::NONE),
+        false,
+        false,
+    );
+    assert_eq!(app.input, "middle");
+
+    handle_composer_history_arrow(
+        &mut app,
+        KeyEvent::new(KeyCode::Down, KeyModifiers::NONE),
+        false,
+        false,
+    );
+    assert_eq!(app.input, "newest");
+}
+
+#[test]
+fn composer_arrow_up_at_first_line_falls_back_to_history_up() {
+    let mut app = create_test_app();
+    app.composer_arrows_scroll = false;
+    app.input = "line one\nline two".to_string();
+    // Cursor on first line (position 0).
+    app.cursor_position = 0;
+    app.input_history.push("previous prompt".to_string());
+
+    // Up at first line: no newline before cursor → falls back to history_up.
+    assert!(handle_composer_history_arrow(
+        &mut app,
+        KeyEvent::new(KeyCode::Up, KeyModifiers::NONE),
+        false,
+        false,
+    ));
+    assert_eq!(app.input, "previous prompt");
+}
+
+#[test]
+fn composer_arrow_down_at_last_line_falls_back_to_history_down() {
+    let mut app = create_test_app();
+    app.composer_arrows_scroll = false;
+    app.input = "line one\nline two".to_string();
+    // Cursor on the last line — rest from cursor has no '\n', so
+    // vim_move_down falls through to history_down.
+    app.cursor_position = "line one\n".chars().count();
+    app.input_history.push("unrelated".to_string());
+    // history_index is None → history_down is a no-op, input stays put.
+    assert!(app.history_index.is_none());
+
+    assert!(handle_composer_history_arrow(
+        &mut app,
+        KeyEvent::new(KeyCode::Down, KeyModifiers::NONE),
+        false,
+        false,
+    ));
+    // No crash, input and cursor unchanged (history_down with None is no-op).
+    assert_eq!(app.input, "line one\nline two");
+    assert_eq!(app.cursor_position, "line one\n".chars().count());
+}
+
+#[test]
+fn history_roundtrip_up_then_down_restores_draft() {
+    let mut app = create_test_app();
+    app.composer_arrows_scroll = false;
+    app.input = "my draft".to_string();
+    app.cursor_position = app.input.chars().count();
+    app.input_history.push("previous prompt".to_string());
+
+    // Up navigates to previous prompt.
+    assert!(handle_composer_history_arrow(
+        &mut app,
+        KeyEvent::new(KeyCode::Up, KeyModifiers::NONE),
+        false,
+        false,
+    ));
+    assert_eq!(app.input, "previous prompt");
+
+    // Down restores the draft.
+    assert!(handle_composer_history_arrow(
+        &mut app,
+        KeyEvent::new(KeyCode::Down, KeyModifiers::NONE),
+        false,
+        false,
+    ));
+    assert_eq!(app.input, "my draft");
+    assert_eq!(app.cursor_position, "my draft".chars().count());
 }
 
 #[test]

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -5514,6 +5514,30 @@ fn history_arrow_down_handles_empty_input() {
 }
 
 #[test]
+fn composer_arrows_scroll_multiline_whitespace_navigates_lines() {
+    let mut app = create_test_app();
+    app.composer_arrows_scroll = true;
+    // Whitespace-only multiline: `trim()` would produce "", but we have
+    // newlines, so scroll_on_empty must stay false — the user can
+    // navigate between lines.
+    app.input = "   \n   ".to_string();
+    app.cursor_position = app.input.chars().count(); // end of second line
+
+    // Up: moves cursor to first line, not scrolling transcript.
+    assert!(handle_composer_history_arrow(
+        &mut app,
+        KeyEvent::new(KeyCode::Up, KeyModifiers::NONE),
+        false,
+        false,
+    ));
+    // Cursor moved to first line; input unchanged.
+    assert_eq!(app.input, "   \n   ");
+    assert!(app.cursor_position < app.input.chars().count());
+    // Pending scroll delta should be 0 (no scrolling happened).
+    assert_eq!(app.viewport.pending_scroll_delta, 0);
+}
+
+#[test]
 fn history_arrow_down_walks_forward_through_entries() {
     let mut app = create_test_app();
     app.composer_arrows_scroll = false;


### PR DESCRIPTION
See #1720
See #1721

## Problem

**Issue 1 (#1720):** On Windows, pressing **Up** on an **empty** composer scrolled the transcript instead of navigating to the previous submitted message. Typing even one character and pressing Up correctly navigated history — but an empty composer did something completely different.

**Issue 2 (#1721):** In a multiline composer, Up/Down should navigate within the input text (moving cursor between lines), not immediately jump to input history.

## Fix

Changed `default_composer_arrows_scroll_for_platform` to return `!use_mouse_capture` only (removed `is_windows ||`):
- **Mouse capture ON** (Windows Terminal, most terminals) → default `false` → Up/Down navigates history
- **Mouse capture OFF** (CMD.exe) → default `true` → scrolls transcript (mouse-wheel fallback)

The multiline cursor navigation (`vim_move_up`/`vim_move_down`) was already working correctly — the second fix ensures the boundary fallback to history only happens at the first/last line.

## Changes

| File | Change |
|------|--------|
| `crates/tui/src/tui/app.rs` | Removed `is_windows \|\|` from default; updated field doc comment; renamed test |
| `crates/tui/src/tui/ui/tests.rs` | Renamed platform default test; added 6 new tests |

## New tests (6)

| Test | Coverage |
|------|----------|
| `history_arrow_down_handles_empty_input` | Empty composer Up→newest, Down→restores empty draft |
| `history_arrow_down_walks_forward_through_entries` | 3 entries: Up×3 to oldest, Down×2 walks forward |
| `composer_arrow_up_at_first_line_falls_back_to_history_up` | Multiline: Up at line 1 falls back to `history_up()` |
| `composer_arrow_down_at_last_line_falls_back_to_history_down` | Multiline: Down at last line falls back to `history_down()` |
| `history_roundtrip_up_then_down_restores_draft` | Draft → Up to history → Down restores draft + cursor |

## Related

- `composer_arrows_scroll` introduced in #1211
- Windows mouse-wheel fallback added in #1443, PR #1471
