### PR TITLE
fix(tui): retry composer history atomic writes

### DIFF
--- a/crates/tui/src/composer_history.rs
+++ b/crates/tui/src/composer_history.rs
@@ -190,12 +190,46 @@ fn append_history_entries_to<'a>(
     }
 
     let payload = entries.join("\n") + "\n";
-    if let Err(err) = crate::utils::write_atomic(path, payload.as_bytes()) {
+    if let Err(err) = write_history_atomic(path, payload.as_bytes()) {
         tracing::warn!(
             "Failed to persist composer history at {}: {err}",
             path.display()
         );
     }
+}
+
+fn write_history_atomic(path: &Path, payload: &[u8]) -> std::io::Result<()> {
+    const RETRY_DELAYS: &[Duration] = &[
+        Duration::from_millis(5),
+        Duration::from_millis(10),
+        Duration::from_millis(25),
+        Duration::from_millis(50),
+        Duration::from_millis(100),
+        Duration::from_millis(200),
+        Duration::from_millis(400),
+    ];
+
+    for (attempt, delay) in RETRY_DELAYS
+        .iter()
+        .map(Some)
+        .chain(std::iter::once(None))
+        .enumerate()
+    {
+        match crate::utils::write_atomic(path, payload) {
+            Ok(()) => return Ok(()),
+            Err(err) if delay.is_some() => {
+                tracing::debug!(
+                    "Retrying composer history write to {} after attempt {} failed: {err}",
+                    path.display(),
+                    attempt + 1
+                );
+                std::thread::sleep(*delay.expect("delay checked"));
+            }
+            Err(err) => return Err(err),
+        }
+    }
+
+    unreachable!("retry iterator always ends with a final write attempt")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- retry composer-history atomic rewrites before dropping a queued batch
- make the async writer robust to transient Windows sharing violations while readers are polling the history file
- addresses the repeated Windows CI failure in `composer_history::tests::append_history_dispatched_does_not_block_the_caller` seen on #2274 and earlier on #2275

Refs #2274.

## Verification
- CARGO_TARGET_DIR=/Volumes/VIXinSSD/whalebro/codewhale/target cargo test -p codewhale-tui append_history_dispatched_does_not_block_the_caller -- --nocapture
- CARGO_TARGET_DIR=/Volumes/VIXinSSD/whalebro/codewhale/target cargo check -p codewhale-tui --all-features --locked
- cargo fmt --all -- --check
- git diff --check