### PR TITLE
feat(execpolicy): add typed ask rule foundation

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1310,7 +1310,6 @@ fn run_sandbox_command(command: SandboxCommand) -> Result<()> {
                 command: &command,
                 cwd: &cwd.display().to_string(),
                 tool: Some("exec_shell"),
-                path: None,
                 ask_for_approval: ask.into(),
                 sandbox_mode: Some("workspace-write"),
             })?;

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1309,6 +1309,8 @@ fn run_sandbox_command(command: SandboxCommand) -> Result<()> {
             let decision = engine.check(ExecPolicyContext {
                 command: &command,
                 cwd: &cwd.display().to_string(),
+                tool: Some("exec_shell"),
+                path: None,
                 ask_for_approval: ask.into(),
                 sandbox_mode: Some("workspace-write"),
             })?;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1010,9 +1010,15 @@ impl Runtime {
     ) -> Result<Value> {
         let fallback_cwd = cwd.display().to_string();
         let (command, policy_cwd, execution_kind) = call.execution_subject(&fallback_cwd);
+        let policy_tool = match &call.payload {
+            ToolPayload::LocalShell { .. } => "exec_shell",
+            _ => call.name.as_str(),
+        };
         let decision = self.exec_policy.check(ExecPolicyContext {
             command: &command,
             cwd: &policy_cwd,
+            tool: Some(policy_tool),
+            path: None,
             ask_for_approval: approval_mode,
             sandbox_mode: None,
         })?;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1018,7 +1018,6 @@ impl Runtime {
             command: &command,
             cwd: &policy_cwd,
             tool: Some(policy_tool),
-            path: None,
             ask_for_approval: approval_mode,
             sandbox_mode: None,
         })?;

--- a/crates/execpolicy/src/lib.rs
+++ b/crates/execpolicy/src/lib.rs
@@ -71,8 +71,6 @@ pub struct ToolAskRule {
     pub tool: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub command: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub path: Option<String>,
 }
 
 impl ToolAskRule {
@@ -80,7 +78,6 @@ impl ToolAskRule {
         Self {
             tool: tool.into(),
             command: None,
-            path: None,
         }
     }
 
@@ -88,15 +85,6 @@ impl ToolAskRule {
         Self {
             tool: "exec_shell".to_string(),
             command: Some(command.into()),
-            path: None,
-        }
-    }
-
-    pub fn file_path(tool: impl Into<String>, path: impl Into<String>) -> Self {
-        Self {
-            tool: tool.into(),
-            command: None,
-            path: Some(path.into()),
         }
     }
 
@@ -104,9 +92,6 @@ impl ToolAskRule {
         let mut parts = vec![format!("tool={}", self.tool)];
         if let Some(command) = &self.command {
             parts.push(format!("command={command}"));
-        }
-        if let Some(path) = &self.path {
-            parts.push(format!("path={path}"));
         }
         parts.join(" ")
     }
@@ -184,7 +169,6 @@ pub struct ExecPolicyContext<'a> {
     pub command: &'a str,
     pub cwd: &'a str,
     pub tool: Option<&'a str>,
-    pub path: Option<&'a str>,
     pub ask_for_approval: AskForApproval,
     pub sandbox_mode: Option<&'a str>,
 }
@@ -262,21 +246,19 @@ impl ExecPolicyEngine {
 
         self.rulesets
             .iter()
-            .flat_map(|ruleset| ruleset.ask_rules.iter())
-            .filter(|rule| rule.tool == tool)
-            .filter(|rule| match rule.command.as_deref() {
+            .flat_map(|ruleset| {
+                ruleset
+                    .ask_rules
+                    .iter()
+                    .map(move |rule| (ruleset.layer, rule))
+            })
+            .filter(|(_, rule)| rule.tool == tool)
+            .filter(|(_, rule)| match rule.command.as_deref() {
                 Some(command) => self.arity_dict.allow_rule_matches(command, ctx.command),
                 None => true,
             })
-            .filter(|rule| match (rule.path.as_deref(), ctx.path) {
-                (Some(pattern), Some(path)) => {
-                    normalize_path_value(pattern) == normalize_path_value(path)
-                }
-                (Some(_), None) => false,
-                (None, _) => true,
-            })
-            .max_by_key(|rule| ask_rule_specificity(rule))
-            .cloned()
+            .max_by_key(|(layer, rule)| (*layer, ask_rule_specificity(rule)))
+            .map(|(_, rule)| rule.clone())
     }
 
     pub fn remember_session_approval(&mut self, approval_key: String) {
@@ -378,7 +360,7 @@ impl ExecPolicyEngine {
         Ok(ExecPolicyDecision {
             allow,
             requires_approval,
-            matched_rule: trusted_rule.or(matched_ask_rule),
+            matched_rule: matched_ask_rule.or(trusted_rule),
             requirement,
         })
     }
@@ -396,21 +378,12 @@ fn first_token(command: &str) -> String {
         .to_string()
 }
 
-fn normalize_path_value(value: &str) -> String {
-    value
-        .replace('\\', "/")
-        .trim_matches('/')
-        .trim()
-        .to_ascii_lowercase()
-}
-
 fn ask_rule_specificity(rule: &ToolAskRule) -> usize {
     rule.tool.len()
         + rule
             .command
             .as_ref()
             .map_or(0, |command| command.len() + 1000)
-        + rule.path.as_ref().map_or(0, |path| path.len() + 1000)
 }
 
 #[cfg(test)]
@@ -422,7 +395,6 @@ mod tests {
             command,
             cwd: "/workspace",
             tool: Some("exec_shell"),
-            path: None,
             ask_for_approval,
             sandbox_mode: Some("workspace-write"),
         }
@@ -592,6 +564,49 @@ mod tests {
             } => assert_eq!(amendment.prefixes, vec!["cargo"]),
             other => panic!("expected unchanged approval behavior, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn typed_ask_rule_prefers_higher_layer_before_specificity() {
+        let engine = ExecPolicyEngine::with_rulesets(vec![
+            Ruleset::agent(vec![], vec![])
+                .with_ask_rules(vec![ToolAskRule::exec_shell("cargo test --workspace")]),
+            Ruleset::user(vec![], vec![])
+                .with_ask_rules(vec![ToolAskRule::exec_shell("cargo test")]),
+        ]);
+
+        let decision = engine
+            .check(ctx(
+                "cargo test --workspace --all-features",
+                AskForApproval::Never,
+            ))
+            .unwrap();
+
+        assert!(!decision.allow);
+        assert_eq!(
+            decision.matched_rule.as_deref(),
+            Some("tool=exec_shell command=cargo test")
+        );
+    }
+
+    #[test]
+    fn typed_ask_rule_explains_forbidden_decision_even_when_trusted_prefix_matches() {
+        let engine = ExecPolicyEngine::with_rulesets(vec![
+            Ruleset::user(vec!["cargo test".to_string()], vec![])
+                .with_ask_rules(vec![ToolAskRule::exec_shell("cargo test")]),
+        ]);
+
+        let decision = engine
+            .check(ctx("cargo test --workspace", AskForApproval::Never))
+            .unwrap();
+
+        assert!(!decision.allow);
+        assert!(!decision.requires_approval);
+        assert_eq!(
+            decision.matched_rule.as_deref(),
+            Some("tool=exec_shell command=cargo test")
+        );
+        assert_eq!(decision.requirement.phase(), "forbidden");
     }
 
     #[test]

--- a/crates/execpolicy/src/lib.rs
+++ b/crates/execpolicy/src/lib.rs
@@ -23,6 +23,8 @@ pub struct Ruleset {
     pub layer: RulesetLayer,
     pub trusted_prefixes: Vec<String>,
     pub denied_prefixes: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub ask_rules: Vec<ToolAskRule>,
 }
 
 impl Ruleset {
@@ -31,6 +33,7 @@ impl Ruleset {
             layer: RulesetLayer::BuiltinDefault,
             trusted_prefixes: vec![],
             denied_prefixes: vec![],
+            ask_rules: vec![],
         }
     }
 
@@ -39,6 +42,7 @@ impl Ruleset {
             layer: RulesetLayer::Agent,
             trusted_prefixes: trusted,
             denied_prefixes: denied,
+            ask_rules: vec![],
         }
     }
 
@@ -47,7 +51,64 @@ impl Ruleset {
             layer: RulesetLayer::User,
             trusted_prefixes: trusted,
             denied_prefixes: denied,
+            ask_rules: vec![],
         }
+    }
+
+    pub fn with_ask_rules(mut self, ask_rules: Vec<ToolAskRule>) -> Self {
+        self.ask_rules = ask_rules;
+        self
+    }
+}
+
+/// Typed rule that marks a tool invocation as requiring approval.
+///
+/// This foundation is intentionally ask-only. Existing trusted/denied command
+/// prefix behavior is preserved while typed ask records can make
+/// `AskForApproval::Never` reject invocations that cannot be approved.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ToolAskRule {
+    pub tool: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+}
+
+impl ToolAskRule {
+    pub fn new(tool: impl Into<String>) -> Self {
+        Self {
+            tool: tool.into(),
+            command: None,
+            path: None,
+        }
+    }
+
+    pub fn exec_shell(command: impl Into<String>) -> Self {
+        Self {
+            tool: "exec_shell".to_string(),
+            command: Some(command.into()),
+            path: None,
+        }
+    }
+
+    pub fn file_path(tool: impl Into<String>, path: impl Into<String>) -> Self {
+        Self {
+            tool: tool.into(),
+            command: None,
+            path: Some(path.into()),
+        }
+    }
+
+    fn label(&self) -> String {
+        let mut parts = vec![format!("tool={}", self.tool)];
+        if let Some(command) = &self.command {
+            parts.push(format!("command={command}"));
+        }
+        if let Some(path) = &self.path {
+            parts.push(format!("path={path}"));
+        }
+        parts.join(" ")
     }
 }
 
@@ -122,6 +183,8 @@ impl ExecPolicyDecision {
 pub struct ExecPolicyContext<'a> {
     pub command: &'a str,
     pub cwd: &'a str,
+    pub tool: Option<&'a str>,
+    pub path: Option<&'a str>,
     pub ask_for_approval: AskForApproval,
     pub sandbox_mode: Option<&'a str>,
 }
@@ -194,6 +257,28 @@ impl ExecPolicyEngine {
         (trusted, denied)
     }
 
+    fn matching_ask_rule(&self, ctx: &ExecPolicyContext<'_>) -> Option<ToolAskRule> {
+        let tool = ctx.tool.unwrap_or("exec_shell");
+
+        self.rulesets
+            .iter()
+            .flat_map(|ruleset| ruleset.ask_rules.iter())
+            .filter(|rule| rule.tool == tool)
+            .filter(|rule| match rule.command.as_deref() {
+                Some(command) => self.arity_dict.allow_rule_matches(command, ctx.command),
+                None => true,
+            })
+            .filter(|rule| match (rule.path.as_deref(), ctx.path) {
+                (Some(pattern), Some(path)) => {
+                    normalize_path_value(pattern) == normalize_path_value(path)
+                }
+                (Some(_), None) => false,
+                (None, _) => true,
+            })
+            .max_by_key(|rule| ask_rule_specificity(rule))
+            .cloned()
+    }
+
     pub fn remember_session_approval(&mut self, approval_key: String) {
         self.approved_for_session.insert(approval_key);
     }
@@ -229,11 +314,24 @@ impl ExecPolicyEngine {
             .cloned();
         let is_trusted = trusted_rule.is_some();
 
-        let requirement = match ctx.ask_for_approval {
-            AskForApproval::Never => ExecApprovalRequirement::Skip {
-                bypass_sandbox: false,
-                proposed_execpolicy_amendment: None,
-            },
+        let ask_rule = self.matching_ask_rule(&ctx);
+
+        let requirement = match &ctx.ask_for_approval {
+            AskForApproval::Never => {
+                if let Some(rule) = &ask_rule {
+                    ExecApprovalRequirement::Forbidden {
+                        reason: format!(
+                            "Typed ask rule '{}' requires approval, but approval policy is never.",
+                            rule.label()
+                        ),
+                    }
+                } else {
+                    ExecApprovalRequirement::Skip {
+                        bypass_sandbox: false,
+                        proposed_execpolicy_amendment: None,
+                    }
+                }
+            }
             AskForApproval::UnlessTrusted if is_trusted => ExecApprovalRequirement::Skip {
                 bypass_sandbox: false,
                 proposed_execpolicy_amendment: None,
@@ -242,7 +340,7 @@ impl ExecPolicyEngine {
                 bypass_sandbox: false,
                 proposed_execpolicy_amendment: None,
             },
-            AskForApproval::Reject { rules, .. } if rules => ExecApprovalRequirement::Forbidden {
+            AskForApproval::Reject { rules, .. } if *rules => ExecApprovalRequirement::Forbidden {
                 reason: "Policy is configured to reject rule-exceptions.".to_string(),
             },
             _ => ExecApprovalRequirement::NeedsApproval {
@@ -271,10 +369,16 @@ impl ExecPolicyEngine {
             ExecApprovalRequirement::Forbidden { .. } => (false, false),
         };
 
+        let matched_ask_rule = if matches!(&ctx.ask_for_approval, AskForApproval::Never) {
+            ask_rule.map(|rule| rule.label())
+        } else {
+            None
+        };
+
         Ok(ExecPolicyDecision {
             allow,
             requires_approval,
-            matched_rule: trusted_rule,
+            matched_rule: trusted_rule.or(matched_ask_rule),
             requirement,
         })
     }
@@ -292,6 +396,23 @@ fn first_token(command: &str) -> String {
         .to_string()
 }
 
+fn normalize_path_value(value: &str) -> String {
+    value
+        .replace('\\', "/")
+        .trim_matches('/')
+        .trim()
+        .to_ascii_lowercase()
+}
+
+fn ask_rule_specificity(rule: &ToolAskRule) -> usize {
+    rule.tool.len()
+        + rule
+            .command
+            .as_ref()
+            .map_or(0, |command| command.len() + 1000)
+        + rule.path.as_ref().map_or(0, |path| path.len() + 1000)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -300,6 +421,8 @@ mod tests {
         ExecPolicyContext {
             command,
             cwd: "/workspace",
+            tool: Some("exec_shell"),
+            path: None,
             ask_for_approval,
             sandbox_mode: Some("workspace-write"),
         }
@@ -421,6 +544,82 @@ mod tests {
         assert_eq!(
             decision.reason(),
             "Policy is configured to reject rule-exceptions."
+        );
+    }
+
+    #[test]
+    fn typed_ask_rule_forbids_matching_command_when_policy_is_never() {
+        let engine = ExecPolicyEngine::with_rulesets(vec![
+            Ruleset::user(vec![], vec![])
+                .with_ask_rules(vec![ToolAskRule::exec_shell("cargo test")]),
+        ]);
+
+        let decision = engine
+            .check(ctx("cargo test --workspace", AskForApproval::Never))
+            .unwrap();
+
+        assert!(!decision.allow);
+        assert!(!decision.requires_approval);
+        assert_eq!(
+            decision.matched_rule.as_deref(),
+            Some("tool=exec_shell command=cargo test")
+        );
+        assert_eq!(decision.requirement.phase(), "forbidden");
+        assert_eq!(
+            decision.reason(),
+            "Typed ask rule 'tool=exec_shell command=cargo test' requires approval, but approval policy is never."
+        );
+    }
+
+    #[test]
+    fn typed_ask_rule_is_ignored_outside_never_mode_for_now() {
+        let engine = ExecPolicyEngine::with_rulesets(vec![
+            Ruleset::user(vec![], vec![])
+                .with_ask_rules(vec![ToolAskRule::exec_shell("cargo test")]),
+        ]);
+
+        let decision = engine
+            .check(ctx("cargo test --workspace", AskForApproval::UnlessTrusted))
+            .unwrap();
+
+        assert!(decision.allow);
+        assert!(decision.requires_approval);
+        assert_eq!(decision.matched_rule, None);
+        match decision.requirement {
+            ExecApprovalRequirement::NeedsApproval {
+                proposed_execpolicy_amendment: Some(amendment),
+                ..
+            } => assert_eq!(amendment.prefixes, vec!["cargo"]),
+            other => panic!("expected unchanged approval behavior, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn typed_ask_rule_does_not_change_allow_deny_precedence() {
+        let engine = ExecPolicyEngine::with_rulesets(vec![
+            Ruleset::user(
+                vec!["cargo test".to_string()],
+                vec!["cargo test --danger".to_string()],
+            )
+            .with_ask_rules(vec![ToolAskRule::exec_shell("cargo test")]),
+        ]);
+
+        let trusted = engine
+            .check(ctx("cargo test --workspace", AskForApproval::UnlessTrusted))
+            .unwrap();
+        assert!(trusted.allow);
+        assert!(!trusted.requires_approval);
+        assert_eq!(trusted.matched_rule.as_deref(), Some("cargo test"));
+
+        let denied = engine
+            .check(ctx("cargo test --danger", AskForApproval::Never))
+            .unwrap();
+        assert!(!denied.allow);
+        assert!(!denied.requires_approval);
+        assert_eq!(denied.matched_rule.as_deref(), Some("cargo test --danger"));
+        assert_eq!(
+            denied.reason(),
+            "Command blocked by denied prefix rule 'cargo test --danger'"
         );
     }
 }

--- a/docs/TOOL_SURFACE.md
+++ b/docs/TOOL_SURFACE.md
@@ -63,6 +63,13 @@ controls for live jobs. Jobs are process-local; after restart, live process
 state is not reattached, and any remembered detached entries must be marked
 stale rather than presented as live processes.
 
+Shell permission policy is evaluated by `crates/execpolicy`. Deny prefixes are
+checked before trusted prefixes and block matching commands regardless of layer.
+Trusted prefixes only skip approval in modes that permit trust shortcuts. Typed
+ask records are currently a narrow foundation: when one matches under
+`AskForApproval::Never`, the command is rejected because the runtime cannot ask
+the user; existing allow/deny behavior is otherwise unchanged.
+
 ### MCP manager and palette discovery
 
 MCP server configuration is surfaced in the TUI through `/mcp` and the


### PR DESCRIPTION
## Summary

- Add typed `ToolAskRule` records to execpolicy rulesets.
- Make matching typed ask rules reject execution under `AskForApproval::Never`, because that mode cannot prompt the user.
- Preserve the existing trusted/denied prefix behavior for all current approval modes.
- Document the narrow permission precedence contract in `docs/TOOL_SURFACE.md`.

## Motivation

This is the smallest foundation slice for persistent typed permission rules. It introduces explainable typed ask records without changing current allow/deny semantics or mid-session approval behavior.

## Context

This PR is a smaller foundation slice extracted from the earlier larger permission-rules PR: #<old-pr-number>.

The previous PR covered typed allow/deny/ask rules, approval-flow integration, and TUI persistence. Per maintainer feedback, this PR intentionally narrows the scope to:

- typed `ask` records in `execpolicy`
- `AskForApproval::Never` handling for matching ask rules
- no changes to existing allow/deny behavior
- no TUI persistence or broader approval-flow changes

Follow-up work can build on this foundation in smaller PRs.

Related discussion:
- #1186
- #2242 

## Validation

- `cargo fmt --all`
- `cargo test -p codewhale-execpolicy --all-features`
- `cargo test -p codewhale-core --all-features`
- `cargo check -p codewhale-cli --all-features`
- `cargo clippy -p codewhale-execpolicy -p codewhale-core --all-targets --all-features -- -D warnings`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a typed `ToolAskRule` record to `execpolicy` rulesets as a narrow foundation for persistent permission rules. Under `AskForApproval::Never`, any matching ask rule causes the command to be rejected with a `Forbidden` decision; all other approval modes are unaffected.

- **New `ToolAskRule` struct** in `Ruleset` with `tool` and optional `command` fields, serialized to/from JSON with serde. `matching_ask_rule` uses layer-then-specificity ordering via `max_by_key` to pick the most authoritative matching rule.
- **`AskForApproval::Never` enforcement**: matching ask rules now produce `Forbidden` instead of `Skip`, with `matched_rule` in `ExecPolicyDecision` reporting the ask rule label rather than any coincidentally-matching trusted prefix.
- **`ExecPolicyContext.tool` field added** to both the CLI and core call sites, mapping `LocalShell` payloads to `"exec_shell"` and other payloads to their call name, enabling tool-aware rule matching.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The ask rule enforcement is narrowly scoped to AskForApproval::Never and leaves all other approval modes unchanged.

The matching_ask_rule logic is straightforward — layer-then-specificity ordering via max_by_key — and five new targeted tests cover the critical combinations: forbid-on-match, ignore-outside-never, layer-over-specificity, trusted+ask-rule overlap, and allow/deny precedence preservation. The matched_rule assignment correctly prioritises the ask rule label over any coincidentally-matching trusted prefix under Never mode. No existing behavior changes for other approval modes.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/execpolicy/src/lib.rs | Core logic change: adds ToolAskRule, matching_ask_rule, ask_rule_specificity, and AskForApproval::Never enforcement. Logic is well-tested with five new tests covering the Happy path, layer/specificity ordering, trusted+ask rule overlap, and allow/deny precedence preservation. |
| crates/core/src/lib.rs | Adds tool field to ExecPolicyContext at the invoke_tool call site, mapping LocalShell to exec_shell and other payloads to their call name. Change is minimal and correct. |
| crates/cli/src/lib.rs | Single-line addition of tool: Some(exec_shell) to the sandbox command policy context. Straightforward and correct. |
| docs/TOOL_SURFACE.md | Documents the execpolicy permission precedence contract and the narrow ask-rule semantics under AskForApproval::Never. Accurate summary of the new behavior. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["check(ExecPolicyContext)"] --> B{Denied prefix match?}
    B -- Yes --> C["Forbidden: 'Command blocked by denied prefix'"]
    B -- No --> D["matching_ask_rule(ctx)\n(layer × specificity ordering)"]
    D --> E{AskForApproval mode?}
    E -- Never + ask_rule Some --> F["Forbidden: 'Typed ask rule requires approval...'"]
    E -- Never + ask_rule None --> G["Skip (allow)"]
    E -- UnlessTrusted + trusted --> G
    E -- OnFailure --> G
    E -- Reject rules=true --> H["Forbidden: 'Policy rejects rule-exceptions'"]
    E -- Other --> I["NeedsApproval"]
    F --> J["matched_rule = ask_rule.label()"]
    G --> K["matched_rule = trusted_rule"]
    I --> K
    H --> L["matched_rule = trusted_rule"]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(execpolicy): tighten typed ask rule ..."](https://github.com/hmbown/codewhale/commit/2f832b22f503ca8664574427e63a306949b8bc81) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34776833)</sub>

<!-- /greptile_comment -->