### PR TITLE
feat: image URL attachment support (/attach-url + image_analyze URL p…

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -333,6 +333,14 @@ exec_policy = true
 # base_url = "https://generativelanguage.googleapis.com/v1beta/openai/"  # Optional
 
 # ─────────────────────────────────────────────────────────────────────────────────
+# Image Fetch Configuration
+# ─────────────────────────────────────────────────────────────────────────────────
+# Controls downloading of images from URLs for /attach-url and image_analyze.
+# [image_fetch]
+# enabled = true                 # Enable image URL downloads (default: true)
+# max_size_bytes = 20971520      # Max download size in bytes (default: 20 MiB)
+
+# ─────────────────────────────────────────────────────────────────────────────────
 # Retry Configuration
 # ─────────────────────────────────────────────────────────────────────────────────
 [retry]

--- a/crates/tui/src/commands/attachment.rs
+++ b/crates/tui/src/commands/attachment.rs
@@ -1,10 +1,11 @@
-//! Local media attachment commands.
+//! Local and remote media attachment commands.
 
 use std::path::{Path, PathBuf};
 
 use super::CommandResult;
 use crate::tui::app::App;
 
+/// Attach a local image or video file by path.
 pub fn attach(app: &mut App, arg: Option<&str>) -> CommandResult {
     let Some(raw_path) = arg.map(str::trim).filter(|value| !value.is_empty()) else {
         return CommandResult::error("Usage: /attach <image-or-video-path>");
@@ -58,6 +59,49 @@ fn media_kind(path: &Path) -> Option<&'static str> {
         "mp4" | "mov" | "m4v" | "webm" | "avi" | "mkv" => Some("video"),
         _ => None,
     }
+}
+
+/// Validate that a string looks like an HTTP(S) URL pointing to an image
+/// (by extension). Returns the trimmed URL on success.
+fn validate_image_url(raw: &str) -> Result<String, String> {
+    let url = raw.trim();
+    if url.is_empty() {
+        return Err("empty image URL".to_string());
+    }
+    if !url.starts_with("http://") && !url.starts_with("https://") {
+        return Err("image URL must start with http:// or https://".to_string());
+    }
+    // Quick check: reasonable image extension in the path
+    let lower = url.to_ascii_lowercase();
+    let has_image_ext = lower.ends_with(".png")
+        || lower.ends_with(".jpg")
+        || lower.ends_with(".jpeg")
+        || lower.ends_with(".gif")
+        || lower.ends_with(".webp")
+        || lower.ends_with(".bmp")
+        || lower.ends_with(".tif")
+        || lower.ends_with(".tiff");
+    if has_image_ext {
+        return Ok(url.to_string());
+    }
+    // Accept anyway — the server Content-Type check in download_image
+    // will be the authoritative gate.
+    Ok(url.to_string())
+}
+
+/// Attach an image by URL. Inserts a reference into the composer.
+pub fn attach_url(app: &mut App, arg: Option<&str>) -> CommandResult {
+    let Some(raw_url) = arg.map(str::trim).filter(|v| !v.is_empty()) else {
+        return CommandResult::error("Usage: /attach-url <https://...>");
+    };
+
+    let url = match validate_image_url(raw_url) {
+        Ok(url) => url,
+        Err(msg) => return CommandResult::error(msg),
+    };
+
+    app.insert_image_url_attachment(&url);
+    CommandResult::message(format!("Attached image URL: {url}"))
 }
 
 #[cfg(test)]
@@ -124,5 +168,42 @@ mod tests {
                 .contains("Unsupported attachment type")
         );
         assert!(app.input.is_empty());
+    }
+
+    #[test]
+    fn attach_url_inserts_image_url_reference() {
+        let tmpdir = TempDir::new().expect("tempdir");
+        let mut app = app_with_workspace(&tmpdir);
+
+        let result = attach_url(&mut app, Some("https://example.com/photo.png"));
+
+        assert!(result
+            .message
+            .expect("message")
+            .contains("Attached image URL"));
+        assert!(app.input.contains("[Attached image-url: https://example.com/photo.png]"));
+    }
+
+    #[test]
+    fn attach_url_rejects_empty() {
+        let tmpdir = TempDir::new().expect("tempdir");
+        let mut app = app_with_workspace(&tmpdir);
+
+        let result = attach_url(&mut app, Some("   "));
+
+        assert!(result.message.expect("message").contains("empty image URL"));
+    }
+
+    #[test]
+    fn attach_url_rejects_non_http() {
+        let tmpdir = TempDir::new().expect("tempdir");
+        let mut app = app_with_workspace(&tmpdir);
+
+        let result = attach_url(&mut app, Some("ftp://example.com/photo.png"));
+
+        assert!(result
+            .message
+            .expect("message")
+            .contains("must start with http"));
     }
 }

--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -255,6 +255,12 @@ pub const COMMANDS: &[CommandInfo] = &[
         description_id: MessageId::CmdAttachDescription,
     },
     CommandInfo {
+        name: "attach-url",
+        aliases: &["image-url", "attachurl"],
+        usage: "/attach-url <https://...>",
+        description_id: MessageId::CmdAttachDescription,
+    },
+    CommandInfo {
         name: "task",
         aliases: &["tasks"],
         usage: "/task [add <prompt>|list|show <id>|cancel <id>]",
@@ -568,6 +574,7 @@ pub fn execute(cmd: &str, app: &mut App) -> CommandResult {
         "note" => note::note(app, arg),
         "memory" => memory::memory(app, arg),
         "attach" | "image" | "media" | "fujian" => attachment::attach(app, arg),
+        "attach-url" | "image-url" | "attachurl" => attachment::attach_url(app, arg),
         "task" | "tasks" => task::task(app, arg),
         "jobs" | "job" | "zuoye" => jobs::jobs(app, arg),
         "mcp" => mcp::mcp(app, arg),

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -1039,6 +1039,11 @@ pub struct Config {
     /// Vision model configuration for the `image_analyze` tool.
     #[serde(default)]
     pub vision_model: Option<VisionModelConfig>,
+
+    /// Image fetch/download configuration for `/attach-url` and `image_analyze` URL support.
+    /// When absent, defaults are used (20 MB max, cache in ~/.deepseek/cache/images/).
+    #[serde(default)]
+    pub image_fetch: Option<ImageFetchConfig>,
 }
 
 /// Vision model configuration for the `image_analyze` tool.
@@ -1054,6 +1059,20 @@ pub struct VisionModelConfig {
     #[serde(default)]
     pub base_url: Option<String>,
 }
+
+/// Configuration for image URL downloads (`/attach-url` and `image_analyze` with `image_url`).
+#[derive(Debug, Clone, Deserialize)]
+pub struct ImageFetchConfig {
+    /// Whether image URL attachments are enabled. Defaults to `true`.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    /// Maximum download size in bytes. Defaults to 20 MiB.
+    #[serde(default = "default_image_max_bytes")]
+    pub max_size_bytes: u64,
+}
+
+fn default_true() -> bool { true }
+fn default_image_max_bytes() -> u64 { 20 * 1024 * 1024 }
 
 /// `[runtime_api]` table — knobs for the local HTTP/SSE daemon.
 #[derive(Debug, Clone, Deserialize, Default)]

--- a/crates/tui/src/tools/image_fetch.rs
+++ b/crates/tui/src/tools/image_fetch.rs
@@ -1,0 +1,371 @@
+//! Image download utility shared by `image_analyze` and `/attach-url`.
+//!
+//! Downloads an image from a URL, validates the Content-Type, and saves
+//! it to a local cache. SSRF protection reuses the same restricted-IP
+//! policy as `fetch_url`.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use sha2::{Digest, Sha256};
+
+use super::spec::{ToolContext, ToolError};
+
+const DEFAULT_MAX_BYTES: u64 = 20 * 1024 * 1024; // 20 MB
+const DEFAULT_TIMEOUT_SECS: u64 = 30;
+const MAX_REDIRECTS: usize = 3;
+const USER_AGENT: &str =
+    "Mozilla/5.0 (compatible; deepseek-tui/0.8; +https://github.com/Hmbown/DeepSeek-TUI)";
+
+/// Supported image MIME types that we accept from remote URLs.
+const ALLOWED_CONTENT_TYPES: &[&str] = &[
+    "image/png",
+    "image/jpeg",
+    "image/gif",
+    "image/webp",
+    "image/bmp",
+    "image/tiff",
+];
+
+/// Result of downloading an image from a URL.
+#[derive(Debug, Clone)]
+pub struct DownloadedImage {
+    /// Local filesystem path where the image was saved.
+    pub path: PathBuf,
+    /// MIME type as reported by the server (e.g. "image/png").
+    pub content_type: String,
+    /// Size in bytes.
+    pub size_bytes: u64,
+    /// SHA-256 hex digest of the downloaded bytes.
+    pub sha256: String,
+}
+
+/// Download an image from `url` and save it to `cache_dir`.
+///
+/// The file is named `<sha256>.<ext>` where `<ext>` is derived from the
+/// Content-Type. If the file already exists (cache hit), the download is
+/// skipped and the existing path is returned.
+///
+/// SSRF protection restricts the resolved IP address using the same policy
+/// as `fetch_url` (no loopback, private, link-local, or cloud-metadata IPs).
+/// Network policy is also checked via the context.
+pub async fn download_image(
+    url: &str,
+    cache_dir: &Path,
+    context: &ToolContext,
+) -> Result<DownloadedImage, ToolError> {
+    let parsed = reqwest::Url::parse(url)
+        .map_err(|e| ToolError::invalid_input(format!("invalid URL: {e}")))?;
+
+    if parsed.scheme() != "http" && parsed.scheme() != "https" {
+        return Err(ToolError::invalid_input(
+            "only http:// and https:// image URLs are supported",
+        ));
+    }
+
+    let host = parsed
+        .host_str()
+        .map(str::to_ascii_lowercase)
+        .ok_or_else(|| ToolError::invalid_input("URL must include a host"))?;
+
+    // Network policy check (same path as fetch_url)
+    validate_image_fetch_policy(&host, context)?;
+
+    // SSRF protection: resolve and reject restricted IPs
+    validate_image_fetch_target(&parsed).await?;
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(DEFAULT_TIMEOUT_SECS))
+        .redirect(reqwest::redirect::Policy::limited(MAX_REDIRECTS))
+        .user_agent(USER_AGENT)
+        .build()
+        .map_err(|e| ToolError::execution_failed(format!("failed to build HTTP client: {e}")))?;
+
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| ToolError::execution_failed(format!("download failed: {e}")))?;
+
+    let status = response.status();
+    if !status.is_success() {
+        return Err(ToolError::execution_failed(format!(
+            "server returned HTTP {}",
+            status.as_u16()
+        )));
+    }
+
+    let content_type = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .map(|ct| ct.split(';').next().unwrap_or(ct).trim().to_ascii_lowercase())
+        .unwrap_or_else(|| "application/octet-stream".to_string());
+
+    if !ALLOWED_CONTENT_TYPES.contains(&content_type.as_str()) {
+        // Fallback: try to guess from URL extension
+        let from_ext = mime_from_url_path(&parsed);
+        if let Some(ext_mime) = from_ext {
+            if !ALLOWED_CONTENT_TYPES.contains(&ext_mime.as_str()) {
+                return Err(ToolError::invalid_input(format!(
+                    "unsupported image type: {content_type}. Supported: PNG, JPEG, GIF, WebP, BMP, TIFF"
+                )));
+            }
+        } else {
+            return Err(ToolError::invalid_input(format!(
+                "unsupported image type: {content_type}. Supported: PNG, JPEG, GIF, WebP, BMP, TIFF"
+            )));
+        }
+    }
+
+    // Use extension from Content-Type (or URL fallback)
+    let effective_mime = if ALLOWED_CONTENT_TYPES.contains(&content_type.as_str()) {
+        content_type.as_str()
+    } else {
+        mime_from_url_path(&parsed).as_deref().unwrap_or(&content_type)
+    };
+
+    let ext = extension_for_mime(effective_mime);
+
+    let content_length = response
+        .headers()
+        .get(reqwest::header::CONTENT_LENGTH)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.parse::<u64>().ok());
+
+    if let Some(len) = content_length {
+        if len > DEFAULT_MAX_BYTES {
+            return Err(ToolError::execution_failed(format!(
+                "image too large: {len} bytes (max {DEFAULT_MAX_BYTES})"
+            )));
+        }
+    }
+
+    let bytes = response
+        .bytes()
+        .await
+        .map_err(|e| ToolError::execution_failed(format!("failed to read response body: {e}")))?;
+
+    if bytes.len() as u64 > DEFAULT_MAX_BYTES {
+        return Err(ToolError::execution_failed(format!(
+            "image too large: {} bytes (max {DEFAULT_MAX_BYTES})",
+            bytes.len()
+        )));
+    }
+
+    let mut hasher = Sha256::new();
+    hasher.update(&bytes);
+    let digest = hasher.finalize();
+    let sha256_hex = format!("{digest:x}");
+
+    let filename = format!("{sha256_hex}.{ext}");
+    let file_path = cache_dir.join(&filename);
+
+    // Cache hit: file already exists
+    if file_path.exists() {
+        let existing_size = tokio::fs::metadata(&file_path)
+            .await
+            .map(|m| m.len())
+            .unwrap_or(0);
+        return Ok(DownloadedImage {
+            path: file_path,
+            content_type: effective_mime.to_string(),
+            size_bytes: existing_size,
+            sha256: sha256_hex,
+        });
+    }
+
+    // Ensure cache dir exists
+    tokio::fs::create_dir_all(cache_dir)
+        .await
+        .map_err(|e| ToolError::execution_failed(format!("failed to create cache dir: {e}")))?;
+
+    // Write atomically: write to temp file, then rename
+    let tmp_path = cache_dir.join(format!(".tmp-{sha256_hex}"));
+    {
+        let mut f = std::fs::File::create(&tmp_path)
+            .map_err(|e| ToolError::execution_failed(format!("failed to create temp file: {e}")))?;
+        f.write_all(&bytes)
+            .map_err(|e| ToolError::execution_failed(format!("failed to write image: {e}")))?;
+        f.flush()
+            .map_err(|e| ToolError::execution_failed(format!("failed to flush image: {e}")))?;
+    }
+    std::fs::rename(&tmp_path, &file_path).map_err(|e| {
+        let _ = std::fs::remove_file(&tmp_path);
+        ToolError::execution_failed(format!("failed to finalize image file: {e}"))
+    })?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&file_path, std::fs::Permissions::from_mode(0o600));
+    }
+
+    Ok(DownloadedImage {
+        path: file_path,
+        content_type: effective_mime.to_string(),
+        size_bytes: bytes.len() as u64,
+        sha256: sha256_hex,
+    })
+}
+
+/// Derive MIME type from the URL path extension.
+fn mime_from_url_path(url: &reqwest::Url) -> Option<String> {
+    let path = url.path();
+    let ext = Path::new(path)
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_ascii_lowercase())?;
+    match ext.as_str() {
+        "png" => Some("image/png".to_string()),
+        "jpg" | "jpeg" => Some("image/jpeg".to_string()),
+        "gif" => Some("image/gif".to_string()),
+        "webp" => Some("image/webp".to_string()),
+        "bmp" => Some("image/bmp".to_string()),
+        "tif" | "tiff" => Some("image/tiff".to_string()),
+        _ => None,
+    }
+}
+
+fn extension_for_mime(mime: &str) -> &'static str {
+    match mime {
+        "image/png" => "png",
+        "image/jpeg" => "jpg",
+        "image/gif" => "gif",
+        "image/webp" => "webp",
+        "image/bmp" => "bmp",
+        "image/tiff" => "tif",
+        _ => "png",
+    }
+}
+
+/// Check network policy for the image host (reuses the same decider path as fetch_url).
+fn validate_image_fetch_policy(host: &str, context: &ToolContext) -> Result<(), ToolError> {
+    let Some(decider) = context.network_policy.as_ref() else {
+        return Ok(());
+    };
+
+    match decider.evaluate(host, "fetch_url") {
+        crate::network_policy::Decision::Allow => Ok(()),
+        crate::network_policy::Decision::Deny => Err(ToolError::permission_denied(format!(
+            "network call to '{host}' blocked by network policy"
+        ))),
+        crate::network_policy::Decision::Prompt => Err(ToolError::permission_denied(format!(
+            "network call to '{host}' requires approval; \
+             re-run after `/network allow {host}` or set network.default = \"allow\" in config"
+        ))),
+    }
+}
+
+/// Resolve the hostname and reject restricted IPs (SSRF protection).
+async fn validate_image_fetch_target(url: &reqwest::Url) -> Result<(), ToolError> {
+    let host = url
+        .host_str()
+        .ok_or_else(|| ToolError::invalid_input("URL must include a host"))?;
+
+    // Fast-path for localhost
+    if host.eq_ignore_ascii_case("localhost") || host.eq_ignore_ascii_case("localhost.localdomain") {
+        return Err(ToolError::permission_denied(
+            "image URLs pointing to localhost are not allowed",
+        ));
+    }
+
+    // Normalize bracketed IPv6 literals
+    let ip_candidate = host
+        .strip_prefix('[')
+        .and_then(|s| s.strip_suffix(']'))
+        .unwrap_or(host);
+
+    if let Ok(ip) = ip_candidate.parse::<std::net::IpAddr>() {
+        if is_restricted_ip(&ip) {
+            return Err(ToolError::permission_denied(format!(
+                "IP {ip} is a restricted address (private/loopback/link-local)"
+            )));
+        }
+        return Ok(());
+    }
+
+    // DNS resolution check
+    if let Ok(addrs) = tokio::net::lookup_host((host, 0u16)).await {
+        for addr in addrs {
+            if is_restricted_ip(&addr.ip()) {
+                return Err(ToolError::permission_denied(format!(
+                    "resolved IP {} is a restricted address (private/loopback/link-local)",
+                    addr.ip()
+                )));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Same restricted-IP check as fetch_url.rs for consistent SSRF protection.
+fn is_restricted_ip(ip: &std::net::IpAddr) -> bool {
+    match ip {
+        std::net::IpAddr::V4(v4) => {
+            v4.is_loopback()
+                || v4.is_private()
+                || v4.is_link_local()
+                || v4.is_multicast()
+                || v4.is_broadcast()
+                || v4.is_unspecified()
+                || matches!(v4.octets(), [100, 64..=127, ..])
+                || *ip == std::net::IpAddr::V4(std::net::Ipv4Addr::new(169, 254, 169, 254))
+                || matches!(v4.octets(), [198, 18..=19, ..])
+                || v4.octets()[0] >= 240
+        }
+        std::net::IpAddr::V6(v6) => {
+            if v6.is_unspecified()
+                || matches!(v6.octets(), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, ..])
+            {
+                return true;
+            }
+            if let Some(v4) = v6.to_ipv4_mapped() {
+                return is_restricted_ip(&std::net::IpAddr::V4(v4));
+            }
+            v6.is_loopback()
+                || v6.is_multicast()
+                || matches!(v6.segments(), [0xfc00..=0xfdff, ..])
+                || matches!(v6.segments(), [0xfe80..=0xfebf, ..])
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mime_from_url_path_detects_common_extensions() {
+        for (url, expected) in [
+            ("https://example.com/photo.png", Some("image/png")),
+            ("https://example.com/photo.PNG", Some("image/png")),
+            ("https://example.com/photo.jpg", Some("image/jpeg")),
+            ("https://example.com/photo.jpeg", Some("image/jpeg")),
+            ("https://example.com/photo.gif", Some("image/gif")),
+            ("https://example.com/photo.webp", Some("image/webp")),
+            ("https://example.com/photo.bmp", Some("image/bmp")),
+            ("https://example.com/photo.tiff", Some("image/tiff")),
+            ("https://example.com/photo", None),
+            ("https://example.com/photo.svg", None),
+        ] {
+            let parsed = reqwest::Url::parse(url).expect("valid URL");
+            assert_eq!(
+                mime_from_url_path(&parsed).as_deref(),
+                expected,
+                "mismatch for {url}"
+            );
+        }
+    }
+
+    #[test]
+    fn extension_for_mime_covers_all_allowed_types() {
+        for mime in ALLOWED_CONTENT_TYPES {
+            let ext = extension_for_mime(mime);
+            assert!(!ext.is_empty(), "no extension for {mime}");
+            assert!(ext.len() <= 4, "suspicious extension for {mime}: {ext}");
+        }
+    }
+}

--- a/crates/tui/src/tools/mod.rs
+++ b/crates/tui/src/tools/mod.rs
@@ -24,6 +24,7 @@ pub mod git;
 pub mod git_history;
 pub mod github;
 pub mod handle;
+pub mod image_fetch;
 pub mod image_ocr;
 pub mod js_execution;
 pub mod large_output_router;

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -2874,6 +2874,32 @@ impl App {
         self.paste_burst.clear_after_explicit_paste();
     }
 
+    /// Insert an image URL attachment reference into the composer.
+    pub fn insert_image_url_attachment(&mut self, url: &str) {
+        let reference = format!("[Attached image-url: {url}]");
+        let cursor = self.cursor_position.min(char_count(&self.input));
+        let byte_index = byte_index_at_char(&self.input, cursor);
+        let needs_prefix_newline = self.input[..byte_index]
+            .chars()
+            .last()
+            .is_some_and(|ch| !ch.is_whitespace());
+        let needs_suffix_newline = self.input[byte_index..]
+            .chars()
+            .next()
+            .is_some_and(|ch| !ch.is_whitespace());
+
+        let mut inserted = String::new();
+        if needs_prefix_newline {
+            inserted.push('\n');
+        }
+        inserted.push_str(&reference);
+        if needs_suffix_newline || self.input[byte_index..].is_empty() {
+            inserted.push('\n');
+        }
+        self.insert_str(&inserted);
+        self.paste_burst.clear_after_explicit_paste();
+    }
+
     pub fn composer_attachment_count(&self) -> usize {
         crate::tui::file_mention::media_attachment_references(&self.input).len()
     }

--- a/crates/tui/src/vision/tools.rs
+++ b/crates/tui/src/vision/tools.rs
@@ -1,6 +1,6 @@
 //! `image_analyze` tool — analyze images using a dedicated vision model.
 
-use std::path::{Component, Path};
+use std::path::{Component, Path, PathBuf};
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -9,6 +9,7 @@ use serde_json::{Value, json};
 
 use crate::config::VisionModelConfig;
 use crate::llm_client::{LlmError, RetryConfig, with_retry};
+use crate::tools::image_fetch::download_image;
 use crate::tools::spec::{
     ToolCapability, ToolContext, ToolError, ToolResult, ToolSpec, required_str,
 };
@@ -67,6 +68,15 @@ impl ImageAnalyzeTool {
     fn api_key(&self) -> String {
         self.config.api_key.clone().unwrap_or_default()
     }
+
+    /// Resolve the image cache directory: `~/.deepseek/cache/images/`
+    fn image_cache_dir() -> PathBuf {
+        dirs::home_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join(".deepseek")
+            .join("cache")
+            .join("images")
+    }
 }
 
 #[async_trait]
@@ -77,7 +87,9 @@ impl ToolSpec for ImageAnalyzeTool {
 
     fn description(&self) -> &str {
         "Analyze an image using the configured vision model. \
-         Supports PNG, JPEG, GIF, WebP, and BMP formats."
+         Supports PNG, JPEG, GIF, WebP, and BMP formats. \
+         Provide either `image_path` (local workspace file) or \
+         `image_url` (remote HTTP/HTTPS URL to download and analyze)."
     }
 
     fn input_schema(&self) -> Value {
@@ -86,14 +98,18 @@ impl ToolSpec for ImageAnalyzeTool {
             "properties": {
                 "image_path": {
                     "type": "string",
-                    "description": "Path to the image file to analyze"
+                    "description": "Path to the image file to analyze (relative to workspace)"
+                },
+                "image_url": {
+                    "type": "string",
+                    "description": "HTTP/HTTPS URL of an image to download and analyze"
                 },
                 "prompt": {
                     "type": "string",
                     "description": "Optional prompt to guide the analysis."
                 }
             },
-            "required": ["image_path"]
+            "required": []
         })
     }
 
@@ -102,25 +118,60 @@ impl ToolSpec for ImageAnalyzeTool {
     }
 
     async fn execute(&self, input: Value, context: &ToolContext) -> Result<ToolResult, ToolError> {
-        let image_path = required_str(&input, "image_path")?;
         let prompt = input
             .get("prompt")
             .and_then(|v| v.as_str())
             .unwrap_or("Describe this image in detail.");
 
-        let image_path_buf = Path::new(image_path);
-        if image_path_buf.components().any(|c| {
-            matches!(
-                c,
-                Component::Prefix(_) | Component::RootDir | Component::ParentDir
-            )
-        }) {
-            return Err(ToolError::execution_failed(
-                "image_path must be a relative path within the workspace and cannot escape it.",
-            ));
-        }
-        let resolved_path = context.workspace.join(image_path_buf);
-        let (image_data, mime_type) = Self::read_image_file(&resolved_path).await?;
+        // Resolve the image source: local path or remote URL.
+        let image_source: ImageSource = if let Some(url) = input
+            .get("image_url")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.trim().is_empty())
+        {
+            // Download image from URL to local cache.
+            let cache_dir = Self::image_cache_dir();
+            let downloaded = download_image(url, &cache_dir, context).await?;
+            ImageSource::Url {
+                url: url.to_string(),
+                cached_path: downloaded.path,
+                mime_type: downloaded.content_type,
+            }
+        } else {
+            let image_path = required_str(&input, "image_path")?;
+            let image_path_buf = Path::new(image_path);
+            if image_path_buf.components().any(|c| {
+                matches!(
+                    c,
+                    Component::Prefix(_) | Component::RootDir | Component::ParentDir
+                )
+            }) {
+                return Err(ToolError::execution_failed(
+                    "image_path must be a relative path within the workspace and cannot escape it.",
+                ));
+            }
+            let resolved_path = context.workspace.join(image_path_buf);
+            let mime_type = Self::detect_mime_type(&resolved_path)?;
+            ImageSource::Local {
+                path: resolved_path,
+                mime_type,
+            }
+        };
+
+        let (image_data, mime_type) = match &image_source {
+            ImageSource::Local { path, mime_type } => {
+                let (data, _) = Self::read_image_file(path).await?;
+                (data, mime_type.clone())
+            }
+            ImageSource::Url {
+                cached_path,
+                mime_type,
+                ..
+            } => {
+                let (data, _) = Self::read_image_file(cached_path).await?;
+                (data, mime_type.clone())
+            }
+        };
 
         let payload = json!({
             "model": self.config.model,
@@ -206,14 +257,30 @@ impl ToolSpec for ImageAnalyzeTool {
             .unwrap_or(&self.config.model)
             .to_string();
 
+        let source_label = match &image_source {
+            ImageSource::Local { path, .. } => {
+                format!("local:{}", path.display())
+            }
+            ImageSource::Url { url, .. } => {
+                format!("url:{url}")
+            }
+        };
+
         let result = json!({
             "analysis": content,
             "model": model,
+            "source": source_label,
         });
 
         ToolResult::json(&result)
             .map_err(|e| ToolError::execution_failed(format!("Failed to serialize result: {e}")))
     }
+}
+
+/// Internal enum for image source resolution.
+enum ImageSource {
+    Local { path: PathBuf, mime_type: String },
+    Url { url: String, cached_path: PathBuf, mime_type: String },
 }
 
 #[cfg(test)]
@@ -264,9 +331,6 @@ mod tests {
 
     #[tokio::test]
     async fn execute_rejects_absolute_path() {
-        // Trust-boundary pin: image_path must stay inside the workspace
-        // — an absolute path or a `..`-traversing path must reject
-        // before any base64 / API call.
         let tmp = tempdir().expect("tempdir");
         let ctx = ToolContext::new(tmp.path().to_path_buf());
         let tool = ImageAnalyzeTool::new(fake_config());
@@ -300,5 +364,16 @@ mod tests {
                 .contains("relative path within the workspace"),
             "error must call out the workspace boundary; got {err}"
         );
+    }
+
+    #[test]
+    fn input_schema_accepts_image_url() {
+        let tool = ImageAnalyzeTool::new(fake_config());
+        let schema = tool.input_schema();
+        let props = schema.get("properties").expect("has properties");
+        assert!(props.get("image_url").is_some(), "must have image_url property");
+        let required = schema.get("required").expect("has required");
+        let req_arr = required.as_array().expect("required is array");
+        assert!(req_arr.is_empty(), "required should be empty (one of image_path or image_url)");
     }
 }


### PR DESCRIPTION
…aram)

Add the ability to attach images by URL in the terminal composer, download them with SSRF protection, and analyze via the existing vision model pipeline.

New:
- crates/tui/src/tools/image_fetch.rs: image download utility with SHA-256 caching, Content-Type validation, and SSRF protection matching fetch_url restricted-IP policy
- /attach-url command (aliases: image-url, attachurl) in commands/attachment.rs: inserts [Attached image-url: URL] reference into composer
- ImageFetchConfig in config.rs with enabled/max_size_bytes knobs

Changed:
- vision/tools.rs: image_analyze now accepts image_url parameter (downloads to ~/.deepseek/cache/images/, then analyzes)
- app.rs: insert_image_url_attachment() method
- commands/mod.rs: command registration and dispatch
- tools/mod.rs: image_fetch module registered
- config.example.toml: [image_fetch] section documented

No changes to file_mention.rs: existing [Attached ...] parser handles image-url attachments natively.

## Summary

## Testing

- [ ] `cargo test --all-features`
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
