### PR TITLE
fix: use effective_model_for_budget instead of raw model in compactio…

### DIFF
--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -5985,10 +5985,20 @@ mod tests {
 
     #[test]
     fn test_compaction_config() {
-        let app = App::new(test_options(false), &Config::default());
+        let mut app = App::new(test_options(false), &Config::default());
         let config = app.compaction_config();
         // Config should be valid (just checking it returns something)
         let _ = config.enabled;
+
+        app.auto_model = true;
+        app.model = "auto".to_string();
+        app.last_effective_model = None;
+        let config = app.compaction_config();
+        assert_eq!(config.model, DEFAULT_TEXT_MODEL);
+
+        app.last_effective_model = Some("deepseek-v4-flash".to_string());
+        let config = app.compaction_config();
+        assert_eq!(config.model, "deepseek-v4-flash");
     }
 
     #[test]

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -4733,7 +4733,7 @@ impl App {
         CompactionConfig {
             enabled: self.auto_compact,
             token_threshold: self.compact_threshold,
-            model: self.model.clone(),
+            model: self.effective_model_for_budget().to_string(),
             ..Default::default()
         }
     }


### PR DESCRIPTION
Bug: `/compact` returns HTTP 400 when model is set to "auto"

When the user switches the model to "auto" mode in the TUI, the App.model field holds the literal string "auto" . The compaction_config() method directly uses self.model.clone() as the model field in CompactionConfig, causing the chat completion request sent to the DeepSeek API to have "model": "auto".

The DeepSeek API only accepts concrete model IDs (e.g., deepseek-v4-flash, deepseek-v4-pro) and rejects "auto" with HTTP 400: "The supported API model names are...".

Root cause: compaction_config() doesn't use effective_model_for_budget() to resolve the actual model name when in auto mode. effective_model_for_budget() returns last_effective_model or falls back to DEFAULT_TEXT_MODEL when auto is active, ensuring a concrete model ID is always used.

Fix: Changed compaction_config() in crates/tui/src/tui/app.rs from model: self.model.clone() to model: self.effective_model_for_budget().to_string().

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where `/compact` returns HTTP 400 from the DeepSeek API when the model is set to "auto" mode, by replacing the raw `self.model.clone()` with `self.effective_model_for_budget().to_string()` in `compaction_config()`. The fix ensures a concrete model ID is always sent to the API.

- **Core fix** in `compaction_config()`: delegates to `effective_model_for_budget()`, which resolves `last_effective_model` (filtered to exclude the literal string `"auto"`) or falls back to `DEFAULT_TEXT_MODEL` — exactly the same resolution already used for token budget calculations elsewhere in the file.
- **Tests added**: two new assertions in `test_compaction_config` cover both branches of the auto-model path (`last_effective_model = None` → `DEFAULT_TEXT_MODEL`, and `last_effective_model = Some("deepseek-v4-flash")` → concrete ID), directly addressing the regression gap flagged in the prior review.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a one-line targeted fix that aligns compaction_config() with the already-established model-resolution pattern used elsewhere in the file.

The fix is minimal and correct: effective_model_for_budget() already handles every edge case (literal "auto" in last_effective_model, None fallback to DEFAULT_TEXT_MODEL, and the non-auto path returning self.model unchanged). The newly added test assertions directly validate both branches of the auto-model path, closing the regression gap from the prior review cycle. No other code paths are affected.

No files require special attention.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/app.rs | Single-line fix in `compaction_config()` replaces `self.model.clone()` with `self.effective_model_for_budget().to_string()`; two new test assertions cover both auto-model branches. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant TUI as TUI (App)
    participant CC as compaction_config()
    participant EMB as effective_model_for_budget()
    participant API as DeepSeek API

    TUI->>CC: trigger /compact
    CC->>EMB: resolve model ID
    alt "auto_model == true"
        EMB->>EMB: check last_effective_model
        alt "last_effective_model is Some and != auto"
            EMB-->>CC: return last_effective_model
        else
            EMB-->>CC: return DEFAULT_TEXT_MODEL
        end
    else "auto_model == false"
        EMB-->>CC: return self.model (concrete ID)
    end
    CC-->>TUI: CompactionConfig with concrete model ID
    TUI->>API: POST /chat/completions with concrete model ID
    API-->>TUI: 200 OK
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/tui/src/tui/app.rs`, line 5986-5992 ([link](https://github.com/hmbown/codewhale/blob/8e71ac06cc58702e45f8c402992fc123daf99e74/crates/tui/src/tui/app.rs#L5986-L5992)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Test doesn't cover the auto-model case**

   The existing `test_compaction_config` only checks that the returned struct is reachable — it never asserts that `config.model` is a concrete ID when `auto_model` is `true`. A test that sets `app.auto_model = true` (with `last_effective_model = None` and again with `Some("deepseek-v4-flash")`) and then asserts `config.model != "auto"` would have caught the original bug and would protect this fix from regressions.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fcompaction-auto-model%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fcompaction-auto-model%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%0ALine%3A%205986-5992%0A%0AComment%3A%0A**Test%20doesn't%20cover%20the%20auto-model%20case**%0A%0AThe%20existing%20%60test_compaction_config%60%20only%20checks%20that%20the%20returned%20struct%20is%20reachable%20%E2%80%94%20it%20never%20asserts%20that%20%60config.model%60%20is%20a%20concrete%20ID%20when%20%60auto_model%60%20is%20%60true%60.%20A%20test%20that%20sets%20%60app.auto_model%20%3D%20true%60%20%28with%20%60last_effective_model%20%3D%20None%60%20and%20again%20with%20%60Some%28%22deepseek-v4-flash%22%29%60%29%20and%20then%20asserts%20%60config.model%20!%3D%20%22auto%22%60%20would%20have%20caught%20the%20original%20bug%20and%20would%20protect%20this%20fix%20from%20regressions.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%0ALine%3A%205986-5992%0A%0AComment%3A%0A**Test%20doesn't%20cover%20the%20auto-model%20case**%0A%0AThe%20existing%20%60test_compaction_config%60%20only%20checks%20that%20the%20returned%20struct%20is%20reachable%20%E2%80%94%20it%20never%20asserts%20that%20%60config.model%60%20is%20a%20concrete%20ID%20when%20%60auto_model%60%20is%20%60true%60.%20A%20test%20that%20sets%20%60app.auto_model%20%3D%20true%60%20%28with%20%60last_effective_model%20%3D%20None%60%20and%20again%20with%20%60Some%28%22deepseek-v4-flash%22%29%60%29%20and%20then%20asserts%20%60config.model%20!%3D%20%22auto%22%60%20would%20have%20caught%20the%20original%20bug%20and%20would%20protect%20this%20fix%20from%20regressions.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2437&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%0ALine%3A%205986-5992%0A%0AComment%3A%0A**Test%20doesn't%20cover%20the%20auto-model%20case**%0A%0AThe%20existing%20%60test_compaction_config%60%20only%20checks%20that%20the%20returned%20struct%20is%20reachable%20%E2%80%94%20it%20never%20asserts%20that%20%60config.model%60%20is%20a%20concrete%20ID%20when%20%60auto_model%60%20is%20%60true%60.%20A%20test%20that%20sets%20%60app.auto_model%20%3D%20true%60%20%28with%20%60last_effective_model%20%3D%20None%60%20and%20again%20with%20%60Some%28%22deepseek-v4-flash%22%29%60%29%20and%20then%20asserts%20%60config.model%20!%3D%20%22auto%22%60%20would%20have%20caught%20the%20original%20bug%20and%20would%20protect%20this%20fix%20from%20regressions.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2437&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["test(tui): cover auto model compaction c..."](https://github.com/hmbown/codewhale/commit/f9bcc7c3bf43ded53912f291f6d129b3bb0f63a7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34792983)</sub>

<!-- /greptile_comment -->