### PR TITLE
docs(state): add doc comments to all public types

### DIFF
--- a/crates/execpolicy/src/lib.rs
+++ b/crates/execpolicy/src/lib.rs
@@ -20,14 +20,19 @@ pub enum RulesetLayer {
 /// A named set of allow/deny prefix rules at a given priority layer.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Ruleset {
+    /// Priority layer this ruleset belongs to.
     pub layer: RulesetLayer,
+    /// Command prefixes that are allowed without requiring approval.
     pub trusted_prefixes: Vec<String>,
+    /// Command prefixes that are always blocked, regardless of trust rules.
     pub denied_prefixes: Vec<String>,
+    /// Typed rules that mark specific tool invocations as requiring approval.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub ask_rules: Vec<ToolAskRule>,
 }
 
 impl Ruleset {
+    /// Creates an empty ruleset at the builtin default priority layer.
     pub fn builtin_default() -> Self {
         Self {
             layer: RulesetLayer::BuiltinDefault,
@@ -37,6 +42,7 @@ impl Ruleset {
         }
     }
 
+    /// Creates an agent-layer ruleset with the given trusted and denied prefixes.
     pub fn agent(trusted: Vec<String>, denied: Vec<String>) -> Self {
         Self {
             layer: RulesetLayer::Agent,
@@ -46,6 +52,7 @@ impl Ruleset {
         }
     }
 
+    /// Creates a user-layer ruleset with the given trusted and denied prefixes.
     pub fn user(trusted: Vec<String>, denied: Vec<String>) -> Self {
         Self {
             layer: RulesetLayer::User,
@@ -55,6 +62,7 @@ impl Ruleset {
         }
     }
 
+    /// Attaches typed ask rules to this ruleset and returns it.
     pub fn with_ask_rules(mut self, ask_rules: Vec<ToolAskRule>) -> Self {
         self.ask_rules = ask_rules;
         self
@@ -68,14 +76,18 @@ impl Ruleset {
 /// `AskForApproval::Never` reject invocations that cannot be approved.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ToolAskRule {
+    /// Name of the tool this rule applies to (e.g. `"exec_shell"`, `"edit_file"`).
     pub tool: String,
+    /// Optional command prefix to match against (uses arity-aware matching).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub command: Option<String>,
+    /// Optional file path pattern to match against.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
 }
 
 impl ToolAskRule {
+    /// Creates a new ask rule matching any invocation of the given tool.
     pub fn new(tool: impl Into<String>) -> Self {
         Self {
             tool: tool.into(),
@@ -84,6 +96,7 @@ impl ToolAskRule {
         }
     }
 
+    /// Creates an ask rule for `exec_shell` matching a specific command prefix.
     pub fn exec_shell(command: impl Into<String>) -> Self {
         Self {
             tool: "exec_shell".to_string(),
@@ -92,6 +105,7 @@ impl ToolAskRule {
         }
     }
 
+    /// Creates an ask rule for a file-tool matching a specific path pattern.
     pub fn file_path(tool: impl Into<String>, path: impl Into<String>) -> Self {
         Self {
             tool: tool.into(),
@@ -114,40 +128,62 @@ impl ToolAskRule {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
+/// Policy mode controlling when tool invocations require human approval.
 pub enum AskForApproval {
+    /// Skip approval if the command matches a trusted prefix; otherwise require it.
     UnlessTrusted,
+    /// Allow execution and only request approval after a failure occurs.
     OnFailure,
+    /// Always require approval before execution.
     OnRequest,
+    /// Reject invocations outright based on specific criteria.
     Reject {
+        /// Whether sandbox approval requests are rejected.
         sandbox_approval: bool,
+        /// Whether rule-exception requests are rejected.
         rules: bool,
+        /// Whether MCP elicitation requests are rejected.
         mcp_elicitations: bool,
     },
+    /// Never require approval; forbid commands that would need it.
     Never,
 }
 
+/// A proposed amendment to the execution policy, suggesting new trusted prefixes.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ExecPolicyAmendment {
+    /// Command prefixes to add to the trusted list.
     pub prefixes: Vec<String>,
 }
 
+/// The approval requirement determined by the execution policy engine.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum ExecApprovalRequirement {
+    /// Execution is allowed without approval.
     Skip {
+        /// Whether the sandbox should be bypassed for this execution.
         bypass_sandbox: bool,
+        /// Optional proposed policy amendment (e.g., to persist the allowed prefix).
         proposed_execpolicy_amendment: Option<ExecPolicyAmendment>,
     },
+    /// Execution is allowed but requires human approval first.
     NeedsApproval {
+        /// Human-readable reason explaining why approval is needed.
         reason: String,
+        /// Optional proposed policy amendment that would be applied on approval.
         proposed_execpolicy_amendment: Option<ExecPolicyAmendment>,
+        /// Proposed network policy amendments that would be applied on approval.
         proposed_network_policy_amendments: Vec<NetworkPolicyAmendment>,
     },
+    /// Execution is forbidden by policy.
     Forbidden {
+        /// Human-readable reason explaining why execution is forbidden.
         reason: String,
     },
 }
 
 impl ExecApprovalRequirement {
+    /// Returns the human-readable reason for this approval requirement.
     pub fn reason(&self) -> &str {
         match self {
             ExecApprovalRequirement::Skip { .. } => "Execution allowed by policy.",
@@ -156,6 +192,7 @@ impl ExecApprovalRequirement {
         }
     }
 
+    /// Returns a short phase label: `"allowed"`, `"needs_approval"`, or `"forbidden"`.
     pub fn phase(&self) -> &'static str {
         match self {
             ExecApprovalRequirement::Skip { .. } => "allowed",
@@ -165,27 +202,40 @@ impl ExecApprovalRequirement {
     }
 }
 
+/// The result of evaluating a command against the execution policy.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ExecPolicyDecision {
+    /// Whether the command is allowed to execute.
     pub allow: bool,
+    /// Whether human approval is required before execution.
     pub requires_approval: bool,
+    /// The detailed approval requirement, including any proposed amendments.
     pub requirement: ExecApprovalRequirement,
+    /// The rule that matched, if any (e.g. a trusted prefix or ask rule label).
     pub matched_rule: Option<String>,
 }
 
 impl ExecPolicyDecision {
+    /// Returns the human-readable reason for this decision.
     pub fn reason(&self) -> &str {
         self.requirement.reason()
     }
 }
 
+/// Input context provided to the execution policy engine for a single check.
 #[derive(Debug, Clone)]
 pub struct ExecPolicyContext<'a> {
+    /// The shell command string being evaluated.
     pub command: &'a str,
+    /// The current working directory at invocation time.
     pub cwd: &'a str,
+    /// The tool name (e.g. `"exec_shell"`, `"edit_file"`). Defaults to `"exec_shell"` when `None`.
     pub tool: Option<&'a str>,
+    /// An optional file path relevant to the invocation (used for path-based ask rules).
     pub path: Option<&'a str>,
+    /// The current approval policy mode.
     pub ask_for_approval: AskForApproval,
+    /// The sandbox mode in effect, if any (e.g. `"workspace-write"`).
     pub sandbox_mode: Option<&'a str>,
 }
 
@@ -279,14 +329,20 @@ impl ExecPolicyEngine {
             .cloned()
     }
 
+    /// Records an approval key for the current session so subsequent checks skip approval.
     pub fn remember_session_approval(&mut self, approval_key: String) {
         self.approved_for_session.insert(approval_key);
     }
 
+    /// Returns whether the given approval key has been recorded for this session.
     pub fn is_session_approved(&self, approval_key: &str) -> bool {
         self.approved_for_session.contains(approval_key)
     }
 
+    /// Evaluates a command against the policy and returns a decision.
+    ///
+    /// The evaluation order is: deny rules first (always win), then trusted prefix
+    /// matching (arity-aware), then typed ask rules, and finally the approval mode.
     pub fn check(&self, ctx: ExecPolicyContext<'_>) -> Result<ExecPolicyDecision> {
         let normalized = normalize_command(ctx.command);
         let (trusted_prefixes, denied_prefixes) = self.resolve_prefixes();

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -1,3 +1,14 @@
+//! Persistent state management for conversation threads, messages, and jobs.
+//!
+//! The [`StateStore`] is the primary entry point, backed by a SQLite database and an
+//! append-only JSONL session index file. It provides CRUD operations for:
+//!
+//! - **Threads** — conversation metadata, archival, and session indexing.
+//! - **Messages** — append-only message storage with tree-structured branching.
+//! - **Checkpoints** — named state snapshots for restoring conversation progress.
+//! - **Jobs** — background task tracking with status and progress.
+//! - **Dynamic tools** — per-thread tool registrations.
+
 use std::collections::HashMap;
 use std::fs::{self, OpenOptions};
 use std::io::{BufRead, BufReader, Write};
@@ -9,104 +20,187 @@ use rusqlite::{Connection, OptionalExtension, params};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+/// Lifecycle status of a conversation thread.
+///
+/// Serialized as lowercase snake_case strings (e.g. `"running"`, `"archived"`).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ThreadStatus {
+    /// Thread is actively being worked on.
     Running,
+    /// Thread exists but has no active work in progress.
     Idle,
+    /// Thread has finished its task successfully.
     Completed,
+    /// Thread encountered an unrecoverable error.
     Failed,
+    /// Thread has been temporarily paused by the user.
     Paused,
+    /// Thread has been archived and is hidden from default listings.
     Archived,
 }
 
+/// Indicates how a session was initiated.
+///
+/// Serialized as lowercase snake_case strings.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum SessionSource {
+    /// Started by a user interacting with the CLI.
     Interactive,
+    /// Resumed from a previously persisted session.
     Resume,
+    /// Created by forking an existing conversation at a specific message.
     Fork,
+    /// Initiated programmatically via the API.
     Api,
+    /// Source is unknown or unspecified.
     Unknown,
 }
 
+/// Metadata for a persisted conversation thread.
+///
+/// Each thread represents a single conversation session and stores its
+/// configuration, git context, and current status.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ThreadMetadata {
+    /// Unique identifier for this thread.
     pub id: String,
+    /// Optional filesystem path to the rollout (JSONL transcript) file.
     pub rollout_path: Option<PathBuf>,
+    /// Short preview or summary of the thread content.
     pub preview: String,
+    /// Whether this thread is ephemeral (not persisted long-term).
     pub ephemeral: bool,
+    /// Identifier of the model provider used for this thread (e.g. `"openai"`).
     pub model_provider: String,
+    /// Unix timestamp (seconds) when the thread was created.
     pub created_at: i64,
+    /// Unix timestamp (seconds) of the most recent update to the thread.
     pub updated_at: i64,
+    /// Current lifecycle status of the thread.
     pub status: ThreadStatus,
+    /// Optional filesystem path associated with the thread working context.
     pub path: Option<PathBuf>,
+    /// Working directory that was active when the thread was created.
     pub cwd: PathBuf,
+    /// Version of the CLI that created this thread.
     pub cli_version: String,
+    /// How this session was initiated.
     pub source: SessionSource,
+    /// User-assigned display name for the thread.
     pub name: Option<String>,
+    /// Serialized sandbox policy applied to this thread, if any.
     pub sandbox_policy: Option<String>,
+    /// Approval mode configured for tool calls in this thread.
     pub approval_mode: Option<String>,
+    /// Whether the thread has been archived.
     pub archived: bool,
+    /// Unix timestamp (seconds) when the thread was archived, or `None` if not archived.
     pub archived_at: Option<i64>,
+    /// Git commit SHA of the working tree when the thread was created.
     pub git_sha: Option<String>,
+    /// Git branch checked out when the thread was created.
     pub git_branch: Option<String>,
+    /// URL of the git remote origin, if available.
     pub git_origin_url: Option<String>,
+    /// Memory mode configured for this thread (e.g. `"local"`, `"remote"`).
     pub memory_mode: Option<String>,
+    /// ID of the current leaf message in the conversation tree.
     pub current_leaf_id: Option<i64>,
 }
 
+/// A dynamically registered tool associated with a thread.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DynamicToolRecord {
+    /// Ordinal position of this tool in the thread tool list.
     pub position: i64,
+    /// Unique name identifying the tool.
     pub name: String,
+    /// Human-readable description of what the tool does.
     pub description: Option<String>,
+    /// JSON Schema describing the tool input parameters.
     pub input_schema: Value,
 }
 
+/// A single message entry in a conversation thread.
+///
+/// Messages form a tree structure via [`parent_entry_id`](Self::parent_entry_id),
+/// enabling conversation branching and forking.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MessageRecord {
+    /// Auto-incremented unique identifier for this message.
     pub id: i64,
+    /// ID of the thread this message belongs to.
     pub thread_id: String,
+    /// Role of the message sender (e.g. `"user"`, `"assistant"`, `"system"`).
     pub role: String,
+    /// Text content of the message.
     pub content: String,
+    /// Optional structured item payload (tool calls, tool results, etc.).
     pub item: Option<Value>,
+    /// Unix timestamp (seconds) when the message was created.
     pub created_at: i64,
+    /// ID of the parent message, forming a tree structure. `None` for root messages.
     pub parent_entry_id: Option<i64>,
 }
 
+/// A named checkpoint capturing the state of a thread at a point in time.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CheckpointRecord {
+    /// ID of the thread this checkpoint belongs to.
     pub thread_id: String,
+    /// Unique identifier for this checkpoint within its thread.
     pub checkpoint_id: String,
+    /// Serialized state snapshot stored as a JSON value.
     pub state: Value,
+    /// Unix timestamp (seconds) when the checkpoint was created or last updated.
     pub created_at: i64,
 }
 
+/// Status of a background job.
+///
+/// Serialized as lowercase snake_case strings.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum JobStateStatus {
+    /// Job is waiting to be executed.
     Queued,
+    /// Job is currently executing.
     Running,
+    /// Job has finished successfully.
     Completed,
+    /// Job has failed with an error.
     Failed,
+    /// Job was cancelled before completion.
     Cancelled,
 }
 
+/// Persisted state of a background job.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JobStateRecord {
+    /// Unique identifier for the job.
     pub id: String,
+    /// Human-readable name describing the job.
     pub name: String,
+    /// Current lifecycle status of the job.
     pub status: JobStateStatus,
+    /// Completion progress as a percentage (0--100), if available.
     pub progress: Option<u8>,
+    /// Optional detail message providing additional status information.
     pub detail: Option<String>,
+    /// Unix timestamp (seconds) when the job was created.
     pub created_at: i64,
+    /// Unix timestamp (seconds) of the most recent status update.
     pub updated_at: i64,
 }
 
+/// Filters for listing conversation threads.
 #[derive(Debug, Clone)]
 pub struct ThreadListFilters {
+    /// Whether to include archived threads in the results.
     pub include_archived: bool,
+    /// Maximum number of threads to return. Defaults to 50.
     pub limit: Option<usize>,
 }
 
@@ -127,6 +221,10 @@ struct SessionIndexEntry {
     rollout_path: Option<PathBuf>,
 }
 
+/// Persistent storage for conversation threads, messages, checkpoints, and jobs.
+///
+/// Backed by a SQLite database and an append-only JSONL session index file.
+/// The database schema is automatically initialized and migrated on [`open`](Self::open).
 #[derive(Debug, Clone)]
 pub struct StateStore {
     db_path: PathBuf,
@@ -134,6 +232,10 @@ pub struct StateStore {
 }
 
 impl StateStore {
+    /// Open (or create) a state store at the given database path.
+    ///
+    /// If `path` is `None`, the default location (`~/.deepseek/state.db`) is used.
+    /// The database schema is created automatically if it does not exist.
     pub fn open(path: Option<PathBuf>) -> Result<Self> {
         let db_path = path.unwrap_or_else(default_state_db_path);
         let session_index_path = db_path
@@ -153,6 +255,7 @@ impl StateStore {
         Ok(store)
     }
 
+    /// Returns the filesystem path of the underlying SQLite database.
     pub fn db_path(&self) -> &Path {
         &self.db_path
     }
@@ -270,7 +373,10 @@ impl StateStore {
         Ok(())
     }
 
-    /// Upsert thread metadata(will not set current_leaf_id)
+    /// Insert or update thread metadata.
+    ///
+    /// This does **not** update `current_leaf_id`; use [`append_message`](Self::append_message)
+    /// or [`set_current_leaf_id`](Self::set_current_leaf_id) for that.
     pub fn upsert_thread(&self, thread: &ThreadMetadata) -> Result<()> {
         let conn = self.conn()?;
         conn.execute(
@@ -341,6 +447,9 @@ impl StateStore {
         Ok(())
     }
 
+    /// Retrieve a single thread by its ID.
+    ///
+    /// Returns `None` if no thread with the given ID exists.
     pub fn get_thread(&self, id: &str) -> Result<Option<ThreadMetadata>> {
         let conn = self.conn()?;
         conn.query_row(
@@ -358,6 +467,10 @@ impl StateStore {
         .context("failed to read thread")
     }
 
+    /// List threads ordered by most recently updated.
+    ///
+    /// Use [`ThreadListFilters`] to control whether archived threads are included
+    /// and the maximum number of results returned.
     pub fn list_threads(&self, filters: ThreadListFilters) -> Result<Vec<ThreadMetadata>> {
         let conn = self.conn()?;
         let sql = if filters.include_archived {
@@ -378,6 +491,8 @@ impl StateStore {
         Ok(out)
     }
 
+    /// Archive a thread, setting its status to [`ThreadStatus::Archived`] and
+    /// recording the current timestamp.
     pub fn mark_archived(&self, id: &str) -> Result<()> {
         let conn = self.conn()?;
         conn.execute(
@@ -392,6 +507,7 @@ impl StateStore {
         Ok(())
     }
 
+    /// Unarchive a thread, removing the archived flag and clearing `archived_at`.
     pub fn mark_unarchived(&self, id: &str) -> Result<()> {
         let conn = self.conn()?;
         conn.execute(
@@ -402,6 +518,8 @@ impl StateStore {
         Ok(())
     }
 
+    /// Permanently delete a thread and all of its associated data
+    /// (messages, checkpoints, dynamic tools) via cascading foreign keys.
     pub fn delete_thread(&self, id: &str) -> Result<()> {
         let conn = self.conn()?;
         conn.execute("DELETE FROM threads WHERE id = ?1", params![id])
@@ -409,6 +527,9 @@ impl StateStore {
         Ok(())
     }
 
+    /// Set the memory mode for a thread.
+    ///
+    /// Pass `None` to clear the memory mode.
     pub fn set_thread_memory_mode(&self, id: &str, mode: Option<&str>) -> Result<()> {
         let conn = self.conn()?;
         conn.execute(
@@ -419,6 +540,9 @@ impl StateStore {
         Ok(())
     }
 
+    /// Get the memory mode configured for a thread.
+    ///
+    /// Returns `None` if the thread does not exist or has no memory mode set.
     pub fn get_thread_memory_mode(&self, id: &str) -> Result<Option<String>> {
         let conn = self.conn()?;
         conn.query_row(
@@ -431,6 +555,10 @@ impl StateStore {
         .map(Option::flatten)
     }
 
+    /// List all leaf messages in a thread.
+    ///
+    /// A leaf message is one that has no other message referencing it as a parent.
+    /// In a branching conversation tree, there may be multiple leaf messages.
     pub fn list_leaf_messages(&self, thread_id: &str) -> Result<Vec<MessageRecord>> {
         let conn = self.conn()?;
         let mut stmt = conn
@@ -469,6 +597,10 @@ impl StateStore {
         Ok(out)
     }
 
+    /// Update the current leaf message pointer for a thread.
+    ///
+    /// This controls which branch of the conversation tree is considered active
+    /// when listing messages via [`list_messages`](Self::list_messages).
     pub fn set_current_leaf_id(&self, thread_id: &str, current_leaf_id: &str) -> Result<()> {
         let conn = self.conn()?;
         conn.execute(
@@ -479,6 +611,10 @@ impl StateStore {
         Ok(())
     }
 
+    /// Replace the dynamic tools for a thread.
+    ///
+    /// All existing dynamic tools for the thread are deleted and replaced with the
+    /// provided list. The operation is performed within a transaction.
     pub fn persist_dynamic_tools(
         &self,
         thread_id: &str,
@@ -510,6 +646,7 @@ impl StateStore {
         Ok(())
     }
 
+    /// Retrieve all dynamic tools registered for a thread, ordered by position.
     pub fn get_dynamic_tools(&self, thread_id: &str) -> Result<Vec<DynamicToolRecord>> {
         let conn = self.conn()?;
         let mut stmt = conn
@@ -538,6 +675,11 @@ impl StateStore {
         Ok(out)
     }
 
+    /// Append a new message to a thread.
+    ///
+    /// The message is linked to the thread's current leaf as its parent, and the
+    /// thread's `current_leaf_id` is updated to the new message. Returns the ID
+    /// of the newly created message.
     pub fn append_message(
         &self,
         thread_id: &str,
@@ -593,6 +735,11 @@ impl StateStore {
         Ok(next_leaf_id)
     }
 
+    /// List messages in the current conversation branch, walking backwards from
+    /// the thread's `current_leaf_id`.
+    ///
+    /// Messages are returned in chronological order (oldest first). The `limit`
+    /// parameter caps how many ancestor messages are traversed; it defaults to 500.
     pub fn list_messages(
         &self,
         thread_id: &str,
@@ -602,7 +749,7 @@ impl StateStore {
         let limit = i64::try_from(limit.unwrap_or(500)).unwrap_or(500);
         let mut stmt = conn
             .prepare(
-                r#"  
+                r#"
                 WITH RECURSIVE
                     leaf_id AS (
                         SELECT current_leaf_id FROM threads WHERE id = ?1
@@ -650,6 +797,11 @@ impl StateStore {
         Ok(out)
     }
 
+    /// Fork the conversation at a specific message.
+    ///
+    /// Creates a new message whose parent is `message_id` and updates the thread's
+    /// `current_leaf_id` to the new message. Returns the ID of the new message.
+    /// This enables branching conversations from any point in the history.
     pub fn fork_at_message(
         &self,
         message_id: &str,
@@ -706,6 +858,9 @@ impl StateStore {
         Ok(next_leaf_id)
     }
 
+    /// Delete all messages belonging to a thread and reset its `current_leaf_id`.
+    ///
+    /// Returns the number of messages deleted.
     pub fn clear_messages(&self, thread_id: &str) -> Result<usize> {
         let mut conn = self.conn()?;
         let tx = conn
@@ -735,6 +890,10 @@ impl StateStore {
         Ok(result)
     }
 
+    /// Save (or update) a named checkpoint for a thread.
+    ///
+    /// If a checkpoint with the same `thread_id` and `checkpoint_id` already exists,
+    /// its state and timestamp are overwritten.
     pub fn save_checkpoint(
         &self,
         thread_id: &str,
@@ -760,6 +919,11 @@ impl StateStore {
         Ok(())
     }
 
+    /// Load a checkpoint for a thread.
+    ///
+    /// If `checkpoint_id` is provided, loads that specific checkpoint. Otherwise,
+    /// loads the most recently created checkpoint for the thread. Returns `None`
+    /// if no matching checkpoint exists.
     pub fn load_checkpoint(
         &self,
         thread_id: &str,
@@ -807,6 +971,9 @@ impl StateStore {
         .with_context(|| format!("failed to load latest checkpoint for thread {thread_id}"))
     }
 
+    /// List checkpoints for a thread, ordered by creation time (newest first).
+    ///
+    /// The `limit` parameter caps the number of results and defaults to 100.
     pub fn list_checkpoints(
         &self,
         thread_id: &str,
@@ -837,6 +1004,7 @@ impl StateStore {
         Ok(out)
     }
 
+    /// Delete a specific checkpoint from a thread.
     pub fn delete_checkpoint(&self, thread_id: &str, checkpoint_id: &str) -> Result<()> {
         let conn = self.conn()?;
         conn.execute(
@@ -849,6 +1017,7 @@ impl StateStore {
         Ok(())
     }
 
+    /// Insert or update a background job record.
     pub fn upsert_job(&self, job: &JobStateRecord) -> Result<()> {
         let conn = self.conn()?;
         conn.execute(
@@ -877,6 +1046,9 @@ impl StateStore {
         Ok(())
     }
 
+    /// Retrieve a single job by its ID.
+    ///
+    /// Returns `None` if no job with the given ID exists.
     pub fn get_job(&self, id: &str) -> Result<Option<JobStateRecord>> {
         let conn = self.conn()?;
         conn.query_row(
@@ -900,6 +1072,9 @@ impl StateStore {
         .with_context(|| format!("failed to read job {id}"))
     }
 
+    /// List jobs ordered by most recently updated.
+    ///
+    /// The `limit` parameter caps the number of results and defaults to 100.
     pub fn list_jobs(&self, limit: Option<usize>) -> Result<Vec<JobStateRecord>> {
         let conn = self.conn()?;
         let limit = i64::try_from(limit.unwrap_or(100)).unwrap_or(100);
@@ -928,6 +1103,7 @@ impl StateStore {
         Ok(out)
     }
 
+    /// Permanently delete a job record.
     pub fn delete_job(&self, id: &str) -> Result<()> {
         let conn = self.conn()?;
         conn.execute("DELETE FROM jobs WHERE id = ?1", params![id])
@@ -935,6 +1111,7 @@ impl StateStore {
         Ok(())
     }
 
+    /// Look up the rollout file path for a thread by its ID.
     pub fn find_rollout_path_by_id(&self, id: &str) -> Result<Option<PathBuf>> {
         let conn = self.conn()?;
         conn.query_row(
@@ -947,6 +1124,11 @@ impl StateStore {
         .map(|opt| opt.flatten().map(PathBuf::from))
     }
 
+    /// Append an entry to the JSONL session index file.
+    ///
+    /// The session index is an append-only log that maps thread IDs to their names,
+    /// update timestamps, and rollout paths. It is used for fast name-based lookups
+    /// without opening the SQLite database.
     pub fn append_thread_name(
         &self,
         thread_id: &str,
@@ -984,6 +1166,9 @@ impl StateStore {
         Ok(())
     }
 
+    /// Find the display name for a thread by its ID, using the session index.
+    ///
+    /// Returns `None` if the thread is not in the index or has no name.
     pub fn find_thread_name_by_id(&self, thread_id: &str) -> Result<Option<String>> {
         let map = self.session_index_map()?;
         Ok(map
@@ -991,6 +1176,9 @@ impl StateStore {
             .and_then(|entry| entry.thread_name.clone()))
     }
 
+    /// Look up display names for multiple thread IDs at once.
+    ///
+    /// Returns a map from thread ID to its name (which may be `None`).
     pub fn find_thread_names_by_ids(
         &self,
         ids: &[String],
@@ -1004,6 +1192,10 @@ impl StateStore {
         Ok(out)
     }
 
+    /// Find the rollout path for a thread by its display name (case-insensitive).
+    ///
+    /// If multiple threads share the same name, the most recently updated one is returned.
+    /// Returns `None` if no matching thread is found.
     pub fn find_thread_path_by_name_str(&self, name: &str) -> Result<Option<PathBuf>> {
         let map = self.session_index_map()?;
         let matched = map

--- a/web/lib/github.test.ts
+++ b/web/lib/github.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// We test the pure helper functions directly.
+// The async fetch functions require mocking the global fetch.
+
+// ── relativeTime ──────────────────────────────────────────────────────
+
+function relativeTime(iso: string): string {
+  const diff = Date.now() - +new Date(iso);
+  const mins = Math.round(diff / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m`;
+  const hrs = Math.round(mins / 60);
+  if (hrs < 24) return `${hrs}h`;
+  const days = Math.round(hrs / 24);
+  if (days < 30) return `${days}d`;
+  const months = Math.round(days / 30);
+  if (months < 12) return `${months}mo`;
+  return `${Math.round(months / 12)}y`;
+}
+
+describe("relativeTime", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-01T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns 'just now' for less than 30 seconds ago", () => {
+    expect(relativeTime("2026-06-01T11:59:45Z")).toBe("just now");
+  });
+
+  it("returns minutes for < 1 hour", () => {
+    expect(relativeTime("2026-06-01T11:55:00Z")).toBe("5m");
+    expect(relativeTime("2026-06-01T11:30:00Z")).toBe("30m");
+  });
+
+  it("returns hours for < 1 day", () => {
+    expect(relativeTime("2026-06-01T09:00:00Z")).toBe("3h");
+    expect(relativeTime("2026-05-31T18:00:00Z")).toBe("18h");
+  });
+
+  it("returns days for < 30 days", () => {
+    expect(relativeTime("2026-05-25T12:00:00Z")).toBe("7d");
+    expect(relativeTime("2026-05-02T12:00:00Z")).toBe("30d");
+  });
+
+  it("returns months for < 12 months", () => {
+    expect(relativeTime("2026-03-01T12:00:00Z")).toBe("3mo");
+    expect(relativeTime("2025-08-01T12:00:00Z")).toBe("10mo");
+  });
+
+  it("returns years for >= 12 months", () => {
+    expect(relativeTime("2024-06-01T12:00:00Z")).toBe("2y");
+    expect(relativeTime("2025-01-01T00:00:00Z")).toBe("2y");
+  });
+});
+
+// ── lastPageFromLink (via re-export test) ──────────────────────────────
+
+function lastPageFromLink(link: string | null): number | undefined {
+  if (!link) return undefined;
+  for (const part of link.split(",")) {
+    const [rawUrl, rawRel] = part
+      .split(";")
+      .map((segment: string) => segment.trim());
+    if (rawRel !== 'rel="last"') continue;
+    const match = rawUrl.match(/^<(.+)>$/);
+    if (!match) continue;
+    const page = new URL(match[1]).searchParams.get("page");
+    const parsed = page ? Number.parseInt(page, 10) : NaN;
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  }
+  return undefined;
+}
+
+describe("lastPageFromLink", () => {
+  it("returns undefined for null input", () => {
+    expect(lastPageFromLink(null)).toBeUndefined();
+  });
+
+  it("returns undefined for empty string", () => {
+    expect(lastPageFromLink("")).toBeUndefined();
+  });
+
+  it("extracts page from Link header with last rel", () => {
+    const link =
+      '<https://api.github.com/repos/Hmbown/CodeWhale/issues?page=5>; rel="last"';
+    expect(lastPageFromLink(link)).toBe(5);
+  });
+
+  it("extracts page from multi-part Link header", () => {
+    const link = [
+      '<https://api.github.com/repos/Hmbown/CodeWhale/issues?page=1>; rel="prev"',
+      '<https://api.github.com/repos/Hmbown/CodeWhale/issues?page=3>; rel="last"',
+    ].join(", ");
+    expect(lastPageFromLink(link)).toBe(3);
+  });
+
+  it("returns undefined when no last rel present", () => {
+    const link =
+      '<https://api.github.com/repos/Hmbown/CodeWhale/issues?page=1>; rel="prev"';
+    expect(lastPageFromLink(link)).toBeUndefined();
+  });
+
+  it("returns undefined for invalid URL format", () => {
+    const link = "not-a-valid-link-header; rel=last";
+    expect(lastPageFromLink(link)).toBeUndefined();
+  });
+});

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["lib/**/*.test.ts", "components/**/*.test.tsx"],
+  },
+});


### PR DESCRIPTION
Add doc comments to all public types in the state crate, covering StateStore, ThreadMetadata, JobStateRecord, session/message persistence, and checkpoint management.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `///` doc comments to all previously undocumented public types, fields, and methods across the `state` and `execpolicy` crates, plus a module-level crate doc to `state/src/lib.rs`.

- **`crates/state/src/lib.rs`**: Adds a top-level crate doc and per-item comments for `ThreadMetadata`, `MessageRecord`, `CheckpointRecord`, `JobStateRecord`, `StateStore`, and all `StateStore` methods. One inaccuracy: `open()` cites `~/.deepseek/state.db` as the default path, exposing an internal branding detail that may not match the deployed product name.
- **`crates/execpolicy/src/lib.rs`**: Adds comments to `Ruleset`, `ToolAskRule`, `AskForApproval`, `ExecApprovalRequirement`, `ExecPolicyDecision`, `ExecPolicyContext`, and the `ExecPolicyEngine` methods. The `AskForApproval` enum doc comment is placed after the `#[serde]` attribute rather than before all attributes, which is non-idiomatic Rust.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Documentation-only change; no runtime behaviour is altered. Safe to merge after the two style issues are addressed.

All changes are doc comments with no effect on compiled code. Two minor issues were found: the `AskForApproval` doc comment is placed after attributes rather than before them (non-idiomatic), and the `open()` doc hardcodes `~/.deepseek/state.db` which leaks an internal path tied to an earlier project name. Neither affects correctness.

Both changed files have minor issues worth fixing before merge: the attribute ordering in `crates/execpolicy/src/lib.rs` and the hardcoded path in `crates/state/src/lib.rs`.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/execpolicy/src/lib.rs | Adds doc comments to all public structs, enums, and methods; one doc comment for `AskForApproval` is placed after the `#[serde]` attribute instead of before all attributes, which is non-idiomatic. |
| crates/state/src/lib.rs | Adds comprehensive module-level and per-item doc comments; the `open()` doc references `~/.deepseek/state.db` which leaks an internal path likely tied to an earlier project name rather than the codewhale branding. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[StateStore::open] --> B{path provided?}
    B -- Yes --> C[Use provided path]
    B -- No --> D[default_state_db_path\n~/.deepseek/state.db]
    C --> E[init_schema]
    D --> E
    E --> F[StateStore ready]
    F --> G[Threads CRUD\nupsert_thread / get_thread\nlist_threads / delete_thread]
    F --> H[Messages\nappend_message / list_messages\nfork_at_message / clear_messages]
    F --> I[Checkpoints\nsave_checkpoint / load_checkpoint\nlist_checkpoints / delete_checkpoint]
    F --> J[Jobs\nupsert_job / get_job\nlist_jobs / delete_job]
    F --> K[Session Index JSONL\nappend_thread_name\nfind_thread_name_by_id]
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22docs%2Fstate-crate-docs%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Fstate-crate-docs%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Fexecpolicy%2Fsrc%2Flib.rs%3A131%0A**Doc%20comment%20placed%20after%20%60%23%5Bserde%5D%60%20attribute**%0A%0AThe%20%60%2F%2F%2F%60%20line%20is%20sandwiched%20between%20the%20%60%23%5Bderive%5D%60%20%2B%20%60%23%5Bserde%5D%60%20attributes%20and%20the%20%60pub%20enum%60%20keyword%2C%20making%20it%20non-idiomatic.%20Every%20other%20public%20item%20in%20this%20PR%20has%20its%20doc%20comment%20first%2C%20then%20the%20attributes.%20While%20rustc%20accepts%20this%20ordering%2C%20%60rustfmt%60%20will%20leave%20it%20in%20place%20%28it%20does%20not%20reorder%20attributes%29%2C%20so%20the%20inconsistency%20will%20persist.%20The%20doc%20comment%20should%20be%20moved%20above%20all%20attributes.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Fstate%2Fsrc%2Flib.rs%3A237%0AThe%20default%20path%20%60~%2F.deepseek%2Fstate.db%60%20hard-codes%20what%20appears%20to%20be%20an%20internal%20implementation%20detail%20from%20an%20earlier%20project%20name.%20If%20this%20codebase%20is%20named%20%22codewhale%2C%22%20a%20reader%20following%20the%20doc%20is%20likely%20to%20look%20in%20the%20wrong%20directory.%20The%20comment%20should%20either%20match%20the%20actual%20path%20resolved%20by%20%60default_state_db_path%60%20generically%20or%20reflect%20the%20real%20branding.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20If%20%60path%60%20is%20%60None%60%2C%20the%20default%20platform-specific%20location%20is%20used.%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Fexecpolicy%2Fsrc%2Flib.rs%3A131%0A**Doc%20comment%20placed%20after%20%60%23%5Bserde%5D%60%20attribute**%0A%0AThe%20%60%2F%2F%2F%60%20line%20is%20sandwiched%20between%20the%20%60%23%5Bderive%5D%60%20%2B%20%60%23%5Bserde%5D%60%20attributes%20and%20the%20%60pub%20enum%60%20keyword%2C%20making%20it%20non-idiomatic.%20Every%20other%20public%20item%20in%20this%20PR%20has%20its%20doc%20comment%20first%2C%20then%20the%20attributes.%20While%20rustc%20accepts%20this%20ordering%2C%20%60rustfmt%60%20will%20leave%20it%20in%20place%20%28it%20does%20not%20reorder%20attributes%29%2C%20so%20the%20inconsistency%20will%20persist.%20The%20doc%20comment%20should%20be%20moved%20above%20all%20attributes.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Fstate%2Fsrc%2Flib.rs%3A237%0AThe%20default%20path%20%60~%2F.deepseek%2Fstate.db%60%20hard-codes%20what%20appears%20to%20be%20an%20internal%20implementation%20detail%20from%20an%20earlier%20project%20name.%20If%20this%20codebase%20is%20named%20%22codewhale%2C%22%20a%20reader%20following%20the%20doc%20is%20likely%20to%20look%20in%20the%20wrong%20directory.%20The%20comment%20should%20either%20match%20the%20actual%20path%20resolved%20by%20%60default_state_db_path%60%20generically%20or%20reflect%20the%20real%20branding.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20If%20%60path%60%20is%20%60None%60%2C%20the%20default%20platform-specific%20location%20is%20used.%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2452&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Fexecpolicy%2Fsrc%2Flib.rs%3A131%0A**Doc%20comment%20placed%20after%20%60%23%5Bserde%5D%60%20attribute**%0A%0AThe%20%60%2F%2F%2F%60%20line%20is%20sandwiched%20between%20the%20%60%23%5Bderive%5D%60%20%2B%20%60%23%5Bserde%5D%60%20attributes%20and%20the%20%60pub%20enum%60%20keyword%2C%20making%20it%20non-idiomatic.%20Every%20other%20public%20item%20in%20this%20PR%20has%20its%20doc%20comment%20first%2C%20then%20the%20attributes.%20While%20rustc%20accepts%20this%20ordering%2C%20%60rustfmt%60%20will%20leave%20it%20in%20place%20%28it%20does%20not%20reorder%20attributes%29%2C%20so%20the%20inconsistency%20will%20persist.%20The%20doc%20comment%20should%20be%20moved%20above%20all%20attributes.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Fstate%2Fsrc%2Flib.rs%3A237%0AThe%20default%20path%20%60~%2F.deepseek%2Fstate.db%60%20hard-codes%20what%20appears%20to%20be%20an%20internal%20implementation%20detail%20from%20an%20earlier%20project%20name.%20If%20this%20codebase%20is%20named%20%22codewhale%2C%22%20a%20reader%20following%20the%20doc%20is%20likely%20to%20look%20in%20the%20wrong%20directory.%20The%20comment%20should%20either%20match%20the%20actual%20path%20resolved%20by%20%60default_state_db_path%60%20generically%20or%20reflect%20the%20real%20branding.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20If%20%60path%60%20is%20%60None%60%2C%20the%20default%20platform-specific%20location%20is%20used.%0A%60%60%60%0A%0A&pr=2452&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs(execpolicy): add doc comments to al..."](https://github.com/hmbown/codewhale/commit/dcf428359ac2ff7d759164bd36255bf93939dc33) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34803150)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->