### PR TITLE
fix(homebrew): install codewhale binaries and legacy shims

### DIFF
--- a/.github/scripts/update-homebrew-tap.sh
+++ b/.github/scripts/update-homebrew-tap.sh
@@ -34,14 +34,24 @@ sha() {
 
 # --- read checksums ---------------------------------------------------
 
-readonly SHA_DISP_MACOS_ARM="$(sha deepseek-macos-arm64)"
-readonly SHA_TUI_MACOS_ARM="$(sha deepseek-tui-macos-arm64)"
-readonly SHA_DISP_MACOS_X64="$(sha deepseek-macos-x64)"
-readonly SHA_TUI_MACOS_X64="$(sha deepseek-tui-macos-x64)"
-readonly SHA_DISP_LINUX_ARM="$(sha deepseek-linux-arm64)"
-readonly SHA_TUI_LINUX_ARM="$(sha deepseek-tui-linux-arm64)"
-readonly SHA_DISP_LINUX_X64="$(sha deepseek-linux-x64)"
-readonly SHA_TUI_LINUX_X64="$(sha deepseek-tui-linux-x64)"
+# Canonical dispatcher and TUI
+readonly SHA_COD_MACOS_ARM="$(sha codewhale-macos-arm64)"
+readonly SHA_TUI_MACOS_ARM="$(sha codewhale-tui-macos-arm64)"
+readonly SHA_COD_MACOS_X64="$(sha codewhale-macos-x64)"
+readonly SHA_TUI_MACOS_X64="$(sha codewhale-tui-macos-x64)"
+readonly SHA_COD_LINUX_ARM="$(sha codewhale-linux-arm64)"
+readonly SHA_TUI_LINUX_ARM="$(sha codewhale-tui-linux-arm64)"
+readonly SHA_COD_LINUX_X64="$(sha codewhale-linux-x64)"
+readonly SHA_TUI_LINUX_X64="$(sha codewhale-tui-linux-x64)"
+# Legacy shims (removed in v0.9.0)
+readonly SHA_LEG_MACOS_ARM="$(sha deepseek-macos-arm64)"
+readonly SHA_LEG_TUI_MACOS_ARM="$(sha deepseek-tui-macos-arm64)"
+readonly SHA_LEG_MACOS_X64="$(sha deepseek-macos-x64)"
+readonly SHA_LEG_TUI_MACOS_X64="$(sha deepseek-tui-macos-x64)"
+readonly SHA_LEG_LINUX_ARM="$(sha deepseek-linux-arm64)"
+readonly SHA_LEG_TUI_LINUX_ARM="$(sha deepseek-tui-linux-arm64)"
+readonly SHA_LEG_LINUX_X64="$(sha deepseek-linux-x64)"
+readonly SHA_LEG_TUI_LINUX_X64="$(sha deepseek-tui-linux-x64)"
 
 # --- temp dirs --------------------------------------------------------
 
@@ -62,47 +72,81 @@ class DeepseekTui < Formula
 
   on_macos do
     if Hardware::CPU.arm?
-      url "${BASE_URL}/deepseek-macos-arm64", using: :nounzip
-      sha256 "${SHA_DISP_MACOS_ARM}"
+      url "${BASE_URL}/codewhale-macos-arm64", using: :nounzip
+      sha256 "${SHA_COD_MACOS_ARM}"
       resource "tui" do
-        url "${BASE_URL}/deepseek-tui-macos-arm64", using: :nounzip
+        url "${BASE_URL}/codewhale-tui-macos-arm64", using: :nounzip
         sha256 "${SHA_TUI_MACOS_ARM}"
       end
+      resource "legacy-shim" do
+        url "${BASE_URL}/deepseek-macos-arm64", using: :nounzip
+        sha256 "${SHA_LEG_MACOS_ARM}"
+      end
+      resource "legacy-tui-shim" do
+        url "${BASE_URL}/deepseek-tui-macos-arm64", using: :nounzip
+        sha256 "${SHA_LEG_TUI_MACOS_ARM}"
+      end
     else
-      url "${BASE_URL}/deepseek-macos-x64", using: :nounzip
-      sha256 "${SHA_DISP_MACOS_X64}"
+      url "${BASE_URL}/codewhale-macos-x64", using: :nounzip
+      sha256 "${SHA_COD_MACOS_X64}"
       resource "tui" do
-        url "${BASE_URL}/deepseek-tui-macos-x64", using: :nounzip
+        url "${BASE_URL}/codewhale-tui-macos-x64", using: :nounzip
         sha256 "${SHA_TUI_MACOS_X64}"
+      end
+      resource "legacy-shim" do
+        url "${BASE_URL}/deepseek-macos-x64", using: :nounzip
+        sha256 "${SHA_LEG_MACOS_X64}"
+      end
+      resource "legacy-tui-shim" do
+        url "${BASE_URL}/deepseek-tui-macos-x64", using: :nounzip
+        sha256 "${SHA_LEG_TUI_MACOS_X64}"
       end
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
-      url "${BASE_URL}/deepseek-linux-arm64", using: :nounzip
-      sha256 "${SHA_DISP_LINUX_ARM}"
+      url "${BASE_URL}/codewhale-linux-arm64", using: :nounzip
+      sha256 "${SHA_COD_LINUX_ARM}"
       resource "tui" do
-        url "${BASE_URL}/deepseek-tui-linux-arm64", using: :nounzip
+        url "${BASE_URL}/codewhale-tui-linux-arm64", using: :nounzip
         sha256 "${SHA_TUI_LINUX_ARM}"
       end
+      resource "legacy-shim" do
+        url "${BASE_URL}/deepseek-linux-arm64", using: :nounzip
+        sha256 "${SHA_LEG_LINUX_ARM}"
+      end
+      resource "legacy-tui-shim" do
+        url "${BASE_URL}/deepseek-tui-linux-arm64", using: :nounzip
+        sha256 "${SHA_LEG_TUI_LINUX_ARM}"
+      end
     else
-      url "${BASE_URL}/deepseek-linux-x64", using: :nounzip
-      sha256 "${SHA_DISP_LINUX_X64}"
+      url "${BASE_URL}/codewhale-linux-x64", using: :nounzip
+      sha256 "${SHA_COD_LINUX_X64}"
       resource "tui" do
-        url "${BASE_URL}/deepseek-tui-linux-x64", using: :nounzip
+        url "${BASE_URL}/codewhale-tui-linux-x64", using: :nounzip
         sha256 "${SHA_TUI_LINUX_X64}"
+      end
+      resource "legacy-shim" do
+        url "${BASE_URL}/deepseek-linux-x64", using: :nounzip
+        sha256 "${SHA_LEG_LINUX_X64}"
+      end
+      resource "legacy-tui-shim" do
+        url "${BASE_URL}/deepseek-tui-linux-x64", using: :nounzip
+        sha256 "${SHA_LEG_TUI_LINUX_X64}"
       end
     end
   end
 
   def install
-    bin.install Dir["*"].first => "deepseek"
-    resource("tui").stage { bin.install Dir["*"].first => "deepseek-tui" }
+    bin.install Dir["*"].first => "codewhale"
+    resource("tui").stage { bin.install Dir["*"].first => "codewhale-tui" }
+    resource("legacy-shim").stage { bin.install Dir["*"].first => "deepseek" }
+    resource("legacy-tui-shim").stage { bin.install Dir["*"].first => "deepseek-tui" }
   end
 
   test do
-    system "#{bin}/deepseek", "--version"
+    system "#{bin}/codewhale", "--version"
   end
 end
 EOF


### PR DESCRIPTION
The Homebrew formula previously downloaded `deepseek-*` artifacts as the primary binaries. After the rebranding, `deepseek` is a legacy shim that dispatches to `codewhale`, but the `codewhale` binary was not installed by the formula. This caused Homebrew installs to fail with `codewhale not found on PATH`.

This PR updates the formula generation script so the formula installs `codewhale-*` as the primary binaries while still installing the legacy `deepseek-*` shims for backwards compatibility.

Closes #2104

## Summary

- Use `codewhale-*` artifacts as the primary Homebrew binaries.
- Install `codewhale` and `codewhale-tui` as the canonical commands.
- Keep `deepseek` and `deepseek-tui` installed as legacy compatibility shims.
- Update the Homebrew formula test to invoke `codewhale --version`.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features`
- [x] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes