### PR TITLE
feat(hooks): add UnixSocketHookSink for real-time event streaming

### DIFF
--- a/crates/app-server/src/lib.rs
+++ b/crates/app-server/src/lib.rs
@@ -13,7 +13,7 @@ use codewhale_agent::ModelRegistry;
 use codewhale_config::{CliRuntimeOverrides, ConfigStore};
 use codewhale_core::Runtime;
 use codewhale_execpolicy::ExecPolicyEngine;
-use codewhale_hooks::{HookDispatcher, JsonlHookSink, StdoutHookSink};
+use codewhale_hooks::{HookDispatcher, JsonlHookSink, StdoutHookSink, UnixSocketHookSink};
 use codewhale_mcp::McpManager;
 use codewhale_protocol::{
     AppRequest, AppResponse, PromptRequest, PromptResponse, ThreadRequest, ThreadResponse,
@@ -313,6 +313,16 @@ fn build_state(config_path: Option<PathBuf>, auth_token: Option<String>) -> Resu
         .and_then(|p| p.parent().map(|parent| parent.join("events.jsonl")))
         .unwrap_or_else(|| PathBuf::from(".deepseek/events.jsonl"));
     hooks.add_sink(Arc::new(JsonlHookSink::new(hook_log_path)));
+
+    // Unix socket sink for external monitoring (e.g. custom dashboards).
+    // Configure via [hooks] in config.toml: sink = "unix-socket"
+    if let Some(ref hooks_cfg) = config.hooks {
+        if hooks_cfg.sink.as_deref() == Some("unix-socket") {
+            let socket_path = hooks_cfg.socket_path.clone()
+                .unwrap_or_else(|| "/tmp/codewhale-island.sock".to_string());
+            hooks.add_sink(Arc::new(UnixSocketHookSink::new(socket_path.into())));
+        }
+    }
 
     let runtime = Runtime::new(
         config.clone(),

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -238,8 +238,34 @@ pub struct ConfigToml {
     /// applies the defaults documented in [`LspConfigToml`].
     #[serde(default)]
     pub lsp: Option<LspConfigToml>,
+    /// Hook sink configuration. When absent, the runtime defaults to
+    /// stdout + JSONL sinks only (current behaviour).
+    #[serde(default)]
+    pub hooks: Option<HooksToml>,
     #[serde(flatten)]
     pub extras: BTreeMap<String, toml::Value>,
+}
+
+
+/// On-disk schema for the `[hooks]` table. Controls which sinks receive
+/// lifecycle events from the engine. See `config.example.toml` for examples.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct HooksToml {
+    /// Sink type: "stdout", "jsonl", "webhook", or "unix-socket".
+    /// When unset, no additional sink is created beyond the runtime defaults.
+    #[serde(default)]
+    pub sink: Option<String>,
+    /// Unix domain socket path used when `sink = "unix-socket"`.
+    /// Defaults to `/tmp/codewhale-island.sock`.
+    #[serde(default)]
+    pub socket_path: Option<String>,
+    /// JSONL file path used when `sink = "jsonl"`.
+    /// Defaults to `events.jsonl` in the config directory.
+    #[serde(default)]
+    pub jsonl_path: Option<String>,
+    /// Webhook URL used when `sink = "webhook"`.
+    #[serde(default)]
+    pub webhook_url: Option<String>,
 }
 
 /// On-disk schema for the `[skills]` table (#140). See `config.example.toml`

--- a/crates/hooks/src/lib.rs
+++ b/crates/hooks/src/lib.rs
@@ -152,6 +152,55 @@ impl HookSink for WebhookHookSink {
     }
 }
 
+/// A [`HookSink`] that sends events over a Unix domain socket.
+///
+/// Each event is serialized as a single JSON line (`{"at": "...", "event": {...}}\n`)
+/// and written to the socket. If the socket is not available (listener not running),
+/// the event is silently dropped — hook sinks are best-effort observability, not
+/// control flow.
+///
+/// On non-Unix platforms this struct exists but its [`HookSink::emit`] is a no-op.
+#[derive(Debug, Clone)]
+pub struct UnixSocketHookSink {
+    path: PathBuf,
+}
+
+impl UnixSocketHookSink {
+    /// Create a sink that connects to the Unix domain socket at `path`.
+    pub fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+}
+
+#[async_trait]
+impl HookSink for UnixSocketHookSink {
+    #[cfg(unix)]
+    async fn emit(&self, event: &HookEvent) -> Result<()> {
+        let mut stream = match tokio::net::UnixStream::connect(&self.path).await {
+            Ok(s) => s,
+            Err(_) => return Ok(()), // listener not running, skip silently
+        };
+        let payload = json!({
+            "at": Utc::now().to_rfc3339(),
+            "event": event
+        });
+        let mut line =
+            serde_json::to_string(&payload).context("failed to encode hook event")?;
+        line.push('\n');
+        stream
+            .write_all(line.as_bytes())
+            .await
+            .context("failed to write to unix socket")?;
+        Ok(())
+    }
+
+    #[cfg(not(unix))]
+    async fn emit(&self, _event: &HookEvent) -> Result<()> {
+        // Unix sockets not available on this platform — no-op.
+        Ok(())
+    }
+}
+
 #[derive(Default, Clone)]
 pub struct HookDispatcher {
     sinks: Vec<Arc<dyn HookSink>>,
@@ -253,6 +302,56 @@ mod tests {
             })]
         );
         assert_eq!(second.events(), first.events());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn unix_socket_sink_skips_when_listener_absent() {
+        let sink = UnixSocketHookSink::new(
+            std::env::temp_dir().join("codewhale-test-nonexistent.sock"),
+        );
+        let result = sink
+            .emit(&HookEvent::ResponseStart {
+                response_id: "resp-1".to_string(),
+            })
+            .await;
+        // Should not error — listener absent is a silent skip.
+        assert!(result.is_ok());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn unix_socket_sink_sends_event_to_listener() {
+        use tokio::io::AsyncBufReadExt;
+        use tokio::net::UnixListener;
+
+        let socket_path = unique_temp_dir("unix_sink").join("test.sock");
+        let _ = std::fs::remove_file(&socket_path);
+
+        let listener = UnixListener::bind(&socket_path).expect("bind");
+        let sink = UnixSocketHookSink::new(socket_path.clone());
+
+        let handle = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("accept");
+            let mut reader = tokio::io::BufReader::new(stream);
+            let mut line = String::new();
+            reader.read_line(&mut line).await.expect("read_line");
+            line
+        });
+
+        sink.emit(&HookEvent::ResponseStart {
+            response_id: "resp-42".to_string(),
+        })
+        .await
+        .expect("emit");
+
+        let received = handle.await.expect("join");
+        let parsed: Value = serde_json::from_str(&received).expect("parse");
+        assert_eq!(parsed["event"]["type"], "response_start");
+        assert_eq!(parsed["event"]["response_id"], "resp-42");
+        assert!(parsed["at"].as_str().is_some());
+
+        let _ = std::fs::remove_file(&socket_path);
     }
 
     #[derive(Default)]


### PR DESCRIPTION
## Summary

Adds a new `UnixSocketHookSink` to the hooks crate, enabling real-time lifecycle event streaming over a Unix domain socket. This extends the hook system beyond stdout / JSONL file / webhook to support low-latency local IPC — useful for external monitoring dashboards, notification systems, and tool integration without polling files.

## Motivation

The current hook sinks all have trade-offs:

| Sink | Latency | Use Case |
|------|---------|----------|
| `StdoutHookSink` | real-time | mixed with other output, hard to parse reliably |
| `JsonlHookSink` | real-time (per-event fsync) | durable audit log, but requires file polling for consumers |
| `WebhookHookSink` | network round-trip | remote monitoring, adds HTTP overhead |

None of them offer **local, push-based, near-zero-overhead** event delivery. A Unix socket fills this gap — connect, receive JSON lines, disconnect. No filesystem polling. No HTTP server. No mixed stdout.

## What this PR does

1. **`crates/hooks/src/lib.rs`**: Adds `UnixSocketHookSink` implementing `HookSink`
   - Connects to a Unix domain socket on each `emit` (stateless)
   - Sends `{"at": "...", "event": {...}}\n` JSON lines
   - **Silently skips** when the listener is not running — hooks are observability, not control flow
   - `#[cfg(unix)]`-guarded; no-op on non-Unix platforms
   - Includes two tests: skip-when-absent, send-to-listener

2. **`crates/config/src/lib.rs`**: Adds `[hooks]` config section (`HooksToml`)
   ```
   [hooks]
   sink = "unix-socket"
   socket_path = "/tmp/codewhale-island.sock"
   ```

3. **`crates/app-server/src/lib.rs`**: Wires up the sink based on config
   - When `[hooks] sink = "unix-socket"`, adds `UnixSocketHookSink` to the dispatcher
   - Defaults socket path to `/tmp/codewhale-island.sock`

## Design Decisions

- **Connect-per-event**: Simpler than persistent connection management. For a local Unix socket, connect overhead is negligible (< 0.1ms).
- **Silent skip on failure**: If the listener is not running, events are dropped rather than erroring. This keeps the hook system non-critical.
- **Reuses existing wire format**: Same `{"at": "...", "event": {...}}` envelope as JsonlHookSink and WebhookHookSink.
- **Config-driven**: Zero code changes needed to enable — just add `[hooks]` to config.toml.

## Future Possibilities

This sink opens the door to:
- External approval interception (listener responds to `ApprovalLifecycle` events)
- Real-time cost/token dashboards
- CI/CD pipeline integration (stream tool execution for audit)
- Desktop notification bridges
- Agent-to-agent communication patterns

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a `UnixSocketHookSink` that delivers lifecycle events as JSON lines over a Unix domain socket, wired up via a new `[hooks]` TOML config section. The sink uses a connect-per-event model and silently drops events when no listener is present.

- **`crates/hooks/src/lib.rs`**: New `UnixSocketHookSink` with `#[cfg(unix)]`-guarded `emit`; connection errors are silently swallowed but write errors (e.g. broken-pipe when a listener crashes mid-write) are propagated, inconsistent with the stated best-effort design.
- **`crates/config/src/lib.rs`**: Adds `HooksToml` and a `hooks` field to `ConfigToml`; `jsonl_path` and `webhook_url` fields are declared but never consumed by `app-server`.
- **`crates/app-server/src/lib.rs`**: Reads the new config and conditionally adds the sink; only the exact string `"unix-socket"` is recognised — all other sink values are silently ignored.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The new sink code is safe to run but has several open correctness issues across all three changed files that should be resolved before merging.

The write-error propagation in `UnixSocketHookSink` is inconsistent with the silent-skip contract. The test helper `unique_temp_dir` returns a non-existent directory path, causing `UnixListener::bind` to fail with ENOENT. The config struct declares `jsonl_path` and `webhook_url` that are parsed but never acted on, and any `sink` value other than `"unix-socket"` is silently ignored in `app-server`. Together these mean the feature doesn't fully behave as documented and the new socket test is broken on most environments.

All three changed files need attention: `crates/hooks/src/lib.rs` for the error-handling inconsistency and test directory bug, `crates/config/src/lib.rs` for the unused declared fields, and `crates/app-server/src/lib.rs` for the silent-ignore behaviour on unrecognised sink values.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/hooks/src/lib.rs | Adds `UnixSocketHookSink` with connect-per-event design and `#[cfg(unix)]`-guarded emit; write errors are propagated while connection errors are silently swallowed (inconsistent), and the new test uses `unique_temp_dir` whose directory is never created before `UnixListener::bind`. |
| crates/config/src/lib.rs | Adds `HooksToml` struct and `hooks` field to `ConfigToml`; serde attribute placement keeps `#[serde(flatten)]` correctly on `extras`, but `jsonl_path` and `webhook_url` fields are declared yet never consumed by `app-server`. |
| crates/app-server/src/lib.rs | Wires `UnixSocketHookSink` from config; only the `"unix-socket"` string is handled — any other configured value is silently ignored with no warning to the user. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Engine as Engine (Runtime)
    participant Dispatcher as HookDispatcher
    participant Sink as UnixSocketHookSink
    participant OS as OS / Unix Socket
    participant Listener as External Listener

    Engine->>Dispatcher: emit(HookEvent)
    loop for each sink
        Dispatcher->>Sink: emit(event)
        Sink->>OS: UnixStream::connect(path)
        alt Listener not running
            OS-->>Sink: Err (ENOENT / ECONNREFUSED)
            Sink-->>Dispatcher: Ok(()) [silent skip]
        else Listener running
            OS-->>Sink: Ok(stream)
            Sink->>Sink: serde_json::to_string(payload)
            Sink->>OS: write_all(json_line + "\n")
            alt Write succeeds
                OS->>Listener: JSON line delivered
                Sink-->>Dispatcher: Ok(())
            else Write fails (broken pipe)
                OS-->>Sink: Err
                Sink-->>Dispatcher: Err [propagated — inconsistent with silent-skip design]
            end
            Sink->>OS: stream dropped → FIN
        end
        Dispatcher->>Dispatcher: log error and continue (if Err)
    end
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feature%2Funix-socket-hook-sink%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Funix-socket-hook-sink%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Fhooks%2Fsrc%2Flib.rs%3A190-193%0AWrite%20errors%20are%20propagated%20while%20connection%20errors%20are%20silently%20swallowed%2C%20which%20is%20inconsistent%20with%20the%20%22best-effort%2C%20silently%20skip%22%20design%20stated%20in%20the%20PR.%20If%20the%20listener%20connects%20but%20closes%20the%20connection%20before%20the%20write%20completes%20%28e.g.%2C%20it%20crashes%20or%20restarts%20mid-event%29%2C%20%60write_all%60%20returns%20a%20broken-pipe%20error%20that%20bubbles%20up%20through%20%60emit%60.%20The%20%60HookDispatcher%60%20will%20log%20this%20as%20a%20sink%20failure%20even%20though%20this%20is%20a%20normal%20%22listener%20went%20away%22%20scenario%20%E2%80%94%20the%20same%20case%20the%20connection-error%20branch%20intentionally%20hides.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20if%20stream.write_all%28line.as_bytes%28%29%29.await.is_err%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20Ok%28%28%29%29%3B%20%2F%2F%20listener%20disappeared%20mid-write%2C%20skip%20silently%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Fhooks%2Fsrc%2Flib.rs%3A190-193%0AWrite%20errors%20are%20propagated%20while%20connection%20errors%20are%20silently%20swallowed%2C%20which%20is%20inconsistent%20with%20the%20%22best-effort%2C%20silently%20skip%22%20design%20stated%20in%20the%20PR.%20If%20the%20listener%20connects%20but%20closes%20the%20connection%20before%20the%20write%20completes%20%28e.g.%2C%20it%20crashes%20or%20restarts%20mid-event%29%2C%20%60write_all%60%20returns%20a%20broken-pipe%20error%20that%20bubbles%20up%20through%20%60emit%60.%20The%20%60HookDispatcher%60%20will%20log%20this%20as%20a%20sink%20failure%20even%20though%20this%20is%20a%20normal%20%22listener%20went%20away%22%20scenario%20%E2%80%94%20the%20same%20case%20the%20connection-error%20branch%20intentionally%20hides.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20if%20stream.write_all%28line.as_bytes%28%29%29.await.is_err%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20Ok%28%28%29%29%3B%20%2F%2F%20listener%20disappeared%20mid-write%2C%20skip%20silently%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2333&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Fhooks%2Fsrc%2Flib.rs%3A190-193%0AWrite%20errors%20are%20propagated%20while%20connection%20errors%20are%20silently%20swallowed%2C%20which%20is%20inconsistent%20with%20the%20%22best-effort%2C%20silently%20skip%22%20design%20stated%20in%20the%20PR.%20If%20the%20listener%20connects%20but%20closes%20the%20connection%20before%20the%20write%20completes%20%28e.g.%2C%20it%20crashes%20or%20restarts%20mid-event%29%2C%20%60write_all%60%20returns%20a%20broken-pipe%20error%20that%20bubbles%20up%20through%20%60emit%60.%20The%20%60HookDispatcher%60%20will%20log%20this%20as%20a%20sink%20failure%20even%20though%20this%20is%20a%20normal%20%22listener%20went%20away%22%20scenario%20%E2%80%94%20the%20same%20case%20the%20connection-error%20branch%20intentionally%20hides.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20if%20stream.write_all%28line.as_bytes%28%29%29.await.is_err%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20Ok%28%28%29%29%3B%20%2F%2F%20listener%20disappeared%20mid-write%2C%20skip%20silently%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A&pr=2333&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["feat(hooks): add UnixSocketHookSink for ..."](https://github.com/hmbown/codewhale/commit/30a09b4c128e6cdbc8aea033a043f562e370ad96) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34491025)</sub>

<!-- /greptile_comment -->