### PR TITLE
docs(docker): add toolbox compose template

### DIFF
--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -93,6 +93,26 @@ Do not bake API keys, SSH private keys, or other secrets into custom images.
 Pass API keys at runtime and mount any SSH material deliberately, preferably
 read-only and only for projects that need it.
 
+### Compose toolbox template
+
+If you prefer a repeatable `docker compose` entry point, use
+[`docs/examples/compose.toolbox.yml`](examples/compose.toolbox.yml). It builds
+the toolbox image from [`docs/examples/Dockerfile.toolbox`](examples/Dockerfile.toolbox)
+and keeps the project state volume explicit:
+
+```bash
+CODEWHALE_IMAGE=ghcr.io/hmbown/codewhale:vX.Y.Z \
+CODEWHALE_TOOLBOX_IMAGE=codewhale-toolbox:my-project \
+CODEWHALE_HOME_VOLUME=codewhale-my-project-home \
+CODEWHALE_WORKSPACE="$PWD" \
+docker compose -f docs/examples/compose.toolbox.yml run --rm codewhale
+```
+
+Use a different `CODEWHALE_TOOLBOX_IMAGE` and `CODEWHALE_HOME_VOLUME` for each
+project that needs an independent toolchain or independent `.deepseek` state.
+The Compose file also shows opt-in, read-only mounts for SSH material and local
+CA certificates; keep those commented out unless the project needs them.
+
 ## Multiple independent projects
 
 Use one named state volume per project so sessions, config, skills, memory, and

--- a/docs/examples/compose.toolbox.yml
+++ b/docs/examples/compose.toolbox.yml
@@ -20,17 +20,17 @@ services:
         CODEWHALE_IMAGE: ${CODEWHALE_IMAGE:-ghcr.io/hmbown/codewhale:latest}
         TOOLBOX_PACKAGES: ${TOOLBOX_PACKAGES:-git openssh-client curl build-essential pkg-config python3 python3-pip nodejs npm}
     environment:
-      DEEPSEEK_API_KEY: ${DEEPSEEK_API_KEY:?set DEEPSEEK_API_KEY}
-      DEEPSEEK_BASE_URL: ${DEEPSEEK_BASE_URL:-}
-      DEEPSEEK_NO_COLOR: ${DEEPSEEK_NO_COLOR:-}
+      - DEEPSEEK_API_KEY=${DEEPSEEK_API_KEY:?set DEEPSEEK_API_KEY}
+      - DEEPSEEK_BASE_URL
+      - DEEPSEEK_NO_COLOR
     volumes:
       - codewhale-home:/home/codewhale/.deepseek
-      - ${CODEWHALE_WORKSPACE:-../..}:/workspace
+      - ${CODEWHALE_WORKSPACE:?set CODEWHALE_WORKSPACE to the project directory}:/workspace
       # Mount SSH material only for projects that need it, and prefer read-only.
       # - ${HOME}/.ssh:/home/codewhale/.ssh:ro
       # Mount local CA certificates only when starting through a command that
       # runs `sudo update-ca-certificates` inside this toolbox image.
-      # - ${CODEWHALE_CERTS_DIR:-./docker/certs}:/usr/local/share/ca-certificates/local:ro
+      # - ${CODEWHALE_CERTS_DIR:-../../docker/certs}:/usr/local/share/ca-certificates/local:ro
     working_dir: /workspace
     stdin_open: true
     tty: true

--- a/docs/examples/compose.toolbox.yml
+++ b/docs/examples/compose.toolbox.yml
@@ -1,0 +1,40 @@
+# Opt-in CodeWhale toolbox workflow.
+#
+# Usage:
+#   CODEWHALE_IMAGE=ghcr.io/hmbown/codewhale:vX.Y.Z \
+#   CODEWHALE_TOOLBOX_IMAGE=codewhale-toolbox:my-project \
+#   CODEWHALE_HOME_VOLUME=codewhale-my-project-home \
+#   CODEWHALE_WORKSPACE="$PWD" \
+#   docker compose -f docs/examples/compose.toolbox.yml run --rm codewhale
+#
+# Keep CODEWHALE_HOME_VOLUME distinct per project so sessions, config, skills,
+# memory, and queued work do not bleed across workspaces.
+
+services:
+  codewhale:
+    image: ${CODEWHALE_TOOLBOX_IMAGE:-codewhale-toolbox:local}
+    build:
+      context: ../..
+      dockerfile: docs/examples/Dockerfile.toolbox
+      args:
+        CODEWHALE_IMAGE: ${CODEWHALE_IMAGE:-ghcr.io/hmbown/codewhale:latest}
+        TOOLBOX_PACKAGES: ${TOOLBOX_PACKAGES:-git openssh-client curl build-essential pkg-config python3 python3-pip nodejs npm}
+    environment:
+      DEEPSEEK_API_KEY: ${DEEPSEEK_API_KEY:?set DEEPSEEK_API_KEY}
+      DEEPSEEK_BASE_URL: ${DEEPSEEK_BASE_URL:-}
+      DEEPSEEK_NO_COLOR: ${DEEPSEEK_NO_COLOR:-}
+    volumes:
+      - codewhale-home:/home/codewhale/.deepseek
+      - ${CODEWHALE_WORKSPACE:-../..}:/workspace
+      # Mount SSH material only for projects that need it, and prefer read-only.
+      # - ${HOME}/.ssh:/home/codewhale/.ssh:ro
+      # Mount local CA certificates only when starting through a command that
+      # runs `sudo update-ca-certificates` inside this toolbox image.
+      # - ${CODEWHALE_CERTS_DIR:-./docker/certs}:/usr/local/share/ca-certificates/local:ro
+    working_dir: /workspace
+    stdin_open: true
+    tty: true
+
+volumes:
+  codewhale-home:
+    name: ${CODEWHALE_HOME_VOLUME:-codewhale-toolbox-home}


### PR DESCRIPTION
Fixes #2217

Summary:
- add a reusable docker compose toolbox template for opt-in sudo/dev packages/custom CA workflows
- document per-project image and .deepseek volume settings for independent project state
- keep the default GHCR image contract minimal and non-root

Validation:
- DEEPSEEK_API_KEY=dummy docker compose -f docs/examples/compose.toolbox.yml config

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a reusable `docker compose` entry point for the opt-in toolbox workflow and documents it in `DOCKER.md`. Both previously flagged issues (the `CODEWHALE_WORKSPACE` silent mis-mount and the `:-`-induced empty-string passthrough for optional env vars) have been corrected: `CODEWHALE_WORKSPACE` and `DEEPSEEK_API_KEY` now use `:?` to fail fast, and `DEEPSEEK_BASE_URL`/`DEEPSEEK_NO_COLOR` use bare variable references so they are only forwarded when set on the host.

- **`compose.toolbox.yml`**: new Compose template that builds from `Dockerfile.toolbox`, enforces required variables, and names the state volume explicitly via `CODEWHALE_HOME_VOLUME` so project isolation is intentional rather than accidental.
- **`DOCKER.md`**: new subsection under \"Opt-in toolbox/custom image\" showing the exact command, per-project variable strategy, and links to the compose and Dockerfile examples.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — documentation and a new compose template with no runtime logic changes to the core application.

Both changes are additive: a new compose template and a documentation subsection. The compose file correctly uses :? mandatory validation for the two variables that previously had risky defaults, and the optional env vars use bare references. The build context and Dockerfile path resolve correctly relative to the compose file's location within the repository. No application code is touched.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/examples/compose.toolbox.yml | New Docker Compose template for the opt-in toolbox workflow; uses :? mandatory validation for DEEPSEEK_API_KEY and CODEWHALE_WORKSPACE, bare variable passthrough for optional vars, and explicit volume naming — previously flagged issues have been addressed. |
| docs/DOCKER.md | Adds a 'Compose toolbox template' subsection under the existing opt-in toolbox section; documents usage, per-project image/volume variables, and links to the new compose file and existing Dockerfile.toolbox. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["User runs:\ndocker compose -f compose.toolbox.yml run --rm codewhale"] --> B{CODEWHALE_WORKSPACE set?}
    B -- No --> C["Compose errors out\n(:? mandatory validation)"]
    B -- Yes --> D{DEEPSEEK_API_KEY set?}
    D -- No --> E["Compose errors out\n(:? mandatory validation)"]
    D -- Yes --> F{CODEWHALE_TOOLBOX_IMAGE\nimage exists locally?}
    F -- No --> G["docker build\ncontext: repo root\nDockerfile: docs/examples/Dockerfile.toolbox\nArgs: CODEWHALE_IMAGE, TOOLBOX_PACKAGES"]
    G --> H["Tag as CODEWHALE_TOOLBOX_IMAGE"]
    F -- Yes --> I["Use cached image"]
    H --> J["Start container"]
    I --> J
    J --> K["Mount: CODEWHALE_WORKSPACE → /workspace"]
    J --> L["Mount: CODEWHALE_HOME_VOLUME → /home/codewhale/.deepseek"]
    J --> M["Env: DEEPSEEK_API_KEY\n+ optional DEEPSEEK_BASE_URL / DEEPSEEK_NO_COLOR"]
    K & L & M --> N["Interactive CodeWhale session"]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["docs(docker): tighten toolbox compose de..."](https://github.com/hmbown/codewhale/commit/81649c5f7d41f04a50780908c3425cb3162f16ff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34273098)</sub>

<!-- /greptile_comment -->