### PR TITLE
feat(tui): add render diff debug log

### DIFF
--- a/crates/tui/src/runtime_log.rs
+++ b/crates/tui/src/runtime_log.rs
@@ -1,5 +1,5 @@
 //! TUI runtime logging. Initializes a `tracing-subscriber` that writes to a
-//! per-process file under `~/.deepseek/logs/tui-YYYY-MM-DD-PID.log`, and (on
+//! per-process file under `~/.codewhale/logs/tui-YYYY-MM-DD-PID.log`, and (on
 //! Unix) redirects the process's `stderr` fd to that same file for the lifetime
 //! of the alt-screen TUI.
 //!
@@ -22,7 +22,7 @@
 //!
 //! Defence-in-depth:
 //!   1. A `tracing-subscriber` writes formatted logs to
-//!      `~/.deepseek/logs/tui-YYYY-MM-DD-PID.log` so `tracing::warn!` /
+//!      `~/.codewhale/logs/tui-YYYY-MM-DD-PID.log` so `tracing::warn!` /
 //!      `tracing::error!` calls go somewhere observable instead of
 //!      disappearing into the void (the TUI previously had no global
 //!      subscriber, so contributors reached for `eprintln!`).
@@ -162,7 +162,11 @@ pub(crate) fn log_directory() -> Option<PathBuf> {
         if primary.exists() {
             return Some(primary);
         }
-        Some(base.join(".deepseek").join("logs"))
+        let legacy = base.join(".deepseek").join("logs");
+        if legacy.exists() {
+            return Some(legacy);
+        }
+        Some(primary)
     };
     if let Some(home) = std::env::var_os("HOME").map(PathBuf::from)
         && !home.as_os_str().is_empty()
@@ -270,7 +274,37 @@ mod tests {
         }
 
         let resolved = log_directory().expect("log_directory should resolve");
-        assert_eq!(resolved, tmp.path().join(".deepseek").join("logs"));
+        assert_eq!(resolved, tmp.path().join(".codewhale").join("logs"));
+
+        // SAFETY: cleanup under the same lock.
+        unsafe {
+            match prev_home {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+            match prev_userprofile {
+                Some(v) => std::env::set_var("USERPROFILE", v),
+                None => std::env::remove_var("USERPROFILE"),
+            }
+        }
+    }
+
+    #[test]
+    fn log_directory_uses_existing_legacy_deepseek_logs() {
+        let _lock = crate::test_support::lock_test_env();
+        let tmp = tempfile::TempDir::new().unwrap();
+        let legacy = tmp.path().join(".deepseek").join("logs");
+        fs::create_dir_all(&legacy).unwrap();
+        let prev_home = std::env::var_os("HOME");
+        let prev_userprofile = std::env::var_os("USERPROFILE");
+        // SAFETY: serialised by lock_test_env.
+        unsafe {
+            std::env::set_var("HOME", tmp.path());
+            std::env::set_var("USERPROFILE", "");
+        }
+
+        let resolved = log_directory().expect("log_directory should resolve");
+        assert_eq!(resolved, legacy);
 
         // SAFETY: cleanup under the same lock.
         unsafe {

--- a/crates/tui/src/runtime_log.rs
+++ b/crates/tui/src/runtime_log.rs
@@ -156,7 +156,7 @@ pub fn init() -> Result<TuiLogGuard> {
     })
 }
 
-fn log_directory() -> Option<PathBuf> {
+pub(crate) fn log_directory() -> Option<PathBuf> {
     let resolve = |base: PathBuf| -> Option<PathBuf> {
         let primary = base.join(".codewhale").join("logs");
         if primary.exists() {

--- a/crates/tui/src/tui/color_compat.rs
+++ b/crates/tui/src/tui/color_compat.rs
@@ -6,6 +6,7 @@
 //! as stray green/cyan backgrounds. This backend adapts every cell to the
 //! detected color depth before handing it to crossterm.
 
+use std::fs::{self, File, OpenOptions};
 use std::io::{self, Write};
 
 use ratatui::{
@@ -15,6 +16,9 @@ use ratatui::{
 };
 
 use crate::palette::{self, ColorDepth, PaletteMode, ThemeId, UiTheme};
+
+const RENDER_DEBUG_ENV: &str = "CODEWHALE_TUI_DEBUG";
+const RENDER_DEBUG_SAMPLE_LIMIT: usize = 24;
 
 #[derive(Debug)]
 pub(crate) struct ColorCompatBackend<W: Write> {
@@ -38,6 +42,7 @@ pub(crate) struct ColorCompatBackend<W: Write> {
     /// Forcing the expected size prevents ratatui's internal `autoresize` from
     /// shrinking the viewport back to the stale dimension inside `draw()`.
     forced_size: Option<Size>,
+    render_debug: Option<RenderDebugLog>,
 }
 
 impl<W: Write> ColorCompatBackend<W> {
@@ -53,6 +58,7 @@ impl<W: Write> ColorCompatBackend<W> {
             // to a community preset.
             active_ui_theme: UiTheme::detect(),
             forced_size: None,
+            render_debug: RenderDebugLog::from_env(),
         }
     }
 
@@ -104,6 +110,14 @@ impl<W: Write> Backend for ColorCompatBackend<W> {
                 (x, y, cell)
             })
             .collect::<Vec<_>>();
+        let viewport = if self.render_debug.is_some() {
+            self.size().ok()
+        } else {
+            None
+        };
+        if let Some(render_debug) = &mut self.render_debug {
+            render_debug.record(viewport, &adapted);
+        }
         self.inner
             .draw(adapted.iter().map(|(x, y, cell)| (*x, *y, cell)))
     }
@@ -152,6 +166,73 @@ impl<W: Write> Backend for ColorCompatBackend<W> {
     }
 }
 
+#[derive(Debug)]
+struct RenderDebugLog {
+    file: File,
+    frame: u64,
+}
+
+impl RenderDebugLog {
+    fn from_env() -> Option<Self> {
+        if !render_debug_enabled_from_value(std::env::var(RENDER_DEBUG_ENV).ok().as_deref()) {
+            return None;
+        }
+
+        let log_dir = crate::runtime_log::log_directory()?;
+        if let Err(err) = fs::create_dir_all(&log_dir) {
+            tracing::debug!(?err, "failed to create TUI render debug log directory");
+            return None;
+        }
+        let path = log_dir.join("tui-render.log");
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .map_err(|err| {
+                tracing::debug!(?err, path = %path.display(), "failed to open TUI render debug log");
+                err
+            })
+            .ok()?;
+
+        Some(Self { file, frame: 0 })
+    }
+
+    fn record(&mut self, viewport: Option<Size>, diff: &[(u16, u16, Cell)]) {
+        self.frame = self.frame.saturating_add(1);
+        let sample = diff
+            .iter()
+            .take(RENDER_DEBUG_SAMPLE_LIMIT)
+            .map(|(x, y, _)| (*x, *y))
+            .collect::<Vec<_>>();
+        let line = render_debug_line(self.frame, viewport, diff.len(), &sample);
+        let _ = self.file.write_all(line.as_bytes());
+    }
+}
+
+fn render_debug_enabled_from_value(value: Option<&str>) -> bool {
+    matches!(
+        value.map(str::trim).map(str::to_ascii_lowercase).as_deref(),
+        Some("1" | "true" | "yes" | "on")
+    )
+}
+
+fn render_debug_line(
+    frame: u64,
+    viewport: Option<Size>,
+    diff_cells: usize,
+    sample: &[(u16, u16)],
+) -> String {
+    let size = viewport
+        .map(|size| format!("{}x{}", size.width, size.height))
+        .unwrap_or_else(|| "unknown".to_string());
+    let sample = sample
+        .iter()
+        .map(|(x, y)| format!("{x}:{y}"))
+        .collect::<Vec<_>>()
+        .join(",");
+    format!("frame={frame} size={size} diff_cells={diff_cells} sample={sample}\n")
+}
+
 fn adapt_cell_colors(
     cell: &mut Cell,
     depth: ColorDepth,
@@ -177,12 +258,13 @@ fn adapt_cell_colors(
 
 #[cfg(test)]
 mod tests {
-    use std::{cell::RefCell, io::Write, rc::Rc};
+    use std::{cell::RefCell, env, fs, io::Write, rc::Rc};
 
     use ratatui::backend::Backend;
     use ratatui::{buffer::Cell, style::Color};
 
     use super::*;
+    use crate::test_support::lock_test_env;
 
     #[derive(Clone, Default)]
     struct SharedWriter(Rc<RefCell<Vec<u8>>>);
@@ -317,5 +399,75 @@ mod tests {
         assert_eq!(backend.palette_mode, PaletteMode::Light);
         backend.set_palette_mode(PaletteMode::Grayscale);
         assert_eq!(backend.palette_mode, PaletteMode::Grayscale);
+    }
+
+    #[test]
+    fn render_debug_env_parser_accepts_truthy_values_only() {
+        assert!(!render_debug_enabled_from_value(None));
+        assert!(!render_debug_enabled_from_value(Some("")));
+        assert!(!render_debug_enabled_from_value(Some("0")));
+        assert!(!render_debug_enabled_from_value(Some("false")));
+        assert!(render_debug_enabled_from_value(Some("1")));
+        assert!(render_debug_enabled_from_value(Some("true")));
+        assert!(render_debug_enabled_from_value(Some("YES")));
+        assert!(render_debug_enabled_from_value(Some("on")));
+    }
+
+    #[test]
+    fn render_debug_line_records_frame_size_and_diff_sample() {
+        let line = render_debug_line(7, Some(Size::new(80, 24)), 42, &[(0, 0), (12, 3), (79, 23)]);
+
+        assert_eq!(
+            line,
+            "frame=7 size=80x24 diff_cells=42 sample=0:0,12:3,79:23\n"
+        );
+    }
+
+    #[test]
+    fn backend_writes_render_debug_log_when_enabled() {
+        let _lock = lock_test_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let previous_home = env::var_os("HOME");
+        let previous_userprofile = env::var_os("USERPROFILE");
+        let previous_debug = env::var_os(RENDER_DEBUG_ENV);
+
+        // SAFETY: environment mutation is serialized by lock_test_env.
+        unsafe {
+            env::set_var("HOME", tmp.path());
+            env::set_var("USERPROFILE", "");
+            env::set_var(RENDER_DEBUG_ENV, "1");
+        }
+
+        let writer = SharedWriter::default();
+        let mut backend = ColorCompatBackend::new(writer, ColorDepth::TrueColor, PaletteMode::Dark);
+        let mut cell = Cell::default();
+        cell.set_symbol("x");
+        backend.draw(std::iter::once((3, 4, &cell))).unwrap();
+
+        let log_path = tmp
+            .path()
+            .join(".deepseek")
+            .join("logs")
+            .join("tui-render.log");
+        let body = fs::read_to_string(log_path).expect("render debug log");
+        assert!(body.contains("frame=1"), "{body}");
+        assert!(body.contains("diff_cells=1"), "{body}");
+        assert!(body.contains("sample=3:4"), "{body}");
+
+        // SAFETY: environment mutation is serialized by lock_test_env.
+        unsafe {
+            match previous_home {
+                Some(value) => env::set_var("HOME", value),
+                None => env::remove_var("HOME"),
+            }
+            match previous_userprofile {
+                Some(value) => env::set_var("USERPROFILE", value),
+                None => env::remove_var("USERPROFILE"),
+            }
+            match previous_debug {
+                Some(value) => env::set_var(RENDER_DEBUG_ENV, value),
+                None => env::remove_var(RENDER_DEBUG_ENV),
+            }
+        }
     }
 }

--- a/crates/tui/src/tui/color_compat.rs
+++ b/crates/tui/src/tui/color_compat.rs
@@ -6,6 +6,7 @@
 //! as stray green/cyan backgrounds. This backend adapts every cell to the
 //! detected color depth before handing it to crossterm.
 
+use std::fmt::Write as _;
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, Write};
 
@@ -222,15 +223,30 @@ fn render_debug_line(
     diff_cells: usize,
     sample: &[(u16, u16)],
 ) -> String {
-    let size = viewport
-        .map(|size| format!("{}x{}", size.width, size.height))
-        .unwrap_or_else(|| "unknown".to_string());
-    let sample = sample
-        .iter()
-        .map(|(x, y)| format!("{x}:{y}"))
-        .collect::<Vec<_>>()
-        .join(",");
-    format!("frame={frame} size={size} diff_cells={diff_cells} sample={sample}\n")
+    let mut line = String::new();
+    match viewport {
+        Some(size) => {
+            let _ = write!(
+                &mut line,
+                "frame={frame} size={}x{} diff_cells={diff_cells} sample=",
+                size.width, size.height
+            );
+        }
+        None => {
+            let _ = write!(
+                &mut line,
+                "frame={frame} size=unknown diff_cells={diff_cells} sample="
+            );
+        }
+    }
+    for (index, (x, y)) in sample.iter().enumerate() {
+        if index > 0 {
+            line.push(',');
+        }
+        let _ = write!(&mut line, "{x}:{y}");
+    }
+    line.push('\n');
+    line
 }
 
 fn adapt_cell_colors(
@@ -258,7 +274,7 @@ fn adapt_cell_colors(
 
 #[cfg(test)]
 mod tests {
-    use std::{cell::RefCell, env, fs, io::Write, rc::Rc};
+    use std::{cell::RefCell, env, ffi::OsString, fs, io::Write, rc::Rc};
 
     use ratatui::backend::Backend;
     use ratatui::{buffer::Cell, style::Color};
@@ -277,6 +293,32 @@ mod tests {
 
         fn flush(&mut self) -> io::Result<()> {
             Ok(())
+        }
+    }
+
+    struct EnvRestore {
+        key: &'static str,
+        value: Option<OsString>,
+    }
+
+    impl EnvRestore {
+        fn capture(key: &'static str) -> Self {
+            Self {
+                key,
+                value: env::var_os(key),
+            }
+        }
+    }
+
+    impl Drop for EnvRestore {
+        fn drop(&mut self) {
+            // SAFETY: environment mutation is serialized by lock_test_env.
+            unsafe {
+                match &self.value {
+                    Some(value) => env::set_var(self.key, value),
+                    None => env::remove_var(self.key),
+                }
+            }
         }
     }
 
@@ -427,9 +469,9 @@ mod tests {
     fn backend_writes_render_debug_log_when_enabled() {
         let _lock = lock_test_env();
         let tmp = tempfile::tempdir().expect("tempdir");
-        let previous_home = env::var_os("HOME");
-        let previous_userprofile = env::var_os("USERPROFILE");
-        let previous_debug = env::var_os(RENDER_DEBUG_ENV);
+        let _home = EnvRestore::capture("HOME");
+        let _userprofile = EnvRestore::capture("USERPROFILE");
+        let _debug = EnvRestore::capture(RENDER_DEBUG_ENV);
 
         // SAFETY: environment mutation is serialized by lock_test_env.
         unsafe {
@@ -446,28 +488,12 @@ mod tests {
 
         let log_path = tmp
             .path()
-            .join(".deepseek")
+            .join(".codewhale")
             .join("logs")
             .join("tui-render.log");
         let body = fs::read_to_string(log_path).expect("render debug log");
         assert!(body.contains("frame=1"), "{body}");
         assert!(body.contains("diff_cells=1"), "{body}");
         assert!(body.contains("sample=3:4"), "{body}");
-
-        // SAFETY: environment mutation is serialized by lock_test_env.
-        unsafe {
-            match previous_home {
-                Some(value) => env::set_var("HOME", value),
-                None => env::remove_var("HOME"),
-            }
-            match previous_userprofile {
-                Some(value) => env::set_var("USERPROFILE", value),
-                None => env::remove_var("USERPROFILE"),
-            }
-            match previous_debug {
-                Some(value) => env::set_var(RENDER_DEBUG_ENV, value),
-                None => env::remove_var(RENDER_DEBUG_ENV),
-            }
-        }
     }
 }


### PR DESCRIPTION
Summary
- add opt-in CODEWHALE_TUI_DEBUG=1 render-diff logging to the TUI backend
- append per-frame size, diff cell count, and sampled coordinates to tui-render.log
- default new installs to the existing CodeWhale log directory while preserving legacy .deepseek/logs fallback
- avoid logging cell text/content

Notes
- The synchronized-output wrapping requested in #2085 is already present on main. This PR covers the missing debug-log portion.

Testing
- cargo test -p codewhale-tui tui::color_compat::tests --all-features --locked
- cargo test -p codewhale-tui runtime_log::tests::log_directory --all-features --locked
- cargo check -p codewhale-tui --all-features --locked
- git diff --check

Part of #2085.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an opt-in render-diff debug log (`CODEWHALE_TUI_DEBUG=1`) to the TUI backend and migrates the `log_directory()` fallback from `.deepseek/logs` to `.codewhale/logs` when neither directory exists yet.

- **`runtime_log.rs`**: `log_directory()` is promoted to `pub(crate)`, the default-fallback path is now `.codewhale/logs`, and a new test covers the legacy `.deepseek/logs` detection branch.
- **`color_compat.rs`**: A new `RenderDebugLog` struct is wired into `ColorCompatBackend::draw()`. When the env var is truthy, each frame appends a structured line (frame number, viewport size, diff cell count, up to 24 sampled coordinates) to `tui-render.log` in the existing TUI log directory. Cell text/content is deliberately omitted.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the feature is fully opt-in behind an env var and the log-directory migration is backwards-compatible with existing `.deepseek/logs` installs.

The render-diff logging is gated behind `CODEWHALE_TUI_DEBUG=1`, making it invisible to normal users. The `log_directory()` migration is backward-compatible — existing `.deepseek/logs` directories are detected and preserved. All error paths fail gracefully. The sole concern is log usability across sessions, not correctness.

No files require special attention beyond the session-boundary suggestion on `color_compat.rs`.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/runtime_log.rs | Made `log_directory()` pub(crate), changed fallback path from `.deepseek/logs` to `.codewhale/logs` when neither directory exists, added legacy-directory test, and cleaned up doc comments. |
| crates/tui/src/tui/color_compat.rs | Added opt-in `RenderDebugLog` that appends per-frame size, diff cell count, and sampled coordinates to `tui-render.log`; no session boundary markers written between sessions, making multi-session log analysis difficult. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Env as Environment
    participant Backend as ColorCompatBackend
    participant RDL as RenderDebugLog
    participant LogDir as log_directory()
    participant File as tui-render.log

    Backend->>Env: var("CODEWHALE_TUI_DEBUG")
    Env-->>Backend: "1" (enabled)
    Backend->>LogDir: log_directory()
    LogDir-->>Backend: ~/.codewhale/logs
    Backend->>File: OpenOptions::append(true).open()
    File-->>Backend: "RenderDebugLog { file, frame: 0 }"

    loop Each draw() call
        Backend->>Backend: adapt cell colors
        Backend->>Backend: "self.size() -> viewport"
        Backend->>RDL: "record(viewport, &adapted_cells)"
        RDL->>RDL: "frame += 1, sample first 24 (x,y)"
        RDL->>File: "write frame=N size=WxH diff_cells=M sample=..."
        Backend->>Backend: inner.draw(adapted_cells)
    end
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22codex%2Ffix-2085-tui-render-debug%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Ffix-2085-tui-render-debug%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fcolor_compat.rs%3A198%0AThe%20debug%20log%20appends%20per-frame%20entries%20across%20sessions%20in%20a%20single%20fixed%20file%2C%20but%20nothing%20marks%20where%20one%20session%20ends%20and%20the%20next%20begins.%20The%20frame%20counter%20resets%20to%201%20every%20time%20%60ColorCompatBackend%60%20is%20constructed%2C%20so%20after%20two%20sessions%20the%20log%20contains%20two%20runs%20of%20%60frame%3D1%2C%202%2C%203%2C%20%E2%80%A6%60%20with%20no%20way%20to%20tell%20them%20apart.%20A%20one-line%20session-start%20entry%20with%20a%20timestamp%20and%20PID%20would%20make%20multi-session%20analysis%20straightforward.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20mut%20log%20%3D%20Self%20%7B%20file%2C%20frame%3A%200%20%7D%3B%0A%20%20%20%20%20%20%20%20%2F%2F%20Write%20a%20session-start%20marker%20so%20multi-session%20append%20logs%20are%20navigable.%0A%20%20%20%20%20%20%20%20let%20_%20%3D%20writeln!%28%0A%20%20%20%20%20%20%20%20%20%20%20%20log.file%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22---%20session%20pid%3D%7B%7D%20ts%3D%7B%7D%20---%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20std%3A%3Aprocess%3A%3Aid%28%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20std%3A%3Atime%3A%3ASystemTime%3A%3Anow%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.duration_since%28std%3A%3Atime%3A%3AUNIX_EPOCH%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.unwrap_or_default%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.as_secs%28%29%0A%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%20%20Some%28log%29%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fcolor_compat.rs%3A198%0AThe%20debug%20log%20appends%20per-frame%20entries%20across%20sessions%20in%20a%20single%20fixed%20file%2C%20but%20nothing%20marks%20where%20one%20session%20ends%20and%20the%20next%20begins.%20The%20frame%20counter%20resets%20to%201%20every%20time%20%60ColorCompatBackend%60%20is%20constructed%2C%20so%20after%20two%20sessions%20the%20log%20contains%20two%20runs%20of%20%60frame%3D1%2C%202%2C%203%2C%20%E2%80%A6%60%20with%20no%20way%20to%20tell%20them%20apart.%20A%20one-line%20session-start%20entry%20with%20a%20timestamp%20and%20PID%20would%20make%20multi-session%20analysis%20straightforward.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20mut%20log%20%3D%20Self%20%7B%20file%2C%20frame%3A%200%20%7D%3B%0A%20%20%20%20%20%20%20%20%2F%2F%20Write%20a%20session-start%20marker%20so%20multi-session%20append%20logs%20are%20navigable.%0A%20%20%20%20%20%20%20%20let%20_%20%3D%20writeln!%28%0A%20%20%20%20%20%20%20%20%20%20%20%20log.file%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22---%20session%20pid%3D%7B%7D%20ts%3D%7B%7D%20---%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20std%3A%3Aprocess%3A%3Aid%28%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20std%3A%3Atime%3A%3ASystemTime%3A%3Anow%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.duration_since%28std%3A%3Atime%3A%3AUNIX_EPOCH%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.unwrap_or_default%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.as_secs%28%29%0A%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%20%20Some%28log%29%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2332&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fcolor_compat.rs%3A198%0AThe%20debug%20log%20appends%20per-frame%20entries%20across%20sessions%20in%20a%20single%20fixed%20file%2C%20but%20nothing%20marks%20where%20one%20session%20ends%20and%20the%20next%20begins.%20The%20frame%20counter%20resets%20to%201%20every%20time%20%60ColorCompatBackend%60%20is%20constructed%2C%20so%20after%20two%20sessions%20the%20log%20contains%20two%20runs%20of%20%60frame%3D1%2C%202%2C%203%2C%20%E2%80%A6%60%20with%20no%20way%20to%20tell%20them%20apart.%20A%20one-line%20session-start%20entry%20with%20a%20timestamp%20and%20PID%20would%20make%20multi-session%20analysis%20straightforward.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20mut%20log%20%3D%20Self%20%7B%20file%2C%20frame%3A%200%20%7D%3B%0A%20%20%20%20%20%20%20%20%2F%2F%20Write%20a%20session-start%20marker%20so%20multi-session%20append%20logs%20are%20navigable.%0A%20%20%20%20%20%20%20%20let%20_%20%3D%20writeln!%28%0A%20%20%20%20%20%20%20%20%20%20%20%20log.file%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22---%20session%20pid%3D%7B%7D%20ts%3D%7B%7D%20---%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20std%3A%3Aprocess%3A%3Aid%28%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20std%3A%3Atime%3A%3ASystemTime%3A%3Anow%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.duration_since%28std%3A%3Atime%3A%3AUNIX_EPOCH%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.unwrap_or_default%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.as_secs%28%29%0A%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%20%20Some%28log%29%0A%60%60%60%0A%0A&pr=2332&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix(tui): keep render debug logs in code..."](https://github.com/hmbown/codewhale/commit/c2e29114d69ebcd104c7552b915a55ede2bd3721) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34490659)</sub>

<!-- /greptile_comment -->