### PR TITLE
test(shell): cover tty controlling terminal

### DIFF
--- a/crates/tui/src/tools/shell/tests.rs
+++ b/crates/tui/src/tools/shell/tests.rs
@@ -264,7 +264,7 @@ fn background_tty_command_has_controlling_terminal() {
         .expect("background tty execution should return task_id");
 
     let done = manager
-        .get_output(&task_id, true, 5000)
+        .get_output(&task_id, true, 10_000)
         .expect("get tty command output");
 
     assert_eq!(done.status, ShellStatus::Completed);

--- a/crates/tui/src/tools/shell/tests.rs
+++ b/crates/tui/src/tools/shell/tests.rs
@@ -242,6 +242,40 @@ fn test_write_stdin_streams_output() {
 }
 
 #[test]
+#[cfg(unix)]
+fn background_tty_command_has_controlling_terminal() {
+    let tmp = tempdir().expect("tempdir");
+    let mut manager = ShellManager::new(tmp.path().to_path_buf());
+
+    let result = manager
+        .execute_with_options(
+            "sh -c 'exec 3<>/dev/tty && printf tty-ok && exec 3>&-'",
+            None,
+            5000,
+            true,
+            None,
+            true,
+            Some(ExecutionSandboxPolicy::DangerFullAccess),
+        )
+        .expect("execute tty command");
+
+    let task_id = result
+        .task_id
+        .expect("background tty execution should return task_id");
+
+    let done = manager
+        .get_output(&task_id, true, 5000)
+        .expect("get tty command output");
+
+    assert_eq!(done.status, ShellStatus::Completed);
+    assert_eq!(done.exit_code, Some(0));
+    assert!(
+        done.stdout.contains("tty-ok"),
+        "tty output should confirm /dev/tty opened; got {done:?}"
+    );
+}
+
+#[test]
 fn test_job_list_poll_cancel_and_stale_snapshot() {
     let tmp = tempdir().expect("tempdir");
     let mut manager = ShellManager::new(tmp.path().to_path_buf());


### PR DESCRIPTION
## Summary
- harvests #2408 with credit to @axobase001
- adds a Unix regression test for `tty=true` background shell jobs opening `/dev/tty`
- exercises the same shell-manager path used by `task_shell_start` with `DangerFullAccess`, so controlling-terminal setup failures are caught in CI
- gives the `get_output` wait window extra margin so the test is less brittle on loaded runners

Partially addresses #2372

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-pr2408-target cargo test -p codewhale-tui --bin codewhale-tui background_tty_command_has_controlling_terminal --locked -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-pr2408-check-target cargo check -p codewhale-tui --locked`
