### PR TITLE
test(runtime): add mobile control smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,9 @@ jobs:
       - name: Run Offline Eval Harness
         if: runner.os != 'Linux'
         run: cargo run -p codewhale-tui --all-features -- eval
+      - name: Smoke mobile runtime API
+        if: runner.os != 'Linux'
+        run: python scripts/runtime-mobile-smoke.py
       - name: Linux test location
         if: runner.os == 'Linux'
         run: echo "Linux workspace tests run on CNB for mirrored first-party branches."

--- a/scripts/runtime-mobile-smoke.py
+++ b/scripts/runtime-mobile-smoke.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Smoke-test the mobile runtime server with real HTTP requests."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+TOKEN = "mobile smoke token + /?=&%"
+
+
+def free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def request(
+    url: str,
+    *,
+    method: str = "GET",
+    token: str | None = None,
+    body: bytes | None = None,
+) -> tuple[int, str]:
+    headers = {}
+    if token is not None:
+        headers["Authorization"] = f"Bearer {token}"
+    if body is not None:
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=body, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=5) as response:
+            return response.status, response.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read().decode("utf-8", errors="replace")
+
+
+def wait_for_server(url: str, proc: subprocess.Popen[str]) -> None:
+    deadline = time.monotonic() + 30
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            raise RuntimeError(f"server exited early with code {proc.returncode}")
+        try:
+            request(url)
+            return
+        except Exception as exc:  # noqa: BLE001 - surface the last startup failure.
+            last_error = exc
+            time.sleep(0.25)
+    raise RuntimeError(f"server did not become reachable: {last_error}")
+
+
+def start_server(binary: Path, *args: str) -> subprocess.Popen[str]:
+    env = os.environ.copy()
+    env.setdefault("NO_COLOR", "1")
+    return subprocess.Popen(
+        [str(binary), "serve", *args],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=env,
+    )
+
+
+def stop_server(proc: subprocess.Popen[str]) -> tuple[str, str]:
+    if proc.poll() is None:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+    stdout, stderr = proc.communicate(timeout=5)
+    return stdout, stderr
+
+
+def assert_status(name: str, actual: int, expected: int) -> None:
+    if actual != expected:
+        raise AssertionError(f"{name}: expected HTTP {expected}, got {actual}")
+
+
+def auth_smoke(binary: Path) -> dict[str, object]:
+    port = free_port()
+    proc = start_server(
+        binary,
+        "--mobile",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        str(port),
+        "--auth-token",
+        TOKEN,
+    )
+    try:
+        base = f"http://127.0.0.1:{port}"
+        wait_for_server(f"{base}/mobile", proc)
+        mobile_no_token, _ = request(f"{base}/mobile")
+        mobile_with_token, html = request(f"{base}/mobile", token=TOKEN)
+        v1_no_token, _ = request(f"{base}/v1/threads/summary?limit=1")
+        v1_with_token, threads = request(f"{base}/v1/threads/summary?limit=1", token=TOKEN)
+        approval_status, approval_body = request(
+            f"{base}/v1/approvals/no_such_id",
+            method="POST",
+            token=TOKEN,
+            body=b'{"decision":"allow","remember":false}',
+        )
+
+        assert_status("mobile without token", mobile_no_token, 401)
+        assert_status("mobile with bearer token", mobile_with_token, 200)
+        assert_status("v1 without token", v1_no_token, 401)
+        assert_status("v1 with bearer token", v1_with_token, 200)
+        assert_status("approval retry missing id", approval_status, 404)
+        if "<title>CodeWhale Mobile</title>" not in html:
+            raise AssertionError("mobile page did not include expected title")
+        if json.loads(threads) != []:
+            raise AssertionError("expected empty thread summary in smoke workspace")
+        if "no pending approval" not in approval_body:
+            raise AssertionError("approval 404 did not include useful error body")
+        return {
+            "mobile_no_token": mobile_no_token,
+            "mobile_with_token": mobile_with_token,
+            "v1_no_token": v1_no_token,
+            "v1_with_token": v1_with_token,
+            "approval_retry_missing_id": approval_status,
+        }
+    finally:
+        stop_server(proc)
+
+
+def insecure_smoke(binary: Path) -> dict[str, object]:
+    port = free_port()
+    proc = start_server(
+        binary,
+        "--mobile",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        str(port),
+        "--insecure",
+    )
+    try:
+        base = f"http://127.0.0.1:{port}"
+        wait_for_server(f"{base}/mobile", proc)
+        mobile_status, html = request(f"{base}/mobile")
+        threads_status, threads = request(f"{base}/v1/threads/summary?limit=1")
+        assert_status("insecure mobile page", mobile_status, 200)
+        assert_status("insecure v1 route", threads_status, 200)
+        if "<title>CodeWhale Mobile</title>" not in html:
+            raise AssertionError("insecure mobile page did not include expected title")
+        if json.loads(threads) != []:
+            raise AssertionError("expected empty thread summary in insecure smoke workspace")
+        return {"mobile": mobile_status, "v1_threads": threads_status}
+    finally:
+        stop_server(proc)
+
+
+def lan_warning_smoke(binary: Path) -> dict[str, object]:
+    port = free_port()
+    proc = start_server(binary, "--mobile", "--port", str(port), "--insecure")
+    try:
+        wait_for_server(f"http://127.0.0.1:{port}/mobile", proc)
+    finally:
+        stdout, stderr = stop_server(proc)
+    output = f"{stdout}\n{stderr}"
+    if f"http://0.0.0.0:{port}" not in output:
+        raise AssertionError("mobile default did not bind to 0.0.0.0")
+    if "WARNING: --mobile is binding to 0.0.0.0" not in output:
+        raise AssertionError("missing LAN binding warning")
+    if "LAN:" not in output:
+        raise AssertionError("missing LAN URL hint")
+    return {"binds_0_0_0_0": True, "warning": True, "lan_hint": True}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "binary",
+        nargs="?",
+        default=str(Path("target") / "debug" / ("codewhale-tui.exe" if os.name == "nt" else "codewhale-tui")),
+        help="Path to the built codewhale-tui binary",
+    )
+    args = parser.parse_args()
+    binary = Path(args.binary)
+    if not binary.exists():
+        raise SystemExit(f"binary not found: {binary}")
+
+    result = {
+        "auth": auth_smoke(binary),
+        "insecure": insecure_smoke(binary),
+        "lan_warning": lan_warning_smoke(binary),
+    }
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add `scripts/runtime-mobile-smoke.py` to launch `codewhale-tui serve --mobile` and verify auth-gated `/mobile`, `/v1`, approval retry 404, `--mobile --insecure`, and the default LAN bind warning
- run the smoke after the existing non-Linux CI test job once the debug `codewhale-tui` binary has been built

Closes #2396

## Validation
- `cargo build -p codewhale-tui --bin codewhale-tui --locked`
- `python scripts/runtime-mobile-smoke.py`
- `python -m py_compile scripts/runtime-mobile-smoke.py`
- `git diff --check`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a Python smoke-test script (`scripts/runtime-mobile-smoke.py`) that launches the `codewhale-tui serve --mobile` binary and exercises auth-gated routes, insecure mode, and the LAN-binding warning, then wires the script into CI after the existing offline eval step on non-Linux runners.

- **`auth_smoke`** starts a token-protected server and verifies `/mobile` and `/v1` return 401 without a bearer token and 200 with one, plus a 404 on an unknown approval ID.
- **`insecure_smoke`** confirms the same routes are openly accessible under `--insecure`, and **`lan_warning_smoke`** checks that the server logs the `0.0.0.0` bind warning and LAN URL hint when no explicit `--host` is provided.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the smoke script adds real coverage and the CI wiring is correct, but the script has a few patterns that could make it brittle on busy runners.

The stop_server function calls proc.wait() before proc.communicate() — a documented Python antipattern that can deadlock when pipe buffers fill, recoverable only by the 5-second timeout. free_port() releases the socket before the server binds, leaving a race window on shared CI machines. Neither issue causes silent wrong results, but both can produce spurious failures that are hard to distinguish from real regressions.

scripts/runtime-mobile-smoke.py — the stop_server shutdown sequence and free_port allocation logic are worth a second look before this runs on shared CI runners.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/runtime-mobile-smoke.py | New smoke-test script; has a proc.wait() + proc.communicate() antipattern that can deadlock on full pipe buffers, a port TOCTOU race in free_port(), and silently discards server output on assertion failure in auth_smoke/insecure_smoke. |
| .github/workflows/ci.yml | Adds the smoke step after cargo run (which builds the debug binary), using the same runner.os != Linux guard as the surrounding steps. Binary path assumption is correct. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant CI as CI Runner
    participant Script as runtime-mobile-smoke.py
    participant Server as codewhale-tui serve

    CI->>Script: python scripts/runtime-mobile-smoke.py

    Note over Script,Server: auth_smoke
    Script->>Server: start (--mobile --host 127.0.0.1 --port N --auth-token TOKEN)
    Script->>Server: GET /mobile (wait loop)
    Script->>Server: GET /mobile (no token) assert 401
    Script->>Server: GET /mobile (Bearer TOKEN) assert 200
    Script->>Server: GET /v1/threads/summary (no token) assert 401
    Script->>Server: GET /v1/threads/summary (Bearer TOKEN) assert 200
    Script->>Server: POST /v1/approvals/no_such_id (Bearer TOKEN) assert 404
    Script->>Server: terminate + communicate

    Note over Script,Server: insecure_smoke
    Script->>Server: start (--mobile --host 127.0.0.1 --port N --insecure)
    Script->>Server: GET /mobile assert 200
    Script->>Server: GET /v1/threads/summary assert 200
    Script->>Server: terminate + communicate

    Note over Script,Server: lan_warning_smoke
    Script->>Server: start (--mobile --port N --insecure binds 0.0.0.0)
    Script->>Server: GET /mobile (wait loop)
    Script->>Server: terminate + communicate
    Script->>Script: assert stdout/stderr has 0.0.0.0 URL + WARNING + LAN hint

    Script->>CI: print JSON result / exit 0
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22codex%2Fmobile-control-smoke%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fmobile-control-smoke%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Ascripts%2Fruntime-mobile-smoke.py%3A76-84%0AThe%20current%20%60stop_server%60%20implementation%20calls%20%60proc.wait%28%29%60%20**before**%20%60proc.communicate%28%29%60%2C%20which%20is%20the%20exact%20pattern%20Python's%20subprocess%20docs%20warn%20against%3A%20if%20the%20server%20writes%20enough%20output%20to%20fill%20the%20OS%20pipe%20buffer%20before%20exiting%2C%20the%20server%20will%20block%20on%20the%20write%2C%20%60proc.wait%28%29%60%20will%20block%20waiting%20for%20the%20server%20to%20exit%2C%20and%20neither%20side%20can%20proceed%20until%20the%205-second%20timeout%20fires.%20The%20correct%20approach%20is%20to%20call%20%60communicate%28%29%60%20directly%20after%20%60terminate%28%29%60%2C%20since%20%60communicate%28%29%60%20drains%20the%20pipes%20while%20waiting%20%E2%80%94%20eliminating%20the%20deadlock%20window%20entirely.%0A%0A%60%60%60suggestion%0Adef%20stop_server%28proc%3A%20subprocess.Popen%5Bstr%5D%29%20-%3E%20tuple%5Bstr%2C%20str%5D%3A%0A%20%20%20%20if%20proc.poll%28%29%20is%20None%3A%0A%20%20%20%20%20%20%20%20proc.terminate%28%29%0A%20%20%20%20try%3A%0A%20%20%20%20%20%20%20%20stdout%2C%20stderr%20%3D%20proc.communicate%28timeout%3D10%29%0A%20%20%20%20except%20subprocess.TimeoutExpired%3A%0A%20%20%20%20%20%20%20%20proc.kill%28%29%0A%20%20%20%20%20%20%20%20stdout%2C%20stderr%20%3D%20proc.communicate%28%29%0A%20%20%20%20return%20stdout%2C%20stderr%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Ascripts%2Fruntime-mobile-smoke.py%3A21-24%0A%60free_port%60%20releases%20the%20socket%20immediately%20before%20returning%2C%20creating%20a%20TOCTOU%20window%20between%20the%20port%20being%20freed%20and%20the%20server%20binding%20to%20it.%20On%20a%20busy%20CI%20runner%20%28or%20with%20parallel%20test%20jobs%29%2C%20another%20process%20can%20grab%20the%20exact%20same%20port%20in%20that%20window%2C%20resulting%20in%20an%20%22address%20already%20in%20use%22%20error%20and%20a%20flaky%20failure.%20A%20common%20mitigation%20is%20to%20bind%20with%20%60SO_REUSEPORT%60%20and%20pass%20the%20already-listening%20FD%20to%20the%20child%2C%20or%20to%20wrap%20%60start_server%60%20in%20a%20retry%20loop%20with%20a%20fresh%20%60free_port%28%29%60%20call%20on%20bind%20failure.%0A%0A%23%23%23%20Issue%203%20of%203%0Ascripts%2Fruntime-mobile-smoke.py%3A129-137%0AIn%20%60auth_smoke%60%20and%20%60insecure_smoke%60%2C%20%60stop_server%60's%20return%20value%20%E2%80%94%20the%20server's%20stdout%2Fstderr%20%E2%80%94%20is%20silently%20discarded%20in%20the%20%60finally%60%20blocks.%20If%20any%20assertion%20above%20fails%2C%20there%20is%20no%20way%20to%20see%20what%20the%20server%20printed%2C%20making%20the%20failure%20very%20hard%20to%20debug%20in%20CI.%20The%20%60lan_warning_smoke%60%20function%20handles%20this%20correctly%3B%20the%20same%20pattern%20should%20apply%20here.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20return%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22mobile_no_token%22%3A%20mobile_no_token%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22mobile_with_token%22%3A%20mobile_with_token%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22v1_no_token%22%3A%20v1_no_token%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22v1_with_token%22%3A%20v1_with_token%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22approval_retry_missing_id%22%3A%20approval_status%2C%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20finally%3A%0A%20%20%20%20%20%20%20%20_out%2C%20_err%20%3D%20stop_server%28proc%29%0A%20%20%20%20%20%20%20%20if%20_out.strip%28%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20print%28%22%5Bauth_smoke%20stdout%5D%22%2C%20_out%2C%20file%3Dsys.stderr%29%0A%20%20%20%20%20%20%20%20if%20_err.strip%28%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20print%28%22%5Bauth_smoke%20stderr%5D%22%2C%20_err%2C%20file%3Dsys.stderr%29%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Ascripts%2Fruntime-mobile-smoke.py%3A76-84%0AThe%20current%20%60stop_server%60%20implementation%20calls%20%60proc.wait%28%29%60%20**before**%20%60proc.communicate%28%29%60%2C%20which%20is%20the%20exact%20pattern%20Python's%20subprocess%20docs%20warn%20against%3A%20if%20the%20server%20writes%20enough%20output%20to%20fill%20the%20OS%20pipe%20buffer%20before%20exiting%2C%20the%20server%20will%20block%20on%20the%20write%2C%20%60proc.wait%28%29%60%20will%20block%20waiting%20for%20the%20server%20to%20exit%2C%20and%20neither%20side%20can%20proceed%20until%20the%205-second%20timeout%20fires.%20The%20correct%20approach%20is%20to%20call%20%60communicate%28%29%60%20directly%20after%20%60terminate%28%29%60%2C%20since%20%60communicate%28%29%60%20drains%20the%20pipes%20while%20waiting%20%E2%80%94%20eliminating%20the%20deadlock%20window%20entirely.%0A%0A%60%60%60suggestion%0Adef%20stop_server%28proc%3A%20subprocess.Popen%5Bstr%5D%29%20-%3E%20tuple%5Bstr%2C%20str%5D%3A%0A%20%20%20%20if%20proc.poll%28%29%20is%20None%3A%0A%20%20%20%20%20%20%20%20proc.terminate%28%29%0A%20%20%20%20try%3A%0A%20%20%20%20%20%20%20%20stdout%2C%20stderr%20%3D%20proc.communicate%28timeout%3D10%29%0A%20%20%20%20except%20subprocess.TimeoutExpired%3A%0A%20%20%20%20%20%20%20%20proc.kill%28%29%0A%20%20%20%20%20%20%20%20stdout%2C%20stderr%20%3D%20proc.communicate%28%29%0A%20%20%20%20return%20stdout%2C%20stderr%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Ascripts%2Fruntime-mobile-smoke.py%3A21-24%0A%60free_port%60%20releases%20the%20socket%20immediately%20before%20returning%2C%20creating%20a%20TOCTOU%20window%20between%20the%20port%20being%20freed%20and%20the%20server%20binding%20to%20it.%20On%20a%20busy%20CI%20runner%20%28or%20with%20parallel%20test%20jobs%29%2C%20another%20process%20can%20grab%20the%20exact%20same%20port%20in%20that%20window%2C%20resulting%20in%20an%20%22address%20already%20in%20use%22%20error%20and%20a%20flaky%20failure.%20A%20common%20mitigation%20is%20to%20bind%20with%20%60SO_REUSEPORT%60%20and%20pass%20the%20already-listening%20FD%20to%20the%20child%2C%20or%20to%20wrap%20%60start_server%60%20in%20a%20retry%20loop%20with%20a%20fresh%20%60free_port%28%29%60%20call%20on%20bind%20failure.%0A%0A%23%23%23%20Issue%203%20of%203%0Ascripts%2Fruntime-mobile-smoke.py%3A129-137%0AIn%20%60auth_smoke%60%20and%20%60insecure_smoke%60%2C%20%60stop_server%60's%20return%20value%20%E2%80%94%20the%20server's%20stdout%2Fstderr%20%E2%80%94%20is%20silently%20discarded%20in%20the%20%60finally%60%20blocks.%20If%20any%20assertion%20above%20fails%2C%20there%20is%20no%20way%20to%20see%20what%20the%20server%20printed%2C%20making%20the%20failure%20very%20hard%20to%20debug%20in%20CI.%20The%20%60lan_warning_smoke%60%20function%20handles%20this%20correctly%3B%20the%20same%20pattern%20should%20apply%20here.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20return%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22mobile_no_token%22%3A%20mobile_no_token%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22mobile_with_token%22%3A%20mobile_with_token%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22v1_no_token%22%3A%20v1_no_token%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22v1_with_token%22%3A%20v1_with_token%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22approval_retry_missing_id%22%3A%20approval_status%2C%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20finally%3A%0A%20%20%20%20%20%20%20%20_out%2C%20_err%20%3D%20stop_server%28proc%29%0A%20%20%20%20%20%20%20%20if%20_out.strip%28%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20print%28%22%5Bauth_smoke%20stdout%5D%22%2C%20_out%2C%20file%3Dsys.stderr%29%0A%20%20%20%20%20%20%20%20if%20_err.strip%28%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20print%28%22%5Bauth_smoke%20stderr%5D%22%2C%20_err%2C%20file%3Dsys.stderr%29%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2398&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Ascripts%2Fruntime-mobile-smoke.py%3A76-84%0AThe%20current%20%60stop_server%60%20implementation%20calls%20%60proc.wait%28%29%60%20**before**%20%60proc.communicate%28%29%60%2C%20which%20is%20the%20exact%20pattern%20Python's%20subprocess%20docs%20warn%20against%3A%20if%20the%20server%20writes%20enough%20output%20to%20fill%20the%20OS%20pipe%20buffer%20before%20exiting%2C%20the%20server%20will%20block%20on%20the%20write%2C%20%60proc.wait%28%29%60%20will%20block%20waiting%20for%20the%20server%20to%20exit%2C%20and%20neither%20side%20can%20proceed%20until%20the%205-second%20timeout%20fires.%20The%20correct%20approach%20is%20to%20call%20%60communicate%28%29%60%20directly%20after%20%60terminate%28%29%60%2C%20since%20%60communicate%28%29%60%20drains%20the%20pipes%20while%20waiting%20%E2%80%94%20eliminating%20the%20deadlock%20window%20entirely.%0A%0A%60%60%60suggestion%0Adef%20stop_server%28proc%3A%20subprocess.Popen%5Bstr%5D%29%20-%3E%20tuple%5Bstr%2C%20str%5D%3A%0A%20%20%20%20if%20proc.poll%28%29%20is%20None%3A%0A%20%20%20%20%20%20%20%20proc.terminate%28%29%0A%20%20%20%20try%3A%0A%20%20%20%20%20%20%20%20stdout%2C%20stderr%20%3D%20proc.communicate%28timeout%3D10%29%0A%20%20%20%20except%20subprocess.TimeoutExpired%3A%0A%20%20%20%20%20%20%20%20proc.kill%28%29%0A%20%20%20%20%20%20%20%20stdout%2C%20stderr%20%3D%20proc.communicate%28%29%0A%20%20%20%20return%20stdout%2C%20stderr%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Ascripts%2Fruntime-mobile-smoke.py%3A21-24%0A%60free_port%60%20releases%20the%20socket%20immediately%20before%20returning%2C%20creating%20a%20TOCTOU%20window%20between%20the%20port%20being%20freed%20and%20the%20server%20binding%20to%20it.%20On%20a%20busy%20CI%20runner%20%28or%20with%20parallel%20test%20jobs%29%2C%20another%20process%20can%20grab%20the%20exact%20same%20port%20in%20that%20window%2C%20resulting%20in%20an%20%22address%20already%20in%20use%22%20error%20and%20a%20flaky%20failure.%20A%20common%20mitigation%20is%20to%20bind%20with%20%60SO_REUSEPORT%60%20and%20pass%20the%20already-listening%20FD%20to%20the%20child%2C%20or%20to%20wrap%20%60start_server%60%20in%20a%20retry%20loop%20with%20a%20fresh%20%60free_port%28%29%60%20call%20on%20bind%20failure.%0A%0A%23%23%23%20Issue%203%20of%203%0Ascripts%2Fruntime-mobile-smoke.py%3A129-137%0AIn%20%60auth_smoke%60%20and%20%60insecure_smoke%60%2C%20%60stop_server%60's%20return%20value%20%E2%80%94%20the%20server's%20stdout%2Fstderr%20%E2%80%94%20is%20silently%20discarded%20in%20the%20%60finally%60%20blocks.%20If%20any%20assertion%20above%20fails%2C%20there%20is%20no%20way%20to%20see%20what%20the%20server%20printed%2C%20making%20the%20failure%20very%20hard%20to%20debug%20in%20CI.%20The%20%60lan_warning_smoke%60%20function%20handles%20this%20correctly%3B%20the%20same%20pattern%20should%20apply%20here.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20return%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22mobile_no_token%22%3A%20mobile_no_token%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22mobile_with_token%22%3A%20mobile_with_token%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22v1_no_token%22%3A%20v1_no_token%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22v1_with_token%22%3A%20v1_with_token%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22approval_retry_missing_id%22%3A%20approval_status%2C%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20finally%3A%0A%20%20%20%20%20%20%20%20_out%2C%20_err%20%3D%20stop_server%28proc%29%0A%20%20%20%20%20%20%20%20if%20_out.strip%28%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20print%28%22%5Bauth_smoke%20stdout%5D%22%2C%20_out%2C%20file%3Dsys.stderr%29%0A%20%20%20%20%20%20%20%20if%20_err.strip%28%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20print%28%22%5Bauth_smoke%20stderr%5D%22%2C%20_err%2C%20file%3Dsys.stderr%29%0A%60%60%60%0A%0A&pr=2398&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["test(runtime): add mobile control smoke"](https://github.com/hmbown/codewhale/commit/d32e618ef7885461dd5fa10869ab74f079ccedb9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34775246)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->