### PR TITLE
feat(web_search): add Volcengine Ark search provider

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -308,7 +308,7 @@ max_subagents = 10 # optional (1-20)
 # API-backed search.
 #
 # [search]
-# provider = "duckduckgo"  # duckduckgo | bing | tavily | bocha | metaso | baidu
+# provider = "duckduckgo"  # duckduckgo | bing | tavily | bocha | metaso | baidu | volcengine
 #                            # duckduckgo: HTML scrape with Bing fallback
 #                            # bing:       HTML scrape, no API key
 #                            # tavily:     https://tavily.com — AI search, needs api_key
@@ -316,6 +316,8 @@ max_subagents = 10 # optional (1-20)
 #                            # metaso:     https://metaso.cn — 秘塔AI搜索，每天 100 次免费
 #                            #             设置 METASO_API_KEY 或 [search] api_key 可提升额度
 #                            # baidu:      百度 AI Search via qianfan.baidubce.com，需 api_key
+#                            # volcengine: 火山引擎 Ark web_search (免费 2 万次/月), 需 api_key
+#                            #             也回退到 VOLCENGINE_API_KEY / VOLCENGINE_ARK_API_KEY / ARK_API_KEY 环境变量
 # api_key = "YOUR_SEARCH_KEY" # required for tavily, bocha, and baidu; optional for metaso
 #                             # WARNING: treat config.toml like a secret file when
 #                             # storing API keys. Prefer env vars for local smoke tests.

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -755,6 +755,12 @@ pub enum SearchProvider {
         alias = "baidu-ai-search"
     )]
     Baidu,
+    /// Volcengine Ark web_search via Responses API. Requires api_key.
+    /// Free tier: 20K queries/month per API key. Falls back to
+    /// `VOLCENGINE_API_KEY` / `VOLCENGINE_ARK_API_KEY` / `ARK_API_KEY`
+    /// env vars when `[search] api_key` is not set.
+    #[serde(alias = "volcengine", alias = "ark", alias = "volc")]
+    Volcengine,
 }
 
 impl SearchProvider {
@@ -769,6 +775,7 @@ impl SearchProvider {
             "baidu" | "baidu-search" | "baidu_search" | "baidu-ai-search" | "baidu_ai_search" => {
                 Some(Self::Baidu)
             }
+            "volcengine" | "ark" | "volc" | "volcengine-ark" => Some(Self::Volcengine),
             _ => None,
         }
     }
@@ -782,6 +789,7 @@ impl SearchProvider {
             Self::Bocha => "bocha",
             Self::Metaso => "metaso",
             Self::Baidu => "baidu",
+            Self::Volcengine => "volcengine",
         }
     }
 }
@@ -813,12 +821,13 @@ pub struct SearchProviderResolution {
 /// Web search provider configuration (`[search]` table in config.toml).
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct SearchConfig {
-    /// Search provider: `bing` | `duckduckgo` | `tavily` | `bocha` | `metaso` | `baidu`. Default: `duckduckgo`.
+    /// Search provider: `bing` | `duckduckgo` | `tavily` | `bocha` | `metaso` | `baidu` | `volcengine`. Default: `duckduckgo`.
     #[serde(default)]
     pub provider: Option<SearchProvider>,
-    /// API key for Tavily, Bocha, Metaso, or Baidu. Not required for Bing or DuckDuckGo.
+    /// API key for Tavily, Bocha, Metaso, Baidu, or Volcengine. Not required for Bing or DuckDuckGo.
     /// Metaso also falls back to `METASO_API_KEY` env var, then a built-in default.
     /// Baidu also falls back to `BAIDU_SEARCH_API_KEY` env var.
+    /// Volcengine also falls back to `VOLCENGINE_API_KEY` / `VOLCENGINE_ARK_API_KEY` / `ARK_API_KEY` env vars.
     #[serde(default)]
     pub api_key: Option<String>,
 }

--- a/crates/tui/src/tools/web_search.rs
+++ b/crates/tui/src/tools/web_search.rs
@@ -1010,10 +1010,10 @@ fn extract_json_block(text: &str) -> Option<&str> {
             return Some(inner[..end].trim());
         }
     }
-    if let Some(start) = text.find('{') {
-        if let Some(end) = text.rfind('}') {
-            return Some(&text[start..=end]);
-        }
+    if let Some(start) = text.find('{')
+        && let Some(end) = text.rfind('}')
+    {
+        return Some(&text[start..=end]);
     }
     None
 }

--- a/crates/tui/src/tools/web_search.rs
+++ b/crates/tui/src/tools/web_search.rs
@@ -980,14 +980,8 @@ fn parse_volcengine_results(response_text: &str, max_results: usize) -> Vec<WebS
         .into_iter()
         .flat_map(|arr| arr.iter())
         .filter_map(|item| {
-            let title = item
-                .get("title")
-                .and_then(|s| s.as_str())?
-                .trim();
-            let url = item
-                .get("url")
-                .and_then(|s| s.as_str())?
-                .trim();
+            let title = item.get("title").and_then(|s| s.as_str())?.trim();
+            let url = item.get("url").and_then(|s| s.as_str())?.trim();
             if title.is_empty() || url.is_empty() {
                 return None;
             }

--- a/crates/tui/src/tools/web_search.rs
+++ b/crates/tui/src/tools/web_search.rs
@@ -1,12 +1,12 @@
 //! Web search tool backed by multiple providers: Bing HTML scrape, DuckDuckGo
 //! (HTML scrape with Bing fallback), Tavily API, Bocha (博查) API,
-//! Metaso API (<https://metaso.cn>), and Baidu AI Search.
+//! Metaso API (<https://metaso.cn>), Baidu AI Search, and Volcengine Ark.
 //!
 //! This is the primary web search surface for agents. For browsing workflows
 //! (page open, click, screenshot) use a direct URL approach instead.
 //!
 //! Set `[search]` in config.toml to switch providers:
-//!   provider = "duckduckgo"  # or tavily/bocha/metaso/baidu
+//!   provider = "duckduckgo"  # or tavily/bocha/metaso/baidu/volcengine
 //!   api_key = "tvly-..."
 
 use super::spec::{
@@ -28,6 +28,7 @@ const TAVILY_ENDPOINT: &str = "https://api.tavily.com/search";
 const BOCHA_ENDPOINT: &str = "https://api.bochaai.com/v1/ai/search";
 const METASO_ENDPOINT: &str = "https://metaso.cn/api/v1";
 const BAIDU_ENDPOINT: &str = "https://qianfan.baidubce.com/v2/ai_search/web_search";
+const VOLCENGINE_RESPONSES_ENDPOINT: &str = "https://ark.cn-beijing.volces.com/api/v3/responses";
 /// Intentionally public default key provided by Metaso for open-source/community use.
 /// Last-resort fallback after config and env var. Rate-limited to ~100 searches/day.
 const METASO_DEFAULT_API_KEY: &str = "mk-E384C1DD5E8501BB7EFE27C949AFDE5B";
@@ -224,6 +225,13 @@ impl ToolSpec for WebSearchTool {
                 check_policy(decider, "qianfan.baidubce.com")?;
                 return self
                     .run_baidu_search(&query, max_results, timeout_ms, context)
+                    .await;
+            }
+            SearchProvider::Volcengine => {
+                let decider = context.network_policy.as_ref();
+                check_policy(decider, "ark.cn-beijing.volces.com")?;
+                return self
+                    .run_volcengine_search(&query, max_results, timeout_ms, context)
                     .await;
             }
             SearchProvider::Bing | SearchProvider::DuckDuckGo => {}
@@ -728,6 +736,84 @@ impl WebSearchTool {
         let results = parse_baidu_results(&parsed, max_results);
         search_tool_result(query.to_string(), "baidu", results, None)
     }
+
+    /// Search via Volcengine Ark Responses API web_search tool.
+    /// Uses strict JSON prompt constraints to extract structured results
+    /// from the model's search-augmented response.
+    async fn run_volcengine_search(
+        &self,
+        query: &str,
+        max_results: usize,
+        timeout_ms: u64,
+        context: &ToolContext,
+    ) -> Result<ToolResult, ToolError> {
+        let volc_key = std::env::var("VOLCENGINE_API_KEY").ok();
+        let volc_ark_key = std::env::var("VOLCENGINE_ARK_API_KEY").ok();
+        let ark_key = std::env::var("ARK_API_KEY").ok();
+        let api_key = context
+            .search_api_key
+            .as_deref()
+            .or(volc_key.as_deref())
+            .or(volc_ark_key.as_deref())
+            .or(ark_key.as_deref())
+            .ok_or_else(|| {
+                ToolError::execution_failed(
+                    "Volcengine search requires an API key. Set `[search] api_key`, \
+                     or DEEPSEEK_SEARCH_API_KEY, or VOLCENGINE_API_KEY env var.",
+                )
+            })?;
+
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_millis(timeout_ms))
+            .build()
+            .map_err(|e| {
+                ToolError::execution_failed(format!("Failed to build HTTP client: {e}"))
+            })?;
+
+        let payload = volcengine_search_payload(query, max_results);
+
+        let resp = client
+            .post(VOLCENGINE_RESPONSES_ENDPOINT)
+            .header("Authorization", format!("Bearer {api_key}"))
+            .json(&payload)
+            .send()
+            .await
+            .map_err(|e| {
+                ToolError::execution_failed(format!("Volcengine search request failed: {e}"))
+            })?;
+
+        let status = resp.status();
+        let body = resp.text().await.map_err(|e| {
+            ToolError::execution_failed(format!("Failed to read Volcengine response: {e}"))
+        })?;
+
+        if !status.is_success() {
+            let msg = match status.as_u16() {
+                401 | 403 => "Volcengine API key rejected — check VOLCENGINE_API_KEY or `[search] api_key` in config.toml".to_string(),
+                429 => "Volcengine API rate-limited — wait and retry, or check your quota".to_string(),
+                _ => {
+                    let truncated = truncate_error_body(&body);
+                    format!("Volcengine search failed: HTTP {} — {truncated}", status.as_u16())
+                }
+            };
+            return Err(ToolError::execution_failed(msg));
+        }
+
+        let parsed: serde_json::Value = serde_json::from_str(&body).map_err(|e| {
+            ToolError::execution_failed(format!("Failed to parse Volcengine response: {e}"))
+        })?;
+
+        if let Some(error) = volcengine_error_message(&parsed) {
+            return Err(ToolError::execution_failed(error));
+        }
+
+        let response_text = volcengine_extract_text(&parsed).ok_or_else(|| {
+            ToolError::execution_failed("Volcengine response contains no output text")
+        })?;
+
+        let results = parse_volcengine_results(&response_text, max_results);
+        search_tool_result(query.to_string(), "volcengine", results, None)
+    }
 }
 
 fn truncate_error_body(body: &str) -> String {
@@ -824,6 +910,118 @@ fn baidu_search_payload(query: &str, max_results: usize) -> Value {
             }
         ],
     })
+}
+
+fn volcengine_search_payload(query: &str, max_results: usize) -> Value {
+    json!({
+        "model": "doubao-seed-1-6-250615",
+        "stream": false,
+        "tools": [{"type": "web_search"}],
+        "input": [{
+            "role": "user",
+            "content": [{
+                "type": "input_text",
+                "text": format!(
+                    "Search the web for: {query}\n\n\
+                     CRITICAL: Respond ONLY with a valid JSON object. No markdown, no explanation.\n\
+                     Schema: {{\"results\":[{{\"title\":\"...\",\"url\":\"https://...\",\"snippet\":\"...\"}}]}}\n\
+                     - results: 1-{max_results} most relevant pages\n\
+                     - title: page title (required)\n\
+                     - url: full URL starting with https:// (required)\n\
+                     - snippet: 1-2 sentence factual summary (required)\n\
+                     - If zero results: {{\"results\":[]}}\n\
+                     - Your entire response must be valid, parseable JSON."
+                )
+            }]
+        }]
+    })
+}
+
+/// Extracts the model's text response from a Volcengine Responses API output.
+fn volcengine_extract_text(parsed: &Value) -> Option<String> {
+    parsed
+        .get("output")
+        .and_then(|v| v.as_array())
+        .into_iter()
+        .flat_map(|arr| arr.iter().rev())
+        .find(|item| item.get("type").and_then(|t| t.as_str()) == Some("message"))
+        .and_then(|msg| msg.get("content").and_then(|c| c.as_array()))
+        .and_then(|content| content.first())
+        .and_then(|c| c.get("text").and_then(|t| t.as_str()))
+        .map(|s| s.to_string())
+}
+
+/// Checks for business-logic errors in a Volcengine Responses API response.
+fn volcengine_error_message(parsed: &Value) -> Option<String> {
+    let error = parsed.get("error")?;
+    let code = error
+        .get("code")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
+    let message = error
+        .get("message")
+        .and_then(|v| v.as_str())
+        .unwrap_or("no details");
+    Some(format!("Volcengine API error (code {code}: {message})"))
+}
+
+/// Parses Volcengine model-generated JSON results into `WebSearchEntry` items.
+fn parse_volcengine_results(response_text: &str, max_results: usize) -> Vec<WebSearchEntry> {
+    let json_text = extract_json_block(response_text).unwrap_or(response_text);
+
+    let parsed: Value = match serde_json::from_str(json_text) {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+
+    parsed
+        .get("results")
+        .and_then(|v| v.as_array())
+        .into_iter()
+        .flat_map(|arr| arr.iter())
+        .filter_map(|item| {
+            let title = item
+                .get("title")
+                .and_then(|s| s.as_str())?
+                .trim();
+            let url = item
+                .get("url")
+                .and_then(|s| s.as_str())?
+                .trim();
+            if title.is_empty() || url.is_empty() {
+                return None;
+            }
+            let snippet = item
+                .get("snippet")
+                .and_then(|s| s.as_str())
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(ToString::to_string);
+            Some(WebSearchEntry {
+                title: title.to_string(),
+                url: url.to_string(),
+                snippet,
+            })
+        })
+        .take(max_results)
+        .collect()
+}
+
+/// Attempts to extract a JSON block from text that may be wrapped in
+/// markdown fences (```json ... ```) or contain surrounding commentary.
+fn extract_json_block(text: &str) -> Option<&str> {
+    if let Some(start) = text.find("```json") {
+        let inner = &text[start + 7..];
+        if let Some(end) = inner.find("```") {
+            return Some(inner[..end].trim());
+        }
+    }
+    if let Some(start) = text.find('{') {
+        if let Some(end) = text.rfind('}') {
+            return Some(&text[start..=end]);
+        }
+    }
+    None
 }
 
 fn extract_search_query(input: &Value) -> Result<String, ToolError> {


### PR DESCRIPTION
## Summary

Add Volcengine Ark (火山引擎方舟) as a new `SearchProvider` in the `web_search` tool, addressing regional availability for users in mainland China (related: #1681, #2132).

**Motivation**

Neither DuckDuckGo nor Bing HTML scraping works reliably for users in China — DuckDuckGo is unreachable, and Bing is unstable. Volcengine Ark provides a first-party search option with native China infrastructure, low latency, and access to ByteDance content sources (Toutiao articles, Douyin encyclopedia, weather data, etc.).

**How it works**

Instead of HTML scraping, this provider calls Volcengine's [Responses API](https://www.volcengine.com/docs/82379/1569618) with `tools: [{type: "web_search"}]` and a strict JSON Schema prompt constraint. The model performs the search internally, then responds with structured JSON in the format `{"results":[{"title":"...","url":"...","snippet":"..."}]}`, which we parse into `WebSearchEntry` items — keeping the tool's output format consistent across all providers.

**API key resolution (4-tier fallback)**

1. `[search] api_key` in config.toml
2. `VOLCENGINE_API_KEY` env var
3. `VOLCENGINE_ARK_API_KEY` env var
4. `ARK_API_KEY` env var

This means users who have already configured Volcengine as their LLM provider (`[providers.volcengine]`) can reuse the same API key for search without additional setup.

**Pricing**

- Free tier: 20,000 queries/month per API key
- Beyond free: 4 CNY / 1,000 queries

**Caveats**

This is an LLM-augmented search — unlike DuckDuckGo/Bing which return raw `[{title, url, snippet}]` lists, Volcengine's search results pass through a model summarization step. The underlying `SearchDocument` structure does contain `title`, `url`, and `summary` fields, but:
- `url` is only present for some content sources
- The raw `SearchDocument[]` is not directly exposed to API callers; we receive the model's synthesized response

The JSON prompt constraint handles this by instructing the model to always output structured results, with `extract_json_block()` providing a markdown-fence fallback if the model wraps JSON in code blocks.

**Files changed**

- `crates/tui/src/config.rs` — new `SearchProvider::Volcengine` variant + string parsing
- `crates/tui/src/tools/web_search.rs` — `run_volcengine_search()` implementation + dispatch case + 4 helper functions
- `config.example.toml` — commented-out example for `provider = "volcengine"`

## Testing

- [x] `cargo fmt --all -- --check` — passes
- [x] `cargo clippy --workspace --all-targets --all-features` — 1 pre-existing warning in `share.rs` (unrelated to this PR)
- [x] `cargo test --workspace --all-features` — all tests pass

## Checklist

- [x] Updated docs or comments as needed (doc comments on `SearchProvider`, `SearchConfig`, file header, `config.example.toml`)
- [x] Added or updated tests where relevant (N/A for network-dependent API calls; existing test suite passes)
- [ ] Verified TUI behavior manually if UI changes (no TUI changes — search provider selection is config-only)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds Volcengine Ark as a new `SearchProvider` option, targeting users in mainland China where DuckDuckGo and Bing are unreliable. Unlike the scraping-based providers, it calls Volcengine's Responses API with a `web_search` tool and parses structured JSON out of the model's response.

- `crates/tui/src/tools/web_search.rs`: New `run_volcengine_search` method plus four helper functions; two bugs flagged below.
- `crates/tui/src/config.rs`: Adds `SearchProvider::Volcengine` variant with a 4-tier API key fallback; the `"volcengine-ark"` alias is in `parse()` but missing from serde attributes.
- `config.example.toml`: Documentation comment updated to list `volcengine` and its free-tier quota.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Two defects in the new Volcengine path will cause immediate runtime failures before any search result is returned.

Two defects in the newly added Volcengine search path will cause immediate runtime failures: the wrong env-var name in the missing-key error actively misleads users, and `volcengine_extract_text` will return `None` for any model response that includes a thinking block, making all searches fail with a 'no output text' error.

crates/tui/src/tools/web_search.rs — the error message text and `volcengine_extract_text` content-traversal logic both need fixes before the provider works reliably.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tools/web_search.rs | Adds `run_volcengine_search` and four helper functions; contains a wrong env-var name in the missing-key error message and a content-extraction bug that fails when the model returns a thinking block before the answer block. |
| crates/tui/src/config.rs | Adds `SearchProvider::Volcengine` variant with serde aliases and `parse()` support; the `"volcengine-ark"` alias is covered by `parse()` but missing from serde attributes. |
| config.example.toml | Documentation-only update adding Volcengine to the provider list and comments; no issues. |

</details>

</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fvolcengine-websearch%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fvolcengine-websearch%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Ftui%2Fsrc%2Ftools%2Fweb_search.rs%3A760-763%0A**Wrong%20env%20var%20name%20in%20error%20message**%0A%0AThe%20error%20message%20tells%20users%20to%20set%20%60DEEPSEEK_SEARCH_API_KEY%60%2C%20but%20the%20actual%20fallback%20chain%20reads%20%60VOLCENGINE_API_KEY%60%2C%20%60VOLCENGINE_ARK_API_KEY%60%2C%20and%20%60ARK_API_KEY%60%20%E2%80%94%20%60DEEPSEEK_SEARCH_API_KEY%60%20is%20never%20checked.%20A%20user%20hitting%20this%20error%20will%20follow%20the%20wrong%20instruction%20and%20still%20fail.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20ToolError%3A%3Aexecution_failed%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22Volcengine%20search%20requires%20an%20API%20key.%20Set%20%60%5Bsearch%5D%20api_key%60%2C%20%5C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20or%20VOLCENGINE_API_KEY%20%2F%20VOLCENGINE_ARK_API_KEY%20%2F%20ARK_API_KEY%20env%20var.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Ftui%2Fsrc%2Ftools%2Fweb_search.rs%3A949-951%0A**%60volcengine_extract_text%60%20only%20reads%20the%20first%20content%20block**%0A%0AAfter%20finding%20the%20last%20%60%22message%22%60%20output%20item%2C%20the%20function%20unconditionally%20calls%20%60.first%28%29%60%20on%20the%20content%20array%20and%20expects%20%60text%60%20to%20be%20present%20there.%20The%20%60doubao-seed-1-6-250615%60%20model%20can%20return%20a%20thinking%2Freasoning%20block%20as%20%60content%5B0%5D%60%2C%20so%20%60text%60%20is%20absent%20and%20the%20function%20returns%20%60None%60%2C%20causing%20every%20such%20response%20to%20fail%20with%20%22Volcengine%20response%20contains%20no%20output%20text%22.%20Scanning%20all%20content%20items%20for%20the%20first%20with%20a%20%60%22text%22%60%20field%20is%20more%20robust.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20.and_then%28%7Ccontent%7C%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20content%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.iter%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.find%28%7Cc%7C%20c.get%28%22text%22%29.and_then%28%7Ct%7C%20t.as_str%28%29%29.is_some%28%29%29%0A%20%20%20%20%20%20%20%20%7D%29%0A%20%20%20%20%20%20%20%20.and_then%28%7Cc%7C%20c.get%28%22text%22%29.and_then%28%7Ct%7C%20t.as_str%28%29%29%29%0A%20%20%20%20%20%20%20%20.map%28%7Cs%7C%20s.to_string%28%29%29%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Ftui%2Fsrc%2Fconfig.rs%3A762-763%0A**%60%22volcengine-ark%22%60%20alias%20missing%20from%20serde**%0A%0AThe%20%60parse%28%29%60%20function%20accepts%20%60%22volcengine-ark%22%60%20as%20a%20valid%20alias%2C%20but%20the%20%60%23%5Bserde%28...%29%5D%60%20attributes%20don't%20include%20it.%20A%20user%20who%20writes%20%60provider%20%3D%20%22volcengine-ark%22%60%20in%20%60config.toml%60%20will%20get%20a%20deserialization%20error%20while%20the%20same%20string%20works%20fine%20via%20the%20%60parse%28%29%60%20path.%0A%0A%60%60%60suggestion%0A%20%20%20%20%23%5Bserde%28alias%20%3D%20%22volcengine%22%2C%20alias%20%3D%20%22ark%22%2C%20alias%20%3D%20%22volc%22%2C%20alias%20%3D%20%22volcengine-ark%22%29%5D%0A%20%20%20%20Volcengine%2C%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Ftui%2Fsrc%2Ftools%2Fweb_search.rs%3A760-763%0A**Wrong%20env%20var%20name%20in%20error%20message**%0A%0AThe%20error%20message%20tells%20users%20to%20set%20%60DEEPSEEK_SEARCH_API_KEY%60%2C%20but%20the%20actual%20fallback%20chain%20reads%20%60VOLCENGINE_API_KEY%60%2C%20%60VOLCENGINE_ARK_API_KEY%60%2C%20and%20%60ARK_API_KEY%60%20%E2%80%94%20%60DEEPSEEK_SEARCH_API_KEY%60%20is%20never%20checked.%20A%20user%20hitting%20this%20error%20will%20follow%20the%20wrong%20instruction%20and%20still%20fail.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20ToolError%3A%3Aexecution_failed%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22Volcengine%20search%20requires%20an%20API%20key.%20Set%20%60%5Bsearch%5D%20api_key%60%2C%20%5C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20or%20VOLCENGINE_API_KEY%20%2F%20VOLCENGINE_ARK_API_KEY%20%2F%20ARK_API_KEY%20env%20var.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Ftui%2Fsrc%2Ftools%2Fweb_search.rs%3A949-951%0A**%60volcengine_extract_text%60%20only%20reads%20the%20first%20content%20block**%0A%0AAfter%20finding%20the%20last%20%60%22message%22%60%20output%20item%2C%20the%20function%20unconditionally%20calls%20%60.first%28%29%60%20on%20the%20content%20array%20and%20expects%20%60text%60%20to%20be%20present%20there.%20The%20%60doubao-seed-1-6-250615%60%20model%20can%20return%20a%20thinking%2Freasoning%20block%20as%20%60content%5B0%5D%60%2C%20so%20%60text%60%20is%20absent%20and%20the%20function%20returns%20%60None%60%2C%20causing%20every%20such%20response%20to%20fail%20with%20%22Volcengine%20response%20contains%20no%20output%20text%22.%20Scanning%20all%20content%20items%20for%20the%20first%20with%20a%20%60%22text%22%60%20field%20is%20more%20robust.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20.and_then%28%7Ccontent%7C%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20content%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.iter%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.find%28%7Cc%7C%20c.get%28%22text%22%29.and_then%28%7Ct%7C%20t.as_str%28%29%29.is_some%28%29%29%0A%20%20%20%20%20%20%20%20%7D%29%0A%20%20%20%20%20%20%20%20.and_then%28%7Cc%7C%20c.get%28%22text%22%29.and_then%28%7Ct%7C%20t.as_str%28%29%29%29%0A%20%20%20%20%20%20%20%20.map%28%7Cs%7C%20s.to_string%28%29%29%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Ftui%2Fsrc%2Fconfig.rs%3A762-763%0A**%60%22volcengine-ark%22%60%20alias%20missing%20from%20serde**%0A%0AThe%20%60parse%28%29%60%20function%20accepts%20%60%22volcengine-ark%22%60%20as%20a%20valid%20alias%2C%20but%20the%20%60%23%5Bserde%28...%29%5D%60%20attributes%20don't%20include%20it.%20A%20user%20who%20writes%20%60provider%20%3D%20%22volcengine-ark%22%60%20in%20%60config.toml%60%20will%20get%20a%20deserialization%20error%20while%20the%20same%20string%20works%20fine%20via%20the%20%60parse%28%29%60%20path.%0A%0A%60%60%60suggestion%0A%20%20%20%20%23%5Bserde%28alias%20%3D%20%22volcengine%22%2C%20alias%20%3D%20%22ark%22%2C%20alias%20%3D%20%22volc%22%2C%20alias%20%3D%20%22volcengine-ark%22%29%5D%0A%20%20%20%20Volcengine%2C%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2426&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Ftui%2Fsrc%2Ftools%2Fweb_search.rs%3A760-763%0A**Wrong%20env%20var%20name%20in%20error%20message**%0A%0AThe%20error%20message%20tells%20users%20to%20set%20%60DEEPSEEK_SEARCH_API_KEY%60%2C%20but%20the%20actual%20fallback%20chain%20reads%20%60VOLCENGINE_API_KEY%60%2C%20%60VOLCENGINE_ARK_API_KEY%60%2C%20and%20%60ARK_API_KEY%60%20%E2%80%94%20%60DEEPSEEK_SEARCH_API_KEY%60%20is%20never%20checked.%20A%20user%20hitting%20this%20error%20will%20follow%20the%20wrong%20instruction%20and%20still%20fail.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20ToolError%3A%3Aexecution_failed%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22Volcengine%20search%20requires%20an%20API%20key.%20Set%20%60%5Bsearch%5D%20api_key%60%2C%20%5C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20or%20VOLCENGINE_API_KEY%20%2F%20VOLCENGINE_ARK_API_KEY%20%2F%20ARK_API_KEY%20env%20var.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Ftui%2Fsrc%2Ftools%2Fweb_search.rs%3A949-951%0A**%60volcengine_extract_text%60%20only%20reads%20the%20first%20content%20block**%0A%0AAfter%20finding%20the%20last%20%60%22message%22%60%20output%20item%2C%20the%20function%20unconditionally%20calls%20%60.first%28%29%60%20on%20the%20content%20array%20and%20expects%20%60text%60%20to%20be%20present%20there.%20The%20%60doubao-seed-1-6-250615%60%20model%20can%20return%20a%20thinking%2Freasoning%20block%20as%20%60content%5B0%5D%60%2C%20so%20%60text%60%20is%20absent%20and%20the%20function%20returns%20%60None%60%2C%20causing%20every%20such%20response%20to%20fail%20with%20%22Volcengine%20response%20contains%20no%20output%20text%22.%20Scanning%20all%20content%20items%20for%20the%20first%20with%20a%20%60%22text%22%60%20field%20is%20more%20robust.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20.and_then%28%7Ccontent%7C%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20content%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.iter%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.find%28%7Cc%7C%20c.get%28%22text%22%29.and_then%28%7Ct%7C%20t.as_str%28%29%29.is_some%28%29%29%0A%20%20%20%20%20%20%20%20%7D%29%0A%20%20%20%20%20%20%20%20.and_then%28%7Cc%7C%20c.get%28%22text%22%29.and_then%28%7Ct%7C%20t.as_str%28%29%29%29%0A%20%20%20%20%20%20%20%20.map%28%7Cs%7C%20s.to_string%28%29%29%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Ftui%2Fsrc%2Fconfig.rs%3A762-763%0A**%60%22volcengine-ark%22%60%20alias%20missing%20from%20serde**%0A%0AThe%20%60parse%28%29%60%20function%20accepts%20%60%22volcengine-ark%22%60%20as%20a%20valid%20alias%2C%20but%20the%20%60%23%5Bserde%28...%29%5D%60%20attributes%20don't%20include%20it.%20A%20user%20who%20writes%20%60provider%20%3D%20%22volcengine-ark%22%60%20in%20%60config.toml%60%20will%20get%20a%20deserialization%20error%20while%20the%20same%20string%20works%20fine%20via%20the%20%60parse%28%29%60%20path.%0A%0A%60%60%60suggestion%0A%20%20%20%20%23%5Bserde%28alias%20%3D%20%22volcengine%22%2C%20alias%20%3D%20%22ark%22%2C%20alias%20%3D%20%22volc%22%2C%20alias%20%3D%20%22volcengine-ark%22%29%5D%0A%20%20%20%20Volcengine%2C%0A%60%60%60%0A%0A&pr=2426&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["chore: fix clippy warning in extract\_jso..."](https://github.com/hmbown/codewhale/commit/c1491f39e9b70e4e787c6fd6255057777676840e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34783330)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->