### PR TITLE
fix(tui): honour DEEPSEEK_YOLO env on TUI startup

### DIFF
--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -773,8 +773,12 @@ async fn main() -> Result<()> {
                     std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
                 });
                 let resume_session_id = resolve_exec_resume_session_id(&args, &workspace)?;
+                // The `deepseek` launcher forwards `--yolo` to this binary via
+                // the DEEPSEEK_YOLO env var (which the config loader folds into
+                // `config.yolo`), not as a CLI flag. Honour either source.
+                let yolo = cli.yolo || config.yolo.unwrap_or(false);
                 let needs_engine = args.auto
-                    || cli.yolo
+                    || yolo
                     || resume_session_id.is_some()
                     || args.output_format == ExecOutputFormat::StreamJson;
                 if needs_engine {
@@ -782,7 +786,7 @@ async fn main() -> Result<()> {
                         || config.max_subagents(),
                         |value| value.clamp(1, MAX_SUBAGENTS),
                     );
-                    let auto_mode = args.auto || cli.yolo;
+                    let auto_mode = args.auto || yolo;
                     run_exec_agent(
                         &config,
                         &model,
@@ -4377,6 +4381,10 @@ async fn run_interactive(
         ),
     }
 
+    // The `deepseek` launcher forwards `--yolo` to this binary via the
+    // DEEPSEEK_YOLO env var (config.yolo), not as a CLI flag. Honour either.
+    let yolo = cli.yolo || config.yolo.unwrap_or(false);
+
     tui::run_tui(
         config,
         tui::TuiOptions {
@@ -4384,7 +4392,7 @@ async fn run_interactive(
             workspace,
             config_path: cli.config.clone(),
             config_profile: cli.profile.clone(),
-            allow_shell: cli.yolo || config.allow_shell(),
+            allow_shell: yolo || config.allow_shell(),
             use_alt_screen,
             use_mouse_capture,
             use_bracketed_paste,
@@ -4393,9 +4401,9 @@ async fn run_interactive(
             notes_path: config.notes_path(),
             mcp_config_path: config.mcp_config_path(),
             use_memory: config.memory_enabled(),
-            start_in_agent_mode: cli.yolo,
+            start_in_agent_mode: yolo,
             skip_onboarding: cli.skip_onboarding,
-            yolo: cli.yolo, // YOLO mode auto-approves all tool executions
+            yolo, // YOLO mode auto-approves all tool executions
             resume_session_id,
             initial_input,
             max_subagents,


### PR DESCRIPTION
## Summary
- `deepseek --yolo` did not start the TUI in YOLO mode. The `deepseek` launcher (`crates/cli/src/lib.rs:1479-1481`) forwards `--yolo` to the child `deepseek-tui` binary via the `DEEPSEEK_YOLO=true` env var, not as a CLI flag.
- The TUI's config loader (`crates/tui/src/config.rs:2544-2546`) already folds that env var into `config.yolo: Option<bool>`, but `run_interactive` and the `exec` subcommand handler in `crates/tui/src/main.rs` only consulted `cli.yolo`, so the env-derived value was loaded and then silently dropped.
- Net effect: `deepseek --yolo` opened a plain Agent-mode session instead of YOLO (shell + trust + auto-approve).

## Fix
Derive `let yolo = cli.yolo || config.yolo.unwrap_or(false);` at both call sites and route it into `TuiOptions` (`start_in_agent_mode`, `allow_shell`, `yolo`) and `run_exec_agent` (`auto_mode`, `needs_engine`). No other behaviour change — when neither source sets YOLO, `cli.yolo` remains the deciding flag exactly as before.

## Test plan
- [x] `cargo check -p deepseek-tui` (passes)
- [x] `cargo test -p deepseek-tui --bin deepseek-tui -- yolo` — 10 yolo-tagged tests pass, including `test_trust_mode_follows_yolo_on_startup`, `leaving_yolo_after_startup_restores_baseline_policies`, `set_mode_yolo_restores_previous_policies_on_exit`, `agent_and_yolo_modes_elevate_shell_sandbox_to_allow_network`, `model_tool_catalog_keeps_everything_loaded_in_yolo_mode`.
- [x] Manual: replaced the `deepseek-tui` binary in a local npm install with the patched release build, ran `deepseek --yolo` in a real tty, footer reports `yolo` (red) and tool approvals are auto-granted.

## Notes
The downstream wiring in `App::new` (`crates/tui/src/tui/app.rs` around `initial_mode = if yolo { AppMode::Yolo } …`) is unchanged — it already correctly sets `trust_mode`, `allow_shell`, `approval_mode = Auto`, and `mode = AppMode::Yolo` whenever `TuiOptions::yolo` is true. The bug was purely in the env→options handoff.