### PR TITLE
feat: add DEEPSEEK.md as project context file

### DIFF
--- a/crates/tui/src/project_context.rs
+++ b/crates/tui/src/project_context.rs
@@ -4,6 +4,7 @@
 //! instructions and context to the AI agent. These include:
 //!
 //! - `AGENTS.md` - Project-level agent instructions (primary)
+//! - `DEEPSEEK.md` - DeepSeek TUI-specific project instructions
 //! - `.claude/instructions.md` - Claude-style hidden instructions
 //! - `CLAUDE.md` - Claude-style instructions
 //! - `.deepseek/instructions.md` - Hidden instructions file (legacy)
@@ -21,6 +22,7 @@ use thiserror::Error;
 /// Names of project context files to look for, in priority order.
 const PROJECT_CONTEXT_FILES: &[&str] = &[
     "AGENTS.md",
+    "DEEPSEEK.md",
     ".claude/instructions.md",
     "CLAUDE.md",
     ".deepseek/instructions.md",

--- a/crates/tui/src/utils.rs
+++ b/crates/tui/src/utils.rs
@@ -27,6 +27,7 @@ pub fn is_key_file(path: &Path) -> bool {
             | "pom.xml"
             | "readme.md"
             | "agents.md"
+            | "deepseek.md"
             | "claude.md"
             | "makefile"
             | "dockerfile"

--- a/crates/tui/src/working_set.rs
+++ b/crates/tui/src/working_set.rs
@@ -1156,6 +1156,7 @@ fn detect_key_files(workspace: &Path) -> Vec<String> {
         "Cargo.toml",
         "README.md",
         "AGENTS.md",
+        "DEEPSEEK.md",
         "CLAUDE.md",
         "package.json",
         "pyproject.toml",


### PR DESCRIPTION
Adds DEEPSEEK.md to PROJECT_CONTEXT_FILES so harnesses like [superpowers](https://github.com/obra/superpowers) can ship a harness-specific instruction file that gets auto-loaded as project_instructions — analogous to GEMINI.md in Gemini CLI.

## What

1 line in the PROJECT_CONTEXT_FILES constant, positioned after AGENTS.md so harness-specific files take priority over generic CLAUDE.md while universal AGENTS.md remains top.

## Files changed

- **`project_context.rs`**: Add `DEEPSEEK.md` to `PROJECT_CONTEXT_FILES` and module docstring
- **`working_set.rs`**: Add `DEEPSEEK.md` to key-file detection candidates
- **`utils.rs`**: Add `deepseek.md` to fallback key-file matcher

## Why

Superpowers needs a harness-specific bootstrap file to inject the `using-superpowers` skill at session start. AGENTS.md is already used for universal contributor guidelines and shouldn't be repurposed. Prior art: Gemini CLI reads `GEMINI.md`, OpenCode reads `.opencode/plugins/`.

Closes #1851
