### PR TITLE
fix(client): replay reasoning_content for DeepSeek models on openai provider (#1739, #1694)

### DIFF
--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -1265,8 +1265,14 @@ mod tests {
 
     #[test]
     fn generic_openai_provider_drops_deepseek_reasoning_content() {
+        // #1542 intent (narrowed by #1739/#1694): a *genuine non-DeepSeek*
+        // model on the generic openai provider must not carry DeepSeek-only
+        // `reasoning_content`. A DeepSeek reasoning model on the openai
+        // provider (DeepSeek-compatible endpoint) is now covered separately
+        // and DOES replay reasoning_content — see
+        // `deepseek_model_on_openai_provider_still_replays_reasoning_content`.
         let request = MessageRequest {
-            model: "deepseek-v4-pro".to_string(),
+            model: "gpt-4o".to_string(),
             messages: vec![Message {
                 role: "assistant".to_string(),
                 content: vec![
@@ -1290,19 +1296,6 @@ mod tests {
             temperature: None,
             top_p: None,
         };
-
-        let deepseek =
-            build_chat_messages_for_request_and_provider(&request, ApiProvider::Deepseek);
-        let native_assistant = deepseek
-            .iter()
-            .find(|value| value.get("role").and_then(Value::as_str) == Some("assistant"))
-            .expect("assistant message");
-        assert_eq!(
-            native_assistant
-                .get("reasoning_content")
-                .and_then(Value::as_str),
-            Some("plan")
-        );
 
         let openai = build_chat_messages_for_request_and_provider(&request, ApiProvider::Openai);
         let generic_assistant = openai
@@ -2707,8 +2700,12 @@ mod tests {
 
     #[test]
     fn sanitize_thinking_mode_skips_generic_openai_provider() {
+        // #1542 intent (narrowed by #1739/#1694): the sanitizer only skips for
+        // a *genuine non-DeepSeek* model on the generic openai provider. A
+        // DeepSeek reasoning model on the openai provider still gets sanitized
+        // (see chat.rs `deepseek_model_on_openai_provider_still_replays_*`).
         let mut body = json!({
-            "model": "deepseek-v4-pro",
+            "model": "gpt-4o",
             "messages": [
                 { "role": "user", "content": "hi" },
                 {
@@ -2721,7 +2718,7 @@ mod tests {
 
         let result = sanitize_thinking_mode_messages(
             &mut body,
-            "deepseek-v4-pro",
+            "gpt-4o",
             Some("max"),
             ApiProvider::Openai,
         );

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -1264,7 +1264,7 @@ mod tests {
     }
 
     #[test]
-    fn generic_openai_provider_drops_deepseek_reasoning_content() {
+    fn generic_openai_provider_drops_reasoning_content_for_non_deepseek_models() {
         // #1542 intent (narrowed by #1739/#1694): a *genuine non-DeepSeek*
         // model on the generic openai provider must not carry DeepSeek-only
         // `reasoning_content`. A DeepSeek reasoning model on the openai

--- a/crates/tui/src/client/chat.rs
+++ b/crates/tui/src/client/chat.rs
@@ -1628,7 +1628,12 @@ fn should_replay_reasoning_content_for_provider(
     model: &str,
     effort: Option<&str>,
 ) -> bool {
-    if !provider_accepts_reasoning_content(provider) {
+    if !provider_accepts_reasoning_content(provider) && !requires_reasoning_content(model) {
+        // Generic non-DeepSeek model on a provider that rejects the field:
+        // keep stripping it (preserves the #1542 fix). But a known DeepSeek
+        // reasoning model pointed at a DeepSeek-compatible endpoint via the
+        // generic `openai` provider still requires reasoning_content replay,
+        // or the thinking-mode API returns 400 (#1739 / #1694).
         return false;
     }
     should_replay_reasoning_content(model, effort)
@@ -2828,7 +2833,7 @@ mod alias_thinking_detection_tests {
     //! https://api-docs.deepseek.com/guides/thinking_mode
     use super::{
         provider_accepts_reasoning_content, requires_reasoning_content,
-        should_replay_reasoning_content,
+        should_replay_reasoning_content, should_replay_reasoning_content_for_provider,
     };
     use crate::config::ApiProvider;
 
@@ -2896,5 +2901,50 @@ mod alias_thinking_detection_tests {
         assert!(!provider_accepts_reasoning_content(ApiProvider::Openai));
         assert!(provider_accepts_reasoning_content(ApiProvider::Deepseek));
         assert!(provider_accepts_reasoning_content(ApiProvider::NvidiaNim));
+    }
+
+    #[test]
+    fn deepseek_model_on_openai_provider_still_replays_reasoning_content() {
+        // #1739 / #1694: a DeepSeek thinking model pointed at a
+        // DeepSeek-compatible endpoint via the generic `openai` provider must
+        // still replay reasoning_content, even though the provider itself does
+        // not accept the field. Otherwise the thinking-mode API returns 400.
+        assert!(should_replay_reasoning_content_for_provider(
+            ApiProvider::Openai,
+            "deepseek-v4-flash",
+            None,
+        ));
+        assert!(should_replay_reasoning_content_for_provider(
+            ApiProvider::Openai,
+            "deepseek-v4-pro",
+            None,
+        ));
+        assert!(should_replay_reasoning_content_for_provider(
+            ApiProvider::Openai,
+            "deepseek-reasoner",
+            Some("medium"),
+        ));
+        // The documented escape hatch still wins over model detection.
+        assert!(!should_replay_reasoning_content_for_provider(
+            ApiProvider::Openai,
+            "deepseek-v4-flash",
+            Some("off"),
+        ));
+    }
+
+    #[test]
+    fn generic_model_on_openai_provider_still_strips_reasoning_content() {
+        // #1542 no-regression guard: a genuine non-DeepSeek model on the
+        // openai provider must continue to have reasoning_content stripped.
+        assert!(!should_replay_reasoning_content_for_provider(
+            ApiProvider::Openai,
+            "gpt-4o",
+            None,
+        ));
+        assert!(!should_replay_reasoning_content_for_provider(
+            ApiProvider::Openai,
+            "claude-sonnet-4-6",
+            None,
+        ));
     }
 }

--- a/crates/tui/src/client/chat.rs
+++ b/crates/tui/src/client/chat.rs
@@ -252,8 +252,7 @@ impl DeepSeekClient {
             let mut text_started = false;
             let mut thinking_started = false;
             let mut tool_indices: std::collections::HashMap<u32, u32> = std::collections::HashMap::new();
-            let is_reasoning_model =
-                requires_reasoning_content(&model) && provider_accepts_reasoning_content(api_provider);
+            let is_reasoning_model = is_reasoning_model_for_stream(api_provider, &model);
 
             let mut byte_stream = std::pin::pin!(byte_stream);
             let idle = stream_idle_timeout();
@@ -1639,6 +1638,27 @@ fn should_replay_reasoning_content_for_provider(
     should_replay_reasoning_content(model, effort)
 }
 
+/// Should the SSE parser treat incoming `reasoning_content` deltas as thinking
+/// (vs. inlining them as answer text)?
+///
+/// This is the streaming-path twin of `should_replay_reasoning_content_for_provider`:
+/// both must agree on whether a model is a DeepSeek-family reasoning model, or
+/// stream parsing stores reasoning tokens in `content` while the replay path
+/// expects them in `reasoning_content` (DeepSeek thinking-mode API 400s —
+/// #1739 / #1694). Like that predicate's model-aware gate, a known reasoning
+/// model is classified as such on ANY provider (including the generic `openai`
+/// provider used for DeepSeek-compatible endpoints); a genuine non-DeepSeek
+/// model is never reclassified, so #1542 is not regressed.
+///
+/// `provider_accepts_reasoning_content(provider) || requires_reasoning_content(model)`
+/// short-circuits to `requires_reasoning_content(model)` once the model gate
+/// already holds, so the effective rule is purely model-driven — kept explicit
+/// here to mirror the predicate above.
+fn is_reasoning_model_for_stream(provider: ApiProvider, model: &str) -> bool {
+    requires_reasoning_content(model)
+        && (provider_accepts_reasoning_content(provider) || requires_reasoning_content(model))
+}
+
 fn provider_accepts_reasoning_content(provider: ApiProvider) -> bool {
     matches!(
         provider,
@@ -2832,8 +2852,9 @@ mod alias_thinking_detection_tests {
     //! turn. See upstream API docs:
     //! https://api-docs.deepseek.com/guides/thinking_mode
     use super::{
-        provider_accepts_reasoning_content, requires_reasoning_content,
-        should_replay_reasoning_content, should_replay_reasoning_content_for_provider,
+        is_reasoning_model_for_stream, provider_accepts_reasoning_content,
+        requires_reasoning_content, should_replay_reasoning_content,
+        should_replay_reasoning_content_for_provider,
     };
     use crate::config::ApiProvider;
 
@@ -2946,5 +2967,67 @@ mod alias_thinking_detection_tests {
             "claude-sonnet-4-6",
             None,
         ));
+    }
+
+    #[test]
+    fn stream_classifies_deepseek_model_on_openai_provider_as_reasoning() {
+        // #1739: the SSE parser must treat a DeepSeek thinking model on the
+        // generic `openai` provider (DeepSeek-compatible endpoint) as a
+        // reasoning model, or incoming `reasoning_content` tokens are stored
+        // as answer text and the subsequent replay still 400s.
+        assert!(is_reasoning_model_for_stream(
+            ApiProvider::Openai,
+            "deepseek-v4-flash"
+        ));
+        assert!(is_reasoning_model_for_stream(
+            ApiProvider::Openai,
+            "deepseek-v4-pro"
+        ));
+        assert!(is_reasoning_model_for_stream(
+            ApiProvider::Openai,
+            "deepseek-reasoner"
+        ));
+        // Native DeepSeek provider was already correct; stays correct.
+        assert!(is_reasoning_model_for_stream(
+            ApiProvider::Deepseek,
+            "deepseek-v4-pro"
+        ));
+    }
+
+    #[test]
+    fn stream_does_not_classify_generic_model_as_reasoning() {
+        // #1542 no-regression guard: a genuine non-DeepSeek model on the
+        // openai provider must NOT be treated as a reasoning model, so the
+        // parser keeps inlining any `reasoning_content` it emits as text.
+        assert!(!is_reasoning_model_for_stream(
+            ApiProvider::Openai,
+            "gpt-4o"
+        ));
+        assert!(!is_reasoning_model_for_stream(
+            ApiProvider::Openai,
+            "claude-sonnet-4-6"
+        ));
+        // Non-DeepSeek model on a reasoning-aware provider is also unchanged.
+        assert!(!is_reasoning_model_for_stream(
+            ApiProvider::Deepseek,
+            "gpt-4o"
+        ));
+    }
+
+    #[test]
+    fn stream_classification_matches_replay_predicate() {
+        // The streaming classifier and the replay predicate must agree on
+        // model identity, or stream parsing and message sanitisation disagree
+        // about where reasoning tokens live. Effort=None isolates the
+        // model/provider dimension shared by both.
+        for model in ["deepseek-v4-pro", "deepseek-reasoner", "gpt-4o"] {
+            for provider in [ApiProvider::Openai, ApiProvider::Deepseek] {
+                assert_eq!(
+                    is_reasoning_model_for_stream(provider, model),
+                    should_replay_reasoning_content_for_provider(provider, model, None),
+                    "stream vs replay disagree for {model} on {provider:?}"
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary / 概述

**EN:** Fixes #1739 and #1694. With provider `openai` pointed at a DeepSeek‑compatible endpoint and a DeepSeek reasoning model (`deepseek-v4-flash`/`-pro`/`deepseek-chat`/`deepseek-reasoner`), multi‑turn or tool‑calling conversations 400 with: *"The `reasoning_content` in the thinking mode must be passed back to the API."* This PR makes `reasoning_content` replay model‑aware, not provider‑only.

**中文：** 修复 #1739 与 #1694。当 provider 为 `openai` 且指向 DeepSeek 兼容端点、模型为 DeepSeek 推理模型（`deepseek-v4-flash`/`-pro`/`deepseek-chat`/`deepseek-reasoner`）时，多轮或带工具调用的会话会 400：*“thinking 模式下的 `reasoning_content` 必须回传给 API。”* 本 PR 让 `reasoning_content` 的回放**按模型判断**，而非仅按 provider。

## Root cause / 根因

**EN:** `should_replay_reasoning_content_for_provider()` in `crates/tui/src/client/chat.rs` returned `false` whenever `provider_accepts_reasoning_content(provider)` was false (true for `ApiProvider::Openai`), **without checking the model**. This single function gates both `PromptBuilder::build_for_provider` (`include_reasoning`) and `sanitize_thinking_mode_messages`, so a DeepSeek reasoning model on the generic `openai` provider had all `reasoning_content` stripped → the DeepSeek thinking‑mode API rejects the next request. Introduced by `ac01b225` (fix #1542), which correctly stopped sending DeepSeek‑only fields to *generic* OpenAI backends but was too aggressive — it also stripped them when the OpenAI‑compatible endpoint actually routes to DeepSeek. A `requires_reasoning_content(model)` predicate already exists in the file.

**中文：** `crates/tui/src/client/chat.rs` 的 `should_replay_reasoning_content_for_provider()`：只要 `provider_accepts_reasoning_content(provider)` 为假（`Openai` 即为假）就返回 `false`，**完全不看模型**。该函数同时把守 `PromptBuilder::build_for_provider`（`include_reasoning`）与 `sanitize_thinking_mode_messages` 两条路径，因此 `openai` provider 下的 DeepSeek 推理模型会被剥掉全部 `reasoning_content` → DeepSeek thinking 模式 API 拒绝下一次请求。该问题由 `ac01b225`（修 #1542）引入：它正确地阻止向*通用* OpenAI 后端发送 DeepSeek 专属字段，但过于激进——当 OpenAI 兼容端点实际转发到 DeepSeek 时也一并剥离。文件中已存在 `requires_reasoning_content(model)` 判定。

## Fix / 修复

One‑line predicate change at the single shared gate:

```rust
-    if !provider_accepts_reasoning_content(provider) {
+    if !provider_accepts_reasoning_content(provider) && !requires_reasoning_content(model) {
         return false;
     }
```

A known DeepSeek reasoning model now replays `reasoning_content` regardless of provider; a genuine non‑DeepSeek model on `openai` still has it stripped (the `effort="off"` escape hatch still wins downstream). `provider_accepts_reasoning_content` is untouched, so **#1542 is not regressed**.

**中文：** 在唯一的共享门处做一行判定变更（见上）。已知 DeepSeek 推理模型从此无视 provider 都会回放 `reasoning_content`；`openai` 上真正的非 DeepSeek 模型仍被剥离（下游 `effort="off"` 逃生口依旧优先）。`provider_accepts_reasoning_content` 不动，**不回退 #1542**。

## Note on two pre‑existing tests / 关于两处既有测试

**EN — please read:** Two existing tests in `crates/tui/src/client.rs` (`generic_openai_provider_drops_deepseek_reasoning_content`, `sanitize_thinking_mode_skips_generic_openai_provider`) used `deepseek-v4-pro` on `ApiProvider::Openai` and asserted reasoning was dropped — i.e. they **encoded the exact behavior #1739/#1694 report as a bug**. They were retargeted to `gpt-4o` (a genuine non‑DeepSeek model), which **preserves their original #1542 intent** (generic model on generic provider → stripped) while no longer asserting the buggy case. One now‑meaningless sub‑assertion (a non‑reasoning model on the native Deepseek provider) was removed. New positive/negative coverage lives in `chat.rs`.

**中文（请注意）：** `crates/tui/src/client.rs` 两处既有测试此前用 `deepseek-v4-pro` + `ApiProvider::Openai` 断言 reasoning 被丢弃——它们恰好把 #1739/#1694 报告的 bug 当成了预期。现改为 `gpt-4o`（真正的非 DeepSeek 模型），**保留 #1542 原意**而不再断言这个 bug；并删除一处因换模型而失去意义的子断言。新增的正/反向覆盖放在 `chat.rs`。

## Testing / 测试

```
cargo test -p deepseek-tui --bin deepseek-tui -- \
  client::chat::alias_thinking_detection_tests \
  client::tests::sanitize_thinking_mode_skips_generic_openai_provider \
  client::tests::generic_openai_provider_drops_deepseek_reasoning_content
# 10 passed; 0 failed  (before this fix the suite was 82 passed / 2 failed —
#  the 2 "failures" were the old tests asserting the bug)
```

New tests: `deepseek_model_on_openai_provider_still_replays_reasoning_content` (deepseek‑v4‑flash/‑pro/‑reasoner replay; `off` still suppresses) and `generic_model_on_openai_provider_still_strips_reasoning_content` (gpt‑4o / claude still stripped — #1542 guard).

Refs #1739, #1694, #1542, #1736.
