### PR TITLE
fix(session): serialize tool_use/tool_result blocks in session detail API

### DIFF
--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -707,13 +707,21 @@ fn session_to_detail(session: SavedSession) -> SessionDetailResponse {
                     crate::models::ContentBlock::Thinking { thinking, .. } => {
                         json!({ "type": "thinking", "text": thinking })
                     }
-                    crate::models::ContentBlock::ToolUse { id, name, input, .. } => {
-                        json!({ "type": "tool_use", "id": id, "name": name, "input": input })
+                    crate::models::ContentBlock::ToolUse { id, name, input, caller } => {
+                        let mut obj =
+                            json!({ "type": "tool_use", "id": id, "name": name, "input": input });
+                        if let Some(caller) = caller {
+                            obj["caller"] = json!(caller);
+                        }
+                        obj
                     }
                     crate::models::ContentBlock::ToolResult { tool_use_id, content, is_error, content_blocks, .. } => {
                         let mut obj = json!({ "type": "tool_result", "tool_use_id": tool_use_id });
                         if let Some(cbs) = content_blocks {
                             obj["content_blocks"] = json!(cbs);
+                            if !content.is_empty() {
+                                obj["content"] = json!(content);
+                            }
                         } else {
                             obj["content"] = json!(content);
                         }
@@ -1927,6 +1935,78 @@ mod tests {
                 error: None,
             }
         }
+    }
+
+    fn saved_session_with_blocks(blocks: Vec<crate::models::ContentBlock>) -> SavedSession {
+        SavedSession {
+            schema_version: 1,
+            metadata: SessionMetadata {
+                id: "session-1".to_string(),
+                title: "test session".to_string(),
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+                message_count: 1,
+                total_tokens: 0,
+                model: "test-model".to_string(),
+                workspace: PathBuf::from("."),
+                mode: None,
+                cost: Default::default(),
+                parent_session_id: None,
+                forked_from_message_count: None,
+                cumulative_turn_secs: 0,
+            },
+            messages: vec![crate::models::Message {
+                role: "assistant".to_string(),
+                content: blocks,
+            }],
+            system_prompt: None,
+            context_references: Vec::new(),
+            artifacts: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn session_detail_tool_use_preserves_caller_metadata() {
+        let detail = session_to_detail(saved_session_with_blocks(vec![
+            crate::models::ContentBlock::ToolUse {
+                id: "tool-1".to_string(),
+                name: "task_shell_start".to_string(),
+                input: json!({ "cmd": "cargo test" }),
+                caller: Some(crate::models::ToolCaller {
+                    caller_type: "subagent".to_string(),
+                    tool_id: Some("parent-tool".to_string()),
+                }),
+            },
+        ]));
+
+        let block = &detail.messages[0]["content"][0];
+        assert_eq!(block["type"].as_str(), Some("tool_use"));
+        assert_eq!(block["caller"]["type"].as_str(), Some("subagent"));
+        assert_eq!(block["caller"]["tool_id"].as_str(), Some("parent-tool"));
+    }
+
+    #[test]
+    fn session_detail_tool_result_keeps_fallback_content_with_blocks() {
+        let detail = session_to_detail(saved_session_with_blocks(vec![
+            crate::models::ContentBlock::ToolResult {
+                tool_use_id: "tool-1".to_string(),
+                content: "fallback text".to_string(),
+                is_error: Some(false),
+                content_blocks: Some(vec![json!({
+                    "type": "text",
+                    "text": "structured text"
+                })]),
+            },
+        ]));
+
+        let block = &detail.messages[0]["content"][0];
+        assert_eq!(block["type"].as_str(), Some("tool_result"));
+        assert_eq!(block["content"].as_str(), Some("fallback text"));
+        assert_eq!(
+            block["content_blocks"][0]["text"].as_str(),
+            Some("structured text")
+        );
+        assert_eq!(block["is_error"].as_bool(), Some(false));
     }
 
     #[test]

--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -707,7 +707,30 @@ fn session_to_detail(session: SavedSession) -> SessionDetailResponse {
                     crate::models::ContentBlock::Thinking { thinking, .. } => {
                         json!({ "type": "thinking", "text": thinking })
                     }
-                    _ => json!({ "type": "other" }),
+                    crate::models::ContentBlock::ToolUse { id, name, input, .. } => {
+                        json!({ "type": "tool_use", "id": id, "name": name, "input": input })
+                    }
+                    crate::models::ContentBlock::ToolResult { tool_use_id, content, is_error, content_blocks, .. } => {
+                        let mut obj = json!({ "type": "tool_result", "tool_use_id": tool_use_id });
+                        if let Some(cbs) = content_blocks {
+                            obj["content_blocks"] = json!(cbs);
+                        } else {
+                            obj["content"] = json!(content);
+                        }
+                        if let Some(e) = is_error {
+                            obj["is_error"] = json!(e);
+                        }
+                        obj
+                    }
+                    crate::models::ContentBlock::ServerToolUse { id, name, input } => {
+                        json!({ "type": "tool_use", "id": id, "name": name, "input": input })
+                    }
+                    crate::models::ContentBlock::ToolSearchToolResult { tool_use_id, content } => {
+                        json!({ "type": "tool_result", "tool_use_id": tool_use_id, "content": content })
+                    }
+                    crate::models::ContentBlock::CodeExecutionToolResult { tool_use_id, content } => {
+                        json!({ "type": "tool_result", "tool_use_id": tool_use_id, "content": content })
+                    }
                 })
                 .collect();
             json!({


### PR DESCRIPTION
## Problem

`session_to_detail()` used a catch-all `_ => json!({"type": "other"})` for ContentBlock variants, causing all tool_use and tool_result blocks to be serialized as `{"type": "other"}` with no data. This broke GUI clients (e.g., VSCode extension) that rely on the session detail API to display tool calls.

## Fix

Explicitly serialize all ContentBlock variants in `session_to_detail()`:

- ToolUse → {"type": "tool_use", "id", "name", "input"}
- ToolResult → {"type": "tool_result", "tool_use_id", "content"|"content_blocks", "is_error"}
- ServerToolUse → {"type": "tool_use", ...}
- ToolSearchToolResult → {"type": "tool_result", ...}
- CodeExecutionToolResult → {"type": "tool_result", ...}

Thinking variant uses "text" field (consistent with existing API convention).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes `session_to_detail()` in the runtime API by replacing the catch-all `_ => json!({"type":"other"})` branch with explicit serialization for all remaining `ContentBlock` variants, restoring correct tool call data for GUI clients like the VSCode extension.

- `ToolUse` now emits `id`, `name`, `input`, and an optional `caller` object; `ToolResult` emits `tool_use_id`, `content_blocks`, a conditional `content` string, and `is_error`.
- `ServerToolUse`, `ToolSearchToolResult`, and `CodeExecutionToolResult` are each serialized to their appropriate `tool_use`/`tool_result` shapes.
- Two unit tests cover the `ToolUse` caller-metadata path and the `ToolResult` fallback-content-with-blocks path.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted, additive fix to a serialization function with no side effects beyond the session detail API response.

All ContentBlock variants are now exhaustively matched (removing the silent catch-all), the previously dropped caller and content fields are correctly included, and the new tests cover the two non-obvious cases. No existing behaviour is regressed.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/runtime_api.rs | Replaces the catch-all `_ => json!({"type":"other"})` with explicit serialization of all five remaining ContentBlock variants; adds two targeted unit tests for ToolUse caller metadata and ToolResult fallback content. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[session_to_detail] --> B[Iterate ContentBlock variants]
    B --> C{match block}
    C -->|Text| D["{ type: text, text }"]
    C -->|Thinking| E["{ type: thinking, text }"]
    C -->|ToolUse| F["{ type: tool_use, id, name, input }"]
    F -->|caller is Some| G["+ caller field from ToolCaller"]
    C -->|ToolResult| H["{ type: tool_result, tool_use_id }"]
    H -->|content_blocks is Some| I["+ content_blocks\n+ content if non-empty"]
    H -->|content_blocks is None| J["+ content always"]
    H -->|is_error is Some| K["+ is_error field"]
    C -->|ServerToolUse| L["{ type: tool_use, id, name, input }"]
    C -->|ToolSearchToolResult| M["{ type: tool_result, tool_use_id, content }"]
    C -->|CodeExecutionToolResult| N["{ type: tool_result, tool_use_id, content }"]
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fsession-tool-api%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fsession-tool-api%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fruntime_api.rs%3A718%0AThe%20%60..%60%20ignore%20on%20%60ToolResult%60%20is%20redundant%20%E2%80%94%20all%20four%20current%20fields%20are%20already%20explicitly%20bound.%20Leaving%20it%20in%20place%20means%20a%20future%20fifth%20field%20on%20%60ToolResult%60%20would%20be%20silently%20dropped%20here%2C%20whereas%20the%20%60ToolUse%60%20arm%20%28which%20binds%20all%20four%20of%20its%20fields%20without%20%60..%60%29%20would%20surface%20a%20compile%20error%20under%20the%20same%20circumstance.%20Removing%20%60..%60%20makes%20both%20arms%20consistently%20exhaustive%20at%20the%20field%20level.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20crate%3A%3Amodels%3A%3AContentBlock%3A%3AToolResult%20%7B%20tool_use_id%2C%20content%2C%20is_error%2C%20content_blocks%20%7D%20%3D%3E%20%7B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fruntime_api.rs%3A718%0AThe%20%60..%60%20ignore%20on%20%60ToolResult%60%20is%20redundant%20%E2%80%94%20all%20four%20current%20fields%20are%20already%20explicitly%20bound.%20Leaving%20it%20in%20place%20means%20a%20future%20fifth%20field%20on%20%60ToolResult%60%20would%20be%20silently%20dropped%20here%2C%20whereas%20the%20%60ToolUse%60%20arm%20%28which%20binds%20all%20four%20of%20its%20fields%20without%20%60..%60%29%20would%20surface%20a%20compile%20error%20under%20the%20same%20circumstance.%20Removing%20%60..%60%20makes%20both%20arms%20consistently%20exhaustive%20at%20the%20field%20level.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20crate%3A%3Amodels%3A%3AContentBlock%3A%3AToolResult%20%7B%20tool_use_id%2C%20content%2C%20is_error%2C%20content_blocks%20%7D%20%3D%3E%20%7B%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2265&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fruntime_api.rs%3A718%0AThe%20%60..%60%20ignore%20on%20%60ToolResult%60%20is%20redundant%20%E2%80%94%20all%20four%20current%20fields%20are%20already%20explicitly%20bound.%20Leaving%20it%20in%20place%20means%20a%20future%20fifth%20field%20on%20%60ToolResult%60%20would%20be%20silently%20dropped%20here%2C%20whereas%20the%20%60ToolUse%60%20arm%20%28which%20binds%20all%20four%20of%20its%20fields%20without%20%60..%60%29%20would%20surface%20a%20compile%20error%20under%20the%20same%20circumstance.%20Removing%20%60..%60%20makes%20both%20arms%20consistently%20exhaustive%20at%20the%20field%20level.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20crate%3A%3Amodels%3A%3AContentBlock%3A%3AToolResult%20%7B%20tool_use_id%2C%20content%2C%20is_error%2C%20content_blocks%20%7D%20%3D%3E%20%7B%0A%60%60%60%0A%0A&pr=2265&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix(runtime): preserve session tool deta..."](https://github.com/hmbown/codewhale/commit/49daadd052a9e386636c6d0b566dc59348c587ef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34111597)</sub>

<!-- /greptile_comment -->