### PR TITLE
Improve update release channels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -851,6 +851,7 @@ dependencies = [
  "codewhale-state",
  "dirs",
  "reqwest",
+ "semver",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ reqwest = { version = "0.13.1", default-features = false, features = ["json", "r
 rusqlite = { version = "0.32.1", features = ["bundled"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
+semver = "1.0.28"
 thiserror = "2.0"
 tokio = { version = "1.49.0", features = ["full"] }
 toml = "0.9.7"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -37,6 +37,7 @@ dirs.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 reqwest = { workspace = true, features = ["blocking"] }
+semver.workspace = true
 tokio.workspace = true
 sha2.workspace = true
 tempfile = "3.16"

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -232,7 +232,14 @@ The command prints the completion script to stdout; redirect it to a path your s
     /// Print a usage rollup from the audit log and session store.
     Metrics(MetricsArgs),
     /// Check for and apply updates to the `codewhale` binary.
-    Update,
+    Update(UpdateArgs),
+}
+
+#[derive(Debug, Args)]
+struct UpdateArgs {
+    /// Update to the latest beta release instead of the latest stable release.
+    #[arg(long)]
+    beta: bool,
 }
 
 #[derive(Debug, Args)]
@@ -557,7 +564,7 @@ fn run() -> Result<()> {
             Ok(())
         }
         Some(Commands::Metrics(args)) => run_metrics_command(args),
-        Some(Commands::Update) => update::run_update(),
+        Some(Commands::Update(args)) => update::run_update(args.beta),
         None => {
             let resolved_runtime = resolve_runtime_for_dispatch(&mut store, &runtime_overrides);
             let forwarded = root_tui_passthrough(&cli)?;
@@ -1795,6 +1802,21 @@ mod tests {
             Some(Commands::Config(ConfigArgs {
                 command: ConfigCommand::Path
             }))
+        ));
+    }
+
+    #[test]
+    fn parses_update_beta_flag() {
+        let cli = parse_ok(&["codewhale", "update"]);
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Update(UpdateArgs { beta: false }))
+        ));
+
+        let cli = parse_ok(&["codewhale", "update", "--beta"]);
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Update(UpdateArgs { beta: true }))
         ));
     }
 

--- a/crates/cli/src/update.rs
+++ b/crates/cli/src/update.rs
@@ -13,6 +13,7 @@ use std::io::Write;
 
 const CHECKSUM_MANIFEST_ASSET: &str = "codewhale-artifacts-sha256.txt";
 const LATEST_RELEASE_URL: &str = "https://api.github.com/repos/Hmbown/CodeWhale/releases/latest";
+const RELEASES_URL: &str = "https://api.github.com/repos/Hmbown/CodeWhale/releases?per_page=100";
 const CNB_REPO_URL: &str = "https://cnb.cool/codewhale.net/codewhale";
 const RELEASE_BASE_URL_ENV: &str = "DEEPSEEK_TUI_RELEASE_BASE_URL";
 const LEGACY_RELEASE_BASE_URL_ENV: &str = "DEEPSEEK_RELEASE_BASE_URL";
@@ -21,18 +22,26 @@ const LEGACY_UPDATE_VERSION_ENV: &str = "DEEPSEEK_VERSION";
 const UPDATE_USER_AGENT: &str = "codewhale-updater";
 
 /// Run the self-update workflow.
-pub fn run_update() -> Result<()> {
+pub fn run_update(beta: bool) -> Result<()> {
     let current_exe =
         std::env::current_exe().context("failed to determine current executable path")?;
     let targets = update_targets_for_exe(&current_exe);
+    let channel = ReleaseChannel::from_beta_flag(beta);
+    let current_version = env!("CARGO_PKG_VERSION");
 
-    println!("Checking for updates...");
+    println!("Checking for {} updates...", channel.label());
     println!("Current binary: {}", current_exe.display());
+    println!("Current version: v{current_version}");
 
     // Step 1: Fetch latest release metadata
-    let release = fetch_latest_release().with_context(update_network_fallback_hint)?;
+    let release = fetch_latest_release(channel).with_context(update_network_fallback_hint)?;
     let latest_tag = &release.tag_name;
-    println!("Latest release: {latest_tag}");
+    println!("Latest {} release: {latest_tag}", channel.label());
+
+    if !update_is_needed(current_version, latest_tag)? {
+        println!("Already up to date; no download needed.");
+        return Ok(());
+    }
 
     // Step 2: Download the aggregated SHA256 checksum manifest if available
     let checksum_manifest = match select_checksum_manifest_asset(&release) {
@@ -120,6 +129,25 @@ pub fn run_update() -> Result<()> {
     );
 
     Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReleaseChannel {
+    Stable,
+    Beta,
+}
+
+impl ReleaseChannel {
+    fn from_beta_flag(beta: bool) -> Self {
+        if beta { Self::Beta } else { Self::Stable }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Stable => "stable",
+            Self::Beta => "beta",
+        }
+    }
 }
 
 pub(crate) fn release_arch_for_rust_arch(arch: &str) -> &str {
@@ -278,6 +306,8 @@ fn expected_sha256_from_manifest(text: &str, asset_name: &str) -> Result<String>
 #[derive(serde::Deserialize, Debug)]
 struct Release {
     tag_name: String,
+    #[serde(default)]
+    prerelease: bool,
     assets: Vec<Asset>,
 }
 
@@ -296,7 +326,7 @@ fn update_http_client() -> Result<reqwest::blocking::Client> {
 }
 
 /// Fetch the latest release metadata from GitHub.
-fn fetch_latest_release() -> Result<Release> {
+fn fetch_latest_release(channel: ReleaseChannel) -> Result<Release> {
     if let Some(base_url) = release_base_url_from_env() {
         let version = update_version_from_env().unwrap_or_else(|| env!("CARGO_PKG_VERSION").into());
         return Ok(release_from_mirror_base_url(
@@ -306,7 +336,10 @@ fn fetch_latest_release() -> Result<Release> {
             std::env::consts::ARCH,
         ));
     }
-    fetch_latest_release_from_url(LATEST_RELEASE_URL)
+    match channel {
+        ReleaseChannel::Stable => fetch_latest_release_from_url(LATEST_RELEASE_URL),
+        ReleaseChannel::Beta => fetch_latest_beta_release_from_url(RELEASES_URL),
+    }
 }
 
 fn release_base_url_from_env() -> Option<String> {
@@ -345,7 +378,11 @@ fn release_from_mirror_base_url(
         });
     }
 
-    Release { tag_name, assets }
+    Release {
+        tag_name,
+        prerelease: false,
+        assets,
+    }
 }
 
 fn mirror_asset_url(base_url: &str, asset_name: &str) -> String {
@@ -386,6 +423,54 @@ fn fetch_latest_release_from_url(url: &str) -> Result<Release> {
     })?;
 
     Ok(release)
+}
+
+fn fetch_latest_beta_release_from_url(url: &str) -> Result<Release> {
+    let client = update_http_client()?;
+    let response = client
+        .get(url)
+        .header(reqwest::header::ACCEPT, "application/vnd.github+json")
+        .send()
+        .with_context(|| format!("failed to fetch release list from {url}"))?;
+    let status = response.status();
+    let body = response
+        .text()
+        .with_context(|| format!("failed to read release list response from {url}"))?;
+
+    if !status.is_success() {
+        bail!("GitHub release list request failed with HTTP {status}: {body}");
+    }
+
+    let releases: Vec<Release> = serde_json::from_str(&body).with_context(|| {
+        format!("failed to parse release list JSON from GitHub API. Response: {body}")
+    })?;
+
+    releases
+        .into_iter()
+        .find(is_beta_release)
+        .context("no beta release found in GitHub releases")
+}
+
+fn is_beta_release(release: &Release) -> bool {
+    release.prerelease || release.tag_name.to_ascii_lowercase().contains("beta")
+}
+
+fn update_is_needed(current_version: &str, latest_tag: &str) -> Result<bool> {
+    let current = parse_release_version(current_version)
+        .with_context(|| format!("failed to parse current version {current_version:?}"))?;
+    let latest = parse_release_version(latest_tag)
+        .with_context(|| format!("failed to parse latest release tag {latest_tag:?}"))?;
+    Ok(current < latest)
+}
+
+fn parse_release_version(value: &str) -> Result<semver::Version> {
+    let version = value
+        .trim()
+        .trim_start_matches('v')
+        .split_whitespace()
+        .next()
+        .unwrap_or("");
+    semver::Version::parse(version).with_context(|| format!("invalid semver: {value:?}"))
 }
 
 /// Download a URL to bytes.
@@ -838,6 +923,50 @@ E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855  *codewhale-win
     }
 
     #[test]
+    fn update_is_needed_only_when_latest_is_newer() {
+        assert!(update_is_needed("0.8.45", "v0.8.46").unwrap());
+        assert!(update_is_needed("0.8.45", "v0.9.0-beta.1").unwrap());
+        assert!(!update_is_needed("0.8.45", "v0.8.45").unwrap());
+        assert!(!update_is_needed("0.9.0", "v0.9.0-beta.1").unwrap());
+        assert!(!update_is_needed("0.9.0-beta.2", "v0.9.0-beta.1").unwrap());
+    }
+
+    #[test]
+    fn parse_release_version_accepts_tags_and_build_suffixes() {
+        assert_eq!(
+            parse_release_version("v0.9.0-beta.1").unwrap(),
+            semver::Version::parse("0.9.0-beta.1").unwrap()
+        );
+        assert_eq!(
+            parse_release_version("0.8.45 (abcdef123456)").unwrap(),
+            semver::Version::parse("0.8.45").unwrap()
+        );
+    }
+
+    #[test]
+    fn beta_release_detection_accepts_prerelease_or_beta_tag() {
+        let prerelease = Release {
+            tag_name: "v0.9.0-rc.1".to_string(),
+            prerelease: true,
+            assets: vec![],
+        };
+        let beta_tag = Release {
+            tag_name: "v0.9.0-beta.1".to_string(),
+            prerelease: false,
+            assets: vec![],
+        };
+        let stable = Release {
+            tag_name: "v0.9.0".to_string(),
+            prerelease: false,
+            assets: vec![],
+        };
+
+        assert!(is_beta_release(&prerelease));
+        assert!(is_beta_release(&beta_tag));
+        assert!(!is_beta_release(&stable));
+    }
+
+    #[test]
     fn update_fallback_hint_points_china_users_to_cnb_and_asset_mirrors() {
         let hint = update_network_fallback_hint();
 
@@ -914,6 +1043,47 @@ E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855  *codewhale-win
 
         assert!(
             err.to_string().contains("HTTP 500"),
+            "unexpected error: {err:#}"
+        );
+        handle.join().expect("test server thread");
+    }
+
+    #[test]
+    fn fetch_latest_beta_release_from_url_selects_first_beta_release() {
+        let body = br#"[
+          { "tag_name": "v0.9.0", "prerelease": false, "assets": [] },
+          { "tag_name": "v0.9.0-beta.2", "prerelease": true, "assets": [
+            { "name": "codewhale-linux-x64", "browser_download_url": "http://example.invalid/codewhale-linux-x64" }
+          ] },
+          { "tag_name": "v0.9.0-beta.1", "prerelease": true, "assets": [] }
+        ]"#;
+        let (url, request_rx, handle) = serve_http_once("200 OK", "application/json", body);
+        let release =
+            fetch_latest_beta_release_from_url(&url).expect("beta release JSON should parse");
+
+        assert_eq!(release.tag_name, "v0.9.0-beta.2");
+        assert!(release.prerelease);
+
+        let request = request_rx.recv().expect("captured request");
+        let request_lower = request.to_ascii_lowercase();
+        assert!(request.starts_with("GET /release "), "got {request:?}");
+        assert!(
+            request_lower.contains("accept: application/vnd.github+json"),
+            "got {request:?}"
+        );
+        handle.join().expect("test server thread");
+    }
+
+    #[test]
+    fn fetch_latest_beta_release_from_url_reports_missing_beta() {
+        let body = br#"[
+          { "tag_name": "v0.9.0", "prerelease": false, "assets": [] }
+        ]"#;
+        let (url, _request_rx, handle) = serve_http_once("200 OK", "application/json", body);
+        let err = fetch_latest_beta_release_from_url(&url).expect_err("missing beta should fail");
+
+        assert!(
+            err.to_string().contains("no beta release found"),
             "unexpected error: {err:#}"
         );
         handle.join().expect("test server thread");

--- a/crates/cli/src/update.rs
+++ b/crates/cli/src/update.rs
@@ -34,11 +34,19 @@ pub fn run_update(beta: bool) -> Result<()> {
     println!("Current version: v{current_version}");
 
     // Step 1: Fetch latest release metadata
-    let release = fetch_latest_release(channel).with_context(update_network_fallback_hint)?;
+    let fetched = fetch_latest_release(channel).with_context(update_network_fallback_hint)?;
+    let release = &fetched.release;
     let latest_tag = &release.tag_name;
     println!("Latest {} release: {latest_tag}", channel.label());
 
-    if !update_is_needed(current_version, latest_tag)? {
+    if let ReleaseSource::Mirror { base_url } = &fetched.source {
+        if channel == ReleaseChannel::Beta {
+            println!(
+                "Using release mirror {}; --beta does not select GitHub beta releases in mirror mode.",
+                base_url
+            );
+        }
+    } else if !update_is_needed(channel, current_version, latest_tag)? {
         println!("Already up to date; no download needed.");
         return Ok(());
     }
@@ -148,6 +156,18 @@ impl ReleaseChannel {
             Self::Beta => "beta",
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FetchedRelease {
+    release: Release,
+    source: ReleaseSource,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ReleaseSource {
+    GitHub,
+    Mirror { base_url: String },
 }
 
 pub(crate) fn release_arch_for_rust_arch(arch: &str) -> &str {
@@ -303,7 +323,7 @@ fn expected_sha256_from_manifest(text: &str, asset_name: &str) -> Result<String>
 }
 
 /// GitHub release metadata.
-#[derive(serde::Deserialize, Debug)]
+#[derive(serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 struct Release {
     tag_name: String,
     #[serde(default)]
@@ -312,7 +332,7 @@ struct Release {
 }
 
 /// A single release asset.
-#[derive(serde::Deserialize, Debug)]
+#[derive(serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 struct Asset {
     name: String,
     browser_download_url: String,
@@ -326,20 +346,27 @@ fn update_http_client() -> Result<reqwest::blocking::Client> {
 }
 
 /// Fetch the latest release metadata from GitHub.
-fn fetch_latest_release(channel: ReleaseChannel) -> Result<Release> {
+fn fetch_latest_release(channel: ReleaseChannel) -> Result<FetchedRelease> {
     if let Some(base_url) = release_base_url_from_env() {
         let version = update_version_from_env().unwrap_or_else(|| env!("CARGO_PKG_VERSION").into());
-        return Ok(release_from_mirror_base_url(
-            &base_url,
-            &version,
-            std::env::consts::OS,
-            std::env::consts::ARCH,
-        ));
+        return Ok(FetchedRelease {
+            release: release_from_mirror_base_url(
+                &base_url,
+                &version,
+                std::env::consts::OS,
+                std::env::consts::ARCH,
+            ),
+            source: ReleaseSource::Mirror { base_url },
+        });
     }
-    match channel {
+    let release = match channel {
         ReleaseChannel::Stable => fetch_latest_release_from_url(LATEST_RELEASE_URL),
         ReleaseChannel::Beta => fetch_latest_beta_release_from_url(RELEASES_URL),
-    }
+    }?;
+    Ok(FetchedRelease {
+        release,
+        source: ReleaseSource::GitHub,
+    })
 }
 
 fn release_base_url_from_env() -> Option<String> {
@@ -441,6 +468,8 @@ fn fetch_latest_beta_release_from_url(url: &str) -> Result<Release> {
         bail!("GitHub release list request failed with HTTP {status}: {body}");
     }
 
+    // GitHub caps this endpoint at 100 releases per page. CodeWhale uses the
+    // first page as the latest-beta search window, matching GitHub's ordering.
     let releases: Vec<Release> = serde_json::from_str(&body).with_context(|| {
         format!("failed to parse release list JSON from GitHub API. Response: {body}")
     })?;
@@ -452,15 +481,30 @@ fn fetch_latest_beta_release_from_url(url: &str) -> Result<Release> {
 }
 
 fn is_beta_release(release: &Release) -> bool {
-    release.prerelease || release.tag_name.to_ascii_lowercase().contains("beta")
+    release.tag_name.to_ascii_lowercase().contains("beta")
 }
 
-fn update_is_needed(current_version: &str, latest_tag: &str) -> Result<bool> {
+fn update_is_needed(
+    channel: ReleaseChannel,
+    current_version: &str,
+    latest_tag: &str,
+) -> Result<bool> {
     let current = parse_release_version(current_version)
         .with_context(|| format!("failed to parse current version {current_version:?}"))?;
     let latest = parse_release_version(latest_tag)
         .with_context(|| format!("failed to parse latest release tag {latest_tag:?}"))?;
-    Ok(current < latest)
+
+    match channel {
+        ReleaseChannel::Stable => Ok(current < latest),
+        ReleaseChannel::Beta => {
+            if current == latest {
+                return Ok(false);
+            }
+            let current_is_beta = version_is_beta(&current);
+            let latest_is_beta = version_is_beta(&latest);
+            Ok(!(current_is_beta && latest_is_beta && current > latest))
+        }
+    }
 }
 
 fn parse_release_version(value: &str) -> Result<semver::Version> {
@@ -471,6 +515,10 @@ fn parse_release_version(value: &str) -> Result<semver::Version> {
         .next()
         .unwrap_or("");
     semver::Version::parse(version).with_context(|| format!("invalid semver: {value:?}"))
+}
+
+fn version_is_beta(version: &semver::Version) -> bool {
+    version.pre.as_str().to_ascii_lowercase().contains("beta")
 }
 
 /// Download a URL to bytes.
@@ -923,12 +971,22 @@ E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855  *codewhale-win
     }
 
     #[test]
-    fn update_is_needed_only_when_latest_is_newer() {
-        assert!(update_is_needed("0.8.45", "v0.8.46").unwrap());
-        assert!(update_is_needed("0.8.45", "v0.9.0-beta.1").unwrap());
-        assert!(!update_is_needed("0.8.45", "v0.8.45").unwrap());
-        assert!(!update_is_needed("0.9.0", "v0.9.0-beta.1").unwrap());
-        assert!(!update_is_needed("0.9.0-beta.2", "v0.9.0-beta.1").unwrap());
+    fn stable_update_is_needed_only_when_latest_is_newer() {
+        assert!(update_is_needed(ReleaseChannel::Stable, "0.8.45", "v0.8.46").unwrap());
+        assert!(update_is_needed(ReleaseChannel::Stable, "0.8.45", "v0.9.0-beta.1").unwrap());
+        assert!(!update_is_needed(ReleaseChannel::Stable, "0.8.45", "v0.8.45").unwrap());
+        assert!(!update_is_needed(ReleaseChannel::Stable, "0.9.0", "v0.9.0-beta.1").unwrap());
+        assert!(
+            !update_is_needed(ReleaseChannel::Stable, "0.9.0-beta.2", "v0.9.0-beta.1").unwrap()
+        );
+    }
+
+    #[test]
+    fn beta_update_allows_switching_from_same_stable_to_beta() {
+        assert!(update_is_needed(ReleaseChannel::Beta, "1.0.0", "v1.0.0-beta.2").unwrap());
+        assert!(!update_is_needed(ReleaseChannel::Beta, "1.0.0-beta.2", "v1.0.0-beta.2").unwrap());
+        assert!(!update_is_needed(ReleaseChannel::Beta, "1.0.0-beta.3", "v1.0.0-beta.2").unwrap());
+        assert!(update_is_needed(ReleaseChannel::Beta, "1.0.0-beta.2", "v1.0.0-beta.3").unwrap());
     }
 
     #[test]
@@ -944,8 +1002,8 @@ E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855  *codewhale-win
     }
 
     #[test]
-    fn beta_release_detection_accepts_prerelease_or_beta_tag() {
-        let prerelease = Release {
+    fn beta_release_detection_requires_beta_tag() {
+        let rc_prerelease = Release {
             tag_name: "v0.9.0-rc.1".to_string(),
             prerelease: true,
             assets: vec![],
@@ -961,7 +1019,7 @@ E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855  *codewhale-win
             assets: vec![],
         };
 
-        assert!(is_beta_release(&prerelease));
+        assert!(!is_beta_release(&rc_prerelease));
         assert!(is_beta_release(&beta_tag));
         assert!(!is_beta_release(&stable));
     }
@@ -1052,6 +1110,7 @@ E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855  *codewhale-win
     fn fetch_latest_beta_release_from_url_selects_first_beta_release() {
         let body = br#"[
           { "tag_name": "v0.9.0", "prerelease": false, "assets": [] },
+          { "tag_name": "v0.9.0-rc.1", "prerelease": true, "assets": [] },
           { "tag_name": "v0.9.0-beta.2", "prerelease": true, "assets": [
             { "name": "codewhale-linux-x64", "browser_download_url": "http://example.invalid/codewhale-linux-x64" }
           ] },

--- a/crates/cli/src/update.rs
+++ b/crates/cli/src/update.rs
@@ -500,9 +500,15 @@ fn update_is_needed(
             if current == latest {
                 return Ok(false);
             }
-            let current_is_beta = version_is_beta(&current);
             let latest_is_beta = version_is_beta(&latest);
-            Ok(!(current_is_beta && latest_is_beta && current > latest))
+            let current_is_stable = current.pre.is_empty();
+            let same_release_line = current.major == latest.major
+                && current.minor == latest.minor
+                && current.patch == latest.patch;
+            if current > latest && !(current_is_stable && same_release_line) {
+                return Ok(false);
+            }
+            Ok(latest_is_beta)
         }
     }
 }
@@ -987,6 +993,8 @@ E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855  *codewhale-win
         assert!(!update_is_needed(ReleaseChannel::Beta, "1.0.0-beta.2", "v1.0.0-beta.2").unwrap());
         assert!(!update_is_needed(ReleaseChannel::Beta, "1.0.0-beta.3", "v1.0.0-beta.2").unwrap());
         assert!(update_is_needed(ReleaseChannel::Beta, "1.0.0-beta.2", "v1.0.0-beta.3").unwrap());
+        assert!(!update_is_needed(ReleaseChannel::Beta, "2.0.0", "v1.0.0-beta.3").unwrap());
+        assert!(!update_is_needed(ReleaseChannel::Beta, "1.0.0-rc.1", "v1.0.0-beta.3").unwrap());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add stable and beta release channels for codewhale update
- skip checksum and binary downloads when the local version is already current or newer
- add semver-based version comparison and focused tests

## Tests
- cargo fmt
- cargo test -p codewhale-cli

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces stable and beta release channels for `codewhale update`, adds semver-based version comparison to skip redundant downloads, and includes focused unit tests for the new logic.

- `ReleaseChannel`, `FetchedRelease`, and `ReleaseSource` types are added to `update.rs`; `run_update` now accepts a `beta: bool` flag wired to a new `--beta` CLI argument in `lib.rs`.
- `fetch_latest_beta_release_from_url` scans the `/releases?per_page=100` list for the first tag containing \"beta\"; `update_is_needed` uses `semver` to guard against redundant downloads and cross-channel downgrades.
- The mirror-source path correctly emits a warning when `--beta` is used, addressing a concern from the previous review thread.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the channel-switching and downgrade-prevention logic is well-tested and the previous review concerns have been addressed.

The core version-comparison logic in update_is_needed handles the key edge cases (stable-to-beta channel switch, cross-version downgrade prevention, RC vs beta disambiguation) and every case is backed by a unit test. The remaining observations are quality improvements rather than present defects.

crates/cli/src/update.rs — specifically the stable-channel branch of update_is_needed and the mirror-source early-exit path.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/cli/src/update.rs | Core update logic: adds ReleaseChannel, FetchedRelease, update_is_needed, fetch_latest_beta_release_from_url; previous-thread issues are addressed; stable channel has no prerelease guard; mirror path skips the version check |
| crates/cli/src/lib.rs | Adds UpdateArgs struct with --beta flag and plumbs it into run_update; CLI parsing test added; straightforward change |
| Cargo.toml | Adds semver 1.0.28 as workspace dependency |
| crates/cli/Cargo.toml | Picks up semver from workspace |
| Cargo.lock | Lock file updated for semver dependency |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[codewhale update] -->|--beta flag| B{ReleaseChannel}
    B -->|Stable| C[fetch /releases/latest]
    B -->|Beta| D[fetch /releases?per_page=100]
    C --> E{Mirror env set?}
    D --> E
    E -->|Yes: Mirror| F[release_from_mirror_base_url]
    F --> G{channel == Beta?}
    G -->|Yes| H[Print mirror warning]
    G -->|No| I[Proceed to download]
    H --> I
    E -->|No: GitHub| J[update_is_needed?]
    J -->|No: already current| K[Exit: no download needed]
    J -->|Yes| I
    I --> L[Download checksum manifest]
    L --> M[Download + verify binaries]
    M --> N[Replace binaries atomically]
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22improve-update-channels%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22improve-update-channels%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Fcli%2Fsrc%2Fupdate.rs%3A498%0AThe%20stable%20channel's%20%60update_is_needed%60%20check%20has%20no%20guard%20against%20installing%20a%20prerelease.%20In%20semver%2C%20%600.8.45%20%3C%200.9.0-beta.1%60%20evaluates%20to%20%60true%60%2C%20so%20if%20a%20mirror%20URL%20or%20an%20unexpected%20GitHub%20response%20ever%20returns%20a%20prerelease%20tag%20as%20the%20%22latest%20stable%22%2C%20this%20function%20would%20approve%20installing%20it.%20The%20test%20on%20line%20982%20explicitly%20documents%20this%20behaviour.%20A%20simple%20%60!latest.pre.is_empty%28%29%60%20check%20can%20prevent%20it.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20ReleaseChannel%3A%3AStable%20%3D%3E%20Ok%28current%20%3C%20latest%20%26%26%20latest.pre.is_empty%28%29%29%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Fcli%2Fsrc%2Fupdate.rs%3A42-52%0A**Mirror%20source%20skips%20version%20check%20for%20stable%20too**%0A%0AThe%20%60if%2Felse%20if%60%20structure%20means%20%60update_is_needed%60%20is%20never%20called%20for%20mirror%20sources%20on%20any%20channel%20%E2%80%94%20not%20just%20%60--beta%60.%20A%20stable%20user%20whose%20mirror%20happens%20to%20serve%20the%20same%20version%20they%20already%20have%20will%20re-download%20and%20reinstall%20every%20time%20they%20run%20%60codewhale%20update%60.%20The%20PR%20description%20says%20%22skip%20checksum%20and%20binary%20downloads%20when%20the%20local%20version%20is%20already%20current%20or%20newer%22%2C%20but%20that%20improvement%20only%20applies%20to%20GitHub%20sources.%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Fcli%2Fsrc%2Fupdate.rs%3A1137-1145%0AThe%20new%20%60fetch_latest_beta_release_from_url%60%20test%20checks%20the%20%60Accept%60%20header%20but%20not%20the%20%60User-Agent%60%2C%20unlike%20the%20existing%20%60fetch_latest_release_from_url%60%20test.%20Adding%20the%20assertion%20keeps%20the%20two%20tests%20consistent%20and%20would%20catch%20a%20regression%20if%20%60update_http_client%60%20stopped%20setting%20the%20user-agent.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20assert!%28%0A%20%20%20%20%20%20%20%20%20%20%20%20request_lower.contains%28%22accept%3A%20application%2Fvnd.github%2Bjson%22%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22got%20%7Brequest%3A%3F%7D%22%0A%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%20%20assert!%28%0A%20%20%20%20%20%20%20%20%20%20%20%20request_lower.contains%28%22user-agent%3A%20codewhale-updater%22%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22got%20%7Brequest%3A%3F%7D%22%0A%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%20%20handle.join%28%29.expect%28%22test%20server%20thread%22%29%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20%23%5Btest%5D%0A%20%20%20%20fn%20fetch_latest_beta_release_from_url_reports_missing_beta%28%29%20%7B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Fcli%2Fsrc%2Fupdate.rs%3A498%0AThe%20stable%20channel's%20%60update_is_needed%60%20check%20has%20no%20guard%20against%20installing%20a%20prerelease.%20In%20semver%2C%20%600.8.45%20%3C%200.9.0-beta.1%60%20evaluates%20to%20%60true%60%2C%20so%20if%20a%20mirror%20URL%20or%20an%20unexpected%20GitHub%20response%20ever%20returns%20a%20prerelease%20tag%20as%20the%20%22latest%20stable%22%2C%20this%20function%20would%20approve%20installing%20it.%20The%20test%20on%20line%20982%20explicitly%20documents%20this%20behaviour.%20A%20simple%20%60!latest.pre.is_empty%28%29%60%20check%20can%20prevent%20it.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20ReleaseChannel%3A%3AStable%20%3D%3E%20Ok%28current%20%3C%20latest%20%26%26%20latest.pre.is_empty%28%29%29%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Fcli%2Fsrc%2Fupdate.rs%3A42-52%0A**Mirror%20source%20skips%20version%20check%20for%20stable%20too**%0A%0AThe%20%60if%2Felse%20if%60%20structure%20means%20%60update_is_needed%60%20is%20never%20called%20for%20mirror%20sources%20on%20any%20channel%20%E2%80%94%20not%20just%20%60--beta%60.%20A%20stable%20user%20whose%20mirror%20happens%20to%20serve%20the%20same%20version%20they%20already%20have%20will%20re-download%20and%20reinstall%20every%20time%20they%20run%20%60codewhale%20update%60.%20The%20PR%20description%20says%20%22skip%20checksum%20and%20binary%20downloads%20when%20the%20local%20version%20is%20already%20current%20or%20newer%22%2C%20but%20that%20improvement%20only%20applies%20to%20GitHub%20sources.%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Fcli%2Fsrc%2Fupdate.rs%3A1137-1145%0AThe%20new%20%60fetch_latest_beta_release_from_url%60%20test%20checks%20the%20%60Accept%60%20header%20but%20not%20the%20%60User-Agent%60%2C%20unlike%20the%20existing%20%60fetch_latest_release_from_url%60%20test.%20Adding%20the%20assertion%20keeps%20the%20two%20tests%20consistent%20and%20would%20catch%20a%20regression%20if%20%60update_http_client%60%20stopped%20setting%20the%20user-agent.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20assert!%28%0A%20%20%20%20%20%20%20%20%20%20%20%20request_lower.contains%28%22accept%3A%20application%2Fvnd.github%2Bjson%22%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22got%20%7Brequest%3A%3F%7D%22%0A%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%20%20assert!%28%0A%20%20%20%20%20%20%20%20%20%20%20%20request_lower.contains%28%22user-agent%3A%20codewhale-updater%22%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22got%20%7Brequest%3A%3F%7D%22%0A%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%20%20handle.join%28%29.expect%28%22test%20server%20thread%22%29%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20%23%5Btest%5D%0A%20%20%20%20fn%20fetch_latest_beta_release_from_url_reports_missing_beta%28%29%20%7B%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2145&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Fcli%2Fsrc%2Fupdate.rs%3A498%0AThe%20stable%20channel's%20%60update_is_needed%60%20check%20has%20no%20guard%20against%20installing%20a%20prerelease.%20In%20semver%2C%20%600.8.45%20%3C%200.9.0-beta.1%60%20evaluates%20to%20%60true%60%2C%20so%20if%20a%20mirror%20URL%20or%20an%20unexpected%20GitHub%20response%20ever%20returns%20a%20prerelease%20tag%20as%20the%20%22latest%20stable%22%2C%20this%20function%20would%20approve%20installing%20it.%20The%20test%20on%20line%20982%20explicitly%20documents%20this%20behaviour.%20A%20simple%20%60!latest.pre.is_empty%28%29%60%20check%20can%20prevent%20it.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20ReleaseChannel%3A%3AStable%20%3D%3E%20Ok%28current%20%3C%20latest%20%26%26%20latest.pre.is_empty%28%29%29%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Fcli%2Fsrc%2Fupdate.rs%3A42-52%0A**Mirror%20source%20skips%20version%20check%20for%20stable%20too**%0A%0AThe%20%60if%2Felse%20if%60%20structure%20means%20%60update_is_needed%60%20is%20never%20called%20for%20mirror%20sources%20on%20any%20channel%20%E2%80%94%20not%20just%20%60--beta%60.%20A%20stable%20user%20whose%20mirror%20happens%20to%20serve%20the%20same%20version%20they%20already%20have%20will%20re-download%20and%20reinstall%20every%20time%20they%20run%20%60codewhale%20update%60.%20The%20PR%20description%20says%20%22skip%20checksum%20and%20binary%20downloads%20when%20the%20local%20version%20is%20already%20current%20or%20newer%22%2C%20but%20that%20improvement%20only%20applies%20to%20GitHub%20sources.%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Fcli%2Fsrc%2Fupdate.rs%3A1137-1145%0AThe%20new%20%60fetch_latest_beta_release_from_url%60%20test%20checks%20the%20%60Accept%60%20header%20but%20not%20the%20%60User-Agent%60%2C%20unlike%20the%20existing%20%60fetch_latest_release_from_url%60%20test.%20Adding%20the%20assertion%20keeps%20the%20two%20tests%20consistent%20and%20would%20catch%20a%20regression%20if%20%60update_http_client%60%20stopped%20setting%20the%20user-agent.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20assert!%28%0A%20%20%20%20%20%20%20%20%20%20%20%20request_lower.contains%28%22accept%3A%20application%2Fvnd.github%2Bjson%22%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22got%20%7Brequest%3A%3F%7D%22%0A%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%20%20assert!%28%0A%20%20%20%20%20%20%20%20%20%20%20%20request_lower.contains%28%22user-agent%3A%20codewhale-updater%22%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22got%20%7Brequest%3A%3F%7D%22%0A%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%20%20handle.join%28%29.expect%28%22test%20server%20thread%22%29%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20%23%5Btest%5D%0A%20%20%20%20fn%20fetch_latest_beta_release_from_url_reports_missing_beta%28%29%20%7B%0A%60%60%60%0A%0A&pr=2145&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["Prevent beta update downgrades"](https://github.com/hmbown/codewhale/commit/6b6101739e8ad1d0aed7bc0128639a7a7ac4c03e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33847822)</sub>

<!-- /greptile_comment -->