### PR TITLE
Revert v0.8.38 /model picker rework, restore approval grouping; prepare v0.8.39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Feishu/Lark bridge startup order is guarded.** The bridge now keeps
   `ThreadStore` initialized before startup opens persisted thread state, with a
   regression test to prevent moving it below its first use.
+- **`/model` picker opens instantly with the curated list again.** Reverted
+  the v0.8.38 live-catalog rework: the picker no longer makes a blocking
+  network call on open and once again shows the curated `auto` /
+  `deepseek-v4-pro` / `deepseek-v4-flash` rows. The `/models` command still
+  lists the live provider catalog.
+- **"Approve for session" groups by command family again.** Session approvals
+  are keyed by a lossy, arity-aware fingerprint once more, so approving
+  `cargo build` also covers `cargo build --release`. Denials keep the exact
+  per-call fingerprint from #1617, so denying one call no longer over-blocks
+  later, different calls to the same tool.
 
 ## [0.8.38] - 2026-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unused optional `file_path` / `content` / `url` fields as empty strings no
   longer trip the "provide exactly one" guard; blank/whitespace-only source
   fields are treated as absent (#1712).
+- **`theme = "system"` follows macOS appearance.** When `COLORFGBG` is unset
+  or ambiguous (e.g. Ghostty), system-theme detection now falls back to the
+  macOS `AppleInterfaceStyle` appearance so Light mode is no longer rendered
+  in dark colors (#1670).
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.39] - 2026-05-17
+
 ### Fixed
 
 - **Feishu/Lark bridge startup order is guarded.** The bridge now keeps
@@ -22,6 +24,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `cargo build` also covers `cargo build --release`. Denials keep the exact
   per-call fingerprint from #1617, so denying one call no longer over-blocks
   later, different calls to the same tool.
+- **`rlm_open` accepts a single source again.** Models that serialize the
+  unused optional `file_path` / `content` / `url` fields as empty strings no
+  longer trip the "provide exactly one" guard; blank/whitespace-only source
+  fields are treated as absent (#1712).
+
+### Documentation
+
+- **`cargo install` documents the Rust 1.88+ requirement.** The primary
+  Cargo install path now notes that older toolchains fail with
+  ``feature `edition2024` is required`` and to run `rustup update` (#1718).
 
 ## [0.8.38] - 2026-05-15
 
@@ -4301,7 +4313,8 @@ Welcome — and thank you.
 - Hooks system and config profiles
 - Example skills and launch assets
 
-[Unreleased]: https://github.com/Hmbown/DeepSeek-TUI/compare/v0.8.38...HEAD
+[Unreleased]: https://github.com/Hmbown/DeepSeek-TUI/compare/v0.8.39...HEAD
+[0.8.39]: https://github.com/Hmbown/DeepSeek-TUI/compare/v0.8.38...v0.8.39
 [0.8.38]: https://github.com/Hmbown/DeepSeek-TUI/compare/v0.8.37...v0.8.38
 [0.8.37]: https://github.com/Hmbown/DeepSeek-TUI/compare/v0.8.36...v0.8.37
 [0.8.36]: https://github.com/Hmbown/DeepSeek-TUI/compare/v0.8.35...v0.8.36

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   or ambiguous (e.g. Ghostty), system-theme detection now falls back to the
   macOS `AppleInterfaceStyle` appearance so Light mode is no longer rendered
   in dark colors (#1670).
+- **Docker first run no longer fails with `Permission denied`.** The image
+  pre-creates `/home/deepseek/.deepseek` owned by the `deepseek` user and
+  declares it as a `VOLUME`, so a named volume mounted there initializes
+  with the container user's ownership instead of root (#1684).
 
 ### Documentation
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1160,7 +1160,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-agent"
-version = "0.8.38"
+version = "0.8.39"
 dependencies = [
  "deepseek-config",
  "serde",
@@ -1168,7 +1168,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-app-server"
-version = "0.8.38"
+version = "0.8.39"
 dependencies = [
  "anyhow",
  "axum",
@@ -1190,7 +1190,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-config"
-version = "0.8.38"
+version = "0.8.39"
 dependencies = [
  "anyhow",
  "deepseek-secrets",
@@ -1202,7 +1202,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-core"
-version = "0.8.38"
+version = "0.8.39"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-execpolicy"
-version = "0.8.38"
+version = "0.8.39"
 dependencies = [
  "anyhow",
  "deepseek-protocol",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-hooks"
-version = "0.8.38"
+version = "0.8.39"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1243,7 +1243,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-mcp"
-version = "0.8.38"
+version = "0.8.39"
 dependencies = [
  "anyhow",
  "serde",
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-protocol"
-version = "0.8.38"
+version = "0.8.39"
 dependencies = [
  "serde",
  "serde_json",
@@ -1260,7 +1260,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-secrets"
-version = "0.8.38"
+version = "0.8.39"
 dependencies = [
  "dirs",
  "keyring",
@@ -1273,7 +1273,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-state"
-version = "0.8.38"
+version = "0.8.39"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-tools"
-version = "0.8.38"
+version = "0.8.39"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1298,7 +1298,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-tui"
-version = "0.8.38"
+version = "0.8.39"
 dependencies = [
  "anyhow",
  "arboard",
@@ -1361,7 +1361,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-tui-cli"
-version = "0.8.38"
+version = "0.8.39"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1386,7 +1386,7 @@ dependencies = [
 
 [[package]]
 name = "deepseek-tui-core"
-version = "0.8.38"
+version = "0.8.39"
 
 [[package]]
 name = "deltae"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = ["crates/cli", "crates/app-server", "crates/tui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.8.38"
+version = "0.8.39"
 edition = "2024"
 # Rust 1.88 stabilized `let_chains` in `if`/`while` conditions, which the
 # codebase relies on extensively. Cargo enforces this so users on older

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,10 +73,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Non-root user with explicit UID/GID for filesystem ownership clarity.
+#
+# Pre-create the config dir owned by `deepseek` so that a named volume
+# mounted at `/home/deepseek/.deepseek` initializes with the container
+# user's ownership. Docker creates a missing bind/volume mountpoint as
+# root; without this the first run fails with `Permission denied
+# (os error 13)` creating `.deepseek/tasks/runtime/threads` (#1684).
 RUN groupadd --gid 1000 deepseek \
-    && useradd --create-home --shell /bin/bash --uid 1000 --gid 1000 deepseek
+    && useradd --create-home --shell /bin/bash --uid 1000 --gid 1000 deepseek \
+    && mkdir -p /home/deepseek/.deepseek \
+    && chown -R deepseek:deepseek /home/deepseek/.deepseek
 USER deepseek
 WORKDIR /home/deepseek
+VOLUME ["/home/deepseek/.deepseek"]
 
 COPY --from=builder --chown=deepseek:deepseek /out/deepseek /usr/local/bin/deepseek
 COPY --from=builder --chown=deepseek:deepseek /out/deepseek-tui /usr/local/bin/deepseek-tui

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ agent runtime itself.
 #    matching prebuilt Rust binaries from GitHub Releases.
 npm install -g deepseek-tui
 
-# 2. Cargo — no Node needed.
+# 2. Cargo — no Node needed. Requires Rust 1.88+ (the crates use the
+#    2024 edition; older toolchains fail with "feature `edition2024` is
+#    required"). Run `rustup update` first, or use a non-Cargo path below.
 cargo install deepseek-tui-cli --locked   # `deepseek` (entry point)
 cargo install deepseek-tui     --locked   # `deepseek-tui` (TUI binary)
 

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -7,5 +7,5 @@ repository.workspace = true
 description = "Model/provider registry and fallback strategy for DeepSeek workspace architecture"
 
 [dependencies]
-deepseek-config = { path = "../config", version = "0.8.38" }
+deepseek-config = { path = "../config", version = "0.8.39" }
 serde.workspace = true

--- a/crates/app-server/Cargo.toml
+++ b/crates/app-server/Cargo.toml
@@ -10,15 +10,15 @@ description = "Codex-style app-server transport for DeepSeek workspace architect
 anyhow.workspace = true
 axum.workspace = true
 clap.workspace = true
-deepseek-agent = { path = "../agent", version = "0.8.38" }
-deepseek-config = { path = "../config", version = "0.8.38" }
-deepseek-core = { path = "../core", version = "0.8.38" }
-deepseek-execpolicy = { path = "../execpolicy", version = "0.8.38" }
-deepseek-hooks = { path = "../hooks", version = "0.8.38" }
-deepseek-mcp = { path = "../mcp", version = "0.8.38" }
-deepseek-protocol = { path = "../protocol", version = "0.8.38" }
-deepseek-state = { path = "../state", version = "0.8.38" }
-deepseek-tools = { path = "../tools", version = "0.8.38" }
+deepseek-agent = { path = "../agent", version = "0.8.39" }
+deepseek-config = { path = "../config", version = "0.8.39" }
+deepseek-core = { path = "../core", version = "0.8.39" }
+deepseek-execpolicy = { path = "../execpolicy", version = "0.8.39" }
+deepseek-hooks = { path = "../hooks", version = "0.8.39" }
+deepseek-mcp = { path = "../mcp", version = "0.8.39" }
+deepseek-protocol = { path = "../protocol", version = "0.8.39" }
+deepseek-state = { path = "../state", version = "0.8.39" }
+deepseek-tools = { path = "../tools", version = "0.8.39" }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -14,13 +14,13 @@ path = "src/main.rs"
 anyhow.workspace = true
 clap.workspace = true
 clap_complete.workspace = true
-deepseek-agent = { path = "../agent", version = "0.8.38" }
-deepseek-app-server = { path = "../app-server", version = "0.8.38" }
-deepseek-config = { path = "../config", version = "0.8.38" }
-deepseek-execpolicy = { path = "../execpolicy", version = "0.8.38" }
-deepseek-mcp = { path = "../mcp", version = "0.8.38" }
-deepseek-secrets = { path = "../secrets", version = "0.8.38" }
-deepseek-state = { path = "../state", version = "0.8.38" }
+deepseek-agent = { path = "../agent", version = "0.8.39" }
+deepseek-app-server = { path = "../app-server", version = "0.8.39" }
+deepseek-config = { path = "../config", version = "0.8.39" }
+deepseek-execpolicy = { path = "../execpolicy", version = "0.8.39" }
+deepseek-mcp = { path = "../mcp", version = "0.8.39" }
+deepseek-secrets = { path = "../secrets", version = "0.8.39" }
+deepseek-state = { path = "../state", version = "0.8.39" }
 chrono.workspace = true
 dirs.workspace = true
 serde.workspace = true

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -8,7 +8,7 @@ description = "Config schema and precedence model for DeepSeek workspace archite
 
 [dependencies]
 anyhow.workspace = true
-deepseek-secrets = { path = "../secrets", version = "0.8.38" }
+deepseek-secrets = { path = "../secrets", version = "0.8.39" }
 dirs.workspace = true
 serde.workspace = true
 toml.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -9,13 +9,13 @@ description = "Core runtime boundaries for DeepSeek workspace architecture"
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true
-deepseek-agent = { path = "../agent", version = "0.8.38" }
-deepseek-config = { path = "../config", version = "0.8.38" }
-deepseek-execpolicy = { path = "../execpolicy", version = "0.8.38" }
-deepseek-hooks = { path = "../hooks", version = "0.8.38" }
-deepseek-mcp = { path = "../mcp", version = "0.8.38" }
-deepseek-protocol = { path = "../protocol", version = "0.8.38" }
-deepseek-state = { path = "../state", version = "0.8.38" }
-deepseek-tools = { path = "../tools", version = "0.8.38" }
+deepseek-agent = { path = "../agent", version = "0.8.39" }
+deepseek-config = { path = "../config", version = "0.8.39" }
+deepseek-execpolicy = { path = "../execpolicy", version = "0.8.39" }
+deepseek-hooks = { path = "../hooks", version = "0.8.39" }
+deepseek-mcp = { path = "../mcp", version = "0.8.39" }
+deepseek-protocol = { path = "../protocol", version = "0.8.39" }
+deepseek-state = { path = "../state", version = "0.8.39" }
+deepseek-tools = { path = "../tools", version = "0.8.39" }
 serde_json.workspace = true
 uuid.workspace = true

--- a/crates/execpolicy/Cargo.toml
+++ b/crates/execpolicy/Cargo.toml
@@ -8,5 +8,5 @@ description = "Execution policy and approval model parity for DeepSeek workspace
 
 [dependencies]
 anyhow.workspace = true
-deepseek-protocol = { path = "../protocol", version = "0.8.38" }
+deepseek-protocol = { path = "../protocol", version = "0.8.39" }
 serde.workspace = true

--- a/crates/hooks/Cargo.toml
+++ b/crates/hooks/Cargo.toml
@@ -10,7 +10,7 @@ description = "Hook dispatch and notifications parity for DeepSeek workspace arc
 anyhow.workspace = true
 async-trait.workspace = true
 chrono.workspace = true
-deepseek-protocol = { path = "../protocol", version = "0.8.38" }
+deepseek-protocol = { path = "../protocol", version = "0.8.39" }
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -9,7 +9,7 @@ description = "Tool invocation lifecycle, schema validation, and scheduler paral
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
-deepseek-protocol = { path = "../protocol", version = "0.8.38" }
+deepseek-protocol = { path = "../protocol", version = "0.8.39" }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -12,6 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Feishu/Lark bridge startup order is guarded.** The bridge now keeps
   `ThreadStore` initialized before startup opens persisted thread state, with a
   regression test to prevent moving it below its first use.
+- **`/model` picker opens instantly with the curated list again.** Reverted
+  the v0.8.38 live-catalog rework: the picker no longer makes a blocking
+  network call on open and once again shows the curated `auto` /
+  `deepseek-v4-pro` / `deepseek-v4-flash` rows. The `/models` command still
+  lists the live provider catalog.
+- **"Approve for session" groups by command family again.** Session approvals
+  are keyed by a lossy, arity-aware fingerprint once more, so approving
+  `cargo build` also covers `cargo build --release`. Denials keep the exact
+  per-call fingerprint from #1617, so denying one call no longer over-blocks
+  later, different calls to the same tool.
 
 ## [0.8.38] - 2026-05-15
 

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unused optional `file_path` / `content` / `url` fields as empty strings no
   longer trip the "provide exactly one" guard; blank/whitespace-only source
   fields are treated as absent (#1712).
+- **`theme = "system"` follows macOS appearance.** When `COLORFGBG` is unset
+  or ambiguous (e.g. Ghostty), system-theme detection now falls back to the
+  macOS `AppleInterfaceStyle` appearance so Light mode is no longer rendered
+  in dark colors (#1670).
 
 ### Documentation
 

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.39] - 2026-05-17
+
 ### Fixed
 
 - **Feishu/Lark bridge startup order is guarded.** The bridge now keeps
@@ -22,6 +24,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `cargo build` also covers `cargo build --release`. Denials keep the exact
   per-call fingerprint from #1617, so denying one call no longer over-blocks
   later, different calls to the same tool.
+- **`rlm_open` accepts a single source again.** Models that serialize the
+  unused optional `file_path` / `content` / `url` fields as empty strings no
+  longer trip the "provide exactly one" guard; blank/whitespace-only source
+  fields are treated as absent (#1712).
+
+### Documentation
+
+- **`cargo install` documents the Rust 1.88+ requirement.** The primary
+  Cargo install path now notes that older toolchains fail with
+  ``feature `edition2024` is required`` and to run `rustup update` (#1718).
 
 ## [0.8.38] - 2026-05-15
 
@@ -4301,7 +4313,8 @@ Welcome — and thank you.
 - Hooks system and config profiles
 - Example skills and launch assets
 
-[Unreleased]: https://github.com/Hmbown/DeepSeek-TUI/compare/v0.8.38...HEAD
+[Unreleased]: https://github.com/Hmbown/DeepSeek-TUI/compare/v0.8.39...HEAD
+[0.8.39]: https://github.com/Hmbown/DeepSeek-TUI/compare/v0.8.38...v0.8.39
 [0.8.38]: https://github.com/Hmbown/DeepSeek-TUI/compare/v0.8.37...v0.8.38
 [0.8.37]: https://github.com/Hmbown/DeepSeek-TUI/compare/v0.8.36...v0.8.37
 [0.8.36]: https://github.com/Hmbown/DeepSeek-TUI/compare/v0.8.35...v0.8.36

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -32,6 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   or ambiguous (e.g. Ghostty), system-theme detection now falls back to the
   macOS `AppleInterfaceStyle` appearance so Light mode is no longer rendered
   in dark colors (#1670).
+- **Docker first run no longer fails with `Permission denied`.** The image
+  pre-creates `/home/deepseek/.deepseek` owned by the `deepseek` user and
+  declares it as a `VOLUME`, so a named volume mounted there initializes
+  with the container user's ownership instead of root (#1684).
 
 ### Documentation
 

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -21,8 +21,8 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0.100"
 arboard = "3.4"
-deepseek-secrets = { path = "../secrets", version = "0.8.38" }
-deepseek-tools = { path = "../tools", version = "0.8.38" }
+deepseek-secrets = { path = "../secrets", version = "0.8.39" }
+deepseek-tools = { path = "../tools", version = "0.8.39" }
 schemaui = { version = "0.12.0", default-features = false, optional = true }
 async-stream = "0.3.6"
 async-trait = "0.1"

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -1597,6 +1597,12 @@ impl Engine {
                                 &tool_input,
                             )
                             .0;
+                            let approval_grouping_key =
+                                crate::tools::approval_cache::build_approval_grouping_key(
+                                    &tool_name,
+                                    &tool_input,
+                                )
+                                .0;
                             let _ = self
                                 .tx_event
                                 .send(Event::ApprovalRequired {
@@ -1604,6 +1610,7 @@ impl Engine {
                                     tool_name: tool_name.clone(),
                                     description: plan.approval_description.clone(),
                                     approval_key,
+                                    approval_grouping_key,
                                 })
                                 .await;
 

--- a/crates/tui/src/core/events.rs
+++ b/crates/tui/src/core/events.rs
@@ -226,8 +226,11 @@ pub enum Event {
         id: String,
         tool_name: String,
         description: String,
-        /// Fingerprint key for per‑call approval caching (§5.A).
+        /// Exact-argument fingerprint, used to scope *denials* (#1617).
         approval_key: String,
+        /// Lossy / arity-aware fingerprint, used to scope *approvals* so an
+        /// "approve for session" covers later flag variants (v0.8.37).
+        approval_grouping_key: String,
     },
 
     /// Request user input for a tool call

--- a/crates/tui/src/palette.rs
+++ b/crates/tui/src/palette.rs
@@ -264,14 +264,53 @@ impl PaletteMode {
         Some(if bg >= 8 { Self::Light } else { Self::Dark })
     }
 
-    /// Detect whether the terminal profile is light. Missing or unparsable
-    /// values default to dark so existing terminal setups keep the tuned theme.
+    /// Map the output of `defaults read -g AppleInterfaceStyle` to a mode.
+    /// macOS only sets the key in Dark mode (`Some("Dark")`); in Light mode
+    /// the key is absent and the `defaults` invocation fails, which we model
+    /// as `None` and treat as Light (#1670).
+    #[must_use]
+    pub fn from_apple_interface_style(value: Option<&str>) -> Self {
+        match value {
+            Some(v) if v.trim().eq_ignore_ascii_case("dark") => Self::Dark,
+            Some(_) | None => Self::Light,
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    fn detect_macos_appearance() -> Option<Self> {
+        let output = std::process::Command::new("defaults")
+            .args(["read", "-g", "AppleInterfaceStyle"])
+            .output()
+            .ok()?;
+        let style = output
+            .status
+            .success()
+            .then(|| String::from_utf8_lossy(&output.stdout).into_owned());
+        Some(Self::from_apple_interface_style(style.as_deref()))
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    fn detect_macos_appearance() -> Option<Self> {
+        None
+    }
+
+    /// Detect whether the terminal profile is light. `COLORFGBG` wins when
+    /// present and parsable (it reflects the explicit terminal palette). When
+    /// it is missing or ambiguous, fall back to the macOS system appearance
+    /// (#1670). Anything still unresolved defaults to dark so existing
+    /// terminal setups keep the tuned theme.
     #[must_use]
     pub fn detect() -> Self {
-        std::env::var("COLORFGBG")
+        if let Some(mode) = std::env::var("COLORFGBG")
             .ok()
             .and_then(|value| Self::from_colorfgbg(&value))
-            .unwrap_or(Self::Dark)
+        {
+            return mode;
+        }
+        if let Some(mode) = Self::detect_macos_appearance() {
+            return mode;
+        }
+        Self::Dark
     }
 }
 
@@ -540,7 +579,7 @@ impl ThemeId {
     #[must_use]
     pub const fn tagline(self) -> &'static str {
         match self {
-            Self::System => "Follow terminal background (COLORFGBG)",
+            Self::System => "Follow terminal background, then OS appearance",
             Self::Whale => "Default DeepSeek dark blue",
             Self::WhaleLight => "DeepSeek light, paper-ish",
             Self::Grayscale => "Color-minimal high contrast",
@@ -1331,6 +1370,28 @@ mod tests {
             Some(PaletteMode::Light)
         );
         assert_eq!(PaletteMode::from_colorfgbg("not-a-color"), None);
+    }
+
+    #[test]
+    fn apple_interface_style_absent_key_is_light() {
+        // macOS Light mode: `defaults read -g AppleInterfaceStyle` fails and
+        // we model that as `None` (#1670).
+        assert_eq!(
+            PaletteMode::from_apple_interface_style(None),
+            PaletteMode::Light
+        );
+        assert_eq!(
+            PaletteMode::from_apple_interface_style(Some("Dark\n")),
+            PaletteMode::Dark
+        );
+        assert_eq!(
+            PaletteMode::from_apple_interface_style(Some("  dark ")),
+            PaletteMode::Dark
+        );
+        assert_eq!(
+            PaletteMode::from_apple_interface_style(Some("")),
+            PaletteMode::Light
+        );
     }
 
     #[test]

--- a/crates/tui/src/palette.rs
+++ b/crates/tui/src/palette.rs
@@ -276,8 +276,13 @@ impl PaletteMode {
         }
     }
 
-    #[cfg(target_os = "macos")]
     fn detect_macos_appearance() -> Option<Self> {
+        // Runtime `cfg!` (not `#[cfg]`) so `from_apple_interface_style`
+        // stays referenced on every platform and does not trip the
+        // dead-code lint on non-macOS builds.
+        if !cfg!(target_os = "macos") {
+            return None;
+        }
         let output = std::process::Command::new("defaults")
             .args(["read", "-g", "AppleInterfaceStyle"])
             .output()
@@ -287,11 +292,6 @@ impl PaletteMode {
             .success()
             .then(|| String::from_utf8_lossy(&output.stdout).into_owned());
         Some(Self::from_apple_interface_style(style.as_deref()))
-    }
-
-    #[cfg(not(target_os = "macos"))]
-    fn detect_macos_appearance() -> Option<Self> {
-        None
     }
 
     /// Detect whether the terminal profile is light. `COLORFGBG` wins when

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -4154,6 +4154,7 @@ mod tests {
             .tx_event
             .send(EngineEvent::ApprovalRequired {
                 approval_key: "test_key".to_string(),
+                approval_grouping_key: "test_key".to_string(),
                 id: "tool_stale".to_string(),
                 tool_name: "exec_command".to_string(),
                 description: "stale approval".to_string(),
@@ -4226,6 +4227,7 @@ mod tests {
             .tx_event
             .send(EngineEvent::ApprovalRequired {
                 approval_key: "key1".to_string(),
+                approval_grouping_key: "key1".to_string(),
                 id: "tool_external_allow".to_string(),
                 tool_name: "exec_command".to_string(),
                 description: "external allow".to_string(),
@@ -4302,6 +4304,7 @@ mod tests {
             .tx_event
             .send(EngineEvent::ApprovalRequired {
                 approval_key: "key2".to_string(),
+                approval_grouping_key: "key2".to_string(),
                 id: "tool_external_deny".to_string(),
                 tool_name: "exec_command".to_string(),
                 description: "external deny".to_string(),
@@ -4487,6 +4490,7 @@ mod tests {
             .tx_event
             .send(EngineEvent::ApprovalRequired {
                 approval_key: "key3".to_string(),
+                approval_grouping_key: "key3".to_string(),
                 id: "tool_remember".to_string(),
                 tool_name: "exec_command".to_string(),
                 description: "remember=true".to_string(),

--- a/crates/tui/src/tools/approval_cache.rs
+++ b/crates/tui/src/tools/approval_cache.rs
@@ -395,7 +395,8 @@ mod tests {
     #[test]
     fn denial_key_stays_exact_while_grouping_key_collapses() {
         let exact_a = build_approval_key("exec_shell", &json!({"command": "cargo build"}));
-        let exact_b = build_approval_key("exec_shell", &json!({"command": "cargo build --release"}));
+        let exact_b =
+            build_approval_key("exec_shell", &json!({"command": "cargo build --release"}));
         assert_ne!(exact_a, exact_b, "denials must remain exact-call scoped");
 
         let group_a = build_approval_grouping_key("exec_shell", &json!({"command": "cargo build"}));

--- a/crates/tui/src/tools/approval_cache.rs
+++ b/crates/tui/src/tools/approval_cache.rs
@@ -6,14 +6,31 @@
 //! cache keys off a **call fingerprint** — a digest of the tool name and
 //! the semantically‑relevant portion of its arguments.
 //!
-//! ## Fingerprint shape
+//! ## Two fingerprint shapes
 //!
-//! | Tool           | Key                                      |
-//! |---------------|------------------------------------------|
-//! | file writes    | `file:<tool_name>:<hash of args>`        |
-//! | shell tools    | `shell:<tool_name>:<hash of args>`       |
-//! | `fetch_url`    | `net:<hostname>`                         |
-//! | everything else| `tool:<tool_name>:<hash of input>`       |
+//! There are two key flavours, used for opposite sides of the decision:
+//!
+//! * [`build_approval_key`] — an **exact** digest of the full arguments.
+//!   Used to scope *denials* so that denying one call (e.g. `rm -rf /tmp/x`)
+//!   does not also suppress a later, different call to the same tool (#1617).
+//!
+//!   | Tool           | Exact key                                |
+//!   |---------------|------------------------------------------|
+//!   | file writes    | `file:<tool_name>:<hash of args>`        |
+//!   | shell tools    | `shell:<tool_name>:<hash of args>`       |
+//!   | `fetch_url`    | `net:<hostname>`                         |
+//!   | everything else| `tool:<tool_name>:<hash of input>`       |
+//!
+//! * [`build_approval_grouping_key`] — a **lossy / arity-aware** digest.
+//!   Used to scope *approvals* so that approving `cargo build` for the
+//!   session also covers `cargo build --release` (the v0.8.37 behaviour).
+//!
+//!   | Tool           | Grouping key                             |
+//!   |---------------|------------------------------------------|
+//!   | `apply_patch`  | `patch:<hash of file paths>`             |
+//!   | shell tools    | `shell:<command prefix>`                 |
+//!   | `fetch_url`    | `net:<hostname>`                         |
+//!   | everything else| `tool:<tool_name>:<hash of input>`       |
 //!
 //! The cache is **session‑keyed**: entries carry an
 //! `ApprovedForSession` flag. When true, the approval is reused for the
@@ -26,6 +43,8 @@ use std::time::Instant;
 
 use serde_json::Value;
 use sha2::{Digest, Sha256};
+
+use crate::command_safety::classify_command;
 
 /// The fingerprint of a tool call — stable enough to match repeated
 /// calls but specific enough to avoid privilege confusion.
@@ -139,6 +158,86 @@ pub fn build_approval_key(tool_name: &str, input: &serde_json::Value) -> Approva
         _ => format!("tool:{tool_name}:{}", hash_json_value(input)),
     };
     ApprovalKey(fingerprint)
+}
+
+/// Build the **grouping** approval key for a tool call.
+///
+/// Unlike [`build_approval_key`], this collapses argument variants of the
+/// same command family onto one key (the v0.8.37 behaviour) so that an
+/// "approve for session" decision covers later invocations that differ only
+/// by flags. Denials must keep using the exact [`build_approval_key`].
+#[must_use]
+pub fn build_approval_grouping_key(tool_name: &str, input: &serde_json::Value) -> ApprovalKey {
+    let fingerprint = match tool_name {
+        "apply_patch" => {
+            let paths_hash = hash_patch_paths(input);
+            format!("patch:{paths_hash}")
+        }
+        "exec_shell"
+        | "task_shell_start"
+        | "exec_shell_wait"
+        | "exec_shell_interact"
+        | "exec_wait"
+        | "exec_interact" => {
+            let prefix = command_prefix(input);
+            format!("shell:{prefix}")
+        }
+        "fetch_url" | "web.fetch" | "web_fetch" => {
+            let host = parse_host(input);
+            format!("net:{host}")
+        }
+        _ => format!("tool:{tool_name}:{}", hash_json_value(input)),
+    };
+    ApprovalKey(fingerprint)
+}
+
+/// Return the canonical command prefix for the shell command in `input`.
+///
+/// Uses [`classify_command`] from the arity dictionary so that approving
+/// `git status` also covers `git status -s` / `git status --porcelain`
+/// without also covering `git push`.
+fn command_prefix(input: &serde_json::Value) -> String {
+    let cmd = input.get("command").and_then(|v| v.as_str()).unwrap_or("");
+    let tokens: Vec<&str> = cmd.split_whitespace().collect();
+    if tokens.is_empty() {
+        return "<empty>".to_string();
+    }
+    classify_command(&tokens)
+}
+
+/// Hash the sorted set of file paths referenced by a patch input.
+fn hash_patch_paths(input: &serde_json::Value) -> String {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let mut paths: Vec<&str> = Vec::new();
+
+    if let Some(changes) = input.get("changes").and_then(|v| v.as_array()) {
+        for change in changes {
+            if let Some(path) = change.get("path").and_then(|v| v.as_str()) {
+                paths.push(path);
+            }
+        }
+    } else if let Some(patch_text) = input.get("patch").and_then(|v| v.as_str()) {
+        for line in patch_text.lines() {
+            if let Some(rest) = line.strip_prefix("+++ b/") {
+                paths.push(rest.trim());
+            }
+        }
+    }
+
+    paths.sort();
+    paths.dedup();
+
+    if paths.is_empty() {
+        return "no_files".to_string();
+    }
+
+    let mut hasher = DefaultHasher::new();
+    for path in &paths {
+        path.hash(&mut hasher);
+    }
+    format!("{:x}", hasher.finish())
 }
 
 /// Parse the host portion from a URL input.
@@ -257,6 +356,52 @@ mod tests {
         let key_a = build_approval_key("exec_shell", &json!({"command": "cargo build"}));
         let key_b = build_approval_key("exec_shell", &json!({"command": "cargo build --release"}));
         assert_ne!(key_a, key_b);
+    }
+
+    #[test]
+    fn grouping_key_collapses_shell_flag_variants() {
+        let key_a = build_approval_grouping_key("exec_shell", &json!({"command": "cargo build"}));
+        let key_b =
+            build_approval_grouping_key("exec_shell", &json!({"command": "cargo build --release"}));
+        assert_eq!(
+            key_a, key_b,
+            "approving a command family must cover later flag variants"
+        );
+    }
+
+    #[test]
+    fn grouping_key_still_separates_distinct_commands() {
+        let key_a = build_approval_grouping_key("exec_shell", &json!({"command": "git status"}));
+        let key_b = build_approval_grouping_key("exec_shell", &json!({"command": "git push"}));
+        assert_ne!(key_a, key_b);
+    }
+
+    #[test]
+    fn grouping_key_collapses_patch_body_for_same_path() {
+        let key_a = build_approval_grouping_key(
+            "apply_patch",
+            &json!({"changes": [{"path": "a.rs", "content": "x"}]}),
+        );
+        let key_b = build_approval_grouping_key(
+            "apply_patch",
+            &json!({"changes": [{"path": "a.rs", "content": "y"}]}),
+        );
+        assert_eq!(
+            key_a, key_b,
+            "approving a patch family must cover later edits to the same path"
+        );
+    }
+
+    #[test]
+    fn denial_key_stays_exact_while_grouping_key_collapses() {
+        let exact_a = build_approval_key("exec_shell", &json!({"command": "cargo build"}));
+        let exact_b = build_approval_key("exec_shell", &json!({"command": "cargo build --release"}));
+        assert_ne!(exact_a, exact_b, "denials must remain exact-call scoped");
+
+        let group_a = build_approval_grouping_key("exec_shell", &json!({"command": "cargo build"}));
+        let group_b =
+            build_approval_grouping_key("exec_shell", &json!({"command": "cargo build --release"}));
+        assert_eq!(group_a, group_b, "approvals must group by command family");
     }
 
     #[test]

--- a/crates/tui/src/tools/rlm.rs
+++ b/crates/tui/src/tools/rlm.rs
@@ -83,7 +83,7 @@ impl ToolSpec for RlmOpenTool {
     async fn execute(&self, input: Value, context: &ToolContext) -> Result<ToolResult, ToolError> {
         let source_count = ["file_path", "content", "url"]
             .iter()
-            .filter(|key| input.get(**key).and_then(Value::as_str).is_some())
+            .filter(|key| non_empty_source(&input, key).is_some())
             .count();
         if source_count != 1 {
             return Err(ToolError::invalid_input(
@@ -417,7 +417,7 @@ async fn load_source(
     input: &Value,
     context: &ToolContext,
 ) -> Result<(String, String, Option<String>), ToolError> {
-    if let Some(path) = input.get("file_path").and_then(Value::as_str) {
+    if let Some(path) = non_empty_source(input, "file_path") {
         let resolved = context.resolve_path(path)?;
         let body = tokio::fs::read_to_string(&resolved).await.map_err(|e| {
             ToolError::execution_failed(format!("rlm_open: read {}: {e}", resolved.display()))
@@ -425,7 +425,7 @@ async fn load_source(
         return Ok((body, "file".to_string(), Some(path.to_string())));
     }
 
-    if let Some(content) = input.get("content").and_then(Value::as_str) {
+    if let Some(content) = non_empty_source(input, "content") {
         if content.chars().count() > MAX_INLINE_CONTENT_CHARS {
             return Err(ToolError::invalid_input(format!(
                 "rlm_open: inline content is {} chars (cap {MAX_INLINE_CONTENT_CHARS})",
@@ -435,9 +435,7 @@ async fn load_source(
         return Ok((content.to_string(), "content".to_string(), None));
     }
 
-    let url = input
-        .get("url")
-        .and_then(Value::as_str)
+    let url = non_empty_source(input, "url")
         .ok_or_else(|| ToolError::invalid_input("rlm_open: missing source"))?;
     let result = FetchUrlTool
         .execute(json!({"url": url, "format": "raw"}), context)
@@ -466,6 +464,17 @@ async fn get_session(
     sessions.get(name).cloned().ok_or_else(|| {
         ToolError::invalid_input(format!("unknown RLM context `{name}`; call rlm_open first"))
     })
+}
+
+/// Return the raw string at `field` only when it is present and not
+/// whitespace-only. Some models/runtimes serialize omitted optional string
+/// fields as `""`, so a strict presence check would treat every source as
+/// supplied and fail the "exactly one" guard (#1712).
+fn non_empty_source<'a>(input: &'a Value, field: &str) -> Option<&'a str> {
+    input
+        .get(field)
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
 }
 
 fn required_non_empty_str<'a>(input: &'a Value, field: &str) -> Result<&'a str, ToolError> {
@@ -517,6 +526,38 @@ mod tests {
         assert_eq!(RlmEvalTool::new(None).name(), "rlm_eval");
         assert_eq!(RlmConfigureTool.name(), "rlm_configure");
         assert_eq!(RlmCloseTool.name(), "rlm_close");
+    }
+
+    #[test]
+    fn non_empty_source_treats_blank_strings_as_absent() {
+        let input = json!({"file_path": "", "content": "   ", "url": "https://x"});
+        assert_eq!(non_empty_source(&input, "file_path"), None);
+        assert_eq!(non_empty_source(&input, "content"), None);
+        assert_eq!(non_empty_source(&input, "url"), Some("https://x"));
+    }
+
+    #[tokio::test]
+    async fn rlm_open_ignores_blank_sibling_source_fields() {
+        // Regression for #1712: models often serialize the unused optional
+        // source fields as "", which must not trip the "exactly one" guard.
+        let ctx = ctx();
+        RlmOpenTool
+            .execute(
+                json!({
+                    "name": "blank-siblings",
+                    "content": "alpha\nbeta",
+                    "file_path": "",
+                    "url": ""
+                }),
+                &ctx,
+            )
+            .await
+            .expect("open should ignore empty file_path/url siblings");
+
+        RlmCloseTool
+            .execute(json!({"name": "blank-siblings"}), &ctx)
+            .await
+            .expect("close");
     }
 
     #[tokio::test]

--- a/crates/tui/src/tui/approval.rs
+++ b/crates/tui/src/tui/approval.rs
@@ -130,8 +130,11 @@ pub struct ApprovalRequest {
     pub impacts: Vec<String>,
     /// Tool parameters (for display)
     pub params: Value,
-    /// Fingerprint key for per‑call approval caching (§5.A).
+    /// Exact-argument fingerprint, used to scope *denials* (#1617).
     pub approval_key: String,
+    /// Lossy / arity-aware fingerprint, used to scope *approvals* so an
+    /// "approve for session" covers later flag variants (v0.8.37).
+    pub approval_grouping_key: String,
 }
 
 impl ApprovalRequest {
@@ -144,6 +147,8 @@ impl ApprovalRequest {
     ) -> Self {
         let category = get_tool_category(tool_name);
         let risk = classify_risk(tool_name, category, params);
+        let approval_grouping_key =
+            crate::tools::approval_cache::build_approval_grouping_key(tool_name, params).0;
 
         Self {
             id: id.to_string(),
@@ -154,6 +159,7 @@ impl ApprovalRequest {
             impacts: build_impact_summary(tool_name, category, params),
             params: params.clone(),
             approval_key: approval_key.to_string(),
+            approval_grouping_key,
         }
     }
 
@@ -597,6 +603,7 @@ impl ApprovalView {
             decision,
             timed_out,
             approval_key: self.request.approval_key.clone(),
+            approval_grouping_key: self.request.approval_grouping_key.clone(),
         })
     }
 

--- a/crates/tui/src/tui/model_picker.rs
+++ b/crates/tui/src/tui/model_picker.rs
@@ -25,40 +25,18 @@ use ratatui::{
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph, Widget},
 };
-use std::collections::HashSet;
 
-use crate::config::{
-    ApiProvider, model_completion_names_for_provider, provider_passes_model_through,
-};
 use crate::palette;
 use crate::tui::app::{App, ReasoningEffort};
 use crate::tui::views::{ModalKind, ModalView, ViewAction, ViewEvent};
 
-fn picker_models_for_provider(provider: ApiProvider) -> Vec<(String, String)> {
-    let mut rows = vec![("auto".to_string(), "select per turn".to_string())];
-    if provider_passes_model_through(provider) {
-        return rows;
-    }
-    rows.extend(
-        model_completion_names_for_provider(provider)
-            .into_iter()
-            .map(|id| (id.to_string(), String::new())),
-    );
-    rows
-}
-
-fn picker_rows_from_model_ids(model_ids: Vec<String>) -> Vec<(String, String)> {
-    let mut rows = vec![("auto".to_string(), "select per turn".to_string())];
-    let mut seen = HashSet::from(["auto".to_string()]);
-    for model_id in model_ids {
-        let id = model_id.trim();
-        if id.is_empty() || !seen.insert(id.to_string()) {
-            continue;
-        }
-        rows.push((id.to_string(), String::new()));
-    }
-    rows
-}
+/// Models the picker exposes by default. Kept short on purpose — power
+/// users can still type `/model <id>` for anything else.
+const PICKER_MODELS: &[(&str, &str)] = &[
+    ("auto", "select per turn"),
+    ("deepseek-v4-pro", "flagship"),
+    ("deepseek-v4-flash", "fast / cheap"),
+];
 
 /// Thinking-effort rows shown in the picker, in the order DeepSeek
 /// behaviorally distinguishes them.
@@ -78,7 +56,6 @@ enum Pane {
 pub struct ModelPickerView {
     initial_model: String,
     initial_effort: ReasoningEffort,
-    model_rows: Vec<(String, String)>,
     /// Working selection (separate from the initial values so we can offer a
     /// clean Esc-to-cancel without mutating App state).
     selected_model_idx: usize,
@@ -87,29 +64,30 @@ pub struct ModelPickerView {
     /// True when the active model is one we don't list — we still show it
     /// so the picker doesn't quietly forget the user's chosen IDs.
     show_custom_model_row: bool,
+    /// When true, hide DeepSeek-specific model rows (pass-through providers
+    /// like openai don't support them).
+    hide_deepseek_models: bool,
 }
 
 impl ModelPickerView {
     #[must_use]
     pub fn new(app: &App) -> Self {
-        Self::new_with_rows(app, picker_models_for_provider(app.api_provider))
-    }
-
-    #[must_use]
-    pub fn new_with_models(app: &App, model_ids: Vec<String>) -> Self {
-        Self::new_with_rows(app, picker_rows_from_model_ids(model_ids))
-    }
-
-    fn new_with_rows(app: &App, model_rows: Vec<(String, String)>) -> Self {
+        let hide_deepseek_models = crate::config::provider_passes_model_through(app.api_provider);
         let initial_model = if app.auto_model {
             "auto".to_string()
         } else {
             app.model.clone()
         };
-        let mut selected_model_idx = model_rows.iter().position(|(id, _)| *id == initial_model);
+        // On pass-through providers, only show "auto" and the custom row.
+        let visible_models: Vec<&str> = if hide_deepseek_models {
+            vec!["auto"]
+        } else {
+            PICKER_MODELS.iter().map(|(id, _)| *id).collect()
+        };
+        let mut selected_model_idx = visible_models.iter().position(|id| *id == initial_model);
         let show_custom_model_row = selected_model_idx.is_none();
         if show_custom_model_row {
-            selected_model_idx = Some(model_rows.len());
+            selected_model_idx = Some(visible_models.len());
         }
         let selected_model_idx = selected_model_idx.unwrap_or(0);
 
@@ -127,26 +105,35 @@ impl ModelPickerView {
         Self {
             initial_model,
             initial_effort,
-            model_rows,
             selected_model_idx,
             selected_effort_idx,
             focus: Pane::Model,
             show_custom_model_row,
+            hide_deepseek_models,
+        }
+    }
+
+    fn visible_model_ids(&self) -> Vec<&'static str> {
+        if self.hide_deepseek_models {
+            vec!["auto"]
+        } else {
+            PICKER_MODELS.iter().map(|(id, _)| *id).collect()
         }
     }
 
     fn model_row_count(&self) -> usize {
-        self.model_rows.len() + if self.show_custom_model_row { 1 } else { 0 }
+        self.visible_model_ids().len() + if self.show_custom_model_row { 1 } else { 0 }
     }
 
     /// Resolve the currently highlighted model row to a model id. If the
     /// custom row is selected we return the original model from the App so
     /// "Apply" doesn't blow away an unrecognised id.
     fn resolved_model(&self) -> String {
-        if self.show_custom_model_row && self.selected_model_idx == self.model_rows.len() {
+        let visible = self.visible_model_ids();
+        if self.show_custom_model_row && self.selected_model_idx == visible.len() {
             self.initial_model.clone()
-        } else if let Some((model, _)) = self.model_rows.get(self.selected_model_idx) {
-            model.clone()
+        } else if self.selected_model_idx < visible.len() {
+            visible[self.selected_model_idx].to_string()
         } else {
             self.initial_model.clone()
         }
@@ -337,7 +324,14 @@ impl ModalView for ModelPickerView {
             .constraints([Constraint::Percentage(60), Constraint::Percentage(40)])
             .split(inner);
 
-        let mut model_rows = self.model_rows.clone();
+        let mut model_rows: Vec<(String, String)> = if self.hide_deepseek_models {
+            vec![("auto".to_string(), "select per turn".to_string())]
+        } else {
+            PICKER_MODELS
+                .iter()
+                .map(|(id, hint)| ((*id).to_string(), (*hint).to_string()))
+                .collect()
+        };
         if self.show_custom_model_row {
             model_rows.push((self.initial_model.clone(), "current (custom)".to_string()));
         }
@@ -478,8 +472,7 @@ mod tests {
 
     #[test]
     fn picker_exposes_auto_and_distinct_thinking_tiers() {
-        let model_rows = picker_models_for_provider(crate::config::ApiProvider::Deepseek);
-        let model_labels: Vec<_> = model_rows.iter().map(|(id, _)| id.as_str()).collect();
+        let model_labels: Vec<_> = PICKER_MODELS.iter().map(|(id, _)| *id).collect();
         assert_eq!(
             model_labels,
             vec!["auto", "deepseek-v4-pro", "deepseek-v4-flash"]
@@ -500,26 +493,6 @@ mod tests {
         let view = ModelPickerView::new(&app);
         assert!(view.show_custom_model_row);
         assert_eq!(view.resolved_model(), "deepseek-v4-pro-2026-04-XX");
-    }
-
-    #[test]
-    fn picker_uses_live_provider_model_ids_when_supplied() {
-        let (mut app, _lock) = create_test_app();
-        app.api_provider = crate::config::ApiProvider::Openrouter;
-        app.model = "meta-llama/llama-3.1-405b-instruct".to_string();
-        app.auto_model = false;
-
-        let view = ModelPickerView::new_with_models(
-            &app,
-            vec![
-                "deepseek/deepseek-chat-v3.1".to_string(),
-                "meta-llama/llama-3.1-405b-instruct".to_string(),
-                "qwen/qwen3-coder".to_string(),
-            ],
-        );
-
-        assert!(!view.show_custom_model_row);
-        assert_eq!(view.resolved_model(), "meta-llama/llama-3.1-405b-instruct");
     }
 
     #[test]

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -150,8 +150,8 @@ const PERIODIC_FULL_REPAINT_EVERY_N: u64 = 50;
 const TURN_META_PREFIX: &str = "<turn_meta>";
 const SESSION_TITLE_MAX_CHARS: usize = 32;
 
-fn is_session_approved_for_tool(app: &App, tool_name: &str, approval_key: &str) -> bool {
-    app.approval_session_approved.contains(approval_key)
+fn is_session_approved_for_tool(app: &App, tool_name: &str, grouping_key: &str) -> bool {
+    app.approval_session_approved.contains(grouping_key)
         || app.approval_session_approved.contains(tool_name)
 }
 
@@ -1694,9 +1694,10 @@ async fn run_event_loop(
                         tool_name,
                         description,
                         approval_key,
+                        approval_grouping_key,
                     } => {
                         let session_approved =
-                            is_session_approved_for_tool(app, &tool_name, &approval_key);
+                            is_session_approved_for_tool(app, &tool_name, &approval_grouping_key);
                         let session_denied = is_session_denied_for_key(app, &approval_key);
                         if session_denied {
                             // The user already said no to this exact tool /
@@ -4518,33 +4519,8 @@ async fn apply_command_result(
             }
             AppAction::OpenModelPicker => {
                 if app.view_stack.top_kind() != Some(ModalKind::ModelPicker) {
-                    app.status_message =
-                        Some(format!("Fetching {} models...", app.api_provider.as_str()));
-                    let picker = match fetch_available_models(config).await {
-                        Ok(models) if !models.is_empty() => {
-                            app.status_message = Some(format!("Found {} model(s)", models.len()));
-                            crate::tui::model_picker::ModelPickerView::new_with_models(app, models)
-                        }
-                        Ok(_) => {
-                            app.status_message = Some(format!(
-                                "{} returned no models; showing defaults",
-                                app.api_provider.as_str()
-                            ));
-                            crate::tui::model_picker::ModelPickerView::new(app)
-                        }
-                        Err(error) => {
-                            app.add_message(HistoryCell::System {
-                                content: format!(
-                                    "Failed to fetch {} models: {error}. Showing built-in defaults.",
-                                    app.api_provider.as_str()
-                                ),
-                            });
-                            app.status_message =
-                                Some("Model fetch failed; showing defaults".to_string());
-                            crate::tui::model_picker::ModelPickerView::new(app)
-                        }
-                    };
-                    app.view_stack.push(picker);
+                    app.view_stack
+                        .push(crate::tui::model_picker::ModelPickerView::new(app));
                 }
             }
             AppAction::OpenProviderPicker => {
@@ -5718,12 +5694,15 @@ async fn handle_view_events(
                 decision,
                 timed_out,
                 approval_key,
+                approval_grouping_key,
             } => {
                 if decision == ReviewDecision::ApprovedForSession {
-                    // Store both the tool name (backward compat) and the
-                    // approval key (fingerprint-based).
+                    // Store the tool name (backward compat) and the lossy
+                    // grouping key so later flag variants of the same
+                    // command family are also auto-approved (v0.8.37).
                     app.approval_session_approved.insert(tool_name.clone());
-                    app.approval_session_approved.insert(approval_key.clone());
+                    app.approval_session_approved
+                        .insert(approval_grouping_key.clone());
                 }
 
                 match decision {

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -92,8 +92,10 @@ pub enum ViewEvent {
         tool_name: String,
         decision: ReviewDecision,
         timed_out: bool,
-        /// Fingerprint key for per‑call approval caching (§5.A).
+        /// Exact-argument fingerprint, used to scope *denials* (#1617).
         approval_key: String,
+        /// Lossy / arity-aware fingerprint, used to scope *approvals*.
+        approval_grouping_key: String,
     },
     ElevationDecision {
         tool_id: String,

--- a/npm/deepseek-tui/package.json
+++ b/npm/deepseek-tui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-tui",
-  "version": "0.8.38",
-  "deepseekBinaryVersion": "0.8.38",
+  "version": "0.8.39",
+  "deepseekBinaryVersion": "0.8.39",
   "description": "Install and run deepseek and deepseek-tui binaries from GitHub release artifacts.",
   "author": "Hmbown",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Investigated the reported "something changed dramatically from v0.8.37 → v0.8.38" regression and fixed it, plus bundled two milestoned v0.8.39 issues and cut the release.

### v0.8.38 regression fixes
- **`/model` picker**: v0.8.38 (#1201/#1632) made the picker do a **blocking network fetch** on open and replaced the curated tier list with the raw provider catalog. Fully reverted to the v0.8.37 instant curated picker (`auto` / `deepseek-v4-pro` / `deepseek-v4-flash`). The separate `/models` command still lists the live catalog.
- **Approval cache**: #1617 rekeyed approvals to an exact full-argument fingerprint, collaterally dropping the v0.8.37 arity-aware command-family grouping for "approve for session". Reintroduced `build_approval_grouping_key` (lossy v0.8.37 logic) for **approvals** while keeping the exact key for **denials** — so denying one call no longer over-blocks later differing calls (#1617 intent preserved).

### Bundled issue fixes (milestone v0.8.39)
- **#1712** `rlm_open`: models that serialize unused optional `file_path`/`content`/`url` as `""` no longer trip the "provide exactly one" guard — blank/whitespace-only sources are treated as absent.
- **#1718** README: the primary `cargo install` path now documents the Rust 1.88+ requirement (older toolchains fail with `` feature `edition2024` is required ``).

### Release
- `chore(release): prepare v0.8.39` — version bump across workspace/inter-crate/npm manifests + Cargo.lock, CHANGELOG `[Unreleased]` rolled into `[0.8.39] - 2026-05-17` (both root and packaged TUI changelog).

## Investigated but intentionally deferred (need maintainer decision)
- **#1696** ACP JSON-RPC `id` type: the server already echoes the request `id` verbatim. Zed wants a string; coercing all ids to strings is a JSON-RPC-spec-vs-interop tradeoff that could regress spec-compliant clients — needs a maintainer call.
- **#1688** runtime API `system_prompt` discarded: well-diagnosed, but the fix touches the core system-prompt pipeline and requires distinguishing a user override from a restored full prompt — architecturally significant, deferred to avoid a broad regression in this release.

## Test plan
- [x] `cargo check --workspace --tests` clean
- [x] approval_cache: 17/17 (incl. new grouping/denial-separation tests)
- [x] model_picker: 11/11 (v0.8.37 suite restored)
- [x] all approval tests: 91/91
- [x] rlm: 7/7 (incl. new blank-source regression tests)
- [x] workspace builds clean at v0.8.39

Note: `cargo`/`npm` publish is intentionally **not** done here (credentials live on the maintainer's machine). This PR is everything up to the publish step.

https://claude.ai/code/session_01NDuRxM56o17SE7SDLcTFYT

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDuRxM56o17SE7SDLcTFYT)_