### PR TITLE
fix(tui): enhance sub-agent file write permissions and approval handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Approved sub-agents can write files in delegated roles.** `general` and
+  `implementer` children now inherit approved `Suggest` file-write tools after
+  `agent_open`, `approval_mode=auto` consistently reaches child tool contexts,
+  and repeated approval blocks fail fast instead of spinning (#1828).
 - **Feishu/Lark bridge startup order is guarded.** The bridge now keeps
   `ThreadStore` initialized before startup opens persisted thread state, with a
   regression test to prevent moving it below its first use.

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -973,8 +973,9 @@ impl Engine {
         self.session.trust_mode = trust_mode;
         self.config.trust_mode = trust_mode;
         self.config.translation_enabled = translation_enabled;
-        self.session.auto_approve = auto_approve;
-        self.session.approval_mode = if auto_approve {
+        let effective_auto_approve = effective_auto_approve(auto_approve, approval_mode);
+        self.session.auto_approve = effective_auto_approve;
+        self.session.approval_mode = if effective_auto_approve {
             crate::tui::approval::ApprovalMode::Auto
         } else {
             approval_mode
@@ -988,7 +989,7 @@ impl Engine {
         let todo_list = self.config.todos.clone();
         let plan_state = self.config.plan_state.clone();
 
-        let tool_context = self.build_tool_context(mode, auto_approve);
+        let tool_context = self.build_tool_context(mode, effective_auto_approve);
         let builder = self.build_turn_tool_registry_builder(mode, todo_list, plan_state);
 
         let fork_context_for_runtime = if self.config.features.enabled(Feature::Subagents) {
@@ -1985,6 +1986,13 @@ use self::tool_catalog::{
 use self::tool_execution::emit_tool_audit;
 use self::tool_setup::sandbox_policy_for_mode;
 use crate::tools::js_execution::execute_js_execution_tool;
+
+fn effective_auto_approve(
+    auto_approve: bool,
+    approval_mode: crate::tui::approval::ApprovalMode,
+) -> bool {
+    auto_approve || approval_mode == crate::tui::approval::ApprovalMode::Auto
+}
 
 #[cfg(test)]
 mod tests;

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -769,6 +769,22 @@ fn agent_mode_can_build_auto_approved_tool_context() {
 }
 
 #[test]
+fn approval_mode_auto_promotes_effective_auto_approve() {
+    assert!(!effective_auto_approve(
+        false,
+        crate::tui::approval::ApprovalMode::Suggest
+    ));
+    assert!(effective_auto_approve(
+        false,
+        crate::tui::approval::ApprovalMode::Auto
+    ));
+    assert!(effective_auto_approve(
+        true,
+        crate::tui::approval::ApprovalMode::Suggest
+    ));
+}
+
+#[test]
 fn agent_and_yolo_modes_elevate_shell_sandbox_to_allow_network() {
     // Regression for #273: the seatbelt-default policy denies all outbound
     // network (including DNS), which broke `curl`, `yt-dlp`, package managers,

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -69,6 +69,7 @@ const TOOL_TIMEOUT: Duration = Duration::from_secs(30);
 /// stuck API call from blocking the sub-agent indefinitely.
 const STEP_API_TIMEOUT: Duration = Duration::from_secs(120);
 const RESULT_POLL_INTERVAL: Duration = Duration::from_millis(250);
+const APPROVAL_BLOCK_FAIL_FAST_THRESHOLD: u32 = 3;
 const DEFAULT_RESULT_TIMEOUT_MS: u64 = 30_000;
 #[allow(dead_code)] // Legacy agent_wait clamp; new agent_eval uses DEFAULT/MAX.
 const MIN_WAIT_TIMEOUT_MS: u64 = 10_000;
@@ -1734,6 +1735,7 @@ impl ToolSpec for AgentOpenTool {
             "Use agent_eval to fetch or wait on the session, and agent_close to cancel/close it.\n\n",
             "Context control is explicit: omit fork_context or set it false for a fresh child with an independent prefill; set fork_context=true for perspective fanout over the current parent context. ",
             "Forked children preserve the parent system prompt and leading message prefix byte-identically where the runtime has that prefix, so DeepSeek can reuse its prefix cache before the child-specific task is appended.\n\n",
+            "Approving agent_open delegates workspace file-write tools to general and implementer children; explore, plan, review, and verifier children remain read-only unless the parent session is auto-approved.\n\n",
             "Sub-agent results are self-reports. Re-verify claimed side effects such as file edits, commands, network writes, tests, or git operations before reporting them as facts."
         )
     }
@@ -3318,9 +3320,11 @@ async fn run_subagent(
         messages: messages.clone(),
         structured_state_block: None,
     });
+    let delegated_suggest_writes = delegated_suggest_writes(&agent_type, &allowed_tools);
     let tool_registry = SubAgentToolRegistry::new(
         runtime_for_tools,
         allowed_tools.clone(),
+        delegated_suggest_writes,
         Arc::new(Mutex::new(TodoList::new())),
         Arc::new(Mutex::new(PlanState::default())),
     );
@@ -3345,6 +3349,7 @@ async fn run_subagent(
     let mut steps = 0;
     let mut final_result: Option<String> = None;
     let mut pending_inputs: VecDeque<SubAgentInput> = VecDeque::new();
+    let mut approval_block_streak = 0;
 
     for _step in 0..max_steps {
         // Cooperative cancellation: bail if the parent (or root) cancelled
@@ -3562,6 +3567,48 @@ async fn run_subagent(
                     tool_name: tool_name.clone(),
                     step: steps,
                     ok: tool_ok,
+                });
+            }
+
+            if is_subagent_approval_block(&result) {
+                approval_block_streak += 1;
+            } else {
+                approval_block_streak = 0;
+            }
+
+            if approval_block_streak >= APPROVAL_BLOCK_FAIL_FAST_THRESHOLD {
+                let blocker = format!(
+                    "BLOCKERS: sub-agent hit {approval_block_streak} consecutive approval blocks. \
+                     Use a general/implementer child for delegated file writes, or switch the parent \
+                     session to auto approval for required tools."
+                );
+                emit_agent_progress(
+                    runtime.event_tx.as_ref(),
+                    runtime.mailbox.as_ref(),
+                    &agent_id,
+                    format!("step {steps}/{max_steps}: failed after repeated approval blocks"),
+                );
+                release_resident_leases_for(&agent_id);
+                return Ok(SubAgentResult {
+                    name: agent_id.clone(),
+                    agent_id: agent_id.clone(),
+                    context_mode: if fork_context_enabled {
+                        "forked"
+                    } else {
+                        "fresh"
+                    }
+                    .to_string(),
+                    fork_context: fork_context_enabled,
+                    agent_type: agent_type.clone(),
+                    assignment: assignment.clone(),
+                    model: runtime.model.clone(),
+                    nickname: None,
+                    status: SubAgentStatus::Failed(blocker.clone()),
+                    result: Some(blocker),
+                    steps_taken: steps,
+                    duration_ms: u64::try_from(started_at.elapsed().as_millis())
+                        .unwrap_or(u64::MAX),
+                    from_prior_session: false,
                 });
             }
 
@@ -4297,6 +4344,42 @@ fn emit_agent_progress(
 
 // === Tool Registry Helpers ===
 
+fn delegated_suggest_writes(
+    agent_type: &SubAgentType,
+    allowed_tools: &Option<Vec<String>>,
+) -> bool {
+    match agent_type {
+        SubAgentType::General | SubAgentType::Implementer => true,
+        SubAgentType::Custom => allowed_tools
+            .as_ref()
+            .is_some_and(|tools| tools.iter().any(|name| is_delegated_write_tool(name))),
+        SubAgentType::Explore
+        | SubAgentType::Plan
+        | SubAgentType::Review
+        | SubAgentType::Verifier => false,
+    }
+}
+
+fn is_delegated_write_tool(name: &str) -> bool {
+    matches!(name, "write_file" | "edit_file" | "apply_patch")
+}
+
+fn subagent_tool_allowed(
+    auto_approve: bool,
+    delegated_suggest_writes: bool,
+    req: ApprovalRequirement,
+) -> bool {
+    match req {
+        ApprovalRequirement::Auto => true,
+        ApprovalRequirement::Suggest => auto_approve || delegated_suggest_writes,
+        ApprovalRequirement::Required => auto_approve,
+    }
+}
+
+fn is_subagent_approval_block(result: &str) -> bool {
+    result.starts_with("Error:") && result.contains("requires approval")
+}
+
 /// Per-sub-agent tool registry.
 ///
 /// Two modes:
@@ -4312,6 +4395,7 @@ struct SubAgentToolRegistry {
     /// only the listed tools are visible to the model and callable.
     allowed_tools: Option<Vec<String>>,
     auto_approve: bool,
+    delegated_suggest_writes: bool,
     registry: ToolRegistry,
 }
 
@@ -4319,6 +4403,7 @@ impl SubAgentToolRegistry {
     fn new(
         runtime: SubAgentRuntime,
         explicit_allowed_tools: Option<Vec<String>>,
+        delegated_suggest_writes: bool,
         todo_list: SharedTodoList,
         plan_state: SharedPlanState,
     ) -> Self {
@@ -4342,6 +4427,7 @@ impl SubAgentToolRegistry {
         Self {
             allowed_tools: explicit_allowed_tools,
             auto_approve: runtime.context.auto_approve,
+            delegated_suggest_writes,
             registry,
         }
     }
@@ -4394,21 +4480,30 @@ impl SubAgentToolRegistry {
         if !self.is_tool_allowed(name) {
             return Err(anyhow!("Tool {name} not allowed for this sub-agent"));
         }
-        if !self.auto_approve {
-            let Some(spec) = self.registry.get(name) else {
-                return Err(anyhow!("Tool {name} is not registered"));
-            };
-            if spec.approval_requirement() != ApprovalRequirement::Auto {
-                return Err(anyhow!(
-                    "Tool {name} requires approval and cannot run inside this sub-agent unless the parent session is auto-approved"
-                ));
-            }
+        let Some(spec) = self.registry.get(name) else {
+            return Err(anyhow!("Tool {name} is not registered"));
+        };
+        let req = spec.approval_requirement();
+        if !subagent_tool_allowed(self.auto_approve, self.delegated_suggest_writes, req) {
+            return Err(anyhow!("{}", subagent_approval_error(name, req)));
         }
         reject_subagent_terminal_takeover(name, &input)?;
         self.registry
             .execute(name, input)
             .await
             .map_err(|e| anyhow!(e))
+    }
+}
+
+fn subagent_approval_error(name: &str, req: ApprovalRequirement) -> String {
+    match req {
+        ApprovalRequirement::Suggest => format!(
+            "Tool {name} requires approval and this sub-agent role is not delegated to run file-write tools"
+        ),
+        ApprovalRequirement::Required => format!(
+            "Tool {name} requires approval and cannot run inside this sub-agent unless the parent session is auto-approved"
+        ),
+        ApprovalRequirement::Auto => format!("Tool {name} is unexpectedly blocked"),
     }
 }
 

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -682,6 +682,7 @@ fn test_subagent_tool_registry_reports_unavailable_tools() {
     let registry = SubAgentToolRegistry::new(
         runtime,
         Some(vec!["read_file".to_string(), "missing_tool".to_string()]),
+        false,
         Arc::new(Mutex::new(TodoList::new())),
         Arc::new(Mutex::new(PlanState::default())),
     );
@@ -700,6 +701,7 @@ fn test_review_agent_tools_exclude_agent_spawn() {
     let registry = SubAgentToolRegistry::new(
         runtime,
         None,
+        false,
         Arc::new(Mutex::new(TodoList::new())),
         Arc::new(Mutex::new(PlanState::default())),
     );
@@ -709,6 +711,59 @@ fn test_review_agent_tools_exclude_agent_spawn() {
         !names.contains(&"agent_spawn"),
         "Review agent must not have agent_spawn; tools: {names:?}"
     );
+}
+
+#[test]
+fn delegated_suggest_writes_are_limited_to_write_roles() {
+    assert!(delegated_suggest_writes(&SubAgentType::General, &None));
+    assert!(delegated_suggest_writes(&SubAgentType::Implementer, &None));
+
+    for agent_type in [
+        SubAgentType::Explore,
+        SubAgentType::Plan,
+        SubAgentType::Review,
+        SubAgentType::Verifier,
+    ] {
+        assert!(
+            !delegated_suggest_writes(&agent_type, &None),
+            "{agent_type:?} should not inherit delegated write approval"
+        );
+    }
+
+    assert!(delegated_suggest_writes(
+        &SubAgentType::Custom,
+        &Some(vec!["read_file".to_string(), "write_file".to_string()])
+    ));
+    assert!(!delegated_suggest_writes(
+        &SubAgentType::Custom,
+        &Some(vec!["read_file".to_string()])
+    ));
+}
+
+#[test]
+fn subagent_tool_allowed_delegates_suggest_but_not_required() {
+    use crate::tools::spec::ApprovalRequirement;
+
+    assert!(subagent_tool_allowed(
+        false,
+        false,
+        ApprovalRequirement::Auto
+    ));
+    assert!(subagent_tool_allowed(
+        false,
+        true,
+        ApprovalRequirement::Suggest
+    ));
+    assert!(!subagent_tool_allowed(
+        false,
+        true,
+        ApprovalRequirement::Required
+    ));
+    assert!(subagent_tool_allowed(
+        true,
+        false,
+        ApprovalRequirement::Required
+    ));
 }
 
 #[tokio::test]
@@ -1153,6 +1208,7 @@ async fn subagent_registry_blocks_approval_tools_without_parent_auto_approve() {
     let registry = SubAgentToolRegistry::new(
         runtime,
         Some(vec!["exec_shell".to_string()]),
+        false,
         Arc::new(Mutex::new(TodoList::new())),
         Arc::new(Mutex::new(PlanState::default())),
     );
@@ -1166,6 +1222,75 @@ async fn subagent_registry_blocks_approval_tools_without_parent_auto_approve() {
         err.to_string().contains("requires approval"),
         "unexpected error: {err}"
     );
+}
+
+#[tokio::test]
+async fn implementer_delegation_allows_suggest_write_file_without_parent_auto_approve() {
+    let tmp = tempdir().expect("tempdir");
+    let mut runtime = stub_runtime();
+    runtime.context = ToolContext::new(tmp.path().to_path_buf());
+    runtime.context.auto_approve = false;
+    let registry = SubAgentToolRegistry::new(
+        runtime,
+        Some(vec!["write_file".to_string()]),
+        true,
+        Arc::new(Mutex::new(TodoList::new())),
+        Arc::new(Mutex::new(PlanState::default())),
+    );
+
+    registry
+        .execute(
+            "agent_test",
+            "write_file",
+            json!({"path": "delegated.txt", "content": "ok"}),
+        )
+        .await
+        .expect("delegated Suggest file write should run");
+
+    let written = std::fs::read_to_string(tmp.path().join("delegated.txt")).expect("written file");
+    assert_eq!(written, "ok");
+}
+
+#[tokio::test]
+async fn non_delegated_subagent_blocks_suggest_write_file() {
+    let tmp = tempdir().expect("tempdir");
+    let mut runtime = stub_runtime();
+    runtime.context = ToolContext::new(tmp.path().to_path_buf());
+    runtime.context.auto_approve = false;
+    let registry = SubAgentToolRegistry::new(
+        runtime,
+        Some(vec!["write_file".to_string()]),
+        false,
+        Arc::new(Mutex::new(TodoList::new())),
+        Arc::new(Mutex::new(PlanState::default())),
+    );
+
+    let err = registry
+        .execute(
+            "agent_test",
+            "write_file",
+            json!({"path": "blocked.txt", "content": "no"}),
+        )
+        .await
+        .expect_err("non-delegated Suggest file write should be blocked");
+
+    assert!(
+        err.to_string().contains("requires approval"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn approval_block_detection_requires_error_prefix_and_approval_text() {
+    assert!(is_subagent_approval_block(
+        "Error: Tool write_file requires approval and cannot run inside this sub-agent"
+    ));
+    assert!(!is_subagent_approval_block(
+        "Tool write_file requires approval but this is model text"
+    ));
+    assert!(!is_subagent_approval_block(
+        "Error: Tool write_file timed out"
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Fixes #1828 by allowing approved `general` and `implementer` sub-agents to run delegated `Suggest` file-write tools after `agent_open`.
- Keeps `Required` tools, including shell execution, gated behind parent auto-approval/YOLO mode.
- Aligns `approval_mode=auto` with child `ToolContext.auto_approve` and fails fast after repeated approval-block errors.

## Testing

- [ ] `cargo test --all-features`
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets --all-features`

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes