### PR TITLE
fix(engine): report loop guard halt as Failed instead of Completed

### DIFF
--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -1872,7 +1872,9 @@ impl Engine {
 
             if let Some(message) = loop_guard_halt {
                 crate::logging::warn(message.clone());
-                let _ = self.tx_event.send(Event::status(message)).await;
+                let _ = self.tx_event.send(Event::status(message.clone())).await;
+                // 设置 turn_error 以确保最终返回 TurnOutcomeStatus::Failed 而非 Completed
+                turn_error = Some(message);
                 break;
             }
 


### PR DESCRIPTION
## Problem

When the LoopGuard triggers a halt (tool failed 8 times consecutively), the turn loop executes reak but 	urn_error remains None, causing TurnOutcomeStatus::Completed to be returned instead of Failed.

This misleads the user into thinking the turn succeeded when it was actually forcefully terminated.

## Fix

Set 	urn_error with the halt message before breaking out of the loop, so the final return correctly yields TurnOutcomeStatus::Failed with the error message.

## Changes

- **File**: crates/tui/src/core/engine/turn_loop.rs 
- Added 	urn_error = Some(message) in the loop_guard_halt branch before reak 
- Cloned message for the event send (since it's now moved into 	urn_error)

## Verification

- cargo check -p deepseek-tui passes