### PR TITLE
  fix(provider): keep picker selection visible

### DIFF
--- a/crates/tui/src/tui/provider_picker.rs
+++ b/crates/tui/src/tui/provider_picker.rs
@@ -21,7 +21,7 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::{
     buffer::Buffer,
     layout::{Constraint, Direction, Layout, Rect},
-    style::{Modifier, Style},
+    style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph, Widget},
 };
@@ -116,6 +116,28 @@ impl ProviderPickerView {
         }
     }
 
+    fn visible_start(&self, visible_rows: usize) -> usize {
+        if visible_rows == 0 {
+            return 0;
+        }
+        let max_start = self.providers.len().saturating_sub(visible_rows);
+        self.selected_idx
+            .saturating_add(1)
+            .saturating_sub(visible_rows)
+            .min(max_start)
+    }
+
+    fn selected_row_style(fg: Color) -> Style {
+        Style::default()
+            .fg(fg)
+            .bg(palette::SURFACE_ELEVATED)
+            .add_modifier(Modifier::BOLD)
+    }
+
+    fn selected_row_bg_style() -> Style {
+        Style::default().bg(palette::SURFACE_ELEVATED)
+    }
+
     fn render_list(&self, area: Rect, buf: &mut Buffer) {
         let outer = Block::default()
             .title(Line::from(Span::styled(
@@ -138,39 +160,64 @@ impl ProviderPickerView {
         let inner = outer.inner(area);
         outer.render(area, buf);
 
-        let mut lines: Vec<Line> = Vec::with_capacity(self.providers.len());
-        for (idx, (provider, has_key)) in self.providers.iter().enumerate() {
+        let visible_rows = usize::from(inner.height);
+        let visible_start = self.visible_start(visible_rows);
+        let mut lines: Vec<Line> = Vec::with_capacity(visible_rows);
+        for (idx, (provider, has_key)) in self
+            .providers
+            .iter()
+            .enumerate()
+            .skip(visible_start)
+            .take(visible_rows)
+        {
             let is_selected = idx == self.selected_idx;
             let is_active = *provider == self.active_provider;
             let arrow = if is_selected { "▸" } else { " " };
             let active_dot = if is_active { " *" } else { "  " };
-            let label_style = if is_selected {
+            let spacer_style = if is_selected {
+                Self::selected_row_bg_style()
+            } else {
                 Style::default()
-                    .fg(palette::SELECTION_TEXT)
-                    .bg(palette::SELECTION_BG)
-                    .add_modifier(Modifier::BOLD)
+            };
+            let label_style = if is_selected {
+                Self::selected_row_style(palette::TEXT_PRIMARY)
             } else {
                 Style::default().fg(palette::TEXT_PRIMARY)
             };
             let hint_style = if is_selected {
-                Style::default()
-                    .fg(palette::SELECTION_TEXT)
-                    .bg(palette::SELECTION_BG)
+                let hint_fg = if *has_key {
+                    palette::TEXT_MUTED
+                } else {
+                    palette::STATUS_WARNING
+                };
+                Self::selected_row_style(hint_fg)
             } else if *has_key {
                 Style::default().fg(palette::TEXT_MUTED)
             } else {
                 Style::default().fg(palette::STATUS_WARNING)
             };
             let hint = Self::provider_hint(*provider, *has_key);
-            lines.push(Line::from(vec![
-                Span::raw(" "),
+            let mut line = Line::from(vec![
+                Span::styled(" ", spacer_style),
                 Span::styled(arrow, label_style),
-                Span::raw(" "),
+                Span::styled(" ", spacer_style),
                 Span::styled(provider.display_name().to_string(), label_style),
                 Span::styled(active_dot, label_style),
-                Span::raw("  "),
+                Span::styled("  ", spacer_style),
                 Span::styled(hint, hint_style),
-            ]));
+            ]);
+            if is_selected {
+                line.style = Self::selected_row_bg_style();
+                let target_width = usize::from(inner.width);
+                let line_width = line.width();
+                if line_width < target_width {
+                    line.spans.push(Span::styled(
+                        " ".repeat(target_width - line_width),
+                        Self::selected_row_bg_style(),
+                    ));
+                }
+            }
+            lines.push(line);
         }
         Paragraph::new(lines).render(inner, buf);
     }
@@ -347,7 +394,7 @@ impl ModalView for ProviderPickerView {
     fn render(&self, area: Rect, buf: &mut Buffer) {
         let popup_width = 64.min(area.width.saturating_sub(4)).max(40);
         let popup_height = match self.stage {
-            Stage::List => 12,
+            Stage::List => (self.providers.len() as u16).saturating_add(2),
             Stage::KeyEntry => 10,
         }
         .min(area.height.saturating_sub(4))
@@ -386,6 +433,16 @@ mod tests {
             picker.handle_key(key(KeyCode::Down));
         }
         panic!("provider {provider:?} not found in picker");
+    }
+
+    fn render_text(picker: &ProviderPickerView, width: u16, height: u16) -> String {
+        let area = Rect::new(0, 0, width, height);
+        let mut buf = Buffer::empty(area);
+        picker.render(area, &mut buf);
+        (0..height)
+            .map(|y| (0..width).map(|x| buf[(x, y)].symbol()).collect::<String>())
+            .collect::<Vec<_>>()
+            .join("\n")
     }
 
     #[test]
@@ -528,5 +585,60 @@ mod tests {
             picker.handle_key(key(KeyCode::Char(c)));
         }
         assert_eq!(picker.api_key_input, "abcdef");
+    }
+
+    #[test]
+    fn small_list_render_keeps_selected_provider_visible_after_down_navigation() {
+        let config = Config::default();
+        let mut picker = ProviderPickerView::new(ApiProvider::Deepseek, &config);
+        move_to_provider(&mut picker, ApiProvider::Ollama);
+
+        let rendered = render_text(&picker, 80, 12);
+
+        assert!(rendered.contains("Ollama"));
+        assert!(!rendered.contains("DeepSeek *"));
+    }
+
+    #[test]
+    fn small_list_render_keeps_initial_active_provider_visible() {
+        let config = Config::default();
+        let picker = ProviderPickerView::new(ApiProvider::Ollama, &config);
+
+        let rendered = render_text(&picker, 80, 12);
+
+        assert!(rendered.contains("Ollama *"));
+    }
+
+    #[test]
+    fn tall_list_render_shows_all_providers_without_scrolling() {
+        let config = Config::default();
+        let picker = ProviderPickerView::new(ApiProvider::Deepseek, &config);
+
+        let rendered = render_text(&picker, 80, 20);
+
+        assert!(rendered.contains("DeepSeek *"));
+        assert!(rendered.contains("Ollama"));
+    }
+
+    #[test]
+    fn selected_provider_row_uses_strong_highlight() {
+        let config = Config::default();
+        let picker = ProviderPickerView::new(ApiProvider::Deepseek, &config);
+        let area = Rect::new(0, 0, 80, 20);
+        let mut buf = Buffer::empty(area);
+
+        picker.render(area, &mut buf);
+
+        let highlighted_cells = area
+            .positions()
+            .filter(|position| {
+                let cell = &buf[*position];
+                cell.bg == palette::SURFACE_ELEVATED
+            })
+            .count();
+        assert!(
+            highlighted_cells >= 32,
+            "selected provider row should use a visible continuous highlight"
+        );
     }
 }

--- a/crates/tui/src/tui/provider_picker.rs
+++ b/crates/tui/src/tui/provider_picker.rs
@@ -65,13 +65,23 @@ impl ProviderPickerView {
     }
 
     fn move_up(&mut self) {
-        if self.selected_idx > 0 {
+        if self.providers.is_empty() {
+            return;
+        }
+        if self.selected_idx == 0 {
+            self.selected_idx = self.providers.len() - 1;
+        } else {
             self.selected_idx -= 1;
         }
     }
 
     fn move_down(&mut self) {
-        if self.selected_idx + 1 < self.providers.len() {
+        if self.providers.is_empty() {
+            return;
+        }
+        if self.selected_idx + 1 == self.providers.len() {
+            self.selected_idx = 0;
+        } else {
             self.selected_idx += 1;
         }
     }
@@ -498,6 +508,18 @@ mod tests {
     }
 
     #[test]
+    fn list_navigation_wraps_between_first_and_last_provider() {
+        let config = Config::default();
+        let mut picker = ProviderPickerView::new(ApiProvider::Deepseek, &config);
+
+        picker.handle_key(key(KeyCode::Up));
+        assert_eq!(picker.selected_provider(), ApiProvider::Ollama);
+
+        picker.handle_key(key(KeyCode::Down));
+        assert_eq!(picker.selected_provider(), ApiProvider::Deepseek);
+    }
+
+    #[test]
     fn enter_with_no_key_transitions_to_key_entry_stage() {
         let config = Config::default();
         let mut picker = ProviderPickerView::new(ApiProvider::Deepseek, &config);
@@ -516,8 +538,7 @@ mod tests {
             ..Config::default()
         };
         let mut picker = ProviderPickerView::new(ApiProvider::NvidiaNim, &config);
-        // Move up twice to DeepSeek (index 0), which has a key from the config.
-        picker.handle_key(key(KeyCode::Up));
+        // Move up once to DeepSeek (index 0), which has a key from the config.
         picker.handle_key(key(KeyCode::Up));
         let action = picker.handle_key(key(KeyCode::Enter));
         match action {


### PR DESCRIPTION
## Summary

  Fixes https://github.com/Hmbown/CodeWhale/issues/2238.

 The `/provider` modal had more provider rows than its fixed-height list could show. Arrow-key navigation changed the selected provider internally, but rendering always started from the first provider, so later providers such as SGLang, vLLM, and Ollama could be selected without becoming visible.

  This updates the picker to:
  - size the list modal to fit all providers when the terminal has enough height
  - scroll the visible rows when the selected provider moves beyond the viewport
  - keep an initially selected bottom provider visible
  - wrap Up/Down navigation between the first and last providers
  - render the selected row with a continuous subtle highlight

from:  cannot move forward to next 

<img width="681" height="309" alt="image" src="https://github.com/user-attachments/assets/8f84b5d1-73a7-47a9-96b5-03aa2529d9bd" />


to:

<img width="743" height="348" alt="image" src="https://github.com/user-attachments/assets/2426502d-6002-4c7d-b8af-80190b8913ef" />

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features`
- [x] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [x] Verified TUI behavior manually if UI changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the `/provider` modal so the selected provider is always visible during keyboard navigation. Previously the list was fixed at height 12, causing providers like SGLang, vLLM, and Ollama to be navigated to but never displayed.

- **Dynamic popup height**: the list stage now sizes to `providers.len() + 2` (clamped to terminal height), showing all 12 providers when the terminal has enough room.
- **Viewport scrolling**: a new `visible_start` helper computes the minimum scroll offset to keep the selection visible, and the render loop uses `.skip(visible_start).take(visible_rows)` to emit only the visible slice.
- **Wrap-around navigation**: `move_up`/`move_down` now wrap from first↔last instead of clamping, and the corresponding test comment is corrected from \"twice\" to \"once\".
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is self-contained to a single TUI modal and carries no state-mutation risk outside the picker.

The visible_start formula correctly computes the minimum scroll offset that keeps the selection on-screen in all navigation scenarios (forward, backward, and wrap-around), and is covered by four focused render tests. The popup height calculation clamps properly to both the terminal size and the 8-row minimum. No data path, persistence, or API surface is affected.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/provider_picker.rs | Adds dynamic popup sizing, viewport-scroll logic, wrap-around navigation, and a full-width row highlight; logic is correct and well-covered by new tests. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["Make the selected row easier to see with..."](https://github.com/hmbown/codewhale/commit/198acc72bae04620a4b3ddaab86348970b84cdaf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34082813)</sub>

<!-- /greptile_comment -->