### PR TITLE
fix(rlm): tolerate non-utf8 repl stdout

### DIFF
--- a/crates/tui/src/repl/runtime.rs
+++ b/crates/tui/src/repl/runtime.rs
@@ -178,7 +178,10 @@ async fn read_stdout_line_lossy(
     if n == 0 {
         return Ok(None);
     }
-    Ok(Some(String::from_utf8_lossy(&buf).into_owned()))
+    match String::from_utf8(buf) {
+        Ok(line) => Ok(Some(line)),
+        Err(err) => Ok(Some(String::from_utf8_lossy(err.as_bytes()).into_owned())),
+    }
 }
 
 impl PythonRuntime {

--- a/crates/tui/src/repl/runtime.rs
+++ b/crates/tui/src/repl/runtime.rs
@@ -167,6 +167,20 @@ pub struct PythonRuntime {
     round_timeout: Option<Duration>,
 }
 
+async fn read_stdout_line_lossy(
+    stdout: &mut BufReader<ChildStdout>,
+) -> Result<Option<String>, String> {
+    let mut buf = Vec::new();
+    let n = stdout
+        .read_until(b'\n', &mut buf)
+        .await
+        .map_err(|e| format!("stdout read: {e}"))?;
+    if n == 0 {
+        return Ok(None);
+    }
+    Ok(Some(String::from_utf8_lossy(&buf).into_owned()))
+}
+
 impl PythonRuntime {
     /// Spawn a REPL with no `context` variable and no LLM helpers wired up.
     /// Used by the agent loop for inline `repl` blocks the model emits in
@@ -288,15 +302,9 @@ impl PythonRuntime {
 
     async fn read_until_ready(&mut self, ready_sentinel: &str) -> Result<(), String> {
         loop {
-            let mut line = String::new();
-            let n = self
-                .stdout
-                .read_line(&mut line)
-                .await
-                .map_err(|e| format!("stdout read: {e}"))?;
-            if n == 0 {
+            let Some(line) = read_stdout_line_lossy(&mut self.stdout).await? else {
                 return Err("Python interpreter closed stdout before ready signal".to_string());
-            }
+            };
             let trimmed = line.trim_end_matches(['\n', '\r']);
             if trimmed == ready_sentinel {
                 return Ok(());
@@ -352,15 +360,9 @@ impl PythonRuntime {
 
         let read_loop = async {
             loop {
-                let mut line = String::new();
-                let n = self
-                    .stdout
-                    .read_line(&mut line)
-                    .await
-                    .map_err(|e| format!("stdout read: {e}"))?;
-                if n == 0 {
+                let Some(line) = read_stdout_line_lossy(&mut self.stdout).await? else {
                     return Err("Python interpreter closed stdout mid-round".to_string());
-                }
+                };
                 let trimmed = line.trim_end_matches(['\n', '\r']);
 
                 if let Some(rest) = trimmed.strip_prefix(&done_prefix) {
@@ -1296,6 +1298,27 @@ mod tests {
         // The runtime is still alive — next round should work.
         let r2 = rt.execute("print('still here')").await.expect("r2");
         assert!(r2.stdout.contains("still here"));
+        rt.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn non_utf8_stdout_decodes_lossy_and_runtime_survives() {
+        let mut rt = PythonRuntime::new().await.expect("spawn");
+        let round = rt
+            .execute(
+                r#"import os, sys
+os.write(sys.stdout.fileno(), b"before\xffafter\n")
+"#,
+            )
+            .await
+            .expect("execute");
+
+        assert!(round.stdout.contains("before"), "{}", round.stdout);
+        assert!(round.stdout.contains("after"), "{}", round.stdout);
+        assert!(round.stdout.contains('\u{fffd}'), "{}", round.stdout);
+
+        let next = rt.execute("print('still here')").await.expect("next");
+        assert!(next.stdout.contains("still here"), "{}", next.stdout);
         rt.shutdown().await;
     }
 


### PR DESCRIPTION
## Summary

- Read Python REPL stdout as bytes and decode lines with `String::from_utf8_lossy` instead of failing on invalid UTF-8.
- Apply the same lossy line reader during bootstrap readiness and normal round processing, keeping the existing newline/sentinel protocol intact.
- Add a regression test that writes `0xff` directly to Python stdout, verifies replacement-character decoding, and confirms the runtime survives a following round.

Closes #1815

## Why

`AsyncBufReadExt::read_line(&mut String)` assumes every stdout line is valid UTF-8. When Python code writes arbitrary bytes, such as data derived from mixed-encoding logs, the read fails with `stream did not contain valid UTF-8`. For RLM this should be treated like display/output data, not as a fatal protocol error.

The control sentinels are ASCII, so byte-oriented line framing plus lossy decoding preserves protocol behavior while making user output robust.

## Validation

Passed:

- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p deepseek-tui --bin deepseek-tui non_utf8_stdout_decodes_lossy_and_runtime_survives`
- `cargo test -p deepseek-tui --bin deepseek-tui repl::runtime::tests::`
- `cargo build`
- `cargo clippy --workspace --all-targets --all-features`

Notes:

- `cargo test --workspace --all-features` was also run locally. It reached 3123 passing tests but failed 4 existing environment-sensitive tests because this Windows machine has real global DeepSeek/Codex config and skills installed:
  - `commands::skills::tests::test_list_skills_empty_directory`
  - `commands::skills::tests::test_list_skills_filters_by_name_prefix`
  - `project_context::tests::test_load_global_agents_when_project_has_no_context`
  - `project_context::tests::test_global_agents_only_no_project_unchanged_fallback`
- `clippy` still reports existing warnings in `schema_migration.rs` and two existing `needless_return` warnings in `tui/ui.rs`; this PR does not touch those files.