### PR TITLE
fix(tui): prioritize exact alias matches in slash-command autocomplete

### DIFF
--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -2125,7 +2125,51 @@ pub(crate) fn slash_completion_hints(
         }
     }
 
-    entries.sort_by(|a, b| a.name.cmp(&b.name));
+    // Prioritize entries where the user's prefix is an exact alias match
+    // (e.g. typing `/q` should rank `/exit` — which has alias `q` — above
+    // `/clear` which only matches via the longer alias `qingping`).
+    // Priority: 0 = exact alias match, 1 = canonical name prefix,
+    //           2 = alias prefix match, 3 = none of the above.
+    // Uses eq_ignore_ascii_case and &str slicing to avoid allocations
+    // inside the O(N log N) comparator.
+    entries.sort_by(|a, b| {
+        let pri = |entry: &SlashMenuEntry| -> u8 {
+            let key = entry
+                .name
+                .trim_start_matches('/')
+                .split_whitespace()
+                .next()
+                .unwrap_or("");
+            if let Some(info) = commands::get_command_info(key) {
+                if info
+                    .aliases
+                    .iter()
+                    .any(|a| a.eq_ignore_ascii_case(&prefix_lower))
+                {
+                    return 0;
+                }
+                if info
+                    .name
+                    .get(..prefix_lower.len())
+                    .is_some_and(|p| p.eq_ignore_ascii_case(&prefix_lower))
+                {
+                    return 1;
+                }
+                if info
+                    .aliases
+                    .iter()
+                    .any(|a| {
+                        a.get(..prefix_lower.len())
+                            .is_some_and(|p| p.eq_ignore_ascii_case(&prefix_lower))
+                    })
+                {
+                    return 2;
+                }
+            }
+            3
+        };
+        pri(a).cmp(&pri(b)).then_with(|| a.name.cmp(&b.name))
+    });
     entries.dedup_by(|a, b| a.name == b.name);
     entries.into_iter().take(limit).collect()
 }


### PR DESCRIPTION
When typing a prefix like /q in the composer, the slash-command autocomplete popup sorts results alphabetically by canonical command name. This means /clear (matched via the alias qingping) appears before /exit (matched via the exact alias q). The user who types /q almost certainly wants to quit — the match quality should drive ordering.

<img width="1110" height="270" alt="image" src="https://github.com/user-attachments/assets/3509405b-4094-4169-858f-1796a12f3c38" />

This PR replaces the alphabetical sort in slash_completion_hints with a three-tier priority sort:
- Priority 0: An alias exactly equals the prefix
- Priority 1: The canonical command
- Priority 2: An alias merely starts with the prefix

Within each tier, results fall back to alphabetical order. Skill entries and non-command completions (no CommandInfo) receive priority 3 and sort to the bottom.

After:

<img width="996" height="244" alt="image" src="https://github.com/user-attachments/assets/a604ebf7-ab31-4e70-94ca-30b10a4f0c9d" />
