### PR TITLE
fix(tui): remove message-count truncation from session persistence

### DIFF
--- a/crates/tui/src/session_manager.rs
+++ b/crates/tui/src/session_manager.rs
@@ -18,11 +18,6 @@ use uuid::Uuid;
 
 /// Maximum number of sessions to retain
 const MAX_SESSIONS: usize = 50;
-/// Maximum number of messages to persist per session (#402 P0).
-/// Beyond this limit, the oldest messages are dropped and a truncation
-/// note is prepended to the system prompt. Keeps session files bounded
-/// so save/load remains fast even for long-running conversations.
-const MAX_PERSISTED_MESSAGES: usize = 500;
 const CURRENT_SESSION_SCHEMA_VERSION: u32 = 1;
 const CURRENT_QUEUE_SCHEMA_VERSION: u32 = 1;
 
@@ -291,7 +286,7 @@ impl SessionManager {
             return Ok(None);
         }
         let content = fs::read_to_string(&path)?;
-        let session: SavedSession = serde_json::from_str(&content)
+        let mut session: SavedSession = serde_json::from_str(&content)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
         if session.schema_version > CURRENT_SESSION_SCHEMA_VERSION {
             return Err(std::io::Error::new(
@@ -302,6 +297,7 @@ impl SessionManager {
                 ),
             ));
         }
+        session.system_prompt = strip_legacy_truncation_note(session.system_prompt);
         Ok(Some(session))
     }
 
@@ -372,7 +368,7 @@ impl SessionManager {
         let path = self.validated_session_path(id)?;
 
         let content = fs::read_to_string(&path)?;
-        let session: SavedSession = serde_json::from_str(&content)
+        let mut session: SavedSession = serde_json::from_str(&content)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
         if session.schema_version > CURRENT_SESSION_SCHEMA_VERSION {
             return Err(std::io::Error::new(
@@ -383,6 +379,8 @@ impl SessionManager {
                 ),
             ));
         }
+
+        session.system_prompt = strip_legacy_truncation_note(session.system_prompt);
 
         Ok(session)
     }
@@ -711,8 +709,6 @@ pub fn create_saved_session_with_id_and_mode(
         })
         .unwrap_or_else(|| "New Session".to_string());
 
-    let (capped_messages, truncation_note) = cap_messages(messages);
-
     SavedSession {
         schema_version: CURRENT_SESSION_SCHEMA_VERSION,
         metadata: SessionMetadata {
@@ -730,11 +726,8 @@ pub fn create_saved_session_with_id_and_mode(
             forked_from_message_count: None,
             cumulative_turn_secs: 0,
         },
-        messages: capped_messages,
-        system_prompt: merge_truncation_note(
-            system_prompt_to_string(system_prompt),
-            truncation_note,
-        ),
+        messages: messages.to_vec(),
+        system_prompt: system_prompt_to_string(system_prompt),
         context_references: Vec::new(),
         artifacts: Vec::new(),
     }
@@ -748,45 +741,34 @@ pub fn update_session(
     system_prompt: Option<&SystemPrompt>,
 ) -> SavedSession {
     session.schema_version = CURRENT_SESSION_SCHEMA_VERSION;
-    let (capped_messages, truncation_note) = cap_messages(messages);
-    session.messages = capped_messages;
+    session.messages.clear();
+    session.messages.extend_from_slice(messages);
     session.metadata.updated_at = Utc::now();
     session.metadata.message_count = messages.len();
     session.metadata.total_tokens = total_tokens;
-    session.system_prompt = merge_truncation_note(
-        system_prompt_to_string(system_prompt).or(session.system_prompt),
-        truncation_note,
-    );
+    if system_prompt.is_some() {
+        session.system_prompt = system_prompt_to_string(system_prompt);
+    }
     session
 }
 
-/// Cap messages to [`MAX_PERSISTED_MESSAGES`], keeping the most recent.
-/// Returns the capped slice and an optional truncation note.
-fn cap_messages(messages: &[Message]) -> (Vec<Message>, Option<String>) {
-    let total = messages.len();
-    if total <= MAX_PERSISTED_MESSAGES {
-        return (messages.to_vec(), None);
+/// Strip a stale `[Session note]` block that was written by the old
+/// 500-message cap. Only removes notes that contain the specific
+/// "older messages were dropped" phrase — ordinary user-added
+/// `[Session note]` prompts are left untouched.
+fn strip_legacy_truncation_note(system_prompt: Option<String>) -> Option<String> {
+    let sp = system_prompt?;
+    let Some(trimmed) = sp.strip_prefix("[Session note]\n") else {
+        return Some(sp);
+    };
+    // Only strip if this is the known cap_messages note.
+    if !trimmed.contains("older messages were dropped") {
+        return Some(sp);
     }
-    let dropped = total - MAX_PERSISTED_MESSAGES;
-    let note = format!(
-        "Note: {dropped} older messages were dropped from the session file \
-         to keep persistence bounded. The full conversation history may \
-         still be recoverable from cycle archives."
-    );
-    (
-        messages[total - MAX_PERSISTED_MESSAGES..].to_vec(),
-        Some(note),
-    )
-}
-
-/// Merge an optional truncation note into the system prompt string.
-fn merge_truncation_note(system_prompt: Option<String>, note: Option<String>) -> Option<String> {
-    match (system_prompt, note) {
-        (None, None) => None,
-        (Some(sp), None) => Some(sp),
-        (None, Some(note)) => Some(format!("[Session note]\n{note}")),
-        (Some(sp), Some(note)) => Some(format!("[Session note]\n{note}\n\n---\n\n{sp}")),
-    }
+    // The note block ends with "\n\n---\n\n" (7 chars) followed by the real prompt.
+    trimmed
+        .find("\n\n---\n\n")
+        .map(|pos| trimmed[pos + 7..].to_string())
 }
 
 /// String-scan a JSON byte buffer for the top-level `"metadata":{...}`
@@ -1513,6 +1495,37 @@ mod tests {
         let updated = update_session(session, &new_messages, 100, None);
         assert_eq!(updated.messages.len(), 2);
         assert_eq!(updated.metadata.total_tokens, 100);
+    }
+
+    #[test]
+    fn save_load_round_trip_preserves_all_messages_for_cache_fidelity() {
+        let tmp = tempdir().expect("tempdir");
+        let manager = SessionManager::new(tmp.path().join("sessions")).expect("new");
+        // Covers the old 500-message cap boundary and well beyond.
+        for count in [0, 1, 500, 501, 600, 1000] {
+            let original: Vec<_> = (0..count)
+                .map(|i| {
+                    make_test_message(
+                        if i % 2 == 0 { "user" } else { "assistant" },
+                        &format!("round-trip message {i}"),
+                    )
+                })
+                .collect();
+
+            let session = create_saved_session(&original, "test-model", tmp.path(), 0, None);
+            manager.save_session(&session).expect("save");
+            let loaded = manager.load_session(&session.metadata.id).expect("load");
+
+            assert_eq!(
+                loaded.messages.len(),
+                count,
+                "count preserved for count={count}"
+            );
+            assert_eq!(
+                loaded.messages, original,
+                "every message byte-identical after round-trip for count={count}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary / 概述
Remove `MAX_PERSISTED_MESSAGES` (500) hard limit and the `cap_messages` tail-truncation from session save paths. The persistence layer no longer silently drops messages.

从 session 保存路径中移除 `MAX_PERSISTED_MESSAGES`(500) 硬限制和 `cap_messages` 尾部截断。持久化层不再静默丢弃消息。

## Problem / 问题

### How tail-truncation kills the cache / 尾部截断如何杀死缓存

```mermaid
flowchart LR
    subgraph Original["原始会话 (600 msgs)"]
        direction LR
        M1["msg1"] --> M2["msg2"] --> M3["..."] --> M100["msg100"] --> M101["msg101"] --> M600["msg600"]
    end

    subgraph Cache["LLM KV-Cache"]
        C["cache_key = hash(msg1 + msg2 + ... + msg600) ← 前缀完整"]
    end

    Original -->|"cap_messages(500)"| Truncated

    subgraph Truncated["截断后 (500 msgs)"]
        direction LR
        T101["msg101"] --> T102["msg102"] --> T600["msg600"]
    end

    subgraph CacheNew["LLM KV-Cache"]
        CN["cache_key = hash(msg101 + msg102 + ... + msg600) ← 前缀变了!"]
    end

    Truncated --> CacheNew

    Cache -.-x|"❌ mismatch"| CacheNew
```

`cap_messages` keeps only the **tail (most recent 500)** and drops the **head (oldest)**. Since LLM KV-cache is **prefix-based**, dropping the head changes the hash of the entire sequence. Result: **100% cache miss on EVERY resume** for any session with >500 messages.

`cap_messages` 保留**尾部**（最新 500 条），丢弃**头部**（最旧消息）。LLM KV-cache 按**前缀**构建哈希键，头部被截断后整个序列的哈希完全改变。结果：>500 条的会话 **每次 resume 都 100% 缓存失效**。

### Why this is worse than the compaction issue / 为什么比 compaction 更严重

| | #2388 (compaction) | This PR (truncation) / 本 PR (截断) |
|---|---|---|
| Trigger / 触发条件 | Single tool output > 12K chars / 单条 tool output > 12K 字符 | Session > 500 messages / 会话消息数 > 500 |
| Cache damage / 缓存失效范围 | Partial (one message changed) / 部分（单条消息变了） | **Entire prefix / 整个前缀** |
| Resume cache hit / resume 缓存命中率 | ~0% after that message / 该消息之后 ~0% | **0% (prefix entirely different) / 0%（前缀完全不同）** |

## Fix / 修复
- Remove `MAX_PERSISTED_MESSAGES` constant
- Remove `cap_messages()` and its two call sites
- Remove `merge_truncation_note()` (now dead code)
- Messages stored verbatim; engine's `should_compact` / `compact_messages_safe` / `recover_context_overflow` handle context budgets at send time

- 移除 `MAX_PERSISTED_MESSAGES` 常量
- 移除 `cap_messages()` 函数及两处调用
- 移除 `merge_truncation_note()`（死代码）
- 消息原样存储；上下文预算由 engine 在发送时处理

## Design rationale / 设计理由
If a context is too large for the model to accept, it is the engine's job to compact it — not the persistence layer's. The file system has orders of magnitude more space than a model's context window. **Save faithfully, compact on send.**

如果一个上下文大到模型都无法接受，应该由 engine 来压缩——文件系统的空间远大于模型上下文窗口。**存储时忠实保存，发送时按需压缩。**

## Builds on / 基于
Follow-up to #2388 (removing `compact_session_tool_outputs`). Together these two PRs ensure the persistence round-trip is a no-op for message content.

#2388（移除 `compact_session_tool_outputs`）的后续。两个 PR 一起确保 persist → load 对消息内容零修改。

## Future directions / 后续建议

### Lazy session loading / 会话延迟加载
With truncation removed, large session files may impact load speed. A better approach:

- **Load metadata + recent messages eagerly** — show the session picker and last few turns instantly
- **Load full history in the background** — stream the rest of messages before the user sends their first message
- This keeps startup fast while preserving cache fidelity for the full conversation

随着截断移除，大型会话文件可能影响加载速度。更好的方案：**元数据 + 最近消息立即加载**（会话列表秒开），**完整历史后台流式加载**（在用户发送第一条消息前就绪），启动快且缓存完整。

### The right place for truncation / 裁剪的正确时机

Truncation should happen **only at send time**, never at save or load:

- **Save**: store everything — the disk has room
- **Load**: restore everything — the user might switch to a larger model before sending, and truncating at load would waste messages unnecessarily
- **Send**: engine checks `context_input_budget(model)` and compacts if needed, with full knowledge of the current model

**Save/load 都不应该裁剪，只在 send 时按需裁剪：**

- **Save**：全部存储——磁盘有空间
- **Load**：全部还原——用户可能在发送前切到更大上下文的模型，load 时裁剪就白丢了消息
- **Send**：engine 根据当前模型的 `context_input_budget` 判断是否需要压缩——此时模型已确定，不会误判

## Tests / 测试
- `cargo test -p codewhale-tui -- session_manager`: 39 passed, 0 failed

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes the 500-message hard cap (`MAX_PERSISTED_MESSAGES`) from the session persistence layer, eliminating silent message loss on long sessions and the resulting LLM KV-cache invalidation on every resume. A `strip_legacy_truncation_note` helper is added to clean up stale `[Session note]` truncation prefixes that were injected into system prompts by the old `merge_truncation_note` path.

- Removes `cap_messages`, `merge_truncation_note`, and `MAX_PERSISTED_MESSAGES`; messages are now stored verbatim and context-budget management is left entirely to the engine's existing `compact_messages_safe` / `recover_context_overflow` paths at send time.
- Adds `strip_legacy_truncation_note` called at both `load_checkpoint` and `load_session` to recover the original system prompt from any session file created under the old cap; the extraction handles all four cases from the old `merge_truncation_note` correctly.
- Includes a parametrised round-trip test covering 0, 1, 500, 501, 600, and 1 000 messages to lock in the no-truncation invariant.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — removes a silent data-loss path and replaces it with a correct legacy-cleanup function; all load paths call the new helper, and the update_session system-prompt preservation is semantically identical to the old code.

The deletion of cap_messages and merge_truncation_note is straightforward. strip_legacy_truncation_note correctly handles all four output shapes produced by the old merge_truncation_note. The update_session change to guard on is_some() is equivalent to the old .or(session.system_prompt). The new round-trip test closes the regression path for the removed cap.

No files require special attention.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/tui/src/session_manager.rs | Removes truncation cap and its system-prompt mutation; adds strip_legacy_truncation_note that correctly handles all four legacy note formats; update_session system-prompt preservation is semantically equivalent to the old path. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/tui/src/session_manager.rs`, line 973-975 ([link](https://github.com/hmbown/codewhale/blob/419a7caa9eae54dfdafa2d8130a1ccbf8fe67489/crates/tui/src/session_manager.rs#L973-L975)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **No regression test for the removed truncation limit**

   The PR removes a hard cap that silently dropped messages — a correctness-sensitive change — but does not add a test asserting that `create_saved_session` or `update_session` now preserves more than 500 messages. A test with 501+ messages verifying `saved.messages.len() == input.len()` would lock in this invariant and prevent accidental re-introduction of any similar cap in the future.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22main%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22main%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fsession_manager.rs%0ALine%3A%20973-975%0A%0AComment%3A%0A**No%20regression%20test%20for%20the%20removed%20truncation%20limit**%0A%0AThe%20PR%20removes%20a%20hard%20cap%20that%20silently%20dropped%20messages%20%E2%80%94%20a%20correctness-sensitive%20change%20%E2%80%94%20but%20does%20not%20add%20a%20test%20asserting%20that%20%60create_saved_session%60%20or%20%60update_session%60%20now%20preserves%20more%20than%20500%20messages.%20A%20test%20with%20501%2B%20messages%20verifying%20%60saved.messages.len%28%29%20%3D%3D%20input.len%28%29%60%20would%20lock%20in%20this%20invariant%20and%20prevent%20accidental%20re-introduction%20of%20any%20similar%20cap%20in%20the%20future.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fsession_manager.rs%0ALine%3A%20973-975%0A%0AComment%3A%0A**No%20regression%20test%20for%20the%20removed%20truncation%20limit**%0A%0AThe%20PR%20removes%20a%20hard%20cap%20that%20silently%20dropped%20messages%20%E2%80%94%20a%20correctness-sensitive%20change%20%E2%80%94%20but%20does%20not%20add%20a%20test%20asserting%20that%20%60create_saved_session%60%20or%20%60update_session%60%20now%20preserves%20more%20than%20500%20messages.%20A%20test%20with%20501%2B%20messages%20verifying%20%60saved.messages.len%28%29%20%3D%3D%20input.len%28%29%60%20would%20lock%20in%20this%20invariant%20and%20prevent%20accidental%20re-introduction%20of%20any%20similar%20cap%20in%20the%20future.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2395&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fsession_manager.rs%0ALine%3A%20973-975%0A%0AComment%3A%0A**No%20regression%20test%20for%20the%20removed%20truncation%20limit**%0A%0AThe%20PR%20removes%20a%20hard%20cap%20that%20silently%20dropped%20messages%20%E2%80%94%20a%20correctness-sensitive%20change%20%E2%80%94%20but%20does%20not%20add%20a%20test%20asserting%20that%20%60create_saved_session%60%20or%20%60update_session%60%20now%20preserves%20more%20than%20500%20messages.%20A%20test%20with%20501%2B%20messages%20verifying%20%60saved.messages.len%28%29%20%3D%3D%20input.len%28%29%60%20would%20lock%20in%20this%20invariant%20and%20prevent%20accidental%20re-introduction%20of%20any%20similar%20cap%20in%20the%20future.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2395&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (6): Last reviewed commit: ["fix(tui): remove message-count truncatio..."](https://github.com/hmbown/codewhale/commit/9b350e8cebdf6fc922f48557303d891a792961e3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34773426)</sub>

<!-- /greptile_comment -->