### PR TITLE
docs: add review pipeline documentation closes #2177

### DIFF
--- a/docs/REVIEW_PIPELINE.md
+++ b/docs/REVIEW_PIPELINE.md
@@ -16,7 +16,7 @@ Before a maintainer reviews your PR, it must pass our continuous integration (CI
 
 Please run these locally before pushing your code to avoid CI failures:
 
-\* \*\*Format:\*\* `cargo fmt --check`
+\* \*\*Format:\*\* `cargo fmt --all -- --check`
 
 \* \*\*Linting:\*\* `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
 

--- a/docs/REVIEW_PIPELINE.md
+++ b/docs/REVIEW_PIPELINE.md
@@ -1,0 +1,84 @@
+\# CodeWhale Review Pipeline
+
+
+
+Welcome to CodeWhale! We receive a high volume of community PRs. To ensure a smooth and fast review process, please review our pipeline expectations below. 
+
+
+
+\## 1. CI Gates (Pre-Review Checklist)
+
+Before a maintainer reviews your PR, it must pass our continuous integration (CI) checks. 
+
+
+
+\*\*Required Checks (Must Pass):\*\*
+
+Please run these locally before pushing your code to avoid CI failures:
+
+\* \*\*Format:\*\* `cargo fmt --check`
+
+\* \*\*Linting:\*\* `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
+
+\* \*\*Tests:\*\* `cargo test --workspace --all-features --locked`
+
+
+
+\*\*Informational Checks:\*\*
+
+Checks from \*\*Greptile\*\* and \*\*GitGuardian\*\* are informational. If they flag something, review it, but they do not strictly block a review on their own unless a secret is leaked.
+
+
+
+\## 2. Common Failure Modes \& Local Fixes
+
+If CI fails, it is usually one of these three reasons:
+
+\* \*\*Version Drift (`Cargo.lock` out of date):\*\* Run `cargo update` or `cargo build` locally to update the lockfile and commit the changes.
+
+\* \*\*Lint Failures:\*\* Check the clippy warnings from the command above and fix the specific lines flagged.
+
+\* \*\*Windows Test Flakiness:\*\* Occasionally, tests may time out on Windows runners. If you are confident your code didn't break it, leave a comment asking a maintainer to re-trigger the CI.
+
+
+
+\## 3. PR Etiquette
+
+To help us review your code quickly, please adhere to the following:
+
+\* \*\*One Concern Per PR:\*\* Keep diffs highly focused. Do not mix refactoring with new feature additions.
+
+\* \*\*Link the Issue:\*\* Always include `Closes #N` (replace N with the issue number) in your PR description so GitHub automatically links them.
+
+\* \*\*Rebase:\*\* Always rebase your branch onto the latest `main` branch before requesting a review.
+
+
+
+\## 4. The Review Workflow
+
+Once CI is green, your PR enters the review queue.
+
+\* \*\*Who reviews:\*\* Core maintainers will review the PR. 
+
+\* \*\*`autonomous-ready` Label:\*\* If a maintainer applies this label, it means the PR is approved in concept and is queued for our automated integration system.
+
+\* \*\*The Nightly Loop:\*\* We run extensive integration loops overnight. If your PR is approved, it may wait for this nightly loop before final merging to ensure system stability.
+
+
+
+\## 5. Post-Merge Actions
+
+After your code is merged, the following automated actions occur:
+
+\* `CHANGELOG.md` is updated.
+
+\* `npm` wrappers are synced.
+
+\* Binary rebuilds are triggered for all platforms.
+
+\* Website and documentation are synced with your new changes.
+
+
+
+Thank you for contributing to CodeWhale!
+

--- a/docs/REVIEW_PIPELINE.md
+++ b/docs/REVIEW_PIPELINE.md
@@ -18,7 +18,7 @@ Please run these locally before pushing your code to avoid CI failures:
 
 \* \*\*Format:\*\* `cargo fmt --all -- --check`
 
-\* \*\*Linting:\*\* `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
+\* \*\*Linting:\*\* `cargo clippy --workspace --all-targets --all-features`
 
 \* \*\*Tests:\*\* `cargo test --workspace --all-features --locked`
 


### PR DESCRIPTION
## Summary

## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a new `docs/REVIEW_PIPELINE.md` file intended to guide community contributors through the CI requirements, common failure modes, PR etiquette, and post-merge automation for the CodeWhale project.

- The entire file is authored with escaped markdown syntax (`\#`, `\*\*`, `\*`) on every heading and list marker, which causes every standard renderer (GitHub, docs sites, editors) to display raw escape characters rather than formatted headings and lists — the document is currently unreadable as intended.
- The test command documented in Section 1 (`cargo test --workspace --all-features --locked`) includes `--locked` which is absent from the canonical PR template, creating an inconsistency that can confuse contributors following this guide.
</details>

<details open><summary><h3>Confidence Score: 2/5</h3></summary>

Not safe to merge — the document will render as unformatted plain text on GitHub and all standard markdown renderers until the escaped markdown syntax is corrected.

The sole changed file is completely broken for its intended audience: every heading, bold label, and bullet point is prefixed with a backslash escape character, so the document renders as raw escape sequences rather than formatted markdown. A contributor reading this on GitHub today would see \# CodeWhale Review Pipeline as a literal string instead of a heading, and all bullet lists would appear as escaped asterisks. The content itself is otherwise accurate (with the minor test-command inconsistency noted), but the formatting regression means the file cannot fulfill its purpose as a readable contribution guide in its current state.

docs/REVIEW_PIPELINE.md — requires removal of all backslash escape prefixes (\#, \*\*, \*) before the document renders correctly.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/REVIEW_PIPELINE.md | New contributor-facing documentation for the PR review pipeline. The entire file uses escaped markdown syntax (backslashes on every heading and list marker), which prevents correct rendering on any standard markdown renderer. The test command also diverges from the canonical PR template. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([Contributor opens PR]) --> B[Run CI checks locally]
    B --> B1["`cargo fmt --all -- --check`"]
    B --> B2["`cargo clippy --workspace --all-targets --all-features`"]
    B --> B3["`cargo test --workspace --all-features`"]
    B1 & B2 & B3 --> C{CI passes?}
    C -- No --> D[Fix failures\nSection 2 guidance]
    D --> B
    C -- Yes --> E[Informational checks\nGreptile / GitGuardian]
    E --> F{Maintainer review}
    F -- Changes requested --> G[Address feedback\nrebase onto main]
    G --> F
    F -- Approved --> H{autonomous-ready\nlabel applied?}
    H -- Yes --> I[Queued for automated\nintegration system]
    H -- No --> J[Direct merge]
    I --> K[Nightly integration loop]
    K --> J
    J --> L[Post-merge automation\nCHANGELOG · npm · binaries · docs]
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22docs%2Freview-pipeline%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Freview-pipeline%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2FREVIEW_PIPELINE.md%3A23%0AThe%20test%20command%20includes%20%60--locked%60%20but%20the%20PR%20template%20%28%60PULL_REQUEST_TEMPLATE.md%60%20line%207%29%20uses%20%60cargo%20test%20--workspace%20--all-features%60%20without%20it.%20This%20inconsistency%20means%20contributors%20following%20this%20document%20will%20run%20a%20stricter%20command%20than%20CI%20actually%20enforces%2C%20and%20could%20also%20encounter%20failures%20if%20their%20local%20%60Cargo.lock%60%20has%20drifted%20%E2%80%94%20even%20though%20Section%202%20explicitly%20instructs%20them%20to%20run%20%60cargo%20update%60%20to%20resolve%20drift.%0A%0A%60%60%60suggestion%0A%5C*%20%5C*%5C*Tests%3A%5C*%5C*%20%60cargo%20test%20--workspace%20--all-features%60%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2FREVIEW_PIPELINE.md%3A23%0AThe%20test%20command%20includes%20%60--locked%60%20but%20the%20PR%20template%20%28%60PULL_REQUEST_TEMPLATE.md%60%20line%207%29%20uses%20%60cargo%20test%20--workspace%20--all-features%60%20without%20it.%20This%20inconsistency%20means%20contributors%20following%20this%20document%20will%20run%20a%20stricter%20command%20than%20CI%20actually%20enforces%2C%20and%20could%20also%20encounter%20failures%20if%20their%20local%20%60Cargo.lock%60%20has%20drifted%20%E2%80%94%20even%20though%20Section%202%20explicitly%20instructs%20them%20to%20run%20%60cargo%20update%60%20to%20resolve%20drift.%0A%0A%60%60%60suggestion%0A%5C*%20%5C*%5C*Tests%3A%5C*%5C*%20%60cargo%20test%20--workspace%20--all-features%60%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2178&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2FREVIEW_PIPELINE.md%3A23%0AThe%20test%20command%20includes%20%60--locked%60%20but%20the%20PR%20template%20%28%60PULL_REQUEST_TEMPLATE.md%60%20line%207%29%20uses%20%60cargo%20test%20--workspace%20--all-features%60%20without%20it.%20This%20inconsistency%20means%20contributors%20following%20this%20document%20will%20run%20a%20stricter%20command%20than%20CI%20actually%20enforces%2C%20and%20could%20also%20encounter%20failures%20if%20their%20local%20%60Cargo.lock%60%20has%20drifted%20%E2%80%94%20even%20though%20Section%202%20explicitly%20instructs%20them%20to%20run%20%60cargo%20update%60%20to%20resolve%20drift.%0A%0A%60%60%60suggestion%0A%5C*%20%5C*%5C*Tests%3A%5C*%5C*%20%60cargo%20test%20--workspace%20--all-features%60%0A%60%60%60%0A%0A&pr=2178&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["docs: remove locked and warning flags fr..."](https://github.com/hmbown/codewhale/commit/eb64c001f00959ddacde62b2af56eb0e332736a8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33914220)</sub>

<!-- /greptile_comment -->