### PR TITLE
test(cache): cover medium tool result dedup

### DIFF
--- a/crates/tui/src/client/chat.rs
+++ b/crates/tui/src/client/chat.rs
@@ -2852,8 +2852,12 @@ mod stream_decoder_tests {
     }
 
     #[test]
-    fn request_builder_deduplicates_large_identical_tool_results_with_retrieval_hint() {
+    fn request_builder_deduplicates_medium_identical_tool_results_with_retrieval_hint() {
         with_tool_result_sha_spillover_root(|| {
+            // 2,000 chars is intentionally above TOOL_RESULT_DEDUP_MIN_CHARS
+            // (1,024) but below TOOL_RESULT_SENT_CHAR_BUDGET (12,000). This
+            // verifies the cache-saving path for repeated medium outputs that
+            // do not otherwise need truncation.
             let output = "A".repeat(2_000);
             let messages = vec![
                 tool_use_message("tool-1", "read_file", json!({"path": "README.md"})),
@@ -2867,6 +2871,7 @@ mod stream_decoder_tests {
             let second = tool_message_content(&built, 1);
 
             assert_eq!(first, output);
+            assert!(!first.contains("[TOOL_RESULT_TRUNCATED]"), "got: {first}");
             assert!(
                 second.starts_with("<TOOL_RESULT_REF sha=\""),
                 "got: {second}"


### PR DESCRIPTION
## Summary

- documents that current upstream already deduplicates repeated medium tool outputs above 1,024 chars and below the 12,000-char truncation budget
- keeps the mutation-tool safety logic untouched
- adds an explicit regression assertion that the first medium result stays inline and untruncated while the repeat becomes a retrieval ref

## Validation

- `cargo test -p codewhale-tui request_builder_deduplicates_medium_identical_tool_results_with_retrieval_hint --all-features`

This is the safe remainder of the wire-payload slice from the superseded large cache-hit optimization PR. The behavioral threshold change had already landed upstream.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Renames and tightens one existing test to accurately reflect the "medium" tool-result range (above 1,024 chars, below the 12,000-char truncation budget). The production dedup logic itself is untouched.

- The test name is corrected from `…large…` to `…medium…` because the 2,000-char payload has always sat between `TOOL_RESULT_DEDUP_MIN_CHARS` (1,024) and `TOOL_RESULT_SENT_CHAR_BUDGET` (12,000); the old name was misleading.
- A new `assert!(!first.contains(\"[TOOL_RESULT_TRUNCATED]\"))` guard is added, making explicit that the first occurrence of a medium result must arrive at the wire untruncated.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Test-only change with no production logic touched; safe to merge.

The change is confined to a single test function: a rename to fix a misleading name and one extra assertion confirming the first occurrence of a medium-sized tool result is never truncated. No production code is modified. The large-result and mutation-tool paths retain their existing coverage in other tests, and the new assertion correctly reflects the invariant documented by the surrounding constants.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/client/chat.rs | Renames the previously-misnamed test to `…medium…` (the payload is 2,000 chars, squarely between the 1,024 dedup floor and the 12,000 truncation budget) and adds an explicit `!first.contains("[TOOL_RESULT_TRUNCATED]")` regression assertion. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[tool result emitted] --> B{chars >= TOOL_RESULT_DEDUP_MIN_CHARS 1024?}
    B -- No --> C[send inline, no SHA store]
    B -- Yes --> D{chars <= TOOL_RESULT_SENT_CHAR_BUDGET 12000?}
    D -- Yes medium path --> E[send inline untruncated, persist to SHA store]
    D -- No large path --> F[truncate head+tail, persist full content to SHA store]
    E --> G{seen SHA before & not mutation tool?}
    F --> G
    G -- No --> H[send content inline]
    G -- Yes --> I[replace with TOOL_RESULT_REF]
    H --> J[new assertion: first medium result = inline & untruncated]
    I --> K[second medium result = REF]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["test: cover medium tool result dedup"](https://github.com/hmbown/codewhale/commit/06607133c4c021ea810f9f20a2cdcf4bf587d774) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34772605)</sub>

<!-- /greptile_comment -->