### PR TITLE
feat(theme): add support for custom UI themes and inline color overrides

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -300,6 +300,38 @@ osc8_links = true            # emit OSC 8 escapes around URLs (Cmd+click in iTer
 #                           # Note: this only affects TUI labels/chrome — it does NOT change model output language.
 
 # ─────────────────────────────────────────────────────────────────────────────────
+# Theme Configuration
+# ─────────────────────────────────────────────────────────────────────────────────
+# Select a built-in theme by name using the `/theme` slash command or
+# the `theme` setting in `~/.deepseek/state/settings.json`.
+#
+# Available themes:
+#   deepseek, grayscale, monokai, nord, tokyo-night, dracula, gruvbox,
+#   catppuccin, solarized, onedark, github, paper, terminal, minimal,
+#   high-contrast, terminal-16, terminal-256
+#
+# Override individual colors from the selected theme. Keys match the
+# `UiTheme` struct field names. Values are `#RRGGBB` hex strings.
+# Any unrecognized keys are silently ignored.
+#
+# [theme_overrides]
+# base = "deepseek"          # optional: base theme to extend (default: current setting)
+# surface_bg = "#1a1b2e"
+# text_body = "#e0e0e0"
+# panel_bg = "#2a2b3e"
+#
+# Define named custom themes by extending a built-in base. Each custom
+# theme is a table under `[themes]` with a `base` field and color overrides.
+#
+# [themes.my-custom]
+# base = "grayscale"
+# surface_bg = "#1a1b2e"
+# text_body = "#e0e0e0"
+#
+# Then select it with `/theme my-custom`.
+
+
+# ─────────────────────────────────────────────────────────────────────────────────
 # Feature Flags
 # ─────────────────────────────────────────────────────────────────────────────────
 [features]

--- a/crates/tui/src/commands/config.rs
+++ b/crates/tui/src/commands/config.rs
@@ -503,6 +503,8 @@ pub fn set_config_value(app: &mut App, key: &str, value: &str, persist: bool) ->
             app.ui_theme = crate::palette::ui_theme_from_settings(
                 &settings.theme,
                 settings.background_color.as_deref(),
+                Some(&settings.custom_themes),
+                Some(&settings.theme_overrides),
             );
             app.needs_redraw = true;
         }

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -1008,6 +1008,17 @@ pub struct Config {
     /// Vision model configuration for the `image_analyze` tool.
     #[serde(default)]
     pub vision_model: Option<VisionModelConfig>,
+
+    /// Inline color overrides applied on top of the resolved theme.
+    /// Loaded from `[theme.overrides]` section of config.toml.
+    /// Keys match `UiTheme` field names (`surface_bg`, `text_body`, etc.).
+    /// Values are `#RRGGBB` hex strings.
+    #[serde(default)]
+    pub theme_overrides: Option<crate::palette::ConfigTheme>,
+
+    /// Named custom theme definitions from `[themes.*]` sections of config.toml.
+    #[serde(default)]
+    pub themes: Option<crate::palette::ConfigThemes>,
 }
 
 /// Vision model configuration for the `image_analyze` tool.
@@ -2834,6 +2845,8 @@ fn merge_config(base: Config, override_cfg: Config) -> Config {
         strict_tool_mode: override_cfg.strict_tool_mode.or(base.strict_tool_mode),
         runtime_api: override_cfg.runtime_api.or(base.runtime_api),
         workshop: override_cfg.workshop.or(base.workshop),
+        theme_overrides: override_cfg.theme_overrides.or(base.theme_overrides),
+        themes: override_cfg.themes.or(base.themes),
     }
 }
 

--- a/crates/tui/src/config_ui.rs
+++ b/crates/tui/src/config_ui.rs
@@ -58,7 +58,7 @@ pub struct SettingsSection {
     pub show_thinking: bool,
     pub show_tool_details: bool,
     pub locale: UiLocale,
-    pub theme: UiThemeValue,
+    pub theme: String,
     #[schemars(
         title = "Background color",
         description = "Main TUI background color as #RRGGBB"
@@ -171,19 +171,6 @@ pub enum UiLocale {
     #[serde(rename = "es-419")]
     #[schemars(rename = "es-419")]
     Es419,
-}
-
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
-#[serde(rename_all = "kebab-case")]
-pub enum UiThemeValue {
-    System,
-    Dark,
-    Light,
-    Grayscale,
-    CatppuccinMocha,
-    TokyoNight,
-    Dracula,
-    GruvboxDark,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -320,7 +307,7 @@ pub fn build_document(app: &App, config: &Config) -> Result<ConfigUiDocument> {
             show_thinking: settings.show_thinking,
             show_tool_details: settings.show_tool_details,
             locale: UiLocale::from_setting(&settings.locale)?,
-            theme: UiThemeValue::from_setting(&settings.theme)?,
+            theme: settings.theme.clone(),
             background_color: settings.background_color.clone(),
             bracketed_paste: settings.bracketed_paste,
             composer_density: settings.composer_density.as_str().into(),
@@ -484,7 +471,7 @@ pub fn apply_document(
             bool_str(doc.settings.show_tool_details),
         ),
         ("locale", doc.settings.locale.as_setting()),
-        ("theme", doc.settings.theme.as_setting()),
+        ("theme", doc.settings.theme.as_str()),
         (
             "background_color",
             doc.settings
@@ -728,36 +715,6 @@ impl UiLocale {
             Some("es-419") => Ok(Self::Es419),
             Some(other) => bail!("unsupported locale '{other}'"),
             None => bail!("invalid locale '{value}'"),
-        }
-    }
-}
-
-impl UiThemeValue {
-    fn as_setting(self) -> &'static str {
-        match self {
-            Self::System => "system",
-            Self::Dark => "dark",
-            Self::Light => "light",
-            Self::Grayscale => "grayscale",
-            Self::CatppuccinMocha => "catppuccin-mocha",
-            Self::TokyoNight => "tokyo-night",
-            Self::Dracula => "dracula",
-            Self::GruvboxDark => "gruvbox-dark",
-        }
-    }
-
-    fn from_setting(value: &str) -> Result<Self> {
-        match crate::palette::normalize_theme_name(value) {
-            Some("system") => Ok(Self::System),
-            Some("dark") => Ok(Self::Dark),
-            Some("light") => Ok(Self::Light),
-            Some("grayscale") => Ok(Self::Grayscale),
-            Some("catppuccin-mocha") => Ok(Self::CatppuccinMocha),
-            Some("tokyo-night") => Ok(Self::TokyoNight),
-            Some("dracula") => Ok(Self::Dracula),
-            Some("gruvbox-dark") => Ok(Self::GruvboxDark),
-            Some(other) => bail!("unsupported theme '{other}'"),
-            None => bail!("invalid theme '{value}'"),
         }
     }
 }
@@ -1172,20 +1129,6 @@ background_color = "#1A1B26"
         assert_eq!(
             locale,
             &serde_json::json!(["auto", "en", "ja", "zh-Hans", "pt-BR", "es-419"])
-        );
-        let theme = &schema["$defs"]["UiThemeValue"]["enum"];
-        assert_eq!(
-            theme,
-            &serde_json::json!([
-                "system",
-                "dark",
-                "light",
-                "grayscale",
-                "catppuccin-mocha",
-                "tokyo-night",
-                "dracula",
-                "gruvbox-dark"
-            ])
         );
     }
 

--- a/crates/tui/src/palette.rs
+++ b/crates/tui/src/palette.rs
@@ -1,8 +1,12 @@
 //! DeepSeek color palette and semantic roles.
 
+use std::collections::HashMap;
+
 use ratatui::style::Color;
 #[cfg(target_os = "macos")]
 use std::process::Command;
+
+use serde::{Deserialize, Serialize};
 
 pub const DEEPSEEK_BLUE_RGB: (u8, u8, u8) = (53, 120, 229); // #3578E5
 pub const DEEPSEEK_SKY_RGB: (u8, u8, u8) = (106, 174, 242);
@@ -624,6 +628,111 @@ pub const SELECTABLE_THEMES: &[ThemeId] = &[
     ThemeId::GruvboxDark,
 ];
 
+/// User-facing theme configuration loaded from config.toml.
+///
+/// Supports two patterns:
+///
+/// 1. **Inline overrides** — select a base theme and override individual colors:
+///    ```toml
+///    [tui]
+///    theme = "catppuccin-mocha"
+///
+///    [theme.overrides]
+///    surface_bg = "#1a1b2e"
+///    text_body = "#e0e0e0"
+///    ```
+///
+/// 2. **Named custom themes** — define one or more complete theme presets:
+///    ```toml
+///    [themes.my-custom]
+///    base = "catppuccin-mocha"
+///    surface_bg = "#1a1b2e"
+///    text_body = "#e0e0e0"
+///    ```
+///    Then select with `theme = "my-custom"`.
+///
+/// All color fields accept `#RRGGBB` hex strings. A field omitted from the
+/// override inherits from the base theme.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub struct ConfigTheme {
+    /// Base theme to extend. Accepts any value that `ThemeId::from_name`
+    /// recognizes. When absent the system-detected theme is used.
+    pub base: Option<String>,
+    /// Per-field color overrides. Keys match `UiTheme` field names
+    /// (`surface_bg`, `panel_bg`, `text_body`, etc.). Values are `#RRGGBB`
+    /// hex strings.
+    #[serde(flatten)]
+    pub overrides: HashMap<String, String>,
+}
+
+impl ConfigTheme {
+    /// Apply this configuration on top of a resolved `UiTheme`, returning
+    /// the merged theme.
+    #[must_use]
+    pub fn apply(self, base: UiTheme) -> UiTheme {
+        let mut theme = base;
+        for (key, hex_value) in self.overrides {
+            if let Some(color) = parse_hex_rgb_color(&hex_value) {
+                match key.as_str() {
+                    "surface_bg" => theme.surface_bg = color,
+                    "panel_bg" => theme.panel_bg = color,
+                    "elevated_bg" => theme.elevated_bg = color,
+                    "composer_bg" => theme.composer_bg = color,
+                    "selection_bg" => theme.selection_bg = color,
+                    "header_bg" => theme.header_bg = color,
+                    "footer_bg" => theme.footer_bg = color,
+                    "mode_agent" => theme.mode_agent = color,
+                    "mode_yolo" => theme.mode_yolo = color,
+                    "mode_plan" => theme.mode_plan = color,
+                    "status_ready" => theme.status_ready = color,
+                    "status_working" => theme.status_working = color,
+                    "status_warning" => theme.status_warning = color,
+                    "text_dim" => theme.text_dim = color,
+                    "text_hint" => theme.text_hint = color,
+                    "text_muted" => theme.text_muted = color,
+                    "text_body" => theme.text_body = color,
+                    "text_soft" => theme.text_soft = color,
+                    "border" => theme.border = color,
+                    _ => { /* unknown key — silently ignored */ }
+                }
+            }
+        }
+        theme
+    }
+}
+
+/// A collection of named custom themes loaded from the `[themes.*]` sections
+/// of config.toml.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub struct ConfigThemes {
+    #[serde(flatten)]
+    pub themes: HashMap<String, ConfigTheme>,
+}
+
+impl ConfigThemes {
+    /// Resolve a theme name against the custom theme registry.
+    ///
+    /// If `name` matches a key in `self.themes`, the custom theme is resolved
+    /// by first loading the base theme (from `ThemeId` or system detection),
+    /// then applying the stored overrides.
+    ///
+    /// Returns `None` when the name is not found in the registry, falling
+    /// back to the standard `ThemeId` resolution path.
+    #[must_use]
+    pub fn resolve(&self, name: &str) -> Option<UiTheme> {
+        let config_theme = self.themes.get(name)?;
+        let base_id = config_theme
+            .base
+            .as_deref()
+            .and_then(ThemeId::from_name)
+            .unwrap_or(ThemeId::System);
+        let base_theme = base_id.ui_theme();
+        Some(config_theme.clone().apply(base_theme))
+    }
+}
+
 impl UiTheme {
     #[must_use]
     pub fn for_mode(mode: PaletteMode) -> Self {
@@ -678,12 +787,43 @@ pub fn theme_label_for_mode(mode: PaletteMode) -> &'static str {
     }
 }
 
+/// Resolve a `UiTheme` from settings, with optional custom theme registry
+/// and inline overrides.
+///
+/// Resolution order:
+/// 1. If `custom_themes` contains an entry for `theme`, resolve it and apply
+///    any `inline_overrides`.
+/// 2. Otherwise, resolve `theme` through `ThemeId::from_name` (or fall back
+///    to system detection).
+/// 3. Apply `inline_overrides` if present.
+/// 4. Apply `background_color` override if present.
 #[must_use]
-pub fn ui_theme_from_settings(theme: &str, background_color: Option<&str>) -> UiTheme {
-    let mut ui_theme = UiTheme::from_setting(theme).unwrap_or_else(UiTheme::detect);
+pub fn ui_theme_from_settings(
+    theme: &str,
+    background_color: Option<&str>,
+    custom_themes: Option<&ConfigThemes>,
+    inline_overrides: Option<&ConfigTheme>,
+) -> UiTheme {
+    // Step 1-2: Resolve the base theme
+    let base_theme = if let Some(ct) = custom_themes {
+        ct.resolve(theme)
+            .unwrap_or_else(|| UiTheme::from_setting(theme).unwrap_or_else(UiTheme::detect))
+    } else {
+        UiTheme::from_setting(theme).unwrap_or_else(UiTheme::detect)
+    };
+
+    // Step 3: Apply inline overrides
+    let mut ui_theme = if let Some(overrides) = inline_overrides {
+        overrides.clone().apply(base_theme)
+    } else {
+        base_theme
+    };
+
+    // Step 4: Apply background color override (highest precedence)
     if let Some(background) = background_color.and_then(parse_hex_rgb_color) {
         ui_theme = ui_theme.with_background_color(background);
     }
+
     ui_theme
 }
 
@@ -1348,6 +1488,7 @@ fn rgb_to_ansi256(r: u8, g: u8, b: u8) -> u8 {
 #[cfg(test)]
 mod tests {
     use super::{
+        ThemeId, ConfigTheme, ConfigThemes,
         ACCENT_REASONING_LIVE, ColorDepth, DEEPSEEK_INK, DEEPSEEK_RED, DEEPSEEK_SKY,
         DEEPSEEK_SLATE, GRAYSCALE_BORDER, GRAYSCALE_ELEVATED, GRAYSCALE_PANEL, GRAYSCALE_REASONING,
         GRAYSCALE_SURFACE, GRAYSCALE_TEXT_BODY, GRAYSCALE_TEXT_HINT, GRAYSCALE_TEXT_SOFT,
@@ -1542,7 +1683,7 @@ mod tests {
 
     #[test]
     fn ui_theme_from_settings_applies_theme_and_background() {
-        let theme = ui_theme_from_settings("grayscale", Some("#111111"));
+        let theme = ui_theme_from_settings("grayscale", Some("#111111"), None, None);
         assert_eq!(theme.mode, PaletteMode::Grayscale);
         assert_eq!(theme.surface_bg, Color::Rgb(17, 17, 17));
         assert_eq!(theme.header_bg, Color::Rgb(17, 17, 17));
@@ -1693,5 +1834,103 @@ mod tests {
         // exercise the path so a panic would surface.
         let _ = ColorDepth::detect();
         let _ = adapt_color(DEEPSEEK_INK, ColorDepth::detect());
+    }
+
+    #[test]
+    fn config_theme_apply_overrides_colors() {
+        let base = ThemeId::Grayscale.ui_theme();
+        let mut overrides = std::collections::HashMap::new();
+        overrides.insert("surface_bg".to_string(), "#1a1b2e".to_string());
+        overrides.insert("text_body".to_string(), "#e0e0e0".to_string());
+
+        let config_theme = ConfigTheme {
+            base: Some("grayscale".to_string()),
+            overrides,
+        };
+
+        let theme = config_theme.apply(base);
+        assert_eq!(theme.surface_bg, Color::Rgb(26, 27, 46));
+        assert_eq!(theme.text_body, Color::Rgb(224, 224, 224));
+        // Other fields should remain from the base theme
+        assert_eq!(theme.panel_bg, GRAYSCALE_PANEL);
+    }
+
+    #[test]
+    fn config_theme_apply_ignores_unknown_keys() {
+        let base = ThemeId::Grayscale.ui_theme();
+        let mut overrides = std::collections::HashMap::new();
+        overrides.insert("unknown_field".to_string(), "#1a1b2e".to_string());
+
+        let config_theme = ConfigTheme {
+            base: Some("grayscale".to_string()),
+            overrides,
+        };
+
+        let theme = config_theme.apply(base);
+        // Should not panic and should keep the base value
+        assert_eq!(theme.surface_bg, GRAYSCALE_SURFACE);
+    }
+
+    #[test]
+    fn config_themes_resolve_custom_theme() {
+        let mut themes_map = std::collections::HashMap::new();
+        let mut overrides = std::collections::HashMap::new();
+        overrides.insert("surface_bg".to_string(), "#2a2b3e".to_string());
+
+        let custom_theme = ConfigTheme {
+            base: Some("grayscale".to_string()),
+            overrides,
+        };
+        themes_map.insert("my-custom".to_string(), custom_theme);
+
+        let config_themes = ConfigThemes { themes: themes_map };
+
+        let theme = config_themes.resolve("my-custom");
+        assert!(theme.is_some());
+        let theme = theme.unwrap();
+        assert_eq!(theme.surface_bg, Color::Rgb(42, 43, 62));
+        // Other fields should come from the grayscale base
+        assert_eq!(theme.panel_bg, GRAYSCALE_PANEL);
+    }
+
+    #[test]
+    fn config_themes_resolve_returns_none_for_unknown() {
+        let config_themes = ConfigThemes::default();
+        let theme = config_themes.resolve("nonexistent");
+        assert!(theme.is_none());
+    }
+
+    #[test]
+    fn ui_theme_from_settings_with_custom_themes() {
+        let mut themes_map = std::collections::HashMap::new();
+        let mut overrides = std::collections::HashMap::new();
+        overrides.insert("surface_bg".to_string(), "#3a3b4e".to_string());
+
+        let custom_theme = ConfigTheme {
+            base: Some("grayscale".to_string()),
+            overrides,
+        };
+        themes_map.insert("test-theme".to_string(), custom_theme);
+
+        let config_themes = ConfigThemes { themes: themes_map };
+
+        let theme = ui_theme_from_settings("test-theme", None, Some(&config_themes), None);
+        assert_eq!(theme.surface_bg, Color::Rgb(58, 59, 78));
+    }
+
+    #[test]
+    fn ui_theme_from_settings_with_inline_overrides() {
+        let mut overrides = std::collections::HashMap::new();
+        overrides.insert("surface_bg".to_string(), "#4a4b5e".to_string());
+
+        let config_theme = ConfigTheme {
+            base: None,
+            overrides,
+        };
+
+        let theme = ui_theme_from_settings("grayscale", None, None, Some(&config_theme));
+        assert_eq!(theme.surface_bg, Color::Rgb(74, 75, 94));
+        // Other fields should come from the grayscale base
+        assert_eq!(theme.panel_bg, GRAYSCALE_PANEL);
     }
 }

--- a/crates/tui/src/palette.rs
+++ b/crates/tui/src/palette.rs
@@ -670,10 +670,10 @@ impl ConfigTheme {
     /// Apply this configuration on top of a resolved `UiTheme`, returning
     /// the merged theme.
     #[must_use]
-    pub fn apply(self, base: UiTheme) -> UiTheme {
+    pub fn apply(&self, base: UiTheme) -> UiTheme {
         let mut theme = base;
-        for (key, hex_value) in self.overrides {
-            if let Some(color) = parse_hex_rgb_color(&hex_value) {
+        for (key, hex_value) in &self.overrides {
+            if let Some(color) = parse_hex_rgb_color(hex_value) {
                 match key.as_str() {
                     "surface_bg" => theme.surface_bg = color,
                     "panel_bg" => theme.panel_bg = color,
@@ -729,7 +729,7 @@ impl ConfigThemes {
             .and_then(ThemeId::from_name)
             .unwrap_or(ThemeId::System);
         let base_theme = base_id.ui_theme();
-        Some(config_theme.clone().apply(base_theme))
+        Some(config_theme.apply(base_theme))
     }
 }
 
@@ -814,7 +814,7 @@ pub fn ui_theme_from_settings(
 
     // Step 3: Apply inline overrides
     let mut ui_theme = if let Some(overrides) = inline_overrides {
-        overrides.clone().apply(base_theme)
+        overrides.apply(base_theme)
     } else {
         base_theme
     };
@@ -1488,15 +1488,14 @@ fn rgb_to_ansi256(r: u8, g: u8, b: u8) -> u8 {
 #[cfg(test)]
 mod tests {
     use super::{
-        ThemeId, ConfigTheme, ConfigThemes,
-        ACCENT_REASONING_LIVE, ColorDepth, DEEPSEEK_INK, DEEPSEEK_RED, DEEPSEEK_SKY,
-        DEEPSEEK_SLATE, GRAYSCALE_BORDER, GRAYSCALE_ELEVATED, GRAYSCALE_PANEL, GRAYSCALE_REASONING,
-        GRAYSCALE_SURFACE, GRAYSCALE_TEXT_BODY, GRAYSCALE_TEXT_HINT, GRAYSCALE_TEXT_SOFT,
-        GRAYSCALE_UI_THEME, LIGHT_BORDER, LIGHT_ELEVATED, LIGHT_PANEL, LIGHT_REASONING,
-        LIGHT_SURFACE, LIGHT_TEXT_BODY, LIGHT_TEXT_HINT, LIGHT_UI_THEME, PaletteMode,
-        SURFACE_REASONING, SURFACE_REASONING_TINT, TEXT_BODY, TEXT_HINT, TEXT_REASONING,
-        TEXT_TOOL_OUTPUT, UI_THEME, adapt_bg, adapt_bg_for_palette_mode, adapt_color,
-        adapt_fg_for_palette_mode, blend, nearest_ansi16, normalize_hex_rgb_color,
+        ACCENT_REASONING_LIVE, ColorDepth, ConfigTheme, ConfigThemes, DEEPSEEK_INK, DEEPSEEK_RED,
+        DEEPSEEK_SKY, DEEPSEEK_SLATE, GRAYSCALE_BORDER, GRAYSCALE_ELEVATED, GRAYSCALE_PANEL,
+        GRAYSCALE_REASONING, GRAYSCALE_SURFACE, GRAYSCALE_TEXT_BODY, GRAYSCALE_TEXT_HINT,
+        GRAYSCALE_TEXT_SOFT, GRAYSCALE_UI_THEME, LIGHT_BORDER, LIGHT_ELEVATED, LIGHT_PANEL,
+        LIGHT_REASONING, LIGHT_SURFACE, LIGHT_TEXT_BODY, LIGHT_TEXT_HINT, LIGHT_UI_THEME,
+        PaletteMode, SURFACE_REASONING, SURFACE_REASONING_TINT, TEXT_BODY, TEXT_HINT,
+        TEXT_REASONING, TEXT_TOOL_OUTPUT, ThemeId, UI_THEME, adapt_bg, adapt_bg_for_palette_mode,
+        adapt_color, adapt_fg_for_palette_mode, blend, nearest_ansi16, normalize_hex_rgb_color,
         normalize_theme_name, parse_hex_rgb_color, pulse_brightness, reasoning_surface_tint,
         rgb_to_ansi256, theme_label_for_mode, ui_theme_from_settings,
     };

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -203,6 +203,14 @@ pub struct Settings {
     pub theme: String,
     /// Optional main TUI background color as a 6-digit hex RGB value.
     pub background_color: Option<String>,
+    /// Inline color overrides applied on top of the resolved theme.
+    /// Keys match `UiTheme` field names (`surface_bg`, `text_body`, etc.).
+    /// Values are `#RRGGBB` hex strings.
+    pub theme_overrides: crate::palette::ConfigTheme,
+    /// Named custom theme definitions from `[themes.*]` sections.
+    /// Each entry specifies a `base` theme and optional color overrides.
+    /// Select with `theme = "my-custom"`.
+    pub custom_themes: crate::palette::ConfigThemes,
     /// Composer layout density: compact, comfortable, spacious
     pub composer_density: String,
     /// Show a border around the composer input area
@@ -295,6 +303,8 @@ impl Default for Settings {
             locale: "auto".to_string(),
             theme: "system".to_string(),
             background_color: None,
+            theme_overrides: Default::default(),
+            custom_themes: Default::default(),
             composer_density: "comfortable".to_string(),
             composer_border: true,
             composer_vim_mode: "normal".to_string(),
@@ -496,21 +506,12 @@ impl Settings {
                 };
                 self.locale = locale.to_string();
             }
-            "theme" => {
-                let Some(id) = crate::palette::ThemeId::from_name(value) else {
-                    anyhow::bail!(
-                        "Failed to update setting: invalid theme '{value}'. Expected: system, dark, light, grayscale, catppuccin-mocha, tokyo-night, dracula, gruvbox-dark."
-                    );
-                };
-                self.theme = id.name().to_string();
-            }
-            "ui_theme" => {
-                let Some(id) = crate::palette::ThemeId::from_name(value) else {
-                    anyhow::bail!(
-                        "Failed to update setting: invalid theme '{value}'. Expected: system, dark, light, grayscale, catppuccin-mocha, tokyo-night, dracula, gruvbox-dark."
-                    );
-                };
-                self.theme = id.name().to_string();
+            "theme" | "ui_theme" => {
+                if let Some(id) = crate::palette::ThemeId::from_name(value) {
+                    self.theme = id.name().to_string();
+                } else {
+                    self.theme = value.to_string();
+                }
             }
             "background_color" | "background" | "bg" => {
                 self.background_color = normalize_background_color_setting(value)?;
@@ -1051,7 +1052,7 @@ mod tests {
     }
 
     #[test]
-    fn theme_normalizes_supported_values_and_rejects_unknowns() {
+    fn theme_normalizes_supported_values_and_accepts_custom_names() {
         let mut settings = Settings::default();
         assert_eq!(settings.theme, "system");
 
@@ -1069,10 +1070,10 @@ mod tests {
             .expect("set community theme alias");
         assert_eq!(settings.theme, "tokyo-night");
 
-        let err = settings
+        settings
             .set("theme", "solarized")
-            .expect_err("unknown theme should fail");
-        assert!(err.to_string().contains("invalid theme"));
+            .expect("set unknown custom theme");
+        assert_eq!(settings.theme, "solarized");
     }
 
     #[test]

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -1335,8 +1335,6 @@ impl App {
         let sidebar_focus = SidebarFocus::from_setting(&settings.sidebar_focus);
         let max_input_history = settings.max_input_history;
         let use_paste_burst_detection = settings.paste_burst_detection;
-        let theme_id =
-            palette::ThemeId::from_name(&settings.theme).unwrap_or(palette::ThemeId::System);
         // Resolve the named theme from settings with custom theme registry
         // and inline overrides. Resolution order:
         // 1. Custom themes from config.toml [themes.*] sections
@@ -1531,7 +1529,8 @@ impl App {
             pending_subagent_dispatch: None,
             agent_activity_started_at: None,
             ui_theme,
-            theme_id,
+            theme_id: palette::ThemeId::from_name(&settings.theme)
+                .unwrap_or(palette::ThemeId::System),
             onboarding,
             onboarding_needs_api_key: needs_api_key,
             onboarding_workspace_trust_gate,

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -1335,19 +1335,23 @@ impl App {
         let sidebar_focus = SidebarFocus::from_setting(&settings.sidebar_focus);
         let max_input_history = settings.max_input_history;
         let use_paste_burst_detection = settings.paste_burst_detection;
-        // Resolve the named theme from settings; unknown values were already
-        // normalised to "system" in Settings::load. The background_color
-        // setting still overlays on top.
         let theme_id =
             palette::ThemeId::from_name(&settings.theme).unwrap_or(palette::ThemeId::System);
-        let mut ui_theme = theme_id.ui_theme();
-        if let Some(background) = settings
-            .background_color
-            .as_deref()
-            .and_then(palette::parse_hex_rgb_color)
-        {
-            ui_theme = ui_theme.with_background_color(background);
-        }
+        // Resolve the named theme from settings with custom theme registry
+        // and inline overrides. Resolution order:
+        // 1. Custom themes from config.toml [themes.*] sections
+        // 2. Named theme from settings.theme
+        // 3. Inline overrides from settings.theme_overrides
+        // 4. background_color override (highest precedence)
+        let ui_theme = palette::ui_theme_from_settings(
+            &settings.theme,
+            settings.background_color.as_deref(),
+            config.themes.as_ref().or(Some(&settings.custom_themes)),
+            config
+                .theme_overrides
+                .as_ref()
+                .or(Some(&settings.theme_overrides)),
+        );
         let model = settings
             .provider_models
             .as_ref()

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -6427,7 +6427,6 @@ fn push_keyboard_enhancement_flags<W: Write>(writer: &mut W) {
                 "PushKeyboardEnhancementFlags direct write failed on Windows"
             );
         }
-        return;
     }
     #[cfg(not(windows))]
     if let Err(err) = execute!(
@@ -6459,7 +6458,6 @@ pub(crate) fn pop_keyboard_enhancement_flags<W: Write>(writer: &mut W) {
                 "PopKeyboardEnhancementFlags direct write failed on Windows"
             );
         }
-        return;
     }
     #[cfg(not(windows))]
     let _ = execute!(writer, PopKeyboardEnhancementFlags);

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -328,11 +328,11 @@ replacement compaction. You can inspect or update these from the TUI with
 Common settings keys:
 
 - `theme` (`system`, `dark`, `light`, `grayscale`, `catppuccin-mocha`,
-  `tokyo-night`, `dracula`, `gruvbox-dark`; default `system`): `system`
+  `tokyo-night`, `dracula`, `gruvbox-dark`, or any custom theme name; default `system`): `system`
   follows terminal background detection, `dark`/`light` use the DeepSeek
   palettes, `grayscale` is the low-opinion black/white theme, and the named
   community presets apply across the TUI. Aliases such as `whale`, `mono`,
-  `black-white`, `tokyonight`, and `gruvbox` are accepted.
+  `black-white`, `tokyonight`, and `gruvbox` are accepted. You can also define custom themes or apply inline color overrides using `[themes.my-custom]` or `[theme.overrides]` in your configuration file.
 - `auto_compact` (on/off, default off)
 - `paste_burst_detection` (on/off, default on): fallback rapid-key paste
   detection for terminals that do not emit bracketed-paste events. This is


### PR DESCRIPTION
This feature enables users to define their own custom themes or override specific colors of existing themes directly in the config.toml file. It introduces a new hemes registry and 	heme_overrides settings block, while also removing the rigid enum validation for themes to allow free-form custom names.

Additionally resolves previously missed compilation issues related to heme_id, missing struct initializers, and type mismatches in the settings resolver.

## Summary

## Testing

- [X] `cargo test --all-features`
- [X] `cargo fmt --all -- --check`
- [X] `cargo clippy --all-targets --all-features`

## Checklist

- [X] Updated docs or comments as needed
- [X] Added or updated tests where relevant
- [X] Verified TUI behavior manually if UI changes
