### PR TITLE
fix(tui): surface thinking-only turns instead of silently ending (#1727)

### DIFF
--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -867,6 +867,17 @@ impl Engine {
                 )
             });
 
+            // Issue #1727: did this turn produce ONLY a reasoning/thinking
+            // block — empty content, no tool calls (e.g. gpt-oss via ollama's
+            // harmony→OpenAI shim mapping to `reasoning_content`)? We do NOT
+            // surface anything here: after this point the same turn can still
+            // CONTINUE for pending steers (~below) or sub-agent completions,
+            // and emitting now would show a spurious "turn ended" notice right
+            // before the turn resumes. Capture the fact and decide later, at
+            // the point the turn is certain to be finishing with no sendable
+            // content (see the `tool_uses.is_empty()` tail).
+            let thinking_only_no_sendable = !has_sendable_assistant_content;
+
             // Add assistant message to session
             if has_sendable_assistant_content {
                 self.add_session_message(Message {
@@ -874,25 +885,6 @@ impl Engine {
                     content: content_blocks,
                 })
                 .await;
-            } else if should_emit_thinking_only_status(
-                tool_uses.is_empty(),
-                turn_error.is_none(),
-                self.cancel_token.is_cancelled(),
-            ) {
-                // Issue #1727: the model streamed ONLY a reasoning/thinking
-                // block — empty content, no tool calls (e.g. gpt-oss via
-                // ollama's harmony→OpenAI shim mapping to `reasoning_content`).
-                // We intentionally do NOT persist an assistant message
-                // (preserves prior behavior), but the previous code emitted
-                // nothing at all and fell straight through to finishing the
-                // turn, leaving the UI spinner hung with no error. Surface a
-                // status so the user knows the turn ended and can retry.
-                let message =
-                    "Model returned reasoning but no answer or tool call; turn ended without \
-                     output. Send a follow-up to retry."
-                        .to_string();
-                crate::logging::warn(&message);
-                let _ = self.tx_event.send(Event::status(message)).await;
             }
 
             // If no tool uses, check for inline REPL blocks (paper §2) or
@@ -1081,6 +1073,39 @@ impl Engine {
                     // No FINAL — let the model iterate with the feedback.
                     turn.next_step();
                     continue;
+                }
+
+                // Issue #1727: the turn is now genuinely finishing with no
+                // sendable content. Control only reaches here when there were
+                // no pending steers (`continue`d above), no sub-agent
+                // completions to resume with, and we were not holding for
+                // running children (the `should_hold_turn_for_subagents`
+                // branch above would have awaited / `continue`d / returned).
+                // If the assistant produced ONLY a reasoning block, the prior
+                // code fell straight through to this `break`, emitting nothing
+                // and leaving the UI spinner hung. Surface a status now —
+                // safe because the turn can no longer resume.
+                if thinking_only_no_sendable {
+                    let holding_for_subagents = {
+                        let running = {
+                            let mgr = self.subagent_manager.read().await;
+                            mgr.running_count()
+                        };
+                        should_hold_turn_for_subagents(0, running)
+                    };
+                    if should_emit_thinking_only_status(
+                        tool_uses.is_empty(),
+                        turn_error.is_none(),
+                        self.cancel_token.is_cancelled(),
+                        !pending_steers.is_empty(),
+                        holding_for_subagents,
+                    ) {
+                        let message = "Model returned reasoning but no answer or tool call; \
+                                       turn ended without output. Send a follow-up to retry."
+                            .to_string();
+                        crate::logging::warn(&message);
+                        let _ = self.tx_event.send(Event::status(message)).await;
+                    }
                 }
 
                 break;
@@ -1988,16 +2013,25 @@ fn should_hold_turn_for_subagents(queued_completions: usize, running_children: u
 ///
 /// Reached when the assistant turn had no sendable content (no Text, no
 /// ToolUse — only a reasoning/thinking block). We notify the user *only* when
-/// the turn is otherwise ending cleanly: no tool uses to dispatch, no
-/// `turn_error` already surfaced for this turn, and the request wasn't
-/// cancelled. In those cases the prior code emitted nothing and the UI
-/// spinner hung silently.
+/// the turn is genuinely finishing: no tool uses to dispatch, no `turn_error`
+/// already surfaced for this turn, the request wasn't cancelled, AND the turn
+/// is not about to CONTINUE — there are no pending steers and we are not
+/// holding the turn open for running sub-agents. The status must fire at the
+/// point the turn truly ends; emitting it earlier (at the persist site) would
+/// show a spurious "turn ended" notice immediately before the turn resumed
+/// for a steer or a sub-agent completion.
 fn should_emit_thinking_only_status(
     tool_uses_empty: bool,
     turn_error_is_none: bool,
     cancelled: bool,
+    steers_pending: bool,
+    holding_for_subagents: bool,
 ) -> bool {
-    tool_uses_empty && turn_error_is_none && !cancelled
+    tool_uses_empty
+        && turn_error_is_none
+        && !cancelled
+        && !steers_pending
+        && !holding_for_subagents
 }
 
 /// Resolve an `"auto"` reasoning-effort tier to a concrete value.
@@ -2092,30 +2126,59 @@ mod tests {
     /// error, looking hung.
     ///
     /// This pins the decision: a clean turn end (no tool uses to dispatch, no
-    /// `turn_error`, not cancelled) must surface a status. We must NOT spam the
-    /// status when the turn is ending for another reason (error already shown,
-    /// cancelled) or when there are tool uses still to dispatch.
+    /// `turn_error`, not cancelled, no pending steers, not holding for
+    /// sub-agents) must surface a status. We must NOT spam the status when the
+    /// turn is ending for another reason (error already shown, cancelled),
+    /// when there are tool uses still to dispatch, or — critically (the
+    /// MEDIUM review finding) — when the turn is about to CONTINUE because a
+    /// steer is pending or sub-agents are still running. Emitting at the old
+    /// persist site fired before those continuations were known.
     ///
     /// Limitation: this tests the extracted pure decision, not the full async
     /// `handle_deepseek_turn` loop (driving it would need a mock DeepSeek
     /// client + session + channels — far beyond a surgical fix and unlike any
     /// existing turn-loop test, which all pin pure helpers the same way). The
-    /// `else if` wiring at the persist site is reviewed by inspection.
+    /// wiring at the `tool_uses.is_empty()` tail (capture-then-decide, with the
+    /// live steer/sub-agent signals) is reviewed by inspection — consistent
+    /// with how the other turn-loop helpers in this module are tested.
     #[test]
     fn thinking_only_turn_emits_status_only_on_clean_end() {
-        // Thinking-only response, turn ending cleanly → surface a status so
-        // the user isn't left staring at a hung spinner.
-        assert!(should_emit_thinking_only_status(true, true, false));
+        // Thinking-only response, turn genuinely ending (no tool uses, no
+        // error, not cancelled, no steers pending, not holding for
+        // sub-agents) → surface a status so the user isn't left staring at a
+        // hung spinner.
+        assert!(should_emit_thinking_only_status(
+            true, true, false, false, false
+        ));
 
         // Tool uses still pending → the normal dispatch path handles it; no
         // thinking-only status.
-        assert!(!should_emit_thinking_only_status(false, true, false));
+        assert!(!should_emit_thinking_only_status(
+            false, true, false, false, false
+        ));
 
         // A turn_error was already surfaced → don't double-report.
-        assert!(!should_emit_thinking_only_status(true, false, false));
+        assert!(!should_emit_thinking_only_status(
+            true, false, false, false, false
+        ));
 
         // Request was cancelled → cancellation status already covers it.
-        assert!(!should_emit_thinking_only_status(true, true, true));
+        assert!(!should_emit_thinking_only_status(
+            true, true, true, false, false
+        ));
+
+        // A steer is pending → the turn will resume with the steer; emitting
+        // "turn ended" now would be a spurious notice right before the turn
+        // continues (the MEDIUM correctness finding).
+        assert!(!should_emit_thinking_only_status(
+            true, true, false, true, false
+        ));
+
+        // Sub-agents are still running / completions queued → the turn is
+        // held open and will resume; do not claim it ended.
+        assert!(!should_emit_thinking_only_status(
+            true, true, false, false, true
+        ));
     }
 
     /// Regression test for the OpenAI streaming batch tool_calls bug.

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -874,6 +874,25 @@ impl Engine {
                     content: content_blocks,
                 })
                 .await;
+            } else if should_emit_thinking_only_status(
+                tool_uses.is_empty(),
+                turn_error.is_none(),
+                self.cancel_token.is_cancelled(),
+            ) {
+                // Issue #1727: the model streamed ONLY a reasoning/thinking
+                // block — empty content, no tool calls (e.g. gpt-oss via
+                // ollama's harmony→OpenAI shim mapping to `reasoning_content`).
+                // We intentionally do NOT persist an assistant message
+                // (preserves prior behavior), but the previous code emitted
+                // nothing at all and fell straight through to finishing the
+                // turn, leaving the UI spinner hung with no error. Surface a
+                // status so the user knows the turn ended and can retry.
+                let message =
+                    "Model returned reasoning but no answer or tool call; turn ended without \
+                     output. Send a follow-up to retry."
+                        .to_string();
+                crate::logging::warn(&message);
+                let _ = self.tx_event.send(Event::status(message)).await;
             }
 
             // If no tool uses, check for inline REPL blocks (paper §2) or
@@ -1965,6 +1984,22 @@ fn should_hold_turn_for_subagents(queued_completions: usize, running_children: u
     queued_completions > 0 || running_children > 0
 }
 
+/// Issue #1727: decide whether to surface a "thinking-only, no output" status.
+///
+/// Reached when the assistant turn had no sendable content (no Text, no
+/// ToolUse — only a reasoning/thinking block). We notify the user *only* when
+/// the turn is otherwise ending cleanly: no tool uses to dispatch, no
+/// `turn_error` already surfaced for this turn, and the request wasn't
+/// cancelled. In those cases the prior code emitted nothing and the UI
+/// spinner hung silently.
+fn should_emit_thinking_only_status(
+    tool_uses_empty: bool,
+    turn_error_is_none: bool,
+    cancelled: bool,
+) -> bool {
+    tool_uses_empty && turn_error_is_none && !cancelled
+}
+
 /// Resolve an `"auto"` reasoning-effort tier to a concrete value.
 ///
 /// When the configured effort is `"auto"`, inspects the last user message
@@ -2045,6 +2080,42 @@ mod tests {
         assert!(should_hold_turn_for_subagents(1, 0));
         assert!(should_hold_turn_for_subagents(0, 1));
         assert!(!should_hold_turn_for_subagents(0, 0));
+    }
+
+    /// Regression test for issue #1727 (P0, release-blocking).
+    ///
+    /// When a model (e.g. gpt-oss via ollama's harmony→OpenAI shim) returns
+    /// ONLY a reasoning/thinking block — empty `content`, no `tool_calls` —
+    /// `has_sendable_assistant_content` is false, so no assistant message is
+    /// persisted. Previously the code also emitted NO event and fell straight
+    /// through to finishing the turn: the UI spinner stayed up forever with no
+    /// error, looking hung.
+    ///
+    /// This pins the decision: a clean turn end (no tool uses to dispatch, no
+    /// `turn_error`, not cancelled) must surface a status. We must NOT spam the
+    /// status when the turn is ending for another reason (error already shown,
+    /// cancelled) or when there are tool uses still to dispatch.
+    ///
+    /// Limitation: this tests the extracted pure decision, not the full async
+    /// `handle_deepseek_turn` loop (driving it would need a mock DeepSeek
+    /// client + session + channels — far beyond a surgical fix and unlike any
+    /// existing turn-loop test, which all pin pure helpers the same way). The
+    /// `else if` wiring at the persist site is reviewed by inspection.
+    #[test]
+    fn thinking_only_turn_emits_status_only_on_clean_end() {
+        // Thinking-only response, turn ending cleanly → surface a status so
+        // the user isn't left staring at a hung spinner.
+        assert!(should_emit_thinking_only_status(true, true, false));
+
+        // Tool uses still pending → the normal dispatch path handles it; no
+        // thinking-only status.
+        assert!(!should_emit_thinking_only_status(false, true, false));
+
+        // A turn_error was already surfaced → don't double-report.
+        assert!(!should_emit_thinking_only_status(true, false, false));
+
+        // Request was cancelled → cancellation status already covers it.
+        assert!(!should_emit_thinking_only_status(true, true, true));
     }
 
     /// Regression test for the OpenAI streaming batch tool_calls bug.


### PR DESCRIPTION
## Summary / 概述

**EN:** Fixes #1727. When a model streams a turn containing **only** a reasoning/thinking block — empty `content`, no `tool_calls` (e.g. gpt-oss via ollama's harmony→OpenAI shim, which maps the answer into `reasoning_content`) — the engine persisted nothing, emitted no event, and finished the turn silently. The UI sat idle: spinner never cleared, no reply, no error. It looked hung. This PR surfaces a `status` notice instead of silence.

**中文：** 修复 #1727。当模型本回合**只**返回了 reasoning/thinking 块——`content` 为空、无 `tool_calls`（例如 ollama 的 harmony→OpenAI 适配把答案塞进 `reasoning_content` 的 gpt-oss）——引擎既不持久化任何消息、也不发出任何事件，回合静默结束。界面就此卡住：spinner 不消失、无回复、无报错，看起来像挂死。本 PR 用一条 `status` 提示替代这种静默。

## Root cause / 根因

**EN:** In `crates/tui/src/core/engine/turn_loop.rs`, the assistant‑message persist site is an `if`‑only branch gated on `has_sendable_assistant_content` (true only for `Text`/`ToolUse`). A thinking‑only stream produces neither, so the `if` is skipped — no message, no event — and `if tool_uses.is_empty()` then falls straight through to `break`, ending the turn with **zero events emitted**. The maintainer's v0.8.40 audit (#1736) confirms #1727 was *not* shipped in v0.8.39 and is release‑blocking, and that this exact status branch is still missing.

**中文：** 在 `crates/tui/src/core/engine/turn_loop.rs` 中，assistant 消息的持久化处是一个仅有 `if` 的分支，条件为 `has_sendable_assistant_content`（仅 `Text`/`ToolUse` 为真）。thinking‑only 流两者皆无，于是该 `if` 被跳过——既无消息也无事件——随后 `if tool_uses.is_empty()` 直接走到 `break`，回合在**零事件**下结束。维护者的 v0.8.40 审计（#1736）确认 #1727 在 v0.8.39 *并未*随版本发布、属于发布阻断项，且这一 status 分支至今缺失。

## Fix / 修复

Minimum‑surface‑area (the issue author's "option 1"): add an `else if` arm at the same persist site that, only on a clean end (`tool_uses` empty, `turn_error.is_none()`, not cancelled), `warn`s and emits an `Event::status(...)`: *"Model returned reasoning but no answer or tool call; turn ended without output. Send a follow‑up to retry."* **No assistant message is persisted** (prior behavior preserved). **No** retry/re‑prompt/placeholder policy is added (explicitly out of scope). The guard ordering is extracted into a tiny pure helper `should_emit_thinking_only_status(...)` so it is unit‑testable and matches the existing `should_hold_turn_for_subagents` style. Reuses the exact surrounding patterns: `Event::status`, `crate::logging::warn`, `self.cancel_token.is_cancelled()`, `turn_error.is_none()`.

**中文：** 最小改动面（issue 作者的“方案一”）：在同一持久化处新增 `else if` 分支，仅在干净结束时（`tool_uses` 为空、`turn_error.is_none()`、未取消）`warn` 并发出 `Event::status(...)`：*“模型返回了推理但没有答案或工具调用；本回合无输出结束，可发送追问重试。”* **不持久化任何 assistant 消息**（保持原行为）；**不**加入重试/重提示/占位策略（明确超出范围）。守卫顺序被抽到一个纯函数小助手 `should_emit_thinking_only_status(...)`，便于单测，并与既有 `should_hold_turn_for_subagents` 风格一致。复用周边既有写法。

## Scope / 改动边界

- The existing `if has_sendable_assistant_content` branch is **untouched**; normal text/tool turns persist and render exactly as before.
- No double‑notice: guarded by `turn_error.is_none()` (stream errors still surface their own error) and `!cancelled`.
- 既有 `if` 分支**不动**；正常文本/工具回合行为不变。受 `turn_error.is_none()`、`!cancelled` 守卫，不会重复提示。

## Testing / 测试

New unit test `thinking_only_turn_emits_status_only_on_clean_end` pins the decision: notify only on clean end; suppressed when tool uses pending / an error already shown / cancelled.

```
cargo test -p deepseek-tui --bin deepseek-tui -- thinking_only_turn_emits_status_only_on_clean_end   # ok
cargo clippy -p deepseek-tui   # clean (no warnings/errors)
```

**Honest test limitation:** the test pins the extracted pure decision, not the full async `handle_deepseek_turn` loop — consistent with every existing turn‑loop test in this module (they all pin pure helpers; an end‑to‑end test would need a mock client/session/channel, outside a surgical fix). The `else if` wiring is covered by inspection.

新增单测 `thinking_only_turn_emits_status_only_on_clean_end`，与本模块既有“纯函数式”测试风格一致；端到端回合测试需 mock 客户端/会话/通道，超出本次外科式修复范围，已如实说明。

Refs #1727, #1736.
