### PR TITLE
test(tui): include Volcengine in provider picker expectation

### DIFF
--- a/crates/tui/src/tui/provider_picker.rs
+++ b/crates/tui/src/tui/provider_picker.rs
@@ -474,6 +474,7 @@ mod tests {
                 "OpenAI-compatible",
                 "AtlasCloud",
                 "Wanjie Ark",
+                "Volcengine Ark",
                 "OpenRouter",
                 "Xiaomi MiMo",
                 "Novita AI",


### PR DESCRIPTION
## Summary
- include Volcengine Ark in the provider picker regression test expectation after #1993 landed
- unblocks macOS CI on provider-unrelated PRs that already contain current main

## Verification
- cargo fmt --all -- --check
- git diff --check
- cargo test -p codewhale-tui picker_lists_all_providers -- --nocapture