### PR TITLE
test(rebrand): residual brand-string cleanup across source and assets [R6/6]

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -185,7 +185,7 @@ impl ProvidersToml {
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ConfigToml {
     /// TUI-compatible DeepSeek API key. Kept at the root so both `deepseek`
-    /// and `deepseek-tui` can share a single config file.
+    /// and `codewhale-tui` can share a single config file.
     pub api_key: Option<String>,
     /// TUI-compatible DeepSeek base URL.
     pub base_url: Option<String>,

--- a/crates/tui/assets/skills/mcp-builder/SKILL.md
+++ b/crates/tui/assets/skills/mcp-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mcp-builder
-description: Design, build, configure, or debug Model Context Protocol servers for DeepSeek TUI, including stdio and HTTP/SSE transports.
+description: Design, build, configure, or debug Model Context Protocol servers for codewhale, including stdio and HTTP/SSE transports.
 ---
 
 # MCP Builder

--- a/crates/tui/assets/skills/plugin-creator/SKILL.md
+++ b/crates/tui/assets/skills/plugin-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plugin-creator
-description: Scaffold DeepSeek local plugin directories and activation notes. Use when the user asks to create, package, or sketch a plugin for DeepSeek TUI.
+description: Scaffold codewhale local plugin directories and activation notes. Use when the user asks to create, package, or sketch a plugin for codewhale.
 ---
 
 # Plugin Creator

--- a/crates/tui/assets/skills/skill-creator/SKILL.md
+++ b/crates/tui/assets/skills/skill-creator/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: skill-creator
-description: Create or improve DeepSeek TUI skills. Use when the user wants a new skill, wants to update an existing skill, or needs guidance on when a skill should be a skill versus MCP, hooks, tools, or a plugin scaffold.
+description: Create or improve codewhale skills. Use when the user wants a new skill, wants to update an existing skill, or needs guidance on when a skill should be a skill versus MCP, hooks, tools, or a plugin scaffold.
 metadata:
   short-description: Create DeepSeek skills
 ---
 
 # Skill Creator
 
-Use this skill to create small, useful DeepSeek TUI skills that match the
+Use this skill to create small, useful codewhale skills that match the
 runtime this repository actually ships.
 
 ## What A Skill Is
@@ -94,7 +94,7 @@ plain single-line values. Use lower-case hyphen-case names.
   unless the user asked for a rewrite.
 - Tighten descriptions when the skill is under-triggering or over-triggering.
 - Remove stale tool names, unavailable dependencies, and copied instructions
-  from other agents that do not apply to DeepSeek TUI.
+  from other agents that do not apply to codewhale.
 - Keep examples short and directly tied to this runtime's commands and tools.
 
 ## Validation Checklist

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -514,7 +514,7 @@ impl DeepSeekClient {
         let mut builder = reqwest::Client::builder()
             .default_headers(headers)
             .user_agent(concat!(
-                "Mozilla/5.0 (compatible; deepseek-tui/",
+                "Mozilla/5.0 (compatible; codewhale/",
                 env!("CARGO_PKG_VERSION"),
                 "; +https://github.com/Hmbown/DeepSeek-TUI)"
             ))

--- a/crates/tui/src/core/capacity.rs
+++ b/crates/tui/src/core/capacity.rs
@@ -766,7 +766,7 @@ mod tests {
     /// Hot-path microbench for `compute_profile`. Run with:
     ///
     /// ```text
-    /// cargo test -p deepseek-tui --release capacity::tests::bench_compute_profile -- --ignored --nocapture
+    /// cargo test -p codewhale-tui --release capacity::tests::bench_compute_profile -- --ignored --nocapture
     /// ```
     ///
     /// Establishes a baseline cost so we can detect regressions when the

--- a/crates/tui/src/core/engine/tool_catalog.rs
+++ b/crates/tui/src/core/engine/tool_catalog.rs
@@ -689,7 +689,7 @@ pub(super) async fn execute_code_execution_tool(
         ToolError::execution_failed(format!(
             "code_execution: no Python interpreter found on PATH (tried {:?}). \
              Install Python 3 and ensure one of these is on PATH, then restart \
-             deepseek-tui.",
+             codewhale.",
             crate::dependencies::PYTHON_CANDIDATES,
         ))
     })?;

--- a/crates/tui/src/features.rs
+++ b/crates/tui/src/features.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-//! Feature flags and metadata for DeepSeek TUI.
+//! Feature flags and metadata for codewhale.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{self, Write as _};

--- a/crates/tui/src/repl/runtime.rs
+++ b/crates/tui/src/repl/runtime.rs
@@ -206,7 +206,7 @@ impl PythonRuntime {
         let interpreter = resolve_python_interpreter().ok_or_else(|| {
             format!(
                 "no Python interpreter found on PATH (tried {:?}). \
-                 Install Python 3 and ensure one of these commands works, then restart deepseek-tui.",
+                 Install Python 3 and ensure one of these commands works, then restart codewhale.",
                 PYTHON_CANDIDATES,
             )
         })?;

--- a/crates/tui/src/snapshot/repo.rs
+++ b/crates/tui/src/snapshot/repo.rs
@@ -272,7 +272,7 @@ impl SnapshotRepo {
             let _ = run_git(
                 &git_dir,
                 &work_tree,
-                &["config", "user.email", "snapshots@deepseek-tui.local"],
+                &["config", "user.email", "snapshots@codewhale.local"],
             );
             // Don't auto-gc on every commit; we manage pruning ourselves.
             let _ = run_git(&git_dir, &work_tree, &["config", "gc.auto", "0"]);

--- a/crates/tui/src/task_manager.rs
+++ b/crates/tui/src/task_manager.rs
@@ -1814,7 +1814,7 @@ mod tests {
                         "gate": {
                             "id": "gate_test",
                             "gate": "test",
-                            "command": "cargo test -p deepseek-tui --lib",
+                            "command": "cargo test -p codewhale-tui --lib",
                             "cwd": ".",
                             "exit_code": 0,
                             "status": "passed",

--- a/crates/tui/src/tools/fetch_url.rs
+++ b/crates/tui/src/tools/fetch_url.rs
@@ -26,7 +26,7 @@ const DEFAULT_TIMEOUT_MS: u64 = 15_000;
 const HARD_MAX_TIMEOUT_MS: u64 = 60_000;
 const MAX_REDIRECTS: usize = 5;
 const USER_AGENT: &str =
-    "Mozilla/5.0 (compatible; deepseek-tui/0.5; +https://github.com/Hmbown/DeepSeek-TUI)";
+    "Mozilla/5.0 (compatible; codewhale/0.5; +https://github.com/Hmbown/DeepSeek-TUI)";
 
 static SCRIPT_RE: OnceLock<Regex> = OnceLock::new();
 static STYLE_RE: OnceLock<Regex> = OnceLock::new();

--- a/crates/tui/src/tools/image_ocr.rs
+++ b/crates/tui/src/tools/image_ocr.rs
@@ -81,7 +81,7 @@ pub(crate) fn ocr_image_path(image_path: &Path) -> Result<String, ToolError> {
     }
 
     Err(ToolError::execution_failed(
-        "image_ocr: no local OCR backend is available. On macOS, update to a version with the Vision framework; on Linux/Windows install tesseract and restart deepseek-tui.",
+        "image_ocr: no local OCR backend is available. On macOS, update to a version with the Vision framework; on Linux/Windows install tesseract and restart codewhale.",
     ))
 }
 

--- a/crates/tui/src/tools/js_execution.rs
+++ b/crates/tui/src/tools/js_execution.rs
@@ -83,7 +83,7 @@ pub async fn execute_js_execution_tool(
         ToolError::execution_failed(
             "js_execution: no Node.js runtime found on PATH (tried `node`). \
              Install Node 18+ and ensure `node` is on PATH, then restart \
-             deepseek-tui."
+             codewhale."
                 .to_string(),
         )
     })?;

--- a/crates/tui/src/tools/pandoc.rs
+++ b/crates/tui/src/tools/pandoc.rs
@@ -150,7 +150,7 @@ impl ToolSpec for PandocConvertTool {
                 "pandoc_convert: pandoc binary not found on PATH. \
                  Install pandoc (macOS: `brew install pandoc`; \
                  Debian/Ubuntu: `apt install pandoc`; \
-                 Windows: `winget install JohnMacFarlane.Pandoc`) and restart deepseek-tui.",
+                 Windows: `winget install JohnMacFarlane.Pandoc`) and restart codewhale.",
             )
         })?;
 

--- a/crates/tui/src/tui/external_editor.rs
+++ b/crates/tui/src/tui/external_editor.rs
@@ -252,7 +252,7 @@ mod tests {
         let _g = EnvGuard::new(&["VISUAL", "EDITOR"]);
         unsafe {
             env::remove_var("VISUAL");
-            env::set_var("EDITOR", "/nonexistent/deepseek-tui-test-editor");
+            env::set_var("EDITOR", "/nonexistent/codewhale-test-editor");
         }
         let out = run_editor_raw("seed").expect("call ok");
         assert_eq!(out, EditorOutcome::Cancelled);

--- a/crates/tui/src/tui/streaming/chunking.rs
+++ b/crates/tui/src/tui/streaming/chunking.rs
@@ -1,6 +1,6 @@
 //! Adaptive stream chunking policy for two-gear streaming.
 //!
-//! Ported from `codex-rs/tui/src/streaming/chunking.rs`, adapted for deepseek-tui's
+//! Ported from `codex-rs/tui/src/streaming/chunking.rs`, adapted for codewhale's
 //! text-based streaming pipeline. The policy is queue-pressure driven and
 //! source-agnostic.
 //!

--- a/scripts/tencent-lighthouse/doctor.sh
+++ b/scripts/tencent-lighthouse/doctor.sh
@@ -109,7 +109,7 @@ check_binaries() {
   fi
   if [[ -x "${tui}" ]]; then
     pass "${tui} is executable"
-    "${tui}" --version 2>/dev/null | sed 's/^/[info] deepseek-tui version: /' || warn "deepseek-tui --version failed"
+    "${tui}" --version 2>/dev/null | sed 's/^/[info] codewhale-tui version: /' || warn "codewhale-tui --version failed"
   else
     fail "${tui} is missing or not executable"
   fi


### PR DESCRIPTION
## Phase 6 of 6 — codewhale rebrand (stacked on R5 #1952)

This PR is stacked on R5 #1952. Final residual cleanup of brand mentions that the previous phases missed.

The R5 sweep handled the big categories (binary names, crate names, prompts, user-facing display strings, tracing targets). This phase picks up the long tail that the regex-based passes left behind because the mentions were hiding in:

- HTTP **User-Agent** format strings (`Mozilla/5.0 (compatible; deepseek-tui/…)` in `client.rs` and `fetch_url.rs`).
- **Multi-line error messages** whose phrase boundary straddled a line break (`"…restart\n             deepseek-tui."` in `js_execution.rs`, `tool_catalog.rs`, `repl/runtime.rs`).
- **Doc comments** mentioning `deepseek-tui` as a binary (`config/src/lib.rs`, `core/capacity.rs`, `tui/streaming/chunking.rs`, `features.rs`).
- **Skill descriptions** shipped in `crates/tui/assets/skills/*/SKILL.md`.
- **Test fixtures** with placeholder paths or git emails (`tui/external_editor.rs`, `snapshot/repo.rs`).
- **task_manager.rs** `cargo test -p deepseek-tui --lib` example.
- **`scripts/tencent-lighthouse/doctor.sh`** info-line prefix.

### What remains as `deepseek-tui` (intentional / anti-scope)

After this phase, the only `deepseek-tui` mentions still in the tree are:

- `crates/tui/Cargo.toml`'s legacy `[[bin]] name = "deepseek-tui"` shim entry (R2 introduced this).
- `npm/deepseek-tui/` — the deprecation shim npm package (R3 introduced this).
- `crates/tui/src/bin/deepseek_tui_legacy_shim.rs` — the shim's own source file (its doc comment and warning message intentionally mention the old name).
- `crates/cli/src/update.rs` `CNB_REPO_URL` (third-party namespace).
- `scripts/release/check-published.sh` legacy `deepseek-tui@<version>` query.
- The historical `CHANGELOG.md` and `crates/tui/CHANGELOG.md` entries — never rewritten.
- `crates/tui/.deepseek/instructions.md` (under the config dir, which stays).
- Repo URLs (`Hmbown/DeepSeek-TUI`), Homebrew tap (`homebrew-deepseek-tui`), Docker image (`ghcr.io/hmbown/deepseek-tui`), security email (`security@deepseek-tui.com`).

### Gates

- `cargo check --workspace --all-targets --locked` — pass
- `cargo fmt --all -- --check` — pass
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — pass
- `cargo test --workspace --all-features --locked` — pass (3226+ tests, 0 failures, 3 ignored)

### Stop conditions (all met)

- All 6 phases opened as draft PRs ✓ (#1947 → #1948 → #1949 → #1950 → #1952 → this).
- No merges / tags / publishes / force-pushes performed.

### Hunter's follow-up checklist

Surfaced in `.private/codewhale-rebrand.md`:

- GitHub repo rename (Settings → General → Repository name).
- `npm publish codewhale@0.8.41` (manual, needs 2FA OTP).
- `npm publish deepseek-tui@0.8.41` (manual; the deprecation shim package).
- Homebrew tap rename (`Hmbown/homebrew-deepseek-tui` → e.g. `Hmbown/homebrew-codewhale`) — separate repo.
- Docker image tag (`ghcr.io/hmbown/deepseek-tui` → `ghcr.io/hmbown/codewhale`) — release workflow edit + image push.
- Security contact email migration (`security@deepseek-tui.com` → whatever Hunter wants to stand up).
- Eventually: `crates.io` publishes for the renamed crates (the project is binary-only AFAIK, so this may not apply).

### Recommended merge order

R1 #1947 → R2 #1948 → R3 #1949 → R4 #1950 → R5 #1952 → R6 (this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)