### PR TITLE
  fix(theme): prevent grayscale preview overflow

### DIFF
--- a/crates/tui/src/palette.rs
+++ b/crates/tui/src/palette.rs
@@ -1089,7 +1089,7 @@ fn grayscale_bg_from_luma(luma: u8) -> Color {
 }
 
 fn luma(r: u8, g: u8, b: u8) -> u8 {
-    (((u16::from(r) * 299) + (u16::from(g) * 587) + (u16::from(b) * 114)) / 1000) as u8
+    (((u32::from(r) * 299) + (u32::from(g) * 587) + (u32::from(b) * 114)) / 1000) as u8
 }
 // === Color depth + brightness helpers (v0.6.6 UI redesign) ===
 
@@ -1537,6 +1537,22 @@ mod tests {
         assert_eq!(
             adapt_fg_for_palette_mode(TEXT_HINT, GRAYSCALE_SURFACE, PaletteMode::Grayscale),
             GRAYSCALE_TEXT_HINT
+        );
+    }
+
+    #[test]
+    fn grayscale_palette_handles_bright_rgb_without_overflow() {
+        assert_eq!(
+            adapt_bg_for_palette_mode(Color::Rgb(255, 255, 255), PaletteMode::Grayscale),
+            GRAYSCALE_REASONING
+        );
+        assert_eq!(
+            adapt_fg_for_palette_mode(
+                Color::Rgb(246, 248, 251),
+                GRAYSCALE_SURFACE,
+                PaletteMode::Grayscale,
+            ),
+            GRAYSCALE_TEXT_BODY
         );
     }
 

--- a/crates/tui/src/tui/theme_picker.rs
+++ b/crates/tui/src/tui/theme_picker.rs
@@ -90,15 +90,22 @@ impl ThemePickerView {
     }
 
     fn move_up(&mut self) {
-        if self.selected > 0 {
+        let len = SELECTABLE_THEMES.len();
+        if len == 0 {
+            self.selected = 0;
+        } else if self.selected == 0 {
+            self.selected = len - 1;
+        } else {
             self.selected -= 1;
         }
     }
 
     fn move_down(&mut self) {
-        let max = SELECTABLE_THEMES.len().saturating_sub(1);
-        if self.selected < max {
-            self.selected += 1;
+        let len = SELECTABLE_THEMES.len();
+        if len == 0 {
+            self.selected = 0;
+        } else {
+            self.selected = (self.selected + 1) % len;
         }
     }
 }
@@ -311,6 +318,17 @@ mod tests {
         let action = v.handle_key(key(KeyCode::Down));
         assert!(matches!(action, ViewAction::Emit(_)));
         assert_eq!(selected_name(&action), Some(ThemeId::Whale.name()));
+    }
+
+    #[test]
+    fn arrow_navigation_wraps_at_picker_edges() {
+        let mut v = ThemePickerView::new("system".to_string());
+
+        let action = v.handle_key(key(KeyCode::Up));
+        assert_eq!(selected_name(&action), Some(ThemeId::GruvboxDark.name()));
+
+        let action = v.handle_key(key(KeyCode::Down));
+        assert_eq!(selected_name(&action), Some(ThemeId::System.name()));
     }
 
     #[test]


### PR DESCRIPTION


## Summary

 Fixes a `/theme` picker crash that can happen while previewing the Grayscale theme. The grayscale RGB luminance calculation used`u16`, but bright colors can exceed `u16::MAX` during the weighted sum, causing a debug panic and incorrect wrapping in release builds.

 This also improves picker navigation so the theme list wraps at the edges: pressing Up on the first item moves to the last item, and pressing Down on the last item moves back to the first.

## Testing

- [x] `cargo test --all-features`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
