### PR TITLE
feat(release): bundle platform archives with install scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,6 +223,104 @@ jobs:
         with:
           name: ${{ matrix.artifact_name }}
           path: ${{ matrix.artifact_name }}
+
+  bundle:
+    needs: [build, resolve]
+    if: ${{ !cancelled() && needs.build.result == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve.outputs.source_ref }}
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: 'codewhale*'
+      - name: Create platform archives
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p bundles/checksums
+          MANIFEST="bundles/checksums/codewhale-bundles-sha256.txt"
+          : > "$MANIFEST"
+
+          bundle() {
+            local platform="$1"   # linux-x64, linux-arm64, macos-x64, macos-arm64, windows-x64
+            local cli_src="$2"    # artifact name for codewhale binary
+            local tui_src="$3"    # artifact name for codewhale-tui binary
+            local ext="$4"        # tar.gz or zip
+            local variant="$5"    # '' (standard) or 'portable' (Windows only, no install script)
+            shift 5
+
+            local dir="bundles/codewhale-${platform}${variant:+-}${variant}"
+            mkdir -p "$dir"
+
+            # Copy binaries, stripping platform suffixes
+            local cli_dst="codewhale"
+            local tui_dst="codewhale-tui"
+            if [[ "$platform" == windows-* ]]; then
+              cli_dst="codewhale.exe"
+              tui_dst="codewhale-tui.exe"
+            fi
+            cp "artifacts/${cli_src}/${cli_src}" "$dir/${cli_dst}"
+            cp "artifacts/${tui_src}/${tui_src}" "$dir/${tui_dst}"
+
+            # Add install script (standard variant only)
+            if [[ "$variant" != "portable" ]]; then
+              if [[ "$platform" == windows-* ]]; then
+                cp scripts/release/install.bat "$dir/"
+                # Convert line endings to CRLF for Windows
+                sed -i 's/$/\r/' "$dir/install.bat" 2>/dev/null || true
+              else
+                cp scripts/release/install.sh "$dir/"
+                chmod +x "$dir/install.sh"
+              fi
+            fi
+
+            if [[ "$ext" == "zip" ]]; then
+              (cd bundles && zip -r "codewhale-${platform}${variant:+-}${variant}.zip" "codewhale-${platform}${variant:+-}${variant}/")
+            else
+              tar -czf "bundles/codewhale-${platform}${variant:+-}${variant}.tar.gz" -C bundles "codewhale-${platform}${variant:+-}${variant}/"
+            fi
+
+            local archive="codewhale-${platform}${variant:+-}${variant}.${ext}"
+            sha256sum "bundles/${archive}" | awk '{printf "%s  %s\n", $1, $2}' >> "$MANIFEST"
+            echo "  Created bundles/${archive}"
+          }
+
+          # Platform: linux-x64
+          bundle linux-x64 \
+            codewhale-linux-x64 codewhale-tui-linux-x64 tar.gz ""
+
+          # Platform: linux-arm64
+          bundle linux-arm64 \
+            codewhale-linux-arm64 codewhale-tui-linux-arm64 tar.gz ""
+
+          # Platform: macos-x64
+          bundle macos-x64 \
+            codewhale-macos-x64 codewhale-tui-macos-x64 tar.gz ""
+
+          # Platform: macos-arm64
+          bundle macos-arm64 \
+            codewhale-macos-arm64 codewhale-tui-macos-arm64 tar.gz ""
+
+          # Platform: windows-x64 (standard + portable)
+          bundle windows-x64 \
+            codewhale-windows-x64.exe codewhale-tui-windows-x64.exe zip ""
+          bundle windows-x64 \
+            codewhale-windows-x64.exe codewhale-tui-windows-x64.exe zip "portable"
+
+          echo ""
+          echo "=== Archive checksums ==="
+          cat "$MANIFEST"
+
+      - name: Upload bundle artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: codewhale-bundles
+          path: bundles/*
+          if-no-files-found: error
+
   docker:
     needs: [build, resolve]
     if: ${{ !cancelled() && needs.build.result == 'success' }}
@@ -292,8 +390,8 @@ jobs:
           cache-to: type=gha,mode=max
 
   release:
-    needs: [build, docker, resolve]
-    if: ${{ !cancelled() && needs.build.result == 'success' && needs.docker.result == 'success' }}
+    needs: [build, bundle, docker, resolve]
+    if: ${{ !cancelled() && needs.build.result == 'success' && needs.bundle.result == 'success' && needs.docker.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -365,35 +463,52 @@ jobs:
 
             Both crates are required — `codewhale-cli` produces the `codewhale` dispatcher and `codewhale-tui` produces the interactive runtime that the dispatcher delegates to. Installing only one binary will fail at runtime with a `MISSING_COMPANION_BINARY` error.
 
-            ### Manual download
+            ### Manual download — platform archives (recommended)
 
-            **Both** binaries below must be downloaded for your platform and dropped into the same directory (e.g. `~/.local/bin/`):
+            Each archive below contains **both** the `codewhale` dispatcher and `codewhale-tui` runtime, plus an install script:
 
-            | Platform | Dispatcher | TUI runtime |
+            | Platform | Archive | Install script |
             |---|---|---|
-            | Linux x64 | `codewhale-linux-x64` | `codewhale-tui-linux-x64` |
-            | Linux ARM64 | `codewhale-linux-arm64` | `codewhale-tui-linux-arm64` |
-            | macOS x64 | `codewhale-macos-x64` | `codewhale-tui-macos-x64` |
-            | macOS ARM | `codewhale-macos-arm64` | `codewhale-tui-macos-arm64` |
-            | Windows x64 | `codewhale-windows-x64.exe` | `codewhale-tui-windows-x64.exe` |
+            | Linux x64 | `codewhale-linux-x64.tar.gz` | `install.sh` |
+            | Linux ARM64 | `codewhale-linux-arm64.tar.gz` | `install.sh` |
+            | macOS x64 | `codewhale-macos-x64.tar.gz` | `install.sh` |
+            | macOS ARM | `codewhale-macos-arm64.tar.gz` | `install.sh` |
+            | Windows x64 | `codewhale-windows-x64.zip` | `install.bat` |
+            | Windows x64 (portable) | `codewhale-windows-x64-portable.zip` | — |
 
-            Then `chmod +x` both (Unix) and run `./codewhale`.
+            **Unix (Linux / macOS):**
+            ```bash
+            tar xzf codewhale-<platform>.tar.gz
+            cd codewhale-<platform>
+            ./install.sh
+            ```
 
-            Legacy `deepseek-*` and `deepseek-tui-*` assets are also attached for one release cycle so that existing `deepseek update` invocations on v0.8.40 keep working; they install the deprecation shims, which forward to the canonical binaries.
+            **Windows:**
+            - Extract `codewhale-windows-x64.zip`
+            - Run `install.bat` (copies to `%USERPROFILE%\bin`)
+            - Add `%USERPROFILE%\bin` to your PATH
+
+            The **portable** Windows archive skips the install script — extract and run from any directory.
+
+            Individual binaries are also attached below for scripting and the npm wrapper. Legacy `deepseek-*` and `deepseek-tui-*` assets ship for one release cycle so that existing `deepseek update` invocations on v0.8.40 keep working; they install the deprecation shims, which forward to the canonical binaries.
 
             ### Verify (recommended)
 
-            Download `codewhale-artifacts-sha256.txt` from this Release and verify:
+            Download the checksum manifests from this Release and verify:
 
             ```bash
-            # Linux
+            # Linux — archive bundles
+            sha256sum -c codewhale-bundles-sha256.txt
+
+            # Linux — individual binaries
             sha256sum -c codewhale-artifacts-sha256.txt
 
             # macOS
+            shasum -a 256 -c codewhale-bundles-sha256.txt
             shasum -a 256 -c codewhale-artifacts-sha256.txt
             ```
 
-            The legacy `deepseek-artifacts-sha256.txt` is also attached for backward compatibility and contains the same hashes.
+            The legacy `deepseek-artifacts-sha256.txt` is also attached for backward compatibility and contains the same hashes as the canonical manifest.
 
             ## Changelog
 

--- a/scripts/release/install.bat
+++ b/scripts/release/install.bat
@@ -1,0 +1,38 @@
+@echo off
+setlocal enabledelayedexpansion
+:: CodeWhale Windows installer
+:: Copies codewhale.exe and codewhale-tui.exe to %USERPROFILE%\bin
+
+set "BIN_DIR=%USERPROFILE%\bin"
+set "SCRIPT_DIR=%~dp0"
+
+if not exist "%BIN_DIR%" mkdir "%BIN_DIR%"
+
+echo Installing codewhale to %BIN_DIR%...
+
+copy /Y "%SCRIPT_DIR%codewhale.exe" "%BIN_DIR%\codewhale.exe" >nul
+if %ERRORLEVEL% neq 0 (
+    echo ERROR: Failed to copy codewhale.exe
+    exit /b 1
+)
+
+copy /Y "%SCRIPT_DIR%codewhale-tui.exe" "%BIN_DIR%\codewhale-tui.exe" >nul
+if %ERRORLEVEL% neq 0 (
+    echo ERROR: Failed to copy codewhale-tui.exe
+    exit /b 1
+)
+
+echo.
+echo Done. Both binaries installed to %BIN_DIR%.
+echo.
+echo Add %BIN_DIR% to your PATH:
+echo   1. Open Start, search "environment variables"
+echo   2. Click "Environment Variables..."
+echo   3. Under "User variables", select "Path" and click "Edit"
+echo   4. Click "New" and add: %BIN_DIR%
+echo   5. Click OK, then restart your terminal
+echo.
+echo Or run this in an admin PowerShell:
+echo   [Environment]::SetEnvironmentVariable('Path', [Environment]::GetEnvironmentVariable('Path', 'User') + ';%BIN_DIR%', 'User')
+echo.
+echo Then run: codewhale

--- a/scripts/release/install.sh
+++ b/scripts/release/install.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# CodeWhale Unix installer
+# Copies codewhale and codewhale-tui to ~/.local/bin (or $PREFIX/bin)
+
+PREFIX="${PREFIX:-$HOME/.local}"
+BIN_DIR="${PREFIX}/bin"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+mkdir -p "$BIN_DIR"
+
+echo "Installing codewhale to $BIN_DIR ..."
+
+for bin in codewhale codewhale-tui; do
+    src="$SCRIPT_DIR/$bin"
+    dst="$BIN_DIR/$bin"
+    if [[ ! -f "$src" ]]; then
+        echo "ERROR: $src not found in archive"
+        exit 1
+    fi
+    cp "$src" "$dst"
+    chmod +x "$dst"
+    echo "  $dst"
+done
+
+echo ""
+echo "Done. Both binaries installed to $BIN_DIR."
+
+# Check if BIN_DIR is on PATH
+if [[ ":$PATH:" != *":$BIN_DIR:"* ]]; then
+    echo ""
+    echo "Add $BIN_DIR to your PATH:"
+    echo ""
+    SHELL_NAME="$(basename "${SHELL:-$SHELL}")"
+    case "$SHELL_NAME" in
+        zsh)  RC="$HOME/.zshrc" ;;
+        bash) RC="$HOME/.bashrc" ;;
+        fish) RC="$HOME/.config/fish/config.fish" ;;
+        *)    RC="your shell profile" ;;
+    esac
+    echo "  echo 'export PATH=\"$BIN_DIR:\$PATH\"' >> $RC"
+    echo "  source $RC"
+fi
+
+echo ""
+echo "Then run: codewhale"


### PR DESCRIPTION
## Summary

Replaces loose binary downloads on the GitHub Release page with bundled platform archives containing both `codewhale` and `codewhale-tui` binaries plus install scripts.

Closes #2193.

## Changes

### Release workflow (release.yml)
- **New `bundle` job** — runs after `build`, downloads all `codewhale*` artifacts, creates per-platform archives:
  - `codewhale-linux-x64.tar.gz` / `codewhale-linux-arm64.tar.gz`
  - `codewhale-macos-x64.tar.gz` / `codewhale-macos-arm64.tar.gz`
  - `codewhale-windows-x64.zip` (with `install.bat`)
  - `codewhale-windows-x64-portable.zip` (binaries only, no install script)
- Generates `codewhale-bundles-sha256.txt` manifest
- `release` job updated to depend on `bundle`
- Release notes updated to promote archives as the primary download method

### Install scripts
- **`scripts/release/install.bat`** — Windows installer:
  - Copies both `.exe`s to `%USERPROFILE%\bin`
  - No admin required
  - Prints PATH setup instructions (GUI + PowerShell)
- **`scripts/release/install.sh`** — Unix installer:
  - Copies both binaries to `~/.local/bin` (respects `$PREFIX`)
  - Detects shell and prints the correct rc-file PATH instruction
  - `chmod +x` applied automatically

### What stays the same
- Individual binaries still uploaded (npm wrapper depends on them)
- `codewhale-artifacts-sha256.txt` manifest unchanged
- Legacy `deepseek-*` shims unaffected

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces loose binary downloads on the GitHub Release page with per-platform archives (`.tar.gz` / `.zip`) that bundle both the `codewhale` dispatcher and `codewhale-tui` runtime alongside install scripts, and updates the release notes accordingly.

- **`bundle` job (release.yml)**: a new CI job runs after `build`, creates six archives across four platforms, writes a SHA256 manifest, and uploads everything as a `codewhale-bundles` artifact; the `release` job is updated to gate on it. Two defects exist: the manifest is written into a `checksums/` subdirectory placing it three levels deep under `artifacts/` at release time — outside the `artifacts/*/*` glob used by `softprops/action-gh-release` — so it is never attached to the GitHub Release; and `sha256sum` is invoked with a `bundles/` path prefix embedding that prefix in every checksum entry, causing `sha256sum -c` verification to fail for end users.
- **`install.sh`**: copies both binaries to `~/.local/bin`, detects the shell, and prints the appropriate rc-file command. Fish users receive `export PATH=…` instructions which is bash/zsh syntax that fish does not understand.
- **`install.bat`**: copies both `.exe`s to `%USERPROFILE%\\bin` without requiring admin; a comment incorrectly labels the user-scope `SetEnvironmentVariable` snippet as needing an admin PowerShell session.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The bundle archives themselves are built and uploaded correctly, but the checksum manifest is both unreachable on the release page and contains wrong file paths — meaning the verification story in the release notes is entirely broken on first release.

The bundle archives themselves are built and uploaded correctly, but the checksum manifest is both unreachable on the release page and contains wrong file paths — meaning the verification story in the release notes is entirely broken on first release. Additionally, fish users who run install.sh get PATH instructions that add invalid syntax to their fish config. The binary bundling and upload logic is otherwise sound.

.github/workflows/release.yml needs attention — specifically the manifest output path and the sha256sum invocation. scripts/release/install.sh needs a fish-specific code path.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | New `bundle` job creates per-platform archives and a SHA256 manifest, but the manifest is nested too deeply for the existing `artifacts/*/*` upload glob and the checksum entries embed a `bundles/` path prefix that will break `sha256sum -c` verification. |
| scripts/release/install.sh | Unix installer correctly copies both binaries and sets execute permissions; fish shell PATH guidance emits `export PATH=` syntax that fish does not understand, and `${SHELL:-$SHELL}` is a no-op fallback. |
| scripts/release/install.bat | Windows installer correctly copies both `.exe`s to `%USERPROFILE%\bin` without requiring admin; misleadingly labels the user-scope `SetEnvironmentVariable` PowerShell snippet as needing an admin shell. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant build as build job
    participant bundle as bundle job
    participant docker as docker job
    participant release as release job
    participant GHRelease as GitHub Release

    build->>bundle: "artifacts: codewhale*"
    build->>docker: (parallel)
    bundle->>bundle: Create platform archives (tar.gz / zip)
    bundle->>bundle: Generate codewhale-bundles-sha256.txt
    bundle->>bundle: Upload artifact: codewhale-bundles
    bundle->>release: success signal
    docker->>release: success signal
    release->>release: "download-artifact pattern:'*'"
    release->>release: Generate codewhale-artifacts-sha256.txt
    release->>GHRelease: "upload files: artifacts/*/*"
    Note over release,GHRelease: archives at artifacts/codewhale-bundles/*.tar.gz matched
    Note over release,GHRelease: manifest at artifacts/codewhale-bundles/checksums/*.txt NOT matched
```
</details>

<a href="https://app.greptile.com/api/ide/devin?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fv0.8.46%2Frelease-zip%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fv0.8.46%2Frelease-zip%22.%0A%0AFix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0A.github%2Fworkflows%2Frelease.yml%3A303%0A**Checksum%20manifest%20won't%20reach%20the%20GitHub%20Release%20page**%0A%0AThe%20manifest%20is%20written%20to%20%60bundles%2Fchecksums%2Fcodewhale-bundles-sha256.txt%60.%20After%20the%20artifact%20is%20downloaded%20in%20the%20%60release%60%20job%20it%20lands%20at%20%60artifacts%2Fcodewhale-bundles%2Fchecksums%2Fcodewhale-bundles-sha256.txt%60%20%E2%80%94%20three%20levels%20deep.%20The%20upload%20to%20%60softprops%2Faction-gh-release%60%20uses%20%60files%3A%20artifacts%2F*%2F*%60%2C%20which%20only%20matches%20exactly%20two%20levels.%20Any%20path%20at%20a%20third%20level%20is%20silently%20skipped%2C%20so%20%60codewhale-bundles-sha256.txt%60%20is%20never%20attached%20to%20the%20release%2C%20yet%20the%20release%20notes%20direct%20users%20to%20download%20and%20%60sha256sum%20-c%60%20it.%0A%0A%23%23%23%20Issue%202%20of%204%0A.github%2Fworkflows%2Frelease.yml%3A286-287%0A**Checksum%20entries%20embed%20a%20%60bundles%2F%60%20path%20prefix%20%E2%80%94%20verification%20will%20always%20fail**%0A%0A%60sha256sum%20%22bundles%2F%24%7Barchive%7D%22%60%20outputs%20%60%3Chash%3E%20%20bundles%2Fcodewhale-linux-x64.tar.gz%60.%20After%20awk%20the%20manifest%20keeps%20the%20same%20path.%20When%20a%20user%20downloads%20the%20archive%20and%20the%20manifest%20into%20the%20same%20directory%20and%20runs%20%60sha256sum%20-c%20codewhale-bundles-sha256.txt%60%2C%20the%20tool%20looks%20for%20the%20file%20at%20%60bundles%2Fcodewhale-linux-x64.tar.gz%60%20%28a%20subdirectory%20that%20doesn't%20exist%29%20and%20exits%20non-zero.%20Run%20%60sha256sum%60%20from%20inside%20%60bundles%2F%60%20to%20record%20bare%20filenames%20instead.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20local%20archive%3D%22codewhale-%24%7Bplatform%7D%24%7Bvariant%3A%2B-%7D%24%7Bvariant%7D.%24%7Bext%7D%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%28cd%20bundles%20%26%26%20sha256sum%20%22%24%7Barchive%7D%22%29%20%7C%20awk%20'%7Bprintf%20%22%25s%20%20%25s%5Cn%22%2C%20%241%2C%20%242%7D'%20%3E%3E%20%22%24MANIFEST%22%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Ascripts%2Frelease%2Finstall.sh%3A34-42%0A**Fish%20PATH%20instructions%20emit%20bash%20syntax%20that%20fish%20rejects**%0A%0AWhen%20%60%24SHELL_NAME%60%20is%20%60fish%60%2C%20the%20script%20still%20prints%20%60export%20PATH%3D%22%E2%80%A6%22%60%20%E2%80%94%20which%20is%20bash%2Fzsh%20syntax.%20Fish%20does%20not%20recognise%20%60export%20PATH%3D%60%2C%20so%20any%20user%20who%20follows%20these%20instructions%20adds%20an%20invalid%20line%20to%20%60~%2F.config%2Ffish%2Fconfig.fish%60.%20Their%20PATH%20is%20never%20updated%2C%20and%20opening%20a%20new%20fish%20session%20may%20print%20a%20parse%20error.%20Use%20%60fish_add_path%60%20for%20fish%20users%20instead.%0A%0A%60%60%60suggestion%0A%20%20%20%20SHELL_NAME%3D%22%24%28basename%20%22%24%7BSHELL%3A-%2Fbin%2Fsh%7D%22%29%22%0A%20%20%20%20case%20%22%24SHELL_NAME%22%20in%0A%20%20%20%20%20%20%20%20zsh%29%20%20RC%3D%22%24HOME%2F.zshrc%22%20%3B%3B%0A%20%20%20%20%20%20%20%20bash%29%20RC%3D%22%24HOME%2F.bashrc%22%20%3B%3B%0A%20%20%20%20%20%20%20%20fish%29%0A%20%20%20%20%20%20%20%20%20%20%20%20echo%20%22%20%20fish_add_path%20%24BIN_DIR%22%0A%20%20%20%20%20%20%20%20%20%20%20%20echo%20%22%22%0A%20%20%20%20%20%20%20%20%20%20%20%20echo%20%22Then%20run%3A%20codewhale%22%0A%20%20%20%20%20%20%20%20%20%20%20%20exit%200%0A%20%20%20%20%20%20%20%20%20%20%20%20%3B%3B%0A%20%20%20%20%20%20%20%20*%29%20%20%20%20RC%3D%22your%20shell%20profile%22%20%3B%3B%0A%20%20%20%20esac%0A%20%20%20%20echo%20%22%20%20echo%20'export%20PATH%3D%5C%22%24BIN_DIR%3A%5C%24PATH%5C%22'%20%3E%3E%20%24RC%22%0A%20%20%20%20echo%20%22%20%20source%20%24RC%22%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%204%0Ascripts%2Frelease%2Finstall.bat%3A35%0A**%22Admin%20PowerShell%22%20label%20is%20incorrect**%0A%0AThe%20%60%5BEnvironment%5D%3A%3ASetEnvironmentVariable%28%E2%80%A6%2C%20'User'%29%60%20call%20modifies%20the%20*User*%20environment%20scope%2C%20which%20does%20not%20require%20administrator%20privileges.%20Telling%20users%20to%20open%20an%20admin%20shell%20needlessly%20raises%20the%20risk%20bar%20and%20may%20confuse%20or%20block%20users%20on%20managed%20machines.%20Drop%20the%20word%20%22admin%22.%0A%0A%60%60%60suggestion%0Aecho%20Or%20run%20this%20in%20PowerShell%20%28no%20admin%20required%29%3A%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&tid=69448&ts=1779803784&sig=e10dce32c5411593b3b0f4a4d86c5422cacc250448343a058c1c60e8ed88bc67&pr=2216&platform=github&fid=9128b1f4-8c7a-40f5-866f-3c7b23413c4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInDevinDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInDevin.svg?v=3"><img alt="Fix All in Devin" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInDevin.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(release): bundle platform archives ..."](https://github.com/hmbown/codewhale/commit/3b8c3db5a8e57075ee0a7b70b7a01e7bbea80b05) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33938884)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->