### PR TITLE
chore(web): bump qs lockfile entry

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10703,9 +10703,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {


### PR DESCRIPTION
## Summary

Harvests the current-main lockfile slice from #2224.

- updates the transitive web lockfile entry for `qs` from 6.15.1 to 6.15.2
- keeps the diff limited to the `node_modules/qs` lock metadata, avoiding stale optional-package metadata churn from the original dependabot branch

## Validation

- git diff --check
- npm --prefix web ci --ignore-scripts
- npm --prefix web run lint

Notes:
- `npm --prefix web run lint` passes with the existing `web/redirect/src/index.ts` anonymous default export warning.

Supersedes #2224.
