### PR TITLE
ci: add web frontend lint and type check workflow

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -1,0 +1,35 @@
+name: Web Frontend
+
+on:
+  push:
+    branches: [master, main]
+    paths:
+      - 'web/**'
+  pull_request:
+    branches: [master, main]
+    paths:
+      - 'web/**'
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint & Type Check
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Run ESLint
+        run: npm run lint
+      - name: TypeScript type check
+        run: npx tsc --noEmit


### PR DESCRIPTION
Add a dedicated GitHub Actions workflow for the Next.js web frontend:

**Triggers**: Runs on push to main and PRs targeting main, scoped to `web/**` path changes only.

**Steps**:
- `npm ci` with cache (uses `web/package-lock.json` for cache key)
- ESLint via `npm run lint`
- TypeScript type checking via `tsc --noEmit`

Currently there is no CI for the web frontend — TypeScript errors and lint issues can land on main undetected. This workflow catches those at PR time.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a GitHub Actions workflow that runs ESLint and TypeScript type checking on the Next.js `web/` frontend, scoped to path changes under `web/**`. The workflow structure is sound — it uses `actions/checkout@v4`, `actions/setup-node@v4` with npm caching, and correct least-privilege permissions — but the TypeScript step has a defect that will cause it to fail on every run.

- The `npx tsc --noEmit` step runs without first generating `next-env.d.ts`, which is listed in `web/.gitignore` and is therefore absent after a clean `npm ci`. This file is needed to resolve `import \"./globals.css\"` in `web/app/layout.tsx` (via `/// <reference types=\"next\" />`); without it, TypeScript emits `TS2307` and exits non-zero.
- The ESLint step (`npm run lint`) and caching configuration are correct and should work as expected.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The workflow will fail on every run due to a missing type-generation step; merging it as-is adds a permanently broken CI job.

The TypeScript check step is broken out of the box: `web/app/layout.tsx` imports `./globals.css`, and the CSS module type declarations that resolve that import are only loaded via `next-env.d.ts`, which is gitignored and never generated in this workflow. Every run of the type-check step will exit with `TS2307`, making the job permanently red. The ESLint step and overall workflow structure are correct.

.github/workflows/web.yml — specifically the `TypeScript type check` step at the bottom of the job.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/web.yml | New GitHub Actions workflow for web frontend lint and type-check; TypeScript step will fail on every run because `next-env.d.ts` (gitignored, required to resolve `import "./globals.css"`) is never generated before `tsc --noEmit`. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Push or PR triggers workflow] --> B[checkout]
    B --> C[setup-node v4 with npm cache]
    C --> D[npm ci]
    D --> E[npm run lint]
    E --> F[npx tsc --noEmit]
    F --> G{next-env.d.ts exists?}
    G -->|No - gitignored missing| H[TS2307 error on globals.css import - FAILS]
    G -->|Yes - if generated first| I[Type check passes]
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22ci%2Fweb-frontend-checks%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ci%2Fweb-frontend-checks%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fweb.yml%3A33-35%0A**TypeScript%20check%20will%20always%20fail%20%E2%80%94%20%60next-env.d.ts%60%20not%20generated**%0A%0A%60web%2Fapp%2Flayout.tsx%60%20contains%20%60import%20%22.%2Fglobals.css%22%60.%20TypeScript%20needs%20a%20%60declare%20module%20%22*.css%22%60%20ambient%20declaration%20to%20resolve%20that%20import%2C%20which%20Next.js%20normally%20provides%20via%20the%20%60%2F%2F%2F%20%3Creference%20types%3D%22next%22%20%2F%3E%60%20directive%20in%20%60next-env.d.ts%60.%20That%20file%20is%20listed%20in%20%60web%2F.gitignore%60%2C%20so%20it%20won't%20exist%20in%20a%20fresh%20checkout%20after%20%60npm%20ci%60.%20With%20no%20%60.d.ts%60%20file%20supplying%20the%20CSS%20module%20declaration%2C%20the%20type-check%20step%20will%20emit%20%60TS2307%3A%20Cannot%20find%20module%20'.%2Fglobals.css'%20or%20its%20corresponding%20type%20declarations.%60%20and%20exit%20non-zero%20on%20every%20run.%0A%0AThe%20most%20reliable%20CI%20fix%20is%20to%20replace%20the%20bare%20%60npx%20tsc%20--noEmit%60%20with%20%60npm%20run%20build%20--%20--no-lint%60%2C%20which%20generates%20%60next-env.d.ts%60%20internally%20before%20checking%20types.%20A%20lighter%20alternative%20is%20to%20add%20a%20dedicated%20script%20to%20%60package.json%60%20that%20runs%20%60next%20build%20--no-lint%60%20for%20CI%20type%20checking%2C%20or%20to%20un-gitignore%20and%20commit%20the%20small%2C%20stable%20%60next-env.d.ts%60%20file.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fweb.yml%3A33-35%0A**TypeScript%20check%20will%20always%20fail%20%E2%80%94%20%60next-env.d.ts%60%20not%20generated**%0A%0A%60web%2Fapp%2Flayout.tsx%60%20contains%20%60import%20%22.%2Fglobals.css%22%60.%20TypeScript%20needs%20a%20%60declare%20module%20%22*.css%22%60%20ambient%20declaration%20to%20resolve%20that%20import%2C%20which%20Next.js%20normally%20provides%20via%20the%20%60%2F%2F%2F%20%3Creference%20types%3D%22next%22%20%2F%3E%60%20directive%20in%20%60next-env.d.ts%60.%20That%20file%20is%20listed%20in%20%60web%2F.gitignore%60%2C%20so%20it%20won't%20exist%20in%20a%20fresh%20checkout%20after%20%60npm%20ci%60.%20With%20no%20%60.d.ts%60%20file%20supplying%20the%20CSS%20module%20declaration%2C%20the%20type-check%20step%20will%20emit%20%60TS2307%3A%20Cannot%20find%20module%20'.%2Fglobals.css'%20or%20its%20corresponding%20type%20declarations.%60%20and%20exit%20non-zero%20on%20every%20run.%0A%0AThe%20most%20reliable%20CI%20fix%20is%20to%20replace%20the%20bare%20%60npx%20tsc%20--noEmit%60%20with%20%60npm%20run%20build%20--%20--no-lint%60%2C%20which%20generates%20%60next-env.d.ts%60%20internally%20before%20checking%20types.%20A%20lighter%20alternative%20is%20to%20add%20a%20dedicated%20script%20to%20%60package.json%60%20that%20runs%20%60next%20build%20--no-lint%60%20for%20CI%20type%20checking%2C%20or%20to%20un-gitignore%20and%20commit%20the%20small%2C%20stable%20%60next-env.d.ts%60%20file.%0A%0A&repo=hmbown%2Fcodewhale&pr=2444&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fweb.yml%3A33-35%0A**TypeScript%20check%20will%20always%20fail%20%E2%80%94%20%60next-env.d.ts%60%20not%20generated**%0A%0A%60web%2Fapp%2Flayout.tsx%60%20contains%20%60import%20%22.%2Fglobals.css%22%60.%20TypeScript%20needs%20a%20%60declare%20module%20%22*.css%22%60%20ambient%20declaration%20to%20resolve%20that%20import%2C%20which%20Next.js%20normally%20provides%20via%20the%20%60%2F%2F%2F%20%3Creference%20types%3D%22next%22%20%2F%3E%60%20directive%20in%20%60next-env.d.ts%60.%20That%20file%20is%20listed%20in%20%60web%2F.gitignore%60%2C%20so%20it%20won't%20exist%20in%20a%20fresh%20checkout%20after%20%60npm%20ci%60.%20With%20no%20%60.d.ts%60%20file%20supplying%20the%20CSS%20module%20declaration%2C%20the%20type-check%20step%20will%20emit%20%60TS2307%3A%20Cannot%20find%20module%20'.%2Fglobals.css'%20or%20its%20corresponding%20type%20declarations.%60%20and%20exit%20non-zero%20on%20every%20run.%0A%0AThe%20most%20reliable%20CI%20fix%20is%20to%20replace%20the%20bare%20%60npx%20tsc%20--noEmit%60%20with%20%60npm%20run%20build%20--%20--no-lint%60%2C%20which%20generates%20%60next-env.d.ts%60%20internally%20before%20checking%20types.%20A%20lighter%20alternative%20is%20to%20add%20a%20dedicated%20script%20to%20%60package.json%60%20that%20runs%20%60next%20build%20--no-lint%60%20for%20CI%20type%20checking%2C%20or%20to%20un-gitignore%20and%20commit%20the%20small%2C%20stable%20%60next-env.d.ts%60%20file.%0A%0A&pr=2444&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["ci: add web frontend lint and type check..."](https://github.com/hmbown/codewhale/commit/b5e16d81889d00ea956a9325fee707967d5064fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34802486)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->