### PR TITLE
fix(file_search): wrap walker in spawn_blocking + 30s timeout

### DIFF
--- a/crates/tui/src/tools/file_search.rs
+++ b/crates/tui/src/tools/file_search.rs
@@ -2,11 +2,23 @@
 
 use std::cmp::Ordering;
 use std::path::Path;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use ignore::WalkBuilder;
 use serde::Serialize;
 use serde_json::{Value, json};
+
+/// Maximum wall-clock time a single `file_search` invocation may run before
+/// being aborted. The synchronous `WalkBuilder` traversal cannot observe the
+/// engine's `CancellationToken`, so this timeout is currently the only path
+/// for unblocking the turn loop when a search targets a very large tree
+/// (e.g. `$HOME`, mounted network volumes, repos with deep `node_modules/`).
+///
+/// 30s is generous for normal workspace usage (typical: <1s) and protective
+/// against pathological cases. A long-term fix to expose `cancel_token`
+/// through `ToolContext` is tracked separately.
+const FILE_SEARCH_TIMEOUT: Duration = Duration::from_secs(30);
 
 use crate::tools::search::matches_glob;
 
@@ -87,7 +99,37 @@ impl ToolSpec for FileSearchTool {
 
         let extensions = parse_extensions(&input);
         let exclude_patterns = parse_exclude_patterns(&input);
-        let matches = search_files(query, &base_path, extensions, exclude_patterns, limit)?;
+
+        // Move the synchronous walker off the async task: it can run for
+        // minutes on large trees and would otherwise block the engine's
+        // turn loop from observing cancellation.
+        let query_owned = query.to_string();
+        let base_path_owned = base_path.clone();
+        let task = tokio::task::spawn_blocking(move || {
+            search_files(
+                &query_owned,
+                &base_path_owned,
+                extensions,
+                exclude_patterns,
+                limit,
+            )
+        });
+        let matches = match tokio::time::timeout(FILE_SEARCH_TIMEOUT, task).await {
+            Ok(Ok(Ok(matches))) => matches,
+            Ok(Ok(Err(e))) => return Err(e),
+            Ok(Err(join_err)) => {
+                return Err(ToolError::execution_failed(format!(
+                    "file_search task panicked: {join_err}"
+                )));
+            }
+            Err(_) => {
+                return Err(ToolError::execution_failed(format!(
+                    "file_search timed out after {}s (base_path={}). Narrow the search with `path` or specific `extensions`.",
+                    FILE_SEARCH_TIMEOUT.as_secs(),
+                    base_path.display()
+                )));
+            }
+        };
         ToolResult::json(&matches).map_err(|e| ToolError::execution_failed(e.to_string()))
     }
 }


### PR DESCRIPTION
## Summary

Wrap `FileSearchTool`'s synchronous `WalkBuilder` traversal in `spawn_blocking` + 30s `timeout` so the engine turn loop stays responsive to cancellation.

## Problem

`FileSearchTool::execute` is `async fn` but `search_files()` is fully synchronous — it iterates the entire directory tree via `ignore::WalkBuilder` while blocking the tokio task. When the model runs `file_search` over a large tree like `$HOME`, the call blocks for tens of seconds to several minutes.

During this blocking call, the engine's turn loop **cannot observe `CancellationToken` updates** — `Op::Cancel` and frontend stop buttons are effectively no-ops until the walker finishes naturally.

Observed in a wrapping GUI (pinvou3): stop button unresponsive for 90+ seconds when the model searched `workspace=$HOME` for `notes.md`.

## Fix

Wrap `search_files()` in `tokio::task::spawn_blocking` and race it against a 30s timeout:

- Blocking walker now runs on the blocking thread pool, freeing the async runtime to poll cancel signals.
- 30s timeout returns a `ToolError` with an actionable hint. The model can then fall back to a scoped search.
- 30s is generous for normal workspaces (<1s typical) and protective against pathological cases.

## Limitations

- After the timeout fires, the orphaned `spawn_blocking` task keeps running until natural completion. There is no portable way to abort it mid-iteration without `unsafe` thread interruption. Acceptable in practice: user-facing cancellation works, and the orphan eventually finishes without holding shared state.
- The deeper fix is to expose `cancel_token` through `ToolContext` so synchronous tools can periodically check it. That's out of scope here — I'll open a follow-up discussion issue covering this and the other affected tools (`grep_files`, `list_dir`).

## Test plan

- `cargo test --bin deepseek-tui file_search` — all 6 existing tests pass (they exercise the new spawn_blocking path).
- `cargo fmt --check` — clean.
- `cargo clippy --workspace --all-targets --all-features` — clean.
- Manually verified in pinvou3 GUI: previously hung searches (`workspace=$HOME`) now return within 30s and stop button works.

No new timeout-specific test added: the behavior is hard to test deterministically without an injectable clock, and the spawn_blocking + timeout pattern is widely understood. Happy to add one if you'd like.