### PR TITLE
fix(mcp): Fix legacy MCP SSE connections

### DIFF
--- a/crates/tui/src/commands/mcp.rs
+++ b/crates/tui/src/commands/mcp.rs
@@ -56,9 +56,15 @@ fn parse_add(parts: Vec<&str>) -> CommandResult {
             command: parts[2].to_string(),
             args: parts[3..].iter().map(|s| (*s).to_string()).collect(),
         })),
-        "http" | "sse" => CommandResult::action(AppAction::Mcp(McpUiAction::AddHttp {
+        "http" => CommandResult::action(AppAction::Mcp(McpUiAction::AddHttp {
             name: parts[1].to_string(),
             url: parts[2].to_string(),
+            transport: None,
+        })),
+        "sse" => CommandResult::action(AppAction::Mcp(McpUiAction::AddHttp {
+            name: parts[1].to_string(),
+            url: parts[2].to_string(),
+            transport: Some("sse".to_string()),
         })),
         _ => CommandResult::error(
             "Usage: /mcp add stdio <name> <command> [args...] OR /mcp add http <name> <url>",

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -631,6 +631,9 @@ enum McpCommand {
         /// URL for streamable HTTP/SSE server
         #[arg(long, conflicts_with = "command")]
         url: Option<String>,
+        /// Explicit URL transport override. Use "sse" for legacy SSE endpoints.
+        #[arg(long, requires = "url")]
+        transport: Option<String>,
         /// Arguments for command-based servers
         #[arg(long = "arg")]
         args: Vec<String>,
@@ -1417,6 +1420,7 @@ fn mcp_template_json() -> Result<String> {
             args: vec!["./path/to/your-mcp-server.js".to_string()],
             env: std::collections::HashMap::new(),
             url: None,
+            transport: None,
             connect_timeout: None,
             execute_timeout: None,
             read_timeout: None,
@@ -4131,10 +4135,16 @@ async fn run_mcp_command(config: &Config, command: McpCommand) -> Result<()> {
             name,
             command,
             url,
+            transport,
             args,
         } => {
             if command.is_none() && url.is_none() {
                 bail!("Provide either --command or --url for `mcp add`.");
+            }
+            if let Some(transport) = transport.as_deref() {
+                if !transport.trim().eq_ignore_ascii_case("sse") {
+                    bail!("Unsupported MCP transport '{transport}'. Supported values: sse");
+                }
             }
             let mut cfg = load_mcp_config(&config_path)?;
             cfg.servers.insert(
@@ -4144,6 +4154,7 @@ async fn run_mcp_command(config: &Config, command: McpCommand) -> Result<()> {
                     args,
                     env: std::collections::HashMap::new(),
                     url,
+                    transport,
                     connect_timeout: None,
                     execute_timeout: None,
                     read_timeout: None,
@@ -4230,6 +4241,7 @@ async fn run_mcp_command(config: &Config, command: McpCommand) -> Result<()> {
                     args,
                     env: std::collections::HashMap::new(),
                     url: None,
+                    transport: None,
                     connect_timeout: None,
                     execute_timeout: None,
                     read_timeout: None,
@@ -6718,6 +6730,7 @@ mod doctor_mcp_tests {
             args: args.iter().map(|s| s.to_string()).collect(),
             env: std::collections::HashMap::new(),
             url: url.map(String::from),
+            transport: None,
             connect_timeout: None,
             execute_timeout: None,
             read_timeout: None,

--- a/crates/tui/src/mcp.rs
+++ b/crates/tui/src/mcp.rs
@@ -1145,8 +1145,15 @@ impl McpTransport for SseTransport {
         .body(msg)
         .send()
         .await?;
-        if !response.status().is_success() {
-            anyhow::bail!("Failed to send message via SSE POST: {}", response.status());
+        let status = response.status();
+        if !status.is_success() {
+            let body_excerpt = bounded_body_excerpt(response, ERROR_BODY_PREVIEW_BYTES).await;
+            anyhow::bail!(
+                "MCP SSE POST rejected (transport=sse endpoint={} status={}): {}",
+                mask_url_secrets(endpoint),
+                status,
+                body_excerpt
+            );
         }
         Ok(())
     }
@@ -3450,6 +3457,49 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn mcp_pool_call_tool_preserves_tool_names_with_dashes() {
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let transport = ScriptedValueTransport {
+            sent: Arc::clone(&sent),
+            responses: VecDeque::from([json_frame(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {"ok": true}
+            }))]),
+        };
+        let mut conn = test_connection(Box::new(transport));
+        conn.name = "dephy".to_string();
+        conn.tools = vec![McpTool {
+            name: "company--search".to_string(),
+            description: None,
+            input_schema: serde_json::json!({}),
+        }];
+
+        let mut pool = McpPool::new(McpConfig {
+            timeouts: McpTimeouts::default(),
+            servers: HashMap::new(),
+        });
+        pool.connections.insert("dephy".to_string(), conn);
+
+        let result = pool
+            .call_tool(
+                "mcp_dephy_company--search",
+                serde_json::json!({"query": "dephy"}),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result, serde_json::json!({"ok": true}));
+        let sent = sent.lock().unwrap();
+        assert_eq!(sent[0]["method"], "tools/call");
+        assert_eq!(sent[0]["params"]["name"], "company--search");
+        assert_eq!(
+            sent[0]["params"]["arguments"],
+            serde_json::json!({"query": "dephy"})
+        );
+    }
+
     /// #1244: when an MCP stdio server fails to spawn, the underlying OS
     /// error (e.g. ENOENT for a missing binary) must reach the user via the
     /// snapshot.error string. Regression test for `err.to_string()` dropping
@@ -4137,6 +4187,90 @@ mod tests {
         assert!(
             post_header_seen.load(AtomicOrdering::SeqCst),
             "legacy SSE POST must include user-configured custom headers"
+        );
+
+        cancel_token.cancel();
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn sse_post_error_includes_response_body_excerpt() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let cancel_token = tokio_util::sync::CancellationToken::new();
+        let server_cancel = cancel_token.clone();
+
+        let server = tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    break;
+                };
+                let server_cancel = server_cancel.clone();
+                tokio::spawn(async move {
+                    let mut request = Vec::new();
+                    let mut buf = [0; 1024];
+                    loop {
+                        let n = socket.read(&mut buf).await.unwrap();
+                        if n == 0 {
+                            return;
+                        }
+                        request.extend_from_slice(&buf[..n]);
+                        if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                            break;
+                        }
+                    }
+                    let request = String::from_utf8_lossy(&request);
+                    if request.starts_with("GET /sse ") {
+                        socket
+                            .write_all(
+                                b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\r\n",
+                            )
+                            .await
+                            .unwrap();
+                        socket
+                            .write_all(b"event: endpoint\ndata: /messages\n\n")
+                            .await
+                            .unwrap();
+                        server_cancel.cancelled().await;
+                    } else if request.starts_with("POST /messages ") {
+                        socket
+                            .write_all(
+                                b"HTTP/1.1 400 Bad Request\r\nContent-Type: application/json\r\nContent-Length: 25\r\n\r\n{\"error\":\"missing query\"}",
+                            )
+                            .await
+                            .unwrap();
+                    }
+                });
+            }
+        });
+
+        let client = reqwest::Client::new();
+        let url = format!("http://{addr}/sse");
+        let mut transport = SseTransport::connect(
+            client,
+            url,
+            HashMap::new(),
+            cancel_token.clone(),
+            Duration::from_secs(2),
+        )
+        .await
+        .unwrap();
+
+        let err = transport
+            .send(json_frame(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize"
+            })))
+            .await
+            .expect_err("POST rejection should be returned");
+        let err = format!("{err:#}");
+        assert!(
+            err.contains("400 Bad Request") && err.contains("missing query"),
+            "SSE POST error should include status and body, got: {err}"
         );
 
         cancel_token.cancel();

--- a/crates/tui/src/mcp.rs
+++ b/crates/tui/src/mcp.rs
@@ -85,6 +85,24 @@ fn is_safe_custom_header(key: &str, value: &str) -> bool {
     !value.contains('\r') && !value.contains('\n')
 }
 
+fn apply_safe_custom_headers(
+    mut request: reqwest::RequestBuilder,
+    headers: &HashMap<String, String>,
+) -> reqwest::RequestBuilder {
+    for (key, value) in headers {
+        if !is_safe_custom_header(key, value) {
+            tracing::warn!(
+                target: "mcp",
+                "skipping unsafe MCP header {:?} (empty/control-char/reserved)",
+                key
+            );
+            continue;
+        }
+        request = request.header(key.as_str(), value.as_str());
+    }
+    request
+}
+
 /// Mask a URL so any embedded credentials in the userinfo portion (e.g.
 /// `https://user:secret@host`) are replaced with `***`. Failures fall back to
 /// the original string so we don't lose context — we never want masking to
@@ -537,6 +555,7 @@ impl Drop for StdioTransport {
 pub struct SseTransport {
     client: reqwest::Client,
     base_url: String,
+    headers: HashMap<String, String>,
     endpoint_url: Option<String>,
     receiver: tokio::sync::mpsc::UnboundedReceiver<SseInbound>,
     pending_messages: VecDeque<Vec<u8>>,
@@ -551,6 +570,7 @@ struct HttpTransport {
     mode: HttpTransportMode,
     client: reqwest::Client,
     base_url: String,
+    headers: HashMap<String, String>,
     cancel_token: tokio_util::sync::CancellationToken,
     endpoint_timeout: Duration,
 }
@@ -587,12 +607,14 @@ impl SseTransport {
     pub async fn connect(
         client: reqwest::Client,
         url: String,
+        headers: HashMap<String, String>,
         cancel_token: tokio_util::sync::CancellationToken,
         endpoint_timeout: Duration,
     ) -> Result<Self> {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
         let client_clone = client.clone();
         let url_clone = url.clone();
+        let headers_clone = headers.clone();
         let wait_cancel_token = cancel_token.clone();
 
         tokio::spawn(async move {
@@ -603,6 +625,7 @@ impl SseTransport {
             let result = std::panic::AssertUnwindSafe(Self::run_sse_loop(
                 client_clone,
                 url_clone,
+                headers_clone,
                 tx,
                 cancel_token,
             ))
@@ -629,6 +652,7 @@ impl SseTransport {
         let mut transport = Self {
             client,
             base_url: url,
+            headers,
             endpoint_url: None,
             receiver: rx,
             pending_messages: VecDeque::new(),
@@ -642,18 +666,22 @@ impl SseTransport {
     async fn run_sse_loop(
         client: reqwest::Client,
         url: String,
+        headers: HashMap<String, String>,
         tx: tokio::sync::mpsc::UnboundedSender<SseInbound>,
         cancel_token: tokio_util::sync::CancellationToken,
     ) -> Result<()> {
-        let response = with_default_mcp_http_headers(client.get(&url), false)
-            .send()
-            .await
-            .with_context(|| {
-                format!(
-                    "MCP SSE connect failed (transport=http url={})",
-                    mask_url_secrets(&url),
-                )
-            })?;
+        let response = apply_safe_custom_headers(
+            with_default_mcp_http_headers(client.get(&url), false),
+            &headers,
+        )
+        .send()
+        .await
+        .with_context(|| {
+            format!(
+                "MCP SSE connect failed (transport=http url={})",
+                mask_url_secrets(&url),
+            )
+        })?;
         let status = response.status();
         if !status.is_success() {
             let body_excerpt = bounded_body_excerpt(response, ERROR_BODY_PREVIEW_BYTES).await;
@@ -783,10 +811,11 @@ impl HttpTransport {
             mode: HttpTransportMode::Streamable(StreamableHttpTransport::new(
                 client.clone(),
                 url.clone(),
-                headers,
+                headers.clone(),
             )),
             client,
             base_url: url,
+            headers,
             cancel_token,
             endpoint_timeout,
         }
@@ -796,6 +825,7 @@ impl HttpTransport {
         let mut sse = SseTransport::connect(
             self.client.clone(),
             self.base_url.clone(),
+            self.headers.clone(),
             self.cancel_token.clone(),
             self.endpoint_timeout,
         )
@@ -836,19 +866,10 @@ impl HttpTransport {
             HttpTransportMode::Sse(_) => return Ok(()),
         };
 
-        let mut request = transport.client.get(&transport.url);
-        request = with_default_mcp_http_headers(request, false);
-        for (key, value) in &transport.headers {
-            if !is_safe_custom_header(key, value) {
-                tracing::warn!(
-                    target: "mcp",
-                    "skipping unsafe MCP header {:?} (empty/control-char/reserved)",
-                    key
-                );
-                continue;
-            }
-            request = request.header(key.as_str(), value.as_str());
-        }
+        let request = apply_safe_custom_headers(
+            with_default_mcp_http_headers(transport.client.get(&transport.url), false),
+            &transport.headers,
+        );
         let response = tokio::time::timeout(Duration::from_secs(5), request.send())
             .await
             .map_err(|_| anyhow::anyhow!("GET timeout"))?
@@ -923,29 +944,12 @@ impl StreamableHttpTransport {
     }
 
     async fn send(&mut self, msg: Vec<u8>) -> std::result::Result<(), StreamableSendError> {
-        let mut request = with_default_mcp_http_headers(self.client.post(&self.url), true);
-        // Apply user-configured custom headers. Skip:
-        //   * empty / whitespace-only keys (would produce reqwest builder
-        //     errors mid-request and abort the whole connection);
-        //   * keys that duplicate the framing we already set (`Accept`,
-        //     `Content-Type`) so a stray entry can't break protocol
-        //     negotiation;
-        //   * values containing CR/LF, which would enable response-
-        //     splitting style requests on a misbehaving proxy.
-        // reqwest itself rejects malformed header names/values; the
-        // duplicates and control-char filter is purely defense in
-        // depth.
-        for (key, value) in &self.headers {
-            if !is_safe_custom_header(key, value) {
-                tracing::warn!(
-                    target: "mcp",
-                    "skipping unsafe MCP header {:?} (empty/control-char/reserved)",
-                    key
-                );
-                continue;
-            }
-            request = request.header(key.as_str(), value.as_str());
-        }
+        // Apply user-configured custom headers after protocol framing so
+        // reserved Accept / Content-Type overrides can be filtered out.
+        let mut request = apply_safe_custom_headers(
+            with_default_mcp_http_headers(self.client.post(&self.url), true),
+            &self.headers,
+        );
         // Attach any previously captured session ID per the Streamable
         // HTTP spec so the server can correlate this request to the
         // existing session.
@@ -1112,10 +1116,13 @@ impl McpTransport for SseTransport {
             .endpoint_url
             .as_ref()
             .context("SSE endpoint not yet discovered")?;
-        let response = with_default_mcp_http_headers(self.client.post(endpoint), true)
-            .body(msg)
-            .send()
-            .await?;
+        let response = apply_safe_custom_headers(
+            with_default_mcp_http_headers(self.client.post(endpoint), true),
+            &self.headers,
+        )
+        .body(msg)
+        .send()
+        .await?;
         if !response.status().is_success() {
             anyhow::bail!("Failed to send message via SSE POST: {}", response.status());
         }
@@ -1235,6 +1242,7 @@ impl McpConnection {
                     SseTransport::connect(
                         client,
                         url.clone(),
+                        config.headers.clone(),
                         cancel_token.clone(),
                         Duration::from_secs(connect_timeout_secs),
                     )
@@ -1350,7 +1358,7 @@ impl McpConnection {
         let init_id = self.next_id();
         self.send(serde_json::json!({
             "jsonrpc": "2.0",
-            "id": init_id.clone(),
+            "id": &init_id,
             "method": "initialize",
             "params": {
                 "protocolVersion": "2024-11-05",
@@ -1401,7 +1409,7 @@ impl McpConnection {
             };
             self.send(serde_json::json!({
                 "jsonrpc": "2.0",
-                "id": list_id.clone(),
+                "id": &list_id,
                 "method": "tools/list",
                 "params": params
             }))
@@ -1453,7 +1461,7 @@ impl McpConnection {
             };
             self.send(serde_json::json!({
                 "jsonrpc": "2.0",
-                "id": list_id.clone(),
+                "id": &list_id,
                 "method": "resources/list",
                 "params": params
             }))
@@ -1497,7 +1505,7 @@ impl McpConnection {
             };
             self.send(serde_json::json!({
                 "jsonrpc": "2.0",
-                "id": list_id.clone(),
+                "id": &list_id,
                 "method": "resources/templates/list",
                 "params": params
             }))
@@ -1545,7 +1553,7 @@ impl McpConnection {
             };
             self.send(serde_json::json!({
                 "jsonrpc": "2.0",
-                "id": list_id.clone(),
+                "id": &list_id,
                 "method": "prompts/list",
                 "params": params
             }))
@@ -1648,7 +1656,7 @@ impl McpConnection {
         let call_id = self.next_id();
         self.send(serde_json::json!({
             "jsonrpc": "2.0",
-            "id": call_id.clone(),
+            "id": &call_id,
             "method": method,
             "params": params
         }))
@@ -3820,10 +3828,15 @@ mod tests {
 
         let client = reqwest::Client::new();
         let url = format!("http://{addr}/sse");
-        let mut transport =
-            SseTransport::connect(client, url, cancel_token.clone(), Duration::from_secs(2))
-                .await
-                .unwrap();
+        let mut transport = SseTransport::connect(
+            client,
+            url,
+            HashMap::new(),
+            cancel_token.clone(),
+            Duration::from_secs(2),
+        )
+        .await
+        .unwrap();
 
         transport
             .send(json_frame(serde_json::json!({
@@ -3905,10 +3918,15 @@ mod tests {
 
         let client = reqwest::Client::new();
         let url = format!("http://{addr}/sse");
-        let mut transport =
-            SseTransport::connect(client, url, cancel_token.clone(), Duration::from_secs(2))
-                .await
-                .unwrap();
+        let mut transport = SseTransport::connect(
+            client,
+            url,
+            HashMap::new(),
+            cancel_token.clone(),
+            Duration::from_secs(2),
+        )
+        .await
+        .unwrap();
 
         transport
             .send(json_frame(serde_json::json!({
@@ -3922,6 +3940,111 @@ mod tests {
         assert!(
             post_seen.load(AtomicOrdering::SeqCst),
             "first SSE send should POST to the CRLF-discovered endpoint"
+        );
+
+        cancel_token.cancel();
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn sse_transport_applies_custom_headers_to_get_and_post() {
+        use std::sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering as AtomicOrdering},
+        };
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let get_header_seen = Arc::new(AtomicBool::new(false));
+        let post_header_seen = Arc::new(AtomicBool::new(false));
+        let server_get_header_seen = Arc::clone(&get_header_seen);
+        let server_post_header_seen = Arc::clone(&post_header_seen);
+        let cancel_token = tokio_util::sync::CancellationToken::new();
+        let server_cancel = cancel_token.clone();
+
+        let server = tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    break;
+                };
+                let get_header_seen = Arc::clone(&server_get_header_seen);
+                let post_header_seen = Arc::clone(&server_post_header_seen);
+                let server_cancel = server_cancel.clone();
+                tokio::spawn(async move {
+                    let mut request = Vec::new();
+                    let mut buf = [0; 1024];
+                    loop {
+                        let n = socket.read(&mut buf).await.unwrap();
+                        if n == 0 {
+                            return;
+                        }
+                        request.extend_from_slice(&buf[..n]);
+                        if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                            break;
+                        }
+                    }
+                    let request = String::from_utf8_lossy(&request);
+                    let request_lower = request.to_lowercase();
+                    if request.starts_with("GET /sse ") {
+                        if request_lower.contains("x-custom-auth: my-test-token") {
+                            get_header_seen.store(true, AtomicOrdering::SeqCst);
+                        }
+                        socket
+                            .write_all(
+                                b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\r\n",
+                            )
+                            .await
+                            .unwrap();
+                        socket
+                            .write_all(b"event: endpoint\ndata: /messages\n\n")
+                            .await
+                            .unwrap();
+                        server_cancel.cancelled().await;
+                    } else if request.starts_with("POST /messages ") {
+                        if request_lower.contains("x-custom-auth: my-test-token") {
+                            post_header_seen.store(true, AtomicOrdering::SeqCst);
+                        }
+                        socket
+                            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+                            .await
+                            .unwrap();
+                    }
+                });
+            }
+        });
+
+        let client = reqwest::Client::new();
+        let url = format!("http://{addr}/sse");
+        let mut headers = HashMap::new();
+        headers.insert("X-Custom-Auth".to_string(), "my-test-token".to_string());
+        let mut transport = SseTransport::connect(
+            client,
+            url,
+            headers,
+            cancel_token.clone(),
+            Duration::from_secs(2),
+        )
+        .await
+        .unwrap();
+
+        transport
+            .send(json_frame(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize"
+            })))
+            .await
+            .unwrap();
+
+        assert!(
+            get_header_seen.load(AtomicOrdering::SeqCst),
+            "legacy SSE GET must include user-configured custom headers"
+        );
+        assert!(
+            post_header_seen.load(AtomicOrdering::SeqCst),
+            "legacy SSE POST must include user-configured custom headers"
         );
 
         cancel_token.cancel();

--- a/crates/tui/src/mcp.rs
+++ b/crates/tui/src/mcp.rs
@@ -1087,6 +1087,24 @@ fn sse_field_value<'a>(line: &'a str, field: &str) -> Option<&'a str> {
     Some(value.strip_prefix(' ').unwrap_or(value))
 }
 
+fn is_legacy_sse_endpoint_url(url: &str) -> bool {
+    reqwest::Url::parse(url)
+        .map(|url| url.path().trim_end_matches('/').ends_with("/sse"))
+        .unwrap_or(false)
+}
+
+fn response_id_matches(id: Option<&serde_json::Value>, expected_id: &str) -> bool {
+    let Some(id) = id else {
+        return false;
+    };
+    if id.as_str() == Some(expected_id) {
+        return true;
+    }
+    id.as_u64()
+        .map(|id| id.to_string() == expected_id)
+        .unwrap_or(false)
+}
+
 #[async_trait::async_trait]
 impl McpTransport for SseTransport {
     async fn send(&mut self, msg: Vec<u8>) -> Result<()> {
@@ -1212,27 +1230,39 @@ impl McpConnection {
                 }
             }
             let client = client_builder.build()?;
-            let mut http = HttpTransport::new(
-                client,
-                url.clone(),
-                config.headers.clone(),
-                cancel_token.clone(),
-                Duration::from_secs(connect_timeout_secs),
-            );
-            // Best-effort session preflight for servers that require
-            // a session ID on every POST including `initialize`
-            // (e.g. Hindsight, #1629). Failures are non-fatal — the
-            // `initialize` POST will proceed and may capture a session
-            // ID from the response instead.
-            if let Err(e) = http.try_establish_session().await {
-                tracing::debug!(
-                    target: "mcp",
-                    server = %name,
-                    error = %e,
-                    "session-establishment GET skipped; proceeding with POST initialize"
+            if is_legacy_sse_endpoint_url(url) {
+                Box::new(
+                    SseTransport::connect(
+                        client,
+                        url.clone(),
+                        cancel_token.clone(),
+                        Duration::from_secs(connect_timeout_secs),
+                    )
+                    .await?,
+                )
+            } else {
+                let mut http = HttpTransport::new(
+                    client,
+                    url.clone(),
+                    config.headers.clone(),
+                    cancel_token.clone(),
+                    Duration::from_secs(connect_timeout_secs),
                 );
+                // Best-effort session preflight for servers that require
+                // a session ID on every POST including `initialize`
+                // (e.g. Hindsight, #1629). Failures are non-fatal — the
+                // `initialize` POST will proceed and may capture a session
+                // ID from the response instead.
+                if let Err(e) = http.try_establish_session().await {
+                    tracing::debug!(
+                        target: "mcp",
+                        server = %name,
+                        error = %e,
+                        "session-establishment GET skipped; proceeding with POST initialize"
+                    );
+                }
+                Box::new(http)
             }
-            Box::new(http)
         } else if let Some(command) = &config.command {
             let mut cmd = tokio::process::Command::new(command);
             cmd.args(&config.args)
@@ -1320,7 +1350,7 @@ impl McpConnection {
         let init_id = self.next_id();
         self.send(serde_json::json!({
             "jsonrpc": "2.0",
-            "id": init_id,
+            "id": init_id.clone(),
             "method": "initialize",
             "params": {
                 "protocolVersion": "2024-11-05",
@@ -1371,7 +1401,7 @@ impl McpConnection {
             };
             self.send(serde_json::json!({
                 "jsonrpc": "2.0",
-                "id": list_id,
+                "id": list_id.clone(),
                 "method": "tools/list",
                 "params": params
             }))
@@ -1423,7 +1453,7 @@ impl McpConnection {
             };
             self.send(serde_json::json!({
                 "jsonrpc": "2.0",
-                "id": list_id,
+                "id": list_id.clone(),
                 "method": "resources/list",
                 "params": params
             }))
@@ -1467,7 +1497,7 @@ impl McpConnection {
             };
             self.send(serde_json::json!({
                 "jsonrpc": "2.0",
-                "id": list_id,
+                "id": list_id.clone(),
                 "method": "resources/templates/list",
                 "params": params
             }))
@@ -1515,7 +1545,7 @@ impl McpConnection {
             };
             self.send(serde_json::json!({
                 "jsonrpc": "2.0",
-                "id": list_id,
+                "id": list_id.clone(),
                 "method": "prompts/list",
                 "params": params
             }))
@@ -1618,7 +1648,7 @@ impl McpConnection {
         let call_id = self.next_id();
         self.send(serde_json::json!({
             "jsonrpc": "2.0",
-            "id": call_id,
+            "id": call_id.clone(),
             "method": method,
             "params": params
         }))
@@ -1689,8 +1719,8 @@ impl McpConnection {
         self.state
     }
 
-    fn next_id(&self) -> u64 {
-        self.request_id.fetch_add(1, Ordering::SeqCst)
+    fn next_id(&self) -> String {
+        self.request_id.fetch_add(1, Ordering::SeqCst).to_string()
     }
 
     async fn send(&mut self, msg: serde_json::Value) -> Result<()> {
@@ -1698,7 +1728,7 @@ impl McpConnection {
         self.transport.send(bytes).await
     }
 
-    async fn recv(&mut self, expected_id: u64) -> Result<serde_json::Value> {
+    async fn recv(&mut self, expected_id: String) -> Result<serde_json::Value> {
         loop {
             let bytes = self.transport.recv().await.inspect_err(|_e| {
                 self.state = ConnectionState::Disconnected;
@@ -1707,8 +1737,11 @@ impl McpConnection {
                 format!("Invalid MCP JSON-RPC message from server '{}'", self.name)
             })?;
 
-            // Check if this is a response with the expected id
-            if value.get("id").and_then(serde_json::Value::as_u64) == Some(expected_id) {
+            // Check if this is a response with the expected id. We emit
+            // string IDs because some MCP gateways reject numeric JSON-RPC
+            // IDs, but accept numeric echoes for compatibility with older
+            // servers and tests.
+            if response_id_matches(value.get("id"), &expected_id) {
                 return Ok(value);
             }
             // Skip notifications (no id) and responses with different ids
@@ -3161,7 +3194,7 @@ mod tests {
         let sent = sent.lock().unwrap();
         assert_eq!(sent.len(), 1);
         assert_eq!(sent[0]["jsonrpc"], "2.0");
-        assert_eq!(sent[0]["id"], 1);
+        assert_eq!(sent[0]["id"], "1");
         assert_eq!(sent[0]["method"], "tools/call");
     }
 
@@ -3375,6 +3408,25 @@ mod tests {
         let value: serde_json::Value = serde_json::from_slice(&messages[0]).unwrap();
         assert_eq!(value["id"], 1);
         assert!(value.get("result").is_some());
+    }
+
+    #[test]
+    fn response_id_matches_string_and_numeric_echoes() {
+        assert!(response_id_matches(Some(&serde_json::json!("1")), "1"));
+        assert!(response_id_matches(Some(&serde_json::json!(1)), "1"));
+        assert!(!response_id_matches(Some(&serde_json::json!("2")), "1"));
+    }
+
+    #[test]
+    fn legacy_sse_endpoint_url_detects_sse_paths_only() {
+        assert!(is_legacy_sse_endpoint_url(
+            "https://example.com/mcp/abc/sse"
+        ));
+        assert!(is_legacy_sse_endpoint_url(
+            "https://example.com/mcp/abc/sse/"
+        ));
+        assert!(!is_legacy_sse_endpoint_url("https://example.com/mcp"));
+        assert!(!is_legacy_sse_endpoint_url("not a url"));
     }
 
     #[test]

--- a/crates/tui/src/mcp.rs
+++ b/crates/tui/src/mcp.rs
@@ -248,6 +248,16 @@ pub struct McpServerConfig {
     #[serde(default)]
     pub env: HashMap<String, String>,
     pub url: Option<String>,
+    /// Optional explicit HTTP transport override.
+    ///
+    /// By default URL-based MCP servers use Streamable HTTP first and fall
+    /// back to legacy SSE only when the server rejects Streamable HTTP with
+    /// a known incompatible status. Set this to `"sse"` for legacy SSE
+    /// endpoints that must start with a long-lived GET endpoint discovery
+    /// stream and cannot accept an initial POST to the configured URL.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transport: Option<String>,
     #[serde(default)]
     pub connect_timeout: Option<u64>,
     #[serde(default)]
@@ -1091,10 +1101,22 @@ fn sse_field_value<'a>(line: &'a str, field: &str) -> Option<&'a str> {
     Some(value.strip_prefix(' ').unwrap_or(value))
 }
 
-fn is_legacy_sse_endpoint_url(url: &str) -> bool {
-    reqwest::Url::parse(url)
-        .map(|url| url.path().trim_end_matches('/').ends_with("/sse"))
+fn is_legacy_sse_transport(config: &McpServerConfig) -> bool {
+    config
+        .transport
+        .as_deref()
+        .map(|transport| transport.trim().eq_ignore_ascii_case("sse"))
         .unwrap_or(false)
+}
+
+fn validate_mcp_transport(transport: Option<&str>) -> Result<()> {
+    let Some(transport) = transport else {
+        return Ok(());
+    };
+    if transport.trim().eq_ignore_ascii_case("sse") {
+        return Ok(());
+    }
+    anyhow::bail!("Unsupported MCP transport '{transport}'. Supported values: sse");
 }
 
 fn response_id_matches(id: Option<&serde_json::Value>, expected_id: &str) -> bool {
@@ -1237,7 +1259,7 @@ impl McpConnection {
                 }
             }
             let client = client_builder.build()?;
-            if is_legacy_sse_endpoint_url(url) {
+            if is_legacy_sse_transport(&config) {
                 Box::new(
                     SseTransport::connect(
                         client,
@@ -2494,6 +2516,7 @@ fn mcp_template_json() -> Result<String> {
             args: vec!["./path/to/your-mcp-server.js".to_string()],
             env: HashMap::new(),
             url: None,
+            transport: None,
             connect_timeout: None,
             execute_timeout: None,
             read_timeout: None,
@@ -2534,10 +2557,12 @@ pub fn add_server_config(
     command: Option<String>,
     url: Option<String>,
     args: Vec<String>,
+    transport: Option<String>,
 ) -> Result<()> {
     if command.is_none() && url.is_none() {
         anyhow::bail!("Provide either a command or URL for MCP server '{name}'.");
     }
+    validate_mcp_transport(transport.as_deref())?;
     let mut cfg = load_config(path)?;
     cfg.servers.insert(
         name,
@@ -2546,6 +2571,7 @@ pub fn add_server_config(
             args,
             env: HashMap::new(),
             url,
+            transport,
             connect_timeout: None,
             execute_timeout: None,
             read_timeout: None,
@@ -2630,7 +2656,11 @@ fn snapshot_from_config(
         .iter()
         .map(|(name, server)| {
             let transport = if server.url.is_some() {
-                "http/sse"
+                if is_legacy_sse_transport(server) {
+                    "sse"
+                } else {
+                    "http/sse"
+                }
             } else {
                 "stdio"
             };
@@ -2841,6 +2871,7 @@ mod tests {
             args: vec!["server.js".into()],
             env: HashMap::new(),
             url: None,
+            transport: None,
             connect_timeout: None,
             execute_timeout: None,
             read_timeout: None,
@@ -3001,6 +3032,7 @@ mod tests {
             Some("node".to_string()),
             None,
             vec!["server.js".to_string()],
+            None,
         )
         .unwrap();
         set_server_enabled(&path, "local", false).unwrap();
@@ -3019,6 +3051,54 @@ mod tests {
     }
 
     #[test]
+    fn test_mcp_config_adds_explicit_sse_transport() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("mcp.json");
+
+        add_server_config(
+            &path,
+            "legacy".to_string(),
+            None,
+            Some("https://example.com/v1/mcp/sse".to_string()),
+            Vec::new(),
+            Some("sse".to_string()),
+        )
+        .unwrap();
+
+        let cfg = load_config(&path).unwrap();
+        assert_eq!(
+            cfg.servers
+                .get("legacy")
+                .and_then(|server| server.transport.as_deref()),
+            Some("sse")
+        );
+
+        let snapshot = manager_snapshot_from_config(&path, false).unwrap();
+        assert_eq!(snapshot.servers[0].transport, "sse");
+    }
+
+    #[test]
+    fn test_mcp_config_rejects_unknown_transport() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("mcp.json");
+
+        let err = add_server_config(
+            &path,
+            "bad".to_string(),
+            None,
+            Some("https://example.com/mcp".to_string()),
+            Vec::new(),
+            Some("streamable".to_string()),
+        )
+        .expect_err("unknown transport should fail");
+
+        assert!(
+            format!("{err:#}").contains("Unsupported MCP transport"),
+            "got: {err:#}"
+        );
+    }
+
+    #[test]
     fn test_server_effective_timeouts() {
         let global = McpTimeouts::default();
 
@@ -3027,6 +3107,7 @@ mod tests {
             args: vec![],
             env: HashMap::new(),
             url: None,
+            transport: None,
             connect_timeout: Some(20),
             execute_timeout: None,
             read_timeout: Some(180),
@@ -3137,6 +3218,7 @@ mod tests {
             args: Vec::new(),
             env: HashMap::new(),
             url: None,
+            transport: None,
             connect_timeout: None,
             execute_timeout: None,
             read_timeout: None,
@@ -3306,6 +3388,7 @@ mod tests {
                 args: vec!["hi".into()],
                 env: Default::default(),
                 url: None,
+                transport: None,
                 connect_timeout: None,
                 execute_timeout: None,
                 read_timeout: None,
@@ -3426,15 +3509,23 @@ mod tests {
     }
 
     #[test]
-    fn legacy_sse_endpoint_url_detects_sse_paths_only() {
-        assert!(is_legacy_sse_endpoint_url(
-            "https://example.com/mcp/abc/sse"
-        ));
-        assert!(is_legacy_sse_endpoint_url(
-            "https://example.com/mcp/abc/sse/"
-        ));
-        assert!(!is_legacy_sse_endpoint_url("https://example.com/mcp"));
-        assert!(!is_legacy_sse_endpoint_url("not a url"));
+    fn legacy_sse_transport_requires_explicit_config() {
+        let mut server = test_server_config();
+        server.url = Some("https://example.com/mcp/abc/sse".to_string());
+
+        assert!(
+            !is_legacy_sse_transport(&server),
+            "/sse paths must not force legacy SSE without an explicit transport override"
+        );
+
+        server.transport = Some("sse".to_string());
+        assert!(is_legacy_sse_transport(&server));
+
+        server.transport = Some("SSE".to_string());
+        assert!(is_legacy_sse_transport(&server));
+
+        server.transport = Some("http".to_string());
+        assert!(!is_legacy_sse_transport(&server));
     }
 
     #[test]
@@ -3562,6 +3653,7 @@ mod tests {
             args: vec![],
             env: HashMap::new(),
             url: Some(format!("http://{addr}/mcp")),
+            transport: None,
             connect_timeout: Some(2),
             execute_timeout: None,
             read_timeout: None,

--- a/crates/tui/src/mcp.rs
+++ b/crates/tui/src/mcp.rs
@@ -610,6 +610,7 @@ struct StreamableHttpTransport {
 #[derive(Debug)]
 enum StreamableSendError {
     Incompatible(String),
+    StaleSession(String),
     Other(anyhow::Error),
 }
 
@@ -922,6 +923,19 @@ impl McpTransport for HttpTransport {
                     );
                     self.switch_to_sse_and_send(msg).await
                 }
+                Err(StreamableSendError::StaleSession(detail)) => {
+                    if let HttpTransportMode::Streamable(transport) = &mut self.mode {
+                        tracing::debug!(
+                            target: "mcp",
+                            error = %detail,
+                            "MCP Streamable HTTP session expired; clearing cached session ID"
+                        );
+                        transport.session_id = None;
+                    }
+                    Err(anyhow::anyhow!(
+                        "MCP Streamable HTTP session expired; retry with a new session required ({detail})"
+                    ))
+                }
                 Err(StreamableSendError::Other(err)) => Err(err),
             },
             HttpTransportMode::Sse(transport) => transport.send(msg).await,
@@ -992,6 +1006,13 @@ impl StreamableHttpTransport {
 
         if !status.is_success() {
             let body_excerpt = bounded_body_excerpt(response, ERROR_BODY_PREVIEW_BYTES).await;
+            if self.session_id.is_some()
+                && is_streamable_http_stale_session_status(status, &body_excerpt)
+            {
+                return Err(StreamableSendError::StaleSession(format!(
+                    "status={status} body={body_excerpt}"
+                )));
+            }
             if is_streamable_http_incompatible_status(status) {
                 return Err(StreamableSendError::Incompatible(format!(
                     "status={status} body={body_excerpt}"
@@ -1056,6 +1077,30 @@ fn is_streamable_http_incompatible_status(status: StatusCode) -> bool {
             | StatusCode::UNSUPPORTED_MEDIA_TYPE
             | StatusCode::NOT_IMPLEMENTED
     )
+}
+
+fn is_streamable_http_stale_session_status(status: StatusCode, body_excerpt: &str) -> bool {
+    if status == StatusCode::NOT_FOUND {
+        return true;
+    }
+    if status != StatusCode::BAD_REQUEST && status != StatusCode::UNAUTHORIZED {
+        return false;
+    }
+    let body = body_excerpt.to_ascii_lowercase();
+    body.contains("session") && (body.contains("expired") || body.contains("invalid"))
+}
+
+fn is_mcp_stale_session_body(body: &str) -> bool {
+    let body = body.to_ascii_lowercase();
+    body.contains("session") && (body.contains("expired") || body.contains("invalid"))
+}
+
+fn is_mcp_stale_session_error(err: &anyhow::Error) -> bool {
+    let err = format!("{err:#}");
+    err.contains("MCP Streamable HTTP session expired")
+        || err.contains("MCP session expired")
+        || err.contains("SSE transport closed")
+        || is_mcp_stale_session_body(&err)
 }
 
 fn parse_sse_message_data(body: &str) -> Vec<Vec<u8>> {
@@ -1148,6 +1193,14 @@ impl McpTransport for SseTransport {
         let status = response.status();
         if !status.is_success() {
             let body_excerpt = bounded_body_excerpt(response, ERROR_BODY_PREVIEW_BYTES).await;
+            if is_mcp_stale_session_body(&body_excerpt) {
+                anyhow::bail!(
+                    "MCP session expired (transport=sse endpoint={} status={}): {}",
+                    mask_url_secrets(endpoint),
+                    status,
+                    body_excerpt
+                );
+            }
             anyhow::bail!(
                 "MCP SSE POST rejected (transport=sse endpoint={} status={}): {}",
                 mask_url_secrets(endpoint),
@@ -1779,6 +1832,11 @@ impl McpConnection {
             // IDs, but accept numeric echoes for compatibility with older
             // servers and tests.
             if response_id_matches(value.get("id"), &expected_id) {
+                if let Some(error) = value.get("error") {
+                    if is_mcp_stale_session_body(&error.to_string()) {
+                        anyhow::bail!("MCP session expired: {error}");
+                    }
+                }
                 return Ok(value);
             }
             // Skip notifications (no id) and responses with different ids
@@ -2359,7 +2417,26 @@ impl McpPool {
             anyhow::bail!("MCP tool '{tool_name}' is disabled for server '{server_name}'");
         }
         let timeout = conn.config().effective_execute_timeout(&global_timeouts);
-        conn.call_tool(tool_name, arguments, timeout).await
+        match conn.call_tool(tool_name, arguments.clone(), timeout).await {
+            Ok(result) => Ok(result),
+            Err(err) if is_mcp_stale_session_error(&err) => {
+                tracing::debug!(
+                    target: "mcp",
+                    server = server_name,
+                    tool = tool_name,
+                    error = %err,
+                    "retrying MCP tool call after stale session"
+                );
+                self.connections.remove(server_name);
+                let conn = self.get_or_connect(server_name).await?;
+                if !conn.config().is_tool_enabled(tool_name) {
+                    anyhow::bail!("MCP tool '{tool_name}' is disabled for server '{server_name}'");
+                }
+                let timeout = conn.config().effective_execute_timeout(&global_timeouts);
+                conn.call_tool(tool_name, arguments, timeout).await
+            }
+            Err(err) => Err(err),
+        }
     }
 
     /// Get list of configured server names
@@ -3500,6 +3577,94 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn json_rpc_session_error_is_marked_stale() {
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let transport = ScriptedValueTransport {
+            sent: Arc::clone(&sent),
+            responses: VecDeque::from([json_frame(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "error": {
+                    "code": -32001,
+                    "message": "MCP session expired"
+                }
+            }))]),
+        };
+        let mut conn = test_connection(Box::new(transport));
+
+        let err = conn
+            .call_tool("search", serde_json::json!({"query": "dephy"}), 1)
+            .await
+            .expect_err("session error should fail");
+
+        assert!(
+            is_mcp_stale_session_error(&err),
+            "JSON-RPC session error should be retryable, got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn sse_transport_closed_is_retryable() {
+        let err = anyhow::anyhow!("SSE transport closed");
+        assert!(
+            is_mcp_stale_session_error(&err),
+            "closed SSE stream should force reconnect before retry"
+        );
+    }
+
+    #[tokio::test]
+    async fn discover_all_ignores_unsupported_optional_capabilities() {
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let transport = ScriptedValueTransport {
+            sent: Arc::clone(&sent),
+            responses: VecDeque::from([
+                json_frame(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {
+                        "tools": [
+                            { "name": "search", "inputSchema": {} }
+                        ]
+                    }
+                })),
+                json_frame(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "error": {
+                        "code": -32601,
+                        "message": "resources not supported"
+                    }
+                })),
+                json_frame(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 3,
+                    "error": {
+                        "code": -32601,
+                        "message": "resource templates not supported"
+                    }
+                })),
+                json_frame(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 4,
+                    "error": {
+                        "code": -32601,
+                        "message": "prompts not supported"
+                    }
+                })),
+            ]),
+        };
+        let mut conn = test_connection(Box::new(transport));
+
+        conn.discover_all().await.expect("discover");
+
+        assert_eq!(conn.tools.len(), 1);
+        assert_eq!(conn.tools[0].name, "search");
+        assert!(conn.resources.is_empty());
+        assert!(conn.resource_templates.is_empty());
+        assert!(conn.prompts.is_empty());
+    }
+
     /// #1244: when an MCP stdio server fails to spawn, the underlying OS
     /// error (e.g. ENOENT for a missing binary) must reach the user via the
     /// snapshot.error string. Regression test for `err.to_string()` dropping
@@ -4274,6 +4439,431 @@ mod tests {
         );
 
         cancel_token.cancel();
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn streamable_http_stale_session_reconnects_and_retries_tool_call() {
+        use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let get_count = Arc::new(AtomicUsize::new(0));
+        let stale_seen = Arc::new(AtomicBool::new(false));
+        let success_seen = Arc::new(AtomicBool::new(false));
+        let server_get_count = Arc::clone(&get_count);
+        let server_stale_seen = Arc::clone(&stale_seen);
+        let server_success_seen = Arc::clone(&success_seen);
+
+        let server = tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    break;
+                };
+                let get_count = Arc::clone(&server_get_count);
+                let stale_seen = Arc::clone(&server_stale_seen);
+                let success_seen = Arc::clone(&server_success_seen);
+                tokio::spawn(async move {
+                    let mut request = Vec::new();
+                    let mut buf = [0; 4096];
+                    let header_end = loop {
+                        let n = socket.read(&mut buf).await.unwrap();
+                        if n == 0 {
+                            return;
+                        }
+                        request.extend_from_slice(&buf[..n]);
+                        if let Some(pos) = request.windows(4).position(|w| w == b"\r\n\r\n") {
+                            break pos + 4;
+                        }
+                    };
+                    let headers = String::from_utf8_lossy(&request[..header_end]).to_string();
+                    let content_length = headers
+                        .lines()
+                        .find_map(|line| {
+                            let (name, value) = line.split_once(':')?;
+                            name.eq_ignore_ascii_case("content-length")
+                                .then(|| value.trim().parse::<usize>().ok())
+                                .flatten()
+                        })
+                        .unwrap_or(0);
+                    while request.len() < header_end + content_length {
+                        let n = socket.read(&mut buf).await.unwrap();
+                        if n == 0 {
+                            return;
+                        }
+                        request.extend_from_slice(&buf[..n]);
+                    }
+                    let body = &request[header_end..header_end + content_length];
+                    let session_header = headers.lines().find_map(|line| {
+                        let (name, value) = line.split_once(':')?;
+                        name.eq_ignore_ascii_case("mcp-session-id")
+                            .then(|| value.trim().to_string())
+                    });
+
+                    if headers.starts_with("GET /mcp ") {
+                        let count = get_count.fetch_add(1, AtomicOrdering::SeqCst);
+                        let session = if count == 0 { "sess-old" } else { "sess-new" };
+                        let response = format!(
+                            "HTTP/1.1 200 OK\r\nMcp-Session-Id: {session}\r\nContent-Length: 0\r\n\r\n"
+                        );
+                        socket.write_all(response.as_bytes()).await.unwrap();
+                        return;
+                    }
+
+                    let request_json: serde_json::Value = serde_json::from_slice(body).unwrap();
+                    let method = request_json
+                        .get("method")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or("");
+                    let id = request_json
+                        .get("id")
+                        .cloned()
+                        .unwrap_or_else(|| serde_json::json!("0"));
+
+                    if method == "tools/call" && session_header.as_deref() == Some("sess-old") {
+                        stale_seen.store(true, AtomicOrdering::SeqCst);
+                        socket
+                            .write_all(
+                                b"HTTP/1.1 404 Not Found\r\nContent-Type: application/json\r\nContent-Length: 27\r\n\r\n{\"error\":\"session expired\"}",
+                            )
+                            .await
+                            .unwrap();
+                        return;
+                    }
+
+                    let result = match method {
+                        "initialize" => serde_json::json!({
+                            "protocolVersion": "2024-11-05",
+                            "capabilities": {}
+                        }),
+                        "tools/list" => serde_json::json!({
+                            "tools": [
+                                { "name": "search", "inputSchema": {} }
+                            ]
+                        }),
+                        "resources/list" => serde_json::json!({ "resources": [] }),
+                        "resources/templates/list" => {
+                            serde_json::json!({ "resourceTemplates": [] })
+                        }
+                        "prompts/list" => serde_json::json!({ "prompts": [] }),
+                        "tools/call" => {
+                            assert_eq!(session_header.as_deref(), Some("sess-new"));
+                            success_seen.store(true, AtomicOrdering::SeqCst);
+                            serde_json::json!({ "content": [{ "type": "text", "text": "ok" }] })
+                        }
+                        _ => {
+                            socket
+                                .write_all(b"HTTP/1.1 202 Accepted\r\nContent-Length: 0\r\n\r\n")
+                                .await
+                                .unwrap();
+                            return;
+                        }
+                    };
+                    let response_body = serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": id,
+                        "result": result
+                    })
+                    .to_string();
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                        response_body.len(),
+                        response_body
+                    );
+                    socket.write_all(response.as_bytes()).await.unwrap();
+                });
+            }
+        });
+
+        let mut cfg = McpConfig::default();
+        cfg.servers.insert(
+            "dephy".to_string(),
+            McpServerConfig {
+                command: None,
+                args: Vec::new(),
+                env: HashMap::new(),
+                url: Some(format!("http://{addr}/mcp")),
+                transport: None,
+                connect_timeout: Some(2),
+                execute_timeout: Some(2),
+                read_timeout: None,
+                disabled: false,
+                enabled: true,
+                required: false,
+                enabled_tools: Vec::new(),
+                disabled_tools: Vec::new(),
+                headers: HashMap::new(),
+            },
+        );
+        let mut pool = McpPool::new(cfg);
+
+        let result = pool
+            .call_tool("mcp_dephy_search", serde_json::json!({ "query": "dephy" }))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            result,
+            serde_json::json!({ "content": [{ "type": "text", "text": "ok" }] })
+        );
+        assert!(stale_seen.load(AtomicOrdering::SeqCst));
+        assert!(success_seen.load(AtomicOrdering::SeqCst));
+        assert_eq!(get_count.load(AtomicOrdering::SeqCst), 2);
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn legacy_sse_session_expiry_is_marked_stale() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+        use tokio::sync::mpsc;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = Vec::new();
+            let mut buf = [0; 4096];
+            let header_end = loop {
+                let n = socket.read(&mut buf).await.unwrap();
+                if n == 0 {
+                    return;
+                }
+                request.extend_from_slice(&buf[..n]);
+                if let Some(pos) = request.windows(4).position(|w| w == b"\r\n\r\n") {
+                    break pos + 4;
+                }
+            };
+            let headers = String::from_utf8_lossy(&request[..header_end]);
+            assert!(headers.starts_with("POST /messages "));
+            socket
+                .write_all(
+                    b"HTTP/1.1 400 Bad Request\r\nContent-Type: application/json\r\nContent-Length: 27\r\n\r\n{\"error\":\"session expired\"}",
+                )
+                .await
+                .unwrap();
+        });
+
+        let (_sender, receiver) = mpsc::unbounded_channel();
+        let mut transport = SseTransport {
+            client: reqwest::Client::new(),
+            base_url: format!("http://{addr}/sse"),
+            headers: HashMap::new(),
+            endpoint_url: Some(format!("http://{addr}/messages")),
+            receiver,
+            pending_messages: VecDeque::new(),
+        };
+
+        let err = transport
+            .send(br#"{"jsonrpc":"2.0","id":1,"method":"tools/call"}"#.to_vec())
+            .await
+            .expect_err("expired SSE session should fail");
+
+        assert!(
+            is_mcp_stale_session_error(&err),
+            "SSE session expiry should be retryable, got: {err:#}"
+        );
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn legacy_sse_closed_stream_reconnects_and_retries_tool_call() {
+        use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::{TcpListener, TcpStream};
+        use tokio::sync::mpsc;
+
+        async fn read_http_request(socket: &mut TcpStream) -> (String, serde_json::Value) {
+            let mut request = Vec::new();
+            let mut buf = [0; 4096];
+            let header_end = loop {
+                let n = socket.read(&mut buf).await.unwrap();
+                if n == 0 {
+                    return (String::new(), serde_json::Value::Null);
+                }
+                request.extend_from_slice(&buf[..n]);
+                if let Some(pos) = request.windows(4).position(|w| w == b"\r\n\r\n") {
+                    break pos + 4;
+                }
+            };
+            let headers = String::from_utf8_lossy(&request[..header_end]).to_string();
+            let content_length = headers
+                .lines()
+                .find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    name.eq_ignore_ascii_case("content-length")
+                        .then(|| value.trim().parse::<usize>().ok())
+                        .flatten()
+                })
+                .unwrap_or(0);
+            while request.len() < header_end + content_length {
+                let n = socket.read(&mut buf).await.unwrap();
+                if n == 0 {
+                    return (headers, serde_json::Value::Null);
+                }
+                request.extend_from_slice(&buf[..n]);
+            }
+            let body = &request[header_end..header_end + content_length];
+            let json = if body.is_empty() {
+                serde_json::Value::Null
+            } else {
+                serde_json::from_slice(body).unwrap()
+            };
+            (headers, json)
+        }
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let active_sse = Arc::new(Mutex::new(None::<mpsc::UnboundedSender<Option<String>>>));
+        let get_count = Arc::new(AtomicUsize::new(0));
+        let tool_call_count = Arc::new(AtomicUsize::new(0));
+        let success_seen = Arc::new(AtomicBool::new(false));
+        let server_active_sse = Arc::clone(&active_sse);
+        let server_get_count = Arc::clone(&get_count);
+        let server_tool_call_count = Arc::clone(&tool_call_count);
+        let server_success_seen = Arc::clone(&success_seen);
+
+        let server = tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    break;
+                };
+                let active_sse = Arc::clone(&server_active_sse);
+                let get_count = Arc::clone(&server_get_count);
+                let tool_call_count = Arc::clone(&server_tool_call_count);
+                let success_seen = Arc::clone(&server_success_seen);
+                tokio::spawn(async move {
+                    let (headers, request_json) = read_http_request(&mut socket).await;
+                    if headers.starts_with("GET /sse ") {
+                        get_count.fetch_add(1, AtomicOrdering::SeqCst);
+                        let (tx, mut rx) = mpsc::unbounded_channel::<Option<String>>();
+                        *active_sse.lock().unwrap() = Some(tx);
+                        socket
+                            .write_all(
+                                b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\r\n",
+                            )
+                            .await
+                            .unwrap();
+                        socket
+                            .write_all(b"event: endpoint\ndata: /messages\n\n")
+                            .await
+                            .unwrap();
+                        while let Some(message) = rx.recv().await {
+                            let Some(message) = message else {
+                                return;
+                            };
+                            let event = format!("event: message\ndata: {message}\n\n");
+                            socket.write_all(event.as_bytes()).await.unwrap();
+                        }
+                        return;
+                    }
+
+                    if !headers.starts_with("POST /messages ") {
+                        return;
+                    }
+
+                    socket
+                        .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+                        .await
+                        .unwrap();
+
+                    let method = request_json
+                        .get("method")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or("");
+                    if method == "notifications/initialized" {
+                        return;
+                    }
+
+                    let id = request_json
+                        .get("id")
+                        .cloned()
+                        .unwrap_or_else(|| serde_json::json!("0"));
+
+                    if method == "tools/call" {
+                        let count = tool_call_count.fetch_add(1, AtomicOrdering::SeqCst);
+                        if count == 0 {
+                            if let Some(tx) = active_sse.lock().unwrap().take() {
+                                let _ = tx.send(None);
+                            }
+                            return;
+                        }
+                    }
+
+                    let result = match method {
+                        "initialize" => serde_json::json!({
+                            "protocolVersion": "2024-11-05",
+                            "capabilities": {}
+                        }),
+                        "tools/list" => serde_json::json!({
+                            "tools": [
+                                { "name": "search", "inputSchema": {} }
+                            ]
+                        }),
+                        "resources/list" => serde_json::json!({ "resources": [] }),
+                        "resources/templates/list" => {
+                            serde_json::json!({ "resourceTemplates": [] })
+                        }
+                        "prompts/list" => serde_json::json!({ "prompts": [] }),
+                        "tools/call" => {
+                            success_seen.store(true, AtomicOrdering::SeqCst);
+                            serde_json::json!({ "content": [{ "type": "text", "text": "ok" }] })
+                        }
+                        other => panic!("unexpected method: {other}"),
+                    };
+                    let response = serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": id,
+                        "result": result
+                    })
+                    .to_string();
+                    if let Some(tx) = active_sse.lock().unwrap().as_ref() {
+                        let _ = tx.send(Some(response));
+                    }
+                });
+            }
+        });
+
+        let mut cfg = McpConfig::default();
+        cfg.servers.insert(
+            "dephy".to_string(),
+            McpServerConfig {
+                command: None,
+                args: Vec::new(),
+                env: HashMap::new(),
+                url: Some(format!("http://{addr}/sse")),
+                transport: Some("sse".to_string()),
+                connect_timeout: Some(2),
+                execute_timeout: Some(2),
+                read_timeout: None,
+                disabled: false,
+                enabled: true,
+                required: false,
+                enabled_tools: Vec::new(),
+                disabled_tools: Vec::new(),
+                headers: HashMap::new(),
+            },
+        );
+        let mut pool = McpPool::new(cfg);
+
+        let result = pool
+            .call_tool("mcp_dephy_search", serde_json::json!({ "query": "dephy" }))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            result,
+            serde_json::json!({ "content": [{ "type": "text", "text": "ok" }] })
+        );
+        assert_eq!(tool_call_count.load(AtomicOrdering::SeqCst), 2);
+        assert_eq!(get_count.load(AtomicOrdering::SeqCst), 2);
+        assert!(success_seen.load(AtomicOrdering::SeqCst));
+
         server.abort();
     }
 

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -4796,6 +4796,7 @@ pub enum McpUiAction {
     AddHttp {
         name: String,
         url: String,
+        transport: Option<String>,
     },
     Enable {
         name: String,

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -5193,12 +5193,16 @@ async fn handle_mcp_ui_action(
             args,
         } => {
             changed = true;
-            mcp::add_server_config(&path, name.clone(), Some(command), None, args)
+            mcp::add_server_config(&path, name.clone(), Some(command), None, args, None)
                 .map(|()| message = Some(format!("Added MCP stdio server '{name}'")))
         }
-        crate::tui::app::McpUiAction::AddHttp { name, url } => {
+        crate::tui::app::McpUiAction::AddHttp {
+            name,
+            url,
+            transport,
+        } => {
             changed = true;
-            mcp::add_server_config(&path, name.clone(), None, Some(url), Vec::new())
+            mcp::add_server_config(&path, name.clone(), None, Some(url), Vec::new(), transport)
                 .map(|()| message = Some(format!("Added MCP HTTP/SSE server '{name}'")))
         }
         crate::tui::app::McpUiAction::Enable { name } => {


### PR DESCRIPTION
## Summary
- treat URLs ending in /sse as legacy MCP SSE endpoints instead of first POSTing to the SSE URL as Streamable HTTP
- send JSON-RPC request ids as strings while still accepting numeric response echoes
- add regression coverage for SSE endpoint detection and mixed string/numeric response ids

## Bugfix
This fixes legacy SSE MCP servers that expose an initial GET /sse stream with an endpoint event, but reject direct Streamable HTTP POSTs to /sse. One observed failure was a 403 api-key not found response from the wrong POST path even though the correct SSE flow does not require an API key.

## Verification
- cargo test -p codewhale-tui mcp
- cargo run -p codewhale-tui -- mcp validate

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes legacy MCP SSE connections by replacing the old URL path heuristic (`/sse` suffix detection) with an explicit `transport: \"sse\"` config field and CLI flag, and addresses the previously noted custom-header forwarding gap for SSE transports. It also sends JSON-RPC request IDs as strings (accepting numeric echoes for backwards compatibility), and adds stale-session detection with a single reconnect-and-retry in `McpPool`.

- **Explicit SSE transport selection**: `McpServerConfig` gains a `transport` field; `/mcp add sse` and `--transport sse` write it; `is_legacy_sse_transport` reads it. Streamable-HTTP servers whose URL ends in `/sse` are no longer misrouted.
- **Custom headers on SSE**: `SseTransport::connect` now accepts and forwards `headers` to both the initial `GET /sse` and the subsequent `POST`, fixing silent header loss for auth-gated legacy endpoints.
- **Stale-session retry**: `StreamableSendError::StaleSession` is added; `McpPool::call_tool` reconnects and retries once on transport-level session expiry (404/session-keyword HTTP responses and closed SSE streams).
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after addressing the stale-session false-positive in recv(); all other changes are well-tested and targeted.

The recv() function now serialises the full JSON-RPC error object to a string before checking for session-expiry keywords. Any tool that returns an error whose parameter name or message text contains 'session' and 'invalid' or 'expired' (common in auth-heavy APIs) will have that error silently reclassified as a transport session expiry, triggering an unnecessary reconnect, swallowing the original error message on the first attempt, and surfacing it only on the second call.

crates/tui/src/mcp.rs — specifically the recv() stale-session body check and the related is_mcp_stale_session_body helper reuse.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/mcp.rs | Core MCP logic: adds explicit SSE transport, apply_safe_custom_headers helper, stale-session reconnect/retry, and string JSON-RPC IDs. One issue: recv() checks stale-session keywords against the full serialised JSON error object rather than just the message field, causing false positives on application-level tool errors. |
| crates/tui/src/commands/mcp.rs | Splits the previously unified 'http'|'sse' command arm into two: http sets transport: None and sse sets transport: Some("sse"). Clean change. |
| crates/tui/src/main.rs | Adds --transport CLI flag with inline validation; updates all McpServerConfig construction sites to include transport: None. |
| crates/tui/src/tui/app.rs | Adds transport: Option<String> field to McpUiAction::AddHttp. Minimal, mechanical change. |
| crates/tui/src/tui/ui.rs | Threads transport from McpUiAction::AddHttp through to mcp::add_server_config. No logic change. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant App
    participant McpPool
    participant McpConnection
    participant Transport

    Note over App,Transport: Legacy SSE path (transport = "sse")
    App->>McpPool: call_tool(name, args)
    McpPool->>McpConnection: "connect() [is_legacy_sse_transport=true]"
    McpConnection->>Transport: SseTransport::connect(url, headers)
    Transport->>Transport: GET /sse (with custom headers)
    Transport-->>McpConnection: endpoint event → endpoint_url
    McpPool->>McpConnection: call_tool → send + recv
    McpConnection->>Transport: POST endpoint_url (with custom headers)

    Note over App,Transport: Streamable HTTP path (transport = None)
    App->>McpPool: call_tool(name, args)
    McpPool->>McpConnection: "connect() [is_legacy_sse_transport=false]"
    McpConnection->>Transport: HttpTransport::new → try_establish_session GET
    Transport-->>McpConnection: Mcp-Session-Id header (optional)
    McpPool->>McpConnection: call_tool → send + recv
    McpConnection->>Transport: POST /url (session-id if known)
    alt Stale session (404 / session-keyword body)
        Transport-->>McpConnection: StaleSession error
        McpConnection-->>McpPool: MCP Streamable HTTP session expired
        McpPool->>McpPool: connections.remove + get_or_connect (reconnect)
        McpPool->>McpConnection: call_tool retry
    end
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22main%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22main%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fmcp.rs%3A1834-1840%0A**Stale-session%20check%20fires%20on%20application-level%20tool%20errors**%0A%0A%60error.to_string%28%29%60%20serializes%20the%20full%20JSON-RPC%20error%20object%20%28e.g.%20%60%7B%22code%22%3A-32000%2C%22message%22%3A%22The%20'session_id'%20field%20is%20invalid%22%7D%60%29.%20%60is_mcp_stale_session_body%60%20then%20checks%20the%20entire%20JSON%20string%20for%20%22session%22%20%2B%20%22invalid%2Fexpired%22%2C%20so%20it%20will%20match%20whenever%20a%20parameter%20name%2C%20field%20key%2C%20or%20message%20text%20happens%20to%20contain%20those%20words%20%E2%80%94%20even%20when%20the%20error%20is%20a%20domain-level%20tool%20failure%20with%20no%20relation%20to%20the%20MCP%20transport%20session.%0A%0AWhen%20that%20false-positive%20fires%20the%20%60recv%60%20call%20bails%20with%20%22MCP%20session%20expired%22%2C%20%60McpPool%60%20teardown%2Freconnects%2C%20retries%20the%20tool%20call%2C%20gets%20the%20same%20error%20again%2C%20and%20finally%20propagates%20it%20%E2%80%94%20masking%20the%20real%20error%20message%20on%20the%20first%20attempt%20and%20adding%20an%20unnecessary%20reconnect%20on%20every%20call%20to%20that%20tool.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20response_id_matches%28value.get%28%22id%22%29%2C%20%26expected_id%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20let%20Some%28error%29%20%3D%20value.get%28%22error%22%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Only%20inspect%20the%20human-readable%20%60message%60%20field%2C%20not%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20the%20full%20serialised%20JSON.%20Serialising%20the%20entire%20error%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20object%20means%20any%20parameter%20name%20or%20field%20key%20that%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20contains%20%22session_id%22%2C%20%22invalid_session%22%2C%20etc.%20would%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20be%20mistaken%20for%20a%20transport-level%20session%20expiry.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20let%20msg%20%3D%20error%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.get%28%22message%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.and_then%28serde_json%3A%3AValue%3A%3Aas_str%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.unwrap_or%28%22%22%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20is_mcp_stale_session_body%28msg%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20anyhow%3A%3Abail!%28%22MCP%20session%20expired%3A%20%7Berror%7D%22%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%20Ok%28value%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fmcp.rs%3A1834-1840%0A**Stale-session%20check%20fires%20on%20application-level%20tool%20errors**%0A%0A%60error.to_string%28%29%60%20serializes%20the%20full%20JSON-RPC%20error%20object%20%28e.g.%20%60%7B%22code%22%3A-32000%2C%22message%22%3A%22The%20'session_id'%20field%20is%20invalid%22%7D%60%29.%20%60is_mcp_stale_session_body%60%20then%20checks%20the%20entire%20JSON%20string%20for%20%22session%22%20%2B%20%22invalid%2Fexpired%22%2C%20so%20it%20will%20match%20whenever%20a%20parameter%20name%2C%20field%20key%2C%20or%20message%20text%20happens%20to%20contain%20those%20words%20%E2%80%94%20even%20when%20the%20error%20is%20a%20domain-level%20tool%20failure%20with%20no%20relation%20to%20the%20MCP%20transport%20session.%0A%0AWhen%20that%20false-positive%20fires%20the%20%60recv%60%20call%20bails%20with%20%22MCP%20session%20expired%22%2C%20%60McpPool%60%20teardown%2Freconnects%2C%20retries%20the%20tool%20call%2C%20gets%20the%20same%20error%20again%2C%20and%20finally%20propagates%20it%20%E2%80%94%20masking%20the%20real%20error%20message%20on%20the%20first%20attempt%20and%20adding%20an%20unnecessary%20reconnect%20on%20every%20call%20to%20that%20tool.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20response_id_matches%28value.get%28%22id%22%29%2C%20%26expected_id%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20let%20Some%28error%29%20%3D%20value.get%28%22error%22%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Only%20inspect%20the%20human-readable%20%60message%60%20field%2C%20not%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20the%20full%20serialised%20JSON.%20Serialising%20the%20entire%20error%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20object%20means%20any%20parameter%20name%20or%20field%20key%20that%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20contains%20%22session_id%22%2C%20%22invalid_session%22%2C%20etc.%20would%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20be%20mistaken%20for%20a%20transport-level%20session%20expiry.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20let%20msg%20%3D%20error%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.get%28%22message%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.and_then%28serde_json%3A%3AValue%3A%3Aas_str%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.unwrap_or%28%22%22%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20is_mcp_stale_session_body%28msg%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20anyhow%3A%3Abail!%28%22MCP%20session%20expired%3A%20%7Berror%7D%22%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%20Ok%28value%29%3B%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2301&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fmcp.rs%3A1834-1840%0A**Stale-session%20check%20fires%20on%20application-level%20tool%20errors**%0A%0A%60error.to_string%28%29%60%20serializes%20the%20full%20JSON-RPC%20error%20object%20%28e.g.%20%60%7B%22code%22%3A-32000%2C%22message%22%3A%22The%20'session_id'%20field%20is%20invalid%22%7D%60%29.%20%60is_mcp_stale_session_body%60%20then%20checks%20the%20entire%20JSON%20string%20for%20%22session%22%20%2B%20%22invalid%2Fexpired%22%2C%20so%20it%20will%20match%20whenever%20a%20parameter%20name%2C%20field%20key%2C%20or%20message%20text%20happens%20to%20contain%20those%20words%20%E2%80%94%20even%20when%20the%20error%20is%20a%20domain-level%20tool%20failure%20with%20no%20relation%20to%20the%20MCP%20transport%20session.%0A%0AWhen%20that%20false-positive%20fires%20the%20%60recv%60%20call%20bails%20with%20%22MCP%20session%20expired%22%2C%20%60McpPool%60%20teardown%2Freconnects%2C%20retries%20the%20tool%20call%2C%20gets%20the%20same%20error%20again%2C%20and%20finally%20propagates%20it%20%E2%80%94%20masking%20the%20real%20error%20message%20on%20the%20first%20attempt%20and%20adding%20an%20unnecessary%20reconnect%20on%20every%20call%20to%20that%20tool.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20response_id_matches%28value.get%28%22id%22%29%2C%20%26expected_id%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20let%20Some%28error%29%20%3D%20value.get%28%22error%22%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Only%20inspect%20the%20human-readable%20%60message%60%20field%2C%20not%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20the%20full%20serialised%20JSON.%20Serialising%20the%20entire%20error%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20object%20means%20any%20parameter%20name%20or%20field%20key%20that%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20contains%20%22session_id%22%2C%20%22invalid_session%22%2C%20etc.%20would%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20be%20mistaken%20for%20a%20transport-level%20session%20expiry.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20let%20msg%20%3D%20error%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.get%28%22message%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.and_then%28serde_json%3A%3AValue%3A%3Aas_str%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.unwrap_or%28%22%22%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20is_mcp_stale_session_body%28msg%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20anyhow%3A%3Abail!%28%22MCP%20session%20expired%3A%20%7Berror%7D%22%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%20Ok%28value%29%3B%0A%60%60%60%0A%0A&pr=2301&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (5): Last reviewed commit: ["Retry MCP calls after stale SSE connecti..."](https://github.com/hmbown/codewhale/commit/8d2222bbf704ee74960ed063d0063196d1a50571) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34292768)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->