### PR TITLE
chore: add contribution gate workflows

### DIFF
--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -1,0 +1,12 @@
+# Approved external contributors for the contribution gate.
+#
+# Format:
+#   <github-login> <scope>[,<scope>]
+#
+# Scopes:
+#   pr     may open pull requests
+#   issue  may open issues
+#
+# Repository owners, members, and collaborators bypass the gate automatically;
+# this file is for external contributors the maintainer has approved.
+Hmbown pr,issue

--- a/.github/workflows/approve-contributor.yml
+++ b/.github/workflows/approve-contributor.yml
@@ -1,0 +1,210 @@
+name: Approve contributor
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  approve:
+    runs-on: ubuntu-latest
+    if: >-
+      ${{
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'
+      }}
+    steps:
+      - name: Add contributor to allowlist via PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const command = (context.payload.comment.body || '').trim().toLowerCase();
+            const scopeByCommand = new Map([
+              ['lgtm', 'pr'],
+              ['lgtmi', 'issue'],
+            ]);
+            const scope = scopeByCommand.get(command);
+            if (!scope) return;
+
+            const target = await getTarget();
+            if (!target.login) {
+              core.warning('Could not resolve the issue or PR author to approve.');
+              return;
+            }
+
+            const allowlistPath = '.github/APPROVED_CONTRIBUTORS';
+            const defaultBranch = context.payload.repository.default_branch;
+            const baseRef = `heads/${defaultBranch}`;
+            const safeLogin = target.login.toLowerCase().replace(/[^a-z0-9-]/g, '-').replace(/^-+|-+$/g, '') || 'contributor';
+            const branch = `automation/approve-${safeLogin}`;
+
+            const base = await github.rest.git.getRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: baseRef,
+            });
+
+            await ensureBranch(branch, base.data.object.sha);
+
+            const current = await readAllowlist(allowlistPath, branch, defaultBranch);
+            const nextContent = updateAllowlist(current.content, target.login, scope);
+
+            if (nextContent === current.content) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.issue.number,
+                body: `@${target.login} is already approved for ${scope === 'pr' ? 'pull requests' : 'issues'}.`,
+              });
+              return;
+            }
+
+            await github.rest.repos.createOrUpdateFileContents({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              path: allowlistPath,
+              message: `chore: approve @${target.login} for ${scope} contributions`,
+              content: Buffer.from(nextContent, 'utf8').toString('base64'),
+              branch,
+              sha: current.sha,
+              committer: {
+                name: 'github-actions[bot]',
+                email: '41898282+github-actions[bot]@users.noreply.github.com',
+              },
+              author: {
+                name: 'github-actions[bot]',
+                email: '41898282+github-actions[bot]@users.noreply.github.com',
+              },
+            });
+
+            const existingPr = await findExistingPullRequest(branch);
+            const title = `chore: approve @${target.login} for ${scope} contributions`;
+            const body = [
+              `Adds @${target.login} to \`.github/APPROVED_CONTRIBUTORS\` for ${scope === 'pr' ? 'pull request' : 'issue'} contributions.`,
+              '',
+              `Triggered by maintainer comment \`${command}\` on #${context.payload.issue.number}.`,
+            ].join('\n');
+
+            if (existingPr) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.issue.number,
+                body: `Allowlist update PR is open: ${existingPr.html_url}`,
+              });
+              return;
+            }
+
+            const pr = await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              head: branch,
+              base: defaultBranch,
+              body,
+              maintainer_can_modify: true,
+            });
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body: `Opened allowlist update PR: ${pr.data.html_url}`,
+            });
+
+            async function getTarget() {
+              const issue = context.payload.issue;
+              if (issue.pull_request) {
+                const pr = await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: issue.number,
+                });
+                return { login: pr.data.user?.login || '' };
+              }
+              return { login: issue.user?.login || '' };
+            }
+
+            async function ensureBranch(name, sha) {
+              try {
+                await github.rest.git.getRef({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ref: `heads/${name}`,
+                });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+                await github.rest.git.createRef({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ref: `refs/heads/${name}`,
+                  sha,
+                });
+              }
+            }
+
+            async function readAllowlist(path, branch, fallbackBranch) {
+              for (const ref of [branch, fallbackBranch]) {
+                try {
+                  const response = await github.rest.repos.getContent({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    path,
+                    ref,
+                  });
+                  return {
+                    content: Buffer.from(response.data.content, response.data.encoding).toString('utf8'),
+                    sha: response.data.sha,
+                  };
+                } catch (error) {
+                  if (error.status !== 404) throw error;
+                }
+              }
+              return { content: '', sha: undefined };
+            }
+
+            function updateAllowlist(content, login, scope) {
+              const lines = content.split(/\r?\n/);
+              const wanted = login.toLowerCase();
+              let changed = false;
+              let found = false;
+              const next = lines.map(line => {
+                const withoutComment = line.replace(/#.*/, '').trim();
+                if (!withoutComment) return line;
+                const [entryLogin, ...scopeParts] = withoutComment.split(/\s+/);
+                if ((entryLogin || '').toLowerCase() !== wanted) return line;
+
+                found = true;
+                const scopes = new Set(scopeParts.join(' ').split(/[,\s]+/).filter(Boolean).map(s => s.toLowerCase()));
+                if (scopeParts.length === 0 || scopes.has('all') || scopes.has(scope)) return line;
+                scopes.add(scope);
+                changed = true;
+                return `${entryLogin} ${[...scopes].sort().join(',')}`;
+              });
+
+              if (!found) {
+                if (next.length > 0 && next[next.length - 1] !== '') next.push('');
+                next.push(`${login} ${scope}`);
+                changed = true;
+              }
+
+              if (!changed) return content;
+              return `${next.join('\n').replace(/\n*$/, '')}\n`;
+            }
+
+            async function findExistingPullRequest(branch) {
+              const prs = await github.rest.pulls.list({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                head: `${context.repo.owner}:${branch}`,
+                base: defaultBranch,
+                per_page: 10,
+              });
+              return prs.data[0] || null;
+            }

--- a/.github/workflows/issue-gate.yml
+++ b/.github/workflows/issue-gate.yml
@@ -1,0 +1,83 @@
+name: Issue contribution gate
+
+on:
+  issues:
+    types: [opened, reopened]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close unapproved external issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            if (!issue || issue.pull_request) return;
+
+            const association = issue.author_association || 'NONE';
+            const trustedAssociations = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
+            if (trustedAssociations.has(association)) return;
+
+            const author = issue.user?.login || '';
+            const approved = await isApproved(author, 'issue');
+            if (approved) return;
+
+            const contributingUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/blob/main/CONTRIBUTING.md`;
+            const body = [
+              `Thanks for opening this, @${author}.`,
+              '',
+              'CodeWhale is currently using a small issue allowlist so a solo maintainer can keep triage, security, and release work manageable.',
+              '',
+              `Please read [CONTRIBUTING.md](${contributingUrl}) before opening new issues. If this topic is a good fit for the project, the maintainer can approve future issue access by commenting \`lgtmi\` here. Once the allowlist update lands, the maintainer can reopen this issue or ask you to file it again.`,
+              '',
+              'Closing this for now to keep the issue tracker focused. Thank you for understanding.',
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              body,
+            });
+
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              state: 'closed',
+              state_reason: 'not_planned',
+            });
+
+            async function isApproved(login, scope) {
+              if (!login) return false;
+              let content;
+              try {
+                const response = await github.rest.repos.getContent({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  path: '.github/APPROVED_CONTRIBUTORS',
+                  ref: context.payload.repository.default_branch,
+                });
+                content = Buffer.from(response.data.content, response.data.encoding).toString('utf8');
+              } catch (error) {
+                core.warning(`Could not read .github/APPROVED_CONTRIBUTORS: ${error.message}`);
+                return false;
+              }
+
+              const wanted = login.toLowerCase();
+              for (const rawLine of content.split(/\r?\n/)) {
+                const line = rawLine.replace(/#.*/, '').trim();
+                if (!line) continue;
+                const [entryLogin, ...scopeParts] = line.split(/\s+/);
+                if ((entryLogin || '').toLowerCase() !== wanted) continue;
+                if (scopeParts.length === 0) return true;
+                const scopes = new Set(scopeParts.join(' ').split(/[,\s]+/).filter(Boolean).map(s => s.toLowerCase()));
+                return scopes.has('all') || scopes.has(scope);
+              }
+              return false;
+            }

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -1,0 +1,83 @@
+name: Pull request contribution gate
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close unapproved external pull requests
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            if (!pr || pr.draft) return;
+
+            const association = pr.author_association || 'NONE';
+            const trustedAssociations = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
+            if (trustedAssociations.has(association)) return;
+
+            const author = pr.user?.login || '';
+            const approved = await isApproved(author, 'pr');
+            if (approved) return;
+
+            const contributingUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/blob/main/CONTRIBUTING.md`;
+            const body = [
+              `Thanks for taking the time to open this PR, @${author}.`,
+              '',
+              'CodeWhale is currently using a small contribution allowlist so a solo maintainer can keep review, security, and release work manageable.',
+              '',
+              `Please read [CONTRIBUTING.md](${contributingUrl}) before sending code changes. If this is a good fit for the project, the maintainer can approve future PR access by commenting \`lgtm\` on this PR. Once the allowlist update lands, the maintainer can reopen this PR or ask you to resend the change.`,
+              '',
+              'Closing this for now to keep the active review queue focused. Thank you for understanding.',
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body,
+            });
+
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              state: 'closed',
+            });
+
+            async function isApproved(login, scope) {
+              if (!login) return false;
+              let content;
+              try {
+                const response = await github.rest.repos.getContent({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  path: '.github/APPROVED_CONTRIBUTORS',
+                  ref: context.payload.repository.default_branch,
+                });
+                content = Buffer.from(response.data.content, response.data.encoding).toString('utf8');
+              } catch (error) {
+                core.warning(`Could not read .github/APPROVED_CONTRIBUTORS: ${error.message}`);
+                return false;
+              }
+
+              const wanted = login.toLowerCase();
+              for (const rawLine of content.split(/\r?\n/)) {
+                const line = rawLine.replace(/#.*/, '').trim();
+                if (!line) continue;
+                const [entryLogin, ...scopeParts] = line.split(/\s+/);
+                if ((entryLogin || '').toLowerCase() !== wanted) continue;
+                if (scopeParts.length === 0) return true;
+                const scopes = new Set(scopeParts.join(' ').split(/[,\s]+/).filter(Boolean).map(s => s.toLowerCase()));
+                return scopes.has('all') || scopes.has(scope);
+              }
+              return false;
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,6 +164,18 @@ these crates, including the bottom-up build order.
 
 ## Submitting Changes
 
+CodeWhale uses a small contribution allowlist so a solo maintainer can keep
+review, security, and release work manageable. Unapproved external PRs and
+issues may be closed automatically with a pointer back to this guide.
+
+Maintainers can approve future access from GitHub comments:
+
+- `lgtm` approves the author for future pull requests.
+- `lgtmi` approves the author for future issues.
+
+Those approvals update `.github/APPROVED_CONTRIBUTORS` through a reviewable
+allowlist change.
+
 1. Create a feature branch from `main`:
    ```bash
    git checkout -b feat/your-feature


### PR DESCRIPTION
## Summary

- add `.github/APPROVED_CONTRIBUTORS` with scoped `pr` / `issue` allowlist entries
- add PR and issue gates that politely close unapproved external contributions with a CONTRIBUTING pointer
- add maintainer comment approvals: `lgtm` for PR access and `lgtmi` for issue access, creating an allowlist update PR
- document the gate in CONTRIBUTING.md

Closes #688
Refs #2086

## Verification

- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/pr-gate.yml .github/workflows/issue-gate.yml .github/workflows/approve-contributor.yml`
- wrapped each `actions/github-script` block and ran `node --check`
- `git diff --cached --check` before commit

Note: `actionlint` was not installed in the local environment.