### PR TITLE
feat(cache): track cache warmup keys

### DIFF
--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -568,6 +568,11 @@ fn build_default_headers(
 }
 
 impl DeepSeekClient {
+    /// Returns the API base URL used by this client.
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
     /// Translate text to the requested target language using a focused
     /// non-streaming chat completion call on the supplied model.
     ///
@@ -1108,7 +1113,7 @@ impl DeepSeekClient {
 
 mod chat;
 
-pub(crate) use chat::PromptInspection;
+pub(crate) use chat::{CacheWarmupKey, PromptInspection};
 
 pub(crate) fn inspect_prompt_for_request(request: &MessageRequest) -> PromptInspection {
     chat::inspect_prompt_for_request(request)

--- a/crates/tui/src/client/chat.rs
+++ b/crates/tui/src/client/chat.rs
@@ -9,6 +9,7 @@ use std::pin::Pin;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use tokio::time::timeout as tokio_timeout;
@@ -551,24 +552,29 @@ const TOOL_RESULT_DEDUP_MIN_CHARS: usize = 1_024;
 /// up with tiny `gh auth status` and `cat package.json` files.
 const TOOL_RESULT_SHA_PERSIST_MIN_CHARS: usize = 1_024;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct PromptInspection {
     pub base_static_prefix_hash: String,
     pub full_request_prefix_hash: String,
+    /// Hash of the rendered tool catalog JSON, or empty when no tools were supplied.
+    pub tool_catalog_hash: String,
     pub layers: Vec<PromptLayerInspection>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct PromptLayerInspection {
     pub name: String,
     pub stability: PromptLayerStability,
     pub char_len: usize,
+    pub byte_len: usize,
+    /// Rough token estimate for quick before/after cache-hit reports.
+    pub token_estimate: usize,
     pub sha256: String,
     pub tool_result: Option<ToolResultInspection>,
     pub turn_meta: Option<TurnMetaInspection>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct ToolResultInspection {
     pub original_chars: usize,
     pub sent_chars: usize,
@@ -576,7 +582,7 @@ pub(crate) struct ToolResultInspection {
     pub deduplicated: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct TurnMetaInspection {
     pub original_chars: usize,
     pub sent_chars: usize,
@@ -584,7 +590,7 @@ pub(crate) struct TurnMetaInspection {
     pub sha256: String,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) enum PromptLayerStability {
     Static,
     History,
@@ -605,6 +611,7 @@ fn inspect_wire_request(tools: Option<&[Tool]>, messages: &[Value]) -> PromptIns
     let mut layers = Vec::new();
     let mut base_static_prefix_parts = Vec::new();
     let mut full_request_prefix_parts = Vec::new();
+    let mut tool_catalog_hash = String::new();
     let mut start_index = 0;
 
     if let Some(message) = messages.first() {
@@ -628,6 +635,7 @@ fn inspect_wire_request(tools: Option<&[Tool]>, messages: &[Value]) -> PromptIns
     }
 
     if let Some(tool_catalog) = tool_catalog_for_inspect(tools) {
+        tool_catalog_hash = sha256_hex(tool_catalog.as_bytes());
         base_static_prefix_parts.push(tool_catalog.clone());
         full_request_prefix_parts.push(tool_catalog.clone());
         layers.push(prompt_layer(
@@ -669,6 +677,7 @@ fn inspect_wire_request(tools: Option<&[Tool]>, messages: &[Value]) -> PromptIns
     PromptInspection {
         base_static_prefix_hash: sha256_hex(base_static_prefix.as_bytes()),
         full_request_prefix_hash: sha256_hex(full_request_prefix.as_bytes()),
+        tool_catalog_hash,
         layers,
     }
 }
@@ -840,10 +849,18 @@ fn prompt_layer(
     stability: PromptLayerStability,
     content: &str,
 ) -> PromptLayerInspection {
+    let char_len = content.chars().count();
+    let token_estimate = if char_len == 0 {
+        0
+    } else {
+        (char_len / 4).max(1)
+    };
     PromptLayerInspection {
         name,
         stability,
-        char_len: content.chars().count(),
+        char_len,
+        byte_len: content.len(),
+        token_estimate,
         sha256: sha256_hex(content.as_bytes()),
         tool_result: None,
         turn_meta: None,

--- a/crates/tui/src/client/chat.rs
+++ b/crates/tui/src/client/chat.rs
@@ -561,6 +561,52 @@ pub(crate) struct PromptInspection {
     pub layers: Vec<PromptLayerInspection>,
 }
 
+/// Identifies the stable prefix that a cache warmup primes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct CacheWarmupKey {
+    pub provider: String,
+    pub model: String,
+    pub base_url: String,
+    pub static_prefix_hash: String,
+    pub tool_catalog_hash: String,
+    pub project_pack_hash: String,
+    pub skills_hash: String,
+}
+
+impl CacheWarmupKey {
+    pub(crate) fn from_inspection(
+        provider: &str,
+        model: &str,
+        base_url: &str,
+        inspection: &PromptInspection,
+    ) -> Self {
+        Self {
+            provider: provider.to_string(),
+            model: model.to_string(),
+            base_url: base_url.to_string(),
+            static_prefix_hash: inspection.base_static_prefix_hash.clone(),
+            tool_catalog_hash: inspection.tool_catalog_hash.clone(),
+            project_pack_hash: layer_hash(inspection, "Project context pack"),
+            skills_hash: layer_hash(inspection, "Skills"),
+        }
+    }
+
+    pub(crate) fn hash_short(&self) -> String {
+        let json = serde_json::to_string(self).unwrap_or_default();
+        let hash = sha256_hex(json.as_bytes());
+        hash[..hash.len().min(12)].to_string()
+    }
+}
+
+fn layer_hash(inspection: &PromptInspection, name: &str) -> String {
+    inspection
+        .layers
+        .iter()
+        .find(|layer| layer.name == name)
+        .map(|layer| layer.sha256.clone())
+        .unwrap_or_default()
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct PromptLayerInspection {
     pub name: String,

--- a/crates/tui/src/commands/core.rs
+++ b/crates/tui/src/commands/core.rs
@@ -100,7 +100,9 @@ pub(crate) fn reset_conversation_state(app: &mut App) -> bool {
     app.session.last_reasoning_replay_tokens = None;
     app.session.turn_cache_history.clear();
     app.session.last_cache_inspection = None;
+    app.session.last_warmup_key = None;
     app.session.last_tool_catalog = None;
+    app.session.last_base_url = None;
     todos_cleared
 }
 
@@ -547,7 +549,9 @@ mod tests {
         app.session.last_prompt_cache_hit_tokens = Some(70);
         app.session.last_prompt_cache_miss_tokens = Some(30);
         app.session.last_reasoning_replay_tokens = Some(12);
+        app.session.last_warmup_key = None;
         app.session.last_tool_catalog = Some(Vec::new());
+        app.session.last_base_url = Some("https://api.deepseek.com".to_string());
         app.session.last_cache_inspection = Some(PromptInspection {
             base_static_prefix_hash: "base".to_string(),
             full_request_prefix_hash: "full".to_string(),
@@ -579,7 +583,9 @@ mod tests {
         assert_eq!(app.session.last_reasoning_replay_tokens, None);
         assert!(app.session.turn_cache_history.is_empty());
         assert_eq!(app.session.last_cache_inspection, None);
+        assert_eq!(app.session.last_warmup_key, None);
         assert_eq!(app.session.last_tool_catalog, None);
+        assert_eq!(app.session.last_base_url, None);
     }
 
     #[test]

--- a/crates/tui/src/commands/core.rs
+++ b/crates/tui/src/commands/core.rs
@@ -100,6 +100,7 @@ pub(crate) fn reset_conversation_state(app: &mut App) -> bool {
     app.session.last_reasoning_replay_tokens = None;
     app.session.turn_cache_history.clear();
     app.session.last_cache_inspection = None;
+    app.session.last_tool_catalog = None;
     todos_cleared
 }
 
@@ -546,9 +547,11 @@ mod tests {
         app.session.last_prompt_cache_hit_tokens = Some(70);
         app.session.last_prompt_cache_miss_tokens = Some(30);
         app.session.last_reasoning_replay_tokens = Some(12);
+        app.session.last_tool_catalog = Some(Vec::new());
         app.session.last_cache_inspection = Some(PromptInspection {
             base_static_prefix_hash: "base".to_string(),
             full_request_prefix_hash: "full".to_string(),
+            tool_catalog_hash: String::new(),
             layers: Vec::new(),
         });
         app.push_turn_cache_record(TurnCacheRecord {
@@ -576,6 +579,7 @@ mod tests {
         assert_eq!(app.session.last_reasoning_replay_tokens, None);
         assert!(app.session.turn_cache_history.is_empty());
         assert_eq!(app.session.last_cache_inspection, None);
+        assert_eq!(app.session.last_tool_catalog, None);
     }
 
     #[test]

--- a/crates/tui/src/commands/debug.rs
+++ b/crates/tui/src/commands/debug.rs
@@ -139,8 +139,11 @@ pub fn context(_app: &mut App) -> CommandResult {
 /// Renders a fixed-width table the user can paste into a bug report.
 pub fn cache(app: &mut App, arg: Option<&str>) -> CommandResult {
     let arg = arg.map(str::trim).filter(|s| !s.is_empty());
-    if matches!(arg, Some("inspect")) {
-        return CommandResult::message(format_cache_inspect(app));
+    if let Some(flags) = arg.and_then(|a| a.strip_prefix("inspect")) {
+        let flags = flags.trim();
+        let verbose = flags.split_whitespace().any(|flag| flag == "--verbose");
+        let json_mode = flags.split_whitespace().any(|flag| flag == "--json");
+        return CommandResult::message(format_cache_inspect(app, verbose, json_mode));
     }
     if matches!(arg, Some("warmup")) {
         return CommandResult::action(AppAction::CacheWarmup);
@@ -162,7 +165,7 @@ pub fn cache(app: &mut App, arg: Option<&str>) -> CommandResult {
     CommandResult::message(format_cache_history(app, count, app.ui_locale))
 }
 
-fn format_cache_inspect(app: &mut App) -> String {
+fn format_cache_inspect(app: &mut App, verbose: bool, json_mode: bool) -> String {
     let reasoning_effort = if app.reasoning_effort == crate::tui::app::ReasoningEffort::Auto {
         app.last_effective_reasoning_effort
             .and_then(crate::tui::app::ReasoningEffort::api_value)
@@ -175,7 +178,7 @@ fn format_cache_inspect(app: &mut App) -> String {
         messages: app.api_messages.clone(),
         max_tokens: 0,
         system: app.system_prompt.clone(),
-        tools: None,
+        tools: app.session.last_tool_catalog.clone(),
         tool_choice: None,
         metadata: None,
         thinking: None,
@@ -186,6 +189,13 @@ fn format_cache_inspect(app: &mut App) -> String {
     };
     let inspection = inspect_prompt_for_request(&request);
     let previous = app.session.last_cache_inspection.as_ref();
+    if json_mode {
+        let output = serde_json::to_string_pretty(&inspection).unwrap_or_else(|_| {
+            "{\"error\":\"cache inspection serialization failed\"}".to_string()
+        });
+        app.session.last_cache_inspection = Some(inspection);
+        return output;
+    }
 
     let mut out = String::new();
     out.push_str("Cache Inspect\n");
@@ -198,16 +208,32 @@ fn format_cache_inspect(app: &mut App) -> String {
         "Full request prefix hash: {}\n",
         inspection.full_request_prefix_hash
     ));
+    out.push_str(&format!(
+        "Tool catalog hash: {}\n",
+        if inspection.tool_catalog_hash.is_empty() {
+            "(no tools registered)".to_string()
+        } else {
+            inspection.tool_catalog_hash.clone()
+        }
+    ));
     out.push_str(&format_static_prefix_status(previous, &inspection));
     out.push_str(&format_first_divergence(previous, &inspection));
+    let total_tokens: usize = inspection
+        .layers
+        .iter()
+        .map(|layer| layer.token_estimate)
+        .sum();
+    out.push_str(&format!("Estimated reusable tokens: ~{total_tokens}\n"));
     out.push('\n');
 
     for layer in &inspection.layers {
         let mut line = format!(
-            "{}: {}, chars={}, hash={}\n",
+            "{}: {}, chars={}, bytes={}, ~{}tok, hash={}\n",
             layer.name,
             layer.stability.label(),
             layer.char_len,
+            layer.byte_len,
+            layer.token_estimate,
             layer.sha256
         );
         if let Some(tool_result) = &layer.tool_result {
@@ -232,8 +258,68 @@ fn format_cache_inspect(app: &mut App) -> String {
         }
         out.push_str(&line);
     }
+    if verbose {
+        out.push_str("\nVerbose diff\n");
+        if let Some(previous) = previous {
+            out.push_str(&format_verbose_diff(previous, &inspection));
+        } else {
+            out.push_str("No previous inspection to compare against.\n");
+        }
+    }
     app.session.last_cache_inspection = Some(inspection);
     out
+}
+
+fn format_verbose_diff(previous: &PromptInspection, current: &PromptInspection) -> String {
+    let mut out = String::new();
+    let max_len = previous.layers.len().max(current.layers.len());
+    for index in 0..max_len {
+        match (previous.layers.get(index), current.layers.get(index)) {
+            (Some(prev), Some(curr)) if prev == curr => {
+                out.push_str(&format!("  [{index}] {} unchanged\n", curr.name));
+            }
+            (Some(prev), Some(curr)) => {
+                out.push_str(&format!("  [{index}] {} changed\n", curr.name));
+                if prev.name != curr.name {
+                    out.push_str(&format!("    name: {} -> {}\n", prev.name, curr.name));
+                }
+                if prev.stability != curr.stability {
+                    out.push_str(&format!(
+                        "    stability: {} -> {}\n",
+                        prev.stability.label(),
+                        curr.stability.label()
+                    ));
+                }
+                if prev.char_len != curr.char_len {
+                    out.push_str(&format!(
+                        "    chars: {} -> {} ({:+})\n",
+                        prev.char_len,
+                        curr.char_len,
+                        curr.char_len as i64 - prev.char_len as i64
+                    ));
+                }
+                if prev.sha256 != curr.sha256 {
+                    out.push_str(&format!(
+                        "    hash: {} -> {}\n",
+                        short_hash(&prev.sha256),
+                        short_hash(&curr.sha256)
+                    ));
+                }
+            }
+            (None, Some(curr)) => {
+                out.push_str(&format!("  [{index}] {} added\n", curr.name));
+            }
+            (Some(prev), None) => {
+                out.push_str(&format!("  [{index}] {} removed\n", prev.name));
+            }
+            (None, None) => {}
+        }
+    }
+    out
+}
+
+fn short_hash(hash: &str) -> &str {
+    &hash[..hash.len().min(12)]
 }
 
 /// Render a prefix-cache stability and health summary for `/cache stats`.
@@ -559,7 +645,7 @@ fn humanize_age(d: std::time::Duration) -> String {
 mod tests {
     use super::*;
     use crate::config::Config;
-    use crate::models::{ContentBlock, Message, SystemBlock};
+    use crate::models::{ContentBlock, Message, SystemBlock, Tool};
     use crate::tui::app::{App, TuiOptions};
     use crate::tui::history::{GenericToolCell, ToolCell, ToolStatus};
     use std::path::PathBuf;
@@ -591,6 +677,25 @@ mod tests {
         app.cost_currency = crate::pricing::CostCurrency::Usd;
         app.api_provider = crate::config::ApiProvider::Deepseek;
         app
+    }
+
+    fn test_tool(name: &str) -> Tool {
+        Tool {
+            tool_type: Some("function".to_string()),
+            name: name.to_string(),
+            description: format!("{name} test tool"),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"}
+                }
+            }),
+            allowed_callers: None,
+            defer_loading: Some(false),
+            input_examples: None,
+            strict: Some(true),
+            cache_control: None,
+        }
     }
 
     #[test]
@@ -734,6 +839,59 @@ mod tests {
         assert!(msg.contains("User task: dynamic"));
         assert!(!msg.contains("SECRET_PROJECT_RULE"));
         assert!(!msg.contains("SECRET_USER_TASK"));
+    }
+
+    #[test]
+    fn cache_inspect_uses_last_request_tool_catalog() {
+        let mut app = create_test_app();
+        app.system_prompt = Some(SystemPrompt::Text("Base policy".to_string()));
+        app.session.last_tool_catalog = Some(vec![test_tool("read_file")]);
+        app.api_messages.push(Message {
+            role: "user".to_string(),
+            content: vec![ContentBlock::Text {
+                text: "Current task".to_string(),
+                cache_control: None,
+            }],
+        });
+
+        let msg = cache(&mut app, Some("inspect"))
+            .message
+            .expect("inspect output");
+
+        assert!(msg.contains("Tool catalog hash: "), "got: {msg}");
+        assert!(!msg.contains("(no tools registered)"), "got: {msg}");
+        assert!(msg.contains("Tool catalog: static"), "got: {msg}");
+        assert!(msg.contains("bytes="), "got: {msg}");
+        assert!(msg.contains("~"), "got: {msg}");
+    }
+
+    #[test]
+    fn cache_inspect_json_reports_tool_catalog_hash_and_layer_sizes() {
+        let mut app = create_test_app();
+        app.system_prompt = Some(SystemPrompt::Text("Base policy".to_string()));
+        app.session.last_tool_catalog = Some(vec![test_tool("read_file")]);
+        app.api_messages.push(Message {
+            role: "user".to_string(),
+            content: vec![ContentBlock::Text {
+                text: "Current task".to_string(),
+                cache_control: None,
+            }],
+        });
+
+        let msg = cache(&mut app, Some("inspect --json"))
+            .message
+            .expect("inspect json output");
+        let parsed: serde_json::Value = serde_json::from_str(&msg).expect("valid json");
+
+        assert_eq!(parsed["tool_catalog_hash"].as_str().unwrap().len(), 64);
+        let tool_layer = parsed["layers"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|layer| layer["name"] == "Tool catalog")
+            .expect("tool catalog layer");
+        assert!(tool_layer["byte_len"].as_u64().unwrap() > 0);
+        assert!(tool_layer["token_estimate"].as_u64().unwrap() > 0);
     }
 
     #[test]

--- a/crates/tui/src/commands/debug.rs
+++ b/crates/tui/src/commands/debug.rs
@@ -5,7 +5,7 @@
 use std::time::Instant;
 
 use super::CommandResult;
-use crate::client::{PromptInspection, inspect_prompt_for_request};
+use crate::client::{CacheWarmupKey, PromptInspection, inspect_prompt_for_request};
 use crate::compaction::estimate_input_tokens_conservative;
 use crate::localization::{Locale, MessageId, tr};
 use crate::models::{ContentBlock, MessageRequest, SystemPrompt, context_window_for_model};
@@ -189,6 +189,12 @@ fn format_cache_inspect(app: &mut App, verbose: bool, json_mode: bool) -> String
     };
     let inspection = inspect_prompt_for_request(&request);
     let previous = app.session.last_cache_inspection.as_ref();
+    let current_warmup_key = CacheWarmupKey::from_inspection(
+        &format!("{:?}", app.api_provider),
+        &app.model,
+        app.session.last_base_url.as_deref().unwrap_or_default(),
+        &inspection,
+    );
     if json_mode {
         let output = serde_json::to_string_pretty(&inspection).unwrap_or_else(|_| {
             "{\"error\":\"cache inspection serialization failed\"}".to_string()
@@ -218,6 +224,10 @@ fn format_cache_inspect(app: &mut App, verbose: bool, json_mode: bool) -> String
     ));
     out.push_str(&format_static_prefix_status(previous, &inspection));
     out.push_str(&format_first_divergence(previous, &inspection));
+    out.push_str(&format_warmup_status(
+        app.session.last_warmup_key.as_ref(),
+        &current_warmup_key,
+    ));
     let total_tokens: usize = inspection
         .layers
         .iter()
@@ -268,6 +278,45 @@ fn format_cache_inspect(app: &mut App, verbose: bool, json_mode: bool) -> String
     }
     app.session.last_cache_inspection = Some(inspection);
     out
+}
+
+fn format_warmup_status(last_warmup: Option<&CacheWarmupKey>, current: &CacheWarmupKey) -> String {
+    match last_warmup {
+        None => format!(
+            "Warmup status: no previous warmup (current key: {})\n",
+            current.hash_short()
+        ),
+        Some(previous) if previous == current => {
+            format!(
+                "Warmup status: valid (key {} matches)\n",
+                current.hash_short()
+            )
+        }
+        Some(previous) => {
+            let mut reasons = Vec::new();
+            if previous.provider != current.provider {
+                reasons.push("provider changed");
+            }
+            if previous.model != current.model {
+                reasons.push("model changed");
+            }
+            if previous.base_url != current.base_url {
+                reasons.push("base URL changed");
+            }
+            if previous.static_prefix_hash != current.static_prefix_hash {
+                reasons.push("static prefix changed");
+            }
+            if previous.tool_catalog_hash != current.tool_catalog_hash {
+                reasons.push("tool catalog changed");
+            }
+            format!(
+                "Warmup status: invalid ({} -> {}; {})\n",
+                previous.hash_short(),
+                current.hash_short(),
+                reasons.join(", ")
+            )
+        }
+    }
 }
 
 fn format_verbose_diff(previous: &PromptInspection, current: &PromptInspection) -> String {
@@ -892,6 +941,35 @@ mod tests {
             .expect("tool catalog layer");
         assert!(tool_layer["byte_len"].as_u64().unwrap() > 0);
         assert!(tool_layer["token_estimate"].as_u64().unwrap() > 0);
+    }
+
+    fn warmup_key(model: &str, static_hash: &str) -> CacheWarmupKey {
+        CacheWarmupKey {
+            provider: "Deepseek".to_string(),
+            model: model.to_string(),
+            base_url: "https://api.deepseek.com".to_string(),
+            static_prefix_hash: static_hash.to_string(),
+            tool_catalog_hash: "tool".to_string(),
+            project_pack_hash: "project".to_string(),
+            skills_hash: "skills".to_string(),
+        }
+    }
+
+    #[test]
+    fn warmup_status_reports_valid_matching_key() {
+        let key = warmup_key("deepseek-v4-pro", "static-a");
+        let result = format_warmup_status(Some(&key), &key);
+        assert!(result.contains("Warmup status: valid"), "got: {result}");
+    }
+
+    #[test]
+    fn warmup_status_reports_invalidation_reason() {
+        let previous = warmup_key("deepseek-v4-pro", "static-a");
+        let current = warmup_key("deepseek-v4-flash", "static-b");
+        let result = format_warmup_status(Some(&previous), &current);
+        assert!(result.contains("Warmup status: invalid"), "got: {result}");
+        assert!(result.contains("model changed"), "got: {result}");
+        assert!(result.contains("static prefix changed"), "got: {result}");
     }
 
     #[test]

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -1024,6 +1024,7 @@ impl Engine {
                     usage: turn.usage.clone(),
                     status: TurnOutcomeStatus::Failed,
                     error: Some(message),
+                    tool_catalog: None,
                 })
                 .await;
             return;
@@ -1194,6 +1195,7 @@ impl Engine {
                 &self.config.tools_always_load,
             )
         });
+        let tool_catalog_for_event = tools.clone();
 
         // Main turn loop
         let (status, error) = self
@@ -1227,6 +1229,7 @@ impl Engine {
                 usage: turn.usage,
                 status,
                 error,
+                tool_catalog: tool_catalog_for_event,
             })
             .await;
 
@@ -1272,6 +1275,7 @@ impl Engine {
                     usage: zero_usage,
                     status: TurnOutcomeStatus::Failed,
                     error: Some(message),
+                    tool_catalog: None,
                 })
                 .await;
             return;
@@ -1349,6 +1353,7 @@ impl Engine {
                 usage: zero_usage,
                 status: turn_status,
                 error: turn_error,
+                tool_catalog: None,
             })
             .await;
     }

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -1025,6 +1025,7 @@ impl Engine {
                     status: TurnOutcomeStatus::Failed,
                     error: Some(message),
                     tool_catalog: None,
+                    base_url: None,
                 })
                 .await;
             return;
@@ -1196,6 +1197,10 @@ impl Engine {
             )
         });
         let tool_catalog_for_event = tools.clone();
+        let base_url_for_event = self
+            .deepseek_client
+            .as_ref()
+            .map(|client| client.base_url().to_string());
 
         // Main turn loop
         let (status, error) = self
@@ -1230,6 +1235,7 @@ impl Engine {
                 status,
                 error,
                 tool_catalog: tool_catalog_for_event,
+                base_url: base_url_for_event,
             })
             .await;
 
@@ -1276,6 +1282,7 @@ impl Engine {
                     status: TurnOutcomeStatus::Failed,
                     error: Some(message),
                     tool_catalog: None,
+                    base_url: None,
                 })
                 .await;
             return;
@@ -1354,6 +1361,7 @@ impl Engine {
                 status: turn_status,
                 error: turn_error,
                 tool_catalog: None,
+                base_url: None,
             })
             .await;
     }

--- a/crates/tui/src/core/events.rs
+++ b/crates/tui/src/core/events.rs
@@ -94,6 +94,8 @@ pub enum Event {
         error: Option<String>,
         /// Tool catalog sent with this turn's model request.
         tool_catalog: Option<Vec<Tool>>,
+        /// API base URL used by this turn's client.
+        base_url: Option<String>,
     },
 
     /// Context compaction started.

--- a/crates/tui/src/core/events.rs
+++ b/crates/tui/src/core/events.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 
 use crate::core::coherence::CoherenceState;
 use crate::error_taxonomy::ErrorEnvelope;
-use crate::models::{Message, SystemPrompt, Usage};
+use crate::models::{Message, SystemPrompt, Tool, Usage};
 use crate::tools::spec::{ToolError, ToolResult};
 use crate::tools::subagent::SubAgentResult;
 use crate::tools::user_input::UserInputRequest;
@@ -92,6 +92,8 @@ pub enum Event {
         usage: Usage,
         status: TurnOutcomeStatus,
         error: Option<String>,
+        /// Tool catalog sent with this turn's model request.
+        tool_catalog: Option<Vec<Tool>>,
     },
 
     /// Context compaction started.

--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -2734,6 +2734,7 @@ mod tests {
                                 },
                                 status: TurnOutcomeStatus::Completed,
                                 error: None,
+                                tool_catalog: None,
                             })
                             .await;
                     }
@@ -2747,6 +2748,7 @@ mod tests {
                                 },
                                 status: TurnOutcomeStatus::Completed,
                                 error: None,
+                                tool_catalog: None,
                             })
                             .await;
                     }
@@ -2879,6 +2881,7 @@ mod tests {
                     },
                     status: TurnOutcomeStatus::Completed,
                     error: None,
+                    tool_catalog: None,
                 })
                 .await;
         });
@@ -3001,6 +3004,7 @@ mod tests {
                     },
                     status: TurnOutcomeStatus::Completed,
                     error: None,
+                    tool_catalog: None,
                 })
                 .await;
         });
@@ -3220,6 +3224,7 @@ mod tests {
                     },
                     status: TurnOutcomeStatus::Completed,
                     error: None,
+                    tool_catalog: None,
                 })
                 .await;
         });

--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -2735,6 +2735,7 @@ mod tests {
                                 status: TurnOutcomeStatus::Completed,
                                 error: None,
                                 tool_catalog: None,
+                                base_url: None,
                             })
                             .await;
                     }
@@ -2749,6 +2750,7 @@ mod tests {
                                 status: TurnOutcomeStatus::Completed,
                                 error: None,
                                 tool_catalog: None,
+                                base_url: None,
                             })
                             .await;
                     }
@@ -2882,6 +2884,7 @@ mod tests {
                     status: TurnOutcomeStatus::Completed,
                     error: None,
                     tool_catalog: None,
+                    base_url: None,
                 })
                 .await;
         });
@@ -3005,6 +3008,7 @@ mod tests {
                     status: TurnOutcomeStatus::Completed,
                     error: None,
                     tool_catalog: None,
+                    base_url: None,
                 })
                 .await;
         });
@@ -3225,6 +3229,7 @@ mod tests {
                     status: TurnOutcomeStatus::Completed,
                     error: None,
                     tool_catalog: None,
+                    base_url: None,
                 })
                 .await;
         });

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -3711,6 +3711,7 @@ mod tests {
                         status: TurnOutcomeStatus::Completed,
                         error: None,
                         tool_catalog: None,
+                        base_url: None,
                     })
                     .await;
             }
@@ -4004,6 +4005,7 @@ mod tests {
                         status: TurnOutcomeStatus::Completed,
                         error: None,
                         tool_catalog: None,
+                        base_url: None,
                     })
                     .await;
                 if turn_index >= 2 {
@@ -4241,6 +4243,7 @@ mod tests {
                 status: TurnOutcomeStatus::Completed,
                 error: None,
                 tool_catalog: None,
+                base_url: None,
             })
             .await?;
 
@@ -4323,6 +4326,7 @@ mod tests {
                 status: TurnOutcomeStatus::Completed,
                 error: None,
                 tool_catalog: None,
+                base_url: None,
             })
             .await?;
         Ok(())
@@ -4401,6 +4405,7 @@ mod tests {
                 status: TurnOutcomeStatus::Completed,
                 error: None,
                 tool_catalog: None,
+                base_url: None,
             })
             .await?;
         Ok(())
@@ -4465,6 +4470,7 @@ mod tests {
                 status: TurnOutcomeStatus::Completed,
                 error: None,
                 tool_catalog: None,
+                base_url: None,
             })
             .await?;
 
@@ -4593,6 +4599,7 @@ mod tests {
                 status: TurnOutcomeStatus::Completed,
                 error: None,
                 tool_catalog: None,
+                base_url: None,
             })
             .await?;
         Ok(())
@@ -4674,6 +4681,7 @@ mod tests {
                 status: TurnOutcomeStatus::Completed,
                 error: None,
                 tool_catalog: None,
+                base_url: None,
             })
             .await?;
 
@@ -4736,6 +4744,7 @@ mod tests {
                         status: TurnOutcomeStatus::Completed,
                         error: None,
                         tool_catalog: None,
+                        base_url: None,
                     })
                     .await;
             }
@@ -4847,6 +4856,7 @@ mod tests {
                                 status: TurnOutcomeStatus::Completed,
                                 error: None,
                                 tool_catalog: None,
+                                base_url: None,
                             })
                             .await;
                     }
@@ -4878,6 +4888,7 @@ mod tests {
                                 status: TurnOutcomeStatus::Completed,
                                 error: None,
                                 tool_catalog: None,
+                                base_url: None,
                             })
                             .await;
                     }

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -2885,6 +2885,7 @@ impl RuntimeThreadManager {
                     usage,
                     status,
                     error,
+                    ..
                 } => {
                     turn_usage = Some(usage);
                     turn_status = match status {
@@ -3709,6 +3710,7 @@ mod tests {
                         },
                         status: TurnOutcomeStatus::Completed,
                         error: None,
+                        tool_catalog: None,
                     })
                     .await;
             }
@@ -4001,6 +4003,7 @@ mod tests {
                         },
                         status: TurnOutcomeStatus::Completed,
                         error: None,
+                        tool_catalog: None,
                     })
                     .await;
                 if turn_index >= 2 {
@@ -4237,6 +4240,7 @@ mod tests {
                 },
                 status: TurnOutcomeStatus::Completed,
                 error: None,
+                tool_catalog: None,
             })
             .await?;
 
@@ -4318,6 +4322,7 @@ mod tests {
                 usage: Usage::default(),
                 status: TurnOutcomeStatus::Completed,
                 error: None,
+                tool_catalog: None,
             })
             .await?;
         Ok(())
@@ -4395,6 +4400,7 @@ mod tests {
                 usage: Usage::default(),
                 status: TurnOutcomeStatus::Completed,
                 error: None,
+                tool_catalog: None,
             })
             .await?;
         Ok(())
@@ -4458,6 +4464,7 @@ mod tests {
                 usage: Usage::default(),
                 status: TurnOutcomeStatus::Completed,
                 error: None,
+                tool_catalog: None,
             })
             .await?;
 
@@ -4585,6 +4592,7 @@ mod tests {
                 usage: Usage::default(),
                 status: TurnOutcomeStatus::Completed,
                 error: None,
+                tool_catalog: None,
             })
             .await?;
         Ok(())
@@ -4665,6 +4673,7 @@ mod tests {
                 },
                 status: TurnOutcomeStatus::Completed,
                 error: None,
+                tool_catalog: None,
             })
             .await?;
 
@@ -4726,6 +4735,7 @@ mod tests {
                         },
                         status: TurnOutcomeStatus::Completed,
                         error: None,
+                        tool_catalog: None,
                     })
                     .await;
             }
@@ -4836,6 +4846,7 @@ mod tests {
                                 },
                                 status: TurnOutcomeStatus::Completed,
                                 error: None,
+                                tool_catalog: None,
                             })
                             .await;
                     }
@@ -4866,6 +4877,7 @@ mod tests {
                                 },
                                 status: TurnOutcomeStatus::Completed,
                                 error: None,
+                                tool_catalog: None,
                             })
                             .await;
                     }

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 use thiserror::Error;
 
 use crate::artifacts::ArtifactRecord;
-use crate::client::PromptInspection;
+use crate::client::{CacheWarmupKey, PromptInspection};
 use crate::compaction::CompactionConfig;
 use crate::config::{
     ApiProvider, Config, DEFAULT_TEXT_MODEL, SavedCredential, has_api_key, save_api_key,
@@ -1034,11 +1034,14 @@ pub struct SessionState {
     pub total_output_tokens: u32,
     pub turn_cache_history: VecDeque<TurnCacheRecord>,
     pub last_cache_inspection: Option<PromptInspection>,
+    pub last_warmup_key: Option<CacheWarmupKey>,
     /// Tool catalog from the most recent model request.
     ///
     /// `/cache inspect` uses this to inspect the same tool schema bytes
     /// that were eligible for the provider's prefix cache.
     pub last_tool_catalog: Option<Vec<Tool>>,
+    /// API base URL used by the most recent model request or cache warmup.
+    pub last_base_url: Option<String>,
 }
 
 /// Sidebar hover state for mouse tooltip support.
@@ -1080,7 +1083,9 @@ impl Default for SessionState {
             total_output_tokens: 0,
             turn_cache_history: VecDeque::new(),
             last_cache_inspection: None,
+            last_warmup_key: None,
             last_tool_catalog: None,
+            last_base_url: None,
         }
     }
 }

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -19,7 +19,7 @@ use crate::core::coherence::CoherenceState;
 use crate::cycle_manager::{CycleBriefing, CycleConfig};
 use crate::hooks::{HookContext, HookEvent, HookExecutor, HookResult};
 use crate::localization::{Locale, MessageId, resolve_locale, tr};
-use crate::models::{Message, SystemPrompt, compaction_threshold_for_model_and_effort};
+use crate::models::{Message, SystemPrompt, Tool, compaction_threshold_for_model_and_effort};
 use crate::palette::{self, UiTheme};
 use crate::pricing::{CostCurrency, CostEstimate};
 use crate::session_manager::SessionContextReference;
@@ -1034,6 +1034,11 @@ pub struct SessionState {
     pub total_output_tokens: u32,
     pub turn_cache_history: VecDeque<TurnCacheRecord>,
     pub last_cache_inspection: Option<PromptInspection>,
+    /// Tool catalog from the most recent model request.
+    ///
+    /// `/cache inspect` uses this to inspect the same tool schema bytes
+    /// that were eligible for the provider's prefix cache.
+    pub last_tool_catalog: Option<Vec<Tool>>,
 }
 
 /// Sidebar hover state for mouse tooltip support.
@@ -1075,6 +1080,7 @@ impl Default for SessionState {
             total_output_tokens: 0,
             turn_cache_history: VecDeque::new(),
             last_cache_inspection: None,
+            last_tool_catalog: None,
         }
     }
 }

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -1442,7 +1442,11 @@ async fn run_event_loop(
                         usage,
                         status,
                         error,
+                        tool_catalog,
                     } => {
+                        if let Some(catalog) = tool_catalog {
+                            app.session.last_tool_catalog = Some(catalog);
+                        }
                         let was_locally_cancelled = app.suppress_stream_events_until_turn_complete;
                         app.suppress_stream_events_until_turn_complete = false;
                         app.active_allowed_tools = None;

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -37,7 +37,9 @@ use windows::Win32::System::Console::{GetConsoleMode, GetStdHandle, SetConsoleMo
 
 use crate::audit::log_sensitive_event;
 use crate::automation_manager::{AutomationManager, AutomationSchedulerConfig, spawn_scheduler};
-use crate::client::{DeepSeekClient, build_cache_warmup_request};
+use crate::client::{
+    CacheWarmupKey, DeepSeekClient, build_cache_warmup_request, inspect_prompt_for_request,
+};
 use crate::commands;
 use crate::compaction::estimate_input_tokens_conservative;
 use crate::config::{
@@ -1443,9 +1445,13 @@ async fn run_event_loop(
                         status,
                         error,
                         tool_catalog,
+                        base_url,
                     } => {
                         if let Some(catalog) = tool_catalog {
                             app.session.last_tool_catalog = Some(catalog);
+                        }
+                        if let Some(url) = base_url {
+                            app.session.last_base_url = Some(url);
                         }
                         let was_locally_cancelled = app.suppress_stream_events_until_turn_complete;
                         app.suppress_stream_events_until_turn_complete = false;
@@ -3869,8 +3875,9 @@ async fn fetch_available_models(config: &Config) -> Result<Vec<String>> {
     Ok(ids)
 }
 
-async fn run_cache_warmup(app: &App, config: &Config) -> Result<Usage> {
+async fn run_cache_warmup(app: &App, config: &Config) -> Result<(Usage, String)> {
     let client = DeepSeekClient::new(config)?;
+    let base_url = client.base_url().to_string();
     let reasoning_effort = if app.reasoning_effort == ReasoningEffort::Auto {
         app.last_effective_reasoning_effort
             .and_then(ReasoningEffort::api_value)
@@ -3883,7 +3890,7 @@ async fn run_cache_warmup(app: &App, config: &Config) -> Result<Usage> {
         messages: app.api_messages.clone(),
         max_tokens: 1024,
         system: app.system_prompt.clone(),
-        tools: None,
+        tools: app.session.last_tool_catalog.clone(),
         tool_choice: None,
         metadata: None,
         thinking: None,
@@ -3895,7 +3902,7 @@ async fn run_cache_warmup(app: &App, config: &Config) -> Result<Usage> {
     let warmup = build_cache_warmup_request(&request);
     let response =
         tokio::time::timeout(Duration::from_secs(45), client.create_message(warmup)).await??;
-    Ok(response.usage)
+    Ok((response.usage, base_url))
 }
 
 // `format_*` chip/message builders moved to `tui/format_helpers.rs`.
@@ -4932,8 +4939,40 @@ async fn apply_command_result(
             AppAction::CacheWarmup => {
                 app.status_message = Some("Warming DeepSeek cache...".to_string());
                 match run_cache_warmup(app, config).await {
-                    Ok(usage) => {
+                    Ok((usage, base_url)) => {
+                        app.session.last_base_url = Some(base_url.clone());
+                        let reasoning_effort = if app.reasoning_effort == ReasoningEffort::Auto {
+                            app.last_effective_reasoning_effort
+                                .and_then(ReasoningEffort::api_value)
+                                .map(str::to_string)
+                        } else {
+                            app.reasoning_effort.api_value().map(str::to_string)
+                        };
+                        let request = MessageRequest {
+                            model: app.model.clone(),
+                            messages: app.api_messages.clone(),
+                            max_tokens: 0,
+                            system: app.system_prompt.clone(),
+                            tools: app.session.last_tool_catalog.clone(),
+                            tool_choice: None,
+                            metadata: None,
+                            thinking: None,
+                            reasoning_effort,
+                            stream: None,
+                            temperature: None,
+                            top_p: None,
+                        };
+                        let inspection = inspect_prompt_for_request(&request);
+                        app.session.last_warmup_key = Some(CacheWarmupKey::from_inspection(
+                            &format!("{:?}", app.api_provider),
+                            &app.model,
+                            &base_url,
+                            &inspection,
+                        ));
                         let mut message = format_helpers::cache_warmup_result(&usage);
+                        if let Some(key) = app.session.last_warmup_key.as_ref() {
+                            message.push_str(&format!("\nWarmup key: {}", key.hash_short()));
+                        }
                         // Append prefix-cache stability info.
                         if app.prefix_checks_total > 0 {
                             let changes = app.prefix_change_count;

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -1,4 +1,4 @@
-use super::*;
+﻿use super::*;
 use crate::config::{ApiProvider, Config, DEFAULT_TEXT_MODEL};
 use crate::config_ui::{self, WebConfigSession, WebConfigSessionEvent};
 use crate::core::engine::mock_engine_handle;
@@ -3015,6 +3015,7 @@ fn local_cancel_marks_late_stream_events_for_suppression() {
             status: crate::core::events::TurnOutcomeStatus::Interrupted,
             error: None,
             tool_catalog: None,
+            base_url: None,
         }
     ));
     assert!(!suppress_engine_event_after_local_cancel(

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -3014,6 +3014,7 @@ fn local_cancel_marks_late_stream_events_for_suppression() {
             usage: Usage::default(),
             status: crate::core::events::TurnOutcomeStatus::Interrupted,
             error: None,
+            tool_catalog: None,
         }
     ));
     assert!(!suppress_engine_event_after_local_cancel(


### PR DESCRIPTION
## Summary

- adds a `CacheWarmupKey` covering provider, model, base URL, static prefix, tool catalog, project pack, and skills hashes
- records the base URL and real tool catalog used by model requests
- stores a warmup key after `/cache warmup` and shows whether `/cache inspect` still matches it

## Validation

- `cargo test -p codewhale-tui warmup_status --all-features`
- `cargo test -p codewhale-tui cache_inspect --all-features`

## Stacking note

This draft currently includes PR #2390 as its first commit because the warmup key needs the same real-tool-catalog plumbing. After #2390 lands, this branch should be rebased so the PR shows only the warmup-key commit.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces `CacheWarmupKey` — a seven-field struct covering provider, model, base URL, static prefix, tool catalog, project pack, and skills hashes — and wires it through the event system so `/cache warmup` stores the key and `/cache inspect` can compare the current state against it. It also records the real tool catalog and base URL from each model request, so both commands now operate on the same data that was eligible for provider prefix caching.

- **`CacheWarmupKey`** is built in `client/chat.rs` from a `PromptInspection`, serialized via Serde, and its `hash_short()` used as a display fingerprint in both warmup and inspect output.
- **Event plumbing** (`events.rs`, `engine.rs`, `ui.rs`, `runtime_threads.rs`) threads `tool_catalog` and `base_url` through the `TurnOutcome` event so `last_tool_catalog` and `last_base_url` are populated on every completed turn.
- **`/cache inspect`** gains `--verbose` (layer-by-layer diff) and `--json` (full Serde output) flags, plus warmup-status and token-estimate lines; `PromptLayerInspection` gains `byte_len` and `token_estimate` fields.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge after fixing the missing reason fields; the warmup key mismatch will otherwise silently show invalid with no explanation whenever project pack or skills content changes.

The warmup status formatter checks five of the seven fields that make up the key. When project_pack_hash or skills_hash is the sole cause of a key mismatch, the output reads Warmup status: invalid with no reason printed and a malformed trailing string. Every other path (event plumbing, new struct fields, reset logic, tests) looks correct and the change is well-scoped.

crates/tui/src/commands/debug.rs — the format_warmup_status function and the json_mode early-return path both need attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/commands/debug.rs | Adds --verbose/--json flags to /cache inspect and the warmup status display; missing project_pack_hash and skills_hash checks in format_warmup_status produce an empty-reason invalid message, and json_mode silently drops the warmup key comparison. |
| crates/tui/src/client/chat.rs | Adds CacheWarmupKey struct and from_inspection constructor, tool_catalog_hash to PromptInspection, byte_len/token_estimate to PromptLayerInspection; logic looks correct. |
| crates/tui/src/tui/ui.rs | run_cache_warmup now returns the base URL; warmup key is derived from a freshly-constructed MessageRequest rather than from the actual request sent to the provider, which may diverge. |
| crates/tui/src/core/events.rs | Adds tool_catalog and base_url fields to the TurnOutcome event variant; straightforward struct extension. |
| crates/tui/src/tui/app.rs | Adds last_warmup_key, last_tool_catalog, and last_base_url to SessionState with correct Default impls and resets in reset_conversation_state. |
| crates/tui/src/tui/ui/tests.rs | Adds new TurnOutcome fields to test fixtures; a UTF-8 BOM was inadvertently introduced at line 1. |
| crates/tui/src/core/engine.rs | Captures tool_catalog and base_url at turn start and passes them into the TurnOutcome event; None is correctly propagated on all early-exit error paths. |
| crates/tui/src/runtime_threads.rs | Uses .. to ignore new TurnOutcome fields in the match arm and adds None to all test fixtures; no logic changes. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant UI as tui/ui.rs
    participant Engine as core/engine.rs
    participant Client as client.rs
    participant Session as SessionState

    User->>UI: /cache warmup
    UI->>Client: run_cache_warmup(app, config)
    Client->>Client: build_cache_warmup_request
    Client-->>UI: Ok((usage, base_url))
    UI->>UI: inspect_prompt_for_request
    UI->>UI: CacheWarmupKey::from_inspection
    UI->>Session: "last_warmup_key = Some(key)"

    User->>UI: /cache inspect
    UI->>UI: inspect_prompt_for_request
    UI->>UI: format_warmup_status
    UI-->>User: inspect output + warmup status

    User->>UI: send message
    Engine->>Client: create_message(request)
    Engine-->>UI: "TurnOutcome { tool_catalog, base_url }"
    UI->>Session: last_tool_catalog, last_base_url updated
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fcache-warmup-key-correctness%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fcache-warmup-key-correctness%22.%0A%0AFix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Acrates%2Ftui%2Fsrc%2Fcommands%2Fdebug.rs%3A309-312%0A%60project_pack_hash%60%20and%20%60skills_hash%60%20are%20fields%20of%20%60CacheWarmupKey%60%20and%20participate%20in%20%60PartialEq%60%2C%20so%20a%20change%20to%20either%20will%20make%20the%20match%20fall%20into%20the%20%60Some%28previous%29%60%20arm.%20However%2C%20neither%20field%20is%20checked%20inside%20the%20reasons-building%20block.%20When%20only%20the%20project%20pack%20or%20skills%20change%2C%20%60reasons%60%20stays%20empty%20and%20the%20output%20is%20%60%22Warmup%20status%3A%20invalid%20%28abc123%20-%3E%20def456%3B%20%29%22%60%20%E2%80%94%20a%20dangling%20%22%3B%20%29%22%20with%20no%20explanation.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20previous.tool_catalog_hash%20!%3D%20current.tool_catalog_hash%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20reasons.push%28%22tool%20catalog%20changed%22%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20previous.project_pack_hash%20!%3D%20current.project_pack_hash%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20reasons.push%28%22project%20pack%20changed%22%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20previous.skills_hash%20!%3D%20current.skills_hash%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20reasons.push%28%22skills%20changed%22%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20format!%28%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0Acrates%2Ftui%2Fsrc%2Fcommands%2Fdebug.rs%3A198-203%0A%60current_warmup_key%60%20is%20computed%20just%20before%20the%20%60json_mode%60%20branch%20but%20is%20dropped%20when%20that%20branch%20is%20taken.%20In%20JSON%20mode%20the%20inspect%20output%20includes%20the%20hash%20fields%2C%20but%20the%20warmup%20key%20comparison%20is%20skipped%20and%20%60last_warmup_key%60%20is%20never%20updated%2C%20so%20a%20%60--json%60%20inspection%20won't%20persist%20the%20key%20for%20a%20future%20%60%2Fcache%20inspect%60%20to%20compare%20against.%0A%0A%23%23%23%20Issue%203%20of%204%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui.rs%3A3875-3893%0A**Warmup%20key%20built%20from%20a%20different%20request%20than%20the%20one%20sent%20to%20the%20API.**%20%60run_cache_warmup%60%20builds%20%60request%60%20then%20passes%20it%20through%20%60build_cache_warmup_request%60%20before%20sending%20to%20the%20provider%2C%20but%20the%20warmup%20key%20is%20derived%20from%20a%20second%2C%20plain%20%60MessageRequest%60%20constructed%20in%20%60apply_command_result%60%20%E2%80%94%20with%20different%20%60max_tokens%60%20%280%20vs%201024%20used%20in%20the%20actual%20call%29.%20If%20%60build_cache_warmup_request%60%20adjusts%20or%20strips%20any%20fields%2C%20the%20inspection%20used%20for%20the%20key%20won't%20reflect%20what%20the%20provider%20actually%20cached.%0A%0A%23%23%23%20Issue%204%20of%204%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui%2Ftests.rs%3A1%0AA%20UTF-8%20BOM%20%28%60%5CxEF%5CxBB%5CxBF%60%29%20was%20introduced%20at%20the%20start%20of%20this%20file.%20Rust%20accepts%20it%20silently%2C%20but%20it%20can%20cause%20issues%20with%20diff%20tools%2C%20%60%23%5Bpath%5D%60%20includes%2C%20and%20some%20CI%20linters%20that%20enforce%20no-BOM%20conventions.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Acrates%2Ftui%2Fsrc%2Fcommands%2Fdebug.rs%3A309-312%0A%60project_pack_hash%60%20and%20%60skills_hash%60%20are%20fields%20of%20%60CacheWarmupKey%60%20and%20participate%20in%20%60PartialEq%60%2C%20so%20a%20change%20to%20either%20will%20make%20the%20match%20fall%20into%20the%20%60Some%28previous%29%60%20arm.%20However%2C%20neither%20field%20is%20checked%20inside%20the%20reasons-building%20block.%20When%20only%20the%20project%20pack%20or%20skills%20change%2C%20%60reasons%60%20stays%20empty%20and%20the%20output%20is%20%60%22Warmup%20status%3A%20invalid%20%28abc123%20-%3E%20def456%3B%20%29%22%60%20%E2%80%94%20a%20dangling%20%22%3B%20%29%22%20with%20no%20explanation.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20previous.tool_catalog_hash%20!%3D%20current.tool_catalog_hash%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20reasons.push%28%22tool%20catalog%20changed%22%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20previous.project_pack_hash%20!%3D%20current.project_pack_hash%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20reasons.push%28%22project%20pack%20changed%22%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20previous.skills_hash%20!%3D%20current.skills_hash%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20reasons.push%28%22skills%20changed%22%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20format!%28%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0Acrates%2Ftui%2Fsrc%2Fcommands%2Fdebug.rs%3A198-203%0A%60current_warmup_key%60%20is%20computed%20just%20before%20the%20%60json_mode%60%20branch%20but%20is%20dropped%20when%20that%20branch%20is%20taken.%20In%20JSON%20mode%20the%20inspect%20output%20includes%20the%20hash%20fields%2C%20but%20the%20warmup%20key%20comparison%20is%20skipped%20and%20%60last_warmup_key%60%20is%20never%20updated%2C%20so%20a%20%60--json%60%20inspection%20won't%20persist%20the%20key%20for%20a%20future%20%60%2Fcache%20inspect%60%20to%20compare%20against.%0A%0A%23%23%23%20Issue%203%20of%204%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui.rs%3A3875-3893%0A**Warmup%20key%20built%20from%20a%20different%20request%20than%20the%20one%20sent%20to%20the%20API.**%20%60run_cache_warmup%60%20builds%20%60request%60%20then%20passes%20it%20through%20%60build_cache_warmup_request%60%20before%20sending%20to%20the%20provider%2C%20but%20the%20warmup%20key%20is%20derived%20from%20a%20second%2C%20plain%20%60MessageRequest%60%20constructed%20in%20%60apply_command_result%60%20%E2%80%94%20with%20different%20%60max_tokens%60%20%280%20vs%201024%20used%20in%20the%20actual%20call%29.%20If%20%60build_cache_warmup_request%60%20adjusts%20or%20strips%20any%20fields%2C%20the%20inspection%20used%20for%20the%20key%20won't%20reflect%20what%20the%20provider%20actually%20cached.%0A%0A%23%23%23%20Issue%204%20of%204%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui%2Ftests.rs%3A1%0AA%20UTF-8%20BOM%20%28%60%5CxEF%5CxBB%5CxBF%60%29%20was%20introduced%20at%20the%20start%20of%20this%20file.%20Rust%20accepts%20it%20silently%2C%20but%20it%20can%20cause%20issues%20with%20diff%20tools%2C%20%60%23%5Bpath%5D%60%20includes%2C%20and%20some%20CI%20linters%20that%20enforce%20no-BOM%20conventions.%0A%0A&repo=hmbown%2Fcodewhale&pr=2391&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Acrates%2Ftui%2Fsrc%2Fcommands%2Fdebug.rs%3A309-312%0A%60project_pack_hash%60%20and%20%60skills_hash%60%20are%20fields%20of%20%60CacheWarmupKey%60%20and%20participate%20in%20%60PartialEq%60%2C%20so%20a%20change%20to%20either%20will%20make%20the%20match%20fall%20into%20the%20%60Some%28previous%29%60%20arm.%20However%2C%20neither%20field%20is%20checked%20inside%20the%20reasons-building%20block.%20When%20only%20the%20project%20pack%20or%20skills%20change%2C%20%60reasons%60%20stays%20empty%20and%20the%20output%20is%20%60%22Warmup%20status%3A%20invalid%20%28abc123%20-%3E%20def456%3B%20%29%22%60%20%E2%80%94%20a%20dangling%20%22%3B%20%29%22%20with%20no%20explanation.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20previous.tool_catalog_hash%20!%3D%20current.tool_catalog_hash%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20reasons.push%28%22tool%20catalog%20changed%22%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20previous.project_pack_hash%20!%3D%20current.project_pack_hash%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20reasons.push%28%22project%20pack%20changed%22%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20previous.skills_hash%20!%3D%20current.skills_hash%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20reasons.push%28%22skills%20changed%22%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20format!%28%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0Acrates%2Ftui%2Fsrc%2Fcommands%2Fdebug.rs%3A198-203%0A%60current_warmup_key%60%20is%20computed%20just%20before%20the%20%60json_mode%60%20branch%20but%20is%20dropped%20when%20that%20branch%20is%20taken.%20In%20JSON%20mode%20the%20inspect%20output%20includes%20the%20hash%20fields%2C%20but%20the%20warmup%20key%20comparison%20is%20skipped%20and%20%60last_warmup_key%60%20is%20never%20updated%2C%20so%20a%20%60--json%60%20inspection%20won't%20persist%20the%20key%20for%20a%20future%20%60%2Fcache%20inspect%60%20to%20compare%20against.%0A%0A%23%23%23%20Issue%203%20of%204%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui.rs%3A3875-3893%0A**Warmup%20key%20built%20from%20a%20different%20request%20than%20the%20one%20sent%20to%20the%20API.**%20%60run_cache_warmup%60%20builds%20%60request%60%20then%20passes%20it%20through%20%60build_cache_warmup_request%60%20before%20sending%20to%20the%20provider%2C%20but%20the%20warmup%20key%20is%20derived%20from%20a%20second%2C%20plain%20%60MessageRequest%60%20constructed%20in%20%60apply_command_result%60%20%E2%80%94%20with%20different%20%60max_tokens%60%20%280%20vs%201024%20used%20in%20the%20actual%20call%29.%20If%20%60build_cache_warmup_request%60%20adjusts%20or%20strips%20any%20fields%2C%20the%20inspection%20used%20for%20the%20key%20won't%20reflect%20what%20the%20provider%20actually%20cached.%0A%0A%23%23%23%20Issue%204%20of%204%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui%2Ftests.rs%3A1%0AA%20UTF-8%20BOM%20%28%60%5CxEF%5CxBB%5CxBF%60%29%20was%20introduced%20at%20the%20start%20of%20this%20file.%20Rust%20accepts%20it%20silently%2C%20but%20it%20can%20cause%20issues%20with%20diff%20tools%2C%20%60%23%5Bpath%5D%60%20includes%2C%20and%20some%20CI%20linters%20that%20enforce%20no-BOM%20conventions.%0A%0A&pr=2391&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat: track cache warmup keys"](https://github.com/hmbown/codewhale/commit/26eb1a7e912c319e34eaab59bdda047742b3a826) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34772582)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->