### PR TITLE
fix(fetch_url): optionally trust fake-ip placeholder ranges to avoid SSRF false-positives

### DIFF
--- a/crates/tui/src/network_policy.rs
+++ b/crates/tui/src/network_policy.rs
@@ -46,6 +46,7 @@
 
 use std::fs::{self, OpenOptions};
 use std::io::Write;
+use std::net::{IpAddr, Ipv4Addr};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
@@ -265,6 +266,27 @@ fn host_matches(entry: &str, normalized_host: &str) -> bool {
     }
 }
 
+/// Parse an IPv4 CIDR string such as `"198.18.0.0/15"` into `(base, prefix)`.
+/// Returns `None` for malformed input or a prefix length above 32.
+fn parse_ipv4_cidr(cidr: &str) -> Option<(Ipv4Addr, u8)> {
+    let (addr, prefix) = cidr.split_once('/')?;
+    let base: Ipv4Addr = addr.trim().parse().ok()?;
+    let prefix: u8 = prefix.trim().parse().ok()?;
+    if prefix > 32 {
+        return None;
+    }
+    Some((base, prefix))
+}
+
+/// Whether `ip` is contained in the `base/prefix` IPv4 CIDR block.
+fn ipv4_in_cidr(ip: Ipv4Addr, base: Ipv4Addr, prefix: u8) -> bool {
+    if prefix == 0 {
+        return true;
+    }
+    let mask: u32 = u32::MAX << (32 - prefix);
+    (u32::from(ip) & mask) == (u32::from(base) & mask)
+}
+
 /// Best-effort writer for the network audit log.
 #[derive(Debug, Clone)]
 pub struct NetworkAuditor {
@@ -415,6 +437,12 @@ pub struct NetworkPolicyDecider {
     policy: NetworkPolicy,
     cache: NetworkSessionCache,
     auditor: Option<NetworkAuditor>,
+    /// IPv4 CIDR ranges that are treated as benign fake-IP placeholders (e.g.
+    /// a transparent-proxy / TUN setup running in `fake-ip` mode, where DNS
+    /// resolves every hostname into a reserved range like `198.18.0.0/15`).
+    /// A resolved IP inside one of these ranges bypasses the restricted-IP SSRF
+    /// block; real private/loopback/link-local/metadata IPs are unaffected.
+    trusted_fakeip_cidrs: Vec<(Ipv4Addr, u8)>,
 }
 
 impl NetworkPolicyDecider {
@@ -425,6 +453,38 @@ impl NetworkPolicyDecider {
             policy,
             cache: NetworkSessionCache::new(),
             auditor,
+            trusted_fakeip_cidrs: Vec::new(),
+        }
+    }
+
+    /// Register IPv4 CIDR ranges to treat as benign fake-IP placeholders.
+    /// Invalid CIDR strings are skipped. See [`Self::is_trusted_fakeip_addr`].
+    #[must_use]
+    pub fn with_trusted_fakeip_cidrs(mut self, cidrs: &[&str]) -> Self {
+        for cidr in cidrs {
+            if let Some(parsed) = parse_ipv4_cidr(cidr) {
+                self.trusted_fakeip_cidrs.push(parsed);
+            }
+        }
+        self
+    }
+
+    /// Whether `ip` falls inside a configured fake-IP placeholder range.
+    ///
+    /// In `fake-ip` proxy/TUN setups the local resolver maps every hostname to
+    /// a reserved range (commonly `198.18.0.0/15`), so the DNS-resolution SSRF
+    /// check would otherwise reject every request. This narrowly trusts only
+    /// those placeholder addresses — real private/loopback/link-local/cloud-
+    /// metadata IPs are *not* matched and stay blocked.
+    #[must_use]
+    pub fn is_trusted_fakeip_addr(&self, ip: &IpAddr) -> bool {
+        match ip {
+            IpAddr::V4(v4) => self
+                .trusted_fakeip_cidrs
+                .iter()
+                .any(|(base, prefix)| ipv4_in_cidr(*v4, *base, *prefix)),
+            // fake-ip placeholders are IPv4-only in practice.
+            IpAddr::V6(_) => false,
         }
     }
 
@@ -641,6 +701,30 @@ mod tests {
 
         assert!(!p.trusts_proxy_fakeip_host("raw.githubusercontent.com"));
         assert!(p.trusts_proxy_fakeip_host("avatars.githubusercontent.com"));
+    }
+
+    #[test]
+    fn trusted_fakeip_cidr_allows_placeholder_but_not_real_private() {
+        let decider = NetworkPolicyDecider::new(NetworkPolicy::default(), None)
+            .with_trusted_fakeip_cidrs(&["198.18.0.0/15"]);
+
+        // fake-ip placeholder range (clash default / IETF benchmark) is trusted
+        assert!(decider.is_trusted_fakeip_addr(&"198.18.0.5".parse::<std::net::IpAddr>().unwrap()));
+        assert!(
+            decider.is_trusted_fakeip_addr(&"198.19.255.255".parse::<std::net::IpAddr>().unwrap())
+        );
+
+        // real private / loopback / link-local / cloud-metadata are NOT trusted
+        for ip in ["192.168.1.1", "10.0.0.1", "127.0.0.1", "169.254.169.254"] {
+            assert!(
+                !decider.is_trusted_fakeip_addr(&ip.parse::<std::net::IpAddr>().unwrap()),
+                "{ip} must not be treated as a fake-ip placeholder"
+            );
+        }
+
+        // no ranges configured → nothing trusted
+        let bare = NetworkPolicyDecider::new(NetworkPolicy::default(), None);
+        assert!(!bare.is_trusted_fakeip_addr(&"198.18.0.5".parse::<std::net::IpAddr>().unwrap()));
     }
 
     #[test]

--- a/crates/tui/src/tools/fetch_url.rs
+++ b/crates/tui/src/tools/fetch_url.rs
@@ -389,8 +389,14 @@ fn validate_dns_resolved_ip(
         return Ok(());
     }
 
+    // Allow the resolved IP past the restricted-IP block if either:
+    //   * it falls inside a configured fake-IP placeholder range (a TUN /
+    //     transparent-proxy setup in `fake-ip` mode resolves every host into a
+    //     reserved range such as `198.18.0.0/15`), or
+    //   * the host is on the explicitly-trusted proxy list.
+    // Real private/loopback/link-local/metadata IPs match neither and stay blocked.
     if let Some(decider) = decider
-        && decider.trusts_proxy_fakeip_host(host)
+        && (decider.is_trusted_fakeip_addr(ip) || decider.trusts_proxy_fakeip_host(host))
     {
         decider.record_trusted_proxy_fakeip_allow(host, "fetch_url");
         return Ok(());


### PR DESCRIPTION
## Summary

The DNS-resolution SSRF guard in `validate_dns_resolved_ip` rejects any hostname that resolves into a restricted IP range. Under a transparent-proxy / TUN setup running in `fake-ip` mode, the local resolver maps **every** hostname into a reserved placeholder range (commonly `198.18.0.0/15`), so the guard rejects all outbound `fetch_url` requests even though the proxy routes them correctly.

This adds a narrowly-scoped, **opt-in** trust list on `NetworkPolicyDecider`:

- `with_trusted_fakeip_cidrs(&["198.18.0.0/15"])` registers IPv4 CIDR ranges to treat as benign fake-ip placeholders. Default is empty — **no behavior change** unless the embedder configures it.
- `is_trusted_fakeip_addr(ip)` matches only those configured ranges.

`validate_dns_resolved_ip` now allows a resolved IP if it is either in a configured fake-ip range **or** the host is on the existing trusted-proxy list. Real private / loopback / link-local / cloud-metadata IPs match neither and stay blocked, so this does not widen SSRF exposure for default configurations.

Includes IPv4 CIDR parse/containment helpers and a unit test covering placeholder-allowed / real-private-blocked / nothing-configured.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo build -p codewhale-tui` (compiles, 42s)
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant (`trusted_fakeip_cidr_allows_placeholder_but_not_real_private`)
- [ ] Verified TUI behavior manually if UI changes (n/a)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an opt-in mechanism to `NetworkPolicyDecider` that lets embedders declare IPv4 CIDR ranges as benign fake-IP placeholders, preventing the DNS-resolution SSRF guard from rejecting all outbound requests in transparent-proxy / TUN `fake-ip` setups. The default configuration is unchanged — no CIDR ranges are trusted unless explicitly registered.

- `with_trusted_fakeip_cidrs` registers CIDR ranges via a builder pattern; `is_trusted_fakeip_addr` tests a resolved IP against them. Both are IPv4-only, consistent with how fake-IP is implemented in practice.
- `validate_dns_resolved_ip` now allows a resolved IP if it matches a configured fake-IP range **or** the host is on the pre-existing trusted-proxy list; all other restricted IPs (loopback, private, link-local, cloud-metadata) continue to be blocked under default configuration.
- A unit test covers placeholder-allowed, real-private-blocked, and nothing-configured cases.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for default deployments; the SSRF bypass is entirely opt-in and the CIDR arithmetic is correct.

The core logic is sound — CIDR masking is applied symmetrically, the prefix-0 edge case is handled before any shift, and IPv4-mapped IPv6 addresses are not affected by the new bypass. Both findings are observability/UX concerns rather than functional defects: invalid CIDR strings are silently dropped with no log, and the audit label is the same whether the IP-range path or the host-list path triggered the allow.

The `with_trusted_fakeip_cidrs` builder in `network_policy.rs` and the updated condition in `fetch_url.rs` are the only files that need a second look.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/tui/src/network_policy.rs | Adds CIDR parse/containment helpers, a `trusted_fakeip_cidrs` field, and a builder method + accessor on `NetworkPolicyDecider`. Logic is correct (prefix-0 edge case handled, mask applied symmetrically to both sides). Minor: invalid CIDRs are silently dropped in `with_trusted_fakeip_cidrs` with no log. |
| crates/tui/src/tools/fetch_url.rs | Extends `validate_dns_resolved_ip` to allow IPs in configured fake-IP CIDR ranges in addition to the existing host-based trust check. The change is minimal and correct; audit label does not distinguish which condition triggered the bypass. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[fetch_url resolves hostname to IP] --> B{is_restricted_ip?}
    B -- No --> C[Allow request]
    B -- Yes --> D{decider configured?}
    D -- No --> E[Block: SSRF guard]
    D -- Yes --> F{is_trusted_fakeip_addr?\nIP in configured CIDR ranges}
    F -- Yes --> G[record_trusted_proxy_fakeip_allow\nAllow request]
    F -- No --> H{trusts_proxy_fakeip_host?\nHost on explicit proxy list}
    H -- Yes --> G
    H -- No --> E
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/tui/src/tools/fetch_url.rs`, line 398-403 ([link](https://github.com/hmbown/codewhale/blob/d43b471d23d704bc533c25237cebb8d84992158e/crates/tui/src/tools/fetch_url.rs#L398-L403)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Audit label doesn't distinguish IP-range bypass from host-list bypass**

   `record_trusted_proxy_fakeip_allow` always writes `"TrustedProxyFakeIp-Allow"` regardless of which branch of the `||` triggered the allow. When the IP matches a configured CIDR (new path) vs. the host being on the explicit proxy trust list (old path), the audit log looks identical. This makes it hard to answer in post-incident analysis whether a bypass came from the new range-trust feature or the pre-existing host allowlist. Consider using a separate audit label (e.g. `"TrustedFakeIpCidr-Allow"`) for the IP-range case.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22pr2%2Ffetch-url-fakeip-trust%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22pr2%2Ffetch-url-fakeip-trust%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftools%2Ffetch_url.rs%0ALine%3A%20398-403%0A%0AComment%3A%0A**Audit%20label%20doesn't%20distinguish%20IP-range%20bypass%20from%20host-list%20bypass**%0A%0A%60record_trusted_proxy_fakeip_allow%60%20always%20writes%20%60%22TrustedProxyFakeIp-Allow%22%60%20regardless%20of%20which%20branch%20of%20the%20%60%7C%7C%60%20triggered%20the%20allow.%20When%20the%20IP%20matches%20a%20configured%20CIDR%20%28new%20path%29%20vs.%20the%20host%20being%20on%20the%20explicit%20proxy%20trust%20list%20%28old%20path%29%2C%20the%20audit%20log%20looks%20identical.%20This%20makes%20it%20hard%20to%20answer%20in%20post-incident%20analysis%20whether%20a%20bypass%20came%20from%20the%20new%20range-trust%20feature%20or%20the%20pre-existing%20host%20allowlist.%20Consider%20using%20a%20separate%20audit%20label%20%28e.g.%20%60%22TrustedFakeIpCidr-Allow%22%60%29%20for%20the%20IP-range%20case.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftools%2Ffetch_url.rs%0ALine%3A%20398-403%0A%0AComment%3A%0A**Audit%20label%20doesn't%20distinguish%20IP-range%20bypass%20from%20host-list%20bypass**%0A%0A%60record_trusted_proxy_fakeip_allow%60%20always%20writes%20%60%22TrustedProxyFakeIp-Allow%22%60%20regardless%20of%20which%20branch%20of%20the%20%60%7C%7C%60%20triggered%20the%20allow.%20When%20the%20IP%20matches%20a%20configured%20CIDR%20%28new%20path%29%20vs.%20the%20host%20being%20on%20the%20explicit%20proxy%20trust%20list%20%28old%20path%29%2C%20the%20audit%20log%20looks%20identical.%20This%20makes%20it%20hard%20to%20answer%20in%20post-incident%20analysis%20whether%20a%20bypass%20came%20from%20the%20new%20range-trust%20feature%20or%20the%20pre-existing%20host%20allowlist.%20Consider%20using%20a%20separate%20audit%20label%20%28e.g.%20%60%22TrustedFakeIpCidr-Allow%22%60%29%20for%20the%20IP-range%20case.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2355&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftools%2Ffetch_url.rs%0ALine%3A%20398-403%0A%0AComment%3A%0A**Audit%20label%20doesn't%20distinguish%20IP-range%20bypass%20from%20host-list%20bypass**%0A%0A%60record_trusted_proxy_fakeip_allow%60%20always%20writes%20%60%22TrustedProxyFakeIp-Allow%22%60%20regardless%20of%20which%20branch%20of%20the%20%60%7C%7C%60%20triggered%20the%20allow.%20When%20the%20IP%20matches%20a%20configured%20CIDR%20%28new%20path%29%20vs.%20the%20host%20being%20on%20the%20explicit%20proxy%20trust%20list%20%28old%20path%29%2C%20the%20audit%20log%20looks%20identical.%20This%20makes%20it%20hard%20to%20answer%20in%20post-incident%20analysis%20whether%20a%20bypass%20came%20from%20the%20new%20range-trust%20feature%20or%20the%20pre-existing%20host%20allowlist.%20Consider%20using%20a%20separate%20audit%20label%20%28e.g.%20%60%22TrustedFakeIpCidr-Allow%22%60%29%20for%20the%20IP-range%20case.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2355&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22pr2%2Ffetch-url-fakeip-trust%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22pr2%2Ffetch-url-fakeip-trust%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fnetwork_policy.rs%3A463-469%0A**Silent%20CIDR%20skip%20makes%20misconfiguration%20invisible**%0A%0AInvalid%20CIDR%20strings%20passed%20to%20%60with_trusted_fakeip_cidrs%60%20are%20silently%20discarded.%20If%20an%20operator%20types%20%60%22198.18.0.0-15%22%60%20or%20%60%22198.18.0.0%2F55%22%60%20by%20mistake%2C%20every%20request%20that%20resolves%20into%20that%20range%20will%20continue%20to%20be%20blocked%20with%20no%20indication%20that%20the%20configuration%20was%20rejected.%20A%20%60tracing%3A%3Awarn!%60%20%28or%20at%20minimum%20a%20debug%20log%29%20when%20a%20CIDR%20fails%20to%20parse%20would%20make%20these%20silent%20drops%20visible%20in%20the%20existing%20audit%20log%20infrastructure.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftools%2Ffetch_url.rs%3A398-403%0A**Audit%20label%20doesn't%20distinguish%20IP-range%20bypass%20from%20host-list%20bypass**%0A%0A%60record_trusted_proxy_fakeip_allow%60%20always%20writes%20%60%22TrustedProxyFakeIp-Allow%22%60%20regardless%20of%20which%20branch%20of%20the%20%60%7C%7C%60%20triggered%20the%20allow.%20When%20the%20IP%20matches%20a%20configured%20CIDR%20%28new%20path%29%20vs.%20the%20host%20being%20on%20the%20explicit%20proxy%20trust%20list%20%28old%20path%29%2C%20the%20audit%20log%20looks%20identical.%20This%20makes%20it%20hard%20to%20answer%20in%20post-incident%20analysis%20whether%20a%20bypass%20came%20from%20the%20new%20range-trust%20feature%20or%20the%20pre-existing%20host%20allowlist.%20Consider%20using%20a%20separate%20audit%20label%20%28e.g.%20%60%22TrustedFakeIpCidr-Allow%22%60%29%20for%20the%20IP-range%20case.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fnetwork_policy.rs%3A463-469%0A**Silent%20CIDR%20skip%20makes%20misconfiguration%20invisible**%0A%0AInvalid%20CIDR%20strings%20passed%20to%20%60with_trusted_fakeip_cidrs%60%20are%20silently%20discarded.%20If%20an%20operator%20types%20%60%22198.18.0.0-15%22%60%20or%20%60%22198.18.0.0%2F55%22%60%20by%20mistake%2C%20every%20request%20that%20resolves%20into%20that%20range%20will%20continue%20to%20be%20blocked%20with%20no%20indication%20that%20the%20configuration%20was%20rejected.%20A%20%60tracing%3A%3Awarn!%60%20%28or%20at%20minimum%20a%20debug%20log%29%20when%20a%20CIDR%20fails%20to%20parse%20would%20make%20these%20silent%20drops%20visible%20in%20the%20existing%20audit%20log%20infrastructure.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftools%2Ffetch_url.rs%3A398-403%0A**Audit%20label%20doesn't%20distinguish%20IP-range%20bypass%20from%20host-list%20bypass**%0A%0A%60record_trusted_proxy_fakeip_allow%60%20always%20writes%20%60%22TrustedProxyFakeIp-Allow%22%60%20regardless%20of%20which%20branch%20of%20the%20%60%7C%7C%60%20triggered%20the%20allow.%20When%20the%20IP%20matches%20a%20configured%20CIDR%20%28new%20path%29%20vs.%20the%20host%20being%20on%20the%20explicit%20proxy%20trust%20list%20%28old%20path%29%2C%20the%20audit%20log%20looks%20identical.%20This%20makes%20it%20hard%20to%20answer%20in%20post-incident%20analysis%20whether%20a%20bypass%20came%20from%20the%20new%20range-trust%20feature%20or%20the%20pre-existing%20host%20allowlist.%20Consider%20using%20a%20separate%20audit%20label%20%28e.g.%20%60%22TrustedFakeIpCidr-Allow%22%60%29%20for%20the%20IP-range%20case.%0A%0A&repo=hmbown%2Fcodewhale&pr=2355&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fnetwork_policy.rs%3A463-469%0A**Silent%20CIDR%20skip%20makes%20misconfiguration%20invisible**%0A%0AInvalid%20CIDR%20strings%20passed%20to%20%60with_trusted_fakeip_cidrs%60%20are%20silently%20discarded.%20If%20an%20operator%20types%20%60%22198.18.0.0-15%22%60%20or%20%60%22198.18.0.0%2F55%22%60%20by%20mistake%2C%20every%20request%20that%20resolves%20into%20that%20range%20will%20continue%20to%20be%20blocked%20with%20no%20indication%20that%20the%20configuration%20was%20rejected.%20A%20%60tracing%3A%3Awarn!%60%20%28or%20at%20minimum%20a%20debug%20log%29%20when%20a%20CIDR%20fails%20to%20parse%20would%20make%20these%20silent%20drops%20visible%20in%20the%20existing%20audit%20log%20infrastructure.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftools%2Ffetch_url.rs%3A398-403%0A**Audit%20label%20doesn't%20distinguish%20IP-range%20bypass%20from%20host-list%20bypass**%0A%0A%60record_trusted_proxy_fakeip_allow%60%20always%20writes%20%60%22TrustedProxyFakeIp-Allow%22%60%20regardless%20of%20which%20branch%20of%20the%20%60%7C%7C%60%20triggered%20the%20allow.%20When%20the%20IP%20matches%20a%20configured%20CIDR%20%28new%20path%29%20vs.%20the%20host%20being%20on%20the%20explicit%20proxy%20trust%20list%20%28old%20path%29%2C%20the%20audit%20log%20looks%20identical.%20This%20makes%20it%20hard%20to%20answer%20in%20post-incident%20analysis%20whether%20a%20bypass%20came%20from%20the%20new%20range-trust%20feature%20or%20the%20pre-existing%20host%20allowlist.%20Consider%20using%20a%20separate%20audit%20label%20%28e.g.%20%60%22TrustedFakeIpCidr-Allow%22%60%29%20for%20the%20IP-range%20case.%0A%0A&pr=2355&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(fetch\_url): optionally trust fake-ip..."](https://github.com/hmbown/codewhale/commit/d43b471d23d704bc533c25237cebb8d84992158e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34558704)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->