### PR TITLE
feat(runtime): add mobile QR bootstrap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1015,6 +1015,7 @@ dependencies = [
  "pdf-extract",
  "portable-pty",
  "pretty_assertions",
+ "qrcode",
  "ratatui",
  "regex",
  "reqwest",
@@ -3707,6 +3708,12 @@ checksum = "7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "qrcode"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
 
 [[package]]
 name = "quick-error"

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -73,6 +73,7 @@ shlex = "1.3.0"
 starlark = "0.13.0"
 tiny_http = "0.12"
 portable-pty = "0.9"
+qrcode = { version = "0.14.1", default-features = false }
 zeroize = "1.8.2"
 ignore = "0.4"
 image = { version = "0.25", default-features = false, features = ["png"] }

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -583,6 +583,9 @@ struct ServeArgs {
     /// Start runtime HTTP/SSE API server with the built-in mobile control page
     #[arg(long)]
     mobile: bool,
+    /// Print a terminal QR code for the mobile control URL
+    #[arg(long = "mobile-qr")]
+    mobile_qr: bool,
     /// Start ACP server over stdio for editor clients such as Zed
     #[arg(long)]
     acp: bool,
@@ -646,6 +649,13 @@ fn validate_serve_mode_selection(mcp: bool, http: bool, mobile: bool, acp: bool)
         bail!("Choose exactly one server mode: --mcp, --http/--mobile, or --acp");
     }
     Ok(http_selected)
+}
+
+fn validate_mobile_qr_selection(mobile: bool, mobile_qr: bool) -> Result<()> {
+    if mobile_qr && !mobile {
+        bail!("--mobile-qr requires --mobile");
+    }
+    Ok(())
 }
 
 #[derive(Subcommand, Debug, Clone)]
@@ -980,6 +990,7 @@ async fn main() -> Result<()> {
                 });
                 let http_selected =
                     validate_serve_mode_selection(args.mcp, args.http, args.mobile, args.acp)?;
+                validate_mobile_qr_selection(args.mobile, args.mobile_qr)?;
                 if args.mcp {
                     tokio::task::block_in_place(|| mcp_server::run_mcp_server(workspace))
                 } else if http_selected {
@@ -1002,6 +1013,7 @@ async fn main() -> Result<()> {
                             auth_token: args.auth_token,
                             insecure_no_auth: args.insecure_no_auth,
                             mobile: args.mobile,
+                            mobile_qr: args.mobile_qr,
                         },
                     )
                     .await
@@ -5760,6 +5772,14 @@ mod serve_bind_host_tests {
             err.to_string()
                 .contains("--http and --mobile are mutually exclusive")
         );
+    }
+
+    #[test]
+    fn mobile_qr_requires_mobile_mode() {
+        let err = validate_mobile_qr_selection(false, true).unwrap_err();
+        assert!(err.to_string().contains("--mobile-qr requires --mobile"));
+
+        validate_mobile_qr_selection(true, true).unwrap();
     }
 }
 

--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -21,6 +21,8 @@ use axum::routing::{get, post};
 use axum::{Json, Router};
 use chrono::Utc;
 use codewhale_protocol::runtime::{RUNTIME_EVENT_ENVELOPE_SCHEMA_VERSION, RuntimeEventEnvelope};
+use qrcode::QrCode;
+use qrcode::render::unicode::Dense1x2;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use tokio::net::TcpListener;
@@ -82,6 +84,8 @@ pub struct RuntimeApiOptions {
     pub insecure_no_auth: bool,
     /// Enables the built-in mobile control page at `/mobile`.
     pub mobile: bool,
+    /// Print a terminal QR code for the mobile control URL when `/mobile` is enabled.
+    pub mobile_qr: bool,
 }
 
 impl Default for RuntimeApiOptions {
@@ -94,6 +98,7 @@ impl Default for RuntimeApiOptions {
             auth_token: None,
             insecure_no_auth: false,
             mobile: false,
+            mobile_qr: false,
         }
     }
 }
@@ -473,7 +478,12 @@ pub async fn run_http_server(
         println!("Runtime API auth: disabled by explicit insecure mode.");
     }
     if options.mobile {
-        print_mobile_urls(addr, runtime_token.as_deref(), auth_enabled);
+        print_mobile_urls(
+            addr,
+            runtime_token.as_deref(),
+            auth_enabled,
+            options.mobile_qr,
+        );
     }
     let is_loopback = options.host == "127.0.0.1" || options.host == "::1";
     if is_loopback {
@@ -669,7 +679,13 @@ async fn mobile_page(State(state): State<RuntimeApiState>, req: Request) -> Resp
     Html(MOBILE_HTML).into_response()
 }
 
-fn print_mobile_urls(addr: SocketAddr, token: Option<&str>, auth_enabled: bool) {
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MobileUrlLine {
+    label: &'static str,
+    url: String,
+}
+
+fn print_mobile_urls(addr: SocketAddr, token: Option<&str>, auth_enabled: bool, mobile_qr: bool) {
     println!("Mobile control page enabled.");
     let token_query = if auth_enabled {
         token
@@ -680,20 +696,78 @@ fn print_mobile_urls(addr: SocketAddr, token: Option<&str>, auth_enabled: bool) 
         String::new()
     };
 
-    let port = addr.port();
-    if addr.ip().is_unspecified() {
-        println!("  Local: http://127.0.0.1:{port}/mobile{token_query}");
-        if let Some(ip) = detect_lan_ip() {
-            println!("  LAN:   http://{ip}:{port}/mobile{token_query}");
-        } else {
-            println!(
-                "  LAN:   bind is 0.0.0.0; open http://<this-machine-ip>:{port}/mobile{token_query}"
-            );
-        }
+    let lan_ip = if addr.ip().is_unspecified() {
+        detect_lan_ip()
     } else {
-        println!("  URL:   http://{addr}/mobile{token_query}");
+        None
+    };
+    let (lines, qr_url) = mobile_url_lines(addr, &token_query, lan_ip);
+    for line in lines {
+        println!("  {:<6} {}", format!("{}:", line.label), line.url);
+    }
+    if addr.ip().is_unspecified() && qr_url.is_none() {
+        println!(
+            "  LAN:   bind is 0.0.0.0; open http://<this-machine-ip>:{}{}",
+            addr.port(),
+            token_query
+        );
+    }
+    if mobile_qr {
+        match qr_url {
+            Some(url) => print_mobile_qr(&url),
+            None => println!(
+                "Mobile QR: skipped because no LAN IP was detected; pass --host <LAN-IP> to print a scannable URL."
+            ),
+        }
     }
     println!("Mobile security: use only on a trusted LAN/VPN; this server does not provide TLS.");
+}
+
+fn mobile_url_lines(
+    addr: SocketAddr,
+    token_query: &str,
+    lan_ip: Option<String>,
+) -> (Vec<MobileUrlLine>, Option<String>) {
+    let port = addr.port();
+    if addr.ip().is_unspecified() {
+        let local_url = format!("http://127.0.0.1:{port}/mobile{token_query}");
+        let mut lines = vec![MobileUrlLine {
+            label: "Local",
+            url: local_url,
+        }];
+        let qr_url = lan_ip.map(|ip| format!("http://{ip}:{port}/mobile{token_query}"));
+        if let Some(url) = qr_url.as_ref() {
+            lines.push(MobileUrlLine {
+                label: "LAN",
+                url: url.clone(),
+            });
+        }
+        (lines, qr_url)
+    } else {
+        let url = format!("http://{addr}/mobile{token_query}");
+        (
+            vec![MobileUrlLine {
+                label: "URL",
+                url: url.clone(),
+            }],
+            Some(url),
+        )
+    }
+}
+
+fn print_mobile_qr(url: &str) {
+    match QrCode::new(url.as_bytes()) {
+        Ok(code) => {
+            println!("Mobile QR: scan to open {url}");
+            let image = code.render::<Dense1x2>().module_dimensions(1, 1).build();
+            for line in image.lines() {
+                println!("  {line}");
+            }
+        }
+        Err(err) => {
+            eprintln!("Mobile QR: failed to encode URL: {err}");
+        }
+    }
 }
 
 fn url_query_component(value: &str) -> String {
@@ -2283,6 +2357,63 @@ mod tests {
         assert_eq!(
             url_query_component("abc ABC+/?:=&%"),
             "abc%20ABC%2B%2F%3F%3A%3D%26%25"
+        );
+    }
+
+    #[test]
+    fn mobile_url_lines_prefers_lan_qr_when_bound_to_all_interfaces() {
+        let addr: SocketAddr = "0.0.0.0:7878".parse().unwrap();
+        let (lines, qr_url) = mobile_url_lines(addr, "?token=abc", Some("192.168.1.42".into()));
+
+        assert_eq!(
+            lines,
+            vec![
+                MobileUrlLine {
+                    label: "Local",
+                    url: "http://127.0.0.1:7878/mobile?token=abc".to_string(),
+                },
+                MobileUrlLine {
+                    label: "LAN",
+                    url: "http://192.168.1.42:7878/mobile?token=abc".to_string(),
+                },
+            ]
+        );
+        assert_eq!(
+            qr_url,
+            Some("http://192.168.1.42:7878/mobile?token=abc".to_string())
+        );
+    }
+
+    #[test]
+    fn mobile_url_lines_skips_qr_when_lan_ip_is_unknown() {
+        let addr: SocketAddr = "0.0.0.0:7878".parse().unwrap();
+        let (lines, qr_url) = mobile_url_lines(addr, "", None);
+
+        assert_eq!(
+            lines,
+            vec![MobileUrlLine {
+                label: "Local",
+                url: "http://127.0.0.1:7878/mobile".to_string(),
+            }]
+        );
+        assert_eq!(qr_url, None);
+    }
+
+    #[test]
+    fn mobile_url_lines_uses_explicit_host_for_qr() {
+        let addr: SocketAddr = "192.168.1.42:7878".parse().unwrap();
+        let (lines, qr_url) = mobile_url_lines(addr, "?token=abc", None);
+
+        assert_eq!(
+            lines,
+            vec![MobileUrlLine {
+                label: "URL",
+                url: "http://192.168.1.42:7878/mobile?token=abc".to_string(),
+            }]
+        );
+        assert_eq!(
+            qr_url,
+            Some("http://192.168.1.42:7878/mobile?token=abc".to_string())
         );
     }
 


### PR DESCRIPTION
## Summary
- add `--mobile-qr` for `codewhale-tui serve --mobile` so the terminal can print a scannable mobile control URL
- prefer the detected LAN URL when binding `0.0.0.0`, use explicit hosts as-is, and skip QR output when no LAN IP can be detected
- reject `--mobile-qr` unless `--mobile` is selected, so the flag is never silently ignored

Closes #2397

## Validation
- `cargo test -p codewhale-tui --bin codewhale-tui mobile_url_lines --locked`
- `cargo test -p codewhale-tui --bin codewhale-tui mobile_qr_requires_mobile_mode --locked`
- `cargo check -p codewhale-tui --locked`
- `git diff --check`
- `target\\debug\\codewhale-tui.exe serve --help | Select-String -Pattern "mobile-qr|mobile control"`

Note: `cargo test -p codewhale-tui mobile_url_lines --locked` ran the three new target tests successfully, then failed when Cargo enumerated the unrelated `skill_install` integration test on this Windows host with `os error 740` (requires elevation). The scoped `--bin codewhale-tui` command above passed.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds `--mobile-qr` to `codewhale-tui serve --mobile`, printing a terminal QR code using the `qrcode` crate's `Dense1x2` Unicode renderer, and rejects the flag when `--mobile` is not set.

- `print_mobile_urls` is refactored into a testable `mobile_url_lines` helper that separates LAN-IP detection from URL formatting, along with three new unit tests covering the main address cases.
- A new `validate_mobile_qr_selection` guard + test ensures `--mobile-qr` is always paired with `--mobile`.
- The fallback path (when `0.0.0.0` binding produces no detected LAN IP) skips the QR output and emits a plain-text hint instead.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The feature addition is mechanically sound for the common case, but runtime_api.rs carries two defects flagged in earlier review rounds that have not yet been corrected in this revision.

The --mobile-qr flag, validation guard, mobile_url_lines refactor, and print_mobile_qr implementation are all correct for the happy path (LAN IP detected, or explicit reachable host). The unresolved issues from the previous review rounds — a missing /mobile path segment in the 0.0.0.0 fallback hint and a QR code being emitted for a loopback-bound explicit host — are still present in this revision and would produce incorrect behavior for those two edge cases.

crates/tui/src/runtime_api.rs — the fallback LAN hint and the explicit-host branch of mobile_url_lines both need the corrections raised in the prior review.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/runtime_api.rs | Core of the feature: adds mobile_url_lines, print_mobile_qr, and QR rendering; two issues flagged in earlier review rounds (missing /mobile in fallback message, QR emitted for loopback hosts) remain unresolved in this revision. |
| crates/tui/src/main.rs | Adds --mobile-qr CLI flag, validate_mobile_qr_selection guard, and wires mobile_qr into RuntimeApiOptions; logic is straightforward and well tested. |
| crates/tui/Cargo.toml | Adds qrcode 0.14.1 with default-features = false; minimal, appropriate dependency addition. |
| Cargo.lock | Lock file updated to include qrcode 0.14.1 with expected checksum; no other dependency changes. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["serve --mobile --mobile-qr"] --> B["validate_mobile_qr_selection"]
    B -- "mobile=false" --> C["bail: --mobile-qr requires --mobile"]
    B -- "mobile=true" --> D["run_http_server"]
    D --> E{"addr unspecified?"}
    E -- yes --> F["detect_lan_ip"]
    F --> G{"LAN IP found?"}
    G -- yes --> H["qr_url = LAN URL\nlines = Local + LAN"]
    G -- no --> I["qr_url = None\nlines = Local only"]
    E -- no --> J["qr_url = explicit addr URL\nlines = URL entry"]
    H --> K["print lines"]
    I --> K
    J --> K
    I --> L["print fallback hint"]
    K --> M{"mobile_qr flag?"}
    M -- false --> N["done"]
    M -- true --> O{"qr_url present?"}
    O -- Some --> P["print_mobile_qr\nDense1x2 Unicode QR"]
    O -- None --> Q["print: QR skipped"]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["feat(runtime): add mobile QR bootstrap"](https://github.com/hmbown/codewhale/commit/3ec2cbf9b0988faf223568fb8b6711263ee083b4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34776301)</sub>

<!-- /greptile_comment -->