### PR TITLE
fix(kimi): support API-key setup for Kimi Code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Kimi Code API-key setup.** `codewhale config set providers.moonshot.*`
+  now writes the Moonshot/Kimi provider table, and Kimi Code API-key
+  endpoints default to `kimi-for-coding` without using the Kimi CLI OAuth path.
+
 ## [0.8.45] - 2026-05-25
 
 ### Added
@@ -17,9 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Command palette voice input.** The command palette can launch a configured
   speech-to-text helper and show footer status while transcription runs
   (#2047).
-- **Moonshot/Kimi OAuth provider.** Moonshot/Kimi is now a first-class
-  provider, including Kimi CLI OAuth reuse, secure refresh writes, model
-  completion, CLI auth, and secret-store integration.
+- **Moonshot/Kimi provider.** Moonshot/Kimi is now a first-class provider,
+  including API-key auth, model completion, CLI auth, secret-store
+  integration, and optional Kimi CLI credential reuse.
 - **Deterministic whale-species sub-agent names.** Sub-agents now get stable,
   human-readable whale-species nicknames (e.g. "Beluga", "Orca") while
   preserving the raw agent ID in the popup (#2035, #2016).

--- a/README.md
+++ b/README.md
@@ -314,15 +314,23 @@ codewhale --provider novita --model deepseek/deepseek-v4-pro
 codewhale auth set --provider fireworks --api-key "YOUR_FIREWORKS_API_KEY"
 codewhale --provider fireworks --model deepseek-v4-pro
 
-# Moonshot/Kimi
-codewhale auth set --provider moonshot --api-key "YOUR_MOONSHOT_OR_KIMI_API_KEY"
-codewhale --provider moonshot --model kimi-k2.6
+# Kimi Code plan API key
+codewhale auth set --provider moonshot --api-key "YOUR_KIMI_CODE_API_KEY"
+codewhale config set providers.moonshot.auth_mode api_key
+codewhale config set providers.moonshot.base_url https://api.kimi.com/coding/v1
+codewhale config set providers.moonshot.model kimi-for-coding
+codewhale --provider moonshot
 
-# Moonshot/Kimi with Kimi CLI OAuth
-kimi login
-mkdir -p ~/.deepseek
-printf 'provider = "moonshot"\n\n[providers.moonshot]\nauth_mode = "kimi_oauth"\n' >> ~/.deepseek/config.toml
-codewhale --provider moonshot --model kimi-for-coding
+# Kimi/Moonshot Platform API key
+codewhale auth set --provider moonshot --api-key "YOUR_MOONSHOT_OR_KIMI_API_KEY"
+codewhale config set providers.moonshot.auth_mode api_key
+codewhale config set providers.moonshot.base_url https://api.moonshot.ai/v1
+codewhale config set providers.moonshot.model kimi-k2.6
+codewhale --provider moonshot
+
+# Kimi through OpenRouter's catalog
+codewhale auth set --provider openrouter --api-key "YOUR_OPENROUTER_API_KEY"
+codewhale --provider openrouter --model moonshotai/kimi-k2.6
 
 # Self-hosted SGLang
 SGLANG_BASE_URL="http://localhost:30000/v1" codewhale --provider sglang --model deepseek-v4-flash
@@ -512,7 +520,7 @@ Key environment variables:
 | `OPENAI_BASE_URL` / `OPENAI_MODEL` | Generic OpenAI-compatible endpoint and model ID |
 | `ATLASCLOUD_BASE_URL` / `ATLASCLOUD_MODEL` | AtlasCloud endpoint and model override |
 | `WANJIE_ARK_BASE_URL` / `WANJIE_BASE_URL` / `WANJIE_MAAS_BASE_URL` / `WANJIE_ARK_MODEL` / `WANJIE_MODEL` / `WANJIE_MAAS_MODEL` | Wanjie Ark endpoint and model override |
-| `MOONSHOT_BASE_URL` / `KIMI_BASE_URL` / `MOONSHOT_MODEL` / `KIMI_MODEL_NAME` / `KIMI_MODEL` | Moonshot/Kimi endpoint and model override |
+| `MOONSHOT_BASE_URL` / `KIMI_BASE_URL` / `MOONSHOT_MODEL` / `KIMI_MODEL_NAME` / `KIMI_MODEL` | Moonshot/Kimi endpoint and model override. For a Kimi Code plan API key, use `KIMI_BASE_URL=https://api.kimi.com/coding/v1` and `KIMI_MODEL=kimi-for-coding`. |
 | `OPENROUTER_BASE_URL` | OpenRouter endpoint override |
 | `NOVITA_BASE_URL` | Novita endpoint override |
 | `FIREWORKS_BASE_URL` | Fireworks endpoint override |

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -462,6 +462,13 @@ impl ConfigToml {
             "providers.fireworks.http_headers" => {
                 serialize_http_headers(&self.providers.fireworks.http_headers)
             }
+            "providers.moonshot.api_key" => self.providers.moonshot.api_key.clone(),
+            "providers.moonshot.base_url" => self.providers.moonshot.base_url.clone(),
+            "providers.moonshot.model" => self.providers.moonshot.model.clone(),
+            "providers.moonshot.auth_mode" => self.providers.moonshot.auth_mode.clone(),
+            "providers.moonshot.http_headers" => {
+                serialize_http_headers(&self.providers.moonshot.http_headers)
+            }
             "providers.sglang.api_key" => self.providers.sglang.api_key.clone(),
             "providers.sglang.base_url" => self.providers.sglang.base_url.clone(),
             "providers.sglang.model" => self.providers.sglang.model.clone(),
@@ -612,6 +619,21 @@ impl ConfigToml {
             "providers.fireworks.http_headers" => {
                 self.providers.fireworks.http_headers = parse_http_headers(value)?;
             }
+            "providers.moonshot.api_key" => {
+                self.providers.moonshot.api_key = Some(value.to_string());
+            }
+            "providers.moonshot.base_url" => {
+                self.providers.moonshot.base_url = Some(value.to_string());
+            }
+            "providers.moonshot.model" => {
+                self.providers.moonshot.model = Some(value.to_string());
+            }
+            "providers.moonshot.auth_mode" => {
+                self.providers.moonshot.auth_mode = Some(value.to_string());
+            }
+            "providers.moonshot.http_headers" => {
+                self.providers.moonshot.http_headers = parse_http_headers(value)?;
+            }
             "providers.sglang.api_key" => {
                 self.providers.sglang.api_key = Some(value.to_string());
             }
@@ -716,6 +738,11 @@ impl ConfigToml {
             "providers.fireworks.base_url" => self.providers.fireworks.base_url = None,
             "providers.fireworks.model" => self.providers.fireworks.model = None,
             "providers.fireworks.http_headers" => self.providers.fireworks.http_headers.clear(),
+            "providers.moonshot.api_key" => self.providers.moonshot.api_key = None,
+            "providers.moonshot.base_url" => self.providers.moonshot.base_url = None,
+            "providers.moonshot.model" => self.providers.moonshot.model = None,
+            "providers.moonshot.auth_mode" => self.providers.moonshot.auth_mode = None,
+            "providers.moonshot.http_headers" => self.providers.moonshot.http_headers.clear(),
             "providers.sglang.api_key" => self.providers.sglang.api_key = None,
             "providers.sglang.base_url" => self.providers.sglang.base_url = None,
             "providers.sglang.model" => self.providers.sglang.model = None,
@@ -868,6 +895,21 @@ impl ConfigToml {
         }
         if let Some(v) = serialize_http_headers(&self.providers.fireworks.http_headers) {
             out.insert("providers.fireworks.http_headers".to_string(), v);
+        }
+        if let Some(v) = self.providers.moonshot.api_key.as_ref() {
+            out.insert("providers.moonshot.api_key".to_string(), redact_secret(v));
+        }
+        if let Some(v) = self.providers.moonshot.base_url.as_ref() {
+            out.insert("providers.moonshot.base_url".to_string(), v.clone());
+        }
+        if let Some(v) = self.providers.moonshot.model.as_ref() {
+            out.insert("providers.moonshot.model".to_string(), v.clone());
+        }
+        if let Some(v) = self.providers.moonshot.auth_mode.as_ref() {
+            out.insert("providers.moonshot.auth_mode".to_string(), v.clone());
+        }
+        if let Some(v) = serialize_http_headers(&self.providers.moonshot.http_headers) {
+            out.insert("providers.moonshot.http_headers".to_string(), v);
         }
         if let Some(v) = self.providers.sglang.api_key.as_ref() {
             out.insert("providers.sglang.api_key".to_string(), redact_secret(v));
@@ -1028,7 +1070,8 @@ impl ConfigToml {
             .or_else(|| self.model.clone())
             .unwrap_or_else(|| {
                 if provider == ProviderKind::Moonshot
-                    && auth_mode.as_deref().is_some_and(auth_mode_uses_kimi_oauth)
+                    && (auth_mode.as_deref().is_some_and(auth_mode_uses_kimi_oauth)
+                        || moonshot_base_url_uses_kimi_code(&base_url))
                 {
                     DEFAULT_KIMI_CODE_MODEL.to_string()
                 } else {
@@ -1255,6 +1298,13 @@ fn default_base_url_for_provider(provider: ProviderKind) -> &'static str {
         ProviderKind::Vllm => DEFAULT_VLLM_BASE_URL,
         ProviderKind::Ollama => DEFAULT_OLLAMA_BASE_URL,
     }
+}
+
+fn moonshot_base_url_uses_kimi_code(base_url: &str) -> bool {
+    let normalized = base_url.trim_end_matches('/').to_ascii_lowercase();
+    normalized == DEFAULT_KIMI_CODE_BASE_URL
+        || normalized == "https://api.kimi.com/coding"
+        || normalized.starts_with("https://api.kimi.com/coding/")
 }
 
 fn base_url_is_custom_for_provider(provider: ProviderKind, base_url: &str) -> bool {
@@ -2359,6 +2409,52 @@ mod tests {
     }
 
     #[test]
+    fn moonshot_provider_config_values_round_trip() -> Result<()> {
+        let mut config = ConfigToml::default();
+
+        config.set_value("providers.moonshot.api_key", "moonshot-secret-value")?;
+        config.set_value("providers.moonshot.base_url", DEFAULT_KIMI_CODE_BASE_URL)?;
+        config.set_value("providers.moonshot.model", DEFAULT_KIMI_CODE_MODEL)?;
+        config.set_value("providers.moonshot.auth_mode", "api_key")?;
+        config.set_value("providers.moonshot.http_headers", "X-Test=ok")?;
+
+        assert_eq!(
+            config
+                .get_display_value("providers.moonshot.api_key")
+                .as_deref(),
+            Some("moon***alue")
+        );
+        assert_eq!(
+            config.get_value("providers.moonshot.base_url").as_deref(),
+            Some(DEFAULT_KIMI_CODE_BASE_URL)
+        );
+        assert_eq!(
+            config.get_value("providers.moonshot.model").as_deref(),
+            Some(DEFAULT_KIMI_CODE_MODEL)
+        );
+        assert_eq!(
+            config.get_value("providers.moonshot.auth_mode").as_deref(),
+            Some("api_key")
+        );
+        assert_eq!(
+            config
+                .list_values()
+                .get("providers.moonshot.api_key")
+                .map(String::as_str),
+            Some("moon***alue")
+        );
+
+        config.unset_value("providers.moonshot.auth_mode")?;
+        config.unset_value("providers.moonshot.base_url")?;
+        config.unset_value("providers.moonshot.model")?;
+
+        assert_eq!(config.get_value("providers.moonshot.auth_mode"), None);
+        assert_eq!(config.get_value("providers.moonshot.base_url"), None);
+        assert_eq!(config.get_value("providers.moonshot.model"), None);
+        Ok(())
+    }
+
+    #[test]
     fn project_merge_denies_credentials_endpoints_and_provider_selection() {
         let mut base = ConfigToml {
             provider: ProviderKind::Deepseek,
@@ -2635,6 +2731,30 @@ mod tests {
         assert_eq!(resolved.model, DEFAULT_KIMI_CODE_MODEL);
         assert_eq!(resolved.api_key, None);
         assert_eq!(resolved.api_key_source, None);
+    }
+
+    #[test]
+    fn moonshot_kimi_code_api_key_endpoint_defaults_to_kimi_for_coding() {
+        let _lock = env_lock();
+        let _env = EnvGuard::without_deepseek_runtime_overrides();
+        let mut config = ConfigToml {
+            provider: ProviderKind::Moonshot,
+            ..ConfigToml::default()
+        };
+        config.providers.moonshot.api_key = Some("kimi-code-key".to_string());
+        config.providers.moonshot.base_url = Some(DEFAULT_KIMI_CODE_BASE_URL.to_string());
+
+        let resolved = config.resolve_runtime_options(&CliRuntimeOverrides::default());
+
+        assert_eq!(resolved.provider, ProviderKind::Moonshot);
+        assert_eq!(resolved.auth_mode, None);
+        assert_eq!(resolved.base_url, DEFAULT_KIMI_CODE_BASE_URL);
+        assert_eq!(resolved.model, DEFAULT_KIMI_CODE_MODEL);
+        assert_eq!(resolved.api_key.as_deref(), Some("kimi-code-key"));
+        assert_eq!(
+            resolved.api_key_source,
+            Some(RuntimeApiKeySource::ConfigFile)
+        );
     }
 
     #[test]

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Kimi Code API-key setup.** `codewhale config set providers.moonshot.*`
+  now writes the Moonshot/Kimi provider table, and Kimi Code API-key
+  endpoints default to `kimi-for-coding` without using the Kimi CLI OAuth path.
+
 ## [0.8.45] - 2026-05-25
 
 ### Added
@@ -17,9 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Command palette voice input.** The command palette can launch a configured
   speech-to-text helper and show footer status while transcription runs
   (#2047).
-- **Moonshot/Kimi OAuth provider.** Moonshot/Kimi is now a first-class
-  provider, including Kimi CLI OAuth reuse, secure refresh writes, model
-  completion, CLI auth, and secret-store integration.
+- **Moonshot/Kimi provider.** Moonshot/Kimi is now a first-class provider,
+  including API-key auth, model completion, CLI auth, secret-store
+  integration, and optional Kimi CLI credential reuse.
 - **Deterministic whale-species sub-agent names.** Sub-agents now get stable,
   human-readable whale-species nicknames (e.g. "Beluga", "Orca") while
   preserving the raw agent ID in the popup (#2035, #2016).

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -1570,11 +1570,17 @@ impl Config {
         {
             return model_for_provider(provider, normalized);
         }
-        if provider == ApiProvider::Moonshot
-            && self
-                .provider_config()
-                .is_some_and(provider_config_uses_kimi_oauth)
-        {
+        let moonshot_config = (provider == ApiProvider::Moonshot)
+            .then(|| self.provider_config())
+            .flatten();
+        let moonshot_uses_kimi_code = moonshot_config.is_some_and(|config| {
+            provider_config_uses_kimi_oauth(config)
+                || config
+                    .base_url
+                    .as_deref()
+                    .is_some_and(moonshot_base_url_uses_kimi_code)
+        });
+        if moonshot_uses_kimi_code {
             return DEFAULT_KIMI_CODE_MODEL.to_string();
         }
 
@@ -1771,8 +1777,9 @@ impl Config {
             ),
             ApiProvider::Moonshot => anyhow::bail!(
                 "Moonshot/Kimi API key not found. Run 'codewhale auth set --provider moonshot', \
-                 set MOONSHOT_API_KEY/KIMI_API_KEY, add [providers.moonshot] api_key, \
-                 or run `kimi login` and set [providers.moonshot] auth_mode = \"kimi_oauth\"."
+                 set MOONSHOT_API_KEY/KIMI_API_KEY, or add [providers.moonshot] api_key. \
+                 For a Kimi Code plan key, set [providers.moonshot] base_url = \
+                 \"https://api.kimi.com/coding/v1\" and model = \"kimi-for-coding\"."
             ),
             // Self-hosted deployments commonly run without auth on localhost.
             // Return an empty key and let the client omit the Authorization header.
@@ -2878,6 +2885,13 @@ fn base_url_is_custom_for_provider(provider: ApiProvider, base_url: &str) -> boo
 
 fn provider_preserves_custom_base_url_model(provider: ApiProvider, base_url: &str) -> bool {
     base_url_is_custom_for_provider(provider, base_url)
+}
+
+fn moonshot_base_url_uses_kimi_code(base_url: &str) -> bool {
+    let normalized = normalize_base_url(base_url).to_ascii_lowercase();
+    normalized == DEFAULT_KIMI_CODE_BASE_URL
+        || normalized == "https://api.kimi.com/coding"
+        || normalized.starts_with("https://api.kimi.com/coding/")
 }
 
 fn provider_config_uses_kimi_oauth(config: &ProviderConfig) -> bool {
@@ -6430,6 +6444,42 @@ api_key = "stale-api-key"
         assert_eq!(config.deepseek_base_url(), DEFAULT_KIMI_CODE_BASE_URL);
         assert_eq!(config.default_model(), DEFAULT_KIMI_CODE_MODEL);
         assert_eq!(config.deepseek_api_key()?, "fresh-oauth-token");
+        assert!(has_api_key_for(&config, ApiProvider::Moonshot));
+        Ok(())
+    }
+
+    #[test]
+    fn moonshot_kimi_code_api_key_uses_coding_model() -> Result<()> {
+        let _lock = lock_test_env();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let temp_root = env::temp_dir().join(format!(
+            "codewhale-tui-kimi-code-key-{}-{}",
+            std::process::id(),
+            nanos
+        ));
+        fs::create_dir_all(&temp_root)?;
+        let _guard = EnvGuard::new(&temp_root);
+
+        let config_path = temp_root.join(".deepseek").join("config.toml");
+        ensure_parent_dir(&config_path)?;
+        fs::write(
+            &config_path,
+            r#"provider = "moonshot"
+
+[providers.moonshot]
+api_key = "kimi-code-key"
+base_url = "https://api.kimi.com/coding/v1"
+"#,
+        )?;
+
+        let config = Config::load(None, None)?;
+        assert_eq!(config.api_provider(), ApiProvider::Moonshot);
+        assert_eq!(config.deepseek_base_url(), DEFAULT_KIMI_CODE_BASE_URL);
+        assert_eq!(config.default_model(), DEFAULT_KIMI_CODE_MODEL);
+        assert_eq!(config.deepseek_api_key()?, "kimi-code-key");
         assert!(has_api_key_for(&config, ApiProvider::Moonshot));
         Ok(())
     }

--- a/web/app/[locale]/docs/page.tsx
+++ b/web/app/[locale]/docs/page.tsx
@@ -267,6 +267,11 @@ command = "~/.deepseek/hooks/pre.sh"         # / message_submit / mode_change / 
                 <p className="mt-5 text-ink-soft leading-[1.9] tracking-wide">
                   开放模型平台方向：CodeWhale 保持 DeepSeek 优先，同时内置 Moonshot/Kimi、OpenRouter、NVIDIA NIM、
                   AtlasCloud、Wanjie Ark、Novita、Fireworks 和自托管 SGLang/vLLM/Ollama 路径。
+                  Kimi Code 会员 API Key 使用 <code className="inline">providers.moonshot.base_url</code>
+                  指向 <code className="inline">https://api.kimi.com/coding/v1</code>，模型为
+                  <code className="inline">kimi-for-coding</code>；Kimi/Moonshot 平台 API Key 继续使用
+                  <code className="inline">https://api.moonshot.ai/v1</code> 和
+                  <code className="inline">kimi-k2.6</code>。
                 </p>
               </section>
 
@@ -515,6 +520,11 @@ command = "~/.deepseek/hooks/pre.sh"         # / message_submit / mode_change / 
                   Open-model platform direction: CodeWhale stays DeepSeek-first while shipping Moonshot/Kimi,
                   OpenRouter, NVIDIA NIM, AtlasCloud, Wanjie Ark, Novita, Fireworks, and self-hosted
                   SGLang/vLLM/Ollama paths.
+                  Kimi Code membership API keys use <code className="inline">providers.moonshot.base_url</code>
+                  set to <code className="inline">https://api.kimi.com/coding/v1</code> with
+                  <code className="inline">kimi-for-coding</code>; Kimi/Moonshot Platform API keys use
+                  <code className="inline">https://api.moonshot.ai/v1</code> with
+                  <code className="inline">kimi-k2.6</code>.
                 </p>
               </section>
 

--- a/web/app/[locale]/faq/page.tsx
+++ b/web/app/[locale]/faq/page.tsx
@@ -112,7 +112,7 @@ codewhale doctor         # full connectivity check`}
         <p className="mb-2">CodeWhale ships with these built-in providers:</p>
         <ul className="list-disc pl-5 space-y-1 text-sm text-ink-soft mb-3">
           <li><strong>DeepSeek</strong> — first-class, native API. Reasoning streaming, cache metrics, thinking effort control.</li>
-          <li><strong>Moonshot/Kimi</strong> — Kimi API key mode or local Kimi CLI OAuth reuse.</li>
+          <li><strong>Moonshot/Kimi</strong> — Kimi Code and Kimi/Moonshot Platform API-key modes.</li>
           <li><strong>OpenRouter</strong> — unified API for DeepSeek models and more.</li>
           <li><strong>OpenAI-compatible</strong>, <strong>NVIDIA NIM</strong>, <strong>AtlasCloud</strong>, <strong>Wanjie Ark</strong>, <strong>Novita</strong>, <strong>Fireworks</strong>, <strong>SGLang</strong>, <strong>vLLM</strong>, <strong>Ollama</strong></li>
         </ul>
@@ -425,7 +425,7 @@ codewhale doctor         # 完整连接检查`}
         <p className="mb-2">CodeWhale 内建以下提供商：</p>
         <ul className="list-disc pl-5 space-y-1 text-sm text-ink-soft mb-3">
           <li><strong>DeepSeek</strong> — 一级支持，原生 API。推理流、缓存指标、思考力度控制。</li>
-          <li><strong>Moonshot/Kimi</strong> — Kimi API key 模式或复用本地 Kimi CLI OAuth。</li>
+          <li><strong>Moonshot/Kimi</strong> — Kimi Code 与 Kimi/Moonshot 平台 API key 模式。</li>
           <li><strong>OpenRouter</strong> — 统一 API，可访问 DeepSeek 等模型。</li>
           <li><strong>OpenAI 兼容</strong>、<strong>NVIDIA NIM</strong>、<strong>AtlasCloud</strong>、<strong>Wanjie Ark</strong>、<strong>Novita</strong>、<strong>Fireworks</strong>、<strong>SGLang</strong>、<strong>vLLM</strong>、<strong>Ollama</strong></li>
         </ul>

--- a/web/app/[locale]/roadmap/page.tsx
+++ b/web/app/[locale]/roadmap/page.tsx
@@ -31,7 +31,7 @@ const tracksEn = [
       { title: "Bidirectional MCP", note: "Consume tools from external servers; expose as server via `codewhale mcp`; ~/.deepseek/mcp.json" },
       { title: "Skills + unified slash palette", note: "~/.deepseek/skills/ auto-loading; /help, /mode, /status, /config, /trust, /feedback" },
       { title: "v0.8.45 provider surface", note: "DeepSeek, NVIDIA NIM, OpenAI-compatible, AtlasCloud, Wanjie Ark, OpenRouter, Novita, Fireworks, Moonshot/Kimi, SGLang, vLLM, and Ollama" },
-      { title: "Moonshot/Kimi OAuth", note: "Kimi CLI OAuth reuse plus API-key mode for Moonshot/Kimi sessions" },
+      { title: "Moonshot/Kimi API-key setup", note: "Kimi Code plan and Kimi/Moonshot Platform API-key paths for Moonshot/Kimi sessions" },
     ],
   },
   {
@@ -97,7 +97,7 @@ const tracksZh = [
       { title: "双向 MCP 协议", note: "消费外部服务器工具；通过 `codewhale mcp` 暴露为服务器；~/.deepseek/mcp.json" },
       { title: "技能 + 统一命令面板", note: "~/.deepseek/skills/ 自动加载；/help、/mode、/status、/config、/trust、/feedback" },
       { title: "v0.8.45 提供商表面", note: "DeepSeek、NVIDIA NIM、OpenAI 兼容、AtlasCloud、Wanjie Ark、OpenRouter、Novita、Fireworks、Moonshot/Kimi、SGLang、vLLM、Ollama" },
-      { title: "Moonshot/Kimi OAuth", note: "复用 Kimi CLI OAuth，也支持 Moonshot/Kimi API key 模式" },
+      { title: "Moonshot/Kimi API-key 设置", note: "Kimi Code 会员与 Kimi/Moonshot 平台 API key 路径" },
     ],
   },
   {

--- a/web/lib/facts.ts
+++ b/web/lib/facts.ts
@@ -11,6 +11,10 @@ interface KVNamespace {
 }
 
 async function getKv(): Promise<KVNamespace | undefined> {
+  if (process.env.NEXT_PHASE === "phase-production-build") {
+    return undefined;
+  }
+
   try {
     const mod = await import("@opennextjs/cloudflare");
     const ctx = await mod.getCloudflareContext({ async: true });

--- a/web/lib/kv.ts
+++ b/web/lib/kv.ts
@@ -23,20 +23,28 @@ interface CloudflareEnv {
   GITHUB_REPO?: string;
 }
 
+function envFromProcess(): CloudflareEnv {
+  return {
+    DEEPSEEK_API_KEY: process.env.DEEPSEEK_API_KEY,
+    DEEPSEEK_BASE_URL: process.env.DEEPSEEK_BASE_URL,
+    DEEPSEEK_MODEL: process.env.DEEPSEEK_MODEL,
+    GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+    CRON_SECRET: process.env.CRON_SECRET,
+    GITHUB_REPO: process.env.GITHUB_REPO,
+  };
+}
+
 export async function getEnv(): Promise<CloudflareEnv> {
+  if (process.env.NEXT_PHASE === "phase-production-build") {
+    return envFromProcess();
+  }
+
   try {
     const mod = await import("@opennextjs/cloudflare");
     const ctx = await mod.getCloudflareContext({ async: true });
     return ctx.env as CloudflareEnv;
   } catch {
-    return {
-      DEEPSEEK_API_KEY: process.env.DEEPSEEK_API_KEY,
-      DEEPSEEK_BASE_URL: process.env.DEEPSEEK_BASE_URL,
-      DEEPSEEK_MODEL: process.env.DEEPSEEK_MODEL,
-      GITHUB_TOKEN: process.env.GITHUB_TOKEN,
-      CRON_SECRET: process.env.CRON_SECRET,
-      GITHUB_REPO: process.env.GITHUB_REPO,
-    };
+    return envFromProcess();
   }
 }
 

--- a/web/lib/roadmap-feed.ts
+++ b/web/lib/roadmap-feed.ts
@@ -58,7 +58,7 @@ interface GhIssue { number: number; title: string; html_url: string; body: strin
 const FALLBACK_SHIPPED: RoadmapItem[] = [
   {
     title: "v0.8.45",
-    note: "Moonshot/Kimi OAuth, provider-surface sync, and current Windows install/runtime guidance",
+    note: "Moonshot/Kimi provider support, API-key setup guidance, provider-surface sync, and current Windows install/runtime guidance",
     href: "https://github.com/Hmbown/CodeWhale/releases/tag/v0.8.45",
   },
 ];


### PR DESCRIPTION
## Summary
- wire `providers.moonshot.*` into `codewhale config get/set/unset/list` instead of treating those keys as inert extras
- default Moonshot/Kimi to `kimi-for-coding` when the provider base URL is the Kimi Code API-key endpoint
- update README, changelog, and website copy to make API-key setup the primary Kimi path and avoid Kimi CLI OAuth setup guidance
- avoid touching local Cloudflare KV SQLite during `next build` so production builds stay warning-free

## Verification
- `cargo fmt --all -- --check`
- `scripts/release/check-versions.sh`
- `git diff --check`
- `cargo test -p codewhale-config moonshot --locked`
- `cargo test -p codewhale-tui moonshot_kimi --locked`
- `cargo test -p codewhale-cli moonshot --locked`
- temp-config CLI smoke for `codewhale config set providers.moonshot.*`
- `cd web && npm run build`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR wires `providers.moonshot.*` configuration keys into the `codewhale config get/set/unset/list` commands, adds a `moonshot_base_url_uses_kimi_code` check so the Kimi Code API endpoint automatically defaults to `kimi-for-coding` without requiring OAuth auth mode, and skips the Cloudflare KV SQLite touch during `next build` to eliminate build-time warnings.

- **Config crate**: Adds `get_value`, `set_value`, `unset_value`, and `list_values` cases for all `providers.moonshot.*` keys, plus a URL-based default-model fallback that triggers when the configured base URL matches the Kimi Code endpoint.
- **TUI crate**: Refactors the `default_model()` Moonshot branch to consult both the OAuth auth-mode check and the new `moonshot_base_url_uses_kimi_code` helper, and updates the missing-API-key error message to guide users toward API-key setup.
- **Web layer**: Adds `NEXT_PHASE === "phase-production-build"` short-circuits in both `kv.ts` and `facts.ts` to skip Cloudflare KV bindings at build time; documentation in README, FAQ, roadmap, and docs pages is updated to make the API-key path primary and de-emphasise Kimi CLI OAuth.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the Moonshot config wiring is complete, the new URL-based model defaulting is covered by tests in both crates, and the build-time KV short-circuit is a clean targeted fix.

The Moonshot config wiring is complete and tested in both crates, the URL-based model defaulting has dedicated integration tests, and the build-time KV short-circuit is a clean targeted fix. The auth_mode api_key step documented in the README affects secret-store routing but is absent from the updated in-app error message, and the duplicate moonshot_base_url_uses_kimi_code helper uses slightly different normalization between the two crates — harmless today but a latent maintenance divergence.

crates/config/src/lib.rs (normalization inconsistency in moonshot_base_url_uses_kimi_code vs tui counterpart) and README.md (auth_mode step missing from the tui error message)
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/config/src/lib.rs | Adds get/set/unset/list support for all providers.moonshot.* keys; introduces moonshot_base_url_uses_kimi_code helper using trim_end_matches('/') instead of the tui crate's normalize_base_url(), a minor inconsistency that has no practical impact for Kimi URLs |
| crates/tui/src/config.rs | Refactors default_model() Moonshot branch to OR the existing kimi-oauth check with the new URL-based check; duplicate moonshot_base_url_uses_kimi_code uses normalize_base_url() correctly; error message updated to guide API-key setup |
| web/lib/kv.ts | Extracts envFromProcess() helper and adds NEXT_PHASE build-time short-circuit before the CloudflareContext call; the refactor also unifies the catch-block fallback path |
| web/lib/facts.ts | Adds NEXT_PHASE === 'phase-production-build' guard before getCloudflareContext() to avoid KV SQLite warnings at build time; safe and consistent with kv.ts pattern |
| README.md | Documents providers.moonshot.auth_mode api_key as a required setup step, but the updated error message in tui/src/config.rs omits auth_mode; minor inconsistency between README and in-app guidance |
| web/lib/roadmap-feed.ts | Fallback shipped-item description updated to reflect API-key guidance; no logic changes |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User runs: codewhale --provider moonshot] --> B{model explicitly set?}
    B -- Yes --> C[Use explicit model]
    B -- No --> D{auth_mode = kimi_oauth?}
    D -- Yes --> E[DEFAULT_KIMI_CODE_MODEL: kimi-for-coding]
    D -- No --> F{base_url matches api.kimi.com/coding/*?}
    F -- Yes --> E
    F -- No --> G[DEFAULT_MOONSHOT_MODEL: kimi-k2.6]
    subgraph moonshot_base_url_uses_kimi_code
        H[== DEFAULT_KIMI_CODE_BASE_URL]
        I[== https://api.kimi.com/coding]
        J[starts_with https://api.kimi.com/coding/]
    end
    F --> H & I & J
```
</details>

<a href="https://app.greptile.com/api/ide/devin?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fkimi-api-key-setup%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fkimi-api-key-setup%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Fconfig%2Fsrc%2Flib.rs%3A1303-1308%0AThe%20normalization%20in%20the%20%60config%60%20crate%20uses%20%60trim_end_matches%28'%2F'%29%60%20directly%2C%20while%20the%20%60tui%60%20crate%20version%20of%20the%20same%20function%20uses%20%60normalize_base_url%28%29%60.%20For%20Kimi%20URLs%20both%20are%20equivalent%20today%20%28since%20%60normalize_base_url%60%20only%20strips%20%60%2Fv1%60%20for%20DeepSeek%20domains%29%2C%20but%20the%20two%20helpers%20will%20silently%20diverge%20if%20%60normalize_base_url%60%20is%20ever%20updated%20for%20non-DeepSeek%20domains.%20Aligning%20both%20to%20the%20same%20logic%20would%20make%20the%20two%20crates%20easier%20to%20keep%20in%20sync.%0A%0A%60%60%60suggestion%0Afn%20moonshot_base_url_uses_kimi_code%28base_url%3A%20%26str%29%20-%3E%20bool%20%7B%0A%20%20%20%20%2F%2F%20Use%20the%20same%20trim-trailing-slash%20normalization%20as%20the%20tui%20crate's%0A%20%20%20%20%2F%2F%20normalize_base_url%28%29%20for%20non-DeepSeek%20URLs%20so%20both%20crates%20stay%20in%20sync.%0A%20%20%20%20let%20normalized%20%3D%20base_url.trim_end_matches%28'%2F'%29.to_ascii_lowercase%28%29%3B%0A%20%20%20%20normalized%20%3D%3D%20DEFAULT_KIMI_CODE_BASE_URL%0A%20%20%20%20%20%20%20%20%7C%7C%20normalized%20%3D%3D%20%22https%3A%2F%2Fapi.kimi.com%2Fcoding%22%0A%20%20%20%20%20%20%20%20%7C%7C%20normalized.starts_with%28%22https%3A%2F%2Fapi.kimi.com%2Fcoding%2F%22%29%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0AREADME.md%3A317-321%0A**%60auth_mode%20api_key%60%20step%20absent%20from%20in-app%20error%20message**%0A%0AThe%20README%20lists%20%60codewhale%20config%20set%20providers.moonshot.auth_mode%20api_key%60%20as%20a%20required%20step%20for%20both%20Kimi%20Code%20and%20Kimi%2FMoonshot%20Platform%20API-key%20setup%2C%20but%20the%20updated%20error%20message%20in%20%60crates%2Ftui%2Fsrc%2Fconfig.rs%60%20only%20mentions%20%60base_url%60%20and%20%60model%60.%20Setting%20%60auth_mode%20%3D%20%22api_key%22%60%20does%20affect%20real%20behavior%20%E2%80%94%20%60auth_mode_requires_api_key%60%20returns%20%60true%60%20for%20that%20value%2C%20which%20prevents%20%60should_skip_secret_store_for_provider%60%20from%20bypassing%20API-key%20lookup.%20A%20user%20who%20only%20reads%20the%20error%20message%20will%20miss%20this%20step%20and%20may%20end%20up%20with%20a%20surprising%20%22key%20not%20found%22%20failure%20if%20the%20secret%20store%20skips%20the%20lookup%20on%20their%20platform.%0A%0A&repo=hmbown%2Fcodewhale&tid=69448&ts=1779770766&sig=6ee7319ba951af286c19c98fdaa7f15e4fe6c72a182cb3e1506a3aab47514bee&pr=2158&platform=github&fid=b7dc2b52-ae8c-40c8-ae43-3d61ffd51110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInDevinDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInDevin.svg?v=3"><img alt="Fix All in Devin" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInDevin.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(kimi): support API-key setup for Kim..."](https://github.com/hmbown/codewhale/commit/ab38635f782c48104635d018a50a163a38065efb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33863848)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->