### PR TITLE
fix(tui): treat slash-space input as message text

### DIFF
--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -86,6 +86,9 @@ pub(crate) fn looks_like_slash_command_input(input: &str) -> bool {
     let Some(rest) = input.trim_start().strip_prefix('/') else {
         return false;
     };
+    if rest.starts_with(char::is_whitespace) {
+        return false;
+    }
     let Some(command) = rest.split_whitespace().next() else {
         return rest.is_empty();
     };
@@ -5010,6 +5013,8 @@ mod tests {
         assert!(looks_like_slash_command_input("/"));
         assert!(looks_like_slash_command_input("/help"));
         assert!(looks_like_slash_command_input("/model deepseek-v4-pro"));
+        assert!(!looks_like_slash_command_input("/ hello"));
+        assert!(!looks_like_slash_command_input("  / hello"));
         assert!(!looks_like_slash_command_input(
             "/usr/lib/x86_64-linux-gnu/ 是标准路径吗？"
         ));


### PR DESCRIPTION
## Summary

- Treat composer input that starts with `/` followed by whitespace as normal message text instead of a slash-command dispatch.
- Keep bare `/` and command forms such as `/help` and `/model ...` on the existing command path.
- Add regression coverage for `/ hello` and leading-space `  / hello`.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features`
  - Command exits successfully on this checkout; upstream warnings remain in legacy shim/config/runtime-log code outside this patch.
- [ ] `cargo test --workspace --all-features`
  - Ran on this Windows checkout; failed after `3409 passed; 13 failed; 4 ignored` with failures outside this patch, including local SSH signing/passphrase failures in git-commit tests, parent-git-root session lookup cases, default API-key environment detection, and skills/project-context prompt environment assumptions.

Additional focused validation:

- [x] `cargo test -p codewhale-tui --bin codewhale-tui slash_command_classifier_treats_absolute_path_as_message`

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
  - Covered by focused slash-command classifier regression test; left unchecked while this stays draft for reviewer/manual confirmation.

Closes #2310

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a one-character classifier bug where `/ hello` (slash followed by a space) was incorrectly dispatched as a slash command instead of being sent as ordinary message text. A three-line guard is inserted into `looks_like_slash_command_input` before the `split_whitespace` split, which previously consumed the leading space and exposed the word after it as a "valid" command token.

- **Classifier fix**: after stripping the leading `/`, `rest.starts_with(char::is_whitespace)` returns `false` immediately, routing `"/ hello"` and `"  / hello"` through the normal message path across all callers (history, slash menu, paste, and UI rendering).
- **Regression tests**: two new assertions (`"/ hello"` and `"  / hello"`) are appended to the existing `slash_command_classifier_treats_absolute_path_as_message` test, keeping the focused test runnable in isolation.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted three-line guard with correct logic, backed by regression tests, and the fix applies consistently across all six call sites.

The guard correctly catches every whitespace-after-slash variant (space, tab, newline) because `char::is_whitespace` covers the full Unicode whitespace set. All pre-existing cases (`"/"`, `"/help"`, `"/model deepseek-v4-pro"`, the absolute-path case) still pass, and the two new assertions verify the fixed behavior directly. Tracing the fix through every caller confirms history recording, slash menu visibility, paste handling, and UI display all behave correctly for `"/ hello"`.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/app.rs | Adds an early-return guard in `looks_like_slash_command_input` so that a `/` immediately followed by whitespace (e.g. `"/ hello"`) is classified as plain message text, not a slash command; two matching regression assertions added to the existing classifier test. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["input string"] --> B["trim_start()"]
    B --> C{"strip_prefix('/')"}
    C -- "no leading '/'" --> D["return false\n(plain message)"]
    C -- "rest after '/'" --> E{"rest starts_with\nwhitespace?"}
    E -- "yes (e.g. '/ hello')" --> F["return false\n(treated as message text) NEW"]
    E -- "no" --> G{"rest.split_whitespace().next()"}
    G -- "None (bare '/')" --> H["return rest.is_empty()\n→ true for '/'"]
    G -- "Some(command)" --> I{"command.contains('/')"}
    I -- "yes (absolute path)" --> J["return false\n(treated as message text)"]
    I -- "no" --> K["return true\n(slash command)"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tui): treat slash-space input as mes..."](https://github.com/hmbown/codewhale/commit/9723075835725fc6e3962604d226bc32465d86ba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34504516)</sub>

<!-- /greptile_comment -->