### PR TITLE
fix(kimi): prefer Kimi Code model on provider switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Kimi Code API-key setup.** `codewhale config set providers.moonshot.*`
   now writes the Moonshot/Kimi provider table, and Kimi Code API-key
   endpoints default to `kimi-for-coding` without using the Kimi CLI OAuth path.
+  A root DeepSeek `default_text_model` no longer overrides that Kimi Code
+  model when switching providers.
 
 ## [0.8.45] - 2026-05-25
 

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Kimi Code API-key setup.** `codewhale config set providers.moonshot.*`
   now writes the Moonshot/Kimi provider table, and Kimi Code API-key
   endpoints default to `kimi-for-coding` without using the Kimi CLI OAuth path.
+  A root DeepSeek `default_text_model` no longer overrides that Kimi Code
+  model when switching providers.
 
 ## [0.8.45] - 2026-05-25
 

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -1554,6 +1554,19 @@ impl Config {
                 }
             }
         }
+        let moonshot_config = (provider == ApiProvider::Moonshot)
+            .then(|| self.provider_config())
+            .flatten();
+        let moonshot_uses_kimi_code = moonshot_config.is_some_and(|config| {
+            provider_config_uses_kimi_oauth(config)
+                || config
+                    .base_url
+                    .as_deref()
+                    .is_some_and(moonshot_base_url_uses_kimi_code)
+        });
+        if moonshot_uses_kimi_code {
+            return DEFAULT_KIMI_CODE_MODEL.to_string();
+        }
         if let Some(model) = self.default_text_model.as_deref()
             && (provider_passes_model_through(provider)
                 || self.active_provider_preserves_custom_base_url_model())
@@ -1569,19 +1582,6 @@ impl Config {
             && let Some(normalized) = normalize_model_name(model)
         {
             return model_for_provider(provider, normalized);
-        }
-        let moonshot_config = (provider == ApiProvider::Moonshot)
-            .then(|| self.provider_config())
-            .flatten();
-        let moonshot_uses_kimi_code = moonshot_config.is_some_and(|config| {
-            provider_config_uses_kimi_oauth(config)
-                || config
-                    .base_url
-                    .as_deref()
-                    .is_some_and(moonshot_base_url_uses_kimi_code)
-        });
-        if moonshot_uses_kimi_code {
-            return DEFAULT_KIMI_CODE_MODEL.to_string();
         }
 
         match provider {
@@ -6481,6 +6481,42 @@ base_url = "https://api.kimi.com/coding/v1"
         assert_eq!(config.default_model(), DEFAULT_KIMI_CODE_MODEL);
         assert_eq!(config.deepseek_api_key()?, "kimi-code-key");
         assert!(has_api_key_for(&config, ApiProvider::Moonshot));
+        Ok(())
+    }
+
+    #[test]
+    fn moonshot_kimi_code_model_overrides_root_deepseek_default() -> Result<()> {
+        let _lock = lock_test_env();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let temp_root = env::temp_dir().join(format!(
+            "codewhale-tui-kimi-code-root-model-{}-{}",
+            std::process::id(),
+            nanos
+        ));
+        fs::create_dir_all(&temp_root)?;
+        let _guard = EnvGuard::new(&temp_root);
+
+        let config_path = temp_root.join(".deepseek").join("config.toml");
+        ensure_parent_dir(&config_path)?;
+        fs::write(
+            &config_path,
+            r#"provider = "deepseek"
+default_text_model = "deepseek-v4-pro"
+
+[providers.moonshot]
+api_key = "kimi-code-key"
+base_url = "https://api.kimi.com/coding/v1"
+"#,
+        )?;
+        unsafe { env::set_var("DEEPSEEK_PROVIDER", "moonshot") };
+
+        let config = Config::load(None, None)?;
+        assert_eq!(config.api_provider(), ApiProvider::Moonshot);
+        assert_eq!(config.deepseek_base_url(), DEFAULT_KIMI_CODE_BASE_URL);
+        assert_eq!(config.default_model(), DEFAULT_KIMI_CODE_MODEL);
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- move Kimi Code endpoint detection ahead of the legacy root `default_text_model` fallback in the TUI model resolver
- add a regression for a DeepSeek-default config switched to Moonshot via `DEEPSEEK_PROVIDER=moonshot`
- extend the Unreleased changelog note from #2158

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `scripts/release/check-versions.sh`
- `cargo test -p codewhale-tui moonshot_kimi --locked`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a model-priority bug in the TUI's `default_model()` resolver where a root-level `default_text_model` (e.g. `deepseek-v4-pro` carried over from a DeepSeek config) was evaluated before the Kimi Code endpoint detection, causing the wrong model to be selected when switching to Moonshot via `DEEPSEEK_PROVIDER=moonshot`.

- The Kimi Code detection block (`moonshot_uses_kimi_code`) is moved up in `default_model()` so it fires before any root `default_text_model` fallback, preserving the correct `kimi-for-coding` default.
- A targeted regression test (`moonshot_kimi_code_model_overrides_root_deepseek_default`) covers the exact provider-switch scenario with a DeepSeek root config and a Moonshot `[providers.moonshot]` block.
- Both `CHANGELOG.md` files receive a short explanatory note extending the existing Kimi Code Unreleased entry.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the change is a minimal reordering of an existing detection block with no new logic introduced.

The fix is a pure reordering of two existing code blocks within default_model(). No new conditions, constants, or data paths are introduced. The provider-scoped model check that precedes the moved block still correctly takes priority, so an explicit providers.moonshot.model entry continues to work as expected. The regression test exercises the exact failure scenario described in the PR and passes. Both changelog files are updated consistently.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/config.rs | Moves the Kimi Code model detection block before the root default_text_model fallback in default_model(), fixing priority ordering; adds a regression test for the DeepSeek-default-switching-to-Moonshot scenario. |
| CHANGELOG.md | Appends a two-line clarification under the existing Kimi Code Unreleased note describing the root default_text_model override fix. |
| crates/tui/CHANGELOG.md | Mirror of the root CHANGELOG.md addition; same two-line fix note appended to the Unreleased section. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[default_model called] --> B{provider_config model set?}
    B -- Yes --> C{passes_model_through OR preserves_base_url_model?}
    C -- Yes --> D[return provider-scoped model verbatim]
    C -- No --> E{normalize_model_for_provider succeeds?}
    E -- Yes --> F[return normalized model]
    E -- No --> G{provider != DeepSeek and model non-empty?}
    G -- Yes --> H[return model verbatim]
    G -- No --> I[fall through]
    B -- No --> I
    I --> J{provider == Moonshot AND uses Kimi Code endpoint/oauth?}
    J -- Yes --> K[return DEFAULT_KIMI_CODE_MODEL NEW PRIORITY]
    J -- No --> L{root default_text_model set AND passes_model_through?}
    L -- Yes --> M[return root default_text_model]
    L -- No --> N{root default_text_model == auto?}
    N -- Yes --> O[return auto]
    N -- No --> P{normalize_model_name succeeds?}
    P -- Yes --> Q[return model_for_provider result]
    P -- No --> R[return provider default constant]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(kimi): prefer Kimi Code model on pro..."](https://github.com/hmbown/codewhale/commit/25583a1fe669827a69826142f8df54a28e70d2a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33864924)</sub>

<!-- /greptile_comment -->