### PR TITLE
feat(cache): expose real tool catalog in cache inspect

### DIFF
--- a/crates/tui/src/client/chat.rs
+++ b/crates/tui/src/client/chat.rs
@@ -9,6 +9,7 @@ use std::pin::Pin;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use tokio::time::timeout as tokio_timeout;
@@ -551,24 +552,29 @@ const TOOL_RESULT_DEDUP_MIN_CHARS: usize = 1_024;
 /// up with tiny `gh auth status` and `cat package.json` files.
 const TOOL_RESULT_SHA_PERSIST_MIN_CHARS: usize = 1_024;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct PromptInspection {
     pub base_static_prefix_hash: String,
     pub full_request_prefix_hash: String,
+    /// Hash of the rendered tool catalog JSON, or empty when no tools were supplied.
+    pub tool_catalog_hash: String,
     pub layers: Vec<PromptLayerInspection>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct PromptLayerInspection {
     pub name: String,
     pub stability: PromptLayerStability,
     pub char_len: usize,
+    pub byte_len: usize,
+    /// Rough token estimate for quick before/after cache-hit reports.
+    pub token_estimate: usize,
     pub sha256: String,
     pub tool_result: Option<ToolResultInspection>,
     pub turn_meta: Option<TurnMetaInspection>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct ToolResultInspection {
     pub original_chars: usize,
     pub sent_chars: usize,
@@ -576,7 +582,7 @@ pub(crate) struct ToolResultInspection {
     pub deduplicated: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct TurnMetaInspection {
     pub original_chars: usize,
     pub sent_chars: usize,
@@ -584,7 +590,7 @@ pub(crate) struct TurnMetaInspection {
     pub sha256: String,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) enum PromptLayerStability {
     Static,
     History,
@@ -605,6 +611,7 @@ fn inspect_wire_request(tools: Option<&[Tool]>, messages: &[Value]) -> PromptIns
     let mut layers = Vec::new();
     let mut base_static_prefix_parts = Vec::new();
     let mut full_request_prefix_parts = Vec::new();
+    let mut tool_catalog_hash = String::new();
     let mut start_index = 0;
 
     if let Some(message) = messages.first() {
@@ -628,6 +635,7 @@ fn inspect_wire_request(tools: Option<&[Tool]>, messages: &[Value]) -> PromptIns
     }
 
     if let Some(tool_catalog) = tool_catalog_for_inspect(tools) {
+        tool_catalog_hash = sha256_hex(tool_catalog.as_bytes());
         base_static_prefix_parts.push(tool_catalog.clone());
         full_request_prefix_parts.push(tool_catalog.clone());
         layers.push(prompt_layer(
@@ -669,6 +677,7 @@ fn inspect_wire_request(tools: Option<&[Tool]>, messages: &[Value]) -> PromptIns
     PromptInspection {
         base_static_prefix_hash: sha256_hex(base_static_prefix.as_bytes()),
         full_request_prefix_hash: sha256_hex(full_request_prefix.as_bytes()),
+        tool_catalog_hash,
         layers,
     }
 }
@@ -840,10 +849,18 @@ fn prompt_layer(
     stability: PromptLayerStability,
     content: &str,
 ) -> PromptLayerInspection {
+    let char_len = content.chars().count();
+    let token_estimate = if char_len == 0 {
+        0
+    } else {
+        (char_len / 4).max(1)
+    };
     PromptLayerInspection {
         name,
         stability,
-        char_len: content.chars().count(),
+        char_len,
+        byte_len: content.len(),
+        token_estimate,
         sha256: sha256_hex(content.as_bytes()),
         tool_result: None,
         turn_meta: None,

--- a/crates/tui/src/commands/core.rs
+++ b/crates/tui/src/commands/core.rs
@@ -100,6 +100,7 @@ pub(crate) fn reset_conversation_state(app: &mut App) -> bool {
     app.session.last_reasoning_replay_tokens = None;
     app.session.turn_cache_history.clear();
     app.session.last_cache_inspection = None;
+    app.session.last_tool_catalog = None;
     todos_cleared
 }
 
@@ -546,9 +547,11 @@ mod tests {
         app.session.last_prompt_cache_hit_tokens = Some(70);
         app.session.last_prompt_cache_miss_tokens = Some(30);
         app.session.last_reasoning_replay_tokens = Some(12);
+        app.session.last_tool_catalog = Some(Vec::new());
         app.session.last_cache_inspection = Some(PromptInspection {
             base_static_prefix_hash: "base".to_string(),
             full_request_prefix_hash: "full".to_string(),
+            tool_catalog_hash: String::new(),
             layers: Vec::new(),
         });
         app.push_turn_cache_record(TurnCacheRecord {
@@ -576,6 +579,7 @@ mod tests {
         assert_eq!(app.session.last_reasoning_replay_tokens, None);
         assert!(app.session.turn_cache_history.is_empty());
         assert_eq!(app.session.last_cache_inspection, None);
+        assert_eq!(app.session.last_tool_catalog, None);
     }
 
     #[test]

--- a/crates/tui/src/commands/debug.rs
+++ b/crates/tui/src/commands/debug.rs
@@ -139,8 +139,11 @@ pub fn context(_app: &mut App) -> CommandResult {
 /// Renders a fixed-width table the user can paste into a bug report.
 pub fn cache(app: &mut App, arg: Option<&str>) -> CommandResult {
     let arg = arg.map(str::trim).filter(|s| !s.is_empty());
-    if matches!(arg, Some("inspect")) {
-        return CommandResult::message(format_cache_inspect(app));
+    if let Some(flags) = arg.and_then(|a| a.strip_prefix("inspect")) {
+        let flags = flags.trim();
+        let verbose = flags.split_whitespace().any(|flag| flag == "--verbose");
+        let json_mode = flags.split_whitespace().any(|flag| flag == "--json");
+        return CommandResult::message(format_cache_inspect(app, verbose, json_mode));
     }
     if matches!(arg, Some("warmup")) {
         return CommandResult::action(AppAction::CacheWarmup);
@@ -162,7 +165,7 @@ pub fn cache(app: &mut App, arg: Option<&str>) -> CommandResult {
     CommandResult::message(format_cache_history(app, count, app.ui_locale))
 }
 
-fn format_cache_inspect(app: &mut App) -> String {
+fn format_cache_inspect(app: &mut App, verbose: bool, json_mode: bool) -> String {
     let reasoning_effort = if app.reasoning_effort == crate::tui::app::ReasoningEffort::Auto {
         app.last_effective_reasoning_effort
             .and_then(crate::tui::app::ReasoningEffort::api_value)
@@ -175,7 +178,7 @@ fn format_cache_inspect(app: &mut App) -> String {
         messages: app.api_messages.clone(),
         max_tokens: 0,
         system: app.system_prompt.clone(),
-        tools: None,
+        tools: app.session.last_tool_catalog.clone(),
         tool_choice: None,
         metadata: None,
         thinking: None,
@@ -186,6 +189,13 @@ fn format_cache_inspect(app: &mut App) -> String {
     };
     let inspection = inspect_prompt_for_request(&request);
     let previous = app.session.last_cache_inspection.as_ref();
+    if json_mode {
+        let output = serde_json::to_string_pretty(&inspection).unwrap_or_else(|_| {
+            "{\"error\":\"cache inspection serialization failed\"}".to_string()
+        });
+        app.session.last_cache_inspection = Some(inspection);
+        return output;
+    }
 
     let mut out = String::new();
     out.push_str("Cache Inspect\n");
@@ -198,16 +208,32 @@ fn format_cache_inspect(app: &mut App) -> String {
         "Full request prefix hash: {}\n",
         inspection.full_request_prefix_hash
     ));
+    out.push_str(&format!(
+        "Tool catalog hash: {}\n",
+        if inspection.tool_catalog_hash.is_empty() {
+            "(no tools registered)".to_string()
+        } else {
+            inspection.tool_catalog_hash.clone()
+        }
+    ));
     out.push_str(&format_static_prefix_status(previous, &inspection));
     out.push_str(&format_first_divergence(previous, &inspection));
+    let total_tokens: usize = inspection
+        .layers
+        .iter()
+        .map(|layer| layer.token_estimate)
+        .sum();
+    out.push_str(&format!("Estimated reusable tokens: ~{total_tokens}\n"));
     out.push('\n');
 
     for layer in &inspection.layers {
         let mut line = format!(
-            "{}: {}, chars={}, hash={}\n",
+            "{}: {}, chars={}, bytes={}, ~{}tok, hash={}\n",
             layer.name,
             layer.stability.label(),
             layer.char_len,
+            layer.byte_len,
+            layer.token_estimate,
             layer.sha256
         );
         if let Some(tool_result) = &layer.tool_result {
@@ -232,8 +258,68 @@ fn format_cache_inspect(app: &mut App) -> String {
         }
         out.push_str(&line);
     }
+    if verbose {
+        out.push_str("\nVerbose diff\n");
+        if let Some(previous) = previous {
+            out.push_str(&format_verbose_diff(previous, &inspection));
+        } else {
+            out.push_str("No previous inspection to compare against.\n");
+        }
+    }
     app.session.last_cache_inspection = Some(inspection);
     out
+}
+
+fn format_verbose_diff(previous: &PromptInspection, current: &PromptInspection) -> String {
+    let mut out = String::new();
+    let max_len = previous.layers.len().max(current.layers.len());
+    for index in 0..max_len {
+        match (previous.layers.get(index), current.layers.get(index)) {
+            (Some(prev), Some(curr)) if prev == curr => {
+                out.push_str(&format!("  [{index}] {} unchanged\n", curr.name));
+            }
+            (Some(prev), Some(curr)) => {
+                out.push_str(&format!("  [{index}] {} changed\n", curr.name));
+                if prev.name != curr.name {
+                    out.push_str(&format!("    name: {} -> {}\n", prev.name, curr.name));
+                }
+                if prev.stability != curr.stability {
+                    out.push_str(&format!(
+                        "    stability: {} -> {}\n",
+                        prev.stability.label(),
+                        curr.stability.label()
+                    ));
+                }
+                if prev.char_len != curr.char_len {
+                    out.push_str(&format!(
+                        "    chars: {} -> {} ({:+})\n",
+                        prev.char_len,
+                        curr.char_len,
+                        curr.char_len as i64 - prev.char_len as i64
+                    ));
+                }
+                if prev.sha256 != curr.sha256 {
+                    out.push_str(&format!(
+                        "    hash: {} -> {}\n",
+                        short_hash(&prev.sha256),
+                        short_hash(&curr.sha256)
+                    ));
+                }
+            }
+            (None, Some(curr)) => {
+                out.push_str(&format!("  [{index}] {} added\n", curr.name));
+            }
+            (Some(prev), None) => {
+                out.push_str(&format!("  [{index}] {} removed\n", prev.name));
+            }
+            (None, None) => {}
+        }
+    }
+    out
+}
+
+fn short_hash(hash: &str) -> &str {
+    &hash[..hash.len().min(12)]
 }
 
 /// Render a prefix-cache stability and health summary for `/cache stats`.
@@ -559,7 +645,7 @@ fn humanize_age(d: std::time::Duration) -> String {
 mod tests {
     use super::*;
     use crate::config::Config;
-    use crate::models::{ContentBlock, Message, SystemBlock};
+    use crate::models::{ContentBlock, Message, SystemBlock, Tool};
     use crate::tui::app::{App, TuiOptions};
     use crate::tui::history::{GenericToolCell, ToolCell, ToolStatus};
     use std::path::PathBuf;
@@ -591,6 +677,25 @@ mod tests {
         app.cost_currency = crate::pricing::CostCurrency::Usd;
         app.api_provider = crate::config::ApiProvider::Deepseek;
         app
+    }
+
+    fn test_tool(name: &str) -> Tool {
+        Tool {
+            tool_type: Some("function".to_string()),
+            name: name.to_string(),
+            description: format!("{name} test tool"),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"}
+                }
+            }),
+            allowed_callers: None,
+            defer_loading: Some(false),
+            input_examples: None,
+            strict: Some(true),
+            cache_control: None,
+        }
     }
 
     #[test]
@@ -734,6 +839,59 @@ mod tests {
         assert!(msg.contains("User task: dynamic"));
         assert!(!msg.contains("SECRET_PROJECT_RULE"));
         assert!(!msg.contains("SECRET_USER_TASK"));
+    }
+
+    #[test]
+    fn cache_inspect_uses_last_request_tool_catalog() {
+        let mut app = create_test_app();
+        app.system_prompt = Some(SystemPrompt::Text("Base policy".to_string()));
+        app.session.last_tool_catalog = Some(vec![test_tool("read_file")]);
+        app.api_messages.push(Message {
+            role: "user".to_string(),
+            content: vec![ContentBlock::Text {
+                text: "Current task".to_string(),
+                cache_control: None,
+            }],
+        });
+
+        let msg = cache(&mut app, Some("inspect"))
+            .message
+            .expect("inspect output");
+
+        assert!(msg.contains("Tool catalog hash: "), "got: {msg}");
+        assert!(!msg.contains("(no tools registered)"), "got: {msg}");
+        assert!(msg.contains("Tool catalog: static"), "got: {msg}");
+        assert!(msg.contains("bytes="), "got: {msg}");
+        assert!(msg.contains("~"), "got: {msg}");
+    }
+
+    #[test]
+    fn cache_inspect_json_reports_tool_catalog_hash_and_layer_sizes() {
+        let mut app = create_test_app();
+        app.system_prompt = Some(SystemPrompt::Text("Base policy".to_string()));
+        app.session.last_tool_catalog = Some(vec![test_tool("read_file")]);
+        app.api_messages.push(Message {
+            role: "user".to_string(),
+            content: vec![ContentBlock::Text {
+                text: "Current task".to_string(),
+                cache_control: None,
+            }],
+        });
+
+        let msg = cache(&mut app, Some("inspect --json"))
+            .message
+            .expect("inspect json output");
+        let parsed: serde_json::Value = serde_json::from_str(&msg).expect("valid json");
+
+        assert_eq!(parsed["tool_catalog_hash"].as_str().unwrap().len(), 64);
+        let tool_layer = parsed["layers"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|layer| layer["name"] == "Tool catalog")
+            .expect("tool catalog layer");
+        assert!(tool_layer["byte_len"].as_u64().unwrap() > 0);
+        assert!(tool_layer["token_estimate"].as_u64().unwrap() > 0);
     }
 
     #[test]

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -1024,6 +1024,7 @@ impl Engine {
                     usage: turn.usage.clone(),
                     status: TurnOutcomeStatus::Failed,
                     error: Some(message),
+                    tool_catalog: None,
                 })
                 .await;
             return;
@@ -1194,6 +1195,7 @@ impl Engine {
                 &self.config.tools_always_load,
             )
         });
+        let tool_catalog_for_event = tools.clone();
 
         // Main turn loop
         let (status, error) = self
@@ -1227,6 +1229,7 @@ impl Engine {
                 usage: turn.usage,
                 status,
                 error,
+                tool_catalog: tool_catalog_for_event,
             })
             .await;
 
@@ -1272,6 +1275,7 @@ impl Engine {
                     usage: zero_usage,
                     status: TurnOutcomeStatus::Failed,
                     error: Some(message),
+                    tool_catalog: None,
                 })
                 .await;
             return;
@@ -1349,6 +1353,7 @@ impl Engine {
                 usage: zero_usage,
                 status: turn_status,
                 error: turn_error,
+                tool_catalog: None,
             })
             .await;
     }

--- a/crates/tui/src/core/events.rs
+++ b/crates/tui/src/core/events.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 
 use crate::core::coherence::CoherenceState;
 use crate::error_taxonomy::ErrorEnvelope;
-use crate::models::{Message, SystemPrompt, Usage};
+use crate::models::{Message, SystemPrompt, Tool, Usage};
 use crate::tools::spec::{ToolError, ToolResult};
 use crate::tools::subagent::SubAgentResult;
 use crate::tools::user_input::UserInputRequest;
@@ -92,6 +92,8 @@ pub enum Event {
         usage: Usage,
         status: TurnOutcomeStatus,
         error: Option<String>,
+        /// Tool catalog sent with this turn's model request.
+        tool_catalog: Option<Vec<Tool>>,
     },
 
     /// Context compaction started.

--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -2734,6 +2734,7 @@ mod tests {
                                 },
                                 status: TurnOutcomeStatus::Completed,
                                 error: None,
+                                tool_catalog: None,
                             })
                             .await;
                     }
@@ -2747,6 +2748,7 @@ mod tests {
                                 },
                                 status: TurnOutcomeStatus::Completed,
                                 error: None,
+                                tool_catalog: None,
                             })
                             .await;
                     }
@@ -2879,6 +2881,7 @@ mod tests {
                     },
                     status: TurnOutcomeStatus::Completed,
                     error: None,
+                    tool_catalog: None,
                 })
                 .await;
         });
@@ -3001,6 +3004,7 @@ mod tests {
                     },
                     status: TurnOutcomeStatus::Completed,
                     error: None,
+                    tool_catalog: None,
                 })
                 .await;
         });
@@ -3220,6 +3224,7 @@ mod tests {
                     },
                     status: TurnOutcomeStatus::Completed,
                     error: None,
+                    tool_catalog: None,
                 })
                 .await;
         });

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -2885,6 +2885,7 @@ impl RuntimeThreadManager {
                     usage,
                     status,
                     error,
+                    ..
                 } => {
                     turn_usage = Some(usage);
                     turn_status = match status {
@@ -3709,6 +3710,7 @@ mod tests {
                         },
                         status: TurnOutcomeStatus::Completed,
                         error: None,
+                        tool_catalog: None,
                     })
                     .await;
             }
@@ -4001,6 +4003,7 @@ mod tests {
                         },
                         status: TurnOutcomeStatus::Completed,
                         error: None,
+                        tool_catalog: None,
                     })
                     .await;
                 if turn_index >= 2 {
@@ -4237,6 +4240,7 @@ mod tests {
                 },
                 status: TurnOutcomeStatus::Completed,
                 error: None,
+                tool_catalog: None,
             })
             .await?;
 
@@ -4318,6 +4322,7 @@ mod tests {
                 usage: Usage::default(),
                 status: TurnOutcomeStatus::Completed,
                 error: None,
+                tool_catalog: None,
             })
             .await?;
         Ok(())
@@ -4395,6 +4400,7 @@ mod tests {
                 usage: Usage::default(),
                 status: TurnOutcomeStatus::Completed,
                 error: None,
+                tool_catalog: None,
             })
             .await?;
         Ok(())
@@ -4458,6 +4464,7 @@ mod tests {
                 usage: Usage::default(),
                 status: TurnOutcomeStatus::Completed,
                 error: None,
+                tool_catalog: None,
             })
             .await?;
 
@@ -4585,6 +4592,7 @@ mod tests {
                 usage: Usage::default(),
                 status: TurnOutcomeStatus::Completed,
                 error: None,
+                tool_catalog: None,
             })
             .await?;
         Ok(())
@@ -4665,6 +4673,7 @@ mod tests {
                 },
                 status: TurnOutcomeStatus::Completed,
                 error: None,
+                tool_catalog: None,
             })
             .await?;
 
@@ -4726,6 +4735,7 @@ mod tests {
                         },
                         status: TurnOutcomeStatus::Completed,
                         error: None,
+                        tool_catalog: None,
                     })
                     .await;
             }
@@ -4836,6 +4846,7 @@ mod tests {
                                 },
                                 status: TurnOutcomeStatus::Completed,
                                 error: None,
+                                tool_catalog: None,
                             })
                             .await;
                     }
@@ -4866,6 +4877,7 @@ mod tests {
                                 },
                                 status: TurnOutcomeStatus::Completed,
                                 error: None,
+                                tool_catalog: None,
                             })
                             .await;
                     }

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -19,7 +19,7 @@ use crate::core::coherence::CoherenceState;
 use crate::cycle_manager::{CycleBriefing, CycleConfig};
 use crate::hooks::{HookContext, HookEvent, HookExecutor, HookResult};
 use crate::localization::{Locale, MessageId, resolve_locale, tr};
-use crate::models::{Message, SystemPrompt, compaction_threshold_for_model_and_effort};
+use crate::models::{Message, SystemPrompt, Tool, compaction_threshold_for_model_and_effort};
 use crate::palette::{self, UiTheme};
 use crate::pricing::{CostCurrency, CostEstimate};
 use crate::session_manager::SessionContextReference;
@@ -1034,6 +1034,11 @@ pub struct SessionState {
     pub total_output_tokens: u32,
     pub turn_cache_history: VecDeque<TurnCacheRecord>,
     pub last_cache_inspection: Option<PromptInspection>,
+    /// Tool catalog from the most recent model request.
+    ///
+    /// `/cache inspect` uses this to inspect the same tool schema bytes
+    /// that were eligible for the provider's prefix cache.
+    pub last_tool_catalog: Option<Vec<Tool>>,
 }
 
 /// Sidebar hover state for mouse tooltip support.
@@ -1075,6 +1080,7 @@ impl Default for SessionState {
             total_output_tokens: 0,
             turn_cache_history: VecDeque::new(),
             last_cache_inspection: None,
+            last_tool_catalog: None,
         }
     }
 }

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -1442,7 +1442,11 @@ async fn run_event_loop(
                         usage,
                         status,
                         error,
+                        tool_catalog,
                     } => {
+                        if let Some(catalog) = tool_catalog {
+                            app.session.last_tool_catalog = Some(catalog);
+                        }
                         let was_locally_cancelled = app.suppress_stream_events_until_turn_complete;
                         app.suppress_stream_events_until_turn_complete = false;
                         app.active_allowed_tools = None;

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -3014,6 +3014,7 @@ fn local_cancel_marks_late_stream_events_for_suppression() {
             usage: Usage::default(),
             status: crate::core::events::TurnOutcomeStatus::Interrupted,
             error: None,
+            tool_catalog: None,
         }
     ));
     assert!(!suppress_engine_event_after_local_cancel(


### PR DESCRIPTION
## Summary

- records the actual tool catalog used by the last model request
- makes `/cache inspect` include the real tool catalog layer/hash instead of inspecting with `tools: None`
- adds JSON/verbose-friendly layer metadata: bytes and rough token estimate

## Validation

- `cargo test -p codewhale-tui cache_inspect --all-features`

Split out of the superseded large cache-hit optimization PR.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR wires the actual tool catalog from the last model request into `/cache inspect`, replacing the previous `tools: None` placeholder. It also enriches layer metadata with `byte_len`, a rough token estimate, and a `tool_catalog_hash`, and adds `--verbose` (layer-level diff) and `--json` output modes.

- `SessionState` gains `last_tool_catalog: Option<Vec<Tool>>`, populated on `TurnComplete` and cleared by `reset_conversation_state`; `inspect_wire_request` uses this catalog to compute a hash and a new "Tool catalog" layer.
- `PromptLayerInspection` and related structs gain `byte_len`, `token_estimate`, and `Serialize`/`Deserialize`; `format_verbose_diff` compares two inspection snapshots layer-by-layer.
- All `TurnComplete` construction sites (engine, runtime threads, tests) are updated to supply the new `tool_catalog` field.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for typical interactive sessions; the stale-catalog edge case only surfaces when a turn fails or runs with no tool registry, and then only when the user immediately runs /cache inspect.

The update guard in ui.rs (`if let Some(catalog)`) means last_tool_catalog is never cleared to None by a TurnComplete event, so after an error turn or a turn with no tool registry the catalog shown by /cache inspect reflects a prior session rather than the actual last request. Everything else — serialisation, hash computation, layer metadata, verbose diff, JSON mode — looks correct and is well-tested.

crates/tui/src/tui/ui.rs (last_tool_catalog update guard) and crates/tui/src/commands/debug.rs (--json --verbose interaction)
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/ui.rs | On TurnComplete, updates last_tool_catalog only when tool_catalog is Some — stale catalog persists when a turn emits None (all error paths, or no tool registry) |
| crates/tui/src/commands/debug.rs | Adds --verbose and --json flags to /cache inspect; uses last_tool_catalog for the wire request; adds format_verbose_diff with a dead (None,None) arm; json_mode silently drops --verbose |
| crates/tui/src/client/chat.rs | Adds byte_len, token_estimate, and tool_catalog_hash to inspection structs; derives Serialize/Deserialize; computes token estimate as (char_len/4).max(1) |
| crates/tui/src/core/engine.rs | Captures tool catalog snapshot before the turn loop and emits it in TurnComplete; error paths emit None as expected |
| crates/tui/src/core/events.rs | Adds tool_catalog field to TurnComplete event variant |
| crates/tui/src/tui/app.rs | Adds last_tool_catalog: Option<Vec<Tool>> to SessionState, initialized to None |

</details>

</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fcache-inspect-truth-surface%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fcache-inspect-truth-surface%22.%0A%0AFix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui.rs%3A1447-1449%0AStale%20tool%20catalog%20after%20no-tool%20or%20error%20turns.%20The%20guard%20%60if%20let%20Some%28catalog%29%60%20means%20%60last_tool_catalog%60%20is%20never%20cleared%20to%20%60None%60%20when%20a%20turn%20emits%20%60tool_catalog%3A%20None%60%20%E2%80%94%20this%20covers%20all%20three%20early-error%20paths%20in%20%60engine.rs%60%20and%20the%20success%20path%20when%20%60tool_registry%60%20is%20%60None%60.%20A%20subsequent%20%60%2Fcache%20inspect%60%20then%20builds%20its%20hash%20against%20the%20previous%20session's%20catalog%20instead%20of%20an%20empty%20one%2C%20producing%20a%20hash%20that%20doesn't%20match%20what%20was%20actually%20sent.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20app.session.last_tool_catalog%20%3D%20tool_catalog%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0Acrates%2Ftui%2Fsrc%2Fcommands%2Fdebug.rs%3A315-319%0AThe%20%60%28None%2C%20None%29%60%20arm%20is%20unreachable.%20The%20loop%20runs%20%600..max_len%60%20where%20%60max_len%20%3D%20previous.layers.len%28%29.max%28current.layers.len%28%29%29%60%2C%20so%20at%20every%20index%20at%20least%20one%20side%20is%20%60Some%60.%20The%20dead%20arm%20adds%20noise%20and%20could%20mask%20a%20future%20refactor%20that%20changes%20the%20loop%20bounds.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%28None%2C%20None%29%20%3D%3E%20unreachable!%28%22index%20is%20within%20max_len%22%29%2C%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%20%20out%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Acrates%2Ftui%2Fsrc%2Fcommands%2Fdebug.rs%3A192-198%0A**%60--json%20--verbose%60%20silently%20drops%20verbose%20output.**%20The%20%60json_mode%60%20branch%20returns%20before%20the%20verbose%20diff%20section%20is%20ever%20reached%2C%20so%20%60--json%20--verbose%60%20produces%20exactly%20the%20same%20output%20as%20%60--json%60.%20There%20is%20no%20indication%20to%20the%20user%20that%20%60--verbose%60%20was%20ignored.%20If%20combined%20JSON%2Bdiff%20output%20isn't%20intended%2C%20a%20warning%20or%20early%20rejection%20would%20make%20the%20behaviour%20explicit.%0A%0A%23%23%23%20Issue%204%20of%204%0Acrates%2Ftui%2Fsrc%2Fclient%2Fchat.rs%3A849-862%0A**Token%20estimate%20significantly%20underestimates%20CJK%2Femoji%20content.**%20%60%28char_len%20%2F%204%29.max%281%29%60%20is%20calibrated%20for%20ASCII%20where%20~4%20chars%20%E2%89%88%201%20token%2C%20but%20a%20CJK%20character%20or%20emoji%20is%20typically%201%E2%80%932%20tokens.%20A%20system%20prompt%20or%20tool%20catalog%20written%20in%20Japanese%20or%20Chinese%20will%20show%20a%20token%20estimate%203%E2%80%934%C3%97%20too%20low.%20The%20doc%20comment%20calls%20it%20%22rough%22%2C%20but%20the%20discrepancy%20is%20large%20enough%20to%20mislead%20when%20comparing%20before%2Fafter%20cache-hit%20reports%20for%20non-Latin%20locales.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui.rs%3A1447-1449%0AStale%20tool%20catalog%20after%20no-tool%20or%20error%20turns.%20The%20guard%20%60if%20let%20Some%28catalog%29%60%20means%20%60last_tool_catalog%60%20is%20never%20cleared%20to%20%60None%60%20when%20a%20turn%20emits%20%60tool_catalog%3A%20None%60%20%E2%80%94%20this%20covers%20all%20three%20early-error%20paths%20in%20%60engine.rs%60%20and%20the%20success%20path%20when%20%60tool_registry%60%20is%20%60None%60.%20A%20subsequent%20%60%2Fcache%20inspect%60%20then%20builds%20its%20hash%20against%20the%20previous%20session's%20catalog%20instead%20of%20an%20empty%20one%2C%20producing%20a%20hash%20that%20doesn't%20match%20what%20was%20actually%20sent.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20app.session.last_tool_catalog%20%3D%20tool_catalog%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0Acrates%2Ftui%2Fsrc%2Fcommands%2Fdebug.rs%3A315-319%0AThe%20%60%28None%2C%20None%29%60%20arm%20is%20unreachable.%20The%20loop%20runs%20%600..max_len%60%20where%20%60max_len%20%3D%20previous.layers.len%28%29.max%28current.layers.len%28%29%29%60%2C%20so%20at%20every%20index%20at%20least%20one%20side%20is%20%60Some%60.%20The%20dead%20arm%20adds%20noise%20and%20could%20mask%20a%20future%20refactor%20that%20changes%20the%20loop%20bounds.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%28None%2C%20None%29%20%3D%3E%20unreachable!%28%22index%20is%20within%20max_len%22%29%2C%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%20%20out%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Acrates%2Ftui%2Fsrc%2Fcommands%2Fdebug.rs%3A192-198%0A**%60--json%20--verbose%60%20silently%20drops%20verbose%20output.**%20The%20%60json_mode%60%20branch%20returns%20before%20the%20verbose%20diff%20section%20is%20ever%20reached%2C%20so%20%60--json%20--verbose%60%20produces%20exactly%20the%20same%20output%20as%20%60--json%60.%20There%20is%20no%20indication%20to%20the%20user%20that%20%60--verbose%60%20was%20ignored.%20If%20combined%20JSON%2Bdiff%20output%20isn't%20intended%2C%20a%20warning%20or%20early%20rejection%20would%20make%20the%20behaviour%20explicit.%0A%0A%23%23%23%20Issue%204%20of%204%0Acrates%2Ftui%2Fsrc%2Fclient%2Fchat.rs%3A849-862%0A**Token%20estimate%20significantly%20underestimates%20CJK%2Femoji%20content.**%20%60%28char_len%20%2F%204%29.max%281%29%60%20is%20calibrated%20for%20ASCII%20where%20~4%20chars%20%E2%89%88%201%20token%2C%20but%20a%20CJK%20character%20or%20emoji%20is%20typically%201%E2%80%932%20tokens.%20A%20system%20prompt%20or%20tool%20catalog%20written%20in%20Japanese%20or%20Chinese%20will%20show%20a%20token%20estimate%203%E2%80%934%C3%97%20too%20low.%20The%20doc%20comment%20calls%20it%20%22rough%22%2C%20but%20the%20discrepancy%20is%20large%20enough%20to%20mislead%20when%20comparing%20before%2Fafter%20cache-hit%20reports%20for%20non-Latin%20locales.%0A%0A&repo=hmbown%2Fcodewhale&pr=2390&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui.rs%3A1447-1449%0AStale%20tool%20catalog%20after%20no-tool%20or%20error%20turns.%20The%20guard%20%60if%20let%20Some%28catalog%29%60%20means%20%60last_tool_catalog%60%20is%20never%20cleared%20to%20%60None%60%20when%20a%20turn%20emits%20%60tool_catalog%3A%20None%60%20%E2%80%94%20this%20covers%20all%20three%20early-error%20paths%20in%20%60engine.rs%60%20and%20the%20success%20path%20when%20%60tool_registry%60%20is%20%60None%60.%20A%20subsequent%20%60%2Fcache%20inspect%60%20then%20builds%20its%20hash%20against%20the%20previous%20session's%20catalog%20instead%20of%20an%20empty%20one%2C%20producing%20a%20hash%20that%20doesn't%20match%20what%20was%20actually%20sent.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20app.session.last_tool_catalog%20%3D%20tool_catalog%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0Acrates%2Ftui%2Fsrc%2Fcommands%2Fdebug.rs%3A315-319%0AThe%20%60%28None%2C%20None%29%60%20arm%20is%20unreachable.%20The%20loop%20runs%20%600..max_len%60%20where%20%60max_len%20%3D%20previous.layers.len%28%29.max%28current.layers.len%28%29%29%60%2C%20so%20at%20every%20index%20at%20least%20one%20side%20is%20%60Some%60.%20The%20dead%20arm%20adds%20noise%20and%20could%20mask%20a%20future%20refactor%20that%20changes%20the%20loop%20bounds.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%28None%2C%20None%29%20%3D%3E%20unreachable!%28%22index%20is%20within%20max_len%22%29%2C%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%20%20out%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Acrates%2Ftui%2Fsrc%2Fcommands%2Fdebug.rs%3A192-198%0A**%60--json%20--verbose%60%20silently%20drops%20verbose%20output.**%20The%20%60json_mode%60%20branch%20returns%20before%20the%20verbose%20diff%20section%20is%20ever%20reached%2C%20so%20%60--json%20--verbose%60%20produces%20exactly%20the%20same%20output%20as%20%60--json%60.%20There%20is%20no%20indication%20to%20the%20user%20that%20%60--verbose%60%20was%20ignored.%20If%20combined%20JSON%2Bdiff%20output%20isn't%20intended%2C%20a%20warning%20or%20early%20rejection%20would%20make%20the%20behaviour%20explicit.%0A%0A%23%23%23%20Issue%204%20of%204%0Acrates%2Ftui%2Fsrc%2Fclient%2Fchat.rs%3A849-862%0A**Token%20estimate%20significantly%20underestimates%20CJK%2Femoji%20content.**%20%60%28char_len%20%2F%204%29.max%281%29%60%20is%20calibrated%20for%20ASCII%20where%20~4%20chars%20%E2%89%88%201%20token%2C%20but%20a%20CJK%20character%20or%20emoji%20is%20typically%201%E2%80%932%20tokens.%20A%20system%20prompt%20or%20tool%20catalog%20written%20in%20Japanese%20or%20Chinese%20will%20show%20a%20token%20estimate%203%E2%80%934%C3%97%20too%20low.%20The%20doc%20comment%20calls%20it%20%22rough%22%2C%20but%20the%20discrepancy%20is%20large%20enough%20to%20mislead%20when%20comparing%20before%2Fafter%20cache-hit%20reports%20for%20non-Latin%20locales.%0A%0A&pr=2390&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat: expose cache inspect tool catalog"](https://github.com/hmbown/codewhale/commit/0a4915179fbeebe4ac1bdb545edd8143e28c3ed6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34772560)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->