### PR TITLE
style: fix clippy warnings and run fmt

### DIFF
--- a/crates/cli/src/update.rs
+++ b/crates/cli/src/update.rs
@@ -364,9 +364,8 @@ fn update_http_client(proxy: Option<&Proxy>) -> Result<reqwest::blocking::Client
 }
 
 fn latest_release_tag(channel: ReleaseChannel, proxy: Option<&Proxy>) -> Result<String> {
-    match fetch_latest_release(channel, proxy)? {
-        FetchedRelease { release, .. } => Ok(release.tag_name),
-    }
+    let FetchedRelease { release, .. } = fetch_latest_release(channel, proxy)?;
+    Ok(release.tag_name)
 }
 
 /// Fetch the latest release metadata from GitHub.

--- a/crates/tui/src/commands/share.rs
+++ b/crates/tui/src/commands/share.rs
@@ -164,7 +164,7 @@ async fn upload_gist(path: &Path) -> Result<String, String> {
             "gist",
             "create",
             "--public",
-            &path_owned.to_string_lossy().to_string(),
+            path_owned.to_string_lossy().as_ref(),
             "--filename",
             "session-export.html",
             "--desc",

--- a/crates/tui/src/tools/plugin.rs
+++ b/crates/tui/src/tools/plugin.rs
@@ -436,10 +436,10 @@ pub fn scan_plugin_dir(dir: &Path) -> Vec<(PathBuf, PluginMetadata)> {
         if path.is_dir() {
             continue;
         }
-        if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-            if name.starts_with('.') || name == "README.md" {
-                continue;
-            }
+        if let Some(name) = path.file_name().and_then(|n| n.to_str())
+            && (name.starts_with('.') || name == "README.md")
+        {
+            continue;
         }
 
         // Try to parse frontmatter


### PR DESCRIPTION
## Summary

fix clippy warnings and run fmt

## Testing

- [ x ] `cargo fmt --all -- --check`
- [ x ] `cargo clippy --workspace --all-targets --all-features`
- [ x ] `cargo test --workspace --all-features`

## Checklist

- [ x ] Updated docs or comments as needed
- [ x ] Added or updated tests where relevant
- [ x ] Verified TUI behavior manually if UI changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR applies mechanical code-quality fixes across three files: an irrefutable `let` destructure replaces a single-arm `match`, an unnecessary heap allocation (`to_string_lossy().to_string()`) is collapsed to `.as_ref()`, and a nested `if let` / inner `if` pair is merged into a single let-chain using the Rust 1.88 `let_chains` feature already required by the workspace.

- `crates/cli/src/update.rs`: replaces a single-arm `match` on `FetchedRelease` with an irrefutable `let` binding — purely cosmetic, identical behavior.
- `crates/tui/src/commands/share.rs`: eliminates a redundant `String` allocation when passing the path to `gh gist create`.
- `crates/tui/src/tools/plugin.rs`: collapses a nested `if let { if { continue; } }` into a single `if let … && … { continue; }` let-chain; logic is unchanged.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

All three changes are purely cosmetic Clippy/fmt fixes with no behavioral differences — safe to merge.

Each change is a direct mechanical equivalence: irrefutable let for a single-arm match, eliminating a redundant String allocation, and collapsing a nested guard into a let-chain. The workspace already locks rust-version = 1.88 which stabilizes let_chains, so no compatibility concerns. No logic is altered across any of the three files.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/cli/src/update.rs | Replaces a single-arm match on FetchedRelease with an irrefutable let binding — no behavioral change, cleaner Clippy-approved form. |
| crates/tui/src/commands/share.rs | Drops an unnecessary to_string() call on a Cow<str> when building the gh CLI argument array, avoiding a pointless heap allocation. |
| crates/tui/src/tools/plugin.rs | Merges nested if-let/if into a single let-chain guard; requires Rust 1.88 which the workspace already mandates. Logic is equivalent to the original. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[scan_plugin_dir: iterate entries] --> B{path.is_dir?}
    B -- Yes --> SKIP1[continue]
    B -- No --> C{file_name resolves to str AND starts with '.' or == README.md}
    C -- Yes --> SKIP2[continue]
    C -- No --> D[read_script_metadata]
    D --> E{metadata found?}
    E -- Yes --> F[push to results]
    E -- No --> G[skip file]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["style: fix clippy warnings and run fmt"](https://github.com/hmbown/codewhale/commit/12cba233df127d1577063e6081fdd4b0f4a5a6f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34786550)</sub>

<!-- /greptile_comment -->