### PR TITLE
fix: clean PDF-extracted text to reduce TUI clutter

### DIFF
--- a/crates/tui/src/tools/file.rs
+++ b/crates/tui/src/tools/file.rs
@@ -256,6 +256,41 @@ fn parse_pages_arg(spec: &str) -> Option<(u32, u32)> {
     }
 }
 
+/// Clean PDF-extracted text for TUI display: collapse consecutive blank
+/// lines (more than 1 becomes 1), strip NUL bytes, replace non-breaking
+/// spaces with regular spaces, and trim trailing whitespace on each line.
+/// Produces output that won't clutter the transcript with vertical gaps
+/// or invisible control characters.
+fn clean_pdf_text(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    let mut blank_run = 0usize;
+    for line in raw.lines() {
+        let trimmed = line.trim_end();
+        if trimmed.is_empty() {
+            blank_run = blank_run.saturating_add(1);
+            if blank_run <= 1 {
+                out.push('\n');
+            }
+        } else {
+            blank_run = 0;
+            // Replace NUL bytes (present in some PDF streams) with a visible
+            // placeholder so they don't truncate the tool output at the first \0.
+            let cleaned: String = trimmed
+                .chars()
+                .map(|c| match c {
+                    '\0' => '\u{FFFD}',
+                    '\u{A0}' => ' ', // non-breaking space → regular space
+                    other => other,
+                })
+                .collect();
+            out.push_str(&cleaned);
+            out.push('\n');
+        }
+    }
+    // Trim leading/trailing blank lines from the whole output.
+    out.trim().to_string()
+}
+
 fn read_pdf(path: &Path, pages: Option<&str>) -> Result<ToolResult, ToolError> {
     // Validate the `pages` spec once, up front, so both extractor paths
     // surface the same error shape on bad input.
@@ -325,7 +360,7 @@ fn read_pdf_via_pdf_extract(
             ))
         })?
     };
-    Ok(ToolResult::success(text))
+    Ok(ToolResult::success(clean_pdf_text(&text)))
 }
 
 fn read_pdf_via_pdftotext(
@@ -382,7 +417,7 @@ fn read_pdf_via_pdftotext(
     }
 
     let text = String::from_utf8_lossy(&output.stdout).to_string();
-    Ok(ToolResult::success(text))
+    Ok(ToolResult::success(clean_pdf_text(&text)))
 }
 
 // === WriteFileTool ===
@@ -1224,6 +1259,36 @@ mod tests {
 
     fn sample_pdf_present() -> bool {
         std::path::Path::new(SAMPLE_PDF_PATH).exists()
+    }
+
+    #[test]
+    fn clean_pdf_text_collapses_consecutive_blank_lines() {
+        let raw = "line1\n\n\n\n\nline2\n\n\nline3";
+        let cleaned = super::clean_pdf_text(raw);
+        assert_eq!(cleaned, "line1\n\nline2\n\nline3");
+    }
+
+    #[test]
+    fn clean_pdf_text_strips_nul_bytes() {
+        let raw = "hello\0world";
+        let cleaned = super::clean_pdf_text(raw);
+        assert!(!cleaned.contains('\0'));
+        assert!(cleaned.contains('\u{FFFD}'));
+    }
+
+    #[test]
+    fn clean_pdf_text_replaces_non_breaking_spaces() {
+        let raw = "hello\u{A0}world";
+        let cleaned = super::clean_pdf_text(raw);
+        assert!(!cleaned.contains('\u{A0}'));
+        assert_eq!(cleaned, "hello world");
+    }
+
+    #[test]
+    fn clean_pdf_text_trims_trailing_whitespace() {
+        let raw = "hello   ";
+        let cleaned = super::clean_pdf_text(raw);
+        assert_eq!(cleaned, "hello");
     }
 
     #[test]

--- a/crates/tui/src/tools/file.rs
+++ b/crates/tui/src/tools/file.rs
@@ -257,13 +257,14 @@ fn parse_pages_arg(spec: &str) -> Option<(u32, u32)> {
 }
 
 /// Clean PDF-extracted text for TUI display: collapse consecutive blank
-/// lines (more than 1 becomes 1), strip NUL bytes, replace non-breaking
-/// spaces with regular spaces, and trim trailing whitespace on each line.
-/// Produces output that won't clutter the transcript with vertical gaps
-/// or invisible control characters.
+/// lines (more than 1 becomes 1), replace NUL bytes with U+FFFD, replace
+/// non-breaking spaces with regular spaces, and trim trailing whitespace
+/// on each line. Produces output that won't clutter the transcript with
+/// vertical gaps or invisible control characters.
 fn clean_pdf_text(raw: &str) -> String {
     let mut out = String::with_capacity(raw.len());
     let mut blank_run = 0usize;
+    let mut any_content = false;
     for line in raw.lines() {
         let trimmed = line.trim_end();
         if trimmed.is_empty() {
@@ -273,22 +274,29 @@ fn clean_pdf_text(raw: &str) -> String {
             }
         } else {
             blank_run = 0;
-            // Replace NUL bytes (present in some PDF streams) with a visible
-            // placeholder so they don't truncate the tool output at the first \0.
-            let cleaned: String = trimmed
-                .chars()
-                .map(|c| match c {
-                    '\0' => '\u{FFFD}',
-                    '\u{A0}' => ' ', // non-breaking space → regular space
-                    other => other,
-                })
-                .collect();
-            out.push_str(&cleaned);
+            any_content = true;
+            // Push cleaned characters directly — avoids a per-line
+            // temporary String allocation.
+            for c in trimmed.chars() {
+                match c {
+                    '\0' => out.push('\u{FFFD}'),
+                    '\u{A0}' => out.push(' '),
+                    other => out.push(other),
+                }
+            }
             out.push('\n');
         }
     }
-    // Trim leading/trailing blank lines from the whole output.
-    out.trim().to_string()
+    // Trim leading blank lines only — don't use str::trim() which
+    // would also strip intentional indentation (e.g. centred titles).
+    if any_content {
+        let start = out.find(|c: char| c != '\n').unwrap_or(0);
+        // Walk back from end to find the last non-newline character.
+        let end = out.rfind(|c: char| c != '\n').map_or(out.len(), |i| i + 1);
+        out[start..end].to_string()
+    } else {
+        String::new()
+    }
 }
 
 fn read_pdf(path: &Path, pages: Option<&str>) -> Result<ToolResult, ToolError> {
@@ -1269,7 +1277,7 @@ mod tests {
     }
 
     #[test]
-    fn clean_pdf_text_strips_nul_bytes() {
+    fn clean_pdf_text_replaces_nul_bytes_with_replacement_char() {
         let raw = "hello\0world";
         let cleaned = super::clean_pdf_text(raw);
         assert!(!cleaned.contains('\0'));
@@ -1289,6 +1297,13 @@ mod tests {
         let raw = "hello   ";
         let cleaned = super::clean_pdf_text(raw);
         assert_eq!(cleaned, "hello");
+    }
+
+    #[test]
+    fn clean_pdf_text_preserves_leading_indentation() {
+        let raw = "   indented line\nregular line";
+        let cleaned = super::clean_pdf_text(raw);
+        assert_eq!(cleaned, "   indented line\nregular line");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Add `clean_pdf_text` post-processing to both PDF extraction paths
(bundled `pdf-extract` and optional `pdftotext`) so PDF output
doesn't clutter the transcript with vertical gaps, invisible
control characters, or non-breaking spaces.

Closes: https://github.com/Hmbown/CodeWhale/issues/2226

## Problem

PDF-extracted text could contain:
- Runs of consecutive blank lines producing large vertical gaps
- NUL bytes that truncate tool output at first \0
- Non-breaking spaces (U+A0) that confuse TUI rendering
- Trailing whitespace on every line

Result: TUI becomes "visually messy and difficult to navigate".

## Fix

`clean_pdf_text(raw: &str) -> String`:
1. Collapses 2+ consecutive blank lines → 1 blank line
2. Replaces NUL bytes with U+FFFD (replacement character)
3. Replaces non-breaking spaces (U+A0) with regular spaces
4. Trims trailing whitespace on each line
5. Trims leading/trailing blank lines from the whole output

Applied in both `read_pdf_via_pdf_extract` and `read_pdf_via_pdftotext`.

## Files Changed

| File | Change |
|---|---|
| `crates/tui/src/tools/file.rs` | +67 / -2 lines |

## Tests

4 new unit tests for `clean_pdf_text`:
- `clean_pdf_text_collapses_consecutive_blank_lines`
- `clean_pdf_text_strips_nul_bytes`
- `clean_pdf_text_replaces_non_breaking_spaces`
- `clean_pdf_text_trims_trailing_whitespace`

All 7 existing PDF tests continue to pass.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a `clean_pdf_text` post-processing step applied to both PDF extraction paths (`pdf-extract` and `pdftotext`) that collapses excess blank lines, replaces NUL bytes with `\u{FFFD}`, normalises non-breaking spaces, and trims trailing whitespace per line, along with five unit tests.

- The trimming logic uses `out.rfind(|c: char| c != '\n').map_or(…, |i| i + 1)` to locate the end boundary, but `rfind` returns the byte offset of the *first byte* of the matched character; adding `1` produces a non-char-boundary slice for any multi-byte character, causing a panic at runtime.
- The panic is reachable through the function's own NUL-replacement path: a PDF whose last visible character is `\0` becomes `\u{FFFD}` (3 UTF-8 bytes), `rfind` yields byte 0, `end = 1`, and `out[0..1]` panics.
- Four of five tests pass only ASCII content through `clean_pdf_text`, so the char-boundary bug is not covered by the new test suite.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe for ASCII-only PDFs but will panic at runtime on any PDF whose last visible character is multi-byte, including the replacement character the function itself introduces for NUL bytes.

The end-boundary calculation adds 1 to the byte index returned by rfind, which is only correct for single-byte characters. For any multi-byte character the function can itself produce, slicing at that offset panics. The new test suite covers only ASCII inputs and would not catch this.

crates/tui/src/tools/file.rs — specifically the end-boundary slice in clean_pdf_text
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tools/file.rs | Adds `clean_pdf_text` post-processing for both PDF extraction paths; the end-boundary calculation in the leading/trailing-newline trim uses `rfind_index + 1` which produces an invalid UTF-8 slice boundary for any multi-byte character, causing a runtime panic. |

</details>

</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fpdf-tui-rendering%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fpdf-tui-rendering%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftools%2Ffile.rs%3A290-299%0A%60rfind%60%20returns%20the%20**byte%20index%20of%20the%20first%20byte**%20of%20the%20matched%20character%2C%20not%20a%20byte-past-the-end%20index.%20Adding%20%601%60%20is%20only%20correct%20for%20single-byte%20%28ASCII%29%20characters.%20For%20any%20multi-byte%20character%20%E2%80%94%20an%20accented%20letter%20like%20%60%C3%A9%60%20%282%20bytes%29%2C%20a%20CJK%20character%20%283%20bytes%29%2C%20or%20%60%5Cu%7BFFFD%7D%60%20itself%20%283%20bytes%2C%20produced%20by%20the%20NUL-replacement%20just%20above%29%20%E2%80%94%20%60i%20%2B%201%60%20lands%20in%20the%20middle%20of%20the%20character%2C%20and%20%60out%5Bstart..end%5D%60%20will%20panic%20with%20%60byte%20index%20N%20is%20not%20a%20char%20boundary%60.%0A%0AConcrete%20panic%3A%20a%20PDF%20whose%20last%20content%20character%20is%20%60%5C0%60%20is%20replaced%20with%20%60%5Cu%7BFFFD%7D%60%20%283%20bytes%29.%20%60rfind%60%20returns%20byte%200%3B%20%60end%20%3D%201%60%3B%20slicing%20%60out%5B0..1%5D%60%20panics.%20Since%20this%20function%20explicitly%20introduces%20%60%5Cu%7BFFFD%7D%60%20replacements%2C%20the%20panic%20is%20reachable%20on%20any%20PDF%20that%20ends%20its%20visible%20content%20with%20a%20NUL%20byte.%20Using%20%60trim_matches%28'%5Cn'%29%60%20sidesteps%20the%20byte-boundary%20arithmetic%20entirely.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%20Trim%20only%20leading%2Ftrailing%20newlines%20%E2%80%94%20trim_matches%28'%5Cn'%29%20stays%20on%0A%20%20%20%20%2F%2F%20char%20boundaries%20and%20won't%20strip%20intentional%20indentation%20on%20the%0A%20%20%20%20%2F%2F%20first%20or%20last%20content%20lines.%0A%20%20%20%20if%20any_content%20%7B%0A%20%20%20%20%20%20%20%20out.trim_matches%28'%5Cn'%29.to_string%28%29%0A%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20String%3A%3Anew%28%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftools%2Ffile.rs%3A290-299%0A%60rfind%60%20returns%20the%20**byte%20index%20of%20the%20first%20byte**%20of%20the%20matched%20character%2C%20not%20a%20byte-past-the-end%20index.%20Adding%20%601%60%20is%20only%20correct%20for%20single-byte%20%28ASCII%29%20characters.%20For%20any%20multi-byte%20character%20%E2%80%94%20an%20accented%20letter%20like%20%60%C3%A9%60%20%282%20bytes%29%2C%20a%20CJK%20character%20%283%20bytes%29%2C%20or%20%60%5Cu%7BFFFD%7D%60%20itself%20%283%20bytes%2C%20produced%20by%20the%20NUL-replacement%20just%20above%29%20%E2%80%94%20%60i%20%2B%201%60%20lands%20in%20the%20middle%20of%20the%20character%2C%20and%20%60out%5Bstart..end%5D%60%20will%20panic%20with%20%60byte%20index%20N%20is%20not%20a%20char%20boundary%60.%0A%0AConcrete%20panic%3A%20a%20PDF%20whose%20last%20content%20character%20is%20%60%5C0%60%20is%20replaced%20with%20%60%5Cu%7BFFFD%7D%60%20%283%20bytes%29.%20%60rfind%60%20returns%20byte%200%3B%20%60end%20%3D%201%60%3B%20slicing%20%60out%5B0..1%5D%60%20panics.%20Since%20this%20function%20explicitly%20introduces%20%60%5Cu%7BFFFD%7D%60%20replacements%2C%20the%20panic%20is%20reachable%20on%20any%20PDF%20that%20ends%20its%20visible%20content%20with%20a%20NUL%20byte.%20Using%20%60trim_matches%28'%5Cn'%29%60%20sidesteps%20the%20byte-boundary%20arithmetic%20entirely.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%20Trim%20only%20leading%2Ftrailing%20newlines%20%E2%80%94%20trim_matches%28'%5Cn'%29%20stays%20on%0A%20%20%20%20%2F%2F%20char%20boundaries%20and%20won't%20strip%20intentional%20indentation%20on%20the%0A%20%20%20%20%2F%2F%20first%20or%20last%20content%20lines.%0A%20%20%20%20if%20any_content%20%7B%0A%20%20%20%20%20%20%20%20out.trim_matches%28'%5Cn'%29.to_string%28%29%0A%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20String%3A%3Anew%28%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2266&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftools%2Ffile.rs%3A290-299%0A%60rfind%60%20returns%20the%20**byte%20index%20of%20the%20first%20byte**%20of%20the%20matched%20character%2C%20not%20a%20byte-past-the-end%20index.%20Adding%20%601%60%20is%20only%20correct%20for%20single-byte%20%28ASCII%29%20characters.%20For%20any%20multi-byte%20character%20%E2%80%94%20an%20accented%20letter%20like%20%60%C3%A9%60%20%282%20bytes%29%2C%20a%20CJK%20character%20%283%20bytes%29%2C%20or%20%60%5Cu%7BFFFD%7D%60%20itself%20%283%20bytes%2C%20produced%20by%20the%20NUL-replacement%20just%20above%29%20%E2%80%94%20%60i%20%2B%201%60%20lands%20in%20the%20middle%20of%20the%20character%2C%20and%20%60out%5Bstart..end%5D%60%20will%20panic%20with%20%60byte%20index%20N%20is%20not%20a%20char%20boundary%60.%0A%0AConcrete%20panic%3A%20a%20PDF%20whose%20last%20content%20character%20is%20%60%5C0%60%20is%20replaced%20with%20%60%5Cu%7BFFFD%7D%60%20%283%20bytes%29.%20%60rfind%60%20returns%20byte%200%3B%20%60end%20%3D%201%60%3B%20slicing%20%60out%5B0..1%5D%60%20panics.%20Since%20this%20function%20explicitly%20introduces%20%60%5Cu%7BFFFD%7D%60%20replacements%2C%20the%20panic%20is%20reachable%20on%20any%20PDF%20that%20ends%20its%20visible%20content%20with%20a%20NUL%20byte.%20Using%20%60trim_matches%28'%5Cn'%29%60%20sidesteps%20the%20byte-boundary%20arithmetic%20entirely.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%20Trim%20only%20leading%2Ftrailing%20newlines%20%E2%80%94%20trim_matches%28'%5Cn'%29%20stays%20on%0A%20%20%20%20%2F%2F%20char%20boundaries%20and%20won't%20strip%20intentional%20indentation%20on%20the%0A%20%20%20%20%2F%2F%20first%20or%20last%20content%20lines.%0A%20%20%20%20if%20any_content%20%7B%0A%20%20%20%20%20%20%20%20out.trim_matches%28'%5Cn'%29.to_string%28%29%0A%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20String%3A%3Anew%28%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0A&pr=2266&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["fix: address code review — preserve inde..."](https://github.com/hmbown/codewhale/commit/e16a3b82a5c09e50610eb5f3314cfa8f28989f8f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34111985)</sub>

<!-- /greptile_comment -->