### PR TITLE
fix(tui): suppress verbose logs while alt-screen is active

### DIFF
--- a/crates/tui/src/logging.rs
+++ b/crates/tui/src/logging.rs
@@ -101,11 +101,17 @@ pub fn warn(message: impl AsRef<str>) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Mutex, OnceLock};
+    use std::sync::{Mutex, MutexGuard, OnceLock};
 
     fn logging_state_test_lock() -> &'static Mutex<()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn lock_logging_state_test() -> MutexGuard<'static, ()> {
+        logging_state_test_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
     fn reset_logging_state() {
@@ -145,7 +151,7 @@ mod tests {
 
     #[test]
     fn set_verbose_respects_alt_screen_suppression() {
-        let _guard = logging_state_test_lock().lock().unwrap();
+        let _guard = lock_logging_state_test();
         reset_logging_state();
         IN_ALT_SCREEN.store(true, Ordering::SeqCst);
         set_verbose(true);
@@ -160,7 +166,7 @@ mod tests {
 
     #[test]
     fn set_verbose_restores_requested_state_outside_alt_screen() {
-        let _guard = logging_state_test_lock().lock().unwrap();
+        let _guard = lock_logging_state_test();
         reset_logging_state();
         set_verbose(true);
         assert!(is_verbose());

--- a/crates/tui/src/logging.rs
+++ b/crates/tui/src/logging.rs
@@ -7,6 +7,7 @@ use colored::Colorize;
 use crate::palette;
 static VERBOSE: AtomicBool = AtomicBool::new(false);
 static REQUESTED_VERBOSE: AtomicBool = AtomicBool::new(false);
+static IN_ALT_SCREEN: AtomicBool = AtomicBool::new(false);
 
 fn alt_screen_verbose_state(
     requested_verbose: bool,
@@ -23,12 +24,16 @@ fn alt_screen_verbose_state(
 /// Enable or disable verbose logging output.
 pub fn set_verbose(enabled: bool) {
     REQUESTED_VERBOSE.store(enabled, Ordering::SeqCst);
-    VERBOSE.store(enabled, Ordering::SeqCst);
+    VERBOSE.store(
+        alt_screen_verbose_state(enabled, IN_ALT_SCREEN.load(Ordering::SeqCst), cfg!(windows)),
+        Ordering::SeqCst,
+    );
 }
 
 /// Suppress verbose CLI logging while the TUI owns the alt-screen.
 pub fn suppress_for_tui_alt_screen() {
     let requested = REQUESTED_VERBOSE.load(Ordering::SeqCst);
+    IN_ALT_SCREEN.store(true, Ordering::SeqCst);
     VERBOSE.store(
         alt_screen_verbose_state(requested, true, cfg!(windows)),
         Ordering::SeqCst,
@@ -38,6 +43,7 @@ pub fn suppress_for_tui_alt_screen() {
 /// Restore the user's requested verbosity after leaving the alt-screen.
 pub fn restore_after_tui_alt_screen() {
     let requested = REQUESTED_VERBOSE.load(Ordering::SeqCst);
+    IN_ALT_SCREEN.store(false, Ordering::SeqCst);
     VERBOSE.store(
         alt_screen_verbose_state(requested, false, cfg!(windows)),
         Ordering::SeqCst,
@@ -123,5 +129,28 @@ mod tests {
     fn alt_screen_verbose_state_is_noop_off_windows() {
         assert!(alt_screen_verbose_state(true, true, false));
         assert!(!alt_screen_verbose_state(false, true, false));
+    }
+
+    #[test]
+    fn set_verbose_respects_alt_screen_suppression() {
+        IN_ALT_SCREEN.store(true, Ordering::SeqCst);
+        set_verbose(true);
+        assert_eq!(
+            is_verbose(),
+            alt_screen_verbose_state(true, IN_ALT_SCREEN.load(Ordering::SeqCst), cfg!(windows))
+        );
+        IN_ALT_SCREEN.store(false, Ordering::SeqCst);
+        VERBOSE.store(false, Ordering::SeqCst);
+        REQUESTED_VERBOSE.store(false, Ordering::SeqCst);
+    }
+
+    #[test]
+    fn set_verbose_restores_requested_state_outside_alt_screen() {
+        IN_ALT_SCREEN.store(false, Ordering::SeqCst);
+        set_verbose(true);
+        assert!(is_verbose());
+        set_verbose(false);
+        assert!(!is_verbose());
+        REQUESTED_VERBOSE.store(false, Ordering::SeqCst);
     }
 }

--- a/crates/tui/src/logging.rs
+++ b/crates/tui/src/logging.rs
@@ -101,6 +101,18 @@ pub fn warn(message: impl AsRef<str>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn logging_state_test_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn reset_logging_state() {
+        IN_ALT_SCREEN.store(false, Ordering::SeqCst);
+        VERBOSE.store(false, Ordering::SeqCst);
+        REQUESTED_VERBOSE.store(false, Ordering::SeqCst);
+    }
 
     #[test]
     fn log_value_parser_accepts_common_rust_log_directives() {
@@ -133,24 +145,25 @@ mod tests {
 
     #[test]
     fn set_verbose_respects_alt_screen_suppression() {
+        let _guard = logging_state_test_lock().lock().unwrap();
+        reset_logging_state();
         IN_ALT_SCREEN.store(true, Ordering::SeqCst);
         set_verbose(true);
         assert_eq!(
             is_verbose(),
             alt_screen_verbose_state(true, IN_ALT_SCREEN.load(Ordering::SeqCst), cfg!(windows))
         );
-        IN_ALT_SCREEN.store(false, Ordering::SeqCst);
-        VERBOSE.store(false, Ordering::SeqCst);
-        REQUESTED_VERBOSE.store(false, Ordering::SeqCst);
+        reset_logging_state();
     }
 
     #[test]
     fn set_verbose_restores_requested_state_outside_alt_screen() {
-        IN_ALT_SCREEN.store(false, Ordering::SeqCst);
+        let _guard = logging_state_test_lock().lock().unwrap();
+        reset_logging_state();
         set_verbose(true);
         assert!(is_verbose());
         set_verbose(false);
         assert!(!is_verbose());
-        REQUESTED_VERBOSE.store(false, Ordering::SeqCst);
+        reset_logging_state();
     }
 }

--- a/crates/tui/src/logging.rs
+++ b/crates/tui/src/logging.rs
@@ -6,10 +6,42 @@ use colored::Colorize;
 
 use crate::palette;
 static VERBOSE: AtomicBool = AtomicBool::new(false);
+static REQUESTED_VERBOSE: AtomicBool = AtomicBool::new(false);
+
+fn alt_screen_verbose_state(
+    requested_verbose: bool,
+    in_alt_screen: bool,
+    is_windows: bool,
+) -> bool {
+    if is_windows && in_alt_screen {
+        false
+    } else {
+        requested_verbose
+    }
+}
 
 /// Enable or disable verbose logging output.
 pub fn set_verbose(enabled: bool) {
+    REQUESTED_VERBOSE.store(enabled, Ordering::SeqCst);
     VERBOSE.store(enabled, Ordering::SeqCst);
+}
+
+/// Suppress verbose CLI logging while the TUI owns the alt-screen.
+pub fn suppress_for_tui_alt_screen() {
+    let requested = REQUESTED_VERBOSE.load(Ordering::SeqCst);
+    VERBOSE.store(
+        alt_screen_verbose_state(requested, true, cfg!(windows)),
+        Ordering::SeqCst,
+    );
+}
+
+/// Restore the user's requested verbosity after leaving the alt-screen.
+pub fn restore_after_tui_alt_screen() {
+    let requested = REQUESTED_VERBOSE.load(Ordering::SeqCst);
+    VERBOSE.store(
+        alt_screen_verbose_state(requested, false, cfg!(windows)),
+        Ordering::SeqCst,
+    );
 }
 
 /// Return true when `DEEPSEEK_LOG_LEVEL` requests verbose output.
@@ -73,5 +105,23 @@ mod tests {
         ));
         assert!(!log_value_enables_verbose("warn"));
         assert!(!log_value_enables_verbose("codewhale_tui=off"));
+    }
+
+    #[test]
+    fn alt_screen_verbose_state_suppresses_verbose_on_windows() {
+        assert!(!alt_screen_verbose_state(true, true, true));
+        assert!(!alt_screen_verbose_state(false, true, true));
+    }
+
+    #[test]
+    fn alt_screen_verbose_state_restores_requested_state_off_alt_screen() {
+        assert!(alt_screen_verbose_state(true, false, true));
+        assert!(!alt_screen_verbose_state(false, false, true));
+    }
+
+    #[test]
+    fn alt_screen_verbose_state_is_noop_off_windows() {
+        assert!(alt_screen_verbose_state(true, true, false));
+        assert!(!alt_screen_verbose_state(false, true, false));
     }
 }

--- a/crates/tui/src/logging.rs
+++ b/crates/tui/src/logging.rs
@@ -149,10 +149,12 @@ mod tests {
         reset_logging_state();
         IN_ALT_SCREEN.store(true, Ordering::SeqCst);
         set_verbose(true);
-        assert_eq!(
-            is_verbose(),
-            alt_screen_verbose_state(true, IN_ALT_SCREEN.load(Ordering::SeqCst), cfg!(windows))
-        );
+        assert!(REQUESTED_VERBOSE.load(Ordering::SeqCst));
+        if cfg!(windows) {
+            assert!(!is_verbose());
+        } else {
+            assert!(is_verbose());
+        }
         reset_logging_state();
     }
 

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -283,6 +283,7 @@ pub async fn run_tui(config: &Config, options: TuiOptions) -> Result<()> {
     let mut stdout = io::stdout();
     if use_alt_screen {
         execute!(stdout, EnterAlternateScreen)?;
+        crate::logging::suppress_for_tui_alt_screen();
     }
     // Initialize the file-backed TUI log and (on Unix) redirect raw stderr
     // away from the alt-screen for the lifetime of this guard. Any
@@ -554,6 +555,7 @@ pub async fn run_tui(config: &Config, options: TuiOptions) -> Result<()> {
     disable_raw_mode()?;
     if use_alt_screen {
         execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+        crate::logging::restore_after_tui_alt_screen();
     }
     if use_mouse_capture {
         execute!(terminal.backend_mut(), DisableMouseCapture)?;
@@ -616,6 +618,7 @@ impl Drop for TerminalCleanupGuard {
         let _ = disable_raw_mode();
         if self.use_alt_screen {
             let _ = execute!(stdout, LeaveAlternateScreen);
+            crate::logging::restore_after_tui_alt_screen();
         }
         if self.use_mouse_capture {
             let _ = execute!(stdout, DisableMouseCapture);
@@ -6907,6 +6910,7 @@ fn pause_terminal(
     disable_raw_mode()?;
     if use_alt_screen {
         execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+        crate::logging::restore_after_tui_alt_screen();
     }
     if use_mouse_capture {
         execute!(terminal.backend_mut(), DisableMouseCapture)?;
@@ -6927,6 +6931,7 @@ fn resume_terminal(
     enable_raw_mode()?;
     if use_alt_screen {
         execute!(terminal.backend_mut(), EnterAlternateScreen)?;
+        crate::logging::suppress_for_tui_alt_screen();
     }
     recover_terminal_modes(
         terminal.backend_mut(),
@@ -7040,6 +7045,7 @@ pub fn emergency_restore_terminal() {
     let _ = execute!(stdout, DisableMouseCapture);
     let _ = disable_raw_mode();
     let _ = execute!(stdout, LeaveAlternateScreen);
+    crate::logging::restore_after_tui_alt_screen();
 }
 
 /// Re-establish terminal mode flags. Idempotent and best-effort: each


### PR DESCRIPTION
## Summary
- track the user-requested verbose setting separately from the currently-active verbose state
- suppress verbose CLI logging while the TUI owns the alt-screen on Windows and restore it on every exit path
- cover the new alt-screen verbosity transitions with focused logging tests

Closes #1909.

## Testing
- tmpdir=$(mktemp -d) && HOME="$tmpdir" USERPROFILE="$tmpdir" RUSTUP_HOME="/Users/bytedance/.rustup" CARGO_HOME="/Users/bytedance/.cargo" cargo test -p codewhale-tui logging::tests::
- tmpdir=$(mktemp -d) && HOME="$tmpdir" USERPROFILE="$tmpdir" RUSTUP_HOME="/Users/bytedance/.rustup" CARGO_HOME="/Users/bytedance/.cargo" cargo test -p codewhale-tui

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes verbose log output leaking into the Windows TUI alt-screen by splitting the single `VERBOSE` atomic into three: `REQUESTED_VERBOSE` (what the user asked for), `IN_ALT_SCREEN` (current TUI state), and `VERBOSE` (the live effective value derived from the other two). Previous review feedback on `set_verbose` bypass and parallel test races has been fully addressed.

- `logging.rs` gains `suppress_for_tui_alt_screen` / `restore_after_tui_alt_screen` helpers and a pure `alt_screen_verbose_state` combinator; stateful tests are serialized with a shared `Mutex` and a start-of-test `reset_logging_state()` call that correctly survives lock poisoning.
- `tui/ui.rs` wires the new helpers into every alt-screen entry and exit site: the normal `run_tui` unwind path, `TerminalCleanupGuard::drop` (panic/early-return safety net), `pause_terminal`/`resume_terminal` (subprocess pauses), and `emergency_restore_terminal`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is self-contained to logging state management with no impact on TUI rendering or data paths.

All exit paths (normal unwind, panic via Drop, subprocess pause/resume, emergency restore) correctly call restore_after_tui_alt_screen, the suppress/restore pair is idempotent, and the test suite serializes the stateful global-atomic tests while leaving the pure-function tests free to run concurrently. No regressions are apparent on non-Windows platforms since alt_screen_verbose_state is a no-op when is_windows is false.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/logging.rs | Adds REQUESTED_VERBOSE and IN_ALT_SCREEN atomics to track the user-requested verbose setting separately from the live VERBOSE state; introduces suppress_for_tui_alt_screen/restore_after_tui_alt_screen helpers and a pure alt_screen_verbose_state combinator; tests are serialized via a shared Mutex with reset at the start of each stateful test, correctly recovering from lock poisoning. |
| crates/tui/src/tui/ui.rs | Hooks suppress_for_tui_alt_screen / restore_after_tui_alt_screen into every alt-screen entry and exit point (run_tui normal path, TerminalCleanupGuard::drop, pause_terminal/resume_terminal, and emergency_restore_terminal), covering all exit paths including panics via the drop guard. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant run_tui
    participant logging
    participant TerminalCleanupGuard

    Caller->>run_tui: run_tui(config, options)
    run_tui->>run_tui: execute!(EnterAlternateScreen)
    run_tui->>logging: suppress_for_tui_alt_screen()
    note over logging: IN_ALT_SCREEN=true<br/>VERBOSE=false (Windows)<br/>REQUESTED_VERBOSE unchanged

    run_tui->>run_tui: "create TerminalCleanupGuard (defused=false)"

    alt Subprocess pause/resume
        run_tui->>run_tui: pause_terminal()
        run_tui->>logging: restore_after_tui_alt_screen()
        note over logging: IN_ALT_SCREEN=false<br/>VERBOSE=REQUESTED_VERBOSE
        run_tui->>run_tui: resume_terminal()
        run_tui->>logging: suppress_for_tui_alt_screen()
    end

    alt Normal exit
        run_tui->>run_tui: "cleanup_guard.defused = true"
        run_tui->>run_tui: execute!(LeaveAlternateScreen)
        run_tui->>logging: restore_after_tui_alt_screen()
        note over logging: IN_ALT_SCREEN=false<br/>VERBOSE=REQUESTED_VERBOSE
    else Panic / early return
        TerminalCleanupGuard->>run_tui: "drop() [defused=false]"
        run_tui->>run_tui: execute!(LeaveAlternateScreen)
        TerminalCleanupGuard->>logging: restore_after_tui_alt_screen()
    else Emergency
        Caller->>run_tui: emergency_restore_terminal()
        run_tui->>logging: restore_after_tui_alt_screen()
    end
```
</details>

<sub>Reviews (5): Last reviewed commit: ["test(logging): recover poisoned test mut..."](https://github.com/hmbown/codewhale/commit/fa54961faba6136cadb82f03f58f3cc9b8cf4634) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34106260)</sub>

<!-- /greptile_comment -->