### PR TITLE
fix(tui): try wl-copy before arboard on non-wlroots Wayland (1920)

### DIFF
--- a/crates/tui/src/tui/clipboard.rs
+++ b/crates/tui/src/tui/clipboard.rs
@@ -220,7 +220,7 @@ fn write_text_with_set_clipboard(text: &str) -> Result<()> {
 /// `wl_data_device_manager` protocol that every Wayland compositor implements.
 #[cfg(all(target_os = "linux", not(test)))]
 fn write_text_with_wlcopy(text: &str) -> Result<()> {
-    write_text_with_wlcopy_using(WLCOPY_BIN, text)
+    write_text_with_wlcopy_using_argv(&[WLCOPY_BIN], text)
 }
 
 #[cfg(all(target_os = "linux", not(test)))]
@@ -228,13 +228,19 @@ const WLCOPY_BIN: &str = "wl-copy";
 
 /// Inner helper that delegates to an arbitrary stdin-fed command. Parameterised
 /// so tests can exercise both success and failure paths without depending on
-/// `wl-copy` being installed on the build host.
+/// `wl-copy` being installed on the build host. `argv[0]` is the program; the
+/// remaining slots are its arguments.
 #[cfg(target_os = "linux")]
-fn write_text_with_wlcopy_using(program: &str, text: &str) -> Result<()> {
+fn write_text_with_wlcopy_using_argv(argv: &[&str], text: &str) -> Result<()> {
     use std::io::Write;
     use std::process::{Command, Stdio};
 
+    let (program, args) = argv.split_first().ok_or_else(|| {
+        anyhow::anyhow!("write_text_with_wlcopy_using_argv requires at least the program name")
+    })?;
+
     let mut child = Command::new(program)
+        .args(args)
         .stdin(Stdio::piped())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -251,7 +257,7 @@ fn write_text_with_wlcopy_using(program: &str, text: &str) -> Result<()> {
     if status.success() {
         return Ok(());
     }
-    Err(anyhow::anyhow!("{program} failed"))
+    bail!("{program} failed with {status}")
 }
 
 #[cfg(not(test))]
@@ -406,9 +412,11 @@ mod tests {
     #[cfg(target_os = "linux")]
     #[test]
     fn wlcopy_helper_errors_when_binary_missing() {
-        let err =
-            write_text_with_wlcopy_using("deepseek-tui-nonexistent-clipboard-binary-zzz", "hi")
-                .expect_err("missing binary should fail");
+        let err = write_text_with_wlcopy_using_argv(
+            &["deepseek-tui-nonexistent-clipboard-binary-zzz"],
+            "hi",
+        )
+        .expect_err("missing binary should fail");
         assert!(
             err.to_string().contains("Failed to run"),
             "unexpected error: {err}"
@@ -418,15 +426,15 @@ mod tests {
     #[cfg(target_os = "linux")]
     #[test]
     fn wlcopy_helper_errors_when_binary_exits_nonzero() {
-        // `/bin/false` exits 1 immediately and drops stdin. The helper must
-        // surface that as a failure so the caller falls through to arboard /
-        // OSC 52 instead of believing the clipboard write succeeded.
-        let err = write_text_with_wlcopy_using("false", "hi")
+        // Drain stdin then exit non-zero. Using `sh -c "cat >/dev/null; exit 1"`
+        // is deterministic — `/bin/false` would race the parent's write_all and
+        // sometimes surface as a broken-pipe write error instead of the
+        // exit-status path we are exercising here. The helper must surface a
+        // non-zero exit so the caller falls through to arboard / OSC 52.
+        let err = write_text_with_wlcopy_using_argv(&["sh", "-c", "cat >/dev/null; exit 1"], "hi")
             .expect_err("non-zero exit must be reported as failure");
-        assert!(
-            err.to_string().contains("failed"),
-            "unexpected error: {err}"
-        );
+        let msg = err.to_string();
+        assert!(msg.contains("failed with"), "unexpected error: {err}");
     }
 
     #[cfg(target_os = "linux")]
@@ -434,7 +442,7 @@ mod tests {
     fn wlcopy_helper_succeeds_when_binary_returns_zero() {
         // `cat` drains stdin and exits 0 — same observable contract as a
         // successful `wl-copy` invocation on a supported compositor.
-        write_text_with_wlcopy_using("cat", "hello").expect("cat should succeed");
+        write_text_with_wlcopy_using_argv(&["cat"], "hello").expect("cat should succeed");
     }
 
     #[test]

--- a/crates/tui/src/tui/clipboard.rs
+++ b/crates/tui/src/tui/clipboard.rs
@@ -131,6 +131,17 @@ impl ClipboardHandler {
 
         #[cfg(not(test))]
         {
+            // On Linux try `wl-copy` first. The `arboard` Wayland backend uses
+            // the wlr-data-control-unstable-v1 protocol, which non-wlroots
+            // compositors (niri, River, cosmic-comp, GNOME) do not implement,
+            // so `set_text()` silently returns `Ok(())` without writing
+            // anything. `wl-copy` uses the standard `wl_data_device_manager`
+            // protocol supported by every Wayland compositor.
+            #[cfg(target_os = "linux")]
+            if write_text_with_wlcopy(text).is_ok() {
+                return Ok(());
+            }
+
             self.ensure_clipboard();
             if let Some(clipboard) = self.clipboard.as_mut()
                 && clipboard.set_text(text.to_string()).is_ok()
@@ -198,6 +209,49 @@ fn write_text_with_set_clipboard(text: &str) -> Result<()> {
         return Ok(());
     }
     Err(anyhow::anyhow!("Set-Clipboard failed"))
+}
+
+/// Write text to the Wayland clipboard via the `wl-copy` CLI.
+///
+/// Used on Linux instead of `arboard` because `arboard`'s Wayland backend
+/// targets the wlroots-specific `wlr-data-control-unstable-v1` protocol, which
+/// non-wlroots compositors (niri, River, cosmic-comp, GNOME mutter) do not
+/// expose. `wl-copy` ships with `wl-clipboard` and uses the standard
+/// `wl_data_device_manager` protocol that every Wayland compositor implements.
+#[cfg(all(target_os = "linux", not(test)))]
+fn write_text_with_wlcopy(text: &str) -> Result<()> {
+    write_text_with_wlcopy_using(WLCOPY_BIN, text)
+}
+
+#[cfg(all(target_os = "linux", not(test)))]
+const WLCOPY_BIN: &str = "wl-copy";
+
+/// Inner helper that delegates to an arbitrary stdin-fed command. Parameterised
+/// so tests can exercise both success and failure paths without depending on
+/// `wl-copy` being installed on the build host.
+#[cfg(target_os = "linux")]
+fn write_text_with_wlcopy_using(program: &str, text: &str) -> Result<()> {
+    use std::io::Write;
+    use std::process::{Command, Stdio};
+
+    let mut child = Command::new(program)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|e| anyhow::anyhow!("Failed to run {program}: {e}"))?;
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin
+            .write_all(text.as_bytes())
+            .map_err(|e| anyhow::anyhow!("Failed to write to {program}: {e}"))?;
+    }
+    let status = child
+        .wait()
+        .map_err(|e| anyhow::anyhow!("Failed to wait for {program}: {e}"))?;
+    if status.success() {
+        return Ok(());
+    }
+    Err(anyhow::anyhow!("{program} failed"))
 }
 
 #[cfg(not(test))]
@@ -347,6 +401,40 @@ mod tests {
     fn osc52_sequence_wraps_for_tmux_passthrough() {
         let sequence = osc52_sequence("copy", true).expect("sequence");
         assert_eq!(sequence, "\x1bPtmux;\x1b\x1b]52;c;Y29weQ==\x07\x1b\\");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn wlcopy_helper_errors_when_binary_missing() {
+        let err =
+            write_text_with_wlcopy_using("deepseek-tui-nonexistent-clipboard-binary-zzz", "hi")
+                .expect_err("missing binary should fail");
+        assert!(
+            err.to_string().contains("Failed to run"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn wlcopy_helper_errors_when_binary_exits_nonzero() {
+        // `/bin/false` exits 1 immediately and drops stdin. The helper must
+        // surface that as a failure so the caller falls through to arboard /
+        // OSC 52 instead of believing the clipboard write succeeded.
+        let err = write_text_with_wlcopy_using("false", "hi")
+            .expect_err("non-zero exit must be reported as failure");
+        assert!(
+            err.to_string().contains("failed"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn wlcopy_helper_succeeds_when_binary_returns_zero() {
+        // `cat` drains stdin and exits 0 — same observable contract as a
+        // successful `wl-copy` invocation on a supported compositor.
+        write_text_with_wlcopy_using("cat", "hello").expect("cat should succeed");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fix 1920

`arboard`'s Wayland backend targets the `wlr-data-control-unstable-v1` protocol, which non-wlroots compositors (niri, River, cosmic-comp, GNOME mutter) do not implement. `Clipboard::set_text()` silently returns `Ok(())` without actually writing to the system clipboard, so the existing OSC 52 fallback is never reached and copy appears successful but produces an empty clipboard.

Reorder the Linux branch of `set_text()` to try `wl-copy` first (uses the standard `wl_data_device_manager` protocol supported by every Wayland compositor), then fall through to `arboard` and OSC 52 only when `wl-copy` is missing or fails.

- New helper `write_text_with_wlcopy` invoked before `arboard` on Linux.
- Inner `write_text_with_wlcopy_using(program, text)` so unit tests can swap the binary without depending on `wl-copy` being on the build host (uses `cat` for success, `false` for non-zero exit, a non-existent name for missing binary).
- Behavior outside Linux unchanged.

## Testing

- [x] `cargo test --bin deepseek-tui wlcopy` — 3 new tests pass
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p deepseek-tui --all-targets --all-features --no-deps` — no new warnings
- [ ] Manual verification on niri — relies on issue reporter's repro path (selection menu copy then paste in another app)

### TDD note

The 3 new tests guard the new `write_text_with_wlcopy_using` helper's contract — success, missing binary, and non-zero exit. They are intentionally scoped to the helper because `set_text`'s production branch is `#[cfg(not(test))]` and its fall-through ordering cannot be exercised from a unit test without refactoring the clipboard subsystem. The integration is verified by the issue reporter's repro on niri (the same compositor environment the patch targets).

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes (relies on issue reporter's environment — no niri compositor on dev host)

## Files changed

| File | Change |
|------|--------|
| `crates/tui/src/tui/clipboard.rs` | Added `write_text_with_wlcopy` + inner helper, reordered `set_text` on Linux, 3 unit tests |
