### PR TITLE
feat(tui): expose auto route in turn metadata

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -910,7 +910,13 @@ impl Engine {
         self.emit_session_updated().await;
     }
 
-    fn turn_metadata_block(&self) -> ContentBlock {
+    fn turn_metadata_block(
+        &self,
+        routed_model: &str,
+        auto_model: bool,
+        reasoning_effort: Option<&str>,
+        reasoning_effort_auto: bool,
+    ) -> ContentBlock {
         let today = chrono::Local::now().format("%Y-%m-%d").to_string();
         let working_set_summary = self
             .session
@@ -919,11 +925,17 @@ impl Engine {
             .map(|s| s.trim().to_string())
             .filter(|s| !s.is_empty());
 
-        let summary = if let Some(working_set_summary) = working_set_summary {
-            format!("Current local date: {today}\n{working_set_summary}")
-        } else {
-            format!("Current local date: {today}")
-        };
+        let mut lines = vec![format!("Current local date: {today}")];
+        if auto_model {
+            lines.push(format!("Auto model route: {routed_model}"));
+        }
+        if reasoning_effort_auto && let Some(reasoning_effort) = reasoning_effort {
+            lines.push(format!("Auto reasoning effort: {reasoning_effort}"));
+        }
+        if let Some(working_set_summary) = working_set_summary {
+            lines.push(working_set_summary);
+        }
+        let summary = lines.join("\n");
 
         ContentBlock::Text {
             text: format!("<turn_meta>\n{summary}\n</turn_meta>"),
@@ -932,10 +944,32 @@ impl Engine {
     }
 
     fn user_text_message_with_turn_metadata(&self, text: String) -> Message {
+        self.user_text_message_with_turn_metadata_for_route(
+            text,
+            &self.session.model,
+            self.session.auto_model,
+            self.session.reasoning_effort.as_deref(),
+            self.session.reasoning_effort_auto,
+        )
+    }
+
+    fn user_text_message_with_turn_metadata_for_route(
+        &self,
+        text: String,
+        routed_model: &str,
+        auto_model: bool,
+        reasoning_effort: Option<&str>,
+        reasoning_effort_auto: bool,
+    ) -> Message {
         Message {
             role: "user".to_string(),
             content: vec![
-                self.turn_metadata_block(),
+                self.turn_metadata_block(
+                    routed_model,
+                    auto_model,
+                    reasoning_effort,
+                    reasoning_effort_auto,
+                ),
                 ContentBlock::Text {
                     text,
                     cache_control: None,
@@ -1041,7 +1075,13 @@ impl Engine {
         let force_update_plan_first = should_force_update_plan_first(mode, &content);
 
         // Add user message to session
-        let user_msg = self.user_text_message_with_turn_metadata(content);
+        let user_msg = self.user_text_message_with_turn_metadata_for_route(
+            content,
+            &model,
+            auto_model,
+            reasoning_effort.as_deref(),
+            reasoning_effort_auto,
+        );
         self.session.add_message(user_msg);
 
         let previous_goal_objective = self.config.goal_objective.clone();

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -1443,6 +1443,32 @@ fn turn_metadata_includes_current_local_date_without_working_set() {
 }
 
 #[test]
+fn turn_metadata_includes_auto_model_route() {
+    let tmp = tempdir().expect("tempdir");
+    let config = EngineConfig {
+        workspace: tmp.path().to_path_buf(),
+        ..Default::default()
+    };
+    let (engine, _handle) = Engine::new(config, &Config::default());
+
+    let user_msg = engine.user_text_message_with_turn_metadata_for_route(
+        "debug this regression".to_string(),
+        "deepseek-v4-pro",
+        true,
+        Some("max"),
+        true,
+    );
+    let first_block = user_msg.content.first().expect("turn metadata block");
+    let ContentBlock::Text { text, .. } = first_block else {
+        panic!("expected text metadata block");
+    };
+
+    assert!(text.contains("Auto model route: deepseek-v4-pro"));
+    assert!(text.contains("Auto reasoning effort: max"));
+    assert!(!text.contains("debug this regression"));
+}
+
+#[test]
 fn user_text_message_keeps_current_turn_input_after_turn_metadata() {
     let tmp = tempdir().expect("tempdir");
     let config = EngineConfig {


### PR DESCRIPTION
## Summary
- include the concrete auto-selected model in each turn's `<turn_meta>` block when `--model auto` is active
- include auto-selected reasoning effort in the same metadata when reasoning effort is controlled automatically
- keep the raw user prompt in its separate text block, with a regression test that the route metadata does not duplicate user text

Partially addresses #2380

## Validation
- `cargo test -p codewhale-tui --bin codewhale-tui turn_metadata_includes_auto_model_route --locked`
- `cargo check -p codewhale-tui --locked`
- `git diff --check`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR exposes the auto-selected model and reasoning effort in each turn's `<turn_meta>` block when `--model auto` is active. The implementation refactors `user_text_message_with_turn_metadata` into a parameterized `_for_route` variant and updates `handle_send_message` to pass the resolved route values at message-construction time — before they are stored in `self.session`.

- `turn_metadata_block` gains four new parameters (`routed_model`, `auto_model`, `reasoning_effort`, `reasoning_effort_auto`) and conditionally appends `Auto model route` / `Auto reasoning effort` lines.
- `user_text_message_with_turn_metadata` becomes a thin wrapper delegating to the new `_for_route` method, preserving existing callers and tests.
- A new test (`turn_metadata_includes_auto_model_route`) verifies that the route appears in the first content block and is not duplicated in the user-text block.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the changes are additive and well-isolated to metadata construction.

The refactor is straightforward: route parameters flow from handle_send_message arguments directly into the new _for_route method before the session state is updated, so the metadata always reflects the current turn's resolved model. The only findings are two inline comments that still name the old helper function after the rename — harmless at runtime but worth fixing for readability.

No files require special attention; both changed files are in good shape.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/tui/src/core/engine.rs | Core change: turn_metadata_block and user_text_message_with_turn_metadata refactored to accept route parameters; handle_send_message updated to call the _for_route variant. Two inline comments still reference the old function name after the rename. |
| crates/tui/src/core/engine/tests.rs | New test turn_metadata_includes_auto_model_route covers the happy-path (both auto flags true) and the user-text isolation assertion; existing tests continue to exercise the non-auto path through the wrapper. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as TUI / runtime_threads
    participant Engine as Engine::handle_send_message
    participant Meta as turn_metadata_block
    participant Session as self.session

    UI->>Engine: "Op::SendMessage { model: effective_model, auto_model, reasoning_effort, reasoning_effort_auto }"
    Engine->>Meta: turn_metadata_block(routed_model, auto_model, reasoning_effort, reasoning_effort_auto)
    Note over Meta: if auto_model → append Auto model route
    Note over Meta: if reasoning_effort_auto && effort.is_some() → append Auto reasoning effort
    Meta-->>Engine: ContentBlock::Text with turn_meta XML
    Engine->>Session: add_message([turn_meta block, user text block])
    Engine->>Session: "session.model = model (resolved route stored for next turn)"
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `crates/tui/src/core/engine.rs`, line 1025-1027 ([link](https://github.com/hmbown/codewhale/blob/68c43bcfe28c40142934b8ab59ebbba94c8c047b/crates/tui/src/core/engine.rs#L1025-L1027)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> These two inline comments still name `user_text_message_with_turn_metadata` but the actual call site was replaced with `user_text_message_with_turn_metadata_for_route` in this PR. A reader following the comment to find the ownership transfer will look for the wrong function.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22codex%2Fauto-route-turn-meta%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fauto-route-turn-meta%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fcore%2Fengine.rs%0ALine%3A%201025-1027%0A%0AComment%3A%0AThese%20two%20inline%20comments%20still%20name%20%60user_text_message_with_turn_metadata%60%20but%20the%20actual%20call%20site%20was%20replaced%20with%20%60user_text_message_with_turn_metadata_for_route%60%20in%20this%20PR.%20A%20reader%20following%20the%20comment%20to%20find%20the%20ownership%20transfer%20will%20look%20for%20the%20wrong%20function.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Clone%20the%20user%20prompt%20now%20%E2%80%94%20%60content%60%20is%20moved%20into%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20%60user_text_message_with_turn_metadata_for_route%60%20below%2C%20so%20we%20need%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20a%20copy%20for%20both%20pre-%20and%20post-turn%20snapshot%20labels.%20The%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fcore%2Fengine.rs%0ALine%3A%201025-1027%0A%0AComment%3A%0AThese%20two%20inline%20comments%20still%20name%20%60user_text_message_with_turn_metadata%60%20but%20the%20actual%20call%20site%20was%20replaced%20with%20%60user_text_message_with_turn_metadata_for_route%60%20in%20this%20PR.%20A%20reader%20following%20the%20comment%20to%20find%20the%20ownership%20transfer%20will%20look%20for%20the%20wrong%20function.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Clone%20the%20user%20prompt%20now%20%E2%80%94%20%60content%60%20is%20moved%20into%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20%60user_text_message_with_turn_metadata_for_route%60%20below%2C%20so%20we%20need%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20a%20copy%20for%20both%20pre-%20and%20post-turn%20snapshot%20labels.%20The%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2406&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fcore%2Fengine.rs%0ALine%3A%201025-1027%0A%0AComment%3A%0AThese%20two%20inline%20comments%20still%20name%20%60user_text_message_with_turn_metadata%60%20but%20the%20actual%20call%20site%20was%20replaced%20with%20%60user_text_message_with_turn_metadata_for_route%60%20in%20this%20PR.%20A%20reader%20following%20the%20comment%20to%20find%20the%20ownership%20transfer%20will%20look%20for%20the%20wrong%20function.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Clone%20the%20user%20prompt%20now%20%E2%80%94%20%60content%60%20is%20moved%20into%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20%60user_text_message_with_turn_metadata_for_route%60%20below%2C%20so%20we%20need%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20a%20copy%20for%20both%20pre-%20and%20post-turn%20snapshot%20labels.%20The%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2406&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>


2. `crates/tui/src/core/engine.rs`, line 1046-1047 ([link](https://github.com/hmbown/codewhale/blob/68c43bcfe28c40142934b8ab59ebbba94c8c047b/crates/tui/src/core/engine.rs#L1046-L1047)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Same stale reference: `content` is now moved into `user_text_message_with_turn_metadata_for_route`, not the old wrapper name.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22codex%2Fauto-route-turn-meta%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fauto-route-turn-meta%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fcore%2Fengine.rs%0ALine%3A%201046-1047%0A%0AComment%3A%0ASame%20stale%20reference%3A%20%60content%60%20is%20now%20moved%20into%20%60user_text_message_with_turn_metadata_for_route%60%2C%20not%20the%20old%20wrapper%20name.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Clone%20user%20prompt%20for%20post-turn%20snapshot%20label%20before%20%60content%60%0A%20%20%20%20%20%20%20%20%2F%2F%20is%20moved%20into%20%60user_text_message_with_turn_metadata_for_route%60%20below.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fcore%2Fengine.rs%0ALine%3A%201046-1047%0A%0AComment%3A%0ASame%20stale%20reference%3A%20%60content%60%20is%20now%20moved%20into%20%60user_text_message_with_turn_metadata_for_route%60%2C%20not%20the%20old%20wrapper%20name.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Clone%20user%20prompt%20for%20post-turn%20snapshot%20label%20before%20%60content%60%0A%20%20%20%20%20%20%20%20%2F%2F%20is%20moved%20into%20%60user_text_message_with_turn_metadata_for_route%60%20below.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2406&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fcore%2Fengine.rs%0ALine%3A%201046-1047%0A%0AComment%3A%0ASame%20stale%20reference%3A%20%60content%60%20is%20now%20moved%20into%20%60user_text_message_with_turn_metadata_for_route%60%2C%20not%20the%20old%20wrapper%20name.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Clone%20user%20prompt%20for%20post-turn%20snapshot%20label%20before%20%60content%60%0A%20%20%20%20%20%20%20%20%2F%2F%20is%20moved%20into%20%60user_text_message_with_turn_metadata_for_route%60%20below.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2406&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22codex%2Fauto-route-turn-meta%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fauto-route-turn-meta%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine.rs%3A1025-1027%0AThese%20two%20inline%20comments%20still%20name%20%60user_text_message_with_turn_metadata%60%20but%20the%20actual%20call%20site%20was%20replaced%20with%20%60user_text_message_with_turn_metadata_for_route%60%20in%20this%20PR.%20A%20reader%20following%20the%20comment%20to%20find%20the%20ownership%20transfer%20will%20look%20for%20the%20wrong%20function.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Clone%20the%20user%20prompt%20now%20%E2%80%94%20%60content%60%20is%20moved%20into%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20%60user_text_message_with_turn_metadata_for_route%60%20below%2C%20so%20we%20need%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20a%20copy%20for%20both%20pre-%20and%20post-turn%20snapshot%20labels.%20The%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine.rs%3A1046-1047%0ASame%20stale%20reference%3A%20%60content%60%20is%20now%20moved%20into%20%60user_text_message_with_turn_metadata_for_route%60%2C%20not%20the%20old%20wrapper%20name.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Clone%20user%20prompt%20for%20post-turn%20snapshot%20label%20before%20%60content%60%0A%20%20%20%20%20%20%20%20%2F%2F%20is%20moved%20into%20%60user_text_message_with_turn_metadata_for_route%60%20below.%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine.rs%3A1025-1027%0AThese%20two%20inline%20comments%20still%20name%20%60user_text_message_with_turn_metadata%60%20but%20the%20actual%20call%20site%20was%20replaced%20with%20%60user_text_message_with_turn_metadata_for_route%60%20in%20this%20PR.%20A%20reader%20following%20the%20comment%20to%20find%20the%20ownership%20transfer%20will%20look%20for%20the%20wrong%20function.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Clone%20the%20user%20prompt%20now%20%E2%80%94%20%60content%60%20is%20moved%20into%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20%60user_text_message_with_turn_metadata_for_route%60%20below%2C%20so%20we%20need%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20a%20copy%20for%20both%20pre-%20and%20post-turn%20snapshot%20labels.%20The%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine.rs%3A1046-1047%0ASame%20stale%20reference%3A%20%60content%60%20is%20now%20moved%20into%20%60user_text_message_with_turn_metadata_for_route%60%2C%20not%20the%20old%20wrapper%20name.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Clone%20user%20prompt%20for%20post-turn%20snapshot%20label%20before%20%60content%60%0A%20%20%20%20%20%20%20%20%2F%2F%20is%20moved%20into%20%60user_text_message_with_turn_metadata_for_route%60%20below.%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2406&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine.rs%3A1025-1027%0AThese%20two%20inline%20comments%20still%20name%20%60user_text_message_with_turn_metadata%60%20but%20the%20actual%20call%20site%20was%20replaced%20with%20%60user_text_message_with_turn_metadata_for_route%60%20in%20this%20PR.%20A%20reader%20following%20the%20comment%20to%20find%20the%20ownership%20transfer%20will%20look%20for%20the%20wrong%20function.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Clone%20the%20user%20prompt%20now%20%E2%80%94%20%60content%60%20is%20moved%20into%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20%60user_text_message_with_turn_metadata_for_route%60%20below%2C%20so%20we%20need%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20a%20copy%20for%20both%20pre-%20and%20post-turn%20snapshot%20labels.%20The%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine.rs%3A1046-1047%0ASame%20stale%20reference%3A%20%60content%60%20is%20now%20moved%20into%20%60user_text_message_with_turn_metadata_for_route%60%2C%20not%20the%20old%20wrapper%20name.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Clone%20user%20prompt%20for%20post-turn%20snapshot%20label%20before%20%60content%60%0A%20%20%20%20%20%20%20%20%2F%2F%20is%20moved%20into%20%60user_text_message_with_turn_metadata_for_route%60%20below.%0A%60%60%60%0A%0A&pr=2406&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(tui): expose auto route in turn met..."](https://github.com/hmbown/codewhale/commit/68c43bcfe28c40142934b8ab59ebbba94c8c047b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34778739)</sub>

<!-- /greptile_comment -->