### PR TITLE
  fix(provider): name DeepSeek in provider help text

### DIFF
--- a/crates/tui/src/localization.rs
+++ b/crates/tui/src/localization.rs
@@ -959,7 +959,7 @@ fn english(id: MessageId) -> &'static str {
         MessageId::CmdNoteDescription => "Add, list, edit, or remove workspace notes",
         MessageId::CmdThemeDescription => "Switch theme or open the theme picker",
         MessageId::CmdProviderDescription => {
-            "Switch or view the active LLM backend (codewhale | nvidia-nim | ollama)"
+            "Switch or view the active LLM backend (deepseek | nvidia-nim | ollama)"
         }
         MessageId::CmdQueueDescription => "View or edit queued messages",
         MessageId::CmdRecallDescription => "Search prior cycle archives (BM25 over message text)",
@@ -1346,7 +1346,7 @@ fn japanese(id: MessageId) -> Option<&'static str> {
             "テーマを切り替え（ダーク/ライト/グレースケール/システム）"
         }
         MessageId::CmdProviderDescription => {
-            "現在の LLM バックエンドを切り替え・確認（codewhale | nvidia-nim | ollama）"
+            "現在の LLM バックエンドを切り替え・確認（deepseek | nvidia-nim | ollama）"
         }
         MessageId::CmdQueueDescription => "キューされたメッセージを確認・編集",
         MessageId::CmdRecallDescription => {
@@ -1692,7 +1692,7 @@ fn chinese_simplified(id: MessageId) -> Option<&'static str> {
         MessageId::CmdNoteDescription => "添加、列出、编辑或删除工作区笔记",
         MessageId::CmdThemeDescription => "切换主题：深色、浅色、灰度或系统",
         MessageId::CmdProviderDescription => {
-            "切换或查看当前 LLM 后端（codewhale | nvidia-nim | ollama）"
+            "切换或查看当前 LLM 后端（deepseek | nvidia-nim | ollama）"
         }
         MessageId::CmdQueueDescription => "查看或编辑已排队的消息",
         MessageId::CmdRecallDescription => "搜索此前的循环归档（基于消息文本的 BM25 检索）",
@@ -2022,7 +2022,7 @@ fn portuguese_brazil(id: MessageId) -> Option<&'static str> {
         MessageId::CmdNoteDescription => "Adicionar, listar, editar ou remover notas do workspace",
         MessageId::CmdThemeDescription => "Alternar tema: escuro, claro, tons de cinza ou sistema",
         MessageId::CmdProviderDescription => {
-            "Trocar ou exibir o backend LLM ativo (codewhale | nvidia-nim | ollama)"
+            "Trocar ou exibir o backend LLM ativo (deepseek | nvidia-nim | ollama)"
         }
         MessageId::CmdQueueDescription => "Ver ou editar mensagens enfileiradas",
         MessageId::CmdRecallDescription => {
@@ -2414,7 +2414,7 @@ fn spanish_latin_america(id: MessageId) -> Option<&'static str> {
         MessageId::CmdNoteDescription => "Agregar nota al archivo persistente (.deepseek/notes.md)",
         MessageId::CmdThemeDescription => "Alternar entre tema claro y oscuro",
         MessageId::CmdProviderDescription => {
-            "Cambiar o mostrar el backend LLM activo (codewhale | nvidia-nim | ollama)"
+            "Cambiar o mostrar el backend LLM activo (deepseek | nvidia-nim | ollama)"
         }
         MessageId::CmdQueueDescription => "Ver o editar mensajes en cola",
         MessageId::CmdRecallDescription => {
@@ -2768,6 +2768,23 @@ mod tests {
             fallback_translation(None, MessageId::ComposerPlaceholder),
             english(MessageId::ComposerPlaceholder)
         );
+    }
+
+    #[test]
+    fn provider_description_names_deepseek_backend() {
+        for locale in Locale::shipped() {
+            let description = tr(*locale, MessageId::CmdProviderDescription);
+            assert!(
+                description.contains("deepseek"),
+                "{} provider description should mention deepseek: {description}",
+                locale.tag()
+            );
+            assert!(
+                !description.contains("codewhale |"),
+                "{} provider description should not name codewhale as a backend: {description}",
+                locale.tag()
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

  Fixes #2363.

  `/provider` help and completion text described the active LLM backend options as:

  ```text
  codewhale | nvidia-nim | ollama
```

  That is confusing because codewhale is the app name, not a provider id accepted by /provider. The actual provider id is deepseek.

  This updates the shipped locale descriptions to show:

  deepseek | nvidia-nim | ollama

  and adds a regression test so the provider help text does not drift back to naming codewhale as a backend.

<img width="652" height="115" alt="image" src="https://github.com/user-attachments/assets/bd906be9-bd37-4de6-9855-7ad402ec9f82" />


## Testing

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Corrects a mislabeled provider name in the `/provider` command help text: the app name "codewhale" was incorrectly listed as a backend identifier in place of the actual provider id "deepseek". The fix is applied to all five actively translated locales (English, Japanese, Simplified Chinese, Brazilian Portuguese, Latin American Spanish); Traditional Chinese inherits the correction through its existing fallback to Simplified Chinese.

- Renames `codewhale` → `deepseek` in `CmdProviderDescription` across all locale functions in `localization.rs`.
- Adds a `provider_description_names_deepseek_backend` test that iterates `Locale::shipped()` and asserts the text contains "deepseek" and does not contain "codewhale |".
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — purely a string correction in locale help text with no logic changes and a new regression test.

All six shipped locales now show the correct provider id; Traditional Chinese inherits the fix through its fallback. The new test covers every locale. The only observation is a minor gap in the negative assertion pattern, which does not affect correctness today.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/localization.rs | Replaces "codewhale" with "deepseek" in CmdProviderDescription across all 5 translated locales (en, ja, zh-Hans, pt-BR, es-419), with ZhHant inheriting the zh-Hans fix via its existing fallback chain; adds a regression test covering all shipped locales. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["tr(locale, CmdProviderDescription)"] --> B{locale}
    B -->|En| C["english() → 'deepseek | nvidia-nim | ollama'"]
    B -->|Ja| D["japanese() → 'deepseek | nvidia-nim | ollama'"]
    B -->|ZhHans| E["chinese_simplified() → 'deepseek | nvidia-nim | ollama'"]
    B -->|ZhHant| F["traditional_chinese()"]
    F -->|CmdProviderDescription not overridden| E
    B -->|PtBr| G["portuguese_brazil() → 'deepseek | nvidia-nim | ollama'"]
    B -->|Es419| H["spanish_latin_america() → 'deepseek | nvidia-nim | ollama'"]
    C & D & E & G & H --> I["Regression test: contains 'deepseek' ✓\nnot contains 'codewhale |' ✓"]
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fprovider-description-deepseek%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fprovider-description-deepseek%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Flocalization.rs%3A2777-2783%0A**Negative%20assertion%20may%20be%20too%20narrow%20to%20catch%20future%20regressions**%0A%0AThe%20guard%20%60!description.contains%28%22codewhale%20%7C%22%29%60%20requires%20both%20the%20name%20and%20a%20trailing%20space%20%2B%20pipe%20to%20match%2C%20so%20a%20typo%20like%20%60%22codewhale%7C%22%60%20or%20just%20%60%22codewhale%22%60%20would%20slip%20past%20it%20silently.%20Checking%20%60!description.contains%28%22codewhale%22%29%60%20%28without%20the%20pipe%29%20would%20be%20a%20stricter%20backstop%20against%20any%20form%20of%20the%20wrong%20name%20reappearing%20in%20this%20string.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Flocalization.rs%3A2777-2783%0A**Negative%20assertion%20may%20be%20too%20narrow%20to%20catch%20future%20regressions**%0A%0AThe%20guard%20%60!description.contains%28%22codewhale%20%7C%22%29%60%20requires%20both%20the%20name%20and%20a%20trailing%20space%20%2B%20pipe%20to%20match%2C%20so%20a%20typo%20like%20%60%22codewhale%7C%22%60%20or%20just%20%60%22codewhale%22%60%20would%20slip%20past%20it%20silently.%20Checking%20%60!description.contains%28%22codewhale%22%29%60%20%28without%20the%20pipe%29%20would%20be%20a%20stricter%20backstop%20against%20any%20form%20of%20the%20wrong%20name%20reappearing%20in%20this%20string.%0A%0A&repo=hmbown%2Fcodewhale&pr=2366&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Flocalization.rs%3A2777-2783%0A**Negative%20assertion%20may%20be%20too%20narrow%20to%20catch%20future%20regressions**%0A%0AThe%20guard%20%60!description.contains%28%22codewhale%20%7C%22%29%60%20requires%20both%20the%20name%20and%20a%20trailing%20space%20%2B%20pipe%20to%20match%2C%20so%20a%20typo%20like%20%60%22codewhale%7C%22%60%20or%20just%20%60%22codewhale%22%60%20would%20slip%20past%20it%20silently.%20Checking%20%60!description.contains%28%22codewhale%22%29%60%20%28without%20the%20pipe%29%20would%20be%20a%20stricter%20backstop%20against%20any%20form%20of%20the%20wrong%20name%20reappearing%20in%20this%20string.%0A%0A&pr=2366&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(provider): name DeepSeek in provider..."](https://github.com/hmbown/codewhale/commit/5b60b530a0fe4891ae704fb13e6ec41aef71ccde) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34676940)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->