### PR TITLE
docs: add provider registry drift check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
       - name: Check provider registry drift
-        run: python scripts/check-provider-registry.py
+        run: python3 scripts/check-provider-registry.py
       - name: Linux clippy location
         run: echo "Linux clippy/test gates run on CNB for mirrored fix/*, rebrand/*, work/v*, and main branches."
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
           components: rustfmt
       - name: Check formatting
         run: cargo fmt --all -- --check
+      - name: Check provider registry drift
+        run: python scripts/check-provider-registry.py
       - name: Linux clippy location
         run: echo "Linux clippy/test gates run on CNB for mirrored fix/*, rebrand/*, work/v*, and main branches."
 

--- a/README.md
+++ b/README.md
@@ -555,6 +555,7 @@ without recreating skills the user deliberately deleted.
 |---|---|
 | [ARCHITECTURE.md](docs/ARCHITECTURE.md) | Codebase internals |
 | [CONFIGURATION.md](docs/CONFIGURATION.md) | Full config reference |
+| [PROVIDERS.md](docs/PROVIDERS.md) | Provider IDs, auth, model defaults, and capability metadata |
 | [MODES.md](docs/MODES.md) | Plan / Agent / YOLO modes |
 | [MCP.md](docs/MCP.md) | Model Context Protocol integration |
 | [RUNTIME_API.md](docs/RUNTIME_API.md) | HTTP/SSE API server |

--- a/crates/cli/src/bin/codew_legacy_shim.rs
+++ b/crates/cli/src/bin/codew_legacy_shim.rs
@@ -37,12 +37,12 @@ fn spawn_codewhale(args: &[String]) -> std::io::Result<std::process::ExitStatus>
     // same directory as this shim but not on PATH (#2006).
     #[cfg(windows)]
     {
-        if let Ok(exe_path) = env::current_exe() {
-            if let Some(dir) = exe_path.parent() {
-                let sibling = dir.join("codewhale.exe");
-                if sibling.is_file() {
-                    return Command::new(sibling).args(args).status();
-                }
+        if let Ok(exe_path) = env::current_exe()
+            && let Some(dir) = exe_path.parent()
+        {
+            let sibling = dir.join("codewhale.exe");
+            if sibling.is_file() {
+                return Command::new(sibling).args(args).status();
             }
         }
     }

--- a/crates/cli/src/bin/deepseek_legacy_shim.rs
+++ b/crates/cli/src/bin/deepseek_legacy_shim.rs
@@ -44,12 +44,12 @@ fn spawn_codewhale(args: &[String]) -> std::io::Result<std::process::ExitStatus>
     // same directory as this shim but not on PATH (#2006).
     #[cfg(windows)]
     {
-        if let Ok(exe_path) = env::current_exe() {
-            if let Some(dir) = exe_path.parent() {
-                let sibling = dir.join("codewhale.exe");
-                if sibling.is_file() {
-                    return Command::new(sibling).args(args).status();
-                }
+        if let Ok(exe_path) = env::current_exe()
+            && let Some(dir) = exe_path.parent()
+        {
+            let sibling = dir.join("codewhale.exe");
+            if sibling.is_file() {
+                return Command::new(sibling).args(args).status();
             }
         }
     }

--- a/crates/tui/src/commands/config.rs
+++ b/crates/tui/src/commands/config.rs
@@ -473,9 +473,9 @@ pub fn set_config_value(app: &mut App, key: &str, value: &str, persist: bool) ->
                     Err(err) => return CommandResult::error(format!("Failed to save: {err}")),
                 }
             }
-            return CommandResult::error(format!(
-                "base_url must be saved with --save; client base URL is loaded from config on startup. Restart and re-open your session after saving."
-            ));
+            return CommandResult::error(
+                "base_url must be saved with --save; client base URL is loaded from config on startup. Restart and re-open your session after saving.",
+            );
         }
         _ => {}
     }

--- a/crates/tui/src/runtime_log.rs
+++ b/crates/tui/src/runtime_log.rs
@@ -174,7 +174,7 @@ fn log_directory() -> Option<PathBuf> {
     {
         return resolve(userprofile);
     }
-    dirs::home_dir().and_then(|h| resolve(h))
+    dirs::home_dir().and_then(resolve)
 }
 
 fn log_file_name(date: &str, pid: u32) -> String {

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -22,7 +22,8 @@ Sources to keep in sync:
 - `config.example.toml` and `docs/CONFIGURATION.md` - user-facing config
   examples and environment variable reference.
 - `scripts/check-provider-registry.py` - drift check for canonical provider
-  IDs, TOML table names, static registry rows, and documented defaults.
+  IDs, live TUI provider IDs, TOML table names, static registry rows, and
+  documented defaults.
 
 ## Provider Selection
 
@@ -147,6 +148,8 @@ python3 scripts/check-provider-registry.py
 The check fails when:
 
 - `docs/PROVIDERS.md` omits a canonical `ProviderKind::as_str()` ID.
+- `crates/tui/src/config.rs` `ApiProvider::as_str()` diverges from
+  `ProviderKind::as_str()` except for the explicit `deepseek-cn` legacy alias.
 - The shipped-provider table omits or adds a `[providers.*]` TOML table.
 - The static model registry table drifts from providers used by
   `crates/agent/src/lib.rs`.

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -21,6 +21,8 @@ Sources to keep in sync:
   `codewhale model list` and `codewhale model resolve`.
 - `config.example.toml` and `docs/CONFIGURATION.md` - user-facing config
   examples and environment variable reference.
+- `scripts/check-provider-registry.py` - drift check for canonical provider
+  IDs, TOML table names, static registry rows, and documented defaults.
 
 ## Provider Selection
 
@@ -133,6 +135,24 @@ DeepSeek compatibility aliases `deepseek-chat` and `deepseek-reasoner` map to
 `deepseek-v4-flash` capability metadata and are scheduled to retire on
 2026-07-24 at 2026-07-24T15:59:00Z.
 
+## Drift Check
+
+Run this before changing provider IDs, provider TOML tables, static model
+registry rows, or provider default strings:
+
+```bash
+python scripts/check-provider-registry.py
+```
+
+The check fails when:
+
+- `docs/PROVIDERS.md` omits a canonical `ProviderKind::as_str()` ID.
+- The shipped-provider table omits or adds a `[providers.*]` TOML table.
+- The static model registry table drifts from providers used by
+  `crates/agent/src/lib.rs`.
+- A provider default model or base URL constant in `crates/tui/src/config.rs`
+  is no longer mentioned here.
+
 ## Planned, Not Shipped Yet
 
 These items belong to the v0.8.47 provider-abstraction milestone or related
@@ -149,9 +169,6 @@ provider docs work, but they are not native shipped behavior in this checkout:
 - Hugging Face model passport metadata in the picker, including license, base
   model, context length, chat template, tool-call support, reasoning support,
   and gated/private status.
-- A generated drift-check script that fails when this file diverges from the
-  provider registry. Until that exists, update this file with a source read of
-  the files listed at the top.
 
 Until native Hugging Face support lands, users can only reach an explicitly
 configured Hugging Face-compatible OpenAI route through the generic `openai`

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -141,7 +141,7 @@ Run this before changing provider IDs, provider TOML tables, static model
 registry rows, or provider default strings:
 
 ```bash
-python scripts/check-provider-registry.py
+python3 scripts/check-provider-registry.py
 ```
 
 The check fails when:

--- a/scripts/check-provider-registry.py
+++ b/scripts/check-provider-registry.py
@@ -6,6 +6,7 @@ the stable identifiers and default strings that are easy for docs to drift from:
 
 - canonical ProviderKind IDs
 - provider TOML tables
+- live TUI ApiProvider IDs
 - shipped-provider table rows
 - static ModelRegistry provider rows
 - default provider model/base URL constants
@@ -23,6 +24,10 @@ CONFIG_RS = ROOT / "crates" / "config" / "src" / "lib.rs"
 TUI_CONFIG_RS = ROOT / "crates" / "tui" / "src" / "config.rs"
 AGENT_RS = ROOT / "crates" / "agent" / "src" / "lib.rs"
 PROVIDERS_MD = ROOT / "docs" / "PROVIDERS.md"
+
+
+API_PROVIDER_ONLY_IDS = {"deepseek-cn"}
+
 
 def read(path: Path) -> str:
     return path.read_text(encoding="utf-8")
@@ -42,8 +47,10 @@ def markdown_section(source: str, heading: str) -> str:
     return source[start:end]
 
 
-def extract_match_block(source: str, signature: str) -> str:
-    start = require_index(source, signature, "crates/config/src/lib.rs")
+def extract_match_block(
+    source: str, signature: str, context: str, start: int = 0
+) -> str:
+    start = require_index(source, signature, context, start)
     match_start = require_index(source, "match", f"match block after {signature!r}", start)
     brace_start = require_index(source, "{", f"match block after {signature!r}", match_start)
     depth = 0
@@ -59,10 +66,34 @@ def extract_match_block(source: str, signature: str) -> str:
 
 
 def provider_kind_ids(config_rs: str) -> dict[str, str]:
-    block = extract_match_block(config_rs, "pub fn as_str(self) -> &'static str")
+    impl_start = require_index(
+        config_rs, "impl ProviderKind", "crates/config/src/lib.rs"
+    )
+    block = extract_match_block(
+        config_rs,
+        "pub fn as_str(self) -> &'static str",
+        "crates/config/src/lib.rs",
+        impl_start,
+    )
     pairs = re.findall(r"Self::(\w+)\s*=>\s*\"([^\"]+)\"", block)
     if not pairs:
         raise ValueError("ProviderKind::as_str returned no providers")
+    return {variant: provider_id for variant, provider_id in pairs}
+
+
+def api_provider_ids(tui_config_rs: str) -> dict[str, str]:
+    impl_start = require_index(
+        tui_config_rs, "impl ApiProvider", "crates/tui/src/config.rs"
+    )
+    block = extract_match_block(
+        tui_config_rs,
+        "pub fn as_str(self) -> &'static str",
+        "crates/tui/src/config.rs",
+        impl_start,
+    )
+    pairs = re.findall(r"Self::(\w+)\s*=>\s*\"([^\"]+)\"", block)
+    if not pairs:
+        raise ValueError("ApiProvider::as_str returned no providers")
     return {variant: provider_id for variant, provider_id in pairs}
 
 
@@ -133,6 +164,34 @@ def report_set(label: str, expected: set[str], actual: set[str]) -> list[str]:
     return errors
 
 
+def report_provider_enum_drift(
+    provider_kind_ids: set[str], api_provider_ids: set[str]
+) -> list[str]:
+    errors = []
+    missing_from_api_provider = sorted(provider_kind_ids - api_provider_ids)
+    unexpected_api_provider_ids = sorted(
+        api_provider_ids - provider_kind_ids - API_PROVIDER_ONLY_IDS
+    )
+    missing_allowlisted_ids = sorted(API_PROVIDER_ONLY_IDS - api_provider_ids)
+
+    if missing_from_api_provider:
+        errors.append(
+            "ApiProvider missing ProviderKind IDs: "
+            + ", ".join(missing_from_api_provider)
+        )
+    if unexpected_api_provider_ids:
+        errors.append(
+            "ApiProvider has non-whitelisted IDs absent from ProviderKind: "
+            + ", ".join(unexpected_api_provider_ids)
+        )
+    if missing_allowlisted_ids:
+        errors.append(
+            "ApiProvider-only whitelist entries are absent from ApiProvider: "
+            + ", ".join(missing_allowlisted_ids)
+        )
+    return errors
+
+
 def main() -> int:
     try:
         config_rs = read(CONFIG_RS)
@@ -142,9 +201,11 @@ def main() -> int:
 
         variant_to_id = provider_kind_ids(config_rs)
         canonical_ids = set(variant_to_id.values())
+        live_api_provider_ids = set(api_provider_ids(tui_config_rs).values())
         expected_tables = {provider_id.replace("-", "_") for provider_id in canonical_ids}
 
         errors: list[str] = []
+        errors += report_provider_enum_drift(canonical_ids, live_api_provider_ids)
         errors += report_set(
             "shipped provider rows",
             canonical_ids,

--- a/scripts/check-provider-registry.py
+++ b/scripts/check-provider-registry.py
@@ -24,30 +24,28 @@ TUI_CONFIG_RS = ROOT / "crates" / "tui" / "src" / "config.rs"
 AGENT_RS = ROOT / "crates" / "agent" / "src" / "lib.rs"
 PROVIDERS_MD = ROOT / "docs" / "PROVIDERS.md"
 
-PROVIDER_VARIANT_TO_TABLE = {
-    "Deepseek": "deepseek",
-    "NvidiaNim": "nvidia_nim",
-    "Openai": "openai",
-    "Atlascloud": "atlascloud",
-    "WanjieArk": "wanjie_ark",
-    "Openrouter": "openrouter",
-    "Novita": "novita",
-    "Fireworks": "fireworks",
-    "Moonshot": "moonshot",
-    "Sglang": "sglang",
-    "Vllm": "vllm",
-    "Ollama": "ollama",
-}
-
-
 def read(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
+def require_index(source: str, needle: str, context: str, start: int = 0) -> int:
+    try:
+        return source.index(needle, start)
+    except ValueError:
+        raise ValueError(f"{context}: missing {needle!r}") from None
+
+
+def markdown_section(source: str, heading: str) -> str:
+    start = require_index(source, heading, "docs/PROVIDERS.md")
+    next_heading = source.find("\n## ", start + len(heading))
+    end = len(source) if next_heading == -1 else next_heading
+    return source[start:end]
+
+
 def extract_match_block(source: str, signature: str) -> str:
-    start = source.index(signature)
-    match_start = source.index("match", start)
-    brace_start = source.index("{", match_start)
+    start = require_index(source, signature, "crates/config/src/lib.rs")
+    match_start = require_index(source, "match", f"match block after {signature!r}", start)
+    brace_start = require_index(source, "{", f"match block after {signature!r}", match_start)
     depth = 0
     for index in range(brace_start, len(source)):
         char = source[index]
@@ -69,8 +67,10 @@ def provider_kind_ids(config_rs: str) -> dict[str, str]:
 
 
 def provider_tables(config_rs: str) -> set[str]:
-    struct_start = config_rs.index("pub struct ProvidersToml")
-    struct_end = config_rs.index("\n}", struct_start)
+    struct_start = require_index(
+        config_rs, "pub struct ProvidersToml", "crates/config/src/lib.rs"
+    )
+    struct_end = require_index(config_rs, "\n}", "ProvidersToml struct", struct_start)
     fields = re.findall(
         r"pub\s+([a-z0-9_]+)\s*:\s*ProviderConfigToml",
         config_rs[struct_start:struct_end],
@@ -81,23 +81,17 @@ def provider_tables(config_rs: str) -> set[str]:
 
 
 def shipped_provider_rows(providers_md: str) -> set[str]:
-    heading = providers_md.index("## Shipped Providers")
-    next_heading = providers_md.index("\n## ", heading + 1)
-    table = providers_md[heading:next_heading]
+    table = markdown_section(providers_md, "## Shipped Providers")
     return set(re.findall(r"^\|\s*`([^`]+)`\s*\|", table, flags=re.MULTILINE))
 
 
 def shipped_provider_tables(providers_md: str) -> set[str]:
-    heading = providers_md.index("## Shipped Providers")
-    next_heading = providers_md.index("\n## ", heading + 1)
-    table = providers_md[heading:next_heading]
+    table = markdown_section(providers_md, "## Shipped Providers")
     return set(re.findall(r"\|\s*`\[providers\.([a-z0-9_]+)\]`\s*\|", table))
 
 
 def static_registry_provider_rows(providers_md: str) -> set[str]:
-    heading = providers_md.index("## Static Model Registry")
-    next_heading = providers_md.index("\n## ", heading + 1)
-    table = providers_md[heading:next_heading]
+    table = markdown_section(providers_md, "## Static Model Registry")
     return set(re.findall(r"^\|\s*`([^`]+)`\s*\|", table, flags=re.MULTILINE))
 
 
@@ -124,7 +118,8 @@ def default_strings(tui_config_rs: str) -> set[str]:
 
 
 def missing_default_strings(providers_md: str, defaults: set[str]) -> list[str]:
-    return sorted(value for value in defaults if value not in providers_md)
+    code_spans = set(re.findall(r"`([^`]+)`", providers_md))
+    return sorted(defaults - code_spans)
 
 
 def report_set(label: str, expected: set[str], actual: set[str]) -> list[str]:
@@ -139,47 +134,42 @@ def report_set(label: str, expected: set[str], actual: set[str]) -> list[str]:
 
 
 def main() -> int:
-    config_rs = read(CONFIG_RS)
-    tui_config_rs = read(TUI_CONFIG_RS)
-    agent_rs = read(AGENT_RS)
-    providers_md = read(PROVIDERS_MD)
+    try:
+        config_rs = read(CONFIG_RS)
+        tui_config_rs = read(TUI_CONFIG_RS)
+        agent_rs = read(AGENT_RS)
+        providers_md = read(PROVIDERS_MD)
 
-    variant_to_id = provider_kind_ids(config_rs)
-    canonical_ids = set(variant_to_id.values())
-    missing_table_mappings = sorted(set(variant_to_id) - set(PROVIDER_VARIANT_TO_TABLE))
-    if missing_table_mappings:
-        raise ValueError(
-            "PROVIDER_VARIANT_TO_TABLE is missing variants: "
-            + ", ".join(missing_table_mappings)
+        variant_to_id = provider_kind_ids(config_rs)
+        canonical_ids = set(variant_to_id.values())
+        expected_tables = {provider_id.replace("-", "_") for provider_id in canonical_ids}
+
+        errors: list[str] = []
+        errors += report_set(
+            "shipped provider rows",
+            canonical_ids,
+            shipped_provider_rows(providers_md),
         )
-    expected_tables = {
-        PROVIDER_VARIANT_TO_TABLE[variant] for variant in variant_to_id
-    }
-
-    errors: list[str] = []
-    errors += report_set(
-        "shipped provider rows",
-        canonical_ids,
-        shipped_provider_rows(providers_md),
-    )
-    errors += report_set("provider TOML tables", expected_tables, provider_tables(config_rs))
-    errors += report_set(
-        "documented provider TOML tables",
-        expected_tables,
-        shipped_provider_tables(providers_md),
-    )
-    errors += report_set(
-        "static ModelRegistry rows",
-        model_registry_providers(agent_rs, variant_to_id),
-        static_registry_provider_rows(providers_md),
-    )
-
-    missing_defaults = missing_default_strings(providers_md, default_strings(tui_config_rs))
-    if missing_defaults:
-        errors.append(
-            "docs/PROVIDERS.md does not mention default strings: "
-            + ", ".join(missing_defaults)
+        errors += report_set("provider TOML tables", expected_tables, provider_tables(config_rs))
+        errors += report_set(
+            "documented provider TOML tables",
+            expected_tables,
+            shipped_provider_tables(providers_md),
         )
+        errors += report_set(
+            "static ModelRegistry rows",
+            model_registry_providers(agent_rs, variant_to_id),
+            static_registry_provider_rows(providers_md),
+        )
+
+        missing_defaults = missing_default_strings(providers_md, default_strings(tui_config_rs))
+        if missing_defaults:
+            errors.append(
+                "docs/PROVIDERS.md does not mention default strings as Markdown code spans: "
+                + ", ".join(missing_defaults)
+            )
+    except ValueError as err:
+        errors = [str(err)]
 
     if errors:
         print("Provider registry drift check failed:", file=sys.stderr)

--- a/scripts/check-provider-registry.py
+++ b/scripts/check-provider-registry.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Check that docs/PROVIDERS.md tracks the shipped provider registry.
+
+This is intentionally lightweight. It does not try to generate prose; it checks
+the stable identifiers and default strings that are easy for docs to drift from:
+
+- canonical ProviderKind IDs
+- provider TOML tables
+- shipped-provider table rows
+- static ModelRegistry provider rows
+- default provider model/base URL constants
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIG_RS = ROOT / "crates" / "config" / "src" / "lib.rs"
+TUI_CONFIG_RS = ROOT / "crates" / "tui" / "src" / "config.rs"
+AGENT_RS = ROOT / "crates" / "agent" / "src" / "lib.rs"
+PROVIDERS_MD = ROOT / "docs" / "PROVIDERS.md"
+
+PROVIDER_VARIANT_TO_TABLE = {
+    "Deepseek": "deepseek",
+    "NvidiaNim": "nvidia_nim",
+    "Openai": "openai",
+    "Atlascloud": "atlascloud",
+    "WanjieArk": "wanjie_ark",
+    "Openrouter": "openrouter",
+    "Novita": "novita",
+    "Fireworks": "fireworks",
+    "Moonshot": "moonshot",
+    "Sglang": "sglang",
+    "Vllm": "vllm",
+    "Ollama": "ollama",
+}
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def extract_match_block(source: str, signature: str) -> str:
+    start = source.index(signature)
+    match_start = source.index("match", start)
+    brace_start = source.index("{", match_start)
+    depth = 0
+    for index in range(brace_start, len(source)):
+        char = source[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[brace_start + 1 : index]
+    raise ValueError(f"could not parse match block after {signature!r}")
+
+
+def provider_kind_ids(config_rs: str) -> dict[str, str]:
+    block = extract_match_block(config_rs, "pub fn as_str(self) -> &'static str")
+    pairs = re.findall(r"Self::(\w+)\s*=>\s*\"([^\"]+)\"", block)
+    if not pairs:
+        raise ValueError("ProviderKind::as_str returned no providers")
+    return {variant: provider_id for variant, provider_id in pairs}
+
+
+def provider_tables(config_rs: str) -> set[str]:
+    struct_start = config_rs.index("pub struct ProvidersToml")
+    struct_end = config_rs.index("\n}", struct_start)
+    fields = re.findall(
+        r"pub\s+([a-z0-9_]+)\s*:\s*ProviderConfigToml",
+        config_rs[struct_start:struct_end],
+    )
+    if not fields:
+        raise ValueError("ProvidersToml returned no provider tables")
+    return set(fields)
+
+
+def shipped_provider_rows(providers_md: str) -> set[str]:
+    heading = providers_md.index("## Shipped Providers")
+    next_heading = providers_md.index("\n## ", heading + 1)
+    table = providers_md[heading:next_heading]
+    return set(re.findall(r"^\|\s*`([^`]+)`\s*\|", table, flags=re.MULTILINE))
+
+
+def shipped_provider_tables(providers_md: str) -> set[str]:
+    heading = providers_md.index("## Shipped Providers")
+    next_heading = providers_md.index("\n## ", heading + 1)
+    table = providers_md[heading:next_heading]
+    return set(re.findall(r"\|\s*`\[providers\.([a-z0-9_]+)\]`\s*\|", table))
+
+
+def static_registry_provider_rows(providers_md: str) -> set[str]:
+    heading = providers_md.index("## Static Model Registry")
+    next_heading = providers_md.index("\n## ", heading + 1)
+    table = providers_md[heading:next_heading]
+    return set(re.findall(r"^\|\s*`([^`]+)`\s*\|", table, flags=re.MULTILINE))
+
+
+def model_registry_providers(agent_rs: str, variant_to_id: dict[str, str]) -> set[str]:
+    variants = set(re.findall(r"provider:\s*ProviderKind::(\w+)", agent_rs))
+    missing = variants - set(variant_to_id)
+    if missing:
+        raise ValueError(f"ModelRegistry uses unknown provider variants: {sorted(missing)}")
+    return {variant_to_id[variant] for variant in variants}
+
+
+def default_strings(tui_config_rs: str) -> set[str]:
+    defaults = set()
+    for name, value in re.findall(
+        r'const\s+(DEFAULT_[A-Z0-9_]+(?:MODEL|BASE_URL)):\s*&str\s*=\s*"([^"]+)"',
+        tui_config_rs,
+    ):
+        if name == "DEFAULT_DEEPSEEKCN_BASE_URL":
+            continue
+        defaults.add(value)
+    if not defaults:
+        raise ValueError("no default provider model/base URL constants found")
+    return defaults
+
+
+def missing_default_strings(providers_md: str, defaults: set[str]) -> list[str]:
+    return sorted(value for value in defaults if value not in providers_md)
+
+
+def report_set(label: str, expected: set[str], actual: set[str]) -> list[str]:
+    errors = []
+    missing = sorted(expected - actual)
+    extra = sorted(actual - expected)
+    if missing:
+        errors.append(f"{label} missing: {', '.join(missing)}")
+    if extra:
+        errors.append(f"{label} extra: {', '.join(extra)}")
+    return errors
+
+
+def main() -> int:
+    config_rs = read(CONFIG_RS)
+    tui_config_rs = read(TUI_CONFIG_RS)
+    agent_rs = read(AGENT_RS)
+    providers_md = read(PROVIDERS_MD)
+
+    variant_to_id = provider_kind_ids(config_rs)
+    canonical_ids = set(variant_to_id.values())
+    missing_table_mappings = sorted(set(variant_to_id) - set(PROVIDER_VARIANT_TO_TABLE))
+    if missing_table_mappings:
+        raise ValueError(
+            "PROVIDER_VARIANT_TO_TABLE is missing variants: "
+            + ", ".join(missing_table_mappings)
+        )
+    expected_tables = {
+        PROVIDER_VARIANT_TO_TABLE[variant] for variant in variant_to_id
+    }
+
+    errors: list[str] = []
+    errors += report_set(
+        "shipped provider rows",
+        canonical_ids,
+        shipped_provider_rows(providers_md),
+    )
+    errors += report_set("provider TOML tables", expected_tables, provider_tables(config_rs))
+    errors += report_set(
+        "documented provider TOML tables",
+        expected_tables,
+        shipped_provider_tables(providers_md),
+    )
+    errors += report_set(
+        "static ModelRegistry rows",
+        model_registry_providers(agent_rs, variant_to_id),
+        static_registry_provider_rows(providers_md),
+    )
+
+    missing_defaults = missing_default_strings(providers_md, default_strings(tui_config_rs))
+    if missing_defaults:
+        errors.append(
+            "docs/PROVIDERS.md does not mention default strings: "
+            + ", ".join(missing_defaults)
+        )
+
+    if errors:
+        print("Provider registry drift check failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print("Provider registry drift check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add `scripts/check-provider-registry.py` to check `docs/PROVIDERS.md` against the shipped provider IDs, `[providers.*]` tables, static `ModelRegistry` provider rows, and default model/base URL strings
- wire the provider-registry drift check into the CI lint job
- document the drift check in `docs/PROVIDERS.md` and link the provider registry from the README docs table
- fix current clippy-only style lints in legacy shim/config/log code so the full clippy gate is clean

## Testing

- [x] `python scripts/check-provider-registry.py`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --all-features`
  - Ran on this Windows checkout; failed after `3411 passed; 11 failed; 4 ignored`.
  - This is listed as run, not as a passing validation.
  - Failures observed: `client::chat::stream_decoder_tests::cache_inspect_reports_tool_result_budget_metadata`, `commands::change::tests::change_in_non_english_without_api_key_uses_explicit_fallback`, `project_context::tests::test_global_agents_only_no_project_unchanged_fallback`, `project_context::tests::test_load_global_agents_when_project_has_no_context`, `prompts::tests::system_prompt_skips_locale_preamble_for_english`, `session_manager::tests::latest_session_for_workspace_ignores_invalid_parent_git_marker`, `session_manager::tests::latest_session_for_workspace_ignores_newer_other_directory`, `tools::pandoc::tests::pandoc_convert_roundtrips_markdown_to_html_inline`, `tools::pandoc::tests::pandoc_convert_writes_output_path_and_reports_summary`, `tui::app::tests::app_new_detects_missing_api_key_with_default_config`, `tui::ui::tests::saved_default_provider_syncs_back_to_runtime_config`.
  - The visible causes are this checkout/environment rather than this patch: parent `C:\.git` workspace detection, pandoc `getXdgDirectory:sHGetFolderPath`, real `%APPDATA%` write denial, and test-home/API-key/global-AGENTS contamination.

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
  - No TUI UI behavior changed.

Closes #2201

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `scripts/check-provider-registry.py`, a lightweight CI drift check that validates `docs/PROVIDERS.md` against canonical provider IDs, TOML table names, `ApiProvider` enum entries, static `ModelRegistry` rows, and default model/base URL constants. It wires the script into the lint job, updates the docs, and cleans up a handful of clippy-only style lints in legacy shim and TUI config code.

- **New drift check script** (`scripts/check-provider-registry.py`): regex-based parser over Rust source files and PROVIDERS.md; three robustness gaps already raised in prior review threads (accumulated-error replacement on `ValueError`, raw `ValueError` tracebacks on structural changes, and error list reset on mid-run exceptions).
- **CI wiring** (`.github/workflows/ci.yml`): uses `python3` explicitly, which is the correct choice for `ubuntu-latest`; no `setup-python` step is needed.
- **Rust clippy fixes**: four small style-only changes (`let`-chain collapsing, redundant `format!` removal, `redundant_closure` fix) with no behavioural impact.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; all changes are additive documentation, a new optional CI check, and mechanical Rust style fixes with no behavioural impact.

The Rust changes are trivially correct clippy simplifications. The new drift-check script runs in CI but does not affect the build artefacts or runtime behaviour — a script failure blocks the lint job but cannot corrupt state. The script's known gaps (accumulated-error replacement, raw ValueError tracebacks) were already raised in prior review threads and are pre-existing in this revision; neither causes incorrect drift verdicts, only noisier failure output.

scripts/check-provider-registry.py — two minor robustness issues remain unaddressed from prior threads, plus the two new P2 findings in this review.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/check-provider-registry.py | New drift-check script: regex-based Rust/Markdown parser with known robustness gaps (accumulated-error replacement on ValueError, substring match for `match` keyword, hardcoded constant exclusion) but structurally sound for current codebase shape. |
| .github/workflows/ci.yml | Adds the drift-check step using `python3` (not `python`), correctly resolving the availability concern on ubuntu-latest; no setup-python step needed. |
| crates/cli/src/bin/codew_legacy_shim.rs | Clippy style fix: nested `if let` chains collapsed to a single let-chain; semantics are identical. |
| crates/cli/src/bin/deepseek_legacy_shim.rs | Same let-chain clippy fix as codew_legacy_shim.rs; no behaviour change. |
| crates/tui/src/commands/config.rs | Removes unnecessary `format!()` wrapping a string literal in `CommandResult::error`; clippy lint fix with no behavioural change. |
| crates/tui/src/runtime_log.rs | Clippy `redundant_closure` fix: `and_then(|h| resolve(h))` → `and_then(resolve)`; no behavioural change. |
| docs/PROVIDERS.md | Adds drift-check reference in sources list, a new "Drift Check" section, and removes the "drift-check script planned" placeholder from the future-work list. |
| README.md | Adds PROVIDERS.md to the docs table in README; straightforward doc update. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CI lint job] --> B[cargo fmt --check]
    A --> C[python3 scripts/check-provider-registry.py]
    C --> D[Read crates/config/src/lib.rs\nProviderKind::as_str]
    C --> E[Read crates/tui/src/config.rs\nApiProvider::as_str + DEFAULT_* consts]
    C --> F[Read crates/agent/src/lib.rs\nModelRegistry provider variants]
    C --> G[Read docs/PROVIDERS.md\nShipped Providers + Static Registry tables]
    D --> H{Drift checks}
    E --> H
    F --> H
    G --> H
    H -->|enum drift| I[report_provider_enum_drift]
    H -->|doc rows| J[report_set: shipped provider rows]
    H -->|TOML tables| K[report_set: provider TOML tables]
    H -->|doc tables| L[report_set: documented TOML tables]
    H -->|registry rows| M[report_set: static ModelRegistry rows]
    H -->|default strings| N[missing_default_strings]
    I & J & K & L & M & N --> O{errors?}
    O -->|yes| P[Print errors to stderr\nexit 1]
    O -->|no| Q[Print passed\nexit 0]
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22nightt5879%2Fprovider-registry-docs%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22nightt5879%2Fprovider-registry-docs%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Fcheck-provider-registry.py%3A143%0A**Hardcoded%20exclusion%20tied%20to%20a%20specific%20constant%20name**%0A%0A%60if%20name%20%3D%3D%20%22DEFAULT_DEEPSEEKCN_BASE_URL%22%3A%20continue%60%20silently%20stops%20filtering%20if%20the%20constant%20is%20ever%20renamed%20%28e.g.%2C%20to%20%60DEFAULT_DEEPSEEK_CN_BASE_URL%60%29.%20When%20the%20exclusion%20stops%20matching%2C%20the%20check%20begins%20failing%20with%20a%20spurious%20%22docs%2FPROVIDERS.md%20does%20not%20mention%20default%20strings%22%20error%20for%20the%20CN%20base%20URL%20value%2C%20with%20no%20indication%20that%20the%20exclusion%20itself%20is%20the%20problem.%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fcheck-provider-registry.py%3A54%0A**Substring%20match%20for%20%60%22match%22%60%20keyword%20can%20find%20false%20occurrences**%0A%0A%60require_index%28source%2C%20%22match%22%2C%20...%29%60%20matches%20any%20substring%2C%20so%20it%20can%20trigger%20on%20identifiers%20like%20%60dispatch_match%60%20or%20%60match_result%60%20in%20comments%20or%20doc-strings%20that%20appear%20between%20the%20function%20signature%20and%20the%20actual%20%60match%20self%20%7B%60%20keyword.%20In%20that%20scenario%2C%20%60brace_start%60%20would%20still%20find%20the%20correct%20opening%20brace%20%28comments%20have%20no%20%60%7B%60%29%2C%20but%20adding%20a%20guard%20comment%20like%20%60%2F%2F%20This%20re-matches%20...%60%20inside%20the%20function%20body%20could%20break%20the%20parser%20silently.%20Using%20a%20word-boundary%20regex%20%28e.g.%20%60re.search%28r'%5Cbmatch%5Cb'%2C%20...%29%60%29%20would%20make%20the%20intent%20explicit.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Fcheck-provider-registry.py%3A143%0A**Hardcoded%20exclusion%20tied%20to%20a%20specific%20constant%20name**%0A%0A%60if%20name%20%3D%3D%20%22DEFAULT_DEEPSEEKCN_BASE_URL%22%3A%20continue%60%20silently%20stops%20filtering%20if%20the%20constant%20is%20ever%20renamed%20%28e.g.%2C%20to%20%60DEFAULT_DEEPSEEK_CN_BASE_URL%60%29.%20When%20the%20exclusion%20stops%20matching%2C%20the%20check%20begins%20failing%20with%20a%20spurious%20%22docs%2FPROVIDERS.md%20does%20not%20mention%20default%20strings%22%20error%20for%20the%20CN%20base%20URL%20value%2C%20with%20no%20indication%20that%20the%20exclusion%20itself%20is%20the%20problem.%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fcheck-provider-registry.py%3A54%0A**Substring%20match%20for%20%60%22match%22%60%20keyword%20can%20find%20false%20occurrences**%0A%0A%60require_index%28source%2C%20%22match%22%2C%20...%29%60%20matches%20any%20substring%2C%20so%20it%20can%20trigger%20on%20identifiers%20like%20%60dispatch_match%60%20or%20%60match_result%60%20in%20comments%20or%20doc-strings%20that%20appear%20between%20the%20function%20signature%20and%20the%20actual%20%60match%20self%20%7B%60%20keyword.%20In%20that%20scenario%2C%20%60brace_start%60%20would%20still%20find%20the%20correct%20opening%20brace%20%28comments%20have%20no%20%60%7B%60%29%2C%20but%20adding%20a%20guard%20comment%20like%20%60%2F%2F%20This%20re-matches%20...%60%20inside%20the%20function%20body%20could%20break%20the%20parser%20silently.%20Using%20a%20word-boundary%20regex%20%28e.g.%20%60re.search%28r'%5Cbmatch%5Cb'%2C%20...%29%60%29%20would%20make%20the%20intent%20explicit.%0A%0A&repo=hmbown%2Fcodewhale&pr=2274&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Fcheck-provider-registry.py%3A143%0A**Hardcoded%20exclusion%20tied%20to%20a%20specific%20constant%20name**%0A%0A%60if%20name%20%3D%3D%20%22DEFAULT_DEEPSEEKCN_BASE_URL%22%3A%20continue%60%20silently%20stops%20filtering%20if%20the%20constant%20is%20ever%20renamed%20%28e.g.%2C%20to%20%60DEFAULT_DEEPSEEK_CN_BASE_URL%60%29.%20When%20the%20exclusion%20stops%20matching%2C%20the%20check%20begins%20failing%20with%20a%20spurious%20%22docs%2FPROVIDERS.md%20does%20not%20mention%20default%20strings%22%20error%20for%20the%20CN%20base%20URL%20value%2C%20with%20no%20indication%20that%20the%20exclusion%20itself%20is%20the%20problem.%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fcheck-provider-registry.py%3A54%0A**Substring%20match%20for%20%60%22match%22%60%20keyword%20can%20find%20false%20occurrences**%0A%0A%60require_index%28source%2C%20%22match%22%2C%20...%29%60%20matches%20any%20substring%2C%20so%20it%20can%20trigger%20on%20identifiers%20like%20%60dispatch_match%60%20or%20%60match_result%60%20in%20comments%20or%20doc-strings%20that%20appear%20between%20the%20function%20signature%20and%20the%20actual%20%60match%20self%20%7B%60%20keyword.%20In%20that%20scenario%2C%20%60brace_start%60%20would%20still%20find%20the%20correct%20opening%20brace%20%28comments%20have%20no%20%60%7B%60%29%2C%20but%20adding%20a%20guard%20comment%20like%20%60%2F%2F%20This%20re-matches%20...%60%20inside%20the%20function%20body%20could%20break%20the%20parser%20silently.%20Using%20a%20word-boundary%20regex%20%28e.g.%20%60re.search%28r'%5Cbmatch%5Cb'%2C%20...%29%60%29%20would%20make%20the%20intent%20explicit.%0A%0A&pr=2274&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["test: check tui provider enum drift"](https://github.com/hmbown/codewhale/commit/626534d3b5e85b3c8ed2a7064e53c452ee1e810c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34136798)</sub>

<!-- /greptile_comment -->