### PR TITLE
[codex] Fix composer arrows with mouse capture

### DIFF
--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -1346,8 +1346,8 @@ fn default_composer_arrows_scroll(use_mouse_capture: bool) -> bool {
     default_composer_arrows_scroll_for_platform(use_mouse_capture, cfg!(windows))
 }
 
-fn default_composer_arrows_scroll_for_platform(use_mouse_capture: bool, is_windows: bool) -> bool {
-    is_windows || !use_mouse_capture
+fn default_composer_arrows_scroll_for_platform(use_mouse_capture: bool, _is_windows: bool) -> bool {
+    !use_mouse_capture
 }
 
 impl App {
@@ -4411,8 +4411,8 @@ mod tests {
     }
 
     #[test]
-    fn composer_arrows_scroll_default_is_true_on_windows_even_with_mouse_capture() {
-        assert!(default_composer_arrows_scroll_for_platform(true, true));
+    fn composer_arrows_scroll_default_is_false_on_windows_with_mouse_capture() {
+        assert!(!default_composer_arrows_scroll_for_platform(true, true));
     }
 
     #[test]

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -5729,8 +5729,8 @@ fn composer_arrows_scroll_defaults_follow_platform_with_mouse_capture() {
         ..create_test_options()
     };
     let app = App::new(options, &Config::default());
-    assert_eq!(
-        app.composer_arrows_scroll, false,
+    assert!(
+        !app.composer_arrows_scroll,
         "arrows-scroll should default to false when mouse capture is on"
     );
 }

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -5730,9 +5730,8 @@ fn composer_arrows_scroll_defaults_follow_platform_with_mouse_capture() {
     };
     let app = App::new(options, &Config::default());
     assert_eq!(
-        app.composer_arrows_scroll,
-        cfg!(windows),
-        "arrows-scroll should default to true on Windows and false on other platforms when mouse capture is on"
+        app.composer_arrows_scroll, false,
+        "arrows-scroll should default to false when mouse capture is on"
     );
 }
 


### PR DESCRIPTION
## Summary
- Default composer arrow scrolling now stays off when mouse capture is enabled.
- Keeps the existing opt-in behavior for configurations without mouse capture.
- Updates regression tests for both app config and UI config loading.

Fixes #1720

## Validation
- cargo fmt --check
- cargo test -p deepseek-tui composer_arrows_scroll_default -- --nocapture