### PR TITLE
fix(file_search): honor cancel_token to keep stop button responsive

### DIFF
--- a/crates/tui/src/tools/file_search.rs
+++ b/crates/tui/src/tools/file_search.rs
@@ -7,8 +7,9 @@ use async_trait::async_trait;
 use ignore::WalkBuilder;
 use serde::Serialize;
 use serde_json::{Value, json};
+use tokio_util::sync::CancellationToken;
 
-use crate::tools::search::matches_glob;
+use crate::tools::search::{check_cancelled, matches_glob};
 
 use super::spec::{
     ApprovalRequirement, ToolCapability, ToolContext, ToolError, ToolResult, ToolSpec,
@@ -87,7 +88,14 @@ impl ToolSpec for FileSearchTool {
 
         let extensions = parse_extensions(&input);
         let exclude_patterns = parse_exclude_patterns(&input);
-        let matches = search_files(query, &base_path, extensions, exclude_patterns, limit)?;
+        let matches = search_files(
+            query,
+            &base_path,
+            extensions,
+            exclude_patterns,
+            limit,
+            context.cancel_token.as_ref(),
+        )?;
         ToolResult::json(&matches).map_err(|e| ToolError::execution_failed(e.to_string()))
     }
 }
@@ -147,6 +155,7 @@ fn search_files(
     extensions: Vec<String>,
     exclude_patterns: Vec<String>,
     limit: usize,
+    cancel_token: Option<&CancellationToken>,
 ) -> Result<Vec<FileSearchMatch>, ToolError> {
     if !base_path.exists() {
         return Err(ToolError::invalid_input(format!(
@@ -163,6 +172,8 @@ fn search_files(
     let walker = builder.build();
 
     for entry in walker {
+        check_cancelled(cancel_token)?;
+
         let entry = match entry {
             Ok(entry) => entry,
             Err(_) => continue,
@@ -429,5 +440,25 @@ mod tests {
 
         assert!(result.success);
         assert!(!result.content.contains("secret.txt"));
+    }
+
+    #[tokio::test]
+    async fn test_file_search_respects_cancel_token() {
+        let tmp = tempdir().expect("tempdir");
+        std::fs::write(tmp.path().join("needle.txt"), "x\n").expect("write");
+        let cancel_token = CancellationToken::new();
+        cancel_token.cancel();
+        let ctx = ToolContext::new(tmp.path().to_path_buf()).with_cancel_token(cancel_token);
+
+        let tool = FileSearchTool;
+        let err = tool
+            .execute(json!({"query": "needle"}), &ctx)
+            .await
+            .expect_err("cancelled file_search should return an error");
+
+        assert!(
+            format!("{err:?}").contains("cancelled"),
+            "unexpected error: {err:?}"
+        );
     }
 }

--- a/crates/tui/src/tools/search.rs
+++ b/crates/tui/src/tools/search.rs
@@ -347,7 +347,7 @@ fn collect_files_recursive(
     Ok(())
 }
 
-fn check_cancelled(cancel_token: Option<&CancellationToken>) -> Result<(), ToolError> {
+pub(super) fn check_cancelled(cancel_token: Option<&CancellationToken>) -> Result<(), ToolError> {
     if cancel_token.is_some_and(CancellationToken::is_cancelled) {
         return Err(ToolError::execution_failed(
             "search cancelled before completion",


### PR DESCRIPTION
## Problem

`FileSearchTool::execute` is `async fn` but `search_files()` synchronously iterates the directory tree via `ignore::WalkBuilder`. On large trees (`$HOME`, mounted network volumes, deep `node_modules/`), this blocks the tokio task for tens of seconds. While the walker runs the engine cannot observe the shared `CancellationToken`, so `Op::Cancel` and frontend stop buttons are effectively no-ops until the walk completes. Observed in a wrapping GUI: the stop button was unresponsive for 90+ seconds when the model ran `file_search` with `workspace=$HOME`.

## Fix

`grep_files` already solved this in `search.rs` by polling `ToolContext.cancel_token` between iterations and returning a `ToolError` on cancel. This PR applies the same pattern to `file_search`:

- Thread `cancel_token` through `search_files()`.
- Call `check_cancelled()` once per `WalkBuilder` entry — cheap, returns fast, lets `Op::Cancel` actually stop the walk.
- Reuse `search.rs::check_cancelled` (promoted to `pub(super)`) rather than duplicating the 5-line helper.
- Add `test_file_search_respects_cancel_token` paralleling the existing `test_grep_files_respects_cancel_token`.

## Relationship to #1790

This **supersedes #1790** (closed as stale post v0.8.41 rebrand). That PR wrapped the walker in `spawn_blocking` with a 30s hard timeout. The gemini reviewer on #1790 correctly flagged that approach as the wrong shape:

> Feedback suggests utilizing the existing CancellationToken from ToolContext to allow for immediate cancellation and avoid orphaned background threads.

This patch follows that guidance:
- No `spawn_blocking` — the walker still runs on the async task, but yields cancel responsiveness via the explicit polling points (same as `grep_files`).
- No orphan threads — `check_cancelled()` returns an error that propagates up cleanly.
- No arbitrary timeout — cancellation is immediate when the token fires.

## Tests

- New: `tools::file_search::tests::test_file_search_respects_cancel_token` — pre-cancelled token returns an error containing "cancelled".
- All 7 `file_search` tests + all 9 `grep_files` tests pass locally.

## Diff stat

```
crates/tui/src/tools/file_search.rs | 33 +++++++++++++++++++++++++++++++--
crates/tui/src/tools/search.rs      |  2 +-
2 files changed, 32 insertions(+), 3 deletions(-)
```