### PR TITLE
fix: update terminal tab title from 'DeepSeek TUI' to 'CodeWhale'

### DIFF
--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -23,7 +23,7 @@ impl Engine {
         // Signal to the terminal / taskbar that a turn is in progress
         // (OSC 9 ; 4 indeterminate progress + title spinner).
         crate::tui::notifications::set_taskbar_progress_busy();
-        crate::tui::notifications::start_title_animation("DeepSeek TUI");
+        crate::tui::notifications::start_title_animation("CodeWhale");
 
         let client = self
             .deepseek_client

--- a/crates/tui/src/tui/notifications.rs
+++ b/crates/tui/src/tui/notifications.rs
@@ -315,7 +315,7 @@ pub fn stop_title_animation() {
     // terminal-level visual indicator (flash/icon).
     let mode = COMPLETION_SOUND_MODE.load(Ordering::SeqCst);
     if mode == 1 {
-        set_terminal_title("✅ DeepSeek TUI");
+        set_terminal_title("✅ CodeWhale");
     }
     play_completion_sound();
 }
@@ -326,7 +326,7 @@ pub fn stop_title_animation() {
 /// marker doesn't persist once the user is back at the terminal.
 pub fn reset_title_on_interaction() {
     if COMPLETION_MARKER_SHOWN.swap(false, Ordering::SeqCst) {
-        set_terminal_title("DeepSeek TUI");
+        set_terminal_title("CodeWhale");
     }
 }
 


### PR DESCRIPTION
## Summary

Update the terminal tab title from the legacy `"DeepSeek TUI"` to `"CodeWhale"` to match the project's current name.

Three locations are affected:
- `crates/tui/src/core/engine/turn_loop.rs` — animated spinner base title
- `crates/tui/src/tui/notifications.rs` — completion marker (`✅ CodeWhale`) and interaction reset title

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features` (1 pre-existing flaky failure in `qa_pty`, unrelated to these changes)

## Checklist

- [x] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR renames three hardcoded `"DeepSeek TUI"` terminal title strings to `"CodeWhale"` across two files, aligning the terminal tab title with the project's current branding.

- `turn_loop.rs`: updates the base title passed to `start_title_animation` so the animated spinner shows `"CodeWhale"` during active turns.
- `notifications.rs`: updates both the ✅ completion marker title (`"✅ CodeWhale"`) and the interaction-reset title (`"CodeWhale"`). One doc comment on `TITLE_FRAMES` still refers to "DeepSeek whale emoji" and was not updated.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — only three string literals are changed and the rest of the notification logic is untouched.

The change is purely cosmetic: three string literals in terminal title calls are renamed. No control flow, no data handling, and no external interfaces are affected. The one leftover stale doc comment is trivial.

No files require special attention.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/tui/src/core/engine/turn_loop.rs | One-line string change: `start_title_animation("DeepSeek TUI")` updated to `"CodeWhale"`. No logic changes. |
| crates/tui/src/tui/notifications.rs | Two title string literals updated from `"DeepSeek TUI"` / `"✅ DeepSeek TUI"` to `"CodeWhale"` / `"✅ CodeWhale"`. A stale doc comment on `TITLE_FRAMES` still mentions "DeepSeek whale emoji". |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Engine as turn_loop.rs
    participant Notif as notifications.rs
    participant Terminal as Terminal

    Engine->>Notif: start_title_animation("CodeWhale")
    activate Notif
    loop Every 800ms while running
        Notif->>Terminal: OSC 0 — "🐳 CodeWhale" / "🐋 CodeWhale"
    end
    Engine->>Notif: stop_title_animation()
    Notif->>Terminal: "OSC 0 — "✅ CodeWhale"  (mode == beep)"
    deactivate Notif

    Engine->>Notif: reset_title_on_interaction()
    Notif->>Terminal: OSC 0 — "CodeWhale"
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/tui/src/tui/notifications.rs`, line 249-251 ([link](https://github.com/hmbown/codewhale/blob/1856f965e9b943e0fefd192253744d3139d0b2e4/crates/tui/src/tui/notifications.rs#L249-L251)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The doc comment on `TITLE_FRAMES` still refers to "DeepSeek whale emoji", which is a leftover from the old branding. Since the terminal title strings in this PR are being updated to "CodeWhale", this comment should be updated as well for consistency.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fterminal-title-codewhale%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fterminal-title-codewhale%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fnotifications.rs%0ALine%3A%20249-251%0A%0AComment%3A%0AThe%20doc%20comment%20on%20%60TITLE_FRAMES%60%20still%20refers%20to%20%22DeepSeek%20whale%20emoji%22%2C%20which%20is%20a%20leftover%20from%20the%20old%20branding.%20Since%20the%20terminal%20title%20strings%20in%20this%20PR%20are%20being%20updated%20to%20%22CodeWhale%22%2C%20this%20comment%20should%20be%20updated%20as%20well%20for%20consistency.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20Animation%20frame%20characters%20for%20the%20terminal%20title.%0A%2F%2F%2F%20Uses%20the%20CodeWhale%20emoji%20%28%F0%9F%90%B3%20spouting%2C%20%F0%9F%90%8B%20resting%29%20to%20match%20the%0A%2F%2F%2F%20existing%20header%20status%20indicator%20in%20the%20TUI.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fnotifications.rs%0ALine%3A%20249-251%0A%0AComment%3A%0AThe%20doc%20comment%20on%20%60TITLE_FRAMES%60%20still%20refers%20to%20%22DeepSeek%20whale%20emoji%22%2C%20which%20is%20a%20leftover%20from%20the%20old%20branding.%20Since%20the%20terminal%20title%20strings%20in%20this%20PR%20are%20being%20updated%20to%20%22CodeWhale%22%2C%20this%20comment%20should%20be%20updated%20as%20well%20for%20consistency.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20Animation%20frame%20characters%20for%20the%20terminal%20title.%0A%2F%2F%2F%20Uses%20the%20CodeWhale%20emoji%20%28%F0%9F%90%B3%20spouting%2C%20%F0%9F%90%8B%20resting%29%20to%20match%20the%0A%2F%2F%2F%20existing%20header%20status%20indicator%20in%20the%20TUI.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2319&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fnotifications.rs%0ALine%3A%20249-251%0A%0AComment%3A%0AThe%20doc%20comment%20on%20%60TITLE_FRAMES%60%20still%20refers%20to%20%22DeepSeek%20whale%20emoji%22%2C%20which%20is%20a%20leftover%20from%20the%20old%20branding.%20Since%20the%20terminal%20title%20strings%20in%20this%20PR%20are%20being%20updated%20to%20%22CodeWhale%22%2C%20this%20comment%20should%20be%20updated%20as%20well%20for%20consistency.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20Animation%20frame%20characters%20for%20the%20terminal%20title.%0A%2F%2F%2F%20Uses%20the%20CodeWhale%20emoji%20%28%F0%9F%90%B3%20spouting%2C%20%F0%9F%90%8B%20resting%29%20to%20match%20the%0A%2F%2F%2F%20existing%20header%20status%20indicator%20in%20the%20TUI.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2319&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fterminal-title-codewhale%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fterminal-title-codewhale%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fnotifications.rs%3A249-251%0AThe%20doc%20comment%20on%20%60TITLE_FRAMES%60%20still%20refers%20to%20%22DeepSeek%20whale%20emoji%22%2C%20which%20is%20a%20leftover%20from%20the%20old%20branding.%20Since%20the%20terminal%20title%20strings%20in%20this%20PR%20are%20being%20updated%20to%20%22CodeWhale%22%2C%20this%20comment%20should%20be%20updated%20as%20well%20for%20consistency.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20Animation%20frame%20characters%20for%20the%20terminal%20title.%0A%2F%2F%2F%20Uses%20the%20CodeWhale%20emoji%20%28%F0%9F%90%B3%20spouting%2C%20%F0%9F%90%8B%20resting%29%20to%20match%20the%0A%2F%2F%2F%20existing%20header%20status%20indicator%20in%20the%20TUI.%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fnotifications.rs%3A249-251%0AThe%20doc%20comment%20on%20%60TITLE_FRAMES%60%20still%20refers%20to%20%22DeepSeek%20whale%20emoji%22%2C%20which%20is%20a%20leftover%20from%20the%20old%20branding.%20Since%20the%20terminal%20title%20strings%20in%20this%20PR%20are%20being%20updated%20to%20%22CodeWhale%22%2C%20this%20comment%20should%20be%20updated%20as%20well%20for%20consistency.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20Animation%20frame%20characters%20for%20the%20terminal%20title.%0A%2F%2F%2F%20Uses%20the%20CodeWhale%20emoji%20%28%F0%9F%90%B3%20spouting%2C%20%F0%9F%90%8B%20resting%29%20to%20match%20the%0A%2F%2F%2F%20existing%20header%20status%20indicator%20in%20the%20TUI.%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2319&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fnotifications.rs%3A249-251%0AThe%20doc%20comment%20on%20%60TITLE_FRAMES%60%20still%20refers%20to%20%22DeepSeek%20whale%20emoji%22%2C%20which%20is%20a%20leftover%20from%20the%20old%20branding.%20Since%20the%20terminal%20title%20strings%20in%20this%20PR%20are%20being%20updated%20to%20%22CodeWhale%22%2C%20this%20comment%20should%20be%20updated%20as%20well%20for%20consistency.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20Animation%20frame%20characters%20for%20the%20terminal%20title.%0A%2F%2F%2F%20Uses%20the%20CodeWhale%20emoji%20%28%F0%9F%90%B3%20spouting%2C%20%F0%9F%90%8B%20resting%29%20to%20match%20the%0A%2F%2F%2F%20existing%20header%20status%20indicator%20in%20the%20TUI.%0A%60%60%60%0A%0A&pr=2319&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix: update terminal tab title from &#39;Dee..."](https://github.com/hmbown/codewhale/commit/1856f965e9b943e0fefd192253744d3139d0b2e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34363553)</sub>

<!-- /greptile_comment -->