### PR TITLE
feat(tui): add /balance slash command to show the balance

### DIFF
--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -660,10 +660,7 @@ impl DeepSeekClient {
 
     /// Fetch the current DeepSeek account balance.
     pub async fn account_balance(&self) -> Result<AccountBalance> {
-        let url = format!(
-            "{}/user/balance",
-            unversioned_base_url(&self.base_url).trim_end_matches('/')
-        );
+        let url = format!("{}/user/balance", unversioned_base_url(&self.base_url));
         let response = self.send_with_retry(|| self.http_client.get(&url)).await?;
 
         let status = response.status();

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -119,6 +119,21 @@ pub struct AvailableModel {
     pub created: Option<u64>,
 }
 
+/// Account balance returned by DeepSeek's `/user/balance` endpoint.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct AccountBalance {
+    pub is_available: bool,
+    pub balance_infos: Vec<AccountBalanceInfo>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct AccountBalanceInfo {
+    pub currency: String,
+    pub total_balance: String,
+    pub granted_balance: String,
+    pub topped_up_balance: String,
+}
+
 /// Client for DeepSeek's OpenAI-compatible APIs.
 #[must_use]
 pub struct DeepSeekClient {
@@ -643,6 +658,26 @@ impl DeepSeekClient {
         parse_models_response(&response_text)
     }
 
+    /// Fetch the current DeepSeek account balance.
+    pub async fn account_balance(&self) -> Result<AccountBalance> {
+        let url = format!(
+            "{}/user/balance",
+            unversioned_base_url(&self.base_url).trim_end_matches('/')
+        );
+        let response = self.send_with_retry(|| self.http_client.get(&url)).await?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let error_text = bounded_error_text(response, ERROR_BODY_MAX_BYTES).await;
+            anyhow::bail!("Failed to fetch account balance: HTTP {status}: {error_text}");
+        }
+
+        response
+            .json::<AccountBalance>()
+            .await
+            .context("Failed to parse account balance response")
+    }
+
     async fn wait_for_rate_limit(&self) {
         let maybe_delay = {
             let mut limiter = self.rate_limiter.lock().await;
@@ -1094,10 +1129,13 @@ mod tests {
         parse_chat_message, parse_sse_chunk, sanitize_thinking_mode_messages, tool_to_chat,
         tool_to_chat_for_base_url,
     };
+    use crate::config::Config;
     use crate::models::{
         ContentBlock, ContentBlockStart, Delta, Message, MessageRequest, StreamEvent, Tool,
     };
     use serde_json::json;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[test]
     fn tool_name_roundtrip_dot() {
@@ -2794,6 +2832,41 @@ mod tests {
             delay >= Duration::from_millis(400) && delay <= Duration::from_millis(600),
             "unexpected refill delay: {delay:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn account_balance_fetches_unversioned_user_balance_endpoint() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/user/balance"))
+            .and(header("authorization", "Bearer sk-test"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "is_available": true,
+                "balance_infos": [
+                    {
+                        "currency": "CNY",
+                        "total_balance": "8.66",
+                        "granted_balance": "0.00",
+                        "topped_up_balance": "8.66"
+                    }
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config {
+            api_key: Some("sk-test".to_string()),
+            base_url: Some(format!("{}/beta", server.uri())),
+            ..Config::default()
+        };
+        let client = DeepSeekClient::new(&config).expect("client should construct");
+
+        let balance = client.account_balance().await.expect("balance response");
+
+        assert!(balance.is_available);
+        assert_eq!(balance.balance_infos.len(), 1);
+        assert_eq!(balance.balance_infos[0].currency, "CNY");
+        assert_eq!(balance.balance_infos[0].total_balance, "8.66");
     }
 
     #[test]

--- a/crates/tui/src/commands/core.rs
+++ b/crates/tui/src/commands/core.rs
@@ -155,6 +155,11 @@ pub fn models(_app: &mut App) -> CommandResult {
     CommandResult::action(AppAction::FetchModels)
 }
 
+/// Fetch the current DeepSeek account balance.
+pub fn balance(_app: &mut App) -> CommandResult {
+    CommandResult::action(AppAction::FetchBalance)
+}
+
 /// List sub-agent status from the engine
 pub fn subagents(app: &mut App) -> CommandResult {
     if app.view_stack.top_kind() != Some(ModalKind::SubAgents) {

--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -177,6 +177,12 @@ pub const COMMANDS: &[CommandInfo] = &[
         description_id: MessageId::CmdModelsDescription,
     },
     CommandInfo {
+        name: "balance",
+        aliases: &["yue"],
+        usage: "/balance",
+        description_id: MessageId::CmdBalanceDescription,
+    },
+    CommandInfo {
         name: "provider",
         aliases: &[],
         usage: "/provider [name]",
@@ -549,6 +555,7 @@ pub fn execute(cmd: &str, app: &mut App) -> CommandResult {
         "exit" | "quit" | "q" | "tuichu" => core::exit(),
         "model" | "moxing" => core::model(app, arg),
         "models" | "moxingliebiao" => core::models(app),
+        "balance" | "yue" => core::balance(app),
         "provider" => provider::provider(app, arg),
         "queue" | "queued" => queue::queue(app, arg),
         "stash" | "park" => stash::stash(app, arg),
@@ -1096,6 +1103,7 @@ mod tests {
         assert!(COMMANDS.iter().any(|cmd| cmd.name == "config"));
         assert!(COMMANDS.iter().any(|cmd| cmd.name == "links"));
         assert!(COMMANDS.iter().any(|cmd| cmd.name == "memory"));
+        assert!(COMMANDS.iter().any(|cmd| cmd.name == "balance"));
         assert!(!COMMANDS.iter().any(|cmd| cmd.name == "set"));
         assert!(!COMMANDS.iter().any(|cmd| cmd.name == "deepseek"));
     }
@@ -1262,6 +1270,14 @@ mod tests {
         let result = execute("/cache warmup", &mut app);
         assert!(result.message.is_none());
         assert!(matches!(result.action, Some(AppAction::CacheWarmup)));
+    }
+
+    #[test]
+    fn balance_command_dispatches_action() {
+        let mut app = create_test_app();
+        let result = execute("/balance", &mut app);
+        assert!(result.message.is_none());
+        assert!(matches!(result.action, Some(AppAction::FetchBalance)));
     }
 
     #[test]

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -700,6 +700,42 @@ impl Engine {
                     };
                     let _ = self.tx_event.send(Event::AgentList { agents }).await;
                 }
+                Op::FetchBalance { provider } => {
+                    let Some(client) = self.deepseek_client.clone() else {
+                        let message = self
+                            .deepseek_client_error
+                            .clone()
+                            .unwrap_or_else(|| "API client not configured".to_string());
+                        let _ = self
+                            .tx_event
+                            .send(Event::AccountBalance {
+                                provider,
+                                result: Err(message),
+                            })
+                            .await;
+                        continue;
+                    };
+                    let tx_event = self.tx_event.clone();
+                    spawn_supervised(
+                        "fetch-account-balance",
+                        std::panic::Location::caller(),
+                        async move {
+                            let result = match tokio::time::timeout(
+                                Duration::from_secs(20),
+                                client.account_balance(),
+                            )
+                            .await
+                            {
+                                Ok(Ok(balance)) => Ok(balance),
+                                Ok(Err(err)) => Err(err.to_string()),
+                                Err(err) => Err(err.to_string()),
+                            };
+                            let _ = tx_event
+                                .send(Event::AccountBalance { provider, result })
+                                .await;
+                        },
+                    );
+                }
                 Op::ChangeMode { mode } => {
                     let _ = self
                         .tx_event

--- a/crates/tui/src/core/events.rs
+++ b/crates/tui/src/core/events.rs
@@ -7,6 +7,7 @@ use std::{path::PathBuf, sync::Arc};
 
 use serde_json::Value;
 
+use crate::client::AccountBalance;
 use crate::core::coherence::CoherenceState;
 use crate::error_taxonomy::ErrorEnvelope;
 use crate::models::{Message, SystemPrompt, Usage};
@@ -191,6 +192,12 @@ pub enum Event {
 
     /// Sub-agent listing
     AgentList { agents: Vec<SubAgentResult> },
+
+    /// DeepSeek account balance response for `/balance`.
+    AccountBalance {
+        provider: String,
+        result: Result<AccountBalance, String>,
+    },
 
     /// Structured sub-agent mailbox envelope (issue #128). Carries the
     /// monotonic seq + the typed `MailboxMessage` so the UI can route each

--- a/crates/tui/src/core/ops.rs
+++ b/crates/tui/src/core/ops.rs
@@ -52,6 +52,9 @@ pub enum Op {
     /// List current sub-agents and their status
     ListSubAgents,
 
+    /// Fetch DeepSeek account balance without blocking the UI loop.
+    FetchBalance { provider: String },
+
     /// Change the operating mode
     #[allow(dead_code)]
     ChangeMode { mode: AppMode },

--- a/crates/tui/src/localization.rs
+++ b/crates/tui/src/localization.rs
@@ -247,6 +247,19 @@ pub enum MessageId {
     CmdAttachDescription,
     CmdAnchorDescription,
     CmdBalanceDescription,
+    AccountBalanceProvider,
+    AccountBalanceBalance,
+    AccountBalanceToppedUp,
+    AccountBalanceGranted,
+    AccountBalanceAvailable,
+    AccountBalanceUnavailable,
+    AccountBalanceYes,
+    AccountBalanceNo,
+    AccountBalanceFetching,
+    AccountBalanceFetched,
+    AccountBalanceFetchFailed,
+    AccountBalanceFetchFailedPrefix,
+    AccountBalanceUnsupportedProviderPrefix,
     CmdCacheDescription,
     CmdChangeDescription,
     CmdChangeHeader,
@@ -486,6 +499,19 @@ pub const ALL_MESSAGE_IDS: &[MessageId] = &[
     MessageId::CmdAnchorDescription,
     MessageId::CmdAttachDescription,
     MessageId::CmdBalanceDescription,
+    MessageId::AccountBalanceProvider,
+    MessageId::AccountBalanceBalance,
+    MessageId::AccountBalanceToppedUp,
+    MessageId::AccountBalanceGranted,
+    MessageId::AccountBalanceAvailable,
+    MessageId::AccountBalanceUnavailable,
+    MessageId::AccountBalanceYes,
+    MessageId::AccountBalanceNo,
+    MessageId::AccountBalanceFetching,
+    MessageId::AccountBalanceFetched,
+    MessageId::AccountBalanceFetchFailed,
+    MessageId::AccountBalanceFetchFailedPrefix,
+    MessageId::AccountBalanceUnsupportedProviderPrefix,
     MessageId::CmdCacheDescription,
     MessageId::CmdClearDescription,
     MessageId::CmdCompactDescription,
@@ -901,6 +927,21 @@ fn english(id: MessageId) -> &'static str {
             "Attach image/video media; use @path for text files or directories"
         }
         MessageId::CmdBalanceDescription => "Show DeepSeek API account balance",
+        MessageId::AccountBalanceProvider => "Provider",
+        MessageId::AccountBalanceBalance => "Balance",
+        MessageId::AccountBalanceToppedUp => "topped up",
+        MessageId::AccountBalanceGranted => "granted",
+        MessageId::AccountBalanceAvailable => "Available",
+        MessageId::AccountBalanceUnavailable => "unavailable",
+        MessageId::AccountBalanceYes => "yes",
+        MessageId::AccountBalanceNo => "no",
+        MessageId::AccountBalanceFetching => "Fetching account balance...",
+        MessageId::AccountBalanceFetched => "Account balance fetched",
+        MessageId::AccountBalanceFetchFailed => "Balance fetch failed",
+        MessageId::AccountBalanceFetchFailedPrefix => "Failed to fetch account balance: ",
+        MessageId::AccountBalanceUnsupportedProviderPrefix => {
+            "/balance is only supported by the DeepSeek provider. Current provider: "
+        }
         MessageId::CmdCacheDescription => {
             "Show DeepSeek prefix-cache hit/miss stats for the last N turns"
         }
@@ -1279,6 +1320,21 @@ fn japanese(id: MessageId) -> Option<&'static str> {
             "画像・動画メディアを添付（テキストファイルやディレクトリは @path）"
         }
         MessageId::CmdBalanceDescription => "DeepSeek API アカウント残高を表示",
+        MessageId::AccountBalanceProvider => "プロバイダー",
+        MessageId::AccountBalanceBalance => "残高",
+        MessageId::AccountBalanceToppedUp => "チャージ分",
+        MessageId::AccountBalanceGranted => "付与分",
+        MessageId::AccountBalanceAvailable => "利用可能",
+        MessageId::AccountBalanceUnavailable => "利用不可",
+        MessageId::AccountBalanceYes => "はい",
+        MessageId::AccountBalanceNo => "いいえ",
+        MessageId::AccountBalanceFetching => "アカウント残高を取得中...",
+        MessageId::AccountBalanceFetched => "アカウント残高を取得しました",
+        MessageId::AccountBalanceFetchFailed => "残高の取得に失敗しました",
+        MessageId::AccountBalanceFetchFailedPrefix => "アカウント残高の取得に失敗しました: ",
+        MessageId::AccountBalanceUnsupportedProviderPrefix => {
+            "/balance は DeepSeek プロバイダーでのみ利用できます。現在のプロバイダー: "
+        }
         MessageId::CmdCacheDescription => {
             "直近 N ターンの DeepSeek プレフィックスキャッシュのヒット/ミス統計を表示"
         }
@@ -1634,6 +1690,21 @@ fn chinese_simplified(id: MessageId) -> Option<&'static str> {
         MessageId::CmdAnchorDescription => "钉选关键事实，在压缩后自动注入上下文",
         MessageId::CmdAttachDescription => "附加图片或视频媒体；文本文件或目录请使用 @path",
         MessageId::CmdBalanceDescription => "显示 DeepSeek API 账户余额",
+        MessageId::AccountBalanceProvider => "提供商",
+        MessageId::AccountBalanceBalance => "余额",
+        MessageId::AccountBalanceToppedUp => "充值余额",
+        MessageId::AccountBalanceGranted => "赠送余额",
+        MessageId::AccountBalanceAvailable => "可用",
+        MessageId::AccountBalanceUnavailable => "不可用",
+        MessageId::AccountBalanceYes => "是",
+        MessageId::AccountBalanceNo => "否",
+        MessageId::AccountBalanceFetching => "正在获取账户余额...",
+        MessageId::AccountBalanceFetched => "账户余额已获取",
+        MessageId::AccountBalanceFetchFailed => "余额获取失败",
+        MessageId::AccountBalanceFetchFailedPrefix => "获取账户余额失败: ",
+        MessageId::AccountBalanceUnsupportedProviderPrefix => {
+            "/balance 仅支持 DeepSeek 提供商。当前提供商: "
+        }
         MessageId::CmdCacheDescription => "显示最近 N 轮的 DeepSeek 前缀缓存命中/未命中统计",
         MessageId::CmdChangeDescription => "显示最新的更新日志",
         MessageId::CmdChangeHeader => "最新更新日志",
@@ -1945,6 +2016,21 @@ fn portuguese_brazil(id: MessageId) -> Option<&'static str> {
             "Anexar imagem ou vídeo; use @path para arquivos de texto ou diretórios"
         }
         MessageId::CmdBalanceDescription => "Exibir o saldo da conta da API DeepSeek",
+        MessageId::AccountBalanceProvider => "Provedor",
+        MessageId::AccountBalanceBalance => "Saldo",
+        MessageId::AccountBalanceToppedUp => "recarregado",
+        MessageId::AccountBalanceGranted => "concedido",
+        MessageId::AccountBalanceAvailable => "Disponível",
+        MessageId::AccountBalanceUnavailable => "indisponível",
+        MessageId::AccountBalanceYes => "sim",
+        MessageId::AccountBalanceNo => "não",
+        MessageId::AccountBalanceFetching => "Buscando saldo da conta...",
+        MessageId::AccountBalanceFetched => "Saldo da conta obtido",
+        MessageId::AccountBalanceFetchFailed => "Falha ao buscar saldo",
+        MessageId::AccountBalanceFetchFailedPrefix => "Falha ao buscar saldo da conta: ",
+        MessageId::AccountBalanceUnsupportedProviderPrefix => {
+            "/balance é compatível apenas com o provedor DeepSeek. Provedor atual: "
+        }
         MessageId::CmdCacheDescription => {
             "Exibir estatísticas de hit/miss do cache de prefixo DeepSeek nas últimas N rodadas"
         }
@@ -2328,6 +2414,21 @@ fn spanish_latin_america(id: MessageId) -> Option<&'static str> {
             "Adjuntar imagen o video; usa @ruta para archivos de texto o directorios"
         }
         MessageId::CmdBalanceDescription => "Mostrar el saldo de la cuenta de la API DeepSeek",
+        MessageId::AccountBalanceProvider => "Proveedor",
+        MessageId::AccountBalanceBalance => "Saldo",
+        MessageId::AccountBalanceToppedUp => "recargado",
+        MessageId::AccountBalanceGranted => "concedido",
+        MessageId::AccountBalanceAvailable => "Disponible",
+        MessageId::AccountBalanceUnavailable => "no disponible",
+        MessageId::AccountBalanceYes => "sí",
+        MessageId::AccountBalanceNo => "no",
+        MessageId::AccountBalanceFetching => "Obteniendo saldo de la cuenta...",
+        MessageId::AccountBalanceFetched => "Saldo de la cuenta obtenido",
+        MessageId::AccountBalanceFetchFailed => "No se pudo obtener el saldo",
+        MessageId::AccountBalanceFetchFailedPrefix => "No se pudo obtener el saldo de la cuenta: ",
+        MessageId::AccountBalanceUnsupportedProviderPrefix => {
+            "/balance solo es compatible con el proveedor DeepSeek. Proveedor actual: "
+        }
         MessageId::CmdCacheDescription => {
             "Mostrar estadísticas de hit/miss del caché de prefijo DeepSeek en las últimas N rondas"
         }

--- a/crates/tui/src/localization.rs
+++ b/crates/tui/src/localization.rs
@@ -246,6 +246,7 @@ pub enum MessageId {
     HelpFooterClose,
     CmdAttachDescription,
     CmdAnchorDescription,
+    CmdBalanceDescription,
     CmdCacheDescription,
     CmdChangeDescription,
     CmdChangeHeader,
@@ -484,6 +485,7 @@ pub const ALL_MESSAGE_IDS: &[MessageId] = &[
     MessageId::HelpFooterClose,
     MessageId::CmdAnchorDescription,
     MessageId::CmdAttachDescription,
+    MessageId::CmdBalanceDescription,
     MessageId::CmdCacheDescription,
     MessageId::CmdClearDescription,
     MessageId::CmdCompactDescription,
@@ -898,6 +900,7 @@ fn english(id: MessageId) -> &'static str {
         MessageId::CmdAttachDescription => {
             "Attach image/video media; use @path for text files or directories"
         }
+        MessageId::CmdBalanceDescription => "Show DeepSeek API account balance",
         MessageId::CmdCacheDescription => {
             "Show DeepSeek prefix-cache hit/miss stats for the last N turns"
         }
@@ -1275,6 +1278,7 @@ fn japanese(id: MessageId) -> Option<&'static str> {
         MessageId::CmdAttachDescription => {
             "画像・動画メディアを添付（テキストファイルやディレクトリは @path）"
         }
+        MessageId::CmdBalanceDescription => "DeepSeek API アカウント残高を表示",
         MessageId::CmdCacheDescription => {
             "直近 N ターンの DeepSeek プレフィックスキャッシュのヒット/ミス統計を表示"
         }
@@ -1629,6 +1633,7 @@ fn chinese_simplified(id: MessageId) -> Option<&'static str> {
         MessageId::HelpFooterClose => " Esc 关闭 ",
         MessageId::CmdAnchorDescription => "钉选关键事实，在压缩后自动注入上下文",
         MessageId::CmdAttachDescription => "附加图片或视频媒体；文本文件或目录请使用 @path",
+        MessageId::CmdBalanceDescription => "显示 DeepSeek API 账户余额",
         MessageId::CmdCacheDescription => "显示最近 N 轮的 DeepSeek 前缀缓存命中/未命中统计",
         MessageId::CmdChangeDescription => "显示最新的更新日志",
         MessageId::CmdChangeHeader => "最新更新日志",
@@ -1939,6 +1944,7 @@ fn portuguese_brazil(id: MessageId) -> Option<&'static str> {
         MessageId::CmdAttachDescription => {
             "Anexar imagem ou vídeo; use @path para arquivos de texto ou diretórios"
         }
+        MessageId::CmdBalanceDescription => "Exibir o saldo da conta da API DeepSeek",
         MessageId::CmdCacheDescription => {
             "Exibir estatísticas de hit/miss do cache de prefixo DeepSeek nas últimas N rodadas"
         }
@@ -2321,6 +2327,7 @@ fn spanish_latin_america(id: MessageId) -> Option<&'static str> {
         MessageId::CmdAttachDescription => {
             "Adjuntar imagen o video; usa @ruta para archivos de texto o directorios"
         }
+        MessageId::CmdBalanceDescription => "Mostrar el saldo de la cuenta de la API DeepSeek",
         MessageId::CmdCacheDescription => {
             "Mostrar estadísticas de hit/miss del caché de prefijo DeepSeek en las últimas N rondas"
         }

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -4094,6 +4094,7 @@ pub enum AppAction {
     SendMessage(String),
     ListSubAgents,
     FetchModels,
+    FetchBalance,
     CacheWarmup,
     /// Switch the active LLM backend (DeepSeek vs NVIDIA NIM) without
     /// restarting the process. The runtime rebuilds its API client from

--- a/crates/tui/src/tui/format_helpers.rs
+++ b/crates/tui/src/tui/format_helpers.rs
@@ -6,6 +6,7 @@
 //! need to scroll past their bodies, and so the labels can be unit
 //! tested in isolation.
 
+use crate::client::AccountBalance;
 use crate::models::Usage;
 use crate::tui::app::App;
 
@@ -74,9 +75,39 @@ pub(super) fn available_models_message(current_model: &str, models: &[String]) -
     lines.join("\n")
 }
 
+pub(super) fn account_balance_message(provider: &str, balance: &AccountBalance) -> String {
+    let mut lines = vec![format!("Provider: {provider}")];
+    if balance.balance_infos.is_empty() {
+        lines.push("Balance : unavailable".to_string());
+    } else {
+        for info in &balance.balance_infos {
+            lines.push(format!(
+                "Balance : {} (topped up: {}, granted: {})",
+                format_money(&info.currency, &info.total_balance),
+                format_money(&info.currency, &info.topped_up_balance),
+                format_money(&info.currency, &info.granted_balance),
+            ));
+        }
+    }
+    lines.push(format!(
+        "Available: {}",
+        if balance.is_available { "yes" } else { "no" }
+    ));
+    lines.join("\n")
+}
+
+fn format_money(currency: &str, amount: &str) -> String {
+    match currency.trim().to_ascii_uppercase().as_str() {
+        "CNY" => format!("¥{amount}"),
+        "USD" => format!("${amount}"),
+        other => format!("{other} {amount}"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::client::AccountBalanceInfo;
 
     #[test]
     fn available_models_message_marks_current_model() {
@@ -99,5 +130,26 @@ mod tests {
         };
         let msg = cache_warmup_result(&usage);
         assert!(msg.contains("cache telemetry unavailable"), "got: {msg}");
+    }
+
+    #[test]
+    fn account_balance_message_matches_deepseek_shape() {
+        let balance = AccountBalance {
+            is_available: true,
+            balance_infos: vec![AccountBalanceInfo {
+                currency: "CNY".to_string(),
+                total_balance: "8.66".to_string(),
+                topped_up_balance: "8.66".to_string(),
+                granted_balance: "0.00".to_string(),
+            }],
+        };
+
+        let msg = account_balance_message("deepseek", &balance);
+        assert!(msg.contains("Provider: deepseek"), "got: {msg}");
+        assert!(
+            msg.contains("Balance : ¥8.66 (topped up: ¥8.66, granted: ¥0.00)"),
+            "got: {msg}"
+        );
+        assert!(msg.contains("Available: yes"), "got: {msg}");
     }
 }

--- a/crates/tui/src/tui/format_helpers.rs
+++ b/crates/tui/src/tui/format_helpers.rs
@@ -7,6 +7,7 @@
 //! tested in isolation.
 
 use crate::client::AccountBalance;
+use crate::localization::{Locale, MessageId, tr};
 use crate::models::Usage;
 use crate::tui::app::App;
 
@@ -75,23 +76,45 @@ pub(super) fn available_models_message(current_model: &str, models: &[String]) -
     lines.join("\n")
 }
 
-pub(super) fn account_balance_message(provider: &str, balance: &AccountBalance) -> String {
-    let mut lines = vec![format!("Provider: {provider}")];
+pub(super) fn account_balance_message(
+    locale: Locale,
+    provider: &str,
+    balance: &AccountBalance,
+) -> String {
+    let mut lines = vec![format!(
+        "{}: {provider}",
+        tr(locale, MessageId::AccountBalanceProvider)
+    )];
     if balance.balance_infos.is_empty() {
-        lines.push("Balance : unavailable".to_string());
+        lines.push(format!(
+            "{} : {}",
+            tr(locale, MessageId::AccountBalanceBalance),
+            tr(locale, MessageId::AccountBalanceUnavailable)
+        ));
     } else {
         for info in &balance.balance_infos {
             lines.push(format!(
-                "Balance : {} (topped up: {}, granted: {})",
+                "{} : {} ({}: {}, {}: {})",
+                tr(locale, MessageId::AccountBalanceBalance),
                 format_money(&info.currency, &info.total_balance),
+                tr(locale, MessageId::AccountBalanceToppedUp),
                 format_money(&info.currency, &info.topped_up_balance),
+                tr(locale, MessageId::AccountBalanceGranted),
                 format_money(&info.currency, &info.granted_balance),
             ));
         }
     }
     lines.push(format!(
-        "Available: {}",
-        if balance.is_available { "yes" } else { "no" }
+        "{}: {}",
+        tr(locale, MessageId::AccountBalanceAvailable),
+        tr(
+            locale,
+            if balance.is_available {
+                MessageId::AccountBalanceYes
+            } else {
+                MessageId::AccountBalanceNo
+            }
+        )
     ));
     lines.join("\n")
 }
@@ -144,7 +167,7 @@ mod tests {
             }],
         };
 
-        let msg = account_balance_message("deepseek", &balance);
+        let msg = account_balance_message(Locale::En, "deepseek", &balance);
         assert!(msg.contains("Provider: deepseek"), "got: {msg}");
         assert!(
             msg.contains("Balance : ¥8.66 (topped up: ¥8.66, granted: ¥0.00)"),

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -1686,6 +1686,42 @@ async fn run_event_loop(
                         // Individual spawn/complete events already log to history;
                         // full list available via /agents command.
                     }
+                    EngineEvent::AccountBalance { provider, result } => match result {
+                        Ok(balance) => {
+                            app.add_message(HistoryCell::System {
+                                content: format_helpers::account_balance_message(
+                                    app.ui_locale,
+                                    &provider,
+                                    &balance,
+                                ),
+                            });
+                            app.status_message = Some(
+                                crate::localization::tr(
+                                    app.ui_locale,
+                                    crate::localization::MessageId::AccountBalanceFetched,
+                                )
+                                .to_string(),
+                            );
+                        }
+                        Err(error) => {
+                            app.add_message(HistoryCell::System {
+                                content: format!(
+                                    "{}{error}",
+                                    crate::localization::tr(
+                                        app.ui_locale,
+                                        crate::localization::MessageId::AccountBalanceFetchFailedPrefix,
+                                    )
+                                ),
+                            });
+                            app.status_message = Some(
+                                crate::localization::tr(
+                                    app.ui_locale,
+                                    crate::localization::MessageId::AccountBalanceFetchFailed,
+                                )
+                                .to_string(),
+                            );
+                        }
+                    },
                     EngineEvent::SubAgentMailbox { seq, message } => {
                         handle_subagent_mailbox(app, seq, &message);
                         transcript_batch_updated = true;
@@ -3474,11 +3510,6 @@ async fn fetch_available_models(config: &Config) -> Result<Vec<String>> {
     Ok(ids)
 }
 
-async fn fetch_account_balance(config: &Config) -> Result<crate::client::AccountBalance> {
-    let client = DeepSeekClient::new(config)?;
-    tokio::time::timeout(Duration::from_secs(20), client.account_balance()).await?
-}
-
 async fn run_cache_warmup(app: &App, config: &Config) -> Result<Usage> {
     let client = DeepSeekClient::new(config)?;
     let reasoning_effort = if app.reasoning_effort == ReasoningEffort::Auto {
@@ -4423,29 +4454,27 @@ async fn apply_command_result(
                 if !matches!(provider, ApiProvider::Deepseek | ApiProvider::DeepseekCN) {
                     app.add_message(HistoryCell::System {
                         content: format!(
-                            "/balance is only supported by the DeepSeek provider. Current provider: {}",
+                            "{}{}",
+                            crate::localization::tr(
+                                app.ui_locale,
+                                crate::localization::MessageId::AccountBalanceUnsupportedProviderPrefix,
+                            ),
                             provider.display_name()
                         ),
                     });
                 } else {
-                    app.status_message = Some("Fetching account balance...".to_string());
-                    match fetch_account_balance(config).await {
-                        Ok(balance) => {
-                            app.add_message(HistoryCell::System {
-                                content: format_helpers::account_balance_message(
-                                    provider.as_str(),
-                                    &balance,
-                                ),
-                            });
-                            app.status_message = Some("Account balance fetched".to_string());
-                        }
-                        Err(error) => {
-                            app.add_message(HistoryCell::System {
-                                content: format!("Failed to fetch account balance: {error}"),
-                            });
-                            app.status_message = Some("Balance fetch failed".to_string());
-                        }
-                    }
+                    app.status_message = Some(
+                        crate::localization::tr(
+                            app.ui_locale,
+                            crate::localization::MessageId::AccountBalanceFetching,
+                        )
+                        .to_string(),
+                    );
+                    let _ = engine_handle
+                        .send(Op::FetchBalance {
+                            provider: provider.as_str().to_string(),
+                        })
+                        .await;
                 }
             }
             AppAction::CacheWarmup => {

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -3474,6 +3474,11 @@ async fn fetch_available_models(config: &Config) -> Result<Vec<String>> {
     Ok(ids)
 }
 
+async fn fetch_account_balance(config: &Config) -> Result<crate::client::AccountBalance> {
+    let client = DeepSeekClient::new(config)?;
+    tokio::time::timeout(Duration::from_secs(20), client.account_balance()).await?
+}
+
 async fn run_cache_warmup(app: &App, config: &Config) -> Result<Usage> {
     let client = DeepSeekClient::new(config)?;
     let reasoning_effort = if app.reasoning_effort == ReasoningEffort::Auto {
@@ -4409,6 +4414,36 @@ async fn apply_command_result(
                             app.add_message(HistoryCell::System {
                                 content: format!("Failed to fetch models: {error}"),
                             });
+                        }
+                    }
+                }
+            }
+            AppAction::FetchBalance => {
+                let provider = config.api_provider();
+                if !matches!(provider, ApiProvider::Deepseek | ApiProvider::DeepseekCN) {
+                    app.add_message(HistoryCell::System {
+                        content: format!(
+                            "/balance is only supported by the DeepSeek provider. Current provider: {}",
+                            provider.display_name()
+                        ),
+                    });
+                } else {
+                    app.status_message = Some("Fetching account balance...".to_string());
+                    match fetch_account_balance(config).await {
+                        Ok(balance) => {
+                            app.add_message(HistoryCell::System {
+                                content: format_helpers::account_balance_message(
+                                    provider.as_str(),
+                                    &balance,
+                                ),
+                            });
+                            app.status_message = Some("Account balance fetched".to_string());
+                        }
+                        Err(error) => {
+                            app.add_message(HistoryCell::System {
+                                content: format!("Failed to fetch account balance: {error}"),
+                            });
+                            app.status_message = Some("Balance fetch failed".to_string());
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

Closes #1735.

This implements the issue's "Plan A" as a TUI slash command named `/balance`.

### User-facing behavior

- Adds a new `/balance` slash command for checking the active DeepSeek account balance from inside the TUI.
- Shows the provider, total balance, topped-up balance, granted balance, and availability in the conversation stream.
- Keeps the command scoped to DeepSeek-compatible providers (`deepseek` and `deepseek-cn`) so unrelated OpenAI-compatible providers do not receive a DeepSeek account endpoint request.
- Adds `/yue` as a short alias for users who prefer the Chinese pinyin shorthand.

Example output shape:

```text
Provider: deepseek
Balance : ¥8.66 (topped up: ¥8.66, granted: ¥0.00)
Available: yes
```

### Implementation details

- Adds `DeepSeekClient::account_balance()` and response structs for the `/user/balance` API.
- Uses the unversioned API root for this endpoint, because DeepSeek exposes balance checks at `/user/balance` rather than the chat-completions versioned path.
- Reuses the active DeepSeek client configuration and authorization headers instead of introducing a separate config path.
- Wires a new `AppAction::FetchBalance` through the slash-command dispatcher and TUI action handler.
- Adds localized command descriptions for the supported UI languages.
- Adds formatting helpers and tests so the displayed output stays stable.

## Validation

- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo build`
- `cargo test -p deepseek-tui balance --all-features`
- `cargo test -p deepseek-tui command_registry_has_unique_names_and_aliases --all-features`
- `cargo clippy --workspace --all-targets --all-features`
- Live `/user/balance` request using a local DeepSeek config, without logging credentials

`cargo build` and `cargo clippy` pass. The workspace still emits existing `schema_migration.rs` dead-code warnings unrelated to this change.
