### PR TITLE
Show git branch in default footer

### DIFF
--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -797,6 +797,7 @@ impl StatusItem {
             StatusItem::Agents,
             StatusItem::ReasoningReplay,
             StatusItem::Cache,
+            StatusItem::GitBranch,
             StatusItem::Tokens,
         ]
     }

--- a/crates/tui/src/tui/footer_ui.rs
+++ b/crates/tui/src/tui/footer_ui.rs
@@ -538,11 +538,15 @@ pub(crate) fn render_footer_from(
 }
 
 pub(crate) fn footer_git_branch_spans(app: &App) -> Vec<Span<'static>> {
-    let Some(branch) = workspace_context::branch(&app.workspace) else {
+    let Some(branch) = app
+        .workspace_context
+        .as_deref()
+        .and_then(workspace_context::branch_from_context)
+    else {
         return Vec::new();
     };
     vec![Span::styled(
-        branch,
+        branch.to_string(),
         Style::default().fg(app.ui_theme.text_muted),
     )]
 }

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -2077,6 +2077,8 @@ fn init_git_repo() -> TempDir {
             "user.name=codewhale Tests",
             "-c",
             "user.email=tests@example.com",
+            "-c",
+            "commit.gpgsign=false",
             "commit",
             "--allow-empty",
             "-m",
@@ -5694,6 +5696,10 @@ fn default_footer_keeps_prefix_stability_opt_in() {
         items.contains(&crate::config::StatusItem::Cache),
         "default footer should still include provider-reported cache hit rate"
     );
+    assert!(
+        items.contains(&crate::config::StatusItem::GitBranch),
+        "default footer should surface the current workspace branch"
+    );
 }
 
 #[test]
@@ -5780,6 +5786,30 @@ fn render_footer_from_git_branch_item_renders_workspace_branch() {
 
     let props = render_footer_from(&app, &[crate::config::StatusItem::GitBranch], None);
     assert_eq!(spans_text(&props.cache), "feature/statusline");
+}
+
+#[test]
+fn default_footer_renders_workspace_branch_when_available() {
+    let repo = init_git_repo();
+    let checkout = Command::new("git")
+        .args(["checkout", "-b", "feature/default-branch-chip"])
+        .current_dir(repo.path())
+        .output()
+        .expect("git checkout should run");
+    assert!(
+        checkout.status.success(),
+        "git checkout failed: {}",
+        String::from_utf8_lossy(&checkout.stderr)
+    );
+
+    let mut app = create_test_app();
+    app.workspace = repo.path().to_path_buf();
+
+    let props = render_footer_from(&app, &crate::config::StatusItem::default_footer(), None);
+    assert!(
+        spans_text(&props.cache).contains("feature/default-branch-chip"),
+        "default footer should include the current git branch"
+    );
 }
 
 /// Regression for issue #244: visible session spend must not decrease.

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -5783,6 +5783,7 @@ fn render_footer_from_git_branch_item_renders_workspace_branch() {
 
     let mut app = create_test_app();
     app.workspace = repo.path().to_path_buf();
+    crate::tui::workspace_context::refresh_if_needed(&mut app, Instant::now(), true);
 
     let props = render_footer_from(&app, &[crate::config::StatusItem::GitBranch], None);
     assert_eq!(spans_text(&props.cache), "feature/statusline");
@@ -5804,6 +5805,7 @@ fn default_footer_renders_workspace_branch_when_available() {
 
     let mut app = create_test_app();
     app.workspace = repo.path().to_path_buf();
+    crate::tui::workspace_context::refresh_if_needed(&mut app, Instant::now(), true);
 
     let props = render_footer_from(&app, &crate::config::StatusItem::default_footer(), None);
     assert!(

--- a/crates/tui/src/tui/workspace_context.rs
+++ b/crates/tui/src/tui/workspace_context.rs
@@ -107,6 +107,11 @@ fn collect(workspace: &Path) -> Option<String> {
     Some(format!("{branch} | {status}"))
 }
 
+pub(crate) fn branch_from_context(context: &str) -> Option<&str> {
+    let (branch, _) = context.rsplit_once(" | ")?;
+    (!branch.is_empty()).then_some(branch)
+}
+
 pub(super) fn branch(workspace: &Path) -> Option<String> {
     let branch = run_git(workspace, &["rev-parse", "--abbrev-ref", "HEAD"]).ok()?;
     let branch = branch.trim().to_string();


### PR DESCRIPTION
## Summary

- Add the existing Git branch status item to the default footer so local branch info is visible without first configuring `/statusline`.
- Use the existing workspace context cache for footer branch rendering so the default footer does not run git synchronously on each draw.
- Harden the git-repo footer test helper against global commit signing config.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features`
  - Passed with existing clippy warnings outside this patch.
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --all-features default_footer`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --all-features render_footer_from_git_branch_item_renders_workspace_branch`
- [x] GitHub Actions CI
  - Lint, Version drift, Test (ubuntu-latest), Test (macos-latest), Test (windows-latest), npm wrapper smoke, GitGuardian, and Greptile all passed.

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [x] Verified TUI behavior manually if UI changes
  - Covered by focused footer rendering tests in this non-interactive Windows session.

Closes #2341