### PR TITLE
fix(v0.8.45): narrow provider scope to DeepSeek (+ self-host) and Kimi K2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **AGENTS.md is now maintainer-local.** The project instructions file no
   longer ships as a tracked repo file; it lives in maintainer-local ignored
   state (#2047).
+- **Supported provider set narrowed.** v0.8.45 ships with DeepSeek (default,
+  on the official endpoint plus the documented NVIDIA NIM escape hatch),
+  Moonshot/Kimi (K2.6 — Kimi OAuth path included), and the self-hosted
+  SGLang, vLLM, and Ollama backends. The generic OpenAI-compatible
+  provider, AtlasCloud, Wanjie Ark, OpenRouter, Novita, and Fireworks
+  surfaces are removed from runtime, pickers, completions, secrets, docs,
+  and examples for this release.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -250,42 +250,18 @@ Both binaries are required. Cross-compilation and platform-specific notes: [docs
 
 ### Other API Providers
 
-Official DeepSeek remains the default and first-class path. Other providers are
-additive, with OpenRouter starting from DeepSeek Pro/Flash before broader
-open-model catalogs are enabled.
+Official DeepSeek remains the default and first-class path. v0.8.45 also
+supports NVIDIA NIM (documented DeepSeek-on-NVIDIA escape hatch), Moonshot/Kimi
+(K2.6), and self-hosted SGLang / vLLM / Ollama endpoints.
 
 ```bash
 # NVIDIA NIM
 codewhale auth set --provider nvidia-nim --api-key "YOUR_NVIDIA_API_KEY"
 codewhale --provider nvidia-nim
 
-# AtlasCloud
-codewhale auth set --provider atlascloud --api-key "YOUR_ATLASCLOUD_API_KEY"
-codewhale --provider atlascloud
-
-# Wanjie Ark
-codewhale auth set --provider wanjie-ark --api-key "YOUR_WANJIE_API_KEY"
-codewhale --provider wanjie-ark --model deepseek-reasoner
-
-# OpenRouter
-codewhale auth set --provider openrouter --api-key "YOUR_OPENROUTER_API_KEY"
-codewhale --provider openrouter --model deepseek/deepseek-v4-pro
-
-# Novita
-codewhale auth set --provider novita --api-key "YOUR_NOVITA_API_KEY"
-codewhale --provider novita --model deepseek/deepseek-v4-pro
-
-# Fireworks
-codewhale auth set --provider fireworks --api-key "YOUR_FIREWORKS_API_KEY"
-codewhale --provider fireworks --model deepseek-v4-pro
-
 # Moonshot/Kimi
 codewhale auth set --provider moonshot --api-key "YOUR_MOONSHOT_OR_KIMI_API_KEY"
 codewhale --provider moonshot --model kimi-k2.6
-
-# Generic OpenAI-compatible endpoint
-codewhale auth set --provider openai --api-key "YOUR_OPENAI_COMPATIBLE_API_KEY"
-OPENAI_BASE_URL="https://openai-compatible.example/v4" codewhale --provider openai --model deepseek-v4-pro
 
 # Self-hosted SGLang
 SGLANG_BASE_URL="http://localhost:30000/v1" codewhale --provider sglang --model deepseek-v4-flash
@@ -294,12 +270,12 @@ SGLANG_BASE_URL="http://localhost:30000/v1" codewhale --provider sglang --model 
 VLLM_BASE_URL="http://localhost:8000/v1" codewhale --provider vllm --model deepseek-v4-flash
 
 # Self-hosted Ollama
-ollama pull codewhale-coder:1.3b
-codewhale --provider ollama --model codewhale-coder:1.3b
+ollama pull deepseek-coder:1.3b
+codewhale --provider ollama --model deepseek-coder:1.3b
 ```
 
 Inside the TUI, `/provider` opens the provider picker and `/model` opens the
-local model/thinking picker. `/provider openrouter` and `/model <id>` switch
+local model/thinking picker. `/provider moonshot` and `/model <id>` switch
 directly, while `/models` explicitly fetches and lists live API models when the
 active provider supports model listing.
 
@@ -466,18 +442,12 @@ Key environment variables:
 | `DEEPSEEK_HTTP_HEADERS` | Optional custom model request headers, e.g. `X-Model-Provider-Id=your-model-provider` |
 | `DEEPSEEK_MODEL` | Default model |
 | `DEEPSEEK_STREAM_IDLE_TIMEOUT_SECS` | Stream idle timeout in seconds, default `300`, clamped to `1..=3600` |
-| `DEEPSEEK_PROVIDER` | `codewhale` (default), `nvidia-nim`, `openai`, `atlascloud`, `wanjie-ark`, `openrouter`, `novita`, `fireworks`, `moonshot`, `sglang`, `vllm`, `ollama` |
+| `DEEPSEEK_PROVIDER` | `deepseek` (default), `nvidia-nim`, `moonshot`, `sglang`, `vllm`, `ollama` |
 | `DEEPSEEK_PROFILE` | Config profile name |
 | `DEEPSEEK_MEMORY` | Set to `on` to enable user memory |
 | `DEEPSEEK_ALLOW_INSECURE_HTTP=1` | Allow non-local `http://` API base URLs on trusted networks |
-| `NVIDIA_API_KEY` / `OPENAI_API_KEY` / `ATLASCLOUD_API_KEY` / `WANJIE_ARK_API_KEY` / `OPENROUTER_API_KEY` / `NOVITA_API_KEY` / `FIREWORKS_API_KEY` / `MOONSHOT_API_KEY` / `KIMI_API_KEY` / `SGLANG_API_KEY` / `VLLM_API_KEY` / `OLLAMA_API_KEY` | Provider auth |
-| `OPENAI_BASE_URL` / `OPENAI_MODEL` | Generic OpenAI-compatible endpoint and model ID |
-| `ATLASCLOUD_BASE_URL` / `ATLASCLOUD_MODEL` | AtlasCloud endpoint and model override |
-| `WANJIE_ARK_BASE_URL` / `WANJIE_ARK_MODEL` | Wanjie Ark endpoint and model override |
+| `NVIDIA_API_KEY` / `MOONSHOT_API_KEY` / `KIMI_API_KEY` / `SGLANG_API_KEY` / `VLLM_API_KEY` / `OLLAMA_API_KEY` | Provider auth |
 | `MOONSHOT_BASE_URL` / `KIMI_BASE_URL` / `MOONSHOT_MODEL` / `KIMI_MODEL` | Moonshot/Kimi endpoint and model override |
-| `OPENROUTER_BASE_URL` | OpenRouter endpoint override |
-| `NOVITA_BASE_URL` | Novita endpoint override |
-| `FIREWORKS_BASE_URL` | Fireworks endpoint override |
 | `SGLANG_BASE_URL` | Self-hosted SGLang endpoint |
 | `SGLANG_MODEL` | Self-hosted SGLang model ID |
 | `VLLM_BASE_URL` | Self-hosted vLLM endpoint |

--- a/config.example.toml
+++ b/config.example.toml
@@ -10,14 +10,13 @@
 # Active provider + DeepSeek defaults
 # ─────────────────────────────────────────────────────────────────────────────────
 # Choose which provider to use by default. Per-provider credentials live in the
-# `[providers.*]` sections near the bottom of
-# this file — keeping both stored at once means `/provider deepseek` and
-# `/provider nvidia-nim` (or `--provider openai`, `--provider wanjie-ark`,
-# `--provider fireworks`, `/provider sglang`, `/provider vllm`, `/provider ollama`)
-# toggle without having to re-enter keys. Top-level `api_key` / `base_url` are
-# still read as DeepSeek defaults when `[providers.deepseek]` is absent
-# (backward compatibility).
-provider = "deepseek" # deepseek | deepseek-cn | nvidia-nim | openai | atlascloud | wanjie-ark | openrouter | novita | fireworks | sglang | vllm | ollama
+# `[providers.*]` sections near the bottom of this file — keeping multiple
+# stored at once means `/provider deepseek` and `/provider nvidia-nim` (or
+# `--provider moonshot`, `/provider sglang`, `/provider vllm`,
+# `/provider ollama`) toggle without having to re-enter keys. Top-level
+# `api_key` / `base_url` are still read as DeepSeek defaults when
+# `[providers.deepseek]` is absent (backward compatibility).
+provider = "deepseek" # deepseek | deepseek-cn | nvidia-nim | moonshot | sglang | vllm | ollama
 api_key = "YOUR_DEEPSEEK_API_KEY" # must be non-empty
 base_url = "https://api.deepseek.com/beta"
 # provider = "deepseek-cn"                       # legacy alias (official host is still https://api.deepseek.com)
@@ -32,14 +31,11 @@ base_url = "https://api.deepseek.com/beta"
 # DeepSeek V4 family:
 #   deepseek-v4-pro             — flagship reasoning model on DeepSeek Platform
 #   deepseek-v4-flash           — fast, cost-efficient (legacy aliases: deepseek-chat, deepseek-reasoner)
-#   deepseek-ai/deepseek-v4-pro   — NVIDIA NIM-hosted Pro model ID
-#   deepseek-ai/deepseek-v4-flash — NVIDIA NIM-hosted Flash model ID
-#   gpt-4.1                         — default generic OpenAI-compatible model ID
-#   deepseek-ai/deepseek-v4-flash   — default AtlasCloud model ID
-#   deepseek-reasoner               — default Wanjie Ark model ID
-#   accounts/fireworks/models/deepseek-v4-pro — Fireworks AI Pro model ID
-#   deepseek-ai/DeepSeek-V4-Pro    — SGLang self-hosted Pro model ID
-#   deepseek-ai/DeepSeek-V4-Flash  — SGLang self-hosted Flash model ID
+#   deepseek-ai/deepseek-v4-pro    — NVIDIA NIM-hosted Pro model ID
+#   deepseek-ai/deepseek-v4-flash  — NVIDIA NIM-hosted Flash model ID
+#   deepseek-ai/DeepSeek-V4-Pro    — SGLang/vLLM self-hosted Pro model ID
+#   deepseek-ai/DeepSeek-V4-Flash  — SGLang/vLLM self-hosted Flash model ID
+#   kimi-k2.6                      — Moonshot/Kimi K2.6 (passthrough)
 default_text_model = "deepseek-v4-pro"
 
 # ─────────────────────────────────────────────────────────────────────────────────
@@ -156,17 +152,14 @@ max_subagents = 10 # optional (1-20)
 # Per-provider credentials (peer providers — NIM is first-class, not a flag)
 # ─────────────────────────────────────────────────────────────────────────────────
 # Providers can be stored at once; `provider = "..."` (top of file) or
-# `/provider deepseek` / `/provider nvidia-nim` / `--provider openai` /
-# `--provider wanjie-ark` / `/provider fireworks` switches between them without
-# having to re-enter keys. Env vars override anything set here:
+# `/provider deepseek` / `/provider nvidia-nim` / `--provider moonshot` /
+# `/provider sglang` / `/provider vllm` / `/provider ollama` switches between
+# them without having to re-enter keys. Env vars override anything set here:
 #   DeepSeek: DEEPSEEK_API_KEY, DEEPSEEK_BASE_URL, DEEPSEEK_MODEL
 #   NIM:      NVIDIA_API_KEY (or NVIDIA_NIM_API_KEY), NIM_BASE_URL
 #             (or NVIDIA_NIM_BASE_URL / NVIDIA_BASE_URL), NVIDIA_NIM_MODEL
-#   OpenAI-compatible: OPENAI_API_KEY, OPENAI_BASE_URL, OPENAI_MODEL
-#   Wanjie Ark: WANJIE_ARK_API_KEY (or WANJIE_API_KEY), WANJIE_ARK_BASE_URL, WANJIE_ARK_MODEL
-#   OpenRouter: OPENROUTER_API_KEY, OPENROUTER_BASE_URL, OPENROUTER_MODEL
-#   Novita:     NOVITA_API_KEY, NOVITA_BASE_URL, NOVITA_MODEL
-#   Fireworks:  FIREWORKS_API_KEY, FIREWORKS_BASE_URL
+#   Moonshot/Kimi: MOONSHOT_API_KEY (or KIMI_API_KEY), MOONSHOT_BASE_URL
+#                  (or KIMI_BASE_URL), MOONSHOT_MODEL (or KIMI_MODEL)
 #   SGLang:    SGLANG_BASE_URL, SGLANG_MODEL, optional SGLANG_API_KEY
 #   vLLM:      VLLM_BASE_URL, VLLM_MODEL, optional VLLM_API_KEY
 #   Ollama:    OLLAMA_BASE_URL, OLLAMA_MODEL, optional OLLAMA_API_KEY
@@ -184,44 +177,13 @@ max_subagents = 10 # optional (1-20)
 # base_url = "https://integrate.api.nvidia.com/v1"
 # model = "deepseek-ai/deepseek-v4-pro"     # or deepseek-ai/deepseek-v4-flash
 
-# Generic OpenAI-compatible endpoint. Use the built-in `openai` provider for
-# third-party gateways; do not invent a custom provider name. For non-local
-# http:// gateways, launch with DEEPSEEK_ALLOW_INSECURE_HTTP=1 only on a
-# trusted network.
-[providers.openai]
-# api_key = "YOUR_OPENAI_COMPATIBLE_API_KEY"
-# base_url = "https://api.openai.com/v1"
-# model = "gpt-4.1"
-
-# AtlasCloud OpenAI-compatible endpoint (https://www.atlascloud.ai/docs/models/llm)
-[providers.atlascloud]
-# api_key = "YOUR_ATLASCLOUD_API_KEY"
-# base_url = "https://api.atlascloud.ai/v1"
-# model = "deepseek-ai/deepseek-v4-flash"
-
-# Wanjie Ark / 万界方舟 OpenAI-compatible endpoint
-[providers.wanjie_ark]
-# api_key = "YOUR_WANJIE_API_KEY"
-# base_url = "https://maas-openapi.wanjiedata.com/api/v1"
-# model = "deepseek-reasoner"                # or the exact model ID enabled on your Wanjie account
-
-# OpenRouter — multi-provider gateway (https://openrouter.ai)
-[providers.openrouter]
-# api_key = "YOUR_OPENROUTER_API_KEY"
-# base_url = "https://openrouter.ai/api/v1"
-# model = "deepseek/deepseek-v4-pro"         # or deepseek/deepseek-v4-flash
-
-# Novita AI-hosted inference (https://novita.ai)
-[providers.novita]
-# api_key = "YOUR_NOVITA_API_KEY"
-# base_url = "https://api.novita.ai/v1"
-# model = "deepseek/deepseek-v4-pro"         # or deepseek/deepseek-v4-flash
-
-# Fireworks AI-hosted DeepSeek V4 (https://fireworks.ai)
-[providers.fireworks]
-# api_key = "YOUR_FIREWORKS_API_KEY"
-# base_url = "https://api.fireworks.ai/inference/v1"
-# model = "accounts/fireworks/models/deepseek-v4-pro"
+# Moonshot/Kimi — official Moonshot API (https://platform.moonshot.ai) or
+# Kimi-for-coding OAuth (https://www.kimi.com/code).
+[providers.moonshot]
+# api_key = "YOUR_MOONSHOT_OR_KIMI_API_KEY"
+# base_url = "https://api.moonshot.ai/v1"
+# model = "kimi-k2.6"
+# auth_mode = "kimi_oauth"  # switch to the Kimi-for-coding OAuth path
 
 # Self-hosted SGLang OpenAI-compatible server
 [providers.sglang]

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -74,84 +74,6 @@ impl Default for ModelRegistry {
                 supports_reasoning: true,
             },
             ModelInfo {
-                id: "deepseek-v4-pro".to_string(),
-                provider: ProviderKind::Openai,
-                aliases: vec!["openai-compatible-deepseek-v4-pro".to_string()],
-                supports_tools: true,
-                supports_reasoning: true,
-            },
-            ModelInfo {
-                id: "deepseek-v4-flash".to_string(),
-                provider: ProviderKind::Openai,
-                aliases: vec!["openai-compatible-deepseek-v4-flash".to_string()],
-                supports_tools: true,
-                supports_reasoning: true,
-            },
-            ModelInfo {
-                id: "deepseek-reasoner".to_string(),
-                provider: ProviderKind::WanjieArk,
-                aliases: vec![
-                    "wanjie-deepseek-reasoner".to_string(),
-                    "ark-wanjie-deepseek-reasoner".to_string(),
-                ],
-                supports_tools: true,
-                supports_reasoning: true,
-            },
-            ModelInfo {
-                id: "deepseek/deepseek-v4-pro".to_string(),
-                provider: ProviderKind::Openrouter,
-                aliases: vec![
-                    "deepseek-v4-pro".to_string(),
-                    "openrouter-deepseek-v4-pro".to_string(),
-                ],
-                supports_tools: true,
-                supports_reasoning: true,
-            },
-            ModelInfo {
-                id: "deepseek/deepseek-v4-flash".to_string(),
-                provider: ProviderKind::Openrouter,
-                aliases: vec![
-                    "deepseek-v4-flash".to_string(),
-                    "deepseek-chat".to_string(),
-                    "deepseek-reasoner".to_string(),
-                    "openrouter-deepseek-v4-flash".to_string(),
-                ],
-                supports_tools: true,
-                supports_reasoning: true,
-            },
-            ModelInfo {
-                id: "deepseek/deepseek-v4-pro".to_string(),
-                provider: ProviderKind::Novita,
-                aliases: vec![
-                    "deepseek-v4-pro".to_string(),
-                    "novita-deepseek-v4-pro".to_string(),
-                ],
-                supports_tools: true,
-                supports_reasoning: true,
-            },
-            ModelInfo {
-                id: "deepseek/deepseek-v4-flash".to_string(),
-                provider: ProviderKind::Novita,
-                aliases: vec![
-                    "deepseek-v4-flash".to_string(),
-                    "deepseek-chat".to_string(),
-                    "deepseek-reasoner".to_string(),
-                    "novita-deepseek-v4-flash".to_string(),
-                ],
-                supports_tools: true,
-                supports_reasoning: true,
-            },
-            ModelInfo {
-                id: "accounts/fireworks/models/deepseek-v4-pro".to_string(),
-                provider: ProviderKind::Fireworks,
-                aliases: vec![
-                    "deepseek-v4-pro".to_string(),
-                    "fireworks-deepseek-v4-pro".to_string(),
-                ],
-                supports_tools: true,
-                supports_reasoning: true,
-            },
-            ModelInfo {
                 id: "kimi-k2.6".to_string(),
                 provider: ProviderKind::Moonshot,
                 aliases: vec![
@@ -374,70 +296,12 @@ mod tests {
     }
 
     #[test]
-    fn openrouter_default_uses_namespaced_model_id() {
-        let registry = ModelRegistry::default();
-        let resolved = registry.resolve(None, Some(ProviderKind::Openrouter));
-
-        assert_eq!(resolved.resolved.provider, ProviderKind::Openrouter);
-        assert_eq!(resolved.resolved.id, "deepseek/deepseek-v4-pro");
-    }
-
-    #[test]
-    fn wanjie_ark_default_uses_reasoner_model_id() {
-        let registry = ModelRegistry::default();
-        let resolved = registry.resolve(None, Some(ProviderKind::WanjieArk));
-
-        assert_eq!(resolved.resolved.provider, ProviderKind::WanjieArk);
-        assert_eq!(resolved.resolved.id, "deepseek-reasoner");
-        assert!(resolved.resolved.supports_reasoning);
-    }
-
-    #[test]
-    fn novita_default_uses_namespaced_model_id() {
-        let registry = ModelRegistry::default();
-        let resolved = registry.resolve(None, Some(ProviderKind::Novita));
-
-        assert_eq!(resolved.resolved.provider, ProviderKind::Novita);
-        assert_eq!(resolved.resolved.id, "deepseek/deepseek-v4-pro");
-    }
-
-    #[test]
-    fn fireworks_default_uses_canonical_model_id() {
-        let registry = ModelRegistry::default();
-        let resolved = registry.resolve(None, Some(ProviderKind::Fireworks));
-
-        assert_eq!(resolved.resolved.provider, ProviderKind::Fireworks);
-        assert_eq!(
-            resolved.resolved.id,
-            "accounts/fireworks/models/deepseek-v4-pro"
-        );
-    }
-
-    #[test]
     fn sglang_default_uses_canonical_model_id() {
         let registry = ModelRegistry::default();
         let resolved = registry.resolve(None, Some(ProviderKind::Sglang));
 
         assert_eq!(resolved.resolved.provider, ProviderKind::Sglang);
         assert_eq!(resolved.resolved.id, "deepseek-ai/DeepSeek-V4-Pro");
-    }
-
-    #[test]
-    fn deepseek_v4_flash_alias_resolves_to_openrouter_when_provider_hinted() {
-        let registry = ModelRegistry::default();
-        let resolved = registry.resolve(Some("deepseek-v4-flash"), Some(ProviderKind::Openrouter));
-
-        assert_eq!(resolved.resolved.provider, ProviderKind::Openrouter);
-        assert_eq!(resolved.resolved.id, "deepseek/deepseek-v4-flash");
-    }
-
-    #[test]
-    fn deepseek_v4_flash_alias_resolves_to_novita_when_provider_hinted() {
-        let registry = ModelRegistry::default();
-        let resolved = registry.resolve(Some("deepseek-v4-flash"), Some(ProviderKind::Novita));
-
-        assert_eq!(resolved.resolved.provider, ProviderKind::Novita);
-        assert_eq!(resolved.resolved.id, "deepseek/deepseek-v4-flash");
     }
 
     #[test]

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -2405,7 +2405,10 @@ mod tests {
 
         assert_eq!(inner.get("deepseek").unwrap(), Some("sk-deep".to_string()));
         assert_eq!(inner.get("moonshot").unwrap(), Some("kimi-key".to_string()));
-        assert_eq!(inner.get("nvidia-nim").unwrap(), Some("nim-key".to_string()));
+        assert_eq!(
+            inner.get("nvidia-nim").unwrap(),
+            Some("nim-key".to_string())
+        );
 
         // Config file must no longer contain the api keys.
         assert!(store.config.api_key.is_none());
@@ -2495,10 +2498,7 @@ mod tests {
         assert_eq!(cli.telemetry, Some(true));
         assert_eq!(cli.approval_policy.as_deref(), Some("on-request"));
         assert_eq!(cli.sandbox_mode.as_deref(), Some("workspace-write"));
-        assert_eq!(
-            cli.base_url.as_deref(),
-            Some("https://api.moonshot.ai/v1")
-        );
+        assert_eq!(cli.base_url.as_deref(), Some("https://api.moonshot.ai/v1"));
         assert_eq!(cli.api_key.as_deref(), Some("sk-test"));
         assert_eq!(cli.workspace, Some(PathBuf::from("/tmp/workspace")));
         assert!(cli.no_alt_screen);

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -25,12 +25,6 @@ use codewhale_state::{StateStore, ThreadListFilters};
 enum ProviderArg {
     Deepseek,
     NvidiaNim,
-    Openai,
-    Atlascloud,
-    WanjieArk,
-    Openrouter,
-    Novita,
-    Fireworks,
     Moonshot,
     Sglang,
     Vllm,
@@ -42,12 +36,6 @@ impl From<ProviderArg> for ProviderKind {
         match value {
             ProviderArg::Deepseek => ProviderKind::Deepseek,
             ProviderArg::NvidiaNim => ProviderKind::NvidiaNim,
-            ProviderArg::Openai => ProviderKind::Openai,
-            ProviderArg::Atlascloud => ProviderKind::Atlascloud,
-            ProviderArg::WanjieArk => ProviderKind::WanjieArk,
-            ProviderArg::Openrouter => ProviderKind::Openrouter,
-            ProviderArg::Novita => ProviderKind::Novita,
-            ProviderArg::Fireworks => ProviderKind::Fireworks,
             ProviderArg::Moonshot => ProviderKind::Moonshot,
             ProviderArg::Sglang => ProviderKind::Sglang,
             ProviderArg::Vllm => ProviderKind::Vllm,
@@ -702,12 +690,6 @@ fn provider_slot(provider: ProviderKind) -> &'static str {
     match provider {
         ProviderKind::Deepseek => "deepseek",
         ProviderKind::NvidiaNim => "nvidia-nim",
-        ProviderKind::Openai => "openai",
-        ProviderKind::Atlascloud => "atlascloud",
-        ProviderKind::WanjieArk => "wanjie-ark",
-        ProviderKind::Openrouter => "openrouter",
-        ProviderKind::Novita => "novita",
-        ProviderKind::Fireworks => "fireworks",
         ProviderKind::Moonshot => "moonshot",
         ProviderKind::Sglang => "sglang",
         ProviderKind::Vllm => "vllm",
@@ -716,15 +698,9 @@ fn provider_slot(provider: ProviderKind) -> &'static str {
 }
 
 /// Provider order used by the `auth list` and `auth status` outputs.
-const PROVIDER_LIST: [ProviderKind; 12] = [
+const PROVIDER_LIST: [ProviderKind; 6] = [
     ProviderKind::Deepseek,
     ProviderKind::NvidiaNim,
-    ProviderKind::Openai,
-    ProviderKind::Atlascloud,
-    ProviderKind::WanjieArk,
-    ProviderKind::Openrouter,
-    ProviderKind::Novita,
-    ProviderKind::Fireworks,
     ProviderKind::Moonshot,
     ProviderKind::Sglang,
     ProviderKind::Vllm,
@@ -776,21 +752,11 @@ fn provider_env_set(provider: ProviderKind) -> bool {
 fn provider_env_vars(provider: ProviderKind) -> &'static [&'static str] {
     match provider {
         ProviderKind::Deepseek => &["DEEPSEEK_API_KEY"],
-        ProviderKind::Openrouter => &["OPENROUTER_API_KEY"],
-        ProviderKind::Novita => &["NOVITA_API_KEY"],
         ProviderKind::NvidiaNim => &["NVIDIA_API_KEY", "NVIDIA_NIM_API_KEY", "DEEPSEEK_API_KEY"],
-        ProviderKind::Fireworks => &["FIREWORKS_API_KEY"],
         ProviderKind::Moonshot => &["MOONSHOT_API_KEY", "KIMI_API_KEY"],
         ProviderKind::Sglang => &["SGLANG_API_KEY"],
         ProviderKind::Vllm => &["VLLM_API_KEY"],
         ProviderKind::Ollama => &["OLLAMA_API_KEY"],
-        ProviderKind::Openai => &["OPENAI_API_KEY"],
-        ProviderKind::Atlascloud => &["ATLASCLOUD_API_KEY"],
-        ProviderKind::WanjieArk => &[
-            "WANJIE_ARK_API_KEY",
-            "WANJIE_API_KEY",
-            "WANJIE_MAAS_API_KEY",
-        ],
     }
 }
 
@@ -1447,18 +1413,13 @@ fn build_tui_command(
         resolved_runtime.provider,
         ProviderKind::Deepseek
             | ProviderKind::NvidiaNim
-            | ProviderKind::Openai
-            | ProviderKind::Atlascloud
-            | ProviderKind::WanjieArk
-            | ProviderKind::Openrouter
-            | ProviderKind::Novita
-            | ProviderKind::Fireworks
+            | ProviderKind::Moonshot
             | ProviderKind::Sglang
             | ProviderKind::Vllm
             | ProviderKind::Ollama
     ) {
         bail!(
-            "The interactive TUI supports DeepSeek, NVIDIA NIM, OpenAI-compatible, AtlasCloud, Wanjie Ark, OpenRouter, Novita, Fireworks, SGLang, vLLM, and Ollama providers. Remove --provider {} or use `codewhale model ...` for provider registry inspection.",
+            "The interactive TUI supports DeepSeek, NVIDIA NIM, Moonshot/Kimi, SGLang, vLLM, and Ollama providers. Remove --provider {} or use `codewhale model ...` for provider registry inspection.",
             resolved_runtime.provider.as_str()
         );
     }
@@ -1480,14 +1441,8 @@ fn build_tui_command(
     }
     if let Some(api_key) = resolved_runtime.api_key.as_ref() {
         cmd.env("DEEPSEEK_API_KEY", api_key);
-        if resolved_runtime.provider == ProviderKind::Openai {
-            cmd.env("OPENAI_API_KEY", api_key);
-        }
-        if resolved_runtime.provider == ProviderKind::Atlascloud {
-            cmd.env("ATLASCLOUD_API_KEY", api_key);
-        }
-        if resolved_runtime.provider == ProviderKind::WanjieArk {
-            cmd.env("WANJIE_ARK_API_KEY", api_key);
+        if resolved_runtime.provider == ProviderKind::Moonshot {
+            cmd.env("MOONSHOT_API_KEY", api_key);
         }
         let source = resolved_runtime
             .api_key_source
@@ -1519,14 +1474,8 @@ fn build_tui_command(
     }
     if let Some(api_key) = cli.api_key.as_ref() {
         cmd.env("DEEPSEEK_API_KEY", api_key);
-        if resolved_runtime.provider == ProviderKind::Openai {
-            cmd.env("OPENAI_API_KEY", api_key);
-        }
-        if resolved_runtime.provider == ProviderKind::Atlascloud {
-            cmd.env("ATLASCLOUD_API_KEY", api_key);
-        }
-        if resolved_runtime.provider == ProviderKind::WanjieArk {
-            cmd.env("WANJIE_ARK_API_KEY", api_key);
+        if resolved_runtime.provider == ProviderKind::Moonshot {
+            cmd.env("MOONSHOT_API_KEY", api_key);
         }
         cmd.env("DEEPSEEK_API_KEY_SOURCE", "cli");
     }
@@ -1808,12 +1757,12 @@ mod tests {
             }))
         ));
 
-        let cli = parse_ok(&["deepseek", "model", "list", "--provider", "openai"]);
+        let cli = parse_ok(&["deepseek", "model", "list", "--provider", "moonshot"]);
         assert!(matches!(
             cli.command,
             Some(Commands::Model(ModelArgs {
                 command: ModelCommand::List {
-                    provider: Some(ProviderArg::Openai)
+                    provider: Some(ProviderArg::Moonshot)
                 }
             }))
         ));
@@ -2067,26 +2016,26 @@ mod tests {
             "auth",
             "set",
             "--provider",
-            "openrouter",
+            "moonshot",
             "--api-key-stdin",
         ]);
         assert!(matches!(
             cli.command,
             Some(Commands::Auth(AuthArgs {
                 command: AuthCommand::Set {
-                    provider: ProviderArg::Openrouter,
+                    provider: ProviderArg::Moonshot,
                     api_key: None,
                     api_key_stdin: true,
                 }
             }))
         ));
 
-        let cli = parse_ok(&["deepseek", "auth", "get", "--provider", "novita"]);
+        let cli = parse_ok(&["deepseek", "auth", "get", "--provider", "moonshot"]);
         assert!(matches!(
             cli.command,
             Some(Commands::Auth(AuthArgs {
                 command: AuthCommand::Get {
-                    provider: ProviderArg::Novita
+                    provider: ProviderArg::Moonshot
                 }
             }))
         ));
@@ -2097,42 +2046,6 @@ mod tests {
             Some(Commands::Auth(AuthArgs {
                 command: AuthCommand::Clear {
                     provider: ProviderArg::NvidiaNim
-                }
-            }))
-        ));
-
-        let cli = parse_ok(&["deepseek", "auth", "set", "--provider", "fireworks"]);
-        assert!(matches!(
-            cli.command,
-            Some(Commands::Auth(AuthArgs {
-                command: AuthCommand::Set {
-                    provider: ProviderArg::Fireworks,
-                    api_key: None,
-                    api_key_stdin: false,
-                }
-            }))
-        ));
-
-        let cli = parse_ok(&["deepseek", "auth", "set", "--provider", "moonshot"]);
-        assert!(matches!(
-            cli.command,
-            Some(Commands::Auth(AuthArgs {
-                command: AuthCommand::Set {
-                    provider: ProviderArg::Moonshot,
-                    api_key: None,
-                    api_key_stdin: false,
-                }
-            }))
-        ));
-
-        let cli = parse_ok(&["deepseek", "auth", "set", "--provider", "wanjie-ark"]);
-        assert!(matches!(
-            cli.command,
-            Some(Commands::Auth(AuthArgs {
-                command: AuthCommand::Set {
-                    provider: ProviderArg::WanjieArk,
-                    api_key: None,
-                    api_key_stdin: false,
                 }
             }))
         ));
@@ -2449,7 +2362,7 @@ mod tests {
         let mut store = ConfigStore::load(Some(path.clone())).expect("store should load");
         store.config.api_key = Some("sk-stale".to_string());
         store.config.providers.deepseek.api_key = Some("sk-stale".to_string());
-        store.config.providers.fireworks.api_key = Some("fw-stale".to_string());
+        store.config.providers.moonshot.api_key = Some("kimi-stale".to_string());
         store.save().unwrap();
 
         let secrets = no_keyring_secrets();
@@ -2458,7 +2371,7 @@ mod tests {
 
         assert!(store.config.api_key.is_none());
         assert!(store.config.providers.deepseek.api_key.is_none());
-        assert!(store.config.providers.fireworks.api_key.is_none());
+        assert!(store.config.providers.moonshot.api_key.is_none());
 
         let _ = std::fs::remove_file(path);
     }
@@ -2476,8 +2389,8 @@ mod tests {
         let mut store = ConfigStore::load(Some(path.clone())).expect("store should load");
         store.config.api_key = Some("sk-deep".to_string());
         store.config.providers.deepseek.api_key = Some("sk-deep".to_string());
-        store.config.providers.openrouter.api_key = Some("or-key".to_string());
-        store.config.providers.novita.api_key = Some("nv-key".to_string());
+        store.config.providers.moonshot.api_key = Some("kimi-key".to_string());
+        store.config.providers.nvidia_nim.api_key = Some("nim-key".to_string());
         store.save().unwrap();
 
         let inner = Arc::new(InMemoryKeyringStore::new());
@@ -2491,19 +2404,19 @@ mod tests {
         .expect("migrate should succeed");
 
         assert_eq!(inner.get("deepseek").unwrap(), Some("sk-deep".to_string()));
-        assert_eq!(inner.get("openrouter").unwrap(), Some("or-key".to_string()));
-        assert_eq!(inner.get("novita").unwrap(), Some("nv-key".to_string()));
+        assert_eq!(inner.get("moonshot").unwrap(), Some("kimi-key".to_string()));
+        assert_eq!(inner.get("nvidia-nim").unwrap(), Some("nim-key".to_string()));
 
         // Config file must no longer contain the api keys.
         assert!(store.config.api_key.is_none());
         assert!(store.config.providers.deepseek.api_key.is_none());
-        assert!(store.config.providers.openrouter.api_key.is_none());
-        assert!(store.config.providers.novita.api_key.is_none());
+        assert!(store.config.providers.moonshot.api_key.is_none());
+        assert!(store.config.providers.nvidia_nim.api_key.is_none());
 
         let saved = std::fs::read_to_string(&path).expect("config exists post-migrate");
         assert!(!saved.contains("sk-deep"), "plaintext leaked: {saved}");
-        assert!(!saved.contains("or-key"), "plaintext leaked: {saved}");
-        assert!(!saved.contains("nv-key"), "plaintext leaked: {saved}");
+        assert!(!saved.contains("kimi-key"), "plaintext leaked: {saved}");
+        assert!(!saved.contains("nim-key"), "plaintext leaked: {saved}");
 
         let _ = std::fs::remove_file(path);
     }
@@ -2519,7 +2432,7 @@ mod tests {
             std::process::id()
         ));
         let mut store = ConfigStore::load(Some(path.clone())).expect("store should load");
-        store.config.providers.openrouter.api_key = Some("or-stay".to_string());
+        store.config.providers.moonshot.api_key = Some("kimi-stay".to_string());
         store.save().unwrap();
 
         let inner = Arc::new(InMemoryKeyringStore::new());
@@ -2528,10 +2441,10 @@ mod tests {
         run_auth_command_with_secrets(&mut store, AuthCommand::Migrate { dry_run: true }, &secrets)
             .expect("dry-run should succeed");
 
-        assert_eq!(inner.get("openrouter").unwrap(), None);
+        assert_eq!(inner.get("moonshot").unwrap(), None);
         assert_eq!(
-            store.config.providers.openrouter.api_key.as_deref(),
-            Some("or-stay")
+            store.config.providers.moonshot.api_key.as_deref(),
+            Some("kimi-stay")
         );
 
         let _ = std::fs::remove_file(path);
@@ -2542,7 +2455,7 @@ mod tests {
         let cli = parse_ok(&[
             "deepseek",
             "--provider",
-            "openai",
+            "moonshot",
             "--config",
             "/tmp/deepseek.toml",
             "--profile",
@@ -2560,7 +2473,7 @@ mod tests {
             "--sandbox-mode",
             "workspace-write",
             "--base-url",
-            "https://openai-compatible.example/v1",
+            "https://api.moonshot.ai/v1",
             "--api-key",
             "sk-test",
             "--workspace",
@@ -2573,7 +2486,7 @@ mod tests {
             "deepseek-v4-pro",
         ]);
 
-        assert!(matches!(cli.provider, Some(ProviderArg::Openai)));
+        assert!(matches!(cli.provider, Some(ProviderArg::Moonshot)));
         assert_eq!(cli.config, Some(PathBuf::from("/tmp/deepseek.toml")));
         assert_eq!(cli.profile.as_deref(), Some("work"));
         assert_eq!(cli.model.as_deref(), Some("deepseek-v4-pro"));
@@ -2584,7 +2497,7 @@ mod tests {
         assert_eq!(cli.sandbox_mode.as_deref(), Some("workspace-write"));
         assert_eq!(
             cli.base_url.as_deref(),
-            Some("https://openai-compatible.example/v1")
+            Some("https://api.moonshot.ai/v1")
         );
         assert_eq!(cli.api_key.as_deref(), Some("sk-test"));
         assert_eq!(cli.workspace, Some(PathBuf::from("/tmp/workspace")));
@@ -2595,7 +2508,7 @@ mod tests {
     }
 
     #[test]
-    fn build_tui_command_allows_openai_and_forwards_provider_key() {
+    fn build_tui_command_allows_moonshot_and_forwards_provider_key() {
         let _lock = env_lock();
         let dir = tempfile::TempDir::new().expect("tempdir");
         let custom = dir
@@ -2608,16 +2521,16 @@ mod tests {
         let cli = parse_ok(&[
             "deepseek",
             "--provider",
-            "openai",
+            "moonshot",
             "--workspace",
             "/tmp/codewhale-workspace",
         ]);
         let resolved = ResolvedRuntimeOptions {
-            provider: ProviderKind::Openai,
-            model: "glm-5".to_string(),
-            api_key: Some("resolved-openai-key".to_string()),
+            provider: ProviderKind::Moonshot,
+            model: "kimi-k2.6".to_string(),
+            api_key: Some("resolved-kimi-key".to_string()),
             api_key_source: Some(RuntimeApiKeySource::Keyring),
-            base_url: "https://openai-compatible.example/v4".to_string(),
+            base_url: "https://api.moonshot.ai/v1".to_string(),
             auth_mode: Some("api_key".to_string()),
             output_mode: None,
             log_level: None,
@@ -2631,23 +2544,23 @@ mod tests {
         let cmd = build_tui_command(&cli, &resolved, Vec::new()).expect("command");
         assert_eq!(
             command_env(&cmd, "DEEPSEEK_PROVIDER").as_deref(),
-            Some("openai")
+            Some("moonshot")
         );
         assert_eq!(
             command_env(&cmd, "DEEPSEEK_MODEL").as_deref(),
-            Some("glm-5")
+            Some("kimi-k2.6")
         );
         assert_eq!(
             command_env(&cmd, "DEEPSEEK_BASE_URL").as_deref(),
-            Some("https://openai-compatible.example/v4")
+            Some("https://api.moonshot.ai/v1")
         );
         assert_eq!(
             command_env(&cmd, "DEEPSEEK_API_KEY").as_deref(),
-            Some("resolved-openai-key")
+            Some("resolved-kimi-key")
         );
         assert_eq!(
-            command_env(&cmd, "OPENAI_API_KEY").as_deref(),
-            Some("resolved-openai-key")
+            command_env(&cmd, "MOONSHOT_API_KEY").as_deref(),
+            Some("resolved-kimi-key")
         );
         assert_eq!(
             command_env(&cmd, "DEEPSEEK_API_KEY_SOURCE").as_deref(),

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -346,6 +346,12 @@ impl ConfigToml {
             "providers.nvidia_nim.http_headers" => {
                 serialize_http_headers(&self.providers.nvidia_nim.http_headers)
             }
+            "providers.moonshot.api_key" => self.providers.moonshot.api_key.clone(),
+            "providers.moonshot.base_url" => self.providers.moonshot.base_url.clone(),
+            "providers.moonshot.model" => self.providers.moonshot.model.clone(),
+            "providers.moonshot.http_headers" => {
+                serialize_http_headers(&self.providers.moonshot.http_headers)
+            }
             "providers.sglang.api_key" => self.providers.sglang.api_key.clone(),
             "providers.sglang.base_url" => self.providers.sglang.base_url.clone(),
             "providers.sglang.model" => self.providers.sglang.model.clone(),
@@ -430,6 +436,18 @@ impl ConfigToml {
             "providers.nvidia_nim.http_headers" => {
                 self.providers.nvidia_nim.http_headers = parse_http_headers(value)?;
             }
+            "providers.moonshot.api_key" => {
+                self.providers.moonshot.api_key = Some(value.to_string());
+            }
+            "providers.moonshot.base_url" => {
+                self.providers.moonshot.base_url = Some(value.to_string());
+            }
+            "providers.moonshot.model" => {
+                self.providers.moonshot.model = Some(value.to_string());
+            }
+            "providers.moonshot.http_headers" => {
+                self.providers.moonshot.http_headers = parse_http_headers(value)?;
+            }
             "providers.sglang.api_key" => {
                 self.providers.sglang.api_key = Some(value.to_string());
             }
@@ -508,6 +526,10 @@ impl ConfigToml {
             "providers.nvidia_nim.base_url" => self.providers.nvidia_nim.base_url = None,
             "providers.nvidia_nim.model" => self.providers.nvidia_nim.model = None,
             "providers.nvidia_nim.http_headers" => self.providers.nvidia_nim.http_headers.clear(),
+            "providers.moonshot.api_key" => self.providers.moonshot.api_key = None,
+            "providers.moonshot.base_url" => self.providers.moonshot.base_url = None,
+            "providers.moonshot.model" => self.providers.moonshot.model = None,
+            "providers.moonshot.http_headers" => self.providers.moonshot.http_headers.clear(),
             "providers.sglang.api_key" => self.providers.sglang.api_key = None,
             "providers.sglang.base_url" => self.providers.sglang.base_url = None,
             "providers.sglang.model" => self.providers.sglang.model = None,
@@ -588,6 +610,18 @@ impl ConfigToml {
         }
         if let Some(v) = serialize_http_headers(&self.providers.nvidia_nim.http_headers) {
             out.insert("providers.nvidia_nim.http_headers".to_string(), v);
+        }
+        if let Some(v) = self.providers.moonshot.api_key.as_ref() {
+            out.insert("providers.moonshot.api_key".to_string(), redact_secret(v));
+        }
+        if let Some(v) = self.providers.moonshot.base_url.as_ref() {
+            out.insert("providers.moonshot.base_url".to_string(), v.clone());
+        }
+        if let Some(v) = self.providers.moonshot.model.as_ref() {
+            out.insert("providers.moonshot.model".to_string(), v.clone());
+        }
+        if let Some(v) = serialize_http_headers(&self.providers.moonshot.http_headers) {
+            out.insert("providers.moonshot.http_headers".to_string(), v);
         }
         if let Some(v) = self.providers.sglang.api_key.as_ref() {
             out.insert("providers.sglang.api_key".to_string(), redact_secret(v));
@@ -1980,7 +2014,7 @@ mod tests {
             api_key: Some("sk-deepseek-secret".to_string()),
             ..ConfigToml::default()
         };
-        config.providers.openrouter.api_key = Some("openrouter-secret-value".to_string());
+        config.providers.moonshot.api_key = Some("moonshot-secret-value".to_string());
         config.model = Some("deepseek-v4-pro".to_string());
 
         assert_eq!(
@@ -1989,9 +2023,9 @@ mod tests {
         );
         assert_eq!(
             config
-                .get_display_value("providers.openrouter.api_key")
+                .get_display_value("providers.moonshot.api_key")
                 .as_deref(),
-            Some("open***alue")
+            Some("moon***alue")
         );
         assert_eq!(
             config.get_display_value("model").as_deref(),
@@ -2008,10 +2042,10 @@ mod tests {
             default_text_model: Some("deepseek-v4-flash".to_string()),
             ..ConfigToml::default()
         };
-        base.providers.openrouter.api_key = Some("user-openrouter-key".to_string());
+        base.providers.moonshot.api_key = Some("user-moonshot-key".to_string());
 
         let mut project = ConfigToml {
-            provider: ProviderKind::Openrouter,
+            provider: ProviderKind::Moonshot,
             api_key: Some("attacker-key".to_string()),
             base_url: Some("https://evil.example/v1".to_string()),
             default_text_model: Some("deepseek-v4-pro".to_string()),
@@ -2019,9 +2053,9 @@ mod tests {
             telemetry: Some(true),
             ..ConfigToml::default()
         };
-        project.providers.openrouter.api_key = Some("attacker-openrouter-key".to_string());
-        project.providers.openrouter.base_url = Some("https://evil.example/openrouter".to_string());
-        project.providers.openrouter.model = Some("deepseek/deepseek-v4-pro".to_string());
+        project.providers.moonshot.api_key = Some("attacker-moonshot-key".to_string());
+        project.providers.moonshot.base_url = Some("https://evil.example/moonshot".to_string());
+        project.providers.moonshot.model = Some("kimi-k2.6".to_string());
 
         base.merge_project_overrides(project);
 
@@ -2031,14 +2065,14 @@ mod tests {
         assert_eq!(base.auth_mode, None);
         assert_eq!(base.telemetry, None);
         assert_eq!(
-            base.providers.openrouter.api_key.as_deref(),
-            Some("user-openrouter-key")
+            base.providers.moonshot.api_key.as_deref(),
+            Some("user-moonshot-key")
         );
-        assert_eq!(base.providers.openrouter.base_url, None);
+        assert_eq!(base.providers.moonshot.base_url, None);
         assert_eq!(base.default_text_model.as_deref(), Some("deepseek-v4-pro"));
         assert_eq!(
-            base.providers.openrouter.model.as_deref(),
-            Some("deepseek/deepseek-v4-pro")
+            base.providers.moonshot.model.as_deref(),
+            Some("kimi-k2.6")
         );
     }
 
@@ -2136,21 +2170,7 @@ mod tests {
     }
 
     #[test]
-    fn provider_kind_parses_openrouter_and_novita_aliases() {
-        assert_eq!(
-            ProviderKind::parse("openrouter"),
-            Some(ProviderKind::Openrouter)
-        );
-        assert_eq!(
-            ProviderKind::parse("OPEN_ROUTER"),
-            Some(ProviderKind::Openrouter)
-        );
-        assert_eq!(ProviderKind::parse("novita"), Some(ProviderKind::Novita));
-        assert_eq!(ProviderKind::parse("Novita"), Some(ProviderKind::Novita));
-        assert_eq!(
-            ProviderKind::parse("fireworks-ai"),
-            Some(ProviderKind::Fireworks)
-        );
+    fn provider_kind_parses_approved_aliases() {
         assert_eq!(ProviderKind::parse("kimi"), Some(ProviderKind::Moonshot));
         assert_eq!(
             ProviderKind::parse("moonshot-ai"),
@@ -2165,17 +2185,16 @@ mod tests {
             Some(ProviderKind::Ollama)
         );
         assert_eq!(
-            ProviderKind::parse("wanjie-ark"),
-            Some(ProviderKind::WanjieArk)
+            ProviderKind::parse("nvidia-nim"),
+            Some(ProviderKind::NvidiaNim)
         );
-        assert_eq!(
-            ProviderKind::parse("ark_wanjie"),
-            Some(ProviderKind::WanjieArk)
-        );
-
-        let parsed: ConfigToml =
-            toml::from_str("provider = \"ark-wanjie\"").expect("wanjie provider alias");
-        assert_eq!(parsed.provider, ProviderKind::WanjieArk);
+        assert_eq!(ProviderKind::parse("nim"), Some(ProviderKind::NvidiaNim));
+        assert_eq!(ProviderKind::parse("openrouter"), None);
+        assert_eq!(ProviderKind::parse("novita"), None);
+        assert_eq!(ProviderKind::parse("fireworks-ai"), None);
+        assert_eq!(ProviderKind::parse("wanjie-ark"), None);
+        assert_eq!(ProviderKind::parse("openai"), None);
+        assert_eq!(ProviderKind::parse("atlascloud"), None);
     }
 
     #[test]
@@ -2192,54 +2211,6 @@ mod tests {
                 toml::from_str(&format!("provider = \"{alias}\"")).expect("legacy provider alias");
             assert_eq!(parsed.provider, ProviderKind::Deepseek);
         }
-    }
-
-    #[test]
-    fn openrouter_provider_defaults_to_canonical_endpoint_and_model() {
-        let _lock = env_lock();
-        let _env = EnvGuard::without_deepseek_runtime_overrides();
-        let config = ConfigToml {
-            provider: ProviderKind::Openrouter,
-            ..ConfigToml::default()
-        };
-
-        let resolved = config.resolve_runtime_options(&CliRuntimeOverrides::default());
-
-        assert_eq!(resolved.provider, ProviderKind::Openrouter);
-        assert_eq!(resolved.base_url, DEFAULT_OPENROUTER_BASE_URL);
-        assert_eq!(resolved.model, DEFAULT_OPENROUTER_MODEL);
-    }
-
-    #[test]
-    fn novita_provider_defaults_to_canonical_endpoint_and_model() {
-        let _lock = env_lock();
-        let _env = EnvGuard::without_deepseek_runtime_overrides();
-        let config = ConfigToml {
-            provider: ProviderKind::Novita,
-            ..ConfigToml::default()
-        };
-
-        let resolved = config.resolve_runtime_options(&CliRuntimeOverrides::default());
-
-        assert_eq!(resolved.provider, ProviderKind::Novita);
-        assert_eq!(resolved.base_url, DEFAULT_NOVITA_BASE_URL);
-        assert_eq!(resolved.model, DEFAULT_NOVITA_MODEL);
-    }
-
-    #[test]
-    fn fireworks_provider_defaults_to_canonical_endpoint_and_model() {
-        let _lock = env_lock();
-        let _env = EnvGuard::without_deepseek_runtime_overrides();
-        let config = ConfigToml {
-            provider: ProviderKind::Fireworks,
-            ..ConfigToml::default()
-        };
-
-        let resolved = config.resolve_runtime_options(&CliRuntimeOverrides::default());
-
-        assert_eq!(resolved.provider, ProviderKind::Fireworks);
-        assert_eq!(resolved.base_url, DEFAULT_FIREWORKS_BASE_URL);
-        assert_eq!(resolved.model, DEFAULT_FIREWORKS_MODEL);
     }
 
     #[test]
@@ -2276,22 +2247,6 @@ mod tests {
         assert_eq!(resolved.model, DEFAULT_KIMI_CODE_MODEL);
         assert_eq!(resolved.api_key, None);
         assert_eq!(resolved.api_key_source, None);
-    }
-
-    #[test]
-    fn wanjie_ark_provider_defaults_to_openai_compatible_endpoint_and_model() {
-        let _lock = env_lock();
-        let _env = EnvGuard::without_deepseek_runtime_overrides();
-        let config = ConfigToml {
-            provider: ProviderKind::WanjieArk,
-            ..ConfigToml::default()
-        };
-
-        let resolved = config.resolve_runtime_options(&CliRuntimeOverrides::default());
-
-        assert_eq!(resolved.provider, ProviderKind::WanjieArk);
-        assert_eq!(resolved.base_url, DEFAULT_WANJIE_ARK_BASE_URL);
-        assert_eq!(resolved.model, DEFAULT_WANJIE_ARK_MODEL);
     }
 
     #[test]
@@ -2470,113 +2425,6 @@ mod tests {
     }
 
     #[test]
-    fn openrouter_env_api_key_falls_back_when_config_missing() {
-        let _lock = env_lock();
-        let _env = EnvGuard::without_deepseek_runtime_overrides();
-        // Safety: test-only environment mutation guarded by a module mutex.
-        unsafe {
-            env::set_var("DEEPSEEK_PROVIDER", "openrouter");
-            env::set_var("OPENROUTER_API_KEY", "or-env-key");
-        }
-
-        let resolved =
-            ConfigToml::default().resolve_runtime_options(&CliRuntimeOverrides::default());
-
-        assert_eq!(resolved.provider, ProviderKind::Openrouter);
-        assert_eq!(resolved.api_key.as_deref(), Some("or-env-key"));
-        assert_eq!(resolved.base_url, DEFAULT_OPENROUTER_BASE_URL);
-    }
-
-    #[test]
-    fn novita_env_api_key_falls_back_when_config_missing() {
-        let _lock = env_lock();
-        let _env = EnvGuard::without_deepseek_runtime_overrides();
-        // Safety: test-only environment mutation guarded by a module mutex.
-        unsafe {
-            env::set_var("DEEPSEEK_PROVIDER", "novita");
-            env::set_var("NOVITA_API_KEY", "novita-env-key");
-        }
-
-        let resolved =
-            ConfigToml::default().resolve_runtime_options(&CliRuntimeOverrides::default());
-
-        assert_eq!(resolved.provider, ProviderKind::Novita);
-        assert_eq!(resolved.api_key.as_deref(), Some("novita-env-key"));
-        assert_eq!(resolved.base_url, DEFAULT_NOVITA_BASE_URL);
-    }
-
-    #[test]
-    fn fireworks_env_api_key_falls_back_when_config_missing() {
-        let _lock = env_lock();
-        let _env = EnvGuard::without_deepseek_runtime_overrides();
-        // Safety: test-only environment mutation guarded by a module mutex.
-        unsafe {
-            env::set_var("DEEPSEEK_PROVIDER", "fireworks");
-            env::set_var("FIREWORKS_API_KEY", "fw-env-key");
-        }
-
-        let resolved =
-            ConfigToml::default().resolve_runtime_options(&CliRuntimeOverrides::default());
-
-        assert_eq!(resolved.provider, ProviderKind::Fireworks);
-        assert_eq!(resolved.api_key.as_deref(), Some("fw-env-key"));
-        assert_eq!(resolved.base_url, DEFAULT_FIREWORKS_BASE_URL);
-    }
-
-    #[test]
-    fn wanjie_ark_env_api_key_and_base_url_fall_back_when_config_missing() {
-        let _lock = env_lock();
-        let _env = EnvGuard::without_deepseek_runtime_overrides();
-        // Safety: test-only environment mutation guarded by a module mutex.
-        unsafe {
-            env::set_var("DEEPSEEK_PROVIDER", "wanjie-ark");
-            env::set_var("WANJIE_ARK_API_KEY", "wanjie-env-key");
-            env::set_var("WANJIE_ARK_BASE_URL", "https://wanjie.example/api/v1");
-            env::set_var("WANJIE_ARK_MODEL", "account-model-id");
-        }
-
-        let resolved =
-            ConfigToml::default().resolve_runtime_options(&CliRuntimeOverrides::default());
-
-        assert_eq!(resolved.provider, ProviderKind::WanjieArk);
-        assert_eq!(resolved.api_key.as_deref(), Some("wanjie-env-key"));
-        assert_eq!(resolved.base_url, "https://wanjie.example/api/v1");
-        assert_eq!(resolved.model, "account-model-id");
-    }
-
-    #[test]
-    fn openrouter_provider_normalizes_flash_aliases() {
-        let _lock = env_lock();
-        let _env = EnvGuard::without_deepseek_runtime_overrides();
-        let cli = CliRuntimeOverrides {
-            provider: Some(ProviderKind::Openrouter),
-            model: Some("deepseek-v4-flash".to_string()),
-            ..CliRuntimeOverrides::default()
-        };
-
-        let resolved = ConfigToml::default().resolve_runtime_options(&cli);
-
-        assert_eq!(resolved.provider, ProviderKind::Openrouter);
-        assert_eq!(resolved.model, DEFAULT_OPENROUTER_FLASH_MODEL);
-    }
-
-    #[test]
-    fn novita_provider_normalizes_flash_aliases() {
-        let _lock = env_lock();
-        let _env = EnvGuard::without_deepseek_runtime_overrides();
-        let cli = CliRuntimeOverrides {
-            provider: Some(ProviderKind::Novita),
-            model: Some("deepseek-v4-flash".to_string()),
-            ..CliRuntimeOverrides::default()
-        };
-
-        let resolved = ConfigToml::default().resolve_runtime_options(&cli);
-
-        assert_eq!(resolved.provider, ProviderKind::Novita);
-        assert_eq!(resolved.model, DEFAULT_NOVITA_FLASH_MODEL);
-    }
-
-    #[test]
     fn sglang_provider_normalizes_flash_aliases() {
         let _lock = env_lock();
         let _env = EnvGuard::without_deepseek_runtime_overrides();
@@ -2606,60 +2454,6 @@ mod tests {
 
         assert_eq!(resolved.provider, ProviderKind::Vllm);
         assert_eq!(resolved.model, DEFAULT_VLLM_FLASH_MODEL);
-    }
-
-    #[test]
-    fn openrouter_provider_specific_config_overrides_env() {
-        let _lock = env_lock();
-        let _env = EnvGuard::without_deepseek_runtime_overrides();
-        let mut config = ConfigToml {
-            provider: ProviderKind::Openrouter,
-            ..ConfigToml::default()
-        };
-        config.providers.openrouter.api_key = Some("file-key".to_string());
-        config.providers.openrouter.base_url = Some("https://or-mirror.example/v1".to_string());
-
-        let resolved = config.resolve_runtime_options(&CliRuntimeOverrides::default());
-
-        assert_eq!(resolved.api_key.as_deref(), Some("file-key"));
-        assert_eq!(resolved.base_url, "https://or-mirror.example/v1");
-    }
-
-    #[test]
-    fn openrouter_custom_base_url_preserves_provider_model() {
-        let _lock = env_lock();
-        let _env = EnvGuard::without_deepseek_runtime_overrides();
-        let mut config = ConfigToml {
-            provider: ProviderKind::Openrouter,
-            ..ConfigToml::default()
-        };
-        config.providers.openrouter.base_url = Some("https://gateway.example.com/v1".to_string());
-        config.providers.openrouter.model = Some("DeepSeek-V4-Pro".to_string());
-
-        let resolved = config.resolve_runtime_options(&CliRuntimeOverrides::default());
-
-        assert_eq!(resolved.provider, ProviderKind::Openrouter);
-        assert_eq!(resolved.base_url, "https://gateway.example.com/v1");
-        assert_eq!(resolved.model, "DeepSeek-V4-Pro");
-    }
-
-    #[test]
-    fn fireworks_custom_base_url_preserves_provider_model() {
-        let _lock = env_lock();
-        let _env = EnvGuard::without_deepseek_runtime_overrides();
-        let mut config = ConfigToml {
-            provider: ProviderKind::Fireworks,
-            ..ConfigToml::default()
-        };
-        config.providers.fireworks.base_url = Some("https://my-gateway.example/v1".to_string());
-        config.providers.fireworks.model = Some("DeepSeek-V4-Pro".to_string());
-
-        let resolved = config.resolve_runtime_options(&CliRuntimeOverrides::default());
-
-        assert_eq!(resolved.provider, ProviderKind::Fireworks);
-        assert_eq!(resolved.base_url, "https://my-gateway.example/v1");
-        // Custom base URL skips provider-specific model prefixing.
-        assert_eq!(resolved.model, "DeepSeek-V4-Pro");
     }
 
     #[test]

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -2070,10 +2070,7 @@ mod tests {
         );
         assert_eq!(base.providers.moonshot.base_url, None);
         assert_eq!(base.default_text_model.as_deref(), Some("deepseek-v4-pro"));
-        assert_eq!(
-            base.providers.moonshot.model.as_deref(),
-            Some("kimi-k2.6")
-        );
+        assert_eq!(base.providers.moonshot.model.as_deref(), Some("kimi-k2.6"));
     }
 
     #[test]

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -17,28 +17,14 @@ pub const CONFIG_FILE_NAME: &str = "config.toml";
 const DEFAULT_DEEPSEEK_MODEL: &str = "deepseek-v4-pro";
 const DEFAULT_NVIDIA_NIM_MODEL: &str = "deepseek-ai/deepseek-v4-pro";
 const DEFAULT_NVIDIA_NIM_FLASH_MODEL: &str = "deepseek-ai/deepseek-v4-flash";
-const DEFAULT_OPENAI_MODEL: &str = "deepseek-v4-pro";
 const DEFAULT_DEEPSEEK_BASE_URL: &str = "https://api.deepseek.com/beta";
 const DEFAULT_NVIDIA_NIM_BASE_URL: &str = "https://integrate.api.nvidia.com/v1";
-const DEFAULT_OPENAI_BASE_URL: &str = "https://api.openai.com/v1";
-const DEFAULT_ATLASCLOUD_MODEL: &str = "deepseek-ai/deepseek-v4-flash";
-const DEFAULT_ATLASCLOUD_BASE_URL: &str = "https://api.atlascloud.ai/v1";
-const DEFAULT_WANJIE_ARK_MODEL: &str = "deepseek-reasoner";
-const DEFAULT_WANJIE_ARK_BASE_URL: &str = "https://maas-openapi.wanjiedata.com/api/v1";
-const DEFAULT_OPENROUTER_MODEL: &str = "deepseek/deepseek-v4-pro";
-const DEFAULT_OPENROUTER_FLASH_MODEL: &str = "deepseek/deepseek-v4-flash";
-const DEFAULT_NOVITA_MODEL: &str = "deepseek/deepseek-v4-pro";
-const DEFAULT_NOVITA_FLASH_MODEL: &str = "deepseek/deepseek-v4-flash";
-const DEFAULT_FIREWORKS_MODEL: &str = "accounts/fireworks/models/deepseek-v4-pro";
 const DEFAULT_MOONSHOT_MODEL: &str = "kimi-k2.6";
 const DEFAULT_MOONSHOT_BASE_URL: &str = "https://api.moonshot.ai/v1";
 const DEFAULT_KIMI_CODE_MODEL: &str = "kimi-for-coding";
 const DEFAULT_KIMI_CODE_BASE_URL: &str = "https://api.kimi.com/coding/v1";
 const DEFAULT_SGLANG_MODEL: &str = "deepseek-ai/DeepSeek-V4-Pro";
 const DEFAULT_SGLANG_FLASH_MODEL: &str = "deepseek-ai/DeepSeek-V4-Flash";
-const DEFAULT_OPENROUTER_BASE_URL: &str = "https://openrouter.ai/api/v1";
-const DEFAULT_NOVITA_BASE_URL: &str = "https://api.novita.ai/v1";
-const DEFAULT_FIREWORKS_BASE_URL: &str = "https://api.fireworks.ai/inference/v1";
 const DEFAULT_SGLANG_BASE_URL: &str = "http://localhost:30000/v1";
 const DEFAULT_VLLM_MODEL: &str = "deepseek-ai/DeepSeek-V4-Pro";
 const DEFAULT_VLLM_FLASH_MODEL: &str = "deepseek-ai/DeepSeek-V4-Flash";
@@ -58,21 +44,6 @@ pub enum ProviderKind {
     )]
     Deepseek,
     NvidiaNim,
-    #[serde(alias = "open-ai")]
-    Openai,
-    Atlascloud,
-    #[serde(
-        alias = "wanjie",
-        alias = "wanjie_ark",
-        alias = "ark-wanjie",
-        alias = "ark_wanjie",
-        alias = "wanjie-maas",
-        alias = "wanjie_maas"
-    )]
-    WanjieArk,
-    Openrouter,
-    Novita,
-    Fireworks,
     Moonshot,
     Sglang,
     Vllm,
@@ -85,12 +56,6 @@ impl ProviderKind {
         match self {
             Self::Deepseek => "deepseek",
             Self::NvidiaNim => "nvidia-nim",
-            Self::Openai => "openai",
-            Self::Atlascloud => "atlascloud",
-            Self::WanjieArk => "wanjie-ark",
-            Self::Openrouter => "openrouter",
-            Self::Novita => "novita",
-            Self::Fireworks => "fireworks",
             Self::Moonshot => "moonshot",
             Self::Sglang => "sglang",
             Self::Vllm => "vllm",
@@ -104,13 +69,6 @@ impl ProviderKind {
             "deepseek" | "deep-seek" | "deepseek-cn" | "deepseek_china" | "deepseekcn"
             | "deepseek-china" => Some(Self::Deepseek),
             "nvidia" | "nvidia-nim" | "nvidia_nim" | "nim" => Some(Self::NvidiaNim),
-            "openai" | "open-ai" => Some(Self::Openai),
-            "atlascloud" | "atlas-cloud" | "atlas_cloud" | "atlas" => Some(Self::Atlascloud),
-            "wanjie" | "wanjie-ark" | "wanjie_ark" | "ark-wanjie" | "ark_wanjie" | "wanjieark"
-            | "wanjie-maas" | "wanjie_maas" | "wanjiemaas" => Some(Self::WanjieArk),
-            "openrouter" | "open_router" => Some(Self::Openrouter),
-            "novita" => Some(Self::Novita),
-            "fireworks" | "fireworks-ai" => Some(Self::Fireworks),
             "moonshot" | "moonshot-ai" | "kimi" | "kimi-k2" => Some(Self::Moonshot),
             "sglang" | "sg-lang" => Some(Self::Sglang),
             "vllm" | "v-llm" => Some(Self::Vllm),
@@ -137,18 +95,6 @@ pub struct ProvidersToml {
     #[serde(default)]
     pub nvidia_nim: ProviderConfigToml,
     #[serde(default)]
-    pub openai: ProviderConfigToml,
-    #[serde(default)]
-    pub atlascloud: ProviderConfigToml,
-    #[serde(default)]
-    pub wanjie_ark: ProviderConfigToml,
-    #[serde(default)]
-    pub openrouter: ProviderConfigToml,
-    #[serde(default)]
-    pub novita: ProviderConfigToml,
-    #[serde(default)]
-    pub fireworks: ProviderConfigToml,
-    #[serde(default)]
     pub moonshot: ProviderConfigToml,
     #[serde(default)]
     pub sglang: ProviderConfigToml,
@@ -164,12 +110,6 @@ impl ProvidersToml {
         match provider {
             ProviderKind::Deepseek => &self.deepseek,
             ProviderKind::NvidiaNim => &self.nvidia_nim,
-            ProviderKind::Openai => &self.openai,
-            ProviderKind::Atlascloud => &self.atlascloud,
-            ProviderKind::WanjieArk => &self.wanjie_ark,
-            ProviderKind::Openrouter => &self.openrouter,
-            ProviderKind::Novita => &self.novita,
-            ProviderKind::Fireworks => &self.fireworks,
             ProviderKind::Moonshot => &self.moonshot,
             ProviderKind::Sglang => &self.sglang,
             ProviderKind::Vllm => &self.vllm,
@@ -181,12 +121,6 @@ impl ProvidersToml {
         match provider {
             ProviderKind::Deepseek => &mut self.deepseek,
             ProviderKind::NvidiaNim => &mut self.nvidia_nim,
-            ProviderKind::Openai => &mut self.openai,
-            ProviderKind::Atlascloud => &mut self.atlascloud,
-            ProviderKind::WanjieArk => &mut self.wanjie_ark,
-            ProviderKind::Openrouter => &mut self.openrouter,
-            ProviderKind::Novita => &mut self.novita,
-            ProviderKind::Fireworks => &mut self.fireworks,
             ProviderKind::Moonshot => &mut self.moonshot,
             ProviderKind::Sglang => &mut self.sglang,
             ProviderKind::Vllm => &mut self.vllm,
@@ -379,21 +313,7 @@ impl ConfigToml {
             &mut self.providers.nvidia_nim,
             &project.providers.nvidia_nim,
         );
-        merge_project_provider_config(&mut self.providers.openai, &project.providers.openai);
-        merge_project_provider_config(
-            &mut self.providers.atlascloud,
-            &project.providers.atlascloud,
-        );
-        merge_project_provider_config(
-            &mut self.providers.wanjie_ark,
-            &project.providers.wanjie_ark,
-        );
-        merge_project_provider_config(
-            &mut self.providers.openrouter,
-            &project.providers.openrouter,
-        );
-        merge_project_provider_config(&mut self.providers.novita, &project.providers.novita);
-        merge_project_provider_config(&mut self.providers.fireworks, &project.providers.fireworks);
+        merge_project_provider_config(&mut self.providers.moonshot, &project.providers.moonshot);
         merge_project_provider_config(&mut self.providers.sglang, &project.providers.sglang);
         merge_project_provider_config(&mut self.providers.vllm, &project.providers.vllm);
         merge_project_provider_config(&mut self.providers.ollama, &project.providers.ollama);
@@ -425,42 +345,6 @@ impl ConfigToml {
             "providers.nvidia_nim.model" => self.providers.nvidia_nim.model.clone(),
             "providers.nvidia_nim.http_headers" => {
                 serialize_http_headers(&self.providers.nvidia_nim.http_headers)
-            }
-            "providers.openai.api_key" => self.providers.openai.api_key.clone(),
-            "providers.openai.base_url" => self.providers.openai.base_url.clone(),
-            "providers.openai.model" => self.providers.openai.model.clone(),
-            "providers.openai.http_headers" => {
-                serialize_http_headers(&self.providers.openai.http_headers)
-            }
-            "providers.atlascloud.api_key" => self.providers.atlascloud.api_key.clone(),
-            "providers.atlascloud.base_url" => self.providers.atlascloud.base_url.clone(),
-            "providers.atlascloud.model" => self.providers.atlascloud.model.clone(),
-            "providers.atlascloud.http_headers" => {
-                serialize_http_headers(&self.providers.atlascloud.http_headers)
-            }
-            "providers.wanjie_ark.api_key" => self.providers.wanjie_ark.api_key.clone(),
-            "providers.wanjie_ark.base_url" => self.providers.wanjie_ark.base_url.clone(),
-            "providers.wanjie_ark.model" => self.providers.wanjie_ark.model.clone(),
-            "providers.wanjie_ark.http_headers" => {
-                serialize_http_headers(&self.providers.wanjie_ark.http_headers)
-            }
-            "providers.openrouter.api_key" => self.providers.openrouter.api_key.clone(),
-            "providers.openrouter.base_url" => self.providers.openrouter.base_url.clone(),
-            "providers.openrouter.model" => self.providers.openrouter.model.clone(),
-            "providers.openrouter.http_headers" => {
-                serialize_http_headers(&self.providers.openrouter.http_headers)
-            }
-            "providers.novita.api_key" => self.providers.novita.api_key.clone(),
-            "providers.novita.base_url" => self.providers.novita.base_url.clone(),
-            "providers.novita.model" => self.providers.novita.model.clone(),
-            "providers.novita.http_headers" => {
-                serialize_http_headers(&self.providers.novita.http_headers)
-            }
-            "providers.fireworks.api_key" => self.providers.fireworks.api_key.clone(),
-            "providers.fireworks.base_url" => self.providers.fireworks.base_url.clone(),
-            "providers.fireworks.model" => self.providers.fireworks.model.clone(),
-            "providers.fireworks.http_headers" => {
-                serialize_http_headers(&self.providers.fireworks.http_headers)
             }
             "providers.sglang.api_key" => self.providers.sglang.api_key.clone(),
             "providers.sglang.base_url" => self.providers.sglang.base_url.clone(),
@@ -534,36 +418,6 @@ impl ConfigToml {
                 self.providers.deepseek.http_headers = headers.clone();
                 self.http_headers = headers;
             }
-            "providers.openai.api_key" => self.providers.openai.api_key = Some(value.to_string()),
-            "providers.openai.base_url" => self.providers.openai.base_url = Some(value.to_string()),
-            "providers.openai.model" => self.providers.openai.model = Some(value.to_string()),
-            "providers.openai.http_headers" => {
-                self.providers.openai.http_headers = parse_http_headers(value)?;
-            }
-            "providers.atlascloud.api_key" => {
-                self.providers.atlascloud.api_key = Some(value.to_string());
-            }
-            "providers.atlascloud.base_url" => {
-                self.providers.atlascloud.base_url = Some(value.to_string());
-            }
-            "providers.atlascloud.model" => {
-                self.providers.atlascloud.model = Some(value.to_string());
-            }
-            "providers.atlascloud.http_headers" => {
-                self.providers.atlascloud.http_headers = parse_http_headers(value)?;
-            }
-            "providers.wanjie_ark.api_key" => {
-                self.providers.wanjie_ark.api_key = Some(value.to_string());
-            }
-            "providers.wanjie_ark.base_url" => {
-                self.providers.wanjie_ark.base_url = Some(value.to_string());
-            }
-            "providers.wanjie_ark.model" => {
-                self.providers.wanjie_ark.model = Some(value.to_string());
-            }
-            "providers.wanjie_ark.http_headers" => {
-                self.providers.wanjie_ark.http_headers = parse_http_headers(value)?;
-            }
             "providers.nvidia_nim.api_key" => {
                 self.providers.nvidia_nim.api_key = Some(value.to_string());
             }
@@ -575,42 +429,6 @@ impl ConfigToml {
             }
             "providers.nvidia_nim.http_headers" => {
                 self.providers.nvidia_nim.http_headers = parse_http_headers(value)?;
-            }
-            "providers.openrouter.api_key" => {
-                self.providers.openrouter.api_key = Some(value.to_string());
-            }
-            "providers.openrouter.base_url" => {
-                self.providers.openrouter.base_url = Some(value.to_string());
-            }
-            "providers.openrouter.model" => {
-                self.providers.openrouter.model = Some(value.to_string());
-            }
-            "providers.openrouter.http_headers" => {
-                self.providers.openrouter.http_headers = parse_http_headers(value)?;
-            }
-            "providers.novita.api_key" => {
-                self.providers.novita.api_key = Some(value.to_string());
-            }
-            "providers.novita.base_url" => {
-                self.providers.novita.base_url = Some(value.to_string());
-            }
-            "providers.novita.model" => {
-                self.providers.novita.model = Some(value.to_string());
-            }
-            "providers.novita.http_headers" => {
-                self.providers.novita.http_headers = parse_http_headers(value)?;
-            }
-            "providers.fireworks.api_key" => {
-                self.providers.fireworks.api_key = Some(value.to_string());
-            }
-            "providers.fireworks.base_url" => {
-                self.providers.fireworks.base_url = Some(value.to_string());
-            }
-            "providers.fireworks.model" => {
-                self.providers.fireworks.model = Some(value.to_string());
-            }
-            "providers.fireworks.http_headers" => {
-                self.providers.fireworks.http_headers = parse_http_headers(value)?;
             }
             "providers.sglang.api_key" => {
                 self.providers.sglang.api_key = Some(value.to_string());
@@ -686,36 +504,10 @@ impl ConfigToml {
                 self.providers.deepseek.http_headers.clear();
                 self.http_headers.clear();
             }
-            "providers.openai.api_key" => self.providers.openai.api_key = None,
-            "providers.openai.base_url" => self.providers.openai.base_url = None,
-            "providers.openai.model" => self.providers.openai.model = None,
-            "providers.openai.http_headers" => self.providers.openai.http_headers.clear(),
-            "providers.atlascloud.api_key" => self.providers.atlascloud.api_key = None,
-            "providers.atlascloud.base_url" => self.providers.atlascloud.base_url = None,
-            "providers.atlascloud.model" => self.providers.atlascloud.model = None,
-            "providers.atlascloud.http_headers" => self.providers.atlascloud.http_headers.clear(),
-            "providers.wanjie_ark.api_key" => self.providers.wanjie_ark.api_key = None,
-            "providers.wanjie_ark.base_url" => self.providers.wanjie_ark.base_url = None,
-            "providers.wanjie_ark.model" => self.providers.wanjie_ark.model = None,
-            "providers.wanjie_ark.http_headers" => {
-                self.providers.wanjie_ark.http_headers.clear();
-            }
             "providers.nvidia_nim.api_key" => self.providers.nvidia_nim.api_key = None,
             "providers.nvidia_nim.base_url" => self.providers.nvidia_nim.base_url = None,
             "providers.nvidia_nim.model" => self.providers.nvidia_nim.model = None,
             "providers.nvidia_nim.http_headers" => self.providers.nvidia_nim.http_headers.clear(),
-            "providers.openrouter.api_key" => self.providers.openrouter.api_key = None,
-            "providers.openrouter.base_url" => self.providers.openrouter.base_url = None,
-            "providers.openrouter.model" => self.providers.openrouter.model = None,
-            "providers.openrouter.http_headers" => self.providers.openrouter.http_headers.clear(),
-            "providers.novita.api_key" => self.providers.novita.api_key = None,
-            "providers.novita.base_url" => self.providers.novita.base_url = None,
-            "providers.novita.model" => self.providers.novita.model = None,
-            "providers.novita.http_headers" => self.providers.novita.http_headers.clear(),
-            "providers.fireworks.api_key" => self.providers.fireworks.api_key = None,
-            "providers.fireworks.base_url" => self.providers.fireworks.base_url = None,
-            "providers.fireworks.model" => self.providers.fireworks.model = None,
-            "providers.fireworks.http_headers" => self.providers.fireworks.http_headers.clear(),
             "providers.sglang.api_key" => self.providers.sglang.api_key = None,
             "providers.sglang.base_url" => self.providers.sglang.base_url = None,
             "providers.sglang.model" => self.providers.sglang.model = None,
@@ -785,42 +577,6 @@ impl ConfigToml {
         if let Some(v) = serialize_http_headers(&self.providers.deepseek.http_headers) {
             out.insert("providers.deepseek.http_headers".to_string(), v);
         }
-        if let Some(v) = self.providers.openai.api_key.as_ref() {
-            out.insert("providers.openai.api_key".to_string(), redact_secret(v));
-        }
-        if let Some(v) = self.providers.openai.base_url.as_ref() {
-            out.insert("providers.openai.base_url".to_string(), v.clone());
-        }
-        if let Some(v) = self.providers.openai.model.as_ref() {
-            out.insert("providers.openai.model".to_string(), v.clone());
-        }
-        if let Some(v) = serialize_http_headers(&self.providers.openai.http_headers) {
-            out.insert("providers.openai.http_headers".to_string(), v);
-        }
-        if let Some(v) = self.providers.atlascloud.api_key.as_ref() {
-            out.insert("providers.atlascloud.api_key".to_string(), redact_secret(v));
-        }
-        if let Some(v) = self.providers.atlascloud.base_url.as_ref() {
-            out.insert("providers.atlascloud.base_url".to_string(), v.clone());
-        }
-        if let Some(v) = self.providers.atlascloud.model.as_ref() {
-            out.insert("providers.atlascloud.model".to_string(), v.clone());
-        }
-        if let Some(v) = serialize_http_headers(&self.providers.atlascloud.http_headers) {
-            out.insert("providers.atlascloud.http_headers".to_string(), v);
-        }
-        if let Some(v) = self.providers.wanjie_ark.api_key.as_ref() {
-            out.insert("providers.wanjie_ark.api_key".to_string(), redact_secret(v));
-        }
-        if let Some(v) = self.providers.wanjie_ark.base_url.as_ref() {
-            out.insert("providers.wanjie_ark.base_url".to_string(), v.clone());
-        }
-        if let Some(v) = self.providers.wanjie_ark.model.as_ref() {
-            out.insert("providers.wanjie_ark.model".to_string(), v.clone());
-        }
-        if let Some(v) = serialize_http_headers(&self.providers.wanjie_ark.http_headers) {
-            out.insert("providers.wanjie_ark.http_headers".to_string(), v);
-        }
         if let Some(v) = self.providers.nvidia_nim.api_key.as_ref() {
             out.insert("providers.nvidia_nim.api_key".to_string(), redact_secret(v));
         }
@@ -832,42 +588,6 @@ impl ConfigToml {
         }
         if let Some(v) = serialize_http_headers(&self.providers.nvidia_nim.http_headers) {
             out.insert("providers.nvidia_nim.http_headers".to_string(), v);
-        }
-        if let Some(v) = self.providers.openrouter.api_key.as_ref() {
-            out.insert("providers.openrouter.api_key".to_string(), redact_secret(v));
-        }
-        if let Some(v) = self.providers.openrouter.base_url.as_ref() {
-            out.insert("providers.openrouter.base_url".to_string(), v.clone());
-        }
-        if let Some(v) = self.providers.openrouter.model.as_ref() {
-            out.insert("providers.openrouter.model".to_string(), v.clone());
-        }
-        if let Some(v) = serialize_http_headers(&self.providers.openrouter.http_headers) {
-            out.insert("providers.openrouter.http_headers".to_string(), v);
-        }
-        if let Some(v) = self.providers.novita.api_key.as_ref() {
-            out.insert("providers.novita.api_key".to_string(), redact_secret(v));
-        }
-        if let Some(v) = self.providers.novita.base_url.as_ref() {
-            out.insert("providers.novita.base_url".to_string(), v.clone());
-        }
-        if let Some(v) = self.providers.novita.model.as_ref() {
-            out.insert("providers.novita.model".to_string(), v.clone());
-        }
-        if let Some(v) = serialize_http_headers(&self.providers.novita.http_headers) {
-            out.insert("providers.novita.http_headers".to_string(), v);
-        }
-        if let Some(v) = self.providers.fireworks.api_key.as_ref() {
-            out.insert("providers.fireworks.api_key".to_string(), redact_secret(v));
-        }
-        if let Some(v) = self.providers.fireworks.base_url.as_ref() {
-            out.insert("providers.fireworks.base_url".to_string(), v.clone());
-        }
-        if let Some(v) = self.providers.fireworks.model.as_ref() {
-            out.insert("providers.fireworks.model".to_string(), v.clone());
-        }
-        if let Some(v) = serialize_http_headers(&self.providers.fireworks.http_headers) {
-            out.insert("providers.fireworks.http_headers".to_string(), v);
         }
         if let Some(v) = self.providers.sglang.api_key.as_ref() {
             out.insert("providers.sglang.api_key".to_string(), redact_secret(v));
@@ -963,12 +683,6 @@ impl ConfigToml {
             .unwrap_or_else(|| match provider {
                 ProviderKind::Deepseek => DEFAULT_DEEPSEEK_BASE_URL.to_string(),
                 ProviderKind::NvidiaNim => DEFAULT_NVIDIA_NIM_BASE_URL.to_string(),
-                ProviderKind::Openai => DEFAULT_OPENAI_BASE_URL.to_string(),
-                ProviderKind::Atlascloud => DEFAULT_ATLASCLOUD_BASE_URL.to_string(),
-                ProviderKind::WanjieArk => DEFAULT_WANJIE_ARK_BASE_URL.to_string(),
-                ProviderKind::Openrouter => DEFAULT_OPENROUTER_BASE_URL.to_string(),
-                ProviderKind::Novita => DEFAULT_NOVITA_BASE_URL.to_string(),
-                ProviderKind::Fireworks => DEFAULT_FIREWORKS_BASE_URL.to_string(),
                 ProviderKind::Moonshot => {
                     if auth_mode.as_deref().is_some_and(auth_mode_uses_kimi_oauth) {
                         DEFAULT_KIMI_CODE_BASE_URL.to_string()
@@ -1166,10 +880,7 @@ pub fn load_project_config(workspace: &Path) -> Option<ConfigToml> {
 }
 
 fn normalize_model_for_provider(provider: ProviderKind, model: &str) -> String {
-    if matches!(
-        provider,
-        ProviderKind::Atlascloud | ProviderKind::WanjieArk | ProviderKind::Ollama
-    ) {
+    if matches!(provider, ProviderKind::Ollama) {
         return model.to_string();
     }
 
@@ -1183,25 +894,6 @@ fn normalize_model_for_provider(provider: ProviderKind, model: &str) -> String {
             "deepseek-v4-flash" | "deepseek-v4flash" | "deepseek-chat" | "deepseek-reasoner"
             | "deepseek-r1" | "deepseek-v3" | "deepseek-v3.2",
         ) => DEFAULT_NVIDIA_NIM_FLASH_MODEL.to_string(),
-        (ProviderKind::Openrouter, "deepseek-v4-pro" | "deepseek-v4pro") => {
-            DEFAULT_OPENROUTER_MODEL.to_string()
-        }
-        (
-            ProviderKind::Openrouter,
-            "deepseek-v4-flash" | "deepseek-v4flash" | "deepseek-chat" | "deepseek-reasoner"
-            | "deepseek-r1" | "deepseek-v3" | "deepseek-v3.2",
-        ) => DEFAULT_OPENROUTER_FLASH_MODEL.to_string(),
-        (ProviderKind::Novita, "deepseek-v4-pro" | "deepseek-v4pro") => {
-            DEFAULT_NOVITA_MODEL.to_string()
-        }
-        (
-            ProviderKind::Novita,
-            "deepseek-v4-flash" | "deepseek-v4flash" | "deepseek-chat" | "deepseek-reasoner"
-            | "deepseek-r1" | "deepseek-v3" | "deepseek-v3.2",
-        ) => DEFAULT_NOVITA_FLASH_MODEL.to_string(),
-        (ProviderKind::Fireworks, "deepseek-v4-pro" | "deepseek-v4pro") => {
-            DEFAULT_FIREWORKS_MODEL.to_string()
-        }
         (ProviderKind::Moonshot, "kimi-k2.6" | "kimi-k2") => DEFAULT_MOONSHOT_MODEL.to_string(),
         (ProviderKind::Sglang, "deepseek-v4-pro" | "deepseek-v4pro") => {
             DEFAULT_SGLANG_MODEL.to_string()
@@ -1227,12 +919,6 @@ fn default_model_for_provider(provider: ProviderKind) -> &'static str {
     match provider {
         ProviderKind::Deepseek => DEFAULT_DEEPSEEK_MODEL,
         ProviderKind::NvidiaNim => DEFAULT_NVIDIA_NIM_MODEL,
-        ProviderKind::Openai => DEFAULT_OPENAI_MODEL,
-        ProviderKind::Atlascloud => DEFAULT_ATLASCLOUD_MODEL,
-        ProviderKind::WanjieArk => DEFAULT_WANJIE_ARK_MODEL,
-        ProviderKind::Openrouter => DEFAULT_OPENROUTER_MODEL,
-        ProviderKind::Novita => DEFAULT_NOVITA_MODEL,
-        ProviderKind::Fireworks => DEFAULT_FIREWORKS_MODEL,
         ProviderKind::Moonshot => DEFAULT_MOONSHOT_MODEL,
         ProviderKind::Sglang => DEFAULT_SGLANG_MODEL,
         ProviderKind::Vllm => DEFAULT_VLLM_MODEL,
@@ -1244,12 +930,6 @@ fn default_base_url_for_provider(provider: ProviderKind) -> &'static str {
     match provider {
         ProviderKind::Deepseek => DEFAULT_DEEPSEEK_BASE_URL,
         ProviderKind::NvidiaNim => DEFAULT_NVIDIA_NIM_BASE_URL,
-        ProviderKind::Openai => DEFAULT_OPENAI_BASE_URL,
-        ProviderKind::Atlascloud => DEFAULT_ATLASCLOUD_BASE_URL,
-        ProviderKind::WanjieArk => DEFAULT_WANJIE_ARK_BASE_URL,
-        ProviderKind::Openrouter => DEFAULT_OPENROUTER_BASE_URL,
-        ProviderKind::Novita => DEFAULT_NOVITA_BASE_URL,
-        ProviderKind::Fireworks => DEFAULT_FIREWORKS_BASE_URL,
         ProviderKind::Moonshot => DEFAULT_MOONSHOT_BASE_URL,
         ProviderKind::Sglang => DEFAULT_SGLANG_BASE_URL,
         ProviderKind::Vllm => DEFAULT_VLLM_BASE_URL,
@@ -1710,7 +1390,6 @@ fn normalize_config_file_path(path: PathBuf) -> Result<PathBuf> {
 struct EnvRuntimeOverrides {
     provider: Option<ProviderKind>,
     model: Option<String>,
-    wanjie_ark_model: Option<String>,
     moonshot_model: Option<String>,
     output_mode: Option<String>,
     auth_mode: Option<String>,
@@ -1722,12 +1401,6 @@ struct EnvRuntimeOverrides {
     http_headers: Option<BTreeMap<String, String>>,
     deepseek_base_url: Option<String>,
     nvidia_base_url: Option<String>,
-    openai_base_url: Option<String>,
-    atlascloud_base_url: Option<String>,
-    wanjie_ark_base_url: Option<String>,
-    openrouter_base_url: Option<String>,
-    novita_base_url: Option<String>,
-    fireworks_base_url: Option<String>,
     moonshot_base_url: Option<String>,
     sglang_base_url: Option<String>,
     vllm_base_url: Option<String>,
@@ -1741,11 +1414,6 @@ impl EnvRuntimeOverrides {
                 .ok()
                 .and_then(|v| ProviderKind::parse(&v)),
             model: std::env::var("DEEPSEEK_MODEL").ok(),
-            wanjie_ark_model: std::env::var("WANJIE_ARK_MODEL")
-                .or_else(|_| std::env::var("WANJIE_MODEL"))
-                .or_else(|_| std::env::var("WANJIE_MAAS_MODEL"))
-                .ok()
-                .filter(|v| !v.trim().is_empty()),
             moonshot_model: std::env::var("MOONSHOT_MODEL")
                 .or_else(|_| std::env::var("KIMI_MODEL_NAME"))
                 .or_else(|_| std::env::var("KIMI_MODEL"))
@@ -1774,26 +1442,6 @@ impl EnvRuntimeOverrides {
                 .or_else(|_| std::env::var("NVIDIA_BASE_URL"))
                 .ok()
                 .filter(|v| !v.trim().is_empty()),
-            openai_base_url: std::env::var("OPENAI_BASE_URL")
-                .ok()
-                .filter(|v| !v.trim().is_empty()),
-            atlascloud_base_url: std::env::var("ATLASCLOUD_BASE_URL")
-                .ok()
-                .filter(|v| !v.trim().is_empty()),
-            wanjie_ark_base_url: std::env::var("WANJIE_ARK_BASE_URL")
-                .or_else(|_| std::env::var("WANJIE_BASE_URL"))
-                .or_else(|_| std::env::var("WANJIE_MAAS_BASE_URL"))
-                .ok()
-                .filter(|v| !v.trim().is_empty()),
-            openrouter_base_url: std::env::var("OPENROUTER_BASE_URL")
-                .ok()
-                .filter(|v| !v.trim().is_empty()),
-            novita_base_url: std::env::var("NOVITA_BASE_URL")
-                .ok()
-                .filter(|v| !v.trim().is_empty()),
-            fireworks_base_url: std::env::var("FIREWORKS_BASE_URL")
-                .ok()
-                .filter(|v| !v.trim().is_empty()),
             moonshot_base_url: std::env::var("MOONSHOT_BASE_URL")
                 .or_else(|_| std::env::var("KIMI_BASE_URL"))
                 .ok()
@@ -1816,12 +1464,6 @@ impl EnvRuntimeOverrides {
         match provider {
             ProviderKind::Deepseek => self.deepseek_base_url.clone(),
             ProviderKind::NvidiaNim => self.nvidia_base_url.clone(),
-            ProviderKind::Openai => self.openai_base_url.clone(),
-            ProviderKind::Atlascloud => self.atlascloud_base_url.clone(),
-            ProviderKind::WanjieArk => self.wanjie_ark_base_url.clone(),
-            ProviderKind::Openrouter => self.openrouter_base_url.clone(),
-            ProviderKind::Novita => self.novita_base_url.clone(),
-            ProviderKind::Fireworks => self.fireworks_base_url.clone(),
             ProviderKind::Moonshot => self.moonshot_base_url.clone(),
             ProviderKind::Sglang => self.sglang_base_url.clone(),
             ProviderKind::Vllm => self.vllm_base_url.clone(),
@@ -1831,7 +1473,6 @@ impl EnvRuntimeOverrides {
 
     fn model_for(&self, provider: ProviderKind) -> Option<String> {
         match provider {
-            ProviderKind::WanjieArk => self.wanjie_ark_model.clone(),
             ProviderKind::Moonshot => self.moonshot_model.clone(),
             _ => None,
         }

--- a/crates/secrets/src/lib.rs
+++ b/crates/secrets/src/lib.rs
@@ -526,27 +526,16 @@ impl Secrets {
 pub fn env_for(name: &str) -> Option<String> {
     let candidates: &[&str] = match name.to_ascii_lowercase().as_str() {
         "deepseek" => &["DEEPSEEK_API_KEY"],
-        "openrouter" => &["OPENROUTER_API_KEY"],
-        "novita" => &["NOVITA_API_KEY"],
         // NVIDIA NIM falls back to `DEEPSEEK_API_KEY` last because the
         // catalog endpoint accepts the same DeepSeek-issued key when no
         // dedicated NVIDIA token is set. This mirrors pre-v0.7 behaviour.
         "nvidia" | "nvidia-nim" | "nvidia_nim" | "nim" => {
             &["NVIDIA_API_KEY", "NVIDIA_NIM_API_KEY", "DEEPSEEK_API_KEY"]
         }
-        "fireworks" | "fireworks-ai" => &["FIREWORKS_API_KEY"],
         "moonshot" | "moonshot-ai" | "kimi" | "kimi-k2" => &["MOONSHOT_API_KEY", "KIMI_API_KEY"],
         "sglang" | "sg-lang" => &["SGLANG_API_KEY"],
         "vllm" | "v-llm" => &["VLLM_API_KEY"],
         "ollama" | "ollama-local" => &["OLLAMA_API_KEY"],
-        "openai" => &["OPENAI_API_KEY"],
-        "atlascloud" | "atlas-cloud" | "atlas_cloud" | "atlas" => &["ATLASCLOUD_API_KEY"],
-        "wanjie" | "wanjie-ark" | "wanjie_ark" | "ark-wanjie" | "ark_wanjie" | "wanjieark"
-        | "wanjie-maas" | "wanjie_maas" | "wanjiemaas" => &[
-            "WANJIE_ARK_API_KEY",
-            "WANJIE_API_KEY",
-            "WANJIE_MAAS_API_KEY",
-        ],
         _ => return None,
     };
     for var in candidates {
@@ -576,19 +565,13 @@ mod tests {
     fn clear_known_envs() {
         for var in [
             "DEEPSEEK_API_KEY",
-            "OPENROUTER_API_KEY",
-            "NOVITA_API_KEY",
             "NVIDIA_API_KEY",
             "NVIDIA_NIM_API_KEY",
-            "FIREWORKS_API_KEY",
+            "MOONSHOT_API_KEY",
+            "KIMI_API_KEY",
             "SGLANG_API_KEY",
             "VLLM_API_KEY",
             "OLLAMA_API_KEY",
-            "OPENAI_API_KEY",
-            "ATLASCLOUD_API_KEY",
-            "WANJIE_ARK_API_KEY",
-            "WANJIE_API_KEY",
-            "WANJIE_MAAS_API_KEY",
             SECRET_BACKEND_ENV,
         ] {
             // Safety: tests serialise on env_lock(); the broader
@@ -741,42 +724,30 @@ mod tests {
     }
 
     #[test]
-    fn atlascloud_env_aliases_resolve() {
+    fn moonshot_env_aliases_resolve() {
         let _guard = env_lock();
         clear_known_envs();
-        unsafe { std::env::set_var("ATLASCLOUD_API_KEY", "atlas-key") };
+        // Safety: env mutation guarded by env_lock().
+        unsafe { std::env::set_var("MOONSHOT_API_KEY", "kimi-key") };
 
-        assert_eq!(env_for("atlascloud").as_deref(), Some("atlas-key"));
-        assert_eq!(env_for("atlas").as_deref(), Some("atlas-key"));
-        assert_eq!(env_for("atlas-cloud").as_deref(), Some("atlas-key"));
+        assert_eq!(env_for("moonshot").as_deref(), Some("kimi-key"));
+        assert_eq!(env_for("moonshot-ai").as_deref(), Some("kimi-key"));
+        assert_eq!(env_for("kimi").as_deref(), Some("kimi-key"));
+        assert_eq!(env_for("kimi-k2").as_deref(), Some("kimi-key"));
 
         clear_known_envs();
     }
 
     #[test]
-    fn wanjie_ark_env_aliases_resolve() {
+    fn dropped_providers_return_none_from_env_for() {
         let _guard = env_lock();
         clear_known_envs();
-        unsafe { std::env::set_var("WANJIE_API_KEY", "wanjie-key") };
-
-        assert_eq!(env_for("wanjie-ark").as_deref(), Some("wanjie-key"));
-        assert_eq!(env_for("ark_wanjie").as_deref(), Some("wanjie-key"));
-        assert_eq!(env_for("wanjie-maas").as_deref(), Some("wanjie-key"));
-
-        clear_known_envs();
-    }
-
-    #[test]
-    fn fireworks_env_aliases_resolve() {
-        let _lock = env_lock();
-        clear_known_envs();
-        // Safety: env mutation guarded by env_lock().
-        unsafe { std::env::set_var("FIREWORKS_API_KEY", "fw-key") };
-
-        assert_eq!(env_for("fireworks").as_deref(), Some("fw-key"));
-        assert_eq!(env_for("fireworks-ai").as_deref(), Some("fw-key"));
-        // Safety: env mutation guarded by env_lock().
-        unsafe { std::env::remove_var("FIREWORKS_API_KEY") };
+        assert!(env_for("openai").is_none());
+        assert!(env_for("openrouter").is_none());
+        assert!(env_for("novita").is_none());
+        assert!(env_for("fireworks").is_none());
+        assert!(env_for("atlascloud").is_none());
+        assert!(env_for("wanjie-ark").is_none());
     }
 
     #[test]

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -30,6 +30,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **AGENTS.md is now maintainer-local.** The project instructions file no
   longer ships as a tracked repo file; it lives in maintainer-local ignored
   state (#2047).
+- **Supported provider set narrowed.** v0.8.45 ships with DeepSeek (default,
+  on the official endpoint plus the documented NVIDIA NIM escape hatch),
+  Moonshot/Kimi (K2.6 — Kimi OAuth path included), and the self-hosted
+  SGLang, vLLM, and Ollama backends. The generic OpenAI-compatible
+  provider, AtlasCloud, Wanjie Ark, OpenRouter, Novita, and Fireworks
+  surfaces are removed from runtime, pickers, completions, secrets, docs,
+  and examples for this release.
 
 ### Fixed
 

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -879,14 +879,9 @@ pub(super) fn apply_reasoning_effort(
     let normalized = effort.trim().to_ascii_lowercase();
     match normalized.as_str() {
         "off" | "disabled" | "none" | "false" => match provider {
-            ApiProvider::Deepseek
-            | ApiProvider::DeepseekCN
-            | ApiProvider::Openrouter
-            | ApiProvider::Novita
-            | ApiProvider::Sglang => {
+            ApiProvider::Deepseek | ApiProvider::DeepseekCN | ApiProvider::Sglang => {
                 body["thinking"] = json!({ "type": "disabled" });
             }
-            ApiProvider::Fireworks => {}
             // vLLM is an OpenAI-protocol server, not an Anthropic-protocol one.
             // For Qwen3 / DeepSeek-R1 / other reasoning models hosted via vLLM,
             // the canonical OpenAI extension to disable thinking is
@@ -901,11 +896,7 @@ pub(super) fn apply_reasoning_effort(
                     "enable_thinking": false,
                 });
             }
-            ApiProvider::Openai
-            | ApiProvider::Atlascloud
-            | ApiProvider::WanjieArk
-            | ApiProvider::Moonshot
-            | ApiProvider::Ollama => {}
+            ApiProvider::Moonshot | ApiProvider::Ollama => {}
             ApiProvider::NvidiaNim => {
                 body["chat_template_kwargs"] = json!({
                     "thinking": false,
@@ -918,32 +909,13 @@ pub(super) fn apply_reasoning_effort(
                 body["reasoning_effort"] = json!("high");
                 body["thinking"] = json!({ "type": "enabled" });
             }
-            // OpenRouter/Novita: pass through the actual user-chosen value.
-            // OpenRouter's unified scale is none/minimal/low/medium/high/xhigh;
-            // DeepSeek models hosted there accept those directly.
-            ApiProvider::Openrouter | ApiProvider::Novita => {
-                let value = match normalized.as_str() {
-                    "low" | "minimal" => "low",
-                    "medium" | "mid" => "medium",
-                    _ => "high",
-                };
-                body["reasoning_effort"] = json!(value);
-                body["thinking"] = json!({ "type": "enabled" });
-            }
-            ApiProvider::Fireworks => {
-                body["reasoning_effort"] = json!("high");
-            }
             ApiProvider::Vllm => {
                 body["chat_template_kwargs"] = json!({
                     "enable_thinking": true,
                 });
                 body["reasoning_effort"] = json!("high");
             }
-            ApiProvider::Openai
-            | ApiProvider::Atlascloud
-            | ApiProvider::WanjieArk
-            | ApiProvider::Moonshot
-            | ApiProvider::Ollama => {}
+            ApiProvider::Moonshot | ApiProvider::Ollama => {}
             ApiProvider::NvidiaNim => {
                 body["chat_template_kwargs"] = json!({
                     "thinking": true,
@@ -956,24 +928,13 @@ pub(super) fn apply_reasoning_effort(
                 body["reasoning_effort"] = json!("max");
                 body["thinking"] = json!({ "type": "enabled" });
             }
-            ApiProvider::Openrouter | ApiProvider::Novita => {
-                body["reasoning_effort"] = json!("xhigh");
-                body["thinking"] = json!({ "type": "enabled" });
-            }
-            ApiProvider::Fireworks => {
-                body["reasoning_effort"] = json!("max");
-            }
             ApiProvider::Vllm => {
                 body["chat_template_kwargs"] = json!({
                     "enable_thinking": true,
                 });
                 body["reasoning_effort"] = json!("max");
             }
-            ApiProvider::Openai
-            | ApiProvider::Atlascloud
-            | ApiProvider::WanjieArk
-            | ApiProvider::Moonshot
-            | ApiProvider::Ollama => {}
+            ApiProvider::Moonshot | ApiProvider::Ollama => {}
             ApiProvider::NvidiaNim => {
                 body["chat_template_kwargs"] = json!({
                     "thinking": true,
@@ -1106,8 +1067,7 @@ pub(crate) fn build_cache_warmup_request(request: &MessageRequest) -> MessageReq
 mod tests {
     use super::*;
     use crate::client::chat::{
-        build_chat_messages, build_chat_messages_for_request,
-        build_chat_messages_for_request_and_provider, count_reasoning_replay_chars,
+        build_chat_messages, build_chat_messages_for_request, count_reasoning_replay_chars,
         parse_chat_message, parse_sse_chunk, sanitize_thinking_mode_messages, tool_to_chat,
         tool_to_chat_for_base_url,
     };
@@ -1277,55 +1237,6 @@ mod tests {
             assistant.get("reasoning_content").and_then(Value::as_str),
             Some("plan"),
             "thinking-mode models keep reasoning_content while still in the current turn"
-        );
-    }
-
-    #[test]
-    fn generic_openai_provider_drops_reasoning_content_for_non_deepseek_models() {
-        // #1542 intent (narrowed by #1739/#1694): a *genuine non-DeepSeek*
-        // model on the generic openai provider must not carry DeepSeek-only
-        // `reasoning_content`. A DeepSeek reasoning model on the openai
-        // provider (DeepSeek-compatible endpoint) is now covered separately
-        // and DOES replay reasoning_content — see
-        // `deepseek_model_on_openai_provider_still_replays_reasoning_content`.
-        let request = MessageRequest {
-            model: "qwen3-coder".to_string(),
-            messages: vec![Message {
-                role: "assistant".to_string(),
-                content: vec![
-                    ContentBlock::Thinking {
-                        thinking: "plan".to_string(),
-                    },
-                    ContentBlock::Text {
-                        text: "done".to_string(),
-                        cache_control: None,
-                    },
-                ],
-            }],
-            max_tokens: 16,
-            system: None,
-            tools: None,
-            tool_choice: None,
-            metadata: None,
-            thinking: None,
-            reasoning_effort: Some("max".to_string()),
-            stream: None,
-            temperature: None,
-            top_p: None,
-        };
-
-        let openai = build_chat_messages_for_request_and_provider(&request, ApiProvider::Openai);
-        let generic_assistant = openai
-            .iter()
-            .find(|value| value.get("role").and_then(Value::as_str) == Some("assistant"))
-            .expect("assistant message");
-        assert_eq!(
-            generic_assistant.get("content").and_then(Value::as_str),
-            Some("done")
-        );
-        assert!(
-            generic_assistant.get("reasoning_content").is_none(),
-            "generic OpenAI-compatible providers reject DeepSeek-only reasoning_content (#1542)"
         );
     }
 
@@ -1930,47 +1841,6 @@ mod tests {
             body.pointer("/chat_template_kwargs/reasoning_effort")
                 .is_none()
         );
-    }
-
-    #[test]
-    fn reasoning_effort_uses_openai_compatible_shape_for_fireworks() {
-        let mut body = json!({});
-        apply_reasoning_effort(&mut body, Some("max"), ApiProvider::Fireworks);
-
-        assert_eq!(
-            body.get("reasoning_effort").and_then(Value::as_str),
-            Some("max")
-        );
-        assert!(
-            body.get("thinking").is_none(),
-            "Fireworks strict-validates OpenAI-compatible requests and rejects top-level thinking"
-        );
-    }
-
-    #[test]
-    fn reasoning_effort_maps_openrouter_scale_without_deepseek_max_label() {
-        for (input, expected) in [
-            ("low", "low"),
-            ("minimal", "low"),
-            ("medium", "medium"),
-            ("mid", "medium"),
-            ("high", "high"),
-            ("max", "xhigh"),
-            ("xhigh", "xhigh"),
-        ] {
-            let mut body = json!({});
-            apply_reasoning_effort(&mut body, Some(input), ApiProvider::Openrouter);
-
-            assert_eq!(
-                body.get("reasoning_effort").and_then(Value::as_str),
-                Some(expected),
-                "OpenRouter effort mapping for {input}"
-            );
-            assert_eq!(
-                body.pointer("/thinking/type").and_then(Value::as_str),
-                Some("enabled")
-            );
-        }
     }
 
     #[test]
@@ -2739,46 +2609,6 @@ mod tests {
         let chars = count_reasoning_replay_chars(&body);
         // "(reasoning omitted)" is 19 bytes.
         assert_eq!(chars, 19);
-    }
-
-    #[test]
-    fn sanitize_thinking_mode_skips_generic_openai_provider() {
-        // #1542 intent (narrowed by #1739/#1694): the sanitizer only skips for
-        // a *genuine non-DeepSeek* model on the generic openai provider. A
-        // DeepSeek reasoning model on the openai provider still gets sanitized
-        // (see chat.rs `deepseek_model_on_openai_provider_still_replays_*`).
-        let mut body = json!({
-            "model": "qwen3-coder",
-            "messages": [
-                { "role": "user", "content": "hi" },
-                {
-                    "role": "assistant",
-                    "content": "",
-                    "tool_calls": [{ "id": "1", "type": "function" }]
-                }
-            ]
-        });
-
-        let result = sanitize_thinking_mode_messages(
-            &mut body,
-            "qwen3-coder",
-            Some("max"),
-            ApiProvider::Openai,
-        );
-
-        assert!(result.is_none());
-        let assistant = body["messages"]
-            .as_array()
-            .and_then(|messages| {
-                messages
-                    .iter()
-                    .find(|message| message["role"] == "assistant")
-            })
-            .expect("assistant message");
-        assert!(
-            assistant.get("reasoning_content").is_none(),
-            "generic OpenAI-compatible provider payload must not get reasoning_content (#1542)"
-        );
     }
 
     #[test]

--- a/crates/tui/src/client/chat.rs
+++ b/crates/tui/src/client/chat.rs
@@ -1698,9 +1698,6 @@ fn provider_accepts_reasoning_content(provider: ApiProvider) -> bool {
         ApiProvider::Deepseek
             | ApiProvider::DeepseekCN
             | ApiProvider::NvidiaNim
-            | ApiProvider::Openrouter
-            | ApiProvider::Novita
-            | ApiProvider::Fireworks
             | ApiProvider::Sglang
     )
 }
@@ -2342,9 +2339,12 @@ mod stream_decoder_tests {
     }
 
     #[test]
-    fn decoder_accepts_openrouter_reasoning_delta_with_extra_fields() {
+    fn decoder_accepts_reasoning_delta_with_extra_provider_specific_fields() {
+        // Defensive: third-party OpenAI-compatible providers sometimes attach
+        // extra fields (reasoning_details, native_finish_reason) alongside the
+        // reasoning delta. The decoder must ignore those rather than crash.
         let events = decode_chunk(
-            r#"{"id":"or-1","choices":[{"delta":{"reasoning":"openrouter thought","reasoning_details":[{"type":"summary","text":"extra"}],"native_finish_reason":null}}],"usage":{"completion_tokens_details":{"reasoning_tokens":3}}}"#,
+            r#"{"id":"or-1","choices":[{"delta":{"reasoning":"a thought","reasoning_details":[{"type":"summary","text":"extra"}],"native_finish_reason":null}}],"usage":{"completion_tokens_details":{"reasoning_tokens":3}}}"#,
         );
 
         assert!(
@@ -2353,9 +2353,9 @@ mod stream_decoder_tests {
                 StreamEvent::ContentBlockDelta {
                     delta: Delta::ThinkingDelta { thinking },
                     ..
-                } if thinking == "openrouter thought"
+                } if thinking == "a thought"
             )),
-            "OpenRouter-style reasoning deltas with extra fields should not crash decoding; got {events:?}"
+            "reasoning deltas with extra provider-specific fields should not crash decoding; got {events:?}"
         );
     }
 
@@ -3128,93 +3128,44 @@ mod alias_thinking_detection_tests {
     }
 
     #[test]
-    fn generic_openai_provider_does_not_accept_reasoning_content_semantics() {
-        assert!(!provider_accepts_reasoning_content(ApiProvider::Openai));
+    fn provider_accept_reasoning_set_matches_approved_providers() {
         assert!(provider_accepts_reasoning_content(ApiProvider::Deepseek));
+        assert!(provider_accepts_reasoning_content(ApiProvider::DeepseekCN));
         assert!(provider_accepts_reasoning_content(ApiProvider::NvidiaNim));
+        assert!(provider_accepts_reasoning_content(ApiProvider::Sglang));
+        assert!(!provider_accepts_reasoning_content(ApiProvider::Moonshot));
+        assert!(!provider_accepts_reasoning_content(ApiProvider::Vllm));
+        assert!(!provider_accepts_reasoning_content(ApiProvider::Ollama));
     }
 
     #[test]
-    fn deepseek_model_on_openai_provider_still_replays_reasoning_content() {
-        // #1739 / #1694: a DeepSeek thinking model pointed at a
-        // DeepSeek-compatible endpoint via the generic `openai` provider must
-        // still replay reasoning_content, even though the provider itself does
-        // not accept the field. Otherwise the thinking-mode API returns 400.
-        assert!(should_replay_reasoning_content_for_provider(
-            ApiProvider::Openai,
-            "deepseek-v4-flash",
-            None,
-        ));
-        assert!(should_replay_reasoning_content_for_provider(
-            ApiProvider::Openai,
-            "deepseek-v4-pro",
-            None,
-        ));
-        assert!(should_replay_reasoning_content_for_provider(
-            ApiProvider::Openai,
-            "deepseek-reasoner",
-            Some("medium"),
-        ));
-        // The documented escape hatch still wins over model detection.
-        assert!(!should_replay_reasoning_content_for_provider(
-            ApiProvider::Openai,
-            "deepseek-v4-flash",
-            Some("off"),
-        ));
-    }
-
-    #[test]
-    fn generic_model_on_openai_provider_still_strips_reasoning_content() {
-        // #1542 no-regression guard: a genuine non-DeepSeek model on the
-        // openai provider must continue to have reasoning_content stripped.
-        assert!(!should_replay_reasoning_content_for_provider(
-            ApiProvider::Openai,
-            "qwen3-coder",
-            None,
-        ));
-        assert!(!should_replay_reasoning_content_for_provider(
-            ApiProvider::Openai,
-            "claude-sonnet-4-6",
-            None,
-        ));
-    }
-
-    #[test]
-    fn stream_classifies_deepseek_model_on_openai_provider_as_reasoning() {
-        // #1739: the SSE parser must treat a DeepSeek thinking model on the
-        // generic `openai` provider (DeepSeek-compatible endpoint) as a
-        // reasoning model, or incoming `reasoning_content` tokens are stored
-        // as answer text and the subsequent replay still 400s.
-        assert!(is_reasoning_model_for_stream(
-            ApiProvider::Openai,
-            "deepseek-v4-flash"
-        ));
-        assert!(is_reasoning_model_for_stream(
-            ApiProvider::Openai,
-            "deepseek-v4-pro"
-        ));
-        assert!(is_reasoning_model_for_stream(
-            ApiProvider::Openai,
-            "deepseek-reasoner"
-        ));
-        // Native DeepSeek provider was already correct; stays correct.
-        assert!(is_reasoning_model_for_stream(
+    fn stream_classifies_deepseek_models_on_supported_providers_as_reasoning() {
+        // #1739: the SSE parser must treat a DeepSeek thinking model as a
+        // reasoning model on each provider that hosts it. Otherwise incoming
+        // `reasoning_content` tokens are stored as answer text and the
+        // subsequent replay 400s.
+        for provider in [
             ApiProvider::Deepseek,
-            "deepseek-v4-pro"
-        ));
+            ApiProvider::DeepseekCN,
+            ApiProvider::NvidiaNim,
+            ApiProvider::Sglang,
+        ] {
+            assert!(is_reasoning_model_for_stream(provider, "deepseek-v4-flash"));
+            assert!(is_reasoning_model_for_stream(provider, "deepseek-v4-pro"));
+            assert!(is_reasoning_model_for_stream(provider, "deepseek-reasoner"));
+        }
     }
 
     #[test]
     fn stream_does_not_classify_generic_model_as_reasoning() {
-        // #1542 no-regression guard: a genuine non-DeepSeek model on the
-        // openai provider must NOT be treated as a reasoning model, so the
-        // parser keeps inlining any `reasoning_content` it emits as text.
+        // Non-reasoning model names must NOT be treated as reasoning even on
+        // providers that accept reasoning_content.
         assert!(!is_reasoning_model_for_stream(
-            ApiProvider::Openai,
+            ApiProvider::NvidiaNim,
             "qwen3-coder"
         ));
         assert!(!is_reasoning_model_for_stream(
-            ApiProvider::Openai,
+            ApiProvider::NvidiaNim,
             "claude-sonnet-4-6"
         ));
         // Non-DeepSeek model on a reasoning-aware provider is also unchanged.
@@ -3231,7 +3182,12 @@ mod alias_thinking_detection_tests {
         // about where reasoning tokens live. Effort=None isolates the
         // model/provider dimension shared by both.
         for model in ["deepseek-v4-pro", "deepseek-reasoner", "qwen3-coder"] {
-            for provider in [ApiProvider::Openai, ApiProvider::Deepseek] {
+            for provider in [
+                ApiProvider::Deepseek,
+                ApiProvider::DeepseekCN,
+                ApiProvider::NvidiaNim,
+                ApiProvider::Sglang,
+            ] {
                 assert_eq!(
                     is_reasoning_model_for_stream(provider, model),
                     should_replay_reasoning_content_for_provider(provider, model, None),

--- a/crates/tui/src/commands/balance.rs
+++ b/crates/tui/src/commands/balance.rs
@@ -13,10 +13,7 @@ use super::CommandResult;
 pub fn balance(app: &mut App) -> CommandResult {
     let provider = app.api_provider;
     match provider {
-        ApiProvider::Deepseek
-        | ApiProvider::DeepseekCN
-        | ApiProvider::Openrouter
-        | ApiProvider::Novita => CommandResult::message(format!(
+        ApiProvider::Deepseek | ApiProvider::DeepseekCN => CommandResult::message(format!(
             "Balance check for {} is planned, but provider balance network dispatch is not wired in this build yet.",
             provider.display_name()
         )),

--- a/crates/tui/src/commands/goal.rs
+++ b/crates/tui/src/commands/goal.rs
@@ -163,7 +163,7 @@ mod tests {
         assert!(matches!(
             result.action,
             Some(AppAction::SendMessage(content))
-                if content == "Implement login flow".to_string()
+                if content == "Implement login flow"
         ));
     }
 

--- a/crates/tui/src/commands/provider.rs
+++ b/crates/tui/src/commands/provider.rs
@@ -27,7 +27,7 @@ pub fn provider(app: &mut App, args: Option<&str>) -> CommandResult {
 
     let Some(target) = ApiProvider::parse(name) else {
         return CommandResult::error(format!(
-            "Unknown provider '{name}'. Expected: deepseek, nvidia-nim, openai, atlascloud, wanjie-ark, openrouter, novita, fireworks, sglang, vllm, or ollama."
+            "Unknown provider '{name}'. Expected: deepseek, nvidia-nim, moonshot, sglang, vllm, or ollama."
         ));
     };
 
@@ -111,71 +111,19 @@ mod tests {
         let result = provider(&mut app, Some("anthropic"));
         let msg = result.message.expect("expected error message");
         assert!(msg.contains("Unknown provider"));
-        assert!(msg.contains("openrouter"));
-        assert!(msg.contains("novita"));
+        assert!(msg.contains("moonshot"));
+        assert!(msg.contains("sglang"));
         assert!(result.action.is_none());
     }
 
     #[test]
-    fn switch_to_openrouter_emits_action() {
+    fn switch_to_moonshot_emits_action() {
         let mut app = create_test_app();
-        let result = provider(&mut app, Some("openrouter"));
+        let result = provider(&mut app, Some("moonshot"));
         match result.action {
             Some(AppAction::SwitchProvider { provider, model }) => {
-                assert_eq!(provider, ApiProvider::Openrouter);
+                assert_eq!(provider, ApiProvider::Moonshot);
                 assert_eq!(model, None);
-            }
-            other => panic!("expected SwitchProvider, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn switch_to_atlascloud_emits_action() {
-        let mut app = create_test_app();
-        let result = provider(&mut app, Some("atlascloud"));
-        match result.action {
-            Some(AppAction::SwitchProvider { provider, model }) => {
-                assert_eq!(provider, ApiProvider::Atlascloud);
-                assert_eq!(model, None);
-            }
-            other => panic!("expected SwitchProvider, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn switch_to_wanjie_ark_preserves_model_id() {
-        let mut app = create_test_app();
-        let result = provider(&mut app, Some("ark-wanjie account-model-id"));
-        match result.action {
-            Some(AppAction::SwitchProvider { provider, model }) => {
-                assert_eq!(provider, ApiProvider::WanjieArk);
-                assert_eq!(model.as_deref(), Some("account-model-id"));
-            }
-            other => panic!("expected SwitchProvider, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn switch_to_novita_emits_action() {
-        let mut app = create_test_app();
-        let result = provider(&mut app, Some("novita"));
-        match result.action {
-            Some(AppAction::SwitchProvider { provider, model }) => {
-                assert_eq!(provider, ApiProvider::Novita);
-                assert_eq!(model, None);
-            }
-            other => panic!("expected SwitchProvider, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn switch_to_fireworks_emits_action() {
-        let mut app = create_test_app();
-        let result = provider(&mut app, Some("fireworks pro"));
-        match result.action {
-            Some(AppAction::SwitchProvider { provider, model }) => {
-                assert_eq!(provider, ApiProvider::Fireworks);
-                assert_eq!(model.as_deref(), Some("deepseek-v4-pro"));
             }
             other => panic!("expected SwitchProvider, got {other:?}"),
         }

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -37,20 +37,6 @@ pub const DEFAULT_DEEPSEEK_BASE_URL: &str = "https://api.deepseek.com/beta";
 pub const DEFAULT_NVIDIA_NIM_MODEL: &str = "deepseek-ai/deepseek-v4-pro";
 pub const DEFAULT_NVIDIA_NIM_FLASH_MODEL: &str = "deepseek-ai/deepseek-v4-flash";
 pub const DEFAULT_NVIDIA_NIM_BASE_URL: &str = "https://integrate.api.nvidia.com/v1";
-pub const DEFAULT_OPENAI_MODEL: &str = "deepseek-v4-pro";
-pub const DEFAULT_OPENAI_BASE_URL: &str = "https://api.openai.com/v1";
-pub const DEFAULT_ATLASCLOUD_MODEL: &str = "deepseek-ai/deepseek-v4-flash";
-pub const DEFAULT_ATLASCLOUD_BASE_URL: &str = "https://api.atlascloud.ai/v1";
-pub const DEFAULT_WANJIE_ARK_MODEL: &str = "deepseek-reasoner";
-pub const DEFAULT_WANJIE_ARK_BASE_URL: &str = "https://maas-openapi.wanjiedata.com/api/v1";
-pub const DEFAULT_OPENROUTER_MODEL: &str = "deepseek/deepseek-v4-pro";
-pub const DEFAULT_OPENROUTER_FLASH_MODEL: &str = "deepseek/deepseek-v4-flash";
-pub const DEFAULT_OPENROUTER_BASE_URL: &str = "https://openrouter.ai/api/v1";
-pub const DEFAULT_NOVITA_MODEL: &str = "deepseek/deepseek-v4-pro";
-pub const DEFAULT_NOVITA_FLASH_MODEL: &str = "deepseek/deepseek-v4-flash";
-pub const DEFAULT_NOVITA_BASE_URL: &str = "https://api.novita.ai/v1";
-pub const DEFAULT_FIREWORKS_MODEL: &str = "accounts/fireworks/models/deepseek-v4-pro";
-pub const DEFAULT_FIREWORKS_BASE_URL: &str = "https://api.fireworks.ai/inference/v1";
 pub const DEFAULT_MOONSHOT_MODEL: &str = "kimi-k2.6";
 pub const DEFAULT_MOONSHOT_BASE_URL: &str = "https://api.moonshot.ai/v1";
 pub const DEFAULT_KIMI_CODE_MODEL: &str = "kimi-for-coding";
@@ -76,8 +62,6 @@ pub const COMMON_DEEPSEEK_MODELS: &[&str] = &[
     "deepseek-v4-flash",
     "deepseek-ai/deepseek-v4-pro",
     "deepseek-ai/deepseek-v4-flash",
-    "deepseek/deepseek-v4-pro",
-    "deepseek/deepseek-v4-flash",
 ];
 pub const OFFICIAL_DEEPSEEK_MODELS: &[&str] = &["deepseek-v4-pro", "deepseek-v4-flash"];
 
@@ -87,12 +71,6 @@ pub enum ApiProvider {
     Deepseek,
     DeepseekCN,
     NvidiaNim,
-    Openai,
-    Atlascloud,
-    WanjieArk,
-    Openrouter,
-    Novita,
-    Fireworks,
     Moonshot,
     Sglang,
     Vllm,
@@ -108,13 +86,6 @@ impl ApiProvider {
                 Some(Self::DeepseekCN)
             }
             "nvidia" | "nvidia-nim" | "nvidia_nim" | "nim" => Some(Self::NvidiaNim),
-            "openai" | "open-ai" => Some(Self::Openai),
-            "atlascloud" | "atlas-cloud" | "atlas_cloud" | "atlas" => Some(Self::Atlascloud),
-            "wanjie" | "wanjie-ark" | "wanjie_ark" | "ark-wanjie" | "ark_wanjie" | "wanjieark"
-            | "wanjie-maas" | "wanjie_maas" | "wanjiemaas" => Some(Self::WanjieArk),
-            "openrouter" | "open_router" => Some(Self::Openrouter),
-            "novita" => Some(Self::Novita),
-            "fireworks" | "fireworks-ai" => Some(Self::Fireworks),
             "moonshot" | "moonshot-ai" | "kimi" | "kimi-k2" => Some(Self::Moonshot),
             "sglang" | "sg-lang" => Some(Self::Sglang),
             "vllm" | "v-llm" => Some(Self::Vllm),
@@ -129,12 +100,6 @@ impl ApiProvider {
             Self::Deepseek => "deepseek",
             Self::DeepseekCN => "deepseek-cn",
             Self::NvidiaNim => "nvidia-nim",
-            Self::Openai => "openai",
-            Self::Atlascloud => "atlascloud",
-            Self::WanjieArk => "wanjie-ark",
-            Self::Openrouter => "openrouter",
-            Self::Novita => "novita",
-            Self::Fireworks => "fireworks",
             Self::Moonshot => "moonshot",
             Self::Sglang => "sglang",
             Self::Vllm => "vllm",
@@ -149,12 +114,6 @@ impl ApiProvider {
             Self::Deepseek => "DeepSeek",
             Self::DeepseekCN => "DeepSeek (legacy alias)",
             Self::NvidiaNim => "NVIDIA NIM",
-            Self::Openai => "OpenAI-compatible",
-            Self::Atlascloud => "AtlasCloud",
-            Self::WanjieArk => "Wanjie Ark",
-            Self::Openrouter => "OpenRouter",
-            Self::Novita => "Novita AI",
-            Self::Fireworks => "Fireworks AI",
             Self::Moonshot => "Moonshot/Kimi",
             Self::Sglang => "SGLang",
             Self::Vllm => "vLLM",
@@ -168,12 +127,6 @@ impl ApiProvider {
         &[
             Self::Deepseek,
             Self::NvidiaNim,
-            Self::Openai,
-            Self::Atlascloud,
-            Self::WanjieArk,
-            Self::Openrouter,
-            Self::Novita,
-            Self::Fireworks,
             Self::Moonshot,
             Self::Sglang,
             Self::Vllm,
@@ -243,10 +196,7 @@ pub enum RequestPayloadMode {
 /// in the API payload (after normalization / provider-specific mapping).
 #[must_use]
 pub fn provider_capability(provider: ApiProvider, resolved_model: &str) -> ProviderCapability {
-    if matches!(
-        provider,
-        ApiProvider::Openai | ApiProvider::Atlascloud | ApiProvider::Moonshot
-    ) {
+    if matches!(provider, ApiProvider::Moonshot) {
         return ProviderCapability {
             provider,
             resolved_model: resolved_model.to_string(),
@@ -283,8 +233,7 @@ pub fn provider_capability(provider: ApiProvider, resolved_model: &str) -> Provi
         || model_lower == "deepseek-v4flash"
         || model_lower == "deepseek-v4"
         || alias_deprecation.is_some();
-    let is_reasoner = matches!(provider, ApiProvider::WanjieArk)
-        && (model_lower.contains("reasoner") || model_lower.contains("r1"));
+    let is_reasoner = false;
 
     // Context window: V4-class models get 1M, everything else falls through
     // to the model's own lookup or a default.
@@ -430,16 +379,10 @@ pub fn model_completion_names_for_provider(provider: ApiProvider) -> Vec<&'stati
     match provider {
         ApiProvider::Deepseek | ApiProvider::DeepseekCN => OFFICIAL_DEEPSEEK_MODELS.to_vec(),
         ApiProvider::NvidiaNim => vec![DEFAULT_NVIDIA_NIM_MODEL, DEFAULT_NVIDIA_NIM_FLASH_MODEL],
-        ApiProvider::Openrouter => vec![DEFAULT_OPENROUTER_MODEL, DEFAULT_OPENROUTER_FLASH_MODEL],
-        ApiProvider::Novita => vec![DEFAULT_NOVITA_MODEL, DEFAULT_NOVITA_FLASH_MODEL],
-        ApiProvider::Fireworks => vec![DEFAULT_FIREWORKS_MODEL],
         ApiProvider::Moonshot => vec![DEFAULT_MOONSHOT_MODEL],
-        ApiProvider::WanjieArk => vec![DEFAULT_WANJIE_ARK_MODEL],
         ApiProvider::Sglang => vec![DEFAULT_SGLANG_MODEL, DEFAULT_SGLANG_FLASH_MODEL],
         ApiProvider::Vllm => vec![DEFAULT_VLLM_MODEL, DEFAULT_VLLM_FLASH_MODEL],
-        ApiProvider::Openai | ApiProvider::Atlascloud | ApiProvider::Ollama => {
-            OFFICIAL_DEEPSEEK_MODELS.to_vec()
-        }
+        ApiProvider::Ollama => OFFICIAL_DEEPSEEK_MODELS.to_vec(),
     }
 }
 
@@ -1237,18 +1180,6 @@ pub struct ProvidersConfig {
     #[serde(default)]
     pub nvidia_nim: ProviderConfig,
     #[serde(default)]
-    pub openai: ProviderConfig,
-    #[serde(default)]
-    pub atlascloud: ProviderConfig,
-    #[serde(default)]
-    pub wanjie_ark: ProviderConfig,
-    #[serde(default)]
-    pub openrouter: ProviderConfig,
-    #[serde(default)]
-    pub novita: ProviderConfig,
-    #[serde(default)]
-    pub fireworks: ProviderConfig,
-    #[serde(default)]
     pub moonshot: ProviderConfig,
     #[serde(default)]
     pub sglang: ProviderConfig,
@@ -1355,12 +1286,6 @@ impl Config {
             return;
         }
         let table = match provider {
-            ApiProvider::Openai => "providers.openai",
-            ApiProvider::Atlascloud => "providers.atlascloud",
-            ApiProvider::WanjieArk => "providers.wanjie_ark",
-            ApiProvider::Openrouter => "providers.openrouter",
-            ApiProvider::Novita => "providers.novita",
-            ApiProvider::Fireworks => "providers.fireworks",
             ApiProvider::Moonshot => "providers.moonshot",
             ApiProvider::Sglang => "providers.sglang",
             ApiProvider::Vllm => "providers.vllm",
@@ -1381,7 +1306,7 @@ impl Config {
             && ApiProvider::parse(provider).is_none()
         {
             anyhow::bail!(
-                "Invalid provider '{provider}': expected deepseek, deepseek-cn, nvidia-nim, openai, atlascloud, wanjie-ark, openrouter, novita, fireworks, sglang, vllm, or ollama."
+                "Invalid provider '{provider}': expected deepseek, deepseek-cn, nvidia-nim, moonshot, sglang, vllm, or ollama."
             );
         }
         if let Some(ref key) = self.api_key
@@ -1497,12 +1422,6 @@ impl Config {
             ApiProvider::Deepseek => &providers.deepseek,
             ApiProvider::DeepseekCN => &providers.deepseek_cn,
             ApiProvider::NvidiaNim => &providers.nvidia_nim,
-            ApiProvider::Openai => &providers.openai,
-            ApiProvider::Atlascloud => &providers.atlascloud,
-            ApiProvider::WanjieArk => &providers.wanjie_ark,
-            ApiProvider::Openrouter => &providers.openrouter,
-            ApiProvider::Novita => &providers.novita,
-            ApiProvider::Fireworks => &providers.fireworks,
             ApiProvider::Moonshot => &providers.moonshot,
             ApiProvider::Sglang => &providers.sglang,
             ApiProvider::Vllm => &providers.vllm,
@@ -1543,10 +1462,9 @@ impl Config {
                 return normalized;
             }
             // An explicit provider-scoped model that is not a recognized
-            // DeepSeek alias is a deliberate custom choice for a non-DeepSeek
-            // provider (e.g. `MiniMax-M2.7` on an OpenAI-compatible endpoint).
-            // It must pass through verbatim rather than fall back to a
-            // DeepSeek/provider default (issue #1714).
+            // DeepSeek alias is a deliberate custom choice; it must pass
+            // through verbatim rather than fall back to a DeepSeek/provider
+            // default (issue #1714).
             if !matches!(provider, ApiProvider::Deepseek | ApiProvider::DeepseekCN) {
                 let trimmed = model.trim();
                 if !trimmed.is_empty() {
@@ -1581,12 +1499,6 @@ impl Config {
         match provider {
             ApiProvider::Deepseek | ApiProvider::DeepseekCN => DEFAULT_TEXT_MODEL,
             ApiProvider::NvidiaNim => DEFAULT_NVIDIA_NIM_MODEL,
-            ApiProvider::Openai => DEFAULT_OPENAI_MODEL,
-            ApiProvider::Atlascloud => DEFAULT_ATLASCLOUD_MODEL,
-            ApiProvider::WanjieArk => DEFAULT_WANJIE_ARK_MODEL,
-            ApiProvider::Openrouter => DEFAULT_OPENROUTER_MODEL,
-            ApiProvider::Novita => DEFAULT_NOVITA_MODEL,
-            ApiProvider::Fireworks => DEFAULT_FIREWORKS_MODEL,
             ApiProvider::Moonshot => DEFAULT_MOONSHOT_MODEL,
             ApiProvider::Sglang => DEFAULT_SGLANG_MODEL,
             ApiProvider::Vllm => DEFAULT_VLLM_MODEL,
@@ -1613,13 +1525,7 @@ impl Config {
                 .as_ref()
                 .filter(|base| base.contains("integrate.api.nvidia.com"))
                 .cloned(),
-            ApiProvider::Openai
-            | ApiProvider::Atlascloud
-            | ApiProvider::WanjieArk
-            | ApiProvider::Openrouter
-            | ApiProvider::Novita
-            | ApiProvider::Fireworks
-            | ApiProvider::Moonshot
+            ApiProvider::Moonshot
             | ApiProvider::Sglang
             | ApiProvider::Vllm
             | ApiProvider::Ollama => None,
@@ -1629,12 +1535,6 @@ impl Config {
                 ApiProvider::Deepseek => DEFAULT_DEEPSEEK_BASE_URL,
                 ApiProvider::DeepseekCN => DEFAULT_DEEPSEEKCN_BASE_URL,
                 ApiProvider::NvidiaNim => DEFAULT_NVIDIA_NIM_BASE_URL,
-                ApiProvider::Openai => DEFAULT_OPENAI_BASE_URL,
-                ApiProvider::Atlascloud => DEFAULT_ATLASCLOUD_BASE_URL,
-                ApiProvider::WanjieArk => DEFAULT_WANJIE_ARK_BASE_URL,
-                ApiProvider::Openrouter => DEFAULT_OPENROUTER_BASE_URL,
-                ApiProvider::Novita => DEFAULT_NOVITA_BASE_URL,
-                ApiProvider::Fireworks => DEFAULT_FIREWORKS_BASE_URL,
                 ApiProvider::Moonshot => {
                     if self
                         .provider_config()
@@ -1672,12 +1572,6 @@ impl Config {
         let slot = match provider {
             ApiProvider::Deepseek | ApiProvider::DeepseekCN => "deepseek",
             ApiProvider::NvidiaNim => "nvidia-nim",
-            ApiProvider::Openai => "openai",
-            ApiProvider::Atlascloud => "atlascloud",
-            ApiProvider::WanjieArk => "wanjie-ark",
-            ApiProvider::Openrouter => "openrouter",
-            ApiProvider::Novita => "novita",
-            ApiProvider::Fireworks => "fireworks",
             ApiProvider::Moonshot => "moonshot",
             ApiProvider::Sglang => "sglang",
             ApiProvider::Vllm => "vllm",
@@ -1743,31 +1637,6 @@ impl Config {
                 "NVIDIA NIM API key not found. Run 'codewhale auth set --provider nvidia-nim', \
                  set NVIDIA_API_KEY/NVIDIA_NIM_API_KEY, or save api_key in ~/.deepseek/config.toml \
                  with provider = \"nvidia-nim\"."
-            ),
-            ApiProvider::Openai => anyhow::bail!(
-                "OpenAI-compatible API key not found. Run 'codewhale auth set --provider openai', \
-                 set OPENAI_API_KEY, or add [providers.openai] api_key in ~/.deepseek/config.toml."
-            ),
-            ApiProvider::Atlascloud => anyhow::bail!(
-                "AtlasCloud API key not found. Run 'codewhale auth set --provider atlascloud', \
-                 set ATLASCLOUD_API_KEY, or add [providers.atlascloud] api_key in ~/.deepseek/config.toml."
-            ),
-            ApiProvider::WanjieArk => anyhow::bail!(
-                "Wanjie Ark API key not found. Run 'codewhale auth set --provider wanjie-ark', \
-                 set WANJIE_ARK_API_KEY/WANJIE_API_KEY/WANJIE_MAAS_API_KEY, or add \
-                 [providers.wanjie_ark] api_key in ~/.deepseek/config.toml."
-            ),
-            ApiProvider::Openrouter => anyhow::bail!(
-                "OpenRouter API key not found. Run 'codewhale auth set --provider openrouter', \
-                 set OPENROUTER_API_KEY, or add [providers.openrouter] api_key in ~/.deepseek/config.toml."
-            ),
-            ApiProvider::Novita => anyhow::bail!(
-                "Novita API key not found. Run 'codewhale auth set --provider novita', \
-                 set NOVITA_API_KEY, or add [providers.novita] api_key in ~/.deepseek/config.toml."
-            ),
-            ApiProvider::Fireworks => anyhow::bail!(
-                "Fireworks AI API key not found. Run 'codewhale auth set --provider fireworks', \
-                 set FIREWORKS_API_KEY, or add [providers.fireworks] api_key in ~/.deepseek/config.toml."
             ),
             ApiProvider::Moonshot => anyhow::bail!(
                 "Moonshot/Kimi API key not found. Run 'codewhale auth set --provider moonshot', \
@@ -2280,41 +2149,6 @@ fn apply_env_overrides(config: &mut Config) {
                     .nvidia_nim
                     .base_url = Some(value);
             }
-            ApiProvider::Openai => {
-                config
-                    .providers
-                    .get_or_insert_with(ProvidersConfig::default)
-                    .openai
-                    .base_url = Some(value);
-            }
-            ApiProvider::Openrouter => {
-                config
-                    .providers
-                    .get_or_insert_with(ProvidersConfig::default)
-                    .openrouter
-                    .base_url = Some(value);
-            }
-            ApiProvider::WanjieArk => {
-                config
-                    .providers
-                    .get_or_insert_with(ProvidersConfig::default)
-                    .wanjie_ark
-                    .base_url = Some(value);
-            }
-            ApiProvider::Novita => {
-                config
-                    .providers
-                    .get_or_insert_with(ProvidersConfig::default)
-                    .novita
-                    .base_url = Some(value);
-            }
-            ApiProvider::Fireworks => {
-                config
-                    .providers
-                    .get_or_insert_with(ProvidersConfig::default)
-                    .fireworks
-                    .base_url = Some(value);
-            }
             ApiProvider::Moonshot => {
                 config
                     .providers
@@ -2343,13 +2177,6 @@ fn apply_env_overrides(config: &mut Config) {
                     .ollama
                     .base_url = Some(value);
             }
-            ApiProvider::Atlascloud => {
-                config
-                    .providers
-                    .get_or_insert_with(ProvidersConfig::default)
-                    .atlascloud
-                    .base_url = Some(value);
-            }
         }
     }
     if matches!(config.api_provider(), ApiProvider::NvidiaNim)
@@ -2361,71 +2188,6 @@ fn apply_env_overrides(config: &mut Config) {
             .providers
             .get_or_insert_with(ProvidersConfig::default)
             .nvidia_nim
-            .base_url = Some(value);
-    }
-    // OpenAI-compatible and non-DeepSeek hosted providers are scoped only on
-    // their own provider entry — the legacy root `base_url` keeps DeepSeek-only
-    // semantics.
-    if matches!(config.api_provider(), ApiProvider::Openai)
-        && let Ok(value) = std::env::var("OPENAI_BASE_URL")
-        && !value.trim().is_empty()
-    {
-        config
-            .providers
-            .get_or_insert_with(ProvidersConfig::default)
-            .openai
-            .base_url = Some(value);
-    }
-    if matches!(config.api_provider(), ApiProvider::Atlascloud)
-        && let Ok(value) = std::env::var("ATLASCLOUD_BASE_URL")
-        && !value.trim().is_empty()
-    {
-        config
-            .providers
-            .get_or_insert_with(ProvidersConfig::default)
-            .atlascloud
-            .base_url = Some(value);
-    }
-    if matches!(config.api_provider(), ApiProvider::Openrouter)
-        && let Ok(value) = std::env::var("OPENROUTER_BASE_URL")
-        && !value.trim().is_empty()
-    {
-        config
-            .providers
-            .get_or_insert_with(ProvidersConfig::default)
-            .openrouter
-            .base_url = Some(value);
-    }
-    if matches!(config.api_provider(), ApiProvider::WanjieArk)
-        && let Ok(value) = std::env::var("WANJIE_ARK_BASE_URL")
-            .or_else(|_| std::env::var("WANJIE_BASE_URL"))
-            .or_else(|_| std::env::var("WANJIE_MAAS_BASE_URL"))
-        && !value.trim().is_empty()
-    {
-        config
-            .providers
-            .get_or_insert_with(ProvidersConfig::default)
-            .wanjie_ark
-            .base_url = Some(value);
-    }
-    if matches!(config.api_provider(), ApiProvider::Novita)
-        && let Ok(value) = std::env::var("NOVITA_BASE_URL")
-        && !value.trim().is_empty()
-    {
-        config
-            .providers
-            .get_or_insert_with(ProvidersConfig::default)
-            .novita
-            .base_url = Some(value);
-    }
-    if matches!(config.api_provider(), ApiProvider::Fireworks)
-        && let Ok(value) = std::env::var("FIREWORKS_BASE_URL")
-        && !value.trim().is_empty()
-    {
-        config
-            .providers
-            .get_or_insert_with(ProvidersConfig::default)
-            .fireworks
             .base_url = Some(value);
     }
     if matches!(config.api_provider(), ApiProvider::Moonshot)
@@ -2475,12 +2237,6 @@ fn apply_env_overrides(config: &mut Config) {
             ApiProvider::Deepseek => &mut providers.deepseek,
             ApiProvider::DeepseekCN => &mut providers.deepseek_cn,
             ApiProvider::NvidiaNim => &mut providers.nvidia_nim,
-            ApiProvider::Openai => &mut providers.openai,
-            ApiProvider::Atlascloud => &mut providers.atlascloud,
-            ApiProvider::WanjieArk => &mut providers.wanjie_ark,
-            ApiProvider::Openrouter => &mut providers.openrouter,
-            ApiProvider::Novita => &mut providers.novita,
-            ApiProvider::Fireworks => &mut providers.fireworks,
             ApiProvider::Moonshot => &mut providers.moonshot,
             ApiProvider::Sglang => &mut providers.sglang,
             ApiProvider::Vllm => &mut providers.vllm,
@@ -2514,31 +2270,6 @@ fn apply_env_overrides(config: &mut Config) {
         && let Ok(value) = std::env::var("OLLAMA_MODEL")
     {
         config.default_text_model = Some(value);
-    }
-    if matches!(config.api_provider(), ApiProvider::Openai)
-        && let Ok(value) = std::env::var("OPENAI_MODEL")
-    {
-        config
-            .providers
-            .get_or_insert_with(ProvidersConfig::default)
-            .openai
-            .model = Some(value);
-    }
-    if matches!(config.api_provider(), ApiProvider::Atlascloud)
-        && let Ok(value) = std::env::var("ATLASCLOUD_MODEL")
-    {
-        config.default_text_model = Some(value);
-    }
-    if matches!(config.api_provider(), ApiProvider::WanjieArk)
-        && let Ok(value) = std::env::var("WANJIE_ARK_MODEL")
-            .or_else(|_| std::env::var("WANJIE_MODEL"))
-            .or_else(|_| std::env::var("WANJIE_MAAS_MODEL"))
-    {
-        config
-            .providers
-            .get_or_insert_with(ProvidersConfig::default)
-            .wanjie_ark
-            .model = Some(value);
     }
     if matches!(config.api_provider(), ApiProvider::Moonshot)
         && let Ok(value) = std::env::var("MOONSHOT_MODEL")
@@ -2574,12 +2305,6 @@ fn apply_env_overrides(config: &mut Config) {
                     "DeepSeek providers are handled in the if branch above (issue #1714)"
                 ),
                 ApiProvider::NvidiaNim => &mut providers.nvidia_nim,
-                ApiProvider::Openai => &mut providers.openai,
-                ApiProvider::Atlascloud => &mut providers.atlascloud,
-                ApiProvider::WanjieArk => &mut providers.wanjie_ark,
-                ApiProvider::Openrouter => &mut providers.openrouter,
-                ApiProvider::Novita => &mut providers.novita,
-                ApiProvider::Fireworks => &mut providers.fireworks,
                 ApiProvider::Moonshot => &mut providers.moonshot,
                 ApiProvider::Sglang => &mut providers.sglang,
                 ApiProvider::Vllm => &mut providers.vllm,
@@ -2790,24 +2515,6 @@ fn normalize_model_config(config: &mut Config) {
         {
             providers.nvidia_nim.model = Some(normalized);
         }
-        if let Some(model) = providers.openrouter.model.as_deref()
-            && !provider_entry_uses_custom_base_url(ApiProvider::Openrouter, &providers.openrouter)
-            && let Some(normalized) = normalize_model_for_provider(ApiProvider::Openrouter, model)
-        {
-            providers.openrouter.model = Some(normalized);
-        }
-        if let Some(model) = providers.novita.model.as_deref()
-            && !provider_entry_uses_custom_base_url(ApiProvider::Novita, &providers.novita)
-            && let Some(normalized) = normalize_model_for_provider(ApiProvider::Novita, model)
-        {
-            providers.novita.model = Some(normalized);
-        }
-        if let Some(model) = providers.fireworks.model.as_deref()
-            && !provider_entry_uses_custom_base_url(ApiProvider::Fireworks, &providers.fireworks)
-            && let Some(normalized) = normalize_model_for_provider(ApiProvider::Fireworks, model)
-        {
-            providers.fireworks.model = Some(normalized);
-        }
         if let Some(model) = providers.moonshot.model.as_deref()
             && !provider_entry_uses_custom_base_url(ApiProvider::Moonshot, &providers.moonshot)
             && let Some(normalized) = normalize_model_for_provider(ApiProvider::Moonshot, model)
@@ -2837,14 +2544,7 @@ fn normalize_model_for_provider(provider: ApiProvider, model: &str) -> Option<St
 }
 
 pub(crate) fn provider_passes_model_through(provider: ApiProvider) -> bool {
-    matches!(
-        provider,
-        ApiProvider::Openai
-            | ApiProvider::Atlascloud
-            | ApiProvider::WanjieArk
-            | ApiProvider::Moonshot
-            | ApiProvider::Ollama
-    )
+    matches!(provider, ApiProvider::Moonshot | ApiProvider::Ollama)
 }
 
 fn provider_entry_uses_custom_base_url(provider: ApiProvider, entry: &ProviderConfig) -> bool {
@@ -2859,12 +2559,6 @@ fn default_base_url_for_provider(provider: ApiProvider) -> &'static str {
         ApiProvider::Deepseek => DEFAULT_DEEPSEEK_BASE_URL,
         ApiProvider::DeepseekCN => DEFAULT_DEEPSEEKCN_BASE_URL,
         ApiProvider::NvidiaNim => DEFAULT_NVIDIA_NIM_BASE_URL,
-        ApiProvider::Openai => DEFAULT_OPENAI_BASE_URL,
-        ApiProvider::Atlascloud => DEFAULT_ATLASCLOUD_BASE_URL,
-        ApiProvider::WanjieArk => DEFAULT_WANJIE_ARK_BASE_URL,
-        ApiProvider::Openrouter => DEFAULT_OPENROUTER_BASE_URL,
-        ApiProvider::Novita => DEFAULT_NOVITA_BASE_URL,
-        ApiProvider::Fireworks => DEFAULT_FIREWORKS_BASE_URL,
         ApiProvider::Moonshot => DEFAULT_MOONSHOT_BASE_URL,
         ApiProvider::Sglang => DEFAULT_SGLANG_BASE_URL,
         ApiProvider::Vllm => DEFAULT_VLLM_BASE_URL,
@@ -2929,17 +2623,6 @@ fn model_for_provider(provider: ApiProvider, normalized: String) -> String {
     match (provider, lowered.as_str()) {
         (ApiProvider::NvidiaNim, "deepseek-v4-pro") => DEFAULT_NVIDIA_NIM_MODEL.to_string(),
         (ApiProvider::NvidiaNim, "deepseek-v4-flash") => DEFAULT_NVIDIA_NIM_FLASH_MODEL.to_string(),
-        (ApiProvider::Openrouter, "deepseek-v4-pro") => DEFAULT_OPENROUTER_MODEL.to_string(),
-        (ApiProvider::Openrouter, "deepseek-v4-flash") => {
-            DEFAULT_OPENROUTER_FLASH_MODEL.to_string()
-        }
-        (ApiProvider::Novita, "deepseek-v4-pro") => DEFAULT_NOVITA_MODEL.to_string(),
-        (ApiProvider::Novita, "deepseek-v4-flash") => DEFAULT_NOVITA_FLASH_MODEL.to_string(),
-        (ApiProvider::Fireworks, "deepseek-v4-pro") => DEFAULT_FIREWORKS_MODEL.to_string(),
-        (ApiProvider::Fireworks, "deepseek-v4-flash") => {
-            // Flash not yet available on Fireworks; fall through to normalized name
-            "accounts/fireworks/models/deepseek-v4-flash".to_string()
-        }
         (ApiProvider::Sglang, "deepseek-v4-pro") => DEFAULT_SGLANG_MODEL.to_string(),
         (ApiProvider::Sglang, "deepseek-v4-flash") => DEFAULT_SGLANG_FLASH_MODEL.to_string(),
         (ApiProvider::Vllm, "deepseek-v4-pro") => DEFAULT_VLLM_MODEL.to_string(),
@@ -3110,12 +2793,6 @@ fn merge_providers(
             deepseek: merge_provider_config(base.deepseek, override_cfg.deepseek),
             deepseek_cn: merge_provider_config(base.deepseek_cn, override_cfg.deepseek_cn),
             nvidia_nim: merge_provider_config(base.nvidia_nim, override_cfg.nvidia_nim),
-            openai: merge_provider_config(base.openai, override_cfg.openai),
-            atlascloud: merge_provider_config(base.atlascloud, override_cfg.atlascloud),
-            wanjie_ark: merge_provider_config(base.wanjie_ark, override_cfg.wanjie_ark),
-            openrouter: merge_provider_config(base.openrouter, override_cfg.openrouter),
-            novita: merge_provider_config(base.novita, override_cfg.novita),
-            fireworks: merge_provider_config(base.fireworks, override_cfg.fireworks),
             moonshot: merge_provider_config(base.moonshot, override_cfg.moonshot),
             sglang: merge_provider_config(base.sglang, override_cfg.sglang),
             vllm: merge_provider_config(base.vllm, override_cfg.vllm),
@@ -3522,22 +3199,6 @@ pub fn active_provider_has_env_api_key(config: &Config) -> bool {
             std::env::var("NVIDIA_API_KEY").is_ok_and(|k| !k.trim().is_empty())
                 || std::env::var("NVIDIA_NIM_API_KEY").is_ok_and(|k| !k.trim().is_empty())
         }
-        ApiProvider::Openai => std::env::var("OPENAI_API_KEY").is_ok_and(|k| !k.trim().is_empty()),
-        ApiProvider::Atlascloud => {
-            std::env::var("ATLASCLOUD_API_KEY").is_ok_and(|k| !k.trim().is_empty())
-        }
-        ApiProvider::WanjieArk => {
-            std::env::var("WANJIE_ARK_API_KEY").is_ok_and(|k| !k.trim().is_empty())
-                || std::env::var("WANJIE_API_KEY").is_ok_and(|k| !k.trim().is_empty())
-                || std::env::var("WANJIE_MAAS_API_KEY").is_ok_and(|k| !k.trim().is_empty())
-        }
-        ApiProvider::Openrouter => {
-            std::env::var("OPENROUTER_API_KEY").is_ok_and(|k| !k.trim().is_empty())
-        }
-        ApiProvider::Novita => std::env::var("NOVITA_API_KEY").is_ok_and(|k| !k.trim().is_empty()),
-        ApiProvider::Fireworks => {
-            std::env::var("FIREWORKS_API_KEY").is_ok_and(|k| !k.trim().is_empty())
-        }
         ApiProvider::Moonshot => {
             std::env::var("MOONSHOT_API_KEY").is_ok_and(|k| !k.trim().is_empty())
                 || std::env::var("KIMI_API_KEY").is_ok_and(|k| !k.trim().is_empty())
@@ -3561,12 +3222,6 @@ pub fn has_api_key_for(config: &Config, provider: ApiProvider) -> bool {
     let env_var = match provider {
         ApiProvider::Deepseek | ApiProvider::DeepseekCN => "DEEPSEEK_API_KEY",
         ApiProvider::NvidiaNim => "NVIDIA_API_KEY",
-        ApiProvider::Openai => "OPENAI_API_KEY",
-        ApiProvider::Atlascloud => "ATLASCLOUD_API_KEY",
-        ApiProvider::WanjieArk => "WANJIE_ARK_API_KEY",
-        ApiProvider::Openrouter => "OPENROUTER_API_KEY",
-        ApiProvider::Novita => "NOVITA_API_KEY",
-        ApiProvider::Fireworks => "FIREWORKS_API_KEY",
         ApiProvider::Moonshot => "MOONSHOT_API_KEY",
         ApiProvider::Sglang => "SGLANG_API_KEY",
         ApiProvider::Vllm => "VLLM_API_KEY",
@@ -3577,12 +3232,6 @@ pub fn has_api_key_for(config: &Config, provider: ApiProvider) -> bool {
     }
     if matches!(provider, ApiProvider::NvidiaNim)
         && std::env::var("NVIDIA_NIM_API_KEY").is_ok_and(|k| !k.trim().is_empty())
-    {
-        return true;
-    }
-    if matches!(provider, ApiProvider::WanjieArk)
-        && (std::env::var("WANJIE_API_KEY").is_ok_and(|k| !k.trim().is_empty())
-            || std::env::var("WANJIE_MAAS_API_KEY").is_ok_and(|k| !k.trim().is_empty()))
     {
         return true;
     }
@@ -3655,12 +3304,6 @@ pub fn save_api_key_for(provider: ApiProvider, api_key: &str) -> Result<PathBuf>
             ));
         }
         ApiProvider::NvidiaNim => "providers.nvidia_nim",
-        ApiProvider::Openai => "providers.openai",
-        ApiProvider::Atlascloud => "providers.atlascloud",
-        ApiProvider::WanjieArk => "providers.wanjie_ark",
-        ApiProvider::Openrouter => "providers.openrouter",
-        ApiProvider::Novita => "providers.novita",
-        ApiProvider::Fireworks => "providers.fireworks",
         ApiProvider::Moonshot => "providers.moonshot",
         ApiProvider::Sglang => "providers.sglang",
         ApiProvider::Vllm => "providers.vllm",
@@ -3692,12 +3335,6 @@ pub fn save_api_key_for(provider: ApiProvider, api_key: &str) -> Result<PathBuf>
             ));
         }
         ApiProvider::NvidiaNim => "nvidia_nim",
-        ApiProvider::Openai => "openai",
-        ApiProvider::Atlascloud => "atlascloud",
-        ApiProvider::WanjieArk => "wanjie_ark",
-        ApiProvider::Openrouter => "openrouter",
-        ApiProvider::Novita => "novita",
-        ApiProvider::Fireworks => "fireworks",
         ApiProvider::Moonshot => "moonshot",
         ApiProvider::Sglang => "sglang",
         ApiProvider::Vllm => "vllm",
@@ -3781,12 +3418,6 @@ fn provider_config_key(provider: ApiProvider) -> Result<&'static str> {
             anyhow::bail!("DeepSeek stores auth at the root config level")
         }
         ApiProvider::NvidiaNim => Ok("nvidia_nim"),
-        ApiProvider::Openai => Ok("openai"),
-        ApiProvider::Atlascloud => Ok("atlascloud"),
-        ApiProvider::WanjieArk => Ok("wanjie_ark"),
-        ApiProvider::Openrouter => Ok("openrouter"),
-        ApiProvider::Novita => Ok("novita"),
-        ApiProvider::Fireworks => Ok("fireworks"),
         ApiProvider::Moonshot => Ok("moonshot"),
         ApiProvider::Sglang => Ok("sglang"),
         ApiProvider::Vllm => Ok("vllm"),
@@ -4657,20 +4288,8 @@ mod tests {
             "nvidia-nim" => {
                 providers.nvidia_nim.api_key = Some(api_key.to_string());
             }
-            "openai" => {
-                providers.openai.api_key = Some(api_key.to_string());
-            }
-            "wanjie-ark" => {
-                providers.wanjie_ark.api_key = Some(api_key.to_string());
-            }
-            "openrouter" => {
-                providers.openrouter.api_key = Some(api_key.to_string());
-            }
-            "novita" => {
-                providers.novita.api_key = Some(api_key.to_string());
-            }
-            "fireworks" => {
-                providers.fireworks.api_key = Some(api_key.to_string());
+            "moonshot" | "kimi" => {
+                providers.moonshot.api_key = Some(api_key.to_string());
             }
             "sglang" => {
                 providers.sglang.api_key = Some(api_key.to_string());
@@ -4693,7 +4312,7 @@ mod tests {
 
     #[test]
     fn has_api_key_uses_active_provider_scoped_config_key() {
-        for provider in ["openai", "wanjie-ark", "openrouter", "novita", "fireworks"] {
+        for provider in ["moonshot", "nvidia-nim"] {
             let config = config_with_provider_scoped_key(provider, "provider-config-key");
 
             assert!(
@@ -4707,11 +4326,8 @@ mod tests {
     fn has_api_key_uses_active_provider_env_key() -> Result<()> {
         let _lock = lock_test_env();
         for (provider, env_var) in [
-            ("openai", "OPENAI_API_KEY"),
-            ("wanjie-ark", "WANJIE_ARK_API_KEY"),
-            ("openrouter", "OPENROUTER_API_KEY"),
-            ("novita", "NOVITA_API_KEY"),
-            ("fireworks", "FIREWORKS_API_KEY"),
+            ("moonshot", "MOONSHOT_API_KEY"),
+            ("nvidia-nim", "NVIDIA_API_KEY"),
         ] {
             unsafe {
                 std::env::set_var(env_var, "provider-env-key");
@@ -5219,9 +4835,8 @@ api_key = "old-openrouter-key"
             Some(DEFAULT_NVIDIA_NIM_MODEL)
         );
         assert_eq!(
-            normalize_model_name_for_provider(ApiProvider::Openrouter, "deepseek-v4-flash")
-                .as_deref(),
-            Some(DEFAULT_OPENROUTER_FLASH_MODEL)
+            normalize_model_name_for_provider(ApiProvider::Sglang, "deepseek-v4-flash").as_deref(),
+            Some(DEFAULT_SGLANG_FLASH_MODEL)
         );
     }
 
@@ -5654,189 +5269,9 @@ http_headers = { "X-Model-Provider-Id" = "from-file" }
         Ok(())
     }
 
-    #[test]
-    fn openai_provider_uses_openai_compatible_defaults() -> Result<()> {
-        let config = Config {
-            provider: Some("openai".to_string()),
-            ..Default::default()
-        };
-
-        config.validate()?;
-        assert_eq!(config.api_provider(), ApiProvider::Openai);
-        assert_eq!(config.default_model(), DEFAULT_OPENAI_MODEL);
-        assert_eq!(config.deepseek_base_url(), DEFAULT_OPENAI_BASE_URL);
-        Ok(())
-    }
-
-    #[test]
-    fn atlascloud_provider_uses_documented_defaults() -> Result<()> {
-        let config = Config {
-            provider: Some("atlascloud".to_string()),
-            ..Default::default()
-        };
-
-        config.validate()?;
-        assert_eq!(config.api_provider(), ApiProvider::Atlascloud);
-        assert_eq!(config.default_model(), DEFAULT_ATLASCLOUD_MODEL);
-        assert_eq!(config.deepseek_base_url(), DEFAULT_ATLASCLOUD_BASE_URL);
-        Ok(())
-    }
-
-    #[test]
-    fn atlascloud_env_overrides_provider_base_url_and_model() -> Result<()> {
-        let _lock = lock_test_env();
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        let temp_root = env::temp_dir().join(format!(
-            "codewhale-tui-atlascloud-env-test-{}-{}",
-            std::process::id(),
-            nanos
-        ));
-        fs::create_dir_all(&temp_root)?;
-        let _guard = EnvGuard::new(&temp_root);
-
-        unsafe {
-            env::set_var("DEEPSEEK_PROVIDER", "atlascloud");
-            env::set_var("ATLASCLOUD_API_KEY", "atlascloud-env-key");
-            env::set_var("ATLASCLOUD_BASE_URL", "https://api.atlascloud.ai/v1");
-            env::set_var("ATLASCLOUD_MODEL", "deepseek-ai/deepseek-v4-flash");
-        }
-
-        let config = Config::load(None, None)?;
-        assert_eq!(config.api_provider(), ApiProvider::Atlascloud);
-        assert_eq!(config.deepseek_api_key()?, "atlascloud-env-key");
-        assert_eq!(config.deepseek_base_url(), "https://api.atlascloud.ai/v1");
-        assert_eq!(config.default_model(), "deepseek-ai/deepseek-v4-flash");
-        Ok(())
-    }
-
-    #[test]
-    fn wanjie_ark_provider_uses_documented_defaults() -> Result<()> {
-        let config = Config {
-            provider: Some("wanjie-ark".to_string()),
-            ..Default::default()
-        };
-
-        config.validate()?;
-        assert_eq!(config.api_provider(), ApiProvider::WanjieArk);
-        assert_eq!(config.default_model(), DEFAULT_WANJIE_ARK_MODEL);
-        assert_eq!(config.deepseek_base_url(), DEFAULT_WANJIE_ARK_BASE_URL);
-        Ok(())
-    }
-
-    #[test]
-    fn wanjie_ark_env_overrides_provider_base_url_model_and_key() -> Result<()> {
-        let _lock = lock_test_env();
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        let temp_root = env::temp_dir().join(format!(
-            "codewhale-tui-wanjie-env-test-{}-{}",
-            std::process::id(),
-            nanos
-        ));
-        fs::create_dir_all(&temp_root)?;
-        let _guard = EnvGuard::new(&temp_root);
-
-        unsafe {
-            env::set_var("DEEPSEEK_PROVIDER", "ark-wanjie");
-            env::set_var("WANJIE_ARK_API_KEY", "wanjie-env-key");
-            env::set_var("WANJIE_ARK_BASE_URL", "https://wanjie.example/api/v1");
-            env::set_var("WANJIE_ARK_MODEL", "wanjie-model-id");
-        }
-
-        let config = Config::load(None, None)?;
-        assert_eq!(config.api_provider(), ApiProvider::WanjieArk);
-        assert_eq!(config.deepseek_api_key()?, "wanjie-env-key");
-        assert_eq!(config.deepseek_base_url(), "https://wanjie.example/api/v1");
-        assert_eq!(config.default_model(), "wanjie-model-id");
-        Ok(())
-    }
-
-    #[test]
-    fn wanjie_ark_provider_accepts_custom_model_and_table_key() -> Result<()> {
-        let _lock = lock_test_env();
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        let temp_root = env::temp_dir().join(format!(
-            "codewhale-tui-wanjie-table-{}-{}",
-            std::process::id(),
-            nanos
-        ));
-        fs::create_dir_all(&temp_root)?;
-        let _guard = EnvGuard::new(&temp_root);
-
-        let config_path = temp_root.join(".deepseek").join("config.toml");
-        ensure_parent_dir(&config_path)?;
-        fs::write(
-            &config_path,
-            r#"provider = "wanjie-ark"
-
-[providers.wanjie_ark]
-api_key = "wanjie-table-key"
-base_url = "https://maas-openapi.wanjiedata.com/api/v1"
-model = "account-model-id"
-"#,
-        )?;
-
-        let config = Config::load(None, None)?;
-        assert_eq!(config.api_provider(), ApiProvider::WanjieArk);
-        assert_eq!(config.deepseek_api_key()?, "wanjie-table-key");
-        assert_eq!(
-            config.deepseek_base_url(),
-            "https://maas-openapi.wanjiedata.com/api/v1"
-        );
-        assert_eq!(config.default_model(), "account-model-id");
-        Ok(())
-    }
-
-    #[test]
-    fn openai_provider_accepts_custom_model_and_base_url() -> Result<()> {
-        let _lock = lock_test_env();
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        let temp_root = env::temp_dir().join(format!(
-            "codewhale-tui-openai-table-{}-{}",
-            std::process::id(),
-            nanos
-        ));
-        fs::create_dir_all(&temp_root)?;
-        let _guard = EnvGuard::new(&temp_root);
-
-        let config_path = temp_root.join(".deepseek").join("config.toml");
-        ensure_parent_dir(&config_path)?;
-        fs::write(
-            &config_path,
-            r#"provider = "openai"
-
-[providers.openai]
-api_key = "openai-table-key"
-base_url = "https://openai-compatible.example/api/coding/paas/v4"
-model = "glm-5"
-"#,
-        )?;
-
-        let config = Config::load(None, None)?;
-        assert_eq!(config.api_provider(), ApiProvider::Openai);
-        assert_eq!(config.deepseek_api_key()?, "openai-table-key");
-        assert_eq!(
-            config.deepseek_base_url(),
-            "https://openai-compatible.example/api/coding/paas/v4"
-        );
-        assert_eq!(config.default_model(), "glm-5");
-        Ok(())
-    }
-
-    // Regression for issue #1714: `codewhale --provider openai --model
-    // MiniMax-M2.7` forwards the choice via DEEPSEEK_MODEL (never
-    // OPENAI_MODEL) and uses the DEFAULT base_url. The explicit custom model
+    // Regression for issue #1714: `codewhale --provider moonshot --model
+    // some-custom-model` forwards the choice via DEEPSEEK_MODEL (never
+    // MOONSHOT_MODEL) and uses the DEFAULT base_url. The explicit custom model
     // must pass through verbatim instead of silently becoming a
     // DeepSeek/provider default.
     #[test]
@@ -5853,188 +5288,19 @@ model = "glm-5"
         ));
         fs::create_dir_all(&temp_root)?;
 
-        // (a) provider=openai + model="MiniMax-M2.7" via env, NO OPENAI_MODEL,
-        // DEFAULT base_url.
-        {
-            let _guard = EnvGuard::new(&temp_root);
-            // Safety: test-only environment mutation guarded by a global mutex.
-            unsafe {
-                env::set_var("DEEPSEEK_PROVIDER", "openai");
-                env::set_var("OPENAI_API_KEY", "openai-env-key");
-                env::set_var("DEEPSEEK_MODEL", "MiniMax-M2.7");
-            }
-
-            let config = Config::load(None, None)?;
-            assert_eq!(config.api_provider(), ApiProvider::Openai);
-            assert_eq!(config.deepseek_base_url(), DEFAULT_OPENAI_BASE_URL);
-            assert_eq!(config.default_model(), "MiniMax-M2.7");
-        }
-
-        // (b) a non-passthrough provider (novita) with an unknown custom model
-        // and the DEFAULT base_url must also be preserved verbatim — never
-        // rewritten to DEFAULT_NOVITA_MODEL.
-        {
-            let _guard = EnvGuard::new(&temp_root);
-            // Safety: test-only environment mutation guarded by a global mutex.
-            unsafe {
-                env::set_var("DEEPSEEK_PROVIDER", "novita");
-                env::set_var("NOVITA_API_KEY", "novita-env-key");
-                env::set_var("DEEPSEEK_MODEL", "MiniMax-M2.7");
-            }
-
-            let config = Config::load(None, None)?;
-            assert_eq!(config.api_provider(), ApiProvider::Novita);
-            assert_eq!(config.deepseek_base_url(), DEFAULT_NOVITA_BASE_URL);
-            assert_ne!(config.default_model(), DEFAULT_NOVITA_MODEL);
-            assert_eq!(config.default_model(), "MiniMax-M2.7");
-        }
-
-        Ok(())
-    }
-
-    #[test]
-    fn openai_env_overrides_provider_base_url_and_model() -> Result<()> {
-        let _lock = lock_test_env();
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        let temp_root = env::temp_dir().join(format!(
-            "codewhale-tui-openai-env-test-{}-{}",
-            std::process::id(),
-            nanos
-        ));
-        fs::create_dir_all(&temp_root)?;
         let _guard = EnvGuard::new(&temp_root);
-
         // Safety: test-only environment mutation guarded by a global mutex.
         unsafe {
-            env::set_var("DEEPSEEK_PROVIDER", "openai");
-            env::set_var("OPENAI_API_KEY", "openai-env-key");
-            env::set_var("OPENAI_BASE_URL", "https://openai-compatible.example/v4");
-            env::set_var("OPENAI_MODEL", "glm-5");
+            env::set_var("DEEPSEEK_PROVIDER", "moonshot");
+            env::set_var("MOONSHOT_API_KEY", "moonshot-env-key");
+            env::set_var("DEEPSEEK_MODEL", "kimi-experimental");
         }
 
         let config = Config::load(None, None)?;
-        assert_eq!(config.api_provider(), ApiProvider::Openai);
-        assert_eq!(config.deepseek_api_key()?, "openai-env-key");
-        assert_eq!(
-            config.deepseek_base_url(),
-            "https://openai-compatible.example/v4"
-        );
-        assert_eq!(config.default_model(), "glm-5");
-        Ok(())
-    }
+        assert_eq!(config.api_provider(), ApiProvider::Moonshot);
+        assert_eq!(config.deepseek_base_url(), DEFAULT_MOONSHOT_BASE_URL);
+        assert_eq!(config.default_model(), "kimi-experimental");
 
-    #[test]
-    fn openai_env_accepts_facade_base_url_forwarding() -> Result<()> {
-        let _lock = lock_test_env();
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        let temp_root = env::temp_dir().join(format!(
-            "codewhale-tui-openai-forwarded-base-url-test-{}-{}",
-            std::process::id(),
-            nanos
-        ));
-        fs::create_dir_all(&temp_root)?;
-        let _guard = EnvGuard::new(&temp_root);
-
-        // Safety: test-only environment mutation guarded by a global mutex.
-        unsafe {
-            env::set_var("DEEPSEEK_PROVIDER", "openai");
-            env::set_var("OPENAI_API_KEY", "forwarded-openai-key");
-            env::set_var("DEEPSEEK_BASE_URL", "https://forwarded-openai.example/v4");
-            env::set_var("DEEPSEEK_MODEL", "glm-5");
-        }
-
-        let config = Config::load(None, None)?;
-        assert_eq!(config.api_provider(), ApiProvider::Openai);
-        assert_eq!(config.deepseek_api_key()?, "forwarded-openai-key");
-        assert_eq!(
-            config.deepseek_base_url(),
-            "https://forwarded-openai.example/v4"
-        );
-        assert_eq!(config.default_model(), "glm-5");
-        Ok(())
-    }
-
-    #[test]
-    fn openrouter_provider_uses_canonical_defaults() -> Result<()> {
-        let _lock = lock_test_env();
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        let temp_root = env::temp_dir().join(format!(
-            "codewhale-tui-or-defaults-{}-{}",
-            std::process::id(),
-            nanos
-        ));
-        fs::create_dir_all(&temp_root)?;
-        let _guard = EnvGuard::new(&temp_root);
-
-        let config = Config {
-            provider: Some("openrouter".to_string()),
-            ..Default::default()
-        };
-        config.validate()?;
-        assert_eq!(config.api_provider(), ApiProvider::Openrouter);
-        assert_eq!(config.default_model(), DEFAULT_OPENROUTER_MODEL);
-        assert_eq!(config.deepseek_base_url(), DEFAULT_OPENROUTER_BASE_URL);
-        Ok(())
-    }
-
-    #[test]
-    fn novita_provider_uses_canonical_defaults() -> Result<()> {
-        let _lock = lock_test_env();
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        let temp_root = env::temp_dir().join(format!(
-            "codewhale-tui-novita-defaults-{}-{}",
-            std::process::id(),
-            nanos
-        ));
-        fs::create_dir_all(&temp_root)?;
-        let _guard = EnvGuard::new(&temp_root);
-
-        let config = Config {
-            provider: Some("novita".to_string()),
-            ..Default::default()
-        };
-        config.validate()?;
-        assert_eq!(config.api_provider(), ApiProvider::Novita);
-        assert_eq!(config.default_model(), DEFAULT_NOVITA_MODEL);
-        assert_eq!(config.deepseek_base_url(), DEFAULT_NOVITA_BASE_URL);
-        Ok(())
-    }
-
-    #[test]
-    fn fireworks_provider_uses_canonical_defaults() -> Result<()> {
-        let _lock = lock_test_env();
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        let temp_root = env::temp_dir().join(format!(
-            "codewhale-tui-fireworks-defaults-{}-{}",
-            std::process::id(),
-            nanos
-        ));
-        fs::create_dir_all(&temp_root)?;
-        let _guard = EnvGuard::new(&temp_root);
-
-        let config = Config {
-            provider: Some("fireworks".to_string()),
-            ..Default::default()
-        };
-        config.validate()?;
-        assert_eq!(config.api_provider(), ApiProvider::Fireworks);
-        assert_eq!(config.default_model(), DEFAULT_FIREWORKS_MODEL);
-        assert_eq!(config.deepseek_base_url(), DEFAULT_FIREWORKS_BASE_URL);
         Ok(())
     }
 
@@ -6193,190 +5459,6 @@ model = "qwen2.5-coder:7b"
     }
 
     #[test]
-    fn openrouter_env_api_key_resolves_via_deepseek_api_key() -> Result<()> {
-        let _lock = lock_test_env();
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        let temp_root = env::temp_dir().join(format!(
-            "codewhale-tui-or-env-key-{}-{}",
-            std::process::id(),
-            nanos
-        ));
-        fs::create_dir_all(&temp_root)?;
-        let _guard = EnvGuard::new(&temp_root);
-
-        // Safety: test-only environment mutation guarded by a global mutex.
-        unsafe {
-            env::set_var("DEEPSEEK_PROVIDER", "openrouter");
-            env::set_var("OPENROUTER_API_KEY", "or-env-key");
-        }
-
-        let config = Config::load(None, None)?;
-        assert_eq!(config.api_provider(), ApiProvider::Openrouter);
-        assert_eq!(config.deepseek_api_key()?, "or-env-key");
-        Ok(())
-    }
-
-    #[test]
-    fn novita_env_api_key_resolves_via_deepseek_api_key() -> Result<()> {
-        let _lock = lock_test_env();
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        let temp_root = env::temp_dir().join(format!(
-            "codewhale-tui-novita-env-key-{}-{}",
-            std::process::id(),
-            nanos
-        ));
-        fs::create_dir_all(&temp_root)?;
-        let _guard = EnvGuard::new(&temp_root);
-
-        // Safety: test-only environment mutation guarded by a global mutex.
-        unsafe {
-            env::set_var("DEEPSEEK_PROVIDER", "novita");
-            env::set_var("NOVITA_API_KEY", "novita-env-key");
-        }
-
-        let config = Config::load(None, None)?;
-        assert_eq!(config.api_provider(), ApiProvider::Novita);
-        assert_eq!(config.deepseek_api_key()?, "novita-env-key");
-        Ok(())
-    }
-
-    #[test]
-    fn openrouter_base_url_env_overrides_default() -> Result<()> {
-        let _lock = lock_test_env();
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        let temp_root = env::temp_dir().join(format!(
-            "codewhale-tui-or-base-url-{}-{}",
-            std::process::id(),
-            nanos
-        ));
-        fs::create_dir_all(&temp_root)?;
-        let _guard = EnvGuard::new(&temp_root);
-
-        // Safety: test-only environment mutation guarded by a global mutex.
-        unsafe {
-            env::set_var("DEEPSEEK_PROVIDER", "openrouter");
-            env::set_var("OPENROUTER_BASE_URL", "https://or-mirror.example/v1");
-        }
-
-        let config = Config::load(None, None)?;
-        assert_eq!(config.api_provider(), ApiProvider::Openrouter);
-        assert_eq!(config.deepseek_base_url(), "https://or-mirror.example/v1");
-        Ok(())
-    }
-
-    #[test]
-    fn openrouter_reads_provider_table_from_config_file() -> Result<()> {
-        let _lock = lock_test_env();
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        let temp_root = env::temp_dir().join(format!(
-            "codewhale-tui-or-table-{}-{}",
-            std::process::id(),
-            nanos
-        ));
-        fs::create_dir_all(&temp_root)?;
-        let _guard = EnvGuard::new(&temp_root);
-
-        let config_path = temp_root.join(".deepseek").join("config.toml");
-        ensure_parent_dir(&config_path)?;
-        fs::write(
-            &config_path,
-            r#"provider = "openrouter"
-
-[providers.openrouter]
-api_key = "or-table-key"
-base_url = "https://or-table.example/v1"
-"#,
-        )?;
-
-        let config = Config::load(None, None)?;
-        assert_eq!(config.api_provider(), ApiProvider::Openrouter);
-        assert_eq!(config.deepseek_api_key()?, "or-table-key");
-        assert_eq!(config.deepseek_base_url(), "https://or-table.example/v1");
-        Ok(())
-    }
-
-    #[test]
-    fn openrouter_custom_base_url_preserves_provider_model() -> Result<()> {
-        let _lock = lock_test_env();
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        let temp_root = env::temp_dir().join(format!(
-            "codewhale-tui-or-custom-model-{}-{}",
-            std::process::id(),
-            nanos
-        ));
-        fs::create_dir_all(&temp_root)?;
-        let _guard = EnvGuard::new(&temp_root);
-
-        let config_path = temp_root.join(".deepseek").join("config.toml");
-        ensure_parent_dir(&config_path)?;
-        fs::write(
-            &config_path,
-            r#"provider = "openrouter"
-
-[providers.openrouter]
-api_key = "or-table-key"
-base_url = "https://gateway.example.com/v1"
-model = "DeepSeek-V4-Pro"
-"#,
-        )?;
-
-        let config = Config::load(None, None)?;
-        assert_eq!(config.api_provider(), ApiProvider::Openrouter);
-        assert_eq!(config.deepseek_api_key()?, "or-table-key");
-        assert_eq!(config.deepseek_base_url(), "https://gateway.example.com/v1");
-        assert_eq!(config.default_model(), "DeepSeek-V4-Pro");
-        Ok(())
-    }
-
-    #[test]
-    fn novita_reads_provider_table_from_config_file() -> Result<()> {
-        let _lock = lock_test_env();
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        let temp_root = env::temp_dir().join(format!(
-            "codewhale-tui-novita-table-{}-{}",
-            std::process::id(),
-            nanos
-        ));
-        fs::create_dir_all(&temp_root)?;
-        let _guard = EnvGuard::new(&temp_root);
-
-        let config_path = temp_root.join(".deepseek").join("config.toml");
-        ensure_parent_dir(&config_path)?;
-        fs::write(
-            &config_path,
-            r#"provider = "novita"
-
-[providers.novita]
-api_key = "novita-table-key"
-"#,
-        )?;
-
-        let config = Config::load(None, None)?;
-        assert_eq!(config.api_provider(), ApiProvider::Novita);
-        assert_eq!(config.deepseek_api_key()?, "novita-table-key");
-        assert_eq!(config.deepseek_base_url(), DEFAULT_NOVITA_BASE_URL);
-        Ok(())
-    }
-
-    #[test]
     fn moonshot_kimi_oauth_reads_fresh_cli_credential() -> Result<()> {
         let _lock = lock_test_env();
         let nanos = SystemTime::now()
@@ -6450,9 +5532,8 @@ api_key = "stale-api-key"
         let _guard = EnvGuard::new(&temp_root);
 
         let mut config = Config::default();
-        assert!(!has_api_key_for(&config, ApiProvider::Openai));
-        assert!(!has_api_key_for(&config, ApiProvider::WanjieArk));
-        assert!(!has_api_key_for(&config, ApiProvider::Openrouter));
+        assert!(!has_api_key_for(&config, ApiProvider::NvidiaNim));
+        assert!(!has_api_key_for(&config, ApiProvider::Moonshot));
         assert!(
             has_api_key_for(&config, ApiProvider::Sglang),
             "SGLang is self-hosted and does not require a key by default"
@@ -6464,30 +5545,23 @@ api_key = "stale-api-key"
 
         // Safety: test-only environment mutation guarded by a global mutex.
         unsafe {
-            env::set_var("OPENROUTER_API_KEY", "or-env");
-            env::set_var("OPENAI_API_KEY", "openai-env");
-            env::set_var("WANJIE_API_KEY", "wanjie-env");
+            env::set_var("NVIDIA_API_KEY", "nim-env");
+            env::set_var("MOONSHOT_API_KEY", "moonshot-env");
         }
-        assert!(has_api_key_for(&config, ApiProvider::Openai));
-        assert!(has_api_key_for(&config, ApiProvider::WanjieArk));
-        assert!(has_api_key_for(&config, ApiProvider::Openrouter));
-        assert!(!has_api_key_for(&config, ApiProvider::Novita));
+        assert!(has_api_key_for(&config, ApiProvider::NvidiaNim));
+        assert!(has_api_key_for(&config, ApiProvider::Moonshot));
 
         // Safety: test-only environment mutation guarded by a global mutex.
         unsafe {
-            env::remove_var("OPENROUTER_API_KEY");
-            env::remove_var("OPENAI_API_KEY");
-            env::remove_var("WANJIE_API_KEY");
+            env::remove_var("NVIDIA_API_KEY");
+            env::remove_var("MOONSHOT_API_KEY");
         }
         let mut providers = ProvidersConfig::default();
-        providers.openai.api_key = Some("file-openai".to_string());
-        providers.wanjie_ark.api_key = Some("file-wanjie".to_string());
-        providers.novita.api_key = Some("file-novita".to_string());
+        providers.nvidia_nim.api_key = Some("file-nim".to_string());
+        providers.moonshot.api_key = Some("file-moonshot".to_string());
         config.providers = Some(providers);
-        assert!(has_api_key_for(&config, ApiProvider::Openai));
-        assert!(has_api_key_for(&config, ApiProvider::WanjieArk));
-        assert!(has_api_key_for(&config, ApiProvider::Novita));
-        assert!(!has_api_key_for(&config, ApiProvider::Openrouter));
+        assert!(has_api_key_for(&config, ApiProvider::NvidiaNim));
+        assert!(has_api_key_for(&config, ApiProvider::Moonshot));
         Ok(())
     }
 
@@ -6526,94 +5600,6 @@ api_key = "stale-api-key"
 
         assert!(has_api_key_for(&config, ApiProvider::Deepseek));
         assert!(has_api_key_for(&config, ApiProvider::DeepseekCN));
-    }
-
-    #[test]
-    fn save_api_key_for_openrouter_writes_provider_table() -> Result<()> {
-        let _lock = lock_test_env();
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        let temp_root = env::temp_dir().join(format!(
-            "codewhale-tui-save-key-or-{}-{}",
-            std::process::id(),
-            nanos
-        ));
-        fs::create_dir_all(&temp_root)?;
-        let _guard = EnvGuard::new(&temp_root);
-        unsafe { std::env::set_var("DEEPSEEK_SECRET_BACKEND", "local") };
-
-        let path = save_api_key_for(ApiProvider::Openrouter, "or-saved-key")?;
-        let contents = fs::read_to_string(&path)?;
-        let parsed: toml::Value = toml::from_str(&contents)?;
-        assert_eq!(
-            parsed
-                .get("providers")
-                .and_then(|p| p.get("openrouter"))
-                .and_then(|t| t.get("api_key"))
-                .and_then(toml::Value::as_str),
-            Some("or-saved-key")
-        );
-        // Re-saving must not duplicate or wipe sibling tables.
-        save_api_key_for(ApiProvider::Novita, "novita-saved-key")?;
-        let contents = fs::read_to_string(&path)?;
-        let parsed: toml::Value = toml::from_str(&contents)?;
-        assert_eq!(
-            parsed
-                .get("providers")
-                .and_then(|p| p.get("openrouter"))
-                .and_then(|t| t.get("api_key"))
-                .and_then(toml::Value::as_str),
-            Some("or-saved-key")
-        );
-        assert_eq!(
-            parsed
-                .get("providers")
-                .and_then(|p| p.get("novita"))
-                .and_then(|t| t.get("api_key"))
-                .and_then(toml::Value::as_str),
-            Some("novita-saved-key")
-        );
-        save_api_key_for(ApiProvider::Openai, "openai-saved-key")?;
-        save_api_key_for(ApiProvider::WanjieArk, "wanjie-saved-key")?;
-        save_api_key_for(ApiProvider::Fireworks, "fireworks-saved-key")?;
-        save_api_key_for(ApiProvider::Sglang, "sglang-saved-key")?;
-        let contents = fs::read_to_string(&path)?;
-        let parsed: toml::Value = toml::from_str(&contents)?;
-        assert_eq!(
-            parsed
-                .get("providers")
-                .and_then(|p| p.get("openai"))
-                .and_then(|t| t.get("api_key"))
-                .and_then(toml::Value::as_str),
-            Some("openai-saved-key")
-        );
-        assert_eq!(
-            parsed
-                .get("providers")
-                .and_then(|p| p.get("wanjie_ark"))
-                .and_then(|t| t.get("api_key"))
-                .and_then(toml::Value::as_str),
-            Some("wanjie-saved-key")
-        );
-        assert_eq!(
-            parsed
-                .get("providers")
-                .and_then(|p| p.get("fireworks"))
-                .and_then(|t| t.get("api_key"))
-                .and_then(toml::Value::as_str),
-            Some("fireworks-saved-key")
-        );
-        assert_eq!(
-            parsed
-                .get("providers")
-                .and_then(|p| p.get("sglang"))
-                .and_then(|t| t.get("api_key"))
-                .and_then(toml::Value::as_str),
-            Some("sglang-saved-key")
-        );
-        Ok(())
     }
 
     #[test]
@@ -6824,47 +5810,6 @@ model = "deepseek-ai/deepseek-v4-pro"
     }
 
     #[test]
-    fn provider_capability_openrouter_v4_pro_has_thinking_no_cache() {
-        let cap = provider_capability(ApiProvider::Openrouter, DEFAULT_OPENROUTER_MODEL);
-        assert_eq!(
-            cap.context_window,
-            crate::models::DEEPSEEK_V4_CONTEXT_WINDOW_TOKENS
-        );
-        assert_eq!(cap.max_output, 384_000);
-        assert!(cap.thinking_supported);
-        // OpenRouter does not return DeepSeek prompt-cache telemetry.
-        assert!(!cap.cache_telemetry_supported);
-        assert_eq!(
-            cap.request_payload_mode,
-            RequestPayloadMode::ChatCompletions
-        );
-    }
-
-    #[test]
-    fn provider_capability_novita_v4_pro_has_thinking_no_cache() {
-        let cap = provider_capability(ApiProvider::Novita, DEFAULT_NOVITA_MODEL);
-        assert_eq!(
-            cap.context_window,
-            crate::models::DEEPSEEK_V4_CONTEXT_WINDOW_TOKENS
-        );
-        assert_eq!(cap.max_output, 384_000);
-        assert!(cap.thinking_supported);
-        assert!(!cap.cache_telemetry_supported);
-    }
-
-    #[test]
-    fn provider_capability_fireworks_v4_pro_has_thinking_no_cache() {
-        let cap = provider_capability(ApiProvider::Fireworks, DEFAULT_FIREWORKS_MODEL);
-        assert_eq!(
-            cap.context_window,
-            crate::models::DEEPSEEK_V4_CONTEXT_WINDOW_TOKENS
-        );
-        assert_eq!(cap.max_output, 384_000);
-        assert!(cap.thinking_supported);
-        assert!(!cap.cache_telemetry_supported);
-    }
-
-    #[test]
     fn provider_capability_sglang_v4_pro_has_thinking_no_cache() {
         let cap = provider_capability(ApiProvider::Sglang, DEFAULT_SGLANG_MODEL);
         assert_eq!(
@@ -6874,67 +5819,6 @@ model = "deepseek-ai/deepseek-v4-pro"
         assert_eq!(cap.max_output, 384_000);
         assert!(cap.thinking_supported);
         assert!(!cap.cache_telemetry_supported);
-    }
-
-    #[test]
-    fn provider_capability_openai_custom_model_is_chat_completions_without_thinking() {
-        let cap = provider_capability(ApiProvider::Openai, "glm-5");
-        assert_eq!(
-            cap.context_window,
-            crate::models::LEGACY_DEEPSEEK_CONTEXT_WINDOW_TOKENS
-        );
-        assert_eq!(cap.max_output, 4096);
-        assert!(!cap.thinking_supported);
-        assert!(!cap.cache_telemetry_supported);
-        assert_eq!(
-            cap.request_payload_mode,
-            RequestPayloadMode::ChatCompletions
-        );
-    }
-
-    #[test]
-    fn provider_capability_atlascloud_custom_model_is_chat_completions_without_thinking() {
-        let cap = provider_capability(ApiProvider::Atlascloud, "deepseek-ai/deepseek-v4-flash");
-        assert_eq!(
-            cap.context_window,
-            crate::models::LEGACY_DEEPSEEK_CONTEXT_WINDOW_TOKENS
-        );
-        assert_eq!(cap.max_output, 4096);
-        assert!(!cap.thinking_supported);
-        assert!(!cap.cache_telemetry_supported);
-        assert_eq!(
-            cap.request_payload_mode,
-            RequestPayloadMode::ChatCompletions
-        );
-    }
-
-    #[test]
-    fn provider_capability_wanjie_ark_reasoner_has_thinking_no_cache() {
-        let cap = provider_capability(ApiProvider::WanjieArk, DEFAULT_WANJIE_ARK_MODEL);
-        assert_eq!(
-            cap.context_window,
-            crate::models::LEGACY_DEEPSEEK_CONTEXT_WINDOW_TOKENS
-        );
-        assert_eq!(cap.max_output, 4096);
-        assert!(cap.thinking_supported);
-        assert!(!cap.cache_telemetry_supported);
-        assert_eq!(
-            cap.request_payload_mode,
-            RequestPayloadMode::ChatCompletions
-        );
-    }
-
-    #[test]
-    fn provider_capability_ollama_is_openai_compatible_without_thinking() {
-        let cap = provider_capability(ApiProvider::Ollama, "deepseek-v3.1:671b");
-        assert_eq!(cap.context_window, 8192);
-        assert_eq!(cap.max_output, 4096);
-        assert!(!cap.thinking_supported);
-        assert!(!cap.cache_telemetry_supported);
-        assert_eq!(
-            cap.request_payload_mode,
-            RequestPayloadMode::ChatCompletions
-        );
     }
 
     #[test]

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -2589,10 +2589,7 @@ fn auth_mode_uses_kimi_oauth(mode: &str) -> bool {
 }
 
 fn normalize_auth_mode(mode: &str) -> String {
-    mode.trim()
-        .to_ascii_lowercase()
-        .replace('-', "_")
-        .replace(' ', "_")
+    mode.trim().to_ascii_lowercase().replace(['-', ' '], "_")
 }
 
 fn base_url_uses_local_host(base_url: &str) -> bool {

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -365,12 +365,6 @@ impl Engine {
         let env_var = match provider {
             ApiProvider::Deepseek | ApiProvider::DeepseekCN => "DEEPSEEK_API_KEY",
             ApiProvider::NvidiaNim => "NVIDIA_API_KEY/NVIDIA_NIM_API_KEY",
-            ApiProvider::Openai => "OPENAI_API_KEY",
-            ApiProvider::Atlascloud => "ATLASCLOUD_API_KEY",
-            ApiProvider::WanjieArk => "WANJIE_ARK_API_KEY/WANJIE_API_KEY/WANJIE_MAAS_API_KEY",
-            ApiProvider::Openrouter => "OPENROUTER_API_KEY",
-            ApiProvider::Novita => "NOVITA_API_KEY",
-            ApiProvider::Fireworks => "FIREWORKS_API_KEY",
             ApiProvider::Moonshot => "MOONSHOT_API_KEY/KIMI_API_KEY",
             ApiProvider::Sglang => "SGLANG_API_KEY",
             ApiProvider::Vllm => "VLLM_API_KEY",

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -1838,30 +1838,6 @@ fn run_setup_status(config: &Config, workspace: &Path) -> Result<()> {
                     "NVIDIA_API_KEY",
                     "codewhale auth set --provider nvidia-nim --api-key \"...\"",
                 ),
-                crate::config::ApiProvider::Openai => (
-                    "OPENAI_API_KEY",
-                    "codewhale auth set --provider openai --api-key \"...\"",
-                ),
-                crate::config::ApiProvider::Atlascloud => (
-                    "ATLASCLOUD_API_KEY",
-                    "codewhale auth set --provider atlascloud --api-key \"...\"",
-                ),
-                crate::config::ApiProvider::WanjieArk => (
-                    "WANJIE_ARK_API_KEY",
-                    "codewhale auth set --provider wanjie-ark --api-key \"...\"",
-                ),
-                crate::config::ApiProvider::Openrouter => (
-                    "OPENROUTER_API_KEY",
-                    "codewhale auth set --provider openrouter --api-key \"...\"",
-                ),
-                crate::config::ApiProvider::Novita => (
-                    "NOVITA_API_KEY",
-                    "codewhale auth set --provider novita --api-key \"...\"",
-                ),
-                crate::config::ApiProvider::Fireworks => (
-                    "FIREWORKS_API_KEY",
-                    "codewhale auth set --provider fireworks --api-key \"...\"",
-                ),
                 crate::config::ApiProvider::Moonshot => (
                     "MOONSHOT_API_KEY/KIMI_API_KEY",
                     "codewhale auth set --provider moonshot --api-key \"...\"",
@@ -1886,12 +1862,6 @@ fn run_setup_status(config: &Config, workspace: &Path) -> Result<()> {
                 "✗".truecolor(red_r, red_g, red_b),
                 match config.api_provider() {
                     crate::config::ApiProvider::NvidiaNim => "nvidia_nim",
-                    crate::config::ApiProvider::Openai => "openai",
-                    crate::config::ApiProvider::Atlascloud => "atlascloud",
-                    crate::config::ApiProvider::WanjieArk => "wanjie_ark",
-                    crate::config::ApiProvider::Openrouter => "openrouter",
-                    crate::config::ApiProvider::Novita => "novita",
-                    crate::config::ApiProvider::Fireworks => "fireworks",
                     crate::config::ApiProvider::Moonshot => "moonshot",
                     crate::config::ApiProvider::Sglang => "sglang",
                     crate::config::ApiProvider::Vllm => "vllm",
@@ -2125,40 +2095,6 @@ async fn run_doctor(config: &Config, workspace: &Path, config_path_override: Opt
             crate::config::ApiProvider::NvidiaNim,
             "nvidia-nim",
             &["NVIDIA_API_KEY", "NVIDIA_NIM_API_KEY"][..],
-        ),
-        (
-            crate::config::ApiProvider::Openai,
-            "openai",
-            &["OPENAI_API_KEY"][..],
-        ),
-        (
-            crate::config::ApiProvider::Atlascloud,
-            "atlascloud",
-            &["ATLASCLOUD_API_KEY"][..],
-        ),
-        (
-            crate::config::ApiProvider::WanjieArk,
-            "wanjie-ark",
-            &[
-                "WANJIE_ARK_API_KEY",
-                "WANJIE_API_KEY",
-                "WANJIE_MAAS_API_KEY",
-            ][..],
-        ),
-        (
-            crate::config::ApiProvider::Openrouter,
-            "openrouter",
-            &["OPENROUTER_API_KEY"][..],
-        ),
-        (
-            crate::config::ApiProvider::Novita,
-            "novita",
-            &["NOVITA_API_KEY"][..],
-        ),
-        (
-            crate::config::ApiProvider::Fireworks,
-            "fireworks",
-            &["FIREWORKS_API_KEY"][..],
         ),
         (
             crate::config::ApiProvider::Moonshot,

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -4829,17 +4829,18 @@ mod tests {
         let config_path = tmp.path().join("config.toml");
         std::fs::write(
             tmp.path().join("settings.toml"),
-            "default_provider = \"openai\"\n",
+            "default_provider = \"moonshot\"\n",
         )
         .expect("settings");
         let _config_path = EnvVarGuard::set("DEEPSEEK_CONFIG_PATH", &config_path);
         let _deepseek_key = EnvVarGuard::remove("DEEPSEEK_API_KEY");
-        let _openai_key = EnvVarGuard::remove("OPENAI_API_KEY");
+        let _moonshot_key = EnvVarGuard::remove("MOONSHOT_API_KEY");
+        let _kimi_key = EnvVarGuard::remove("KIMI_API_KEY");
 
         let config = Config {
             providers: Some(ProvidersConfig {
-                openai: ProviderConfig {
-                    api_key: Some("openai-config-key".to_string()),
+                moonshot: ProviderConfig {
+                    api_key: Some("moonshot-config-key".to_string()),
                     ..ProviderConfig::default()
                 },
                 ..ProvidersConfig::default()
@@ -4849,10 +4850,10 @@ mod tests {
 
         let app = App::new(test_options(false), &config);
 
-        assert_eq!(app.api_provider, ApiProvider::Openai);
+        assert_eq!(app.api_provider, ApiProvider::Moonshot);
         assert!(
             !app.onboarding_needs_api_key,
-            "OpenAI provider config key should satisfy startup auth without a DeepSeek key"
+            "Moonshot provider config key should satisfy startup auth without a DeepSeek key"
         );
         assert_ne!(app.onboarding, OnboardingState::ApiKey);
         assert!(!app.api_key_env_only);

--- a/crates/tui/src/tui/provider_picker.rs
+++ b/crates/tui/src/tui/provider_picker.rs
@@ -88,12 +88,6 @@ impl ProviderPickerView {
         match provider {
             ApiProvider::Deepseek | ApiProvider::DeepseekCN => "DEEPSEEK_API_KEY",
             ApiProvider::NvidiaNim => "NVIDIA_API_KEY",
-            ApiProvider::Openai => "OPENAI_API_KEY",
-            ApiProvider::Atlascloud => "ATLASCLOUD_API_KEY",
-            ApiProvider::WanjieArk => "WANJIE_ARK_API_KEY",
-            ApiProvider::Openrouter => "OPENROUTER_API_KEY",
-            ApiProvider::Novita => "NOVITA_API_KEY",
-            ApiProvider::Fireworks => "FIREWORKS_API_KEY",
             ApiProvider::Moonshot => "MOONSHOT_API_KEY / KIMI_API_KEY",
             ApiProvider::Sglang => "SGLANG_API_KEY",
             ApiProvider::Vllm => "VLLM_API_KEY",
@@ -402,12 +396,6 @@ mod tests {
             vec![
                 "DeepSeek",
                 "NVIDIA NIM",
-                "OpenAI-compatible",
-                "AtlasCloud",
-                "Wanjie Ark",
-                "OpenRouter",
-                "Novita AI",
-                "Fireworks AI",
                 "Moonshot/Kimi",
                 "SGLang",
                 "vLLM",
@@ -435,9 +423,9 @@ mod tests {
     #[test]
     fn picker_marks_active_provider_as_initial_selection() {
         let config = Config::default();
-        let picker = ProviderPickerView::new(ApiProvider::Openrouter, &config);
-        assert_eq!(picker.selected_provider(), ApiProvider::Openrouter);
-        assert_eq!(picker.active_provider, ApiProvider::Openrouter);
+        let picker = ProviderPickerView::new(ApiProvider::NvidiaNim, &config);
+        assert_eq!(picker.selected_provider(), ApiProvider::NvidiaNim);
+        assert_eq!(picker.active_provider, ApiProvider::NvidiaNim);
     }
 
     #[test]
@@ -445,8 +433,8 @@ mod tests {
         let config = Config::default();
         let mut picker = ProviderPickerView::new(ApiProvider::Deepseek, &config);
         // Move to OpenRouter, which has no key in default config.
-        move_to_provider(&mut picker, ApiProvider::Openrouter);
-        assert_eq!(picker.selected_provider(), ApiProvider::Openrouter);
+        move_to_provider(&mut picker, ApiProvider::NvidiaNim);
+        assert_eq!(picker.selected_provider(), ApiProvider::NvidiaNim);
         let action = picker.handle_key(key(KeyCode::Enter));
         assert!(matches!(action, ViewAction::None));
         assert_eq!(picker.stage, Stage::KeyEntry);
@@ -476,7 +464,7 @@ mod tests {
         let config = Config::default();
         let mut picker = ProviderPickerView::new(ApiProvider::Deepseek, &config);
         // Navigate to Novita and trigger key entry.
-        move_to_provider(&mut picker, ApiProvider::Novita);
+        move_to_provider(&mut picker, ApiProvider::NvidiaNim);
         picker.handle_key(key(KeyCode::Enter));
         assert_eq!(picker.stage, Stage::KeyEntry);
         for c in "novita-key".chars() {
@@ -488,7 +476,7 @@ mod tests {
                 provider,
                 api_key,
             }) => {
-                assert_eq!(provider, ApiProvider::Novita);
+                assert_eq!(provider, ApiProvider::NvidiaNim);
                 assert_eq!(api_key, "novita-key");
             }
             other => panic!("expected ProviderPickerApiKeySubmitted, got {other:?}"),
@@ -499,7 +487,7 @@ mod tests {
     fn key_entry_esc_returns_to_list_without_emitting() {
         let config = Config::default();
         let mut picker = ProviderPickerView::new(ApiProvider::Deepseek, &config);
-        move_to_provider(&mut picker, ApiProvider::Openrouter);
+        move_to_provider(&mut picker, ApiProvider::NvidiaNim);
         picker.handle_key(key(KeyCode::Enter));
         assert_eq!(picker.stage, Stage::KeyEntry);
         picker.handle_key(key(KeyCode::Char('a')));
@@ -521,7 +509,7 @@ mod tests {
     fn key_entry_strips_whitespace_chars() {
         let config = Config::default();
         let mut picker = ProviderPickerView::new(ApiProvider::Deepseek, &config);
-        move_to_provider(&mut picker, ApiProvider::Openrouter);
+        move_to_provider(&mut picker, ApiProvider::NvidiaNim);
         picker.handle_key(key(KeyCode::Enter));
         assert_eq!(picker.stage, Stage::KeyEntry);
         for c in "abc def".chars() {

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -5250,11 +5250,7 @@ async fn execute_command_input(
             providers.deepseek.api_key = None;
             providers.deepseek_cn.api_key = None;
             providers.nvidia_nim.api_key = None;
-            providers.openai.api_key = None;
-            providers.atlascloud.api_key = None;
-            providers.openrouter.api_key = None;
-            providers.novita.api_key = None;
-            providers.fireworks.api_key = None;
+            providers.moonshot.api_key = None;
             providers.sglang.api_key = None;
             providers.vllm.api_key = None;
             providers.ollama.api_key = None;
@@ -5633,12 +5629,6 @@ fn render(f: &mut Frame, app: &mut App) {
             crate::config::ApiProvider::Deepseek => None,
             crate::config::ApiProvider::DeepseekCN => None,
             crate::config::ApiProvider::NvidiaNim => Some("NIM"),
-            crate::config::ApiProvider::Openai => Some("OpenAI"),
-            crate::config::ApiProvider::Atlascloud => Some("Atlas"),
-            crate::config::ApiProvider::WanjieArk => Some("Wanjie"),
-            crate::config::ApiProvider::Openrouter => Some("OR"),
-            crate::config::ApiProvider::Novita => Some("Novita"),
-            crate::config::ApiProvider::Fireworks => Some("Fireworks"),
             crate::config::ApiProvider::Moonshot => Some("Kimi"),
             crate::config::ApiProvider::Sglang => Some("SGLang"),
             crate::config::ApiProvider::Vllm => Some("vLLM"),
@@ -6492,12 +6482,6 @@ async fn apply_provider_picker_api_key(
                 return;
             }
             ApiProvider::NvidiaNim => &mut providers.nvidia_nim,
-            ApiProvider::Openai => &mut providers.openai,
-            ApiProvider::Atlascloud => &mut providers.atlascloud,
-            ApiProvider::WanjieArk => &mut providers.wanjie_ark,
-            ApiProvider::Openrouter => &mut providers.openrouter,
-            ApiProvider::Novita => &mut providers.novita,
-            ApiProvider::Fireworks => &mut providers.fireworks,
             ApiProvider::Moonshot => &mut providers.moonshot,
             ApiProvider::Sglang => &mut providers.sglang,
             ApiProvider::Vllm => &mut providers.vllm,
@@ -6544,12 +6528,6 @@ fn set_provider_auth_mode_in_memory(config: &mut Config, provider: ApiProvider, 
     let entry: &mut ProviderConfig = match provider {
         ApiProvider::Deepseek | ApiProvider::DeepseekCN => return,
         ApiProvider::NvidiaNim => &mut providers.nvidia_nim,
-        ApiProvider::Openai => &mut providers.openai,
-        ApiProvider::Atlascloud => &mut providers.atlascloud,
-        ApiProvider::WanjieArk => &mut providers.wanjie_ark,
-        ApiProvider::Openrouter => &mut providers.openrouter,
-        ApiProvider::Novita => &mut providers.novita,
-        ApiProvider::Fireworks => &mut providers.fireworks,
         ApiProvider::Moonshot => &mut providers.moonshot,
         ApiProvider::Sglang => &mut providers.sglang,
         ApiProvider::Vllm => &mut providers.vllm,

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -198,7 +198,7 @@ The memory file lives entirely on your machine in `~/.deepseek/`.
 It's never uploaded to any cloud service — the TUI only ever
 includes it inline in the system prompt that the LLM provider
 receives, and only when memory is enabled. If you switch providers
-(DeepSeek / NVIDIA NIM / Fireworks / etc.) the same memory file is
+(DeepSeek / NVIDIA NIM / Moonshot / etc.) the same memory file is
 used; the file is provider-agnostic.
 
 The file is per-user, not per-project. If you want project-specific

--- a/docs/superpowers/plans/2026-05-25-v0.8.45-provider-scope.md
+++ b/docs/superpowers/plans/2026-05-25-v0.8.45-provider-scope.md
@@ -1,0 +1,702 @@
+# v0.8.45 Provider Scope Narrowing — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Narrow the v0.8.45 release surface to DeepSeek (on its official endpoint plus documented self-host backends) and Kimi K2.6. Remove every other provider/model from runtime, defaults, pickers, completions, secrets, docs, examples, and tests so the release is boring and reviewable.
+
+**Architecture:** Deletion-driven. Each task strips one layer (registry → config enum → config plumbing → secrets → pickers/CLI → docs → tests fixup → verification). Tests guide the removal — for each provider we drop, the tests covering it go first so the compile is clean.
+
+**Tech Stack:** Rust 1.88+ (edition 2024, stable only). Workspace crates: `crates/agent`, `crates/config`, `crates/secrets`, `crates/cli`, `crates/tui`. No new dependencies.
+
+**Approved set (the only surfaces that may appear in v0.8.45 UX / completions / docs):**
+
+| Provider enum   | Models                                                                                                | Endpoint                          |
+|-----------------|-------------------------------------------------------------------------------------------------------|-----------------------------------|
+| `Deepseek`      | `deepseek-v4-pro`, `deepseek-v4-flash` (aliases: `deepseek-chat`, `deepseek-reasoner`, `deepseek-r1`, `deepseek-v3`, `deepseek-v3.2`) | `https://api.deepseek.com` / `https://api.deepseeki.com` (CN) |
+| `NvidiaNim`     | `deepseek-ai/deepseek-v4-pro`, `deepseek-ai/deepseek-v4-flash` (aliases keep `nvidia-*`, `nim-*`)    | NVIDIA NIM (NVIDIA_API_KEY)       |
+| `Sglang`        | `deepseek-ai/DeepSeek-V4-Pro`, `deepseek-ai/DeepSeek-V4-Flash`                                       | `http://localhost:30000/v1`       |
+| `Vllm`          | `deepseek-ai/DeepSeek-V4-Pro`, `deepseek-ai/DeepSeek-V4-Flash`                                       | `http://localhost:8000/v1`        |
+| `Ollama`        | `deepseek-coder:1.3b`                                                                                | `http://localhost:11434/v1`       |
+| `Moonshot`      | `kimi-k2.6` (aliases: `kimi`, `kimi-k2`, `moonshot-kimi-k2.6`)                                       | Moonshot + Kimi-code OAuth path   |
+
+**Removed providers (must not appear anywhere user-visible in v0.8.45):** `Openai` (generic OpenAI-compatible), `Atlascloud`, `WanjieArk`, `Openrouter`, `Novita`, `Fireworks`.
+
+**Out of scope for this plan (do not touch):** Codex/ChatGPT OAuth (already removed; just verify), Kimi K2.6 OAuth (already on main, keep working), web/ marketing site, npm wrapper version bumps beyond version constancy check, sandbox/seatbelt, voice input, RLM, sub-agent naming.
+
+---
+
+## File Structure
+
+Files modified by this plan (no new files created):
+
+| File | Responsibility |
+|------|----------------|
+| `crates/agent/src/lib.rs` | Model registry — drop 8 `ModelInfo` entries, drop 9 tests for removed providers. |
+| `crates/config/src/lib.rs` | `ProviderKind` enum, `ProvidersToml`, all match arms on provider, env handling, constants, tests. Largest single change. |
+| `crates/secrets/src/lib.rs` | `env_for` aliases for removed providers + corresponding tests. |
+| `crates/tui/src/config.rs` | `MiniMax-M2.7` / `glm-5` test sentinels (replace with approved sentinels). |
+| `crates/tui/src/commands/provider.rs` | `/provider` command UI (list, validation). |
+| `crates/tui/src/commands/config.rs` | `/config` provider field handling. |
+| `crates/tui/src/tui/provider_picker.rs` | Provider list shown in UI picker. |
+| `crates/tui/src/tui/model_picker.rs` | Model list (if it hard-codes any non-DeepSeek/Kimi entries). |
+| `crates/tui/src/tui/command_palette.rs` | Palette entries that mention removed providers. |
+| `crates/tui/src/config_ui.rs` | Provider sections in settings UI. |
+| `crates/tui/src/client.rs` + `crates/tui/src/client/chat.rs` | Provider routing — remove arms for removed providers; keep DeepSeek/NIM/vLLM/Sglang/Ollama/Moonshot. |
+| `crates/tui/src/llm_client/mod.rs` | Same as client. |
+| `crates/cli/src/lib.rs` | clap help text / completions that enumerate providers. |
+| `crates/cli/src/bin/codew_legacy_shim.rs`, `deepseek_legacy_shim.rs` | Strip mentions if any. |
+| `README.md`, `config.example.toml`, `.env.example` | Public docs and examples. |
+| `CHANGELOG.md`, `crates/tui/CHANGELOG.md` | Verify v0.8.45 entries don't claim broader support (current `[0.8.45]` block looks scoped already — confirm). |
+| `docs/CONFIGURATION.md`, `docs/MODES.md`, `docs/ARCHITECTURE.md` | Trim provider tables. |
+
+Files **not** touched: anything under `web/`, `npm/`, `crates/protocol/`, `crates/state/`, `crates/tui-core/`, `crates/hooks/`, `crates/execpolicy/`, `crates/core/`, `crates/tools/`, `crates/mcp/`, `crates/app-server/` unless a transitive compile error forces it. If something there does break, fix the minimum needed and note it in the commit.
+
+---
+
+## Task 1 — Drop 8 non-approved entries from agent registry
+
+**Files:**
+- Modify: `crates/agent/src/lib.rs:50-216` (Default::default impl)
+- Modify: `crates/agent/src/lib.rs:336-524` (tests module)
+
+- [ ] **Step 1: Confirm baseline tests pass before touching anything**
+
+Run:
+```
+cargo test -p codewhale-agent --locked
+```
+Expected: PASS (all current tests).
+
+- [ ] **Step 2: Delete the 9 tests in `tests` module that assert non-approved providers**
+
+In `crates/agent/src/lib.rs` remove these tests (each is ~6-9 lines; identify by function name):
+- `deepseek_v4_pro_alias_resolves_to_nvidia_nim_when_provider_hinted` → KEEP (NvidiaNim is approved)
+- `nvidia_nim_default_uses_catalog_model_id` → KEEP
+- `deepseek_v4_flash_alias_resolves_to_nvidia_nim_when_provider_hinted` → KEEP
+- `openrouter_default_uses_namespaced_model_id` → **DELETE**
+- `wanjie_ark_default_uses_reasoner_model_id` → **DELETE**
+- `novita_default_uses_namespaced_model_id` → **DELETE**
+- `fireworks_default_uses_canonical_model_id` → **DELETE**
+- `sglang_default_uses_canonical_model_id` → KEEP (Sglang is approved)
+- `deepseek_v4_flash_alias_resolves_to_openrouter_when_provider_hinted` → **DELETE**
+- `deepseek_v4_flash_alias_resolves_to_novita_when_provider_hinted` → **DELETE**
+- `deepseek_v4_flash_alias_resolves_to_sglang_when_provider_hinted` → KEEP
+- `vllm_default_uses_canonical_model_id` → KEEP
+- `ollama_default_uses_small_local_model_id` → KEEP
+
+So total deleted in tests: 6 tests (`openrouter`, `wanjie_ark`, `novita`, `fireworks`, `flash→openrouter`, `flash→novita`).
+
+- [ ] **Step 3: Run tests — they should still pass (we only removed tests, no code yet)**
+
+Run:
+```
+cargo test -p codewhale-agent --locked
+```
+Expected: PASS, fewer tests reported. This proves the kept tests don't depend on removed-provider machinery.
+
+- [ ] **Step 4: Delete the 8 ModelInfo entries for removed providers**
+
+In `crates/agent/src/lib.rs` `Default::default` for `ModelRegistry`, delete (by `provider:` field):
+- `provider: ProviderKind::Openai` (2 entries: `deepseek-v4-pro`, `deepseek-v4-flash`)
+- `provider: ProviderKind::WanjieArk` (1 entry: `deepseek-reasoner`)
+- `provider: ProviderKind::Openrouter` (2 entries)
+- `provider: ProviderKind::Novita` (2 entries)
+- `provider: ProviderKind::Fireworks` (1 entry: `accounts/fireworks/models/deepseek-v4-pro`)
+
+Leave intact: Deepseek×2, NvidiaNim×2, Sglang×2, Vllm×2, Ollama×1, Moonshot×1 = 10 entries.
+
+- [ ] **Step 5: Compile — it WILL fail because `ProviderKind::Openai` etc. are still on the enum but unused in registry. That's fine; the enum gets removed in Task 2. If compile passes already that's also fine.**
+
+Run:
+```
+cargo build -p codewhale-agent --locked 2>&1 | tail -20
+```
+Expected: compiles (we only removed Vec elements; ProviderKind variants are still defined). If warnings appear about unused variants, ignore — Task 2 deletes them.
+
+- [ ] **Step 6: Re-run tests**
+
+Run:
+```
+cargo test -p codewhale-agent --locked
+```
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```
+git add crates/agent/src/lib.rs
+git commit -m "fix(v0.8.45): drop non-approved providers from agent registry
+
+Removes Openai, WanjieArk, Openrouter, Novita, Fireworks model entries
+and their tests from the agent crate. Keeps Deepseek, NvidiaNim, Sglang,
+Vllm, Ollama, Moonshot/Kimi to match the narrowed v0.8.45 surface."
+```
+
+---
+
+## Task 2 — Drop 6 provider variants from `ProviderKind` enum
+
+**Files:**
+- Modify: `crates/config/src/lib.rs:49-128` (enum + as_str + parse)
+- Modify: `crates/config/src/lib.rs:134-200` (ProvidersToml struct + for_provider/for_provider_mut)
+
+- [ ] **Step 1: Delete the 6 variants from `ProviderKind` enum**
+
+Remove from `enum ProviderKind { ... }` at `crates/config/src/lib.rs:49`:
+- `Openai`
+- `Atlascloud`
+- `WanjieArk` (with its `#[serde(alias ...)]` block)
+- `Openrouter`
+- `Novita`
+- `Fireworks`
+
+Keep: `Deepseek` (default), `NvidiaNim`, `Moonshot`, `Sglang`, `Vllm`, `Ollama`.
+
+- [ ] **Step 2: Delete the matching arms from `as_str()` (lines ~88-104)**
+
+Each removed variant maps to a string; remove those arms.
+
+- [ ] **Step 3: Delete the matching arms from `parse()` (lines ~108-128)**
+
+Remove the lowercase-string match arms for the 6 removed providers.
+
+- [ ] **Step 4: Delete the 6 fields from `ProvidersToml` struct (lines ~134-158)**
+
+Remove fields: `openai`, `atlascloud`, `wanjie_ark`, `openrouter`, `novita`, `fireworks`.
+
+- [ ] **Step 5: Delete the 6 arms from `for_provider` and `for_provider_mut` (lines ~163-198)**
+
+- [ ] **Step 6: Compile and follow the errors**
+
+Run:
+```
+cargo build -p codewhale-config --locked 2>&1 | tail -80
+```
+Expected: many errors in `lib.rs` for unmatched arms in other functions (`merge_project_provider_config`, `get_value`, `set_value`, `unset_value`, `list_values`, `resolve_runtime_options_with_secrets`, `default_model_for_provider`, `normalize_model_for_provider`, `EnvRuntimeOverrides::apply`, `SuspendedEnvRuntimeOverrides`, etc.).
+
+For each error, delete the arm for the removed provider. Do **not** add a wildcard `_ =>` arm — let exhaustiveness catch new variants in the future.
+
+Iterate `cargo build` until clean. Plan budget: ~30-50 small deletions across the file.
+
+- [ ] **Step 7: Delete obsolete constants (lines ~17-47)**
+
+Remove constants only referenced by removed providers:
+- `DEFAULT_OPENAI_MODEL`
+- `DEFAULT_ATLASCLOUD_MODEL`, `DEFAULT_ATLASCLOUD_BASE_URL`
+- `DEFAULT_WANJIE_ARK_MODEL`, `DEFAULT_WANJIE_ARK_BASE_URL`
+- `DEFAULT_OPENROUTER_MODEL`, `DEFAULT_OPENROUTER_FLASH_MODEL`, `DEFAULT_OPENROUTER_BASE_URL`
+- `DEFAULT_NOVITA_MODEL`, `DEFAULT_NOVITA_FLASH_MODEL`, `DEFAULT_NOVITA_BASE_URL`
+- `DEFAULT_FIREWORKS_MODEL`, `DEFAULT_FIREWORKS_BASE_URL`
+
+Keep: `DEFAULT_DEEPSEEK_*`, `DEFAULT_NVIDIA_NIM_*`, `DEFAULT_MOONSHOT_*`, `DEFAULT_KIMI_CODE_*`, `DEFAULT_SGLANG_*`, `DEFAULT_VLLM_*`, `DEFAULT_OLLAMA_*`.
+
+If a `cargo build` warning says any kept constant is now unused, leave it — it's used by tests or example macros that the agent might miss. Confirm with a quick `rg "DEFAULT_SGLANG_BASE_URL"` before deletion.
+
+- [ ] **Step 8: Compile clean**
+
+Run:
+```
+cargo build --workspace --locked 2>&1 | tail -40
+```
+Expected: build passes (even if downstream crates have stale references that will be fixed in later tasks). If `crates/tui` or `crates/cli` errors reference removed `ProviderKind` variants, those are Task 5/6 territory — note them but do **not** patch yet; commit this slice first.
+
+If `crates/tui` errors block the workspace build entirely, complete Task 2 in two commits: (a) the config-internal cleanup that compiles `crates/config` standalone, then (b) the downstream fixes inline at the bottom of this task. Prefer one commit if you can.
+
+- [ ] **Step 9: Run config tests**
+
+Run:
+```
+cargo test -p codewhale-config --locked 2>&1 | tail -40
+```
+Expected: most tests pass. Some test functions still reference removed providers — Task 4 deletes them. If any test panic prevents compilation, comment out the test temporarily with `// TODO Task 4 delete` and proceed.
+
+- [ ] **Step 10: Commit**
+
+```
+git add crates/config/src/lib.rs
+git commit -m "fix(v0.8.45): remove non-approved providers from config
+
+Drops Openai, Atlascloud, WanjieArk, Openrouter, Novita, Fireworks from
+ProviderKind, ProvidersToml, and all match arms (parse, as_str,
+for_provider, get/set/unset/list_value, env overrides, base URL +
+default model resolution, normalize_model_for_provider). Constants for
+those providers also removed."
+```
+
+---
+
+## Task 3 — Strip removed-provider env handling and tests in config
+
+**Files:**
+- Modify: `crates/config/src/lib.rs` `EnvRuntimeOverrides` struct, `SuspendedEnvRuntimeOverrides`, env apply loop, `env_var` lookup tables (search for `OPENAI_API_KEY`, `OPENROUTER_API_KEY`, etc.)
+- Modify: `crates/config/src/lib.rs` tests (search for `#[test]` functions naming removed providers)
+
+- [ ] **Step 1: Locate env-handling structs**
+
+Run:
+```
+rg -n "openai|atlascloud|wanjie|openrouter|novita|fireworks" crates/config/src/lib.rs | grep -v "^[0-9]*:\s*//" | head -80
+```
+Identify remaining references. Delete struct fields, env-var name constants, and `apply` arms.
+
+- [ ] **Step 2: Delete config tests for removed providers**
+
+Search for tests that hardcode removed provider names:
+```
+rg -n "fn .*openai|fn .*atlascloud|fn .*wanjie|fn .*openrouter|fn .*novita|fn .*fireworks" crates/config/src/lib.rs
+```
+
+For each match, delete the test function (typically `#[test]` plus 5–40 lines).
+
+Also fix the two test cases at `crates/config/src/lib.rs` ~lines 5822, 5915, 5949 that use `glm-5` or `MiniMax-M2.7` as sentinels (they were added to prove `default_model` passthrough works for unknown providers). Replace the sentinel string with an approved model like `deepseek-v4-pro` so the test still covers the same behavior — model passthrough — without referencing a non-shipped model.
+
+Specifically:
+- `crates/config/src/lib.rs:5822`: replace `model = "glm-5"` with `model = "deepseek-v4-pro"` and the corresponding assertion below.
+- `crates/config/src/lib.rs:5838`, `5856`, `5864`, `5870`, `5882`, `5889`, `5915`, `5925`, `5949`, `5959`, `6881`: replace `glm-5` and `MiniMax-M2.7` with `deepseek-v4-pro` (or another approved string) and update assertions consistently.
+
+Also `crates/config/src/lib.rs:1547` — the comment referencing `MiniMax-M2.7` should be rephrased: "provider (e.g. a custom model name forwarded as-is)."
+
+- [ ] **Step 3: Run config tests**
+
+Run:
+```
+cargo test -p codewhale-config --locked 2>&1 | tail -40
+```
+Expected: PASS.
+
+- [ ] **Step 4: Run workspace build**
+
+Run:
+```
+cargo build --workspace --locked 2>&1 | tail -40
+```
+Expected: builds. If downstream errors remain (tui, cli), they are addressed in Tasks 5-7.
+
+- [ ] **Step 5: Commit**
+
+```
+git add crates/config/src/lib.rs
+git commit -m "fix(v0.8.45): remove env handling and tests for dropped providers
+
+Drops EnvRuntimeOverrides fields, env-var constants, and test functions
+covering Openai, Atlascloud, WanjieArk, Openrouter, Novita, Fireworks.
+Test sentinels using glm-5 / MiniMax-M2.7 replaced with deepseek-v4-pro
+so passthrough behavior is still exercised without referencing models
+the v0.8.45 release no longer surfaces."
+```
+
+---
+
+## Task 4 — Strip removed-provider entries from `crates/secrets`
+
+**Files:**
+- Modify: `crates/secrets/src/lib.rs:526` `env_for` body
+- Modify: `crates/secrets/src/lib.rs:749-816` tests
+
+- [ ] **Step 1: Read `env_for` function fully**
+
+Run:
+```
+sed -n '520,640p' crates/secrets/src/lib.rs
+```
+
+Identify match arms for `openai`, `atlascloud`, `wanjie-ark`, `openrouter`, `novita`, `fireworks`.
+
+- [ ] **Step 2: Delete those match arms (and their lowercase aliases)**
+
+- [ ] **Step 3: Delete the corresponding test functions**
+
+In `crates/secrets/src/lib.rs` tests:
+- Delete test at `:749-751` (`env_for("atlascloud")` / `atlas-cloud` / `atlas`).
+- Delete test at `:762-764` (wanjie-ark / ark_wanjie / wanjie-maas).
+- Delete test at `:776-777` (fireworks / fireworks-ai).
+- KEEP `:789-790` sglang, `:802-803` vllm, `:815-816` ollama.
+- Find and delete any openai / openrouter / novita tests in the same block.
+
+Use:
+```
+rg -n "fn .*test.*(openai|atlascloud|wanjie|openrouter|novita|fireworks)" crates/secrets/src/lib.rs
+```
+
+- [ ] **Step 4: Test**
+
+Run:
+```
+cargo test -p codewhale-secrets --locked
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```
+git add crates/secrets/src/lib.rs
+git commit -m "fix(v0.8.45): drop removed-provider env lookups from secrets crate
+
+Removes env_for arms for openai, atlascloud, wanjie-ark, openrouter,
+novita, fireworks plus their tests."
+```
+
+---
+
+## Task 5 — Strip removed providers from TUI pickers, palette, commands
+
+**Files:**
+- Modify: `crates/tui/src/commands/provider.rs`
+- Modify: `crates/tui/src/commands/config.rs`
+- Modify: `crates/tui/src/tui/provider_picker.rs`
+- Modify: `crates/tui/src/tui/model_picker.rs`
+- Modify: `crates/tui/src/tui/command_palette.rs`
+- Modify: `crates/tui/src/config_ui.rs`
+- Modify: `crates/tui/src/client.rs`, `crates/tui/src/client/chat.rs`, `crates/tui/src/llm_client/mod.rs`
+- Modify: `crates/tui/src/main.rs`, `crates/tui/src/config.rs` if they enumerate providers
+
+- [ ] **Step 1: Drive by compile errors from Task 2**
+
+Run:
+```
+cargo build -p codewhale-tui --locked 2>&1 | tail -120
+```
+
+For each `error[E0599]: no variant or associated item named ...` or `error[E0004]: non-exhaustive patterns`:
+- If it's a match on `ProviderKind` referencing a removed variant, delete the arm.
+- If it's a struct field reference, delete the use.
+- If it's a hardcoded provider string in a UI list (e.g. `"openrouter"`), delete the entry.
+
+Iterate until clean.
+
+- [ ] **Step 2: Audit UI surfaces for hardcoded strings**
+
+Run:
+```
+rg -n -i "openai|atlascloud|wanjie|openrouter|novita|fireworks" crates/tui/src/commands/ crates/tui/src/tui/ crates/tui/src/config_ui.rs crates/tui/src/config.rs
+```
+
+For each match:
+- If it's user-visible (help text, picker label, palette description, settings label), delete it.
+- If it's a comment, delete or update if misleading.
+- If it's still useful internally (it shouldn't be, since the enum is gone — but check), keep but mark with `// removed: reason` only if absolutely necessary.
+
+- [ ] **Step 3: Same audit for client/router paths**
+
+Run:
+```
+rg -n -i "openai|atlascloud|wanjie|openrouter|novita|fireworks" crates/tui/src/client.rs crates/tui/src/client/ crates/tui/src/llm_client/
+```
+
+Delete corresponding routing arms / base-url switches.
+
+- [ ] **Step 4: Build and test the TUI crate**
+
+Run:
+```
+cargo build -p codewhale-tui --locked
+cargo test -p codewhale-tui --locked --lib 2>&1 | tail -40
+```
+
+If tests reference removed providers, delete those test cases. (Snapshot tests, if any, may need regen; do **not** regenerate blindly — inspect the snapshot diff first.)
+
+- [ ] **Step 5: Commit**
+
+```
+git add crates/tui/
+git commit -m "fix(v0.8.45): scrub removed providers from TUI pickers and routing
+
+Pickers, command palette, /provider and /config commands, client/router
+arms, and settings UI no longer mention Openai, Atlascloud, WanjieArk,
+Openrouter, Novita, Fireworks."
+```
+
+---
+
+## Task 6 — CLI flags, help text, completions, legacy shims
+
+**Files:**
+- Modify: `crates/cli/src/lib.rs`
+- Modify: `crates/cli/src/bin/codew_legacy_shim.rs`
+- Modify: `crates/cli/src/bin/deepseek_legacy_shim.rs`
+
+- [ ] **Step 1: Locate provider strings**
+
+Run:
+```
+rg -n -i "openai|atlascloud|wanjie|openrouter|novita|fireworks" crates/cli/src/
+```
+
+- [ ] **Step 2: Update --provider clap help and possible values**
+
+Edit `--provider` arg definition (search for `provider` in `clap::Arg` builders or derived attrs). Update the enum of valid values to only: `deepseek`, `nvidia-nim`, `moonshot`, `sglang`, `vllm`, `ollama`. Update help text accordingly.
+
+- [ ] **Step 3: Update shell completion generation**
+
+If `crates/cli/src/lib.rs` enumerates providers for completion (`PossibleValuesParser`, `value_parser!`), update the list.
+
+- [ ] **Step 4: Build CLI**
+
+Run:
+```
+cargo build -p codewhale-cli --locked
+```
+
+- [ ] **Step 5: Commit**
+
+```
+git add crates/cli/
+git commit -m "fix(v0.8.45): trim --provider values and CLI help to approved set"
+```
+
+---
+
+## Task 7 — Docs, README, config.example.toml, .env.example
+
+**Files:**
+- Modify: `README.md`
+- Modify: `config.example.toml`
+- Modify: `.env.example`
+- Modify: `docs/CONFIGURATION.md`
+- Modify: `docs/MODES.md` (if it mentions providers)
+- Modify: `docs/ARCHITECTURE.md` (provider section if any)
+
+- [ ] **Step 1: Find every public-doc mention**
+
+Run:
+```
+rg -n -i "openai|atlascloud|wanjie|openrouter|novita|fireworks" README.md config.example.toml .env.example docs/
+```
+
+- [ ] **Step 2: For each mention, decide:**
+- Provider list / supported providers table → remove the row.
+- Example command (`codewhale --provider openrouter ...`) → remove the example.
+- Env var documentation (`OPENROUTER_API_KEY=...`) → remove the line/section.
+- Historical CHANGELOG entries below `[Unreleased]` and `[0.8.45]` → **leave untouched** (those describe prior shipped releases truthfully).
+
+- [ ] **Step 3: Verify v0.8.45 CHANGELOG block is consistent**
+
+Read `CHANGELOG.md` `[0.8.45]` section (top, before `[0.8.44]`). It currently lists RLM session objects, sub-agent naming, /balance scaffold, restore snapshot labels, sidebar hover tooltips, sub-agent completion handoff fixes, self-hosted context budgeting, goal prompts, composer session title, approval prompts, model picker survival, slash recovery, remembered approvals, YAML block scalars, user message highlight, cancellable list_dir.
+
+Confirm no mention of new provider support. If clean, leave it. Otherwise scrub.
+
+Same for `crates/tui/CHANGELOG.md`.
+
+- [ ] **Step 4: Diff sanity-check**
+
+Run:
+```
+git diff README.md config.example.toml .env.example docs/
+```
+Read the diff. Confirm the public docs now show only Deepseek, NvidiaNim (DeepSeek-on-NVIDIA), Moonshot/Kimi, Sglang, Vllm, Ollama.
+
+- [ ] **Step 5: Commit**
+
+```
+git add README.md config.example.toml .env.example docs/
+git commit -m "docs(v0.8.45): scrub removed providers from public docs and examples
+
+README, config.example.toml, .env.example, docs/CONFIGURATION.md no
+longer reference Openai, Atlascloud, WanjieArk, Openrouter, Novita,
+Fireworks. Historical CHANGELOG entries left intact."
+```
+
+---
+
+## Task 8 — Verify Codex/ChatGPT OAuth is still absent
+
+**Files:**
+- Verify: `crates/tui/src/client/chatgpt_backend.rs` (was an untracked file in the parent dirty checkout — should NOT be present in origin/main)
+- Search: anything in the worktree referencing `chatgpt` or `codex-oauth`
+
+- [ ] **Step 1: Confirm chatgpt_backend.rs is not in this worktree**
+
+Run:
+```
+ls crates/tui/src/client/ | grep -i chatgpt && echo PRESENT || echo ABSENT
+```
+Expected: `ABSENT`.
+
+- [ ] **Step 2: Search for any leftover Codex/ChatGPT OAuth references**
+
+Run:
+```
+rg -n -i "codex.*oauth|chatgpt.*backend|chatgpt_login" --type rust --type md
+```
+Expected: no matches in code; matches only in historical CHANGELOG describing removal are OK.
+
+- [ ] **Step 3: No commit (verification only)**
+
+---
+
+## Task 9 — Verify Kimi OAuth still works
+
+**Files:**
+- Verify: `crates/config/src/lib.rs` (Kimi-code defaults still present)
+- Verify: `crates/tui/` Kimi OAuth code paths still compile
+
+- [ ] **Step 1: Locate Kimi OAuth code**
+
+Run:
+```
+rg -n -i "kimi.*oauth|kimi-code|kimi_code|DEFAULT_KIMI_CODE" --type rust
+```
+
+Expected: hits in `crates/config/src/lib.rs` (constants), and TUI module(s) implementing OAuth flow.
+
+- [ ] **Step 2: Confirm constants kept in Task 2/3**
+
+```
+rg -n "DEFAULT_KIMI_CODE_MODEL|DEFAULT_KIMI_CODE_BASE_URL|DEFAULT_MOONSHOT_MODEL|DEFAULT_MOONSHOT_BASE_URL" crates/config/src/lib.rs
+```
+Expected: still present.
+
+- [ ] **Step 3: Run Kimi-related tests**
+
+Run:
+```
+cargo test -p codewhale-config --locked moonshot
+cargo test --workspace --locked kimi
+```
+Expected: PASS.
+
+- [ ] **Step 4: No commit (verification only)**
+
+---
+
+## Task 10 — Format, version check, full build, targeted tests, binary smoke
+
+- [ ] **Step 1: cargo fmt**
+
+```
+cargo fmt --all
+```
+If anything changes, stage and commit as `style: cargo fmt`.
+
+- [ ] **Step 2: Version constancy check**
+
+```
+./scripts/release/check-versions.sh
+```
+Expected: PASS (workspace Cargo.toml and `npm/codewhale/package.json` both at 0.8.45). If it fails, fix the version mismatch (most likely no change needed since we didn't touch versions).
+
+- [ ] **Step 3: Targeted provider/model tests**
+
+```
+cargo test -p codewhale-agent --locked
+cargo test -p codewhale-config --locked
+cargo test -p codewhale-secrets --locked
+cargo test -p codewhale-tui --locked --lib 2>&1 | tail -40
+```
+Expected: PASS.
+
+- [ ] **Step 4: Full workspace build**
+
+```
+cargo build --workspace --all-features --locked 2>&1 | tail -20
+```
+Expected: PASS.
+
+- [ ] **Step 5: Parity gates (release-blocking)**
+
+```
+cargo test -p codewhale-tui-core --test snapshot --locked
+cargo test -p codewhale-protocol --test parity_protocol --locked
+cargo test -p codewhale-state --test parity_state --locked
+```
+Expected: PASS. If snapshot fails, inspect the snapshot diff — it likely doesn't involve our provider changes. If it does, regenerate only after confirming the change is expected.
+
+- [ ] **Step 6: Clippy with -D warnings (CI parity)**
+
+```
+cargo clippy --workspace --all-targets --all-features --locked -- -D warnings 2>&1 | tail -40
+```
+Expected: PASS. If clippy flags removed-but-still-referenced items, finish the cleanup.
+
+- [ ] **Step 7: Binary smoke**
+
+```
+./target/debug/codewhale --version
+./target/debug/codewhale-tui --version
+```
+Expected: both print `codewhale 0.8.45` (or equivalent).
+
+- [ ] **Step 8: Confirm Cargo.lock is clean**
+
+```
+git diff --exit-code -- Cargo.lock
+```
+Expected: no diff. If Cargo.lock changed, investigate why — we shouldn't have added or bumped any deps.
+
+- [ ] **Step 9: Commit any final formatting cleanup**
+
+```
+git status
+# If anything is dirty:
+git add -A
+git commit -m "style: cargo fmt after provider scope narrowing"
+```
+
+---
+
+## Task 11 — Push branch and open PR to main (do NOT merge)
+
+- [ ] **Step 1: Rename worktree branch to user-preferred name**
+
+EnterWorktree created the branch as `worktree-fix+v0.8.45-provider-scope`. Push it under the user-requested name `fix/v0.8.45-provider-scope`:
+
+```
+git push origin HEAD:refs/heads/fix/v0.8.45-provider-scope
+```
+
+- [ ] **Step 2: Open PR via gh**
+
+```
+gh pr create --base main --head fix/v0.8.45-provider-scope --title "fix(v0.8.45): narrow provider/model scope to DeepSeek + Kimi K2.6" --body "$(cat <<'EOF'
+## Summary
+
+Narrows the v0.8.45 release surface to a supportable set:
+
+- **DeepSeek** (first-class) on api.deepseek.com plus documented self-host backends: NVIDIA NIM, Sglang, vLLM, Ollama.
+- **Kimi K2.6** via Moonshot (OAuth path already on main, preserved).
+
+Removes from runtime, pickers, completions, secrets, docs, examples, and tests every reference to providers we are not committing to support in 0.8.45: OpenAI-compatible (generic), Atlascloud, WanjieArk, OpenRouter, Novita, Fireworks.
+
+## What stays
+
+- `ProviderKind`: `Deepseek`, `NvidiaNim`, `Moonshot`, `Sglang`, `Vllm`, `Ollama`.
+- Models: `deepseek-v4-pro`, `deepseek-v4-flash` (+ legacy aliases), `kimi-k2.6`, plus the self-host variants.
+- Kimi OAuth (just merged).
+
+## What goes
+
+- Provider enum variants, env handling, defaults, base URLs, normalization, tests, and docs for the six removed providers.
+- Test sentinels using `MiniMax-M2.7` / `glm-5` replaced with `deepseek-v4-pro` (the tests still cover passthrough behavior).
+
+## Out of scope
+
+Codex/ChatGPT OAuth (still removed — verified). Web/marketing site. npm wrapper version. Broader provider work goes to future branches.
+
+## Test plan
+
+- [ ] `cargo fmt --all -- --check`
+- [ ] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
+- [ ] `cargo test --workspace --all-features --locked`
+- [ ] Parity gates: snapshot, parity_protocol, parity_state
+- [ ] `./target/debug/codewhale --version` and `codewhale-tui --version`
+- [ ] Kimi OAuth smoke (configure key, list models, run a turn)
+- [ ] DeepSeek default path smoke
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Do NOT merge. Report PR URL.**
+
+---
+
+## Self-Review Checklist (run before handing off)
+
+- [x] Spec coverage: every requirement in the user's narrowed scope (DeepSeek + self-host backends + Kimi K2.6) is implemented; every removed provider is addressed in Tasks 1-7; verification in 8-10; PR in 11.
+- [x] No placeholders. Each task names the exact files and the exact strings to search/delete.
+- [x] Type consistency: `ProviderKind` variant names match across tasks; struct field names match.
+- [x] Approved set documented in the header so reviewers (and future me) can sanity-check the diff against one source of truth.
+- [x] Test discipline: tests for removed code are deleted; tests for kept code are preserved and re-run after each task; sentinel tests using non-shipped model strings are repaired, not silently removed.
+- [x] Cargo.lock cleanliness: no dep changes; the build picks up the trimmed code without lockfile drift.
+- [x] Bypass discipline: no `--no-verify`, no `_ =>` wildcards added to provider matches (exhaustiveness is the safety net).


### PR DESCRIPTION
## Summary

Narrows the v0.8.45 release surface to a supportable set:

- **DeepSeek** (first-class) on `api.deepseek.com` plus documented self-host backends: **NVIDIA NIM**, **SGLang**, **vLLM**, **Ollama**.
- **Kimi K2.6** via **Moonshot** (the OAuth path that just landed on `main` is preserved).

Removes from runtime, pickers, completions, secrets, docs, examples, and tests every reference to providers we are not committing to support in 0.8.45: generic OpenAI-compatible, AtlasCloud, WanjieArk, OpenRouter, Novita, Fireworks.

Net diff: **-1663 LOC across 21 files** (mostly deletions plus the plan doc).

## What stays

- `ProviderKind` / `ApiProvider`: `Deepseek`, `DeepseekCN`, `NvidiaNim`, `Moonshot`, `Sglang`, `Vllm`, `Ollama`.
- Models: `deepseek-v4-pro`, `deepseek-v4-flash` (with legacy aliases `deepseek-chat`, `deepseek-reasoner`, `deepseek-r1`, `deepseek-v3`, `deepseek-v3.2`), self-host variants of those, `kimi-k2.6` (with `kimi` / `kimi-k2` / `moonshot-kimi-k2.6` aliases), `deepseek-coder:1.3b` (Ollama).
- Kimi OAuth (kimi-for-coding, `auth_mode = "kimi_oauth"`).
- Codex/ChatGPT OAuth stays removed (verified — no `chatgpt_backend.rs`, no `codex-oauth` references).

## What goes

- Six `ProviderKind` / `ApiProvider` variants and every match arm that named them.
- `[providers.openai]` / `[providers.atlascloud]` / `[providers.wanjie_ark]` / `[providers.openrouter]` / `[providers.novita]` / `[providers.fireworks]` from `ProvidersToml` / `ProvidersConfig`.
- `OPENAI_*`, `ATLASCLOUD_*`, `WANJIE_*`, `OPENROUTER_*`, `NOVITA_*`, `FIREWORKS_*` env-var handling in `EnvRuntimeOverrides`, `crates/secrets`, and the TUI per-provider env loader.
- ModelInfo registry entries for those providers (`crates/agent/src/lib.rs`).
- The corresponding provider-default / env-fallback / passthrough / capability tests.
- Public docs and `config.example.toml` sections.
- Test sentinels using `MiniMax-M2.7` / `glm-5` as generic non-DeepSeek placeholders — replaced with approved models so the passthrough behaviour stays covered.

## Side fixes

- **Moonshot config-key interface gap.** `Config::{get,set,unset}_value` and `list_values` were missing `providers.moonshot.*` keys — so `codewhale config set providers.moonshot.api_key …` silently fell through. The new release calls Moonshot/Kimi a first-class provider, so the gap is closed here.
- **Provider-config merge for Moonshot.** `merge_project_overrides` learned to merge `providers.moonshot` from project-level config; previously it was the only kept provider being skipped.
- **Two pre-existing clippy lints** (`collapsible_str_replace` in `normalize_auth_mode`, `cmp_owned` in `goal.rs` test) fixed to keep CI green under `-D warnings`.

## Out of scope

- Codex/ChatGPT OAuth (already removed in prior releases; verified absent in this PR).
- Web / marketing site, npm wrapper version bump.
- Reintroducing any removed provider — that goes to future branches and milestones.

## Commits

```
fix(v0.8.45): drop non-approved providers from agent registry
fix(v0.8.45): remove non-approved providers from config
fix(v0.8.45): repair config tests + close moonshot config-key gap
fix(v0.8.45): trim secrets env lookups to approved provider set
fix(v0.8.45): scrub removed providers from TUI
fix(v0.8.45): trim CLI provider surface to approved set
docs(v0.8.45): scrub removed providers from public docs
style: cargo fmt after provider scope narrowing
fix: satisfy clippy collapsible_str_replace and cmp_owned
```

## Test plan

Already green locally:

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- [x] `cargo test --workspace --all-features --locked` (3313 TUI unit + integration tests + agent/config/secrets/cli/etc.)
- [x] Parity gates: `codewhale-tui-core::snapshot`, `codewhale-protocol::parity_protocol`, `codewhale-state::parity_state`
- [x] `./scripts/release/check-versions.sh` (workspace=0.8.45, npm=0.8.45, lockfile in sync)
- [x] `./target/debug/codewhale --version` → `codewhale 0.8.45`
- [x] `./target/debug/codewhale-tui --version` → `codewhale-tui 0.8.45`
- [x] `Cargo.lock` clean (`git diff --exit-code -- Cargo.lock`)

Recommended pre-merge checks on a fresh shell:

- [ ] DeepSeek default path smoke (single one-shot)
- [ ] Kimi OAuth smoke (`/provider moonshot`, OAuth path, single turn)
- [ ] NVIDIA NIM smoke if NVIDIA_API_KEY is available
- [ ] CI on Ubuntu / macOS / Windows

**Do not merge without review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hmbown/codewhale/pull/2150" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR narrows the v0.8.45 supported provider set to DeepSeek (official + self-host), NVIDIA NIM, Moonshot/Kimi K2.6, SGLang, vLLM, and Ollama, removing six providers (OpenAI-compatible, AtlasCloud, WanjieArk, OpenRouter, Novita, Fireworks) from every layer: enum variants, config structs, secrets env lookups, CLI, TUI pickers, model completions, docs, and tests.

- Removes six `ProviderKind`/`ApiProvider` variants and all their match arms across `crates/config`, `crates/secrets`, `crates/cli`, `crates/agent`, and every TUI module; replaces provider-specific test placeholders with Moonshot/NVIDIA NIM equivalents.
- Closes a pre-existing Moonshot config-key gap (`providers.moonshot.*` keys now handled in `get/set/unset_value` and `list_values`), adds `merge_project_overrides` support for `providers.moonshot`, and fixes two clippy lints (`collapsible_str_replace`, `cmp_owned`).
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the removals are consistent across all layers and the remaining six-provider set is internally coherent.

The change is a large but mechanical deletion — every removed provider was scrubbed from enums, match arms, config structs, env lookups, model completions, picker UI, CLI args, and tests in a consistent way, and three pre-existing gaps (Moonshot config-key, merge_project_overrides, two clippy lints) were also closed. The only residual issues are two stale test strings and an inert always-false variable — none affect runtime behaviour.

crates/tui/src/tui/provider_picker.rs has two stale comment/string artefacts from the Novita→NvidiaNim migration that should be updated before merge.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/config/src/lib.rs | Removes six ProviderKind variants and all match arms, default constants, EnvRuntimeOverrides fields, and test coverage for dropped providers; adds full providers.moonshot.* handling in get/set/unset_value and list_values; logic is consistent and complete. |
| crates/tui/src/config.rs | Mirrors config/src/lib.rs: removes six ApiProvider variants and all associated match arms, default constants, ProvidersConfig fields, env-override branches, and merge helpers; all match arms remain exhaustive. |
| crates/tui/src/tui/provider_picker.rs | Removes six providers from the picker list and env-var display; replaces test helpers that referenced Novita/Openrouter with NvidiaNim, but leaves a stale comment and stale key string in the key-entry test. |
| crates/secrets/src/lib.rs | Drops env-var lookup arms for six removed providers; adds a new test that explicitly asserts those provider names now return None from env_for(), providing a clear regression guard. |
| crates/cli/src/lib.rs | Removes six ProviderArg variants and their From/match impls; shrinks PROVIDER_LIST from 12 to 6 entries; updates TUI-support guard and key-forwarding logic for the remaining set. |
| crates/agent/src/lib.rs | Removes ModelInfo registry entries for OpenAI, WanjieArk, OpenRouter, Novita, and Fireworks providers; drops corresponding resolver tests; no regressions to remaining provider resolution logic. |
| crates/tui/src/client.rs | Removes reasoning-effort arms for Openrouter, Novita, Fireworks, Openai, Atlascloud, WanjieArk; remaining reasoning logic for DeepSeek, NvidiaNim, vLLM, Moonshot, Ollama, Sglang is preserved correctly. |
| crates/tui/src/client/chat.rs | Removes removed providers from provider_accepts_reasoning_content; consolidates reasoning-stream classification tests to loop over only the approved set; renames SSE decoder robustness test to be provider-agnostic. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CLI / TUI startup] --> B{Provider selection}
    B -->|deepseek / deepseek-cn| C[Deepseek]
    B -->|nvidia-nim / nim| D[NvidiaNim]
    B -->|moonshot / kimi| E[Moonshot]
    B -->|sglang| F[Sglang]
    B -->|vllm| G[Vllm]
    B -->|ollama| H[Ollama]
    B -->|openai / atlascloud / wanjie-ark / openrouter / novita / fireworks| X[Removed in v0.8.45 - returns None / error]

    C --> C1[api.deepseek.com - deepseek-v4-pro]
    D --> D1[integrate.api.nvidia.com - deepseek-ai/deepseek-v4-pro]
    E -->|api_key| E1[api.moonshot.ai - kimi-k2.6]
    E -->|kimi_oauth| E2[api.kimi.com/coding - kimi-for-coding]
    F --> F1[localhost:30000 - deepseek-ai/DeepSeek-V4-Pro]
    G --> G1[localhost:8000 - deepseek-ai/DeepSeek-V4-Pro]
    H --> H1[localhost:11434 - deepseek-coder:1.3b]

    style X fill:#ff6b6b,color:#fff
```
</details>

<a href="https://app.greptile.com/api/ide/devin?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fv0.8.45-provider-scope%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fv0.8.45-provider-scope%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Ftui%2Fsrc%2Ftui%2Fprovider_picker.rs%3A466-470%0AThe%20comment%20and%20key%20string%20are%20stale%20from%20the%20Novita-to-NvidiaNim%20migration.%20The%20test%20still%20passes%20because%20the%20assertion%20only%20checks%20that%20the%20emitted%20%60api_key%60%20equals%20whatever%20was%20typed%20%E2%80%94%20but%20the%20values%20are%20confusing%20and%20will%20mislead%20anyone%20reading%20this%20test%20in%20the%20future.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Navigate%20to%20NvidiaNim%20and%20trigger%20key%20entry.%0A%20%20%20%20%20%20%20%20move_to_provider%28%26mut%20picker%2C%20ApiProvider%3A%3ANvidiaNim%29%3B%0A%20%20%20%20%20%20%20%20picker.handle_key%28key%28KeyCode%3A%3AEnter%29%29%3B%0A%20%20%20%20%20%20%20%20assert_eq!%28picker.stage%2C%20Stage%3A%3AKeyEntry%29%3B%0A%20%20%20%20%20%20%20%20for%20c%20in%20%22nim-key%22.chars%28%29%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Ftui%2Fsrc%2Ftui%2Fprovider_picker.rs%3A479-480%0AThe%20asserted%20%60api_key%60%20value%20is%20still%20%60%22novita-key%22%60%20after%20the%20provider%20was%20changed%20to%20%60NvidiaNim%60.%20The%20assertion%20remains%20semantically%20correct%20%28it%20matches%20what%20was%20typed%20in%20the%20loop%20above%29%2C%20but%20should%20be%20updated%20alongside%20the%20loop%20string%20to%20avoid%20confusion.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20assert_eq!%28provider%2C%20ApiProvider%3A%3ANvidiaNim%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20assert_eq!%28api_key%2C%20%22nim-key%22%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Ftui%2Fsrc%2Fconfig.rs%3A236-239%0AWith%20%60WanjieArk%60%20removed%2C%20%60is_reasoner%60%20is%20now%20always%20%60false%60%2C%20making%20the%20%60%7C%7C%20is_reasoner%60%20arm%20in%20%60thinking_supported%60%20dead.%20This%20is%20harmless%20and%20clippy%20doesn't%20flag%20it%2C%20but%20removing%20the%20variable%20makes%20the%20intent%20clearer%20and%20avoids%20any%20future%20confusion%20about%20whether%20%22reasoner%22%20detection%20is%20still%20active%20for%20the%20remaining%20providers.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%20Context%20window%3A%20V4-class%20models%20get%201M%2C%20everything%20else%20falls%20through%0A%20%20%20%20%2F%2F%20to%20the%20model's%20own%20lookup%20or%20a%20default.%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&tid=69448&ts=1779761848&sig=54304f10f1096e7f9e4cf4cecfb73d009d15462f030bfe48d2e3fac3898aca53&pr=2150&platform=github&fid=6a024898-22f4-436f-9a3d-06aaa18e682a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInDevinDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInDevin.svg?v=3"><img alt="Fix All in Devin" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInDevin.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix: satisfy clippy collapsible\_str\_repl..."](https://github.com/hmbown/codewhale/commit/4b755296c9fe315270bf7da4ddaed05654e0794f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33851596)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->