### PR TITLE
  fix(tui): suppress inline skill completions in slash command args

### DIFF
--- a/crates/tui/src/tui/slash_menu.rs
+++ b/crates/tui/src/tui/slash_menu.rs
@@ -87,6 +87,10 @@ pub(crate) fn partial_inline_skill_mention_at_cursor(
     input: &str,
     cursor_chars: usize,
 ) -> Option<(usize, String)> {
+    if looks_like_slash_command_input(input) {
+        return None;
+    }
+
     let chars: Vec<char> = input.chars().collect();
     if cursor_chars > chars.len() {
         return None;

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -3324,6 +3324,28 @@ fn inline_skill_slash_popup_filters_partial_without_leaking_to_command_position(
 }
 
 #[test]
+fn inline_skill_slash_popup_does_not_open_inside_command_arguments() {
+    let mut app = create_test_app();
+    app.cached_skills = vec![
+        (
+            "config-doctor".to_string(),
+            "Diagnose configuration".to_string(),
+        ),
+        ("cargo-ci-fixer".to_string(), "Fix CI failures".to_string()),
+    ];
+    app.input = "/attach /".to_string();
+    app.cursor_position = app.input.chars().count();
+
+    let entries = visible_slash_menu_entries(&app, 128);
+
+    assert!(
+        entries.is_empty(),
+        "command argument paths should not show inline skill entries: {:?}",
+        entries.iter().map(|entry| &entry.name).collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn apply_slash_menu_selection_splices_inline_skill_mention() {
     let mut app = create_test_app();
     app.input = "please use /se here".to_string();


### PR DESCRIPTION
## Summary

  Fixes a composer autocomplete edge case where typing `/attach /` opened the inline skill picker instead of
  letting the user continue an absolute file path.

  `/attach` accepts local image/video paths, and absolute paths naturally start with `/`. The previous slash-menu
  flow treated the second slash as an inline skill mention, showing entries such as `/config-doctor` and making it
  easy to accidentally turn the input into `/attach /config-doctor`, which then failed as a missing file.

  This change suppresses inline skill completions whenever the whole composer input is already a slash command.
  Normal inline skill completions inside regular messages still work.


<img width="1025" height="257" alt="QQ20260531-184717" src="https://github.com/user-attachments/assets/9b756e37-3632-42d7-ae96-0f44fc42e235" />

to:


## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes an autocomplete edge case where typing `/attach /` in the composer would open the inline skill picker instead of allowing the user to continue an absolute file path. The fix adds a four-line early-exit guard to `partial_inline_skill_mention_at_cursor` that delegates to the pre-existing `looks_like_slash_command_input` predicate.

- **`slash_menu.rs`**: When the full composer input already looks like a slash command (starts with `/<word>`), `partial_inline_skill_mention_at_cursor` now returns `None` immediately, so neither `visible_slash_menu_entries` nor `apply_slash_menu_selection` will treat a subsequent `/` as an inline skill trigger.
- **`ui/tests.rs`**: Adds a regression test for the `/attach /` case, asserting that `visible_slash_menu_entries` returns an empty list when the input is a slash command with a path argument beginning with `/`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal, well-scoped guard with no impact on existing inline skill or slash-command flows outside the specific edge case being fixed.

The four-line guard reuses a battle-tested predicate (`looks_like_slash_command_input`) that already drives `slash_completion_hints` and `try_autocomplete_slash_command`. The only execution path changed is the one where input starts with a slash command and contains a second `/` in its arguments; all other paths are unaffected. The regression test directly exercises the broken scenario.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/slash_menu.rs | Adds an early-exit guard to `partial_inline_skill_mention_at_cursor` using the pre-existing `looks_like_slash_command_input` predicate to suppress inline skill completions whenever the whole input is already a slash command. |
| crates/tui/src/tui/ui/tests.rs | Adds a focused regression test for the `/attach /` edge case that directly exercises the new guard path through `visible_slash_menu_entries`. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["visible_slash_menu_entries(app)"] --> B{slash_menu_hidden?}
    B -- yes --> Z["return []"]
    B -- no --> C["partial_inline_skill_mention_at_cursor(input, cursor)"]
    C --> D{"looks_like_slash_command_input(input)?"}
    D -- yes --> E["return None  NEW GUARD"]
    D -- no --> F{cursor behind a slash?}
    F -- no --> G["return None"]
    F -- yes --> H{is_inline_skill_mention_start?}
    H -- no --> G
    H -- yes --> I{text before slash is empty?}
    I -- yes --> G
    I -- no --> J["return Some((byte_start, partial))"]
    E --> K["slash_completion_hints()"]
    J --> L["skill_mention_entries(partial)"]
    G --> K
    K --> M["Command/completion popup"]
    L --> N["Inline skill popup"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tui): suppress inline skill completi..."](https://github.com/hmbown/codewhale/commit/ff7ef7951eb47fb6fef2eee20bcbf50fa770e322) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34786328)</sub>

<!-- /greptile_comment -->