### PR TITLE
fix: sync ActiveTurnState.auto_approve when remember checkbox is set

### DIFF
--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -865,6 +865,15 @@ impl RuntimeThreadManager {
                 err
             );
         }
+
+        {
+            let mut active = self.active.lock().await;
+            if let Some(state) = active.engines.get_mut(thread_id) {
+                if let Some(turn) = state.active_turn.as_mut() {
+                    turn.auto_approve = true;
+                }
+            }
+        }
     }
 
     #[must_use]


### PR DESCRIPTION
## Problem

When a user checks "Remember for this tool" and approves a tool call, subsequent tool calls within the **same turn** still require manual approval. The remember checkbox appears non-functional.

## Root Cause

`remember_thread_auto_approve()` only persists `thread.auto_approve = true` to disk, but does **not** update the in-memory `ActiveTurnState.auto_approve` for the current turn.

When the next `ApprovalRequired` event arrives, `active_turn_flags()` reads from `ActiveTurnState` (which is still `false`), so `approval_decision()` returns `DenyTool` and the approval dialog pops up again.

The persisted `thread.auto_approve` only takes effect when the **next turn** starts (which creates a fresh `ActiveTurnState` from the stored thread record).

## Fix

In `remember_thread_auto_approve()`, after persisting the thread record, also update the current turn's `ActiveTurnState.auto_approve` to `true`:

```rust
{
    let mut active = self.active.lock().await;
    if let Some(state) = active.engines.get_mut(thread_id) {
        if let Some(turn) = state.active_turn.as_mut() {
            turn.auto_approve = true;
        }
    }
}
```

This ensures `active_turn_flags()` returns the correct value immediately, and `approval_decision()` auto-approves remaining tool calls within the current turn.

## Testing

- Existing test `approval_required_remember_flips_thread_auto_approve` continues to pass (it only verifies persisted `thread.auto_approve`).
- The fix adds the missing in-memory sync that the existing test does not cover.