### PR TITLE
feat: macos display notification

### DIFF
--- a/crates/tui/src/tui/notifications.rs
+++ b/crates/tui/src/tui/notifications.rs
@@ -909,7 +909,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
     fn auto_detect_picks_bel_for_unknown_on_unix() {
         let _lock = env_lock();
         let prev_tp = std::env::var_os("TERM_PROGRAM");
@@ -992,7 +992,7 @@ mod tests {
     /// `TERM_PROGRAM` but do set `TERM=xterm-ghostty`. The `$TERM`
     /// fallback should catch them.
     #[test]
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
     fn auto_detect_picks_osc9_for_xterm_ghostty_term_fallback() {
         let _lock = env_lock();
         let prev_tp = std::env::var_os("TERM_PROGRAM");
@@ -1060,7 +1060,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
     fn auto_detect_picks_kitty_from_term_fallback() {
         let _lock = env_lock();
         let prev_tp = std::env::var_os("TERM_PROGRAM");
@@ -1093,8 +1093,11 @@ mod tests {
 
     /// When neither `TERM_PROGRAM` nor `TERM` suggests a known capable
     /// terminal, the fallback on Unix is `Bel`.
+    ///
+    /// On macOS the `MacOS` method takes priority, so this test is
+    /// excluded there.
     #[test]
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
     fn auto_detect_falls_back_to_bel_for_unrelated_term() {
         let _lock = env_lock();
         let prev_tp = std::env::var_os("TERM_PROGRAM");

--- a/crates/tui/src/tui/notifications.rs
+++ b/crates/tui/src/tui/notifications.rs
@@ -186,7 +186,8 @@ pub fn notify_done_to<W: Write>(
     };
 
     // macOS Notification Center: handled via osascript, not terminal escapes.
-    if Method::MacOS==effective {
+    #[cfg(target_os = "macos")]
+    if Method::MacOS == effective {
         macos_display_notification(msg);
         return;
     }
@@ -396,15 +397,23 @@ fn bell_sound() {
 /// Runs on a dedicated background thread so the caller is not blocked.
 ///
 /// The notification includes:
-/// - **Title**: "DeepSeek TUI"
+/// - **Title**: "CodeWhale"
 /// - **Subtitle**: First line of `msg` (when the message contains a newline,
 ///   e.g. the response preview from a completed turn)
 /// - **Body**: Remaining lines of `msg`, or the full `msg` if single-line
 /// - **Sound**: Default macOS notification sound
 ///
-/// The whole body is capped at 200 **characters** (not bytes) to keep the
-/// bubble readable while correctly handling multi-byte text. Embedded double
-/// quotes are escaped as `\"` so AppleScript tokenises correctly.
+/// The message body is capped at 200 **characters** (not bytes) to keep the
+/// bubble readable while correctly handling multi-byte text.
+///
+/// **Security**: The message is passed to `osascript` as a command-line
+/// argument via `ARGV`, never embedded inline in the AppleScript source.
+/// AppleScript does not treat backslash as an escape inside double-quoted
+/// string literals, so the previous `\"` approach would terminate the
+/// string at the `"` and leave any text between unbalanced quotes
+/// evaluated as raw AppleScript code — a code-injection vector for
+/// AI-generated notification text. Passing via `ARGV` avoids this
+/// entirely because the message is never parsed as AppleScript syntax.
 ///
 /// This is best-effort: if `osascript` is not available (e.g. headless SSH
 /// session) the error is logged via `tracing::warn!` instead of silently
@@ -420,32 +429,55 @@ fn macos_display_notification(msg: &str) {
         .name("osascript-notif".into())
         .spawn(move || {
             // Char-bounded truncation (not byte-bounded) so we don't slice
-            // through a multi-byte sequence and emit invalid UTF-8 to the
-            // AppleScript parser.
+            // through a multi-byte sequence and emit invalid UTF-8.
             let body_str: String = body.chars().take(200).collect();
 
-            // Escape embedded double-quote characters for AppleScript.
-            let escaped = body_str.replace('"', "\\\"");
+            // Build AppleScript that receives the message via ARGV
+            // instead of inline string interpolation. AppleScript does
+            // not treat backslash as an escape inside double-quoted
+            // string literals, so `\"` would terminate the string at
+            // the `"` and leave a dangling `\`. Passing the message as
+            // a command-line argument avoids any injection risk.
+            //
+            // When the message has multiple lines, the first line
+            // becomes the subtitle and the rest becomes the body —
+            // this lets turn notifications show the response preview
+            // in the subtitle and the duration/cost summary in the body.
+            let mut args: Vec<String> = Vec::new();
 
-            // Build the AppleScript command.
-            // When the message has multiple lines, the first line becomes
-            // the subtitle and the rest becomes the body — this lets turn
-            // notifications show the response preview in the subtitle and
-            // the duration/cost summary in the body.
-            let script = if let Some(idx) = escaped.find('\n') {
-                let subtitle = escaped[..idx].trim();
-                let body_text = escaped[idx + 1..].trim();
-                format!(
-                    "display notification \"{body_text}\" with title \"DeepSeek TUI\" subtitle \"{subtitle}\" sound name \"default\""
-                )
+            if let Some(idx) = body_str.find('\n') {
+                let subtitle = body_str[..idx].trim();
+                let body_text = body_str[idx + 1..].trim();
+                args.extend_from_slice(&[
+                    "-e".into(),
+                    "on run argv".into(),
+                    "-e".into(),
+                    "set theBody to item 1 of argv".into(),
+                    "-e".into(),
+                    "set theSubtitle to item 2 of argv".into(),
+                    "-e".into(),
+                    "display notification theBody with title \"CodeWhale\" subtitle theSubtitle sound name \"default\"".into(),
+                    "-e".into(),
+                    "end run".into(),
+                    "--".into(),
+                    body_text.into(),
+                    subtitle.into(),
+                ]);
             } else {
-                format!(
-                    "display notification \"{escaped}\" with title \"DeepSeek TUI\" sound name \"default\""
-                )
-            };
+                args.extend_from_slice(&[
+                    "-e".into(),
+                    "on run argv".into(),
+                    "-e".into(),
+                    "display notification (item 1 of argv) with title \"CodeWhale\" sound name \"default\"".into(),
+                    "-e".into(),
+                    "end run".into(),
+                    "--".into(),
+                    body_str,
+                ]);
+            }
 
             match std::process::Command::new("osascript")
-                .args(["-e", &script])
+                .args(&args)
                 .output()
             {
                 Ok(output) if !output.status.success() => {

--- a/crates/tui/src/tui/notifications.rs
+++ b/crates/tui/src/tui/notifications.rs
@@ -32,6 +32,8 @@ pub enum Method {
     Osc9,
     /// Plain BEL character: `\x07`
     Bel,
+    /// osascript
+    MacOS,
     /// Kitty notification protocol (OSC 99) with ST terminator.
     /// Uses `ESC ] 99 ; params ST` — no audible beep, unlike BEL.
     Kitty,
@@ -96,6 +98,10 @@ fn resolve_method() -> Method {
         return Method::Bel;
     }
 
+    if cfg!(target_os = "macos") {
+        return Method::MacOS;
+    }
+
     // Ghostty-based terminals (cmux, etc.) may not set their own
     // TERM_PROGRAM but do set TERM=xterm-ghostty. Likewise for Kitty.
     let term = std::env::var("TERM").unwrap_or_default();
@@ -153,8 +159,8 @@ fn build_escape(method: Method, in_tmux: bool, msg: &str) -> Vec<u8> {
             let seq = format!("\x1b]777;notify;codewhale;{msg}\x07");
             wrap_for_multiplexer(&seq, in_tmux).into_bytes()
         }
-        // Auto and Off should not reach build_escape.
-        Method::Auto | Method::Off => vec![],
+        // Auto and Off and MacOS should not reach build_escape.
+        Method::Auto | Method::Off | Method::MacOS => vec![],
     }
 }
 
@@ -178,6 +184,13 @@ pub fn notify_done_to<W: Write>(
         Method::Auto => resolve_method(),
         other => other,
     };
+
+    // macOS Notification Center: handled via osascript, not terminal escapes.
+    if Method::MacOS==effective {
+        macos_display_notification(msg);
+        return;
+    }
+
     let bytes = build_escape(effective, in_tmux, msg);
     if bytes.is_empty() {
         return;
@@ -376,6 +389,75 @@ fn beep_sound() {
 /// Pure terminal BEL character.
 fn bell_sound() {
     let _ = io::stdout().write_all(b"\x07");
+}
+
+/// Show a macOS Notification Center alert via `osascript`.
+///
+/// Runs on a dedicated background thread so the caller is not blocked.
+///
+/// The notification includes:
+/// - **Title**: "DeepSeek TUI"
+/// - **Subtitle**: First line of `msg` (when the message contains a newline,
+///   e.g. the response preview from a completed turn)
+/// - **Body**: Remaining lines of `msg`, or the full `msg` if single-line
+/// - **Sound**: Default macOS notification sound
+///
+/// The whole body is capped at 200 **characters** (not bytes) to keep the
+/// bubble readable while correctly handling multi-byte text. Embedded double
+/// quotes are escaped as `\"` so AppleScript tokenises correctly.
+///
+/// This is best-effort: if `osascript` is not available (e.g. headless SSH
+/// session) the error is logged via `tracing::warn!` instead of silently
+/// swallowed.
+#[cfg(target_os = "macos")]
+fn macos_display_notification(msg: &str) {
+    let body = msg.to_string();
+
+    // Spawn on a background thread so we don't block the caller.
+    // osascript itself is fast (~50 ms), but spawning a subprocess
+    // synchronously from an async context steals a tokio thread.
+    let _ = std::thread::Builder::new()
+        .name("osascript-notif".into())
+        .spawn(move || {
+            // Char-bounded truncation (not byte-bounded) so we don't slice
+            // through a multi-byte sequence and emit invalid UTF-8 to the
+            // AppleScript parser.
+            let body_str: String = body.chars().take(200).collect();
+
+            // Escape embedded double-quote characters for AppleScript.
+            let escaped = body_str.replace('"', "\\\"");
+
+            // Build the AppleScript command.
+            // When the message has multiple lines, the first line becomes
+            // the subtitle and the rest becomes the body — this lets turn
+            // notifications show the response preview in the subtitle and
+            // the duration/cost summary in the body.
+            let script = if let Some(idx) = escaped.find('\n') {
+                let subtitle = escaped[..idx].trim();
+                let body_text = escaped[idx + 1..].trim();
+                format!(
+                    "display notification \"{body_text}\" with title \"DeepSeek TUI\" subtitle \"{subtitle}\" sound name \"default\""
+                )
+            } else {
+                format!(
+                    "display notification \"{escaped}\" with title \"DeepSeek TUI\" sound name \"default\""
+                )
+            };
+
+            match std::process::Command::new("osascript")
+                .args(["-e", &script])
+                .output()
+            {
+                Ok(output) if !output.status.success() => {
+                    let stderr = String::from_utf8_lossy(&output.stderr);
+                    tracing::warn!(stderr = %stderr, "osascript notification failed");
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "osascript notification error");
+                }
+                _ => {}
+            }
+        });
 }
 
 /// Return a human-readable duration string, capped at two units so

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -22,40 +22,40 @@ use crossterm::{
         EnableFocusChange, EnableMouseCapture, Event, KeyCode, KeyEventKind, KeyModifiers,
     },
     execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
 use ratatui::{
-    layout::{Constraint, Direction, Layout, Rect, Size}, prelude::Widget,
+    Frame, Terminal,
+    layout::{Constraint, Direction, Layout, Rect, Size},
+    prelude::Widget,
     style::Style,
     widgets::Block,
-    Frame,
-    Terminal,
 };
 use tracing;
 
 use crate::audit::log_sensitive_event;
-use crate::automation_manager::{spawn_scheduler, AutomationManager, AutomationSchedulerConfig};
-use crate::client::{build_cache_warmup_request, DeepSeekClient};
+use crate::automation_manager::{AutomationManager, AutomationSchedulerConfig, spawn_scheduler};
+use crate::client::{DeepSeekClient, build_cache_warmup_request};
 use crate::commands;
 use crate::compaction::estimate_input_tokens_conservative;
 use crate::config::{
-    save_provider_auth_mode_for, ApiProvider, Config, ProviderConfig, ProvidersConfig,
-    DEFAULT_NVIDIA_NIM_BASE_URL,
+    ApiProvider, Config, DEFAULT_NVIDIA_NIM_BASE_URL, ProviderConfig, ProvidersConfig,
+    save_provider_auth_mode_for,
 };
 use crate::config_ui::{self, ConfigUiMode, WebConfigSession, WebConfigSessionEvent};
-use crate::core::engine::{spawn_engine, EngineConfig, EngineHandle};
+use crate::core::engine::{EngineConfig, EngineHandle, spawn_engine};
 use crate::core::events::Event as EngineEvent;
 use crate::core::ops::Op;
 use crate::hooks::{HookEvent, HookExecutor};
 use crate::llm_client::LlmClient;
 use crate::models::{
-    context_window_for_model, ContentBlock, Message, MessageRequest, SystemPrompt, Usage,
+    ContentBlock, Message, MessageRequest, SystemPrompt, Usage, context_window_for_model,
 };
 use crate::palette;
 use crate::prompts;
 use crate::session_manager::{
-    create_saved_session_with_id_and_mode, create_saved_session_with_mode, update_session, OfflineQueueState,
-    QueuedSessionMessage, SavedSession, SessionManager,
+    OfflineQueueState, QueuedSessionMessage, SavedSession, SessionManager,
+    create_saved_session_with_id_and_mode, create_saved_session_with_mode, update_session,
 };
 use crate::task_manager::{
     NewTaskRequest, SharedTaskManager, TaskManager, TaskManagerConfig, TaskStatus, TaskSummary,
@@ -65,7 +65,7 @@ use crate::tools::subagent::SubAgentStatus;
 use crate::tui::auto_router;
 use crate::tui::color_compat::ColorCompatBackend;
 use crate::tui::command_palette::{
-    build_entries as build_command_palette_entries, CommandPaletteView,
+    CommandPaletteView, build_entries as build_command_palette_entries,
 };
 use crate::tui::composer_ui::*;
 use crate::tui::context_inspector::build_context_inspector_text;
@@ -109,16 +109,16 @@ use crate::tui::workspace_context;
 use super::key_actions;
 
 use super::app::{
-    looks_like_slash_command_input, App, AppAction, AppMode, OnboardingState, QueuedMessage, ReasoningEffort,
-    SidebarFocus, StatusToastLevel, SubmitDisposition, TaskPanelEntry,
-    TuiOptions,
+    App, AppAction, AppMode, OnboardingState, QueuedMessage, ReasoningEffort, SidebarFocus,
+    StatusToastLevel, SubmitDisposition, TaskPanelEntry, TuiOptions,
+    looks_like_slash_command_input,
 };
 use super::approval::{
     ApprovalMode, ApprovalRequest, ApprovalView, ElevationRequest, ElevationView, ReviewDecision,
 };
 use super::history::{
-    history_cells_from_message, summarize_tool_output, HistoryCell, ToolCell, ToolStatus,
-    TranscriptRenderOptions,
+    HistoryCell, ToolCell, ToolStatus, TranscriptRenderOptions, history_cells_from_message,
+    summarize_tool_output,
 };
 use super::slash_menu::{
     apply_slash_menu_selection, partial_inline_skill_mention_at_cursor,

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -9,14 +9,6 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
-use crossterm::{
-    event::{
-        self, DisableBracketedPaste, DisableFocusChange, DisableMouseCapture, EnableBracketedPaste,
-        EnableFocusChange, EnableMouseCapture, Event, KeyCode, KeyEventKind, KeyModifiers,
-    },
-    execute,
-    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
-};
 // On Windows the push/pop helpers write the escapes directly; crossterm's
 // PushKeyboardEnhancementFlags / PopKeyboardEnhancementFlags commands are
 // never referenced, so the imports are gated to avoid -D warnings failures.
@@ -24,38 +16,46 @@ use crossterm::{
 use crossterm::event::{
     KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
 };
+use crossterm::{
+    event::{
+        self, DisableBracketedPaste, DisableFocusChange, DisableMouseCapture, EnableBracketedPaste,
+        EnableFocusChange, EnableMouseCapture, Event, KeyCode, KeyEventKind, KeyModifiers,
+    },
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
 use ratatui::{
-    Frame, Terminal,
-    layout::{Constraint, Direction, Layout, Rect, Size},
-    prelude::Widget,
+    layout::{Constraint, Direction, Layout, Rect, Size}, prelude::Widget,
     style::Style,
     widgets::Block,
+    Frame,
+    Terminal,
 };
 use tracing;
 
 use crate::audit::log_sensitive_event;
-use crate::automation_manager::{AutomationManager, AutomationSchedulerConfig, spawn_scheduler};
-use crate::client::{DeepSeekClient, build_cache_warmup_request};
+use crate::automation_manager::{spawn_scheduler, AutomationManager, AutomationSchedulerConfig};
+use crate::client::{build_cache_warmup_request, DeepSeekClient};
 use crate::commands;
 use crate::compaction::estimate_input_tokens_conservative;
 use crate::config::{
-    ApiProvider, Config, DEFAULT_NVIDIA_NIM_BASE_URL, ProviderConfig, ProvidersConfig,
-    save_provider_auth_mode_for,
+    save_provider_auth_mode_for, ApiProvider, Config, ProviderConfig, ProvidersConfig,
+    DEFAULT_NVIDIA_NIM_BASE_URL,
 };
 use crate::config_ui::{self, ConfigUiMode, WebConfigSession, WebConfigSessionEvent};
-use crate::core::engine::{EngineConfig, EngineHandle, spawn_engine};
+use crate::core::engine::{spawn_engine, EngineConfig, EngineHandle};
 use crate::core::events::Event as EngineEvent;
 use crate::core::ops::Op;
 use crate::hooks::{HookEvent, HookExecutor};
 use crate::llm_client::LlmClient;
 use crate::models::{
-    ContentBlock, Message, MessageRequest, SystemPrompt, Usage, context_window_for_model,
+    context_window_for_model, ContentBlock, Message, MessageRequest, SystemPrompt, Usage,
 };
 use crate::palette;
 use crate::prompts;
 use crate::session_manager::{
-    OfflineQueueState, QueuedSessionMessage, SavedSession, SessionManager,
-    create_saved_session_with_id_and_mode, create_saved_session_with_mode, update_session,
+    create_saved_session_with_id_and_mode, create_saved_session_with_mode, update_session, OfflineQueueState,
+    QueuedSessionMessage, SavedSession, SessionManager,
 };
 use crate::task_manager::{
     NewTaskRequest, SharedTaskManager, TaskManager, TaskManagerConfig, TaskStatus, TaskSummary,
@@ -65,7 +65,7 @@ use crate::tools::subagent::SubAgentStatus;
 use crate::tui::auto_router;
 use crate::tui::color_compat::ColorCompatBackend;
 use crate::tui::command_palette::{
-    CommandPaletteView, build_entries as build_command_palette_entries,
+    build_entries as build_command_palette_entries, CommandPaletteView,
 };
 use crate::tui::composer_ui::*;
 use crate::tui::context_inspector::build_context_inspector_text;
@@ -109,16 +109,16 @@ use crate::tui::workspace_context;
 use super::key_actions;
 
 use super::app::{
-    App, AppAction, AppMode, OnboardingState, QueuedMessage, ReasoningEffort, SidebarFocus,
-    StatusToastLevel, SubmitDisposition, TaskPanelEntry, TuiOptions,
-    looks_like_slash_command_input,
+    looks_like_slash_command_input, App, AppAction, AppMode, OnboardingState, QueuedMessage, ReasoningEffort,
+    SidebarFocus, StatusToastLevel, SubmitDisposition, TaskPanelEntry,
+    TuiOptions,
 };
 use super::approval::{
     ApprovalMode, ApprovalRequest, ApprovalView, ElevationRequest, ElevationView, ReviewDecision,
 };
 use super::history::{
-    HistoryCell, ToolCell, ToolStatus, TranscriptRenderOptions, history_cells_from_message,
-    summarize_tool_output,
+    history_cells_from_message, summarize_tool_output, HistoryCell, ToolCell, ToolStatus,
+    TranscriptRenderOptions,
 };
 use super::slash_menu::{
     apply_slash_menu_selection, partial_inline_skill_mention_at_cursor,
@@ -1970,8 +1970,7 @@ async fn run_event_loop(
                             if let Some((method, _, _)) =
                                 crate::tui::notifications::settings(config)
                             {
-                                let in_tmux =
-                                    std::env::var("TMUX").is_ok_and(|v| !v.is_empty());
+                                let in_tmux = std::env::var("TMUX").is_ok_and(|v| !v.is_empty());
                                 crate::tui::notifications::notify_done(
                                     method,
                                     in_tmux,
@@ -1987,11 +1986,8 @@ async fn run_event_loop(
                     }
                     EngineEvent::UserInputRequired { id, request } => {
                         app.view_stack.push(UserInputView::new(id.clone(), request));
-                        if let Some((method, _, _)) =
-                            crate::tui::notifications::settings(config)
-                        {
-                            let in_tmux =
-                                std::env::var("TMUX").is_ok_and(|v| !v.is_empty());
+                        if let Some((method, _, _)) = crate::tui::notifications::settings(config) {
+                            let in_tmux = std::env::var("TMUX").is_ok_and(|v| !v.is_empty());
                             crate::tui::notifications::notify_done(
                                 method,
                                 in_tmux,
@@ -2058,14 +2054,11 @@ async fn run_event_loop(
                             if let Some((method, _, _)) =
                                 crate::tui::notifications::settings(config)
                             {
-                                let in_tmux =
-                                    std::env::var("TMUX").is_ok_and(|v| !v.is_empty());
+                                let in_tmux = std::env::var("TMUX").is_ok_and(|v| !v.is_empty());
                                 crate::tui::notifications::notify_done(
                                     method,
                                     in_tmux,
-                                    &format!(
-                                        "Sandbox: {denial_reason} for '{tool_name}'"
-                                    ),
+                                    &format!("Sandbox: {denial_reason} for '{tool_name}'"),
                                     Duration::ZERO,
                                     Duration::ZERO,
                                 );

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -1967,6 +1967,19 @@ async fn run_event_loop(
                             );
                             app.view_stack
                                 .push(ApprovalView::new_for_locale(request, app.ui_locale));
+                            if let Some((method, _, _)) =
+                                crate::tui::notifications::settings(config)
+                            {
+                                let in_tmux =
+                                    std::env::var("TMUX").is_ok_and(|v| !v.is_empty());
+                                crate::tui::notifications::notify_done(
+                                    method,
+                                    in_tmux,
+                                    &format!("Approval needed: {tool_name} - {description}"),
+                                    Duration::ZERO,
+                                    Duration::ZERO,
+                                );
+                            }
                             app.status_message = Some(format!(
                                 "Approval required for '{tool_name}': {description}"
                             ));
@@ -1974,6 +1987,19 @@ async fn run_event_loop(
                     }
                     EngineEvent::UserInputRequired { id, request } => {
                         app.view_stack.push(UserInputView::new(id.clone(), request));
+                        if let Some((method, _, _)) =
+                            crate::tui::notifications::settings(config)
+                        {
+                            let in_tmux =
+                                std::env::var("TMUX").is_ok_and(|v| !v.is_empty());
+                            crate::tui::notifications::notify_done(
+                                method,
+                                in_tmux,
+                                "Action required: please respond in the terminal",
+                                Duration::ZERO,
+                                Duration::ZERO,
+                            );
+                        }
                         app.status_message = Some(
                             "Action required: answer the popup with 1-4, arrows, or Enter"
                                 .to_string(),
@@ -2029,6 +2055,21 @@ async fn run_event_loop(
                                 blocked_write,
                             );
                             app.view_stack.push(ElevationView::new(request));
+                            if let Some((method, _, _)) =
+                                crate::tui::notifications::settings(config)
+                            {
+                                let in_tmux =
+                                    std::env::var("TMUX").is_ok_and(|v| !v.is_empty());
+                                crate::tui::notifications::notify_done(
+                                    method,
+                                    in_tmux,
+                                    &format!(
+                                        "Sandbox: {denial_reason} for '{tool_name}'"
+                                    ),
+                                    Duration::ZERO,
+                                    Duration::ZERO,
+                                );
+                            }
                             app.status_message =
                                 Some(format!("Sandbox blocked {tool_name}: {denial_reason}"));
                         }


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds macOS Notification Center support by introducing a new `Method::MacOS` variant that dispatches via `osascript` instead of terminal escape sequences, and extends the existing notification system to fire on user-action events (tool approval, user input, sandbox elevation) in addition to turn completion.

- `macos_display_notification` uses the `osascript ARGV` approach instead of inline string interpolation, correctly addressing the AppleScript injection risk flagged in a prior review; the title is \"CodeWhale\" and the function runs on a background thread to avoid blocking the tokio runtime.
- Three new notification call sites are added in `ui.rs` for `ApprovalRequired`, `UserInputRequired`, and `ElevationRequired` events; all three intentionally pass `Duration::ZERO` for threshold and elapsed so urgent user-action events are always surfaced regardless of the user-configured completion threshold.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The macOS notification path has an unresolved ordering issue where the macOS guard fires before the $TERM-based terminal-protocol checks, causing macOS users in Ghostty or Kitty without TERM_PROGRAM set to always receive osascript notifications instead of the richer in-terminal protocol.

The core injection concern and compile-guard omission have been fixed, but the resolve_method() ordering issue at line 101 remains, silently regressing terminal-native notification protocols for a class of macOS users on every notification.

crates/tui/src/tui/notifications.rs — the ordering of the cfg!(target_os = macos) guard relative to the $TERM-based protocol detection block in resolve_method().
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/notifications.rs | Adds MacOS method variant + macos_display_notification() via osascript ARGV (injection-safe); macOS guard still placed before $TERM-based protocol fallbacks, which means macOS users in Ghostty/Kitty without TERM_PROGRAM will bypass richer in-terminal protocols. |
| crates/tui/src/tui/ui.rs | Adds immediate notifications for ApprovalRequired, UserInputRequired, and ElevationRequired engine events; correctly bypasses configured threshold (Duration::ZERO) so user-action events always notify; import block reorder is cosmetic only. |

</details>

</details>

<sub>Reviews (4): Last reviewed commit: ["fix: test"](https://github.com/hmbown/codewhale/commit/5068f8cab466b2d53c1bf332ae69b3b634b9d697) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34105040)</sub>

<!-- /greptile_comment -->