### PR TITLE
fix(cli): avoid default env overrides for profiles

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1464,33 +1464,28 @@ fn build_tui_command(
         );
     }
 
-    cmd.env("DEEPSEEK_MODEL", &resolved_runtime.model);
-    cmd.env("DEEPSEEK_BASE_URL", &resolved_runtime.base_url);
-    cmd.env("DEEPSEEK_PROVIDER", resolved_runtime.provider.as_str());
-    if let Some(auth_mode) = resolved_runtime.auth_mode.as_ref() {
-        cmd.env("DEEPSEEK_AUTH_MODE", auth_mode);
+    if let Some(provider) = cli.provider {
+        let provider: ProviderKind = provider.into();
+        cmd.env("DEEPSEEK_PROVIDER", provider.as_str());
     }
-    if !resolved_runtime.http_headers.is_empty() {
-        let encoded = resolved_runtime
-            .http_headers
-            .iter()
-            .map(|(name, value)| format!("{}={}", name.trim(), value.trim()))
-            .collect::<Vec<_>>()
-            .join(",");
-        cmd.env("DEEPSEEK_HTTP_HEADERS", encoded);
-    }
-    if let Some(api_key) = resolved_runtime.api_key.as_ref() {
+    if matches!(
+        resolved_runtime.api_key_source,
+        Some(RuntimeApiKeySource::Keyring)
+    ) && let Some(api_key) = resolved_runtime.api_key.as_ref()
+    {
+        // TUI reloads auth_mode from config/profile, but it does not re-query the
+        // platform keyring on normal startup. Bridge only the recovered secret;
+        // replaying auth_mode here would turn it back into a profile override.
         cmd.env("DEEPSEEK_API_KEY", api_key);
         for var in provider_env_vars(resolved_runtime.provider) {
             if *var != "DEEPSEEK_API_KEY" {
                 cmd.env(var, api_key);
             }
         }
-        let source = resolved_runtime
-            .api_key_source
-            .unwrap_or(RuntimeApiKeySource::Env)
-            .as_env_value();
-        cmd.env("DEEPSEEK_API_KEY_SOURCE", source);
+        cmd.env(
+            "DEEPSEEK_API_KEY_SOURCE",
+            RuntimeApiKeySource::Keyring.as_env_value(),
+        );
     }
 
     if let Some(model) = cli.model.as_ref() {
@@ -2631,14 +2626,6 @@ mod tests {
             Some("openai")
         );
         assert_eq!(
-            command_env(&cmd, "DEEPSEEK_MODEL").as_deref(),
-            Some("glm-5")
-        );
-        assert_eq!(
-            command_env(&cmd, "DEEPSEEK_BASE_URL").as_deref(),
-            Some("https://openai-compatible.example/v4")
-        );
-        assert_eq!(
             command_env(&cmd, "DEEPSEEK_API_KEY").as_deref(),
             Some("resolved-openai-key")
         );
@@ -2650,10 +2637,6 @@ mod tests {
             command_env(&cmd, "DEEPSEEK_API_KEY_SOURCE").as_deref(),
             Some("keyring")
         );
-        assert_eq!(
-            command_env(&cmd, "DEEPSEEK_AUTH_MODE").as_deref(),
-            Some("api_key")
-        );
         let args: Vec<String> = cmd
             .get_args()
             .map(|arg| arg.to_string_lossy().into_owned())
@@ -2662,6 +2645,55 @@ mod tests {
             args.windows(2)
                 .any(|pair| pair == ["--workspace", "/tmp/codewhale-workspace"]),
             "expected workspace forwarding in args: {args:?}"
+        );
+    }
+
+    #[test]
+    fn build_tui_command_does_not_export_default_runtime_overrides_for_profiles() {
+        let _lock = env_lock();
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let custom = dir
+            .path()
+            .join(format!("custom-tui{}", std::env::consts::EXE_SUFFIX));
+        std::fs::write(&custom, b"").unwrap();
+        let custom_str = custom.to_string_lossy().into_owned();
+        let _bin = ScopedEnvVar::set("DEEPSEEK_TUI_BIN", &custom_str);
+
+        let cli = parse_ok(&["deepseek", "--profile", "google"]);
+        let mut resolved_headers = std::collections::BTreeMap::new();
+        resolved_headers.insert("X-From-Base".to_string(), "base".to_string());
+        let resolved = ResolvedRuntimeOptions {
+            provider: ProviderKind::Deepseek,
+            model: "deepseek-v4-pro".to_string(),
+            api_key: Some("config-file-key".to_string()),
+            api_key_source: Some(RuntimeApiKeySource::ConfigFile),
+            base_url: "https://api.deepseek.com/beta".to_string(),
+            auth_mode: Some("api_key".to_string()),
+            output_mode: None,
+            log_level: None,
+            telemetry: false,
+            approval_policy: None,
+            sandbox_mode: None,
+            yolo: None,
+            http_headers: resolved_headers,
+        };
+
+        let cmd = build_tui_command(&cli, &resolved, Vec::new()).expect("command");
+
+        assert_eq!(command_env(&cmd, "DEEPSEEK_PROVIDER"), None);
+        assert_eq!(command_env(&cmd, "DEEPSEEK_MODEL"), None);
+        assert_eq!(command_env(&cmd, "DEEPSEEK_BASE_URL"), None);
+        assert_eq!(command_env(&cmd, "DEEPSEEK_API_KEY"), None);
+        assert_eq!(command_env(&cmd, "DEEPSEEK_API_KEY_SOURCE"), None);
+        assert_eq!(command_env(&cmd, "DEEPSEEK_AUTH_MODE"), None);
+        assert_eq!(command_env(&cmd, "DEEPSEEK_HTTP_HEADERS"), None);
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+        assert!(
+            args.windows(2).any(|pair| pair == ["--profile", "google"]),
+            "expected profile forwarding in args: {args:?}"
         );
     }
 
@@ -2689,7 +2721,7 @@ mod tests {
             provider: ProviderKind::Moonshot,
             model: "kimi-k2.6".to_string(),
             api_key: Some("resolved-kimi-key".to_string()),
-            api_key_source: Some(RuntimeApiKeySource::Env),
+            api_key_source: Some(RuntimeApiKeySource::Keyring),
             base_url: "https://api.moonshot.ai/v1".to_string(),
             auth_mode: Some("api_key".to_string()),
             output_mode: None,
@@ -2711,10 +2743,6 @@ mod tests {
             Some("kimi-k2.6")
         );
         assert_eq!(
-            command_env(&cmd, "DEEPSEEK_BASE_URL").as_deref(),
-            Some("https://api.moonshot.ai/v1")
-        );
-        assert_eq!(
             command_env(&cmd, "DEEPSEEK_API_KEY").as_deref(),
             Some("resolved-kimi-key")
         );
@@ -2728,12 +2756,67 @@ mod tests {
         );
         assert_eq!(
             command_env(&cmd, "DEEPSEEK_API_KEY_SOURCE").as_deref(),
-            Some("env")
+            Some("keyring")
+        );
+        assert_eq!(command_env(&cmd, "DEEPSEEK_AUTH_MODE"), None);
+    }
+
+    #[test]
+    fn build_tui_command_exports_explicit_provider_model_and_base_url() {
+        let _lock = env_lock();
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let custom = dir
+            .path()
+            .join(format!("custom-tui{}", std::env::consts::EXE_SUFFIX));
+        std::fs::write(&custom, b"").unwrap();
+        let custom_str = custom.to_string_lossy().into_owned();
+        let _bin = ScopedEnvVar::set("DEEPSEEK_TUI_BIN", &custom_str);
+
+        let cli = parse_ok(&[
+            "deepseek",
+            "--profile",
+            "google",
+            "--provider",
+            "openai",
+            "--model",
+            "glm-5",
+            "--base-url",
+            "https://openai-compatible.example/v4",
+        ]);
+        let resolved = ResolvedRuntimeOptions {
+            provider: ProviderKind::Openai,
+            model: "glm-5".to_string(),
+            api_key: None,
+            api_key_source: None,
+            base_url: "https://openai-compatible.example/v4".to_string(),
+            auth_mode: None,
+            output_mode: None,
+            log_level: None,
+            telemetry: false,
+            approval_policy: None,
+            sandbox_mode: None,
+            yolo: None,
+            http_headers: std::collections::BTreeMap::new(),
+        };
+
+        let cmd = build_tui_command(&cli, &resolved, Vec::new()).expect("command");
+
+        assert_eq!(
+            command_env(&cmd, "DEEPSEEK_PROVIDER").as_deref(),
+            Some("openai")
+        );
+        assert_eq!(
+            command_env(&cmd, "DEEPSEEK_MODEL").as_deref(),
+            Some("glm-5")
+        );
+        assert_eq!(
+            command_env(&cmd, "DEEPSEEK_BASE_URL").as_deref(),
+            Some("https://openai-compatible.example/v4")
         );
     }
 
     #[test]
-    fn build_tui_command_forwards_provider_env_vars_for_all_providers() {
+    fn build_tui_command_forwards_provider_keyring_env_vars_for_all_providers() {
         let _lock = env_lock();
         let dir = tempfile::TempDir::new().expect("tempdir");
         let custom = dir
@@ -2788,7 +2871,7 @@ mod tests {
                 provider,
                 model: "test-model".to_string(),
                 api_key: Some("test-key".to_string()),
-                api_key_source: Some(RuntimeApiKeySource::Env),
+                api_key_source: Some(RuntimeApiKeySource::Keyring),
                 base_url: "http://localhost:8000/v1".to_string(),
                 auth_mode: Some("api_key".to_string()),
                 output_mode: None,
@@ -2815,10 +2898,19 @@ mod tests {
                     "{flag}: {var} not forwarded"
                 );
             }
+            assert_eq!(
+                command_env(&cmd, "DEEPSEEK_API_KEY_SOURCE").as_deref(),
+                Some("keyring"),
+                "{flag}: expected keyring source bridge"
+            );
+            assert_eq!(
+                command_env(&cmd, "DEEPSEEK_AUTH_MODE"),
+                None,
+                "{flag}: auth mode should come from config/profile, not env handoff"
+            );
         }
     }
 
-    #[test]
     fn parses_top_level_prompt_flag_for_canonical_one_shot() {
         let cli = parse_ok(&["deepseek", "-p", "Reply with exactly OK."]);
 

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -2912,6 +2912,7 @@ mod tests {
         }
     }
 
+    #[test]
     fn parses_top_level_prompt_flag_for_canonical_one_shot() {
         let cli = parse_ok(&["deepseek", "-p", "Reply with exactly OK."]);
 

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -2637,6 +2637,7 @@ mod tests {
             command_env(&cmd, "DEEPSEEK_API_KEY_SOURCE").as_deref(),
             Some("keyring")
         );
+        assert_eq!(command_env(&cmd, "DEEPSEEK_AUTH_MODE"), None);
         let args: Vec<String> = cmd
             .get_args()
             .map(|arg| arg.to_string_lossy().into_owned())


### PR DESCRIPTION
## Summary
- stop exporting dispatcher-resolved default provider/model/base URL as TUI env overrides
- keep explicit CLI provider/model/base URL flags working as intentional overrides
- add regression coverage for profile startup handoff and explicit override behavior

Closes #2114

## Verification
- cargo fmt --all --check
- git diff --check
- cargo test -p codewhale-cli build_tui_command
- cargo check -p codewhale-cli

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where the CLI dispatcher-resolved defaults (model, base_url, provider, auth_mode, http_headers) were unconditionally exported as environment variables when spawning the TUI, causing them to override profile-specific settings loaded by the TUI itself. The fix narrows handoff to only explicit CLI flags and keyring-sourced secrets.

- Resolved runtime values (model, base_url, auth_mode, http_headers) are no longer injected as env overrides; the TUI now reads these from its own profile/config merge.
- The keyring path is preserved: when the API key came from the platform keyring, the secret and source tag are still bridged because the TUI does not re-query the keyring on startup.
- New regression tests cover profile startup handoff (no stray overrides) and explicit override forwarding.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for the profile-override regression, but the explicit --api-key path drops provider-specific key vars for most providers.

The core fix is correct and well-tested. However, the new cli.api_key block manually enumerates only Openai, Atlascloud, and WanjieArk (partially) instead of using provider_env_vars(). Anyone who passes --provider moonshot --api-key or any of the other eight supported providers will have their provider-specific env var missing in the TUI process, which is a regression from the previous code that used provider_env_vars() for all sources.

crates/cli/src/lib.rs — specifically the cli.api_key forwarding block (lines 1512–1524)
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/cli/src/lib.rs | Correctly stops forwarding dispatcher-resolved defaults as TUI env overrides; keyring and explicit-flag paths are sound. However, the new cli.api_key block manually enumerates only three providers instead of calling provider_env_vars(), leaving Moonshot, NvidiaNim, Openrouter, Novita, Fireworks, SGLang, vLLM, and Ollama without their provider-specific key env vars when --api-key is passed explicitly. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant CLI as codewhale CLI
    participant Dispatcher as Config Dispatcher
    participant TUI as codewhale TUI

    User->>CLI: deepseek --profile google
    CLI->>Dispatcher: resolve runtime options
    Dispatcher-->>CLI: ResolvedRuntimeOptions(provider, model, base_url, auth_mode, api_key)

    Note over CLI: OLD: forwarded all resolved values as env overrides
    Note over CLI: NEW: only forwards explicit CLI flags

    alt explicit --provider flag
        CLI->>TUI: DEEPSEEK_PROVIDER injected
    end
    alt explicit --model flag
        CLI->>TUI: DEEPSEEK_MODEL injected
    end
    alt explicit --base-url flag
        CLI->>TUI: DEEPSEEK_BASE_URL injected
    end
    alt api_key_source is Keyring
        CLI->>TUI: "API key env vars + source=keyring injected"
    end
    alt explicit --api-key flag
        CLI->>TUI: "API key env vars + source=cli injected"
    end

    CLI->>TUI: --profile google passed as arg
    TUI->>TUI: reads profile config for model, base_url, auth_mode
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/cli/src/lib.rs`, line 1512-1524 ([link](https://github.com/hmbown/codewhale/blob/2da889e24553a2dc37d75fe597754e2c0ce5b284/crates/cli/src/lib.rs#L1512-L1524)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> Missing `provider_env_vars()` in the `--api-key` CLI path leaves provider-specific keys unset for the TUI. Providers like Moonshot (`MOONSHOT_API_KEY`, `KIMI_API_KEY`), NvidiaNim (`NVIDIA_API_KEY`, `NVIDIA_NIM_API_KEY`), Openrouter, Novita, Fireworks, SGLang, vLLM, and Ollama are all skipped — only `DEEPSEEK_API_KEY` is forwarded. Even the WanjieArk case is incomplete: `provider_env_vars` returns three vars (`WANJIE_ARK_API_KEY`, `WANJIE_API_KEY`, `WANJIE_MAAS_API_KEY`) but only the first is set. The keyring path uses `provider_env_vars()` correctly; this path should match it.

   

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fissue-2114-profile-provider-env%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fissue-2114-profile-provider-env%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fcli%2Fsrc%2Flib.rs%0ALine%3A%201512-1524%0A%0AComment%3A%0AMissing%20%60provider_env_vars%28%29%60%20in%20the%20%60--api-key%60%20CLI%20path%20leaves%20provider-specific%20keys%20unset%20for%20the%20TUI.%20Providers%20like%20Moonshot%20%28%60MOONSHOT_API_KEY%60%2C%20%60KIMI_API_KEY%60%29%2C%20NvidiaNim%20%28%60NVIDIA_API_KEY%60%2C%20%60NVIDIA_NIM_API_KEY%60%29%2C%20Openrouter%2C%20Novita%2C%20Fireworks%2C%20SGLang%2C%20vLLM%2C%20and%20Ollama%20are%20all%20skipped%20%E2%80%94%20only%20%60DEEPSEEK_API_KEY%60%20is%20forwarded.%20Even%20the%20WanjieArk%20case%20is%20incomplete%3A%20%60provider_env_vars%60%20returns%20three%20vars%20%28%60WANJIE_ARK_API_KEY%60%2C%20%60WANJIE_API_KEY%60%2C%20%60WANJIE_MAAS_API_KEY%60%29%20but%20only%20the%20first%20is%20set.%20The%20keyring%20path%20uses%20%60provider_env_vars%28%29%60%20correctly%3B%20this%20path%20should%20match%20it.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20let%20Some%28api_key%29%20%3D%20cli.api_key.as_ref%28%29%20%7B%0A%20%20%20%20%20%20%20%20cmd.env%28%22DEEPSEEK_API_KEY%22%2C%20api_key%29%3B%0A%20%20%20%20%20%20%20%20for%20var%20in%20provider_env_vars%28resolved_runtime.provider%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20*var%20!%3D%20%22DEEPSEEK_API_KEY%22%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20cmd.env%28var%2C%20api_key%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20cmd.env%28%22DEEPSEEK_API_KEY_SOURCE%22%2C%20%22cli%22%29%3B%0A%20%20%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fcli%2Fsrc%2Flib.rs%0ALine%3A%201512-1524%0A%0AComment%3A%0AMissing%20%60provider_env_vars%28%29%60%20in%20the%20%60--api-key%60%20CLI%20path%20leaves%20provider-specific%20keys%20unset%20for%20the%20TUI.%20Providers%20like%20Moonshot%20%28%60MOONSHOT_API_KEY%60%2C%20%60KIMI_API_KEY%60%29%2C%20NvidiaNim%20%28%60NVIDIA_API_KEY%60%2C%20%60NVIDIA_NIM_API_KEY%60%29%2C%20Openrouter%2C%20Novita%2C%20Fireworks%2C%20SGLang%2C%20vLLM%2C%20and%20Ollama%20are%20all%20skipped%20%E2%80%94%20only%20%60DEEPSEEK_API_KEY%60%20is%20forwarded.%20Even%20the%20WanjieArk%20case%20is%20incomplete%3A%20%60provider_env_vars%60%20returns%20three%20vars%20%28%60WANJIE_ARK_API_KEY%60%2C%20%60WANJIE_API_KEY%60%2C%20%60WANJIE_MAAS_API_KEY%60%29%20but%20only%20the%20first%20is%20set.%20The%20keyring%20path%20uses%20%60provider_env_vars%28%29%60%20correctly%3B%20this%20path%20should%20match%20it.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20let%20Some%28api_key%29%20%3D%20cli.api_key.as_ref%28%29%20%7B%0A%20%20%20%20%20%20%20%20cmd.env%28%22DEEPSEEK_API_KEY%22%2C%20api_key%29%3B%0A%20%20%20%20%20%20%20%20for%20var%20in%20provider_env_vars%28resolved_runtime.provider%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20*var%20!%3D%20%22DEEPSEEK_API_KEY%22%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20cmd.env%28var%2C%20api_key%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20cmd.env%28%22DEEPSEEK_API_KEY_SOURCE%22%2C%20%22cli%22%29%3B%0A%20%20%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2119&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fcli%2Fsrc%2Flib.rs%0ALine%3A%201512-1524%0A%0AComment%3A%0AMissing%20%60provider_env_vars%28%29%60%20in%20the%20%60--api-key%60%20CLI%20path%20leaves%20provider-specific%20keys%20unset%20for%20the%20TUI.%20Providers%20like%20Moonshot%20%28%60MOONSHOT_API_KEY%60%2C%20%60KIMI_API_KEY%60%29%2C%20NvidiaNim%20%28%60NVIDIA_API_KEY%60%2C%20%60NVIDIA_NIM_API_KEY%60%29%2C%20Openrouter%2C%20Novita%2C%20Fireworks%2C%20SGLang%2C%20vLLM%2C%20and%20Ollama%20are%20all%20skipped%20%E2%80%94%20only%20%60DEEPSEEK_API_KEY%60%20is%20forwarded.%20Even%20the%20WanjieArk%20case%20is%20incomplete%3A%20%60provider_env_vars%60%20returns%20three%20vars%20%28%60WANJIE_ARK_API_KEY%60%2C%20%60WANJIE_API_KEY%60%2C%20%60WANJIE_MAAS_API_KEY%60%29%20but%20only%20the%20first%20is%20set.%20The%20keyring%20path%20uses%20%60provider_env_vars%28%29%60%20correctly%3B%20this%20path%20should%20match%20it.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20let%20Some%28api_key%29%20%3D%20cli.api_key.as_ref%28%29%20%7B%0A%20%20%20%20%20%20%20%20cmd.env%28%22DEEPSEEK_API_KEY%22%2C%20api_key%29%3B%0A%20%20%20%20%20%20%20%20for%20var%20in%20provider_env_vars%28resolved_runtime.provider%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20*var%20!%3D%20%22DEEPSEEK_API_KEY%22%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20cmd.env%28var%2C%20api_key%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20cmd.env%28%22DEEPSEEK_API_KEY_SOURCE%22%2C%20%22cli%22%29%3B%0A%20%20%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2119&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fissue-2114-profile-provider-env%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fissue-2114-profile-provider-env%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Fcli%2Fsrc%2Flib.rs%3A1512-1524%0AMissing%20%60provider_env_vars%28%29%60%20in%20the%20%60--api-key%60%20CLI%20path%20leaves%20provider-specific%20keys%20unset%20for%20the%20TUI.%20Providers%20like%20Moonshot%20%28%60MOONSHOT_API_KEY%60%2C%20%60KIMI_API_KEY%60%29%2C%20NvidiaNim%20%28%60NVIDIA_API_KEY%60%2C%20%60NVIDIA_NIM_API_KEY%60%29%2C%20Openrouter%2C%20Novita%2C%20Fireworks%2C%20SGLang%2C%20vLLM%2C%20and%20Ollama%20are%20all%20skipped%20%E2%80%94%20only%20%60DEEPSEEK_API_KEY%60%20is%20forwarded.%20Even%20the%20WanjieArk%20case%20is%20incomplete%3A%20%60provider_env_vars%60%20returns%20three%20vars%20%28%60WANJIE_ARK_API_KEY%60%2C%20%60WANJIE_API_KEY%60%2C%20%60WANJIE_MAAS_API_KEY%60%29%20but%20only%20the%20first%20is%20set.%20The%20keyring%20path%20uses%20%60provider_env_vars%28%29%60%20correctly%3B%20this%20path%20should%20match%20it.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20let%20Some%28api_key%29%20%3D%20cli.api_key.as_ref%28%29%20%7B%0A%20%20%20%20%20%20%20%20cmd.env%28%22DEEPSEEK_API_KEY%22%2C%20api_key%29%3B%0A%20%20%20%20%20%20%20%20for%20var%20in%20provider_env_vars%28resolved_runtime.provider%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20*var%20!%3D%20%22DEEPSEEK_API_KEY%22%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20cmd.env%28var%2C%20api_key%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20cmd.env%28%22DEEPSEEK_API_KEY_SOURCE%22%2C%20%22cli%22%29%3B%0A%20%20%20%20%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Fcli%2Fsrc%2Flib.rs%3A1512-1524%0AMissing%20%60provider_env_vars%28%29%60%20in%20the%20%60--api-key%60%20CLI%20path%20leaves%20provider-specific%20keys%20unset%20for%20the%20TUI.%20Providers%20like%20Moonshot%20%28%60MOONSHOT_API_KEY%60%2C%20%60KIMI_API_KEY%60%29%2C%20NvidiaNim%20%28%60NVIDIA_API_KEY%60%2C%20%60NVIDIA_NIM_API_KEY%60%29%2C%20Openrouter%2C%20Novita%2C%20Fireworks%2C%20SGLang%2C%20vLLM%2C%20and%20Ollama%20are%20all%20skipped%20%E2%80%94%20only%20%60DEEPSEEK_API_KEY%60%20is%20forwarded.%20Even%20the%20WanjieArk%20case%20is%20incomplete%3A%20%60provider_env_vars%60%20returns%20three%20vars%20%28%60WANJIE_ARK_API_KEY%60%2C%20%60WANJIE_API_KEY%60%2C%20%60WANJIE_MAAS_API_KEY%60%29%20but%20only%20the%20first%20is%20set.%20The%20keyring%20path%20uses%20%60provider_env_vars%28%29%60%20correctly%3B%20this%20path%20should%20match%20it.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20let%20Some%28api_key%29%20%3D%20cli.api_key.as_ref%28%29%20%7B%0A%20%20%20%20%20%20%20%20cmd.env%28%22DEEPSEEK_API_KEY%22%2C%20api_key%29%3B%0A%20%20%20%20%20%20%20%20for%20var%20in%20provider_env_vars%28resolved_runtime.provider%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20*var%20!%3D%20%22DEEPSEEK_API_KEY%22%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20cmd.env%28var%2C%20api_key%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20cmd.env%28%22DEEPSEEK_API_KEY_SOURCE%22%2C%20%22cli%22%29%3B%0A%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2119&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Fcli%2Fsrc%2Flib.rs%3A1512-1524%0AMissing%20%60provider_env_vars%28%29%60%20in%20the%20%60--api-key%60%20CLI%20path%20leaves%20provider-specific%20keys%20unset%20for%20the%20TUI.%20Providers%20like%20Moonshot%20%28%60MOONSHOT_API_KEY%60%2C%20%60KIMI_API_KEY%60%29%2C%20NvidiaNim%20%28%60NVIDIA_API_KEY%60%2C%20%60NVIDIA_NIM_API_KEY%60%29%2C%20Openrouter%2C%20Novita%2C%20Fireworks%2C%20SGLang%2C%20vLLM%2C%20and%20Ollama%20are%20all%20skipped%20%E2%80%94%20only%20%60DEEPSEEK_API_KEY%60%20is%20forwarded.%20Even%20the%20WanjieArk%20case%20is%20incomplete%3A%20%60provider_env_vars%60%20returns%20three%20vars%20%28%60WANJIE_ARK_API_KEY%60%2C%20%60WANJIE_API_KEY%60%2C%20%60WANJIE_MAAS_API_KEY%60%29%20but%20only%20the%20first%20is%20set.%20The%20keyring%20path%20uses%20%60provider_env_vars%28%29%60%20correctly%3B%20this%20path%20should%20match%20it.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20let%20Some%28api_key%29%20%3D%20cli.api_key.as_ref%28%29%20%7B%0A%20%20%20%20%20%20%20%20cmd.env%28%22DEEPSEEK_API_KEY%22%2C%20api_key%29%3B%0A%20%20%20%20%20%20%20%20for%20var%20in%20provider_env_vars%28resolved_runtime.provider%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20*var%20!%3D%20%22DEEPSEEK_API_KEY%22%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20cmd.env%28var%2C%20api_key%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20cmd.env%28%22DEEPSEEK_API_KEY_SOURCE%22%2C%20%22cli%22%29%3B%0A%20%20%20%20%7D%0A%60%60%60%0A%0A&pr=2119&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["test(cli): restore prompt flag coverage"](https://github.com/hmbown/codewhale/commit/2da889e24553a2dc37d75fe597754e2c0ce5b284) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33797874)</sub>

<!-- /greptile_comment -->