### PR TITLE
test(app-server): add unit tests for auth, CORS, and JSON-RPC helpers

### DIFF
--- a/crates/app-server/src/lib.rs
+++ b/crates/app-server/src/lib.rs
@@ -1069,4 +1069,154 @@ mod tests {
 
         assert_eq!(response.data["value"], "sk-deepseek-secret");
     }
+
+    // ── resolve_auth_token ─────────────────────────────────────────────
+
+    #[test]
+    fn auth_token_empty_string_fails() {
+        let options = AppServerOptions {
+            listen: "127.0.0.1:0".parse().expect("addr"),
+            config_path: None,
+            auth_token: Some("  ".to_string()),
+            insecure_no_auth: false,
+            cors_origins: Vec::new(),
+        };
+        let err = resolve_auth_token(&options).expect_err("empty token should fail");
+        assert!(err.to_string().contains("cannot be empty"));
+    }
+
+    #[test]
+    fn auth_token_generated_when_none_provided() {
+        let options = AppServerOptions {
+            listen: "127.0.0.1:0".parse().expect("addr"),
+            config_path: None,
+            auth_token: None,
+            insecure_no_auth: false,
+            cors_origins: Vec::new(),
+        };
+        let token = resolve_auth_token(&options).unwrap();
+        assert!(token.is_some());
+        assert!(token.unwrap().starts_with("cwapp_"));
+    }
+
+    #[test]
+    fn auth_token_explicit_is_preserved() {
+        let options = AppServerOptions {
+            listen: "127.0.0.1:0".parse().expect("addr"),
+            config_path: None,
+            auth_token: Some("my-secret".to_string()),
+            insecure_no_auth: false,
+            cors_origins: Vec::new(),
+        };
+        let token = resolve_auth_token(&options).unwrap();
+        assert_eq!(token.as_deref(), Some("my-secret"));
+    }
+
+    #[test]
+    fn insecure_no_auth_on_loopback_returns_none() {
+        let options = AppServerOptions {
+            listen: "127.0.0.1:0".parse().expect("addr"),
+            config_path: None,
+            auth_token: None,
+            insecure_no_auth: true,
+            cors_origins: Vec::new(),
+        };
+        let token = resolve_auth_token(&options).unwrap();
+        assert!(token.is_none());
+    }
+
+    // ── cors_layer ─────────────────────────────────────────────────────
+
+    #[test]
+    fn cors_layer_includes_default_origins() {
+        let layer = cors_layer(&[]);
+        // Just verify it doesn't panic and creates successfully
+        let _ = layer;
+    }
+
+    #[test]
+    fn cors_layer_adds_extra_origins() {
+        let extras = vec!["https://example.com".to_string()];
+        let layer = cors_layer(&extras);
+        let _ = layer;
+    }
+
+    #[test]
+    fn cors_layer_skips_empty_origins() {
+        let extras = vec!["".to_string(), "  ".to_string()];
+        let layer = cors_layer(&extras);
+        let _ = layer;
+    }
+
+    // ── JsonRpc helpers ────────────────────────────────────────────────
+
+    #[test]
+    fn params_or_object_returns_object_for_null() {
+        let result = params_or_object(Value::Null);
+        assert_eq!(result, json!({}));
+    }
+
+    #[test]
+    fn params_or_object_passthrough_for_non_null() {
+        let input = json!({"key": "value"});
+        let result = params_or_object(input.clone());
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn jsonrpc_result_format() {
+        let result = jsonrpc_result(Some(json!(1)), json!({"ok": true}));
+        assert_eq!(result["jsonrpc"], "2.0");
+        assert_eq!(result["id"], 1);
+        assert_eq!(result["result"]["ok"], true);
+    }
+
+    #[test]
+    fn jsonrpc_result_null_id() {
+        let result = jsonrpc_result(None, json!(null));
+        assert_eq!(result["id"], Value::Null);
+    }
+
+    #[test]
+    fn jsonrpc_error_format() {
+        let err = jsonrpc_error(Some(json!(2)), JsonRpcError::internal("oops"));
+        assert_eq!(err["jsonrpc"], "2.0");
+        assert_eq!(err["id"], 2);
+        assert_eq!(err["error"]["code"], -32603);
+        assert_eq!(err["error"]["message"], "oops");
+    }
+
+    #[test]
+    fn jsonrpc_error_codes() {
+        assert_eq!(JsonRpcError::parse_error("").code, -32700);
+        assert_eq!(JsonRpcError::invalid_request("").code, -32600);
+        assert_eq!(JsonRpcError::method_not_found("x").code, -32601);
+        assert_eq!(JsonRpcError::invalid_params("").code, -32602);
+        assert_eq!(JsonRpcError::internal("").code, -32603);
+    }
+
+    // ── AppServerOptions ───────────────────────────────────────────────
+
+    #[test]
+    fn app_server_options_debug_does_not_leak_token() {
+        let options = AppServerOptions {
+            listen: "127.0.0.1:8080".parse().expect("addr"),
+            config_path: None,
+            auth_token: Some("secret-token".to_string()),
+            insecure_no_auth: false,
+            cors_origins: vec!["https://example.com".to_string()],
+        };
+        let debug = format!("{options:?}");
+        assert!(debug.contains("secret-token")); // Debug shows it since it's not redacted
+        assert!(debug.contains("8080"));
+    }
+
+    // ── Default CORS origins ──────────────────────────────────────────
+
+    #[test]
+    fn default_cors_origins_include_common_dev_ports() {
+        assert!(DEFAULT_CORS_ORIGINS.contains(&"http://localhost:3000"));
+        assert!(DEFAULT_CORS_ORIGINS.contains(&"http://localhost:5173"));
+        assert!(DEFAULT_CORS_ORIGINS.contains(&"tauri://localhost"));
+    }
 }

--- a/crates/app-server/src/lib.rs
+++ b/crates/app-server/src/lib.rs
@@ -38,13 +38,28 @@ const DEFAULT_CORS_ORIGINS: &[&str] = &[
     "tauri://localhost",
 ];
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct AppServerOptions {
     pub listen: SocketAddr,
     pub config_path: Option<PathBuf>,
     pub auth_token: Option<String>,
     pub insecure_no_auth: bool,
     pub cors_origins: Vec<String>,
+}
+
+impl std::fmt::Debug for AppServerOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AppServerOptions")
+            .field("listen", &self.listen)
+            .field("config_path", &self.config_path)
+            .field(
+                "auth_token",
+                &self.auth_token.as_ref().map(|_| "<redacted>"),
+            )
+            .field("insecure_no_auth", &self.insecure_no_auth)
+            .field("cors_origins", &self.cors_origins)
+            .finish()
+    }
 }
 
 #[derive(Clone)]
@@ -1207,7 +1222,8 @@ mod tests {
             cors_origins: vec!["https://example.com".to_string()],
         };
         let debug = format!("{options:?}");
-        assert!(debug.contains("secret-token")); // Debug shows it since it's not redacted
+        assert!(!debug.contains("secret-token"));
+        assert!(debug.contains("<redacted>"));
         assert!(debug.contains("8080"));
     }
 


### PR DESCRIPTION
Add 16 new unit tests (20 total) to the app-server crate:

- **resolve_auth_token**: empty token rejection, auto-generation with cwapp_ prefix, explicit token preservation, insecure loopback mode
- **cors_layer**: creation with default/extra/empty origins
- **JSON-RPC helpers**: params_or_object null handling, jsonrpc_result/error formatting, all 5 error code constructors
- **Configuration**: default CORS origins include common dev ports

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds 16 unit tests for `resolve_auth_token`, `cors_layer`, JSON-RPC helpers, and `DEFAULT_CORS_ORIGINS` in the `app-server` crate. Most tests are correct and well-targeted, but one test has a name that directly contradicts its assertion, and three `cors_layer` tests are empty smoke tests.

- The `auth_token_*` and JSON-RPC tests are accurate and cover meaningful branches of the production code.
- `app_server_options_debug_does_not_leak_token` asserts `debug.contains(\"secret-token\")` (token *is* present), while the name claims it is *not* leaked — these are direct opposites; a future attempt to add `Debug` redaction for `auth_token` would be blocked by this failing test.
- The three `cors_layer_*` tests call the function and immediately discard the result with `let _ = layer`, verifying only non-panicking execution without checking any CORS behavior.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with the misleading test name addressed — it is test-only code with no production behaviour changes, but the contradicting assertion could actively block a future security improvement.

The change is test-only and introduces no production code changes. However, app_server_options_debug_does_not_leak_token has a name that says 'does not leak' while the assertion proves the token is plaintext in debug output. This inversion could cause a legitimate Debug-redaction patch to fail and appear as a regression. The three CORS smoke tests add negligible coverage value. All other new tests are correct and well-targeted.

crates/app-server/src/lib.rs — specifically the app_server_options_debug_does_not_leak_token test around line 1193 and the three cors_layer_* smoke tests around lines 1133–1148.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/app-server/src/lib.rs | Adds 16 new unit tests covering resolve_auth_token, cors_layer, JSON-RPC helpers, and DEFAULT_CORS_ORIGINS; one test has a name that directly contradicts its assertion (claims no token leak but asserts the token is present), and three cors_layer tests are pure smoke tests with no behavioral assertions. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[resolve_auth_token] --> B{auth_token set?}
    B -->|Yes, whitespace-only| C[bail: cannot be empty]
    B -->|Yes, non-empty| D{insecure_no_auth?}
    B -->|None| D
    D -->|true + non-loopback| E[bail: refusing unauthenticated bind]
    D -->|true + loopback| F[return None]
    D -->|false + explicit token| G[return Some token]
    D -->|false + no token| H[generate cwapp_uuid token]

    subgraph Tests Added
        T1[auth_token_empty_string_fails ✓]
        T2[auth_token_generated_when_none_provided ✓]
        T3[auth_token_explicit_is_preserved ✓]
        T4[insecure_no_auth_on_loopback_returns_none ✓]
        T5[app_server_options_debug_does_not_leak_token ⚠️ name contradicts assertion]
    end

    C -.->|tested| T1
    H -.->|tested| T2
    G -.->|tested| T3
    F -.->|tested| T4
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22test%2Fapp-server-more-tests%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22test%2Fapp-server-more-tests%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Fapp-server%2Fsrc%2Flib.rs%3A1193-1205%0A**Test%20name%20contradicts%20its%20assertion**%0A%0AThe%20test%20is%20named%20%60app_server_options_debug_does_not_leak_token%60%2C%20but%20%60assert!%28debug.contains%28%22secret-token%22%29%29%60%20verifies%20that%20the%20token%20*is*%20present%20in%20the%20debug%20output.%20These%20are%20opposites.%20If%20someone%20later%20adds%20redaction%20to%20the%20%60Debug%60%20output%20of%20%60AppServerOptions%60%20%28the%20correct%20security%20fix%29%2C%20this%20test%20will%20fail%2C%20and%20the%20misleading%20name%20will%20make%20the%20failure%20look%20like%20a%20regression%20rather%20than%20expected%20behavior%20change.%20The%20test%20should%20either%20be%20renamed%20to%20%60app_server_options_debug_exposes_token_unredacted%60%20to%20document%20the%20current%20%28undesirable%29%20state%2C%20or%20the%20assertion%20should%20be%20inverted%20to%20%60assert!%28!debug.contains%28%22secret-token%22%29%29%60%20with%20a%20corresponding%20TODO%20to%20add%20%60Debug%60%20redaction%20for%20%60auth_token%60.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Fapp-server%2Fsrc%2Flib.rs%3A1133-1148%0A**Smoke%20tests%20provide%20no%20behavioral%20coverage**%0A%0AThe%20three%20%60cors_layer_*%60%20tests%20call%20the%20function%2C%20discard%20the%20result%20with%20%60let%20_%20%3D%20layer%3B%60%2C%20and%20make%20no%20assertions.%20They%20only%20verify%20the%20function%20doesn't%20panic%2C%20but%20the%20interesting%20behaviors%20%28e.g.%20that%20default%20origins%20are%20actually%20included%2C%20that%20a%20duplicate%20extra%20origin%20is%20deduplicated%2C%20that%20an%20invalid%20origin%20is%20silently%20skipped%20rather%20than%20included%29%20are%20not%20tested%20at%20all.%20The%20existing%20%60cors_does_not_allow_arbitrary_origins%60%20integration%20test%20in%20the%20same%20file%20is%20a%20better%20model%20%E2%80%94%20consider%20adding%20similar%20assertions%20here%2C%20or%20removing%20these%20tests%20if%20they%20are%20intentional%20placeholders.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Fapp-server%2Fsrc%2Flib.rs%3A1193-1205%0A**Test%20name%20contradicts%20its%20assertion**%0A%0AThe%20test%20is%20named%20%60app_server_options_debug_does_not_leak_token%60%2C%20but%20%60assert!%28debug.contains%28%22secret-token%22%29%29%60%20verifies%20that%20the%20token%20*is*%20present%20in%20the%20debug%20output.%20These%20are%20opposites.%20If%20someone%20later%20adds%20redaction%20to%20the%20%60Debug%60%20output%20of%20%60AppServerOptions%60%20%28the%20correct%20security%20fix%29%2C%20this%20test%20will%20fail%2C%20and%20the%20misleading%20name%20will%20make%20the%20failure%20look%20like%20a%20regression%20rather%20than%20expected%20behavior%20change.%20The%20test%20should%20either%20be%20renamed%20to%20%60app_server_options_debug_exposes_token_unredacted%60%20to%20document%20the%20current%20%28undesirable%29%20state%2C%20or%20the%20assertion%20should%20be%20inverted%20to%20%60assert!%28!debug.contains%28%22secret-token%22%29%29%60%20with%20a%20corresponding%20TODO%20to%20add%20%60Debug%60%20redaction%20for%20%60auth_token%60.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Fapp-server%2Fsrc%2Flib.rs%3A1133-1148%0A**Smoke%20tests%20provide%20no%20behavioral%20coverage**%0A%0AThe%20three%20%60cors_layer_*%60%20tests%20call%20the%20function%2C%20discard%20the%20result%20with%20%60let%20_%20%3D%20layer%3B%60%2C%20and%20make%20no%20assertions.%20They%20only%20verify%20the%20function%20doesn't%20panic%2C%20but%20the%20interesting%20behaviors%20%28e.g.%20that%20default%20origins%20are%20actually%20included%2C%20that%20a%20duplicate%20extra%20origin%20is%20deduplicated%2C%20that%20an%20invalid%20origin%20is%20silently%20skipped%20rather%20than%20included%29%20are%20not%20tested%20at%20all.%20The%20existing%20%60cors_does_not_allow_arbitrary_origins%60%20integration%20test%20in%20the%20same%20file%20is%20a%20better%20model%20%E2%80%94%20consider%20adding%20similar%20assertions%20here%2C%20or%20removing%20these%20tests%20if%20they%20are%20intentional%20placeholders.%0A%0A&repo=hmbown%2Fcodewhale&pr=2448&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Fapp-server%2Fsrc%2Flib.rs%3A1193-1205%0A**Test%20name%20contradicts%20its%20assertion**%0A%0AThe%20test%20is%20named%20%60app_server_options_debug_does_not_leak_token%60%2C%20but%20%60assert!%28debug.contains%28%22secret-token%22%29%29%60%20verifies%20that%20the%20token%20*is*%20present%20in%20the%20debug%20output.%20These%20are%20opposites.%20If%20someone%20later%20adds%20redaction%20to%20the%20%60Debug%60%20output%20of%20%60AppServerOptions%60%20%28the%20correct%20security%20fix%29%2C%20this%20test%20will%20fail%2C%20and%20the%20misleading%20name%20will%20make%20the%20failure%20look%20like%20a%20regression%20rather%20than%20expected%20behavior%20change.%20The%20test%20should%20either%20be%20renamed%20to%20%60app_server_options_debug_exposes_token_unredacted%60%20to%20document%20the%20current%20%28undesirable%29%20state%2C%20or%20the%20assertion%20should%20be%20inverted%20to%20%60assert!%28!debug.contains%28%22secret-token%22%29%29%60%20with%20a%20corresponding%20TODO%20to%20add%20%60Debug%60%20redaction%20for%20%60auth_token%60.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Fapp-server%2Fsrc%2Flib.rs%3A1133-1148%0A**Smoke%20tests%20provide%20no%20behavioral%20coverage**%0A%0AThe%20three%20%60cors_layer_*%60%20tests%20call%20the%20function%2C%20discard%20the%20result%20with%20%60let%20_%20%3D%20layer%3B%60%2C%20and%20make%20no%20assertions.%20They%20only%20verify%20the%20function%20doesn't%20panic%2C%20but%20the%20interesting%20behaviors%20%28e.g.%20that%20default%20origins%20are%20actually%20included%2C%20that%20a%20duplicate%20extra%20origin%20is%20deduplicated%2C%20that%20an%20invalid%20origin%20is%20silently%20skipped%20rather%20than%20included%29%20are%20not%20tested%20at%20all.%20The%20existing%20%60cors_does_not_allow_arbitrary_origins%60%20integration%20test%20in%20the%20same%20file%20is%20a%20better%20model%20%E2%80%94%20consider%20adding%20similar%20assertions%20here%2C%20or%20removing%20these%20tests%20if%20they%20are%20intentional%20placeholders.%0A%0A&pr=2448&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["test(app-server): add unit tests for aut..."](https://github.com/hmbown/codewhale/commit/06c21ee19e7f819711860acb21477c0ad0b08498) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34802917)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->