### PR TITLE
feat(tui): add sidebar hover tooltip for truncated Work/Tasks lines

### DIFF
--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -1009,6 +1009,22 @@ pub struct SessionState {
     pub last_cache_inspection: Option<PromptInspection>,
 }
 
+/// Sidebar hover state for mouse tooltip support.
+#[derive(Debug, Clone, Default)]
+pub struct SidebarHoverState {
+    /// Rendered sections with their areas and full-text lines.
+    pub sections: Vec<SidebarHoverSection>,
+}
+
+/// Per-section metadata for sidebar hover detection.
+#[derive(Debug, Clone)]
+pub struct SidebarHoverSection {
+    /// Content area within the section (inside border + padding).
+    pub content_area: Rect,
+    /// Full original text for each content line rendered.
+    pub lines: Vec<String>,
+}
+
 impl Default for SessionState {
     fn default() -> Self {
         Self {
@@ -1156,6 +1172,12 @@ pub struct App {
     pub transcript_spacing: TranscriptSpacing,
     pub sidebar_width_percent: u16,
     pub sidebar_focus: SidebarFocus,
+    /// Sidebar hover state for mouse tooltip support.
+    pub sidebar_hover: SidebarHoverState,
+    /// Current hover tooltip text, if any.
+    pub sidebar_hover_tooltip: Option<String>,
+    /// Last known mouse position for tooltip placement.
+    pub last_mouse_pos: Option<(u16, u16)>,
     /// Whether the session-context panel is enabled (#504).
     pub context_panel: bool,
     /// File-tree pane state. `None` when hidden; `Some` when visible.
@@ -1830,6 +1852,9 @@ impl App {
             transcript_spacing,
             sidebar_width_percent,
             sidebar_focus,
+            sidebar_hover: SidebarHoverState::default(),
+            sidebar_hover_tooltip: None,
+            last_mouse_pos: None,
             context_panel: settings.context_panel,
             file_tree: None,
             file_tree_visible: false,

--- a/crates/tui/src/tui/mouse_ui.rs
+++ b/crates/tui/src/tui/mouse_ui.rs
@@ -53,6 +53,43 @@ pub(crate) fn handle_mouse_event(app: &mut App, mouse: MouseEvent) -> Vec<ViewEv
     }
 
     match mouse.kind {
+        MouseEventKind::Moved => {
+            // Update last mouse position for tooltip rendering.
+            app.last_mouse_pos = Some((mouse.column, mouse.row));
+
+            // Check sidebar sections for hover tooltip.
+            let mut found = false;
+            for section in &app.sidebar_hover.sections {
+                if mouse.column >= section.content_area.x
+                    && mouse.column
+                        < section
+                            .content_area
+                            .x
+                            .saturating_add(section.content_area.width)
+                    && mouse.row >= section.content_area.y
+                    && mouse.row
+                        < section
+                            .content_area
+                            .y
+                            .saturating_add(section.content_area.height)
+                {
+                    let line_idx = (mouse.row.saturating_sub(section.content_area.y)) as usize;
+                    if line_idx < section.lines.len() {
+                        let new_tooltip = section.lines[line_idx].clone();
+                        if app.sidebar_hover_tooltip.as_deref() != Some(&new_tooltip) {
+                            app.sidebar_hover_tooltip = Some(new_tooltip);
+                            app.needs_redraw = true;
+                        }
+                        found = true;
+                        break;
+                    }
+                }
+            }
+            if !found && app.sidebar_hover_tooltip.is_some() {
+                app.sidebar_hover_tooltip = None;
+                app.needs_redraw = true;
+            }
+        }
         MouseEventKind::ScrollUp => {
             let update = app.viewport.mouse_scroll.on_scroll(ScrollDirection::Up);
             app.viewport.pending_scroll_delta = app

--- a/crates/tui/src/tui/sidebar.rs
+++ b/crates/tui/src/tui/sidebar.rs
@@ -22,7 +22,7 @@ use crate::tools::plan::StepStatus;
 use crate::tools::subagent::SubAgentStatus;
 use crate::tools::todo::TodoStatus;
 
-use super::app::{App, SidebarFocus, TaskPanelEntry};
+use super::app::{App, SidebarFocus, SidebarHoverSection, SidebarHoverState, TaskPanelEntry};
 use super::history::{GenericToolCell, HistoryCell, ToolCell, ToolStatus, summarize_tool_output};
 use super::subagent_routing::active_fanout_counts;
 use super::ui_text::{concise_shell_command_label, truncate_line_to_width};
@@ -35,7 +35,9 @@ const RECENT_TOOL_SCAN_LIMIT: usize = 24;
 const ACTIVE_TOOL_COMPLETED_ROW_TTL: Duration = Duration::from_secs(8);
 const ACTIVE_TOOL_STALE_RUNNING_ROW_TTL: Duration = Duration::from_secs(600);
 
-pub fn render_sidebar(f: &mut Frame, area: Rect, app: &App) {
+pub fn render_sidebar(f: &mut Frame, area: Rect, app: &mut App) {
+    // Clear hover state at the start of each render
+    app.sidebar_hover = SidebarHoverState::default();
     if area.width < 24 || area.height < 8 {
         // Paint a styled block over the area so stale cells from a previous
         // (wider) frame don't persist as bleed-through artifacts (#400).
@@ -60,7 +62,7 @@ pub fn render_sidebar(f: &mut Frame, area: Rect, app: &App) {
 /// Build the Auto-mode panel stack. Empty panels collapse to zero height so
 /// non-empty ones get the full sidebar real estate. Work appears when it has
 /// useful content, or as the one quiet empty state when nothing else is active.
-fn render_sidebar_auto(f: &mut Frame, area: Rect, app: &App) {
+fn render_sidebar_auto(f: &mut Frame, area: Rect, app: &mut App) {
     let work_has_content = sidebar_work_summary(app).has_useful_content();
     let tasks_empty = app.runtime_turn_id.is_none() && app.task_panel.is_empty();
     let agents_empty = app.subagent_cache.is_empty()
@@ -557,7 +559,7 @@ fn work_panel_empty_hint(content_width: usize) -> String {
     truncate_line_to_width("No active work", content_width)
 }
 
-fn render_sidebar_work(f: &mut Frame, area: Rect, app: &App) {
+fn render_sidebar_work(f: &mut Frame, area: Rect, app: &mut App) {
     if area.height < 3 {
         return;
     }
@@ -572,10 +574,11 @@ fn render_sidebar_work(f: &mut Frame, area: Rect, app: &App) {
         app.ui_theme.mode,
     );
 
-    render_sidebar_section(f, area, "Work", lines, app);
+    let full_texts: Vec<String> = lines.iter().map(|l| spans_to_text(&l.spans)).collect();
+    render_sidebar_section(f, area, "Work", lines, full_texts, app);
 }
 
-fn render_sidebar_tasks(f: &mut Frame, area: Rect, app: &App) {
+fn render_sidebar_tasks(f: &mut Frame, area: Rect, app: &mut App) {
     if area.height < 3 {
         return;
     }
@@ -584,7 +587,8 @@ fn render_sidebar_tasks(f: &mut Frame, area: Rect, app: &App) {
     let usable_rows = area.height.saturating_sub(3) as usize;
     let lines = task_panel_lines(app, content_width.max(1), usable_rows.max(1));
 
-    render_sidebar_section(f, area, "Tasks", lines, app);
+    let full_texts: Vec<String> = lines.iter().map(|l| spans_to_text(&l.spans)).collect();
+    render_sidebar_section(f, area, "Tasks", lines, full_texts, app);
 }
 
 #[derive(Debug, Clone)]
@@ -1374,7 +1378,7 @@ fn duration_ms(duration: Duration) -> u64 {
     u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
 }
 
-fn render_sidebar_subagents(f: &mut Frame, area: Rect, app: &App) {
+fn render_sidebar_subagents(f: &mut Frame, area: Rect, app: &mut App) {
     if area.height < 3 {
         return;
     }
@@ -1421,7 +1425,7 @@ fn render_sidebar_subagents(f: &mut Frame, area: Rect, app: &App) {
     let rows = sidebar_agent_rows(app);
     let lines = subagent_panel_lines(&summary, &rows, content_width, usable_rows.max(1));
 
-    render_sidebar_section(f, area, "Agents", lines, app);
+    render_sidebar_section(f, area, "Agents", lines, Vec::new(), app);
 }
 
 /// Minimal projection of the data the sub-agent sidebar needs. Lifted out
@@ -1659,7 +1663,7 @@ fn agent_status_marker(status: &str) -> (&'static str, ratatui::style::Color) {
 /// cost, MCP server count, LSP toggle state, cycle count, and memory
 /// file size + mtime. Each section is a compact one-liner so the panel
 /// reads as a dashboard rather than a scrolling list.
-fn render_context_panel(f: &mut Frame, area: Rect, app: &App) {
+fn render_context_panel(f: &mut Frame, area: Rect, app: &mut App) {
     if area.height < 3 {
         return;
     }
@@ -1789,7 +1793,15 @@ fn render_context_panel(f: &mut Frame, area: Rect, app: &App) {
         )));
     }
 
-    render_sidebar_section(f, area, "Session", lines, app);
+    render_sidebar_section(f, area, "Session", lines, Vec::new(), app);
+}
+
+fn spans_to_text(spans: &[Span<'_>]) -> String {
+    let mut s = String::new();
+    for span in spans {
+        s.push_str(span.content.as_ref());
+    }
+    s
 }
 
 fn render_sidebar_section(
@@ -1797,7 +1809,8 @@ fn render_sidebar_section(
     area: Rect,
     title: &str,
     lines: Vec<Line<'static>>,
-    app: &App,
+    full_texts: Vec<String>,
+    app: &mut App,
 ) {
     if area.width < 4 || area.height < 3 {
         // Clear stale cells before bailing out (#400).
@@ -1808,6 +1821,19 @@ fn render_sidebar_section(
     }
 
     let theme = Theme::for_palette_mode(app.ui_theme.mode);
+
+    // Record hover metadata for mouse tooltip support.
+    let padding = theme.section_padding;
+    let content_area = Rect {
+        x: area.x + 1 + padding.left,
+        y: area.y + 1 + padding.top,
+        width: area.width.saturating_sub(2 + padding.left + padding.right),
+        height: area.height.saturating_sub(2 + padding.top + padding.bottom),
+    };
+    app.sidebar_hover.sections.push(SidebarHoverSection {
+        content_area,
+        lines: full_texts,
+    });
     // Truncate the panel title so it always fits within the section width
     // even after a resize. The title occupies up to 4 chars of border chrome
     // (two spaces + one space on each side), so the max title length is
@@ -1850,9 +1876,10 @@ fn render_sidebar_section(
 mod tests {
     use super::{
         ACTIVE_TOOL_COMPLETED_ROW_TTL, ACTIVE_TOOL_STALE_RUNNING_ROW_TTL, AutoSidebarPanel,
-        AutoSidebarState, SidebarAgentRow, SidebarSubagentSummary, SidebarWorkChecklistItem,
-        SidebarWorkStrategyStep, SidebarWorkSummary, auto_sidebar_panels, subagent_panel_lines,
-        task_panel_lines, work_panel_empty_hint, work_panel_lines,
+        AutoSidebarState, SidebarAgentRow, SidebarHoverSection, SidebarHoverState,
+        SidebarSubagentSummary, SidebarWorkChecklistItem, SidebarWorkStrategyStep,
+        SidebarWorkSummary, auto_sidebar_panels, subagent_panel_lines, task_panel_lines,
+        work_panel_empty_hint, work_panel_lines,
     };
     use crate::config::Config;
     use crate::palette::PaletteMode;
@@ -2663,5 +2690,49 @@ mod tests {
                 .any(|line| line.contains("RLM foreground work active")),
             "RLM work must be visible in Agents panel: {text:?}"
         );
+    }
+
+    // ---- Sidebar hover tooltip tests ----
+
+    #[test]
+    fn sidebar_hover_state_default_is_empty() {
+        let state = SidebarHoverState::default();
+        assert!(state.sections.is_empty());
+    }
+
+    #[test]
+    fn sidebar_hover_section_stores_lines() {
+        use ratatui::layout::Rect;
+        let section = SidebarHoverSection {
+            content_area: Rect::new(1, 1, 38, 8),
+            lines: vec!["line 1".to_string(), "line 2".to_string()],
+        };
+        assert_eq!(section.lines.len(), 2);
+        assert_eq!(section.lines[0], "line 1");
+        assert!(section.content_area.x > 0);
+    }
+
+    #[test]
+    fn hover_line_matching_respects_content_area_offset() {
+        use ratatui::layout::Rect;
+        let section = SidebarHoverSection {
+            content_area: Rect::new(62, 2, 36, 6),
+            lines: vec![
+                "first".to_string(),
+                "second".to_string(),
+                "third".to_string(),
+            ],
+        };
+
+        // Mouse within content area, first line
+        let line_idx = (2u16.saturating_sub(section.content_area.y)) as usize;
+        assert_eq!(section.lines[line_idx], "first");
+
+        // Mouse within content area, second line
+        let line_idx = (3u16.saturating_sub(section.content_area.y)) as usize;
+        assert_eq!(section.lines[line_idx], "second");
+
+        // Mouse outside content area (above) — row < content_area.y
+        assert!((1u16) < section.content_area.y);
     }
 }

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -5813,6 +5813,34 @@ fn render(f: &mut Frame, app: &mut App) {
 
         if let Some(sidebar_area) = sidebar_area {
             super::sidebar::render_sidebar(f, sidebar_area, app);
+
+            // Render sidebar hover tooltip if active.
+            if let Some(ref tooltip_text) = app.sidebar_hover_tooltip
+                && let Some((mouse_col, mouse_row)) = app.last_mouse_pos
+            {
+                let text_width = (tooltip_text.len() as u16).clamp(10, 60);
+                let tooltip_height = 1u16;
+                let x = mouse_col
+                    .saturating_add(2)
+                    .min(size.width.saturating_sub(text_width));
+                let y = mouse_row
+                    .saturating_sub(1)
+                    .min(size.height.saturating_sub(tooltip_height));
+                if text_width > 0 && tooltip_height > 0 {
+                    let tooltip_area = Rect {
+                        x,
+                        y,
+                        width: text_width,
+                        height: tooltip_height,
+                    };
+                    let tooltip = ratatui::widgets::Paragraph::new(tooltip_text.as_str()).style(
+                        Style::default()
+                            .bg(palette::STATUS_WARNING)
+                            .fg(palette::TEXT_MUTED),
+                    );
+                    f.render_widget(tooltip, tooltip_area);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Resubmitted from PR #1420.

## Summary

When sidebar content (Work panel goals / checklists / strategy steps,
Tasks panel labels) is truncated to fit the available panel height,
hovering over a truncated line with the mouse now shows the full
original text as a one-line tooltip popup.

## Changes

| File | Δ | Description |
|------|---|-------------|
| `crates/tui/src/tui/app.rs` | +25 | Add `SidebarHoverState` / `SidebarHoverSection` structs and `sidebar_hover`, `sidebar_hover_tooltip`, `last_mouse_pos` fields to `App` |
| `crates/tui/src/tui/sidebar.rs` | +101/−15 | Change all render signatures from `&App` to `&mut App`; record hover metadata via `full_texts` parameter in `render_sidebar_section`; add `spans_to_text` helper; add 3 unit tests |
| `crates/tui/src/tui/mouse_ui.rs` | +37 | Add `MouseEventKind::Moved` arm in `handle_mouse_event` — updates `last_mouse_pos` and detects hover over sidebar content areas |
| `crates/tui/src/tui/ui.rs` | +28 | Render tooltip `Paragraph` overlay after sidebar (warning background, muted foreground) |

## Test results

- **Build**: `cargo build -p codewhale-tui` — ✅ passed
- **Full suite**: `cargo test -p codewhale-tui` — 3330 passed, 4 pre-existing failures
- **Sidebar**: 40/40 passed (incl. 3 new hover tests)

## Notes

- The current `main` has merged Plan + Todos into the Work panel and
  moved mouse event handling to `mouse_ui.rs`. Changes are adapted
  accordingly.
- Tooltip only activates when the sidebar is visible and mouse moves
  within a section's content area.