### PR TITLE
test(tui-core): add unit tests for UiState state machine

### DIFF
--- a/crates/tui-core/src/lib.rs
+++ b/crates/tui-core/src/lib.rs
@@ -190,3 +190,244 @@ impl UiState {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Default state ──────────────────────────────────────────────────
+
+    #[test]
+    fn default_state_is_chat_pane_and_ready() {
+        let state = UiState::default();
+        assert_eq!(state.active_pane, Pane::Chat);
+        assert!(!state.paused);
+        assert_eq!(state.last_response_delta, None);
+        assert_eq!(state.active_tool, None);
+        assert_eq!(state.pending_tasks, 0);
+        assert_eq!(state.active_jobs, 0);
+        assert_eq!(state.pending_approvals, 0);
+        assert_eq!(state.status_line, "ready");
+    }
+
+    // ── Key navigation ─────────────────────────────────────────────────
+
+    #[test]
+    fn key_1_switches_to_chat_pane() {
+        let mut state = UiState::default();
+        let effects = state.reduce(UiEvent::KeyPressed('1'));
+        assert_eq!(state.active_pane, Pane::Chat);
+        assert_eq!(effects, vec![UiEffect::Render]);
+    }
+
+    #[test]
+    fn key_2_switches_to_diff_pane() {
+        let mut state = UiState::default();
+        state.reduce(UiEvent::KeyPressed('2'));
+        assert_eq!(state.active_pane, Pane::Diff);
+    }
+
+    #[test]
+    fn key_3_switches_to_tasks_pane() {
+        let mut state = UiState::default();
+        state.reduce(UiEvent::KeyPressed('3'));
+        assert_eq!(state.active_pane, Pane::Tasks);
+    }
+
+    #[test]
+    fn key_4_switches_to_agents_pane() {
+        let mut state = UiState::default();
+        state.reduce(UiEvent::KeyPressed('4'));
+        assert_eq!(state.active_pane, Pane::Agents);
+    }
+
+    #[test]
+    fn key_5_switches_to_jobs_pane() {
+        let mut state = UiState::default();
+        state.reduce(UiEvent::KeyPressed('5'));
+        assert_eq!(state.active_pane, Pane::Jobs);
+    }
+
+    #[test]
+    fn unknown_key_produces_no_effects() {
+        let mut state = UiState::default();
+        let effects = state.reduce(UiEvent::KeyPressed('x'));
+        assert!(effects.is_empty());
+        assert_eq!(state.active_pane, Pane::Chat);
+    }
+
+    // ── Prompt lifecycle ───────────────────────────────────────────────
+
+    #[test]
+    fn prompt_submitted_increments_pending_tasks() {
+        let mut state = UiState::default();
+        let effects = state.reduce(UiEvent::PromptSubmitted("hello".to_string()));
+        assert_eq!(state.pending_tasks, 1);
+        assert_eq!(state.status_line, "prompt submitted");
+        assert!(effects.contains(&UiEffect::Render));
+        assert!(effects.contains(&UiEffect::PersistCheckpoint));
+    }
+
+    #[test]
+    fn response_delta_updates_last_delta() {
+        let mut state = UiState::default();
+        state.reduce(UiEvent::ResponseDelta("partial".to_string()));
+        assert_eq!(state.last_response_delta, Some("partial".to_string()));
+        assert_eq!(state.status_line, "streaming response");
+    }
+
+    // ── Tool lifecycle ─────────────────────────────────────────────────
+
+    #[test]
+    fn tool_started_sets_active_tool() {
+        let mut state = UiState::default();
+        state.reduce(UiEvent::ToolStarted("shell".to_string()));
+        assert_eq!(state.active_tool, Some("shell".to_string()));
+        assert_eq!(state.status_line, "tool running: shell");
+    }
+
+    #[test]
+    fn tool_finished_clears_active_tool_and_decrements_tasks() {
+        let mut state = UiState::default();
+        state.reduce(UiEvent::PromptSubmitted("test".to_string()));
+        assert_eq!(state.pending_tasks, 1);
+        state.reduce(UiEvent::ToolFinished("shell".to_string()));
+        assert_eq!(state.active_tool, None);
+        assert_eq!(state.pending_tasks, 0);
+        assert_eq!(state.status_line, "tool finished: shell");
+    }
+
+    #[test]
+    fn tool_finished_saturates_at_zero() {
+        let mut state = UiState::default();
+        state.reduce(UiEvent::ToolFinished("shell".to_string()));
+        assert_eq!(state.pending_tasks, 0);
+    }
+
+    // ── Job lifecycle ──────────────────────────────────────────────────
+
+    #[test]
+    fn job_queued_increments_active_jobs() {
+        let mut state = UiState::default();
+        state.reduce(UiEvent::JobQueued("build".to_string()));
+        assert_eq!(state.active_jobs, 1);
+        assert_eq!(state.status_line, "job queued");
+    }
+
+    #[test]
+    fn job_progress_updates_status_line() {
+        let mut state = UiState::default();
+        state.reduce(UiEvent::JobProgress {
+            job_id: "j1".to_string(),
+            progress: 75,
+        });
+        assert_eq!(state.status_line, "job progress: 75%");
+    }
+
+    #[test]
+    fn job_progress_clamps_over_100() {
+        let mut state = UiState::default();
+        state.reduce(UiEvent::JobProgress {
+            job_id: "j1".to_string(),
+            progress: 150,
+        });
+        assert_eq!(state.status_line, "job progress: 100%");
+    }
+
+    #[test]
+    fn job_completed_decrements_active_jobs() {
+        let mut state = UiState::default();
+        state.reduce(UiEvent::JobQueued("build".to_string()));
+        assert_eq!(state.active_jobs, 1);
+        state.reduce(UiEvent::JobCompleted("build".to_string()));
+        assert_eq!(state.active_jobs, 0);
+        assert_eq!(state.status_line, "job completed");
+    }
+
+    #[test]
+    fn job_completed_saturates_at_zero() {
+        let mut state = UiState::default();
+        state.reduce(UiEvent::JobCompleted("build".to_string()));
+        assert_eq!(state.active_jobs, 0);
+    }
+
+    // ── Approval lifecycle ─────────────────────────────────────────────
+
+    #[test]
+    fn approval_requested_increments_pending() {
+        let mut state = UiState::default();
+        state.reduce(UiEvent::ApprovalRequested("exec".to_string()));
+        assert_eq!(state.pending_approvals, 1);
+        assert_eq!(state.status_line, "approval requested");
+    }
+
+    #[test]
+    fn approval_resolved_decrements_pending() {
+        let mut state = UiState::default();
+        state.reduce(UiEvent::ApprovalRequested("exec".to_string()));
+        state.reduce(UiEvent::ApprovalResolved("exec".to_string()));
+        assert_eq!(state.pending_approvals, 0);
+        assert_eq!(state.status_line, "approval resolved");
+    }
+
+    #[test]
+    fn approval_resolved_saturates_at_zero() {
+        let mut state = UiState::default();
+        state.reduce(UiEvent::ApprovalResolved("exec".to_string()));
+        assert_eq!(state.pending_approvals, 0);
+    }
+
+    // ── Pause/Resume ───────────────────────────────────────────────────
+
+    #[test]
+    fn pause_sets_paused_flag() {
+        let mut state = UiState::default();
+        state.reduce(UiEvent::PauseRequested);
+        assert!(state.paused);
+        assert_eq!(state.status_line, "paused");
+    }
+
+    #[test]
+    fn resume_clears_paused_flag() {
+        let mut state = UiState::default();
+        state.reduce(UiEvent::PauseRequested);
+        state.reduce(UiEvent::ResumeRequested);
+        assert!(!state.paused);
+        assert_eq!(state.status_line, "resumed");
+    }
+
+    // ── Tick ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn tick_schedules_background_refresh() {
+        let mut state = UiState::default();
+        let effects = state.reduce(UiEvent::Tick);
+        assert_eq!(effects, vec![UiEffect::ScheduleBackgroundRefresh]);
+    }
+
+    // ── Snapshot ────────────────────────────────────────────────────────
+
+    #[test]
+    fn snapshot_contains_all_fields() {
+        let state = UiState::default();
+        let snap = state.snapshot();
+        assert!(snap.contains("pane=Chat"));
+        assert!(snap.contains("paused=false"));
+        assert!(snap.contains("pending_tasks=0"));
+        assert!(snap.contains("active_jobs=0"));
+        assert!(snap.contains("pending_approvals=0"));
+        assert!(snap.contains("status=ready"));
+    }
+
+    #[test]
+    fn snapshot_reflects_state_changes() {
+        let mut state = UiState::default();
+        state.reduce(UiEvent::KeyPressed('2'));
+        state.reduce(UiEvent::PauseRequested);
+        state.reduce(UiEvent::PromptSubmitted("test".to_string()));
+        let snap = state.snapshot();
+        assert!(snap.contains("pane=Diff"));
+        assert!(snap.contains("paused=true"));
+        assert!(snap.contains("pending_tasks=1"));
+    }
+}


### PR DESCRIPTION
Add 25 unit tests covering the previously untested `tui-core` crate:

- **Default state**: verifies initial Chat pane, ready status, zero counters
- **Key navigation**: pane switching via keys 1-5, unknown key produces no effects
- **Prompt lifecycle**: pending_tasks increment on submit, response delta tracking
- **Tool lifecycle**: active_tool set/clear, pending_tasks decrement with saturation
- **Job lifecycle**: active_jobs increment/decrement, progress percentage clamping at 100%
- **Approval lifecycle**: pending_approvals increment/decrement with saturation
- **Pause/Resume**: paused flag toggling and status line updates
- **Tick**: ScheduleBackgroundRefresh effect emission
- **Snapshot**: format verification, state change reflection

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds 25 unit tests covering the `UiState` state machine in `tui-core`, bringing the previously untested crate to full behavioural coverage across navigation, prompt/tool/job/approval lifecycles, pause/resume, tick, and snapshot formatting. No production code is changed.

- **Vacuous \"clears\" assertion**: `tool_finished_clears_active_tool_and_decrements_tasks` never calls `ToolStarted` first, so `active_tool` is already `None` when `ToolFinished` fires — the clearing assertion is always trivially true and won't catch a regression where `ToolFinished` stops resetting the field.
- **Inconsistent effect verification for keys 2–5**: Only the key-1 test checks the returned `Vec<UiEffect>`; tests for keys 2–5 silently discard it, leaving a blind spot for unexpected effect changes on those branches.
- **`EmitStatusLine` never asserted**: Every event arm that mutates `status_line` also emits `UiEffect::EmitStatusLine`, but no test verifies this effect or its payload, creating a silent gap for that entire effect type.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is test-only and does not touch any production logic.

All findings are in the test code itself rather than production code. The most notable gap is a test that claims to verify active_tool is cleared by ToolFinished but never sets it first, meaning a real regression in that behaviour would pass undetected. The key-navigation tests for keys 2-5 also silently discard returned effects, and no test ever checks the EmitStatusLine effect. None of these gaps affect runtime behaviour today, but they leave parts of the state machine under-asserted.

crates/tui-core/src/lib.rs — the three test gaps described above are all in this file.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui-core/src/lib.rs | Adds 25 unit tests for `UiState::reduce` and `snapshot`; one test has a vacuous assertion for "clears active_tool" because `ToolStarted` is never called first, and key navigation tests for keys 2-5 silently discard returned effects vectors. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant T as Test
    participant S as UiState
    participant E as Effects

    T->>S: "PromptSubmitted"
    S-->>E: "Render, PersistCheckpoint, EmitStatusLine"
    Note over S: pending_tasks += 1

    T->>S: "ToolStarted"
    S-->>E: "Render, EmitStatusLine"
    Note over S: active_tool = Some

    T->>S: "ToolFinished"
    S-->>E: "Render, PersistCheckpoint, EmitStatusLine"
    Note over S: active_tool = None, pending_tasks -= 1

    T->>S: "Tick"
    S-->>E: "ScheduleBackgroundRefresh"

    T->>S: "snapshot()"
    S-->>T: "serialized state string"
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22test%2Ftui-core-state-machine-tests%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22test%2Ftui-core-state-machine-tests%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Ftui-core%2Fsrc%2Flib.rs%3A290-294%0AThe%20test%20name%20claims%20to%20verify%20that%20%60ToolFinished%60%20*clears*%20%60active_tool%60%2C%20but%20%60ToolStarted%60%20is%20never%20called%20beforehand.%20Since%20%60active_tool%60%20starts%20as%20%60None%60%20by%20default%2C%20the%20assertion%20%60assert_eq!%28state.active_tool%2C%20None%29%60%20is%20vacuously%20true%20and%20would%20still%20pass%20even%20if%20the%20production%20code%20stopped%20clearing%20the%20field.%20Adding%20a%20%60ToolStarted%60%20call%20before%20%60ToolFinished%60%20makes%20the%20assertion%20meaningful.%0A%0A%60%60%60suggestion%0A%20%20%20%20fn%20tool_finished_clears_active_tool_and_decrements_tasks%28%29%20%7B%0A%20%20%20%20%20%20%20%20let%20mut%20state%20%3D%20UiState%3A%3Adefault%28%29%3B%0A%20%20%20%20%20%20%20%20state.reduce%28UiEvent%3A%3APromptSubmitted%28%22test%22.to_string%28%29%29%29%3B%0A%20%20%20%20%20%20%20%20assert_eq!%28state.pending_tasks%2C%201%29%3B%0A%20%20%20%20%20%20%20%20state.reduce%28UiEvent%3A%3AToolStarted%28%22shell%22.to_string%28%29%29%29%3B%0A%20%20%20%20%20%20%20%20assert_eq!%28state.active_tool%2C%20Some%28%22shell%22.to_string%28%29%29%29%3B%0A%20%20%20%20%20%20%20%20state.reduce%28UiEvent%3A%3AToolFinished%28%22shell%22.to_string%28%29%29%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Ftui-core%2Fsrc%2Flib.rs%3A224-249%0ATests%20for%20keys%202%E2%80%935%20silently%20discard%20the%20returned%20%60Vec%3CUiEffect%3E%60%2C%20so%20a%20future%20change%20that%20stops%20emitting%20%60UiEffect%3A%3ARender%60%20for%20those%20keys%20would%20go%20undetected.%20The%20key%201%20test%20already%20uses%20exact-equality%20checking%20%E2%80%94%20applying%20the%20same%20pattern%20here%20keeps%20coverage%20consistent%20across%20all%20navigation%20keys.%0A%0A%60%60%60suggestion%0A%20%20%20%20fn%20key_2_switches_to_diff_pane%28%29%20%7B%0A%20%20%20%20%20%20%20%20let%20mut%20state%20%3D%20UiState%3A%3Adefault%28%29%3B%0A%20%20%20%20%20%20%20%20let%20effects%20%3D%20state.reduce%28UiEvent%3A%3AKeyPressed%28'2'%29%29%3B%0A%20%20%20%20%20%20%20%20assert_eq!%28state.active_pane%2C%20Pane%3A%3ADiff%29%3B%0A%20%20%20%20%20%20%20%20assert_eq!%28effects%2C%20vec!%5BUiEffect%3A%3ARender%5D%29%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20%23%5Btest%5D%0A%20%20%20%20fn%20key_3_switches_to_tasks_pane%28%29%20%7B%0A%20%20%20%20%20%20%20%20let%20mut%20state%20%3D%20UiState%3A%3Adefault%28%29%3B%0A%20%20%20%20%20%20%20%20let%20effects%20%3D%20state.reduce%28UiEvent%3A%3AKeyPressed%28'3'%29%29%3B%0A%20%20%20%20%20%20%20%20assert_eq!%28state.active_pane%2C%20Pane%3A%3ATasks%29%3B%0A%20%20%20%20%20%20%20%20assert_eq!%28effects%2C%20vec!%5BUiEffect%3A%3ARender%5D%29%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20%23%5Btest%5D%0A%20%20%20%20fn%20key_4_switches_to_agents_pane%28%29%20%7B%0A%20%20%20%20%20%20%20%20let%20mut%20state%20%3D%20UiState%3A%3Adefault%28%29%3B%0A%20%20%20%20%20%20%20%20let%20effects%20%3D%20state.reduce%28UiEvent%3A%3AKeyPressed%28'4'%29%29%3B%0A%20%20%20%20%20%20%20%20assert_eq!%28state.active_pane%2C%20Pane%3A%3AAgents%29%3B%0A%20%20%20%20%20%20%20%20assert_eq!%28effects%2C%20vec!%5BUiEffect%3A%3ARender%5D%29%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20%23%5Btest%5D%0A%20%20%20%20fn%20key_5_switches_to_jobs_pane%28%29%20%7B%0A%20%20%20%20%20%20%20%20let%20mut%20state%20%3D%20UiState%3A%3Adefault%28%29%3B%0A%20%20%20%20%20%20%20%20let%20effects%20%3D%20state.reduce%28UiEvent%3A%3AKeyPressed%28'5'%29%29%3B%0A%20%20%20%20%20%20%20%20assert_eq!%28state.active_pane%2C%20Pane%3A%3AJobs%29%3B%0A%20%20%20%20%20%20%20%20assert_eq!%28effects%2C%20vec!%5BUiEffect%3A%3ARender%5D%29%3B%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Ftui-core%2Fsrc%2Flib.rs%3A267-268%0ANo%20test%20verifies%20that%20%60EmitStatusLine%60%20is%20emitted%20%28or%20carries%20the%20correct%20payload%29%20for%20any%20event.%20Every%20event%20handler%20that%20updates%20%60status_line%60%20also%20pushes%20%60UiEffect%3A%3AEmitStatusLine%28...%29%60%2C%20but%20all%20tests%20that%20call%20%60effects.contains%28...%29%60%20only%20check%20%60Render%60%20and%20%60PersistCheckpoint%60.%20A%20change%20that%20accidentally%20dropped%20%60EmitStatusLine%60%20from%20any%20arm%20would%20go%20unnoticed.%20Consider%20adding%20at%20least%20one%20representative%20check%20per%20category.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20assert!%28effects.contains%28%26UiEffect%3A%3ARender%29%29%3B%0A%20%20%20%20%20%20%20%20assert!%28effects.contains%28%26UiEffect%3A%3APersistCheckpoint%29%29%3B%0A%20%20%20%20%20%20%20%20assert!%28effects.contains%28%26UiEffect%3A%3AEmitStatusLine%28%22prompt%20submitted%22.to_string%28%29%29%29%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Ftui-core%2Fsrc%2Flib.rs%3A290-294%0AThe%20test%20name%20claims%20to%20verify%20that%20%60ToolFinished%60%20*clears*%20%60active_tool%60%2C%20but%20%60ToolStarted%60%20is%20never%20called%20beforehand.%20Since%20%60active_tool%60%20starts%20as%20%60None%60%20by%20default%2C%20the%20assertion%20%60assert_eq!%28state.active_tool%2C%20None%29%60%20is%20vacuously%20true%20and%20would%20still%20pass%20even%20if%20the%20production%20code%20stopped%20clearing%20the%20field.%20Adding%20a%20%60ToolStarted%60%20call%20before%20%60ToolFinished%60%20makes%20the%20assertion%20meaningful.%0A%0A%60%60%60suggestion%0A%20%20%20%20fn%20tool_finished_clears_active_tool_and_decrements_tasks%28%29%20%7B%0A%20%20%20%20%20%20%20%20let%20mut%20state%20%3D%20UiState%3A%3Adefault%28%29%3B%0A%20%20%20%20%20%20%20%20state.reduce%28UiEvent%3A%3APromptSubmitted%28%22test%22.to_string%28%29%29%29%3B%0A%20%20%20%20%20%20%20%20assert_eq!%28state.pending_tasks%2C%201%29%3B%0A%20%20%20%20%20%20%20%20state.reduce%28UiEvent%3A%3AToolStarted%28%22shell%22.to_string%28%29%29%29%3B%0A%20%20%20%20%20%20%20%20assert_eq!%28state.active_tool%2C%20Some%28%22shell%22.to_string%28%29%29%29%3B%0A%20%20%20%20%20%20%20%20state.reduce%28UiEvent%3A%3AToolFinished%28%22shell%22.to_string%28%29%29%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Ftui-core%2Fsrc%2Flib.rs%3A224-249%0ATests%20for%20keys%202%E2%80%935%20silently%20discard%20the%20returned%20%60Vec%3CUiEffect%3E%60%2C%20so%20a%20future%20change%20that%20stops%20emitting%20%60UiEffect%3A%3ARender%60%20for%20those%20keys%20would%20go%20undetected.%20The%20key%201%20test%20already%20uses%20exact-equality%20checking%20%E2%80%94%20applying%20the%20same%20pattern%20here%20keeps%20coverage%20consistent%20across%20all%20navigation%20keys.%0A%0A%60%60%60suggestion%0A%20%20%20%20fn%20key_2_switches_to_diff_pane%28%29%20%7B%0A%20%20%20%20%20%20%20%20let%20mut%20state%20%3D%20UiState%3A%3Adefault%28%29%3B%0A%20%20%20%20%20%20%20%20let%20effects%20%3D%20state.reduce%28UiEvent%3A%3AKeyPressed%28'2'%29%29%3B%0A%20%20%20%20%20%20%20%20assert_eq!%28state.active_pane%2C%20Pane%3A%3ADiff%29%3B%0A%20%20%20%20%20%20%20%20assert_eq!%28effects%2C%20vec!%5BUiEffect%3A%3ARender%5D%29%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20%23%5Btest%5D%0A%20%20%20%20fn%20key_3_switches_to_tasks_pane%28%29%20%7B%0A%20%20%20%20%20%20%20%20let%20mut%20state%20%3D%20UiState%3A%3Adefault%28%29%3B%0A%20%20%20%20%20%20%20%20let%20effects%20%3D%20state.reduce%28UiEvent%3A%3AKeyPressed%28'3'%29%29%3B%0A%20%20%20%20%20%20%20%20assert_eq!%28state.active_pane%2C%20Pane%3A%3ATasks%29%3B%0A%20%20%20%20%20%20%20%20assert_eq!%28effects%2C%20vec!%5BUiEffect%3A%3ARender%5D%29%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20%23%5Btest%5D%0A%20%20%20%20fn%20key_4_switches_to_agents_pane%28%29%20%7B%0A%20%20%20%20%20%20%20%20let%20mut%20state%20%3D%20UiState%3A%3Adefault%28%29%3B%0A%20%20%20%20%20%20%20%20let%20effects%20%3D%20state.reduce%28UiEvent%3A%3AKeyPressed%28'4'%29%29%3B%0A%20%20%20%20%20%20%20%20assert_eq!%28state.active_pane%2C%20Pane%3A%3AAgents%29%3B%0A%20%20%20%20%20%20%20%20assert_eq!%28effects%2C%20vec!%5BUiEffect%3A%3ARender%5D%29%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20%23%5Btest%5D%0A%20%20%20%20fn%20key_5_switches_to_jobs_pane%28%29%20%7B%0A%20%20%20%20%20%20%20%20let%20mut%20state%20%3D%20UiState%3A%3Adefault%28%29%3B%0A%20%20%20%20%20%20%20%20let%20effects%20%3D%20state.reduce%28UiEvent%3A%3AKeyPressed%28'5'%29%29%3B%0A%20%20%20%20%20%20%20%20assert_eq!%28state.active_pane%2C%20Pane%3A%3AJobs%29%3B%0A%20%20%20%20%20%20%20%20assert_eq!%28effects%2C%20vec!%5BUiEffect%3A%3ARender%5D%29%3B%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Ftui-core%2Fsrc%2Flib.rs%3A267-268%0ANo%20test%20verifies%20that%20%60EmitStatusLine%60%20is%20emitted%20%28or%20carries%20the%20correct%20payload%29%20for%20any%20event.%20Every%20event%20handler%20that%20updates%20%60status_line%60%20also%20pushes%20%60UiEffect%3A%3AEmitStatusLine%28...%29%60%2C%20but%20all%20tests%20that%20call%20%60effects.contains%28...%29%60%20only%20check%20%60Render%60%20and%20%60PersistCheckpoint%60.%20A%20change%20that%20accidentally%20dropped%20%60EmitStatusLine%60%20from%20any%20arm%20would%20go%20unnoticed.%20Consider%20adding%20at%20least%20one%20representative%20check%20per%20category.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20assert!%28effects.contains%28%26UiEffect%3A%3ARender%29%29%3B%0A%20%20%20%20%20%20%20%20assert!%28effects.contains%28%26UiEffect%3A%3APersistCheckpoint%29%29%3B%0A%20%20%20%20%20%20%20%20assert!%28effects.contains%28%26UiEffect%3A%3AEmitStatusLine%28%22prompt%20submitted%22.to_string%28%29%29%29%29%3B%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2450&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Ftui-core%2Fsrc%2Flib.rs%3A290-294%0AThe%20test%20name%20claims%20to%20verify%20that%20%60ToolFinished%60%20*clears*%20%60active_tool%60%2C%20but%20%60ToolStarted%60%20is%20never%20called%20beforehand.%20Since%20%60active_tool%60%20starts%20as%20%60None%60%20by%20default%2C%20the%20assertion%20%60assert_eq!%28state.active_tool%2C%20None%29%60%20is%20vacuously%20true%20and%20would%20still%20pass%20even%20if%20the%20production%20code%20stopped%20clearing%20the%20field.%20Adding%20a%20%60ToolStarted%60%20call%20before%20%60ToolFinished%60%20makes%20the%20assertion%20meaningful.%0A%0A%60%60%60suggestion%0A%20%20%20%20fn%20tool_finished_clears_active_tool_and_decrements_tasks%28%29%20%7B%0A%20%20%20%20%20%20%20%20let%20mut%20state%20%3D%20UiState%3A%3Adefault%28%29%3B%0A%20%20%20%20%20%20%20%20state.reduce%28UiEvent%3A%3APromptSubmitted%28%22test%22.to_string%28%29%29%29%3B%0A%20%20%20%20%20%20%20%20assert_eq!%28state.pending_tasks%2C%201%29%3B%0A%20%20%20%20%20%20%20%20state.reduce%28UiEvent%3A%3AToolStarted%28%22shell%22.to_string%28%29%29%29%3B%0A%20%20%20%20%20%20%20%20assert_eq!%28state.active_tool%2C%20Some%28%22shell%22.to_string%28%29%29%29%3B%0A%20%20%20%20%20%20%20%20state.reduce%28UiEvent%3A%3AToolFinished%28%22shell%22.to_string%28%29%29%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Ftui-core%2Fsrc%2Flib.rs%3A224-249%0ATests%20for%20keys%202%E2%80%935%20silently%20discard%20the%20returned%20%60Vec%3CUiEffect%3E%60%2C%20so%20a%20future%20change%20that%20stops%20emitting%20%60UiEffect%3A%3ARender%60%20for%20those%20keys%20would%20go%20undetected.%20The%20key%201%20test%20already%20uses%20exact-equality%20checking%20%E2%80%94%20applying%20the%20same%20pattern%20here%20keeps%20coverage%20consistent%20across%20all%20navigation%20keys.%0A%0A%60%60%60suggestion%0A%20%20%20%20fn%20key_2_switches_to_diff_pane%28%29%20%7B%0A%20%20%20%20%20%20%20%20let%20mut%20state%20%3D%20UiState%3A%3Adefault%28%29%3B%0A%20%20%20%20%20%20%20%20let%20effects%20%3D%20state.reduce%28UiEvent%3A%3AKeyPressed%28'2'%29%29%3B%0A%20%20%20%20%20%20%20%20assert_eq!%28state.active_pane%2C%20Pane%3A%3ADiff%29%3B%0A%20%20%20%20%20%20%20%20assert_eq!%28effects%2C%20vec!%5BUiEffect%3A%3ARender%5D%29%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20%23%5Btest%5D%0A%20%20%20%20fn%20key_3_switches_to_tasks_pane%28%29%20%7B%0A%20%20%20%20%20%20%20%20let%20mut%20state%20%3D%20UiState%3A%3Adefault%28%29%3B%0A%20%20%20%20%20%20%20%20let%20effects%20%3D%20state.reduce%28UiEvent%3A%3AKeyPressed%28'3'%29%29%3B%0A%20%20%20%20%20%20%20%20assert_eq!%28state.active_pane%2C%20Pane%3A%3ATasks%29%3B%0A%20%20%20%20%20%20%20%20assert_eq!%28effects%2C%20vec!%5BUiEffect%3A%3ARender%5D%29%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20%23%5Btest%5D%0A%20%20%20%20fn%20key_4_switches_to_agents_pane%28%29%20%7B%0A%20%20%20%20%20%20%20%20let%20mut%20state%20%3D%20UiState%3A%3Adefault%28%29%3B%0A%20%20%20%20%20%20%20%20let%20effects%20%3D%20state.reduce%28UiEvent%3A%3AKeyPressed%28'4'%29%29%3B%0A%20%20%20%20%20%20%20%20assert_eq!%28state.active_pane%2C%20Pane%3A%3AAgents%29%3B%0A%20%20%20%20%20%20%20%20assert_eq!%28effects%2C%20vec!%5BUiEffect%3A%3ARender%5D%29%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20%23%5Btest%5D%0A%20%20%20%20fn%20key_5_switches_to_jobs_pane%28%29%20%7B%0A%20%20%20%20%20%20%20%20let%20mut%20state%20%3D%20UiState%3A%3Adefault%28%29%3B%0A%20%20%20%20%20%20%20%20let%20effects%20%3D%20state.reduce%28UiEvent%3A%3AKeyPressed%28'5'%29%29%3B%0A%20%20%20%20%20%20%20%20assert_eq!%28state.active_pane%2C%20Pane%3A%3AJobs%29%3B%0A%20%20%20%20%20%20%20%20assert_eq!%28effects%2C%20vec!%5BUiEffect%3A%3ARender%5D%29%3B%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Ftui-core%2Fsrc%2Flib.rs%3A267-268%0ANo%20test%20verifies%20that%20%60EmitStatusLine%60%20is%20emitted%20%28or%20carries%20the%20correct%20payload%29%20for%20any%20event.%20Every%20event%20handler%20that%20updates%20%60status_line%60%20also%20pushes%20%60UiEffect%3A%3AEmitStatusLine%28...%29%60%2C%20but%20all%20tests%20that%20call%20%60effects.contains%28...%29%60%20only%20check%20%60Render%60%20and%20%60PersistCheckpoint%60.%20A%20change%20that%20accidentally%20dropped%20%60EmitStatusLine%60%20from%20any%20arm%20would%20go%20unnoticed.%20Consider%20adding%20at%20least%20one%20representative%20check%20per%20category.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20assert!%28effects.contains%28%26UiEffect%3A%3ARender%29%29%3B%0A%20%20%20%20%20%20%20%20assert!%28effects.contains%28%26UiEffect%3A%3APersistCheckpoint%29%29%3B%0A%20%20%20%20%20%20%20%20assert!%28effects.contains%28%26UiEffect%3A%3AEmitStatusLine%28%22prompt%20submitted%22.to_string%28%29%29%29%29%3B%0A%60%60%60%0A%0A&pr=2450&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["test(tui-core): add unit tests for UiSta..."](https://github.com/hmbown/codewhale/commit/37d9b92d363a646e01b4d0fa934fa907b1baf9b4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34803014)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->