### PR TITLE
fix(tui): set spillover root in dedup tests for Nix sandbox builds

### DIFF
--- a/crates/tui/src/client/chat.rs
+++ b/crates/tui/src/client/chat.rs
@@ -2206,6 +2206,24 @@ mod stream_decoder_tests {
     //! directly to verify each "class of stream failure" the engine relies on.
     use super::*;
     use crate::models::{ContentBlockStart, Delta, StreamEvent};
+    use std::path::PathBuf;
+
+    struct SpilloverRootGuard {
+        prior: Option<PathBuf>,
+    }
+
+    impl SpilloverRootGuard {
+        fn new(path: PathBuf) -> Self {
+            let prior = crate::tools::truncate::set_test_spillover_root(Some(path));
+            Self { prior }
+        }
+    }
+
+    impl Drop for SpilloverRootGuard {
+        fn drop(&mut self) {
+            crate::tools::truncate::set_test_spillover_root(self.prior.take());
+        }
+    }
 
     /// Decode a raw SSE-data JSON chunk into our internal events, mirroring
     /// the per-event call shape used by `handle_chat_completion_stream`.
@@ -2715,6 +2733,14 @@ mod stream_decoder_tests {
 
     #[test]
     fn request_builder_deduplicates_large_identical_tool_results_with_retrieval_hint() {
+        let _lock = crate::tools::truncate::TEST_SPILLOVER_GUARD
+            .lock()
+            .unwrap_or_else(|err| err.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = SpilloverRootGuard::new(
+            tmp.path().join(".deepseek").join("tool_outputs"),
+        );
+
         let output = "A".repeat(2_000);
         let messages = vec![
             tool_use_message("tool-1", "read_file", json!({"path": "README.md"})),
@@ -2767,6 +2793,14 @@ mod stream_decoder_tests {
 
     #[test]
     fn cache_inspect_reports_tool_result_budget_metadata() {
+        let _lock = crate::tools::truncate::TEST_SPILLOVER_GUARD
+            .lock()
+            .unwrap_or_else(|err| err.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = SpilloverRootGuard::new(
+            tmp.path().join(".deepseek").join("tool_outputs"),
+        );
+
         let long_output = format!("{}{}", "A".repeat(7_000), "Z".repeat(7_000));
         let request = MessageRequest {
             model: "deepseek-v4-flash".to_string(),


### PR DESCRIPTION
## Summary

- Two tool-result deduplication tests (`request_builder_deduplicates_large_identical_tool_results_with_retrieval_hint` and `cache_inspect_reports_tool_result_budget_metadata`) fail under `nix build` because the sandbox has no writable `$HOME`
- The spillover write silently fails, dedup is skipped, and assertions break
- Adds a temp-dir-backed `SpilloverRootGuard` (matching the existing pattern in `tool_result_retrieval.rs`) so the tests pass in both sandboxed and normal environments

## Test plan

- [x] `cargo test -p deepseek-tui --bin deepseek-tui -- stream_decoder_tests::request_builder_deduplicates_large stream_decoder_tests::cache_inspect_reports_tool_result` passes
- [x] `nix build .#` succeeds (tests pass in sandbox)