### PR TITLE
test(shell): cover tty controlling terminal

### DIFF
--- a/crates/tui/src/tools/shell/tests.rs
+++ b/crates/tui/src/tools/shell/tests.rs
@@ -242,6 +242,40 @@ fn test_write_stdin_streams_output() {
 }
 
 #[test]
+#[cfg(unix)]
+fn background_tty_command_has_controlling_terminal() {
+    let tmp = tempdir().expect("tempdir");
+    let mut manager = ShellManager::new(tmp.path().to_path_buf());
+
+    let result = manager
+        .execute_with_options(
+            "sh -c 'exec 3<>/dev/tty && printf tty-ok && exec 3>&-'",
+            None,
+            5000,
+            true,
+            None,
+            true,
+            Some(ExecutionSandboxPolicy::DangerFullAccess),
+        )
+        .expect("execute tty command");
+
+    let task_id = result
+        .task_id
+        .expect("background tty execution should return task_id");
+
+    let done = manager
+        .get_output(&task_id, true, 5000)
+        .expect("get tty command output");
+
+    assert_eq!(done.status, ShellStatus::Completed);
+    assert_eq!(done.exit_code, Some(0));
+    assert!(
+        done.stdout.contains("tty-ok"),
+        "tty output should confirm /dev/tty opened; got {done:?}"
+    );
+}
+
+#[test]
 fn test_job_list_poll_cancel_and_stale_snapshot() {
     let tmp = tempdir().expect("tempdir");
     let mut manager = ShellManager::new(tmp.path().to_path_buf());


### PR DESCRIPTION
## Summary
- add a Unix regression test for `tty=true` background shell jobs opening `/dev/tty`
- exercise the same shell-manager path used by `task_shell_start` with `DangerFullAccess`, so controlling-terminal setup failures are caught in CI

Partially addresses #2372

## Validation
- `cargo test -p codewhale-tui --bin codewhale-tui background_tty_command_has_controlling_terminal --locked` (Windows host: compiles test binary; Unix test is cfg-gated)
- `cargo check -p codewhale-tui --locked`
- `git diff --check`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a Unix-only regression test for `tty=true` background shell jobs, verifying that the shell manager's PTY setup gives the spawned process a proper controlling terminal so that `exec 3</dev/tty` succeeds.

- A new `background_tty_command_has_controlling_terminal` test (gated with `#[cfg(unix)]`) runs a short `sh -c` command that opens `/dev/tty` on fd 3 and emits `tty-ok` to stdout, then asserts `Completed`/exit-0/`tty-ok` in output — covering the same `spawn_background_sandboxed` + PTY path used by production `task_shell_start` with `DangerFullAccess`.
- No production code changes; test-only addition consistent with the surrounding test module's existing patterns.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Test-only change with no production code touched; safe to merge.

The new test is logically correct: `tty=true` allocates a PTY, the process is spawned on the slave, `printf tty-ok` goes through the PTY master reader thread into `stdout_buffer`, and all three assertions (status, exit code, stdout content) are appropriate. The one minor concern is that both the background-job execution timeout and the `get_output` polling deadline are set to the same 5000 ms value, leaving no margin if the PTY teardown is slow on a loaded CI runner — but for a command this short it is unlikely to matter in practice.

Only `crates/tui/src/tools/shell/tests.rs` changed; no production files require attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tools/shell/tests.rs | Adds one new Unix-gated test; logic is sound, one minor concern about the `get_output` wait timeout matching the command execution timeout exactly. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Test
    participant ShellManager
    participant PTY as PTY (master/slave)
    participant Shell as sh -c '...' (slave)
    participant ReaderThread

    Test->>ShellManager: "execute_with_options(tty=true, background=true)"
    ShellManager->>PTY: openpty()
    ShellManager->>Shell: spawn_command on slave
    ShellManager->>PTY: drop(slave fd)
    ShellManager->>ReaderThread: spawn reader on master
    ShellManager-->>Test: "ShellResult { task_id }"

    Test->>ShellManager: "get_output(task_id, wait=true, 5000ms)"

    Shell->>PTY: "exec 3<>/dev/tty"
    Shell->>PTY: printf tty-ok → fd1 (PTY slave)
    Shell->>PTY: "exec 3>&- (close fd3)"
    Shell->>PTY: exit 0

    PTY->>ReaderThread: forward output + EOF
    ReaderThread->>ShellManager: stdout_buffer ← tty-ok

    ShellManager->>ShellManager: poll() detects exit
    ShellManager-->>Test: "ShellResult { Completed, exit_code=0, stdout=tty-ok }"
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22codex%2Ftty-controlling-terminal-test%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Ftty-controlling-terminal-test%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftools%2Fshell%2Ftests.rs%3A267-268%0A**%60get_output%60%20wait%20window%20equals%20the%20command%20execution%20timeout**%0A%0ABoth%20the%20command%20timeout%20passed%20to%20%60execute_with_options%60%20%285000%20ms%29%20and%20the%20%60get_output%60%20poll%20deadline%20%285000%20ms%29%20are%20identical.%20Looking%20at%20%60get_output%60%2C%20it%20polls%20in%20100%20ms%20increments%20and%20returns%20a%20%60Running%60%20snapshot%20if%20the%20deadline%20passes%20without%20the%20process%20finishing%20%E2%80%94%20so%20if%20the%20command%20were%20to%20linger%20close%20to%205%20s%20%28e.g.%2C%20slow%20PTY%20teardown%20under%20CI%20load%29%2C%20the%20assertion%20on%20%60ShellStatus%3A%3ACompleted%60%20could%20fail%20spuriously.%20The%20sibling%20%60test_orphaned_subprocess_does_not_block_collect_output%60%20uses%203%20000%20ms%20for%20%60get_output%60%20against%20a%205%20000%20ms%20command%20timeout%2C%20which%20gives%20the%20poller%20room.%20Giving%20%60get_output%60%20a%20larger%20margin%20%28e.g.%2C%2010%20000%20ms%29%20would%20make%20this%20test%20more%20robust%20on%20loaded%20runners.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftools%2Fshell%2Ftests.rs%3A267-268%0A**%60get_output%60%20wait%20window%20equals%20the%20command%20execution%20timeout**%0A%0ABoth%20the%20command%20timeout%20passed%20to%20%60execute_with_options%60%20%285000%20ms%29%20and%20the%20%60get_output%60%20poll%20deadline%20%285000%20ms%29%20are%20identical.%20Looking%20at%20%60get_output%60%2C%20it%20polls%20in%20100%20ms%20increments%20and%20returns%20a%20%60Running%60%20snapshot%20if%20the%20deadline%20passes%20without%20the%20process%20finishing%20%E2%80%94%20so%20if%20the%20command%20were%20to%20linger%20close%20to%205%20s%20%28e.g.%2C%20slow%20PTY%20teardown%20under%20CI%20load%29%2C%20the%20assertion%20on%20%60ShellStatus%3A%3ACompleted%60%20could%20fail%20spuriously.%20The%20sibling%20%60test_orphaned_subprocess_does_not_block_collect_output%60%20uses%203%20000%20ms%20for%20%60get_output%60%20against%20a%205%20000%20ms%20command%20timeout%2C%20which%20gives%20the%20poller%20room.%20Giving%20%60get_output%60%20a%20larger%20margin%20%28e.g.%2C%2010%20000%20ms%29%20would%20make%20this%20test%20more%20robust%20on%20loaded%20runners.%0A%0A&repo=hmbown%2Fcodewhale&pr=2408&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftools%2Fshell%2Ftests.rs%3A267-268%0A**%60get_output%60%20wait%20window%20equals%20the%20command%20execution%20timeout**%0A%0ABoth%20the%20command%20timeout%20passed%20to%20%60execute_with_options%60%20%285000%20ms%29%20and%20the%20%60get_output%60%20poll%20deadline%20%285000%20ms%29%20are%20identical.%20Looking%20at%20%60get_output%60%2C%20it%20polls%20in%20100%20ms%20increments%20and%20returns%20a%20%60Running%60%20snapshot%20if%20the%20deadline%20passes%20without%20the%20process%20finishing%20%E2%80%94%20so%20if%20the%20command%20were%20to%20linger%20close%20to%205%20s%20%28e.g.%2C%20slow%20PTY%20teardown%20under%20CI%20load%29%2C%20the%20assertion%20on%20%60ShellStatus%3A%3ACompleted%60%20could%20fail%20spuriously.%20The%20sibling%20%60test_orphaned_subprocess_does_not_block_collect_output%60%20uses%203%20000%20ms%20for%20%60get_output%60%20against%20a%205%20000%20ms%20command%20timeout%2C%20which%20gives%20the%20poller%20room.%20Giving%20%60get_output%60%20a%20larger%20margin%20%28e.g.%2C%2010%20000%20ms%29%20would%20make%20this%20test%20more%20robust%20on%20loaded%20runners.%0A%0A&pr=2408&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["test(shell): cover tty controlling termi..."](https://github.com/hmbown/codewhale/commit/a66196d62bcfccf0e1c65ce78404322d18534b84) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34779409)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->