### PR TITLE
style: fix two clippy warnings

### DIFF
--- a/crates/tui/src/commands/config.rs
+++ b/crates/tui/src/commands/config.rs
@@ -473,9 +473,7 @@ pub fn set_config_value(app: &mut App, key: &str, value: &str, persist: bool) ->
                     Err(err) => return CommandResult::error(format!("Failed to save: {err}")),
                 }
             }
-            return CommandResult::error(format!(
-                "base_url must be saved with --save; client base URL is loaded from config on startup. Restart and re-open your session after saving."
-            ));
+            return CommandResult::error("base_url must be saved with --save; client base URL is loaded from config on startup. Restart and re-open your session after saving.".to_string());
         }
         _ => {}
     }

--- a/crates/tui/src/runtime_log.rs
+++ b/crates/tui/src/runtime_log.rs
@@ -174,7 +174,7 @@ fn log_directory() -> Option<PathBuf> {
     {
         return resolve(userprofile);
     }
-    dirs::home_dir().and_then(|h| resolve(h))
+    dirs::home_dir().and_then(resolve)
 }
 
 fn log_file_name(date: &str, pid: u32) -> String {


### PR DESCRIPTION
## Summary

Run "cargo clippy" find two warnings, use "cargo clippy --fix" fix them.

## Testing

- [ x ] `cargo fmt --all -- --check`
- [ x ] `cargo clippy --workspace --all-targets --all-features`
- [ x ] `cargo test --workspace --all-features`

## Checklist

- [ x ] Updated docs or comments as needed
- [ x ] Added or updated tests where relevant
- [ x ] Verified TUI behavior manually if UI changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR applies two mechanical clippy lint fixes generated by `cargo clippy --fix`, with no behavioral changes.

- **`config.rs`**: Removes a redundant `format!()` call wrapping a plain string literal, replacing it with `.to_string()` directly on the literal (`clippy::useless_format`).
- **`runtime_log.rs`**: Eta-reduces a closure `|h| resolve(h)` to pass the local closure `resolve` directly into `and_then`, eliminating a needless wrapper (`clippy::redundant_closure`).
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Both changes are purely cosmetic clippy fixes with identical runtime behavior — safe to merge.

The two edits are exact semantic equivalents of the code they replace: removing a no-op format! wrapper and inlining a single-argument closure pass-through. Neither touches logic, data flow, or any externally visible behavior.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/commands/config.rs | Replaces unnecessary `format!("literal")` with `"literal".to_string()` — a correct one-line clippy lint fix with no semantic change. |
| crates/tui/src/runtime_log.rs | Eta-reduces `|h| resolve(h)` to `resolve` in the `and_then` call — a correct clippy redundant-closure fix; the local closure satisfies `FnOnce(PathBuf) -> Option<PathBuf>` directly. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[set_config_value: base_url branch] --> B{persist?}
    B -- yes --> C[persist_root_string_key]
    C -- Ok --> D[CommandResult::message]
    C -- Err --> E["CommandResult::error(format!(...))"]
    B -- no --> F["CommandResult::error('base_url must be saved...'.to_string())"]

    G[log_directory] --> H{HOME env set?}
    H -- yes --> I[resolve HOME]
    H -- no --> J{USERPROFILE env set?}
    J -- yes --> K[resolve USERPROFILE]
    J -- no --> L["dirs::home_dir().and_then(resolve)"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["style: fix two clippy warnings"](https://github.com/hmbown/codewhale/commit/b11c076e6fa43cb65dbffc122d6cb9ee902e9316) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34073804)</sub>

<!-- /greptile_comment -->