### PR TITLE
feat(ide-bridge): add MCP-over-WS IDE bridge with cwd-scoped discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **IDE bridge integration.** New `deepseek-ide-bridge` workspace crate that
+  speaks MCP-over-WebSocket to an IDE host (VS Code via the Claude Code
+  extension, Cursor, Zed, etc.) discovered through the `~/.claude/ide/<port>.lock`
+  files. The TUI auto-connects in the background, surfaces the active editor
+  selection in the footer, and injects an `<editor_context>` block (file path +
+  selection range + selected text) into the system prompt so the model can act
+  on what the user is looking at. Discovery is **scoped to the current working
+  directory** — only a lockfile whose `workspaceFolders` contains the cwd is
+  picked, so an unrelated VS Code window can never leak its selection into the
+  current project's prompts. Set `CLAUDE_CODE_SSE_PORT=<port>` to force-attach
+  to a specific bridge.
+
 ## [0.8.39] - 2026-05-17
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1242,6 +1242,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "deepseek-ide-bridge"
+version = "0.8.39"
+dependencies = [
+ "anyhow",
+ "dirs",
+ "futures-util",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "deepseek-mcp"
 version = "0.8.39"
 dependencies = [
@@ -1311,6 +1327,7 @@ dependencies = [
  "clap_complete",
  "colored",
  "crossterm 0.28.1",
+ "deepseek-ide-bridge",
  "deepseek-secrets",
  "deepseek-tools",
  "dirs",
@@ -5252,6 +5269,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5471,6 +5500,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.6",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
 name = "type1-encoding-parser"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5582,6 +5629,12 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/core",
     "crates/execpolicy",
     "crates/hooks",
+    "crates/ide-bridge",
     "crates/mcp",
     "crates/protocol",
     "crates/secrets",

--- a/crates/ide-bridge/Cargo.toml
+++ b/crates/ide-bridge/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "deepseek-ide-bridge"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "MCP-over-WebSocket IDE bridge client for DeepSeek workspace architecture"
+
+[dependencies]
+anyhow.workspace = true
+dirs.workspace = true
+futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true }
+# We only ever talk to a loopback bridge published by the IDE host process,
+# so we deliberately exclude the TLS feature flags. Pinned to 0.24 because
+# the 0.24 line is what the rest of the workspace's transitive graph
+# already exercises through `axum`/`reqwest`-adjacent crates and it has
+# the most stable `http` re-export surface for our auth-header needs.
+tokio-tungstenite = { version = "0.24", default-features = false, features = ["connect"] }
+tracing.workspace = true
+uuid.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/crates/ide-bridge/src/client.rs
+++ b/crates/ide-bridge/src/client.rs
@@ -1,0 +1,768 @@
+//! WebSocket client for the IDE bridge.
+//!
+//! Mirrors opencode's editor-context client: JSON-RPC 2.0 over a loopback
+//! WebSocket, framed by the MCP `initialize` → `notifications/initialized`
+//! handshake. Server-pushed `selection_changed` events are cached so the
+//! TUI can include the latest editor selection in prompts without an
+//! explicit round-trip.
+
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock as StdRwLock};
+use std::time::Duration;
+
+use futures_util::{SinkExt, StreamExt};
+use serde_json::{Value, json};
+use tokio::sync::{Mutex, Notify, mpsc, oneshot};
+use tokio::task::JoinHandle;
+
+use crate::discovery::{BridgeAuth, BridgeTarget};
+use crate::protocol::{Diagnostic, SelectionChange, WorkspaceFolders};
+use crate::{Error, IDE_BRIDGE_AUTHORIZATION_HEADER, MCP_PROTOCOL_VERSION, Result};
+
+/// Hard cap on the cached `SelectionChange.text` size. The IDE host can
+/// publish arbitrarily large selections (e.g. user hits Ctrl+A on a big
+/// log file). Truncating *at the cache boundary* — not just at render
+/// time — bounds the memory footprint of the always-resident selection
+/// snapshot, every cache deduplication compare, and any future feature
+/// that reads `latest_selection()`.
+///
+/// The render-time limit (`MAX_SELECTED_TEXT_BYTES` in `tui/src/ide_bridge.rs`)
+/// is much smaller — this is a defensive cap, not a presentation limit.
+const MAX_CACHED_SELECTION_BYTES: usize = 64 * 1024;
+
+/// Hard cap on inbound WebSocket message / frame size. The IDE bridge
+/// is loopback-only and only sends modestly-sized JSON-RPC frames; any
+/// frame larger than 8 MiB is either a buggy or malicious peer. Without
+/// this, tungstenite defaults to 64 MiB / 16 MiB which is enough to
+/// crash a TUI session before it can even disconnect.
+const MAX_INBOUND_FRAME_BYTES: usize = 8 * 1024 * 1024;
+
+#[derive(Debug, Clone)]
+pub struct ConnectOptions {
+    pub handshake_timeout: Duration,
+    pub call_timeout: Duration,
+}
+
+impl Default for ConnectOptions {
+    fn default() -> Self {
+        // Match what the TUI actually uses so callers relying on
+        // defaults don't surprise themselves with a longer timeout.
+        Self {
+            handshake_timeout: Duration::from_secs(3),
+            call_timeout: Duration::from_secs(3),
+        }
+    }
+}
+
+fn ws_config() -> tokio_tungstenite::tungstenite::protocol::WebSocketConfig {
+    tokio_tungstenite::tungstenite::protocol::WebSocketConfig {
+        max_message_size: Some(MAX_INBOUND_FRAME_BYTES),
+        max_frame_size: Some(MAX_INBOUND_FRAME_BYTES),
+        ..Default::default()
+    }
+}
+
+type PendingMap = HashMap<u64, oneshot::Sender<Value>>;
+
+struct Inner {
+    selection: StdRwLock<Option<SelectionChange>>,
+    /// Monotonic counter bumped every time `selection` is mutated. Used as a
+    /// SolidJS-style "signal" — receivers can park on a `watch::Receiver`
+    /// and react when the cached selection changes, without polling.
+    selection_seq: tokio::sync::watch::Sender<u64>,
+    pending: Mutex<PendingMap>,
+    next_id: std::sync::atomic::AtomicU64,
+    tx: mpsc::Sender<String>,
+    shutdown: Notify,
+    reader_handle: Mutex<Option<JoinHandle<()>>>,
+    writer_handle: Mutex<Option<JoinHandle<()>>>,
+    call_timeout: Duration,
+    ide_name: Option<String>,
+}
+
+#[derive(Clone)]
+pub struct IdeBridgeClient {
+    inner: Arc<Inner>,
+}
+
+impl IdeBridgeClient {
+    pub async fn connect(target: &BridgeTarget, opts: ConnectOptions) -> Result<Self> {
+        let request = build_ws_request(&target.ws_url(), &target.auth)?;
+
+        let (ws, _) = tokio::time::timeout(
+            opts.handshake_timeout,
+            tokio_tungstenite::connect_async_with_config(request, Some(ws_config()), false),
+        )
+        .await
+        .map_err(|_| Error::Connect("handshake timed out".into()))?
+        .map_err(|e| Error::Connect(e.to_string()))?;
+
+        let (sink, stream) = ws.split();
+        let (tx, rx) = mpsc::channel::<String>(64);
+        let (selection_seq, _) = tokio::sync::watch::channel::<u64>(0);
+
+        let inner = Arc::new(Inner {
+            selection: StdRwLock::new(None),
+            selection_seq,
+            pending: Mutex::new(HashMap::new()),
+            next_id: std::sync::atomic::AtomicU64::new(1),
+            tx,
+            shutdown: Notify::new(),
+            reader_handle: Mutex::new(None),
+            writer_handle: Mutex::new(None),
+            call_timeout: opts.call_timeout,
+            ide_name: target.ide_name.clone(),
+        });
+
+        let w = Arc::clone(&inner);
+        let writer_handle = tokio::spawn(run_writer(w, sink, rx));
+
+        let r = Arc::clone(&inner);
+        let reader_handle = tokio::spawn(run_reader(r, stream));
+
+        *inner.writer_handle.lock().await = Some(writer_handle);
+        *inner.reader_handle.lock().await = Some(reader_handle);
+
+        let client = Self { inner };
+        if let Err(err) = client.handshake(opts.handshake_timeout).await {
+            client.shutdown().await;
+            return Err(err);
+        }
+        Ok(client)
+    }
+
+    pub fn ide_name(&self) -> Option<&str> {
+        self.inner.ide_name.as_deref()
+    }
+
+    pub fn latest_selection(&self) -> Option<SelectionChange> {
+        self.inner.selection.read().ok()?.clone()
+    }
+
+    /// Borrow the cached selection without cloning. The closure runs
+    /// while a read lock is held, so callers must keep the closure body
+    /// fast (no awaits, no further `latest_selection` reentry). Returns
+    /// `None` when the cache is empty.
+    pub fn with_latest_selection<R>(&self, f: impl FnOnce(&SelectionChange) -> R) -> Option<R> {
+        let guard = self.inner.selection.read().ok()?;
+        guard.as_ref().map(f)
+    }
+
+    /// Subscribe to a SolidJS-style "selection changed" signal. The
+    /// returned receiver advances by one every time the cached selection
+    /// is mutated (server push, explicit `getCurrentSelection`, etc.).
+    /// Callers should call `borrow_and_update()` / `changed().await` and
+    /// then read `latest_selection()` to fetch the new value.
+    pub fn subscribe_selection(&self) -> tokio::sync::watch::Receiver<u64> {
+        self.inner.selection_seq.subscribe()
+    }
+
+    pub async fn get_current_selection(&self) -> Result<SelectionChange> {
+        let result = self.call_tool("getCurrentSelection", json!({})).await?;
+        let sel: SelectionChange = decode_tool_json(&result)?;
+        update_selection(&self.inner, Some(sel.clone()));
+        Ok(sel)
+    }
+
+    pub async fn get_latest_selection(&self) -> Result<SelectionChange> {
+        let result = self.call_tool("getLatestSelection", json!({})).await?;
+        let sel: SelectionChange = decode_tool_json(&result)?;
+        update_selection(&self.inner, Some(sel.clone()));
+        Ok(sel)
+    }
+
+    pub async fn get_workspace_folders(&self) -> Result<WorkspaceFolders> {
+        let result = self.call_tool("getWorkspaceFolders", json!({})).await?;
+        decode_tool_json(&result)
+    }
+
+    pub async fn get_diagnostics(&self, uri: Option<&str>) -> Result<Vec<Diagnostic>> {
+        let args = match uri {
+            Some(u) => json!({ "uri": u }),
+            None => json!({}),
+        };
+        let result = self.call_tool("getDiagnostics", args).await?;
+        decode_tool_json(&result)
+    }
+
+    pub async fn close_all_diff_tabs(&self) -> Result<String> {
+        let result = self.call_tool("closeAllDiffTabs", json!({})).await?;
+        extract_text(&result)
+    }
+
+    pub async fn shutdown(&self) {
+        self.inner.shutdown.notify_waiters();
+        if let Some(h) = self.inner.writer_handle.lock().await.take() {
+            h.abort();
+        }
+        if let Some(h) = self.inner.reader_handle.lock().await.take() {
+            h.abort();
+        }
+    }
+
+    // ── Private ──────────────────────────────────────────────────────────
+
+    async fn handshake(&self, timeout: Duration) -> Result<()> {
+        let result = self
+            .send_request(
+                "initialize",
+                json!({
+                    "protocolVersion": MCP_PROTOCOL_VERSION,
+                    "capabilities": {},
+                    "clientInfo": {
+                        "name": "deepseek-tui",
+                        "version": env!("CARGO_PKG_VERSION")
+                    }
+                }),
+                Some(timeout),
+            )
+            .await
+            .map_err(|e| match e {
+                Error::Timeout(_) => Error::Handshake("initialize timed out".into()),
+                other => Error::Handshake(other.to_string()),
+            })?;
+
+        if let Some(v) = result.get("protocolVersion").and_then(Value::as_str) {
+            tracing::debug!(protocol_version = v, "IDE bridge initialized");
+        }
+
+        // Per MCP spec / opencode: the client follows up with
+        // `notifications/initialized` and nothing else. The previous
+        // `ide_connected` notification was a DeepSeek-only extension that
+        // no third-party IDE host actually consumes — drop it.
+        self.send_notification("notifications/initialized", json!({}))
+            .await
+    }
+
+    async fn call_tool(&self, name: &str, arguments: Value) -> Result<Value> {
+        let timeout = self.inner.call_timeout;
+        let result = self
+            .send_request(
+                "tools/call",
+                json!({ "name": name, "arguments": arguments }),
+                Some(timeout),
+            )
+            .await?;
+        if result
+            .get("isError")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+        {
+            return Err(Error::ToolError(extract_text(&result)?));
+        }
+        Ok(result)
+    }
+
+    async fn send_request(
+        &self,
+        method: &str,
+        params: Value,
+        timeout: Option<Duration>,
+    ) -> Result<Value> {
+        let id = self
+            .inner
+            .next_id
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+        let (tx, rx) = oneshot::channel();
+        self.inner.pending.lock().await.insert(id, tx);
+
+        let payload = json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params
+        });
+        if self.inner.tx.send(payload.to_string()).await.is_err() {
+            self.inner.pending.lock().await.remove(&id);
+            return Err(Error::Closed);
+        }
+
+        let response = match timeout {
+            Some(duration) => match tokio::time::timeout(duration, rx).await {
+                Ok(Ok(response)) => response,
+                Ok(Err(_)) => {
+                    self.inner.pending.lock().await.remove(&id);
+                    return Err(Error::Closed);
+                }
+                Err(_) => {
+                    self.inner.pending.lock().await.remove(&id);
+                    return Err(Error::Timeout(duration));
+                }
+            },
+            None => rx.await.map_err(|_| Error::Closed)?,
+        };
+        if let Some(err) = response.get("error") {
+            return Err(Error::Call(format_jsonrpc_error(err)));
+        }
+        Ok(response.get("result").cloned().unwrap_or(Value::Null))
+    }
+
+    async fn send_notification(&self, method: &str, params: Value) -> Result<()> {
+        let payload = json!({ "jsonrpc": "2.0", "method": method, "params": params });
+        self.inner
+            .tx
+            .send(payload.to_string())
+            .await
+            .map_err(|_| Error::Closed)?;
+        Ok(())
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Background tasks
+// ──────────────────────────────────────────────────────────────────────────────
+
+type WsSink = futures_util::stream::SplitSink<
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
+    tokio_tungstenite::tungstenite::Message,
+>;
+
+type WsStream = futures_util::stream::SplitStream<
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
+>;
+
+async fn run_writer(inner: Arc<Inner>, mut sink: WsSink, mut rx: mpsc::Receiver<String>) {
+    loop {
+        tokio::select! {
+            msg = rx.recv() => match msg {
+                Some(text) => {
+                    if sink.send(tokio_tungstenite::tungstenite::Message::Text(text)).await.is_err() {
+                        break;
+                    }
+                }
+                None => break,
+            },
+            _ = inner.shutdown.notified() => break,
+        }
+    }
+}
+
+async fn run_reader(inner: Arc<Inner>, mut stream: WsStream) {
+    loop {
+        tokio::select! {
+            frame = stream.next() => match frame {
+                Some(Ok(tokio_tungstenite::tungstenite::Message::Text(text))) => {
+                    dispatch_frame(&inner, &text).await;
+                }
+                Some(Ok(tokio_tungstenite::tungstenite::Message::Close(_))) | None => break,
+                Some(Err(_)) => break,
+                _ => {}
+            },
+            _ = inner.shutdown.notified() => break,
+        }
+    }
+    // Drain pending requests so callers don't hang.
+    for (_, tx) in inner.pending.lock().await.drain() {
+        let _ = tx.send(json!({ "error": { "code": -1, "message": "closed" } }));
+    }
+}
+
+async fn dispatch_frame(inner: &Inner, text: &str) {
+    // Single-pass deserialize: peek at `id` first because responses are
+    // by far the hot path (every tools/call answer comes through here),
+    // then fall back to the notification shape. This avoids parsing the
+    // whole frame into a `Value` and cloning `params` for every frame.
+    if let Ok(resp) = serde_json::from_str::<RawResponse>(text)
+        && let Some(id) = resp.id
+    {
+        if let Some(tx) = inner.pending.lock().await.remove(&id) {
+            // Re-parse the original frame as a Value only when we have
+            // a waiter — there's no point materialising it otherwise.
+            // The cost shows up only on requests we actually issued,
+            // not on every server push.
+            if let Ok(value) = serde_json::from_str::<Value>(text) {
+                let _ = tx.send(value);
+            }
+        }
+        return;
+    }
+
+    if let Ok(notif) = serde_json::from_str::<SelectionChangedNotification>(text)
+        && notif.method == "selection_changed"
+    {
+        update_selection(inner, Some(notif.params));
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct RawResponse {
+    #[serde(default)]
+    id: Option<u64>,
+}
+
+#[derive(serde::Deserialize)]
+struct SelectionChangedNotification {
+    method: String,
+    #[serde(default)]
+    params: SelectionChange,
+}
+
+/// Write the new selection into the shared cache and bump the watch
+/// signal so subscribers wake up.  Skips the wakeup when the cached
+/// value is byte-identical to the incoming one — IDEs frequently re-emit
+/// `selection_changed` with the same payload (e.g. on focus events).
+///
+/// The incoming `selection.text` is truncated at the cache boundary so
+/// pathological IDE pushes (50 MiB selection on Ctrl+A) cannot inflate
+/// resident memory or turn dedup compares into multi-megabyte memcmps.
+fn update_selection(inner: &Inner, mut selection: Option<SelectionChange>) {
+    if let Some(s) = selection.as_mut() {
+        truncate_selection_text_in_place(&mut s.text, MAX_CACHED_SELECTION_BYTES);
+    }
+
+    if let Ok(mut guard) = inner.selection.write() {
+        if !selection_changed(guard.as_ref(), selection.as_ref()) {
+            return;
+        }
+        *guard = selection;
+    } else {
+        return;
+    }
+    let next = inner.selection_seq.borrow().wrapping_add(1);
+    let _ = inner.selection_seq.send(next);
+}
+
+/// Cheap field-wise compare that avoids the full O(n) byte compare on
+/// long `text`. We hash-compare nothing — `text.len()` plus the small
+/// metadata (file path / range) is enough to skip the duplicate-push
+/// case (IDEs replay the *same* payload, not a same-length-different-
+/// content one). On the rare false positive we just miss one wakeup,
+/// which is harmless because the next non-duplicate push will catch up.
+fn selection_changed(prev: Option<&SelectionChange>, next: Option<&SelectionChange>) -> bool {
+    match (prev, next) {
+        (None, None) => false,
+        (Some(_), None) | (None, Some(_)) => true,
+        (Some(a), Some(b)) => {
+            a.file_path != b.file_path
+                || a.file_url != b.file_url
+                || a.selection != b.selection
+                || a.text.len() != b.text.len()
+                || a.text != b.text
+        }
+    }
+}
+
+/// Truncate at a UTF-8 char boundary in place. Leaves a short marker so
+/// downstream renderers know the payload was clamped.
+fn truncate_selection_text_in_place(text: &mut String, limit: usize) {
+    if text.len() <= limit {
+        return;
+    }
+    let mut end = limit;
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    let dropped = text.len() - end;
+    text.truncate(end);
+    text.push_str(&format!(
+        "\n... [{dropped} bytes truncated by ide-bridge cache]"
+    ));
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+fn build_ws_request(
+    url: &str,
+    auth: &BridgeAuth,
+) -> Result<tokio_tungstenite::tungstenite::http::Request<()>> {
+    let uri: tokio_tungstenite::tungstenite::http::Uri = url
+        .parse()
+        .map_err(|e| Error::Connect(format!("invalid url: {e}")))?;
+    let host = uri.authority().map(|a| a.to_string()).unwrap_or_default();
+
+    let mut builder = tokio_tungstenite::tungstenite::http::Request::builder()
+        .uri(url)
+        .header("Host", &host)
+        .header("Connection", "Upgrade")
+        .header("Upgrade", "websocket")
+        .header(
+            "Sec-WebSocket-Key",
+            tokio_tungstenite::tungstenite::handshake::client::generate_key(),
+        )
+        .header("Sec-WebSocket-Version", "13")
+        .header("Sec-WebSocket-Protocol", "mcp");
+
+    if let BridgeAuth::Token(token) = auth {
+        builder = builder.header(IDE_BRIDGE_AUTHORIZATION_HEADER, token.as_str());
+    }
+
+    builder
+        .body(())
+        .map_err(|e| Error::Connect(format!("build request: {e}")))
+}
+
+fn format_jsonrpc_error(error: &Value) -> String {
+    let message = error
+        .get("message")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    match error.get("code").and_then(Value::as_i64) {
+        Some(code) => format!("{message} ({code})"),
+        None => message.to_string(),
+    }
+}
+
+fn extract_text(result: &Value) -> Result<String> {
+    if let Some(content) = result.get("content").and_then(Value::as_array) {
+        for block in content {
+            if block.get("type").and_then(Value::as_str) == Some("text")
+                && let Some(text) = block.get("text").and_then(Value::as_str)
+            {
+                return Ok(text.to_string());
+            }
+        }
+    }
+    if let Some(text) = result.as_str() {
+        return Ok(text.to_string());
+    }
+    Ok(result.to_string())
+}
+
+fn decode_tool_json<T: serde::de::DeserializeOwned>(result: &Value) -> Result<T> {
+    if let Some(structured) = result.get("structuredContent") {
+        return serde_json::from_value(structured.clone())
+            .map_err(|e| Error::Decode(e.to_string()));
+    }
+    if result.is_object()
+        && result.get("content").is_none()
+        && let Ok(value) = serde_json::from_value(result.clone())
+    {
+        return Ok(value);
+    }
+    let text = extract_text(result)?;
+    serde_json::from_str(&text).map_err(|e| Error::Decode(e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::RwLock as StdRwLock;
+
+    fn test_client(call_timeout: Duration) -> IdeBridgeClient {
+        let (client, mut rx) = test_client_with_rx(call_timeout);
+        tokio::spawn(async move { while rx.recv().await.is_some() {} });
+        client
+    }
+
+    fn test_client_with_rx(call_timeout: Duration) -> (IdeBridgeClient, mpsc::Receiver<String>) {
+        let (tx, rx) = mpsc::channel::<String>(8);
+        let (selection_seq, _) = tokio::sync::watch::channel::<u64>(0);
+        let client = IdeBridgeClient {
+            inner: Arc::new(Inner {
+                selection: StdRwLock::new(None),
+                selection_seq,
+                pending: Mutex::new(HashMap::new()),
+                next_id: std::sync::atomic::AtomicU64::new(1),
+                tx,
+                shutdown: Notify::new(),
+                reader_handle: Mutex::new(None),
+                writer_handle: Mutex::new(None),
+                call_timeout,
+                ide_name: None,
+            }),
+        };
+        (client, rx)
+    }
+
+    #[tokio::test]
+    async fn handshake_uses_mcp_version_and_only_emits_initialized() {
+        let (client, mut rx) = test_client_with_rx(Duration::from_secs(1));
+        let responder = client.clone();
+        let capture = tokio::spawn(async move {
+            let init = rx.recv().await.expect("initialize request");
+            let init_json: Value = serde_json::from_str(&init).unwrap();
+            assert_eq!(init_json["method"], "initialize");
+            assert_eq!(
+                init_json["params"]["protocolVersion"],
+                crate::MCP_PROTOCOL_VERSION
+            );
+
+            let id = init_json["id"].as_u64().unwrap();
+            let tx = responder.inner.pending.lock().await.remove(&id).unwrap();
+            tx.send(json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "result": { "protocolVersion": crate::MCP_PROTOCOL_VERSION }
+            }))
+            .unwrap();
+
+            let initialized: Value =
+                serde_json::from_str(&rx.recv().await.expect("initialized notification")).unwrap();
+
+            // Confirm there is no follow-up notification (e.g. legacy ide_connected).
+            let lingering = tokio::time::timeout(Duration::from_millis(50), rx.recv()).await;
+            assert!(lingering.is_err(), "no extra notifications expected");
+
+            initialized
+        });
+
+        client.handshake(Duration::from_secs(1)).await.unwrap();
+        let initialized = capture.await.unwrap();
+        assert_eq!(initialized["method"], "notifications/initialized");
+    }
+
+    #[tokio::test]
+    async fn timed_out_request_is_removed_from_pending() {
+        let client = test_client(Duration::from_millis(1));
+        let err = client
+            .send_request("tools/call", json!({}), Some(Duration::from_millis(1)))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, Error::Timeout(_)));
+        assert!(client.inner.pending.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn selection_changed_push_advances_subscriber() {
+        let client = test_client(Duration::from_secs(1));
+        let mut rx = client.subscribe_selection();
+        let initial = *rx.borrow_and_update();
+
+        // Simulate a server push.
+        let frame = json!({
+            "jsonrpc": "2.0",
+            "method": "selection_changed",
+            "params": {
+                "filePath": "/tmp/a.rs",
+                "text": "foo",
+                "selection": {
+                    "start": { "line": 1, "character": 2 },
+                    "end":   { "line": 1, "character": 7 }
+                }
+            }
+        })
+        .to_string();
+        super::dispatch_frame(&client.inner, &frame).await;
+
+        // Watch advanced exactly once and the cache reflects the new value.
+        rx.changed().await.unwrap();
+        assert_ne!(*rx.borrow(), initial);
+        let cached = client.latest_selection().unwrap();
+        assert_eq!(cached.file_path.as_deref(), Some("/tmp/a.rs"));
+
+        // Replaying the same frame must NOT bump the signal again — IDEs
+        // frequently re-emit identical selections on focus changes.
+        super::dispatch_frame(&client.inner, &frame).await;
+        let lingering = tokio::time::timeout(Duration::from_millis(50), rx.changed()).await;
+        assert!(
+            lingering.is_err(),
+            "duplicate push must not wake subscribers"
+        );
+    }
+
+    #[test]
+    fn decode_tool_json_accepts_structured_content() {
+        let result = json!({
+            "structuredContent": {
+                "filePath": "/tmp/a.rs",
+                "text": "selected"
+            }
+        });
+        let selection: SelectionChange = decode_tool_json(&result).unwrap();
+        assert_eq!(selection.file_path.as_deref(), Some("/tmp/a.rs"));
+        assert_eq!(selection.text, "selected");
+    }
+
+    #[test]
+    fn decode_tool_json_accepts_direct_json() {
+        let result = json!({
+            "filePath": "/tmp/a.rs",
+            "text": "selected"
+        });
+        let selection: SelectionChange = decode_tool_json(&result).unwrap();
+        assert_eq!(selection.file_path.as_deref(), Some("/tmp/a.rs"));
+        assert_eq!(selection.text, "selected");
+    }
+
+    #[test]
+    fn decode_tool_json_accepts_mcp_text_content() {
+        let result = json!({
+            "content": [
+                {
+                    "type": "text",
+                    "text": "{\"filePath\":\"/tmp/a.rs\",\"text\":\"selected\"}"
+                }
+            ]
+        });
+        let selection: SelectionChange = decode_tool_json(&result).unwrap();
+        assert_eq!(selection.file_path.as_deref(), Some("/tmp/a.rs"));
+        assert_eq!(selection.text, "selected");
+    }
+
+    #[test]
+    fn jsonrpc_errors_include_code_when_available() {
+        let error = json!({ "code": -32601, "message": "method not found" });
+        assert_eq!(format_jsonrpc_error(&error), "method not found (-32601)");
+    }
+
+    #[test]
+    fn ws_request_uses_ide_auth_header_and_mcp_protocol() {
+        let request =
+            build_ws_request("ws://127.0.0.1:4242/", &BridgeAuth::Token("secret".into())).unwrap();
+        let headers = request.headers();
+
+        assert_eq!(
+            headers
+                .get(IDE_BRIDGE_AUTHORIZATION_HEADER)
+                .and_then(|value| value.to_str().ok()),
+            Some("secret")
+        );
+        assert_eq!(
+            headers
+                .get("Sec-WebSocket-Protocol")
+                .and_then(|value| value.to_str().ok()),
+            Some("mcp")
+        );
+    }
+
+    #[test]
+    fn cached_selection_text_is_truncated_at_boundary() {
+        let mut text = "a".repeat(MAX_CACHED_SELECTION_BYTES + 1024);
+        truncate_selection_text_in_place(&mut text, MAX_CACHED_SELECTION_BYTES);
+        assert!(text.len() < MAX_CACHED_SELECTION_BYTES + 256);
+        assert!(text.contains("bytes truncated by ide-bridge cache"));
+    }
+
+    #[test]
+    fn truncate_preserves_utf8_boundary() {
+        // Each "深" is 3 bytes in UTF-8. Limit chosen to land mid-codepoint.
+        let mut text = "深".repeat(10);
+        truncate_selection_text_in_place(&mut text, 4);
+        // Must not panic and must remain valid UTF-8 (String invariant).
+        assert!(text.starts_with('\u{6df1}'));
+        assert!(text.contains("bytes truncated"));
+    }
+
+    #[test]
+    fn cache_truncates_giant_inbound_selection() {
+        let (selection_seq, _) = tokio::sync::watch::channel::<u64>(0);
+        let (tx, _rx) = mpsc::channel::<String>(1);
+        let inner = Inner {
+            selection: StdRwLock::new(None),
+            selection_seq,
+            pending: Mutex::new(HashMap::new()),
+            next_id: std::sync::atomic::AtomicU64::new(1),
+            tx,
+            shutdown: Notify::new(),
+            reader_handle: Mutex::new(None),
+            writer_handle: Mutex::new(None),
+            call_timeout: Duration::from_secs(1),
+            ide_name: None,
+        };
+
+        let huge = SelectionChange {
+            file_path: Some("/tmp/big.log".into()),
+            file_url: None,
+            text: "x".repeat(MAX_CACHED_SELECTION_BYTES * 4),
+            selection: None,
+        };
+        update_selection(&inner, Some(huge));
+
+        let cached = inner.selection.read().unwrap().clone().unwrap();
+        assert!(cached.text.len() < MAX_CACHED_SELECTION_BYTES + 256);
+    }
+}

--- a/crates/ide-bridge/src/client.rs
+++ b/crates/ide-bridge/src/client.rs
@@ -423,12 +423,11 @@ fn update_selection(inner: &Inner, mut selection: Option<SelectionChange>) {
     let _ = inner.selection_seq.send(next);
 }
 
-/// Cheap field-wise compare that avoids the full O(n) byte compare on
-/// long `text`. We hash-compare nothing — `text.len()` plus the small
-/// metadata (file path / range) is enough to skip the duplicate-push
-/// case (IDEs replay the *same* payload, not a same-length-different-
-/// content one). On the rare false positive we just miss one wakeup,
-/// which is harmless because the next non-duplicate push will catch up.
+/// Cheap field-wise compare to skip the duplicate-push case (IDEs
+/// frequently replay the same payload on focus changes). Falls through
+/// to `String`'s `PartialEq`, which is itself O(1) on length mismatch
+/// before the byte compare, so an explicit length check would be
+/// redundant.
 fn selection_changed(prev: Option<&SelectionChange>, next: Option<&SelectionChange>) -> bool {
     match (prev, next) {
         (None, None) => false,
@@ -437,7 +436,6 @@ fn selection_changed(prev: Option<&SelectionChange>, next: Option<&SelectionChan
             a.file_path != b.file_path
                 || a.file_url != b.file_url
                 || a.selection != b.selection
-                || a.text.len() != b.text.len()
                 || a.text != b.text
         }
     }

--- a/crates/ide-bridge/src/client.rs
+++ b/crates/ide-bridge/src/client.rs
@@ -160,14 +160,24 @@ impl IdeBridgeClient {
     pub async fn get_current_selection(&self) -> Result<SelectionChange> {
         let result = self.call_tool("getCurrentSelection", json!({})).await?;
         let sel: SelectionChange = decode_tool_json(&result)?;
-        update_selection(&self.inner, Some(sel.clone()));
+        // Same validation as `selection_changed` notifications: only
+        // overwrite the cache when the response actually describes an
+        // active editor selection. An empty response (no filePath / no
+        // range) means the IDE has no active editor — keep the previous
+        // selection so the footer chip and `<editor_context>` block
+        // don't blink when the user toggles focus.
+        if is_usable_selection_push(&sel) {
+            update_selection(&self.inner, Some(sel.clone()));
+        }
         Ok(sel)
     }
 
     pub async fn get_latest_selection(&self) -> Result<SelectionChange> {
         let result = self.call_tool("getLatestSelection", json!({})).await?;
         let sel: SelectionChange = decode_tool_json(&result)?;
-        update_selection(&self.inner, Some(sel.clone()));
+        if is_usable_selection_push(&sel) {
+            update_selection(&self.inner, Some(sel.clone()));
+        }
         Ok(sel)
     }
 
@@ -381,8 +391,41 @@ async fn dispatch_frame(inner: &Inner, text: &str) {
     if let Ok(notif) = serde_json::from_str::<SelectionChangedNotification>(text)
         && notif.method == "selection_changed"
     {
+        // Mirror opencode's `EditorSelectionSchema` validation
+        // (`packages/opencode/src/cli/cmd/tui/context/editor.ts`):
+        // a usable `selection_changed` payload must carry **both** a
+        // non-empty `filePath` **and** a complete `selection: {start, end}`
+        // range. The Claude Code IDE extension fires defective pushes
+        // when focus leaves the editor (e.g. clicking into the
+        // integrated terminal):
+        //   • `{}` / `{filePath: ""}`            — no editor at all
+        //   • `{filePath, selection: null}`      — focus left the editor
+        //   • `{filePath}` (selection omitted)   — same as above
+        // opencode's schema rejects all three, so the cached selection
+        // survives the focus toggle. We do the same here. Without this
+        // guard the previous selection is overwritten with an empty
+        // payload the moment the user moves focus back to the TUI,
+        // wiping the footer "IDE: file:line" chip and the
+        // `<editor_context>` system block.
+        if !is_usable_selection_push(&notif.params) {
+            tracing::debug!(
+                file_path = ?notif.params.file_path,
+                has_range = notif.params.selection.is_some(),
+                "ignoring selection_changed without filePath+selection (focus likely moved off the editor)"
+            );
+            return;
+        }
         update_selection(inner, Some(notif.params));
     }
+}
+
+/// Reject pushes that opencode's schema would reject. Keeps the cached
+/// selection intact when the IDE host emits a "no active editor" signal
+/// (focus moved to terminal panel, sidebar, etc.).
+fn is_usable_selection_push(sel: &SelectionChange) -> bool {
+    let has_file_path = sel.file_path.as_deref().is_some_and(|p| !p.is_empty());
+    let has_range = sel.selection.is_some();
+    has_file_path && has_range
 }
 
 #[derive(serde::Deserialize)]
@@ -649,6 +692,89 @@ mod tests {
         assert!(
             lingering.is_err(),
             "duplicate push must not wake subscribers"
+        );
+    }
+
+    /// Reproduces the regression where focusing away from the IDE editor
+    /// (e.g. clicking into the integrated terminal) wiped the cached
+    /// selection. The Claude Code extension publishes one of several
+    /// "no active editor" shapes in that case; opencode's
+    /// `EditorSelectionSchema` rejects them all because both `filePath`
+    /// AND `selection: {start, end}` are required. We mirror that here.
+    #[tokio::test]
+    async fn empty_selection_changed_does_not_clobber_cache() {
+        let client = test_client(Duration::from_secs(1));
+        let mut rx = client.subscribe_selection();
+        rx.borrow_and_update();
+
+        // Seed a real selection.
+        let real = json!({
+            "jsonrpc": "2.0",
+            "method": "selection_changed",
+            "params": {
+                "filePath": "/tmp/a.rs",
+                "text": "foo",
+                "selection": {
+                    "start": { "line": 1, "character": 2 },
+                    "end":   { "line": 1, "character": 7 }
+                }
+            }
+        })
+        .to_string();
+        super::dispatch_frame(&client.inner, &real).await;
+        rx.changed().await.unwrap();
+
+        // Now simulate every focus-away push shape the IDE host can emit.
+        // None of them must be allowed to overwrite the cached selection.
+        for empty in [
+            // Completely empty params.
+            json!({ "jsonrpc": "2.0", "method": "selection_changed", "params": {} }).to_string(),
+            // Empty filePath.
+            json!({
+                "jsonrpc": "2.0",
+                "method": "selection_changed",
+                "params": { "filePath": "", "text": "" }
+            })
+            .to_string(),
+            // Missing filePath.
+            json!({
+                "jsonrpc": "2.0",
+                "method": "selection_changed",
+                "params": { "text": "leftover" }
+            })
+            .to_string(),
+            // filePath present, but no selection range — the most common
+            // shape when focus moves to a non-editor panel.
+            json!({
+                "jsonrpc": "2.0",
+                "method": "selection_changed",
+                "params": { "filePath": "/tmp/a.rs", "text": "" }
+            })
+            .to_string(),
+            // filePath + null selection.
+            json!({
+                "jsonrpc": "2.0",
+                "method": "selection_changed",
+                "params": { "filePath": "/tmp/a.rs", "text": "", "selection": null }
+            })
+            .to_string(),
+        ] {
+            super::dispatch_frame(&client.inner, &empty).await;
+        }
+
+        // Cache must still hold the previous real selection, and the
+        // subscriber must not have been woken by any of the empty pushes.
+        let cached = client.latest_selection().unwrap();
+        assert_eq!(cached.file_path.as_deref(), Some("/tmp/a.rs"));
+        assert_eq!(cached.text, "foo");
+        let range = cached.selection.expect("range survives focus toggle");
+        assert_eq!(range.start.line, 1);
+        assert_eq!(range.end.character, 7);
+
+        let lingering = tokio::time::timeout(Duration::from_millis(50), rx.changed()).await;
+        assert!(
+            lingering.is_err(),
+            "empty selection_changed must not wake subscribers"
         );
     }
 

--- a/crates/ide-bridge/src/discovery.rs
+++ b/crates/ide-bridge/src/discovery.rs
@@ -1,0 +1,481 @@
+//! Bridge discovery via the IDE host's MCP-over-WebSocket contract.
+//!
+//! Discovery order (mirrors opencode's `resolveEditorConnection`):
+//! 1. `CLAUDE_CODE_SSE_PORT` or `DEEPSEEK_EDITOR_SSE_PORT` — explicit port
+//!    override, always `ws://127.0.0.1:<port>`, no lockfile needed.
+//! 2. Scan `~/.claude/ide/*.lock` for the best workspace match against cwd.
+//!    "Best" = longest `workspaceFolders` entry that contains cwd, then most
+//!    recently modified. If no lockfile's workspace contains cwd, discovery
+//!    returns `None` and the TUI stays disconnected.
+//!
+//! Lockfiles must be JSON. A lockfile is accepted unless it explicitly
+//! declares a `transport` value that is not `"ws"` (missing `transport` is
+//! fine — opencode treats it the same way).
+
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    DEFAULT_BRIDGE_HOST, Error, IDE_BRIDGE_DEEPSEEK_PORT_ENV, IDE_BRIDGE_LOCKFILE_DIR,
+    IDE_BRIDGE_PORT_ENV, Result,
+};
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Public types
+// ──────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub enum BridgeAuth {
+    Inherited,
+    Token(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiscoverySource {
+    EnvPort,
+    Lockfile,
+}
+
+#[derive(Debug, Clone)]
+pub struct BridgeTarget {
+    pub port: u16,
+    pub host: String,
+    pub auth: BridgeAuth,
+    pub source: DiscoverySource,
+    pub workspace_folders: Vec<String>,
+    pub lockfile: Option<PathBuf>,
+    pub ide_name: Option<String>,
+}
+
+impl BridgeTarget {
+    pub fn ws_url(&self) -> String {
+        format!("ws://{}:{}/", self.host, self.port)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct LockfileEntry {
+    pub port: u16,
+    pub path: PathBuf,
+    pub modified: Option<SystemTime>,
+    pub data: LockfileBody,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LockfileBody {
+    #[serde(default)]
+    pub pid: Option<u32>,
+    #[serde(default)]
+    pub workspace_folders: Vec<String>,
+    #[serde(default)]
+    pub ide_name: Option<String>,
+    #[serde(default)]
+    pub transport: Option<String>,
+    #[serde(default)]
+    pub running_in_windows: Option<bool>,
+    #[serde(default)]
+    pub auth_token: Option<String>,
+}
+
+impl LockfileBody {
+    /// Accept the lockfile unless it explicitly declares a non-ws transport.
+    /// Missing `transport` is fine (opencode compat).
+    fn supports_websocket(&self) -> bool {
+        match self.transport.as_deref() {
+            None => true,
+            Some(t) => t.eq_ignore_ascii_case("ws"),
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Public API
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Discover the best IDE bridge target for the current process.
+pub fn discover() -> Result<Option<BridgeTarget>> {
+    let cwd = std::env::current_dir().ok();
+    discover_inner(cwd.as_deref())
+}
+
+/// Discover with an explicit directory (used when reconnecting after cd).
+pub fn discover_for(directory: &Path) -> Result<Option<BridgeTarget>> {
+    discover_inner(Some(directory))
+}
+
+fn discover_inner(cwd: Option<&Path>) -> Result<Option<BridgeTarget>> {
+    // 1. Env port override (highest priority, no lockfile needed).
+    if let Some(port) = port_from_env()? {
+        return Ok(Some(BridgeTarget {
+            port,
+            host: DEFAULT_BRIDGE_HOST.to_string(),
+            auth: BridgeAuth::Inherited,
+            source: DiscoverySource::EnvPort,
+            workspace_folders: Vec::new(),
+            lockfile: None,
+            ide_name: None,
+        }));
+    }
+
+    // 2. Lockfile scan.
+    let Some(home) = dirs::home_dir() else {
+        return Ok(None);
+    };
+    let dir = lockfile_dir(&home);
+    let entries = scan_lockfile_dir(&dir)?;
+    Ok(pick_best(entries, cwd).map(|entry| {
+        let auth = match entry.data.auth_token {
+            Some(ref token) if !token.is_empty() => BridgeAuth::Token(token.clone()),
+            _ => BridgeAuth::Inherited,
+        };
+        BridgeTarget {
+            port: entry.port,
+            host: DEFAULT_BRIDGE_HOST.to_string(),
+            auth,
+            source: DiscoverySource::Lockfile,
+            workspace_folders: entry.data.workspace_folders.clone(),
+            lockfile: Some(entry.path),
+            ide_name: entry.data.ide_name.clone(),
+        }
+    }))
+}
+
+pub fn scan_lockfile_dir(dir: &Path) -> Result<Vec<LockfileEntry>> {
+    let rd = match std::fs::read_dir(dir) {
+        Ok(rd) => rd,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(Error::Discovery(format!("read {}: {e}", dir.display()))),
+    };
+
+    let mut out = Vec::new();
+    for entry in rd.flatten() {
+        let path = entry.path();
+        let Some(port) = parse_port_from_filename(&path) else {
+            continue;
+        };
+        let Ok(meta) = entry.metadata() else { continue };
+        if !meta.is_file() {
+            continue;
+        }
+        let Ok(content) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let Some(body) = parse_lockfile_body(&content, &path) else {
+            continue;
+        };
+        if !body.supports_websocket() {
+            tracing::debug!(path = %path.display(), "skipping non-WebSocket IDE lockfile");
+            continue;
+        }
+        out.push(LockfileEntry {
+            port,
+            path,
+            modified: meta.modified().ok(),
+            data: body,
+        });
+    }
+    Ok(out)
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Internal helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+fn port_from_env() -> Result<Option<u16>> {
+    let raw = std::env::var(IDE_BRIDGE_PORT_ENV)
+        .ok()
+        .or_else(|| std::env::var(IDE_BRIDGE_DEEPSEEK_PORT_ENV).ok());
+    let Some(raw) = raw else {
+        return Ok(None);
+    };
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    let port: u16 = trimmed
+        .parse()
+        .map_err(|e| Error::Discovery(format!("port env is not a valid port number: {e}")))?;
+    Ok(Some(port))
+}
+
+fn lockfile_dir(home: &Path) -> PathBuf {
+    let mut path = home.to_path_buf();
+    for segment in IDE_BRIDGE_LOCKFILE_DIR.split('/') {
+        path.push(segment);
+    }
+    path
+}
+
+fn parse_port_from_filename(path: &Path) -> Option<u16> {
+    let stem = path.file_name()?.to_str()?.strip_suffix(".lock")?;
+    stem.parse().ok()
+}
+
+fn parse_lockfile_body(content: &str, path: &Path) -> Option<LockfileBody> {
+    match serde_json::from_str(content) {
+        Ok(body) => Some(body),
+        Err(e) => {
+            tracing::debug!(path = %path.display(), error = %e, "skipping malformed IDE lockfile");
+            None
+        }
+    }
+}
+
+/// Pick the best lockfile: longest workspace-folder match against cwd, then
+/// most recently modified. If no lockfile's workspace contains cwd, return
+/// `None` (never fall back to an unrelated lockfile).
+fn pick_best(entries: Vec<LockfileEntry>, cwd: Option<&Path>) -> Option<LockfileEntry> {
+    let Some(cwd) = cwd else {
+        // Without a cwd we cannot tell which lockfile belongs to the current
+        // project. Return None rather than guessing.
+        return None;
+    };
+
+    let cwd_normalized = normalize_path(cwd);
+
+    let mut scored: Vec<(LockfileEntry, usize)> = entries
+        .into_iter()
+        .filter_map(|entry| {
+            let best = entry
+                .data
+                .workspace_folders
+                .iter()
+                .map(|folder| {
+                    path_contains_length(&normalize_path(Path::new(folder)), &cwd_normalized)
+                })
+                .max()
+                .unwrap_or(0);
+            if best > 0 { Some((entry, best)) } else { None }
+        })
+        .collect();
+
+    if scored.is_empty() {
+        return None;
+    }
+
+    // Sort: longest match first, then newest mtime.
+    scored.sort_by(|a, b| {
+        b.1.cmp(&a.1).then_with(|| {
+            let ta = a.0.modified.unwrap_or(SystemTime::UNIX_EPOCH);
+            let tb = b.0.modified.unwrap_or(SystemTime::UNIX_EPOCH);
+            tb.cmp(&ta)
+        })
+    });
+
+    Some(scored.remove(0).0)
+}
+
+fn normalize_path(p: &Path) -> String {
+    let s = p.to_string_lossy().replace('\\', "/");
+    let s = s.trim_end_matches('/');
+    if cfg!(windows) {
+        s.to_lowercase()
+    } else {
+        s.to_string()
+    }
+}
+
+/// Returns the length of `parent` if `child` is equal to or nested inside
+/// `parent`, otherwise 0. This is the "longest match" metric.
+fn path_contains_length(parent: &str, child: &str) -> usize {
+    if parent.is_empty() {
+        return 0;
+    }
+    if child == parent {
+        return parent.len();
+    }
+    if let Some(rest) = child.strip_prefix(parent)
+        && rest.starts_with('/')
+    {
+        return parent.len();
+    }
+    0
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Tests
+// ──────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::time::Duration;
+
+    fn temp_dir(suffix: &str) -> PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "deepseek-ide-bridge-{}-{}-{}",
+            suffix,
+            std::process::id(),
+            uuid::Uuid::new_v4(),
+        ));
+        fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    #[test]
+    fn lockfile_without_transport_is_accepted() {
+        let home = temp_dir("no-transport");
+        let dir = lockfile_dir(&home);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(
+            dir.join("5000.lock"),
+            r#"{"workspaceFolders":["/projects/app"],"authToken":"tok"}"#,
+        )
+        .unwrap();
+
+        let entries = scan_lockfile_dir(&dir).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].port, 5000);
+        fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn explicit_non_ws_transport_is_rejected() {
+        let home = temp_dir("sse-transport");
+        let dir = lockfile_dir(&home);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(
+            dir.join("5000.lock"),
+            r#"{"transport":"sse","workspaceFolders":["/projects/app"]}"#,
+        )
+        .unwrap();
+
+        let entries = scan_lockfile_dir(&dir).unwrap();
+        assert!(entries.is_empty());
+        fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn longest_workspace_match_wins() {
+        let home = temp_dir("longest-match");
+        let dir = lockfile_dir(&home);
+        fs::create_dir_all(&dir).unwrap();
+
+        // Port 1000: workspace is /projects
+        fs::write(
+            dir.join("1000.lock"),
+            r#"{"transport":"ws","workspaceFolders":["/projects"]}"#,
+        )
+        .unwrap();
+        std::thread::sleep(Duration::from_millis(50));
+        // Port 2000: workspace is /projects/app (longer match)
+        fs::write(
+            dir.join("2000.lock"),
+            r#"{"transport":"ws","workspaceFolders":["/projects/app"]}"#,
+        )
+        .unwrap();
+
+        let entries = scan_lockfile_dir(&dir).unwrap();
+        let chosen = pick_best(entries, Some(Path::new("/projects/app/src"))).unwrap();
+        assert_eq!(chosen.port, 2000);
+        fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn mtime_breaks_tie_when_match_length_equal() {
+        let home = temp_dir("mtime-tie");
+        let dir = lockfile_dir(&home);
+        fs::create_dir_all(&dir).unwrap();
+
+        fs::write(
+            dir.join("1000.lock"),
+            r#"{"transport":"ws","workspaceFolders":["/projects/app"]}"#,
+        )
+        .unwrap();
+        std::thread::sleep(Duration::from_millis(50));
+        fs::write(
+            dir.join("2000.lock"),
+            r#"{"transport":"ws","workspaceFolders":["/projects/app"]}"#,
+        )
+        .unwrap();
+
+        let entries = scan_lockfile_dir(&dir).unwrap();
+        let chosen = pick_best(entries, Some(Path::new("/projects/app"))).unwrap();
+        // 2000 is newer
+        assert_eq!(chosen.port, 2000);
+        fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn unrelated_lockfile_returns_none() {
+        let home = temp_dir("unrelated");
+        let dir = lockfile_dir(&home);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(
+            dir.join("3000.lock"),
+            r#"{"transport":"ws","workspaceFolders":["F:/obsidian-changqiu"]}"#,
+        )
+        .unwrap();
+
+        let entries = scan_lockfile_dir(&dir).unwrap();
+        let chosen = pick_best(entries, Some(Path::new("E:\\GitHub\\DeepSeek-TUI")));
+        assert!(chosen.is_none());
+        fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn path_boundary_respected() {
+        let home = temp_dir("boundary");
+        let dir = lockfile_dir(&home);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(
+            dir.join("1000.lock"),
+            r#"{"transport":"ws","workspaceFolders":["E:\\projects\\app"]}"#,
+        )
+        .unwrap();
+
+        let entries = scan_lockfile_dir(&dir).unwrap();
+        // "E:\projects\application" shares prefix but is a different dir
+        let chosen = pick_best(entries, Some(Path::new("E:\\projects\\application")));
+        assert!(chosen.is_none());
+        fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn no_cwd_returns_none() {
+        let home = temp_dir("no-cwd");
+        let dir = lockfile_dir(&home);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("1000.lock"), r#"{"transport":"ws"}"#).unwrap();
+
+        let entries = scan_lockfile_dir(&dir).unwrap();
+        assert!(pick_best(entries, None).is_none());
+        fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn malformed_lockfiles_are_skipped() {
+        let home = temp_dir("malformed");
+        let dir = lockfile_dir(&home);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("1234.lock"), "not json").unwrap();
+        fs::write(
+            dir.join("2345.lock"),
+            r#"{"authToken":"ok","ideName":"ok","transport":"ws","workspaceFolders":["/x"]}"#,
+        )
+        .unwrap();
+
+        let entries = scan_lockfile_dir(&dir).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].port, 2345);
+        fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn ws_url_format() {
+        let target = BridgeTarget {
+            port: 5000,
+            host: DEFAULT_BRIDGE_HOST.to_string(),
+            auth: BridgeAuth::Inherited,
+            source: DiscoverySource::Lockfile,
+            workspace_folders: Vec::new(),
+            lockfile: None,
+            ide_name: None,
+        };
+        assert_eq!(target.ws_url(), "ws://127.0.0.1:5000/");
+    }
+}

--- a/crates/ide-bridge/src/lib.rs
+++ b/crates/ide-bridge/src/lib.rs
@@ -1,0 +1,69 @@
+//! MCP-over-WebSocket IDE bridge consumer for DeepSeek TUI.
+//!
+//! The wire contract is the one Claude Code's IDE extensions publish to
+//! `~/.claude/ide/<port>.lock`: a loopback WebSocket carrying JSON-RPC 2.0
+//! framed MCP. The behavioural shape mirrors `opencode`'s editor-context
+//! consumer (`packages/opencode/src/cli/cmd/tui/context/editor.ts`) so the
+//! two TUIs negotiate identically with any third-party IDE that already
+//! speaks the Claude Code lockfile protocol.
+
+#![forbid(unsafe_code)]
+
+mod client;
+pub mod discovery;
+mod protocol;
+
+pub use client::{ConnectOptions, IdeBridgeClient};
+pub use discovery::{BridgeAuth, BridgeTarget, DiscoverySource, LockfileEntry, discover};
+pub use protocol::{
+    Diagnostic, Position, Selection, SelectionChange, SelectionRange, WorkspaceFolder,
+    WorkspaceFolders,
+};
+
+/// Primary port env var, set by the IDE bridge host. This is the
+/// cross-product wire name shared with Claude Code.
+pub const IDE_BRIDGE_PORT_ENV: &str = "CLAUDE_CODE_SSE_PORT";
+
+/// DeepSeek-specific port override, used when callers prefer not to set
+/// the Claude-namespaced env. Mirrors opencode's `OPENCODE_EDITOR_SSE_PORT`.
+pub const IDE_BRIDGE_DEEPSEEK_PORT_ENV: &str = "DEEPSEEK_EDITOR_SSE_PORT";
+
+/// Lockfile directory under `$HOME`.
+pub const IDE_BRIDGE_LOCKFILE_DIR: &str = ".claude/ide";
+
+/// Header used when an IDE bridge lockfile publishes an auth token.
+pub const IDE_BRIDGE_AUTHORIZATION_HEADER: &str = "x-claude-code-ide-authorization";
+
+/// Loopback host the IDE bridge always publishes on.
+pub const DEFAULT_BRIDGE_HOST: &str = "127.0.0.1";
+
+/// Latest MCP protocol version supported by the IDE bridge client.
+///
+/// Per the MCP spec, `initialize.params.protocolVersion` is the latest
+/// version the client supports. The server can respond with the version
+/// it wants to use for the session.
+pub const MCP_PROTOCOL_VERSION: &str = "2025-11-25";
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("discovery: {0}")]
+    Discovery(String),
+    #[error("connect: {0}")]
+    Connect(String),
+    #[error("handshake: {0}")]
+    Handshake(String),
+    #[error("transport: {0}")]
+    Transport(String),
+    #[error("call: {0}")]
+    Call(String),
+    #[error("tool error: {0}")]
+    ToolError(String),
+    #[error("decode: {0}")]
+    Decode(String),
+    #[error("timeout after {0:?}")]
+    Timeout(std::time::Duration),
+    #[error("connection closed")]
+    Closed,
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/ide-bridge/src/protocol.rs
+++ b/crates/ide-bridge/src/protocol.rs
@@ -1,0 +1,109 @@
+//! Wire types for the IDE bridge MCP protocol.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SelectionChange {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file_url: Option<String>,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub text: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selection: Option<SelectionRange>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SelectionRange {
+    pub start: Position,
+    pub end: Position,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub is_empty: Option<bool>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Position {
+    pub line: u32,
+    pub character: u32,
+}
+
+pub type Selection = SelectionChange;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceFolders {
+    #[serde(default)]
+    pub success: bool,
+    #[serde(default)]
+    pub folders: Vec<WorkspaceFolder>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub root_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_file: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceFolder {
+    pub name: String,
+    pub uri: String,
+    pub path: String,
+    #[serde(default)]
+    pub index: u32,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Diagnostic {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uri: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub severity: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_camel_case() {
+        let value = serde_json::json!({
+            "filePath": "/tmp/example.md",
+            "fileUrl": "file:///tmp/example.md",
+            "text": "hello",
+            "selection": {
+                "start": { "line": 1, "character": 2 },
+                "end": { "line": 1, "character": 7 },
+                "isEmpty": false
+            }
+        });
+        let parsed: SelectionChange = serde_json::from_value(value.clone()).unwrap();
+        assert_eq!(parsed.file_path.as_deref(), Some("/tmp/example.md"));
+        assert_eq!(parsed.text, "hello");
+
+        let range = parsed.selection.clone().unwrap();
+        assert_eq!(range.start.line, 1);
+        assert_eq!(range.end.character, 7);
+        assert_eq!(range.is_empty, Some(false));
+
+        let reserialized = serde_json::to_value(&parsed).unwrap();
+        assert_eq!(reserialized, value);
+    }
+
+    #[test]
+    fn tolerant_to_missing_fields() {
+        let parsed: SelectionChange = serde_json::from_str(r#"{"text":""}"#).unwrap();
+        assert!(parsed.file_path.is_none());
+        assert!(parsed.selection.is_none());
+        assert!(parsed.text.is_empty());
+    }
+}

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -21,6 +21,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0.100"
 arboard = "3.4"
+deepseek-ide-bridge = { path = "../ide-bridge", version = "0.8.39" }
 deepseek-secrets = { path = "../secrets", version = "0.8.39" }
 deepseek-tools = { path = "../tools", version = "0.8.39" }
 schemaui = { version = "0.12.0", default-features = false, optional = true }

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -660,6 +660,8 @@ pub enum StatusItem {
     LastToolElapsed,
     /// Remaining rate-limit budget (placeholder until wired).
     RateLimit,
+    /// Active editor file/selection from a connected IDE bridge.
+    Ide,
 }
 
 impl StatusItem {
@@ -678,6 +680,7 @@ impl StatusItem {
             StatusItem::Agents,
             StatusItem::ReasoningReplay,
             StatusItem::Cache,
+            StatusItem::Ide,
         ]
     }
 
@@ -698,6 +701,7 @@ impl StatusItem {
             StatusItem::GitBranch => "git_branch",
             StatusItem::LastToolElapsed => "last_tool_elapsed",
             StatusItem::RateLimit => "rate_limit",
+            StatusItem::Ide => "ide",
         }
     }
 
@@ -718,6 +722,7 @@ impl StatusItem {
             StatusItem::GitBranch => "Git branch",
             StatusItem::LastToolElapsed => "Last tool elapsed",
             StatusItem::RateLimit => "Rate-limit remaining",
+            StatusItem::Ide => "IDE editor context",
         }
     }
 
@@ -739,6 +744,7 @@ impl StatusItem {
             StatusItem::GitBranch => "current workspace branch",
             StatusItem::LastToolElapsed => "ms of the most recent tool call (placeholder)",
             StatusItem::RateLimit => "remaining requests in the budget (placeholder)",
+            StatusItem::Ide => "active file and selection from a connected IDE",
         }
     }
 
@@ -759,6 +765,7 @@ impl StatusItem {
             StatusItem::GitBranch,
             StatusItem::LastToolElapsed,
             StatusItem::RateLimit,
+            StatusItem::Ide,
         ]
     }
 

--- a/crates/tui/src/config_ui.rs
+++ b/crates/tui/src/config_ui.rs
@@ -278,6 +278,7 @@ pub enum StatusItemValue {
     GitBranch,
     LastToolElapsed,
     RateLimit,
+    Ide,
 }
 
 pub fn parse_mode(arg: Option<&str>) -> Result<ConfigUiMode, String> {
@@ -996,6 +997,7 @@ impl From<StatusItem> for StatusItemValue {
             StatusItem::GitBranch => Self::GitBranch,
             StatusItem::LastToolElapsed => Self::LastToolElapsed,
             StatusItem::RateLimit => Self::RateLimit,
+            StatusItem::Ide => Self::Ide,
         }
     }
 }
@@ -1016,6 +1018,7 @@ impl From<StatusItemValue> for StatusItem {
             StatusItemValue::GitBranch => Self::GitBranch,
             StatusItemValue::LastToolElapsed => Self::LastToolElapsed,
             StatusItemValue::RateLimit => Self::RateLimit,
+            StatusItemValue::Ide => Self::Ide,
         }
     }
 }

--- a/crates/tui/src/ide_bridge.rs
+++ b/crates/tui/src/ide_bridge.rs
@@ -1,0 +1,517 @@
+//! IDE bridge integration — discovers and connects to an MCP-over-WS
+//! bridge published by an IDE host (VS Code via Claude Code extension,
+//! Cursor, Zed, etc.).
+//!
+//! Behavioural shape mirrors opencode's editor-context client:
+//! * exponential backoff retry that never gives up;
+//! * `reconnect(Option<PathBuf>)` so callers can re-resolve the lockfile
+//!   after `cd` into a different project;
+//! * cwd-scoped lockfile selection (via `deepseek_ide_bridge::discover_for`)
+//!   so unrelated IDE windows don't leak their selection into prompts;
+//! * a SolidJS-style "selection changed" signal exposed as
+//!   [`IdeBridgeHandle::take_dirty`] — the main UI loop reads it once per
+//!   tick and flips `needs_redraw` to true on change, so editor selection
+//!   updates surface in the footer / prompt block immediately rather than
+//!   waiting for the next unrelated event.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+
+use deepseek_ide_bridge::{
+    BridgeTarget, ConnectOptions, IdeBridgeClient, SelectionChange, WorkspaceFolders,
+};
+use tokio::sync::{Notify, OnceCell};
+
+static GLOBAL: OnceCell<IdeBridgeHandle> = OnceCell::const_new();
+
+/// Initial reconnect delay; doubles each failure up to `BACKOFF_MAX`.
+const BACKOFF_MIN: Duration = Duration::from_secs(1);
+const BACKOFF_MAX: Duration = Duration::from_secs(10);
+
+/// After this many consecutive failed connect attempts the worker stops
+/// burning CPU/IO on a host that clearly has no IDE bridge running and
+/// parks until a `reconnect()` (e.g. user `cd`-ed into a project that
+/// does have one) wakes it back up. Roughly aligns with one minute of
+/// retries at the 10 s ceiling.
+const MAX_FAILURES_BEFORE_PARK: u32 = 8;
+
+#[derive(Default)]
+struct State {
+    client: Option<IdeBridgeClient>,
+    directory: Option<PathBuf>,
+    /// Aborts the per-connection selection-watch task when the client is
+    /// torn down (reconnect, shutdown). Keyed off `OnceCell` semantics so
+    /// only one task can ever be live at a time.
+    watcher: Option<tokio::task::JoinHandle<()>>,
+}
+
+#[derive(Default)]
+struct Inner {
+    state: RwLock<State>,
+    /// Monotonic counter that advances every time the IDE pushes a new
+    /// selection. The UI loop calls [`IdeBridgeHandle::take_dirty`] once
+    /// per tick and triggers a redraw on change. Atomic + relaxed because
+    /// missing an update by a single tick (~24 ms) is harmless and we
+    /// never need a happens-before with other state.
+    selection_seq: AtomicU64,
+    /// Last value the UI consumed via `take_dirty`. Stored alongside
+    /// `selection_seq` so all IDE-bridge state lives in one struct.
+    selection_seq_seen: AtomicU64,
+    /// Pulsed by `reconnect()` to wake the single connect worker. The
+    /// worker parks on this `Notify` whenever (a) it has hit the failure
+    /// ceiling and is in passive mode, or (b) it just tore down a live
+    /// connection because the directory changed. Coalesces N concurrent
+    /// `reconnect()` calls into a single re-resolve.
+    wake: Notify,
+}
+
+#[derive(Clone, Default)]
+pub struct IdeBridgeHandle {
+    inner: Arc<Inner>,
+}
+
+#[allow(dead_code)]
+impl IdeBridgeHandle {
+    pub fn instance() -> Option<&'static Self> {
+        GLOBAL.get()
+    }
+
+    pub async fn init() -> &'static Self {
+        GLOBAL
+            .get_or_init(|| async {
+                let handle = Self::default();
+                handle.set_directory(std::env::current_dir().ok());
+                handle.spawn_worker();
+                handle
+            })
+            .await
+    }
+
+    pub fn is_connected(&self) -> bool {
+        self.inner
+            .state
+            .read()
+            .ok()
+            .is_some_and(|s| s.client.is_some())
+    }
+
+    pub fn ide_name(&self) -> Option<String> {
+        let guard = self.inner.state.read().ok()?;
+        guard.client.as_ref()?.ide_name().map(str::to_string)
+    }
+
+    pub fn latest_selection(&self) -> Option<SelectionChange> {
+        let guard = self.inner.state.read().ok()?;
+        guard.client.as_ref()?.latest_selection()
+    }
+
+    /// Borrow the cached selection without cloning. Returns `None` when
+    /// no client is connected or the cache is empty. Closure runs while
+    /// a read lock is held — keep it fast and synchronous.
+    pub fn with_latest_selection<R>(&self, f: impl FnOnce(&SelectionChange) -> R) -> Option<R> {
+        let guard = self.inner.state.read().ok()?;
+        guard.client.as_ref()?.with_latest_selection(f)
+    }
+
+    pub async fn current_selection(&self) -> Option<SelectionChange> {
+        let client = self.inner.state.read().ok()?.client.as_ref()?.clone();
+        client.get_current_selection().await.ok()
+    }
+
+    pub async fn workspace_folders(&self) -> Option<WorkspaceFolders> {
+        let client = self.inner.state.read().ok()?.client.as_ref()?.clone();
+        client.get_workspace_folders().await.ok()
+    }
+
+    pub async fn shutdown(&self) {
+        let (client, watcher) = if let Ok(mut s) = self.inner.state.write() {
+            (s.client.take(), s.watcher.take())
+        } else {
+            (None, None)
+        };
+        if let Some(w) = watcher {
+            w.abort();
+        }
+        if let Some(c) = client {
+            c.shutdown().await;
+        }
+    }
+
+    /// Returns true once after every selection update from the IDE. The
+    /// UI loop calls this once per tick: if it returns true, flip
+    /// `needs_redraw` so the footer chip / `<editor_context>` block
+    /// reflect the new selection on the very next frame.
+    pub fn take_dirty(&self) -> bool {
+        let current = self.inner.selection_seq.load(Ordering::Relaxed);
+        let previous = self
+            .inner
+            .selection_seq_seen
+            .swap(current, Ordering::Relaxed);
+        current != previous
+    }
+
+    /// Re-resolve the IDE bridge against a new working directory.
+    /// Pass `None` to use `process::current_dir()`.
+    ///
+    /// Cheap and idempotent: just records the new directory and pulses
+    /// the long-lived worker. Multiple rapid `reconnect()` calls collapse
+    /// to a single re-resolve, and a parked worker (one that has given
+    /// up retrying because no IDE was around) wakes up.
+    pub fn reconnect(&self, directory: Option<PathBuf>) {
+        let new_dir = directory.or_else(|| std::env::current_dir().ok());
+        let same = self
+            .inner
+            .state
+            .read()
+            .ok()
+            .and_then(|s| s.directory.clone())
+            .as_deref()
+            == new_dir.as_deref();
+        if same {
+            return;
+        }
+        self.set_directory(new_dir);
+        // If we're already connected, we need to tear down the live
+        // client first so the worker re-resolves against the new
+        // directory. `tear_down_for_reconnect` pulses `wake` for us.
+        // Otherwise the worker is either retrying or parked — pulsing
+        // `wake` directly is enough.
+        if self.is_connected() {
+            let handle = self.clone();
+            tokio::spawn(async move { handle.tear_down_for_reconnect().await });
+        } else {
+            self.inner.wake.notify_one();
+        }
+    }
+
+    fn set_directory(&self, directory: Option<PathBuf>) {
+        if let Ok(mut s) = self.inner.state.write() {
+            s.directory = directory;
+        }
+    }
+
+    fn current_directory(&self) -> Option<PathBuf> {
+        self.inner.state.read().ok()?.directory.clone()
+    }
+
+    fn bump_selection_seq(&self) {
+        self.inner.selection_seq.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Spawn the **single** long-running connect/retry worker. Replaces
+    /// the previous "spawn-on-every-reconnect" model that could leak
+    /// tasks blocked on a serialising mutex when no IDE was available.
+    fn spawn_worker(&self) {
+        let handle = self.clone();
+        tokio::spawn(async move {
+            handle.run_worker().await;
+        });
+    }
+
+    /// Single-task event loop:
+    ///   - if disconnected: try to connect; on success, park until torn
+    ///     down (directory change → `reconnect()` calls `tear_down`);
+    ///   - on failure: exponential backoff, capped by `BACKOFF_MAX` and
+    ///     `MAX_FAILURES_BEFORE_PARK`. After the cap, sleep on `wake`
+    ///     instead of polling — `reconnect()` resumes the worker.
+    async fn run_worker(&self) {
+        let mut backoff = BACKOFF_MIN;
+        let mut failures: u32 = 0;
+
+        loop {
+            // Already connected → park until something tears it down.
+            // `tear_down_for_reconnect()` clears `client` and pulses
+            // `wake`, which is exactly what we wait on here.
+            if self.is_connected() {
+                self.inner.wake.notified().await;
+                continue;
+            }
+
+            let directory = self.current_directory();
+            let target = match resolve_target(directory.as_deref()) {
+                Some(t) => t,
+                None => {
+                    failures = failures.saturating_add(1);
+                    if failures >= MAX_FAILURES_BEFORE_PARK {
+                        tracing::debug!(
+                            failures,
+                            "no IDE bridge discovered; parking until reconnect()"
+                        );
+                        self.inner.wake.notified().await;
+                        failures = 0;
+                        backoff = BACKOFF_MIN;
+                        continue;
+                    }
+                    self.sleep_or_wake(backoff).await;
+                    backoff = next_backoff(backoff);
+                    continue;
+                }
+            };
+
+            tracing::info!(
+                attempt = failures + 1,
+                port = target.port,
+                ide = ?target.ide_name,
+                source = ?target.source,
+                "connecting to IDE bridge"
+            );
+
+            let opts = ConnectOptions {
+                handshake_timeout: Duration::from_secs(3),
+                call_timeout: Duration::from_secs(3),
+            };
+
+            match IdeBridgeClient::connect(&target, opts).await {
+                Ok(client) => {
+                    tracing::info!(
+                        ide = client.ide_name().unwrap_or("unknown"),
+                        "IDE bridge connected"
+                    );
+
+                    // Subscribe to the client's selection watch BEFORE we
+                    // publish the client so the very first push (including
+                    // the seed `getCurrentSelection` below) bumps the
+                    // dirty flag and reaches the UI on the next tick.
+                    let watcher = self.spawn_watcher(client.subscribe_selection());
+
+                    if let Ok(mut s) = self.inner.state.write() {
+                        s.client = Some(client.clone());
+                        s.watcher = Some(watcher);
+                    }
+
+                    // Seed the selection cache so the next prompt can include
+                    // the current editor context even before the IDE pushes
+                    // its first `selection_changed`.
+                    if let Ok(sel) = client.get_current_selection().await {
+                        tracing::debug!(file = ?sel.file_path, "initial editor selection");
+                    }
+
+                    failures = 0;
+                    backoff = BACKOFF_MIN;
+                    // Loop top: now `is_connected()` is true → park.
+                }
+                Err(e) => {
+                    failures = failures.saturating_add(1);
+                    tracing::warn!(failures, error = %e, "IDE bridge connect failed");
+                    if failures >= MAX_FAILURES_BEFORE_PARK {
+                        tracing::debug!(failures, "IDE bridge connect repeatedly failing; parking");
+                        self.inner.wake.notified().await;
+                        failures = 0;
+                        backoff = BACKOFF_MIN;
+                        continue;
+                    }
+                    self.sleep_or_wake(backoff).await;
+                    backoff = next_backoff(backoff);
+                }
+            }
+        }
+    }
+
+    /// Sleep for `delay`, returning early when `reconnect()` pulses the
+    /// worker. Lets a `cd` shortcut the backoff timer immediately.
+    async fn sleep_or_wake(&self, delay: Duration) {
+        tokio::select! {
+            _ = tokio::time::sleep(delay) => {}
+            _ = self.inner.wake.notified() => {}
+        }
+    }
+
+    /// Tear down the live client (called by `reconnect()` after the
+    /// directory changes) and pulse the worker so it loops back to
+    /// reconnect against the new directory.
+    async fn tear_down_for_reconnect(&self) {
+        let (client, watcher) = if let Ok(mut s) = self.inner.state.write() {
+            (s.client.take(), s.watcher.take())
+        } else {
+            (None, None)
+        };
+        if let Some(w) = watcher {
+            w.abort();
+        }
+        if let Some(c) = client {
+            c.shutdown().await;
+        }
+        self.inner.wake.notify_one();
+    }
+
+    fn spawn_watcher(
+        &self,
+        mut rx: tokio::sync::watch::Receiver<u64>,
+    ) -> tokio::task::JoinHandle<()> {
+        let handle = self.clone();
+        tokio::spawn(async move {
+            // Discard the seed value so we only react to genuine updates.
+            rx.borrow_and_update();
+            while rx.changed().await.is_ok() {
+                handle.bump_selection_seq();
+            }
+        })
+    }
+}
+
+fn resolve_target(directory: Option<&std::path::Path>) -> Option<BridgeTarget> {
+    let result = match directory {
+        Some(dir) => deepseek_ide_bridge::discovery::discover_for(dir),
+        None => deepseek_ide_bridge::discover(),
+    };
+    match result {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::warn!(error = %e, "IDE bridge discovery failed");
+            None
+        }
+    }
+}
+
+fn next_backoff(current: Duration) -> Duration {
+    let doubled = current.saturating_mul(2);
+    if doubled > BACKOFF_MAX {
+        BACKOFF_MAX
+    } else {
+        doubled
+    }
+}
+
+/// Maximum bytes of `selected_text` to include in the prompt block.
+/// Larger selections are truncated with a marker so the system prompt
+/// stays within sane token budgets even when the user has the entire
+/// file selected in the IDE.
+const MAX_SELECTED_TEXT_BYTES: usize = 4 * 1024;
+
+/// Render the active editor selection as a system-prompt block.
+/// Returns `None` when no IDE bridge is connected or no selection is available.
+pub fn editor_context_block() -> Option<String> {
+    let handle = IdeBridgeHandle::instance()?;
+    handle
+        .with_latest_selection(|selection| {
+            // No file path → the selection is unusable as editor context.
+            let path = selection.file_path.as_deref()?;
+            let mut out =
+                String::with_capacity(128 + selection.text.len().min(MAX_SELECTED_TEXT_BYTES));
+            out.push_str("<editor_context>\n");
+            out.push_str("file: ");
+            out.push_str(path);
+            out.push('\n');
+            if let Some(range) = &selection.selection {
+                out.push_str(&format!(
+                    "selection: line {}:{} -> {}:{}\n",
+                    range.start.line, range.start.character, range.end.line, range.end.character,
+                ));
+            }
+            if !selection.text.is_empty() {
+                out.push_str("selected_text:\n");
+                append_truncated(&mut out, &selection.text, MAX_SELECTED_TEXT_BYTES);
+                if !out.ends_with('\n') {
+                    out.push('\n');
+                }
+            }
+            out.push_str("</editor_context>");
+            Some(out)
+        })
+        .flatten()
+}
+
+/// Append `text` to `out`, clamping at `limit` bytes on a UTF-8 char
+/// boundary. Avoids the intermediate `String` allocation that the old
+/// `truncate_text(...)` helper produced for every prompt assembly.
+fn append_truncated(out: &mut String, text: &str, limit: usize) {
+    if text.len() <= limit {
+        out.push_str(text);
+        return;
+    }
+    let mut end = limit;
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    let truncated_bytes = text.len() - end;
+    out.push_str(&text[..end]);
+    out.push_str(&format!("\n... [{truncated_bytes} bytes truncated]"));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BACKOFF_MAX, BACKOFF_MIN, IdeBridgeHandle, append_truncated, next_backoff};
+    use std::sync::atomic::Ordering;
+    use std::time::Duration;
+
+    fn render_truncated(text: &str, limit: usize) -> String {
+        let mut out = String::new();
+        append_truncated(&mut out, text, limit);
+        out
+    }
+
+    #[test]
+    fn truncate_text_preserves_char_boundaries() {
+        let text = "abc深度def";
+        let truncated = render_truncated(text, 5);
+        assert!(truncated.starts_with("abc"));
+        assert!(truncated.contains("bytes truncated"));
+    }
+
+    #[test]
+    fn truncate_text_leaves_short_text_unchanged() {
+        assert_eq!(render_truncated("short", 16), "short");
+    }
+
+    #[test]
+    fn backoff_doubles_until_capped() {
+        let mut delay = BACKOFF_MIN;
+        let mut steps = 0;
+        while delay < BACKOFF_MAX && steps < 10 {
+            delay = next_backoff(delay);
+            steps += 1;
+        }
+        assert_eq!(delay, BACKOFF_MAX);
+        assert_eq!(next_backoff(BACKOFF_MAX), BACKOFF_MAX);
+    }
+
+    #[test]
+    fn backoff_does_not_overflow_on_huge_input() {
+        let huge = Duration::from_secs(u64::MAX / 2);
+        assert_eq!(next_backoff(huge), BACKOFF_MAX);
+    }
+
+    #[test]
+    fn take_dirty_flips_on_change_and_clears_after_consume() {
+        let handle = IdeBridgeHandle::default();
+        // No update yet → clean.
+        assert!(!handle.take_dirty());
+
+        // Simulate a selection push.
+        handle.bump_selection_seq();
+        assert!(handle.take_dirty(), "first read after bump must be dirty");
+        assert!(
+            !handle.take_dirty(),
+            "second read without further bumps must be clean"
+        );
+
+        // Two pushes between reads coalesce into a single dirty flag —
+        // exactly what we want for a per-tick UI redraw signal.
+        handle.bump_selection_seq();
+        handle.bump_selection_seq();
+        assert!(handle.take_dirty());
+        assert!(!handle.take_dirty());
+    }
+
+    #[test]
+    fn take_dirty_handles_seq_wraparound() {
+        // Pre-seed the counters so the next bump wraps from u64::MAX → 0.
+        let handle = IdeBridgeHandle::default();
+        handle
+            .inner
+            .selection_seq
+            .store(u64::MAX, Ordering::Relaxed);
+        handle
+            .inner
+            .selection_seq_seen
+            .store(u64::MAX, Ordering::Relaxed);
+
+        handle.bump_selection_seq();
+        assert!(
+            handle.take_dirty(),
+            "wraparound must still register as dirty"
+        );
+    }
+}

--- a/crates/tui/src/ide_bridge.rs
+++ b/crates/tui/src/ide_bridge.rs
@@ -395,9 +395,16 @@ pub fn editor_context_block() -> Option<String> {
             out.push_str(path);
             out.push('\n');
             if let Some(range) = &selection.selection {
+                // LSP positions are 0-based; render as 1-based for both
+                // human readers and the model — matches the footer chip
+                // (`IDE: foo.rs:21`) and the line/column convention used
+                // in compiler errors, `grep -n`, stack traces, etc.
                 out.push_str(&format!(
                     "selection: line {}:{} -> {}:{}\n",
-                    range.start.line, range.start.character, range.end.line, range.end.character,
+                    range.start.line + 1,
+                    range.start.character + 1,
+                    range.end.line + 1,
+                    range.end.character + 1,
                 ));
             }
             if !selection.text.is_empty() {

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -37,6 +37,7 @@ mod execpolicy;
 mod features;
 mod handoff;
 mod hooks;
+mod ide_bridge;
 mod llm_client;
 mod localization;
 mod logging;
@@ -4306,6 +4307,10 @@ async fn run_interactive(
     if let Err(e) = crate::skills::install_system_skills(&skills_dir) {
         logging::warn(format!("Failed to install system skills: {e}"));
     }
+
+    // Best-effort connection to an IDE bridge published by an IDE host.
+    // No-op when no bridge is available; never blocks startup on failure.
+    crate::ide_bridge::IdeBridgeHandle::init().await;
 
     // Prune stale workspace snapshots from prior sessions (7-day default).
     // Non-fatal: a flaky disk, missing `git`, or read-only home should

--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -721,6 +721,12 @@ pub fn system_prompt_for_mode_with_context_skills_session_and_approval(
         );
     }
 
+    // 6d. Active editor context from the IDE bridge, if connected.
+    // Volatile per-turn: changes whenever the user moves the cursor.
+    if let Some(editor_block) = crate::ide_bridge::editor_context_block() {
+        full_prompt = format!("{full_prompt}\n\n{editor_block}");
+    }
+
     // 7. Previous-session relay (file-backed, rewritten by `/compact`).
     if let Some(handoff_block) = load_handoff_block(workspace) {
         full_prompt = format!("{full_prompt}\n\n{handoff_block}");

--- a/crates/tui/src/tui/footer_ui.rs
+++ b/crates/tui/src/tui/footer_ui.rs
@@ -415,6 +415,7 @@ pub(crate) fn render_footer_from(
             S::Cache => cache_chip.clone(),
             S::ContextPercent => footer_context_percent_spans(app),
             S::GitBranch => footer_git_branch_spans(app),
+            S::Ide => crate::tui::widgets::footer_ide_chip(),
             S::LastToolElapsed | S::RateLimit => Vec::new(),
             _ => continue,
         };

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -1969,6 +1969,18 @@ async fn run_event_loop(
             !app.is_loading && !has_running_agents && !app.is_compacting;
         workspace_context::refresh_if_needed(app, now, allow_workspace_context_refresh);
 
+        // Drain any IDE-bridge selection updates pushed by the connected
+        // IDE since the last tick. The bridge writes selections into a
+        // shared cache and bumps an atomic seq; if it advanced, we flip
+        // `needs_redraw` so the footer chip / `<editor_context>` block
+        // catch up on the next frame instead of waiting for an unrelated
+        // event to wake the loop.
+        if let Some(handle) = crate::ide_bridge::IdeBridgeHandle::instance()
+            && handle.take_dirty()
+        {
+            app.needs_redraw = true;
+        }
+
         // Draw is gated by the frame-rate limiter (120 FPS cap). When a
         // redraw is needed but the limiter says we're inside the cooldown
         // window, leave `needs_redraw = true` and shorten the poll timeout

--- a/crates/tui/src/tui/widgets/footer.rs
+++ b/crates/tui/src/tui/widgets/footer.rs
@@ -218,6 +218,44 @@ pub fn footer_mcp_chip(connected: Option<usize>, configured: usize) -> Vec<Span<
     vec![Span::styled(label, Style::default().fg(color))]
 }
 
+/// "IDE: <basename>:<line>" chip — surfaces the active editor file and
+/// selection from a connected IDE bridge. Returns an empty span list when
+/// no bridge is connected or no selection has arrived yet, so the chip
+/// disappears cleanly when there's nothing to show.
+#[must_use]
+pub fn footer_ide_chip() -> Vec<Span<'static>> {
+    let Some(handle) = crate::ide_bridge::IdeBridgeHandle::instance() else {
+        return Vec::new();
+    };
+    let label = handle.with_latest_selection(|selection| {
+        let path = selection.file_path.as_deref()?;
+        let basename = std::path::Path::new(path)
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or(path);
+
+        Some(match selection.selection.as_ref() {
+            Some(range) if range.start.line == range.end.line => {
+                format!("IDE: {basename}:{}", range.start.line + 1)
+            }
+            Some(range) => format!(
+                "IDE: {basename}:{}-{}",
+                range.start.line + 1,
+                range.end.line + 1,
+            ),
+            None => format!("IDE: {basename}"),
+        })
+    });
+    let Some(Some(label)) = label else {
+        return Vec::new();
+    };
+
+    vec![Span::styled(
+        label,
+        Style::default().fg(palette::TEXT_MUTED),
+    )]
+}
+
 /// A status toast routed to the footer's left segment for a short time.
 #[derive(Debug, Clone)]
 pub struct FooterToast {

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -15,7 +15,8 @@ mod renderable;
 pub mod tool_card;
 
 pub use footer::{
-    FooterProps, FooterToast, FooterWidget, footer_agents_chip, footer_working_label,
+    FooterProps, FooterToast, FooterWidget, footer_agents_chip, footer_ide_chip,
+    footer_working_label,
 };
 pub use header::{HeaderData, HeaderWidget, header_status_indicator_frame};
 pub use renderable::Renderable;


### PR DESCRIPTION
## Summary

Adds a new `deepseek-ide-bridge` workspace crate that speaks MCP-over-WebSocket
to an IDE host (VS Code via the Claude Code extension, Cursor, Zed, etc.)
discovered through `~/.claude/ide/<port>.lock` files. The TUI auto-connects in
the background, surfaces the active editor selection in the footer, and injects
an `<editor_context>` block (file path + selection range + selected text) into
the system prompt so the model can act on what the user is currently looking at.

## Why cwd-scoped discovery

The naive approach — pick the newest lockfile in `~/.claude/ide/` — leaks
selections from completely unrelated IDE windows. If you have a VS Code window
open on project A and run `deepseek` in project B, the footer ends up showing
something like `IDE: .gitignore:21` from project A and the model sees that file
in `<editor_context>`. This PR scopes discovery to the current working
directory: only a lockfile whose `workspaceFolders` list contains the cwd is
picked. To force-attach to a specific bridge, set `CLAUDE_CODE_SSE_PORT=<port>`.

<img width="1440" height="900" alt="20260520-140153" src="https://github.com/user-attachments/assets/adaece10-aba0-47c5-9b8d-f6c14374d10f" />

## What's added

- `crates/ide-bridge/` — new workspace crate
  - `discovery.rs` — cwd-scoped lockfile resolution with longest-match-wins +
    mtime tiebreak; explicit `CLAUDE_CODE_SSE_PORT` env override
  - `client.rs` — JSON-RPC over WebSocket, MCP `initialize` handshake,
    selection cache + `tokio::sync::watch` change signal, bounded selection
    text truncation
  - `protocol.rs` — typed `SelectionChange` / `WorkspaceFolders` schemas
- `crates/tui/src/ide_bridge.rs` — single long-running connect/retry worker
  with exponential backoff, parking after a failure ceiling, `reconnect()`
  on `cd`, and a `take_dirty()` per-tick redraw signal
- TUI wiring: footer chip showing connected IDE + selection, event-loop hook
  to flip `needs_redraw` on selection change, prompt assembly hook for
  `<editor_context>` injection, config toggle

## Tests

- `crates/ide-bridge`: 22 unit tests covering discovery boundary cases
  (longest-match, mtime tiebreak, unrelated lockfile rejection, malformed
  files), MCP handshake, selection cache truncation, JSON-RPC error decoding
- `crates/tui` ide_bridge module: 6 unit tests covering backoff, dirty-flag
  semantics, UTF-8 boundary truncation, seq wraparound

## Verification

```
cargo fmt --all --check    # clean
cargo check --workspace --all-features    # ok
cargo test -p deepseek-ide-bridge    # 22 passed
cargo test -p deepseek-tui --bin deepseek-tui ide_bridge    # 6 passed
cargo clippy --workspace --all-targets --all-features    # clean for this PR
```

## Notes

- No external network calls — the bridge only connects to loopback ports
  published by IDE host processes.
- `tokio-tungstenite` is added without TLS feature flags (loopback only).
- Auto-connect is best-effort: when no IDE is running, the worker parks
  silently after a failure ceiling and wakes on `reconnect()` after `cd`.
