### PR TITLE
fix: Fix vLLM provider sending hard-coded `reasoning_effort` values that fail server-side validation

### DIFF
--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -937,7 +937,14 @@ pub(super) fn apply_reasoning_effort(
                 body["chat_template_kwargs"] = json!({
                     "enable_thinking": true,
                 });
-                body["reasoning_effort"] = json!("high");
+                // vLLM supports low/medium/high natively — pass through the
+                // user-chosen value instead of hard-coding "high".
+                let value = match normalized.as_str() {
+                    "low" | "minimal" => "low",
+                    "medium" | "mid" => "medium",
+                    _ => "high",
+                };
+                body["reasoning_effort"] = json!(value);
             }
             ApiProvider::Openai
             | ApiProvider::Atlascloud
@@ -967,7 +974,9 @@ pub(super) fn apply_reasoning_effort(
                 body["chat_template_kwargs"] = json!({
                     "enable_thinking": true,
                 });
-                body["reasoning_effort"] = json!("max");
+                // vLLM only supports none/low/medium/high — downgrade
+                // "max" to "high" instead of sending an invalid value.
+                body["reasoning_effort"] = json!("high");
             }
             ApiProvider::Openai
             | ApiProvider::Atlascloud


### PR DESCRIPTION
# Commit Message — vLLM reasoning_effort fix (#2169)

## Summary

Fix vLLM provider sending hard-coded `reasoning_effort` values that
fail server-side validation.

Closes: https://github.com/Hmbown/CodeWhale/issues/2169

## Problem

CodeWhale's `apply_reasoning_effort` function hard-coded invalid values
for the vLLM provider:

- `"max"` branch sent `reasoning_effort: "max"` — vLLM only supports
  `none`, `low`, `medium`, `high`
- `"low"/"medium"/"high"` branch always sent `"high"`, ignoring the
  user's actual configured value

Result: 400 Bad Request on every chat completion attempt.

## Fix

Two-line change in `crates/tui/src/client.rs`:

| Branch | Before | After |
|---|---|---|
| `medium` / `high` | hard-coded `"high"` | pass through actual `low` / `medium` / `high` |
| `max` | hard-coded `"max"` | downgrade to `"high"` (vLLM-compatible) |

## Files Changed

| File | Change |
|---|---|
| `crates/tui/src/client.rs` | +11 / -2 lines |

## How to Test

```bash
cargo test -p codewhale-tui -- client
```

Config:
```toml
[providers.vllm]
reasoning_effort = "medium"
```

Send any chat message — should no longer receive 400.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes two bugs in `apply_reasoning_effort` for `ApiProvider::Vllm`: the `low`/`medium`/`high` branch was always sending `"high"` regardless of the user's config, and the `max` branch was sending `"max"` which vLLM rejects with a 400.

- **`low`/`medium`/`high` branch**: a new inner `match` now maps `"low"/"minimal" → "low"`, `"medium"/"mid" → "medium"`, and all others → `"high"`, mirroring the existing Openrouter/Novita logic.
- **`max`/`xhigh` branch**: now sends `"high"` (vLLM's maximum) instead of the invalid `"max"` string, with a clarifying comment.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The fix is targeted and correct; both vLLM branches now send valid values. The only gap is missing test coverage for the new code paths.

The two-line bug — always sending 'high' for configurable efforts and the invalid 'max' for the top tier — is correctly patched. The inner match mirrors proven logic already used for Openrouter/Novita. No vLLM-specific unit tests accompany the change, so if someone later edits the inner match arms, there's nothing to catch a regression.

crates/tui/src/client.rs — the two new vLLM branches in apply_reasoning_effort have no dedicated tests.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/tui/src/client.rs | Fixes hard-coded reasoning_effort values for vLLM: low/medium/high are now passed through correctly, and 'max' is downgraded to 'high'. Logic is correct; no vLLM-specific tests were added to cover the new branches. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[apply_reasoning_effort called\nwith vLLM provider] --> B{normalized effort}
    B -- off/disabled/none --> C[chat_template_kwargs:\nenable_thinking: false]
    B -- low/minimal/medium/mid/high/empty --> D[chat_template_kwargs:\nenable_thinking: true]
    D --> E{inner match}
    E -- low or minimal --> F[reasoning_effort: 'low']
    E -- medium or mid --> G[reasoning_effort: 'medium']
    E -- high or empty or other --> H[reasoning_effort: 'high']
    B -- xhigh/max/highest --> I[chat_template_kwargs:\nenable_thinking: true]
    I --> J[reasoning_effort: 'high'\n downgraded from max]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/tui/src/client.rs`, line 936-947 ([link](https://github.com/hmbown/codewhale/blob/2a5db58569f629dbc987ae1b9193b8823db113c6/crates/tui/src/client.rs#L936-L947)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **No tests added for vLLM reasoning effort mapping**

   Every other provider in `apply_reasoning_effort` has at least one test (Deepseek, NvidiaNim, Fireworks, Openrouter each have dedicated `#[test]` cases), but the two vLLM branches changed in this PR have no coverage at all. Without tests, a future refactor of the inner `match` arms or a mistaken copy-paste could silently reintroduce the hard-coded `"high"` regression. A test along the lines of the existing `reasoning_effort_maps_openrouter_scale_without_deepseek_max_label` test that covers `low → "low"`, `medium → "medium"`, `high → "high"`, and `max → "high"` for `ApiProvider::Vllm` would lock in the fix.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fvllm-reasoning-effort%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fvllm-reasoning-effort%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fclient.rs%0ALine%3A%20936-947%0A%0AComment%3A%0A**No%20tests%20added%20for%20vLLM%20reasoning%20effort%20mapping**%0A%0AEvery%20other%20provider%20in%20%60apply_reasoning_effort%60%20has%20at%20least%20one%20test%20%28Deepseek%2C%20NvidiaNim%2C%20Fireworks%2C%20Openrouter%20each%20have%20dedicated%20%60%23%5Btest%5D%60%20cases%29%2C%20but%20the%20two%20vLLM%20branches%20changed%20in%20this%20PR%20have%20no%20coverage%20at%20all.%20Without%20tests%2C%20a%20future%20refactor%20of%20the%20inner%20%60match%60%20arms%20or%20a%20mistaken%20copy-paste%20could%20silently%20reintroduce%20the%20hard-coded%20%60%22high%22%60%20regression.%20A%20test%20along%20the%20lines%20of%20the%20existing%20%60reasoning_effort_maps_openrouter_scale_without_deepseek_max_label%60%20test%20that%20covers%20%60low%20%E2%86%92%20%22low%22%60%2C%20%60medium%20%E2%86%92%20%22medium%22%60%2C%20%60high%20%E2%86%92%20%22high%22%60%2C%20and%20%60max%20%E2%86%92%20%22high%22%60%20for%20%60ApiProvider%3A%3AVllm%60%20would%20lock%20in%20the%20fix.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fclient.rs%0ALine%3A%20936-947%0A%0AComment%3A%0A**No%20tests%20added%20for%20vLLM%20reasoning%20effort%20mapping**%0A%0AEvery%20other%20provider%20in%20%60apply_reasoning_effort%60%20has%20at%20least%20one%20test%20%28Deepseek%2C%20NvidiaNim%2C%20Fireworks%2C%20Openrouter%20each%20have%20dedicated%20%60%23%5Btest%5D%60%20cases%29%2C%20but%20the%20two%20vLLM%20branches%20changed%20in%20this%20PR%20have%20no%20coverage%20at%20all.%20Without%20tests%2C%20a%20future%20refactor%20of%20the%20inner%20%60match%60%20arms%20or%20a%20mistaken%20copy-paste%20could%20silently%20reintroduce%20the%20hard-coded%20%60%22high%22%60%20regression.%20A%20test%20along%20the%20lines%20of%20the%20existing%20%60reasoning_effort_maps_openrouter_scale_without_deepseek_max_label%60%20test%20that%20covers%20%60low%20%E2%86%92%20%22low%22%60%2C%20%60medium%20%E2%86%92%20%22medium%22%60%2C%20%60high%20%E2%86%92%20%22high%22%60%2C%20and%20%60max%20%E2%86%92%20%22high%22%60%20for%20%60ApiProvider%3A%3AVllm%60%20would%20lock%20in%20the%20fix.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2170&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fclient.rs%0ALine%3A%20936-947%0A%0AComment%3A%0A**No%20tests%20added%20for%20vLLM%20reasoning%20effort%20mapping**%0A%0AEvery%20other%20provider%20in%20%60apply_reasoning_effort%60%20has%20at%20least%20one%20test%20%28Deepseek%2C%20NvidiaNim%2C%20Fireworks%2C%20Openrouter%20each%20have%20dedicated%20%60%23%5Btest%5D%60%20cases%29%2C%20but%20the%20two%20vLLM%20branches%20changed%20in%20this%20PR%20have%20no%20coverage%20at%20all.%20Without%20tests%2C%20a%20future%20refactor%20of%20the%20inner%20%60match%60%20arms%20or%20a%20mistaken%20copy-paste%20could%20silently%20reintroduce%20the%20hard-coded%20%60%22high%22%60%20regression.%20A%20test%20along%20the%20lines%20of%20the%20existing%20%60reasoning_effort_maps_openrouter_scale_without_deepseek_max_label%60%20test%20that%20covers%20%60low%20%E2%86%92%20%22low%22%60%2C%20%60medium%20%E2%86%92%20%22medium%22%60%2C%20%60high%20%E2%86%92%20%22high%22%60%2C%20and%20%60max%20%E2%86%92%20%22high%22%60%20for%20%60ApiProvider%3A%3AVllm%60%20would%20lock%20in%20the%20fix.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2170&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fvllm-reasoning-effort%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fvllm-reasoning-effort%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fclient.rs%3A936-947%0A**No%20tests%20added%20for%20vLLM%20reasoning%20effort%20mapping**%0A%0AEvery%20other%20provider%20in%20%60apply_reasoning_effort%60%20has%20at%20least%20one%20test%20%28Deepseek%2C%20NvidiaNim%2C%20Fireworks%2C%20Openrouter%20each%20have%20dedicated%20%60%23%5Btest%5D%60%20cases%29%2C%20but%20the%20two%20vLLM%20branches%20changed%20in%20this%20PR%20have%20no%20coverage%20at%20all.%20Without%20tests%2C%20a%20future%20refactor%20of%20the%20inner%20%60match%60%20arms%20or%20a%20mistaken%20copy-paste%20could%20silently%20reintroduce%20the%20hard-coded%20%60%22high%22%60%20regression.%20A%20test%20along%20the%20lines%20of%20the%20existing%20%60reasoning_effort_maps_openrouter_scale_without_deepseek_max_label%60%20test%20that%20covers%20%60low%20%E2%86%92%20%22low%22%60%2C%20%60medium%20%E2%86%92%20%22medium%22%60%2C%20%60high%20%E2%86%92%20%22high%22%60%2C%20and%20%60max%20%E2%86%92%20%22high%22%60%20for%20%60ApiProvider%3A%3AVllm%60%20would%20lock%20in%20the%20fix.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fclient.rs%3A936-947%0A**No%20tests%20added%20for%20vLLM%20reasoning%20effort%20mapping**%0A%0AEvery%20other%20provider%20in%20%60apply_reasoning_effort%60%20has%20at%20least%20one%20test%20%28Deepseek%2C%20NvidiaNim%2C%20Fireworks%2C%20Openrouter%20each%20have%20dedicated%20%60%23%5Btest%5D%60%20cases%29%2C%20but%20the%20two%20vLLM%20branches%20changed%20in%20this%20PR%20have%20no%20coverage%20at%20all.%20Without%20tests%2C%20a%20future%20refactor%20of%20the%20inner%20%60match%60%20arms%20or%20a%20mistaken%20copy-paste%20could%20silently%20reintroduce%20the%20hard-coded%20%60%22high%22%60%20regression.%20A%20test%20along%20the%20lines%20of%20the%20existing%20%60reasoning_effort_maps_openrouter_scale_without_deepseek_max_label%60%20test%20that%20covers%20%60low%20%E2%86%92%20%22low%22%60%2C%20%60medium%20%E2%86%92%20%22medium%22%60%2C%20%60high%20%E2%86%92%20%22high%22%60%2C%20and%20%60max%20%E2%86%92%20%22high%22%60%20for%20%60ApiProvider%3A%3AVllm%60%20would%20lock%20in%20the%20fix.%0A%0A&repo=hmbown%2Fcodewhale&pr=2170&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fclient.rs%3A936-947%0A**No%20tests%20added%20for%20vLLM%20reasoning%20effort%20mapping**%0A%0AEvery%20other%20provider%20in%20%60apply_reasoning_effort%60%20has%20at%20least%20one%20test%20%28Deepseek%2C%20NvidiaNim%2C%20Fireworks%2C%20Openrouter%20each%20have%20dedicated%20%60%23%5Btest%5D%60%20cases%29%2C%20but%20the%20two%20vLLM%20branches%20changed%20in%20this%20PR%20have%20no%20coverage%20at%20all.%20Without%20tests%2C%20a%20future%20refactor%20of%20the%20inner%20%60match%60%20arms%20or%20a%20mistaken%20copy-paste%20could%20silently%20reintroduce%20the%20hard-coded%20%60%22high%22%60%20regression.%20A%20test%20along%20the%20lines%20of%20the%20existing%20%60reasoning_effort_maps_openrouter_scale_without_deepseek_max_label%60%20test%20that%20covers%20%60low%20%E2%86%92%20%22low%22%60%2C%20%60medium%20%E2%86%92%20%22medium%22%60%2C%20%60high%20%E2%86%92%20%22high%22%60%2C%20and%20%60max%20%E2%86%92%20%22high%22%60%20for%20%60ApiProvider%3A%3AVllm%60%20would%20lock%20in%20the%20fix.%0A%0A&pr=2170&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix: vLLM provider — pass through reason..."](https://github.com/hmbown/codewhale/commit/2a5db58569f629dbc987ae1b9193b8823db113c6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33895594)</sub>

<!-- /greptile_comment -->