### PR TITLE
test(mcp): add comprehensive unit tests for MCP manager and helpers

### DIFF
--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -957,3 +957,392 @@ impl JsonRpcError {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── InMemoryMcpClient ──────────────────────────────────────────────
+
+    #[test]
+    fn in_memory_client_list_tools_returns_registered() {
+        let client = InMemoryMcpClient::default()
+            .with_tool("echo", json!({"output": "hi"}))
+            .with_tool("greet", json!({"msg": "hello"}));
+        let tools = client.list_tools().unwrap();
+        assert_eq!(tools.len(), 2);
+        let names: Vec<&str> = tools.iter().map(|t| t.tool_name.as_str()).collect();
+        assert!(names.contains(&"echo"));
+        assert!(names.contains(&"greet"));
+    }
+
+    #[test]
+    fn in_memory_client_call_tool_returns_value() {
+        let client = InMemoryMcpClient::default()
+            .with_tool("echo", json!({"output": "hi"}));
+        let result = client.call_tool("echo", json!({})).unwrap();
+        assert_eq!(result["output"], "hi");
+    }
+
+    #[test]
+    fn in_memory_client_call_tool_errors_on_missing() {
+        let client = InMemoryMcpClient::default();
+        let err = client.call_tool("nope", json!({})).unwrap_err();
+        assert!(err.to_string().contains("not found"));
+    }
+
+    #[test]
+    fn in_memory_client_list_resources_returns_registered() {
+        let client = InMemoryMcpClient::default()
+            .with_resource("mcp://s/health", json!({"ok": true}))
+            .with_resource("mcp://s/caps", json!({"tools": []}));
+        let resources = client.list_resources().unwrap();
+        assert_eq!(resources.len(), 2);
+    }
+
+    #[test]
+    fn in_memory_client_read_resource_returns_value() {
+        let client = InMemoryMcpClient::default()
+            .with_resource("mcp://s/health", json!({"ok": true}));
+        let result = client.read_resource("mcp://s/health").unwrap();
+        assert_eq!(result["ok"], true);
+    }
+
+    #[test]
+    fn in_memory_client_read_resource_errors_on_missing() {
+        let client = InMemoryMcpClient::default();
+        let err = client.read_resource("mcp://s/nope").unwrap_err();
+        assert!(err.to_string().contains("not found"));
+    }
+
+    // ── McpManager ─────────────────────────────────────────────────────
+
+    fn make_server_config(name: &str) -> McpServerConfig {
+        McpServerConfig {
+            name: name.to_string(),
+            command: "test".to_string(),
+            args: vec![],
+            env: HashMap::new(),
+            enabled: true,
+        }
+    }
+
+    #[test]
+    fn manager_start_all_marks_ready_for_registered_clients() {
+        let mut manager = McpManager::default();
+        manager.register_server(
+            make_server_config("s1"),
+            ToolFilter::default(),
+            Box::new(InMemoryMcpClient::default().with_tool("t", json!(null))),
+        );
+        let mut events = Vec::new();
+        let summary = manager.start_all(|e| events.push(e));
+        assert_eq!(summary.ready, vec!["s1"]);
+        assert!(summary.failed.is_empty());
+        assert_eq!(events.len(), 2); // Starting + Ready
+    }
+
+    #[test]
+    fn manager_start_all_marks_failed_when_client_missing() {
+        let mut manager = McpManager::default();
+        manager.configs.insert(
+            "s1".to_string(),
+            (
+                make_server_config("s1"),
+                ToolFilter::default(),
+            ),
+        );
+        let summary = manager.start_all(|_| {});
+        assert!(summary.ready.is_empty());
+        assert_eq!(summary.failed.len(), 1);
+        assert_eq!(summary.failed[0].server_name, "s1");
+    }
+
+    #[test]
+    fn manager_start_all_cancels_disabled_servers() {
+        let mut manager = McpManager::default();
+        let mut cfg = make_server_config("s1");
+        cfg.enabled = false;
+        manager.register_server(cfg, ToolFilter::default(), Box::new(InMemoryMcpClient::default()));
+        let summary = manager.start_all(|_| {});
+        assert!(summary.ready.is_empty());
+        assert_eq!(summary.cancelled, vec!["s1"]);
+    }
+
+    #[test]
+    fn manager_list_tools_applies_filter() {
+        let mut manager = McpManager::default();
+        let client = InMemoryMcpClient::default()
+            .with_tool("allowed", json!(null))
+            .with_tool("denied", json!(null));
+        manager.register_server(
+            make_server_config("s1"),
+            ToolFilter {
+                allow: vec!["allowed".to_string()],
+                deny: vec![],
+            },
+            Box::new(client),
+        );
+        let tools = manager.list_tools().unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].tool_name, "allowed");
+    }
+
+    #[test]
+    fn manager_list_tools_deny_overrides_allow() {
+        let mut manager = McpManager::default();
+        let client = InMemoryMcpClient::default()
+            .with_tool("a", json!(null))
+            .with_tool("b", json!(null));
+        manager.register_server(
+            make_server_config("s1"),
+            ToolFilter {
+                allow: vec!["a".to_string(), "b".to_string()],
+                deny: vec!["b".to_string()],
+            },
+            Box::new(client),
+        );
+        let tools = manager.list_tools().unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].tool_name, "a");
+    }
+
+    #[test]
+    fn manager_call_tool_delegates_to_client() {
+        let mut manager = McpManager::default();
+        manager.register_server(
+            make_server_config("s1"),
+            ToolFilter::default(),
+            Box::new(InMemoryMcpClient::default().with_tool("t", json!({"v": 42}))),
+        );
+        let result = manager.call_tool("s1", "t", json!({})).unwrap();
+        assert_eq!(result["v"], 42);
+    }
+
+    #[test]
+    fn manager_call_tool_errors_on_missing_server() {
+        let manager = McpManager::default();
+        let err = manager.call_tool("nope", "t", json!({})).unwrap_err();
+        assert!(err.to_string().contains("not available"));
+    }
+
+    #[test]
+    fn manager_call_qualified_tool_parses_name() {
+        let mut manager = McpManager::default();
+        manager.register_server(
+            make_server_config("my_server"),
+            ToolFilter::default(),
+            Box::new(InMemoryMcpClient::default().with_tool("my_tool", json!({"ok": true}))),
+        );
+        let result = manager
+            .call_qualified_tool("mcp__my_server__my_tool", json!({}))
+            .unwrap();
+        assert_eq!(result["ok"], true);
+    }
+
+    #[test]
+    fn manager_unregister_removes_server() {
+        let mut manager = McpManager::default();
+        manager.register_server(
+            make_server_config("s1"),
+            ToolFilter::default(),
+            Box::new(InMemoryMcpClient::default()),
+        );
+        manager.unregister_server("s1").unwrap();
+        assert!(manager.configs.is_empty());
+    }
+
+    #[test]
+    fn manager_unregister_errors_on_unknown() {
+        let mut manager = McpManager::default();
+        let err = manager.unregister_server("nope").unwrap_err();
+        assert!(err.to_string().contains("not registered"));
+    }
+
+    #[test]
+    fn manager_stop_server_errors_on_unknown() {
+        let mut manager = McpManager::default();
+        let err = manager.stop_server("nope").unwrap_err();
+        assert!(err.to_string().contains("not running"));
+    }
+
+    #[test]
+    fn manager_list_resources_returns_from_clients() {
+        let mut manager = McpManager::default();
+        manager.register_server(
+            make_server_config("s1"),
+            ToolFilter::default(),
+            Box::new(
+                InMemoryMcpClient::default()
+                    .with_resource("mcp://s1/health", json!({"ok": true})),
+            ),
+        );
+        let resources = manager.list_resources().unwrap();
+        assert_eq!(resources.len(), 1);
+        assert_eq!(resources[0].server_name, "s1");
+    }
+
+    #[test]
+    fn manager_read_resource_delegates() {
+        let mut manager = McpManager::default();
+        manager.register_server(
+            make_server_config("s1"),
+            ToolFilter::default(),
+            Box::new(
+                InMemoryMcpClient::default()
+                    .with_resource("mcp://s1/health", json!({"ok": true})),
+            ),
+        );
+        let result = manager.read_resource("s1", "mcp://s1/health").unwrap();
+        assert_eq!(result["ok"], true);
+    }
+
+    #[test]
+    fn manager_update_sandbox_state_returns_notices() {
+        let mut manager = McpManager::default();
+        manager.register_server(
+            make_server_config("s1"),
+            ToolFilter::default(),
+            Box::new(InMemoryMcpClient::default()),
+        );
+        let notices = manager.update_sandbox_state("strict", "/tmp").unwrap();
+        assert_eq!(notices.len(), 1);
+        assert_eq!(notices[0]["server_name"], "s1");
+    }
+
+    // ── Tool filter ────────────────────────────────────────────────────
+
+    #[test]
+    fn allowed_by_filter_empty_allow_permits_all() {
+        let filter = ToolFilter {
+            allow: vec![],
+            deny: vec![],
+        };
+        assert!(allowed_by_filter("anything", &filter));
+    }
+
+    #[test]
+    fn allowed_by_filter_deny_blocks() {
+        let filter = ToolFilter {
+            allow: vec![],
+            deny: vec!["danger".to_string()],
+        };
+        assert!(!allowed_by_filter("danger", &filter));
+        assert!(allowed_by_filter("safe", &filter));
+    }
+
+    #[test]
+    fn allowed_by_filter_allow_only_permits_listed() {
+        let filter = ToolFilter {
+            allow: vec!["a".to_string()],
+            deny: vec![],
+        };
+        assert!(allowed_by_filter("a", &filter));
+        assert!(!allowed_by_filter("b", &filter));
+    }
+
+    // ── Helper functions ───────────────────────────────────────────────
+
+    #[test]
+    fn sanitize_component_lowercases_and_replaces_specials() {
+        assert_eq!(sanitize_component("My-Server.Name"), "my_server_name");
+        assert_eq!(sanitize_component("ABC123"), "abc123");
+    }
+
+    #[test]
+    fn qualify_tool_name_produces_mcp_prefix() {
+        let name = qualify_tool_name("server", "tool");
+        assert!(name.starts_with("mcp__server__tool"));
+    }
+
+    #[test]
+    fn qualify_tool_name_truncates_long_names() {
+        let long_server = "a".repeat(100);
+        let name = qualify_tool_name(&long_server, "tool");
+        assert!(name.len() <= 64);
+    }
+
+    #[test]
+    fn parse_qualified_tool_name_round_trip() {
+        let qualified = qualify_tool_name("my_server", "my_tool");
+        let (server, tool) = parse_qualified_tool_name(&qualified).unwrap();
+        assert_eq!(server, "my_server");
+        assert_eq!(tool, "my_tool");
+    }
+
+    #[test]
+    fn parse_qualified_tool_name_rejects_missing_prefix() {
+        let err = parse_qualified_tool_name("not_mcp__server__tool").unwrap_err();
+        assert!(err.to_string().contains("missing mcp__ prefix"));
+    }
+
+    #[test]
+    fn parse_qualified_tool_name_rejects_empty_segments() {
+        let err = parse_qualified_tool_name("mcp____tool").unwrap_err();
+        assert!(err.to_string().contains("missing server segment"));
+    }
+
+    #[test]
+    fn parse_server_from_uri_extracts_server() {
+        assert_eq!(
+            parse_server_from_uri("mcp://my-server/capabilities"),
+            Some("my-server".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_server_from_uri_returns_none_for_invalid() {
+        assert!(parse_server_from_uri("http://not-mcp").is_none());
+        assert!(parse_server_from_uri("mcp:///path").is_none());
+    }
+
+    // ── JsonRpcError ───────────────────────────────────────────────────
+
+    #[test]
+    fn jsonrpc_error_codes_are_correct() {
+        assert_eq!(JsonRpcError::parse_error("").code, -32700);
+        assert_eq!(JsonRpcError::invalid_request("").code, -32600);
+        assert_eq!(JsonRpcError::method_not_found("x").code, -32601);
+        assert_eq!(JsonRpcError::invalid_params("").code, -32602);
+        assert_eq!(JsonRpcError::internal("").code, -32603);
+    }
+
+    #[test]
+    fn jsonrpc_result_produces_valid_envelope() {
+        let result = jsonrpc_result(Some(json!(1)), json!({"ok": true}));
+        assert_eq!(result["jsonrpc"], "2.0");
+        assert_eq!(result["id"], 1);
+        assert_eq!(result["result"]["ok"], true);
+    }
+
+    #[test]
+    fn jsonrpc_error_produces_valid_envelope() {
+        let err = jsonrpc_error(
+            Some(json!(2)),
+            JsonRpcError::invalid_params("bad"),
+        );
+        assert_eq!(err["jsonrpc"], "2.0");
+        assert_eq!(err["id"], 2);
+        assert_eq!(err["error"]["code"], -32602);
+    }
+
+    // ── McpServerConfig serialization ──────────────────────────────────
+
+    #[test]
+    fn mcp_server_config_defaults_enabled_to_true() {
+        let json = json!({"name": "s", "command": "cmd"});
+        let config: McpServerConfig = serde_json::from_value(json).unwrap();
+        assert!(config.enabled);
+        assert!(config.args.is_empty());
+        assert!(config.env.is_empty());
+    }
+
+    #[test]
+    fn mcp_startup_status_serializes_with_snake_case() {
+        let status = McpStartupStatus::Failed {
+            error: "oops".to_string(),
+        };
+        let json = serde_json::to_value(&status).unwrap();
+        assert_eq!(json["failed"]["error"], "oops");
+    }
+}

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -318,8 +318,31 @@ impl McpManager {
         qualified_tool_name: &str,
         arguments: Value,
     ) -> Result<Value> {
-        let (server_name, tool_name) = parse_qualified_tool_name(qualified_tool_name)
-            .with_context(|| format!("invalid qualified MCP tool name: {qualified_tool_name}"))?;
+        let parsed = parse_qualified_tool_name(qualified_tool_name)
+            .with_context(|| format!("invalid qualified MCP tool name: {qualified_tool_name}"));
+
+        if let Ok((server_name, tool_name)) = &parsed
+            && self.clients.contains_key(server_name)
+            && let Ok(result) = self.call_tool(server_name, tool_name, arguments.clone())
+        {
+            return Ok(result);
+        }
+
+        for (server_name, (_, filter)) in &self.configs {
+            let Some(client) = self.clients.get(server_name) else {
+                continue;
+            };
+            for tool in client.list_tools()? {
+                if !allowed_by_filter(&tool.tool_name, filter) {
+                    continue;
+                }
+                if qualify_tool_name(server_name, &tool.tool_name) == qualified_tool_name {
+                    return client.call_tool(&tool.tool_name, arguments);
+                }
+            }
+        }
+
+        let (server_name, tool_name) = parsed?;
         self.call_tool(&server_name, &tool_name, arguments)
     }
 
@@ -392,18 +415,29 @@ fn sanitize_component(value: &str) -> String {
 }
 
 fn qualify_tool_name(server: &str, tool: &str) -> String {
-    let mut name = format!(
-        "mcp__{}__{}",
-        sanitize_component(server),
-        sanitize_component(tool)
-    );
+    let server = sanitize_component(server);
+    let tool = sanitize_component(tool);
+    let mut name = format!("mcp__{server}__{tool}");
     if name.len() > 64 {
         let mut hasher = DefaultHasher::new();
         name.hash(&mut hasher);
         let hash = format!("{:x}", hasher.finish());
-        name.truncate(48);
-        name.push('_');
-        name.push_str(&hash[..12]);
+        let suffix = format!("_{}", &hash[..12]);
+        let component_budget = 64 - "mcp__".len() - "__".len() - suffix.len();
+        let mut server_len = server.len().min(component_budget / 2);
+        let mut tool_len = tool.len().min(component_budget - server_len);
+        let remaining = component_budget - server_len - tool_len;
+        if remaining > 0 {
+            let server_extra = (server.len() - server_len).min(remaining);
+            server_len += server_extra;
+            tool_len += (tool.len() - tool_len).min(remaining - server_extra);
+        }
+        name = format!(
+            "mcp__{}__{}{}",
+            &server[..server_len],
+            &tool[..tool_len],
+            suffix
+        );
     }
     name
 }
@@ -1038,16 +1072,25 @@ mod tests {
         let summary = manager.start_all(|e| events.push(e));
         assert_eq!(summary.ready, vec!["s1"]);
         assert!(summary.failed.is_empty());
-        assert_eq!(events.len(), 2); // Starting + Ready
+        assert!(events.iter().any(|event| {
+            event.server_name == "s1" && event.status == McpStartupStatus::Starting
+        }));
+        assert!(
+            events.iter().any(|event| {
+                event.server_name == "s1" && event.status == McpStartupStatus::Ready
+            })
+        );
     }
 
     #[test]
     fn manager_start_all_marks_failed_when_client_missing() {
         let mut manager = McpManager::default();
-        manager.configs.insert(
-            "s1".to_string(),
-            (make_server_config("s1"), ToolFilter::default()),
+        manager.register_server(
+            make_server_config("s1"),
+            ToolFilter::default(),
+            Box::new(InMemoryMcpClient::default()),
         );
+        manager.stop_server("s1").unwrap();
         let summary = manager.start_all(|_| {});
         assert!(summary.ready.is_empty());
         assert_eq!(summary.failed.len(), 1);
@@ -1137,6 +1180,25 @@ mod tests {
         let result = manager
             .call_qualified_tool("mcp__my_server__my_tool", json!({}))
             .unwrap();
+        assert_eq!(result["ok"], true);
+    }
+
+    #[test]
+    fn manager_call_qualified_tool_handles_truncated_names() {
+        let long_server = "server".repeat(20);
+        let long_tool = "tool".repeat(20);
+        let mut manager = McpManager::default();
+        manager.register_server(
+            make_server_config(&long_server),
+            ToolFilter::default(),
+            Box::new(InMemoryMcpClient::default().with_tool(&long_tool, json!({"ok": true}))),
+        );
+        let tools = manager.list_tools().unwrap();
+        let qualified = &tools[0].qualified_name;
+        assert!(qualified.len() <= 64);
+        assert!(parse_qualified_tool_name(qualified).is_ok());
+
+        let result = manager.call_qualified_tool(qualified, json!({})).unwrap();
         assert_eq!(result["ok"], true);
     }
 
@@ -1258,6 +1320,7 @@ mod tests {
         let long_server = "a".repeat(100);
         let name = qualify_tool_name(&long_server, "tool");
         assert!(name.len() <= 64);
+        assert!(parse_qualified_tool_name(&name).is_ok());
     }
 
     #[test]

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -978,8 +978,7 @@ mod tests {
 
     #[test]
     fn in_memory_client_call_tool_returns_value() {
-        let client = InMemoryMcpClient::default()
-            .with_tool("echo", json!({"output": "hi"}));
+        let client = InMemoryMcpClient::default().with_tool("echo", json!({"output": "hi"}));
         let result = client.call_tool("echo", json!({})).unwrap();
         assert_eq!(result["output"], "hi");
     }
@@ -1002,8 +1001,8 @@ mod tests {
 
     #[test]
     fn in_memory_client_read_resource_returns_value() {
-        let client = InMemoryMcpClient::default()
-            .with_resource("mcp://s/health", json!({"ok": true}));
+        let client =
+            InMemoryMcpClient::default().with_resource("mcp://s/health", json!({"ok": true}));
         let result = client.read_resource("mcp://s/health").unwrap();
         assert_eq!(result["ok"], true);
     }
@@ -1047,10 +1046,7 @@ mod tests {
         let mut manager = McpManager::default();
         manager.configs.insert(
             "s1".to_string(),
-            (
-                make_server_config("s1"),
-                ToolFilter::default(),
-            ),
+            (make_server_config("s1"), ToolFilter::default()),
         );
         let summary = manager.start_all(|_| {});
         assert!(summary.ready.is_empty());
@@ -1063,7 +1059,11 @@ mod tests {
         let mut manager = McpManager::default();
         let mut cfg = make_server_config("s1");
         cfg.enabled = false;
-        manager.register_server(cfg, ToolFilter::default(), Box::new(InMemoryMcpClient::default()));
+        manager.register_server(
+            cfg,
+            ToolFilter::default(),
+            Box::new(InMemoryMcpClient::default()),
+        );
         let summary = manager.start_all(|_| {});
         assert!(summary.ready.is_empty());
         assert_eq!(summary.cancelled, vec!["s1"]);
@@ -1173,8 +1173,7 @@ mod tests {
             make_server_config("s1"),
             ToolFilter::default(),
             Box::new(
-                InMemoryMcpClient::default()
-                    .with_resource("mcp://s1/health", json!({"ok": true})),
+                InMemoryMcpClient::default().with_resource("mcp://s1/health", json!({"ok": true})),
             ),
         );
         let resources = manager.list_resources().unwrap();
@@ -1189,8 +1188,7 @@ mod tests {
             make_server_config("s1"),
             ToolFilter::default(),
             Box::new(
-                InMemoryMcpClient::default()
-                    .with_resource("mcp://s1/health", json!({"ok": true})),
+                InMemoryMcpClient::default().with_resource("mcp://s1/health", json!({"ok": true})),
             ),
         );
         let result = manager.read_resource("s1", "mcp://s1/health").unwrap();
@@ -1317,10 +1315,7 @@ mod tests {
 
     #[test]
     fn jsonrpc_error_produces_valid_envelope() {
-        let err = jsonrpc_error(
-            Some(json!(2)),
-            JsonRpcError::invalid_params("bad"),
-        );
+        let err = jsonrpc_error(Some(json!(2)), JsonRpcError::invalid_params("bad"));
         assert_eq!(err["jsonrpc"], "2.0");
         assert_eq!(err["id"], 2);
         assert_eq!(err["error"]["code"], -32602);


### PR DESCRIPTION
Add 36 unit tests covering the previously untested `mcp` crate:

- **InMemoryMcpClient**: tool/resource registration, listing, calling, error on missing
- **McpManager**: start_all (ready/failed/cancelled states), list_tools with allow/deny filters, call_tool, call_qualified_tool, unregister, stop, list_resources, read_resource, sandbox state updates
- **Tool filter**: allow/deny semantics, deny-overrides-allow precedence
- **Helper functions**: sanitize_component, qualify_tool_name (incl. truncation), parse_qualified_tool_name round-trip and validation, parse_server_from_uri
- **JsonRpcError**: all 5 error code constructors, envelope formatting
- **Serialization**: McpServerConfig default deserialization, McpStartupStatus snake_case

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds 36 unit tests for the previously untested `mcp` crate, covering `InMemoryMcpClient`, `McpManager`, `ToolFilter`, helper functions, `JsonRpcError`, and serialization. The tests are generally well-structured and match the public API, but one test for `qualify_tool_name` truncation is incomplete in a way that conceals a real production-code defect.

- **Truncation round-trip gap**: `qualify_tool_name` strips the `__` separator when it appends a hash suffix for long names. `parse_qualified_tool_name` (used by `call_qualified_tool`) then fails with \"missing tool segment\" on any such name — meaning tools on servers with long names can be listed but never called. The truncation test only asserts `name.len() <= 64` and misses this.
- **Private-field access in one test**: `manager_start_all_marks_failed_when_client_missing` directly inserts into the private `configs` HashMap rather than going through the public API, making the test fragile to internal refactoring.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge as a test-only change with no production code modifications, but the incomplete truncation test leaves a real tool-invocation defect undetected.

The truncation test only checks output length and misses verifying that the resulting name survives a round-trip through parse_qualified_tool_name. In production, list_tools() generates qualified names via qualify_tool_name and call_qualified_tool parses them. When truncation fires, the __ separator is eliminated, so every call_qualified_tool invocation on a long-named tool will error with 'missing tool segment'. The test suite does not currently surface this defect.

crates/mcp/src/lib.rs — specifically the qualify_tool_name_truncates_long_names test and the associated production logic in qualify_tool_name/parse_qualified_tool_name.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/mcp/src/lib.rs | Adds 36 unit tests covering InMemoryMcpClient, McpManager, ToolFilter, helper functions, JsonRpcError, and serialization. One significant gap: the truncation test for qualify_tool_name only asserts length <= 64 but does not verify the resulting name is parseable, hiding a real production bug where truncated names cannot be round-tripped through parse_qualified_tool_name. One test also bypasses the public API by directly mutating a private field. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant AI as AI / Caller
    participant MM as McpManager
    participant QFN as qualify_tool_name
    participant PQN as parse_qualified_tool_name
    participant Client as McpManagedClient

    AI->>MM: list_tools()
    MM->>Client: list_tools() → [tool_name]
    MM->>QFN: qualify_tool_name(server, tool_name)
    QFN-->>MM: "qualified_name (may be truncated if >64 chars)"
    MM-->>AI: "[McpToolDescriptor { qualified_name }]"

    AI->>MM: call_qualified_tool(qualified_name, args)
    MM->>PQN: parse_qualified_tool_name(qualified_name)
    alt name was truncated (no __ separator between server/tool)
        PQN-->>MM: Err(missing tool segment)
        MM-->>AI: Error
    else name fits in 64 chars (normal case)
        PQN-->>MM: (server_name, tool_name)
        MM->>Client: call_tool(tool_name, args)
        Client-->>MM: result
        MM-->>AI: result
    end
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22test%2Fmcp-crate-unit-tests%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22test%2Fmcp-crate-unit-tests%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Fmcp%2Fsrc%2Flib.rs%3A1155-1160%0A**Truncation%20test%20doesn't%20verify%20parseability%20%E2%80%94%20hides%20a%20production%20bug**%0A%0A%60qualify_tool_name%60%20appends%20a%20hash%20suffix%20when%20the%20full%20name%20exceeds%2064%20characters%2C%20which%20removes%20the%20%60__%60%20separator%20between%20the%20server%20and%20tool%20segments.%20Because%20of%20this%2C%20%60parse_qualified_tool_name%60%20%28and%20therefore%20%60call_qualified_tool%60%29%20will%20always%20return%20%60Err%28%22missing%20tool%20segment%22%29%60%20for%20any%20truncated%20name.%20The%20test%20currently%20only%20checks%20that%20%60name.len%28%29%20%3C%3D%2064%60%3B%20it%20should%20also%20assert%20that%20the%20result%20can%20be%20parsed%2C%20or%20pair%20with%20a%20round-trip%20through%20%60call_qualified_tool%60.%20A%20failing%20assertion%20here%20would%20surface%20the%20underlying%20bug%20where%20any%20tool%20on%20a%20server%20with%20a%20long%20name%20can%20be%20listed%20by%20%60list_tools%28%29%60%20but%20never%20actually%20invoked.%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Fmcp%2Fsrc%2Flib.rs%3A986-998%0A**Test%20bypasses%20the%20public%20API%20by%20directly%20mutating%20private%20fields**%0A%0A%60manager.configs%60%20is%20a%20private%20field%3B%20accessing%20it%20from%20the%20test%20module%20is%20permitted%20in%20Rust%20%28child%20modules%20inherit%20parent-module%20privacy%29%20but%20it%20tightly%20couples%20the%20test%20to%20internal%20struct%20layout.%20If%20%60configs%60%20is%20renamed%20or%20its%20type%20changes%2C%20this%20test%20breaks%20at%20compile%20time%20without%20any%20indication%20of%20which%20behavior%20regressed.%20The%20same%20scenario%20%28a%20config%20registered%20without%20a%20live%20client%29%20could%20be%20simulated%20via%20the%20public%20API%20by%20inserting%20the%20config%20through%20%60register_server%60%20and%20then%20immediately%20calling%20%60stop_server%60%20to%20remove%20the%20client%2C%20keeping%20the%20config%20in%20place.%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Fmcp%2Fsrc%2Flib.rs%3A965-978%0A**Hardcoded%20event%20count%20is%20sensitive%20to%20HashMap%20iteration%20order**%0A%0A%60McpManager.configs%60%20is%20a%20%60HashMap%60%2C%20so%20when%20multiple%20servers%20are%20present%20the%20iteration%20order%20in%20%60start_all%60%20is%20non-deterministic.%20This%20single-server%20test%20sidesteps%20the%20problem%20today%2C%20but%20the%20%60assert_eq!%28events.len%28%29%2C%202%29%60%20comment%20%28%22Starting%20%2B%20Ready%22%29%20also%20implicitly%20documents%20that%20exactly%20two%20events%20are%20emitted%20per%20ready%20server.%20If%20a%20future%20implementation%20change%20emits%20an%20intermediate%20event%20%28e.g.%20%22Connecting%22%29%2C%20this%20assertion%20would%20spuriously%20fail.%20Consider%20asserting%20on%20the%20event%20*variants*%20rather%20than%20the%20raw%20count%2C%20e.g.%20check%20that%20the%20events%20contain%20a%20%60Starting%60%20followed%20by%20a%20%60Ready%60%20status%20for%20%22s1%22.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Fmcp%2Fsrc%2Flib.rs%3A1155-1160%0A**Truncation%20test%20doesn't%20verify%20parseability%20%E2%80%94%20hides%20a%20production%20bug**%0A%0A%60qualify_tool_name%60%20appends%20a%20hash%20suffix%20when%20the%20full%20name%20exceeds%2064%20characters%2C%20which%20removes%20the%20%60__%60%20separator%20between%20the%20server%20and%20tool%20segments.%20Because%20of%20this%2C%20%60parse_qualified_tool_name%60%20%28and%20therefore%20%60call_qualified_tool%60%29%20will%20always%20return%20%60Err%28%22missing%20tool%20segment%22%29%60%20for%20any%20truncated%20name.%20The%20test%20currently%20only%20checks%20that%20%60name.len%28%29%20%3C%3D%2064%60%3B%20it%20should%20also%20assert%20that%20the%20result%20can%20be%20parsed%2C%20or%20pair%20with%20a%20round-trip%20through%20%60call_qualified_tool%60.%20A%20failing%20assertion%20here%20would%20surface%20the%20underlying%20bug%20where%20any%20tool%20on%20a%20server%20with%20a%20long%20name%20can%20be%20listed%20by%20%60list_tools%28%29%60%20but%20never%20actually%20invoked.%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Fmcp%2Fsrc%2Flib.rs%3A986-998%0A**Test%20bypasses%20the%20public%20API%20by%20directly%20mutating%20private%20fields**%0A%0A%60manager.configs%60%20is%20a%20private%20field%3B%20accessing%20it%20from%20the%20test%20module%20is%20permitted%20in%20Rust%20%28child%20modules%20inherit%20parent-module%20privacy%29%20but%20it%20tightly%20couples%20the%20test%20to%20internal%20struct%20layout.%20If%20%60configs%60%20is%20renamed%20or%20its%20type%20changes%2C%20this%20test%20breaks%20at%20compile%20time%20without%20any%20indication%20of%20which%20behavior%20regressed.%20The%20same%20scenario%20%28a%20config%20registered%20without%20a%20live%20client%29%20could%20be%20simulated%20via%20the%20public%20API%20by%20inserting%20the%20config%20through%20%60register_server%60%20and%20then%20immediately%20calling%20%60stop_server%60%20to%20remove%20the%20client%2C%20keeping%20the%20config%20in%20place.%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Fmcp%2Fsrc%2Flib.rs%3A965-978%0A**Hardcoded%20event%20count%20is%20sensitive%20to%20HashMap%20iteration%20order**%0A%0A%60McpManager.configs%60%20is%20a%20%60HashMap%60%2C%20so%20when%20multiple%20servers%20are%20present%20the%20iteration%20order%20in%20%60start_all%60%20is%20non-deterministic.%20This%20single-server%20test%20sidesteps%20the%20problem%20today%2C%20but%20the%20%60assert_eq!%28events.len%28%29%2C%202%29%60%20comment%20%28%22Starting%20%2B%20Ready%22%29%20also%20implicitly%20documents%20that%20exactly%20two%20events%20are%20emitted%20per%20ready%20server.%20If%20a%20future%20implementation%20change%20emits%20an%20intermediate%20event%20%28e.g.%20%22Connecting%22%29%2C%20this%20assertion%20would%20spuriously%20fail.%20Consider%20asserting%20on%20the%20event%20*variants*%20rather%20than%20the%20raw%20count%2C%20e.g.%20check%20that%20the%20events%20contain%20a%20%60Starting%60%20followed%20by%20a%20%60Ready%60%20status%20for%20%22s1%22.%0A%0A&repo=hmbown%2Fcodewhale&pr=2441&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Fmcp%2Fsrc%2Flib.rs%3A1155-1160%0A**Truncation%20test%20doesn't%20verify%20parseability%20%E2%80%94%20hides%20a%20production%20bug**%0A%0A%60qualify_tool_name%60%20appends%20a%20hash%20suffix%20when%20the%20full%20name%20exceeds%2064%20characters%2C%20which%20removes%20the%20%60__%60%20separator%20between%20the%20server%20and%20tool%20segments.%20Because%20of%20this%2C%20%60parse_qualified_tool_name%60%20%28and%20therefore%20%60call_qualified_tool%60%29%20will%20always%20return%20%60Err%28%22missing%20tool%20segment%22%29%60%20for%20any%20truncated%20name.%20The%20test%20currently%20only%20checks%20that%20%60name.len%28%29%20%3C%3D%2064%60%3B%20it%20should%20also%20assert%20that%20the%20result%20can%20be%20parsed%2C%20or%20pair%20with%20a%20round-trip%20through%20%60call_qualified_tool%60.%20A%20failing%20assertion%20here%20would%20surface%20the%20underlying%20bug%20where%20any%20tool%20on%20a%20server%20with%20a%20long%20name%20can%20be%20listed%20by%20%60list_tools%28%29%60%20but%20never%20actually%20invoked.%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Fmcp%2Fsrc%2Flib.rs%3A986-998%0A**Test%20bypasses%20the%20public%20API%20by%20directly%20mutating%20private%20fields**%0A%0A%60manager.configs%60%20is%20a%20private%20field%3B%20accessing%20it%20from%20the%20test%20module%20is%20permitted%20in%20Rust%20%28child%20modules%20inherit%20parent-module%20privacy%29%20but%20it%20tightly%20couples%20the%20test%20to%20internal%20struct%20layout.%20If%20%60configs%60%20is%20renamed%20or%20its%20type%20changes%2C%20this%20test%20breaks%20at%20compile%20time%20without%20any%20indication%20of%20which%20behavior%20regressed.%20The%20same%20scenario%20%28a%20config%20registered%20without%20a%20live%20client%29%20could%20be%20simulated%20via%20the%20public%20API%20by%20inserting%20the%20config%20through%20%60register_server%60%20and%20then%20immediately%20calling%20%60stop_server%60%20to%20remove%20the%20client%2C%20keeping%20the%20config%20in%20place.%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Fmcp%2Fsrc%2Flib.rs%3A965-978%0A**Hardcoded%20event%20count%20is%20sensitive%20to%20HashMap%20iteration%20order**%0A%0A%60McpManager.configs%60%20is%20a%20%60HashMap%60%2C%20so%20when%20multiple%20servers%20are%20present%20the%20iteration%20order%20in%20%60start_all%60%20is%20non-deterministic.%20This%20single-server%20test%20sidesteps%20the%20problem%20today%2C%20but%20the%20%60assert_eq!%28events.len%28%29%2C%202%29%60%20comment%20%28%22Starting%20%2B%20Ready%22%29%20also%20implicitly%20documents%20that%20exactly%20two%20events%20are%20emitted%20per%20ready%20server.%20If%20a%20future%20implementation%20change%20emits%20an%20intermediate%20event%20%28e.g.%20%22Connecting%22%29%2C%20this%20assertion%20would%20spuriously%20fail.%20Consider%20asserting%20on%20the%20event%20*variants*%20rather%20than%20the%20raw%20count%2C%20e.g.%20check%20that%20the%20events%20contain%20a%20%60Starting%60%20followed%20by%20a%20%60Ready%60%20status%20for%20%22s1%22.%0A%0A&pr=2441&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["test(mcp): add comprehensive unit tests ..."](https://github.com/hmbown/codewhale/commit/73e0a3f134ff2b67e82bf90cb6d7377b267252be) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34802289)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->