### PR TITLE
fix(paste): preserve Enter suppression window after non-char keys during paste

### DIFF
--- a/crates/tui/src/tui/paste_burst.rs
+++ b/crates/tui/src/tui/paste_burst.rs
@@ -231,7 +231,16 @@ impl PasteBurst {
     /// part of table-data paste. The buffer was flushed upstream; only the
     /// active state is reset so `burst_window_until` stays alive and a trailing
     /// Enter is still absorbed as a newline (#2134).
+    ///
+    /// # Panics
+    ///
+    /// Panics in debug builds if `buffer` is non-empty — the caller must flush
+    /// via [`flush_before_modified_input`] first.
     pub fn deactivate_keep_window(&mut self) {
+        debug_assert!(
+            self.buffer.is_empty(),
+            "buffer must be flushed before deactivating"
+        );
         self.consecutive_plain_char_burst = 0;
         self.last_plain_char_time = None;
         self.active = false;

--- a/crates/tui/src/tui/paste_burst.rs
+++ b/crates/tui/src/tui/paste_burst.rs
@@ -225,12 +225,18 @@ impl PasteBurst {
         Some(out)
     }
 
-    pub fn clear_window_after_non_char(&mut self) {
+    /// Reset burst-accumulation state without clearing the suppression window.
+    ///
+    /// Used when a non-char key (Tab, etc.) arrives during an active burst as
+    /// part of table-data paste. The buffer was flushed upstream; only the
+    /// active state is reset so `burst_window_until` stays alive and a trailing
+    /// Enter is still absorbed as a newline (#2134).
+    pub fn deactivate_keep_window(&mut self) {
         self.consecutive_plain_char_burst = 0;
         self.last_plain_char_time = None;
-        self.burst_window_until = None;
         self.active = false;
         self.pending_first_char = None;
+        // burst_window_until intentionally NOT cleared
     }
 
     pub fn is_active(&self) -> bool {
@@ -331,5 +337,48 @@ mod tests {
 
         let due = t0 + Duration::from_millis(20);
         assert_eq!(burst.next_flush_delay(due), Some(Duration::ZERO));
+    }
+
+    /// Simulate #2134: when a non-char key (Tab) arrives during table-data
+    /// paste, `deactivate_keep_window` resets accumulation state but
+    /// preserves the Enter-suppression window so a trailing newline is still
+    /// absorbed instead of submitting the partial input.
+    #[test]
+    fn deactivate_keep_window_preserves_enter_suppression_window() {
+        let mut burst = PasteBurst::default();
+        let t0 = Instant::now();
+
+        assert!(matches!(
+            burst.on_plain_char('a', t0),
+            CharDecision::RetainFirstChar
+        ));
+        let t1 = t0 + Duration::from_millis(1);
+        assert!(matches!(
+            burst.on_plain_char('b', t1),
+            CharDecision::BeginBufferFromPending
+        ));
+        burst.append_char_to_buffer('b', t1);
+        assert!(burst.is_active());
+        assert!(burst.newline_should_insert_instead_of_submit(t1));
+
+        let flushed = burst.flush_before_modified_input();
+        assert!(flushed.is_some());
+        assert!(!burst.is_active());
+
+        burst.deactivate_keep_window();
+
+        assert!(!burst.is_active());
+
+        let t_tab = t1 + Duration::from_millis(2);
+        assert!(
+            burst.newline_should_insert_instead_of_submit(t_tab),
+            "Enter within suppression window should insert newline, not submit"
+        );
+
+        let t_expired = t_tab + PASTE_ENTER_SUPPRESS_WINDOW + Duration::from_millis(1);
+        assert!(
+            !burst.newline_should_insert_instead_of_submit(t_expired),
+            "Enter after suppression window expires should submit"
+        );
     }
 }

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -3629,7 +3629,7 @@ async fn run_event_loop(
             }
 
             if !is_plain_char && !is_enter {
-                app.paste_burst.clear_window_after_non_char();
+                app.paste_burst.deactivate_keep_window();
             }
         }
     }


### PR DESCRIPTION
## Summary
When pasting table data (e.g. from Visual Studio error list), Tab keys embedded in the clipboard were triggering `clear_window_after_non_char`, which cleared the Enter suppression window (`burst_window_until`). 

This caused the trailing newline to submit the partial input instead of being absorbed as a line break.
    
Replace `clear_window_after_non_char` with `deactivate_keep_window`, which resets burst accumulation state (`active`, `pending_first_char`, etc.) but intentionally preserves `burst_window_until` so the suppression window survives and trailing Enter is still absorbed as a newline.

Closes #2134

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features`
- [x] `cargo test --workspace --all-features`

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug (#2134) where Tab characters embedded in clipboard table data (e.g. from the VS error list) were incorrectly clearing the Enter-suppression window, causing the trailing newline of the paste to submit partial input instead of being absorbed as a line break.

- Renames `clear_window_after_non_char` → `deactivate_keep_window`, which resets burst-accumulation fields (`active`, `pending_first_char`, `consecutive_plain_char_burst`, `last_plain_char_time`) but intentionally leaves `burst_window_until` intact so the suppression window survives non-char keys mid-paste.
- Adds a `debug_assert!(self.buffer.is_empty())` to enforce the upstream-flush precondition in debug builds, and a new regression test that simulates the full Tab-during-paste scenario end-to-end.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is minimal, well-reasoned, and thoroughly tested.

The fix is a targeted, two-file change: one new method on PasteBurst with a debug_assert precondition guard, and a single call-site rename in ui.rs. The call ordering in the event loop guarantees the buffer is always flushed before deactivate_keep_window is invoked, so the assert invariant holds in both the use_paste_burst_detection=true and =false paths. A new regression test exercises the exact scenario from the bug report. No existing tests were modified.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/paste_burst.rs | Adds deactivate_keep_window that resets burst-accumulation state while intentionally preserving burst_window_until; adds a debug_assert precondition guard and a targeted regression test covering the #2134 scenario. |
| crates/tui/src/tui/ui.rs | One-line call-site change: replaces clear_window_after_non_char with deactivate_keep_window; call ordering (flush at line ~2755, then deactivate at line ~3632) ensures the buffer precondition is always met. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Term as Terminal
    participant UI as ui.rs event loop
    participant PB as PasteBurst

    Note over Term,PB: Table paste: "col1\tcol2\n"
    Term->>UI: KeyCode::Char('c') [plain char]
    UI->>PB: handle_paste_burst_key → on_plain_char / append_char_to_buffer
    PB-->>UI: "burst active, burst_window_until = now + 120ms"

    Term->>UI: KeyCode::Char('o') [plain char]
    UI->>PB: on_plain_char / append_char_to_buffer
    PB-->>UI: burst_window_until extended

    Note over Term,UI: Tab key arrives (non-char, non-enter)
    Term->>UI: KeyCode::Tab
    UI->>PB: flush_paste_burst_before_modified_input_if_enabled()
    PB-->>UI: "Some("col") — buffer flushed, active=false, burst_window_until preserved"

    UI->>PB: deactivate_keep_window()
    Note over PB: clears active, pending_first_char,<br/>consecutive_plain_char_burst,<br/>last_plain_char_time<br/>burst_window_until NOT cleared ✓

    Term->>UI: KeyCode::Enter (trailing newline of paste)
    UI->>PB: newline_should_insert_instead_of_submit(now)
    PB-->>UI: true (burst_window_until still active)
    Note over UI: Enter absorbed as newline — not submitted ✓
```
</details>

<sub>Reviews (2): Last reviewed commit: ["chore(paste): add debug\_assert for buffe..."](https://github.com/hmbown/codewhale/commit/4befd0946475adacd67ceac4e03fc49b1f279685) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33904601)</sub>

<!-- /greptile_comment -->