### PR TITLE
feat: configurable auto-compact threshold with Ctrl+L keybinding

### DIFF
--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -664,7 +664,7 @@ pub fn system_prompt_for_mode_with_context_skills_session_and_approval(
              1. Use `/compact` to summarize earlier context and free up space\n\
              2. The system will preserve important information (files you're working on, recent messages, tool results)\n\
              3. After compaction, you'll see a summary of what was discussed and can continue seamlessly\n\n\
-             If you notice context is getting long (>60% during sustained work), proactively suggest using `/compact` to the user.\n\n\
+             If you notice context is getting long (>60% during sustained work), proactively suggest using `/compact` to the user. If `auto_compact` is enabled (check via `/config auto_compact`), the engine will automatically compact before the next send when context crosses the configured threshold (default 70%). The user can also press `Ctrl+L` at any time to trigger manual compaction.\n\n\
              ### Prompt-cache awareness\n\n\
              DeepSeek caches the longest *byte-stable prefix* of every request and charges roughly 100× less for cache-hit tokens than miss tokens. The system prompt above is layered most-static-first specifically so the prefix stays stable turn-over-turn. To keep cache hits high:\n\
              - **Working set location:** the current repo working set is stored on new user messages inside a `<turn_meta>` block. Treat it as high-priority turn metadata, not as a stable system-prompt section.\n\

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -167,6 +167,11 @@ impl TuiPrefs {
 pub struct Settings {
     /// Auto-compact conversations when they approach the model limit.
     pub auto_compact: bool,
+    /// Context-usage percentage at which auto-compaction triggers before the
+    /// next send (when `auto_compact` is true). Default 70% balances V4
+    /// prefix-cache protection with headroom safety. Respects the 500K-token
+    /// hard floor regardless of percentage.
+    pub auto_compact_threshold_percent: f64,
     /// Reduce status noise and collapse details more aggressively
     pub calm_mode: bool,
     /// Streaming pacing mode. `true` pins the chunker to one-character-per-
@@ -285,6 +290,7 @@ impl Default for Settings {
             // available for users / agents that decide compaction is
             // worth the cache hit on their workload (#664).
             auto_compact: false,
+            auto_compact_threshold_percent: 70.0,
             calm_mode: false,
             low_motion: false,
             fancy_animations: false,
@@ -466,6 +472,19 @@ impl Settings {
         match key {
             "auto_compact" | "compact" => {
                 self.auto_compact = parse_bool(value)?;
+            }
+            "auto_compact_threshold" | "compact_threshold_pct" => {
+                let pct: f64 = value
+                    .parse()
+                    .map_err(|_| anyhow::anyhow!(
+                        "Failed to parse auto_compact_threshold '{value}': expected a number (e.g. 70)"
+                    ))?;
+                if pct < 10.0 || pct > 100.0 {
+                    anyhow::bail!(
+                        "auto_compact_threshold must be between 10 and 100 (got {pct})"
+                    );
+                }
+                self.auto_compact_threshold_percent = pct;
             }
             "calm_mode" | "calm" => {
                 self.calm_mode = parse_bool(value)?;
@@ -720,6 +739,10 @@ impl Settings {
             (
                 "auto_compact",
                 "Auto-compact near the hard context limit: on/off (default off)",
+            ),
+            (
+                "auto_compact_threshold",
+                "Context % at which auto-compaction fires before send (default 70)",
             ),
             ("calm_mode", "Calmer UI defaults: on/off"),
             (

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -840,6 +840,7 @@ pub struct App {
     #[allow(dead_code)]
     pub system_prompt: Option<SystemPrompt>,
     pub auto_compact: bool,
+    pub auto_compact_threshold_pct: f64,
     pub calm_mode: bool,
     pub low_motion: bool,
     /// Pending #61 (animated working strip). Set from config but not read
@@ -1312,6 +1313,7 @@ impl App {
             crate::config::active_provider_uses_env_only_api_key(&effective_auth_config);
         let was_onboarded = crate::tui::onboarding::is_onboarded();
         let auto_compact = settings.auto_compact;
+        let auto_compact_threshold_pct = settings.auto_compact_threshold_percent;
         let calm_mode = settings.calm_mode;
         let low_motion = settings.low_motion;
         let fancy_animations = settings.fancy_animations;
@@ -1499,6 +1501,7 @@ impl App {
             bracketed_paste_seen: false,
             system_prompt: None,
             auto_compact,
+            auto_compact_threshold_pct,
             calm_mode,
             low_motion,
             fancy_animations,

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -133,6 +133,7 @@ const SLASH_MENU_LIMIT: usize = 128;
 const MENTION_MENU_LIMIT: usize = 6;
 const MIN_CHAT_HEIGHT: u16 = 3;
 const MIN_COMPOSER_HEIGHT: u16 = 2;
+const CONTEXT_SUGGEST_COMPACT_THRESHOLD_PERCENT: f64 = 60.0;
 const CONTEXT_WARNING_THRESHOLD_PERCENT: f64 = 85.0;
 const CONTEXT_CRITICAL_THRESHOLD_PERCENT: f64 = 95.0;
 const UI_IDLE_POLL_MS: u64 = 48;
@@ -2461,6 +2462,19 @@ async fn run_event_loop(
                 && app.view_stack.is_empty()
             {
                 open_shell_control(app);
+                continue;
+            }
+
+            // Ctrl+L: manual context compaction — breaks the chicken-and-egg
+            // deadlock when the model is too slow to suggest /compact at high
+            // context saturation. Fires even when a turn is streaming so the
+            // user can compact between turns without canceling.
+            if matches!(key.code, KeyCode::Char('l') | KeyCode::Char('L'))
+                && key.modifiers.contains(KeyModifiers::CONTROL)
+                && app.view_stack.is_empty()
+            {
+                app.status_message = Some("Compacting context (Ctrl+L)...".to_string());
+                let _ = engine_handle.send(Op::CompactContext).await;
                 continue;
             }
 
@@ -6786,6 +6800,25 @@ fn maybe_warn_context_pressure(app: &mut App) {
         return;
     };
 
+    // Early heads-up at 60% — the same threshold the model is told to
+    // suggest /compact at. Non-intrusive: only sets the status message when
+    // it's currently empty, so it never stomps on a more important message.
+    if percent >= CONTEXT_SUGGEST_COMPACT_THRESHOLD_PERCENT
+        && percent < CONTEXT_WARNING_THRESHOLD_PERCENT
+        && app.status_message.is_none()
+    {
+        let hint = if app.auto_compact {
+            "Auto-compaction will fire before next send."
+        } else {
+            "Consider enabling auto_compact or use /compact."
+        };
+        app.status_message = Some(format!(
+            "Context building: {:.0}% ({used}/{max} tokens). {hint}",
+            percent
+        ));
+        return;
+    }
+
     if percent < CONTEXT_WARNING_THRESHOLD_PERCENT {
         return;
     }
@@ -6816,8 +6849,20 @@ fn should_auto_compact_before_send(app: &App) -> bool {
     if !app.auto_compact {
         return false;
     }
+    // Use the configurable threshold (default 70%) instead of the old
+    // hardcoded 95% critical threshold. The 500K-token hard floor from
+    // compaction.rs is also respected here so small sessions are never
+    // auto-compacted even if the percentage looks high.
     context_usage_snapshot(app)
-        .map(|(_, _, pct)| pct >= CONTEXT_CRITICAL_THRESHOLD_PERCENT)
+        .map(|(used, _, pct)| {
+            // Hard floor: below 500K tokens, auto-compaction is refused
+            // because rewriting the prefix kills V4's prefix cache for
+            // little budget recovery.
+            if (used as usize) < crate::compaction::MINIMUM_AUTO_COMPACTION_TOKENS {
+                return false;
+            }
+            pct >= app.auto_compact_threshold_pct
+        })
         .unwrap_or(false)
 }
 

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -6803,14 +6803,40 @@ fn maybe_warn_context_pressure(app: &mut App) {
     // Early heads-up at 60% — the same threshold the model is told to
     // suggest /compact at. Non-intrusive: only sets the status message when
     // it's currently empty, so it never stomps on a more important message.
-    if percent >= CONTEXT_SUGGEST_COMPACT_THRESHOLD_PERCENT
+    let effective_warn_threshold = if app.auto_compact {
+        CONTEXT_SUGGEST_COMPACT_THRESHOLD_PERCENT.min(app.auto_compact_threshold_pct)
+    } else {
+        CONTEXT_SUGGEST_COMPACT_THRESHOLD_PERCENT
+    };
+
+    if percent >= effective_warn_threshold
         && percent < CONTEXT_WARNING_THRESHOLD_PERCENT
         && app.status_message.is_none()
     {
         let hint = if app.auto_compact {
-            "Auto-compaction will fire before next send."
+            let below_floor =
+                (used as usize) < crate::compaction::MINIMUM_AUTO_COMPACTION_TOKENS;
+            let below_threshold = percent < app.auto_compact_threshold_pct;
+
+            if below_floor && below_threshold {
+                format!(
+                    "Auto-compact enabled but below 500K floor and {:.0}% threshold; won't fire yet.",
+                    app.auto_compact_threshold_pct
+                )
+            } else if below_floor {
+                "Auto-compact enabled but below 500K token floor; won't fire yet."
+                    .to_string()
+            } else if below_threshold {
+                format!(
+                    "Auto-compact will fire at {:.0}% (currently {:.0}%).",
+                    app.auto_compact_threshold_pct, percent
+                )
+            } else {
+                "Auto-compaction would fire now; it will run before the next send."
+                    .to_string()
+            }
         } else {
-            "Consider enabling auto_compact or use /compact."
+            "Consider enabling auto_compact or use /compact.".to_string()
         };
         app.status_message = Some(format!(
             "Context building: {:.0}% ({used}/{max} tokens). {hint}",


### PR DESCRIPTION
## Problem

At ~99.6% context saturation, the TUI becomes completely unresponsive — a chicken-and-egg deadlock where the model is too slow to suggest `/compact` and no automatic compaction fires. Both guardrails (capacity controller and auto-compact) are disabled by default since v0.8.11.

Closes #1722

## Solution

Adds a **configurable auto-compact threshold** (default 70%) and a **Ctrl+L keybinding** for manual compaction, closing the gap between model guidance (suggest `/compact` at 60%) and engine action (which previously only fired at 95%).

### Changes

| File | +/- | Description |
|------|-----|-------------|
| `crates/tui/src/settings.rs` | +25 | New `auto_compact_threshold_percent` field, default 70.0, set handler with validation (10-100), help text |
| `crates/tui/src/tui/app.rs` | +3 | `auto_compact_threshold_pct` field in App struct, wired from settings |
| `crates/tui/src/tui/ui.rs` | +49 | New 60% early-warning constant, `maybe_warn_context_pressure()` early-warning tier, `should_auto_compact_before_send()` uses configurable threshold + 500K floor, **Ctrl+L keybinding** |
| `crates/tui/src/prompts.rs` | +1/-1 | System prompt informs model about auto-compact threshold and Ctrl+L |

### Configuration

```toml
# ~/.deepseek/config.toml
auto_compact = true                     # master switch (still defaults to false)
auto_compact_threshold_percent = 70     # fires at 70% (NEW)
```

### Behavior

- 60% -> Status bar: "Context building - Auto-compaction will fire before next send." (non-intrusive)
- 70% -> **Engine compacts before next send** (if >500K tokens)
- **Ctrl+L** -> Manual compaction at any time, even mid-turn

### Backward Compatibility

- `auto_compact` still defaults to `false` — no change for existing users
- 500K hard floor unchanged — protects small sessions from cache destruction
- Existing `/compact` command unchanged