### PR TITLE
docs: clarify custom provider configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,11 @@ codewhale --provider fireworks --model deepseek-v4-pro
 codewhale auth set --provider openai --api-key "YOUR_OPENAI_COMPATIBLE_API_KEY"
 OPENAI_BASE_URL="https://openai-compatible.example/v4" codewhale --provider openai --model glm-5
 
+# Custom DeepSeek-compatible endpoint
+DEEPSEEK_BASE_URL="https://your-provider.example/v1" \
+  DEEPSEEK_MODEL="deepseek-ai/DeepSeek-V4-Pro" \
+  codewhale --provider deepseek
+
 # Self-hosted SGLang
 SGLANG_BASE_URL="http://localhost:30000/v1" codewhale --provider sglang --model deepseek-v4-flash
 
@@ -467,6 +472,12 @@ Full shortcut catalog: [docs/KEYBINDINGS.md](docs/KEYBINDINGS.md).
 ## Configuration
 
 User config: `~/.codewhale/config.toml` (legacy `~/.deepseek/config.toml` fallback). Project overlay: `<workspace>/.codewhale/config.toml` (legacy `<workspace>/.deepseek/config.toml`) (denied: `api_key`, `base_url`, `provider`, `mcp_config_path`). [config.example.toml](config.example.toml) has every option.
+
+Custom DeepSeek-compatible endpoints usually do not need a new provider. Keep
+`provider = "deepseek"` and set `[providers.deepseek].base_url` / `model`, or
+use `provider = "openai"` for generic OpenAI-compatible gateways. Keep
+`provider`, `api_key`, and `base_url` in user config or environment variables;
+project overlays cannot set them.
 
 Key environment variables:
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -191,12 +191,21 @@ max_subagents = 10 # optional (1-20)
 #   SGLang:    SGLANG_BASE_URL, SGLANG_MODEL, optional SGLANG_API_KEY
 #   vLLM:      VLLM_BASE_URL, VLLM_MODEL, optional VLLM_API_KEY
 #   Ollama:    OLLAMA_BASE_URL, OLLAMA_MODEL, optional OLLAMA_API_KEY
+#
+# Custom DeepSeek-compatible APIs usually do not need a new provider table:
+# set `provider = "deepseek"` and override [providers.deepseek].base_url/model.
+# For generic OpenAI-compatible gateways, use `provider = "openai"` and the
+# [providers.openai] table below. Keep provider/api_key/base_url in user config
+# or environment variables; project overlays are not allowed to set them.
 
 # DeepSeek Platform (https://platform.deepseek.com)
 [providers.deepseek]
 # api_key = "YOUR_DEEPSEEK_API_KEY"
 # base_url = "https://api.deepseek.com/beta"
 # model = "deepseek-v4-pro"
+# Custom DeepSeek-compatible example:
+# base_url = "https://your-provider.example/v1"
+# model = "deepseek-ai/DeepSeek-V4-Pro"
 # http_headers = { "X-Model-Provider-Id" = "your-model-provider" } # optional custom request headers
 
 # NVIDIA NIM-hosted DeepSeek V4 (https://build.nvidia.com)
@@ -213,6 +222,9 @@ max_subagents = 10 # optional (1-20)
 # api_key = "YOUR_OPENAI_COMPATIBLE_API_KEY"
 # base_url = "https://api.openai.com/v1"
 # model = "gpt-4.1"
+# Gateway example:
+# base_url = "https://gateway.example/v1"
+# model = "your-deepseek-compatible-model"
 
 # AtlasCloud OpenAI-compatible endpoint (https://www.atlascloud.ai/docs/models/llm)
 [providers.atlascloud]

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -1137,6 +1137,7 @@ fn config_hint_for_key(key: &str) -> &'static str {
         "theme" => "system | dark | light | grayscale",
         "locale" => "auto | en | ja | zh-Hans | pt-BR",
         "background_color" => "#RRGGBB | default",
+        "base_url" => "save user config; e.g. https://api.deepseek.com/beta or https://gateway/v1",
         "default_mode" => "agent | plan | yolo",
         "sidebar_width" => "10..=50",
         "sidebar_focus" => "auto | work | tasks | agents | context | hidden",

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -61,6 +61,48 @@ Non-local `http://` base URLs are rejected unless
 `DEEPSEEK_ALLOW_INSECURE_HTTP=1` is set. Loopback HTTP URLs are allowed for
 self-hosted runtimes.
 
+## Custom DeepSeek-Compatible Endpoints
+
+Most custom DeepSeek-compatible deployments can use an existing provider ID.
+Do not create `[providers.deepseek_custom]`; the provider table names are fixed.
+Instead, choose the closest shipped route and override its endpoint/model:
+
+- DeepSeek-compatible hosted API: keep `provider = "deepseek"` and set
+  `[providers.deepseek].base_url` plus `[providers.deepseek].model`, or launch
+  with `DEEPSEEK_BASE_URL` and `DEEPSEEK_MODEL`.
+- Generic OpenAI-compatible gateway: use `provider = "openai"` with
+  `[providers.openai].base_url` plus `[providers.openai].model`, or launch with
+  `OPENAI_BASE_URL` and `OPENAI_MODEL`.
+- Local OpenAI-compatible runtimes: use `provider = "vllm"`, `"sglang"`, or
+  `"ollama"` with the matching provider-specific base URL/model values.
+
+Example user config for a DeepSeek-compatible host:
+
+```toml
+provider = "deepseek"
+
+[providers.deepseek]
+api_key = "YOUR_API_KEY"
+base_url = "https://your-provider.example/v1"
+model = "deepseek-ai/DeepSeek-V4-Pro"
+```
+
+Example user config for a generic gateway:
+
+```toml
+provider = "openai"
+
+[providers.openai]
+api_key = "YOUR_GATEWAY_API_KEY"
+base_url = "https://gateway.example/v1"
+model = "your-deepseek-compatible-model"
+```
+
+Keep `provider`, `api_key`, and `base_url` in user config or process
+environment. Project-local config overlays intentionally cannot set those keys,
+so a repository cannot silently redirect prompts or credentials to another
+endpoint.
+
 ## Shipped Providers
 
 | Provider ID | TOML table | Auth env | Base URL env and default | Default or static models | Notes |


### PR DESCRIPTION
## Summary
- document how existing provider IDs cover custom DeepSeek-compatible endpoints and generic OpenAI-compatible gateways
- add concrete README and config.example.toml examples for DeepSeek-compatible and gateway base_url/model overrides
- add a native /config base_url hint so the TUI points users toward saved user config instead of project overlays

Closes #2247

## Verification
- git diff --check
- cargo fmt --all --check
- cargo test -p codewhale-tui --bin codewhale-tui config_view --all-features

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This is a docs-only PR that clarifies how existing provider IDs (`deepseek`, `openai`) can be reused for custom DeepSeek-compatible endpoints and generic OpenAI-compatible gateways, rather than requiring users to invent new provider names.

- Adds a new "Custom DeepSeek-Compatible Endpoints" section to `docs/PROVIDERS.md` with concrete TOML examples and a note that project overlays cannot override `provider`/`api_key`/`base_url`.
- Extends `README.md` with a CLI quickstart snippet for custom endpoints and a short prose paragraph reinforcing the user-config restriction.
- Adds commented-out gateway/custom-endpoint examples in `config.example.toml` and a new `base_url` hint in the TUI `/config` editor.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Documentation-only changes; no executable logic is altered beyond adding a single hint string in the TUI config view.

All changes are in Markdown, TOML comments, and a single Rust string constant. The TUI hint for `base_url` mixes an imperative instruction with example URLs, making it inconsistent with every other hint in the same function. The `config.example.toml` now has two commented `base_url`/`model` pairs in `[providers.deepseek]` without a clear mutual-exclusion note, which could mislead users who uncomment both. Neither issue affects runtime behaviour.

`crates/tui/src/tui/views/mod.rs` (hint text format) and `config.example.toml` (duplicate commented key pairs).
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/views/mod.rs | Adds a `base_url` hint to `config_hint_for_key`; the hint text blends an instruction ("save user config") with example URLs, inconsistent with the format every other hint in this function uses. |
| config.example.toml | Adds documentation comments for custom provider endpoint overrides; introduces duplicate commented-out `base_url`/`model` keys in `[providers.deepseek]` that could confuse users who uncomment them simultaneously. |
| docs/PROVIDERS.md | Adds a clear "Custom DeepSeek-Compatible Endpoints" section with worked TOML examples and an explanation of the project-overlay restriction; content is accurate and well-structured. |
| README.md | Adds a CLI quickstart example for custom DeepSeek-compatible endpoints and a prose paragraph explaining the user-config restriction; content is consistent with PROVIDERS.md. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User wants custom endpoint] --> B{DeepSeek-compatible?}
    B -->|Yes| C[provider = deepseek]
    B -->|No - generic OpenAI| D[provider = openai]
    B -->|No - local runtime| E[provider = vllm / sglang / ollama]

    C --> F[Set providers.deepseek.base_url + model\nor DEEPSEEK_BASE_URL + DEEPSEEK_MODEL]
    D --> G[Set providers.openai.base_url + model\nor OPENAI_BASE_URL + OPENAI_MODEL]
    E --> H[Set provider-specific BASE_URL + MODEL env vars]

    F --> I{Where to save?}
    G --> I
    H --> I

    I -->|Allowed| J["~/.codewhale/config.toml\nor process env vars"]
    I -->|Blocked| K["workspace/.codewhale/config.toml\n(project overlay — provider/api_key/base_url denied)"]

    J --> L[TUI /config base_url hint now points here]
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2F2247-provider-discoverability%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F2247-provider-discoverability%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fviews%2Fmod.rs%3A1140%0AThe%20%60base_url%60%20hint%20mixes%20an%20imperative%20instruction%20%28%22save%20user%20config%22%29%20with%20example%20URL%20values%2C%20which%20is%20inconsistent%20with%20every%20other%20entry%20in%20this%20function%20%28all%20of%20which%20show%20only%20valid%20value%20formats%20or%20examples%29.%20A%20user%20typing%20in%20the%20TUI%20field%20would%20see%20%22save%20user%20config%3B%20e.g.%20%E2%80%A6%22%20as%20the%20hint%20and%20might%20be%20confused%20about%20what%20to%20actually%20enter.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%22base_url%22%20%3D%3E%20%22https%3A%2F%2Fapi.deepseek.com%2Fbeta%20%7C%20https%3A%2F%2Fgateway%2Fv1%20%20%28set%20in%20user%20config%29%22%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aconfig.example.toml%3A203-209%0AThere%20are%20now%20two%20separate%20commented%20%60base_url%60%20and%20%60model%60%20lines%20inside%20%60%5Bproviders.deepseek%5D%60%20%E2%80%94%20the%20original%20defaults%20and%20the%20new%20custom-endpoint%20examples.%20If%20a%20user%20naively%20uncomments%20both%20groups%2C%20TOML%20parsers%20that%20enforce%20unique%20keys%20will%20error%3B%20others%20will%20silently%20use%20the%20last%20value.%20Adding%20a%20clear%20mutual-exclusion%20note%20or%20restructuring%20so%20only%20one%20pair%20appears%20at%20a%20time%20would%20prevent%20the%20confusion.%0A%0A%60%60%60suggestion%0A%23%20api_key%20%3D%20%22YOUR_DEEPSEEK_API_KEY%22%0A%23%20base_url%20%3D%20%22https%3A%2F%2Fapi.deepseek.com%2Fbeta%22%20%20%20%23%20default%20DeepSeek%20platform%20%28beta%20features%29%0A%23%20model%20%3D%20%22deepseek-v4-pro%22%0A%23%20---%20OR%3A%20custom%20DeepSeek-compatible%20endpoint%20%28pick%20one%20base_url%2Fmodel%20pair%29%20---%0A%23%20base_url%20%3D%20%22https%3A%2F%2Fyour-provider.example%2Fv1%22%0A%23%20model%20%3D%20%22deepseek-ai%2FDeepSeek-V4-Pro%22%0A%23%20http_headers%20%3D%20%7B%20%22X-Model-Provider-Id%22%20%3D%20%22your-model-provider%22%20%7D%20%23%20optional%20custom%20request%20headers%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fviews%2Fmod.rs%3A1140%0AThe%20%60base_url%60%20hint%20mixes%20an%20imperative%20instruction%20%28%22save%20user%20config%22%29%20with%20example%20URL%20values%2C%20which%20is%20inconsistent%20with%20every%20other%20entry%20in%20this%20function%20%28all%20of%20which%20show%20only%20valid%20value%20formats%20or%20examples%29.%20A%20user%20typing%20in%20the%20TUI%20field%20would%20see%20%22save%20user%20config%3B%20e.g.%20%E2%80%A6%22%20as%20the%20hint%20and%20might%20be%20confused%20about%20what%20to%20actually%20enter.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%22base_url%22%20%3D%3E%20%22https%3A%2F%2Fapi.deepseek.com%2Fbeta%20%7C%20https%3A%2F%2Fgateway%2Fv1%20%20%28set%20in%20user%20config%29%22%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aconfig.example.toml%3A203-209%0AThere%20are%20now%20two%20separate%20commented%20%60base_url%60%20and%20%60model%60%20lines%20inside%20%60%5Bproviders.deepseek%5D%60%20%E2%80%94%20the%20original%20defaults%20and%20the%20new%20custom-endpoint%20examples.%20If%20a%20user%20naively%20uncomments%20both%20groups%2C%20TOML%20parsers%20that%20enforce%20unique%20keys%20will%20error%3B%20others%20will%20silently%20use%20the%20last%20value.%20Adding%20a%20clear%20mutual-exclusion%20note%20or%20restructuring%20so%20only%20one%20pair%20appears%20at%20a%20time%20would%20prevent%20the%20confusion.%0A%0A%60%60%60suggestion%0A%23%20api_key%20%3D%20%22YOUR_DEEPSEEK_API_KEY%22%0A%23%20base_url%20%3D%20%22https%3A%2F%2Fapi.deepseek.com%2Fbeta%22%20%20%20%23%20default%20DeepSeek%20platform%20%28beta%20features%29%0A%23%20model%20%3D%20%22deepseek-v4-pro%22%0A%23%20---%20OR%3A%20custom%20DeepSeek-compatible%20endpoint%20%28pick%20one%20base_url%2Fmodel%20pair%29%20---%0A%23%20base_url%20%3D%20%22https%3A%2F%2Fyour-provider.example%2Fv1%22%0A%23%20model%20%3D%20%22deepseek-ai%2FDeepSeek-V4-Pro%22%0A%23%20http_headers%20%3D%20%7B%20%22X-Model-Provider-Id%22%20%3D%20%22your-model-provider%22%20%7D%20%23%20optional%20custom%20request%20headers%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2287&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fviews%2Fmod.rs%3A1140%0AThe%20%60base_url%60%20hint%20mixes%20an%20imperative%20instruction%20%28%22save%20user%20config%22%29%20with%20example%20URL%20values%2C%20which%20is%20inconsistent%20with%20every%20other%20entry%20in%20this%20function%20%28all%20of%20which%20show%20only%20valid%20value%20formats%20or%20examples%29.%20A%20user%20typing%20in%20the%20TUI%20field%20would%20see%20%22save%20user%20config%3B%20e.g.%20%E2%80%A6%22%20as%20the%20hint%20and%20might%20be%20confused%20about%20what%20to%20actually%20enter.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%22base_url%22%20%3D%3E%20%22https%3A%2F%2Fapi.deepseek.com%2Fbeta%20%7C%20https%3A%2F%2Fgateway%2Fv1%20%20%28set%20in%20user%20config%29%22%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aconfig.example.toml%3A203-209%0AThere%20are%20now%20two%20separate%20commented%20%60base_url%60%20and%20%60model%60%20lines%20inside%20%60%5Bproviders.deepseek%5D%60%20%E2%80%94%20the%20original%20defaults%20and%20the%20new%20custom-endpoint%20examples.%20If%20a%20user%20naively%20uncomments%20both%20groups%2C%20TOML%20parsers%20that%20enforce%20unique%20keys%20will%20error%3B%20others%20will%20silently%20use%20the%20last%20value.%20Adding%20a%20clear%20mutual-exclusion%20note%20or%20restructuring%20so%20only%20one%20pair%20appears%20at%20a%20time%20would%20prevent%20the%20confusion.%0A%0A%60%60%60suggestion%0A%23%20api_key%20%3D%20%22YOUR_DEEPSEEK_API_KEY%22%0A%23%20base_url%20%3D%20%22https%3A%2F%2Fapi.deepseek.com%2Fbeta%22%20%20%20%23%20default%20DeepSeek%20platform%20%28beta%20features%29%0A%23%20model%20%3D%20%22deepseek-v4-pro%22%0A%23%20---%20OR%3A%20custom%20DeepSeek-compatible%20endpoint%20%28pick%20one%20base_url%2Fmodel%20pair%29%20---%0A%23%20base_url%20%3D%20%22https%3A%2F%2Fyour-provider.example%2Fv1%22%0A%23%20model%20%3D%20%22deepseek-ai%2FDeepSeek-V4-Pro%22%0A%23%20http_headers%20%3D%20%7B%20%22X-Model-Provider-Id%22%20%3D%20%22your-model-provider%22%20%7D%20%23%20optional%20custom%20request%20headers%0A%60%60%60%0A%0A&pr=2287&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs: clarify custom provider configurat..."](https://github.com/hmbown/codewhale/commit/7d6264c3c69ae3cc9ceaaac3acf3f8bc7fc2405a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34159850)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->