### PR TITLE
Fix git_status output for unicode paths

### DIFF
--- a/crates/tui/src/tools/git.rs
+++ b/crates/tui/src/tools/git.rs
@@ -72,8 +72,11 @@ impl ToolSpec for GitStatusTool {
             args.push(pathspec.display().to_string());
         }
 
-        let command_str = format_command(&git_ctx.working_dir, &args);
-        let output = run_git_command(&git_ctx.working_dir, &args)?;
+        let mut status_args = vec!["-c".to_string(), "core.quotepath=false".to_string()];
+        status_args.extend(args);
+
+        let command_str = format_command(&git_ctx.working_dir, &status_args);
+        let output = run_git_command(&git_ctx.working_dir, &status_args)?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -418,6 +421,45 @@ mod tests {
                 .and_then(|m| m.get("cached"))
                 .and_then(Value::as_bool)
                 .unwrap_or(false)
+        );
+    }
+
+    #[tokio::test]
+    async fn git_status_reports_unquoted_unicode_paths() {
+        if !git_available() {
+            return;
+        }
+        let tmp = tempdir().expect("tempdir");
+        init_git_repo(tmp.path());
+
+        let run_git = |args: &[&str]| {
+            let status = Command::new("git")
+                .args(args)
+                .current_dir(tmp.path())
+                .status()
+                .expect("git should spawn");
+            assert!(status.success(), "git {:?} failed", args);
+        };
+
+        run_git(&["config", "core.quotepath", "true"]);
+
+        let workdir = tmp.path().join("中文目录");
+        fs::create_dir_all(&workdir).expect("mkdir");
+        let file = workdir.join("新文件.md");
+        fs::write(&file, "hello\n").expect("write");
+        commit_all(tmp.path(), "init unicode path");
+
+        fs::write(&file, "hello\nworld\n").expect("modify");
+
+        let ctx = ToolContext::new(tmp.path());
+        let tool = GitStatusTool;
+        let result = tool.execute(json!({}), &ctx).await.expect("execute");
+
+        assert!(result.success);
+        assert!(
+            result.content.contains("中文目录/新文件.md"),
+            "expected decoded unicode filename in git_status output, got: {}",
+            result.content
         );
     }
 


### PR DESCRIPTION
## Summary

- run `git status` with `-c core.quotepath=false` in `git_status` so unicode paths are returned in readable form
- keep the reported command metadata aligned with the actual git invocation
- add a regression test for a tracked file inside a Chinese-named directory

## Root cause

When `core.quotepath` is enabled, Git can emit non-ASCII paths as quoted octal escapes. That makes `git_status` output hard to use for workspaces with Chinese path names. Passing `-c core.quotepath=false` keeps this behavior local to the command without changing user or repository configuration.

Fixes #1936

## Tests

- `cargo fmt --all -- --check`
- `cargo test -p deepseek-tui tools::git::tests::`
- `git diff --check`