### PR TITLE
feat(cache): surface prefix hash drift

### DIFF
--- a/crates/tui/src/commands/debug.rs
+++ b/crates/tui/src/commands/debug.rs
@@ -19,6 +19,10 @@ fn token_count(value: Option<u32>, locale: Locale) -> String {
     )
 }
 
+fn short_hash(hash: &str) -> &str {
+    hash.get(..12).unwrap_or(hash)
+}
+
 fn active_context_summary(app: &App, locale: Locale) -> String {
     let estimated =
         estimate_input_tokens_conservative(&app.api_messages, app.system_prompt.as_ref());
@@ -142,6 +146,9 @@ pub fn cache(app: &mut App, arg: Option<&str>) -> CommandResult {
     if matches!(arg, Some("inspect")) {
         return CommandResult::message(format_cache_inspect(app));
     }
+    if matches!(arg, Some("stats")) {
+        return CommandResult::message(format_cache_stats(app));
+    }
     if matches!(arg, Some("warmup")) {
         return CommandResult::action(AppAction::CacheWarmup);
     }
@@ -230,6 +237,88 @@ fn format_cache_inspect(app: &mut App) -> String {
         out.push_str(&line);
     }
     app.session.last_cache_inspection = Some(inspection);
+    out
+}
+
+fn format_cache_stats(app: &App) -> String {
+    let checks = app.prefix_checks_total;
+    let changes = app.prefix_change_count;
+    let stable = checks.saturating_sub(changes);
+    let pct = app
+        .prefix_stability_pct
+        .map(|pct| format!("{pct}%"))
+        .unwrap_or_else(|| "unavailable".to_string());
+    let current_hash = app
+        .current_stable_prefix_hash
+        .as_deref()
+        .map(short_hash)
+        .unwrap_or("unavailable");
+
+    let mut out = String::new();
+    out.push_str("Cache Stats\n");
+    out.push_str(&format!("Model: {}\n", app.model));
+    out.push_str(&format!("Stable prefix hash: {current_hash}\n"));
+
+    if checks == 0 {
+        out.push_str("Stable prefix drift: no checks yet\n");
+    } else if changes == 0 {
+        out.push_str(&format!(
+            "Stable prefix drift: OK ({stable}/{checks} checks stable)\n"
+        ));
+    } else {
+        out.push_str(&format!(
+            "Stable prefix drift: WARNING ({changes} change{} across {checks} checks)\n",
+            if changes == 1 { "" } else { "s" }
+        ));
+        if let (Some(previous), Some(current)) = (
+            app.previous_stable_prefix_hash.as_deref(),
+            app.current_stable_prefix_hash.as_deref(),
+        ) {
+            out.push_str(&format!(
+                "Last hash change: {} -> {}\n",
+                short_hash(previous),
+                short_hash(current)
+            ));
+        }
+        if let Some(desc) = app.last_prefix_change_desc.as_deref() {
+            out.push_str(&format!("Last change: {desc}\n"));
+        }
+    }
+
+    out.push_str(&format!(
+        "Prefix checks: {checks} total, {stable} stable, {changes} changed, stability {pct}\n"
+    ));
+
+    let mut turns = 0usize;
+    let mut total_input = 0u64;
+    let mut total_hit = 0u64;
+    let mut total_miss = 0u64;
+    for rec in &app.session.turn_cache_history {
+        turns += 1;
+        total_input += u64::from(rec.input_tokens);
+        if let Some(hit) = rec.cache_hit_tokens {
+            let miss = rec
+                .cache_miss_tokens
+                .unwrap_or_else(|| rec.input_tokens.saturating_sub(hit));
+            total_hit += u64::from(hit);
+            total_miss += u64::from(miss);
+        }
+    }
+
+    if turns == 0 {
+        out.push_str("Recent cache telemetry: no turns recorded yet\n");
+    } else {
+        let accounted = total_hit + total_miss;
+        let avg = if accounted == 0 {
+            "unavailable".to_string()
+        } else {
+            format!("{:.1}%", 100.0 * total_hit as f64 / accounted as f64)
+        };
+        out.push_str(&format!(
+            "Recent cache telemetry: {turns} turns, {total_input} input, {total_hit} hit, {total_miss} miss, avg hit {avg}\n"
+        ));
+    }
+
     out
 }
 
@@ -816,6 +905,59 @@ mod tests {
         let msg = result.message.expect("cache produces a message");
         // Asked for 100 turns, only 3 exist — should report "last 3 of 3".
         assert!(msg.contains("last 3 of 3 turn(s)"), "got: {msg}");
+    }
+
+    #[test]
+    fn cache_stats_reports_stable_prefix_hash_without_turn_history() {
+        let mut app = create_test_app();
+        app.prefix_checks_total = 2;
+        app.prefix_stability_pct = Some(100);
+        app.current_stable_prefix_hash = Some("abcdef1234567890".to_string());
+
+        let result = cache(&mut app, Some("stats"));
+        let msg = result.message.expect("cache stats output");
+
+        assert!(msg.contains("Cache Stats"), "got: {msg}");
+        assert!(
+            msg.contains("Stable prefix hash: abcdef123456"),
+            "got: {msg}"
+        );
+        assert!(
+            msg.contains("Stable prefix drift: OK (2/2 checks stable)"),
+            "got: {msg}"
+        );
+        assert!(
+            msg.contains("Recent cache telemetry: no turns recorded yet"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn cache_stats_warns_when_stable_prefix_hash_drifted() {
+        let mut app = create_test_app();
+        app.prefix_checks_total = 3;
+        app.prefix_change_count = 1;
+        app.prefix_stability_pct = Some(67);
+        app.previous_stable_prefix_hash = Some("111111111111aaaa".to_string());
+        app.current_stable_prefix_hash = Some("222222222222bbbb".to_string());
+        app.last_prefix_change_desc =
+            Some("prefix cache invalidated: tool set changed".to_string());
+
+        let result = cache(&mut app, Some("stats"));
+        let msg = result.message.expect("cache stats output");
+
+        assert!(
+            msg.contains("Stable prefix drift: WARNING (1 change across 3 checks)"),
+            "got: {msg}"
+        );
+        assert!(
+            msg.contains("Last hash change: 111111111111 -> 222222222222"),
+            "got: {msg}"
+        );
+        assert!(
+            msg.contains("Last change: prefix cache invalidated: tool set changed"),
+            "got: {msg}"
+        );
     }
 
     #[test]

--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -543,7 +543,7 @@ pub const COMMANDS: &[CommandInfo] = &[
     CommandInfo {
         name: "cache",
         aliases: &[],
-        usage: "/cache [count|inspect|warmup]",
+        usage: "/cache [count|stats|inspect|warmup]",
         description_id: MessageId::CmdCacheDescription,
     },
 ];

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -249,6 +249,8 @@ impl Engine {
                 let tools_ref: Option<&[crate::models::Tool]> = active_tools.as_deref();
                 match pm.check_and_update(&system_text, tools_ref) {
                     Err(change) => {
+                        let previous_stable_prefix_hash = Some(change.old.combined_sha256.clone());
+                        let current_stable_prefix_hash = Some(change.new.combined_sha256.clone());
                         tracing::debug!(
                             target: "prefix_cache",
                             "{}",
@@ -258,6 +260,8 @@ impl Engine {
                             .tx_event
                             .send(Event::PrefixCacheChange {
                                 description: change.description(),
+                                previous_stable_prefix_hash,
+                                current_stable_prefix_hash,
                                 system_prompt_changed: change.system_changed,
                                 tools_changed: change.tools_changed,
                                 stability_pct: (pm.stability_ratio() * 100.0).round() as u32,
@@ -266,11 +270,16 @@ impl Engine {
                             .await;
                     }
                     Ok(_) => {
+                        let current_stable_prefix_hash = pm
+                            .current_fingerprint()
+                            .map(|fp| fp.combined_sha256.clone());
                         // Stable check — keep the TUI counter in sync.
                         let _ = self
                             .tx_event
                             .send(Event::PrefixCacheChange {
                                 description: String::new(),
+                                previous_stable_prefix_hash: None,
+                                current_stable_prefix_hash,
                                 system_prompt_changed: false,
                                 tools_changed: false,
                                 stability_pct: (pm.stability_ratio() * 100.0).round() as u32,

--- a/crates/tui/src/core/events.rs
+++ b/crates/tui/src/core/events.rs
@@ -272,6 +272,10 @@ pub enum Event {
     PrefixCacheChange {
         /// Human-readable description of what changed.
         description: String,
+        /// Previous stable prefix hash, when a drift was detected.
+        previous_stable_prefix_hash: Option<String>,
+        /// Current stable prefix hash after the check.
+        current_stable_prefix_hash: Option<String>,
         /// Whether the system prompt component changed.
         system_prompt_changed: bool,
         /// Whether the tool set component changed.

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -1464,6 +1464,10 @@ pub struct App {
     pub prefix_checks_total: u64,
     /// Current prefix stability percentage, if known.
     pub prefix_stability_pct: Option<u32>,
+    /// Previous stable prefix hash from the last detected drift.
+    pub previous_stable_prefix_hash: Option<String>,
+    /// Current stable prefix hash from the most recent prefix check.
+    pub current_stable_prefix_hash: Option<String>,
     /// Description of the last prefix change, if any.
     pub last_prefix_change_desc: Option<String>,
 
@@ -2002,6 +2006,8 @@ impl App {
             prefix_change_count: 0,
             prefix_checks_total: 0,
             prefix_stability_pct: None,
+            previous_stable_prefix_hash: None,
+            current_stable_prefix_hash: None,
             last_prefix_change_desc: None,
             cycle: CycleConfig::default(),
             collapsed_cells: HashSet::new(),

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -1734,17 +1734,42 @@ async fn run_event_loop(
                     }
                     EngineEvent::PrefixCacheChange {
                         description,
+                        previous_stable_prefix_hash,
+                        current_stable_prefix_hash,
                         stability_pct,
                         changed,
                         ..
                     } => {
                         app.prefix_checks_total = app.prefix_checks_total.saturating_add(1);
                         app.prefix_stability_pct = Some(stability_pct);
+                        if let Some(hash) = previous_stable_prefix_hash {
+                            app.previous_stable_prefix_hash = Some(hash);
+                        }
+                        if let Some(hash) = current_stable_prefix_hash {
+                            app.current_stable_prefix_hash = Some(hash);
+                        }
                         if changed {
                             app.prefix_change_count = app.prefix_change_count.saturating_add(1);
                             if !description.is_empty() {
-                                app.last_prefix_change_desc = Some(description);
+                                app.last_prefix_change_desc = Some(description.clone());
                             }
+                            let old_hash = app
+                                .previous_stable_prefix_hash
+                                .as_deref()
+                                .map(|hash| hash.get(..12).unwrap_or(hash))
+                                .unwrap_or("unknown");
+                            let new_hash = app
+                                .current_stable_prefix_hash
+                                .as_deref()
+                                .map(|hash| hash.get(..12).unwrap_or(hash))
+                                .unwrap_or("unknown");
+                            let reason = if description.is_empty() {
+                                "stable prefix hash changed"
+                            } else {
+                                description.as_str()
+                            };
+                            app.status_message =
+                                Some(format!("Warning: {reason} ({old_hash} -> {new_hash})"));
                         }
                     }
                     EngineEvent::CapacityDecision { .. } => {


### PR DESCRIPTION
## Summary
- carry stable prefix hashes on prefix-cache stability events
- add /cache stats with stable prefix hash, drift status, last drift hash delta, and recent cache telemetry totals
- show a TUI warning when the stable prefix hash changes between turns

Refs #2264

## Verification
- cargo test -p codewhale-tui --bin codewhale-tui cache_stats --all-features
- cargo test -p codewhale-tui --bin codewhale-tui cache_command --all-features
- cargo test -p codewhale-tui --bin codewhale-tui prefix_cache --all-features
- cargo test -p codewhale-tui --bin codewhale-tui cache --all-features
- cargo fmt --all --check
- git diff --check
- cargo clippy -p codewhale-tui --all-targets --all-features

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends the prefix-cache stability tracking system to carry stable prefix hashes on every `PrefixCacheChange` event, stores them in `App`, and exposes them through a new `/cache stats` subcommand and a TUI status-bar warning when hash drift is detected between turns.

- Adds `previous_stable_prefix_hash` / `current_stable_prefix_hash` to the `PrefixCacheChange` event and `App` struct; the engine populates both hashes on drift events and only the current hash on stable heartbeats.
- Introduces `format_cache_stats` in `debug.rs` with drift status, hash delta, and per-turn cache telemetry totals, backed by two new tests covering the stable and drifted cases.
- Wires the new hash fields into the TUI event loop to update app state and emit a `Warning: …` status message when the stable prefix hash changes.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — all new behaviour is additive and the two regression tests cover the main stable and drifted paths.

The event schema extension and app-state wiring are straightforward and well-tested. The main rough edge is in format_cache_stats: total_input is summed over all turns while total_hit/total_miss are only accumulated for turns with cache telemetry, so the three columns can appear inconsistent in mixed sessions.

crates/tui/src/commands/debug.rs — the telemetry totals section; crates/tui/src/tui/ui.rs — the inlined hash-truncation logic.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/commands/debug.rs | Adds `/cache stats` subcommand with `format_cache_stats` that surfaces prefix hash drift state, stability counters, and per-turn cache telemetry totals; also defines a `short_hash` helper. Minor inconsistency: `total_input` counts all turns while hit/miss only count turns with telemetry. |
| crates/tui/src/commands/mod.rs | One-line update to `/cache` usage string to include the new `stats` subcommand option. |
| crates/tui/src/core/engine/turn_loop.rs | Populates `previous_stable_prefix_hash` / `current_stable_prefix_hash` on every `PrefixCacheChange` event — both hashes on drift, only current hash on stable checks. Logic is correct and consistent with the event schema. |
| crates/tui/src/core/events.rs | Adds two optional hash fields to `PrefixCacheChange` event variant with clear doc comments; schema change is backward-compatible. |
| crates/tui/src/tui/app.rs | Adds `previous_stable_prefix_hash` and `current_stable_prefix_hash` fields to `App` with proper `None` initialization; straightforward struct extension. |
| crates/tui/src/tui/ui.rs | Handles new hash fields in the `PrefixCacheChange` event loop, updates app state, and emits a status-bar warning on drift. Duplicates the 12-char truncation logic from `debug.rs::short_hash` inline instead of reusing the helper. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Engine as Engine (turn_loop)
    participant Event as Event Bus
    participant UI as TUI Event Loop (ui.rs)
    participant App as App State
    participant Cmd as /cache stats (debug.rs)

    Engine->>Engine: pm.check_and_update(system, tools)
    alt Stable (Ok)
        Engine->>Event: "PrefixCacheChange { changed: false, current_hash: Some(H), previous_hash: None }"
        Event->>UI: dispatch
        UI->>App: "prefix_checks_total += 1"
        UI->>App: "current_stable_prefix_hash = Some(H)"
    else Drift (Err)
        Engine->>Event: "PrefixCacheChange { changed: true, previous_hash: Some(old), current_hash: Some(new) }"
        Event->>UI: dispatch
        UI->>App: "prefix_checks_total += 1, prefix_change_count += 1"
        UI->>App: "previous_stable_prefix_hash = Some(old)"
        UI->>App: "current_stable_prefix_hash = Some(new)"
        UI->>App: "status_message = Warning"
    end

    Note over Cmd,App: User runs /cache stats
    Cmd->>App: read prefix_checks_total, prefix_change_count
    Cmd->>App: read current/previous_stable_prefix_hash
    Cmd->>App: read turn_cache_history
    Cmd-->>UI: formatted stats string
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2F2264-cache-prefix-drift%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F2264-cache-prefix-drift%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui.rs%3A1756-1765%0A**Duplicated%20short-hash%20truncation%20logic**%0A%0A%60debug.rs%60%20already%20defines%20a%20%60short_hash%60%20helper%20%28%60hash.get%28..12%29.unwrap_or%28hash%29%60%29%2C%20but%20the%20same%2012-character%20truncation%20is%20inlined%20twice%20here%20in%20%60ui.rs%60.%20If%20the%20display%20width%20ever%20changes%2C%20it%20will%20need%20to%20be%20updated%20in%20two%20places%20instead%20of%20one.%20Consider%20either%20moving%20%60short_hash%60%20to%20a%20shared%20module%20or%20re-exporting%20it%20from%20%60debug.rs%60.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fcommands%2Fdebug.rs%3A277-305%0A**%60total_input%60%20and%20%60total_hit%60%2F%60total_miss%60%20can%20diverge%20silently**%0A%0A%60total_input%60%20accumulates%20for%20every%20turn%20in%20%60turn_cache_history%60%2C%20but%20%60total_hit%60%20and%20%60total_miss%60%20are%20only%20incremented%20when%20%60cache_hit_tokens%60%20is%20%60Some%60.%20For%20models%20that%20don't%20report%20cache%20telemetry%2C%20%60total_input%60%20will%20include%20those%20turns'%20tokens%20while%20%60total_hit%20%2B%20total_miss%60%20will%20not%2C%20making%20the%20displayed%20numbers%20appear%20inconsistent%20%28e.g.%20%225%20turns%2C%205000%20input%2C%201200%20hit%2C%20800%20miss%22%20where%20hit%2Bmiss%20%E2%89%A0%20input%29.%20Consider%20either%20restricting%20%60total_input%60%20to%20only%20the%20turns%20that%20have%20cache%20telemetry%2C%20or%20labelling%20the%20output%20to%20make%20clear%20that%20%60input%60%20is%20the%20session-wide%20total%20while%20hit%2Fmiss%20cover%20only%20telemetry-reporting%20turns.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui.rs%3A1756-1765%0A**Duplicated%20short-hash%20truncation%20logic**%0A%0A%60debug.rs%60%20already%20defines%20a%20%60short_hash%60%20helper%20%28%60hash.get%28..12%29.unwrap_or%28hash%29%60%29%2C%20but%20the%20same%2012-character%20truncation%20is%20inlined%20twice%20here%20in%20%60ui.rs%60.%20If%20the%20display%20width%20ever%20changes%2C%20it%20will%20need%20to%20be%20updated%20in%20two%20places%20instead%20of%20one.%20Consider%20either%20moving%20%60short_hash%60%20to%20a%20shared%20module%20or%20re-exporting%20it%20from%20%60debug.rs%60.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fcommands%2Fdebug.rs%3A277-305%0A**%60total_input%60%20and%20%60total_hit%60%2F%60total_miss%60%20can%20diverge%20silently**%0A%0A%60total_input%60%20accumulates%20for%20every%20turn%20in%20%60turn_cache_history%60%2C%20but%20%60total_hit%60%20and%20%60total_miss%60%20are%20only%20incremented%20when%20%60cache_hit_tokens%60%20is%20%60Some%60.%20For%20models%20that%20don't%20report%20cache%20telemetry%2C%20%60total_input%60%20will%20include%20those%20turns'%20tokens%20while%20%60total_hit%20%2B%20total_miss%60%20will%20not%2C%20making%20the%20displayed%20numbers%20appear%20inconsistent%20%28e.g.%20%225%20turns%2C%205000%20input%2C%201200%20hit%2C%20800%20miss%22%20where%20hit%2Bmiss%20%E2%89%A0%20input%29.%20Consider%20either%20restricting%20%60total_input%60%20to%20only%20the%20turns%20that%20have%20cache%20telemetry%2C%20or%20labelling%20the%20output%20to%20make%20clear%20that%20%60input%60%20is%20the%20session-wide%20total%20while%20hit%2Fmiss%20cover%20only%20telemetry-reporting%20turns.%0A%0A&repo=hmbown%2Fcodewhale&pr=2289&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui.rs%3A1756-1765%0A**Duplicated%20short-hash%20truncation%20logic**%0A%0A%60debug.rs%60%20already%20defines%20a%20%60short_hash%60%20helper%20%28%60hash.get%28..12%29.unwrap_or%28hash%29%60%29%2C%20but%20the%20same%2012-character%20truncation%20is%20inlined%20twice%20here%20in%20%60ui.rs%60.%20If%20the%20display%20width%20ever%20changes%2C%20it%20will%20need%20to%20be%20updated%20in%20two%20places%20instead%20of%20one.%20Consider%20either%20moving%20%60short_hash%60%20to%20a%20shared%20module%20or%20re-exporting%20it%20from%20%60debug.rs%60.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fcommands%2Fdebug.rs%3A277-305%0A**%60total_input%60%20and%20%60total_hit%60%2F%60total_miss%60%20can%20diverge%20silently**%0A%0A%60total_input%60%20accumulates%20for%20every%20turn%20in%20%60turn_cache_history%60%2C%20but%20%60total_hit%60%20and%20%60total_miss%60%20are%20only%20incremented%20when%20%60cache_hit_tokens%60%20is%20%60Some%60.%20For%20models%20that%20don't%20report%20cache%20telemetry%2C%20%60total_input%60%20will%20include%20those%20turns'%20tokens%20while%20%60total_hit%20%2B%20total_miss%60%20will%20not%2C%20making%20the%20displayed%20numbers%20appear%20inconsistent%20%28e.g.%20%225%20turns%2C%205000%20input%2C%201200%20hit%2C%20800%20miss%22%20where%20hit%2Bmiss%20%E2%89%A0%20input%29.%20Consider%20either%20restricting%20%60total_input%60%20to%20only%20the%20turns%20that%20have%20cache%20telemetry%2C%20or%20labelling%20the%20output%20to%20make%20clear%20that%20%60input%60%20is%20the%20session-wide%20total%20while%20hit%2Fmiss%20cover%20only%20telemetry-reporting%20turns.%0A%0A&pr=2289&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(cache): surface prefix hash drift"](https://github.com/hmbown/codewhale/commit/80a327ef2241bd42320012ad83f4bddb03d7cd80) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34162992)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->