### PR TITLE
  feat(update): add version check output to doctor and update

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -202,7 +202,14 @@ The command prints the completion script to stdout; redirect it to a path your s
     /// Print a usage rollup from the audit log and session store.
     Metrics(MetricsArgs),
     /// Check for and apply updates to the `deepseek` binary.
-    Update,
+    Update(UpdateArgs),
+}
+
+#[derive(Debug, Args)]
+struct UpdateArgs {
+    /// Only check the latest release; do not download or replace binaries.
+    #[arg(long)]
+    check: bool,
 }
 
 #[derive(Debug, Args)]
@@ -523,7 +530,7 @@ fn run() -> Result<()> {
             Ok(())
         }
         Some(Commands::Metrics(args)) => run_metrics_command(args),
-        Some(Commands::Update) => update::run_update(),
+        Some(Commands::Update(args)) => update::run_update(args.check),
         None => {
             let resolved_runtime = resolve_runtime_for_dispatch(&mut store, &runtime_overrides);
             let mut forwarded = Vec::new();

--- a/crates/cli/src/update.rs
+++ b/crates/cli/src/update.rs
@@ -5,6 +5,7 @@
 //! platform-correct binary, verifies its SHA256 checksum, and atomically
 //! replaces the currently running binary.
 
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
@@ -21,7 +22,7 @@ const LEGACY_UPDATE_VERSION_ENV: &str = "DEEPSEEK_VERSION";
 const UPDATE_USER_AGENT: &str = "deepseek-tui-updater";
 
 /// Run the self-update workflow.
-pub fn run_update() -> Result<()> {
+pub fn run_update(check_only: bool) -> Result<()> {
     let current_exe =
         std::env::current_exe().context("failed to determine current executable path")?;
     let targets = update_targets_for_exe(&current_exe);
@@ -32,7 +33,24 @@ pub fn run_update() -> Result<()> {
     // Step 1: Fetch latest release metadata
     let release = fetch_latest_release().with_context(update_network_fallback_hint)?;
     let latest_tag = &release.tag_name;
+    let current_version = env!("CARGO_PKG_VERSION");
+    println!("Current version: v{current_version}");
     println!("Latest release: {latest_tag}");
+
+    if check_only {
+        match compare_release_versions(current_version, latest_tag) {
+            Ordering::Less => {
+                println!("Update available. Run `deepseek update` to install {latest_tag}.");
+            }
+            Ordering::Equal => {
+                println!("Already up to date.");
+            }
+            Ordering::Greater => {
+                println!("Current build is newer than the latest published release.");
+            }
+        }
+        return Ok(());
+    }
 
     // Step 2: Download the aggregated SHA256 checksum manifest if available
     let checksum_manifest = match select_checksum_manifest_asset(&release) {
@@ -323,6 +341,24 @@ fn update_version_from_env() -> Option<String> {
         .or_else(|| std::env::var(LEGACY_UPDATE_VERSION_ENV).ok())
         .map(|value| value.trim().trim_start_matches('v').to_string())
         .filter(|value| !value.is_empty())
+}
+
+fn compare_release_versions(current: &str, latest_tag: &str) -> Ordering {
+    parse_version_components(current).cmp(&parse_version_components(latest_tag))
+}
+
+fn parse_version_components(version: &str) -> Vec<u64> {
+    let trimmed = version.trim().trim_start_matches('v');
+    let core = trimmed.split(['-', '+', ' ']).next().unwrap_or(trimmed);
+    core.split('.')
+        .map(|part| {
+            part.chars()
+                .take_while(|ch| ch.is_ascii_digit())
+                .collect::<String>()
+                .parse::<u64>()
+                .unwrap_or(0)
+        })
+        .collect()
 }
 
 fn release_from_mirror_base_url(
@@ -820,6 +856,22 @@ E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855  *deepseek-wind
         assert!(
             select_platform_asset(&release, "deepseek-tui-windows-x64")
                 .is_some_and(|asset| asset.name == "deepseek-tui-windows-x64.exe")
+        );
+    }
+
+    #[test]
+    fn release_version_compare_ignores_v_prefix_and_build_sha() {
+        assert_eq!(
+            compare_release_versions("0.8.39 (eeccf7d)", "v0.8.39"),
+            std::cmp::Ordering::Equal
+        );
+        assert_eq!(
+            compare_release_versions("0.8.39", "v0.8.40"),
+            std::cmp::Ordering::Less
+        );
+        assert_eq!(
+            compare_release_versions("0.8.40", "v0.8.39"),
+            std::cmp::Ordering::Greater
         );
     }
 

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -1431,6 +1431,84 @@ fn skills_count_for(dir: &Path) -> usize {
     crate::skills::SkillRegistry::discover(dir).len()
 }
 
+const DOCTOR_LATEST_RELEASE_URL: &str =
+    "https://api.github.com/repos/Hmbown/DeepSeek-TUI/releases/latest";
+const DOCTOR_RELEASE_BASE_URL_ENV: &str = "DEEPSEEK_TUI_RELEASE_BASE_URL";
+const DOCTOR_LEGACY_RELEASE_BASE_URL_ENV: &str = "DEEPSEEK_RELEASE_BASE_URL";
+const DOCTOR_UPDATE_VERSION_ENV: &str = "DEEPSEEK_TUI_VERSION";
+const DOCTOR_LEGACY_UPDATE_VERSION_ENV: &str = "DEEPSEEK_VERSION";
+const DOCTOR_UPDATE_USER_AGENT: &str = "deepseek-tui-doctor";
+
+#[derive(serde::Deserialize)]
+struct DoctorRelease {
+    tag_name: String,
+}
+
+async fn doctor_latest_release_tag() -> Result<String> {
+    if doctor_release_base_url_from_env().is_some() {
+        let version =
+            doctor_update_version_from_env().unwrap_or_else(|| env!("CARGO_PKG_VERSION").into());
+        return Ok(format!("v{}", version.trim_start_matches('v')));
+    }
+
+    let client = reqwest::Client::builder()
+        .user_agent(DOCTOR_UPDATE_USER_AGENT)
+        .timeout(std::time::Duration::from_secs(5))
+        .build()
+        .context("failed to build release check HTTP client")?;
+    let response = client
+        .get(DOCTOR_LATEST_RELEASE_URL)
+        .header(reqwest::header::ACCEPT, "application/vnd.github+json")
+        .send()
+        .await
+        .context("failed to fetch latest GitHub release")?;
+    let status = response.status();
+    let body = response
+        .text()
+        .await
+        .context("failed to read latest release response")?;
+    if !status.is_success() {
+        bail!("GitHub release request failed with HTTP {status}");
+    }
+    let release: DoctorRelease =
+        serde_json::from_str(&body).context("failed to parse latest release response")?;
+    Ok(release.tag_name)
+}
+
+fn doctor_release_base_url_from_env() -> Option<String> {
+    std::env::var(DOCTOR_RELEASE_BASE_URL_ENV)
+        .ok()
+        .or_else(|| std::env::var(DOCTOR_LEGACY_RELEASE_BASE_URL_ENV).ok())
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn doctor_update_version_from_env() -> Option<String> {
+    std::env::var(DOCTOR_UPDATE_VERSION_ENV)
+        .ok()
+        .or_else(|| std::env::var(DOCTOR_LEGACY_UPDATE_VERSION_ENV).ok())
+        .map(|value| value.trim().trim_start_matches('v').to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn compare_release_versions(current: &str, latest_tag: &str) -> std::cmp::Ordering {
+    parse_version_components(current).cmp(&parse_version_components(latest_tag))
+}
+
+fn parse_version_components(version: &str) -> Vec<u64> {
+    let trimmed = version.trim().trim_start_matches('v');
+    let core = trimmed.split(['-', '+', ' ']).next().unwrap_or(trimmed);
+    core.split('.')
+        .map(|part| {
+            part.chars()
+                .take_while(|ch| ch.is_ascii_digit())
+                .collect::<String>()
+                .parse::<u64>()
+                .unwrap_or(0)
+        })
+        .collect()
+}
+
 fn run_setup_status(config: &Config, workspace: &Path) -> Result<()> {
     use crate::palette;
     use colored::Colorize;
@@ -1670,6 +1748,39 @@ async fn run_doctor(config: &Config, workspace: &Path, config_path_override: Opt
     println!("{}", "Version Information:".bold());
     println!("  deepseek-tui: {}", env!("DEEPSEEK_BUILD_VERSION"));
     println!("  rust: {}", rustc_version());
+    println!();
+
+    println!("{}", "Updates:".bold());
+    println!("  · current: v{}", env!("CARGO_PKG_VERSION"));
+    match doctor_latest_release_tag().await {
+        Ok(latest_tag) => {
+            let icon = match compare_release_versions(env!("CARGO_PKG_VERSION"), &latest_tag) {
+                std::cmp::Ordering::Less => "!".truecolor(sky_r, sky_g, sky_b),
+                std::cmp::Ordering::Equal => "✓".truecolor(aqua_r, aqua_g, aqua_b),
+                std::cmp::Ordering::Greater => "·".dimmed(),
+            };
+            println!("  {} latest: {}", icon, latest_tag);
+            match compare_release_versions(env!("CARGO_PKG_VERSION"), &latest_tag) {
+                std::cmp::Ordering::Less => {
+                    println!("    Update available. Run `deepseek update` to install.");
+                }
+                std::cmp::Ordering::Equal => {
+                    println!("    Already up to date.");
+                }
+                std::cmp::Ordering::Greater => {
+                    println!("    Current build is newer than the latest published release.");
+                }
+            }
+        }
+        Err(err) => {
+            println!(
+                "  {} latest release check failed: {}",
+                "!".truecolor(sky_r, sky_g, sky_b),
+                err
+            );
+            println!("    Run `deepseek update --check` to retry.");
+        }
+    }
     println!();
 
     // Configuration summary
@@ -5012,6 +5123,22 @@ async fn run_exec_agent(
 #[cfg(test)]
 mod doctor_endpoint_tests {
     use super::*;
+
+    #[test]
+    fn release_version_compare_ignores_v_prefix_and_build_sha() {
+        assert_eq!(
+            compare_release_versions("0.8.39 (eeccf7d)", "v0.8.39"),
+            std::cmp::Ordering::Equal
+        );
+        assert_eq!(
+            compare_release_versions("0.8.39", "v0.8.40"),
+            std::cmp::Ordering::Less
+        );
+        assert_eq!(
+            compare_release_versions("0.8.40", "v0.8.39"),
+            std::cmp::Ordering::Greater
+        );
+    }
 
     #[test]
     fn doctor_api_target_reports_default_endpoint() {


### PR DESCRIPTION


## Summary

  Adds a lightweight way to check whether the installed binary is current.

 Before this change, `deepseek update` could perform an update, but there was no check-only path, and `deepseek doctor` did not report whether a newer release was available. This made it harder for users to confirm whether local issues might already be fixed in a newer version.

  This PR adds:

  - `deepseek update --check` to report the current version and latest release without downloading or replacing binaries
  - an `Updates` section in `deepseek doctor`
  - version comparison that handles `v0.8.x`, `0.8.x`, and build suffixes like `0.8.x (commit)`
  - async release checking in doctor so diagnostics continue to run normally inside the TUI runtime

```
deepseek doctor
DeepSeek TUI Doctor
==================

Version Information:
  deepseek-tui: 0.8.39 (eeccf7de6c3b)
  rust: rustc 1.93.1 (01f6ddf75 2026-02-11)

Updates:
  · current: v0.8.39
  ✓ latest: v0.8.39
    Already up to date.
....



deepseek update --check
Checking for updates...
Current binary: /home/reid/github/DeepSeek-TUI/target/debug/deepseek
Current version: v0.8.39
Latest release: v0.8.39
Already up to date.

```

## Testing

- [x] `cargo test --all-features`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
