### PR TITLE
fix(grep_files): wrap walk in spawn_blocking + 30s timeout

### DIFF
--- a/crates/tui/src/tools/search.rs
+++ b/crates/tui/src/tools/search.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 
 /// Maximum number of results to return to avoid overwhelming output
@@ -20,6 +21,11 @@ const MAX_RESULTS: usize = 100;
 
 /// Maximum file size to search (skip large binaries)
 const MAX_FILE_SIZE: u64 = 10 * 1024 * 1024; // 10MB
+
+/// Hard cap on a single grep_files run. The directory walk plus per-file regex
+/// is synchronous blocking work; without this it can run for minutes on a large
+/// tree. Mirrors the file_search tool so both blocking searches behave the same.
+const GREP_FILES_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Result of a grep match
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -149,98 +155,152 @@ impl ToolSpec for GrepFilesTool {
         // Resolve search path
         let search_path = context.resolve_path(path_str)?;
 
-        let cancel_token = context.cancel_token.as_ref();
+        let workspace = context.workspace.clone();
+        let cancel_token = context.cancel_token.clone();
 
-        // Collect files to search
-        let files = collect_files(
-            &search_path,
-            &include_patterns,
-            &exclude_patterns,
-            cancel_token,
-        )?;
+        // The directory walk and per-file regex are synchronous blocking work.
+        // Run them on a blocking worker bounded by a hard timeout so a huge tree
+        // can't pin the async runtime and leave the stop button unresponsive.
+        let result = run_blocking_grep(GREP_FILES_TIMEOUT, cancel_token.clone(), move || {
+            let cancel_token = cancel_token.as_ref();
 
-        // Search files
-        let mut results: Vec<GrepMatch> = Vec::new();
-        let mut files_searched = 0;
-        let mut total_matches = 0;
+            // Collect files to search
+            let files = collect_files(
+                &search_path,
+                &include_patterns,
+                &exclude_patterns,
+                cancel_token,
+            )?;
 
-        for file_path in files {
-            check_cancelled(cancel_token)?;
+            // Search files
+            let mut results: Vec<GrepMatch> = Vec::new();
+            let mut files_searched = 0;
+            let mut total_matches = 0;
 
-            if results.len() >= max_results {
-                break;
-            }
-
-            // Skip files that are too large
-            if let Ok(metadata) = fs::metadata(&file_path)
-                && metadata.len() > MAX_FILE_SIZE
-            {
-                continue;
-            }
-
-            // Read file content
-            let Ok(file_content) = fs::read_to_string(&file_path) else {
-                continue; // Skip binary or unreadable files
-            };
-
-            files_searched += 1;
-            let lines: Vec<&str> = file_content.lines().collect();
-
-            for (line_idx, line) in lines.iter().enumerate() {
+            for file_path in files {
                 check_cancelled(cancel_token)?;
 
-                if regex.is_match(line) {
-                    total_matches += 1;
+                if results.len() >= max_results {
+                    break;
+                }
 
-                    // Get context lines
-                    let context_before: Vec<String> = (line_idx.saturating_sub(context_lines)
-                        ..line_idx)
-                        .filter_map(|i| lines.get(i).map(|s| (*s).to_string()))
-                        .collect();
+                // Skip files that are too large
+                if let Ok(metadata) = fs::metadata(&file_path)
+                    && metadata.len() > MAX_FILE_SIZE
+                {
+                    continue;
+                }
 
-                    let context_after: Vec<String> = ((line_idx + 1)
-                        ..=(line_idx + context_lines).min(lines.len() - 1))
-                        .filter_map(|i| lines.get(i).map(|s| (*s).to_string()))
-                        .collect();
+                // Read file content
+                let Ok(file_content) = fs::read_to_string(&file_path) else {
+                    continue; // Skip binary or unreadable files
+                };
 
-                    // Get relative path from workspace
-                    let relative_path = file_path
-                        .strip_prefix(&context.workspace)
-                        .unwrap_or(&file_path)
-                        .to_string_lossy()
-                        .to_string();
+                files_searched += 1;
+                let lines: Vec<&str> = file_content.lines().collect();
 
-                    results.push(GrepMatch {
-                        file: relative_path,
-                        line_number: line_idx + 1,
-                        line: (*line).to_string(),
-                        context_before,
-                        context_after,
-                    });
+                for (line_idx, line) in lines.iter().enumerate() {
+                    check_cancelled(cancel_token)?;
 
-                    if results.len() >= max_results {
-                        break;
+                    if regex.is_match(line) {
+                        total_matches += 1;
+
+                        // Get context lines
+                        let context_before: Vec<String> = (line_idx.saturating_sub(context_lines)
+                            ..line_idx)
+                            .filter_map(|i| lines.get(i).map(|s| (*s).to_string()))
+                            .collect();
+
+                        let context_after: Vec<String> = ((line_idx + 1)
+                            ..=(line_idx + context_lines).min(lines.len() - 1))
+                            .filter_map(|i| lines.get(i).map(|s| (*s).to_string()))
+                            .collect();
+
+                        // Get relative path from workspace
+                        let relative_path = file_path
+                            .strip_prefix(&workspace)
+                            .unwrap_or(&file_path)
+                            .to_string_lossy()
+                            .to_string();
+
+                        results.push(GrepMatch {
+                            file: relative_path,
+                            line_number: line_idx + 1,
+                            line: (*line).to_string(),
+                            context_before,
+                            context_after,
+                        });
+
+                        if results.len() >= max_results {
+                            break;
+                        }
                     }
                 }
             }
-        }
 
-        let matches_json: Vec<Value> = results
-            .iter()
-            .map(|item| grep_match_to_json(item, context_lines))
-            .collect();
+            let matches_json: Vec<Value> = results
+                .iter()
+                .map(|item| grep_match_to_json(item, context_lines))
+                .collect();
 
-        // Build result. When context_lines == 1, return the single context
-        // line as a string instead of a one-item array. That keeps the common
-        // "show just the adjacent line" case easy for model callers to read.
-        let result = json!({
-            "matches": matches_json,
-            "total_matches": total_matches,
-            "files_searched": files_searched,
-            "truncated": total_matches > max_results,
-        });
+            // Build result. When context_lines == 1, return the single context
+            // line as a string instead of a one-item array. That keeps the common
+            // "show just the adjacent line" case easy for model callers to read.
+            Ok(json!({
+                "matches": matches_json,
+                "total_matches": total_matches,
+                "files_searched": files_searched,
+                "truncated": total_matches > max_results,
+            }))
+        })
+        .await?;
 
         ToolResult::json(&result).map_err(|e| ToolError::execution_failed(e.to_string()))
+    }
+}
+
+/// Run the synchronous grep walk on a blocking worker, cancellable via the
+/// token and bounded by `timeout`. Mirrors `run_blocking_file_search`.
+async fn run_blocking_grep<F>(
+    timeout: Duration,
+    cancel_token: Option<CancellationToken>,
+    search: F,
+) -> Result<Value, ToolError>
+where
+    F: FnOnce() -> Result<Value, ToolError> + Send + 'static,
+{
+    if cancel_token
+        .as_ref()
+        .is_some_and(CancellationToken::is_cancelled)
+    {
+        return Err(grep_cancelled());
+    }
+
+    let task = tokio::task::spawn_blocking(search);
+    let result = match cancel_token {
+        Some(token) => {
+            tokio::select! {
+                biased;
+                () = token.cancelled() => return Err(grep_cancelled()),
+                result = tokio::time::timeout(timeout, task) => result,
+            }
+        }
+        None => tokio::time::timeout(timeout, task).await,
+    };
+
+    let joined = result.map_err(|_| grep_timeout(timeout))?;
+    joined.map_err(|err| {
+        ToolError::execution_failed(format!("grep_files worker failed before completion: {err}"))
+    })?
+}
+
+fn grep_cancelled() -> ToolError {
+    ToolError::execution_failed("grep_files cancelled before completion")
+}
+
+fn grep_timeout(timeout: Duration) -> ToolError {
+    ToolError::Timeout {
+        seconds: timeout.as_secs().max(1),
     }
 }
 


### PR DESCRIPTION
## Problem

`grep_files` runs its directory walk and per-file regex **synchronously inside the async `execute()`**. On a large tree this pins the Tokio worker thread for the whole scan (can be minutes). While the per-file/per-line `check_cancelled` checks let it bail *between* files, the synchronous stretch monopolizes the runtime worker, so the turn loop can't make progress and the **stop button stays unresponsive** until the scan reaches the next check point.

This is the same failure mode `file_search` had, fixed in #2035 by moving the blocking walk onto `spawn_blocking` with a hard timeout. `grep_files` has identical structure but wasn't given the same treatment — so the two blocking searches behave inconsistently.

## Fix

Mirror the `file_search` fix:

- Move the blocking walk + per-file regex onto `tokio::task::spawn_blocking`.
- Bound it with a 30s hard timeout and a **biased `select!` on the cancel token**, via a new `run_blocking_grep` helper that parallels `run_blocking_file_search`.
- Keep the existing per-file/per-line `check_cancelled` calls and `MAX_FILE_SIZE` skip — output is byte-for-byte unchanged.

Net effect: the stop button stays responsive during a large grep (the runtime worker is no longer pinned), and a pathological scan can't run unbounded.

## Test

`cargo test -p codewhale-tui --bins tools::search` — all 15 tests pass, including `test_grep_files_respects_cancel_token` (which now also exercises the new `run_blocking_grep` cancel path). `cargo fmt` + `cargo clippy` clean on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR moves the synchronous directory walk and per-file regex work in `grep_files` off the Tokio async worker thread and onto `spawn_blocking`, bounded by a 30-second hard timeout and a biased `select!` on the cancellation token. The change directly mirrors the identical fix previously applied to `file_search` in #2035.

- `run_blocking_grep` is added as a new async helper that faithfully replicates the structure of `run_blocking_file_search`, including the early-cancellation guard, biased `select!`, and `JoinError` unwrapping.
- Existing per-file/per-line `check_cancelled` checkpoints and `MAX_FILE_SIZE` skips are preserved unchanged inside the closure; output is byte-for-byte identical to the previous synchronous path.
- The `file_search.rs` mirror has a dedicated unit test (`test_file_search_blocking_wrapper_reports_timeout`) that directly exercises the timeout return path; no equivalent test was added here for `run_blocking_grep`.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change correctly offloads blocking work to a dedicated thread pool and the existing cancel and file-size guards remain intact.

The blocking-to-spawn_blocking refactor is structurally identical to the already-shipped file_search fix, so the pattern is battle-tested. The only concrete gaps are a missing unit test for the 30s timeout path and a minor inconsistency in the cancellation error message — neither affects correctness of the main fix.

Only crates/tui/src/tools/search.rs changed; the timeout test gap in that file is the one area worth a second look before merging.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tools/search.rs | Wraps the synchronous directory walk and per-file regex in `tokio::task::spawn_blocking` with a 30-second `tokio::time::timeout` and biased `select!` on the cancel token, mirroring the existing `run_blocking_file_search` pattern. Minor: the new `grep_cancelled` error message is inconsistent with the existing `check_cancelled` message, and there is no unit test for the `run_blocking_grep` timeout path (unlike the equivalent function in `file_search.rs`). |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller as execute()
    participant RBG as run_blocking_grep()
    participant BT as spawn_blocking task
    participant CT as CancellationToken

    Caller->>RBG: run_blocking_grep(30s, cancel_token.clone(), closure)
    RBG->>CT: is_cancelled()? (early guard)
    CT-->>RBG: false continue

    RBG->>BT: tokio::task::spawn_blocking(closure)
    Note over BT: walk dirs, regex per file

    alt cancel fires before timeout
        CT-->>RBG: token.cancelled() (biased select!)
        RBG-->>Caller: Err(grep_cancelled)
    else task completes within 30s
        BT-->>RBG: Ok(json result)
        RBG-->>Caller: Ok(Value)
    else 30s timeout expires
        RBG-->>Caller: Err(ToolError::Timeout)
    end
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fgrep-files-timeout%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fgrep-files-timeout%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftools%2Fsearch.rs%3A264-295%0A**Missing%20timeout%20unit%20test%20for%20%60run_blocking_grep%60**%0A%0A%60file_search.rs%60%20has%20%60test_file_search_blocking_wrapper_reports_timeout%60%20which%20directly%20calls%20%60run_blocking_file_search%60%20with%20a%201ms%20timeout%20and%20a%2050ms%20%60sleep%60%2C%20confirming%20that%20%60ToolError%3A%3ATimeout%20%7B%20seconds%3A%201%20%7D%60%20is%20returned.%20%60file.rs%60%20has%20the%20same%20test%20for%20%60list_dir%60.%20The%20new%20%60run_blocking_grep%60%20has%20no%20equivalent%20test%2C%20so%20the%2030-second%20timeout%20path%20is%20unexercised.%20A%20slow%20or%20stuck%20scan%20that%20hits%20the%20cap%20would%20silently%20skip%20validation%20of%20the%20%60ToolError%3A%3ATimeout%60%20shape%20and%20the%20correct%20%60seconds%60%20value%20returned%20to%20callers.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftools%2Fsearch.rs%3A297-299%0A**Inconsistent%20cancellation%20error%20messages**%0A%0A%60grep_cancelled%28%29%60%20returns%20%60%22grep_files%20cancelled%20before%20completion%22%60%2C%20while%20the%20existing%20%60check_cancelled%28%29%60%20helper%20in%20the%20same%20file%20returns%20%60%22search%20cancelled%20before%20completion%22%60.%20When%20a%20cancel%20fires%20through%20the%20%60select!%60%20path%20the%20user%20sees%20one%20message%3B%20when%20it%20fires%20through%20the%20per-file%20%60check_cancelled%60%20checkpoint%20they%20see%20a%20different%20one.%20Aligning%20both%20to%20the%20same%20string%20avoids%20confusing%20diagnostics.%0A%0A%60%60%60suggestion%0Afn%20grep_cancelled%28%29%20-%3E%20ToolError%20%7B%0A%20%20%20%20ToolError%3A%3Aexecution_failed%28%22search%20cancelled%20before%20completion%22%29%0A%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftools%2Fsearch.rs%3A264-295%0A**Missing%20timeout%20unit%20test%20for%20%60run_blocking_grep%60**%0A%0A%60file_search.rs%60%20has%20%60test_file_search_blocking_wrapper_reports_timeout%60%20which%20directly%20calls%20%60run_blocking_file_search%60%20with%20a%201ms%20timeout%20and%20a%2050ms%20%60sleep%60%2C%20confirming%20that%20%60ToolError%3A%3ATimeout%20%7B%20seconds%3A%201%20%7D%60%20is%20returned.%20%60file.rs%60%20has%20the%20same%20test%20for%20%60list_dir%60.%20The%20new%20%60run_blocking_grep%60%20has%20no%20equivalent%20test%2C%20so%20the%2030-second%20timeout%20path%20is%20unexercised.%20A%20slow%20or%20stuck%20scan%20that%20hits%20the%20cap%20would%20silently%20skip%20validation%20of%20the%20%60ToolError%3A%3ATimeout%60%20shape%20and%20the%20correct%20%60seconds%60%20value%20returned%20to%20callers.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftools%2Fsearch.rs%3A297-299%0A**Inconsistent%20cancellation%20error%20messages**%0A%0A%60grep_cancelled%28%29%60%20returns%20%60%22grep_files%20cancelled%20before%20completion%22%60%2C%20while%20the%20existing%20%60check_cancelled%28%29%60%20helper%20in%20the%20same%20file%20returns%20%60%22search%20cancelled%20before%20completion%22%60.%20When%20a%20cancel%20fires%20through%20the%20%60select!%60%20path%20the%20user%20sees%20one%20message%3B%20when%20it%20fires%20through%20the%20per-file%20%60check_cancelled%60%20checkpoint%20they%20see%20a%20different%20one.%20Aligning%20both%20to%20the%20same%20string%20avoids%20confusing%20diagnostics.%0A%0A%60%60%60suggestion%0Afn%20grep_cancelled%28%29%20-%3E%20ToolError%20%7B%0A%20%20%20%20ToolError%3A%3Aexecution_failed%28%22search%20cancelled%20before%20completion%22%29%0A%7D%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2146&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftools%2Fsearch.rs%3A264-295%0A**Missing%20timeout%20unit%20test%20for%20%60run_blocking_grep%60**%0A%0A%60file_search.rs%60%20has%20%60test_file_search_blocking_wrapper_reports_timeout%60%20which%20directly%20calls%20%60run_blocking_file_search%60%20with%20a%201ms%20timeout%20and%20a%2050ms%20%60sleep%60%2C%20confirming%20that%20%60ToolError%3A%3ATimeout%20%7B%20seconds%3A%201%20%7D%60%20is%20returned.%20%60file.rs%60%20has%20the%20same%20test%20for%20%60list_dir%60.%20The%20new%20%60run_blocking_grep%60%20has%20no%20equivalent%20test%2C%20so%20the%2030-second%20timeout%20path%20is%20unexercised.%20A%20slow%20or%20stuck%20scan%20that%20hits%20the%20cap%20would%20silently%20skip%20validation%20of%20the%20%60ToolError%3A%3ATimeout%60%20shape%20and%20the%20correct%20%60seconds%60%20value%20returned%20to%20callers.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftools%2Fsearch.rs%3A297-299%0A**Inconsistent%20cancellation%20error%20messages**%0A%0A%60grep_cancelled%28%29%60%20returns%20%60%22grep_files%20cancelled%20before%20completion%22%60%2C%20while%20the%20existing%20%60check_cancelled%28%29%60%20helper%20in%20the%20same%20file%20returns%20%60%22search%20cancelled%20before%20completion%22%60.%20When%20a%20cancel%20fires%20through%20the%20%60select!%60%20path%20the%20user%20sees%20one%20message%3B%20when%20it%20fires%20through%20the%20per-file%20%60check_cancelled%60%20checkpoint%20they%20see%20a%20different%20one.%20Aligning%20both%20to%20the%20same%20string%20avoids%20confusing%20diagnostics.%0A%0A%60%60%60suggestion%0Afn%20grep_cancelled%28%29%20-%3E%20ToolError%20%7B%0A%20%20%20%20ToolError%3A%3Aexecution_failed%28%22search%20cancelled%20before%20completion%22%29%0A%7D%0A%60%60%60%0A%0A&pr=2146&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(grep\_files): wrap walk in spawn\_bloc..."](https://github.com/hmbown/codewhale/commit/f2153f1097ec6d0a4137b05afce1c605f96e5158) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33849135)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->