### PR TITLE
  fix(tui): highlight user messages in cached transcript

### DIFF
--- a/crates/tui/src/tui/history.rs
+++ b/crates/tui/src/tui/history.rs
@@ -309,13 +309,9 @@ impl HistoryCell {
         options: TranscriptRenderOptions,
     ) -> Vec<RenderedTranscriptLine> {
         match self {
-            HistoryCell::User { content } => render_message_with_copy_metadata(
-                USER_GLYPH,
-                user_label_style(),
-                user_body_style(),
-                content,
-                width,
-            ),
+            HistoryCell::User { content } => {
+                hard_break_copy_lines(render_user_message(content, width))
+            }
             HistoryCell::Assistant { content, streaming } => render_message_with_copy_metadata(
                 ASSISTANT_GLYPH,
                 assistant_label_style_for(*streaming, options.low_motion),

--- a/crates/tui/src/tui/transcript.rs
+++ b/crates/tui/src/tui/transcript.rs
@@ -554,6 +554,7 @@ fn truncate_spans_to_width(spans: Vec<Span<'static>>, max_width: usize) -> Vec<S
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::palette;
     use crate::tui::history::{ExecCell, ExecSource, HistoryCell, ToolCell, ToolStatus};
 
     fn plain_lines(cache: &TranscriptViewCache) -> Vec<String> {
@@ -593,6 +594,20 @@ mod tests {
             interaction: None,
             output_summary: None,
         }))
+    }
+
+    #[test]
+    fn cache_renders_user_cells_with_highlight_background() {
+        let cells = vec![user_cell("# literal user prompt")];
+        let revisions = vec![1u64];
+
+        let mut cache = TranscriptViewCache::new();
+        cache.ensure(&cells, &revisions, 40, TranscriptRenderOptions::default());
+
+        let lines = cache.lines();
+        assert_eq!(lines[0].style.bg, Some(palette::SURFACE_ELEVATED));
+        assert_eq!(lines[0].width(), 40);
+        assert_eq!(plain_lines(&cache)[0].trim_end(), "▎ # literal user prompt");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes https://github.com/Hmbown/CodeWhale/issues/1672

  Submitted user messages were intended to stand out with a full-row highlight, but the main chat transcript did
  not show it. The existing highlight renderer was only used by some render paths; the cached transcript path used
  by the live chat view bypassed it.

  This updates user cells in the transcript cache path to reuse the existing user-message renderer, so submitted
  prompts get the same full-row background in the main TUI transcript.

previsous pr #1703

from:
<img width="759" height="504" alt="image" src="https://github.com/user-attachments/assets/25424deb-e6f8-45e2-b70f-54b69c043788" />


to:

<img width="777" height="560" alt="image" src="https://github.com/user-attachments/assets/69491052-5066-4249-b05b-0102391f9a53" />



## Testing

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes user message highlighting in the cached transcript path by replacing the old `render_message_with_copy_metadata` call with `render_user_message` (wrapped in `hard_break_copy_lines`), aligning the cache path with the live-view path that already applied `apply_user_message_highlight`.

- The `lines_with_copy_metadata` user branch now calls `render_user_message`, which applies the full-row `SURFACE_ELEVATED` background and pads to the full terminal width, matching what the live chat view renders.
- The change also switches user-message rendering in this path from `render_markdown_tagged` to `render_plain_message`, making it consistent with `lines_with_options` and `transcript_lines`, both of which already treat user input as plain text.
- A new test `cache_renders_user_cells_with_highlight_background` in `transcript.rs` directly verifies the background colour, line width, and literal text rendering of the fixed path.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted one-line swap in a single match arm, reusing a well-tested renderer already used by two other code paths.

The fix delegates to render_user_message, which is already exercised by lines_with_options and covered by existing tests. The new test directly asserts the background colour, line width, and rendered text for the previously-broken cache path. No other match arms are touched, and the assistant/system/tool paths in lines_with_copy_metadata are unchanged.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/history.rs | Core fix: lines_with_copy_metadata user branch swapped from render_message_with_copy_metadata to hard_break_copy_lines(render_user_message(...)), applying the full-row highlight and plain-text rendering consistently with all other user-message paths. |
| crates/tui/src/tui/transcript.rs | Adds a targeted test cache_renders_user_cells_with_highlight_background that verifies the background colour (SURFACE_ELEVATED), full-width padding, and literal-text rendering of user cells in the TranscriptViewCache path; adds required palette import. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["HistoryCell::User"] --> B{"Render path?"}
    B --> C["lines_with_options\n(live chat view)"]
    B --> D["lines_with_copy_metadata\n(cached transcript)"]
    B --> E["transcript_lines\n(pager / clipboard)"]

    C --> F["render_user_message()"]
    D -->|"BEFORE (bug)"| G["render_message_with_copy_metadata()\nmarkdown, no highlight"]
    D -->|"AFTER (fix)"| H["hard_break_copy_lines(\n  render_user_message()\n)"]
    E --> I["render_plain_message()"]

    F --> J["render_plain_message()"]
    H --> J
    J --> K["apply_user_message_highlight()\nSURFACE_ELEVATED bg\nfull-width padding"]
    G --> L["No highlight"]
    I --> M["No highlight"]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(tui): highlight user messages in cac..."](https://github.com/hmbown/codewhale/commit/b37e4d31cd73a6842277d952e627ecfa29e00147) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34766981)</sub>

<!-- /greptile_comment -->