### PR TITLE
feat(state): add parent_entry_id on the message table for fork support

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -643,6 +643,7 @@ impl ThreadManager {
             git_branch: None,
             git_origin_url: None,
             memory_mode: None,
+            current_leaf_id: None,
         })
     }
 }

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -270,6 +270,7 @@ impl StateStore {
         Ok(())
     }
 
+    /// Upsert thread metadata(will not set current_leaf_id)
     pub fn upsert_thread(&self, thread: &ThreadMetadata) -> Result<()> {
         let conn = self.conn()?;
         conn.execute(
@@ -277,11 +278,11 @@ impl StateStore {
             INSERT INTO threads (
                 id, rollout_path, preview, ephemeral, model_provider, created_at, updated_at, status, path, cwd,
                 cli_version, source, title, sandbox_policy, approval_mode, archived, archived_at,
-                git_sha, git_branch, git_origin_url, memory_mode, current_leaf_id
+                git_sha, git_branch, git_origin_url, memory_mode
             ) VALUES (
                 ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10,
                 ?11, ?12, ?13, ?14, ?15, ?16, ?17,
-                ?18, ?19, ?20, ?21, ?22
+                ?18, ?19, ?20, ?21
             )
             ON CONFLICT(id) DO UPDATE SET
                 rollout_path=excluded.rollout_path,
@@ -303,8 +304,7 @@ impl StateStore {
                 git_sha=excluded.git_sha,
                 git_branch=excluded.git_branch,
                 git_origin_url=excluded.git_origin_url,
-                memory_mode=excluded.memory_mode,
-                current_leaf_id=excluded.current_leaf_id
+                memory_mode=excluded.memory_mode
             "#,
             params![
                 thread.id,
@@ -328,7 +328,6 @@ impl StateStore {
                 thread.git_branch,
                 thread.git_origin_url,
                 thread.memory_mode,
-                thread.current_leaf_id,
             ],
         )
         .context("failed to upsert thread metadata")?;
@@ -708,12 +707,32 @@ impl StateStore {
     }
 
     pub fn clear_messages(&self, thread_id: &str) -> Result<usize> {
-        let conn = self.conn()?;
-        conn.execute(
-            "DELETE FROM messages WHERE thread_id = ?1",
+        let mut conn = self.conn()?;
+        let tx = conn
+            .transaction()
+            .context("failed to begin clear messages transaction")?;
+
+        tx.execute(
+            r#"
+            UPDATE threads
+            SET current_leaf_id = NULL
+            WHERE id = ?1;
+            "#,
             params![thread_id],
         )
-        .with_context(|| format!("failed to clear messages for thread {thread_id}"))
+        .with_context(|| format!("failed to clear messages for thread {thread_id}"))?;
+        let result = tx
+            .execute(
+                r#"
+                DELETE FROM messages WHERE thread_id = ?1
+                "#,
+                params![thread_id],
+            )
+            .with_context(|| format!("failed to clear messages for thread {thread_id}"))?;
+        tx.commit()
+            .context("failed to commit clear messages transaction")?;
+
+        Ok(result)
     }
 
     pub fn save_checkpoint(

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -53,6 +53,7 @@ pub struct ThreadMetadata {
     pub git_branch: Option<String>,
     pub git_origin_url: Option<String>,
     pub memory_mode: Option<String>,
+    pub current_leaf_id: Option<i64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -71,6 +72,7 @@ pub struct MessageRecord {
     pub content: String,
     pub item: Option<Value>,
     pub created_at: i64,
+    pub parent_entry_id: Option<i64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -162,79 +164,107 @@ impl StateStore {
 
     fn init_schema(&self) -> Result<()> {
         let conn = self.conn()?;
-        conn.execute_batch(
-            r#"
-            CREATE TABLE IF NOT EXISTS threads (
-                id TEXT PRIMARY KEY,
-                rollout_path TEXT,
-                preview TEXT NOT NULL,
-                ephemeral INTEGER NOT NULL,
-                model_provider TEXT NOT NULL,
-                created_at INTEGER NOT NULL,
-                updated_at INTEGER NOT NULL,
-                status TEXT NOT NULL,
-                path TEXT,
-                cwd TEXT NOT NULL,
-                cli_version TEXT NOT NULL,
-                source TEXT NOT NULL,
-                title TEXT,
-                sandbox_policy TEXT,
-                approval_mode TEXT,
-                archived INTEGER NOT NULL DEFAULT 0,
-                archived_at INTEGER,
-                git_sha TEXT,
-                git_branch TEXT,
-                git_origin_url TEXT,
-                memory_mode TEXT
-            );
-            CREATE INDEX IF NOT EXISTS idx_threads_updated_at ON threads(updated_at DESC);
-            CREATE INDEX IF NOT EXISTS idx_threads_archived_at ON threads(archived_at DESC);
-            CREATE INDEX IF NOT EXISTS idx_threads_archived_updated ON threads(archived, updated_at DESC);
+        let user_version: u32 = conn.query_row("PRAGMA user_version;", [], |row| row.get(0))?;
+        if user_version == 0 {
+            conn.execute_batch(
+                r#"
+                CREATE TABLE IF NOT EXISTS threads (
+                    id TEXT PRIMARY KEY,
+                    rollout_path TEXT,
+                    preview TEXT NOT NULL,
+                    ephemeral INTEGER NOT NULL,
+                    model_provider TEXT NOT NULL,
+                    created_at INTEGER NOT NULL,
+                    updated_at INTEGER NOT NULL,
+                    status TEXT NOT NULL,
+                    path TEXT,
+                    cwd TEXT NOT NULL,
+                    cli_version TEXT NOT NULL,
+                    source TEXT NOT NULL,
+                    title TEXT,
+                    sandbox_policy TEXT,
+                    approval_mode TEXT,
+                    archived INTEGER NOT NULL DEFAULT 0,
+                    archived_at INTEGER,
+                    git_sha TEXT,
+                    git_branch TEXT,
+                    git_origin_url TEXT,
+                    memory_mode TEXT
+                );
+                CREATE INDEX IF NOT EXISTS idx_threads_updated_at ON threads(updated_at DESC);
+                CREATE INDEX IF NOT EXISTS idx_threads_archived_at ON threads(archived_at DESC);
+                CREATE INDEX IF NOT EXISTS idx_threads_archived_updated ON threads(archived, updated_at DESC);
 
-            CREATE TABLE IF NOT EXISTS thread_dynamic_tools (
-                thread_id TEXT NOT NULL,
-                position INTEGER NOT NULL,
-                name TEXT NOT NULL,
-                description TEXT,
-                input_schema TEXT NOT NULL,
-                PRIMARY KEY (thread_id, position),
-                FOREIGN KEY(thread_id) REFERENCES threads(id) ON DELETE CASCADE
-            );
+                CREATE TABLE IF NOT EXISTS thread_dynamic_tools (
+                    thread_id TEXT NOT NULL,
+                    position INTEGER NOT NULL,
+                    name TEXT NOT NULL,
+                    description TEXT,
+                    input_schema TEXT NOT NULL,
+                    PRIMARY KEY (thread_id, position),
+                    FOREIGN KEY(thread_id) REFERENCES threads(id) ON DELETE CASCADE
+                );
 
-            CREATE TABLE IF NOT EXISTS messages (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                thread_id TEXT NOT NULL,
-                role TEXT NOT NULL,
-                content TEXT NOT NULL,
-                item_json TEXT,
-                created_at INTEGER NOT NULL,
-                FOREIGN KEY(thread_id) REFERENCES threads(id) ON DELETE CASCADE
-            );
-            CREATE INDEX IF NOT EXISTS idx_messages_thread_created_at ON messages(thread_id, created_at ASC);
+                CREATE TABLE IF NOT EXISTS messages (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    thread_id TEXT NOT NULL,
+                    role TEXT NOT NULL,
+                    content TEXT NOT NULL,
+                    item_json TEXT,
+                    created_at INTEGER NOT NULL,
+                    FOREIGN KEY(thread_id) REFERENCES threads(id) ON DELETE CASCADE
+                );
+                CREATE INDEX IF NOT EXISTS idx_messages_thread_created_at ON messages(thread_id, created_at ASC);
 
-            CREATE TABLE IF NOT EXISTS checkpoints (
-                thread_id TEXT NOT NULL,
-                checkpoint_id TEXT NOT NULL,
-                state_json TEXT NOT NULL,
-                created_at INTEGER NOT NULL,
-                PRIMARY KEY(thread_id, checkpoint_id),
-                FOREIGN KEY(thread_id) REFERENCES threads(id) ON DELETE CASCADE
-            );
-            CREATE INDEX IF NOT EXISTS idx_checkpoints_thread_created_at ON checkpoints(thread_id, created_at DESC);
+                CREATE TABLE IF NOT EXISTS checkpoints (
+                    thread_id TEXT NOT NULL,
+                    checkpoint_id TEXT NOT NULL,
+                    state_json TEXT NOT NULL,
+                    created_at INTEGER NOT NULL,
+                    PRIMARY KEY(thread_id, checkpoint_id),
+                    FOREIGN KEY(thread_id) REFERENCES threads(id) ON DELETE CASCADE
+                );
+                CREATE INDEX IF NOT EXISTS idx_checkpoints_thread_created_at ON checkpoints(thread_id, created_at DESC);
 
-            CREATE TABLE IF NOT EXISTS jobs (
-                id TEXT PRIMARY KEY,
-                name TEXT NOT NULL,
-                status TEXT NOT NULL,
-                progress INTEGER,
-                detail TEXT,
-                created_at INTEGER NOT NULL,
-                updated_at INTEGER NOT NULL
-            );
-            CREATE INDEX IF NOT EXISTS idx_jobs_updated_at ON jobs(updated_at DESC);
-            "#,
-        )
-        .context("failed to initialize thread schema")?;
+                CREATE TABLE IF NOT EXISTS jobs (
+                    id TEXT PRIMARY KEY,
+                    name TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    progress INTEGER,
+                    detail TEXT,
+                    created_at INTEGER NOT NULL,
+                    updated_at INTEGER NOT NULL
+                );
+                CREATE INDEX IF NOT EXISTS idx_jobs_updated_at ON jobs(updated_at DESC);
+
+                -- Add parent_entry_id column, and set to last message before current message
+                ALTER TABLE messages ADD COLUMN parent_entry_id INTEGER NULL;
+                UPDATE messages
+                    SET parent_entry_id = (
+                        SELECT m2.id
+                        FROM messages m2
+                        WHERE m2.created_at < messages.created_at AND m2.thread_id = messages.thread_id
+                        ORDER BY m2.created_at DESC
+                        LIMIT 1
+                    );
+                CREATE INDEX idx_messages_parent_entry_id ON messages(parent_entry_id);
+
+                -- Add current_leaf_id column, and set to last message in thread
+                ALTER TABLE threads ADD COLUMN current_leaf_id INTEGER NULL;
+                UPDATE threads
+                    SET current_leaf_id = (
+                        SELECT m.id
+                        FROM messages m
+                        WHERE m.thread_id = threads.id
+                        ORDER BY m.created_at DESC
+                        LIMIT 1
+                    );
+
+                PRAGMA user_version = 1;
+                "#,
+            )
+            .context("failed to initialize thread schema")?;
+        }
         Ok(())
     }
 
@@ -245,11 +275,11 @@ impl StateStore {
             INSERT INTO threads (
                 id, rollout_path, preview, ephemeral, model_provider, created_at, updated_at, status, path, cwd,
                 cli_version, source, title, sandbox_policy, approval_mode, archived, archived_at,
-                git_sha, git_branch, git_origin_url, memory_mode
+                git_sha, git_branch, git_origin_url, memory_mode, current_leaf_id
             ) VALUES (
                 ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10,
                 ?11, ?12, ?13, ?14, ?15, ?16, ?17,
-                ?18, ?19, ?20, ?21
+                ?18, ?19, ?20, ?21, ?22
             )
             ON CONFLICT(id) DO UPDATE SET
                 rollout_path=excluded.rollout_path,
@@ -271,7 +301,8 @@ impl StateStore {
                 git_sha=excluded.git_sha,
                 git_branch=excluded.git_branch,
                 git_origin_url=excluded.git_origin_url,
-                memory_mode=excluded.memory_mode
+                memory_mode=excluded.memory_mode,
+                current_leaf_id=excluded.current_leaf_id
             "#,
             params![
                 thread.id,
@@ -295,6 +326,7 @@ impl StateStore {
                 thread.git_branch,
                 thread.git_origin_url,
                 thread.memory_mode,
+                thread.current_leaf_id,
             ],
         )
         .context("failed to upsert thread metadata")?;
@@ -314,7 +346,7 @@ impl StateStore {
             r#"
             SELECT id, rollout_path, preview, ephemeral, model_provider, created_at, updated_at, status, path, cwd,
                    cli_version, source, title, sandbox_policy, approval_mode, archived, archived_at,
-                   git_sha, git_branch, git_origin_url, memory_mode
+                   git_sha, git_branch, git_origin_url, memory_mode, current_leaf_id
             FROM threads
             WHERE id = ?1
             "#,
@@ -328,9 +360,9 @@ impl StateStore {
     pub fn list_threads(&self, filters: ThreadListFilters) -> Result<Vec<ThreadMetadata>> {
         let conn = self.conn()?;
         let sql = if filters.include_archived {
-            "SELECT id, rollout_path, preview, ephemeral, model_provider, created_at, updated_at, status, path, cwd, cli_version, source, title, sandbox_policy, approval_mode, archived, archived_at, git_sha, git_branch, git_origin_url, memory_mode FROM threads ORDER BY updated_at DESC LIMIT ?1"
+            "SELECT id, rollout_path, preview, ephemeral, model_provider, created_at, updated_at, status, path, cwd, cli_version, source, title, sandbox_policy, approval_mode, archived, archived_at, git_sha, git_branch, git_origin_url, memory_mode, current_leaf_id FROM threads ORDER BY updated_at DESC LIMIT ?1"
         } else {
-            "SELECT id, rollout_path, preview, ephemeral, model_provider, created_at, updated_at, status, path, cwd, cli_version, source, title, sandbox_policy, approval_mode, archived, archived_at, git_sha, git_branch, git_origin_url, memory_mode FROM threads WHERE archived = 0 ORDER BY updated_at DESC LIMIT ?1"
+            "SELECT id, rollout_path, preview, ephemeral, model_provider, created_at, updated_at, status, path, cwd, cli_version, source, title, sandbox_policy, approval_mode, archived, archived_at, git_sha, git_branch, git_origin_url, memory_mode, current_leaf_id FROM threads WHERE archived = 0 ORDER BY updated_at DESC LIMIT ?1"
         };
 
         let mut stmt = conn.prepare(sql).context("failed to prepare list query")?;
@@ -396,6 +428,54 @@ impl StateStore {
         .optional()
         .context("failed to read thread memory mode")
         .map(Option::flatten)
+    }
+
+    pub fn list_leaf_messages(&self, thread_id: &str) -> Result<Vec<MessageRecord>> {
+        let conn = self.conn()?;
+        let mut stmt = conn
+            .prepare(
+                r#"
+                SELECT m1.id, m1.thread_id, m1.role, m1.content, m1.item_json, m1.created_at, m1.parent_entry_id
+                FROM messages m1
+                LEFT JOIN messages m2 ON m1.id = m2.parent_entry_id
+                WHERE m1.thread_id = ?1 AND m2.id IS NULL
+                "#,
+            )
+            .context("failed to prepare message listing query")?;
+        let mut rows = stmt
+            .query(params![thread_id])
+            .with_context(|| format!("failed to list leaf messages for thread {thread_id}"))?;
+        let mut out = Vec::new();
+        while let Some(row) = rows.next().context("failed to iterate message rows")? {
+            let item_json: Option<String> = row.get(4).context("failed to read item json")?;
+            let item = item_json
+                .as_deref()
+                .map(serde_json::from_str)
+                .transpose()
+                .with_context(|| {
+                    format!("failed to parse message item json in thread {thread_id}")
+                })?;
+            out.push(MessageRecord {
+                id: row.get(0).context("failed to read message id")?,
+                thread_id: row.get(1).context("failed to read message thread id")?,
+                role: row.get(2).context("failed to read message role")?,
+                content: row.get(3).context("failed to read message content")?,
+                item,
+                created_at: row.get(5).context("failed to read message timestamp")?,
+                parent_entry_id: row.get(6).context("failed to read parent entry id")?,
+            });
+        }
+        Ok(out)
+    }
+
+    pub fn set_current_leaf_id(&self, thread_id: &str, current_leaf_id: &str) -> Result<()> {
+        let conn = self.conn()?;
+        conn.execute(
+            "UPDATE threads SET current_leaf_id = ?1 WHERE id = ?2",
+            params![current_leaf_id, thread_id],
+        )
+        .context("failed to update thread current leaf id")?;
+        Ok(())
     }
 
     pub fn persist_dynamic_tools(
@@ -464,18 +544,51 @@ impl StateStore {
         content: &str,
         item: Option<Value>,
     ) -> Result<i64> {
-        let conn = self.conn()?;
+        let mut conn = self.conn()?;
         let created_at = Utc::now().timestamp();
         let item_json = item
             .as_ref()
             .map(serde_json::to_string)
             .transpose()
             .context("failed to serialize message item payload")?;
-        conn.execute(
-            "INSERT INTO messages(thread_id, role, content, item_json, created_at) VALUES (?1, ?2, ?3, ?4, ?5)",
-            params![thread_id, role, content, item_json, created_at],
+
+        let tx = conn
+            .transaction()
+            .context("failed to begin append message transaction")?;
+
+        let current_leaf_id: Option<i64> = tx
+            .query_row(
+                "SELECT current_leaf_id FROM threads WHERE id = ?1",
+                params![thread_id],
+                |row| row.get(0),
+            )
+            .with_context(|| {
+                format!("failed to query thread current leaf id for thread {thread_id}")
+            })?;
+
+        let next_leaf_id: i64 = tx.query_row(
+            r#"
+                INSERT INTO messages(thread_id, role, content, item_json, created_at, parent_entry_id)
+                SELECT ?1, ?2, ?3, ?4, ?5, ?6
+                RETURNING id
+            "#, params![thread_id, role, content, item_json, created_at, current_leaf_id], |row| row.get(0)
+        ).with_context(|| format!("failed to append message for thread {thread_id}"))?;
+
+        tx.execute(
+            r#"
+            UPDATE threads
+            SET current_leaf_id = ?1
+            WHERE id = ?2;
+            "#,
+            params![next_leaf_id, thread_id],
         )
-        .with_context(|| format!("failed to append message for thread {thread_id}"))?;
+        .with_context(|| {
+            format!("failed to update thread current leaf id for thread {thread_id}")
+        })?;
+
+        tx.commit()
+            .context("failed to commit append message transaction")?;
+
         Ok(conn.last_insert_rowid())
     }
 
@@ -488,11 +601,30 @@ impl StateStore {
         let limit = i64::try_from(limit.unwrap_or(500)).unwrap_or(500);
         let mut stmt = conn
             .prepare(
-                "SELECT id, thread_id, role, content, item_json, created_at FROM messages WHERE thread_id = ?1 ORDER BY created_at ASC LIMIT ?2",
+                r#"  
+                WITH RECURSIVE
+                    leaf_id AS (
+                        SELECT current_leaf_id FROM threads WHERE id = ?1
+                    ),
+                    ancestors AS (
+                        SELECT id, thread_id, role, content, item_json, created_at, parent_entry_id, 0 AS depth
+                        FROM messages
+                        WHERE id = (SELECT current_leaf_id FROM leaf_id)
+
+                        UNION ALL
+
+                        SELECT m.id, m.thread_id, m.role, m.content, m.item_json, m.created_at, m.parent_entry_id, a.depth + 1
+                        FROM messages m
+                        JOIN ancestors a ON m.id = a.parent_entry_id
+                        WHERE a.depth < ?2
+                    )
+                    SELECT id, thread_id, role, content, item_json, created_at, parent_entry_id FROM ancestors
+                    ORDER BY depth ASC
+                "#
             )
             .context("failed to prepare message listing query")?;
         let mut rows = stmt
-            .query(params![thread_id, limit])
+            .query(params![thread_id, limit - 1])
             .with_context(|| format!("failed to list messages for thread {thread_id}"))?;
         let mut out = Vec::new();
         while let Some(row) = rows.next().context("failed to iterate message rows")? {
@@ -511,9 +643,66 @@ impl StateStore {
                 content: row.get(3).context("failed to read message content")?,
                 item,
                 created_at: row.get(5).context("failed to read message timestamp")?,
+                parent_entry_id: row.get(6).context("failed to read parent entry id")?,
             });
         }
         Ok(out)
+    }
+
+    pub fn fork_at_message(
+        &self,
+        message_id: &str,
+        role: &str,
+        content: &str,
+        item: Option<Value>,
+    ) -> Result<i64> {
+        let mut conn = self.conn()?;
+        let created_at = Utc::now().timestamp();
+        let item_json = item
+            .as_ref()
+            .map(serde_json::to_string)
+            .transpose()
+            .context("failed to serialize message item payload")?;
+
+        let tx = conn
+            .transaction()
+            .context("failed to begin fork message transaction")?;
+
+        let thread_id: Option<String> = tx
+            .query_row(
+                "SELECT thread_id FROM messages WHERE id = ?1",
+                params![message_id],
+                |row| row.get(0),
+            )
+            .with_context(|| format!("failed to query thread id for message {message_id}"))?;
+
+        let next_leaf_id: i64 = tx.query_row(
+            r#"
+                INSERT INTO messages(thread_id, role, content, item_json, created_at, parent_entry_id)
+                SELECT ?1, ?2, ?3, ?4, ?5, ?6
+                RETURNING id
+            "#, params![thread_id, role, content, item_json, created_at, message_id], |row| row.get(0)
+        ).with_context(|| format!("failed to fork at message for thread {:?}", thread_id))?;
+
+        tx.execute(
+            r#"
+            UPDATE threads
+            SET current_leaf_id = ?1
+            WHERE id = ?2;
+            "#,
+            params![next_leaf_id, thread_id],
+        )
+        .with_context(|| {
+            format!(
+                "failed to update thread current leaf id for thread {:?}",
+                thread_id
+            )
+        })?;
+
+        tx.commit()
+            .context("failed to commit fork message transaction")?;
+
+        Ok(next_leaf_id)
     }
 
     pub fn clear_messages(&self, thread_id: &str) -> Result<usize> {
@@ -946,5 +1135,6 @@ fn row_to_thread(row: &rusqlite::Row<'_>) -> rusqlite::Result<ThreadMetadata> {
         git_branch: row.get(18)?,
         git_origin_url: row.get(19)?,
         memory_mode: row.get(20)?,
+        current_leaf_id: row.get(21)?,
     })
 }

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -168,6 +168,7 @@ impl StateStore {
         if user_version == 0 {
             conn.execute_batch(
                 r#"
+                BEGIN;
                 CREATE TABLE IF NOT EXISTS threads (
                     id TEXT PRIMARY KEY,
                     rollout_path TEXT,
@@ -244,7 +245,7 @@ impl StateStore {
                         SELECT m2.id
                         FROM messages m2
                         WHERE m2.created_at < messages.created_at AND m2.thread_id = messages.thread_id
-                        ORDER BY m2.created_at DESC
+                        ORDER BY m2.id DESC
                         LIMIT 1
                     );
                 CREATE INDEX idx_messages_parent_entry_id ON messages(parent_entry_id);
@@ -256,11 +257,12 @@ impl StateStore {
                         SELECT m.id
                         FROM messages m
                         WHERE m.thread_id = threads.id
-                        ORDER BY m.created_at DESC
+                        ORDER BY m.id DESC
                         LIMIT 1
                     );
 
                 PRAGMA user_version = 1;
+                COMMIT;
                 "#,
             )
             .context("failed to initialize thread schema")?;
@@ -589,7 +591,7 @@ impl StateStore {
         tx.commit()
             .context("failed to commit append message transaction")?;
 
-        Ok(conn.last_insert_rowid())
+        Ok(next_leaf_id)
     }
 
     pub fn list_messages(
@@ -619,7 +621,7 @@ impl StateStore {
                         WHERE a.depth < ?2
                     )
                     SELECT id, thread_id, role, content, item_json, created_at, parent_entry_id FROM ancestors
-                    ORDER BY depth ASC
+                    ORDER BY depth DESC
                 "#
             )
             .context("failed to prepare message listing query")?;
@@ -668,7 +670,7 @@ impl StateStore {
             .transaction()
             .context("failed to begin fork message transaction")?;
 
-        let thread_id: Option<String> = tx
+        let thread_id: String = tx
             .query_row(
                 "SELECT thread_id FROM messages WHERE id = ?1",
                 params![message_id],

--- a/crates/state/tests/parity_state.rs
+++ b/crates/state/tests/parity_state.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use codewhale_state::{SessionSource, StateStore, ThreadListFilters, ThreadMetadata, ThreadStatus};
+use rusqlite::Connection;
 
 fn temp_state_path(label: &str) -> PathBuf {
     std::env::temp_dir().join(format!(
@@ -38,6 +39,7 @@ fn upsert_and_resume_thread_metadata() {
         git_branch: None,
         git_origin_url: None,
         memory_mode: Some("extended".to_string()),
+        current_leaf_id: None,
     };
     store.upsert_thread(&thread).expect("upsert thread");
 
@@ -69,4 +71,197 @@ fn upsert_and_resume_thread_metadata() {
         })
         .expect("list threads");
     assert!(!listed.is_empty());
+}
+
+#[test]
+fn init_schema_migration() {
+    let path = temp_state_path("init_schema_migration");
+    let conn = Connection::open(&path).expect("open state db");
+    conn.execute_batch(
+        r#"
+        CREATE TABLE IF NOT EXISTS threads (
+            id TEXT PRIMARY KEY,
+            rollout_path TEXT,
+            preview TEXT NOT NULL,
+            ephemeral INTEGER NOT NULL,
+            model_provider TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            status TEXT NOT NULL,
+            path TEXT,
+            cwd TEXT NOT NULL,
+            cli_version TEXT NOT NULL,
+            source TEXT NOT NULL,
+            title TEXT,
+            sandbox_policy TEXT,
+            approval_mode TEXT,
+            archived INTEGER NOT NULL DEFAULT 0,
+            archived_at INTEGER,
+            git_sha TEXT,
+            git_branch TEXT,
+            git_origin_url TEXT,
+            memory_mode TEXT
+        );
+        CREATE TABLE IF NOT EXISTS messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            thread_id TEXT NOT NULL,
+            role TEXT NOT NULL,
+            content TEXT NOT NULL,
+            item_json TEXT,
+            created_at INTEGER NOT NULL,
+            FOREIGN KEY(thread_id) REFERENCES threads(id) ON DELETE CASCADE
+        );
+        INSERT INTO threads (
+            id, preview, ephemeral, model_provider, created_at, updated_at, status, cwd, cli_version, source, archived
+        )
+        VALUES (
+            'thread-test-1', 'hello', false, 'deepseek', 0, 0, 'running', '/tmp/project', '0.0.0-test', 'interactive', false
+        );
+        INSERT INTO messages (thread_id, role, content, created_at) VALUES 
+        ('thread-test-1', 'foo0', 'bar0', 0),
+        ('thread-test-1', 'foo1', 'bar1', 1),
+        ('thread-test-1', 'foo2', 'bar2', 2);
+        "#,
+    )
+    .expect("init schema migration");
+
+    let store = StateStore::open(Some(path.clone())).expect("open state store");
+    let thread = store
+        .get_thread("thread-test-1")
+        .expect("read thread")
+        .unwrap();
+    assert_eq!(thread.id, "thread-test-1");
+    assert_eq!(thread.preview, "hello");
+    assert!(!thread.ephemeral);
+    assert_eq!(thread.model_provider, "deepseek");
+    assert_eq!(thread.created_at, 0);
+    assert_eq!(thread.updated_at, 0);
+    assert_eq!(thread.status, ThreadStatus::Running);
+    assert_eq!(thread.cwd, PathBuf::from("/tmp/project"));
+    assert_eq!(thread.cli_version, "0.0.0-test");
+    assert_eq!(thread.source, SessionSource::Interactive);
+    assert!(thread.current_leaf_id.is_some());
+
+    let messages = store
+        .list_messages("thread-test-1", None)
+        .expect("list messages");
+    assert_eq!(messages.len(), 3);
+    for (i, message) in messages.iter().enumerate() {
+        assert_eq!(message.thread_id, "thread-test-1");
+        assert_eq!(message.role, format!("foo{}", 2 - i));
+        assert_eq!(message.content, format!("bar{}", 2 - i));
+        assert_eq!(message.created_at, 2 - i as i64);
+    }
+
+    // Test idempotent
+    StateStore::open(Some(path.clone())).expect("open state store");
+}
+
+#[test]
+fn test_fork() {
+    let path = temp_state_path("test_fork");
+    let store = StateStore::open(Some(path.clone())).expect("open state store");
+    let now = chrono::Utc::now().timestamp();
+    let thread = ThreadMetadata {
+        id: "thread-test-1".to_string(),
+        rollout_path: Some(PathBuf::from("/tmp/rollout.jsonl")),
+        preview: "hello".to_string(),
+        ephemeral: false,
+        model_provider: "deepseek".to_string(),
+        created_at: now,
+        updated_at: now,
+        status: ThreadStatus::Running,
+        path: Some(PathBuf::from("/tmp/project")),
+        cwd: PathBuf::from("/tmp/project"),
+        cli_version: "0.0.0-test".to_string(),
+        source: SessionSource::Interactive,
+        name: Some("Test Thread".to_string()),
+        sandbox_policy: Some("workspace-write".to_string()),
+        approval_mode: Some("on-request".to_string()),
+        archived: false,
+        archived_at: None,
+        git_sha: None,
+        git_branch: None,
+        git_origin_url: None,
+        memory_mode: Some("extended".to_string()),
+        current_leaf_id: None,
+    };
+
+    store.upsert_thread(&thread).expect("upsert thread");
+    store
+        .append_message("thread-test-1", "foo0", "bar0", None)
+        .expect("append message");
+    store
+        .append_message("thread-test-1", "foo1", "bar1", None)
+        .expect("append message");
+    store
+        .append_message("thread-test-1", "foo2", "bar2", None)
+        .expect("append message");
+    store
+        .append_message("thread-test-1", "foo3", "bar3", None)
+        .expect("append message");
+    store
+        .append_message("thread-test-1", "foo4", "bar4", None)
+        .expect("append message");
+
+    let messages = store
+        .list_messages("thread-test-1", None)
+        .expect("list messages");
+    assert_eq!(messages.len(), 5);
+    let ids = messages
+        .iter()
+        .enumerate()
+        .map(|(i, message)| {
+            assert_eq!(message.thread_id, "thread-test-1");
+            assert_eq!(message.role, format!("foo{}", 4 - i));
+            assert_eq!(message.content, format!("bar{}", 4 - i));
+            message.id.to_string()
+        })
+        .collect::<Vec<_>>();
+
+    store
+        .fork_at_message(&ids[2], "foo5", "bar5", None)
+        .expect("fork at message");
+    let messages = store
+        .list_messages("thread-test-1", None)
+        .expect("list messages");
+    assert_eq!(messages.len(), 4);
+    const LIST_1: [i64; 4] = [5, 2, 1, 0];
+    messages
+        .iter()
+        .zip(LIST_1.iter())
+        .for_each(|(message, &i)| {
+            assert_eq!(message.thread_id, "thread-test-1");
+            assert_eq!(message.role, format!("foo{}", i));
+            assert_eq!(message.content, format!("bar{}", i));
+        });
+    let leaves = store
+        .list_leaf_messages("thread-test-1")
+        .expect("list leaf messages");
+    assert_eq!(leaves.len(), 2);
+
+    store
+        .set_current_leaf_id("thread-test-1", &ids[0])
+        .expect("set current leaf id");
+    store
+        .append_message("thread-test-1", "foo6", "bar6", None)
+        .expect("append message");
+    let messages = store
+        .list_messages("thread-test-1", None)
+        .expect("list messages");
+    assert_eq!(messages.len(), 6);
+    const LIST_2: [i64; 6] = [6, 4, 3, 2, 1, 0];
+    messages
+        .iter()
+        .zip(LIST_2.iter())
+        .for_each(|(message, &i)| {
+            assert_eq!(message.thread_id, "thread-test-1");
+            assert_eq!(message.role, format!("foo{}", i));
+            assert_eq!(message.content, format!("bar{}", i));
+        });
+
+    let leaves = store
+        .list_leaf_messages("thread-test-1")
+        .expect("list leaf messages");
+    assert_eq!(leaves.len(), 2);
 }

--- a/crates/state/tests/parity_state.rs
+++ b/crates/state/tests/parity_state.rs
@@ -219,6 +219,8 @@ fn test_fork() {
         })
         .collect::<Vec<_>>();
 
+    store.upsert_thread(&thread).expect("upsert thread");
+
     store
         .fork_at_message(&ids[2], "foo5", "bar5", None)
         .expect("fork at message");
@@ -264,4 +266,18 @@ fn test_fork() {
         .list_leaf_messages("thread-test-1")
         .expect("list leaf messages");
     assert_eq!(leaves.len(), 2);
+
+    store
+        .clear_messages("thread-test-1")
+        .expect("clear messages");
+    let leaves = store
+        .list_leaf_messages("thread-test-1")
+        .expect("list leaf messages");
+    assert_eq!(leaves.len(), 0);
+    let thread = store
+        .get_thread("thread-test-1")
+        .expect("get thread")
+        .unwrap();
+    dbg!(&thread);
+    assert!(thread.current_leaf_id.is_none());
 }

--- a/crates/state/tests/parity_state.rs
+++ b/crates/state/tests/parity_state.rs
@@ -148,9 +148,9 @@ fn init_schema_migration() {
     assert_eq!(messages.len(), 3);
     for (i, message) in messages.iter().enumerate() {
         assert_eq!(message.thread_id, "thread-test-1");
-        assert_eq!(message.role, format!("foo{}", 2 - i));
-        assert_eq!(message.content, format!("bar{}", 2 - i));
-        assert_eq!(message.created_at, 2 - i as i64);
+        assert_eq!(message.role, format!("foo{}", i));
+        assert_eq!(message.content, format!("bar{}", i));
+        assert_eq!(message.created_at, i as i64);
     }
 
     // Test idempotent
@@ -213,8 +213,8 @@ fn test_fork() {
         .enumerate()
         .map(|(i, message)| {
             assert_eq!(message.thread_id, "thread-test-1");
-            assert_eq!(message.role, format!("foo{}", 4 - i));
-            assert_eq!(message.content, format!("bar{}", 4 - i));
+            assert_eq!(message.role, format!("foo{}", i));
+            assert_eq!(message.content, format!("bar{}", i));
             message.id.to_string()
         })
         .collect::<Vec<_>>();
@@ -226,7 +226,7 @@ fn test_fork() {
         .list_messages("thread-test-1", None)
         .expect("list messages");
     assert_eq!(messages.len(), 4);
-    const LIST_1: [i64; 4] = [5, 2, 1, 0];
+    const LIST_1: [i64; 4] = [0, 1, 2, 5];
     messages
         .iter()
         .zip(LIST_1.iter())
@@ -241,7 +241,7 @@ fn test_fork() {
     assert_eq!(leaves.len(), 2);
 
     store
-        .set_current_leaf_id("thread-test-1", &ids[0])
+        .set_current_leaf_id("thread-test-1", &ids[4])
         .expect("set current leaf id");
     store
         .append_message("thread-test-1", "foo6", "bar6", None)
@@ -250,7 +250,7 @@ fn test_fork() {
         .list_messages("thread-test-1", None)
         .expect("list messages");
     assert_eq!(messages.len(), 6);
-    const LIST_2: [i64; 6] = [6, 4, 3, 2, 1, 0];
+    const LIST_2: [i64; 6] = [0, 1, 2, 3, 4, 6];
     messages
         .iter()
         .zip(LIST_2.iter())


### PR DESCRIPTION
## Summary

Refs #2082 add fork support to state crate, add parent_entry_id to message table and current_leaf_id to threads table

## Change

- change some structs and other crate to add fields to match the database
- init_schema: use user_version to determine whether an update is needed, on update do old migration first then add new column and use created_at to make chain
- append_message: add message under current leaf message and set current to new
- list_messages: list the parent chain of current leaf
- (Add) list_leaf_messages: return messages on leaf node of the message tree
- (Add) fork_at_message: add message under specified message and set current to new
- (Test) init_schema_migration: make sure it can migration from existing sessions
- (Test) test_fork: test forks a 5-message session and proves both leaves are queryable independently

## Testing

- [ x ] `cargo fmt --all -- --check`
- [ x ] `cargo clippy --workspace --all-targets --all-features`
- [ x ] `cargo test --workspace --all-features`

## Checklist

- [ x ] Updated docs or comments as needed
- [ x ] Added or updated tests where relevant
- [ x ] Verified TUI behavior manually if UI changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds fork support to the `state` crate by introducing `parent_entry_id` on the `messages` table and `current_leaf_id` on the `threads` table, enabling a message-tree structure where conversations can branch from any historical message.

- `init_schema` is now versioned via `PRAGMA user_version`: on first open it runs `CREATE TABLE IF NOT EXISTS` for all tables and immediately `ALTER TABLE` to add the two new columns, sets `user_version = 1`, and wraps everything in a `BEGIN/COMMIT` to make the migration atomic.
- `append_message` is rewritten as a transaction that reads `current_leaf_id`, inserts the new message with that value as `parent_entry_id`, then advances `current_leaf_id`; `list_messages` switches from a flat `ORDER BY created_at` to a recursive CTE that walks the parent chain from `current_leaf_id`.
- New public API: `fork_at_message` inserts a child under an arbitrary existing message and sets it as the new current leaf; `list_leaf_messages` returns all tip nodes; `set_current_leaf_id` lets callers switch the active branch.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The migration parent-chain reconstruction uses strict less-than on a seconds-precision timestamp, which silently truncates conversation history for any existing thread where two or more messages share the same second.

Any thread with rapid message exchanges — the common case for LLM tool-call/response cycles — will have messages with identical created_at values. The migration sets parent_entry_id to NULL for all of them, breaking the ancestor chain. list_messages then returns only the fragment from current_leaf_id to the first orphan, dropping older messages permanently and irreversibly.

crates/state/src/lib.rs — the UPDATE messages SET parent_entry_id subquery in the migration block (lines 243–250).
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/state/src/lib.rs | Core state layer rewritten to support fork: adds parent_entry_id/current_leaf_id, new CTE-based list_messages, fork_at_message, list_leaf_messages, set_current_leaf_id. Migration timestamp collision (strict < on created_at) can break the parent chain for existing sessions with same-second messages. |
| crates/core/src/lib.rs | Adds current_leaf_id: None to the ThreadMetadata literal in persist_thread; upsert_thread's ON CONFLICT clause intentionally omits current_leaf_id so the stored value is preserved. |
| crates/state/tests/parity_state.rs | Adds two new tests: init_schema_migration (migration from a pre-existing schema) and test_fork (full fork/leaf/clear lifecycle). A stray dbg! macro is left in test_fork. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/core/src/lib.rs`, line 624-647 ([link](https://github.com/hmbown/codewhale/blob/2a8bc6f69a11fb30b59b33c6781dcf168c4be3e7/crates/core/src/lib.rs#L624-L647)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`persist_thread` hard-codes `current_leaf_id: None`, wiping it on every resume**

   `persist_thread` builds a `ThreadMetadata` literal with `current_leaf_id: None`. Because `upsert_thread`'s `ON CONFLICT` clause includes `current_leaf_id = excluded.current_leaf_id`, any call to `persist_thread` on an existing thread writes NULL over the value that `append_message` painstakingly maintained. `resume_thread_with_history` calls `persist_thread` before it conditionally appends history (line 502), so resuming a thread that has no new history clears `current_leaf_id` permanently — after which `list_messages` returns an empty list because the CTE base case `WHERE id = NULL` never matches.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Ffork-support-on-state%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Ffork-support-on-state%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fcore%2Fsrc%2Flib.rs%0ALine%3A%20624-647%0A%0AComment%3A%0A**%60persist_thread%60%20hard-codes%20%60current_leaf_id%3A%20None%60%2C%20wiping%20it%20on%20every%20resume**%0A%0A%60persist_thread%60%20builds%20a%20%60ThreadMetadata%60%20literal%20with%20%60current_leaf_id%3A%20None%60.%20Because%20%60upsert_thread%60's%20%60ON%20CONFLICT%60%20clause%20includes%20%60current_leaf_id%20%3D%20excluded.current_leaf_id%60%2C%20any%20call%20to%20%60persist_thread%60%20on%20an%20existing%20thread%20writes%20NULL%20over%20the%20value%20that%20%60append_message%60%20painstakingly%20maintained.%20%60resume_thread_with_history%60%20calls%20%60persist_thread%60%20before%20it%20conditionally%20appends%20history%20%28line%20502%29%2C%20so%20resuming%20a%20thread%20that%20has%20no%20new%20history%20clears%20%60current_leaf_id%60%20permanently%20%E2%80%94%20after%20which%20%60list_messages%60%20returns%20an%20empty%20list%20because%20the%20CTE%20base%20case%20%60WHERE%20id%20%3D%20NULL%60%20never%20matches.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fcore%2Fsrc%2Flib.rs%0ALine%3A%20624-647%0A%0AComment%3A%0A**%60persist_thread%60%20hard-codes%20%60current_leaf_id%3A%20None%60%2C%20wiping%20it%20on%20every%20resume**%0A%0A%60persist_thread%60%20builds%20a%20%60ThreadMetadata%60%20literal%20with%20%60current_leaf_id%3A%20None%60.%20Because%20%60upsert_thread%60's%20%60ON%20CONFLICT%60%20clause%20includes%20%60current_leaf_id%20%3D%20excluded.current_leaf_id%60%2C%20any%20call%20to%20%60persist_thread%60%20on%20an%20existing%20thread%20writes%20NULL%20over%20the%20value%20that%20%60append_message%60%20painstakingly%20maintained.%20%60resume_thread_with_history%60%20calls%20%60persist_thread%60%20before%20it%20conditionally%20appends%20history%20%28line%20502%29%2C%20so%20resuming%20a%20thread%20that%20has%20no%20new%20history%20clears%20%60current_leaf_id%60%20permanently%20%E2%80%94%20after%20which%20%60list_messages%60%20returns%20an%20empty%20list%20because%20the%20CTE%20base%20case%20%60WHERE%20id%20%3D%20NULL%60%20never%20matches.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2308&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fcore%2Fsrc%2Flib.rs%0ALine%3A%20624-647%0A%0AComment%3A%0A**%60persist_thread%60%20hard-codes%20%60current_leaf_id%3A%20None%60%2C%20wiping%20it%20on%20every%20resume**%0A%0A%60persist_thread%60%20builds%20a%20%60ThreadMetadata%60%20literal%20with%20%60current_leaf_id%3A%20None%60.%20Because%20%60upsert_thread%60's%20%60ON%20CONFLICT%60%20clause%20includes%20%60current_leaf_id%20%3D%20excluded.current_leaf_id%60%2C%20any%20call%20to%20%60persist_thread%60%20on%20an%20existing%20thread%20writes%20NULL%20over%20the%20value%20that%20%60append_message%60%20painstakingly%20maintained.%20%60resume_thread_with_history%60%20calls%20%60persist_thread%60%20before%20it%20conditionally%20appends%20history%20%28line%20502%29%2C%20so%20resuming%20a%20thread%20that%20has%20no%20new%20history%20clears%20%60current_leaf_id%60%20permanently%20%E2%80%94%20after%20which%20%60list_messages%60%20returns%20an%20empty%20list%20because%20the%20CTE%20base%20case%20%60WHERE%20id%20%3D%20NULL%60%20never%20matches.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2308&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Ffork-support-on-state%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Ffork-support-on-state%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Fstate%2Fsrc%2Flib.rs%3A243-251%0A**Migration%20silently%20drops%20messages%20when%20timestamps%20collide**%0A%0AThe%20subquery%20uses%20strict%20%60%3C%60%20on%20%60created_at%60%2C%20which%20is%20seconds-precision%20%28%60Utc%3A%3Anow%28%29.timestamp%28%29%60%29.%20Any%20two%20messages%20in%20the%20same%20thread%20written%20within%20the%20same%20second%20will%20both%20resolve%20their%20parent%20as%20the%20message%20*before*%20that%20second%20%E2%80%94%20or%20NULL%20if%20the%20entire%20conversation%20happened%20within%20one%20second.%20After%20migration%2C%20%60list_messages%60%20walks%20the%20%60parent_entry_id%60%20chain%20from%20%60current_leaf_id%60%2C%20so%20the%20chain%20breaks%20at%20the%20first%20same-second%20pair%20and%20older%20messages%20are%20silently%20omitted.%20A%20five-message%20conversation%20where%20all%20messages%20share%20a%20timestamp%20would%20become%20a%20chain%20of%20length%201.%20The%20reliable%20fix%20is%20to%20use%20the%20AUTOINCREMENT%20%60id%60%20for%20ordering%2C%20which%20is%20always%20strictly%20monotonic%3A%20%60WHERE%20m2.id%20%3C%20messages.id%20AND%20m2.thread_id%20%3D%20messages.thread_id%20ORDER%20BY%20m2.id%20DESC%20LIMIT%201%60.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Fstate%2Ftests%2Fparity_state.rs%3A281%0A%60dbg!%60%20macro%20left%20in%20test%20%E2%80%94%20it%20will%20print%20the%20full%20%60ThreadMetadata%60%20debug%20representation%20to%20stderr%20on%20every%20test%20run.%0A%0A%60%60%60suggestion%0A%20%20%20%20assert!%28thread.current_leaf_id.is_none%28%29%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Fstate%2Fsrc%2Flib.rs%3A243-251%0A**Migration%20silently%20drops%20messages%20when%20timestamps%20collide**%0A%0AThe%20subquery%20uses%20strict%20%60%3C%60%20on%20%60created_at%60%2C%20which%20is%20seconds-precision%20%28%60Utc%3A%3Anow%28%29.timestamp%28%29%60%29.%20Any%20two%20messages%20in%20the%20same%20thread%20written%20within%20the%20same%20second%20will%20both%20resolve%20their%20parent%20as%20the%20message%20*before*%20that%20second%20%E2%80%94%20or%20NULL%20if%20the%20entire%20conversation%20happened%20within%20one%20second.%20After%20migration%2C%20%60list_messages%60%20walks%20the%20%60parent_entry_id%60%20chain%20from%20%60current_leaf_id%60%2C%20so%20the%20chain%20breaks%20at%20the%20first%20same-second%20pair%20and%20older%20messages%20are%20silently%20omitted.%20A%20five-message%20conversation%20where%20all%20messages%20share%20a%20timestamp%20would%20become%20a%20chain%20of%20length%201.%20The%20reliable%20fix%20is%20to%20use%20the%20AUTOINCREMENT%20%60id%60%20for%20ordering%2C%20which%20is%20always%20strictly%20monotonic%3A%20%60WHERE%20m2.id%20%3C%20messages.id%20AND%20m2.thread_id%20%3D%20messages.thread_id%20ORDER%20BY%20m2.id%20DESC%20LIMIT%201%60.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Fstate%2Ftests%2Fparity_state.rs%3A281%0A%60dbg!%60%20macro%20left%20in%20test%20%E2%80%94%20it%20will%20print%20the%20full%20%60ThreadMetadata%60%20debug%20representation%20to%20stderr%20on%20every%20test%20run.%0A%0A%60%60%60suggestion%0A%20%20%20%20assert!%28thread.current_leaf_id.is_none%28%29%29%3B%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2308&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Fstate%2Fsrc%2Flib.rs%3A243-251%0A**Migration%20silently%20drops%20messages%20when%20timestamps%20collide**%0A%0AThe%20subquery%20uses%20strict%20%60%3C%60%20on%20%60created_at%60%2C%20which%20is%20seconds-precision%20%28%60Utc%3A%3Anow%28%29.timestamp%28%29%60%29.%20Any%20two%20messages%20in%20the%20same%20thread%20written%20within%20the%20same%20second%20will%20both%20resolve%20their%20parent%20as%20the%20message%20*before*%20that%20second%20%E2%80%94%20or%20NULL%20if%20the%20entire%20conversation%20happened%20within%20one%20second.%20After%20migration%2C%20%60list_messages%60%20walks%20the%20%60parent_entry_id%60%20chain%20from%20%60current_leaf_id%60%2C%20so%20the%20chain%20breaks%20at%20the%20first%20same-second%20pair%20and%20older%20messages%20are%20silently%20omitted.%20A%20five-message%20conversation%20where%20all%20messages%20share%20a%20timestamp%20would%20become%20a%20chain%20of%20length%201.%20The%20reliable%20fix%20is%20to%20use%20the%20AUTOINCREMENT%20%60id%60%20for%20ordering%2C%20which%20is%20always%20strictly%20monotonic%3A%20%60WHERE%20m2.id%20%3C%20messages.id%20AND%20m2.thread_id%20%3D%20messages.thread_id%20ORDER%20BY%20m2.id%20DESC%20LIMIT%201%60.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Fstate%2Ftests%2Fparity_state.rs%3A281%0A%60dbg!%60%20macro%20left%20in%20test%20%E2%80%94%20it%20will%20print%20the%20full%20%60ThreadMetadata%60%20debug%20representation%20to%20stderr%20on%20every%20test%20run.%0A%0A%60%60%60suggestion%0A%20%20%20%20assert!%28thread.current_leaf_id.is_none%28%29%29%3B%0A%60%60%60%0A%0A&pr=2308&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (5): Last reviewed commit: ["fix: upsert\_thread will not set current\_..."](https://github.com/hmbown/codewhale/commit/734127f75cfd80b52a23e25d7e19fbd094b88d6f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34329612)</sub>

<!-- /greptile_comment -->