### PR TITLE
fix(tui): clarify shell tool availability errors

### DIFF
--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -2309,6 +2309,27 @@ fn missing_tool_error_message_includes_discovery_guidance_when_no_match() {
 }
 
 #[test]
+fn missing_shell_tool_error_message_names_allow_shell_gate() {
+    let catalog = vec![Tool {
+        tool_type: None,
+        name: "read_file".to_string(),
+        description: "Read file contents".to_string(),
+        input_schema: json!({"type":"object","properties":{"path":{"type":"string"}}}),
+        allowed_callers: Some(vec!["direct".to_string()]),
+        defer_loading: Some(false),
+        input_examples: None,
+        strict: None,
+        cache_control: None,
+    }];
+
+    let message = missing_tool_error_message("exec_shell", &catalog);
+    assert!(message.contains("not available in the current tool catalog"));
+    assert!(message.contains("allow_shell"));
+    assert!(message.contains("trusted workspaces"));
+    assert!(message.contains(TOOL_SEARCH_BM25_NAME));
+}
+
+#[test]
 fn filter_tool_call_delta_strips_bracket_marker() {
     let mut in_block = false;
     let visible = filter_tool_call_delta(

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -2310,20 +2310,37 @@ fn missing_tool_error_message_includes_discovery_guidance_when_no_match() {
 
 #[test]
 fn missing_shell_tool_error_message_names_allow_shell_gate() {
-    let catalog = vec![Tool {
-        tool_type: None,
-        name: "read_file".to_string(),
-        description: "Read file contents".to_string(),
-        input_schema: json!({"type":"object","properties":{"path":{"type":"string"}}}),
-        allowed_callers: Some(vec!["direct".to_string()]),
-        defer_loading: Some(false),
-        input_examples: None,
-        strict: None,
-        cache_control: None,
-    }];
+    let catalog = vec![api_tool("read_file")];
+
+    for tool_name in [
+        "exec_shell",
+        "exec_shell_wait",
+        "exec_shell_interact",
+        "task_shell_start",
+        "task_shell_wait",
+    ] {
+        let message = missing_tool_error_message(tool_name, &catalog);
+        assert!(message.contains("not available in the current tool catalog"));
+        assert!(message.contains("allow_shell"), "{tool_name}: {message}");
+        assert!(
+            message.contains("trusted workspaces"),
+            "{tool_name}: {message}"
+        );
+        assert!(
+            message.contains(TOOL_SEARCH_BM25_NAME),
+            "{tool_name}: {message}"
+        );
+    }
+}
+
+#[test]
+fn missing_shell_tool_error_message_keeps_allow_shell_hint_with_suggestions() {
+    let catalog = vec![api_tool("exec")];
 
     let message = missing_tool_error_message("exec_shell", &catalog);
-    assert!(message.contains("not available in the current tool catalog"));
+
+    assert!(message.contains("Did you mean:"));
+    assert!(message.contains("exec"));
     assert!(message.contains("allow_shell"));
     assert!(message.contains("trusted workspaces"));
     assert!(message.contains(TOOL_SEARCH_BM25_NAME));

--- a/crates/tui/src/core/engine/tool_catalog.rs
+++ b/crates/tui/src/core/engine/tool_catalog.rs
@@ -437,6 +437,14 @@ fn suggest_tool_names(catalog: &[Tool], requested: &str, limit: usize) -> Vec<St
 pub(super) fn missing_tool_error_message(tool_name: &str, catalog: &[Tool]) -> String {
     let suggestions = suggest_tool_names(catalog, tool_name, 3);
     if suggestions.is_empty() {
+        if is_shell_tool_name(tool_name) {
+            return format!(
+                "Tool '{tool_name}' is not available in the current tool catalog. \
+                 Shell tools are gated by `allow_shell`; enable `allow_shell = true` \
+                 for trusted workspaces, switch to an auto-approve mode that permits shell access, \
+                 or use {TOOL_SEARCH_BM25_NAME} with a short query."
+            );
+        }
         return format!(
             "Tool '{tool_name}' is not available in the current tool catalog. \
              Verify mode/feature flags, or use {TOOL_SEARCH_BM25_NAME} with a short query."
@@ -447,6 +455,18 @@ pub(super) fn missing_tool_error_message(tool_name: &str, catalog: &[Tool]) -> S
         "Tool '{tool_name}' is not available in the current tool catalog. \
          Did you mean: {}? You can also use {TOOL_SEARCH_BM25_NAME} to discover tools.",
         suggestions.join(", ")
+    )
+}
+
+fn is_shell_tool_name(tool_name: &str) -> bool {
+    matches!(
+        tool_name,
+        "exec_shell"
+            | "exec_shell_wait"
+            | "exec_shell_interact"
+            | "task_shell_start"
+            | "task_shell_wait"
+            | "task_shell_cancel"
     )
 }
 

--- a/crates/tui/src/core/engine/tool_catalog.rs
+++ b/crates/tui/src/core/engine/tool_catalog.rs
@@ -436,13 +436,16 @@ fn suggest_tool_names(catalog: &[Tool], requested: &str, limit: usize) -> Vec<St
 
 pub(super) fn missing_tool_error_message(tool_name: &str, catalog: &[Tool]) -> String {
     let suggestions = suggest_tool_names(catalog, tool_name, 3);
+    let shell_hint = if is_shell_tool_name(tool_name) {
+        Some(shell_tool_allow_shell_hint())
+    } else {
+        None
+    };
     if suggestions.is_empty() {
-        if is_shell_tool_name(tool_name) {
+        if let Some(shell_hint) = shell_hint {
             return format!(
                 "Tool '{tool_name}' is not available in the current tool catalog. \
-                 Shell tools are gated by `allow_shell`; enable `allow_shell = true` \
-                 for trusted workspaces, switch to an auto-approve mode that permits shell access, \
-                 or use {TOOL_SEARCH_BM25_NAME} with a short query."
+                 {shell_hint}, or use {TOOL_SEARCH_BM25_NAME} with a short query."
             );
         }
         return format!(
@@ -451,11 +454,24 @@ pub(super) fn missing_tool_error_message(tool_name: &str, catalog: &[Tool]) -> S
         );
     }
 
+    let suggestion_text = format!("Did you mean: {}?", suggestions.join(", "));
+    if let Some(shell_hint) = shell_hint {
+        return format!(
+            "Tool '{tool_name}' is not available in the current tool catalog. \
+             {suggestion_text} {shell_hint}. \
+             You can also use {TOOL_SEARCH_BM25_NAME} to discover tools."
+        );
+    }
+
     format!(
         "Tool '{tool_name}' is not available in the current tool catalog. \
-         Did you mean: {}? You can also use {TOOL_SEARCH_BM25_NAME} to discover tools.",
-        suggestions.join(", ")
+         {suggestion_text} You can also use {TOOL_SEARCH_BM25_NAME} to discover tools."
     )
+}
+
+fn shell_tool_allow_shell_hint() -> &'static str {
+    "Shell tools are gated by `allow_shell`; enable `allow_shell = true` for trusted workspaces, \
+     or switch to an auto-approve mode that permits shell access"
 }
 
 fn is_shell_tool_name(tool_name: &str) -> bool {
@@ -466,7 +482,6 @@ fn is_shell_tool_name(tool_name: &str) -> bool {
             | "exec_shell_interact"
             | "task_shell_start"
             | "task_shell_wait"
-            | "task_shell_cancel"
     )
 }
 


### PR DESCRIPTION
## Summary
- harvests #2402 with credit to @axobase001
- makes missing shell-tool errors explain that `exec_shell` and task shell tools are gated by `allow_shell`
- preserves the shell guidance even when the missing-tool path also has a nearby suggestion
- keeps the security default unchanged; the message points users to trusted-workspace opt-in or auto-approve modes instead of broadening shell access
- removes the nonexistent `task_shell_cancel` name from the gate matcher and broadens regression coverage across shipped shell tool names

Partially addresses #2328

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-pr2402-target cargo test -p codewhale-tui --bin codewhale-tui missing_shell_tool_error_message --locked -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-pr2402-check-target cargo check -p codewhale-tui --locked`
