### PR TITLE
feat: force English reasoning_content when show_thinking is off

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -99,6 +99,10 @@ pub struct EngineConfig {
     /// When true, the model is instructed to respond in the current locale
     /// and a post-hoc translation layer replaces remaining English output.
     pub translation_enabled: bool,
+    /// When false, thinking blocks are hidden in the TUI. Propagated to the
+    /// system prompt builder so `reasoning_content` stays in English (saving
+    /// tokens) while the final reply still matches the user's language.
+    pub show_thinking: bool,
     /// Maximum number of assistant steps before stopping.
     pub max_steps: u32,
     /// Maximum number of concurrently active subagents.
@@ -181,6 +185,7 @@ impl Default for EngineConfig {
             instructions: Vec::new(),
             project_context_pack_enabled: true,
             translation_enabled: false,
+            show_thinking: true,
             max_steps: 100,
             max_subagents: DEFAULT_MAX_SUBAGENTS,
             features: Features::with_defaults(),
@@ -434,6 +439,7 @@ impl Engine {
                     project_context_pack_enabled: config.project_context_pack_enabled,
                     locale_tag: &config.locale_tag,
                     translation_enabled: config.translation_enabled,
+                    show_thinking: config.show_thinking,
                 },
                 session.approval_mode,
             );
@@ -589,6 +595,7 @@ impl Engine {
                     auto_approve,
                     approval_mode,
                     translation_enabled,
+                    show_thinking,
                 } => {
                     self.handle_send_message(
                         content,
@@ -603,6 +610,7 @@ impl Engine {
                         auto_approve,
                         approval_mode,
                         translation_enabled,
+                        show_thinking,
                     )
                     .await;
                 }
@@ -802,6 +810,7 @@ impl Engine {
                         self.session.auto_approve,
                         self.session.approval_mode,
                         self.config.translation_enabled,
+                        self.config.show_thinking,
                     )
                     .await;
                 }
@@ -890,6 +899,7 @@ impl Engine {
         auto_approve: bool,
         approval_mode: crate::tui::approval::ApprovalMode,
         translation_enabled: bool,
+        show_thinking: bool,
     ) {
         // Reset cancel token for fresh turn (in case previous was cancelled)
         self.reset_cancel_token();
@@ -973,6 +983,7 @@ impl Engine {
         self.session.trust_mode = trust_mode;
         self.config.trust_mode = trust_mode;
         self.config.translation_enabled = translation_enabled;
+        self.config.show_thinking = show_thinking;
         self.session.auto_approve = auto_approve;
         self.session.approval_mode = if auto_approve {
             crate::tui::approval::ApprovalMode::Auto
@@ -1792,6 +1803,7 @@ impl Engine {
                 project_context_pack_enabled: self.config.project_context_pack_enabled,
                 locale_tag: &self.config.locale_tag,
                 translation_enabled: self.config.translation_enabled,
+                show_thinking: self.config.show_thinking,
             },
             self.session.approval_mode,
         );

--- a/crates/tui/src/core/ops.rs
+++ b/crates/tui/src/core/ops.rs
@@ -31,6 +31,7 @@ pub enum Op {
         auto_approve: bool,
         approval_mode: ApprovalMode,
         translation_enabled: bool,
+        show_thinking: bool,
     },
 
     /// Cancel the current request

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -4636,6 +4636,7 @@ async fn run_exec_agent(
         instructions: config.instructions_paths(),
         project_context_pack_enabled: config.project_context_pack_enabled(),
         translation_enabled: false,
+        show_thinking: true,
         max_steps: 100,
         max_subagents,
         features: config.features(),
@@ -4725,6 +4726,7 @@ async fn run_exec_agent(
             trust_mode,
             auto_approve,
             translation_enabled: false,
+            show_thinking: true,
             approval_mode: if auto_approve {
                 crate::tui::approval::ApprovalMode::Auto
             } else {

--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -28,6 +28,11 @@ pub struct PromptSessionContext<'a> {
     /// to the system prompt instructing the model to respond in
     /// the resolved session locale.
     pub translation_enabled: bool,
+    /// When false, the user has hidden thinking blocks in the UI.
+    /// The prompt builder injects a language override so
+    /// `reasoning_content` stays in English (saving tokens) while
+    /// the final reply still matches the user's language.
+    pub show_thinking: bool,
 }
 
 /// Conventional location for the structured session relay artifact (#32).
@@ -549,6 +554,7 @@ pub fn system_prompt_for_mode_with_context_and_skills(
             project_context_pack_enabled: true,
             locale_tag: "en",
             translation_enabled: false,
+            show_thinking: true,
         },
     )
 }
@@ -638,6 +644,22 @@ pub fn system_prompt_for_mode_with_context_skills_session_and_approval(
         full_prompt = format!(
             "{full_prompt}\n\n{}",
             translation_output_instruction(session_context.locale_tag)
+        );
+    }
+
+    // 2.3b. Thinking language override — when the user has hidden
+    // thinking blocks in the UI, redirect reasoning_content to
+    // English regardless of user language. This saves tokens
+    // (English is the most token-efficient language) while keeping
+    // the final reply in the user's language as described above.
+    if !session_context.show_thinking {
+        full_prompt.push_str(
+            "\n\n## Thinking Language\n\n\
+             The user has disabled thinking display in settings. To save tokens, \
+             your `reasoning_content` (internal thinking) MUST be in English \
+             regardless of the user's language. This directive overrides the \
+             `## Language` section above for reasoning_content only. \
+             Your final reply must STILL match the user's language.",
         );
     }
 
@@ -881,6 +903,7 @@ mod tests {
                 project_context_pack_enabled: false,
                 locale_tag: "zh-Hans",
                 translation_enabled: false,
+                show_thinking: true,
             },
             ApprovalMode::Suggest,
         ) {
@@ -950,6 +973,7 @@ mod tests {
                 project_context_pack_enabled: false,
                 locale_tag: "zh-Hans",
                 translation_enabled: false,
+                show_thinking: true,
             },
             ApprovalMode::Suggest,
         ) {
@@ -994,6 +1018,7 @@ mod tests {
                 project_context_pack_enabled: false,
                 locale_tag: "en",
                 translation_enabled: false,
+                show_thinking: true,
             },
             ApprovalMode::Suggest,
         ) {
@@ -1083,6 +1108,7 @@ mod tests {
                 project_context_pack_enabled: true,
                 locale_tag: "ja",
                 translation_enabled: false,
+                show_thinking: true,
             },
         ) {
             SystemPrompt::Text(text) => text,
@@ -1118,6 +1144,7 @@ mod tests {
                 project_context_pack_enabled: false,
                 locale_tag: "en",
                 translation_enabled: false,
+                show_thinking: true,
             },
         ) {
             SystemPrompt::Text(text) => text,
@@ -1145,6 +1172,7 @@ mod tests {
                 project_context_pack_enabled: false,
                 locale_tag: "en",
                 translation_enabled: false,
+                show_thinking: true,
             },
         ) {
             SystemPrompt::Text(text) => text,
@@ -1174,6 +1202,7 @@ mod tests {
                 project_context_pack_enabled: false,
                 locale_tag: "en",
                 translation_enabled: false,
+                show_thinking: true,
             },
         ) {
             SystemPrompt::Text(text) => text,
@@ -1201,6 +1230,7 @@ mod tests {
                 project_context_pack_enabled: true,
                 locale_tag: "en",
                 translation_enabled: false,
+                show_thinking: true,
             },
         ) {
             SystemPrompt::Text(text) => text,
@@ -1395,6 +1425,7 @@ mod tests {
                 project_context_pack_enabled: true,
                 locale_tag: "en",
                 translation_enabled: false,
+                show_thinking: true,
             },
         ) {
             SystemPrompt::Text(text) => text,
@@ -1428,6 +1459,7 @@ mod tests {
                 project_context_pack_enabled: true,
                 locale_tag: "en",
                 translation_enabled: false,
+                show_thinking: true,
             },
         ) {
             SystemPrompt::Text(text) => text,

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -1616,6 +1616,7 @@ impl RuntimeThreadManager {
                 trust_mode,
                 auto_approve,
                 translation_enabled: false,
+                show_thinking: false,
                 approval_mode: if auto_approve {
                     crate::tui::approval::ApprovalMode::Auto
                 } else {
@@ -1933,6 +1934,7 @@ impl RuntimeThreadManager {
             instructions: self.config.instructions_paths(),
             project_context_pack_enabled: self.config.project_context_pack_enabled(),
             translation_enabled: false,
+            show_thinking: false,
             max_steps: 100,
             max_subagents: self.config.max_subagents().clamp(1, MAX_SUBAGENTS),
             features: self.config.features(),

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -676,6 +676,7 @@ fn build_engine_config(app: &App, config: &Config) -> EngineConfig {
         instructions: config.instructions_paths(),
         project_context_pack_enabled: config.project_context_pack_enabled(),
         translation_enabled: app.translation_enabled,
+        show_thinking: app.show_thinking,
         // Effectively unlimited. V4 has a 1M context window and the user
         // wants the model running until it's actually done. The previous cap
         // of 100 hit the ceiling on long multi-step plans (wide refactors,
@@ -3882,6 +3883,7 @@ async fn dispatch_user_message(
                 project_context_pack_enabled: config.project_context_pack_enabled(),
                 locale_tag: app.ui_locale.tag(),
                 translation_enabled: app.translation_enabled,
+                show_thinking: app.show_thinking,
             },
         ),
     );
@@ -3978,6 +3980,7 @@ async fn dispatch_user_message(
             auto_approve: app.mode == AppMode::Yolo,
             approval_mode: app.approval_mode,
             translation_enabled: app.translation_enabled,
+            show_thinking: app.show_thinking,
         })
         .await
     {


### PR DESCRIPTION
## Problem

  When `show_thinking` is disabled in settings, thinking blocks are hidden from the UI but the API still generates
  `reasoning_content`. Because of the `## Language` rule in the system prompt (`base.md`), the thinking chain language
  follows the user's input — so Chinese/Japanese/etc. users pay extra tokens for non-English thinking they never see.

  This is a **pure waste**: Chinese `reasoning_content` costs ~30-50% more tokens than English for the same semantic
  content, and the user can't even read it.

  ## Solution

  Inject a `## Thinking Language` override into the system prompt when `show_thinking = false`:

  Thinking Language

  The user has disabled thinking display in settings. To save tokens,
  your reasoning_content (internal thinking) MUST be in English
  regardless of the user's language. Your final reply must STILL match
  the user's language.

  This keeps reasoning quality intact (thinking still happens) while using the most token-efficient language for
  invisible content.

  ## Changes (6 files, +52 lines)

  - `prompts.rs` — Add `show_thinking` to `PromptSessionContext`, inject override block
  - `core/ops.rs` — Add `show_thinking` to `Op::SendMessage`
  - `core/engine.rs` — Add `show_thinking` to `EngineConfig`, thread through `handle_send_message` and
  `refresh_system_prompt`
  - `ui.rs` — Wire `app.show_thinking` through engine config and prompt construction
  - `main.rs` — Pass `show_thinking` in CLI exec path
  - `runtime_threads.rs` — Pass `show_thinking: false` for background agent threads

  ## Behavior

  | `show_thinking` | Reasoning language | Reply language | Token cost |
  |---|---|---|---|
  | `true` (default) | Matches user input | Matches user input | Unchanged |
  | `false` | **English** (forced) | Matches user input | **~30-50% less** |

  ## Verification

  1. Set `show_thinking = true`, ask a Chinese question, note the session cost in the sidebar
  2. Set `show_thinking = false`, ask a similar question, compare cost — should be noticeably lower