### PR TITLE
fix(engine): keep write_file loaded in agent mode

### DIFF
--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -401,6 +401,7 @@ fn non_yolo_mode_retains_default_defer_policy() {
     assert!(!should_default_defer_tool("exec_shell", AppMode::Agent));
     assert!(should_default_defer_tool("exec_shell", AppMode::Plan));
     assert!(!should_default_defer_tool("read_file", AppMode::Agent));
+    assert!(!should_default_defer_tool("write_file", AppMode::Agent));
     assert!(should_default_defer_tool(
         "mcp_read_resource",
         AppMode::Agent
@@ -412,6 +413,7 @@ fn model_tool_catalog_applies_native_and_mcp_deferral() {
     let catalog = build_model_tool_catalog(
         vec![
             api_tool("read_file"),
+            api_tool("write_file"),
             api_tool("exec_shell"),
             api_tool("project_map"),
         ],
@@ -427,6 +429,7 @@ fn model_tool_catalog_applies_native_and_mcp_deferral() {
     };
 
     assert_eq!(defer_loading("read_file"), Some(false));
+    assert_eq!(defer_loading("write_file"), Some(false));
     assert_eq!(defer_loading("exec_shell"), Some(false));
     assert_eq!(defer_loading("project_map"), Some(true));
     assert_eq!(defer_loading("list_mcp_resources"), Some(false));

--- a/crates/tui/src/core/engine/tool_catalog.rs
+++ b/crates/tui/src/core/engine/tool_catalog.rs
@@ -54,6 +54,7 @@ pub(super) fn should_default_defer_tool(name: &str, mode: AppMode) -> bool {
     !matches!(
         name,
         "read_file"
+            | "write_file"
             | "list_dir"
             | "grep_files"
             | "file_search"


### PR DESCRIPTION
## Summary

- keep `write_file` loaded by default in Agent mode instead of deferring it on first use
- preserve approval handling; this only changes whether the first `write_file` call reaches the normal approval/execution path
- cover the deferral policy with engine tests

## Why

`write_file` is the primary tool for brand-new files and full-file rewrites. Deferring it means the first valid call can return "Tool `write_file` was deferred and has now been loaded" without writing anything, which is especially confusing for new-file creation.

Fixes #1825.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p deepseek-tui core::engine::tests`
- `cargo test -p deepseek-tui tools::file::tests::test_write_file_creates_dirs`
