### PR TITLE
feat(tui): expose subagent model config

### DIFF
--- a/crates/tui/src/commands/config.rs
+++ b/crates/tui/src/commands/config.rs
@@ -5,7 +5,10 @@ use std::time::Duration;
 
 use super::CommandResult;
 use crate::client::DeepSeekClient;
-use crate::config::{COMMON_DEEPSEEK_MODELS, clear_api_key, normalize_model_name_for_provider};
+use crate::config::{
+    COMMON_DEEPSEEK_MODELS, MAX_SUBAGENTS, clear_api_key, normalize_model_name,
+    normalize_model_name_for_provider,
+};
 use crate::config_ui::{ConfigUiMode, parse_mode};
 use crate::llm_client::LlmClient;
 use crate::localization::resolve_locale;
@@ -348,6 +351,129 @@ pub fn persist_root_string_key(key: &str, value: &str) -> anyhow::Result<PathBuf
     Ok(path)
 }
 
+fn active_config_toml_path(app: &App) -> anyhow::Result<PathBuf> {
+    app.config_path.clone().map_or_else(config_toml_path, Ok)
+}
+
+fn subagents_table_for_write<'a>(
+    root: &'a mut toml::value::Table,
+    profile: Option<&str>,
+) -> anyhow::Result<&'a mut toml::value::Table> {
+    use anyhow::Context;
+
+    let target = if let Some(profile) = profile {
+        let profiles_entry = root
+            .entry("profiles".to_string())
+            .or_insert_with(|| toml::Value::Table(toml::value::Table::new()));
+        let profiles = profiles_entry
+            .as_table_mut()
+            .context("`profiles` section in config.toml must be a table")?;
+        let profile_entry = profiles
+            .entry(profile.to_string())
+            .or_insert_with(|| toml::Value::Table(toml::value::Table::new()));
+        profile_entry.as_table_mut().with_context(|| {
+            format!("`profiles.{profile}` section in config.toml must be a table")
+        })?
+    } else {
+        root
+    };
+
+    let subagents_entry = target
+        .entry("subagents".to_string())
+        .or_insert_with(|| toml::Value::Table(toml::value::Table::new()));
+    subagents_entry
+        .as_table_mut()
+        .context("`subagents` section in config.toml must be a table")
+}
+
+fn update_subagents_table(
+    app: &App,
+    update: impl FnOnce(&mut toml::value::Table),
+) -> anyhow::Result<PathBuf> {
+    use anyhow::Context;
+    use std::fs;
+
+    let path = active_config_toml_path(app)?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create config directory {}", parent.display()))?;
+    }
+
+    let mut doc: toml::Value = if path.exists() {
+        let raw = fs::read_to_string(&path)
+            .with_context(|| format!("failed to read config at {}", path.display()))?;
+        toml::from_str(&raw)
+            .with_context(|| format!("failed to parse config at {}", path.display()))?
+    } else {
+        toml::Value::Table(toml::value::Table::new())
+    };
+    let table = doc
+        .as_table_mut()
+        .context("config.toml root must be a table")?;
+    let subagents = subagents_table_for_write(table, app.config_profile.as_deref())?;
+    update(subagents);
+
+    let body = toml::to_string_pretty(&doc).context("failed to serialize config.toml")?;
+    fs::write(&path, body)
+        .with_context(|| format!("failed to write config at {}", path.display()))?;
+    Ok(path)
+}
+
+fn persist_subagents_config_value(
+    app: &App,
+    key: &str,
+    value: toml::Value,
+) -> anyhow::Result<PathBuf> {
+    update_subagents_table(app, |subagents| {
+        subagents.insert(key.to_string(), value);
+    })
+}
+
+fn remove_subagents_config_value(app: &App, key: &str) -> anyhow::Result<PathBuf> {
+    update_subagents_table(app, |subagents| {
+        subagents.remove(key);
+    })
+}
+
+fn is_config_clear_value(value: &str) -> bool {
+    let trimmed = value.trim();
+    trimmed.is_empty()
+        || matches!(
+            trimmed.to_ascii_lowercase().as_str(),
+            "inherit" | "default" | "none" | "unset" | "(inherit)" | "(default)"
+        )
+}
+
+fn subagent_override_aliases(key: &str) -> Option<&'static [&'static str]> {
+    match key {
+        "default_model" => Some(&["default"]),
+        "worker_model" => Some(&["worker", "general"]),
+        "explorer_model" => Some(&["explorer", "explore"]),
+        "awaiter_model" => Some(&["awaiter", "plan"]),
+        "review_model" => Some(&["review"]),
+        "custom_model" => Some(&["custom"]),
+        _ => None,
+    }
+}
+
+fn subagent_model_overrides_after_change(
+    app: &App,
+    key: &str,
+    model: Option<&str>,
+) -> std::collections::HashMap<String, String> {
+    let mut overrides = app.subagent_model_overrides.clone();
+    if let Some(aliases) = subagent_override_aliases(key) {
+        for alias in aliases {
+            if let Some(model) = model {
+                overrides.insert((*alias).to_string(), model.to_string());
+            } else {
+                overrides.remove(*alias);
+            }
+        }
+    }
+    overrides
+}
+
 /// Resolve the path to `~/.deepseek/config.toml` (or
 /// `$DEEPSEEK_CONFIG_PATH`). Mirrors what `Config::load` accepts so we
 /// never write to a different file than the one we read.
@@ -368,6 +494,97 @@ pub fn set_config_value(app: &mut App, key: &str, value: &str, persist: bool) ->
     let key = key.to_lowercase();
 
     match key.as_str() {
+        "subagents.default_model"
+        | "subagents.worker_model"
+        | "subagents.explorer_model"
+        | "subagents.awaiter_model"
+        | "subagents.review_model"
+        | "subagents.custom_model" => {
+            let subagent_key = key.trim_start_matches("subagents.");
+            let clear_value = is_config_clear_value(value);
+            let model = if clear_value {
+                None
+            } else {
+                let Some(model) = normalize_model_name(value) else {
+                    return CommandResult::error(format!(
+                        "Invalid sub-agent model '{value}'. Expected a DeepSeek model ID. Common models: {}",
+                        COMMON_DEEPSEEK_MODELS.join(", ")
+                    ));
+                };
+                Some(model)
+            };
+            let overrides =
+                subagent_model_overrides_after_change(app, subagent_key, model.as_deref());
+            let message = if persist {
+                let save_result = if let Some(model) = model.as_deref() {
+                    persist_subagents_config_value(
+                        app,
+                        subagent_key,
+                        toml::Value::String(model.to_string()),
+                    )
+                } else {
+                    remove_subagents_config_value(app, subagent_key)
+                };
+                match save_result {
+                    Ok(path) => format!(
+                        "{key} = {} (saved to {})",
+                        model.as_deref().unwrap_or("inherit"),
+                        path.display()
+                    ),
+                    Err(err) => return CommandResult::error(format!("Failed to save: {err}")),
+                }
+            } else {
+                format!(
+                    "{key} = {} (session only)",
+                    model.as_deref().unwrap_or("inherit")
+                )
+            };
+            app.subagent_model_overrides = overrides.clone();
+            return CommandResult::with_message_and_action(
+                message,
+                AppAction::UpdateSubagentModelOverrides(overrides),
+            );
+        }
+        "subagents.max_concurrent" => {
+            let clear_value = is_config_clear_value(value);
+            let message = if clear_value {
+                if persist {
+                    match remove_subagents_config_value(app, "max_concurrent") {
+                        Ok(path) => format!(
+                            "subagents.max_concurrent = default (saved to {}; restart required)",
+                            path.display()
+                        ),
+                        Err(err) => return CommandResult::error(format!("Failed to save: {err}")),
+                    }
+                } else {
+                    "subagents.max_concurrent = default (session only; restart required)"
+                        .to_string()
+                }
+            } else {
+                let Ok(limit) = value.trim().parse::<usize>() else {
+                    return CommandResult::error(format!(
+                        "Invalid subagents.max_concurrent '{value}'. Use a number from 1 to {MAX_SUBAGENTS}."
+                    ));
+                };
+                let limit = limit.clamp(1, MAX_SUBAGENTS);
+                if persist {
+                    match persist_subagents_config_value(
+                        app,
+                        "max_concurrent",
+                        toml::Value::Integer(limit as i64),
+                    ) {
+                        Ok(path) => format!(
+                            "subagents.max_concurrent = {limit} (saved to {}; restart required)",
+                            path.display()
+                        ),
+                        Err(err) => return CommandResult::error(format!("Failed to save: {err}")),
+                    }
+                } else {
+                    format!("subagents.max_concurrent = {limit} (session only; restart required)")
+                }
+            };
+            return CommandResult::message(message);
+        }
         "model" => {
             // Support "/model auto" — auto-select model based on request complexity
             if value.trim().eq_ignore_ascii_case("auto") {
@@ -1484,6 +1701,173 @@ mod tests {
         // Note: This test may fail in environments where settings can't be saved
         // The important thing is that the model is updated
         assert_eq!(app.model, "deepseek-v4-flash");
+    }
+
+    #[test]
+    fn set_subagent_model_persists_and_updates_runtime_overrides() {
+        let temp_root = env::temp_dir().join(format!(
+            "deepseek-tui-subagent-model-{}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&temp_root).unwrap();
+        let _guard = EnvGuard::new(&temp_root);
+        let mut app = create_test_app();
+
+        let result = set_config_value(
+            &mut app,
+            "subagents.worker_model",
+            "deepseek-v4-flash",
+            true,
+        );
+
+        assert!(!result.is_error, "{:?}", result.message);
+        assert!(
+            result
+                .message
+                .as_deref()
+                .unwrap_or_default()
+                .contains("subagents.worker_model = deepseek-v4-flash")
+        );
+        let Some(AppAction::UpdateSubagentModelOverrides(overrides)) = result.action else {
+            panic!("expected sub-agent override update action");
+        };
+        assert_eq!(
+            overrides.get("worker").map(String::as_str),
+            Some("deepseek-v4-flash")
+        );
+        assert_eq!(
+            overrides.get("general").map(String::as_str),
+            Some("deepseek-v4-flash")
+        );
+
+        let raw = fs::read_to_string(temp_root.join(".deepseek").join("config.toml")).unwrap();
+        assert!(raw.contains("[subagents]"));
+        assert!(raw.contains("worker_model = \"deepseek-v4-flash\""));
+    }
+
+    #[test]
+    fn clear_subagent_model_removes_saved_override() {
+        let temp_root = env::temp_dir().join(format!(
+            "deepseek-tui-subagent-clear-{}",
+            std::process::id()
+        ));
+        fs::create_dir_all(temp_root.join(".deepseek")).unwrap();
+        fs::write(
+            temp_root.join(".deepseek").join("config.toml"),
+            "[subagents]\nworker_model = \"deepseek-v4-flash\"\n",
+        )
+        .unwrap();
+        let _guard = EnvGuard::new(&temp_root);
+        let mut app = create_test_app();
+
+        let result = set_config_value(&mut app, "subagents.worker_model", "inherit", true);
+
+        assert!(!result.is_error, "{:?}", result.message);
+        let Some(AppAction::UpdateSubagentModelOverrides(overrides)) = result.action else {
+            panic!("expected sub-agent override update action");
+        };
+        assert!(!overrides.contains_key("worker"));
+        assert!(!overrides.contains_key("general"));
+        let raw = fs::read_to_string(temp_root.join(".deepseek").join("config.toml")).unwrap();
+        assert!(!raw.contains("worker_model"));
+    }
+
+    #[test]
+    fn session_only_subagent_model_edits_are_merged() {
+        let mut app = create_test_app();
+
+        let worker = set_config_value(
+            &mut app,
+            "subagents.worker_model",
+            "deepseek-v4-flash",
+            false,
+        );
+        assert!(!worker.is_error, "{:?}", worker.message);
+
+        let review = set_config_value(&mut app, "subagents.review_model", "deepseek-v4-pro", false);
+        assert!(!review.is_error, "{:?}", review.message);
+        let Some(AppAction::UpdateSubagentModelOverrides(overrides)) = review.action else {
+            panic!("expected sub-agent override update action");
+        };
+
+        assert_eq!(
+            overrides.get("worker").map(String::as_str),
+            Some("deepseek-v4-flash")
+        );
+        assert_eq!(
+            overrides.get("review").map(String::as_str),
+            Some("deepseek-v4-pro")
+        );
+        assert_eq!(app.subagent_model_overrides, overrides);
+    }
+
+    #[test]
+    fn set_subagent_model_uses_custom_config_path_and_profile() {
+        let temp_root = env::temp_dir().join(format!(
+            "deepseek-tui-subagent-profile-{}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&temp_root).unwrap();
+        let default_root = temp_root.join("default-home");
+        fs::create_dir_all(&default_root).unwrap();
+        let _guard = EnvGuard::new(&default_root);
+        let custom_path = temp_root.join("custom-config.toml");
+        fs::write(
+            &custom_path,
+            "[subagents]\ndefault_model = \"deepseek-v4-pro\"\n\n[profiles.work]\nprovider = \"deepseek\"\n",
+        )
+        .unwrap();
+        let mut app = create_test_app();
+        app.config_path = Some(custom_path.clone());
+        app.config_profile = Some("work".to_string());
+        app.subagent_model_overrides
+            .insert("default".to_string(), "deepseek-v4-pro".to_string());
+
+        let result = set_config_value(
+            &mut app,
+            "subagents.worker_model",
+            "deepseek-v4-flash",
+            true,
+        );
+
+        assert!(!result.is_error, "{:?}", result.message);
+        assert!(!default_root.join(".deepseek").join("config.toml").exists());
+        let raw = fs::read_to_string(&custom_path).unwrap();
+        assert!(raw.contains("[profiles.work.subagents]"), "{raw}");
+        assert!(
+            raw.contains("worker_model = \"deepseek-v4-flash\""),
+            "{raw}"
+        );
+        assert_eq!(
+            app.subagent_model_overrides
+                .get("default")
+                .map(String::as_str),
+            Some("deepseek-v4-pro")
+        );
+        assert_eq!(
+            app.subagent_model_overrides
+                .get("worker")
+                .map(String::as_str),
+            Some("deepseek-v4-flash")
+        );
+    }
+
+    #[test]
+    fn set_subagent_max_concurrent_persists_clamped_limit() {
+        let temp_root = env::temp_dir().join(format!(
+            "deepseek-tui-subagent-limit-{}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&temp_root).unwrap();
+        let _guard = EnvGuard::new(&temp_root);
+        let mut app = create_test_app();
+
+        let result = set_config_value(&mut app, "subagents.max_concurrent", "999", true);
+
+        assert!(!result.is_error, "{:?}", result.message);
+        assert!(result.action.is_none());
+        let raw = fs::read_to_string(temp_root.join(".deepseek").join("config.toml")).unwrap();
+        assert!(raw.contains("max_concurrent = 20"));
     }
 
     #[test]

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -2972,10 +2972,41 @@ fn merge_config(base: Config, override_cfg: Config) -> Config {
                 .or(base.context.cycle_threshold),
             seam_model: override_cfg.context.seam_model.or(base.context.seam_model),
         },
-        subagents: override_cfg.subagents.or(base.subagents),
+        subagents: merge_subagents(base.subagents, override_cfg.subagents),
         strict_tool_mode: override_cfg.strict_tool_mode.or(base.strict_tool_mode),
         runtime_api: override_cfg.runtime_api.or(base.runtime_api),
         workshop: override_cfg.workshop.or(base.workshop),
+    }
+}
+
+fn merge_subagents(
+    base: Option<SubagentsConfig>,
+    override_cfg: Option<SubagentsConfig>,
+) -> Option<SubagentsConfig> {
+    match (base, override_cfg) {
+        (Some(base), Some(override_cfg)) => {
+            let models = match (base.models, override_cfg.models) {
+                (Some(mut base_models), Some(override_models)) => {
+                    base_models.extend(override_models);
+                    Some(base_models)
+                }
+                (None, Some(models)) | (Some(models), None) => Some(models),
+                (None, None) => None,
+            };
+            Some(SubagentsConfig {
+                default_model: override_cfg.default_model.or(base.default_model),
+                worker_model: override_cfg.worker_model.or(base.worker_model),
+                explorer_model: override_cfg.explorer_model.or(base.explorer_model),
+                awaiter_model: override_cfg.awaiter_model.or(base.awaiter_model),
+                review_model: override_cfg.review_model.or(base.review_model),
+                custom_model: override_cfg.custom_model.or(base.custom_model),
+                models,
+                max_concurrent: override_cfg.max_concurrent.or(base.max_concurrent),
+                api_timeout_secs: override_cfg.api_timeout_secs.or(base.api_timeout_secs),
+            })
+        }
+        (None, Some(cfg)) | (Some(cfg), None) => Some(cfg),
+        (None, None) => None,
     }
 }
 
@@ -4888,6 +4919,42 @@ api_key = "old-openrouter-key"
 
         let merged = apply_profile(config, Some("work")).expect("profile");
         assert_eq!(merged.context.enabled, Some(true));
+    }
+
+    #[test]
+    fn profile_subagents_merge_with_base_subagents() {
+        let mut profiles = HashMap::new();
+        profiles.insert(
+            "work".to_string(),
+            Config {
+                subagents: Some(SubagentsConfig {
+                    worker_model: Some("deepseek-v4-flash".to_string()),
+                    ..SubagentsConfig::default()
+                }),
+                ..Config::default()
+            },
+        );
+        let config = ConfigFile {
+            base: Config {
+                subagents: Some(SubagentsConfig {
+                    default_model: Some("deepseek-v4-pro".to_string()),
+                    ..SubagentsConfig::default()
+                }),
+                ..Config::default()
+            },
+            profiles: Some(profiles),
+        };
+
+        let merged = apply_profile(config, Some("work")).expect("profile");
+        let overrides = merged.subagent_model_overrides();
+        assert_eq!(
+            overrides.get("default").map(String::as_str),
+            Some("deepseek-v4-pro")
+        );
+        assert_eq!(
+            overrides.get("worker").map(String::as_str),
+            Some("deepseek-v4-flash")
+        );
     }
 
     #[test]

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -745,6 +745,15 @@ impl Engine {
                         )))
                         .await;
                 }
+                Op::SetSubagentModelOverrides { overrides } => {
+                    self.config.subagent_model_overrides = overrides;
+                    let _ = self
+                        .tx_event
+                        .send(Event::status(
+                            "Sub-agent model overrides updated".to_string(),
+                        ))
+                        .await;
+                }
                 Op::SyncSession {
                     session_id,
                     messages,

--- a/crates/tui/src/core/ops.rs
+++ b/crates/tui/src/core/ops.rs
@@ -7,6 +7,7 @@ use crate::compaction::CompactionConfig;
 use crate::models::{Message, SystemPrompt};
 use crate::tui::app::AppMode;
 use crate::tui::approval::ApprovalMode;
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 /// Operations that can be submitted to the engine.
@@ -62,6 +63,9 @@ pub enum Op {
 
     /// Update auto-compaction settings
     SetCompaction { config: CompactionConfig },
+
+    /// Update model overrides used for subsequently spawned sub-agents.
+    SetSubagentModelOverrides { overrides: HashMap<String, String> },
 
     /// Sync engine session state (used for resume/load)
     SyncSession {

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -979,6 +979,9 @@ pub struct App {
     pub max_input_history: usize,
     pub allow_shell: bool,
     pub max_subagents: usize,
+    /// Active model overrides for subsequently spawned sub-agents. This
+    /// includes config/profile values plus any session-only `/config` edits.
+    pub subagent_model_overrides: HashMap<String, String>,
     /// Cached sub-agent snapshots for UI views.
     pub subagent_cache: Vec<SubAgentResult>,
     /// Last known per-agent progress text for running sub-agents.
@@ -1631,6 +1634,7 @@ impl App {
             max_input_history,
             allow_shell,
             max_subagents,
+            subagent_model_overrides: config.subagent_model_overrides(),
             subagent_cache: Vec::new(),
             agent_progress: HashMap::new(),
             subagent_card_index: HashMap::new(),
@@ -4284,6 +4288,7 @@ pub enum AppAction {
         model: Option<String>,
     },
     UpdateCompaction(CompactionConfig),
+    UpdateSubagentModelOverrides(HashMap<String, String>),
     OpenContextInspector,
     CompactContext,
     TaskAdd {

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -37,7 +37,7 @@ use crate::automation_manager::{AutomationManager, AutomationSchedulerConfig, sp
 use crate::client::{DeepSeekClient, build_cache_warmup_request};
 use crate::commands;
 use crate::compaction::estimate_input_tokens_conservative;
-use crate::config::{ApiProvider, Config, DEFAULT_NVIDIA_NIM_BASE_URL};
+use crate::config::{ApiProvider, Config, DEFAULT_NVIDIA_NIM_BASE_URL, MAX_SUBAGENTS};
 use crate::config_ui::{self, ConfigUiMode, WebConfigSession, WebConfigSessionEvent};
 use crate::core::engine::{EngineConfig, EngineHandle, spawn_engine};
 use crate::core::events::Event as EngineEvent;
@@ -437,7 +437,7 @@ pub async fn run_tui(config: &Config, options: TuiOptions) -> Result<()> {
             config,
             app.workspace.clone(),
             Some(app.model.clone()),
-            Some(app.max_subagents.clamp(1, 4)),
+            Some(app.max_subagents.clamp(1, MAX_SUBAGENTS)),
         ),
         config.clone(),
     )
@@ -706,7 +706,7 @@ fn build_engine_config(app: &App, config: &Config) -> EngineConfig {
             .clone()
             .map(crate::config::LspConfigToml::into_runtime),
         runtime_services: app.runtime_services.clone(),
-        subagent_model_overrides: config.subagent_model_overrides(),
+        subagent_model_overrides: app.subagent_model_overrides.clone(),
         subagent_api_timeout: Duration::from_secs(config.subagent_api_timeout_secs()),
         memory_enabled: config.memory_enabled(),
         memory_path: config.memory_path(),
@@ -4013,6 +4013,15 @@ async fn apply_model_and_compaction_update(
         .await;
 }
 
+async fn apply_subagent_model_overrides_update(
+    engine_handle: &EngineHandle,
+    overrides: std::collections::HashMap<String, String>,
+) {
+    let _ = engine_handle
+        .send(Op::SetSubagentModelOverrides { overrides })
+        .await;
+}
+
 async fn drain_web_config_events(
     web_config_session: &mut Option<WebConfigSession>,
     app: &mut App,
@@ -4458,6 +4467,9 @@ async fn apply_command_result(
             AppAction::UpdateCompaction(compaction) => {
                 apply_model_and_compaction_update(engine_handle, compaction).await;
             }
+            AppAction::UpdateSubagentModelOverrides(overrides) => {
+                apply_subagent_model_overrides_update(engine_handle, overrides).await;
+            }
             AppAction::OpenConfigEditor(mode) => match mode {
                 ConfigUiMode::Native => {
                     if app.view_stack.top_kind() != Some(ModalKind::Config) {
@@ -4669,6 +4681,7 @@ async fn apply_command_result(
                     Ok(new_config) => {
                         *config = new_config.clone();
                         app.api_provider = config.api_provider();
+                        app.subagent_model_overrides = config.subagent_model_overrides();
                         let new_model = config.default_model();
                         app.set_model_selection(new_model.clone());
                         app.update_model_compaction_budget();
@@ -5872,6 +5885,9 @@ async fn handle_view_events(
                     match action {
                         AppAction::UpdateCompaction(compaction) => {
                             apply_model_and_compaction_update(engine_handle, compaction).await;
+                        }
+                        AppAction::UpdateSubagentModelOverrides(overrides) => {
+                            apply_subagent_model_overrides_update(engine_handle, overrides).await;
                         }
                         AppAction::OpenConfigView => {}
                         _ => {}

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -523,6 +523,7 @@ struct ConfigRow {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ConfigSection {
     Model,
+    Subagents,
     Permissions,
     Display,
     Composer,
@@ -535,6 +536,7 @@ impl ConfigSection {
     fn label(self) -> &'static str {
         match self {
             ConfigSection::Model => "Model",
+            ConfigSection::Subagents => "Subagents",
             ConfigSection::Permissions => "Permissions",
             ConfigSection::Display => "Display",
             ConfigSection::Composer => "Composer",
@@ -579,6 +581,16 @@ const CONFIG_VALUE_COLUMN_WIDTH: usize = 44;
 impl ConfigView {
     pub fn new_for_app(app: &App) -> Self {
         let settings = Settings::load().unwrap_or_else(|_| Settings::default());
+        let subagent_model_value = |aliases: &[&str]| {
+            aliases
+                .iter()
+                .find_map(|alias| app.subagent_model_overrides.get(*alias))
+                .map(|value| value.trim())
+                .filter(|value| !value.is_empty())
+                .unwrap_or("(inherit)")
+                .to_string()
+        };
+        let subagent_limit_value = app.max_subagents.to_string();
         let rows = vec![
             ConfigRow {
                 section: ConfigSection::Model,
@@ -606,6 +618,55 @@ impl ConfigView {
                     .as_deref()
                     .unwrap_or("(config/default)")
                     .to_string(),
+                editable: true,
+                scope: ConfigScope::Saved,
+            },
+            ConfigRow {
+                section: ConfigSection::Subagents,
+                key: "subagents.default_model".to_string(),
+                value: subagent_model_value(&["default"]),
+                editable: true,
+                scope: ConfigScope::Saved,
+            },
+            ConfigRow {
+                section: ConfigSection::Subagents,
+                key: "subagents.worker_model".to_string(),
+                value: subagent_model_value(&["worker", "general"]),
+                editable: true,
+                scope: ConfigScope::Saved,
+            },
+            ConfigRow {
+                section: ConfigSection::Subagents,
+                key: "subagents.explorer_model".to_string(),
+                value: subagent_model_value(&["explorer", "explore"]),
+                editable: true,
+                scope: ConfigScope::Saved,
+            },
+            ConfigRow {
+                section: ConfigSection::Subagents,
+                key: "subagents.awaiter_model".to_string(),
+                value: subagent_model_value(&["awaiter", "plan"]),
+                editable: true,
+                scope: ConfigScope::Saved,
+            },
+            ConfigRow {
+                section: ConfigSection::Subagents,
+                key: "subagents.review_model".to_string(),
+                value: subagent_model_value(&["review"]),
+                editable: true,
+                scope: ConfigScope::Saved,
+            },
+            ConfigRow {
+                section: ConfigSection::Subagents,
+                key: "subagents.custom_model".to_string(),
+                value: subagent_model_value(&["custom"]),
+                editable: true,
+                scope: ConfigScope::Saved,
+            },
+            ConfigRow {
+                section: ConfigSection::Subagents,
+                key: "subagents.max_concurrent".to_string(),
+                value: subagent_limit_value,
                 editable: true,
                 scope: ConfigScope::Saved,
             },
@@ -2129,6 +2190,7 @@ mod tests {
             visible_section_labels(&view),
             vec![
                 ConfigSection::Model.label(),
+                ConfigSection::Subagents.label(),
                 ConfigSection::Permissions.label(),
                 ConfigSection::Display.label(),
                 ConfigSection::Composer.label(),
@@ -2150,6 +2212,13 @@ mod tests {
             .collect::<Vec<_>>();
         assert!(keys.contains(&"model"));
         assert!(keys.contains(&"reasoning_effort"));
+        assert!(keys.contains(&"subagents.default_model"));
+        assert!(keys.contains(&"subagents.worker_model"));
+        assert!(keys.contains(&"subagents.explorer_model"));
+        assert!(keys.contains(&"subagents.awaiter_model"));
+        assert!(keys.contains(&"subagents.review_model"));
+        assert!(keys.contains(&"subagents.custom_model"));
+        assert!(keys.contains(&"subagents.max_concurrent"));
         assert!(keys.contains(&"approval_mode"));
         assert!(keys.contains(&"theme"));
         assert!(keys.contains(&"locale"));

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -454,7 +454,10 @@ If you are upgrading from older releases:
   with `0` or unset preserving the legacy 120 second default.
   `[subagents.models]` accepts lower-case role or type keys such as `worker`,
   `explorer`, `general`, `explore`, `plan`, and `review`. Values must normalize
-  to a supported DeepSeek model id before an agent is spawned.
+  to a supported DeepSeek model id before an agent is spawned. The native
+  `/config` view exposes the convenience keys; model changes apply to newly
+  spawned sub-agents immediately, while `max_concurrent` still requires a
+  restart because it changes the manager capacity.
 - `skills_dir` (string, optional): defaults to `~/.deepseek/skills` (each skill is
   a directory containing `SKILL.md`). Workspace-local `.agents/skills` or
   `./skills` are preferred when present; the runtime also discovers global


### PR DESCRIPTION
## Summary

Refs #1768

This PR fills the configuration-interface gap for sub-agent model routing. The lower-level pieces already supported explicit per-agent `model` values and `[subagents]` config defaults; this adds a visible/editable path for those defaults and makes model changes take effect for newly spawned sub-agents without restarting.

Changes:
- Add a `Subagents` section to the native `/config` view with:
  - `subagents.default_model`
  - `subagents.worker_model`
  - `subagents.explorer_model`
  - `subagents.awaiter_model`
  - `subagents.review_model`
  - `subagents.custom_model`
  - `subagents.max_concurrent`
- Support `/config subagents.* <value> --save` by writing the nested `[subagents]` table in `config.toml`.
- Respect custom config paths and active profiles when persisting sub-agent settings.
- Track active sub-agent model overrides in `App`, so session-only edits merge correctly and show up in `/config`.
- Validate sub-agent model values using the same DeepSeek model normalization path used by sub-agent spawning.
- Allow clearing model overrides with an empty value, `inherit`, `default`, `none`, or the UI placeholders.
- Hot-sync model override changes to the running engine for future sub-agent spawns.
- Keep `subagents.max_concurrent` persisted and clamped, with a restart note because the manager capacity is created at startup.
- Align the TUI task manager capacity clamp with `MAX_SUBAGENTS` instead of capping it at 4.
- Merge profile `[subagents]` settings field-by-field so profile overrides do not discard base sub-agent defaults.
- Document that the native `/config` view exposes these keys and clarify the hot-sync/restart behavior.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p deepseek-tui set_subagent_model_persists_and_updates_runtime_overrides --all-features`
- `cargo test -p deepseek-tui clear_subagent_model_removes_saved_override --all-features`
- `cargo test -p deepseek-tui session_only_subagent_model_edits_are_merged --all-features`
- `cargo test -p deepseek-tui set_subagent_model_uses_custom_config_path_and_profile --all-features`
- `cargo test -p deepseek-tui set_subagent_max_concurrent_persists_clamped_limit --all-features`
- `cargo test -p deepseek-tui profile_subagents_merge_with_base_subagents --all-features`
- `cargo test -p deepseek-tui config_view --all-features`
- `cargo test -p deepseek-tui subagent_model --all-features`
- `cargo clippy -p deepseek-tui --all-targets --all-features`

Note: clippy still reports pre-existing warnings in `schema_migration.rs` and two existing `needless_return` warnings in `tui/ui.rs`; the command exits successfully.
