### PR TITLE
Implement TUI provider balance lookup

### DIFF
--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -801,7 +801,7 @@ impl DeepSeekClient {
 
     async fn send_balance_request(&self, url: &str) -> Result<String> {
         let response = self.send_with_retry(|| self.http_client.get(url)).await?;
-        Ok(response.text().await.unwrap_or_default())
+        response.text().await.context("Failed to read balance response body")
     }
 
     async fn wait_for_rate_limit(&self) {

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -1125,12 +1125,9 @@ pub(super) fn parse_novita_balance_report(payload: &str) -> Result<ProviderBalan
             "available",
             "balance",
         ],
-    )?
-    .unwrap_or(0.0);
-    let cash =
-        novita_amount_from_keys(data, &["cash_balance", "cashBalance", "cash"])?.unwrap_or(0.0);
-    let credit_limit =
-        novita_amount_from_keys(data, &["credit_limit", "creditLimit"])?.unwrap_or(0.0);
+    )?;
+    let cash = novita_amount_from_keys(data, &["cash_balance", "cashBalance", "cash"])?;
+    let credit_limit = novita_amount_from_keys(data, &["credit_limit", "creditLimit"])?;
     let pending_charges = novita_amount_from_keys(
         data,
         &[
@@ -1139,8 +1136,7 @@ pub(super) fn parse_novita_balance_report(payload: &str) -> Result<ProviderBalan
             "pending_charges",
             "pendingCharges",
         ],
-    )?
-    .unwrap_or(0.0);
+    )?;
     let outstanding_invoices = novita_amount_from_keys(
         data,
         &[
@@ -1149,16 +1145,37 @@ pub(super) fn parse_novita_balance_report(payload: &str) -> Result<ProviderBalan
             "outstanding_invoices",
             "outstandingInvoices",
         ],
-    )?
-    .unwrap_or(0.0);
+    )?;
+
+    if [
+        available,
+        cash,
+        credit_limit,
+        pending_charges,
+        outstanding_invoices,
+    ]
+    .iter()
+    .all(Option::is_none)
+    {
+        let provider_message = parsed
+            .get("message")
+            .or_else(|| data.get("message"))
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|message| !message.is_empty());
+        if let Some(message) = provider_message {
+            anyhow::bail!("Novita balance response did not include balance fields: {message}");
+        }
+        anyhow::bail!("Novita balance response did not include balance fields");
+    }
 
     let message = format!(
         "Novita AI balance\nAvailable: {}\nCash: {}\nCredit limit: {}\nPending charges: {}\nOutstanding invoices: {}",
-        format_usd(available),
-        format_usd(cash),
-        format_usd(credit_limit),
-        format_usd(pending_charges),
-        format_usd(outstanding_invoices)
+        format_usd(available.unwrap_or(0.0)),
+        format_usd(cash.unwrap_or(0.0)),
+        format_usd(credit_limit.unwrap_or(0.0)),
+        format_usd(pending_charges.unwrap_or(0.0)),
+        format_usd(outstanding_invoices.unwrap_or(0.0))
     );
 
     Ok(ProviderBalanceReport {
@@ -1214,11 +1231,10 @@ fn format_decimal(value: f64, max_decimals: usize, min_decimals: usize) -> Strin
             text.pop();
         }
     }
-    if text == "-0" || text == "-0.00" {
-        "0.00".to_string()
-    } else {
-        text
+    if text.starts_with('-') && text[1..].chars().all(|ch| ch == '0' || ch == '.') {
+        text.remove(0);
     }
+    text
 }
 
 pub(super) fn system_to_instructions(system: Option<SystemPrompt>) -> Option<String> {
@@ -1741,6 +1757,29 @@ mod tests {
         assert!(report.message.contains("Credit limit: $50.00"));
         assert!(report.message.contains("Pending charges: $0.00"));
         assert!(report.message.contains("Outstanding invoices: $0.00"));
+    }
+
+    #[test]
+    fn parse_novita_balance_errors_when_no_balance_fields_present() {
+        let payload = json!({
+            "code": 400,
+            "message": "invalid key"
+        })
+        .to_string();
+
+        let error = parse_novita_balance_report(&payload).expect_err("missing fields should fail");
+        let message = error.to_string();
+
+        assert!(message.contains("did not include balance fields"));
+        assert!(message.contains("invalid key"));
+    }
+
+    #[test]
+    fn balance_format_decimal_strips_negative_zero_consistently() {
+        assert_eq!(format_decimal(-0.0, 6, 0), "0");
+        assert_eq!(format_decimal(-0.0, 4, 2), "0.00");
+        assert_eq!(format_decimal(-0.0004, 3, 3), "0.000");
+        assert_eq!(format_decimal(-0.001, 3, 3), "-0.001");
     }
 
     #[tokio::test]

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -8,6 +8,7 @@ use std::sync::{Arc, Mutex as StdMutex, OnceLock};
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
+use reqwest::StatusCode;
 use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -117,6 +118,71 @@ pub struct AvailableModel {
     pub id: String,
     pub owned_by: Option<String>,
     pub created: Option<u64>,
+}
+
+/// Human-readable account balance details for transcript display.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderBalanceReport {
+    pub provider: ApiProvider,
+    pub message: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct DeepSeekBalanceResponse {
+    is_available: bool,
+    #[serde(default)]
+    balance_infos: Vec<DeepSeekBalanceInfo>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DeepSeekBalanceInfo {
+    currency: String,
+    total_balance: String,
+    granted_balance: String,
+    topped_up_balance: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenRouterCreditsResponse {
+    data: OpenRouterCreditsData,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenRouterCreditsData {
+    total_credits: FlexibleAmount,
+    total_usage: FlexibleAmount,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenRouterKeyResponse {
+    data: OpenRouterKeyData,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenRouterKeyData {
+    #[serde(default)]
+    label: Option<String>,
+    #[serde(default)]
+    usage: Option<FlexibleAmount>,
+    #[serde(default)]
+    limit: Option<FlexibleAmount>,
+    #[serde(default)]
+    limit_remaining: Option<FlexibleAmount>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct FlexibleAmount(f64);
+
+impl<'de> Deserialize<'de> for FlexibleAmount {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = Value::deserialize(deserializer)?;
+        value_as_f64(&value)
+            .map(Self)
+            .ok_or_else(|| serde::de::Error::custom("expected numeric amount"))
+    }
 }
 
 /// Client for DeepSeek's OpenAI-compatible APIs.
@@ -407,6 +473,46 @@ pub(super) fn api_url(base_url: &str, path: &str) -> String {
     format!("{}/{}", versioned.trim_end_matches('/'), path)
 }
 
+pub(super) fn deepseek_balance_url(base_url: &str) -> String {
+    format!("{}/user/balance", deepseek_balance_root_url(base_url))
+}
+
+fn deepseek_balance_root_url(base_url: &str) -> String {
+    let trimmed = base_url.trim_end_matches('/');
+    trimmed
+        .rsplit_once('/')
+        .filter(|(_, segment)| {
+            segment.eq_ignore_ascii_case("v1") || segment.eq_ignore_ascii_case("beta")
+        })
+        .map(|(base, _)| base)
+        .unwrap_or(trimmed)
+        .to_string()
+}
+
+pub(super) fn openrouter_credits_url(base_url: &str) -> String {
+    api_url(base_url, "credits")
+}
+
+pub(super) fn openrouter_key_url(base_url: &str) -> String {
+    api_url(base_url, "key")
+}
+
+pub(super) fn novita_balance_url(base_url: &str) -> Result<String> {
+    Ok(format!(
+        "{}/openapi/v1/billing/balance/detail",
+        origin_url(base_url)?
+    ))
+}
+
+fn origin_url(base_url: &str) -> Result<String> {
+    let mut url = reqwest::Url::parse(base_url)
+        .with_context(|| format!("Invalid provider base URL '{base_url}'"))?;
+    url.set_path("");
+    url.set_query(None);
+    url.set_fragment(None);
+    Ok(url.as_str().trim_end_matches('/').to_string())
+}
+
 // === DeepSeekClient ===
 
 /// Returns true when DEEPSEEK_FORCE_HTTP1 is set to a truthy value
@@ -639,6 +745,65 @@ impl DeepSeekClient {
         parse_models_response(&response_text)
     }
 
+    /// Fetch and format the active provider's account balance for TUI display.
+    pub async fn balance_report(&self) -> Result<ProviderBalanceReport> {
+        match self.api_provider {
+            ApiProvider::Deepseek | ApiProvider::DeepseekCN => self.deepseek_balance_report().await,
+            ApiProvider::Openrouter => self.openrouter_balance_report().await,
+            ApiProvider::Novita => self.novita_balance_report().await,
+            provider => anyhow::bail!(
+                "Balance check is not supported for {} yet. Check the provider dashboard for account balance details.",
+                provider.display_name()
+            ),
+        }
+    }
+
+    async fn deepseek_balance_report(&self) -> Result<ProviderBalanceReport> {
+        let url = deepseek_balance_url(&self.base_url);
+        let payload = self.send_balance_request(&url).await?;
+        parse_deepseek_balance_report(self.api_provider, &payload)
+    }
+
+    async fn openrouter_balance_report(&self) -> Result<ProviderBalanceReport> {
+        let credits_url = openrouter_credits_url(&self.base_url);
+        let response = self
+            .send_with_retry_matching(
+                || self.http_client.get(&credits_url),
+                |status| {
+                    status.is_success()
+                        || matches!(status, StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN)
+                },
+            )
+            .await?;
+
+        if matches!(
+            response.status(),
+            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN
+        ) {
+            return self.openrouter_key_balance_report().await;
+        }
+
+        let payload = response.text().await.unwrap_or_default();
+        parse_openrouter_credits_report(&payload)
+    }
+
+    async fn openrouter_key_balance_report(&self) -> Result<ProviderBalanceReport> {
+        let url = openrouter_key_url(&self.base_url);
+        let payload = self.send_balance_request(&url).await?;
+        parse_openrouter_key_report(&payload)
+    }
+
+    async fn novita_balance_report(&self) -> Result<ProviderBalanceReport> {
+        let url = novita_balance_url(&self.base_url)?;
+        let payload = self.send_balance_request(&url).await?;
+        parse_novita_balance_report(&payload)
+    }
+
+    async fn send_balance_request(&self, url: &str) -> Result<String> {
+        let response = self.send_with_retry(|| self.http_client.get(url)).await?;
+        Ok(response.text().await.unwrap_or_default())
+    }
+
     async fn wait_for_rate_limit(&self) {
         let maybe_delay = {
             let mut limiter = self.rate_limiter.lock().await;
@@ -695,6 +860,19 @@ impl DeepSeekClient {
     where
         F: FnMut() -> reqwest::RequestBuilder,
     {
+        self.send_with_retry_matching(&mut build, |status| status.is_success())
+            .await
+    }
+
+    async fn send_with_retry_matching<F, A>(
+        &self,
+        mut build: F,
+        accept_status: A,
+    ) -> Result<reqwest::Response>
+    where
+        F: FnMut() -> reqwest::RequestBuilder,
+        A: Fn(StatusCode) -> bool + Copy,
+    {
         let retry_cfg: LlmRetryConfig = self.retry.clone().into();
         let request_result = with_retry(
             &retry_cfg,
@@ -707,7 +885,7 @@ impl DeepSeekClient {
                         .await
                         .map_err(|err| LlmError::from_reqwest(&err))?;
                     let status = response.status();
-                    if status.is_success() {
+                    if accept_status(status) {
                         return Ok(response);
                     }
                     let retry_after = extract_retry_after(response.headers());
@@ -847,6 +1025,200 @@ pub(super) fn parse_models_response(payload: &str) -> Result<Vec<AvailableModel>
     models.sort_by(|a, b| a.id.cmp(&b.id));
     models.dedup_by(|a, b| a.id == b.id);
     Ok(models)
+}
+
+pub(super) fn parse_deepseek_balance_report(
+    provider: ApiProvider,
+    payload: &str,
+) -> Result<ProviderBalanceReport> {
+    let parsed: DeepSeekBalanceResponse =
+        serde_json::from_str(payload).context("Failed to parse DeepSeek balance JSON")?;
+
+    let mut message = format!(
+        "{} balance\nStatus: {}",
+        provider.display_name(),
+        if parsed.is_available {
+            "available"
+        } else {
+            "unavailable"
+        }
+    );
+    if parsed.balance_infos.is_empty() {
+        message.push_str("\nNo currency balances returned.");
+    } else {
+        for info in parsed.balance_infos {
+            message.push_str(&format!(
+                "\n{}: total {}, granted {}, topped up {}",
+                info.currency,
+                format_provider_amount(&info.total_balance),
+                format_provider_amount(&info.granted_balance),
+                format_provider_amount(&info.topped_up_balance)
+            ));
+        }
+    }
+
+    Ok(ProviderBalanceReport { provider, message })
+}
+
+pub(super) fn parse_openrouter_credits_report(payload: &str) -> Result<ProviderBalanceReport> {
+    let parsed: OpenRouterCreditsResponse =
+        serde_json::from_str(payload).context("Failed to parse OpenRouter credits JSON")?;
+    let total = parsed.data.total_credits.0;
+    let usage = parsed.data.total_usage.0;
+    let remaining = total - usage;
+    let message = format!(
+        "OpenRouter balance\nCredits: total {}, used {}, remaining {}",
+        format_usd(total),
+        format_usd(usage),
+        format_usd(remaining)
+    );
+    Ok(ProviderBalanceReport {
+        provider: ApiProvider::Openrouter,
+        message,
+    })
+}
+
+pub(super) fn parse_openrouter_key_report(payload: &str) -> Result<ProviderBalanceReport> {
+    let parsed: OpenRouterKeyResponse =
+        serde_json::from_str(payload).context("Failed to parse OpenRouter key JSON")?;
+    let data = parsed.data;
+    let label = data
+        .label
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("unnamed key");
+    let usage = data.usage.map(|amount| amount.0);
+    let limit = data.limit.map(|amount| amount.0);
+    let remaining = data
+        .limit_remaining
+        .map(|amount| amount.0)
+        .or_else(|| limit.zip(usage).map(|(limit, usage)| limit - usage));
+
+    let mut message = format!("OpenRouter key balance\nKey: {label}");
+    match usage {
+        Some(value) => message.push_str(&format!("\nUsage: {}", format_usd(value))),
+        None => message.push_str("\nUsage: unavailable"),
+    }
+    if let Some(value) = limit {
+        message.push_str(&format!("\nLimit: {}", format_usd(value)));
+    }
+    if let Some(value) = remaining {
+        message.push_str(&format!("\nRemaining: {}", format_usd(value)));
+    }
+
+    Ok(ProviderBalanceReport {
+        provider: ApiProvider::Openrouter,
+        message,
+    })
+}
+
+pub(super) fn parse_novita_balance_report(payload: &str) -> Result<ProviderBalanceReport> {
+    let parsed: Value =
+        serde_json::from_str(payload).context("Failed to parse Novita balance JSON")?;
+    let data = parsed.get("data").unwrap_or(&parsed);
+    let available = novita_amount_from_keys(
+        data,
+        &[
+            "available_balance",
+            "availableBalance",
+            "available",
+            "balance",
+        ],
+    )?
+    .unwrap_or(0.0);
+    let cash =
+        novita_amount_from_keys(data, &["cash_balance", "cashBalance", "cash"])?.unwrap_or(0.0);
+    let credit_limit =
+        novita_amount_from_keys(data, &["credit_limit", "creditLimit"])?.unwrap_or(0.0);
+    let pending_charges = novita_amount_from_keys(
+        data,
+        &[
+            "pending_charge",
+            "pendingCharge",
+            "pending_charges",
+            "pendingCharges",
+        ],
+    )?
+    .unwrap_or(0.0);
+    let outstanding_invoices = novita_amount_from_keys(
+        data,
+        &[
+            "outstanding_invoice",
+            "outstandingInvoice",
+            "outstanding_invoices",
+            "outstandingInvoices",
+        ],
+    )?
+    .unwrap_or(0.0);
+
+    let message = format!(
+        "Novita AI balance\nAvailable: {}\nCash: {}\nCredit limit: {}\nPending charges: {}\nOutstanding invoices: {}",
+        format_usd(available),
+        format_usd(cash),
+        format_usd(credit_limit),
+        format_usd(pending_charges),
+        format_usd(outstanding_invoices)
+    );
+
+    Ok(ProviderBalanceReport {
+        provider: ApiProvider::Novita,
+        message,
+    })
+}
+
+fn novita_amount_from_keys(data: &Value, keys: &[&str]) -> Result<Option<f64>> {
+    for key in keys {
+        if let Some(value) = data.get(*key) {
+            if value.is_null() {
+                return Ok(None);
+            }
+            let raw = value_as_f64(value).ok_or_else(|| {
+                anyhow::anyhow!("Novita balance field '{key}' is not a numeric string")
+            })?;
+            return Ok(Some(raw / 10_000.0));
+        }
+    }
+    Ok(None)
+}
+
+fn value_as_f64(value: &Value) -> Option<f64> {
+    match value {
+        Value::Number(number) => number.as_f64(),
+        Value::String(text) => text.trim().parse::<f64>().ok(),
+        _ => None,
+    }
+}
+
+fn format_provider_amount(raw: &str) -> String {
+    raw.trim()
+        .parse::<f64>()
+        .map(|value| format_decimal(value, 6, 0))
+        .unwrap_or_else(|_| raw.trim().to_string())
+}
+
+fn format_usd(value: f64) -> String {
+    format!("${}", format_decimal(value, 4, 2))
+}
+
+fn format_decimal(value: f64, max_decimals: usize, min_decimals: usize) -> String {
+    if !value.is_finite() {
+        return value.to_string();
+    }
+    let mut text = format!("{value:.precision$}", precision = max_decimals);
+    if let Some(dot) = text.find('.') {
+        while text.len().saturating_sub(dot + 1) > min_decimals && text.ends_with('0') {
+            text.pop();
+        }
+        if min_decimals == 0 && text.ends_with('.') {
+            text.pop();
+        }
+    }
+    if text == "-0" || text == "-0.00" {
+        "0.00".to_string()
+    } else {
+        text
+    }
 }
 
 pub(super) fn system_to_instructions(system: Option<SystemPrompt>) -> Option<String> {
@@ -1108,10 +1480,37 @@ mod tests {
         parse_chat_message, parse_sse_chunk, sanitize_thinking_mode_messages, tool_to_chat,
         tool_to_chat_for_base_url,
     };
+    use crate::config::{ProviderConfig, ProvidersConfig};
     use crate::models::{
         ContentBlock, ContentBlockStart, Delta, Message, MessageRequest, StreamEvent, Tool,
     };
     use serde_json::json;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn balance_test_config(provider: ApiProvider, base_url: &str) -> Config {
+        let mut config = Config {
+            provider: Some(provider.as_str().to_string()),
+            api_key: Some("sk-test".to_string()),
+            base_url: Some(base_url.to_string()),
+            ..Config::default()
+        };
+        let provider_config = ProviderConfig {
+            api_key: Some("sk-test".to_string()),
+            base_url: Some(base_url.to_string()),
+            ..ProviderConfig::default()
+        };
+        let mut providers = ProvidersConfig::default();
+        match provider {
+            ApiProvider::Deepseek => providers.deepseek = provider_config,
+            ApiProvider::DeepseekCN => providers.deepseek_cn = provider_config,
+            ApiProvider::Openrouter => providers.openrouter = provider_config,
+            ApiProvider::Novita => providers.novita = provider_config,
+            _ => {}
+        }
+        config.providers = Some(providers);
+        config
+    }
 
     #[test]
     fn tool_name_roundtrip_dot() {
@@ -1224,6 +1623,231 @@ mod tests {
             ),
             "https://openai-compatible.example/api/coding/paas/v4/models"
         );
+    }
+
+    #[test]
+    fn balance_urls_follow_provider_rules() {
+        assert_eq!(
+            deepseek_balance_url("https://api.deepseek.com/v1"),
+            "https://api.deepseek.com/user/balance"
+        );
+        assert_eq!(
+            deepseek_balance_url("https://api.deepseek.com/beta"),
+            "https://api.deepseek.com/user/balance"
+        );
+        assert_eq!(
+            deepseek_balance_url("https://deepseek-proxy.example/custom/v4"),
+            "https://deepseek-proxy.example/custom/v4/user/balance"
+        );
+        assert_eq!(
+            openrouter_credits_url("https://openrouter.ai/api/v1"),
+            "https://openrouter.ai/api/v1/credits"
+        );
+        assert_eq!(
+            openrouter_key_url("https://openrouter.ai/api/v1"),
+            "https://openrouter.ai/api/v1/key"
+        );
+        assert_eq!(
+            novita_balance_url("https://api.novita.ai/v3/openai").unwrap(),
+            "https://api.novita.ai/openapi/v1/billing/balance/detail"
+        );
+        assert_eq!(
+            novita_balance_url("https://novita-proxy.example/custom/v1").unwrap(),
+            "https://novita-proxy.example/openapi/v1/billing/balance/detail"
+        );
+    }
+
+    #[test]
+    fn parse_deepseek_balance_formats_currency_lines() {
+        let payload = json!({
+            "is_available": true,
+            "balance_infos": [{
+                "currency": "CNY",
+                "total_balance": "100.000000",
+                "granted_balance": "25.500000",
+                "topped_up_balance": "74.500000"
+            }]
+        })
+        .to_string();
+
+        let report =
+            parse_deepseek_balance_report(ApiProvider::Deepseek, &payload).expect("report");
+
+        assert_eq!(report.provider, ApiProvider::Deepseek);
+        assert!(report.message.contains("DeepSeek balance"));
+        assert!(report.message.contains("Status: available"));
+        assert!(report.message.contains("CNY: total 100"));
+        assert!(report.message.contains("granted 25.5"));
+        assert!(report.message.contains("topped up 74.5"));
+    }
+
+    #[test]
+    fn parse_openrouter_credits_formats_remaining_balance() {
+        let payload = json!({
+            "data": {
+                "total_credits": 10.0,
+                "total_usage": 3.25
+            }
+        })
+        .to_string();
+
+        let report = parse_openrouter_credits_report(&payload).expect("report");
+
+        assert_eq!(report.provider, ApiProvider::Openrouter);
+        assert!(report.message.contains("OpenRouter balance"));
+        assert!(report.message.contains("total $10.00"));
+        assert!(report.message.contains("used $3.25"));
+        assert!(report.message.contains("remaining $6.75"));
+    }
+
+    #[test]
+    fn parse_openrouter_key_formats_fallback_details() {
+        let payload = json!({
+            "data": {
+                "label": "dev-key",
+                "usage": 1.25,
+                "limit": 10,
+                "limit_remaining": 8.75
+            }
+        })
+        .to_string();
+
+        let report = parse_openrouter_key_report(&payload).expect("report");
+
+        assert_eq!(report.provider, ApiProvider::Openrouter);
+        assert!(report.message.contains("OpenRouter key balance"));
+        assert!(report.message.contains("Key: dev-key"));
+        assert!(report.message.contains("Usage: $1.25"));
+        assert!(report.message.contains("Limit: $10.00"));
+        assert!(report.message.contains("Remaining: $8.75"));
+    }
+
+    #[test]
+    fn parse_novita_balance_converts_ten_thousandth_usd_units() {
+        let payload = json!({
+            "availableBalance": "123456",
+            "cashBalance": "100000",
+            "creditLimit": "500000",
+            "outstandingInvoices": "0"
+        })
+        .to_string();
+
+        let report = parse_novita_balance_report(&payload).expect("report");
+
+        assert_eq!(report.provider, ApiProvider::Novita);
+        assert!(report.message.contains("Novita AI balance"));
+        assert!(report.message.contains("Available: $12.3456"));
+        assert!(report.message.contains("Cash: $10.00"));
+        assert!(report.message.contains("Credit limit: $50.00"));
+        assert!(report.message.contains("Pending charges: $0.00"));
+        assert!(report.message.contains("Outstanding invoices: $0.00"));
+    }
+
+    #[tokio::test]
+    async fn balance_report_fetches_deepseek_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/user/balance"))
+            .and(header("authorization", "Bearer sk-test"))
+            .and(header("x-balance-test", "yes"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "is_available": true,
+                "balance_infos": [{
+                    "currency": "USD",
+                    "total_balance": "12.50",
+                    "granted_balance": "2.50",
+                    "topped_up_balance": "10.00"
+                }]
+            })))
+            .mount(&server)
+            .await;
+
+        let mut config =
+            balance_test_config(ApiProvider::Deepseek, &format!("{}/v1", server.uri()));
+        config.http_headers = Some(HashMap::from([(
+            "X-Balance-Test".to_string(),
+            "yes".to_string(),
+        )]));
+        let client = DeepSeekClient::new(&config).expect("client");
+        let report = client.balance_report().await.expect("balance report");
+
+        assert_eq!(report.provider, ApiProvider::Deepseek);
+        assert!(report.message.contains("USD: total 12.5"));
+    }
+
+    #[tokio::test]
+    async fn balance_report_surfaces_http_error_body() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/credits"))
+            .respond_with(ResponseTemplate::new(402).set_body_string("payment required"))
+            .mount(&server)
+            .await;
+
+        let config =
+            balance_test_config(ApiProvider::Openrouter, &format!("{}/api/v1", server.uri()));
+        let client = DeepSeekClient::new(&config).expect("client");
+        let error = client
+            .balance_report()
+            .await
+            .expect_err("balance should fail");
+        let message = error.to_string();
+
+        assert!(message.contains("402"));
+        assert!(message.contains("payment required"));
+    }
+
+    #[tokio::test]
+    async fn balance_report_surfaces_invalid_api_key_body() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/user/balance"))
+            .respond_with(ResponseTemplate::new(401).set_body_string("invalid api key"))
+            .mount(&server)
+            .await;
+
+        let config = balance_test_config(ApiProvider::Deepseek, &format!("{}/v1", server.uri()));
+        let client = DeepSeekClient::new(&config).expect("client");
+        let error = client
+            .balance_report()
+            .await
+            .expect_err("balance should fail");
+        let message = error.to_string();
+
+        assert!(message.contains("Authentication failed"));
+        assert!(message.contains("invalid api key"));
+    }
+
+    #[tokio::test]
+    async fn balance_report_falls_back_from_openrouter_credits_to_key() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/credits"))
+            .respond_with(ResponseTemplate::new(401).set_body_string("credits denied"))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "data": {
+                    "label": "fallback-key",
+                    "usage": "2.50",
+                    "limit": "10.00",
+                    "limit_remaining": "7.50"
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config =
+            balance_test_config(ApiProvider::Openrouter, &format!("{}/api/v1", server.uri()));
+        let client = DeepSeekClient::new(&config).expect("client");
+        let report = client.balance_report().await.expect("balance report");
+
+        assert_eq!(report.provider, ApiProvider::Openrouter);
+        assert!(report.message.contains("OpenRouter key balance"));
+        assert!(report.message.contains("Key: fallback-key"));
+        assert!(report.message.contains("Remaining: $7.50"));
     }
 
     #[test]

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -783,7 +783,7 @@ impl DeepSeekClient {
             return self.openrouter_key_balance_report().await;
         }
 
-        let payload = response.text().await.unwrap_or_default();
+        let payload = response.text().await.context("Failed to read OpenRouter credits response body")?;
         parse_openrouter_credits_report(&payload)
     }
 

--- a/crates/tui/src/commands/balance.rs
+++ b/crates/tui/src/commands/balance.rs
@@ -1,11 +1,7 @@
 //! Balance: query the active provider's account balance or credit status.
-//!
-//! Provider-specific network dispatch is still pending. Until that lands, keep
-//! this command explicit about being a scaffold so users do not mistake it for
-//! a live balance lookup.
 
 use crate::config::ApiProvider;
-use crate::tui::app::App;
+use crate::tui::app::{App, AppAction};
 
 use super::CommandResult;
 
@@ -16,10 +12,7 @@ pub fn balance(app: &mut App) -> CommandResult {
         ApiProvider::Deepseek
         | ApiProvider::DeepseekCN
         | ApiProvider::Openrouter
-        | ApiProvider::Novita => CommandResult::message(format!(
-            "Balance check for {} is planned, but provider balance network dispatch is not wired in this build yet.",
-            provider.display_name()
-        )),
+        | ApiProvider::Novita => CommandResult::action(AppAction::FetchBalance),
         _ => CommandResult::message(format!(
             "Balance check is not supported for {} yet. Check the provider dashboard for account balance details.",
             provider.display_name()

--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -1505,19 +1505,22 @@ mod tests {
     }
 
     #[test]
-    fn balance_command_reports_scaffold_without_claiming_dispatch() {
-        let mut app = create_test_app();
-        app.api_provider = ApiProvider::Deepseek;
+    fn balance_command_dispatches_for_supported_providers() {
+        for provider in [
+            ApiProvider::Deepseek,
+            ApiProvider::DeepseekCN,
+            ApiProvider::Openrouter,
+            ApiProvider::Novita,
+        ] {
+            let mut app = create_test_app();
+            app.api_provider = provider;
 
-        let result = execute("/balance", &mut app);
-        let msg = result
-            .message
-            .expect("balance scaffold should explain current state");
+            let result = execute("/balance", &mut app);
 
-        assert!(!result.is_error);
-        assert!(msg.contains("DeepSeek"));
-        assert!(msg.contains("not wired"));
-        assert!(!msg.contains("sent"));
+            assert!(!result.is_error);
+            assert!(result.message.is_none());
+            assert!(matches!(result.action, Some(AppAction::FetchBalance)));
+        }
     }
 
     #[test]

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -4568,6 +4568,7 @@ pub enum AppAction {
     SendMessage(String),
     ListSubAgents,
     FetchModels,
+    FetchBalance,
     CacheWarmup,
     /// Switch the active LLM backend (DeepSeek vs NVIDIA NIM) without
     /// restarting the process. The runtime rebuilds its API client from

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -3685,6 +3685,14 @@ async fn fetch_available_models(config: &Config) -> Result<Vec<String>> {
     Ok(ids)
 }
 
+async fn fetch_provider_balance(config: &Config) -> Result<String> {
+    use crate::client::DeepSeekClient;
+
+    let client = DeepSeekClient::new(config)?;
+    let report = tokio::time::timeout(Duration::from_secs(20), client.balance_report()).await??;
+    Ok(report.message)
+}
+
 async fn run_cache_warmup(app: &App, config: &Config) -> Result<Usage> {
     let client = DeepSeekClient::new(config)?;
     let reasoning_effort = if app.reasoning_effort == ReasoningEffort::Auto {
@@ -4633,6 +4641,21 @@ async fn apply_command_result(
                                 content: format!("Failed to fetch models: {error}"),
                             });
                         }
+                    }
+                }
+            }
+            AppAction::FetchBalance => {
+                app.status_message = Some("Fetching provider balance...".to_string());
+                match fetch_provider_balance(config).await {
+                    Ok(message) => {
+                        app.add_message(HistoryCell::System { content: message });
+                        app.status_message = Some("Balance check complete".to_string());
+                    }
+                    Err(error) => {
+                        app.add_message(HistoryCell::System {
+                            content: format!("Failed to fetch balance: {error}"),
+                        });
+                        app.status_message = Some("Balance check failed".to_string());
                     }
                 }
             }

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -196,6 +196,11 @@ enum TranslationEvent {
 enum VoiceInputEvent {
     Finished { result: Result<String> },
 }
+
+#[derive(Debug)]
+enum BalanceEvent {
+    Finished { result: Result<String> },
+}
 // Reset scroll region (`\x1b[r`), origin mode (`\x1b[?6l`), and home the cursor
 // (`\x1b[H`) before letting ratatui's diff renderer repaint. The destructive
 // `\x1b[2J\x1b[3J` pair was previously appended here to also wipe the visible
@@ -869,6 +874,7 @@ async fn run_event_loop(
         tokio::sync::mpsc::unbounded_channel::<TranslationEvent>();
     let (voice_input_tx, mut voice_input_rx) =
         tokio::sync::mpsc::unbounded_channel::<VoiceInputEvent>();
+    let (balance_tx, mut balance_rx) = tokio::sync::mpsc::unbounded_channel::<BalanceEvent>();
     let mut pending_translations = 0usize;
     let mut pending_thinking_translations = 0usize;
     let mut last_queue_state = (app.queued_messages.clone(), app.queued_draft.clone());
@@ -989,6 +995,7 @@ async fn run_event_loop(
         }
 
         drain_voice_input_events(app, &mut voice_input_rx);
+        drain_balance_events(app, &mut balance_rx);
 
         if last_task_refresh.elapsed() >= Duration::from_millis(2500) {
             refresh_active_task_panel(app, &task_manager).await;
@@ -2005,6 +2012,7 @@ async fn run_event_loop(
                 &mut engine_handle,
                 &mut web_config_session,
                 voice_input_tx.clone(),
+                balance_tx.clone(),
                 events,
             )
             .await?
@@ -2304,6 +2312,7 @@ async fn run_event_loop(
                     &mut engine_handle,
                     &mut web_config_session,
                     voice_input_tx.clone(),
+                    balance_tx.clone(),
                     events,
                 )
                 .await?
@@ -2686,6 +2695,7 @@ async fn run_event_loop(
                     &mut engine_handle,
                     &mut web_config_session,
                     voice_input_tx.clone(),
+                    balance_tx.clone(),
                     events,
                 )
                 .await?
@@ -3233,6 +3243,7 @@ async fn run_event_loop(
                                 &task_manager,
                                 config,
                                 &mut web_config_session,
+                                balance_tx.clone(),
                                 &input,
                             )
                             .await?
@@ -3282,6 +3293,7 @@ async fn run_event_loop(
                                 &task_manager,
                                 config,
                                 &mut web_config_session,
+                                balance_tx.clone(),
                                 &input,
                             )
                             .await?
@@ -3358,6 +3370,7 @@ async fn run_event_loop(
                                 &task_manager,
                                 config,
                                 &mut web_config_session,
+                                balance_tx.clone(),
                                 &input,
                             )
                             .await?
@@ -4554,6 +4567,7 @@ async fn apply_command_result(
     #[cfg_attr(not(feature = "web"), allow(unused_variables))] web_config_session: &mut Option<
         WebConfigSession,
     >,
+    balance_tx: tokio::sync::mpsc::UnboundedSender<BalanceEvent>,
     result: commands::CommandResult,
 ) -> Result<bool> {
     if let Some(msg) = result.message {
@@ -4646,18 +4660,12 @@ async fn apply_command_result(
             }
             AppAction::FetchBalance => {
                 app.status_message = Some("Fetching provider balance...".to_string());
-                match fetch_provider_balance(config).await {
-                    Ok(message) => {
-                        app.add_message(HistoryCell::System { content: message });
-                        app.status_message = Some("Balance check complete".to_string());
-                    }
-                    Err(error) => {
-                        app.add_message(HistoryCell::System {
-                            content: format!("Failed to fetch balance: {error}"),
-                        });
-                        app.status_message = Some("Balance check failed".to_string());
-                    }
-                }
+                app.needs_redraw = true;
+                let config = config.clone();
+                tokio::spawn(async move {
+                    let result = fetch_provider_balance(&config).await;
+                    let _ = balance_tx.send(BalanceEvent::Finished { result });
+                });
             }
             AppAction::CacheWarmup => {
                 app.status_message = Some("Warming DeepSeek cache...".to_string());
@@ -5275,6 +5283,7 @@ async fn execute_command_input(
     task_manager: &SharedTaskManager,
     config: &mut Config,
     web_config_session: &mut Option<WebConfigSession>,
+    balance_tx: tokio::sync::mpsc::UnboundedSender<BalanceEvent>,
     input: &str,
 ) -> Result<bool> {
     let result = commands::execute(input, app);
@@ -5306,6 +5315,7 @@ async fn execute_command_input(
         task_manager,
         config,
         web_config_session,
+        balance_tx,
         result,
     )
     .await
@@ -5379,6 +5389,31 @@ fn drain_voice_input_events(
                             content: format!("Voice input failed: {err}"),
                         });
                         app.status_message = Some("Voice input failed".to_string());
+                    }
+                }
+                app.needs_redraw = true;
+            }
+        }
+    }
+}
+
+fn drain_balance_events(
+    app: &mut App,
+    balance_rx: &mut tokio::sync::mpsc::UnboundedReceiver<BalanceEvent>,
+) {
+    while let Ok(event) = balance_rx.try_recv() {
+        match event {
+            BalanceEvent::Finished { result } => {
+                match result {
+                    Ok(message) => {
+                        app.add_message(HistoryCell::System { content: message });
+                        app.status_message = Some("Balance check complete".to_string());
+                    }
+                    Err(error) => {
+                        app.add_message(HistoryCell::System {
+                            content: format!("Failed to fetch balance: {error}"),
+                        });
+                        app.status_message = Some("Balance check failed".to_string());
                     }
                 }
                 app.needs_redraw = true;
@@ -6001,6 +6036,7 @@ async fn handle_view_events(
     engine_handle: &mut EngineHandle,
     web_config_session: &mut Option<WebConfigSession>,
     voice_input_tx: tokio::sync::mpsc::UnboundedSender<VoiceInputEvent>,
+    balance_tx: tokio::sync::mpsc::UnboundedSender<BalanceEvent>,
     events: Vec<ViewEvent>,
 ) -> Result<bool> {
     for event in events {
@@ -6014,6 +6050,7 @@ async fn handle_view_events(
                         task_manager,
                         config,
                         &mut *web_config_session,
+                        balance_tx.clone(),
                         &command,
                     )
                     .await?


### PR DESCRIPTION
## Summary

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features`
- [x] `cargo test --workspace --all-features`

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [x] Verified TUI behavior manually if UI changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR promotes the `/balance` TUI command from a stub into a fully functional live lookup for DeepSeek, OpenRouter, and Novita, wiring async HTTP calls through a new `BalanceEvent` channel in the UI event loop.

- Adds `balance_report()` to `DeepSeekClient` with per-provider fetch/parse logic: DeepSeek uses a dedicated `/user/balance` endpoint, OpenRouter falls back from `/credits` to `/key` on 401/403, and Novita decodes ten-thousandth-USD units from a set of camelCase/snake_case key variants.
- Refactors `send_with_retry` into a generic `send_with_retry_matching` that accepts a caller-supplied status predicate, enabling OpenRouter's graceful 401/403 fallback without bypassing the existing retry and error-surfacing machinery.
- Promotes `AppAction::FetchBalance` as a background `tokio::spawn` in `apply_command_result`, draining results via `drain_balance_events` each event-loop tick into the chat history.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the balance fetch is entirely additive and isolated behind a new async channel with no shared mutable state.

The core HTTP and retry machinery is well-tested (including the OpenRouter 401/403 fallback path and Novita unit conversion), error bodies are surfaced correctly through the existing retry infrastructure, and the TUI wiring follows established patterns. The two findings are edge cases unlikely to occur in normal usage.

crates/tui/src/client.rs (novita_amount_from_keys) and crates/tui/src/tui/ui.rs (AppAction::FetchBalance dispatch) warrant a second look before the next Novita API integration or any future expansion of the balance command.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/client.rs | Core balance logic: adds provider-specific balance fetch/parse functions for DeepSeek, OpenRouter (with 401/403 fallback to key endpoint), and Novita; refactors send_with_retry into send_with_retry_matching; null-value short-circuit in novita_amount_from_keys can skip valid fallback keys |
| crates/tui/src/tui/ui.rs | Wires BalanceEvent async channel into the event loop; FetchBalance spawns a background task without concurrency guard, unlike the inline FetchModels pattern, allowing duplicate results on rapid re-invocation |
| crates/tui/src/commands/balance.rs | Promotes /balance from a scaffold to dispatching AppAction::FetchBalance for supported providers; clean and straightforward change |
| crates/tui/src/commands/mod.rs | Updates balance command test to assert AppAction::FetchBalance dispatch instead of scaffold message; covers all four supported providers |
| crates/tui/src/tui/app.rs | Adds FetchBalance variant to AppAction enum; minimal, safe change |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    actor User
    participant TUI as TUI Event Loop
    participant Cmd as commands/balance.rs
    participant UI as ui.rs (apply_command_result)
    participant Fetch as fetch_provider_balance (tokio::spawn)
    participant API as Provider HTTP API

    User->>TUI: /balance
    TUI->>Cmd: execute("/balance", app)
    Cmd-->>TUI: "CommandResult { action: FetchBalance }"
    TUI->>UI: apply_command_result(FetchBalance)
    UI->>Fetch: tokio::spawn(fetch_provider_balance)

    alt DeepSeek / DeepseekCN
        Fetch->>API: GET /user/balance
        API-->>Fetch: 200 JSON
    else OpenRouter credits
        Fetch->>API: GET /credits
        API-->>Fetch: 200 JSON
    else OpenRouter key fallback
        Fetch->>API: GET /credits
        API-->>Fetch: 401/403
        Fetch->>API: GET /key
        API-->>Fetch: 200 JSON
    else Novita
        Fetch->>API: GET /openapi/v1/billing/balance/detail
        API-->>Fetch: 200 JSON
    end

    Fetch->>TUI: balance_tx.send(BalanceEvent::Finished)
    TUI->>UI: drain_balance_events
    UI-->>User: Balance displayed in chat history
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22balance-provider-lookup%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22balance-provider-lookup%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fclient.rs%3A1188-1201%0A**Null%20value%20short-circuits%20remaining%20fallback%20keys**%0A%0AWhen%20the%20first%20matching%20key%20exists%20in%20the%20response%20but%20has%20a%20JSON%20%60null%60%20value%2C%20the%20function%20immediately%20returns%20%60Ok%28None%29%60%20without%20trying%20the%20remaining%20candidate%20keys.%20For%20example%2C%20a%20response%20like%20%60%7B%22available_balance%22%3A%20null%2C%20%22availableBalance%22%3A%20%2250000%22%7D%60%20would%20yield%20%60None%60%20%28displayed%20as%20%60%240.00%60%29%20instead%20of%20%60%245.00%60%2C%20because%20%60%22available_balance%22%60%20is%20found%20first%20and%20the%20early%20return%20skips%20%60%22availableBalance%22%60.%20The%20fallback%20list%20exists%20precisely%20to%20tolerate%20API%20version%20differences%2C%20so%20a%20null%20on%20one%20key%20variant%20should%20fall%20through%20to%20the%20next.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui.rs%3A4925-4933%0A**No%20guard%20against%20concurrent%20balance%20fetches**%0A%0AEvery%20invocation%20of%20%60%2Fbalance%60%20spawns%20an%20independent%20%60tokio%3A%3Aspawn%60%20task%20with%20no%20check%20for%20an%20in-flight%20request.%20Unlike%20%60FetchModels%60%20%28which%20awaits%20inline%29%2C%20a%20user%20who%20presses%20%60%2Fbalance%60%20twice%20before%20the%20first%20responds%20gets%20two%20separate%20%60BalanceEvent%3A%3AFinished%60%20messages%20posted%20to%20the%20channel.%20Both%20are%20drained%20and%20appended%20to%20the%20chat%20history%2C%20resulting%20in%20duplicate%20balance%20entries.%20A%20simple%20boolean%20flag%20on%20%60App%60%20%28or%20reusing%20the%20existing%20%60status_message%60%20as%20a%20sentinel%29%20would%20prevent%20re-entrancy.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fclient.rs%3A1188-1201%0A**Null%20value%20short-circuits%20remaining%20fallback%20keys**%0A%0AWhen%20the%20first%20matching%20key%20exists%20in%20the%20response%20but%20has%20a%20JSON%20%60null%60%20value%2C%20the%20function%20immediately%20returns%20%60Ok%28None%29%60%20without%20trying%20the%20remaining%20candidate%20keys.%20For%20example%2C%20a%20response%20like%20%60%7B%22available_balance%22%3A%20null%2C%20%22availableBalance%22%3A%20%2250000%22%7D%60%20would%20yield%20%60None%60%20%28displayed%20as%20%60%240.00%60%29%20instead%20of%20%60%245.00%60%2C%20because%20%60%22available_balance%22%60%20is%20found%20first%20and%20the%20early%20return%20skips%20%60%22availableBalance%22%60.%20The%20fallback%20list%20exists%20precisely%20to%20tolerate%20API%20version%20differences%2C%20so%20a%20null%20on%20one%20key%20variant%20should%20fall%20through%20to%20the%20next.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui.rs%3A4925-4933%0A**No%20guard%20against%20concurrent%20balance%20fetches**%0A%0AEvery%20invocation%20of%20%60%2Fbalance%60%20spawns%20an%20independent%20%60tokio%3A%3Aspawn%60%20task%20with%20no%20check%20for%20an%20in-flight%20request.%20Unlike%20%60FetchModels%60%20%28which%20awaits%20inline%29%2C%20a%20user%20who%20presses%20%60%2Fbalance%60%20twice%20before%20the%20first%20responds%20gets%20two%20separate%20%60BalanceEvent%3A%3AFinished%60%20messages%20posted%20to%20the%20channel.%20Both%20are%20drained%20and%20appended%20to%20the%20chat%20history%2C%20resulting%20in%20duplicate%20balance%20entries.%20A%20simple%20boolean%20flag%20on%20%60App%60%20%28or%20reusing%20the%20existing%20%60status_message%60%20as%20a%20sentinel%29%20would%20prevent%20re-entrancy.%0A%0A&repo=hmbown%2Fcodewhale&pr=2141&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fclient.rs%3A1188-1201%0A**Null%20value%20short-circuits%20remaining%20fallback%20keys**%0A%0AWhen%20the%20first%20matching%20key%20exists%20in%20the%20response%20but%20has%20a%20JSON%20%60null%60%20value%2C%20the%20function%20immediately%20returns%20%60Ok%28None%29%60%20without%20trying%20the%20remaining%20candidate%20keys.%20For%20example%2C%20a%20response%20like%20%60%7B%22available_balance%22%3A%20null%2C%20%22availableBalance%22%3A%20%2250000%22%7D%60%20would%20yield%20%60None%60%20%28displayed%20as%20%60%240.00%60%29%20instead%20of%20%60%245.00%60%2C%20because%20%60%22available_balance%22%60%20is%20found%20first%20and%20the%20early%20return%20skips%20%60%22availableBalance%22%60.%20The%20fallback%20list%20exists%20precisely%20to%20tolerate%20API%20version%20differences%2C%20so%20a%20null%20on%20one%20key%20variant%20should%20fall%20through%20to%20the%20next.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui.rs%3A4925-4933%0A**No%20guard%20against%20concurrent%20balance%20fetches**%0A%0AEvery%20invocation%20of%20%60%2Fbalance%60%20spawns%20an%20independent%20%60tokio%3A%3Aspawn%60%20task%20with%20no%20check%20for%20an%20in-flight%20request.%20Unlike%20%60FetchModels%60%20%28which%20awaits%20inline%29%2C%20a%20user%20who%20presses%20%60%2Fbalance%60%20twice%20before%20the%20first%20responds%20gets%20two%20separate%20%60BalanceEvent%3A%3AFinished%60%20messages%20posted%20to%20the%20channel.%20Both%20are%20drained%20and%20appended%20to%20the%20chat%20history%2C%20resulting%20in%20duplicate%20balance%20entries.%20A%20simple%20boolean%20flag%20on%20%60App%60%20%28or%20reusing%20the%20existing%20%60status_message%60%20as%20a%20sentinel%29%20would%20prevent%20re-entrancy.%0A%0A&pr=2141&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Address balance lookup review feedback"](https://github.com/hmbown/codewhale/commit/c7243fc05828dc878c4c1fcdc1b3d470b27e91a5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33808330)</sub>

<!-- /greptile_comment -->