### PR TITLE
fix(tui): stop compacting tool outputs on session save/load to preserve LLM cache

### DIFF
--- a/crates/tui/src/commands/session.rs
+++ b/crates/tui/src/commands/session.rs
@@ -48,9 +48,7 @@ pub fn save(app: &mut App, path: Option<&str>) -> CommandResult {
 
     match std::fs::create_dir_all(&sessions_dir) {
         Ok(()) => {
-            let mut persisted = session.clone();
-            crate::session_manager::compact_session_tool_outputs(&mut persisted);
-            let json = match serde_json::to_string_pretty(&persisted) {
+            let json = match serde_json::to_string_pretty(&session) {
                 Ok(j) => j,
                 Err(e) => return CommandResult::error(format!("Failed to serialize session: {e}")),
             };
@@ -221,13 +219,12 @@ pub fn load(app: &mut App, path: Option<&str>) -> CommandResult {
         }
     };
 
-    let mut session: crate::session_manager::SavedSession = match serde_json::from_str(&content) {
+    let session: crate::session_manager::SavedSession = match serde_json::from_str(&content) {
         Ok(s) => s,
         Err(e) => {
             return CommandResult::error(format!("Failed to parse session file: {e}"));
         }
     };
-    crate::session_manager::compact_session_tool_outputs(&mut session);
 
     app.api_messages.clone_from(&session.messages);
     app.clear_history();

--- a/crates/tui/src/session_manager.rs
+++ b/crates/tui/src/session_manager.rs
@@ -261,10 +261,7 @@ impl SessionManager {
     pub fn save_session(&self, session: &SavedSession) -> std::io::Result<PathBuf> {
         let path = self.validated_session_path(&session.metadata.id)?;
 
-        let mut persisted = session.clone();
-        compact_session_tool_outputs(&mut persisted);
-
-        let content = serde_json::to_string_pretty(&persisted)
+        let content = serde_json::to_string_pretty(&session)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
 
         // Atomic write via write_atomic (NamedTempFile + fsync + persist)
@@ -281,9 +278,7 @@ impl SessionManager {
         let checkpoints = self.sessions_dir.join("checkpoints");
         fs::create_dir_all(&checkpoints)?;
         let path = checkpoints.join("latest.json");
-        let mut persisted = session.clone();
-        compact_session_tool_outputs(&mut persisted);
-        let content = serde_json::to_string_pretty(&persisted)
+        let content = serde_json::to_string_pretty(&session)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
         write_atomic(&path, content.as_bytes())?;
         Ok(path)
@@ -296,7 +291,7 @@ impl SessionManager {
             return Ok(None);
         }
         let content = fs::read_to_string(&path)?;
-        let mut session: SavedSession = serde_json::from_str(&content)
+        let session: SavedSession = serde_json::from_str(&content)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
         if session.schema_version > CURRENT_SESSION_SCHEMA_VERSION {
             return Err(std::io::Error::new(
@@ -307,7 +302,6 @@ impl SessionManager {
                 ),
             ));
         }
-        compact_session_tool_outputs(&mut session);
         Ok(Some(session))
     }
 
@@ -378,7 +372,7 @@ impl SessionManager {
         let path = self.validated_session_path(id)?;
 
         let content = fs::read_to_string(&path)?;
-        let mut session: SavedSession = serde_json::from_str(&content)
+        let session: SavedSession = serde_json::from_str(&content)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
         if session.schema_version > CURRENT_SESSION_SCHEMA_VERSION {
             return Err(std::io::Error::new(
@@ -390,7 +384,6 @@ impl SessionManager {
             ));
         }
 
-        compact_session_tool_outputs(&mut session);
         Ok(session)
     }
 
@@ -767,17 +760,6 @@ pub fn update_session(
     session
 }
 
-pub(crate) fn compact_session_tool_outputs(
-    session: &mut SavedSession,
-) -> crate::tool_output_receipts::ToolOutputReceiptStats {
-    let (messages, stats) = crate::tool_output_receipts::compact_messages_for_persistence(
-        &session.messages,
-        &session.artifacts,
-    );
-    session.messages = messages;
-    stats
-}
-
 /// Cap messages to [`MAX_PERSISTED_MESSAGES`], keeping the most recent.
 /// Returns the capped slice and an optional truncation note.
 fn cap_messages(messages: &[Message]) -> (Vec<Message>, Option<String>) {
@@ -1138,7 +1120,7 @@ mod tests {
     }
 
     #[test]
-    fn save_session_compacts_large_tool_outputs_to_artifact_receipts() {
+    fn save_session_preserves_large_tool_outputs_for_cache_fidelity() {
         let tmp = tempdir().expect("tempdir");
         let manager = SessionManager::new(tmp.path().join("sessions")).expect("new");
         let raw = "RAW_SESSION_SENTINEL\n".repeat(2_000);
@@ -1177,20 +1159,20 @@ mod tests {
 
         let path = manager.save_session(&session).expect("save");
         let persisted_json = fs::read_to_string(path).expect("read persisted session");
-        assert!(!persisted_json.contains("RAW_SESSION_SENTINEL"));
+        // Raw output is preserved in-session so resume can hit the LLM cache.
+        assert!(persisted_json.contains("RAW_SESSION_SENTINEL"));
 
         let loaded = manager.load_session(&session.metadata.id).expect("load");
         let ContentBlock::ToolResult { content, .. } = &loaded.messages[1].content[0] else {
             panic!("expected loaded tool result");
         };
-        assert!(!content.contains("RAW_SESSION_SENTINEL"));
-        assert!(content.contains("[TOOL_OUTPUT_RECEIPT]"));
-        assert!(content.contains("detail_handle: art_call-big"));
-        assert!(content.contains("retrieve: retrieve_tool_result ref=art_call-big"));
+        // Loaded session retains the original output for cache fidelity.
+        assert!(content.contains("RAW_SESSION_SENTINEL"));
+        assert!(!content.contains("[TOOL_OUTPUT_RECEIPT]"));
     }
 
     #[test]
-    fn load_session_compacts_legacy_large_tool_outputs_before_resume() {
+    fn load_session_preserves_legacy_large_tool_outputs_for_cache_fidelity() {
         let tmp = tempdir().expect("tempdir");
         let manager = SessionManager::new(tmp.path().join("sessions")).expect("new");
         let raw = "RAW_LEGACY_RESUME_SENTINEL\n".repeat(2_000);
@@ -1244,10 +1226,9 @@ mod tests {
         let ContentBlock::ToolResult { content, .. } = &loaded.messages[1].content[0] else {
             panic!("expected loaded tool result");
         };
-        assert!(!content.contains("RAW_LEGACY_RESUME_SENTINEL"));
-        assert!(content.contains("[TOOL_OUTPUT_RECEIPT]"));
-        assert!(content.contains("detail_handle: art_call-legacy"));
-        assert!(content.contains("retrieve: retrieve_tool_result ref=art_call-legacy"));
+        // Loaded session preserves original output so resume can hit the LLM cache.
+        assert!(content.contains("RAW_LEGACY_RESUME_SENTINEL"));
+        assert!(!content.contains("[TOOL_OUTPUT_RECEIPT]"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary / 概述
Remove `compact_session_tool_outputs` from session save/load paths to preserve message fidelity for LLM KV-cache hits on resume.

从 session 的 save/load 路径中移除 `compact_session_tool_outputs`，保持消息完整性以确保 resume 时 LLM KV-cache 命中。

## Problem / 问题
Session compaction replaces large tool outputs (>12K chars) with compact receipts during save and load. This changes message content between sessions, breaking the LLM KV-cache prefix on resume and causing near-zero cache hit rates for continued conversations.

Session 持久化时，`compact_session_tool_outputs` 会将超过 12K 字符的大型 tool output 替换为简短的 receipt。这导致 save/load 后消息内容发生变化，LLM 的 KV-cache 前缀不再匹配，resume 时缓存命中率几乎为零。

## Fix / 修复
- Remove compaction from `save_session`, `save_checkpoint`, `/save` command
- Remove compaction from `load_session`, `load_checkpoint`, `/load` command
- Remove the now-unused `compact_session_tool_outputs` wrapper
- Live compaction (`compact_messages_for_persistence` in tui/ui.rs) is unaffected — context budgets remain protected during active conversation
- Remove unnecessary `mut` on loaded session variables

- 移除 `save_session`、`save_checkpoint`、`/save` 命令中的 compaction
- 移除 `load_session`、`load_checkpoint`、`/load` 命令中的 compaction
- 移除已无调用的 `compact_session_tool_outputs` 包装函数
- 交互时的实时 compaction（`tui/ui.rs` 中的 `compact_messages_for_persistence`）不受影响，对话过程中的上下文预算保护仍然有效
- 移除 loaded session 变量上不必要的 `mut`

## Tradeoffs / 权衡

**Pros / 优点:**
- Resumed sessions preserve exact message content → LLM prefix-cache hits on every continue
- No silent content mutation across save/load round-trips
- Simpler code: persistence layer stores what the user sees, context management stays in the engine

Resume 后的消息内容与原始完全一致 → 每次 continue 都能命中 LLM 前缀缓存；持久化层不再静默修改消息内容；代码更简洁。

**Cons / 代价:**
- Session JSON files may grow larger for conversations with many large tool outputs
- Resuming a session on a smaller-context model may trigger emergency compaction (`recover_context_overflow`) on the first turn — this is reactive but bounded by the existing `cap_messages` (500) and cycle-archive safety nets

包含大量 tool output 的会话 JSON 文件可能变大；切换到小上下文模型 resume 时首次发送可能触发紧急压缩（`recover_context_overflow`），但受现有 `cap_messages`(500) 和 cycle-archive 安全网保护，不会无限循环。

---

## ⚠️ Remaining Risk / 仍存在的风险: `MAX_PERSISTED_MESSAGES`

**This PR fixes one source of cache invalidation, but a bigger one remains.**

本次 PR 修复了缓存失效的一个来源，但一个更大的问题依然存在。

### The problem / 问题分析

`MAX_PERSISTED_MESSAGES = 500` (`session_manager.rs:25`) performs **tail truncation** when a session exceeds 500 messages — the oldest messages are silently dropped, while the most recent 500 are kept.

Since LLM KV-cache is **prefix-based** (keyed by the full message sequence from the start), dropping oldest messages changes the entire cache prefix. The first message after truncation becomes a new "first message", so the cache key is completely different. Every resume of a session with >500 messages results in a **100% cache miss** — even worse than the compaction issue this PR fixes.

LLM 的 KV-cache 是按前缀（prefix）构建的，缓存键基于从第一条消息开始的完整序列。`cap_messages` 保留最新 500 条（尾部），丢弃最旧消息（头部）。截断后的第一条消息变成了新的"第一条"，缓存前缀完全改变 → **100% 缓存失效**，比本 PR 修复的 compaction 问题更严重。

### Why 500 is arbitrary / 为什么 500 不合理

- 500 messages can be well under the budget for large-context models (1M tokens) → **wastes cache unnecessarily**
- 500 messages can already overflow small-context models (32K tokens) → **does not actually protect them**
- The limit is driven by file-size concerns, not model capability

- 对大上下文模型（1M tokens），500 条消息远未触及预算 → **白白浪费缓存**
- 对小上下文模型（32K tokens），500 条消息可能已经超了 → **实际上也保护不了**
- 这个限制来自文件大小的工程考量，而非模型能力

### Recommended direction / 建议方向

Replace `MAX_PERSISTED_MESSAGES` with a **token-budget-aware cap** that uses the saved model's context window as the bound, or move truncation to load time so the same model on resume gets the full, cacheable message list. The persistence layer should store faithfully; context limits should be enforced at send time by the engine.

建议将 `MAX_PERSISTED_MESSAGES` 替换为基于 **token 预算** 的智能裁剪——使用模型上下文窗口作为上限，或在 load 时按当前模型预算动态裁剪。持久化层应忠实存储，上下文限制应由 engine 在发送时按模型能力执行。

## Tests / 测试
- Updated two existing tests to verify raw output preservation instead of compaction
- `cargo test -p codewhale-tui -- session_manager`: 39 passed, 0 failed

- 更新两个已有测试，验证原始输出保留而非压缩
- `cargo test -p codewhale-tui -- session_manager`: 39 passed, 0 failed
