### PR TITLE
fix(feishu): reply inside thread/topic instead of creating standalone topics

### DIFF
--- a/integrations/feishu-bridge/src/index.mjs
+++ b/integrations/feishu-bridge/src/index.mjs
@@ -145,6 +145,29 @@ async function handleIncomingMessage(event) {
   const identity = incomingIdentity(event);
   if (!identity.chatId) return;
 
+  // Store the incoming message ID so sendText() can reply inside the same
+  // Feishu thread/topic — without this, every bot message creates a new
+  // standalone topic in thread-enabled groups.
+  // / 缓存入站消息 ID，让 sendText 能通过 reply API 在同一话题内回复。
+  // / 否则每条 bot 消息都会在话题群中创建独立的新话题（见 #1710）。
+  if (identity.messageId) {
+    const existing = await threadStore.getChat(identity.chatId);
+    if (existing) {
+      await threadStore.patchChat(identity.chatId, {
+        replyToMessageId: identity.messageId,
+        updatedAt: new Date().toISOString()
+      });
+    } else {
+      await threadStore.setChat(identity.chatId, {
+        replyToMessageId: identity.messageId,
+        threadId: null,
+        lastSeq: 0,
+        activeTurnId: null,
+        updatedAt: new Date().toISOString()
+      });
+    }
+  }
+
   if (identity.messageType && identity.messageType !== "text") {
     await sendText(identity.chatId, "Only text messages are supported in this first bridge.");
     return;
@@ -531,21 +554,40 @@ async function decideApproval(chatId, action) {
 }
 
 async function sendText(chatId, text) {
+  // Try reply API first — keeps bot responses inside the same Feishu
+  // thread/topic instead of spawning new standalone topics.
+  // / 优先使用 reply API，确保 bot 回复留在话题群的同一条话题内。
+  const state = await threadStore.getChat(chatId);
+  const replyToMessageId = state?.replyToMessageId || null;
+
+  const replyMessage =
+    replyToMessageId
+      ? client.im?.v1?.message?.reply?.bind(client.im.v1.message) ||
+        client.im?.message?.reply?.bind(client.im.message)
+      : null;
   const createMessage =
     client.im?.v1?.message?.create?.bind(client.im.v1.message) ||
     client.im?.message?.create?.bind(client.im.message);
   if (!createMessage) {
     throw new Error("Lark SDK client does not expose im message create API");
   }
+
   for (const chunk of splitMessage(text, config.maxReplyChars)) {
-    await createMessage({
-      params: { receive_id_type: "chat_id" },
-      data: {
-        receive_id: chatId,
-        msg_type: "text",
-        content: JSON.stringify({ text: chunk })
-      }
-    });
+    const body = {
+      msg_type: "text",
+      content: JSON.stringify({ text: chunk })
+    };
+    if (replyMessage) {
+      await replyMessage({
+        path: { message_id: replyToMessageId },
+        data: body
+      });
+    } else {
+      await createMessage({
+        params: { receive_id_type: "chat_id" },
+        data: { ...body, receive_id: chatId }
+      });
+    }
   }
 }
 

--- a/integrations/feishu-bridge/src/lib.mjs
+++ b/integrations/feishu-bridge/src/lib.mjs
@@ -67,7 +67,13 @@ export function incomingIdentity(event) {
     messageType: message.message_type || "",
     openId: sender.open_id || "",
     unionId: sender.union_id || "",
-    userId: sender.user_id || ""
+    userId: sender.user_id || "",
+    // Thread/topic group context: these fields let the bridge reply
+    // inside the same topic instead of spawning a new standalone topic.
+    // / 话题群上下文：用于在同一话题内回复，而非新建独立话题。
+    parentId: message.parent_id || "",
+    rootId: message.root_id || "",
+    threadId: message.thread_id || ""
   };
 }
 


### PR DESCRIPTION
## Summary

When running in a Feishu thread-enabled group (话题群), every bot response — status messages, approval prompts, streaming progress, turn results — creates a **new standalone topic** instead of staying under the original user message.

**Before**: User sees a cluttered group with orphan topics for every intermediate bot message ("Started turn xxx", approval requests, progress updates, etc.).

**After**: All bot responses are nested under the original user message inside the same topic, keeping the group clean.

## Root Cause

`sendText()` in `integrations/feishu-bridge/src/index.mjs` exclusively used the Lark SDK `client.im.message.create()` API with only a bare `chat_id`. The Feishu `reply` API (`client.im.message.reply()`) — which keeps messages inside the same thread — was never called.

## Fix

Two changes:

### 1. `lib.mjs` — `incomingIdentity()`
Added `parentId`, `rootId`, `threadId` fields from the raw Feishu message event, making thread context available to downstream code.

### 2. `index.mjs`
- **`handleIncomingMessage()`**: stores the latest incoming `messageId` as `replyToMessageId` in the per-chat thread store.
- **`sendText()`**: reads `replyToMessageId` from the thread store. When present, calls `client.im.message.reply()` instead of `create()`. This keeps ALL bot responses nested under the original user message.

Existing chats without `replyToMessageId` in the store automatically fall back to the old `create` behavior — no data loss or breaking changes.

## Testing
Manually verified by sending messages in a Feishu thread-enabled group and observing that all bot responses now appear inside the same topic thread.

Closes #1710

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes Feishu thread-enabled groups ("话题群") where every bot response was creating a new standalone topic instead of staying nested under the original user message. It achieves this by storing the incoming `messageId` as `replyToMessageId` in the per-chat store and switching `sendText` to call `client.im.message.reply()` when that value is present.

- **`lib.mjs`**: `incomingIdentity` gains three new Feishu thread-context fields (`parentId`, `rootId`, `threadId`), none of which are read by the rest of the PR.
- **`index.mjs`**: `handleIncomingMessage` writes `replyToMessageId` into the thread store, and `sendText` reads it back to choose between the reply and create APIs; however, `ensureThread` (called for every new chat and for `/new`/`/resume` commands) replaces the entire chat entry with `setChat`, silently dropping `replyToMessageId` before `sendText` is invoked.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The reply-threading fix works correctly for repeat messages in established chats, but silently fails for the most common new-user path and after /new and /resume commands.

The central problem is that `ensureThread` calls `setChat` with a fresh object whenever it creates a new runtime thread, wiping out the `replyToMessageId` that `handleIncomingMessage` just wrote. This means every first-ever message in a brand-new chat — the primary scenario a new user would encounter — still produces standalone Feishu topics instead of nested replies. The same wipe happens after `/new` and `/resume`. The feature works as intended only for subsequent messages in an already-threaded chat, which is the minority case. The fallback to `create` is graceful (no crash, no data loss), but the stated goal of the PR is not fully achieved.

integrations/feishu-bridge/src/index.mjs — specifically the setChat call inside ensureThread (line ~261) and the matching call inside resumeThread (line ~497).
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| integrations/feishu-bridge/src/index.mjs | Adds thread-reply logic to sendText and stores replyToMessageId on each incoming message; however ensureThread's setChat call overwrites the replyToMessageId for new chats and after /new or /resume, breaking threading for those cases. |
| integrations/feishu-bridge/src/lib.mjs | Adds parentId, rootId, and threadId fields to incomingIdentity; none of the three new fields is consumed by downstream code in this PR. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant U as Feishu User
    participant H as handleIncomingMessage
    participant TS as ThreadStore
    participant ET as ensureThread
    participant ST as sendText
    participant Lark as Lark SDK

    U->>H: first message (new chat)
    H->>TS: "setChat(chatId, {replyToMessageId: msgId, threadId: null, ...})"
    Note over TS: replyToMessageId stored ✓
    H->>ET: ensureThread(chatId)
    ET->>TS: "getChat(chatId) → {threadId: null, ...}"
    ET->>ET: threadId is null → create runtime thread
    ET->>TS: "setChat(chatId, {threadId: runtimeId, ...})"
    Note over TS: replyToMessageId LOST ✗
    ET-->>H: state (no replyToMessageId)
    H->>ST: sendText("Started turn X")
    ST->>TS: getChat(chatId) → no replyToMessageId
    ST->>Lark: im.message.create() ← standalone topic

    U->>H: second message (existing chat)
    H->>TS: "patchChat(chatId, {replyToMessageId: msg2Id})"
    Note over TS: replyToMessageId stored ✓
    H->>ET: ensureThread(chatId)
    ET->>TS: "getChat(chatId) → {threadId: runtimeId, ...}"
    Note over ET: threadId present → early return, no setChat
    H->>ST: sendText("Started turn Y")
    ST->>TS: getChat(chatId) → replyToMessageId present
    ST->>Lark: im.message.reply() ← stays in thread ✓
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `integrations/feishu-bridge/src/index.mjs`, line 261-268 ([link](https://github.com/hmbown/codewhale/blob/c0b82b6ec0253d847ba02a5a529b13ba40666d5d/integrations/feishu-bridge/src/index.mjs#L261-L268)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`setChat` in `ensureThread` erases `replyToMessageId`**

   `ensureThread` calls `threadStore.setChat(chatId, state)` with a fresh object that does not include `replyToMessageId`. This completely overwrites the entry that `handleIncomingMessage` just wrote, so for every **first-ever message in a new chat** the store no longer carries a `replyToMessageId` by the time `sendText` is called. The same problem occurs after `/new` (`forceNew: true`) and `/resume` (which also calls `setChat` at line 497). All "Started turn …" confirmations, streaming chunks, and turn-completed messages for those cases fall back to `client.im.message.create`, creating standalone topics — exactly the behaviour this PR intends to fix.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Ffeishu-thread-reply%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Ffeishu-thread-reply%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20integrations%2Ffeishu-bridge%2Fsrc%2Findex.mjs%0ALine%3A%20261-268%0A%0AComment%3A%0A**%60setChat%60%20in%20%60ensureThread%60%20erases%20%60replyToMessageId%60**%0A%0A%60ensureThread%60%20calls%20%60threadStore.setChat%28chatId%2C%20state%29%60%20with%20a%20fresh%20object%20that%20does%20not%20include%20%60replyToMessageId%60.%20This%20completely%20overwrites%20the%20entry%20that%20%60handleIncomingMessage%60%20just%20wrote%2C%20so%20for%20every%20**first-ever%20message%20in%20a%20new%20chat**%20the%20store%20no%20longer%20carries%20a%20%60replyToMessageId%60%20by%20the%20time%20%60sendText%60%20is%20called.%20The%20same%20problem%20occurs%20after%20%60%2Fnew%60%20%28%60forceNew%3A%20true%60%29%20and%20%60%2Fresume%60%20%28which%20also%20calls%20%60setChat%60%20at%20line%20497%29.%20All%20%22Started%20turn%20%E2%80%A6%22%20confirmations%2C%20streaming%20chunks%2C%20and%20turn-completed%20messages%20for%20those%20cases%20fall%20back%20to%20%60client.im.message.create%60%2C%20creating%20standalone%20topics%20%E2%80%94%20exactly%20the%20behaviour%20this%20PR%20intends%20to%20fix.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20integrations%2Ffeishu-bridge%2Fsrc%2Findex.mjs%0ALine%3A%20261-268%0A%0AComment%3A%0A**%60setChat%60%20in%20%60ensureThread%60%20erases%20%60replyToMessageId%60**%0A%0A%60ensureThread%60%20calls%20%60threadStore.setChat%28chatId%2C%20state%29%60%20with%20a%20fresh%20object%20that%20does%20not%20include%20%60replyToMessageId%60.%20This%20completely%20overwrites%20the%20entry%20that%20%60handleIncomingMessage%60%20just%20wrote%2C%20so%20for%20every%20**first-ever%20message%20in%20a%20new%20chat**%20the%20store%20no%20longer%20carries%20a%20%60replyToMessageId%60%20by%20the%20time%20%60sendText%60%20is%20called.%20The%20same%20problem%20occurs%20after%20%60%2Fnew%60%20%28%60forceNew%3A%20true%60%29%20and%20%60%2Fresume%60%20%28which%20also%20calls%20%60setChat%60%20at%20line%20497%29.%20All%20%22Started%20turn%20%E2%80%A6%22%20confirmations%2C%20streaming%20chunks%2C%20and%20turn-completed%20messages%20for%20those%20cases%20fall%20back%20to%20%60client.im.message.create%60%2C%20creating%20standalone%20topics%20%E2%80%94%20exactly%20the%20behaviour%20this%20PR%20intends%20to%20fix.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2148&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20integrations%2Ffeishu-bridge%2Fsrc%2Findex.mjs%0ALine%3A%20261-268%0A%0AComment%3A%0A**%60setChat%60%20in%20%60ensureThread%60%20erases%20%60replyToMessageId%60**%0A%0A%60ensureThread%60%20calls%20%60threadStore.setChat%28chatId%2C%20state%29%60%20with%20a%20fresh%20object%20that%20does%20not%20include%20%60replyToMessageId%60.%20This%20completely%20overwrites%20the%20entry%20that%20%60handleIncomingMessage%60%20just%20wrote%2C%20so%20for%20every%20**first-ever%20message%20in%20a%20new%20chat**%20the%20store%20no%20longer%20carries%20a%20%60replyToMessageId%60%20by%20the%20time%20%60sendText%60%20is%20called.%20The%20same%20problem%20occurs%20after%20%60%2Fnew%60%20%28%60forceNew%3A%20true%60%29%20and%20%60%2Fresume%60%20%28which%20also%20calls%20%60setChat%60%20at%20line%20497%29.%20All%20%22Started%20turn%20%E2%80%A6%22%20confirmations%2C%20streaming%20chunks%2C%20and%20turn-completed%20messages%20for%20those%20cases%20fall%20back%20to%20%60client.im.message.create%60%2C%20creating%20standalone%20topics%20%E2%80%94%20exactly%20the%20behaviour%20this%20PR%20intends%20to%20fix.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2148&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Ffeishu-thread-reply%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Ffeishu-thread-reply%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aintegrations%2Ffeishu-bridge%2Fsrc%2Findex.mjs%3A261-268%0A**%60setChat%60%20in%20%60ensureThread%60%20erases%20%60replyToMessageId%60**%0A%0A%60ensureThread%60%20calls%20%60threadStore.setChat%28chatId%2C%20state%29%60%20with%20a%20fresh%20object%20that%20does%20not%20include%20%60replyToMessageId%60.%20This%20completely%20overwrites%20the%20entry%20that%20%60handleIncomingMessage%60%20just%20wrote%2C%20so%20for%20every%20**first-ever%20message%20in%20a%20new%20chat**%20the%20store%20no%20longer%20carries%20a%20%60replyToMessageId%60%20by%20the%20time%20%60sendText%60%20is%20called.%20The%20same%20problem%20occurs%20after%20%60%2Fnew%60%20%28%60forceNew%3A%20true%60%29%20and%20%60%2Fresume%60%20%28which%20also%20calls%20%60setChat%60%20at%20line%20497%29.%20All%20%22Started%20turn%20%E2%80%A6%22%20confirmations%2C%20streaming%20chunks%2C%20and%20turn-completed%20messages%20for%20those%20cases%20fall%20back%20to%20%60client.im.message.create%60%2C%20creating%20standalone%20topics%20%E2%80%94%20exactly%20the%20behaviour%20this%20PR%20intends%20to%20fix.%0A%0A%23%23%23%20Issue%202%20of%202%0Aintegrations%2Ffeishu-bridge%2Fsrc%2Flib.mjs%3A74-76%0A**%60threadId%60%20%2F%20%60parentId%60%20%2F%20%60rootId%60%20are%20never%20consumed**%0A%0AThe%20three%20new%20fields%20%28%60parentId%60%2C%20%60rootId%60%2C%20%60threadId%60%29%20are%20populated%20in%20%60incomingIdentity%60%20but%20none%20of%20them%20is%20read%20anywhere%20in%20%60index.mjs%60.%20The%20threading%20logic%20in%20%60handleIncomingMessage%60%20exclusively%20stores%20%60identity.messageId%60%20as%20%60replyToMessageId%60.%20If%20these%20fields%20are%20intended%20for%20future%20use%2C%20a%20comment%20noting%20that%20would%20help%3B%20if%20they%20are%20not%20needed%20now%2C%20omitting%20them%20avoids%20confusion%20with%20the%20runtime%20%60threadId%60%20already%20stored%20in%20%60ThreadStore%60.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aintegrations%2Ffeishu-bridge%2Fsrc%2Findex.mjs%3A261-268%0A**%60setChat%60%20in%20%60ensureThread%60%20erases%20%60replyToMessageId%60**%0A%0A%60ensureThread%60%20calls%20%60threadStore.setChat%28chatId%2C%20state%29%60%20with%20a%20fresh%20object%20that%20does%20not%20include%20%60replyToMessageId%60.%20This%20completely%20overwrites%20the%20entry%20that%20%60handleIncomingMessage%60%20just%20wrote%2C%20so%20for%20every%20**first-ever%20message%20in%20a%20new%20chat**%20the%20store%20no%20longer%20carries%20a%20%60replyToMessageId%60%20by%20the%20time%20%60sendText%60%20is%20called.%20The%20same%20problem%20occurs%20after%20%60%2Fnew%60%20%28%60forceNew%3A%20true%60%29%20and%20%60%2Fresume%60%20%28which%20also%20calls%20%60setChat%60%20at%20line%20497%29.%20All%20%22Started%20turn%20%E2%80%A6%22%20confirmations%2C%20streaming%20chunks%2C%20and%20turn-completed%20messages%20for%20those%20cases%20fall%20back%20to%20%60client.im.message.create%60%2C%20creating%20standalone%20topics%20%E2%80%94%20exactly%20the%20behaviour%20this%20PR%20intends%20to%20fix.%0A%0A%23%23%23%20Issue%202%20of%202%0Aintegrations%2Ffeishu-bridge%2Fsrc%2Flib.mjs%3A74-76%0A**%60threadId%60%20%2F%20%60parentId%60%20%2F%20%60rootId%60%20are%20never%20consumed**%0A%0AThe%20three%20new%20fields%20%28%60parentId%60%2C%20%60rootId%60%2C%20%60threadId%60%29%20are%20populated%20in%20%60incomingIdentity%60%20but%20none%20of%20them%20is%20read%20anywhere%20in%20%60index.mjs%60.%20The%20threading%20logic%20in%20%60handleIncomingMessage%60%20exclusively%20stores%20%60identity.messageId%60%20as%20%60replyToMessageId%60.%20If%20these%20fields%20are%20intended%20for%20future%20use%2C%20a%20comment%20noting%20that%20would%20help%3B%20if%20they%20are%20not%20needed%20now%2C%20omitting%20them%20avoids%20confusion%20with%20the%20runtime%20%60threadId%60%20already%20stored%20in%20%60ThreadStore%60.%0A%0A&repo=hmbown%2Fcodewhale&pr=2148&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aintegrations%2Ffeishu-bridge%2Fsrc%2Findex.mjs%3A261-268%0A**%60setChat%60%20in%20%60ensureThread%60%20erases%20%60replyToMessageId%60**%0A%0A%60ensureThread%60%20calls%20%60threadStore.setChat%28chatId%2C%20state%29%60%20with%20a%20fresh%20object%20that%20does%20not%20include%20%60replyToMessageId%60.%20This%20completely%20overwrites%20the%20entry%20that%20%60handleIncomingMessage%60%20just%20wrote%2C%20so%20for%20every%20**first-ever%20message%20in%20a%20new%20chat**%20the%20store%20no%20longer%20carries%20a%20%60replyToMessageId%60%20by%20the%20time%20%60sendText%60%20is%20called.%20The%20same%20problem%20occurs%20after%20%60%2Fnew%60%20%28%60forceNew%3A%20true%60%29%20and%20%60%2Fresume%60%20%28which%20also%20calls%20%60setChat%60%20at%20line%20497%29.%20All%20%22Started%20turn%20%E2%80%A6%22%20confirmations%2C%20streaming%20chunks%2C%20and%20turn-completed%20messages%20for%20those%20cases%20fall%20back%20to%20%60client.im.message.create%60%2C%20creating%20standalone%20topics%20%E2%80%94%20exactly%20the%20behaviour%20this%20PR%20intends%20to%20fix.%0A%0A%23%23%23%20Issue%202%20of%202%0Aintegrations%2Ffeishu-bridge%2Fsrc%2Flib.mjs%3A74-76%0A**%60threadId%60%20%2F%20%60parentId%60%20%2F%20%60rootId%60%20are%20never%20consumed**%0A%0AThe%20three%20new%20fields%20%28%60parentId%60%2C%20%60rootId%60%2C%20%60threadId%60%29%20are%20populated%20in%20%60incomingIdentity%60%20but%20none%20of%20them%20is%20read%20anywhere%20in%20%60index.mjs%60.%20The%20threading%20logic%20in%20%60handleIncomingMessage%60%20exclusively%20stores%20%60identity.messageId%60%20as%20%60replyToMessageId%60.%20If%20these%20fields%20are%20intended%20for%20future%20use%2C%20a%20comment%20noting%20that%20would%20help%3B%20if%20they%20are%20not%20needed%20now%2C%20omitting%20them%20avoids%20confusion%20with%20the%20runtime%20%60threadId%60%20already%20stored%20in%20%60ThreadStore%60.%0A%0A&pr=2148&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(feishu): reply inside thread/topic i..."](https://github.com/hmbown/codewhale/commit/c0b82b6ec0253d847ba02a5a529b13ba40666d5d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33849524)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->