### PR TITLE
fix(tui): make update hint transient (#2254)

### DIFF
--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -1114,10 +1114,6 @@ pub struct App {
     pub status_toasts: VecDeque<StatusToast>,
     /// Sticky status toast used for important warnings/errors.
     pub sticky_status: Option<StatusToast>,
-    /// Version-update hint shown in the footer when a newer release
-    /// is available. Set by a background GitHub API check after app
-    /// startup; `None` until the check completes or if up-to-date.
-    pub version_hint: Option<String>,
     /// Last status text already promoted from `status_message` into toast state.
     pub last_status_message_seen: Option<String>,
     pub model: String,
@@ -1844,7 +1840,6 @@ impl App {
             status_message: None,
             status_toasts: VecDeque::new(),
             sticky_status: None,
-            version_hint: None,
             last_status_message_seen: None,
             model,
             auto_model,

--- a/crates/tui/src/tui/footer_ui.rs
+++ b/crates/tui/src/tui/footer_ui.rs
@@ -43,21 +43,12 @@ pub(crate) fn render_footer(f: &mut Frame, area: Rect, app: &mut App) {
     } else {
         None
     };
-    let toast = quit_prompt
-        .or_else(|| {
-            // Version-update hint takes precedence over ephemeral status toasts
-            // so the user sees it even when status traffic would hide it.
-            app.version_hint.as_ref().map(|hint| FooterToast {
-                text: hint.clone(),
-                color: palette::STATUS_INFO,
-            })
+    let toast = quit_prompt.or_else(|| {
+        app.active_status_toast().map(|toast| FooterToast {
+            text: toast.text,
+            color: status_color(toast.level),
         })
-        .or_else(|| {
-            app.active_status_toast().map(|toast| FooterToast {
-                text: toast.text,
-                color: status_color(toast.level),
-            })
-        });
+    });
 
     // Drive every cluster from the user's configured `status_items`. Mode
     // and Model are always rendered by `FooterProps` itself (their position

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -8146,10 +8146,7 @@ fn release_has_uploaded_asset(json: &serde_json::Value, required: &str) -> bool 
     };
     assets.iter().any(|asset| {
         asset.get("name").and_then(serde_json::Value::as_str) == Some(required)
-            && matches!(
-                asset.get("state").and_then(serde_json::Value::as_str),
-                None | Some("uploaded")
-            )
+            && asset.get("state").and_then(serde_json::Value::as_str) == Some("uploaded")
     })
 }
 

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -156,6 +156,27 @@ const DEFAULT_TERMINAL_PROBE_TIMEOUT_MS: u64 = 500;
 const PERIODIC_FULL_REPAINT_EVERY_N: u64 = 50;
 const TURN_META_PREFIX: &str = "<turn_meta>";
 const SESSION_TITLE_MAX_CHARS: usize = 32;
+const VERSION_HINT_TOAST_TTL_MS: u64 = 12_000;
+
+const REQUIRED_RELEASE_ASSETS: &[&str] = &[
+    "codewhale-artifacts-sha256.txt",
+    "codewhale-linux-arm64",
+    "codewhale-linux-arm64.tar.gz",
+    "codewhale-linux-x64",
+    "codewhale-linux-x64.tar.gz",
+    "codewhale-macos-arm64",
+    "codewhale-macos-arm64.tar.gz",
+    "codewhale-macos-x64",
+    "codewhale-macos-x64.tar.gz",
+    "codewhale-tui-linux-arm64",
+    "codewhale-tui-linux-x64",
+    "codewhale-tui-macos-arm64",
+    "codewhale-tui-macos-x64",
+    "codewhale-tui-windows-x64.exe",
+    "codewhale-windows-x64.exe",
+    "codewhale-windows-x64-portable.zip",
+    "codewhale-windows-x64.zip",
+];
 
 fn is_session_approved_for_tool(app: &App, tool_name: &str, grouping_key: &str) -> bool {
     app.approval_session_approved.contains(grouping_key)
@@ -900,8 +921,8 @@ async fn run_event_loop(
         .unwrap_or_else(Instant::now);
 
     // Fire-and-forget version check — runs once per session in the
-    // background. On success, `app.version_hint` is set and the footer
-    // renders the update recommendation on the next frame.
+    // background. On success, a short status toast advertises the update
+    // without replacing the user's configured footer/status-line chips.
     let mut version_check: Option<tokio::task::JoinHandle<Option<String>>> = Some({
         let current = env!("CARGO_PKG_VERSION").to_string();
         tokio::spawn(async move {
@@ -920,22 +941,7 @@ async fn run_event_loop(
                 .await
                 .ok()?;
             let json: serde_json::Value = resp.json().await.ok()?;
-            let tag = json["tag_name"].as_str()?;
-            let latest = tag.trim_start_matches('v');
-            // Compare semver so dev builds (e.g. "0.8.46-pre") don't
-            // trigger false hints. Falls back to string compare on
-            // unparseable versions.
-            let newer = match (parse_semver(latest), parse_semver(&current)) {
-                (Some(l), Some(c)) => l > c,
-                _ => latest != current,
-            };
-            if newer {
-                Some(format!(
-                    "v{latest} available — run `codewhale update` and restart"
-                ))
-            } else {
-                None
-            }
+            version_hint_from_release_json(&json, &current)
         })
     });
 
@@ -947,7 +953,11 @@ async fn run_event_loop(
             done = handle.is_finished();
         }
         if done && let Ok(Some(hint)) = version_check.take().unwrap().await {
-            app.version_hint = Some(hint);
+            app.push_status_toast(
+                hint,
+                StatusToastLevel::Info,
+                Some(VERSION_HINT_TOAST_TTL_MS),
+            );
         }
 
         if !drain_web_config_events(&mut web_config_session, app, config, &engine_handle).await {
@@ -8090,6 +8100,65 @@ fn extract_reasoning_header(text: &str) -> Option<String> {
         None
     } else {
         Some(header.to_string())
+    }
+}
+
+fn version_hint_from_release_json(json: &serde_json::Value, current: &str) -> Option<String> {
+    if !release_has_required_assets(json) {
+        return None;
+    }
+
+    let tag = json["tag_name"].as_str()?;
+    let latest = tag.trim_start_matches('v');
+    if !is_newer_version(latest, current) {
+        return None;
+    }
+
+    Some(format!(
+        "v{latest} available - run `codewhale update` and restart"
+    ))
+}
+
+fn release_has_required_assets(json: &serde_json::Value) -> bool {
+    if json
+        .get("draft")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
+    {
+        return false;
+    }
+    if json
+        .get("prerelease")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
+    {
+        return false;
+    }
+
+    REQUIRED_RELEASE_ASSETS
+        .iter()
+        .all(|required| release_has_uploaded_asset(json, required))
+}
+
+fn release_has_uploaded_asset(json: &serde_json::Value, required: &str) -> bool {
+    let Some(assets) = json.get("assets").and_then(serde_json::Value::as_array) else {
+        return false;
+    };
+    assets.iter().any(|asset| {
+        asset.get("name").and_then(serde_json::Value::as_str) == Some(required)
+            && matches!(
+                asset.get("state").and_then(serde_json::Value::as_str),
+                None | Some("uploaded")
+            )
+    })
+}
+
+fn is_newer_version(latest: &str, current: &str) -> bool {
+    // Compare semver so dev builds (e.g. "0.8.46-pre") don't trigger false
+    // hints. Falls back to string compare on unparseable versions.
+    match (parse_semver(latest), parse_semver(current)) {
+        (Some(l), Some(c)) => l > c,
+        _ => latest != current,
     }
 }
 

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -2378,6 +2378,23 @@ fn version_hint_requires_complete_release_assets() {
         version_hint_from_release_json(&missing_manifest, "0.8.46").is_none(),
         "do not advertise a release before checksums are uploaded"
     );
+
+    let mut pending_asset = complete_release_json("v0.8.47");
+    pending_asset["assets"].as_array_mut().expect("assets")[0]["state"] = serde_json::json!("open");
+    assert!(
+        version_hint_from_release_json(&pending_asset, "0.8.46").is_none(),
+        "do not advertise a release before every asset is uploaded"
+    );
+
+    let mut missing_state = complete_release_json("v0.8.47");
+    missing_state["assets"].as_array_mut().expect("assets")[0]
+        .as_object_mut()
+        .expect("asset object")
+        .remove("state");
+    assert!(
+        version_hint_from_release_json(&missing_state, "0.8.46").is_none(),
+        "do not accept malformed asset state as uploaded"
+    );
 }
 
 #[test]

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -2342,6 +2342,58 @@ fn event_poll_timeout_has_nonzero_floor() {
     );
 }
 
+fn complete_release_json(tag: &str) -> serde_json::Value {
+    let assets = REQUIRED_RELEASE_ASSETS
+        .iter()
+        .map(|name| serde_json::json!({ "name": name, "state": "uploaded" }))
+        .collect::<Vec<_>>();
+    serde_json::json!({
+        "tag_name": tag,
+        "draft": false,
+        "prerelease": false,
+        "assets": assets,
+    })
+}
+
+#[test]
+fn version_hint_requires_complete_release_assets() {
+    let complete = complete_release_json("v0.8.47");
+    let hint = version_hint_from_release_json(&complete, "0.8.46").expect("newer complete release");
+    assert!(hint.contains("v0.8.47 available"));
+
+    let mut missing_manifest = complete_release_json("v0.8.47");
+    missing_manifest["assets"] = serde_json::Value::Array(
+        missing_manifest["assets"]
+            .as_array()
+            .expect("assets")
+            .iter()
+            .filter(|asset| {
+                asset.get("name").and_then(serde_json::Value::as_str)
+                    != Some("codewhale-artifacts-sha256.txt")
+            })
+            .cloned()
+            .collect(),
+    );
+    assert!(
+        version_hint_from_release_json(&missing_manifest, "0.8.46").is_none(),
+        "do not advertise a release before checksums are uploaded"
+    );
+}
+
+#[test]
+fn version_hint_ignores_draft_prerelease_and_current_versions() {
+    let mut draft = complete_release_json("v0.8.47");
+    draft["draft"] = serde_json::Value::Bool(true);
+    assert!(version_hint_from_release_json(&draft, "0.8.46").is_none());
+
+    let mut prerelease = complete_release_json("v0.8.47");
+    prerelease["prerelease"] = serde_json::Value::Bool(true);
+    assert!(version_hint_from_release_json(&prerelease, "0.8.46").is_none());
+
+    let current = complete_release_json("v0.8.46");
+    assert!(version_hint_from_release_json(&current, "0.8.46").is_none());
+}
+
 #[test]
 #[cfg(any(unix, windows))]
 fn external_url_launcher_does_not_wait_for_browser_process() {


### PR DESCRIPTION
## Summary
- only advertise a newer release after the GitHub release is non-draft, non-prerelease, and has the required CodeWhale assets plus checksum manifest uploaded
- route the update notice through the existing timed status-toast queue instead of storing a persistent footer override
- preserve the user-configured footer/statusline chips as the steady display

Fixes #2254.

Reported by @bevis-wong in #2254.

Also credits @idling11 for #2268, which identified the draft/prerelease guard that this PR folds into the broader release-readiness fix.

## Verification
- cargo test -p codewhale-tui version_hint_requires_complete_release_assets -- --nocapture
- cargo test -p codewhale-tui version_hint_ignores_draft_prerelease_and_current_versions -- --nocapture
- cargo check -p codewhale-tui --all-features --locked
- cargo fmt --all -- --check
- git diff --check

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes issue #2254 by routing the version-update notification through the existing timed status-toast queue (12 s TTL) instead of storing it as a persistent `version_hint` field that permanently overrode the user's configured footer chips. It also adds release-completeness validation before advertising an update.

- Removes `App::version_hint` and the footer override path in `footer_ui.rs`; the update notice is now a `StatusToastLevel::Info` toast pushed once via `push_status_toast`.
- Adds `version_hint_from_release_json`, `release_has_required_assets`, and `release_has_uploaded_asset` to gate the hint behind draft/prerelease flags and a per-asset `state == \"uploaded\"` check against `REQUIRED_RELEASE_ASSETS`.
- New unit tests exercise the complete-release happy path, missing-manifest, pending-state, missing-state-field, draft, prerelease, and same-version cases.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is narrowly scoped to the update-notification path and preserves all existing footer behaviour.

The removal of version_hint and the simplified footer path are straightforward; the new asset-validation helpers are covered by a thorough test suite that explicitly checks the previously flagged missing-state-field case. The is_newer_version string-compare fallback for unparseable semver tags is pre-existing behaviour, not introduced here. No state is silently dropped and the toast fires exactly once per session.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/ui.rs | Extracts version-check logic into three helper functions with thorough asset-validation; routes the result to the toast queue; adds REQUIRED_RELEASE_ASSETS constant and VERSION_HINT_TOAST_TTL_MS. Logic is correct and well-separated. |
| crates/tui/src/tui/app.rs | Removes the now-unused `version_hint: Option<String>` field and its initialiser; no other logic changes. |
| crates/tui/src/tui/footer_ui.rs | Removes the special-cased `version_hint` branch; footer now delegates entirely to `active_status_toast()`, simplifying the precedence chain. |
| crates/tui/src/tui/ui/tests.rs | Adds two new tests covering the full matrix of release-validation cases including missing-state-field, covering the fix for the previously flagged None-arm issue. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant EL as Event Loop
    participant BG as Background Task (tokio::spawn)
    participant GH as GitHub API
    participant App as App (status_toasts)
    participant FUI as footer_ui

    EL->>BG: spawn version check (once per session)
    BG->>GH: GET /releases/latest
    GH-->>BG: JSON (tag_name, draft, prerelease, assets[])
    BG->>BG: release_has_required_assets()
    BG->>BG: is_newer_version(latest, current)
    BG-->>EL: Some(hint)

    EL->>App: push_status_toast(hint, Info, 12_000ms)
    Note over App: StatusToast queued with TTL

    loop every render frame
        FUI->>App: active_status_toast()
        App-->>FUI: Some(toast) or None (expired)
        FUI->>FUI: render toast in footer (or user chips if None)
    end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(tui): require uploaded release asset..."](https://github.com/hmbown/codewhale/commit/4eebfeba0af894699cab59f6b3555590b3b40abe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34137020)</sub>

<!-- /greptile_comment -->