### PR TITLE
fix(runtime): harden mobile QR smoke output

### DIFF
--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -711,7 +711,7 @@ fn print_mobile_urls(addr: SocketAddr, token: Option<&str>, auth_enabled: bool, 
     if show_qr {
         match qrcode::QrCode::new(qr_url.as_bytes()) {
             Ok(qr) => {
-                let qr_str = qr.render::<char>().module_dimensions(2, 1).build();
+                let qr_str = qr.render::<qrcode::render::unicode::Dense1x2>().build();
                 println!("\n{qr_str}");
             }
             Err(e) => {

--- a/scripts/mobile-smoke.sh
+++ b/scripts/mobile-smoke.sh
@@ -155,7 +155,12 @@ log "=== Test Group 3: Binding warnings (0.0.0.0 default) ==="
 STDOUT_FILE=$(mktemp)
 "$BINARY" serve --port "$PORT" --mobile --insecure > "$STDOUT_FILE" 2>&1 &
 SERVER_PID=$!
-sleep 2
+for _ in $(seq 1 30); do
+    if curl -sf "http://127.0.0.1:${PORT}/health" > /dev/null 2>&1; then
+        break
+    fi
+    sleep 0.3
+done
 STDOUT=$(cat "$STDOUT_FILE")
 rm -f "$STDOUT_FILE"
 


### PR DESCRIPTION
## Summary
- render the mobile QR code with `qrcode::render::unicode::Dense1x2` instead of the plain `char` renderer, improving terminal legibility on dark backgrounds
- replace the mobile smoke binding-warning test's fixed `sleep 2` with the same `/health` polling loop used by the rest of the script

Follow-up to #2403

## Validation
- `cargo check -p codewhale-tui --locked`
- `git diff --check`

Note: this Windows host does not have Bash available, so `scripts/mobile-smoke.sh` syntax/runtime validation is left to the PR's Ubuntu CI job. A local `cargo test -p codewhale-tui --bin codewhale-tui mobile --locked` attempt timed out while building/running the broad test filter, so I stopped the leftover cargo/rustc processes after `cargo check` had already passed.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes two targeted improvements to the mobile runtime surface: it upgrades the QR code renderer to `Dense1x2` (Unicode half-block characters) for better legibility on dark terminals, and replaces the fixed `sleep 2` in the binding-warning smoke test with the same `/health` polling loop already used by the rest of the script.

- **`crates/tui/src/runtime_api.rs`**: Swaps `qr.render::<char>().module_dimensions(2, 1)` for `qr.render::<qrcode::render::unicode::Dense1x2>()`, producing a more compact, visually correct QR output in modern terminals.
- **`scripts/mobile-smoke.sh`**: Test Group 3 now waits for the server to become healthy before reading its captured output, eliminating the flakiness of a fixed 2-second pause on slow CI runners.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; changes are small and well-scoped with no impact on production paths.

The Rust change is a straightforward renderer swap with no logic involved. The shell script improvement is correct and materially better than a fixed sleep, but the inline polling loop omits the timeout-failure call that the existing start_server() helper provides, leaving a gap in diagnostic clarity if the server is very slow to start on CI.

scripts/mobile-smoke.sh — the polling loop should mirror start_server()'s timeout fallback.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/runtime_api.rs | Switches QR renderer from char (ASCII, module_dimensions 2×1) to Dense1x2 (Unicode half-block), giving a more compact and visually correct output on dark terminals. Change is minimal and correct. |
| scripts/mobile-smoke.sh | Replaces fixed sleep 2 with a /health polling loop matching the pattern used by start_server(). The inline loop lacks the timeout-failure fallback that start_server() provides, so a slow-start server will silently slip through to the binding-warning assertions. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant S as mobile-smoke.sh
    participant B as codewhale-tui binary
    participant H as /health endpoint

    S->>B: spawn (--mobile --insecure, stdout → STDOUT_FILE)
    Note over S: poll loop (≤30 × 0.3 s)
    loop until healthy or timeout
        S->>H: curl -sf /health
        H-->>S: 200 OK (or connection refused)
    end
    S->>S: "STDOUT=$(cat STDOUT_FILE)"
    S->>S: rm STDOUT_FILE
    S->>S: grep "0.0.0.0" in STDOUT
    S->>S: grep "mobile" in STDOUT
    S->>B: kill SERVER_PID
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22codex%2Fmobile-qr-dense-renderer%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fmobile-qr-dense-renderer%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fmobile-smoke.sh%3A158-163%0A**Missing%20timeout%20fallback%20after%20polling%20loop**%0A%0AThe%20existing%20%60start_server%28%29%60%20helper%20%28lines%2045%E2%80%9353%29%20calls%20%60fail%20%22Server%20did%20not%20become%20ready%E2%80%A6%22%60%20and%20then%20%60cleanup%60%20when%20the%2030-iteration%20loop%20exhausts%20without%20a%20healthy%20response.%20The%20new%20inline%20loop%20has%20no%20equivalent%3A%20if%20the%20server%20never%20answers%20%60%2Fhealth%60%20within%20~9%20s%2C%20execution%20silently%20continues%20with%20whatever%20partial%20output%20is%20in%20%60%24STDOUT_FILE%60.%20The%20subsequent%20%60grep%60%20assertions%20over%20%60%24STDOUT%60%20would%20then%20either%20pass%20vacuously%20or%20produce%20misleading%20failures%2C%20without%20a%20clear%20signal%20that%20the%20root%20cause%20was%20a%20startup%20timeout.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fmobile-smoke.sh%3A158-163%0A**Missing%20timeout%20fallback%20after%20polling%20loop**%0A%0AThe%20existing%20%60start_server%28%29%60%20helper%20%28lines%2045%E2%80%9353%29%20calls%20%60fail%20%22Server%20did%20not%20become%20ready%E2%80%A6%22%60%20and%20then%20%60cleanup%60%20when%20the%2030-iteration%20loop%20exhausts%20without%20a%20healthy%20response.%20The%20new%20inline%20loop%20has%20no%20equivalent%3A%20if%20the%20server%20never%20answers%20%60%2Fhealth%60%20within%20~9%20s%2C%20execution%20silently%20continues%20with%20whatever%20partial%20output%20is%20in%20%60%24STDOUT_FILE%60.%20The%20subsequent%20%60grep%60%20assertions%20over%20%60%24STDOUT%60%20would%20then%20either%20pass%20vacuously%20or%20produce%20misleading%20failures%2C%20without%20a%20clear%20signal%20that%20the%20root%20cause%20was%20a%20startup%20timeout.%0A%0A&repo=hmbown%2Fcodewhale&pr=2415&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fmobile-smoke.sh%3A158-163%0A**Missing%20timeout%20fallback%20after%20polling%20loop**%0A%0AThe%20existing%20%60start_server%28%29%60%20helper%20%28lines%2045%E2%80%9353%29%20calls%20%60fail%20%22Server%20did%20not%20become%20ready%E2%80%A6%22%60%20and%20then%20%60cleanup%60%20when%20the%2030-iteration%20loop%20exhausts%20without%20a%20healthy%20response.%20The%20new%20inline%20loop%20has%20no%20equivalent%3A%20if%20the%20server%20never%20answers%20%60%2Fhealth%60%20within%20~9%20s%2C%20execution%20silently%20continues%20with%20whatever%20partial%20output%20is%20in%20%60%24STDOUT_FILE%60.%20The%20subsequent%20%60grep%60%20assertions%20over%20%60%24STDOUT%60%20would%20then%20either%20pass%20vacuously%20or%20produce%20misleading%20failures%2C%20without%20a%20clear%20signal%20that%20the%20root%20cause%20was%20a%20startup%20timeout.%0A%0A&pr=2415&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(runtime): harden mobile QR smoke out..."](https://github.com/hmbown/codewhale/commit/df1976962d85f647c7a07f476c436fa957acf069) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34780097)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->