### PR TITLE
feat(tools): add explicit shell kind parameter to exec_shell

### DIFF
--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -100,25 +100,18 @@ fn render_environment_block(workspace: &Path, locale_tag: &str) -> String {
     let shell = std::env::var("SHELL").unwrap_or_else(|_| "unknown".to_string());
     let pwd = workspace.display();
 
-    // Build a comma-separated list of available shells for the `exec_shell`
-    // tool. Every platform has `sh`; `bash`/`zsh` are Unix-specific;
-    // `cmd` and `powershell` are Windows-specific.
-    let available_shells = {
+    // Build a comma-separated list of shells supported by the `exec_shell`
+    // tool on this platform. Only high-confidence built-in shells are listed —
+    // bash, zsh, and pwsh are not included without runtime detection since
+    // they may not be installed.
+    let supported_shells = {
         #[cfg(windows)]
         {
-            "cmd, powershell"
+            "auto, cmd, powershell"
         }
-        #[cfg(target_os = "macos")]
+        #[cfg(not(windows))]
         {
-            "sh, bash, zsh"
-        }
-        #[cfg(target_os = "linux")]
-        {
-            "sh, bash, zsh"
-        }
-        #[cfg(not(any(windows, target_os = "macos", target_os = "linux")))]
-        {
-            "sh"
+            "auto, sh"
         }
     };
 
@@ -130,12 +123,12 @@ fn render_environment_block(workspace: &Path, locale_tag: &str) -> String {
          - platform: {platform}\n\
          - shell: {shell}\n\
          - pwd: {pwd}\n\
-         - available_shells: {available_shells}\n\
+         - supported_shells: {supported_shells}\n\
          \n\
-         The `exec_shell` tool accepts an optional `shell` parameter. \
-         On this platform the default is `sh` (Unix) or `cmd` (Windows). \
-         Choose from the `available_shells` list when the command needs \
-         a specific shell dialect."
+         The optional `shell` parameter of `exec_shell` chooses the shell \
+         dialect. `auto` preserves the platform default (sh on Unix, cmd on \
+         Windows). Use an explicit value when the command depends on a \
+         specific shell's syntax."
     )
 }
 
@@ -844,8 +837,8 @@ mod tests {
         assert!(block.contains(&format!("- pwd: {}", tmp.path().display())));
         assert!(block.contains("- platform:"));
         assert!(block.contains("- shell:"));
-        assert!(block.contains("- available_shells:"));
-        assert!(block.contains("exec_shell tool accepts an optional `shell` parameter"));
+        assert!(block.contains("- supported_shells:"));
+        assert!(block.contains("optional `shell` parameter"));
     }
 
     #[test]

--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -100,6 +100,28 @@ fn render_environment_block(workspace: &Path, locale_tag: &str) -> String {
     let shell = std::env::var("SHELL").unwrap_or_else(|_| "unknown".to_string());
     let pwd = workspace.display();
 
+    // Build a comma-separated list of available shells for the `exec_shell`
+    // tool. Every platform has `sh`; `bash`/`zsh` are Unix-specific;
+    // `cmd` and `powershell` are Windows-specific.
+    let available_shells = {
+        #[cfg(windows)]
+        {
+            "cmd, powershell"
+        }
+        #[cfg(target_os = "macos")]
+        {
+            "sh, bash, zsh"
+        }
+        #[cfg(target_os = "linux")]
+        {
+            "sh, bash, zsh"
+        }
+        #[cfg(not(any(windows, target_os = "macos", target_os = "linux")))]
+        {
+            "sh"
+        }
+    };
+
     format!(
         "## Environment\n\
          \n\
@@ -107,7 +129,13 @@ fn render_environment_block(workspace: &Path, locale_tag: &str) -> String {
          - deepseek_version: {deepseek_version}\n\
          - platform: {platform}\n\
          - shell: {shell}\n\
-         - pwd: {pwd}"
+         - pwd: {pwd}\n\
+         - available_shells: {available_shells}\n\
+         \n\
+         The `exec_shell` tool accepts an optional `shell` parameter. \
+         On this platform the default is `sh` (Unix) or `cmd` (Windows). \
+         Choose from the `available_shells` list when the command needs \
+         a specific shell dialect."
     )
 }
 
@@ -816,6 +844,8 @@ mod tests {
         assert!(block.contains(&format!("- pwd: {}", tmp.path().display())));
         assert!(block.contains("- platform:"));
         assert!(block.contains("- shell:"));
+        assert!(block.contains("- available_shells:"));
+        assert!(block.contains("exec_shell tool accepts an optional `shell` parameter"));
     }
 
     #[test]

--- a/crates/tui/src/prompts/base.md
+++ b/crates/tui/src/prompts/base.md
@@ -191,6 +191,8 @@ Use `edit_file` for one clear replacement in one file. Do not use it for multi-b
 ### `exec_shell`
 Use `exec_shell` for shell-native diagnostics, pipelines, and bounded commands. Use structured tools for structured operations when they map directly (`grep_files`, `git_diff`, `read_file`). For long commands, servers, full test suites, or release computations, start background work with `task_shell_start` or `exec_shell` using `background: true`, then poll with `task_shell_wait` or `exec_shell_wait`.
 
+The optional `shell` parameter selects the shell dialect. On Windows, prefer `shell: "powershell"` for modern commands or `shell: "cmd"` for cmd syntax. On Unix, `shell: "auto"` uses `sh`. Use an explicit shell only when the command uses syntax specific to that shell — simple commands like `mkdir -p` work with any shell.
+
 ### `agent_open` / `agent_eval` / `agent_close`
 Use `agent_open` for independent investigations or implementation slices that can run while you continue coordinating. Fresh sessions are the default and are best when the child only needs the assignment you pass. Use `fork_context: true` when multiple perspectives should share the same parent context: the runtime preserves the parent prefill/prompt prefix byte-identically where available so DeepSeek prefix-cache reuse stays high, then appends the child instructions and task at the tail.
 

--- a/crates/tui/src/sandbox/mod.rs
+++ b/crates/tui/src/sandbox/mod.rs
@@ -72,8 +72,8 @@ impl ShellKind {
         match self {
             ShellKind::Auto => Self::auto(command),
             ShellKind::Sh => ("sh", vec!["-c".to_string(), command.to_string()]),
-            ShellKind::Bash => ("bash", vec!["-lc".to_string(), command.to_string()]),
-            ShellKind::Zsh => ("zsh", vec!["-lc".to_string(), command.to_string()]),
+            ShellKind::Bash => ("bash", vec!["-c".to_string(), command.to_string()]),
+            ShellKind::Zsh => ("zsh", vec!["-c".to_string(), command.to_string()]),
             ShellKind::Cmd => (
                 "cmd",
                 vec!["/C".to_string(), format!("chcp 65001 >NUL & {command}")],
@@ -653,6 +653,72 @@ mod tests {
             assert_eq!(spec.args, vec!["-c", "echo hello"]);
         }
         assert_eq!(spec.display_command(), "echo hello");
+    }
+
+    #[test]
+    fn test_shell_with_kind_auto_equals_default_shell() {
+        // shell_with_kind(…, Auto) must match the old shell() exactly
+        for cmd in ["echo hi", "ls", "cd /tmp && python -c 'print(1)'"] {
+            let old = CommandSpec::shell(cmd, PathBuf::from("."), Duration::from_secs(30));
+            let new = CommandSpec::shell_with_kind(
+                cmd,
+                PathBuf::from("."),
+                Duration::from_secs(30),
+                ShellKind::Auto,
+            );
+            assert_eq!(
+                old.program, new.program,
+                "Auto program must match default for: {cmd}"
+            );
+            assert_eq!(
+                old.args, new.args,
+                "Auto args must match default for: {cmd}"
+            );
+            assert_eq!(old.display_command(), cmd);
+        }
+    }
+
+    #[test]
+    fn test_shell_with_kind_resolves_all_variants() {
+        // Verify each ShellKind produces a valid (program, args) pair
+        // without panicking or returning empty args.
+        let command = "echo test";
+        for &kind in &[
+            ShellKind::Sh,
+            ShellKind::Bash,
+            ShellKind::Zsh,
+            ShellKind::Cmd,
+            ShellKind::Powershell,
+            ShellKind::Pwsh,
+        ] {
+            let spec = CommandSpec::shell_with_kind(
+                command,
+                PathBuf::from("."),
+                Duration::from_secs(30),
+                kind,
+            );
+            assert!(
+                !spec.program.is_empty(),
+                "program must not be empty for {kind:?}"
+            );
+            assert!(!spec.args.is_empty(), "args must not be empty for {kind:?}");
+            // display_command should unwrap to the raw command
+            assert_eq!(
+                spec.display_command(),
+                command,
+                "display_command failed for {kind:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_shell_kind_resolve_platform_defaults() {
+        // On any platform, Auto must resolve without cfg clashes
+        let (prog, _) = ShellKind::Auto.resolve("cmd");
+        #[cfg(windows)]
+        assert_eq!(prog, "cmd");
+        #[cfg(not(windows))]
+        assert_eq!(prog, "sh");
     }
 
     #[test]

--- a/crates/tui/src/sandbox/mod.rs
+++ b/crates/tui/src/sandbox/mod.rs
@@ -46,6 +46,77 @@ use std::time::Duration;
 
 pub use policy::SandboxPolicy;
 
+/// The shell to use when interpreting a shell command.
+///
+/// `Auto` picks the platform default (`cmd` on Windows, `sh` on Unix).
+/// Explicit choices let the model declare intent and let the executor
+/// validate availability.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ShellKind {
+    #[default]
+    Auto,
+    Sh,
+    Bash,
+    Zsh,
+    Cmd,
+    Powershell,
+    Pwsh,
+}
+
+impl ShellKind {
+    pub const VARIANTS: &'static [&'static str] =
+        &["auto", "sh", "bash", "zsh", "cmd", "powershell", "pwsh"];
+
+    /// Resolve this shell kind into (program, args) for the given command.
+    pub fn resolve(self, command: &str) -> (&'static str, Vec<String>) {
+        match self {
+            ShellKind::Auto => Self::auto(command),
+            ShellKind::Sh => ("sh", vec!["-c".to_string(), command.to_string()]),
+            ShellKind::Bash => ("bash", vec!["-lc".to_string(), command.to_string()]),
+            ShellKind::Zsh => ("zsh", vec!["-lc".to_string(), command.to_string()]),
+            ShellKind::Cmd => (
+                "cmd",
+                vec!["/C".to_string(), format!("chcp 65001 >NUL & {command}")],
+            ),
+            ShellKind::Powershell => (
+                "powershell.exe",
+                vec![
+                    "-NoLogo".to_string(),
+                    "-NoProfile".to_string(),
+                    "-ExecutionPolicy".to_string(),
+                    "Bypass".to_string(),
+                    "-Command".to_string(),
+                    command.to_string(),
+                ],
+            ),
+            ShellKind::Pwsh => (
+                "pwsh",
+                vec![
+                    "-NoLogo".to_string(),
+                    "-NoProfile".to_string(),
+                    "-Command".to_string(),
+                    command.to_string(),
+                ],
+            ),
+        }
+    }
+
+    /// Platform-default shell: `cmd` on Windows, `sh` on Unix.
+    fn auto(command: &str) -> (&'static str, Vec<String>) {
+        #[cfg(windows)]
+        {
+            (
+                "cmd",
+                vec!["/C".to_string(), format!("chcp 65001 >NUL & {command}")],
+            )
+        }
+        #[cfg(not(windows))]
+        {
+            ("sh", vec!["-c".to_string(), command.to_string()])
+        }
+    }
+}
+
 /// Specification for a command to be executed, potentially within a sandbox.
 ///
 /// This struct captures all the information needed to execute a command:
@@ -77,25 +148,24 @@ pub struct CommandSpec {
 }
 
 impl CommandSpec {
-    /// Create a `CommandSpec` for running a shell command via the platform shell.
+    /// Create a `CommandSpec` for running a shell command via the platform
+    /// default shell.  Equivalent to `shell_with_kind(…, ShellKind::Auto)`.
     pub fn shell(command: &str, cwd: PathBuf, timeout: Duration) -> Self {
-        #[cfg(windows)]
-        let (program, args) = {
-            // Force UTF-8 output on Windows by running `chcp 65001` before the
-            // actual command. Without this, subprocesses output in the system's
-            // ANSI code page (e.g. GBK for Chinese locales), causing garbled
-            // text in the shell output panel. See issue #982.
-            let cmd = format!("chcp 65001 >NUL & {command}");
-            ("cmd".to_string(), vec!["/C".to_string(), cmd])
-        };
-        #[cfg(not(windows))]
-        let (program, args) = (
-            "sh".to_string(),
-            vec!["-c".to_string(), command.to_string()],
-        );
+        Self::shell_with_kind(command, cwd, timeout, ShellKind::Auto)
+    }
 
+    /// Create a `CommandSpec` for running a shell command with an explicit
+    /// [`ShellKind`].  The shell resolver picks the program and arguments;
+    /// unknown or unavailable shells can be detected at execution time.
+    pub fn shell_with_kind(
+        command: &str,
+        cwd: PathBuf,
+        timeout: Duration,
+        kind: ShellKind,
+    ) -> Self {
+        let (program, args) = kind.resolve(command);
         Self {
-            program,
+            program: program.to_string(),
             args,
             cwd,
             env: HashMap::new(),
@@ -144,21 +214,31 @@ impl CommandSpec {
 
     /// Get the original command as a single string (for display).
     pub fn display_command(&self) -> String {
-        if self.program == "sh" && self.args.len() == 2 && self.args[0] == "-c" {
-            // For shell commands, show the actual command
-            self.args[1].clone()
-        } else if self.program.eq_ignore_ascii_case("cmd")
-            && self.args.len() == 2
-            && self.args[0].eq_ignore_ascii_case("/C")
+        // Shell invocations: unwrap to the raw command string.
+        let is_sh = |prog: &str| prog == "sh" || prog == "bash" || prog == "zsh";
+        let is_cmd = |prog: &str| prog.eq_ignore_ascii_case("cmd");
+        let is_pwsh = |prog: &str| {
+            prog.eq_ignore_ascii_case("powershell.exe") || prog.eq_ignore_ascii_case("pwsh")
+        };
+
+        if is_sh(&self.program)
+            && self.args.len() >= 2
+            && (self.args[0] == "-c" || self.args[0] == "-lc")
         {
-            // Strip the `chcp 65001 >NUL & ` prefix we add on Windows for
-            // UTF-8 output (issue #982).
-            let raw = &self.args[1];
+            self.args.last().expect("-c/-lc command arg").clone()
+        } else if is_cmd(&self.program) && self.args.len() >= 2 && self.args[0] == "/C" {
+            let raw = &self.args.last().expect("/C command arg");
             raw.strip_prefix("chcp 65001 >NUL & ")
                 .unwrap_or(raw)
                 .to_string()
+        } else if is_pwsh(&self.program) {
+            // powershell.exe / pwsh last arg is the -Command script block
+            self.args.last().cloned().unwrap_or_else(|| {
+                let mut parts = vec![self.program.clone()];
+                parts.extend(self.args.clone());
+                parts.join(" ")
+            })
         } else {
-            // For other commands, join program and args
             let mut parts = vec![self.program.clone()];
             parts.extend(self.args.clone());
             parts.join(" ")

--- a/crates/tui/src/tools/shell.rs
+++ b/crates/tui/src/tools/shell.rs
@@ -32,6 +32,7 @@ use crate::sandbox::{
     SandboxManager,
     SandboxPolicy as ExecutionSandboxPolicy, // Rename to avoid conflict with spec::SandboxPolicy
     SandboxType,
+    ShellKind,
 };
 
 /// Status of a shell process
@@ -681,6 +682,34 @@ impl ShellManager {
         policy_override: Option<ExecutionSandboxPolicy>,
         extra_env: HashMap<String, String>,
     ) -> Result<ShellResult> {
+        self.execute_with_options_env_shell(
+            command,
+            working_dir,
+            timeout_ms,
+            background,
+            stdin_data,
+            tty,
+            policy_override,
+            extra_env,
+            ShellKind::Auto,
+        )
+    }
+
+    /// Like `execute_with_options_env`, but with an explicit
+    /// [`ShellKind`] that overrides the platform default.
+    #[allow(clippy::too_many_arguments)]
+    pub fn execute_with_options_env_shell(
+        &mut self,
+        command: &str,
+        working_dir: Option<&str>,
+        timeout_ms: u64,
+        background: bool,
+        stdin_data: Option<&str>,
+        tty: bool,
+        policy_override: Option<ExecutionSandboxPolicy>,
+        extra_env: HashMap<String, String>,
+        shell_kind: ShellKind,
+    ) -> Result<ShellResult> {
         let work_dir = working_dir.map_or_else(|| self.default_workspace.clone(), PathBuf::from);
 
         // Clamp timeout to max 10 minutes (600000ms)
@@ -690,9 +719,14 @@ impl ShellManager {
         let policy = policy_override.unwrap_or_else(|| self.sandbox_policy.clone());
 
         // Create command spec and prepare sandboxed environment
-        let spec = CommandSpec::shell(command, work_dir.clone(), Duration::from_millis(timeout_ms))
-            .with_policy(policy)
-            .with_env(extra_env);
+        let spec = CommandSpec::shell_with_kind(
+            command,
+            work_dir.clone(),
+            Duration::from_millis(timeout_ms),
+            shell_kind,
+        )
+        .with_policy(policy)
+        .with_env(extra_env);
         let exec_env = self.sandbox_manager.prepare(&spec);
 
         if background {
@@ -744,14 +778,41 @@ impl ShellManager {
         policy_override: Option<ExecutionSandboxPolicy>,
         extra_env: HashMap<String, String>,
     ) -> Result<ShellResult> {
+        self.execute_interactive_with_policy_env_shell(
+            command,
+            working_dir,
+            timeout_ms,
+            policy_override,
+            extra_env,
+            ShellKind::Auto,
+        )
+    }
+
+    /// Like `execute_interactive_with_policy_env` with an explicit
+    /// [`ShellKind`] override.
+    #[allow(clippy::too_many_arguments)]
+    pub fn execute_interactive_with_policy_env_shell(
+        &mut self,
+        command: &str,
+        working_dir: Option<&str>,
+        timeout_ms: u64,
+        policy_override: Option<ExecutionSandboxPolicy>,
+        extra_env: HashMap<String, String>,
+        shell_kind: ShellKind,
+    ) -> Result<ShellResult> {
         let work_dir = working_dir.map_or_else(|| self.default_workspace.clone(), PathBuf::from);
 
         let timeout_ms = timeout_ms.clamp(1000, 600_000);
         let policy = policy_override.unwrap_or_else(|| self.sandbox_policy.clone());
 
-        let spec = CommandSpec::shell(command, work_dir.clone(), Duration::from_millis(timeout_ms))
-            .with_policy(policy)
-            .with_env(extra_env);
+        let spec = CommandSpec::shell_with_kind(
+            command,
+            work_dir.clone(),
+            Duration::from_millis(timeout_ms),
+            shell_kind,
+        )
+        .with_policy(policy)
+        .with_env(extra_env);
         let exec_env = self.sandbox_manager.prepare(&spec);
 
         Self::execute_interactive_sandboxed(command, &work_dir, timeout_ms, &exec_env)
@@ -1592,6 +1653,7 @@ async fn execute_foreground_via_background(
     tty: bool,
     policy_override: Option<ExecutionSandboxPolicy>,
     extra_env: HashMap<String, String>,
+    shell_kind: ShellKind,
 ) -> Result<ShellResult> {
     let timeout_ms = timeout_ms.clamp(1000, 600_000);
     let spawned = {
@@ -1600,7 +1662,7 @@ async fn execute_foreground_via_background(
             .lock()
             .map_err(|_| anyhow!("shell manager lock poisoned"))?;
         manager.clear_foreground_background_request();
-        manager.execute_with_options_env(
+        manager.execute_with_options_env_shell(
             command,
             None,
             timeout_ms,
@@ -1609,6 +1671,7 @@ async fn execute_foreground_via_background(
             tty,
             policy_override,
             extra_env,
+            shell_kind,
         )?
     };
     let task_id = spawned
@@ -1687,6 +1750,11 @@ impl ToolSpec for ExecShellTool {
                     "type": "string",
                     "description": "The shell command to execute"
                 },
+                "shell": {
+                    "type": "string",
+                    "enum": ["auto", "sh", "bash", "zsh", "cmd", "powershell", "pwsh"],
+                    "description": "Shell used to interpret command (default: auto). On Windows the default is cmd; on Unix the default is sh. Use powershell or pwsh on Windows for modern PowerShell syntax, bash/zsh on Unix for interactive login shells."
+                },
                 "timeout_ms": {
                     "type": "integer",
                     "description": "Timeout in milliseconds (default: 120000, max: 600000)"
@@ -1749,6 +1817,17 @@ impl ToolSpec for ExecShellTool {
             .or_else(|| input.get("data"))
             .and_then(serde_json::Value::as_str)
             .map(str::to_string);
+
+        // Parse optional shell kind, defaulting to Auto (platform default).
+        let shell_kind: ShellKind = match input.get("shell").and_then(serde_json::Value::as_str) {
+            Some("sh") => ShellKind::Sh,
+            Some("bash") => ShellKind::Bash,
+            Some("zsh") => ShellKind::Zsh,
+            Some("cmd") => ShellKind::Cmd,
+            Some("powershell") => ShellKind::Powershell,
+            Some("pwsh") => ShellKind::Pwsh,
+            _ => ShellKind::Auto,
+        };
 
         if interactive && background {
             return Ok(ToolResult::error(
@@ -1950,19 +2029,20 @@ impl ToolSpec for ExecShellTool {
                 .shell_manager
                 .lock()
                 .map_err(|_| ToolError::execution_failed("shell manager lock poisoned"))?;
-            manager.execute_interactive_with_policy_env(
+            manager.execute_interactive_with_policy_env_shell(
                 command,
                 working_dir.as_deref(),
                 timeout_ms,
                 policy_override,
                 extra_env,
+                shell_kind,
             )
         } else if background {
             let mut manager = context
                 .shell_manager
                 .lock()
                 .map_err(|_| ToolError::execution_failed("shell manager lock poisoned"))?;
-            manager.execute_with_options_env(
+            manager.execute_with_options_env_shell(
                 command,
                 working_dir.as_deref(),
                 timeout_ms,
@@ -1971,6 +2051,7 @@ impl ToolSpec for ExecShellTool {
                 tty,
                 policy_override,
                 extra_env,
+                shell_kind,
             )
         } else {
             execute_foreground_via_background(
@@ -1981,6 +2062,7 @@ impl ToolSpec for ExecShellTool {
                 combined_output,
                 policy_override,
                 extra_env,
+                shell_kind,
             )
             .await
         };

--- a/crates/tui/src/tools/shell.rs
+++ b/crates/tui/src/tools/shell.rs
@@ -1645,6 +1645,7 @@ fn shell_network_restricted_hint<'a>(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn execute_foreground_via_background(
     context: &ToolContext,
     command: &str,
@@ -1739,7 +1740,10 @@ impl ToolSpec for ExecShellTool {
     }
 
     fn description(&self) -> &'static str {
-        "Execute a shell command in the workspace directory. Foreground mode is for bounded commands; use background=true or task_shell_start for long-running work, then poll/wait."
+        "Execute a shell command in the workspace directory. \
+         Use the optional `shell` parameter to control which shell interprets the command. \
+         Foreground mode is for bounded commands; use background=true or task_shell_start \
+         for long-running work, then poll/wait."
     }
 
     fn input_schema(&self) -> serde_json::Value {
@@ -1753,7 +1757,13 @@ impl ToolSpec for ExecShellTool {
                 "shell": {
                     "type": "string",
                     "enum": ["auto", "sh", "bash", "zsh", "cmd", "powershell", "pwsh"],
-                    "description": "Shell used to interpret command (default: auto). On Windows the default is cmd; on Unix the default is sh. Use powershell or pwsh on Windows for modern PowerShell syntax, bash/zsh on Unix for interactive login shells."
+                    "description": "Shell used to interpret the command (default: auto). \
+                        `auto` preserves DeepSeek-TUI's existing platform default behavior \
+                        (cmd on Windows, sh on Unix) and does not translate command syntax. \
+                        Use an explicit shell when the command uses shell-specific syntax: \
+                        powershell for `$env:` / `Get-ChildItem` / `Select-String`; \
+                        cmd for `%FOO%` / `dir`; \
+                        bash/zsh for `export` / POSIX pipes / `grep`."
                 },
                 "timeout_ms": {
                     "type": "integer",


### PR DESCRIPTION
## Summary

Add an optional `shell` parameter to `exec_shell` so the model can explicitly declare the target shell dialect. Fixes the common Windows issue where bash-style commands fail in cmd/PowerShell.

Closes #1754.

## Changes

- **ShellKind enum** (Auto/Sh/Bash/Zsh/Cmd/Powershell/Pwsh) with platform resolver
- **exec_shell schema** — new optional `shell` field, default `auto`
- **Execution chain** — wired through all 3 paths (foreground, background, interactive)
- **Environment block** — `supported_shells` listed; `base.md` shell guidance added

## Design

- **Backward compatible**: `auto` preserves existing behavior (cmd + UTF-8 on Windows, `sh -c` on Unix). `auto` does NOT detect or translate syntax.
- **Cache-stable**: fixed schema, no dynamic tool changes.

## Testing

- [x] `cargo check --workspace --all-targets --locked` passes
- [x] `cargo fmt` passes
- [x] 27 sandbox tests pass (incl. 3 new ShellKind tests + backward-compat)
- [x] Prompt rendering test passes

## Why it matters

Previously `exec_shell` had no way for the model to declare shell dialect. On Windows, the model generated `export`/`grep`/POSIX pipes that only work in bash but got executed in cmd. Making shell selection explicit fixes this at the tool contract level.
