### PR TITLE
fix(paste): defer large-paste @file consolidation to submit time

### DIFF
--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -3128,7 +3128,7 @@ impl App {
         // safety-net at submit time so any other code path that fills
         // self.input above the cap still consolidates rather than
         // silently truncating.
-        self.consolidate_large_input_if_oversized();
+        // self.consolidate_large_input_if_oversized(); // deferred to submit time
     }
 
     pub fn insert_media_attachment(&mut self, kind: &str, path: &Path, description: Option<&str>) {
@@ -4255,7 +4255,7 @@ impl App {
         self.input = format!("@{rel_path}");
         self.cursor_position = char_count(&self.input);
         self.push_status_toast(
-            "Large paste consolidated — sent as @mention",
+            "Large paste consolidated — auto-wrote to file and replaced with @mention. The text is still fully accessible to the model.",
             StatusToastLevel::Info,
             Some(5_000),
         );


### PR DESCRIPTION
## Problem

Pasting large text into the CodeWhale TUI composer (e.g. pasting a 20KB log file or code block) immediately converts it to an `@.deepseek/pastes/paste-xxx.md` mention. The user's text vanishes from the composer and is replaced by a cryptic `@file` reference they did not ask for. This is confusing — the user expected to see their pasted text and be able to review/edit it before sending.

## Root Cause

`insert_paste_text()` calls `consolidate_large_input_if_oversized()` at paste time, which checks if `char_count(input) > MAX_SUBMITTED_INPUT_CHARS` (16,000 chars). When exceeded, it immediately writes the text to a paste file and replaces the composer input with `@.deepseek/pastes/paste-xxx.md`.

The consolidation is useful at submit time (safety net), but at paste time it is surprising and confusing.

## Fix

1. **Remove the immediate consolidation from `insert_paste_text()`** — the text now stays in the composer as-is after pasting.
2. **Keep the consolidation as a safety net at submit time** — the same logic already runs when the user presses Enter, so the model still gets the `@file` reference if needed.
3. **Improve the toast message** — explain what happened when the submit-time consolidation fires.

The user now sees their full pasted text in the composer and can review/edit before sending. The consolidation only triggers when they press Enter if the text is still over the 16K char limit.

## Files

- `crates/tui/src/tui/app.rs`: commented out `self.consolidate_large_input_if_oversized()` in `insert_paste_text`, updated toast message

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR defers large-paste consolidation from paste time to submit time: `consolidate_large_input_if_oversized()` is commented out in `insert_paste_text()` so pasted text stays visible and editable in the composer, with the safety-net consolidation still firing in `submit_input()`. The toast message is also updated to better describe what happens at submit time.

- The consolidation call is commented out in `insert_paste_text`; large pastes now remain inline until Enter is pressed.
- The existing test `paste_consolidates_oversized_text_into_paste_file_visibly` asserts the old immediate-consolidation behavior and will fail with the new code.
- Three comment blocks (`insert_paste_text`, `submit_input`, `consolidate_large_input_if_oversized`) still describe the old paste-time path and need to be updated to reflect the deferred approach.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The behavioral change is correct but the existing test for large-paste consolidation still asserts the old immediate behavior and will break CI.

The core logic change is intentional and sound — deferring consolidation to submit time improves UX without removing the safety net. However, the test `paste_consolidates_oversized_text_into_paste_file_visibly` was not updated to match the new contract and will fail. Three comment blocks also still describe the removed paste-time path.

crates/tui/src/tui/app.rs — specifically the `paste_consolidates_oversized_text_into_paste_file_visibly` test and three stale comment blocks.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/app.rs | Removes immediate consolidation from `insert_paste_text`; test `paste_consolidates_oversized_text_into_paste_file_visibly` still asserts the old behavior and will fail. Three comment blocks also describe the removed behavior and need updating. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (4)</h3></summary>

1. `crates/tui/src/tui/app.rs`, line 5298-5333 ([link](https://github.com/hmbown/codewhale/blob/11cb323abc84c5f9a4d44d882dcd9592f80f18e5/crates/tui/src/tui/app.rs#L5298-L5333)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Test now asserts the removed behavior and will fail**

   `paste_consolidates_oversized_text_into_paste_file_visibly` calls `insert_paste_text` with an oversized buffer and then asserts that `app.input` is an `@.deepseek/pastes/…` mention. Because this PR removed the `consolidate_large_input_if_oversized()` call from `insert_paste_text`, the input will now hold the raw full text after paste — not the mention. The assertions on lines 5313–5317 and 5318–5319 will both fail. The test should be rewritten to assert the new contract: full text stays in the composer after `insert_paste_text`, and the `@mention` only appears after `submit_input`.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fpaste-large-text-auto-file%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fpaste-large-text-auto-file%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%0ALine%3A%205298-5333%0A%0AComment%3A%0A**Test%20now%20asserts%20the%20removed%20behavior%20and%20will%20fail**%0A%0A%60paste_consolidates_oversized_text_into_paste_file_visibly%60%20calls%20%60insert_paste_text%60%20with%20an%20oversized%20buffer%20and%20then%20asserts%20that%20%60app.input%60%20is%20an%20%60%40.deepseek%2Fpastes%2F%E2%80%A6%60%20mention.%20Because%20this%20PR%20removed%20the%20%60consolidate_large_input_if_oversized%28%29%60%20call%20from%20%60insert_paste_text%60%2C%20the%20input%20will%20now%20hold%20the%20raw%20full%20text%20after%20paste%20%E2%80%94%20not%20the%20mention.%20The%20assertions%20on%20lines%205313%E2%80%935317%20and%205318%E2%80%935319%20will%20both%20fail.%20The%20test%20should%20be%20rewritten%20to%20assert%20the%20new%20contract%3A%20full%20text%20stays%20in%20the%20composer%20after%20%60insert_paste_text%60%2C%20and%20the%20%60%40mention%60%20only%20appears%20after%20%60submit_input%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%0ALine%3A%205298-5333%0A%0AComment%3A%0A**Test%20now%20asserts%20the%20removed%20behavior%20and%20will%20fail**%0A%0A%60paste_consolidates_oversized_text_into_paste_file_visibly%60%20calls%20%60insert_paste_text%60%20with%20an%20oversized%20buffer%20and%20then%20asserts%20that%20%60app.input%60%20is%20an%20%60%40.deepseek%2Fpastes%2F%E2%80%A6%60%20mention.%20Because%20this%20PR%20removed%20the%20%60consolidate_large_input_if_oversized%28%29%60%20call%20from%20%60insert_paste_text%60%2C%20the%20input%20will%20now%20hold%20the%20raw%20full%20text%20after%20paste%20%E2%80%94%20not%20the%20mention.%20The%20assertions%20on%20lines%205313%E2%80%935317%20and%205318%E2%80%935319%20will%20both%20fail.%20The%20test%20should%20be%20rewritten%20to%20assert%20the%20new%20contract%3A%20full%20text%20stays%20in%20the%20composer%20after%20%60insert_paste_text%60%2C%20and%20the%20%60%40mention%60%20only%20appears%20after%20%60submit_input%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2168&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%0ALine%3A%205298-5333%0A%0AComment%3A%0A**Test%20now%20asserts%20the%20removed%20behavior%20and%20will%20fail**%0A%0A%60paste_consolidates_oversized_text_into_paste_file_visibly%60%20calls%20%60insert_paste_text%60%20with%20an%20oversized%20buffer%20and%20then%20asserts%20that%20%60app.input%60%20is%20an%20%60%40.deepseek%2Fpastes%2F%E2%80%A6%60%20mention.%20Because%20this%20PR%20removed%20the%20%60consolidate_large_input_if_oversized%28%29%60%20call%20from%20%60insert_paste_text%60%2C%20the%20input%20will%20now%20hold%20the%20raw%20full%20text%20after%20paste%20%E2%80%94%20not%20the%20mention.%20The%20assertions%20on%20lines%205313%E2%80%935317%20and%205318%E2%80%935319%20will%20both%20fail.%20The%20test%20should%20be%20rewritten%20to%20assert%20the%20new%20contract%3A%20full%20text%20stays%20in%20the%20composer%20after%20%60insert_paste_text%60%2C%20and%20the%20%60%40mention%60%20only%20appears%20after%20%60submit_input%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2168&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>


2. `crates/tui/src/tui/app.rs`, line 4097-4101 ([link](https://github.com/hmbown/codewhale/blob/11cb323abc84c5f9a4d44d882dcd9592f80f18e5/crates/tui/src/tui/app.rs#L4097-L4101)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The comment in `submit_input` still says "Bracketed pastes hit the consolidation in `insert_paste_text` first, so the user sees the `@mention` in the composer before submission." That is the exact behavior this PR removed — pastes no longer trigger early consolidation. The comment now actively misleads future readers.

   

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fpaste-large-text-auto-file%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fpaste-large-text-auto-file%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%0ALine%3A%204097-4101%0A%0AComment%3A%0AThe%20comment%20in%20%60submit_input%60%20still%20says%20%22Bracketed%20pastes%20hit%20the%20consolidation%20in%20%60insert_paste_text%60%20first%2C%20so%20the%20user%20sees%20the%20%60%40mention%60%20in%20the%20composer%20before%20submission.%22%20That%20is%20the%20exact%20behavior%20this%20PR%20removed%20%E2%80%94%20pastes%20no%20longer%20trigger%20early%20consolidation.%20The%20comment%20now%20actively%20misleads%20future%20readers.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Safety%20net%3A%20if%20any%20path%20filled%20the%20buffer%20above%20the%20safety%20cap%0A%20%20%20%20%20%20%20%20%2F%2F%20without%20going%20through%20submit%2C%20fold%20it%20into%20a%20workspace%20paste%0A%20%20%20%20%20%20%20%20%2F%2F%20file%20now%20%28%23553%29.%20Large%20pastes%20are%20left%20inline%20until%20the%20user%0A%20%20%20%20%20%20%20%20%2F%2F%20presses%20Enter%20%E2%80%94%20the%20consolidation%20here%20is%20the%20only%20enforcement%0A%20%20%20%20%20%20%20%20%2F%2F%20point.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%0ALine%3A%204097-4101%0A%0AComment%3A%0AThe%20comment%20in%20%60submit_input%60%20still%20says%20%22Bracketed%20pastes%20hit%20the%20consolidation%20in%20%60insert_paste_text%60%20first%2C%20so%20the%20user%20sees%20the%20%60%40mention%60%20in%20the%20composer%20before%20submission.%22%20That%20is%20the%20exact%20behavior%20this%20PR%20removed%20%E2%80%94%20pastes%20no%20longer%20trigger%20early%20consolidation.%20The%20comment%20now%20actively%20misleads%20future%20readers.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Safety%20net%3A%20if%20any%20path%20filled%20the%20buffer%20above%20the%20safety%20cap%0A%20%20%20%20%20%20%20%20%2F%2F%20without%20going%20through%20submit%2C%20fold%20it%20into%20a%20workspace%20paste%0A%20%20%20%20%20%20%20%20%2F%2F%20file%20now%20%28%23553%29.%20Large%20pastes%20are%20left%20inline%20until%20the%20user%0A%20%20%20%20%20%20%20%20%2F%2F%20presses%20Enter%20%E2%80%94%20the%20consolidation%20here%20is%20the%20only%20enforcement%0A%20%20%20%20%20%20%20%20%2F%2F%20point.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2168&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%0ALine%3A%204097-4101%0A%0AComment%3A%0AThe%20comment%20in%20%60submit_input%60%20still%20says%20%22Bracketed%20pastes%20hit%20the%20consolidation%20in%20%60insert_paste_text%60%20first%2C%20so%20the%20user%20sees%20the%20%60%40mention%60%20in%20the%20composer%20before%20submission.%22%20That%20is%20the%20exact%20behavior%20this%20PR%20removed%20%E2%80%94%20pastes%20no%20longer%20trigger%20early%20consolidation.%20The%20comment%20now%20actively%20misleads%20future%20readers.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Safety%20net%3A%20if%20any%20path%20filled%20the%20buffer%20above%20the%20safety%20cap%0A%20%20%20%20%20%20%20%20%2F%2F%20without%20going%20through%20submit%2C%20fold%20it%20into%20a%20workspace%20paste%0A%20%20%20%20%20%20%20%20%2F%2F%20file%20now%20%28%23553%29.%20Large%20pastes%20are%20left%20inline%20until%20the%20user%0A%20%20%20%20%20%20%20%20%2F%2F%20presses%20Enter%20%E2%80%94%20the%20consolidation%20here%20is%20the%20only%20enforcement%0A%20%20%20%20%20%20%20%20%2F%2F%20point.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2168&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>


3. `crates/tui/src/tui/app.rs`, line 4204-4208 ([link](https://github.com/hmbown/codewhale/blob/11cb323abc84c5f9a4d44d882dcd9592f80f18e5/crates/tui/src/tui/app.rs#L4204-L4208)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The doc comment for `consolidate_large_input_if_oversized` still says "Both the paste-insert path (visible-before-submit) and the submit-time safety net route through here". After this PR only the submit-time path calls it, so the first sentence is now incorrect.

   

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fpaste-large-text-auto-file%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fpaste-large-text-auto-file%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%0ALine%3A%204204-4208%0A%0AComment%3A%0AThe%20doc%20comment%20for%20%60consolidate_large_input_if_oversized%60%20still%20says%20%22Both%20the%20paste-insert%20path%20%28visible-before-submit%29%20and%20the%20submit-time%20safety%20net%20route%20through%20here%22.%20After%20this%20PR%20only%20the%20submit-time%20path%20calls%20it%2C%20so%20the%20first%20sentence%20is%20now%20incorrect.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Public%20wrapper%20around%20%5B%60Self%3A%3Aconsolidate_large_input%60%5D%20that%20no-ops%0A%20%20%20%20%2F%2F%2F%20when%20the%20current%20input%20fits%20inside%20the%20safety%20cap.%20Called%20at%20submit%0A%20%20%20%20%2F%2F%2F%20time%20as%20the%20single%20enforcement%20point%20for%20the%20character%20cap.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%0ALine%3A%204204-4208%0A%0AComment%3A%0AThe%20doc%20comment%20for%20%60consolidate_large_input_if_oversized%60%20still%20says%20%22Both%20the%20paste-insert%20path%20%28visible-before-submit%29%20and%20the%20submit-time%20safety%20net%20route%20through%20here%22.%20After%20this%20PR%20only%20the%20submit-time%20path%20calls%20it%2C%20so%20the%20first%20sentence%20is%20now%20incorrect.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Public%20wrapper%20around%20%5B%60Self%3A%3Aconsolidate_large_input%60%5D%20that%20no-ops%0A%20%20%20%20%2F%2F%2F%20when%20the%20current%20input%20fits%20inside%20the%20safety%20cap.%20Called%20at%20submit%0A%20%20%20%20%2F%2F%2F%20time%20as%20the%20single%20enforcement%20point%20for%20the%20character%20cap.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2168&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%0ALine%3A%204204-4208%0A%0AComment%3A%0AThe%20doc%20comment%20for%20%60consolidate_large_input_if_oversized%60%20still%20says%20%22Both%20the%20paste-insert%20path%20%28visible-before-submit%29%20and%20the%20submit-time%20safety%20net%20route%20through%20here%22.%20After%20this%20PR%20only%20the%20submit-time%20path%20calls%20it%2C%20so%20the%20first%20sentence%20is%20now%20incorrect.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Public%20wrapper%20around%20%5B%60Self%3A%3Aconsolidate_large_input%60%5D%20that%20no-ops%0A%20%20%20%20%2F%2F%2F%20when%20the%20current%20input%20fits%20inside%20the%20safety%20cap.%20Called%20at%20submit%0A%20%20%20%20%2F%2F%2F%20time%20as%20the%20single%20enforcement%20point%20for%20the%20character%20cap.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2168&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>


4. `crates/tui/src/tui/app.rs`, line 3124-3131 ([link](https://github.com/hmbown/codewhale/blob/11cb323abc84c5f9a4d44d882dcd9592f80f18e5/crates/tui/src/tui/app.rs#L3124-L3131)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The block comment immediately above the commented-out call still describes the old "visible-before-submit" rationale, so it reads as justification for behaviour that no longer exists. Replacing it with a short note explaining why consolidation is intentionally deferred will prevent confusion.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fpaste-large-text-auto-file%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fpaste-large-text-auto-file%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%0ALine%3A%203124-3131%0A%0AComment%3A%0AThe%20block%20comment%20immediately%20above%20the%20commented-out%20call%20still%20describes%20the%20old%20%22visible-before-submit%22%20rationale%2C%20so%20it%20reads%20as%20justification%20for%20behaviour%20that%20no%20longer%20exists.%20Replacing%20it%20with%20a%20short%20note%20explaining%20why%20consolidation%20is%20intentionally%20deferred%20will%20prevent%20confusion.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Consolidation%20is%20intentionally%20deferred%20to%20submit%20time%20so%20the%0A%20%20%20%20%20%20%20%20%2F%2F%20user%20can%20see%20and%20edit%20their%20full%20pasted%20text%20before%20it%20is%0A%20%20%20%20%20%20%20%20%2F%2F%20written%20to%20a%20paste%20file.%20%60submit_input%60%20calls%0A%20%20%20%20%20%20%20%20%2F%2F%20%60consolidate_large_input_if_oversized%60%20as%20the%20single%20enforcement%0A%20%20%20%20%20%20%20%20%2F%2F%20point.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%0ALine%3A%203124-3131%0A%0AComment%3A%0AThe%20block%20comment%20immediately%20above%20the%20commented-out%20call%20still%20describes%20the%20old%20%22visible-before-submit%22%20rationale%2C%20so%20it%20reads%20as%20justification%20for%20behaviour%20that%20no%20longer%20exists.%20Replacing%20it%20with%20a%20short%20note%20explaining%20why%20consolidation%20is%20intentionally%20deferred%20will%20prevent%20confusion.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Consolidation%20is%20intentionally%20deferred%20to%20submit%20time%20so%20the%0A%20%20%20%20%20%20%20%20%2F%2F%20user%20can%20see%20and%20edit%20their%20full%20pasted%20text%20before%20it%20is%0A%20%20%20%20%20%20%20%20%2F%2F%20written%20to%20a%20paste%20file.%20%60submit_input%60%20calls%0A%20%20%20%20%20%20%20%20%2F%2F%20%60consolidate_large_input_if_oversized%60%20as%20the%20single%20enforcement%0A%20%20%20%20%20%20%20%20%2F%2F%20point.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2168&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%0ALine%3A%203124-3131%0A%0AComment%3A%0AThe%20block%20comment%20immediately%20above%20the%20commented-out%20call%20still%20describes%20the%20old%20%22visible-before-submit%22%20rationale%2C%20so%20it%20reads%20as%20justification%20for%20behaviour%20that%20no%20longer%20exists.%20Replacing%20it%20with%20a%20short%20note%20explaining%20why%20consolidation%20is%20intentionally%20deferred%20will%20prevent%20confusion.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Consolidation%20is%20intentionally%20deferred%20to%20submit%20time%20so%20the%0A%20%20%20%20%20%20%20%20%2F%2F%20user%20can%20see%20and%20edit%20their%20full%20pasted%20text%20before%20it%20is%0A%20%20%20%20%20%20%20%20%2F%2F%20written%20to%20a%20paste%20file.%20%60submit_input%60%20calls%0A%20%20%20%20%20%20%20%20%2F%2F%20%60consolidate_large_input_if_oversized%60%20as%20the%20single%20enforcement%0A%20%20%20%20%20%20%20%20%2F%2F%20point.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2168&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fpaste-large-text-auto-file%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fpaste-large-text-auto-file%22.%0A%0AFix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Acrates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%3A5298-5333%0A**Test%20now%20asserts%20the%20removed%20behavior%20and%20will%20fail**%0A%0A%60paste_consolidates_oversized_text_into_paste_file_visibly%60%20calls%20%60insert_paste_text%60%20with%20an%20oversized%20buffer%20and%20then%20asserts%20that%20%60app.input%60%20is%20an%20%60%40.deepseek%2Fpastes%2F%E2%80%A6%60%20mention.%20Because%20this%20PR%20removed%20the%20%60consolidate_large_input_if_oversized%28%29%60%20call%20from%20%60insert_paste_text%60%2C%20the%20input%20will%20now%20hold%20the%20raw%20full%20text%20after%20paste%20%E2%80%94%20not%20the%20mention.%20The%20assertions%20on%20lines%205313%E2%80%935317%20and%205318%E2%80%935319%20will%20both%20fail.%20The%20test%20should%20be%20rewritten%20to%20assert%20the%20new%20contract%3A%20full%20text%20stays%20in%20the%20composer%20after%20%60insert_paste_text%60%2C%20and%20the%20%60%40mention%60%20only%20appears%20after%20%60submit_input%60.%0A%0A%23%23%23%20Issue%202%20of%204%0Acrates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%3A4097-4101%0AThe%20comment%20in%20%60submit_input%60%20still%20says%20%22Bracketed%20pastes%20hit%20the%20consolidation%20in%20%60insert_paste_text%60%20first%2C%20so%20the%20user%20sees%20the%20%60%40mention%60%20in%20the%20composer%20before%20submission.%22%20That%20is%20the%20exact%20behavior%20this%20PR%20removed%20%E2%80%94%20pastes%20no%20longer%20trigger%20early%20consolidation.%20The%20comment%20now%20actively%20misleads%20future%20readers.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Safety%20net%3A%20if%20any%20path%20filled%20the%20buffer%20above%20the%20safety%20cap%0A%20%20%20%20%20%20%20%20%2F%2F%20without%20going%20through%20submit%2C%20fold%20it%20into%20a%20workspace%20paste%0A%20%20%20%20%20%20%20%20%2F%2F%20file%20now%20%28%23553%29.%20Large%20pastes%20are%20left%20inline%20until%20the%20user%0A%20%20%20%20%20%20%20%20%2F%2F%20presses%20Enter%20%E2%80%94%20the%20consolidation%20here%20is%20the%20only%20enforcement%0A%20%20%20%20%20%20%20%20%2F%2F%20point.%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Acrates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%3A4204-4208%0AThe%20doc%20comment%20for%20%60consolidate_large_input_if_oversized%60%20still%20says%20%22Both%20the%20paste-insert%20path%20%28visible-before-submit%29%20and%20the%20submit-time%20safety%20net%20route%20through%20here%22.%20After%20this%20PR%20only%20the%20submit-time%20path%20calls%20it%2C%20so%20the%20first%20sentence%20is%20now%20incorrect.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Public%20wrapper%20around%20%5B%60Self%3A%3Aconsolidate_large_input%60%5D%20that%20no-ops%0A%20%20%20%20%2F%2F%2F%20when%20the%20current%20input%20fits%20inside%20the%20safety%20cap.%20Called%20at%20submit%0A%20%20%20%20%2F%2F%2F%20time%20as%20the%20single%20enforcement%20point%20for%20the%20character%20cap.%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%204%0Acrates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%3A3124-3131%0AThe%20block%20comment%20immediately%20above%20the%20commented-out%20call%20still%20describes%20the%20old%20%22visible-before-submit%22%20rationale%2C%20so%20it%20reads%20as%20justification%20for%20behaviour%20that%20no%20longer%20exists.%20Replacing%20it%20with%20a%20short%20note%20explaining%20why%20consolidation%20is%20intentionally%20deferred%20will%20prevent%20confusion.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Consolidation%20is%20intentionally%20deferred%20to%20submit%20time%20so%20the%0A%20%20%20%20%20%20%20%20%2F%2F%20user%20can%20see%20and%20edit%20their%20full%20pasted%20text%20before%20it%20is%0A%20%20%20%20%20%20%20%20%2F%2F%20written%20to%20a%20paste%20file.%20%60submit_input%60%20calls%0A%20%20%20%20%20%20%20%20%2F%2F%20%60consolidate_large_input_if_oversized%60%20as%20the%20single%20enforcement%0A%20%20%20%20%20%20%20%20%2F%2F%20point.%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Acrates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%3A5298-5333%0A**Test%20now%20asserts%20the%20removed%20behavior%20and%20will%20fail**%0A%0A%60paste_consolidates_oversized_text_into_paste_file_visibly%60%20calls%20%60insert_paste_text%60%20with%20an%20oversized%20buffer%20and%20then%20asserts%20that%20%60app.input%60%20is%20an%20%60%40.deepseek%2Fpastes%2F%E2%80%A6%60%20mention.%20Because%20this%20PR%20removed%20the%20%60consolidate_large_input_if_oversized%28%29%60%20call%20from%20%60insert_paste_text%60%2C%20the%20input%20will%20now%20hold%20the%20raw%20full%20text%20after%20paste%20%E2%80%94%20not%20the%20mention.%20The%20assertions%20on%20lines%205313%E2%80%935317%20and%205318%E2%80%935319%20will%20both%20fail.%20The%20test%20should%20be%20rewritten%20to%20assert%20the%20new%20contract%3A%20full%20text%20stays%20in%20the%20composer%20after%20%60insert_paste_text%60%2C%20and%20the%20%60%40mention%60%20only%20appears%20after%20%60submit_input%60.%0A%0A%23%23%23%20Issue%202%20of%204%0Acrates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%3A4097-4101%0AThe%20comment%20in%20%60submit_input%60%20still%20says%20%22Bracketed%20pastes%20hit%20the%20consolidation%20in%20%60insert_paste_text%60%20first%2C%20so%20the%20user%20sees%20the%20%60%40mention%60%20in%20the%20composer%20before%20submission.%22%20That%20is%20the%20exact%20behavior%20this%20PR%20removed%20%E2%80%94%20pastes%20no%20longer%20trigger%20early%20consolidation.%20The%20comment%20now%20actively%20misleads%20future%20readers.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Safety%20net%3A%20if%20any%20path%20filled%20the%20buffer%20above%20the%20safety%20cap%0A%20%20%20%20%20%20%20%20%2F%2F%20without%20going%20through%20submit%2C%20fold%20it%20into%20a%20workspace%20paste%0A%20%20%20%20%20%20%20%20%2F%2F%20file%20now%20%28%23553%29.%20Large%20pastes%20are%20left%20inline%20until%20the%20user%0A%20%20%20%20%20%20%20%20%2F%2F%20presses%20Enter%20%E2%80%94%20the%20consolidation%20here%20is%20the%20only%20enforcement%0A%20%20%20%20%20%20%20%20%2F%2F%20point.%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Acrates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%3A4204-4208%0AThe%20doc%20comment%20for%20%60consolidate_large_input_if_oversized%60%20still%20says%20%22Both%20the%20paste-insert%20path%20%28visible-before-submit%29%20and%20the%20submit-time%20safety%20net%20route%20through%20here%22.%20After%20this%20PR%20only%20the%20submit-time%20path%20calls%20it%2C%20so%20the%20first%20sentence%20is%20now%20incorrect.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Public%20wrapper%20around%20%5B%60Self%3A%3Aconsolidate_large_input%60%5D%20that%20no-ops%0A%20%20%20%20%2F%2F%2F%20when%20the%20current%20input%20fits%20inside%20the%20safety%20cap.%20Called%20at%20submit%0A%20%20%20%20%2F%2F%2F%20time%20as%20the%20single%20enforcement%20point%20for%20the%20character%20cap.%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%204%0Acrates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%3A3124-3131%0AThe%20block%20comment%20immediately%20above%20the%20commented-out%20call%20still%20describes%20the%20old%20%22visible-before-submit%22%20rationale%2C%20so%20it%20reads%20as%20justification%20for%20behaviour%20that%20no%20longer%20exists.%20Replacing%20it%20with%20a%20short%20note%20explaining%20why%20consolidation%20is%20intentionally%20deferred%20will%20prevent%20confusion.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Consolidation%20is%20intentionally%20deferred%20to%20submit%20time%20so%20the%0A%20%20%20%20%20%20%20%20%2F%2F%20user%20can%20see%20and%20edit%20their%20full%20pasted%20text%20before%20it%20is%0A%20%20%20%20%20%20%20%20%2F%2F%20written%20to%20a%20paste%20file.%20%60submit_input%60%20calls%0A%20%20%20%20%20%20%20%20%2F%2F%20%60consolidate_large_input_if_oversized%60%20as%20the%20single%20enforcement%0A%20%20%20%20%20%20%20%20%2F%2F%20point.%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2168&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Acrates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%3A5298-5333%0A**Test%20now%20asserts%20the%20removed%20behavior%20and%20will%20fail**%0A%0A%60paste_consolidates_oversized_text_into_paste_file_visibly%60%20calls%20%60insert_paste_text%60%20with%20an%20oversized%20buffer%20and%20then%20asserts%20that%20%60app.input%60%20is%20an%20%60%40.deepseek%2Fpastes%2F%E2%80%A6%60%20mention.%20Because%20this%20PR%20removed%20the%20%60consolidate_large_input_if_oversized%28%29%60%20call%20from%20%60insert_paste_text%60%2C%20the%20input%20will%20now%20hold%20the%20raw%20full%20text%20after%20paste%20%E2%80%94%20not%20the%20mention.%20The%20assertions%20on%20lines%205313%E2%80%935317%20and%205318%E2%80%935319%20will%20both%20fail.%20The%20test%20should%20be%20rewritten%20to%20assert%20the%20new%20contract%3A%20full%20text%20stays%20in%20the%20composer%20after%20%60insert_paste_text%60%2C%20and%20the%20%60%40mention%60%20only%20appears%20after%20%60submit_input%60.%0A%0A%23%23%23%20Issue%202%20of%204%0Acrates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%3A4097-4101%0AThe%20comment%20in%20%60submit_input%60%20still%20says%20%22Bracketed%20pastes%20hit%20the%20consolidation%20in%20%60insert_paste_text%60%20first%2C%20so%20the%20user%20sees%20the%20%60%40mention%60%20in%20the%20composer%20before%20submission.%22%20That%20is%20the%20exact%20behavior%20this%20PR%20removed%20%E2%80%94%20pastes%20no%20longer%20trigger%20early%20consolidation.%20The%20comment%20now%20actively%20misleads%20future%20readers.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Safety%20net%3A%20if%20any%20path%20filled%20the%20buffer%20above%20the%20safety%20cap%0A%20%20%20%20%20%20%20%20%2F%2F%20without%20going%20through%20submit%2C%20fold%20it%20into%20a%20workspace%20paste%0A%20%20%20%20%20%20%20%20%2F%2F%20file%20now%20%28%23553%29.%20Large%20pastes%20are%20left%20inline%20until%20the%20user%0A%20%20%20%20%20%20%20%20%2F%2F%20presses%20Enter%20%E2%80%94%20the%20consolidation%20here%20is%20the%20only%20enforcement%0A%20%20%20%20%20%20%20%20%2F%2F%20point.%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Acrates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%3A4204-4208%0AThe%20doc%20comment%20for%20%60consolidate_large_input_if_oversized%60%20still%20says%20%22Both%20the%20paste-insert%20path%20%28visible-before-submit%29%20and%20the%20submit-time%20safety%20net%20route%20through%20here%22.%20After%20this%20PR%20only%20the%20submit-time%20path%20calls%20it%2C%20so%20the%20first%20sentence%20is%20now%20incorrect.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Public%20wrapper%20around%20%5B%60Self%3A%3Aconsolidate_large_input%60%5D%20that%20no-ops%0A%20%20%20%20%2F%2F%2F%20when%20the%20current%20input%20fits%20inside%20the%20safety%20cap.%20Called%20at%20submit%0A%20%20%20%20%2F%2F%2F%20time%20as%20the%20single%20enforcement%20point%20for%20the%20character%20cap.%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%204%0Acrates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%3A3124-3131%0AThe%20block%20comment%20immediately%20above%20the%20commented-out%20call%20still%20describes%20the%20old%20%22visible-before-submit%22%20rationale%2C%20so%20it%20reads%20as%20justification%20for%20behaviour%20that%20no%20longer%20exists.%20Replacing%20it%20with%20a%20short%20note%20explaining%20why%20consolidation%20is%20intentionally%20deferred%20will%20prevent%20confusion.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Consolidation%20is%20intentionally%20deferred%20to%20submit%20time%20so%20the%0A%20%20%20%20%20%20%20%20%2F%2F%20user%20can%20see%20and%20edit%20their%20full%20pasted%20text%20before%20it%20is%0A%20%20%20%20%20%20%20%20%2F%2F%20written%20to%20a%20paste%20file.%20%60submit_input%60%20calls%0A%20%20%20%20%20%20%20%20%2F%2F%20%60consolidate_large_input_if_oversized%60%20as%20the%20single%20enforcement%0A%20%20%20%20%20%20%20%20%2F%2F%20point.%0A%60%60%60%0A%0A&pr=2168&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(paste): defer large-paste @file cons..."](https://github.com/hmbown/codewhale/commit/11cb323abc84c5f9a4d44d882dcd9592f80f18e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33878055)</sub>

<!-- /greptile_comment -->