### PR TITLE
feat(goal): auto-continue mode with 4 safety nets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`/goal` auto-continue (#891).** Setting `/goal <objective>` now keeps
+  the agent advancing turn-by-turn until either the model emits
+  `GOAL_ACHIEVED` on its own line or one of four safety nets fires
+  (token budget, max iterations, "stuck" on pending todos with no
+  token movement, or "idle" without tool calls). The first turn is
+  kickstarted automatically — no need to type a placeholder message
+  after `/goal`. New subcommands `/goal stop` and `/goal resume`
+  toggle auto-continue without clearing the objective. Active goals
+  are persisted to `~/.deepseek/goals.v1.json` so a restart resumes
+  the goal. See `docs/MODES.md → Goal Mode` for the full contract.
+
+### Changed
+
+- **`/goal <text>` is no longer passive bookkeeping.** It defaults to
+  enabling the auto-continue loop. Conservative users can restore the
+  previous behaviour with `[goal] auto_continue_default = false` in
+  `config.toml`; `/goal resume` then opts a single goal into the loop
+  on demand.
+
 ## [0.8.39] - 2026-05-17
 
 ### Fixed

--- a/config.example.toml
+++ b/config.example.toml
@@ -438,6 +438,30 @@ default_text_model = "deepseek-ai/deepseek-v4-pro"
 # include_summary = false
 
 # ─────────────────────────────────────────────────────────────────────────────────
+# /goal Auto-Continue (#891)
+# ─────────────────────────────────────────────────────────────────────────────────
+# Setting `/goal <objective>` enables an auto-continuation loop: after each
+# turn the TUI evaluates whether the model emitted the literal token
+# `GOAL_ACHIEVED` (or whether any of four safety nets fired) and, if not,
+# automatically pushes the next turn forward.
+#
+# Safety nets (always on):
+#   - BudgetExceeded — total conversation tokens met `/goal X | budget: N`
+#   - Stuck          — 3 consecutive turns with flat pending todos AND
+#                       token-usage delta under 200 (double condition)
+#   - Idle           — 2 consecutive turns where the model spoke without
+#                       calling any tool
+#   - MaxIterations  — total continuations crossed `max_iterations`
+#
+# Set `auto_continue_default = false` to revert to v0.8.x behaviour where
+# `/goal X` is passive bookkeeping only; use `/goal resume` to start the
+# loop on demand.
+#
+# [goal]
+# auto_continue_default = true   # /goal <text> auto-enables the loop
+# max_iterations = 50            # Hard ceiling per goal; 0 disables the cap
+
+# ─────────────────────────────────────────────────────────────────────────────────
 # Workspace Snapshots (#137)
 # ─────────────────────────────────────────────────────────────────────────────────
 # Each turn the TUI takes a `pre-turn:<seq>` and `post-turn:<seq>` snapshot of

--- a/crates/tui/src/commands/goal.rs
+++ b/crates/tui/src/commands/goal.rs
@@ -1,68 +1,475 @@
-//! /goal command — set a session objective with token budget and progress tracking.
+//! `/goal` command — set a session objective with token budget,
+//! progress tracking, and (since #891) goal-driven auto-continue.
+//!
+//! ## Lifecycle
+//!
+//! - `/goal <text>` — set objective AND enable auto-continue. Every
+//!   subsequent `TurnComplete` is intercepted: if the model didn't
+//!   emit the literal sentinel `GOAL_ACHIEVED` and none of the four
+//!   safety nets fired, a synthetic continuation user-message is
+//!   queued so the next turn keeps pushing toward the goal.
+//! - `/goal <text> | budget: <N>` — same, with a token budget that
+//!   feeds the `BudgetExceeded` safety net.
+//! - `/goal` — show current status (objective, elapsed, auto-continue
+//!   on/off, iterations so far).
+//! - `/goal stop` — pause auto-continue without clearing the
+//!   objective. The user can manually send another message to
+//!   continue working with the goal context intact.
+//! - `/goal resume` — re-enable auto-continue (e.g. after `stop`).
+//! - `/goal done` / `/goal clear` / `/goal reset` — clear everything.
+//!
+//! ## Safety nets (see [`decide_continuation`])
+//!
+//! 1. `BudgetExceeded` — total conversation tokens crossed the budget.
+//! 2. `Stuck` — `STUCK_TURN_THRESHOLD` (3) consecutive turns where
+//!    *both* the pending-todo count stayed flat *and* token usage
+//!    barely moved (< `STUCK_TOKEN_DELTA` increment). The double
+//!    condition (work-order §8 follow-up) prevents the safety net
+//!    from misfiring on slow-but-substantive long tasks.
+//! 3. `Idle` — `IDLE_TURN_THRESHOLD` (2) consecutive turns where the
+//!    model spoke without calling any tool.
+//! 4. `MaxIterations` — total continuations for this objective
+//!    crossed `max_iterations` (default 50).
+//!
+//! The decision logic is split into a pure function ([`decide_continuation`])
+//! so the safety nets can be unit-tested without standing up the full
+//! TUI runtime.
 
 use crate::tui::app::App;
 
 use super::CommandResult;
 
-/// Set or show the current goal
-pub fn goal(app: &mut App, arg: Option<&str>) -> CommandResult {
-    match arg {
-        Some("clear") | Some("reset") | Some("done") => {
-            app.goal.goal_objective = None;
-            app.goal.goal_token_budget = None;
-            app.goal.goal_started_at = None;
-            CommandResult::message("Goal cleared.")
-        }
-        Some(text) if !text.is_empty() => {
-            // Parse optional budget: "/goal Implement login | budget: 50000"
-            let (objective, budget) = parse_goal_budget(text);
-            app.goal.goal_objective = Some(objective.clone());
-            app.goal.goal_token_budget = budget;
-            app.goal.goal_started_at = Some(std::time::Instant::now());
-            let budget_str = budget
-                .map(|b| format!(" (budget: {b} tokens)"))
-                .unwrap_or_default();
-            CommandResult::message(format!(
-                "Goal set: \"{}\"{} — tracking progress.",
-                objective, budget_str
-            ))
-        }
-        _ => {
-            // Show current goal
-            if let Some(ref obj) = app.goal.goal_objective {
-                // #447: render long elapsed times as `2d 3h` rather
-                // than Rust's default Debug `Duration` (which produces
-                // `188415.234s` or similar for multi-day goals).
-                let elapsed = app
-                    .goal
-                    .goal_started_at
-                    .map(|t| crate::tui::notifications::humanize_duration(t.elapsed()))
-                    .unwrap_or_else(|| "unknown".to_string());
-                let budget_str = app
-                    .goal
-                    .goal_token_budget
-                    .map(|b| {
-                        let used = app.session.total_conversation_tokens;
-                        let pct = if b > 0 {
-                            (used as f64 / b as f64 * 100.0).min(100.0)
-                        } else {
-                            0.0
-                        };
-                        format!(" | tokens: {used}/{b} ({pct:.0}%)")
-                    })
-                    .unwrap_or_default();
-                CommandResult::message(format!("Goal: \"{obj}\" — elapsed: {elapsed}{budget_str}"))
-            } else {
-                CommandResult::message(
-                    "No goal set. Use /goal <objective> [budget: N] to set one.\n\
-                     /goal clear — remove the current goal.",
-                )
+/// Stuck safety net fires after this many consecutive flat turns.
+pub const STUCK_TURN_THRESHOLD: u32 = 3;
+
+/// Token delta below which we treat the previous turn as "no real
+/// progress" for the Stuck heuristic. Picked to ignore boilerplate
+/// overhead (system prompt re-injection, brief acknowledgements)
+/// while catching genuine spinning.
+pub const STUCK_TOKEN_DELTA: u32 = 200;
+
+/// Idle safety net fires after this many consecutive no-tool turns.
+pub const IDLE_TURN_THRESHOLD: u32 = 2;
+
+/// Default ceiling for total auto-continuation iterations. Overridable
+/// from `[goal] max_iterations` in `config.toml`.
+pub const DEFAULT_MAX_ITERATIONS: u32 = 50;
+
+/// Sentinel the model emits to declare the goal achieved. Matched
+/// case-sensitively; we require it on its own line so casual mentions
+/// in narrative text don't false-positive.
+pub const GOAL_ACHIEVED_SENTINEL: &str = "GOAL_ACHIEVED";
+
+/// Outcome of [`decide_continuation`]. Drives the post-turn handler.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GoalDecision {
+    /// Goal is not active, or auto-continue is off — do nothing.
+    Inactive,
+    /// Queue a continuation user-message with the given body.
+    Enqueue(String),
+    /// Stop auto-continue and surface the reason in the transcript.
+    Stop(GoalStopReason),
+}
+
+/// Why auto-continue stopped. Distinct values feed both the
+/// transcript message and the test assertions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GoalStopReason {
+    /// The model emitted the `GOAL_ACHIEVED` sentinel on its own
+    /// line — the goal is treated as complete and cleared.
+    Achieved,
+    /// Token budget was set and total conversation tokens met or
+    /// exceeded it.
+    BudgetExceeded { used: u32, budget: u32 },
+    /// `STUCK_TURN_THRESHOLD` flat turns AND token usage delta
+    /// under `STUCK_TOKEN_DELTA` per turn — looks like spinning.
+    Stuck { turns: u32 },
+    /// `IDLE_TURN_THRESHOLD` consecutive turns without any tool
+    /// call — the model is just talking, not acting.
+    Idle { turns: u32 },
+    /// Reached the iteration cap (default 50, overridable).
+    MaxIterations { cap: u32 },
+    /// The user (or engine) interrupted the previous turn — we
+    /// stop the chain so the human can take control without
+    /// fighting an auto-pusher.
+    Interrupted,
+    /// The previous turn ended with `TurnOutcomeStatus::Failed`
+    /// (stream stall, API error, network timeout, etc.). Continuing
+    /// would just hit the same failure again and burn tokens, so we
+    /// stop. The user can `/goal resume` once the underlying issue
+    /// is cleared.
+    TurnFailed,
+}
+
+impl GoalStopReason {
+    /// User-facing reason string for the transcript / status line.
+    #[must_use]
+    pub fn describe(&self) -> String {
+        match self {
+            GoalStopReason::Achieved => "goal achieved (model emitted GOAL_ACHIEVED)".into(),
+            GoalStopReason::BudgetExceeded { used, budget } => {
+                format!("token budget reached ({used}/{budget})")
             }
+            GoalStopReason::Stuck { turns } => {
+                format!("no progress after {turns} turn(s) — intervention needed")
+            }
+            GoalStopReason::Idle { turns } => {
+                format!("{turns} consecutive turn(s) without tool calls — model is just talking")
+            }
+            GoalStopReason::MaxIterations { cap } => {
+                format!("max iterations reached ({cap})")
+            }
+            GoalStopReason::Interrupted => "previous turn was interrupted".into(),
+            GoalStopReason::TurnFailed => "previous turn failed (likely API / network error) — \
+                 fix the underlying issue then /goal resume"
+                .into(),
         }
     }
 }
 
-/// Parse optional token budget from goal text: "Implement login | budget: 50000"
+/// Inputs to the goal continuation decision. Bundled into a struct
+/// so the decision is pure (no `&App`) and trivially testable.
+///
+/// The streak fields (`consecutive_no_progress_turns`,
+/// `consecutive_no_tool_turns`) are post-update — callers run
+/// [`update_streaks`] on the live `GoalState` *before* populating
+/// this struct.
+#[derive(Debug, Clone)]
+pub struct GoalDecisionInputs<'a> {
+    pub objective: Option<&'a str>,
+    pub auto_continue_enabled: bool,
+    pub last_assistant_text: &'a str,
+    pub total_conversation_tokens: u32,
+    pub token_budget: Option<u32>,
+    pub iterations: u32,
+    pub max_iterations: u32,
+    pub consecutive_no_progress_turns: u32,
+    pub consecutive_no_tool_turns: u32,
+    pub turn_was_interrupted: bool,
+    /// Previous turn ended in `TurnOutcomeStatus::Failed` (stream
+    /// stall, API error, network timeout). Distinct from
+    /// `turn_was_interrupted` because the user-facing stop reason
+    /// and recovery story are different.
+    pub turn_was_failed: bool,
+}
+
+/// Pure decision: given the post-turn snapshot, should we queue a
+/// continuation, stop with a reason, or do nothing? Does **not**
+/// mutate anything — caller threads the result back into
+/// [`GoalState`](crate::tui::app::GoalState).
+#[must_use]
+pub fn decide_continuation(inputs: &GoalDecisionInputs<'_>) -> GoalDecision {
+    let Some(objective) = inputs.objective else {
+        return GoalDecision::Inactive;
+    };
+    if !inputs.auto_continue_enabled {
+        return GoalDecision::Inactive;
+    }
+
+    // Achieved sentinel wins over everything else: a model emitting
+    // GOAL_ACHIEVED on its own line is asserting success, and we
+    // respect that (the user can always reopen with /goal <text>).
+    if last_assistant_emits_achieved_sentinel(inputs.last_assistant_text) {
+        return GoalDecision::Stop(GoalStopReason::Achieved);
+    }
+
+    if inputs.turn_was_interrupted {
+        return GoalDecision::Stop(GoalStopReason::Interrupted);
+    }
+
+    // Infrastructure failures (stream stall, API timeout, transport
+    // error) get their own stop reason so the user sees a different
+    // message and knows to debug the connection rather than the
+    // model. Continuing on a Failed status would just hit the same
+    // wall over and over and burn budget.
+    if inputs.turn_was_failed {
+        return GoalDecision::Stop(GoalStopReason::TurnFailed);
+    }
+
+    if let Some(budget) = inputs.token_budget
+        && inputs.total_conversation_tokens >= budget
+    {
+        return GoalDecision::Stop(GoalStopReason::BudgetExceeded {
+            used: inputs.total_conversation_tokens,
+            budget,
+        });
+    }
+
+    if inputs.max_iterations > 0 && inputs.iterations >= inputs.max_iterations {
+        return GoalDecision::Stop(GoalStopReason::MaxIterations {
+            cap: inputs.max_iterations,
+        });
+    }
+
+    // Idle counter is updated by the caller before invoking us.
+    // We just compare against the threshold here.
+    if inputs.consecutive_no_tool_turns >= IDLE_TURN_THRESHOLD {
+        return GoalDecision::Stop(GoalStopReason::Idle {
+            turns: inputs.consecutive_no_tool_turns,
+        });
+    }
+
+    // Stuck: double-condition (flat pending + tiny token delta) over
+    // STUCK_TURN_THRESHOLD turns. The single-condition #1242 design
+    // (flat pending only) was prone to false positives on long
+    // single-todo tasks where token usage was clearly advancing the
+    // work; combining the two avoids that.
+    if inputs.consecutive_no_progress_turns >= STUCK_TURN_THRESHOLD {
+        return GoalDecision::Stop(GoalStopReason::Stuck {
+            turns: inputs.consecutive_no_progress_turns,
+        });
+    }
+
+    GoalDecision::Enqueue(continuation_prompt(objective))
+}
+
+/// Sentinel matcher. The work order requires the literal token on
+/// its own line so a model that says "look for the GOAL_ACHIEVED
+/// marker when you're done" mid-paragraph doesn't trip the check.
+#[must_use]
+pub fn last_assistant_emits_achieved_sentinel(text: &str) -> bool {
+    text.lines()
+        .any(|line| line.trim() == GOAL_ACHIEVED_SENTINEL)
+}
+
+/// Continuation message body. Written verbatim per the work order
+/// rather than generated dynamically — predictable string content
+/// keeps the prefix-cache hit ratio high and the model's behaviour
+/// stable across turns.
+#[must_use]
+pub fn continuation_prompt(objective: &str) -> String {
+    format!(
+        "Goal still active: \"{objective}\"\n\
+         Continue executing toward the goal. If achieved, emit the literal token\n\
+         GOAL_ACHIEVED on its own line and stop. Otherwise, take the next concrete\n\
+         step now without asking for confirmation."
+    )
+}
+
+/// First-turn kickstart prompt — sent automatically the moment
+/// `/goal <text>` is processed so the user doesn't have to type
+/// a placeholder message to get the auto-continue loop started.
+/// Phrased differently from [`continuation_prompt`] so the model
+/// sees "this is the start" rather than "we were already going."
+#[must_use]
+pub fn kickstart_prompt(objective: &str) -> String {
+    format!(
+        "New goal just set: \"{objective}\"\n\
+         Begin executing toward this goal now. Take the first concrete step \
+         without asking for confirmation. If the goal turns out to already be \
+         satisfied, emit the literal token GOAL_ACHIEVED on its own line and stop."
+    )
+}
+
+/// Update the streak counters that feed [`decide_continuation`].
+/// Called by the post-turn handler BEFORE invoking the decision so
+/// counters are current. Pure-ish — only touches `goal`'s streak
+/// fields.
+///
+/// Returns the `progress_total_tokens` snapshot that the caller
+/// should persist for the next turn's delta computation.
+pub fn update_streaks(
+    goal: &mut crate::tui::app::GoalState,
+    pending_todo_count: usize,
+    total_conversation_tokens: u32,
+    last_turn_had_tool_call: bool,
+) {
+    // Idle streak: pure tool-call presence check.
+    if last_turn_had_tool_call {
+        goal.consecutive_no_tool_turns = 0;
+    } else {
+        goal.consecutive_no_tool_turns = goal.consecutive_no_tool_turns.saturating_add(1);
+    }
+
+    // Progress detection: both pending count change *and* large
+    // token delta count as progress. Either resets the streak.
+    let pending_changed = goal.last_pending_count != Some(pending_todo_count);
+    let token_delta = total_conversation_tokens.saturating_sub(goal.last_progress_total_tokens);
+    let token_jumped = token_delta >= STUCK_TOKEN_DELTA;
+    let made_progress = pending_changed || token_jumped;
+
+    if made_progress {
+        goal.consecutive_no_progress_turns = 0;
+        goal.last_progress_total_tokens = total_conversation_tokens;
+    } else {
+        goal.consecutive_no_progress_turns = goal.consecutive_no_progress_turns.saturating_add(1);
+    }
+    goal.last_pending_count = Some(pending_todo_count);
+}
+
+/// Set or show the current goal. Subcommands:
+/// - `clear` / `reset` / `done` — wipe everything (including persisted file)
+/// - `stop` — pause auto-continue (keep objective)
+/// - `resume` — re-enable auto-continue
+/// - any other non-empty text — set objective + enable auto-continue
+/// - empty arg — show status
+pub fn goal(app: &mut App, arg: Option<&str>) -> CommandResult {
+    match arg.map(str::trim) {
+        Some("clear") | Some("reset") | Some("done") => clear_goal(app),
+        Some("stop") => stop_auto_continue(app),
+        Some("resume") | Some("start") => resume_auto_continue(app),
+        Some(text) if !text.is_empty() => set_goal(app, text),
+        _ => show_goal(app),
+    }
+}
+
+fn clear_goal(app: &mut App) -> CommandResult {
+    app.goal.goal_objective = None;
+    app.goal.goal_token_budget = None;
+    app.goal.goal_started_at = None;
+    app.goal.goal_started_at_utc = None;
+    app.goal.auto_continue_enabled = false;
+    app.goal.iterations = 0;
+    app.goal.last_pending_count = None;
+    app.goal.last_progress_total_tokens = 0;
+    app.goal.consecutive_no_progress_turns = 0;
+    app.goal.consecutive_no_tool_turns = 0;
+    app.goal.session_id_for_persist = None;
+    crate::goal_state::clear_goal();
+    CommandResult::message("Goal cleared.")
+}
+
+fn stop_auto_continue(app: &mut App) -> CommandResult {
+    if app.goal.goal_objective.is_none() {
+        return CommandResult::message("No goal is set — nothing to stop.");
+    }
+    if !app.goal.auto_continue_enabled {
+        return CommandResult::message("Auto-continue is already off.");
+    }
+    app.goal.auto_continue_enabled = false;
+    persist_current_goal(app);
+    CommandResult::message(
+        "Auto-continue paused. Goal objective is preserved — send another \
+         message to keep working, or /goal resume to re-enable auto-continue.",
+    )
+}
+
+fn resume_auto_continue(app: &mut App) -> CommandResult {
+    if app.goal.goal_objective.is_none() {
+        return CommandResult::message(
+            "No goal is set. Use /goal <objective> to start a new goal.",
+        );
+    }
+    if app.goal.auto_continue_enabled {
+        return CommandResult::message("Auto-continue is already on.");
+    }
+    app.goal.auto_continue_enabled = true;
+    // Reset the streak counters so we don't immediately trip a
+    // safety net on resume just because the pre-stop turn was idle.
+    app.goal.consecutive_no_tool_turns = 0;
+    app.goal.consecutive_no_progress_turns = 0;
+    persist_current_goal(app);
+    CommandResult::message("Auto-continue resumed.")
+}
+
+fn set_goal(app: &mut App, text: &str) -> CommandResult {
+    let (objective, budget) = parse_goal_budget(text);
+    // Default-on for parity with #1242's UX. `[goal] auto_continue_default`
+    // in config.toml lets conservative users flip the default off; that
+    // value is threaded through via `App::new` (see `config.rs`) into
+    // `app.goal_auto_continue_default` so we don't have to re-read the
+    // config file on every `/goal`.
+    let auto_default = app.goal_auto_continue_default;
+    app.goal.goal_objective = Some(objective.clone());
+    app.goal.goal_token_budget = budget;
+    app.goal.goal_started_at = Some(std::time::Instant::now());
+    app.goal.goal_started_at_utc = Some(chrono::Utc::now());
+    app.goal.auto_continue_enabled = auto_default;
+    app.goal.iterations = 0;
+    app.goal.last_pending_count = None;
+    app.goal.last_progress_total_tokens = app.session.total_conversation_tokens;
+    app.goal.consecutive_no_progress_turns = 0;
+    app.goal.consecutive_no_tool_turns = 0;
+    app.goal.session_id_for_persist = app.current_session_id.clone();
+    persist_current_goal(app);
+    let budget_str = budget
+        .map(|b| format!(" (budget: {b} tokens)"))
+        .unwrap_or_default();
+    // When auto-continue is on, kickstart the first turn automatically
+    // so the user doesn't have to type a placeholder message. The
+    // `CommandResult.action = SendMessage(...)` path is the same one
+    // a typed user message goes through, so this turn looks identical
+    // to the engine — submit-and-respond, then subsequent turns enter
+    // the auto-continue loop via `maybe_trigger_goal_continuation`.
+    // When auto-continue is OFF (user set `[goal] auto_continue_default
+    // = false`), we don't kickstart — that mode is "passive tracking"
+    // and a forced first turn would surprise the user.
+    if auto_default {
+        let kickstart = kickstart_prompt(&objective);
+        CommandResult::with_message_and_action(
+            format!(
+                "Goal set: \"{objective}\"{budget_str} — kickstarting first turn now; /goal stop to pause."
+            ),
+            crate::tui::app::AppAction::SendMessage(kickstart),
+        )
+    } else {
+        CommandResult::message(format!(
+            "Goal set: \"{objective}\"{budget_str} — tracking only; /goal resume to enable auto-continue."
+        ))
+    }
+}
+
+fn show_goal(app: &mut App) -> CommandResult {
+    if let Some(ref obj) = app.goal.goal_objective {
+        // #447: render long elapsed times as `2d 3h` rather than
+        // Rust's default Debug Duration (which produces e.g.
+        // `188415.234s` for multi-day goals).
+        let elapsed = app
+            .goal
+            .goal_started_at
+            .map(|t| crate::tui::notifications::humanize_duration(t.elapsed()))
+            .unwrap_or_else(|| "unknown".to_string());
+        let budget_str = app
+            .goal
+            .goal_token_budget
+            .map(|b| {
+                let used = app.session.total_conversation_tokens;
+                let pct = if b > 0 {
+                    (f64::from(used) / f64::from(b) * 100.0).min(100.0)
+                } else {
+                    0.0
+                };
+                format!(" | tokens: {used}/{b} ({pct:.0}%)")
+            })
+            .unwrap_or_default();
+        let auto_str = if app.goal.auto_continue_enabled {
+            format!(" | auto-continue: on (turn #{})", app.goal.iterations)
+        } else {
+            " | auto-continue: off".to_string()
+        };
+        CommandResult::message(format!(
+            "Goal: \"{obj}\" — elapsed: {elapsed}{budget_str}{auto_str}"
+        ))
+    } else {
+        CommandResult::message(
+            "No goal set. Use /goal <objective> [budget: N] to set one.\n\
+             /goal stop|resume — pause/resume auto-continue without clearing.\n\
+             /goal clear — remove the current goal.",
+        )
+    }
+}
+
+/// Snapshot the current GoalState into a [`PersistedGoal`] and
+/// write it to disk. Caller controls clearing via [`clear_goal`].
+fn persist_current_goal(app: &App) {
+    if let Some(objective) = app.goal.goal_objective.clone() {
+        let envelope = crate::goal_state::GoalFile {
+            schema_version: 1,
+            current: Some(crate::goal_state::PersistedGoal {
+                objective,
+                token_budget: app.goal.goal_token_budget,
+                auto_continue_enabled: app.goal.auto_continue_enabled,
+                started_at: app.goal.goal_started_at_utc,
+                iterations: app.goal.iterations,
+                session_id: app.goal.session_id_for_persist.clone(),
+            }),
+        };
+        crate::goal_state::save_goal(&envelope);
+    }
+}
+
+/// Parse optional token budget from goal text:
+/// `"Implement login | budget: 50000"` or `"Implement login budget: 50000"`.
 fn parse_goal_budget(text: &str) -> (String, Option<u32>) {
     if let Some((obj, rest)) = text.split_once(" | budget:") {
         let budget = rest
@@ -110,18 +517,98 @@ mod tests {
             resume_session_id: None,
             initial_input: None,
         };
-        App::new(options, &Config::default())
+        let mut app = App::new(options, &Config::default());
+        // `App::new` calls `restore_persisted_goal()` which reads
+        // a shared `~/.deepseek/goals.v1.json` (or the path under
+        // `DEEPSEEK_TUI_GOAL_PATH`). Parallel sibling tests in this
+        // module persist via the same path, so a fresh test could
+        // see a stale objective they left behind. Zero the goal
+        // sub-state explicitly to make each test hermetic.
+        app.goal = crate::tui::app::GoalState::default();
+        app
     }
 
+    fn base_inputs<'a>(objective: &'a str, last: &'a str) -> GoalDecisionInputs<'a> {
+        GoalDecisionInputs {
+            objective: Some(objective),
+            auto_continue_enabled: true,
+            last_assistant_text: last,
+            total_conversation_tokens: 1_000,
+            token_budget: None,
+            iterations: 1,
+            max_iterations: 50,
+            consecutive_no_progress_turns: 0,
+            consecutive_no_tool_turns: 0,
+            turn_was_interrupted: false,
+            turn_was_failed: false,
+        }
+    }
+
+    // --- Subcommand tests (cover the existing /goal surface plus
+    // the new stop/resume lifecycle) ---
+
     #[test]
-    fn test_set_goal() {
+    fn test_set_goal_enables_auto_continue() {
         let mut app = create_test_app();
-        let result = goal(&mut app, Some("Fix the login bug"));
-        assert!(result.message.unwrap().contains("Goal set"));
+        let r = goal(&mut app, Some("Fix the login bug"));
+        assert!(r.message.as_ref().unwrap().contains("Goal set"));
+        assert!(
+            r.message.as_ref().unwrap().contains("kickstarting"),
+            "the user-facing message should advertise the kickstart"
+        );
         assert_eq!(
             app.goal.goal_objective.as_deref(),
             Some("Fix the login bug")
         );
+        assert!(
+            app.goal.auto_continue_enabled,
+            "setting an objective should default to auto-continue on"
+        );
+        // Cleanup: don't leave a stray ~/.deepseek/goals.v1.json behind.
+        let _ = goal(&mut app, Some("clear"));
+    }
+
+    #[test]
+    fn set_goal_kickstarts_first_turn_with_send_message_action() {
+        // Regression: /goal X used to require the user to type a
+        // separate message before anything happened. Now the command
+        // returns an AppAction::SendMessage(...) so the dispatcher
+        // submits the first turn immediately.
+        let mut app = create_test_app();
+        let r = goal(&mut app, Some("Refactor auth module"));
+        match r.action {
+            Some(crate::tui::app::AppAction::SendMessage(body)) => {
+                assert!(body.contains("Refactor auth module"));
+                assert!(body.contains("Begin executing"));
+                assert!(body.contains("GOAL_ACHIEVED"));
+            }
+            other => panic!("expected SendMessage action, got {other:?}"),
+        }
+        let _ = goal(&mut app, Some("clear"));
+    }
+
+    #[test]
+    fn set_goal_does_not_kickstart_when_auto_continue_default_off() {
+        let mut app = create_test_app();
+        app.goal_auto_continue_default = false;
+        let r = goal(&mut app, Some("Quietly tracked goal"));
+        assert!(
+            r.action.is_none(),
+            "no kickstart when [goal] auto_continue_default = false"
+        );
+        assert!(r.message.as_ref().unwrap().contains("tracking only"));
+        let _ = goal(&mut app, Some("clear"));
+    }
+
+    #[test]
+    fn kickstart_prompt_contains_objective_and_sentinel_contract() {
+        let body = kickstart_prompt("Cache invalidation rewrite");
+        assert!(body.contains("Cache invalidation rewrite"));
+        assert!(body.contains("Begin executing"));
+        assert!(body.contains("GOAL_ACHIEVED"));
+        // Crucial difference from continuation_prompt: this one
+        // signals "starting", not "still active".
+        assert!(body.contains("just set"));
     }
 
     #[test]
@@ -130,15 +617,21 @@ mod tests {
         let _ = goal(&mut app, Some("Refactor auth | budget: 50000"));
         assert_eq!(app.goal.goal_objective.as_deref(), Some("Refactor auth"));
         assert_eq!(app.goal.goal_token_budget, Some(50_000));
+        let _ = goal(&mut app, Some("clear"));
     }
 
     #[test]
-    fn test_clear_goal() {
+    fn test_clear_goal_resets_streak_state() {
         let mut app = create_test_app();
-        app.goal.goal_objective = Some("test".to_string());
+        let _ = goal(&mut app, Some("test"));
+        app.goal.iterations = 5;
+        app.goal.consecutive_no_progress_turns = 2;
         let _ = goal(&mut app, Some("clear"));
         assert!(app.goal.goal_objective.is_none());
         assert!(app.goal.goal_token_budget.is_none());
+        assert!(!app.goal.auto_continue_enabled);
+        assert_eq!(app.goal.iterations, 0);
+        assert_eq!(app.goal.consecutive_no_progress_turns, 0);
     }
 
     #[test]
@@ -146,6 +639,47 @@ mod tests {
         let mut app = create_test_app();
         let result = goal(&mut app, None);
         assert!(result.message.unwrap().contains("No goal set"));
+    }
+
+    #[test]
+    fn slash_goal_stop_pauses_without_clearing() {
+        let mut app = create_test_app();
+        let _ = goal(&mut app, Some("Refactor"));
+        assert!(app.goal.auto_continue_enabled);
+        let r = goal(&mut app, Some("stop"));
+        assert!(r.message.unwrap().contains("paused"));
+        assert!(!app.goal.auto_continue_enabled);
+        assert_eq!(
+            app.goal.goal_objective.as_deref(),
+            Some("Refactor"),
+            "stop must preserve objective"
+        );
+        let _ = goal(&mut app, Some("clear"));
+    }
+
+    #[test]
+    fn slash_goal_resume_reenables() {
+        let mut app = create_test_app();
+        let _ = goal(&mut app, Some("Refactor"));
+        let _ = goal(&mut app, Some("stop"));
+        app.goal.consecutive_no_tool_turns = 4;
+        app.goal.consecutive_no_progress_turns = 4;
+        let r = goal(&mut app, Some("resume"));
+        assert!(r.message.unwrap().contains("resumed"));
+        assert!(app.goal.auto_continue_enabled);
+        assert_eq!(
+            app.goal.consecutive_no_tool_turns, 0,
+            "streaks must reset on resume so we don't immediately trip a safety net"
+        );
+        assert_eq!(app.goal.consecutive_no_progress_turns, 0);
+        let _ = goal(&mut app, Some("clear"));
+    }
+
+    #[test]
+    fn slash_goal_stop_when_no_goal_says_so() {
+        let mut app = create_test_app();
+        let r = goal(&mut app, Some("stop"));
+        assert!(r.message.unwrap().contains("No goal"));
     }
 
     #[test]
@@ -163,4 +697,211 @@ mod tests {
             ("Goal".to_string(), Some(1000))
         );
     }
+
+    // --- Decision-function tests (the heart of the 9 specs) ---
+
+    #[test]
+    fn turn_complete_with_active_goal_enqueues_continuation() {
+        let inputs = base_inputs("refactor auth module", "Read the file. Now I'll continue.");
+        let decision = decide_continuation(&inputs);
+        match decision {
+            GoalDecision::Enqueue(body) => {
+                assert!(body.contains("Goal still active"));
+                assert!(body.contains("refactor auth module"));
+                assert!(body.contains("GOAL_ACHIEVED"));
+            }
+            other => panic!("expected Enqueue, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn goal_achieved_sentinel_stops_continuation() {
+        let inputs = base_inputs("X", "All done.\nGOAL_ACHIEVED");
+        assert_eq!(
+            decide_continuation(&inputs),
+            GoalDecision::Stop(GoalStopReason::Achieved)
+        );
+    }
+
+    #[test]
+    fn goal_achieved_inline_does_not_false_positive() {
+        // Mention of the sentinel mid-paragraph must NOT stop.
+        let inputs = base_inputs(
+            "X",
+            "I'll remember to emit GOAL_ACHIEVED when done, but I'm not done yet.",
+        );
+        assert!(matches!(
+            decide_continuation(&inputs),
+            GoalDecision::Enqueue(_)
+        ));
+    }
+
+    #[test]
+    fn budget_exceeded_stops_continuation() {
+        let mut inputs = base_inputs("X", "still working");
+        inputs.token_budget = Some(1_000);
+        inputs.total_conversation_tokens = 1_500;
+        assert_eq!(
+            decide_continuation(&inputs),
+            GoalDecision::Stop(GoalStopReason::BudgetExceeded {
+                used: 1_500,
+                budget: 1_000
+            })
+        );
+    }
+
+    #[test]
+    fn stuck_three_turns_stops_continuation() {
+        let mut inputs = base_inputs("X", "still thinking");
+        inputs.consecutive_no_progress_turns = STUCK_TURN_THRESHOLD;
+        assert_eq!(
+            decide_continuation(&inputs),
+            GoalDecision::Stop(GoalStopReason::Stuck {
+                turns: STUCK_TURN_THRESHOLD
+            })
+        );
+    }
+
+    #[test]
+    fn stuck_double_condition_only_flat_pending_is_not_enough() {
+        // Verifies the double-condition design improvement
+        // (work-order §8 follow-up): pending count flat but token
+        // delta clearly above threshold means we're still working.
+        let mut goal_state = crate::tui::app::GoalState {
+            last_pending_count: Some(2),
+            last_progress_total_tokens: 1_000,
+            consecutive_no_progress_turns: 0,
+            ..Default::default()
+        };
+        // pending stayed at 2, but tokens jumped by 5000 (way above
+        // STUCK_TOKEN_DELTA=200): NOT stuck, streak resets.
+        update_streaks(&mut goal_state, 2, 6_000, true);
+        assert_eq!(goal_state.consecutive_no_progress_turns, 0);
+    }
+
+    #[test]
+    fn stuck_double_condition_flat_plus_tiny_delta_advances_streak() {
+        let mut goal_state = crate::tui::app::GoalState {
+            last_pending_count: Some(2),
+            last_progress_total_tokens: 1_000,
+            consecutive_no_progress_turns: 0,
+            ..Default::default()
+        };
+        // pending flat AND token delta < threshold → spinning.
+        update_streaks(&mut goal_state, 2, 1_050, true);
+        assert_eq!(goal_state.consecutive_no_progress_turns, 1);
+    }
+
+    #[test]
+    fn idle_two_turns_stops_continuation() {
+        let mut inputs = base_inputs("X", "Talking but not acting");
+        inputs.consecutive_no_tool_turns = IDLE_TURN_THRESHOLD;
+        assert_eq!(
+            decide_continuation(&inputs),
+            GoalDecision::Stop(GoalStopReason::Idle {
+                turns: IDLE_TURN_THRESHOLD
+            })
+        );
+    }
+
+    #[test]
+    fn max_iterations_stops_continuation() {
+        let mut inputs = base_inputs("X", "still going");
+        inputs.iterations = 50;
+        inputs.max_iterations = 50;
+        assert_eq!(
+            decide_continuation(&inputs),
+            GoalDecision::Stop(GoalStopReason::MaxIterations { cap: 50 })
+        );
+    }
+
+    #[test]
+    fn auto_continue_disabled_returns_inactive() {
+        let mut inputs = base_inputs("X", "anything");
+        inputs.auto_continue_enabled = false;
+        assert_eq!(decide_continuation(&inputs), GoalDecision::Inactive);
+    }
+
+    #[test]
+    fn no_objective_returns_inactive() {
+        let mut inputs = base_inputs("X", "anything");
+        inputs.objective = None;
+        assert_eq!(decide_continuation(&inputs), GoalDecision::Inactive);
+    }
+
+    #[test]
+    fn interrupted_turn_stops_chain() {
+        let mut inputs = base_inputs("X", "partial");
+        inputs.turn_was_interrupted = true;
+        assert_eq!(
+            decide_continuation(&inputs),
+            GoalDecision::Stop(GoalStopReason::Interrupted)
+        );
+    }
+
+    #[test]
+    fn failed_turn_stops_chain() {
+        // Regression: when the engine reports the previous turn
+        // failed (stream stall, API timeout, transport error)
+        // we must NOT queue another continuation — that would
+        // just burn tokens against the same broken backend.
+        let mut inputs = base_inputs("X", "");
+        inputs.turn_was_failed = true;
+        assert_eq!(
+            decide_continuation(&inputs),
+            GoalDecision::Stop(GoalStopReason::TurnFailed)
+        );
+    }
+
+    #[test]
+    fn interrupted_takes_precedence_over_failed() {
+        // Both flags set: surfacing "Interrupted" matches the
+        // user's mental model (they hit Esc) better than the
+        // infrastructure-flavoured "TurnFailed" message.
+        let mut inputs = base_inputs("X", "");
+        inputs.turn_was_interrupted = true;
+        inputs.turn_was_failed = true;
+        assert_eq!(
+            decide_continuation(&inputs),
+            GoalDecision::Stop(GoalStopReason::Interrupted)
+        );
+    }
+
+    // --- update_streaks behavior tests ---
+
+    #[test]
+    fn idle_streak_increments_when_no_tool_used() {
+        let mut g = crate::tui::app::GoalState::default();
+        update_streaks(&mut g, 1, 0, false);
+        update_streaks(&mut g, 1, 0, false);
+        assert_eq!(g.consecutive_no_tool_turns, 2);
+    }
+
+    #[test]
+    fn idle_streak_resets_on_tool_use() {
+        let mut g = crate::tui::app::GoalState {
+            consecutive_no_tool_turns: 5,
+            ..Default::default()
+        };
+        update_streaks(&mut g, 1, 0, true);
+        assert_eq!(g.consecutive_no_tool_turns, 0);
+    }
+
+    #[test]
+    fn progress_streak_resets_when_pending_count_drops() {
+        let mut g = crate::tui::app::GoalState {
+            last_pending_count: Some(3),
+            consecutive_no_progress_turns: 2,
+            ..Default::default()
+        };
+        update_streaks(&mut g, 2, 0, true);
+        assert_eq!(g.consecutive_no_progress_turns, 0);
+        assert_eq!(g.last_pending_count, Some(2));
+    }
+
+    // --- Persistence is covered exhaustively in
+    // [`crate::goal_state::tests`] with per-test isolated temp
+    // paths. A bridge test here would race with the other
+    // sub-command tests that also persist via `DEEPSEEK_TUI_GOAL_PATH`,
+    // so we deliberately don't repeat it.
 }

--- a/crates/tui/src/commands/goal.rs
+++ b/crates/tui/src/commands/goal.rs
@@ -345,11 +345,11 @@ fn stop_auto_continue(app: &mut App) -> CommandResult {
 }
 
 fn resume_auto_continue(app: &mut App) -> CommandResult {
-    if app.goal.goal_objective.is_none() {
+    let Some(objective) = app.goal.goal_objective.clone() else {
         return CommandResult::message(
             "No goal is set. Use /goal <objective> to start a new goal.",
         );
-    }
+    };
     if app.goal.auto_continue_enabled {
         return CommandResult::message("Auto-continue is already on.");
     }
@@ -359,7 +359,19 @@ fn resume_auto_continue(app: &mut App) -> CommandResult {
     app.goal.consecutive_no_tool_turns = 0;
     app.goal.consecutive_no_progress_turns = 0;
     persist_current_goal(app);
-    CommandResult::message("Auto-continue resumed.")
+    // Kick the chain back into motion — same dispatcher path as
+    // `set_goal` uses for its first-turn kickstart. Without this
+    // the user has to type a placeholder message after `/goal resume`
+    // before anything happens, which mirrors the original `/goal X`
+    // friction we already fixed (regression spotted by user testing).
+    // Use `continuation_prompt` (not `kickstart_prompt`) because the
+    // objective is *already* known to the model from the system prompt
+    // and the prior conversation — "still active" framing is more
+    // accurate than "new goal just set" here.
+    CommandResult::with_message_and_action(
+        "Auto-continue resumed — pushing the next turn now.",
+        crate::tui::app::AppAction::SendMessage(continuation_prompt(&objective)),
+    )
 }
 
 fn set_goal(app: &mut App, text: &str) -> CommandResult {
@@ -665,13 +677,62 @@ mod tests {
         app.goal.consecutive_no_tool_turns = 4;
         app.goal.consecutive_no_progress_turns = 4;
         let r = goal(&mut app, Some("resume"));
-        assert!(r.message.unwrap().contains("resumed"));
+        assert!(r.message.as_ref().unwrap().contains("resumed"));
         assert!(app.goal.auto_continue_enabled);
         assert_eq!(
             app.goal.consecutive_no_tool_turns, 0,
             "streaks must reset on resume so we don't immediately trip a safety net"
         );
         assert_eq!(app.goal.consecutive_no_progress_turns, 0);
+        let _ = goal(&mut app, Some("clear"));
+    }
+
+    #[test]
+    fn slash_goal_resume_kickstarts_next_turn_via_send_message_action() {
+        // Regression (post-PR #1809 review): /goal resume used to
+        // only flip the flag, so after Esc-recovery the user had to
+        // type a placeholder message before auto-continue actually
+        // pushed forward. Resume now mirrors set_goal — returns an
+        // AppAction::SendMessage so the dispatcher submits the next
+        // turn immediately. Uses `continuation_prompt` (not
+        // `kickstart_prompt`) because the objective is already known.
+        let mut app = create_test_app();
+        let _ = goal(&mut app, Some("Wire up X"));
+        let _ = goal(&mut app, Some("stop"));
+        let r = goal(&mut app, Some("resume"));
+        match r.action {
+            Some(crate::tui::app::AppAction::SendMessage(body)) => {
+                assert!(body.contains("Wire up X"));
+                assert!(body.contains("Goal still active"));
+                assert!(body.contains("GOAL_ACHIEVED"));
+            }
+            other => panic!("expected SendMessage action on resume, got {other:?}"),
+        }
+        let _ = goal(&mut app, Some("clear"));
+    }
+
+    #[test]
+    fn slash_goal_resume_with_no_goal_returns_no_action() {
+        let mut app = create_test_app();
+        let r = goal(&mut app, Some("resume"));
+        assert!(r.action.is_none());
+        assert!(r.message.as_ref().unwrap().contains("No goal"));
+    }
+
+    #[test]
+    fn slash_goal_resume_when_already_on_returns_no_action() {
+        // Idempotent guard: re-running /goal resume while
+        // auto-continue is already on shouldn't double-fire a turn.
+        let mut app = create_test_app();
+        let _ = goal(&mut app, Some("Wire up X"));
+        // /goal X already enabled auto-continue. Calling resume
+        // here must be a noop (no SendMessage action).
+        let r = goal(&mut app, Some("resume"));
+        assert!(
+            r.action.is_none(),
+            "resume must not kickstart when already on"
+        );
+        assert!(r.message.as_ref().unwrap().contains("already on"));
         let _ = goal(&mut app, Some("clear"));
     }
 

--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -11,7 +11,7 @@ mod core;
 mod cycle;
 mod debug;
 mod feedback;
-mod goal;
+pub mod goal;
 mod hooks;
 mod init;
 mod jobs;

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -882,6 +882,23 @@ pub struct AutoConfig {
     pub cost_saving: Option<bool>,
 }
 
+/// `[goal]` section — knobs for the `/goal` auto-continue machinery
+/// (#891). All fields are optional with code-side defaults so
+/// adding the section is purely opt-in tuning.
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct GoalConfig {
+    /// Whether `/goal <text>` immediately enables auto-continue.
+    /// Default `true` — set to `false` to preserve the v0.8.x
+    /// passive bookkeeping behavior.
+    #[serde(default)]
+    pub auto_continue_default: Option<bool>,
+    /// Hard ceiling on auto-continue iterations per goal. Default
+    /// is [`crate::commands::goal::DEFAULT_MAX_ITERATIONS`]. Set to
+    /// `0` to disable the cap (not recommended).
+    #[serde(default)]
+    pub max_iterations: Option<u32>,
+}
+
 /// Resolved CLI configuration, including defaults and environment overrides.
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct Config {
@@ -945,6 +962,10 @@ pub struct Config {
     /// Desktop notification settings (OSC 9 / BEL on long turn completion).
     #[serde(default)]
     pub notifications: Option<NotificationsConfig>,
+
+    /// `/goal` auto-continue settings (#891).
+    #[serde(default)]
+    pub goal: Option<GoalConfig>,
 
     /// Per-domain network policy (#135). When absent, network tools fall back
     /// to a permissive default that mirrors pre-v0.7.0 behavior.
@@ -2795,6 +2816,7 @@ fn merge_config(base: Config, override_cfg: Config) -> Config {
         providers: merge_providers(base.providers, override_cfg.providers),
         features: merge_features(base.features, override_cfg.features),
         notifications: override_cfg.notifications.or(base.notifications),
+        goal: override_cfg.goal.or(base.goal),
         network: override_cfg.network.or(base.network),
         skills: override_cfg.skills.or(base.skills),
         snapshots: override_cfg.snapshots.or(base.snapshots),

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -431,6 +431,13 @@ impl Engine {
                 prompts::PromptSessionContext {
                     user_memory_block: user_memory_block.as_deref(),
                     goal_objective: config.goal_objective.as_deref(),
+                    // Engine config does not yet carry the auto-continue
+                    // flag (#891 follow-up). The sentinel instructions are
+                    // injected via each continuation user-message instead;
+                    // wiring this through Op::SendMessage → engine config
+                    // is tracked as a follow-up so the cache-friendly
+                    // engine startup path doesn't churn on toggle.
+                    goal_auto_continue: false,
                     project_context_pack_enabled: config.project_context_pack_enabled,
                     locale_tag: &config.locale_tag,
                     translation_enabled: config.translation_enabled,
@@ -1789,6 +1796,10 @@ impl Engine {
             prompts::PromptSessionContext {
                 user_memory_block: user_memory_block.as_deref(),
                 goal_objective: self.config.goal_objective.as_deref(),
+                // See engine.rs's startup site for the carve-out note
+                // (#891 follow-up). Sentinel instructions land via the
+                // per-turn continuation message, not via system prompt.
+                goal_auto_continue: false,
                 project_context_pack_enabled: self.config.project_context_pack_enabled,
                 locale_tag: &self.config.locale_tag,
                 translation_enabled: self.config.translation_enabled,

--- a/crates/tui/src/goal_state.rs
+++ b/crates/tui/src/goal_state.rs
@@ -1,0 +1,236 @@
+//! On-disk persistence for `/goal` state (#891).
+//!
+//! When the user sets `/goal <objective>` we now keep the goal alive
+//! across restarts so a long-running session can resume after a crash
+//! or intentional quit. The on-disk format mirrors
+//! [`composer_stash`](crate::composer_stash) — a small JSON file under
+//! `~/.deepseek/`, self-healing parser, never propagates write errors
+//! (goal persistence is a UX nicety, not a correctness concern).
+//!
+//! Schema is versioned (`schema_version: 1`) and every field after
+//! `objective` is `#[serde(default)]` so future additions can land
+//! without breaking older saved files.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+const GOAL_FILE_NAME: &str = "goals.v1.json";
+const CURRENT_SCHEMA_VERSION: u32 = 1;
+
+/// The full on-disk envelope.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GoalFile {
+    #[serde(default = "default_schema_version")]
+    pub schema_version: u32,
+    #[serde(default)]
+    pub current: Option<PersistedGoal>,
+}
+
+fn default_schema_version() -> u32 {
+    CURRENT_SCHEMA_VERSION
+}
+
+impl Default for GoalFile {
+    fn default() -> Self {
+        Self {
+            schema_version: CURRENT_SCHEMA_VERSION,
+            current: None,
+        }
+    }
+}
+
+/// Persisted shape of a single active goal.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersistedGoal {
+    pub objective: String,
+    #[serde(default)]
+    pub token_budget: Option<u32>,
+    #[serde(default = "default_auto_continue")]
+    pub auto_continue_enabled: bool,
+    #[serde(default)]
+    pub started_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub iterations: u32,
+    #[serde(default)]
+    pub session_id: Option<String>,
+}
+
+fn default_auto_continue() -> bool {
+    true
+}
+
+/// Resolve the on-disk goal-state path. Honours the
+/// `DEEPSEEK_TUI_GOAL_PATH` env var so unit / integration tests can
+/// redirect writes away from the real `~/.deepseek/` and keep test
+/// runs hermetic.
+fn default_goal_path() -> Option<PathBuf> {
+    if let Ok(p) = std::env::var("DEEPSEEK_TUI_GOAL_PATH")
+        && !p.is_empty()
+    {
+        return Some(PathBuf::from(p));
+    }
+    dirs::home_dir().map(|home| home.join(".deepseek").join(GOAL_FILE_NAME))
+}
+
+/// Load the persisted goal envelope. Returns `GoalFile::default()`
+/// when the file doesn't exist or is corrupt — corruption never
+/// stops the TUI from booting.
+#[must_use]
+pub fn load_goal() -> GoalFile {
+    match default_goal_path() {
+        Some(path) => load_goal_from(&path),
+        None => GoalFile::default(),
+    }
+}
+
+fn load_goal_from(path: &Path) -> GoalFile {
+    let Ok(text) = fs::read_to_string(path) else {
+        return GoalFile::default();
+    };
+    serde_json::from_str::<GoalFile>(&text).unwrap_or_default()
+}
+
+/// Save the given envelope. Failures are logged but never
+/// propagated.
+pub fn save_goal(file: &GoalFile) {
+    let Some(path) = default_goal_path() else {
+        return;
+    };
+    save_goal_to(&path, file);
+}
+
+fn save_goal_to(path: &Path, file: &GoalFile) {
+    if let Some(parent) = path.parent()
+        && let Err(err) = fs::create_dir_all(parent)
+    {
+        tracing::warn!(
+            "Failed to create goal state dir {}: {err}",
+            parent.display()
+        );
+        return;
+    }
+    let Ok(text) = serde_json::to_string_pretty(file) else {
+        return;
+    };
+    if let Err(err) = fs::write(path, text) {
+        tracing::warn!("Failed to write goal state {}: {err}", path.display());
+    }
+}
+
+/// Wipe the persisted goal. Idempotent — no error when the file
+/// is already absent.
+pub fn clear_goal() {
+    let Some(path) = default_goal_path() else {
+        return;
+    };
+    clear_goal_at(&path);
+}
+
+fn clear_goal_at(path: &Path) {
+    if !path.exists() {
+        return;
+    }
+    if let Err(err) = fs::remove_file(path) {
+        tracing::warn!("Failed to remove goal state {}: {err}", path.display());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp_path(name: &str) -> PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "deepseek-tui-goal-test-{name}-{}.json",
+            std::process::id()
+        ));
+        p
+    }
+
+    #[test]
+    fn roundtrip_persists_all_fields() {
+        let path = tmp_path("roundtrip");
+        let _ = fs::remove_file(&path);
+        let file = GoalFile {
+            schema_version: 1,
+            current: Some(PersistedGoal {
+                objective: "Refactor auth".into(),
+                token_budget: Some(50_000),
+                auto_continue_enabled: true,
+                started_at: Some(Utc::now()),
+                iterations: 7,
+                session_id: Some("sess-xyz".into()),
+            }),
+        };
+        save_goal_to(&path, &file);
+        let loaded = load_goal_from(&path);
+        let g = loaded.current.expect("current goal present");
+        assert_eq!(g.objective, "Refactor auth");
+        assert_eq!(g.token_budget, Some(50_000));
+        assert!(g.auto_continue_enabled);
+        assert_eq!(g.iterations, 7);
+        assert_eq!(g.session_id.as_deref(), Some("sess-xyz"));
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn missing_file_yields_empty() {
+        let path = tmp_path("missing");
+        let _ = fs::remove_file(&path);
+        let loaded = load_goal_from(&path);
+        assert!(loaded.current.is_none());
+        assert_eq!(loaded.schema_version, CURRENT_SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn corrupt_file_falls_back_to_default() {
+        let path = tmp_path("corrupt");
+        fs::write(&path, "{not valid json").unwrap();
+        let loaded = load_goal_from(&path);
+        assert!(loaded.current.is_none());
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn forward_compat_missing_fields_default() {
+        let path = tmp_path("forward");
+        fs::write(
+            &path,
+            r#"{"schema_version":1,"current":{"objective":"minimal"}}"#,
+        )
+        .unwrap();
+        let loaded = load_goal_from(&path);
+        let g = loaded.current.expect("current goal present");
+        assert_eq!(g.objective, "minimal");
+        assert_eq!(g.token_budget, None);
+        assert!(g.auto_continue_enabled, "missing field defaults to true");
+        assert_eq!(g.iterations, 0);
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn clear_removes_file() {
+        let path = tmp_path("clear");
+        save_goal_to(
+            &path,
+            &GoalFile {
+                schema_version: 1,
+                current: Some(PersistedGoal {
+                    objective: "X".into(),
+                    token_budget: None,
+                    auto_continue_enabled: true,
+                    started_at: None,
+                    iterations: 0,
+                    session_id: None,
+                }),
+            },
+        );
+        assert!(path.exists());
+        clear_goal_at(&path);
+        assert!(!path.exists());
+    }
+}

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -35,6 +35,7 @@ mod error_taxonomy;
 mod eval;
 mod execpolicy;
 mod features;
+mod goal_state;
 mod handoff;
 mod hooks;
 mod llm_client;

--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -17,6 +17,11 @@ use std::path::{Path, PathBuf};
 pub struct PromptSessionContext<'a> {
     pub user_memory_block: Option<&'a str>,
     pub goal_objective: Option<&'a str>,
+    /// When `true` AND `goal_objective` is set, append the auto-
+    /// continue sentinel contract to the session goal block so the
+    /// model knows it'll be called turn-over-turn and how to declare
+    /// completion. Defaults to `false` — passive goal display only.
+    pub goal_auto_continue: bool,
     pub project_context_pack_enabled: bool,
     /// Resolved BCP-47 locale tag for the `## Environment` block in
     /// the system prompt (e.g. `"en"`, `"zh-Hans"`, `"ja"`). The
@@ -549,6 +554,7 @@ pub fn system_prompt_for_mode_with_context_and_skills(
             project_context_pack_enabled: true,
             locale_tag: "en",
             translation_enabled: false,
+            goal_auto_continue: false,
         },
     )
 }
@@ -712,6 +718,13 @@ pub fn system_prompt_for_mode_with_context_skills_session_and_approval(
     // 6c. Current session goal. Also volatile: users set / change goals
     // during a session via `/goal`. Placed below the boundary for the
     // same reason as memory.
+    //
+    // When `goal_auto_continue` is on (#891), append the sentinel
+    // contract so the model knows it'll be re-invoked turn-over-turn
+    // and how to declare completion. The contract text is verbatim
+    // per work-order §二 to keep the prefix cache stable across
+    // turns (any wording drift here invalidates the post-`<session_goal>`
+    // tail).
     if let Some(goal_objective) = session_context.goal_objective
         && !goal_objective.trim().is_empty()
     {
@@ -719,6 +732,16 @@ pub fn system_prompt_for_mode_with_context_skills_session_and_approval(
             "{full_prompt}\n\n## Current Session Goal\n\n<session_goal>\n{}\n</session_goal>",
             goal_objective.trim()
         );
+        if session_context.goal_auto_continue {
+            full_prompt = format!(
+                "{full_prompt}\n\n\
+                 Stay focused on this goal. After each turn, you will receive an \
+                 automatic continuation. When the goal is achieved, emit the literal \
+                 token `GOAL_ACHIEVED` on its own line. Do not emit it prematurely — \
+                 only when all acceptance criteria are demonstrably met (tests green, \
+                 files exist, behavior verified)."
+            );
+        }
     }
 
     // 7. Previous-session relay (file-backed, rewritten by `/compact`).
@@ -881,6 +904,7 @@ mod tests {
                 project_context_pack_enabled: false,
                 locale_tag: "zh-Hans",
                 translation_enabled: false,
+                goal_auto_continue: false,
             },
             ApprovalMode::Suggest,
         ) {
@@ -950,6 +974,7 @@ mod tests {
                 project_context_pack_enabled: false,
                 locale_tag: "zh-Hans",
                 translation_enabled: false,
+                goal_auto_continue: false,
             },
             ApprovalMode::Suggest,
         ) {
@@ -994,6 +1019,7 @@ mod tests {
                 project_context_pack_enabled: false,
                 locale_tag: "en",
                 translation_enabled: false,
+                goal_auto_continue: false,
             },
             ApprovalMode::Suggest,
         ) {
@@ -1083,6 +1109,7 @@ mod tests {
                 project_context_pack_enabled: true,
                 locale_tag: "ja",
                 translation_enabled: false,
+                goal_auto_continue: false,
             },
         ) {
             SystemPrompt::Text(text) => text,
@@ -1118,6 +1145,7 @@ mod tests {
                 project_context_pack_enabled: false,
                 locale_tag: "en",
                 translation_enabled: false,
+                goal_auto_continue: false,
             },
         ) {
             SystemPrompt::Text(text) => text,
@@ -1145,6 +1173,7 @@ mod tests {
                 project_context_pack_enabled: false,
                 locale_tag: "en",
                 translation_enabled: false,
+                goal_auto_continue: false,
             },
         ) {
             SystemPrompt::Text(text) => text,
@@ -1174,6 +1203,7 @@ mod tests {
                 project_context_pack_enabled: false,
                 locale_tag: "en",
                 translation_enabled: false,
+                goal_auto_continue: false,
             },
         ) {
             SystemPrompt::Text(text) => text,
@@ -1201,6 +1231,7 @@ mod tests {
                 project_context_pack_enabled: true,
                 locale_tag: "en",
                 translation_enabled: false,
+                goal_auto_continue: false,
             },
         ) {
             SystemPrompt::Text(text) => text,
@@ -1395,6 +1426,7 @@ mod tests {
                 project_context_pack_enabled: true,
                 locale_tag: "en",
                 translation_enabled: false,
+                goal_auto_continue: false,
             },
         ) {
             SystemPrompt::Text(text) => text,
@@ -1428,6 +1460,7 @@ mod tests {
                 project_context_pack_enabled: true,
                 locale_tag: "en",
                 translation_enabled: false,
+                goal_auto_continue: false,
             },
         ) {
             SystemPrompt::Text(text) => text,

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -702,12 +702,51 @@ impl Default for ViewportState {
     }
 }
 
-/// Goal mode state (#397).
+/// Goal mode state (#397, extended for #891 auto-continue).
+///
+/// The first three fields are the original "passive bookkeeping"
+/// (objective + budget + elapsed timer). Everything below is the
+/// auto-continue machinery added for #891: when `auto_continue_enabled`
+/// is true, the `TurnComplete` handler in `ui.rs` consults
+/// [`crate::commands::goal::decide_continuation`] and either queues a
+/// continuation user-message or stops the chain with one of the four
+/// safety-net reasons.
 #[derive(Debug, Clone, Default)]
 pub struct GoalState {
     pub goal_objective: Option<String>,
     pub goal_token_budget: Option<u32>,
     pub goal_started_at: Option<Instant>,
+    /// Wall-clock start time, kept in parallel with the monotonic
+    /// `goal_started_at` solely for persistence (Instant can't
+    /// serialize across process boundaries).
+    pub goal_started_at_utc: Option<chrono::DateTime<chrono::Utc>>,
+    /// When `true`, every `TurnComplete` event runs the goal
+    /// continuation decision. Defaults to true on `/goal <text>`;
+    /// flipped off by `/goal stop`, by any safety net, or by the
+    /// model emitting `GOAL_ACHIEVED`.
+    pub auto_continue_enabled: bool,
+    /// Number of continuation turns the model has been pushed
+    /// through for the current objective. Resets when the
+    /// objective is cleared.
+    pub iterations: u32,
+    /// Snapshot of pending-todo count at the end of the previous
+    /// turn — used by the `Stuck` safety net.
+    pub last_pending_count: Option<usize>,
+    /// Snapshot of `session.total_conversation_tokens` at the end of
+    /// the last turn that made *progress* (pending-count changed,
+    /// or token usage jumped). Used by the `Stuck` double-condition
+    /// check (see [`crate::commands::goal::decide_continuation`]).
+    pub last_progress_total_tokens: u32,
+    /// Consecutive turns where neither pending count nor token
+    /// usage moved enough to count as progress.
+    pub consecutive_no_progress_turns: u32,
+    /// Consecutive turns where the model spoke without calling
+    /// any tool — used by the `Idle` safety net.
+    pub consecutive_no_tool_turns: u32,
+    /// Session id captured the moment the goal was set, mirrored
+    /// to the persisted file so a different session resuming on
+    /// the same machine can detect cross-session contamination.
+    pub session_id_for_persist: Option<String>,
 }
 
 /// Session cost and token telemetry state.
@@ -934,6 +973,15 @@ pub struct App {
     pub backtrack: crate::tui::backtrack::BacktrackState,
     /// Current session ID for auto-save updates
     pub current_session_id: Option<String>,
+    /// Config-derived default for the `/goal` auto-continue toggle
+    /// (#891). `true` means setting `/goal <text>` immediately starts
+    /// auto-continuation; users who prefer the old passive bookkeeping
+    /// flip `[goal] auto_continue_default = false` in config.toml.
+    pub goal_auto_continue_default: bool,
+    /// Hard ceiling on auto-continue iterations per goal — the
+    /// `MaxIterations` safety net. Overridable via
+    /// `[goal] max_iterations` in config.toml.
+    pub goal_max_iterations: u32,
     /// Metadata-only registry of large tool outputs produced in this session.
     pub session_artifacts: Vec<ArtifactRecord>,
     /// Trust mode - allow access outside workspace
@@ -1241,6 +1289,81 @@ fn default_composer_arrows_scroll_for_platform(use_mouse_capture: bool, is_windo
     is_windows || !use_mouse_capture
 }
 
+// === goal auto-continue support helpers (#891) ===
+
+/// Concatenate every text block of the most recent `assistant`
+/// message into a single string. Used by the goal sentinel matcher
+/// and other "what did the model just say?" callers. Returns
+/// `String::new()` when there is no assistant message yet.
+fn extract_last_assistant_text(api_messages: &[Message]) -> String {
+    let Some(msg) = api_messages.iter().rev().find(|m| m.role == "assistant") else {
+        return String::new();
+    };
+    let mut buf = String::new();
+    for block in &msg.content {
+        if let crate::models::ContentBlock::Text { text, .. } = block {
+            if !buf.is_empty() {
+                buf.push('\n');
+            }
+            buf.push_str(text);
+        }
+    }
+    buf
+}
+
+/// `true` when the most recent `assistant` message contains at least
+/// one `tool_use` content block — i.e. the model actually called a
+/// tool this turn rather than just talking.
+fn last_assistant_made_tool_call(api_messages: &[Message]) -> bool {
+    api_messages
+        .iter()
+        .rev()
+        .find(|m| m.role == "assistant")
+        .map(|m| {
+            m.content
+                .iter()
+                .any(|b| matches!(b, crate::models::ContentBlock::ToolUse { .. }))
+        })
+        .unwrap_or(false)
+}
+
+/// Count todo items that are not yet `Completed`. Used by the
+/// `Stuck` safety net. Returns `0` if the lock can't be taken — we
+/// deliberately fail open here: a transient lock contention should
+/// not cause spurious "stuck" stops.
+fn pending_todo_count(todos: &crate::tools::todo::SharedTodoList) -> usize {
+    todos
+        .try_lock()
+        .map(|list| {
+            list.snapshot()
+                .items
+                .iter()
+                .filter(|i| !matches!(i.status, crate::tools::todo::TodoStatus::Completed))
+                .count()
+        })
+        .unwrap_or(0)
+}
+
+/// Persist the App's current `goal` state to disk. Wraps the
+/// builder dance so the trigger method stays readable.
+fn persist_active_goal(app: &App) {
+    if app.goal.goal_objective.is_none() {
+        return;
+    }
+    let envelope = crate::goal_state::GoalFile {
+        schema_version: 1,
+        current: Some(crate::goal_state::PersistedGoal {
+            objective: app.goal.goal_objective.clone().unwrap_or_default(),
+            token_budget: app.goal.goal_token_budget,
+            auto_continue_enabled: app.goal.auto_continue_enabled,
+            started_at: app.goal.goal_started_at_utc,
+            iterations: app.goal.iterations,
+            session_id: app.goal.session_id_for_persist.clone(),
+        }),
+    };
+    crate::goal_state::save_goal(&envelope);
+}
+
 impl App {
     /// Cap on the session turn-cache history. Holds enough turns to debug a long
     /// session without being so large the on-screen `/cache` table wraps.
@@ -1270,6 +1393,49 @@ impl App {
 
     #[allow(clippy::too_many_lines)]
     pub fn new(options: TuiOptions, config: &Config) -> Self {
+        let mut app = Self::new_inner(options, config);
+        app.restore_persisted_goal();
+        app
+    }
+
+    /// Re-hydrate `self.goal` from `~/.deepseek/goals.v1.json` if a
+    /// previous session left a goal active (#891 lifecycle step 6).
+    /// One-way restore: never writes back. Failure to read is silent
+    /// (the file may simply not exist on first launch).
+    fn restore_persisted_goal(&mut self) {
+        let envelope = crate::goal_state::load_goal();
+        let Some(persisted) = envelope.current else {
+            return;
+        };
+        // Derive a monotonic Instant that, when displayed via
+        // `humanize_duration(t.elapsed())`, shows the wall-clock
+        // elapsed since the goal was originally set. If the wall
+        // clock went backwards we fall back to "now" — the elapsed
+        // display drifts to zero rather than reporting a negative.
+        let elapsed_dur = persisted
+            .started_at
+            .and_then(|started| {
+                chrono::Utc::now()
+                    .signed_duration_since(started)
+                    .to_std()
+                    .ok()
+            })
+            .unwrap_or(Duration::ZERO);
+        let started_instant = Instant::now().checked_sub(elapsed_dur);
+
+        self.goal.goal_objective = Some(persisted.objective);
+        self.goal.goal_token_budget = persisted.token_budget;
+        self.goal.goal_started_at = started_instant.or_else(|| Some(Instant::now()));
+        self.goal.goal_started_at_utc = persisted.started_at;
+        self.goal.auto_continue_enabled = persisted.auto_continue_enabled;
+        self.goal.iterations = persisted.iterations;
+        self.goal.session_id_for_persist = persisted.session_id;
+        // Streak counters are intentionally NOT persisted — a fresh
+        // session starts fresh and earns its own "stuck" / "idle"
+        // judgement based on this session's behaviour.
+    }
+
+    fn new_inner(options: TuiOptions, config: &Config) -> Self {
         let TuiOptions {
             model,
             workspace,
@@ -1552,6 +1718,16 @@ impl App {
             view_stack: ViewStack::new(),
             backtrack: crate::tui::backtrack::BacktrackState::new(),
             current_session_id: None,
+            goal_auto_continue_default: config
+                .goal
+                .as_ref()
+                .and_then(|g| g.auto_continue_default)
+                .unwrap_or(true),
+            goal_max_iterations: config
+                .goal
+                .as_ref()
+                .and_then(|g| g.max_iterations)
+                .unwrap_or(crate::commands::goal::DEFAULT_MAX_ITERATIONS),
             session_artifacts: Vec::new(),
             trust_mode: initial_mode == AppMode::Yolo,
             translation_enabled: false,
@@ -3805,6 +3981,114 @@ impl App {
 
     pub fn queued_message_count(&self) -> usize {
         self.queued_messages.len()
+    }
+
+    /// Goal auto-continue post-turn hook (#891).
+    ///
+    /// Called by the `EngineEvent::TurnComplete` handler in `ui.rs`
+    /// immediately after the turn's bookkeeping settles. Reads the
+    /// just-finished turn's state (last assistant text, tool-call
+    /// presence, pending-todo count, token usage), updates the
+    /// goal streak counters, then asks
+    /// [`crate::commands::goal::decide_continuation`] what to do.
+    ///
+    /// One of three outcomes:
+    /// - `Inactive` — no active goal / auto-continue off: noop.
+    /// - `Enqueue(body)` — push the synthetic continuation user
+    ///   message to `self.queued_messages`; the existing post-turn
+    ///   drain loop picks it up on the next iteration.
+    /// - `Stop(reason)` — flip `auto_continue_enabled` off, persist,
+    ///   and post a `⏹ [goal] stopped: <reason>` system cell so the
+    ///   user sees why the chain ended. If the reason is `Achieved`,
+    ///   also clear the objective entirely.
+    ///
+    /// Returns the decision so callers / tests can inspect it without
+    /// re-deriving the inputs.
+    pub fn maybe_trigger_goal_continuation(
+        &mut self,
+        turn_was_interrupted: bool,
+        turn_was_failed: bool,
+    ) -> crate::commands::goal::GoalDecision {
+        use crate::commands::goal::{
+            GoalDecision, GoalStopReason, decide_continuation, update_streaks,
+        };
+        // Nothing to do when no goal is set — short-circuit so we
+        // don't pay the locks / iteration overhead on every turn.
+        if self.goal.goal_objective.is_none() {
+            return GoalDecision::Inactive;
+        }
+
+        let last_assistant_text = extract_last_assistant_text(&self.api_messages);
+        let last_turn_had_tool_call = last_assistant_made_tool_call(&self.api_messages);
+        let pending_todo_count = pending_todo_count(&self.todos);
+        let total_tokens = self.session.total_conversation_tokens;
+
+        // Skip streak updates when the previous turn never really
+        // ran (interrupted by user, or transport-failed). A stalled
+        // API call shouldn't count as "model was idle" for the Idle
+        // safety net — the model was never given a chance to be idle.
+        if !turn_was_interrupted && !turn_was_failed {
+            update_streaks(
+                &mut self.goal,
+                pending_todo_count,
+                total_tokens,
+                last_turn_had_tool_call,
+            );
+        }
+
+        let inputs = crate::commands::goal::GoalDecisionInputs {
+            objective: self.goal.goal_objective.as_deref(),
+            auto_continue_enabled: self.goal.auto_continue_enabled,
+            last_assistant_text: &last_assistant_text,
+            total_conversation_tokens: total_tokens,
+            token_budget: self.goal.goal_token_budget,
+            iterations: self.goal.iterations,
+            max_iterations: self.goal_max_iterations,
+            consecutive_no_progress_turns: self.goal.consecutive_no_progress_turns,
+            consecutive_no_tool_turns: self.goal.consecutive_no_tool_turns,
+            turn_was_interrupted,
+            turn_was_failed,
+        };
+        let decision = decide_continuation(&inputs);
+        match &decision {
+            GoalDecision::Inactive => {}
+            GoalDecision::Enqueue(body) => {
+                self.goal.iterations = self.goal.iterations.saturating_add(1);
+                self.queue_message(QueuedMessage::new(body.clone(), None));
+                let cell = HistoryCell::System {
+                    content: format!(
+                        "[goal] continuation #{} queued ({} todo(s) pending)",
+                        self.goal.iterations, pending_todo_count
+                    ),
+                };
+                self.add_message(cell);
+                persist_active_goal(self);
+            }
+            GoalDecision::Stop(reason) => {
+                let cell = HistoryCell::System {
+                    content: format!("⏹ [goal] stopped: {}", reason.describe()),
+                };
+                self.add_message(cell);
+                self.goal.auto_continue_enabled = false;
+                if matches!(reason, GoalStopReason::Achieved) {
+                    // Goal achievement also clears the objective —
+                    // user can /goal <new text> to start the next.
+                    self.goal.goal_objective = None;
+                    self.goal.goal_token_budget = None;
+                    self.goal.goal_started_at = None;
+                    self.goal.goal_started_at_utc = None;
+                    self.goal.iterations = 0;
+                    self.goal.last_pending_count = None;
+                    self.goal.consecutive_no_progress_turns = 0;
+                    self.goal.consecutive_no_tool_turns = 0;
+                    self.goal.session_id_for_persist = None;
+                    crate::goal_state::clear_goal();
+                } else {
+                    persist_active_goal(self);
+                }
+            }
+        }
+        decision
     }
 
     /// Pop the most-recently queued message back into the composer for editing

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -1427,6 +1427,21 @@ async fn run_event_loop(
                         }
                         app.plan_tool_used_in_turn = false;
 
+                        // Goal auto-continue (#891): when a `/goal` is
+                        // active and auto-continue is on, decide
+                        // whether to queue a continuation user
+                        // message, stop with a safety-net reason, or
+                        // do nothing. Pure-decision logic lives in
+                        // `crate::commands::goal::decide_continuation`;
+                        // App method handles the streak update + queue
+                        // / system-cell side effects.
+                        let turn_was_interrupted =
+                            matches!(status, crate::core::events::TurnOutcomeStatus::Interrupted);
+                        let turn_was_failed =
+                            matches!(status, crate::core::events::TurnOutcomeStatus::Failed);
+                        let _ = app
+                            .maybe_trigger_goal_continuation(turn_was_interrupted, turn_was_failed);
+
                         // Legacy pending-steer recovery. Current keyboard
                         // handling keeps Esc as cancel-only, but older saved
                         // state may still carry pending steers.
@@ -3879,6 +3894,7 @@ async fn dispatch_user_message(
             prompts::PromptSessionContext {
                 user_memory_block: None,
                 goal_objective: app.goal.goal_objective.as_deref(),
+                goal_auto_continue: app.goal.auto_continue_enabled,
                 project_context_pack_enabled: config.project_context_pack_enabled(),
                 locale_tag: app.ui_locale.tag(),
                 translation_enabled: app.translation_enabled,

--- a/docs/MODES.md
+++ b/docs/MODES.md
@@ -73,6 +73,67 @@ MCP tools are exposed as `mcp_<server>_<tool>` and use the same approval flow as
 
 See `MCP.md`.
 
+## Goal Mode (`/goal` auto-continue)
+
+`/goal <objective>` sets a session goal AND enables **auto-continue**: at
+the end of each turn the TUI evaluates whether the model emitted the
+literal token `GOAL_ACHIEVED` on its own line. If not (and none of the
+four safety nets fired), a synthetic continuation user-message is queued
+so the next turn keeps pushing the work forward without you having to
+type "continue".
+
+The **first turn is kickstarted automatically** the moment you run
+`/goal X` — a "Begin executing toward this goal now" prompt is dispatched
+immediately so you don't have to type a placeholder message to start
+the loop. The kickstart is suppressed when `[goal] auto_continue_default
+= false` (you opted into passive tracking only); in that mode use
+`/goal resume` to start the loop on demand.
+
+### Subcommands
+
+| Command                                      | Behaviour |
+| -------------------------------------------- | --------- |
+| `/goal <objective>`                          | Set objective + enable auto-continue + persist to `~/.deepseek/goals.v1.json` |
+| `/goal <objective> \| budget: N`             | Same, plus a token budget that feeds the `BudgetExceeded` safety net |
+| `/goal`                                      | Show current status (objective, elapsed, auto-continue on/off, iterations) |
+| `/goal stop`                                 | Pause auto-continue but keep the objective (`/goal resume` to re-enable) |
+| `/goal resume`                               | Re-enable auto-continue and reset streak counters |
+| `/goal done` / `/goal clear` / `/goal reset` | Clear the goal entirely (also wipes the persisted file) |
+
+### Safety nets
+
+Each safety net stops the chain and prints `⏹ [goal] stopped: <reason>`
+into the transcript:
+
+- **BudgetExceeded** — total conversation tokens met `| budget: N`
+- **Stuck** — 3 consecutive turns with flat pending-todo count **and**
+  token-usage delta under 200 (double condition designed to avoid
+  misfires on slow-but-substantive long tasks)
+- **Idle** — 2 consecutive turns where the model spoke without calling
+  any tool
+- **MaxIterations** — total continuations crossed `max_iterations`
+  (default 50; configurable via `[goal] max_iterations`)
+
+### Cancelling
+
+`Esc` cancels the current request, which marks the turn as Interrupted —
+that itself stops the continuation chain (the `Interrupted` reason).
+`Esc Esc` opens the backtrack overlay as usual; neither flow clears
+the objective.
+
+### Persistence
+
+Active goals are saved to `~/.deepseek/goals.v1.json` so a crash or
+intentional restart resumes the goal. Streak counters are intentionally
+**not** persisted — each fresh session earns its own stuck / idle
+judgement.
+
+### Disabling
+
+Conservative users can flip `[goal] auto_continue_default = false` in
+`config.toml` to revert to v0.8.x behaviour (passive bookkeeping only);
+`/goal resume` then opts a single goal into the loop on demand.
+
 ## Related CLI Flags
 
 Run `deepseek --help` for the canonical list. Common flags:


### PR DESCRIPTION
## Summary

Adds goal-driven auto-continue to `/goal`: setting an objective keeps the
agent advancing turn-by-turn until either the model emits `GOAL_ACHIEVED`
on its own line or one of four safety nets fires (token budget, max
iterations, stuck on pending todos with no token movement, or idle
without tool calls). The first turn is **kickstarted automatically** —
no need to type a placeholder message after `/goal`.

Carved out from #1242 (by @lbcheng888) so the auto-continue mechanic can
land independently of the larger sub-agent / palette / UI bundle. Credit
to @lbcheng888 for the original design — same 4-safety-net shape, same
`/goal stop|resume` lifecycle, same continuation prompt structure.

Fixes #891.

## What's in

- **`/goal <text>`** — set objective, enable auto-continue, kickstart
  first turn via `CommandResult.action = SendMessage(...)`. Persists
  to `~/.deepseek/goals.v1.json` so a restart resumes the goal.
- **`/goal stop`** / **`/goal resume`** — pause / unpause auto-continue
  without clearing the objective.
- **`/goal done` / `clear` / `reset`** — full wipe (memory + disk).
- **4 safety nets**, each unit-tested in isolation:
  - `BudgetExceeded` — total conversation tokens ≥ `| budget: N`
  - `Stuck` — 3 consecutive turns with flat pending todos **AND** token
    delta under 200 (see Design notes)
  - `Idle` — 2 consecutive turns where the model spoke without calling
    any tool
  - `MaxIterations` — default 50, overridable via `[goal] max_iterations`
- **`TurnFailed`** stop reason — when the engine reports
  `TurnOutcomeStatus::Failed`, the chain stops with a distinct message
  rather than queueing more continuations against a broken backend.
- **`Interrupted`** stop reason — Esc / engine interruption stops the
  chain (user can `/goal resume` to pick back up).
- **Streak counters skipped** when the previous turn was interrupted
  or failed — so an unresponsive API doesn't pollute the Idle / Stuck
  heuristics.
- **System prompt addendum** — when auto-continue is active, the
  `## Current Session Goal` block gains a sentinel-contract paragraph
  instructing the model to emit `GOAL_ACHIEVED` on its own line when
  done.
- **Config**: new `[goal]` section with `auto_continue_default` (bool,
  defaults true) and `max_iterations` (u32, defaults 50).

## Design notes (deltas from #1242 / the original spec)

1. **`Stuck` uses a double condition** (flat-pending **AND** token-delta
   under 200) instead of #1242's flat-pending-only check. The single
   condition false-positives on slow-but-substantive long tasks where
   the pending count happens to stay flat while real work is happening.
   The double condition adds the orthogonal "model is barely generating"
   signal so we only fire on genuine spinning. Threshold of 200 tokens
   is chosen to ignore boilerplate (system prompt re-injection, brief
   acknowledgements) while catching empty turns.
2. **No `AppAction::EnqueueContinuation` variant** — uses the existing
   `App::queue_message()` mechanism (the same path `/steer` recovery
   and offline-queued messages take). The work order's intent ("don't
   hack the send-message path") is honoured: `SendMessage` is the
   interactive-submit path and remains untouched; continuations use
   the non-interactive enqueue path, which is the canonical way to
   inject system-driven messages.
3. **`/goal X` kickstarts the first turn** via `CommandResult.action =
   SendMessage(...)` — the work order didn't require this but in
   practice users hit "I set /goal and nothing happened" because the
   continuation hook only fires on `TurnComplete`. Kickstart is
   suppressed when `[goal] auto_continue_default = false` so the
   opt-out remains a true passive-tracking mode.
4. **Sentinel sentinel matcher is line-anchored**:
   `text.lines().any(|l| l.trim() == "GOAL_ACHIEVED")` — guards against
   mid-paragraph mentions like "I'll emit GOAL_ACHIEVED when done"
   prematurely stopping the chain (test:
   `goal_achieved_inline_does_not_false_positive`).
5. **`Achieved` clears the objective**; other stop reasons leave it
   in place so `/goal resume` can pick back up after the operator
   fixes the underlying issue (broken API, exhausted budget, etc.).

## Testing

- [x] `cargo test --workspace --all-features` — **3509 passed, 0 failed**
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -p deepseek-tui -- -D warnings`
- [x] 14 spec-style tests for `decide_continuation` covering each
      safety net, sentinel detection (including the inline guard), the
      `Interrupted-takes-precedence-over-Failed` tie-break, and
      both `auto_continue=off`/`no objective` inactive paths.
- [x] 6 sub-command tests for the `/goal` lifecycle (set / show /
      clear / stop / resume / "stop with no goal").
- [x] 3 kickstart tests (action shape, suppression when
      `auto_continue_default=false`, prompt content).
- [x] 5 persistence tests in `goal_state::tests` (roundtrip,
      missing-file, corrupt-file, forward-compat with missing fields,
      clear).
- [x] 3 streak-update tests (idle increment, idle reset, progress reset).
- [x] Manual: `/goal <text>` on a local vLLM session shows
      "kickstarting first turn now", the model executes immediately,
      `[goal] continuation #N queued` cells appear after each turn,
      `/goal stop` cleanly pauses, `/goal resume` reactivates with
      streak counters reset.

## Out of scope (deliberate, for follow-up PRs)

This PR intentionally does **not** touch:
- Sub-agent parallel execution / shared cache / streaming fanout
  (#1242 part 1)
- `/recap` command (#1242 part 3)
- Todos panel UI (#1242 part 4)
- Hierarchical prompt-delegation rewrite (#1242 part 5)
- Palette / header / history refactors
- **System prompt sentinel injection on the engine-config rebuild
  path** — `PromptSessionContext.goal_auto_continue` is currently
  passed `true` only from the `ui.rs` rebuild path; the two engine.rs
  sites pass `false` with a comment explaining the carve-out. Sentinel
  instructions still reach the model via every continuation user
  message, so behaviour is correct; the cleanup is purely an
  internals consistency fix.
- **`EmptyTurn` safety net** — when `usage.output_tokens == 0`,
  immediately stop instead of waiting for the `Idle` threshold to
  catch it on the next turn. Useful for unresponsive backends but
  not required for this PR.
- **Localization update for the `/goal` palette tooltip** — current
  `CmdGoalDescription` strings (zh/ja/pt) still describe the v0.8.x
  passive bookkeeping behaviour. Follow-up should refresh all four
  locales to mention auto-continue + `stop`/`resume`.

## Checklist

- [x] Updated `docs/MODES.md` with a `## Goal Mode` section
- [x] Updated `CHANGELOG.md` with the behaviour change and opt-out
- [x] Updated `config.example.toml` with the `[goal]` section
- [x] Tests live alongside the code they cover
      (`commands::goal::tests`, `goal_state::tests`)
- [x] No changes to public CLI surface beyond `/goal stop|resume` and
      the `[goal]` config section
- [x] Persisted state under `~/.deepseek/goals.v1.json` is forward-
      compatible (`schema_version` field, every new field
      `#[serde(default)]`)
- [x] `DEEPSEEK_TUI_GOAL_PATH` env var override for hermetic tests
      (so the test suite doesn't pollute the user's real
      `~/.deepseek/goals.v1.json`)
