### PR TITLE
fix(engine): use user role for sub-agent completion runtime message

### DIFF
--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -2021,8 +2021,16 @@ impl Engine {
 }
 
 fn subagent_completion_runtime_message(payload: &str) -> Message {
+    // Role is "user", not "system": some OpenAI-compatible backends apply a
+    // strict chat template (e.g. vLLM serving Qwen3) that requires any system
+    // message to be messages[0]. A system message appended mid-conversation
+    // makes the template raise "System message must be at the beginning",
+    // which surfaces as a 400 BadRequest and breaks the whole sub-agent
+    // hand-off in the parent turn. The `visibility="internal"` tag already
+    // tells the model this is a runtime event rather than user input, so the
+    // role carries no semantic weight here — only template-compatibility cost.
     Message {
-        role: "system".to_string(),
+        role: "user".to_string(),
         content: vec![ContentBlock::Text {
             text: format!(
                 "<codewhale:runtime_event kind=\"subagent_completion\" visibility=\"internal\">\n\
@@ -2122,12 +2130,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn subagent_completion_handoff_is_internal_system_message() {
+    fn subagent_completion_handoff_is_internal_user_message() {
         let message = subagent_completion_runtime_message(
             "Build passed\n<codewhale:subagent.done>{\"agent_id\":\"agent_a\"}</codewhale:subagent.done>",
         );
 
-        assert_eq!(message.role, "system");
+        // Must be "user", not "system": a system message appended mid-stream
+        // trips strict chat templates (vLLM/Qwen3) into a 400 BadRequest
+        // ("System message must be at the beginning"). The internal-event
+        // framing lives in the text + visibility tag, not the role.
+        assert_eq!(message.role, "user");
         let text = match &message.content[0] {
             ContentBlock::Text { text, .. } => text,
             other => panic!("expected text block, got {other:?}"),


### PR DESCRIPTION
## Problem

`subagent_completion_runtime_message` builds the sub-agent completion hand-off that gets appended into the **parent** turn with `role: "system"`. That message is injected mid-conversation (not at the front).

Some OpenAI-compatible backends apply a strict chat template that requires any `system` message to be `messages[0]`. The clearest case is **vLLM serving Qwen3** — its chat template raises:

```
System message must be at the beginning
```

vLLM returns this as a **400 BadRequest**, which fails the request that carries the sub-agent result back to the parent. The whole sub-agent hand-off breaks on these backends.

## Fix

Switch the role of this single internal runtime message from `system` to `user`.

The "this is an internal runtime event, not user input" framing is already carried by the `visibility="internal"` tag and the surrounding instruction text, so the role itself carries no semantic weight to the model here — it only determines chat-template placement. Using `user` keeps the message valid mid-conversation on strict templates while reading identically to lenient ones (Anthropic / OpenAI proper).

## Scope

- One-line behavior change in `subagent_completion_runtime_message`, plus a rationale comment.
- Updates the colocated unit test (`subagent_completion_handoff_is_internal_user_message`) to pin the new role.
- No trust-boundary surface touched (no auth / sandbox / publishing / prompts).

## Test

```
cargo test -p codewhale-tui --bins subagent_completion_handoff
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)