### PR TITLE
fix(tui): clarify shell tool availability errors

### DIFF
--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -2309,6 +2309,27 @@ fn missing_tool_error_message_includes_discovery_guidance_when_no_match() {
 }
 
 #[test]
+fn missing_shell_tool_error_message_names_allow_shell_gate() {
+    let catalog = vec![Tool {
+        tool_type: None,
+        name: "read_file".to_string(),
+        description: "Read file contents".to_string(),
+        input_schema: json!({"type":"object","properties":{"path":{"type":"string"}}}),
+        allowed_callers: Some(vec!["direct".to_string()]),
+        defer_loading: Some(false),
+        input_examples: None,
+        strict: None,
+        cache_control: None,
+    }];
+
+    let message = missing_tool_error_message("exec_shell", &catalog);
+    assert!(message.contains("not available in the current tool catalog"));
+    assert!(message.contains("allow_shell"));
+    assert!(message.contains("trusted workspaces"));
+    assert!(message.contains(TOOL_SEARCH_BM25_NAME));
+}
+
+#[test]
 fn filter_tool_call_delta_strips_bracket_marker() {
     let mut in_block = false;
     let visible = filter_tool_call_delta(

--- a/crates/tui/src/core/engine/tool_catalog.rs
+++ b/crates/tui/src/core/engine/tool_catalog.rs
@@ -437,6 +437,14 @@ fn suggest_tool_names(catalog: &[Tool], requested: &str, limit: usize) -> Vec<St
 pub(super) fn missing_tool_error_message(tool_name: &str, catalog: &[Tool]) -> String {
     let suggestions = suggest_tool_names(catalog, tool_name, 3);
     if suggestions.is_empty() {
+        if is_shell_tool_name(tool_name) {
+            return format!(
+                "Tool '{tool_name}' is not available in the current tool catalog. \
+                 Shell tools are gated by `allow_shell`; enable `allow_shell = true` \
+                 for trusted workspaces, switch to an auto-approve mode that permits shell access, \
+                 or use {TOOL_SEARCH_BM25_NAME} with a short query."
+            );
+        }
         return format!(
             "Tool '{tool_name}' is not available in the current tool catalog. \
              Verify mode/feature flags, or use {TOOL_SEARCH_BM25_NAME} with a short query."
@@ -447,6 +455,18 @@ pub(super) fn missing_tool_error_message(tool_name: &str, catalog: &[Tool]) -> S
         "Tool '{tool_name}' is not available in the current tool catalog. \
          Did you mean: {}? You can also use {TOOL_SEARCH_BM25_NAME} to discover tools.",
         suggestions.join(", ")
+    )
+}
+
+fn is_shell_tool_name(tool_name: &str) -> bool {
+    matches!(
+        tool_name,
+        "exec_shell"
+            | "exec_shell_wait"
+            | "exec_shell_interact"
+            | "task_shell_start"
+            | "task_shell_wait"
+            | "task_shell_cancel"
     )
 }
 


### PR DESCRIPTION
## Summary
- make missing shell-tool errors explain that `exec_shell`/task shell tools are gated by `allow_shell`
- keep the security default unchanged; the message points users to trusted-workspace opt-in or auto-approve modes instead of silently broadening shell access
- add a regression test for the `exec_shell` missing-tool guidance

Partially addresses #2328

## Validation
- `cargo test -p codewhale-tui --bin codewhale-tui missing_shell_tool_error_message_names_allow_shell_gate --locked`
- `cargo check -p codewhale-tui --locked`
- `git diff --check`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR improves the error message shown when a model requests a missing shell tool (`exec_shell`, `task_shell_*`, etc.) by injecting a hint that the tool is gated behind `allow_shell`. No security defaults are changed; the message purely directs users toward the existing opt-in paths.

- `tool_catalog.rs`: Adds `is_shell_tool_name` and a dedicated error branch in `missing_tool_error_message`. The branch only fires when `suggest_tool_names` returns nothing — if the catalog contains any similarly-named tool (e.g. a bare `exec` MCP tool), suggestions win and the `allow_shell` hint is silently dropped. Additionally, `task_shell_cancel` is listed in `is_shell_tool_name` but has no corresponding tool registration anywhere in the codebase.
- `tests.rs`: Adds a regression test covering only `exec_shell`; the other five names in `is_shell_tool_name` are not exercised.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The change is additive and touches only error message formatting, so no existing behavior regresses. However, the shell-gate hint can be silently suppressed by any catalog tool with a similar name, which is the exact failure the PR aims to prevent.

The core goal — always showing the `allow_shell` guidance for shell tool names — is not reliably achieved: the guidance only appears in the `suggestions.is_empty()` branch, so a catalog entry similar to the requested shell tool name causes the hint to be dropped entirely. The change itself is low-risk since it only affects error message text, but the logic gap means the fix is incomplete.

crates/tui/src/core/engine/tool_catalog.rs — the conditional structure of `missing_tool_error_message` and the presence of `task_shell_cancel` warrant a closer look.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/core/engine/tool_catalog.rs | Adds `is_shell_tool_name` matcher and shell-specific error branch in `missing_tool_error_message`; the shell hint is only reachable when suggestions are empty, so it can be silently bypassed if the catalog has any similarly-named tool. Also includes `task_shell_cancel` which has no corresponding tool registration anywhere in the codebase. |
| crates/tui/src/core/engine/tests.rs | Adds a single regression test for the `exec_shell` missing-tool message; five of the six shell tool names in `is_shell_tool_name` remain untested. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[missing_tool_error_message called] --> B[suggest_tool_names]
    B --> C{suggestions empty?}
    C -- "Yes (no similar names)" --> D{is_shell_tool_name?}
    D -- Yes --> E[Return allow_shell guidance message]
    D -- No --> F[Return generic no-match message]
    C -- "No (similar names found)" --> G[Return 'Did you mean: X?' message]
    G:::issue
    classDef issue fill:#ffcccc,stroke:#cc0000
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22codex%2Fexec-shell-availability-message%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fexec-shell-availability-message%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine%2Ftool_catalog.rs%3A437-459%0A**Shell%20gate%20hint%20silently%20dropped%20when%20suggestions%20exist**%0A%0A%60is_shell_tool_name%60%20is%20only%20checked%20inside%20%60if%20suggestions.is_empty%28%29%60.%20If%20the%20catalog%20contains%20any%20tool%20whose%20name%20is%20similar%20enough%20to%20a%20shell%20tool%20for%20%60suggest_tool_names%60%20to%20surface%20it%20%E2%80%94%20e.g.%20a%20tool%20literally%20named%20%60exec%60%20causes%20%60%22exec_shell%22.contains%28%22exec%22%29%60%20to%20be%20true%20%E2%80%94%20the%20user%20receives%20%22Did%20you%20mean%3A%20exec%3F%22%20with%20no%20mention%20of%20%60allow_shell%60.%20The%20%60allow_shell%60%20gate%20hint%20should%20be%20added%20to%20the%20suggestions%20branch%20as%20well%2C%20or%20%60is_shell_tool_name%60%20should%20be%20evaluated%20before%20the%20suggestions%20branch%20to%20ensure%20it%20always%20fires%20for%20the%20six%20gated%20names.%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine%2Ftool_catalog.rs%3A461-471%0A**%60task_shell_cancel%60%20not%20registered%20anywhere%20in%20the%20codebase**%0A%0AEvery%20other%20name%20in%20this%20list%20%28%60exec_shell%60%2C%20%60exec_shell_wait%60%2C%20%60exec_shell_interact%60%2C%20%60task_shell_start%60%2C%20%60task_shell_wait%60%29%20appears%20in%20%60DEFAULT_ACTIVE_NATIVE_TOOLS%60%20and%20is%20referenced%20in%20the%20rest%20of%20the%20engine.%20%60task_shell_cancel%60%20appears%20only%20here%20%E2%80%94%20it%20is%20absent%20from%20%60DEFAULT_ACTIVE_NATIVE_TOOLS%60%2C%20has%20no%20tool%20spec%2C%20and%20has%20no%20other%20reference%20in%20the%20codebase.%20If%20this%20tool%20does%20not%20exist%2C%20the%20match%20arm%20is%20dead%20code%3B%20if%20it%20is%20planned%20but%20not%20yet%20shipped%2C%20a%20note%20in%20the%20source%20would%20clarify%20intent.%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine%2Ftests.rs%3A2311-2330%0A**Test%20only%20covers%20%60exec_shell%60%2C%20leaving%20five%20other%20shell%20names%20untested**%0A%0A%60is_shell_tool_name%60%20matches%20six%20names%2C%20but%20the%20test%20only%20calls%20%60missing_tool_error_message%28%22exec_shell%22%2C%20%E2%80%A6%29%60.%20The%20%60task_shell_*%60%20variants%20and%20%60exec_shell_wait%60%20%2F%20%60exec_shell_interact%60%20are%20never%20exercised.%20A%20future%20edit%20to%20%60is_shell_tool_name%60%20that%20accidentally%20removes%20one%20of%20those%20names%20would%20go%20undetected.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine%2Ftool_catalog.rs%3A437-459%0A**Shell%20gate%20hint%20silently%20dropped%20when%20suggestions%20exist**%0A%0A%60is_shell_tool_name%60%20is%20only%20checked%20inside%20%60if%20suggestions.is_empty%28%29%60.%20If%20the%20catalog%20contains%20any%20tool%20whose%20name%20is%20similar%20enough%20to%20a%20shell%20tool%20for%20%60suggest_tool_names%60%20to%20surface%20it%20%E2%80%94%20e.g.%20a%20tool%20literally%20named%20%60exec%60%20causes%20%60%22exec_shell%22.contains%28%22exec%22%29%60%20to%20be%20true%20%E2%80%94%20the%20user%20receives%20%22Did%20you%20mean%3A%20exec%3F%22%20with%20no%20mention%20of%20%60allow_shell%60.%20The%20%60allow_shell%60%20gate%20hint%20should%20be%20added%20to%20the%20suggestions%20branch%20as%20well%2C%20or%20%60is_shell_tool_name%60%20should%20be%20evaluated%20before%20the%20suggestions%20branch%20to%20ensure%20it%20always%20fires%20for%20the%20six%20gated%20names.%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine%2Ftool_catalog.rs%3A461-471%0A**%60task_shell_cancel%60%20not%20registered%20anywhere%20in%20the%20codebase**%0A%0AEvery%20other%20name%20in%20this%20list%20%28%60exec_shell%60%2C%20%60exec_shell_wait%60%2C%20%60exec_shell_interact%60%2C%20%60task_shell_start%60%2C%20%60task_shell_wait%60%29%20appears%20in%20%60DEFAULT_ACTIVE_NATIVE_TOOLS%60%20and%20is%20referenced%20in%20the%20rest%20of%20the%20engine.%20%60task_shell_cancel%60%20appears%20only%20here%20%E2%80%94%20it%20is%20absent%20from%20%60DEFAULT_ACTIVE_NATIVE_TOOLS%60%2C%20has%20no%20tool%20spec%2C%20and%20has%20no%20other%20reference%20in%20the%20codebase.%20If%20this%20tool%20does%20not%20exist%2C%20the%20match%20arm%20is%20dead%20code%3B%20if%20it%20is%20planned%20but%20not%20yet%20shipped%2C%20a%20note%20in%20the%20source%20would%20clarify%20intent.%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine%2Ftests.rs%3A2311-2330%0A**Test%20only%20covers%20%60exec_shell%60%2C%20leaving%20five%20other%20shell%20names%20untested**%0A%0A%60is_shell_tool_name%60%20matches%20six%20names%2C%20but%20the%20test%20only%20calls%20%60missing_tool_error_message%28%22exec_shell%22%2C%20%E2%80%A6%29%60.%20The%20%60task_shell_*%60%20variants%20and%20%60exec_shell_wait%60%20%2F%20%60exec_shell_interact%60%20are%20never%20exercised.%20A%20future%20edit%20to%20%60is_shell_tool_name%60%20that%20accidentally%20removes%20one%20of%20those%20names%20would%20go%20undetected.%0A%0A&repo=hmbown%2Fcodewhale&pr=2402&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine%2Ftool_catalog.rs%3A437-459%0A**Shell%20gate%20hint%20silently%20dropped%20when%20suggestions%20exist**%0A%0A%60is_shell_tool_name%60%20is%20only%20checked%20inside%20%60if%20suggestions.is_empty%28%29%60.%20If%20the%20catalog%20contains%20any%20tool%20whose%20name%20is%20similar%20enough%20to%20a%20shell%20tool%20for%20%60suggest_tool_names%60%20to%20surface%20it%20%E2%80%94%20e.g.%20a%20tool%20literally%20named%20%60exec%60%20causes%20%60%22exec_shell%22.contains%28%22exec%22%29%60%20to%20be%20true%20%E2%80%94%20the%20user%20receives%20%22Did%20you%20mean%3A%20exec%3F%22%20with%20no%20mention%20of%20%60allow_shell%60.%20The%20%60allow_shell%60%20gate%20hint%20should%20be%20added%20to%20the%20suggestions%20branch%20as%20well%2C%20or%20%60is_shell_tool_name%60%20should%20be%20evaluated%20before%20the%20suggestions%20branch%20to%20ensure%20it%20always%20fires%20for%20the%20six%20gated%20names.%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine%2Ftool_catalog.rs%3A461-471%0A**%60task_shell_cancel%60%20not%20registered%20anywhere%20in%20the%20codebase**%0A%0AEvery%20other%20name%20in%20this%20list%20%28%60exec_shell%60%2C%20%60exec_shell_wait%60%2C%20%60exec_shell_interact%60%2C%20%60task_shell_start%60%2C%20%60task_shell_wait%60%29%20appears%20in%20%60DEFAULT_ACTIVE_NATIVE_TOOLS%60%20and%20is%20referenced%20in%20the%20rest%20of%20the%20engine.%20%60task_shell_cancel%60%20appears%20only%20here%20%E2%80%94%20it%20is%20absent%20from%20%60DEFAULT_ACTIVE_NATIVE_TOOLS%60%2C%20has%20no%20tool%20spec%2C%20and%20has%20no%20other%20reference%20in%20the%20codebase.%20If%20this%20tool%20does%20not%20exist%2C%20the%20match%20arm%20is%20dead%20code%3B%20if%20it%20is%20planned%20but%20not%20yet%20shipped%2C%20a%20note%20in%20the%20source%20would%20clarify%20intent.%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine%2Ftests.rs%3A2311-2330%0A**Test%20only%20covers%20%60exec_shell%60%2C%20leaving%20five%20other%20shell%20names%20untested**%0A%0A%60is_shell_tool_name%60%20matches%20six%20names%2C%20but%20the%20test%20only%20calls%20%60missing_tool_error_message%28%22exec_shell%22%2C%20%E2%80%A6%29%60.%20The%20%60task_shell_*%60%20variants%20and%20%60exec_shell_wait%60%20%2F%20%60exec_shell_interact%60%20are%20never%20exercised.%20A%20future%20edit%20to%20%60is_shell_tool_name%60%20that%20accidentally%20removes%20one%20of%20those%20names%20would%20go%20undetected.%0A%0A&pr=2402&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(tui): clarify shell tool availabilit..."](https://github.com/hmbown/codewhale/commit/ed40a2ee84bbda16fdfdbad41a8fe64e61caef38) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34776990)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->