### PR TITLE
fix(engine): recover from stalled in-progress turns

### DIFF
--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -3916,9 +3916,19 @@ fn reconcile_turn_liveness(app: &mut App, now: Instant, has_running_agents: bool
             now.saturating_duration_since(started) > TURN_STALL_WATCHDOG_TIMEOUT
         })
     {
+        // Finalize in-flight thinking / assistant / tool cells so the
+        // transcript doesn't show permanent spinners after recovery.
+        streaming_thinking::finalize_current(app);
+        app.finalize_streaming_assistant_as_interrupted();
+        app.finalize_active_cell_as_interrupted();
+        app.streaming_state.reset();
+        app.streaming_message_index = None;
+        app.streaming_thinking_active_entry = None;
+
         app.is_loading = false;
         app.turn_started_at = None;
         app.runtime_turn_status = None;
+        app.runtime_turn_id = None;
         app.dispatch_started_at = None;
         app.push_status_toast(
             "Turn stalled — no completion signal received. Please try again.",

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -146,6 +146,11 @@ const UI_IDLE_POLL_MS: u64 = 48;
 const UI_ACTIVE_POLL_MS: u64 = 24;
 const WEB_CONFIG_POLL_MS: u64 = 16;
 const DISPATCH_WATCHDOG_TIMEOUT: Duration = Duration::from_secs(30);
+/// Maximum wall-clock time a turn may stay in `"in_progress"` before the UI
+/// assumes the engine stalled (e.g. sub-agent hang, lost completion event,
+/// engine panic).  Matched to [`DEFAULT_STREAM_IDLE_TIMEOUT`] so legitimate
+/// long-running tool chains are not interrupted prematurely.
+const TURN_STALL_WATCHDOG_TIMEOUT: Duration = Duration::from_secs(300);
 // Forced repaint cadence while a turn is live (model loading, compacting,
 // sub-agents running). Drives the footer water-spout animation as well as
 // the per-tool spinner pulse — keep this fast enough that the spout reads as
@@ -3896,6 +3901,28 @@ fn reconcile_turn_liveness(app: &mut App, now: Instant, has_running_agents: bool
         app.push_status_toast(
             "Recovered from an inconsistent busy state.",
             StatusToastLevel::Warning,
+            None,
+        );
+        return true;
+    }
+
+    // Branch 3: turn started but never completed — engine may have
+    // panicked, sub-agent may be stuck, or the completion event was lost.
+    if app.is_loading
+        && matches!(app.runtime_turn_status.as_deref(), Some("in_progress"))
+        && !has_running_agents
+        && !app.is_compacting
+        && app.turn_started_at.is_some_and(|started| {
+            now.saturating_duration_since(started) > TURN_STALL_WATCHDOG_TIMEOUT
+        })
+    {
+        app.is_loading = false;
+        app.turn_started_at = None;
+        app.runtime_turn_status = None;
+        app.dispatch_started_at = None;
+        app.push_status_toast(
+            "Turn stalled — no completion signal received. Please try again.",
+            StatusToastLevel::Error,
             None,
         );
         return true;

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -3930,6 +3930,8 @@ fn reconcile_turn_liveness(app: &mut App, now: Instant, has_running_agents: bool
         app.runtime_turn_status = None;
         app.runtime_turn_id = None;
         app.dispatch_started_at = None;
+        // Per-turn scroll lock — clear so the next turn auto-scrolls.
+        app.user_scrolled_during_stream = false;
         app.push_status_toast(
             "Turn stalled — no completion signal received. Please try again.",
             StatusToastLevel::Error,

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -2021,15 +2021,34 @@ fn turn_liveness_leaves_active_turn_running() {
     let mut app = create_test_app();
     app.is_loading = true;
     app.runtime_turn_status = Some("in_progress".to_string());
-    app.dispatch_started_at =
-        Some(Instant::now() - DISPATCH_WATCHDOG_TIMEOUT - Duration::from_secs(10));
+    app.turn_started_at = Some(Instant::now() - Duration::from_secs(60));
 
     let recovered = reconcile_turn_liveness(&mut app, Instant::now(), false);
 
     assert!(!recovered);
     assert!(app.is_loading);
-    assert!(app.dispatch_started_at.is_some());
+    assert!(app.turn_started_at.is_some());
     assert!(app.status_toasts.is_empty());
+}
+
+#[test]
+fn turn_liveness_recovers_stalled_in_progress_turn() {
+    let mut app = create_test_app();
+    app.is_loading = true;
+    app.runtime_turn_status = Some("in_progress".to_string());
+    app.turn_started_at =
+        Some(Instant::now() - TURN_STALL_WATCHDOG_TIMEOUT - Duration::from_millis(1));
+
+    let recovered = reconcile_turn_liveness(&mut app, Instant::now(), false);
+
+    assert!(recovered);
+    assert!(!app.is_loading);
+    assert!(app.turn_started_at.is_none());
+    assert!(app.runtime_turn_status.is_none());
+    assert!(app.dispatch_started_at.is_none());
+    let toast = app.status_toasts.back().expect("stall toast");
+    assert_eq!(toast.level, StatusToastLevel::Error);
+    assert!(toast.text.contains("Turn stalled"));
 }
 
 #[test]

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -2036,8 +2036,10 @@ fn turn_liveness_recovers_stalled_in_progress_turn() {
     let mut app = create_test_app();
     app.is_loading = true;
     app.runtime_turn_status = Some("in_progress".to_string());
+    app.runtime_turn_id = Some("stale-turn-id".to_string());
     app.turn_started_at =
         Some(Instant::now() - TURN_STALL_WATCHDOG_TIMEOUT - Duration::from_millis(1));
+    app.streaming_message_index = Some(0);
 
     let recovered = reconcile_turn_liveness(&mut app, Instant::now(), false);
 
@@ -2045,7 +2047,10 @@ fn turn_liveness_recovers_stalled_in_progress_turn() {
     assert!(!app.is_loading);
     assert!(app.turn_started_at.is_none());
     assert!(app.runtime_turn_status.is_none());
+    assert!(app.runtime_turn_id.is_none());
     assert!(app.dispatch_started_at.is_none());
+    assert!(app.streaming_message_index.is_none());
+    assert!(app.streaming_thinking_active_entry.is_none());
     let toast = app.status_toasts.back().expect("stall toast");
     assert_eq!(toast.level, StatusToastLevel::Error);
     assert!(toast.text.contains("Turn stalled"));

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -2040,6 +2040,7 @@ fn turn_liveness_recovers_stalled_in_progress_turn() {
     app.turn_started_at =
         Some(Instant::now() - TURN_STALL_WATCHDOG_TIMEOUT - Duration::from_millis(1));
     app.streaming_message_index = Some(0);
+    app.user_scrolled_during_stream = true;
 
     let recovered = reconcile_turn_liveness(&mut app, Instant::now(), false);
 
@@ -2051,6 +2052,7 @@ fn turn_liveness_recovers_stalled_in_progress_turn() {
     assert!(app.dispatch_started_at.is_none());
     assert!(app.streaming_message_index.is_none());
     assert!(app.streaming_thinking_active_entry.is_none());
+    assert!(!app.user_scrolled_during_stream);
     let toast = app.status_toasts.back().expect("stall toast");
     assert_eq!(toast.level, StatusToastLevel::Error);
     assert!(toast.text.contains("Turn stalled"));


### PR DESCRIPTION
## Summary

- Fix watchdog blind spot in `reconcile_turn_liveness()` where a turn stuck in `"in_progress"` was never recovered, leaving `is_loading` permanently `true`
- Add `TURN_STALL_WATCHDOG_TIMEOUT` (5 min) constant matched to stream idle timeout
- Add Branch 3 that checks `turn_started_at` for staleness when no sub-agents are running

## Problem

Users reported requests hanging indefinitely — the UI showed a spinner, new messages were queued ("edit last queued message"), and the app appeared frozen.

**Root cause:** `reconcile_turn_liveness()` had two branches that missed the `"in_progress"` state:

| Branch | Checks | Covers |
|--------|--------|--------|
| 1 | `runtime_turn_status.is_none()` | Before `TurnStarted` arrives |
| 2 | `runtime_turn_status ∈ {completed, interrupted, failed}` | After `TurnComplete` |
| **3 (new)** | `runtime_turn_status == "in_progress"` + timeout | **Turn started but never completed** |

When `TurnStarted` arrived but `TurnComplete` was lost (sub-agent hang, engine panic, etc.), neither existing branch triggered. `dispatch_started_at` is cleared on `TurnStarted` (line 1387), so Branch 1's 30s timeout only covers the dispatch window, not the actual turn execution.

## Fix

Added a third recovery branch that fires when:
- `is_loading` is true
- `runtime_turn_status` is `"in_progress"`
- No running sub-agents (they legitimately extend turn lifetime)
- Not compacting
- `turn_started_at` exceeds `TURN_STALL_WATCHDOG_TIMEOUT` (300s)

Recovery clears `is_loading`, `turn_started_at`, `runtime_turn_status`, and `dispatch_started_at`, then shows an Error toast.

## Test plan

- [x] `turn_liveness_leaves_active_turn_running` — turn within timeout does NOT trigger recovery
- [x] `turn_liveness_recovers_stalled_in_progress_turn` — turn exceeding timeout DOES trigger recovery
- [x] Existing tests pass (`turn_liveness_watchdog_clears_stale_dispatch`, `turn_liveness_reconciles_completed_busy_state`)
- [x] No new clippy warnings in modified files

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a watchdog blind spot in `reconcile_turn_liveness()` where a turn stuck in `\"in_progress\"` (engine panic, lost completion event) was never recovered, leaving `is_loading` permanently `true` and the UI frozen. All three issues flagged in the previous review round are addressed in this version.

- **Branch 3 recovery** clears `is_loading`, `turn_started_at`, `runtime_turn_status`, `runtime_turn_id`, `dispatch_started_at`, and `user_scrolled_during_stream`, calls the same cell-finalisation helpers as `apply_engine_error_to_app`, and fires an Error toast after 300 s with no completion signal.
- **Tests** cover both the happy path (within-timeout turn stays running) and the recovery path (turn past timeout triggers cleanup), with assertions on every field the branch modifies.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the new watchdog branch is well-guarded and mirrors the existing error-recovery helpers correctly.

The change adds one new conditional branch with tight guards. All fields touched by the branch are the same ones cleared in the existing TurnComplete and apply_engine_error_to_app paths. The only open item is a broken rustdoc link, which has no runtime impact.

No files require special attention; both changed files are narrow in scope.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/ui.rs | Adds TURN_STALL_WATCHDOG_TIMEOUT constant (300s) and Branch 3 in reconcile_turn_liveness() that recovers a stalled in-progress turn; cleanly clears streaming state, resets per-turn flags, and fires an Error toast. |
| crates/tui/src/tui/ui/tests.rs | Adds turn_liveness_recovers_stalled_in_progress_turn and updates turn_liveness_leaves_active_turn_running to assert Branch 3 does not fire within the timeout window. |

</details>

</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fturn-stall-watchdog%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fturn-stall-watchdog%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui.rs%3A149-152%0AThe%20rustdoc%20intra-link%20%60%5B%60DEFAULT_STREAM_IDLE_TIMEOUT%60%5D%60%20resolves%20to%20a%20private%20constant%20in%20a%20different%20module%20%28%60crates%2Ftui%2Fsrc%2Fclient%2Fchat.rs%60%29.%20Rustdoc%20cannot%20resolve%20cross-module%20links%20to%20private%20items%2C%20so%20this%20becomes%20a%20broken-link%20warning%20%28and%20an%20error%20under%20%60--deny%20rustdoc%3A%3Abroken_intra_doc_links%60%29.%20A%20plain%20prose%20reference%20avoids%20the%20warning.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20Maximum%20wall-clock%20time%20a%20turn%20may%20stay%20in%20%60%22in_progress%22%60%20before%20the%20UI%0A%2F%2F%2F%20assumes%20the%20engine%20stalled%20%28e.g.%20sub-agent%20hang%2C%20lost%20completion%20event%2C%0A%2F%2F%2F%20engine%20panic%29.%20%20Matched%20to%20the%20stream%20idle%20timeout%20%28300%20s%29%20so%20legitimate%0A%2F%2F%2F%20long-running%20tool%20chains%20are%20not%20interrupted%20prematurely.%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui.rs%3A149-152%0AThe%20rustdoc%20intra-link%20%60%5B%60DEFAULT_STREAM_IDLE_TIMEOUT%60%5D%60%20resolves%20to%20a%20private%20constant%20in%20a%20different%20module%20%28%60crates%2Ftui%2Fsrc%2Fclient%2Fchat.rs%60%29.%20Rustdoc%20cannot%20resolve%20cross-module%20links%20to%20private%20items%2C%20so%20this%20becomes%20a%20broken-link%20warning%20%28and%20an%20error%20under%20%60--deny%20rustdoc%3A%3Abroken_intra_doc_links%60%29.%20A%20plain%20prose%20reference%20avoids%20the%20warning.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20Maximum%20wall-clock%20time%20a%20turn%20may%20stay%20in%20%60%22in_progress%22%60%20before%20the%20UI%0A%2F%2F%2F%20assumes%20the%20engine%20stalled%20%28e.g.%20sub-agent%20hang%2C%20lost%20completion%20event%2C%0A%2F%2F%2F%20engine%20panic%29.%20%20Matched%20to%20the%20stream%20idle%20timeout%20%28300%20s%29%20so%20legitimate%0A%2F%2F%2F%20long-running%20tool%20chains%20are%20not%20interrupted%20prematurely.%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2283&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui.rs%3A149-152%0AThe%20rustdoc%20intra-link%20%60%5B%60DEFAULT_STREAM_IDLE_TIMEOUT%60%5D%60%20resolves%20to%20a%20private%20constant%20in%20a%20different%20module%20%28%60crates%2Ftui%2Fsrc%2Fclient%2Fchat.rs%60%29.%20Rustdoc%20cannot%20resolve%20cross-module%20links%20to%20private%20items%2C%20so%20this%20becomes%20a%20broken-link%20warning%20%28and%20an%20error%20under%20%60--deny%20rustdoc%3A%3Abroken_intra_doc_links%60%29.%20A%20plain%20prose%20reference%20avoids%20the%20warning.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20Maximum%20wall-clock%20time%20a%20turn%20may%20stay%20in%20%60%22in_progress%22%60%20before%20the%20UI%0A%2F%2F%2F%20assumes%20the%20engine%20stalled%20%28e.g.%20sub-agent%20hang%2C%20lost%20completion%20event%2C%0A%2F%2F%2F%20engine%20panic%29.%20%20Matched%20to%20the%20stream%20idle%20timeout%20%28300%20s%29%20so%20legitimate%0A%2F%2F%2F%20long-running%20tool%20chains%20are%20not%20interrupted%20prematurely.%0A%60%60%60%0A%0A&pr=2283&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["fix(tui): reset user\_scrolled\_during\_str..."](https://github.com/hmbown/codewhale/commit/a1e92cd6c2abe60a9752977921b365b9b88938ff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34155011)</sub>

<!-- /greptile_comment -->