### PR TITLE
feat: embed user prompt in snapshot labels for readable /restore listings

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -933,11 +933,17 @@ impl Engine {
         // work on the blocking pool so the async runtime stays responsive;
         // failure is non-fatal (the helper logs at WARN).
         if self.config.snapshots_enabled {
+            // Clone the user prompt now — `content` is moved into
+            // `user_text_message_with_turn_metadata` below, so we need
+            // a copy for both pre- and post-turn snapshot labels. The
+            // label carries a truncated first line so `/restore`
+            // listings are human-readable.
+            let snapshot_prompt = content.clone();
             let pre_workspace = self.session.workspace.clone();
             let pre_seq = self.turn_counter;
             let pre_cap = self.config.snapshots_max_workspace_bytes;
             let _ = tokio::task::spawn_blocking(move || {
-                pre_turn_snapshot(&pre_workspace, pre_seq, pre_cap)
+                pre_turn_snapshot(&pre_workspace, pre_seq, pre_cap, Some(&snapshot_prompt))
             })
             .await;
         }
@@ -947,6 +953,10 @@ impl Engine {
         // so the footer doesn't display a stale failure row across
         // turns (#499).
         crate::retry_status::clear();
+
+        // Clone user prompt for post-turn snapshot label before `content`
+        // is moved into `user_text_message_with_turn_metadata` below.
+        let snapshot_prompt_post = content.clone();
 
         // Check if we have the appropriate client
         if self.deepseek_client.is_none() {
@@ -1157,11 +1167,13 @@ impl Engine {
         // paste immediately (#234). The git work proceeds on the blocking
         // pool without forcing the engine loop to await it.
         if self.config.snapshots_enabled {
+            // `snapshot_prompt_post` was cloned from `content` above,
+            // before `content` was moved into the session messages.
             let post_workspace = self.session.workspace.clone();
             let post_seq = self.turn_counter;
             let post_cap = self.config.snapshots_max_workspace_bytes;
             crate::utils::spawn_blocking_supervised("post-turn-snapshot", move || {
-                post_turn_snapshot(&post_workspace, post_seq, post_cap);
+                post_turn_snapshot(&post_workspace, post_seq, post_cap, Some(&snapshot_prompt_post));
             });
         }
     }

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -1173,7 +1173,12 @@ impl Engine {
             let post_seq = self.turn_counter;
             let post_cap = self.config.snapshots_max_workspace_bytes;
             crate::utils::spawn_blocking_supervised("post-turn-snapshot", move || {
-                post_turn_snapshot(&post_workspace, post_seq, post_cap, Some(&snapshot_prompt_post));
+                post_turn_snapshot(
+                    &post_workspace,
+                    post_seq,
+                    post_cap,
+                    Some(&snapshot_prompt_post),
+                );
             });
         }
     }

--- a/crates/tui/src/core/turn.rs
+++ b/crates/tui/src/core/turn.rs
@@ -128,16 +128,45 @@ fn add_optional_usage(total: Option<u32>, delta: Option<u32>) -> Option<u32> {
     }
 }
 
+/// Maximum characters of the user prompt snippet to embed in a snapshot
+/// label. Longer prompts are truncated with an ellipsis.
+const USER_PROMPT_LABEL_MAX: usize = 100;
+
+/// Format a snapshot label that includes the user prompt for readability
+/// in `/restore` listings.
+///
+/// Takes the first line of the prompt (up to `USER_PROMPT_LABEL_MAX`
+/// characters) and appends it to the traditional `type:seq` label so
+/// users can identify which turn each snapshot belongs to.
+fn format_snapshot_label(prefix: &str, turn_seq: u64, user_prompt: Option<&str>) -> String {
+    let base = format!("{prefix}:{turn_seq}");
+    match user_prompt {
+        None | Some("") => base,
+        Some(prompt) => {
+            let first_line = prompt.lines().next().unwrap_or("");
+            let truncated: String = first_line.chars().take(USER_PROMPT_LABEL_MAX).collect();
+            if truncated.chars().count() < first_line.chars().count() {
+                format!("{base}: {truncated}…")
+            } else {
+                format!("{base}: {truncated}")
+            }
+        }
+    }
+}
+
 /// Take a `pre-turn:<seq>` workspace snapshot.
 ///
 /// `cap_bytes` is the workspace-size ceiling that gates first-init
 /// (passed through to [`SnapshotRepo::open_or_init_with_cap`]); pass
 /// `0` to disable the cap.
+/// `user_prompt` is an optional snippet of the user's message for this
+/// turn, embedded in the snapshot label so `/restore` listings are
+/// human-readable.
 ///
 /// Returns the snapshot SHA on success, `None` on any error. Errors are
 /// logged at WARN; the turn loop must not block on this.
-pub fn pre_turn_snapshot(workspace: &Path, turn_seq: u64, cap_bytes: u64) -> Option<String> {
-    snapshot_with_label(workspace, &format!("pre-turn:{turn_seq}"), cap_bytes)
+pub fn pre_turn_snapshot(workspace: &Path, turn_seq: u64, cap_bytes: u64, user_prompt: Option<&str>) -> Option<String> {
+    snapshot_with_label(workspace, &format_snapshot_label("pre-turn", turn_seq, user_prompt), cap_bytes)
 }
 
 /// Take a `tool:<call_id>` workspace snapshot, taken before executing a
@@ -154,8 +183,8 @@ pub fn pre_tool_snapshot(workspace: &Path, call_id: &str, cap_bytes: u64) -> Opt
 
 /// Take a `post-turn:<seq>` workspace snapshot. Same failure model as
 /// [`pre_turn_snapshot`].
-pub fn post_turn_snapshot(workspace: &Path, turn_seq: u64, cap_bytes: u64) -> Option<String> {
-    snapshot_with_label(workspace, &format!("post-turn:{turn_seq}"), cap_bytes)
+pub fn post_turn_snapshot(workspace: &Path, turn_seq: u64, cap_bytes: u64, user_prompt: Option<&str>) -> Option<String> {
+    snapshot_with_label(workspace, &format_snapshot_label("post-turn", turn_seq, user_prompt), cap_bytes)
 }
 
 fn snapshot_with_label(workspace: &Path, label: &str, cap_bytes: u64) -> Option<String> {

--- a/crates/tui/src/core/turn.rs
+++ b/crates/tui/src/core/turn.rs
@@ -165,8 +165,17 @@ fn format_snapshot_label(prefix: &str, turn_seq: u64, user_prompt: Option<&str>)
 ///
 /// Returns the snapshot SHA on success, `None` on any error. Errors are
 /// logged at WARN; the turn loop must not block on this.
-pub fn pre_turn_snapshot(workspace: &Path, turn_seq: u64, cap_bytes: u64, user_prompt: Option<&str>) -> Option<String> {
-    snapshot_with_label(workspace, &format_snapshot_label("pre-turn", turn_seq, user_prompt), cap_bytes)
+pub fn pre_turn_snapshot(
+    workspace: &Path,
+    turn_seq: u64,
+    cap_bytes: u64,
+    user_prompt: Option<&str>,
+) -> Option<String> {
+    snapshot_with_label(
+        workspace,
+        &format_snapshot_label("pre-turn", turn_seq, user_prompt),
+        cap_bytes,
+    )
 }
 
 /// Take a `tool:<call_id>` workspace snapshot, taken before executing a
@@ -183,8 +192,17 @@ pub fn pre_tool_snapshot(workspace: &Path, call_id: &str, cap_bytes: u64) -> Opt
 
 /// Take a `post-turn:<seq>` workspace snapshot. Same failure model as
 /// [`pre_turn_snapshot`].
-pub fn post_turn_snapshot(workspace: &Path, turn_seq: u64, cap_bytes: u64, user_prompt: Option<&str>) -> Option<String> {
-    snapshot_with_label(workspace, &format_snapshot_label("post-turn", turn_seq, user_prompt), cap_bytes)
+pub fn post_turn_snapshot(
+    workspace: &Path,
+    turn_seq: u64,
+    cap_bytes: u64,
+    user_prompt: Option<&str>,
+) -> Option<String> {
+    snapshot_with_label(
+        workspace,
+        &format_snapshot_label("post-turn", turn_seq, user_prompt),
+        cap_bytes,
+    )
 }
 
 fn snapshot_with_label(workspace: &Path, label: &str, cap_bytes: u64) -> Option<String> {


### PR DESCRIPTION
Resubmitted from PR #1798.

## Problem

`/restore` lists snapshots with opaque labels like `pre-turn:1` and
`post-turn:1`. Users can't tell which conversation turn each snapshot
belongs to or which one to restore.

## Solution

Embed the first line of the user's input prompt (truncated to 100 chars)
into each snapshot's git commit label, making `/restore` listings
immediately human-readable.

## Before / After

```
Before:
  #1   abcdef12  post-turn:3
  #2   12345678  pre-turn:3

After:
  #1   abcdef12  post-turn:3: 帮我改进 /restore 命令
  #2   12345678  pre-turn:3: 帮我改进 /restore 命令
```

## Changes

| File | Δ | Description |
|------|---|-------------|
| `crates/tui/src/core/turn.rs` | +55/−4 | Add `format_snapshot_label()` helper: `type:N: <first line of user prompt>`; truncates at 100 chars with `…`; falls back to old format when prompt is empty; add optional `user_prompt: Option<&str>` param to `pre_turn_snapshot` and `post_turn_snapshot` |
| `crates/tui/src/core/engine.rs` | +21/−2 | Clone `content` before it's moved into session messages, pass to both pre and post turn snapshot calls |

## Backward Compatibility

- `revert_turn` tool's `starts_with("pre-turn:")` filter is unaffected
- Existing old-format snapshots display normally (just without a prompt suffix)
- When `user_prompt: None`, label format is identical to the previous version

## Test results

| Check | Result |
|-------|--------|
| `cargo build` | ✅ Passed |
| snapshot tests | 48/48 passed |
| turn tests | 256/256 passed |
| revert_turn tests | 4/4 passed |