### PR TITLE
fix(tui): suppress verbose CLI logging on Windows alt-screen to prevent TUI leak

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,7 +803,7 @@ checksum = "e9b18233253483ce2f65329a24072ec414db782531bdbb7d0bbc4bd2ce6b7e21"
 
 [[package]]
 name = "codewhale-agent"
-version = "0.8.43"
+version = "0.8.44"
 dependencies = [
  "codewhale-config",
  "serde",
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-app-server"
-version = "0.8.43"
+version = "0.8.44"
 dependencies = [
  "anyhow",
  "axum",
@@ -833,7 +833,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-cli"
-version = "0.8.43"
+version = "0.8.44"
 dependencies = [
  "anyhow",
  "chrono",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-config"
-version = "0.8.43"
+version = "0.8.44"
 dependencies = [
  "anyhow",
  "codewhale-secrets",
@@ -870,7 +870,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-core"
-version = "0.8.43"
+version = "0.8.44"
 dependencies = [
  "anyhow",
  "chrono",
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-execpolicy"
-version = "0.8.43"
+version = "0.8.44"
 dependencies = [
  "anyhow",
  "codewhale-protocol",
@@ -897,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-hooks"
-version = "0.8.43"
+version = "0.8.44"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-mcp"
-version = "0.8.43"
+version = "0.8.44"
 dependencies = [
  "anyhow",
  "serde",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-protocol"
-version = "0.8.43"
+version = "0.8.44"
 dependencies = [
  "serde",
  "serde_json",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-secrets"
-version = "0.8.43"
+version = "0.8.44"
 dependencies = [
  "dirs",
  "keyring",
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-state"
-version = "0.8.43"
+version = "0.8.44"
 dependencies = [
  "anyhow",
  "chrono",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-tools"
-version = "0.8.43"
+version = "0.8.44"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-tui"
-version = "0.8.43"
+version = "0.8.44"
 dependencies = [
  "anyhow",
  "arboard",
@@ -977,6 +977,7 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
+ "codewhale-config",
  "codewhale-secrets",
  "codewhale-tools",
  "colored",
@@ -1031,7 +1032,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-tui-core"
-version = "0.8.43"
+version = "0.8.44"
 
 [[package]]
 name = "colorchoice"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = ["crates/cli", "crates/app-server", "crates/tui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.8.43"
+version = "0.8.44"
 edition = "2024"
 # Rust 1.88 stabilized `let_chains` in `if`/`while` conditions, which the
 # codebase relies on extensively. Cargo enforces this so users on older


### PR DESCRIPTION
## Summary

This is the **missing second commit** from PR #1776. The maintainer merged the first commit (stop `RUST_LOG` from leaking tracing messages) but closed PR #1776 without merging this follow-up fix.

## Problem

On Windows, `stderr` cannot be redirected to the log file (no `dup2`). When `--verbose` or `DEEPSEEK_LOG_LEVEL=debug` is set, `eprintln!` calls from `crate::logging` still leak into the TUI alt-screen buffer, corrupting the display � even after the `RUST_LOG` fix was merged.

## Fix

Call `crate::logging::set_verbose(false)` at two points:

1. **`run_tui()`** � right after `EnterAlternateScreen`, so verbose logging is suppressed for the entire TUI session on Windows.
2. **`resume_terminal()`** � right after re-entering alt-screen during terminal recovery, so the suppression holds across suspend/resume cycles.

## Changes

- `crates/tui/src/tui/ui.rs`: +9 lines � `set_verbose(false)` calls in `run_tui` and `resume_terminal`, gated by `#[cfg(windows)]`.

## Related

- Issue: #1774 (original bug report)
- PR #1776 (original PR � only first commit was merged)
- Closes #1909 (tracking issue for this missing fix)

Urgent: this is a regression on Windows for users who run with verbose/debug logging.
