### PR TITLE
fix(web_search): decode HTML entities in Bing result URLs (default backend returns 0 results)

### DIFF
--- a/crates/tui/src/tools/web_search.rs
+++ b/crates/tui/src/tools/web_search.rs
@@ -901,6 +901,14 @@ fn normalize_url(href: &str) -> String {
 }
 
 fn normalize_bing_url(href: &str) -> String {
+    // Bing wraps every SERP result URL in a `/ck/a?...&u=<base64>` click-tracking
+    // redirect, and in the raw HTML the separators are `&amp;` entities. Without
+    // decoding entities first, `extract_query_param` looks for `u` but the actual
+    // key is `amp;u`, so the real URL is never recovered: every result collapses to
+    // a `bing.com` root domain, which the spam heuristic then rejects — yielding
+    // zero results for the default Bing backend. Decode entities before parsing.
+    let href = decode_html_entities(href);
+    let href = href.as_str();
     if let Some(encoded) = extract_query_param(href, "u") {
         let decoded = percent_decode(&encoded);
         let token = decoded.strip_prefix("a1").unwrap_or(&decoded);
@@ -1027,10 +1035,21 @@ fn extract_query_param(url: &str, key: &str) -> Option<String> {
 mod tests {
     use super::{
         ERROR_BODY_PREVIEW_BYTES, WebSearchEntry, WebSearchTool, decode_html_entities,
-        extract_search_query, is_likely_spam_results, optional_search_max_results, root_domain,
-        sanitize_error_body, truncate_error_body,
+        extract_search_query, is_likely_spam_results, normalize_bing_url,
+        optional_search_max_results, root_domain, sanitize_error_body, truncate_error_body,
     };
     use serde_json::json;
+
+    // Regression guard: Bing /ck/a redirect hrefs are HTML-entity-encoded
+    // (`&amp;`). normalize_bing_url must decode entities before extracting the
+    // `u=` base64 payload, otherwise the real URL is never recovered and the
+    // result's root domain collapses to bing.com (then dropped as spam → 0
+    // results for the default Bing backend).
+    #[test]
+    fn bing_ckurl_with_html_entities_decodes_real_url() {
+        let href = "https://www.bing.com/ck/a?!&amp;&amp;p=abc&amp;u=a1aHR0cHM6Ly9ydXN0LWxhbmcub3JnLw&amp;ntb=1";
+        assert_eq!(normalize_bing_url(href), "https://rust-lang.org/");
+    }
 
     fn entry(url: &str) -> WebSearchEntry {
         WebSearchEntry {


### PR DESCRIPTION
## Problem

With the default **Bing** backend, `web_search` returns **0 results** for normal queries.

Bing's SERP wraps each result URL in a `/ck/a?...&u=<base64>` click-tracking redirect, and the raw HTML encodes the separators as `&amp;` entities. `normalize_bing_url` extracts the `u` query param *without* decoding HTML entities first, so it looks for key `u` while the actual key in the string is `amp;u`. The base64 redirect target is never decoded, so every result's URL collapses to the `bing.com` root domain. `is_likely_spam_results` then sees an all-`bing.com` batch and rejects it → 0 results.

## Fix

Decode HTML entities (`decode_html_entities`, already used elsewhere in this module) before parsing the redirect, restoring the real target URLs.

## Test

Adds `bing_ckurl_with_html_entities_decodes_real_url`, covering a realistic `&amp;`-encoded `/ck/a` href.

## Notes

- Affects the **default** search backend, so it hits any user who hasn't switched providers.
- The DuckDuckGo path (`normalize_url`, `uddg` param) may have a similar entity issue; left out of this PR to keep it focused.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a zero-results bug in the default Bing backend caused by HTML entity encoding (`&amp;`) in click-tracking redirect URLs not being decoded before query-parameter parsing. The two-line fix adds a `decode_html_entities` call at the top of `normalize_bing_url`, exactly where the raw href is first processed, and a targeted regression test validates the full decode-→-base64-extract flow.

- **Root-cause fix**: `normalize_bing_url` now calls `decode_html_entities` before `extract_query_param`, so `amp;u` is no longer mistaken for the parameter key and the real URL is correctly extracted from the base64 payload.
- **Test coverage**: `bing_ckurl_with_html_entities_decodes_real_url` exercises a realistic `&amp;`-encoded Bing `/ck/a` href end-to-end, confirming the decoded URL matches the expected target.
- **Known gap (out of scope)**: `normalize_url` (the DuckDuckGo path) has the same entity-decoding omission for its `uddg` parameter, acknowledged in the PR description and deferred to a follow-up.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a two-line, single-function addition that restores correct URL extraction for the default Bing backend.

The fix is minimal and correctly placed: `decode_html_entities` is already used elsewhere in the same module for the same class of problem, the new code follows the established variable-shadowing pattern, and the regression test exercises the full decode path end-to-end. No existing behavior is removed or altered for non-Bing URL shapes.

`normalize_url` (the DuckDuckGo path) has an analogous missing entity-decode step for its `uddg` parameter — acknowledged in the PR description and deferred. No other files need attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tools/web_search.rs | Adds `decode_html_entities` before `extract_query_param` in `normalize_bing_url` (two lines), plus a new unit test; fix is minimal, correct, and consistent with how `normalize_text` already uses the same helper. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Raw Bing SERP HTML href"] --> B["decode_html_entities(href) 🆕"]
    B --> C["Decoded href with real & separators"]
    C --> D["extract_query_param(href, 'u')"]
    D --> E["percent_decode(encoded)"]
    E --> F["strip_prefix('a1')"]
    F --> G["base64 pad & decode"]
    G --> H{Valid http/https URL?}
    H -- Yes --> I["✅ Return real target URL"]
    H -- No --> J["Fallback: return href as-is"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web\_search): decode HTML entities in..."](https://github.com/hmbown/codewhale/commit/07e2fba1b1c1ac6392bcc751f8f4f445a51ea729) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34086837)</sub>

<!-- /greptile_comment -->