### PR TITLE
feat: make TLS certificate verification configurable

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -274,12 +274,14 @@ max_subagents = 10 # optional (1-20)
 # model = "deepseek-ai/DeepSeek-V4-Pro"
 # http_headers = { "X-Model-Provider-Id" = "your-model-provider" } # optional custom request headers
 # path_suffix = "/chat/completions" # override the API path; skips /v1 versioning when set
+# insecure_skip_tls_verify = false          # set to true to accept self-signed/invalid certs (insecure)
 
 # NVIDIA NIM-hosted DeepSeek V4 (https://build.nvidia.com)
 [providers.nvidia_nim]
 # api_key = "YOUR_NVIDIA_API_KEY"
 # base_url = "https://integrate.api.nvidia.com/v1"
 # model = "deepseek-ai/deepseek-v4-pro"     # or deepseek-ai/deepseek-v4-flash
+# insecure_skip_tls_verify = false
 
 # Generic OpenAI-compatible endpoint. Use the built-in `openai` provider for
 # third-party gateways; do not invent a custom provider name. For non-local
@@ -292,18 +294,21 @@ max_subagents = 10 # optional (1-20)
 # Gateway example:
 # base_url = "https://gateway.example/v1"
 # model = "your-deepseek-compatible-model"
+# insecure_skip_tls_verify = false
 
 # AtlasCloud OpenAI-compatible endpoint (https://www.atlascloud.ai/docs/models/llm)
 [providers.atlascloud]
 # api_key = "YOUR_ATLASCLOUD_API_KEY"
 # base_url = "https://api.atlascloud.ai/v1"
 # model = "deepseek-ai/deepseek-v4-flash"
+# insecure_skip_tls_verify = false
 
 # Wanjie Ark / 万界方舟 OpenAI-compatible endpoint
 [providers.wanjie_ark]
 # api_key = "YOUR_WANJIE_API_KEY"
 # base_url = "https://maas-openapi.wanjiedata.com/api/v1"
 # model = "deepseek-reasoner"                # or the exact model ID enabled on your Wanjie account
+# insecure_skip_tls_verify = false
 
 # Volcengine / Volcano Engine Ark Coding API
 [providers.volcengine]
@@ -343,6 +348,7 @@ max_subagents = 10 # optional (1-20)
 # api_key = "YOUR_FIREWORKS_API_KEY"
 # base_url = "https://api.fireworks.ai/inference/v1"
 # model = "accounts/fireworks/models/deepseek-v4-pro"
+# insecure_skip_tls_verify = false
 
 # SiliconFlow-hosted DeepSeek V4 (https://siliconflow.com)
 [providers.siliconflow]
@@ -371,18 +377,21 @@ max_subagents = 10 # optional (1-20)
 # api_key = "OPTIONAL_SGLANG_TOKEN"
 # base_url = "http://localhost:30000/v1"
 # model = "deepseek-ai/DeepSeek-V4-Pro"     # or deepseek-ai/DeepSeek-V4-Flash
+# insecure_skip_tls_verify = false
 
 # Self-hosted vLLM OpenAI-compatible server
 [providers.vllm]
 # api_key = "OPTIONAL_VLLM_TOKEN"
 # base_url = "http://localhost:8000/v1"
 # model = "deepseek-ai/DeepSeek-V4-Pro"     # or deepseek-ai/DeepSeek-V4-Flash
+# insecure_skip_tls_verify = false
 
 # Self-hosted Ollama OpenAI-compatible server
 [providers.ollama]
 # api_key = "OPTIONAL_OLLAMA_TOKEN"
 # base_url = "http://localhost:11434/v1"
 # model = "deepseek-coder:1.3b"             # or any local Ollama tag
+# insecure_skip_tls_verify = false
 
 # Hugging Face Inference Providers (https://huggingface.co/docs/api-inference)
 [providers.huggingface]

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -200,6 +200,11 @@ pub struct ProviderConfigToml {
     #[serde(default)]
     pub http_headers: BTreeMap<String, String>,
     pub path_suffix: Option<String>,
+    /// Skip TLS certificate verification when talking to this provider.
+    /// Defaults to `false` (verify certificates). Set to `true` only for
+    /// self-hosted endpoints or development servers with self-signed certs.
+    #[serde(default)]
+    pub insecure_skip_tls_verify: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -585,6 +585,15 @@ impl DeepSeekClient {
         let path_suffix = config
             .provider_config_for(api_provider)
             .and_then(|p| p.path_suffix.clone());
+        let skip_verify = config.deepseek_insecure_skip_tls_verify();
+
+        if skip_verify {
+            logging::warn(
+                "TLS certificate verification is DISABLED for this provider \
+                 (insecure_skip_tls_verify = true). This is insecure and should \
+                 only be used for development or trusted internal servers.",
+            );
+        }
 
         logging::info(format!("API provider: {}", api_provider.as_str()));
         logging::info(format!("API base URL: {base_url}"));
@@ -602,7 +611,7 @@ impl DeepSeekClient {
             retry.enabled, retry.max_retries, retry.initial_delay, retry.max_delay
         ));
 
-        let http_client = Self::build_http_client(&api_key, &http_headers)?;
+        let http_client = Self::build_http_client(&api_key, &http_headers, skip_verify)?;
 
         Ok(Self {
             http_client,
@@ -620,9 +629,11 @@ impl DeepSeekClient {
     fn build_http_client(
         api_key: &str,
         extra_headers: &HashMap<String, String>,
+        skip_verify: bool,
     ) -> Result<reqwest::Client> {
         let headers = build_default_headers(api_key, extra_headers)?;
         let mut builder = reqwest::Client::builder()
+            .danger_accept_invalid_certs(skip_verify)
             .default_headers(headers)
             .user_agent(concat!(
                 "Mozilla/5.0 (compatible; codewhale/",
@@ -3552,5 +3563,24 @@ mod tests {
             api_url_with_suffix("https://api.deepseek.com", "chat/completions", None),
             "https://api.deepseek.com/v1/chat/completions"
         );
+    }
+    #[test]
+    fn build_http_client_with_skip_verify_false() {
+        let client = DeepSeekClient::build_http_client(
+            "test-key",
+            &HashMap::new(),
+            false,
+        );
+        assert!(client.is_ok(), "should succeed with skip_verify=false");
+    }
+
+    #[test]
+    fn build_http_client_with_skip_verify_true() {
+        let client = DeepSeekClient::build_http_client(
+            "test-key",
+            &HashMap::new(),
+            true,
+        );
+        assert!(client.is_ok(), "should succeed with skip_verify=true");
     }
 }

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -1859,6 +1859,10 @@ pub struct ProviderConfig {
     pub auth_mode: Option<String>,
     pub http_headers: Option<HashMap<String, String>>,
     pub path_suffix: Option<String>,
+    /// Skip TLS certificate verification when talking to this provider.
+    /// Defaults to `false` (verify certificates).
+    #[serde(default)]
+    pub insecure_skip_tls_verify: Option<bool>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -2594,6 +2598,18 @@ impl Config {
             // Return an empty key and let the client omit the Authorization header.
             ApiProvider::Sglang | ApiProvider::Vllm | ApiProvider::Ollama => Ok(String::new()),
         }
+    }
+
+    /// Whether the active provider should have TLS certificate verification skipped.
+    ///
+    /// Returns `true` only when the provider explicitly sets
+    /// `insecure_skip_tls_verify = true` in its `[providers.<name>]` table.
+    /// Defaults to `false` (verify certificates).
+    #[must_use]
+    pub fn deepseek_insecure_skip_tls_verify(&self) -> bool {
+        self.provider_config()
+            .and_then(|provider| provider.insecure_skip_tls_verify)
+            .unwrap_or(false)
     }
 
     /// Resolve the skills directory path.
@@ -4320,6 +4336,7 @@ fn merge_provider_config(base: ProviderConfig, override_cfg: ProviderConfig) -> 
         auth_mode: override_cfg.auth_mode.or(base.auth_mode),
         http_headers: override_cfg.http_headers.or(base.http_headers),
         path_suffix: override_cfg.path_suffix.or(base.path_suffix),
+        insecure_skip_tls_verify: override_cfg.insecure_skip_tls_verify.or(base.insecure_skip_tls_verify),
     }
 }
 
@@ -10036,6 +10053,76 @@ model = "deepseek-ai/deepseek-v4-pro"
         "#;
         let tui: TuiConfig = toml::from_str(toml_str).expect("missing status_items should parse");
         assert_eq!(tui.status_items, None);
+    }
+    // ── per-provider insecure_skip_tls_verify ──
+
+    #[test]
+    fn insecure_skip_tls_verify_defaults_to_false() {
+        let config = Config::default();
+        assert!(!config.deepseek_insecure_skip_tls_verify());
+    }
+
+    #[test]
+    fn insecure_skip_tls_verify_toml_deserializes_true() {
+        let toml = r#"
+            provider = "ollama"
+            [providers.ollama]
+            base_url = "https://localhost:11434/v1"
+            insecure_skip_tls_verify = true
+        "#;
+        let config: ConfigFile = toml::from_str(toml).unwrap();
+        let config = config.base;
+        assert!(config.deepseek_insecure_skip_tls_verify());
+    }
+
+    #[test]
+    fn insecure_skip_tls_verify_toml_explicit_false() {
+        let toml = r#"
+            provider = "ollama"
+            [providers.ollama]
+            base_url = "https://localhost:11434/v1"
+            insecure_skip_tls_verify = false
+        "#;
+        let config: ConfigFile = toml::from_str(toml).unwrap();
+        let config = config.base;
+        assert!(!config.deepseek_insecure_skip_tls_verify());
+    }
+
+    #[test]
+    fn insecure_skip_tls_verify_toml_missing_defaults_false() {
+        let toml = r#"
+            provider = "ollama"
+            [providers.ollama]
+            base_url = "https://localhost:11434/v1"
+        "#;
+        let config: ConfigFile = toml::from_str(toml).unwrap();
+        let config = config.base;
+        assert!(!config.deepseek_insecure_skip_tls_verify());
+    }
+
+    #[test]
+    fn merge_provider_config_insecure_skip_tls_verify_override_wins() {
+        let base = ProviderConfig {
+            insecure_skip_tls_verify: Some(false),
+            ..ProviderConfig::default()
+        };
+        let ovr = ProviderConfig {
+            insecure_skip_tls_verify: Some(true),
+            ..ProviderConfig::default()
+        };
+        let merged = merge_provider_config(base, ovr);
+        assert_eq!(merged.insecure_skip_tls_verify, Some(true));
+    }
+
+    #[test]
+    fn merge_provider_config_insecure_skip_tls_verify_falls_back() {
+        let base = ProviderConfig {
+            insecure_skip_tls_verify: Some(true),
+            ..ProviderConfig::default()
+        };
+        let ovr = ProviderConfig::default();
+        let merged = merge_provider_config(base, ovr);
+        assert_eq!(merged.insecure_skip_tls_verify, Some(true));
     }
 
     #[test]

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -2551,6 +2551,26 @@ async fn run_doctor(config: &Config, workspace: &Path, config_path_override: Opt
         println!("  {} Skipped (no API key configured)", "·".dimmed());
     }
 
+    // TLS certificate verification status
+    let tls_insecure = config.deepseek_insecure_skip_tls_verify();
+    if tls_insecure {
+        println!();
+        println!(
+            "{}",
+            "! TLS certificate verification is DISABLED"
+                .truecolor(sky_r, sky_g, sky_b)
+                .bold()
+        );
+        println!(
+            "    insecure_skip_tls_verify = true for provider `{}` — outbound HTTPS",
+            config.api_provider().as_str()
+        );
+        println!(
+            "    requests will accept untrusted certificates. This is intended for"
+        );
+        println!("    development and trusted internal networks only.");
+    }
+
     // MCP configuration
     println!();
     println!("{}", "MCP Servers:".bold());
@@ -3252,6 +3272,7 @@ fn run_doctor_json(
         },
         "base_url": api_target.base_url,
         "default_text_model": api_target.model,
+        "insecure_skip_tls_verify": config.deepseek_insecure_skip_tls_verify(),
         "strict_tool_mode": {
             "enabled": strict_tool_mode.enabled,
             "status": strict_tool_mode.status,


### PR DESCRIPTION
## Rewrite: per-provider TLS toggle (no global switch)

Rebased and rewritten as a **provider-scoped** version per review feedback. No global `insecure_skip_tls_verify` — each `[providers.<name>]` independently opts in, and it **only** affects the LLM API client.

**Design**
- Per-provider only — no global flag; tools, MCP, sandbox, updater, hooks untouched
- Default `false` — TLS verified unless explicitly opted out
- `logging::warn` emitted when TLS is disabled for the active provider
- `deepseek doctor` shows TLS status in both human and `--json` modes

**Usage**
```toml
[providers.ollama]
base_url = "https://localhost:11434/v1"
insecure_skip_tls_verify = true
```

**Tests**
`cargo build` ✅
`cargo test -p codewhale-tui -- insecure_skip_verify build_http_client` → 8/8 ✅
`cargo test -p codewhale-tui -- status_item` → 7/7 ✅

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a per-provider `insecure_skip_tls_verify` flag to the `[providers.<name>]` TOML table, letting users accept self-signed or invalid TLS certificates on a provider-by-provider basis without any global bypass switch. The feature is correctly defaulted to `false`, emits a `logging::warn` when active, and is surfaced in both the human-readable and `--json` `doctor` output.

- `ProviderConfigToml` and `ProviderConfig` gain an `insecure_skip_tls_verify: Option<bool>` field; `build_http_client` passes the resolved value to `reqwest`'s `danger_accept_invalid_certs`.
- `Config::deepseek_insecure_skip_tls_verify()` resolves the flag for the active provider; it is consumed in `client.rs` and in both `run_doctor` / `run_doctor_json` in `main.rs`.
- `merge_provider_config` (TUI-side) correctly propagates the new field; a subset of providers in `config.example.toml` received the commented-out example line.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the core TLS toggle wires correctly end-to-end and defaults to secure behaviour.

The implementation correctly threads skip_verify through build_http_client, emits a log warning when TLS is disabled, surfaces the setting in both doctor output modes, and merges the field properly in the TUI-side merge_provider_config. The only new issues found in this review pass are naming style and a documentation gap in the example file — nothing that affects runtime correctness.

The merge_project_provider_config function in crates/config/src/lib.rs (already flagged in a prior review thread) still silently drops the new field for project-level configs — worth confirming that is addressed before merge.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/tui/src/config.rs | Adds insecure_skip_tls_verify to ProviderConfig and introduces deepseek_insecure_skip_tls_verify() — a method that applies to any active provider despite its DeepSeek-scoped name. merge_provider_config correctly propagates the field. |
| crates/config/src/lib.rs | Adds insecure_skip_tls_verify: Option<bool> to ProviderConfigToml. However, merge_project_provider_config (line 1527) still only propagates model and path_suffix, so the new field is silently dropped for project-level config files. |
| crates/tui/src/client.rs | Threads skip_verify through to build_http_client / danger_accept_invalid_certs correctly; emits a logging::warn when disabled; new unit tests cover both false and true cases. |
| crates/tui/src/main.rs | Adds TLS-disabled warning block to run_doctor output and insecure_skip_tls_verify field to run_doctor_json; both correctly call deepseek_insecure_skip_tls_verify(). |
| config.example.toml | Adds commented-out insecure_skip_tls_verify = false examples for a subset of providers; volcengine, openrouter, xiaomi_mimo, novita, siliconflow, arcee, moonshot, and huggingface sections are missing the line. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[config.toml\nproviders.X.insecure_skip_tls_verify] --> B[ProviderConfigToml]
    B --> C{merge_project_provider_config\ncrates/config}
    C -- "model, path_suffix only\n⚠ insecure_skip_tls_verify dropped" --> D[Merged ProviderConfigToml]
    D --> E[Config::deepseek_insecure_skip_tls_verify\ncrates/tui/src/config.rs]
    E --> F{skip_verify?}
    F -- true --> G[logging::warn emitted]
    F -- true --> H[reqwest::Client::builder\n.danger_accept_invalid_certs true]
    F -- false --> H2[reqwest::Client::builder\n.danger_accept_invalid_certs false]
    E --> I[run_doctor / run_doctor_json\nmain.rs]
    H --> J[DeepSeekClient]
    H2 --> J
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/config/src/lib.rs`, line 1527-1534 ([link](https://github.com/hmbown/codewhale/blob/0975f9afe3e1982f77e9c23331b712b035f15bd6/crates/config/src/lib.rs#L1527-L1534)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> `merge_project_provider_config` silently drops `insecure_skip_tls_verify` set in a project-level config file. Only `model` and `path_suffix` are propagated, so a `.codewhale/config.toml` entry like `[providers.ollama] insecure_skip_tls_verify = true` will always be ignored — the effective config retains the user-level value (`None`/`false`) even when the project explicitly opts in.

   

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Finsecure-skip-tls-verify-config%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Finsecure-skip-tls-verify-config%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fconfig%2Fsrc%2Flib.rs%0ALine%3A%201527-1534%0A%0AComment%3A%0A%60merge_project_provider_config%60%20silently%20drops%20%60insecure_skip_tls_verify%60%20set%20in%20a%20project-level%20config%20file.%20Only%20%60model%60%20and%20%60path_suffix%60%20are%20propagated%2C%20so%20a%20%60.codewhale%2Fconfig.toml%60%20entry%20like%20%60%5Bproviders.ollama%5D%20insecure_skip_tls_verify%20%3D%20true%60%20will%20always%20be%20ignored%20%E2%80%94%20the%20effective%20config%20retains%20the%20user-level%20value%20%28%60None%60%2F%60false%60%29%20even%20when%20the%20project%20explicitly%20opts%20in.%0A%0A%60%60%60suggestion%0Afn%20merge_project_provider_config%28target%3A%20%26mut%20ProviderConfigToml%2C%20source%3A%20%26ProviderConfigToml%29%20%7B%0A%20%20%20%20if%20source.model.is_some%28%29%20%7B%0A%20%20%20%20%20%20%20%20target.model%20%3D%20source.model.clone%28%29%3B%0A%20%20%20%20%7D%0A%20%20%20%20if%20source.path_suffix.is_some%28%29%20%7B%0A%20%20%20%20%20%20%20%20target.path_suffix%20%3D%20source.path_suffix.clone%28%29%3B%0A%20%20%20%20%7D%0A%20%20%20%20if%20source.insecure_skip_tls_verify.is_some%28%29%20%7B%0A%20%20%20%20%20%20%20%20target.insecure_skip_tls_verify%20%3D%20source.insecure_skip_tls_verify%3B%0A%20%20%20%20%7D%0A%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=1893&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fconfig%2Fsrc%2Flib.rs%0ALine%3A%201527-1534%0A%0AComment%3A%0A%60merge_project_provider_config%60%20silently%20drops%20%60insecure_skip_tls_verify%60%20set%20in%20a%20project-level%20config%20file.%20Only%20%60model%60%20and%20%60path_suffix%60%20are%20propagated%2C%20so%20a%20%60.codewhale%2Fconfig.toml%60%20entry%20like%20%60%5Bproviders.ollama%5D%20insecure_skip_tls_verify%20%3D%20true%60%20will%20always%20be%20ignored%20%E2%80%94%20the%20effective%20config%20retains%20the%20user-level%20value%20%28%60None%60%2F%60false%60%29%20even%20when%20the%20project%20explicitly%20opts%20in.%0A%0A%60%60%60suggestion%0Afn%20merge_project_provider_config%28target%3A%20%26mut%20ProviderConfigToml%2C%20source%3A%20%26ProviderConfigToml%29%20%7B%0A%20%20%20%20if%20source.model.is_some%28%29%20%7B%0A%20%20%20%20%20%20%20%20target.model%20%3D%20source.model.clone%28%29%3B%0A%20%20%20%20%7D%0A%20%20%20%20if%20source.path_suffix.is_some%28%29%20%7B%0A%20%20%20%20%20%20%20%20target.path_suffix%20%3D%20source.path_suffix.clone%28%29%3B%0A%20%20%20%20%7D%0A%20%20%20%20if%20source.insecure_skip_tls_verify.is_some%28%29%20%7B%0A%20%20%20%20%20%20%20%20target.insecure_skip_tls_verify%20%3D%20source.insecure_skip_tls_verify%3B%0A%20%20%20%20%7D%0A%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=1893&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fconfig%2Fsrc%2Flib.rs%0ALine%3A%201527-1534%0A%0AComment%3A%0A%60merge_project_provider_config%60%20silently%20drops%20%60insecure_skip_tls_verify%60%20set%20in%20a%20project-level%20config%20file.%20Only%20%60model%60%20and%20%60path_suffix%60%20are%20propagated%2C%20so%20a%20%60.codewhale%2Fconfig.toml%60%20entry%20like%20%60%5Bproviders.ollama%5D%20insecure_skip_tls_verify%20%3D%20true%60%20will%20always%20be%20ignored%20%E2%80%94%20the%20effective%20config%20retains%20the%20user-level%20value%20%28%60None%60%2F%60false%60%29%20even%20when%20the%20project%20explicitly%20opts%20in.%0A%0A%60%60%60suggestion%0Afn%20merge_project_provider_config%28target%3A%20%26mut%20ProviderConfigToml%2C%20source%3A%20%26ProviderConfigToml%29%20%7B%0A%20%20%20%20if%20source.model.is_some%28%29%20%7B%0A%20%20%20%20%20%20%20%20target.model%20%3D%20source.model.clone%28%29%3B%0A%20%20%20%20%7D%0A%20%20%20%20if%20source.path_suffix.is_some%28%29%20%7B%0A%20%20%20%20%20%20%20%20target.path_suffix%20%3D%20source.path_suffix.clone%28%29%3B%0A%20%20%20%20%7D%0A%20%20%20%20if%20source.insecure_skip_tls_verify.is_some%28%29%20%7B%0A%20%20%20%20%20%20%20%20target.insecure_skip_tls_verify%20%3D%20source.insecure_skip_tls_verify%3B%0A%20%20%20%20%7D%0A%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=1893&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Finsecure-skip-tls-verify-config%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Finsecure-skip-tls-verify-config%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fconfig.rs%3A2603-2609%0A**Misleading%20%60deepseek_%60%20prefix%20on%20a%20provider-agnostic%20method.**%20The%20function%20reads%20%60self.provider_config%28%29%60%2C%20which%20resolves%20the%20*active*%20provider%20%28Ollama%2C%20vLLM%2C%20OpenAI%2C%20etc.%29%2C%20not%20just%20DeepSeek.%20The%20%60deepseek_%60%20prefix%20implies%20DeepSeek-only%20scope%2C%20which%20will%20confuse%20future%20callers%20and%20makes%20grepping%20for%20per-provider%20helpers%20harder.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Whether%20the%20active%20provider%20should%20have%20TLS%20certificate%20verification%20skipped.%0A%20%20%20%20%2F%2F%2F%0A%20%20%20%20%2F%2F%2F%20Returns%20%60true%60%20only%20when%20the%20provider%20explicitly%20sets%0A%20%20%20%20%2F%2F%2F%20%60insecure_skip_tls_verify%20%3D%20true%60%20in%20its%20%60%5Bproviders.%3Cname%3E%5D%60%20table.%0A%20%20%20%20%2F%2F%2F%20Defaults%20to%20%60false%60%20%28verify%20certificates%29.%0A%20%20%20%20%23%5Bmust_use%5D%0A%20%20%20%20pub%20fn%20insecure_skip_tls_verify%28%26self%29%20-%3E%20bool%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aconfig.example.toml%3A313-401%0A**%60insecure_skip_tls_verify%60%20omitted%20from%20several%20provider%20sections.**%20Eight%20provider%20blocks%20%E2%80%94%20%60volcengine%60%2C%20%60openrouter%60%2C%20%60xiaomi_mimo%60%2C%20%60novita%60%2C%20%60siliconflow%60%2C%20%60arcee%60%2C%20%60moonshot%60%2C%20and%20%60huggingface%60%20%E2%80%94%20do%20not%20include%20the%20commented-out%20%60%23%20insecure_skip_tls_verify%20%3D%20false%60%20line%20that%20all%20other%20providers%20now%20have.%20Users%20of%20these%20providers%20won't%20see%20the%20option%20while%20browsing%20the%20example%20file.%0A%0A&repo=hmbown%2Fcodewhale&pr=1893&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fconfig.rs%3A2603-2609%0A**Misleading%20%60deepseek_%60%20prefix%20on%20a%20provider-agnostic%20method.**%20The%20function%20reads%20%60self.provider_config%28%29%60%2C%20which%20resolves%20the%20*active*%20provider%20%28Ollama%2C%20vLLM%2C%20OpenAI%2C%20etc.%29%2C%20not%20just%20DeepSeek.%20The%20%60deepseek_%60%20prefix%20implies%20DeepSeek-only%20scope%2C%20which%20will%20confuse%20future%20callers%20and%20makes%20grepping%20for%20per-provider%20helpers%20harder.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Whether%20the%20active%20provider%20should%20have%20TLS%20certificate%20verification%20skipped.%0A%20%20%20%20%2F%2F%2F%0A%20%20%20%20%2F%2F%2F%20Returns%20%60true%60%20only%20when%20the%20provider%20explicitly%20sets%0A%20%20%20%20%2F%2F%2F%20%60insecure_skip_tls_verify%20%3D%20true%60%20in%20its%20%60%5Bproviders.%3Cname%3E%5D%60%20table.%0A%20%20%20%20%2F%2F%2F%20Defaults%20to%20%60false%60%20%28verify%20certificates%29.%0A%20%20%20%20%23%5Bmust_use%5D%0A%20%20%20%20pub%20fn%20insecure_skip_tls_verify%28%26self%29%20-%3E%20bool%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aconfig.example.toml%3A313-401%0A**%60insecure_skip_tls_verify%60%20omitted%20from%20several%20provider%20sections.**%20Eight%20provider%20blocks%20%E2%80%94%20%60volcengine%60%2C%20%60openrouter%60%2C%20%60xiaomi_mimo%60%2C%20%60novita%60%2C%20%60siliconflow%60%2C%20%60arcee%60%2C%20%60moonshot%60%2C%20and%20%60huggingface%60%20%E2%80%94%20do%20not%20include%20the%20commented-out%20%60%23%20insecure_skip_tls_verify%20%3D%20false%60%20line%20that%20all%20other%20providers%20now%20have.%20Users%20of%20these%20providers%20won't%20see%20the%20option%20while%20browsing%20the%20example%20file.%0A%0A&repo=hmbown%2Fcodewhale&pr=1893&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fconfig.rs%3A2603-2609%0A**Misleading%20%60deepseek_%60%20prefix%20on%20a%20provider-agnostic%20method.**%20The%20function%20reads%20%60self.provider_config%28%29%60%2C%20which%20resolves%20the%20*active*%20provider%20%28Ollama%2C%20vLLM%2C%20OpenAI%2C%20etc.%29%2C%20not%20just%20DeepSeek.%20The%20%60deepseek_%60%20prefix%20implies%20DeepSeek-only%20scope%2C%20which%20will%20confuse%20future%20callers%20and%20makes%20grepping%20for%20per-provider%20helpers%20harder.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Whether%20the%20active%20provider%20should%20have%20TLS%20certificate%20verification%20skipped.%0A%20%20%20%20%2F%2F%2F%0A%20%20%20%20%2F%2F%2F%20Returns%20%60true%60%20only%20when%20the%20provider%20explicitly%20sets%0A%20%20%20%20%2F%2F%2F%20%60insecure_skip_tls_verify%20%3D%20true%60%20in%20its%20%60%5Bproviders.%3Cname%3E%5D%60%20table.%0A%20%20%20%20%2F%2F%2F%20Defaults%20to%20%60false%60%20%28verify%20certificates%29.%0A%20%20%20%20%23%5Bmust_use%5D%0A%20%20%20%20pub%20fn%20insecure_skip_tls_verify%28%26self%29%20-%3E%20bool%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aconfig.example.toml%3A313-401%0A**%60insecure_skip_tls_verify%60%20omitted%20from%20several%20provider%20sections.**%20Eight%20provider%20blocks%20%E2%80%94%20%60volcengine%60%2C%20%60openrouter%60%2C%20%60xiaomi_mimo%60%2C%20%60novita%60%2C%20%60siliconflow%60%2C%20%60arcee%60%2C%20%60moonshot%60%2C%20and%20%60huggingface%60%20%E2%80%94%20do%20not%20include%20the%20commented-out%20%60%23%20insecure_skip_tls_verify%20%3D%20false%60%20line%20that%20all%20other%20providers%20now%20have.%20Users%20of%20these%20providers%20won't%20see%20the%20option%20while%20browsing%20the%20example%20file.%0A%0A&pr=1893&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (14): Last reviewed commit: ["feat: per-provider TLS toggle (rebased)"](https://github.com/hmbown/codewhale/commit/02932f1ea75cbfaf6484ea2a923255d1edfd7106) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33797989)</sub>

<!-- /greptile_comment -->