### PR TITLE
feat: configurable path_suffix for OpenAI-compat endpoints

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -213,6 +213,11 @@ max_subagents = 10 # optional (1-20)
 # api_key = "YOUR_OPENAI_COMPATIBLE_API_KEY"
 # base_url = "https://api.openai.com/v1"
 # model = "gpt-4.1"
+# # path_suffix = ""      # Override the version path segment. Use "" to drop
+#                         # the /v1 prefix (e.g. third-party endpoints that
+#                         # reject /v1/chat/completions). Custom values like
+#                         # "v2" produce /v2/chat/completions. Default is None
+#                         # (current /v1-adding behavior).
 
 # AtlasCloud OpenAI-compatible endpoint (https://www.atlascloud.ai/docs/models/llm)
 [providers.atlascloud]

--- a/config.example.toml
+++ b/config.example.toml
@@ -213,7 +213,7 @@ max_subagents = 10 # optional (1-20)
 # api_key = "YOUR_OPENAI_COMPATIBLE_API_KEY"
 # base_url = "https://api.openai.com/v1"
 # model = "gpt-4.1"
-# # path_suffix = ""      # Override the version path segment. Use "" to drop
+# path_suffix = ""       # Override the version path segment. Use "" to drop
 #                         # the /v1 prefix (e.g. third-party endpoints that
 #                         # reject /v1/chat/completions). Custom values like
 #                         # "v2" produce /v2/chat/completions. Default is None

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -128,6 +128,12 @@ pub struct ProviderConfigToml {
     pub auth_mode: Option<String>,
     #[serde(default)]
     pub http_headers: BTreeMap<String, String>,
+    /// Override the version path segment between base_url and API routes.
+    /// When `Some("")`, routes go directly on the unversioned base (e.g.
+    /// `https://host/chat/completions`). When `None`, the default `/v1`
+    /// versioning logic applies.
+    #[serde(default)]
+    pub path_suffix: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -1154,6 +1160,9 @@ impl ConfigToml {
 fn merge_project_provider_config(target: &mut ProviderConfigToml, source: &ProviderConfigToml) {
     if source.model.is_some() {
         target.model = source.model.clone();
+    }
+    if source.path_suffix.is_some() {
+        target.path_suffix = source.path_suffix.clone();
     }
 }
 

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -130,6 +130,7 @@ pub struct DeepSeekClient {
     default_model: String,
     connection_health: Arc<AsyncMutex<ConnectionHealth>>,
     rate_limiter: Arc<AsyncMutex<TokenBucket>>,
+    path_suffix: Option<String>,
 }
 
 const CONNECTION_FAILURE_THRESHOLD: u32 = 2;
@@ -296,6 +297,7 @@ impl Clone for DeepSeekClient {
             default_model: self.default_model.clone(),
             connection_health: self.connection_health.clone(),
             rate_limiter: self.rate_limiter.clone(),
+            path_suffix: self.path_suffix.clone(),
         }
     }
 }
@@ -390,10 +392,18 @@ fn is_version_segment(segment: &str) -> bool {
             .is_some_and(|rest| !rest.is_empty() && rest.chars().all(|ch| ch.is_ascii_digit()))
 }
 
-pub(super) fn api_url(base_url: &str, path: &str) -> String {
+pub(super) fn api_url(base_url: &str, path: &str, path_suffix: Option<&str>) -> String {
     let path = path.trim_start_matches('/');
     if path.starts_with("beta/") {
         return format!("{}/{}", unversioned_base_url(base_url), path);
+    }
+    if let Some(suffix) = path_suffix {
+        let base = unversioned_base_url(base_url).trim_end_matches('/').to_string();
+        let suffix = suffix.trim_matches('/');
+        if suffix.is_empty() {
+            return format!("{base}/{path}");
+        }
+        return format!("{base}/{suffix}/{path}");
     }
     let mut versioned = versioned_base_url(base_url);
     // The /beta suffix is not a real API version — it is an
@@ -474,9 +484,13 @@ impl DeepSeekClient {
         let retry = config.retry_policy();
         let default_model = config.default_model();
         let http_headers = config.http_headers();
+        let path_suffix = config.path_suffix();
 
         logging::info(format!("API provider: {}", api_provider.as_str()));
         logging::info(format!("API base URL: {base_url}"));
+        if let Some(ref suffix) = path_suffix {
+            logging::info(format!("API path suffix: {suffix}"));
+        }
         if !http_headers.is_empty() {
             logging::info(format!(
                 "{} custom HTTP header(s) configured",
@@ -499,6 +513,7 @@ impl DeepSeekClient {
             default_model,
             connection_health: Arc::new(AsyncMutex::new(ConnectionHealth::default())),
             rate_limiter: Arc::new(AsyncMutex::new(TokenBucket::from_env())),
+            path_suffix,
         })
     }
 
@@ -580,7 +595,7 @@ impl DeepSeekClient {
         model: &str,
         target_language: &str,
     ) -> Result<String> {
-        let url = api_url(&self.base_url, "chat/completions");
+        let url = api_url(&self.base_url, "chat/completions", self.path_suffix.as_deref());
         let mut body = serde_json::json!({
             "model": model,
             "messages": [
@@ -626,7 +641,7 @@ impl DeepSeekClient {
 
     /// List available models from the provider.
     pub async fn list_models(&self) -> Result<Vec<AvailableModel>> {
-        let url = api_url(&self.base_url, "models");
+        let url = api_url(&self.base_url, "models", self.path_suffix.as_deref());
         let response = self.send_with_retry(|| self.http_client.get(&url)).await?;
 
         let status = response.status();
@@ -673,7 +688,7 @@ impl DeepSeekClient {
         if !should_probe {
             return;
         }
-        let health_url = api_url(&self.base_url, "models");
+        let health_url = api_url(&self.base_url, "models", self.path_suffix.as_deref());
         let probe = self.http_client.get(health_url).send().await;
         match probe {
             Ok(resp) if resp.status().is_success() => {
@@ -784,7 +799,7 @@ impl LlmClient for DeepSeekClient {
     }
 
     async fn health_check(&self) -> Result<bool> {
-        let health_url = api_url(&self.base_url, "models");
+        let health_url = api_url(&self.base_url, "models", self.path_suffix.as_deref());
         self.wait_for_rate_limit().await;
         let response = self.http_client.get(health_url).send().await;
         match response {
@@ -1073,7 +1088,7 @@ impl DeepSeekClient {
         suffix: &str,
         max_tokens: u32,
     ) -> anyhow::Result<String> {
-        let url = api_url(&self.base_url, "beta/completions");
+        let url = api_url(&self.base_url, "beta/completions", self.path_suffix.as_deref());
         let body = json!({
             "model": model,
             "prompt": prompt,
@@ -1190,23 +1205,24 @@ mod tests {
     #[test]
     fn api_url_handles_default_v1_and_beta_base_urls() {
         assert_eq!(
-            api_url("https://api.deepseek.com", "chat/completions"),
+            api_url("https://api.deepseek.com", "chat/completions", None),
             "https://api.deepseek.com/v1/chat/completions"
         );
         assert_eq!(
-            api_url("https://api.deepseek.com/v1", "chat/completions"),
+            api_url("https://api.deepseek.com/v1", "chat/completions", None),
             "https://api.deepseek.com/v1/chat/completions"
         );
         // Non-beta paths from a /beta base URL route to /v1.
         // Only paths with an explicit beta/ prefix use the beta surface.
         assert_eq!(
-            api_url("https://api.deepseek.com/beta", "chat/completions"),
+            api_url("https://api.deepseek.com/beta", "chat/completions", None),
             "https://api.deepseek.com/v1/chat/completions"
         );
         assert_eq!(
             api_url(
                 "https://openai-compatible.example/api/coding/paas/v4",
-                "chat/completions"
+                "chat/completions",
+                None,
             ),
             "https://openai-compatible.example/api/coding/paas/v4/chat/completions"
         );
@@ -1215,15 +1231,15 @@ mod tests {
     #[test]
     fn api_url_routes_beta_paths_from_any_deepseek_base() {
         assert_eq!(
-            api_url("https://api.deepseek.com", "beta/completions"),
+            api_url("https://api.deepseek.com", "beta/completions", None),
             "https://api.deepseek.com/beta/completions"
         );
         assert_eq!(
-            api_url("https://api.deepseek.com/v1", "beta/completions"),
+            api_url("https://api.deepseek.com/v1", "beta/completions", None),
             "https://api.deepseek.com/beta/completions"
         );
         assert_eq!(
-            api_url("https://api.deepseek.com/beta", "beta/completions"),
+            api_url("https://api.deepseek.com/beta", "beta/completions", None),
             "https://api.deepseek.com/beta/completions"
         );
     }
@@ -1234,24 +1250,75 @@ mod tests {
         // /beta/models. Non-beta paths from a /beta base URL must
         // still route to /v1.
         assert_eq!(
-            api_url("https://api.deepseek.com", "models"),
+            api_url("https://api.deepseek.com", "models", None),
             "https://api.deepseek.com/v1/models"
         );
         assert_eq!(
-            api_url("https://api.deepseek.com/v1", "models"),
+            api_url("https://api.deepseek.com/v1", "models", None),
             "https://api.deepseek.com/v1/models"
         );
         assert_eq!(
-            api_url("https://api.deepseek.com/beta", "models"),
+            api_url("https://api.deepseek.com/beta", "models", None),
             "https://api.deepseek.com/v1/models"
         );
         // explicit v<N> versions other than /v1 should be preserved
         assert_eq!(
             api_url(
                 "https://openai-compatible.example/api/coding/paas/v4",
-                "models"
+                "models",
+                None,
             ),
             "https://openai-compatible.example/api/coding/paas/v4/models"
+        );
+    }
+
+    #[test]
+    fn api_url_respects_path_suffix() {
+        // Empty string suffix — no version segment
+        assert_eq!(
+            api_url("https://api.example.com", "chat/completions", Some("")),
+            "https://api.example.com/chat/completions"
+        );
+        // Non-empty suffix — replaces /v1
+        assert_eq!(
+            api_url("https://api.example.com", "chat/completions", Some("v2")),
+            "https://api.example.com/v2/chat/completions"
+        );
+        // Suffix with trailing slash
+        assert_eq!(
+            api_url("https://api.example.com", "chat/completions", Some("/v2/")),
+            "https://api.example.com/v2/chat/completions"
+        );
+        // Suffix on a base_url that already has a version segment
+        assert_eq!(
+            api_url("https://api.example.com/v1", "chat/completions", Some("v2")),
+            "https://api.example.com/v2/chat/completions"
+        );
+        // None suffix — existing default behaviour
+        assert_eq!(
+            api_url("https://api.example.com", "chat/completions", None),
+            "https://api.example.com/v1/chat/completions"
+        );
+    }
+
+    #[test]
+    fn api_url_path_suffix_with_models_endpoint() {
+        assert_eq!(
+            api_url("https://api.example.com", "models", Some("")),
+            "https://api.example.com/models"
+        );
+        assert_eq!(
+            api_url("https://api.example.com", "models", Some("v2")),
+            "https://api.example.com/v2/models"
+        );
+    }
+
+    #[test]
+    fn api_url_path_suffix_does_not_affect_beta_paths() {
+        // beta/ paths always use the unversioned base regardless of suffix
+        assert_eq!(
+            api_url("https://api.deepseek.com", "beta/completions", Some("v2")),
+            "https://api.deepseek.com/beta/completions"
         );
     }
 

--- a/crates/tui/src/client/chat.rs
+++ b/crates/tui/src/client/chat.rs
@@ -108,7 +108,7 @@ impl DeepSeekClient {
             self.api_provider,
         );
 
-        let url = api_url(&self.base_url, "chat/completions");
+        let url = api_url(&self.base_url, "chat/completions", self.path_suffix.as_deref());
         let open_timeout = stream_open_timeout();
         let response = match tokio_timeout(
             open_timeout,
@@ -197,7 +197,7 @@ impl DeepSeekClient {
             self.api_provider,
         );
 
-        let url = api_url(&self.base_url, "chat/completions");
+        let url = api_url(&self.base_url, "chat/completions", self.path_suffix.as_deref());
         let response = self
             .send_with_retry(|| self.http_client.post(&url).json(&body))
             .await?;

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -1322,6 +1322,10 @@ pub struct ProviderConfig {
     pub model: Option<String>,
     pub auth_mode: Option<String>,
     pub http_headers: Option<HashMap<String, String>>,
+    /// Override the version path segment between base_url and API routes.
+    /// When `Some("")`, routes go directly on the unversioned base.
+    #[serde(default)]
+    pub path_suffix: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -1804,6 +1808,15 @@ impl Config {
     fn active_provider_preserves_custom_base_url_model(&self) -> bool {
         let provider = self.api_provider();
         provider_preserves_custom_base_url_model(provider, &self.deepseek_base_url())
+    }
+
+    /// Return the configured API path suffix for the active provider.
+    /// When `None`, the default `/v1` versioning logic applies.
+    #[must_use]
+    pub fn path_suffix(&self) -> Option<String> {
+        let provider = self.api_provider();
+        self.provider_config_for(provider)
+            .and_then(|c| c.path_suffix.clone())
     }
 
     /// Read the API key.
@@ -3308,6 +3321,7 @@ fn merge_provider_config(base: ProviderConfig, override_cfg: ProviderConfig) -> 
         model: override_cfg.model.or(base.model),
         auth_mode: override_cfg.auth_mode.or(base.auth_mode),
         http_headers: override_cfg.http_headers.or(base.http_headers),
+        path_suffix: override_cfg.path_suffix.or(base.path_suffix),
     }
 }
 


### PR DESCRIPTION
## Summary

Some third-party OpenAI-compatible endpoints reject `/v1/chat/completions` and serve exclusively at `/chat/completions`. This PR adds `path_suffix: Option<String>` to both `ProviderConfigToml` (config crate) and `ProviderConfig` (TUI crate), allowing users to override the version path segment between the base URL and API routes.

- `path_suffix = ""` — routes go directly on the unversioned base: `https://host/chat/completions`
- `path_suffix = "v2"` — `https://host/v2/chat/completions`
- `path_suffix = None` (default) — current `/v1`-adding behavior unchanged

### Changes

| File | Change |
|------|--------|
| `crates/config/src/lib.rs` | Added `path_suffix` to `ProviderConfigToml`, updated `merge_project_provider_config` |
| `crates/tui/src/config.rs` | Added `path_suffix` to `ProviderConfig`, updated `merge_provider_config`, added `Config::path_suffix()` getter |
| `crates/tui/src/client.rs` | Added `path_suffix` to `DeepSeekClient`, threaded through `api_url()`, updated all callers, added tests |
| `crates/tui/src/client/chat.rs` | Updated `api_url` calls to pass `path_suffix` |
| `config.example.toml` | Added usage documentation under `[providers.openai]` |

## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [x] Updated docs in `config.example.toml`
- [x] Added 3 test functions for `path_suffix` behavior
- [ ] Verified TUI behavior manually (N/A — config-only change)

Closes #2089, closes #1874

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a `path_suffix: Option<String>` field to both `ProviderConfigToml` (config crate) and `ProviderConfig` (TUI crate), letting users override the version segment injected between the base URL and API routes for OpenAI-compatible providers.

- `api_url()` gains a third `path_suffix` parameter; when `Some(\"\")` it omits any version prefix, when `Some(\"v2\")` it injects `/v2`, and when `None` it falls back to the existing `/v1` logic unchanged.
- All five call sites in `client.rs` and `chat.rs` are updated; `DeepSeekClient`, its `Clone` impl, and the constructor are all wired up. Three new unit tests cover the suffix, models endpoint, and the intentional beta-path bypass.
- The example config documents the option with inline prose under `[providers.openai]`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is additive and fully backwards-compatible; `None` preserves all existing behaviour.

All existing tests are updated, three new tests cover the new code paths, and the `None` default keeps every current call site behaving identically. The logic is isolated to `api_url()` and the new field is never written unless explicitly configured.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/client.rs | Adds `path_suffix: Option<String>` to `DeepSeekClient`, threads it through `api_url()`, and updates all five call sites plus the `Clone` impl. Three new unit tests cover the suffix, models, and beta-bypass cases. |
| crates/tui/src/config.rs | Adds `path_suffix: Option<String>` to `ProviderConfig`, wires it into `merge_provider_config` with `or()`, and exposes it via a new `Config::path_suffix()` getter that reads from the active provider's config. |
| crates/config/src/lib.rs | Adds `path_suffix: Option<String>` to `ProviderConfigToml` with a doc comment, and extends `merge_project_provider_config` to propagate it with the same `if source.is_some()` guard used for all other fields. |
| crates/tui/src/client/chat.rs | Two `api_url` call sites updated to pass `self.path_suffix.as_deref()`. Mechanical, no logic changes. |
| config.example.toml | Adds a commented-out `path_suffix` entry under `[providers.openai]` with an inline explanation of all three modes (empty string, custom value, None default). |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[api_url called\nbase_url, path, path_suffix] --> B{path starts\nwith beta/?}
    B -- Yes --> C[unversioned_base_url + path\nbeta/ prefix always wins]
    B -- No --> D{path_suffix\nis Some?}
    D -- Yes --> E[base = unversioned_base_url]
    E --> F{suffix\nempty?}
    F -- Yes --> G[base/path\ne.g. host/chat/completions]
    F -- No --> H[base/suffix/path\ne.g. host/v2/chat/completions]
    D -- No --> I[versioned_base_url logic\nappend /v1 if no version]
    I --> J{ends with\nbeta?}
    J -- Yes --> K[replace with /v1]
    J -- No --> L[base/path\ne.g. host/v1/chat/completions]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: remove double comment symbol in con..."](https://github.com/hmbown/codewhale/commit/4f2adfbdf22dd65847f99a45aca901fc45049dd4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34160724)</sub>

<!-- /greptile_comment -->