### PR TITLE
feat(tui): add terminal-transparent theme (#2230)

### DIFF
--- a/crates/tui/src/palette.rs
+++ b/crates/tui/src/palette.rs
@@ -844,23 +844,42 @@ pub const TERMINAL_UI_THEME: UiTheme = UiTheme {
     selection_bg: Color::Reset,
     header_bg: Color::Reset,
     footer_bg: Color::Reset,
-    mode_agent: Color::Blue,
-    mode_yolo: Color::Red,
-    // Magenta keeps Plan visually distinct from `status_warning` (yellow)
-    // so the mode indicator and warning chip don't collide on themes that
-    // render both in the status row.
-    mode_plan: Color::Magenta,
-    // DarkGray gives "Ready" a low-contrast but still distinguishable hue
-    // versus default body text (which is `Color::Reset` on this theme).
-    status_ready: Color::DarkGray,
-    status_working: Color::Cyan,
-    status_warning: Color::Yellow,
     text_dim: Color::Reset,
     text_hint: Color::Reset,
     text_muted: Color::Reset,
     text_body: Color::Reset,
     text_soft: Color::Reset,
     border: Color::Reset,
+    accent_primary: Color::Blue,
+    accent_secondary: Color::Cyan,
+    accent_action: Color::Yellow,
+    error_fg: Color::Red,
+    error_hover: Color::Red,
+    error_surface: Color::Reset,
+    error_border: Color::Red,
+    error_text: Color::Red,
+    warning: Color::Yellow,
+    success: Color::Green,
+    info: Color::Cyan,
+    mode_agent: Color::Blue,
+    mode_yolo: Color::Red,
+    // Magenta keeps Plan visually distinct from `status_warning` (yellow)
+    // so the mode indicator and warning chip don't collide on themes that
+    // render both in the status row.
+    mode_plan: Color::Magenta,
+    mode_goal: Color::Green,
+    // DarkGray gives "Ready" a low-contrast but still distinguishable hue
+    // versus default body text (which is `Color::Reset` on this theme).
+    status_ready: Color::DarkGray,
+    status_working: Color::Cyan,
+    status_warning: Color::Yellow,
+    diff_added_fg: Color::Green,
+    diff_deleted_fg: Color::Red,
+    diff_added_bg: Color::Reset,
+    diff_deleted_bg: Color::Reset,
+    tool_running: Color::Cyan,
+    tool_success: Color::Green,
+    tool_failed: Color::Red,
 };
 
 pub const GRUVBOX_DARK_UI_THEME: UiTheme = UiTheme {
@@ -980,9 +999,7 @@ impl ThemeId {
     pub const fn tagline(self) -> &'static str {
         match self {
             Self::System => "Follow terminal background (COLORFGBG / macOS appearance)",
-            Self::Terminal => {
-                "Inherit terminal colors fully (transparent surfaces, ANSI accents)"
-            }
+            Self::Terminal => "Inherit terminal colors fully (transparent surfaces, ANSI accents)",
             Self::Whale => "Whale dark — deep navy & gold",
             Self::WhaleLight => "DeepSeek light, paper-ish",
             Self::Grayscale => "Color-minimal high contrast",
@@ -1729,14 +1746,15 @@ fn rgb_to_ansi256(r: u8, g: u8, b: u8) -> u8 {
 mod tests {
     use super::{
         ACCENT_REASONING_LIVE, ColorDepth, DEEPSEEK_INK, DEEPSEEK_RED, DEEPSEEK_SKY,
-        DEEPSEEK_SLATE, GRAYSCALE_BORDER, GRAYSCALE_ELEVATED, GRAYSCALE_PANEL, GRAYSCALE_REASONING,
-        GRAYSCALE_SURFACE, GRAYSCALE_TEXT_BODY, GRAYSCALE_TEXT_HINT, GRAYSCALE_TEXT_SOFT,
-        GRAYSCALE_UI_THEME, LIGHT_BORDER, LIGHT_ELEVATED, LIGHT_PANEL, LIGHT_REASONING,
-        LIGHT_SURFACE, LIGHT_TEXT_BODY, LIGHT_TEXT_HINT, LIGHT_UI_THEME, PaletteMode,
-        SURFACE_REASONING, SURFACE_REASONING_TINT, TEXT_BODY, TEXT_HINT, TEXT_REASONING,
-        TEXT_TOOL_OUTPUT, UI_THEME, WHALE_REASONING_TEXT_RGB, WHALE_REASONING_TINT_RGB,
-        WHALE_TEXT_BODY_RGB, adapt_bg, adapt_bg_for_palette_mode, adapt_color,
-        adapt_fg_for_palette_mode, blend, luma, nearest_ansi16, normalize_hex_rgb_color,
+        DEEPSEEK_SLATE, DIFF_ADDED, DIFF_ADDED_BG, GRAYSCALE_BORDER, GRAYSCALE_ELEVATED,
+        GRAYSCALE_PANEL, GRAYSCALE_REASONING, GRAYSCALE_SURFACE, GRAYSCALE_TEXT_BODY,
+        GRAYSCALE_TEXT_HINT, GRAYSCALE_TEXT_SOFT, GRAYSCALE_UI_THEME, LIGHT_BORDER, LIGHT_ELEVATED,
+        LIGHT_PANEL, LIGHT_REASONING, LIGHT_SURFACE, LIGHT_TEXT_BODY, LIGHT_TEXT_HINT,
+        LIGHT_UI_THEME, PaletteMode, SURFACE_REASONING, SURFACE_REASONING_TINT, TERMINAL_UI_THEME,
+        TEXT_BODY, TEXT_HINT, TEXT_REASONING, TEXT_TOOL_OUTPUT, ThemeId, UI_THEME,
+        WHALE_REASONING_TEXT_RGB, WHALE_REASONING_TINT_RGB, WHALE_TEXT_BODY_RGB, adapt_bg,
+        adapt_bg_for_palette_mode, adapt_bg_for_theme, adapt_color, adapt_fg_for_palette_mode,
+        adapt_fg_for_theme, blend, luma, nearest_ansi16, normalize_hex_rgb_color,
         normalize_theme_name, parse_hex_rgb_color, pulse_brightness, reasoning_surface_tint,
         rgb_to_ansi256, theme_label_for_mode, ui_theme_from_settings,
     };
@@ -1822,10 +1840,37 @@ mod tests {
         assert_eq!(normalize_theme_name("system"), Some("system"));
         assert_eq!(normalize_theme_name("default"), Some("system"));
         assert_eq!(normalize_theme_name("whale"), Some("dark"));
+        assert_eq!(normalize_theme_name("transparent"), Some("terminal"));
+        assert_eq!(normalize_theme_name("inherit"), Some("terminal"));
         assert_eq!(normalize_theme_name("black-white"), Some("grayscale"));
         assert_eq!(normalize_theme_name("mono"), Some("grayscale"));
         assert_eq!(normalize_theme_name("solarized"), None);
         assert_eq!(theme_label_for_mode(PaletteMode::Grayscale), "grayscale");
+    }
+
+    #[test]
+    fn terminal_theme_resets_surfaces_and_remaps_direct_palette_constants() {
+        assert_eq!(ThemeId::from_name("terminal"), Some(ThemeId::Terminal));
+        assert_eq!(TERMINAL_UI_THEME.surface_bg, Color::Reset);
+        assert_eq!(TERMINAL_UI_THEME.footer_bg, Color::Reset);
+        assert_eq!(TERMINAL_UI_THEME.text_body, Color::Reset);
+
+        assert_eq!(
+            adapt_bg_for_theme(DEEPSEEK_INK, ThemeId::Terminal, &TERMINAL_UI_THEME),
+            Color::Reset
+        );
+        assert_eq!(
+            adapt_bg_for_theme(DIFF_ADDED_BG, ThemeId::Terminal, &TERMINAL_UI_THEME),
+            Color::Reset
+        );
+        assert_eq!(
+            adapt_fg_for_theme(TEXT_BODY, ThemeId::Terminal, &TERMINAL_UI_THEME),
+            Color::Reset
+        );
+        assert_eq!(
+            adapt_fg_for_theme(DIFF_ADDED, ThemeId::Terminal, &TERMINAL_UI_THEME),
+            Color::Green
+        );
     }
 
     #[test]

--- a/crates/tui/src/palette.rs
+++ b/crates/tui/src/palette.rs
@@ -825,6 +825,39 @@ pub const DRACULA_UI_THEME: UiTheme = UiTheme {
     tool_failed: Color::Rgb(0xff, 0x55, 0x55),  // red
 };
 
+/// "Terminal" theme: lets the host terminal's color scheme show through
+/// instead of painting any RGB surface. Backgrounds use `Color::Reset`
+/// (the terminal's own default bg) and most text uses `Color::Reset`
+/// (terminal's own default fg). Accents are ANSI named colors so they
+/// also inherit the user's terminal palette (Solarized, Nord, custom
+/// schemes, etc.) rather than DeepSeek brand RGB.
+pub const TERMINAL_UI_THEME: UiTheme = UiTheme {
+    name: "terminal",
+    // Mode is reported as Dark to avoid the dark→light cell remap kicking
+    // in; the terminal-theme cell remap already normalizes everything to
+    // `Color::Reset`, and we never want a second pass overwriting that.
+    mode: PaletteMode::Dark,
+    surface_bg: Color::Reset,
+    panel_bg: Color::Reset,
+    elevated_bg: Color::Reset,
+    composer_bg: Color::Reset,
+    selection_bg: Color::Reset,
+    header_bg: Color::Reset,
+    footer_bg: Color::Reset,
+    mode_agent: Color::Blue,
+    mode_yolo: Color::Red,
+    mode_plan: Color::Yellow,
+    status_ready: Color::Reset,
+    status_working: Color::Cyan,
+    status_warning: Color::Yellow,
+    text_dim: Color::Reset,
+    text_hint: Color::Reset,
+    text_muted: Color::Reset,
+    text_body: Color::Reset,
+    text_soft: Color::Reset,
+    border: Color::Reset,
+};
+
 pub const GRUVBOX_DARK_UI_THEME: UiTheme = UiTheme {
     name: "gruvbox-dark",
     mode: PaletteMode::Dark,
@@ -874,6 +907,7 @@ pub const GRUVBOX_DARK_UI_THEME: UiTheme = UiTheme {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ThemeId {
     System,
+    Terminal,
     Whale,
     WhaleLight,
     Grayscale,
@@ -891,6 +925,7 @@ impl ThemeId {
     pub fn from_name(value: &str) -> Option<Self> {
         match normalize_theme_name(value)? {
             "system" => Some(Self::System),
+            "terminal" => Some(Self::Terminal),
             "dark" => Some(Self::Whale),
             "light" => Some(Self::WhaleLight),
             "grayscale" => Some(Self::Grayscale),
@@ -908,6 +943,7 @@ impl ThemeId {
     pub const fn name(self) -> &'static str {
         match self {
             Self::System => "system",
+            Self::Terminal => "terminal",
             Self::Whale => "dark",
             Self::WhaleLight => "light",
             Self::Grayscale => "grayscale",
@@ -923,6 +959,7 @@ impl ThemeId {
     pub const fn display_name(self) -> &'static str {
         match self {
             Self::System => "System",
+            Self::Terminal => "Terminal",
             Self::Whale => "Whale (Dark)",
             Self::WhaleLight => "Whale Light",
             Self::Grayscale => "Grayscale",
@@ -938,6 +975,9 @@ impl ThemeId {
     pub const fn tagline(self) -> &'static str {
         match self {
             Self::System => "Follow terminal background (COLORFGBG / macOS appearance)",
+            Self::Terminal => {
+                "Inherit terminal colors fully (transparent surfaces, ANSI accents)"
+            }
             Self::Whale => "Whale dark — deep navy & gold",
             Self::WhaleLight => "DeepSeek light, paper-ish",
             Self::Grayscale => "Color-minimal high contrast",
@@ -956,6 +996,7 @@ impl ThemeId {
     pub fn ui_theme(self) -> UiTheme {
         match self {
             Self::System => UiTheme::detect(),
+            Self::Terminal => TERMINAL_UI_THEME,
             Self::Whale => UI_THEME,
             Self::WhaleLight => LIGHT_UI_THEME,
             Self::Grayscale => GRAYSCALE_UI_THEME,
@@ -970,6 +1011,7 @@ impl ThemeId {
 /// Themes shown in the `/theme` picker, in display order.
 pub const SELECTABLE_THEMES: &[ThemeId] = &[
     ThemeId::System,
+    ThemeId::Terminal,
     ThemeId::Whale,
     ThemeId::WhaleLight,
     ThemeId::Grayscale,
@@ -1012,6 +1054,7 @@ impl UiTheme {
 pub fn normalize_theme_name(value: &str) -> Option<&'static str> {
     match value.trim().to_ascii_lowercase().as_str() {
         "" | "auto" | "system" | "default" => Some("system"),
+        "terminal" | "term" | "transparent" | "follow-terminal" | "inherit" => Some("terminal"),
         "dark" | "whale" | "whale-dark" => Some("dark"),
         "light" | "whale-light" => Some("light"),
         "grayscale" | "greyscale" | "gray" | "grey" | "mono" | "monochrome" | "black-white"
@@ -1189,7 +1232,11 @@ const fn theme_diff_deleted_bg(ui: &UiTheme) -> Color {
 pub const fn theme_remap_active(theme: ThemeId) -> bool {
     matches!(
         theme,
-        ThemeId::CatppuccinMocha | ThemeId::TokyoNight | ThemeId::Dracula | ThemeId::GruvboxDark
+        ThemeId::Terminal
+            | ThemeId::CatppuccinMocha
+            | ThemeId::TokyoNight
+            | ThemeId::Dracula
+            | ThemeId::GruvboxDark
     )
 }
 

--- a/crates/tui/src/palette.rs
+++ b/crates/tui/src/palette.rs
@@ -846,8 +846,13 @@ pub const TERMINAL_UI_THEME: UiTheme = UiTheme {
     footer_bg: Color::Reset,
     mode_agent: Color::Blue,
     mode_yolo: Color::Red,
-    mode_plan: Color::Yellow,
-    status_ready: Color::Reset,
+    // Magenta keeps Plan visually distinct from `status_warning` (yellow)
+    // so the mode indicator and warning chip don't collide on themes that
+    // render both in the status row.
+    mode_plan: Color::Magenta,
+    // DarkGray gives "Ready" a low-contrast but still distinguishable hue
+    // versus default body text (which is `Color::Reset` on this theme).
+    status_ready: Color::DarkGray,
     status_working: Color::Cyan,
     status_warning: Color::Yellow,
     text_dim: Color::Reset,

--- a/crates/tui/src/tui/theme_picker.rs
+++ b/crates/tui/src/tui/theme_picker.rs
@@ -317,7 +317,7 @@ mod tests {
         let mut v = ThemePickerView::new("system".to_string());
         let action = v.handle_key(key(KeyCode::Down));
         assert!(matches!(action, ViewAction::Emit(_)));
-        assert_eq!(selected_name(&action), Some(ThemeId::Whale.name()));
+        assert_eq!(selected_name(&action), Some(ThemeId::Terminal.name()));
     }
 
     #[test]
@@ -334,6 +334,7 @@ mod tests {
     #[test]
     fn enter_commits_with_persist_true() {
         let mut v = ThemePickerView::new("system".to_string());
+        v.handle_key(key(KeyCode::Down));
         v.handle_key(key(KeyCode::Down));
         v.handle_key(key(KeyCode::Down));
         v.handle_key(key(KeyCode::Down));
@@ -376,8 +377,8 @@ mod tests {
     #[test]
     fn digit_jumps_to_row() {
         let mut v = ThemePickerView::new("system".to_string());
-        let action = v.handle_key(key(KeyCode::Char('5')));
-        // Row 5 (1-indexed) -> index 4 -> CatppuccinMocha
+        let action = v.handle_key(key(KeyCode::Char('6')));
+        // Row 6 (1-indexed) -> index 5 -> CatppuccinMocha
         assert_eq!(
             selected_name(&action),
             Some(ThemeId::CatppuccinMocha.name())


### PR DESCRIPTION
## Summary
- add selectable `terminal` theme with transparent surfaces and ANSI accents so Windows Terminal background images and transparent palettes can show through
- add aliases: `term`, `transparent`, `follow-terminal`, and `inherit`
- keep the default `system` behavior unchanged; users opt in through `/theme` or settings
- update the stale #1831 work for the current palette schema and add coverage for Terminal remapping

Refs #2230.
Harvested from PR #1831 by @Sskift; original authored commits are preserved, with current-main cleanup and tests added here.

## Verification
- cargo test -p codewhale-tui terminal_theme_resets_surfaces_and_remaps_direct_palette_constants -- --nocapture
- cargo test -p codewhale-tui theme_picker -- --nocapture
- cargo test -p codewhale-tui theme_names_normalize_common_grayscale_aliases -- --nocapture
- cargo test -p codewhale-tui theme_qa -- --nocapture
- cargo check -p codewhale-tui --all-features --locked
- cargo fmt --all -- --check
- git diff --check

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a `terminal` theme that lets the host terminal's color scheme show through by using `Color::Reset` for all background and most foreground slots, with ANSI named colors for accents. It hooks into the existing community-theme remap pipeline (`theme_remap_active`, `adapt_fg_for_theme`, `adapt_bg_for_theme`) and sets `mode: PaletteMode::Dark` on the theme constant to prevent the legacy dark↔light Stage-2 remap from overwriting the `Color::Reset` outputs.

- `TERMINAL_UI_THEME` is added to `palette.rs` with `Color::Reset` surfaces and ANSI-named accents; `ThemeId::Terminal` is wired into all existing match arms and five aliases are registered in `normalize_theme_name`.
- `theme_picker.rs` tests are updated to account for Terminal's insertion at picker index 1: arrow-down preview, Enter-commit key-count, and digit-jump row number are all correctly adjusted.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The theme logic and remap pipeline integration look correct, but the transparent selection background will make selected items invisible in any list or picker when this theme is active.

The core architecture is sound and well-commented. The main concern is selection_bg: Color::Reset — with no visible selection highlight, a user navigating a list (including the theme picker itself) cannot tell which row is active. This affects every selectable widget while the theme is in use.

crates/tui/src/palette.rs — specifically the selection_bg slot in TERMINAL_UI_THEME and the test coverage gaps for the term and follow-terminal aliases.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/palette.rs | Adds TERMINAL_UI_THEME constant, ThemeId::Terminal variant, aliases, and hooks into the community-theme remap pipeline; selection_bg is Color::Reset which makes the selection highlight invisible |
| crates/tui/src/tui/theme_picker.rs | Updates picker tests to account for Terminal being inserted at index 1; navigation counts and digit-jump row numbers are correctly adjusted |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Cell draw] --> B{theme_remap_active?}
    B -- "No (System/Whale/WhaleLight)" --> D[Stage 2: dark↔light remap]
    B -- "Yes (Terminal/Catppuccin/etc.)" --> C["Stage 1: adapt_fg/bg_for_theme\n(dark-palette constants → UiTheme slots)"]
    C --> C1{"ThemeId::Terminal?"}
    C1 -- "Yes" --> C2["bg constants → Color::Reset\nfg constants → Color::Reset\naccents → ANSI named colors"]
    C1 -- "No" --> C3["Map to community preset RGB slots"]
    C2 --> D
    C3 --> D
    D --> D1{"palette_mode\n(= ui_theme.mode)"}
    D1 -- "Dark (Terminal always Dark)" --> E[Stage 3: depth downsampling]
    D1 -- "Light" --> D2[adapt light-palette overrides]
    D2 --> E
    E --> F[Emit to crossterm]
```
</details>

<a href="https://app.greptile.com/api/ide/devin?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2F2230-terminal-theme%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F2230-terminal-theme%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Ftui%2Fsrc%2Fpalette.rs%3A852%0A**Invisible%20selection%20with%20%60Color%3A%3AReset%60%20selection%20background**%0A%0A%60selection_bg%3A%20Color%3A%3AReset%60%20means%20the%20highlighted%20item%20in%20any%20list%2Fpicker%20looks%20identical%20to%20un-highlighted%20items%20%E2%80%94%20both%20use%20the%20terminal's%20default%20background.%20A%20user%20navigating%20the%20theme%20picker%20or%20any%20other%20selectable%20list%20while%20on%20the%20Terminal%20theme%20will%20have%20no%20visual%20cue%20about%20what%20is%20currently%20selected.%20Even%20a%20named%20ANSI%20color%20%28%60Color%3A%3ABlue%60%2C%20%60Color%3A%3ADarkGray%60%29%20would%20preserve%20the%20terminal-transparent%20aesthetic%20while%20keeping%20selections%20legible.%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Ftui%2Fsrc%2Fpalette.rs%3A1840-1847%0A**Stale%20test%20name%20after%20appending%20terminal-alias%20assertions**%0A%0ATerminal%20alias%20assertions%20%28%60transparent%60%2C%20%60inherit%60%29%20were%20added%20to%20a%20test%20named%20%60theme_names_normalize_common_grayscale_aliases%60.%20The%20name%20no%20longer%20describes%20what%20the%20test%20actually%20covers%2C%20making%20it%20harder%20to%20locate%20the%20right%20test%20when%20a%20future%20alias%20change%20breaks%20it.%20Consider%20renaming%20it%20or%20splitting%20it%20into%20a%20dedicated%20%60theme_names_normalize_terminal_aliases%60%20test.%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Ftui%2Fsrc%2Fpalette.rs%3A1079%0A**%60term%60%20and%20%60follow-terminal%60%20aliases%20lack%20test%20coverage**%0A%0AThe%20existing%20test%20only%20exercises%20%60transparent%60%20and%20%60inherit%60.%20The%20%60term%60%20and%20%60follow-terminal%60%20aliases%20introduced%20in%20the%20same%20match%20arm%20have%20no%20assertions%2C%20so%20a%20future%20typo%20or%20refactor%20could%20silently%20break%20them.%0A%0A&repo=hmbown%2Fcodewhale&tid=69448&ts=1779880237&sig=2312835a21376091036fe77e5ca212d7c7e44768524fa8e1e3f9a11e37a3a7de&pr=2276&platform=github&fid=02daa844-ded2-4193-a9f3-81fa1d060c28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInDevinDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInDevin.svg?v=3"><img alt="Fix All in Devin" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInDevin.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["test(tui): cover terminal theme palette ..."](https://github.com/hmbown/codewhale/commit/e72bf3827d150c5e8bf2e1f7185431378951e894) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34138279)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->