### PR TITLE
feat(config): allow provider chat path suffix

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -191,6 +191,7 @@ max_subagents = 10 # optional (1-20)
 [providers.openai]
 # api_key = "YOUR_OPENAI_COMPATIBLE_API_KEY"
 # base_url = "https://api.openai.com/v1"
+# path_suffix = "chat/completions"       # use with base_url without /v1 for gateways that reject /v1/chat/completions
 # model = "gpt-4.1"
 
 # AtlasCloud OpenAI-compatible endpoint (https://www.atlascloud.ai/docs/models/llm)

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -2616,6 +2616,7 @@ mod tests {
             api_key: Some("resolved-openai-key".to_string()),
             api_key_source: Some(RuntimeApiKeySource::Keyring),
             base_url: "https://openai-compatible.example/v4".to_string(),
+            path_suffix: None,
             auth_mode: Some("api_key".to_string()),
             output_mode: None,
             log_level: None,

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -116,6 +116,7 @@ impl ProviderKind {
 pub struct ProviderConfigToml {
     pub api_key: Option<String>,
     pub base_url: Option<String>,
+    pub path_suffix: Option<String>,
     pub model: Option<String>,
     #[serde(default)]
     pub http_headers: BTreeMap<String, String>,
@@ -437,66 +438,77 @@ impl ConfigToml {
             "sandbox_mode" => self.sandbox_mode.clone(),
             "providers.deepseek.api_key" => self.providers.deepseek.api_key.clone(),
             "providers.deepseek.base_url" => self.providers.deepseek.base_url.clone(),
+            "providers.deepseek.path_suffix" => self.providers.deepseek.path_suffix.clone(),
             "providers.deepseek.model" => self.providers.deepseek.model.clone(),
             "providers.deepseek.http_headers" => {
                 serialize_http_headers(&self.providers.deepseek.http_headers)
             }
             "providers.nvidia_nim.api_key" => self.providers.nvidia_nim.api_key.clone(),
             "providers.nvidia_nim.base_url" => self.providers.nvidia_nim.base_url.clone(),
+            "providers.nvidia_nim.path_suffix" => self.providers.nvidia_nim.path_suffix.clone(),
             "providers.nvidia_nim.model" => self.providers.nvidia_nim.model.clone(),
             "providers.nvidia_nim.http_headers" => {
                 serialize_http_headers(&self.providers.nvidia_nim.http_headers)
             }
             "providers.openai.api_key" => self.providers.openai.api_key.clone(),
             "providers.openai.base_url" => self.providers.openai.base_url.clone(),
+            "providers.openai.path_suffix" => self.providers.openai.path_suffix.clone(),
             "providers.openai.model" => self.providers.openai.model.clone(),
             "providers.openai.http_headers" => {
                 serialize_http_headers(&self.providers.openai.http_headers)
             }
             "providers.atlascloud.api_key" => self.providers.atlascloud.api_key.clone(),
             "providers.atlascloud.base_url" => self.providers.atlascloud.base_url.clone(),
+            "providers.atlascloud.path_suffix" => self.providers.atlascloud.path_suffix.clone(),
             "providers.atlascloud.model" => self.providers.atlascloud.model.clone(),
             "providers.atlascloud.http_headers" => {
                 serialize_http_headers(&self.providers.atlascloud.http_headers)
             }
             "providers.wanjie_ark.api_key" => self.providers.wanjie_ark.api_key.clone(),
             "providers.wanjie_ark.base_url" => self.providers.wanjie_ark.base_url.clone(),
+            "providers.wanjie_ark.path_suffix" => self.providers.wanjie_ark.path_suffix.clone(),
             "providers.wanjie_ark.model" => self.providers.wanjie_ark.model.clone(),
             "providers.wanjie_ark.http_headers" => {
                 serialize_http_headers(&self.providers.wanjie_ark.http_headers)
             }
             "providers.openrouter.api_key" => self.providers.openrouter.api_key.clone(),
             "providers.openrouter.base_url" => self.providers.openrouter.base_url.clone(),
+            "providers.openrouter.path_suffix" => self.providers.openrouter.path_suffix.clone(),
             "providers.openrouter.model" => self.providers.openrouter.model.clone(),
             "providers.openrouter.http_headers" => {
                 serialize_http_headers(&self.providers.openrouter.http_headers)
             }
             "providers.novita.api_key" => self.providers.novita.api_key.clone(),
             "providers.novita.base_url" => self.providers.novita.base_url.clone(),
+            "providers.novita.path_suffix" => self.providers.novita.path_suffix.clone(),
             "providers.novita.model" => self.providers.novita.model.clone(),
             "providers.novita.http_headers" => {
                 serialize_http_headers(&self.providers.novita.http_headers)
             }
             "providers.fireworks.api_key" => self.providers.fireworks.api_key.clone(),
             "providers.fireworks.base_url" => self.providers.fireworks.base_url.clone(),
+            "providers.fireworks.path_suffix" => self.providers.fireworks.path_suffix.clone(),
             "providers.fireworks.model" => self.providers.fireworks.model.clone(),
             "providers.fireworks.http_headers" => {
                 serialize_http_headers(&self.providers.fireworks.http_headers)
             }
             "providers.sglang.api_key" => self.providers.sglang.api_key.clone(),
             "providers.sglang.base_url" => self.providers.sglang.base_url.clone(),
+            "providers.sglang.path_suffix" => self.providers.sglang.path_suffix.clone(),
             "providers.sglang.model" => self.providers.sglang.model.clone(),
             "providers.sglang.http_headers" => {
                 serialize_http_headers(&self.providers.sglang.http_headers)
             }
             "providers.vllm.api_key" => self.providers.vllm.api_key.clone(),
             "providers.vllm.base_url" => self.providers.vllm.base_url.clone(),
+            "providers.vllm.path_suffix" => self.providers.vllm.path_suffix.clone(),
             "providers.vllm.model" => self.providers.vllm.model.clone(),
             "providers.vllm.http_headers" => {
                 serialize_http_headers(&self.providers.vllm.http_headers)
             }
             "providers.ollama.api_key" => self.providers.ollama.api_key.clone(),
             "providers.ollama.base_url" => self.providers.ollama.base_url.clone(),
+            "providers.ollama.path_suffix" => self.providers.ollama.path_suffix.clone(),
             "providers.ollama.model" => self.providers.ollama.model.clone(),
             "providers.ollama.http_headers" => {
                 serialize_http_headers(&self.providers.ollama.http_headers)
@@ -547,6 +559,9 @@ impl ConfigToml {
                 self.providers.deepseek.base_url = Some(value.clone());
                 self.base_url = Some(value);
             }
+            "providers.deepseek.path_suffix" => {
+                self.providers.deepseek.path_suffix = Some(value.to_string());
+            }
             "providers.deepseek.model" => {
                 let value = value.to_string();
                 self.providers.deepseek.model = Some(value.clone());
@@ -559,6 +574,9 @@ impl ConfigToml {
             }
             "providers.openai.api_key" => self.providers.openai.api_key = Some(value.to_string()),
             "providers.openai.base_url" => self.providers.openai.base_url = Some(value.to_string()),
+            "providers.openai.path_suffix" => {
+                self.providers.openai.path_suffix = Some(value.to_string());
+            }
             "providers.openai.model" => self.providers.openai.model = Some(value.to_string()),
             "providers.openai.http_headers" => {
                 self.providers.openai.http_headers = parse_http_headers(value)?;
@@ -568,6 +586,9 @@ impl ConfigToml {
             }
             "providers.atlascloud.base_url" => {
                 self.providers.atlascloud.base_url = Some(value.to_string());
+            }
+            "providers.atlascloud.path_suffix" => {
+                self.providers.atlascloud.path_suffix = Some(value.to_string());
             }
             "providers.atlascloud.model" => {
                 self.providers.atlascloud.model = Some(value.to_string());
@@ -581,6 +602,9 @@ impl ConfigToml {
             "providers.wanjie_ark.base_url" => {
                 self.providers.wanjie_ark.base_url = Some(value.to_string());
             }
+            "providers.wanjie_ark.path_suffix" => {
+                self.providers.wanjie_ark.path_suffix = Some(value.to_string());
+            }
             "providers.wanjie_ark.model" => {
                 self.providers.wanjie_ark.model = Some(value.to_string());
             }
@@ -592,6 +616,9 @@ impl ConfigToml {
             }
             "providers.nvidia_nim.base_url" => {
                 self.providers.nvidia_nim.base_url = Some(value.to_string());
+            }
+            "providers.nvidia_nim.path_suffix" => {
+                self.providers.nvidia_nim.path_suffix = Some(value.to_string());
             }
             "providers.nvidia_nim.model" => {
                 self.providers.nvidia_nim.model = Some(value.to_string());
@@ -605,6 +632,9 @@ impl ConfigToml {
             "providers.openrouter.base_url" => {
                 self.providers.openrouter.base_url = Some(value.to_string());
             }
+            "providers.openrouter.path_suffix" => {
+                self.providers.openrouter.path_suffix = Some(value.to_string());
+            }
             "providers.openrouter.model" => {
                 self.providers.openrouter.model = Some(value.to_string());
             }
@@ -616,6 +646,9 @@ impl ConfigToml {
             }
             "providers.novita.base_url" => {
                 self.providers.novita.base_url = Some(value.to_string());
+            }
+            "providers.novita.path_suffix" => {
+                self.providers.novita.path_suffix = Some(value.to_string());
             }
             "providers.novita.model" => {
                 self.providers.novita.model = Some(value.to_string());
@@ -629,6 +662,9 @@ impl ConfigToml {
             "providers.fireworks.base_url" => {
                 self.providers.fireworks.base_url = Some(value.to_string());
             }
+            "providers.fireworks.path_suffix" => {
+                self.providers.fireworks.path_suffix = Some(value.to_string());
+            }
             "providers.fireworks.model" => {
                 self.providers.fireworks.model = Some(value.to_string());
             }
@@ -640,6 +676,9 @@ impl ConfigToml {
             }
             "providers.sglang.base_url" => {
                 self.providers.sglang.base_url = Some(value.to_string());
+            }
+            "providers.sglang.path_suffix" => {
+                self.providers.sglang.path_suffix = Some(value.to_string());
             }
             "providers.sglang.model" => {
                 self.providers.sglang.model = Some(value.to_string());
@@ -653,6 +692,9 @@ impl ConfigToml {
             "providers.vllm.base_url" => {
                 self.providers.vllm.base_url = Some(value.to_string());
             }
+            "providers.vllm.path_suffix" => {
+                self.providers.vllm.path_suffix = Some(value.to_string());
+            }
             "providers.vllm.model" => {
                 self.providers.vllm.model = Some(value.to_string());
             }
@@ -664,6 +706,9 @@ impl ConfigToml {
             }
             "providers.ollama.base_url" => {
                 self.providers.ollama.base_url = Some(value.to_string());
+            }
+            "providers.ollama.path_suffix" => {
+                self.providers.ollama.path_suffix = Some(value.to_string());
             }
             "providers.ollama.model" => {
                 self.providers.ollama.model = Some(value.to_string());
@@ -703,6 +748,7 @@ impl ConfigToml {
                 self.providers.deepseek.base_url = None;
                 self.base_url = None;
             }
+            "providers.deepseek.path_suffix" => self.providers.deepseek.path_suffix = None,
             "providers.deepseek.model" => {
                 self.providers.deepseek.model = None;
                 self.default_text_model = None;
@@ -713,44 +759,54 @@ impl ConfigToml {
             }
             "providers.openai.api_key" => self.providers.openai.api_key = None,
             "providers.openai.base_url" => self.providers.openai.base_url = None,
+            "providers.openai.path_suffix" => self.providers.openai.path_suffix = None,
             "providers.openai.model" => self.providers.openai.model = None,
             "providers.openai.http_headers" => self.providers.openai.http_headers.clear(),
             "providers.atlascloud.api_key" => self.providers.atlascloud.api_key = None,
             "providers.atlascloud.base_url" => self.providers.atlascloud.base_url = None,
+            "providers.atlascloud.path_suffix" => self.providers.atlascloud.path_suffix = None,
             "providers.atlascloud.model" => self.providers.atlascloud.model = None,
             "providers.atlascloud.http_headers" => self.providers.atlascloud.http_headers.clear(),
             "providers.wanjie_ark.api_key" => self.providers.wanjie_ark.api_key = None,
             "providers.wanjie_ark.base_url" => self.providers.wanjie_ark.base_url = None,
+            "providers.wanjie_ark.path_suffix" => self.providers.wanjie_ark.path_suffix = None,
             "providers.wanjie_ark.model" => self.providers.wanjie_ark.model = None,
             "providers.wanjie_ark.http_headers" => {
                 self.providers.wanjie_ark.http_headers.clear();
             }
             "providers.nvidia_nim.api_key" => self.providers.nvidia_nim.api_key = None,
             "providers.nvidia_nim.base_url" => self.providers.nvidia_nim.base_url = None,
+            "providers.nvidia_nim.path_suffix" => self.providers.nvidia_nim.path_suffix = None,
             "providers.nvidia_nim.model" => self.providers.nvidia_nim.model = None,
             "providers.nvidia_nim.http_headers" => self.providers.nvidia_nim.http_headers.clear(),
             "providers.openrouter.api_key" => self.providers.openrouter.api_key = None,
             "providers.openrouter.base_url" => self.providers.openrouter.base_url = None,
+            "providers.openrouter.path_suffix" => self.providers.openrouter.path_suffix = None,
             "providers.openrouter.model" => self.providers.openrouter.model = None,
             "providers.openrouter.http_headers" => self.providers.openrouter.http_headers.clear(),
             "providers.novita.api_key" => self.providers.novita.api_key = None,
             "providers.novita.base_url" => self.providers.novita.base_url = None,
+            "providers.novita.path_suffix" => self.providers.novita.path_suffix = None,
             "providers.novita.model" => self.providers.novita.model = None,
             "providers.novita.http_headers" => self.providers.novita.http_headers.clear(),
             "providers.fireworks.api_key" => self.providers.fireworks.api_key = None,
             "providers.fireworks.base_url" => self.providers.fireworks.base_url = None,
+            "providers.fireworks.path_suffix" => self.providers.fireworks.path_suffix = None,
             "providers.fireworks.model" => self.providers.fireworks.model = None,
             "providers.fireworks.http_headers" => self.providers.fireworks.http_headers.clear(),
             "providers.sglang.api_key" => self.providers.sglang.api_key = None,
             "providers.sglang.base_url" => self.providers.sglang.base_url = None,
+            "providers.sglang.path_suffix" => self.providers.sglang.path_suffix = None,
             "providers.sglang.model" => self.providers.sglang.model = None,
             "providers.sglang.http_headers" => self.providers.sglang.http_headers.clear(),
             "providers.vllm.api_key" => self.providers.vllm.api_key = None,
             "providers.vllm.base_url" => self.providers.vllm.base_url = None,
+            "providers.vllm.path_suffix" => self.providers.vllm.path_suffix = None,
             "providers.vllm.model" => self.providers.vllm.model = None,
             "providers.vllm.http_headers" => self.providers.vllm.http_headers.clear(),
             "providers.ollama.api_key" => self.providers.ollama.api_key = None,
             "providers.ollama.base_url" => self.providers.ollama.base_url = None,
+            "providers.ollama.path_suffix" => self.providers.ollama.path_suffix = None,
             "providers.ollama.model" => self.providers.ollama.model = None,
             "providers.ollama.http_headers" => self.providers.ollama.http_headers.clear(),
             _ => {
@@ -810,6 +866,9 @@ impl ConfigToml {
         if let Some(v) = self.providers.deepseek.base_url.as_ref() {
             out.insert("providers.deepseek.base_url".to_string(), v.clone());
         }
+        if let Some(v) = self.providers.deepseek.path_suffix.as_ref() {
+            out.insert("providers.deepseek.path_suffix".to_string(), v.clone());
+        }
         if let Some(v) = self.providers.deepseek.model.as_ref() {
             out.insert("providers.deepseek.model".to_string(), v.clone());
         }
@@ -821,6 +880,9 @@ impl ConfigToml {
         }
         if let Some(v) = self.providers.openai.base_url.as_ref() {
             out.insert("providers.openai.base_url".to_string(), v.clone());
+        }
+        if let Some(v) = self.providers.openai.path_suffix.as_ref() {
+            out.insert("providers.openai.path_suffix".to_string(), v.clone());
         }
         if let Some(v) = self.providers.openai.model.as_ref() {
             out.insert("providers.openai.model".to_string(), v.clone());
@@ -834,6 +896,9 @@ impl ConfigToml {
         if let Some(v) = self.providers.atlascloud.base_url.as_ref() {
             out.insert("providers.atlascloud.base_url".to_string(), v.clone());
         }
+        if let Some(v) = self.providers.atlascloud.path_suffix.as_ref() {
+            out.insert("providers.atlascloud.path_suffix".to_string(), v.clone());
+        }
         if let Some(v) = self.providers.atlascloud.model.as_ref() {
             out.insert("providers.atlascloud.model".to_string(), v.clone());
         }
@@ -845,6 +910,9 @@ impl ConfigToml {
         }
         if let Some(v) = self.providers.wanjie_ark.base_url.as_ref() {
             out.insert("providers.wanjie_ark.base_url".to_string(), v.clone());
+        }
+        if let Some(v) = self.providers.wanjie_ark.path_suffix.as_ref() {
+            out.insert("providers.wanjie_ark.path_suffix".to_string(), v.clone());
         }
         if let Some(v) = self.providers.wanjie_ark.model.as_ref() {
             out.insert("providers.wanjie_ark.model".to_string(), v.clone());
@@ -858,6 +926,9 @@ impl ConfigToml {
         if let Some(v) = self.providers.nvidia_nim.base_url.as_ref() {
             out.insert("providers.nvidia_nim.base_url".to_string(), v.clone());
         }
+        if let Some(v) = self.providers.nvidia_nim.path_suffix.as_ref() {
+            out.insert("providers.nvidia_nim.path_suffix".to_string(), v.clone());
+        }
         if let Some(v) = self.providers.nvidia_nim.model.as_ref() {
             out.insert("providers.nvidia_nim.model".to_string(), v.clone());
         }
@@ -869,6 +940,9 @@ impl ConfigToml {
         }
         if let Some(v) = self.providers.openrouter.base_url.as_ref() {
             out.insert("providers.openrouter.base_url".to_string(), v.clone());
+        }
+        if let Some(v) = self.providers.openrouter.path_suffix.as_ref() {
+            out.insert("providers.openrouter.path_suffix".to_string(), v.clone());
         }
         if let Some(v) = self.providers.openrouter.model.as_ref() {
             out.insert("providers.openrouter.model".to_string(), v.clone());
@@ -882,6 +956,9 @@ impl ConfigToml {
         if let Some(v) = self.providers.novita.base_url.as_ref() {
             out.insert("providers.novita.base_url".to_string(), v.clone());
         }
+        if let Some(v) = self.providers.novita.path_suffix.as_ref() {
+            out.insert("providers.novita.path_suffix".to_string(), v.clone());
+        }
         if let Some(v) = self.providers.novita.model.as_ref() {
             out.insert("providers.novita.model".to_string(), v.clone());
         }
@@ -893,6 +970,9 @@ impl ConfigToml {
         }
         if let Some(v) = self.providers.fireworks.base_url.as_ref() {
             out.insert("providers.fireworks.base_url".to_string(), v.clone());
+        }
+        if let Some(v) = self.providers.fireworks.path_suffix.as_ref() {
+            out.insert("providers.fireworks.path_suffix".to_string(), v.clone());
         }
         if let Some(v) = self.providers.fireworks.model.as_ref() {
             out.insert("providers.fireworks.model".to_string(), v.clone());
@@ -906,6 +986,9 @@ impl ConfigToml {
         if let Some(v) = self.providers.sglang.base_url.as_ref() {
             out.insert("providers.sglang.base_url".to_string(), v.clone());
         }
+        if let Some(v) = self.providers.sglang.path_suffix.as_ref() {
+            out.insert("providers.sglang.path_suffix".to_string(), v.clone());
+        }
         if let Some(v) = self.providers.sglang.model.as_ref() {
             out.insert("providers.sglang.model".to_string(), v.clone());
         }
@@ -918,6 +1001,9 @@ impl ConfigToml {
         if let Some(v) = self.providers.vllm.base_url.as_ref() {
             out.insert("providers.vllm.base_url".to_string(), v.clone());
         }
+        if let Some(v) = self.providers.vllm.path_suffix.as_ref() {
+            out.insert("providers.vllm.path_suffix".to_string(), v.clone());
+        }
         if let Some(v) = self.providers.vllm.model.as_ref() {
             out.insert("providers.vllm.model".to_string(), v.clone());
         }
@@ -929,6 +1015,9 @@ impl ConfigToml {
         }
         if let Some(v) = self.providers.ollama.base_url.as_ref() {
             out.insert("providers.ollama.base_url".to_string(), v.clone());
+        }
+        if let Some(v) = self.providers.ollama.path_suffix.as_ref() {
+            out.insert("providers.ollama.path_suffix".to_string(), v.clone());
         }
         if let Some(v) = self.providers.ollama.model.as_ref() {
             out.insert("providers.ollama.model".to_string(), v.clone());
@@ -998,6 +1087,10 @@ impl ConfigToml {
                 ProviderKind::Vllm => DEFAULT_VLLM_BASE_URL.to_string(),
                 ProviderKind::Ollama => DEFAULT_OLLAMA_BASE_URL.to_string(),
             });
+        let path_suffix = provider_cfg
+            .path_suffix
+            .as_deref()
+            .and_then(normalize_path_suffix);
         let auth_mode = cli
             .auth_mode
             .clone()
@@ -1101,6 +1194,7 @@ impl ConfigToml {
             sandbox_mode,
             yolo,
             http_headers,
+            path_suffix,
         }
     }
 }
@@ -1111,6 +1205,9 @@ fn merge_provider_config(target: &mut ProviderConfigToml, source: &ProviderConfi
     }
     if source.base_url.is_some() {
         target.base_url = source.base_url.clone();
+    }
+    if source.path_suffix.is_some() {
+        target.path_suffix = source.path_suffix.clone();
     }
     if source.model.is_some() {
         target.model = source.model.clone();
@@ -1347,6 +1444,7 @@ pub struct ResolvedRuntimeOptions {
     pub api_key: Option<String>,
     pub api_key_source: Option<RuntimeApiKeySource>,
     pub base_url: String,
+    pub path_suffix: Option<String>,
     pub auth_mode: Option<String>,
     pub output_mode: Option<String>,
     pub log_level: Option<String>,
@@ -1355,6 +1453,11 @@ pub struct ResolvedRuntimeOptions {
     pub sandbox_mode: Option<String>,
     pub yolo: Option<bool>,
     pub http_headers: BTreeMap<String, String>,
+}
+
+fn normalize_path_suffix(path_suffix: &str) -> Option<String> {
+    let trimmed = path_suffix.trim().trim_matches('/');
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
 }
 
 #[derive(Debug, Clone)]
@@ -2408,6 +2511,28 @@ mod tests {
         assert_eq!(resolved.provider, ProviderKind::Openrouter);
         assert_eq!(resolved.base_url, DEFAULT_OPENROUTER_BASE_URL);
         assert_eq!(resolved.model, DEFAULT_OPENROUTER_MODEL);
+    }
+
+    #[test]
+    fn provider_path_suffix_resolves_for_openai_compatible_chat_endpoints() {
+        let _lock = env_lock();
+        let _env = EnvGuard::without_deepseek_runtime_overrides();
+        let mut config = ConfigToml {
+            provider: ProviderKind::Openai,
+            ..ConfigToml::default()
+        };
+        config.providers.openai.base_url = Some("https://gateway.example".to_string());
+        config.providers.openai.path_suffix = Some("/chat/completions".to_string());
+
+        let resolved = config.resolve_runtime_options(&CliRuntimeOverrides::default());
+
+        assert_eq!(resolved.provider, ProviderKind::Openai);
+        assert_eq!(resolved.base_url, "https://gateway.example");
+        assert_eq!(resolved.path_suffix.as_deref(), Some("chat/completions"));
+        assert_eq!(
+            config.get_value("providers.openai.path_suffix").as_deref(),
+            Some("/chat/completions")
+        );
     }
 
     #[test]

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -125,6 +125,7 @@ pub struct DeepSeekClient {
     pub(super) http_client: reqwest::Client,
     api_key: String,
     pub(super) base_url: String,
+    chat_path_suffix: Option<String>,
     pub(super) api_provider: ApiProvider,
     retry: RetryPolicy,
     default_model: String,
@@ -291,6 +292,7 @@ impl Clone for DeepSeekClient {
             http_client: self.http_client.clone(),
             api_key: self.api_key.clone(),
             base_url: self.base_url.clone(),
+            chat_path_suffix: self.chat_path_suffix.clone(),
             api_provider: self.api_provider,
             retry: self.retry.clone(),
             default_model: self.default_model.clone(),
@@ -407,6 +409,21 @@ pub(super) fn api_url(base_url: &str, path: &str) -> String {
     format!("{}/{}", versioned.trim_end_matches('/'), path)
 }
 
+pub(super) fn api_url_with_path_suffix(
+    base_url: &str,
+    default_path: &str,
+    path_suffix: Option<&str>,
+) -> String {
+    let Some(path_suffix) = path_suffix else {
+        return api_url(base_url, default_path);
+    };
+    let path_suffix = path_suffix.trim().trim_matches('/');
+    if path_suffix.is_empty() {
+        return api_url(base_url, default_path);
+    }
+    format!("{}/{}", base_url.trim_end_matches('/'), path_suffix)
+}
+
 // === DeepSeekClient ===
 
 /// Returns true when DEEPSEEK_FORCE_HTTP1 is set to a truthy value
@@ -469,6 +486,7 @@ impl DeepSeekClient {
     pub fn new(config: &Config) -> Result<Self> {
         let api_key = config.deepseek_api_key()?;
         let base_url = config.deepseek_base_url();
+        let chat_path_suffix = config.chat_completions_path_suffix();
         let api_provider = config.api_provider();
         validate_base_url_security(&base_url)?;
         let retry = config.retry_policy();
@@ -494,12 +512,21 @@ impl DeepSeekClient {
             http_client,
             api_key,
             base_url,
+            chat_path_suffix,
             api_provider,
             retry,
             default_model,
             connection_health: Arc::new(AsyncMutex::new(ConnectionHealth::default())),
             rate_limiter: Arc::new(AsyncMutex::new(TokenBucket::from_env())),
         })
+    }
+
+    pub(super) fn chat_completions_url(&self) -> String {
+        api_url_with_path_suffix(
+            &self.base_url,
+            "chat/completions",
+            self.chat_path_suffix.as_deref(),
+        )
     }
 
     fn build_http_client(
@@ -580,7 +607,7 @@ impl DeepSeekClient {
         model: &str,
         target_language: &str,
     ) -> Result<String> {
-        let url = api_url(&self.base_url, "chat/completions");
+        let url = self.chat_completions_url();
         let mut body = serde_json::json!({
             "model": model,
             "messages": [
@@ -1180,6 +1207,34 @@ mod tests {
                 "chat/completions"
             ),
             "https://openai-compatible.example/api/coding/paas/v4/chat/completions"
+        );
+    }
+
+    #[test]
+    fn api_url_path_suffix_bypasses_automatic_v1_insertion() {
+        assert_eq!(
+            api_url_with_path_suffix(
+                "https://openai-compatible.example",
+                "chat/completions",
+                Some("/chat/completions")
+            ),
+            "https://openai-compatible.example/chat/completions"
+        );
+        assert_eq!(
+            api_url_with_path_suffix(
+                "https://openai-compatible.example/",
+                "chat/completions",
+                Some("  /api/chat/completions/  ")
+            ),
+            "https://openai-compatible.example/api/chat/completions"
+        );
+        assert_eq!(
+            api_url_with_path_suffix(
+                "https://openai-compatible.example",
+                "chat/completions",
+                Some("  ")
+            ),
+            "https://openai-compatible.example/v1/chat/completions"
         );
     }
 

--- a/crates/tui/src/client/chat.rs
+++ b/crates/tui/src/client/chat.rs
@@ -66,7 +66,7 @@ use crate::models::{
 
 use super::{
     DeepSeekClient, ERROR_BODY_MAX_BYTES, SSE_BACKPRESSURE_HIGH_WATERMARK,
-    SSE_BACKPRESSURE_SLEEP_MS, SSE_MAX_LINES_PER_CHUNK, acquire_stream_buffer, api_url,
+    SSE_BACKPRESSURE_SLEEP_MS, SSE_MAX_LINES_PER_CHUNK, acquire_stream_buffer,
     apply_reasoning_effort, bounded_error_text, from_api_tool_name, parse_usage,
     release_stream_buffer, system_to_instructions, to_api_tool_name,
 };
@@ -108,7 +108,7 @@ impl DeepSeekClient {
             self.api_provider,
         );
 
-        let url = api_url(&self.base_url, "chat/completions");
+        let url = self.chat_completions_url();
         let open_timeout = stream_open_timeout();
         let response = match tokio_timeout(
             open_timeout,
@@ -197,7 +197,7 @@ impl DeepSeekClient {
             self.api_provider,
         );
 
-        let url = api_url(&self.base_url, "chat/completions");
+        let url = self.chat_completions_url();
         let response = self
             .send_with_retry(|| self.http_client.post(&url).json(&body))
             .await?;

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -1208,6 +1208,7 @@ impl LspConfigToml {
 pub struct ProviderConfig {
     pub api_key: Option<String>,
     pub base_url: Option<String>,
+    pub path_suffix: Option<String>,
     pub model: Option<String>,
     pub http_headers: Option<HashMap<String, String>>,
 }
@@ -1613,6 +1614,18 @@ impl Config {
             .to_string()
         });
         normalize_base_url(&base)
+    }
+
+    /// Optional provider-scoped chat completions path override.
+    ///
+    /// Defaults to the current OpenAI-compatible `/v1/chat/completions`
+    /// routing. When set, the value is appended directly to the configured
+    /// `base_url`, which lets gateways that only expose `/chat/completions`
+    /// opt out of the automatic `/v1` insertion.
+    #[must_use]
+    pub fn chat_completions_path_suffix(&self) -> Option<String> {
+        self.provider_config()
+            .and_then(|provider| normalize_path_suffix(provider.path_suffix.as_deref()?))
     }
 
     fn active_provider_preserves_custom_base_url_model(&self) -> bool {
@@ -2847,6 +2860,11 @@ fn normalize_base_url(base: &str) -> String {
     trimmed.to_string()
 }
 
+fn normalize_path_suffix(path_suffix: &str) -> Option<String> {
+    let trimmed = path_suffix.trim().trim_matches('/');
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
 fn parse_http_headers(raw: &str) -> Result<HashMap<String, String>> {
     let mut headers = HashMap::new();
     for pair in raw.trim().split(',') {
@@ -2978,6 +2996,7 @@ fn merge_provider_config(base: ProviderConfig, override_cfg: ProviderConfig) -> 
     ProviderConfig {
         api_key: override_cfg.api_key.or(base.api_key),
         base_url: override_cfg.base_url.or(base.base_url),
+        path_suffix: override_cfg.path_suffix.or(base.path_suffix),
         model: override_cfg.model.or(base.model),
         http_headers: override_cfg.http_headers.or(base.http_headers),
     }
@@ -5408,6 +5427,7 @@ model = "account-model-id"
 [providers.openai]
 api_key = "openai-table-key"
 base_url = "https://openai-compatible.example/api/coding/paas/v4"
+path_suffix = "/chat/completions"
 model = "glm-5"
 "#,
         )?;
@@ -5418,6 +5438,10 @@ model = "glm-5"
         assert_eq!(
             config.deepseek_base_url(),
             "https://openai-compatible.example/api/coding/paas/v4"
+        );
+        assert_eq!(
+            config.chat_completions_path_suffix().as_deref(),
+            Some("chat/completions")
         );
         assert_eq!(config.default_model(), "glm-5");
         Ok(())

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -108,6 +108,16 @@ legacy top-level `base_url`, so the OpenAI-compatible provider receives it.
 provider tables in one config, `[providers.openai].model` can be used as the
 OpenAI-provider-specific override.
 
+Most gateways accept the OpenAI-style `/v1/chat/completions` path. If your
+gateway only accepts `/chat/completions`, set `base_url` to the gateway root
+and add a provider-scoped path suffix:
+
+```toml
+[providers.openai]
+base_url = "https://your-gateway.example"
+path_suffix = "chat/completions"
+```
+
 Local HTTP endpoints such as Ollama, SGLang, and vLLM are allowed by default
 when they use localhost or loopback addresses. For a non-local `http://`
 gateway, launch with `DEEPSEEK_ALLOW_INSECURE_HTTP=1` only on a trusted network:
@@ -479,6 +489,7 @@ If you are upgrading from older releases:
 - `provider` (string, optional): `codewhale` (default), `nvidia-nim`, `openai`, `atlascloud`, `wanjie-ark`, `openrouter`, `novita`, `fireworks`, `sglang`, `vllm`, or `ollama`. Legacy `deepseek-cn` configs are still accepted as an alias for `codewhale`; DeepSeek uses the same official host [`https://api.deepseek.com`](https://api-docs.deepseek.com/) worldwide. `nvidia-nim` targets NVIDIA's NIM-hosted DeepSeek endpoints through `https://integrate.api.nvidia.com/v1`; `openai` targets a generic OpenAI-compatible endpoint, defaulting to `https://api.openai.com/v1`; `atlascloud` targets AtlasCloud's OpenAI-compatible endpoint at `https://api.atlascloud.ai/v1`; `wanjie-ark` targets Wanjie Ark's OpenAI-compatible endpoint at `https://maas-openapi.wanjiedata.com/api/v1`; `fireworks` targets `https://api.fireworks.ai/inference/v1`; `sglang` targets a self-hosted OpenAI-compatible endpoint, defaulting to `http://localhost:30000/v1`; `vllm` targets a self-hosted vLLM OpenAI-compatible endpoint, defaulting to `http://localhost:8000/v1`; `ollama` targets Ollama's OpenAI-compatible endpoint, defaulting to `http://localhost:11434/v1`.
 - `api_key` (string, required for hosted providers): must be non-empty for DeepSeek/hosted providers (or set the provider API key env var). Self-hosted SGLang, vLLM, and Ollama can omit it.
 - `base_url` (string, optional): defaults to `https://api.deepseek.com/beta` for DeepSeek's OpenAI-compatible Chat Completions API, including legacy `provider = "deepseek-cn"` configs, `https://api.openai.com/v1` for `provider = "openai"`, `https://api.atlascloud.ai/v1` for `provider = "atlascloud"`, `https://maas-openapi.wanjiedata.com/api/v1` for `provider = "wanjie-ark"`, or the provider-specific endpoint for hosted/self-hosted providers. Set `https://api.deepseek.com` or `https://api.deepseek.com/v1` explicitly to opt out of DeepSeek beta features.
+- `path_suffix` (string, optional, provider tables only): overrides the chat-completions path appended to that provider's `base_url`. Leave unset for the normal `/v1/chat/completions` behavior; use `path_suffix = "chat/completions"` with a root `base_url` for gateways that reject `/v1/chat/completions`.
 - `default_text_model` (string, optional): defaults to `deepseek-v4-pro` for DeepSeek, `deepseek-ai/deepseek-v4-pro` for NVIDIA NIM, `gpt-4.1` for generic OpenAI-compatible endpoints, `deepseek-ai/deepseek-v4-flash` for AtlasCloud, `deepseek-reasoner` for Wanjie Ark, `accounts/fireworks/models/deepseek-v4-pro` for Fireworks, `deepseek-ai/DeepSeek-V4-Pro` for SGLang/vLLM, and `codewhale-coder:1.3b` for Ollama. Current public DeepSeek IDs are `deepseek-v4-pro` and `deepseek-v4-flash`, both with 1M context windows, 384K max output, and thinking mode enabled by default. Legacy `deepseek-chat` and `deepseek-reasoner` remain compatibility aliases for `deepseek-v4-flash` until July 24, 2026. Provider-specific mappings translate `deepseek-v4-pro` / `deepseek-v4-flash` to each provider's model ID where supported. Generic `openai`, `atlascloud`, `wanjie-ark`, and Ollama model IDs are passed through unchanged. OpenRouter provider configs with a custom `base_url` also preserve explicit model values, which lets OpenAI-compatible gateways accept bare model IDs. Use `/models` or `codewhale models` to discover live IDs from your configured endpoint. `DEEPSEEK_MODEL` overrides this for a single process.
 - `reasoning_effort` (string, optional): `off`, `low`, `medium`, `high`, or `max`; defaults to the configured UI tier. DeepSeek Platform receives top-level `thinking` / `reasoning_effort` fields. NVIDIA NIM receives equivalent settings through `chat_template_kwargs`.
 - `allow_shell` (bool, optional): defaults to `true` (sandboxed).


### PR DESCRIPTION
## Summary
- add provider-scoped `path_suffix` config for OpenAI-compatible chat completions endpoints
- route chat-completion requests through the override while keeping models, health, and beta FIM URL behavior unchanged
- document the `/chat/completions` gateway setup in config docs and example config

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p codewhale-config path_suffix`
- `CARGO_TARGET_DIR=/Volumes/VIXinSSD/whalebro/codewhale-target/issue-2089 cargo test -p codewhale-tui path_suffix`
- `CARGO_TARGET_DIR=/Volumes/VIXinSSD/whalebro/codewhale-target/issue-2089 cargo test -p codewhale-tui openai_provider_accepts_custom_model_and_base_url`
- `CARGO_TARGET_DIR=/Volumes/VIXinSSD/whalebro/codewhale-target/issue-2089 cargo test -p codewhale-cli build_tui_command_forwards_resolved_runtime` (compile-only; filter matched 0 tests)

Closes #2089
Closes #1874