### PR TITLE
test(tui): make composer history flush deterministic

### DIFF
--- a/crates/tui/src/composer_history.rs
+++ b/crates/tui/src/composer_history.rs
@@ -79,29 +79,44 @@ pub fn append_history(entry: &str) {
 /// write if the channel send fails) so callers never block on disk I/O.
 fn append_history_dispatched(path: &Path, entry: &str) {
     let entry = entry.to_string();
-    if writer_sender()
-        .send((path.to_path_buf(), entry.clone()))
-        .is_err()
-    {
-        append_history_to(path, &entry);
+    if let Err(err) = writer_sender().send(HistoryWrite::Append(path.to_path_buf(), entry)) {
+        match err.0 {
+            HistoryWrite::Append(path, entry) => append_history_to(&path, &entry),
+            #[cfg(test)]
+            HistoryWrite::Flush(_) => unreachable!("flush messages are only sent by tests"),
+        }
     }
+}
+
+enum HistoryWrite {
+    Append(PathBuf, String),
+    #[cfg(test)]
+    Flush(Sender<()>),
 }
 
 /// Lazy singleton sender for the dedicated composer-history writer
 /// thread. Initialised on first use; the thread runs for the lifetime
 /// of the process and drains queued writes in arrival order.
-fn writer_sender() -> &'static Sender<(PathBuf, String)> {
-    static SENDER: OnceLock<Sender<(PathBuf, String)>> = OnceLock::new();
+fn writer_sender() -> &'static Sender<HistoryWrite> {
+    static SENDER: OnceLock<Sender<HistoryWrite>> = OnceLock::new();
     SENDER.get_or_init(|| {
-        let (tx, rx) = channel::<(PathBuf, String)>();
+        let (tx, rx) = channel::<HistoryWrite>();
         let spawn_result = std::thread::Builder::new()
             .name("composer-history-writer".to_string())
             .spawn(move || {
                 // recv() returns Err when all senders have dropped, which
                 // only happens at process shutdown because the singleton
                 // sender lives in a static for the lifetime of the process.
-                while let Ok(first) = rx.recv() {
-                    append_history_batch(&rx, first);
+                while let Ok(message) = rx.recv() {
+                    match message {
+                        HistoryWrite::Append(path, entry) => {
+                            append_history_batch(&rx, (path, entry));
+                        }
+                        #[cfg(test)]
+                        HistoryWrite::Flush(done) => {
+                            let _ = done.send(());
+                        }
+                    }
                 }
             });
         if let Err(err) = spawn_result {
@@ -111,12 +126,19 @@ fn writer_sender() -> &'static Sender<(PathBuf, String)> {
     })
 }
 
-fn append_history_batch(rx: &Receiver<(PathBuf, String)>, first: (PathBuf, String)) {
+fn append_history_batch(rx: &Receiver<HistoryWrite>, first: (PathBuf, String)) {
     let mut pending = vec![first];
+    #[cfg(test)]
+    let mut flush = None;
 
     loop {
         match rx.recv_timeout(Duration::from_millis(2)) {
-            Ok(next) => pending.push(next),
+            Ok(HistoryWrite::Append(path, entry)) => pending.push((path, entry)),
+            #[cfg(test)]
+            Ok(HistoryWrite::Flush(done)) => {
+                flush = Some(done);
+                break;
+            }
             Err(RecvTimeoutError::Timeout) => break,
             Err(RecvTimeoutError::Disconnected) => break,
         }
@@ -124,6 +146,11 @@ fn append_history_batch(rx: &Receiver<(PathBuf, String)>, first: (PathBuf, Strin
 
     for (path, entries) in group_history_writes_by_path(pending) {
         append_history_entries_to(&path, entries.iter().map(String::as_str));
+    }
+
+    #[cfg(test)]
+    if let Some(done) = flush {
+        let _ = done.send(());
     }
 }
 
@@ -201,6 +228,7 @@ fn append_history_entries_to<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::{Duration, Instant};
 
     /// Tests use the path-injecting `*_from` / `*_to` helpers so they
     /// don't have to mutate `HOME` (which is not honored by
@@ -211,6 +239,16 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let path = tmp.path().join(HISTORY_FILE_NAME);
         (tmp, path)
+    }
+
+    fn flush_history_writer_for_tests(timeout: Duration) {
+        let (done_tx, done_rx) = channel();
+        writer_sender()
+            .send(HistoryWrite::Flush(done_tx))
+            .expect("history writer accepts flush");
+        done_rx
+            .recv_timeout(timeout)
+            .expect("history writer flush timed out");
     }
 
     #[test]
@@ -283,8 +321,6 @@ mod tests {
     /// stall the user reports.
     #[test]
     fn append_history_dispatched_does_not_block_the_caller() {
-        use std::time::{Duration, Instant};
-
         let (_tmp, path) = temp_history_path();
         // Seed close to the cap so a synchronous rewrite is non-trivial.
         let seed = (0..(MAX_HISTORY_ENTRIES - 50))
@@ -311,26 +347,16 @@ mod tests {
              (likely re-introduced #1927: caller blocked on disk write)"
         );
 
-        // Give the writer thread time to drain the queue, then verify the
-        // new entries landed.
-        // Use 10s on Windows (slow CI I/O) vs 5s on other platforms.
-        let deadline = Instant::now() + Duration::from_secs(if cfg!(windows) { 10 } else { 5 });
-        loop {
-            let loaded = load_history_from(&path);
-            if loaded.iter().any(|line| line == "new entry 49") {
-                // Last dispatched entry observed; queue is drained.
-                assert!(loaded.iter().any(|line| line == "new entry 0"));
-                break;
-            }
-            if Instant::now() >= deadline {
-                panic!(
-                    "writer thread did not persist the dispatched entries; \
-                     loaded {} entries, last = {:?}",
-                    loaded.len(),
-                    loaded.last()
-                );
-            }
-            std::thread::sleep(Duration::from_millis(25));
-        }
+        flush_history_writer_for_tests(Duration::from_secs(if cfg!(windows) { 10 } else { 5 }));
+
+        let loaded = load_history_from(&path);
+        assert!(
+            loaded.iter().any(|line| line == "new entry 49"),
+            "writer thread did not persist the dispatched entries; \
+             loaded {} entries, last = {:?}",
+            loaded.len(),
+            loaded.last()
+        );
+        assert!(loaded.iter().any(|line| line == "new entry 0"));
     }
 }


### PR DESCRIPTION
## Summary

- replace the composer history writer test's polling loop with a deterministic test-only flush message
- keep production writes on the same async writer thread and preserve arrival-order batching
- verify the dispatched append test after the writer has processed all prior queued writes

## Why

The Windows CI failure seen on #2252 timed out while waiting for the async composer history writer to persist entries. The runtime envelope diff does not touch this path; the failure comes from the test relying on sleep/polling to observe a background writer.

This change gives tests a queue barrier instead. After the append messages are sent, the test sends `Flush` through the same channel and waits for the writer thread to acknowledge it. That makes the assertion depend on writer ordering instead of scheduler timing.

## Verification

- `cargo test -p codewhale-tui composer_history::tests::append_history_dispatched_does_not_block_the_caller --all-features --locked -- --nocapture`
- `cargo fmt`
- `cargo test -p codewhale-tui composer_history::tests --all-features --locked -- --nocapture`
- `cargo check -p codewhale-tui --all-features --locked`
- `git diff --check`
- repeated `append_history_dispatched_does_not_block_the_caller` 20 times locally

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces a timing-dependent polling loop in the composer history writer test with a deterministic queue-barrier mechanism, fixing a flaky Windows CI timeout (#2252). The change is test-infrastructure only — production write behavior is unchanged.

- Introduces a `cfg(test)`-only `HistoryWrite::Flush(Sender<()>)` variant that, when received by the writer thread, signals completion after all previously enqueued `Append` messages have been written to disk.
- Replaces the `sleep`/polling loop in `append_history_dispatched_does_not_block_the_caller` with a `flush_history_writer_for_tests` helper that sends `Flush` through the same FIFO channel and blocks on an ack, making the assertion depend on writer ordering rather than scheduler timing.
- Moves the `Duration`/`Instant` import to the module level since `flush_history_writer_for_tests` also needs `Duration`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is confined to test infrastructure and adds no production-path risk.

The flush mechanism is cfg(test)-only, production write semantics are untouched, and the FIFO channel guarantees the writer has processed all prior appends before acknowledging the flush. Both the batch-internal and outer-loop Flush handling paths correctly ack only after preceding writes complete. The test still covers the non-blocking dispatch assertion and verifies both first and last dispatched entries landed on disk.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/composer_history.rs | Replaces polling-loop test with a deterministic flush barrier; production code paths are unchanged. Logic is sound: channel FIFO ordering guarantees all prior Append messages are processed before Flush is acknowledged. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant T as Test Thread
    participant CH as Channel (FIFO)
    participant W as Writer Thread

    T->>CH: Append("new entry 0")
    T->>CH: Append("new entry 1")
    Note over T,CH: ... (50 total)
    T->>CH: Append("new entry 49")
    T->>CH: Flush(done_tx)
    T->>T: "assert dispatch < 150ms"

    W->>CH: recv() → Append("new entry 0")
    W->>W: append_history_batch()
    Note over W: batch drains remaining Appends within 2ms recv_timeout window
    W->>CH: recv_timeout() → Append("new entry 1..49")
    W->>CH: recv_timeout() → Flush(done_tx)
    W->>W: write batch to disk
    W->>T: done_tx.send(())

    T->>T: done_rx.recv_timeout() ← ()
    T->>T: load_history_from(path)
    T->>T: assert "new entry 49" present
    T->>T: assert "new entry 0" present
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test(tui): make composer history flush d..."](https://github.com/hmbown/codewhale/commit/f8e3aa24d65a665b8f3fc1d6cd4ad2d971de12e6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34706790)</sub>

<!-- /greptile_comment -->