### PR TITLE
fix(config): honor explicit custom model for non-DeepSeek providers (#1714)

### DIFF
--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -1487,6 +1487,17 @@ impl Config {
             if let Some(normalized) = normalize_model_for_provider(provider, model) {
                 return normalized;
             }
+            // An explicit provider-scoped model that is not a recognized
+            // DeepSeek alias is a deliberate custom choice for a non-DeepSeek
+            // provider (e.g. `MiniMax-M2.7` on an OpenAI-compatible endpoint).
+            // It must pass through verbatim rather than fall back to a
+            // DeepSeek/provider default (issue #1714).
+            if !matches!(provider, ApiProvider::Deepseek | ApiProvider::DeepseekCN) {
+                let trimmed = model.trim();
+                if !trimmed.is_empty() {
+                    return trimmed.to_string();
+                }
+            }
         }
         if let Some(model) = self.default_text_model.as_deref()
             && (provider_passes_model_through(provider)
@@ -2365,7 +2376,36 @@ fn apply_env_overrides(config: &mut Config) {
     if let Ok(value) =
         std::env::var("DEEPSEEK_MODEL").or_else(|_| std::env::var("DEEPSEEK_DEFAULT_TEXT_MODEL"))
     {
-        config.default_text_model = Some(value);
+        // The CLI `--model` handoff always sets DEEPSEEK_MODEL, never the
+        // provider-specific *_MODEL var. The legacy root `default_text_model`
+        // is a DeepSeek-only slot (the validator rejects non-DeepSeek IDs
+        // there). For a non-DeepSeek provider the explicit model must land in
+        // the provider-scoped slot instead so the verbatim-passthrough path
+        // honors it rather than falling back to a DeepSeek/provider default
+        // (issue #1714). Mirror the OPENAI_MODEL branch above for every
+        // non-DeepSeek provider.
+        let provider = config.api_provider();
+        if matches!(provider, ApiProvider::Deepseek | ApiProvider::DeepseekCN) {
+            config.default_text_model = Some(value);
+        } else {
+            let providers = config
+                .providers
+                .get_or_insert_with(ProvidersConfig::default);
+            let entry = match provider {
+                ApiProvider::Deepseek => &mut providers.deepseek,
+                ApiProvider::DeepseekCN => &mut providers.deepseek_cn,
+                ApiProvider::NvidiaNim => &mut providers.nvidia_nim,
+                ApiProvider::Openai => &mut providers.openai,
+                ApiProvider::Atlascloud => &mut providers.atlascloud,
+                ApiProvider::Openrouter => &mut providers.openrouter,
+                ApiProvider::Novita => &mut providers.novita,
+                ApiProvider::Fireworks => &mut providers.fireworks,
+                ApiProvider::Sglang => &mut providers.sglang,
+                ApiProvider::Vllm => &mut providers.vllm,
+                ApiProvider::Ollama => &mut providers.ollama,
+            };
+            entry.model = Some(value);
+        }
     }
     if matches!(config.api_provider(), ApiProvider::NvidiaNim)
         && let Ok(value) = std::env::var("NVIDIA_NIM_MODEL")
@@ -5096,6 +5136,64 @@ model = "glm-5"
             "https://openai-compatible.example/api/coding/paas/v4"
         );
         assert_eq!(config.default_model(), "glm-5");
+        Ok(())
+    }
+
+    // Regression for issue #1714: `deepseek --provider openai --model
+    // MiniMax-M2.7` forwards the choice via DEEPSEEK_MODEL (never
+    // OPENAI_MODEL) and uses the DEFAULT base_url. The explicit custom model
+    // must pass through verbatim instead of silently becoming a
+    // DeepSeek/provider default.
+    #[test]
+    fn deepseek_model_env_passes_custom_model_through_for_non_deepseek_providers() -> Result<()> {
+        let _lock = lock_test_env();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let temp_root = env::temp_dir().join(format!(
+            "deepseek-tui-1714-passthrough-{}-{}",
+            std::process::id(),
+            nanos
+        ));
+        fs::create_dir_all(&temp_root)?;
+
+        // (a) provider=openai + model="MiniMax-M2.7" via env, NO OPENAI_MODEL,
+        // DEFAULT base_url.
+        {
+            let _guard = EnvGuard::new(&temp_root);
+            // Safety: test-only environment mutation guarded by a global mutex.
+            unsafe {
+                env::set_var("DEEPSEEK_PROVIDER", "openai");
+                env::set_var("OPENAI_API_KEY", "openai-env-key");
+                env::set_var("DEEPSEEK_MODEL", "MiniMax-M2.7");
+            }
+
+            let config = Config::load(None, None)?;
+            assert_eq!(config.api_provider(), ApiProvider::Openai);
+            assert_eq!(config.deepseek_base_url(), DEFAULT_OPENAI_BASE_URL);
+            assert_eq!(config.default_model(), "MiniMax-M2.7");
+        }
+
+        // (b) a non-passthrough provider (novita) with an unknown custom model
+        // and the DEFAULT base_url must also be preserved verbatim — never
+        // rewritten to DEFAULT_NOVITA_MODEL.
+        {
+            let _guard = EnvGuard::new(&temp_root);
+            // Safety: test-only environment mutation guarded by a global mutex.
+            unsafe {
+                env::set_var("DEEPSEEK_PROVIDER", "novita");
+                env::set_var("NOVITA_API_KEY", "novita-env-key");
+                env::set_var("DEEPSEEK_MODEL", "MiniMax-M2.7");
+            }
+
+            let config = Config::load(None, None)?;
+            assert_eq!(config.api_provider(), ApiProvider::Novita);
+            assert_eq!(config.deepseek_base_url(), DEFAULT_NOVITA_BASE_URL);
+            assert_ne!(config.default_model(), DEFAULT_NOVITA_MODEL);
+            assert_eq!(config.default_model(), "MiniMax-M2.7");
+        }
+
         Ok(())
     }
 

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -2392,8 +2392,7 @@ fn apply_env_overrides(config: &mut Config) {
                 .providers
                 .get_or_insert_with(ProvidersConfig::default);
             let entry = match provider {
-                ApiProvider::Deepseek => &mut providers.deepseek,
-                ApiProvider::DeepseekCN => &mut providers.deepseek_cn,
+                ApiProvider::Deepseek | ApiProvider::DeepseekCN => unreachable!("DeepSeek providers are handled in the if branch above (issue #1714)"),
                 ApiProvider::NvidiaNim => &mut providers.nvidia_nim,
                 ApiProvider::Openai => &mut providers.openai,
                 ApiProvider::Atlascloud => &mut providers.atlascloud,


### PR DESCRIPTION
## Summary / 概述

**EN:** Fixes #1714. An explicit custom model for a non‑DeepSeek provider (e.g. `deepseek --provider openai --model MiniMax-M2.7`) was silently replaced by a DeepSeek/provider default, so the configured model never reached the endpoint. This PR makes an explicitly‑chosen custom model pass through verbatim for every non‑DeepSeek provider.

**中文：** 修复 #1714。当使用非 DeepSeek 提供方并显式指定自定义模型时（例如 `deepseek --provider openai --model MiniMax-M2.7`），配置的模型名会被静默替换为 DeepSeek/提供方默认值，导致请求实际发送的并不是用户指定的模型。本 PR 让任何非 DeepSeek 提供方下显式指定的自定义模型**原样透传**。

## Root cause / 根因

**EN:** The CLI `--model` handoff only ever exports `DEEPSEEK_MODEL` (never the provider‑specific `*_MODEL` var). In `apply_env_overrides`, `DEEPSEEK_MODEL` was funneled into the root `default_text_model` slot — a DeepSeek‑only slot the validator rejects for non‑DeepSeek IDs. `Config::default_model()` then treated it as a weak, normalizable default and, for an unrecognized custom model on a non‑DeepSeek provider, fell through to a DeepSeek/provider default instead of returning the user's string. This matches the maintainer's own suspicion in the v0.8.40 audit (#1736): *“explicit `DEEPSEEK_MODEL` or `--model` getting overridden later by `settings.provider_models` or provider‑switch state.”*

**中文：** CLI 的 `--model` 透传只会导出 `DEEPSEEK_MODEL`（永远不会导出提供方专用的 `*_MODEL` 变量）。`apply_env_overrides` 把 `DEEPSEEK_MODEL` 写进了根级 `default_text_model` 槽位——而该槽位是 DeepSeek 专用的，校验器会拒绝非 DeepSeek 的模型 ID。随后 `Config::default_model()` 把它当作一个可被规范化的弱默认值；对于非 DeepSeek 提供方上无法识别的自定义模型，便回退成 DeepSeek/提供方默认值，而不是返回用户指定的字符串。这与维护者在 v0.8.40 审计（#1736）中的判断一致：*“显式的 `DEEPSEEK_MODEL` 或 `--model` 之后被 `settings.provider_models` 或切换提供方的状态覆盖。”*

## Fix / 修复

Two surgical changes in `crates/tui/src/config.rs`, reusing the **existing** provider‑scoped passthrough mechanism (no new code path):

1. `apply_env_overrides`: for a non‑DeepSeek provider, route `DEEPSEEK_MODEL` into the **active provider's** model slot (mirroring the existing `OPENAI_MODEL` branch) instead of the DeepSeek‑only root slot. DeepSeek/DeepSeekCN behavior is unchanged.
2. `default_model()`: an explicit provider‑scoped model that is not a recognized DeepSeek alias is returned **verbatim** for non‑DeepSeek providers, instead of falling back to a default.

**中文：** 在 `crates/tui/src/config.rs` 中做两处精准改动，复用**既有**的按提供方透传机制（不新增代码路径）：① `apply_env_overrides` 对非 DeepSeek 提供方，将 `DEEPSEEK_MODEL` 写入**当前提供方**的模型槽位（与既有 `OPENAI_MODEL` 分支一致），而非 DeepSeek 专用根槽位；② `default_model()` 对非 DeepSeek 提供方，若显式模型不是已知 DeepSeek 别名，则**原样返回**，不再回退默认值。DeepSeek/DeepSeekCN 行为保持不变。

## Scope / 改动边界

- Does **not** touch `normalize_model_config`, `provider_passes_model_through`, the validator, the existing `SGLANG/VLLM/OLLAMA/NVIDIA_NIM_MODEL` env branches, or any other file.
- Does **not** change DeepSeek/DeepSeekCN model resolution.
- 不改动上述函数与其他文件；不改变 DeepSeek 系列的模型解析。

## Testing / 测试

New regression test `deepseek_model_env_passes_custom_model_through_for_non_deepseek_providers` (next to `openai_provider_accepts_custom_model_and_base_url`), covering: (a) `provider=openai` + `DEEPSEEK_MODEL=MiniMax-M2.7`, no `OPENAI_MODEL`, default base_url → `default_model() == "MiniMax-M2.7"`; (b) a non‑passthrough provider (`novita`) with the same custom model preserved verbatim.

```
cargo test -p deepseek-tui --bin deepseek-tui -- \
  deepseek_model_env_passes_custom_model_through_for_non_deepseek_providers \
  openai_provider_accepts_custom_model_and_base_url
# both pass; full config:: module: 146 passed, 0 failed
```

新增回归测试 `deepseek_model_env_passes_custom_model_through_for_non_deepseek_providers`，覆盖 OpenAI 兼容端点与一个非透传提供方两种情形；既有 `openai_provider_accepts_custom_model_and_base_url` 等仍全部通过。

Refs #1714, #1739, #1736.
