### PR TITLE
fix(tui): compact statusline token chip

### DIFF
--- a/crates/tui/src/tui/footer_ui.rs
+++ b/crates/tui/src/tui/footer_ui.rs
@@ -631,22 +631,16 @@ pub(crate) fn should_show_footer_cost(displayed_cost: f64) -> bool {
 
 /// Session token-usage chip for the footer right cluster.
 ///
-/// Renders the accumulated input / cache-hit / output token breakdown
-/// since the current runtime session started (not persisted across
-/// restarts). Returns empty when no tokens have been recorded yet.
+/// Renders a compact accumulated token count for the current runtime session.
+/// Detailed cache stats live in the separate `cache` chip.
 pub(crate) fn footer_session_tokens_spans(app: &App) -> Vec<Span<'static>> {
     let session = &app.session;
     if session.total_input_tokens == 0 && session.total_output_tokens == 0 {
         return Vec::new();
     }
-    let in_str = format_token_count_compact(u64::from(session.total_input_tokens));
-    let out_str = format_token_count_compact(u64::from(session.total_output_tokens));
-    let text = if session.total_cache_hit_tokens == 0 && session.total_cache_miss_tokens == 0 {
-        format!("{in_str} in · {out_str} out")
-    } else {
-        let cache_str = format_token_count_compact(u64::from(session.total_cache_hit_tokens));
-        format!("{in_str} in · {cache_str} cch · {out_str} out")
-    };
+    let total = u64::from(session.total_input_tokens)
+        .saturating_add(u64::from(session.total_output_tokens));
+    let text = format!("tok {}", format_token_count_compact(total));
     vec![Span::styled(text, Style::default().fg(palette::TEXT_MUTED))]
 }
 

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -10,8 +10,9 @@ use crate::tui::file_mention::{
 };
 use crate::tui::footer_ui::{
     active_tool_status_label, footer_auxiliary_spans, footer_balance_spans, footer_cache_spans,
-    footer_coherence_spans, footer_state_label, footer_status_line_spans, format_context_budget,
-    format_token_count_compact, friendly_subagent_progress, render_footer_from,
+    footer_coherence_spans, footer_session_tokens_spans, footer_state_label,
+    footer_status_line_spans, format_context_budget, format_token_count_compact,
+    friendly_subagent_progress, render_footer_from,
 };
 use crate::tui::history::{
     ExecCell, ExecSource, GenericToolCell, HistoryCell, ToolCell, ToolStatus,
@@ -2419,6 +2420,21 @@ fn format_token_count_compact_formats_units() {
     assert_eq!(format_token_count_compact(999), "999");
     assert_eq!(format_token_count_compact(1_200), "1.2k");
     assert_eq!(format_token_count_compact(1_000_000), "1.0M");
+}
+
+#[test]
+fn footer_session_tokens_chip_uses_single_compact_total() {
+    let mut app = create_test_app();
+    app.session.total_input_tokens = 1_400_000;
+    app.session.total_cache_hit_tokens = 1_200_000;
+    app.session.total_cache_miss_tokens = 200_000;
+    app.session.total_output_tokens = 7_600;
+
+    let text = spans_text(&footer_session_tokens_spans(&app));
+
+    assert_eq!(text, "tok 1.4M");
+    assert!(!text.contains(" cch "));
+    assert!(!text.contains(" out"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- compact the `tokens` statusline chip to a single cumulative token count like `tok 1.4M`
- stop duplicating cache-hit details in the tokens chip because the footer already has a dedicated `cache` chip
- add a regression test that locks the compact output and ensures `cch/out` details stay out of the token chip

Partially addresses #2309

## Validation
- `cargo test -p codewhale-tui --bin codewhale-tui footer_session_tokens_chip_uses_single_compact_total --locked`
- `cargo check -p codewhale-tui --locked`
- `git diff --check`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR compacts the footer token chip from a verbose `in · cch · out` breakdown down to a single `tok 1.4M` cumulative figure, delegating cache detail to the dedicated `cache` chip. A regression test locks the new format and asserts the old `cch`/`out` substrings no longer appear.

- `footer_session_tokens_spans` now sums `total_input_tokens + total_output_tokens` via `saturating_add` and formats the result with the existing `format_token_count_compact` helper, removing all cache-specific branches.
- The new test `footer_session_tokens_chip_uses_single_compact_total` verifies the exact output string and negatively asserts against the legacy format tokens.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the implementation correctly sums input and output tokens (cache tokens are already a subset of input, not additive), and the format change is purely cosmetic.

The core logic is sound and the refactor is narrow. The only observation is that the new regression test uses token values that happen to collapse to the same display string whether or not output tokens are included, so it doesn't fully lock the input + output contract it was written to guard.

crates/tui/src/tui/ui/tests.rs — the new test's input values could be improved to actually verify the output-token contribution.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/footer_ui.rs | Token chip simplified to input+output sum; logic is correct since cache tokens are a subset of input tokens, not additive. |
| crates/tui/src/tui/ui/tests.rs | New regression test locks the compact format and asserts absence of legacy cache substrings; chosen values make it impossible to detect if output tokens were accidentally dropped from the sum. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["footer_session_tokens_spans(app)"] --> B{"input == 0 AND output == 0?"}
    B -- yes --> C["return Vec::new() (chip hidden)"]
    B -- no --> D["total = total_input_tokens.saturating_add(total_output_tokens)"]
    D --> E["format_token_count_compact(total)"]
    E --> F{{"total >= 1_000_000?"}}
    F -- yes --> G["format: '{:.1}M'"]
    F -- no --> H{{"total >= 1_000?"}}
    H -- yes --> I["format: '{:.1}k'"]
    H -- no --> J["format: raw number"]
    G & I & J --> K["Span::styled('tok {result}', TEXT_MUTED)"]
    K --> L["render in footer Tokens chip slot"]
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22codex%2Fstatusline-compact-tokens%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fstatusline-compact-tokens%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui%2Ftests.rs%3A2426-2438%0A**Test%20values%20don't%20distinguish%20input-only%20from%20input%2Boutput%20sum**%0A%0AThe%20chosen%20values%20%28%60total_input_tokens%20%3D%201_400_000%60%2C%20%60total_output_tokens%20%3D%207_600%60%29%20both%20round%20to%20%60%221.4M%22%60%20at%20one%20decimal%20place%2C%20so%20this%20assertion%20would%20still%20pass%20even%20if%20%60total_output_tokens%60%20were%20silently%20dropped%20from%20the%20sum%20in%20%60footer_session_tokens_spans%60.%20A%20value%20pair%20where%20output%20tokens%20shift%20the%20display%20unit%E2%80%94e.g.%20%60total_input_tokens%20%3D%20900_000%60%20%2B%20%60total_output_tokens%20%3D%20600_000%60%20expecting%20%60%221.5M%22%60%E2%80%94would%20make%20the%20test%20fail%20if%20only%20input%20is%20summed%2C%20actually%20locking%20the%20full%20%60input%20%2B%20output%60%20contract%20the%20PR%20intends.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui%2Ftests.rs%3A2426-2438%0A**Test%20values%20don't%20distinguish%20input-only%20from%20input%2Boutput%20sum**%0A%0AThe%20chosen%20values%20%28%60total_input_tokens%20%3D%201_400_000%60%2C%20%60total_output_tokens%20%3D%207_600%60%29%20both%20round%20to%20%60%221.4M%22%60%20at%20one%20decimal%20place%2C%20so%20this%20assertion%20would%20still%20pass%20even%20if%20%60total_output_tokens%60%20were%20silently%20dropped%20from%20the%20sum%20in%20%60footer_session_tokens_spans%60.%20A%20value%20pair%20where%20output%20tokens%20shift%20the%20display%20unit%E2%80%94e.g.%20%60total_input_tokens%20%3D%20900_000%60%20%2B%20%60total_output_tokens%20%3D%20600_000%60%20expecting%20%60%221.5M%22%60%E2%80%94would%20make%20the%20test%20fail%20if%20only%20input%20is%20summed%2C%20actually%20locking%20the%20full%20%60input%20%2B%20output%60%20contract%20the%20PR%20intends.%0A%0A&repo=hmbown%2Fcodewhale&pr=2405&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui%2Ftests.rs%3A2426-2438%0A**Test%20values%20don't%20distinguish%20input-only%20from%20input%2Boutput%20sum**%0A%0AThe%20chosen%20values%20%28%60total_input_tokens%20%3D%201_400_000%60%2C%20%60total_output_tokens%20%3D%207_600%60%29%20both%20round%20to%20%60%221.4M%22%60%20at%20one%20decimal%20place%2C%20so%20this%20assertion%20would%20still%20pass%20even%20if%20%60total_output_tokens%60%20were%20silently%20dropped%20from%20the%20sum%20in%20%60footer_session_tokens_spans%60.%20A%20value%20pair%20where%20output%20tokens%20shift%20the%20display%20unit%E2%80%94e.g.%20%60total_input_tokens%20%3D%20900_000%60%20%2B%20%60total_output_tokens%20%3D%20600_000%60%20expecting%20%60%221.5M%22%60%E2%80%94would%20make%20the%20test%20fail%20if%20only%20input%20is%20summed%2C%20actually%20locking%20the%20full%20%60input%20%2B%20output%60%20contract%20the%20PR%20intends.%0A%0A&pr=2405&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(tui): compact statusline token chip"](https://github.com/hmbown/codewhale/commit/1bef334917f41d02997c747ae50d78e9cdc2babc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34778194)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->