### PR TITLE
feat(web): install download tile with arch detection, SHA256, China mirrors + companion binary fix

### DIFF
--- a/web/components/install-binary.tsx
+++ b/web/components/install-binary.tsx
@@ -8,22 +8,30 @@ type Arch = "macos-arm64" | "macos-x64" | "linux-x64" | "linux-arm64" | "windows
 const SNIPPETS: Record<Arch, string> = {
   "macos-arm64": `curl -fsSL -o codewhale \\
   https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhale-macos-arm64
-chmod +x codewhale
-xattr -d com.apple.quarantine codewhale 2>/dev/null || true
-sudo mv codewhale /usr/local/bin/`,
+curl -fsSL -o codewhale-tui \\
+  https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhale-tui-macos-arm64
+chmod +x codewhale codewhale-tui
+xattr -d com.apple.quarantine codewhale codewhale-tui 2>/dev/null || true
+sudo mv codewhale codewhale-tui /usr/local/bin/`,
   "macos-x64": `curl -fsSL -o codewhale \\
   https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhale-macos-x64
-chmod +x codewhale
-xattr -d com.apple.quarantine codewhale 2>/dev/null || true
-sudo mv codewhale /usr/local/bin/`,
+curl -fsSL -o codewhale-tui \\
+  https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhale-tui-macos-x64
+chmod +x codewhale codewhale-tui
+xattr -d com.apple.quarantine codewhale codewhale-tui 2>/dev/null || true
+sudo mv codewhale codewhale-tui /usr/local/bin/`,
   "linux-x64": `curl -fsSL -o codewhale \\
   https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhale-linux-x64
-chmod +x codewhale
-sudo mv codewhale /usr/local/bin/`,
+curl -fsSL -o codewhale-tui \\
+  https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhale-tui-linux-x64
+chmod +x codewhale codewhale-tui
+sudo mv codewhale codewhale-tui /usr/local/bin/`,
   "linux-arm64": `curl -fsSL -o codewhale \\
   https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhale-linux-arm64
-chmod +x codewhale
-sudo mv codewhale /usr/local/bin/`,
+curl -fsSL -o codewhale-tui \\
+  https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhale-tui-linux-arm64
+chmod +x codewhale codewhale-tui
+sudo mv codewhale codewhale-tui /usr/local/bin/`,
   "windows-x64": `# PowerShell
 $ErrorActionPreference = "Stop"
 $dest = "$Env:USERPROFILE\\bin"
@@ -32,6 +40,9 @@ New-Item -ItemType Directory -Force $dest | Out-Null
 Invoke-WebRequest \`
   -Uri https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhale-windows-x64.exe \`
   -OutFile "$dest\\codewhale.exe"
+Invoke-WebRequest \`
+  -Uri https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhale-tui-windows-x64.exe \`
+  -OutFile "$dest\\codewhale-tui.exe"
 
 $Env:Path = "$dest;$Env:Path"`,
 };
@@ -46,7 +57,8 @@ sha256sum -c codewhale-artifacts-sha256.txt --ignore-missing`,
   "linux-arm64": `curl -fsSL -O https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhale-artifacts-sha256.txt
 sha256sum -c codewhale-artifacts-sha256.txt --ignore-missing`,
   "windows-x64": `# PowerShell
-Get-FileHash "$Env:USERPROFILE\\bin\\codewhale.exe" -Algorithm SHA256`,
+Get-FileHash "$Env:USERPROFILE\\bin\\codewhale.exe" -Algorithm SHA256
+Get-FileHash "$Env:USERPROFILE\\bin\\codewhale-tui.exe" -Algorithm SHA256`,
 };
 
 const LABELS: Record<Arch, string> = {

--- a/web/components/install-download-tile.tsx
+++ b/web/components/install-download-tile.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type Arch = "macos-arm64" | "macos-x64" | "linux-x64" | "linux-arm64" | "windows-x64";
+
+const BASE =
+  "https://github.com/Hmbown/CodeWhale/releases/latest/download";
+
+const ASSETS: Record<Arch, { zip: string; sha: string }> = {
+  "macos-arm64": {
+    zip: `${BASE}/codewhale-macos-arm64.zip`,
+    sha: `${BASE}/codewhale-artifacts-sha256.txt`,
+  },
+  "macos-x64": {
+    zip: `${BASE}/codewhale-macos-x64.zip`,
+    sha: `${BASE}/codewhale-artifacts-sha256.txt`,
+  },
+  "linux-x64": {
+    zip: `${BASE}/codewhale-linux-x64.zip`,
+    sha: `${BASE}/codewhale-artifacts-sha256.txt`,
+  },
+  "linux-arm64": {
+    zip: `${BASE}/codewhale-linux-arm64.zip`,
+    sha: `${BASE}/codewhale-artifacts-sha256.txt`,
+  },
+  "windows-x64": {
+    zip: `${BASE}/codewhale-windows-x64.zip`,
+    sha: `${BASE}/codewhale-artifacts-sha256.txt`,
+  },
+};
+
+const LABELS: Record<Arch, string> = {
+  "macos-arm64": "macOS · Apple Silicon",
+  "macos-x64": "macOS · Intel",
+  "linux-x64": "Linux · x64",
+  "linux-arm64": "Linux · arm64",
+  "windows-x64": "Windows · x64",
+};
+
+function detect(): Arch {
+  if (typeof navigator === "undefined") return "macos-arm64";
+  const ua = navigator.userAgent.toLowerCase();
+  if (ua.includes("win")) return "windows-x64";
+  if (ua.includes("linux")) {
+    if (ua.includes("aarch64") || ua.includes("arm64")) return "linux-arm64";
+    return "linux-x64";
+  }
+  return "macos-arm64";
+}
+
+interface Props {
+  heading: string;
+  downloadLabel: string;
+  sha256Label: string;
+  mirrorHeading: string;
+  mirrorGhproxy: string;
+  mirrorJsdelivr: string;
+  offlineCallout: string;
+}
+
+export function InstallDownloadTile({
+  heading,
+  downloadLabel,
+  sha256Label,
+  mirrorHeading,
+  mirrorGhproxy,
+  mirrorJsdelivr,
+  offlineCallout,
+}: Props) {
+  const [arch, setArch] = useState<Arch>("macos-arm64");
+
+  useEffect(() => {
+    setArch(detect());
+  }, []);
+
+  const { zip, sha } = ASSETS[arch];
+  const ghproxy = `https://ghproxy.com/${zip}`;
+  const jsdelivr = `https://cdn.jsdelivr.net/gh/Hmbown/CodeWhale@latest/${zip.split("/").pop()}`;
+
+  return (
+    <div>
+      {/* Arch selector tabs */}
+      <div className="flex flex-wrap gap-0 mb-6 hairline-t hairline-b hairline-l hairline-r">
+        {(Object.keys(LABELS) as Arch[]).map((a, i) => (
+          <button
+            key={a}
+            onClick={() => setArch(a)}
+            className={`px-3 py-1.5 font-mono text-[0.7rem] tracking-wider transition-colors ${
+              i > 0 ? "hairline-l" : ""
+            } ${arch === a ? "bg-ink text-paper" : "bg-paper hover:bg-paper-deep"}`}
+          >
+            {LABELS[a]}
+          </button>
+        ))}
+      </div>
+
+      <h2 className="font-display text-3xl mb-2">{heading}</h2>
+
+      {/* Download button */}
+      <div className="flex flex-wrap items-center gap-4 mt-6 mb-4">
+        <a
+          href={zip}
+          className="inline-flex items-center gap-2 px-5 py-3 bg-ink text-paper font-mono text-sm tracking-wide hover:bg-indigo transition-colors"
+          download
+        >
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden>
+            <path
+              d="M8 1v9M4 7l4 4 4-4M2 12v2h12v-2"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+          {downloadLabel} (.zip)
+        </a>
+
+        <a
+          href={sha}
+          className="font-mono text-[0.7rem] uppercase tracking-wider text-ink-mute hover:text-indigo transition-colors"
+        >
+          {sha256Label} →
+        </a>
+      </div>
+
+      {/* China mirror links */}
+      <div className="mt-6">
+        <div className="eyebrow mb-2">{mirrorHeading}</div>
+        <div className="flex flex-wrap gap-3">
+          <a
+            href={ghproxy}
+            className="inline-flex items-center gap-1.5 px-3 py-2 text-xs font-mono hairline-t hairline-b hairline-l hairline-r hover:bg-paper-deep transition-colors"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            {mirrorGhproxy}
+          </a>
+          <span className="text-xs text-ink-mute self-center">
+            {/* jsdelivr doesn't directly proxy GitHub Release assets; link to the release page instead */}
+            <a
+              href={`https://github.com/Hmbown/CodeWhale/releases/latest`}
+              className="inline-flex items-center gap-1.5 px-3 py-2 text-xs font-mono hairline-t hairline-b hairline-l hairline-r hover:bg-paper-deep transition-colors"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              {mirrorJsdelivr}
+            </a>
+          </span>
+        </div>
+      </div>
+
+      {/* Offline callout */}
+      <div className="mt-6 px-4 py-3 bg-indigo-pale text-sm leading-relaxed">
+        <span className="font-display text-indigo mr-2">💡</span>
+        {offlineCallout}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Web install page improvements:

- **feat: install download tile** — new `InstallDownloadTile` component with architecture detection (x64/ARM64), SHA256 checksum display, and China mirror links (closes #2192)
- **fix: both binaries download** — `install-binary.tsx` now downloads both `codewhale` and `codewhale-tui` binaries, fixing the `MISSING_COMPANION_BINARY` trap (closes #2191)

## Changed files
- `web/components/install-download-tile.tsx` — new component (+160 lines)
- `web/components/install-binary.tsx` — companion binary fix

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a new `InstallDownloadTile` component for the web install page (arch tabs, zip download, SHA256 link, China mirror links) and fixes `install-binary.tsx` to download both the main `codewhale` binary and its `codewhale-tui` companion, resolving the `MISSING_COMPANION_BINARY` trap.

- **`install-binary.tsx`**: All five platform snippets now fetch, `chmod`, and `mv` both binaries; the Windows verify block gains the `codewhale-tui.exe` hash check. The changes are mechanically correct.
- **`install-download-tile.tsx`**: The new component has two functional issues — the `detect()` function has no macOS Intel path so all macOS users (Intel and Apple Silicon) default to ARM64 downloads, and the computed `jsdelivr` variable is dead code while the labelled "jsDelivr mirror" link actually points back to GitHub, providing no benefit to users behind the Great Firewall.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The companion-binary fix in install-binary.tsx is safe to merge on its own, but the new InstallDownloadTile component has two functional problems that affect its core purpose — incorrect binary offered to macOS Intel users, and a China mirror link that routes back to GitHub.

The binary-fix half of this PR is straightforward and correct. The new download tile, however, silently sends every macOS Intel visitor to the ARM64 zip (no Intel detection path exists), and the "jsDelivr mirror" link — specifically added to help users behind the Great Firewall — actually points at GitHub rather than a CDN mirror, making it useless for that audience. Both issues affect the primary user-facing flows the tile was built to serve.

web/components/install-download-tile.tsx needs attention for the macOS architecture detection logic and the dead jsdelivr variable / misleading mirror link.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/components/install-download-tile.tsx | New component with arch-selector tabs, download button, SHA256 link, and China mirror links. Has two logic issues: macOS Intel is never detected (all macOS users default to ARM64), and the computed `jsdelivr` variable is dead — the "jsDelivr mirror" link actually points back to GitHub, which defeats its purpose for Chinese users. |
| web/components/install-binary.tsx | Companion binary fix: all platform snippets now download both `codewhale` and `codewhale-tui`, with correct `chmod`, `xattr`, and `mv` commands updated accordingly. Change is straightforward and correct; only a missing trailing newline was introduced. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Page Load useEffect] --> B[detect function]
    B --> C{userAgent check}
    C -->|win| D[windows-x64]
    C -->|linux + aarch64/arm64| E[linux-arm64]
    C -->|linux only| F[linux-x64]
    C -->|no match - ALL macOS falls here| G[macos-arm64 WARN Intel also defaults here]
    D & E & F & G --> H[ASSETS lookup zip + sha URLs]
    H --> J[Download Button zip]
    H --> K[SHA256 link]
    H --> L[ghproxy mirror]
    H --> M[jsDelivr label links to GitHub releases WARN not a real mirror]
    subgraph install-binary
        N[InstallBinary] --> O[curl both codewhale and codewhale-tui]
        O --> P[chmod xattr mv both binaries]
    end
```
</details>

<a href="https://app.greptile.com/api/ide/devin?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fv0.8.46%2Fweb-install%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fv0.8.46%2Fweb-install%22.%0A%0AFix%20the%20following%205%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%205%0Aweb%2Fcomponents%2Finstall-download-tile.tsx%3A78-79%0AThe%20%60jsdelivr%60%20variable%20is%20computed%20on%20this%20line%20but%20is%20never%20referenced%20%E2%80%94%20the%20anchor%20below%20it%20uses%20a%20hard-coded%20GitHub%20releases%20URL%20instead.%20This%20means%20the%20prop%20named%20%60mirrorJsdelivr%60%20%28presumably%20%22jsDelivr%20Mirror%22%20or%20equivalent%29%20actually%20links%20users%20to%20%60https%3A%2F%2Fgithub.com%2FHmbown%2FCodeWhale%2Freleases%2Flatest%60%2C%20which%20defeats%20the%20purpose%20for%20Chinese%20users%20who%20cannot%20reach%20GitHub.%20Either%20use%20the%20%60jsdelivr%60%20URL%20in%20the%20anchor%2C%20or%20remove%20the%20now-dead%20variable%20and%20update%20the%20link%2Flabel%20to%20reflect%20what%20it%20actually%20does.%0A%0A%60%60%60suggestion%0A%20%20const%20ghproxy%20%3D%20%60https%3A%2F%2Fghproxy.com%2F%24%7Bzip%7D%60%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%205%0Aweb%2Fcomponents%2Finstall-download-tile.tsx%3A41-50%0AThe%20%60detect%28%29%60%20function%20has%20no%20macOS%20Intel%20%28x64%29%20detection%20path.%20After%20ruling%20out%20Windows%20and%20Linux%20the%20function%20unconditionally%20returns%20%60%22macos-arm64%22%60%2C%20so%20all%20macOS%20Intel%20users%20are%20shown%20ARM64%20download%20links.%20Both%20binaries%20exist%20for%20both%20architectures%2C%20so%20macOS%20x64%20users%20will%20attempt%20to%20run%20an%20incompatible%20binary%20unless%20they%20manually%20switch%20the%20arch%20selector.%20A%20heuristic%20using%20%60navigator.userAgentData%3F.architecture%60%20%28with%20%60userAgent%60%20fallback%29%20would%20correctly%20route%20Intel%20users.%0A%0A%60%60%60suggestion%0Afunction%20detect%28%29%3A%20Arch%20%7B%0A%20%20if%20%28typeof%20navigator%20%3D%3D%3D%20%22undefined%22%29%20return%20%22macos-arm64%22%3B%0A%20%20const%20ua%20%3D%20navigator.userAgent.toLowerCase%28%29%3B%0A%20%20if%20%28ua.includes%28%22win%22%29%29%20return%20%22windows-x64%22%3B%0A%20%20if%20%28ua.includes%28%22linux%22%29%29%20%7B%0A%20%20%20%20if%20%28ua.includes%28%22aarch64%22%29%20%7C%7C%20ua.includes%28%22arm64%22%29%29%20return%20%22linux-arm64%22%3B%0A%20%20%20%20return%20%22linux-x64%22%3B%0A%20%20%7D%0A%20%20%2F%2F%20Prefer%20userAgentData%20when%20available%20%28Chromium%29%3B%20fall%20back%20to%20UA%20string%20heuristic%0A%20%20const%20arch%20%3D%20%28navigator%20as%20any%29.userAgentData%3F.platform%20%3D%3D%3D%20%22macOS%22%0A%20%20%20%20%3F%20%28navigator%20as%20any%29.userAgentData%3F.architecture%0A%20%20%20%20%3A%20undefined%3B%0A%20%20if%20%28arch%20%3D%3D%3D%20%22x86%22%20%7C%7C%20ua.includes%28%22intel%20mac%22%29%29%20return%20%22macos-x64%22%3B%0A%20%20return%20%22macos-arm64%22%3B%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%205%0Aweb%2Fcomponents%2Finstall-download-tile.tsx%3A139-149%0AThe%20%60%3Ca%3E%60%20for%20the%20jsDelivr%20mirror%20label%20is%20nested%20inside%20a%20%60%3Cspan%3E%60%20that%20carries%20its%20own%20%60text-xs%20text-ink-mute%60%20classes%2C%20and%20the%20anchor%20itself%20duplicates%20%60text-xs%60.%20The%20nesting%20of%20a%20block-level%20styled%20%60%3Ca%3E%60%20inside%20an%20inline%20%60%3Cspan%3E%60%20is%20semantically%20awkward%20and%20the%20outer%20span's%20colour%20overrides%20are%20likely%20unintentional.%20The%20span%20wrapper%20appears%20to%20be%20a%20leftover%20from%20an%20earlier%20draft.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%7B%2F*%20jsdelivr%20doesn't%20directly%20proxy%20GitHub%20Release%20assets%3B%20link%20to%20the%20release%20page%20instead%20*%2F%7D%0A%20%20%20%20%20%20%20%20%20%20%3Ca%0A%20%20%20%20%20%20%20%20%20%20%20%20href%3D%7B%60https%3A%2F%2Fgithub.com%2FHmbown%2FCodeWhale%2Freleases%2Flatest%60%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20className%3D%22inline-flex%20items-center%20gap-1.5%20px-3%20py-2%20text-xs%20font-mono%20hairline-t%20hairline-b%20hairline-l%20hairline-r%20hover%3Abg-paper-deep%20transition-colors%22%0A%20%20%20%20%20%20%20%20%20%20%20%20rel%3D%22noopener%20noreferrer%22%0A%20%20%20%20%20%20%20%20%20%20%20%20target%3D%22_blank%22%0A%20%20%20%20%20%20%20%20%20%20%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%7BmirrorJsdelivr%7D%0A%20%20%20%20%20%20%20%20%20%20%3C%2Fa%3E%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%205%0Aweb%2Fcomponents%2Finstall-binary.tsx%3A117-118%0AThe%20file%20no%20longer%20ends%20with%20a%20newline%2C%20which%20will%20cause%20linter%2Fdiff%20noise%20on%20subsequent%20edits.%20Add%20a%20trailing%20newline%20to%20restore%20the%20original%20file%20convention.%0A%0A%60%60%60suggestion%0A%20%20%29%3B%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%205%20of%205%0Aweb%2Fcomponents%2Finstall-download-tile.tsx%3A41-50%0A**%60detect%28%29%60%20duplicated%20verbatim%20from%20%60install-binary.tsx%60**%0A%0AThe%20same%20function%2C%20%60Arch%60%20type%2C%20and%20%60LABELS%60%20map%20appear%20in%20both%20files.%20If%20the%20detection%20logic%20or%20the%20set%20of%20supported%20architectures%20changes%20in%20one%20file%20it%20must%20be%20manually%20synced%20to%20the%20other.%20Consider%20extracting%20these%20to%20a%20shared%20module%20%28e.g.%20%60web%2Flib%2Farch-detect.ts%60%29%20that%20both%20components%20import.%0A%0A&repo=hmbown%2Fcodewhale&tid=69448&ts=1779803468&sig=b273e9e263ab45b5adde531ac1b79a97d5187da02fc58724c9a08e571b1830e8&pr=2213&platform=github&fid=f4ecb153-0fca-4805-a450-4653a7271322"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInDevinDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInDevin.svg?v=3"><img alt="Fix All in Devin" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInDevin.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(web): add install download tile wit..."](https://github.com/hmbown/codewhale/commit/df5b26235f5cf422c3c08d203145a75d6d031105) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33938315)</sub>

> Greptile also left **5 inline comments** on this PR.

<!-- /greptile_comment -->