### PR TITLE
feat(runtime): restore mobile control page

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,7 @@ codewhale resume --last                           # resume the most recent sessi
 codewhale resume <SESSION_ID>                     # resume a specific session by UUID
 codewhale fork <SESSION_ID>                       # fork a saved session into a sibling path
 codewhale serve --http                            # HTTP/SSE API server
+codewhale serve --mobile                          # LAN mobile control page; token-gated by default
 codewhale serve --acp                             # ACP stdio adapter for Zed/custom agents
 codewhale run pr <N>                              # fetch PR and pre-seed review prompt
 codewhale mcp list                                # list configured MCP servers
@@ -557,7 +558,7 @@ without recreating skills the user deliberately deleted.
 | [CONFIGURATION.md](docs/CONFIGURATION.md) | Full config reference |
 | [MODES.md](docs/MODES.md) | Plan / Agent / YOLO modes |
 | [MCP.md](docs/MCP.md) | Model Context Protocol integration |
-| [RUNTIME_API.md](docs/RUNTIME_API.md) | HTTP/SSE API server |
+| [RUNTIME_API.md](docs/RUNTIME_API.md) | HTTP/SSE API server and mobile control page |
 | [INSTALL.md](docs/INSTALL.md) | Platform-specific install guide |
 | [DOCKER.md](docs/DOCKER.md) | GHCR image, volumes, and Docker usage |
 | [CNB_MIRROR.md](docs/CNB_MIRROR.md) | CNB mirror and China-friendly install notes |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -316,6 +316,7 @@ codewhale resume --last                         # 恢复最近会话
 codewhale resume <SESSION_ID>                   # 按 UUID 恢复指定会话
 codewhale fork <SESSION_ID>                     # 将已保存会话分叉为兄弟路径
 codewhale serve --http                          # HTTP/SSE API 服务
+codewhale serve --mobile                        # 局域网移动端控制页，默认启用 token 保护
 codewhale serve --acp                           # Zed/自定义智能体的 ACP stdio 适配器
 codewhale run pr <N>                            # 获取 PR 并预填审查提示
 codewhale mcp list                              # 列出已配置 MCP 服务器
@@ -494,7 +495,7 @@ description: 当 DeepSeek 需要遵循我的自定义工作流时使用这个技
 | [CONFIGURATION.md](docs/CONFIGURATION.md) | 完整配置参考 |
 | [MODES.md](docs/MODES.md) | Plan / Agent / YOLO 模式 |
 | [MCP.md](docs/MCP.md) | Model Context Protocol 集成 |
-| [RUNTIME_API.md](docs/RUNTIME_API.md) | HTTP/SSE API 服务 |
+| [RUNTIME_API.md](docs/RUNTIME_API.md) | HTTP/SSE API 服务和移动端控制页 |
 | [INSTALL.md](docs/INSTALL.md) | 各平台安装指南 |
 | [DOCKER.md](docs/DOCKER.md) | GHCR 镜像、volume 和 Docker 用法 |
 | [CNB_MIRROR.md](docs/CNB_MIRROR.md) | CNB 镜像和中国大陆友好安装说明 |

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -578,9 +578,9 @@ struct ServeArgs {
     /// Start ACP server over stdio for editor clients such as Zed
     #[arg(long)]
     acp: bool,
-    /// Bind host for HTTP server (default localhost)
-    #[arg(long, default_value = "127.0.0.1")]
-    host: String,
+    /// Bind host for HTTP server (default localhost; --mobile defaults to 0.0.0.0)
+    #[arg(long)]
+    host: Option<String>,
     /// Bind port for HTTP server
     #[arg(long, default_value_t = 7878)]
     port: u16,
@@ -600,6 +600,29 @@ struct ServeArgs {
     /// Disable runtime API auth when no token is configured. Only use on a trusted loopback.
     #[arg(long = "insecure")]
     insecure_no_auth: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ServeBindHost {
+    host: String,
+    mobile_rebound_to_lan: bool,
+}
+
+fn resolve_serve_bind_host(mobile: bool, host: Option<String>) -> ServeBindHost {
+    match (mobile, host) {
+        (true, None) => ServeBindHost {
+            host: "0.0.0.0".to_string(),
+            mobile_rebound_to_lan: true,
+        },
+        (_, Some(host)) => ServeBindHost {
+            host,
+            mobile_rebound_to_lan: false,
+        },
+        (false, None) => ServeBindHost {
+            host: "127.0.0.1".to_string(),
+            mobile_rebound_to_lan: false,
+        },
+    }
 }
 
 #[derive(Subcommand, Debug, Clone)]
@@ -942,16 +965,17 @@ async fn main() -> Result<()> {
                 } else if http_selected {
                     let config = load_config_from_cli(&cli)?;
                     let cors_origins = resolve_cors_origins(&config, &args.cors_origin);
-                    let host = if args.mobile && args.host == "127.0.0.1" {
-                        "0.0.0.0".to_string()
-                    } else {
-                        args.host
-                    };
+                    let bind_host = resolve_serve_bind_host(args.mobile, args.host);
+                    if bind_host.mobile_rebound_to_lan {
+                        println!(
+                            "WARNING: --mobile is binding to 0.0.0.0 so LAN devices can reach the mobile control page. Use --host 127.0.0.1 to keep mobile loopback-only."
+                        );
+                    }
                     runtime_api::run_http_server(
                         config,
                         workspace,
                         runtime_api::RuntimeApiOptions {
-                            host,
+                            host: bind_host.host,
                             port: args.port,
                             workers: args.workers.clamp(1, 8),
                             cors_origins,
@@ -5579,6 +5603,44 @@ async fn run_exec_agent(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod serve_bind_host_tests {
+    use super::*;
+
+    #[test]
+    fn http_defaults_to_loopback() {
+        assert_eq!(
+            resolve_serve_bind_host(false, None),
+            ServeBindHost {
+                host: "127.0.0.1".to_string(),
+                mobile_rebound_to_lan: false,
+            }
+        );
+    }
+
+    #[test]
+    fn mobile_default_rebinds_to_lan_with_warning_flag() {
+        assert_eq!(
+            resolve_serve_bind_host(true, None),
+            ServeBindHost {
+                host: "0.0.0.0".to_string(),
+                mobile_rebound_to_lan: true,
+            }
+        );
+    }
+
+    #[test]
+    fn mobile_respects_explicit_loopback_host() {
+        assert_eq!(
+            resolve_serve_bind_host(true, Some("127.0.0.1".to_string())),
+            ServeBindHost {
+                host: "127.0.0.1".to_string(),
+                mobile_rebound_to_lan: false,
+            }
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -625,6 +625,21 @@ fn resolve_serve_bind_host(mobile: bool, host: Option<String>) -> ServeBindHost 
     }
 }
 
+fn validate_serve_mode_selection(mcp: bool, http: bool, mobile: bool, acp: bool) -> Result<bool> {
+    if http && mobile {
+        bail!("--http and --mobile are mutually exclusive; choose one");
+    }
+    let http_selected = http || mobile;
+    let selected_modes = [mcp, http_selected, acp]
+        .into_iter()
+        .filter(|selected| *selected)
+        .count();
+    if selected_modes != 1 {
+        bail!("Choose exactly one server mode: --mcp, --http/--mobile, or --acp");
+    }
+    Ok(http_selected)
+}
+
 #[derive(Subcommand, Debug, Clone)]
 enum McpCommand {
     /// List configured MCP servers
@@ -952,14 +967,8 @@ async fn main() -> Result<()> {
                 let workspace = cli.workspace.clone().unwrap_or_else(|| {
                     std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
                 });
-                let http_selected = args.http || args.mobile;
-                let selected_modes = [args.mcp, http_selected, args.acp]
-                    .into_iter()
-                    .filter(|selected| *selected)
-                    .count();
-                if selected_modes != 1 {
-                    bail!("Choose exactly one server mode: --mcp, --http/--mobile, or --acp");
-                }
+                let http_selected =
+                    validate_serve_mode_selection(args.mcp, args.http, args.mobile, args.acp)?;
                 if args.mcp {
                     mcp_server::run_mcp_server(workspace)
                 } else if http_selected {
@@ -5639,6 +5648,15 @@ mod serve_bind_host_tests {
                 host: "127.0.0.1".to_string(),
                 mobile_rebound_to_lan: false,
             }
+        );
+    }
+
+    #[test]
+    fn http_and_mobile_are_mutually_exclusive() {
+        let err = validate_serve_mode_selection(false, true, true, false).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("--http and --mobile are mutually exclusive")
         );
     }
 }

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -572,6 +572,9 @@ struct ServeArgs {
     /// Start runtime HTTP/SSE API server
     #[arg(long)]
     http: bool,
+    /// Start runtime HTTP/SSE API server with the built-in mobile control page
+    #[arg(long)]
+    mobile: bool,
     /// Start ACP server over stdio for editor clients such as Zed
     #[arg(long)]
     acp: bool,
@@ -926,28 +929,35 @@ async fn main() -> Result<()> {
                 let workspace = cli.workspace.clone().unwrap_or_else(|| {
                     std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
                 });
-                let selected_modes = [args.mcp, args.http, args.acp]
+                let http_selected = args.http || args.mobile;
+                let selected_modes = [args.mcp, http_selected, args.acp]
                     .into_iter()
                     .filter(|selected| *selected)
                     .count();
                 if selected_modes != 1 {
-                    bail!("Choose exactly one server mode: --mcp, --http, or --acp");
+                    bail!("Choose exactly one server mode: --mcp, --http/--mobile, or --acp");
                 }
                 if args.mcp {
                     mcp_server::run_mcp_server(workspace)
-                } else if args.http {
+                } else if http_selected {
                     let config = load_config_from_cli(&cli)?;
                     let cors_origins = resolve_cors_origins(&config, &args.cors_origin);
+                    let host = if args.mobile && args.host == "127.0.0.1" {
+                        "0.0.0.0".to_string()
+                    } else {
+                        args.host
+                    };
                     runtime_api::run_http_server(
                         config,
                         workspace,
                         runtime_api::RuntimeApiOptions {
-                            host: args.host,
+                            host,
                             port: args.port,
                             workers: args.workers.clamp(1, 8),
                             cors_origins,
                             auth_token: args.auth_token,
                             insecure_no_auth: args.insecure_no_auth,
+                            mobile: args.mobile,
                         },
                     )
                     .await

--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -554,8 +554,17 @@ async fn require_runtime_token(
     let Some(expected) = state.runtime_token.as_deref() else {
         return next.run(req).await;
     };
-    let authorized = req
-        .headers()
+    let authorized = request_has_runtime_token(&req, expected);
+
+    if authorized {
+        next.run(req).await
+    } else {
+        runtime_token_required_response()
+    }
+}
+
+fn request_has_runtime_token(req: &Request, expected: &str) -> bool {
+    req.headers()
         .get(header::AUTHORIZATION)
         .and_then(|value| value.to_str().ok())
         .and_then(|raw| raw.strip_prefix("Bearer "))
@@ -565,40 +574,72 @@ async fn require_runtime_token(
             .get("x-deepseek-runtime-token")
             .and_then(|value| value.to_str().ok())
             .is_some_and(|token| token == expected)
-        || token_from_query(req.uri().query()).is_some_and(|token| token == expected);
-
-    if authorized {
-        next.run(req).await
-    } else {
-        (
-            StatusCode::UNAUTHORIZED,
-            Json(json!({
-                "error": {
-                    "message": "runtime API bearer token required",
-                    "status": StatusCode::UNAUTHORIZED.as_u16(),
-                }
-            })),
-        )
-            .into_response()
-    }
+        || token_from_query(req.uri().query()).is_some_and(|token| token == expected)
 }
 
-fn token_from_query(query: Option<&str>) -> Option<&str> {
+fn runtime_token_required_response() -> Response {
+    (
+        StatusCode::UNAUTHORIZED,
+        Json(json!({
+            "error": {
+                "message": "runtime API bearer token required",
+                "status": StatusCode::UNAUTHORIZED.as_u16(),
+            }
+        })),
+    )
+        .into_response()
+}
+
+fn token_from_query(query: Option<&str>) -> Option<String> {
     query.and_then(|query| {
         query.split('&').find_map(|pair| {
             let (key, value) = pair.split_once('=')?;
-            (key == "token").then_some(value)
+            (key == "token")
+                .then(|| percent_decode_query_component(value))
+                .flatten()
         })
     })
 }
 
-async fn mobile_page(State(state): State<RuntimeApiState>) -> Response {
+fn percent_decode_query_component(value: &str) -> Option<String> {
+    let bytes = value.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'%' => {
+                let hi = *bytes.get(index + 1)?;
+                let lo = *bytes.get(index + 2)?;
+                let hi = (hi as char).to_digit(16)? as u8;
+                let lo = (lo as char).to_digit(16)? as u8;
+                decoded.push((hi << 4) | lo);
+                index += 3;
+            }
+            b'+' => {
+                decoded.push(b' ');
+                index += 1;
+            }
+            byte => {
+                decoded.push(byte);
+                index += 1;
+            }
+        }
+    }
+    String::from_utf8(decoded).ok()
+}
+
+async fn mobile_page(State(state): State<RuntimeApiState>, req: Request) -> Response {
     if !state.mobile_enabled {
         return (
             StatusCode::NOT_FOUND,
             "mobile control is disabled; start with `codewhale serve --mobile`",
         )
             .into_response();
+    }
+    if let Some(expected) = state.runtime_token.as_deref()
+        && !request_has_runtime_token(&req, expected)
+    {
+        return runtime_token_required_response();
     }
     Html(MOBILE_HTML).into_response()
 }
@@ -2033,6 +2074,15 @@ mod tests {
             url_query_component("abc ABC+/?:=&%"),
             "abc%20ABC%2B%2F%3F%3A%3D%26%25"
         );
+    }
+
+    #[test]
+    fn token_from_query_decodes_percent_encoded_token() {
+        assert_eq!(
+            token_from_query(Some("since_seq=0&token=abc%20ABC%2B%2F%3F%3A%3D%26%25")),
+            Some("abc ABC+/?:=&%".to_string())
+        );
+        assert_eq!(token_from_query(Some("token=bad%ZZ")), None);
     }
 
     async fn spawn_test_server_with_root(
@@ -3734,6 +3784,77 @@ mod tests {
         let html = enabled.text().await?;
         assert!(html.contains("CodeWhale Mobile"));
         assert!(html.contains("/v1/approvals/"));
+
+        handle.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn mobile_page_requires_runtime_token_when_auth_enabled() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let root = tmp.path().to_path_buf();
+        let sessions_dir = root.join("sessions");
+        let token = "abc ABC+/?:=&%".to_string();
+        let Some((addr, _runtime_threads, handle)) = spawn_test_server_with_root_token_and_mobile(
+            root,
+            sessions_dir,
+            Some(token.clone()),
+            true,
+        )
+        .await?
+        else {
+            return Ok(());
+        };
+        let client = reqwest::Client::new();
+
+        let unauthorized = client.get(format!("http://{addr}/mobile")).send().await?;
+        assert_eq!(unauthorized.status(), StatusCode::UNAUTHORIZED);
+
+        let encoded = url_query_component(&token);
+        let query = client
+            .get(format!("http://{addr}/mobile?token={encoded}"))
+            .send()
+            .await?
+            .error_for_status()?;
+        assert!(query.text().await?.contains("CodeWhale Mobile"));
+
+        let bearer = client
+            .get(format!("http://{addr}/mobile"))
+            .bearer_auth(&token)
+            .send()
+            .await?
+            .error_for_status()?;
+        assert!(bearer.text().await?.contains("CodeWhale Mobile"));
+
+        handle.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn mobile_insecure_mode_allows_page_and_v1_routes_without_token() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let root = tmp.path().to_path_buf();
+        let sessions_dir = root.join("sessions");
+        let Some((addr, _runtime_threads, handle)) =
+            spawn_test_server_with_root_token_and_mobile(root, sessions_dir, None, true).await?
+        else {
+            return Ok(());
+        };
+        let client = reqwest::Client::new();
+
+        let page = client
+            .get(format!("http://{addr}/mobile"))
+            .send()
+            .await?
+            .error_for_status()?;
+        assert!(page.text().await?.contains("CodeWhale Mobile"));
+
+        let summary = client
+            .get(format!("http://{addr}/v1/threads/summary"))
+            .send()
+            .await?
+            .error_for_status()?;
+        assert_eq!(summary.status(), StatusCode::OK);
 
         handle.abort();
         Ok(())

--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -608,7 +608,7 @@ fn print_mobile_urls(addr: SocketAddr, token: Option<&str>, auth_enabled: bool) 
     let token_query = if auth_enabled {
         token
             .filter(|token| !token.trim().is_empty())
-            .map(|token| format!("?token={token}"))
+            .map(|token| format!("?token={}", url_query_component(token)))
             .unwrap_or_default()
     } else {
         String::new()
@@ -628,6 +628,22 @@ fn print_mobile_urls(addr: SocketAddr, token: Option<&str>, auth_enabled: bool) 
         println!("  URL:   http://{addr}/mobile{token_query}");
     }
     println!("Mobile security: use only on a trusted LAN/VPN; this server does not provide TLS.");
+}
+
+fn url_query_component(value: &str) -> String {
+    let mut encoded = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                encoded.push(byte as char);
+            }
+            _ => {
+                use std::fmt::Write as _;
+                let _ = write!(encoded, "%{byte:02X}");
+            }
+        }
+    }
+    encoded
 }
 
 fn detect_lan_ip() -> Option<String> {
@@ -2009,6 +2025,14 @@ mod tests {
         let auth = resolve_runtime_auth(Some(" ".to_string()), Some("\t".to_string()), false);
         assert!(auth.generated);
         assert!(auth.token.is_some());
+    }
+
+    #[test]
+    fn url_query_component_percent_encodes_token() {
+        assert_eq!(
+            url_query_component("abc ABC+/?:=&%"),
+            "abc%20ABC%2B%2F%3F%3A%3D%26%25"
+        );
     }
 
     async fn spawn_test_server_with_root(

--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -632,7 +632,8 @@ fn print_mobile_urls(addr: SocketAddr, token: Option<&str>, auth_enabled: bool) 
 
 fn detect_lan_ip() -> Option<String> {
     let socket = UdpSocket::bind("0.0.0.0:0").ok()?;
-    socket.connect("8.8.8.8:80").ok()?;
+    // UDP connect only selects the outbound interface locally; no packet is sent.
+    socket.connect("10.255.255.255:1").ok()?;
     let addr = socket.local_addr().ok()?;
     Some(addr.ip().to_string())
 }

--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -3,7 +3,7 @@
 use std::collections::HashSet;
 use std::convert::Infallible;
 use std::fs;
-use std::net::SocketAddr;
+use std::net::{SocketAddr, UdpSocket};
 use std::path::PathBuf;
 use std::process::Command;
 use std::sync::Arc;
@@ -14,6 +14,7 @@ use async_stream::stream;
 use axum::extract::{Path, Query, Request, State};
 use axum::http::{HeaderValue, Method, StatusCode, header};
 use axum::middleware::{self, Next};
+use axum::response::Html;
 use axum::response::sse::{Event as SseEvent, KeepAlive, Sse};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
@@ -60,6 +61,7 @@ pub struct RuntimeApiState {
     auth_required: bool,
     bind_host: String,
     bind_port: u16,
+    mobile_enabled: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -78,6 +80,8 @@ pub struct RuntimeApiOptions {
     pub auth_token: Option<String>,
     /// Allow `/v1/*` routes without auth when no token is configured.
     pub insecure_no_auth: bool,
+    /// Enables the built-in mobile control page at `/mobile`.
+    pub mobile: bool,
 }
 
 impl Default for RuntimeApiOptions {
@@ -89,6 +93,7 @@ impl Default for RuntimeApiOptions {
             cors_origins: Vec::new(),
             auth_token: None,
             insecure_no_auth: false,
+            mobile: false,
         }
     }
 }
@@ -423,6 +428,7 @@ pub async fn run_http_server(
         auth_required: auth_enabled,
         bind_host: options.host.clone(),
         bind_port: options.port,
+        mobile_enabled: options.mobile,
     };
     let app = build_router(state);
 
@@ -444,6 +450,9 @@ pub async fn run_http_server(
         println!("Runtime API auth: bearer token required for /v1/* routes.");
     } else {
         println!("Runtime API auth: disabled by explicit insecure mode.");
+    }
+    if options.mobile {
+        print_mobile_urls(addr, runtime_token.as_deref(), auth_enabled);
     }
     let is_loopback = options.host == "127.0.0.1" || options.host == "::1";
     if is_loopback {
@@ -529,6 +538,8 @@ pub fn build_router(state: RuntimeApiState) -> Router {
 
     Router::new()
         .route("/health", get(health))
+        .route("/mobile", get(mobile_page))
+        .route("/mobile/", get(mobile_page))
         .route("/v1/runtime/info", get(runtime_info))
         .merge(api_routes)
         .layer(cors_layer(&state.cors_origins))
@@ -579,6 +590,51 @@ fn token_from_query(query: Option<&str>) -> Option<&str> {
             (key == "token").then_some(value)
         })
     })
+}
+
+async fn mobile_page(State(state): State<RuntimeApiState>) -> Response {
+    if !state.mobile_enabled {
+        return (
+            StatusCode::NOT_FOUND,
+            "mobile control is disabled; start with `codewhale serve --mobile`",
+        )
+            .into_response();
+    }
+    Html(MOBILE_HTML).into_response()
+}
+
+fn print_mobile_urls(addr: SocketAddr, token: Option<&str>, auth_enabled: bool) {
+    println!("Mobile control page enabled.");
+    let token_query = if auth_enabled {
+        token
+            .filter(|token| !token.trim().is_empty())
+            .map(|token| format!("?token={token}"))
+            .unwrap_or_default()
+    } else {
+        String::new()
+    };
+
+    let port = addr.port();
+    if addr.ip().is_unspecified() {
+        println!("  Local: http://127.0.0.1:{port}/mobile{token_query}");
+        if let Some(ip) = detect_lan_ip() {
+            println!("  LAN:   http://{ip}:{port}/mobile{token_query}");
+        } else {
+            println!(
+                "  LAN:   bind is 0.0.0.0; open http://<this-machine-ip>:{port}/mobile{token_query}"
+            );
+        }
+    } else {
+        println!("  URL:   http://{addr}/mobile{token_query}");
+    }
+    println!("Mobile security: use only on a trusted LAN/VPN; this server does not provide TLS.");
+}
+
+fn detect_lan_ip() -> Option<String> {
+    let socket = UdpSocket::bind("0.0.0.0:0").ok()?;
+    socket.connect("8.8.8.8:80").ok()?;
+    let addr = socket.local_addr().ok()?;
+    Some(addr.ip().to_string())
 }
 
 async fn health() -> Json<HealthResponse> {
@@ -1562,6 +1618,8 @@ fn map_compat_stream_event(event: &crate::runtime_threads::RuntimeEventRecord) -
             }
         }
         "approval.required" => Some(sse_json("approval.required", payload.clone())),
+        "approval.decided" => Some(sse_json("approval.decided", payload.clone())),
+        "approval.timeout" => Some(sse_json("approval.timeout", payload.clone())),
         "sandbox.denied" => Some(sse_json("sandbox.denied", payload.clone())),
         "turn.completed" => {
             let usage = payload
@@ -1741,6 +1799,8 @@ async fn get_usage(
         .map_err(|e| ApiError::internal(e.to_string()))?;
     Ok(Json(json!(aggregation)))
 }
+
+const MOBILE_HTML: &str = include_str!("runtime_mobile.html");
 
 /// Built-in dev origins always allowed by the runtime API (whalescale#255).
 const DEFAULT_CORS_ORIGINS: &[&str] = &[
@@ -1974,6 +2034,21 @@ mod tests {
             tokio::task::JoinHandle<()>,
         )>,
     > {
+        spawn_test_server_with_root_token_and_mobile(root, sessions_dir, runtime_token, false).await
+    }
+
+    async fn spawn_test_server_with_root_token_and_mobile(
+        root: PathBuf,
+        sessions_dir: PathBuf,
+        runtime_token: Option<String>,
+        mobile_enabled: bool,
+    ) -> Result<
+        Option<(
+            SocketAddr,
+            SharedRuntimeThreadManager,
+            tokio::task::JoinHandle<()>,
+        )>,
+    > {
         fs::create_dir_all(&sessions_dir)?;
         let manager = TaskManager::start_with_executor(
             TaskManagerConfig {
@@ -2035,6 +2110,7 @@ mod tests {
             auth_required,
             bind_host: "127.0.0.1".to_string(),
             bind_port: 0,
+            mobile_enabled,
         };
         let app = build_router(state);
         let listener = match TcpListener::bind("127.0.0.1:0").await {
@@ -3595,6 +3671,44 @@ mod tests {
         assert_eq!(info["bind_host"], "127.0.0.1");
         assert_eq!(info["auth_required"], false);
         assert!(info["version"].is_string());
+
+        handle.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn mobile_page_is_available_only_when_enabled() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let root = tmp.path().to_path_buf();
+        let sessions_dir = root.join("sessions");
+        let Some((addr, _runtime_threads, handle)) = spawn_test_server_with_root_token_and_mobile(
+            root.clone(),
+            sessions_dir.clone(),
+            None,
+            false,
+        )
+        .await?
+        else {
+            return Ok(());
+        };
+        let client = reqwest::Client::new();
+        let disabled = client.get(format!("http://{addr}/mobile")).send().await?;
+        assert_eq!(disabled.status(), StatusCode::NOT_FOUND);
+        handle.abort();
+
+        let Some((addr, _runtime_threads, handle)) =
+            spawn_test_server_with_root_token_and_mobile(root, sessions_dir, None, true).await?
+        else {
+            return Ok(());
+        };
+        let enabled = client
+            .get(format!("http://{addr}/mobile"))
+            .send()
+            .await?
+            .error_for_status()?;
+        let html = enabled.text().await?;
+        assert!(html.contains("CodeWhale Mobile"));
+        assert!(html.contains("/v1/approvals/"));
 
         handle.abort();
         Ok(())

--- a/crates/tui/src/runtime_mobile.html
+++ b/crates/tui/src/runtime_mobile.html
@@ -275,7 +275,7 @@
     }
 
     function token() {
-      return $("token").value.trim();
+      return $("token").value;
     }
 
     function takeTokenFromUrl() {
@@ -368,7 +368,8 @@
         method: "POST",
         body: JSON.stringify({ decision, remember })
       });
-      container.innerHTML = "<span class='meta'>Decision sent: " + escapeHtml(result.decision) + "</span>";
+      const decided = result?.decision ?? decision;
+      container.innerHTML = "<span class='meta'>Decision sent: " + escapeHtml(decided) + "</span>";
     }
 
     function appendEvent(name, data) {

--- a/crates/tui/src/runtime_mobile.html
+++ b/crates/tui/src/runtime_mobile.html
@@ -1,0 +1,543 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <title>CodeWhale Mobile</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #101214;
+      --panel: #181b1f;
+      --panel-2: #20242a;
+      --line: #323840;
+      --text: #f4f1e8;
+      --muted: #a8a49a;
+      --accent: #48c2a8;
+      --accent-2: #c89543;
+      --danger: #e86458;
+      --ok: #76c46b;
+    }
+    * { box-sizing: border-box; }
+    html, body { min-height: 100%; }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font: 15px/1.45 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      letter-spacing: 0;
+    }
+    header {
+      position: sticky;
+      top: 0;
+      z-index: 4;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      padding: calc(12px + env(safe-area-inset-top)) 14px 12px;
+      background: rgba(16, 18, 20, 0.96);
+      border-bottom: 1px solid var(--line);
+      backdrop-filter: blur(12px);
+    }
+    h1 {
+      margin: 0;
+      font-size: 18px;
+      font-weight: 740;
+    }
+    main {
+      display: grid;
+      gap: 12px;
+      padding: 12px 12px calc(14px + env(safe-area-inset-bottom));
+    }
+    section {
+      border: 1px solid var(--line);
+      background: var(--panel);
+      border-radius: 8px;
+      overflow: hidden;
+    }
+    .head {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+      padding: 10px 12px;
+      border-bottom: 1px solid var(--line);
+      min-height: 46px;
+    }
+    .body { padding: 12px; }
+    .grid { display: grid; gap: 10px; }
+    .row { display: flex; align-items: center; gap: 8px; }
+    .row > * { flex: 1; min-width: 0; }
+    button, input, textarea, select {
+      color: var(--text);
+      background: var(--panel-2);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      font: inherit;
+      letter-spacing: 0;
+    }
+    button {
+      min-height: 40px;
+      padding: 8px 11px;
+      font-weight: 680;
+      cursor: pointer;
+    }
+    button.primary {
+      background: #173d36;
+      border-color: #2a8b77;
+    }
+    button.warn {
+      background: #3c2b14;
+      border-color: #8b682b;
+    }
+    button.danger {
+      background: #421f1d;
+      border-color: #9b4038;
+    }
+    button:disabled {
+      cursor: not-allowed;
+      opacity: 0.55;
+    }
+    input, textarea, select {
+      width: 100%;
+      padding: 10px;
+    }
+    textarea {
+      min-height: 96px;
+      resize: vertical;
+    }
+    label.toggle {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      min-height: 40px;
+      padding: 8px 10px;
+      color: var(--muted);
+      background: var(--panel-2);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      font-size: 13px;
+    }
+    label.toggle input { width: auto; }
+    .status {
+      min-height: 38px;
+      padding: 9px 10px;
+      border-radius: 8px;
+      background: #121518;
+      border: 1px solid var(--line);
+      color: var(--muted);
+      overflow-wrap: anywhere;
+    }
+    .status.ok { color: var(--ok); }
+    .status.bad { color: var(--danger); }
+    .status.warn { color: var(--accent-2); }
+    #threads {
+      display: grid;
+      gap: 8px;
+      max-height: 260px;
+      overflow: auto;
+    }
+    .thread {
+      width: 100%;
+      padding: 10px;
+      text-align: left;
+      border-radius: 8px;
+      background: var(--panel-2);
+    }
+    .thread.active { border-color: var(--accent); }
+    .thread-title {
+      font-weight: 720;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .meta {
+      margin-top: 3px;
+      color: var(--muted);
+      font-size: 12px;
+      overflow-wrap: anywhere;
+    }
+    #events {
+      display: grid;
+      gap: 8px;
+      max-height: 54vh;
+      overflow: auto;
+      padding-right: 2px;
+    }
+    .event {
+      padding: 9px 10px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: #121518;
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+    }
+    .event.agent { border-color: #357969; }
+    .event.tool { border-color: #8b682b; }
+    .event.error { border-color: #9b4038; }
+    .event.ok { border-color: #4d8048; }
+    .approval-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 9px;
+    }
+    .approval-actions button {
+      flex: 0 0 auto;
+      min-width: 84px;
+    }
+    .empty {
+      color: var(--muted);
+      font-size: 13px;
+    }
+    @media (min-width: 900px) {
+      main {
+        grid-template-columns: 330px minmax(0, 1fr);
+        align-items: start;
+      }
+      section.chat {
+        grid-column: 2;
+        grid-row: 1 / span 3;
+      }
+      #threads { max-height: 420px; }
+      #events { max-height: calc(100vh - 150px); }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>CodeWhale Mobile</h1>
+    <button id="refresh" title="Refresh threads">Refresh</button>
+  </header>
+
+  <main>
+    <section>
+      <div class="head">
+        <strong>Connection</strong>
+        <button id="save-token">Save</button>
+      </div>
+      <div class="body grid">
+        <input id="token" autocomplete="off" spellcheck="false" placeholder="Runtime token">
+        <div id="conn" class="status">Not connected</div>
+      </div>
+    </section>
+
+    <section>
+      <div class="head">
+        <strong>Threads</strong>
+        <button id="new-thread" class="primary">New</button>
+      </div>
+      <div class="body"><div id="threads"></div></div>
+    </section>
+
+    <section class="chat">
+      <div class="head">
+        <strong id="active-title">No thread selected</strong>
+        <span id="event-count" class="meta">0 events</span>
+      </div>
+      <div class="body"><div id="events"></div></div>
+    </section>
+
+    <section>
+      <div class="head">
+        <strong>Composer</strong>
+        <button id="interrupt" class="danger">Interrupt</button>
+      </div>
+      <div class="body grid">
+        <textarea id="prompt" spellcheck="true" placeholder="Message"></textarea>
+        <div class="row">
+          <label class="toggle"><input id="allow-shell" type="checkbox"> shell</label>
+          <label class="toggle"><input id="auto-approve" type="checkbox"> auto</label>
+          <label class="toggle"><input id="remember-approval" type="checkbox"> remember</label>
+        </div>
+        <div class="row">
+          <button id="send" class="primary">Send</button>
+          <button id="steer" class="warn">Steer</button>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    const $ = (id) => document.getElementById(id);
+    const state = {
+      threadId: "",
+      activeTurnId: "",
+      source: null,
+      eventCount: 0
+    };
+
+    function setStatus(message, tone = "") {
+      const el = $("conn");
+      el.textContent = message;
+      el.className = "status" + (tone ? " " + tone : "");
+    }
+
+    function token() {
+      return $("token").value.trim();
+    }
+
+    function takeTokenFromUrl() {
+      const params = new URLSearchParams(location.search);
+      const urlToken = params.get("token");
+      if (!urlToken) return;
+      localStorage.setItem("codewhale_runtime_token", urlToken);
+      params.delete("token");
+      const qs = params.toString();
+      history.replaceState(null, "", location.pathname + (qs ? "?" + qs : ""));
+    }
+
+    function headers(extra = {}) {
+      const out = Object.assign({ "Content-Type": "application/json" }, extra);
+      if (token()) out.Authorization = "Bearer " + token();
+      return out;
+    }
+
+    async function api(path, options = {}) {
+      const res = await fetch(path, Object.assign({}, options, {
+        headers: headers(options.headers || {})
+      }));
+      if (!res.ok) {
+        let detail = await res.text();
+        try {
+          const parsed = JSON.parse(detail);
+          detail = parsed.error?.message || detail;
+        } catch (_) {}
+        throw new Error(detail || ("HTTP " + res.status));
+      }
+      if (res.status === 204) return null;
+      return res.json();
+    }
+
+    function escapeHtml(raw) {
+      return String(raw).replace(/[&<>"']/g, (char) => ({
+        "&": "&amp;",
+        "<": "&lt;",
+        ">": "&gt;",
+        "\"": "&quot;",
+        "'": "&#039;"
+      }[char]));
+    }
+
+    function eventPayload(data) {
+      return data && typeof data === "object" && "payload" in data ? data.payload : data;
+    }
+
+    function eventText(name, data) {
+      const payload = eventPayload(data) || {};
+      if (name === "item.delta") return payload.delta || "";
+      if (name === "item.started") {
+        const tool = payload.tool;
+        if (tool) return "Tool started: " + tool.name + "\n" + JSON.stringify(tool.input || {}, null, 2);
+      }
+      if (name === "item.completed" || name === "item.failed") {
+        const item = payload.item || {};
+        return (name === "item.completed" ? "Completed: " : "Failed: ") + (item.summary || item.kind || "");
+      }
+      if (name === "approval.required") {
+        return "Approval required: " + (payload.tool_name || "") + "\n" + (payload.description || "");
+      }
+      if (name === "approval.decided") {
+        return "Approval " + (payload.decision || "decided") + ": " + (payload.approval_id || "");
+      }
+      if (name === "approval.timeout") {
+        return "Approval timed out: " + (payload.approval_id || "");
+      }
+      if (name === "sandbox.denied") {
+        return "Sandbox denied: " + (payload.tool_name || "") + "\n" + (payload.reason || "");
+      }
+      if (name === "turn.lifecycle") return "Turn status: " + (payload.status || "");
+      if (name === "turn.completed") return "Turn completed";
+      if (name === "coherence.state") return JSON.stringify(payload, null, 2);
+      return JSON.stringify(payload, null, 2);
+    }
+
+    function approvalInfo(name, data) {
+      if (name !== "approval.required") return null;
+      const payload = eventPayload(data) || {};
+      const approvalId = payload.approval_id || payload.id;
+      if (!approvalId) return null;
+      return { id: approvalId };
+    }
+
+    async function decideApproval(approvalId, decision, container) {
+      for (const button of container.querySelectorAll("button")) button.disabled = true;
+      const remember = $("remember-approval").checked;
+      const result = await api("/v1/approvals/" + encodeURIComponent(approvalId), {
+        method: "POST",
+        body: JSON.stringify({ decision, remember })
+      });
+      container.innerHTML = "<span class='meta'>Decision sent: " + escapeHtml(result.decision) + "</span>";
+    }
+
+    function appendEvent(name, data) {
+      const text = eventText(name, data);
+      if (!text) return;
+      const item = document.createElement("div");
+      item.className = "event";
+      if (name === "item.delta") item.classList.add("agent");
+      if (name === "item.started" || name.includes("tool")) item.classList.add("tool");
+      if (name.includes("failed") || name.includes("denied") || name.includes("timeout")) item.classList.add("error");
+      if (name === "turn.completed" || name === "approval.decided") item.classList.add("ok");
+      item.innerHTML = "<div class='meta'>" + escapeHtml(name) + "</div>" + escapeHtml(text);
+
+      const approval = approvalInfo(name, data);
+      if (approval) {
+        const actions = document.createElement("div");
+        actions.className = "approval-actions";
+        const allow = document.createElement("button");
+        allow.className = "primary";
+        allow.textContent = "Allow";
+        allow.onclick = () => decideApproval(approval.id, "allow", actions)
+          .catch((err) => setStatus(err.message, "bad"));
+        const deny = document.createElement("button");
+        deny.className = "danger";
+        deny.textContent = "Deny";
+        deny.onclick = () => decideApproval(approval.id, "deny", actions)
+          .catch((err) => setStatus(err.message, "bad"));
+        actions.appendChild(allow);
+        actions.appendChild(deny);
+        item.appendChild(actions);
+      }
+
+      $("events").appendChild(item);
+      state.eventCount += 1;
+      $("event-count").textContent = state.eventCount + " events";
+      $("events").scrollTop = $("events").scrollHeight;
+    }
+
+    async function loadThreads() {
+      const threads = await api("/v1/threads/summary?limit=60&include_archived=false");
+      const list = $("threads");
+      list.innerHTML = "";
+      if (!threads.length) {
+        list.innerHTML = "<div class='empty'>No active threads.</div>";
+        return;
+      }
+      for (const thread of threads) {
+        const el = document.createElement("button");
+        el.className = "thread" + (thread.id === state.threadId ? " active" : "");
+        el.innerHTML =
+          "<div class='thread-title'>" + escapeHtml(thread.title || thread.id) + "</div>" +
+          "<div class='meta'>" + escapeHtml(thread.mode || "") + " / " +
+          escapeHtml(thread.model || "") + "</div>";
+        el.onclick = () => selectThread(thread.id, thread.title || thread.id);
+        list.appendChild(el);
+      }
+    }
+
+    async function newThread() {
+      const thread = await api("/v1/threads", {
+        method: "POST",
+        body: JSON.stringify({
+          mode: "agent",
+          allow_shell: $("allow-shell").checked,
+          trust_mode: false,
+          auto_approve: $("auto-approve").checked
+        })
+      });
+      await loadThreads();
+      selectThread(thread.id, thread.title || thread.id);
+    }
+
+    async function selectThread(id, title) {
+      state.threadId = id;
+      state.activeTurnId = "";
+      state.eventCount = 0;
+      $("event-count").textContent = "0 events";
+      $("active-title").textContent = title || id;
+      $("events").innerHTML = "";
+      if (state.source) state.source.close();
+      const qs = "?since_seq=0" + (token() ? "&token=" + encodeURIComponent(token()) : "");
+      const source = new EventSource("/v1/threads/" + encodeURIComponent(id) + "/events" + qs);
+      state.source = source;
+      const names = [
+        "thread.started",
+        "turn.started",
+        "turn.lifecycle",
+        "turn.steered",
+        "turn.interrupt_requested",
+        "turn.completed",
+        "item.started",
+        "item.delta",
+        "item.completed",
+        "item.failed",
+        "approval.required",
+        "approval.decided",
+        "approval.timeout",
+        "sandbox.denied",
+        "coherence.state"
+      ];
+      for (const name of names) {
+        source.addEventListener(name, (ev) => {
+          let data = {};
+          try { data = JSON.parse(ev.data || "{}"); } catch (_) {}
+          if (data.turn_id) state.activeTurnId = data.turn_id;
+          appendEvent(name, data);
+        });
+      }
+      source.onopen = () => setStatus("Connected", "ok");
+      source.onerror = () => setStatus("Event stream disconnected", "warn");
+      await loadThreads();
+    }
+
+    async function sendPrompt() {
+      if (!state.threadId) await newThread();
+      const prompt = $("prompt").value.trim();
+      if (!prompt) return;
+      const res = await api("/v1/threads/" + encodeURIComponent(state.threadId) + "/turns", {
+        method: "POST",
+        body: JSON.stringify({
+          prompt,
+          allow_shell: $("allow-shell").checked,
+          trust_mode: false,
+          auto_approve: $("auto-approve").checked
+        })
+      });
+      state.activeTurnId = res.turn?.id || state.activeTurnId;
+      $("prompt").value = "";
+      await loadThreads();
+    }
+
+    async function steerTurn() {
+      if (!state.threadId || !state.activeTurnId) throw new Error("No active turn");
+      const prompt = $("prompt").value.trim();
+      if (!prompt) return;
+      await api(
+        "/v1/threads/" + encodeURIComponent(state.threadId) +
+        "/turns/" + encodeURIComponent(state.activeTurnId) + "/steer",
+        { method: "POST", body: JSON.stringify({ prompt }) }
+      );
+      $("prompt").value = "";
+    }
+
+    async function interruptTurn() {
+      if (!state.threadId || !state.activeTurnId) throw new Error("No active turn");
+      await api(
+        "/v1/threads/" + encodeURIComponent(state.threadId) +
+        "/turns/" + encodeURIComponent(state.activeTurnId) + "/interrupt",
+        { method: "POST", body: "{}" }
+      );
+    }
+
+    async function boot() {
+      takeTokenFromUrl();
+      $("token").value = localStorage.getItem("codewhale_runtime_token") || "";
+      $("save-token").onclick = async () => {
+        localStorage.setItem("codewhale_runtime_token", token());
+        await loadThreads().catch((err) => setStatus(err.message, "bad"));
+      };
+      $("refresh").onclick = () => loadThreads().catch((err) => setStatus(err.message, "bad"));
+      $("new-thread").onclick = () => newThread().catch((err) => setStatus(err.message, "bad"));
+      $("send").onclick = () => sendPrompt().catch((err) => setStatus(err.message, "bad"));
+      $("steer").onclick = () => steerTurn().catch((err) => setStatus(err.message, "bad"));
+      $("interrupt").onclick = () => interruptTurn().catch((err) => setStatus(err.message, "bad"));
+      await loadThreads();
+      setStatus("Connected", "ok");
+    }
+
+    boot().catch((err) => setStatus(err.message, "bad"));
+  </script>
+</body>
+</html>

--- a/crates/tui/src/runtime_mobile.html
+++ b/crates/tui/src/runtime_mobile.html
@@ -364,12 +364,17 @@
     async function decideApproval(approvalId, decision, container) {
       for (const button of container.querySelectorAll("button")) button.disabled = true;
       const remember = $("remember-approval").checked;
-      const result = await api("/v1/approvals/" + encodeURIComponent(approvalId), {
-        method: "POST",
-        body: JSON.stringify({ decision, remember })
-      });
-      const decided = result?.decision ?? decision;
-      container.innerHTML = "<span class='meta'>Decision sent: " + escapeHtml(decided) + "</span>";
+      try {
+        const result = await api("/v1/approvals/" + encodeURIComponent(approvalId), {
+          method: "POST",
+          body: JSON.stringify({ decision, remember })
+        });
+        const decided = result?.decision ?? decision;
+        container.innerHTML = "<span class='meta'>Decision sent: " + escapeHtml(decided) + "</span>";
+      } catch (err) {
+        for (const button of container.querySelectorAll("button")) button.disabled = false;
+        throw err;
+      }
     }
 
     function appendEvent(name, data) {
@@ -412,7 +417,7 @@
       const threads = await api("/v1/threads/summary?limit=60&include_archived=false");
       const list = $("threads");
       list.innerHTML = "";
-      if (!threads.length) {
+      if (!threads || !threads.length) {
         list.innerHTML = "<div class='empty'>No active threads.</div>";
         return;
       }

--- a/docs/RUNTIME_API.md
+++ b/docs/RUNTIME_API.md
@@ -117,7 +117,7 @@ codewhale doctor --json
 
 ```bash
 codewhale serve --http [--host 127.0.0.1] [--port 7878] [--workers 2] [--auth-token TOKEN]
-codewhale serve --mobile [--port 7878] [--auth-token TOKEN]
+codewhale serve --mobile [--host 0.0.0.0] [--port 7878] [--auth-token TOKEN]
 ```
 
 Defaults: host `127.0.0.1`, port `7878`, 2 workers (clamped 1–8).
@@ -128,8 +128,10 @@ there is no `[app_server]` config section.
 `/v1/*` routes require a bearer token unless `--insecure` is explicitly set.
 Pass `--auth-token TOKEN` or set `DEEPSEEK_RUNTIME_TOKEN=TOKEN` before starting
 the server. If neither is set, the process generates a one-time token and prints
-it at startup. `/health`, `/mobile`, and `/v1/runtime/info` remain public for
-local supervision and bootstrap.
+it at startup. `/health` and `/v1/runtime/info` remain public for local
+supervision and bootstrap. `/mobile` returns 404 when mobile mode is disabled;
+when mobile mode is enabled and auth is enabled, `/mobile` returns 401 unless
+the request supplies the runtime token.
 
 Authenticated clients can provide the token as `Authorization: Bearer TOKEN`,
 `X-DeepSeek-Runtime-Token: TOKEN`, or `?token=TOKEN` for EventSource-style
@@ -139,9 +141,12 @@ clients that cannot set custom headers.
 
 `codewhale serve --mobile` starts the same HTTP/SSE runtime API and serves a
 phone-friendly control page at `/mobile`. When the bind host is left at the
-default, mobile mode binds to `0.0.0.0` and prints local/LAN URLs. If a runtime
-token is generated or supplied, the printed mobile URL includes it as a query
-parameter; the page stores it locally and removes it from the address bar.
+default, mobile mode binds to `0.0.0.0`, prints a warning, and prints local/LAN
+URLs. Pass `--host 127.0.0.1` to keep the mobile page loopback-only. If a
+runtime token is generated or supplied, the printed mobile URL includes it as a
+query parameter; the page stores it locally and removes it from the address bar.
+The static HTML page contains no secrets, but it is still token-gated when auth
+is enabled so unauthenticated LAN clients cannot fingerprint the mobile surface.
 
 The mobile page can list/create threads, send prompts, follow live SSE events,
 steer or interrupt an active turn, and resolve normal tool approvals through
@@ -331,10 +336,11 @@ Common event names: `thread.started`, `thread.forked`, `turn.started`,
 ## Security boundary
 
 - **Localhost by default**. The server binds to `127.0.0.1` by default.
-  `--mobile` binds to `0.0.0.0` when the host is left at the default so phones
-  on the same LAN can reach it. Set a non-loopback host only when you trust the
-  network path or have a reverse-proxy / VPN that authenticates. The runtime
-  does not provide user isolation or TLS.
+  `--mobile` binds to `0.0.0.0` when no host is supplied so phones on the same
+  LAN can reach it, and the CLI prints a warning for that rebind. Pass
+  `--host 127.0.0.1` for a loopback-only mobile page. Set a non-loopback host
+  only when you trust the network path or have a reverse-proxy / VPN that
+  authenticates. The runtime does not provide user isolation or TLS.
 - **Optional token guard**. `--auth-token` or `DEEPSEEK_RUNTIME_TOKEN`
   requires a matching bearer token for `/v1/*` routes. This is a local
   convenience guard, not a replacement for TLS, VPN, or a trusted reverse

--- a/docs/RUNTIME_API.md
+++ b/docs/RUNTIME_API.md
@@ -117,6 +117,7 @@ codewhale doctor --json
 
 ```bash
 codewhale serve --http [--host 127.0.0.1] [--port 7878] [--workers 2] [--auth-token TOKEN]
+codewhale serve --mobile [--port 7878] [--auth-token TOKEN]
 ```
 
 Defaults: host `127.0.0.1`, port `7878`, 2 workers (clamped 1–8).
@@ -124,15 +125,29 @@ Defaults: host `127.0.0.1`, port `7878`, 2 workers (clamped 1–8).
 The server binds to `localhost` by default. Configuration is via CLI flags —
 there is no `[app_server]` config section.
 
-By default, existing local behavior is unchanged and `/v1/*` routes are not
-authenticated. To require a bearer token for `/v1/*` routes, pass
-`--auth-token TOKEN` or set `DEEPSEEK_RUNTIME_TOKEN=TOKEN` before starting the
-server. `/health` remains public for local process supervision and readiness
-checks.
+`/v1/*` routes require a bearer token unless `--insecure` is explicitly set.
+Pass `--auth-token TOKEN` or set `DEEPSEEK_RUNTIME_TOKEN=TOKEN` before starting
+the server. If neither is set, the process generates a one-time token and prints
+it at startup. `/health`, `/mobile`, and `/v1/runtime/info` remain public for
+local supervision and bootstrap.
 
 Authenticated clients can provide the token as `Authorization: Bearer TOKEN`,
 `X-DeepSeek-Runtime-Token: TOKEN`, or `?token=TOKEN` for EventSource-style
 clients that cannot set custom headers.
+
+### Mobile control page
+
+`codewhale serve --mobile` starts the same HTTP/SSE runtime API and serves a
+phone-friendly control page at `/mobile`. When the bind host is left at the
+default, mobile mode binds to `0.0.0.0` and prints local/LAN URLs. If a runtime
+token is generated or supplied, the printed mobile URL includes it as a query
+parameter; the page stores it locally and removes it from the address bar.
+
+The mobile page can list/create threads, send prompts, follow live SSE events,
+steer or interrupt an active turn, and resolve normal tool approvals through
+`POST /v1/approvals/{approval_id}`. It is still a local/LAN convenience surface:
+do not expose it directly to the public internet without TLS and a trusted
+fronting layer.
 
 ### Endpoints
 
@@ -187,6 +202,10 @@ accept an empty string to clear a previously-set value. Added in v0.8.10 (#562):
 - `POST /v1/threads/{id}/turns/{turn_id}/steer`
 - `POST /v1/threads/{id}/turns/{turn_id}/interrupt`
 - `POST /v1/threads/{id}/compact` (manual compaction)
+
+**Approvals**
+- `POST /v1/approvals/{approval_id}` with body
+  `{ "decision": "allow" | "deny", "remember": false }`
 
 **Events** (SSE replay + live stream)
 - `GET /v1/threads/{id}/events?since_seq=<u64>`
@@ -306,14 +325,16 @@ The SSE event payload shape:
 Common event names: `thread.started`, `thread.forked`, `turn.started`,
 `turn.lifecycle`, `turn.steered`, `turn.interrupt_requested`,
 `turn.completed`, `item.started`, `item.delta`, `item.completed`,
-`item.failed`, `item.interrupted`, `approval.required`, `sandbox.denied`,
-`coherence.state`.
+`item.failed`, `item.interrupted`, `approval.required`, `approval.decided`,
+`approval.timeout`, `sandbox.denied`, `coherence.state`.
 
 ## Security boundary
 
-- **Localhost only**. The server binds to `127.0.0.1` by default. Set
-  `--host 0.0.0.0` only when you have a reverse-proxy / VPN that
-  authenticates. The runtime does not provide user isolation or TLS.
+- **Localhost by default**. The server binds to `127.0.0.1` by default.
+  `--mobile` binds to `0.0.0.0` when the host is left at the default so phones
+  on the same LAN can reach it. Set a non-loopback host only when you trust the
+  network path or have a reverse-proxy / VPN that authenticates. The runtime
+  does not provide user isolation or TLS.
 - **Optional token guard**. `--auth-token` or `DEEPSEEK_RUNTIME_TOKEN`
   requires a matching bearer token for `/v1/*` routes. This is a local
   convenience guard, not a replacement for TLS, VPN, or a trusted reverse


### PR DESCRIPTION
Rebased replacement for #852 after the v0.8.41 CodeWhale rebrand.

What changed:
- adds `codewhale serve --mobile` as a thin mobile/LAN entry point over the existing runtime HTTP/SSE API
- serves a built-in `/mobile` control page from a separate `runtime_mobile.html` file via `include_str!`
- uses the current `/v1/approvals/{approval_id}` bridge instead of restoring the old per-turn approval routes
- keeps the already-merged runtime token guard intact rather than reintroducing the old #852 auth implementation
- updates runtime API docs plus README command listings

Validation:
- `cargo fmt --all`
- `git diff --check`
- `cargo check -p codewhale-tui --locked`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked runtime_api::tests::`
- local smoke: `codewhale-tui serve --mobile --port 7879 --insecure`, `GET /mobile` returned HTTP 200 with title `CodeWhale Mobile`

Note: `cargo test -p codewhale-tui --locked runtime_api::tests::` also passed the runtime API module tests, but the full cargo invocation then tried to launch the filtered `skill_install` integration binary on Windows and hit OS error 740 (requires elevation). The bin-scoped command above avoids that unrelated Windows integration-test launcher issue.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `codewhale serve --mobile` as a thin LAN entry point: it starts the existing HTTP/SSE runtime API and serves a compiled-in mobile control page at `/mobile`. The approach reuses the current `/v1/approvals/{id}` bridge and the existing token-guard middleware rather than restoring any old auth code.

- **New `--mobile` flag** (mutually exclusive with `--http`) defaults the bind host to `0.0.0.0` with an explicit CLI warning, and passes `mobile: bool` through to `RuntimeApiOptions`/`RuntimeApiState` so the `/mobile` route returns 404 when the flag is absent.
- **`runtime_mobile.html`** (embedded via `include_str!`) is a single-file mobile page with thread listing, SSE live-stream, prompt/steer/interrupt controls, and token-gated approval buttons; all server-supplied text is HTML-escaped before insertion.
- **Token URL round-trip** is now percent-decoded server-side via a new `percent_decode_query_component` helper so tokens with special characters survive the `?token=` query parameter path.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The mobile feature is well-contained, reuses the existing auth middleware correctly, and the new token percent-decode path is covered by tests.

The auth logic for /mobile (inline check using the same request_has_runtime_token helper as the middleware) is consistent and correct. XSS is addressed throughout the HTML page. The percent-decode/encode round-trip for special-character tokens is tested end-to-end. The only issues found are display-only: the LAN IP detection probe address and a JSON-vs-HTML auth error for direct browser navigation.

No files require special attention. The two suggestions are in runtime_api.rs but neither affects correctness or security.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/runtime_api.rs | Adds mobile_enabled flag to state, /mobile route with inline auth check (consistent with /health pattern), percent-decoding for ?token= query params, detect_lan_ip() helper, and two new SSE compat events (approval.decided/timeout). Logic is sound; new helpers are unit-tested. |
| crates/tui/src/runtime_mobile.html | New single-file mobile control page embedded at compile time. All server-sourced strings pass through escapeHtml(); approval decision uses result?.decision ?? decision which correctly handles 204 null; token is read from input value without trim(). No XSS vectors identified. |
| crates/tui/src/main.rs | Adds --mobile flag, changes --host to Option<String>, extracts validate_serve_mode_selection (with --http/--mobile mutual exclusion) and resolve_serve_bind_host into testable functions, prints 0.0.0.0 rebind warning. All paths covered by new unit tests. |
| docs/RUNTIME_API.md | Documents --mobile flag, /mobile endpoint auth behaviour, approval bridge, new SSE event names, and updated security-boundary section. Accurate reflection of the implementation. |
| README.md | Adds codewhale serve --mobile entry to command listing and updates RUNTIME_API.md table caption. Minor doc change, no issues. |
| README.zh-CN.md | Chinese README mirrors the same one-line addition and table caption update as README.md. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User as Mobile Browser
    participant Server as codewhale serve --mobile

    Note over Server: binds 0.0.0.0 (default)<br/>prints Local + LAN URLs with ?token=

    User->>Server: "GET /mobile?token=XYZ"
    alt "mobile_enabled && token valid"
        Server-->>User: 200 HTML (MOBILE_HTML)
    else token missing/invalid
        Server-->>User: 401 JSON error
    end

    Note over User: JS stores token to localStorage<br/>removes from URL (history.replaceState)

    User->>Server: GET /v1/threads/summary (Bearer token)
    Server-->>User: JSON thread list

    User->>Server: POST /v1/threads (Bearer token)
    Server-->>User: 201 thread object

    User->>Server: "GET /v1/threads/{id}/events?since_seq=0&token=XYZ (EventSource)"
    loop SSE stream
        Server-->>User: approval.required event
        User->>Server: "POST /v1/approvals/{id} {decision, remember}"
        Server-->>User: "200 {decision}"
        Server-->>User: approval.decided event
    end

    User->>Server: "POST /v1/threads/{id}/turns/{tid}/interrupt"
    Server-->>User: 200
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fmobile-remote-control%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fmobile-remote-control%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fruntime_api.rs%3A714-720%0A%60detect_lan_ip%60%20connects%20to%20%6010.255.255.255%60%20to%20probe%20the%20outbound%20interface.%20On%20machines%20where%20a%20VPN%20claims%20the%20%6010.0.0.0%2F8%60%20subnet%20%28common%20for%20WireGuard%2C%20OpenVPN%2C%20and%20most%20corporate%20VPNs%29%2C%20the%20OS%20routes%20this%20probe%20through%20the%20VPN%20tunnel%2C%20so%20%60local_addr%28%29%60%20returns%20the%20VPN%20interface%20IP%20rather%20than%20the%20physical%20WiFi%2FEthernet%20IP.%20The%20printed%20LAN%20URL%20would%20be%20unreachable%20from%20the%20phone.%20A%20public%20anycast%20address%20is%20more%20likely%20to%20leave%20the%20physical%20interface%20on%20a%20split-tunnel%20VPN.%0A%0A%60%60%60suggestion%0Afn%20detect_lan_ip%28%29%20-%3E%20Option%3CString%3E%20%7B%0A%20%20%20%20let%20socket%20%3D%20UdpSocket%3A%3Abind%28%220.0.0.0%3A0%22%29.ok%28%29%3F%3B%0A%20%20%20%20%2F%2F%20UDP%20connect%20only%20selects%20the%20outbound%20interface%20locally%3B%20no%20packet%20is%20sent.%0A%20%20%20%20%2F%2F%20Use%20a%20public%20address%20so%20split-tunnel%20VPNs%20%28which%20claim%20RFC-1918%20space%29%20do%0A%20%20%20%20%2F%2F%20not%20intercept%20the%20probe%20and%20return%20the%20VPN%20interface%20IP%20instead%20of%20the%20LAN%20IP.%0A%20%20%20%20socket.connect%28%228.8.8.8%3A80%22%29.ok%28%29%3F%3B%0A%20%20%20%20let%20addr%20%3D%20socket.local_addr%28%29.ok%28%29%3F%3B%0A%20%20%20%20Some%28addr.ip%28%29.to_string%28%29%29%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fruntime_api.rs%3A373-387%0A**JSON%20401%20body%20served%20to%20plain%20browser%20navigation**%0A%0AWhen%20auth%20is%20enabled%20and%20a%20user%20navigates%20directly%20to%20%60%2Fmobile%60%20in%20a%20browser%20without%20the%20token%20in%20the%20URL%20or%20%60localStorage%60%2C%20%60runtime_token_required_response%28%29%60%20returns%20%60%7B%22error%22%3A%7B%22message%22%3A%22runtime%20API%20bearer%20token%20required%22%2C%22status%22%3A401%7D%7D%60%20as%20the%20response%20body.%20Since%20the%20browser%20issued%20an%20HTML%20page%20request%2C%20it%20renders%20this%20raw%20JSON%20rather%20than%20a%20user-friendly%20message.%20The%20happy%20path%20%28opening%20the%20printed%20URL%20that%20contains%20%60%3Ftoken%3D%60%29%20works%20correctly%3B%20this%20only%20affects%20the%20failure%20path%2C%20but%20it%20can%20be%20confusing%20on%20mobile.%20Returning%20a%20minimal%20HTML%20page%20with%20instructions%20when%20the%20%60Accept%60%20header%20indicates%20a%20browser%20request%20would%20improve%20the%20experience.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fruntime_api.rs%3A714-720%0A%60detect_lan_ip%60%20connects%20to%20%6010.255.255.255%60%20to%20probe%20the%20outbound%20interface.%20On%20machines%20where%20a%20VPN%20claims%20the%20%6010.0.0.0%2F8%60%20subnet%20%28common%20for%20WireGuard%2C%20OpenVPN%2C%20and%20most%20corporate%20VPNs%29%2C%20the%20OS%20routes%20this%20probe%20through%20the%20VPN%20tunnel%2C%20so%20%60local_addr%28%29%60%20returns%20the%20VPN%20interface%20IP%20rather%20than%20the%20physical%20WiFi%2FEthernet%20IP.%20The%20printed%20LAN%20URL%20would%20be%20unreachable%20from%20the%20phone.%20A%20public%20anycast%20address%20is%20more%20likely%20to%20leave%20the%20physical%20interface%20on%20a%20split-tunnel%20VPN.%0A%0A%60%60%60suggestion%0Afn%20detect_lan_ip%28%29%20-%3E%20Option%3CString%3E%20%7B%0A%20%20%20%20let%20socket%20%3D%20UdpSocket%3A%3Abind%28%220.0.0.0%3A0%22%29.ok%28%29%3F%3B%0A%20%20%20%20%2F%2F%20UDP%20connect%20only%20selects%20the%20outbound%20interface%20locally%3B%20no%20packet%20is%20sent.%0A%20%20%20%20%2F%2F%20Use%20a%20public%20address%20so%20split-tunnel%20VPNs%20%28which%20claim%20RFC-1918%20space%29%20do%0A%20%20%20%20%2F%2F%20not%20intercept%20the%20probe%20and%20return%20the%20VPN%20interface%20IP%20instead%20of%20the%20LAN%20IP.%0A%20%20%20%20socket.connect%28%228.8.8.8%3A80%22%29.ok%28%29%3F%3B%0A%20%20%20%20let%20addr%20%3D%20socket.local_addr%28%29.ok%28%29%3F%3B%0A%20%20%20%20Some%28addr.ip%28%29.to_string%28%29%29%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fruntime_api.rs%3A373-387%0A**JSON%20401%20body%20served%20to%20plain%20browser%20navigation**%0A%0AWhen%20auth%20is%20enabled%20and%20a%20user%20navigates%20directly%20to%20%60%2Fmobile%60%20in%20a%20browser%20without%20the%20token%20in%20the%20URL%20or%20%60localStorage%60%2C%20%60runtime_token_required_response%28%29%60%20returns%20%60%7B%22error%22%3A%7B%22message%22%3A%22runtime%20API%20bearer%20token%20required%22%2C%22status%22%3A401%7D%7D%60%20as%20the%20response%20body.%20Since%20the%20browser%20issued%20an%20HTML%20page%20request%2C%20it%20renders%20this%20raw%20JSON%20rather%20than%20a%20user-friendly%20message.%20The%20happy%20path%20%28opening%20the%20printed%20URL%20that%20contains%20%60%3Ftoken%3D%60%29%20works%20correctly%3B%20this%20only%20affects%20the%20failure%20path%2C%20but%20it%20can%20be%20confusing%20on%20mobile.%20Returning%20a%20minimal%20HTML%20page%20with%20instructions%20when%20the%20%60Accept%60%20header%20indicates%20a%20browser%20request%20would%20improve%20the%20experience.%0A%0A&repo=hmbown%2Fcodewhale&pr=1968&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fruntime_api.rs%3A714-720%0A%60detect_lan_ip%60%20connects%20to%20%6010.255.255.255%60%20to%20probe%20the%20outbound%20interface.%20On%20machines%20where%20a%20VPN%20claims%20the%20%6010.0.0.0%2F8%60%20subnet%20%28common%20for%20WireGuard%2C%20OpenVPN%2C%20and%20most%20corporate%20VPNs%29%2C%20the%20OS%20routes%20this%20probe%20through%20the%20VPN%20tunnel%2C%20so%20%60local_addr%28%29%60%20returns%20the%20VPN%20interface%20IP%20rather%20than%20the%20physical%20WiFi%2FEthernet%20IP.%20The%20printed%20LAN%20URL%20would%20be%20unreachable%20from%20the%20phone.%20A%20public%20anycast%20address%20is%20more%20likely%20to%20leave%20the%20physical%20interface%20on%20a%20split-tunnel%20VPN.%0A%0A%60%60%60suggestion%0Afn%20detect_lan_ip%28%29%20-%3E%20Option%3CString%3E%20%7B%0A%20%20%20%20let%20socket%20%3D%20UdpSocket%3A%3Abind%28%220.0.0.0%3A0%22%29.ok%28%29%3F%3B%0A%20%20%20%20%2F%2F%20UDP%20connect%20only%20selects%20the%20outbound%20interface%20locally%3B%20no%20packet%20is%20sent.%0A%20%20%20%20%2F%2F%20Use%20a%20public%20address%20so%20split-tunnel%20VPNs%20%28which%20claim%20RFC-1918%20space%29%20do%0A%20%20%20%20%2F%2F%20not%20intercept%20the%20probe%20and%20return%20the%20VPN%20interface%20IP%20instead%20of%20the%20LAN%20IP.%0A%20%20%20%20socket.connect%28%228.8.8.8%3A80%22%29.ok%28%29%3F%3B%0A%20%20%20%20let%20addr%20%3D%20socket.local_addr%28%29.ok%28%29%3F%3B%0A%20%20%20%20Some%28addr.ip%28%29.to_string%28%29%29%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fruntime_api.rs%3A373-387%0A**JSON%20401%20body%20served%20to%20plain%20browser%20navigation**%0A%0AWhen%20auth%20is%20enabled%20and%20a%20user%20navigates%20directly%20to%20%60%2Fmobile%60%20in%20a%20browser%20without%20the%20token%20in%20the%20URL%20or%20%60localStorage%60%2C%20%60runtime_token_required_response%28%29%60%20returns%20%60%7B%22error%22%3A%7B%22message%22%3A%22runtime%20API%20bearer%20token%20required%22%2C%22status%22%3A401%7D%7D%60%20as%20the%20response%20body.%20Since%20the%20browser%20issued%20an%20HTML%20page%20request%2C%20it%20renders%20this%20raw%20JSON%20rather%20than%20a%20user-friendly%20message.%20The%20happy%20path%20%28opening%20the%20printed%20URL%20that%20contains%20%60%3Ftoken%3D%60%29%20works%20correctly%3B%20this%20only%20affects%20the%20failure%20path%2C%20but%20it%20can%20be%20confusing%20on%20mobile.%20Returning%20a%20minimal%20HTML%20page%20with%20instructions%20when%20the%20%60Accept%60%20header%20indicates%20a%20browser%20request%20would%20improve%20the%20experience.%0A%0A&pr=1968&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (4): Last reviewed commit: ["fix(runtime): restore mobile retry guard..."](https://github.com/hmbown/codewhale/commit/a0bab58059068e14210a9f92b09a5d8ac8d4815d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33797925)</sub>

<!-- /greptile_comment -->