### PR TITLE
[codex] refine shell prompt and powershell invocation

### DIFF
--- a/crates/tui/src/eval.rs
+++ b/crates/tui/src/eval.rs
@@ -806,6 +806,7 @@ mod tests {
             powershell.args,
             vec![
                 "-NoProfile".to_string(),
+                "-NonInteractive".to_string(),
                 "-Command".to_string(),
                 command.to_string()
             ]

--- a/crates/tui/src/eval.rs
+++ b/crates/tui/src/eval.rs
@@ -15,7 +15,7 @@ use std::process::Command;
 use std::time::{Duration, Instant};
 use tempfile::TempDir;
 
-use crate::shell_invocation::{ShellInvocation, shell_invocation};
+use crate::shell_invocation::{ShellInvocation, shell_invocation, shell_program_stem};
 #[cfg(test)]
 use crate::shell_invocation::{ShellPlatform, ShellProbe, shell_invocation_for_platform};
 
@@ -36,8 +36,9 @@ fn push_eval_shell_args(cmd: &mut Command, invocation: &ShellInvocation) {
     #[cfg(windows)]
     {
         use std::os::windows::process::CommandExt;
+        let is_cmd = shell_program_stem(&invocation.program).is_some_and(|stem| stem == "cmd");
         if invocation.raw_payload_on_windows
-            && invocation.program.eq_ignore_ascii_case("cmd")
+            && is_cmd
             && invocation.args.len() == 2
             && invocation.args[0].eq_ignore_ascii_case("/C")
         {
@@ -819,5 +820,27 @@ mod tests {
         assert_eq!(unix.program, "sh");
         assert_eq!(unix.args, vec!["-c".to_string(), command.to_string()]);
         assert!(!unix.raw_payload_on_windows);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn push_eval_shell_args_uses_raw_arg_for_full_path_cmd() {
+        let invocation = ShellInvocation {
+            program: r"C:\Windows\System32\cmd.exe".to_string(),
+            args: vec![
+                "/C".to_string(),
+                r#"chcp 65001 >NUL & git commit -m "quoted""#.to_string(),
+            ],
+            raw_payload_on_windows: true,
+        };
+
+        let mut cmd = Command::new("cmd");
+        push_eval_shell_args(&mut cmd, &invocation);
+        let got: Vec<String> = cmd
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+
+        assert_eq!(got, invocation.args);
     }
 }

--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -9,6 +9,7 @@
 
 use crate::models::SystemPrompt;
 use crate::project_context::{ProjectContext, load_project_context_with_parents};
+use crate::shell_invocation::{shell_invocation, shell_program_stem};
 use crate::tui::app::AppMode;
 use crate::tui::approval::ApprovalMode;
 use std::path::{Path, PathBuf};
@@ -143,7 +144,8 @@ fn render_environment_block(workspace: &Path, locale_tag: &str) -> String {
     let deepseek_version = env!("CARGO_PKG_VERSION");
     let platform = std::env::consts::OS;
     let shell = if cfg!(windows) {
-        crate::shell_invocation::shell_invocation("").program
+        let resolved = shell_invocation("").program;
+        shell_program_stem(&resolved).unwrap_or(resolved)
     } else {
         std::env::var("SHELL").unwrap_or_else(|_| "unknown".to_string())
     };
@@ -1074,6 +1076,18 @@ mod tests {
         assert!(block.contains(&format!("- pwd: {}", tmp.path().display())));
         assert!(block.contains("- platform:"));
         assert!(block.contains("- shell:"));
+
+        #[cfg(windows)]
+        {
+            let shell_line = block
+                .lines()
+                .find(|line| line.starts_with("- shell: "))
+                .expect("shell line present");
+            assert!(
+                !shell_line.contains('\\') && !shell_line.contains('/'),
+                "Windows prompt shell should use the stem, not a full path"
+            );
+        }
     }
 
     #[test]

--- a/crates/tui/src/shell_invocation.rs
+++ b/crates/tui/src/shell_invocation.rs
@@ -126,6 +126,9 @@ fn windows_shell_invocation(command: &str, probe: &ShellProbe) -> ShellInvocatio
         return shell;
     }
 
+    // Default Windows resolution is intentionally pwsh.exe -> cmd.exe. Windows
+    // PowerShell 5.x can still be selected explicitly through SHELL, but it is
+    // not used as an implicit fallback.
     if probe.pwsh_on_path {
         return powershell_invocation("pwsh.exe", command);
     }
@@ -288,6 +291,30 @@ mod tests {
             ["-NoProfile", "-NonInteractive", "-Command", "Get-ChildItem"]
         );
         assert!(!invocation.raw_payload_on_windows);
+    }
+
+    #[test]
+    fn windows_falls_back_to_comspec_cmd_with_utf8_prefix() {
+        let invocation = shell_invocation_for_platform(
+            "git status --short",
+            ShellPlatform::Windows,
+            &ShellProbe {
+                comspec: Some(r"C:\Windows\System32\cmd.exe".to_string()),
+                pwsh_on_path: false,
+                ..probe()
+            },
+        );
+
+        assert_eq!(invocation.program, r"C:\Windows\System32\cmd.exe");
+        assert_eq!(
+            invocation.args,
+            ["/C", "chcp 65001 >NUL & git status --short"]
+        );
+        assert!(invocation.raw_payload_on_windows);
+        assert_eq!(
+            invocation.display_command().as_deref(),
+            Some("git status --short")
+        );
     }
 
     #[test]

--- a/crates/tui/src/shell_invocation.rs
+++ b/crates/tui/src/shell_invocation.rs
@@ -167,6 +167,7 @@ fn powershell_invocation(program: &str, command: &str) -> ShellInvocation {
         program: program.to_string(),
         args: vec![
             "-NoProfile".to_string(),
+            "-NonInteractive".to_string(),
             "-Command".to_string(),
             command.to_string(),
         ],
@@ -257,6 +258,7 @@ mod tests {
             invocation.args,
             [
                 "-NoProfile",
+                "-NonInteractive",
                 "-Command",
                 r#"Remove-Item -Path "target file.txt" -Force"#
             ]
@@ -281,7 +283,10 @@ mod tests {
         );
 
         assert_eq!(invocation.program, "pwsh.exe");
-        assert_eq!(invocation.args, ["-NoProfile", "-Command", "Get-ChildItem"]);
+        assert_eq!(
+            invocation.args,
+            ["-NoProfile", "-NonInteractive", "-Command", "Get-ChildItem"]
+        );
         assert!(!invocation.raw_payload_on_windows);
     }
 

--- a/crates/tui/src/shell_invocation.rs
+++ b/crates/tui/src/shell_invocation.rs
@@ -274,6 +274,35 @@ mod tests {
     }
 
     #[test]
+    fn windows_shell_env_can_select_windows_powershell() {
+        let invocation = shell_invocation_for_platform(
+            "Get-ChildItem",
+            ShellPlatform::Windows,
+            &ShellProbe {
+                shell: Some(
+                    r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe".to_string(),
+                ),
+                comspec: Some(r"C:\Windows\System32\cmd.exe".to_string()),
+                pwsh_on_path: false,
+            },
+        );
+
+        assert_eq!(
+            invocation.program,
+            r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"
+        );
+        assert_eq!(
+            invocation.args,
+            ["-NoProfile", "-NonInteractive", "-Command", "Get-ChildItem"]
+        );
+        assert!(!invocation.raw_payload_on_windows);
+        assert_eq!(
+            invocation.display_command().as_deref(),
+            Some("Get-ChildItem")
+        );
+    }
+
+    #[test]
     fn windows_uses_pwsh_before_cmd_when_available() {
         let invocation = shell_invocation_for_platform(
             "Get-ChildItem",
@@ -291,6 +320,32 @@ mod tests {
             ["-NoProfile", "-NonInteractive", "-Command", "Get-ChildItem"]
         );
         assert!(!invocation.raw_payload_on_windows);
+    }
+
+    #[test]
+    fn windows_without_pwsh_falls_straight_to_cmd_not_windows_powershell() {
+        let invocation = shell_invocation_for_platform(
+            "git status --short",
+            ShellPlatform::Windows,
+            &ShellProbe {
+                comspec: Some(
+                    r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe".to_string(),
+                ),
+                pwsh_on_path: false,
+                ..probe()
+            },
+        );
+
+        assert_eq!(invocation.program, "cmd");
+        assert_eq!(
+            invocation.args,
+            ["/C", "chcp 65001 >NUL & git status --short"]
+        );
+        assert!(invocation.raw_payload_on_windows);
+        assert_eq!(
+            invocation.display_command().as_deref(),
+            Some("git status --short")
+        );
     }
 
     #[test]

--- a/crates/tui/src/shell_invocation.rs
+++ b/crates/tui/src/shell_invocation.rs
@@ -75,7 +75,6 @@ pub(crate) struct ShellProbe {
     pub(crate) shell: Option<String>,
     pub(crate) comspec: Option<String>,
     pub(crate) pwsh_on_path: bool,
-    pub(crate) powershell_on_path: bool,
 }
 
 impl ShellProbe {
@@ -89,7 +88,6 @@ impl ShellProbe {
                 .ok()
                 .filter(|value| !value.trim().is_empty()),
             pwsh_on_path: command_on_path("pwsh.exe") || command_on_path("pwsh"),
-            powershell_on_path: command_on_path("powershell.exe") || command_on_path("powershell"),
         }
     }
 }
@@ -130,10 +128,6 @@ fn windows_shell_invocation(command: &str, probe: &ShellProbe) -> ShellInvocatio
 
     if probe.pwsh_on_path {
         return powershell_invocation("pwsh.exe", command);
-    }
-
-    if probe.powershell_on_path {
-        return powershell_invocation("powershell.exe", command);
     }
 
     if let Some(comspec) = probe
@@ -196,17 +190,14 @@ fn windows_posix_shell_program<'a>(shell: &'a str, stem: &'a str) -> &'a str {
     }
 }
 
-fn shell_program_stem(program: &str) -> Option<String> {
+pub(crate) fn shell_program_stem(program: &str) -> Option<String> {
     let normalized = program.trim().replace('\\', "/");
-    let filename = normalized.rsplit('/').next()?.trim();
-    let stem = filename
-        .strip_suffix(".exe")
-        .or_else(|| filename.strip_suffix(".EXE"))
-        .unwrap_or(filename);
+    let filename = normalized.rsplit('/').next()?.trim().to_ascii_lowercase();
+    let stem = filename.strip_suffix(".exe").unwrap_or(&filename);
     if stem.is_empty() {
         None
     } else {
-        Some(stem.to_ascii_lowercase())
+        Some(stem.to_string())
     }
 }
 
@@ -292,29 +283,6 @@ mod tests {
         assert_eq!(invocation.program, "pwsh.exe");
         assert_eq!(invocation.args, ["-NoProfile", "-Command", "Get-ChildItem"]);
         assert!(!invocation.raw_payload_on_windows);
-    }
-
-    #[test]
-    fn windows_falls_back_to_comspec_cmd_with_utf8_prefix() {
-        let invocation = shell_invocation_for_platform(
-            r#"git commit -m "hello world""#,
-            ShellPlatform::Windows,
-            &ShellProbe {
-                comspec: Some(r"C:\Windows\System32\cmd.exe".to_string()),
-                ..probe()
-            },
-        );
-
-        assert_eq!(invocation.program, r"C:\Windows\System32\cmd.exe");
-        assert_eq!(
-            invocation.args,
-            ["/C", r#"chcp 65001 >NUL & git commit -m "hello world""#]
-        );
-        assert!(invocation.raw_payload_on_windows);
-        assert_eq!(
-            invocation.display_command().as_deref(),
-            Some(r#"git commit -m "hello world""#)
-        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- refine the Windows shell prompt so it shows a shell stem instead of a full path
- add `-NonInteractive` to PowerShell invocation
- keep the `cmd.exe` full-path raw-argument handling fix and its regression coverage
- keep the `shell_program_stem` helper reusable inside the crate

This is a follow-up branch because I cannot push directly to the maintainer branch from this environment.

Paulo Aboim Pinto

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refines Windows shell handling in three focused ways: the system-prompt environment block now shows a shell stem (`pwsh`, `cmd`) instead of a full executable path; PowerShell invocations gain `-NonInteractive`; and `push_eval_shell_args` in `eval.rs` correctly matches full-path `cmd.exe` references by routing through `shell_program_stem` rather than a plain case-insensitive string compare.

- The removal of the implicit `powershell.exe` (Windows PowerShell 5.x) auto-detection fallback is intentional and is now documented with a code comment; users can still select it explicitly via the `SHELL` environment variable.
- `-NonInteractive` is added to every `powershell_invocation` call (both `pwsh.exe` and explicit `powershell.exe` via `SHELL`), preventing PowerShell from waiting for user input in automated contexts.
- `shell_program_stem` is promoted to `pub(crate)` and reused consistently across `eval.rs` and `prompts.rs`, eliminating duplicated path-normalisation logic.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; all behaviour changes are intentional, documented, and covered by new tests.

The three changed files make tightly scoped improvements. The powershell.exe auto-detection removal is explicitly documented in a code comment and a new test confirms the correct fallback path. The shell_program_stem refactor produces identical output for all edge cases. The -NonInteractive addition and stem-only prompt display have targeted regression tests. No logic regressions or data-correctness issues were identified.

No files require special attention.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/tui/src/shell_invocation.rs | Removes powershell_on_path auto-detection (now documented as intentional); adds -NonInteractive to PowerShell invocation; makes shell_program_stem pub(crate); refactors stem extraction to lowercase upfront; adds three new targeted tests. |
| crates/tui/src/prompts.rs | Uses shell_program_stem on the resolved program to emit only the shell stem instead of a full path in the Environment block; adds a Windows-only assertion to the existing environment-block test. |
| crates/tui/src/eval.rs | Imports shell_program_stem and replaces the direct case-insensitive program name check so full-path cmd.exe invocations correctly use raw args; adds a Windows-only regression test. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/tui/src/shell_invocation.rs`, line 129-131 ([link](https://github.com/hmbown/codewhale/blob/8e1a27e439aa30b3cc05f005054a89094d15a93c/crates/tui/src/shell_invocation.rs#L129-L131)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Silent removal of `powershell.exe` auto-detection fallback**

   The `powershell_on_path` field and its associated fallback branch were removed, which means Windows users who only have `powershell.exe` (Windows PowerShell 5.x) installed — but not `pwsh` (PowerShell 7) — will now silently fall through to `cmd.exe`. This is a non-trivial behaviour change for any Windows machine that ships PowerShell 5.x exclusively (e.g. Windows Server 2019, unmanaged enterprise desktops). The PR description does not mention this removal, so it is unclear whether it is intentional. If `powershell.exe` is being deliberately dropped, a short comment or changelog entry would help reviewers and users understand the new minimum requirement.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22codex%2F2279-followup%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2F2279-followup%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fshell_invocation.rs%0ALine%3A%20129-131%0A%0AComment%3A%0A**Silent%20removal%20of%20%60powershell.exe%60%20auto-detection%20fallback**%0A%0AThe%20%60powershell_on_path%60%20field%20and%20its%20associated%20fallback%20branch%20were%20removed%2C%20which%20means%20Windows%20users%20who%20only%20have%20%60powershell.exe%60%20%28Windows%20PowerShell%205.x%29%20installed%20%E2%80%94%20but%20not%20%60pwsh%60%20%28PowerShell%207%29%20%E2%80%94%20will%20now%20silently%20fall%20through%20to%20%60cmd.exe%60.%20This%20is%20a%20non-trivial%20behaviour%20change%20for%20any%20Windows%20machine%20that%20ships%20PowerShell%205.x%20exclusively%20%28e.g.%20Windows%20Server%202019%2C%20unmanaged%20enterprise%20desktops%29.%20The%20PR%20description%20does%20not%20mention%20this%20removal%2C%20so%20it%20is%20unclear%20whether%20it%20is%20intentional.%20If%20%60powershell.exe%60%20is%20being%20deliberately%20dropped%2C%20a%20short%20comment%20or%20changelog%20entry%20would%20help%20reviewers%20and%20users%20understand%20the%20new%20minimum%20requirement.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fshell_invocation.rs%0ALine%3A%20129-131%0A%0AComment%3A%0A**Silent%20removal%20of%20%60powershell.exe%60%20auto-detection%20fallback**%0A%0AThe%20%60powershell_on_path%60%20field%20and%20its%20associated%20fallback%20branch%20were%20removed%2C%20which%20means%20Windows%20users%20who%20only%20have%20%60powershell.exe%60%20%28Windows%20PowerShell%205.x%29%20installed%20%E2%80%94%20but%20not%20%60pwsh%60%20%28PowerShell%207%29%20%E2%80%94%20will%20now%20silently%20fall%20through%20to%20%60cmd.exe%60.%20This%20is%20a%20non-trivial%20behaviour%20change%20for%20any%20Windows%20machine%20that%20ships%20PowerShell%205.x%20exclusively%20%28e.g.%20Windows%20Server%202019%2C%20unmanaged%20enterprise%20desktops%29.%20The%20PR%20description%20does%20not%20mention%20this%20removal%2C%20so%20it%20is%20unclear%20whether%20it%20is%20intentional.%20If%20%60powershell.exe%60%20is%20being%20deliberately%20dropped%2C%20a%20short%20comment%20or%20changelog%20entry%20would%20help%20reviewers%20and%20users%20understand%20the%20new%20minimum%20requirement.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2284&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fshell_invocation.rs%0ALine%3A%20129-131%0A%0AComment%3A%0A**Silent%20removal%20of%20%60powershell.exe%60%20auto-detection%20fallback**%0A%0AThe%20%60powershell_on_path%60%20field%20and%20its%20associated%20fallback%20branch%20were%20removed%2C%20which%20means%20Windows%20users%20who%20only%20have%20%60powershell.exe%60%20%28Windows%20PowerShell%205.x%29%20installed%20%E2%80%94%20but%20not%20%60pwsh%60%20%28PowerShell%207%29%20%E2%80%94%20will%20now%20silently%20fall%20through%20to%20%60cmd.exe%60.%20This%20is%20a%20non-trivial%20behaviour%20change%20for%20any%20Windows%20machine%20that%20ships%20PowerShell%205.x%20exclusively%20%28e.g.%20Windows%20Server%202019%2C%20unmanaged%20enterprise%20desktops%29.%20The%20PR%20description%20does%20not%20mention%20this%20removal%2C%20so%20it%20is%20unclear%20whether%20it%20is%20intentional.%20If%20%60powershell.exe%60%20is%20being%20deliberately%20dropped%2C%20a%20short%20comment%20or%20changelog%20entry%20would%20help%20reviewers%20and%20users%20understand%20the%20new%20minimum%20requirement.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2284&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["test(tui): lock Windows shell fallback b..."](https://github.com/hmbown/codewhale/commit/0360192ad72e88d16e2021cca63c74ab1a45d9e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34156950)</sub>

<!-- /greptile_comment -->