### PR TITLE
Add MockLlmClient factory steps

### DIFF
--- a/crates/tui/src/llm_client/mock.rs
+++ b/crates/tui/src/llm_client/mock.rs
@@ -63,6 +63,19 @@ use super::{LlmClient, StreamEventBox};
 /// the mock does not require `MessageStart` to be present.
 pub type CannedTurn = Vec<StreamEvent>;
 
+/// One queued mock response step.
+pub enum FauxStep {
+    Canned(CannedTurn),
+    /// Build the mock response from the live outgoing request.
+    ///
+    /// Use this for request-shape assertions that must happen at the trait
+    /// boundary. In particular, DeepSeek V4 thinking-mode tool calls require
+    /// every follow-up request to replay the assistant turn's
+    /// `reasoning_content`; dropping it caused HTTP 400 regressions in
+    /// v0.4.9-v0.5.1.
+    Factory(Box<dyn Fn(&MessageRequest) -> CannedTurn + Send + Sync>),
+}
+
 /// A queue-driven mock LLM client.
 ///
 /// The mock holds a FIFO queue of canned response turns. Each call to
@@ -75,7 +88,7 @@ pub type CannedTurn = Vec<StreamEvent>;
 /// can assert on the outgoing payload (e.g. that prior `reasoning_content` is
 /// preserved across turns).
 pub struct MockLlmClient {
-    canned: Mutex<VecDeque<CannedTurn>>,
+    canned: Mutex<VecDeque<FauxStep>>,
     captured_requests: Mutex<Vec<MessageRequest>>,
     calls: AtomicUsize,
     provider_name: &'static str,
@@ -90,8 +103,14 @@ impl MockLlmClient {
     /// Construct a mock that will replay the given canned turns in order.
     #[must_use]
     pub fn new(canned: Vec<CannedTurn>) -> Self {
+        Self::from_steps(canned.into_iter().map(FauxStep::Canned).collect())
+    }
+
+    /// Construct a mock that will replay or evaluate the given steps in order.
+    #[must_use]
+    pub fn from_steps(steps: Vec<FauxStep>) -> Self {
         Self {
-            canned: Mutex::new(canned.into()),
+            canned: Mutex::new(steps.into()),
             captured_requests: Mutex::new(Vec::new()),
             calls: AtomicUsize::new(0),
             provider_name: "mock",
@@ -119,7 +138,15 @@ impl MockLlmClient {
         self.canned
             .lock()
             .expect("MockLlmClient.canned mutex poisoned")
-            .push_back(turn);
+            .push_back(FauxStep::Canned(turn));
+    }
+
+    /// Push a factory step onto the back of the queue.
+    pub fn push_factory(&self, factory: Box<dyn Fn(&MessageRequest) -> CannedTurn + Send + Sync>) {
+        self.canned
+            .lock()
+            .expect("MockLlmClient.canned mutex poisoned")
+            .push_back(FauxStep::Factory(factory));
     }
 
     /// Push a canned non-streaming `MessageResponse`. Consumed by
@@ -175,11 +202,18 @@ impl MockLlmClient {
         self.calls.fetch_add(1, Ordering::SeqCst);
     }
 
-    fn pop_turn(&self) -> Option<CannedTurn> {
-        self.canned
+    fn pop_turn(&self, request: &MessageRequest) -> Option<CannedTurn> {
+        let step = self
+            .canned
             .lock()
             .expect("MockLlmClient.canned mutex poisoned")
-            .pop_front()
+            .pop_front();
+
+        match step {
+            Some(FauxStep::Canned(turn)) => Some(turn),
+            Some(FauxStep::Factory(factory)) => Some(factory(request)),
+            None => None,
+        }
     }
 
     fn pop_message(&self) -> Option<MessageResponse> {
@@ -207,7 +241,7 @@ impl LlmClient for MockLlmClient {
         }
 
         // Fallback: synthesize a MessageResponse from the next streaming turn.
-        let Some(turn) = self.pop_turn() else {
+        let Some(turn) = self.pop_turn(&request) else {
             return Err(anyhow!(
                 "MockLlmClient: create_message called but no canned response queued (request #{})",
                 self.calls.load(Ordering::SeqCst)
@@ -220,7 +254,7 @@ impl LlmClient for MockLlmClient {
     async fn create_message_stream(&self, request: MessageRequest) -> Result<StreamEventBox> {
         self.record_request(&request);
 
-        let Some(turn) = self.pop_turn() else {
+        let Some(turn) = self.pop_turn(&request) else {
             return Err(anyhow!(
                 "MockLlmClient: create_message_stream called but no canned turn queued (call #{})",
                 self.calls.load(Ordering::SeqCst)

--- a/crates/tui/tests/reasoning_content_replayed_after_tool_call.rs
+++ b/crates/tui/tests/reasoning_content_replayed_after_tool_call.rs
@@ -1,0 +1,162 @@
+//! Regression coverage for DeepSeek V4 reasoning-content replay after tools.
+
+use futures_util::StreamExt;
+
+#[path = "../src/models.rs"]
+#[allow(dead_code)]
+mod models;
+
+#[path = "support/llm_client.rs"]
+mod llm_client;
+
+use crate::llm_client::LlmClient;
+use crate::llm_client::mock::{FauxStep, MockLlmClient, canned};
+use crate::models::{ContentBlock, Message, MessageRequest};
+
+fn user_message(text: &str) -> Message {
+    Message {
+        role: "user".to_string(),
+        content: vec![ContentBlock::Text {
+            text: text.to_string(),
+            cache_control: None,
+        }],
+    }
+}
+
+fn assistant_tool_call_with_reasoning(
+    reasoning_content: &str,
+    id: &str,
+    name: &str,
+    input: serde_json::Value,
+) -> Message {
+    Message {
+        role: "assistant".to_string(),
+        content: vec![
+            ContentBlock::Thinking {
+                thinking: reasoning_content.to_string(),
+            },
+            ContentBlock::ToolUse {
+                id: id.to_string(),
+                name: name.to_string(),
+                input,
+                caller: None,
+            },
+        ],
+    }
+}
+
+fn tool_result_message(tool_use_id: &str, content: &str) -> Message {
+    Message {
+        role: "user".to_string(),
+        content: vec![ContentBlock::ToolResult {
+            tool_use_id: tool_use_id.to_string(),
+            content: content.to_string(),
+            is_error: None,
+            content_blocks: None,
+        }],
+    }
+}
+
+fn make_request(messages: Vec<Message>) -> MessageRequest {
+    MessageRequest {
+        model: "deepseek-v4-pro".to_string(),
+        messages,
+        max_tokens: 4096,
+        system: None,
+        tools: None,
+        tool_choice: None,
+        metadata: None,
+        thinking: None,
+        reasoning_effort: Some("high".to_string()),
+        stream: Some(true),
+        temperature: None,
+        top_p: None,
+    }
+}
+
+#[tokio::test]
+async fn factory_asserts_reasoning_content_is_replayed_after_tool_call() {
+    let reasoning_content = "I need the directory listing before I answer.";
+    let tool_call_turn = vec![
+        canned::message_start("r1"),
+        canned::thinking_delta(0, reasoning_content),
+        canned::tool_use_block_start(1, "call_list", "list_dir"),
+        canned::tool_input_delta(1, r#"{"path":"/tmp"}"#),
+        canned::block_stop(1),
+        canned::message_delta("tool_use", None),
+        canned::message_stop(),
+    ];
+
+    let mock = MockLlmClient::from_steps(vec![
+        FauxStep::Canned(tool_call_turn),
+        FauxStep::Factory(Box::new(move |request| {
+            assert!(
+                matches!(
+                    request.messages.last().and_then(|message| message.content.first()),
+                    Some(ContentBlock::ToolResult { tool_use_id, .. }) if tool_use_id == "call_list"
+                ),
+                "follow-up request should append the tool result after the assistant tool call"
+            );
+
+            let replayed = request
+                .messages
+                .iter()
+                .rev()
+                .find(|message| message.role == "assistant")
+                .and_then(|message| {
+                    message.content.iter().find_map(|block| match block {
+                        ContentBlock::Thinking { thinking } => Some(thinking.as_str()),
+                        _ => None,
+                    })
+                });
+
+            assert_eq!(
+                replayed,
+                Some(reasoning_content),
+                "DeepSeek V4 follow-up requests must replay reasoning_content from the assistant tool-call turn"
+            );
+
+            canned::simple_text_turn("done")
+        })),
+    ]);
+
+    let mut first_stream = mock
+        .create_message_stream(make_request(vec![user_message("list /tmp")]))
+        .await
+        .expect("first stream opens");
+    while let Some(event) = first_stream.next().await {
+        if matches!(
+            event.expect("first event"),
+            crate::models::StreamEvent::MessageStop
+        ) {
+            break;
+        }
+    }
+
+    let follow_up = make_request(vec![
+        user_message("list /tmp"),
+        assistant_tool_call_with_reasoning(
+            reasoning_content,
+            "call_list",
+            "list_dir",
+            serde_json::json!({ "path": "/tmp" }),
+        ),
+        tool_result_message("call_list", "/tmp/file1\n/tmp/file2"),
+    ]);
+
+    let mut second_stream = mock
+        .create_message_stream(follow_up)
+        .await
+        .expect("factory-backed stream opens");
+    while let Some(event) = second_stream.next().await {
+        if matches!(
+            event.expect("second event"),
+            crate::models::StreamEvent::MessageStop
+        ) {
+            break;
+        }
+    }
+
+    assert_eq!(mock.call_count(), 2);
+    assert_eq!(mock.remaining_turns(), 0);
+}


### PR DESCRIPTION
## Summary
- Add `FauxStep::Factory(Box<dyn Fn(&MessageRequest) -> CannedTurn + Send + Sync>)` for live request-shape assertions in `MockLlmClient`
- Preserve existing `MockLlmClient::new(Vec<CannedTurn>)` callers while adding `from_steps` / `push_factory` for factory-backed tests
- Add regression coverage for DeepSeek V4 `reasoning_content` replay after a thinking + tool-call turn

Fixes #2074.

## Verification
- `cargo fmt --all`
- `cargo test -p codewhale-tui reasoning_content` (passes: 10 tests run across filtered targets, including `factory_asserts_reasoning_content_is_replayed_after_tool_call`)
