### PR TITLE
  fix(statusline): keep picker selection visible

### DIFF
--- a/crates/tui/src/tui/views/status_picker.rs
+++ b/crates/tui/src/tui/views/status_picker.rs
@@ -19,8 +19,12 @@ use ratatui::{
 };
 
 use crate::config::StatusItem;
+use crate::localization::truncate_to_width;
 use crate::palette;
 use crate::tui::views::{ModalKind, ModalView, ViewAction, ViewEvent};
+use unicode_width::UnicodeWidthStr;
+
+const STATUS_PICKER_SELECTION_BG: ratatui::style::Color = ratatui::style::Color::Rgb(54, 72, 104);
 
 /// Picker state. We hold both the user's working selection AND the original
 /// snapshot so Esc can perfectly revert the live preview.
@@ -62,16 +66,21 @@ impl StatusPickerView {
     }
 
     fn move_up(&mut self) {
-        if self.cursor > 0 {
+        if self.rows.is_empty() {
+            return;
+        }
+        if self.cursor == 0 {
+            self.cursor = self.rows.len() - 1;
+        } else {
             self.cursor -= 1;
         }
     }
 
     fn move_down(&mut self) {
-        let max = self.rows.len().saturating_sub(1);
-        if self.cursor < max {
-            self.cursor += 1;
+        if self.rows.is_empty() {
+            return;
         }
+        self.cursor = (self.cursor + 1) % self.rows.len();
     }
 
     fn toggle_current(&mut self) {
@@ -201,7 +210,16 @@ impl ModalView for StatusPickerView {
         )));
         lines.push(Line::from(""));
 
-        for (idx, item) in self.rows.iter().enumerate() {
+        let visible_rows = inner.height.saturating_sub(2) as usize;
+        let row_start = visible_row_start(self.rows.len(), self.cursor, visible_rows);
+
+        for (idx, item) in self
+            .rows
+            .iter()
+            .enumerate()
+            .skip(row_start)
+            .take(visible_rows)
+        {
             let checked = *self.selected.get(idx).unwrap_or(&false);
             let is_cursor = idx == self.cursor;
             let mark = if checked { "[✓]" } else { "[ ]" };
@@ -225,18 +243,48 @@ impl ModalView for StatusPickerView {
             };
             let pointer = if is_cursor { "▸" } else { " " };
 
-            lines.push(Line::from(vec![
-                Span::styled(format!(" {pointer} "), row_style),
-                Span::styled(mark.to_string(), row_style),
-                Span::raw(" "),
-                Span::styled(item.label().to_string(), row_style),
-                Span::raw("  "),
-                Span::styled(format!("({})", item.hint()), hint_style),
-            ]));
+            if is_cursor {
+                let selected_style = Style::default()
+                    .fg(palette::SELECTION_TEXT)
+                    .bg(STATUS_PICKER_SELECTION_BG)
+                    .add_modifier(Modifier::BOLD);
+                let line = status_row_text(pointer, mark, item, inner.width as usize);
+                lines.push(Line::from(Span::styled(line, selected_style)));
+            } else {
+                lines.push(Line::from(vec![
+                    Span::styled(format!(" {pointer} "), row_style),
+                    Span::styled(mark.to_string(), row_style),
+                    Span::styled(" ", row_style),
+                    Span::styled(item.label().to_string(), row_style),
+                    Span::styled("  ", row_style),
+                    Span::styled(format!("({})", item.hint()), hint_style),
+                ]));
+            }
         }
 
         Paragraph::new(lines).render(inner, buf);
     }
+}
+
+fn visible_row_start(total_rows: usize, cursor: usize, visible_rows: usize) -> usize {
+    if total_rows == 0 || visible_rows == 0 || total_rows <= visible_rows {
+        return 0;
+    }
+    let max_start = total_rows - visible_rows;
+    cursor
+        .saturating_add(1)
+        .saturating_sub(visible_rows)
+        .min(max_start)
+}
+
+fn status_row_text(pointer: &str, mark: &str, item: &StatusItem, width: usize) -> String {
+    let text = format!(" {pointer} {mark} {}  ({})", item.label(), item.hint());
+    let mut text = truncate_to_width(&text, width);
+    let current_width = text.width();
+    if current_width < width {
+        text.push_str(&" ".repeat(width - current_width));
+    }
+    text
 }
 
 #[cfg(test)]
@@ -317,18 +365,32 @@ mod tests {
     }
 
     #[test]
-    fn arrow_keys_move_cursor_within_bounds() {
+    fn arrow_keys_wrap_cursor_at_edges() {
         let active = StatusItem::default_footer();
         let mut view = StatusPickerView::new(&active);
+        assert_eq!(view.cursor, 0);
+        view.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
+        assert_eq!(view.cursor, StatusItem::all().len() - 1);
+        view.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
         assert_eq!(view.cursor, 0);
         view.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
         assert_eq!(view.cursor, 1);
         view.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
         assert_eq!(view.cursor, 0);
-        // Move past the bottom shouldn't wrap.
-        for _ in 0..StatusItem::all().len() + 5 {
-            view.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
-        }
-        assert_eq!(view.cursor, StatusItem::all().len() - 1);
+    }
+
+    #[test]
+    fn visible_row_start_keeps_cursor_in_view() {
+        assert_eq!(visible_row_start(14, 0, 8), 0);
+        assert_eq!(visible_row_start(14, 7, 8), 0);
+        assert_eq!(visible_row_start(14, 8, 8), 1);
+        assert_eq!(visible_row_start(14, 13, 8), 6);
+    }
+
+    #[test]
+    fn selected_row_text_fills_available_width() {
+        let text = status_row_text("▸", "[ ]", &StatusItem::LastToolElapsed, 40);
+        assert_eq!(text.width(), 40);
+        assert!(text.starts_with(" ▸ [ ] Last tool elapsed"));
     }
 }


### PR DESCRIPTION
## Summary

  Fixes the `/statusline` picker navigation and selected-row visibility.

  When the terminal is not tall enough to show every status item, the cursor could move onto rows that were clipped by the modal. This  made the selection appear to disappear after moving down past the last visible item, and some available statusline items were effectively hidden until the window was made taller.

  This PR updates the picker so:

  - the visible row window follows the cursor, so lower items become visible while navigating down
  - Up from the first item wraps to the last item
  - Down from the last item wraps to the first item
  - the selected row uses a continuous background instead of broken span backgrounds
  - the selected row background is slightly brighter while staying close to the original selection color

from: the cursor disappear
<img width="684" height="460" alt="image" src="https://github.com/user-attachments/assets/f3668dd9-dd3b-4532-9943-038b4690ca27" />

to:
<img width="697" height="427" alt="image" src="https://github.com/user-attachments/assets/408aa9ce-93b0-4e6e-b61d-137f5ba448cf" />

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features`
- [x] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes two intertwined problems in the `/statusline` picker: the cursor previously could not scroll the visible window, so items below the visible area were unreachable without resizing the terminal; and the selected row's highlight was visually broken because each `Span` inside the line had its own background, leaving gaps. The fix introduces a `visible_row_start` scroll-window function, cursor wrap-around at both edges, and a single full-width padded `Span` for the highlighted row.

- **Scroll windowing**: `visible_row_start` computes the first visible index so the cursor row is always on-screen; items are fetched with `.skip(row_start).take(visible_rows)` rather than rendering all rows and relying on `Paragraph` to clip them.
- **Cursor wrap-around**: `move_up` wraps from index 0 to the last item and `move_down` wraps from the last item back to 0, replacing the previous clamped behaviour.
- **Continuous highlight**: the cursor row is built as a single space-padded string via `status_row_text` (using `truncate_to_width` + `UnicodeWidthStr`) and styled with one `Span`, so the background fills the full inner width without gaps.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; all navigation paths, the scroll window, and the full-width highlight are correct and covered by tests.

The wrapping logic, visible_row_start arithmetic, and status_row_text padding have all been verified and are accompanied by new unit tests that pin the key invariants. The two observations — dead style computation in the cursor branch and the absence of a scroll-position indicator — are cosmetic and do not affect runtime correctness.

No files require special attention; the single changed file is self-contained and straightforward.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/views/status_picker.rs | Navigation, windowing, and highlight logic all updated; logic is correct and well-tested, with two minor style observations (dead style computation for cursor branch, no scroll-position indicator). |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Key Event] --> B{KeyCode}
    B -->|Up or k| C[move_up]
    B -->|Down or j| D[move_down]
    B -->|Space or x| E[toggle_current]
    B -->|Enter| F[EmitAndClose final_event]
    B -->|Esc| G[EmitAndClose revert_event]

    C --> C1{rows empty?}
    C1 -->|yes| C2[return]
    C1 -->|no| C3{cursor == 0?}
    C3 -->|yes| C4[cursor = rows.len - 1]
    C3 -->|no| C5[cursor -= 1]

    D --> D1{rows empty?}
    D1 -->|yes| D2[return]
    D1 -->|no| D3[cursor = cursor+1 mod rows.len]

    C4 & C5 & D3 --> R[render]

    R --> R1[visible_rows = inner.height - 2]
    R1 --> R2[row_start = visible_row_start]
    R2 --> R3[rows.skip row_start .take visible_rows]
    R3 --> R4{is_cursor?}
    R4 -->|yes| R5[status_row_text single full-width Span]
    R4 -->|no| R6[multi-Span line with row_style and hint_style]
    R5 & R6 --> R7[Paragraph render]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/tui/src/tui/views/status_picker.rs`, line 227-244 ([link](https://github.com/hmbown/codewhale/blob/b701979a27db08ecc88163a64c74aea5b4b443cb/crates/tui/src/tui/views/status_picker.rs#L227-L244)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Dead style values for the cursor row**

   `row_style` and `hint_style` are computed unconditionally every iteration; when `is_cursor = true` the branch immediately constructs its own `selected_style` (using `STATUS_PICKER_SELECTION_BG`) and never touches `row_style` or `hint_style`. The `is_cursor` arm of `row_style` even references `palette::SELECTION_BG`, which could mislead a future reader into thinking `SELECTION_BG` is what colours the highlighted row — in practice it is `STATUS_PICKER_SELECTION_BG`. Moving `row_style`/`hint_style` into the `else` branch (or guarding them behind `if !is_cursor`) would make the intent unambiguous.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fstatusline-picker-navigation%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fstatusline-picker-navigation%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fviews%2Fstatus_picker.rs%0ALine%3A%20227-244%0A%0AComment%3A%0A**Dead%20style%20values%20for%20the%20cursor%20row**%0A%0A%60row_style%60%20and%20%60hint_style%60%20are%20computed%20unconditionally%20every%20iteration%3B%20when%20%60is_cursor%20%3D%20true%60%20the%20branch%20immediately%20constructs%20its%20own%20%60selected_style%60%20%28using%20%60STATUS_PICKER_SELECTION_BG%60%29%20and%20never%20touches%20%60row_style%60%20or%20%60hint_style%60.%20The%20%60is_cursor%60%20arm%20of%20%60row_style%60%20even%20references%20%60palette%3A%3ASELECTION_BG%60%2C%20which%20could%20mislead%20a%20future%20reader%20into%20thinking%20%60SELECTION_BG%60%20is%20what%20colours%20the%20highlighted%20row%20%E2%80%94%20in%20practice%20it%20is%20%60STATUS_PICKER_SELECTION_BG%60.%20Moving%20%60row_style%60%2F%60hint_style%60%20into%20the%20%60else%60%20branch%20%28or%20guarding%20them%20behind%20%60if%20!is_cursor%60%29%20would%20make%20the%20intent%20unambiguous.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fviews%2Fstatus_picker.rs%0ALine%3A%20227-244%0A%0AComment%3A%0A**Dead%20style%20values%20for%20the%20cursor%20row**%0A%0A%60row_style%60%20and%20%60hint_style%60%20are%20computed%20unconditionally%20every%20iteration%3B%20when%20%60is_cursor%20%3D%20true%60%20the%20branch%20immediately%20constructs%20its%20own%20%60selected_style%60%20%28using%20%60STATUS_PICKER_SELECTION_BG%60%29%20and%20never%20touches%20%60row_style%60%20or%20%60hint_style%60.%20The%20%60is_cursor%60%20arm%20of%20%60row_style%60%20even%20references%20%60palette%3A%3ASELECTION_BG%60%2C%20which%20could%20mislead%20a%20future%20reader%20into%20thinking%20%60SELECTION_BG%60%20is%20what%20colours%20the%20highlighted%20row%20%E2%80%94%20in%20practice%20it%20is%20%60STATUS_PICKER_SELECTION_BG%60.%20Moving%20%60row_style%60%2F%60hint_style%60%20into%20the%20%60else%60%20branch%20%28or%20guarding%20them%20behind%20%60if%20!is_cursor%60%29%20would%20make%20the%20intent%20unambiguous.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2324&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fviews%2Fstatus_picker.rs%0ALine%3A%20227-244%0A%0AComment%3A%0A**Dead%20style%20values%20for%20the%20cursor%20row**%0A%0A%60row_style%60%20and%20%60hint_style%60%20are%20computed%20unconditionally%20every%20iteration%3B%20when%20%60is_cursor%20%3D%20true%60%20the%20branch%20immediately%20constructs%20its%20own%20%60selected_style%60%20%28using%20%60STATUS_PICKER_SELECTION_BG%60%29%20and%20never%20touches%20%60row_style%60%20or%20%60hint_style%60.%20The%20%60is_cursor%60%20arm%20of%20%60row_style%60%20even%20references%20%60palette%3A%3ASELECTION_BG%60%2C%20which%20could%20mislead%20a%20future%20reader%20into%20thinking%20%60SELECTION_BG%60%20is%20what%20colours%20the%20highlighted%20row%20%E2%80%94%20in%20practice%20it%20is%20%60STATUS_PICKER_SELECTION_BG%60.%20Moving%20%60row_style%60%2F%60hint_style%60%20into%20the%20%60else%60%20branch%20%28or%20guarding%20them%20behind%20%60if%20!is_cursor%60%29%20would%20make%20the%20intent%20unambiguous.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2324&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fstatusline-picker-navigation%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fstatusline-picker-navigation%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fviews%2Fstatus_picker.rs%3A227-244%0A**Dead%20style%20values%20for%20the%20cursor%20row**%0A%0A%60row_style%60%20and%20%60hint_style%60%20are%20computed%20unconditionally%20every%20iteration%3B%20when%20%60is_cursor%20%3D%20true%60%20the%20branch%20immediately%20constructs%20its%20own%20%60selected_style%60%20%28using%20%60STATUS_PICKER_SELECTION_BG%60%29%20and%20never%20touches%20%60row_style%60%20or%20%60hint_style%60.%20The%20%60is_cursor%60%20arm%20of%20%60row_style%60%20even%20references%20%60palette%3A%3ASELECTION_BG%60%2C%20which%20could%20mislead%20a%20future%20reader%20into%20thinking%20%60SELECTION_BG%60%20is%20what%20colours%20the%20highlighted%20row%20%E2%80%94%20in%20practice%20it%20is%20%60STATUS_PICKER_SELECTION_BG%60.%20Moving%20%60row_style%60%2F%60hint_style%60%20into%20the%20%60else%60%20branch%20%28or%20guarding%20them%20behind%20%60if%20!is_cursor%60%29%20would%20make%20the%20intent%20unambiguous.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fviews%2Fstatus_picker.rs%3A213-214%0A**No%20scroll-position%20indicator%20when%20the%20list%20is%20windowed**%0A%0AWhen%20%60row_start%20%3E%200%60%20or%20when%20items%20below%20the%20visible%20window%20exist%2C%20there%20is%20no%20visual%20cue%20%28e.g.%20a%20%60%E2%96%B2%60%20%2F%20%60%E2%96%BC%60%20arrow%20or%20a%20count%20like%20%60%283%2F14%29%60%29%20that%20the%20list%20is%20scrolled.%20A%20user%20who%20opens%20the%20picker%20in%20a%20short%20terminal%20may%20not%20realise%20items%20above%20or%20below%20the%20viewport%20are%20available%2C%20which%20is%20the%20exact%20UX%20problem%20this%20PR%20aims%20to%20solve.%20A%20single%20line%20added%20to%20the%20header%20or%20appended%20after%20the%20last%20visible%20item%20would%20surface%20this.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fviews%2Fstatus_picker.rs%3A227-244%0A**Dead%20style%20values%20for%20the%20cursor%20row**%0A%0A%60row_style%60%20and%20%60hint_style%60%20are%20computed%20unconditionally%20every%20iteration%3B%20when%20%60is_cursor%20%3D%20true%60%20the%20branch%20immediately%20constructs%20its%20own%20%60selected_style%60%20%28using%20%60STATUS_PICKER_SELECTION_BG%60%29%20and%20never%20touches%20%60row_style%60%20or%20%60hint_style%60.%20The%20%60is_cursor%60%20arm%20of%20%60row_style%60%20even%20references%20%60palette%3A%3ASELECTION_BG%60%2C%20which%20could%20mislead%20a%20future%20reader%20into%20thinking%20%60SELECTION_BG%60%20is%20what%20colours%20the%20highlighted%20row%20%E2%80%94%20in%20practice%20it%20is%20%60STATUS_PICKER_SELECTION_BG%60.%20Moving%20%60row_style%60%2F%60hint_style%60%20into%20the%20%60else%60%20branch%20%28or%20guarding%20them%20behind%20%60if%20!is_cursor%60%29%20would%20make%20the%20intent%20unambiguous.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fviews%2Fstatus_picker.rs%3A213-214%0A**No%20scroll-position%20indicator%20when%20the%20list%20is%20windowed**%0A%0AWhen%20%60row_start%20%3E%200%60%20or%20when%20items%20below%20the%20visible%20window%20exist%2C%20there%20is%20no%20visual%20cue%20%28e.g.%20a%20%60%E2%96%B2%60%20%2F%20%60%E2%96%BC%60%20arrow%20or%20a%20count%20like%20%60%283%2F14%29%60%29%20that%20the%20list%20is%20scrolled.%20A%20user%20who%20opens%20the%20picker%20in%20a%20short%20terminal%20may%20not%20realise%20items%20above%20or%20below%20the%20viewport%20are%20available%2C%20which%20is%20the%20exact%20UX%20problem%20this%20PR%20aims%20to%20solve.%20A%20single%20line%20added%20to%20the%20header%20or%20appended%20after%20the%20last%20visible%20item%20would%20surface%20this.%0A%0A&repo=hmbown%2Fcodewhale&pr=2324&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fviews%2Fstatus_picker.rs%3A227-244%0A**Dead%20style%20values%20for%20the%20cursor%20row**%0A%0A%60row_style%60%20and%20%60hint_style%60%20are%20computed%20unconditionally%20every%20iteration%3B%20when%20%60is_cursor%20%3D%20true%60%20the%20branch%20immediately%20constructs%20its%20own%20%60selected_style%60%20%28using%20%60STATUS_PICKER_SELECTION_BG%60%29%20and%20never%20touches%20%60row_style%60%20or%20%60hint_style%60.%20The%20%60is_cursor%60%20arm%20of%20%60row_style%60%20even%20references%20%60palette%3A%3ASELECTION_BG%60%2C%20which%20could%20mislead%20a%20future%20reader%20into%20thinking%20%60SELECTION_BG%60%20is%20what%20colours%20the%20highlighted%20row%20%E2%80%94%20in%20practice%20it%20is%20%60STATUS_PICKER_SELECTION_BG%60.%20Moving%20%60row_style%60%2F%60hint_style%60%20into%20the%20%60else%60%20branch%20%28or%20guarding%20them%20behind%20%60if%20!is_cursor%60%29%20would%20make%20the%20intent%20unambiguous.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fviews%2Fstatus_picker.rs%3A213-214%0A**No%20scroll-position%20indicator%20when%20the%20list%20is%20windowed**%0A%0AWhen%20%60row_start%20%3E%200%60%20or%20when%20items%20below%20the%20visible%20window%20exist%2C%20there%20is%20no%20visual%20cue%20%28e.g.%20a%20%60%E2%96%B2%60%20%2F%20%60%E2%96%BC%60%20arrow%20or%20a%20count%20like%20%60%283%2F14%29%60%29%20that%20the%20list%20is%20scrolled.%20A%20user%20who%20opens%20the%20picker%20in%20a%20short%20terminal%20may%20not%20realise%20items%20above%20or%20below%20the%20viewport%20are%20available%2C%20which%20is%20the%20exact%20UX%20problem%20this%20PR%20aims%20to%20solve.%20A%20single%20line%20added%20to%20the%20header%20or%20appended%20after%20the%20last%20visible%20item%20would%20surface%20this.%0A%0A&pr=2324&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(statusline): keep picker selection v..."](https://github.com/hmbown/codewhale/commit/b701979a27db08ecc88163a64c74aea5b4b443cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34383925)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->