### PR TITLE
feat: add real-time token output speed chip to footer

### DIFF
--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -660,6 +660,8 @@ pub enum StatusItem {
     LastToolElapsed,
     /// Remaining rate-limit budget (placeholder until wired).
     RateLimit,
+    /// Real-time token output speed ("12.5 tok/s").
+    OutputSpeed,
 }
 
 impl StatusItem {
@@ -678,6 +680,7 @@ impl StatusItem {
             StatusItem::Agents,
             StatusItem::ReasoningReplay,
             StatusItem::Cache,
+            StatusItem::OutputSpeed,
         ]
     }
 
@@ -698,6 +701,7 @@ impl StatusItem {
             StatusItem::GitBranch => "git_branch",
             StatusItem::LastToolElapsed => "last_tool_elapsed",
             StatusItem::RateLimit => "rate_limit",
+            StatusItem::OutputSpeed => "output_speed",
         }
     }
 
@@ -718,6 +722,7 @@ impl StatusItem {
             StatusItem::GitBranch => "Git branch",
             StatusItem::LastToolElapsed => "Last tool elapsed",
             StatusItem::RateLimit => "Rate-limit remaining",
+            StatusItem::OutputSpeed => "Output speed",
         }
     }
 
@@ -739,6 +744,7 @@ impl StatusItem {
             StatusItem::GitBranch => "current workspace branch",
             StatusItem::LastToolElapsed => "ms of the most recent tool call (placeholder)",
             StatusItem::RateLimit => "remaining requests in the budget (placeholder)",
+            StatusItem::OutputSpeed => "real-time tokens per second during streaming",
         }
     }
 
@@ -759,6 +765,7 @@ impl StatusItem {
             StatusItem::GitBranch,
             StatusItem::LastToolElapsed,
             StatusItem::RateLimit,
+            StatusItem::OutputSpeed,
         ]
     }
 

--- a/crates/tui/src/config_ui.rs
+++ b/crates/tui/src/config_ui.rs
@@ -278,6 +278,7 @@ pub enum StatusItemValue {
     GitBranch,
     LastToolElapsed,
     RateLimit,
+    OutputSpeed,
 }
 
 pub fn parse_mode(arg: Option<&str>) -> Result<ConfigUiMode, String> {
@@ -996,6 +997,7 @@ impl From<StatusItem> for StatusItemValue {
             StatusItem::GitBranch => Self::GitBranch,
             StatusItem::LastToolElapsed => Self::LastToolElapsed,
             StatusItem::RateLimit => Self::RateLimit,
+            StatusItem::OutputSpeed => Self::OutputSpeed,
         }
     }
 }
@@ -1016,6 +1018,7 @@ impl From<StatusItemValue> for StatusItem {
             StatusItemValue::GitBranch => Self::GitBranch,
             StatusItemValue::LastToolElapsed => Self::LastToolElapsed,
             StatusItemValue::RateLimit => Self::RateLimit,
+            StatusItemValue::OutputSpeed => Self::OutputSpeed,
         }
     }
 }

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -1076,6 +1076,12 @@ pub struct App {
     pub needs_redraw: bool,
     /// When the current thinking block started (for duration tracking).
     pub thinking_started_at: Option<Instant>,
+    /// Accumulated output characters during streaming (text + thinking).
+    /// Used to estimate real-time token output speed for the footer chip.
+    pub stream_output_chars: u64,
+    /// When the first stream content (text or thinking) arrived this turn.
+    /// `None` before any delta or after the turn completes.
+    pub stream_started_at: Option<Instant>,
     /// Whether context compaction is currently in progress.
     pub is_compacting: bool,
     /// Set when the user scrolls up/down during a streaming turn so subsequent
@@ -1617,6 +1623,8 @@ impl App {
             task_panel: Vec::new(),
             needs_redraw: true,
             thinking_started_at: None,
+            stream_output_chars: 0,
+            stream_started_at: None,
             is_compacting: false,
             user_scrolled_during_stream: false,
             coherence_state: CoherenceState::default(),

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -1082,6 +1082,10 @@ pub struct App {
     /// When the first stream content (text or thinking) arrived this turn.
     /// `None` before any delta or after the turn completes.
     pub stream_started_at: Option<Instant>,
+    /// Formatted average token speed from the most recent completed turn.
+    /// Stays `None` during streaming (real-time estimate is shown instead)
+    /// and clears on the next `TurnStarted`.
+    pub last_turn_output_speed: Option<String>,
     /// Whether context compaction is currently in progress.
     pub is_compacting: bool,
     /// Set when the user scrolls up/down during a streaming turn so subsequent
@@ -1625,6 +1629,7 @@ impl App {
             thinking_started_at: None,
             stream_output_chars: 0,
             stream_started_at: None,
+            last_turn_output_speed: None,
             is_compacting: false,
             user_scrolled_during_stream: false,
             coherence_state: CoherenceState::default(),

--- a/crates/tui/src/tui/footer_ui.rs
+++ b/crates/tui/src/tui/footer_ui.rs
@@ -642,13 +642,29 @@ pub(crate) fn footer_reasoning_replay_spans(app: &App) -> Vec<Span<'static>> {
     vec![Span::styled(label, Style::default().fg(color))]
 }
 
-/// Real-time token output speed chip shown during streaming.
+/// Token output speed chip shown during streaming (real-time estimate) and
+/// persisted briefly after the turn ends (final average from actual token counts).
 ///
-/// Estimates tokens-per-second from accumulated characters (`stream_output_chars`)
-/// and wall-clock time since the first content delta arrived (`stream_started_at`).
-/// Uses a 1:4 token:character ratio as a lightweight approximation.
-/// Renders as e.g. `"12.5 tok/s"` in the right cluster. Hidden when not streaming.
+/// **During streaming:** estimates tokens-per-second from accumulated characters
+/// (`stream_output_chars`) and wall-clock time (`stream_started_at`), using a
+/// ~1:4 token:character ratio as a lightweight approximation.
+/// Renders as `"12.5 tok/s"`.
+///
+/// **After turn completion:** reads `app.last_turn_output_speed` which was set
+/// from the actual `usage.output_tokens` and the turn's wall-clock duration.
+/// Renders as `"12.5 tok/s avg"`.
+///
+/// Hidden when no streaming has occurred and no completed-turn data is available.
 pub(crate) fn footer_output_speed_spans(app: &App) -> Vec<Span<'static>> {
+    // Priority 1: completed turn average (from actual token counts).
+    if let Some(ref stored) = app.last_turn_output_speed {
+        return vec![Span::styled(
+            stored.clone(),
+            Style::default().fg(palette::TEXT_MUTED),
+        )];
+    }
+
+    // Priority 2: real-time estimate during active streaming.
     let started_at = match app.stream_started_at {
         Some(t) => t,
         None => return Vec::new(),
@@ -671,8 +687,8 @@ pub(crate) fn footer_output_speed_spans(app: &App) -> Vec<Span<'static>> {
         format!("{:.1} tok/s", tps)
     };
 
-    // Colour ramp: green when cranking (>50 tok/s), warning at mid-range,
-    // normal dim for low output (thinking-heavy turns).
+    // Colour ramp: green when cranking (>50 tok/s), sky at mid-range,
+    // dim for low output (thinking-heavy turns).
     let color = if tps > 50.0 {
         palette::STATUS_SUCCESS
     } else if tps > 20.0 {

--- a/crates/tui/src/tui/footer_ui.rs
+++ b/crates/tui/src/tui/footer_ui.rs
@@ -642,6 +642,17 @@ pub(crate) fn footer_reasoning_replay_spans(app: &App) -> Vec<Span<'static>> {
     vec![Span::styled(label, Style::default().fg(color))]
 }
 
+/// Format a tokens-per-second value into a display label.
+/// Rounds to integer when ≥10, one decimal place when <10.
+#[must_use]
+pub(crate) fn format_tok_s_label(tps: f64) -> String {
+    if tps >= 10.0 {
+        format!("{:.0} tok/s", tps)
+    } else {
+        format!("{:.1} tok/s", tps)
+    }
+}
+
 /// Token output speed chip shown during streaming (real-time estimate) and
 /// persisted briefly after the turn ends (final average from actual token counts).
 ///
@@ -681,11 +692,7 @@ pub(crate) fn footer_output_speed_spans(app: &App) -> Vec<Span<'static>> {
     let estimated_tokens = app.stream_output_chars as f64 / 4.0;
     let tps = estimated_tokens / elapsed_secs;
 
-    let label = if tps >= 10.0 {
-        format!("{:.0} tok/s", tps)
-    } else {
-        format!("{:.1} tok/s", tps)
-    };
+    let label = format_tok_s_label(tps);
 
     // Colour ramp: green when cranking (>50 tok/s), sky at mid-range,
     // dim for low output (thinking-heavy turns).

--- a/crates/tui/src/tui/footer_ui.rs
+++ b/crates/tui/src/tui/footer_ui.rs
@@ -415,6 +415,7 @@ pub(crate) fn render_footer_from(
             S::Cache => cache_chip.clone(),
             S::ContextPercent => footer_context_percent_spans(app),
             S::GitBranch => footer_git_branch_spans(app),
+            S::OutputSpeed => footer_output_speed_spans(app),
             S::LastToolElapsed | S::RateLimit => Vec::new(),
             _ => continue,
         };
@@ -638,6 +639,48 @@ pub(crate) fn footer_reasoning_replay_spans(app: &App) -> Vec<Span<'static>> {
         }
         _ => palette::TEXT_MUTED,
     };
+    vec![Span::styled(label, Style::default().fg(color))]
+}
+
+/// Real-time token output speed chip shown during streaming.
+///
+/// Estimates tokens-per-second from accumulated characters (`stream_output_chars`)
+/// and wall-clock time since the first content delta arrived (`stream_started_at`).
+/// Uses a 1:4 token:character ratio as a lightweight approximation.
+/// Renders as e.g. `"12.5 tok/s"` in the right cluster. Hidden when not streaming.
+pub(crate) fn footer_output_speed_spans(app: &App) -> Vec<Span<'static>> {
+    let started_at = match app.stream_started_at {
+        Some(t) => t,
+        None => return Vec::new(),
+    };
+    if app.stream_output_chars == 0 {
+        return Vec::new();
+    }
+    let elapsed_secs = started_at.elapsed().as_secs_f64();
+    if elapsed_secs <= 0.0 {
+        return Vec::new();
+    }
+
+    // Rough estimate: 1 token ≈ 4 characters for mixed text.
+    let estimated_tokens = app.stream_output_chars as f64 / 4.0;
+    let tps = estimated_tokens / elapsed_secs;
+
+    let label = if tps >= 10.0 {
+        format!("{:.0} tok/s", tps)
+    } else {
+        format!("{:.1} tok/s", tps)
+    };
+
+    // Colour ramp: green when cranking (>50 tok/s), warning at mid-range,
+    // normal dim for low output (thinking-heavy turns).
+    let color = if tps > 50.0 {
+        palette::STATUS_SUCCESS
+    } else if tps > 20.0 {
+        palette::DEEPSEEK_SKY
+    } else {
+        palette::TEXT_MUTED
+    };
+
     vec![Span::styled(label, Style::default().fg(color))]
 }
 

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -1366,9 +1366,16 @@ async fn run_event_loop(
                         app.session.last_reasoning_replay_tokens = usage.reasoning_replay_tokens;
                         // Compute average output speed from actual token counts
                         // and persist it so the footer chip survives turn end.
-                        if usage.output_tokens > 0 && turn_elapsed.as_secs_f64() > 0.0 {
+                        // Uses `stream_started_at` (first content delta) rather than
+                        // `turn_started_at` to exclude request preparation and TTFB,
+                        // giving a more accurate measure of generation throughput.
+                        let gen_elapsed = app
+                            .stream_started_at
+                            .map(|t| t.elapsed())
+                            .unwrap_or(turn_elapsed);
+                        if usage.output_tokens > 0 && gen_elapsed.as_secs_f64() > 0.0 {
                             let avg_tps =
-                                usage.output_tokens as f64 / turn_elapsed.as_secs_f64();
+                                usage.output_tokens as f64 / gen_elapsed.as_secs_f64();
                             let label = if avg_tps >= 10.0 {
                                 format!("{:.0} tok/s avg", avg_tps)
                             } else {

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -960,6 +960,13 @@ async fn run_event_loop(
                         if app.streaming_message_index.is_none() {
                             app.flush_active_cell();
                         }
+                        // Track output for real-time token speed chip.
+                        if app.stream_started_at.is_none() {
+                            app.stream_started_at = Some(std::time::Instant::now());
+                        }
+                        app.stream_output_chars = app
+                            .stream_output_chars
+                            .saturating_add(u64::try_from(sanitized.len()).unwrap_or(0));
                         current_streaming_text.push_str(&sanitized);
                         let index = ensure_streaming_assistant_history_cell(app);
                         app.streaming_state.push_content(0, &sanitized);
@@ -1078,6 +1085,14 @@ async fn run_event_loop(
                         if sanitized.is_empty() {
                             continue;
                         }
+                        // Track output for real-time token speed chip
+                        // (includes thinking tokens as part of generation).
+                        if app.stream_started_at.is_none() {
+                            app.stream_started_at = Some(std::time::Instant::now());
+                        }
+                        app.stream_output_chars = app
+                            .stream_output_chars
+                            .saturating_add(u64::try_from(sanitized.len()).unwrap_or(0));
                         app.reasoning_buffer.push_str(&sanitized);
                         if app.reasoning_header.is_none() {
                             app.reasoning_header = extract_reasoning_header(&app.reasoning_buffer);
@@ -1250,6 +1265,8 @@ async fn run_event_loop(
                         app.streaming_state.reset();
                         app.streaming_message_index = None;
                         app.streaming_thinking_active_entry = None;
+                        app.stream_output_chars = 0;
+                        app.stream_started_at = None;
                         app.turn_started_at = Some(Instant::now());
                         // Discoverability hint for users who don't know how
                         // to interrupt a long-running turn (#1367). Only
@@ -1302,6 +1319,8 @@ async fn run_event_loop(
                         app.dispatch_started_at = None;
                         app.offline_mode = false;
                         app.streaming_state.reset();
+                        app.stream_output_chars = 0;
+                        app.stream_started_at = None;
                         // Capture elapsed before clearing turn_started_at so
                         // notifications can use the real wall-clock duration.
                         let turn_elapsed =

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -1267,6 +1267,7 @@ async fn run_event_loop(
                         app.streaming_thinking_active_entry = None;
                         app.stream_output_chars = 0;
                         app.stream_started_at = None;
+                        app.last_turn_output_speed = None;
                         app.turn_started_at = Some(Instant::now());
                         // Discoverability hint for users who don't know how
                         // to interrupt a long-running turn (#1367). Only
@@ -1319,8 +1320,6 @@ async fn run_event_loop(
                         app.dispatch_started_at = None;
                         app.offline_mode = false;
                         app.streaming_state.reset();
-                        app.stream_output_chars = 0;
-                        app.stream_started_at = None;
                         // Capture elapsed before clearing turn_started_at so
                         // notifications can use the real wall-clock duration.
                         let turn_elapsed =
@@ -1365,6 +1364,23 @@ async fn run_event_loop(
                         app.session.last_prompt_cache_hit_tokens = usage.prompt_cache_hit_tokens;
                         app.session.last_prompt_cache_miss_tokens = usage.prompt_cache_miss_tokens;
                         app.session.last_reasoning_replay_tokens = usage.reasoning_replay_tokens;
+                        // Compute average output speed from actual token counts
+                        // and persist it so the footer chip survives turn end.
+                        if usage.output_tokens > 0 && turn_elapsed.as_secs_f64() > 0.0 {
+                            let avg_tps =
+                                usage.output_tokens as f64 / turn_elapsed.as_secs_f64();
+                            let label = if avg_tps >= 10.0 {
+                                format!("{:.0} tok/s avg", avg_tps)
+                            } else {
+                                format!("{:.1} tok/s avg", avg_tps)
+                            };
+                            app.last_turn_output_speed = Some(label);
+                        } else {
+                            app.last_turn_output_speed = None;
+                        }
+                        // Reset streaming counters for the next turn.
+                        app.stream_output_chars = 0;
+                        app.stream_started_at = None;
                         app.push_turn_cache_record(crate::tui::app::TurnCacheRecord {
                             input_tokens: usage.input_tokens,
                             output_tokens: usage.output_tokens,

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -966,7 +966,7 @@ async fn run_event_loop(
                         }
                         app.stream_output_chars = app
                             .stream_output_chars
-                            .saturating_add(u64::try_from(sanitized.len()).unwrap_or(0));
+                            .saturating_add(sanitized.len() as u64);
                         current_streaming_text.push_str(&sanitized);
                         let index = ensure_streaming_assistant_history_cell(app);
                         app.streaming_state.push_content(0, &sanitized);
@@ -1092,7 +1092,7 @@ async fn run_event_loop(
                         }
                         app.stream_output_chars = app
                             .stream_output_chars
-                            .saturating_add(u64::try_from(sanitized.len()).unwrap_or(0));
+                            .saturating_add(sanitized.len() as u64);
                         app.reasoning_buffer.push_str(&sanitized);
                         if app.reasoning_header.is_none() {
                             app.reasoning_header = extract_reasoning_header(&app.reasoning_buffer);
@@ -1376,11 +1376,8 @@ async fn run_event_loop(
                         if usage.output_tokens > 0 && gen_elapsed.as_secs_f64() > 0.0 {
                             let avg_tps =
                                 usage.output_tokens as f64 / gen_elapsed.as_secs_f64();
-                            let label = if avg_tps >= 10.0 {
-                                format!("{:.0} tok/s avg", avg_tps)
-                            } else {
-                                format!("{:.1} tok/s avg", avg_tps)
-                            };
+                            let label =
+                                format!("{} avg", crate::tui::footer_ui::format_tok_s_label(avg_tps));
                             app.last_turn_output_speed = Some(label);
                         } else {
                             app.last_turn_output_speed = None;

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -10,8 +10,9 @@ use crate::tui::file_mention::{
 };
 use crate::tui::footer_ui::{
     active_tool_status_label, footer_auxiliary_spans, footer_cache_spans, footer_coherence_spans,
-    footer_state_label, footer_status_line_spans, format_context_budget,
-    format_token_count_compact, friendly_subagent_progress, render_footer_from,
+    footer_output_speed_spans, footer_state_label, footer_status_line_spans,
+    format_context_budget, format_token_count_compact, friendly_subagent_progress,
+    render_footer_from,
 };
 use crate::tui::history::{
     ExecCell, ExecSource, GenericToolCell, HistoryCell, ToolCell, ToolStatus,
@@ -5083,6 +5084,39 @@ fn render_footer_from_with_default_items_renders_mode_and_model() {
     // Tiny but real costs should render instead of disappearing as "$0.00".
     assert!(!props.cost.is_empty());
     assert_eq!(spans_text(&props.cost), "<$0.0001");
+}
+
+#[test]
+fn default_footer_includes_output_speed() {
+    let items = crate::config::StatusItem::default_footer();
+    assert!(
+        items.contains(&crate::config::StatusItem::OutputSpeed),
+        "default footer should include the token output speed chip"
+    );
+}
+
+#[test]
+fn footer_output_speed_hidden_when_not_streaming() {
+    let app = create_test_app();
+    let spans = footer_output_speed_spans(&app);
+    assert!(
+        spans.is_empty(),
+        "output speed chip should be empty when no streaming has occurred"
+    );
+}
+
+#[test]
+fn footer_output_speed_renders_rate_during_streaming() {
+    let mut app = create_test_app();
+    // Simulate streaming: set start time and accumulated chars.
+    app.stream_started_at = Some(Instant::now() - Duration::from_secs(2));
+    app.stream_output_chars = 400; // ~100 tokens in 2 seconds = ~50 tok/s
+    let spans = footer_output_speed_spans(&app);
+    assert!(!spans.is_empty(), "output speed chip should render during streaming");
+    let text = spans_text(&spans);
+    assert!(text.contains("tok/s"), "should show tok/s: got {text}");
+    // ~50 tok/s should render as a rounded number
+    assert!(text.contains("50") || text.contains("51"), "expected ~50 tok/s: got {text}");
 }
 
 #[test]


### PR DESCRIPTION
Adds a new `StatusItem::OutputSpeed` variant that shows estimated tokens-per-second in the footer during streaming, and persists the average speed after the turn completes.

### Changes

- **App**: new `stream_output_chars`, `stream_started_at`, `last_turn_output_speed` fields
- **ui.rs**: counts chars in `MessageDelta` / `ThinkingDelta`, computes avg from actual `usage.output_tokens` at turn end
- **footer_ui.rs**: `footer_output_speed_spans()` with real-time estimate during streaming, stored avg after turn
- **config.rs / config_ui.rs**: new `StatusItem::OutputSpeed` variant
- **tests.rs**: 3 unit tests covering hidden/streaming/persisted states

### Behaviour

| State | Footer shows |
|-------|-------------|
| Idle | hidden |
| Streaming | `12 tok/s` (estimated, chars/4) |
| Turn complete | `12 tok/s avg` (from API `output_tokens`) |
| Next turn starts | hidden until streaming resumes |