### PR TITLE
Add model family identity palettes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -977,6 +977,7 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
+ "codewhale-agent",
  "codewhale-config",
  "codewhale-secrets",
  "codewhale-tools",

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -3,6 +3,190 @@ use std::collections::HashMap;
 use codewhale_config::ProviderKind;
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ModelFamily {
+    DeepSeek,
+    Anthropic,
+    OpenAI,
+    Google,
+    Meta,
+    Mistral,
+    Qwen,
+    Grok,
+    Cohere,
+    GptOss,
+    Inferencer,
+    Unknown,
+}
+
+impl ModelFamily {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::DeepSeek => "deepseek",
+            Self::Anthropic => "anthropic",
+            Self::OpenAI => "openai",
+            Self::Google => "google",
+            Self::Meta => "meta",
+            Self::Mistral => "mistral",
+            Self::Qwen => "qwen",
+            Self::Grok => "grok",
+            Self::Cohere => "cohere",
+            Self::GptOss => "gpt-oss",
+            Self::Inferencer => "inferencer",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ModelFamilyPalette {
+    pub accent: (u8, u8, u8),
+    pub accent_dim: (u8, u8, u8),
+    pub thinking: (u8, u8, u8),
+    pub tool_call: (u8, u8, u8),
+}
+
+impl ModelFamilyPalette {
+    #[must_use]
+    pub const fn for_family(family: ModelFamily) -> Self {
+        match family {
+            ModelFamily::DeepSeek => Self {
+                accent: (72, 140, 220),
+                accent_dim: (36, 76, 132),
+                thinking: (52, 104, 148),
+                tool_call: (80, 170, 198),
+            },
+            ModelFamily::Anthropic => Self {
+                accent: (198, 116, 76),
+                accent_dim: (112, 66, 48),
+                thinking: (146, 102, 68),
+                tool_call: (214, 154, 112),
+            },
+            ModelFamily::OpenAI => Self {
+                accent: (82, 176, 150),
+                accent_dim: (44, 98, 88),
+                thinking: (70, 128, 112),
+                tool_call: (118, 206, 176),
+            },
+            ModelFamily::Google => Self {
+                accent: (86, 154, 228),
+                accent_dim: (62, 92, 142),
+                thinking: (224, 160, 72),
+                tool_call: (92, 180, 116),
+            },
+            ModelFamily::Meta => Self {
+                accent: (74, 132, 214),
+                accent_dim: (42, 70, 128),
+                thinking: (94, 148, 200),
+                tool_call: (104, 186, 222),
+            },
+            ModelFamily::Mistral => Self {
+                accent: (214, 122, 54),
+                accent_dim: (118, 70, 42),
+                thinking: (174, 104, 58),
+                tool_call: (232, 158, 86),
+            },
+            ModelFamily::Qwen => Self {
+                accent: (152, 112, 224),
+                accent_dim: (78, 60, 134),
+                thinking: (126, 94, 174),
+                tool_call: (188, 146, 238),
+            },
+            ModelFamily::Grok => Self {
+                accent: (184, 190, 198),
+                accent_dim: (92, 98, 106),
+                thinking: (132, 138, 148),
+                tool_call: (216, 220, 224),
+            },
+            ModelFamily::Cohere => Self {
+                accent: (230, 112, 136),
+                accent_dim: (126, 58, 76),
+                thinking: (176, 86, 110),
+                tool_call: (238, 150, 166),
+            },
+            ModelFamily::GptOss => Self {
+                accent: (92, 196, 176),
+                accent_dim: (48, 110, 100),
+                thinking: (76, 150, 138),
+                tool_call: (128, 224, 204),
+            },
+            ModelFamily::Inferencer => Self {
+                accent: (144, 164, 188),
+                accent_dim: (74, 88, 108),
+                thinking: (112, 130, 154),
+                tool_call: (164, 188, 214),
+            },
+            ModelFamily::Unknown => Self {
+                accent: (150, 160, 174),
+                accent_dim: (72, 82, 96),
+                thinking: (112, 122, 136),
+                tool_call: (176, 188, 202),
+            },
+        }
+    }
+}
+
+#[must_use]
+pub fn model_family(model_id: &str) -> ModelFamily {
+    let normalized = model_id.trim().to_ascii_lowercase();
+    if normalized.is_empty() {
+        return ModelFamily::Unknown;
+    }
+
+    let compact = normalized.replace(['_', '.', ':', '/', '\\'], "-");
+    let family_markers = [
+        (ModelFamily::GptOss, &["gpt-oss", "gptoss"][..]),
+        (ModelFamily::DeepSeek, &["deepseek", "deep-seek"]),
+        (ModelFamily::Anthropic, &["claude", "anthropic"]),
+        (ModelFamily::Google, &["gemini", "gemma", "google"]),
+        (
+            ModelFamily::Meta,
+            &["llama", "codellama", "meta-llama", "meta"],
+        ),
+        (ModelFamily::Mistral, &["mistral", "mixtral", "codestral"]),
+        (ModelFamily::Qwen, &["qwen", "qwq", "qvq"]),
+        (ModelFamily::Grok, &["grok", "x-ai", "xai"]),
+        (ModelFamily::Cohere, &["cohere", "command-r", "command-a"]),
+        (
+            ModelFamily::OpenAI,
+            &["gpt-5", "gpt-4", "gpt-3", "gpt4", "gpt3", "o1", "o3", "o4"][..],
+        ),
+    ];
+
+    for (family, markers) in family_markers {
+        if markers
+            .iter()
+            .any(|marker| normalized.contains(marker) || compact.contains(marker))
+        {
+            return family;
+        }
+    }
+
+    let inferencer_markers = [
+        "openrouter",
+        "groq",
+        "together",
+        "cerebras",
+        "fireworks",
+        "deepinfra",
+        "novita",
+        "replicate",
+        "nvidia-nim",
+        "sglang",
+        "vllm",
+        "ollama",
+    ];
+    if inferencer_markers
+        .iter()
+        .any(|marker| normalized.contains(marker) || compact.contains(marker))
+    {
+        return ModelFamily::Inferencer;
+    }
+
+    ModelFamily::Unknown
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelInfo {
     pub id: String,
@@ -325,6 +509,71 @@ fn preserve_requested_model_id_case(mut model: ModelInfo, requested: &str) -> Mo
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn model_family_maps_representative_model_ids() {
+        let cases = [
+            ("deepseek-v4-pro", ModelFamily::DeepSeek),
+            ("deepseek/deepseek-v4-flash", ModelFamily::DeepSeek),
+            ("anthropic/claude-opus-4-7", ModelFamily::Anthropic),
+            ("claude-3-5-sonnet", ModelFamily::Anthropic),
+            ("openai/gpt-5.4", ModelFamily::OpenAI),
+            ("gpt-4.1-mini", ModelFamily::OpenAI),
+            ("google/gemini-3.1-pro", ModelFamily::Google),
+            ("gemini-2.5-pro", ModelFamily::Google),
+            ("meta-llama/llama-3.3-70b-instruct", ModelFamily::Meta),
+            ("llama3.3:70b", ModelFamily::Meta),
+            ("mistralai/mistral-large", ModelFamily::Mistral),
+            ("qwen/qwen3-coder", ModelFamily::Qwen),
+            ("x-ai/grok-4", ModelFamily::Grok),
+            ("cohere/command-r-plus", ModelFamily::Cohere),
+            ("openai/gpt-oss-120b", ModelFamily::GptOss),
+            ("gpt-oss:20b", ModelFamily::GptOss),
+            ("openrouter/auto", ModelFamily::Inferencer),
+            ("unknown-model", ModelFamily::Unknown),
+        ];
+
+        for (model_id, expected) in cases {
+            assert_eq!(model_family(model_id), expected, "{model_id}");
+        }
+    }
+
+    #[test]
+    fn routed_ids_prefer_underlying_family_over_gateway() {
+        let cases = [
+            (
+                "openrouter/meta-llama/llama-3.3-70b-instruct",
+                ModelFamily::Meta,
+            ),
+            ("groq/openai/gpt-oss-120b", ModelFamily::GptOss),
+            ("together/qwen/qwen3-coder", ModelFamily::Qwen),
+            (
+                "fireworks/deepseek-ai/deepseek-v4-pro",
+                ModelFamily::DeepSeek,
+            ),
+            ("deepinfra/google/gemini-3.1-pro", ModelFamily::Google),
+        ];
+
+        for (model_id, expected) in cases {
+            assert_eq!(model_family(model_id), expected, "{model_id}");
+        }
+    }
+
+    #[test]
+    fn model_family_palettes_are_stable_and_distinct() {
+        assert_eq!(
+            ModelFamilyPalette::for_family(ModelFamily::DeepSeek).accent,
+            (72, 140, 220)
+        );
+        assert_eq!(
+            ModelFamilyPalette::for_family(ModelFamily::Qwen).tool_call,
+            (188, 146, 238)
+        );
+        assert_ne!(
+            ModelFamilyPalette::for_family(ModelFamily::DeepSeek).accent,
+            ModelFamilyPalette::for_family(ModelFamily::Anthropic).accent
+        );
+    }
 
     #[test]
     fn deepseek_v4_pro_alias_stays_deepseek_by_default() {

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -28,6 +28,7 @@ path = "src/bin/deepseek_tui_legacy_shim.rs"
 anyhow = "1.0.100"
 arboard = "3.4"
 codewhale-config = { path = "../config", version = "0.8.44" }
+codewhale-agent = { path = "../agent", version = "0.8.44" }
 codewhale-secrets = { path = "../secrets", version = "0.8.44" }
 codewhale-tools = { path = "../tools", version = "0.8.44" }
 schemaui = { version = "0.12.0", default-features = false, optional = true }

--- a/crates/tui/src/palette.rs
+++ b/crates/tui/src/palette.rs
@@ -4,6 +4,10 @@ use ratatui::style::Color;
 #[cfg(target_os = "macos")]
 use std::process::Command;
 
+pub fn rgb_tuple_color(rgb: (u8, u8, u8)) -> Color {
+    Color::Rgb(rgb.0, rgb.1, rgb.2)
+}
+
 pub const DEEPSEEK_BLUE_RGB: (u8, u8, u8) = (53, 120, 229); // #3578E5
 pub const DEEPSEEK_SKY_RGB: (u8, u8, u8) = (106, 174, 242);
 #[allow(dead_code)]

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -5719,6 +5719,10 @@ fn render(f: &mut Frame, app: &mut App) {
             .filter(|value| !value.is_empty())
             .unwrap_or("workspace");
         let model_label = app.model_display_label();
+        let model_palette = codewhale_agent::ModelFamilyPalette::for_family(
+            codewhale_agent::model_family(&app.model),
+        );
+        let model_accent = palette::rgb_tuple_color(model_palette.accent);
         let effort_label = app.reasoning_effort_display_label();
         let provider_label = match app.api_provider {
             crate::config::ApiProvider::Deepseek => None,
@@ -5753,6 +5757,7 @@ fn render(f: &mut Frame, app: &mut App) {
             sanitized_prompt_tokens,
         )
         .with_reasoning_effort(Some(&effort_label))
+        .with_model_accent(Some(model_accent))
         .with_provider(provider_label)
         .with_status_indicator(crate::tui::widgets::header_status_indicator_frame(
             status_indicator_started_at,

--- a/crates/tui/src/tui/widgets/header.rs
+++ b/crates/tui/src/tui/widgets/header.rs
@@ -96,6 +96,8 @@ pub struct HeaderData<'a> {
     /// so the widget itself stays a pure pre-built render. `None` hides the
     /// chip entirely (e.g., `status_indicator = "off"`).
     pub status_indicator_frame: Option<&'static str>,
+    /// Accent color for the model label, derived from the model family.
+    pub model_accent: Option<Color>,
 }
 
 impl<'a> HeaderData<'a> {
@@ -121,6 +123,7 @@ impl<'a> HeaderData<'a> {
             reasoning_effort_label: None,
             provider_label: None,
             status_indicator_frame: None,
+            model_accent: None,
         }
     }
 
@@ -137,6 +140,12 @@ impl<'a> HeaderData<'a> {
     #[must_use]
     pub fn with_status_indicator(mut self, frame: Option<&'static str>) -> Self {
         self.status_indicator_frame = frame;
+        self
+    }
+
+    #[must_use]
+    pub fn with_model_accent(mut self, color: Option<Color>) -> Self {
+        self.model_accent = color;
         self
     }
 
@@ -460,6 +469,7 @@ impl<'a> HeaderWidget<'a> {
     fn metadata_spans(&self, max_width: usize) -> Vec<Span<'static>> {
         let workspace = self.data.workspace_name.trim();
         let model = self.data.model.trim();
+        let model_style = Style::default().fg(self.data.model_accent.unwrap_or(palette::TEXT_HINT));
 
         if max_width < 4 || (workspace.is_empty() && model.is_empty()) {
             return Vec::new();
@@ -468,7 +478,7 @@ impl<'a> HeaderWidget<'a> {
         if workspace.is_empty() {
             return vec![Span::styled(
                 Self::truncate_to_width(model, max_width),
-                Style::default().fg(palette::TEXT_HINT),
+                model_style,
             )];
         }
 
@@ -487,7 +497,7 @@ impl<'a> HeaderWidget<'a> {
                     Style::default().fg(palette::TEXT_SECONDARY),
                 ),
                 Span::styled(" · ", Style::default().fg(palette::TEXT_HINT)),
-                Span::styled(model.to_string(), Style::default().fg(palette::TEXT_HINT)),
+                Span::styled(model.to_string(), model_style),
             ];
         }
 
@@ -517,10 +527,7 @@ impl<'a> HeaderWidget<'a> {
                 Style::default().fg(palette::TEXT_SECONDARY),
             ),
             Span::styled(" · ", Style::default().fg(palette::TEXT_HINT)),
-            Span::styled(
-                Self::truncate_to_width(model, model_budget),
-                Style::default().fg(palette::TEXT_HINT),
-            ),
+            Span::styled(Self::truncate_to_width(model, model_budget), model_style),
         ]
     }
 
@@ -602,7 +609,7 @@ mod tests {
     use super::{HeaderData, HeaderWidget, Renderable};
     use crate::palette;
     use crate::tui::app::AppMode;
-    use ratatui::{buffer::Buffer, layout::Rect};
+    use ratatui::{buffer::Buffer, layout::Rect, style::Color};
 
     fn render_header(data: HeaderData<'_>, width: u16) -> String {
         let widget = HeaderWidget::new(data);
@@ -611,6 +618,14 @@ mod tests {
         widget.render(area, &mut buf);
 
         (0..width).map(|x| buf[(x, 0)].symbol()).collect::<String>()
+    }
+
+    fn render_header_buffer(data: HeaderData<'_>, width: u16) -> Buffer {
+        let widget = HeaderWidget::new(data);
+        let area = Rect::new(0, 0, width, 1);
+        let mut buf = Buffer::empty(area);
+        widget.render(area, &mut buf);
+        buf
     }
 
     #[test]
@@ -631,6 +646,26 @@ mod tests {
         assert!(rendered.contains("deepseek-v4-pro"));
         assert!(!rendered.contains("Plan"));
         assert!(!rendered.contains("Yolo"));
+    }
+
+    #[test]
+    fn header_uses_model_accent_on_model_label() {
+        let accent = Color::Rgb(152, 112, 224);
+        let buf = render_header_buffer(
+            HeaderData::new(
+                AppMode::Agent,
+                "qwen3-coder",
+                "codewhale-tui",
+                false,
+                palette::DEEPSEEK_INK,
+            )
+            .with_model_accent(Some(accent)),
+            72,
+        );
+        let rendered = (0..72).map(|x| buf[(x, 0)].symbol()).collect::<String>();
+        let idx = rendered.find("qwen3-coder").expect("model label visible") as u16;
+
+        assert_eq!(buf[(idx, 0)].fg, accent);
     }
 
     #[test]

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -359,6 +359,12 @@ Common settings keys:
 - `background_color` (`#RRGGBB`, `RRGGBB`, or `default`): optional main TUI
   background color applied to the root, header, transcript, and footer
   surfaces while preserving panel contrast.
+- Model family accents are built in for shared client identity: DeepSeek,
+  Anthropic, OpenAI, Google, Meta, Mistral, Qwen, Grok, Cohere, GptOss,
+  Inferencer, and Unknown each have an inspired, non-brand-exact palette with
+  `accent`, `accent_dim`, `thinking`, and `tool_call` slots. The current TUI
+  uses the family `accent` for the active model label; per-user palette
+  overrides are not a config surface yet.
 - `cost_currency` (`usd`, `cny`; default `usd`): currency used by the footer,
   context panel, `/cost`, `/tokens`, and long-turn notification summaries. The
   aliases `rmb` and `yuan` normalize to `cny`.


### PR DESCRIPTION
## Summary
- add exported `ModelFamily`, `model_family(model_id)`, and `ModelFamilyPalette` APIs in `codewhale-agent`
- cover DeepSeek, Anthropic, OpenAI, Google, Meta, Mistral, Qwen, Grok, Cohere, GptOss, Inferencer, and Unknown with deterministic routed-ID tests
- tint the TUI header model label from the shared family accent and document the built-in palette slots

## Verification
- `CARGO_TARGET_DIR=/Volumes/VIXinSSD/whalebro/codewhale-2081-target cargo test -p codewhale-agent`
- `CARGO_TARGET_DIR=/Volumes/VIXinSSD/whalebro/codewhale-2081-target cargo test -p codewhale-tui header_uses_model_accent_on_model_label`
- `git diff --check`

## Scope notes
- Refs #2081
- Partially addresses #2026
- This MVP does not implement provider house-model defaults, `codewhale models default`, config-file palette overrides, or desktop/iOS/web shell integration. The docs call out that per-user palette overrides are not a config surface yet.
