### PR TITLE
  feat(/new): add new session command

### DIFF
--- a/crates/tui/src/commands/core.rs
+++ b/crates/tui/src/commands/core.rs
@@ -46,6 +46,28 @@ pub fn help(app: &mut App, topic: Option<&str>) -> CommandResult {
 
 /// Clear conversation history
 pub fn clear(app: &mut App) -> CommandResult {
+    let todos_cleared = reset_conversation_state(app);
+    app.current_session_id = None;
+    let locale = app.ui_locale;
+    let message = if todos_cleared {
+        tr(locale, MessageId::ClearConversation).to_string()
+    } else {
+        tr(locale, MessageId::ClearConversationBusy).to_string()
+    };
+    CommandResult::with_message_and_action(
+        message,
+        AppAction::SyncSession {
+            session_id: None,
+            messages: Vec::new(),
+            system_prompt: None,
+            model: app.model.clone(),
+            workspace: app.workspace.clone(),
+        },
+    )
+}
+
+/// Reset the active conversation without choosing the next session id.
+pub(crate) fn reset_conversation_state(app: &mut App) -> bool {
     app.clear_history();
     app.mark_history_updated();
     app.api_messages.clear();
@@ -78,23 +100,7 @@ pub fn clear(app: &mut App) -> CommandResult {
     app.session.last_reasoning_replay_tokens = None;
     app.session.turn_cache_history.clear();
     app.session.last_cache_inspection = None;
-    app.current_session_id = None;
-    let locale = app.ui_locale;
-    let message = if todos_cleared {
-        tr(locale, MessageId::ClearConversation).to_string()
-    } else {
-        tr(locale, MessageId::ClearConversationBusy).to_string()
-    };
-    CommandResult::with_message_and_action(
-        message,
-        AppAction::SyncSession {
-            session_id: None,
-            messages: Vec::new(),
-            system_prompt: None,
-            model: app.model.clone(),
-            workspace: app.workspace.clone(),
-        },
-    )
+    todos_cleared
 }
 
 /// Exit the application

--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -299,6 +299,12 @@ pub const COMMANDS: &[CommandInfo] = &[
         description_id: MessageId::CmdForkDescription,
     },
     CommandInfo {
+        name: "new",
+        aliases: &[],
+        usage: "/new [--force]",
+        description_id: MessageId::CmdNewDescription,
+    },
+    CommandInfo {
         name: "sessions",
         aliases: &["resume"],
         usage: "/sessions [show|prune <days>]",
@@ -585,6 +591,7 @@ pub fn execute(cmd: &str, app: &mut App) -> CommandResult {
         "rename" | "gaiming" | "chongmingming" => rename::rename(app, arg),
         "save" => session::save(app, arg),
         "fork" | "branch" => session::fork(app),
+        "new" => session::new_session(app, arg),
         "sessions" | "resume" => session::sessions(app, arg),
         "relay" | "batonpass" | "接力" => relay(app, arg),
         "load" | "jiazai" => session::load(app, arg),

--- a/crates/tui/src/commands/session.rs
+++ b/crates/tui/src/commands/session.rs
@@ -135,6 +135,73 @@ pub fn fork(app: &mut App) -> CommandResult {
     )
 }
 
+/// Start a fresh saved session from the current TUI state.
+pub fn new_session(app: &mut App, arg: Option<&str>) -> CommandResult {
+    let force = match arg.map(str::trim).filter(|s| !s.is_empty()) {
+        None => false,
+        Some("--force" | "force") => true,
+        Some(other) => {
+            return CommandResult::error(format!(
+                "Usage: /new [--force]\n\nUnknown argument: {other}"
+            ));
+        }
+    };
+
+    if !force {
+        let blockers = new_session_blockers(app);
+        if !blockers.is_empty() {
+            return CommandResult::error(format!(
+                "Cannot start a new session while {}. Run `/new --force` to discard pending work and start a fresh session.",
+                blockers.join(", ")
+            ));
+        }
+    }
+
+    let new_id = uuid::Uuid::new_v4().to_string();
+    super::core::reset_conversation_state(app);
+    app.clear_input();
+    app.session_artifacts.clear();
+    app.session_context_references.clear();
+    app.tool_evidence.clear();
+    app.current_session_id = Some(new_id.clone());
+    app.session_title = Some("New Session".to_string());
+    app.scroll_to_bottom();
+
+    CommandResult::with_message_and_action(
+        format!(
+            "Started new session {} (New Session). Previous sessions remain available via /resume.",
+            crate::session_manager::truncate_id(&new_id)
+        ),
+        AppAction::SyncSession {
+            session_id: Some(new_id),
+            messages: Vec::new(),
+            system_prompt: None,
+            model: app.model.clone(),
+            workspace: app.workspace.clone(),
+        },
+    )
+}
+
+fn new_session_blockers(app: &App) -> Vec<&'static str> {
+    let mut blockers = Vec::new();
+    if !app.input.trim().is_empty() {
+        blockers.push("the composer has unsent text");
+    }
+    if !app.queued_messages.is_empty() || app.queued_draft.is_some() {
+        blockers.push("queued messages are pending");
+    }
+    if app.is_loading || app.runtime_turn_status.as_deref() == Some("in_progress") {
+        blockers.push("a turn is in progress");
+    }
+    if app.is_compacting {
+        blockers.push("context compaction is running");
+    }
+    if app.task_panel.iter().any(|task| task.status == "running") {
+        blockers.push("background tasks are running");
+    }
+    blockers
+}
+
 /// Load session from file
 pub fn load(app: &mut App, path: Option<&str>) -> CommandResult {
     let load_path = if let Some(p) = path {
@@ -487,6 +554,110 @@ mod tests {
                 std::env::remove_var("HOME");
             }
         }
+    }
+
+    #[test]
+    fn new_session_from_resumed_state_creates_distinct_empty_session() {
+        let tmpdir = TempDir::new().unwrap();
+        let mut app = create_test_app_with_tmpdir(&tmpdir);
+        app.current_session_id = Some("old-session".to_string());
+        app.session_title = Some("Old Session".to_string());
+        app.api_messages.push(crate::models::Message {
+            role: "user".to_string(),
+            content: vec![crate::models::ContentBlock::Text {
+                text: "continue this thread".to_string(),
+                cache_control: None,
+            }],
+        });
+        app.add_message(HistoryCell::System {
+            content: "old transcript".to_string(),
+        });
+        app.system_prompt = Some(crate::models::SystemPrompt::Text("old prompt".to_string()));
+        app.session.total_tokens = 123;
+        app.session.session_cost = 1.25;
+
+        let result = new_session(&mut app, None);
+
+        assert!(!result.is_error, "{:?}", result.message);
+        let new_id = app.current_session_id.clone().expect("new session id");
+        assert_ne!(new_id, "old-session");
+        assert_eq!(app.session_title.as_deref(), Some("New Session"));
+        assert!(app.api_messages.is_empty());
+        assert!(app.history.is_empty());
+        assert!(app.system_prompt.is_none());
+        assert_eq!(app.session.total_tokens, 0);
+        assert_eq!(app.session.session_cost, 0.0);
+        assert!(
+            result
+                .message
+                .as_deref()
+                .unwrap_or_default()
+                .contains("/resume")
+        );
+        match result.action {
+            Some(AppAction::SyncSession {
+                session_id,
+                messages,
+                system_prompt,
+                ..
+            }) => {
+                assert_eq!(session_id.as_deref(), Some(new_id.as_str()));
+                assert!(messages.is_empty());
+                assert!(system_prompt.is_none());
+            }
+            other => panic!("expected SyncSession action, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn new_session_blocks_unsent_input_without_force() {
+        let tmpdir = TempDir::new().unwrap();
+        let mut app = create_test_app_with_tmpdir(&tmpdir);
+        app.current_session_id = Some("old-session".to_string());
+        app.input = "draft text".to_string();
+
+        let result = new_session(&mut app, None);
+
+        assert!(result.is_error);
+        assert_eq!(app.current_session_id.as_deref(), Some("old-session"));
+        assert_eq!(app.input, "draft text");
+        assert!(result.action.is_none());
+        assert!(
+            result
+                .message
+                .as_deref()
+                .unwrap_or_default()
+                .contains("/new --force")
+        );
+    }
+
+    #[test]
+    fn new_session_force_discards_unsent_input() {
+        let tmpdir = TempDir::new().unwrap();
+        let mut app = create_test_app_with_tmpdir(&tmpdir);
+        app.current_session_id = Some("old-session".to_string());
+        app.input = "draft text".to_string();
+
+        let result = new_session(&mut app, Some("--force"));
+
+        assert!(!result.is_error, "{:?}", result.message);
+        assert_ne!(app.current_session_id.as_deref(), Some("old-session"));
+        assert!(app.input.is_empty());
+        assert!(matches!(result.action, Some(AppAction::SyncSession { .. })));
+    }
+
+    #[test]
+    fn new_session_blocks_in_flight_turn_without_force() {
+        let tmpdir = TempDir::new().unwrap();
+        let mut app = create_test_app_with_tmpdir(&tmpdir);
+        app.current_session_id = Some("old-session".to_string());
+        app.is_loading = true;
+
+        let result = new_session(&mut app, None);
+
+        assert!(result.is_error);
+        assert_eq!(app.current_session_id.as_deref(), Some("old-session"));
+        assert!(result.action.is_none());
     }
 
     #[test]

--- a/crates/tui/src/localization.rs
+++ b/crates/tui/src/localization.rs
@@ -294,6 +294,7 @@ pub enum MessageId {
     CmdRlmDescription,
     CmdSaveDescription,
     CmdForkDescription,
+    CmdNewDescription,
     CmdSessionsDescription,
     CmdSettingsDescription,
     CmdSkillDescription,
@@ -527,6 +528,7 @@ pub const ALL_MESSAGE_IDS: &[MessageId] = &[
     MessageId::CmdReviewDescription,
     MessageId::CmdRlmDescription,
     MessageId::CmdSaveDescription,
+    MessageId::CmdNewDescription,
     MessageId::CmdSessionsDescription,
     MessageId::CmdSettingsDescription,
     MessageId::CmdSkillDescription,
@@ -971,6 +973,7 @@ fn english(id: MessageId) -> &'static str {
         MessageId::CmdRlmDescription => "Open a persistent RLM context: /rlm [0-3] <file_or_text>",
         MessageId::CmdSaveDescription => "Save session to file",
         MessageId::CmdForkDescription => "Fork the active conversation into a sibling session",
+        MessageId::CmdNewDescription => "Start a fresh saved session",
         MessageId::CmdSessionsDescription => "Open session history picker",
         MessageId::CmdSettingsDescription => "Show persistent settings",
         MessageId::CmdSkillDescription => {
@@ -1359,6 +1362,7 @@ fn japanese(id: MessageId) -> Option<&'static str> {
         MessageId::CmdRlmDescription => "永続 RLM コンテキストを開く: /rlm [0-3] <file_or_text>",
         MessageId::CmdSaveDescription => "セッションをファイルに保存",
         MessageId::CmdForkDescription => "現在の会話を兄弟セッションに fork",
+        MessageId::CmdNewDescription => "新しい保存済みセッションを開始",
         MessageId::CmdSessionsDescription => "セッション履歴ピッカーを開く",
         MessageId::CmdSettingsDescription => "永続化された設定を表示",
         MessageId::CmdSkillDescription => {
@@ -1702,6 +1706,7 @@ fn chinese_simplified(id: MessageId) -> Option<&'static str> {
         MessageId::CmdRlmDescription => "打开持久 RLM 上下文：/rlm [0-3] <file_or_text>",
         MessageId::CmdSaveDescription => "将会话保存到文件",
         MessageId::CmdForkDescription => "将当前对话分叉为兄弟会话",
+        MessageId::CmdNewDescription => "开始一个新的已保存会话",
         MessageId::CmdSessionsDescription => "打开会话历史选择器",
         MessageId::CmdSettingsDescription => "显示持久化设置",
         MessageId::CmdSkillDescription => "激活技能，或安装/更新/卸载/信任社区技能",
@@ -2037,6 +2042,7 @@ fn portuguese_brazil(id: MessageId) -> Option<&'static str> {
         }
         MessageId::CmdSaveDescription => "Salvar a sessão em arquivo",
         MessageId::CmdForkDescription => "Bifurcar a conversa ativa para uma sessão irmã",
+        MessageId::CmdNewDescription => "Iniciar uma nova sessão salva",
         MessageId::CmdSessionsDescription => "Abrir seletor de histórico de sessões",
         MessageId::CmdSettingsDescription => "Exibir as configurações persistidas",
         MessageId::CmdSkillDescription => {
@@ -2428,6 +2434,7 @@ fn spanish_latin_america(id: MessageId) -> Option<&'static str> {
         }
         MessageId::CmdSaveDescription => "Guardar la sesión en archivo",
         MessageId::CmdForkDescription => "Bifurcar la conversación activa a una sesión hermana",
+        MessageId::CmdNewDescription => "Iniciar una nueva sesión guardada",
         MessageId::CmdSessionsDescription => "Abrir el selector de sesiones",
         MessageId::CmdSettingsDescription => "Mostrar las configuraciones persistidas",
         MessageId::CmdSkillDescription => {


### PR DESCRIPTION
## Summary

Fixes https://github.com/Hmbown/CodeWhale/issues/2234

  Adds `/new [--force]` as an explicit way to start a fresh saved session from inside the TUI.

  Previously, `/clear` could reset conversation state, but that made session lifecycle behavior ambiguous: clearing a
  transcript is not the same user intent as starting a new saved session after `resume`. `/new` now gives that action its own command.

  This change:
  - adds `/new [--force]` to the command registry, help, and completions
  - creates a distinct new session id and syncs an empty saved session
  - keeps previous sessions available through `/resume`
  - blocks switching when there is unsent input, queued work, an active turn, compaction, or running background tasks
  - allows explicit discard with `/new --force`
  - preserves `/clear` as a cleanup command

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features`
- [x] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces `/new [--force]` as a first-class TUI command for starting a fresh saved session, distinct from `/clear` (which only resets transcript state). It achieves this by extracting the shared state-reset logic from `clear()` into a new `reset_conversation_state()` helper in `core.rs`, then building `new_session()` on top of it with its own blocker guards, a pre-generated UUID session ID, and a `SyncSession` dispatch that persists an empty snapshot.

- `core.rs`: Refactors `clear()` into `clear()` + `reset_conversation_state()`; the observable behaviour of `/clear` is unchanged.
- `session.rs`: Adds `new_session()` with five blocker conditions (unsent input, queued messages, in-flight turn, compaction, running tasks), `--force` override, and four new unit tests; the session title and success message are hardcoded English strings rather than going through the locale system.
- `localization.rs`: Adds `CmdNewDescription` to the enum, `ALL_MESSAGE_IDS`, and all five locale translation functions.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the new command is additive, the /clear refactor is a pure extraction with no behavioural change, and the blocker logic is well-tested.

The refactor of clear() into reset_conversation_state() is low-risk and covered by existing tests. The new_session() logic is straightforward and has four targeted unit tests. The two findings — a hardcoded English session title/message that bypasses the locale system, and an undocumented 'force' shorthand — are cosmetic and do not affect correctness or data integrity.

crates/tui/src/commands/session.rs — the session title and confirmation message are hardcoded English and the undocumented 'force' shorthand is accepted; all other changed files are clean.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/commands/session.rs | Adds new_session() with blocker guards, UUID-based ID creation, state reset, and SyncSession dispatch; session title and confirmation message are hardcoded English; "force" (without --) accepted as undocumented alias |
| crates/tui/src/commands/core.rs | Refactors clear() by extracting shared state-reset logic into reset_conversation_state(); clear() behavior is functionally unchanged, all existing tests still cover the reset path |
| crates/tui/src/commands/mod.rs | Registers /new command in COMMANDS registry and dispatch table; ordering and wiring look correct |
| crates/tui/src/localization.rs | Adds CmdNewDescription to the MessageId enum, ALL_MESSAGE_IDS list, and all five locale translation functions (traditional_chinese delegates to chinese_simplified which is covered); no gaps |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant TUI as TUI (ui.rs)
    participant Cmd as new_session()
    participant Core as reset_conversation_state()
    participant Engine as EngineHandle
    participant Persist as persistence_actor

    User->>TUI: /new [--force]
    TUI->>Cmd: new_session(app, arg)
    alt !force
        Cmd->>Cmd: new_session_blockers(app)
        Note over Cmd: checks unsent input,<br/>queued msgs, is_loading,<br/>is_compacting, running tasks
        Cmd-->>TUI: CommandResult::error (if blocked)
    end
    Cmd->>Core: reset_conversation_state(app)
    Core-->>Cmd: todos_cleared (bool)
    Cmd->>Cmd: app.clear_input() / session_artifacts / context_references / tool_evidence cleared
    Cmd->>Cmd: "app.current_session_id = Some(new_uuid)"
    Cmd-->>TUI: "CommandResult::SyncSession{session_id: Some(new_uuid), messages: []}"
    TUI->>Engine: "Op::SyncSession{session_id: Some(new_uuid), messages: []}"
    TUI->>Persist: PersistRequest::SessionSnapshot (empty, new_uuid)
    TUI->>Persist: PersistRequest::ClearCheckpoint
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fnew-session-command%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fnew-session-command%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fcommands%2Fsession.rs%3A166-174%0AThe%20session%20title%20%60%22New%20Session%22%60%20and%20the%20full%20success%20message%20are%20hardcoded%20English%20strings%20that%20bypass%20the%20locale%20system.%20Every%20other%20command-level%20user-visible%20string%20goes%20through%20%60tr%28locale%2C%20MessageId%3A%3A...%29%60.%20A%20Japanese%20or%20Simplified-Chinese%20user%20who%20runs%20%60%2Fnew%60%20will%20see%20English%20text%20in%20both%20the%20status%20bar%20and%20the%20sessions%20picker.%20Adding%20%60MessageId%3A%3ANewSessionTitle%60%20and%20%60MessageId%3A%3ANewSessionConfirm%60%20%28analogous%20to%20%60ClearConversation%60%29%20and%20wiring%20them%20through%20%60localization.rs%60%20would%20make%20this%20consistent.%0A%0A%60%60%60suggestion%0A%20%20%20%20app.current_session_id%20%3D%20Some%28new_id.clone%28%29%29%3B%0A%20%20%20%20let%20locale%20%3D%20app.ui_locale%3B%0A%20%20%20%20app.session_title%20%3D%20Some%28tr%28locale%2C%20MessageId%3A%3ANewSessionTitle%29.to_string%28%29%29%3B%0A%20%20%20%20app.scroll_to_bottom%28%29%3B%0A%0A%20%20%20%20CommandResult%3A%3Awith_message_and_action%28%0A%20%20%20%20%20%20%20%20tr%28locale%2C%20MessageId%3A%3ANewSessionConfirm%29%0A%20%20%20%20%20%20%20%20%20%20%20%20.replace%28%22%7Bid%7D%22%2C%20%26crate%3A%3Asession_manager%3A%3Atruncate_id%28%26new_id%29.to_string%28%29%29%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fcommands%2Fsession.rs%3A142%0AThe%20pattern%20match%20accepts%20%60%22force%22%60%20%28without%20the%20%60--%60%20prefix%29%20as%20a%20valid%20flag%2C%20but%20the%20help%20text%20and%20%60usage%60%20string%20only%20document%20%60--force%60.%20A%20user%20who%20accidentally%20types%20%60%2Fnew%20force%60%20expecting%20an%20error%20will%20silently%20discard%20pending%20work.%20Accepting%20only%20the%20documented%20form%20avoids%20surprising%20behaviour.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20Some%28%22--force%22%29%20%3D%3E%20true%2C%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fcommands%2Fsession.rs%3A166-174%0AThe%20session%20title%20%60%22New%20Session%22%60%20and%20the%20full%20success%20message%20are%20hardcoded%20English%20strings%20that%20bypass%20the%20locale%20system.%20Every%20other%20command-level%20user-visible%20string%20goes%20through%20%60tr%28locale%2C%20MessageId%3A%3A...%29%60.%20A%20Japanese%20or%20Simplified-Chinese%20user%20who%20runs%20%60%2Fnew%60%20will%20see%20English%20text%20in%20both%20the%20status%20bar%20and%20the%20sessions%20picker.%20Adding%20%60MessageId%3A%3ANewSessionTitle%60%20and%20%60MessageId%3A%3ANewSessionConfirm%60%20%28analogous%20to%20%60ClearConversation%60%29%20and%20wiring%20them%20through%20%60localization.rs%60%20would%20make%20this%20consistent.%0A%0A%60%60%60suggestion%0A%20%20%20%20app.current_session_id%20%3D%20Some%28new_id.clone%28%29%29%3B%0A%20%20%20%20let%20locale%20%3D%20app.ui_locale%3B%0A%20%20%20%20app.session_title%20%3D%20Some%28tr%28locale%2C%20MessageId%3A%3ANewSessionTitle%29.to_string%28%29%29%3B%0A%20%20%20%20app.scroll_to_bottom%28%29%3B%0A%0A%20%20%20%20CommandResult%3A%3Awith_message_and_action%28%0A%20%20%20%20%20%20%20%20tr%28locale%2C%20MessageId%3A%3ANewSessionConfirm%29%0A%20%20%20%20%20%20%20%20%20%20%20%20.replace%28%22%7Bid%7D%22%2C%20%26crate%3A%3Asession_manager%3A%3Atruncate_id%28%26new_id%29.to_string%28%29%29%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fcommands%2Fsession.rs%3A142%0AThe%20pattern%20match%20accepts%20%60%22force%22%60%20%28without%20the%20%60--%60%20prefix%29%20as%20a%20valid%20flag%2C%20but%20the%20help%20text%20and%20%60usage%60%20string%20only%20document%20%60--force%60.%20A%20user%20who%20accidentally%20types%20%60%2Fnew%20force%60%20expecting%20an%20error%20will%20silently%20discard%20pending%20work.%20Accepting%20only%20the%20documented%20form%20avoids%20surprising%20behaviour.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20Some%28%22--force%22%29%20%3D%3E%20true%2C%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2235&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fcommands%2Fsession.rs%3A166-174%0AThe%20session%20title%20%60%22New%20Session%22%60%20and%20the%20full%20success%20message%20are%20hardcoded%20English%20strings%20that%20bypass%20the%20locale%20system.%20Every%20other%20command-level%20user-visible%20string%20goes%20through%20%60tr%28locale%2C%20MessageId%3A%3A...%29%60.%20A%20Japanese%20or%20Simplified-Chinese%20user%20who%20runs%20%60%2Fnew%60%20will%20see%20English%20text%20in%20both%20the%20status%20bar%20and%20the%20sessions%20picker.%20Adding%20%60MessageId%3A%3ANewSessionTitle%60%20and%20%60MessageId%3A%3ANewSessionConfirm%60%20%28analogous%20to%20%60ClearConversation%60%29%20and%20wiring%20them%20through%20%60localization.rs%60%20would%20make%20this%20consistent.%0A%0A%60%60%60suggestion%0A%20%20%20%20app.current_session_id%20%3D%20Some%28new_id.clone%28%29%29%3B%0A%20%20%20%20let%20locale%20%3D%20app.ui_locale%3B%0A%20%20%20%20app.session_title%20%3D%20Some%28tr%28locale%2C%20MessageId%3A%3ANewSessionTitle%29.to_string%28%29%29%3B%0A%20%20%20%20app.scroll_to_bottom%28%29%3B%0A%0A%20%20%20%20CommandResult%3A%3Awith_message_and_action%28%0A%20%20%20%20%20%20%20%20tr%28locale%2C%20MessageId%3A%3ANewSessionConfirm%29%0A%20%20%20%20%20%20%20%20%20%20%20%20.replace%28%22%7Bid%7D%22%2C%20%26crate%3A%3Asession_manager%3A%3Atruncate_id%28%26new_id%29.to_string%28%29%29%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fcommands%2Fsession.rs%3A142%0AThe%20pattern%20match%20accepts%20%60%22force%22%60%20%28without%20the%20%60--%60%20prefix%29%20as%20a%20valid%20flag%2C%20but%20the%20help%20text%20and%20%60usage%60%20string%20only%20document%20%60--force%60.%20A%20user%20who%20accidentally%20types%20%60%2Fnew%20force%60%20expecting%20an%20error%20will%20silently%20discard%20pending%20work.%20Accepting%20only%20the%20documented%20form%20avoids%20surprising%20behaviour.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20Some%28%22--force%22%29%20%3D%3E%20true%2C%0A%60%60%60%0A%0A&pr=2235&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat: add new session command"](https://github.com/hmbown/codewhale/commit/ed23a48e040302a571ebc9b07561e5558cf581a2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34065162)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->