### PR TITLE
fix(rlm): route large stdout/stderr via var_handle instead of inlining

### DIFF
--- a/crates/tui/src/tools/rlm.rs
+++ b/crates/tui/src/tools/rlm.rs
@@ -27,6 +27,11 @@ const DEFAULT_CHILD_MODEL: &str = "deepseek-v4-flash";
 const MAX_INLINE_CONTENT_CHARS: usize = 200_000;
 const FULL_STDOUT_HEAD_CHARS: usize = 4_096;
 const FULL_STDOUT_TAIL_CHARS: usize = 1_024;
+
+/// When `rlm_eval` stdout exceeds this many characters the full body is
+/// stored as a `var_handle` instead of inlined into the parent transcript.
+/// The model retrieves the body via `handle_read` using the returned handle.
+const STDOUT_HANDLE_THRESHOLD_CHARS: usize = 1_000;
 const HARD_SUB_RLM_DEPTH_CAP: u32 = 3;
 
 pub struct RlmSessionObjectsTool;
@@ -217,8 +222,11 @@ impl ToolSpec for RlmEvalTool {
          bounded projection of stdout/stderr plus metadata. If the code calls \
          FINAL/finalize, the final value is stored as a var_handle retrievable \
          with handle_read instead of copied unbounded into the parent context. \
-         Batch child helpers require dependency_mode='independent'; use \
-         sub_query_sequence or a sequential loop for dependent work."
+         Large stdout/stderr payloads (>1k chars) are also stored as \
+         var_handles (returned in stdout_handle / stderr_handle) to keep the \
+         parent transcript lean. Batch child helpers require \
+         dependency_mode='independent'; use sub_query_sequence or a \
+         sequential loop for dependent work."
     }
 
     fn input_schema(&self) -> Value {
@@ -299,14 +307,45 @@ impl ToolSpec for RlmEvalTool {
         let had_error = round.has_error;
         let rpc_count = round.rpc_count;
         let duration_ms = round.elapsed.as_millis() as u64;
-        let stdout_preview = match config.output_feedback {
-            OutputFeedback::Full => Some(preview_output(&round.full_stdout)),
-            OutputFeedback::Metadata => None,
-        };
-        let stderr_preview = match config.output_feedback {
-            OutputFeedback::Full if !round.stderr.is_empty() => Some(preview_output(&round.stderr)),
-            _ => None,
-        };
+        // Route large stdout/stderr into a var_handle to avoid bloat in
+        // the parent transcript. The model calls handle_read for bounded
+        // projections; a short inline note describes availability.
+        fn route_output(
+            text: &str,
+            feedback: &OutputFeedback,
+            store: &mut crate::tools::handle::HandleStore,
+            session_id: &str,
+            tag: &str,
+        ) -> (Option<String>, Option<crate::tools::handle::VarHandle>) {
+            let threshold = STDOUT_HANDLE_THRESHOLD_CHARS;
+            match (feedback, text.len()) {
+                (OutputFeedback::Full, len) if len <= threshold => {
+                    (Some(preview_output(text)), None)
+                }
+                (OutputFeedback::Full, _) if !text.trim().is_empty() => {
+                    // Store full body as a handle for out-of-band retrieval
+                    let name = format!("{tag}_{}", 0); // single counter is fine
+                    let handle = store.insert_text(session_id, name, text);
+                    (Some(format!("{} chars; retrieve via handle_read", text.len())), Some(handle))
+                }
+                _ => (None, None),
+            }
+        }
+
+        let (stdout_preview, stdout_handle) = route_output(
+            &round.full_stdout,
+            &config.output_feedback,
+            &mut *context.runtime.handle_store.lock().await,
+            &session.id,
+            "stdout",
+        );
+        let (stderr_preview, stderr_handle) = route_output(
+            &round.stderr,
+            &config.output_feedback,
+            &mut *context.runtime.handle_store.lock().await,
+            &session.id,
+            "stderr",
+        );
 
         let mut output = json!({
             "name": session.name,
@@ -322,6 +361,12 @@ impl ToolSpec for RlmEvalTool {
         }
         if let Some(stderr_preview) = stderr_preview {
             output["stderr_preview"] = json!(stderr_preview);
+        }
+        if let (Some(h), Some(c)) = (stdout_handle, stdout_preview) {
+            output["stdout_handle"] = json!(h);
+        }
+        if let (Some(h), Some(c)) = (stderr_handle, stderr_preview) {
+            output["stderr_handle"] = json!(h);
         }
         if let Some(confidence) = round.final_confidence.clone() {
             output["confidence"] = confidence;


### PR DESCRIPTION
RLM sessions that produce large stdout/stderr (e.g. reading a local log file, dumping a large JSON table, or printing diagnostic output) currently inline the full preview into the parent tool result. On long-running RLM sessions this bloat accumulates and pressures the parent context window.

Fix: when `rlm_eval` stdout or stderr exceeds 1000 characters, the full body is stored as a `var_handle` in the handle store. The tool result returns a short inline note (`"N chars; retrieve via handle_read"`) plus `stdout_handle` / `stderr_handle` fields containing the handle reference. The model calls `handle_read` for bounded projections.

Changes:
- `rlm.rs`: Added `STDOUT_HANDLE_THRESHOLD_CHARS` constant
- `rlm.rs`: Added `route_output()` helper that stores large text as a var_handle
- `rlm.rs`: Modified `rlm_eval` execute to route stdout/stderr >= 1k chars into handles
- `rlm.rs`: Updated description to document the new handle-routing behavior

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refactors `rlm_eval` to route large stdout/stderr payloads into `var_handle` entries instead of inlining them in the parent transcript, and updates the tool description accordingly.

- The handle-emission block reuses `stdout_preview` and `stderr_preview` after they have already been moved by earlier `if let Some(…)` patterns, producing an `E0382: use of moved value` compile error that prevents the crate from building.
- The `route_output` helper always names handles `{tag}_0`, so repeated large-output evals on the same session overwrite each other in the `HandleStore`, silently corrupting previously issued handles.
- A missing `!text.is_empty()` guard means every successful eval now emits `"stderr_preview": ""` regardless of whether the subprocess wrote anything to stderr, regressing the prior behaviour.
</details>

<details open><summary><h3>Confidence Score: 1/5</h3></summary>

Not safe to merge — the changed code introduces a Rust E0382 compile error that will break the build.

The handle-emission block reuses two `Option<String>` variables after they are consumed by earlier `if let` patterns. Rust's ownership rules make this a hard compile error (E0382), so the crate cannot build at all with this change. Two additional logic regressions — handle name collisions across evals and empty-stderr noise — would also affect runtime correctness once the compile error is resolved.

crates/tui/src/tools/rlm.rs — the entire new routing block (lines 313–370) needs attention before this can land.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tools/rlm.rs | Introduces large-output routing via var_handles, but contains a Rust E0382 compile error (moved values reused), a handle name collision on repeated evals, an empty-stderr regression, and a byte-vs-char length inconsistency. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[rlm_eval called] --> B[run kernel code]
    B --> C[route_output stdout]
    B --> D[route_output stderr]

    C --> C1{Full feedback?}
    C1 -- No --> C2[None, None]
    C1 -- Yes --> C3{text.len bytes lte 1000}
    C3 -- Yes --> C4[Some preview, None - inline]
    C3 -- No --> C5{text is whitespace?}
    C5 -- Yes --> C6[None, None]
    C5 -- No --> C7[insert_text with tag_0 - ALWAYS OVERWRITES]
    C7 --> C8[Some N-chars note, Some handle]

    D --> D1{Full feedback?}
    D1 -- No --> D2[None, None]
    D1 -- Yes --> D3{text.len bytes lte 1000 - BYTES NOT CHARS}
    D3 -- Yes --> D4[Some preview, None - fires for empty stderr too]
    D3 -- No --> D5[insert_text with tag_0]
    D5 --> D6[Some N-chars note, Some handle]

    C4 --> E[if-let moves stdout_preview]
    C8 --> E
    D4 --> F[if-let moves stderr_preview]
    D6 --> F

    E --> G[reuse stdout_preview after move - E0382 compile error]
    F --> H[reuse stderr_preview after move - E0382 compile error]
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Frlm-handle-routing%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Frlm-handle-routing%22.%0A%0AFix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Acrates%2Ftui%2Fsrc%2Ftools%2Frlm.rs%3A365-370%0A%60stdout_preview%60%20and%20%60stderr_preview%60%20are%20%60Option%3CString%3E%60%2C%20which%20is%20not%20%60Copy%60.%20The%20%60if%20let%20Some%28...%29%20%3D%20stdout_preview%60%20patterns%20on%20lines%20359%20and%20362%20**move**%20%28consume%29%20those%20bindings.%20Reusing%20them%20as%20the%20second%20element%20of%20the%20tuple%20on%20lines%20365%20and%20368%20is%20%60E0382%3A%20use%20of%20moved%20value%60%20in%20Rust%20%E2%80%94%20the%20code%20will%20not%20compile.%20Because%20%60route_output%60%20already%20guarantees%20that%20a%20handle%20is%20%60Some%60%20only%20when%20a%20preview%20is%20also%20%60Some%60%2C%20the%20preview%20check%20on%20the%20second%20pair%20of%20%60if%20let%60s%20is%20redundant%3B%20the%20handles%20can%20be%20emitted%20unconditionally.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20if%20let%20Some%28h%29%20%3D%20stdout_handle%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20output%5B%22stdout_handle%22%5D%20%3D%20json!%28h%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20if%20let%20Some%28h%29%20%3D%20stderr_handle%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20output%5B%22stderr_handle%22%5D%20%3D%20json!%28h%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0Acrates%2Ftui%2Fsrc%2Ftools%2Frlm.rs%3A327%0AThe%20handle%20name%20is%20hardcoded%20to%20%60%7Btag%7D_0%60%20on%20every%20call.%20%60HandleStore%3A%3Ainsert%60%20uses%20a%20%60HashMap%3CHandleKey%2C%20%E2%80%A6%3E%60%20keyed%20by%20%60%28session_id%2C%20name%29%60%2C%20so%20repeated%20%60rlm_eval%60%20calls%20on%20the%20same%20session%20with%20large%20output%20silently%20overwrite%20%60stdout_0%60%2F%60stderr_0%60.%20Any%20handle%20the%20model%20retained%20from%20an%20earlier%20eval%20now%20silently%20points%20to%20the%20latest%20eval's%20content%20instead.%20The%20session's%20%60rpc_count%60%20%28already%20incremented%20per%20eval%29%20is%20available%20in%20scope%20and%20makes%20a%20natural%20per-eval%20counter.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20let%20name%20%3D%20format!%28%22%7Btag%7D_%7B%7D%22%2C%20session.rpc_count%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Acrates%2Ftui%2Fsrc%2Ftools%2Frlm.rs%3A321-322%0A%60text.len%28%29%60%20returns%20the%20byte%20length%20of%20the%20UTF-8%20string%2C%20but%20%60STDOUT_HANDLE_THRESHOLD_CHARS%60%20is%20documented%20and%20named%20in%20terms%20of%20characters.%20For%20output%20containing%20multi-byte%20characters%20%28e.g.%20CJK%20text%2C%20emoji%29%2C%20a%20999-character%20string%20can%20exceed%201%2C000%20bytes%20and%20be%20incorrectly%20routed%20to%20a%20handle.%20The%20rest%20of%20the%20file%20%28%60preview_output%60%2C%20%60MAX_INLINE_CONTENT_CHARS%60%29%20consistently%20uses%20%60chars%28%29.count%28%29%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20match%20%28feedback%2C%20text.chars%28%29.count%28%29%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%28OutputFeedback%3A%3AFull%2C%20len%29%20if%20len%20%3C%3D%20threshold%20%3D%3E%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%204%0Acrates%2Ftui%2Fsrc%2Ftools%2Frlm.rs%3A321-323%0A**Empty%20stderr%20now%20always%20emitted%20as%20%60%22%22%60**%0A%0AThe%20old%20code%20guarded%20with%20%60if%20!round.stderr.is_empty%28%29%60%2C%20so%20a%20clean%20run%20produced%20no%20%60stderr_preview%60%20key.%20The%20new%20first%20arm%20fires%20for%20any%20%60len%20%3C%3D%20threshold%60%20%E2%80%94%20including%20%60len%20%3D%3D%200%60%20%E2%80%94%20returning%20%60Some%28preview_output%28%22%22%29%29%60%20%E2%86%92%20%60Some%28%22%22%29%60.%20Every%20successful%20%60rlm_eval%60%20call%20now%20adds%20%60%22stderr_preview%22%3A%20%22%22%60%20to%20the%20output%2C%20introducing%20noise%20the%20model%20must%20silently%20ignore.%20Adding%20%60%26%26%20!text.is_empty%28%29%60%20to%20the%20first-arm%20guard%20restores%20the%20previous%20behaviour.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Acrates%2Ftui%2Fsrc%2Ftools%2Frlm.rs%3A365-370%0A%60stdout_preview%60%20and%20%60stderr_preview%60%20are%20%60Option%3CString%3E%60%2C%20which%20is%20not%20%60Copy%60.%20The%20%60if%20let%20Some%28...%29%20%3D%20stdout_preview%60%20patterns%20on%20lines%20359%20and%20362%20**move**%20%28consume%29%20those%20bindings.%20Reusing%20them%20as%20the%20second%20element%20of%20the%20tuple%20on%20lines%20365%20and%20368%20is%20%60E0382%3A%20use%20of%20moved%20value%60%20in%20Rust%20%E2%80%94%20the%20code%20will%20not%20compile.%20Because%20%60route_output%60%20already%20guarantees%20that%20a%20handle%20is%20%60Some%60%20only%20when%20a%20preview%20is%20also%20%60Some%60%2C%20the%20preview%20check%20on%20the%20second%20pair%20of%20%60if%20let%60s%20is%20redundant%3B%20the%20handles%20can%20be%20emitted%20unconditionally.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20if%20let%20Some%28h%29%20%3D%20stdout_handle%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20output%5B%22stdout_handle%22%5D%20%3D%20json!%28h%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20if%20let%20Some%28h%29%20%3D%20stderr_handle%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20output%5B%22stderr_handle%22%5D%20%3D%20json!%28h%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0Acrates%2Ftui%2Fsrc%2Ftools%2Frlm.rs%3A327%0AThe%20handle%20name%20is%20hardcoded%20to%20%60%7Btag%7D_0%60%20on%20every%20call.%20%60HandleStore%3A%3Ainsert%60%20uses%20a%20%60HashMap%3CHandleKey%2C%20%E2%80%A6%3E%60%20keyed%20by%20%60%28session_id%2C%20name%29%60%2C%20so%20repeated%20%60rlm_eval%60%20calls%20on%20the%20same%20session%20with%20large%20output%20silently%20overwrite%20%60stdout_0%60%2F%60stderr_0%60.%20Any%20handle%20the%20model%20retained%20from%20an%20earlier%20eval%20now%20silently%20points%20to%20the%20latest%20eval's%20content%20instead.%20The%20session's%20%60rpc_count%60%20%28already%20incremented%20per%20eval%29%20is%20available%20in%20scope%20and%20makes%20a%20natural%20per-eval%20counter.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20let%20name%20%3D%20format!%28%22%7Btag%7D_%7B%7D%22%2C%20session.rpc_count%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Acrates%2Ftui%2Fsrc%2Ftools%2Frlm.rs%3A321-322%0A%60text.len%28%29%60%20returns%20the%20byte%20length%20of%20the%20UTF-8%20string%2C%20but%20%60STDOUT_HANDLE_THRESHOLD_CHARS%60%20is%20documented%20and%20named%20in%20terms%20of%20characters.%20For%20output%20containing%20multi-byte%20characters%20%28e.g.%20CJK%20text%2C%20emoji%29%2C%20a%20999-character%20string%20can%20exceed%201%2C000%20bytes%20and%20be%20incorrectly%20routed%20to%20a%20handle.%20The%20rest%20of%20the%20file%20%28%60preview_output%60%2C%20%60MAX_INLINE_CONTENT_CHARS%60%29%20consistently%20uses%20%60chars%28%29.count%28%29%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20match%20%28feedback%2C%20text.chars%28%29.count%28%29%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%28OutputFeedback%3A%3AFull%2C%20len%29%20if%20len%20%3C%3D%20threshold%20%3D%3E%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%204%0Acrates%2Ftui%2Fsrc%2Ftools%2Frlm.rs%3A321-323%0A**Empty%20stderr%20now%20always%20emitted%20as%20%60%22%22%60**%0A%0AThe%20old%20code%20guarded%20with%20%60if%20!round.stderr.is_empty%28%29%60%2C%20so%20a%20clean%20run%20produced%20no%20%60stderr_preview%60%20key.%20The%20new%20first%20arm%20fires%20for%20any%20%60len%20%3C%3D%20threshold%60%20%E2%80%94%20including%20%60len%20%3D%3D%200%60%20%E2%80%94%20returning%20%60Some%28preview_output%28%22%22%29%29%60%20%E2%86%92%20%60Some%28%22%22%29%60.%20Every%20successful%20%60rlm_eval%60%20call%20now%20adds%20%60%22stderr_preview%22%3A%20%22%22%60%20to%20the%20output%2C%20introducing%20noise%20the%20model%20must%20silently%20ignore.%20Adding%20%60%26%26%20!text.is_empty%28%29%60%20to%20the%20first-arm%20guard%20restores%20the%20previous%20behaviour.%0A%0A&repo=hmbown%2Fcodewhale&pr=2163&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Acrates%2Ftui%2Fsrc%2Ftools%2Frlm.rs%3A365-370%0A%60stdout_preview%60%20and%20%60stderr_preview%60%20are%20%60Option%3CString%3E%60%2C%20which%20is%20not%20%60Copy%60.%20The%20%60if%20let%20Some%28...%29%20%3D%20stdout_preview%60%20patterns%20on%20lines%20359%20and%20362%20**move**%20%28consume%29%20those%20bindings.%20Reusing%20them%20as%20the%20second%20element%20of%20the%20tuple%20on%20lines%20365%20and%20368%20is%20%60E0382%3A%20use%20of%20moved%20value%60%20in%20Rust%20%E2%80%94%20the%20code%20will%20not%20compile.%20Because%20%60route_output%60%20already%20guarantees%20that%20a%20handle%20is%20%60Some%60%20only%20when%20a%20preview%20is%20also%20%60Some%60%2C%20the%20preview%20check%20on%20the%20second%20pair%20of%20%60if%20let%60s%20is%20redundant%3B%20the%20handles%20can%20be%20emitted%20unconditionally.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20if%20let%20Some%28h%29%20%3D%20stdout_handle%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20output%5B%22stdout_handle%22%5D%20%3D%20json!%28h%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20if%20let%20Some%28h%29%20%3D%20stderr_handle%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20output%5B%22stderr_handle%22%5D%20%3D%20json!%28h%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0Acrates%2Ftui%2Fsrc%2Ftools%2Frlm.rs%3A327%0AThe%20handle%20name%20is%20hardcoded%20to%20%60%7Btag%7D_0%60%20on%20every%20call.%20%60HandleStore%3A%3Ainsert%60%20uses%20a%20%60HashMap%3CHandleKey%2C%20%E2%80%A6%3E%60%20keyed%20by%20%60%28session_id%2C%20name%29%60%2C%20so%20repeated%20%60rlm_eval%60%20calls%20on%20the%20same%20session%20with%20large%20output%20silently%20overwrite%20%60stdout_0%60%2F%60stderr_0%60.%20Any%20handle%20the%20model%20retained%20from%20an%20earlier%20eval%20now%20silently%20points%20to%20the%20latest%20eval's%20content%20instead.%20The%20session's%20%60rpc_count%60%20%28already%20incremented%20per%20eval%29%20is%20available%20in%20scope%20and%20makes%20a%20natural%20per-eval%20counter.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20let%20name%20%3D%20format!%28%22%7Btag%7D_%7B%7D%22%2C%20session.rpc_count%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Acrates%2Ftui%2Fsrc%2Ftools%2Frlm.rs%3A321-322%0A%60text.len%28%29%60%20returns%20the%20byte%20length%20of%20the%20UTF-8%20string%2C%20but%20%60STDOUT_HANDLE_THRESHOLD_CHARS%60%20is%20documented%20and%20named%20in%20terms%20of%20characters.%20For%20output%20containing%20multi-byte%20characters%20%28e.g.%20CJK%20text%2C%20emoji%29%2C%20a%20999-character%20string%20can%20exceed%201%2C000%20bytes%20and%20be%20incorrectly%20routed%20to%20a%20handle.%20The%20rest%20of%20the%20file%20%28%60preview_output%60%2C%20%60MAX_INLINE_CONTENT_CHARS%60%29%20consistently%20uses%20%60chars%28%29.count%28%29%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20match%20%28feedback%2C%20text.chars%28%29.count%28%29%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%28OutputFeedback%3A%3AFull%2C%20len%29%20if%20len%20%3C%3D%20threshold%20%3D%3E%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%204%0Acrates%2Ftui%2Fsrc%2Ftools%2Frlm.rs%3A321-323%0A**Empty%20stderr%20now%20always%20emitted%20as%20%60%22%22%60**%0A%0AThe%20old%20code%20guarded%20with%20%60if%20!round.stderr.is_empty%28%29%60%2C%20so%20a%20clean%20run%20produced%20no%20%60stderr_preview%60%20key.%20The%20new%20first%20arm%20fires%20for%20any%20%60len%20%3C%3D%20threshold%60%20%E2%80%94%20including%20%60len%20%3D%3D%200%60%20%E2%80%94%20returning%20%60Some%28preview_output%28%22%22%29%29%60%20%E2%86%92%20%60Some%28%22%22%29%60.%20Every%20successful%20%60rlm_eval%60%20call%20now%20adds%20%60%22stderr_preview%22%3A%20%22%22%60%20to%20the%20output%2C%20introducing%20noise%20the%20model%20must%20silently%20ignore.%20Adding%20%60%26%26%20!text.is_empty%28%29%60%20to%20the%20first-arm%20guard%20restores%20the%20previous%20behaviour.%0A%0A&pr=2163&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(rlm): route large stdout/stderr via ..."](https://github.com/hmbown/codewhale/commit/f268fe31f7e6bb873b33d3cdf146c25647b7732b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33867222)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->