### PR TITLE
feat(tui): replace [x] completion marker with [✓] across all sidebar panels

### DIFF
--- a/crates/tui/src/commands/skills.rs
+++ b/crates/tui/src/commands/skills.rs
@@ -441,7 +441,7 @@ fn sync_skills(app: &mut App) -> CommandResult {
                     }
                     SkillSyncOutcome::Denied { name, host } => {
                         failed += 1;
-                        let _ = writeln!(out, "  [x] {name} — network denied ({host})");
+                        let _ = writeln!(out, "  [✓] {name} — network denied ({host})");
                     }
                     SkillSyncOutcome::NeedsApproval { name, host } => {
                         failed += 1;

--- a/crates/tui/src/cycle_manager.rs
+++ b/crates/tui/src/cycle_manager.rs
@@ -284,7 +284,7 @@ impl StructuredState {
                 let marker = match item.status {
                     crate::tools::todo::TodoStatus::Pending => "[ ]",
                     crate::tools::todo::TodoStatus::InProgress => "[~]",
-                    crate::tools::todo::TodoStatus::Completed => "[x]",
+                    crate::tools::todo::TodoStatus::Completed => "[✓]",
                 };
                 out.push_str(&format!("- {marker} {}\n", item.content));
             }
@@ -299,7 +299,7 @@ impl StructuredState {
                 let marker = match item.status {
                     crate::tools::plan::StepStatus::Pending => "[ ]",
                     crate::tools::plan::StepStatus::InProgress => "[~]",
-                    crate::tools::plan::StepStatus::Completed => "[x]",
+                    crate::tools::plan::StepStatus::Completed => "[✓]",
                 };
                 out.push_str(&format!("- {marker} {}\n", item.step));
             }

--- a/crates/tui/src/tui/sidebar.rs
+++ b/crates/tui/src/tui/sidebar.rs
@@ -410,7 +410,7 @@ fn push_work_checklist_lines(
         let (prefix, color) = match item.status {
             TodoStatus::Pending => ("[ ]", palette::TEXT_MUTED),
             TodoStatus::InProgress => ("[~]", palette::STATUS_WARNING),
-            TodoStatus::Completed => ("[x]", palette::STATUS_SUCCESS),
+            TodoStatus::Completed => ("[✓]", palette::STATUS_SUCCESS),
         };
         let text = format!("{prefix} #{} {}", item.id, item.content);
         lines.push(Line::from(Span::styled(
@@ -501,7 +501,7 @@ fn push_work_strategy_lines(
         let (prefix, color) = match step.status {
             StepStatus::Pending => ("[ ]", theme.plan_pending_color),
             StepStatus::InProgress => ("[~]", theme.plan_in_progress_color),
-            StepStatus::Completed => ("[x]", theme.plan_completed_color),
+            StepStatus::Completed => ("[✓]", theme.plan_completed_color),
         };
         let mut text = format!("{prefix} {}", step.text);
         if !step.elapsed.is_empty() {
@@ -1304,7 +1304,7 @@ fn first_nonempty_line(text: &str) -> &str {
 fn tool_status_marker(status: ToolStatus) -> (&'static str, ratatui::style::Color) {
     match status {
         ToolStatus::Running => ("[~]", palette::STATUS_WARNING),
-        ToolStatus::Success => ("[x]", palette::STATUS_SUCCESS),
+        ToolStatus::Success => ("[✓]", palette::STATUS_SUCCESS),
         ToolStatus::Failed => ("[!]", palette::STATUS_ERROR),
     }
 }
@@ -1593,7 +1593,7 @@ pub fn subagent_panel_lines(
 fn agent_status_marker(status: &str) -> (&'static str, ratatui::style::Color) {
     match status {
         "running" => ("[~]", palette::STATUS_WARNING),
-        "done" => ("[x]", palette::STATUS_SUCCESS),
+        "done" => ("[✓]", palette::STATUS_SUCCESS),
         "failed" => ("[!]", palette::STATUS_ERROR),
         "canceled" | "interrupted" => ("[-]", palette::TEXT_MUTED),
         _ => ("[ ]", palette::TEXT_MUTED),
@@ -2066,7 +2066,7 @@ mod tests {
             "recent section missing: {text:?}"
         );
         assert!(
-            text.iter().any(|line| line.contains("[x] read_file")),
+            text.iter().any(|line| line.contains("[✓] read_file")),
             "recent read_file row missing: {text:?}"
         );
     }
@@ -2095,7 +2095,7 @@ mod tests {
         let text = lines_to_text(&task_panel_lines(&app, 64, 8));
 
         assert!(
-            !text.iter().any(|line| line.contains("[x] read_file")),
+            !text.iter().any(|line| line.contains("[✓] read_file")),
             "expired completed active row should leave the sidebar: {text:?}"
         );
     }
@@ -2133,7 +2133,7 @@ mod tests {
         let text = lines_to_text(&task_panel_lines(&app, 64, 8));
 
         assert!(
-            text.iter().any(|line| line.contains("[x] read_file")),
+            text.iter().any(|line| line.contains("[✓] read_file")),
             "fresh completed active row should linger briefly: {text:?}"
         );
     }
@@ -2262,7 +2262,7 @@ mod tests {
             .expect("failed grep row should stay visible");
         let read_group_index = text
             .iter()
-            .position(|line| line.contains("[x] read_file x3"))
+            .position(|line| line.contains("[✓] read_file x3"))
             .expect("repeated read_file rows should collapse");
 
         assert!(
@@ -2271,7 +2271,7 @@ mod tests {
         );
         assert_eq!(
             text.iter()
-                .filter(|line| line.contains("[x] read_file"))
+                .filter(|line| line.contains("[✓] read_file"))
                 .count(),
             1,
             "read_file should render once after grouping: {text:?}"
@@ -2371,7 +2371,7 @@ mod tests {
 
         assert!(
             text.iter()
-                .any(|line| line.contains("[x] cargo check 1.2s")),
+                .any(|line| line.contains("[✓] cargo check 1.2s")),
             "status marker and duration should stay in the row label: {text:?}"
         );
         assert!(

--- a/crates/tui/src/tui/views/status_picker.rs
+++ b/crates/tui/src/tui/views/status_picker.rs
@@ -204,7 +204,7 @@ impl ModalView for StatusPickerView {
         for (idx, item) in self.rows.iter().enumerate() {
             let checked = *self.selected.get(idx).unwrap_or(&false);
             let is_cursor = idx == self.cursor;
-            let mark = if checked { "[x]" } else { "[ ]" };
+            let mark = if checked { "[✓]" } else { "[ ]" };
 
             let row_style = if is_cursor {
                 Style::default()


### PR DESCRIPTION
## Summary
In tui mode, replace [x] completion marker with [✓] across all sidebar panels (more Chinese style lol)

<img width="468" height="342" alt="image" src="https://github.com/user-attachments/assets/bd89e0b3-c3ed-4bc5-ba1b-8f7323148dfa" />

## Testing

- [x] `cargo test --all-features`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features`

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [x] Verified TUI behavior manually if UI changes
