### PR TITLE
feat: session token breakdown in footer and /status

### DIFF
--- a/crates/tui/src/commands/core.rs
+++ b/crates/tui/src/commands/core.rs
@@ -55,10 +55,7 @@ pub fn clear(app: &mut App) -> CommandResult {
     app.queued_draft = None;
     app.session.total_tokens = 0;
     app.session.total_conversation_tokens = 0;
-    app.session.total_input_tokens = 0;
-    app.session.total_cache_hit_tokens = 0;
-    app.session.total_cache_miss_tokens = 0;
-    app.session.total_output_tokens = 0;
+    app.session.reset_token_breakdown();
     app.session.session_cost = 0.0;
     app.session.session_cost_cny = 0.0;
     app.session.subagent_cost = 0.0;

--- a/crates/tui/src/commands/core.rs
+++ b/crates/tui/src/commands/core.rs
@@ -55,6 +55,10 @@ pub fn clear(app: &mut App) -> CommandResult {
     app.queued_draft = None;
     app.session.total_tokens = 0;
     app.session.total_conversation_tokens = 0;
+    app.session.total_input_tokens = 0;
+    app.session.total_cache_hit_tokens = 0;
+    app.session.total_cache_miss_tokens = 0;
+    app.session.total_output_tokens = 0;
     app.session.session_cost = 0.0;
     app.session.session_cost_cny = 0.0;
     app.session.subagent_cost = 0.0;

--- a/crates/tui/src/commands/session.rs
+++ b/crates/tui/src/commands/session.rs
@@ -174,6 +174,11 @@ pub fn load(app: &mut App, path: Option<&str>) -> CommandResult {
     app.workspace.clone_from(&session.metadata.workspace);
     app.session.total_tokens = u32::try_from(session.metadata.total_tokens).unwrap_or(u32::MAX);
     app.session.total_conversation_tokens = app.session.total_tokens;
+    // Accumulated token breakdown is per-runtime-session; zero on load.
+    app.session.total_input_tokens = 0;
+    app.session.total_cache_hit_tokens = 0;
+    app.session.total_cache_miss_tokens = 0;
+    app.session.total_output_tokens = 0;
     app.session.session_cost = 0.0;
     app.session.session_cost_cny = 0.0;
     app.session.subagent_cost = 0.0;

--- a/crates/tui/src/commands/session.rs
+++ b/crates/tui/src/commands/session.rs
@@ -175,10 +175,7 @@ pub fn load(app: &mut App, path: Option<&str>) -> CommandResult {
     app.session.total_tokens = u32::try_from(session.metadata.total_tokens).unwrap_or(u32::MAX);
     app.session.total_conversation_tokens = app.session.total_tokens;
     // Accumulated token breakdown is per-runtime-session; zero on load.
-    app.session.total_input_tokens = 0;
-    app.session.total_cache_hit_tokens = 0;
-    app.session.total_cache_miss_tokens = 0;
-    app.session.total_output_tokens = 0;
+    app.session.reset_token_breakdown();
     app.session.session_cost = 0.0;
     app.session.session_cost_cny = 0.0;
     app.session.subagent_cost = 0.0;

--- a/crates/tui/src/commands/status.rs
+++ b/crates/tui/src/commands/status.rs
@@ -66,6 +66,24 @@ fn format_status(app: &App) -> String {
     push_row(&mut out, "Cache hit/miss:", &cache_summary(app));
     push_row(
         &mut out,
+        "Session input:",
+        &app.session.total_input_tokens.to_string(),
+    );
+    push_row(
+        &mut out,
+        "Session cache:",
+        &format!(
+            "{} hit / {} miss",
+            app.session.total_cache_hit_tokens, app.session.total_cache_miss_tokens
+        ),
+    );
+    push_row(
+        &mut out,
+        "Session output:",
+        &app.session.total_output_tokens.to_string(),
+    );
+    push_row(
+        &mut out,
         "Total tokens:",
         &app.session.total_tokens.to_string(),
     );

--- a/crates/tui/src/commands/status.rs
+++ b/crates/tui/src/commands/status.rs
@@ -69,14 +69,16 @@ fn format_status(app: &App) -> String {
         "Session input:",
         &app.session.total_input_tokens.to_string(),
     );
-    push_row(
-        &mut out,
-        "Session cache:",
-        &format!(
-            "{} hit / {} miss",
-            app.session.total_cache_hit_tokens, app.session.total_cache_miss_tokens
-        ),
-    );
+    let session_cache =
+        if app.session.total_cache_hit_tokens == 0 && app.session.total_cache_miss_tokens == 0 {
+            "not reported".to_string()
+        } else {
+            format!(
+                "{} hit / {} miss",
+                app.session.total_cache_hit_tokens, app.session.total_cache_miss_tokens
+            )
+        };
+    push_row(&mut out, "Session cache:", &session_cache);
     push_row(
         &mut out,
         "Session output:",

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -683,6 +683,8 @@ pub enum StatusItem {
     LastToolElapsed,
     /// Remaining rate-limit budget (placeholder until wired).
     RateLimit,
+    /// Session token usage: input / cache-hit / output.
+    Tokens,
 }
 
 impl StatusItem {
@@ -701,6 +703,7 @@ impl StatusItem {
             StatusItem::Agents,
             StatusItem::ReasoningReplay,
             StatusItem::Cache,
+            StatusItem::Tokens,
         ]
     }
 
@@ -721,6 +724,7 @@ impl StatusItem {
             StatusItem::GitBranch => "git_branch",
             StatusItem::LastToolElapsed => "last_tool_elapsed",
             StatusItem::RateLimit => "rate_limit",
+            StatusItem::Tokens => "tokens",
         }
     }
 
@@ -741,6 +745,7 @@ impl StatusItem {
             StatusItem::GitBranch => "Git branch",
             StatusItem::LastToolElapsed => "Last tool elapsed",
             StatusItem::RateLimit => "Rate-limit remaining",
+            StatusItem::Tokens => "Session tokens",
         }
     }
 
@@ -762,6 +767,7 @@ impl StatusItem {
             StatusItem::GitBranch => "current workspace branch",
             StatusItem::LastToolElapsed => "ms of the most recent tool call (placeholder)",
             StatusItem::RateLimit => "remaining requests in the budget (placeholder)",
+            StatusItem::Tokens => "input / cache-hit / output token totals",
         }
     }
 
@@ -782,6 +788,7 @@ impl StatusItem {
             StatusItem::GitBranch,
             StatusItem::LastToolElapsed,
             StatusItem::RateLimit,
+            StatusItem::Tokens,
         ]
     }
 

--- a/crates/tui/src/config_ui.rs
+++ b/crates/tui/src/config_ui.rs
@@ -278,6 +278,7 @@ pub enum StatusItemValue {
     GitBranch,
     LastToolElapsed,
     RateLimit,
+    Tokens,
 }
 
 pub fn parse_mode(arg: Option<&str>) -> Result<ConfigUiMode, String> {
@@ -996,6 +997,7 @@ impl From<StatusItem> for StatusItemValue {
             StatusItem::GitBranch => Self::GitBranch,
             StatusItem::LastToolElapsed => Self::LastToolElapsed,
             StatusItem::RateLimit => Self::RateLimit,
+            StatusItem::Tokens => Self::Tokens,
         }
     }
 }
@@ -1016,6 +1018,7 @@ impl From<StatusItemValue> for StatusItem {
             StatusItemValue::GitBranch => Self::GitBranch,
             StatusItemValue::LastToolElapsed => Self::LastToolElapsed,
             StatusItemValue::RateLimit => Self::RateLimit,
+            StatusItemValue::Tokens => Self::Tokens,
         }
     }
 }

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -1041,6 +1041,16 @@ impl Default for SessionState {
     }
 }
 
+impl SessionState {
+    /// Reset the accumulated token breakdown fields to zero.
+    pub fn reset_token_breakdown(&mut self) {
+        self.total_input_tokens = 0;
+        self.total_cache_hit_tokens = 0;
+        self.total_cache_miss_tokens = 0;
+        self.total_output_tokens = 0;
+    }
+}
+
 /// Evidence collected during a turn for the post-turn receipt.
 #[derive(Debug, Clone)]
 pub struct ToolEvidence {

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -1005,6 +1005,11 @@ pub struct SessionState {
     pub last_reasoning_replay_tokens: Option<u32>,
     pub total_tokens: u32,
     pub total_conversation_tokens: u32,
+    /// Accumulated token breakdown for the session.
+    pub total_input_tokens: u32,
+    pub total_cache_hit_tokens: u32,
+    pub total_cache_miss_tokens: u32,
+    pub total_output_tokens: u32,
     pub turn_cache_history: VecDeque<TurnCacheRecord>,
     pub last_cache_inspection: Option<PromptInspection>,
 }
@@ -1026,6 +1031,10 @@ impl Default for SessionState {
             last_reasoning_replay_tokens: None,
             total_tokens: 0,
             total_conversation_tokens: 0,
+            total_input_tokens: 0,
+            total_cache_hit_tokens: 0,
+            total_cache_miss_tokens: 0,
+            total_output_tokens: 0,
             turn_cache_history: VecDeque::new(),
             last_cache_inspection: None,
         }

--- a/crates/tui/src/tui/footer_ui.rs
+++ b/crates/tui/src/tui/footer_ui.rs
@@ -605,12 +605,14 @@ pub(crate) fn footer_session_tokens_spans(app: &App) -> Vec<Span<'static>> {
         return Vec::new();
     }
     let in_str = format_token_count_compact(u64::from(session.total_input_tokens));
-    let cache_str = format_token_count_compact(u64::from(session.total_cache_hit_tokens));
     let out_str = format_token_count_compact(u64::from(session.total_output_tokens));
-    vec![Span::styled(
-        format!("{in_str} in · {cache_str} cch · {out_str} out"),
-        Style::default().fg(palette::TEXT_MUTED),
-    )]
+    let text = if session.total_cache_hit_tokens == 0 && session.total_cache_miss_tokens == 0 {
+        format!("{in_str} in · {out_str} out")
+    } else {
+        let cache_str = format_token_count_compact(u64::from(session.total_cache_hit_tokens));
+        format!("{in_str} in · {cache_str} cch · {out_str} out")
+    };
+    vec![Span::styled(text, Style::default().fg(palette::TEXT_MUTED))]
 }
 
 /// Test-only helper retained as a parity reference for `FooterWidget`'s

--- a/crates/tui/src/tui/footer_ui.rs
+++ b/crates/tui/src/tui/footer_ui.rs
@@ -518,6 +518,7 @@ pub(crate) fn render_footer_from(
             S::ContextPercent => footer_context_percent_spans(app),
             S::GitBranch => footer_git_branch_spans(app),
             S::LastToolElapsed | S::RateLimit => Vec::new(),
+            S::Tokens => footer_session_tokens_spans(app),
             _ => continue,
         };
         if chip.is_empty() {
@@ -591,6 +592,25 @@ pub(crate) fn footer_cost_spans(app: &App) -> Vec<Span<'static>> {
 
 pub(crate) fn should_show_footer_cost(displayed_cost: f64) -> bool {
     displayed_cost.is_finite() && displayed_cost > 0.0
+}
+
+/// Session token-usage chip for the footer right cluster.
+///
+/// Renders the accumulated input / cache-hit / output token breakdown
+/// since the current runtime session started (not persisted across
+/// restarts). Returns empty when no tokens have been recorded yet.
+pub(crate) fn footer_session_tokens_spans(app: &App) -> Vec<Span<'static>> {
+    let session = &app.session;
+    if session.total_input_tokens == 0 && session.total_output_tokens == 0 {
+        return Vec::new();
+    }
+    let in_str = format_token_count_compact(u64::from(session.total_input_tokens));
+    let cache_str = format_token_count_compact(u64::from(session.total_cache_hit_tokens));
+    let out_str = format_token_count_compact(u64::from(session.total_output_tokens));
+    vec![Span::styled(
+        format!("{in_str} in · {cache_str} cch · {out_str} out"),
+        Style::default().fg(palette::TEXT_MUTED),
+    )]
 }
 
 /// Test-only helper retained as a parity reference for `FooterWidget`'s

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -1442,19 +1442,20 @@ async fn run_event_loop(
                             .session
                             .total_output_tokens
                             .saturating_add(usage.output_tokens);
-                        app.session.total_cache_hit_tokens = app
-                            .session
-                            .total_cache_hit_tokens
-                            .saturating_add(usage.prompt_cache_hit_tokens.unwrap_or(0));
-                        let cache_miss = usage.prompt_cache_miss_tokens.unwrap_or_else(|| {
-                            usage
-                                .input_tokens
-                                .saturating_sub(usage.prompt_cache_hit_tokens.unwrap_or(0))
-                        });
-                        app.session.total_cache_miss_tokens = app
-                            .session
-                            .total_cache_miss_tokens
-                            .saturating_add(cache_miss);
+                        // Only accumulate cache telemetry when reported.
+                        if let Some(hit_tokens) = usage.prompt_cache_hit_tokens {
+                            app.session.total_cache_hit_tokens = app
+                                .session
+                                .total_cache_hit_tokens
+                                .saturating_add(hit_tokens);
+                            let cache_miss = usage
+                                .prompt_cache_miss_tokens
+                                .unwrap_or_else(|| usage.input_tokens.saturating_sub(hit_tokens));
+                            app.session.total_cache_miss_tokens = app
+                                .session
+                                .total_cache_miss_tokens
+                                .saturating_add(cache_miss);
+                        }
                         app.session.last_prompt_tokens = Some(usage.input_tokens);
                         app.session.last_completion_tokens = Some(usage.output_tokens);
                         app.session.last_prompt_cache_hit_tokens = usage.prompt_cache_hit_tokens;
@@ -6628,11 +6629,9 @@ fn apply_loaded_session(app: &mut App, config: &Config, session: &SavedSession) 
     app.session.last_prompt_cache_miss_tokens = None;
     app.session.last_reasoning_replay_tokens = None;
     // Accumulated token breakdown is per-runtime-session; reset on load.
-    app.session.total_input_tokens = 0;
-    app.session.total_cache_hit_tokens = 0;
-    app.session.total_cache_miss_tokens = 0;
-    app.session.total_output_tokens = 0;
+    app.session.reset_token_breakdown();
     app.session.turn_cache_history.clear();
+    app.current_session_id = Some(session.metadata.id.clone());
     app.session_artifacts = session.artifacts.clone();
     app.session_title = Some(session.metadata.title.clone());
     app.workspace_context = None;

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -1434,6 +1434,27 @@ async fn run_event_loop(
                             .session
                             .total_conversation_tokens
                             .saturating_add(turn_tokens);
+                        app.session.total_input_tokens = app
+                            .session
+                            .total_input_tokens
+                            .saturating_add(usage.input_tokens);
+                        app.session.total_output_tokens = app
+                            .session
+                            .total_output_tokens
+                            .saturating_add(usage.output_tokens);
+                        app.session.total_cache_hit_tokens = app
+                            .session
+                            .total_cache_hit_tokens
+                            .saturating_add(usage.prompt_cache_hit_tokens.unwrap_or(0));
+                        let cache_miss = usage.prompt_cache_miss_tokens.unwrap_or_else(|| {
+                            usage
+                                .input_tokens
+                                .saturating_sub(usage.prompt_cache_hit_tokens.unwrap_or(0))
+                        });
+                        app.session.total_cache_miss_tokens = app
+                            .session
+                            .total_cache_miss_tokens
+                            .saturating_add(cache_miss);
                         app.session.last_prompt_tokens = Some(usage.input_tokens);
                         app.session.last_completion_tokens = Some(usage.output_tokens);
                         app.session.last_prompt_cache_hit_tokens = usage.prompt_cache_hit_tokens;
@@ -6606,8 +6627,12 @@ fn apply_loaded_session(app: &mut App, config: &Config, session: &SavedSession) 
     app.session.last_prompt_cache_hit_tokens = None;
     app.session.last_prompt_cache_miss_tokens = None;
     app.session.last_reasoning_replay_tokens = None;
+    // Accumulated token breakdown is per-runtime-session; reset on load.
+    app.session.total_input_tokens = 0;
+    app.session.total_cache_hit_tokens = 0;
+    app.session.total_cache_miss_tokens = 0;
+    app.session.total_output_tokens = 0;
     app.session.turn_cache_history.clear();
-    app.current_session_id = Some(session.metadata.id.clone());
     app.session_artifacts = session.artifacts.clone();
     app.session_title = Some(session.metadata.title.clone());
     app.workspace_context = None;


### PR DESCRIPTION
## Summary

Re-submit of #1666, rebased onto current `main` (v0.8.45) after the CodeWhale rebrand.

Add accumulated session token tracking with input / cache-hit / output breakdown:

- **SessionState**: new `total_input_tokens`, `total_cache_hit_tokens`, `total_cache_miss_tokens`, `total_output_tokens` fields
- **Turn outcome handler**: accumulate per-turn token breakdown from `usage` struct
- **StatusItem::Tokens**: new footer chip, enabled by default
- **Footer chip**: compact format — `12K in · 8.1K cch · 2.5K out`
- **/status command**: expanded with session input / cache / output rows
- **/clear and /load**: reset accumulated breakdown (per-runtime-session, not persisted)

### Verified

- `cargo fmt --check` ✓
- `cargo check` ✓
- `cargo clippy` ✓ (no new warnings)
- `cargo test --workspace --all-features` — 3329 passed; 2 pre-existing failures unrelated to this change

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds accumulated session token tracking (input / cache-hit / cache-miss / output) to the TUI footer chip and `/status` command. It is a rebase of #1666 onto the CodeWhale-branded `main`.

- **`SessionState`** gains four `u32` accumulator fields and a `reset_token_breakdown` helper that is called consistently from `/clear`, `/load`, and `apply_loaded_session`, keeping all token-reset paths in sync.
- **`TurnOutcome` handler** accumulates per-turn input and output tokens unconditionally; cache telemetry is gated on `prompt_cache_hit_tokens` being `Some`, which avoids double-counting when the provider doesn't report cache data.
- **Footer chip** (`StatusItem::Tokens`, enabled by default) renders a compact `N in · N cch · N out` label; the chip is hidden until the first turn completes. The `/status` command gets three new rows showing the same breakdown in raw counts.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; all accumulation, reset, and display paths are correctly wired and symmetric.

The accumulation logic is straightforward: four counters incremented per turn, reset in all three load/clear paths, displayed in the footer chip and `/status`. The cache-telemetry guard (`if let Some(hit_tokens)`) correctly prevents double-counting when the provider omits cache fields. Config enum and UI mappings are complete with no missing arms. The only gaps are missing test assertions for the new `/status` rows.

The `status_report_includes_runtime_fields` test in `crates/tui/src/commands/status.rs` would benefit from asserting the new Session input/cache/output rows.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/app.rs | Adds four `u32` accumulator fields and a `reset_token_breakdown` helper to `SessionState`; defaults are zero and the `Default` impl is updated correctly. |
| crates/tui/src/tui/ui.rs | Accumulates per-turn input/output/cache-hit/cache-miss tokens in the `TurnOutcome` handler; cache telemetry is gated on `prompt_cache_hit_tokens` being `Some`, avoiding the double-count bug. Also calls `reset_token_breakdown` inside `apply_loaded_session`. |
| crates/tui/src/tui/footer_ui.rs | Adds `footer_session_tokens_spans` and wires it into the `Tokens` chip slot; chip is hidden when both input and output are zero, consistent with other optional chips. |
| crates/tui/src/commands/status.rs | Adds three new rows to `/status` output (Session input/cache/output); existing test does not assert the new rows, so a regression there would go undetected. |
| crates/tui/src/commands/core.rs | Calls `reset_token_breakdown` in the `/clear` handler alongside the existing token-counter resets; correctly symmetric with the load and session-select paths. |
| crates/tui/src/commands/session.rs | Calls `reset_token_breakdown` in the `/load` handler; comment correctly explains that the breakdown is per-runtime-session, not persisted. |
| crates/tui/src/config.rs | Adds `StatusItem::Tokens` to the enum and all five required match arms (`key`, `label`, `description`, `defaults`, `all`); no arms are missing. |
| crates/tui/src/config_ui.rs | Mirrors `StatusItem::Tokens` into `StatusItemValue` with both `From` impls updated symmetrically. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Engine
    participant ui.rs as run_event_loop
    participant SessionState
    participant FooterUI as footer_ui.rs
    participant StatusCmd as /status

    Engine->>ui.rs: "TurnOutcome { usage }"
    ui.rs->>SessionState: "total_input_tokens += usage.input_tokens"
    ui.rs->>SessionState: "total_output_tokens += usage.output_tokens"
    alt prompt_cache_hit_tokens is Some(hit)
        ui.rs->>SessionState: "total_cache_hit_tokens += hit"
        ui.rs->>SessionState: "total_cache_miss_tokens += miss (or input-hit)"
    end

    Note over ui.rs,SessionState: /clear or /load or apply_loaded_session
    ui.rs->>SessionState: reset_token_breakdown()

    SessionState-->>FooterUI: total_input/cache_hit/output_tokens
    FooterUI-->>FooterUI: render N in · N cch · N out chip

    SessionState-->>StatusCmd: total_input/cache_hit/cache_miss/output_tokens
    StatusCmd-->>StatusCmd: render Session input/cache/output rows
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fsession-token-breakdown-v2%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fsession-token-breakdown-v2%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Ftui%2Fsrc%2Fcommands%2Fstatus.rs%3A232-236%0AThe%20%60status_report_includes_runtime_fields%60%20test%20doesn't%20assert%20the%20three%20new%20rows%20added%20by%20this%20PR.%20If%20the%20labels%20or%20the%20accumulator%20fields%20were%20accidentally%20broken%20or%20removed%2C%20the%20test%20would%20still%20pass.%20Setting%20the%20new%20fields%20to%20non-zero%20values%20and%20asserting%20their%20presence%20would%20catch%20regressions.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20app.session.total_tokens%20%3D%201234%3B%0A%20%20%20%20%20%20%20%20app.session.last_prompt_tokens%20%3D%20Some%28100%29%3B%0A%20%20%20%20%20%20%20%20app.session.last_completion_tokens%20%3D%20Some%2825%29%3B%0A%20%20%20%20%20%20%20%20app.session.last_prompt_cache_hit_tokens%20%3D%20Some%2870%29%3B%0A%20%20%20%20%20%20%20%20app.session.last_prompt_cache_miss_tokens%20%3D%20Some%2830%29%3B%0A%20%20%20%20%20%20%20%20app.session.total_input_tokens%20%3D%20500%3B%0A%20%20%20%20%20%20%20%20app.session.total_cache_hit_tokens%20%3D%20200%3B%0A%20%20%20%20%20%20%20%20app.session.total_cache_miss_tokens%20%3D%20300%3B%0A%20%20%20%20%20%20%20%20app.session.total_output_tokens%20%3D%2080%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Ftui%2Fsrc%2Fcommands%2Fstatus.rs%3A260-262%0APairing%20with%20the%20suggestion%20above%3A%20assert%20the%20new%20rows%20appear%20in%20the%20output%20so%20a%20future%20removal%20or%20label%20change%20is%20caught.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20assert!%28msg.contains%28%22Cache%20hit%2Fmiss%3A%22%29%29%3B%0A%20%20%20%20%20%20%20%20assert!%28msg.contains%28%2270%20hit%20%2F%2030%20miss%22%29%29%3B%0A%20%20%20%20%20%20%20%20assert!%28msg.contains%28%22Session%20input%3A%22%29%29%3B%0A%20%20%20%20%20%20%20%20assert!%28msg.contains%28%22Session%20cache%3A%22%29%29%3B%0A%20%20%20%20%20%20%20%20assert!%28msg.contains%28%22200%20hit%20%2F%20300%20miss%22%29%29%3B%0A%20%20%20%20%20%20%20%20assert!%28msg.contains%28%22Session%20output%3A%22%29%29%3B%0A%20%20%20%20%20%20%20%20assert!%28msg.contains%28%22Use%20%2Fstatusline%20to%20configure%20footer%20items.%22%29%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Ftui%2Fsrc%2Ftui%2Ffooter_ui.rs%3A609-613%0A**Footer%20hides%20cache%20column%20when%20hit%20count%20is%20zero**%0A%0AWhen%20a%20provider%20reports%20cache%20data%20with%20zero%20hits%20%28e.g.%20%60prompt_cache_hit_tokens%3A%20Some%280%29%60%2C%20%60prompt_cache_miss_tokens%3A%20Some%28N%29%60%29%2C%20the%20accumulation%20logic%20will%20leave%20%60total_cache_hit_tokens%20%3D%200%60%20while%20%60total_cache_miss_tokens%20%3D%20N%60.%20The%20condition%20%60total_cache_hit_tokens%20%3D%3D%200%20%26%26%20total_cache_miss_tokens%20%3D%3D%200%60%20would%20be%20false%20in%20this%20case%2C%20so%20the%20column%20would%20still%20appear%20%E2%80%94%20this%20specific%20scenario%20is%20handled%20correctly.%20However%20the%20symmetric%20edge%20case%20%28provider%20reports%20%60Some%280%29%60%20for%20both%29%20would%20keep%20both%20at%200%20and%20the%20footer%20would%20silently%20omit%20the%20cache%20column%20even%20though%20caching%20was%20actively%20reported.%20This%20is%20a%20very%20unlikely%20edge%20case%20but%20worth%20being%20aware%20of%3B%20the%20%60%2Fstatus%60%20output%20has%20the%20same%20ambiguity%20via%20the%20%60%22not%20reported%22%60%20string.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Ftui%2Fsrc%2Fcommands%2Fstatus.rs%3A232-236%0AThe%20%60status_report_includes_runtime_fields%60%20test%20doesn't%20assert%20the%20three%20new%20rows%20added%20by%20this%20PR.%20If%20the%20labels%20or%20the%20accumulator%20fields%20were%20accidentally%20broken%20or%20removed%2C%20the%20test%20would%20still%20pass.%20Setting%20the%20new%20fields%20to%20non-zero%20values%20and%20asserting%20their%20presence%20would%20catch%20regressions.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20app.session.total_tokens%20%3D%201234%3B%0A%20%20%20%20%20%20%20%20app.session.last_prompt_tokens%20%3D%20Some%28100%29%3B%0A%20%20%20%20%20%20%20%20app.session.last_completion_tokens%20%3D%20Some%2825%29%3B%0A%20%20%20%20%20%20%20%20app.session.last_prompt_cache_hit_tokens%20%3D%20Some%2870%29%3B%0A%20%20%20%20%20%20%20%20app.session.last_prompt_cache_miss_tokens%20%3D%20Some%2830%29%3B%0A%20%20%20%20%20%20%20%20app.session.total_input_tokens%20%3D%20500%3B%0A%20%20%20%20%20%20%20%20app.session.total_cache_hit_tokens%20%3D%20200%3B%0A%20%20%20%20%20%20%20%20app.session.total_cache_miss_tokens%20%3D%20300%3B%0A%20%20%20%20%20%20%20%20app.session.total_output_tokens%20%3D%2080%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Ftui%2Fsrc%2Fcommands%2Fstatus.rs%3A260-262%0APairing%20with%20the%20suggestion%20above%3A%20assert%20the%20new%20rows%20appear%20in%20the%20output%20so%20a%20future%20removal%20or%20label%20change%20is%20caught.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20assert!%28msg.contains%28%22Cache%20hit%2Fmiss%3A%22%29%29%3B%0A%20%20%20%20%20%20%20%20assert!%28msg.contains%28%2270%20hit%20%2F%2030%20miss%22%29%29%3B%0A%20%20%20%20%20%20%20%20assert!%28msg.contains%28%22Session%20input%3A%22%29%29%3B%0A%20%20%20%20%20%20%20%20assert!%28msg.contains%28%22Session%20cache%3A%22%29%29%3B%0A%20%20%20%20%20%20%20%20assert!%28msg.contains%28%22200%20hit%20%2F%20300%20miss%22%29%29%3B%0A%20%20%20%20%20%20%20%20assert!%28msg.contains%28%22Session%20output%3A%22%29%29%3B%0A%20%20%20%20%20%20%20%20assert!%28msg.contains%28%22Use%20%2Fstatusline%20to%20configure%20footer%20items.%22%29%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Ftui%2Fsrc%2Ftui%2Ffooter_ui.rs%3A609-613%0A**Footer%20hides%20cache%20column%20when%20hit%20count%20is%20zero**%0A%0AWhen%20a%20provider%20reports%20cache%20data%20with%20zero%20hits%20%28e.g.%20%60prompt_cache_hit_tokens%3A%20Some%280%29%60%2C%20%60prompt_cache_miss_tokens%3A%20Some%28N%29%60%29%2C%20the%20accumulation%20logic%20will%20leave%20%60total_cache_hit_tokens%20%3D%200%60%20while%20%60total_cache_miss_tokens%20%3D%20N%60.%20The%20condition%20%60total_cache_hit_tokens%20%3D%3D%200%20%26%26%20total_cache_miss_tokens%20%3D%3D%200%60%20would%20be%20false%20in%20this%20case%2C%20so%20the%20column%20would%20still%20appear%20%E2%80%94%20this%20specific%20scenario%20is%20handled%20correctly.%20However%20the%20symmetric%20edge%20case%20%28provider%20reports%20%60Some%280%29%60%20for%20both%29%20would%20keep%20both%20at%200%20and%20the%20footer%20would%20silently%20omit%20the%20cache%20column%20even%20though%20caching%20was%20actively%20reported.%20This%20is%20a%20very%20unlikely%20edge%20case%20but%20worth%20being%20aware%20of%3B%20the%20%60%2Fstatus%60%20output%20has%20the%20same%20ambiguity%20via%20the%20%60%22not%20reported%22%60%20string.%0A%0A&repo=hmbown%2Fcodewhale&pr=2152&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Ftui%2Fsrc%2Fcommands%2Fstatus.rs%3A232-236%0AThe%20%60status_report_includes_runtime_fields%60%20test%20doesn't%20assert%20the%20three%20new%20rows%20added%20by%20this%20PR.%20If%20the%20labels%20or%20the%20accumulator%20fields%20were%20accidentally%20broken%20or%20removed%2C%20the%20test%20would%20still%20pass.%20Setting%20the%20new%20fields%20to%20non-zero%20values%20and%20asserting%20their%20presence%20would%20catch%20regressions.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20app.session.total_tokens%20%3D%201234%3B%0A%20%20%20%20%20%20%20%20app.session.last_prompt_tokens%20%3D%20Some%28100%29%3B%0A%20%20%20%20%20%20%20%20app.session.last_completion_tokens%20%3D%20Some%2825%29%3B%0A%20%20%20%20%20%20%20%20app.session.last_prompt_cache_hit_tokens%20%3D%20Some%2870%29%3B%0A%20%20%20%20%20%20%20%20app.session.last_prompt_cache_miss_tokens%20%3D%20Some%2830%29%3B%0A%20%20%20%20%20%20%20%20app.session.total_input_tokens%20%3D%20500%3B%0A%20%20%20%20%20%20%20%20app.session.total_cache_hit_tokens%20%3D%20200%3B%0A%20%20%20%20%20%20%20%20app.session.total_cache_miss_tokens%20%3D%20300%3B%0A%20%20%20%20%20%20%20%20app.session.total_output_tokens%20%3D%2080%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Ftui%2Fsrc%2Fcommands%2Fstatus.rs%3A260-262%0APairing%20with%20the%20suggestion%20above%3A%20assert%20the%20new%20rows%20appear%20in%20the%20output%20so%20a%20future%20removal%20or%20label%20change%20is%20caught.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20assert!%28msg.contains%28%22Cache%20hit%2Fmiss%3A%22%29%29%3B%0A%20%20%20%20%20%20%20%20assert!%28msg.contains%28%2270%20hit%20%2F%2030%20miss%22%29%29%3B%0A%20%20%20%20%20%20%20%20assert!%28msg.contains%28%22Session%20input%3A%22%29%29%3B%0A%20%20%20%20%20%20%20%20assert!%28msg.contains%28%22Session%20cache%3A%22%29%29%3B%0A%20%20%20%20%20%20%20%20assert!%28msg.contains%28%22200%20hit%20%2F%20300%20miss%22%29%29%3B%0A%20%20%20%20%20%20%20%20assert!%28msg.contains%28%22Session%20output%3A%22%29%29%3B%0A%20%20%20%20%20%20%20%20assert!%28msg.contains%28%22Use%20%2Fstatusline%20to%20configure%20footer%20items.%22%29%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Ftui%2Fsrc%2Ftui%2Ffooter_ui.rs%3A609-613%0A**Footer%20hides%20cache%20column%20when%20hit%20count%20is%20zero**%0A%0AWhen%20a%20provider%20reports%20cache%20data%20with%20zero%20hits%20%28e.g.%20%60prompt_cache_hit_tokens%3A%20Some%280%29%60%2C%20%60prompt_cache_miss_tokens%3A%20Some%28N%29%60%29%2C%20the%20accumulation%20logic%20will%20leave%20%60total_cache_hit_tokens%20%3D%200%60%20while%20%60total_cache_miss_tokens%20%3D%20N%60.%20The%20condition%20%60total_cache_hit_tokens%20%3D%3D%200%20%26%26%20total_cache_miss_tokens%20%3D%3D%200%60%20would%20be%20false%20in%20this%20case%2C%20so%20the%20column%20would%20still%20appear%20%E2%80%94%20this%20specific%20scenario%20is%20handled%20correctly.%20However%20the%20symmetric%20edge%20case%20%28provider%20reports%20%60Some%280%29%60%20for%20both%29%20would%20keep%20both%20at%200%20and%20the%20footer%20would%20silently%20omit%20the%20cache%20column%20even%20though%20caching%20was%20actively%20reported.%20This%20is%20a%20very%20unlikely%20edge%20case%20but%20worth%20being%20aware%20of%3B%20the%20%60%2Fstatus%60%20output%20has%20the%20same%20ambiguity%20via%20the%20%60%22not%20reported%22%60%20string.%0A%0A&pr=2152&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix: address review feedback — current\_s..."](https://github.com/hmbown/codewhale/commit/8828bd7b26f42453bca0456919d60b94c7ccee72) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33854972)</sub>

<!-- /greptile_comment -->