### PR TITLE
  fix(mcp): avoid nested runtime panic on stdio shutdown

### DIFF
--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -934,7 +934,7 @@ async fn main() -> Result<()> {
                     bail!("Choose exactly one server mode: --mcp, --http, or --acp");
                 }
                 if args.mcp {
-                    mcp_server::run_mcp_server(workspace)
+                    tokio::task::block_in_place(|| mcp_server::run_mcp_server(workspace))
                 } else if args.http {
                     let config = load_config_from_cli(&cli)?;
                     let cors_origins = resolve_cors_origins(&config, &args.cors_origin);


### PR DESCRIPTION
## Summary

Fixes #2352.

  `codewhale-tui serve --mcp` could panic when stdin closed, for example when an MCP client disconnected or when running:

  ```bash
  ./target/debug/codewhale-tui serve --mcp < /dev/null
```

 The panic happened because the CLI entrypoint already runs inside Tokio, while the stdio MCP server creates and owns its own runtime. When stdin closed, that inner runtime was dropped from the async context, triggering Tokio's "Cannot drop a runtime in a context where blocking is not allowed" panic.

This change runs the stdio MCP server through tokio::task::block_in_place, keeping the existing synchronous MCP implementation while allowing its internal runtime to shut down safely.

## Testing

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a panic in `codewhale-tui serve --mcp` that occurred when stdin was closed — the root cause being that `McpServer::run` creates its own `tokio::Runtime` and dropping it from within the outer async context violates Tokio's "no blocking drop" invariant. The fix wraps the call in `tokio::task::block_in_place`, which moves the current thread out of the async pool and allows the inner runtime to be dropped safely.

- **One-line change** in `crates/tui/src/main.rs`: `mcp_server::run_mcp_server(workspace)` is now called inside `tokio::task::block_in_place(|| ...)`, keeping the synchronous MCP implementation intact while resolving the shutdown panic.
- **Implicit runtime-flavor dependency**: `block_in_place` requires a multi-threaded outer runtime; the default `#[tokio::main]` satisfies this, but no comment or assertion documents the assumption.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the fix correctly resolves the nested-runtime drop panic with the current multi-threaded executor.

The change is minimal and well-targeted. `block_in_place` is the right primitive here — it lets the synchronous `run_mcp_server` (which creates and drops its own `tokio::Runtime`) execute safely from within the outer async context. The only latent concern is that `block_in_place` will itself panic if the outer runtime is ever changed to `current_thread` flavor, which is an undocumented assumption in the changed line. This doesn't affect correctness today but is worth a clarifying comment.

Only `crates/tui/src/main.rs` changed; the `mcp_server.rs` implementation is unchanged and was read for context only.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/main.rs | Single-line fix wrapping the synchronous MCP server call in `block_in_place` to prevent a nested-runtime drop panic; correct approach for the multi-threaded outer runtime, but silently breaks if the outer runtime is ever switched to `current_thread` flavor. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant OS as OS / Shell
    participant Main as async main (Tokio multi-thread)
    participant BIP as block_in_place thread
    participant MCP as McpServer (sync)
    participant RT as Inner tokio::Runtime

    OS->>Main: launch codewhale-tui serve --mcp
    Main->>BIP: "tokio::task::block_in_place(|| ...)"
    Note over BIP: current thread exits async pool,<br/>blocking is now allowed
    BIP->>MCP: mcp_server::run_mcp_server(workspace)
    MCP->>RT: Runtime::new()
    MCP->>MCP: stdin line loop (blocking)
    MCP-->>RT: runtime.block_on(tool calls)
    OS-->>MCP: stdin closed / client disconnect
    MCP->>RT: drop Runtime (safe — not in async context)
    MCP-->>BIP: Ok(())
    BIP-->>Main: Result returned
    Main-->>OS: process exits
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fmcp-stdio-runtime-shutdown%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fmcp-stdio-runtime-shutdown%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fmain.rs%3A936-937%0A%60block_in_place%60%20panics%20at%20runtime%20with%20%22Cannot%20use%20%60blocking%60%20in%20a%20%60current_thread%60%20Tokio%20runtime%22%20if%20the%20outer%20executor%20is%20ever%20switched%20to%20%60%23%5Btokio%3A%3Amain%28flavor%20%3D%20%22current_thread%22%29%5D%60.%20The%20current%20default%20multi-threaded%20runtime%20is%20fine%2C%20but%20the%20assumption%20isn't%20enforced%20anywhere.%20A%20small%20comment%20would%20make%20this%20dependency%20explicit%20and%20prevent%20a%20silent%20breakage%20if%20the%20runtime%20flavor%20changes%20later.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20args.mcp%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20block_in_place%20requires%20a%20multi-threaded%20runtime%20%28the%20default%20for%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20%23%5Btokio%3A%3Amain%5D%29.%20It%20allows%20the%20inner%20tokio%3A%3ARuntime%20created%20by%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20run_mcp_server%20to%20be%20dropped%20safely%20without%20triggering%20the%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20%22Cannot%20drop%20a%20runtime%20in%20a%20context%20where%20blocking%20is%20not%20allowed%22%20panic.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20tokio%3A%3Atask%3A%3Ablock_in_place%28%7C%7C%20mcp_server%3A%3Arun_mcp_server%28workspace%29%29%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fmain.rs%3A936-937%0A%60block_in_place%60%20panics%20at%20runtime%20with%20%22Cannot%20use%20%60blocking%60%20in%20a%20%60current_thread%60%20Tokio%20runtime%22%20if%20the%20outer%20executor%20is%20ever%20switched%20to%20%60%23%5Btokio%3A%3Amain%28flavor%20%3D%20%22current_thread%22%29%5D%60.%20The%20current%20default%20multi-threaded%20runtime%20is%20fine%2C%20but%20the%20assumption%20isn't%20enforced%20anywhere.%20A%20small%20comment%20would%20make%20this%20dependency%20explicit%20and%20prevent%20a%20silent%20breakage%20if%20the%20runtime%20flavor%20changes%20later.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20args.mcp%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20block_in_place%20requires%20a%20multi-threaded%20runtime%20%28the%20default%20for%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20%23%5Btokio%3A%3Amain%5D%29.%20It%20allows%20the%20inner%20tokio%3A%3ARuntime%20created%20by%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20run_mcp_server%20to%20be%20dropped%20safely%20without%20triggering%20the%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20%22Cannot%20drop%20a%20runtime%20in%20a%20context%20where%20blocking%20is%20not%20allowed%22%20panic.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20tokio%3A%3Atask%3A%3Ablock_in_place%28%7C%7C%20mcp_server%3A%3Arun_mcp_server%28workspace%29%29%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2357&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fmain.rs%3A936-937%0A%60block_in_place%60%20panics%20at%20runtime%20with%20%22Cannot%20use%20%60blocking%60%20in%20a%20%60current_thread%60%20Tokio%20runtime%22%20if%20the%20outer%20executor%20is%20ever%20switched%20to%20%60%23%5Btokio%3A%3Amain%28flavor%20%3D%20%22current_thread%22%29%5D%60.%20The%20current%20default%20multi-threaded%20runtime%20is%20fine%2C%20but%20the%20assumption%20isn't%20enforced%20anywhere.%20A%20small%20comment%20would%20make%20this%20dependency%20explicit%20and%20prevent%20a%20silent%20breakage%20if%20the%20runtime%20flavor%20changes%20later.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20args.mcp%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20block_in_place%20requires%20a%20multi-threaded%20runtime%20%28the%20default%20for%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20%23%5Btokio%3A%3Amain%5D%29.%20It%20allows%20the%20inner%20tokio%3A%3ARuntime%20created%20by%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20run_mcp_server%20to%20be%20dropped%20safely%20without%20triggering%20the%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20%22Cannot%20drop%20a%20runtime%20in%20a%20context%20where%20blocking%20is%20not%20allowed%22%20panic.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20tokio%3A%3Atask%3A%3Ablock_in_place%28%7C%7C%20mcp_server%3A%3Arun_mcp_server%28workspace%29%29%0A%60%60%60%0A%0A&pr=2357&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(mcp): avoid nested runtime panic on ..."](https://github.com/hmbown/codewhale/commit/9ce3e52064dd5e206d04a91799c07da3150f0fbb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34581847)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->