### PR TITLE
perf(prompts): move environment block below volatile boundary for per-session workspace embedders

### DIFF
--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -722,17 +722,6 @@ pub fn system_prompt_for_mode_with_context_skills_session_and_approval(
         full_prompt = format!("{full_prompt}\n\n{pack}");
     }
 
-    // 2.25. Environment block — locale, platform, shell, pwd. All
-    // four inputs are session-stable (workspace path is fixed for
-    // the run; locale is loaded once by the caller; platform/shell
-    // come from process env). Inserted above skills so it remains in
-    // the workspace-static cache layer alongside the mode prompt and
-    // project context.
-    full_prompt = format!(
-        "{full_prompt}\n\n{}",
-        render_environment_block(workspace, session_context.locale_tag),
-    );
-
     // 2.3a. Translation output instruction — when enabled, instruct
     // the model to respond in the resolved session locale. Stays
     // above the volatile-content boundary because it's a per-session
@@ -791,6 +780,24 @@ pub fn system_prompt_for_mode_with_context_skills_session_and_approval(
     // skills, context management, compact template) live above this line
     // so DeepSeek's KV prefix cache can hit on the entire system prompt
     // regardless of per-session edits to memory, goals, or instructions.
+
+    // 6. Environment block — platform, shell, pwd, locale.
+    //
+    // Placed below the volatile-content boundary. The original comment claimed
+    // "workspace path is fixed for the run" → static-cacheable, which is true
+    // for the terminal use case (one process owns one workspace for its
+    // lifetime). It is **not** true for embedders that swap workspaces between
+    // sessions (the Op::SyncSession path, multi-engine pools, IDE
+    // integrations binding the engine to a per-tab workspace, etc.):
+    // `pwd` drifts session-to-session and drags the entire static prefix
+    // out of cache reuse. Moving the block below the volatile boundary keeps
+    // mode / project / skills / context-mgmt / compact-template byte-stable
+    // across sessions while preserving the pwd info the model needs for
+    // `exec_shell` and structured search tools.
+    full_prompt = format!(
+        "{full_prompt}\n\n{}",
+        render_environment_block(workspace, session_context.locale_tag),
+    );
 
     // 6a. Configured `instructions = [...]` files (#454). Loaded
     // and concatenated in declared order. Placed below the volatile boundary


### PR DESCRIPTION
## Summary

The environment block (`platform`, `shell`, `pwd`, `lang`) currently renders **above** the volatile-content boundary, as part of the workspace-static cache layer. The justification in the original comment:

> Inserted above skills so it remains in the workspace-static cache layer alongside the mode prompt and project context.

This works for the terminal use case (one process owns one workspace for its lifetime) but breaks down for embedders that swap workspaces between sessions:

- IDE/GUI integrations binding the engine to a per-tab workspace
- Multi-engine pools with one engine per session
- Anything sending `Op::SyncSession` with a new workspace

For these embedders, `pwd` drifts session-to-session, dragging the entire static prefix (mode prompt + project context + skills + context management + compact template, ~30KB) out of cache reuse on every session switch. That's a big cache miss for a few-byte path change.

This PR moves the environment block **below** the volatile-content boundary, alongside the configured `instructions = [...]` block. Effects:

- Static prefix stays byte-stable across sessions even when workspace changes (much better KV prefix cache hit rate for multi-session embedders)
- Model still sees `pwd` / `platform` / `shell` (needed for `exec_shell` and structured search tools), just in a slightly later position
- No behavior change for terminal callers — when the workspace is fixed for the process lifetime, the block content is identical session-to-session and the move is a no-op for caching

## Discovered via

Building a multi-session embedder that swaps workspaces between sessions. Profiling cache hit rates revealed every session switch was busting prefix cache from the environment block forward — even though the rest of the static prefix was byte-identical across sessions.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features` (no new warnings)
- [x] `cargo test --workspace --all-features` (3448 passed / 1 known-flaky env test / 4 ignored)

Existing `render_environment_block_*` tests + `instructions_block_appears_in_system_prompt_when_configured` continue to pass — they don't constrain position within the prompt, only block content.

## Checklist

- [x] Updated docs or comments as needed (rewrote the inline comment to explain the per-session-workspace motivation; both old comment ("workspace-static cache layer") and the new behavior are documented)
- [x] Added or updated tests where relevant — no new test added; position is a perf optimization with structural impact below the line that existing block-content tests already cover
- [ ] Verified TUI behavior manually if UI changes — N/A

## Note for terminal users

This is intentionally invisible for the terminal use case. If you run a single `codewhale` process with a stable workspace for its lifetime, the prompt content is byte-identical to before — the environment block just appears slightly later in the prompt. The prefix cache hit rate is unchanged for you.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR moves the environment block (`platform`, `shell`, `pwd`, `locale`) from above the volatile-content boundary (static prefix) to below it, so that per-session workspace switches no longer bust the KV prefix cache for the entire ~30 KB static prefix. Terminal callers see byte-identical output; only multi-session embedders that swap workspaces benefit.

- The `render_environment_block` call is removed from section 2.25 (above the boundary) and re-inserted as section 6 immediately below the boundary, before the `instructions = [...]` and memory blocks.
- The inline comment on the new placement thoroughly documents the multi-session embedder motivation and the trade-off with the old "session-stable" reasoning.
- The volatile-content boundary banner still lists `env` among the static layers above the line — a minor stale comment introduced by the move.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is a prompt ordering adjustment with no behavioral impact for terminal users and a well-reasoned caching benefit for multi-session embedders.

The code change is straightforward and low-risk: one render_environment_block call relocated across the volatile boundary. Existing block-content tests continue to cover the rendered output. The only issue is the boundary banner comment still listing env as a static-prefix layer after the move.

crates/tui/src/prompts.rs — the volatile-content boundary banner comment needs a one-line update to drop env from its list of static layers.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/tui/src/prompts.rs | Environment block moved from above to below the volatile-content boundary; the volatile-boundary banner comment still incorrectly names `env` as a static-prefix layer above the line. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as system_prompt_for_mode_...
    participant SP as Static Prefix (above boundary)
    participant VP as Volatile Prefix (below boundary)

    C->>SP: mode_prompt + project_context
    C->>SP: locale preamble (if show_thinking)
    C->>SP: project_context_pack (if enabled)
    C->>SP: translation_output_instruction (if enabled)
    C->>SP: skills_block
    C->>SP: context_management (Agent/Yolo only)
    C->>SP: COMPACT_TEMPLATE

    Note over SP,VP: Volatile-content boundary

    C->>VP: render_environment_block pwd/platform/shell/locale MOVED HERE
    C->>VP: instructions files section 6a
    C->>VP: user_memory_block section 6b
    C->>VP: session_goal section 6c
    C->>VP: handoff_block section 7
    C->>VP: AUTHORITY_RECAP section 7a
    C->>VP: locale closer section 8
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/tui/src/prompts.rs`, line 777-782 ([link](https://github.com/hmbown/codewhale/blob/28966fd51618d88d593036776f282e7fb1768d26/crates/tui/src/prompts.rs#L777-L782)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The volatile-content boundary banner still lists `env` as one of the static layers that lives *above* the line, but this PR explicitly moves it *below*. A reader following the numbered sections in order will find the comment contradicts the code they're about to read at section 6.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22pr%2Fenv-block-volatile-side%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22pr%2Fenv-block-volatile-side%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fprompts.rs%0ALine%3A%20777-782%0A%0AComment%3A%0AThe%20volatile-content%20boundary%20banner%20still%20lists%20%60env%60%20as%20one%20of%20the%20static%20layers%20that%20lives%20*above*%20the%20line%2C%20but%20this%20PR%20explicitly%20moves%20it%20*below*.%20A%20reader%20following%20the%20numbered%20sections%20in%20order%20will%20find%20the%20comment%20contradicts%20the%20code%20they're%20about%20to%20read%20at%20section%206.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%20%E2%94%80%E2%94%80%20Volatile-content%20boundary%20%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%0A%20%20%20%20%2F%2F%20Everything%20below%20drifts%20mid-session%20and%20busts%20the%20prefix%20cache%20for%0A%20%20%20%20%2F%2F%20bytes%20that%20follow.%20All%20static%20layers%20%28mode%2C%20project%20context%2C%20skills%2C%0A%20%20%20%20%2F%2F%20context%20management%2C%20compact%20template%29%20live%20above%20this%20line%20so%0A%20%20%20%20%2F%2F%20DeepSeek's%20KV%20prefix%20cache%20can%20hit%20on%20the%20entire%20system%20prompt%0A%20%20%20%20%2F%2F%20regardless%20of%20per-session%20edits%20to%20memory%2C%20goals%2C%20or%20instructions.%0A%20%20%20%20%2F%2F%20Note%3A%20the%20environment%20block%20%28pwd%20%2F%20platform%20%2F%20shell%20%2F%20locale%29%20is%0A%20%20%20%20%2F%2F%20intentionally%20placed%20below%20this%20boundary%20%E2%80%94%20see%20section%206%20comment.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fprompts.rs%0ALine%3A%20777-782%0A%0AComment%3A%0AThe%20volatile-content%20boundary%20banner%20still%20lists%20%60env%60%20as%20one%20of%20the%20static%20layers%20that%20lives%20*above*%20the%20line%2C%20but%20this%20PR%20explicitly%20moves%20it%20*below*.%20A%20reader%20following%20the%20numbered%20sections%20in%20order%20will%20find%20the%20comment%20contradicts%20the%20code%20they're%20about%20to%20read%20at%20section%206.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%20%E2%94%80%E2%94%80%20Volatile-content%20boundary%20%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%0A%20%20%20%20%2F%2F%20Everything%20below%20drifts%20mid-session%20and%20busts%20the%20prefix%20cache%20for%0A%20%20%20%20%2F%2F%20bytes%20that%20follow.%20All%20static%20layers%20%28mode%2C%20project%20context%2C%20skills%2C%0A%20%20%20%20%2F%2F%20context%20management%2C%20compact%20template%29%20live%20above%20this%20line%20so%0A%20%20%20%20%2F%2F%20DeepSeek's%20KV%20prefix%20cache%20can%20hit%20on%20the%20entire%20system%20prompt%0A%20%20%20%20%2F%2F%20regardless%20of%20per-session%20edits%20to%20memory%2C%20goals%2C%20or%20instructions.%0A%20%20%20%20%2F%2F%20Note%3A%20the%20environment%20block%20%28pwd%20%2F%20platform%20%2F%20shell%20%2F%20locale%29%20is%0A%20%20%20%20%2F%2F%20intentionally%20placed%20below%20this%20boundary%20%E2%80%94%20see%20section%206%20comment.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2314&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fprompts.rs%0ALine%3A%20777-782%0A%0AComment%3A%0AThe%20volatile-content%20boundary%20banner%20still%20lists%20%60env%60%20as%20one%20of%20the%20static%20layers%20that%20lives%20*above*%20the%20line%2C%20but%20this%20PR%20explicitly%20moves%20it%20*below*.%20A%20reader%20following%20the%20numbered%20sections%20in%20order%20will%20find%20the%20comment%20contradicts%20the%20code%20they're%20about%20to%20read%20at%20section%206.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%20%E2%94%80%E2%94%80%20Volatile-content%20boundary%20%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%0A%20%20%20%20%2F%2F%20Everything%20below%20drifts%20mid-session%20and%20busts%20the%20prefix%20cache%20for%0A%20%20%20%20%2F%2F%20bytes%20that%20follow.%20All%20static%20layers%20%28mode%2C%20project%20context%2C%20skills%2C%0A%20%20%20%20%2F%2F%20context%20management%2C%20compact%20template%29%20live%20above%20this%20line%20so%0A%20%20%20%20%2F%2F%20DeepSeek's%20KV%20prefix%20cache%20can%20hit%20on%20the%20entire%20system%20prompt%0A%20%20%20%20%2F%2F%20regardless%20of%20per-session%20edits%20to%20memory%2C%20goals%2C%20or%20instructions.%0A%20%20%20%20%2F%2F%20Note%3A%20the%20environment%20block%20%28pwd%20%2F%20platform%20%2F%20shell%20%2F%20locale%29%20is%0A%20%20%20%20%2F%2F%20intentionally%20placed%20below%20this%20boundary%20%E2%80%94%20see%20section%206%20comment.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2314&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22pr%2Fenv-block-volatile-side%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22pr%2Fenv-block-volatile-side%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fprompts.rs%3A777-782%0AThe%20volatile-content%20boundary%20banner%20still%20lists%20%60env%60%20as%20one%20of%20the%20static%20layers%20that%20lives%20*above*%20the%20line%2C%20but%20this%20PR%20explicitly%20moves%20it%20*below*.%20A%20reader%20following%20the%20numbered%20sections%20in%20order%20will%20find%20the%20comment%20contradicts%20the%20code%20they're%20about%20to%20read%20at%20section%206.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%20%E2%94%80%E2%94%80%20Volatile-content%20boundary%20%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%0A%20%20%20%20%2F%2F%20Everything%20below%20drifts%20mid-session%20and%20busts%20the%20prefix%20cache%20for%0A%20%20%20%20%2F%2F%20bytes%20that%20follow.%20All%20static%20layers%20%28mode%2C%20project%20context%2C%20skills%2C%0A%20%20%20%20%2F%2F%20context%20management%2C%20compact%20template%29%20live%20above%20this%20line%20so%0A%20%20%20%20%2F%2F%20DeepSeek's%20KV%20prefix%20cache%20can%20hit%20on%20the%20entire%20system%20prompt%0A%20%20%20%20%2F%2F%20regardless%20of%20per-session%20edits%20to%20memory%2C%20goals%2C%20or%20instructions.%0A%20%20%20%20%2F%2F%20Note%3A%20the%20environment%20block%20%28pwd%20%2F%20platform%20%2F%20shell%20%2F%20locale%29%20is%0A%20%20%20%20%2F%2F%20intentionally%20placed%20below%20this%20boundary%20%E2%80%94%20see%20section%206%20comment.%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fprompts.rs%3A777-782%0AThe%20volatile-content%20boundary%20banner%20still%20lists%20%60env%60%20as%20one%20of%20the%20static%20layers%20that%20lives%20*above*%20the%20line%2C%20but%20this%20PR%20explicitly%20moves%20it%20*below*.%20A%20reader%20following%20the%20numbered%20sections%20in%20order%20will%20find%20the%20comment%20contradicts%20the%20code%20they're%20about%20to%20read%20at%20section%206.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%20%E2%94%80%E2%94%80%20Volatile-content%20boundary%20%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%0A%20%20%20%20%2F%2F%20Everything%20below%20drifts%20mid-session%20and%20busts%20the%20prefix%20cache%20for%0A%20%20%20%20%2F%2F%20bytes%20that%20follow.%20All%20static%20layers%20%28mode%2C%20project%20context%2C%20skills%2C%0A%20%20%20%20%2F%2F%20context%20management%2C%20compact%20template%29%20live%20above%20this%20line%20so%0A%20%20%20%20%2F%2F%20DeepSeek's%20KV%20prefix%20cache%20can%20hit%20on%20the%20entire%20system%20prompt%0A%20%20%20%20%2F%2F%20regardless%20of%20per-session%20edits%20to%20memory%2C%20goals%2C%20or%20instructions.%0A%20%20%20%20%2F%2F%20Note%3A%20the%20environment%20block%20%28pwd%20%2F%20platform%20%2F%20shell%20%2F%20locale%29%20is%0A%20%20%20%20%2F%2F%20intentionally%20placed%20below%20this%20boundary%20%E2%80%94%20see%20section%206%20comment.%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2314&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fprompts.rs%3A777-782%0AThe%20volatile-content%20boundary%20banner%20still%20lists%20%60env%60%20as%20one%20of%20the%20static%20layers%20that%20lives%20*above*%20the%20line%2C%20but%20this%20PR%20explicitly%20moves%20it%20*below*.%20A%20reader%20following%20the%20numbered%20sections%20in%20order%20will%20find%20the%20comment%20contradicts%20the%20code%20they're%20about%20to%20read%20at%20section%206.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%20%E2%94%80%E2%94%80%20Volatile-content%20boundary%20%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%0A%20%20%20%20%2F%2F%20Everything%20below%20drifts%20mid-session%20and%20busts%20the%20prefix%20cache%20for%0A%20%20%20%20%2F%2F%20bytes%20that%20follow.%20All%20static%20layers%20%28mode%2C%20project%20context%2C%20skills%2C%0A%20%20%20%20%2F%2F%20context%20management%2C%20compact%20template%29%20live%20above%20this%20line%20so%0A%20%20%20%20%2F%2F%20DeepSeek's%20KV%20prefix%20cache%20can%20hit%20on%20the%20entire%20system%20prompt%0A%20%20%20%20%2F%2F%20regardless%20of%20per-session%20edits%20to%20memory%2C%20goals%2C%20or%20instructions.%0A%20%20%20%20%2F%2F%20Note%3A%20the%20environment%20block%20%28pwd%20%2F%20platform%20%2F%20shell%20%2F%20locale%29%20is%0A%20%20%20%20%2F%2F%20intentionally%20placed%20below%20this%20boundary%20%E2%80%94%20see%20section%206%20comment.%0A%60%60%60%0A%0A&pr=2314&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["perf(prompts): move environment block be..."](https://github.com/hmbown/codewhale/commit/28966fd51618d88d593036776f282e7fb1768d26) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34339375)</sub>

<!-- /greptile_comment -->