### PR TITLE
docs(tools): add doc comments to remaining public types

### DIFF
--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -234,37 +234,69 @@ pub fn optional_bool(input: &Value, field: &str, default: bool) -> bool {
     input.get(field).and_then(Value::as_bool).unwrap_or(default)
 }
 
+/// Specification that describes a tool available in the registry.
+///
+/// Contains the tool's name, its JSON input/output schemas, and
+/// execution constraints such as timeout and parallelism.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolSpec {
+    /// Unique name used to look up the tool.
     pub name: String,
+    /// JSON Schema describing the tool's expected input parameters.
     pub input_schema: Value,
+    /// JSON Schema describing the tool's output format.
     pub output_schema: Value,
+    /// Whether multiple invocations of this tool may run concurrently.
     pub supports_parallel_tool_calls: bool,
+    /// Optional per-call timeout in milliseconds; `None` means no timeout.
     pub timeout_ms: Option<u64>,
 }
 
+/// A [`ToolSpec`] together with its runtime configuration.
+///
+/// Wraps a `ToolSpec` and exposes the parallelism flag directly so the
+/// dispatcher can check it without digging into the inner spec.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ConfiguredToolSpec {
+    /// The underlying tool specification.
     pub spec: ToolSpec,
+    /// Whether this tool supports concurrent invocations.
     pub supports_parallel_tool_calls: bool,
 }
 
+/// Identifies where a tool call originated from.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ToolCallSource {
+    /// Direct invocation from the model or user.
     Direct,
+    /// Invocation through the JavaScript REPL environment.
     JsRepl,
 }
 
+/// A tool invocation request before it has been validated and dispatched.
+///
+/// Contains the tool name, its input payload, and metadata about where the
+/// call originated.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolCall {
+    /// Name of the tool to invoke.
     pub name: String,
+    /// The input payload for the tool.
     pub payload: ToolPayload,
+    /// Where this call originated (direct or REPL).
     pub source: ToolCallSource,
+    /// Optional raw tool-call identifier from the upstream provider.
     pub raw_tool_call_id: Option<String>,
 }
 
 impl ToolCall {
+    /// Derive the execution subject for this call.
+    ///
+    /// For local shell payloads this returns the shell command and its
+    /// working directory; for all other payloads the tool name and the
+    /// provided `fallback_cwd` are returned instead. The third element
+    /// of the tuple is a human-readable kind label (`"shell"` or `"tool"`).
     pub fn execution_subject(&self, fallback_cwd: &str) -> (String, String, &'static str) {
         match &self.payload {
             ToolPayload::LocalShell { params } => (
@@ -280,43 +312,82 @@ impl ToolCall {
     }
 }
 
+/// A validated tool invocation ready to be handled.
+///
+/// Created by the registry after a [`ToolCall`] passes validation, this
+/// carries all the context a [`ToolHandler`] needs to execute the tool.
 #[derive(Debug, Clone)]
 pub struct ToolInvocation {
+    /// Unique identifier for this invocation (generated or from the provider).
     pub call_id: String,
+    /// Name of the tool being invoked.
     pub tool_name: String,
+    /// The input payload for the tool.
     pub payload: ToolPayload,
+    /// Where this invocation originated.
     pub source: ToolCallSource,
 }
 
+/// Errors that can occur during tool dispatch and execution.
+///
+/// Unlike [`ToolError`], which represents input validation failures within
+/// a tool, `FunctionCallError` covers problems at the dispatch layer: the
+/// tool was not found, its kind did not match, it was rejected because it
+/// is mutating, it timed out, was cancelled, or its handler returned an
+/// error.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum FunctionCallError {
+    /// No tool with the given name is registered.
     ToolNotFound { name: String },
+    /// The payload kind does not match the handler's expected kind.
     KindMismatch { expected: ToolKind, got: ToolKind },
+    /// The tool is mutating but `allow_mutating` was `false`.
     MutatingToolRejected { name: String },
+    /// The tool execution exceeded its configured timeout.
     TimedOut { name: String, timeout_ms: u64 },
+    /// The tool execution was cancelled.
     Cancelled { name: String },
+    /// The tool handler returned an error.
     ExecutionFailed { name: String, error: String },
 }
 
+/// Trait implemented by concrete tool handlers.
+///
+/// Each registered tool is backed by a handler that reports its kind,
+/// whether it is mutating, and performs the actual execution.
 #[async_trait]
 pub trait ToolHandler: Send + Sync {
+    /// The [`ToolKind`] this handler expects (e.g. `Function` or `Mcp`).
     fn kind(&self) -> ToolKind;
+
+    /// Returns `true` if `kind` matches this handler's expected kind.
+    ///
+    /// The default implementation compares against [`kind()`](ToolHandler::kind).
     fn matches_kind(&self, kind: ToolKind) -> bool {
         self.kind() == kind
     }
+
+    /// Whether this tool performs side-effects that require user approval.
+    ///
+    /// Defaults to `false` (read-only / safe).
     fn is_mutating(&self) -> bool {
         false
     }
+
+    /// Execute the tool with the given invocation context.
     async fn handle(
         &self,
         invocation: ToolInvocation,
     ) -> std::result::Result<ToolOutput, FunctionCallError>;
 }
 
+/// Manages concurrent tool execution via a read/write lock.
+///
+/// Parallel-safe tools acquire a read lock (allowing overlap), while
+/// serial tools acquire a write lock (exclusive access). Reentrant calls
+/// (e.g. a tool invoking another tool) skip locking to avoid deadlock.
 #[derive(Debug)]
 pub struct ToolCallRuntime {
-    /// Preserve read/write tool execution semantics: parallel-safe tools may
-    /// overlap, while serial tools run exclusively.
     execution_lock: Arc<RwLock<()>>,
 }
 
@@ -349,6 +420,11 @@ impl ToolCallRuntime {
     }
 }
 
+/// Central registry that maps tool names to their specs and handlers.
+///
+/// Use [`register()`](ToolRegistry::register) to add tools, then
+/// [`dispatch()`](ToolRegistry::dispatch) to invoke them. The registry
+/// owns a [`ToolCallRuntime`] that manages concurrent execution.
 #[derive(Default)]
 pub struct ToolRegistry {
     handlers: HashMap<String, Arc<dyn ToolHandler>>,
@@ -357,6 +433,11 @@ pub struct ToolRegistry {
 }
 
 impl ToolRegistry {
+    /// Register a tool with its specification and handler.
+    ///
+    /// The tool's name is taken from `spec.name`. Returns an error if
+    /// registration fails (currently infallible, but the `Result` is
+    /// reserved for future validation).
     pub fn register(&mut self, spec: ToolSpec, handler: Arc<dyn ToolHandler>) -> Result<()> {
         let name = spec.name.clone();
         self.specs.insert(
@@ -370,10 +451,18 @@ impl ToolRegistry {
         Ok(())
     }
 
+    /// Return the configured specs for every registered tool.
     pub fn list_specs(&self) -> Vec<ConfiguredToolSpec> {
         self.specs.values().cloned().collect()
     }
 
+    /// Validate and execute a tool call.
+    ///
+    /// Looks up the tool by name, verifies the payload kind matches the
+    /// handler, enforces the `allow_mutating` guard, acquires the
+    /// appropriate execution lock, and forwards the call to the handler.
+    /// Returns a [`FunctionCallError`] if any validation step fails or
+    /// the handler returns an error.
     pub async fn dispatch(
         &self,
         call: ToolCall,


### PR DESCRIPTION
Add doc comments to public types in the tools crate that were missing them: ToolSpec, ConfiguredToolSpec, ToolCallSource, ToolCall, ToolInvocation, FunctionCallError, ToolHandler trait, ToolCallRuntime, and ToolRegistry.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds doc comments to the previously undocumented public types in `crates/tools/src/lib.rs`: `ToolSpec`, `ConfiguredToolSpec`, `ToolCallSource`, `ToolCall`, `ToolInvocation`, `FunctionCallError`, `ToolHandler`, `ToolCallRuntime`, and `ToolRegistry`. No logic is changed.

- Struct-level and field-level doc comments are added for all nine types/traits, accurately describing their roles in tool registration, dispatch, and concurrent execution.
- One existing field comment on `ToolCallRuntime.execution_lock` was promoted to a struct-level doc block.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Pure documentation change — no logic, data flow, or public API signatures are modified, so there is no risk of behavioral regression.

Every added comment accurately describes the code it annotates. The one minor inaccuracy — calling ToolError an 'input validation' type when it also covers execution failures, timeouts, and path escapes — is cosmetic and does not affect runtime behavior.

No files require special attention; the single changed file contains only documentation additions.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tools/src/lib.rs | Documentation-only change: adds accurate doc comments to nine public types/traits; one comment slightly mischaracterises ToolError's scope. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant ToolRegistry
    participant ToolCallRuntime
    participant ToolHandler

    Caller->>ToolRegistry: dispatch(ToolCall, allow_mutating)
    ToolRegistry->>ToolRegistry: "lookup handler & ConfiguredToolSpec by name"
    alt tool not found
        ToolRegistry-->>Caller: Err(ToolNotFound)
    end
    ToolRegistry->>ToolRegistry: verify payload kind via matches_kind()
    alt kind mismatch
        ToolRegistry-->>Caller: Err(KindMismatch)
    end
    ToolRegistry->>ToolRegistry: "check is_mutating() && !allow_mutating"
    alt mutating rejected
        ToolRegistry-->>Caller: Err(MutatingToolRejected)
    end
    ToolRegistry->>ToolCallRuntime: acquire(supports_parallel_tool_calls)
    alt parallel-safe
        ToolCallRuntime-->>ToolRegistry: ReadGuard
    else serial
        ToolCallRuntime-->>ToolRegistry: WriteGuard
    else reentrant
        ToolCallRuntime-->>ToolRegistry: Reentrant (no lock)
    end
    ToolRegistry->>ToolHandler: handle(ToolInvocation) [with optional timeout]
    alt success
        ToolHandler-->>ToolRegistry: Ok(ToolOutput)
        ToolRegistry-->>Caller: Ok(ToolOutput)
    else timeout
        ToolRegistry-->>Caller: Err(TimedOut)
    else handler error
        ToolHandler-->>ToolRegistry: Err(FunctionCallError)
        ToolRegistry-->>Caller: Err(ExecutionFailed)
    end
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22docs%2Ftools-crate-docs%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Ftools-crate-docs%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftools%2Fsrc%2Flib.rs%3A333-334%0AThe%20description%20of%20%60ToolError%60%20is%20too%20narrow.%20%60ToolError%60%20covers%20%60ExecutionFailed%60%2C%20%60Timeout%60%2C%20%60PathEscape%60%2C%20%60NotAvailable%60%2C%20and%20%60PermissionDenied%60%20in%20addition%20to%20input-validation%20failures%20%E2%80%94%20so%20calling%20it%20the%20type%20for%20%22input%20validation%20failures%20within%20a%20tool%22%20misrepresents%20its%20scope.%20Describing%20it%20as%20the%20type%20for%20errors%20that%20arise%20*inside*%20a%20handler%20%28as%20opposed%20to%20at%20the%20dispatch%20layer%29%20is%20more%20accurate.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20Unlike%20%5B%60ToolError%60%5D%2C%20which%20represents%20errors%20that%20arise%20inside%20a%20tool%0A%2F%2F%2F%20handler%20%28bad%20input%2C%20path%20escapes%2C%20execution%20failures%2C%20timeouts%2C%20etc.%29%2C%0A%2F%2F%2F%20%60FunctionCallError%60%20covers%20problems%20at%20the%20dispatch%20layer%3A%20the%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftools%2Fsrc%2Flib.rs%3A333-334%0AThe%20description%20of%20%60ToolError%60%20is%20too%20narrow.%20%60ToolError%60%20covers%20%60ExecutionFailed%60%2C%20%60Timeout%60%2C%20%60PathEscape%60%2C%20%60NotAvailable%60%2C%20and%20%60PermissionDenied%60%20in%20addition%20to%20input-validation%20failures%20%E2%80%94%20so%20calling%20it%20the%20type%20for%20%22input%20validation%20failures%20within%20a%20tool%22%20misrepresents%20its%20scope.%20Describing%20it%20as%20the%20type%20for%20errors%20that%20arise%20*inside*%20a%20handler%20%28as%20opposed%20to%20at%20the%20dispatch%20layer%29%20is%20more%20accurate.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20Unlike%20%5B%60ToolError%60%5D%2C%20which%20represents%20errors%20that%20arise%20inside%20a%20tool%0A%2F%2F%2F%20handler%20%28bad%20input%2C%20path%20escapes%2C%20execution%20failures%2C%20timeouts%2C%20etc.%29%2C%0A%2F%2F%2F%20%60FunctionCallError%60%20covers%20problems%20at%20the%20dispatch%20layer%3A%20the%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2451&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftools%2Fsrc%2Flib.rs%3A333-334%0AThe%20description%20of%20%60ToolError%60%20is%20too%20narrow.%20%60ToolError%60%20covers%20%60ExecutionFailed%60%2C%20%60Timeout%60%2C%20%60PathEscape%60%2C%20%60NotAvailable%60%2C%20and%20%60PermissionDenied%60%20in%20addition%20to%20input-validation%20failures%20%E2%80%94%20so%20calling%20it%20the%20type%20for%20%22input%20validation%20failures%20within%20a%20tool%22%20misrepresents%20its%20scope.%20Describing%20it%20as%20the%20type%20for%20errors%20that%20arise%20*inside*%20a%20handler%20%28as%20opposed%20to%20at%20the%20dispatch%20layer%29%20is%20more%20accurate.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20Unlike%20%5B%60ToolError%60%5D%2C%20which%20represents%20errors%20that%20arise%20inside%20a%20tool%0A%2F%2F%2F%20handler%20%28bad%20input%2C%20path%20escapes%2C%20execution%20failures%2C%20timeouts%2C%20etc.%29%2C%0A%2F%2F%2F%20%60FunctionCallError%60%20covers%20problems%20at%20the%20dispatch%20layer%3A%20the%0A%60%60%60%0A%0A&pr=2451&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs(tools): add doc comments to remaini..."](https://github.com/hmbown/codewhale/commit/c94719ad7af3008e8a061db83748093d46af8102) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34803053)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->