### PR TITLE
docs: add macos python FAQ

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -453,6 +453,31 @@ Approvals are part of the safety model. Shell commands, paid tools, writes, and
 actions outside the expected workspace can have side effects. Approval prompts
 let you keep control while still letting the model do useful work.
 
+### How do I run a Python file on macOS?
+
+Open Terminal in the folder that contains the file and run:
+
+```bash
+python3 your_file.py
+```
+
+If macOS says `python3` is missing, install Python from
+[python.org](https://www.python.org/downloads/macos/) or with Homebrew:
+
+```bash
+brew install python
+```
+
+Inside CodeWhale, ask the agent to inspect the file and run it with
+`python3 your_file.py`. If the script needs packages, install them in a virtual
+environment first:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+python3 -m pip install -r requirements.txt
+```
+
 ### Where is my config stored?
 
 New CodeWhale config uses `~/.codewhale/config.toml`. Legacy


### PR DESCRIPTION
## Summary
- add a FAQ entry for running Python files on macOS with `python3`
- point first-time users to python.org/Homebrew installation options
- include a minimal virtualenv flow for scripts with dependencies and explain how to ask CodeWhale to run the script

Addresses #2351

## Validation
- `git diff --check`
- `rg -n "How do I run a Python file on macOS|python3 your_file.py|brew install python" docs\GUIDE.md`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a new FAQ entry to `docs/GUIDE.md` for first-time macOS users asking how to run a Python script with CodeWhale, covering the `python3` invocation, installation via python.org or Homebrew, and a virtualenv setup for scripts with dependencies.

- The core instructions and installation guidance are accurate and well-placed in the existing FAQ structure.
- The virtualenv code block ends at `pip install -r requirements.txt` without a final `python3 your_file.py` step, leaving the \"with dependencies\" flow incomplete for a first-time reader.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change is documentation-only and introduces no runtime risk.

The new FAQ entry is accurate and well-structured, but the virtualenv walkthrough ends one step short — it never shows the user how to actually run the script after setting up the environment. A first-time reader following the guide would be left with an activated venv and no obvious next step.

docs/GUIDE.md — the virtualenv code block needs a final `python3 your_file.py` line to complete the flow.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/GUIDE.md | Adds a new macOS Python FAQ entry covering basic execution, installation via python.org/Homebrew, and a virtualenv flow; the venv block is missing its final run step. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User wants to run a Python file on macOS] --> B{python3 available?}
    B -- Yes --> C[python3 your_file.py]
    B -- No --> D{Install Python}
    D --> E[python.org download]
    D --> F[brew install python]
    E --> C
    F --> C
    C --> G{Script needs packages?}
    G -- No --> H[Done ✓]
    G -- Yes --> I[python3 -m venv .venv]
    I --> J[source .venv/bin/activate]
    J --> K[python3 -m pip install -r requirements.txt]
    K --> L[python3 your_file.py ⚠️ missing from guide]
    L --> H
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22codex%2Fmacos-python-faq%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fmacos-python-faq%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2FGUIDE.md%3A476-479%0AAfter%20activating%20the%20venv%20and%20installing%20requirements%2C%20the%20guide%20should%20show%20the%20user%20how%20to%20actually%20run%20their%20script%20%E2%80%94%20otherwise%20the%20flow%20is%20left%20incomplete.%0A%0A%60%60%60suggestion%0Apython3%20-m%20venv%20.venv%0Asource%20.venv%2Fbin%2Factivate%0Apython3%20-m%20pip%20install%20-r%20requirements.txt%0Apython3%20your_file.py%0A%60%60%60%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2FGUIDE.md%3A476-479%0AAfter%20activating%20the%20venv%20and%20installing%20requirements%2C%20the%20guide%20should%20show%20the%20user%20how%20to%20actually%20run%20their%20script%20%E2%80%94%20otherwise%20the%20flow%20is%20left%20incomplete.%0A%0A%60%60%60suggestion%0Apython3%20-m%20venv%20.venv%0Asource%20.venv%2Fbin%2Factivate%0Apython3%20-m%20pip%20install%20-r%20requirements.txt%0Apython3%20your_file.py%0A%60%60%60%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2407&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2FGUIDE.md%3A476-479%0AAfter%20activating%20the%20venv%20and%20installing%20requirements%2C%20the%20guide%20should%20show%20the%20user%20how%20to%20actually%20run%20their%20script%20%E2%80%94%20otherwise%20the%20flow%20is%20left%20incomplete.%0A%0A%60%60%60suggestion%0Apython3%20-m%20venv%20.venv%0Asource%20.venv%2Fbin%2Factivate%0Apython3%20-m%20pip%20install%20-r%20requirements.txt%0Apython3%20your_file.py%0A%60%60%60%0A%60%60%60%0A%0A&pr=2407&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs: add macos python FAQ"](https://github.com/hmbown/codewhale/commit/58e5c43e5af161c6b237e56de9b4934d0c210aca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34778828)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->