### PR TITLE
Fix/Paste large text silently converted to @file

### DIFF
--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -728,7 +728,7 @@ fn match_kitty_csi_fragment(chars: &[char], start: usize) -> Option<usize> {
     None
 }
 
-const MAX_SUBMITTED_INPUT_CHARS: usize = 32_000;
+const MAX_SUBMITTED_INPUT_CHARS: usize = 16_000;
 const MAX_DRAFT_HISTORY: usize = 50;
 
 impl AppMode {
@@ -3121,14 +3121,10 @@ impl App {
             self.insert_str(&normalized);
         }
         self.paste_burst.clear_after_explicit_paste();
-        // Visible-before-submit consolidation: when the post-paste input
-        // is over the cap, swap it for an @paste-…md mention immediately
-        // (instead of waiting until the user presses Enter and getting
-        // surprised by an auto-sent @mention). The same logic runs as a
-        // safety-net at submit time so any other code path that fills
-        // self.input above the cap still consolidates rather than
-        // silently truncating.
-        self.consolidate_large_input_if_oversized();
+        // Consolidation is deferred to submit time only (#2159).
+        // Pasting large text should not silently replace the composer
+        // content — the user pasted it to see and edit it. The submit
+        // path still enforces the cap as a safety net.
     }
 
     pub fn insert_media_attachment(&mut self, kind: &str, path: &Path, description: Option<&str>) {
@@ -5298,12 +5294,10 @@ mod tests {
     }
 
     #[test]
-    fn paste_consolidates_oversized_text_into_paste_file_visibly() {
-        // Visible-before-submit consolidation (paste UX): when a single
-        // bracketed paste exceeds the safety cap, the @mention must
-        // replace the input *immediately*, so the user sees what's
-        // about to be sent before pressing Enter — not as a side effect
-        // of submit.
+    fn paste_oversized_text_is_preserved_in_composer_not_consolidated() {
+        // #2159: large pastes must NOT silently replace the composer
+        // content. Consolidation is deferred to submit time so the user
+        // can see and edit what they pasted.
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let mut opts = test_options(false);
         opts.workspace = tmp.path().to_path_buf();
@@ -5312,27 +5306,12 @@ mod tests {
 
         app.insert_paste_text(&full_content);
 
-        // Composer should now contain the @mention, not the full text.
-        assert!(
-            app.input.starts_with("@.deepseek/pastes/paste-") && app.input.ends_with(".md"),
-            "expected @mention in composer after large paste, got: {}",
-            app.input
+        // Composer should contain the full pasted text, not an @mention.
+        assert_eq!(
+            app.input, full_content,
+            "large paste should stay visible in composer, got @mention"
         );
-        // The cursor moves to the end of the @mention.
         assert_eq!(app.cursor_position, app.input.chars().count());
-        // The paste file must exist with the full content.
-        let rel_path = &app.input[1..];
-        let abs = tmp.path().join(rel_path);
-        assert!(abs.is_file(), "paste file must exist at {abs:?}");
-        let written = std::fs::read_to_string(&abs).expect("read");
-        assert_eq!(written, full_content);
-        // A toast confirms what happened so the user isn't surprised.
-        assert!(
-            app.status_toasts
-                .iter()
-                .any(|t| t.text.contains("consolidated")),
-            "expected consolidation toast"
-        );
     }
 
     #[test]

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -728,7 +728,7 @@ fn match_kitty_csi_fragment(chars: &[char], start: usize) -> Option<usize> {
     None
 }
 
-const MAX_SUBMITTED_INPUT_CHARS: usize = 16_000;
+const MAX_SUBMITTED_INPUT_CHARS: usize = 32_000;
 const MAX_DRAFT_HISTORY: usize = 50;
 
 impl AppMode {
@@ -4218,6 +4218,9 @@ impl App {
     /// pointing at it so the model can read the full content via the
     /// normal file-mention resolution path (#553).
     fn consolidate_large_input(&mut self) {
+        self.status_message = Some("Consolidating large paste to file…".to_string());
+        self.needs_redraw = true;
+
         let full_input = std::mem::take(&mut self.input);
         self.cursor_position = 0;
 


### PR DESCRIPTION
## Summary

Defer paste consolidation to submit time so pasted text remains
visible and editable in the composer.

Closes: https://github.com/Hmbown/CodeWhale/issues/2159

## Problem

`insert_paste_text` called `consolidate_large_input_if_oversized`
immediately after paste, silently replacing the composer content
with an `@.deepseek/pastes/...` file reference. Users pasting
large text saw their content disappear with no chance to preview
or edit it.

## Fix

Remove the paste-time consolidation call. The submit path (Enter)
still enforces the same safety cap, so oversized input is still
protected — but now the user sees their full text until they
choose to submit.

Also keep the "Consolidating large paste to file…" status message
in `consolidate_large_input` so the submit-time consolidation is
visible.

## Files Changed

| File | Change |
|---|---|
| `crates/tui/src/tui/app.rs` | Remove paste-time consolidate + update test |

## Test

Updated `paste_consolidates_oversized_text_into_paste_file_visibly` →
`paste_oversized_text_is_preserved_in_composer_not_consolidated`.
All 27 paste-related tests pass.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR defers large-paste consolidation from paste time to submit time, so pasted text stays visible and editable in the composer rather than being silently replaced with an `@file` mention. A status message is now emitted inside `consolidate_large_input` to make the submit-time swap visible to users.

- `insert_paste_text` no longer calls `consolidate_large_input_if_oversized`; the submit path in `submit_input` retains the safety-net call, so oversized input is still capped before being sent.
- The test `paste_consolidates_oversized_text_into_paste_file_visibly` is replaced by `paste_oversized_text_is_preserved_in_composer_not_consolidated`, correctly asserting the new behaviour; two inline comments that described the old dual-path flow were not updated and now describe behaviour that no longer exists.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the submit-time safety net remains intact and the test suite was updated to match the new paste behaviour.

The logic change is straightforward and well-tested. Two inline comments that described the old dual-path consolidation flow were not updated, leaving inaccurate descriptions of how `insert_paste_text` and `consolidate_large_input_if_oversized` interact — worth fixing before this becomes a maintenance trap, but not a correctness issue.

The stale comments in `submit_input` (around the `consolidate_large_input_if_oversized` call) and the doc comment on `consolidate_large_input_if_oversized` itself both describe the removed paste-time path and should be updated.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/app.rs | Removes paste-time consolidation from `insert_paste_text` and adds a status message to `consolidate_large_input`; two inline comments that described the old dual-path behaviour were not updated and now mislead readers. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant insert_paste_text
    participant submit_input
    participant consolidate_large_input

    Note over User,consolidate_large_input: Before this PR (old behaviour)
    User->>insert_paste_text: paste large text
    insert_paste_text->>consolidate_large_input: consolidate_large_input_if_oversized()
    consolidate_large_input-->>insert_paste_text: "composer replaced with @mention"
    insert_paste_text-->>User: "sees @mention (content gone)"

    Note over User,consolidate_large_input: After this PR (new behaviour)
    User->>insert_paste_text: paste large text
    insert_paste_text-->>User: full text visible in composer (no consolidation)
    User->>submit_input: press Enter
    submit_input->>consolidate_large_input: consolidate_large_input_if_oversized()
    consolidate_large_input-->>submit_input: "status_message set, input replaced with @mention"
    submit_input-->>User: "@mention submitted, composer cleared"
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `crates/tui/src/tui/app.rs`, line 4093-4098 ([link](https://github.com/hmbown/codewhale/blob/ef55d972c9b3ca111ba8ce27ed92dbe7efb01b87/crates/tui/src/tui/app.rs#L4093-L4098)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The comment on lines 4095-4097 still describes the old behaviour — bracketed pastes no longer pre-consolidate in `insert_paste_text`, so "Bracketed pastes hit the consolidation in `insert_paste_text` first" is now factually wrong and will mislead future readers.

   

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fpaste-large-text-hang%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fpaste-large-text-hang%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%0ALine%3A%204093-4098%0A%0AComment%3A%0AThe%20comment%20on%20lines%204095-4097%20still%20describes%20the%20old%20behaviour%20%E2%80%94%20bracketed%20pastes%20no%20longer%20pre-consolidate%20in%20%60insert_paste_text%60%2C%20so%20%22Bracketed%20pastes%20hit%20the%20consolidation%20in%20%60insert_paste_text%60%20first%22%20is%20now%20factually%20wrong%20and%20will%20mislead%20future%20readers.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Safety%20net%3A%20if%20any%20path%20filled%20the%20buffer%20above%20the%20safety%20cap%0A%20%20%20%20%20%20%20%20%2F%2F%20%28including%20large%20bracketed%20pastes%2C%20which%20are%20now%20deferred%20from%0A%20%20%20%20%20%20%20%20%2F%2F%20%60insert_paste_text%60%20per%20%232159%29%2C%20fold%20it%20into%20a%20workspace%20paste%0A%20%20%20%20%20%20%20%20%2F%2F%20file%20here%20at%20submit%20time%20%28%23553%29.%0A%20%20%20%20%20%20%20%20self.consolidate_large_input_if_oversized%28%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%0ALine%3A%204093-4098%0A%0AComment%3A%0AThe%20comment%20on%20lines%204095-4097%20still%20describes%20the%20old%20behaviour%20%E2%80%94%20bracketed%20pastes%20no%20longer%20pre-consolidate%20in%20%60insert_paste_text%60%2C%20so%20%22Bracketed%20pastes%20hit%20the%20consolidation%20in%20%60insert_paste_text%60%20first%22%20is%20now%20factually%20wrong%20and%20will%20mislead%20future%20readers.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Safety%20net%3A%20if%20any%20path%20filled%20the%20buffer%20above%20the%20safety%20cap%0A%20%20%20%20%20%20%20%20%2F%2F%20%28including%20large%20bracketed%20pastes%2C%20which%20are%20now%20deferred%20from%0A%20%20%20%20%20%20%20%20%2F%2F%20%60insert_paste_text%60%20per%20%232159%29%2C%20fold%20it%20into%20a%20workspace%20paste%0A%20%20%20%20%20%20%20%20%2F%2F%20file%20here%20at%20submit%20time%20%28%23553%29.%0A%20%20%20%20%20%20%20%20self.consolidate_large_input_if_oversized%28%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2172&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%0ALine%3A%204093-4098%0A%0AComment%3A%0AThe%20comment%20on%20lines%204095-4097%20still%20describes%20the%20old%20behaviour%20%E2%80%94%20bracketed%20pastes%20no%20longer%20pre-consolidate%20in%20%60insert_paste_text%60%2C%20so%20%22Bracketed%20pastes%20hit%20the%20consolidation%20in%20%60insert_paste_text%60%20first%22%20is%20now%20factually%20wrong%20and%20will%20mislead%20future%20readers.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Safety%20net%3A%20if%20any%20path%20filled%20the%20buffer%20above%20the%20safety%20cap%0A%20%20%20%20%20%20%20%20%2F%2F%20%28including%20large%20bracketed%20pastes%2C%20which%20are%20now%20deferred%20from%0A%20%20%20%20%20%20%20%20%2F%2F%20%60insert_paste_text%60%20per%20%232159%29%2C%20fold%20it%20into%20a%20workspace%20paste%0A%20%20%20%20%20%20%20%20%2F%2F%20file%20here%20at%20submit%20time%20%28%23553%29.%0A%20%20%20%20%20%20%20%20self.consolidate_large_input_if_oversized%28%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2172&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>


2. `crates/tui/src/tui/app.rs`, line 4200-4205 ([link](https://github.com/hmbown/codewhale/blob/ef55d972c9b3ca111ba8ce27ed92dbe7efb01b87/crates/tui/src/tui/app.rs#L4200-L4205)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The doc comment on `consolidate_large_input_if_oversized` still refers to "the paste-insert path (visible-before-submit)" routing through it. That path was removed by this PR, so the "enforced exactly once even when both paths fire" rationale no longer applies and will confuse future readers.

   

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fpaste-large-text-hang%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fpaste-large-text-hang%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%0ALine%3A%204200-4205%0A%0AComment%3A%0AThe%20doc%20comment%20on%20%60consolidate_large_input_if_oversized%60%20still%20refers%20to%20%22the%20paste-insert%20path%20%28visible-before-submit%29%22%20routing%20through%20it.%20That%20path%20was%20removed%20by%20this%20PR%2C%20so%20the%20%22enforced%20exactly%20once%20even%20when%20both%20paths%20fire%22%20rationale%20no%20longer%20applies%20and%20will%20confuse%20future%20readers.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Public%20wrapper%20around%20%5B%60Self%3A%3Aconsolidate_large_input%60%5D%20that%20no-ops%0A%20%20%20%20%2F%2F%2F%20when%20the%20current%20input%20fits%20inside%20the%20safety%20cap.%20Only%20the%20submit-%0A%20%20%20%20%2F%2F%2F%20time%20path%20routes%20through%20here%3B%20paste%20insertion%20no%20longer%20pre-%0A%20%20%20%20%2F%2F%2F%20consolidates%20%28%232159%29.%0A%20%20%20%20fn%20consolidate_large_input_if_oversized%28%26mut%20self%29%20%7B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%0ALine%3A%204200-4205%0A%0AComment%3A%0AThe%20doc%20comment%20on%20%60consolidate_large_input_if_oversized%60%20still%20refers%20to%20%22the%20paste-insert%20path%20%28visible-before-submit%29%22%20routing%20through%20it.%20That%20path%20was%20removed%20by%20this%20PR%2C%20so%20the%20%22enforced%20exactly%20once%20even%20when%20both%20paths%20fire%22%20rationale%20no%20longer%20applies%20and%20will%20confuse%20future%20readers.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Public%20wrapper%20around%20%5B%60Self%3A%3Aconsolidate_large_input%60%5D%20that%20no-ops%0A%20%20%20%20%2F%2F%2F%20when%20the%20current%20input%20fits%20inside%20the%20safety%20cap.%20Only%20the%20submit-%0A%20%20%20%20%2F%2F%2F%20time%20path%20routes%20through%20here%3B%20paste%20insertion%20no%20longer%20pre-%0A%20%20%20%20%2F%2F%2F%20consolidates%20%28%232159%29.%0A%20%20%20%20fn%20consolidate_large_input_if_oversized%28%26mut%20self%29%20%7B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2172&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%0ALine%3A%204200-4205%0A%0AComment%3A%0AThe%20doc%20comment%20on%20%60consolidate_large_input_if_oversized%60%20still%20refers%20to%20%22the%20paste-insert%20path%20%28visible-before-submit%29%22%20routing%20through%20it.%20That%20path%20was%20removed%20by%20this%20PR%2C%20so%20the%20%22enforced%20exactly%20once%20even%20when%20both%20paths%20fire%22%20rationale%20no%20longer%20applies%20and%20will%20confuse%20future%20readers.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Public%20wrapper%20around%20%5B%60Self%3A%3Aconsolidate_large_input%60%5D%20that%20no-ops%0A%20%20%20%20%2F%2F%2F%20when%20the%20current%20input%20fits%20inside%20the%20safety%20cap.%20Only%20the%20submit-%0A%20%20%20%20%2F%2F%2F%20time%20path%20routes%20through%20here%3B%20paste%20insertion%20no%20longer%20pre-%0A%20%20%20%20%2F%2F%2F%20consolidates%20%28%232159%29.%0A%20%20%20%20fn%20consolidate_large_input_if_oversized%28%26mut%20self%29%20%7B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2172&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fpaste-large-text-hang%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fpaste-large-text-hang%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%3A4093-4098%0AThe%20comment%20on%20lines%204095-4097%20still%20describes%20the%20old%20behaviour%20%E2%80%94%20bracketed%20pastes%20no%20longer%20pre-consolidate%20in%20%60insert_paste_text%60%2C%20so%20%22Bracketed%20pastes%20hit%20the%20consolidation%20in%20%60insert_paste_text%60%20first%22%20is%20now%20factually%20wrong%20and%20will%20mislead%20future%20readers.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Safety%20net%3A%20if%20any%20path%20filled%20the%20buffer%20above%20the%20safety%20cap%0A%20%20%20%20%20%20%20%20%2F%2F%20%28including%20large%20bracketed%20pastes%2C%20which%20are%20now%20deferred%20from%0A%20%20%20%20%20%20%20%20%2F%2F%20%60insert_paste_text%60%20per%20%232159%29%2C%20fold%20it%20into%20a%20workspace%20paste%0A%20%20%20%20%20%20%20%20%2F%2F%20file%20here%20at%20submit%20time%20%28%23553%29.%0A%20%20%20%20%20%20%20%20self.consolidate_large_input_if_oversized%28%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%3A4200-4205%0AThe%20doc%20comment%20on%20%60consolidate_large_input_if_oversized%60%20still%20refers%20to%20%22the%20paste-insert%20path%20%28visible-before-submit%29%22%20routing%20through%20it.%20That%20path%20was%20removed%20by%20this%20PR%2C%20so%20the%20%22enforced%20exactly%20once%20even%20when%20both%20paths%20fire%22%20rationale%20no%20longer%20applies%20and%20will%20confuse%20future%20readers.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Public%20wrapper%20around%20%5B%60Self%3A%3Aconsolidate_large_input%60%5D%20that%20no-ops%0A%20%20%20%20%2F%2F%2F%20when%20the%20current%20input%20fits%20inside%20the%20safety%20cap.%20Only%20the%20submit-%0A%20%20%20%20%2F%2F%2F%20time%20path%20routes%20through%20here%3B%20paste%20insertion%20no%20longer%20pre-%0A%20%20%20%20%2F%2F%2F%20consolidates%20%28%232159%29.%0A%20%20%20%20fn%20consolidate_large_input_if_oversized%28%26mut%20self%29%20%7B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%3A4093-4098%0AThe%20comment%20on%20lines%204095-4097%20still%20describes%20the%20old%20behaviour%20%E2%80%94%20bracketed%20pastes%20no%20longer%20pre-consolidate%20in%20%60insert_paste_text%60%2C%20so%20%22Bracketed%20pastes%20hit%20the%20consolidation%20in%20%60insert_paste_text%60%20first%22%20is%20now%20factually%20wrong%20and%20will%20mislead%20future%20readers.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Safety%20net%3A%20if%20any%20path%20filled%20the%20buffer%20above%20the%20safety%20cap%0A%20%20%20%20%20%20%20%20%2F%2F%20%28including%20large%20bracketed%20pastes%2C%20which%20are%20now%20deferred%20from%0A%20%20%20%20%20%20%20%20%2F%2F%20%60insert_paste_text%60%20per%20%232159%29%2C%20fold%20it%20into%20a%20workspace%20paste%0A%20%20%20%20%20%20%20%20%2F%2F%20file%20here%20at%20submit%20time%20%28%23553%29.%0A%20%20%20%20%20%20%20%20self.consolidate_large_input_if_oversized%28%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%3A4200-4205%0AThe%20doc%20comment%20on%20%60consolidate_large_input_if_oversized%60%20still%20refers%20to%20%22the%20paste-insert%20path%20%28visible-before-submit%29%22%20routing%20through%20it.%20That%20path%20was%20removed%20by%20this%20PR%2C%20so%20the%20%22enforced%20exactly%20once%20even%20when%20both%20paths%20fire%22%20rationale%20no%20longer%20applies%20and%20will%20confuse%20future%20readers.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Public%20wrapper%20around%20%5B%60Self%3A%3Aconsolidate_large_input%60%5D%20that%20no-ops%0A%20%20%20%20%2F%2F%2F%20when%20the%20current%20input%20fits%20inside%20the%20safety%20cap.%20Only%20the%20submit-%0A%20%20%20%20%2F%2F%2F%20time%20path%20routes%20through%20here%3B%20paste%20insertion%20no%20longer%20pre-%0A%20%20%20%20%2F%2F%2F%20consolidates%20%28%232159%29.%0A%20%20%20%20fn%20consolidate_large_input_if_oversized%28%26mut%20self%29%20%7B%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2172&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%3A4093-4098%0AThe%20comment%20on%20lines%204095-4097%20still%20describes%20the%20old%20behaviour%20%E2%80%94%20bracketed%20pastes%20no%20longer%20pre-consolidate%20in%20%60insert_paste_text%60%2C%20so%20%22Bracketed%20pastes%20hit%20the%20consolidation%20in%20%60insert_paste_text%60%20first%22%20is%20now%20factually%20wrong%20and%20will%20mislead%20future%20readers.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Safety%20net%3A%20if%20any%20path%20filled%20the%20buffer%20above%20the%20safety%20cap%0A%20%20%20%20%20%20%20%20%2F%2F%20%28including%20large%20bracketed%20pastes%2C%20which%20are%20now%20deferred%20from%0A%20%20%20%20%20%20%20%20%2F%2F%20%60insert_paste_text%60%20per%20%232159%29%2C%20fold%20it%20into%20a%20workspace%20paste%0A%20%20%20%20%20%20%20%20%2F%2F%20file%20here%20at%20submit%20time%20%28%23553%29.%0A%20%20%20%20%20%20%20%20self.consolidate_large_input_if_oversized%28%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%3A4200-4205%0AThe%20doc%20comment%20on%20%60consolidate_large_input_if_oversized%60%20still%20refers%20to%20%22the%20paste-insert%20path%20%28visible-before-submit%29%22%20routing%20through%20it.%20That%20path%20was%20removed%20by%20this%20PR%2C%20so%20the%20%22enforced%20exactly%20once%20even%20when%20both%20paths%20fire%22%20rationale%20no%20longer%20applies%20and%20will%20confuse%20future%20readers.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Public%20wrapper%20around%20%5B%60Self%3A%3Aconsolidate_large_input%60%5D%20that%20no-ops%0A%20%20%20%20%2F%2F%2F%20when%20the%20current%20input%20fits%20inside%20the%20safety%20cap.%20Only%20the%20submit-%0A%20%20%20%20%2F%2F%2F%20time%20path%20routes%20through%20here%3B%20paste%20insertion%20no%20longer%20pre-%0A%20%20%20%20%2F%2F%2F%20consolidates%20%28%232159%29.%0A%20%20%20%20fn%20consolidate_large_input_if_oversized%28%26mut%20self%29%20%7B%0A%60%60%60%0A%0A&pr=2172&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix: defer paste consolidation to submit..."](https://github.com/hmbown/codewhale/commit/ef55d972c9b3ca111ba8ce27ed92dbe7efb01b87) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33901500)</sub>

<!-- /greptile_comment -->