### PR TITLE
fix(tui): skip hidden worktrees in discovery walks (#2211)

### DIFF
--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -78,6 +78,7 @@ mod tui;
 mod utils;
 mod vision;
 mod working_set;
+mod workspace_discovery;
 mod workspace_trust;
 
 use crate::config::{Config, DEFAULT_TEXT_MODEL, MAX_SUBAGENTS, effective_home_dir};

--- a/crates/tui/src/tui/file_picker.rs
+++ b/crates/tui/src/tui/file_picker.rs
@@ -24,6 +24,7 @@ use ratatui::{
 
 use crate::palette;
 use crate::tui::views::{ModalKind, ModalView, ViewAction, ViewEvent};
+use crate::workspace_discovery::{DISCOVERY_ALWAYS_DIRS, path_is_excluded_from_discovery};
 
 /// Maximum number of candidates collected from the initial walk. Keeps memory
 /// bounded for very large monorepos; matches the limits codex-rs uses for the
@@ -437,7 +438,7 @@ fn collect_candidates(root: &Path) -> Vec<String> {
 
     // Whitelist AI-tool dot-directories so they're discoverable even when
     // gitignored. Walk each one separately with gitignore disabled.
-    for dir in [".deepseek", ".cursor", ".claude", ".agents"] {
+    for dir in DISCOVERY_ALWAYS_DIRS {
         let dot_dir = root.join(dir);
         if !dot_dir.is_dir() {
             continue;
@@ -451,7 +452,7 @@ fn collect_candidates(root: &Path) -> Vec<String> {
             .max_depth(Some(WALK_DEPTH.saturating_sub(1)));
         for entry in dot_builder.build().flatten() {
             // Exclude machine-generated bulk (e.g. .deepseek/snapshots/).
-            if entry.path().starts_with(root.join(".deepseek/snapshots")) {
+            if path_is_excluded_from_discovery(root, entry.path()) {
                 continue;
             }
             if !entry.file_type().is_some_and(|ft| ft.is_file()) {
@@ -731,6 +732,60 @@ mod tests {
         assert!(
             !visible.iter().any(|p| p.ends_with("skipme.txt")),
             "skipme.txt should be filtered by .ignore: {visible:?}"
+        );
+    }
+
+    #[test]
+    fn picker_skips_generated_worktree_bulk_inside_unignored_dot_dirs() {
+        let dir = TempDir::new().expect("tempdir");
+        let root = dir.path();
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::write(root.join("src/main.rs"), "fn main() {}").unwrap();
+
+        fs::create_dir_all(root.join(".deepseek/commands")).unwrap();
+        fs::write(root.join(".deepseek/commands/build.md"), "build").unwrap();
+        fs::create_dir_all(root.join(".deepseek/snapshots/deadbeef/.git/objects")).unwrap();
+        fs::write(
+            root.join(".deepseek/snapshots/deadbeef/.git/objects/snapshot.pack"),
+            "pack",
+        )
+        .unwrap();
+
+        fs::create_dir_all(root.join(".claude/commands")).unwrap();
+        fs::write(root.join(".claude/commands/test.md"), "test").unwrap();
+        fs::create_dir_all(root.join(".claude/worktrees/agent/src")).unwrap();
+        fs::write(
+            root.join(".claude/worktrees/agent/src/agent-only.md"),
+            "agent",
+        )
+        .unwrap();
+
+        let candidates = collect_candidates(root);
+
+        assert!(candidates.iter().any(|path| path == "src/main.rs"));
+        assert!(
+            candidates
+                .iter()
+                .any(|path| path == ".deepseek/commands/build.md"),
+            "normal .deepseek command files should stay discoverable: {candidates:?}",
+        );
+        assert!(
+            candidates
+                .iter()
+                .any(|path| path == ".claude/commands/test.md"),
+            "normal .claude command files should stay discoverable: {candidates:?}",
+        );
+        assert!(
+            candidates
+                .iter()
+                .all(|path| !path.starts_with(".deepseek/snapshots/")),
+            "snapshot side repo files must not enter picker candidates: {candidates:?}",
+        );
+        assert!(
+            candidates
+                .iter()
+                .all(|path| !path.starts_with(".claude/worktrees/")),
+            ".claude worktree files must not enter picker candidates: {candidates:?}",
         );
     }
 }

--- a/crates/tui/src/working_set.rs
+++ b/crates/tui/src/working_set.rs
@@ -7,6 +7,9 @@
 //! - pinned message indices that compaction should preserve
 
 use crate::models::{ContentBlock, Message};
+use crate::workspace_discovery::{
+    DISCOVERY_ALWAYS_DIRS, path_is_excluded_from_discovery, should_skip_unignored_discovery_entry,
+};
 use ignore::WalkBuilder;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -269,32 +272,6 @@ const COMPLETIONS_WALK_DEPTH: usize = 6;
 /// above the actual entry count and the cap is a no-op.
 const FILE_INDEX_MAX_ENTRIES: usize = 50_000;
 
-/// Directories that must remain discoverable for `@`-mention completion and
-/// fuzzy file resolution even when excluded by `.gitignore`. AI-tool
-/// convention directories (`.deepseek/`, `.cursor/`, `.claude/`, `.agents/`)
-/// are routinely gitignored, but users need to `@`-mention files inside them.
-const DISCOVERY_ALWAYS_DIRS: &[&str] = &[".deepseek", ".cursor", ".claude", ".agents"];
-
-/// Subdirectories under `DISCOVERY_ALWAYS_DIRS` that must NOT be indexed
-/// even when the parent dir is walked with gitignore disabled. These are
-/// large, machine-generated, or sensitive paths that would blow up the
-/// walker (e.g. `.deepseek/snapshots/` — the snapshot side repo that
-/// #1112 caps at 500 MB; indexing it would trigger the same OOM/hang
-/// the cap was built to prevent).
-const DISCOVERY_EXCLUDED_SUBDIRS: &[&str] = &[".deepseek/snapshots"];
-
-/// Check whether a path resolved against `walk_root` falls inside any
-/// `DISCOVERY_EXCLUDED_SUBDIRS` entry. Used to keep the snapshot side
-/// repo (`.deepseek/snapshots/`) out of the completion/index walk.
-fn path_is_excluded_from_discovery(walk_root: &Path, path: &Path) -> bool {
-    for excluded in DISCOVERY_EXCLUDED_SUBDIRS {
-        if path.starts_with(walk_root.join(excluded)) {
-            return true;
-        }
-    }
-    false
-}
-
 /// Configure a `WalkBuilder` for workspace discovery: hidden files, no
 /// symlink following, depth-limited, custom `.deepseekignore` honored,
 /// and gitignore overrides for AI-tool dot-directories so `@`-completion
@@ -494,7 +471,10 @@ fn local_reference_paths(root: &Path, limit: usize) -> Vec<PathBuf> {
         .git_global(false)
         .git_exclude(false);
     let _ = builder.add_custom_ignore_filename(".deepseekignore");
-    builder.filter_entry(|entry| !should_skip_local_reference_dir(entry.path()));
+    let root_for_filter = root.to_path_buf();
+    builder.filter_entry(move |entry| {
+        !should_skip_unignored_discovery_entry(&root_for_filter, entry.path())
+    });
 
     for entry in builder.build().flatten() {
         if out.len() >= limit {
@@ -512,25 +492,6 @@ fn local_reference_paths(root: &Path, limit: usize) -> Vec<PathBuf> {
         }
     }
     out
-}
-
-fn should_skip_local_reference_dir(path: &Path) -> bool {
-    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
-        return false;
-    };
-    matches!(
-        name,
-        ".git"
-            | "target"
-            | "node_modules"
-            | ".venv"
-            | "venv"
-            | "env"
-            | "dist"
-            | "build"
-            | "__pycache__"
-            | ".ruff_cache"
-    )
 }
 
 impl Clone for Workspace {
@@ -1521,6 +1482,82 @@ mod tests {
                 .any(|e| e == ".generated/specs/secrets.env"),
             ".deepseekignore entries must not be reintroduced by local fallback: {generated_entries:?}",
         );
+    }
+
+    #[test]
+    fn workspace_completions_skip_hidden_worktrees_and_build_bulk() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        std::fs::write(root.join(".gitignore"), ".worktrees/\n.generated/\n").unwrap();
+
+        std::fs::create_dir_all(root.join(".worktrees/release/src")).unwrap();
+        std::fs::write(
+            root.join(".worktrees/release/src/worktree-only.rs"),
+            "fn main() {}",
+        )
+        .unwrap();
+        std::fs::create_dir_all(root.join(".worktrees/release/target/debug")).unwrap();
+        std::fs::write(
+            root.join(".worktrees/release/target/debug/generated.o"),
+            "object",
+        )
+        .unwrap();
+
+        std::fs::create_dir_all(root.join(".claude/worktrees/agent/src")).unwrap();
+        std::fs::write(
+            root.join(".claude/worktrees/agent/src/agent-only.md"),
+            "agent note",
+        )
+        .unwrap();
+        std::fs::create_dir_all(root.join(".claude/commands")).unwrap();
+        std::fs::write(root.join(".claude/commands/keep.md"), "command").unwrap();
+
+        std::fs::create_dir_all(root.join(".generated/specs")).unwrap();
+        std::fs::write(root.join(".generated/specs/device-layout.md"), "layout").unwrap();
+
+        let ws = Workspace::with_cwd(root.to_path_buf(), Some(root.to_path_buf()));
+
+        let worktree_entries = ws.completions(".worktrees", 32);
+        assert!(
+            worktree_entries
+                .iter()
+                .all(|entry| !entry.starts_with(".worktrees/")),
+            "hidden release worktrees must stay out of completions: {worktree_entries:?}",
+        );
+
+        let claude_worktree_entries = ws.completions(".claude/worktrees", 32);
+        assert!(
+            claude_worktree_entries
+                .iter()
+                .all(|entry| !entry.starts_with(".claude/worktrees/")),
+            ".claude/worktrees must stay out of completions: {claude_worktree_entries:?}",
+        );
+
+        let generated_entries = ws.completions(".generated/specs", 32);
+        assert!(
+            generated_entries
+                .iter()
+                .any(|entry| entry == ".generated/specs/device-layout.md"),
+            "explicit user-generated hidden folders should still complete: {generated_entries:?}",
+        );
+
+        let command_entries = ws.completions(".claude/commands", 32);
+        assert!(
+            command_entries
+                .iter()
+                .any(|entry| entry == ".claude/commands/keep.md"),
+            "normal .claude command files should still complete: {command_entries:?}",
+        );
+
+        assert!(
+            ws.resolve("worktree-only.rs").is_err(),
+            "fuzzy resolution must not index files from hidden release worktrees"
+        );
+        assert!(
+            ws.resolve("agent-only.md").is_err(),
+            "fuzzy resolution must not index files from .claude/worktrees"
+        );
+        assert!(ws.resolve("keep.md").is_ok());
     }
 
     #[test]

--- a/crates/tui/src/workspace_discovery.rs
+++ b/crates/tui/src/workspace_discovery.rs
@@ -1,0 +1,53 @@
+//! Shared workspace discovery filters for UI path pickers and mentions.
+
+use std::path::Path;
+
+/// Directories that must remain discoverable for `@`-mention completion and
+/// fuzzy file resolution even when excluded by `.gitignore`.
+pub(crate) const DISCOVERY_ALWAYS_DIRS: &[&str] = &[".deepseek", ".cursor", ".claude", ".agents"];
+
+/// Root-relative directories that are too large or generated to discover
+/// with gitignore disabled. Exact user-specified paths may still resolve.
+const DISCOVERY_EXCLUDED_SUBDIRS: &[&str] =
+    &[".deepseek/snapshots", ".worktrees", ".claude/worktrees"];
+
+/// Directory basenames that should not be traversed by fallback discovery
+/// walks that deliberately disable gitignore.
+const DISCOVERY_EXCLUDED_DIR_NAMES: &[&str] = &[
+    ".git",
+    "target",
+    "node_modules",
+    ".venv",
+    "venv",
+    "env",
+    "dist",
+    "build",
+    ".next",
+    ".turbo",
+    "coverage",
+    "__pycache__",
+    ".pytest_cache",
+    ".ruff_cache",
+];
+
+/// Check whether `path` is under a root-relative excluded discovery subtree.
+pub(crate) fn path_is_excluded_from_discovery(walk_root: &Path, path: &Path) -> bool {
+    DISCOVERY_EXCLUDED_SUBDIRS
+        .iter()
+        .any(|excluded| path.starts_with(walk_root.join(excluded)))
+}
+
+/// Filter for walks that turn off gitignore to surface explicit hidden paths.
+pub(crate) fn should_skip_unignored_discovery_entry(walk_root: &Path, path: &Path) -> bool {
+    if path == walk_root {
+        return false;
+    }
+
+    if path_is_excluded_from_discovery(walk_root, path) {
+        return true;
+    }
+
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| DISCOVERY_EXCLUDED_DIR_NAMES.contains(&name))
+}


### PR DESCRIPTION
## Summary
- add shared discovery filters for gitignore-disabled TUI walks
- skip hidden release worktrees, Claude worktrees, DeepSeek snapshots, and common build/cache directories during fallback discovery
- keep normal AI command folders and explicit user hidden folders discoverable

Refs #2211. This intentionally leaves the broader sub-agent fanout/backpressure UI acceptance criteria open.

## Verification
- cargo test -p codewhale-tui workspace_completions_skip_hidden_worktrees_and_build_bulk -- --nocapture
- cargo test -p codewhale-tui picker_skips_generated_worktree_bulk_inside_unignored_dot_dirs -- --nocapture
- cargo check -p codewhale-tui --all-features --locked
- cargo fmt --all -- --check
- git diff --check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hmbown/codewhale/pull/2273" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extracts shared workspace-discovery predicates into a new `workspace_discovery` module and expands what gets excluded from gitignore-disabled TUI walks: hidden release worktrees (`.worktrees/`), Claude agent worktrees (`.claude/worktrees/`), DeepSeek snapshot repos (`.deepseek/snapshots/`), and common build/cache directories. Normal AI-tool command folders remain fully discoverable.

- **`workspace_discovery.rs`** (new): defines `DISCOVERY_ALWAYS_DIRS`, `DISCOVERY_EXCLUDED_SUBDIRS`, `DISCOVERY_EXCLUDED_DIR_NAMES`, and two public predicates (`path_is_excluded_from_discovery`, `should_skip_unignored_discovery_entry`).
- **`local_reference_paths`** in `working_set.rs`: correctly swaps `should_skip_local_reference_dir` for `should_skip_unignored_discovery_entry` via `filter_entry`, giving proper early-pruning of excluded subtrees.
- **Dot-dir walks** in both `working_set::walk_always_discoverable_dirs` and `file_picker::collect_candidates`: continue using `path_is_excluded_from_discovery` as a post-loop `if-continue` guard rather than `filter_entry`, so the walker still descends into excluded subtrees before discarding their entries; the `DISCOVERY_EXCLUDED_DIR_NAMES` check is also not applied there.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The change is safe to merge; it correctly prevents hidden worktree files from appearing in completions and the file picker, and adds well-tested filtering logic.

The refactoring achieves its goal cleanly and all three changed predicates are exercised by the new tests. The two gaps — dot-dir walks not using filter_entry for early pruning, and DISCOVERY_EXCLUDED_DIR_NAMES not being applied in those same walks — are efficiency/consistency concerns rather than correctness bugs, and both are pre-existing patterns.

The dot-dir walk sections in working_set.rs (walk_always_discoverable_dirs) and file_picker.rs (collect_candidates) would benefit from follow-up to adopt filter_entry with should_skip_unignored_discovery_entry for consistency with local_reference_paths.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/tui/src/workspace_discovery.rs | New module centralizing discovery filter constants and predicates; logic is correct but should_skip_unignored_discovery_entry is only partially adopted across call sites. |
| crates/tui/src/working_set.rs | Replaces should_skip_local_reference_dir with the unified filter in local_reference_paths (correct, uses filter_entry), but walk_always_discoverable_dirs still uses only path_is_excluded_from_discovery as a post-loop check without early pruning. |
| crates/tui/src/tui/file_picker.rs | Switches from a hardcoded .deepseek/snapshots check to path_is_excluded_from_discovery; same post-entry filter pattern without filter_entry pruning — pre-existing but not improved. |
| crates/tui/src/main.rs | Trivial: adds mod workspace_discovery declaration. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/tui/src/working_set.rs`, line 317-326 ([link](https://github.com/hmbown/codewhale/blob/4ec2df9a4f44b31fe1b77190f1d3958778098094/crates/tui/src/working_set.rs#L317-L326)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Dot-dir walk still descends into excluded subtrees**

   `path_is_excluded_from_discovery` is called as a post-loop `if-continue` guard, not as a `filter_entry` predicate. The `WalkBuilder` will still enumerate every file under `.claude/worktrees/` or `.deepseek/snapshots/` before those entries are discarded. `local_reference_paths` was correctly updated to use `filter_entry` with `should_skip_unignored_discovery_entry`, but `walk_always_discoverable_dirs` (and the parallel loop in `file_picker::collect_candidates`) still lack early pruning. If a hidden worktree contains thousands of files within `max_depth`, all of them are traversed but silently dropped — the same traversal overhead the `.deepseek/snapshots` comment in the old code warned about.

   <a href="https://app.greptile.com/api/ide/devin?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2F2211-discovery-skip-worktrees%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F2211-discovery-skip-worktrees%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fworking_set.rs%0ALine%3A%20317-326%0A%0AComment%3A%0A**Dot-dir%20walk%20still%20descends%20into%20excluded%20subtrees**%0A%0A%60path_is_excluded_from_discovery%60%20is%20called%20as%20a%20post-loop%20%60if-continue%60%20guard%2C%20not%20as%20a%20%60filter_entry%60%20predicate.%20The%20%60WalkBuilder%60%20will%20still%20enumerate%20every%20file%20under%20%60.claude%2Fworktrees%2F%60%20or%20%60.deepseek%2Fsnapshots%2F%60%20before%20those%20entries%20are%20discarded.%20%60local_reference_paths%60%20was%20correctly%20updated%20to%20use%20%60filter_entry%60%20with%20%60should_skip_unignored_discovery_entry%60%2C%20but%20%60walk_always_discoverable_dirs%60%20%28and%20the%20parallel%20loop%20in%20%60file_picker%3A%3Acollect_candidates%60%29%20still%20lack%20early%20pruning.%20If%20a%20hidden%20worktree%20contains%20thousands%20of%20files%20within%20%60max_depth%60%2C%20all%20of%20them%20are%20traversed%20but%20silently%20dropped%20%E2%80%94%20the%20same%20traversal%20overhead%20the%20%60.deepseek%2Fsnapshots%60%20comment%20in%20the%20old%20code%20warned%20about.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&tid=69448&ts=1779878914&sig=59e3ce1cdfdca9d8c7639a1678809af2f355aeda6a2d69b58b592c9fd539edc3&pr=2273&platform=github&fid=cb7da251-4ba8-4042-87cb-34b648288fc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInDevinDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInDevin.svg?v=3"><img alt="Fix in Devin" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInDevin.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/devin?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2F2211-discovery-skip-worktrees%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F2211-discovery-skip-worktrees%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fworking_set.rs%3A317-326%0A**Dot-dir%20walk%20still%20descends%20into%20excluded%20subtrees**%0A%0A%60path_is_excluded_from_discovery%60%20is%20called%20as%20a%20post-loop%20%60if-continue%60%20guard%2C%20not%20as%20a%20%60filter_entry%60%20predicate.%20The%20%60WalkBuilder%60%20will%20still%20enumerate%20every%20file%20under%20%60.claude%2Fworktrees%2F%60%20or%20%60.deepseek%2Fsnapshots%2F%60%20before%20those%20entries%20are%20discarded.%20%60local_reference_paths%60%20was%20correctly%20updated%20to%20use%20%60filter_entry%60%20with%20%60should_skip_unignored_discovery_entry%60%2C%20but%20%60walk_always_discoverable_dirs%60%20%28and%20the%20parallel%20loop%20in%20%60file_picker%3A%3Acollect_candidates%60%29%20still%20lack%20early%20pruning.%20If%20a%20hidden%20worktree%20contains%20thousands%20of%20files%20within%20%60max_depth%60%2C%20all%20of%20them%20are%20traversed%20but%20silently%20dropped%20%E2%80%94%20the%20same%20traversal%20overhead%20the%20%60.deepseek%2Fsnapshots%60%20comment%20in%20the%20old%20code%20warned%20about.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fworkspace_discovery.rs%3A40-53%0A**%60DISCOVERY_EXCLUDED_DIR_NAMES%60%20only%20applied%20in%20the%20full%20root%20walk%2C%20not%20dot-dir%20walks**%0A%0A%60should_skip_unignored_discovery_entry%60%20%28which%20combines%20path-prefix%20exclusion%20with%20basename%20exclusion%29%20is%20used%20in%20%60local_reference_paths%60%2C%20but%20both%20%60walk_always_discoverable_dirs%60%20in%20%60working_set.rs%60%20and%20the%20equivalent%20loop%20in%20%60file_picker%3A%3Acollect_candidates%60%20call%20only%20%60path_is_excluded_from_discovery%60%20%E2%80%94%20skipping%20the%20%60DISCOVERY_EXCLUDED_DIR_NAMES%60%20check%20entirely.%20A%20%60target%2F%60%20or%20%60node_modules%2F%60%20directory%20inside%20%60.claude%2F%60%20is%20therefore%20traversed%20and%20indexed%20by%20the%20dot-dir%20walks%20even%20though%20%60local_reference_paths%60%20would%20prune%20it.%20The%20new%20unified%20function%20is%20not%20uniformly%20applied.%0A%0A&repo=hmbown%2Fcodewhale&tid=69448&ts=1779878909&sig=96101e082ee1227cf7f14a3af1bc94b88786c70f3da64a4d40c6d7fe3fac109b&pr=2273&platform=github&fid=fed4d835-dde8-4005-86d6-b9a5860f8102"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInDevinDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInDevin.svg?v=3"><img alt="Fix All in Devin" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInDevin.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(tui): skip hidden worktrees in disco..."](https://github.com/hmbown/codewhale/commit/4ec2df9a4f44b31fe1b77190f1d3958778098094) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34135978)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->