### PR TITLE
Wrap TUI frames with synchronized output

### DIFF
--- a/crates/tui/src/tui/color_compat.rs
+++ b/crates/tui/src/tui/color_compat.rs
@@ -16,6 +16,9 @@ use ratatui::{
 
 use crate::palette::{self, ColorDepth, PaletteMode, ThemeId, UiTheme};
 
+const BEGIN_SYNC_UPDATE: &[u8] = b"\x1b[?2026h";
+const END_SYNC_UPDATE: &[u8] = b"\x1b[?2026l";
+
 #[derive(Debug)]
 pub(crate) struct ColorCompatBackend<W: Write> {
     inner: CrosstermBackend<W>,
@@ -38,6 +41,8 @@ pub(crate) struct ColorCompatBackend<W: Write> {
     /// Forcing the expected size prevents ratatui's internal `autoresize` from
     /// shrinking the viewport back to the stale dimension inside `draw()`.
     forced_size: Option<Size>,
+    synchronized_output_enabled: bool,
+    synchronized_output_active: bool,
 }
 
 impl<W: Write> ColorCompatBackend<W> {
@@ -53,6 +58,8 @@ impl<W: Write> ColorCompatBackend<W> {
             // to a community preset.
             active_ui_theme: UiTheme::detect(),
             forced_size: None,
+            synchronized_output_enabled: false,
+            synchronized_output_active: false,
         }
     }
 
@@ -71,6 +78,26 @@ impl<W: Write> ColorCompatBackend<W> {
     pub(crate) fn set_theme(&mut self, theme_id: ThemeId, ui_theme: UiTheme) {
         self.theme_id = theme_id;
         self.active_ui_theme = ui_theme;
+    }
+
+    pub(crate) fn set_synchronized_output(&mut self, enabled: bool) {
+        self.synchronized_output_enabled = enabled;
+    }
+
+    fn begin_synchronized_output(&mut self) -> io::Result<()> {
+        if self.synchronized_output_enabled && !self.synchronized_output_active {
+            self.inner.write_all(BEGIN_SYNC_UPDATE)?;
+            self.synchronized_output_active = true;
+        }
+        Ok(())
+    }
+
+    fn end_synchronized_output(&mut self) -> io::Result<()> {
+        if self.synchronized_output_active {
+            self.inner.write_all(END_SYNC_UPDATE)?;
+            self.synchronized_output_active = false;
+        }
+        Ok(())
     }
 }
 
@@ -91,6 +118,7 @@ impl<W: Write> Backend for ColorCompatBackend<W> {
     where
         I: Iterator<Item = (u16, u16, &'a Cell)>,
     {
+        self.begin_synchronized_output()?;
         let adapted = content
             .map(|(x, y, cell)| {
                 let mut cell = cell.clone();
@@ -148,6 +176,7 @@ impl<W: Write> Backend for ColorCompatBackend<W> {
     }
 
     fn flush(&mut self) -> io::Result<()> {
+        self.end_synchronized_output()?;
         Backend::flush(&mut self.inner)
     }
 }
@@ -249,6 +278,25 @@ mod tests {
         let output = String::from_utf8_lossy(&capture.borrow()).to_string();
         assert!(!output.contains("38;2;"), "{output:?}");
         assert!(!output.contains("48;2;"), "{output:?}");
+    }
+
+    #[test]
+    fn synchronized_output_wraps_backend_draw_until_flush() {
+        let writer = SharedWriter::default();
+        let capture = writer.0.clone();
+        let mut backend = ColorCompatBackend::new(writer, ColorDepth::TrueColor, PaletteMode::Dark);
+        backend.set_synchronized_output(true);
+        let cell = Cell::new("x");
+
+        backend.draw(std::iter::once((0, 0, &cell))).unwrap();
+        let after_draw = String::from_utf8_lossy(&capture.borrow()).to_string();
+        assert!(after_draw.contains("\x1b[?2026h"), "{after_draw:?}");
+        assert!(!after_draw.contains("\x1b[?2026l"), "{after_draw:?}");
+
+        Backend::flush(&mut backend).unwrap();
+        let after_flush = String::from_utf8_lossy(&capture.borrow()).to_string();
+        assert!(after_flush.contains("\x1b[?2026h"), "{after_flush:?}");
+        assert!(after_flush.contains("\x1b[?2026l"), "{after_flush:?}");
     }
 
     #[test]

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -1,11 +1,12 @@
 //! TUI event loop and rendering logic for `DeepSeek` CLI.
 
 use std::fmt::Write as _;
+use std::fs::{File, OpenOptions};
 use std::io::{self, Stdout, Write};
 use std::path::PathBuf;
 #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
 use std::process::{Command, Stdio};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
@@ -26,6 +27,7 @@ use crossterm::event::{
 };
 use ratatui::{
     Frame, Terminal,
+    buffer::{Buffer, Cell},
     layout::{Constraint, Direction, Layout, Rect, Size},
     prelude::Widget,
     style::Style,
@@ -5893,13 +5895,15 @@ fn draw_app_frame_inner(
 ) -> Result<()> {
     terminal.backend_mut().set_palette_mode(app.ui_theme.mode);
     terminal.backend_mut().set_theme(app.theme_id, app.ui_theme);
-    // DEC 2026 wrapping is on by default but can be turned off for
-    // terminals that mishandle it (Ptyxis 50.x + VTE 0.84.x flashes the
-    // whole viewport on every wrapped frame instead of deferring as the
-    // standard requires). Settings::synchronized_output_enabled resolves
-    // the user's setting against the Ptyxis env auto-detect.
     let wrap_in_sync_update = app.synchronized_output_enabled;
-    if wrap_in_sync_update {
+    // Normal frames are wrapped by the backend's draw/flush boundary so the
+    // DEC 2026 envelope sits exactly around ratatui's diff output. Full
+    // repaints still start the envelope here because they include viewport
+    // reset bytes before `Terminal::draw` begins.
+    terminal
+        .backend_mut()
+        .set_synchronized_output(wrap_in_sync_update && !full_repaint);
+    if full_repaint && wrap_in_sync_update {
         let _ = terminal.backend_mut().write_all(BEGIN_SYNC_UPDATE);
     }
 
@@ -5912,16 +5916,99 @@ fn draw_app_frame_inner(
             terminal.backend_mut().write_all(TERMINAL_ORIGIN_RESET)?;
             terminal.clear()?;
         }
-        terminal.draw(|f| render(f, app))?;
+        let frame = terminal.draw(|f| render(f, app))?;
+        log_render_debug_frame(&frame.buffer, frame.area, frame.count, full_repaint);
         Ok(())
     })();
 
     // Always end the synchronized update, regardless of success or failure.
-    if wrap_in_sync_update {
+    if full_repaint && wrap_in_sync_update {
         let _ = terminal.backend_mut().write_all(END_SYNC_UPDATE);
     }
     let _ = terminal.backend_mut().flush();
     result
+}
+
+fn log_render_debug_frame(buffer: &Buffer, area: Rect, frame_count: usize, full_repaint: bool) {
+    static LOGGER: OnceLock<Mutex<Option<RenderDebugLogger>>> = OnceLock::new();
+    let logger = LOGGER.get_or_init(|| Mutex::new(RenderDebugLogger::open()));
+    let Ok(mut logger) = logger.lock() else {
+        return;
+    };
+    if let Some(logger) = logger.as_mut() {
+        let _ = logger.log_frame(buffer, area, frame_count, full_repaint);
+    }
+}
+
+struct RenderDebugLogger {
+    file: File,
+    previous_area: Option<Rect>,
+    previous_cells: Vec<Cell>,
+}
+
+impl RenderDebugLogger {
+    fn open() -> Option<Self> {
+        if std::env::var("CODEWHALE_TUI_DEBUG").ok().as_deref() != Some("1") {
+            return None;
+        }
+        let log_dir = dirs::home_dir()?.join(".deepseek").join("logs");
+        std::fs::create_dir_all(&log_dir).ok()?;
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(log_dir.join("tui-render.log"))
+            .ok()?;
+        Some(Self {
+            file,
+            previous_area: None,
+            previous_cells: Vec::new(),
+        })
+    }
+
+    fn log_frame(
+        &mut self,
+        buffer: &Buffer,
+        area: Rect,
+        frame_count: usize,
+        full_repaint: bool,
+    ) -> io::Result<()> {
+        let cells = buffer.content();
+        let area_changed = self.previous_area != Some(area);
+        let mut first_changed = None;
+        let changed = if area_changed || self.previous_cells.len() != cells.len() {
+            if !cells.is_empty() {
+                first_changed = Some(0);
+            }
+            cells.len()
+        } else {
+            let mut changed = 0usize;
+            for (idx, (next, prev)) in cells.iter().zip(self.previous_cells.iter()).enumerate() {
+                if next != prev {
+                    changed += 1;
+                    first_changed.get_or_insert(idx);
+                }
+            }
+            changed
+        };
+
+        write!(
+            self.file,
+            "frame={frame_count} area={}x{}+{},{} full_repaint={full_repaint} changed={changed}",
+            area.width, area.height, area.x, area.y
+        )?;
+        write!(self.file, " area_changed={area_changed}")?;
+        if let Some(idx) = first_changed {
+            let width = area.width.max(1);
+            let x = area.x + (idx as u16 % width);
+            let y = area.y + (idx as u16 / width);
+            write!(self.file, " first_changed={x},{y}")?;
+        }
+        writeln!(self.file)?;
+        self.previous_area = Some(area);
+        self.previous_cells.clear();
+        self.previous_cells.extend_from_slice(cells);
+        Ok(())
+    }
 }
 
 /// Pull the latest snapshot of cells / revisions / render options into the


### PR DESCRIPTION
## Summary
- wrap regular ratatui backend draw/flush output in DEC 2026 synchronized-output sequences when the existing synchronized_output setting is enabled
- keep full repaint viewport resets wrapped explicitly so reset bytes stay in the same synchronized frame
- add CODEWHALE_TUI_DEBUG=1 per-frame render summaries to ~/.deepseek/logs/tui-render.log

Addresses #2085. Partially addresses #1812 and related tearing/debug issues.

## Verification
- cargo fmt --all --check
- CARGO_TARGET_DIR=/Volumes/VIXinSSD/whalebro/target-codewhale-issue-2085 cargo test -p codewhale-tui tui::color_compat::tests::synchronized_output_wraps_backend_draw_until_flush
- CARGO_TARGET_DIR=/Volumes/VIXinSSD/whalebro/target-codewhale-issue-2085 cargo check -p codewhale-tui