### PR TITLE
fix(runtime): harden mobile QR smoke output

### DIFF
--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -712,7 +712,7 @@ fn print_mobile_urls(addr: SocketAddr, token: Option<&str>, auth_enabled: bool, 
     if show_qr {
         match qrcode::QrCode::new(qr_url.as_bytes()) {
             Ok(qr) => {
-                let qr_str = qr.render::<char>().module_dimensions(2, 1).build();
+                let qr_str = qr.render::<qrcode::render::unicode::Dense1x2>().build();
                 println!("\n{qr_str}");
             }
             Err(e) => {

--- a/scripts/mobile-smoke.sh
+++ b/scripts/mobile-smoke.sh
@@ -155,7 +155,20 @@ log "=== Test Group 3: Binding warnings (0.0.0.0 default) ==="
 STDOUT_FILE=$(mktemp)
 "$BINARY" serve --port "$PORT" --mobile --insecure > "$STDOUT_FILE" 2>&1 &
 SERVER_PID=$!
-sleep 2
+SERVER_READY=0
+for _ in $(seq 1 30); do
+    if curl -sf "http://127.0.0.1:${PORT}/health" > /dev/null 2>&1; then
+        SERVER_READY=1
+        break
+    fi
+    sleep 0.3
+done
+if [[ "$SERVER_READY" -ne 1 ]]; then
+    rm -f "$STDOUT_FILE"
+    fail "Server did not become ready on port $PORT"
+    cleanup
+    exit 1
+fi
 STDOUT=$(cat "$STDOUT_FILE")
 rm -f "$STDOUT_FILE"
 


### PR DESCRIPTION
Harvested from #2415 with thanks to @axobase001.\n\nKeeps the denser mobile QR renderer and replaces the fixed binding-warning sleep with health polling plus an explicit timeout failure path, so slow starts fail with the useful cause instead of drifting into misleading assertions.\n\nFollow-up to #2403.\n\nValidation:\n- git diff --cached --check\n- bash -n scripts/mobile-smoke.sh\n- cargo check -p codewhale-tui --locked