### PR TITLE
fix(tui): keep task shell tools eagerly loaded (#2253)

### DIFF
--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -464,6 +464,16 @@ fn non_yolo_mode_retains_default_defer_policy() {
         AppMode::Agent,
         &always_load
     ));
+    assert!(!should_default_defer_tool(
+        "task_shell_start",
+        AppMode::Agent,
+        &always_load
+    ));
+    assert!(!should_default_defer_tool(
+        "task_shell_wait",
+        AppMode::Agent,
+        &always_load
+    ));
     assert!(should_default_defer_tool(
         "git_show",
         AppMode::Agent,

--- a/crates/tui/src/core/engine/tool_catalog.rs
+++ b/crates/tui/src/core/engine/tool_catalog.rs
@@ -46,6 +46,8 @@ pub(super) const DEFAULT_ACTIVE_NATIVE_TOOLS: &[&str] = &[
     "task_create",
     "task_list",
     "task_read",
+    "task_shell_start",
+    "task_shell_wait",
     "update_plan",
     "web_search",
     "write_file",


### PR DESCRIPTION
## Summary
- keep task_shell_start and task_shell_wait in the default eager native-tool catalog
- prevent first-use schema hydration from replacing execution for the long-running shell flow
- add regression coverage to the native deferral policy

Closes #2253.

Thanks @bevis-wong for the clear Windows/deepseek-v4-flash report and logs.

## Verification
- cargo fmt --all -- --check
- git diff --check
- cargo test -p codewhale-tui non_yolo_mode_retains_default_defer_policy -- --nocapture
- cargo check -p codewhale-tui --all-features --locked
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hmbown/codewhale/pull/2271" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a regression where `task_shell_start` and `task_shell_wait` were omitted from the eagerly-loaded native tool catalog, causing first-use calls to be intercepted by the deferred schema-hydration path instead of executing — breaking the long-running shell flow, notably on Windows with deepseek-v4-flash.

- **`tool_catalog.rs`**: Inserts `task_shell_start` and `task_shell_wait` into `DEFAULT_ACTIVE_NATIVE_TOOLS` in the correct alphabetical position, so `should_default_defer_tool` returns `false` for both and `maybe_hydrate_requested_deferred_tool` no longer intercepts their first call.
- **`tests.rs`**: Adds two assertions to the existing `non_yolo_mode_retains_default_defer_policy` test, providing targeted regression coverage for the fix.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a two-line catalog addition with a matching regression test; no existing behavior is altered for any other tool.

The fix is minimal and surgical: two tool names added to an alphabetically-ordered constant, a targeted should_default_defer_tool check confirmed by two new test assertions, and the logic path through maybe_hydrate_requested_deferred_tool is already well-exercised by the surrounding test suite. There is no risk of side-effects on other tools in the catalog.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/core/engine/tool_catalog.rs | Adds task_shell_start and task_shell_wait to DEFAULT_ACTIVE_NATIVE_TOOLS, keeping them eagerly loaded and preventing first-use schema hydration from intercepting the long-running shell flow. |
| crates/tui/src/core/engine/tests.rs | Extends non_yolo_mode_retains_default_defer_policy with two new assertions confirming task_shell_start and task_shell_wait are not deferred; regression coverage is correct and well-placed. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Model requests task_shell_start / task_shell_wait"] --> B{"Is tool in DEFAULT_ACTIVE_NATIVE_TOOLS?"}
    B -- "Before fix: NO (deferred)" --> C["maybe_hydrate_requested_deferred_tool intercepts call"]
    C --> D["Returns schema-hydration response\n(tool NOT executed, retry required)"]
    D --> E["Long-running shell flow broken\n(regression on Windows / deepseek-v4-flash)"]
    B -- "After fix: YES (eager)" --> F["should_default_defer_tool returns false\ndefer_loading = Some(false)"]
    F --> G["maybe_hydrate_requested_deferred_tool returns None\n(tool proceeds to execution)"]
    G --> H["task_shell_start / task_shell_wait execute normally"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tui): keep task shell tools eagerly ..."](https://github.com/hmbown/codewhale/commit/810130ed63c657033ef5cc474c805e86ffe5a2de) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34132962)</sub>

<!-- /greptile_comment -->