### PR TITLE
feat(tui): enrich activity detail context

### DIFF
--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -7591,15 +7591,20 @@ fn activity_detail_text(app: &App, cell_index: usize, width: u16) -> Option<Stri
         sections.push(status);
     }
 
-    if let Some((position, total)) = activity_position(app, cell_index) {
-        sections.push(format!("Activity chunk: {position} of {total}"));
+    let activity_indices = activity_indices(app);
+    if let Some(position) = activity_indices.iter().position(|&idx| idx == cell_index) {
+        sections.push(format!(
+            "Activity chunk: {} of {}",
+            position + 1,
+            activity_indices.len()
+        ));
+        sections.extend(activity_navigation_lines(app, position, &activity_indices));
     }
 
     if let Some(handle) = activity_detail_handle_line(app, cell_index, cell) {
         sections.push(handle);
     }
 
-    sections.extend(activity_navigation_lines(app, cell_index));
     sections.push(String::new());
     sections.push(activity_cell_to_text(cell, width));
     Some(sections.join("\n"))
@@ -7826,34 +7831,20 @@ fn format_activity_duration_ms(ms: u64) -> String {
     }
 }
 
-fn activity_position(app: &App, cell_index: usize) -> Option<(usize, usize)> {
-    let mut total = 0usize;
-    let mut position = None;
-    for idx in 0..app.virtual_cell_count() {
-        let Some(cell) = app.cell_at_virtual_index(idx) else {
-            continue;
-        };
-        if !is_meaningful_activity_cell(cell) {
-            continue;
-        }
-        total += 1;
-        if idx == cell_index {
-            position = Some(total);
-        }
-    }
-    position.map(|pos| (pos, total))
-}
-
-fn activity_navigation_lines(app: &App, cell_index: usize) -> Vec<String> {
-    let activity_indices: Vec<usize> = (0..app.virtual_cell_count())
+fn activity_indices(app: &App) -> Vec<usize> {
+    (0..app.virtual_cell_count())
         .filter(|&idx| {
             app.cell_at_virtual_index(idx)
                 .is_some_and(is_meaningful_activity_cell)
         })
-        .collect();
-    let Some(position) = activity_indices.iter().position(|&idx| idx == cell_index) else {
-        return Vec::new();
-    };
+        .collect()
+}
+
+fn activity_navigation_lines(
+    app: &App,
+    position: usize,
+    activity_indices: &[usize],
+) -> Vec<String> {
     let total = activity_indices.len();
     let mut lines = Vec::new();
     if position > 0 {
@@ -7900,9 +7891,7 @@ fn activity_detail_handle_line(app: &App, cell_index: usize, cell: &HistoryCell)
     }
 
     match cell {
-        HistoryCell::Tool(_) if app.cell_has_detail_target(cell_index) => {
-            Some("Detail handle: Alt+V raw details".to_string())
-        }
+        HistoryCell::Tool(_) => Some("Detail handle: Alt+V details".to_string()),
         HistoryCell::SubAgent(_) => Some("Detail handle: Alt+V details".to_string()),
         _ => None,
     }

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -7591,10 +7591,15 @@ fn activity_detail_text(app: &App, cell_index: usize, width: u16) -> Option<Stri
         sections.push(status);
     }
 
-    if let Some((position, total)) = thinking_chunk_position(app, cell_index) {
-        sections.push(format!("Thinking chunk: {position} of {total}"));
+    if let Some((position, total)) = activity_position(app, cell_index) {
+        sections.push(format!("Activity chunk: {position} of {total}"));
     }
 
+    if let Some(handle) = activity_detail_handle_line(app, cell_index, cell) {
+        sections.push(handle);
+    }
+
+    sections.extend(activity_navigation_lines(app, cell_index));
     sections.push(String::new());
     sections.push(activity_cell_to_text(cell, width));
     Some(sections.join("\n"))
@@ -7644,6 +7649,22 @@ fn reasoning_timeline_text(app: &App, selected_cell_index: usize) -> Option<Stri
     ));
     if let Some(position) = selected_position {
         sections.push(format!("Selected chunk: {position} of {total}"));
+        if position > 1 {
+            let previous_index = thinking_indices[position - 2];
+            let preview = thinking_chunk_preview(app, previous_index);
+            sections.push(format!(
+                "Previous chunk: {} of {total} - {preview}",
+                position - 1
+            ));
+        }
+        if position < total {
+            let next_index = thinking_indices[position];
+            let preview = thinking_chunk_preview(app, next_index);
+            sections.push(format!(
+                "Next chunk: {} of {total} - {preview}",
+                position + 1
+            ));
+        }
     }
     sections.push(String::new());
 
@@ -7683,6 +7704,18 @@ fn reasoning_timeline_text(app: &App, selected_cell_index: usize) -> Option<Stri
     }
 
     Some(sections.join("\n"))
+}
+
+fn thinking_chunk_preview(app: &App, cell_index: usize) -> String {
+    let Some(HistoryCell::Thinking { content, .. }) = app.cell_at_virtual_index(cell_index) else {
+        return "thinking".to_string();
+    };
+    let preview = one_line_summary(content, 64);
+    if preview.is_empty() {
+        "thinking".to_string()
+    } else {
+        preview
+    }
 }
 
 fn activity_cell_label(app: &App, cell_index: usize, cell: &HistoryCell) -> String {
@@ -7793,28 +7826,86 @@ fn format_activity_duration_ms(ms: u64) -> String {
     }
 }
 
-fn thinking_chunk_position(app: &App, cell_index: usize) -> Option<(usize, usize)> {
-    if !matches!(
-        app.cell_at_virtual_index(cell_index),
-        Some(HistoryCell::Thinking { .. })
-    ) {
-        return None;
-    }
-
+fn activity_position(app: &App, cell_index: usize) -> Option<(usize, usize)> {
     let mut total = 0usize;
     let mut position = None;
     for idx in 0..app.virtual_cell_count() {
-        if matches!(
-            app.cell_at_virtual_index(idx),
-            Some(HistoryCell::Thinking { .. })
-        ) {
-            total += 1;
-            if idx == cell_index {
-                position = Some(total);
-            }
+        let Some(cell) = app.cell_at_virtual_index(idx) else {
+            continue;
+        };
+        if !is_meaningful_activity_cell(cell) {
+            continue;
+        }
+        total += 1;
+        if idx == cell_index {
+            position = Some(total);
         }
     }
     position.map(|pos| (pos, total))
+}
+
+fn activity_navigation_lines(app: &App, cell_index: usize) -> Vec<String> {
+    let activity_indices: Vec<usize> = (0..app.virtual_cell_count())
+        .filter(|&idx| {
+            app.cell_at_virtual_index(idx)
+                .is_some_and(is_meaningful_activity_cell)
+        })
+        .collect();
+    let Some(position) = activity_indices.iter().position(|&idx| idx == cell_index) else {
+        return Vec::new();
+    };
+    let total = activity_indices.len();
+    let mut lines = Vec::new();
+    if position > 0 {
+        let previous_idx = activity_indices[position - 1];
+        if let Some(cell) = app.cell_at_virtual_index(previous_idx) {
+            let label = activity_cell_label(app, previous_idx, cell);
+            lines.push(format!(
+                "Previous activity: {} of {total} - {}",
+                position,
+                truncate_line_to_width(&label, 56)
+            ));
+        }
+    }
+    if position + 1 < total {
+        let next_idx = activity_indices[position + 1];
+        if let Some(cell) = app.cell_at_virtual_index(next_idx) {
+            let label = activity_cell_label(app, next_idx, cell);
+            lines.push(format!(
+                "Next activity: {} of {total} - {}",
+                position + 2,
+                truncate_line_to_width(&label, 56)
+            ));
+        }
+    }
+    lines
+}
+
+fn activity_detail_handle_line(app: &App, cell_index: usize, cell: &HistoryCell) -> Option<String> {
+    if let Some(detail) = app.tool_detail_record_for_cell(cell_index) {
+        if let Some(artifact) = app
+            .session_artifacts
+            .iter()
+            .find(|artifact| artifact.tool_call_id == detail.tool_id)
+        {
+            return Some(format!(
+                "Detail handle: {} (retrieve_tool_result ref={}; Alt+V raw details)",
+                artifact.id, artifact.id
+            ));
+        }
+        return Some(format!(
+            "Detail handle: tool:{} (Alt+V raw details)",
+            detail.tool_id
+        ));
+    }
+
+    match cell {
+        HistoryCell::Tool(_) if app.cell_has_detail_target(cell_index) => {
+            Some("Detail handle: Alt+V raw details".to_string())
+        }
+        HistoryCell::SubAgent(_) => Some("Detail handle: Alt+V details".to_string()),
+        _ => None,
+    }
 }
 
 fn activity_cell_to_text(cell: &HistoryCell, width: u16) -> String {

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -5048,6 +5048,10 @@ fn activity_detail_opens_reasoning_timeline_for_selected_thinking() {
         body.contains("Selected chunk: 1 of 2"),
         "chunk position missing: {body}"
     );
+    assert!(
+        body.contains("Next chunk: 2 of 2 - second chunk reasoning"),
+        "neighboring chunk missing: {body}"
+    );
     assert!(body.contains("Thinking chunk 1 of 2 (selected)"), "{body}");
     assert!(body.contains("Thinking chunk 2 of 2"), "{body}");
     assert!(body.contains("first chunk reasoning"), "body: {body}");
@@ -5055,6 +5059,95 @@ fn activity_detail_opens_reasoning_timeline_for_selected_thinking() {
         body.contains("second chunk reasoning"),
         "timeline should include the whole session's thinking: {body}"
     );
+}
+
+#[test]
+fn activity_detail_includes_tool_handle_and_neighbor_context() {
+    let mut app = create_test_app();
+    app.history = vec![
+        HistoryCell::Thinking {
+            content: "checked approach".to_string(),
+            streaming: false,
+            duration_secs: Some(0.6),
+        },
+        HistoryCell::Tool(ToolCell::Generic(GenericToolCell {
+            name: "read_file".to_string(),
+            status: ToolStatus::Success,
+            input_summary: Some("src/main.rs".to_string()),
+            output: Some("bounded preview".to_string()),
+            prompts: None,
+            spillover_path: None,
+            output_summary: None,
+            is_diff: false,
+        })),
+        HistoryCell::Tool(ToolCell::Generic(GenericToolCell {
+            name: "grep_files".to_string(),
+            status: ToolStatus::Success,
+            input_summary: Some("TODO".to_string()),
+            output: Some("grep summary".to_string()),
+            prompts: None,
+            spillover_path: None,
+            output_summary: None,
+            is_diff: false,
+        })),
+    ];
+    app.tool_details_by_cell.insert(
+        1,
+        ToolDetailRecord {
+            tool_id: "call-read".to_string(),
+            tool_name: "read_file".to_string(),
+            input: serde_json::json!({"path": "src/main.rs"}),
+            output: Some("full output behind raw details".to_string()),
+        },
+    );
+    app.session_artifacts
+        .push(crate::artifacts::ArtifactRecord {
+            id: "art_call-read".to_string(),
+            kind: crate::artifacts::ArtifactKind::ToolOutput,
+            session_id: "session-activity".to_string(),
+            tool_call_id: "call-read".to_string(),
+            tool_name: "read_file".to_string(),
+            created_at: chrono::Utc::now(),
+            byte_size: 42,
+            preview: "bounded preview".to_string(),
+            storage_path: PathBuf::from("artifacts").join("art_call-read.txt"),
+        });
+    app.resync_history_revisions();
+    let revisions = app.history_revisions.clone();
+    app.viewport.transcript_cache.ensure(
+        &app.history,
+        &revisions,
+        100,
+        app.transcript_render_options(),
+    );
+    let line = first_line_for_cell(&app, 1);
+    let point = TranscriptSelectionPoint {
+        line_index: line,
+        column: 0,
+    };
+    app.viewport.transcript_selection.anchor = Some(point);
+    app.viewport.transcript_selection.head = Some(point);
+
+    assert!(open_activity_detail_pager(&mut app));
+    let body = pop_pager_body(&mut app);
+
+    assert!(body.contains("Activity: read_file"), "{body}");
+    assert!(body.contains("Activity chunk: 2 of 3"), "{body}");
+    assert!(
+        body.contains("Previous activity: 1 of 3 - thinking"),
+        "{body}"
+    );
+    assert!(
+        body.contains("Next activity: 3 of 3 - tool grep_files"),
+        "{body}"
+    );
+    assert!(body.contains("Detail handle: art_call-read"), "{body}");
+    assert!(
+        body.contains("retrieve_tool_result ref=art_call-read"),
+        "{body}"
+    );
+    assert!(body.contains("Alt+V"), "{body}");
+    assert!(body.contains("raw details"), "{body}");
 }
 
 #[test]

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -5208,6 +5208,11 @@ fn activity_detail_fallback_uses_recent_meaningful_activity_without_full_tool_du
         body.contains("Alt+V for details"),
         "activity detail should stay bounded and point to Alt+V for raw detail: {body}"
     );
+    assert!(body.contains("Detail handle: Alt+V details"), "{body}");
+    assert!(
+        !body.contains("Detail handle: Alt+V raw details"),
+        "fallback tool details should not be labeled raw: {body}"
+    );
     assert!(
         !body.contains("line 10"),
         "middle of large raw output should not be dumped into Activity Detail: {body}"


### PR DESCRIPTION
Fixes #1547

Summary:
- add Activity Detail position and previous/next activity context for Ctrl+O
- include artifact/retrieve or Alt+V detail handles without dumping raw tool output into the pager
- add neighboring reasoning chunk previews in the reasoning timeline

Validation:
- cargo test -p codewhale-tui --bin codewhale-tui activity_detail

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR enriches the Activity Detail pager (Ctrl+O) with position/navigation context and tool artifact handle lines, and adds neighboring reasoning-chunk previews in the reasoning timeline view.

- `activity_detail_text` now computes an `activity_indices` vector and emits an "Activity chunk: X of Y" line plus Previous/Next activity labels by delegating to the new `activity_navigation_lines` helper; `activity_detail_handle_line` adds a "Detail handle" line that describes whether the cell is backed by a session artifact, a raw tool-call record, or a generic Alt+V shortcut.
- `reasoning_timeline_text` gains "Previous chunk" / "Next chunk" preview lines around the selected chunk, sourcing content from the new `thinking_chunk_preview` helper.
- `tests.rs` gains one new test (`activity_detail_includes_tool_handle_and_neighbor_context`) and extends two existing tests to cover the new output lines.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all new display-only helpers are read-only and bounded correctly.

The changes are purely presentational: no state mutation, no new I/O paths, and no changes to data ownership. The indexing arithmetic in both the 0-based activity helpers and the 1-based reasoning-timeline helpers is correct, all array accesses are guarded against out-of-bounds, and the new test covers the artifact-handle and neighbor-navigation paths end-to-end.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/ui.rs | Adds activity_indices, activity_navigation_lines, activity_detail_handle_line, and thinking_chunk_preview helpers; updates activity_detail_text and reasoning_timeline_text to emit position/navigation/handle context. Indexing arithmetic is correct and bounds guards are sound. |
| crates/tui/src/tui/ui/tests.rs | New test activity_detail_includes_tool_handle_and_neighbor_context covers artifact-backed handle lines and prev/next navigation; existing tests extended with neighboring-chunk assertions. Coverage is thorough and assertions are precise. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Ctrl+O pressed"] --> B["open_activity_detail_pager"]
    B --> C["activity_detail_text(app, cell_index, width)"]
    C --> D{Is cell Thinking?}
    D -- Yes --> E["reasoning_timeline_text(app, cell_index)"]
    D -- No --> F["Build sections: turn, activity label, status"]
    E --> G["Compute thinking_indices (all Thinking cells)"]
    G --> H["Emit 'Selected chunk: X of N'"]
    H --> I{position > 1?}
    I -- Yes --> J["thinking_chunk_preview → 'Previous chunk: X-1 of N - preview'"]
    I -- No --> K
    J --> K{position < total?}
    K -- Yes --> L["thinking_chunk_preview → 'Next chunk: X+1 of N - preview'"]
    K -- No --> M["Emit full timeline list"]
    L --> M
    F --> N["activity_indices (all meaningful cells)"]
    N --> O["Emit 'Activity chunk: X of Y'"]
    O --> P["activity_navigation_lines → prev/next labels"]
    P --> Q["activity_detail_handle_line"]
    Q --> R{tool_detail_record?}
    R -- Yes + artifact --> S["'Detail handle: ART_ID (retrieve_tool_result ref=...; Alt+V raw details)'"]
    R -- Yes, no artifact --> T["'Detail handle: tool:CALL_ID (Alt+V raw details)'"]
    R -- No, Tool/SubAgent --> U["'Detail handle: Alt+V details'"]
    R -- No, other --> V["no handle line"]
    S & T & U & V --> W["Emit activity body text"]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(tui): refine activity detail review ..."](https://github.com/hmbown/codewhale/commit/6d004597301fa6dccb76dd36112d612bd8371028) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34273151)</sub>

<!-- /greptile_comment -->