### PR TITLE
feat(tui): add "Terminal" theme

### DIFF
--- a/crates/tui/src/palette.rs
+++ b/crates/tui/src/palette.rs
@@ -510,8 +510,13 @@ pub const TERMINAL_UI_THEME: UiTheme = UiTheme {
     footer_bg: Color::Reset,
     mode_agent: Color::Blue,
     mode_yolo: Color::Red,
-    mode_plan: Color::Yellow,
-    status_ready: Color::Reset,
+    // Magenta keeps Plan visually distinct from `status_warning` (yellow)
+    // so the mode indicator and warning chip don't collide on themes that
+    // render both in the status row.
+    mode_plan: Color::Magenta,
+    // DarkGray gives "Ready" a low-contrast but still distinguishable hue
+    // versus default body text (which is `Color::Reset` on this theme).
+    status_ready: Color::DarkGray,
     status_working: Color::Cyan,
     status_warning: Color::Yellow,
     text_dim: Color::Reset,

--- a/crates/tui/src/palette.rs
+++ b/crates/tui/src/palette.rs
@@ -1138,7 +1138,10 @@ fn grayscale_bg_from_luma(luma: u8) -> Color {
 }
 
 fn luma(r: u8, g: u8, b: u8) -> u8 {
-    (((u16::from(r) * 299) + (u16::from(g) * 587) + (u16::from(b) * 114)) / 1000) as u8
+    // Coefficients sum to 1000; an RGB triple of (255,255,255) yields
+    // 255 * 1000 = 255_000 which overflows u16 (max 65_535). Use u32 to
+    // hold the weighted sum, then divide back into the 0..=255 range.
+    (((u32::from(r) * 299) + (u32::from(g) * 587) + (u32::from(b) * 114)) / 1000) as u8
 }
 // === Color depth + brightness helpers (v0.6.6 UI redesign) ===
 

--- a/crates/tui/src/palette.rs
+++ b/crates/tui/src/palette.rs
@@ -489,6 +489,39 @@ pub const DRACULA_UI_THEME: UiTheme = UiTheme {
     border: Color::Rgb(0x44, 0x47, 0x5a),
 };
 
+/// "Terminal" theme: lets the host terminal's color scheme show through
+/// instead of painting any RGB surface. Backgrounds use `Color::Reset`
+/// (the terminal's own default bg) and most text uses `Color::Reset`
+/// (terminal's own default fg). Accents are ANSI named colors so they
+/// also inherit the user's terminal palette (Solarized, Nord, custom
+/// schemes, etc.) rather than DeepSeek brand RGB.
+pub const TERMINAL_UI_THEME: UiTheme = UiTheme {
+    name: "terminal",
+    // Mode is reported as Dark to avoid the dark→light cell remap kicking
+    // in; the terminal-theme cell remap already normalizes everything to
+    // `Color::Reset`, and we never want a second pass overwriting that.
+    mode: PaletteMode::Dark,
+    surface_bg: Color::Reset,
+    panel_bg: Color::Reset,
+    elevated_bg: Color::Reset,
+    composer_bg: Color::Reset,
+    selection_bg: Color::Reset,
+    header_bg: Color::Reset,
+    footer_bg: Color::Reset,
+    mode_agent: Color::Blue,
+    mode_yolo: Color::Red,
+    mode_plan: Color::Yellow,
+    status_ready: Color::Reset,
+    status_working: Color::Cyan,
+    status_warning: Color::Yellow,
+    text_dim: Color::Reset,
+    text_hint: Color::Reset,
+    text_muted: Color::Reset,
+    text_body: Color::Reset,
+    text_soft: Color::Reset,
+    border: Color::Reset,
+};
+
 pub const GRUVBOX_DARK_UI_THEME: UiTheme = UiTheme {
     name: "gruvbox-dark",
     mode: PaletteMode::Dark,
@@ -519,6 +552,7 @@ pub const GRUVBOX_DARK_UI_THEME: UiTheme = UiTheme {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ThemeId {
     System,
+    Terminal,
     Whale,
     WhaleLight,
     Grayscale,
@@ -536,6 +570,7 @@ impl ThemeId {
     pub fn from_name(value: &str) -> Option<Self> {
         match normalize_theme_name(value)? {
             "system" => Some(Self::System),
+            "terminal" => Some(Self::Terminal),
             "dark" => Some(Self::Whale),
             "light" => Some(Self::WhaleLight),
             "grayscale" => Some(Self::Grayscale),
@@ -553,6 +588,7 @@ impl ThemeId {
     pub const fn name(self) -> &'static str {
         match self {
             Self::System => "system",
+            Self::Terminal => "terminal",
             Self::Whale => "dark",
             Self::WhaleLight => "light",
             Self::Grayscale => "grayscale",
@@ -568,6 +604,7 @@ impl ThemeId {
     pub const fn display_name(self) -> &'static str {
         match self {
             Self::System => "System",
+            Self::Terminal => "Terminal",
             Self::Whale => "Whale (Dark)",
             Self::WhaleLight => "Whale Light",
             Self::Grayscale => "Grayscale",
@@ -583,6 +620,7 @@ impl ThemeId {
     pub const fn tagline(self) -> &'static str {
         match self {
             Self::System => "Follow terminal background (COLORFGBG / macOS appearance)",
+            Self::Terminal => "Inherit terminal colors fully (transparent surfaces, ANSI accents)",
             Self::Whale => "Default DeepSeek dark blue",
             Self::WhaleLight => "DeepSeek light, paper-ish",
             Self::Grayscale => "Color-minimal high contrast",
@@ -601,6 +639,7 @@ impl ThemeId {
     pub fn ui_theme(self) -> UiTheme {
         match self {
             Self::System => UiTheme::detect(),
+            Self::Terminal => TERMINAL_UI_THEME,
             Self::Whale => UI_THEME,
             Self::WhaleLight => LIGHT_UI_THEME,
             Self::Grayscale => GRAYSCALE_UI_THEME,
@@ -615,6 +654,7 @@ impl ThemeId {
 /// Themes shown in the `/theme` picker, in display order.
 pub const SELECTABLE_THEMES: &[ThemeId] = &[
     ThemeId::System,
+    ThemeId::Terminal,
     ThemeId::Whale,
     ThemeId::WhaleLight,
     ThemeId::Grayscale,
@@ -657,6 +697,7 @@ impl UiTheme {
 pub fn normalize_theme_name(value: &str) -> Option<&'static str> {
     match value.trim().to_ascii_lowercase().as_str() {
         "" | "auto" | "system" | "default" => Some("system"),
+        "terminal" | "term" | "transparent" | "follow-terminal" | "inherit" => Some("terminal"),
         "dark" | "whale" | "whale-dark" => Some("dark"),
         "light" | "whale-light" => Some("light"),
         "grayscale" | "greyscale" | "gray" | "grey" | "mono" | "monochrome" | "black-white"
@@ -806,6 +847,7 @@ fn adapt_bg_for_light_palette(color: Color) -> Color {
 #[must_use]
 const fn theme_green(theme: ThemeId) -> Color {
     match theme {
+        ThemeId::Terminal => Color::Green,
         ThemeId::CatppuccinMocha => Color::Rgb(0xa6, 0xe3, 0xa1),
         ThemeId::TokyoNight => Color::Rgb(0x9e, 0xce, 0x6a),
         ThemeId::Dracula => Color::Rgb(0x50, 0xfa, 0x7b),
@@ -818,6 +860,7 @@ const fn theme_green(theme: ThemeId) -> Color {
 #[must_use]
 const fn theme_red(theme: ThemeId) -> Color {
     match theme {
+        ThemeId::Terminal => Color::Red,
         ThemeId::CatppuccinMocha => Color::Rgb(0xf3, 0x8b, 0xa8),
         ThemeId::TokyoNight => Color::Rgb(0xf7, 0x76, 0x8e),
         ThemeId::Dracula => Color::Rgb(0xff, 0x55, 0x55),
@@ -830,6 +873,7 @@ const fn theme_red(theme: ThemeId) -> Color {
 #[must_use]
 const fn theme_diff_added_bg(theme: ThemeId) -> Color {
     match theme {
+        ThemeId::Terminal => Color::Reset,
         ThemeId::CatppuccinMocha => Color::Rgb(0x1f, 0x33, 0x29),
         ThemeId::TokyoNight => Color::Rgb(0x1b, 0x2b, 0x1f),
         ThemeId::Dracula => Color::Rgb(0x21, 0x3a, 0x2a),
@@ -842,6 +886,7 @@ const fn theme_diff_added_bg(theme: ThemeId) -> Color {
 #[must_use]
 const fn theme_diff_deleted_bg(theme: ThemeId) -> Color {
     match theme {
+        ThemeId::Terminal => Color::Reset,
         ThemeId::CatppuccinMocha => Color::Rgb(0x3a, 0x1f, 0x2a),
         ThemeId::TokyoNight => Color::Rgb(0x33, 0x1c, 0x24),
         ThemeId::Dracula => Color::Rgb(0x3a, 0x1f, 0x22),
@@ -858,7 +903,11 @@ const fn theme_diff_deleted_bg(theme: ThemeId) -> Color {
 pub const fn theme_remap_active(theme: ThemeId) -> bool {
     matches!(
         theme,
-        ThemeId::CatppuccinMocha | ThemeId::TokyoNight | ThemeId::Dracula | ThemeId::GruvboxDark
+        ThemeId::Terminal
+            | ThemeId::CatppuccinMocha
+            | ThemeId::TokyoNight
+            | ThemeId::Dracula
+            | ThemeId::GruvboxDark
     )
 }
 

--- a/crates/tui/src/tui/theme_picker.rs
+++ b/crates/tui/src/tui/theme_picker.rs
@@ -310,12 +310,13 @@ mod tests {
         let mut v = ThemePickerView::new("system".to_string());
         let action = v.handle_key(key(KeyCode::Down));
         assert!(matches!(action, ViewAction::Emit(_)));
-        assert_eq!(selected_name(&action), Some(ThemeId::Whale.name()));
+        assert_eq!(selected_name(&action), Some(ThemeId::Terminal.name()));
     }
 
     #[test]
     fn enter_commits_with_persist_true() {
         let mut v = ThemePickerView::new("system".to_string());
+        v.handle_key(key(KeyCode::Down));
         v.handle_key(key(KeyCode::Down));
         v.handle_key(key(KeyCode::Down));
         v.handle_key(key(KeyCode::Down));
@@ -358,8 +359,8 @@ mod tests {
     #[test]
     fn digit_jumps_to_row() {
         let mut v = ThemePickerView::new("system".to_string());
-        let action = v.handle_key(key(KeyCode::Char('5')));
-        // Row 5 (1-indexed) -> index 4 -> CatppuccinMocha
+        let action = v.handle_key(key(KeyCode::Char('6')));
+        // Row 6 (1-indexed) -> index 5 -> CatppuccinMocha
         assert_eq!(
             selected_name(&action),
             Some(ThemeId::CatppuccinMocha.name())


### PR DESCRIPTION
## Summary

This PR adds a new selectable theme **`terminal`** that lets the host terminal's color scheme show through the TUI completely (instead of painting any DeepSeek brand RGB), and fixes a pre-existing debug-build panic in the grayscale theme path that I tripped over while testing.

The two changes are in separate commits so either can be cherry-picked independently.

## Why

The existing `system` theme picks between two RGB themes (Whale dark / Whale Light) based on `COLORFGBG` / macOS appearance — that's helpful, but it still paints brand-colored RGB surfaces. Users with custom terminal palettes (Solarized, Nord, Gruvbox configured at the terminal level, transparent backgrounds, custom Ghostty / iTerm / Alacritty schemes, light-mode terminals that aren't quite the Whale Light beige…) had no way to make the TUI honor their terminal palette. The Whale Light surface (`#F6F8FB`) shows up as a near-white block over their carefully tuned theme.

The new `Terminal` theme paints **nothing**: every background is `Color::Reset` and most foregrounds are `Color::Reset` too, so the terminal's own bg/fg are what's visible. The few accents that semantically need a color (mode label, diff +/−, status_working) use ANSI named colors (`Color::Blue`, `Color::Red`, `Color::Yellow`, `Color::Cyan`, `Color::Green`) so they also inherit the user's terminal palette rather than DeepSeek brand RGB.

## Commit 1 — feat(tui): add "Terminal" theme

- New `TERMINAL_UI_THEME` const where every `*_bg` slot and most text slots are `Color::Reset`. Accents are ANSI named colors (Blue/Red/Yellow/Cyan).
- `ThemeId::Terminal` plumbed through `from_name`, `name`, `display_name`, `tagline`, `ui_theme`, `SELECTABLE_THEMES`. Aliases registered in `normalize_theme_name`: `term`, `transparent`, `follow-terminal`, `inherit`.
- `theme_remap_active(Terminal) → true` so `ColorCompatBackend`'s per-cell remap rewrites every hard-coded palette constant (`DEEPSEEK_INK`, `DEEPSEEK_SLATE`, `BORDER_COLOR`, `TEXT_BODY`, …) to `Color::Reset`. Without this, the dozens of render sites that reach for the named palette constants directly would still paint brand RGB.
- `theme_green`, `theme_red`, `theme_diff_added_bg`, `theme_diff_deleted_bg` get a `ThemeId::Terminal` arm so diff highlighting still reads as +/− but follows the user's terminal palette.
- Inserted as the second entry in `SELECTABLE_THEMES` (right after System) so it surfaces prominently in the `/theme` picker.

The default (`theme = "system"`) is unchanged. Existing users see no difference until they opt in via `/theme` or `theme = "terminal"` in `settings.toml`.

### Why `PaletteMode::Dark`?

`TERMINAL_UI_THEME.mode` is set to `PaletteMode::Dark` even though the theme is palette-neutral. This avoids the dark→light cell remap kicking in on top of the Terminal cell remap; the Terminal remap already normalizes everything to `Color::Reset`, and a second pass would either be a no-op or risk overwriting it. There's a comment to that effect on the const.

### Test fallout

Inserting `Terminal` in row 2 of `SELECTABLE_THEMES` shifts indices three existing tests rely on — `arrow_down_previews_next_theme`, `enter_commits_with_persist_true`, `digit_jumps_to_row` — so those expectations are updated to match the new ordering. No production behavior change in those tests, just index arithmetic.

## Commit 2 — fix(tui): widen `luma()` accumulator to u32

While testing the Terminal theme I tripped a separate, pre-existing bug. Opening `/theme` and previewing **Grayscale** on a cell carrying a bright RGB color in a debug build panics:

```
thread '...' panicked at crates/tui/src/palette.rs:1141:7:
attempt to add with overflow
```

Path: `adapt_*_for_grayscale_palette → grayscale_*_from_luma → luma()`. The accumulator was `u16`, but `r*299 + g*587 + b*114` reaches `255 * 1000 = 255_000` for white — far above `u16::MAX = 65_535`. Release builds wrap silently (so on `--release` the function silently returned a wrong luma instead of panicking, which is its own correctness issue).

Fix: hold the weighted sum in `u32`. The result still divides by 1000 and casts back to `u8`, so the public contract is bit-identical for all non-overflowing inputs and now correct for inputs that previously overflowed.

No test added because `luma` is private and any RGB above the previous overflow threshold trivially exercises it through the existing grayscale code paths — the existing grayscale tests pass with the new arithmetic.

## Backwards compatibility

- Default theme unchanged.
- Existing settings strings (`system`, `dark`, `light`, `grayscale`, etc.) all still parse to the same `ThemeId` they did before.
- All existing `UiTheme` consts and palette functions are unchanged.
- The `ThemeId` enum gained one variant; any external matcher would need an arm, but `ThemeId` is internal to this crate.
- Tests: `cargo test -p deepseek-tui --bin deepseek-tui` → 3149 passed / 0 failed / 3 ignored locally on macOS Apple Silicon, debug.

## How to try it

```toml
# ~/.config/deepseek/settings.toml
theme = "terminal"
```

Or open the TUI and run `/theme`, then arrow-key down to **Terminal** (second row).

## Files changed

- `crates/tui/src/palette.rs` — new theme, enum/picker plumbing, `luma` overflow fix
- `crates/tui/src/tui/theme_picker.rs` — index updates in three tests for the new selector ordering
