### PR TITLE
feat(project-context): stabilize pack ordering

### DIFF
--- a/crates/tui/src/project_context.rs
+++ b/crates/tui/src/project_context.rs
@@ -170,7 +170,7 @@ struct ReadmePack {
 pub fn generate_project_context_pack(workspace: &Path) -> Option<String> {
     let mut entries = Vec::new();
     collect_pack_entries(workspace, workspace, 0, &mut entries);
-    entries.sort();
+    sort_pack_paths(&mut entries);
     entries.truncate(PACK_MAX_ENTRIES);
 
     let mut config_files = entries
@@ -179,7 +179,7 @@ pub fn generate_project_context_pack(workspace: &Path) -> Option<String> {
         .take(PACK_MAX_CONFIG_FILES)
         .cloned()
         .collect::<Vec<_>>();
-    config_files.sort();
+    sort_pack_paths(&mut config_files);
 
     let mut key_source_files = entries
         .iter()
@@ -187,7 +187,7 @@ pub fn generate_project_context_pack(workspace: &Path) -> Option<String> {
         .take(PACK_MAX_SOURCE_FILES)
         .cloned()
         .collect::<Vec<_>>();
-    key_source_files.sort();
+    sort_pack_paths(&mut key_source_files);
 
     let readme = read_readme_excerpt(workspace, &entries);
     let mut counts = BTreeMap::new();
@@ -289,10 +289,50 @@ fn relative_slash_path(root: &Path, path: &Path) -> Option<String> {
     for component in relative.components() {
         parts.push(component.as_os_str().to_string_lossy().to_string());
     }
-    if parts.is_empty() {
-        None
+    normalize_pack_relative_path(&parts.join("/"))
+}
+
+fn normalize_pack_relative_path(path: &str) -> Option<String> {
+    let normalized = path.replace('\\', "/");
+    let mut parts = Vec::new();
+    for part in normalized.split('/') {
+        if part.is_empty() || part == "." {
+            continue;
+        }
+        if part == ".." {
+            return None;
+        }
+        parts.push(part);
+    }
+    (!parts.is_empty()).then(|| parts.join("/"))
+}
+
+fn sort_pack_paths(paths: &mut [String]) {
+    paths.sort_by(|a, b| {
+        pack_path_priority(a)
+            .cmp(&pack_path_priority(b))
+            .then_with(|| pack_path_sort_key(a).cmp(&pack_path_sort_key(b)))
+            .then_with(|| a.cmp(b))
+    });
+}
+
+fn pack_path_sort_key(path: &str) -> String {
+    path.replace('\\', "/").to_ascii_lowercase()
+}
+
+fn pack_path_priority(path: &str) -> u8 {
+    let lower = pack_path_sort_key(path);
+    let name = lower.trim_end_matches('/').rsplit('/').next().unwrap_or("");
+    if matches!(name, "readme.md" | "readme.txt" | "readme") {
+        0
+    } else if is_config_file(&lower) {
+        1
+    } else if is_source_file(&lower) {
+        2
+    } else if lower.ends_with('/') {
+        3
     } else {
-        Some(parts.join("/"))
+        4
     }
 }
 
@@ -1027,6 +1067,55 @@ mod tests {
             pack.contains("\"zzz-important/\""),
             "breadth-first packing should keep later top-level directories visible:\n{pack}"
         );
+    }
+
+    #[test]
+    fn project_context_pack_sort_is_cross_platform_and_priority_aware() {
+        let mut unix_paths = vec![
+            "src/z.rs".to_string(),
+            "docs/".to_string(),
+            "README.md".to_string(),
+            "Cargo.toml".to_string(),
+            "src/a.rs".to_string(),
+            "notes.txt".to_string(),
+        ];
+        let mut windows_paths = vec![
+            "src\\z.rs".to_string(),
+            "docs\\".to_string(),
+            "README.md".to_string(),
+            "Cargo.toml".to_string(),
+            "src\\a.rs".to_string(),
+            "notes.txt".to_string(),
+        ];
+
+        sort_pack_paths(&mut unix_paths);
+        sort_pack_paths(&mut windows_paths);
+
+        let normalized_windows = windows_paths
+            .iter()
+            .map(|path| path.replace('\\', "/"))
+            .collect::<Vec<_>>();
+        assert_eq!(unix_paths, normalized_windows);
+        assert_eq!(
+            unix_paths,
+            vec![
+                "README.md",
+                "Cargo.toml",
+                "src/a.rs",
+                "src/z.rs",
+                "docs/",
+                "notes.txt",
+            ]
+        );
+    }
+
+    #[test]
+    fn normalize_pack_relative_path_rejects_parent_segments() {
+        assert_eq!(
+            normalize_pack_relative_path(".\\src\\main.rs"),
+            Some("src/main.rs".to_string())
+        );
+        assert_eq!(normalize_pack_relative_path("../secret.txt"), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- replaces plain lexical sorting with explicit project-context pack ordering
- prioritizes README, config files, source files, directories, then other files
- normalizes path separators before sorting so Windows/Unix path forms produce the same order

## Validation

- `cargo test -p codewhale-tui project_context_pack --all-features`

Split out of the superseded large cache-hit optimization PR.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces three plain `entries.sort()` calls in `generate_project_context_pack` with a new `sort_pack_paths` helper that applies a deterministic, priority-aware ordering (README → config → source → directory → other) and normalizes backslashes before comparing so Windows and Unix path forms produce an identical sort result.

- `sort_pack_paths` / `pack_path_priority` introduce the five-tier priority scheme; `pack_path_sort_key` normalizes separators and lowercases before lexicographic comparison.
- `normalize_pack_relative_path` is extracted from `relative_slash_path` to strip `.` and reject `..` segments, providing a small defense-in-depth guard against path traversal in the relative-path computation.
- Two new unit tests cover the cross-platform ordering contract and the `..`-rejection behavior.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change is well-scoped to sorting logic with good test coverage and no impact on data correctness.

The sorting logic is self-contained and the new tests validate both the cross-platform ordering contract and path normalization. The two findings are minor: `pack_path_sort_key` is recomputed multiple times per comparison (redundant allocations, not incorrect), and READMEs nested in subdirectories receive the same top priority as the root README, which may silently reorder results in multi-readme projects.

crates/tui/src/project_context.rs — specifically the `pack_path_priority` function and the `sort_pack_paths` comparator closure
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/project_context.rs | Replaces plain `sort()` calls with a priority-aware `sort_pack_paths` helper that orders README → config → source → directory → other, normalizes path separators for cross-platform consistency, and adds `..` traversal rejection in `normalize_pack_relative_path`. Two minor issues: `pack_path_sort_key` is allocated redundantly on every sort comparison, and any README at any depth (not just root) receives priority 0. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["sort_pack_paths(paths)"] --> B["For each pair (a, b): compare pack_path_priority"]
    B --> C{Priorities equal?}
    C -- No --> D["Order by priority\n(0=README, 1=config, 2=source,\n3=dir, 4=other)"]
    C -- Yes --> E["Compare pack_path_sort_key\n(lowercase + backslash→slash)"]
    E --> F{Keys equal?}
    F -- No --> G["Order by normalized key"]
    F -- Yes --> H["Order by original string\n(case-sensitive tiebreaker)"]

    subgraph pack_path_priority
        P1["lower = pack_path_sort_key(path)"]
        P2["name = last segment after trim '/'"]
        P3{name matches readme?}
        P4{is_config_file?}
        P5{is_source_file?}
        P6{ends with '/'?}
        P1 --> P2 --> P3
        P3 -- Yes --> R0["priority 0"]
        P3 -- No --> P4
        P4 -- Yes --> R1["priority 1"]
        P4 -- No --> P5
        P5 -- Yes --> R2["priority 2"]
        P5 -- No --> P6
        P6 -- Yes --> R3["priority 3 (directory)"]
        P6 -- No --> R4["priority 4 (other)"]
    end
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fproject-context-determinism%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fproject-context-determinism%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fproject_context.rs%3A310-317%0A**Redundant%20allocations%20per%20sort%20comparison**%0A%0A%60pack_path_priority%60%20already%20calls%20%60pack_path_sort_key%60%20internally%2C%20and%20%60sort_pack_paths%60%20then%20calls%20it%20again%20in%20the%20%60then_with%60%20closure.%20For%20each%20comparison%20pair%20this%20creates%204%20short-lived%20%60String%60%20allocations.%20With%20up%20to%20220%20entries%20and%20O%28n%20log%20n%29%20comparisons%2C%20this%20is%20~1800%20allocations%20per%20sort%20call.%20Consider%20pre-computing%20sort%20keys%20%28e.g.%2C%20%60%28priority%2C%20lowercase_key%2C%20original%29%60%20tuples%29%20before%20sorting%20to%20reduce%20allocation%20pressure.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fproject_context.rs%3A323-337%0A**Subdirectory%20READMEs%20get%20the%20same%20priority%20as%20the%20root%20README**%0A%0A%60pack_path_priority%60%20extracts%20just%20the%20file%20name%20with%20%60rsplit%28'%2F'%29.next%28%29%60%2C%20so%20%60%22docs%2FREADME.md%22%60%20gets%20priority%200%20%E2%80%94%20identical%20to%20%60%22README.md%22%60.%20In%20a%20project%20with%20nested%20READMEs%20this%20causes%20all%20of%20them%20to%20sort%20before%20root-level%20config%20files%20like%20%60Cargo.toml%60%2C%20which%20may%20not%20be%20the%20intended%20behavior.%20If%20only%20the%20root%20README%20should%20be%20elevated%2C%20a%20depth%20check%20%28e.g.%2C%20path%20contains%20no%20%60%2F%60%29%20would%20be%20needed.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fproject_context.rs%3A310-317%0A**Redundant%20allocations%20per%20sort%20comparison**%0A%0A%60pack_path_priority%60%20already%20calls%20%60pack_path_sort_key%60%20internally%2C%20and%20%60sort_pack_paths%60%20then%20calls%20it%20again%20in%20the%20%60then_with%60%20closure.%20For%20each%20comparison%20pair%20this%20creates%204%20short-lived%20%60String%60%20allocations.%20With%20up%20to%20220%20entries%20and%20O%28n%20log%20n%29%20comparisons%2C%20this%20is%20~1800%20allocations%20per%20sort%20call.%20Consider%20pre-computing%20sort%20keys%20%28e.g.%2C%20%60%28priority%2C%20lowercase_key%2C%20original%29%60%20tuples%29%20before%20sorting%20to%20reduce%20allocation%20pressure.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fproject_context.rs%3A323-337%0A**Subdirectory%20READMEs%20get%20the%20same%20priority%20as%20the%20root%20README**%0A%0A%60pack_path_priority%60%20extracts%20just%20the%20file%20name%20with%20%60rsplit%28'%2F'%29.next%28%29%60%2C%20so%20%60%22docs%2FREADME.md%22%60%20gets%20priority%200%20%E2%80%94%20identical%20to%20%60%22README.md%22%60.%20In%20a%20project%20with%20nested%20READMEs%20this%20causes%20all%20of%20them%20to%20sort%20before%20root-level%20config%20files%20like%20%60Cargo.toml%60%2C%20which%20may%20not%20be%20the%20intended%20behavior.%20If%20only%20the%20root%20README%20should%20be%20elevated%2C%20a%20depth%20check%20%28e.g.%2C%20path%20contains%20no%20%60%2F%60%29%20would%20be%20needed.%0A%0A&repo=hmbown%2Fcodewhale&pr=2392&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fproject_context.rs%3A310-317%0A**Redundant%20allocations%20per%20sort%20comparison**%0A%0A%60pack_path_priority%60%20already%20calls%20%60pack_path_sort_key%60%20internally%2C%20and%20%60sort_pack_paths%60%20then%20calls%20it%20again%20in%20the%20%60then_with%60%20closure.%20For%20each%20comparison%20pair%20this%20creates%204%20short-lived%20%60String%60%20allocations.%20With%20up%20to%20220%20entries%20and%20O%28n%20log%20n%29%20comparisons%2C%20this%20is%20~1800%20allocations%20per%20sort%20call.%20Consider%20pre-computing%20sort%20keys%20%28e.g.%2C%20%60%28priority%2C%20lowercase_key%2C%20original%29%60%20tuples%29%20before%20sorting%20to%20reduce%20allocation%20pressure.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fproject_context.rs%3A323-337%0A**Subdirectory%20READMEs%20get%20the%20same%20priority%20as%20the%20root%20README**%0A%0A%60pack_path_priority%60%20extracts%20just%20the%20file%20name%20with%20%60rsplit%28'%2F'%29.next%28%29%60%2C%20so%20%60%22docs%2FREADME.md%22%60%20gets%20priority%200%20%E2%80%94%20identical%20to%20%60%22README.md%22%60.%20In%20a%20project%20with%20nested%20READMEs%20this%20causes%20all%20of%20them%20to%20sort%20before%20root-level%20config%20files%20like%20%60Cargo.toml%60%2C%20which%20may%20not%20be%20the%20intended%20behavior.%20If%20only%20the%20root%20README%20should%20be%20elevated%2C%20a%20depth%20check%20%28e.g.%2C%20path%20contains%20no%20%60%2F%60%29%20would%20be%20needed.%0A%0A&pr=2392&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat: stabilize project context pack ord..."](https://github.com/hmbown/codewhale/commit/cf5f0008f475ed81d90adde7a9e48d380543d560) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34772589)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->