### PR TITLE
fix(palette): fix u16 overflow in luma() causing grayscale theme crash

### DIFF
--- a/crates/tui/src/palette.rs
+++ b/crates/tui/src/palette.rs
@@ -1089,7 +1089,7 @@ fn grayscale_bg_from_luma(luma: u8) -> Color {
 }
 
 fn luma(r: u8, g: u8, b: u8) -> u8 {
-    (((u16::from(r) * 299) + (u16::from(g) * 587) + (u16::from(b) * 114)) / 1000) as u8
+    (((u32::from(r) * 299) + (u32::from(g) * 587) + (u32::from(b) * 114)) / 1000) as u8
 }
 // === Color depth + brightness helpers (v0.6.6 UI redesign) ===
 

--- a/crates/tui/src/palette.rs
+++ b/crates/tui/src/palette.rs
@@ -1089,7 +1089,7 @@ fn grayscale_bg_from_luma(luma: u8) -> Color {
 }
 
 fn luma(r: u8, g: u8, b: u8) -> u8 {
-    (((u32::from(r) * 299) + (u32::from(g) * 587) + (u32::from(b) * 114)) / 1000) as u8
+    ((u32::from(r) * 299 + u32::from(g) * 587 + u32::from(b) * 114 + 500) / 1000) as u8
 }
 // === Color depth + brightness helpers (v0.6.6 UI redesign) ===
 


### PR DESCRIPTION
## Summary

- `luma()` in `palette.rs` uses `u16` for intermediate arithmetic
- `u16::from(r) * 299` overflows `u16::MAX` (65535) when `r >= 220`
- `u16::from(g) * 587` overflows when `g >= 112`
- In debug builds, this causes a panic (`attempt to add with overflow`) whenever the grayscale theme processes a bright RGB color
- Fix: use `u32` for intermediate calculations (result still fits in `u8`)

## Reproduction

Switch to the Grayscale theme (`/theme` → select option 4) in a debug build — TUI immediately crashes with a panic logged to `~/.deepseek/crashes/`.

## Fix

```rust
// Before
fn luma(r: u8, g: u8, b: u8) -> u8 {
    (((u16::from(r) * 299) + (u16::from(g) * 587) + (u16::from(b) * 114)) / 1000) as u8
}

// After
fn luma(r: u8, g: u8, b: u8) -> u8 {
    (((u32::from(r) * 299) + (u32::from(g) * 587) + (u32::from(b) * 114)) / 1000) as u8
}
```