### PR TITLE
docs: document layered PR process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,8 +139,8 @@ dependent layers. For those changes, use this workflow:
    what is explicitly out of scope, which issues it references, and which local
    commands were run.
 6. Use `Closes #...` only when the slice fully satisfies an issue. Use
-   `Refs #...` or `Partial #...` when the PR advances a broad issue but leaves
-   follow-up work.
+   `Refs #...` with a short `(partial)` note when the PR advances a broad issue
+   but leaves follow-up work.
 7. Structured commits are fine during review. Maintainers may squash or harvest
    at merge time, with contributor credit preserved through authorship,
    co-author trailers, changelog entries, or PR/issue comments.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,6 +121,52 @@ instead of the Harvest path, the highest-leverage things you can do are:
    these without prior discussion are unlikely to merge directly even
    when the change is well-implemented.
 
+## Layered and EPIC-Sized Work
+
+Some architecture work is too large for one PR but still needs to be built in
+dependent layers. For those changes, use this workflow:
+
+1. Start with a tracking issue or EPIC when the work spans multiple PRs. Name
+   the intended slices and state what each slice is not trying to close yet.
+2. Keep each implementation PR focused on one behavior boundary.
+3. Later layers may stay in your fork or open as draft PRs while the lower
+   layer is still moving. Draft stacked PR titles or descriptions should say
+   `Draft / depends on #NNNN`.
+4. A dependent PR is not ready for merge review until the lower layer has
+   landed, the branch has been rebased onto current `main`, and the PR targets
+   `main`.
+5. The PR body should identify which earlier PR it builds on, what is in scope,
+   what is explicitly out of scope, which issues it references, and which local
+   commands were run.
+6. Use `Closes #...` only when the slice fully satisfies an issue. Use
+   `Refs #...` or `Partial #...` when the PR advances a broad issue but leaves
+   follow-up work.
+7. Structured commits are fine during review. Maintainers may squash or harvest
+   at merge time, with contributor credit preserved through authorship,
+   co-author trailers, changelog entries, or PR/issue comments.
+
+Before asking for merge review on a layered PR, check that it is:
+
+- rebased onto current `main`
+- marked ready for review, not draft
+- focused to one behavior boundary
+- backed by local command evidence in the PR body
+- green in CI, or has any remaining red lane clearly explained
+- covered by round-trip or migration-preservation tests when it changes config
+  or schema behavior
+- referencing broad issues as partial unless it really closes them
+
+For layered work, a useful PR description shape is:
+
+```text
+Summary:
+Scope:
+Not in this slice:
+Builds on:
+Issues:
+Validation:
+```
+
 ## Agent-Assisted Improvements
 
 CodeWhale is allowed to help improve CodeWhale, but the contribution still has


### PR DESCRIPTION
Summary:
- Adds CONTRIBUTING.md guidance for layered and EPIC-sized work.
- Documents tracking issues, draft dependent PRs, rebasing onto main before merge review, closure wording, credit, and the ready checklist.

Scope:
- Documentation only.
- Focused on the process clarified in issue #2427.

Not in this slice:
- No issue-template, CI, or code changes.
- No changes to the harvest workflow outside the new layered-work section.

Builds on:
- Maintainer guidance from #2427.

Issues:
- Refs #2427

Validation:
- git diff --check

Paulo Aboim Pinto

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This documentation-only PR adds a \"Layered and EPIC-Sized Work\" section to `CONTRIBUTING.md`, documenting the workflow for large changes that must be delivered as dependent PR stacks.

- Introduces a 7-step workflow covering tracking issues, per-layer scoping, draft stacking, rebase discipline, PR body structure, `Closes` vs `Refs` usage, and credit/squash handling.
- Adds a pre-merge-review checklist and a lightweight PR description template (`Summary / Scope / Not in this slice / Builds on / Issues / Validation`).
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change with no code, config, or CI modifications — safe to merge.

The change touches only a markdown file and introduces no executable logic. All additions are prose guidance for contributors. The one flagged concern — ambiguity between the new PR description template and the existing `.github/PULL_REQUEST_TEMPLATE.md` — is a clarity gap, not a correctness defect.

No files require special attention; `CONTRIBUTING.md` is the only changed file and the change is additive prose.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| CONTRIBUTING.md | Adds a new "Layered and EPIC-Sized Work" section with a 7-step workflow, a pre-review checklist, and a PR description template; the new template's relationship to the existing `.github/PULL_REQUEST_TEMPLATE.md` is ambiguous. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Large / EPIC work identified] --> B[Open tracking issue or EPIC]
    B --> C[Slice work into dependent layers]
    C --> D[Implement Layer N PR]
    D --> E{Layer N merged?}
    E -- No --> F[Keep in fork or open as Draft PR\nTitle: 'Draft / depends on #NNNN']
    F --> E
    E -- Yes --> G[Rebase onto current main]
    G --> H[Mark PR ready for review\nTarget: main]
    H --> I{Pre-review checklist}
    I -- Fails --> J[Fix: rebase / CI / tests / scope]
    J --> I
    I -- Passes --> K[Request merge review]
    K --> L{Maintainer decision}
    L -- Direct merge --> M[PR merged, issue updated]
    L -- Harvest --> N[Commits harvested to main\nCredit preserved via authorship\nor co-author trailers]
    N --> M
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22docs%2Fstacked-pr-process%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Fstacked-pr-process%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACONTRIBUTING.md%3A159-168%0A**New%20template%20conflicts%20with%20the%20existing%20PR%20template%20requirement**%0A%0AThe%20%22Pull%20Request%20Guidelines%22%20section%20%28line%20233%29%20explicitly%20tells%20contributors%20to%20%22use%20the%20%5Bpull%20request%20template%5D%28.github%2FPULL_REQUEST_TEMPLATE.md%29%20when%20opening%20a%20PR%20%E2%80%94%20it%20includes%20the%20Summary%2C%20Testing%2C%20and%20Checklist%20sections%20reviewers%20expect.%22%20The%20existing%20template%20has%20a%20%60%23%23%20Testing%60%20section%20with%20explicit%20%60cargo%20fmt%60%2C%20%60cargo%20clippy%60%2C%20and%20%60cargo%20test%60%20checkboxes%2C%20plus%20a%20%60%23%23%20Checklist%60%20section.%0A%0AThe%20new%20layered-work%20template%20replaces%20those%20structured%20checkboxes%20with%20a%20free-form%20%60Validation%3A%60%20field%20and%20omits%20the%20%60%23%23%20Checklist%60%20entirely.%20A%20contributor%20working%20on%20a%20layered%20implementation%20PR%20who%20uses%20only%20this%20new%20shape%20would%20skip%20the%20standard%20Rust%20quality%20gates%20that%20the%20project%20relies%20on.%20The%20guidance%20should%20clarify%20whether%20this%20shape%20supplements%20the%20existing%20template%20%28i.e.%2C%20replace%20%60%23%23%20Summary%60%20with%20these%20fields%2C%20keep%20%60%23%23%20Testing%60%20and%20%60%23%23%20Checklist%60%29%20or%20replaces%20it%20for%20layered%20PRs%20%E2%80%94%20and%20if%20the%20latter%2C%20the%20cargo%20checks%20should%20be%20called%20out%20explicitly%20in%20%60Validation%3A%60.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACONTRIBUTING.md%3A159-168%0A**New%20template%20conflicts%20with%20the%20existing%20PR%20template%20requirement**%0A%0AThe%20%22Pull%20Request%20Guidelines%22%20section%20%28line%20233%29%20explicitly%20tells%20contributors%20to%20%22use%20the%20%5Bpull%20request%20template%5D%28.github%2FPULL_REQUEST_TEMPLATE.md%29%20when%20opening%20a%20PR%20%E2%80%94%20it%20includes%20the%20Summary%2C%20Testing%2C%20and%20Checklist%20sections%20reviewers%20expect.%22%20The%20existing%20template%20has%20a%20%60%23%23%20Testing%60%20section%20with%20explicit%20%60cargo%20fmt%60%2C%20%60cargo%20clippy%60%2C%20and%20%60cargo%20test%60%20checkboxes%2C%20plus%20a%20%60%23%23%20Checklist%60%20section.%0A%0AThe%20new%20layered-work%20template%20replaces%20those%20structured%20checkboxes%20with%20a%20free-form%20%60Validation%3A%60%20field%20and%20omits%20the%20%60%23%23%20Checklist%60%20entirely.%20A%20contributor%20working%20on%20a%20layered%20implementation%20PR%20who%20uses%20only%20this%20new%20shape%20would%20skip%20the%20standard%20Rust%20quality%20gates%20that%20the%20project%20relies%20on.%20The%20guidance%20should%20clarify%20whether%20this%20shape%20supplements%20the%20existing%20template%20%28i.e.%2C%20replace%20%60%23%23%20Summary%60%20with%20these%20fields%2C%20keep%20%60%23%23%20Testing%60%20and%20%60%23%23%20Checklist%60%29%20or%20replaces%20it%20for%20layered%20PRs%20%E2%80%94%20and%20if%20the%20latter%2C%20the%20cargo%20checks%20should%20be%20called%20out%20explicitly%20in%20%60Validation%3A%60.%0A%0A&repo=hmbown%2Fcodewhale&pr=2433&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACONTRIBUTING.md%3A159-168%0A**New%20template%20conflicts%20with%20the%20existing%20PR%20template%20requirement**%0A%0AThe%20%22Pull%20Request%20Guidelines%22%20section%20%28line%20233%29%20explicitly%20tells%20contributors%20to%20%22use%20the%20%5Bpull%20request%20template%5D%28.github%2FPULL_REQUEST_TEMPLATE.md%29%20when%20opening%20a%20PR%20%E2%80%94%20it%20includes%20the%20Summary%2C%20Testing%2C%20and%20Checklist%20sections%20reviewers%20expect.%22%20The%20existing%20template%20has%20a%20%60%23%23%20Testing%60%20section%20with%20explicit%20%60cargo%20fmt%60%2C%20%60cargo%20clippy%60%2C%20and%20%60cargo%20test%60%20checkboxes%2C%20plus%20a%20%60%23%23%20Checklist%60%20section.%0A%0AThe%20new%20layered-work%20template%20replaces%20those%20structured%20checkboxes%20with%20a%20free-form%20%60Validation%3A%60%20field%20and%20omits%20the%20%60%23%23%20Checklist%60%20entirely.%20A%20contributor%20working%20on%20a%20layered%20implementation%20PR%20who%20uses%20only%20this%20new%20shape%20would%20skip%20the%20standard%20Rust%20quality%20gates%20that%20the%20project%20relies%20on.%20The%20guidance%20should%20clarify%20whether%20this%20shape%20supplements%20the%20existing%20template%20%28i.e.%2C%20replace%20%60%23%23%20Summary%60%20with%20these%20fields%2C%20keep%20%60%23%23%20Testing%60%20and%20%60%23%23%20Checklist%60%29%20or%20replaces%20it%20for%20layered%20PRs%20%E2%80%94%20and%20if%20the%20latter%2C%20the%20cargo%20checks%20should%20be%20called%20out%20explicitly%20in%20%60Validation%3A%60.%0A%0A&pr=2433&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["docs: clarify partial issue references"](https://github.com/hmbown/codewhale/commit/1b710311134b5a7b1ad52a811b3f276b9b057614) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34786718)</sub>

<!-- /greptile_comment -->