### PR TITLE
feat(engine): env override for max_output_tokens on tight providers

### DIFF
--- a/crates/tui/src/core/engine/context.rs
+++ b/crates/tui/src/core/engine/context.rs
@@ -28,7 +28,21 @@ const API_MAX_OUTPUT_TOKENS: u32 = 65_536;
 /// model. Uses `API_MAX_OUTPUT_TOKENS` (64K) which fits within common provider
 /// limits (128K+ total). For non-V4 models with smaller context windows, caps
 /// at half the context window.
+///
+/// Override: when the env var `DEEPSEEK_MAX_OUTPUT_TOKENS` is set to a positive
+/// integer, this function returns that value directly. Use this for self-hosted
+/// providers (vLLM/SGLang) whose `max-model-len` is tight and where the
+/// model-table heuristic above would over-allocate. Example: vLLM serving
+/// Qwen3.6 with `--max-model-len 65536` should set
+/// `DEEPSEEK_MAX_OUTPUT_TOKENS=16384` so input + output stays well under the
+/// provider's hard limit.
 pub(super) fn effective_max_output_tokens(model: &str) -> u32 {
+    if let Ok(raw) = std::env::var("DEEPSEEK_MAX_OUTPUT_TOKENS")
+        && let Ok(n) = raw.trim().parse::<u32>()
+        && n > 0
+    {
+        return n;
+    }
     let window = context_window_for_model(model).unwrap_or(128_000);
     if window >= 500_000 {
         // V4-class models on large-context providers: use 64K which is safe

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -915,6 +915,9 @@ fn detects_context_length_errors_from_provider_payloads() {
 
 #[test]
 fn context_budget_reserves_output_and_headroom() {
+    // Serialize with other tests that mutate DEEPSEEK_MAX_OUTPUT_TOKENS so
+    // the internal effective_max_output_tokens() call sees a stable env.
+    let _lock = lock_test_env();
     // V4 has a 1M context window — the only family that comfortably hosts
     // a 256K output reservation without saturating the input budget to 0.
     let budget = context_input_budget("deepseek-v4-pro")
@@ -926,6 +929,9 @@ fn context_budget_reserves_output_and_headroom() {
 
 #[test]
 fn effective_max_output_tokens_caps_api_request_for_large_window_models() {
+    // Serialize with other tests that mutate DEEPSEEK_MAX_OUTPUT_TOKENS so
+    // v4_cap and flash_cap below see the same env state.
+    let _lock = lock_test_env();
     // V4 models have a 1M context window but the API request cap must stay
     // well below common provider limits (e.g., 131K total on self-hosted
     // vLLM/SGLang). The cap should never exceed 65K.
@@ -943,8 +949,84 @@ fn effective_max_output_tokens_caps_api_request_for_large_window_models() {
     assert_eq!(v4_cap, flash_cap);
 }
 
+struct ScopedDeepSeekMaxOutputTokens {
+    previous: Option<OsString>,
+}
+
+impl ScopedDeepSeekMaxOutputTokens {
+    fn set(value: &str) -> Self {
+        let previous = std::env::var_os("DEEPSEEK_MAX_OUTPUT_TOKENS");
+        // Safety: tests using this helper serialize with lock_test_env() and
+        // restore the original value in Drop.
+        unsafe {
+            std::env::set_var("DEEPSEEK_MAX_OUTPUT_TOKENS", value);
+        }
+        Self { previous }
+    }
+
+    fn unset() -> Self {
+        let previous = std::env::var_os("DEEPSEEK_MAX_OUTPUT_TOKENS");
+        // Safety: see set().
+        unsafe {
+            std::env::remove_var("DEEPSEEK_MAX_OUTPUT_TOKENS");
+        }
+        Self { previous }
+    }
+}
+
+impl Drop for ScopedDeepSeekMaxOutputTokens {
+    fn drop(&mut self) {
+        // Safety: tests using this helper serialize with lock_test_env().
+        unsafe {
+            if let Some(previous) = self.previous.take() {
+                std::env::set_var("DEEPSEEK_MAX_OUTPUT_TOKENS", previous);
+            } else {
+                std::env::remove_var("DEEPSEEK_MAX_OUTPUT_TOKENS");
+            }
+        }
+    }
+}
+
+#[test]
+fn effective_max_output_tokens_env_override_returns_positive_value() {
+    let _lock = lock_test_env();
+    let _guard = ScopedDeepSeekMaxOutputTokens::set("16384");
+
+    // Override applies regardless of model — V4 hosted, V4 flash, sub-500K
+    // self-hosted all return the env value verbatim.
+    assert_eq!(effective_max_output_tokens("deepseek-v4-pro"), 16_384);
+    assert_eq!(effective_max_output_tokens("deepseek-v4-flash"), 16_384);
+    assert_eq!(effective_max_output_tokens("qwen3-32b-256k"), 16_384);
+}
+
+#[test]
+fn effective_max_output_tokens_env_override_rejects_zero_and_invalid() {
+    let _lock = lock_test_env();
+    // Establish the heuristic baseline with the env unset.
+    let baseline = {
+        let _guard = ScopedDeepSeekMaxOutputTokens::unset();
+        effective_max_output_tokens("deepseek-v4-pro")
+    };
+    assert!(baseline > 0);
+
+    // 0, non-numeric, and empty values must all fall through to the heuristic
+    // rather than producing a zero/garbage cap that would silently break
+    // request budgeting.
+    for raw in ["0", "abc", "", "  ", "-1"] {
+        let _guard = ScopedDeepSeekMaxOutputTokens::set(raw);
+        assert_eq!(
+            effective_max_output_tokens("deepseek-v4-pro"),
+            baseline,
+            "env={raw:?} should fall through to heuristic"
+        );
+    }
+}
+
 #[test]
 fn internal_context_budget_tiers_reserved_output_by_window() {
+    // Serialize with other tests that mutate DEEPSEEK_MAX_OUTPUT_TOKENS so
+    // both branches below see a stable env.
+    let _lock = lock_test_env();
     // Large-context (>=500K) models reserve the full TURN_MAX_OUTPUT_TOKENS
     // headroom so long V4 sessions don't compact prematurely.
     let internal_budget =


### PR DESCRIPTION
## Problem

`effective_max_output_tokens` decides the `max_tokens` we send in each API request. For models not in the `context_window_for_model` table it falls back to a 128K window assumption and returns `API_MAX_OUTPUT_TOKENS` (64K).

That heuristic is fine for the hosted CodeWhale/DeepSeek API but immediately HTTP 400s on self-hosted providers with a tight `--max-model-len`. Concrete failure:

- vLLM serving Qwen3.6 with `--max-model-len 65536`
- Request input ≈ 1.5K tokens + the requested 64K output ⇒ provider rejects (total > 65536 by 1 token).

Operators today have no way to lower the requested output without forking the engine, because the cap is a code-internal constant rather than config.

## Fix

A short escape hatch at the top of `effective_max_output_tokens`: if `DEEPSEEK_MAX_OUTPUT_TOKENS` is set to a positive integer, return it directly. Otherwise existing behavior is unchanged.

```rust
if let Ok(raw) = std::env::var("DEEPSEEK_MAX_OUTPUT_TOKENS")
    && let Ok(n) = raw.trim().parse::<u32>()
    && n > 0
{
    return n;
}
```

Typical use: `DEEPSEEK_MAX_OUTPUT_TOKENS=16384` for a 64K-window vLLM deployment.

## Scope

- One function in `crates/tui/src/core/engine/context.rs`, +14/-0 of behavior.
- No new config struct field. Env-only override keeps the public API unchanged, matching the existing `DEEPSEEK_*` knob convention (`DEEPSEEK_CAPACITY_*`, `DEEPSEEK_BASE_URL`, ...).
- Composes with #2060: that PR fixed the *input* budget math for sub-500K windows; this one lets operators cap the *output* request to fit the provider's hard limit.
- Does not touch the trust-boundary surface (no auth / sandbox / publishing / prompts).

## Tests

Two new unit tests in `crates/tui/src/core/engine/tests.rs`:

- `effective_max_output_tokens_env_override_returns_positive_value` — env=16384 applies regardless of model (V4 hosted, V4 flash, sub-500K self-hosted).
- `effective_max_output_tokens_env_override_rejects_zero_and_invalid` — env=\`0\` / \`abc\` / \`\` / \`  \` / \`-1\` all fall through to the heuristic (no silent zero cap on typo'd config).

Three pre-existing tests that internally call `effective_max_output_tokens` now acquire `lock_test_env()` so they stay isolated from the new env-mutating tests:

- `context_budget_reserves_output_and_headroom`
- `effective_max_output_tokens_caps_api_request_for_large_window_models`
- `internal_context_budget_tiers_reserved_output_by_window`

\`\`\`
cargo test -p codewhale-tui --bin codewhale-tui -- effective_max_output_tokens context_budget context_input_budget internal_context_budget
\`\`\`

All 6 pass. Full \`cargo test --workspace --all-features\` is green except for one pre-existing failure (\`prompts::tests::system_prompt_skips_locale_preamble_for_english\`) that also reproduces on a clean \`origin/main\` checkout and is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a runtime escape hatch — a new env var — that lets operators cap `max_tokens` in API requests when running against self-hosted providers (vLLM/SGLang) whose `--max-model-len` is tighter than the engine's default 64 K output assumption. Existing behavior is completely unchanged when the var is unset.

- `effective_max_output_tokens` gains an early-return for positive-integer values of the env var, with the existing heuristic as fallback for zero, non-numeric, or unset values.
- Three pre-existing tests are updated to hold the process-wide env lock for isolation; two new tests cover the override and the rejection of zero/invalid values.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with one fix: the env override is not clamped, so a misconfigured value above the model's context window can silently disable compaction for sub-500K deployments.

The override correctly falls through on zero/invalid input and leaves V4 models unaffected. The risk is that `context_input_budget` reuses `effective_max_output_tokens` for sub-500K models, so an env value larger than the window causes a `checked_sub` underflow, returning `None` and disabling compaction without any error. A one-line `.min(API_MAX_OUTPUT_TOKENS)` clamp would close this gap.

crates/tui/src/core/engine/context.rs — the new early-return in `effective_max_output_tokens` and its downstream effect on `context_input_budget`
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/core/engine/context.rs | Adds DEEPSEEK_MAX_OUTPUT_TOKENS env-var early-exit to effective_max_output_tokens; no upper-bound guard against values that exceed the model's context window |
| crates/tui/src/core/engine/tests.rs | Adds ScopedDeepSeekMaxOutputTokens RAII guard with proper lock-serialised env cleanup; three existing tests acquire lock_test_env() for isolation; two new tests cover the override path |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["effective_max_output_tokens(model)"] --> B{"env var set and > 0?"}
    B -- Yes --> C["return env value (new path)"]
    B -- No --> D["context_window_for_model(model)"]
    D -- Some --> E{"window >= 500K?"}
    D -- None --> F["fallback: 128K window"]
    F --> E
    E -- Yes --> G["return API_MAX_OUTPUT_TOKENS (64K)"]
    E -- No --> H["return min(window/2, 64K)"]
    C --> I["API request: max_tokens = env value"]
    G --> I
    H --> I
    J["context_input_budget(model)"] --> K{"window >= 500K?"}
    K -- Yes --> L["reserved = TURN_MAX_OUTPUT_TOKENS (262K)"]
    K -- No --> M["reserved = effective_max_output_tokens(model) -- affected by env var"]
    L --> N["budget = window - reserved - 1024"]
    M --> N
    N --> O{"underflow?"}
    O -- Yes --> P["None: compaction disabled"]
    O -- No --> Q["Some(budget): compaction active"]
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fmax-output-tokens-env%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fmax-output-tokens-env%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine%2Fcontext.rs%3A40-44%0A**%60DEEPSEEK_*%60%20prefix%20misleads%20non-DeepSeek%20operators**%0A%0AThe%20env%20var%20controls%20%60max_tokens%60%20for%20*any*%20model%20routed%20through%20the%20engine%20%E2%80%94%20a%20Qwen3%20or%20Llama%20operator%20using%20vLLM%20would%20not%20intuitively%20reach%20for%20%60DEEPSEEK_MAX_OUTPUT_TOKENS%60%20to%20solve%20their%20tight-context%20problem.%20The%20%60DEEPSEEK_*%60%20convention%20makes%20sense%20for%20vendor-specific%20keys%20%28%60DEEPSEEK_BASE_URL%60%2C%20%60DEEPSEEK_CAPACITY_*%60%29%2C%20but%20this%20knob%20is%20provider-agnostic.%20Was%20a%20more%20generic%20name%20like%20%60CODEWHALE_MAX_OUTPUT_TOKENS%60%20considered%3F%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine%2Fcontext.rs%3A40-45%0A**Missing%20upper-bound%20guard%20can%20silently%20disable%20compaction**%0A%0A%60context_input_budget%60%20calls%20%60effective_max_output_tokens%60%20as%20the%20%60reserved_output%60%20term%20for%20sub-500K%20models.%20If%20the%20env%20override%20is%20set%20above%20%60window%20%E2%88%92%20CONTEXT_HEADROOM_TOKENS%60%20%28e.g.%20%6070000%60%20on%20a%2065%20536-token%20vLLM%20deployment%29%2C%20%60checked_sub%60%20underflows%20to%20%60None%60%2C%20silently%20disabling%20all%20compaction%20and%20preflight%20checks%20for%20that%20session.%20Adding%20%60.min%28API_MAX_OUTPUT_TOKENS%29%60%20before%20returning%20%60n%60%20caps%20the%20override%20at%20the%20same%20ceiling%20already%20used%20by%20the%20heuristic%20path.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine%2Fcontext.rs%3A40-44%0A**%60DEEPSEEK_*%60%20prefix%20misleads%20non-DeepSeek%20operators**%0A%0AThe%20env%20var%20controls%20%60max_tokens%60%20for%20*any*%20model%20routed%20through%20the%20engine%20%E2%80%94%20a%20Qwen3%20or%20Llama%20operator%20using%20vLLM%20would%20not%20intuitively%20reach%20for%20%60DEEPSEEK_MAX_OUTPUT_TOKENS%60%20to%20solve%20their%20tight-context%20problem.%20The%20%60DEEPSEEK_*%60%20convention%20makes%20sense%20for%20vendor-specific%20keys%20%28%60DEEPSEEK_BASE_URL%60%2C%20%60DEEPSEEK_CAPACITY_*%60%29%2C%20but%20this%20knob%20is%20provider-agnostic.%20Was%20a%20more%20generic%20name%20like%20%60CODEWHALE_MAX_OUTPUT_TOKENS%60%20considered%3F%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine%2Fcontext.rs%3A40-45%0A**Missing%20upper-bound%20guard%20can%20silently%20disable%20compaction**%0A%0A%60context_input_budget%60%20calls%20%60effective_max_output_tokens%60%20as%20the%20%60reserved_output%60%20term%20for%20sub-500K%20models.%20If%20the%20env%20override%20is%20set%20above%20%60window%20%E2%88%92%20CONTEXT_HEADROOM_TOKENS%60%20%28e.g.%20%6070000%60%20on%20a%2065%20536-token%20vLLM%20deployment%29%2C%20%60checked_sub%60%20underflows%20to%20%60None%60%2C%20silently%20disabling%20all%20compaction%20and%20preflight%20checks%20for%20that%20session.%20Adding%20%60.min%28API_MAX_OUTPUT_TOKENS%29%60%20before%20returning%20%60n%60%20caps%20the%20override%20at%20the%20same%20ceiling%20already%20used%20by%20the%20heuristic%20path.%0A%0A&repo=hmbown%2Fcodewhale&pr=2147&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine%2Fcontext.rs%3A40-44%0A**%60DEEPSEEK_*%60%20prefix%20misleads%20non-DeepSeek%20operators**%0A%0AThe%20env%20var%20controls%20%60max_tokens%60%20for%20*any*%20model%20routed%20through%20the%20engine%20%E2%80%94%20a%20Qwen3%20or%20Llama%20operator%20using%20vLLM%20would%20not%20intuitively%20reach%20for%20%60DEEPSEEK_MAX_OUTPUT_TOKENS%60%20to%20solve%20their%20tight-context%20problem.%20The%20%60DEEPSEEK_*%60%20convention%20makes%20sense%20for%20vendor-specific%20keys%20%28%60DEEPSEEK_BASE_URL%60%2C%20%60DEEPSEEK_CAPACITY_*%60%29%2C%20but%20this%20knob%20is%20provider-agnostic.%20Was%20a%20more%20generic%20name%20like%20%60CODEWHALE_MAX_OUTPUT_TOKENS%60%20considered%3F%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine%2Fcontext.rs%3A40-45%0A**Missing%20upper-bound%20guard%20can%20silently%20disable%20compaction**%0A%0A%60context_input_budget%60%20calls%20%60effective_max_output_tokens%60%20as%20the%20%60reserved_output%60%20term%20for%20sub-500K%20models.%20If%20the%20env%20override%20is%20set%20above%20%60window%20%E2%88%92%20CONTEXT_HEADROOM_TOKENS%60%20%28e.g.%20%6070000%60%20on%20a%2065%20536-token%20vLLM%20deployment%29%2C%20%60checked_sub%60%20underflows%20to%20%60None%60%2C%20silently%20disabling%20all%20compaction%20and%20preflight%20checks%20for%20that%20session.%20Adding%20%60.min%28API_MAX_OUTPUT_TOKENS%29%60%20before%20returning%20%60n%60%20caps%20the%20override%20at%20the%20same%20ceiling%20already%20used%20by%20the%20heuristic%20path.%0A%0A&pr=2147&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(engine): allow DEEPSEEK\_MAX\_OUTPUT\_..."](https://github.com/hmbown/codewhale/commit/01f2678df4484ad959a6385f8596152b25fc00a3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33849319)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->