### PR TITLE
fix: 修复 macOS 终端标题悬浮居中，改为贴顶布局

### DIFF
--- a/crates/tui/src/tui/onboarding/mod.rs
+++ b/crates/tui/src/tui/onboarding/mod.rs
@@ -22,11 +22,12 @@ pub fn render(f: &mut Frame, area: Rect, app: &App) {
     let block = Block::default().style(Style::default().bg(palette::DEEPSEEK_INK));
     f.render_widget(block, area);
 
+    const TOP_MARGIN: u16 = 2;
     let content_width = 76.min(area.width.saturating_sub(4));
-    let content_height = 20.min(area.height.saturating_sub(4));
+    let content_height = 20.min(area.height.saturating_sub(TOP_MARGIN + 2));
     let content_area = Rect {
-        x: (area.width - content_width) / 2,
-        y: (area.height - content_height) / 2,
+        x: (area.width.saturating_sub(content_width)) / 2,
+        y: TOP_MARGIN,
         width: content_width,
         height: content_height,
     };

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -1940,7 +1940,8 @@ fn build_empty_state_lines(app: &App, area: Rect) -> Vec<Line<'static>> {
         )),
     ];
 
-    let top_padding = usize::from(area.height.saturating_sub(body.len() as u16) / 3);
+    // Keep the welcome block near the top of the chat pane (header is separate).
+    let top_padding = 2usize;
     let mut lines = Vec::new();
     for _ in 0..top_padding {
         lines.push(Line::from(""));


### PR DESCRIPTION
修复了macOS终端中标题垂直居中悬浮的UI缺陷，修改内容如下：
1.  调整标题组件的垂直对齐方式，强制贴顶布局
2.  优化窗口分块比例，标题区域固定在顶部

关联Issue: #1834 
