### PR TITLE
fix(web_search): improve Volcengine reliability — 90 s timeout, retry, and faster model

### DIFF
--- a/crates/tui/src/tools/web_search.rs
+++ b/crates/tui/src/tools/web_search.rs
@@ -770,7 +770,7 @@ impl WebSearchTool {
             })?;
 
         // Volcengine Responses API pipeline (search + model inference) is
-        // slow — enforce a floor of 60 s while still honouring explicit
+        // slow — enforce a floor of 90 s while still honouring explicit
         // shorter timeouts from the caller (e.g. tests).
         let effective_timeout = timeout_ms.max(90_000);
 

--- a/crates/tui/src/tools/web_search.rs
+++ b/crates/tui/src/tools/web_search.rs
@@ -740,6 +740,12 @@ impl WebSearchTool {
     /// Search via Volcengine Ark Responses API web_search tool.
     /// Uses strict JSON prompt constraints to extract structured results
     /// from the model's search-augmented response.
+    ///
+    /// Overrides the user-supplied timeout to a minimum of 60 s because the
+    /// Responses API pipeline (web search → model inference → JSON generation)
+    /// is inherently slower than simple search-API round-trips.  A separate
+    /// `connect_timeout` of 15 s lets DNS/TLS failures surface quickly.
+    /// Transient transport errors are retried twice with exponential backoff.
     async fn run_volcengine_search(
         &self,
         query: &str,
@@ -763,8 +769,18 @@ impl WebSearchTool {
                 )
             })?;
 
+        // Volcengine Responses API pipeline (search + model inference) is
+        // slow — enforce a floor of 60 s while still honouring explicit
+        // shorter timeouts from the caller (e.g. tests).
+        let effective_timeout = timeout_ms.max(60_000);
+
         let client = reqwest::Client::builder()
-            .timeout(Duration::from_millis(timeout_ms))
+            .connect_timeout(Duration::from_secs(15))
+            .timeout(Duration::from_millis(effective_timeout))
+            .tcp_keepalive(Some(Duration::from_secs(30)))
+            .http2_keep_alive_interval(Some(Duration::from_secs(15)))
+            .http2_keep_alive_timeout(Duration::from_secs(20))
+            .user_agent(USER_AGENT)
             .build()
             .map_err(|e| {
                 ToolError::execution_failed(format!("Failed to build HTTP client: {e}"))
@@ -772,47 +788,77 @@ impl WebSearchTool {
 
         let payload = volcengine_search_payload(query, max_results);
 
-        let resp = client
-            .post(VOLCENGINE_RESPONSES_ENDPOINT)
-            .header("Authorization", format!("Bearer {api_key}"))
-            .json(&payload)
-            .send()
-            .await
-            .map_err(|e| {
-                ToolError::execution_failed(format!("Volcengine search request failed: {e}"))
-            })?;
+        // Retry transient transport errors (DNS, connection reset, timeout)
+        // up to 2 times with exponential backoff: 1 s, 2 s.
+        let mut last_err: Option<ToolError> = None;
+        for attempt in 0..3 {
+            if attempt > 0 {
+                tokio::time::sleep(Duration::from_millis(1000 * (1 << (attempt - 1)))).await;
+            }
 
-        let status = resp.status();
-        let body = resp.text().await.map_err(|e| {
-            ToolError::execution_failed(format!("Failed to read Volcengine response: {e}"))
-        })?;
+            match client
+                .post(VOLCENGINE_RESPONSES_ENDPOINT)
+                .header("Authorization", format!("Bearer {api_key}"))
+                .json(&payload)
+                .send()
+                .await
+            {
+                Ok(resp) => {
+                    let status = resp.status();
+                    let body = resp.text().await.map_err(|e| {
+                        ToolError::execution_failed(format!(
+                            "Failed to read Volcengine response: {e}"
+                        ))
+                    })?;
 
-        if !status.is_success() {
-            let msg = match status.as_u16() {
-                401 | 403 => "Volcengine API key rejected — check VOLCENGINE_API_KEY or `[search] api_key` in config.toml".to_string(),
-                429 => "Volcengine API rate-limited — wait and retry, or check your quota".to_string(),
-                _ => {
-                    let truncated = truncate_error_body(&body);
-                    format!("Volcengine search failed: HTTP {} — {truncated}", status.as_u16())
+                    if !status.is_success() {
+                        let msg = match status.as_u16() {
+                            401 | 403 => "Volcengine API key rejected — check VOLCENGINE_API_KEY or `[search] api_key` in config.toml".to_string(),
+                            429 => "Volcengine API rate-limited — wait and retry, or check your quota".to_string(),
+                            _ => {
+                                let truncated = truncate_error_body(&body);
+                                format!("Volcengine search failed: HTTP {} — {truncated}", status.as_u16())
+                            }
+                        };
+                        return Err(ToolError::execution_failed(msg));
+                    }
+
+                    let parsed: serde_json::Value = serde_json::from_str(&body).map_err(|e| {
+                        ToolError::execution_failed(format!(
+                            "Failed to parse Volcengine response: {e}"
+                        ))
+                    })?;
+
+                    if let Some(error) = volcengine_error_message(&parsed) {
+                        return Err(ToolError::execution_failed(error));
+                    }
+
+                    let response_text = volcengine_extract_text(&parsed).ok_or_else(|| {
+                        ToolError::execution_failed("Volcengine response contains no output text")
+                    })?;
+
+                    let results = parse_volcengine_results(&response_text, max_results);
+                    return search_tool_result(query.to_string(), "volcengine", results, None);
                 }
-            };
-            return Err(ToolError::execution_failed(msg));
+                Err(e) => {
+                    let is_transient = e.is_timeout() || e.is_connect() || e.is_request();
+                    if !is_transient || attempt == 2 {
+                        return Err(ToolError::execution_failed(format!(
+                            "Volcengine search request failed: {e}"
+                        )));
+                    }
+                    last_err = Some(ToolError::execution_failed(format!(
+                        "Volcengine search request failed (attempt {}/3): {e}",
+                        attempt + 1
+                    )));
+                }
+            }
         }
 
-        let parsed: serde_json::Value = serde_json::from_str(&body).map_err(|e| {
-            ToolError::execution_failed(format!("Failed to parse Volcengine response: {e}"))
-        })?;
-
-        if let Some(error) = volcengine_error_message(&parsed) {
-            return Err(ToolError::execution_failed(error));
-        }
-
-        let response_text = volcengine_extract_text(&parsed).ok_or_else(|| {
-            ToolError::execution_failed("Volcengine response contains no output text")
-        })?;
-
-        let results = parse_volcengine_results(&response_text, max_results);
-        search_tool_result(query.to_string(), "volcengine", results, None)
+        // Unreachable — the final iteration always returns above.
+        Err(last_err.unwrap_or_else(|| {
+            ToolError::execution_failed("Volcengine search: unexpected retry exit")
+        }))
     }
 }
 
@@ -914,7 +960,7 @@ fn baidu_search_payload(query: &str, max_results: usize) -> Value {
 
 fn volcengine_search_payload(query: &str, max_results: usize) -> Value {
     json!({
-        "model": "doubao-seed-1-6-250615",
+        "model": "doubao-seed-2-0-lite-260428",
         "stream": false,
         "tools": [{"type": "web_search"}],
         "input": [{

--- a/crates/tui/src/tools/web_search.rs
+++ b/crates/tui/src/tools/web_search.rs
@@ -770,8 +770,8 @@ impl WebSearchTool {
             })?;
 
         // Volcengine Responses API pipeline (search + model inference) is
-        // slow — enforce a floor of 90 s while still honouring explicit
-        // shorter timeouts from the caller (e.g. tests).
+        // slow, so enforce a floor of 90 s. The caller's value is used only
+        // when it exceeds 90_000 ms.
         let effective_timeout = timeout_ms.max(90_000);
 
         let client = reqwest::Client::builder()
@@ -841,7 +841,7 @@ impl WebSearchTool {
                     return search_tool_result(query.to_string(), "volcengine", results, None);
                 }
                 Err(e) => {
-                    let is_transient = e.is_timeout() || e.is_connect() || e.is_request();
+                    let is_transient = e.is_timeout() || e.is_connect();
                     if !is_transient || attempt == 2 {
                         return Err(ToolError::execution_failed(format!(
                             "Volcengine search request failed: {e}"

--- a/crates/tui/src/tools/web_search.rs
+++ b/crates/tui/src/tools/web_search.rs
@@ -741,7 +741,7 @@ impl WebSearchTool {
     /// Uses strict JSON prompt constraints to extract structured results
     /// from the model's search-augmented response.
     ///
-    /// Overrides the user-supplied timeout to a minimum of 60 s because the
+    /// Overrides the user-supplied timeout to a minimum of 90 s because the
     /// Responses API pipeline (web search → model inference → JSON generation)
     /// is inherently slower than simple search-API round-trips.  A separate
     /// `connect_timeout` of 15 s lets DNS/TLS failures surface quickly.
@@ -772,7 +772,7 @@ impl WebSearchTool {
         // Volcengine Responses API pipeline (search + model inference) is
         // slow — enforce a floor of 60 s while still honouring explicit
         // shorter timeouts from the caller (e.g. tests).
-        let effective_timeout = timeout_ms.max(60_000);
+        let effective_timeout = timeout_ms.max(90_000);
 
         let client = reqwest::Client::builder()
             .connect_timeout(Duration::from_secs(15))


### PR DESCRIPTION
## Summary

Improve Volcengine search reliability by addressing timeout issues and upgrading the underlying model:

- **Raise timeout floor to 90 s**: The Volcengine Responses API pipeline (web search → model inference → JSON generation) can take 50+ seconds on complex queries. The previous 60 s floor was too tight at the boundary; 90 s provides safe headroom.
- **Separate connect timeout**: A 15 s `connect_timeout` surfaces DNS/TLS failures quickly without being coupled to the overall request timeout.
- **Retry transient errors**: Transport errors (timeouts, connection resets) are retried up to 3 times with exponential backoff (1 s / 2 s).
- **Add keepalive and User-Agent**: TCP keepalive (30 s), HTTP/2 keepalive (15 s / 20 s idle), and a standard `User-Agent` header — matching patterns used elsewhere in the codebase.
- **Upgrade default model**: Switched from `doubao-seed-1-6-250615` to `doubao-seed-2-0-lite-260428`. The newer lite model delivers faster responses, which helps keep average request latency well within the timeout window.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features`
- [x] `cargo test --workspace --all-features` — **3733 passed**, 2 flaky MCP tests unrelated to this change failed:

  - `mcp::tests::legacy_sse_closed_stream_reconnects_and_retries_tool_call` (connection reset by peer)
  - `mcp::tests::streamable_http_stale_session_reconnects_and_retries_tool_call` (connection closed before message completed)

## Checklist

- [x] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [x] Verified TUI behavior manually if UI changes
<img width="1056" height="450" alt="image" src="https://github.com/user-attachments/assets/f1a90547-08aa-4992-b4b6-8522613aecb0" />

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR improves the reliability of the Volcengine web-search path by enforcing a 90 s request timeout floor (up from 60 s), splitting out a 15 s connect timeout, adding an exponential-backoff retry loop (up to 3 attempts) for transient transport errors, adding TCP/HTTP2 keepalives and a `User-Agent` header, and upgrading the default model from `doubao-seed-1-6-250615` to the faster `doubao-seed-2-0-lite-260428`.

- **Timeout and keepalive hardening** (`run_volcengine_search`): All networking improvements are applied to a per-call `reqwest::Client` built inside the function. The effective timeout respects the caller's value only when it exceeds 90,000 ms.
- **Retry loop**: `send()` errors are retried on `is_timeout() || is_connect()` with 1 s / 2 s delays; however, errors from the subsequent `resp.text()` body-read are not covered by the retry path, leaving a gap in the stated \"transient transport errors are retried\" guarantee.
- **Model upgrade**: The Volcengine payload switches to a lighter, faster model to reduce average latency relative to the new timeout floor.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is narrowly scoped to the Volcengine search path and does not touch shared infrastructure or other providers.

All changes are confined to `run_volcengine_search` and `volcengine_search_payload`. The timeout floor, keepalive settings, and model upgrade are straightforward configuration adjustments. The retry logic is correct for the `send()` phase and safe to apply to this idempotent read operation. The one gap — body-read failures not being retried — is a minor inconsistency with the stated intent rather than a functional regression; the non-streaming API makes mid-stream drops uncommon in practice.

No files require special attention beyond the retry coverage gap noted in `run_volcengine_search`.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tools/web_search.rs | Adds 90 s timeout floor, separate 15 s connect timeout, up to 3-attempt retry with exponential backoff, TCP/HTTP2 keepalives, User-Agent header, and upgrades the default Volcengine model. Retry coverage is limited to errors from `.send()` — body-read failures from `resp.text()` bypass the retry loop, partially contradicting the documented behaviour. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant run_volcengine_search
    participant reqwest Client
    participant Volcengine API

    Caller->>run_volcengine_search: query, max_results, timeout_ms
    run_volcengine_search->>run_volcengine_search: "effective_timeout = timeout_ms.max(90_000)"
    run_volcengine_search->>reqwest Client: build(connect_timeout=15s, timeout=effective_timeout, keepalive)

    loop attempts 0..2
        run_volcengine_search->>Volcengine API: POST /api/v3/responses (Bearer token, model=doubao-seed-2-0-lite-260428)
        alt send() succeeds
            Volcengine API-->>run_volcengine_search: HTTP response headers
            run_volcengine_search->>run_volcengine_search: resp.text() — NOT retried on failure
            run_volcengine_search->>Caller: Ok(results)
        else send() fails — is_timeout() or is_connect()
            run_volcengine_search->>run_volcengine_search: "sleep(1s << attempt)"
            Note over run_volcengine_search: retry (max 2 retries)
        else "send() fails — non-transient OR attempt==2"
            run_volcengine_search->>Caller: Err(ToolError)
        end
    end
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fvolcengine-search-timeout%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fvolcengine-search-timeout%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftools%2Fweb_search.rs%3A806-812%0A**Body-read%20failures%20bypass%20the%20retry%20loop**%0A%0AOnce%20%60send%28%29%60%20returns%20%60Ok%28resp%29%60%2C%20any%20error%20from%20%60resp.text%28%29.await%60%20propagates%20immediately%20through%20%60%3F%60%2C%20exiting%20the%20function%20entirely%20rather%20than%20looping%20back%20for%20another%20attempt.%20The%20doc-comment%20on%20the%20function%20and%20the%20inline%20comment%20at%20the%20start%20of%20the%20loop%20both%20say%20%22transient%20transport%20errors%20are%20retried%22%2C%20but%20a%20connection%20drop%20or%20timeout%20that%20fires%20while%20the%20response%20body%20is%20streaming%20will%20not%20be%20retried.%20This%20is%20inconsistent%20with%20the%20stated%20behaviour%3A%20a%20server%20that%20closes%20the%20connection%20mid-stream%2C%20or%20a%2090%20s%20timeout%20that%20fires%20during%20body%20receipt%2C%20will%20still%20produce%20an%20unretried%20error.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftools%2Fweb_search.rs%3A806-812%0A**Body-read%20failures%20bypass%20the%20retry%20loop**%0A%0AOnce%20%60send%28%29%60%20returns%20%60Ok%28resp%29%60%2C%20any%20error%20from%20%60resp.text%28%29.await%60%20propagates%20immediately%20through%20%60%3F%60%2C%20exiting%20the%20function%20entirely%20rather%20than%20looping%20back%20for%20another%20attempt.%20The%20doc-comment%20on%20the%20function%20and%20the%20inline%20comment%20at%20the%20start%20of%20the%20loop%20both%20say%20%22transient%20transport%20errors%20are%20retried%22%2C%20but%20a%20connection%20drop%20or%20timeout%20that%20fires%20while%20the%20response%20body%20is%20streaming%20will%20not%20be%20retried.%20This%20is%20inconsistent%20with%20the%20stated%20behaviour%3A%20a%20server%20that%20closes%20the%20connection%20mid-stream%2C%20or%20a%2090%20s%20timeout%20that%20fires%20during%20body%20receipt%2C%20will%20still%20produce%20an%20unretried%20error.%0A%0A&repo=hmbown%2Fcodewhale&pr=2439&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftools%2Fweb_search.rs%3A806-812%0A**Body-read%20failures%20bypass%20the%20retry%20loop**%0A%0AOnce%20%60send%28%29%60%20returns%20%60Ok%28resp%29%60%2C%20any%20error%20from%20%60resp.text%28%29.await%60%20propagates%20immediately%20through%20%60%3F%60%2C%20exiting%20the%20function%20entirely%20rather%20than%20looping%20back%20for%20another%20attempt.%20The%20doc-comment%20on%20the%20function%20and%20the%20inline%20comment%20at%20the%20start%20of%20the%20loop%20both%20say%20%22transient%20transport%20errors%20are%20retried%22%2C%20but%20a%20connection%20drop%20or%20timeout%20that%20fires%20while%20the%20response%20body%20is%20streaming%20will%20not%20be%20retried.%20This%20is%20inconsistent%20with%20the%20stated%20behaviour%3A%20a%20server%20that%20closes%20the%20connection%20mid-stream%2C%20or%20a%2090%20s%20timeout%20that%20fires%20during%20body%20receipt%2C%20will%20still%20produce%20an%20unretried%20error.%0A%0A&pr=2439&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["fix(web\_search): tighten Volcengine retr..."](https://github.com/hmbown/codewhale/commit/fa1c9e3a13b9c13c9d6d687ca4c981e12a98039d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34800669)</sub>

<!-- /greptile_comment -->