### PR TITLE
fix(tui): surface thinking-only turns instead of silently ending

### DIFF
--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -874,6 +874,15 @@ impl Engine {
                     content: content_blocks,
                 })
                 .await;
+            } else if turn_error.is_none() && !self.cancel_token.is_cancelled() {
+                // gpt-oss via ollama's harmony→OpenAI shim can return
+                // `reasoning_content` with empty `content` and no
+                // `tool_calls`, which would otherwise leave the UI silently
+                // idle while the engine quietly ends the turn.
+                let notice = "Model returned reasoning but no answer or tool call; \
+                              turn ended without output. Send a follow-up to retry.";
+                crate::logging::warn(notice);
+                let _ = self.tx_event.send(Event::status(notice.to_string())).await;
             }
 
             // If no tool uses, check for inline REPL blocks (paper §2) or


### PR DESCRIPTION
## Summary
- gpt-oss (and any model whose response gets mapped to `reasoning_content` with empty `content` and no `tool_calls`) returns chunks where the only thing the engine has at the end of the stream is a `Thinking` block.
- The persist site at `crates/tui/src/core/engine/turn_loop.rs:863-877` was an `if`-only branch on `has_sendable_assistant_content` — when false, the assistant message was silently not persisted, no event was emitted, and `if tool_uses.is_empty()` fell straight through to "finish the turn." The UI sat idle with no spinner clear and no error.
- This PR adds an `else if turn_error.is_none() && !cancel_token.is_cancelled()` branch that emits a `status` event so the user sees "Model returned reasoning but no answer or tool call; turn ended without output. Send a follow-up to retry." instead of silence. No assistant message is persisted (matches prior behavior).

## Reproduction
1. Configure `provider_models.ollama = "gpt-oss:120b"` (or any gpt-oss variant) and `show_thinking = true` in `~/.deepseek/config.toml`.
2. Run the TUI in agent mode against ollama.
3. Periodically gpt-oss emits an analysis-channel-only response (ollama's harmony→OpenAI shim puts the content into `reasoning_content` and leaves `content`/`tool_calls` empty).
4. Before this fix: spinner clears nothing, no error, no reply — UI looks hung.
5. After this fix: status event surfaces with the notice above; user knows the turn ended and can send a follow-up.

I caught this on my own machine debugging a "hang" — session `~/.deepseek/sessions/<id>.json` showed the user typing "are you stopped?" after gpt-oss returned a 200 with no persisted assistant message.

## Test plan
- [ ] `cargo test -p deepseek-tui` passes
- [ ] `cargo clippy --workspace --all-targets --all-features` passes
- [ ] Manual: reproduce the gpt-oss thinking-only response against ollama and confirm the status event renders
- [ ] Manual: confirm a normal text/tool_use turn still persists and renders unchanged (the `if` branch is untouched)
- [ ] Manual: confirm a stream error still surfaces its own error event (no double-notice — guarded by `turn_error.is_none()`)
- [ ] Manual: confirm a cancelled turn doesn't fire the new notice (guarded by `!cancel_token.is_cancelled()`)

## Notes
- I couldn't run `cargo check` locally — my build host is missing `libdbus-1-dev` and I didn't want to install system packages without asking. CI should cover it. The patch uses the same `Event::status(String)` / `self.cancel_token.is_cancelled()` / `crate::logging::warn(&str)` / `turn_error.is_none()` patterns already used a few lines above in the same function.
- This is option 1 of the three approaches I considered (minimum-surface-area fix). Option 2 (re-prompt with a "produce a final-channel response" nudge) and option 3 (persist a placeholder text block) are deliberately not in this PR — option 1 unblocks the perceived hang without making policy decisions about retry behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)