### PR TITLE
fix(kimi): drop DEEPSEEK_PROVIDER framing from public Moonshot setup path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`CODEWHALE_*` env aliases.** `CODEWHALE_PROVIDER`, `CODEWHALE_MODEL`,
+  and `CODEWHALE_BASE_URL` are public aliases that take precedence over
+  the legacy `DEEPSEEK_*` forms. The `DEEPSEEK_*` names remain accepted
+  for back-compat. Recommended setup paths are `codewhale --provider <name>`,
+  `provider = "<name>"` in `~/.codewhale/config.toml`, or
+  `CODEWHALE_PROVIDER=<name>` — never `DEEPSEEK_PROVIDER=<name>` in
+  user-facing docs.
+
 ### Fixed
 
 - **Kimi Code API-key setup.** `codewhale config set providers.moonshot.*`
   now writes the Moonshot/Kimi provider table, and Kimi Code API-key
   endpoints default to `kimi-for-coding` without using the Kimi CLI OAuth path.
+- **Kimi Code model precedence.** When `[providers.moonshot]` points at the
+  Kimi Code endpoint, the resolver now returns `kimi-for-coding` even when
+  a root DeepSeek `default_text_model` (e.g. `deepseek-v4-pro`) is still in
+  the config from a previous setup.
 
 ## [0.8.45] - 2026-05-25
 

--- a/README.md
+++ b/README.md
@@ -506,12 +506,15 @@ Key environment variables:
 
 | Variable | Purpose |
 |---|---|
+| `CODEWHALE_PROVIDER` | Active provider. Same value set as `DEEPSEEK_PROVIDER`; this is the public alias and wins when both are set. |
+| `CODEWHALE_MODEL` | Default model for the active provider. Public alias for `DEEPSEEK_MODEL`. |
+| `CODEWHALE_BASE_URL` | Base URL for the active provider. Public alias for `DEEPSEEK_BASE_URL`. |
 | `DEEPSEEK_API_KEY` | API key |
-| `DEEPSEEK_BASE_URL` | API base URL |
+| `DEEPSEEK_BASE_URL` | API base URL (legacy alias of `CODEWHALE_BASE_URL`) |
 | `DEEPSEEK_HTTP_HEADERS` | Optional custom model request headers, e.g. `X-Model-Provider-Id=your-model-provider` |
-| `DEEPSEEK_MODEL` | Default model |
+| `DEEPSEEK_MODEL` | Default model (legacy alias of `CODEWHALE_MODEL`) |
 | `DEEPSEEK_STREAM_IDLE_TIMEOUT_SECS` | Stream idle timeout in seconds, default `300`, clamped to `1..=3600` |
-| `DEEPSEEK_PROVIDER` | `deepseek` (default), `nvidia-nim`, `openai`, `atlascloud`, `wanjie-ark`, `openrouter`, `novita`, `fireworks`, `moonshot`, `sglang`, `vllm`, `ollama` |
+| `DEEPSEEK_PROVIDER` | Legacy alias of `CODEWHALE_PROVIDER`. Accepts `deepseek` (default), `nvidia-nim`, `openai`, `atlascloud`, `wanjie-ark`, `openrouter`, `novita`, `fireworks`, `moonshot`, `sglang`, `vllm`, `ollama`. |
 | `DEEPSEEK_PROFILE` | Config profile name |
 | `DEEPSEEK_MEMORY` | Set to `on` to enable user memory |
 | `DEEPSEEK_ALLOW_INSECURE_HTTP=1` | Allow non-local `http://` API base URLs on trusted networks |

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1793,7 +1793,9 @@ impl EnvRuntimeOverrides {
                 .and_then(|v| ProviderKind::parse(&v)),
             model: std::env::var("CODEWHALE_MODEL")
                 .or_else(|_| std::env::var("DEEPSEEK_MODEL"))
-                .ok(),
+                .or_else(|_| std::env::var("DEEPSEEK_DEFAULT_TEXT_MODEL"))
+                .ok()
+                .filter(|v| !v.trim().is_empty()),
             wanjie_ark_model: std::env::var("WANJIE_ARK_MODEL")
                 .or_else(|_| std::env::var("WANJIE_MODEL"))
                 .or_else(|_| std::env::var("WANJIE_MAAS_MODEL"))
@@ -1925,6 +1927,7 @@ mod tests {
         deepseek_base_url: Option<OsString>,
         deepseek_http_headers: Option<OsString>,
         deepseek_model: Option<OsString>,
+        deepseek_default_text_model: Option<OsString>,
         deepseek_provider: Option<OsString>,
         deepseek_auth_mode: Option<OsString>,
         nvidia_api_key: Option<OsString>,
@@ -1970,6 +1973,7 @@ mod tests {
                 deepseek_base_url: env::var_os("DEEPSEEK_BASE_URL"),
                 deepseek_http_headers: env::var_os("DEEPSEEK_HTTP_HEADERS"),
                 deepseek_model: env::var_os("DEEPSEEK_MODEL"),
+                deepseek_default_text_model: env::var_os("DEEPSEEK_DEFAULT_TEXT_MODEL"),
                 deepseek_provider: env::var_os("DEEPSEEK_PROVIDER"),
                 deepseek_auth_mode: env::var_os("DEEPSEEK_AUTH_MODE"),
                 codewhale_provider: env::var_os("CODEWHALE_PROVIDER"),
@@ -2013,6 +2017,7 @@ mod tests {
                 env::remove_var("DEEPSEEK_BASE_URL");
                 env::remove_var("DEEPSEEK_HTTP_HEADERS");
                 env::remove_var("DEEPSEEK_MODEL");
+                env::remove_var("DEEPSEEK_DEFAULT_TEXT_MODEL");
                 env::remove_var("DEEPSEEK_PROVIDER");
                 env::remove_var("DEEPSEEK_AUTH_MODE");
                 env::remove_var("CODEWHALE_PROVIDER");
@@ -2070,6 +2075,10 @@ mod tests {
                 Self::restore_var("DEEPSEEK_BASE_URL", self.deepseek_base_url.take());
                 Self::restore_var("DEEPSEEK_HTTP_HEADERS", self.deepseek_http_headers.take());
                 Self::restore_var("DEEPSEEK_MODEL", self.deepseek_model.take());
+                Self::restore_var(
+                    "DEEPSEEK_DEFAULT_TEXT_MODEL",
+                    self.deepseek_default_text_model.take(),
+                );
                 Self::restore_var("DEEPSEEK_PROVIDER", self.deepseek_provider.take());
                 Self::restore_var("DEEPSEEK_AUTH_MODE", self.deepseek_auth_mode.take());
                 Self::restore_var("CODEWHALE_PROVIDER", self.codewhale_provider.take());
@@ -2881,7 +2890,24 @@ mod tests {
         // Safety: test-only env mutation guarded by env_lock().
         unsafe {
             env::set_var("CODEWHALE_PROVIDER", "moonshot");
-            env::set_var("CODEWHALE_MODEL", "kimi-k2.6");
+            env::set_var("CODEWHALE_MODEL", "custom-kimi-test-model");
+        }
+        let config = ConfigToml::default();
+
+        let resolved = config.resolve_runtime_options(&CliRuntimeOverrides::default());
+
+        assert_eq!(resolved.provider, ProviderKind::Moonshot);
+        assert_eq!(resolved.model, "custom-kimi-test-model");
+    }
+
+    #[test]
+    fn blank_codewhale_model_env_alias_does_not_override_default_for_active_provider() {
+        let _lock = env_lock();
+        let _env = EnvGuard::without_deepseek_runtime_overrides();
+        // Safety: test-only env mutation guarded by env_lock().
+        unsafe {
+            env::set_var("CODEWHALE_PROVIDER", "moonshot");
+            env::set_var("CODEWHALE_MODEL", "   ");
         }
         let config = ConfigToml::default();
 
@@ -2889,6 +2915,23 @@ mod tests {
 
         assert_eq!(resolved.provider, ProviderKind::Moonshot);
         assert_eq!(resolved.model, DEFAULT_MOONSHOT_MODEL);
+    }
+
+    #[test]
+    fn deepseek_default_text_model_legacy_alias_still_overrides_active_provider_model() {
+        let _lock = env_lock();
+        let _env = EnvGuard::without_deepseek_runtime_overrides();
+        // Safety: test-only env mutation guarded by env_lock().
+        unsafe {
+            env::set_var("CODEWHALE_PROVIDER", "moonshot");
+            env::set_var("DEEPSEEK_DEFAULT_TEXT_MODEL", "legacy-env-model");
+        }
+        let config = ConfigToml::default();
+
+        let resolved = config.resolve_runtime_options(&CliRuntimeOverrides::default());
+
+        assert_eq!(resolved.provider, ProviderKind::Moonshot);
+        assert_eq!(resolved.model, "legacy-env-model");
     }
 
     #[test]

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1787,10 +1787,13 @@ struct EnvRuntimeOverrides {
 impl EnvRuntimeOverrides {
     fn load() -> Self {
         Self {
-            provider: std::env::var("DEEPSEEK_PROVIDER")
+            provider: std::env::var("CODEWHALE_PROVIDER")
+                .or_else(|_| std::env::var("DEEPSEEK_PROVIDER"))
                 .ok()
                 .and_then(|v| ProviderKind::parse(&v)),
-            model: std::env::var("DEEPSEEK_MODEL").ok(),
+            model: std::env::var("CODEWHALE_MODEL")
+                .or_else(|_| std::env::var("DEEPSEEK_MODEL"))
+                .ok(),
             wanjie_ark_model: std::env::var("WANJIE_ARK_MODEL")
                 .or_else(|_| std::env::var("WANJIE_MODEL"))
                 .or_else(|_| std::env::var("WANJIE_MAAS_MODEL"))
@@ -1816,7 +1819,8 @@ impl EnvRuntimeOverrides {
                 .ok()
                 .and_then(|value| parse_http_headers(&value).ok())
                 .filter(|headers| !headers.is_empty()),
-            deepseek_base_url: std::env::var("DEEPSEEK_BASE_URL")
+            deepseek_base_url: std::env::var("CODEWHALE_BASE_URL")
+                .or_else(|_| std::env::var("DEEPSEEK_BASE_URL"))
                 .ok()
                 .filter(|v| !v.trim().is_empty()),
             nvidia_base_url: std::env::var("NVIDIA_NIM_BASE_URL")
@@ -1954,6 +1958,9 @@ mod tests {
         vllm_base_url: Option<OsString>,
         ollama_api_key: Option<OsString>,
         ollama_base_url: Option<OsString>,
+        codewhale_provider: Option<OsString>,
+        codewhale_model: Option<OsString>,
+        codewhale_base_url: Option<OsString>,
     }
 
     impl EnvGuard {
@@ -1965,6 +1972,9 @@ mod tests {
                 deepseek_model: env::var_os("DEEPSEEK_MODEL"),
                 deepseek_provider: env::var_os("DEEPSEEK_PROVIDER"),
                 deepseek_auth_mode: env::var_os("DEEPSEEK_AUTH_MODE"),
+                codewhale_provider: env::var_os("CODEWHALE_PROVIDER"),
+                codewhale_model: env::var_os("CODEWHALE_MODEL"),
+                codewhale_base_url: env::var_os("CODEWHALE_BASE_URL"),
                 nvidia_api_key: env::var_os("NVIDIA_API_KEY"),
                 nvidia_nim_api_key: env::var_os("NVIDIA_NIM_API_KEY"),
                 nim_base_url: env::var_os("NIM_BASE_URL"),
@@ -2005,6 +2015,9 @@ mod tests {
                 env::remove_var("DEEPSEEK_MODEL");
                 env::remove_var("DEEPSEEK_PROVIDER");
                 env::remove_var("DEEPSEEK_AUTH_MODE");
+                env::remove_var("CODEWHALE_PROVIDER");
+                env::remove_var("CODEWHALE_MODEL");
+                env::remove_var("CODEWHALE_BASE_URL");
                 env::remove_var("NVIDIA_API_KEY");
                 env::remove_var("NVIDIA_NIM_API_KEY");
                 env::remove_var("NIM_BASE_URL");
@@ -2059,6 +2072,9 @@ mod tests {
                 Self::restore_var("DEEPSEEK_MODEL", self.deepseek_model.take());
                 Self::restore_var("DEEPSEEK_PROVIDER", self.deepseek_provider.take());
                 Self::restore_var("DEEPSEEK_AUTH_MODE", self.deepseek_auth_mode.take());
+                Self::restore_var("CODEWHALE_PROVIDER", self.codewhale_provider.take());
+                Self::restore_var("CODEWHALE_MODEL", self.codewhale_model.take());
+                Self::restore_var("CODEWHALE_BASE_URL", self.codewhale_base_url.take());
                 Self::restore_var("NVIDIA_API_KEY", self.nvidia_api_key.take());
                 Self::restore_var("NVIDIA_NIM_API_KEY", self.nvidia_nim_api_key.take());
                 Self::restore_var("NIM_BASE_URL", self.nim_base_url.take());
@@ -2408,6 +2424,55 @@ mod tests {
         );
     }
 
+    /// End-to-end smoke for the preferred Kimi Code setup path:
+    ///   1. Start from a fresh root config that uses DeepSeek defaults.
+    ///   2. Mutate it through the same key-value setters the
+    ///      `codewhale config set providers.moonshot.*` CLI invokes.
+    ///   3. Switch the active provider through `CODEWHALE_PROVIDER` —
+    ///      the public env alias — without ever touching the legacy
+    ///      `DEEPSEEK_PROVIDER` name.
+    ///   4. Resolve the runtime and confirm the doctor/runtime values.
+    ///
+    /// No real API key is required; the `api_key` here is just a
+    /// non-empty placeholder.
+    #[test]
+    fn moonshot_kimi_code_smoke_config_set_then_resolve() -> Result<()> {
+        let _lock = env_lock();
+        let _env = EnvGuard::without_deepseek_runtime_overrides();
+
+        let mut config = ConfigToml {
+            provider: ProviderKind::Deepseek,
+            default_text_model: Some("deepseek-v4-pro".to_string()),
+            ..ConfigToml::default()
+        };
+
+        // Same key paths a user would run via `codewhale config set`.
+        config.set_value("providers.moonshot.api_key", "kimi-code-key-placeholder")?;
+        config.set_value("providers.moonshot.auth_mode", "api_key")?;
+        config.set_value("providers.moonshot.base_url", DEFAULT_KIMI_CODE_BASE_URL)?;
+        config.set_value("providers.moonshot.model", DEFAULT_KIMI_CODE_MODEL)?;
+
+        // Public env alias for the active-provider switch.
+        // Safety: test-only env mutation guarded by env_lock().
+        unsafe { env::set_var("CODEWHALE_PROVIDER", "moonshot") };
+
+        let resolved = config.resolve_runtime_options(&CliRuntimeOverrides::default());
+
+        assert_eq!(resolved.provider, ProviderKind::Moonshot);
+        assert_eq!(resolved.base_url, DEFAULT_KIMI_CODE_BASE_URL);
+        assert_eq!(resolved.model, DEFAULT_KIMI_CODE_MODEL);
+        assert_eq!(resolved.auth_mode.as_deref(), Some("api_key"));
+        assert_eq!(
+            resolved.api_key.as_deref(),
+            Some("kimi-code-key-placeholder")
+        );
+        assert_eq!(
+            resolved.api_key_source,
+            Some(RuntimeApiKeySource::ConfigFile)
+        );
+        Ok(())
+    }
+
     #[test]
     fn moonshot_provider_config_values_round_trip() -> Result<()> {
         let mut config = ConfigToml::default();
@@ -2755,6 +2820,75 @@ mod tests {
             resolved.api_key_source,
             Some(RuntimeApiKeySource::ConfigFile)
         );
+    }
+
+    /// `CODEWHALE_PROVIDER` is the user-facing env alias for switching the
+    /// active provider. It must be honored by the runtime resolver and win
+    /// over a root `provider = "deepseek"` config entry.
+    #[test]
+    fn codewhale_provider_env_switches_active_provider() {
+        let _lock = env_lock();
+        let _env = EnvGuard::without_deepseek_runtime_overrides();
+        // Safety: test-only env mutation guarded by env_lock().
+        unsafe {
+            env::set_var("CODEWHALE_PROVIDER", "moonshot");
+        }
+        let mut config = ConfigToml {
+            provider: ProviderKind::Deepseek,
+            ..ConfigToml::default()
+        };
+        config.providers.moonshot.api_key = Some("kimi-code-key".to_string());
+        config.providers.moonshot.base_url = Some(DEFAULT_KIMI_CODE_BASE_URL.to_string());
+
+        let resolved = config.resolve_runtime_options(&CliRuntimeOverrides::default());
+
+        assert_eq!(resolved.provider, ProviderKind::Moonshot);
+        assert_eq!(resolved.base_url, DEFAULT_KIMI_CODE_BASE_URL);
+        assert_eq!(resolved.model, DEFAULT_KIMI_CODE_MODEL);
+        assert_eq!(resolved.api_key.as_deref(), Some("kimi-code-key"));
+    }
+
+    /// When both `CODEWHALE_PROVIDER` and the legacy `DEEPSEEK_PROVIDER`
+    /// are set, the public alias wins — a user adopting `CODEWHALE_*` in a
+    /// fresh shell config is not tripped up by a stale legacy export still
+    /// living in their dotfiles.
+    #[test]
+    fn codewhale_provider_env_wins_over_deepseek_provider_env() {
+        let _lock = env_lock();
+        let _env = EnvGuard::without_deepseek_runtime_overrides();
+        // Safety: test-only env mutation guarded by env_lock().
+        unsafe {
+            env::set_var("CODEWHALE_PROVIDER", "moonshot");
+            env::set_var("DEEPSEEK_PROVIDER", "openrouter");
+        }
+        let config = ConfigToml {
+            provider: ProviderKind::Deepseek,
+            ..ConfigToml::default()
+        };
+
+        let resolved = config.resolve_runtime_options(&CliRuntimeOverrides::default());
+
+        assert_eq!(resolved.provider, ProviderKind::Moonshot);
+    }
+
+    /// `CODEWHALE_MODEL` is the user-facing env alias for picking a model
+    /// against the active provider. It must be honored by the runtime
+    /// resolver in place of `DEEPSEEK_MODEL`.
+    #[test]
+    fn codewhale_model_env_alias_overrides_default_for_active_provider() {
+        let _lock = env_lock();
+        let _env = EnvGuard::without_deepseek_runtime_overrides();
+        // Safety: test-only env mutation guarded by env_lock().
+        unsafe {
+            env::set_var("CODEWHALE_PROVIDER", "moonshot");
+            env::set_var("CODEWHALE_MODEL", "kimi-k2.6");
+        }
+        let config = ConfigToml::default();
+
+        let resolved = config.resolve_runtime_options(&CliRuntimeOverrides::default());
+
+        assert_eq!(resolved.provider, ProviderKind::Moonshot);
+        assert_eq!(resolved.model, DEFAULT_MOONSHOT_MODEL);
     }
 
     #[test]

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -7,11 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`CODEWHALE_*` env aliases.** `CODEWHALE_PROVIDER`, `CODEWHALE_MODEL`,
+  and `CODEWHALE_BASE_URL` are public aliases that take precedence over
+  the legacy `DEEPSEEK_*` forms. The `DEEPSEEK_*` names remain accepted
+  for back-compat. Recommended setup paths are `codewhale --provider <name>`,
+  `provider = "<name>"` in `~/.codewhale/config.toml`, or
+  `CODEWHALE_PROVIDER=<name>` — never `DEEPSEEK_PROVIDER=<name>` in
+  user-facing docs.
+
 ### Fixed
 
 - **Kimi Code API-key setup.** `codewhale config set providers.moonshot.*`
   now writes the Moonshot/Kimi provider table, and Kimi Code API-key
   endpoints default to `kimi-for-coding` without using the Kimi CLI OAuth path.
+- **Kimi Code model precedence.** When `[providers.moonshot]` points at the
+  Kimi Code endpoint, the resolver now returns `kimi-for-coding` even when
+  a root DeepSeek `default_text_model` (e.g. `deepseek-v4-pro`) is still in
+  the config from a previous setup.
 
 ## [0.8.45] - 2026-05-25
 

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -1554,6 +1554,19 @@ impl Config {
                 }
             }
         }
+        let moonshot_config = (provider == ApiProvider::Moonshot)
+            .then(|| self.provider_config())
+            .flatten();
+        let moonshot_uses_kimi_code = moonshot_config.is_some_and(|config| {
+            provider_config_uses_kimi_oauth(config)
+                || config
+                    .base_url
+                    .as_deref()
+                    .is_some_and(moonshot_base_url_uses_kimi_code)
+        });
+        if moonshot_uses_kimi_code {
+            return DEFAULT_KIMI_CODE_MODEL.to_string();
+        }
         if let Some(model) = self.default_text_model.as_deref()
             && (provider_passes_model_through(provider)
                 || self.active_provider_preserves_custom_base_url_model())
@@ -1569,19 +1582,6 @@ impl Config {
             && let Some(normalized) = normalize_model_name(model)
         {
             return model_for_provider(provider, normalized);
-        }
-        let moonshot_config = (provider == ApiProvider::Moonshot)
-            .then(|| self.provider_config())
-            .flatten();
-        let moonshot_uses_kimi_code = moonshot_config.is_some_and(|config| {
-            provider_config_uses_kimi_oauth(config)
-                || config
-                    .base_url
-                    .as_deref()
-                    .is_some_and(moonshot_base_url_uses_kimi_code)
-        });
-        if moonshot_uses_kimi_code {
-            return DEFAULT_KIMI_CODE_MODEL.to_string();
         }
 
         match provider {
@@ -2271,11 +2271,23 @@ fn default_memory_path() -> Option<PathBuf> {
 
 // === Environment Overrides ===
 
+/// Read a CodeWhale env var, preferring the `CODEWHALE_*` form over the
+/// legacy `DEEPSEEK_*` form. Used for the four user-facing slots (provider,
+/// model, base URL, API key) so external setup can switch to the
+/// product-scoped names without breaking shells that still export the
+/// legacy ones.
+fn codewhale_env_var(
+    codewhale_name: &str,
+    legacy_name: &str,
+) -> Result<String, std::env::VarError> {
+    std::env::var(codewhale_name).or_else(|_| std::env::var(legacy_name))
+}
+
 fn apply_env_overrides(config: &mut Config) {
-    if let Ok(value) = std::env::var("DEEPSEEK_PROVIDER") {
+    if let Ok(value) = codewhale_env_var("CODEWHALE_PROVIDER", "DEEPSEEK_PROVIDER") {
         config.provider = Some(value);
     }
-    if let Ok(value) = std::env::var("DEEPSEEK_BASE_URL") {
+    if let Ok(value) = codewhale_env_var("CODEWHALE_BASE_URL", "DEEPSEEK_BASE_URL") {
         match config.api_provider() {
             ApiProvider::Deepseek | ApiProvider::DeepseekCN => {
                 config.base_url = Some(value);
@@ -2558,8 +2570,9 @@ fn apply_env_overrides(config: &mut Config) {
             .moonshot
             .model = Some(value);
     }
-    if let Ok(value) =
-        std::env::var("DEEPSEEK_MODEL").or_else(|_| std::env::var("DEEPSEEK_DEFAULT_TEXT_MODEL"))
+    if let Ok(value) = std::env::var("CODEWHALE_MODEL")
+        .or_else(|_| std::env::var("DEEPSEEK_MODEL"))
+        .or_else(|_| std::env::var("DEEPSEEK_DEFAULT_TEXT_MODEL"))
     {
         // The CLI `--model` handoff always sets DEEPSEEK_MODEL, never the
         // provider-specific *_MODEL var. The legacy root `default_text_model`
@@ -4075,6 +4088,9 @@ mod tests {
         deepseek_http_headers: Option<OsString>,
         deepseek_model: Option<OsString>,
         deepseek_default_text_model: Option<OsString>,
+        codewhale_provider: Option<OsString>,
+        codewhale_model: Option<OsString>,
+        codewhale_base_url: Option<OsString>,
         nvidia_api_key: Option<OsString>,
         nvidia_nim_api_key: Option<OsString>,
         nim_base_url: Option<OsString>,
@@ -4137,6 +4153,9 @@ mod tests {
             let http_headers_prev = env::var_os("DEEPSEEK_HTTP_HEADERS");
             let model_prev = env::var_os("DEEPSEEK_MODEL");
             let default_text_model_prev = env::var_os("DEEPSEEK_DEFAULT_TEXT_MODEL");
+            let codewhale_provider_prev = env::var_os("CODEWHALE_PROVIDER");
+            let codewhale_model_prev = env::var_os("CODEWHALE_MODEL");
+            let codewhale_base_url_prev = env::var_os("CODEWHALE_BASE_URL");
             let nvidia_api_key_prev = env::var_os("NVIDIA_API_KEY");
             let nvidia_nim_api_key_prev = env::var_os("NVIDIA_NIM_API_KEY");
             let nim_base_url_prev = env::var_os("NIM_BASE_URL");
@@ -4194,6 +4213,9 @@ mod tests {
                 env::remove_var("DEEPSEEK_HTTP_HEADERS");
                 env::remove_var("DEEPSEEK_MODEL");
                 env::remove_var("DEEPSEEK_DEFAULT_TEXT_MODEL");
+                env::remove_var("CODEWHALE_PROVIDER");
+                env::remove_var("CODEWHALE_MODEL");
+                env::remove_var("CODEWHALE_BASE_URL");
                 env::remove_var("NVIDIA_API_KEY");
                 env::remove_var("NVIDIA_NIM_API_KEY");
                 env::remove_var("NIM_BASE_URL");
@@ -4251,6 +4273,9 @@ mod tests {
                 deepseek_http_headers: http_headers_prev,
                 deepseek_model: model_prev,
                 deepseek_default_text_model: default_text_model_prev,
+                codewhale_provider: codewhale_provider_prev,
+                codewhale_model: codewhale_model_prev,
+                codewhale_base_url: codewhale_base_url_prev,
                 nvidia_api_key: nvidia_api_key_prev,
                 nvidia_nim_api_key: nvidia_nim_api_key_prev,
                 nim_base_url: nim_base_url_prev,
@@ -4317,6 +4342,9 @@ mod tests {
                     "DEEPSEEK_DEFAULT_TEXT_MODEL",
                     self.deepseek_default_text_model.take(),
                 );
+                Self::restore_var("CODEWHALE_PROVIDER", self.codewhale_provider.take());
+                Self::restore_var("CODEWHALE_MODEL", self.codewhale_model.take());
+                Self::restore_var("CODEWHALE_BASE_URL", self.codewhale_base_url.take());
                 Self::restore_var("NVIDIA_API_KEY", self.nvidia_api_key.take());
                 Self::restore_var("NVIDIA_NIM_API_KEY", self.nvidia_nim_api_key.take());
                 Self::restore_var("NIM_BASE_URL", self.nim_base_url.take());
@@ -6481,6 +6509,162 @@ base_url = "https://api.kimi.com/coding/v1"
         assert_eq!(config.default_model(), DEFAULT_KIMI_CODE_MODEL);
         assert_eq!(config.deepseek_api_key()?, "kimi-code-key");
         assert!(has_api_key_for(&config, ApiProvider::Moonshot));
+        Ok(())
+    }
+
+    /// Regression for issue #2160: a stale root `default_text_model` carried
+    /// over from a DeepSeek setup must not steer the Kimi Code endpoint to
+    /// `deepseek-v4-pro`. The user-facing trigger here is the legacy
+    /// `DEEPSEEK_PROVIDER` env var (still produced by the `codewhale
+    /// --provider moonshot` dispatcher for compat); the test also has a
+    /// `CODEWHALE_PROVIDER` twin below for the public env path.
+    #[test]
+    fn moonshot_kimi_code_model_overrides_root_deepseek_default() -> Result<()> {
+        let _lock = lock_test_env();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let temp_root = env::temp_dir().join(format!(
+            "codewhale-tui-kimi-code-root-model-{}-{}",
+            std::process::id(),
+            nanos
+        ));
+        fs::create_dir_all(&temp_root)?;
+        let _guard = EnvGuard::new(&temp_root);
+
+        let config_path = temp_root.join(".deepseek").join("config.toml");
+        ensure_parent_dir(&config_path)?;
+        fs::write(
+            &config_path,
+            r#"provider = "deepseek"
+default_text_model = "deepseek-v4-pro"
+
+[providers.moonshot]
+api_key = "kimi-code-key"
+base_url = "https://api.kimi.com/coding/v1"
+"#,
+        )?;
+        // Safety: test-only env mutation guarded by lock_test_env().
+        unsafe { env::set_var("DEEPSEEK_PROVIDER", "moonshot") };
+
+        let config = Config::load(None, None)?;
+        assert_eq!(config.api_provider(), ApiProvider::Moonshot);
+        assert_eq!(config.deepseek_base_url(), DEFAULT_KIMI_CODE_BASE_URL);
+        assert_eq!(config.default_model(), DEFAULT_KIMI_CODE_MODEL);
+        Ok(())
+    }
+
+    /// Same regression as above, but driven by the public `CODEWHALE_PROVIDER`
+    /// env var. Documents the recommended user-facing setup path: never
+    /// `DEEPSEEK_PROVIDER=moonshot`, always `CODEWHALE_PROVIDER=moonshot`
+    /// (or `codewhale --provider moonshot`, which also resolves through
+    /// this code path internally).
+    #[test]
+    fn moonshot_kimi_code_model_resolves_via_codewhale_provider_env() -> Result<()> {
+        let _lock = lock_test_env();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let temp_root = env::temp_dir().join(format!(
+            "codewhale-tui-kimi-code-cw-env-{}-{}",
+            std::process::id(),
+            nanos
+        ));
+        fs::create_dir_all(&temp_root)?;
+        let _guard = EnvGuard::new(&temp_root);
+
+        let config_path = temp_root.join(".deepseek").join("config.toml");
+        ensure_parent_dir(&config_path)?;
+        fs::write(
+            &config_path,
+            r#"provider = "deepseek"
+default_text_model = "deepseek-v4-pro"
+
+[providers.moonshot]
+api_key = "kimi-code-key"
+base_url = "https://api.kimi.com/coding/v1"
+"#,
+        )?;
+        // Safety: test-only env mutation guarded by lock_test_env().
+        unsafe { env::set_var("CODEWHALE_PROVIDER", "moonshot") };
+
+        let config = Config::load(None, None)?;
+        assert_eq!(config.api_provider(), ApiProvider::Moonshot);
+        assert_eq!(config.deepseek_base_url(), DEFAULT_KIMI_CODE_BASE_URL);
+        assert_eq!(config.default_model(), DEFAULT_KIMI_CODE_MODEL);
+        Ok(())
+    }
+
+    /// `CODEWHALE_PROVIDER` wins when both it and the legacy
+    /// `DEEPSEEK_PROVIDER` are set, so a user adding the new alias to their
+    /// shell isn't surprised by a stale legacy export.
+    #[test]
+    fn codewhale_provider_env_takes_precedence_over_deepseek_provider() -> Result<()> {
+        let _lock = lock_test_env();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let temp_root = env::temp_dir().join(format!(
+            "codewhale-tui-cw-vs-ds-provider-{}-{}",
+            std::process::id(),
+            nanos
+        ));
+        fs::create_dir_all(&temp_root)?;
+        let _guard = EnvGuard::new(&temp_root);
+
+        let config_path = temp_root.join(".deepseek").join("config.toml");
+        ensure_parent_dir(&config_path)?;
+        fs::write(&config_path, "provider = \"deepseek\"\n")?;
+        // Safety: test-only env mutation guarded by lock_test_env().
+        unsafe {
+            env::set_var("CODEWHALE_PROVIDER", "moonshot");
+            env::set_var("DEEPSEEK_PROVIDER", "openrouter");
+        }
+
+        let config = Config::load(None, None)?;
+        assert_eq!(config.api_provider(), ApiProvider::Moonshot);
+        Ok(())
+    }
+
+    /// Moonshot Platform path: when [providers.moonshot] is empty (or
+    /// missing) and no Kimi Code endpoint is configured, the resolver
+    /// defaults to the Moonshot Platform base URL and the `kimi-k2.6`
+    /// model. This is the "I have a Moonshot Platform API key, not a
+    /// Kimi Code plan key" path.
+    #[test]
+    fn moonshot_platform_defaults_to_kimi_k26() -> Result<()> {
+        let _lock = lock_test_env();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let temp_root = env::temp_dir().join(format!(
+            "codewhale-tui-moonshot-platform-{}-{}",
+            std::process::id(),
+            nanos
+        ));
+        fs::create_dir_all(&temp_root)?;
+        let _guard = EnvGuard::new(&temp_root);
+
+        let config_path = temp_root.join(".deepseek").join("config.toml");
+        ensure_parent_dir(&config_path)?;
+        fs::write(
+            &config_path,
+            r#"provider = "moonshot"
+
+[providers.moonshot]
+api_key = "moonshot-platform-key"
+"#,
+        )?;
+
+        let config = Config::load(None, None)?;
+        assert_eq!(config.api_provider(), ApiProvider::Moonshot);
+        assert_eq!(config.deepseek_base_url(), DEFAULT_MOONSHOT_BASE_URL);
+        assert_eq!(config.default_model(), DEFAULT_MOONSHOT_MODEL);
+        assert_eq!(config.deepseek_api_key()?, "moonshot-platform-key");
         Ok(())
     }
 

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -2272,15 +2272,21 @@ fn default_memory_path() -> Option<PathBuf> {
 // === Environment Overrides ===
 
 /// Read a CodeWhale env var, preferring the `CODEWHALE_*` form over the
-/// legacy `DEEPSEEK_*` form. Used for the four user-facing slots (provider,
-/// model, base URL, API key) so external setup can switch to the
-/// product-scoped names without breaking shells that still export the
-/// legacy ones.
+/// legacy `DEEPSEEK_*` form. Empty values are ignored so a blank shell export
+/// does not erase configured provider settings.
 fn codewhale_env_var(
     codewhale_name: &str,
     legacy_name: &str,
 ) -> Result<String, std::env::VarError> {
-    std::env::var(codewhale_name).or_else(|_| std::env::var(legacy_name))
+    std::env::var(codewhale_name)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| {
+            std::env::var(legacy_name)
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+        })
+        .ok_or(std::env::VarError::NotPresent)
 }
 
 fn apply_env_overrides(config: &mut Config) {
@@ -2570,9 +2576,13 @@ fn apply_env_overrides(config: &mut Config) {
             .moonshot
             .model = Some(value);
     }
-    if let Ok(value) = std::env::var("CODEWHALE_MODEL")
-        .or_else(|_| std::env::var("DEEPSEEK_MODEL"))
-        .or_else(|_| std::env::var("DEEPSEEK_DEFAULT_TEXT_MODEL"))
+    if let Some(value) = codewhale_env_var("CODEWHALE_MODEL", "DEEPSEEK_MODEL")
+        .ok()
+        .or_else(|| {
+            std::env::var("DEEPSEEK_DEFAULT_TEXT_MODEL")
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+        })
     {
         // The CLI `--model` handoff always sets DEEPSEEK_MODEL, never the
         // provider-specific *_MODEL var. The legacy root `default_text_model`

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -202,7 +202,7 @@ If a profile is selected but missing, codewhale exits with an error listing avai
 Most runtime environment variables override config values. API-key variables are
 fallbacks after saved config and keyring credentials.
 
-The four user-facing slots — provider, model, base URL — expose `CODEWHALE_*`
+The three user-facing slots — provider, model, base URL — expose `CODEWHALE_*`
 aliases. When both forms are set the `CODEWHALE_*` value wins; the
 `DEEPSEEK_*` form is kept for older shells:
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -200,13 +200,22 @@ If a profile is selected but missing, codewhale exits with an error listing avai
 ## Environment Variables
 
 Most runtime environment variables override config values. API-key variables are
-fallbacks after saved config and keyring credentials:
+fallbacks after saved config and keyring credentials.
+
+The four user-facing slots — provider, model, base URL — expose `CODEWHALE_*`
+aliases. When both forms are set the `CODEWHALE_*` value wins; the
+`DEEPSEEK_*` form is kept for older shells:
+
+- `CODEWHALE_PROVIDER` (preferred) / `DEEPSEEK_PROVIDER` (legacy alias) —
+  `deepseek|nvidia-nim|openai|atlascloud|wanjie-ark|openrouter|novita|fireworks|moonshot|sglang|vllm|ollama`
+- `CODEWHALE_MODEL` (preferred) / `DEEPSEEK_MODEL` (legacy alias) — default model for the active provider
+- `CODEWHALE_BASE_URL` (preferred) / `DEEPSEEK_BASE_URL` (legacy alias) — base URL for the active provider
+
+Remaining variables:
 
 - `DEEPSEEK_API_KEY`
-- `DEEPSEEK_BASE_URL`
 - `DEEPSEEK_HTTP_HEADERS` (custom model request headers, comma-separated `name=value` pairs)
-- `DEEPSEEK_PROVIDER` (`codewhale|nvidia-nim|openai|atlascloud|wanjie-ark|openrouter|novita|fireworks|moonshot|sglang|vllm|ollama`)
-- `DEEPSEEK_MODEL` or `DEEPSEEK_DEFAULT_TEXT_MODEL`
+- `DEEPSEEK_DEFAULT_TEXT_MODEL` (extra legacy alias of `DEEPSEEK_MODEL`)
 - `DEEPSEEK_STREAM_IDLE_TIMEOUT_SECS` (stream idle timeout in seconds; default `300`, clamped to `1..=3600`)
 - `DEEPSEEK_STREAM_OPEN_TIMEOUT_SECS` (connection setup + response-header wait in seconds; default `45`, clamped to `5..=300`; distinct from the per-chunk idle timeout)
 - `NVIDIA_API_KEY` or `NVIDIA_NIM_API_KEY` (preferred when provider is `nvidia-nim`; falls back to `DEEPSEEK_API_KEY`)


### PR DESCRIPTION
## Summary

Supersedes #2160 with a broader fix: keeps the same Kimi-Code model
precedence reordering, but routes the user-facing provider/model/base-url
switches through `CODEWHALE_*` env aliases (with `DEEPSEEK_*` retained as
legacy fallback only) and tests both paths.

## Why

Local setup exposed that a stale root `default_text_model = "deepseek-v4-pro"`
in `~/.codewhale/config.toml` was overriding the Kimi Code endpoint's
`kimi-for-coding` model when a user switched provider — even if they had
written `[providers.moonshot] base_url = "https://api.kimi.com/coding/v1"`.
#2160 had the right code fix (reorder the Kimi Code detection above the
root `default_text_model` fallback) but its regression test drove the
switch through `DEEPSEEK_PROVIDER=moonshot`, baking the legacy name
into a user-facing setup story we don't want to recommend.

This PR keeps the fix, adds the `CODEWHALE_*` aliases (`CODEWHALE_PROVIDER`,
`CODEWHALE_MODEL`, `CODEWHALE_BASE_URL`), and tests both the new public
path and the legacy `DEEPSEEK_*` path side-by-side.

## What changed

- **`crates/tui/src/config.rs`** — Move the Kimi Code model detection
  block above the root `default_text_model` fallback in `default_model()`
  (same logic as #2160; reordering only). Read `CODEWHALE_PROVIDER`,
  `CODEWHALE_MODEL`, and `CODEWHALE_BASE_URL` in `apply_env_overrides`
  with the matching `DEEPSEEK_*` names as fallback. Extend the test-only
  `EnvGuard` to save/restore the new vars.
- **`crates/config/src/lib.rs`** — Read the same `CODEWHALE_*` aliases in
  `EnvRuntimeOverrides::load()` so the CLI dispatcher's runtime resolver
  honors them too. Extend `EnvGuard` similarly.
- **Tests**:
  - `moonshot_kimi_code_model_overrides_root_deepseek_default` — legacy
    `DEEPSEEK_PROVIDER` regression (the original case from #2160).
  - `moonshot_kimi_code_model_resolves_via_codewhale_provider_env` —
    same scenario, switched through the public `CODEWHALE_PROVIDER`.
  - `codewhale_provider_env_takes_precedence_over_deepseek_provider` —
    user adopting the new alias is not tripped up by a stale legacy export.
  - `moonshot_platform_defaults_to_kimi_k26` — confirms the non-Kimi-Code
    Moonshot setup still resolves to `kimi-k2.6` against
    `https://api.moonshot.ai/v1`.
  - `codewhale_*` tests in `codewhale-config` covering the same paths at
    the runtime-resolver layer.
  - `moonshot_kimi_code_smoke_config_set_then_resolve` — end-to-end smoke
    that calls the same `set_value` keys as `codewhale config set
    providers.moonshot.*` and then resolves the runtime. No real API key.
- **Docs (`README.md`, `docs/CONFIGURATION.md`, `CHANGELOG.md`,
  `crates/tui/CHANGELOG.md`)** — Document `CODEWHALE_PROVIDER`,
  `CODEWHALE_MODEL`, `CODEWHALE_BASE_URL` as the public names and
  `DEEPSEEK_*` as legacy aliases. No user-facing example sets
  `DEEPSEEK_PROVIDER=moonshot`.

## What didn't change

- Provider list (`v0.8.45`-frozen): Deepseek, NvidiaNim, Openai, Atlascloud,
  WanjieArk, Openrouter, Novita, Fireworks, Moonshot, Sglang, Vllm, Ollama.
- Kimi CLI OAuth path: still supported in code, not promoted in docs.
- CLI dispatcher's internal handoff: still propagates via `DEEPSEEK_*` env
  vars (back-compat surface; users don't see this).
- No version bump. `0.8.45` stands.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `scripts/release/check-versions.sh`
- [x] `git diff --check`
- [x] `cargo test -p codewhale-config moonshot --locked` (6 pass)
- [x] `cargo test -p codewhale-config codewhale_ --locked` (3 pass)
- [x] `cargo test -p codewhale-tui moonshot --locked` (6 pass)
- [x] `cargo test -p codewhale-tui codewhale_provider --locked` (2 pass)
- [x] `cargo test -p codewhale-cli moonshot --locked` (1 pass)
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked` (3354 pass)
- [x] `cargo clippy -p codewhale-config --all-targets --locked -- -D warnings` clean
- [x] `cargo clippy -p codewhale-cli --all-targets --all-features --locked` clean
  (pre-existing TUI clippy warnings on `main` are out of scope here — they
  pre-date this branch and only gate at release time, not on PRs)

Closes #2160 (superseded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the Kimi Code model-precedence bug from #2160 and introduces `CODEWHALE_PROVIDER`, `CODEWHALE_MODEL`, and `CODEWHALE_BASE_URL` as the public, user-facing env aliases (taking precedence over their legacy `DEEPSEEK_*` counterparts), with comprehensive regression tests and doc updates.

- **Core fix (`tui/config.rs`)**: moves Kimi Code endpoint detection above the `default_text_model` fallback in `default_model()`, so a stale root `deepseek-v4-pro` model entry no longer overrides `kimi-for-coding` when the Moonshot base URL points at the Kimi Code endpoint.
- **`CODEWHALE_*` aliases**: both `crates/tui/src/config.rs` and `crates/config/src/lib.rs` now read `CODEWHALE_PROVIDER/MODEL/BASE_URL` first, falling back to `DEEPSEEK_*`; the TUI path uses the shared `codewhale_env_var` helper that filters empty strings before each fallback step; the config-crate path uses a plain `or_else(|_|)` chain that does not filter empty `CODEWHALE_MODEL` before the fallback, creating a minor divergence between the two resolvers.
- **Tests and docs**: six new integration tests (three per crate) cover the public and legacy env paths, precedence ordering, and the original regression; README/CONFIGURATION.md/CHANGELOGs updated to demote `DEEPSEEK_*` to legacy status.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the ordering fix is a straightforward block reorder, all new env-var aliases have fallback behaviour, and the existing test suite is comprehensive.

The Kimi Code detection reorder is a low-risk change confined to a single function, the alias wiring is additive with backward-compatible fallbacks, and every new code path is covered by dedicated tests. The only divergence noted (empty-string CODEWHALE_MODEL not falling through to DEEPSEEK_MODEL in the config-crate path) requires an unusual environment configuration to surface and does not affect the main Kimi Code setup scenario this PR is fixing.

crates/config/src/lib.rs — the model env-var fallback chain differs slightly from the TUI's codewhale_env_var helper in how it handles an empty CODEWHALE_MODEL export.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/config.rs | Core fix: moves Kimi Code model detection above default_text_model fallback in default_model(); adds codewhale_env_var() helper and wires CODEWHALE_PROVIDER/MODEL/BASE_URL into apply_env_overrides with correct empty-string filtering; EnvGuard extended for the new vars |
| crates/config/src/lib.rs | EnvRuntimeOverrides::load() updated to prefer CODEWHALE_PROVIDER/MODEL/BASE_URL over DEEPSEEK_* fallbacks; model chain uses or_else(|_|) which does not fall through when CODEWHALE_MODEL is set to an empty string, creating a subtle divergence from TUI's codewhale_env_var behaviour; new tests cover the alias paths |
| CHANGELOG.md | Unreleased section updated to document CODEWHALE_* env aliases and the Kimi Code model-precedence fix |
| README.md | Env-variable table updated to list CODEWHALE_PROVIDER/MODEL/BASE_URL as public aliases and demote DEEPSEEK_* to legacy |
| crates/tui/CHANGELOG.md | Mirror of root CHANGELOG.md for the TUI crate; Unreleased section updated correctly |
| docs/CONFIGURATION.md | Environment variables section restructured to lead with CODEWHALE_* aliases and move DEEPSEEK_* to legacy; count corrected to three user-facing slots |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([Env vars present]) --> B{CODEWHALE_PROVIDER set\nand non-empty?}
    B -- Yes --> C[Use CODEWHALE_PROVIDER]
    B -- No --> D{DEEPSEEK_PROVIDER set?}
    D -- Yes --> C
    D -- No --> E[Use config file / default provider]

    C --> F{Provider == Moonshot?}
    E --> F

    F -- Yes --> G{providers.moonshot.base_url\npoints to Kimi Code endpoint?}
    G -- Yes --> H[Return DEFAULT_KIMI_CODE_MODEL]
    G -- No --> I{default_text_model set in config?}
    I -- Yes, applicable --> J[Use default_text_model]
    I -- No / not applicable --> K[Return DEFAULT_MOONSHOT_MODEL]
    F -- No --> L[Continue normal model resolution]

    subgraph Model ENV resolution - config crate
    M{CODEWHALE_MODEL set?} --> |non-empty Ok| N[Use CODEWHALE_MODEL]
    M --> |Err or empty after filter| O{DEEPSEEK_MODEL set?}
    O --> |non-empty| N
    O --> |Err| P{DEEPSEEK_DEFAULT_TEXT_MODEL?}
    P --> |non-empty| N
    P --> |Err| Q[model = None]
    end

    subgraph Model ENV resolution - TUI codewhale_env_var
    R{CODEWHALE_MODEL set\nand non-empty?} -- Yes --> S[Use CODEWHALE_MODEL]
    R -- No / blank --> T{DEEPSEEK_MODEL non-empty?}
    T -- Yes --> S
    T -- No --> U[Fallback to DEEPSEEK_DEFAULT_TEXT_MODEL or default]
    end
```
</details>

<a href="https://app.greptile.com/api/ide/devin?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fkimi-provider-setup-cleanup%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fkimi-provider-setup-cleanup%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Fconfig%2Fsrc%2Flib.rs%3A1794-1798%0AEmpty-%60CODEWHALE_MODEL%60%20does%20not%20fall%20through%20to%20%60DEEPSEEK_MODEL%60%20in%20this%20crate%2C%20while%20%60tui%2Fconfig.rs%60's%20%60codewhale_env_var%60%20does.%20When%20%60CODEWHALE_MODEL%60%20is%20exported%20as%20an%20empty%20string%20%28%60export%20CODEWHALE_MODEL%3D%22%22%60%29%2C%20%60std%3A%3Aenv%3A%3Avar%60%20returns%20%60Ok%28%22%22%29%60%2C%20which%20is%20not%20an%20%60Err%60%2C%20so%20%60.or_else%28%7C_%7C%20std%3A%3Aenv%3A%3Avar%28%22DEEPSEEK_MODEL%22%29%29%60%20is%20never%20reached.%20The%20final%20%60.filter%60%20discards%20the%20empty%20string%2C%20leaving%20%60model%20%3D%20None%60%20and%20silently%20dropping%20a%20previously-effective%20%60DEEPSEEK_MODEL%60%20value.%20The%20TUI%20path%20explicitly%20strips%20empty%20values%20before%20the%20fallback%2C%20so%20a%20user%20with%20both%20vars%20set%20would%20observe%20different%20model%20selection%20between%20the%20CLI%20and%20TUI%20entry%20points.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20model%3A%20std%3A%3Aenv%3A%3Avar%28%22CODEWHALE_MODEL%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.ok%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.filter%28%7Cv%7C%20!v.trim%28%29.is_empty%28%29%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.or_else%28%7C%7C%20std%3A%3Aenv%3A%3Avar%28%22DEEPSEEK_MODEL%22%29.ok%28%29.filter%28%7Cv%7C%20!v.trim%28%29.is_empty%28%29%29%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.or_else%28%7C%7C%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20std%3A%3Aenv%3A%3Avar%28%22DEEPSEEK_DEFAULT_TEXT_MODEL%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.ok%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.filter%28%7Cv%7C%20!v.trim%28%29.is_empty%28%29%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%29%2C%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&tid=69448&ts=1779787565&sig=2fdaca17ad0909e149c8f3dead4428c7ed3728c49827a31803c679f776655162&pr=2164&platform=github&fid=4961e6df-cf1b-442f-b789-8253a431d47a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInDevinDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInDevin.svg?v=3"><img alt="Fix All in Devin" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInDevin.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix(kimi): tighten public env aliases"](https://github.com/hmbown/codewhale/commit/871785b12ce050a51cba90bc83fbc38dcee65f27) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33868991)</sub>

<!-- /greptile_comment -->