### PR TITLE
docs: align configuration paths with codewhale home

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -9,22 +9,26 @@ only the provider and safety knobs you need.
 
 Default config path:
 
-- `~/.deepseek/config.toml`
+- `~/.codewhale/config.toml`
+- Legacy fallback: `~/.deepseek/config.toml`
 
 Overrides:
 
 - CLI: `codewhale --config /path/to/config.toml`
-- Env: `DEEPSEEK_CONFIG_PATH=/path/to/config.toml`
+- Env: `CODEWHALE_CONFIG_PATH=/path/to/config.toml`
+- Legacy env alias: `DEEPSEEK_CONFIG_PATH=/path/to/config.toml`
 
 If both are set, `--config` wins. Environment variable overrides are applied after the file is loaded.
 
 ### Per-project overlay (#485)
 
 When the TUI starts in a workspace that contains a
-`<workspace>/.deepseek/config.toml` file, the values declared in that
-file are merged on top of the global config. This lets a repo lock its
-own provider, model, sandbox policy, or approval policy without
-touching the user's `~/.deepseek/config.toml`. Pass
+`<workspace>/.codewhale/config.toml` file, the values declared in that
+file are merged on top of the global config. Legacy
+`<workspace>/.deepseek/config.toml` files are still read when the
+CodeWhale path is absent. This lets a repo lock its own provider,
+model, sandbox policy, or approval policy without touching the user's
+`~/.codewhale/config.toml`. Pass
 `--no-project-config` to skip the overlay for one launch.
 
 Supported keys in the project overlay (top-level fields only):
@@ -52,8 +56,9 @@ specific use case.
 The `codewhale` facade and `codewhale-tui` binary share the same config file for
 DeepSeek auth and model defaults. `codewhale auth set --provider deepseek` (and
 the legacy `codewhale login --api-key ...` alias) saves the key to
-`~/.deepseek/config.toml`, and `codewhale --model deepseek-v4-flash` is forwarded
-to the TUI as `DEEPSEEK_MODEL`.
+`~/.codewhale/config.toml` (migrating legacy `~/.deepseek/config.toml` on first
+launch when needed), and `codewhale --model deepseek-v4-flash` is forwarded to
+the TUI as `DEEPSEEK_MODEL`.
 
 Credential lookup uses `config -> keyring -> env` after any explicit CLI
 `--api-key`. Run `codewhale auth status` to inspect the active provider's config
@@ -298,11 +303,15 @@ Remaining variables:
 - `DEEPSEEK_MANAGED_CONFIG_PATH`
 - `DEEPSEEK_REQUIREMENTS_PATH`
 - `DEEPSEEK_MAX_SUBAGENTS` (clamped to `1..=20`)
-- `DEEPSEEK_TASKS_DIR` (runtime task queue/artifact storage, default `~/.deepseek/tasks`)
+- `DEEPSEEK_TASKS_DIR` (runtime task queue/artifact storage, default
+  `~/.codewhale/tasks`, with legacy `~/.deepseek/tasks` fallback when only the
+  legacy directory exists)
 - `DEEPSEEK_ALLOW_INSECURE_HTTP` (`1`/`true` allows non-local `http://` base URLs; default is reject)
 - `DEEPSEEK_FORCE_HTTP1` (`1|true|yes|on` pins the HTTP client to HTTP/1.1, disabling HTTP/2; useful on Windows or behind proxies that mishandle long-lived H2 streams)
-- `DEEPSEEK_HOME` (override the base data directory; defaults to `~/.deepseek`)
-- `DEEPSEEK_AUTOMATIONS_DIR` (override the automations storage directory; defaults to `~/.deepseek/automations`)
+- `CODEWHALE_HOME` (override the base data directory; defaults to `~/.codewhale`)
+- `DEEPSEEK_AUTOMATIONS_DIR` (override the automations storage directory; uses
+  `~/.codewhale/automations` when that directory exists, otherwise the legacy
+  `~/.deepseek/automations` path)
 - `DEEPSEEK_CAPACITY_ENABLED`
 - `DEEPSEEK_CAPACITY_LOW_RISK_MAX`
 - `DEEPSEEK_CAPACITY_MEDIUM_RISK_MAX`
@@ -336,7 +345,7 @@ concatenated, in declared order, alongside the auto-loaded
 ```toml
 instructions = [
     "./AGENTS.md",
-    "~/.deepseek/global.md",
+    "~/.codewhale/global.md",
     "~/team/agents-shared.md",
 ]
 ```
@@ -348,7 +357,8 @@ Rules:
   truncated with a `[…elided]` marker rather than skipped.
 - Missing files are skipped with a tracing warning so a stale
   entry doesn't fail the launch.
-- Project config (`<workspace>/.deepseek/config.toml`)
+- Project config (`<workspace>/.codewhale/config.toml`, or legacy
+  `<workspace>/.deepseek/config.toml`)
   **replaces** the user array wholesale rather than merging.
   If you want both, list `~/global.md` inside the project
   array. Set `instructions = []` in the project to clear the
@@ -508,24 +518,28 @@ If you are upgrading from older releases:
   `[subagents.models]` accepts lower-case role or type keys such as `worker`,
   `explorer`, `general`, `explore`, `plan`, and `review`. Values must normalize
   to a supported DeepSeek model id before an agent is spawned.
-- `skills_dir` (string, optional): defaults to `~/.deepseek/skills` (each skill is
+- `skills_dir` (string, optional): defaults to `~/.codewhale/skills` (each skill is
   a directory containing `SKILL.md`). Workspace-local `.agents/skills` or
   `./skills` are preferred when present; the runtime also discovers global
   agentskills.io-compatible `~/.agents/skills` and the broader Claude-ecosystem
   `~/.claude/skills`. First launch installs versioned bundled skills for common
   workflows including skill creation, delegation, MCP/plugin scaffolding,
   documents, presentations, spreadsheets, PDFs, and Feishu/Lark.
-- `mcp_config_path` (string, optional): defaults to `~/.deepseek/mcp.json`.
+- `mcp_config_path` (string, optional): defaults to `~/.codewhale/mcp.json`, with
+  legacy `~/.deepseek/mcp.json` fallback when the CodeWhale path is absent.
   It is visible in `/config` and can be changed from the TUI. The new path is
   used immediately by `/mcp`, but rebuilding the model-visible MCP tool pool
   requires restarting the TUI.
-- `notes_path` (string, optional): defaults to `~/.deepseek/notes.txt` and is used by the model-visible `note` tool.
+- `notes_path` (string, optional): defaults to `~/.codewhale/notes.txt`, with
+  legacy `~/.deepseek/notes.txt` fallback when the CodeWhale path is absent, and
+  is used by the model-visible `note` tool.
 - `[memory].enabled` (bool, optional): defaults to `false`. When `true`,
   the TUI loads the user memory file into a `<user_memory>` prompt block,
   enables `# foo` quick-capture in the composer, surfaces the `/memory`
   slash command, and registers the `remember` tool. The same toggle is
   available via `DEEPSEEK_MEMORY=on`.
-- `memory_path` (string, optional): defaults to `~/.deepseek/memory.md`.
+- `memory_path` (string, optional): defaults to `~/.codewhale/memory.md`, with
+  legacy `~/.deepseek/memory.md` fallback when the CodeWhale path is absent.
   Used by the user-memory feature when enabled — see
   [`MEMORY.md`](MEMORY.md) for the full feature surface (`# foo`
   composer prefix, `/memory` slash command, `remember` tool, opt-in
@@ -533,7 +547,10 @@ If you are upgrading from older releases:
 - `snapshots.*` (optional): side-git workspace snapshots for file rollback:
   - `[snapshots].enabled` (bool, default `true`)
   - `[snapshots].max_age_days` (int, default `7`)
-  - snapshots live under `~/.deepseek/snapshots/<project_hash>/<worktree_hash>/.git` and never use the workspace's own `.git` directory
+  - snapshots live under
+    `~/.codewhale/snapshots/<project_hash>/<worktree_hash>/.git`, with legacy
+    `~/.deepseek/snapshots/...` fallback when only the legacy state exists, and
+    never use the workspace's own `.git` directory
 - `context.*` (optional): append-only Fin seam manager, currently opt-in.
   Fin is the fast `deepseek-v4-flash` path with thinking off used for
   coordination work such as routing, summaries, and context maintenance.
@@ -617,7 +634,7 @@ User memory is split across one top-level path setting and one opt-in
 toggle table:
 
 ```toml
-memory_path = "~/.deepseek/memory.md"
+memory_path = "~/.codewhale/memory.md"
 
 [memory]
 enabled = true
@@ -755,7 +772,8 @@ See `docs/capacity_controller.md` for formulas, intervention behavior, and telem
 ## Notes On `codewhale-tui doctor`
 
 `codewhale-tui doctor` follows the same config resolution rules as the rest of the
-TUI. That means `--config` / `DEEPSEEK_CONFIG_PATH` are respected, and MCP/skills
+TUI. That means `--config`, `CODEWHALE_CONFIG_PATH`, and the legacy
+`DEEPSEEK_CONFIG_PATH` are respected, and MCP/skills
 checks use the resolved `mcp_config_path` / `skills_dir` (including env overrides).
 
 To bootstrap missing MCP/skills paths, run `codewhale-tui setup --all`. You can
@@ -790,17 +808,17 @@ configure reasoning effort.
   MCP/skills/tools/plugins counts, sandbox, `.env` presence). Read-only and
   network-free; safe to run in CI. If `.env` is missing and `.env.example` is
   present in the workspace, the status output points at `cp .env.example .env`.
-- `--tools` — scaffold `~/.deepseek/tools/` with a `README.md` describing the
+- `--tools` — scaffold `~/.codewhale/tools/` with a `README.md` describing the
   self-describing frontmatter convention (`# name:` / `# description:` /
   `# usage:`) and an `example.sh` that follows it. The directory is
   intentionally not auto-loaded; wire individual scripts into the agent via
   MCP, hooks, or skills.
-- `--plugins` — scaffold `~/.deepseek/plugins/` with a `README.md` and an
+- `--plugins` — scaffold `~/.codewhale/plugins/` with a `README.md` and an
   `example/PLUGIN.md` placeholder using the same frontmatter shape as
   `SKILL.md`. Plugins are not loaded automatically either; reference them
   from a skill, hook, or MCP wrapper when you want them active.
 - `--all` now scaffolds MCP + skills + tools + plugins together.
-- `--clean` — list `~/.deepseek/sessions/checkpoints/latest.json` and
+- `--clean` — list `~/.codewhale/sessions/checkpoints/latest.json` and
   `offline_queue.json` if they exist. Pass `--force` to actually remove them.
   This never touches real session history or the task queue.
 


### PR DESCRIPTION
## Summary
- update `docs/CONFIGURATION.md` to describe `~/.codewhale/config.toml` as the primary config path with `~/.deepseek/config.toml` as legacy fallback
- document `CODEWHALE_CONFIG_PATH` / `CODEWHALE_HOME` alongside legacy env compatibility
- align documented state defaults for tasks, skills, MCP, notes, memory, snapshots, setup tools/plugins, and clean checkpoints with the current CodeWhale home behavior

Closes #2322

## Validation
- `git diff --check`
- `rg -n "default `~/.deepseek|defaults to `~/.deepseek|saves.*~/.deepseek|user's `~/.deepseek|<workspace>/.deepseek/config.toml` file|DEEPSEEK_HOME" docs/CONFIGURATION.md` returns no matches

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates `docs/CONFIGURATION.md` to reflect the renaming of the CodeWhale home directory from `~/.deepseek` to `~/.codewhale`, documenting new primary paths and env vars (`CODEWHALE_HOME`, `CODEWHALE_CONFIG_PATH`) while preserving notes about the legacy `~/.deepseek` fallbacks throughout the file.

- Default config path, per-project overlay, tasks dir, skills dir, MCP config, notes, memory, snapshots, and `setup` scaffold targets all updated to prefer `~/.codewhale/*` with documented legacy fallbacks.
- `DEEPSEEK_HOME` is silently dropped from the env-var table and replaced by `CODEWHALE_HOME` without a legacy-alias note, unlike `CODEWHALE_CONFIG_PATH` which explicitly lists `DEEPSEEK_CONFIG_PATH` as a legacy alias.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge for most users, but anyone relying on a custom `DEEPSEEK_HOME` may silently lose their configured data directory on upgrade.

The `DEEPSEEK_HOME` → `CODEWHALE_HOME` rename is the only env-var change in the entire list that doesn't carry a legacy alias note. Every other renamed variable in this PR pairs the new name with its old fallback; leaving `DEEPSEEK_HOME` undocumented means users who export a custom base path could experience a silent data-directory regression with no hint in the docs about what happened or how to fix it.

docs/CONFIGURATION.md — specifically the `CODEWHALE_HOME` entry and the `--clean` flag description.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/CONFIGURATION.md | Aligns documented paths and env vars to `~/.codewhale` with legacy `~/.deepseek` fallbacks; `DEEPSEEK_HOME` is removed from the env-var list without a legacy alias note, inconsistent with the treatment of `CODEWHALE_CONFIG_PATH`. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Process startup] --> B{CODEWHALE_CONFIG_PATH set?}
    B -- yes --> C[Load CODEWHALE_CONFIG_PATH]
    B -- no --> D{DEEPSEEK_CONFIG_PATH set? legacy alias}
    D -- yes --> E[Load DEEPSEEK_CONFIG_PATH]
    D -- no --> F{~/.codewhale/config.toml exists?}
    F -- yes --> G[Load ~/.codewhale/config.toml]
    F -- no --> H[Load ~/.deepseek/config.toml legacy fallback]
    C & E & G & H --> I{Per-project overlay?}
    I -- .codewhale/config.toml exists --> J[Merge .codewhale/config.toml]
    I -- only .deepseek/config.toml exists --> K[Merge .deepseek/config.toml legacy fallback]
    I -- neither --> L[No overlay]
    J & K & L --> M[Resolved config]
    M --> N{CODEWHALE_HOME set?}
    N -- yes --> O[Base dir = CODEWHALE_HOME DEEPSEEK_HOME legacy alias ???]
    N -- no --> P[Base dir = ~/.codewhale]
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22codex%2Fconfig-docs-codewhale%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fconfig-docs-codewhale%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Adocs%2FCONFIGURATION.md%3A311-314%0A**%60DEEPSEEK_HOME%60%20legacy%20alias%20not%20documented**%0A%0AEvery%20other%20renamed%20env%20var%20in%20this%20PR%20documents%20a%20legacy%20alias%20%E2%80%94%20%60CODEWHALE_CONFIG_PATH%60%20explicitly%20lists%20%60DEEPSEEK_CONFIG_PATH%60%20as%20a%20%22Legacy%20env%20alias.%22%20But%20%60CODEWHALE_HOME%60%2C%20which%20replaces%20%60DEEPSEEK_HOME%60%2C%20has%20no%20such%20note.%20A%20user%20who%20currently%20exports%20%60DEEPSEEK_HOME%3D%2Fsome%2Fcustom%2Fpath%60%20will%20silently%20fall%20back%20to%20the%20%60~%2F.codewhale%60%20default%20on%20upgrade%2C%20potentially%20causing%20the%20binary%20to%20lose%20its%20custom%20data%20directory%20without%20any%20warning.%20If%20the%20runtime%20still%20honors%20%60DEEPSEEK_HOME%60%20as%20a%20fallback%2C%20it%20should%20be%20listed%20here%20%E2%80%94%20and%20if%20it%20doesn't%2C%20the%20omission%20is%20a%20breaking%20change%20worth%20calling%20out%20explicitly%20in%20the%20documentation.%0A%0A%23%23%23%20Issue%202%20of%202%0Adocs%2FCONFIGURATION.md%3A821-823%0AThe%20%60--clean%60%20flag%20now%20documents%20only%20the%20new%20%60~%2F.codewhale%2F%60%20path%2C%20but%20every%20other%20home-directory%20path%20in%20this%20PR%20documents%20the%20legacy%20%60~%2F.deepseek%2F%60%20fallback.%20If%20the%20%60doctor%20--clean%60%20logic%20also%20inspects%20the%20legacy%20location%2C%20this%20should%20say%20so%20for%20consistency%3B%20if%20not%2C%20a%20user%20whose%20checkpoints%20are%20still%20in%20%60~%2F.deepseek%2Fsessions%2F%60%20will%20think%20they%20have%20no%20stale%20files%20to%20clean.%0A%0A%60%60%60suggestion%0A-%20%60--clean%60%20%E2%80%94%20list%20%60~%2F.codewhale%2Fsessions%2Fcheckpoints%2Flatest.json%60%20and%0A%20%20%60offline_queue.json%60%20if%20they%20exist%20%28legacy%20%60~%2F.deepseek%2Fsessions%2Fcheckpoints%2F%60%0A%20%20is%20also%20checked%20when%20the%20CodeWhale%20path%20is%20absent%29.%20Pass%20%60--force%60%20to%20actually%0A%20%20remove%20them.%20This%20never%20touches%20real%20session%20history%20or%20the%20task%20queue.%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Adocs%2FCONFIGURATION.md%3A311-314%0A**%60DEEPSEEK_HOME%60%20legacy%20alias%20not%20documented**%0A%0AEvery%20other%20renamed%20env%20var%20in%20this%20PR%20documents%20a%20legacy%20alias%20%E2%80%94%20%60CODEWHALE_CONFIG_PATH%60%20explicitly%20lists%20%60DEEPSEEK_CONFIG_PATH%60%20as%20a%20%22Legacy%20env%20alias.%22%20But%20%60CODEWHALE_HOME%60%2C%20which%20replaces%20%60DEEPSEEK_HOME%60%2C%20has%20no%20such%20note.%20A%20user%20who%20currently%20exports%20%60DEEPSEEK_HOME%3D%2Fsome%2Fcustom%2Fpath%60%20will%20silently%20fall%20back%20to%20the%20%60~%2F.codewhale%60%20default%20on%20upgrade%2C%20potentially%20causing%20the%20binary%20to%20lose%20its%20custom%20data%20directory%20without%20any%20warning.%20If%20the%20runtime%20still%20honors%20%60DEEPSEEK_HOME%60%20as%20a%20fallback%2C%20it%20should%20be%20listed%20here%20%E2%80%94%20and%20if%20it%20doesn't%2C%20the%20omission%20is%20a%20breaking%20change%20worth%20calling%20out%20explicitly%20in%20the%20documentation.%0A%0A%23%23%23%20Issue%202%20of%202%0Adocs%2FCONFIGURATION.md%3A821-823%0AThe%20%60--clean%60%20flag%20now%20documents%20only%20the%20new%20%60~%2F.codewhale%2F%60%20path%2C%20but%20every%20other%20home-directory%20path%20in%20this%20PR%20documents%20the%20legacy%20%60~%2F.deepseek%2F%60%20fallback.%20If%20the%20%60doctor%20--clean%60%20logic%20also%20inspects%20the%20legacy%20location%2C%20this%20should%20say%20so%20for%20consistency%3B%20if%20not%2C%20a%20user%20whose%20checkpoints%20are%20still%20in%20%60~%2F.deepseek%2Fsessions%2F%60%20will%20think%20they%20have%20no%20stale%20files%20to%20clean.%0A%0A%60%60%60suggestion%0A-%20%60--clean%60%20%E2%80%94%20list%20%60~%2F.codewhale%2Fsessions%2Fcheckpoints%2Flatest.json%60%20and%0A%20%20%60offline_queue.json%60%20if%20they%20exist%20%28legacy%20%60~%2F.deepseek%2Fsessions%2Fcheckpoints%2F%60%0A%20%20is%20also%20checked%20when%20the%20CodeWhale%20path%20is%20absent%29.%20Pass%20%60--force%60%20to%20actually%0A%20%20remove%20them.%20This%20never%20touches%20real%20session%20history%20or%20the%20task%20queue.%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2400&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Adocs%2FCONFIGURATION.md%3A311-314%0A**%60DEEPSEEK_HOME%60%20legacy%20alias%20not%20documented**%0A%0AEvery%20other%20renamed%20env%20var%20in%20this%20PR%20documents%20a%20legacy%20alias%20%E2%80%94%20%60CODEWHALE_CONFIG_PATH%60%20explicitly%20lists%20%60DEEPSEEK_CONFIG_PATH%60%20as%20a%20%22Legacy%20env%20alias.%22%20But%20%60CODEWHALE_HOME%60%2C%20which%20replaces%20%60DEEPSEEK_HOME%60%2C%20has%20no%20such%20note.%20A%20user%20who%20currently%20exports%20%60DEEPSEEK_HOME%3D%2Fsome%2Fcustom%2Fpath%60%20will%20silently%20fall%20back%20to%20the%20%60~%2F.codewhale%60%20default%20on%20upgrade%2C%20potentially%20causing%20the%20binary%20to%20lose%20its%20custom%20data%20directory%20without%20any%20warning.%20If%20the%20runtime%20still%20honors%20%60DEEPSEEK_HOME%60%20as%20a%20fallback%2C%20it%20should%20be%20listed%20here%20%E2%80%94%20and%20if%20it%20doesn't%2C%20the%20omission%20is%20a%20breaking%20change%20worth%20calling%20out%20explicitly%20in%20the%20documentation.%0A%0A%23%23%23%20Issue%202%20of%202%0Adocs%2FCONFIGURATION.md%3A821-823%0AThe%20%60--clean%60%20flag%20now%20documents%20only%20the%20new%20%60~%2F.codewhale%2F%60%20path%2C%20but%20every%20other%20home-directory%20path%20in%20this%20PR%20documents%20the%20legacy%20%60~%2F.deepseek%2F%60%20fallback.%20If%20the%20%60doctor%20--clean%60%20logic%20also%20inspects%20the%20legacy%20location%2C%20this%20should%20say%20so%20for%20consistency%3B%20if%20not%2C%20a%20user%20whose%20checkpoints%20are%20still%20in%20%60~%2F.deepseek%2Fsessions%2F%60%20will%20think%20they%20have%20no%20stale%20files%20to%20clean.%0A%0A%60%60%60suggestion%0A-%20%60--clean%60%20%E2%80%94%20list%20%60~%2F.codewhale%2Fsessions%2Fcheckpoints%2Flatest.json%60%20and%0A%20%20%60offline_queue.json%60%20if%20they%20exist%20%28legacy%20%60~%2F.deepseek%2Fsessions%2Fcheckpoints%2F%60%0A%20%20is%20also%20checked%20when%20the%20CodeWhale%20path%20is%20absent%29.%20Pass%20%60--force%60%20to%20actually%0A%20%20remove%20them.%20This%20never%20touches%20real%20session%20history%20or%20the%20task%20queue.%0A%60%60%60%0A%0A&pr=2400&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs: align configuration paths with cod..."](https://github.com/hmbown/codewhale/commit/b2a77d80c71cc8824e3462bf5e24d01337a9927f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34776449)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->