### PR TITLE
fix: skip draft/pre-release versions in update banner check (#2254)

### DIFF
--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -920,6 +920,14 @@ async fn run_event_loop(
                 .await
                 .ok()?;
             let json: serde_json::Value = resp.json().await.ok()?;
+            // Only notify for fully-published releases — skip drafts and
+            // pre-releases so a pushed tag doesn't trigger a premature
+            // "new version" banner before assets are uploaded (#2254).
+            if json["draft"].as_bool().unwrap_or(true)
+                || json["prerelease"].as_bool().unwrap_or(false)
+            {
+                return None;
+            }
             let tag = json["tag_name"].as_str()?;
             let latest = tag.trim_start_matches('v');
             // Compare semver so dev builds (e.g. "0.8.46-pre") don't


### PR DESCRIPTION
## Summary

Version-check background task now ignores draft and pre-release
GitHub releases so a pushed tag does not trigger a premature
"vX.Y.Z available" banner before release assets are uploaded.

Closes: https://github.com/Hmbown/CodeWhale/issues/2254

## Problem

`/releases/latest` GitHub API returns the most recent release
including drafts and pre-releases. When a maintainer pushes a tag
(but hasn't uploaded binary assets yet), the status bar shows
a persistent "new version available" message that:
1. Is premature — the release isn't actually ready to download
2. Cannot be dismissed — permanently overrides user-configured
   statusline items

## Fix

After fetching the release JSON, check `draft` and `prerelease`
fields. If either is `true`, return `None` so no hint is shown.

## Files Changed

| File | Change |
|---|---|
| `crates/tui/src/tui/ui.rs` | +8 lines |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a guard in the background version-check task that skips GitHub releases where `draft` or `prerelease` is `true`, preventing a premature "new version available" banner before release assets are ready.

- The fix correctly reads both fields from the GitHub API response and returns `None` (no banner) when either flag is set.
- The fallback defaults are asymmetric: `draft` uses `unwrap_or(true)` (treat missing as draft → always skip) while `prerelease` uses `unwrap_or(false)` (treat missing as stable → don't skip). This inconsistency means an absent or non-boolean `draft` field would permanently silence all update notifications.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The change is safe to merge — it tightens the update-notification filter and cannot break any other functionality.

The logic is sound and the GitHub API reliably returns these fields, so the asymmetric defaults are unlikely to cause problems in practice. However, unwrap_or(true) on draft silently suppresses all update banners any time the field is missing, while unwrap_or(false) on prerelease takes the opposite stance.

Only crates/tui/src/tui/ui.rs is affected; the inconsistent fallback defaults in the new guard are the only item worth a second look.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/ui.rs | Adds draft/pre-release guard in the version-check background task; the `draft` field's fallback default is inconsistent with `prerelease`'s, risking silent suppression of all update notifications if the field is absent. |

</details>

</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fversion-banner-premature%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fversion-banner-premature%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui.rs%3A926-928%0AThe%20fallback%20defaults%20for%20the%20two%20fields%20are%20inconsistent.%20%60draft%60%20uses%20%60unwrap_or%28true%29%60%20%E2%80%94%20treating%20a%20missing%2Fnon-bool%20value%20as%20%22yes%2C%20it's%20a%20draft%22%20%28skip%20the%20banner%29%20%E2%80%94%20while%20%60prerelease%60%20uses%20%60unwrap_or%28false%29%60%20%E2%80%94%20treating%20missing%20as%20%22no%2C%20it's%20not%20a%20pre-release%22%20%28don't%20skip%29.%20If%20the%20%60draft%60%20key%20is%20ever%20absent%20from%20the%20response%2C%20all%20update%20notifications%20will%20be%20silently%20suppressed%20forever.%20Both%20fields%20should%20use%20the%20same%20default.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20json%5B%22draft%22%5D.as_bool%28%29.unwrap_or%28false%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%7C%20json%5B%22prerelease%22%5D.as_bool%28%29.unwrap_or%28false%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui.rs%3A926-928%0AThe%20fallback%20defaults%20for%20the%20two%20fields%20are%20inconsistent.%20%60draft%60%20uses%20%60unwrap_or%28true%29%60%20%E2%80%94%20treating%20a%20missing%2Fnon-bool%20value%20as%20%22yes%2C%20it's%20a%20draft%22%20%28skip%20the%20banner%29%20%E2%80%94%20while%20%60prerelease%60%20uses%20%60unwrap_or%28false%29%60%20%E2%80%94%20treating%20missing%20as%20%22no%2C%20it's%20not%20a%20pre-release%22%20%28don't%20skip%29.%20If%20the%20%60draft%60%20key%20is%20ever%20absent%20from%20the%20response%2C%20all%20update%20notifications%20will%20be%20silently%20suppressed%20forever.%20Both%20fields%20should%20use%20the%20same%20default.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20json%5B%22draft%22%5D.as_bool%28%29.unwrap_or%28false%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%7C%20json%5B%22prerelease%22%5D.as_bool%28%29.unwrap_or%28false%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7B%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2268&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui.rs%3A926-928%0AThe%20fallback%20defaults%20for%20the%20two%20fields%20are%20inconsistent.%20%60draft%60%20uses%20%60unwrap_or%28true%29%60%20%E2%80%94%20treating%20a%20missing%2Fnon-bool%20value%20as%20%22yes%2C%20it's%20a%20draft%22%20%28skip%20the%20banner%29%20%E2%80%94%20while%20%60prerelease%60%20uses%20%60unwrap_or%28false%29%60%20%E2%80%94%20treating%20missing%20as%20%22no%2C%20it's%20not%20a%20pre-release%22%20%28don't%20skip%29.%20If%20the%20%60draft%60%20key%20is%20ever%20absent%20from%20the%20response%2C%20all%20update%20notifications%20will%20be%20silently%20suppressed%20forever.%20Both%20fields%20should%20use%20the%20same%20default.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20json%5B%22draft%22%5D.as_bool%28%29.unwrap_or%28false%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%7C%20json%5B%22prerelease%22%5D.as_bool%28%29.unwrap_or%28false%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7B%0A%60%60%60%0A%0A&pr=2268&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix: skip draft/prerelease versions in u..."](https://github.com/hmbown/codewhale/commit/8d88c75576d08575b7b269ef305531a06b6f9131) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34115645)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->