### PR TITLE
fix(tui): clear footer row before rendering statusline

### DIFF
--- a/crates/tui/src/tui/widgets/footer.rs
+++ b/crates/tui/src/tui/widgets/footer.rs
@@ -11,7 +11,7 @@ use ratatui::{
     layout::Rect,
     style::{Color, Style},
     text::{Line, Span},
-    widgets::{Block, Paragraph, Widget},
+    widgets::{Paragraph, Widget},
 };
 use unicode_width::UnicodeWidthStr;
 
@@ -573,12 +573,16 @@ impl Renderable for FooterWidget {
             return;
         }
 
-        // Repaint the whole footer row first so stale transcript glyphs from
+        // Clear the whole footer row first so stale transcript glyphs from
         // the previous frame cannot survive in cells this frame's spans do not
         // touch (#2244).
-        Block::default()
-            .style(Style::default().bg(self.props.footer_bg))
-            .render(area, buf);
+        for y in area.top()..area.bottom() {
+            for x in area.left()..area.right() {
+                buf[(x, y)]
+                    .set_symbol(" ")
+                    .set_style(Style::default().bg(self.props.footer_bg));
+            }
+        }
 
         let preview_left_spans = self.left_spans(available_width);
         let preview_left_width = span_width(&preview_left_spans);

--- a/crates/tui/src/tui/widgets/footer.rs
+++ b/crates/tui/src/tui/widgets/footer.rs
@@ -11,7 +11,7 @@ use ratatui::{
     layout::Rect,
     style::{Color, Style},
     text::{Line, Span},
-    widgets::{Paragraph, Widget},
+    widgets::{Block, Paragraph, Widget},
 };
 use unicode_width::UnicodeWidthStr;
 
@@ -573,6 +573,13 @@ impl Renderable for FooterWidget {
             return;
         }
 
+        // Repaint the whole footer row first so stale transcript glyphs from
+        // the previous frame cannot survive in cells this frame's spans do not
+        // touch (#2244).
+        Block::default()
+            .style(Style::default().bg(self.props.footer_bg))
+            .render(area, buf);
+
         let preview_left_spans = self.left_spans(available_width);
         let preview_left_width = span_width(&preview_left_spans);
         let right_budget = available_width
@@ -652,6 +659,8 @@ mod tests {
     use crate::palette;
     use crate::tui::app::{App, AppMode, TuiOptions};
     use ratatui::{
+        buffer::Buffer,
+        layout::Rect,
         style::{Color, Style},
         text::Span,
     };
@@ -1376,5 +1385,37 @@ mod tests {
         assert!(rendered.contains("session saved"));
         assert!(!rendered.contains("agent"));
         assert!(!rendered.contains("deepseek-v4-flash"));
+    }
+
+    #[test]
+    fn render_clears_stale_cells_across_entire_footer_row() {
+        let app = make_app();
+        let widget = FooterWidget::new(idle_props_for(&app));
+        let area = Rect::new(0, 0, 48, 1);
+        let mut buf = Buffer::empty(area);
+
+        for x in area.x..area.x.saturating_add(area.width) {
+            buf[(x, area.y)]
+                .set_symbol("X")
+                .set_style(Style::default().fg(Color::Red).bg(Color::Blue));
+        }
+
+        widget.render(area, &mut buf);
+
+        let rendered: String = (area.x..area.x.saturating_add(area.width))
+            .map(|x| buf[(x, area.y)].symbol())
+            .collect();
+
+        assert!(
+            !rendered.contains('X'),
+            "footer render must clear stale row content before painting: {rendered:?}"
+        );
+        for x in area.x..area.x.saturating_add(area.width) {
+            assert_eq!(
+                buf[(x, area.y)].bg,
+                app.ui_theme.footer_bg,
+                "footer background should cover the full row"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
- repaint the entire footer row before drawing status spans so stale transcript glyphs cannot survive on the footer line
- add a regression test that seeds stale cells across the full row and verifies the render clears them while applying the footer background

Closes #2244.

## Testing
- cargo test -p codewhale-tui render_clears_stale_cells_across_entire_footer_row
- cargo test -p codewhale-tui render_swaps_toast_for_status_line
- HOME="$(mktemp -d)" USERPROFILE="$HOME" RUSTUP_HOME="/Users/bytedance/.rustup" CARGO_HOME="/Users/bytedance/.cargo" cargo test -p codewhale-tui

## Notes
- the host environment has local skills in HOME that cause the unrelated `prompts::tests::system_prompt_skips_locale_preamble_for_english` test to fail outside an isolated HOME

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a stale-cell rendering bug (#2244) in the TUI footer widget where leftover glyphs from the transcript pane could persist in footer row cells not touched by the current frame's status spans.

- Adds a pre-clear loop in `FooterWidget::render` that fills every cell in the footer area with a space and the configured footer background before painting the status-line spans.
- Adds a regression test (`render_clears_stale_cells_across_entire_footer_row`) that seeds the buffer with visually distinct stale content and asserts both that no stale symbol survives and that the full row carries the correct background colour.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a narrow, well-bounded defensive clear of a single-row buffer before an existing Paragraph render, with a direct regression test covering the exact failure mode.

The pre-clear loop iterates only over the footer area (typically 1 row wide), the bounds use ratatui's own top()/bottom()/left()/right() helpers so there is no off-by-one risk, and the subsequent Paragraph::render call is unchanged. The new regression test seeds the buffer with unmistakable stale content and asserts both symbol-level and background-level correctness, covering the exact scenario from issue #2244.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/widgets/footer.rs | Adds a defensive pre-clear loop before Paragraph::render and a focused regression test; bounds arithmetic and buffer indexing are correct. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant F as FooterWidget::render
    participant B as ratatui Buffer
    participant P as Paragraph::render

    F->>F: "guard: height/width == 0?"
    F->>B: pre-clear loop set every cell to space with footer_bg
    F->>F: build left_spans, spacer_span, right_spans
    F->>P: Paragraph::new(spans).style(footer_bg)
    P->>B: paint spans over cleared cells
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(tui): clear footer cells before rend..."](https://github.com/hmbown/codewhale/commit/129c9fc286c05ff08990d1ab7d05ccdcee0e6cdd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34091645)</sub>

<!-- /greptile_comment -->