### PR TITLE
feat(execpolicy): add typed permission rules and config schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         if: runner.os != 'Linux'
         with:
-          cache-bin: false
+          cache-bin: "false"
       - name: Run tests
         if: runner.os != 'Linux'
         run: cargo test --workspace --all-features --locked
@@ -90,7 +90,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         if: runner.os != 'Linux'
         with:
-          cache-bin: false
+          cache-bin: "false"
       - name: Build wrapper binaries
         if: runner.os != 'Linux'
         run: cargo build --release --locked -p codewhale-cli -p codewhale-tui
@@ -120,7 +120,7 @@ jobs:
           sudo apt-get install -y libdbus-1-dev pkg-config
       - uses: Swatinem/rust-cache@v2
         with:
-          cache-bin: false
+          cache-bin: "false"
       - name: Build docs
         run: cargo doc --workspace --no-deps
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1397,6 +1397,7 @@ dependencies = [
  "serde_json",
 ]
 
+[[package]]
 name = "deltae"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -897,6 +897,7 @@ version = "0.8.45"
 dependencies = [
  "anyhow",
  "codewhale-protocol",
+ "globset",
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -864,6 +864,7 @@ name = "codewhale-config"
 version = "0.8.45"
 dependencies = [
  "anyhow",
+ "codewhale-execpolicy",
  "codewhale-secrets",
  "dirs",
  "serde",
@@ -1395,7 +1396,6 @@ dependencies = [
  "serde_json",
 ]
 
-[[package]]
 name = "deltae"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/config.example.toml
+++ b/config.example.toml
@@ -141,6 +141,21 @@ sandbox_mode = "workspace-write" # read-only | workspace-write | danger-full-acc
 #   auto_allow = ["cargo check", "npm run"]
 #
 # auto_allow = []
+# auto_deny = ["rm -rf"]
+#
+# Typed persistent permission rules. These are intentionally conservative:
+# shell commands use the same arity-aware matching as auto_allow, and file
+# paths are workspace-relative globs.
+#
+# [[permissions.rules]]
+# tool = "exec_shell"
+# decision = "allow" # "allow", "deny", or "ask"
+# command = "cargo test"
+#
+# [[permissions.rules]]
+# tool = "file_edit"
+# decision = "ask"
+# path = "src/**"
 max_subagents = 10 # optional (1-20)
 
 # Optional sub-agent tuning. max_concurrent overrides top-level max_subagents.

--- a/crates/app-server/src/lib.rs
+++ b/crates/app-server/src/lib.rs
@@ -12,7 +12,6 @@ use axum::{Json, Router};
 use codewhale_agent::ModelRegistry;
 use codewhale_config::{CliRuntimeOverrides, ConfigStore};
 use codewhale_core::Runtime;
-use codewhale_execpolicy::ExecPolicyEngine;
 use codewhale_hooks::{HookDispatcher, JsonlHookSink, StdoutHookSink};
 use codewhale_mcp::McpManager;
 use codewhale_protocol::{
@@ -320,7 +319,7 @@ fn build_state(config_path: Option<PathBuf>, auth_token: Option<String>) -> Resu
         state_store,
         Arc::new(ToolRegistry::default()),
         Arc::new(McpManager::default()),
-        ExecPolicyEngine::new(Vec::new(), Vec::new()),
+        config.exec_policy_engine(),
         hooks,
     );
 

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -8,6 +8,7 @@ description = "Config schema and precedence model for DeepSeek workspace archite
 
 [dependencies]
 anyhow.workspace = true
+codewhale-execpolicy = { path = "../execpolicy", version = "0.8.45" }
 codewhale-secrets = { path = "../secrets", version = "0.8.45" }
 dirs.workspace = true
 serde.workspace = true

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1969,10 +1969,10 @@ mod tests {
         let engine = config.exec_policy_engine();
 
         let allowed = engine
-            .check(deepseek_execpolicy::ExecPolicyContext {
+            .check(codewhale_execpolicy::ExecPolicyContext {
                 command: "git status --porcelain",
                 cwd: ".",
-                ask_for_approval: deepseek_execpolicy::AskForApproval::UnlessTrusted,
+                ask_for_approval: codewhale_execpolicy::AskForApproval::UnlessTrusted,
                 sandbox_mode: Some("workspace-write"),
             })
             .expect("policy decision");
@@ -1980,10 +1980,10 @@ mod tests {
         assert!(!allowed.requires_approval);
 
         let denied = engine
-            .check(deepseek_execpolicy::ExecPolicyContext {
+            .check(codewhale_execpolicy::ExecPolicyContext {
                 command: "git status --dangerous",
                 cwd: ".",
-                ask_for_approval: deepseek_execpolicy::AskForApproval::UnlessTrusted,
+                ask_for_approval: codewhale_execpolicy::AskForApproval::UnlessTrusted,
                 sandbox_mode: Some("workspace-write"),
             })
             .expect("policy decision");

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -6,6 +6,8 @@ use std::path::{Component, Path, PathBuf};
 use std::sync::OnceLock;
 
 use anyhow::{Context, Result, bail};
+use codewhale_execpolicy::{ExecPolicyEngine, Ruleset};
+pub use codewhale_execpolicy::{PermissionDecision, ToolPermissionRule};
 use codewhale_secrets::SecretSource;
 pub use codewhale_secrets::Secrets;
 use serde::{Deserialize, Serialize};
@@ -195,6 +197,19 @@ impl ProvidersToml {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct PermissionsToml {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub rules: Vec<ToolPermissionRule>,
+}
+
+impl PermissionsToml {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.rules.is_empty()
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ConfigToml {
     /// TUI-compatible DeepSeek API key. Kept at the root so both `deepseek`
@@ -216,6 +231,16 @@ pub struct ConfigToml {
     pub telemetry: Option<bool>,
     pub approval_policy: Option<String>,
     pub sandbox_mode: Option<String>,
+    /// Legacy command allow-list. Entries become `exec_shell` allow rules.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub auto_allow: Vec<String>,
+    /// Legacy command deny-list. Entries become `exec_shell` deny rules.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub auto_deny: Vec<String>,
+    /// Typed tool permission rules. First version supports tool name, command
+    /// prefix, and workspace-relative path glob matching.
+    #[serde(default, skip_serializing_if = "PermissionsToml::is_empty")]
+    pub permissions: PermissionsToml,
     #[serde(default)]
     pub providers: ProvidersToml,
     /// Per-domain network policy (#135). When absent, network tools fall back
@@ -373,6 +398,15 @@ impl ConfigToml {
         {
             self.sandbox_mode = Some(mode);
         }
+        if !project.auto_deny.is_empty() {
+            self.auto_deny.extend(project.auto_deny);
+        }
+        let project_rules = project
+            .permissions
+            .rules
+            .into_iter()
+            .filter(|rule| rule.decision != PermissionDecision::Allow);
+        self.permissions.rules.extend(project_rules);
 
         merge_project_provider_config(&mut self.providers.deepseek, &project.providers.deepseek);
         merge_project_provider_config(
@@ -400,6 +434,17 @@ impl ConfigToml {
     }
 
     #[must_use]
+    pub fn permission_ruleset(&self) -> Ruleset {
+        Ruleset::user(self.auto_allow.clone(), self.auto_deny.clone())
+            .with_rules(self.permissions.rules.clone())
+    }
+
+    #[must_use]
+    pub fn exec_policy_engine(&self) -> ExecPolicyEngine {
+        ExecPolicyEngine::with_rulesets(vec![self.permission_ruleset()])
+    }
+
+    #[must_use]
     pub fn get_value(&self, key: &str) -> Option<String> {
         match key {
             "provider" => Some(self.provider.as_str().to_string()),
@@ -414,6 +459,8 @@ impl ConfigToml {
             "telemetry" => self.telemetry.map(|v| v.to_string()),
             "approval_policy" => self.approval_policy.clone(),
             "sandbox_mode" => self.sandbox_mode.clone(),
+            "auto_allow" => serialize_string_list(&self.auto_allow),
+            "auto_deny" => serialize_string_list(&self.auto_deny),
             "providers.deepseek.api_key" => self.providers.deepseek.api_key.clone(),
             "providers.deepseek.base_url" => self.providers.deepseek.base_url.clone(),
             "providers.deepseek.model" => self.providers.deepseek.model.clone(),
@@ -1663,6 +1710,13 @@ fn serialize_http_headers(headers: &BTreeMap<String, String>) -> Option<String> 
     )
 }
 
+fn serialize_string_list(values: &[String]) -> Option<String> {
+    if values.is_empty() {
+        return None;
+    }
+    Some(values.join(","))
+}
+
 fn redact_secret(secret: &str) -> String {
     let chars: Vec<char> = secret.chars().collect();
     if chars.len() <= 16 {
@@ -1864,6 +1918,77 @@ mod tests {
         assert_eq!(policy.default, "allow");
         assert_eq!(policy.proxy, ["github.com", ".githubusercontent.com"]);
         assert!(policy.audit);
+    }
+
+    #[test]
+    fn permissions_toml_deserializes_typed_rules_and_legacy_lists() {
+        let config: ConfigToml = toml::from_str(
+            r#"
+            auto_allow = ["git status"]
+            auto_deny = ["rm -rf"]
+
+            [[permissions.rules]]
+            tool = "exec_shell"
+            decision = "allow"
+            command = "cargo test"
+
+            [[permissions.rules]]
+            tool = "file_edit"
+            decision = "ask"
+            path = "src/**"
+            "#,
+        )
+        .expect("permissions toml");
+
+        assert_eq!(config.auto_allow, ["git status"]);
+        assert_eq!(config.auto_deny, ["rm -rf"]);
+        assert_eq!(config.permissions.rules.len(), 2);
+        assert_eq!(
+            config.permissions.rules[0],
+            ToolPermissionRule::exec_shell(PermissionDecision::Allow, "cargo test")
+        );
+        assert_eq!(
+            config.permissions.rules[1],
+            ToolPermissionRule::file_path("file_edit", PermissionDecision::Ask, "src/**")
+        );
+    }
+
+    #[test]
+    fn config_builds_exec_policy_engine_with_legacy_and_typed_rules() {
+        let config: ConfigToml = toml::from_str(
+            r#"
+            auto_allow = ["git status"]
+
+            [[permissions.rules]]
+            tool = "exec_shell"
+            decision = "deny"
+            command = "git status --dangerous"
+            "#,
+        )
+        .expect("permissions toml");
+        let engine = config.exec_policy_engine();
+
+        let allowed = engine
+            .check(deepseek_execpolicy::ExecPolicyContext {
+                command: "git status --porcelain",
+                cwd: ".",
+                ask_for_approval: deepseek_execpolicy::AskForApproval::UnlessTrusted,
+                sandbox_mode: Some("workspace-write"),
+            })
+            .expect("policy decision");
+        assert!(allowed.allow);
+        assert!(!allowed.requires_approval);
+
+        let denied = engine
+            .check(deepseek_execpolicy::ExecPolicyContext {
+                command: "git status --dangerous",
+                cwd: ".",
+                ask_for_approval: deepseek_execpolicy::AskForApproval::UnlessTrusted,
+                sandbox_mode: Some("workspace-write"),
+            })
+            .expect("policy decision");
+        assert!(!denied.allow);
+        assert_eq!(denied.requirement.phase(), "forbidden");
     }
 
     struct EnvGuard {

--- a/crates/execpolicy/Cargo.toml
+++ b/crates/execpolicy/Cargo.toml
@@ -9,4 +9,5 @@ description = "Execution policy and approval model parity for DeepSeek workspace
 [dependencies]
 anyhow.workspace = true
 codewhale-protocol = { path = "../protocol", version = "0.8.45" }
+globset = "0.4.18"
 serde.workspace = true

--- a/crates/execpolicy/src/lib.rs
+++ b/crates/execpolicy/src/lib.rs
@@ -8,7 +8,8 @@ use codewhale_protocol::{NetworkPolicyAmendment, NetworkPolicyRuleAction};
 use serde::{Deserialize, Serialize};
 
 /// Priority layer for a permission ruleset. Higher ordinal = higher priority.
-/// On conflict, the highest-priority layer's longest matching prefix wins.
+/// Deny rules still win across layers; for non-deny ties the higher-priority
+/// layer wins before pattern specificity is considered.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum RulesetLayer {
@@ -17,12 +18,100 @@ pub enum RulesetLayer {
     User = 2,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PermissionDecision {
+    Allow,
+    Deny,
+    Ask,
+}
+
+impl PermissionDecision {
+    fn precedence(self) -> u8 {
+        match self {
+            Self::Deny => 3,
+            Self::Ask => 2,
+            Self::Allow => 1,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Allow => "allow",
+            Self::Deny => "deny",
+            Self::Ask => "ask",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ToolPermissionRule {
+    pub tool: String,
+    pub decision: PermissionDecision,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+}
+
+impl ToolPermissionRule {
+    #[must_use]
+    pub fn new(tool: impl Into<String>, decision: PermissionDecision) -> Self {
+        Self {
+            tool: tool.into(),
+            decision,
+            command: None,
+            path: None,
+        }
+    }
+
+    #[must_use]
+    pub fn exec_shell(decision: PermissionDecision, command: impl Into<String>) -> Self {
+        Self {
+            tool: "exec_shell".to_string(),
+            decision,
+            command: Some(command.into()),
+            path: None,
+        }
+    }
+
+    #[must_use]
+    pub fn file_path(
+        tool: impl Into<String>,
+        decision: PermissionDecision,
+        path: impl Into<String>,
+    ) -> Self {
+        Self {
+            tool: tool.into(),
+            decision,
+            command: None,
+            path: Some(path.into()),
+        }
+    }
+
+    #[must_use]
+    pub fn pattern_label(&self) -> String {
+        let mut parts = vec![format!("tool '{}'", self.tool)];
+        if let Some(command) = self.command.as_deref() {
+            parts.push(format!("command '{command}'"));
+        }
+        if let Some(path) = self.path.as_deref() {
+            parts.push(format!("path '{path}'"));
+        }
+        parts.join(", ")
+    }
+}
+
 /// A named set of allow/deny prefix rules at a given priority layer.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Ruleset {
     pub layer: RulesetLayer,
+    #[serde(default)]
     pub trusted_prefixes: Vec<String>,
+    #[serde(default)]
     pub denied_prefixes: Vec<String>,
+    #[serde(default)]
+    pub rules: Vec<ToolPermissionRule>,
 }
 
 impl Ruleset {
@@ -31,6 +120,7 @@ impl Ruleset {
             layer: RulesetLayer::BuiltinDefault,
             trusted_prefixes: vec![],
             denied_prefixes: vec![],
+            rules: vec![],
         }
     }
 
@@ -39,6 +129,7 @@ impl Ruleset {
             layer: RulesetLayer::Agent,
             trusted_prefixes: trusted,
             denied_prefixes: denied,
+            rules: vec![],
         }
     }
 
@@ -47,7 +138,14 @@ impl Ruleset {
             layer: RulesetLayer::User,
             trusted_prefixes: trusted,
             denied_prefixes: denied,
+            rules: vec![],
         }
+    }
+
+    #[must_use]
+    pub fn with_rules(mut self, rules: Vec<ToolPermissionRule>) -> Self {
+        self.rules = rules;
+        self
     }
 }
 
@@ -126,6 +224,52 @@ pub struct ExecPolicyContext<'a> {
     pub sandbox_mode: Option<&'a str>,
 }
 
+#[derive(Debug, Clone)]
+pub struct ToolPermissionContext<'a> {
+    pub tool: &'a str,
+    pub command: Option<&'a str>,
+    pub path: Option<&'a str>,
+}
+
+impl<'a> ToolPermissionContext<'a> {
+    #[must_use]
+    pub fn exec_shell(command: &'a str) -> Self {
+        Self {
+            tool: "exec_shell",
+            command: Some(command),
+            path: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MatchedToolPermissionRule {
+    pub layer: RulesetLayer,
+    pub rule: ToolPermissionRule,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ToolPermissionCheck {
+    pub decision: Option<PermissionDecision>,
+    pub matched_rule: Option<MatchedToolPermissionRule>,
+}
+
+impl ToolPermissionCheck {
+    #[must_use]
+    pub fn unmatched() -> Self {
+        Self {
+            decision: None,
+            matched_rule: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct LayeredToolPermissionRule {
+    layer: RulesetLayer,
+    rule: ToolPermissionRule,
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct ExecPolicyEngine {
     /// Layered rulesets (builtin → agent → user). When non-empty, takes precedence
@@ -170,28 +314,40 @@ impl ExecPolicyEngine {
         self.rulesets.sort_by_key(|r| r.layer);
     }
 
-    /// Resolve the effective trusted/denied prefix sets by merging all rulesets.
-    ///
-    /// Collects all prefixes from every layer (builtin → agent → user) into flat
-    /// trusted/denied lists. The `check()` method then applies deny-always-wins
-    /// semantics: any matching deny prefix blocks the command regardless of layer.
-    /// Trusted rules are only consulted after deny checks pass.
-    fn resolve_prefixes(&self) -> (Vec<String>, Vec<String>) {
+    fn layered_permission_rules(&self) -> Vec<LayeredToolPermissionRule> {
+        let mut rules = Vec::new();
         if self.rulesets.is_empty() {
-            return (self.trusted_prefixes.clone(), self.denied_prefixes.clone());
+            rules.extend(legacy_command_rules(
+                RulesetLayer::User,
+                &self.trusted_prefixes,
+                &self.denied_prefixes,
+            ));
+            return rules;
         }
-        // Collect all trusted/denied across all layers, highest-priority last so they
-        // shadow lower-priority entries with the same prefix.
-        let mut trusted: Vec<String> = vec![];
-        let mut denied: Vec<String> = vec![];
-        for rs in &self.rulesets {
-            trusted.extend(rs.trusted_prefixes.iter().cloned());
-            denied.extend(rs.denied_prefixes.iter().cloned());
+
+        for ruleset in &self.rulesets {
+            rules.extend(
+                ruleset
+                    .rules
+                    .iter()
+                    .cloned()
+                    .map(|rule| LayeredToolPermissionRule {
+                        layer: ruleset.layer,
+                        rule,
+                    }),
+            );
+            rules.extend(legacy_command_rules(
+                ruleset.layer,
+                &ruleset.trusted_prefixes,
+                &ruleset.denied_prefixes,
+            ));
         }
-        // Also merge legacy flat lists as user-layer.
-        trusted.extend(self.trusted_prefixes.iter().cloned());
-        denied.extend(self.denied_prefixes.iter().cloned());
-        (trusted, denied)
+        rules.extend(legacy_command_rules(
+            RulesetLayer::User,
+            &self.trusted_prefixes,
+            &self.denied_prefixes,
+        ));
+        rules
     }
 
     pub fn remember_session_approval(&mut self, approval_key: String) {
@@ -202,62 +358,95 @@ impl ExecPolicyEngine {
         self.approved_for_session.contains(approval_key)
     }
 
+    #[must_use]
+    pub fn check_tool_permission(&self, ctx: ToolPermissionContext<'_>) -> ToolPermissionCheck {
+        let mut best: Option<(LayeredToolPermissionRule, usize)> = None;
+
+        for candidate in self.layered_permission_rules() {
+            if !tool_rule_matches(&candidate.rule, &ctx, &self.arity_dict) {
+                continue;
+            }
+            let specificity = rule_specificity(&candidate.rule);
+            let should_replace = best.as_ref().is_none_or(|(current, current_specificity)| {
+                compare_rule_priority(&candidate, specificity, current, *current_specificity)
+            });
+            if should_replace {
+                best = Some((candidate, specificity));
+            }
+        }
+
+        match best {
+            Some((matched, _)) => ToolPermissionCheck {
+                decision: Some(matched.rule.decision),
+                matched_rule: Some(MatchedToolPermissionRule {
+                    layer: matched.layer,
+                    rule: matched.rule,
+                }),
+            },
+            None => ToolPermissionCheck::unmatched(),
+        }
+    }
+
     pub fn check(&self, ctx: ExecPolicyContext<'_>) -> Result<ExecPolicyDecision> {
-        let normalized = normalize_command(ctx.command);
-        let (trusted_prefixes, denied_prefixes) = self.resolve_prefixes();
-        // Deny rules use simple prefix matching (no arity semantics needed).
-        if let Some(rule) = denied_prefixes
-            .iter()
-            .find(|rule| normalized.starts_with(&normalize_command(rule)))
+        let tool_rule = self.check_tool_permission(ToolPermissionContext::exec_shell(ctx.command));
+        if let Some(matched) = tool_rule
+            .matched_rule
+            .as_ref()
+            .filter(|matched| matched.rule.decision == PermissionDecision::Deny)
         {
             return Ok(ExecPolicyDecision {
                 allow: false,
                 requires_approval: false,
-                matched_rule: Some(rule.clone()),
+                matched_rule: Some(matched.rule.pattern_label()),
                 requirement: ExecApprovalRequirement::Forbidden {
-                    reason: format!("Command blocked by denied prefix rule '{rule}'"),
+                    reason: format!(
+                        "Command blocked by {} rule ({})",
+                        matched.rule.decision.as_str(),
+                        matched.rule.pattern_label()
+                    ),
                 },
             });
         }
-
-        // Allow (trusted) rules use arity-aware prefix matching so that
-        // `auto_allow = ["git status"]` matches `git status -s` but NOT
-        // `git push origin main`.
-        let trusted_rule = trusted_prefixes
-            .iter()
-            .find(|rule| self.arity_dict.allow_rule_matches(rule, ctx.command))
-            .cloned();
-        let is_trusted = trusted_rule.is_some();
 
         let requirement = match ctx.ask_for_approval {
             AskForApproval::Never => ExecApprovalRequirement::Skip {
                 bypass_sandbox: false,
                 proposed_execpolicy_amendment: None,
             },
-            AskForApproval::UnlessTrusted if is_trusted => ExecApprovalRequirement::Skip {
-                bypass_sandbox: false,
-                proposed_execpolicy_amendment: None,
+            AskForApproval::Reject { rules, .. } if rules => ExecApprovalRequirement::Forbidden {
+                reason: "Policy is configured to reject rule-exceptions.".to_string(),
             },
+            _ if matches!(tool_rule.decision, Some(PermissionDecision::Ask)) => {
+                ExecApprovalRequirement::NeedsApproval {
+                    reason: tool_rule
+                        .matched_rule
+                        .as_ref()
+                        .map(|matched| {
+                            format!(
+                                "Approval required by ask rule ({})",
+                                matched.rule.pattern_label()
+                            )
+                        })
+                        .unwrap_or_else(|| "Approval required by ask rule.".to_string()),
+                    proposed_execpolicy_amendment: None,
+                    proposed_network_policy_amendments: vec![],
+                }
+            }
+            _ if matches!(tool_rule.decision, Some(PermissionDecision::Allow)) => {
+                ExecApprovalRequirement::Skip {
+                    bypass_sandbox: false,
+                    proposed_execpolicy_amendment: None,
+                }
+            }
             AskForApproval::OnFailure => ExecApprovalRequirement::Skip {
                 bypass_sandbox: false,
                 proposed_execpolicy_amendment: None,
             },
-            AskForApproval::Reject { rules, .. } if rules => ExecApprovalRequirement::Forbidden {
-                reason: "Policy is configured to reject rule-exceptions.".to_string(),
-            },
             _ => ExecApprovalRequirement::NeedsApproval {
-                reason: if is_trusted {
-                    "Approval requested by policy mode.".to_string()
-                } else {
-                    "Unmatched command prefix requires approval.".to_string()
-                },
-                proposed_execpolicy_amendment: if is_trusted {
-                    None
-                } else {
-                    Some(ExecPolicyAmendment {
-                        prefixes: vec![first_token(ctx.command)],
-                    })
-                },
+                reason: "Unmatched command prefix requires approval.".to_string(),
+                proposed_execpolicy_amendment: Some(ExecPolicyAmendment {
+                    prefixes: vec![first_token(ctx.command)],
+                }),
                 proposed_network_policy_amendments: vec![NetworkPolicyAmendment {
                     host: ctx.cwd.to_string(),
                     action: NetworkPolicyRuleAction::Allow,
@@ -274,14 +463,190 @@ impl ExecPolicyEngine {
         Ok(ExecPolicyDecision {
             allow,
             requires_approval,
-            matched_rule: trusted_rule,
+            matched_rule: tool_rule
+                .matched_rule
+                .as_ref()
+                .map(|matched| matched.rule.pattern_label()),
             requirement,
         })
     }
 }
 
+fn legacy_command_rules(
+    layer: RulesetLayer,
+    trusted_prefixes: &[String],
+    denied_prefixes: &[String],
+) -> Vec<LayeredToolPermissionRule> {
+    trusted_prefixes
+        .iter()
+        .map(|command| LayeredToolPermissionRule {
+            layer,
+            rule: ToolPermissionRule::exec_shell(PermissionDecision::Allow, command.clone()),
+        })
+        .chain(
+            denied_prefixes
+                .iter()
+                .map(|command| LayeredToolPermissionRule {
+                    layer,
+                    rule: ToolPermissionRule::exec_shell(PermissionDecision::Deny, command.clone()),
+                }),
+        )
+        .collect()
+}
+
+fn compare_rule_priority(
+    candidate: &LayeredToolPermissionRule,
+    candidate_specificity: usize,
+    current: &LayeredToolPermissionRule,
+    current_specificity: usize,
+) -> bool {
+    (
+        candidate.rule.decision.precedence(),
+        candidate.layer,
+        candidate_specificity,
+    ) > (
+        current.rule.decision.precedence(),
+        current.layer,
+        current_specificity,
+    )
+}
+
+fn tool_rule_matches(
+    rule: &ToolPermissionRule,
+    ctx: &ToolPermissionContext<'_>,
+    arity_dict: &BashArityDict,
+) -> bool {
+    if !rule.tool.eq_ignore_ascii_case(ctx.tool) {
+        return false;
+    }
+    if let Some(command_rule) = rule.command.as_deref() {
+        let Some(command) = ctx.command else {
+            return false;
+        };
+        if !command_rule_matches(rule.decision, command_rule, command, arity_dict) {
+            return false;
+        }
+    }
+    if let Some(path_rule) = rule.path.as_deref() {
+        let Some(path) = ctx.path else {
+            return false;
+        };
+        if !path_pattern_matches(path_rule, path) {
+            return false;
+        }
+    }
+    true
+}
+
+fn command_rule_matches(
+    decision: PermissionDecision,
+    pattern: &str,
+    command: &str,
+    arity_dict: &BashArityDict,
+) -> bool {
+    match decision {
+        PermissionDecision::Deny => {
+            normalize_command(command).starts_with(&normalize_command(pattern))
+        }
+        PermissionDecision::Allow | PermissionDecision::Ask => {
+            arity_dict.allow_rule_matches(pattern, command)
+        }
+    }
+}
+
+fn path_pattern_matches(pattern: &str, path: &str) -> bool {
+    let pattern = normalize_path_pattern(pattern);
+    let path = normalize_path_pattern(path);
+    if let Some(prefix) = pattern.strip_suffix("/**")
+        && (path == prefix || path.starts_with(&format!("{prefix}/")))
+    {
+        return true;
+    }
+    if !pattern.contains('*') && !pattern.contains('?') {
+        return pattern == path;
+    }
+    glob_match(pattern.as_bytes(), path.as_bytes())
+}
+
+fn glob_match(pattern: &[u8], path: &[u8]) -> bool {
+    if pattern.is_empty() {
+        return path.is_empty();
+    }
+
+    match pattern[0] {
+        b'*' if pattern.get(1) == Some(&b'*') => {
+            let rest = &pattern[2..];
+            (0..=path.len()).any(|idx| glob_match(rest, &path[idx..]))
+        }
+        b'*' => {
+            if glob_match(&pattern[1..], path) {
+                return true;
+            }
+            let mut idx = 0;
+            while idx < path.len() && path[idx] != b'/' {
+                idx += 1;
+                if glob_match(&pattern[1..], &path[idx..]) {
+                    return true;
+                }
+            }
+            false
+        }
+        b'?' => !path.is_empty() && path[0] != b'/' && glob_match(&pattern[1..], &path[1..]),
+        literal => !path.is_empty() && path[0] == literal && glob_match(&pattern[1..], &path[1..]),
+    }
+}
+
+fn rule_specificity(rule: &ToolPermissionRule) -> usize {
+    let mut score = rule.tool.len();
+    if let Some(command) = rule.command.as_deref() {
+        score += 1_000 + non_wildcard_len(command);
+    }
+    if let Some(path) = rule.path.as_deref() {
+        score += 1_000 + non_wildcard_len(path);
+    }
+    score
+}
+
+fn non_wildcard_len(value: &str) -> usize {
+    value.chars().filter(|ch| *ch != '*' && *ch != '?').count()
+}
+
 fn normalize_command(value: &str) -> String {
-    value.trim().to_ascii_lowercase()
+    value
+        .trim()
+        .to_ascii_lowercase()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn normalize_path_pattern(value: &str) -> String {
+    let raw = value.trim().replace('\\', "/");
+    let absolute = raw.starts_with('/');
+    let mut segments = Vec::new();
+
+    for segment in raw.split('/') {
+        match segment {
+            "" | "." => {}
+            ".." => {
+                if segments.is_empty() || segments.last() == Some(&"..") {
+                    segments.push(segment);
+                } else {
+                    segments.pop();
+                }
+            }
+            _ => segments.push(segment),
+        }
+    }
+
+    let normalized = segments.join("/");
+    if absolute && normalized.is_empty() {
+        "/".to_string()
+    } else if absolute {
+        format!("/{normalized}")
+    } else {
+        normalized
+    }
 }
 
 fn first_token(command: &str) -> String {
@@ -305,6 +670,10 @@ mod tests {
         }
     }
 
+    fn exec_ctx(command: &str) -> ExecPolicyContext<'_> {
+        ctx(command, AskForApproval::UnlessTrusted)
+    }
+
     #[test]
     fn trusted_prefix_skips_approval_when_policy_is_unless_trusted() {
         let engine = ExecPolicyEngine::new(vec!["git status".to_string()], vec![]);
@@ -315,7 +684,10 @@ mod tests {
 
         assert!(decision.allow);
         assert!(!decision.requires_approval);
-        assert_eq!(decision.matched_rule.as_deref(), Some("git status"));
+        assert_eq!(
+            decision.matched_rule.as_deref(),
+            Some("tool 'exec_shell', command 'git status'")
+        );
         assert!(matches!(
             decision.requirement,
             ExecApprovalRequirement::Skip {
@@ -338,14 +710,31 @@ mod tests {
 
         assert!(!decision.allow);
         assert!(!decision.requires_approval);
-        assert_eq!(decision.matched_rule.as_deref(), Some("git status"));
+        assert_eq!(
+            decision.matched_rule.as_deref(),
+            Some("tool 'exec_shell', command 'git status'")
+        );
         assert!(matches!(
             decision.requirement,
             ExecApprovalRequirement::Forbidden { .. }
         ));
         assert_eq!(
             decision.reason(),
-            "Command blocked by denied prefix rule 'git status'"
+            "Command blocked by deny rule (tool 'exec_shell', command 'git status')"
+        );
+    }
+
+    #[test]
+    fn legacy_auto_allow_prefixes_become_exec_shell_rules() {
+        let engine = ExecPolicyEngine::new(vec!["git status".to_string()], vec![]);
+
+        let decision = engine.check(exec_ctx("git status --porcelain")).unwrap();
+
+        assert!(decision.allow);
+        assert!(!decision.requires_approval);
+        assert_eq!(
+            decision.matched_rule.as_deref(),
+            Some("tool 'exec_shell', command 'git status'")
         );
     }
 
@@ -389,7 +778,10 @@ mod tests {
 
         assert!(decision.allow);
         assert!(decision.requires_approval);
-        assert_eq!(decision.matched_rule.as_deref(), Some("cargo test"));
+        assert_eq!(
+            decision.matched_rule.as_deref(),
+            Some("tool 'exec_shell', command 'cargo test'")
+        );
         match decision.requirement {
             ExecApprovalRequirement::NeedsApproval {
                 proposed_execpolicy_amendment,
@@ -422,5 +814,123 @@ mod tests {
             decision.reason(),
             "Policy is configured to reject rule-exceptions."
         );
+    }
+
+    #[test]
+    fn legacy_auto_allow_uses_bash_arity() {
+        let engine = ExecPolicyEngine::new(vec!["git status".to_string()], vec![]);
+
+        let decision = engine.check(exec_ctx("git push origin main")).unwrap();
+
+        assert!(decision.requires_approval);
+        assert_eq!(decision.matched_rule, None);
+    }
+
+    #[test]
+    fn deny_rule_wins_over_user_allow_rule() {
+        let engine = ExecPolicyEngine::with_rulesets(vec![
+            Ruleset::builtin_default().with_rules(vec![ToolPermissionRule::exec_shell(
+                PermissionDecision::Deny,
+                "cargo",
+            )]),
+            Ruleset::user(vec![], vec![]).with_rules(vec![ToolPermissionRule::exec_shell(
+                PermissionDecision::Allow,
+                "cargo test",
+            )]),
+        ]);
+
+        let decision = engine.check(exec_ctx("cargo test --workspace")).unwrap();
+
+        assert!(!decision.allow);
+        assert_eq!(decision.requirement.phase(), "forbidden");
+        assert_eq!(
+            decision.matched_rule.as_deref(),
+            Some("tool 'exec_shell', command 'cargo'")
+        );
+    }
+
+    #[test]
+    fn ask_rule_wins_over_allow_rule() {
+        let engine =
+            ExecPolicyEngine::with_rulesets(vec![Ruleset::user(vec![], vec![]).with_rules(vec![
+                ToolPermissionRule::exec_shell(PermissionDecision::Allow, "cargo"),
+                ToolPermissionRule::exec_shell(PermissionDecision::Ask, "cargo test"),
+            ])]);
+
+        let decision = engine.check(exec_ctx("cargo test --workspace")).unwrap();
+
+        assert!(decision.allow);
+        assert!(decision.requires_approval);
+        assert_eq!(decision.requirement.phase(), "needs_approval");
+        assert_eq!(
+            decision.matched_rule.as_deref(),
+            Some("tool 'exec_shell', command 'cargo test'")
+        );
+    }
+
+    #[test]
+    fn ask_rule_overrides_on_failure_policy() {
+        let engine =
+            ExecPolicyEngine::with_rulesets(vec![Ruleset::user(vec![], vec![]).with_rules(vec![
+                ToolPermissionRule::exec_shell(PermissionDecision::Ask, "cargo test"),
+            ])]);
+
+        let decision = engine
+            .check(ExecPolicyContext {
+                command: "cargo test --workspace",
+                cwd: ".",
+                ask_for_approval: AskForApproval::OnFailure,
+                sandbox_mode: Some("workspace-write"),
+            })
+            .unwrap();
+
+        assert!(decision.allow);
+        assert!(decision.requires_approval);
+        assert_eq!(decision.requirement.phase(), "needs_approval");
+    }
+
+    #[test]
+    fn path_rules_match_workspace_relative_globs() {
+        let engine =
+            ExecPolicyEngine::with_rulesets(vec![Ruleset::user(vec![], vec![]).with_rules(vec![
+                ToolPermissionRule::file_path("file_edit", PermissionDecision::Allow, "docs/**"),
+            ])]);
+
+        let decision = engine.check_tool_permission(ToolPermissionContext {
+            tool: "file_edit",
+            command: None,
+            path: Some("./docs/guide/setup.md"),
+        });
+
+        assert_eq!(decision.decision, Some(PermissionDecision::Allow));
+    }
+
+    #[test]
+    fn path_star_does_not_cross_directory_separator() {
+        assert!(path_pattern_matches("docs/*.md", "docs/readme.md"));
+        assert!(!path_pattern_matches("docs/*.md", "docs/guides/readme.md"));
+    }
+
+    #[test]
+    fn path_rules_normalize_dot_segments() {
+        assert!(path_pattern_matches("src/**", "src/./lib.rs"));
+        assert!(!path_pattern_matches("src/**", "src/../secret.txt"));
+        assert!(!path_pattern_matches("src/**", "../src/lib.rs"));
+    }
+
+    #[test]
+    fn tool_name_only_rule_matches_unknown_tool() {
+        let engine =
+            ExecPolicyEngine::with_rulesets(vec![Ruleset::user(vec![], vec![]).with_rules(vec![
+                ToolPermissionRule::new("agent_spawn", PermissionDecision::Ask),
+            ])]);
+
+        let decision = engine.check_tool_permission(ToolPermissionContext {
+            tool: "agent_spawn",
+            command: None,
+            path: None,
+        });
+
+        assert_eq!(decision.decision, Some(PermissionDecision::Ask));
     }
 }

--- a/crates/execpolicy/src/lib.rs
+++ b/crates/execpolicy/src/lib.rs
@@ -555,9 +555,7 @@ fn command_rule_matches(
     arity_dict: &BashArityDict,
 ) -> bool {
     match decision {
-        PermissionDecision::Deny => {
-            normalize_command(command).starts_with(&normalize_command(pattern))
-        }
+        PermissionDecision::Deny => command_prefix_matches(pattern, command),
         PermissionDecision::Allow | PermissionDecision::Ask => {
             arity_dict.allow_rule_matches(pattern, command)
         }
@@ -604,6 +602,17 @@ fn normalize_command(value: &str) -> String {
         .split_whitespace()
         .collect::<Vec<_>>()
         .join(" ")
+}
+
+fn command_prefix_matches(pattern: &str, command: &str) -> bool {
+    let pattern = normalize_command(pattern);
+    if pattern.is_empty() {
+        return false;
+    }
+    let command = normalize_command(command);
+    command
+        .strip_prefix(&pattern)
+        .is_some_and(|suffix| suffix.is_empty() || suffix.starts_with(' '))
 }
 
 fn normalize_path_pattern(value: &str) -> String {
@@ -710,6 +719,20 @@ mod tests {
             decision.reason(),
             "Command blocked by deny rule (tool 'exec_shell', command 'git status')"
         );
+    }
+
+    #[test]
+    fn denied_prefix_respects_command_word_boundaries() {
+        let engine = ExecPolicyEngine::new(vec![], vec!["ls".to_string()]);
+
+        let blocked = engine.check(exec_ctx("ls -la")).unwrap();
+        assert!(!blocked.allow);
+        assert_eq!(blocked.requirement.phase(), "forbidden");
+
+        let separate_binary = engine.check(exec_ctx("ls-remote origin")).unwrap();
+        assert!(separate_binary.allow);
+        assert!(separate_binary.requires_approval);
+        assert_eq!(separate_binary.matched_rule, None);
     }
 
     #[test]

--- a/crates/execpolicy/src/lib.rs
+++ b/crates/execpolicy/src/lib.rs
@@ -433,6 +433,15 @@ impl ExecPolicyEngine {
                     proposed_network_policy_amendments: vec![],
                 }
             }
+            AskForApproval::OnRequest
+                if matches!(tool_rule.decision, Some(PermissionDecision::Allow)) =>
+            {
+                ExecApprovalRequirement::NeedsApproval {
+                    reason: "Approval requested by policy mode.".to_string(),
+                    proposed_execpolicy_amendment: None,
+                    proposed_network_policy_amendments: vec![],
+                }
+            }
             _ if matches!(tool_rule.decision, Some(PermissionDecision::Allow)) => {
                 ExecApprovalRequirement::Skip {
                     bypass_sandbox: false,

--- a/crates/execpolicy/src/lib.rs
+++ b/crates/execpolicy/src/lib.rs
@@ -230,6 +230,9 @@ pub struct ToolPermissionContext<'a> {
     pub tool: &'a str,
     pub command: Option<&'a str>,
     pub path: Option<&'a str>,
+    /// Workspace root used to normalize absolute tool paths before matching
+    /// workspace-relative path rules.
+    pub workspace_root: Option<&'a str>,
 }
 
 impl<'a> ToolPermissionContext<'a> {
@@ -239,6 +242,7 @@ impl<'a> ToolPermissionContext<'a> {
             tool: "exec_shell",
             command: Some(command),
             path: None,
+            workspace_root: None,
         }
     }
 }
@@ -541,7 +545,7 @@ fn tool_rule_matches(
         let Some(path) = ctx.path else {
             return false;
         };
-        if !path_pattern_matches(path_rule, path) {
+        if !path_pattern_matches(path_rule, path, ctx.workspace_root) {
             return false;
         }
     }
@@ -562,11 +566,11 @@ fn command_rule_matches(
     }
 }
 
-fn path_pattern_matches(pattern: &str, path: &str) -> bool {
+fn path_pattern_matches(pattern: &str, path: &str, workspace_root: Option<&str>) -> bool {
     let pattern = normalize_path_pattern(pattern);
-    let path = normalize_path_pattern(path);
+    let path = normalize_path_for_matching(path, workspace_root);
     if let Some(prefix) = pattern.strip_suffix("/**")
-        && (path == prefix || path.starts_with(&format!("{prefix}/")))
+        && path.starts_with(&format!("{prefix}/"))
     {
         return true;
     }
@@ -644,6 +648,24 @@ fn normalize_path_pattern(value: &str) -> String {
     } else {
         normalized
     }
+}
+
+fn normalize_path_for_matching(path: &str, workspace_root: Option<&str>) -> String {
+    let path = normalize_path_pattern(path);
+    let Some(workspace_root) = workspace_root else {
+        return path;
+    };
+    let workspace_root = normalize_path_pattern(workspace_root);
+    if workspace_root.is_empty() {
+        return path;
+    }
+    if path == workspace_root {
+        return String::new();
+    }
+    let workspace_prefix = format!("{workspace_root}/");
+    path.strip_prefix(&workspace_prefix)
+        .unwrap_or(&path)
+        .to_string()
 }
 
 fn first_token(command: &str) -> String {
@@ -911,6 +933,7 @@ mod tests {
             tool: "file_edit",
             command: None,
             path: Some("./docs/guide/setup.md"),
+            workspace_root: None,
         });
 
         assert_eq!(decision.decision, Some(PermissionDecision::Allow));
@@ -918,17 +941,51 @@ mod tests {
 
     #[test]
     fn path_star_does_not_cross_directory_separator() {
-        assert!(path_pattern_matches("docs/*.md", "docs/readme.md"));
-        assert!(!path_pattern_matches("docs/*.md", "docs/guides/readme.md"));
+        assert!(path_pattern_matches("docs/*.md", "docs/readme.md", None));
+        assert!(!path_pattern_matches(
+            "docs/*.md",
+            "docs/guides/readme.md",
+            None
+        ));
+    }
+
+    #[test]
+    fn path_double_star_requires_child_path() {
+        assert!(path_pattern_matches("docs/**", "docs/readme.md", None));
+        assert!(!path_pattern_matches("docs/**", "docs", None));
     }
 
     #[test]
     fn path_rules_normalize_dot_segments() {
-        assert!(path_pattern_matches("src/**", "src/./lib.rs"));
-        assert!(!path_pattern_matches("src/**", "src/../secret.txt"));
-        assert!(!path_pattern_matches("src/**", "../src/lib.rs"));
-        assert!(path_pattern_matches("/foo", "/../foo"));
-        assert!(!path_pattern_matches("/src/**", "/src/../secret.txt"));
+        assert!(path_pattern_matches("src/**", "src/./lib.rs", None));
+        assert!(!path_pattern_matches("src/**", "src/../secret.txt", None));
+        assert!(!path_pattern_matches("src/**", "../src/lib.rs", None));
+        assert!(path_pattern_matches("/foo", "/../foo", None));
+        assert!(!path_pattern_matches("/src/**", "/src/../secret.txt", None));
+    }
+
+    #[test]
+    fn path_rules_match_absolute_paths_inside_workspace_root() {
+        let engine =
+            ExecPolicyEngine::with_rulesets(vec![Ruleset::user(vec![], vec![]).with_rules(vec![
+                ToolPermissionRule::file_path("file_edit", PermissionDecision::Deny, "secret.toml"),
+            ])]);
+
+        let denied = engine.check_tool_permission(ToolPermissionContext {
+            tool: "file_edit",
+            command: None,
+            path: Some("/workspace/project/secret.toml"),
+            workspace_root: Some("/workspace/project"),
+        });
+        assert_eq!(denied.decision, Some(PermissionDecision::Deny));
+
+        let outside_workspace = engine.check_tool_permission(ToolPermissionContext {
+            tool: "file_edit",
+            command: None,
+            path: Some("/workspace/other/secret.toml"),
+            workspace_root: Some("/workspace/project"),
+        });
+        assert_eq!(outside_workspace.decision, None);
     }
 
     #[test]
@@ -942,6 +999,7 @@ mod tests {
             tool: "agent_spawn",
             command: None,
             path: None,
+            workspace_root: None,
         });
 
         assert_eq!(decision.decision, Some(PermissionDecision::Ask));

--- a/crates/execpolicy/src/lib.rs
+++ b/crates/execpolicy/src/lib.rs
@@ -5,6 +5,7 @@ use std::collections::HashSet;
 use anyhow::Result;
 use bash_arity::BashArityDict;
 use codewhale_protocol::{NetworkPolicyAmendment, NetworkPolicyRuleAction};
+use globset::GlobBuilder;
 use serde::{Deserialize, Serialize};
 
 /// Priority layer for a permission ruleset. Higher ordinal = higher priority.
@@ -565,35 +566,11 @@ fn path_pattern_matches(pattern: &str, path: &str) -> bool {
     if !pattern.contains('*') && !pattern.contains('?') {
         return pattern == path;
     }
-    glob_match(pattern.as_bytes(), path.as_bytes())
-}
-
-fn glob_match(pattern: &[u8], path: &[u8]) -> bool {
-    if pattern.is_empty() {
-        return path.is_empty();
-    }
-
-    match pattern[0] {
-        b'*' if pattern.get(1) == Some(&b'*') => {
-            let rest = &pattern[2..];
-            (0..=path.len()).any(|idx| glob_match(rest, &path[idx..]))
-        }
-        b'*' => {
-            if glob_match(&pattern[1..], path) {
-                return true;
-            }
-            let mut idx = 0;
-            while idx < path.len() && path[idx] != b'/' {
-                idx += 1;
-                if glob_match(&pattern[1..], &path[idx..]) {
-                    return true;
-                }
-            }
-            false
-        }
-        b'?' => !path.is_empty() && path[0] != b'/' && glob_match(&pattern[1..], &path[1..]),
-        literal => !path.is_empty() && path[0] == literal && glob_match(&pattern[1..], &path[1..]),
-    }
+    GlobBuilder::new(&pattern)
+        .literal_separator(true)
+        .build()
+        .map(|glob| glob.compile_matcher().is_match(path))
+        .unwrap_or(false)
 }
 
 fn rule_specificity(rule: &ToolPermissionRule) -> usize {
@@ -629,7 +606,9 @@ fn normalize_path_pattern(value: &str) -> String {
         match segment {
             "" | "." => {}
             ".." => {
-                if segments.is_empty() || segments.last() == Some(&"..") {
+                if absolute {
+                    segments.pop();
+                } else if segments.is_empty() || segments.last() == Some(&"..") {
                     segments.push(segment);
                 } else {
                     segments.pop();
@@ -916,6 +895,8 @@ mod tests {
         assert!(path_pattern_matches("src/**", "src/./lib.rs"));
         assert!(!path_pattern_matches("src/**", "src/../secret.txt"));
         assert!(!path_pattern_matches("src/**", "../src/lib.rs"));
+        assert!(path_pattern_matches("/foo", "/../foo"));
+        assert!(!path_pattern_matches("/src/**", "/src/../secret.txt"));
     }
 
     #[test]

--- a/crates/tui/src/composer_history.rs
+++ b/crates/tui/src/composer_history.rs
@@ -33,6 +33,9 @@ use std::time::Duration;
 pub const MAX_HISTORY_ENTRIES: usize = 1000;
 
 const HISTORY_FILE_NAME: &str = "composer_history.txt";
+// Prevent a steady stream of test/UI writes from delaying persistence
+// indefinitely while waiting for a 2ms idle window.
+const WRITER_BATCH_LIMIT: usize = 128;
 
 fn default_history_path() -> Option<PathBuf> {
     dirs::home_dir().map(|home| home.join(".deepseek").join(HISTORY_FILE_NAME))
@@ -114,7 +117,7 @@ fn writer_sender() -> &'static Sender<(PathBuf, String)> {
 fn append_history_batch(rx: &Receiver<(PathBuf, String)>, first: (PathBuf, String)) {
     let mut pending = vec![first];
 
-    loop {
+    while pending.len() < WRITER_BATCH_LIMIT {
         match rx.recv_timeout(Duration::from_millis(2)) {
             Ok(next) => pending.push(next),
             Err(RecvTimeoutError::Timeout) => break,

--- a/crates/tui/src/composer_history.rs
+++ b/crates/tui/src/composer_history.rs
@@ -37,6 +37,12 @@ const HISTORY_FILE_NAME: &str = "composer_history.txt";
 // indefinitely while waiting for a 2ms idle window.
 const WRITER_BATCH_LIMIT: usize = 128;
 
+enum HistoryWrite {
+    Append(PathBuf, String),
+    #[cfg(test)]
+    Flush(Sender<()>),
+}
+
 fn default_history_path() -> Option<PathBuf> {
     dirs::home_dir().map(|home| home.join(".deepseek").join(HISTORY_FILE_NAME))
 }
@@ -83,7 +89,7 @@ pub fn append_history(entry: &str) {
 fn append_history_dispatched(path: &Path, entry: &str) {
     let entry = entry.to_string();
     if writer_sender()
-        .send((path.to_path_buf(), entry.clone()))
+        .send(HistoryWrite::Append(path.to_path_buf(), entry.clone()))
         .is_err()
     {
         append_history_to(path, &entry);
@@ -93,10 +99,10 @@ fn append_history_dispatched(path: &Path, entry: &str) {
 /// Lazy singleton sender for the dedicated composer-history writer
 /// thread. Initialised on first use; the thread runs for the lifetime
 /// of the process and drains queued writes in arrival order.
-fn writer_sender() -> &'static Sender<(PathBuf, String)> {
-    static SENDER: OnceLock<Sender<(PathBuf, String)>> = OnceLock::new();
+fn writer_sender() -> &'static Sender<HistoryWrite> {
+    static SENDER: OnceLock<Sender<HistoryWrite>> = OnceLock::new();
     SENDER.get_or_init(|| {
-        let (tx, rx) = channel::<(PathBuf, String)>();
+        let (tx, rx) = channel::<HistoryWrite>();
         let spawn_result = std::thread::Builder::new()
             .name("composer-history-writer".to_string())
             .spawn(move || {
@@ -104,7 +110,15 @@ fn writer_sender() -> &'static Sender<(PathBuf, String)> {
                 // only happens at process shutdown because the singleton
                 // sender lives in a static for the lifetime of the process.
                 while let Ok(first) = rx.recv() {
-                    append_history_batch(&rx, first);
+                    match first {
+                        HistoryWrite::Append(path, entry) => {
+                            append_history_batch(&rx, (path, entry));
+                        }
+                        #[cfg(test)]
+                        HistoryWrite::Flush(done) => {
+                            let _ = done.send(());
+                        }
+                    }
                 }
             });
         if let Err(err) = spawn_result {
@@ -114,17 +128,27 @@ fn writer_sender() -> &'static Sender<(PathBuf, String)> {
     })
 }
 
-fn append_history_batch(rx: &Receiver<(PathBuf, String)>, first: (PathBuf, String)) {
+fn append_history_batch(rx: &Receiver<HistoryWrite>, first: (PathBuf, String)) {
     let mut pending = vec![first];
 
     while pending.len() < WRITER_BATCH_LIMIT {
         match rx.recv_timeout(Duration::from_millis(2)) {
-            Ok(next) => pending.push(next),
+            Ok(HistoryWrite::Append(path, entry)) => pending.push((path, entry)),
+            #[cfg(test)]
+            Ok(HistoryWrite::Flush(done)) => {
+                persist_history_batch(pending);
+                let _ = done.send(());
+                return;
+            }
             Err(RecvTimeoutError::Timeout) => break,
             Err(RecvTimeoutError::Disconnected) => break,
         }
     }
 
+    persist_history_batch(pending);
+}
+
+fn persist_history_batch(pending: Vec<(PathBuf, String)>) {
     for (path, entries) in group_history_writes_by_path(pending) {
         append_history_entries_to(&path, entries.iter().map(String::as_str));
     }
@@ -149,6 +173,12 @@ fn group_history_writes_by_path(writes: Vec<(PathBuf, String)>) -> Vec<(PathBuf,
 
 fn append_history_to(path: &Path, entry: &str) {
     append_history_entries_to(path, std::iter::once(entry));
+}
+
+#[cfg(test)]
+fn flush_history_writer_for_test(timeout: Duration) -> bool {
+    let (tx, rx) = channel();
+    writer_sender().send(HistoryWrite::Flush(tx)).is_ok() && rx.recv_timeout(timeout).is_ok()
 }
 
 fn append_history_entries_to<'a>(
@@ -314,26 +344,23 @@ mod tests {
              (likely re-introduced #1927: caller blocked on disk write)"
         );
 
-        // Give the writer thread time to drain the queue, then verify the
-        // new entries landed.
-        // Use 10s on Windows (slow CI I/O) vs 5s on other platforms.
-        let deadline = Instant::now() + Duration::from_secs(if cfg!(windows) { 10 } else { 5 });
-        loop {
-            let loaded = load_history_from(&path);
-            if loaded.iter().any(|line| line == "new entry 49") {
-                // Last dispatched entry observed; queue is drained.
-                assert!(loaded.iter().any(|line| line == "new entry 0"));
-                break;
-            }
-            if Instant::now() >= deadline {
-                panic!(
-                    "writer thread did not persist the dispatched entries; \
-                     loaded {} entries, last = {:?}",
-                    loaded.len(),
-                    loaded.last()
-                );
-            }
-            std::thread::sleep(Duration::from_millis(25));
-        }
+        // Wait for a FIFO flush marker instead of polling wall-clock time.
+        // Other tests may also enqueue history writes through the process-wide
+        // singleton, so a sleep-based assertion can observe only the seed file
+        // even though this test's writes are merely queued behind earlier work.
+        assert!(
+            flush_history_writer_for_test(Duration::from_secs(if cfg!(windows) { 30 } else { 15 })),
+            "writer thread did not acknowledge the dispatched entries"
+        );
+
+        let loaded = load_history_from(&path);
+        assert!(
+            loaded.iter().any(|line| line == "new entry 49"),
+            "writer thread did not persist the dispatched entries; \
+             loaded {} entries, last = {:?}",
+            loaded.len(),
+            loaded.last()
+        );
+        assert!(loaded.iter().any(|line| line == "new entry 0"));
     }
 }

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -2895,10 +2895,7 @@ fn auth_mode_uses_kimi_oauth(mode: &str) -> bool {
 }
 
 fn normalize_auth_mode(mode: &str) -> String {
-    mode.trim()
-        .to_ascii_lowercase()
-        .replace('-', "_")
-        .replace(' ', "_")
+    mode.trim().to_ascii_lowercase().replace(['-', ' '], "_")
 }
 
 fn base_url_uses_local_host(base_url: &str) -> bool {

--- a/crates/tui/src/tools/pandoc.rs
+++ b/crates/tui/src/tools/pandoc.rs
@@ -144,7 +144,9 @@ impl ToolSpec for PandocConvertTool {
         // gated on resolve_pandoc(), but a concurrent uninstall between
         // catalog build and the model's call should produce a clear
         // error rather than the cryptic "program not found" from raw
-        // Command::spawn.
+        // Command::spawn. Input validation above intentionally runs first
+        // so tests and users get deterministic schema/actionable errors
+        // even on machines without pandoc installed.
         let pandoc = crate::dependencies::resolve_pandoc().ok_or_else(|| {
             ToolError::execution_failed(
                 "pandoc_convert: pandoc binary not found on PATH. \

--- a/crates/tui/src/tui/sidebar.rs
+++ b/crates/tui/src/tui/sidebar.rs
@@ -1878,8 +1878,8 @@ mod tests {
         ACTIVE_TOOL_COMPLETED_ROW_TTL, ACTIVE_TOOL_STALE_RUNNING_ROW_TTL, AutoSidebarPanel,
         AutoSidebarState, SidebarAgentRow, SidebarHoverSection, SidebarHoverState,
         SidebarSubagentSummary, SidebarWorkChecklistItem, SidebarWorkStrategyStep,
-        SidebarWorkSummary, auto_sidebar_panels, subagent_panel_lines, task_panel_lines,
-        work_panel_empty_hint, work_panel_lines,
+        SidebarWorkSummary, auto_sidebar_panels, duration_ms, subagent_panel_lines,
+        task_panel_lines, work_panel_empty_hint, work_panel_lines,
     };
     use crate::config::Config;
     use crate::palette::PaletteMode;
@@ -2222,6 +2222,8 @@ mod tests {
     fn tasks_panel_collapses_stale_running_tool_rows() {
         let mut app = create_test_app();
         let mut active = ActiveCell::new();
+        let stale_duration_ms =
+            duration_ms(ACTIVE_TOOL_STALE_RUNNING_ROW_TTL).saturating_add(1_000);
         for (idx, command) in ["long one", "long two"].into_iter().enumerate() {
             active.push_tool(
                 format!("shell-{idx}"),
@@ -2230,7 +2232,7 @@ mod tests {
                     status: ToolStatus::Running,
                     output: None,
                     started_at: None,
-                    duration_ms: Some(ACTIVE_TOOL_STALE_RUNNING_ROW_TTL.as_millis() as u64 + 1),
+                    duration_ms: Some(stale_duration_ms),
                     source: ExecSource::Assistant,
                     interaction: None,
                     output_summary: None,

--- a/crates/tui/src/vision/tools.rs
+++ b/crates/tui/src/vision/tools.rs
@@ -270,13 +270,13 @@ mod tests {
         let tmp = tempdir().expect("tempdir");
         let ctx = ToolContext::new(tmp.path().to_path_buf());
         let tool = ImageAnalyzeTool::new(fake_config());
-        let outside_workspace = if cfg!(windows) {
+        let absolute_path = if cfg!(windows) {
             r"C:\Windows\System32\drivers\etc\hosts"
         } else {
             "/etc/hosts"
         };
         let err = tool
-            .execute(json!({"image_path": outside_workspace}), &ctx)
+            .execute(json!({"image_path": absolute_path}), &ctx)
             .await
             .expect_err("absolute path must reject");
         assert!(


### PR DESCRIPTION
Rebased replacement for #1189 on current `main` after the v0.8.41 CodeWhale rebrand.

## Summary
- Add typed persistent permission rules with `allow`, `deny`, and `ask` decisions.
- Support `exec_shell` command-prefix matching and workspace-relative path glob matching.
- Preserve compatibility with existing `auto_allow` / `auto_deny` config lists.
- Reuse the existing execpolicy ruleset layering and bash arity matching.
- Harden path matching with normalized paths and `globset` for glob evaluation.

## Validation
- `cargo fmt --all`
- `cargo test -p codewhale-execpolicy -p codewhale-config -p codewhale-app-server -p codewhale-cli --all-features`
- `cargo test -p codewhale-tui pandoc_convert_rejects_inline_request_for_binary_format --all-features`
- `cargo test -p codewhale-tui execute_rejects_absolute_path --all-features`
- `cargo test -p codewhale-tui tasks_panel_collapses_stale_running_tool_rows --all-features`
- `cargo clippy -p codewhale-execpolicy -p codewhale-config -p codewhale-app-server -p codewhale-cli --all-targets --all-features -- -D warnings`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces typed persistent permission rules (`allow`, `deny`, `ask`) to the execpolicy crate, wires them through the config schema, and replaces the app-server's placeholder `ExecPolicyEngine::new([], [])` with a properly configured instance driven by user config.

- Adds `ToolPermissionRule` / `PermissionDecision` to `crates/execpolicy`, with `check_tool_permission()` and a rewritten `check()` that unifies legacy prefix lists and typed rules under a single priority model (deny beats ask beats allow, higher layer beats lower, longer non-wildcard length breaks ties).
- Adds `[[permissions.rules]]` TOML schema to `crates/config`, preserving backward compatibility with `auto_allow`/`auto_deny`; project-level `Allow` rules are intentionally filtered out during `merge_from_project()` to prevent untrusted repos from granting themselves permissions.
- Fixes a pre-existing timing-dependent test in `composer_history` by introducing a `Flush` sync message and a `WRITER_BATCH_LIMIT` cap on the writer thread's batch loop.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with one behavioral gap in check() that needs a decision: Ask rules don't override Never mode, inconsistently with how they override OnFailure.

The new check() match statement places AskForApproval::Never before the Ask-rule wildcard arm, so a typed ask rule is silently skipped whenever the approval mode is Never. The existing test suite demonstrates this inconsistency — ask_rule_overrides_on_failure_policy verifies that Ask beats OnFailure, but no test covers Never + Ask. Either the ordering is intentional (Never is an absolute bypass) and should be documented, or it is an oversight and the arm ordering needs adjustment before typed Ask rules can be relied on for mandatory-approval workflows.

crates/execpolicy/src/lib.rs — the check() match ordering around AskForApproval::Never and the Ask-rule wildcard arm.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/execpolicy/src/lib.rs | Core of the PR — adds ToolPermissionRule, PermissionDecision, check_tool_permission(), and rewires check() through the new rule system; contains the AskForApproval::Never / Ask-rule precedence inconsistency. |
| crates/config/src/lib.rs | Adds PermissionsToml, auto_allow/auto_deny fields to ConfigToml, merge_from_project filtering (Allow rules excluded intentionally), and exec_policy_engine() factory; no new issues found. |
| crates/tui/src/composer_history.rs | Adds WRITER_BATCH_LIMIT cap and a test-only Flush message to eliminate timing-dependent polling in tests; logic is correct. |
| crates/app-server/src/lib.rs | Replaces ExecPolicyEngine::new([], []) placeholder with config.exec_policy_engine(), wiring the new typed rules into the server startup path. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[check ctx: ExecPolicyContext] --> B[check_tool_permission\nexec_shell context]
    B --> C{Matched rule\ndecision == Deny?}
    C -->|Yes| D[Return Forbidden]
    C -->|No| E{ask_for_approval}
    E -->|Never| F[Skip — no approval]
    E -->|Reject rules=true| G[Forbidden]
    E -->|Any + Ask rule| H[NeedsApproval\nask rule fires]
    E -->|OnRequest + Allow| I[NeedsApproval\npolicy mode]
    E -->|Any + Allow| F
    E -->|OnFailure| F
    E -->|Fallthrough| J[NeedsApproval\npropose amendment]

    subgraph check_tool_permission
        K[layered_permission_rules\nBuiltin to Agent to User] --> L[For each candidate\ntool_rule_matches?]
        L --> M[compare_rule_priority\ndecision precedence\nlayer\nspecificity]
        M --> N[Return highest-priority\nmatched rule]
    end
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fexecpolicy-typed-rules%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fexecpolicy-typed-rules%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Fexecpolicy%2Fsrc%2Flib.rs%3A417-424%0A**%60AskForApproval%3A%3ANever%60%20silently%20bypasses%20%60Ask%60%20rules**%0A%0A%60AskForApproval%3A%3ANever%60%20is%20the%20first%20arm%20and%20short-circuits%20before%20the%20%60_%20if%20Ask%60%20wildcard%20arm%20ever%20executes.%20A%20user%20who%20configures%20%60%7B%20tool%20%3D%20%22exec_shell%22%2C%20decision%20%3D%20%22ask%22%2C%20command%20%3D%20%22rm%20-rf%22%20%7D%60%20expecting%20a%20mandatory%20prompt%20will%20get%20no%20prompt%20at%20all%20when%20the%20approval%20mode%20is%20%60Never%60%20%E2%80%94%20the%20rule%20is%20silently%20ignored.%20This%20is%20inconsistent%20with%20%60OnFailure%60%2C%20which%20the%20new%20test%20%60ask_rule_overrides_on_failure_policy%60%20explicitly%20verifies%20IS%20overridden%20by%20%60Ask%60%20rules%20%28because%20%60OnFailure%60%20falls%20after%20the%20%60_%20if%20Ask%60%20wildcard%29.%20Moving%20the%20%60Never%60%20arm%20below%20the%20%60_%20if%20Ask%60%20guard%20%E2%80%94%20or%20adding%20a%20separate%20%60Never%20if%20!matches!%28Ask%29%60%20arm%20%E2%80%94%20would%20make%20%60Ask%60%20rules%20consistently%20override%20all%20non-%60Reject%60%20policy%20modes.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Fexecpolicy%2Fsrc%2Flib.rs%3A417-424%0A**%60AskForApproval%3A%3ANever%60%20silently%20bypasses%20%60Ask%60%20rules**%0A%0A%60AskForApproval%3A%3ANever%60%20is%20the%20first%20arm%20and%20short-circuits%20before%20the%20%60_%20if%20Ask%60%20wildcard%20arm%20ever%20executes.%20A%20user%20who%20configures%20%60%7B%20tool%20%3D%20%22exec_shell%22%2C%20decision%20%3D%20%22ask%22%2C%20command%20%3D%20%22rm%20-rf%22%20%7D%60%20expecting%20a%20mandatory%20prompt%20will%20get%20no%20prompt%20at%20all%20when%20the%20approval%20mode%20is%20%60Never%60%20%E2%80%94%20the%20rule%20is%20silently%20ignored.%20This%20is%20inconsistent%20with%20%60OnFailure%60%2C%20which%20the%20new%20test%20%60ask_rule_overrides_on_failure_policy%60%20explicitly%20verifies%20IS%20overridden%20by%20%60Ask%60%20rules%20%28because%20%60OnFailure%60%20falls%20after%20the%20%60_%20if%20Ask%60%20wildcard%29.%20Moving%20the%20%60Never%60%20arm%20below%20the%20%60_%20if%20Ask%60%20guard%20%E2%80%94%20or%20adding%20a%20separate%20%60Never%20if%20!matches!%28Ask%29%60%20arm%20%E2%80%94%20would%20make%20%60Ask%60%20rules%20consistently%20override%20all%20non-%60Reject%60%20policy%20modes.%0A%0A&repo=hmbown%2Fcodewhale&pr=2046&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Fexecpolicy%2Fsrc%2Flib.rs%3A417-424%0A**%60AskForApproval%3A%3ANever%60%20silently%20bypasses%20%60Ask%60%20rules**%0A%0A%60AskForApproval%3A%3ANever%60%20is%20the%20first%20arm%20and%20short-circuits%20before%20the%20%60_%20if%20Ask%60%20wildcard%20arm%20ever%20executes.%20A%20user%20who%20configures%20%60%7B%20tool%20%3D%20%22exec_shell%22%2C%20decision%20%3D%20%22ask%22%2C%20command%20%3D%20%22rm%20-rf%22%20%7D%60%20expecting%20a%20mandatory%20prompt%20will%20get%20no%20prompt%20at%20all%20when%20the%20approval%20mode%20is%20%60Never%60%20%E2%80%94%20the%20rule%20is%20silently%20ignored.%20This%20is%20inconsistent%20with%20%60OnFailure%60%2C%20which%20the%20new%20test%20%60ask_rule_overrides_on_failure_policy%60%20explicitly%20verifies%20IS%20overridden%20by%20%60Ask%60%20rules%20%28because%20%60OnFailure%60%20falls%20after%20the%20%60_%20if%20Ask%60%20wildcard%29.%20Moving%20the%20%60Never%60%20arm%20below%20the%20%60_%20if%20Ask%60%20guard%20%E2%80%94%20or%20adding%20a%20separate%20%60Never%20if%20!matches!%28Ask%29%60%20arm%20%E2%80%94%20would%20make%20%60Ask%60%20rules%20consistently%20override%20all%20non-%60Reject%60%20policy%20modes.%0A%0A&pr=2046&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["fix(tui): satisfy auth mode clippy lint"](https://github.com/hmbown/codewhale/commit/3d2587576facb46797777029d696c7112c486ed3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33797902)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->