### PR TITLE
test(settings): handle TERM_PROGRAM env var in no_animations_env_reco…

### DIFF
--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -1317,19 +1317,27 @@ mod tests {
         let prev_tmux = std::env::var_os("TMUX");
         let prev_sty = std::env::var_os("STY");
         let prev_term_program = std::env::var_os("TERM_PROGRAM");
+        let prev_ssh_client = std::env::var_os("SSH_CLIENT");
+        let prev_ssh_tty = std::env::var_os("SSH_TTY");
+        let prev_tilix_id = std::env::var_os("TILIX_ID");
+        let prev_terminator_uuid = std::env::var_os("TERMINATOR_UUID");
 
         // The test is about NO_ANIMATIONS only. On Windows CI, an unmarked
         // console host now independently enables low_motion, so mark the host
         // as non-legacy while checking falsy spellings.
         // Clear multiplexer markers for the same reason: they also force
         // low_motion independently of NO_ANIMATIONS.
-        // Clear TERM_PROGRAM as they also force low_motion in vscode, ghostty
-        // and Termius.
+        // Clear TERM_PROGRAM, SSH, and other terminal-specific variables as they
+        // also force low_motion independently of NO_ANIMATIONS.
         // SAFETY: serialised by the guard.
         unsafe {
             std::env::remove_var("TMUX");
             std::env::remove_var("STY");
             std::env::remove_var("TERM_PROGRAM");
+            std::env::remove_var("SSH_CLIENT");
+            std::env::remove_var("SSH_TTY");
+            std::env::remove_var("TILIX_ID");
+            std::env::remove_var("TERMINATOR_UUID");
         }
         #[cfg(windows)]
         unsafe {
@@ -1371,6 +1379,22 @@ mod tests {
             match prev_term_program {
                 Some(v) => std::env::set_var("TERM_PROGRAM", v),
                 None => std::env::remove_var("TERM_PROGRAM"),
+            }
+            match prev_ssh_client {
+                Some(v) => std::env::set_var("SSH_CLIENT", v),
+                None => std::env::remove_var("SSH_CLIENT"),
+            }
+            match prev_ssh_tty {
+                Some(v) => std::env::set_var("SSH_TTY", v),
+                None => std::env::remove_var("SSH_TTY"),
+            }
+            match prev_tilix_id {
+                Some(v) => std::env::set_var("TILIX_ID", v),
+                None => std::env::remove_var("TILIX_ID"),
+            }
+            match prev_terminator_uuid {
+                Some(v) => std::env::set_var("TERMINATOR_UUID", v),
+                None => std::env::remove_var("TERMINATOR_UUID"),
             }
         }
     }

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -1316,15 +1316,20 @@ mod tests {
         let prev_wt_session = std::env::var_os("WT_SESSION");
         let prev_tmux = std::env::var_os("TMUX");
         let prev_sty = std::env::var_os("STY");
+        let prev_term_program = std::env::var_os("TERM_PROGRAM");
+
         // The test is about NO_ANIMATIONS only. On Windows CI, an unmarked
         // console host now independently enables low_motion, so mark the host
         // as non-legacy while checking falsy spellings.
         // Clear multiplexer markers for the same reason: they also force
         // low_motion independently of NO_ANIMATIONS.
+        // Clear TERM_PROGRAM as they also force low_motion in vscode, ghostty
+        // and Termius.
         // SAFETY: serialised by the guard.
         unsafe {
             std::env::remove_var("TMUX");
             std::env::remove_var("STY");
+            std::env::remove_var("TERM_PROGRAM");
         }
         #[cfg(windows)]
         unsafe {
@@ -1362,6 +1367,10 @@ mod tests {
             match prev_sty {
                 Some(v) => std::env::set_var("STY", v),
                 None => std::env::remove_var("STY"),
+            }
+            match prev_term_program {
+                Some(v) => std::env::set_var("TERM_PROGRAM", v),
+                None => std::env::remove_var("TERM_PROGRAM"),
             }
         }
     }


### PR DESCRIPTION
…gnises_truthy_spellings_only

## Summary

Clear and restore TERM_PROGRAM environment variable during tests to prevent low_motion being forced in vscode, ghostty and Termius.

## Problem

The test "codewhale_tui::settings::tests::no_animations_env_recognises_truthy_spellings_only" fails on some terminals, such as vscode, ghostty and Termius.

## Root Cause

When TERM_PROGRAM is set to vscode, ghostty, or Termius, low_motion is enforced, causing the test to fail, and TERM_PROGRAM is not cleared before the test.

## Fix

- Add prev_term_program to save var of TERM_PROGRAM.
- Clear TERM_PROGRAM before test.
- Cleanup TERM_PROGRAM under the guard.

## Additional Notes

The Cargo Clippy check has completed. These changes did not introduce any new warnings. However, some existing warnings were detected.
```
warning: used consecutive `str::replace` call
    --> crates/tui/src/config.rs:2914:10
     |
2914 |           .replace('-', "_")
     |  __________^
2915 | |         .replace(' ', "_")
     | |__________________________^ help: replace with: `replace(['-', ' '], "_")`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#collapsible_str_replace
     = note: `#[warn(clippy::collapsible_str_replace)]` on by default

warning: `codewhale-tui` (bin "codewhale-tui") generated 1 warning (run `cargo clippy --fix --bin "codewhale-tui" -p codewhale-tui -- ` to apply 1 suggestion)
warning: this creates an owned instance just for comparison
   --> crates/tui/src/commands/goal.rs:166:31
    |
166 |                 if content == "Implement login flow".to_string()
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `"Implement login flow"`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#cmp_owned
    = note: `#[warn(clippy::cmp_owned)]` on by default

warning: `codewhale-tui` (bin "codewhale-tui" test) generated 2 warnings (1 duplicate) (run `cargo clippy --fix --bin "codewhale-tui" -p codewhale-tui --tests -- ` to apply 1 suggestion)
```

## Testing

- [ x ] `cargo fmt --all -- --check`
- [ x ] `cargo clippy --workspace --all-targets --all-features`
- [ x ] `cargo test --workspace --all-features`

## Checklist

- [ x ] Updated docs or comments as needed
- [ x ] Added or updated tests where relevant
- [ x ] Verified TUI behavior manually if UI changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes test failures in `no_animations_env_recognises_truthy_spellings_only` that occurred in terminals such as VS Code, Ghostty, and Termius, where environment variables (`TERM_PROGRAM`, `SSH_CLIENT`, `SSH_TTY`, `TILIX_ID`, `TERMINATOR_UUID`) independently trigger `low_motion`, causing false assertion failures.

- Saves and clears all five newly-relevant env vars before the test loops, consistent with the existing `TMUX`/`STY` handling pattern.
- Restores each variable in the cleanup block (matching the save/remove idiom already used for `WT_SESSION`, `TMUX`, `STY`).
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is narrowly scoped to one test function and correctly covers all env vars that apply_env_overrides checks for low_motion.

The fix is complete: every environment variable that apply_env_overrides reads to set low_motion (TERM_PROGRAM, SSH_CLIENT, SSH_TTY, TILIX_ID, TERMINATOR_UUID, plus the pre-existing TMUX/STY) is now saved, cleared, and restored around the assertion loops. The implementation follows the established pattern in the test exactly, no production code is touched, and the pre-existing panic-safety concern is unchanged and well-understood.

No files require special attention — only one test function in crates/tui/src/settings.rs was modified.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/tui/src/settings.rs | Saves, clears, and restores TERM_PROGRAM, SSH_CLIENT, SSH_TTY, TILIX_ID, and TERMINATOR_UUID around the truthy-spellings test, covering all env vars that apply_env_overrides checks for low_motion. Change is consistent with existing test patterns and covers all relevant variables. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant T as Test
    participant E as Environment
    participant S as Settings::apply_env_overrides

    T->>E: save TMUX, STY, TERM_PROGRAM, SSH_CLIENT, SSH_TTY, TILIX_ID, TERMINATOR_UUID
    T->>E: remove_var(all above)
    loop truthy spellings ["1","true","YES","on","True"]
        T->>E: set_var(NO_ANIMATIONS, truthy)
        T->>S: apply_env_overrides()
        S-->>T: "low_motion = true ✓"
    end
    loop falsy spellings ["0","false","no","off",""]
        T->>E: set_var(NO_ANIMATIONS, falsy)
        T->>S: apply_env_overrides()
        S-->>T: "low_motion = false ✓"
    end
    T->>E: remove_var(NO_ANIMATIONS)
    T->>E: restore all saved vars
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/tui/src/settings.rs`, line 1356-1375 ([link](https://github.com/hmbown/codewhale/blob/bf635956f12594dffee95a314d7b61136430d34c/crates/tui/src/settings.rs#L1356-L1375)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Cleanup skipped on assertion panic**

   If any `assert!` inside the truthy/falsy loops fires, the function unwinds before reaching the cleanup block, leaving `TERM_PROGRAM` (and `TMUX`, `STY`, `NO_ANIMATIONS`) removed from the environment permanently for the rest of the test process. The `MutexGuard` `_g` is dropped correctly via unwind, but that only releases the lock — it does not restore the env vars.

   This is a pre-existing issue that affects all the env vars managed in this test. The `TERM_PROGRAM` addition is consistent with the existing pattern, but none of them are panic-safe. Wrapping the state in a custom `Drop` guard (one struct that holds all the `prev_*` values and restores them on drop) would make the entire group panic-safe and could replace the manual cleanup block.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix-test%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix-test%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fsettings.rs%0ALine%3A%201356-1375%0A%0AComment%3A%0A**Cleanup%20skipped%20on%20assertion%20panic**%0A%0AIf%20any%20%60assert!%60%20inside%20the%20truthy%2Ffalsy%20loops%20fires%2C%20the%20function%20unwinds%20before%20reaching%20the%20cleanup%20block%2C%20leaving%20%60TERM_PROGRAM%60%20%28and%20%60TMUX%60%2C%20%60STY%60%2C%20%60NO_ANIMATIONS%60%29%20removed%20from%20the%20environment%20permanently%20for%20the%20rest%20of%20the%20test%20process.%20The%20%60MutexGuard%60%20%60_g%60%20is%20dropped%20correctly%20via%20unwind%2C%20but%20that%20only%20releases%20the%20lock%20%E2%80%94%20it%20does%20not%20restore%20the%20env%20vars.%0A%0AThis%20is%20a%20pre-existing%20issue%20that%20affects%20all%20the%20env%20vars%20managed%20in%20this%20test.%20The%20%60TERM_PROGRAM%60%20addition%20is%20consistent%20with%20the%20existing%20pattern%2C%20but%20none%20of%20them%20are%20panic-safe.%20Wrapping%20the%20state%20in%20a%20custom%20%60Drop%60%20guard%20%28one%20struct%20that%20holds%20all%20the%20%60prev_*%60%20values%20and%20restores%20them%20on%20drop%29%20would%20make%20the%20entire%20group%20panic-safe%20and%20could%20replace%20the%20manual%20cleanup%20block.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fsettings.rs%0ALine%3A%201356-1375%0A%0AComment%3A%0A**Cleanup%20skipped%20on%20assertion%20panic**%0A%0AIf%20any%20%60assert!%60%20inside%20the%20truthy%2Ffalsy%20loops%20fires%2C%20the%20function%20unwinds%20before%20reaching%20the%20cleanup%20block%2C%20leaving%20%60TERM_PROGRAM%60%20%28and%20%60TMUX%60%2C%20%60STY%60%2C%20%60NO_ANIMATIONS%60%29%20removed%20from%20the%20environment%20permanently%20for%20the%20rest%20of%20the%20test%20process.%20The%20%60MutexGuard%60%20%60_g%60%20is%20dropped%20correctly%20via%20unwind%2C%20but%20that%20only%20releases%20the%20lock%20%E2%80%94%20it%20does%20not%20restore%20the%20env%20vars.%0A%0AThis%20is%20a%20pre-existing%20issue%20that%20affects%20all%20the%20env%20vars%20managed%20in%20this%20test.%20The%20%60TERM_PROGRAM%60%20addition%20is%20consistent%20with%20the%20existing%20pattern%2C%20but%20none%20of%20them%20are%20panic-safe.%20Wrapping%20the%20state%20in%20a%20custom%20%60Drop%60%20guard%20%28one%20struct%20that%20holds%20all%20the%20%60prev_*%60%20values%20and%20restores%20them%20on%20drop%29%20would%20make%20the%20entire%20group%20panic-safe%20and%20could%20replace%20the%20manual%20cleanup%20block.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2171&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fsettings.rs%0ALine%3A%201356-1375%0A%0AComment%3A%0A**Cleanup%20skipped%20on%20assertion%20panic**%0A%0AIf%20any%20%60assert!%60%20inside%20the%20truthy%2Ffalsy%20loops%20fires%2C%20the%20function%20unwinds%20before%20reaching%20the%20cleanup%20block%2C%20leaving%20%60TERM_PROGRAM%60%20%28and%20%60TMUX%60%2C%20%60STY%60%2C%20%60NO_ANIMATIONS%60%29%20removed%20from%20the%20environment%20permanently%20for%20the%20rest%20of%20the%20test%20process.%20The%20%60MutexGuard%60%20%60_g%60%20is%20dropped%20correctly%20via%20unwind%2C%20but%20that%20only%20releases%20the%20lock%20%E2%80%94%20it%20does%20not%20restore%20the%20env%20vars.%0A%0AThis%20is%20a%20pre-existing%20issue%20that%20affects%20all%20the%20env%20vars%20managed%20in%20this%20test.%20The%20%60TERM_PROGRAM%60%20addition%20is%20consistent%20with%20the%20existing%20pattern%2C%20but%20none%20of%20them%20are%20panic-safe.%20Wrapping%20the%20state%20in%20a%20custom%20%60Drop%60%20guard%20%28one%20struct%20that%20holds%20all%20the%20%60prev_*%60%20values%20and%20restores%20them%20on%20drop%29%20would%20make%20the%20entire%20group%20panic-safe%20and%20could%20replace%20the%20manual%20cleanup%20block.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2171&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["test(settings): handle other environment..."](https://github.com/hmbown/codewhale/commit/ba3d9fbb8ff5205456ef89fc31a33278c85ac094) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33895838)</sub>

<!-- /greptile_comment -->