### PR TITLE
fix(tui): receipt live large tool outputs

### DIFF
--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -60,7 +60,7 @@ use crate::session_manager::{
 use crate::task_manager::{
     NewTaskRequest, SharedTaskManager, TaskManager, TaskManagerConfig, TaskStatus, TaskSummary,
 };
-use crate::tools::spec::RuntimeToolServices;
+use crate::tools::spec::{RuntimeToolServices, ToolResult};
 use crate::tools::subagent::SubAgentStatus;
 use crate::tui::auto_router;
 use crate::tui::color_compat::ColorCompatBackend;
@@ -1328,9 +1328,7 @@ async fn run_event_loop(
                         }
                         let tool_content = match &result {
                             Ok(output) => sanitize_stream_chunk(
-                                &crate::core::engine::compact_tool_result_for_context(
-                                    &app.model, &name, output,
-                                ),
+                                &tool_result_content_for_api_message(app, &id, &name, output),
                             ),
                             Err(err) => sanitize_stream_chunk(&format!("Error: {err}")),
                         };
@@ -4077,6 +4075,43 @@ fn push_assistant_message(
             content: blocks,
         });
     }
+}
+
+fn tool_result_content_for_api_message(
+    app: &App,
+    id: &str,
+    name: &str,
+    output: &ToolResult,
+) -> String {
+    let raw = output.content.trim();
+    if raw.is_empty() {
+        return String::new();
+    }
+
+    if raw.chars().count() > crate::tool_output_receipts::RAW_TOOL_OUTPUT_RECEIPT_THRESHOLD_CHARS {
+        let mut messages = app.api_messages.clone();
+        messages.push(Message {
+            role: "user".to_string(),
+            content: vec![ContentBlock::ToolResult {
+                tool_use_id: id.to_string(),
+                content: raw.to_string(),
+                is_error: Some(!output.success),
+                content_blocks: None,
+            }],
+        });
+        let (compacted, stats) = crate::tool_output_receipts::compact_messages_for_persistence(
+            &messages,
+            &app.session_artifacts,
+        );
+        if stats.compacted_count > 0
+            && let Some(Message { content, .. }) = compacted.last()
+            && let Some(ContentBlock::ToolResult { content, .. }) = content.first()
+        {
+            return content.clone();
+        }
+    }
+
+    crate::core::engine::compact_tool_result_for_context(&app.model, name, output)
 }
 
 fn replace_matching_assistant_text(

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -1328,7 +1328,7 @@ async fn run_event_loop(
                         }
                         let tool_content = match &result {
                             Ok(output) => sanitize_stream_chunk(
-                                &tool_result_content_for_api_message(app, &id, &name, output),
+                                &tool_result_content_for_api_message(app, &id, &name, output).await,
                             ),
                             Err(err) => sanitize_stream_chunk(&format!("Error: {err}")),
                         };
@@ -4077,7 +4077,7 @@ fn push_assistant_message(
     }
 }
 
-fn tool_result_content_for_api_message(
+async fn tool_result_content_for_api_message(
     app: &App,
     id: &str,
     name: &str,
@@ -4089,29 +4089,69 @@ fn tool_result_content_for_api_message(
     }
 
     if raw.chars().count() > crate::tool_output_receipts::RAW_TOOL_OUTPUT_RECEIPT_THRESHOLD_CHARS {
-        let mut messages = app.api_messages.clone();
-        messages.push(Message {
-            role: "user".to_string(),
-            content: vec![ContentBlock::ToolResult {
-                tool_use_id: id.to_string(),
-                content: raw.to_string(),
-                is_error: Some(!output.success),
-                content_blocks: None,
-            }],
-        });
-        let (compacted, stats) = crate::tool_output_receipts::compact_messages_for_persistence(
-            &messages,
-            &app.session_artifacts,
-        );
-        if stats.compacted_count > 0
-            && let Some(Message { content, .. }) = compacted.last()
-            && let Some(ContentBlock::ToolResult { content, .. }) = content.first()
+        let messages = live_tool_receipt_messages(app, id, raw, output.success);
+        let artifacts = app.session_artifacts.clone();
+        let raw = raw.to_string();
+        match tokio::task::spawn_blocking(move || {
+            compact_live_tool_receipt(messages, artifacts, raw)
+        })
+        .await
         {
-            return content.clone();
+            Ok(Some(receipt)) => return receipt,
+            Ok(None) => {}
+            Err(err) => {
+                crate::logging::warn(format!("live tool-output receipt compaction failed: {err}"));
+            }
         }
     }
 
     crate::core::engine::compact_tool_result_for_context(&app.model, name, output)
+}
+
+fn live_tool_receipt_messages(app: &App, id: &str, raw: &str, success: bool) -> Vec<Message> {
+    let mut messages = Vec::with_capacity(2);
+    if let Some(tool_use_msg) = app.api_messages.iter().rev().find(|message| {
+        message.content.iter().any(|block| {
+            matches!(block, ContentBlock::ToolUse { id: tool_use_id, .. } if tool_use_id == id)
+        })
+    }) {
+        messages.push(tool_use_msg.clone());
+    }
+    messages.push(Message {
+        role: "user".to_string(),
+        content: vec![ContentBlock::ToolResult {
+            tool_use_id: id.to_string(),
+            content: raw.to_string(),
+            is_error: Some(!success),
+            content_blocks: None,
+        }],
+    });
+    messages
+}
+
+fn compact_live_tool_receipt(
+    messages: Vec<Message>,
+    artifacts: Vec<crate::artifacts::ArtifactRecord>,
+    raw: String,
+) -> Option<String> {
+    let (compacted, _) =
+        crate::tool_output_receipts::compact_messages_for_persistence(&messages, &artifacts);
+    let content = compacted
+        .last()
+        .and_then(|message| message.content.first())
+        .and_then(|block| match block {
+            ContentBlock::ToolResult { content, .. } => Some(content),
+            _ => None,
+        })?;
+    if content != &raw && live_tool_content_is_receipt(content) {
+        Some(content.clone())
+    } else {
+        None
+    }
+}
+
+fn live_tool_content_is_receipt(content: &str) -> bool {
+    content.trim_start().starts_with("[TOOL_OUTPUT_RECEIPT]")
 }
 
 fn replace_matching_assistant_text(

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -1359,6 +1359,50 @@ fn create_test_options() -> TuiOptions {
     }
 }
 
+#[test]
+fn tool_result_api_content_receipts_large_live_output() {
+    let _guard = crate::tools::truncate::TEST_SPILLOVER_GUARD
+        .lock()
+        .unwrap_or_else(|err| err.into_inner());
+    let tmp = TempDir::new().expect("spillover tempdir");
+    let prior = crate::tools::truncate::set_test_spillover_root(Some(
+        tmp.path().join(".deepseek").join("tool_outputs"),
+    ));
+    struct Restore(Option<PathBuf>);
+    impl Drop for Restore {
+        fn drop(&mut self) {
+            crate::tools::truncate::set_test_spillover_root(self.0.take());
+        }
+    }
+    let _restore = Restore(prior);
+
+    let mut app = App::new(create_test_options(), &Config::default());
+    app.api_messages.push(Message {
+        role: "assistant".to_string(),
+        content: vec![ContentBlock::ToolUse {
+            id: "call-live-big".to_string(),
+            name: "exec_shell".to_string(),
+            input: serde_json::json!({"command": "cargo test"}),
+            caller: None,
+        }],
+    });
+
+    let raw = "LIVE_RAW_SENTINEL\n".repeat(900);
+    let output = crate::tools::spec::ToolResult::success(raw.clone());
+    let content = tool_result_content_for_api_message(&app, "call-live-big", "exec_shell", &output);
+
+    assert!(content.contains("[TOOL_OUTPUT_RECEIPT]"));
+    assert!(content.contains("tool: exec_shell"));
+    assert!(content.contains("tool_call_id: call-live-big"));
+    assert!(content.contains("detail_handle: sha:"));
+    assert!(content.contains("retrieve: retrieve_tool_result ref=sha:"));
+    assert!(!content.contains(&raw));
+    assert!(
+        content.chars().count()
+            < crate::tool_output_receipts::RAW_TOOL_OUTPUT_RECEIPT_THRESHOLD_CHARS
+    );
+}
+
 fn text_message(role: &str, text: &str) -> Message {
     Message {
         role: role.to_string(),

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -1359,8 +1359,8 @@ fn create_test_options() -> TuiOptions {
     }
 }
 
-#[test]
-fn tool_result_api_content_receipts_large_live_output() {
+#[tokio::test]
+async fn tool_result_api_content_receipts_large_live_output() {
     let _guard = crate::tools::truncate::TEST_SPILLOVER_GUARD
         .lock()
         .unwrap_or_else(|err| err.into_inner());
@@ -1389,7 +1389,8 @@ fn tool_result_api_content_receipts_large_live_output() {
 
     let raw = "LIVE_RAW_SENTINEL\n".repeat(900);
     let output = crate::tools::spec::ToolResult::success(raw.clone());
-    let content = tool_result_content_for_api_message(&app, "call-live-big", "exec_shell", &output);
+    let content =
+        tool_result_content_for_api_message(&app, "call-live-big", "exec_shell", &output).await;
 
     assert!(content.contains("[TOOL_OUTPUT_RECEIPT]"));
     assert!(content.contains("tool: exec_shell"));
@@ -1401,6 +1402,51 @@ fn tool_result_api_content_receipts_large_live_output() {
         content.chars().count()
             < crate::tool_output_receipts::RAW_TOOL_OUTPUT_RECEIPT_THRESHOLD_CHARS
     );
+}
+
+#[test]
+fn live_tool_receipt_messages_clones_only_matching_tool_use() {
+    let mut app = App::new(create_test_options(), &Config::default());
+    app.api_messages.push(Message {
+        role: "assistant".to_string(),
+        content: vec![ContentBlock::ToolUse {
+            id: "call-old".to_string(),
+            name: "exec_shell".to_string(),
+            input: serde_json::json!({"command": "old"}),
+            caller: None,
+        }],
+    });
+    app.api_messages.push(Message {
+        role: "user".to_string(),
+        content: vec![ContentBlock::ToolResult {
+            tool_use_id: "call-old".to_string(),
+            content: "OLD_RAW\n".repeat(2_000),
+            is_error: None,
+            content_blocks: None,
+        }],
+    });
+    app.api_messages.push(Message {
+        role: "assistant".to_string(),
+        content: vec![ContentBlock::ToolUse {
+            id: "call-new".to_string(),
+            name: "read_file".to_string(),
+            input: serde_json::json!({"path": "src/main.rs"}),
+            caller: None,
+        }],
+    });
+
+    let messages = live_tool_receipt_messages(&app, "call-new", "NEW_RAW", true);
+
+    assert_eq!(messages.len(), 2);
+    assert!(matches!(
+        &messages[0].content[0],
+        ContentBlock::ToolUse { id, name, .. } if id == "call-new" && name == "read_file"
+    ));
+    assert!(matches!(
+        &messages[1].content[0],
+        ContentBlock::ToolResult { tool_use_id, content, .. }
+            if tool_use_id == "call-new" && content == "NEW_RAW"
+    ));
 }
 
 fn text_message(role: &str, text: &str) -> Message {


### PR DESCRIPTION
Fixes #2021

Summary:
- cap live tool-result replay before it enters api_messages
- persist oversized raw output behind SHA/detail handles and send bounded TOOL_OUTPUT_RECEIPT text instead
- keep existing model-specific context compaction for small outputs and add regression coverage

Validation:
- cargo test -p codewhale-tui --bin codewhale-tui tool_result_api_content_receipts_large_live_output
- cargo test -p codewhale-tui --bin codewhale-tui compacts_large_tool_result_to_sha_receipt_when_no_artifact_exists
- cargo test -p codewhale-tui --bin codewhale-tui save_session_compacts_large_tool_outputs_to_artifact_receipts

Note:
- An unqualified cargo test filter also tried to launch tests/skill_install on Windows and failed with OS error 740 (requires elevation), so validation was rerun with --bin codewhale-tui.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR caps large live tool outputs before they enter `api_messages` by generating a `[TOOL_OUTPUT_RECEIPT]` summary (with a SHA-addressed spillover file for later retrieval) instead of forwarding the raw text verbatim. It also addresses three issues raised in the previous review round.

- **Minimal slice compaction**: `live_tool_receipt_messages` now builds a 2-message slice (matching ToolUse + new ToolResult) instead of cloning the full conversation history, eliminating the O(n²) allocation cost for long sessions with repeated large outputs.
- **Non-blocking I/O**: The SHA spillover write (`persist_sha_tool_result`) is now offloaded to `tokio::task::spawn_blocking`, preventing disk I/O from stalling the TUI event loop on single-threaded runtimes.
- **Precise compaction guard**: The old `stats.compacted_count > 0` check (which could be tripped by earlier unrelated receipts in history) is replaced by `content != &raw && live_tool_content_is_receipt(content)`, directly verifying that the returned content is actually a receipt for the current output.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the three previously raised issues are addressed and no new defects were found on the changed path.

The compaction guard now directly verifies the returned content is a receipt (not a reused stat from an unrelated prior message), the file write is moved off the event-loop thread, and the history clone is replaced by a minimal 2-message slice. All three changes are narrowly scoped and covered by new regression tests. The only remaining observation is a minor style point about live_tool_content_is_receipt duplicating part of looks_like_receipt.

No files require special attention. The single style observation is in ui.rs at the live_tool_content_is_receipt helper.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/ui.rs | Adds tool_result_content_for_api_message (async), live_tool_receipt_messages, compact_live_tool_receipt, and live_tool_content_is_receipt to cap large live tool outputs before they enter api_messages; offloads file I/O to spawn_blocking and limits compaction input to a 2-message slice. |
| crates/tui/src/tui/ui/tests.rs | Adds two regression tests: an async end-to-end test confirming large live output becomes a [TOOL_OUTPUT_RECEIPT], and a unit test verifying live_tool_receipt_messages only clones the single matching ToolUse message. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant EL as run_event_loop
    participant TR as tool_result_content_for_api_message
    participant LR as live_tool_receipt_messages
    participant SB as spawn_blocking thread
    participant CM as compact_messages_for_persistence
    participant FB as compact_tool_result_for_context

    EL->>TR: await (app, id, name, output)
    alt "output.chars > RAW_THRESHOLD (12k)"
        TR->>LR: build minimal msg slice
        Note over LR: search api_messages rev for matching ToolUse id, push [ToolUse?, ToolResult]
        LR-->>TR: "Vec<Message> (1-2 msgs)"
        TR->>SB: spawn_blocking(compact_live_tool_receipt)
        SB->>CM: compact_messages_for_persistence(2-msg slice, artifacts)
        CM-->>SB: (compacted, _)
        Note over SB: check content != raw AND starts_with [TOOL_OUTPUT_RECEIPT]
        SB-->>TR: "Option<String>"
        alt Some(receipt)
            TR-->>EL: receipt string
        else None or JoinError
            TR->>FB: compact_tool_result_for_context(model, name, output)
            FB-->>TR: model-specific snippet
            TR-->>EL: compacted snippet
        end
    else "output <= threshold or empty"
        TR->>FB: compact_tool_result_for_context
        FB-->>TR: model-specific snippet
        TR-->>EL: compacted snippet
    end
    EL->>EL: push to api_messages
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2F2021-live-tool-output-receipts%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F2021-live-tool-output-receipts%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui.rs%3A4153-4155%0A%60live_tool_content_is_receipt%60%20only%20checks%20for%20the%20%60%5BTOOL_OUTPUT_RECEIPT%5D%60%20prefix%2C%20while%20%60looks_like_receipt%60%20in%20%60tool_output_receipts%60%20also%20covers%20%60%5Bartifact%3A%60%2C%20%60%5BTOOL_RESULT_TRUNCATED%5D%60%2C%20and%20%60%3CTOOL_RESULT_REF%60.%20Today%20%60render_tool_output_receipt%60%20always%20emits%20%60%5BTOOL_OUTPUT_RECEIPT%5D%60%2C%20so%20this%20is%20harmless%3B%20but%20if%20a%20new%20receipt%20format%20is%20ever%20added%2C%20%60compact_live_tool_receipt%60%20would%20fail%20to%20recognise%20it%20and%20silently%20fall%20back%20to%20%60compact_tool_result_for_context%60.%20Consider%20making%20%60looks_like_receipt%60%20pub%28crate%29%20and%20reusing%20it%20here%20for%20a%20single%20source%20of%20truth.%0A%0A%60%60%60suggestion%0Afn%20live_tool_content_is_receipt%28content%3A%20%26str%29%20-%3E%20bool%20%7B%0A%20%20%20%20crate%3A%3Atool_output_receipts%3A%3Alooks_like_receipt%28content%29%0A%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui.rs%3A4153-4155%0A%60live_tool_content_is_receipt%60%20only%20checks%20for%20the%20%60%5BTOOL_OUTPUT_RECEIPT%5D%60%20prefix%2C%20while%20%60looks_like_receipt%60%20in%20%60tool_output_receipts%60%20also%20covers%20%60%5Bartifact%3A%60%2C%20%60%5BTOOL_RESULT_TRUNCATED%5D%60%2C%20and%20%60%3CTOOL_RESULT_REF%60.%20Today%20%60render_tool_output_receipt%60%20always%20emits%20%60%5BTOOL_OUTPUT_RECEIPT%5D%60%2C%20so%20this%20is%20harmless%3B%20but%20if%20a%20new%20receipt%20format%20is%20ever%20added%2C%20%60compact_live_tool_receipt%60%20would%20fail%20to%20recognise%20it%20and%20silently%20fall%20back%20to%20%60compact_tool_result_for_context%60.%20Consider%20making%20%60looks_like_receipt%60%20pub%28crate%29%20and%20reusing%20it%20here%20for%20a%20single%20source%20of%20truth.%0A%0A%60%60%60suggestion%0Afn%20live_tool_content_is_receipt%28content%3A%20%26str%29%20-%3E%20bool%20%7B%0A%20%20%20%20crate%3A%3Atool_output_receipts%3A%3Alooks_like_receipt%28content%29%0A%7D%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2297&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui.rs%3A4153-4155%0A%60live_tool_content_is_receipt%60%20only%20checks%20for%20the%20%60%5BTOOL_OUTPUT_RECEIPT%5D%60%20prefix%2C%20while%20%60looks_like_receipt%60%20in%20%60tool_output_receipts%60%20also%20covers%20%60%5Bartifact%3A%60%2C%20%60%5BTOOL_RESULT_TRUNCATED%5D%60%2C%20and%20%60%3CTOOL_RESULT_REF%60.%20Today%20%60render_tool_output_receipt%60%20always%20emits%20%60%5BTOOL_OUTPUT_RECEIPT%5D%60%2C%20so%20this%20is%20harmless%3B%20but%20if%20a%20new%20receipt%20format%20is%20ever%20added%2C%20%60compact_live_tool_receipt%60%20would%20fail%20to%20recognise%20it%20and%20silently%20fall%20back%20to%20%60compact_tool_result_for_context%60.%20Consider%20making%20%60looks_like_receipt%60%20pub%28crate%29%20and%20reusing%20it%20here%20for%20a%20single%20source%20of%20truth.%0A%0A%60%60%60suggestion%0Afn%20live_tool_content_is_receipt%28content%3A%20%26str%29%20-%3E%20bool%20%7B%0A%20%20%20%20crate%3A%3Atool_output_receipts%3A%3Alooks_like_receipt%28content%29%0A%7D%0A%60%60%60%0A%0A&pr=2297&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix(tui): avoid live receipt history clo..."](https://github.com/hmbown/codewhale/commit/679a844d406b288bd3a9fc7ec6c12d9531db11b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34273131)</sub>

<!-- /greptile_comment -->