### PR TITLE
feat(v0.8.46): quick fixes — palette, model picker Esc, sub-agent sidebar, shell chip, model name casing, CVE bump

### DIFF
--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -411,12 +411,24 @@ fn canonical_official_deepseek_model_id(model: &str) -> Option<&'static str> {
 /// aliases are valid for some compatible backends, but sending them to
 /// DeepSeek's own API causes a 400. Keep the generic normalizer permissive for
 /// config/back-compat, and canonicalize only when the active provider is known.
+///
+/// Preserves the caller's casing when the model is already a recognised
+/// DeepSeek id (e.g. `DeepSeek-V4-Flash` stays as-is). Only rewrites compact
+/// aliases like `deepseek-v4pro` → `deepseek-v4-pro`.
 #[must_use]
 pub fn normalize_model_name_for_provider(provider: ApiProvider, model: &str) -> Option<String> {
     let normalized = normalize_model_name(model)?;
     if matches!(provider, ApiProvider::Deepseek | ApiProvider::DeepseekCN)
         && let Some(canonical) = canonical_official_deepseek_model_id(&normalized)
     {
+        // When the user's input already matches a known model id
+        // case-insensitively, keep their original casing; only rewrite
+        // compact aliases (e.g. v4pro → v4-pro).
+        if canonical.eq_ignore_ascii_case(&normalized)
+            || normalized.to_ascii_lowercase() == canonical
+        {
+            return Some(normalized);
+        }
         return Some(canonical.to_string());
     }
     if let Some(canonical) = canonical_official_deepseek_model_id(&normalized) {

--- a/crates/tui/src/palette.rs
+++ b/crates/tui/src/palette.rs
@@ -4,17 +4,17 @@ use ratatui::style::Color;
 #[cfg(target_os = "macos")]
 use std::process::Command;
 
-// v0.8.45 Whale dark palette — refreshed ocean/navy identity.
-pub const WHALE_BG_RGB: (u8, u8, u8) = (13, 21, 37); // #0D1525 Deep Navy
-pub const WHALE_PANEL_RGB: (u8, u8, u8) = (19, 29, 48); // #131D30
-pub const WHALE_ELEVATED_RGB: (u8, u8, u8) = (26, 40, 64); // #1A2840
-pub const WHALE_SELECTION_RGB: (u8, u8, u8) = (30, 50, 82); // #1E3252
+// v0.8.46 Whale dark palette — improved contrast and layer separation.
+pub const WHALE_BG_RGB: (u8, u8, u8) = (10, 17, 32); // #0A1120 Deep Navy
+pub const WHALE_PANEL_RGB: (u8, u8, u8) = (22, 34, 56); // #162238
+pub const WHALE_ELEVATED_RGB: (u8, u8, u8) = (36, 52, 78); // #24344E
+pub const WHALE_SELECTION_RGB: (u8, u8, u8) = (48, 68, 100); // #304464
 pub const WHALE_TEXT_BODY_RGB: (u8, u8, u8) = (246, 242, 232); // #F6F2E8 Whale Ivory
 pub const WHALE_TEXT_SOFT_RGB: (u8, u8, u8) = (217, 224, 234); // #D9E0EA
 pub const WHALE_TEXT_MUTED_RGB: (u8, u8, u8) = (169, 180, 199); // #A9B4C7 Mist Gray
-pub const WHALE_TEXT_HINT_RGB: (u8, u8, u8) = (122, 134, 158); // #7A869E
+pub const WHALE_TEXT_HINT_RGB: (u8, u8, u8) = (138, 150, 174); // #8A96AE
 #[allow(dead_code)]
-pub const WHALE_TEXT_DIM_RGB: (u8, u8, u8) = (107, 120, 146); // #6B7892
+pub const WHALE_TEXT_DIM_RGB: (u8, u8, u8) = (118, 130, 156); // #76829C
 pub const WHALE_ACCENT_PRIMARY_RGB: (u8, u8, u8) = (246, 196, 83); // #F6C453 Signal Gold
 pub const WHALE_ACCENT_SECONDARY_RGB: (u8, u8, u8) = (79, 209, 197); // #4FD1C5 Seafoam
 pub const WHALE_ACCENT_ACTION_RGB: (u8, u8, u8) = (255, 122, 89); // #FF7A59 Coral Spark
@@ -26,10 +26,10 @@ pub const WHALE_ERROR_TEXT_RGB: (u8, u8, u8) = (255, 214, 222); // #FFD6DE Error
 pub const WHALE_WARNING_RGB: (u8, u8, u8) = (240, 160, 48); // #F0A030
 pub const WHALE_SUCCESS_RGB: (u8, u8, u8) = (79, 209, 197); // #4FD1C5 Seafoam
 pub const WHALE_INFO_RGB: (u8, u8, u8) = (106, 174, 242); // #6AAEF2 Sky
-pub const WHALE_BORDER_RGB: (u8, u8, u8) = (42, 74, 127); // #2A4A7F
+pub const WHALE_BORDER_RGB: (u8, u8, u8) = (52, 88, 145); // #345891
 pub const WHALE_REASONING_TEXT_RGB: (u8, u8, u8) = (224, 153, 72); // #E09948
 pub const WHALE_REASONING_SURFACE_RGB: (u8, u8, u8) = (42, 34, 24); // #2A2218
-pub const WHALE_REASONING_TINT_RGB: (u8, u8, u8) = (20, 30, 42); // #141E2A
+pub const WHALE_REASONING_TINT_RGB: (u8, u8, u8) = (24, 36, 52); // #182434
 pub const WHALE_DIFF_ADDED_RGB: (u8, u8, u8) = (87, 199, 133); // #57C785
 #[allow(dead_code)]
 pub const WHALE_DIFF_DELETED_RGB: (u8, u8, u8) = (255, 92, 122); // #FF5C7A Rose Red
@@ -39,11 +39,11 @@ pub const WHALE_MODE_AGENT_RGB: (u8, u8, u8) = (80, 150, 255); // #5096FF
 pub const WHALE_MODE_YOLO_RGB: (u8, u8, u8) = (255, 100, 100); // #FF6464
 pub const WHALE_MODE_PLAN_RGB: (u8, u8, u8) = (246, 196, 83); // #F6C453 Signal Gold
 pub const WHALE_MODE_GOAL_RGB: (u8, u8, u8) = (100, 220, 160); // #64DCA0
-pub const WHALE_TOOL_LIVE_RGB: (u8, u8, u8) = (133, 184, 234); // #85B8EA
-pub const WHALE_TOOL_ISSUE_RGB: (u8, u8, u8) = (192, 143, 153); // #C08F99
+pub const WHALE_TOOL_LIVE_RGB: (u8, u8, u8) = (140, 190, 238); // #8CBEEE
+pub const WHALE_TOOL_ISSUE_RGB: (u8, u8, u8) = (198, 150, 160); // #C696A0
 pub const WHALE_TOOL_OUTPUT_RGB: (u8, u8, u8) = (194, 208, 224); // #C2D0E0
-pub const WHALE_TOOL_SURFACE_RGB: (u8, u8, u8) = (24, 34, 53); // #182235
-pub const WHALE_TOOL_ACTIVE_RGB: (u8, u8, u8) = (31, 45, 69); // #1F2D45
+pub const WHALE_TOOL_SURFACE_RGB: (u8, u8, u8) = (28, 40, 62); // #1C283E
+pub const WHALE_TOOL_ACTIVE_RGB: (u8, u8, u8) = (38, 54, 80); // #263650
 
 // Backward-compatible aliases for existing call sites.
 pub const DEEPSEEK_BLUE_RGB: (u8, u8, u8) = WHALE_ACCENT_PRIMARY_RGB;

--- a/crates/tui/src/tui/footer_ui.rs
+++ b/crates/tui/src/tui/footer_ui.rs
@@ -474,9 +474,16 @@ pub(crate) fn render_footer_from(
         props.model.clear();
     }
 
+    // Shell-running chip: visible whenever a foreground shell command is
+    // active, regardless of user-configured status items.
+    let shell_chip = crate::tui::widgets::footer_shell_chip(active_foreground_shell_running(app));
+
     // Right-cluster extension chips: append in `items` order so user
     // ordering is preserved across the new variants.
     let mut extra: Vec<Span<'static>> = Vec::new();
+    if !shell_chip.is_empty() {
+        extra.extend(shell_chip);
+    }
     for item in items {
         let chip = match *item {
             S::PrefixStability => prefix_stability.clone(),
@@ -597,6 +604,9 @@ pub(crate) fn footer_auxiliary_spans(app: &App, max_width: usize) -> Vec<Span<'s
         })
         .unwrap_or_default();
 
+    let shell_spans =
+        crate::tui::widgets::footer_shell_chip(active_foreground_shell_running(app));
+
     let parts: Vec<&Vec<Span<'static>>> = [
         &coherence_spans,
         &agents_spans,
@@ -604,6 +614,7 @@ pub(crate) fn footer_auxiliary_spans(app: &App, max_width: usize) -> Vec<Span<'s
         &prefix_spans,
         &cache_spans,
         &cost_spans,
+        &shell_spans,
     ]
     .iter()
     .filter(|spans| !spans.is_empty())

--- a/crates/tui/src/tui/model_picker.rs
+++ b/crates/tui/src/tui/model_picker.rs
@@ -3,8 +3,8 @@
 //!
 //! Two side-by-side panes — Models on the left, Thinking effort on the
 //! right. Tab swaps focus, ↑/↓ moves within the focused pane, Enter applies
-//! both and closes the modal. Esc closes immediately when nothing moved; after
-//! a selection move it keeps the highlighted choice.
+//! both and closes the modal. Esc applies the last-highlighted choice and
+//! closes.
 //!
 //! The effort pane intentionally only exposes `Off / High / Max`. Per
 //! DeepSeek's [Thinking Mode docs](https://api-docs.deepseek.com/guides/reasoning_model),
@@ -274,8 +274,7 @@ impl ModalView for ModelPickerView {
 
     fn handle_key(&mut self, key: KeyEvent) -> ViewAction {
         match key.code {
-            KeyCode::Esc if self.selection_touched => ViewAction::EmitAndClose(self.build_event()),
-            KeyCode::Esc => ViewAction::Close,
+            KeyCode::Esc => ViewAction::EmitAndClose(self.build_event()),
             KeyCode::Enter => ViewAction::EmitAndClose(self.build_event()),
             KeyCode::Up => {
                 self.selection_touched |= self.move_up();
@@ -321,7 +320,7 @@ impl ModalView for ModelPickerView {
                 Span::styled(" Enter ", Style::default().fg(palette::TEXT_MUTED)),
                 Span::raw("apply "),
                 Span::styled(" Esc ", Style::default().fg(palette::TEXT_MUTED)),
-                Span::raw("cancel "),
+                Span::raw("apply "),
             ]))
             .borders(Borders::ALL)
             .border_style(Style::default().fg(palette::BORDER_COLOR))
@@ -577,14 +576,19 @@ mod tests {
     }
 
     #[test]
-    fn immediate_esc_closes_without_emitting() {
+    fn immediate_esc_applies_current_selection() {
         let (app, _lock) = create_test_app();
         let mut view = ModelPickerView::new(&app);
         let action = view.handle_key(KeyEvent::new(
             KeyCode::Esc,
             crossterm::event::KeyModifiers::NONE,
         ));
-        assert!(matches!(action, ViewAction::Close));
+        match action {
+            ViewAction::EmitAndClose(ViewEvent::ModelPickerApplied { model, .. }) => {
+                assert_eq!(model, "deepseek-v4-pro");
+            }
+            other => panic!("expected Esc to apply current selection, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/tui/src/tui/sidebar.rs
+++ b/crates/tui/src/tui/sidebar.rs
@@ -1606,6 +1606,12 @@ pub fn subagent_panel_lines(
             Style::default().fg(color),
         )));
 
+        // Auto-collapse finished sub-agents: hide detail lines for completed
+        // agents so the sidebar stays compact when work is done.
+        if row.status == "done" {
+            continue;
+        }
+
         if lines.len() >= max_rows {
             break;
         }

--- a/crates/tui/src/tui/widgets/footer.rs
+++ b/crates/tui/src/tui/widgets/footer.rs
@@ -152,6 +152,19 @@ pub fn footer_working_label(frame: u64, locale: Locale) -> String {
     out
 }
 
+/// Build a "⏳ shell running" chip span when a foreground shell command is
+/// active. Empty when no shell is running, which hides the chip entirely.
+#[must_use]
+pub fn footer_shell_chip(active: bool) -> Vec<Span<'static>> {
+    if !active {
+        return Vec::new();
+    }
+    vec![Span::styled(
+        "\u{23F3} shell running".to_string(),
+        Style::default().fg(palette::STATUS_WARNING),
+    )]
+}
+
 /// Build a "N agents" chip span list when there are sub-agents in flight.
 /// Empty list when N == 0 hides the chip entirely. Singular for N == 1
 /// reads naturally; plural otherwise. The pluralization template lives in

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -16,7 +16,8 @@ mod renderable;
 pub mod tool_card;
 
 pub use footer::{
-    FooterProps, FooterToast, FooterWidget, footer_agents_chip, footer_working_label,
+    FooterProps, FooterToast, FooterWidget, footer_agents_chip, footer_shell_chip,
+    footer_working_label,
 };
 pub use header::{HeaderData, HeaderWidget, header_status_indicator_frame};
 pub use renderable::Renderable;

--- a/integrations/feishu-bridge/package-lock.json
+++ b/integrations/feishu-bridge/package-lock.json
@@ -510,9 +510,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/integrations/feishu-bridge/package.json
+++ b/integrations/feishu-bridge/package.json
@@ -15,7 +15,8 @@
     "@larksuiteoapi/node-sdk": "^1.52.0"
   },
   "overrides": {
-    "axios": "^1.16.1"
+    "axios": "^1.16.1",
+    "qs": ">=6.15.2"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
## Summary

Bundle of quick fixes for v0.8.46:

- **fix: preserve model name casing** — `normalize_model_name_for_provider` no longer lowercases user-set model names (closes #2211, closes #2109)
- **feat: refresh Whale dark palette** — better contrast and layer separation in the TUI (closes #2197)
- **feat: auto-collapse finished sub-agents** — completed sub-agents collapse automatically in sidebar (closes #2195)
- **feat: shell-running chip in footer** — shows '⏳ shell running' when background shell tasks are active (closes #2194)
- **fix: Esc in model picker** — Esc now applies the last-highlighted choice instead of reverting (closes #2196)
- **fix: bump qs to >=6.15.2** — addresses CVE-2026-8723 in feishu-bridge deps (closes #2198)

## Changed files
- `crates/tui/src/config.rs` — model name casing
- `crates/tui/src/palette.rs` — Whale dark palette
- `crates/tui/src/tui/sidebar.rs` — auto-collapse sub-agents
- `crates/tui/src/tui/footer_ui.rs` — shell running chip
- `crates/tui/src/tui/model_picker.rs` — Esc fix
- `crates/tui/src/tui/widgets/footer.rs` + `mod.rs` — shell chip widget
- `integrations/feishu-bridge/package.json` + `package-lock.json` — CVE bump

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR bundles six quick fixes for v0.8.46: a model-name casing preservation, a refreshed TUI dark palette, auto-collapse of finished sub-agents in the sidebar, a "shell running" footer chip, an Esc-applies behavior change in the model picker, and a `qs` CVE bump in the Feishu integration.

- `config.rs` adds a case-preservation guard so user-supplied casing (e.g. `DeepSeek-V4-Flash`) is passed through unchanged to the API, with compact aliases still rewritten.
- `model_picker.rs` changes Esc to always emit the current selection instead of silently closing, leaving `selection_touched` set but no longer read.
- `sidebar.rs` skips detail lines for `"done"` agents, keeping the sidebar compact; `footer.rs` and `footer_ui.rs` wire in a new `⏳ shell running` chip visible when a foreground shell command is active.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; all changes are well-scoped UI and config fixes with no data-path regressions.

The behavioral changes are straightforward and correctly implemented. The `selection_touched` field in the model picker is now written but never read — dead code left over from the Esc refactor. The redundant `||` condition in the casing guard and the shell-chip ordering difference between the two footer functions are minor inconsistencies that don't affect correctness under normal use.

crates/tui/src/tui/footer_ui.rs — shell chip is appended last in footer_auxiliary_spans, making it the first item dropped under width pressure, which is inconsistent with its "always visible" treatment in render_footer_from.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/tui/src/config.rs | Adds case-preservation guard in normalize_model_name_for_provider; the two OR'd conditions are logically redundant (canonical is always lowercase), but the behavior is correct. |
| crates/tui/src/tui/model_picker.rs | Esc now always emits EmitAndClose; selection_touched field is still set in Up/Down handlers but is no longer read anywhere. |
| crates/tui/src/tui/sidebar.rs | Auto-collapse for done agents implemented cleanly; continue placed after header line push and before detail lines, max_rows boundary still respected. |
| crates/tui/src/tui/footer_ui.rs | Shell chip prepended (highest priority) in render_footer_from but appended last (lowest priority, dropped first) in footer_auxiliary_spans — ordering is inconsistent with the stated "always visible" intent. |
| crates/tui/src/tui/widgets/footer.rs | New footer_shell_chip function is clean; returns empty Vec when inactive, styled span when active. |
| crates/tui/src/palette.rs | Palette constants updated with improved contrast values; trailing newline at EOF was removed. |
| integrations/feishu-bridge/package.json | qs override added to >=6.15.2 to address CVE-2026-8723; package-lock updated to match. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph ModelPicker["Model Picker — handle_key"]
        A[KeyCode::Esc] --> C[EmitAndClose: build_event]
        B[KeyCode::Enter] --> C
        C --> D[ModelPickerApplied\ncurrent model + effort\nprevious model + effort]
    end

    subgraph Normalize["normalize_model_name_for_provider"]
        G[provider + model input] --> H{DeepSeek provider?}
        H -- No --> I[model_for_provider wrap]
        H -- Yes --> J[canonical lookup]
        J -- None --> K[return normalized string]
        J -- Found --> L{case-insensitive match?}
        L -- Yes --> M[return normalized\npreserve user casing]
        L -- No --> N[return canonical\nrewrite alias]
    end

    subgraph Sidebar["subagent_panel_lines"]
        O[iterate rows] --> P{status == done?}
        P -- Yes --> Q[header line only\nskip detail lines]
        P -- No --> R[header + detail lines]
    end

    subgraph FooterChip["Shell chip placement"]
        S[render_footer_from] --> T[shell chip prepended first]
        U[footer_auxiliary_spans] --> V[shell chip appended last\ndropped first under width pressure]
    end
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/tui/src/tui/model_picker.rs`, line 60-65 ([link](https://github.com/hmbown/codewhale/blob/7932278179575390aa77ad02053bbcc9cf27b5b7/crates/tui/src/tui/model_picker.rs#L60-L65)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> `selection_touched` is now a write-only field — it is set in the Up/Down handlers but is no longer read anywhere since the Esc branch was unified. The struct comment on `selected_model_idx` ("clean Esc-to-cancel") is also stale. Both can be cleaned up to avoid confusion for future readers.

   

   <a href="https://app.greptile.com/api/ide/devin?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fv0.8.46%2Fquick-fixes%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fv0.8.46%2Fquick-fixes%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fmodel_picker.rs%0ALine%3A%2060-65%0A%0AComment%3A%0A%60selection_touched%60%20is%20now%20a%20write-only%20field%20%E2%80%94%20it%20is%20set%20in%20the%20Up%2FDown%20handlers%20but%20is%20no%20longer%20read%20anywhere%20since%20the%20Esc%20branch%20was%20unified.%20The%20struct%20comment%20on%20%60selected_model_idx%60%20%28%22clean%20Esc-to-cancel%22%29%20is%20also%20stale.%20Both%20can%20be%20cleaned%20up%20to%20avoid%20confusion%20for%20future%20readers.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Working%20selection%20%28separate%20from%20the%20initial%20values%20so%20we%20can%20offer%20a%0A%20%20%20%20%2F%2F%2F%20non-destructive%20picker%20without%20mutating%20App%20state%20until%20confirmed%29.%0A%20%20%20%20selected_model_idx%3A%20usize%2C%0A%20%20%20%20selected_effort_idx%3A%20usize%2C%0A%20%20%20%20focus%3A%20Pane%2C%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&tid=69448&ts=1779803517&sig=ba088ad1132775096b89ee1f432c81c111d8be3992fed6457d2395a503d8bff6&pr=2212&platform=github&fid=48d83e20-60b9-4dc9-a3dd-4680a1c565a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInDevinDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInDevin.svg?v=3"><img alt="Fix in Devin" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInDevin.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/devin?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fv0.8.46%2Fquick-fixes%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fv0.8.46%2Fquick-fixes%22.%0A%0AFix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Acrates%2Ftui%2Fsrc%2Ftui%2Fmodel_picker.rs%3A60-65%0A%60selection_touched%60%20is%20now%20a%20write-only%20field%20%E2%80%94%20it%20is%20set%20in%20the%20Up%2FDown%20handlers%20but%20is%20no%20longer%20read%20anywhere%20since%20the%20Esc%20branch%20was%20unified.%20The%20struct%20comment%20on%20%60selected_model_idx%60%20%28%22clean%20Esc-to-cancel%22%29%20is%20also%20stale.%20Both%20can%20be%20cleaned%20up%20to%20avoid%20confusion%20for%20future%20readers.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Working%20selection%20%28separate%20from%20the%20initial%20values%20so%20we%20can%20offer%20a%0A%20%20%20%20%2F%2F%2F%20non-destructive%20picker%20without%20mutating%20App%20state%20until%20confirmed%29.%0A%20%20%20%20selected_model_idx%3A%20usize%2C%0A%20%20%20%20selected_effort_idx%3A%20usize%2C%0A%20%20%20%20focus%3A%20Pane%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0Acrates%2Ftui%2Fsrc%2Fconfig.rs%3A427-431%0AThe%20two%20branches%20of%20the%20%60%7C%7C%60%20are%20logically%20identical%20when%20%60canonical%60%20is%20always%20a%20lowercase%20%60%26'static%20str%60%20literal.%20%60canonical.eq_ignore_ascii_case%28%26normalized%29%60%20is%20true%20exactly%20when%20%60normalized.to_ascii_lowercase%28%29%20%3D%3D%20canonical%60%2C%20so%20the%20second%20arm%20is%20redundant.%20Simplifying%20to%20one%20condition%20removes%20the%20confusion.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20if%20canonical.eq_ignore_ascii_case%28%26normalized%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20Some%28normalized%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Acrates%2Ftui%2Fsrc%2Ftui%2Ffooter_ui.rs%3A610-618%0AIn%20%60render_footer_from%60%20the%20shell%20chip%20is%20prepended%20to%20%60extra%60%20so%20it%20appears%20before%20every%20user-configured%20item%2C%20consistent%20with%20the%20comment%20%22visible%20regardless%20of%20user-configured%20status%20items.%22%20In%20%60footer_auxiliary_spans%60%2C%20however%2C%20%60shell_spans%60%20is%20placed%20last%20in%20%60parts%60%2C%20making%20it%20the%20first%20candidate%20to%20be%20dropped%20when%20width%20is%20tight%20%E2%80%94%20the%20opposite%20priority.%20If%20the%20chip%20should%20remain%20visible%20under%20width%20pressure%20here%20too%2C%20it%20should%20be%20moved%20earlier%20in%20the%20slice.%0A%0A%60%60%60suggestion%0A%20%20%20%20let%20parts%3A%20Vec%3C%26Vec%3CSpan%3C'static%3E%3E%3E%20%3D%20%5B%0A%20%20%20%20%20%20%20%20%26shell_spans%2C%0A%20%20%20%20%20%20%20%20%26coherence_spans%2C%0A%20%20%20%20%20%20%20%20%26agents_spans%2C%0A%20%20%20%20%20%20%20%20%26replay_spans%2C%0A%20%20%20%20%20%20%20%20%26prefix_spans%2C%0A%20%20%20%20%20%20%20%20%26cache_spans%2C%0A%20%20%20%20%20%20%20%20%26cost_spans%2C%0A%20%20%20%20%5D%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%204%0Acrates%2Ftui%2Fsrc%2Fpalette.rs%3A2063%0AThe%20final%20%60%7D%60%20is%20missing%20a%20trailing%20newline%20%28%60%5C%20No%20newline%20at%20end%20of%20file%60%20in%20the%20diff%29.%20%60rustfmt%60%20and%20most%20editor%20integrations%20will%20keep%20re-flagging%20this%3B%20worth%20adding%20the%20newline%20back.%0A%0A&repo=hmbown%2Fcodewhale&tid=69448&ts=1779803508&sig=c7f2809c00e27fc6b31dc6e48b5039f927dc80d9a81d4e1aa5507482f27c1bc5&pr=2212&platform=github&fid=66df3ca2-27ec-49cc-95f7-3e12ac82e919"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInDevinDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInDevin.svg?v=3"><img alt="Fix All in Devin" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInDevin.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix: preserve model name casing in norma..."](https://github.com/hmbown/codewhale/commit/7932278179575390aa77ad02053bbcc9cf27b5b7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33938272)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->