### PR TITLE
feat: add /cache stats — prefix hash/drift exposure and cache-hit summary

### DIFF
--- a/crates/tui/src/commands/debug.rs
+++ b/crates/tui/src/commands/debug.rs
@@ -310,14 +310,24 @@ fn format_cache_stats(app: &App) -> String {
     if history.is_empty() {
         out.push_str("  No turn telemetry recorded yet.\n");
     } else {
+        // Aggregate only cache-aware turns; skip turns where the provider
+        // did not report cache telemetry (cache_hit_tokens is None).
+        // When cache_miss_tokens is None, infer it as
+        //   input_tokens − cache_hit_tokens  (matches /cache table logic).
+        let mut turns = 0u64;
         let (hit, miss, input) = app.session.turn_cache_history.iter().fold(
             (0u64, 0u64, 0u64),
             |(hit, miss, input), rec| {
-                (
-                    hit + u64::from(rec.cache_hit_tokens.unwrap_or(0)),
-                    miss + u64::from(rec.cache_miss_tokens.unwrap_or(0)),
-                    input + u64::from(rec.input_tokens),
-                )
+                let Some(hit_tokens) = rec.cache_hit_tokens else {
+                    return (hit, miss, input);
+                };
+                let h = u64::from(hit_tokens);
+                let m = u64::from(
+                    rec.cache_miss_tokens
+                        .unwrap_or(rec.input_tokens.saturating_sub(hit_tokens)),
+                );
+                turns += 1;
+                (hit + h, miss + m, input + u64::from(rec.input_tokens))
             },
         );
         let total_cache = hit + miss;
@@ -326,7 +336,7 @@ fn format_cache_stats(app: &App) -> String {
         } else {
             0.0
         };
-        out.push_str(&format!("  Turns recorded: {}\n", history.len()));
+        out.push_str(&format!("  Turns recorded: {turns}\n"));
         out.push_str(&format!(
             "  Cache hit tokens:  {hit} ({avg_pct:.1}% of {total_cache} cache-aware tokens)\n",
             hit = format_tokens(hit),

--- a/crates/tui/src/commands/debug.rs
+++ b/crates/tui/src/commands/debug.rs
@@ -288,7 +288,11 @@ fn format_cache_stats(app: &App) -> String {
                 out.push_str(&format!(
                     "               ({change} change{plural} detected)\n",
                     change = app.prefix_change_count,
-                    plural = if app.prefix_change_count == 1 { "" } else { "s" }
+                    plural = if app.prefix_change_count == 1 {
+                        ""
+                    } else {
+                        "s"
+                    }
                 ));
             } else {
                 out.push_str("  Drift:       none (hash stable)\n");
@@ -1534,7 +1538,10 @@ mod tests {
         let result = cache(&mut app, Some("stats"));
         let msg = result.message.expect("cache stats produces a message");
         assert!(msg.contains("Cache Stats"), "got: {msg}");
-        assert!(msg.contains("unknown (no checks recorded yet)"), "got: {msg}");
+        assert!(
+            msg.contains("unknown (no checks recorded yet)"),
+            "got: {msg}"
+        );
         assert!(msg.contains("Pinned hash: unavailable"), "got: {msg}");
         assert!(msg.contains("No turn telemetry recorded yet"), "got: {msg}");
     }
@@ -1554,7 +1561,10 @@ mod tests {
         assert!(msg.contains("Stability: 100%"), "got: {msg}");
         assert!(msg.contains("stable (no prefix changes"), "got: {msg}");
         assert!(msg.contains("Pinned hash: a1b2c3d4e5f6"), "got: {msg}");
-        assert!(msg.contains("Drift:       none (hash stable)"), "got: {msg}");
+        assert!(
+            msg.contains("Drift:       none (hash stable)"),
+            "got: {msg}"
+        );
     }
 
     #[test]
@@ -1563,9 +1573,11 @@ mod tests {
         app.prefix_stability_pct = Some(67);
         app.prefix_checks_total = 3;
         app.prefix_change_count = 1;
-        app.last_prefix_change_desc = Some("prefix cache invalidated: system prompt changed".to_string());
-        app.last_pinned_prefix_hash =
-            Some("deadbeef0000deadbeef0000deadbeef0000deadbeef0000deadbeef0000deadbeef".to_string());
+        app.last_prefix_change_desc =
+            Some("prefix cache invalidated: system prompt changed".to_string());
+        app.last_pinned_prefix_hash = Some(
+            "deadbeef0000deadbeef0000deadbeef0000deadbeef0000deadbeef0000deadbeef".to_string(),
+        );
 
         let result = cache(&mut app, Some("stats"));
         let msg = result.message.expect("cache stats produces a message");
@@ -1582,7 +1594,8 @@ mod tests {
         let mut app = create_test_app();
         app.prefix_stability_pct = Some(100);
         app.prefix_checks_total = 1;
-        app.last_pinned_prefix_hash = Some("abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234".to_string());
+        app.last_pinned_prefix_hash =
+            Some("abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234".to_string());
 
         app.push_turn_cache_record(TurnCacheRecord {
             input_tokens: 10_000,
@@ -1614,7 +1627,8 @@ mod tests {
         let mut app = create_test_app();
         app.prefix_stability_pct = Some(100);
         app.prefix_checks_total = 1;
-        app.last_pinned_prefix_hash = Some("abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234".to_string());
+        app.last_pinned_prefix_hash =
+            Some("abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234".to_string());
 
         app.push_turn_cache_record(TurnCacheRecord {
             input_tokens: 10_000,

--- a/crates/tui/src/commands/debug.rs
+++ b/crates/tui/src/commands/debug.rs
@@ -145,6 +145,9 @@ pub fn cache(app: &mut App, arg: Option<&str>) -> CommandResult {
     if matches!(arg, Some("warmup")) {
         return CommandResult::action(AppAction::CacheWarmup);
     }
+    if matches!(arg, Some("stats")) {
+        return CommandResult::message(format_cache_stats(app));
+    }
 
     let want = arg.and_then(|s| s.parse::<usize>().ok()).unwrap_or(10);
     let cap = app.session.turn_cache_history.len();
@@ -231,6 +234,126 @@ fn format_cache_inspect(app: &mut App) -> String {
     }
     app.session.last_cache_inspection = Some(inspection);
     out
+}
+
+/// Render a prefix-cache stability and health summary for `/cache stats`.
+///
+/// Surfaces the current prefix fingerprint, stability ratio, change history,
+/// and an aggregated cache-hit summary from per-turn telemetry.  When the
+/// prefix has changed, a prominent warning is included so users can
+/// correlate cache misses with prefix drift.
+fn format_cache_stats(app: &App) -> String {
+    let mut out = String::new();
+    out.push_str("Cache Stats\n");
+
+    // ── Prefix stability ──────────────────────────────────────────────
+    out.push_str("\n── Prefix Stability\n");
+    match app.prefix_stability_pct {
+        Some(pct) => {
+            let checks = app.prefix_checks_total;
+            let changes = app.prefix_change_count;
+            let stable_checks = checks.saturating_sub(changes);
+
+            if changes == 0 {
+                out.push_str(&format!(
+                    "  Stability: {pct}% ({stable_checks}/{checks} checks)\n"
+                ));
+                out.push_str("  Status:    stable (no prefix changes this session)\n");
+            } else {
+                out.push_str(&format!(
+                    "  Stability: {pct}% ({stable_checks}/{checks} checks, {changes} change{})\n",
+                    if changes == 1 { "" } else { "s" }
+                ));
+                out.push_str("  Status:    WARNING — prefix has changed\n");
+                if let Some(ref desc) = app.last_prefix_change_desc {
+                    out.push_str(&format!("  Last change: {desc}\n"));
+                }
+            }
+        }
+        None => {
+            out.push_str("  Stability: unknown (no checks recorded yet)\n");
+            out.push_str("  Run a turn first to collect prefix stability data.\n");
+        }
+    }
+
+    // ── Prefix fingerprint ────────────────────────────────────────────
+    out.push_str("\n── Prefix Fingerprint\n");
+    match &app.last_pinned_prefix_hash {
+        Some(hash) => {
+            out.push_str(&format!("  Pinned hash: {hash}\n"));
+            let short = if hash.len() >= 12 { &hash[..12] } else { hash };
+            out.push_str(&format!("  Short id:    {short}\n"));
+            if app.prefix_change_count > 0 {
+                out.push_str("  Drift:       WARNING — hash has changed during this session\n");
+                out.push_str(&format!(
+                    "               ({change} change{plural} detected)\n",
+                    change = app.prefix_change_count,
+                    plural = if app.prefix_change_count == 1 { "" } else { "s" }
+                ));
+            } else {
+                out.push_str("  Drift:       none (hash stable)\n");
+            }
+        }
+        None => {
+            out.push_str("  Pinned hash: unavailable\n");
+            out.push_str("  Run a turn first, or use /cache inspect.\n");
+        }
+    }
+
+    // ── Cache hit-rate summary ────────────────────────────────────────
+    out.push_str("\n── Cache Hit Rate\n");
+    let history = &app.session.turn_cache_history;
+    if history.is_empty() {
+        out.push_str("  No turn telemetry recorded yet.\n");
+    } else {
+        let (hit, miss, input) = app.session.turn_cache_history.iter().fold(
+            (0u64, 0u64, 0u64),
+            |(hit, miss, input), rec| {
+                (
+                    hit + u64::from(rec.cache_hit_tokens.unwrap_or(0)),
+                    miss + u64::from(rec.cache_miss_tokens.unwrap_or(0)),
+                    input + u64::from(rec.input_tokens),
+                )
+            },
+        );
+        let total_cache = hit + miss;
+        let avg_pct = if total_cache > 0 {
+            (hit as f64 / total_cache as f64 * 100.0).clamp(0.0, 100.0)
+        } else {
+            0.0
+        };
+        out.push_str(&format!("  Turns recorded: {}\n", history.len()));
+        out.push_str(&format!(
+            "  Cache hit tokens:  {hit} ({avg_pct:.1}% of {total_cache} cache-aware tokens)\n",
+            hit = format_tokens(hit),
+            total_cache = format_tokens(total_cache),
+        ));
+        out.push_str(&format!(
+            "  Cache miss tokens: {miss}\n",
+            miss = format_tokens(miss),
+        ));
+        out.push_str(&format!(
+            "  Total input tokens: {input}\n",
+            input = format_tokens(input),
+        ));
+        if avg_pct < 80.0 {
+            out.push_str("  NOTE: cache hit rate is low (< 80%). Check prefix stability above or consider /compact.\n");
+        }
+    }
+
+    out
+}
+
+/// Formats a u64 token count with a compact suffix: K for thousands,
+/// M for millions. Never returns scientific notation.
+fn format_tokens(n: u64) -> String {
+    if n >= 1_000_000 {
+        format!("{:.1}M", n as f64 / 1_000_000.0)
+    } else if n >= 1_000 {
+        format!("{:.1}K", n as f64 / 1_000.0)
+    } else {
+        n.to_string()
+    }
 }
 
 fn format_static_prefix_status(
@@ -1401,6 +1524,126 @@ mod tests {
             &app.api_messages[2].content[0],
             ContentBlock::ToolResult { tool_use_id, .. } if tool_use_id == "call-a"
         ));
+    }
+
+    // ── /cache stats tests ──────────────────────────────────────────────
+
+    #[test]
+    fn cache_stats_no_data_before_first_turn() {
+        let mut app = create_test_app();
+        let result = cache(&mut app, Some("stats"));
+        let msg = result.message.expect("cache stats produces a message");
+        assert!(msg.contains("Cache Stats"), "got: {msg}");
+        assert!(msg.contains("unknown (no checks recorded yet)"), "got: {msg}");
+        assert!(msg.contains("Pinned hash: unavailable"), "got: {msg}");
+        assert!(msg.contains("No turn telemetry recorded yet"), "got: {msg}");
+    }
+
+    #[test]
+    fn cache_stats_shows_stable_prefix_with_hash() {
+        let mut app = create_test_app();
+        app.prefix_stability_pct = Some(100);
+        app.prefix_checks_total = 5;
+        app.prefix_change_count = 0;
+        app.last_pinned_prefix_hash =
+            Some("a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2".to_string());
+
+        let result = cache(&mut app, Some("stats"));
+        let msg = result.message.expect("cache stats produces a message");
+
+        assert!(msg.contains("Stability: 100%"), "got: {msg}");
+        assert!(msg.contains("stable (no prefix changes"), "got: {msg}");
+        assert!(msg.contains("Pinned hash: a1b2c3d4e5f6"), "got: {msg}");
+        assert!(msg.contains("Drift:       none (hash stable)"), "got: {msg}");
+    }
+
+    #[test]
+    fn cache_stats_warns_on_prefix_change() {
+        let mut app = create_test_app();
+        app.prefix_stability_pct = Some(67);
+        app.prefix_checks_total = 3;
+        app.prefix_change_count = 1;
+        app.last_prefix_change_desc = Some("prefix cache invalidated: system prompt changed".to_string());
+        app.last_pinned_prefix_hash =
+            Some("deadbeef0000deadbeef0000deadbeef0000deadbeef0000deadbeef0000deadbeef".to_string());
+
+        let result = cache(&mut app, Some("stats"));
+        let msg = result.message.expect("cache stats produces a message");
+
+        assert!(msg.contains("Stability: 67%"), "got: {msg}");
+        assert!(msg.contains("WARNING — prefix has changed"), "got: {msg}");
+        assert!(msg.contains("system prompt changed"), "got: {msg}");
+        assert!(msg.contains("Drift:       WARNING"), "got: {msg}");
+        assert!(msg.contains("1 change detected"), "got: {msg}");
+    }
+
+    #[test]
+    fn cache_stats_shows_cache_hit_summary() {
+        let mut app = create_test_app();
+        app.prefix_stability_pct = Some(100);
+        app.prefix_checks_total = 1;
+        app.last_pinned_prefix_hash = Some("abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234".to_string());
+
+        app.push_turn_cache_record(TurnCacheRecord {
+            input_tokens: 10_000,
+            output_tokens: 1_000,
+            cache_hit_tokens: Some(8_000),
+            cache_miss_tokens: Some(2_000),
+            reasoning_replay_tokens: None,
+            recorded_at: Instant::now(),
+        });
+        app.push_turn_cache_record(TurnCacheRecord {
+            input_tokens: 5_000,
+            output_tokens: 500,
+            cache_hit_tokens: Some(4_500),
+            cache_miss_tokens: Some(500),
+            reasoning_replay_tokens: None,
+            recorded_at: Instant::now(),
+        });
+
+        let result = cache(&mut app, Some("stats"));
+        let msg = result.message.expect("cache stats produces a message");
+
+        assert!(msg.contains("Turns recorded: 2"), "got: {msg}");
+        // Total: 12,500 hit out of 15,000 cache-aware = 83.3%
+        assert!(msg.contains("83.3%"), "got: {msg}");
+    }
+
+    #[test]
+    fn cache_stats_low_hit_rate_shows_note() {
+        let mut app = create_test_app();
+        app.prefix_stability_pct = Some(100);
+        app.prefix_checks_total = 1;
+        app.last_pinned_prefix_hash = Some("abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234".to_string());
+
+        app.push_turn_cache_record(TurnCacheRecord {
+            input_tokens: 10_000,
+            output_tokens: 1_000,
+            cache_hit_tokens: Some(1_000),
+            cache_miss_tokens: Some(9_000),
+            reasoning_replay_tokens: None,
+            recorded_at: Instant::now(),
+        });
+
+        let result = cache(&mut app, Some("stats"));
+        let msg = result.message.expect("cache stats produces a message");
+
+        // 10% hit rate → below 80% threshold
+        assert!(msg.contains("10.0%"), "got: {msg}");
+        assert!(
+            msg.contains("cache hit rate is low"),
+            "should show low-hit-rate advisory, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn format_tokens_handles_all_scales() {
+        assert_eq!(format_tokens(0), "0");
+        assert_eq!(format_tokens(999), "999");
+        assert_eq!(format_tokens(1_000), "1.0K");
+        assert_eq!(format_tokens(15_500), "15.5K");
+        assert_eq!(format_tokens(1_000_000), "1.0M");
+        assert_eq!(format_tokens(2_500_000), "2.5M");
     }
 }
 

--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -543,7 +543,7 @@ pub const COMMANDS: &[CommandInfo] = &[
     CommandInfo {
         name: "cache",
         aliases: &[],
-        usage: "/cache [count|inspect|warmup]",
+        usage: "/cache [count|inspect|stats|warmup]",
         description_id: MessageId::CmdCacheDescription,
     },
 ];

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -247,6 +247,10 @@ impl Engine {
                 let system_text =
                     crate::prefix_cache::system_prompt_text(self.session.system_prompt.as_ref());
                 let tools_ref: Option<&[crate::models::Tool]> = active_tools.as_deref();
+                let pinned_hash = pm
+                    .pinned_fingerprint()
+                    .map(|fp| fp.combined_sha256.clone())
+                    .unwrap_or_default();
                 match pm.check_and_update(&system_text, tools_ref) {
                     Err(change) => {
                         tracing::debug!(
@@ -262,6 +266,7 @@ impl Engine {
                                 tools_changed: change.tools_changed,
                                 stability_pct: (pm.stability_ratio() * 100.0).round() as u32,
                                 changed: true,
+                                pinned_combined_hash: pinned_hash,
                             })
                             .await;
                     }
@@ -275,6 +280,7 @@ impl Engine {
                                 tools_changed: false,
                                 stability_pct: (pm.stability_ratio() * 100.0).round() as u32,
                                 changed: false,
+                                pinned_combined_hash: pinned_hash,
                             })
                             .await;
                     }

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -247,12 +247,12 @@ impl Engine {
                 let system_text =
                     crate::prefix_cache::system_prompt_text(self.session.system_prompt.as_ref());
                 let tools_ref: Option<&[crate::models::Tool]> = active_tools.as_deref();
-                let pinned_hash = pm
-                    .pinned_fingerprint()
-                    .map(|fp| fp.combined_sha256.clone())
-                    .unwrap_or_default();
                 match pm.check_and_update(&system_text, tools_ref) {
                     Err(change) => {
+                        let pinned_hash = pm
+                            .pinned_fingerprint()
+                            .map(|fp| fp.combined_sha256.clone())
+                            .unwrap_or_default();
                         tracing::debug!(
                             target: "prefix_cache",
                             "{}",
@@ -271,6 +271,10 @@ impl Engine {
                             .await;
                     }
                     Ok(_) => {
+                        let pinned_hash = pm
+                            .pinned_fingerprint()
+                            .map(|fp| fp.combined_sha256.clone())
+                            .unwrap_or_default();
                         // Stable check — keep the TUI counter in sync.
                         let _ = self
                             .tx_event

--- a/crates/tui/src/core/events.rs
+++ b/crates/tui/src/core/events.rs
@@ -281,6 +281,10 @@ pub enum Event {
         /// True when the prefix actually changed (cache invalidated).
         /// False for routine stable-check heartbeats.
         changed: bool,
+        /// Current pinned prefix combined hash (SHA-256, 64 hex chars).
+        /// Carried so `/cache stats` can surface it without reaching
+        /// into the engine's PrefixStabilityManager.
+        pinned_combined_hash: String,
     },
 }
 

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -1628,6 +1628,7 @@ impl App {
         self.session.last_prompt_cache_miss_tokens = None;
         self.session.last_reasoning_replay_tokens = None;
         self.session.turn_cache_history.clear();
+        self.last_pinned_prefix_hash = None;
     }
 
     pub fn tr(&self, id: MessageId) -> &'static str {

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -1466,6 +1466,10 @@ pub struct App {
     pub prefix_stability_pct: Option<u32>,
     /// Description of the last prefix change, if any.
     pub last_prefix_change_desc: Option<String>,
+    /// Current pinned prefix combined hash (SHA-256, 64 hex chars).
+    /// Updated per-turn via PrefixCacheChange events; surfaced by
+    /// `/cache stats` for cache-hit debugging.
+    pub last_pinned_prefix_hash: Option<String>,
 
     /// Active cycle configuration (token threshold, briefing cap, per-model
     /// overrides). Loaded from config and forwarded to the engine.
@@ -2003,6 +2007,7 @@ impl App {
             prefix_checks_total: 0,
             prefix_stability_pct: None,
             last_prefix_change_desc: None,
+            last_pinned_prefix_hash: None,
             cycle: CycleConfig::default(),
             collapsed_cells: HashSet::new(),
             collapsed_cell_map: Vec::new(),

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -1736,10 +1736,14 @@ async fn run_event_loop(
                         description,
                         stability_pct,
                         changed,
+                        pinned_combined_hash,
                         ..
                     } => {
                         app.prefix_checks_total = app.prefix_checks_total.saturating_add(1);
                         app.prefix_stability_pct = Some(stability_pct);
+                        if !pinned_combined_hash.is_empty() {
+                            app.last_pinned_prefix_hash = Some(pinned_combined_hash);
+                        }
                         if changed {
                             app.prefix_change_count = app.prefix_change_count.saturating_add(1);
                             if !description.is_empty() {

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -1741,9 +1741,8 @@ async fn run_event_loop(
                     } => {
                         app.prefix_checks_total = app.prefix_checks_total.saturating_add(1);
                         app.prefix_stability_pct = Some(stability_pct);
-                        if !pinned_combined_hash.is_empty() {
-                            app.last_pinned_prefix_hash = Some(pinned_combined_hash);
-                        }
+                        app.last_pinned_prefix_hash =
+                            (!pinned_combined_hash.is_empty()).then_some(pinned_combined_hash);
                         if changed {
                             app.prefix_change_count = app.prefix_change_count.saturating_add(1);
                             if !description.is_empty() {


### PR DESCRIPTION
Closes #2264 (low-risk 0.8.x slice).

## What

New `/cache stats` subcommand that surfaces prefix-cache stability diagnostics in three sections:

**Prefix Stability** — percentage, check/change counts, WARNING when drifted
**Prefix Fingerprint** — full SHA-256 combined hash, short id, drift warning
**Cache Hit Rate** — aggregated hit/miss/input tokens from per-turn telemetry, low-hit advisory below 80%

## Plumbing

| Layer | Change |
|---|---|
| `PrefixCacheChange` event | +`pinned_combined_hash: String` — carries pinned prefix fingerprint to TUI |
| `turn_loop.rs` | Extracts `pinned_fingerprint().combined_sha256` before `check_and_update` |
| `App` | +`last_pinned_prefix_hash: Option<String>` — updated per-turn |
| `ui.rs` | Stores hash from event into App |

## Files

```
crates/tui/src/commands/debug.rs      | +212  (format_cache_stats, format_tokens, "stats" branch, 6 tests)
crates/tui/src/commands/mod.rs        |   +1  (usage string)
crates/tui/src/core/events.rs         |   +4  (pinned_combined_hash field)
crates/tui/src/core/engine/turn_loop.rs|   +6  (populate hash)
crates/tui/src/tui/app.rs             |   +5  (field + init)
crates/tui/src/tui/ui.rs              |   +4  (store hash from event)
```

6 files, +232 −1

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `/cache stats`, a new subcommand that surfaces prefix-cache stability, a pinned SHA-256 fingerprint, and a per-session cache-hit rate summary. It also includes a largely undocumented second feature: a "whale routes" single-column model picker for DeepSeek providers, with a new `whale_routes.rs` taxonomy and matching refactor of `model_picker.rs`.

- **`/cache stats` plumbing** (`debug.rs`, `events.rs`, `turn_loop.rs`, `app.rs`, `ui.rs`): the new `format_cache_stats` function aggregates per-turn telemetry, displays prefix stability and fingerprint data, and fires a low-hit advisory below 80%. The six accompanying tests cover the main paths. The `pinned_combined_hash` field is populated after `check_and_update` in both branches (the PR description says "before", which is a minor doc discrepancy but not a functional issue).
- **Whale-routes model picker** (`whale_routes.rs`, `model_picker.rs`): introduces six named model+effort combinations (Blue Whale → Porpoise) and replaces the two-column picker with a single-column list for DeepSeek providers. `model_picker.rs` contains a compile error in `render_whale_routes` — `popup_height` calls `.min()` on a `usize` (from `whale_route_row_count()`) against a `u16` (from `area.height`), which will not compile. The `sort_order` field on `WhaleRoute` also silently doubles as an array index without an explicit invariant test.
</details>


<details open><summary><h3>Confidence Score: 2/5</h3></summary>

Not safe to merge: `render_whale_routes` in `model_picker.rs` will not compile due to a type mismatch in the `popup_height` expression.

The `/cache stats` wiring is clean and the logic is correct, but the PR includes a second undocumented feature (whale-routes model picker) that contains a definite compile error: `(row_count + 4).min(area.height.saturating_sub(4))` mixes `usize` with `u16`, which Rust will reject. This would prevent the entire TUI crate from building.

`crates/tui/src/tui/model_picker.rs` — the `render_whale_routes` method has the compile error. `crates/tui/src/tui/whale_routes.rs` should also add an assertion that `sort_order == array index`.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/model_picker.rs | Substantial refactor adding whale-route single-column layout for DeepSeek providers; contains a compile error — `usize` vs `u16` type mismatch in `popup_height` computation that prevents this code from building. |
| crates/tui/src/tui/whale_routes.rs | New file defining six canonical whale-route (model + effort) combinations with lookup helpers; well-tested, but `sort_order` doubles silently as the array index, a load-bearing invariant with no direct assertion. |
| crates/tui/src/commands/debug.rs | Adds `format_cache_stats` and `format_tokens` for the new `/cache stats` subcommand, with six unit tests; main logic is correct and well-guarded. |
| crates/tui/src/core/engine/turn_loop.rs | Extracts `pinned_fingerprint().combined_sha256` in both changed and stable branches and populates the new event field; straightforward and correct. |
| crates/tui/src/tui/app.rs | Adds `last_pinned_prefix_hash: Option<String>` field, initialises it to `None`, and clears it on session reset; clean. |
| crates/tui/src/tui/ui.rs | Stores `pinned_combined_hash` from the event into `App`, converting empty strings to `None`; correct. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Engine as turn_loop.rs
    participant PM as PrefixStabilityManager
    participant Event as PrefixCacheChange event
    participant UI as ui.rs (event loop)
    participant App as App state
    participant Cmd as /cache stats

    Engine->>PM: check_and_update(system_text, tools)
    PM-->>Engine: Ok(_) or Err(change)
    Engine->>PM: pinned_fingerprint()
    PM-->>Engine: combined_sha256
    Engine->>Event: "emit PrefixCacheChange { pinned_combined_hash, stability_pct, changed }"
    Event->>UI: received in run_event_loop
    UI->>App: "last_pinned_prefix_hash = Some(hash)"
    UI->>App: "prefix_stability_pct = Some(pct)"
    UI->>App: "prefix_change_count += 1 (if changed)"

    Note over Cmd,App: User runs /cache stats
    Cmd->>App: read prefix_stability_pct, last_pinned_prefix_hash
    Cmd->>App: read session.turn_cache_history
    Cmd-->>Cmd: format_cache_stats(app) → String message
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/tui/src/tui/model_picker.rs`, line 371 ([link](https://github.com/hmbown/codewhale/blob/617528520c85db34af873b82e2efa2a01a1eb436/crates/tui/src/tui/model_picker.rs#L371)) 

   <a href="#"><img alt="P0" src="https://greptile-static-assets.s3.amazonaws.com/badges/p0.svg?v=9" align="top"></a> `popup_height` mixes `usize` (from `whale_route_row_count()`) with `u16` (from `area.height.saturating_sub(4)`) in the same `.min()` call. Rust requires both sides of `.min()` to be the same type, so this will not compile. The `as u16` cast only applies to the final result and does not resolve the intermediate type mismatch.

   

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fcache-stats-2264%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fcache-stats-2264%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fmodel_picker.rs%0ALine%3A%20371%0A%0AComment%3A%0A%60popup_height%60%20mixes%20%60usize%60%20%28from%20%60whale_route_row_count%28%29%60%29%20with%20%60u16%60%20%28from%20%60area.height.saturating_sub%284%29%60%29%20in%20the%20same%20%60.min%28%29%60%20call.%20Rust%20requires%20both%20sides%20of%20%60.min%28%29%60%20to%20be%20the%20same%20type%2C%20so%20this%20will%20not%20compile.%20The%20%60as%20u16%60%20cast%20only%20applies%20to%20the%20final%20result%20and%20does%20not%20resolve%20the%20intermediate%20type%20mismatch.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20popup_height%20%3D%20%28%28row_count%20%2B%204%29%20as%20u16%29.min%28area.height.saturating_sub%284%29%29.max%288%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fmodel_picker.rs%0ALine%3A%20371%0A%0AComment%3A%0A%60popup_height%60%20mixes%20%60usize%60%20%28from%20%60whale_route_row_count%28%29%60%29%20with%20%60u16%60%20%28from%20%60area.height.saturating_sub%284%29%60%29%20in%20the%20same%20%60.min%28%29%60%20call.%20Rust%20requires%20both%20sides%20of%20%60.min%28%29%60%20to%20be%20the%20same%20type%2C%20so%20this%20will%20not%20compile.%20The%20%60as%20u16%60%20cast%20only%20applies%20to%20the%20final%20result%20and%20does%20not%20resolve%20the%20intermediate%20type%20mismatch.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20popup_height%20%3D%20%28%28row_count%20%2B%204%29%20as%20u16%29.min%28area.height.saturating_sub%284%29%29.max%288%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2336&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fmodel_picker.rs%0ALine%3A%20371%0A%0AComment%3A%0A%60popup_height%60%20mixes%20%60usize%60%20%28from%20%60whale_route_row_count%28%29%60%29%20with%20%60u16%60%20%28from%20%60area.height.saturating_sub%284%29%60%29%20in%20the%20same%20%60.min%28%29%60%20call.%20Rust%20requires%20both%20sides%20of%20%60.min%28%29%60%20to%20be%20the%20same%20type%2C%20so%20this%20will%20not%20compile.%20The%20%60as%20u16%60%20cast%20only%20applies%20to%20the%20final%20result%20and%20does%20not%20resolve%20the%20intermediate%20type%20mismatch.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20popup_height%20%3D%20%28%28row_count%20%2B%204%29%20as%20u16%29.min%28area.height.saturating_sub%284%29%29.max%288%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2336&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fcache-stats-2264%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fcache-stats-2264%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Ftui%2Fsrc%2Ftui%2Fmodel_picker.rs%3A371%0A%60popup_height%60%20mixes%20%60usize%60%20%28from%20%60whale_route_row_count%28%29%60%29%20with%20%60u16%60%20%28from%20%60area.height.saturating_sub%284%29%60%29%20in%20the%20same%20%60.min%28%29%60%20call.%20Rust%20requires%20both%20sides%20of%20%60.min%28%29%60%20to%20be%20the%20same%20type%2C%20so%20this%20will%20not%20compile.%20The%20%60as%20u16%60%20cast%20only%20applies%20to%20the%20final%20result%20and%20does%20not%20resolve%20the%20intermediate%20type%20mismatch.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20popup_height%20%3D%20%28%28row_count%20%2B%204%29%20as%20u16%29.min%28area.height.saturating_sub%284%29%29.max%288%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Ftui%2Fsrc%2Ftui%2Fmodel_picker.rs%3A413-426%0A**Duplicate%20else%20branch%20in%20fallback%20label%2Fhint**%0A%0AThe%20outer%20%60else%60%20arms%20of%20both%20%60fallback_label%60%20and%20%60fallback_hint%60%20are%20identical%20to%20the%20first%20%60if%20self.initial_model%20%3D%3D%20%22auto%22%60%20arm.%20Since%20this%20method%20is%20only%20called%20when%20%60show_whale_routes%60%20is%20%60true%60%2C%20%60show_custom_model_row%60%20is%20the%20only%20meaningful%20discriminant.%20When%20neither%20%60%22auto%22%60%20nor%20%60show_custom_model_row%60%20holds%2C%20the%20fallback%20silently%20shows%20the%20same%20label%20as%20the%20%60%22auto%22%60%20case%2C%20which%20may%20confuse%20users%20who%20have%20a%20non-%22auto%22%2C%20non-custom%20model%20set.%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Ftui%2Fsrc%2Ftui%2Fwhale_routes.rs%3A907-908%0A**%60sort_order%60%20silently%20doubles%20as%20an%20array%20index**%0A%0A%60model_picker.rs%60%20uses%20%60r.sort_order%60%20directly%20as%20an%20index%20into%20%60WHALE_ROUTES%60%20%28e.g.%20%60WHALE_ROUTES%5Bself.selected_route_idx%5D%60%29%2C%20so%20the%20invariant%20%60sort_order%20%3D%3D%20position%20in%20WHALE_ROUTES%60%20is%20load-bearing.%20There%20is%20no%20test%20asserting%20%60sort_order%20%3D%3D%20index%60%3B%20the%20existing%20%60routes_are_sorted_by_size%60%20test%20only%20checks%20monotonicity%2C%20not%20that%20values%20start%20at%200%20and%20match%20positions.%20A%20future%20contributor%20inserting%20a%20route%20mid-list%20without%20renumbering%20all%20%60sort_order%60%20values%20would%20silently%20select%20the%20wrong%20route%20in%20the%20picker.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Ftui%2Fsrc%2Ftui%2Fmodel_picker.rs%3A371%0A%60popup_height%60%20mixes%20%60usize%60%20%28from%20%60whale_route_row_count%28%29%60%29%20with%20%60u16%60%20%28from%20%60area.height.saturating_sub%284%29%60%29%20in%20the%20same%20%60.min%28%29%60%20call.%20Rust%20requires%20both%20sides%20of%20%60.min%28%29%60%20to%20be%20the%20same%20type%2C%20so%20this%20will%20not%20compile.%20The%20%60as%20u16%60%20cast%20only%20applies%20to%20the%20final%20result%20and%20does%20not%20resolve%20the%20intermediate%20type%20mismatch.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20popup_height%20%3D%20%28%28row_count%20%2B%204%29%20as%20u16%29.min%28area.height.saturating_sub%284%29%29.max%288%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Ftui%2Fsrc%2Ftui%2Fmodel_picker.rs%3A413-426%0A**Duplicate%20else%20branch%20in%20fallback%20label%2Fhint**%0A%0AThe%20outer%20%60else%60%20arms%20of%20both%20%60fallback_label%60%20and%20%60fallback_hint%60%20are%20identical%20to%20the%20first%20%60if%20self.initial_model%20%3D%3D%20%22auto%22%60%20arm.%20Since%20this%20method%20is%20only%20called%20when%20%60show_whale_routes%60%20is%20%60true%60%2C%20%60show_custom_model_row%60%20is%20the%20only%20meaningful%20discriminant.%20When%20neither%20%60%22auto%22%60%20nor%20%60show_custom_model_row%60%20holds%2C%20the%20fallback%20silently%20shows%20the%20same%20label%20as%20the%20%60%22auto%22%60%20case%2C%20which%20may%20confuse%20users%20who%20have%20a%20non-%22auto%22%2C%20non-custom%20model%20set.%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Ftui%2Fsrc%2Ftui%2Fwhale_routes.rs%3A907-908%0A**%60sort_order%60%20silently%20doubles%20as%20an%20array%20index**%0A%0A%60model_picker.rs%60%20uses%20%60r.sort_order%60%20directly%20as%20an%20index%20into%20%60WHALE_ROUTES%60%20%28e.g.%20%60WHALE_ROUTES%5Bself.selected_route_idx%5D%60%29%2C%20so%20the%20invariant%20%60sort_order%20%3D%3D%20position%20in%20WHALE_ROUTES%60%20is%20load-bearing.%20There%20is%20no%20test%20asserting%20%60sort_order%20%3D%3D%20index%60%3B%20the%20existing%20%60routes_are_sorted_by_size%60%20test%20only%20checks%20monotonicity%2C%20not%20that%20values%20start%20at%200%20and%20match%20positions.%20A%20future%20contributor%20inserting%20a%20route%20mid-list%20without%20renumbering%20all%20%60sort_order%60%20values%20would%20silently%20select%20the%20wrong%20route%20in%20the%20picker.%0A%0A&repo=hmbown%2Fcodewhale&pr=2336&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Ftui%2Fsrc%2Ftui%2Fmodel_picker.rs%3A371%0A%60popup_height%60%20mixes%20%60usize%60%20%28from%20%60whale_route_row_count%28%29%60%29%20with%20%60u16%60%20%28from%20%60area.height.saturating_sub%284%29%60%29%20in%20the%20same%20%60.min%28%29%60%20call.%20Rust%20requires%20both%20sides%20of%20%60.min%28%29%60%20to%20be%20the%20same%20type%2C%20so%20this%20will%20not%20compile.%20The%20%60as%20u16%60%20cast%20only%20applies%20to%20the%20final%20result%20and%20does%20not%20resolve%20the%20intermediate%20type%20mismatch.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20popup_height%20%3D%20%28%28row_count%20%2B%204%29%20as%20u16%29.min%28area.height.saturating_sub%284%29%29.max%288%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Ftui%2Fsrc%2Ftui%2Fmodel_picker.rs%3A413-426%0A**Duplicate%20else%20branch%20in%20fallback%20label%2Fhint**%0A%0AThe%20outer%20%60else%60%20arms%20of%20both%20%60fallback_label%60%20and%20%60fallback_hint%60%20are%20identical%20to%20the%20first%20%60if%20self.initial_model%20%3D%3D%20%22auto%22%60%20arm.%20Since%20this%20method%20is%20only%20called%20when%20%60show_whale_routes%60%20is%20%60true%60%2C%20%60show_custom_model_row%60%20is%20the%20only%20meaningful%20discriminant.%20When%20neither%20%60%22auto%22%60%20nor%20%60show_custom_model_row%60%20holds%2C%20the%20fallback%20silently%20shows%20the%20same%20label%20as%20the%20%60%22auto%22%60%20case%2C%20which%20may%20confuse%20users%20who%20have%20a%20non-%22auto%22%2C%20non-custom%20model%20set.%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Ftui%2Fsrc%2Ftui%2Fwhale_routes.rs%3A907-908%0A**%60sort_order%60%20silently%20doubles%20as%20an%20array%20index**%0A%0A%60model_picker.rs%60%20uses%20%60r.sort_order%60%20directly%20as%20an%20index%20into%20%60WHALE_ROUTES%60%20%28e.g.%20%60WHALE_ROUTES%5Bself.selected_route_idx%5D%60%29%2C%20so%20the%20invariant%20%60sort_order%20%3D%3D%20position%20in%20WHALE_ROUTES%60%20is%20load-bearing.%20There%20is%20no%20test%20asserting%20%60sort_order%20%3D%3D%20index%60%3B%20the%20existing%20%60routes_are_sorted_by_size%60%20test%20only%20checks%20monotonicity%2C%20not%20that%20values%20start%20at%200%20and%20match%20positions.%20A%20future%20contributor%20inserting%20a%20route%20mid-list%20without%20renumbering%20all%20%60sort_order%60%20values%20would%20silently%20select%20the%20wrong%20route%20in%20the%20picker.%0A%0A&pr=2336&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["fix: clear last\_pinned\_prefix\_hash on mo..."](https://github.com/hmbown/codewhale/commit/617528520c85db34af873b82e2efa2a01a1eb436) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34498896)</sub>

<!-- /greptile_comment -->