### PR TITLE
feat(prompt): add core tool taxonomy block

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -2085,6 +2085,10 @@ mod tool_execution;
 mod tool_setup;
 mod turn_loop;
 
+pub(crate) fn default_active_native_tool_names() -> &'static [&'static str] {
+    tool_catalog::DEFAULT_ACTIVE_NATIVE_TOOLS
+}
+
 use self::approval::{ApprovalDecision, ApprovalResult, UserInputDecision};
 #[cfg(test)]
 use self::dispatch::should_parallelize_tool_batch;

--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -2,7 +2,7 @@
 //! System prompts for different modes.
 //!
 //! Prompts are assembled from composable layers loaded at compile time:
-//!   base.md → personality overlay → mode delta → approval policy
+//!   tool taxonomy → base.md → personality overlay → mode delta → approval policy
 //!
 //! This keeps each concern in its own file and makes prompt tuning
 //! a single-file operation.
@@ -490,10 +490,11 @@ fn approval_prompt_for_mode(mode: AppMode, approval_mode: ApprovalMode) -> &'sta
 }
 
 /// Compose the full system prompt in deterministic order:
-///   1. base.md        — core identity, toolbox, execution contract
-///   2. personality    — voice and tone overlay
-///   3. mode delta     — mode-specific permissions and workflow
-///   4. approval policy — tool-approval behavior
+///   1. tool taxonomy  — compact hints generated from the eager core tools
+///   2. base.md        — core identity, toolbox, execution contract
+///   3. personality    — voice and tone overlay
+///   4. mode delta     — mode-specific permissions and workflow
+///   5. approval policy — tool-approval behavior
 ///
 /// Each layer is separated by a blank line for readability in the
 /// rendered prompt (the model sees them as contiguous sections).
@@ -504,6 +505,30 @@ fn approval_prompt_for_mode(mode: AppMode, approval_mode: ApprovalMode) -> &'sta
 /// of a static placeholder.
 fn apply_model_template(prompt: &str, model_id: &str) -> String {
     prompt.replace("{model_id}", model_id)
+}
+
+const TOOL_TAXONOMY_DISCOVERY: &[&str] = &["grep_files", "file_search"];
+const TOOL_TAXONOMY_GIT: &[&str] = &["git_status", "git_diff"];
+const TOOL_TAXONOMY_VERIFICATION: &[&str] = &["run_tests"];
+
+fn render_core_tool_taxonomy_block() -> String {
+    let core_tools = crate::core::engine::default_active_native_tool_names();
+    format!(
+        "## Core Tool Taxonomy\n\nUse {} for discovery. Use {} for git inspection. Use {} for verification.",
+        render_core_tool_group(TOOL_TAXONOMY_DISCOVERY, core_tools),
+        render_core_tool_group(TOOL_TAXONOMY_GIT, core_tools),
+        render_core_tool_group(TOOL_TAXONOMY_VERIFICATION, core_tools)
+    )
+}
+
+fn render_core_tool_group(group: &[&str], core_tools: &[&str]) -> String {
+    group
+        .iter()
+        .copied()
+        .filter(|tool| core_tools.contains(tool))
+        .map(|tool| format!("`{tool}`"))
+        .collect::<Vec<_>>()
+        .join("/")
 }
 
 /// Authority recap block — appended at the end of the system prompt,
@@ -541,8 +566,11 @@ pub fn compose_prompt_with_approval_and_model(
     approval_mode: ApprovalMode,
     model_id: &str,
 ) -> String {
-    let parts: [&str; 4] = [
-        &apply_model_template(BASE_PROMPT.trim(), model_id),
+    let tool_taxonomy = render_core_tool_taxonomy_block();
+    let base_prompt = apply_model_template(BASE_PROMPT.trim(), model_id);
+    let parts: [&str; 5] = [
+        tool_taxonomy.as_str(),
+        base_prompt.as_str(),
         personality.prompt().trim(),
         mode_prompt(mode).trim(),
         approval_prompt_for_mode(mode, approval_mode).trim(),
@@ -994,6 +1022,36 @@ mod tests {
     }
 
     #[test]
+    fn composed_prompt_starts_with_core_tool_taxonomy() {
+        let prompt = compose_prompt_with_approval_and_model(
+            AppMode::Agent,
+            Personality::Calm,
+            ApprovalMode::Suggest,
+            "deepseek-v4-pro",
+        );
+
+        assert!(
+            prompt.starts_with("## Core Tool Taxonomy\n\nUse `grep_files`/`file_search` for discovery. Use `git_status`/`git_diff` for git inspection. Use `run_tests` for verification."),
+            "composed prompt should start with the compact generated tool taxonomy"
+        );
+    }
+
+    #[test]
+    fn core_tool_taxonomy_only_references_default_active_tools() {
+        let core_tools = crate::core::engine::default_active_native_tool_names();
+        for tool in TOOL_TAXONOMY_DISCOVERY
+            .iter()
+            .chain(TOOL_TAXONOMY_GIT)
+            .chain(TOOL_TAXONOMY_VERIFICATION)
+        {
+            assert!(
+                core_tools.contains(tool),
+                "tool taxonomy references {tool}, but it is not in the eager native-tool list"
+            );
+        }
+    }
+
+    #[test]
     fn authority_recap_appears_in_full_prompt() {
         let tmp = tempdir().expect("tempdir");
         let text = match system_prompt_for_mode_with_context_skills_session_and_approval(
@@ -1337,10 +1395,10 @@ mod tests {
             !text.contains("Reforço de Idioma"),
             "English locale must not get a pt-BR closer: {text:?}"
         );
-        assert!(
-            !contains_cjk(&text),
-            "English system prompt should avoid native-script priming tokens: {text:?}"
-        );
+        // Do not assert on arbitrary CJK in the full system prompt: project
+        // context may legitimately contain localized file names, README text,
+        // or user-authored instructions. The locale bookend markers above are
+        // the priming tokens this test is meant to guard.
     }
 
     #[test]

--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -511,24 +511,45 @@ const TOOL_TAXONOMY_DISCOVERY: &[&str] = &["grep_files", "file_search"];
 const TOOL_TAXONOMY_GIT: &[&str] = &["git_status", "git_diff"];
 const TOOL_TAXONOMY_VERIFICATION: &[&str] = &["run_tests"];
 
-fn render_core_tool_taxonomy_block() -> String {
-    let core_tools = crate::core::engine::default_active_native_tool_names();
-    format!(
-        "## Core Tool Taxonomy\n\nUse {} for discovery. Use {} for git inspection. Use {} for verification.",
-        render_core_tool_group(TOOL_TAXONOMY_DISCOVERY, core_tools),
-        render_core_tool_group(TOOL_TAXONOMY_GIT, core_tools),
-        render_core_tool_group(TOOL_TAXONOMY_VERIFICATION, core_tools)
-    )
+fn render_core_tool_taxonomy_block(mode: AppMode) -> String {
+    let core_tools = core_taxonomy_tools_for_mode(mode);
+    let mut sentences = Vec::new();
+
+    if let Some(discovery) = render_core_tool_group(TOOL_TAXONOMY_DISCOVERY, &core_tools) {
+        sentences.push(format!("Use {discovery} for discovery."));
+    }
+    if let Some(git) = render_core_tool_group(TOOL_TAXONOMY_GIT, &core_tools) {
+        sentences.push(format!("Use {git} for git inspection."));
+    }
+    if let Some(verification) = render_core_tool_group(TOOL_TAXONOMY_VERIFICATION, &core_tools) {
+        sentences.push(format!("Use {verification} for verification."));
+    }
+
+    debug_assert!(
+        !sentences.is_empty(),
+        "core tool taxonomy has no active tool groups"
+    );
+    format!("## Core Tool Taxonomy\n\n{}", sentences.join(" "))
 }
 
-fn render_core_tool_group(group: &[&str], core_tools: &[&str]) -> String {
-    group
+fn core_taxonomy_tools_for_mode(mode: AppMode) -> Vec<&'static str> {
+    let core_tools = crate::core::engine::default_active_native_tool_names();
+    core_tools
+        .iter()
+        .copied()
+        .filter(|tool| mode != AppMode::Plan || *tool != "run_tests")
+        .collect()
+}
+
+fn render_core_tool_group(group: &[&str], core_tools: &[&str]) -> Option<String> {
+    let rendered = group
         .iter()
         .copied()
         .filter(|tool| core_tools.contains(tool))
         .map(|tool| format!("`{tool}`"))
         .collect::<Vec<_>>()
-        .join("/")
+        .join("/");
+    (!rendered.is_empty()).then_some(rendered)
 }
 
 /// Authority recap block — appended at the end of the system prompt,
@@ -566,7 +587,7 @@ pub fn compose_prompt_with_approval_and_model(
     approval_mode: ApprovalMode,
     model_id: &str,
 ) -> String {
-    let tool_taxonomy = render_core_tool_taxonomy_block();
+    let tool_taxonomy = render_core_tool_taxonomy_block(mode);
     let base_prompt = apply_model_template(BASE_PROMPT.trim(), model_id);
     let parts: [&str; 5] = [
         tool_taxonomy.as_str(),
@@ -1029,10 +1050,38 @@ mod tests {
             ApprovalMode::Suggest,
             "deepseek-v4-pro",
         );
+        let expected_taxonomy = render_core_tool_taxonomy_block(AppMode::Agent);
 
         assert!(
-            prompt.starts_with("## Core Tool Taxonomy\n\nUse `grep_files`/`file_search` for discovery. Use `git_status`/`git_diff` for git inspection. Use `run_tests` for verification."),
+            prompt.starts_with(&expected_taxonomy),
             "composed prompt should start with the compact generated tool taxonomy"
+        );
+    }
+
+    #[test]
+    fn plan_prompt_taxonomy_omits_run_tests() {
+        let prompt = compose_prompt_with_approval_and_model(
+            AppMode::Plan,
+            Personality::Calm,
+            ApprovalMode::Never,
+            "deepseek-v4-pro",
+        );
+        let expected_taxonomy = render_core_tool_taxonomy_block(AppMode::Plan);
+
+        assert!(
+            prompt.starts_with(&expected_taxonomy),
+            "Plan prompt should start with its mode-specific tool taxonomy"
+        );
+        assert!(
+            expected_taxonomy.contains("for discovery")
+                && expected_taxonomy.contains("for git inspection"),
+            "Plan taxonomy should keep read-only discovery and git guidance"
+        );
+        assert!(
+            !expected_taxonomy.contains("run_tests")
+                && !expected_taxonomy.contains("for verification")
+                && !expected_taxonomy.contains("Use  "),
+            "Plan taxonomy must not advertise unavailable verification tools: {expected_taxonomy:?}"
         );
     }
 
@@ -1395,6 +1444,17 @@ mod tests {
             !text.contains("Reforço de Idioma"),
             "English locale must not get a pt-BR closer: {text:?}"
         );
+        assert!(
+            !contains_cjk(BASE_PROMPT),
+            "base prompt must not contain static CJK priming tokens"
+        );
+        for mode in [AppMode::Agent, AppMode::Plan, AppMode::Yolo] {
+            let taxonomy = render_core_tool_taxonomy_block(mode);
+            assert!(
+                !contains_cjk(&taxonomy),
+                "tool taxonomy must not contain static CJK priming tokens: {taxonomy:?}"
+            );
+        }
         // Do not assert on arbitrary CJK in the full system prompt: project
         // context may legitimately contain localized file names, README text,
         // or user-authored instructions. The locale bookend markers above are


### PR DESCRIPTION
## Summary
- prepend a compact core tool taxonomy block to the composed system prompt
- generate taxonomy tool names from the eager native-tool list instead of duplicating a separate prompt-only list
- add prompt tests covering the taxonomy text, eager-tool sync, and locale-bookend guard behavior

Refs #2084

## Verification
- cargo test -p codewhale-tui --bin codewhale-tui tool_taxonomy --all-features
- cargo test -p codewhale-tui --bin codewhale-tui compose_prompt --all-features
- cargo test -p codewhale-tui --bin codewhale-tui prompts::tests --all-features
- cargo fmt --all --check
- git diff --check
- cargo clippy -p codewhale-tui --all-targets --all-features

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prepends a compact `## Core Tool Taxonomy` block to the assembled system prompt, grouping core tools into discovery, git-inspection, and verification categories. Tool names are derived at runtime from `DEFAULT_ACTIVE_NATIVE_TOOLS` (via the new `default_active_native_tool_names` accessor in `engine.rs`) so the taxonomy cannot silently diverge from the eager-load list.

- `render_core_tool_taxonomy_block` correctly returns `Option<String>` per group, eliminating the malformed-sentence case; `run_tests` is filtered from Plan-mode prompts via `core_taxonomy_tools_for_mode`.
- Three new tests cover taxonomy prefix order, Plan/Agent mode differences, and the sync invariant; the CJK guard is now scoped to `BASE_PROMPT` and each per-mode taxonomy string.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the taxonomy block is generated entirely from the existing eagerly-loaded tool list, making the prompt change deterministic and self-consistent.

The logic is correct: render_core_tool_group returns Option<String> so empty groups produce no output, the Plan-mode filter is explicit and tested, and the sync test guarantees taxonomy constants stay in step with the engine tool list.

No files require special attention. crates/tui/src/prompts.rs is the main change and its new tests cover the key invariants.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/core/engine.rs | Adds a thin pub(crate) accessor that re-exports tool_catalog::DEFAULT_ACTIVE_NATIVE_TOOLS so prompts.rs can reference it without accessing a private sub-module directly. Change is minimal and correct. |
| crates/tui/src/prompts.rs | Prepends a mode-aware Core Tool Taxonomy block to the composed system prompt; correctly guards empty groups via Option<String>, filters run_tests from Plan mode, and adds three new tests covering taxonomy content, eager-tool sync, and the scoped CJK guard. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[compose_prompt_with_approval_and_model] --> B[render_core_tool_taxonomy_block mode]
    B --> C[core_taxonomy_tools_for_mode mode]
    C --> D[default_active_native_tool_names]
    C -->|Plan mode| E[filter out run_tests]
    B --> F[render_core_tool_group DISCOVERY]
    B --> G[render_core_tool_group GIT]
    B --> H[render_core_tool_group VERIFICATION]
    F -->|Some| I[Use ... for discovery.]
    G -->|Some| J[Use ... for git inspection.]
    H -->|Some if not Plan| K[Use ... for verification.]
    I & J & K --> L[Core Tool Taxonomy block]
    L --> M[parts array assembled]
    M --> N[Final system prompt]
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2F2084-tool-taxonomy-prompt%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F2084-tool-taxonomy-prompt%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fprompts.rs%3A1451%0AThe%20taxonomy%20CJK%20guard%20iterates%20a%20hand-written%20%60AppMode%60%20variant%20list.%20%60AppMode%60%20currently%20has%20exactly%20three%20variants%20so%20the%20coverage%20is%20complete%2C%20but%20if%20a%20new%20variant%20is%20added%20later%20the%20compiler%20will%20not%20flag%20this%20test%20as%20stale.%20Deriving%20the%20iteration%20via%20a%20%60strum%60%20iterator%20or%20an%20exhaustive%20%60match%60%20would%20tie%20the%20test%20lifetime%20to%20the%20enum%20definition.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20for%20mode%20in%20AppMode%3A%3AALL%20%7B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fprompts.rs%3A1451%0AThe%20taxonomy%20CJK%20guard%20iterates%20a%20hand-written%20%60AppMode%60%20variant%20list.%20%60AppMode%60%20currently%20has%20exactly%20three%20variants%20so%20the%20coverage%20is%20complete%2C%20but%20if%20a%20new%20variant%20is%20added%20later%20the%20compiler%20will%20not%20flag%20this%20test%20as%20stale.%20Deriving%20the%20iteration%20via%20a%20%60strum%60%20iterator%20or%20an%20exhaustive%20%60match%60%20would%20tie%20the%20test%20lifetime%20to%20the%20enum%20definition.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20for%20mode%20in%20AppMode%3A%3AALL%20%7B%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2292&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fprompts.rs%3A1451%0AThe%20taxonomy%20CJK%20guard%20iterates%20a%20hand-written%20%60AppMode%60%20variant%20list.%20%60AppMode%60%20currently%20has%20exactly%20three%20variants%20so%20the%20coverage%20is%20complete%2C%20but%20if%20a%20new%20variant%20is%20added%20later%20the%20compiler%20will%20not%20flag%20this%20test%20as%20stale.%20Deriving%20the%20iteration%20via%20a%20%60strum%60%20iterator%20or%20an%20exhaustive%20%60match%60%20would%20tie%20the%20test%20lifetime%20to%20the%20enum%20definition.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20for%20mode%20in%20AppMode%3A%3AALL%20%7B%0A%60%60%60%0A%0A&pr=2292&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix(prompt): make tool taxonomy mode-awa..."](https://github.com/hmbown/codewhale/commit/539f6b5eaec7e37a0ade1d919ef851512e4d7b77) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34172112)</sub>

<!-- /greptile_comment -->