### PR TITLE
fix(tui): compact statusline token chip

### DIFF
--- a/crates/tui/src/tui/footer_ui.rs
+++ b/crates/tui/src/tui/footer_ui.rs
@@ -631,22 +631,16 @@ pub(crate) fn should_show_footer_cost(displayed_cost: f64) -> bool {
 
 /// Session token-usage chip for the footer right cluster.
 ///
-/// Renders the accumulated input / cache-hit / output token breakdown
-/// since the current runtime session started (not persisted across
-/// restarts). Returns empty when no tokens have been recorded yet.
+/// Renders a compact accumulated token count for the current runtime session.
+/// Detailed cache stats live in the separate `cache` chip.
 pub(crate) fn footer_session_tokens_spans(app: &App) -> Vec<Span<'static>> {
     let session = &app.session;
     if session.total_input_tokens == 0 && session.total_output_tokens == 0 {
         return Vec::new();
     }
-    let in_str = format_token_count_compact(u64::from(session.total_input_tokens));
-    let out_str = format_token_count_compact(u64::from(session.total_output_tokens));
-    let text = if session.total_cache_hit_tokens == 0 && session.total_cache_miss_tokens == 0 {
-        format!("{in_str} in · {out_str} out")
-    } else {
-        let cache_str = format_token_count_compact(u64::from(session.total_cache_hit_tokens));
-        format!("{in_str} in · {cache_str} cch · {out_str} out")
-    };
+    let total = u64::from(session.total_input_tokens)
+        .saturating_add(u64::from(session.total_output_tokens));
+    let text = format!("tok {}", format_token_count_compact(total));
     vec![Span::styled(text, Style::default().fg(palette::TEXT_MUTED))]
 }
 

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -2425,14 +2425,14 @@ fn format_token_count_compact_formats_units() {
 #[test]
 fn footer_session_tokens_chip_uses_single_compact_total() {
     let mut app = create_test_app();
-    app.session.total_input_tokens = 1_400_000;
-    app.session.total_cache_hit_tokens = 1_200_000;
+    app.session.total_input_tokens = 900_000;
+    app.session.total_cache_hit_tokens = 700_000;
     app.session.total_cache_miss_tokens = 200_000;
-    app.session.total_output_tokens = 7_600;
+    app.session.total_output_tokens = 600_000;
 
     let text = spans_text(&footer_session_tokens_spans(&app));
 
-    assert_eq!(text, "tok 1.4M");
+    assert_eq!(text, "tok 1.5M");
     assert!(!text.contains(" cch "));
     assert!(!text.contains(" out"));
 }

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -10,8 +10,9 @@ use crate::tui::file_mention::{
 };
 use crate::tui::footer_ui::{
     active_tool_status_label, footer_auxiliary_spans, footer_balance_spans, footer_cache_spans,
-    footer_coherence_spans, footer_state_label, footer_status_line_spans, format_context_budget,
-    format_token_count_compact, friendly_subagent_progress, render_footer_from,
+    footer_coherence_spans, footer_session_tokens_spans, footer_state_label,
+    footer_status_line_spans, format_context_budget, format_token_count_compact,
+    friendly_subagent_progress, render_footer_from,
 };
 use crate::tui::history::{
     ExecCell, ExecSource, GenericToolCell, HistoryCell, ToolCell, ToolStatus,
@@ -2419,6 +2420,21 @@ fn format_token_count_compact_formats_units() {
     assert_eq!(format_token_count_compact(999), "999");
     assert_eq!(format_token_count_compact(1_200), "1.2k");
     assert_eq!(format_token_count_compact(1_000_000), "1.0M");
+}
+
+#[test]
+fn footer_session_tokens_chip_uses_single_compact_total() {
+    let mut app = create_test_app();
+    app.session.total_input_tokens = 1_400_000;
+    app.session.total_cache_hit_tokens = 1_200_000;
+    app.session.total_cache_miss_tokens = 200_000;
+    app.session.total_output_tokens = 7_600;
+
+    let text = spans_text(&footer_session_tokens_spans(&app));
+
+    assert_eq!(text, "tok 1.4M");
+    assert!(!text.contains(" cch "));
+    assert!(!text.contains(" out"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- harvests #2405 with credit to @axobase001
- compacts the `tokens` statusline chip to a single cumulative token count like `tok 1.5M`
- stops duplicating cache-hit details in the tokens chip because the footer already has a dedicated `cache` chip
- strengthens the regression test so it proves output tokens contribute to the compact total

Partially addresses #2309

## Validation
- `git diff --check`
- `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-pr2405-target cargo test -p codewhale-tui --bin codewhale-tui footer_session_tokens_chip_uses_single_compact_total --locked -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-pr2405-check-target cargo check -p codewhale-tui --locked`
