### PR TITLE
fix(edit_file): always retry fuzzy fallback on first search miss

### DIFF
--- a/crates/tui/src/tools/file.rs
+++ b/crates/tui/src/tools/file.rs
@@ -496,7 +496,7 @@ impl ToolSpec for EditFileTool {
     }
 
     fn description(&self) -> &'static str {
-        "Replace text in a single file via exact search/replace. Use this instead of `sed -i` in `exec_shell` for one unambiguous in-place edit. `search` matches exactly by default, including whitespace and indentation; set `fuzz: true` to tolerate leading-indentation differences. Returns a compact unified diff, not the full file. For structural, multi-block, or cross-file changes, use `apply_patch` or `write_file` instead."
+        "Replace text in a single file via exact search/replace. Use this instead of `sed -i` in `exec_shell` for one unambiguous in-place edit. `search` matches exactly by default; when no exact match is found the tool retries with leading-whitespace-tolerant fuzzy matching automatically. The optional `fuzz` parameter is accepted for backward compatibility and is no longer needed. Returns a compact unified diff, not the full file. For structural, multi-block, or cross-file changes, use `apply_patch` or `write_file` instead."
     }
 
     fn input_schema(&self) -> Value {
@@ -517,7 +517,7 @@ impl ToolSpec for EditFileTool {
                 },
                 "fuzz": {
                     "type": "boolean",
-                    "description": "When true, tolerate leading whitespace differences on each searched line (default false)"
+                    "description": "Deprecated: fuzzy fallback is now automatic. Accepted for backward compatibility but ignored."
                 }
             },
             "required": ["path", "search", "replace"]
@@ -555,7 +555,7 @@ impl ToolSpec for EditFileTool {
         })?;
 
         let count = contents.matches(search).count();
-        let (updated, count, fuzz_kind) = if count == 0 && fuzz {
+        let (updated, count, fuzz_kind) = if count == 0 {
             // First fallback: tolerate indentation differences.
             let indent_matches = leading_whitespace_fuzzy_matches(&contents, search);
             match indent_matches.as_slice() {
@@ -600,11 +600,6 @@ impl ToolSpec for EditFileTool {
                     )));
                 }
             }
-        } else if count == 0 {
-            return Err(ToolError::execution_failed(format!(
-                "Search string not found in {}",
-                file_path.display()
-            )));
         } else {
             (contents.replace(search, replace), count, None)
         };


### PR DESCRIPTION
The optional `fuzz` parameter was required to attempt the leading-indentation fuzzy fallback when exact search found zero matches. This forced the model to make two calls on every edit that needed fuzzy matching (first without fuzz -> error -> second with fuzz: true), causing a round-trip delay.

Fix: remove the `fuzz` gate from the count == 0 branch. The tool now automatically retries with indentation-tolerant fuzzy matching when exact search produces no results. The `fuzz` parameter is kept in the schema for backward compatibility but marked deprecated.

Changes:
- crates/tui/src/tools/file.rs: `if count == 0 && fuzz` -> `if count == 0` (always retry fuzzy fallback)
- crates/tui/src/tools/file.rs: removed dead `else if count == 0 { error }` branch
- crates/tui/src/tools/file.rs: updated description to note automatic fuzzy fallback
- crates/tui/src/tools/file.rs: marked fuzz parameter as deprecated in schema

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes the `fuzz` gate from the zero-match branch in `EditFileTool::execute`, so the indentation-tolerant and punctuation-normalised fuzzy fallbacks now fire automatically whenever an exact search finds nothing. The `fuzz` schema parameter is retained and marked deprecated for backward compatibility.

- The conditional `if count == 0 && fuzz` is simplified to `if count == 0`, and the now-redundant `else if count == 0 { error }` branch is deleted.
- Tool description and schema description for `fuzz` are updated to reflect the new automatic-fallback behaviour.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the behavioural change is intentional and the fallback error paths are preserved. The only code-quality gap is a now-unused variable that will emit a compiler warning.

The core logic change is small and correct — the fuzzy fallback paths were already there and tested, and the removed branch was made entirely redundant by the restructured condition. The `fuzz` variable is still parsed but never read, which will generate a Rust `unused variable` warning on every build.

crates/tui/src/tools/file.rs — the `fuzz` binding at line 543 should be prefixed with `_` to suppress the compiler warning.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/tui/src/tools/file.rs | Removes the `fuzz` gate so indentation- and punctuation-tolerant fuzzy fallbacks are always tried on an exact-match miss. The `fuzz` binding is now unused, producing a compiler warning. Logic and error paths are otherwise correct. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[edit_file called] --> B{exact match count}
    B -- count > 0 --> C[replace all occurrences]
    B -- "count == 0\n(was: count==0 && fuzz)" --> D[indentation fuzzy match]
    D -- 1 match --> E[replace_range + fuzz_kind = indentation]
    D -- 0 matches --> F[punctuation fuzzy match]
    D -- 2+ matches --> G[Error: ambiguous fuzzy match]
    F -- 1 match --> H[replace_range + fuzz_kind = punctuation]
    F -- 0 matches --> I[Error: search string not found]
    F -- 2+ matches --> J[Error: ambiguous punctuation match]
    C --> K[write file + unified diff]
    E --> K
    H --> K
    B -. removed branch .-> L[was: Error if count==0 and fuzz=false]
    style L stroke-dasharray: 5 5,fill:#ffcccc
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/tui/src/tools/file.rs`, line 543 ([link](https://github.com/hmbown/codewhale/blob/5fc0d1d7da66300894262aa643c41921b0858c83/crates/tui/src/tools/file.rs#L543)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `fuzz` value is parsed into a binding but never referenced after this change. Rust will emit an `unused variable: fuzz` warning for every compilation. Prefix the binding with an underscore to signal intentional discard (while still calling `optional_bool` to validate the incoming JSON).

   

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fedit_file-fuzz-automatic%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fedit_file-fuzz-automatic%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftools%2Ffile.rs%0ALine%3A%20543%0A%0AComment%3A%0AThe%20%60fuzz%60%20value%20is%20parsed%20into%20a%20binding%20but%20never%20referenced%20after%20this%20change.%20Rust%20will%20emit%20an%20%60unused%20variable%3A%20fuzz%60%20warning%20for%20every%20compilation.%20Prefix%20the%20binding%20with%20an%20underscore%20to%20signal%20intentional%20discard%20%28while%20still%20calling%20%60optional_bool%60%20to%20validate%20the%20incoming%20JSON%29.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20_fuzz%20%3D%20optional_bool%28%26input%2C%20%22fuzz%22%2C%20false%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftools%2Ffile.rs%0ALine%3A%20543%0A%0AComment%3A%0AThe%20%60fuzz%60%20value%20is%20parsed%20into%20a%20binding%20but%20never%20referenced%20after%20this%20change.%20Rust%20will%20emit%20an%20%60unused%20variable%3A%20fuzz%60%20warning%20for%20every%20compilation.%20Prefix%20the%20binding%20with%20an%20underscore%20to%20signal%20intentional%20discard%20%28while%20still%20calling%20%60optional_bool%60%20to%20validate%20the%20incoming%20JSON%29.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20_fuzz%20%3D%20optional_bool%28%26input%2C%20%22fuzz%22%2C%20false%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2154&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftools%2Ffile.rs%0ALine%3A%20543%0A%0AComment%3A%0AThe%20%60fuzz%60%20value%20is%20parsed%20into%20a%20binding%20but%20never%20referenced%20after%20this%20change.%20Rust%20will%20emit%20an%20%60unused%20variable%3A%20fuzz%60%20warning%20for%20every%20compilation.%20Prefix%20the%20binding%20with%20an%20underscore%20to%20signal%20intentional%20discard%20%28while%20still%20calling%20%60optional_bool%60%20to%20validate%20the%20incoming%20JSON%29.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20_fuzz%20%3D%20optional_bool%28%26input%2C%20%22fuzz%22%2C%20false%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2154&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fedit_file-fuzz-automatic%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fedit_file-fuzz-automatic%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftools%2Ffile.rs%3A543%0AThe%20%60fuzz%60%20value%20is%20parsed%20into%20a%20binding%20but%20never%20referenced%20after%20this%20change.%20Rust%20will%20emit%20an%20%60unused%20variable%3A%20fuzz%60%20warning%20for%20every%20compilation.%20Prefix%20the%20binding%20with%20an%20underscore%20to%20signal%20intentional%20discard%20%28while%20still%20calling%20%60optional_bool%60%20to%20validate%20the%20incoming%20JSON%29.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20_fuzz%20%3D%20optional_bool%28%26input%2C%20%22fuzz%22%2C%20false%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftools%2Ffile.rs%3A543%0AThe%20%60fuzz%60%20value%20is%20parsed%20into%20a%20binding%20but%20never%20referenced%20after%20this%20change.%20Rust%20will%20emit%20an%20%60unused%20variable%3A%20fuzz%60%20warning%20for%20every%20compilation.%20Prefix%20the%20binding%20with%20an%20underscore%20to%20signal%20intentional%20discard%20%28while%20still%20calling%20%60optional_bool%60%20to%20validate%20the%20incoming%20JSON%29.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20_fuzz%20%3D%20optional_bool%28%26input%2C%20%22fuzz%22%2C%20false%29%3B%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2154&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftools%2Ffile.rs%3A543%0AThe%20%60fuzz%60%20value%20is%20parsed%20into%20a%20binding%20but%20never%20referenced%20after%20this%20change.%20Rust%20will%20emit%20an%20%60unused%20variable%3A%20fuzz%60%20warning%20for%20every%20compilation.%20Prefix%20the%20binding%20with%20an%20underscore%20to%20signal%20intentional%20discard%20%28while%20still%20calling%20%60optional_bool%60%20to%20validate%20the%20incoming%20JSON%29.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20_fuzz%20%3D%20optional_bool%28%26input%2C%20%22fuzz%22%2C%20false%29%3B%0A%60%60%60%0A%0A&pr=2154&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(edit\_file): always retry fuzzy fallb..."](https://github.com/hmbown/codewhale/commit/5fc0d1d7da66300894262aa643c41921b0858c83) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33859477)</sub>

<!-- /greptile_comment -->