### PR TITLE
  fix(composer): allow slash-space messages

### DIFF
--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -86,6 +86,9 @@ pub(crate) fn looks_like_slash_command_input(input: &str) -> bool {
     let Some(rest) = input.trim_start().strip_prefix('/') else {
         return false;
     };
+    if rest.chars().next().is_some_and(|ch| ch.is_whitespace()) {
+        return false;
+    }
     let Some(command) = rest.split_whitespace().next() else {
         return rest.is_empty();
     };
@@ -5010,6 +5013,8 @@ mod tests {
         assert!(looks_like_slash_command_input("/"));
         assert!(looks_like_slash_command_input("/help"));
         assert!(looks_like_slash_command_input("/model deepseek-v4-pro"));
+        assert!(!looks_like_slash_command_input("/ hello"));
+        assert!(!looks_like_slash_command_input("  / hello"));
         assert!(!looks_like_slash_command_input(
             "/usr/lib/x86_64-linux-gnu/ 是标准路径吗？"
         ));


### PR DESCRIPTION
## Summary

  Fixes #2310.

  CodeWhale currently treats any input that starts with `/` as a slash command. That means a user cannot send a normal message such as `/ hello`; it is parsed as a command and fails with an unknown-command error.

 This PR updates the slash-command classifier so `/` followed immediately by whitespace is treated as plain text. Normal commands such as `/help` and `/model deepseek-v4-pro` continue to work as before.
from: input / hi
<img width="643" height="155" alt="image" src="https://github.com/user-attachments/assets/9eeb1be2-d901-4cae-a42c-c4733483d452" />

to:
<img width="535" height="230" alt="image" src="https://github.com/user-attachments/assets/bc64efba-eb35-4fb9-bcf3-2c0f87b2e65c" />


## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features`
- [x] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a classifier bug where any input starting with `/ ` (slash followed by whitespace) was incorrectly treated as a slash command instead of plain text. The fix is a single guard added to `looks_like_slash_command_input` in `app.rs`.

- Adds an early-return in `looks_like_slash_command_input`: if the character immediately after the leading `/` is whitespace, the function returns `false`, letting the input flow through as a normal message.
- Extends the existing unit test with two new assertions covering `"/ hello"` and `"  / hello"`, confirming the new behaviour without touching any callers.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal, well-tested guard that only affects the slash-space edge case and leaves all existing command paths intact.

The guard is inserted before any command-word parsing, so /help, /model …, and bare / all continue along the same code path as before. The only callers of looks_like_slash_command_input branch on its boolean result, so returning false for '/ hello' correctly routes it to the plain-message path in every call site.

No files require special attention.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/app.rs | Adds a whitespace guard in `looks_like_slash_command_input` so `/ hello`-style inputs are treated as plain text, and extends the unit-test block with two matching assertions. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User presses Enter] --> B[submit_input]
    B --> C{looks_like_slash_command_input?}
    C -->|strip leading whitespace then strip '/' prefix → prefix absent| D[return false]
    C -->|next char is whitespace e.g. '/ hello'| E[return false — NEW]
    C -->|rest is empty e.g. bare '/'| F[return true]
    C -->|command word contains '/' e.g. absolute path| G[return false]
    C -->|command word is clean e.g. '/help'| H[return true]
    D --> I[Send as plain message, add to history]
    E --> I
    G --> I
    F --> J[execute_command_input]
    H --> J
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/tui/src/tui/app.rs`, line 5012 ([link](https://github.com/hmbown/codewhale/blob/12fe9df6971891c899a2084768ae549a65e448d0/crates/tui/src/tui/app.rs#L5012)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The test name `slash_command_classifier_treats_absolute_path_as_message` no longer describes the new cases (`"/ hello"`, `"  / hello"`), which are about slash-space messages rather than filesystem paths. A broader name would keep the intent clear for future readers.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fslash-space-message%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fslash-space-message%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%0ALine%3A%205012%0A%0AComment%3A%0AThe%20test%20name%20%60slash_command_classifier_treats_absolute_path_as_message%60%20no%20longer%20describes%20the%20new%20cases%20%28%60%22%2F%20hello%22%60%2C%20%60%22%20%20%2F%20hello%22%60%29%2C%20which%20are%20about%20slash-space%20messages%20rather%20than%20filesystem%20paths.%20A%20broader%20name%20would%20keep%20the%20intent%20clear%20for%20future%20readers.%0A%0A%60%60%60suggestion%0A%20%20%20%20fn%20slash_command_classifier_treats_slash_space_and_absolute_path_as_message%28%29%20%7B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%0ALine%3A%205012%0A%0AComment%3A%0AThe%20test%20name%20%60slash_command_classifier_treats_absolute_path_as_message%60%20no%20longer%20describes%20the%20new%20cases%20%28%60%22%2F%20hello%22%60%2C%20%60%22%20%20%2F%20hello%22%60%29%2C%20which%20are%20about%20slash-space%20messages%20rather%20than%20filesystem%20paths.%20A%20broader%20name%20would%20keep%20the%20intent%20clear%20for%20future%20readers.%0A%0A%60%60%60suggestion%0A%20%20%20%20fn%20slash_command_classifier_treats_slash_space_and_absolute_path_as_message%28%29%20%7B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2316&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%0ALine%3A%205012%0A%0AComment%3A%0AThe%20test%20name%20%60slash_command_classifier_treats_absolute_path_as_message%60%20no%20longer%20describes%20the%20new%20cases%20%28%60%22%2F%20hello%22%60%2C%20%60%22%20%20%2F%20hello%22%60%29%2C%20which%20are%20about%20slash-space%20messages%20rather%20than%20filesystem%20paths.%20A%20broader%20name%20would%20keep%20the%20intent%20clear%20for%20future%20readers.%0A%0A%60%60%60suggestion%0A%20%20%20%20fn%20slash_command_classifier_treats_slash_space_and_absolute_path_as_message%28%29%20%7B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2316&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fslash-space-message%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fslash-space-message%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%3A5012%0AThe%20test%20name%20%60slash_command_classifier_treats_absolute_path_as_message%60%20no%20longer%20describes%20the%20new%20cases%20%28%60%22%2F%20hello%22%60%2C%20%60%22%20%20%2F%20hello%22%60%29%2C%20which%20are%20about%20slash-space%20messages%20rather%20than%20filesystem%20paths.%20A%20broader%20name%20would%20keep%20the%20intent%20clear%20for%20future%20readers.%0A%0A%60%60%60suggestion%0A%20%20%20%20fn%20slash_command_classifier_treats_slash_space_and_absolute_path_as_message%28%29%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%3A5016-5017%0AThe%20new%20guard%20only%20checks%20the%20very%20first%20character%20after%20%60%2F%60%2C%20so%20%60%22%2F%09hello%22%60%20%28tab%29%20and%20%60%22%2F%0Ahello%22%60%20%28newline%29%20are%20also%20deflected%20%E2%80%94%20that's%20probably%20intentional%2C%20but%20a%20tab%20case%20in%20the%20existing%20test%20block%20would%20make%20the%20contract%20explicit%20without%20adding%20overhead.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20assert!%28!looks_like_slash_command_input%28%22%2F%20hello%22%29%29%3B%0A%20%20%20%20%20%20%20%20assert!%28!looks_like_slash_command_input%28%22%20%20%2F%20hello%22%29%29%3B%0A%20%20%20%20%20%20%20%20assert!%28!looks_like_slash_command_input%28%22%2F%5Cthello%22%29%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%3A5012%0AThe%20test%20name%20%60slash_command_classifier_treats_absolute_path_as_message%60%20no%20longer%20describes%20the%20new%20cases%20%28%60%22%2F%20hello%22%60%2C%20%60%22%20%20%2F%20hello%22%60%29%2C%20which%20are%20about%20slash-space%20messages%20rather%20than%20filesystem%20paths.%20A%20broader%20name%20would%20keep%20the%20intent%20clear%20for%20future%20readers.%0A%0A%60%60%60suggestion%0A%20%20%20%20fn%20slash_command_classifier_treats_slash_space_and_absolute_path_as_message%28%29%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%3A5016-5017%0AThe%20new%20guard%20only%20checks%20the%20very%20first%20character%20after%20%60%2F%60%2C%20so%20%60%22%2F%09hello%22%60%20%28tab%29%20and%20%60%22%2F%0Ahello%22%60%20%28newline%29%20are%20also%20deflected%20%E2%80%94%20that's%20probably%20intentional%2C%20but%20a%20tab%20case%20in%20the%20existing%20test%20block%20would%20make%20the%20contract%20explicit%20without%20adding%20overhead.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20assert!%28!looks_like_slash_command_input%28%22%2F%20hello%22%29%29%3B%0A%20%20%20%20%20%20%20%20assert!%28!looks_like_slash_command_input%28%22%20%20%2F%20hello%22%29%29%3B%0A%20%20%20%20%20%20%20%20assert!%28!looks_like_slash_command_input%28%22%2F%5Cthello%22%29%29%3B%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2316&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%3A5012%0AThe%20test%20name%20%60slash_command_classifier_treats_absolute_path_as_message%60%20no%20longer%20describes%20the%20new%20cases%20%28%60%22%2F%20hello%22%60%2C%20%60%22%20%20%2F%20hello%22%60%29%2C%20which%20are%20about%20slash-space%20messages%20rather%20than%20filesystem%20paths.%20A%20broader%20name%20would%20keep%20the%20intent%20clear%20for%20future%20readers.%0A%0A%60%60%60suggestion%0A%20%20%20%20fn%20slash_command_classifier_treats_slash_space_and_absolute_path_as_message%28%29%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%3A5016-5017%0AThe%20new%20guard%20only%20checks%20the%20very%20first%20character%20after%20%60%2F%60%2C%20so%20%60%22%2F%09hello%22%60%20%28tab%29%20and%20%60%22%2F%0Ahello%22%60%20%28newline%29%20are%20also%20deflected%20%E2%80%94%20that's%20probably%20intentional%2C%20but%20a%20tab%20case%20in%20the%20existing%20test%20block%20would%20make%20the%20contract%20explicit%20without%20adding%20overhead.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20assert!%28!looks_like_slash_command_input%28%22%2F%20hello%22%29%29%3B%0A%20%20%20%20%20%20%20%20assert!%28!looks_like_slash_command_input%28%22%20%20%2F%20hello%22%29%29%3B%0A%20%20%20%20%20%20%20%20assert!%28!looks_like_slash_command_input%28%22%2F%5Cthello%22%29%29%3B%0A%60%60%60%0A%0A&pr=2316&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(composer): allow slash-space message..."](https://github.com/hmbown/codewhale/commit/12fe9df6971891c899a2084768ae549a65e448d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34341117)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->