### PR TITLE
fix(tui): reset displayed cost on clear

### DIFF
--- a/crates/tui/src/commands/core.rs
+++ b/crates/tui/src/commands/core.rs
@@ -74,6 +74,8 @@ pub fn clear(app: &mut App) -> CommandResult {
     app.session.last_completion_tokens = None;
     app.session.last_prompt_cache_hit_tokens = None;
     app.session.last_prompt_cache_miss_tokens = None;
+    app.session.last_reasoning_replay_tokens = None;
+    app.session.last_cache_inspection = None;
     app.session.turn_cache_history.clear();
     app.current_session_id = None;
     let locale = app.ui_locale;
@@ -375,6 +377,7 @@ pub fn translate(app: &mut App) -> CommandResult {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::client::PromptInspection;
     use crate::config::Config;
     use crate::models::Message;
     use crate::tui::app::{App, AppMode, TuiOptions, TurnCacheRecord};
@@ -535,6 +538,12 @@ mod tests {
         app.session.displayed_cost_high_water_cny = 3.85;
         app.session.last_prompt_cache_hit_tokens = Some(70);
         app.session.last_prompt_cache_miss_tokens = Some(30);
+        app.session.last_reasoning_replay_tokens = Some(12);
+        app.session.last_cache_inspection = Some(PromptInspection {
+            base_static_prefix_hash: "base".to_string(),
+            full_request_prefix_hash: "full".to_string(),
+            layers: Vec::new(),
+        });
         app.push_turn_cache_record(TurnCacheRecord {
             input_tokens: 100,
             output_tokens: 25,
@@ -558,6 +567,8 @@ mod tests {
         assert_eq!(app.displayed_session_cost(), 0.0);
         assert_eq!(app.session.last_prompt_cache_hit_tokens, None);
         assert_eq!(app.session.last_prompt_cache_miss_tokens, None);
+        assert_eq!(app.session.last_reasoning_replay_tokens, None);
+        assert_eq!(app.session.last_cache_inspection, None);
         assert!(app.session.turn_cache_history.is_empty());
     }
 

--- a/crates/tui/src/commands/core.rs
+++ b/crates/tui/src/commands/core.rs
@@ -57,6 +57,11 @@ pub fn clear(app: &mut App) -> CommandResult {
     app.session.total_conversation_tokens = 0;
     app.session.session_cost = 0.0;
     app.session.session_cost_cny = 0.0;
+    app.session.subagent_cost = 0.0;
+    app.session.subagent_cost_cny = 0.0;
+    app.session.subagent_cost_event_seqs.clear();
+    app.session.displayed_cost_high_water = 0.0;
+    app.session.displayed_cost_high_water_cny = 0.0;
     let todos_cleared = app.clear_todos();
     app.tool_log.clear();
     app.tool_cells.clear();
@@ -523,6 +528,11 @@ mod tests {
         app.session.total_conversation_tokens = 123;
         app.session.session_cost = 0.42;
         app.session.session_cost_cny = 3.05;
+        app.session.subagent_cost = 0.11;
+        app.session.subagent_cost_cny = 0.80;
+        app.session.subagent_cost_event_seqs.insert(7);
+        app.session.displayed_cost_high_water = 0.53;
+        app.session.displayed_cost_high_water_cny = 3.85;
         app.session.last_prompt_cache_hit_tokens = Some(70);
         app.session.last_prompt_cache_miss_tokens = Some(30);
         app.push_turn_cache_record(TurnCacheRecord {
@@ -540,6 +550,12 @@ mod tests {
         assert_eq!(app.session.total_conversation_tokens, 0);
         assert_eq!(app.session.session_cost, 0.0);
         assert_eq!(app.session.session_cost_cny, 0.0);
+        assert_eq!(app.session.subagent_cost, 0.0);
+        assert_eq!(app.session.subagent_cost_cny, 0.0);
+        assert!(app.session.subagent_cost_event_seqs.is_empty());
+        assert_eq!(app.session.displayed_cost_high_water, 0.0);
+        assert_eq!(app.session.displayed_cost_high_water_cny, 0.0);
+        assert_eq!(app.displayed_session_cost(), 0.0);
         assert_eq!(app.session.last_prompt_cache_hit_tokens, None);
         assert_eq!(app.session.last_prompt_cache_miss_tokens, None);
         assert!(app.session.turn_cache_history.is_empty());


### PR DESCRIPTION
## Summary

- Reset sub-agent cost accumulators when `/clear` resets the conversation session.
- Reset displayed cost high-water marks so the footer/sidebar visible total returns to zero after `/clear`.
- Extend `/clear` telemetry coverage to assert sub-agent cost, high-water state, and `displayed_session_cost()` are zeroed.

Closes #1788

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p deepseek-tui --bin deepseek-tui test_clear_resets_all_state`
- `cargo test -p deepseek-tui --bin deepseek-tui clear_resets_session_telemetry`

## Notes

- `cargo clippy --workspace --all-targets --all-features -- -D warnings` was attempted, but current `upstream/main` fails on pre-existing warnings unrelated to this change: dead-code warnings in `crates/tui/src/schema_migration.rs` and `clippy::needless_return` in `crates/tui/src/tui/ui.rs`.
