### PR TITLE
fix(tui): make subagent api timeout configurable

### DIFF
--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -870,7 +870,8 @@ pub struct SubagentsConfig {
     /// setting. Clamped to [1, MAX_SUBAGENTS].
     #[serde(default)]
     pub max_concurrent: Option<usize>,
-    /// Per-step model API timeout for sub-agents, in seconds. Values above
+    /// Per-step model API timeout for sub-agents, in seconds. Lower values
+    /// are honored as configured; only values above
     /// MAX_SUBAGENT_API_TIMEOUT_SECS are clamped.
     #[serde(default)]
     pub api_timeout_secs: Option<u64>,
@@ -3835,7 +3836,7 @@ mod tests {
     }
 
     #[test]
-    fn subagent_api_timeout_only_clamps_to_maximum() {
+    fn subagent_api_timeout_honors_configured_values_and_clamps_only_maximum() {
         let low = Config {
             subagents: Some(SubagentsConfig {
                 api_timeout_secs: Some(0),
@@ -3843,6 +3844,8 @@ mod tests {
             }),
             ..Config::default()
         };
+        // Do not impose a floor: callers may intentionally configure an
+        // aggressive timeout for tests or fail-fast sessions.
         assert_eq!(low.subagent_api_timeout_secs(), 0);
 
         let configured = Config {

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -19,6 +19,8 @@ use crate::hooks::HooksConfig;
 
 pub const DEFAULT_MAX_SUBAGENTS: usize = 10;
 pub const MAX_SUBAGENTS: usize = 20;
+pub const DEFAULT_SUBAGENT_API_TIMEOUT_SECS: u64 = 120;
+pub const MAX_SUBAGENT_API_TIMEOUT_SECS: u64 = 1800;
 pub const DEFAULT_TEXT_MODEL: &str = "deepseek-v4-pro";
 pub const DEFAULT_DEEPSEEK_BASE_URL: &str = "https://api.deepseek.com/beta";
 pub const DEFAULT_NVIDIA_NIM_MODEL: &str = "deepseek-ai/deepseek-v4-pro";
@@ -868,6 +870,10 @@ pub struct SubagentsConfig {
     /// setting. Clamped to [1, MAX_SUBAGENTS].
     #[serde(default)]
     pub max_concurrent: Option<usize>,
+    /// Per-step model API timeout for sub-agents, in seconds. Values above
+    /// MAX_SUBAGENT_API_TIMEOUT_SECS are clamped.
+    #[serde(default)]
+    pub api_timeout_secs: Option<u64>,
 }
 
 /// `[auto]` table — knobs for the `--model auto` / `/model auto` router.
@@ -1778,6 +1784,16 @@ impl Config {
         self.max_subagents
             .unwrap_or(DEFAULT_MAX_SUBAGENTS)
             .clamp(1, MAX_SUBAGENTS)
+    }
+
+    /// Return the per-step sub-agent model API timeout in seconds.
+    #[must_use]
+    pub fn subagent_api_timeout_secs(&self) -> u64 {
+        self.subagents
+            .as_ref()
+            .and_then(|cfg| cfg.api_timeout_secs)
+            .unwrap_or(DEFAULT_SUBAGENT_API_TIMEOUT_SECS)
+            .min(MAX_SUBAGENT_API_TIMEOUT_SECS)
     }
 
     /// Raw sub-agent model override map. Values are validated at spawn time
@@ -3807,6 +3823,48 @@ mod tests {
             ..Config::default()
         };
         assert_eq!(high.max_subagents(), MAX_SUBAGENTS);
+    }
+
+    #[test]
+    fn subagent_api_timeout_defaults_to_legacy_120s() {
+        assert_eq!(
+            Config::default().subagent_api_timeout_secs(),
+            DEFAULT_SUBAGENT_API_TIMEOUT_SECS
+        );
+        assert_eq!(DEFAULT_SUBAGENT_API_TIMEOUT_SECS, 120);
+    }
+
+    #[test]
+    fn subagent_api_timeout_only_clamps_to_maximum() {
+        let low = Config {
+            subagents: Some(SubagentsConfig {
+                api_timeout_secs: Some(0),
+                ..SubagentsConfig::default()
+            }),
+            ..Config::default()
+        };
+        assert_eq!(low.subagent_api_timeout_secs(), 0);
+
+        let configured = Config {
+            subagents: Some(SubagentsConfig {
+                api_timeout_secs: Some(600),
+                ..SubagentsConfig::default()
+            }),
+            ..Config::default()
+        };
+        assert_eq!(configured.subagent_api_timeout_secs(), 600);
+
+        let high = Config {
+            subagents: Some(SubagentsConfig {
+                api_timeout_secs: Some(MAX_SUBAGENT_API_TIMEOUT_SECS + 1),
+                ..SubagentsConfig::default()
+            }),
+            ..Config::default()
+        };
+        assert_eq!(
+            high.subagent_api_timeout_secs(),
+            MAX_SUBAGENT_API_TIMEOUT_SECS
+        );
     }
 
     #[test]

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -25,7 +25,10 @@ use crate::client::DeepSeekClient;
 use crate::compaction::{
     CompactionConfig, compact_messages_safe, merge_system_prompts, should_compact,
 };
-use crate::config::{ApiProvider, Config, DEFAULT_MAX_SUBAGENTS, DEFAULT_TEXT_MODEL};
+use crate::config::{
+    ApiProvider, Config, DEFAULT_MAX_SUBAGENTS, DEFAULT_SUBAGENT_API_TIMEOUT_SECS,
+    DEFAULT_TEXT_MODEL,
+};
 use crate::cycle_manager::{
     CycleBriefing, CycleConfig, StructuredState, archive_cycle, build_seed_messages,
     estimate_briefing_tokens, produce_briefing, should_advance_cycle,
@@ -126,6 +129,8 @@ pub struct EngineConfig {
     /// `SubAgentRuntime::max_spawn_depth`. Override via
     /// `[runtime] max_spawn_depth = N` in `~/.deepseek/config.toml`.
     pub max_spawn_depth: u32,
+    /// Per-step model API timeout for sub-agents.
+    pub subagent_api_timeout: Duration,
     /// Per-domain network policy decider (#135). Shared across the session so
     /// session-scoped approvals (`/network allow <host>`) persist for the
     /// remainder of the run.
@@ -190,6 +195,7 @@ impl Default for EngineConfig {
             todos: new_shared_todo_list(),
             plan_state: new_shared_plan_state(),
             max_spawn_depth: crate::tools::subagent::DEFAULT_MAX_SPAWN_DEPTH,
+            subagent_api_timeout: Duration::from_secs(DEFAULT_SUBAGENT_API_TIMEOUT_SECS),
             network_policy: None,
             snapshots_enabled: true,
             snapshots_max_workspace_bytes:
@@ -655,6 +661,7 @@ impl Engine {
                         self.session.reasoning_effort_auto,
                     )
                     .with_max_spawn_depth(self.config.max_spawn_depth)
+                    .with_api_timeout(self.config.subagent_api_timeout)
                     .background_runtime();
                     let route = resolve_subagent_assignment_route(&runtime, None, &prompt).await;
                     runtime.model = route.model;
@@ -1062,6 +1069,7 @@ impl Engine {
                             self.session.reasoning_effort_auto,
                         )
                         .with_max_spawn_depth(self.config.max_spawn_depth)
+                        .with_api_timeout(self.config.subagent_api_timeout)
                         .with_parent_completion_tx(self.tx_subagent_completion.clone());
                         if let Some(context) = fork_context_for_runtime.clone() {
                             rt = rt.with_fork_context(context);

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -4645,6 +4645,7 @@ async fn run_exec_agent(
         todos: new_shared_todo_list(),
         plan_state: new_shared_plan_state(),
         max_spawn_depth: crate::tools::subagent::DEFAULT_MAX_SPAWN_DEPTH,
+        subagent_api_timeout: std::time::Duration::from_secs(config.subagent_api_timeout_secs()),
         network_policy,
         snapshots_enabled: config.snapshots_config().enabled,
         snapshots_max_workspace_bytes: config

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -1944,6 +1944,9 @@ impl RuntimeThreadManager {
             todos: new_shared_todo_list(),
             plan_state: new_shared_plan_state(),
             max_spawn_depth: crate::tools::subagent::DEFAULT_MAX_SPAWN_DEPTH,
+            subagent_api_timeout: std::time::Duration::from_secs(
+                self.config.subagent_api_timeout_secs(),
+            ),
             network_policy,
             snapshots_enabled: self.config.snapshots_config().enabled,
             snapshots_max_workspace_bytes: self

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -25,7 +25,7 @@ use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 use crate::client::DeepSeekClient;
-use crate::config::MAX_SUBAGENTS;
+use crate::config::{DEFAULT_SUBAGENT_API_TIMEOUT_SECS, MAX_SUBAGENTS};
 use crate::core::events::Event;
 use crate::llm_client::LlmClient;
 use crate::models::{ContentBlock, Message, MessageRequest, SystemPrompt, Tool};
@@ -64,10 +64,6 @@ fn release_resident_leases_for(agent_id: &str) {
 
 const DEFAULT_MAX_STEPS: u32 = 100;
 const TOOL_TIMEOUT: Duration = Duration::from_secs(30);
-/// Per-step LLM API call timeout. Each `create_message` request must complete
-/// within this window or the step is treated as timed out. Prevents a single
-/// stuck API call from blocking the sub-agent indefinitely.
-const STEP_API_TIMEOUT: Duration = Duration::from_secs(120);
 const RESULT_POLL_INTERVAL: Duration = Duration::from_millis(250);
 const DEFAULT_RESULT_TIMEOUT_MS: u64 = 30_000;
 #[allow(dead_code)] // Legacy agent_wait clamp; new agent_eval uses DEFAULT/MAX.
@@ -625,6 +621,9 @@ pub struct SubAgentRuntime {
     /// exceed this is rejected at the spawn entry. Use `>` (strictly
     /// greater than) so equality is allowed — matches codex's pattern.
     pub max_spawn_depth: u32,
+    /// Per-step model API timeout. Configured through
+    /// `[subagents] api_timeout_secs`.
+    pub api_timeout: Duration,
     /// Cooperative cancellation token. Children derive a child_token() from
     /// the parent so cancelling the root cascades down.
     pub cancel_token: CancellationToken,
@@ -669,6 +668,7 @@ impl SubAgentRuntime {
             manager,
             spawn_depth: 0,
             max_spawn_depth: DEFAULT_MAX_SPAWN_DEPTH,
+            api_timeout: Duration::from_secs(DEFAULT_SUBAGENT_API_TIMEOUT_SECS),
             cancel_token: CancellationToken::new(),
             mailbox: None,
             parent_completion_tx: None,
@@ -722,6 +722,13 @@ impl SubAgentRuntime {
     #[allow(dead_code)]
     pub fn with_max_spawn_depth(mut self, max: u32) -> Self {
         self.max_spawn_depth = max;
+        self
+    }
+
+    /// Override the per-step model API timeout.
+    #[must_use]
+    pub fn with_api_timeout(mut self, timeout: Duration) -> Self {
+        self.api_timeout = timeout;
         self
     }
 
@@ -792,6 +799,7 @@ impl SubAgentRuntime {
             manager: self.manager.clone(),
             spawn_depth: self.spawn_depth + 1,
             max_spawn_depth: self.max_spawn_depth,
+            api_timeout: self.api_timeout,
             cancel_token: self.cancel_token.child_token(),
             mailbox: self.mailbox.clone(),
             parent_completion_tx: self.parent_completion_tx.clone(),
@@ -3460,8 +3468,8 @@ async fn run_subagent(
                     from_prior_session: false,
                 });
             }
-            api = tokio::time::timeout(STEP_API_TIMEOUT, runtime.client.create_message(request)) => {
-                api.map_err(|_| anyhow!("API call timed out after {}s", STEP_API_TIMEOUT.as_secs()))??
+            api = tokio::time::timeout(runtime.api_timeout, runtime.client.create_message(request)) => {
+                api.map_err(|_| anyhow!("API call timed out after {}s", runtime.api_timeout.as_secs()))??
             }
         };
 

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -1104,6 +1104,34 @@ fn subagent_runtime_default_max_depth_is_three() {
 }
 
 #[test]
+fn subagent_runtime_default_api_timeout_is_legacy_120s() {
+    assert_eq!(DEFAULT_SUBAGENT_API_TIMEOUT_SECS, 120);
+    assert_eq!(
+        SubAgentRuntime::new(
+            stub_client(),
+            "deepseek-v4-flash".to_string(),
+            ToolContext::new("."),
+            true,
+            None,
+            new_shared_subagent_manager(PathBuf::from("."), 5),
+        )
+        .api_timeout,
+        Duration::from_secs(120)
+    );
+}
+
+#[test]
+fn child_runtime_preserves_api_timeout() {
+    let parent = stub_runtime().with_api_timeout(Duration::from_secs(600));
+
+    let child = parent.child_runtime();
+    let background = parent.background_runtime();
+
+    assert_eq!(child.api_timeout, Duration::from_secs(600));
+    assert_eq!(background.api_timeout, Duration::from_secs(600));
+}
+
+#[test]
 fn would_exceed_depth_at_boundary() {
     // depth=2, max=3 → next spawn (depth 3) is allowed (allow-equal).
     // depth=3, max=3 → next spawn (depth 4) exceeds.
@@ -1398,6 +1426,7 @@ fn stub_runtime() -> SubAgentRuntime {
         manager: new_shared_subagent_manager(workspace, 5),
         spawn_depth: 0,
         max_spawn_depth: DEFAULT_MAX_SPAWN_DEPTH,
+        api_timeout: Duration::from_secs(DEFAULT_SUBAGENT_API_TIMEOUT_SECS),
         cancel_token: CancellationToken::new(),
         mailbox: None,
         parent_completion_tx: None,

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -693,6 +693,7 @@ fn build_engine_config(app: &App, config: &Config) -> EngineConfig {
         todos: app.todos.clone(),
         plan_state: app.plan_state.clone(),
         max_spawn_depth: crate::tools::subagent::DEFAULT_MAX_SPAWN_DEPTH,
+        subagent_api_timeout: std::time::Duration::from_secs(config.subagent_api_timeout_secs()),
         network_policy: config.network.clone().map(|toml_cfg| {
             crate::network_policy::NetworkPolicyDecider::with_default_audit(toml_cfg.into_runtime())
         }),

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -443,10 +443,10 @@ If you are upgrading from older releases:
   `[subagents] max_concurrent` value overrides top-level `max_subagents` and is
   also clamped to `1..=20`. `[subagents] api_timeout_secs` controls the
   per-step model API timeout for sub-agents; it defaults to `120` and values
-  above `1800` are clamped. `[subagents.models]` accepts lower-case role or
-  type keys such as `worker`, `explorer`, `general`, `explore`, `plan`, and
-  `review`. Values must normalize to a supported DeepSeek model id before an
-  agent is spawned.
+  above `1800` are clamped. Lower timeout values are honored as configured.
+  `[subagents.models]` accepts lower-case role or type keys such as `worker`,
+  `explorer`, `general`, `explore`, `plan`, and `review`. Values must normalize
+  to a supported DeepSeek model id before an agent is spawned.
 - `skills_dir` (string, optional): defaults to `~/.deepseek/skills` (each skill is
   a directory containing `SKILL.md`). Workspace-local `.agents/skills` or
   `./skills` are preferred when present; the runtime also discovers global

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -439,10 +439,12 @@ If you are upgrading from older releases:
   related persistent sub-agent sessions. Explicit tool `model` values win, then role/type
   overrides, then the parent runtime model. Supported convenience keys are
   `default_model`, `worker_model`, `explorer_model`, `awaiter_model`,
-  `review_model`, `custom_model`, and `max_concurrent`. The
+  `review_model`, `custom_model`, `max_concurrent`, and `api_timeout_secs`. The
   `[subagents] max_concurrent` value overrides top-level `max_subagents` and is
-  also clamped to `1..=20`. `[subagents.models]` accepts lower-case role or type
-  keys such as `worker`, `explorer`, `general`, `explore`, `plan`, and
+  also clamped to `1..=20`. `[subagents] api_timeout_secs` controls the
+  per-step model API timeout for sub-agents; it defaults to `120` and values
+  above `1800` are clamped. `[subagents.models]` accepts lower-case role or
+  type keys such as `worker`, `explorer`, `general`, `explore`, `plan`, and
   `review`. Values must normalize to a supported DeepSeek model id before an
   agent is spawned.
 - `skills_dir` (string, optional): defaults to `~/.deepseek/skills` (each skill is

--- a/docs/SUBAGENTS.md
+++ b/docs/SUBAGENTS.md
@@ -113,7 +113,7 @@ restart) also don't count against the cap.
 Each sub-agent model step keeps the legacy 120-second API timeout by
 default. Long-running assignments can raise this with
 `[subagents] api_timeout_secs = N` in `~/.deepseek/config.toml`. Values above
-1800 seconds are clamped.
+1800 seconds are clamped; lower values are honored as configured.
 
 ## Lifecycle
 

--- a/docs/SUBAGENTS.md
+++ b/docs/SUBAGENTS.md
@@ -108,6 +108,13 @@ cancelled records persist for inspection but don't occupy a slot.
 Agents that lost their `task_handle` (e.g. across a process
 restart) also don't count against the cap.
 
+## API timeout
+
+Each sub-agent model step keeps the legacy 120-second API timeout by
+default. Long-running assignments can raise this with
+`[subagents] api_timeout_secs = N` in `~/.deepseek/config.toml`. Values above
+1800 seconds are clamped.
+
 ## Lifecycle
 
 Each opened session produces a record that progresses through:


### PR DESCRIPTION
## Summary

Closes #1806.

This PR makes the sub-agent per-step model API timeout configurable without changing the legacy default:

- adds `[subagents] api_timeout_secs`
- keeps the default at 120 seconds for backwards compatibility
- caps configured values at 1800 seconds
- threads the resolved timeout through `EngineConfig` into `SubAgentRuntime`
- uses the configured timeout around each sub-agent `create_message` call
- documents the setting in `docs/CONFIGURATION.md` and `docs/SUBAGENTS.md`

## Scope

This intentionally implements the minimal timeout-control fix from the issue. It does not change sub-agent tool permissions, write access, streaming, or checkpoint behavior.

## Validation

Passed:

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p deepseek-tui --bin deepseek-tui`
- `cargo test -p deepseek-tui --bin deepseek-tui subagent_api_timeout_defaults_to_legacy_120s`
- `cargo test -p deepseek-tui --bin deepseek-tui subagent_api_timeout_only_clamps_to_maximum`
- `cargo test -p deepseek-tui --bin deepseek-tui child_runtime_preserves_api_timeout`
- `cargo test -p deepseek-tui --bin deepseek-tui subagent_runtime_default_api_timeout_is_legacy_120s`
- `cargo test -p deepseek-tui --bin deepseek-tui tools::subagent::tests::`
- `cargo build`
- `cargo clippy --workspace --all-targets --all-features`

Notes:

- `cargo build` / `cargo clippy` still report pre-existing warnings in `schema_migration.rs`.
- `cargo clippy` also still reports the pre-existing `needless_return` warnings in `tui/ui.rs`.
