### PR TITLE
feat(subagent): add stop-on-failure and bounded-effort guidance to general agent intro

### DIFF
--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -4988,7 +4988,9 @@ const SUBAGENT_OUTPUT_FORMAT: &str = include_str!("../../prompts/subagent_output
 const GENERAL_AGENT_INTRO: &str = concat!(
     "You are a general-purpose sub-agent spawned to handle a specific task autonomously.\n",
     "Stay inside the assigned scope; put adjacent work under RISKS/BLOCKERS.\n",
-    "Plan multi-step work with `checklist_write`; add `update_plan` for complex strategy.\n\n"
+    "Plan multi-step work with `checklist_write`; add `update_plan` for complex strategy.\n",
+    "**Stop quickly on failure**: if the same tool call fails 2 times in a row, stop retrying and return what you have so far with a one-line note explaining what's missing. Do not loop on impossible queries (e.g. external API unreachable, rate-limited, or returning empty).\n",
+    "**Bounded effort**: prefer one focused attempt over many speculative retries. If you cannot complete the task with available data within 3-5 tool calls, return your current partial findings — the parent agent can compensate with its own knowledge.\n\n"
 );
 
 const EXPLORE_AGENT_INTRO: &str = concat!(


### PR DESCRIPTION
## Summary

The general-purpose sub-agent intro (`GENERAL_AGENT_INTRO`) tells the agent how to plan but never says when to **stop**. With less capable models this produces a failure mode where the agent retries the same failing tool call (e.g. an unreachable or rate-limited external API) over and over until it hits the elapsed/step ceiling — burning the whole budget and returning nothing useful.

This adds two short clauses:

- **Stop quickly on failure**: after the same call fails twice, return partial results with a one-line note instead of looping.
- **Bounded effort**: prefer one focused attempt; if the task can't be completed within a few tool calls, return current findings so the parent can compensate.

Prompt-only change; no behavioral code paths touched.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo build -p codewhale-tui` (compiles)
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [x] Updated docs or comments as needed
- [ ] Added or updated tests where relevant (prompt-string change, no test target)
- [ ] Verified TUI behavior manually if UI changes (n/a)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This prompt-only change adds two stopping-condition clauses to `GENERAL_AGENT_INTRO` to prevent less-capable models from looping endlessly on failing or blocked tool calls.

- **Stop quickly on failure** instructs the agent to halt and return partial results after 2 consecutive failures of the same tool call, citing the missing piece.
- **Bounded effort** tells the agent to prefer one focused attempt and return partial findings rather than speculating indefinitely — but the "3-5 tool calls" phrasing creates a numerical cap that conflicts with the existing `checklist_write` multi-step planning guidance in the same string.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The change targets a real failure mode, but the '3-5 tool calls' wording in Bounded effort directly contradicts the existing multi-step checklist guidance in the same prompt string — a general agent working through a legitimate checklist will consistently hit that count and may truncate healthy work.

The bounded-effort clause introduces an ambiguous numerical threshold that a model could reasonably interpret as a hard cap, causing it to abandon legitimately complex tasks that the same prompt elsewhere encourages it to plan with a multi-step checklist. This is a present logic conflict in the instruction set, not a future risk.

crates/tui/src/tools/subagent/mod.rs — specifically the two new lines added to GENERAL_AGENT_INTRO and their interaction with the existing checklist-planning guidance directly above them.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tools/subagent/mod.rs | Adds two prompt-only guidance clauses to GENERAL_AGENT_INTRO; the "3-5 tool calls" threshold in the bounded-effort clause directly conflicts with the existing multi-step checklist guidance in the same string. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[General Agent Receives Task] --> B{Multi-step?}
    B -- Yes --> C[checklist_write]
    C --> D[Execute Tool Calls]
    D --> E{Same call failed 2x in a row?}
    E -- Yes --> F[Stop: return partial + one-line note]
    E -- No --> G{3-5 tool calls reached without complete data?}
    G -- Yes --> H[Stop: return partial findings]
    G -- No --> D
    B -- No --> D
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22pr2%2Fsubagent-stop-on-failure%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22pr2%2Fsubagent-stop-on-failure%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftools%2Fsubagent%2Fmod.rs%3A4993%0AThe%20phrase%20%22within%203-5%20tool%20calls%22%20clashes%20directly%20with%20the%20preceding%20line%20that%20tells%20the%20agent%20to%20plan%20multi-step%20work%20with%20%60checklist_write%60.%20A%20%60checklist_write%60%20call%20is%20itself%201%20tool%20call%3B%20every%20checklist%20item%20update%20is%20another%3B%20any%20non-trivial%20legitimate%20task%20%28read%20files%2C%20make%20edits%2C%20run%20verification%29%20will%20routinely%20exceed%205%20tool%20calls%20without%20being%20%22stuck.%22%20An%20LLM%20reading%20both%20instructions%20together%20may%20abandon%20a%20healthy%2C%20in-progress%20multi-step%20task%20as%20soon%20as%20the%20counter%20reaches%205.%20The%20intent%E2%80%94give%20up%20only%20when%20the%20required%20data%20is%20unavailable%E2%80%94should%20be%20spelled%20out%20explicitly%20to%20avoid%20this%20false-positive%20early%20stop.%0A%0A%60%60%60suggestion%0A%20%20%20%20%22**Bounded%20effort**%3A%20prefer%20one%20focused%20attempt%20over%20many%20speculative%20retries.%20If%20critical%20data%20remains%20unavailable%20despite%20focused%20searching%20%28e.g.%20the%20required%20resource%20does%20not%20exist%20or%20cannot%20be%20fetched%29%2C%20return%20your%20current%20partial%20findings%20rather%20than%20chasing%20it%20indefinitely%20%E2%80%94%20the%20parent%20agent%20can%20compensate%20with%20its%20own%20knowledge.%5Cn%5Cn%22%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftools%2Fsubagent%2Fmod.rs%3A4992%0AThe%20parenthetical%20example%20includes%20%60rate-limited%60%20alongside%20permanently%20unreachable%20endpoints%2C%20but%20rate-limiting%20is%20a%20transient%20condition%20%E2%80%94%20it%20clears%20in%20seconds%20and%20a%20single%20retry%20after%20a%20short%20pause%20is%20standard%20practice.%20Treating%20a%20429%2Frate-limit%20response%20the%20same%20as%20a%20DNS%20failure%20and%20stopping%20after%202%20attempts%20could%20cause%20the%20agent%20to%20abandon%20otherwise-completable%20tasks%20during%20brief%20quota%20windows.%0A%0A%60%60%60suggestion%0A%20%20%20%20%22**Stop%20quickly%20on%20failure**%3A%20if%20the%20same%20tool%20call%20fails%202%20times%20in%20a%20row%20with%20a%20persistent%20error%20%28e.g.%20external%20API%20unreachable%2C%20returning%20empty%2C%20or%20consistently%20erroring%29%2C%20stop%20retrying%20and%20return%20what%20you%20have%20so%20far%20with%20a%20one-line%20note%20explaining%20what's%20missing.%20Do%20not%20loop%20on%20impossible%20queries.%5Cn%22%2C%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftools%2Fsubagent%2Fmod.rs%3A4993%0AThe%20phrase%20%22within%203-5%20tool%20calls%22%20clashes%20directly%20with%20the%20preceding%20line%20that%20tells%20the%20agent%20to%20plan%20multi-step%20work%20with%20%60checklist_write%60.%20A%20%60checklist_write%60%20call%20is%20itself%201%20tool%20call%3B%20every%20checklist%20item%20update%20is%20another%3B%20any%20non-trivial%20legitimate%20task%20%28read%20files%2C%20make%20edits%2C%20run%20verification%29%20will%20routinely%20exceed%205%20tool%20calls%20without%20being%20%22stuck.%22%20An%20LLM%20reading%20both%20instructions%20together%20may%20abandon%20a%20healthy%2C%20in-progress%20multi-step%20task%20as%20soon%20as%20the%20counter%20reaches%205.%20The%20intent%E2%80%94give%20up%20only%20when%20the%20required%20data%20is%20unavailable%E2%80%94should%20be%20spelled%20out%20explicitly%20to%20avoid%20this%20false-positive%20early%20stop.%0A%0A%60%60%60suggestion%0A%20%20%20%20%22**Bounded%20effort**%3A%20prefer%20one%20focused%20attempt%20over%20many%20speculative%20retries.%20If%20critical%20data%20remains%20unavailable%20despite%20focused%20searching%20%28e.g.%20the%20required%20resource%20does%20not%20exist%20or%20cannot%20be%20fetched%29%2C%20return%20your%20current%20partial%20findings%20rather%20than%20chasing%20it%20indefinitely%20%E2%80%94%20the%20parent%20agent%20can%20compensate%20with%20its%20own%20knowledge.%5Cn%5Cn%22%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftools%2Fsubagent%2Fmod.rs%3A4992%0AThe%20parenthetical%20example%20includes%20%60rate-limited%60%20alongside%20permanently%20unreachable%20endpoints%2C%20but%20rate-limiting%20is%20a%20transient%20condition%20%E2%80%94%20it%20clears%20in%20seconds%20and%20a%20single%20retry%20after%20a%20short%20pause%20is%20standard%20practice.%20Treating%20a%20429%2Frate-limit%20response%20the%20same%20as%20a%20DNS%20failure%20and%20stopping%20after%202%20attempts%20could%20cause%20the%20agent%20to%20abandon%20otherwise-completable%20tasks%20during%20brief%20quota%20windows.%0A%0A%60%60%60suggestion%0A%20%20%20%20%22**Stop%20quickly%20on%20failure**%3A%20if%20the%20same%20tool%20call%20fails%202%20times%20in%20a%20row%20with%20a%20persistent%20error%20%28e.g.%20external%20API%20unreachable%2C%20returning%20empty%2C%20or%20consistently%20erroring%29%2C%20stop%20retrying%20and%20return%20what%20you%20have%20so%20far%20with%20a%20one-line%20note%20explaining%20what's%20missing.%20Do%20not%20loop%20on%20impossible%20queries.%5Cn%22%2C%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2354&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftools%2Fsubagent%2Fmod.rs%3A4993%0AThe%20phrase%20%22within%203-5%20tool%20calls%22%20clashes%20directly%20with%20the%20preceding%20line%20that%20tells%20the%20agent%20to%20plan%20multi-step%20work%20with%20%60checklist_write%60.%20A%20%60checklist_write%60%20call%20is%20itself%201%20tool%20call%3B%20every%20checklist%20item%20update%20is%20another%3B%20any%20non-trivial%20legitimate%20task%20%28read%20files%2C%20make%20edits%2C%20run%20verification%29%20will%20routinely%20exceed%205%20tool%20calls%20without%20being%20%22stuck.%22%20An%20LLM%20reading%20both%20instructions%20together%20may%20abandon%20a%20healthy%2C%20in-progress%20multi-step%20task%20as%20soon%20as%20the%20counter%20reaches%205.%20The%20intent%E2%80%94give%20up%20only%20when%20the%20required%20data%20is%20unavailable%E2%80%94should%20be%20spelled%20out%20explicitly%20to%20avoid%20this%20false-positive%20early%20stop.%0A%0A%60%60%60suggestion%0A%20%20%20%20%22**Bounded%20effort**%3A%20prefer%20one%20focused%20attempt%20over%20many%20speculative%20retries.%20If%20critical%20data%20remains%20unavailable%20despite%20focused%20searching%20%28e.g.%20the%20required%20resource%20does%20not%20exist%20or%20cannot%20be%20fetched%29%2C%20return%20your%20current%20partial%20findings%20rather%20than%20chasing%20it%20indefinitely%20%E2%80%94%20the%20parent%20agent%20can%20compensate%20with%20its%20own%20knowledge.%5Cn%5Cn%22%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftools%2Fsubagent%2Fmod.rs%3A4992%0AThe%20parenthetical%20example%20includes%20%60rate-limited%60%20alongside%20permanently%20unreachable%20endpoints%2C%20but%20rate-limiting%20is%20a%20transient%20condition%20%E2%80%94%20it%20clears%20in%20seconds%20and%20a%20single%20retry%20after%20a%20short%20pause%20is%20standard%20practice.%20Treating%20a%20429%2Frate-limit%20response%20the%20same%20as%20a%20DNS%20failure%20and%20stopping%20after%202%20attempts%20could%20cause%20the%20agent%20to%20abandon%20otherwise-completable%20tasks%20during%20brief%20quota%20windows.%0A%0A%60%60%60suggestion%0A%20%20%20%20%22**Stop%20quickly%20on%20failure**%3A%20if%20the%20same%20tool%20call%20fails%202%20times%20in%20a%20row%20with%20a%20persistent%20error%20%28e.g.%20external%20API%20unreachable%2C%20returning%20empty%2C%20or%20consistently%20erroring%29%2C%20stop%20retrying%20and%20return%20what%20you%20have%20so%20far%20with%20a%20one-line%20note%20explaining%20what's%20missing.%20Do%20not%20loop%20on%20impossible%20queries.%5Cn%22%2C%0A%60%60%60%0A%0A&pr=2354&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(subagent): add stop-on-failure and ..."](https://github.com/hmbown/codewhale/commit/ea79ae508b48abd4feb1c69a40f67a77f64497ab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34558671)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->