### PR TITLE
fix: preserve scroll position across terminal resize

### DIFF
--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -2441,16 +2441,16 @@ impl App {
     pub fn handle_resize(&mut self, _width: u16, _height: u16) {
         self.viewport.transcript_cache = TranscriptViewCache::new();
 
-        if !self.viewport.transcript_scroll.is_at_tail() {
-            self.viewport.transcript_scroll = TranscriptScroll::to_bottom();
-        }
-
         self.viewport.pending_scroll_delta = 0;
         self.viewport.transcript_selection.clear();
 
         self.viewport.last_transcript_area = None;
         self.viewport.last_transcript_top = 0;
-        self.viewport.last_transcript_visible = 0;
+        // Seed visible height from resize event so paging keys (PageUp/Down)
+        // use a sensible page size immediately, before the next render updates
+        // it.  Subtract 2 to roughly account for borders/status bar so the
+        // fallback is conservative rather than over-shooting.
+        self.viewport.last_transcript_visible = (_height as usize).saturating_sub(2).max(1);
         self.viewport.last_transcript_total = 0;
         self.viewport.last_transcript_padding_top = 0;
 


### PR DESCRIPTION
## Problem

Terminal resize (even slight window-manager adjustments) was destroying the user's scroll position in the transcript. The `handle_resize` method unconditionally forced `TranscriptScroll::to_bottom()` whenever the user had scrolled up, causing:

- **Viewport drift** — losing your place in long conversation history
- **Agent thinking blocks becoming inaccessible** after resize (visible but scroll position teleported away)
- **PageUp/PageDown degraded to 1-line jumps** after every resize — `last_transcript_visible` was reset to `0`

## Fix

Two changes in `App::handle_resize` (`crates/tui/src/tui/app.rs`):

1. **Removed the force-to-bottom block.** Scroll position is now preserved across resize. On the next render, `resolve_top()` naturally clamps the offset to the new valid range — collapsing to tail only when geometrically necessary, not unconditionally.

2. **Seeded `last_transcript_visible` from the resize height.** Previously reset to `0`, which made the first PageUp/Down after resize fall back to a 1-line default. Now uses `(_height as usize).saturating_sub(2).max(1)` so paging keys work correctly immediately after resize.

## Existing infrastructure (unchanged)

The full scroll infrastructure was already in place:
- `TranscriptScroll` with flat line-offset model and `TAIL_SENTINEL`
- `ViewportState` with `pending_scroll_delta` lazy-resolution
- PageUp/Down, arrow keys, Home/End keybindings
- `TranscriptScrollbar` visual indicator
- Auto-scroll behavior (pins to bottom when following, stays put when user scrolls away)

The resize handler was the single point sabotaging all of it.

## Testing

- Built on Windows with MSVC toolchain (stable-x86_64-pc-windows-msvc)
- All existing tests pass
- Manual testing: scroll up mid-session, resize terminal window, verify scroll position preserved
