### PR TITLE
fix(tui): resolve Windows shell commands via PowerShell

### DIFF
--- a/crates/tui/src/eval.rs
+++ b/crates/tui/src/eval.rs
@@ -15,52 +15,24 @@ use std::process::Command;
 use std::time::{Duration, Instant};
 use tempfile::TempDir;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum EvalShellPlatform {
-    Windows,
-    Unix,
+use crate::shell_invocation::{ShellInvocation, shell_invocation};
+#[cfg(test)]
+use crate::shell_invocation::{ShellPlatform, ShellProbe, shell_invocation_for_platform};
+
+fn eval_shell_invocation(command: &str) -> ShellInvocation {
+    shell_invocation(command)
 }
 
-impl EvalShellPlatform {
-    fn current() -> Self {
-        if cfg!(windows) {
-            Self::Windows
-        } else {
-            Self::Unix
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct EvalShellInvocation {
-    program: &'static str,
-    args: Vec<String>,
-    raw_payload_on_windows: bool,
-}
-
-fn eval_shell_invocation(command: &str) -> EvalShellInvocation {
-    eval_shell_invocation_for_platform(command, EvalShellPlatform::current())
-}
-
+#[cfg(test)]
 fn eval_shell_invocation_for_platform(
     command: &str,
-    platform: EvalShellPlatform,
-) -> EvalShellInvocation {
-    match platform {
-        EvalShellPlatform::Windows => EvalShellInvocation {
-            program: "cmd",
-            args: vec!["/C".to_string(), command.to_string()],
-            raw_payload_on_windows: true,
-        },
-        EvalShellPlatform::Unix => EvalShellInvocation {
-            program: "sh",
-            args: vec!["-c".to_string(), command.to_string()],
-            raw_payload_on_windows: false,
-        },
-    }
+    platform: ShellPlatform,
+    probe: &ShellProbe,
+) -> ShellInvocation {
+    shell_invocation_for_platform(command, platform, probe)
 }
 
-fn push_eval_shell_args(cmd: &mut Command, invocation: &EvalShellInvocation) {
+fn push_eval_shell_args(cmd: &mut Command, invocation: &ShellInvocation) {
     #[cfg(windows)]
     {
         use std::os::windows::process::CommandExt;
@@ -768,7 +740,7 @@ fn apply_patch(root: &Path, patch: &str) -> Result<()> {
 
 fn exec_shell(root: &Path, command: &str) -> Result<String> {
     let invocation = eval_shell_invocation(command);
-    let mut cmd = Command::new(invocation.program);
+    let mut cmd = Command::new(&invocation.program);
     push_eval_shell_args(&mut cmd, &invocation);
     let output = cmd
         .current_dir(root)
@@ -805,12 +777,45 @@ mod tests {
     fn eval_shell_invocation_preserves_quoted_payload_as_single_arg() {
         let command = r#"git commit -m "feat: complete sub-pages""#;
 
-        let windows = eval_shell_invocation_for_platform(command, EvalShellPlatform::Windows);
-        assert_eq!(windows.program, "cmd");
-        assert_eq!(windows.args, vec!["/C".to_string(), command.to_string()]);
+        let windows = eval_shell_invocation_for_platform(
+            command,
+            ShellPlatform::Windows,
+            &ShellProbe {
+                comspec: Some("cmd.exe".to_string()),
+                ..ShellProbe::default()
+            },
+        );
+        assert_eq!(windows.program, "cmd.exe");
+        assert_eq!(
+            windows.args,
+            vec!["/C".to_string(), format!("chcp 65001 >NUL & {command}")]
+        );
         assert!(windows.raw_payload_on_windows);
 
-        let unix = eval_shell_invocation_for_platform(command, EvalShellPlatform::Unix);
+        let powershell = eval_shell_invocation_for_platform(
+            command,
+            ShellPlatform::Windows,
+            &ShellProbe {
+                pwsh_on_path: true,
+                ..ShellProbe::default()
+            },
+        );
+        assert_eq!(powershell.program, "pwsh.exe");
+        assert_eq!(
+            powershell.args,
+            vec![
+                "-NoProfile".to_string(),
+                "-Command".to_string(),
+                command.to_string()
+            ]
+        );
+        assert!(!powershell.raw_payload_on_windows);
+
+        let unix = eval_shell_invocation_for_platform(
+            command,
+            ShellPlatform::Unix,
+            &ShellProbe::default(),
+        );
         assert_eq!(unix.program, "sh");
         assert_eq!(unix.args, vec!["-c".to_string(), command.to_string()]);
         assert!(!unix.raw_payload_on_windows);

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -65,6 +65,7 @@ mod seam_manager;
 mod session_failure_classifier;
 mod session_manager;
 mod settings;
+mod shell_invocation;
 mod skill_state;
 mod skills;
 mod snapshot;

--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -142,7 +142,11 @@ for the current turn."
 fn render_environment_block(workspace: &Path, locale_tag: &str) -> String {
     let deepseek_version = env!("CARGO_PKG_VERSION");
     let platform = std::env::consts::OS;
-    let shell = std::env::var("SHELL").unwrap_or_else(|_| "unknown".to_string());
+    let shell = if cfg!(windows) {
+        crate::shell_invocation::shell_invocation("").program
+    } else {
+        std::env::var("SHELL").unwrap_or_else(|_| "unknown".to_string())
+    };
     let pwd = workspace.display();
 
     format!(

--- a/crates/tui/src/sandbox/mod.rs
+++ b/crates/tui/src/sandbox/mod.rs
@@ -51,6 +51,8 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::Duration;
 
+use crate::shell_invocation::{ShellInvocation, shell_invocation};
+
 pub use policy::SandboxPolicy;
 
 /// Specification for a command to be executed, potentially within a sandbox.
@@ -86,24 +88,11 @@ pub struct CommandSpec {
 impl CommandSpec {
     /// Create a `CommandSpec` for running a shell command via the platform shell.
     pub fn shell(command: &str, cwd: PathBuf, timeout: Duration) -> Self {
-        #[cfg(windows)]
-        let (program, args) = {
-            // Force UTF-8 output on Windows by running `chcp 65001` before the
-            // actual command. Without this, subprocesses output in the system's
-            // ANSI code page (e.g. GBK for Chinese locales), causing garbled
-            // text in the shell output panel. See issue #982.
-            let cmd = format!("chcp 65001 >NUL & {command}");
-            ("cmd".to_string(), vec!["/C".to_string(), cmd])
-        };
-        #[cfg(not(windows))]
-        let (program, args) = (
-            "sh".to_string(),
-            vec!["-c".to_string(), command.to_string()],
-        );
+        let invocation = shell_invocation(command);
 
         Self {
-            program,
-            args,
+            program: invocation.program,
+            args: invocation.args,
             cwd,
             env: HashMap::new(),
             timeout,
@@ -151,19 +140,13 @@ impl CommandSpec {
 
     /// Get the original command as a single string (for display).
     pub fn display_command(&self) -> String {
-        if self.program == "sh" && self.args.len() == 2 && self.args[0] == "-c" {
-            // For shell commands, show the actual command
-            self.args[1].clone()
-        } else if self.program.eq_ignore_ascii_case("cmd")
-            && self.args.len() == 2
-            && self.args[0].eq_ignore_ascii_case("/C")
-        {
-            // Strip the `chcp 65001 >NUL & ` prefix we add on Windows for
-            // UTF-8 output (issue #982).
-            let raw = &self.args[1];
-            raw.strip_prefix("chcp 65001 >NUL & ")
-                .unwrap_or(raw)
-                .to_string()
+        let invocation = ShellInvocation {
+            program: self.program.clone(),
+            args: self.args.clone(),
+            raw_payload_on_windows: false,
+        };
+        if let Some(command) = invocation.display_command() {
+            command
         } else {
             // For other commands, join program and args
             let mut parts = vec![self.program.clone()];
@@ -584,19 +567,10 @@ impl SandboxManager {
 mod tests {
     use super::*;
 
-    fn expected_shell_command(command: &str) -> Vec<String> {
-        #[cfg(windows)]
-        {
-            vec![
-                "cmd".to_string(),
-                "/C".to_string(),
-                format!("chcp 65001 >NUL & {command}"),
-            ]
-        }
-        #[cfg(not(windows))]
-        {
-            vec!["sh".to_string(), "-c".to_string(), command.to_string()]
-        }
+    fn expected_shell_command(spec: &CommandSpec) -> Vec<String> {
+        let mut command = vec![spec.program.clone()];
+        command.extend(spec.args.clone());
+        command
     }
 
     #[test]
@@ -605,8 +579,7 @@ mod tests {
 
         #[cfg(windows)]
         {
-            assert_eq!(spec.program, "cmd");
-            assert_eq!(spec.args, vec!["/C", "chcp 65001 >NUL & echo hello"]);
+            assert_windows_shell_spec_displays_command(&spec, "echo hello");
         }
         #[cfg(not(windows))]
         {
@@ -628,11 +601,7 @@ mod tests {
 
         #[cfg(windows)]
         {
-            assert_eq!(spec.program, "cmd");
-            assert_eq!(
-                spec.args,
-                vec!["/C".to_string(), format!("chcp 65001 >NUL & {cmd}")]
-            );
+            assert_windows_shell_spec_displays_command(&spec, cmd);
         }
         #[cfg(not(windows))]
         {
@@ -702,8 +671,29 @@ mod tests {
         let env = manager.prepare(&spec);
 
         assert_eq!(env.sandbox_type, SandboxType::None);
-        assert_eq!(env.command, expected_shell_command("echo test"));
+        assert_eq!(env.command, expected_shell_command(&spec));
         assert!(!env.is_sandboxed());
+    }
+
+    #[cfg(windows)]
+    fn assert_windows_shell_spec_displays_command(spec: &CommandSpec, command: &str) {
+        assert_eq!(spec.display_command(), command);
+
+        let program = spec.program.replace('\\', "/").to_ascii_lowercase();
+        if program.ends_with("/cmd.exe") || program == "cmd" || program == "cmd.exe" {
+            assert_eq!(spec.args[0], "/C");
+            assert!(spec.args[1].ends_with(command));
+        } else if program.ends_with("/pwsh.exe")
+            || program == "pwsh"
+            || program == "pwsh.exe"
+            || program.ends_with("/powershell.exe")
+            || program == "powershell"
+            || program == "powershell.exe"
+        {
+            assert_eq!(spec.args, ["-NoProfile", "-Command", command]);
+        } else {
+            assert_eq!(spec.args, ["-c", command]);
+        }
     }
 
     #[test]

--- a/crates/tui/src/shell_invocation.rs
+++ b/crates/tui/src/shell_invocation.rs
@@ -1,0 +1,351 @@
+//! Platform shell resolution for shell-command tools.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ShellPlatform {
+    Windows,
+    Unix,
+}
+
+impl ShellPlatform {
+    #[must_use]
+    pub(crate) fn current() -> Self {
+        if cfg!(windows) {
+            Self::Windows
+        } else {
+            Self::Unix
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ShellInvocation {
+    pub(crate) program: String,
+    pub(crate) args: Vec<String>,
+    pub(crate) raw_payload_on_windows: bool,
+}
+
+impl ShellInvocation {
+    #[must_use]
+    pub(crate) fn display_command(&self) -> Option<String> {
+        if self.program == "sh" && self.args.len() == 2 && self.args[0] == "-c" {
+            return Some(self.args[1].clone());
+        }
+
+        if shell_program_stem(&self.program)
+            .is_some_and(|stem| matches!(stem.as_str(), "bash" | "zsh" | "fish" | "sh"))
+            && self.args.len() == 2
+            && self.args[0] == "-c"
+        {
+            return Some(self.args[1].clone());
+        }
+
+        if shell_program_stem(&self.program).is_some_and(|stem| stem == "cmd")
+            && self.args.len() == 2
+            && self.args[0].eq_ignore_ascii_case("/C")
+        {
+            let raw = &self.args[1];
+            return Some(
+                raw.strip_prefix("chcp 65001 >NUL & ")
+                    .unwrap_or(raw)
+                    .to_string(),
+            );
+        }
+
+        if shell_program_stem(&self.program)
+            .is_some_and(|stem| matches!(stem.as_str(), "pwsh" | "powershell"))
+        {
+            if let Some((idx, _)) = self
+                .args
+                .iter()
+                .enumerate()
+                .find(|(_, arg)| arg.eq_ignore_ascii_case("-Command"))
+            {
+                if let Some(command) = self.args.get(idx + 1) {
+                    return Some(command.clone());
+                }
+            }
+        }
+
+        None
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub(crate) struct ShellProbe {
+    pub(crate) shell: Option<String>,
+    pub(crate) comspec: Option<String>,
+    pub(crate) pwsh_on_path: bool,
+    pub(crate) powershell_on_path: bool,
+}
+
+impl ShellProbe {
+    #[must_use]
+    pub(crate) fn from_env() -> Self {
+        Self {
+            shell: std::env::var("SHELL")
+                .ok()
+                .filter(|value| !value.trim().is_empty()),
+            comspec: std::env::var("COMSPEC")
+                .ok()
+                .filter(|value| !value.trim().is_empty()),
+            pwsh_on_path: command_on_path("pwsh.exe") || command_on_path("pwsh"),
+            powershell_on_path: command_on_path("powershell.exe") || command_on_path("powershell"),
+        }
+    }
+}
+
+#[must_use]
+pub(crate) fn shell_invocation(command: &str) -> ShellInvocation {
+    shell_invocation_for_platform(command, ShellPlatform::current(), &ShellProbe::from_env())
+}
+
+#[must_use]
+pub(crate) fn shell_invocation_for_platform(
+    command: &str,
+    platform: ShellPlatform,
+    probe: &ShellProbe,
+) -> ShellInvocation {
+    match platform {
+        ShellPlatform::Unix => unix_shell_invocation(command),
+        ShellPlatform::Windows => windows_shell_invocation(command, probe),
+    }
+}
+
+fn unix_shell_invocation(command: &str) -> ShellInvocation {
+    ShellInvocation {
+        program: "sh".to_string(),
+        args: vec!["-c".to_string(), command.to_string()],
+        raw_payload_on_windows: false,
+    }
+}
+
+fn windows_shell_invocation(command: &str, probe: &ShellProbe) -> ShellInvocation {
+    if let Some(shell) = probe
+        .shell
+        .as_deref()
+        .and_then(|shell| invocation_from_shell_env(shell, command))
+    {
+        return shell;
+    }
+
+    if probe.pwsh_on_path {
+        return powershell_invocation("pwsh.exe", command);
+    }
+
+    if probe.powershell_on_path {
+        return powershell_invocation("powershell.exe", command);
+    }
+
+    if let Some(comspec) = probe
+        .comspec
+        .as_deref()
+        .filter(|value| shell_program_stem(value).is_some_and(|stem| stem == "cmd"))
+    {
+        return cmd_invocation(comspec, command);
+    }
+
+    cmd_invocation("cmd", command)
+}
+
+fn invocation_from_shell_env(shell: &str, command: &str) -> Option<ShellInvocation> {
+    let stem = shell_program_stem(shell)?;
+    match stem.as_str() {
+        "pwsh" | "powershell" => Some(powershell_invocation(shell, command)),
+        "cmd" => Some(cmd_invocation(shell, command)),
+        "bash" | "zsh" | "fish" | "sh" => Some(posix_like_invocation(
+            windows_posix_shell_program(shell, &stem),
+            command,
+        )),
+        _ => None,
+    }
+}
+
+fn cmd_invocation(program: &str, command: &str) -> ShellInvocation {
+    ShellInvocation {
+        program: program.to_string(),
+        args: vec!["/C".to_string(), format!("chcp 65001 >NUL & {command}")],
+        raw_payload_on_windows: true,
+    }
+}
+
+fn powershell_invocation(program: &str, command: &str) -> ShellInvocation {
+    ShellInvocation {
+        program: program.to_string(),
+        args: vec![
+            "-NoProfile".to_string(),
+            "-Command".to_string(),
+            command.to_string(),
+        ],
+        raw_payload_on_windows: false,
+    }
+}
+
+fn posix_like_invocation(program: &str, command: &str) -> ShellInvocation {
+    ShellInvocation {
+        program: program.to_string(),
+        args: vec!["-c".to_string(), command.to_string()],
+        raw_payload_on_windows: false,
+    }
+}
+
+fn windows_posix_shell_program<'a>(shell: &'a str, stem: &'a str) -> &'a str {
+    if shell.trim_start().starts_with('/') {
+        stem
+    } else {
+        shell
+    }
+}
+
+fn shell_program_stem(program: &str) -> Option<String> {
+    let normalized = program.trim().replace('\\', "/");
+    let filename = normalized.rsplit('/').next()?.trim();
+    let stem = filename
+        .strip_suffix(".exe")
+        .or_else(|| filename.strip_suffix(".EXE"))
+        .unwrap_or(filename);
+    if stem.is_empty() {
+        None
+    } else {
+        Some(stem.to_ascii_lowercase())
+    }
+}
+
+#[cfg(windows)]
+fn command_on_path(program: &str) -> bool {
+    use std::path::PathBuf;
+
+    let candidate = PathBuf::from(program);
+    if candidate.components().count() > 1 {
+        return candidate.is_file();
+    }
+
+    let Some(path) = std::env::var_os("PATH") else {
+        return false;
+    };
+    std::env::split_paths(&path).any(|dir| dir.join(program).is_file())
+}
+
+#[cfg(not(windows))]
+fn command_on_path(_program: &str) -> bool {
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn probe() -> ShellProbe {
+        ShellProbe::default()
+    }
+
+    #[test]
+    fn unix_shell_stays_sh_c() {
+        let invocation = shell_invocation_for_platform("printf ok", ShellPlatform::Unix, &probe());
+        assert_eq!(invocation.program, "sh");
+        assert_eq!(invocation.args, ["-c", "printf ok"]);
+        assert!(!invocation.raw_payload_on_windows);
+        assert_eq!(invocation.display_command().as_deref(), Some("printf ok"));
+    }
+
+    #[test]
+    fn windows_prefers_shell_env_powershell() {
+        let invocation = shell_invocation_for_platform(
+            r#"Remove-Item -Path "target file.txt" -Force"#,
+            ShellPlatform::Windows,
+            &ShellProbe {
+                shell: Some(r"C:\Program Files\PowerShell\7\pwsh.exe".to_string()),
+                ..probe()
+            },
+        );
+
+        assert_eq!(
+            invocation.program,
+            r"C:\Program Files\PowerShell\7\pwsh.exe"
+        );
+        assert_eq!(
+            invocation.args,
+            [
+                "-NoProfile",
+                "-Command",
+                r#"Remove-Item -Path "target file.txt" -Force"#
+            ]
+        );
+        assert!(!invocation.raw_payload_on_windows);
+        assert_eq!(
+            invocation.display_command().as_deref(),
+            Some(r#"Remove-Item -Path "target file.txt" -Force"#)
+        );
+    }
+
+    #[test]
+    fn windows_uses_pwsh_before_cmd_when_available() {
+        let invocation = shell_invocation_for_platform(
+            "Get-ChildItem",
+            ShellPlatform::Windows,
+            &ShellProbe {
+                comspec: Some(r"C:\Windows\System32\cmd.exe".to_string()),
+                pwsh_on_path: true,
+                ..probe()
+            },
+        );
+
+        assert_eq!(invocation.program, "pwsh.exe");
+        assert_eq!(invocation.args, ["-NoProfile", "-Command", "Get-ChildItem"]);
+        assert!(!invocation.raw_payload_on_windows);
+    }
+
+    #[test]
+    fn windows_falls_back_to_comspec_cmd_with_utf8_prefix() {
+        let invocation = shell_invocation_for_platform(
+            r#"git commit -m "hello world""#,
+            ShellPlatform::Windows,
+            &ShellProbe {
+                comspec: Some(r"C:\Windows\System32\cmd.exe".to_string()),
+                ..probe()
+            },
+        );
+
+        assert_eq!(invocation.program, r"C:\Windows\System32\cmd.exe");
+        assert_eq!(
+            invocation.args,
+            ["/C", r#"chcp 65001 >NUL & git commit -m "hello world""#]
+        );
+        assert!(invocation.raw_payload_on_windows);
+        assert_eq!(
+            invocation.display_command().as_deref(),
+            Some(r#"git commit -m "hello world""#)
+        );
+    }
+
+    #[test]
+    fn windows_honors_posix_like_shell_env() {
+        let invocation = shell_invocation_for_platform(
+            "printf ok",
+            ShellPlatform::Windows,
+            &ShellProbe {
+                shell: Some(r"C:\Program Files\Git\usr\bin\bash.exe".to_string()),
+                pwsh_on_path: true,
+                ..probe()
+            },
+        );
+
+        assert_eq!(invocation.program, r"C:\Program Files\Git\usr\bin\bash.exe");
+        assert_eq!(invocation.args, ["-c", "printf ok"]);
+        assert!(!invocation.raw_payload_on_windows);
+    }
+
+    #[test]
+    fn windows_posix_shell_env_with_unix_path_uses_stem() {
+        let invocation = shell_invocation_for_platform(
+            "printf ok",
+            ShellPlatform::Windows,
+            &ShellProbe {
+                shell: Some("/usr/bin/bash".to_string()),
+                ..probe()
+            },
+        );
+
+        assert_eq!(invocation.program, "bash");
+        assert_eq!(invocation.args, ["-c", "printf ok"]);
+    }
+}

--- a/crates/tui/src/tools/shell/tests.rs
+++ b/crates/tui/src/tools/shell/tests.rs
@@ -931,14 +931,33 @@ fn issue_1691_quoted_commit_message_round_trips() {
 
     #[cfg(windows)]
     {
-        // `cmd /C <payload>`: payload carries the quotes verbatim. The fix
-        // routes /C + payload through `raw_arg` so `cmd.exe` (not MSVCRT)
-        // parses it, matching what a terminal does.
-        assert_eq!(spec.program, "cmd");
-        assert_eq!(
-            spec.args,
-            ["/C".to_string(), format!("chcp 65001 >NUL & {cmd}")]
-        );
+        let program = spec.program.replace('\\', "/").to_ascii_lowercase();
+        if program.ends_with("/cmd.exe") || program == "cmd" || program == "cmd.exe" {
+            // `cmd /C <payload>`: payload carries the quotes verbatim. The fix
+            // routes /C + payload through `raw_arg` so `cmd.exe` (not MSVCRT)
+            // parses it, matching what a terminal does.
+            assert_eq!(
+                spec.args,
+                ["/C".to_string(), format!("chcp 65001 >NUL & {cmd}")]
+            );
+        } else if program.ends_with("/pwsh.exe")
+            || program == "pwsh"
+            || program == "pwsh.exe"
+            || program.ends_with("/powershell.exe")
+            || program == "powershell"
+            || program == "powershell.exe"
+        {
+            assert_eq!(
+                spec.args,
+                [
+                    "-NoProfile".to_string(),
+                    "-Command".to_string(),
+                    cmd.to_string()
+                ]
+            );
+        } else {
+            assert_eq!(spec.args, ["-c".to_string(), cmd.to_string()]);
+        }
         let mut built = Command::new(&spec.program);
         push_shell_args(&mut built, &spec.program, &spec.args);
         let got: Vec<String> = built
@@ -947,4 +966,19 @@ fn issue_1691_quoted_commit_message_round_trips() {
             .collect();
         assert_eq!(got, spec.args);
     }
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_cmd_fallback_still_uses_raw_args() {
+    let cmd = r#"git commit -m "feat: complete sub-pages""#;
+    let args = vec!["/C".to_string(), format!("chcp 65001 >NUL & {cmd}")];
+
+    let mut built = Command::new("cmd");
+    push_shell_args(&mut built, "cmd", &args);
+    let got: Vec<String> = built
+        .get_args()
+        .map(|a| a.to_string_lossy().into_owned())
+        .collect();
+    assert_eq!(got, args);
 }

--- a/crates/tui/tests/eval_harness.rs
+++ b/crates/tui/tests/eval_harness.rs
@@ -2,6 +2,9 @@
 
 use std::fs;
 
+#[path = "../src/shell_invocation.rs"]
+mod shell_invocation;
+
 #[path = "../src/eval.rs"]
 mod eval;
 


### PR DESCRIPTION
## Summary

- add a small shared shell invocation resolver for shell-backed tools
- on Windows, honor a known `SHELL` first, then prefer `pwsh.exe` / `powershell.exe`, with `cmd /C` kept as the UTF-8 fallback
- route `CommandSpec::shell`, the offline eval shell step, and the prompt environment shell label through the resolver
- keep the existing `cmd` raw-argument fallback covered so quoted command payloads still survive when PowerShell is unavailable

Fixes #1779.
Refs #1781.

## Credit

Reported by @aboimpinto in #1779, with the broader ShellDispatcher v2 exploration in #1781. This PR intentionally harvests the narrow shell-resolution piece without taking the raw-mode/logging parts from that stale branch.

## Testing

- `CARGO_TARGET_DIR=/Volumes/VIXinSSD/whalebro/codewhale/target cargo test -p codewhale-tui shell_invocation -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/VIXinSSD/whalebro/codewhale/target cargo test -p codewhale-tui test_command_spec_shell -- --nocapture`
- `RUSTFLAGS=-Dwarnings CARGO_TARGET_DIR=/Volumes/VIXinSSD/whalebro/codewhale/target cargo check -p codewhale-tui --all-features --locked`
- `cargo fmt --all -- --check`
- `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hmbown/codewhale/pull/2279" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->