### PR TITLE
feat: configurable path_suffix for OpenAI-compat endpoints

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -213,6 +213,11 @@ max_subagents = 10 # optional (1-20)
 # api_key = "YOUR_OPENAI_COMPATIBLE_API_KEY"
 # base_url = "https://api.openai.com/v1"
 # model = "gpt-4.1"
+# # path_suffix = ""      # Override the version path segment. Use "" to drop
+#                         # the /v1 prefix (e.g. third-party endpoints that
+#                         # reject /v1/chat/completions). Custom values like
+#                         # "v2" produce /v2/chat/completions. Default is None
+#                         # (current /v1-adding behavior).
 
 # AtlasCloud OpenAI-compatible endpoint (https://www.atlascloud.ai/docs/models/llm)
 [providers.atlascloud]

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -128,6 +128,12 @@ pub struct ProviderConfigToml {
     pub auth_mode: Option<String>,
     #[serde(default)]
     pub http_headers: BTreeMap<String, String>,
+    /// Override the version path segment between base_url and API routes.
+    /// When `Some("")`, routes go directly on the unversioned base (e.g.
+    /// `https://host/chat/completions`). When `None`, the default `/v1`
+    /// versioning logic applies.
+    #[serde(default)]
+    pub path_suffix: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -1154,6 +1160,9 @@ impl ConfigToml {
 fn merge_project_provider_config(target: &mut ProviderConfigToml, source: &ProviderConfigToml) {
     if source.model.is_some() {
         target.model = source.model.clone();
+    }
+    if source.path_suffix.is_some() {
+        target.path_suffix = source.path_suffix.clone();
     }
 }
 

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -130,6 +130,7 @@ pub struct DeepSeekClient {
     default_model: String,
     connection_health: Arc<AsyncMutex<ConnectionHealth>>,
     rate_limiter: Arc<AsyncMutex<TokenBucket>>,
+    path_suffix: Option<String>,
 }
 
 const CONNECTION_FAILURE_THRESHOLD: u32 = 2;
@@ -296,6 +297,7 @@ impl Clone for DeepSeekClient {
             default_model: self.default_model.clone(),
             connection_health: self.connection_health.clone(),
             rate_limiter: self.rate_limiter.clone(),
+            path_suffix: self.path_suffix.clone(),
         }
     }
 }
@@ -390,10 +392,18 @@ fn is_version_segment(segment: &str) -> bool {
             .is_some_and(|rest| !rest.is_empty() && rest.chars().all(|ch| ch.is_ascii_digit()))
 }
 
-pub(super) fn api_url(base_url: &str, path: &str) -> String {
+pub(super) fn api_url(base_url: &str, path: &str, path_suffix: Option<&str>) -> String {
     let path = path.trim_start_matches('/');
     if path.starts_with("beta/") {
         return format!("{}/{}", unversioned_base_url(base_url), path);
+    }
+    if let Some(suffix) = path_suffix {
+        let base = unversioned_base_url(base_url).trim_end_matches('/').to_string();
+        let suffix = suffix.trim_matches('/');
+        if suffix.is_empty() {
+            return format!("{base}/{path}");
+        }
+        return format!("{base}/{suffix}/{path}");
     }
     let mut versioned = versioned_base_url(base_url);
     // The /beta suffix is not a real API version — it is an
@@ -474,9 +484,13 @@ impl DeepSeekClient {
         let retry = config.retry_policy();
         let default_model = config.default_model();
         let http_headers = config.http_headers();
+        let path_suffix = config.path_suffix();
 
         logging::info(format!("API provider: {}", api_provider.as_str()));
         logging::info(format!("API base URL: {base_url}"));
+        if let Some(ref suffix) = path_suffix {
+            logging::info(format!("API path suffix: {suffix}"));
+        }
         if !http_headers.is_empty() {
             logging::info(format!(
                 "{} custom HTTP header(s) configured",
@@ -499,6 +513,7 @@ impl DeepSeekClient {
             default_model,
             connection_health: Arc::new(AsyncMutex::new(ConnectionHealth::default())),
             rate_limiter: Arc::new(AsyncMutex::new(TokenBucket::from_env())),
+            path_suffix,
         })
     }
 
@@ -580,7 +595,7 @@ impl DeepSeekClient {
         model: &str,
         target_language: &str,
     ) -> Result<String> {
-        let url = api_url(&self.base_url, "chat/completions");
+        let url = api_url(&self.base_url, "chat/completions", self.path_suffix.as_deref());
         let mut body = serde_json::json!({
             "model": model,
             "messages": [
@@ -626,7 +641,7 @@ impl DeepSeekClient {
 
     /// List available models from the provider.
     pub async fn list_models(&self) -> Result<Vec<AvailableModel>> {
-        let url = api_url(&self.base_url, "models");
+        let url = api_url(&self.base_url, "models", self.path_suffix.as_deref());
         let response = self.send_with_retry(|| self.http_client.get(&url)).await?;
 
         let status = response.status();
@@ -673,7 +688,7 @@ impl DeepSeekClient {
         if !should_probe {
             return;
         }
-        let health_url = api_url(&self.base_url, "models");
+        let health_url = api_url(&self.base_url, "models", self.path_suffix.as_deref());
         let probe = self.http_client.get(health_url).send().await;
         match probe {
             Ok(resp) if resp.status().is_success() => {
@@ -784,7 +799,7 @@ impl LlmClient for DeepSeekClient {
     }
 
     async fn health_check(&self) -> Result<bool> {
-        let health_url = api_url(&self.base_url, "models");
+        let health_url = api_url(&self.base_url, "models", self.path_suffix.as_deref());
         self.wait_for_rate_limit().await;
         let response = self.http_client.get(health_url).send().await;
         match response {
@@ -1073,7 +1088,7 @@ impl DeepSeekClient {
         suffix: &str,
         max_tokens: u32,
     ) -> anyhow::Result<String> {
-        let url = api_url(&self.base_url, "beta/completions");
+        let url = api_url(&self.base_url, "beta/completions", self.path_suffix.as_deref());
         let body = json!({
             "model": model,
             "prompt": prompt,
@@ -1190,23 +1205,24 @@ mod tests {
     #[test]
     fn api_url_handles_default_v1_and_beta_base_urls() {
         assert_eq!(
-            api_url("https://api.deepseek.com", "chat/completions"),
+            api_url("https://api.deepseek.com", "chat/completions", None),
             "https://api.deepseek.com/v1/chat/completions"
         );
         assert_eq!(
-            api_url("https://api.deepseek.com/v1", "chat/completions"),
+            api_url("https://api.deepseek.com/v1", "chat/completions", None),
             "https://api.deepseek.com/v1/chat/completions"
         );
         // Non-beta paths from a /beta base URL route to /v1.
         // Only paths with an explicit beta/ prefix use the beta surface.
         assert_eq!(
-            api_url("https://api.deepseek.com/beta", "chat/completions"),
+            api_url("https://api.deepseek.com/beta", "chat/completions", None),
             "https://api.deepseek.com/v1/chat/completions"
         );
         assert_eq!(
             api_url(
                 "https://openai-compatible.example/api/coding/paas/v4",
-                "chat/completions"
+                "chat/completions",
+                None,
             ),
             "https://openai-compatible.example/api/coding/paas/v4/chat/completions"
         );
@@ -1215,15 +1231,15 @@ mod tests {
     #[test]
     fn api_url_routes_beta_paths_from_any_deepseek_base() {
         assert_eq!(
-            api_url("https://api.deepseek.com", "beta/completions"),
+            api_url("https://api.deepseek.com", "beta/completions", None),
             "https://api.deepseek.com/beta/completions"
         );
         assert_eq!(
-            api_url("https://api.deepseek.com/v1", "beta/completions"),
+            api_url("https://api.deepseek.com/v1", "beta/completions", None),
             "https://api.deepseek.com/beta/completions"
         );
         assert_eq!(
-            api_url("https://api.deepseek.com/beta", "beta/completions"),
+            api_url("https://api.deepseek.com/beta", "beta/completions", None),
             "https://api.deepseek.com/beta/completions"
         );
     }
@@ -1234,24 +1250,75 @@ mod tests {
         // /beta/models. Non-beta paths from a /beta base URL must
         // still route to /v1.
         assert_eq!(
-            api_url("https://api.deepseek.com", "models"),
+            api_url("https://api.deepseek.com", "models", None),
             "https://api.deepseek.com/v1/models"
         );
         assert_eq!(
-            api_url("https://api.deepseek.com/v1", "models"),
+            api_url("https://api.deepseek.com/v1", "models", None),
             "https://api.deepseek.com/v1/models"
         );
         assert_eq!(
-            api_url("https://api.deepseek.com/beta", "models"),
+            api_url("https://api.deepseek.com/beta", "models", None),
             "https://api.deepseek.com/v1/models"
         );
         // explicit v<N> versions other than /v1 should be preserved
         assert_eq!(
             api_url(
                 "https://openai-compatible.example/api/coding/paas/v4",
-                "models"
+                "models",
+                None,
             ),
             "https://openai-compatible.example/api/coding/paas/v4/models"
+        );
+    }
+
+    #[test]
+    fn api_url_respects_path_suffix() {
+        // Empty string suffix — no version segment
+        assert_eq!(
+            api_url("https://api.example.com", "chat/completions", Some("")),
+            "https://api.example.com/chat/completions"
+        );
+        // Non-empty suffix — replaces /v1
+        assert_eq!(
+            api_url("https://api.example.com", "chat/completions", Some("v2")),
+            "https://api.example.com/v2/chat/completions"
+        );
+        // Suffix with trailing slash
+        assert_eq!(
+            api_url("https://api.example.com", "chat/completions", Some("/v2/")),
+            "https://api.example.com/v2/chat/completions"
+        );
+        // Suffix on a base_url that already has a version segment
+        assert_eq!(
+            api_url("https://api.example.com/v1", "chat/completions", Some("v2")),
+            "https://api.example.com/v2/chat/completions"
+        );
+        // None suffix — existing default behaviour
+        assert_eq!(
+            api_url("https://api.example.com", "chat/completions", None),
+            "https://api.example.com/v1/chat/completions"
+        );
+    }
+
+    #[test]
+    fn api_url_path_suffix_with_models_endpoint() {
+        assert_eq!(
+            api_url("https://api.example.com", "models", Some("")),
+            "https://api.example.com/models"
+        );
+        assert_eq!(
+            api_url("https://api.example.com", "models", Some("v2")),
+            "https://api.example.com/v2/models"
+        );
+    }
+
+    #[test]
+    fn api_url_path_suffix_does_not_affect_beta_paths() {
+        // beta/ paths always use the unversioned base regardless of suffix
+        assert_eq!(
+            api_url("https://api.deepseek.com", "beta/completions", Some("v2")),
+            "https://api.deepseek.com/beta/completions"
         );
     }
 

--- a/crates/tui/src/client/chat.rs
+++ b/crates/tui/src/client/chat.rs
@@ -108,7 +108,7 @@ impl DeepSeekClient {
             self.api_provider,
         );
 
-        let url = api_url(&self.base_url, "chat/completions");
+        let url = api_url(&self.base_url, "chat/completions", self.path_suffix.as_deref());
         let open_timeout = stream_open_timeout();
         let response = match tokio_timeout(
             open_timeout,
@@ -197,7 +197,7 @@ impl DeepSeekClient {
             self.api_provider,
         );
 
-        let url = api_url(&self.base_url, "chat/completions");
+        let url = api_url(&self.base_url, "chat/completions", self.path_suffix.as_deref());
         let response = self
             .send_with_retry(|| self.http_client.post(&url).json(&body))
             .await?;

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -1806,6 +1806,15 @@ impl Config {
         provider_preserves_custom_base_url_model(provider, &self.deepseek_base_url())
     }
 
+    /// Return the configured API path suffix for the active provider.
+    /// When `None`, the default `/v1` versioning logic applies.
+    #[must_use]
+    pub fn path_suffix(&self) -> Option<String> {
+        let provider = self.api_provider();
+        self.provider_config_for(provider)
+            .and_then(|c| c.path_suffix.clone())
+    }
+
     /// Read the API key.
     ///
     /// Precedence: **explicit in-memory override → provider/root config


### PR DESCRIPTION
## Summary

Some third-party OpenAI-compatible endpoints reject `/v1/chat/completions` and serve exclusively at `/chat/completions`. This PR adds `path_suffix: Option<String>` to `ProviderConfigToml` to allow overriding the version path segment between the base URL and API routes.

- `path_suffix = ""` → routes go directly on the unversioned base: `https://host/chat/completions`
- `path_suffix = "v2"` → `https://host/v2/chat/completions`
- `path_suffix = None` (default) → current `/v1`-adding behavior is unchanged

### Changes

| File | Change |
|------|--------|
| `crates/config/src/lib.rs` | Added `path_suffix` field to `ProviderConfigToml`, updated `merge_project_provider_config` |
| `crates/tui/src/client.rs` | Added `path_suffix` to `DeepSeekClient`, threaded through `api_url()`, updated all callers, added tests |
| `crates/tui/src/client/chat.rs` | Updated `api_url` calls to pass `path_suffix` |
| `crates/tui/src/config.rs` | Added `path_suffix()` getter |
| `config.example.toml` | Added usage documentation |

## Testing

Note: Rust toolchain not available on this machine — unable to run local CI checks. Please verify with:

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [x] Updated docs in `config.example.toml`
- [x] Added tests for `path_suffix` behavior (3 new test functions)
- [ ] Verified TUI behavior manually if UI changes (N/A — config-only change)

Closes #2089, closes #1874

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a `path_suffix` config option to `ProviderConfigToml` that lets users override the version path segment (normally `/v1`) on OpenAI-compatible endpoints. The `api_url` helper is extended with a third parameter, all call sites are updated, and three new unit tests cover the relevant cases.

- `path_suffix` is correctly added to `ProviderConfigToml` (config crate) and merged in `merge_project_provider_config`, but the parallel `ProviderConfig` struct in `crates/tui/src/config.rs` was not updated — `Config::path_suffix()` accesses `c.path_suffix` on a type that has no such field, which is an unconditional compile error.
- The `api_url` logic itself is sound: `beta/` paths are checked first (bypassing the suffix), `unversioned_base_url` strips any existing version segment before the suffix is applied, and slash-trimming on the suffix value handles user input like `\"/v2/\"` correctly.
</details>


<details open><summary><h3>Confidence Score: 2/5</h3></summary>

Not safe to merge — the change will not compile as written.

The `Config::path_suffix()` getter accesses `c.path_suffix` on `ProviderConfig`, a struct that was never given that field; every cargo build of the `tui` crate will fail at this line. The rest of the change — the `api_url` extension, the `DeepSeekClient` wiring, the config-crate `ProviderConfigToml` update, and the new tests — is logically correct and well-structured, but none of it can be exercised until the missing field is added.

crates/tui/src/config.rs — `ProviderConfig` needs a `pub path_suffix: Option<String>` field to match the getter added on line 1812.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/tui/src/config.rs | Adds `Config::path_suffix()` getter that accesses a field (`path_suffix`) on `ProviderConfig` which was never added to that struct — compile error. |
| crates/config/src/lib.rs | Correctly adds `path_suffix: Option<String>` to `ProviderConfigToml` with `#[serde(default)]` and wires it into `merge_project_provider_config`, consistent with how `model` is handled. |
| crates/tui/src/client.rs | Extends `api_url` with `path_suffix: Option<&str>`, adds the field to `DeepSeekClient`, updates all seven call sites, and adds three new test functions covering empty, non-empty, slash-padded, and `None` cases. Logic is correct; beta-path bypass is tested. |
| crates/tui/src/client/chat.rs | Both `api_url` call sites in the chat module updated to pass `self.path_suffix.as_deref()` — straightforward and complete. |
| config.example.toml | Documentation comment added explaining `path_suffix` semantics: empty string removes `/v1`, custom value replaces it, absent means default behavior. Clear and accurate. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["api_url(base_url, path, path_suffix)"] --> B{path starts with 'beta/'?}
    B -- Yes --> C["unversioned_base_url(base_url) + '/' + path"]
    B -- No --> D{path_suffix is Some?}
    D -- "Some(suffix)" --> E["unversioned_base_url(base_url)\nstrip '/' from suffix"]
    E --> F{suffix is empty?}
    F -- Yes --> G["base + '/' + path"]
    F -- No --> H["base + '/' + suffix + '/' + path"]
    D -- None --> I["versioned_base_url(base_url)"]
    I --> J{ends with 'beta'?}
    J -- Yes --> K["unversioned_base_url + '/v1/' + path"]
    J -- No --> L["versioned + '/' + path"]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/tui/src/config.rs`, line 1319-1325 ([link](https://github.com/hmbown/codewhale/blob/b3e53bfdcad724a8ceda6463da940ebc4a185e0e/crates/tui/src/config.rs#L1319-L1325)) 

   <a href="#"><img alt="P0" src="https://greptile-static-assets.s3.amazonaws.com/badges/p0.svg?v=9" align="top"></a> **Missing `path_suffix` field in `ProviderConfig`**

   The `Config::path_suffix()` getter (line 1815) accesses `c.path_suffix` on a `&ProviderConfig`, but `ProviderConfig` has no such field — the field was added only to `ProviderConfigToml` in the `config` crate. This is an unconditional compile error: `cargo build` will fail with "no field `path_suffix` on type `&ProviderConfig`".

   The fix is to add `pub path_suffix: Option<String>` to `ProviderConfig` here, mirroring the field added to `ProviderConfigToml`.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fpath-suffix-openai-compat%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fpath-suffix-openai-compat%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fconfig.rs%0ALine%3A%201319-1325%0A%0AComment%3A%0A**Missing%20%60path_suffix%60%20field%20in%20%60ProviderConfig%60**%0A%0AThe%20%60Config%3A%3Apath_suffix%28%29%60%20getter%20%28line%201815%29%20accesses%20%60c.path_suffix%60%20on%20a%20%60%26ProviderConfig%60%2C%20but%20%60ProviderConfig%60%20has%20no%20such%20field%20%E2%80%94%20the%20field%20was%20added%20only%20to%20%60ProviderConfigToml%60%20in%20the%20%60config%60%20crate.%20This%20is%20an%20unconditional%20compile%20error%3A%20%60cargo%20build%60%20will%20fail%20with%20%22no%20field%20%60path_suffix%60%20on%20type%20%60%26ProviderConfig%60%22.%0A%0AThe%20fix%20is%20to%20add%20%60pub%20path_suffix%3A%20Option%3CString%3E%60%20to%20%60ProviderConfig%60%20here%2C%20mirroring%20the%20field%20added%20to%20%60ProviderConfigToml%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fconfig.rs%0ALine%3A%201319-1325%0A%0AComment%3A%0A**Missing%20%60path_suffix%60%20field%20in%20%60ProviderConfig%60**%0A%0AThe%20%60Config%3A%3Apath_suffix%28%29%60%20getter%20%28line%201815%29%20accesses%20%60c.path_suffix%60%20on%20a%20%60%26ProviderConfig%60%2C%20but%20%60ProviderConfig%60%20has%20no%20such%20field%20%E2%80%94%20the%20field%20was%20added%20only%20to%20%60ProviderConfigToml%60%20in%20the%20%60config%60%20crate.%20This%20is%20an%20unconditional%20compile%20error%3A%20%60cargo%20build%60%20will%20fail%20with%20%22no%20field%20%60path_suffix%60%20on%20type%20%60%26ProviderConfig%60%22.%0A%0AThe%20fix%20is%20to%20add%20%60pub%20path_suffix%3A%20Option%3CString%3E%60%20to%20%60ProviderConfig%60%20here%2C%20mirroring%20the%20field%20added%20to%20%60ProviderConfigToml%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2286&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fconfig.rs%0ALine%3A%201319-1325%0A%0AComment%3A%0A**Missing%20%60path_suffix%60%20field%20in%20%60ProviderConfig%60**%0A%0AThe%20%60Config%3A%3Apath_suffix%28%29%60%20getter%20%28line%201815%29%20accesses%20%60c.path_suffix%60%20on%20a%20%60%26ProviderConfig%60%2C%20but%20%60ProviderConfig%60%20has%20no%20such%20field%20%E2%80%94%20the%20field%20was%20added%20only%20to%20%60ProviderConfigToml%60%20in%20the%20%60config%60%20crate.%20This%20is%20an%20unconditional%20compile%20error%3A%20%60cargo%20build%60%20will%20fail%20with%20%22no%20field%20%60path_suffix%60%20on%20type%20%60%26ProviderConfig%60%22.%0A%0AThe%20fix%20is%20to%20add%20%60pub%20path_suffix%3A%20Option%3CString%3E%60%20to%20%60ProviderConfig%60%20here%2C%20mirroring%20the%20field%20added%20to%20%60ProviderConfigToml%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2286&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fpath-suffix-openai-compat%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fpath-suffix-openai-compat%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fconfig.rs%3A1319-1325%0A**Missing%20%60path_suffix%60%20field%20in%20%60ProviderConfig%60**%0A%0AThe%20%60Config%3A%3Apath_suffix%28%29%60%20getter%20%28line%201815%29%20accesses%20%60c.path_suffix%60%20on%20a%20%60%26ProviderConfig%60%2C%20but%20%60ProviderConfig%60%20has%20no%20such%20field%20%E2%80%94%20the%20field%20was%20added%20only%20to%20%60ProviderConfigToml%60%20in%20the%20%60config%60%20crate.%20This%20is%20an%20unconditional%20compile%20error%3A%20%60cargo%20build%60%20will%20fail%20with%20%22no%20field%20%60path_suffix%60%20on%20type%20%60%26ProviderConfig%60%22.%0A%0AThe%20fix%20is%20to%20add%20%60pub%20path_suffix%3A%20Option%3CString%3E%60%20to%20%60ProviderConfig%60%20here%2C%20mirroring%20the%20field%20added%20to%20%60ProviderConfigToml%60.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fconfig.rs%3A1319-1325%0A**Missing%20%60path_suffix%60%20field%20in%20%60ProviderConfig%60**%0A%0AThe%20%60Config%3A%3Apath_suffix%28%29%60%20getter%20%28line%201815%29%20accesses%20%60c.path_suffix%60%20on%20a%20%60%26ProviderConfig%60%2C%20but%20%60ProviderConfig%60%20has%20no%20such%20field%20%E2%80%94%20the%20field%20was%20added%20only%20to%20%60ProviderConfigToml%60%20in%20the%20%60config%60%20crate.%20This%20is%20an%20unconditional%20compile%20error%3A%20%60cargo%20build%60%20will%20fail%20with%20%22no%20field%20%60path_suffix%60%20on%20type%20%60%26ProviderConfig%60%22.%0A%0AThe%20fix%20is%20to%20add%20%60pub%20path_suffix%3A%20Option%3CString%3E%60%20to%20%60ProviderConfig%60%20here%2C%20mirroring%20the%20field%20added%20to%20%60ProviderConfigToml%60.%0A%0A&repo=hmbown%2Fcodewhale&pr=2286&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fconfig.rs%3A1319-1325%0A**Missing%20%60path_suffix%60%20field%20in%20%60ProviderConfig%60**%0A%0AThe%20%60Config%3A%3Apath_suffix%28%29%60%20getter%20%28line%201815%29%20accesses%20%60c.path_suffix%60%20on%20a%20%60%26ProviderConfig%60%2C%20but%20%60ProviderConfig%60%20has%20no%20such%20field%20%E2%80%94%20the%20field%20was%20added%20only%20to%20%60ProviderConfigToml%60%20in%20the%20%60config%60%20crate.%20This%20is%20an%20unconditional%20compile%20error%3A%20%60cargo%20build%60%20will%20fail%20with%20%22no%20field%20%60path_suffix%60%20on%20type%20%60%26ProviderConfig%60%22.%0A%0AThe%20fix%20is%20to%20add%20%60pub%20path_suffix%3A%20Option%3CString%3E%60%20to%20%60ProviderConfig%60%20here%2C%20mirroring%20the%20field%20added%20to%20%60ProviderConfigToml%60.%0A%0A&pr=2286&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat: add configurable path\_suffix for O..."](https://github.com/hmbown/codewhale/commit/b3e53bfdcad724a8ceda6463da940ebc4a185e0e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34158440)</sub>

<!-- /greptile_comment -->