### PR TITLE
docs(mcp): add comprehensive doc comments to all public types

### DIFF
--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -7,83 +7,130 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
+/// Configuration for a single MCP server process.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct McpServerConfig {
+    /// Unique server identifier used for tool name qualification.
     pub name: String,
+    /// Path or name of the server executable.
     pub command: String,
+    /// Command-line arguments passed to the server process.
     #[serde(default)]
     pub args: Vec<String>,
+    /// Environment variables set for the server process.
     #[serde(default)]
     pub env: HashMap<String, String>,
+    /// Whether this server should be started. Disabled servers are skipped.
     #[serde(default = "default_true")]
     pub enabled: bool,
 }
 
+/// Filter controlling which tools from an MCP server are exposed.
+///
+/// When `allow` is empty, all tools are permitted (unless denied).
+/// `deny` takes precedence over `allow`.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ToolFilter {
+    /// Tool names to expose. Empty means expose all.
     #[serde(default)]
     pub allow: Vec<String>,
+    /// Tool names to exclude. Takes precedence over `allow`.
     #[serde(default)]
     pub deny: Vec<String>,
 }
 
+/// A complete MCP server definition including config and tool filter.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct McpServerDefinition {
+    /// Server process configuration.
     pub config: McpServerConfig,
+    /// Tool filter controlling which tools are exposed.
     #[serde(default)]
     pub filter: ToolFilter,
 }
 
+/// Status of an individual MCP server during startup.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum McpStartupStatus {
+    /// Server process is starting.
     Starting,
+    /// Server is ready to accept tool calls.
     Ready,
+    /// Server failed to start.
     Failed { error: String },
+    /// Server startup was cancelled (e.g., disabled in config).
     Cancelled,
 }
 
+/// Status update for a single MCP server during startup.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct McpStartupUpdateEvent {
+    /// Name of the server this update pertains to.
     pub server_name: String,
+    /// Current startup status.
     pub status: McpStartupStatus,
 }
 
+/// Record of an MCP server that failed to start.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct McpStartupFailure {
+    /// Name of the server that failed.
     pub server_name: String,
+    /// Error message describing the failure.
     pub error: String,
 }
 
+/// Summary emitted after all MCP servers have completed startup.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct McpStartupCompleteEvent {
+    /// Names of servers that started successfully.
     pub ready: Vec<String>,
+    /// Servers that failed with error details.
     pub failed: Vec<McpStartupFailure>,
+    /// Names of servers that were skipped (disabled).
     pub cancelled: Vec<String>,
 }
 
+/// Describes a single tool provided by an MCP server.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct McpToolDescriptor {
+    /// Name of the server providing this tool.
     pub server_name: String,
+    /// Original tool name as reported by the server.
     pub tool_name: String,
+    /// Fully qualified name (e.g., `mcp__server__tool`).
     pub qualified_name: String,
+    /// Human-readable description of what the tool does.
     pub description: Option<String>,
 }
 
+/// Describes a resource provided by an MCP server.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct McpResourceDescriptor {
+    /// Name of the server providing this resource.
     pub server_name: String,
+    /// URI identifying the resource.
     pub uri: String,
+    /// Human-readable description.
     pub description: Option<String>,
 }
 
+/// Trait abstracting an MCP client connection.
+///
+/// Implementations handle communication with a single MCP server process.
 pub trait McpManagedClient: Send + Sync {
+    /// List all tools provided by this server.
     fn list_tools(&self) -> Result<Vec<McpToolDescriptor>>;
+    /// Invoke a tool by name with the given arguments.
     fn call_tool(&self, tool_name: &str, arguments: Value) -> Result<Value>;
+    /// List all resources provided by this server.
     fn list_resources(&self) -> Result<Vec<McpResourceDescriptor>>;
+    /// Read a resource by URI.
     fn read_resource(&self, uri: &str) -> Result<Value>;
 }
 
+/// A simple in-memory MCP client for testing and default server stubs.
 #[derive(Debug, Default)]
 pub struct InMemoryMcpClient {
     tools: HashMap<String, Value>,
@@ -91,11 +138,13 @@ pub struct InMemoryMcpClient {
 }
 
 impl InMemoryMcpClient {
+    /// Register a tool with a fixed response value.
     pub fn with_tool(mut self, name: &str, sample_result: Value) -> Self {
         self.tools.insert(name.to_string(), sample_result);
         self
     }
 
+    /// Register a resource with a fixed data value.
     pub fn with_resource(mut self, uri: &str, data: Value) -> Self {
         self.resources.insert(uri.to_string(), data);
         self
@@ -143,6 +192,7 @@ impl McpManagedClient for InMemoryMcpClient {
     }
 }
 
+/// Manages multiple MCP server connections and their tool/resource registrations.
 #[derive(Default)]
 pub struct McpManager {
     configs: HashMap<String, (McpServerConfig, ToolFilter)>,
@@ -150,6 +200,7 @@ pub struct McpManager {
 }
 
 impl McpManager {
+    /// Register an MCP server with its config, tool filter, and client implementation.
     pub fn register_server(
         &mut self,
         config: McpServerConfig,
@@ -160,6 +211,9 @@ impl McpManager {
         self.configs.insert(config.name.clone(), (config, filter));
     }
 
+    /// Start all registered servers, emitting status updates via the callback.
+    ///
+    /// Returns a summary of which servers are ready, failed, or cancelled.
     pub fn start_all<F>(&self, mut emit: F) -> McpStartupCompleteEvent
     where
         F: FnMut(McpStartupUpdateEvent),
@@ -207,6 +261,7 @@ impl McpManager {
         }
     }
 
+    /// Stop a running server by removing its client.
     pub fn stop_server(&mut self, server_name: &str) -> Result<()> {
         self.clients
             .remove(server_name)
@@ -214,6 +269,7 @@ impl McpManager {
         Ok(())
     }
 
+    /// Remove a server entirely (config and client).
     pub fn unregister_server(&mut self, server_name: &str) -> Result<()> {
         let had_config = self.configs.remove(server_name).is_some();
         self.clients.remove(server_name);
@@ -223,6 +279,7 @@ impl McpManager {
         Ok(())
     }
 
+    /// List all tools from all running servers, applying tool filters.
     pub fn list_tools(&self) -> Result<Vec<McpToolDescriptor>> {
         let mut out = Vec::new();
         for (server_name, (_, filter)) in &self.configs {
@@ -246,6 +303,7 @@ impl McpManager {
         Ok(out)
     }
 
+    /// Call a tool on a specific server by name.
     pub fn call_tool(&self, server_name: &str, tool_name: &str, arguments: Value) -> Result<Value> {
         let client = self
             .clients
@@ -254,6 +312,7 @@ impl McpManager {
         client.call_tool(tool_name, arguments)
     }
 
+    /// Call a tool using its fully qualified name (e.g., `mcp__server__tool`).
     pub fn call_qualified_tool(
         &self,
         qualified_tool_name: &str,
@@ -264,6 +323,7 @@ impl McpManager {
         self.call_tool(&server_name, &tool_name, arguments)
     }
 
+    /// List all resources from all running servers.
     pub fn list_resources(&self) -> Result<Vec<McpResourceDescriptor>> {
         let mut out = Vec::new();
         for server_name in self.configs.keys() {
@@ -278,6 +338,7 @@ impl McpManager {
         Ok(out)
     }
 
+    /// Read a resource from a specific server.
     pub fn read_resource(&self, server_name: &str, uri: &str) -> Result<Value> {
         let client = self
             .clients
@@ -286,6 +347,7 @@ impl McpManager {
         client.read_resource(uri)
     }
 
+    /// Generate sandbox state update notices for all registered servers.
     pub fn update_sandbox_state(&self, sandbox_mode: &str, cwd: &str) -> Result<Vec<Value>> {
         let mut notices = Vec::new();
         for server_name in self.configs.keys() {
@@ -434,6 +496,10 @@ struct StdioMcpState {
     lifecycle_state: String,
 }
 
+/// Run an MCP stdio server that reads JSON-RPC requests from stdin and writes responses to stdout.
+///
+/// Returns the final server definitions after the session ends (useful for persisting
+/// runtime changes like server registrations).
 pub fn run_stdio_server(
     initial_definitions: Vec<McpServerDefinition>,
 ) -> Result<Vec<McpServerDefinition>> {


### PR DESCRIPTION
Add doc comments to all public types in the `mcp` crate (previously 0% doc coverage):

- **Config types**: `McpServerConfig`, `ToolFilter`, `McpServerDefinition` with field-level docs
- **Startup types**: `McpStartupStatus`, `McpStartupUpdateEvent`, `McpStartupFailure`, `McpStartupCompleteEvent`
- **Descriptor types**: `McpToolDescriptor`, `McpResourceDescriptor`
- **Trait**: `McpManagedClient` and all 4 methods
- **Client**: `InMemoryMcpClient` and builder methods
- **Manager**: `McpManager` and all 10 public methods
- **Server**: `run_stdio_server` function

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds comprehensive `///` doc comments to every public type, field, trait method, and function in `crates/mcp/src/lib.rs`, bringing doc coverage from 0% to full. No logic is changed.

- All config, startup, and descriptor types (`McpServerConfig`, `ToolFilter`, `McpStartupStatus`, etc.) now have struct- and field-level comments explaining their role in the MCP lifecycle.
- `McpManagedClient`, `InMemoryMcpClient`, and `McpManager` (including all 10 public methods) are documented, as is the top-level `run_stdio_server` entry point.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is documentation-only and touches no runtime logic.

No code behaviour changes; the only concerns are two doc inaccuracies. `start_all` is described as starting servers when it actually only emits status events for pre-registered clients, and `qualified_name`'s doc omits the 64-character truncation+hash behaviour. Both could mislead downstream consumers of this API.

crates/mcp/src/lib.rs — specifically the `start_all` and `qualified_name` doc comments flagged above.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/mcp/src/lib.rs | Docs-only change adding /// comments to all public types; no logic altered. Two minor doc inaccuracies: `start_all` implies process spawning that doesn't occur, and `qualified_name` omits the truncation behaviour for long names. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[McpServerDefinition\nconfig + filter] --> B[McpManager.register_server]
    B --> C{McpManager.start_all}
    C -->|cfg.enabled == false| D[Emit Cancelled]
    C -->|client pre-registered| E[Emit Ready]
    C -->|no client| F[Emit Failed\n'client not registered']
    D & E & F --> G[McpStartupCompleteEvent\nready / failed / cancelled]

    H[run_stdio_server] --> I[build_stdio_state\nregisters default_stdio_client per enabled server]
    I --> B
    H --> J[JSON-RPC dispatch loop\nstdin to stdout]
    J -->|tools/list| K[McpManager.list_tools\napplies ToolFilter]
    J -->|tools/call| L[McpManager.call_tool\nor call_qualified_tool]
    J -->|resources/list| M[McpManager.list_resources]
    J -->|resources/read| N[McpManager.read_resource]
    J -->|server/register| B
    J -->|shutdown| O[Return final McpServerDefinitions]
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22docs%2Fmcp-crate-docs%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Fmcp-crate-docs%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Fmcp%2Fsrc%2Flib.rs%3A214-216%0A**%60start_all%60%20doc%20implies%20process%20spawning%20that%20doesn't%20happen**%0A%0AThe%20doc%20says%20%22Start%20all%20registered%20servers%22%2C%20but%20the%20method%20only%20emits%20status%20events%20based%20on%20whether%20a%20client%20is%20*already%20present*%20in%20%60self.clients%60.%20If%20no%20client%20was%20pre-registered%20%28via%20%60register_server%60%29%2C%20the%20server%20is%20immediately%20reported%20as%20%60Failed%60%20with%20%22client%20not%20registered%22%20%E2%80%94%20nothing%20is%20actually%20launched.%20A%20reader%20building%20on%20this%20API%20could%20mistakenly%20expect%20%60start_all%60%20to%20perform%20process%20startup.%20A%20clearer%20description%20would%20be%3A%20%22Emit%20startup%20status%20events%20for%20all%20configured%20servers%3B%20servers%20without%20a%20pre-registered%20client%20are%20reported%20as%20failed.%22%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Fmcp%2Fsrc%2Flib.rs%3A102%0AThe%20example%20format%20for%20%60qualified_name%60%20%28%60mcp__server__tool%60%29%20is%20correct%20for%20the%20common%20case%2C%20but%20the%20doc%20omits%20the%20truncation%20behavior%3A%20when%20the%20raw%20qualified%20name%20exceeds%2064%20characters%2C%20the%20name%20is%20truncated%20to%2048%20characters%20and%20a%2012-character%20hex%20hash%20suffix%20is%20appended%20%28e.g.%20%60mcp__longservername__longtoolname_1a2b3c4d5e6f%60%29.%20Without%20this%20note%2C%20callers%20who%20match%20or%20parse%20qualified%20names%20by%20their%20expected%20format%20may%20be%20surprised%20by%20truncated%20names%20in%20practice.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Fully%20qualified%20name%20%28e.g.%2C%20%60mcp__server__tool%60%29.%0A%20%20%20%20%2F%2F%2F%0A%20%20%20%20%2F%2F%2F%20Names%20exceeding%2064%20characters%20are%20truncated%20to%2048%20characters%20and%20a%2012-character%0A%20%20%20%20%2F%2F%2F%20hex%20hash%20suffix%20is%20appended%20to%20avoid%20collisions%20%28e.g.%2C%20%60mcp__longserver__longtool_1a2b3c4d5e6f%60%29.%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Fmcp%2Fsrc%2Flib.rs%3A214-216%0A**%60start_all%60%20doc%20implies%20process%20spawning%20that%20doesn't%20happen**%0A%0AThe%20doc%20says%20%22Start%20all%20registered%20servers%22%2C%20but%20the%20method%20only%20emits%20status%20events%20based%20on%20whether%20a%20client%20is%20*already%20present*%20in%20%60self.clients%60.%20If%20no%20client%20was%20pre-registered%20%28via%20%60register_server%60%29%2C%20the%20server%20is%20immediately%20reported%20as%20%60Failed%60%20with%20%22client%20not%20registered%22%20%E2%80%94%20nothing%20is%20actually%20launched.%20A%20reader%20building%20on%20this%20API%20could%20mistakenly%20expect%20%60start_all%60%20to%20perform%20process%20startup.%20A%20clearer%20description%20would%20be%3A%20%22Emit%20startup%20status%20events%20for%20all%20configured%20servers%3B%20servers%20without%20a%20pre-registered%20client%20are%20reported%20as%20failed.%22%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Fmcp%2Fsrc%2Flib.rs%3A102%0AThe%20example%20format%20for%20%60qualified_name%60%20%28%60mcp__server__tool%60%29%20is%20correct%20for%20the%20common%20case%2C%20but%20the%20doc%20omits%20the%20truncation%20behavior%3A%20when%20the%20raw%20qualified%20name%20exceeds%2064%20characters%2C%20the%20name%20is%20truncated%20to%2048%20characters%20and%20a%2012-character%20hex%20hash%20suffix%20is%20appended%20%28e.g.%20%60mcp__longservername__longtoolname_1a2b3c4d5e6f%60%29.%20Without%20this%20note%2C%20callers%20who%20match%20or%20parse%20qualified%20names%20by%20their%20expected%20format%20may%20be%20surprised%20by%20truncated%20names%20in%20practice.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Fully%20qualified%20name%20%28e.g.%2C%20%60mcp__server__tool%60%29.%0A%20%20%20%20%2F%2F%2F%0A%20%20%20%20%2F%2F%2F%20Names%20exceeding%2064%20characters%20are%20truncated%20to%2048%20characters%20and%20a%2012-character%0A%20%20%20%20%2F%2F%2F%20hex%20hash%20suffix%20is%20appended%20to%20avoid%20collisions%20%28e.g.%2C%20%60mcp__longserver__longtool_1a2b3c4d5e6f%60%29.%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2446&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Fmcp%2Fsrc%2Flib.rs%3A214-216%0A**%60start_all%60%20doc%20implies%20process%20spawning%20that%20doesn't%20happen**%0A%0AThe%20doc%20says%20%22Start%20all%20registered%20servers%22%2C%20but%20the%20method%20only%20emits%20status%20events%20based%20on%20whether%20a%20client%20is%20*already%20present*%20in%20%60self.clients%60.%20If%20no%20client%20was%20pre-registered%20%28via%20%60register_server%60%29%2C%20the%20server%20is%20immediately%20reported%20as%20%60Failed%60%20with%20%22client%20not%20registered%22%20%E2%80%94%20nothing%20is%20actually%20launched.%20A%20reader%20building%20on%20this%20API%20could%20mistakenly%20expect%20%60start_all%60%20to%20perform%20process%20startup.%20A%20clearer%20description%20would%20be%3A%20%22Emit%20startup%20status%20events%20for%20all%20configured%20servers%3B%20servers%20without%20a%20pre-registered%20client%20are%20reported%20as%20failed.%22%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Fmcp%2Fsrc%2Flib.rs%3A102%0AThe%20example%20format%20for%20%60qualified_name%60%20%28%60mcp__server__tool%60%29%20is%20correct%20for%20the%20common%20case%2C%20but%20the%20doc%20omits%20the%20truncation%20behavior%3A%20when%20the%20raw%20qualified%20name%20exceeds%2064%20characters%2C%20the%20name%20is%20truncated%20to%2048%20characters%20and%20a%2012-character%20hex%20hash%20suffix%20is%20appended%20%28e.g.%20%60mcp__longservername__longtoolname_1a2b3c4d5e6f%60%29.%20Without%20this%20note%2C%20callers%20who%20match%20or%20parse%20qualified%20names%20by%20their%20expected%20format%20may%20be%20surprised%20by%20truncated%20names%20in%20practice.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Fully%20qualified%20name%20%28e.g.%2C%20%60mcp__server__tool%60%29.%0A%20%20%20%20%2F%2F%2F%0A%20%20%20%20%2F%2F%2F%20Names%20exceeding%2064%20characters%20are%20truncated%20to%2048%20characters%20and%20a%2012-character%0A%20%20%20%20%2F%2F%2F%20hex%20hash%20suffix%20is%20appended%20to%20avoid%20collisions%20%28e.g.%2C%20%60mcp__longserver__longtool_1a2b3c4d5e6f%60%29.%0A%60%60%60%0A%0A&pr=2446&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs(mcp): add comprehensive doc comment..."](https://github.com/hmbown/codewhale/commit/715f7459e5515ff8b72054c59457212c6827fdcd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34802799)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->