### PR TITLE
feat(prompts): support inline string sources in EngineConfig.instructions

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -91,11 +91,15 @@ pub struct EngineConfig {
     pub mcp_config_path: PathBuf,
     /// Directory containing discoverable skills.
     pub skills_dir: PathBuf,
-    /// Additional instruction files concatenated into the system
-    /// prompt (#454). Loaded in declared order from the user's
-    /// `instructions = [...]` config (or the per-project override).
-    /// Resolved via `expand_path` so `~` works.
-    pub instructions: Vec<PathBuf>,
+    /// Sources injected as `<instructions source="…">` blocks in the system
+    /// prompt (#454). Each entry is either a disk path (read at render time)
+    /// or an inline string. Loaded in declared order from the user's
+    /// `instructions = [...]` config or constructed by embedders.
+    ///
+    /// Generalized from `Vec<PathBuf>` so embedders can inject inline content
+    /// without staging a disk file. `From<PathBuf>` impl keeps existing callers
+    /// working with `.into()` at the call site.
+    pub instructions: Vec<crate::prompts::InstructionSource>,
     pub project_context_pack_enabled: bool,
     /// When true, the model is instructed to respond in the current locale
     /// and a post-hoc translation layer replaces remaining English output.

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -5181,7 +5181,11 @@ async fn run_exec_agent(
         notes_path: config.notes_path(),
         mcp_config_path: config.mcp_config_path(),
         skills_dir: config.skills_dir(),
-        instructions: config.instructions_paths(),
+        instructions: config
+            .instructions_paths()
+            .into_iter()
+            .map(Into::into)
+            .collect(),
         project_context_pack_enabled: config.project_context_pack_enabled(),
         translation_enabled: false,
         show_thinking: settings.show_thinking,

--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -156,44 +156,88 @@ fn render_environment_block(workspace: &Path, locale_tag: &str) -> String {
     )
 }
 
+/// Source for an `EngineConfig.instructions` entry. Either a disk file (loaded
+/// at render time, original semantics) or an inline string (content baked into
+/// `EngineConfig`, no disk I/O at render time).
+///
+/// The inline variant is useful for embedders that compute instructions at
+/// runtime (e.g. rendering a template with workspace-specific substitutions)
+/// and don't want to stage the content to a disk file just to satisfy a path
+/// API. Staging adds two problems the inline path avoids:
+///
+///   1. The disk file looks like editable config but gets overwritten on
+///      every launch — confusing for users browsing the install dir.
+///   2. Multi-engine setups need per-engine paths to avoid `rehydrate`
+///      reading another session's instructions; with inline sources the
+///      content lives in the per-engine `EngineConfig` and the race
+///      surface goes away.
+///
+/// `From<PathBuf>` is provided so existing callers passing `Vec<PathBuf>` can
+/// keep working with a `.into()` upgrade at the call site.
+#[derive(Debug, Clone)]
+pub enum InstructionSource {
+    /// Load this file from disk at prompt-render time. Original behavior:
+    /// missing files are skipped with a warning, oversized files are
+    /// truncated to `INSTRUCTIONS_FILE_MAX_BYTES` with an `[…elided]`
+    /// marker.
+    File(PathBuf),
+    /// Use the provided string directly. `name` becomes the
+    /// `<instructions source="…">` attribute (typically a synthetic
+    /// identifier like `embedded:my-template` or a logical path).
+    Inline { name: String, content: String },
+}
+
+impl From<PathBuf> for InstructionSource {
+    fn from(path: PathBuf) -> Self {
+        InstructionSource::File(path)
+    }
+}
+
+impl From<&PathBuf> for InstructionSource {
+    fn from(path: &PathBuf) -> Self {
+        InstructionSource::File(path.clone())
+    }
+}
+
 /// Render the `instructions = [...]` config array as a single
-/// system-prompt block (#454). Each path is loaded in declared order;
-/// missing files are skipped with a tracing warning so a stale entry
-/// in `~/.deepseek/config.toml` doesn't fail the launch. Empty input
-/// (or all paths missing) returns `None` so callers append nothing.
-fn render_instructions_block(paths: &[PathBuf]) -> Option<String> {
+/// system-prompt block (#454). Each source is processed in declared order;
+/// missing `File` sources are skipped with a tracing warning so a stale entry
+/// doesn't fail the launch. Empty input (or all sources missing/empty)
+/// returns `None` so callers append nothing.
+fn render_instructions_block(sources: &[InstructionSource]) -> Option<String> {
     let mut sections: Vec<String> = Vec::new();
-    for path in paths {
-        match std::fs::read_to_string(path) {
-            Ok(raw) => {
-                let trimmed = raw.trim();
-                if trimmed.is_empty() {
+    for source in sources {
+        let (raw_source_name, raw_content): (String, String) = match source {
+            InstructionSource::File(path) => match std::fs::read_to_string(path) {
+                Ok(raw) => (path.display().to_string(), raw),
+                Err(err) => {
+                    tracing::warn!(
+                        target: "instructions",
+                        ?err,
+                        ?path,
+                        "skipping unreadable instructions file"
+                    );
                     continue;
                 }
-                let body = if trimmed.len() > INSTRUCTIONS_FILE_MAX_BYTES {
-                    let head_end = (0..=INSTRUCTIONS_FILE_MAX_BYTES)
-                        .rev()
-                        .find(|&i| trimmed.is_char_boundary(i))
-                        .unwrap_or(0);
-                    format!("{}\n[…elided]", &trimmed[..head_end])
-                } else {
-                    trimmed.to_string()
-                };
-                sections.push(format!(
-                    "<instructions source=\"{}\">\n{}\n</instructions>",
-                    path.display(),
-                    body
-                ));
-            }
-            Err(err) => {
-                tracing::warn!(
-                    target: "instructions",
-                    ?err,
-                    ?path,
-                    "skipping unreadable instructions file"
-                );
-            }
+            },
+            InstructionSource::Inline { name, content } => (name.clone(), content.clone()),
+        };
+        let trimmed = raw_content.trim();
+        if trimmed.is_empty() {
+            continue;
         }
+        let body = if trimmed.len() > INSTRUCTIONS_FILE_MAX_BYTES {
+            let head_end = (0..=INSTRUCTIONS_FILE_MAX_BYTES)
+                .rev()
+                .find(|&i| trimmed.is_char_boundary(i))
+                .unwrap_or(0);
+            format!("{}\n[…elided]", &trimmed[..head_end])
+        } else {
+            trimmed.to_string()
+        };
+        sections.push(format!(
+            "<instructions source=\"{raw_source_name}\">\n{body}\n</instructions>"
+        ));
     }
     if sections.is_empty() {
         None
@@ -630,7 +674,7 @@ pub fn system_prompt_for_mode_with_context_and_skills(
     workspace: &Path,
     working_set_summary: Option<&str>,
     skills_dir: Option<&Path>,
-    instructions: Option<&[PathBuf]>,
+    instructions: Option<&[InstructionSource]>,
     user_memory_block: Option<&str>,
 ) -> SystemPrompt {
     system_prompt_for_mode_with_context_skills_and_session(
@@ -656,7 +700,7 @@ pub fn system_prompt_for_mode_with_context_skills_and_session(
     workspace: &Path,
     _working_set_summary: Option<&str>,
     skills_dir: Option<&Path>,
-    instructions: Option<&[PathBuf]>,
+    instructions: Option<&[InstructionSource]>,
     session_context: PromptSessionContext<'_>,
 ) -> SystemPrompt {
     system_prompt_for_mode_with_context_skills_session_and_approval(
@@ -675,7 +719,7 @@ pub fn system_prompt_for_mode_with_context_skills_session_and_approval(
     workspace: &Path,
     _working_set_summary: Option<&str>,
     skills_dir: Option<&Path>,
-    instructions: Option<&[PathBuf]>,
+    instructions: Option<&[InstructionSource]>,
     session_context: PromptSessionContext<'_>,
     approval_mode: ApprovalMode,
 ) -> SystemPrompt {
@@ -797,8 +841,8 @@ pub fn system_prompt_for_mode_with_context_skills_session_and_approval(
     // because these files are workspace-scoped and may differ between
     // sessions; any edit to them would otherwise bust the prefix cache for
     // all subsequent static layers.
-    if let Some(paths) = instructions
-        && let Some(block) = render_instructions_block(paths)
+    if let Some(sources) = instructions
+        && let Some(block) = render_instructions_block(sources)
     {
         full_prompt = format!("{full_prompt}\n\n{block}");
     }
@@ -1901,10 +1945,6 @@ mod tests {
     #[test]
     fn workspace_orientation_guidance_present() {
         let prompt = compose_prompt(AppMode::Agent, Personality::Calm);
-        // Workspace orientation guidance is now distributed across the
-        // Constitutional preamble (project context loading) and the
-        // Local Law tier (AGENTS.md/instructions.md). Verify the
-        // key guidance anchors are still present.
         assert!(prompt.contains("AGENTS.md"));
         assert!(prompt.contains("Local Law"));
         assert!(
@@ -2146,7 +2186,8 @@ mod tests {
 
     #[test]
     fn render_instructions_block_returns_none_for_empty_input() {
-        assert!(super::render_instructions_block(&[]).is_none());
+        let empty: &[super::InstructionSource] = &[];
+        assert!(super::render_instructions_block(empty).is_none());
     }
 
     #[test]
@@ -2156,7 +2197,7 @@ mod tests {
         std::fs::write(&real, "real content here").unwrap();
         let bogus = tmp.path().join("does-not-exist.md");
 
-        let block = super::render_instructions_block(&[bogus.clone(), real.clone()])
+        let block = super::render_instructions_block(&[bogus.clone().into(), real.clone().into()])
             .expect("present file should produce a block");
         assert!(block.contains("real content here"));
         assert!(block.contains(&real.display().to_string()));
@@ -2172,7 +2213,7 @@ mod tests {
         std::fs::write(&a, "ALPHA_MARKER").unwrap();
         std::fs::write(&b, "BRAVO_MARKER").unwrap();
 
-        let block = super::render_instructions_block(&[a, b]).expect("non-empty");
+        let block = super::render_instructions_block(&[a.into(), b.into()]).expect("non-empty");
         let alpha_pos = block.find("ALPHA_MARKER").expect("alpha rendered");
         let bravo_pos = block.find("BRAVO_MARKER").expect("bravo rendered");
         assert!(
@@ -2189,7 +2230,8 @@ mod tests {
         std::fs::write(&empty, "   \n   \n").unwrap();
         std::fs::write(&real, "real content").unwrap();
 
-        let block = super::render_instructions_block(&[empty, real]).expect("non-empty");
+        let block =
+            super::render_instructions_block(&[empty.into(), real.into()]).expect("non-empty");
         // Empty file produces no `<instructions>` section, only the real one.
         let count = block.matches("<instructions").count();
         assert_eq!(count, 1, "only the non-empty file should produce a section");
@@ -2202,13 +2244,58 @@ mod tests {
         // 200 KiB of content — well above the 100 KiB cap.
         std::fs::write(&big, "X".repeat(200 * 1024)).unwrap();
 
-        let block = super::render_instructions_block(&[big]).expect("non-empty");
+        let block = super::render_instructions_block(&[big.into()]).expect("non-empty");
         assert!(block.contains("[…elided]"), "truncation marker missing");
         // Block should be much smaller than the original file.
         assert!(
             block.len() < 110 * 1024,
             "block should be capped near 100 KiB"
         );
+    }
+
+    /// `InstructionSource::Inline` bypasses disk reads — the content is used
+    /// directly and `name` becomes the `<instructions source="…">` attribute.
+    /// Empty / oversize handling mirrors `File` variant.
+    #[test]
+    fn render_instructions_block_handles_inline_source() {
+        let block = super::render_instructions_block(&[super::InstructionSource::Inline {
+            name: "embedded:test/template".to_string(),
+            content: "INLINE_MARKER_CONTENT".to_string(),
+        }])
+        .expect("non-empty");
+        assert!(block.contains("INLINE_MARKER_CONTENT"));
+        assert!(block.contains("source=\"embedded:test/template\""));
+
+        // Empty inline → skipped just like empty file.
+        let empty_inline = super::InstructionSource::Inline {
+            name: "empty".to_string(),
+            content: "   ".to_string(),
+        };
+        assert!(super::render_instructions_block(&[empty_inline]).is_none());
+
+        // Oversize inline → truncated with elided marker.
+        let big_inline = super::InstructionSource::Inline {
+            name: "huge".to_string(),
+            content: "Y".repeat(200 * 1024),
+        };
+        let trimmed = super::render_instructions_block(&[big_inline]).expect("non-empty");
+        assert!(trimmed.contains("[…elided]"));
+
+        // File + Inline 混用,顺序保持。
+        let tmp = tempdir().expect("tempdir");
+        let file_path = tmp.path().join("file-first.md");
+        std::fs::write(&file_path, "FILE_MARKER").unwrap();
+        let mixed = super::render_instructions_block(&[
+            file_path.into(),
+            super::InstructionSource::Inline {
+                name: "inline-second".to_string(),
+                content: "INLINE_MARKER".to_string(),
+            },
+        ])
+        .expect("non-empty");
+        let file_pos = mixed.find("FILE_MARKER").expect("file rendered");
+        let inline_pos = mixed.find("INLINE_MARKER").expect("inline rendered");
+        assert!(file_pos < inline_pos, "声明顺序必须保留(File then Inline)");
     }
 
     #[test]
@@ -2218,12 +2305,13 @@ mod tests {
         let extra = workspace.join("extra-instructions.md");
         std::fs::write(&extra, "EXTRA_INSTRUCTIONS_MARKER_BODY").unwrap();
 
+        let extra_source: super::InstructionSource = extra.clone().into();
         let prompt = match super::system_prompt_for_mode_with_context_and_skills(
             AppMode::Agent,
             workspace,
             None,
             None,
-            Some(std::slice::from_ref(&extra)),
+            Some(std::slice::from_ref(&extra_source)),
             None,
         ) {
             SystemPrompt::Text(text) => text,

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -1944,7 +1944,12 @@ impl RuntimeThreadManager {
             notes_path: self.config.notes_path(),
             mcp_config_path: self.config.mcp_config_path(),
             skills_dir: self.config.skills_dir(),
-            instructions: self.config.instructions_paths(),
+            instructions: self
+                .config
+                .instructions_paths()
+                .into_iter()
+                .map(Into::into)
+                .collect(),
             project_context_pack_enabled: self.config.project_context_pack_enabled(),
             translation_enabled: false,
             show_thinking: settings.show_thinking,

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -681,7 +681,11 @@ fn build_engine_config(app: &App, config: &Config) -> EngineConfig {
         notes_path: config.notes_path(),
         mcp_config_path: config.mcp_config_path(),
         skills_dir: app.skills_dir.clone(),
-        instructions: config.instructions_paths(),
+        instructions: config
+            .instructions_paths()
+            .into_iter()
+            .map(Into::into)
+            .collect(),
         project_context_pack_enabled: config.project_context_pack_enabled(),
         translation_enabled: app.translation_enabled,
         show_thinking: app.show_thinking,


### PR DESCRIPTION
## Summary

Adds a `pub enum InstructionSource { File(PathBuf), Inline { name, content } }` to `prompts.rs` and generalizes `EngineConfig.instructions` from `Vec<PathBuf>` to `Vec<InstructionSource>`, so embedders can inject instructions either by path (current behavior) or as inline strings.

### Why

`EngineConfig.instructions: Vec<PathBuf>` forces embedders that compute instructions at runtime (e.g. rendering a template with workspace-specific substitutions) to stage content to a disk file just to satisfy the path API. That has two awkward side-effects:

1. **Confusing UX** — the disk file looks like editable config but gets overwritten on every launch.
2. **Race in multi-engine setups** — `rehydrate_latest_canonical_state` re-reads the disk path, so concurrent engines need per-engine paths to avoid leaking instructions across sessions. Inline sources live in the per-engine `EngineConfig` and the race surface disappears.

Discovered while building a GUI embedder that injects per-session computed instructions and didn't want disk roundtrip.

### What changes

- `prompts.rs`: new `pub enum InstructionSource` + `From<PathBuf>` impl + `render_instructions_block` dispatches on variant (File → `fs::read_to_string` original semantics, Inline → use content directly, `name` becomes the `<instructions source="…">` attribute). Shared truncate / skip-empty logic.
- `core/engine.rs`: `EngineConfig.instructions: Vec<PathBuf>` → `Vec<InstructionSource>`.
- 3 existing call sites (`main.rs` exec_agent + `runtime_threads.rs` + `tui/ui.rs::build_engine_config`) upgrade with `.into_iter().map(Into::into).collect()` — one-line change each, zero behavior change for path callers.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features`
- [x] `cargo test --workspace --all-features`

Test results: **3449 passed / 1 failed / 4 ignored**.

- The 5 existing `render_instructions_block_*` tests updated to use `.into()` on `PathBuf` — still assert File-variant behavior (missing-file skip + warn, oversize truncate with `[…elided]`, declaration order, empty-content skip).
- New `render_instructions_block_handles_inline_source` covers Inline empty / oversize / File+Inline mixed-order.
- Clippy: 2 warnings in `runtime_log.rs` + `main.rs` are pre-existing in `main`, not introduced by this PR.
- The 1 test failure (`system_prompt_skips_locale_preamble_for_english`) is local environment noise (sensitive to whether `~/.agents/skills/` has non-English skill content during the test) — also fails on `main` in the same environment, should pass in CI.

## Checklist

- [x] Updated docs or comments as needed (added doc comments on `InstructionSource` enum variants + the field on `EngineConfig`)
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes — N/A (no UI changes)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR generalizes `EngineConfig.instructions` from `Vec<PathBuf>` to `Vec<InstructionSource>`, adding a new `Inline { name, content }` variant so embedders can inject runtime-computed instructions without staging content to disk. The three existing call sites are migrated with a single `.map(Into::into)` each, preserving all prior file-path semantics.

- **`prompts.rs`**: New `InstructionSource` enum with `File(PathBuf)` and `Inline { name, content }` variants, `From<PathBuf>` conversions, and a refactored `render_instructions_block` that dispatches on the variant — shared truncation and empty-skip logic applies to both.
- **`engine.rs`**: Field type updated and doc comment revised; no logic change.
- **Call sites** (`main.rs`, `runtime_threads.rs`, `tui/ui.rs`): Each does a one-liner `into_iter().map(Into::into).collect()` — zero behavior change for path-based callers.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The change is backward-compatible and the migration at existing call sites is mechanical and correct, but the new Inline variant has an unguarded XML attribute injection point that could silently corrupt system prompts for embedders who supply a name containing double-quotes or angle brackets.

The core logic refactor is clean and well-tested. The unguarded XML attribute injection in the new Inline variant is the key concern — an embedder supplying a name with a double-quote or angle brackets will silently corrupt the system prompt structure with no error or warning.

crates/tui/src/prompts.rs — specifically the render_instructions_block format string where raw_source_name is used as an XML attribute value without escaping.
</details>

<details open><summary><h3>Security Review</h3></summary>

- **XML attribute injection (`prompts.rs`, `render_instructions_block`)**: The `name` field of `InstructionSource::Inline` is interpolated directly into `source="..."` without escaping. A name containing `"` breaks the attribute boundary; a name containing `"><` can inject sibling XML tags into the system prompt. The `Inline` variant is the new attack surface — the `File` path had the same structural issue for `path.display()` but file paths rarely contain XML metacharacters, whereas the inline API is explicitly designed to accept arbitrary embedder-supplied strings.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/prompts.rs | Adds `InstructionSource` enum and refactors `render_instructions_block` to handle File/Inline variants; the `name` field of `Inline` is interpolated into an XML attribute without escaping, enabling attribute injection into the system prompt. |
| crates/tui/src/core/engine.rs | Updates `EngineConfig.instructions` type from `Vec<PathBuf>` to `Vec<InstructionSource>` with updated doc comment; mechanical type change, no logic issues. |
| crates/tui/src/main.rs | Call site updated to map `Vec<PathBuf>` to `Vec<InstructionSource>` via `Into::into`; zero behavior change for the existing file-path flow. |
| crates/tui/src/runtime_threads.rs | Same one-liner migration as `main.rs`; behavior unchanged for existing path-based callers. |
| crates/tui/src/tui/ui.rs | Same one-liner migration in `build_engine_config`; no behavioral change. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[EngineConfig.instructions
Vec&lt;InstructionSource&gt;] --> B{InstructionSource variant}
    B -- File(PathBuf) --> C[fs::read_to_string]
    C -- Ok --> D[raw_content]
    C -- Err --> E[tracing::warn + skip]
    B -- "Inline { name, content }" --> D
    D --> F{trimmed.is_empty?}
    F -- yes --> G[skip]
    F -- no --> H{len > MAX_BYTES?}
    H -- yes --> I[truncate + append elided marker]
    H -- no --> J[use as-is]
    I --> K["format XML block"]
    J --> K
    K --> L[sections.join]
    L --> M[system prompt]
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22pr%2Finstruction-source-enum%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22pr%2Finstruction-source-enum%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fprompts.rs%3A238-240%0A**Unescaped%20%60name%60%20injected%20into%20XML%20attribute**%0A%0AThe%20%60name%60%20field%20from%20%60InstructionSource%3A%3AInline%60%20is%20used%20verbatim%20as%20an%20XML%20attribute%20value%20without%20escaping.%20A%20%60name%60%20containing%20%60%22%60%20%28double-quote%29%20breaks%20the%20attribute%20boundary%20%E2%80%94%20e.g.%2C%20%60name%20%3D%20r%23%22foo%22%20injected%3D%22bar%22%60%20produces%20%60%3Cinstructions%20source%3D%22foo%22%20injected%3D%22bar%22%3E%60%20%E2%80%94%20and%20a%20name%20containing%20%60%22%3E%3C%60%20can%20inject%20arbitrary%20sibling%20XML%20tags%20directly%20into%20the%20system%20prompt.%20Since%20the%20%60Inline%60%20variant%20is%20explicitly%20designed%20for%20embedder-provided%20strings%2C%20callers%20have%20no%20indication%20that%20%60name%60%20must%20be%20free%20of%20XML%20metacharacters.%20The%20%60content%60%20side%20is%20subject%20to%20the%20same%20risk%20%28%60%3C%2Finstructions%3E%60%20in%20the%20content%20closes%20the%20tag%20early%29%2C%20but%20that%20pre-existed%20in%20the%20%60File%60%20path%3B%20the%20%60name%60%20injection%20is%20new%20surface%20area%20introduced%20by%20this%20PR.%20At%20minimum%2C%20%60%22%60%20in%20%60name%60%20should%20be%20escaped%20to%20%60%26quot%3B%60%20before%20interpolation.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fprompts.rs%3A2284-2298%0AThe%20mixed-language%20comment%20and%20assertion%20message%20%28Chinese%20inside%20an%20otherwise%20English%20test%20suite%29%20will%20confuse%20contributors%20who%20don't%20read%20Chinese.%20The%20assertion%20message%20is%20especially%20important%20to%20keep%20in%20English%20since%20it%20surfaces%20in%20test%20failure%20output.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20File%20%2B%20Inline%20mixed%3A%20declaration%20order%20must%20be%20preserved.%0A%20%20%20%20%20%20%20%20let%20tmp%20%3D%20tempdir%28%29.expect%28%22tempdir%22%29%3B%0A%20%20%20%20%20%20%20%20let%20file_path%20%3D%20tmp.path%28%29.join%28%22file-first.md%22%29%3B%0A%20%20%20%20%20%20%20%20std%3A%3Afs%3A%3Awrite%28%26file_path%2C%20%22FILE_MARKER%22%29.unwrap%28%29%3B%0A%20%20%20%20%20%20%20%20let%20mixed%20%3D%20super%3A%3Arender_instructions_block%28%26%5B%0A%20%20%20%20%20%20%20%20%20%20%20%20file_path.into%28%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20super%3A%3AInstructionSource%3A%3AInline%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20name%3A%20%22inline-second%22.to_string%28%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20content%3A%20%22INLINE_MARKER%22.to_string%28%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%20%20%5D%29%0A%20%20%20%20%20%20%20%20.expect%28%22non-empty%22%29%3B%0A%20%20%20%20%20%20%20%20let%20file_pos%20%3D%20mixed.find%28%22FILE_MARKER%22%29.expect%28%22file%20rendered%22%29%3B%0A%20%20%20%20%20%20%20%20let%20inline_pos%20%3D%20mixed.find%28%22INLINE_MARKER%22%29.expect%28%22inline%20rendered%22%29%3B%0A%20%20%20%20%20%20%20%20assert!%28file_pos%20%3C%20inline_pos%2C%20%22declaration%20order%20must%20be%20preserved%20%28File%20then%20Inline%29%22%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fprompts.rs%3A238-240%0A**Unescaped%20%60name%60%20injected%20into%20XML%20attribute**%0A%0AThe%20%60name%60%20field%20from%20%60InstructionSource%3A%3AInline%60%20is%20used%20verbatim%20as%20an%20XML%20attribute%20value%20without%20escaping.%20A%20%60name%60%20containing%20%60%22%60%20%28double-quote%29%20breaks%20the%20attribute%20boundary%20%E2%80%94%20e.g.%2C%20%60name%20%3D%20r%23%22foo%22%20injected%3D%22bar%22%60%20produces%20%60%3Cinstructions%20source%3D%22foo%22%20injected%3D%22bar%22%3E%60%20%E2%80%94%20and%20a%20name%20containing%20%60%22%3E%3C%60%20can%20inject%20arbitrary%20sibling%20XML%20tags%20directly%20into%20the%20system%20prompt.%20Since%20the%20%60Inline%60%20variant%20is%20explicitly%20designed%20for%20embedder-provided%20strings%2C%20callers%20have%20no%20indication%20that%20%60name%60%20must%20be%20free%20of%20XML%20metacharacters.%20The%20%60content%60%20side%20is%20subject%20to%20the%20same%20risk%20%28%60%3C%2Finstructions%3E%60%20in%20the%20content%20closes%20the%20tag%20early%29%2C%20but%20that%20pre-existed%20in%20the%20%60File%60%20path%3B%20the%20%60name%60%20injection%20is%20new%20surface%20area%20introduced%20by%20this%20PR.%20At%20minimum%2C%20%60%22%60%20in%20%60name%60%20should%20be%20escaped%20to%20%60%26quot%3B%60%20before%20interpolation.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fprompts.rs%3A2284-2298%0AThe%20mixed-language%20comment%20and%20assertion%20message%20%28Chinese%20inside%20an%20otherwise%20English%20test%20suite%29%20will%20confuse%20contributors%20who%20don't%20read%20Chinese.%20The%20assertion%20message%20is%20especially%20important%20to%20keep%20in%20English%20since%20it%20surfaces%20in%20test%20failure%20output.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20File%20%2B%20Inline%20mixed%3A%20declaration%20order%20must%20be%20preserved.%0A%20%20%20%20%20%20%20%20let%20tmp%20%3D%20tempdir%28%29.expect%28%22tempdir%22%29%3B%0A%20%20%20%20%20%20%20%20let%20file_path%20%3D%20tmp.path%28%29.join%28%22file-first.md%22%29%3B%0A%20%20%20%20%20%20%20%20std%3A%3Afs%3A%3Awrite%28%26file_path%2C%20%22FILE_MARKER%22%29.unwrap%28%29%3B%0A%20%20%20%20%20%20%20%20let%20mixed%20%3D%20super%3A%3Arender_instructions_block%28%26%5B%0A%20%20%20%20%20%20%20%20%20%20%20%20file_path.into%28%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20super%3A%3AInstructionSource%3A%3AInline%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20name%3A%20%22inline-second%22.to_string%28%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20content%3A%20%22INLINE_MARKER%22.to_string%28%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%20%20%5D%29%0A%20%20%20%20%20%20%20%20.expect%28%22non-empty%22%29%3B%0A%20%20%20%20%20%20%20%20let%20file_pos%20%3D%20mixed.find%28%22FILE_MARKER%22%29.expect%28%22file%20rendered%22%29%3B%0A%20%20%20%20%20%20%20%20let%20inline_pos%20%3D%20mixed.find%28%22INLINE_MARKER%22%29.expect%28%22inline%20rendered%22%29%3B%0A%20%20%20%20%20%20%20%20assert!%28file_pos%20%3C%20inline_pos%2C%20%22declaration%20order%20must%20be%20preserved%20%28File%20then%20Inline%29%22%29%3B%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2311&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fprompts.rs%3A238-240%0A**Unescaped%20%60name%60%20injected%20into%20XML%20attribute**%0A%0AThe%20%60name%60%20field%20from%20%60InstructionSource%3A%3AInline%60%20is%20used%20verbatim%20as%20an%20XML%20attribute%20value%20without%20escaping.%20A%20%60name%60%20containing%20%60%22%60%20%28double-quote%29%20breaks%20the%20attribute%20boundary%20%E2%80%94%20e.g.%2C%20%60name%20%3D%20r%23%22foo%22%20injected%3D%22bar%22%60%20produces%20%60%3Cinstructions%20source%3D%22foo%22%20injected%3D%22bar%22%3E%60%20%E2%80%94%20and%20a%20name%20containing%20%60%22%3E%3C%60%20can%20inject%20arbitrary%20sibling%20XML%20tags%20directly%20into%20the%20system%20prompt.%20Since%20the%20%60Inline%60%20variant%20is%20explicitly%20designed%20for%20embedder-provided%20strings%2C%20callers%20have%20no%20indication%20that%20%60name%60%20must%20be%20free%20of%20XML%20metacharacters.%20The%20%60content%60%20side%20is%20subject%20to%20the%20same%20risk%20%28%60%3C%2Finstructions%3E%60%20in%20the%20content%20closes%20the%20tag%20early%29%2C%20but%20that%20pre-existed%20in%20the%20%60File%60%20path%3B%20the%20%60name%60%20injection%20is%20new%20surface%20area%20introduced%20by%20this%20PR.%20At%20minimum%2C%20%60%22%60%20in%20%60name%60%20should%20be%20escaped%20to%20%60%26quot%3B%60%20before%20interpolation.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fprompts.rs%3A2284-2298%0AThe%20mixed-language%20comment%20and%20assertion%20message%20%28Chinese%20inside%20an%20otherwise%20English%20test%20suite%29%20will%20confuse%20contributors%20who%20don't%20read%20Chinese.%20The%20assertion%20message%20is%20especially%20important%20to%20keep%20in%20English%20since%20it%20surfaces%20in%20test%20failure%20output.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20File%20%2B%20Inline%20mixed%3A%20declaration%20order%20must%20be%20preserved.%0A%20%20%20%20%20%20%20%20let%20tmp%20%3D%20tempdir%28%29.expect%28%22tempdir%22%29%3B%0A%20%20%20%20%20%20%20%20let%20file_path%20%3D%20tmp.path%28%29.join%28%22file-first.md%22%29%3B%0A%20%20%20%20%20%20%20%20std%3A%3Afs%3A%3Awrite%28%26file_path%2C%20%22FILE_MARKER%22%29.unwrap%28%29%3B%0A%20%20%20%20%20%20%20%20let%20mixed%20%3D%20super%3A%3Arender_instructions_block%28%26%5B%0A%20%20%20%20%20%20%20%20%20%20%20%20file_path.into%28%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20super%3A%3AInstructionSource%3A%3AInline%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20name%3A%20%22inline-second%22.to_string%28%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20content%3A%20%22INLINE_MARKER%22.to_string%28%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%20%20%5D%29%0A%20%20%20%20%20%20%20%20.expect%28%22non-empty%22%29%3B%0A%20%20%20%20%20%20%20%20let%20file_pos%20%3D%20mixed.find%28%22FILE_MARKER%22%29.expect%28%22file%20rendered%22%29%3B%0A%20%20%20%20%20%20%20%20let%20inline_pos%20%3D%20mixed.find%28%22INLINE_MARKER%22%29.expect%28%22inline%20rendered%22%29%3B%0A%20%20%20%20%20%20%20%20assert!%28file_pos%20%3C%20inline_pos%2C%20%22declaration%20order%20must%20be%20preserved%20%28File%20then%20Inline%29%22%29%3B%0A%60%60%60%0A%0A&pr=2311&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(prompts): support inline string sou..."](https://github.com/hmbown/codewhale/commit/6e6093a8d58db3f5bc8dfcde17f154238d8c3833) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34337521)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->