### PR TITLE
fix(client): keep mutation-tool result confirmations off wire dedup (#1695)

### DIFF
--- a/crates/tui/src/client/chat.rs
+++ b/crates/tui/src/client/chat.rs
@@ -945,12 +945,26 @@ fn compact_tool_result_for_wire(
     let original_chars = content.chars().count();
     let sha = sha256_hex(content.as_bytes());
 
+    // Two independent size-and-kind predicates, deliberately decoupled:
+    //
+    // * `persist_eligible` — size only. Any large result (including a
+    //   mutation tool's big diff) is written to the SHA-addressed store
+    //   so that, if it gets truncated below, the elided middle stays
+    //   retrievable via `retrieve_tool_result`. Mutation tools must NOT
+    //   be excluded here: a >12k-char `write_file` diff that we truncate
+    //   without persisting would leave the model unable to recover it.
+    // * `dedup_eligible` — size AND non-mutation. Only this predicate
+    //   gates collapsing a later identical result to a
+    //   `<TOOL_RESULT_REF>`. Mutation-tool results are write
+    //   *confirmations*, never dedup-eligible (#1695): two identical
+    //   large `write_file` calls must each keep their full confirmation
+    //   inline.
+    //
     // Below the threshold, repeating the content is safer than asking
-    // the model to chase a reference. Above it, persist a SHA-addressed
-    // copy before any later message can point at that SHA. Mutation-tool
-    // results are write *confirmations*, never dedup-eligible (#1695).
-    let dedup_eligible =
-        original_chars >= TOOL_RESULT_DEDUP_MIN_CHARS && !is_mutation_tool(tool_name);
+    // the model to chase a reference, and there's no retrieval burden to
+    // satisfy, so both predicates are false.
+    let persist_eligible = original_chars >= TOOL_RESULT_DEDUP_MIN_CHARS;
+    let dedup_eligible = persist_eligible && !is_mutation_tool(tool_name);
 
     if dedup_eligible && let Some(previous) = seen_tool_results.get(&sha) {
         // Re-check persistence before emitting a ref. If the file is
@@ -981,11 +995,17 @@ fn compact_tool_result_for_wire(
         };
     }
 
-    if dedup_eligible {
-        // Persist before registering the content as dedupable. If the
-        // write fails, later occurrences stay inline instead of pointing
-        // at a file that was never created.
-        if persist_tool_result_for_sha(&sha, content) {
+    if persist_eligible {
+        // Persist any large result so a later truncation below stays
+        // retrievable by SHA — this includes mutation tools, whose big
+        // diffs are NOT dedup-eligible but still must be recoverable
+        // when elided. Only register the SHA as dedup-able (eligible to
+        // be replaced by a back-reference later) when `dedup_eligible`:
+        // if the write fails, skip registration so later occurrences
+        // stay inline instead of pointing at a file that was never
+        // created.
+        let persisted = persist_tool_result_for_sha(&sha, content);
+        if persisted && dedup_eligible {
             seen_tool_results.insert(
                 sha.clone(),
                 SeenToolResult {
@@ -2795,6 +2815,97 @@ mod stream_decoder_tests {
         assert!(
             read_second.starts_with("<TOOL_RESULT_REF sha=\""),
             "got: {read_second}"
+        );
+    }
+
+    #[test]
+    fn large_write_file_result_stays_inline_but_is_persisted_for_retrieval() {
+        // Decoupling regression (#1695 follow-up): a SINGLE very large
+        // `write_file` result must (a) never collapse to a
+        // `<TOOL_RESULT_REF>` (mutation confirmations stay inline) yet
+        // (b) still be persisted to the SHA store so the content elided
+        // by truncation remains retrievable via `retrieve_tool_result`.
+        // Before the fix, folding `!is_mutation_tool` into the single
+        // `dedup_eligible` gate also disabled persistence, so a >12k
+        // mutation diff was truncated AND unrecoverable.
+        let _guard = crate::tools::truncate::TEST_SPILLOVER_GUARD
+            .lock()
+            .unwrap_or_else(|err| err.into_inner());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prior = crate::tools::truncate::set_test_spillover_root(Some(
+            tmp.path().join(".deepseek").join("tool_outputs"),
+        ));
+        struct Restore(Option<std::path::PathBuf>);
+        impl Drop for Restore {
+            fn drop(&mut self) {
+                crate::tools::truncate::set_test_spillover_root(self.0.take());
+            }
+        }
+        let _restore = Restore(prior);
+
+        // > TOOL_RESULT_SENT_CHAR_BUDGET (12_000) so the wire path
+        // truncates and would need a SHA to recover the middle.
+        let big_diff = "D".repeat(20_000);
+        let sha = sha256_hex(big_diff.as_bytes());
+
+        let messages = vec![
+            tool_use_message("w-1", "write_file", json!({"path": "huge.rs"})),
+            tool_result_message("w-1", &big_diff),
+            tool_use_message("w-2", "write_file", json!({"path": "huge.rs"})),
+            tool_result_message("w-2", &big_diff),
+        ];
+        let built = build_chat_messages(None, &messages, "deepseek-v4-flash");
+        let first = tool_message_content(&built, 0);
+        let second = tool_message_content(&built, 1);
+
+        // (a) Both confirmations stay inline — truncated, never a ref.
+        assert!(
+            first.contains("[TOOL_RESULT_TRUNCATED]"),
+            "first should be truncated, got: {first}"
+        );
+        assert!(
+            !first.contains("<TOOL_RESULT_REF"),
+            "first must not be a dedup ref, got: {first}"
+        );
+        assert!(
+            !second.contains("<TOOL_RESULT_REF"),
+            "second identical write_file must stay inline (#1695), got: {second}"
+        );
+        assert!(
+            second.contains("[TOOL_RESULT_TRUNCATED]"),
+            "second should also be inline-truncated, got: {second}"
+        );
+        assert!(
+            first.contains(&format!("sha256: {sha}")),
+            "truncation block should advertise the recovery SHA, got: {first}"
+        );
+
+        // (b) The full content was persisted to the SHA store and is
+        // retrievable — the seam `persist_tool_result_for_sha` writes
+        // to and `retrieve_tool_result ref=sha:` reads back from.
+        let path = crate::tools::truncate::sha_spillover_path(&sha)
+            .expect("sha spillover path resolvable under test root");
+        assert!(path.exists(), "large write_file output not persisted: {path:?}");
+        let persisted = std::fs::read_to_string(&path).expect("read persisted spillover");
+        assert_eq!(
+            persisted, big_diff,
+            "persisted content must match the original write_file result verbatim"
+        );
+
+        // Sanity: a large NON-mutation result still dedups (back-ref on
+        // the second sighting) — decoupling didn't regress #1695's
+        // preserved read-path behavior.
+        let read_messages = vec![
+            tool_use_message("r-1", "read_file", json!({"path": "huge.rs"})),
+            tool_result_message("r-1", &big_diff),
+            tool_use_message("r-2", "read_file", json!({"path": "huge.rs"})),
+            tool_result_message("r-2", &big_diff),
+        ];
+        let read_built = build_chat_messages(None, &read_messages, "deepseek-v4-flash");
+        let read_second = tool_message_content(&read_built, 1);
+        assert!(
+            read_second.starts_with("<TOOL_RESULT_REF sha=\""),
+            "large read_file must still dedup to a ref, got: {read_second}"
         );
     }
 

--- a/crates/tui/src/client/chat.rs
+++ b/crates/tui/src/client/chat.rs
@@ -923,6 +923,18 @@ fn turn_meta_budget_json(turn_meta: &TurnMetaBudget) -> Value {
     })
 }
 
+/// Mutating/write tools whose result body is a *confirmation* (it embeds
+/// the unified diff + summary of what was just written), not retrievable
+/// reference data. Two identical large `write_file` calls must each keep
+/// their full confirmation inline: collapsing the later one to a
+/// `<TOOL_RESULT_REF sha="..." />` makes the model lose the write-success
+/// context and behave as if the file is missing (issue #1695). Read-style
+/// tools (`read_file`, `grep_files`, `exec_shell`, …) are unaffected and
+/// still dedup normally.
+fn is_mutation_tool(tool_name: &str) -> bool {
+    matches!(tool_name, "write_file" | "edit_file" | "apply_patch")
+}
+
 fn compact_tool_result_for_wire(
     tool_name: &str,
     input: &Value,
@@ -935,8 +947,10 @@ fn compact_tool_result_for_wire(
 
     // Below the threshold, repeating the content is safer than asking
     // the model to chase a reference. Above it, persist a SHA-addressed
-    // copy before any later message can point at that SHA.
-    let dedup_eligible = original_chars >= TOOL_RESULT_DEDUP_MIN_CHARS;
+    // copy before any later message can point at that SHA. Mutation-tool
+    // results are write *confirmations*, never dedup-eligible (#1695).
+    let dedup_eligible =
+        original_chars >= TOOL_RESULT_DEDUP_MIN_CHARS && !is_mutation_tool(tool_name);
 
     if dedup_eligible && let Some(previous) = seen_tool_results.get(&sha) {
         // Re-check persistence before emitting a ref. If the file is
@@ -2740,6 +2754,47 @@ mod stream_decoder_tests {
         assert!(
             second.contains("retrieve: retrieve_tool_result ref=sha:"),
             "got: {second}"
+        );
+    }
+
+    #[test]
+    fn request_builder_never_dedups_large_identical_write_file_confirmations() {
+        // A `write_file` result embeds the unified diff + summary; it is a
+        // confirmation, not retrievable data. Two identical >1024-char
+        // write_file results must BOTH stay inline — collapsing the second
+        // to a SHA ref makes the model lose write-success context and
+        // report the file as missing (#1695).
+        let output = "A".repeat(2_000);
+        let messages = vec![
+            tool_use_message("tool-1", "write_file", json!({"path": "big.txt"})),
+            tool_result_message("tool-1", &output),
+            tool_use_message("tool-2", "write_file", json!({"path": "big.txt"})),
+            tool_result_message("tool-2", &output),
+        ];
+
+        let built = build_chat_messages(None, &messages, "deepseek-v4-flash");
+        let first = tool_message_content(&built, 0);
+        let second = tool_message_content(&built, 1);
+
+        assert_eq!(first, output);
+        assert_eq!(second, output);
+        assert!(!second.contains("<TOOL_RESULT_REF"), "got: {second}");
+
+        // Non-mutation tools still dedup: an identical large read_file
+        // result collapses to a retrievable SHA ref.
+        let read_messages = vec![
+            tool_use_message("read-1", "read_file", json!({"path": "README.md"})),
+            tool_result_message("read-1", &output),
+            tool_use_message("read-2", "read_file", json!({"path": "README.md"})),
+            tool_result_message("read-2", &output),
+        ];
+        let read_built = build_chat_messages(None, &read_messages, "deepseek-v4-flash");
+        let read_first = tool_message_content(&read_built, 0);
+        let read_second = tool_message_content(&read_built, 1);
+        assert_eq!(read_first, output);
+        assert!(
+            read_second.starts_with("<TOOL_RESULT_REF sha=\""),
+            "got: {read_second}"
         );
     }
 

--- a/crates/tui/src/commands/debug.rs
+++ b/crates/tui/src/commands/debug.rs
@@ -641,6 +641,13 @@ mod tests {
 
     #[test]
     fn cache_inspect_displays_tool_result_budget_metadata() {
+        // Wire dedup persists to the process-global SHA spillover root.
+        // Serialize through the same guard other tests use to override
+        // that root, so a parallel test pointing it at a temp dir can't
+        // make this test's second-sighting dedup silently fail.
+        let _spill_guard = crate::tools::truncate::TEST_SPILLOVER_GUARD
+            .lock()
+            .unwrap_or_else(|err| err.into_inner());
         let mut app = create_test_app();
         let long_output = format!("{}{}", "A".repeat(7_000), "Z".repeat(7_000));
         app.api_messages.push(Message {


### PR DESCRIPTION
## Summary / 概述

**EN:** Addresses #1695. After repeated identical `write_file` calls on a file larger than ~1 KB, the model behaves and reports as if the write never happened ("No such file or directory" on a follow‑up read), and the same truncated sha (`b39a442`) appears across the "ghosted" writes. Root cause is **not** a disk‑write failure — it is the wire compactor collapsing a write *confirmation* into a `<TOOL_RESULT_REF>` reference, which destroys the model's proof that the write landed.

**中文：** 处理 #1695。对大于约 1 KB 的文件重复执行相同的 `write_file` 后，模型表现/汇报得就像写入从未发生（后续读取报 “No such file or directory”），并且这些“写丢了”的调用都带着同一个截断 sha（`b39a442`）。根因**不是磁盘写入失败**，而是 wire 压缩器把写入**确认信息**折叠成了 `<TOOL_RESULT_REF>` 引用，导致模型失去了“写入已落盘”的证据。

## Root cause / 根因

**EN:** `compact_tool_result_for_wire` in `crates/tui/src/client/chat.rs` deduplicates any tool result whose body is ≥ `TOOL_RESULT_DEDUP_MIN_CHARS` (1024) when an identical SHA was seen before, replacing the later copy on the wire with a `<TOOL_RESULT_REF sha="…" />`. A `write_file` result body is `"{unified_diff}\n{summary}"` — it **embeds the full written content**, so two identical >1 KB writes hash to the same SHA (the constant `b39a442` the reporter observed) and the second is collapsed to a reference. For retrievable read‑style outputs that is correct and valuable; for a *mutation confirmation* it is wrong — the model loses the success signal and concludes the file is missing. The 1024 constant lines up exactly with the reporter's ~991 B (lands) / ~1129 B (ghosts) boundary. The on‑disk `fs::write` in `crates/tui/src/tools/file.rs` always succeeded; this was always a wire context‑loss defect.

**中文：** `crates/tui/src/client/chat.rs` 的 `compact_tool_result_for_wire`：当某工具结果体长度 ≥ `TOOL_RESULT_DEDUP_MIN_CHARS`（1024）且此前出现过相同 SHA 时，会在 wire 上把后一份替换为 `<TOOL_RESULT_REF sha="…" />`。而 `write_file` 的结果体是 `"{unified_diff}\n{summary}"`——**内嵌了被写入的完整内容**，因此两次相同的 >1 KB 写入会得到同一个 SHA（即报告者看到的常量 `b39a442`），第二份被折叠成引用。对可检索的读类输出这是正确且有价值的优化；但对**变更确认**而言是错误的——模型因此丢失写入成功信号，进而判定文件不存在。1024 这个常量恰好对应报告中 ~991 B（成功）/ ~1129 B（丢失）的分界。`crates/tui/src/tools/file.rs` 中的磁盘 `fs::write` 始终是成功的；这一直是 wire 层上下文丢失的缺陷。

## Fix / 修复

One surgical change in `crates/tui/src/client/chat.rs`: add `is_mutation_tool(tool_name)` (`write_file | edit_file | apply_patch`) and AND `!is_mutation_tool(tool_name)` into the existing `dedup_eligible` predicate. Mutation‑tool confirmations now always stay inline; read‑style large outputs (`read_file`, `grep_files`, `exec_shell`, …) still dedup exactly as before.

**中文：** 在 `crates/tui/src/client/chat.rs` 中做一处精准改动：新增 `is_mutation_tool(tool_name)`（匹配 `write_file | edit_file | apply_patch`），并把 `!is_mutation_tool(tool_name)` 与到既有的 `dedup_eligible` 判定中。变更类工具的确认信息从此始终内联；读类的大输出仍与此前完全一致地去重。

## Honest scope / 改动边界（如实说明）

- This fixes the **observable behavior** (model losing write‑confirmation context on repeated identical large writes and reporting the file as missing). It does **not** alter on‑disk write behavior, which already works correctly — so the original "data never reaches disk" framing in the report is, per code inspection at v0.8.39, a *symptom* of wire context loss, not a `fs::write` failure. Worth confirming on the reporter's exact repro.
- No change to `file.rs`, the large‑output router, SHA persistence, or non‑mutation dedup.
- 仅修复**可观测行为**；不改动磁盘写入逻辑（其本身正确）。报告中“数据没写入磁盘”的描述，按 v0.8.39 代码审查，是 wire 上下文丢失的*表象*，并非 `fs::write` 失败，建议在报告者的复现场景上再确认。不改动 `file.rs`、大输出路由、SHA 持久化或非变更类去重。

## Testing / 测试

New regression test `request_builder_never_dedups_large_identical_write_file_confirmations`: two identical 2000‑char `write_file` results both stay inline (no `<TOOL_RESULT_REF`); two identical 2000‑char `read_file` results still collapse to a SHA ref (non‑mutation dedup preserved).

```
cargo test -p deepseek-tui --bin deepseek-tui -- \
  request_builder_never_dedups_large_identical_write_file_confirmations \
  request_builder_deduplicates_large_identical_tool_results_with_retrieval_hint
# 2 passed; 0 failed
```

新增回归测试 `request_builder_never_dedups_large_identical_write_file_confirmations`，并保留既有去重测试以证明非变更类去重不受影响；两者均通过。

Refs #1695, #1736.
