### PR TITLE
fix(runtime): truncate assistant summary on UTF-8 char boundary to prevent CJK panic

### DIFF
--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -1434,7 +1434,7 @@ impl RuntimeThreadManager {
 
             if let Some(assistant_text) = assistant_text {
                 let asst_summary = if assistant_text.len() > SUMMARY_LIMIT {
-                    format!("{}...", &assistant_text[..SUMMARY_LIMIT.saturating_sub(3)])
+                    crate::utils::truncate_with_ellipsis(&assistant_text, SUMMARY_LIMIT, "...")
                 } else {
                     assistant_text.clone()
                 };


### PR DESCRIPTION
## Bug

When `assistant_text` contains CJK characters (3-byte UTF-8), the byte slice
`&assistant_text[..SUMMARY_LIMIT.saturating_sub(3)]` (byte 277) can land in
the middle of a multi-byte sequence, causing a panic:

```
byte index 277 is not a char boundary (it is inside a 3-byte UTF-8 sequence)
```

## Fix

Replace the raw byte-index slice with `truncate_with_ellipsis()` which already
finds the nearest safe char boundary via `char_indices()`.

## Change

```diff
-format!("{}...", &assistant_text[..SUMMARY_LIMIT.saturating_sub(3)])
+crate::utils::truncate_with_ellipsis(&assistant_text, SUMMARY_LIMIT, "...")
```

1 line changed.

## Files

- crates/tui/src/runtime_threads.rs:1437

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a panic that occurred when `assistant_text` contained CJK (or any multi-byte UTF-8) characters by replacing a raw byte-index slice with the existing `truncate_with_ellipsis` helper, which already walks `char_indices()` to guarantee a safe boundary.

- The one-line change in `runtime_threads.rs` (line 1437) is correct: `truncate_with_ellipsis` safely handles all UTF-8 sequences by finding the last character start index that fits within the byte budget before appending the ellipsis.
- The outer `if assistant_text.len() > SUMMARY_LIMIT` guard (lines 1436–1440) is now redundant—`truncate_with_ellipsis` already has an identical early-return—and is inconsistent with the `user_text` path on line 1414 that calls the helper directly.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the fix correctly eliminates the UTF-8 boundary panic and the only remaining note is a minor cleanup opportunity.

The one-line change replaces a demonstrably dangerous raw byte slice with a well-tested helper that walks char_indices(). The surrounding outer guard is now dead weight and inconsistent with the adjacent user_text path, but it does not introduce wrong behavior.

No files require special attention; the change is isolated to a single expression in runtime_threads.rs.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/runtime_threads.rs | Single-line fix replaces an unsafe raw byte-index slice with truncate_with_ellipsis; the outer length guard is now redundant but harmless. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["assistant_text available?"] -->|yes| B["assistant_text.len() > SUMMARY_LIMIT?"]
    B -->|yes, OLD path| C["&assistant_text[..SUMMARY_LIMIT - 3]\n⚠️ panics on CJK char boundary"]
    B -->|yes, NEW path| D["truncate_with_ellipsis()\nwalks char_indices() → safe boundary"]
    B -->|no| E["assistant_text.clone()"]
    D --> F["asst_summary = truncated + '...'"]
    E --> F
    C --> G["💥 panic: byte index not a char boundary"]
    F --> H["save_item(TurnItemRecord { summary: asst_summary })"]
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fcjk-byte-boundary%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fcjk-byte-boundary%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fruntime_threads.rs%3A1436-1440%0AThe%20outer%20%60if%20assistant_text.len%28%29%20%3E%20SUMMARY_LIMIT%60%20guard%20is%20now%20redundant.%20%60truncate_with_ellipsis%60%20already%20contains%20an%20identical%20early-return%20%28%60if%20s.len%28%29%20%3C%3D%20max_len%20%7B%20return%20s.to_string%28%29%3B%20%7D%60%29%2C%20so%20the%20branch%20never%20provides%20additional%20protection.%20The%20%60user_text%60%20path%20directly%20above%20%28line%201414%29%20calls%20the%20helper%20without%20a%20guard%2C%20making%20the%20two%20paths%20inconsistent.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20let%20asst_summary%20%3D%20crate%3A%3Autils%3A%3Atruncate_with_ellipsis%28%26assistant_text%2C%20SUMMARY_LIMIT%2C%20%22...%22%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fruntime_threads.rs%3A1436-1440%0AThe%20outer%20%60if%20assistant_text.len%28%29%20%3E%20SUMMARY_LIMIT%60%20guard%20is%20now%20redundant.%20%60truncate_with_ellipsis%60%20already%20contains%20an%20identical%20early-return%20%28%60if%20s.len%28%29%20%3C%3D%20max_len%20%7B%20return%20s.to_string%28%29%3B%20%7D%60%29%2C%20so%20the%20branch%20never%20provides%20additional%20protection.%20The%20%60user_text%60%20path%20directly%20above%20%28line%201414%29%20calls%20the%20helper%20without%20a%20guard%2C%20making%20the%20two%20paths%20inconsistent.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20let%20asst_summary%20%3D%20crate%3A%3Autils%3A%3Atruncate_with_ellipsis%28%26assistant_text%2C%20SUMMARY_LIMIT%2C%20%22...%22%29%3B%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2167&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fruntime_threads.rs%3A1436-1440%0AThe%20outer%20%60if%20assistant_text.len%28%29%20%3E%20SUMMARY_LIMIT%60%20guard%20is%20now%20redundant.%20%60truncate_with_ellipsis%60%20already%20contains%20an%20identical%20early-return%20%28%60if%20s.len%28%29%20%3C%3D%20max_len%20%7B%20return%20s.to_string%28%29%3B%20%7D%60%29%2C%20so%20the%20branch%20never%20provides%20additional%20protection.%20The%20%60user_text%60%20path%20directly%20above%20%28line%201414%29%20calls%20the%20helper%20without%20a%20guard%2C%20making%20the%20two%20paths%20inconsistent.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20let%20asst_summary%20%3D%20crate%3A%3Autils%3A%3Atruncate_with_ellipsis%28%26assistant_text%2C%20SUMMARY_LIMIT%2C%20%22...%22%29%3B%0A%60%60%60%0A%0A&pr=2167&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(runtime): truncate assistant summary..."](https://github.com/hmbown/codewhale/commit/857f43f9eca9dc1967cba3f07d90e2eb5ebbc0ab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33873440)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->