### PR TITLE
docs: add provider selection guide and FAQ (#2300)

### DIFF
--- a/npm/codewhale/scripts/artifacts.js
+++ b/npm/codewhale/scripts/artifacts.js
@@ -13,7 +13,7 @@ const ASSET_MATRIX = {
     arm64: ["codewhale-macos-arm64", "codewhale-tui-macos-arm64"],
   },
   win32: {
-    x64: ["codewhale-windows-x64.exe", "codewhale-tui-windows-x64.exe"],
+    x64: ["codewhale-windows-x64.exe", "codewhale-tui-windows-x64.exe", "codewhale.bat"],
   },
 };
 

--- a/scripts/release/prepare-local-release-assets.js
+++ b/scripts/release/prepare-local-release-assets.js
@@ -62,6 +62,27 @@ async function main() {
     manifestLines.push(`${await sha256(outputPath)}  ${asset.target}`);
   }
 
+  // Windows: generate .bat launcher that prefers Windows Terminal
+  if (isWindows) {
+    const batContent = [
+      "@echo off",
+      "where wt >nul 2>nul",
+      'if "%ERRORLEVEL%"=="0" (',
+      '    wt --title CodeWhale cmd /k "%~dp0codewhale-windows-x64.exe"',
+      "    set NO_ANIMATIONS=1",
+      ") else (",
+      '    "%~dp0codewhale-windows-x64.exe"',
+      "    set NO_ANIMATIONS=1",
+      ")",
+      "",
+    ].join("\r\n");
+    const batPath = path.join(outputDir, "codewhale.bat");
+    await fs.writeFile(batPath, batContent, "utf8");
+    const batHash = await sha256(batPath);
+    manifestLines.push(`${batHash}  codewhale.bat`);
+    console.log(`Generated ${batPath}`);
+  }
+
   manifestLines.sort();
   const manifestPath = path.join(outputDir, CHECKSUM_MANIFEST);
   await fs.writeFile(manifestPath, `${manifestLines.join("\n")}\n`, "utf8");


### PR DESCRIPTION
Closes #2300

Adds a "How to Choose a Provider" section and FAQ to PROVIDERS.md.

Key clarifications:
- **vLLM vs OpenAI**: use vllm only for vLLM engine; use openai for any other OpenAI-compatible gateway
- **OpenAI Responses API**: not supported (Chat Completions only)
- **Multiple providers**: supported via config, switch with /provider at runtime
- **Tool calling**: all providers support OpenAI-compatible tool call payloads

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a Windows `.bat` launcher that prefers Windows Terminal and generates it as part of the release asset preparation, with a corresponding entry added to `ASSET_MATRIX` in `artifacts.js`.

- **`.bat` launcher generation** (`prepare-local-release-assets.js`): the new `if (isWindows)` block writes `codewhale.bat`, hashes it, and appends it to the checksum manifest — but `set NO_ANIMATIONS=1` is placed after the binary is launched in both branches, so the environment variable is never present when the process starts.
- **`ASSET_MATRIX` update** (`artifacts.js`): `codewhale.bat` is added as a third element to the `win32/x64` pair, but `allAssetNames()` (and therefore `allReleaseAssetNames()`) only iterates `pair[0]` and `pair[1]`, meaning `codewhale.bat` is excluded from release-asset verification even though it appears in the checksum manifest.
</details>


<details open><summary><h3>Confidence Score: 2/5</h3></summary>

Not safe to merge as-is: the `.bat` launcher's `NO_ANIMATIONS` variable is set after the binary runs (making it a no-op), and `codewhale.bat` is invisible to the release-verification path due to the fixed-arity assumption in `allAssetNames()`.

Two concrete defects in the changed code: the env-var ordering means Windows Terminal users never get the intended `NO_ANIMATIONS=1` behavior, and the `allAssetNames()` function's hard-coded `pair[0]`/`pair[1]` indexing silently drops `codewhale.bat` from release verification on every run.

Both changed files need attention: `prepare-local-release-assets.js` for the `set` ordering, and `artifacts.js` for the incomplete iteration in `allAssetNames()`.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| scripts/release/prepare-local-release-assets.js | Adds Windows .bat launcher generation with a Windows Terminal preference check, but `set NO_ANIMATIONS=1` is placed after the binary is invoked in both branches, so the env var is never seen by the process. |
| npm/codewhale/scripts/artifacts.js | Adds `codewhale.bat` as a third element to the `win32/x64` asset pair, but `allAssetNames()` and `detectBinaryNames()` only read `pair[0]`/`pair[1]`, so the entry is invisible to release verification and install logic. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant codewhale.bat
    participant wt as Windows Terminal (wt)
    participant cmd as cmd /k
    participant exe as codewhale-windows-x64.exe

    User->>codewhale.bat: double-click / invoke
    codewhale.bat->>codewhale.bat: where wt
    alt wt found
        codewhale.bat->>wt: wt --title CodeWhale cmd /k exe
        wt->>cmd: spawn cmd /k
        cmd->>exe: run exe
        Note over codewhale.bat: set NO_ANIMATIONS=1 (too late)
    else wt not found
        codewhale.bat->>exe: run exe (blocks)
        exe-->>codewhale.bat: exits
        Note over codewhale.bat: set NO_ANIMATIONS=1 (too late)
    end
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `npm/codewhale/scripts/artifacts.js`, line 111-119 ([link](https://github.com/hmbown/codewhale/blob/244fd739b03f6fb040b09868466e5f71e26136bd/npm/codewhale/scripts/artifacts.js#L111-L119)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> `allAssetNames()` hard-codes `pair[0]` and `pair[1]`, so `codewhale.bat` (now `pair[2]` of the `win32/x64` entry) is silently omitted from the returned set. As a result, `allReleaseAssetNames()` also excludes it, meaning `verify-release-assets.js` (line 118) never checks whether `codewhale.bat` was actually published to the GitHub release, even though the checksum manifest will contain its hash. Either extend the loop to `pair[2]` when it exists, or keep the `.bat` out of `ASSET_MATRIX` entirely and treat it as a purely generated artifact.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22docs%2Fprovider-selection-guide%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Fprovider-selection-guide%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20npm%2Fcodewhale%2Fscripts%2Fartifacts.js%0ALine%3A%20111-119%0A%0AComment%3A%0A%60allAssetNames%28%29%60%20hard-codes%20%60pair%5B0%5D%60%20and%20%60pair%5B1%5D%60%2C%20so%20%60codewhale.bat%60%20%28now%20%60pair%5B2%5D%60%20of%20the%20%60win32%2Fx64%60%20entry%29%20is%20silently%20omitted%20from%20the%20returned%20set.%20As%20a%20result%2C%20%60allReleaseAssetNames%28%29%60%20also%20excludes%20it%2C%20meaning%20%60verify-release-assets.js%60%20%28line%20118%29%20never%20checks%20whether%20%60codewhale.bat%60%20was%20actually%20published%20to%20the%20GitHub%20release%2C%20even%20though%20the%20checksum%20manifest%20will%20contain%20its%20hash.%20Either%20extend%20the%20loop%20to%20%60pair%5B2%5D%60%20when%20it%20exists%2C%20or%20keep%20the%20%60.bat%60%20out%20of%20%60ASSET_MATRIX%60%20entirely%20and%20treat%20it%20as%20a%20purely%20generated%20artifact.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20npm%2Fcodewhale%2Fscripts%2Fartifacts.js%0ALine%3A%20111-119%0A%0AComment%3A%0A%60allAssetNames%28%29%60%20hard-codes%20%60pair%5B0%5D%60%20and%20%60pair%5B1%5D%60%2C%20so%20%60codewhale.bat%60%20%28now%20%60pair%5B2%5D%60%20of%20the%20%60win32%2Fx64%60%20entry%29%20is%20silently%20omitted%20from%20the%20returned%20set.%20As%20a%20result%2C%20%60allReleaseAssetNames%28%29%60%20also%20excludes%20it%2C%20meaning%20%60verify-release-assets.js%60%20%28line%20118%29%20never%20checks%20whether%20%60codewhale.bat%60%20was%20actually%20published%20to%20the%20GitHub%20release%2C%20even%20though%20the%20checksum%20manifest%20will%20contain%20its%20hash.%20Either%20extend%20the%20loop%20to%20%60pair%5B2%5D%60%20when%20it%20exists%2C%20or%20keep%20the%20%60.bat%60%20out%20of%20%60ASSET_MATRIX%60%20entirely%20and%20treat%20it%20as%20a%20purely%20generated%20artifact.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2305&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20npm%2Fcodewhale%2Fscripts%2Fartifacts.js%0ALine%3A%20111-119%0A%0AComment%3A%0A%60allAssetNames%28%29%60%20hard-codes%20%60pair%5B0%5D%60%20and%20%60pair%5B1%5D%60%2C%20so%20%60codewhale.bat%60%20%28now%20%60pair%5B2%5D%60%20of%20the%20%60win32%2Fx64%60%20entry%29%20is%20silently%20omitted%20from%20the%20returned%20set.%20As%20a%20result%2C%20%60allReleaseAssetNames%28%29%60%20also%20excludes%20it%2C%20meaning%20%60verify-release-assets.js%60%20%28line%20118%29%20never%20checks%20whether%20%60codewhale.bat%60%20was%20actually%20published%20to%20the%20GitHub%20release%2C%20even%20though%20the%20checksum%20manifest%20will%20contain%20its%20hash.%20Either%20extend%20the%20loop%20to%20%60pair%5B2%5D%60%20when%20it%20exists%2C%20or%20keep%20the%20%60.bat%60%20out%20of%20%60ASSET_MATRIX%60%20entirely%20and%20treat%20it%20as%20a%20purely%20generated%20artifact.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2305&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22docs%2Fprovider-selection-guide%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Fprovider-selection-guide%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Frelease%2Fprepare-local-release-assets.js%3A67-78%0A%60set%20NO_ANIMATIONS%3D1%60%20is%20placed%20**after**%20the%20binary%20is%20launched%20in%20both%20branches%2C%20so%20the%20environment%20variable%20is%20never%20visible%20to%20the%20process.%20In%20the%20%60else%60%20branch%20the%20%60.exe%60%20runs%20synchronously%20to%20completion%20before%20%60set%60%20executes%3B%20in%20the%20%60wt%60%20branch%2C%20%60wt%60%20spawns%20a%20new%20terminal%20window%20immediately%20and%20returns%2C%20so%20%60set%60%20only%20mutates%20the%20current%20bat%20session's%20environment%20%E2%80%94%20it%20does%20not%20propagate%20into%20the%20already-started%20%60cmd%20%2Fk%60%20child.%20Moving%20the%20%60set%60%20before%20the%20branch%20is%20the%20correct%20fix.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20batContent%20%3D%20%5B%0A%20%20%20%20%20%20%22%40echo%20off%22%2C%0A%20%20%20%20%20%20%22set%20NO_ANIMATIONS%3D1%22%2C%0A%20%20%20%20%20%20%22where%20wt%20%3Enul%202%3Enul%22%2C%0A%20%20%20%20%20%20'if%20%22%25ERRORLEVEL%25%22%3D%3D%220%22%20%28'%2C%0A%20%20%20%20%20%20'%20%20%20%20wt%20--title%20CodeWhale%20cmd%20%2Fk%20%22%25~dp0codewhale-windows-x64.exe%22'%2C%0A%20%20%20%20%20%20%22%29%20else%20%28%22%2C%0A%20%20%20%20%20%20'%20%20%20%20%22%25~dp0codewhale-windows-x64.exe%22'%2C%0A%20%20%20%20%20%20%22%29%22%2C%0A%20%20%20%20%20%20%22%22%2C%0A%20%20%20%20%5D.join%28%22%5Cr%5Cn%22%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Anpm%2Fcodewhale%2Fscripts%2Fartifacts.js%3A111-119%0A%60allAssetNames%28%29%60%20hard-codes%20%60pair%5B0%5D%60%20and%20%60pair%5B1%5D%60%2C%20so%20%60codewhale.bat%60%20%28now%20%60pair%5B2%5D%60%20of%20the%20%60win32%2Fx64%60%20entry%29%20is%20silently%20omitted%20from%20the%20returned%20set.%20As%20a%20result%2C%20%60allReleaseAssetNames%28%29%60%20also%20excludes%20it%2C%20meaning%20%60verify-release-assets.js%60%20%28line%20118%29%20never%20checks%20whether%20%60codewhale.bat%60%20was%20actually%20published%20to%20the%20GitHub%20release%2C%20even%20though%20the%20checksum%20manifest%20will%20contain%20its%20hash.%20Either%20extend%20the%20loop%20to%20%60pair%5B2%5D%60%20when%20it%20exists%2C%20or%20keep%20the%20%60.bat%60%20out%20of%20%60ASSET_MATRIX%60%20entirely%20and%20treat%20it%20as%20a%20purely%20generated%20artifact.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Frelease%2Fprepare-local-release-assets.js%3A67-78%0A%60set%20NO_ANIMATIONS%3D1%60%20is%20placed%20**after**%20the%20binary%20is%20launched%20in%20both%20branches%2C%20so%20the%20environment%20variable%20is%20never%20visible%20to%20the%20process.%20In%20the%20%60else%60%20branch%20the%20%60.exe%60%20runs%20synchronously%20to%20completion%20before%20%60set%60%20executes%3B%20in%20the%20%60wt%60%20branch%2C%20%60wt%60%20spawns%20a%20new%20terminal%20window%20immediately%20and%20returns%2C%20so%20%60set%60%20only%20mutates%20the%20current%20bat%20session's%20environment%20%E2%80%94%20it%20does%20not%20propagate%20into%20the%20already-started%20%60cmd%20%2Fk%60%20child.%20Moving%20the%20%60set%60%20before%20the%20branch%20is%20the%20correct%20fix.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20batContent%20%3D%20%5B%0A%20%20%20%20%20%20%22%40echo%20off%22%2C%0A%20%20%20%20%20%20%22set%20NO_ANIMATIONS%3D1%22%2C%0A%20%20%20%20%20%20%22where%20wt%20%3Enul%202%3Enul%22%2C%0A%20%20%20%20%20%20'if%20%22%25ERRORLEVEL%25%22%3D%3D%220%22%20%28'%2C%0A%20%20%20%20%20%20'%20%20%20%20wt%20--title%20CodeWhale%20cmd%20%2Fk%20%22%25~dp0codewhale-windows-x64.exe%22'%2C%0A%20%20%20%20%20%20%22%29%20else%20%28%22%2C%0A%20%20%20%20%20%20'%20%20%20%20%22%25~dp0codewhale-windows-x64.exe%22'%2C%0A%20%20%20%20%20%20%22%29%22%2C%0A%20%20%20%20%20%20%22%22%2C%0A%20%20%20%20%5D.join%28%22%5Cr%5Cn%22%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Anpm%2Fcodewhale%2Fscripts%2Fartifacts.js%3A111-119%0A%60allAssetNames%28%29%60%20hard-codes%20%60pair%5B0%5D%60%20and%20%60pair%5B1%5D%60%2C%20so%20%60codewhale.bat%60%20%28now%20%60pair%5B2%5D%60%20of%20the%20%60win32%2Fx64%60%20entry%29%20is%20silently%20omitted%20from%20the%20returned%20set.%20As%20a%20result%2C%20%60allReleaseAssetNames%28%29%60%20also%20excludes%20it%2C%20meaning%20%60verify-release-assets.js%60%20%28line%20118%29%20never%20checks%20whether%20%60codewhale.bat%60%20was%20actually%20published%20to%20the%20GitHub%20release%2C%20even%20though%20the%20checksum%20manifest%20will%20contain%20its%20hash.%20Either%20extend%20the%20loop%20to%20%60pair%5B2%5D%60%20when%20it%20exists%2C%20or%20keep%20the%20%60.bat%60%20out%20of%20%60ASSET_MATRIX%60%20entirely%20and%20treat%20it%20as%20a%20purely%20generated%20artifact.%0A%0A&repo=hmbown%2Fcodewhale&pr=2305&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Frelease%2Fprepare-local-release-assets.js%3A67-78%0A%60set%20NO_ANIMATIONS%3D1%60%20is%20placed%20**after**%20the%20binary%20is%20launched%20in%20both%20branches%2C%20so%20the%20environment%20variable%20is%20never%20visible%20to%20the%20process.%20In%20the%20%60else%60%20branch%20the%20%60.exe%60%20runs%20synchronously%20to%20completion%20before%20%60set%60%20executes%3B%20in%20the%20%60wt%60%20branch%2C%20%60wt%60%20spawns%20a%20new%20terminal%20window%20immediately%20and%20returns%2C%20so%20%60set%60%20only%20mutates%20the%20current%20bat%20session's%20environment%20%E2%80%94%20it%20does%20not%20propagate%20into%20the%20already-started%20%60cmd%20%2Fk%60%20child.%20Moving%20the%20%60set%60%20before%20the%20branch%20is%20the%20correct%20fix.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20batContent%20%3D%20%5B%0A%20%20%20%20%20%20%22%40echo%20off%22%2C%0A%20%20%20%20%20%20%22set%20NO_ANIMATIONS%3D1%22%2C%0A%20%20%20%20%20%20%22where%20wt%20%3Enul%202%3Enul%22%2C%0A%20%20%20%20%20%20'if%20%22%25ERRORLEVEL%25%22%3D%3D%220%22%20%28'%2C%0A%20%20%20%20%20%20'%20%20%20%20wt%20--title%20CodeWhale%20cmd%20%2Fk%20%22%25~dp0codewhale-windows-x64.exe%22'%2C%0A%20%20%20%20%20%20%22%29%20else%20%28%22%2C%0A%20%20%20%20%20%20'%20%20%20%20%22%25~dp0codewhale-windows-x64.exe%22'%2C%0A%20%20%20%20%20%20%22%29%22%2C%0A%20%20%20%20%20%20%22%22%2C%0A%20%20%20%20%5D.join%28%22%5Cr%5Cn%22%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Anpm%2Fcodewhale%2Fscripts%2Fartifacts.js%3A111-119%0A%60allAssetNames%28%29%60%20hard-codes%20%60pair%5B0%5D%60%20and%20%60pair%5B1%5D%60%2C%20so%20%60codewhale.bat%60%20%28now%20%60pair%5B2%5D%60%20of%20the%20%60win32%2Fx64%60%20entry%29%20is%20silently%20omitted%20from%20the%20returned%20set.%20As%20a%20result%2C%20%60allReleaseAssetNames%28%29%60%20also%20excludes%20it%2C%20meaning%20%60verify-release-assets.js%60%20%28line%20118%29%20never%20checks%20whether%20%60codewhale.bat%60%20was%20actually%20published%20to%20the%20GitHub%20release%2C%20even%20though%20the%20checksum%20manifest%20will%20contain%20its%20hash.%20Either%20extend%20the%20loop%20to%20%60pair%5B2%5D%60%20when%20it%20exists%2C%20or%20keep%20the%20%60.bat%60%20out%20of%20%60ASSET_MATRIX%60%20entirely%20and%20treat%20it%20as%20a%20purely%20generated%20artifact.%0A%0A&pr=2305&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix: Windows .bat launcher with correct ..."](https://github.com/hmbown/codewhale/commit/244fd739b03f6fb040b09868466e5f71e26136bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34322920)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->