### PR TITLE
per-run-log-pid-suffix

### DIFF
--- a/crates/tui/src/runtime_log.rs
+++ b/crates/tui/src/runtime_log.rs
@@ -1,7 +1,7 @@
 //! TUI runtime logging. Initializes a `tracing-subscriber` that writes to a
-//! daily-rolling file under `~/.deepseek/logs/`, and (on Unix) redirects the
-//! process's `stderr` fd to that same file for the lifetime of the alt-screen
-//! TUI.
+//! per-instance file under `~/.deepseek/logs/tui-YYYY-MM-DD-PID.log`, and
+//! (on Unix) redirects the process's `stderr` fd to that same file for the
+//! lifetime of the alt-screen TUI.
 //!
 //! Why this exists:
 //!
@@ -22,7 +22,7 @@
 //!
 //! Defence-in-depth:
 //!   1. A `tracing-subscriber` writes formatted logs to
-//!      `~/.deepseek/logs/tui-YYYY-MM-DD.log` so `tracing::warn!` /
+//!      `~/.deepseek/logs/tui-YYYY-MM-DD-PID.log` so `tracing::warn!` /
 //!      `tracing::error!` calls go somewhere observable instead of
 //!      disappearing into the void (the TUI previously had no global
 //!      subscriber, so contributors reached for `eprintln!`).

--- a/crates/tui/src/runtime_log.rs
+++ b/crates/tui/src/runtime_log.rs
@@ -102,7 +102,9 @@ pub fn init() -> Result<TuiLogGuard> {
         .with_context(|| format!("failed to create {}", log_dir.display()))?;
 
     let date = chrono::Local::now().format("%Y-%m-%d");
-    let log_path = log_dir.join(format!("tui-{date}.log"));
+    // Per-run suffix avoids multiple concurrent TUI instances writing to the
+    // same file. Process ID is unique enough per boot.
+    let log_path = log_dir.join(format!("tui-{date}-{}.log", std::process::id()));
 
     let file = OpenOptions::new()
         .create(true)


### PR DESCRIPTION
## Problem

Multiple concurrent TUI instances write to the same log file (`tui-YYYY-MM-DD.log`), causing interleaved entries and file contention.

## Fix

Append process ID to log filename: `tui-YYYY-MM-DD-<PID>.log`.

One line change in `crates/tui/src/runtime_log.rs`.

Closes #1782
