### PR TITLE
fix(tui): suppress verbose CLI logging on Windows alt-screen

### DIFF
--- a/crates/tui/src/logging.rs
+++ b/crates/tui/src/logging.rs
@@ -6,10 +6,22 @@ use colored::Colorize;
 
 use crate::palette;
 static VERBOSE: AtomicBool = AtomicBool::new(false);
+static VERBOSE_SNAPSHOT: AtomicBool = AtomicBool::new(false);
 
 /// Enable or disable verbose logging output.
 pub fn set_verbose(enabled: bool) {
     VERBOSE.store(enabled, Ordering::SeqCst);
+}
+
+/// Capture the current verbose state so the TUI can restore it after
+/// temporarily suppressing Windows alt-screen output.
+pub fn snapshot_verbose_state() {
+    VERBOSE_SNAPSHOT.store(is_verbose(), Ordering::SeqCst);
+}
+
+/// Restore the last captured verbose state.
+pub fn restore_verbose_state() {
+    set_verbose(VERBOSE_SNAPSHOT.load(Ordering::SeqCst));
 }
 
 /// Return true when `DEEPSEEK_LOG_LEVEL` requests verbose output.
@@ -63,6 +75,9 @@ pub fn warn(message: impl AsRef<str>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    static TEST_GUARD: Mutex<()> = Mutex::new(());
 
     #[test]
     fn log_value_parser_accepts_common_rust_log_directives() {
@@ -73,5 +88,24 @@ mod tests {
         ));
         assert!(!log_value_enables_verbose("warn"));
         assert!(!log_value_enables_verbose("codewhale_tui=off"));
+    }
+
+    #[test]
+    fn snapshot_and_restore_verbose_state_round_trip() {
+        let _guard = TEST_GUARD.lock().unwrap_or_else(|err| err.into_inner());
+
+        set_verbose(false);
+        snapshot_verbose_state();
+        set_verbose(true);
+        restore_verbose_state();
+        assert!(!is_verbose());
+
+        set_verbose(true);
+        snapshot_verbose_state();
+        set_verbose(false);
+        restore_verbose_state();
+        assert!(is_verbose());
+
+        set_verbose(false);
     }
 }

--- a/crates/tui/src/logging.rs
+++ b/crates/tui/src/logging.rs
@@ -6,6 +6,7 @@ use colored::Colorize;
 
 use crate::palette;
 static VERBOSE: AtomicBool = AtomicBool::new(false);
+#[cfg(windows)]
 static VERBOSE_SNAPSHOT: AtomicBool = AtomicBool::new(false);
 
 /// Enable or disable verbose logging output.
@@ -15,11 +16,13 @@ pub fn set_verbose(enabled: bool) {
 
 /// Capture the current verbose state so the TUI can restore it after
 /// temporarily suppressing Windows alt-screen output.
+#[cfg(windows)]
 pub fn snapshot_verbose_state() {
     VERBOSE_SNAPSHOT.store(is_verbose(), Ordering::SeqCst);
 }
 
 /// Restore the last captured verbose state.
+#[cfg(windows)]
 pub fn restore_verbose_state() {
     set_verbose(VERBOSE_SNAPSHOT.load(Ordering::SeqCst));
 }
@@ -73,6 +76,7 @@ pub fn warn(message: impl AsRef<str>) {
 }
 
 #[cfg(test)]
+#[cfg(windows)]
 mod tests {
     use super::*;
     use std::sync::Mutex;

--- a/crates/tui/src/logging.rs
+++ b/crates/tui/src/logging.rs
@@ -112,4 +112,21 @@ mod tests {
 
         set_verbose(false);
     }
+
+    #[test]
+    fn restore_keeps_cli_verbose_state_even_when_env_is_not_verbose() {
+        let _guard = TEST_GUARD.lock().unwrap_or_else(|err| err.into_inner());
+
+        set_verbose(true);
+        snapshot_verbose_state();
+
+        // Simulate the Windows alt-screen suppression path. The restore must
+        // bring back the pre-suppression CLI state without depending on the
+        // environment.
+        set_verbose(false);
+        restore_verbose_state();
+
+        assert!(is_verbose());
+        set_verbose(false);
+    }
 }

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -283,12 +283,12 @@ pub async fn run_tui(config: &Config, options: TuiOptions) -> Result<()> {
     let mut stdout = io::stdout();
     if use_alt_screen {
         execute!(stdout, EnterAlternateScreen)?;
+        // On Windows, stderr cannot be redirected to the log file (no dup2).
+        // Suppress verbose CLI logging once the alt-screen is active so
+        // eprintln! calls from crate::logging don't leak into the TUI buffer.
+        #[cfg(windows)]
+        crate::logging::set_verbose(false);
     }
-    // On Windows, stderr cannot be redirected to the log file (no dup2).
-    // Suppress verbose CLI logging once the alt-screen is active so
-    // eprintln! calls from crate::logging don't leak into the TUI buffer.
-    #[cfg(windows)]
-    crate::logging::set_verbose(false);
     // Initialize the file-backed TUI log and (on Unix) redirect raw stderr
     // away from the alt-screen for the lifetime of this guard. Any
     // `eprintln!`, panic message, or third-party stderr write that would
@@ -623,8 +623,6 @@ impl Drop for TerminalCleanupGuard {
         let _ = disable_raw_mode();
         if self.use_alt_screen {
             let _ = execute!(stdout, LeaveAlternateScreen);
-            #[cfg(windows)]
-            crate::logging::set_verbose(crate::logging::env_requests_verbose_logging());
         }
         if self.use_mouse_capture {
             let _ = execute!(stdout, DisableMouseCapture);
@@ -6938,11 +6936,11 @@ fn resume_terminal(
     enable_raw_mode()?;
     if use_alt_screen {
         execute!(terminal.backend_mut(), EnterAlternateScreen)?;
+        // Re-entering alt-screen after mode recovery — suppress verbose
+        // CLI logging again so eprintln! doesn't leak into the TUI.
+        #[cfg(windows)]
+        crate::logging::set_verbose(false);
     }
-    // Re-entering alt-screen after mode recovery — suppress verbose
-    // CLI logging again so eprintln! doesn't leak into the TUI.
-    #[cfg(windows)]
-    crate::logging::set_verbose(false);
     recover_terminal_modes(
         terminal.backend_mut(),
         use_mouse_capture,
@@ -7055,8 +7053,6 @@ pub fn emergency_restore_terminal() {
     let _ = execute!(stdout, DisableMouseCapture);
     let _ = disable_raw_mode();
     let _ = execute!(stdout, LeaveAlternateScreen);
-    #[cfg(windows)]
-    crate::logging::set_verbose(crate::logging::env_requests_verbose_logging());
 }
 
 /// Re-establish terminal mode flags. Idempotent and best-effort: each

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -284,6 +284,11 @@ pub async fn run_tui(config: &Config, options: TuiOptions) -> Result<()> {
     if use_alt_screen {
         execute!(stdout, EnterAlternateScreen)?;
     }
+    // On Windows, stderr cannot be redirected to the log file (no dup2).
+    // Suppress verbose CLI logging once the alt-screen is active so
+    // eprintln! calls from crate::logging don't leak into the TUI buffer.
+    #[cfg(windows)]
+    crate::logging::set_verbose(false);
     // Initialize the file-backed TUI log and (on Unix) redirect raw stderr
     // away from the alt-screen for the lifetime of this guard. Any
     // `eprintln!`, panic message, or third-party stderr write that would
@@ -554,6 +559,8 @@ pub async fn run_tui(config: &Config, options: TuiOptions) -> Result<()> {
     disable_raw_mode()?;
     if use_alt_screen {
         execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+        #[cfg(windows)]
+        crate::logging::set_verbose(crate::logging::env_requests_verbose_logging());
     }
     if use_mouse_capture {
         execute!(terminal.backend_mut(), DisableMouseCapture)?;
@@ -616,6 +623,8 @@ impl Drop for TerminalCleanupGuard {
         let _ = disable_raw_mode();
         if self.use_alt_screen {
             let _ = execute!(stdout, LeaveAlternateScreen);
+            #[cfg(windows)]
+            crate::logging::set_verbose(crate::logging::env_requests_verbose_logging());
         }
         if self.use_mouse_capture {
             let _ = execute!(stdout, DisableMouseCapture);
@@ -6907,6 +6916,8 @@ fn pause_terminal(
     disable_raw_mode()?;
     if use_alt_screen {
         execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+        #[cfg(windows)]
+        crate::logging::set_verbose(crate::logging::env_requests_verbose_logging());
     }
     if use_mouse_capture {
         execute!(terminal.backend_mut(), DisableMouseCapture)?;
@@ -6928,6 +6939,10 @@ fn resume_terminal(
     if use_alt_screen {
         execute!(terminal.backend_mut(), EnterAlternateScreen)?;
     }
+    // Re-entering alt-screen after mode recovery — suppress verbose
+    // CLI logging again so eprintln! doesn't leak into the TUI.
+    #[cfg(windows)]
+    crate::logging::set_verbose(false);
     recover_terminal_modes(
         terminal.backend_mut(),
         use_mouse_capture,
@@ -7040,6 +7055,8 @@ pub fn emergency_restore_terminal() {
     let _ = execute!(stdout, DisableMouseCapture);
     let _ = disable_raw_mode();
     let _ = execute!(stdout, LeaveAlternateScreen);
+    #[cfg(windows)]
+    crate::logging::set_verbose(crate::logging::env_requests_verbose_logging());
 }
 
 /// Re-establish terminal mode flags. Idempotent and best-effort: each

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -287,6 +287,8 @@ pub async fn run_tui(config: &Config, options: TuiOptions) -> Result<()> {
         // Suppress verbose CLI logging once the alt-screen is active so
         // eprintln! calls from crate::logging don't leak into the TUI buffer.
         #[cfg(windows)]
+        crate::logging::snapshot_verbose_state();
+        #[cfg(windows)]
         crate::logging::set_verbose(false);
     }
     // Initialize the file-backed TUI log and (on Unix) redirect raw stderr
@@ -560,7 +562,7 @@ pub async fn run_tui(config: &Config, options: TuiOptions) -> Result<()> {
     if use_alt_screen {
         execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
         #[cfg(windows)]
-        crate::logging::set_verbose(crate::logging::env_requests_verbose_logging());
+        crate::logging::restore_verbose_state();
     }
     if use_mouse_capture {
         execute!(terminal.backend_mut(), DisableMouseCapture)?;
@@ -6915,7 +6917,7 @@ fn pause_terminal(
     if use_alt_screen {
         execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
         #[cfg(windows)]
-        crate::logging::set_verbose(crate::logging::env_requests_verbose_logging());
+        crate::logging::restore_verbose_state();
     }
     if use_mouse_capture {
         execute!(terminal.backend_mut(), DisableMouseCapture)?;


### PR DESCRIPTION
This PR is the cleaned replacement for the old `#1910` branch.

It carries the same Windows alt-screen verbose-leak fix, but rebased onto current `main` so the review starts from a clean history instead of the stale DeepSeek-era workspace snapshot.

What changed:
- suppress verbose CLI logging on Windows while the TUI alt-screen is active
- restore the previous verbose state when leaving alt-screen or during cleanup

Validation:
- `cargo fmt --all`
- `cargo check -p codewhale-tui --all-features --locked`

Reference:
- Closed PR `#1910`, especially the maintainer note explaining that the broader Windows verbose-leak work was being split into defense-in-depth layers (`#2259` and `#2262`). This PR keeps only the alt-screen suppression fix and replays it cleanly on current `main`.

The old PR branch was superseded by this clean cherry-pick on top of `main`.

Paulo Aboim Pinto

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR suppresses verbose CLI logging on Windows while the TUI alt-screen is active, replacing the approach from #1910 with a snapshot/restore pattern that correctly preserves the pre-suppression verbose state (including `--verbose` CLI flags) across alt-screen entry and exit.

- `logging.rs` gains `snapshot_verbose_state` / `restore_verbose_state` backed by a `VERBOSE_SNAPSHOT` atomic; `ui.rs` calls these at every alt-screen enter/leave site (`run_tui`, `pause_terminal`, `resume_terminal`), all correctly guarded inside `if use_alt_screen`.
- Adding `#[cfg(windows)]` to the whole `mod tests` block silently drops the cross-platform `log_value_parser_accepts_common_rust_log_directives` test from Linux/macOS CI runs; only the new snapshot/restore tests need the Windows gate.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the core suppress/restore logic is correct and properly scoped to alt-screen sessions.

The suppress/restore pairs are consistently placed inside if use_alt_screen guards across all changed call sites, and the snapshot correctly captures the full verbose state including CLI flags rather than re-reading the environment. The only issue is a test-module attribute that drops cross-platform coverage for an existing test, which does not affect runtime behavior.

crates/tui/src/logging.rs — the #[cfg(windows)] gate on the test module needs to be narrowed so the cross-platform parser test keeps running on Linux/macOS.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/tui/src/logging.rs | Adds Windows-only VERBOSE_SNAPSHOT atomic, snapshot_verbose_state, and restore_verbose_state helpers. The new snapshot/restore tests are correct, but gating the entire mod tests block with #[cfg(windows)] accidentally removes cross-platform coverage for the pre-existing log_value_parser_accepts_common_rust_log_directives test. |
| crates/tui/src/tui/ui.rs | Integrates snapshot/restore calls at all alt-screen transitions: run_tui entry, normal exit, pause_terminal, and resume_terminal. The suppress/restore pairs are correctly placed inside if use_alt_screen guards. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant main
    participant run_tui
    participant logging
    participant pause_terminal
    participant resume_terminal

    main->>run_tui: "run_tui(use_alt_screen=true)"
    run_tui->>logging: snapshot_verbose_state() [Windows]
    run_tui->>logging: set_verbose(false) [Windows]
    Note over run_tui: TUI event loop running...
    run_tui->>pause_terminal: "pause_terminal(use_alt_screen=true)"
    pause_terminal->>logging: restore_verbose_state() [Windows]
    Note over pause_terminal: LeaveAlternateScreen
    pause_terminal-->>run_tui: Ok
    Note over run_tui: child process running...
    run_tui->>resume_terminal: "resume_terminal(use_alt_screen=true)"
    Note over resume_terminal: EnterAlternateScreen
    resume_terminal->>logging: set_verbose(false) [Windows]
    resume_terminal-->>run_tui: Ok
    Note over run_tui: TUI event loop running...
    run_tui->>logging: restore_verbose_state() [Windows, normal exit]
    run_tui-->>main: Ok
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `crates/tui/src/tui/ui.rs`, line 626-628 ([link](https://github.com/hmbown/codewhale/blob/74be1cad99d349c75b1177105ac30b4ea950d44a/crates/tui/src/tui/ui.rs#L626-L628)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`TerminalCleanupGuard::drop` skips `restore_verbose_state` on Windows**

   The drop handler is the safety net for every early-return path between guard creation (line ~338) and `defused = true` (line ~558). On Windows with `use_alt_screen = true`, it leaves the alt-screen correctly but never calls `crate::logging::restore_verbose_state()`. Any `?`-propagated error that escapes `run_tui` before the normal cleanup will leave `VERBOSE` permanently cleared, silencing all subsequent `crate::logging::info/warn` calls in the same process — including any post-TUI diagnostics or retry logic in the caller.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2F1910-verbose-main%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F1910-verbose-main%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fui.rs%0ALine%3A%20626-628%0A%0AComment%3A%0A**%60TerminalCleanupGuard%3A%3Adrop%60%20skips%20%60restore_verbose_state%60%20on%20Windows**%0A%0AThe%20drop%20handler%20is%20the%20safety%20net%20for%20every%20early-return%20path%20between%20guard%20creation%20%28line%20~338%29%20and%20%60defused%20%3D%20true%60%20%28line%20~558%29.%20On%20Windows%20with%20%60use_alt_screen%20%3D%20true%60%2C%20it%20leaves%20the%20alt-screen%20correctly%20but%20never%20calls%20%60crate%3A%3Alogging%3A%3Arestore_verbose_state%28%29%60.%20Any%20%60%3F%60-propagated%20error%20that%20escapes%20%60run_tui%60%20before%20the%20normal%20cleanup%20will%20leave%20%60VERBOSE%60%20permanently%20cleared%2C%20silencing%20all%20subsequent%20%60crate%3A%3Alogging%3A%3Ainfo%2Fwarn%60%20calls%20in%20the%20same%20process%20%E2%80%94%20including%20any%20post-TUI%20diagnostics%20or%20retry%20logic%20in%20the%20caller.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fui.rs%0ALine%3A%20626-628%0A%0AComment%3A%0A**%60TerminalCleanupGuard%3A%3Adrop%60%20skips%20%60restore_verbose_state%60%20on%20Windows**%0A%0AThe%20drop%20handler%20is%20the%20safety%20net%20for%20every%20early-return%20path%20between%20guard%20creation%20%28line%20~338%29%20and%20%60defused%20%3D%20true%60%20%28line%20~558%29.%20On%20Windows%20with%20%60use_alt_screen%20%3D%20true%60%2C%20it%20leaves%20the%20alt-screen%20correctly%20but%20never%20calls%20%60crate%3A%3Alogging%3A%3Arestore_verbose_state%28%29%60.%20Any%20%60%3F%60-propagated%20error%20that%20escapes%20%60run_tui%60%20before%20the%20normal%20cleanup%20will%20leave%20%60VERBOSE%60%20permanently%20cleared%2C%20silencing%20all%20subsequent%20%60crate%3A%3Alogging%3A%3Ainfo%2Fwarn%60%20calls%20in%20the%20same%20process%20%E2%80%94%20including%20any%20post-TUI%20diagnostics%20or%20retry%20logic%20in%20the%20caller.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2295&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fui.rs%0ALine%3A%20626-628%0A%0AComment%3A%0A**%60TerminalCleanupGuard%3A%3Adrop%60%20skips%20%60restore_verbose_state%60%20on%20Windows**%0A%0AThe%20drop%20handler%20is%20the%20safety%20net%20for%20every%20early-return%20path%20between%20guard%20creation%20%28line%20~338%29%20and%20%60defused%20%3D%20true%60%20%28line%20~558%29.%20On%20Windows%20with%20%60use_alt_screen%20%3D%20true%60%2C%20it%20leaves%20the%20alt-screen%20correctly%20but%20never%20calls%20%60crate%3A%3Alogging%3A%3Arestore_verbose_state%28%29%60.%20Any%20%60%3F%60-propagated%20error%20that%20escapes%20%60run_tui%60%20before%20the%20normal%20cleanup%20will%20leave%20%60VERBOSE%60%20permanently%20cleared%2C%20silencing%20all%20subsequent%20%60crate%3A%3Alogging%3A%3Ainfo%2Fwarn%60%20calls%20in%20the%20same%20process%20%E2%80%94%20including%20any%20post-TUI%20diagnostics%20or%20retry%20logic%20in%20the%20caller.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2295&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

2. `crates/tui/src/tui/ui.rs`, line 616-637 ([link](https://github.com/hmbown/codewhale/blob/85c10b1ca429fbe3b99ddc7ac95b1d4dbbb53701/crates/tui/src/tui/ui.rs#L616-L637)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> `TerminalCleanupGuard::drop` is the safety net for all early-return paths between guard creation and `cleanup_guard.defused = true`. On Windows with `use_alt_screen = true`, the drop correctly issues `LeaveAlternateScreen`, but never calls `crate::logging::restore_verbose_state()`. Any `?`-propagated error that escapes `run_tui` before line 558 will leave `VERBOSE` permanently cleared — silencing all subsequent `crate::logging::info`/`warn` calls in the same process, including any post-TUI diagnostics in the caller.

   The fix is to add the same `#[cfg(windows)]` restore call that the normal-exit path already has, inside the `if self.use_alt_screen { … }` branch of `Drop::drop`.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2F1910-verbose-main%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F1910-verbose-main%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fui.rs%0ALine%3A%20616-637%0A%0AComment%3A%0A%60TerminalCleanupGuard%3A%3Adrop%60%20is%20the%20safety%20net%20for%20all%20early-return%20paths%20between%20guard%20creation%20and%20%60cleanup_guard.defused%20%3D%20true%60.%20On%20Windows%20with%20%60use_alt_screen%20%3D%20true%60%2C%20the%20drop%20correctly%20issues%20%60LeaveAlternateScreen%60%2C%20but%20never%20calls%20%60crate%3A%3Alogging%3A%3Arestore_verbose_state%28%29%60.%20Any%20%60%3F%60-propagated%20error%20that%20escapes%20%60run_tui%60%20before%20line%20558%20will%20leave%20%60VERBOSE%60%20permanently%20cleared%20%E2%80%94%20silencing%20all%20subsequent%20%60crate%3A%3Alogging%3A%3Ainfo%60%2F%60warn%60%20calls%20in%20the%20same%20process%2C%20including%20any%20post-TUI%20diagnostics%20in%20the%20caller.%0A%0AThe%20fix%20is%20to%20add%20the%20same%20%60%23%5Bcfg%28windows%29%5D%60%20restore%20call%20that%20the%20normal-exit%20path%20already%20has%2C%20inside%20the%20%60if%20self.use_alt_screen%20%7B%20%E2%80%A6%20%7D%60%20branch%20of%20%60Drop%3A%3Adrop%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fui.rs%0ALine%3A%20616-637%0A%0AComment%3A%0A%60TerminalCleanupGuard%3A%3Adrop%60%20is%20the%20safety%20net%20for%20all%20early-return%20paths%20between%20guard%20creation%20and%20%60cleanup_guard.defused%20%3D%20true%60.%20On%20Windows%20with%20%60use_alt_screen%20%3D%20true%60%2C%20the%20drop%20correctly%20issues%20%60LeaveAlternateScreen%60%2C%20but%20never%20calls%20%60crate%3A%3Alogging%3A%3Arestore_verbose_state%28%29%60.%20Any%20%60%3F%60-propagated%20error%20that%20escapes%20%60run_tui%60%20before%20line%20558%20will%20leave%20%60VERBOSE%60%20permanently%20cleared%20%E2%80%94%20silencing%20all%20subsequent%20%60crate%3A%3Alogging%3A%3Ainfo%60%2F%60warn%60%20calls%20in%20the%20same%20process%2C%20including%20any%20post-TUI%20diagnostics%20in%20the%20caller.%0A%0AThe%20fix%20is%20to%20add%20the%20same%20%60%23%5Bcfg%28windows%29%5D%60%20restore%20call%20that%20the%20normal-exit%20path%20already%20has%2C%20inside%20the%20%60if%20self.use_alt_screen%20%7B%20%E2%80%A6%20%7D%60%20branch%20of%20%60Drop%3A%3Adrop%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2295&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fui.rs%0ALine%3A%20616-637%0A%0AComment%3A%0A%60TerminalCleanupGuard%3A%3Adrop%60%20is%20the%20safety%20net%20for%20all%20early-return%20paths%20between%20guard%20creation%20and%20%60cleanup_guard.defused%20%3D%20true%60.%20On%20Windows%20with%20%60use_alt_screen%20%3D%20true%60%2C%20the%20drop%20correctly%20issues%20%60LeaveAlternateScreen%60%2C%20but%20never%20calls%20%60crate%3A%3Alogging%3A%3Arestore_verbose_state%28%29%60.%20Any%20%60%3F%60-propagated%20error%20that%20escapes%20%60run_tui%60%20before%20line%20558%20will%20leave%20%60VERBOSE%60%20permanently%20cleared%20%E2%80%94%20silencing%20all%20subsequent%20%60crate%3A%3Alogging%3A%3Ainfo%60%2F%60warn%60%20calls%20in%20the%20same%20process%2C%20including%20any%20post-TUI%20diagnostics%20in%20the%20caller.%0A%0AThe%20fix%20is%20to%20add%20the%20same%20%60%23%5Bcfg%28windows%29%5D%60%20restore%20call%20that%20the%20normal-exit%20path%20already%20has%2C%20inside%20the%20%60if%20self.use_alt_screen%20%7B%20%E2%80%A6%20%7D%60%20branch%20of%20%60Drop%3A%3Adrop%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2295&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2F1910-verbose-main%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F1910-verbose-main%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Flogging.rs%3A78-132%0AAdding%20%60%23%5Bcfg%28windows%29%5D%60%20to%20the%20entire%20%60mod%20tests%60%20block%20gates%20the%20pre-existing%20%60log_value_parser_accepts_common_rust_log_directives%60%20test%20behind%20Windows%20as%20well.%20%60log_value_enables_verbose%60%20is%20fully%20cross-platform%20code%3B%20that%20test%20previously%20ran%20on%20every%20platform%20in%20CI.%20Splitting%20the%20module%20so%20only%20the%20snapshot%2Frestore%20tests%20are%20Windows-gated%20preserves%20the%20original%20coverage%20on%20Linux%2FmacOS.%0A%0A%60%60%60suggestion%0A%23%5Bcfg%28test%29%5D%0Amod%20tests%20%7B%0A%20%20%20%20use%20super%3A%3A*%3B%0A%0A%20%20%20%20%23%5Btest%5D%0A%20%20%20%20fn%20log_value_parser_accepts_common_rust_log_directives%28%29%20%7B%0A%20%20%20%20%20%20%20%20assert!%28log_value_enables_verbose%28%22debug%22%29%29%3B%0A%20%20%20%20%20%20%20%20assert!%28log_value_enables_verbose%28%22codewhale_cli%3Ddebug%22%29%29%3B%0A%20%20%20%20%20%20%20%20assert!%28log_value_enables_verbose%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%22warn%2Ccodewhale_tui%3A%3Aclient%3Dtrace%22%0A%20%20%20%20%20%20%20%20%29%29%3B%0A%20%20%20%20%20%20%20%20assert!%28!log_value_enables_verbose%28%22warn%22%29%29%3B%0A%20%20%20%20%20%20%20%20assert!%28!log_value_enables_verbose%28%22codewhale_tui%3Doff%22%29%29%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20%23%5Bcfg%28windows%29%5D%0A%20%20%20%20mod%20windows_verbose_snapshot%20%7B%0A%20%20%20%20%20%20%20%20use%20super%3A%3Asuper%3A%3A*%3B%0A%20%20%20%20%20%20%20%20use%20std%3A%3Async%3A%3AMutex%3B%0A%0A%20%20%20%20%20%20%20%20static%20TEST_GUARD%3A%20Mutex%3C%28%29%3E%20%3D%20Mutex%3A%3Anew%28%28%29%29%3B%0A%0A%20%20%20%20%20%20%20%20%23%5Btest%5D%0A%20%20%20%20%20%20%20%20fn%20snapshot_and_restore_verbose_state_round_trip%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20let%20_guard%20%3D%20TEST_GUARD.lock%28%29.unwrap_or_else%28%7Cerr%7C%20err.into_inner%28%29%29%3B%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20set_verbose%28false%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20snapshot_verbose_state%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20set_verbose%28true%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20restore_verbose_state%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20assert!%28!is_verbose%28%29%29%3B%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20set_verbose%28true%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20snapshot_verbose_state%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20set_verbose%28false%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20restore_verbose_state%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20assert!%28is_verbose%28%29%29%3B%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20set_verbose%28false%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20%23%5Btest%5D%0A%20%20%20%20%20%20%20%20fn%20restore_keeps_cli_verbose_state_even_when_env_is_not_verbose%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20let%20_guard%20%3D%20TEST_GUARD.lock%28%29.unwrap_or_else%28%7Cerr%7C%20err.into_inner%28%29%29%3B%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20set_verbose%28true%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20snapshot_verbose_state%28%29%3B%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Simulate%20the%20Windows%20alt-screen%20suppression%20path.%20The%20restore%20must%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20bring%20back%20the%20pre-suppression%20CLI%20state%20without%20depending%20on%20the%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20environment.%0A%20%20%20%20%20%20%20%20%20%20%20%20set_verbose%28false%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20restore_verbose_state%28%29%3B%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20assert!%28is_verbose%28%29%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20set_verbose%28false%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Flogging.rs%3A78-132%0AAdding%20%60%23%5Bcfg%28windows%29%5D%60%20to%20the%20entire%20%60mod%20tests%60%20block%20gates%20the%20pre-existing%20%60log_value_parser_accepts_common_rust_log_directives%60%20test%20behind%20Windows%20as%20well.%20%60log_value_enables_verbose%60%20is%20fully%20cross-platform%20code%3B%20that%20test%20previously%20ran%20on%20every%20platform%20in%20CI.%20Splitting%20the%20module%20so%20only%20the%20snapshot%2Frestore%20tests%20are%20Windows-gated%20preserves%20the%20original%20coverage%20on%20Linux%2FmacOS.%0A%0A%60%60%60suggestion%0A%23%5Bcfg%28test%29%5D%0Amod%20tests%20%7B%0A%20%20%20%20use%20super%3A%3A*%3B%0A%0A%20%20%20%20%23%5Btest%5D%0A%20%20%20%20fn%20log_value_parser_accepts_common_rust_log_directives%28%29%20%7B%0A%20%20%20%20%20%20%20%20assert!%28log_value_enables_verbose%28%22debug%22%29%29%3B%0A%20%20%20%20%20%20%20%20assert!%28log_value_enables_verbose%28%22codewhale_cli%3Ddebug%22%29%29%3B%0A%20%20%20%20%20%20%20%20assert!%28log_value_enables_verbose%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%22warn%2Ccodewhale_tui%3A%3Aclient%3Dtrace%22%0A%20%20%20%20%20%20%20%20%29%29%3B%0A%20%20%20%20%20%20%20%20assert!%28!log_value_enables_verbose%28%22warn%22%29%29%3B%0A%20%20%20%20%20%20%20%20assert!%28!log_value_enables_verbose%28%22codewhale_tui%3Doff%22%29%29%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20%23%5Bcfg%28windows%29%5D%0A%20%20%20%20mod%20windows_verbose_snapshot%20%7B%0A%20%20%20%20%20%20%20%20use%20super%3A%3Asuper%3A%3A*%3B%0A%20%20%20%20%20%20%20%20use%20std%3A%3Async%3A%3AMutex%3B%0A%0A%20%20%20%20%20%20%20%20static%20TEST_GUARD%3A%20Mutex%3C%28%29%3E%20%3D%20Mutex%3A%3Anew%28%28%29%29%3B%0A%0A%20%20%20%20%20%20%20%20%23%5Btest%5D%0A%20%20%20%20%20%20%20%20fn%20snapshot_and_restore_verbose_state_round_trip%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20let%20_guard%20%3D%20TEST_GUARD.lock%28%29.unwrap_or_else%28%7Cerr%7C%20err.into_inner%28%29%29%3B%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20set_verbose%28false%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20snapshot_verbose_state%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20set_verbose%28true%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20restore_verbose_state%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20assert!%28!is_verbose%28%29%29%3B%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20set_verbose%28true%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20snapshot_verbose_state%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20set_verbose%28false%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20restore_verbose_state%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20assert!%28is_verbose%28%29%29%3B%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20set_verbose%28false%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20%23%5Btest%5D%0A%20%20%20%20%20%20%20%20fn%20restore_keeps_cli_verbose_state_even_when_env_is_not_verbose%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20let%20_guard%20%3D%20TEST_GUARD.lock%28%29.unwrap_or_else%28%7Cerr%7C%20err.into_inner%28%29%29%3B%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20set_verbose%28true%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20snapshot_verbose_state%28%29%3B%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Simulate%20the%20Windows%20alt-screen%20suppression%20path.%20The%20restore%20must%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20bring%20back%20the%20pre-suppression%20CLI%20state%20without%20depending%20on%20the%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20environment.%0A%20%20%20%20%20%20%20%20%20%20%20%20set_verbose%28false%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20restore_verbose_state%28%29%3B%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20assert!%28is_verbose%28%29%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20set_verbose%28false%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%7D%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2295&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Flogging.rs%3A78-132%0AAdding%20%60%23%5Bcfg%28windows%29%5D%60%20to%20the%20entire%20%60mod%20tests%60%20block%20gates%20the%20pre-existing%20%60log_value_parser_accepts_common_rust_log_directives%60%20test%20behind%20Windows%20as%20well.%20%60log_value_enables_verbose%60%20is%20fully%20cross-platform%20code%3B%20that%20test%20previously%20ran%20on%20every%20platform%20in%20CI.%20Splitting%20the%20module%20so%20only%20the%20snapshot%2Frestore%20tests%20are%20Windows-gated%20preserves%20the%20original%20coverage%20on%20Linux%2FmacOS.%0A%0A%60%60%60suggestion%0A%23%5Bcfg%28test%29%5D%0Amod%20tests%20%7B%0A%20%20%20%20use%20super%3A%3A*%3B%0A%0A%20%20%20%20%23%5Btest%5D%0A%20%20%20%20fn%20log_value_parser_accepts_common_rust_log_directives%28%29%20%7B%0A%20%20%20%20%20%20%20%20assert!%28log_value_enables_verbose%28%22debug%22%29%29%3B%0A%20%20%20%20%20%20%20%20assert!%28log_value_enables_verbose%28%22codewhale_cli%3Ddebug%22%29%29%3B%0A%20%20%20%20%20%20%20%20assert!%28log_value_enables_verbose%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%22warn%2Ccodewhale_tui%3A%3Aclient%3Dtrace%22%0A%20%20%20%20%20%20%20%20%29%29%3B%0A%20%20%20%20%20%20%20%20assert!%28!log_value_enables_verbose%28%22warn%22%29%29%3B%0A%20%20%20%20%20%20%20%20assert!%28!log_value_enables_verbose%28%22codewhale_tui%3Doff%22%29%29%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20%23%5Bcfg%28windows%29%5D%0A%20%20%20%20mod%20windows_verbose_snapshot%20%7B%0A%20%20%20%20%20%20%20%20use%20super%3A%3Asuper%3A%3A*%3B%0A%20%20%20%20%20%20%20%20use%20std%3A%3Async%3A%3AMutex%3B%0A%0A%20%20%20%20%20%20%20%20static%20TEST_GUARD%3A%20Mutex%3C%28%29%3E%20%3D%20Mutex%3A%3Anew%28%28%29%29%3B%0A%0A%20%20%20%20%20%20%20%20%23%5Btest%5D%0A%20%20%20%20%20%20%20%20fn%20snapshot_and_restore_verbose_state_round_trip%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20let%20_guard%20%3D%20TEST_GUARD.lock%28%29.unwrap_or_else%28%7Cerr%7C%20err.into_inner%28%29%29%3B%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20set_verbose%28false%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20snapshot_verbose_state%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20set_verbose%28true%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20restore_verbose_state%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20assert!%28!is_verbose%28%29%29%3B%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20set_verbose%28true%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20snapshot_verbose_state%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20set_verbose%28false%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20restore_verbose_state%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20assert!%28is_verbose%28%29%29%3B%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20set_verbose%28false%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20%23%5Btest%5D%0A%20%20%20%20%20%20%20%20fn%20restore_keeps_cli_verbose_state_even_when_env_is_not_verbose%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20let%20_guard%20%3D%20TEST_GUARD.lock%28%29.unwrap_or_else%28%7Cerr%7C%20err.into_inner%28%29%29%3B%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20set_verbose%28true%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20snapshot_verbose_state%28%29%3B%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Simulate%20the%20Windows%20alt-screen%20suppression%20path.%20The%20restore%20must%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20bring%20back%20the%20pre-suppression%20CLI%20state%20without%20depending%20on%20the%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20environment.%0A%20%20%20%20%20%20%20%20%20%20%20%20set_verbose%28false%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20restore_verbose_state%28%29%3B%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20assert!%28is_verbose%28%29%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20set_verbose%28false%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%7D%0A%60%60%60%0A%0A&pr=2295&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (5): Last reviewed commit: ["test(tui): cover windows verbose state r..."](https://github.com/hmbown/codewhale/commit/96bea497aa7821f90a3e4b622ad37fbc8fcad231) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34228347)</sub>

<!-- /greptile_comment -->