### PR TITLE
fix(shell): preserve quoted args on Windows cmd /C invocation (#1691)

### DIFF
--- a/crates/tui/src/sandbox/mod.rs
+++ b/crates/tui/src/sandbox/mod.rs
@@ -576,6 +576,37 @@ mod tests {
     }
 
     #[test]
+    fn test_command_spec_shell_quoted_arg_not_split() {
+        // Regression for #1691: a `-m` message containing spaces must remain a
+        // single, unsplit argv entry. The shell command string is passed
+        // verbatim as ONE argument (`sh -c <cmd>` / `cmd /C <payload>`); we
+        // must never tokenize it ourselves into `feat:` / `complete` /
+        // `sub-pages"`.
+        let cmd = r#"git commit -m "feat: complete sub-pages""#;
+        let spec = CommandSpec::shell(cmd, PathBuf::from("/tmp"), Duration::from_secs(30));
+
+        #[cfg(windows)]
+        {
+            assert_eq!(spec.program, "cmd");
+            assert_eq!(
+                spec.args,
+                vec!["/C".to_string(), format!("chcp 65001 >NUL & {cmd}")]
+            );
+        }
+        #[cfg(not(windows))]
+        {
+            assert_eq!(spec.program, "sh");
+            assert_eq!(spec.args, vec!["-c".to_string(), cmd.to_string()]);
+            // The quoted message is intact in a single argv slot — `sh -c`
+            // performs POSIX tokenization, yielding the correct argv:
+            // ["git","commit","-m","feat: complete sub-pages"].
+            assert_eq!(spec.args.len(), 2);
+            assert!(spec.args[1].contains(r#""feat: complete sub-pages""#));
+        }
+        assert_eq!(spec.display_command(), cmd);
+    }
+
+    #[test]
     fn test_command_spec_program() {
         let spec = CommandSpec::program(
             "cargo",

--- a/crates/tui/src/tools/shell.rs
+++ b/crates/tui/src/tools/shell.rs
@@ -192,8 +192,15 @@ fn push_shell_args(cmd: &mut Command, program: &str, args: &[String]) {
     use std::os::windows::process::CommandExt;
     // The `cmd /C <payload>` shape is the only place std's per-arg escaping
     // corrupts a quoted command. Pass `/C` and the payload raw so the quotes
-    // survive; any other program keeps normal (correct) escaping.
-    if program.eq_ignore_ascii_case("cmd")
+    // survive; any other program keeps normal (correct) escaping. Match `cmd`
+    // by file stem so a full path (`C:\Windows\System32\cmd.exe`) or `.exe`
+    // suffix still triggers the raw-arg path.
+    let is_cmd = std::path::Path::new(program)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .map(|s| s.eq_ignore_ascii_case("cmd"))
+        .unwrap_or(false);
+    if is_cmd
         && args.len() == 2
         && args[0].eq_ignore_ascii_case("/C")
     {

--- a/crates/tui/src/tools/shell.rs
+++ b/crates/tui/src/tools/shell.rs
@@ -174,6 +174,43 @@ fn install_parent_death_signal(cmd: &mut Command) {
     }
 }
 
+/// Attach `args` to a `std::process::Command`, honoring shell-quoting on
+/// Windows.
+///
+/// Issue #1691: on Windows the shell command is invoked as
+/// `cmd /C "chcp 65001 >NUL & <command>"`. Rust's `Command::arg` applies
+/// MSVCRT (`CommandLineToArgvW`) escaping, turning the embedded `"` in a
+/// quoted argument (e.g. `git commit -m "feat: complete sub-pages"`) into
+/// `\"`. `cmd.exe` does NOT use MSVCRT parsing — it treats `\` literally and
+/// `"` as a bare quote toggle — so the escaped payload is mis-tokenized and
+/// `git` receives `feat:`, `complete`, `sub-pages"` as separate pathspecs
+/// (the reported `pathspec 'sub-pages"' did not match` symptom). Passing the
+/// `cmd /C` payload through `CommandExt::raw_arg` suppresses std's escaping so
+/// the string reaches `cmd.exe` verbatim, exactly as a terminal would.
+#[cfg(windows)]
+fn push_shell_args(cmd: &mut Command, program: &str, args: &[String]) {
+    use std::os::windows::process::CommandExt;
+    // The `cmd /C <payload>` shape is the only place std's per-arg escaping
+    // corrupts a quoted command. Pass `/C` and the payload raw so the quotes
+    // survive; any other program keeps normal (correct) escaping.
+    if program.eq_ignore_ascii_case("cmd")
+        && args.len() == 2
+        && args[0].eq_ignore_ascii_case("/C")
+    {
+        cmd.raw_arg(&args[0]);
+        cmd.raw_arg(&args[1]);
+    } else {
+        cmd.args(args);
+    }
+}
+
+#[cfg(not(windows))]
+fn push_shell_args(cmd: &mut Command, _program: &str, args: &[String]) {
+    // Unix delegates tokenization entirely to `sh -c <command>`; the command
+    // string is passed as a single argv entry and never split by us.
+    cmd.args(args);
+}
+
 #[cfg(not(target_os = "linux"))]
 fn install_parent_death_signal(_cmd: &mut Command) {
     // No kernel-level equivalent on macOS / Windows. The cooperative
@@ -775,8 +812,8 @@ impl ShellManager {
         let args = exec_env.args();
 
         let mut cmd = Command::new(program);
-        cmd.args(args)
-            .current_dir(working_dir)
+        push_shell_args(&mut cmd, program, args);
+        cmd.current_dir(working_dir)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
         #[cfg(unix)]
@@ -914,8 +951,8 @@ impl ShellManager {
         let args = exec_env.args();
 
         let mut cmd = Command::new(program);
-        cmd.args(args)
-            .current_dir(working_dir)
+        push_shell_args(&mut cmd, program, args);
+        cmd.current_dir(working_dir)
             .stdin(Stdio::inherit())
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit());
@@ -1055,8 +1092,8 @@ impl ShellManager {
             )
         } else {
             let mut cmd = Command::new(program);
-            cmd.args(args)
-                .current_dir(working_dir)
+            push_shell_args(&mut cmd, program, args);
+            cmd.current_dir(working_dir)
                 .stdin(Stdio::piped())
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped());

--- a/crates/tui/src/tools/shell/tests.rs
+++ b/crates/tui/src/tools/shell/tests.rs
@@ -812,3 +812,46 @@ fn test_list_jobs_cleans_up_completed_old_processes() {
         "completed processes should be evicted by cleanup"
     );
 }
+
+/// Regression for #1691: a `git commit -m "feat: complete sub-pages"` shell
+/// command must reach the OS shell with its quoted message intact (one argv
+/// slot), never split into `feat:` / `complete` / `sub-pages"`.
+#[test]
+fn issue_1691_quoted_commit_message_round_trips() {
+    let cmd = r#"git commit -m "feat: complete sub-pages""#;
+    let spec = CommandSpec::shell(cmd, std::path::PathBuf::from("/tmp"), Duration::from_secs(5));
+
+    #[cfg(not(windows))]
+    {
+        // `sh -c <cmd>`: the whole command (with quotes) is a single argv
+        // entry. `sh` then POSIX-tokenizes it → correct git argv. We never
+        // split the command string ourselves.
+        assert_eq!(spec.program, "sh");
+        assert_eq!(spec.args, ["-c".to_string(), cmd.to_string()]);
+        assert_eq!(spec.args.len(), 2);
+
+        // push_shell_args is a faithful pass-through on Unix.
+        let mut built = Command::new(&spec.program);
+        push_shell_args(&mut built, &spec.program, &spec.args);
+        let got: Vec<String> = built
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(got, ["-c".to_string(), cmd.to_string()]);
+    }
+
+    #[cfg(windows)]
+    {
+        // `cmd /C <payload>`: payload carries the quotes verbatim. The fix
+        // routes /C + payload through `raw_arg` so `cmd.exe` (not MSVCRT)
+        // parses it, matching what a terminal does.
+        assert_eq!(spec.program, "cmd");
+        assert_eq!(
+            spec.args,
+            ["/C".to_string(), format!("chcp 65001 >NUL & {cmd}")]
+        );
+        let mut built = Command::new(&spec.program);
+        push_shell_args(&mut built, &spec.program, &spec.args);
+        assert_eq!(built.get_args().count(), 2);
+    }
+}

--- a/crates/tui/src/tools/shell/tests.rs
+++ b/crates/tui/src/tools/shell/tests.rs
@@ -852,6 +852,10 @@ fn issue_1691_quoted_commit_message_round_trips() {
         );
         let mut built = Command::new(&spec.program);
         push_shell_args(&mut built, &spec.program, &spec.args);
-        assert_eq!(built.get_args().count(), 2);
+        let got: Vec<String> = built
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(got, spec.args);
     }
 }


### PR DESCRIPTION
## Summary / 概述

**EN:** Fixes #1691. On Windows, `git commit -m "feat: complete sub-pages"` run by the agent fails with `error: pathspec 'sub-pages"' did not match any file(s)` / `error: pathspec 'feat:' did not match` — the quoted `-m` message is split on spaces and a stray `"` leaks into a token. The same command works when typed in a terminal. This is **not** a DeepSeek‑TUI tokenizer bug; it is a Rust‑std ↔ `cmd.exe` escaping mismatch on the Windows shell‑invocation path.

**中文：** 修复 #1691。Windows 上，agent 执行 `git commit -m "feat: complete sub-pages"` 报 `error: pathspec 'sub-pages"' did not match any file(s)` / `error: pathspec 'feat:' did not match`——带空格的 `-m` 引号消息被按空格切开、且尾引号 `"` 残留进了 token；同样命令在终端手敲却正常。这**不是** DeepSeek‑TUI 自己的分词 bug，而是 Windows shell 调用路径上 Rust 标准库与 `cmd.exe` 的转义规则不匹配。

## Root cause / 根因

**EN:** `CommandSpec::shell()` (`crates/tui/src/sandbox/mod.rs`) builds, on Windows, `cmd /C "chcp 65001 >NUL & <command>"`. That payload is handed to `std::process::Command` at the spawn sites in `crates/tui/src/tools/shell.rs`. Rust std applies MSVCRT (`CommandLineToArgvW`) escaping, turning the embedded `"` into `\"`. **`cmd.exe` does not parse with MSVCRT rules** — it treats `\` literally and `"` as a bare quote toggle — so the quoting is destroyed and `git` (an MSVCRT program) receives `feat:`, `complete`, `sub-pages"` as separate argv entries. The Unix path (`sh -c <command>`, command string passed as a single argv slot) was already correct — verified empirically. There is **no** hand‑rolled tokenizer that splits quoted args anywhere in the exec path; `shlex` is used only for safety analysis and never feeds exec.

**中文：** `CommandSpec::shell()`（`crates/tui/src/sandbox/mod.rs`）在 Windows 上构造 `cmd /C "chcp 65001 >NUL & <command>"`，该 payload 在 `crates/tui/src/tools/shell.rs` 的 spawn 处交给 `std::process::Command`。Rust 标准库套用 MSVCRT（`CommandLineToArgvW`）转义，把内嵌 `"` 变成 `\"`。**`cmd.exe` 不按 MSVCRT 规则解析**——它把 `\` 当字面量、`"` 当裸引号开关——于是引号被破坏，`git`（MSVCRT 程序）收到 `feat:`、`complete`、`sub-pages"` 三个独立参数。Unix 路径（`sh -c <command>`，命令串作为单个 argv 槽）本就正确（已实测）。exec 路径中**不存在**会切分引号参数的手写分词器；`shlex` 仅用于安全分析、绝不回灌 exec。

## Fix / 修复

A cfg‑split `push_shell_args(cmd, program, args)` helper replaces `cmd.args(args)` at the 3 std spawn sites in `shell.rs`:

- **Windows:** for the `cmd /C <payload>` shape only, pass `/C` and the payload via `std::os::windows::process::CommandExt::raw_arg`, suppressing std's per‑arg escaping so the string reaches `cmd.exe` verbatim — exactly as a terminal does. Any other program keeps normal (correct) escaping.
- **Non‑Windows:** faithful pass‑through (`cmd.args(args)`) — **byte‑for‑byte unchanged behavior**.

`portable_pty::CommandBuilder` (tty path) is intentionally not touched: different type with no `raw_arg`, and the reported `git commit` path is non‑tty foreground `std::Command`. Out of scope for this fix.

**中文：** 新增按平台切分的 `push_shell_args(cmd, program, args)`，替换 `shell.rs` 中 3 处 std spawn 的 `cmd.args(args)`：Windows 仅对 `cmd /C <payload>` 形态用 `CommandExt::raw_arg` 透传，绕过 std 的逐参转义，让字符串原样抵达 `cmd.exe`（与终端一致），其他程序保持正常转义；非 Windows 为忠实透传，**行为逐字节不变**。pty 路径（`portable_pty::CommandBuilder`）刻意不动，超出范围。

## Honest scope — please verify on Windows CI / 如实说明——请在 Windows CI 验证

**EN:** This is a well‑understood, documented std↔`cmd.exe` escaping fix, **not** speculative process‑control. The Unix/macOS path is provably unchanged (a test asserts `push_shell_args` is a pass‑through there). However, the corrupting code is `#[cfg(windows)]` and the runtime correctness of the `raw_arg` payload can **only be verified on a Windows runner** — it is not runtime‑testable on macOS/Linux. The added tests pin the contract (command stays one unsplit argv slot; Unix pass‑through) and pass on macOS, but please confirm the `git commit -m "feat: complete sub-pages"` round‑trip on Windows CI before merge. Per the v0.8.40 audit (#1736) Windows policy, flagging this explicitly rather than claiming a smoke‑tested fix.

**中文：** 这是一处机理清晰、有文档依据的 std↔`cmd.exe` 转义修复，**并非**臆测性的进程控制改动。Unix/macOS 路径可证明不变（有测试断言此处为透传）。但出错代码是 `#[cfg(windows)]`，`raw_arg` payload 的运行时正确性**只能在 Windows runner 上验证**，macOS/Linux 无法运行时测试。新增测试锁定契约（命令保持单个不切分 argv 槽；Unix 透传）并在 macOS 通过，但合并前请在 Windows CI 确认 `git commit -m "feat: complete sub-pages"` 往返。遵循 v0.8.40 审计（#1736）的 Windows 策略，特此显式标注，不谎称已 smoke 验证。

## Testing / 测试

```
cargo test -p deepseek-tui --bin deepseek-tui -- \
  issue_1691_quoted_commit_message_round_trips test_command_spec_shell
# 3 passed; 0 failed  (incl. pre-existing test_command_spec_shell — no regression)
```

New tests: `sandbox::tests::test_command_spec_shell_quoted_arg_not_split`, `tools::shell::tests::issue_1691_quoted_commit_message_round_trips`.

Refs #1691, #1736.
