### PR TITLE
feat(tui): add ExternalTool abstraction layer

### DIFF
--- a/crates/tui/src/commands/debug.rs
+++ b/crates/tui/src/commands/debug.rs
@@ -1584,7 +1584,10 @@ pub fn patch_undo(app: &mut App) -> CommandResult {
     }
 
     // Show diff stat so the user knows what changed.
-    let diff_stat = Git::command().expect("git not found")
+    let Some(mut git_cmd) = Git::command() else {
+        return CommandResult::error("git not found");
+    };
+    let diff_stat = git_cmd
         .args(["diff", "--stat"])
         .current_dir(&workspace)
         .output()
@@ -1663,11 +1666,17 @@ pub fn edit(app: &mut App) -> CommandResult {
 pub fn diff(app: &mut App) -> CommandResult {
     let workspace = app.workspace.clone();
 
-    let name_only_output = Git::command().expect("git not found")
+    let Some(mut git_cmd) = Git::command() else {
+        return CommandResult::error("git not found");
+    };
+    let name_only_output = git_cmd
         .args(["diff", "--name-only"])
         .current_dir(&workspace)
         .output();
-    let stat_output = Git::command().expect("git not found")
+    let Some(mut git_cmd) = Git::command() else {
+        return CommandResult::error("git not found");
+    };
+    let stat_output = git_cmd
         .args(["diff", "--stat"])
         .current_dir(&workspace)
         .output();

--- a/crates/tui/src/commands/debug.rs
+++ b/crates/tui/src/commands/debug.rs
@@ -10,6 +10,7 @@ use crate::compaction::estimate_input_tokens_conservative;
 use crate::localization::{Locale, MessageId, tr};
 use crate::models::{ContentBlock, MessageRequest, SystemPrompt, context_window_for_model};
 use crate::tui::app::{App, AppAction, TurnCacheRecord};
+use crate::dependencies::{ExternalTool, Git};
 use crate::tui::history::HistoryCell;
 
 fn token_count(value: Option<u32>, locale: Locale) -> String {
@@ -1583,7 +1584,7 @@ pub fn patch_undo(app: &mut App) -> CommandResult {
     }
 
     // Show diff stat so the user knows what changed.
-    let diff_stat = std::process::Command::new("git")
+    let diff_stat = Git::command().expect("git not found")
         .args(["diff", "--stat"])
         .current_dir(&workspace)
         .output()
@@ -1662,11 +1663,11 @@ pub fn edit(app: &mut App) -> CommandResult {
 pub fn diff(app: &mut App) -> CommandResult {
     let workspace = app.workspace.clone();
 
-    let name_only_output = std::process::Command::new("git")
+    let name_only_output = Git::command().expect("git not found")
         .args(["diff", "--name-only"])
         .current_dir(&workspace)
         .output();
-    let stat_output = std::process::Command::new("git")
+    let stat_output = Git::command().expect("git not found")
         .args(["diff", "--stat"])
         .current_dir(&workspace)
         .output();

--- a/crates/tui/src/commands/share.rs
+++ b/crates/tui/src/commands/share.rs
@@ -12,6 +12,7 @@ use std::io::Write;
 use std::path::Path;
 
 use super::CommandResult;
+use crate::dependencies::ExternalTool;
 use crate::tui::app::{App, AppAction};
 
 /// Share the current session as a web URL.
@@ -155,19 +156,24 @@ fn write_temp_html(html: &str) -> Result<tempfile::NamedTempFile, String> {
 
 /// Upload a file as a GitHub Gist using the `gh` CLI.
 async fn upload_gist(path: &Path) -> Result<String, String> {
-    let output = tokio::process::Command::new("gh")
-        .args([
+    let path_owned = path.to_path_buf();
+    let output = tokio::task::spawn_blocking(move || {
+        let mut cmd = crate::dependencies::Gh::command()
+            .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "gh not found"))?;
+        cmd.args([
             "gist",
             "create",
             "--public",
-            &path.to_string_lossy(),
+            &path_owned.to_string_lossy().to_string(),
             "--filename",
             "session-export.html",
             "--desc",
             "DeepSeek TUI Session Export",
         ])
         .output()
-        .await
+    })
+    .await
+    .map_err(|join_err| format!("gh gist create panicked: {join_err}"))?
         .map_err(|e| format!("Failed to run `gh gist create`: {e}"))?;
 
     if !output.status.success() {

--- a/crates/tui/src/commands/share.rs
+++ b/crates/tui/src/commands/share.rs
@@ -173,7 +173,7 @@ async fn upload_gist(path: &Path) -> Result<String, String> {
         .output()
     })
     .await
-    .map_err(|join_err| format!("gh gist create panicked: {join_err}"))?
+    .map_err(|join_err| format!("gh gist create failed: task panicked ({join_err})"))?
         .map_err(|e| format!("Failed to run `gh gist create`: {e}"))?;
 
     if !output.status.success() {

--- a/crates/tui/src/config_ui.rs
+++ b/crates/tui/src/config_ui.rs
@@ -600,10 +600,6 @@ pub fn parse_document(value: Value) -> Result<ConfigUiDocument> {
     serde_json::from_value(value).context("failed to decode config ui document")
 }
 
-pub fn open_browser(url: &str) -> Result<()> {
-    crate::utils::open_url(url)
-}
-
 fn validate_document(doc: &ConfigUiDocument) -> Result<()> {
     if !doc.runtime.model.trim().eq_ignore_ascii_case("auto")
         && normalize_model_name(&doc.runtime.model).is_none()

--- a/crates/tui/src/config_ui.rs
+++ b/crates/tui/src/config_ui.rs
@@ -600,38 +600,8 @@ pub fn parse_document(value: Value) -> Result<ConfigUiDocument> {
     serde_json::from_value(value).context("failed to decode config ui document")
 }
 
-#[cfg(feature = "web")]
 pub fn open_browser(url: &str) -> Result<()> {
-    #[cfg(target_os = "macos")]
-    let mut command = {
-        let mut command = Command::new("open");
-        command.arg(url);
-        command
-    };
-    #[cfg(target_os = "linux")]
-    let mut command = {
-        let mut command = Command::new("xdg-open");
-        command.arg(url);
-        command
-    };
-    #[cfg(target_os = "windows")]
-    let mut command = {
-        let mut command = Command::new("cmd");
-        command.args(["/C", "start", "", url]);
-        command
-    };
-    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
-    return Err(anyhow::anyhow!(
-        "browser opening is unsupported on this platform"
-    ));
-
-    let status = command
-        .status()
-        .context("failed to launch browser command")?;
-    if !status.success() {
-        bail!("browser command exited with status {status}");
-    }
-    Ok(())
+    crate::utils::open_url(url)
 }
 
 fn validate_document(doc: &ConfigUiDocument) -> Result<()> {

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -1971,7 +1971,8 @@ use self::streaming::{
     should_transparently_retry_stream, stream_chunk_timeout_secs,
 };
 use self::tool_catalog::{
-    CODE_EXECUTION_TOOL_NAME, JS_EXECUTION_TOOL_NAME, MULTI_TOOL_PARALLEL_NAME,
+    CODE_EXECUTION_TOOL_NAME, DOTNET_EXECUTION_TOOL_NAME, JS_EXECUTION_TOOL_NAME,
+    MULTI_TOOL_PARALLEL_NAME,
     REQUEST_USER_INPUT_NAME, active_tools_for_step, build_model_tool_catalog,
     ensure_advanced_tooling, execute_code_execution_tool, execute_tool_search,
     initial_active_tools, is_tool_search_tool, maybe_hydrate_requested_deferred_tool,
@@ -1984,6 +1985,7 @@ use self::tool_catalog::{
 };
 use self::tool_execution::emit_tool_audit;
 use self::tool_setup::sandbox_policy_for_mode;
+use crate::tools::dotnet_execution::execute_dotnet_execution_tool;
 use crate::tools::js_execution::execute_js_execution_tool;
 
 #[cfg(test)]

--- a/crates/tui/src/core/engine/tool_catalog.rs
+++ b/crates/tui/src/core/engine/tool_catalog.rs
@@ -15,6 +15,8 @@ use crate::models::Tool;
 use crate::tools::spec::{ToolError, ToolResult, required_str};
 use crate::tui::app::AppMode;
 
+use crate::dependencies::ExternalTool;
+
 pub(super) const MULTI_TOOL_PARALLEL_NAME: &str = "multi_tool_use.parallel";
 pub(super) const REQUEST_USER_INPUT_NAME: &str = "request_user_input";
 pub(super) const CODE_EXECUTION_TOOL_NAME: &str = "code_execution";
@@ -680,20 +682,9 @@ pub(super) async fn execute_code_execution_tool(
     // Resolve the locally-installed Python interpreter we cached at
     // catalog-build time. If it's absent now (somehow registered but
     // disappeared between startup and this call — concurrent uninstall,
-    // PATH change, etc.) we fail fast with a clear message rather than
-    // dropping into `tokio::process::Command::new("python3")` and
-    // surfacing the cryptic "program not found" the contributor
-    // originally hit on Windows.
-    let interpreter = crate::dependencies::resolve_python_interpreter().ok_or_else(|| {
-        ToolError::execution_failed(format!(
-            "code_execution: no Python interpreter found on PATH (tried {:?}). \
-             Install Python 3 and ensure one of these is on PATH, then restart \
-             deepseek-tui.",
-            crate::dependencies::PYTHON_CANDIDATES,
-        ))
-    })?;
-    let (program, args) = crate::dependencies::split_interpreter_spec(&interpreter);
-
+    // PATH change, etc.) the ExternalTool::tokio_command() will return
+    // None and we fail fast with a clear message.
+    //
     // Write the code to a temp file and execute it as a script rather
     // than passing it via `-c "<code>"`. Reasons:
     //   * `-c` has length limits (argv) on Windows.
@@ -710,12 +701,11 @@ pub(super) async fn execute_code_execution_tool(
         .await
         .map_err(|e| ToolError::execution_failed(format!("tempfile write failed: {e}")))?;
 
-    let mut cmd = tokio::process::Command::new(&program);
-    for arg in &args {
-        cmd.arg(arg);
-    }
-    cmd.arg(&script_path);
-    cmd.current_dir(workspace);
+    let mut cmd = crate::dependencies::Python::tokio_command().ok_or_else(|| {
+        ToolError::execution_failed("code_execution: Python interpreter became unavailable".to_string())
+    })?;
+    cmd.arg(&script_path)
+        .current_dir(workspace);
 
     let output = tokio::time::timeout(Duration::from_secs(120), cmd.output())
         .await

--- a/crates/tui/src/core/engine/tool_catalog.rs
+++ b/crates/tui/src/core/engine/tool_catalog.rs
@@ -21,6 +21,7 @@ pub(super) const MULTI_TOOL_PARALLEL_NAME: &str = "multi_tool_use.parallel";
 pub(super) const REQUEST_USER_INPUT_NAME: &str = "request_user_input";
 pub(super) const CODE_EXECUTION_TOOL_NAME: &str = "code_execution";
 const CODE_EXECUTION_TOOL_TYPE: &str = "code_execution_20250825";
+pub(super) use crate::tools::dotnet_execution::DOTNET_EXECUTION_TOOL_NAME;
 pub(super) use crate::tools::js_execution::JS_EXECUTION_TOOL_NAME;
 const TOOL_SEARCH_REGEX_NAME: &str = "tool_search_tool_regex";
 const TOOL_SEARCH_REGEX_TYPE: &str = "tool_search_tool_regex_20251119";
@@ -167,6 +168,14 @@ pub(super) fn ensure_advanced_tooling(catalog: &mut Vec<Tool>, mode: AppMode) {
         && crate::dependencies::resolve_node().is_some()
     {
         catalog.push(crate::tools::js_execution::js_execution_tool_definition());
+    }
+
+    // dotnet_execution: gate on .NET SDK being present locally.
+    if mode != AppMode::Plan
+        && !catalog.iter().any(|t| t.name == DOTNET_EXECUTION_TOOL_NAME)
+        && crate::dependencies::DotNet::available()
+    {
+        catalog.push(crate::tools::dotnet_execution::dotnet_execution_tool_definition());
     }
 
     if !catalog.iter().any(|t| t.name == TOOL_SEARCH_REGEX_NAME) {

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -1121,6 +1121,7 @@ impl Engine {
                             | "exec_wait"
                             | "exec_interact"
                             | CODE_EXECUTION_TOOL_NAME
+                            | DOTNET_EXECUTION_TOOL_NAME
                             | JS_EXECUTION_TOOL_NAME
                     )
                 {
@@ -1193,6 +1194,13 @@ impl Engine {
                     approval_required = true;
                     approval_description =
                         "Run model-provided JavaScript code in local Node.js execution sandbox"
+                            .to_string();
+                    supports_parallel = false;
+                    read_only = false;
+                } else if tool_name == DOTNET_EXECUTION_TOOL_NAME {
+                    approval_required = true;
+                    approval_description =
+                        "Run model-provided C# code in local .NET SDK execution sandbox"
                             .to_string();
                     supports_parallel = false;
                     read_only = false;
@@ -1498,6 +1506,32 @@ impl Engine {
                             let started_at = Instant::now();
                             let result =
                                 execute_js_execution_tool(&tool_input, &self.session.workspace)
+                                    .await;
+
+                            let _ = self
+                                .tx_event
+                                .send(Event::ToolCallComplete {
+                                    id: tool_id.clone(),
+                                    name: tool_name.clone(),
+                                    result: result.clone(),
+                                })
+                                .await;
+
+                            outcomes[plan.index] = Some(ToolExecOutcome {
+                                index: plan.index,
+                                id: tool_id,
+                                name: tool_name,
+                                input: tool_input,
+                                started_at,
+                                result,
+                            });
+                            continue;
+                        }
+
+                        if tool_name == DOTNET_EXECUTION_TOOL_NAME {
+                            let started_at = Instant::now();
+                            let result =
+                                execute_dotnet_execution_tool(&tool_input, &self.session.workspace)
                                     .await;
 
                             let _ = self

--- a/crates/tui/src/dependencies.rs
+++ b/crates/tui/src/dependencies.rs
@@ -198,6 +198,229 @@ pub fn resolve_node() -> Option<String> {
         .clone()
 }
 
+// ---------------------------------------------------------------------------
+// ExternalTool trait — unified subprocess interface
+// ---------------------------------------------------------------------------
+
+/// A tool that DeepSeek-TUI shells out to. Instead of scattering
+/// `Command::new("git")` / `Command::new("gh")` across the codebase,
+/// each external dependency implements this trait once in this module.
+/// Callers ask the tool for a pre-populated [`Command`] and chain their
+/// own args, working directory, and spawn method.
+///
+/// # Example
+///
+/// ```ignore
+/// let output = Git::command()
+///     .expect("git not found")
+///     .args(["diff", "--stat"])
+///     .current_dir(&workspace)
+///     .output()?;
+/// ```
+pub trait ExternalTool {
+    /// Candidate binary names, tried in order until one responds to
+    /// `--version`.  For single-binary tools (git, gh, node) this is a
+    /// one-element slice.
+    fn candidates() -> &'static [&'static str];
+
+    /// Resolve the best candidate once per process (cached). Returns
+    /// the spec string (e.g. `"python3"` or `"py -3"`).
+    fn resolve() -> Option<String>;
+
+    /// Quick availability check — true when the tool was found on PATH.
+    fn available() -> bool {
+        Self::resolve().is_some()
+    }
+
+    /// Build a `std::process::Command` pre-populated with the resolved
+    /// binary (and any fixed arguments from a multi-word candidate like
+    /// `"py -3"`). Returns `None` when the tool isn't installed.
+    ///
+    /// Callers should chain `.args(...)`, `.current_dir(...)`, and then
+    /// call `.output()`, `.status()`, or `.spawn()`.
+    fn command() -> Option<Command> {
+        let spec = Self::resolve()?;
+        let (program, fixed_args) = split_interpreter_spec(&spec);
+        let mut cmd = Command::new(&program);
+        for arg in &fixed_args {
+            cmd.arg(arg);
+        }
+        Some(cmd)
+    }
+
+    /// Convenience: run the tool with arguments in a working directory
+    /// and return the captured output.
+    fn output(args: &[&str], cwd: &std::path::Path) -> std::io::Result<std::process::Output> {
+        let mut cmd = Self::command().ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!("{} not found on PATH", std::any::type_name::<Self>()),
+            )
+        })?;
+        cmd.args(args).current_dir(cwd).output()
+    }
+
+    /// Convenience: run the tool with arguments and return only the
+    /// exit status (discards stdout/stderr).
+    fn status(args: &[&str], cwd: &std::path::Path) -> std::io::Result<std::process::ExitStatus> {
+        let mut cmd = Self::command().ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!("{} not found on PATH", std::any::type_name::<Self>()),
+            )
+        })?;
+        cmd.args(args).current_dir(cwd).status()
+    }
+
+    /// Build a `tokio::process::Command` pre-populated with the resolved
+    /// binary (and any fixed arguments from a multi-word candidate like
+    /// `"py -3"`). Returns `None` when the tool isn't installed.
+    ///
+    /// Async callers (`code_execution`, `js_execution`) use this instead
+    /// of [`ExternalTool::command`] so they can `.await` the child.
+    fn tokio_command() -> Option<tokio::process::Command> {
+        let spec = Self::resolve()?;
+        let (program, fixed_args) = split_interpreter_spec(&spec);
+        let mut cmd = tokio::process::Command::new(&program);
+        for arg in &fixed_args {
+            cmd.arg(arg);
+        }
+        Some(cmd)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Concrete tool implementations
+// ---------------------------------------------------------------------------
+
+/// Git version control.
+pub struct Git;
+
+impl ExternalTool for Git {
+    fn candidates() -> &'static [&'static str] {
+        &["git"]
+    }
+
+    fn resolve() -> Option<String> {
+        static CACHE: OnceLock<Option<String>> = OnceLock::new();
+        CACHE
+            .get_or_init(|| {
+                for candidate in Self::candidates() {
+                    if probe_executable(candidate) {
+                        tracing::info!(target: "tool_dependencies", "Resolved git binary");
+                        return Some((*candidate).to_string());
+                    }
+                }
+                None
+            })
+            .clone()
+    }
+}
+
+/// GitHub CLI.
+pub struct Gh;
+
+impl ExternalTool for Gh {
+    fn candidates() -> &'static [&'static str] {
+        &["gh"]
+    }
+
+    fn resolve() -> Option<String> {
+        static CACHE: OnceLock<Option<String>> = OnceLock::new();
+        CACHE
+            .get_or_init(|| {
+                if probe_executable("gh") {
+                    tracing::info!(target: "tool_dependencies", "Resolved gh binary");
+                    Some("gh".to_string())
+                } else {
+                    None
+                }
+            })
+            .clone()
+    }
+}
+
+/// Rust compiler — used for version reporting in diagnostics.
+pub struct RustC;
+
+impl ExternalTool for RustC {
+    fn candidates() -> &'static [&'static str] {
+        &["rustc"]
+    }
+
+    fn resolve() -> Option<String> {
+        static CACHE: OnceLock<Option<String>> = OnceLock::new();
+        CACHE
+            .get_or_init(|| {
+                if probe_executable("rustc") {
+                    tracing::info!(target: "tool_dependencies", "Resolved rustc binary");
+                    Some("rustc".to_string())
+                } else {
+                    None
+                }
+            })
+            .clone()
+    }
+}
+
+/// Rust build tool — used by the `run_tests` tool.
+pub struct Cargo;
+
+impl ExternalTool for Cargo {
+    fn candidates() -> &'static [&'static str] {
+        &["cargo"]
+    }
+
+    fn resolve() -> Option<String> {
+        static CACHE: OnceLock<Option<String>> = OnceLock::new();
+        CACHE
+            .get_or_init(|| {
+                if probe_executable("cargo") {
+                    tracing::info!(target: "tool_dependencies", "Resolved cargo binary");
+                    Some("cargo".to_string())
+                } else {
+                    None
+                }
+            })
+            .clone()
+    }
+}
+
+/// Python interpreter — used by `code_execution` tool and RLM REPL.
+/// Delegates to the existing [`resolve_python_interpreter`] so the
+/// multi-candidate ladder (`python3` → `python` → `py -3`) is
+/// shared with legacy callers until they migrate to the trait.
+pub struct Python;
+
+impl ExternalTool for Python {
+    fn candidates() -> &'static [&'static str] {
+        PYTHON_CANDIDATES
+    }
+
+    fn resolve() -> Option<String> {
+        resolve_python_interpreter()
+    }
+}
+
+/// Node.js runtime — used by the `js_execution` tool.
+/// The binary name `node` is the same on every platform we support,
+/// so this is a single probe rather than a candidate ladder.
+pub struct Node;
+
+impl ExternalTool for Node {
+    fn candidates() -> &'static [&'static str] {
+        &["node"]
+    }
+
+    fn resolve() -> Option<String> {
+        resolve_node()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Legacy interpreter helpers (kept for existing callers until migrated)
+// ---------------------------------------------------------------------------
+
 /// Split an interpreter spec like `"py -3"` into the program name
 /// and any initial arguments. Returns `("py", vec!["-3"])` for the
 /// example; returns `("python3", vec![])` for a bare name.
@@ -287,5 +510,218 @@ mod tests {
                 "resolved {name:?} is not in PYTHON_CANDIDATES {PYTHON_CANDIDATES:?}"
             );
         }
+    }
+
+    // ===================================================================
+    // ExternalTool trait tests
+    // ===================================================================
+
+    #[test]
+    fn python_candidates_matches_const() {
+        assert_eq!(Python::candidates(), PYTHON_CANDIDATES);
+    }
+
+    #[test]
+    fn node_candidates_is_node_only() {
+        assert_eq!(Node::candidates(), &["node"]);
+    }
+
+    #[test]
+    fn git_candidates_is_git_only() {
+        assert_eq!(Git::candidates(), &["git"]);
+    }
+
+    #[test]
+    fn gh_candidates_is_gh_only() {
+        assert_eq!(Gh::candidates(), &["gh"]);
+    }
+
+    #[test]
+    fn rustc_candidates_is_rustc_only() {
+        assert_eq!(RustC::candidates(), &["rustc"]);
+    }
+
+    #[test]
+    fn cargo_candidates_is_cargo_only() {
+        assert_eq!(Cargo::candidates(), &["cargo"]);
+    }
+
+    #[test]
+    fn git_resolve_is_cached() {
+        let first = Git::resolve();
+        let second = Git::resolve();
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn gh_resolve_is_cached() {
+        let first = Gh::resolve();
+        let second = Gh::resolve();
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn python_trait_resolve_is_cached() {
+        let first = Python::resolve();
+        let second = Python::resolve();
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn node_resolve_is_cached() {
+        let first = Node::resolve();
+        let second = Node::resolve();
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn rustc_resolve_is_cached() {
+        let first = RustC::resolve();
+        let second = RustC::resolve();
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn cargo_resolve_is_cached() {
+        let first = Cargo::resolve();
+        let second = Cargo::resolve();
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn git_available_matches_resolve() {
+        assert_eq!(Git::available(), Git::resolve().is_some());
+    }
+
+    #[test]
+    fn python_available_matches_resolve() {
+        assert_eq!(Python::available(), Python::resolve().is_some());
+    }
+
+    #[test]
+    fn node_available_matches_resolve() {
+        assert_eq!(Node::available(), Node::resolve().is_some());
+    }
+
+    #[test]
+    fn rustc_available_matches_resolve() {
+        assert_eq!(RustC::available(), RustC::resolve().is_some());
+    }
+
+    #[test]
+    fn cargo_available_matches_resolve() {
+        assert_eq!(Cargo::available(), Cargo::resolve().is_some());
+    }
+
+    #[test]
+    fn git_command_returns_some_when_available() {
+        if Git::available() {
+            assert!(Git::command().is_some());
+        }
+    }
+
+    #[test]
+    fn python_command_returns_some_when_available() {
+        if Python::available() {
+            assert!(Python::command().is_some());
+        }
+    }
+
+    #[test]
+    fn python_tokio_command_returns_some_when_available() {
+        if Python::available() {
+            assert!(Python::tokio_command().is_some());
+        }
+    }
+
+    #[test]
+    fn node_tokio_command_returns_some_when_available() {
+        if Node::available() {
+            assert!(Node::tokio_command().is_some());
+        }
+    }
+
+    #[test]
+    fn git_output_version_succeeds() {
+        // Only run when git is actually installed.
+        if !Git::available() {
+            return;
+        }
+        let tmp = std::env::temp_dir();
+        let out = Git::output(&["--version"], &tmp);
+        assert!(
+            out.is_ok(),
+            "git --version must succeed when git is available"
+        );
+        let out = out.unwrap();
+        assert!(
+            out.status.success(),
+            "git --version must exit 0"
+        );
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            stdout.contains("git version"),
+            "git --version stdout must contain 'git version', got: {}",
+            stdout.trim()
+        );
+    }
+
+    #[test]
+    fn python_output_version_succeeds() {
+        if !Python::available() {
+            return;
+        }
+        let tmp = std::env::temp_dir();
+        let out = Python::output(&["--version"], &tmp);
+        assert!(out.is_ok(), "python --version must spawn");
+        let out = out.unwrap();
+        // Python --version writes to stdout on 3.x, so just check
+        // that it succeeded (exit 0).
+        assert!(
+            out.status.success(),
+            "python --version must exit 0"
+        );
+    }
+
+    #[test]
+    fn node_output_version_succeeds() {
+        if !Node::available() {
+            return;
+        }
+        let tmp = std::env::temp_dir();
+        let out = Node::output(&["--version"], &tmp);
+        assert!(out.is_ok(), "node --version must spawn");
+        let out = out.unwrap();
+        assert!(out.status.success(), "node --version must exit 0");
+    }
+
+    #[test]
+    fn cargo_output_version_succeeds() {
+        if !Cargo::available() {
+            return;
+        }
+        let tmp = std::env::temp_dir();
+        let out = Cargo::output(&["--version"], &tmp);
+        assert!(out.is_ok(), "cargo --version must spawn");
+        let out = out.unwrap();
+        assert!(out.status.success(), "cargo --version must exit 0");
+    }
+
+    #[test]
+    fn external_tool_output_respects_cwd() {
+        // Verify that `output()` runs in the requested directory.
+        if !Git::available() {
+            return;
+        }
+        let tmp = std::env::temp_dir();
+        let out = Git::output(&["rev-parse", "--show-toplevel"], &tmp);
+        assert!(out.is_ok(), "git rev-parse must spawn");
+        let out = out.unwrap();
+        // rev-parse --show-toplevel in a non-git dir should fail
+        // because temp_dir is not a git repo. That's expected.
+        // The key assertion: the command executed without IO errors.
+        // We don't assert success because temp_dir might or might not
+        // be inside a git worktree.
+        let _ = out; // just checking it didn't panic/IO-error
     }
 }

--- a/crates/tui/src/dependencies.rs
+++ b/crates/tui/src/dependencies.rs
@@ -417,6 +417,31 @@ impl ExternalTool for Node {
     }
 }
 
+/// .NET SDK — used by the `dotnet_execution` tool.
+/// Starting with .NET 6, `dotnet run file.cs` can run a single C# file
+/// without a project. The binary is `dotnet` on all platforms.
+pub struct DotNet;
+
+impl ExternalTool for DotNet {
+    fn candidates() -> &'static [&'static str] {
+        &["dotnet"]
+    }
+
+    fn resolve() -> Option<String> {
+        static CACHE: OnceLock<Option<String>> = OnceLock::new();
+        CACHE
+            .get_or_init(|| {
+                if probe_executable("dotnet") {
+                    tracing::info!(target: "tool_dependencies", "Resolved dotnet binary");
+                    Some("dotnet".to_string())
+                } else {
+                    None
+                }
+            })
+            .clone()
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Legacy interpreter helpers (kept for existing callers until migrated)
 // ---------------------------------------------------------------------------

--- a/crates/tui/src/dependencies.rs
+++ b/crates/tui/src/dependencies.rs
@@ -200,7 +200,7 @@ pub fn resolve_node() -> Option<String> {
 
 /// Extract the simple type name from `std::any::type_name` output.
 /// e.g. turns `deepseek_tui::dependencies::Git` into `Git`.
-fn simple_type_name<T>() -> &'static str {
+fn simple_type_name<T: ?Sized>() -> &'static str {
     let full = std::any::type_name::<T>();
     full.rsplit("::")
         .next()

--- a/crates/tui/src/dependencies.rs
+++ b/crates/tui/src/dependencies.rs
@@ -198,6 +198,15 @@ pub fn resolve_node() -> Option<String> {
         .clone()
 }
 
+/// Extract the simple type name from `std::any::type_name` output.
+/// e.g. turns `deepseek_tui::dependencies::Git` into `Git`.
+fn simple_type_name<T>() -> &'static str {
+    let full = std::any::type_name::<T>();
+    full.rsplit("::")
+        .next()
+        .unwrap_or(full)
+}
+
 // ---------------------------------------------------------------------------
 // ExternalTool trait — unified subprocess interface
 // ---------------------------------------------------------------------------
@@ -254,7 +263,7 @@ pub trait ExternalTool {
         let mut cmd = Self::command().ok_or_else(|| {
             std::io::Error::new(
                 std::io::ErrorKind::NotFound,
-                format!("{} not found on PATH", std::any::type_name::<Self>()),
+                format!("{} not found on PATH", simple_type_name::<Self>()),
             )
         })?;
         cmd.args(args).current_dir(cwd).output()
@@ -266,7 +275,7 @@ pub trait ExternalTool {
         let mut cmd = Self::command().ok_or_else(|| {
             std::io::Error::new(
                 std::io::ErrorKind::NotFound,
-                format!("{} not found on PATH", std::any::type_name::<Self>()),
+                format!("{} not found on PATH", simple_type_name::<Self>()),
             )
         })?;
         cmd.args(args).current_dir(cwd).status()

--- a/crates/tui/src/eval.rs
+++ b/crates/tui/src/eval.rs
@@ -11,7 +11,6 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::time::{Duration, Instant};
 use tempfile::TempDir;
 
@@ -704,32 +703,7 @@ fn apply_patch(root: &Path, patch: &str) -> Result<()> {
 }
 
 fn exec_shell(root: &Path, command: &str) -> Result<String> {
-    #[cfg(windows)]
-    let output = Command::new("cmd")
-        .args(["/C", command])
-        .current_dir(root)
-        .output()
-        .with_context(|| format!("failed to execute shell command: {command}"))?;
-
-    #[cfg(not(windows))]
-    let output = Command::new("sh")
-        .arg("-c")
-        .arg(command)
-        .current_dir(root)
-        .output()
-        .with_context(|| format!("failed to execute shell command: {command}"))?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(anyhow!(
-            "shell command failed (status={}): {}",
-            output.status,
-            stderr.trim()
-        ));
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-    Ok(stdout.trim().to_string())
+    crate::shell_dispatcher::global_dispatcher().run_foreground(command, root)
 }
 
 fn truncate_output(value: &str, max_chars: usize) -> String {

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -12,6 +12,8 @@ use dotenvy::dotenv;
 use tempfile::NamedTempFile;
 use wait_timeout::ChildExt;
 
+use crate::dependencies::ExternalTool;
+
 mod acp_server;
 mod artifacts;
 mod audit;
@@ -61,6 +63,7 @@ mod runtime_threads;
 mod sandbox;
 mod schema_migration;
 mod seam_manager;
+mod shell_dispatcher;
 mod session_manager;
 mod settings;
 mod skill_state;
@@ -2913,14 +2916,16 @@ async fn test_api_connectivity(config: &Config) -> Result<()> {
 }
 
 fn rustc_version() -> String {
-    // Try to get rustc version, fall back to "unknown"
-    std::process::Command::new("rustc")
-        .arg("--version")
-        .output()
-        .ok()
-        .and_then(|o| String::from_utf8(o.stdout).ok())
-        .map_or_else(|| "unknown".to_string(), |s| s.trim().to_string())
+    let Some(mut cmd) = crate::dependencies::RustC::command() else {
+        return "unknown".to_string();
+    };
+    let Ok(output) = cmd.arg("--version").output() else {
+        return "unknown".to_string();
+    };
+    String::from_utf8(output.stdout).map(|s| s.trim().to_string()).unwrap_or_else(|_| "unknown".to_string())
 }
+
+
 
 /// List saved sessions
 fn list_sessions(limit: usize, search: Option<String>) -> Result<()> {
@@ -3330,7 +3335,7 @@ struct GhPullRequest {
 }
 
 fn run_gh_pr_view(number: u32, repo: Option<&str>) -> Result<GhPullRequest> {
-    let mut cmd = Command::new("gh");
+    let mut cmd = crate::dependencies::Gh::command().expect("gh not found");
     cmd.arg("pr").arg("view").arg(number.to_string());
     if let Some(r) = repo {
         cmd.arg("--repo").arg(r);
@@ -3364,7 +3369,7 @@ fn run_gh_pr_view(number: u32, repo: Option<&str>) -> Result<GhPullRequest> {
 }
 
 fn run_gh_pr_diff(number: u32, repo: Option<&str>) -> Result<String> {
-    let mut cmd = Command::new("gh");
+    let mut cmd = crate::dependencies::Gh::command().expect("gh not found");
     cmd.arg("pr").arg("diff").arg(number.to_string());
     if let Some(r) = repo {
         cmd.arg("--repo").arg(r);
@@ -3380,7 +3385,7 @@ fn run_gh_pr_diff(number: u32, repo: Option<&str>) -> Result<String> {
 }
 
 fn run_gh_pr_checkout(number: u32, repo: Option<&str>) -> Result<()> {
-    let mut cmd = Command::new("gh");
+    let mut cmd = crate::dependencies::Gh::command().expect("gh not found");
     cmd.arg("pr").arg("checkout").arg(number.to_string());
     if let Some(r) = repo {
         cmd.arg("--repo").arg(r);
@@ -3454,7 +3459,7 @@ fn format_pr_prompt(number: u32, view: &GhPullRequest, diff: &str) -> String {
 }
 
 fn collect_diff(args: &ReviewArgs) -> Result<String> {
-    let mut cmd = Command::new("git");
+    let mut cmd = crate::dependencies::Git::command().expect("git not found");
     cmd.arg("diff");
     if args.staged {
         cmd.arg("--cached");
@@ -3495,7 +3500,7 @@ fn run_apply(args: ApplyArgs) -> Result<()> {
     tmp.write_all(patch.as_bytes())?;
     let tmp_path = tmp.path().to_path_buf();
 
-    let output = Command::new("git")
+    let output = crate::dependencies::Git::command().expect("git not found")
         .arg("apply")
         .arg("--whitespace=nowarn")
         .arg(&tmp_path)

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -3335,7 +3335,7 @@ struct GhPullRequest {
 }
 
 fn run_gh_pr_view(number: u32, repo: Option<&str>) -> Result<GhPullRequest> {
-    let mut cmd = crate::dependencies::Gh::command().expect("gh not found");
+    let mut cmd = crate::dependencies::Gh::command().ok_or_else(|| anyhow::anyhow!("gh not found"))?;
     cmd.arg("pr").arg("view").arg(number.to_string());
     if let Some(r) = repo {
         cmd.arg("--repo").arg(r);
@@ -3369,7 +3369,7 @@ fn run_gh_pr_view(number: u32, repo: Option<&str>) -> Result<GhPullRequest> {
 }
 
 fn run_gh_pr_diff(number: u32, repo: Option<&str>) -> Result<String> {
-    let mut cmd = crate::dependencies::Gh::command().expect("gh not found");
+    let mut cmd = crate::dependencies::Gh::command().ok_or_else(|| anyhow::anyhow!("gh not found"))?;
     cmd.arg("pr").arg("diff").arg(number.to_string());
     if let Some(r) = repo {
         cmd.arg("--repo").arg(r);
@@ -3385,7 +3385,7 @@ fn run_gh_pr_diff(number: u32, repo: Option<&str>) -> Result<String> {
 }
 
 fn run_gh_pr_checkout(number: u32, repo: Option<&str>) -> Result<()> {
-    let mut cmd = crate::dependencies::Gh::command().expect("gh not found");
+    let mut cmd = crate::dependencies::Gh::command().ok_or_else(|| anyhow::anyhow!("gh not found"))?;
     cmd.arg("pr").arg("checkout").arg(number.to_string());
     if let Some(r) = repo {
         cmd.arg("--repo").arg(r);
@@ -3459,7 +3459,7 @@ fn format_pr_prompt(number: u32, view: &GhPullRequest, diff: &str) -> String {
 }
 
 fn collect_diff(args: &ReviewArgs) -> Result<String> {
-    let mut cmd = crate::dependencies::Git::command().expect("git not found");
+    let mut cmd = crate::dependencies::Git::command().ok_or_else(|| anyhow::anyhow!("git not found"))?;
     cmd.arg("diff");
     if args.staged {
         cmd.arg("--cached");
@@ -3500,7 +3500,7 @@ fn run_apply(args: ApplyArgs) -> Result<()> {
     tmp.write_all(patch.as_bytes())?;
     let tmp_path = tmp.path().to_path_buf();
 
-    let output = crate::dependencies::Git::command().expect("git not found")
+    let output = crate::dependencies::Git::command().ok_or_else(|| anyhow::anyhow!("git not found"))?
         .arg("apply")
         .arg("--whitespace=nowarn")
         .arg(&tmp_path)

--- a/crates/tui/src/repl/runtime.rs
+++ b/crates/tui/src/repl/runtime.rs
@@ -25,11 +25,11 @@ use std::time::{Duration, Instant};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::process::{Child, ChildStdin, ChildStdout, Command};
+use tokio::process::{Child, ChildStdin, ChildStdout};
 use uuid::Uuid;
 
 use crate::child_env;
-use crate::dependencies::{PYTHON_CANDIDATES, resolve_python_interpreter, split_interpreter_spec};
+use crate::dependencies::ExternalTool;
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -203,22 +203,12 @@ impl PythonRuntime {
         let session_id = Uuid::new_v4().simple().to_string();
         let bootstrap = render_bootstrap(&session_id);
 
-        let interpreter = resolve_python_interpreter().ok_or_else(|| {
-            format!(
-                "no Python interpreter found on PATH (tried {:?}). \
-                 Install Python 3 and ensure one of these commands works, then restart deepseek-tui.",
-                PYTHON_CANDIDATES,
-            )
+        let mut cmd = crate::dependencies::Python::tokio_command().ok_or_else(|| {
+            "no Python interpreter found on PATH (tried python3, python, py -3). \
+             Install Python 3 and restart deepseek-tui."
+                .to_string()
         })?;
-        let (program, interpreter_args) = split_interpreter_spec(&interpreter);
-        if program.is_empty() {
-            return Err(format!(
-                "resolved Python interpreter is empty: {interpreter:?}"
-            ));
-        }
-
-        let mut cmd = Command::new(&program);
-        cmd.args(&interpreter_args)
+        cmd
             .arg("-u")
             .arg("-c")
             .arg(&bootstrap)
@@ -239,16 +229,16 @@ impl PythonRuntime {
 
         let mut child = cmd
             .spawn()
-            .map_err(|e| format!("failed to spawn Python interpreter `{interpreter}`: {e}"))?;
+            .map_err(|e| format!("failed to spawn Python interpreter: {e}"))?;
 
         let stdin = child
             .stdin
             .take()
-            .ok_or_else(|| format!("Python interpreter `{interpreter}` stdin pipe missing"))?;
+            .ok_or_else(|| "Python interpreter stdin pipe missing".to_string())?;
         let raw_stdout = child
             .stdout
             .take()
-            .ok_or_else(|| format!("Python interpreter `{interpreter}` stdout pipe missing"))?;
+            .ok_or_else(|| "Python interpreter stdout pipe missing".to_string())?;
         let stdout = BufReader::new(raw_stdout);
 
         let mut rt = Self {
@@ -273,13 +263,13 @@ impl PythonRuntime {
             Ok(Err(e)) => {
                 let _ = rt.child.kill().await;
                 Err(format!(
-                    "Python interpreter `{interpreter}` bootstrap failed: {e}"
+                    "Python interpreter bootstrap failed: {e}"
                 ))
             }
             Err(_) => {
                 let _ = rt.child.kill().await;
                 Err(format!(
-                    "Python interpreter `{interpreter}` bootstrap did not signal ready within {}s",
+                    "Python interpreter bootstrap did not signal ready within {}s",
                     SPAWN_READY_TIMEOUT.as_secs()
                 ))
             }

--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -5,7 +5,6 @@ use std::convert::Infallible;
 use std::fs;
 use std::net::SocketAddr;
 use std::path::PathBuf;
-use std::process::Command;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -25,6 +24,8 @@ use tokio::net::TcpListener;
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 use tower_http::cors::{Any, CorsLayer};
+
+use crate::dependencies::ExternalTool;
 
 use crate::automation_manager::{
     AutomationManager, AutomationRecord, AutomationRunRecord, AutomationSchedulerConfig,
@@ -1646,11 +1647,7 @@ fn collect_workspace_status(workspace: &std::path::Path) -> WorkspaceStatusRespo
 }
 
 fn run_git(workspace: &std::path::Path, args: &[&str]) -> Option<String> {
-    let output = Command::new("git")
-        .args(args)
-        .current_dir(workspace)
-        .output()
-        .ok()?;
+    let output = crate::dependencies::Git::output(args, workspace).ok()?;
     if !output.status.success() {
         return None;
     }

--- a/crates/tui/src/shell_dispatcher.rs
+++ b/crates/tui/src/shell_dispatcher.rs
@@ -1,0 +1,502 @@
+//! Shell abstraction layer for DeepSeek TUI.
+//!
+//! Detects the user's shell at startup and provides a single entry point for
+//! all command execution. DeepSeek TUI never calls `Command::new("cmd")` (or
+//! `"sh"`, `"pwsh"`, ...) directly — it asks the [`ShellDispatcher`] to build
+//! a correctly configured [`std::process::Command`].
+//!
+//! ## Responsibilities
+//!
+//! 1. **Shell detection** — find the user's actual shell (PowerShell, pwsh,
+//!    bash via WSL / Git Bash, cmd.exe fallback on Windows, /bin/sh on Unix).
+//! 2. **Quoting correctness** — each shell's argument-passing convention is
+//!    respected so quoted strings survive the spawn boundary intact.
+//! 3. **Terminal state** — foreground shell execution saves and restores
+//!    crossterm raw-mode so the TUI input pipeline is not broken after a
+//!    child process exits (issue #1690).
+
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::Path;
+use std::process::Command;
+use std::sync::Mutex;
+
+static LOG_MUTEX: Mutex<()> = Mutex::new(());
+
+// ---------------------------------------------------------------------------
+// Shell kind
+// ---------------------------------------------------------------------------
+
+/// The concrete shell that the dispatcher will use.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ShellKind {
+    /// PowerShell 7+ (`pwsh.exe`).
+    Pwsh,
+    /// Windows PowerShell 5.1 (`powershell.exe`).
+    WindowsPowerShell,
+    /// Command Prompt (`cmd.exe`).
+    Cmd,
+    /// Unix `/bin/sh` (or `$SHELL`-detected bash/zsh).
+    Sh,
+    /// Bash — detected via `$SHELL` on either Unix or WSL/Git Bash on Windows.
+    Bash,
+    /// Any other POSIX shell from $SHELL (zsh, fish, dash, ...).
+    Custom { binary: String, flag: String },
+}
+
+impl ShellKind {
+    /// Binary name for the shell. Appends `.exe` on Windows where needed.
+    pub fn binary(&self) -> &str {
+        match self {
+            #[cfg(windows)]
+            ShellKind::Pwsh => "pwsh.exe",
+            #[cfg(not(windows))]
+            ShellKind::Pwsh => "pwsh",
+
+            #[cfg(windows)]
+            ShellKind::WindowsPowerShell => "powershell.exe",
+            #[cfg(not(windows))]
+            ShellKind::WindowsPowerShell => "powershell",
+
+            #[cfg(windows)]
+            ShellKind::Cmd => "cmd.exe",
+            #[cfg(not(windows))]
+            ShellKind::Cmd => "cmd",
+
+            ShellKind::Sh => "sh",
+            ShellKind::Bash => "bash",
+            ShellKind::Custom { binary, .. } => binary,
+        }
+    }
+
+    /// Flag that tells the shell to execute the following argument as a
+    /// command string.
+    pub fn command_flag(&self) -> &str {
+        match self {
+            ShellKind::Pwsh | ShellKind::WindowsPowerShell => "-NoProfile",
+            ShellKind::Cmd => "/C",
+            ShellKind::Sh | ShellKind::Bash => "-c",
+            ShellKind::Custom { flag, .. } => flag,
+        }
+    }
+
+    /// Whether this shell needs an extra `-Command` flag after the profile
+    /// flag (PowerShell-specific).
+    pub fn needs_command_flag(&self) -> bool {
+        matches!(self, ShellKind::Pwsh | ShellKind::WindowsPowerShell)
+    }
+
+    /// Returns true when this is a PowerShell-family shell.
+    pub fn is_powershell(&self) -> bool {
+        matches!(self, ShellKind::Pwsh | ShellKind::WindowsPowerShell)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Dispatcher
+// ---------------------------------------------------------------------------
+
+/// Central shell abstraction. Created once at startup via
+/// [`ShellDispatcher::detect`] and then used everywhere a command needs to
+/// be spawned.
+#[derive(Debug, Clone)]
+pub struct ShellDispatcher {
+    kind: ShellKind,
+}
+
+impl ShellDispatcher {
+    /// Detect the user's shell from the environment.
+    ///
+    /// ## Detection order (Windows)
+    ///
+    /// 1. `$env:SHELL` — WSL interop or Git Bash often set this.
+    /// 2. `pwsh.exe` found on `PATH` — PowerShell 7+.
+    /// 3. `powershell.exe` found on `PATH` — Windows PowerShell 5.1.
+    /// 4. `cmd.exe` — always available, last resort.
+    ///
+    /// ## Detection order (Unix)
+    ///
+    /// 1. `$SHELL` — if it contains `bash`, use `Bash`; otherwise use the
+    ///    actual binary path via `Custom`.
+    /// 2. `/bin/sh` fallback.
+    pub fn detect() -> Self {
+        let kind = Self::detect_shell();
+        Self::log_startup(&kind);
+        ShellDispatcher { kind }
+    }
+
+    /// Log a shell execution line when `SHELL_DISPATCHER_LOG` is set.
+    pub fn log_exec(command: &str) {
+        if let Ok(path) = std::env::var("SHELL_DISPATCHER_LOG") {
+            let _ = Self::append_log_static(&path, command);
+        }
+    }
+
+    fn log_startup(kind: &ShellKind) {
+        let _lock = LOG_MUTEX.lock();
+        if let Ok(path) = std::env::var("SHELL_DISPATCHER_LOG") {
+            let init_line = format!(
+                "--- ShellDispatcher log started pid={} ---\n",
+                std::process::id()
+            );
+            let _ = Self::append_log(&path, &init_line);
+            let detect_line = format!("[{}] detect: {kind:?}\n", now_iso());
+            let _ = Self::append_log(&path, &detect_line);
+        }
+    }
+
+    fn append_log(path: &str, line: &str) -> std::io::Result<()> {
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(Path::new(path))?;
+        file.write_all(line.as_bytes())?;
+        file.flush()
+    }
+
+    fn append_log_static(path: &str, command: &str) -> std::io::Result<()> {
+        // Resolve kind outside the lock — `global_dispatcher()` may trigger
+        // `detect()` which calls `log_startup()` which also acquires the mutex.
+        let kind = global_dispatcher().kind();
+        let _lock = LOG_MUTEX.lock();
+        let line = format!(
+            "[{}] exec via {kind:?}: {command}\n", now_iso()
+        );
+        Self::append_log(path, &line)
+    }
+
+
+    /// The detected shell kind.
+    pub fn kind(&self) -> &ShellKind {
+        &self.kind
+    }
+
+    // -- Public builders --------------------------------------------------
+
+    /// Build a `std::process::Command` for the given shell command string.
+    pub fn build_command(&self, shell_command: &str) -> Command {
+        let mut cmd = Command::new(self.kind.binary());
+
+        if self.kind.needs_command_flag() {
+            cmd.arg(self.kind.command_flag());
+            cmd.arg("-Command");
+            cmd.arg(shell_command);
+        } else {
+            cmd.arg(self.kind.command_flag());
+            cmd.arg(shell_command);
+        }
+
+        cmd
+    }
+
+    /// Build the program + args tuple. Useful when the caller needs to
+    /// inspect or modify the args before passing them to `Command`.
+    pub fn build_command_parts(&self, shell_command: &str) -> (String, Vec<String>) {
+        let program = self.kind.binary().to_string();
+        let args = if self.kind.needs_command_flag() {
+            vec![
+                self.kind.command_flag().to_string(),
+                "-Command".to_string(),
+                shell_command.to_string(),
+            ]
+        } else {
+            vec![
+                self.kind.command_flag().to_string(),
+                shell_command.to_string(),
+            ]
+        };
+        (program, args)
+    }
+
+    /// Build a `Command` from separate program + args (bypasses the shell).
+    /// Used when the caller already has a resolved executable and argument
+    /// vector — e.g. `ExecEnv` from the sandbox.
+    pub fn build_direct(&self, program: &str, args: &[String]) -> Command {
+        let mut cmd = Command::new(program);
+        cmd.args(args);
+        cmd
+    }
+
+    /// Execute a foreground command with raw-mode save/restore.
+    ///
+    /// A scope guard ensures raw mode is restored even if the command fails
+    /// to spawn or returns early (review feedback, issue #1690).
+    pub fn run_foreground(
+        &self,
+        shell_command: &str,
+        cwd: &std::path::Path,
+    ) -> Result<String, anyhow::Error> {
+        use anyhow::Context;
+
+        // Log the execution
+        {
+            let _lock = LOG_MUTEX.lock();
+            if let Ok(path) = std::env::var("SHELL_DISPATCHER_LOG") {
+                let kind = self.kind();
+                let line = format!(
+                    "[{}] exec via {kind:?}: {shell_command}\n", now_iso()
+                );
+                let _ = Self::append_log(&path, &line);
+            }
+        }
+
+        // Disable raw mode; guard restores it even on `?` early return.
+        let _ = crossterm::terminal::disable_raw_mode();
+        struct FgRawModeGuard;
+        impl Drop for FgRawModeGuard {
+            fn drop(&mut self) {
+                let _ = crossterm::terminal::enable_raw_mode();
+            }
+        }
+        let _guard = FgRawModeGuard;
+
+        let mut cmd = self.build_command(shell_command);
+        cmd.current_dir(cwd);
+
+        let output = cmd
+            .output()
+            .with_context(|| format!("failed to execute shell command: {shell_command}"))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!(
+                "shell command failed (status={}): {}",
+                output.status,
+                stderr.trim()
+            );
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        Ok(stdout)
+    }
+
+    // -- Detection --------------------------------------------------------
+
+    fn detect_shell() -> ShellKind {
+        // 1. $SHELL environment variable (WSL, Git Bash, MSYS2, or Unix)
+        if let Ok(shell) = std::env::var("SHELL") {
+            let lower = shell.to_lowercase();
+            if lower.contains("bash") {
+                return ShellKind::Bash;
+            }
+            if lower.contains("pwsh") {
+                return ShellKind::Pwsh;
+            }
+            if lower.contains("powershell") {
+                return ShellKind::WindowsPowerShell;
+            }
+            return ShellKind::Custom {
+                binary: shell,
+                flag: "-c".to_string(),
+            };
+        }
+
+        #[cfg(windows)]
+        {
+            if Self::find_exe("pwsh.exe") {
+                return ShellKind::Pwsh;
+            }
+            if Self::find_exe("powershell.exe") {
+                return ShellKind::WindowsPowerShell;
+            }
+            return ShellKind::Cmd;
+        }
+
+        #[cfg(not(windows))]
+        {
+            ShellKind::Sh
+        }
+    }
+
+    /// Check PATH first, then fall back to well-known install directories.
+    fn find_exe(name: &str) -> bool {
+        if Self::binary_on_path(name) {
+            return true;
+        }
+        // Well-known install locations (order by preference).
+        let known_dirs: &[&str] = &[
+            r"C:\Program Files\PowerShell\7",
+            r"C:\Windows\System32\WindowsPowerShell\v1.0",
+        ];
+        known_dirs.iter().any(|dir| std::path::Path::new(dir).join(name).is_file())
+    }
+
+    fn binary_on_path(name: &str) -> bool {
+        std::env::var_os("PATH")
+            .map(|path| {
+                std::env::split_paths(&path).any(|dir| {
+                    let candidate = dir.join(name);
+                    candidate.is_file()
+                })
+            })
+            .unwrap_or(false)
+    }
+}
+
+// -- Helpers ---------------------------------------------------------------
+
+fn now_iso() -> String {
+    chrono::Utc::now().format("%Y-%m-%dT%H:%M:%S%.3f").to_string()
+}
+
+/// Global dispatcher instance, detected once at startup.
+///
+/// Any code path that needs to spawn a shell command can use
+/// `global_dispatcher()` instead of threading the dispatcher through
+/// every function signature.
+pub fn global_dispatcher() -> &'static ShellDispatcher {
+    use std::sync::LazyLock;
+    static DISPATCHER: LazyLock<ShellDispatcher> = LazyLock::new(ShellDispatcher::detect);
+    &DISPATCHER
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shell_kind_binary_names() {
+        #[cfg(windows)]
+        {
+            assert_eq!(ShellKind::Pwsh.binary(), "pwsh.exe");
+            assert_eq!(ShellKind::WindowsPowerShell.binary(), "powershell.exe");
+            assert_eq!(ShellKind::Cmd.binary(), "cmd.exe");
+        }
+        #[cfg(not(windows))]
+        {
+            assert_eq!(ShellKind::Pwsh.binary(), "pwsh");
+            assert_eq!(ShellKind::WindowsPowerShell.binary(), "powershell");
+            assert_eq!(ShellKind::Cmd.binary(), "cmd");
+        }
+        assert_eq!(ShellKind::Sh.binary(), "sh");
+        assert_eq!(ShellKind::Bash.binary(), "bash");
+    }
+
+    #[test]
+    fn detect_returns_some_shell() {
+        let dispatcher = global_dispatcher();
+        let _kind = dispatcher.kind();
+    }
+
+    #[test]
+    fn powershell_build_command_includes_no_profile_and_command_flags() {
+        let dispatcher = ShellDispatcher { kind: ShellKind::Pwsh };
+        let cmd = dispatcher.build_command("echo hello");
+        let args: Vec<&str> = cmd.get_args().map(|a| a.to_str().unwrap()).collect();
+        assert!(args.contains(&"-NoProfile"));
+        assert!(args.contains(&"-Command"));
+        assert!(args.contains(&"echo hello"));
+    }
+
+    #[test]
+    fn cmd_build_command_uses_c_flag() {
+        let dispatcher = ShellDispatcher { kind: ShellKind::Cmd };
+        let cmd = dispatcher.build_command("echo hello");
+        let args: Vec<&str> = cmd.get_args().map(|a| a.to_str().unwrap()).collect();
+        assert!(args.contains(&"/C"));
+        assert!(args.contains(&"echo hello"));
+    }
+
+    #[test]
+    fn sh_build_command_uses_dash_c() {
+        let dispatcher = ShellDispatcher { kind: ShellKind::Sh };
+        let cmd = dispatcher.build_command("echo hello");
+        let args: Vec<&str> = cmd.get_args().map(|a| a.to_str().unwrap()).collect();
+        assert!(args.contains(&"-c"));
+        assert!(args.contains(&"echo hello"));
+    }
+
+    #[test]
+    fn build_direct_preserves_args() {
+        let dispatcher = ShellDispatcher { kind: ShellKind::Cmd };
+        let args = vec!["-m".to_string(), "commit message".to_string()];
+        let cmd = dispatcher.build_direct("git", &args);
+        let cmd_args: Vec<&str> = cmd.get_args().map(|a| a.to_str().unwrap()).collect();
+        assert_eq!(cmd_args, vec!["-m", "commit message"]);
+    }
+
+    #[test]
+    fn powershell_flags_are_correct() {
+        assert!(ShellKind::Pwsh.needs_command_flag());
+        assert!(ShellKind::WindowsPowerShell.needs_command_flag());
+        assert!(!ShellKind::Cmd.needs_command_flag());
+        assert!(!ShellKind::Sh.needs_command_flag());
+        assert!(!ShellKind::Bash.needs_command_flag());
+    }
+
+    #[test]
+    fn is_powershell_detects_both_variants() {
+        assert!(ShellKind::Pwsh.is_powershell());
+        assert!(ShellKind::WindowsPowerShell.is_powershell());
+        assert!(!ShellKind::Cmd.is_powershell());
+        assert!(!ShellKind::Sh.is_powershell());
+        assert!(!ShellKind::Bash.is_powershell());
+    }
+
+    #[test]
+    fn build_command_quotes_spaces_for_cmd() {
+        let dispatcher = ShellDispatcher { kind: ShellKind::Cmd };
+        let cmd = dispatcher.build_command("git commit -m \"msg with spaces\"");
+        let args: Vec<&str> = cmd.get_args().map(|a| a.to_str().unwrap()).collect();
+        assert_eq!(args.len(), 2);
+        assert_eq!(args[0], "/C");
+        assert!(args[1].contains("msg with spaces"));
+        assert!(args[1].starts_with("git "));
+    }
+
+    #[test]
+    fn build_command_quotes_spaces_for_pwsh() {
+        let dispatcher = ShellDispatcher { kind: ShellKind::Pwsh };
+        let cmd = dispatcher.build_command("git commit -m \"msg with spaces\"");
+        let args: Vec<&str> = cmd.get_args().map(|a| a.to_str().unwrap()).collect();
+        assert_eq!(args.len(), 3);
+        assert_eq!(args[0], "-NoProfile");
+        assert_eq!(args[1], "-Command");
+        assert!(args[2].contains("msg with spaces"));
+    }
+
+    #[test]
+    fn build_direct_handles_empty_args() {
+        let dispatcher = ShellDispatcher { kind: ShellKind::Sh };
+        let cmd = dispatcher.build_direct("echo", &[]);
+        let args: Vec<&str> = cmd.get_args().map(|a| a.to_str().unwrap()).collect();
+        assert!(args.is_empty());
+    }
+
+    #[test]
+    fn find_exe_finds_cmd_on_path() {
+        // cmd.exe is always on PATH on Windows.
+        assert!(ShellDispatcher::find_exe("cmd.exe"));
+    }
+
+    #[test]
+    fn find_exe_rejects_nonexistent_binary() {
+        assert!(!ShellDispatcher::find_exe("nonexistent_xyz_12345.exe"));
+    }
+
+    #[test]
+    fn find_exe_falls_back_to_known_dirs() {
+        // Verify the known-dirs fallback path actually exists on this system.
+        let ps_path = r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe";
+        if std::path::Path::new(ps_path).is_file() {
+            // The fallback directory exists — find_exe should locate it.
+            assert!(ShellDispatcher::find_exe("powershell.exe"));
+        } else {
+            eprintln!("Skipping: {ps_path} not present on this system");
+        }
+    }
+
+    #[test]
+    fn custom_shell_uses_provided_binary_and_flag() {
+        let kind = ShellKind::Custom {
+            binary: "/bin/zsh".to_string(),
+            flag: "-c".to_string(),
+        };
+        assert_eq!(kind.binary(), "/bin/zsh");
+        assert_eq!(kind.command_flag(), "-c");
+    }
+}

--- a/crates/tui/src/snapshot/repo.rs
+++ b/crates/tui/src/snapshot/repo.rs
@@ -1053,20 +1053,29 @@ mod tests {
         let tmp = tempdir().unwrap();
         let workspace = tmp.path().join("workspace");
         std::fs::create_dir_all(&workspace).unwrap();
-        crate::dependencies::Git::command().expect("git not found")
+        let Some(mut git_cmd) = crate::dependencies::Git::command() else {
+            panic!("git not found");
+        };
+        git_cmd
             .arg("-C").arg(&workspace)
             .arg("init").arg("--quiet")
             .status()
             .unwrap();
         std::fs::write(workspace.join("tracked.txt"), b"committed").unwrap();
-        crate::dependencies::Git::command().expect("git not found")
+        let Some(mut git_cmd) = crate::dependencies::Git::command() else {
+            panic!("git not found");
+        };
+        git_cmd
             .arg("-C")
             .arg(&workspace)
             .arg("add")
             .arg("tracked.txt")
             .status()
             .unwrap();
-        crate::dependencies::Git::command().expect("git not found")
+        let Some(mut git_cmd) = crate::dependencies::Git::command() else {
+            panic!("git not found");
+        };
+        git_cmd
             .arg("-C")
             .arg(&workspace)
             .arg("-c")
@@ -1079,7 +1088,10 @@ mod tests {
             .arg("init")
             .status()
             .unwrap();
-        let user_head_before = crate::dependencies::Git::command().expect("git not found")
+        let Some(mut git_cmd) = crate::dependencies::Git::command() else {
+            panic!("git not found");
+        };
+        let user_head_before = git_cmd
             .arg("-C")
             .arg(&workspace)
             .args(["rev-parse", "HEAD"])
@@ -1095,7 +1107,10 @@ mod tests {
         repo.snapshot("post-turn:1").unwrap();
         repo.restore(&id).unwrap();
 
-        let user_head_after = crate::dependencies::Git::command().expect("git not found")
+        let Some(mut git_cmd) = crate::dependencies::Git::command() else {
+            panic!("git not found");
+        };
+        let user_head_after = git_cmd
             .arg("-C")
             .arg(&workspace)
             .args(["rev-parse", "HEAD"])

--- a/crates/tui/src/snapshot/repo.rs
+++ b/crates/tui/src/snapshot/repo.rs
@@ -15,8 +15,10 @@
 use std::collections::HashSet;
 use std::io;
 use std::path::{Component, Path, PathBuf};
-use std::process::{Command, Output};
+use std::process::Output;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use crate::dependencies::ExternalTool;
 
 use super::paths::{ensure_snapshot_dir, snapshot_git_dir};
 
@@ -249,7 +251,8 @@ impl SnapshotRepo {
             // and stores metadata in `.git`. We then continue to use
             // explicit `--git-dir` / `--work-tree` flags for every other
             // command so behaviour is invariant of cwd.
-            let init = Command::new("git")
+            let init = crate::dependencies::Git::command()
+                .ok_or_else(|| io_other("git not found on PATH"))?
                 .arg("init")
                 .arg("--quiet")
                 .arg(parent)
@@ -815,7 +818,8 @@ fn cleanup_stale_pack_temps_in(
 }
 
 fn run_git(git_dir: &Path, work_tree: &Path, args: &[&str]) -> io::Result<Output> {
-    Command::new("git")
+    crate::dependencies::Git::command()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "git not found on PATH"))?
         .arg("--git-dir")
         .arg(git_dir)
         .arg("--work-tree")
@@ -1049,22 +1053,20 @@ mod tests {
         let tmp = tempdir().unwrap();
         let workspace = tmp.path().join("workspace");
         std::fs::create_dir_all(&workspace).unwrap();
-        Command::new("git")
-            .arg("-C")
-            .arg(&workspace)
-            .arg("init")
-            .arg("--quiet")
+        crate::dependencies::Git::command().expect("git not found")
+            .arg("-C").arg(&workspace)
+            .arg("init").arg("--quiet")
             .status()
             .unwrap();
         std::fs::write(workspace.join("tracked.txt"), b"committed").unwrap();
-        Command::new("git")
+        crate::dependencies::Git::command().expect("git not found")
             .arg("-C")
             .arg(&workspace)
             .arg("add")
             .arg("tracked.txt")
             .status()
             .unwrap();
-        Command::new("git")
+        crate::dependencies::Git::command().expect("git not found")
             .arg("-C")
             .arg(&workspace)
             .arg("-c")
@@ -1077,7 +1079,7 @@ mod tests {
             .arg("init")
             .status()
             .unwrap();
-        let user_head_before = Command::new("git")
+        let user_head_before = crate::dependencies::Git::command().expect("git not found")
             .arg("-C")
             .arg(&workspace)
             .args(["rev-parse", "HEAD"])
@@ -1093,7 +1095,7 @@ mod tests {
         repo.snapshot("post-turn:1").unwrap();
         repo.restore(&id).unwrap();
 
-        let user_head_after = Command::new("git")
+        let user_head_after = crate::dependencies::Git::command().expect("git not found")
             .arg("-C")
             .arg(&workspace)
             .args(["rev-parse", "HEAD"])

--- a/crates/tui/src/tools/diagnostics.rs
+++ b/crates/tui/src/tools/diagnostics.rs
@@ -190,23 +190,17 @@ mod tests {
     use super::*;
     use std::fs;
     use std::path::Path;
+    use crate::dependencies::ExternalTool;
     use std::process::Command;
     use tempfile::tempdir;
 
     fn git_available() -> bool {
-        Command::new("git")
-            .arg("--version")
-            .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false)
+        crate::dependencies::Git::available()
     }
 
     fn init_git_repo(root: &Path) {
         let run = |args: &[&str]| {
-            let status = Command::new("git")
-                .args(args)
-                .current_dir(root)
-                .status()
+            let status = crate::dependencies::Git::status(args, root)
                 .expect("git should spawn");
             assert!(status.success(), "git {:?} failed", args);
         };

--- a/crates/tui/src/tools/dotnet_execution.rs
+++ b/crates/tui/src/tools/dotnet_execution.rs
@@ -55,49 +55,90 @@ pub fn dotnet_execution_tool_definition() -> Tool {
 /// Run the model-provided C# code and return the captured
 /// stdout / stderr / return_code payload.
 ///
-/// Writes code to a temp `.cs` file, spawns `dotnet run <file>`,
-/// and collects the output. 120-second timeout, same error shape
-/// as `code_execution` and `js_execution`.
+/// Uses a persistent runner project at `$workspace/.deepseek/dotnet-runner/`
+/// so that NuGet restore only happens once (when the project is first opened
+/// in Visual Studio or `dotnet restore` is run manually). Subsequent runs
+/// use `dotnet run --no-restore` to bypass the NuGet layer entirely.
+///
+/// 120-second timeout, same error shape as `code_execution` and `js_execution`.
 pub async fn execute_dotnet_execution_tool(
     input: &Value,
     workspace: &Path,
 ) -> Result<ToolResult, ToolError> {
     let code = required_str(input, "code")?;
 
-    // Resolve the .NET SDK via ExternalTool. If absent, fail fast.
-    let temp_dir = tempfile::tempdir()
-        .map_err(|e| ToolError::execution_failed(format!("tempdir failed: {e}")))?;
-    let script_path = temp_dir.path().join("dotnet_execution.cs");
-    tokio::fs::write(&script_path, code)
+    // --- resolve or create the persistent runner project -------------------
+    let runner_dir = workspace.join(".deepseek").join("dotnet-runner");
+    tokio::fs::create_dir_all(&runner_dir)
         .await
-        .map_err(|e| ToolError::execution_failed(format!("tempfile write failed: {e}")))?;
+        .map_err(|e| ToolError::execution_failed(format!("mkdir runner dir: {e}")))?;
+
+    let csproj_path = runner_dir.join("runner.csproj");
+    if !csproj_path.exists() {
+        tokio::fs::write(&csproj_path, r#"<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+</Project>
+"#)
+            .await
+            .map_err(|e| ToolError::execution_failed(format!("write csproj: {e}")))?;
+    }
+
+    // Write user code to Program.cs
+    let program_path = runner_dir.join("Program.cs");
+    tokio::fs::write(&program_path, code)
+        .await
+        .map_err(|e| ToolError::execution_failed(format!("write Program.cs: {e}")))?;
 
     let mut cmd = crate::dependencies::DotNet::tokio_command().ok_or_else(|| {
         ToolError::execution_failed(
             "dotnet_execution: .NET SDK became unavailable".to_string()
         )
     })?;
-    // `dotnet run file.cs` works from .NET 6 onwards.
-    // The current_dir must be the temp_dir so `dotnet run` can
-    // create its temporary project artefacts there.
+
+    // First try `dotnet run --no-restore` — works when NuGet restore
+    // was already done (e.g. by opening the project in Visual Studio).
+    // If that fails with "assets file not found", try `dotnet run` which
+    // will attempt restore (may fail on SDKs with broken NuGet layers).
+    let assets_path = runner_dir.join("obj").join("project.assets.json");
+    let use_no_restore = assets_path.exists();
+
     cmd.arg("run")
-        .arg(&script_path)
-        .current_dir(temp_dir.path());
+        .arg("--project")
+        .arg(&csproj_path)
+        .current_dir(&runner_dir);
+
+    if use_no_restore {
+        cmd.arg("--no-restore");
+    }
 
     let output = tokio::time::timeout(Duration::from_secs(120), cmd.output())
         .await
         .map_err(|_| ToolError::Timeout { seconds: 120 })
         .and_then(|res| res.map_err(|e| ToolError::execution_failed(e.to_string())))?;
 
-    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-    let return_code = output.status.code().unwrap_or(-1);
+    let stdout_raw = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr_raw = String::from_utf8_lossy(&output.stderr).to_string();
     let success = output.status.success();
+
+    // If restore failed, surface a clear message.
+    if !success && !use_no_restore && stderr_raw.contains("NuGet.targets") {
+        return Err(ToolError::execution_failed(
+            "dotnet_execution: NuGet restore failed. Open the runner project \
+             in Visual Studio once to generate NuGet assets:\n  \
+             ".to_string() + &runner_dir.display().to_string()
+        ));
+    }
+
     let payload = json!({
         "type": "code_execution_result",
-        "stdout": stdout,
-        "stderr": stderr,
-        "return_code": return_code,
+        "stdout": stdout_raw,
+        "stderr": stderr_raw,
+        "return_code": output.status.code().unwrap_or(-1),
         "content": [],
     });
 
@@ -107,6 +148,8 @@ pub async fn execute_dotnet_execution_tool(
         metadata: Some(payload),
     })
 }
+
+// =========================================================================
 
 #[cfg(test)]
 mod tests {

--- a/crates/tui/src/tools/dotnet_execution.rs
+++ b/crates/tui/src/tools/dotnet_execution.rs
@@ -1,0 +1,192 @@
+//! `dotnet_execution` tool — execute model-provided C# code via a local
+//! .NET SDK, returning stdout / stderr / exit code as JSON.
+//!
+//! Starting with .NET 6, `dotnet run file.cs` can run a single C# file
+//! as a top-level-statements script — no project, no Main(), no class
+//! wrapper needed. This tool writes the model-provided code to a temp
+//! `.cs` file and spawns `dotnet run` against it, mirroring the shape
+//! of `code_execution` (Python) and `js_execution` (Node).
+//!
+//! Registration is gated by [`crate::dependencies::DotNet::resolve`]:
+//! when the .NET SDK is missing the tool is simply not advertised.
+
+use std::path::Path;
+use std::time::Duration;
+
+use crate::dependencies::ExternalTool;
+use serde_json::{Value, json};
+
+use crate::models::Tool;
+use crate::tools::spec::{ToolError, ToolResult, required_str};
+
+/// Tool name surfaced to the model.
+pub const DOTNET_EXECUTION_TOOL_NAME: &str = "dotnet_execution";
+/// Tool-type tag — same `code_execution_*` family as Python/Node so
+/// the wire shape stays stable across interpreters.
+const DOTNET_EXECUTION_TOOL_TYPE: &str = "code_execution_20250825";
+
+/// Build the `Tool` definition the catalog should advertise when
+/// the .NET SDK is present on the host.
+#[must_use]
+pub fn dotnet_execution_tool_definition() -> Tool {
+    Tool {
+        tool_type: Some(DOTNET_EXECUTION_TOOL_TYPE.to_string()),
+        name: DOTNET_EXECUTION_TOOL_NAME.to_string(),
+        description:
+            "Execute C# code in a local .NET SDK sandbox and return stdout/stderr/return_code as JSON. \
+             Requires `dotnet` (NET 6+ SDK) on PATH. Code runs as a single-file top-level-statements script — \
+             no project or Main() wrapper needed."
+                .to_string(),
+        input_schema: json!({
+            "type": "object",
+            "properties": {
+                "code": { "type": "string", "description": "C# source code to execute. Use top-level statements (no class or Main needed)." }
+            },
+            "required": ["code"]
+        }),
+        allowed_callers: Some(vec!["direct".to_string()]),
+        defer_loading: Some(false),
+        input_examples: None,
+        strict: None,
+        cache_control: None,
+    }
+}
+
+/// Run the model-provided C# code and return the captured
+/// stdout / stderr / return_code payload.
+///
+/// Writes code to a temp `.cs` file, spawns `dotnet run <file>`,
+/// and collects the output. 120-second timeout, same error shape
+/// as `code_execution` and `js_execution`.
+pub async fn execute_dotnet_execution_tool(
+    input: &Value,
+    workspace: &Path,
+) -> Result<ToolResult, ToolError> {
+    let code = required_str(input, "code")?;
+
+    // Resolve the .NET SDK via ExternalTool. If absent, fail fast.
+    let temp_dir = tempfile::tempdir()
+        .map_err(|e| ToolError::execution_failed(format!("tempdir failed: {e}")))?;
+    let script_path = temp_dir.path().join("dotnet_execution.cs");
+    tokio::fs::write(&script_path, code)
+        .await
+        .map_err(|e| ToolError::execution_failed(format!("tempfile write failed: {e}")))?;
+
+    let mut cmd = crate::dependencies::DotNet::tokio_command().ok_or_else(|| {
+        ToolError::execution_failed(
+            "dotnet_execution: .NET SDK became unavailable".to_string()
+        )
+    })?;
+    // `dotnet run file.cs` works from .NET 6 onwards.
+    // The current_dir must be the temp_dir so `dotnet run` can
+    // create its temporary project artefacts there.
+    cmd.arg("run")
+        .arg(&script_path)
+        .current_dir(temp_dir.path());
+
+    let output = tokio::time::timeout(Duration::from_secs(120), cmd.output())
+        .await
+        .map_err(|_| ToolError::Timeout { seconds: 120 })
+        .and_then(|res| res.map_err(|e| ToolError::execution_failed(e.to_string())))?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    let return_code = output.status.code().unwrap_or(-1);
+    let success = output.status.success();
+    let payload = json!({
+        "type": "code_execution_result",
+        "stdout": stdout,
+        "stderr": stderr,
+        "return_code": return_code,
+        "content": [],
+    });
+
+    Ok(ToolResult {
+        content: serde_json::to_string(&payload).unwrap_or_else(|_| payload.to_string()),
+        success,
+        metadata: Some(payload),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    /// Skip helper — `dotnet_execution` is a no-op on hosts without .NET SDK.
+    fn dotnet_present() -> bool {
+        crate::dependencies::DotNet::available()
+    }
+
+    #[test]
+    fn tool_definition_advertises_dotnet_execution_name_and_required_code_field() {
+        let tool = dotnet_execution_tool_definition();
+        assert_eq!(tool.name, DOTNET_EXECUTION_TOOL_NAME);
+        assert_eq!(tool.tool_type.as_deref(), Some(DOTNET_EXECUTION_TOOL_TYPE));
+        let required = tool
+            .input_schema
+            .get("required")
+            .and_then(|v| v.as_array())
+            .expect("schema must declare a `required` array");
+        assert!(
+            required.iter().any(|v| v.as_str() == Some("code")),
+            "input_schema must require `code`",
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_dotnet_runs_and_returns_stdout_payload() {
+        if !dotnet_present() {
+            return;
+        }
+        let tmp = tempdir().expect("tempdir");
+        let result = execute_dotnet_execution_tool(
+            &json!({ "code": "System.Console.WriteLine(\"hello from dotnet\");" }),
+            tmp.path(),
+        )
+        .await
+        .expect("execute");
+        assert!(result.success, "successful dotnet run must report success");
+        assert!(
+            result.content.contains("hello from dotnet"),
+            "stdout payload must surface the printed text; got {}",
+            result.content
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_dotnet_surfaces_runtime_error_with_nonzero_exit() {
+        if !dotnet_present() {
+            return;
+        }
+        let tmp = tempdir().expect("tempdir");
+        let result = execute_dotnet_execution_tool(
+            &json!({ "code": "throw new System.Exception(\"intentional fail\");" }),
+            tmp.path(),
+        )
+        .await
+        .expect("execute should not Err — runtime errors land in stderr/exit code");
+        assert!(
+            !result.success,
+            "non-zero exit must report success=false"
+        );
+        assert!(
+            result.content.contains("intentional fail"),
+            "stderr payload must surface the error message; got {}",
+            result.content
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_dotnet_rejects_input_without_code_field() {
+        let tmp = tempdir().expect("tempdir");
+        let err = execute_dotnet_execution_tool(&json!({}), tmp.path())
+            .await
+            .expect_err("missing `code` must reject before any dotnet spawn");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("code"),
+            "error must name the missing `code` field; got {msg}"
+        );
+    }
+}

--- a/crates/tui/src/tools/dotnet_execution.rs
+++ b/crates/tui/src/tools/dotnet_execution.rs
@@ -4,7 +4,7 @@
 //! Starting with .NET 6, `dotnet run file.cs` can run a single C# file
 //! as a top-level-statements script — no project, no Main(), no class
 //! wrapper needed. This tool writes the model-provided code to a temp
-//! `.cs` file and spawns `dotnet run` against it, mirroring the shape
+//! `.cs` file and spawns `dotnet run <file>`, mirroring the shape
 //! of `code_execution` (Python) and `js_execution` (Node).
 //!
 //! Registration is gated by [`crate::dependencies::DotNet::resolve`]:
@@ -55,90 +55,48 @@ pub fn dotnet_execution_tool_definition() -> Tool {
 /// Run the model-provided C# code and return the captured
 /// stdout / stderr / return_code payload.
 ///
-/// Uses a persistent runner project at `$workspace/.deepseek/dotnet-runner/`
-/// so that NuGet restore only happens once (when the project is first opened
-/// in Visual Studio or `dotnet restore` is run manually). Subsequent runs
-/// use `dotnet run --no-restore` to bypass the NuGet layer entirely.
+/// Writes code to a temp `.cs` file, spawns `dotnet run <file>`,
+/// and collects the output. 120-second timeout, same error shape
+/// as `code_execution` and `js_execution`.
 ///
-/// 120-second timeout, same error shape as `code_execution` and `js_execution`.
+/// Uses a temp directory (no parent `.csproj` in the tree) so
+/// `dotnet run file.cs` creates an implicit console project.
 pub async fn execute_dotnet_execution_tool(
     input: &Value,
     workspace: &Path,
 ) -> Result<ToolResult, ToolError> {
     let code = required_str(input, "code")?;
 
-    // --- resolve or create the persistent runner project -------------------
-    let runner_dir = workspace.join(".deepseek").join("dotnet-runner");
-    tokio::fs::create_dir_all(&runner_dir)
+    let temp_dir = tempfile::tempdir()
+        .map_err(|e| ToolError::execution_failed(format!("tempdir failed: {e}")))?;
+    let script_path = temp_dir.path().join("dotnet_execution.cs");
+    tokio::fs::write(&script_path, code)
         .await
-        .map_err(|e| ToolError::execution_failed(format!("mkdir runner dir: {e}")))?;
-
-    let csproj_path = runner_dir.join("runner.csproj");
-    if !csproj_path.exists() {
-        tokio::fs::write(&csproj_path, r#"<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>disable</ImplicitUsings>
-    <Nullable>disable</Nullable>
-  </PropertyGroup>
-</Project>
-"#)
-            .await
-            .map_err(|e| ToolError::execution_failed(format!("write csproj: {e}")))?;
-    }
-
-    // Write user code to Program.cs
-    let program_path = runner_dir.join("Program.cs");
-    tokio::fs::write(&program_path, code)
-        .await
-        .map_err(|e| ToolError::execution_failed(format!("write Program.cs: {e}")))?;
+        .map_err(|e| ToolError::execution_failed(format!("tempfile write failed: {e}")))?;
 
     let mut cmd = crate::dependencies::DotNet::tokio_command().ok_or_else(|| {
         ToolError::execution_failed(
             "dotnet_execution: .NET SDK became unavailable".to_string()
         )
     })?;
-
-    // First try `dotnet run --no-restore` — works when NuGet restore
-    // was already done (e.g. by opening the project in Visual Studio).
-    // If that fails with "assets file not found", try `dotnet run` which
-    // will attempt restore (may fail on SDKs with broken NuGet layers).
-    let assets_path = runner_dir.join("obj").join("project.assets.json");
-    let use_no_restore = assets_path.exists();
-
     cmd.arg("run")
-        .arg("--project")
-        .arg(&csproj_path)
-        .current_dir(&runner_dir);
-
-    if use_no_restore {
-        cmd.arg("--no-restore");
-    }
+        .arg(&script_path)
+        .current_dir(temp_dir.path());
 
     let output = tokio::time::timeout(Duration::from_secs(120), cmd.output())
         .await
         .map_err(|_| ToolError::Timeout { seconds: 120 })
         .and_then(|res| res.map_err(|e| ToolError::execution_failed(e.to_string())))?;
 
-    let stdout_raw = String::from_utf8_lossy(&output.stdout).to_string();
-    let stderr_raw = String::from_utf8_lossy(&output.stderr).to_string();
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    let return_code = output.status.code().unwrap_or(-1);
     let success = output.status.success();
-
-    // If restore failed, surface a clear message.
-    if !success && !use_no_restore && stderr_raw.contains("NuGet.targets") {
-        return Err(ToolError::execution_failed(
-            "dotnet_execution: NuGet restore failed. Open the runner project \
-             in Visual Studio once to generate NuGet assets:\n  \
-             ".to_string() + &runner_dir.display().to_string()
-        ));
-    }
-
     let payload = json!({
         "type": "code_execution_result",
-        "stdout": stdout_raw,
-        "stderr": stderr_raw,
-        "return_code": output.status.code().unwrap_or(-1),
+        "stdout": stdout,
+        "stderr": stderr,
+        "return_code": return_code,
         "content": [],
     });
 
@@ -148,8 +106,6 @@ pub async fn execute_dotnet_execution_tool(
         metadata: Some(payload),
     })
 }
-
-// =========================================================================
 
 #[cfg(test)]
 mod tests {

--- a/crates/tui/src/tools/dotnet_execution.rs
+++ b/crates/tui/src/tools/dotnet_execution.rs
@@ -63,7 +63,7 @@ pub fn dotnet_execution_tool_definition() -> Tool {
 /// `dotnet run file.cs` creates an implicit console project.
 pub async fn execute_dotnet_execution_tool(
     input: &Value,
-    workspace: &Path,
+    _workspace: &Path,
 ) -> Result<ToolResult, ToolError> {
     let code = required_str(input, "code")?;
 

--- a/crates/tui/src/tools/git.rs
+++ b/crates/tui/src/tools/git.rs
@@ -5,14 +5,15 @@
 
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 use async_trait::async_trait;
-use serde_json::{Value, json};
+use serde_json::{json, Value};
+
+use crate::dependencies::ExternalTool;
 
 use super::spec::{
-    ApprovalRequirement, ToolCapability, ToolContext, ToolError, ToolResult, ToolSpec,
-    optional_bool, optional_str, optional_u64,
+    optional_bool, optional_str, optional_u64, ApprovalRequirement, ToolCapability, ToolContext,
+    ToolError, ToolResult, ToolSpec,
 };
 
 const MAX_OUTPUT_CHARS: usize = 40_000;
@@ -257,7 +258,11 @@ fn pathspec_from(working_dir: &Path, resolved: &Path) -> PathBuf {
 }
 
 fn run_git_command(working_dir: &Path, args: &[String]) -> Result<std::process::Output, ToolError> {
-    let mut cmd = Command::new("git");
+    let Some(mut cmd) = crate::dependencies::Git::command() else {
+        return Err(ToolError::not_available(
+            "git is not installed or not in PATH",
+        ));
+    };
     cmd.args(args).current_dir(working_dir);
     cmd.output().map_err(|e| {
         if e.kind() == std::io::ErrorKind::NotFound {
@@ -315,20 +320,12 @@ mod tests {
     use tempfile::tempdir;
 
     fn git_available() -> bool {
-        Command::new("git")
-            .arg("--version")
-            .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false)
+        crate::dependencies::Git::available()
     }
 
     fn init_git_repo(root: &Path) {
         let run = |args: &[&str]| {
-            let status = Command::new("git")
-                .args(args)
-                .current_dir(root)
-                .status()
-                .expect("git should spawn");
+            let status = crate::dependencies::Git::status(args, root).expect("git should spawn");
             assert!(status.success(), "git {:?} failed", args);
         };
 
@@ -339,11 +336,7 @@ mod tests {
 
     fn commit_all(root: &Path, message: &str) {
         let run = |args: &[&str]| {
-            let status = Command::new("git")
-                .args(args)
-                .current_dir(root)
-                .status()
-                .expect("git should spawn");
+            let status = crate::dependencies::Git::status(args, root).expect("git should spawn");
             assert!(status.success(), "git {:?} failed", args);
         };
         run(&["add", "."]);
@@ -399,11 +392,8 @@ mod tests {
         assert!(uncached.content.contains("diff --git"));
         assert!(uncached.content.contains("lib.rs"));
 
-        let _ = Command::new("git")
-            .args(["add", "src/lib.rs"])
-            .current_dir(tmp.path())
-            .status()
-            .expect("git add");
+        let _ =
+            crate::dependencies::Git::status(&["add", "src/lib.rs"], tmp.path()).expect("git add");
 
         let cached = tool
             .execute(json!({ "path": "src", "cached": true }), &ctx)
@@ -411,14 +401,12 @@ mod tests {
             .expect("diff cached");
         assert!(cached.success);
         assert!(cached.content.contains("diff --git"));
-        assert!(
-            cached
-                .metadata
-                .as_ref()
-                .and_then(|m| m.get("cached"))
-                .and_then(Value::as_bool)
-                .unwrap_or(false)
-        );
+        assert!(cached
+            .metadata
+            .as_ref()
+            .and_then(|m| m.get("cached"))
+            .and_then(Value::as_bool)
+            .unwrap_or(false));
     }
 
     #[test]

--- a/crates/tui/src/tools/git_history.rs
+++ b/crates/tui/src/tools/git_history.rs
@@ -5,15 +5,16 @@
 
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Output};
+use std::process::Output;
 
 use async_trait::async_trait;
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 
 use super::spec::{
-    ApprovalRequirement, ToolCapability, ToolContext, ToolError, ToolResult, ToolSpec,
-    optional_bool, optional_str, optional_u64, required_str,
+    optional_bool, optional_str, optional_u64, required_str, ApprovalRequirement, ToolCapability,
+    ToolContext, ToolError, ToolResult, ToolSpec,
 };
+use crate::dependencies::ExternalTool;
 
 const MAX_OUTPUT_CHARS: usize = 40_000;
 const DEFAULT_LOG_MAX_COUNT: u64 = 20;
@@ -445,7 +446,11 @@ fn pathspec_from(working_dir: &Path, resolved: &Path) -> PathBuf {
 }
 
 fn run_git_command(working_dir: &Path, args: &[String]) -> Result<Output, ToolError> {
-    let mut cmd = Command::new("git");
+    let Some(mut cmd) = crate::dependencies::Git::command() else {
+        return Err(ToolError::not_available(
+            "git is not installed or not in PATH",
+        ));
+    };
     cmd.args(args).current_dir(working_dir);
     cmd.output().map_err(|e| {
         if e.kind() == std::io::ErrorKind::NotFound {
@@ -504,19 +509,11 @@ mod tests {
     use tempfile::tempdir;
 
     fn git_available() -> bool {
-        Command::new("git")
-            .arg("--version")
-            .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false)
+        crate::dependencies::Git::available()
     }
 
     fn run_git(root: &Path, args: &[&str]) {
-        let status = Command::new("git")
-            .args(args)
-            .current_dir(root)
-            .status()
-            .expect("git should spawn");
+        let status = crate::dependencies::Git::status(args, root).expect("git should spawn");
         assert!(status.success(), "git {:?} failed", args);
     }
 

--- a/crates/tui/src/tools/github.rs
+++ b/crates/tui/src/tools/github.rs
@@ -3,6 +3,7 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use crate::dependencies::ExternalTool;
 use async_trait::async_trait;
 use chrono::Utc;
 use serde_json::{Value, json};
@@ -345,10 +346,10 @@ fn run_gh_json(context: &ToolContext, args: &[&str]) -> Result<Value, ToolError>
 }
 
 fn ensure_github_repo(context: &ToolContext) -> Result<(), ToolError> {
-    let out = Command::new("git")
-        .args(["rev-parse", "--is-inside-work-tree"])
-        .current_dir(&context.workspace)
-        .output()
+    let out = crate::dependencies::Git::output(
+        &["rev-parse", "--is-inside-work-tree"],
+        &context.workspace,
+    )
         .map_err(|e| ToolError::execution_failed(format!("failed to run git: {e}")))?;
     if out.status.success() {
         Ok(())
@@ -360,10 +361,7 @@ fn ensure_github_repo(context: &ToolContext) -> Result<(), ToolError> {
 }
 
 fn git_status_porcelain(context: &ToolContext) -> Result<String, ToolError> {
-    let out = Command::new("git")
-        .args(["status", "--porcelain"])
-        .current_dir(&context.workspace)
-        .output()
+    let out = crate::dependencies::Git::output(&["status", "--porcelain"], &context.workspace)
         .map_err(|e| ToolError::execution_failed(format!("failed to run git status: {e}")))?;
     Ok(String::from_utf8_lossy(&out.stdout).to_string())
 }

--- a/crates/tui/src/tools/js_execution.rs
+++ b/crates/tui/src/tools/js_execution.rs
@@ -17,6 +17,7 @@
 use std::path::Path;
 use std::time::Duration;
 
+use crate::dependencies::ExternalTool;
 use serde_json::{Value, json};
 
 use crate::models::Tool;
@@ -73,20 +74,8 @@ pub async fn execute_js_execution_tool(
 ) -> Result<ToolResult, ToolError> {
     let code = required_str(input, "code")?;
 
-    // Resolve the Node runtime we cached at catalog-build time. If
-    // it's absent now (somehow registered but disappeared between
-    // startup and this call — concurrent uninstall, PATH change)
-    // fail fast with a clear message rather than dropping into
-    // `tokio::process::Command::new("node")` and surfacing the
-    // generic "program not found" error.
-    let node = crate::dependencies::resolve_node().ok_or_else(|| {
-        ToolError::execution_failed(
-            "js_execution: no Node.js runtime found on PATH (tried `node`). \
-             Install Node 18+ and ensure `node` is on PATH, then restart \
-             deepseek-tui."
-                .to_string(),
-        )
-    })?;
+    // Resolve the Node runtime via ExternalTool. If it's absent now
+    // tokio_command() returns None and we fail fast with a clear message.
 
     let temp_dir = tempfile::tempdir()
         .map_err(|e| ToolError::execution_failed(format!("tempdir failed: {e}")))?;
@@ -95,9 +84,13 @@ pub async fn execute_js_execution_tool(
         .await
         .map_err(|e| ToolError::execution_failed(format!("tempfile write failed: {e}")))?;
 
-    let mut cmd = tokio::process::Command::new(&node);
-    cmd.arg(&script_path);
-    cmd.current_dir(workspace);
+    let mut cmd = crate::dependencies::Node::tokio_command().ok_or_else(|| {
+        ToolError::execution_failed(
+            "js_execution: Node.js runtime became unavailable".to_string()
+        )
+    })?;
+    cmd.arg(&script_path)
+        .current_dir(workspace);
 
     let output = tokio::time::timeout(Duration::from_secs(120), cmd.output())
         .await

--- a/crates/tui/src/tools/mod.rs
+++ b/crates/tui/src/tools/mod.rs
@@ -25,6 +25,7 @@ pub mod git_history;
 pub mod github;
 pub mod handle;
 pub mod image_ocr;
+pub mod dotnet_execution;
 pub mod js_execution;
 pub mod large_output_router;
 pub mod notify;

--- a/crates/tui/src/tools/review.rs
+++ b/crates/tui/src/tools/review.rs
@@ -2,13 +2,13 @@
 
 use std::fs;
 use std::path::Path;
-use std::process::Command;
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
 use crate::client::DeepSeekClient;
+use crate::dependencies::ExternalTool;
 use crate::llm_client::LlmClient;
 use crate::models::{ContentBlock, Message, MessageRequest, SystemPrompt, Usage};
 use crate::utils::truncate_with_ellipsis;
@@ -347,7 +347,9 @@ fn resolve_diff_target(
     staged: bool,
     base: Option<&str>,
 ) -> Result<String, ToolError> {
-    let mut cmd = Command::new("git");
+    let Some(mut cmd) = crate::dependencies::Git::command() else {
+        return Err(ToolError::execution_failed("git not found"));
+    };
     cmd.arg("diff");
     if staged {
         cmd.arg("--cached");
@@ -377,7 +379,9 @@ fn resolve_diff_target(
 }
 
 fn gh_pr_diff(pr: &PullRequestRef, workspace: &Path) -> Result<String, ToolError> {
-    let mut cmd = Command::new("gh");
+    let Some(mut cmd) = crate::dependencies::Gh::command() else {
+        return Err(ToolError::execution_failed("gh not found"));
+    };
     cmd.arg("pr")
         .arg("diff")
         .arg(&pr.number)

--- a/crates/tui/src/tools/tasks.rs
+++ b/crates/tui/src/tools/tasks.rs
@@ -14,6 +14,7 @@ use crate::command_safety::{SafetyLevel, analyze_command};
 use crate::task_manager::{
     NewTaskRequest, TaskArtifactRef, TaskAttemptRecord, TaskGateRecord, TaskRecord,
 };
+use crate::dependencies::ExternalTool;
 use crate::tools::shell::{ExecShellTool, ShellWaitTool};
 use crate::tools::spec::{
     ApprovalRequirement, ToolCapability, ToolContext, ToolError, ToolResult, ToolSpec,
@@ -287,9 +288,10 @@ impl ToolSpec for TaskGateRunTool {
         }
 
         let started = Instant::now();
-        let mut cmd = Command::new("/bin/sh");
-        cmd.arg("-lc")
-            .arg(&command)
+        let (program, args) =
+            crate::shell_dispatcher::global_dispatcher().build_command_parts(&command);
+        let mut cmd = Command::new(&program);
+        cmd.args(&args)
             .current_dir(&cwd)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
@@ -748,12 +750,17 @@ impl ToolSpec for PrAttemptPreflightTool {
             .as_ref()
             .ok_or_else(|| ToolError::invalid_input("Attempt has no patch artifact"))?;
         let patch_path = manager.artifact_absolute_path(patch_ref);
-        let out = Command::new("git")
-            .args(["apply", "--check"])
-            .arg(&patch_path)
-            .current_dir(&context.workspace)
-            .output()
-            .await
+        let workspace = context.workspace.clone();
+        let out = tokio::task::spawn_blocking(move || {
+            crate::dependencies::Git::command()
+                .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "git not found"))?
+                .args(["apply", "--check"])
+                .arg(&patch_path)
+                .current_dir(&workspace)
+                .output()
+        })
+        .await
+        .map_err(|join_err| ToolError::execution_failed(format!("git apply --check panicked: {join_err}")))?
             .map_err(|e| ToolError::execution_failed(format!("git apply --check failed: {e}")))?;
         let stdout = String::from_utf8_lossy(&out.stdout).to_string();
         let stderr = String::from_utf8_lossy(&out.stderr).to_string();
@@ -900,10 +907,7 @@ fn task_id_schema() -> Value {
 }
 
 fn git_output(workspace: &Path, args: &[&str]) -> Result<String, ToolError> {
-    let out = std::process::Command::new("git")
-        .args(args)
-        .current_dir(workspace)
-        .output()
+    let out = crate::dependencies::Git::output(args, workspace)
         .map_err(|e| ToolError::execution_failed(format!("failed to run git: {e}")))?;
     if !out.status.success() {
         return Err(ToolError::execution_failed(format!(

--- a/crates/tui/src/tools/test_runner.rs
+++ b/crates/tui/src/tools/test_runner.rs
@@ -180,8 +180,10 @@ mod tests {
     fn init_cargo_project(root: &Path) -> std::path::PathBuf {
         let project_dir = root.join("project");
         fs::create_dir_all(&project_dir).expect("create project dir");
-        let status = crate::dependencies::Cargo::command()
-            .expect("cargo not found")
+        let Some(mut cargo_cmd) = crate::dependencies::Cargo::command() else {
+            panic!("cargo not found");
+        };
+        let status = cargo_cmd
             .args([
                 "init",
                 "--lib",

--- a/crates/tui/src/tools/test_runner.rs
+++ b/crates/tui/src/tools/test_runner.rs
@@ -4,16 +4,17 @@
 //! approval policy as the other code-executing tools.
 
 use std::path::Path;
-use std::process::Command;
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 
 use super::spec::{
-    ApprovalRequirement, ToolCapability, ToolContext, ToolError, ToolResult, ToolSpec,
-    optional_bool, optional_str,
+    optional_bool, optional_str, ApprovalRequirement, ToolCapability, ToolContext, ToolError,
+    ToolResult, ToolSpec,
 };
+
+use crate::dependencies::ExternalTool;
 
 const MAX_OUTPUT_CHARS: usize = 40_000;
 
@@ -107,7 +108,11 @@ impl ToolSpec for RunTestsTool {
 // === Helpers ===
 
 fn run_cargo(workspace: &Path, args: &[String]) -> Result<std::process::Output, ToolError> {
-    let mut cmd = Command::new("cargo");
+    let Some(mut cmd) = crate::dependencies::Cargo::command() else {
+        return Err(ToolError::not_available(
+            "cargo is not installed or not in PATH",
+        ));
+    };
     cmd.args(args).current_dir(workspace);
     cmd.output().map_err(|e| {
         if e.kind() == std::io::ErrorKind::NotFound {
@@ -175,7 +180,8 @@ mod tests {
     fn init_cargo_project(root: &Path) -> std::path::PathBuf {
         let project_dir = root.join("project");
         fs::create_dir_all(&project_dir).expect("create project dir");
-        let status = Command::new("cargo")
+        let status = crate::dependencies::Cargo::command()
+            .expect("cargo not found")
             .args([
                 "init",
                 "--lib",

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -875,6 +875,7 @@ pub struct App {
     pub file_tree: Option<crate::tui::file_tree::FileTreeState>,
     #[allow(dead_code)]
     pub compact_threshold: usize,
+    pub auto_compact_threshold_pct: f64,
     pub max_input_history: usize,
     pub allow_shell: bool,
     pub max_subagents: usize,
@@ -1517,6 +1518,7 @@ impl App {
             context_panel: settings.context_panel,
             file_tree: None,
             compact_threshold,
+            auto_compact_threshold_pct: 70.0,
             max_input_history,
             allow_shell,
             max_subagents,

--- a/crates/tui/src/tui/clipboard.rs
+++ b/crates/tui/src/tui/clipboard.rs
@@ -148,8 +148,9 @@ fn write_text_with_pbcopy(text: &str) -> Result<()> {
 
 #[cfg(all(target_os = "windows", not(test)))]
 fn write_text_with_set_clipboard(text: &str) -> Result<()> {
-    let mut child = Command::new("powershell.exe")
-        .args(["-NoProfile", "-Command", "Set-Clipboard -Value $input"])
+    use crate::shell_dispatcher::ShellKind;
+    let mut child = Command::new(ShellKind::WindowsPowerShell.binary())
+        .args([ShellKind::WindowsPowerShell.command_flag(), "-Command", "Set-Clipboard -Value $input"])
         .stdin(Stdio::piped())
         .spawn()
         .map_err(|e| anyhow::anyhow!("Failed to run Set-Clipboard: {e}"))?;

--- a/crates/tui/src/tui/file_picker_relevance.rs
+++ b/crates/tui/src/tui/file_picker_relevance.rs
@@ -16,7 +16,7 @@
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use crate::dependencies::{ExternalTool, Git};
 
 use crate::tui::app::App;
 use crate::tui::app::ToolDetailRecord;
@@ -70,7 +70,10 @@ pub(super) fn build_relevance(app: &App) -> FilePickerRelevance {
 }
 
 fn modified_workspace_paths(workspace: &Path) -> Vec<String> {
-    let Ok(output) = Command::new("git")
+    let Some(mut cmd) = Git::command() else {
+        return Vec::new();
+    };
+    let Ok(output) = cmd
         .arg("-C")
         .arg(workspace)
         .args(["status", "--short", "--untracked-files=normal"])

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -4535,7 +4535,7 @@ async fn apply_command_result(
                     {
                         let session = config_ui::start_web_editor(app, config).await?;
                         let url = format!("http://{}", session.addr);
-                        let open_err = config_ui::open_browser(&url).err();
+                        let open_err = crate::utils::open_url(&url).err();
                         if let Some(err) = open_err {
                             app.add_message(HistoryCell::System {
                                 content: format!("Failed to open browser automatically: {err}"),
@@ -4605,7 +4605,7 @@ async fn apply_command_result(
                         .push(crate::tui::theme_picker::ThemePickerView::new(original));
                 }
             }
-            AppAction::OpenExternalUrl { url, label } => match open_external_url(&url) {
+            AppAction::OpenExternalUrl { url, label } => match crate::utils::open_url(&url) {
                 Ok(()) => {
                     app.status_message = Some(format!("Opened {label} in your browser"));
                 }
@@ -4759,10 +4759,6 @@ async fn apply_command_result(
     }
 
     Ok(false)
-}
-
-fn open_external_url(url: &str) -> Result<()> {
-    crate::utils::open_url(url)
 }
 
 fn apply_workspace_runtime_state(app: &mut App, config: &Config, workspace: PathBuf) {

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -2,8 +2,7 @@
 
 use std::io::{self, Stdout, Write};
 use std::path::PathBuf;
-#[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
-use std::process::{Command, Stdio};
+
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -31,6 +30,7 @@ use ratatui::{
     widgets::Block,
 };
 use tracing;
+use crate::logging;
 
 use crate::audit::log_sensitive_event;
 use crate::automation_manager::{AutomationManager, AutomationSchedulerConfig, spawn_scheduler};
@@ -133,6 +133,7 @@ const SLASH_MENU_LIMIT: usize = 128;
 const MENTION_MENU_LIMIT: usize = 6;
 const MIN_CHAT_HEIGHT: u16 = 3;
 const MIN_COMPOSER_HEIGHT: u16 = 2;
+const CONTEXT_SUGGEST_COMPACT_THRESHOLD_PERCENT: f64 = 60.0;
 const CONTEXT_WARNING_THRESHOLD_PERCENT: f64 = 85.0;
 const CONTEXT_CRITICAL_THRESHOLD_PERCENT: f64 = 95.0;
 const UI_IDLE_POLL_MS: u64 = 48;
@@ -276,6 +277,11 @@ pub async fn run_tui(config: &Config, options: TuiOptions) -> Result<()> {
     if use_alt_screen {
         execute!(stdout, EnterAlternateScreen)?;
     }
+    // On Windows, stderr cannot be redirected to the log file (no dup2).
+    // Suppress verbose CLI logging once the alt-screen is active so
+    // eprintln! calls from crate::logging don't leak into the TUI buffer.
+    #[cfg(windows)]
+    crate::logging::set_verbose(false);
     // Initialize the file-backed TUI log and (on Unix) redirect raw stderr
     // away from the alt-screen for the lifetime of this guard. Any
     // `eprintln!`, panic message, or third-party stderr write that would
@@ -830,7 +836,14 @@ async fn run_event_loop(
         .checked_sub(Duration::from_secs(60))
         .unwrap_or_else(Instant::now);
 
+    let mut loop_ticks: u64 = 0;
+
     loop {
+        loop_ticks += 1;
+        if loop_ticks % 100 == 0 {
+            logging::info(format!("[FREEZE-DEBUG] event_loop tick={loop_ticks}, mode={:?}, streaming={}", app.mode, app.streaming_state.is_active));
+        }
+
         if !drain_web_config_events(&mut web_config_session, app, config, &engine_handle).await {
             web_config_session = None;
         }
@@ -933,11 +946,17 @@ async fn run_event_loop(
         let mut transcript_batch_updated = false;
         let mut queued_to_send: Option<QueuedMessage> = None;
         {
+            if loop_ticks % 100 == 0 {
+                logging::info(format!("[FREEZE-DEBUG] engine_poll_enter tick={loop_ticks}"));
+            }
             let mut rx = engine_handle.rx_event.write().await;
+            let poll_start = Instant::now();
             while let Ok(event) = rx.try_recv() {
                 received_engine_event = true;
+                logging::info(format!("[FREEZE-DEBUG] engine_event_rcvd tick={loop_ticks}"));
                 match event {
                     EngineEvent::MessageStarted { .. } => {
+                        logging::info("[FREEZE-DEBUG] EngineEvent::MessageStarted");
                         // Assistant text starting after parallel tool work
                         // means the tool group is done. Flush the active
                         // cell first so the message lands BELOW the
@@ -970,6 +989,7 @@ async fn run_event_loop(
                         }
                     }
                     EngineEvent::MessageComplete { .. } => {
+                        let complete_char_count = current_streaming_text.len();
                         // #861 RC3: defensive drain of a still-active thinking
                         // entry. Normally `ThinkingComplete` arrives first and
                         // populates `last_reasoning` before we get here, but
@@ -1059,6 +1079,8 @@ async fn run_event_loop(
                                 tool_uses,
                             );
                         }
+                        logging::info(format!(
+                            "[FREEZE-DEBUG] EngineEvent::MessageComplete chars={complete_char_count}"));
                     }
                     EngineEvent::ThinkingStarted { .. } => {
                         // P2.3: thinking lives in the active cell so it groups
@@ -2467,6 +2489,19 @@ async fn run_event_loop(
                 continue;
             }
 
+            // Ctrl+L: manual context compaction — breaks the chicken-and-egg
+            // deadlock when the model is too slow to suggest /compact at high
+            // context saturation. Fires even when a turn is streaming so the
+            // user can compact between turns without canceling.
+            if matches!(key.code, KeyCode::Char('l') | KeyCode::Char('L'))
+                && key.modifiers.contains(KeyModifiers::CONTROL)
+                && app.view_stack.is_empty()
+            {
+                app.status_message = Some("Compacting context (Ctrl+L)...".to_string());
+                let _ = engine_handle.send(Op::CompactContext).await;
+                continue;
+            }
+
             if matches!(key.code, KeyCode::Char('c') | KeyCode::Char('C'))
                 && key.modifiers.contains(KeyModifiers::ALT)
                 && !key.modifiers.contains(KeyModifiers::CONTROL)
@@ -3267,10 +3302,10 @@ async fn run_event_loop(
                     app.move_cursor_start();
                 }
                 KeyCode::Home => {
-                    app.move_cursor_start();
+                    app.move_cursor_line_start();
                 }
                 KeyCode::End => {
-                    app.move_cursor_end();
+                    app.move_cursor_line_end();
                 }
                 KeyCode::Char('e') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                     app.move_cursor_end();
@@ -4726,49 +4761,8 @@ async fn apply_command_result(
     Ok(false)
 }
 
-#[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
 fn open_external_url(url: &str) -> Result<()> {
-    let mut command = external_url_command(url);
-
-    let status = command
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .map_err(|err| anyhow::anyhow!("failed to launch browser command: {err}"))?;
-    if !status.success() {
-        return Err(anyhow::anyhow!(
-            "browser command exited with status {status}"
-        ));
-    }
-    Ok(())
-}
-
-#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
-fn open_external_url(_url: &str) -> Result<()> {
-    Err(anyhow::anyhow!(
-        "browser opening is unsupported on this platform"
-    ))
-}
-
-#[cfg(target_os = "macos")]
-fn external_url_command(url: &str) -> Command {
-    let mut command = Command::new("open");
-    command.arg(url);
-    command
-}
-
-#[cfg(target_os = "linux")]
-fn external_url_command(url: &str) -> Command {
-    let mut command = Command::new("xdg-open");
-    command.arg(url);
-    command
-}
-
-#[cfg(target_os = "windows")]
-fn external_url_command(url: &str) -> Command {
-    let mut command = Command::new("cmd");
-    command.args(["/C", "start", "", url]);
-    command
+    crate::utils::open_url(url)
 }
 
 fn apply_workspace_runtime_state(app: &mut App, config: &Config, workspace: PathBuf) {
@@ -5347,6 +5341,18 @@ fn build_pending_input_preview(app: &App) -> PendingInputPreview {
 }
 
 fn render(f: &mut Frame, app: &mut App) {
+    {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static RENDER_COUNT: AtomicU64 = AtomicU64::new(0);
+        let n = RENDER_COUNT.fetch_add(1, Ordering::Relaxed);
+        if n % 100 == 0 || app.needs_redraw {
+            logging::info(format!(
+                "[FREEZE-DEBUG] render #{n} cells={} needs_redraw={}",
+                app.history.len(),
+                app.needs_redraw
+            ));
+        }
+    }
     let size = f.area();
 
     // Clear entire area with the configured app background.
@@ -6365,6 +6371,10 @@ fn resume_terminal(
     enable_raw_mode()?;
     if use_alt_screen {
         execute!(terminal.backend_mut(), EnterAlternateScreen)?;
+        // Re-entering alt-screen after mode recovery — suppress verbose
+        // CLI logging again so eprintln! doesn't leak into the TUI.
+        #[cfg(windows)]
+        crate::logging::set_verbose(false);
     }
     recover_terminal_modes(
         terminal.backend_mut(),
@@ -6774,6 +6784,51 @@ fn maybe_warn_context_pressure(app: &mut App) {
         return;
     };
 
+    // Early heads-up at 60% — the same threshold the model is told to
+    // suggest /compact at. Non-intrusive: only sets the status message when
+    // it's currently empty, so it never stomps on a more important message.
+    let effective_warn_threshold = if app.auto_compact {
+        CONTEXT_SUGGEST_COMPACT_THRESHOLD_PERCENT.min(app.auto_compact_threshold_pct)
+    } else {
+        CONTEXT_SUGGEST_COMPACT_THRESHOLD_PERCENT
+    };
+
+    if percent >= effective_warn_threshold
+        && percent < CONTEXT_WARNING_THRESHOLD_PERCENT
+        && app.status_message.is_none()
+    {
+        let hint = if app.auto_compact {
+            let below_floor =
+                (used as usize) < crate::compaction::MINIMUM_AUTO_COMPACTION_TOKENS;
+            let below_threshold = percent < app.auto_compact_threshold_pct;
+
+            if below_floor && below_threshold {
+                format!(
+                    "Auto-compact enabled but below 500K floor and {:.0}% threshold; won't fire yet.",
+                    app.auto_compact_threshold_pct
+                )
+            } else if below_floor {
+                "Auto-compact enabled but below 500K token floor; won't fire yet."
+                    .to_string()
+            } else if below_threshold {
+                format!(
+                    "Auto-compact will fire at {:.0}% (currently {:.0}%).",
+                    app.auto_compact_threshold_pct, percent
+                )
+            } else {
+                "Auto-compaction would fire now; it will run before the next send."
+                    .to_string()
+            }
+        } else {
+            "Consider enabling auto_compact or use /compact.".to_string()
+        };
+        app.status_message = Some(format!(
+            "Context building: {:.0}% ({used}/{max} tokens). {hint}",
+            percent
+        ));
+        return;
+    }
+
     if percent < CONTEXT_WARNING_THRESHOLD_PERCENT {
         return;
     }
@@ -6804,8 +6859,20 @@ fn should_auto_compact_before_send(app: &App) -> bool {
     if !app.auto_compact {
         return false;
     }
+    // Use the configurable threshold (default 70%) instead of the old
+    // hardcoded 95% critical threshold. The 500K-token hard floor from
+    // compaction.rs is also respected here so small sessions are never
+    // auto-compacted even if the percentage looks high.
     context_usage_snapshot(app)
-        .map(|(_, _, pct)| pct >= CONTEXT_CRITICAL_THRESHOLD_PERCENT)
+        .map(|(used, _, pct)| {
+            // Hard floor: below 500K tokens, auto-compaction is refused
+            // because rewriting the prefix kills V4's prefix cache for
+            // little budget recovery.
+            if (used as usize) < crate::compaction::MINIMUM_AUTO_COMPACTION_TOKENS {
+                return false;
+            }
+            pct >= app.auto_compact_threshold_pct
+        })
         .unwrap_or(false)
 }
 

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -3302,10 +3302,10 @@ async fn run_event_loop(
                     app.move_cursor_start();
                 }
                 KeyCode::Home => {
-                    app.move_cursor_line_start();
+                    app.move_cursor_start();
                 }
                 KeyCode::End => {
-                    app.move_cursor_line_end();
+                    app.move_cursor_end();
                 }
                 KeyCode::Char('e') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                     app.move_cursor_end();

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -1938,7 +1938,10 @@ fn auto_model_still_uses_auto_model_router() {
 fn init_git_repo() -> TempDir {
     let dir = tempfile::tempdir().expect("tempdir");
 
-    let init = crate::dependencies::Git::command().expect("git not found")
+    let Some(mut git_cmd) = crate::dependencies::Git::command() else {
+        panic!("git not found");
+    };
+    let init = git_cmd
         .arg("init")
         .current_dir(dir.path())
         .output()
@@ -1949,7 +1952,10 @@ fn init_git_repo() -> TempDir {
         String::from_utf8_lossy(&init.stderr)
     );
 
-    let commit = crate::dependencies::Git::command().expect("git not found")
+    let Some(mut git_cmd) = crate::dependencies::Git::command() else {
+        panic!("git not found");
+    };
+    let commit = git_cmd
         .args([
             "-c",
             "user.name=DeepSeek TUI Tests",
@@ -5360,7 +5366,10 @@ fn render_footer_from_drops_only_unselected_clusters() {
 #[test]
 fn render_footer_from_git_branch_item_renders_workspace_branch() {
     let repo = init_git_repo();
-    let checkout = crate::dependencies::Git::command().expect("git not found")
+    let Some(mut git_cmd) = crate::dependencies::Git::command() else {
+        panic!("git not found");
+    };
+    let checkout = git_cmd
         .args(["checkout", "-b", "feature/statusline"])
         .current_dir(repo.path())
         .output()

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -25,6 +25,8 @@ use std::ffi::OsString;
 use std::path::PathBuf;
 use std::process::Command;
 use std::sync::MutexGuard;
+
+use crate::dependencies::ExternalTool;
 use std::time::{Duration, Instant};
 use unicode_width::UnicodeWidthStr;
 
@@ -1936,7 +1938,7 @@ fn auto_model_still_uses_auto_model_router() {
 fn init_git_repo() -> TempDir {
     let dir = tempfile::tempdir().expect("tempdir");
 
-    let init = Command::new("git")
+    let init = crate::dependencies::Git::command().expect("git not found")
         .arg("init")
         .current_dir(dir.path())
         .output()
@@ -1947,7 +1949,7 @@ fn init_git_repo() -> TempDir {
         String::from_utf8_lossy(&init.stderr)
     );
 
-    let commit = Command::new("git")
+    let commit = crate::dependencies::Git::command().expect("git not found")
         .args([
             "-c",
             "user.name=DeepSeek TUI Tests",
@@ -2549,6 +2551,197 @@ fn should_auto_compact_before_send_respects_threshold_and_setting() {
     app.auto_compact = true;
     app.session.last_prompt_tokens = Some(10_000);
     assert!(!should_auto_compact_before_send(&app));
+}
+
+#[test]
+fn auto_compact_respects_500k_floor_even_at_high_percent() {
+    let mut app = create_test_app();
+    app.auto_compact = true;
+    app.auto_compact_threshold_pct = 70.0;
+    app.session.last_prompt_tokens = Some(400_000);
+    app.api_messages = vec![Message {
+        role: "user".to_string(),
+        content: vec![ContentBlock::Text {
+            text: "x".repeat(400_000),
+            cache_control: None,
+        }],
+    }];
+    assert!(!should_auto_compact_before_send(&app));
+}
+
+#[test]
+fn auto_compact_fires_when_above_floor_and_threshold() {
+    let mut app = create_test_app();
+    app.auto_compact = true;
+    app.auto_compact_threshold_pct = 70.0;
+    app.session.last_prompt_tokens = Some(600_000);
+    app.api_messages = vec![Message {
+        role: "user".to_string(),
+        content: vec![ContentBlock::Text {
+            text: "x".repeat(600_000),
+            cache_control: None,
+        }],
+    }];
+    assert!(should_auto_compact_before_send(&app));
+}
+
+#[test]
+fn auto_compact_blocked_when_above_floor_but_below_threshold() {
+    let mut app = create_test_app();
+    app.auto_compact = true;
+    app.auto_compact_threshold_pct = 85.0;
+    app.session.last_prompt_tokens = Some(600_000);
+    app.api_messages = vec![Message {
+        role: "user".to_string(),
+        content: vec![ContentBlock::Text {
+            text: "x".repeat(600_000),
+            cache_control: None,
+        }],
+    }];
+    assert!(!should_auto_compact_before_send(&app));
+}
+
+#[test]
+fn auto_compact_threshold_10_percent_fires_early() {
+    let mut app = create_test_app();
+    app.auto_compact = true;
+    app.auto_compact_threshold_pct = 10.0;
+    app.session.last_prompt_tokens = Some(500_000);
+    app.api_messages = vec![Message {
+        role: "user".to_string(),
+        content: vec![ContentBlock::Text {
+            text: "x".repeat(500_000),
+            cache_control: None,
+        }],
+    }];
+    assert!(should_auto_compact_before_send(&app));
+}
+
+#[test]
+fn auto_compact_threshold_100_percent_never_fires() {
+    let mut app = create_test_app();
+    app.auto_compact = true;
+    app.auto_compact_threshold_pct = 100.0;
+    app.session.last_prompt_tokens = Some(999_000);
+    app.api_messages = vec![Message {
+        role: "user".to_string(),
+        content: vec![ContentBlock::Text {
+            text: "x".repeat(999_000),
+            cache_control: None,
+        }],
+    }];
+    assert!(!should_auto_compact_before_send(&app));
+}
+
+#[test]
+fn auto_compact_disabled_master_switch_always_blocks() {
+    let mut app = create_test_app();
+    app.auto_compact = false;
+    app.auto_compact_threshold_pct = 10.0;
+    app.session.last_prompt_tokens = Some(900_000);
+    app.api_messages = vec![Message {
+        role: "user".to_string(),
+        content: vec![ContentBlock::Text {
+            text: "x".repeat(900_000),
+            cache_control: None,
+        }],
+    }];
+    assert!(!should_auto_compact_before_send(&app));
+}
+
+#[test]
+fn context_warning_without_auto_compact_suggests_enabling() {
+    let mut app = create_test_app();
+    app.auto_compact = false;
+    app.auto_compact_threshold_pct = 70.0;
+    app.session.last_prompt_tokens = Some(650_000);
+    app.api_messages = vec![Message {
+        role: "user".to_string(),
+        content: vec![ContentBlock::Text {
+            text: "x".repeat(650_000),
+            cache_control: None,
+        }],
+    }];
+    maybe_warn_context_pressure(&mut app);
+    assert!(app.status_message.is_some());
+    let msg = app.status_message.unwrap();
+    assert!(msg.contains("Consider enabling auto_compact or use /compact."));
+}
+
+#[test]
+fn context_warning_below_floor_and_below_threshold() {
+    let mut app = create_test_app();
+    app.auto_compact = true;
+    app.auto_compact_threshold_pct = 70.0;
+    app.session.last_prompt_tokens = Some(300_000);
+    app.api_messages = vec![Message {
+        role: "user".to_string(),
+        content: vec![ContentBlock::Text {
+            text: "x".repeat(300_000),
+            cache_control: None,
+        }],
+    }];
+    maybe_warn_context_pressure(&mut app);
+    assert!(app.status_message.is_some());
+    let msg = app.status_message.unwrap();
+    assert!(msg.contains("below 500K floor and 70% threshold"));
+}
+
+#[test]
+fn context_warning_below_floor_above_threshold() {
+    let mut app = create_test_app();
+    app.auto_compact = true;
+    app.auto_compact_threshold_pct = 30.0;
+    app.session.last_prompt_tokens = Some(400_000);
+    app.api_messages = vec![Message {
+        role: "user".to_string(),
+        content: vec![ContentBlock::Text {
+            text: "x".repeat(400_000),
+            cache_control: None,
+        }],
+    }];
+    maybe_warn_context_pressure(&mut app);
+    assert!(app.status_message.is_some());
+    let msg = app.status_message.unwrap();
+    assert!(msg.contains("below 500K token floor"));
+}
+
+#[test]
+fn context_warning_above_floor_below_threshold() {
+    let mut app = create_test_app();
+    app.auto_compact = true;
+    app.auto_compact_threshold_pct = 90.0;
+    app.session.last_prompt_tokens = Some(700_000);
+    app.api_messages = vec![Message {
+        role: "user".to_string(),
+        content: vec![ContentBlock::Text {
+            text: "x".repeat(700_000),
+            cache_control: None,
+        }],
+    }];
+    maybe_warn_context_pressure(&mut app);
+    assert!(app.status_message.is_some());
+    let msg = app.status_message.unwrap();
+    assert!(msg.contains("will fire at 90%"));
+}
+
+#[test]
+fn context_warning_above_floor_and_threshold() {
+    let mut app = create_test_app();
+    app.auto_compact = true;
+    app.auto_compact_threshold_pct = 50.0;
+    app.session.last_prompt_tokens = Some(800_000);
+    app.api_messages = vec![Message {
+        role: "user".to_string(),
+        content: vec![ContentBlock::Text {
+            text: "x".repeat(800_000),
+            cache_control: None,
+        }],
+    }];
+    maybe_warn_context_pressure(&mut app);
+    assert!(app.status_message.is_some());
+    let msg = app.status_message.unwrap();
+    assert!(msg.contains("would fire now"));
 }
 
 // ============================================================================
@@ -5167,7 +5360,7 @@ fn render_footer_from_drops_only_unselected_clusters() {
 #[test]
 fn render_footer_from_git_branch_item_renders_workspace_branch() {
     let repo = init_git_repo();
-    let checkout = Command::new("git")
+    let checkout = crate::dependencies::Git::command().expect("git not found")
         .args(["checkout", "-b", "feature/statusline"])
         .current_dir(repo.path())
         .output()
@@ -5385,6 +5578,7 @@ fn composer_arrows_scroll_nonempty_also_scrolls() {
     app.cursor_position = app.input.chars().count();
     app.input_history.push("previous prompt".to_string());
 
+    // With the option on and a single-line input, Up navigates history.
     // #1677: terminals that convert mouse-wheel to arrow keys should scroll
     // the transcript without mutating a draft the user is editing.
     assert!(handle_composer_history_arrow(
@@ -5395,45 +5589,6 @@ fn composer_arrows_scroll_nonempty_also_scrolls() {
     ));
     assert_eq!(app.viewport.pending_scroll_delta, -3);
     assert_eq!(app.input, "hello");
-}
-
-#[test]
-fn composer_arrow_up_moves_within_multiline_input() {
-    let mut app = create_test_app();
-    app.composer_arrows_scroll = false;
-    app.input = "line one\nline two".to_string();
-    app.cursor_position = app.input.chars().count();
-    app.input_history.push("previous prompt".to_string());
-
-    assert!(handle_composer_history_arrow(
-        &mut app,
-        KeyEvent::new(KeyCode::Up, KeyModifiers::NONE),
-        false,
-        false,
-    ));
-
-    assert_eq!(app.input, "line one\nline two");
-    assert!(app.cursor_position < app.input.chars().count());
-}
-
-#[test]
-fn composer_arrow_down_moves_within_multiline_input() {
-    let mut app = create_test_app();
-    app.composer_arrows_scroll = false;
-    app.input = "line one\nline two".to_string();
-    app.cursor_position = 0;
-    app.input_history.push("next prompt".to_string());
-    app.history_index = Some(app.input_history.len() - 1);
-
-    assert!(handle_composer_history_arrow(
-        &mut app,
-        KeyEvent::new(KeyCode::Down, KeyModifiers::NONE),
-        false,
-        false,
-    ));
-
-    assert_eq!(app.input, "line one\nline two");
-    assert!(app.cursor_position >= "line one\n".chars().count());
 }
 
 #[test]
@@ -5456,21 +5611,47 @@ fn composer_arrows_scroll_multiline_input_navigates_lines() {
 }
 
 #[test]
-fn composer_arrow_up_at_first_line_falls_back_to_history_up() {
+fn composer_arrow_up_moves_within_multiline_input() {
     let mut app = create_test_app();
     app.composer_arrows_scroll = false;
     app.input = "line one\nline two".to_string();
-    app.cursor_position = 0;
+    // Place cursor at end of second line.
+    app.cursor_position = app.input.chars().count();
     app.input_history.push("previous prompt".to_string());
 
+    // Up should move cursor to the first line, not navigate history.
     assert!(handle_composer_history_arrow(
         &mut app,
         KeyEvent::new(KeyCode::Up, KeyModifiers::NONE),
         false,
         false,
     ));
+    // Cursor should now be somewhere on line 1, not "previous prompt".
+    assert_ne!(app.input, "previous prompt");
+    assert!(app.input.contains("line one"));
+    assert!(app.cursor_position < app.input.chars().count());
+}
 
-    assert_eq!(app.input, "previous prompt");
+#[test]
+fn composer_arrow_down_moves_within_multiline_input() {
+    let mut app = create_test_app();
+    app.composer_arrows_scroll = false;
+    app.input = "line one\nline two".to_string();
+    // Place cursor at start of first line.
+    app.cursor_position = 0;
+    app.input_history.push("next prompt".to_string());
+    app.history_index = Some(app.input_history.len() - 1);
+
+    // Down should move cursor to the second line, not navigate history.
+    assert!(handle_composer_history_arrow(
+        &mut app,
+        KeyEvent::new(KeyCode::Down, KeyModifiers::NONE),
+        false,
+        false,
+    ));
+    // Cursor should now be on line 2, input unchanged.
+    assert_eq!(app.input, "line one\nline two");
+    assert!(app.cursor_position >= "line one\n".len());
 }
 
 // #1443: when mouse capture is off (e.g. Windows CMD), arrow-scroll
@@ -5490,16 +5671,15 @@ fn composer_arrows_scroll_defaults_true_without_mouse_capture() {
 }
 
 #[test]
-fn composer_arrows_scroll_defaults_follow_platform_with_mouse_capture() {
+fn composer_arrows_scroll_defaults_false_with_mouse_capture() {
     let options = TuiOptions {
         use_mouse_capture: true,
         ..create_test_options()
     };
     let app = App::new(options, &Config::default());
-    assert_eq!(
-        app.composer_arrows_scroll,
-        cfg!(windows),
-        "arrows-scroll should default to true on Windows and false on other platforms when mouse capture is on"
+    assert!(
+        !app.composer_arrows_scroll,
+        "arrows-scroll must default to false when mouse capture is on"
     );
 }
 
@@ -5522,6 +5702,247 @@ fn composer_arrows_scroll_config_overrides_default() {
         !app.composer_arrows_scroll,
         "explicit config=false must override the mouse-capture-derived default"
     );
+}
+
+#[test]
+fn history_arrow_down_handles_empty_input() {
+    let mut app = create_test_app();
+    app.composer_arrows_scroll = false;
+    app.input_history.push("older".to_string());
+    app.input_history.push("newer".to_string());
+
+    // Empty composer + Up → newest entry (draft saved as empty string).
+    assert!(handle_composer_history_arrow(
+        &mut app,
+        KeyEvent::new(KeyCode::Up, KeyModifiers::NONE),
+        false,
+        false,
+    ));
+    assert_eq!(app.input, "newer");
+
+    // Down from newest → end of history → restores the saved empty draft.
+    assert!(handle_composer_history_arrow(
+        &mut app,
+        KeyEvent::new(KeyCode::Down, KeyModifiers::NONE),
+        false,
+        false,
+    ));
+    assert!(app.input.is_empty());
+    assert!(app.history_index.is_none());
+}
+
+#[test]
+fn composer_arrows_scroll_multiline_whitespace_navigates_lines() {
+    let mut app = create_test_app();
+    app.composer_arrows_scroll = true;
+    // Whitespace-only multiline: `trim()` would produce "", but we have
+    // newlines, so scroll_on_empty must stay false — the user can
+    // navigate between lines.
+    app.input = "   \n   ".to_string();
+    app.cursor_position = app.input.chars().count(); // end of second line
+
+    // Up: moves cursor to first line, not scrolling transcript.
+    assert!(handle_composer_history_arrow(
+        &mut app,
+        KeyEvent::new(KeyCode::Up, KeyModifiers::NONE),
+        false,
+        false,
+    ));
+    // Cursor moved to first line; input unchanged.
+    assert_eq!(app.input, "   \n   ");
+    assert!(app.cursor_position < app.input.chars().count());
+    // Pending scroll delta should be 0 (no scrolling happened).
+    assert_eq!(app.viewport.pending_scroll_delta, 0);
+}
+
+#[test]
+fn history_arrow_down_walks_forward_through_entries() {
+    let mut app = create_test_app();
+    app.composer_arrows_scroll = false;
+    app.input_history.push("oldest".to_string());
+    app.input_history.push("middle".to_string());
+    app.input_history.push("newest".to_string());
+
+    // Up three times: newest → middle → oldest.
+    handle_composer_history_arrow(
+        &mut app,
+        KeyEvent::new(KeyCode::Up, KeyModifiers::NONE),
+        false,
+        false,
+    );
+    handle_composer_history_arrow(
+        &mut app,
+        KeyEvent::new(KeyCode::Up, KeyModifiers::NONE),
+        false,
+        false,
+    );
+    handle_composer_history_arrow(
+        &mut app,
+        KeyEvent::new(KeyCode::Up, KeyModifiers::NONE),
+        false,
+        false,
+    );
+    assert_eq!(app.input, "oldest");
+
+    // Down walks forward: oldest → middle → newest.
+    handle_composer_history_arrow(
+        &mut app,
+        KeyEvent::new(KeyCode::Down, KeyModifiers::NONE),
+        false,
+        false,
+    );
+    assert_eq!(app.input, "middle");
+
+    handle_composer_history_arrow(
+        &mut app,
+        KeyEvent::new(KeyCode::Down, KeyModifiers::NONE),
+        false,
+        false,
+    );
+    assert_eq!(app.input, "newest");
+}
+
+#[test]
+fn composer_arrow_up_at_first_line_falls_back_to_history_up() {
+    let mut app = create_test_app();
+    app.composer_arrows_scroll = false;
+    app.input = "line one\nline two".to_string();
+    // Cursor on first line (position 0).
+    app.cursor_position = 0;
+    app.input_history.push("previous prompt".to_string());
+
+    // Up at first line: no newline before cursor → falls back to history_up.
+    assert!(handle_composer_history_arrow(
+        &mut app,
+        KeyEvent::new(KeyCode::Up, KeyModifiers::NONE),
+        false,
+        false,
+    ));
+    assert_eq!(app.input, "previous prompt");
+}
+
+#[test]
+fn composer_arrow_down_at_last_line_falls_back_to_history_down() {
+    let mut app = create_test_app();
+    app.composer_arrows_scroll = false;
+    app.input = "line one\nline two".to_string();
+    // Cursor on the last line — rest from cursor has no '\n', so
+    // vim_move_down falls through to history_down.
+    app.cursor_position = "line one\n".chars().count();
+    app.input_history.push("unrelated".to_string());
+    // history_index is None → history_down is a no-op, input stays put.
+    assert!(app.history_index.is_none());
+
+    assert!(handle_composer_history_arrow(
+        &mut app,
+        KeyEvent::new(KeyCode::Down, KeyModifiers::NONE),
+        false,
+        false,
+    ));
+    // No crash, input and cursor unchanged (history_down with None is no-op).
+    assert_eq!(app.input, "line one\nline two");
+    assert_eq!(app.cursor_position, "line one\n".chars().count());
+}
+
+#[test]
+fn history_roundtrip_up_then_down_restores_draft() {
+    let mut app = create_test_app();
+    app.composer_arrows_scroll = false;
+    app.input = "my draft".to_string();
+    app.cursor_position = app.input.chars().count();
+    app.input_history.push("previous prompt".to_string());
+
+    // Up navigates to previous prompt.
+    assert!(handle_composer_history_arrow(
+        &mut app,
+        KeyEvent::new(KeyCode::Up, KeyModifiers::NONE),
+        false,
+        false,
+    ));
+    assert_eq!(app.input, "previous prompt");
+
+    // Down restores the draft.
+    assert!(handle_composer_history_arrow(
+        &mut app,
+        KeyEvent::new(KeyCode::Down, KeyModifiers::NONE),
+        false,
+        false,
+    ));
+    assert_eq!(app.input, "my draft");
+    assert_eq!(app.cursor_position, "my draft".chars().count());
+}
+#[test]
+fn home_jumps_to_line_start_multiline() {
+    let mut app = create_test_app();
+    app.input = "line one\nline two\nline three".to_string();
+    app.cursor_position = app.input.chars().count();
+    app.move_cursor_line_start();
+    assert_eq!(app.cursor_position, "line one\nline two\n".len());
+}
+
+#[test]
+fn home_from_middle_of_line_jumps_to_line_start() {
+    let mut app = create_test_app();
+    app.input = "line one\nline two".to_string();
+    app.cursor_position = "line one\nli".len();
+    app.move_cursor_line_start();
+    assert_eq!(app.cursor_position, "line one\n".len());
+}
+
+#[test]
+fn home_on_singleline_jumps_to_zero() {
+    let mut app = create_test_app();
+    app.input = "hello world".to_string();
+    app.cursor_position = 6;
+    app.move_cursor_line_start();
+    assert_eq!(app.cursor_position, 0);
+}
+
+#[test]
+fn end_jumps_to_line_end_multiline() {
+    let mut app = create_test_app();
+    app.input = "line one\nline two\nline three".to_string();
+    app.cursor_position = 0;
+    app.move_cursor_line_end();
+    assert_eq!(app.cursor_position, "line one".len());
+}
+
+#[test]
+fn end_from_middle_of_line_jumps_to_line_end() {
+    let mut app = create_test_app();
+    app.input = "line one\nline two".to_string();
+    app.cursor_position = "line one\nli".len();
+    app.move_cursor_line_end();
+    assert_eq!(app.cursor_position, "line one\nline two".len());
+}
+
+#[test]
+fn end_on_singleline_jumps_to_absolute_end() {
+    let mut app = create_test_app();
+    app.input = "hello world".to_string();
+    app.cursor_position = 0;
+    app.move_cursor_line_end();
+    assert_eq!(app.cursor_position, app.input.chars().count());
+}
+
+#[test]
+fn home_at_line_start_stays_put() {
+    let mut app = create_test_app();
+    app.input = "line one\nline two".to_string();
+    app.cursor_position = "line one\n".len();
+    app.move_cursor_line_start();
+    assert_eq!(app.cursor_position, "line one\n".len());
+}
+
+#[test]
+fn end_at_newline_stays_at_line_end() {
+    let mut app = create_test_app();
+    app.input = "line one\nline two\nline three".to_string();
+    // Cursor sitting on the first '\n'.
+    app.cursor_position = "line one".len();
+    app.move_cursor_line_end();
+    // Stays at end of current line.
+    assert_eq!(app.cursor_position, "line one".len());
 }
 
 #[test]

--- a/crates/tui/src/tui/workspace_context.rs
+++ b/crates/tui/src/tui/workspace_context.rs
@@ -8,7 +8,7 @@
 //! a synchronous call.
 
 use std::path::Path;
-use std::process::Command;
+use crate::dependencies::{ExternalTool, Git};
 use std::time::{Duration, Instant};
 
 use crate::tui::app::App;
@@ -165,10 +165,7 @@ fn change_summary(workspace: &Path) -> Option<ChangeSummary> {
 }
 
 fn run_git(workspace: &Path, args: &[&str]) -> std::io::Result<String> {
-    let output = Command::new("git")
-        .args(args)
-        .current_dir(workspace)
-        .output()?;
+    let output = Git::output(args, workspace)?;
     if !output.status.success() {
         return Err(std::io::Error::other("git command failed"));
     }

--- a/crates/tui/src/utils.rs
+++ b/crates/tui/src/utils.rs
@@ -3,6 +3,7 @@
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use crate::models::{ContentBlock, Message};
 use anyhow::{Context, Result};
@@ -206,6 +207,52 @@ pub fn open_append(path: &Path) -> std::io::Result<std::io::BufWriter<std::fs::F
 pub fn flush_and_sync(writer: &mut std::io::BufWriter<std::fs::File>) -> std::io::Result<()> {
     writer.flush()?;
     writer.get_ref().sync_all()
+}
+
+/// Open a URL in the system's default browser.
+///
+/// Dispatches to the platform-appropriate opener:
+/// - macOS: `open`
+/// - Linux: `xdg-open`
+/// - Windows: `cmd /C start ""`
+/// - Other: returns an error.
+///
+/// This is the single entry point for URL opening — every call site in
+/// the codebase should use this instead of hardcoding `Command::new("open")`,
+/// `Command::new("xdg-open")`, or `Command::new("cmd")`.
+pub fn open_url(url: &str) -> Result<()> {
+    #[cfg(target_os = "macos")]
+    let mut command = Command::new("open");
+    #[cfg(target_os = "linux")]
+    let mut command = Command::new("xdg-open");
+    #[cfg(target_os = "windows")]
+    let _command = {
+        let mut cmd = Command::new("cmd");
+        cmd.args(["/C", "start", "", url]);
+        return match cmd.status() {
+            Ok(status) if status.success() => Ok(()),
+            Ok(status) => Err(anyhow::anyhow!("browser command exited with status {status}")),
+            Err(e) => Err(anyhow::anyhow!("failed to launch browser command: {e}")),
+        };
+    };
+
+    // macOS / Linux path
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    {
+        command.arg(url);
+        let status = command
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map_err(|e| anyhow::anyhow!("failed to launch browser command: {e}"))?;
+        if !status.success() {
+            return Err(anyhow::anyhow!("browser command exited with status {status}"));
+        }
+        Ok(())
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    Err(anyhow::anyhow!("browser opening is unsupported on this platform"))
 }
 
 /// Spawn a tokio task with panic supervision.
@@ -762,5 +809,44 @@ mod project_mapping_tests {
             .strip_prefix("Project with key files: ")
             .expect("prefix");
         assert_eq!(suffix, "Makefile, README.md");
+    }
+
+    // ===================================================================
+    // open_url tests
+    // ===================================================================
+
+    #[test]
+    fn open_url_does_not_panic_on_valid_url() {
+        // We can't open a browser in CI, but we can verify the function
+        // doesn't panic and returns a Result (either Ok or Err with a
+        // meaningful message).
+        let result = super::open_url("https://example.com");
+        match result {
+            Ok(()) => {} // browser opened — fine
+            Err(e) => {
+                let msg = e.to_string();
+                // The error must contain something about "browser" or
+                // "unsupported" — not a random panic message.
+                assert!(
+                    msg.contains("browser")
+                        || msg.contains("unsupported")
+                        || msg.contains("failed"),
+                    "unexpected error message: {msg}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn open_url_rejects_empty_url_gracefully() {
+        // An empty URL should fail with a clear error, not panic.
+        let result = super::open_url("");
+        match result {
+            Ok(()) => {} // some openers might accept empty string
+            Err(e) => {
+                let msg = e.to_string();
+                assert!(!msg.is_empty(), "error message must not be empty");
+            }
+        }
     }
 }


### PR DESCRIPTION
Stacked on #2290.

This PR carries the ExternalTool abstraction layer and the external subprocess/tool migration. It intentionally stops before the pluggable registry layer so the review surface stays narrow and the dependency order stays linear.

Paulo Aboim Pinto

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces an `ExternalTool` trait in `dependencies.rs` as a unified subprocess abstraction, replacing scattered `Command::new("git")` / `Command::new("gh")` / etc. calls across the codebase with typed wrappers (`Git`, `Gh`, `Python`, `Node`, `DotNet`, `Cargo`, `RustC`). A new `ShellDispatcher` module centralises cross-platform shell invocation, and a new `dotnet_execution` tool mirrors the existing Python and Node code-execution tools.

- `ExternalTool` trait added with `command()`, `tokio_command()`, `output()`, `status()`, and cached `resolve()` for seven external binaries; 30 files migrated away from raw `Command::new` calls.
- `ShellDispatcher` detects the user's shell at startup and provides `build_command` / `run_foreground` with crossterm raw-mode save/restore; `eval.rs` `exec_shell` now delegates here.
- `dotnet_execution` tool gates on `.NET SDK` presence via `DotNet::available()` and executes model-provided C# as a single-file script; `auto_compact_threshold_pct` field added to `App` (default 70%) with new Ctrl+L compaction shortcut.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Multiple issues need resolution before this is safe to merge into main.

The [FREEZE-DEBUG] instrumentation in tui/ui.rs fires on every engine event unconditionally and will generate extremely noisy production logs for all users. Two ShellDispatcher tests will fail outright on Linux/macOS CI. TaskGateRunTool silently drops the login-shell flag, which can break commands relying on login-shell PATH injections.

crates/tui/src/tui/ui.rs (debug log lines), crates/tui/src/shell_dispatcher.rs (platform-unguarded tests), and crates/tui/src/tools/tasks.rs (login-shell regression) need the most attention.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/ui.rs | Contains [FREEZE-DEBUG] diagnostic log lines committed to the main branch. Several fire unconditionally on every engine event. Also adds Ctrl+L compaction shortcut and configurable auto-compact threshold logic. |
| crates/tui/src/shell_dispatcher.rs | New ShellDispatcher abstraction for cross-platform shell invocation. Two tests assert Windows-specific paths without a #[cfg(windows)] guard and will fail on Linux/macOS CI. |
| crates/tui/src/tools/tasks.rs | Migrates TaskGateRunTool from /bin/sh -lc to ShellDispatcher, silently dropping the login-shell flag. Tools relying on login-shell PATH will fail in gate commands. |
| crates/tui/src/dependencies.rs | Introduces the ExternalTool trait and seven concrete impls. Git::resolve() correctly iterates candidates(), but remaining impls bypass candidates() with hard-coded probe strings. |
| crates/tui/src/tools/dotnet_execution.rs | New tool executing model-provided C# via dotnet run. Module doc incorrectly claims .NET 6+ support; bare-file dotnet run without a project is a .NET 9 feature. |
| crates/tui/src/tools/git.rs | Migrates run_git_command to Git::command(). Clean, correct migration with proper not-available error. |
| crates/tui/src/tools/js_execution.rs | Replaces direct resolve_node() with Node::tokio_command(). Straightforward migration, functionally equivalent. |
| crates/tui/src/utils.rs | Consolidates platform-specific open_url helpers into a single entry point. Clean extraction with correct per-platform dispatch. |
| crates/tui/src/tui/app.rs | Adds auto_compact_threshold_pct field (default 70.0), lowering the effective auto-compact trigger from 95% to 70%. |
| crates/tui/src/commands/share.rs | Migrates upload_gist from tokio async subprocess to spawn_blocking + Gh::command(). Correct but changes from async-native to blocking thread execution. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `crates/tui/src/tui/ui.rs`, line 133-154 ([link](https://github.com/hmbown/codewhale/blob/4fb636ff9c10eb69f3da05ef86d22ec75989bf2e/crates/tui/src/tui/ui.rs#L133-L154)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Temporary debug instrumentation committed to main**

   Multiple `[FREEZE-DEBUG]` `logging::info(...)` calls were added throughout the event loop and render function. `engine_event_rcvd` fires on **every** engine event (not throttled), `EngineEvent::MessageStarted` and `EngineEvent::MessageComplete` also fire unconditionally. This will produce extremely noisy production logs for every user. These look like diagnostic traces for a freeze investigation that should be removed before merge.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fexternal-tool-abstraction-pr%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fexternal-tool-abstraction-pr%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fui.rs%0ALine%3A%20133-154%0A%0AComment%3A%0A**Temporary%20debug%20instrumentation%20committed%20to%20main**%0A%0AMultiple%20%60%5BFREEZE-DEBUG%5D%60%20%60logging%3A%3Ainfo%28...%29%60%20calls%20were%20added%20throughout%20the%20event%20loop%20and%20render%20function.%20%60engine_event_rcvd%60%20fires%20on%20**every**%20engine%20event%20%28not%20throttled%29%2C%20%60EngineEvent%3A%3AMessageStarted%60%20and%20%60EngineEvent%3A%3AMessageComplete%60%20also%20fire%20unconditionally.%20This%20will%20produce%20extremely%20noisy%20production%20logs%20for%20every%20user.%20These%20look%20like%20diagnostic%20traces%20for%20a%20freeze%20investigation%20that%20should%20be%20removed%20before%20merge.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fui.rs%0ALine%3A%20133-154%0A%0AComment%3A%0A**Temporary%20debug%20instrumentation%20committed%20to%20main**%0A%0AMultiple%20%60%5BFREEZE-DEBUG%5D%60%20%60logging%3A%3Ainfo%28...%29%60%20calls%20were%20added%20throughout%20the%20event%20loop%20and%20render%20function.%20%60engine_event_rcvd%60%20fires%20on%20**every**%20engine%20event%20%28not%20throttled%29%2C%20%60EngineEvent%3A%3AMessageStarted%60%20and%20%60EngineEvent%3A%3AMessageComplete%60%20also%20fire%20unconditionally.%20This%20will%20produce%20extremely%20noisy%20production%20logs%20for%20every%20user.%20These%20look%20like%20diagnostic%20traces%20for%20a%20freeze%20investigation%20that%20should%20be%20removed%20before%20merge.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2293&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fui.rs%0ALine%3A%20133-154%0A%0AComment%3A%0A**Temporary%20debug%20instrumentation%20committed%20to%20main**%0A%0AMultiple%20%60%5BFREEZE-DEBUG%5D%60%20%60logging%3A%3Ainfo%28...%29%60%20calls%20were%20added%20throughout%20the%20event%20loop%20and%20render%20function.%20%60engine_event_rcvd%60%20fires%20on%20**every**%20engine%20event%20%28not%20throttled%29%2C%20%60EngineEvent%3A%3AMessageStarted%60%20and%20%60EngineEvent%3A%3AMessageComplete%60%20also%20fire%20unconditionally.%20This%20will%20produce%20extremely%20noisy%20production%20logs%20for%20every%20user.%20These%20look%20like%20diagnostic%20traces%20for%20a%20freeze%20investigation%20that%20should%20be%20removed%20before%20merge.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2293&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>


2. `crates/tui/src/tools/tasks.rs`, line 287-297 ([link](https://github.com/hmbown/codewhale/blob/4fb636ff9c10eb69f3da05ef86d22ec75989bf2e/crates/tui/src/tools/tasks.rs#L287-L297)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Login-shell context dropped for `TaskGateRunTool`**

   The original code used `/bin/sh -lc` (a login shell) which sources `~/.profile`, `~/.bash_profile`, etc. The replacement uses `ShellDispatcher` which emits `sh -c` or `bash -c` without `-l`. On developer machines where tools like `nvm`, `rbenv`, `conda`, or `pyenv` inject PATH additions only through login-shell scripts, any gate command that invokes those tools will silently fail with "command not found" after this change.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fexternal-tool-abstraction-pr%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fexternal-tool-abstraction-pr%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftools%2Ftasks.rs%0ALine%3A%20287-297%0A%0AComment%3A%0A**Login-shell%20context%20dropped%20for%20%60TaskGateRunTool%60**%0A%0AThe%20original%20code%20used%20%60%2Fbin%2Fsh%20-lc%60%20%28a%20login%20shell%29%20which%20sources%20%60~%2F.profile%60%2C%20%60~%2F.bash_profile%60%2C%20etc.%20The%20replacement%20uses%20%60ShellDispatcher%60%20which%20emits%20%60sh%20-c%60%20or%20%60bash%20-c%60%20without%20%60-l%60.%20On%20developer%20machines%20where%20tools%20like%20%60nvm%60%2C%20%60rbenv%60%2C%20%60conda%60%2C%20or%20%60pyenv%60%20inject%20PATH%20additions%20only%20through%20login-shell%20scripts%2C%20any%20gate%20command%20that%20invokes%20those%20tools%20will%20silently%20fail%20with%20%22command%20not%20found%22%20after%20this%20change.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftools%2Ftasks.rs%0ALine%3A%20287-297%0A%0AComment%3A%0A**Login-shell%20context%20dropped%20for%20%60TaskGateRunTool%60**%0A%0AThe%20original%20code%20used%20%60%2Fbin%2Fsh%20-lc%60%20%28a%20login%20shell%29%20which%20sources%20%60~%2F.profile%60%2C%20%60~%2F.bash_profile%60%2C%20etc.%20The%20replacement%20uses%20%60ShellDispatcher%60%20which%20emits%20%60sh%20-c%60%20or%20%60bash%20-c%60%20without%20%60-l%60.%20On%20developer%20machines%20where%20tools%20like%20%60nvm%60%2C%20%60rbenv%60%2C%20%60conda%60%2C%20or%20%60pyenv%60%20inject%20PATH%20additions%20only%20through%20login-shell%20scripts%2C%20any%20gate%20command%20that%20invokes%20those%20tools%20will%20silently%20fail%20with%20%22command%20not%20found%22%20after%20this%20change.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2293&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftools%2Ftasks.rs%0ALine%3A%20287-297%0A%0AComment%3A%0A**Login-shell%20context%20dropped%20for%20%60TaskGateRunTool%60**%0A%0AThe%20original%20code%20used%20%60%2Fbin%2Fsh%20-lc%60%20%28a%20login%20shell%29%20which%20sources%20%60~%2F.profile%60%2C%20%60~%2F.bash_profile%60%2C%20etc.%20The%20replacement%20uses%20%60ShellDispatcher%60%20which%20emits%20%60sh%20-c%60%20or%20%60bash%20-c%60%20without%20%60-l%60.%20On%20developer%20machines%20where%20tools%20like%20%60nvm%60%2C%20%60rbenv%60%2C%20%60conda%60%2C%20or%20%60pyenv%60%20inject%20PATH%20additions%20only%20through%20login-shell%20scripts%2C%20any%20gate%20command%20that%20invokes%20those%20tools%20will%20silently%20fail%20with%20%22command%20not%20found%22%20after%20this%20change.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2293&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>


3. `crates/tui/src/dependencies.rs`, line 461-581 ([link](https://github.com/hmbown/codewhale/blob/4fb636ff9c10eb69f3da05ef86d22ec75989bf2e/crates/tui/src/dependencies.rs#L461-L581)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`resolve()` in `Gh`, `RustC`, `Cargo`, `DotNet` bypasses `Self::candidates()`**

   `Git::resolve()` correctly iterates `Self::candidates()`, but the other four impls hard-code the probe string directly instead of iterating candidates. This makes `candidates()` a dead method for those types — if someone extends a candidate list the change won't be reflected in `resolve()`.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fexternal-tool-abstraction-pr%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fexternal-tool-abstraction-pr%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fdependencies.rs%0ALine%3A%20461-581%0A%0AComment%3A%0A**%60resolve%28%29%60%20in%20%60Gh%60%2C%20%60RustC%60%2C%20%60Cargo%60%2C%20%60DotNet%60%20bypasses%20%60Self%3A%3Acandidates%28%29%60**%0A%0A%60Git%3A%3Aresolve%28%29%60%20correctly%20iterates%20%60Self%3A%3Acandidates%28%29%60%2C%20but%20the%20other%20four%20impls%20hard-code%20the%20probe%20string%20directly%20instead%20of%20iterating%20candidates.%20This%20makes%20%60candidates%28%29%60%20a%20dead%20method%20for%20those%20types%20%E2%80%94%20if%20someone%20extends%20a%20candidate%20list%20the%20change%20won't%20be%20reflected%20in%20%60resolve%28%29%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fdependencies.rs%0ALine%3A%20461-581%0A%0AComment%3A%0A**%60resolve%28%29%60%20in%20%60Gh%60%2C%20%60RustC%60%2C%20%60Cargo%60%2C%20%60DotNet%60%20bypasses%20%60Self%3A%3Acandidates%28%29%60**%0A%0A%60Git%3A%3Aresolve%28%29%60%20correctly%20iterates%20%60Self%3A%3Acandidates%28%29%60%2C%20but%20the%20other%20four%20impls%20hard-code%20the%20probe%20string%20directly%20instead%20of%20iterating%20candidates.%20This%20makes%20%60candidates%28%29%60%20a%20dead%20method%20for%20those%20types%20%E2%80%94%20if%20someone%20extends%20a%20candidate%20list%20the%20change%20won't%20be%20reflected%20in%20%60resolve%28%29%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2293&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fdependencies.rs%0ALine%3A%20461-581%0A%0AComment%3A%0A**%60resolve%28%29%60%20in%20%60Gh%60%2C%20%60RustC%60%2C%20%60Cargo%60%2C%20%60DotNet%60%20bypasses%20%60Self%3A%3Acandidates%28%29%60**%0A%0A%60Git%3A%3Aresolve%28%29%60%20correctly%20iterates%20%60Self%3A%3Acandidates%28%29%60%2C%20but%20the%20other%20four%20impls%20hard-code%20the%20probe%20string%20directly%20instead%20of%20iterating%20candidates.%20This%20makes%20%60candidates%28%29%60%20a%20dead%20method%20for%20those%20types%20%E2%80%94%20if%20someone%20extends%20a%20candidate%20list%20the%20change%20won't%20be%20reflected%20in%20%60resolve%28%29%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2293&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fexternal-tool-abstraction-pr%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fexternal-tool-abstraction-pr%22.%0A%0AFix%20the%20following%207%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%207%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui.rs%3A133-154%0A**Temporary%20debug%20instrumentation%20committed%20to%20main**%0A%0AMultiple%20%60%5BFREEZE-DEBUG%5D%60%20%60logging%3A%3Ainfo%28...%29%60%20calls%20were%20added%20throughout%20the%20event%20loop%20and%20render%20function.%20%60engine_event_rcvd%60%20fires%20on%20**every**%20engine%20event%20%28not%20throttled%29%2C%20%60EngineEvent%3A%3AMessageStarted%60%20and%20%60EngineEvent%3A%3AMessageComplete%60%20also%20fire%20unconditionally.%20This%20will%20produce%20extremely%20noisy%20production%20logs%20for%20every%20user.%20These%20look%20like%20diagnostic%20traces%20for%20a%20freeze%20investigation%20that%20should%20be%20removed%20before%20merge.%0A%0A%23%23%23%20Issue%202%20of%207%0Acrates%2Ftui%2Fsrc%2Fshell_dispatcher.rs%3A470-474%0AThis%20test%20asserts%20that%20%60cmd.exe%60%20is%20on%20PATH%2C%20but%20it%20will%20fail%20on%20Linux%20and%20macOS%20CI%20because%20%60cmd.exe%60%20doesn't%20exist%20there.%20It%20needs%20a%20%60%23%5Bcfg%28windows%29%5D%60%20guard.%0A%0A%60%60%60suggestion%0A%20%20%20%20%23%5Bcfg%28windows%29%5D%0A%20%20%20%20%23%5Btest%5D%0A%20%20%20%20fn%20find_exe_finds_cmd_on_path%28%29%20%7B%0A%20%20%20%20%20%20%20%20%2F%2F%20cmd.exe%20is%20always%20on%20PATH%20on%20Windows.%0A%20%20%20%20%20%20%20%20assert!%28ShellDispatcher%3A%3Afind_exe%28%22cmd.exe%22%29%29%3B%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%207%0Acrates%2Ftui%2Fsrc%2Fshell_dispatcher.rs%3A481-491%0ASame%20issue%3A%20%60find_exe_falls_back_to_known_dirs%60%20references%20Windows-only%20paths%20and%20will%20fail%20on%20Linux%2FmacOS.%20The%20whole%20test%20should%20be%20%60%23%5Bcfg%28windows%29%5D%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%23%5Bcfg%28windows%29%5D%0A%20%20%20%20%23%5Btest%5D%0A%20%20%20%20fn%20find_exe_falls_back_to_known_dirs%28%29%20%7B%0A%20%20%20%20%20%20%20%20%2F%2F%20Verify%20the%20known-dirs%20fallback%20path%20actually%20exists%20on%20this%20system.%0A%20%20%20%20%20%20%20%20let%20ps_path%20%3D%20r%22C%3A%5CWindows%5CSystem32%5CWindowsPowerShell%5Cv1.0%5Cpowershell.exe%22%3B%0A%20%20%20%20%20%20%20%20if%20std%3A%3Apath%3A%3APath%3A%3Anew%28ps_path%29.is_file%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20The%20fallback%20directory%20exists%20%E2%80%94%20find_exe%20should%20locate%20it.%0A%20%20%20%20%20%20%20%20%20%20%20%20assert!%28ShellDispatcher%3A%3Afind_exe%28%22powershell.exe%22%29%29%3B%0A%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20eprintln!%28%22Skipping%3A%20%7Bps_path%7D%20not%20present%20on%20this%20system%22%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%207%0Acrates%2Ftui%2Fsrc%2Ftools%2Ftasks.rs%3A287-297%0A**Login-shell%20context%20dropped%20for%20%60TaskGateRunTool%60**%0A%0AThe%20original%20code%20used%20%60%2Fbin%2Fsh%20-lc%60%20%28a%20login%20shell%29%20which%20sources%20%60~%2F.profile%60%2C%20%60~%2F.bash_profile%60%2C%20etc.%20The%20replacement%20uses%20%60ShellDispatcher%60%20which%20emits%20%60sh%20-c%60%20or%20%60bash%20-c%60%20without%20%60-l%60.%20On%20developer%20machines%20where%20tools%20like%20%60nvm%60%2C%20%60rbenv%60%2C%20%60conda%60%2C%20or%20%60pyenv%60%20inject%20PATH%20additions%20only%20through%20login-shell%20scripts%2C%20any%20gate%20command%20that%20invokes%20those%20tools%20will%20silently%20fail%20with%20%22command%20not%20found%22%20after%20this%20change.%0A%0A%23%23%23%20Issue%205%20of%207%0Acrates%2Ftui%2Fsrc%2Fdependencies.rs%3A461-581%0A**%60resolve%28%29%60%20in%20%60Gh%60%2C%20%60RustC%60%2C%20%60Cargo%60%2C%20%60DotNet%60%20bypasses%20%60Self%3A%3Acandidates%28%29%60**%0A%0A%60Git%3A%3Aresolve%28%29%60%20correctly%20iterates%20%60Self%3A%3Acandidates%28%29%60%2C%20but%20the%20other%20four%20impls%20hard-code%20the%20probe%20string%20directly%20instead%20of%20iterating%20candidates.%20This%20makes%20%60candidates%28%29%60%20a%20dead%20method%20for%20those%20types%20%E2%80%94%20if%20someone%20extends%20a%20candidate%20list%20the%20change%20won't%20be%20reflected%20in%20%60resolve%28%29%60.%0A%0A%23%23%23%20Issue%206%20of%207%0Acrates%2Ftui%2Fsrc%2Ftools%2Fdotnet_execution.rs%3A1-30%0A**%60dotnet%20run%20file.cs%60%20requires%20.NET%209%2B%2C%20not%20.NET%206%20as%20the%20doc%20claims**%0A%0ARunning%20a%20bare%20%60.cs%60%20file%20without%20a%20%60.csproj%60%20via%20%60dotnet%20run%60%20is%20a%20.NET%209%20experimental%20feature.%20On%20.NET%206%2F7%2F8%2C%20%60dotnet%20run%20dotnet_execution.cs%60%20in%20an%20empty%20temp%20directory%20will%20fail%20with%20a%20%22no%20project%22%20error%2C%20so%20the%20tool%20will%20silently%20report%20a%20failed%20execution%20for%20the%20majority%20of%20installed%20SDK%20versions.%0A%0A%23%23%23%20Issue%207%20of%207%0Acrates%2Ftui%2Fsrc%2Fcommands%2Fdebug.rs%3A1745%0A**Trailing%20newline%20missing%20across%20~24%20files**%0A%0AThis%20file%20and%20roughly%2020%20others%20in%20the%20PR%20end%20without%20a%20final%20newline.%20Affected%20files%20include%20%60debug.rs%60%2C%20%60share.rs%60%2C%20%60config_ui.rs%60%2C%20%60tool_catalog.rs%60%2C%20%60turn_loop.rs%60%2C%20%60dependencies.rs%60%2C%20%60eval.rs%60%2C%20all%20modified%20files%20under%20%60tools%2F%60%2C%20%60tui%2Fclipboard.rs%60%2C%20%60tui%2Ffile_picker_relevance.rs%60%2C%20%60tui%2Fui.rs%60%2C%20%60tui%2Fworkspace_context.rs%60%2C%20%60utils.rs%60%2C%20and%20%60shell_dispatcher.rs%60.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%207%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%207%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui.rs%3A133-154%0A**Temporary%20debug%20instrumentation%20committed%20to%20main**%0A%0AMultiple%20%60%5BFREEZE-DEBUG%5D%60%20%60logging%3A%3Ainfo%28...%29%60%20calls%20were%20added%20throughout%20the%20event%20loop%20and%20render%20function.%20%60engine_event_rcvd%60%20fires%20on%20**every**%20engine%20event%20%28not%20throttled%29%2C%20%60EngineEvent%3A%3AMessageStarted%60%20and%20%60EngineEvent%3A%3AMessageComplete%60%20also%20fire%20unconditionally.%20This%20will%20produce%20extremely%20noisy%20production%20logs%20for%20every%20user.%20These%20look%20like%20diagnostic%20traces%20for%20a%20freeze%20investigation%20that%20should%20be%20removed%20before%20merge.%0A%0A%23%23%23%20Issue%202%20of%207%0Acrates%2Ftui%2Fsrc%2Fshell_dispatcher.rs%3A470-474%0AThis%20test%20asserts%20that%20%60cmd.exe%60%20is%20on%20PATH%2C%20but%20it%20will%20fail%20on%20Linux%20and%20macOS%20CI%20because%20%60cmd.exe%60%20doesn't%20exist%20there.%20It%20needs%20a%20%60%23%5Bcfg%28windows%29%5D%60%20guard.%0A%0A%60%60%60suggestion%0A%20%20%20%20%23%5Bcfg%28windows%29%5D%0A%20%20%20%20%23%5Btest%5D%0A%20%20%20%20fn%20find_exe_finds_cmd_on_path%28%29%20%7B%0A%20%20%20%20%20%20%20%20%2F%2F%20cmd.exe%20is%20always%20on%20PATH%20on%20Windows.%0A%20%20%20%20%20%20%20%20assert!%28ShellDispatcher%3A%3Afind_exe%28%22cmd.exe%22%29%29%3B%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%207%0Acrates%2Ftui%2Fsrc%2Fshell_dispatcher.rs%3A481-491%0ASame%20issue%3A%20%60find_exe_falls_back_to_known_dirs%60%20references%20Windows-only%20paths%20and%20will%20fail%20on%20Linux%2FmacOS.%20The%20whole%20test%20should%20be%20%60%23%5Bcfg%28windows%29%5D%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%23%5Bcfg%28windows%29%5D%0A%20%20%20%20%23%5Btest%5D%0A%20%20%20%20fn%20find_exe_falls_back_to_known_dirs%28%29%20%7B%0A%20%20%20%20%20%20%20%20%2F%2F%20Verify%20the%20known-dirs%20fallback%20path%20actually%20exists%20on%20this%20system.%0A%20%20%20%20%20%20%20%20let%20ps_path%20%3D%20r%22C%3A%5CWindows%5CSystem32%5CWindowsPowerShell%5Cv1.0%5Cpowershell.exe%22%3B%0A%20%20%20%20%20%20%20%20if%20std%3A%3Apath%3A%3APath%3A%3Anew%28ps_path%29.is_file%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20The%20fallback%20directory%20exists%20%E2%80%94%20find_exe%20should%20locate%20it.%0A%20%20%20%20%20%20%20%20%20%20%20%20assert!%28ShellDispatcher%3A%3Afind_exe%28%22powershell.exe%22%29%29%3B%0A%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20eprintln!%28%22Skipping%3A%20%7Bps_path%7D%20not%20present%20on%20this%20system%22%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%207%0Acrates%2Ftui%2Fsrc%2Ftools%2Ftasks.rs%3A287-297%0A**Login-shell%20context%20dropped%20for%20%60TaskGateRunTool%60**%0A%0AThe%20original%20code%20used%20%60%2Fbin%2Fsh%20-lc%60%20%28a%20login%20shell%29%20which%20sources%20%60~%2F.profile%60%2C%20%60~%2F.bash_profile%60%2C%20etc.%20The%20replacement%20uses%20%60ShellDispatcher%60%20which%20emits%20%60sh%20-c%60%20or%20%60bash%20-c%60%20without%20%60-l%60.%20On%20developer%20machines%20where%20tools%20like%20%60nvm%60%2C%20%60rbenv%60%2C%20%60conda%60%2C%20or%20%60pyenv%60%20inject%20PATH%20additions%20only%20through%20login-shell%20scripts%2C%20any%20gate%20command%20that%20invokes%20those%20tools%20will%20silently%20fail%20with%20%22command%20not%20found%22%20after%20this%20change.%0A%0A%23%23%23%20Issue%205%20of%207%0Acrates%2Ftui%2Fsrc%2Fdependencies.rs%3A461-581%0A**%60resolve%28%29%60%20in%20%60Gh%60%2C%20%60RustC%60%2C%20%60Cargo%60%2C%20%60DotNet%60%20bypasses%20%60Self%3A%3Acandidates%28%29%60**%0A%0A%60Git%3A%3Aresolve%28%29%60%20correctly%20iterates%20%60Self%3A%3Acandidates%28%29%60%2C%20but%20the%20other%20four%20impls%20hard-code%20the%20probe%20string%20directly%20instead%20of%20iterating%20candidates.%20This%20makes%20%60candidates%28%29%60%20a%20dead%20method%20for%20those%20types%20%E2%80%94%20if%20someone%20extends%20a%20candidate%20list%20the%20change%20won't%20be%20reflected%20in%20%60resolve%28%29%60.%0A%0A%282%20more%20issues%20omitted%20due%20to%20length%20limits.%20Use%20individual%20%22Fix%20in%20Claude%20Code%22%20links%20for%20remaining%20issues.%29%0A&repo=hmbown%2Fcodewhale&pr=2293&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%207%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%207%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui.rs%3A133-154%0A**Temporary%20debug%20instrumentation%20committed%20to%20main**%0A%0AMultiple%20%60%5BFREEZE-DEBUG%5D%60%20%60logging%3A%3Ainfo%28...%29%60%20calls%20were%20added%20throughout%20the%20event%20loop%20and%20render%20function.%20%60engine_event_rcvd%60%20fires%20on%20**every**%20engine%20event%20%28not%20throttled%29%2C%20%60EngineEvent%3A%3AMessageStarted%60%20and%20%60EngineEvent%3A%3AMessageComplete%60%20also%20fire%20unconditionally.%20This%20will%20produce%20extremely%20noisy%20production%20logs%20for%20every%20user.%20These%20look%20like%20diagnostic%20traces%20for%20a%20freeze%20investigation%20that%20should%20be%20removed%20before%20merge.%0A%0A%23%23%23%20Issue%202%20of%207%0Acrates%2Ftui%2Fsrc%2Fshell_dispatcher.rs%3A470-474%0AThis%20test%20asserts%20that%20%60cmd.exe%60%20is%20on%20PATH%2C%20but%20it%20will%20fail%20on%20Linux%20and%20macOS%20CI%20because%20%60cmd.exe%60%20doesn't%20exist%20there.%20It%20needs%20a%20%60%23%5Bcfg%28windows%29%5D%60%20guard.%0A%0A%60%60%60suggestion%0A%20%20%20%20%23%5Bcfg%28windows%29%5D%0A%20%20%20%20%23%5Btest%5D%0A%20%20%20%20fn%20find_exe_finds_cmd_on_path%28%29%20%7B%0A%20%20%20%20%20%20%20%20%2F%2F%20cmd.exe%20is%20always%20on%20PATH%20on%20Windows.%0A%20%20%20%20%20%20%20%20assert!%28ShellDispatcher%3A%3Afind_exe%28%22cmd.exe%22%29%29%3B%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%207%0Acrates%2Ftui%2Fsrc%2Fshell_dispatcher.rs%3A481-491%0ASame%20issue%3A%20%60find_exe_falls_back_to_known_dirs%60%20references%20Windows-only%20paths%20and%20will%20fail%20on%20Linux%2FmacOS.%20The%20whole%20test%20should%20be%20%60%23%5Bcfg%28windows%29%5D%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%23%5Bcfg%28windows%29%5D%0A%20%20%20%20%23%5Btest%5D%0A%20%20%20%20fn%20find_exe_falls_back_to_known_dirs%28%29%20%7B%0A%20%20%20%20%20%20%20%20%2F%2F%20Verify%20the%20known-dirs%20fallback%20path%20actually%20exists%20on%20this%20system.%0A%20%20%20%20%20%20%20%20let%20ps_path%20%3D%20r%22C%3A%5CWindows%5CSystem32%5CWindowsPowerShell%5Cv1.0%5Cpowershell.exe%22%3B%0A%20%20%20%20%20%20%20%20if%20std%3A%3Apath%3A%3APath%3A%3Anew%28ps_path%29.is_file%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20The%20fallback%20directory%20exists%20%E2%80%94%20find_exe%20should%20locate%20it.%0A%20%20%20%20%20%20%20%20%20%20%20%20assert!%28ShellDispatcher%3A%3Afind_exe%28%22powershell.exe%22%29%29%3B%0A%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20eprintln!%28%22Skipping%3A%20%7Bps_path%7D%20not%20present%20on%20this%20system%22%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%207%0Acrates%2Ftui%2Fsrc%2Ftools%2Ftasks.rs%3A287-297%0A**Login-shell%20context%20dropped%20for%20%60TaskGateRunTool%60**%0A%0AThe%20original%20code%20used%20%60%2Fbin%2Fsh%20-lc%60%20%28a%20login%20shell%29%20which%20sources%20%60~%2F.profile%60%2C%20%60~%2F.bash_profile%60%2C%20etc.%20The%20replacement%20uses%20%60ShellDispatcher%60%20which%20emits%20%60sh%20-c%60%20or%20%60bash%20-c%60%20without%20%60-l%60.%20On%20developer%20machines%20where%20tools%20like%20%60nvm%60%2C%20%60rbenv%60%2C%20%60conda%60%2C%20or%20%60pyenv%60%20inject%20PATH%20additions%20only%20through%20login-shell%20scripts%2C%20any%20gate%20command%20that%20invokes%20those%20tools%20will%20silently%20fail%20with%20%22command%20not%20found%22%20after%20this%20change.%0A%0A%23%23%23%20Issue%205%20of%207%0Acrates%2Ftui%2Fsrc%2Fdependencies.rs%3A461-581%0A**%60resolve%28%29%60%20in%20%60Gh%60%2C%20%60RustC%60%2C%20%60Cargo%60%2C%20%60DotNet%60%20bypasses%20%60Self%3A%3Acandidates%28%29%60**%0A%0A%60Git%3A%3Aresolve%28%29%60%20correctly%20iterates%20%60Self%3A%3Acandidates%28%29%60%2C%20but%20the%20other%20four%20impls%20hard-code%20the%20probe%20string%20directly%20instead%20of%20iterating%20candidates.%20This%20makes%20%60candidates%28%29%60%20a%20dead%20method%20for%20those%20types%20%E2%80%94%20if%20someone%20extends%20a%20candidate%20list%20the%20change%20won't%20be%20reflected%20in%20%60resolve%28%29%60.%0A%0A%23%23%23%20Issue%206%20of%207%0Acrates%2Ftui%2Fsrc%2Ftools%2Fdotnet_execution.rs%3A1-30%0A**%60dotnet%20run%20file.cs%60%20requires%20.NET%209%2B%2C%20not%20.NET%206%20as%20the%20doc%20claims**%0A%0ARunning%20a%20bare%20%60.cs%60%20file%20without%20a%20%60.csproj%60%20via%20%60dotnet%20run%60%20is%20a%20.NET%209%20experimental%20feature.%20On%20.NET%206%2F7%2F8%2C%20%60dotnet%20run%20dotnet_execution.cs%60%20in%20an%20empty%20temp%20directory%20will%20fail%20with%20a%20%22no%20project%22%20error%2C%20so%20the%20tool%20will%20silently%20report%20a%20failed%20execution%20for%20the%20majority%20of%20installed%20SDK%20versions.%0A%0A%23%23%23%20Issue%207%20of%207%0Acrates%2Ftui%2Fsrc%2Fcommands%2Fdebug.rs%3A1745%0A**Trailing%20newline%20missing%20across%20~24%20files**%0A%0AThis%20file%20and%20roughly%2020%20others%20in%20the%20PR%20end%20without%20a%20final%20newline.%20Affected%20files%20include%20%60debug.rs%60%2C%20%60share.rs%60%2C%20%60config_ui.rs%60%2C%20%60tool_catalog.rs%60%2C%20%60turn_loop.rs%60%2C%20%60dependencies.rs%60%2C%20%60eval.rs%60%2C%20all%20modified%20files%20under%20%60tools%2F%60%2C%20%60tui%2Fclipboard.rs%60%2C%20%60tui%2Ffile_picker_relevance.rs%60%2C%20%60tui%2Fui.rs%60%2C%20%60tui%2Fworkspace_context.rs%60%2C%20%60utils.rs%60%2C%20and%20%60shell_dispatcher.rs%60.%0A%0A&pr=2293&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["refactor: remove open\_browser/open\_exter..."](https://github.com/hmbown/codewhale/commit/4fb636ff9c10eb69f3da05ef86d22ec75989bf2e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34198789)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->