### PR TITLE
fix(tui): clear stale tool failures from sidebar (#1884)

### DIFF
--- a/crates/tui/src/tui/sidebar.rs
+++ b/crates/tui/src/tui/sidebar.rs
@@ -1155,9 +1155,21 @@ fn editorial_tool_rows(rows: Vec<SidebarToolRow>, limit: usize) -> Vec<SidebarTo
     let mut ci_poll_groups: Vec<(usize, SidebarToolRow, usize)> = Vec::new();
     let mut shell_wait_groups: Vec<(usize, SidebarToolRow, usize, String)> = Vec::new();
     let mut seen_success: Vec<String> = Vec::new();
+    let mut seen_tool_names_succeeded: Vec<String> = Vec::new();
+    let mut seen_failures: Vec<String> = Vec::new();
+    let mut visible_failure_count: usize = 0;
+    const MAX_VISIBLE_FAILURES: usize = 2;
 
     for (order, mut row) in rows.into_iter().enumerate() {
         if row.status == ToolStatus::Failed {
+            // Deduplicate failures for the same tool name: keep only the most
+            // recent failure per tool. Fixes #1884 — stale failures from
+            // tools that have since succeeded no longer crowd the sidebar.
+            let fail_key = row.name.trim().to_ascii_lowercase();
+            if seen_failures.contains(&fail_key) {
+                continue;
+            }
+            seen_failures.push(fail_key);
             row.summary = failure_summary_with_hint(&row.summary);
         }
 
@@ -1213,10 +1225,40 @@ fn editorial_tool_rows(rows: Vec<SidebarToolRow>, limit: usize) -> Vec<SidebarTo
         }
         if row.status == ToolStatus::Success {
             seen_success.push(key);
+            let normalized = row.name.trim().to_ascii_lowercase();
+            if !seen_tool_names_succeeded.contains(&normalized) {
+                seen_tool_names_succeeded.push(normalized);
+            }
         }
 
+        // When a tool succeeds, remove any prior failure for the same
+        // tool name. Prevents stale `gh issue create (failed)` from
+        // lingering after a successful retry. (#1884)
+        if row.status == ToolStatus::Success {
+            let normalized = row.name.trim().to_ascii_lowercase();
+            candidates.retain(|c| {
+                c.row.name.trim().to_ascii_lowercase() != normalized
+                    || c.row.status != ToolStatus::Failed
+            });
+        }
+
+        // Cap visible failures at MAX_VISIBLE_FAILURES. Excess failures
+        // get demoted to rank 3 so they don't crowd the top of the
+        // sidebar. (#1884)
+        let rank = if row.status == ToolStatus::Failed {
+            if visible_failure_count >= MAX_VISIBLE_FAILURES {
+                visible_failure_count += 1;
+                3
+            } else {
+                visible_failure_count += 1;
+                0
+            }
+        } else {
+            tool_row_rank(&row)
+        };
+
         candidates.push(Candidate {
-            rank: tool_row_rank(&row),
+            rank,
             order,
             row,
         });

--- a/crates/tui/src/tui/sidebar.rs
+++ b/crates/tui/src/tui/sidebar.rs
@@ -770,7 +770,7 @@ fn active_tool_rows(app: &App) -> Vec<SidebarToolRow> {
     if !stale_running.is_empty() {
         rows.push(collapsed_stale_running_row(stale_running));
     }
-    editorial_tool_rows(rows, usize::MAX)
+    editorial_tool_rows(rows, usize::MAX, ToolRowOrder::OldestFirst)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -837,7 +837,7 @@ fn recent_tool_rows(app: &App, limit: usize) -> Vec<SidebarToolRow> {
         .filter_map(sidebar_tool_row_from_cell)
         .take(RECENT_TOOL_SCAN_LIMIT)
         .collect();
-    editorial_tool_rows(rows, limit)
+    editorial_tool_rows(rows, limit, ToolRowOrder::NewestFirst)
 }
 
 fn push_tool_rows(
@@ -1142,7 +1142,17 @@ fn background_task_duplicates_live_tool(
         })
 }
 
-fn editorial_tool_rows(rows: Vec<SidebarToolRow>, limit: usize) -> Vec<SidebarToolRow> {
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ToolRowOrder {
+    OldestFirst,
+    NewestFirst,
+}
+
+fn editorial_tool_rows(
+    rows: Vec<SidebarToolRow>,
+    limit: usize,
+    order_mode: ToolRowOrder,
+) -> Vec<SidebarToolRow> {
     #[derive(Clone)]
     struct Candidate {
         rank: u8,
@@ -1155,7 +1165,7 @@ fn editorial_tool_rows(rows: Vec<SidebarToolRow>, limit: usize) -> Vec<SidebarTo
     let mut ci_poll_groups: Vec<(usize, SidebarToolRow, usize)> = Vec::new();
     let mut shell_wait_groups: Vec<(usize, SidebarToolRow, usize, String)> = Vec::new();
     let mut seen_success: Vec<String> = Vec::new();
-    let mut seen_tool_names_succeeded: Vec<String> = Vec::new();
+    let mut seen_success_tool_names: Vec<String> = Vec::new();
     let mut seen_failures: Vec<String> = Vec::new();
     let mut visible_failure_count: usize = 0;
     const MAX_VISIBLE_FAILURES: usize = 2;
@@ -1166,6 +1176,11 @@ fn editorial_tool_rows(rows: Vec<SidebarToolRow>, limit: usize) -> Vec<SidebarTo
             // recent failure per tool. Fixes #1884 — stale failures from
             // tools that have since succeeded no longer crowd the sidebar.
             let fail_key = row.name.trim().to_ascii_lowercase();
+            if order_mode == ToolRowOrder::NewestFirst
+                && seen_success_tool_names.contains(&fail_key)
+            {
+                continue;
+            }
             if seen_failures.contains(&fail_key) {
                 continue;
             }
@@ -1226,20 +1241,34 @@ fn editorial_tool_rows(rows: Vec<SidebarToolRow>, limit: usize) -> Vec<SidebarTo
         if row.status == ToolStatus::Success {
             seen_success.push(key);
             let normalized = row.name.trim().to_ascii_lowercase();
-            if !seen_tool_names_succeeded.contains(&normalized) {
-                seen_tool_names_succeeded.push(normalized);
+            if !seen_success_tool_names.contains(&normalized) {
+                seen_success_tool_names.push(normalized.clone());
             }
-        }
 
-        // When a tool succeeds, remove any prior failure for the same
-        // tool name. Prevents stale `gh issue create (failed)` from
-        // lingering after a successful retry. (#1884)
-        if row.status == ToolStatus::Success {
-            let normalized = row.name.trim().to_ascii_lowercase();
-            candidates.retain(|c| {
-                c.row.name.trim().to_ascii_lowercase() != normalized
-                    || c.row.status != ToolStatus::Failed
-            });
+            // Active rows are oldest-first, so a success means any candidate
+            // failure for the same tool is stale. Recent history rows are
+            // newest-first; in that path the success is older than any
+            // already-seen failure and must not remove it.
+            if order_mode == ToolRowOrder::OldestFirst {
+                let mut removed_visible_failures = 0usize;
+                let mut removed_any_failure = false;
+                candidates.retain(|c| {
+                    let remove = c.row.status == ToolStatus::Failed
+                        && c.row.name.trim().eq_ignore_ascii_case(&normalized);
+                    if remove {
+                        removed_any_failure = true;
+                        if c.rank == 0 {
+                            removed_visible_failures += 1;
+                        }
+                    }
+                    !remove
+                });
+                if removed_any_failure {
+                    seen_failures.retain(|seen| seen != &normalized);
+                    visible_failure_count =
+                        visible_failure_count.saturating_sub(removed_visible_failures);
+                }
+            }
         }
 
         // Cap visible failures at MAX_VISIBLE_FAILURES. Excess failures
@@ -1247,7 +1276,6 @@ fn editorial_tool_rows(rows: Vec<SidebarToolRow>, limit: usize) -> Vec<SidebarTo
         // sidebar. (#1884)
         let rank = if row.status == ToolStatus::Failed {
             if visible_failure_count >= MAX_VISIBLE_FAILURES {
-                visible_failure_count += 1;
                 3
             } else {
                 visible_failure_count += 1;
@@ -1257,11 +1285,7 @@ fn editorial_tool_rows(rows: Vec<SidebarToolRow>, limit: usize) -> Vec<SidebarTo
             tool_row_rank(&row)
         };
 
-        candidates.push(Candidate {
-            rank,
-            order,
-            row,
-        });
+        candidates.push(Candidate { rank, order, row });
     }
 
     for (order, mut row, count) in ci_poll_groups {
@@ -1925,9 +1949,9 @@ mod tests {
     use super::{
         ACTIVE_TOOL_COMPLETED_ROW_TTL, ACTIVE_TOOL_STALE_RUNNING_ROW_TTL, AutoSidebarPanel,
         AutoSidebarState, SidebarAgentRow, SidebarHoverSection, SidebarHoverState,
-        SidebarSubagentSummary, SidebarWorkChecklistItem, SidebarWorkStrategyStep,
-        SidebarWorkSummary, auto_sidebar_panels, subagent_panel_lines, task_panel_lines,
-        work_panel_empty_hint, work_panel_lines,
+        SidebarSubagentSummary, SidebarToolRow, SidebarWorkChecklistItem, SidebarWorkStrategyStep,
+        SidebarWorkSummary, ToolRowOrder, auto_sidebar_panels, editorial_tool_rows,
+        subagent_panel_lines, task_panel_lines, work_panel_empty_hint, work_panel_lines,
     };
     use crate::config::Config;
     use crate::palette::PaletteMode;
@@ -1967,6 +1991,15 @@ mod tests {
         App::new(options, &Config::default())
     }
 
+    fn sidebar_tool_row(name: &str, status: ToolStatus) -> SidebarToolRow {
+        SidebarToolRow {
+            name: name.to_string(),
+            status,
+            summary: String::new(),
+            duration_ms: None,
+        }
+    }
+
     fn lines_to_text(lines: &[Line<'static>]) -> Vec<String> {
         lines
             .iter()
@@ -1977,6 +2010,62 @@ mod tests {
                     .collect::<String>()
             })
             .collect()
+    }
+
+    #[test]
+    fn editorial_rows_keep_newer_failure_when_older_success_is_seen_later() {
+        let rows = vec![
+            sidebar_tool_row("gh issue create", ToolStatus::Failed),
+            sidebar_tool_row("gh issue create", ToolStatus::Success),
+        ];
+
+        let rendered = editorial_tool_rows(rows, 4, ToolRowOrder::NewestFirst);
+
+        assert!(
+            rendered
+                .iter()
+                .any(|row| row.name == "gh issue create" && row.status == ToolStatus::Failed),
+            "newest-first rows must keep a failure newer than a later-seen success: {rendered:?}"
+        );
+    }
+
+    #[test]
+    fn editorial_rows_hide_older_failure_after_newer_success() {
+        let rows = vec![
+            sidebar_tool_row("gh issue create", ToolStatus::Success),
+            sidebar_tool_row("gh issue create", ToolStatus::Failed),
+        ];
+
+        let rendered = editorial_tool_rows(rows, 4, ToolRowOrder::NewestFirst);
+
+        assert!(
+            !rendered
+                .iter()
+                .any(|row| row.name == "gh issue create" && row.status == ToolStatus::Failed),
+            "newest-first rows should hide stale failures older than success: {rendered:?}"
+        );
+    }
+
+    #[test]
+    fn editorial_rows_reclaim_failure_slot_after_oldest_first_success() {
+        let rows = vec![
+            sidebar_tool_row("gh issue create", ToolStatus::Failed),
+            sidebar_tool_row("grep_files", ToolStatus::Failed),
+            sidebar_tool_row("gh issue create", ToolStatus::Success),
+            sidebar_tool_row("cargo test", ToolStatus::Failed),
+        ];
+
+        let rendered = editorial_tool_rows(rows, 2, ToolRowOrder::OldestFirst);
+
+        assert_eq!(
+            rendered
+                .iter()
+                .filter(|row| row.status == ToolStatus::Failed)
+                .map(|row| row.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["grep_files", "cargo test"],
+            "success should clear its stale failure and free a visible failure slot"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem
The sidebar's editorial_tool_rows function never deduplicated or capped failed tool entries, causing old failures like 'gh issue create (failed)' to linger as the top-ranked items even after the task moved on or the same tool succeeded in a later attempt.

## Fix
Three targeted changes:
1. **Deduplicate failures per tool name** — keep only the most recent failure for each tool
2. **Clear stale failures on success** — when a tool name appears with Success status, any prior Failure entry for that name is removed from the candidate list
3. **Cap visible failures at 2** — excess failures are demoted to rank 3 (low-priority) so they don't crowd out running tasks and recent successes

## Verification
- `cargo check --workspace` ✅
- `cargo test -p codewhale-tui` ✅ — 3,449 passed, 0 failed

Closes #1884
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hmbown/codewhale/pull/2258" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes stale tool-failure entries lingering in the TUI sidebar by introducing three targeted improvements to `editorial_tool_rows`: per-tool failure deduplication, clearing of stale failures when a newer success is seen (correctly gated on `OldestFirst` order), and a two-failure visibility cap that demotes excess entries to rank 3.

- A new `ToolRowOrder` enum is threaded through both callers (`active_tool_rows` uses `OldestFirst`, `recent_tool_rows` uses `NewestFirst`) to guard the retain-on-success logic against removing still-fresh failures in the history path.
- `visible_failure_count` is correctly decremented and `seen_failures` is cleared when the retain removes candidates, reclaiming failure slots for subsequent failures.
- Three new unit tests cover the key ordering scenarios and the slot-reclaim behaviour.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the changes are scoped to sidebar display logic and carry no risk of data loss or crashes.

All three issues flagged in previous review rounds (retain direction, seen_failures cleanup, visible_failure_count decrement) are correctly addressed. The only remaining gap is cosmetic: in the OldestFirst path, repeated failures for the same tool keep the oldest error summary rather than the most recent one. This does not break any existing behaviour.

crates/tui/src/tui/sidebar.rs — specifically the seen_failures deduplication block around the OldestFirst path.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/sidebar.rs | Adds failure deduplication, stale-failure clearing on success, and a visible-failure cap (MAX=2) to editorial_tool_rows. The retain/counter cleanup for OldestFirst is correct; a minor ordering issue causes the oldest failure summary (not the newest) to be kept when a tool fails multiple times consecutively in the OldestFirst path. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[editorial_tool_rows called] --> B{row.status == Failed?}
    B -- Yes --> C{NewestFirst AND tool already succeeded?}
    C -- Yes --> SKIP1[continue — stale failure dropped]
    C -- No --> D{seen_failures contains tool?}
    D -- Yes --> SKIP2[continue — duplicate failure dropped]
    D -- No --> E[push to seen_failures\napply failure_summary_with_hint]
    E --> F{visible_failure_count >= MAX 2?}
    F -- Yes --> G[rank = 3\ndemoted failure]
    F -- No --> H[visible_failure_count++\nrank = 0]
    B -- No --> I{row.status == Success AND OldestFirst?}
    I -- Yes --> J[candidates.retain: remove same-tool failures\ndecrement visible_failure_count\nclear seen_failures entry]
    I -- No --> K[rank = tool_row_rank]
    G --> PUSH[candidates.push]
    H --> PUSH
    J --> K
    K --> PUSH
    PUSH --> SORT[sort by rank, order\ntake limit]
    SORT --> OUT[final SidebarToolRow list]
```
</details>

<a href="https://app.greptile.com/api/ide/devin?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2F1884-sidebar-stale-failures-clean%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F1884-sidebar-stale-failures-clean%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fsidebar.rs%3A1184-1187%0A**OldestFirst%20deduplication%20keeps%20the%20oldest%20failure%2C%20not%20the%20most%20recent**%0A%0A%60seen_failures%60%20deduplicates%20per%20tool%20name%20using%20first-seen%20wins%2C%20which%20is%20correct%20for%20%60NewestFirst%60%20%28first%20encountered%20%3D%20newest%20event%29%20but%20wrong%20for%20%60OldestFirst%60.%20In%20the%20active-rows%20path%2C%20rows%20arrive%20oldest-to-newest%3A%20the%20first%20failure%20pushed%20into%20%60seen_failures%60%20is%20the%20stale%20one%2C%20and%20every%20later%20%28more%20informative%29%20failure%20for%20the%20same%20tool%20is%20silently%20dropped%20via%20%60continue%60.%20The%20user%20ends%20up%20seeing%20the%20oldest%20error%20summary%20rather%20than%20the%20one%20from%20the%20most%20recent%20attempt.%20One%20way%20to%20fix%20this%20in%20the%20%60OldestFirst%60%20branch%20is%20to%20replace%20the%20existing%20candidate%20with%20the%20newer%20failure%20%28update%20name%2C%20summary%2C%20order%29%20instead%20of%20skipping%20it.%0A%0A&repo=hmbown%2Fcodewhale&tid=69448&ts=1779875709&sig=e8decca2db26a9a074a6eb70248911d5e6aaec1c5440540c11a58b8aa927d075&pr=2258&platform=github&fid=5aafeb18-6d27-456a-b0ee-ab56745e6c77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInDevinDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInDevin.svg?v=3"><img alt="Fix All in Devin" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInDevin.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix(tui): make sidebar failure clearing ..."](https://github.com/hmbown/codewhale/commit/939bfb58c8308b668f89506f5cc32b4343245dd1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34098709)</sub>

<!-- /greptile_comment -->