### PR TITLE
docs(agent): add doc comments to all public types

### DIFF
--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -3,29 +3,53 @@ use std::collections::HashMap;
 use codewhale_config::ProviderKind;
 use serde::{Deserialize, Serialize};
 
+/// Metadata for a single model entry in the registry.
+///
+/// Each model has a canonical `id` used by the provider, a list of `aliases`
+/// that users may reference, and capability flags indicating whether the model
+/// supports tool use and reasoning.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelInfo {
+    /// The canonical model identifier used by the provider (e.g. `"deepseek-v4-pro"`).
     pub id: String,
+    /// The provider that serves this model.
     pub provider: ProviderKind,
+    /// Alternative names that users can use to reference this model (case-insensitive).
     pub aliases: Vec<String>,
+    /// Whether this model supports tool/function calling.
     pub supports_tools: bool,
+    /// Whether this model supports extended reasoning.
     pub supports_reasoning: bool,
 }
 
+/// The result of resolving a user-requested model name to a concrete model entry.
+///
+/// Contains the resolved [`ModelInfo`], whether a fallback was used, and the
+/// chain of resolution strategies that were attempted.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelResolution {
+    /// The original model name requested by the user, if any.
     pub requested: Option<String>,
+    /// The concrete model that was resolved.
     pub resolved: ModelInfo,
+    /// Whether a fallback was used because the requested model was not found.
     pub used_fallback: bool,
+    /// The ordered list of resolution strategies that were attempted.
     pub fallback_chain: Vec<String>,
 }
 
+/// A registry of supported models and their aliases, used to resolve user-facing
+/// model names to concrete provider-specific model entries.
+///
+/// The default registry is populated with all built-in models across supported
+/// providers (DeepSeek, NVIDIA NIM, OpenAI-compatible, and others).
 #[derive(Debug, Clone)]
 pub struct ModelRegistry {
     models: Vec<ModelInfo>,
     alias_map: HashMap<String, usize>,
 }
 
+/// Creates a registry pre-populated with all built-in models and their aliases.
 impl Default for ModelRegistry {
     fn default() -> Self {
         let models = vec![
@@ -300,6 +324,11 @@ impl Default for ModelRegistry {
 }
 
 impl ModelRegistry {
+    /// Creates a new registry from a list of [`ModelInfo`] entries.
+    ///
+    /// Builds an internal alias map for fast lookup by model id or alias.
+    /// If multiple models share the same id or alias, the first one registered
+    /// takes priority.
     #[must_use]
     pub fn new(models: Vec<ModelInfo>) -> Self {
         let mut alias_map = HashMap::new();
@@ -312,11 +341,23 @@ impl ModelRegistry {
         Self { models, alias_map }
     }
 
+    /// Returns a clone of all models in the registry.
     #[must_use]
     pub fn list(&self) -> Vec<ModelInfo> {
         self.models.clone()
     }
 
+    /// Resolves a user-requested model name to a concrete [`ModelInfo`].
+    ///
+    /// Resolution follows this priority order:
+    /// 1. If the provider is Ollama, the requested name is used as-is (to
+    ///    support arbitrary local model tags like `qwen2.5-coder:7b`).
+    /// 2. If a `provider_hint` is given, search for a model matching that
+    ///    provider whose id or alias matches the request (case-insensitive).
+    /// 3. Look up the alias map for a case-insensitive match.
+    /// 4. Fall back to the first model belonging to the hinted provider
+    ///    (or DeepSeek if no hint was given).
+    /// 5. As a last resort, fall back to the first model in the registry.
     #[must_use]
     pub fn resolve(
         &self,


### PR DESCRIPTION
Add doc comments to all public types in the agent crate: ModelInfo, ModelResolution, and ModelRegistry with its resolution logic.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `///` doc comments to all public types in the `agent` crate — `ModelInfo`, `ModelResolution`, and `ModelRegistry` — including their fields and methods. The comments accurately describe most of the resolution logic, with two small exceptions noted below.

- The `/// Creates a registry…` comment is placed on the `impl Default for ModelRegistry` block rather than on the `fn default()` method inside it, so rustdoc will not surface it on the method's documentation page.
- The `resolve()` doc lists five resolution steps as if they always apply, but steps 1–3 are entirely skipped when `requested` is `None`; only step 4 (provider default) is reached in that path.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — purely additive doc comments with no runtime behaviour change.

All changes are documentation only. Two doc comments contain minor inaccuracies: the Default impl comment is attached to the impl block rather than the method, and the resolve() numbered list implies steps 1–3 always run regardless of whether requested is Some. Neither affects compiled code or runtime behaviour.

crates/agent/src/lib.rs — the doc comment placement on the Default impl block and the resolve() step ordering description.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/agent/src/lib.rs | Adds doc comments to all public types and methods; two minor inaccuracies: the Default impl doc comment is on the impl block rather than on fn default(), and the resolve() doc omits that steps 1–3 are skipped when requested is None. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([resolve called]) --> B{requested is Some?}
    B -- No --> F
    B -- Yes --> C{provider_hint == Ollama?}
    C -- Yes --> D[Return synthetic Ollama ModelInfo\nused_fallback: false]
    C -- No --> E{provider_hint given AND\nmodel matches in registry?}
    E -- Yes --> G[Return matched model\nused_fallback: false]
    E -- No --> H{alias_map lookup hit?}
    H -- Yes --> I[Return registry model\npreserving requested casing\nused_fallback: false]
    H -- No --> F
    F{First model for\nhinted provider\nor DeepSeek?}
    F -- Found --> J[Return first provider model\nused_fallback: true]
    F -- Not Found --> K[Return first model in registry\nor hardcoded deepseek-v4-pro\nused_fallback: true]
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22docs%2Fagent-crate-docs%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Fagent-crate-docs%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Fagent%2Fsrc%2Flib.rs%3A52-53%0A**Doc%20comment%20placed%20on%20%60impl%60%20block%2C%20not%20on%20the%20method**%0A%0AThe%20%60%2F%2F%2F%60%20comment%20at%20this%20line%20is%20attached%20to%20the%20%60impl%20Default%20for%20ModelRegistry%60%20block%20rather%20than%20to%20the%20%60fn%20default%28%29%60%20method%20inside%20it.%20In%20Rust%2C%20%60rustdoc%60%20does%20not%20render%20impl-block-level%20doc%20comments%20on%20the%20individual%20methods%2C%20so%20this%20description%20will%20not%20appear%20in%20the%20generated%20docs%20for%20%60ModelRegistry%3A%3Adefault%28%29%60.%20The%20comment%20should%20be%20moved%20inside%20the%20impl%20block%2C%20directly%20above%20%60fn%20default%28%29%20-%3E%20Self%60.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Fagent%2Fsrc%2Flib.rs%3A350-360%0A**Resolution%20steps%202%20and%203%20are%20silently%20skipped%20when%20%60requested%60%20is%20%60None%60**%0A%0AThe%20doc%20lists%20steps%201%E2%80%933%20unconditionally%2C%20but%20all%20three%20are%20gated%20inside%20%60if%20let%20Some%28name%29%20%3D%20requested%20%7B%20%E2%80%A6%20%7D%60.%20When%20the%20caller%20passes%20%60requested%3A%20None%60%2C%20the%20code%20bypasses%20steps%201%E2%80%933%20entirely%20and%20falls%20directly%20to%20step%204%20%28provider%20default%29.%20A%20caller%20reading%20only%20these%20docs%20would%20expect%20step%202%20to%20be%20evaluated%20even%20without%20a%20requested%20name%2C%20which%20is%20not%20what%20happens.%20Adding%20a%20note%20such%20as%20%22steps%201%E2%80%933%20only%20apply%20when%20%60requested%60%20is%20%60Some%60%22%20%28or%20restructuring%20the%20numbered%20list%29%20would%20prevent%20this%20misunderstanding.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Fagent%2Fsrc%2Flib.rs%3A52-53%0A**Doc%20comment%20placed%20on%20%60impl%60%20block%2C%20not%20on%20the%20method**%0A%0AThe%20%60%2F%2F%2F%60%20comment%20at%20this%20line%20is%20attached%20to%20the%20%60impl%20Default%20for%20ModelRegistry%60%20block%20rather%20than%20to%20the%20%60fn%20default%28%29%60%20method%20inside%20it.%20In%20Rust%2C%20%60rustdoc%60%20does%20not%20render%20impl-block-level%20doc%20comments%20on%20the%20individual%20methods%2C%20so%20this%20description%20will%20not%20appear%20in%20the%20generated%20docs%20for%20%60ModelRegistry%3A%3Adefault%28%29%60.%20The%20comment%20should%20be%20moved%20inside%20the%20impl%20block%2C%20directly%20above%20%60fn%20default%28%29%20-%3E%20Self%60.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Fagent%2Fsrc%2Flib.rs%3A350-360%0A**Resolution%20steps%202%20and%203%20are%20silently%20skipped%20when%20%60requested%60%20is%20%60None%60**%0A%0AThe%20doc%20lists%20steps%201%E2%80%933%20unconditionally%2C%20but%20all%20three%20are%20gated%20inside%20%60if%20let%20Some%28name%29%20%3D%20requested%20%7B%20%E2%80%A6%20%7D%60.%20When%20the%20caller%20passes%20%60requested%3A%20None%60%2C%20the%20code%20bypasses%20steps%201%E2%80%933%20entirely%20and%20falls%20directly%20to%20step%204%20%28provider%20default%29.%20A%20caller%20reading%20only%20these%20docs%20would%20expect%20step%202%20to%20be%20evaluated%20even%20without%20a%20requested%20name%2C%20which%20is%20not%20what%20happens.%20Adding%20a%20note%20such%20as%20%22steps%201%E2%80%933%20only%20apply%20when%20%60requested%60%20is%20%60Some%60%22%20%28or%20restructuring%20the%20numbered%20list%29%20would%20prevent%20this%20misunderstanding.%0A%0A&repo=hmbown%2Fcodewhale&pr=2455&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Fagent%2Fsrc%2Flib.rs%3A52-53%0A**Doc%20comment%20placed%20on%20%60impl%60%20block%2C%20not%20on%20the%20method**%0A%0AThe%20%60%2F%2F%2F%60%20comment%20at%20this%20line%20is%20attached%20to%20the%20%60impl%20Default%20for%20ModelRegistry%60%20block%20rather%20than%20to%20the%20%60fn%20default%28%29%60%20method%20inside%20it.%20In%20Rust%2C%20%60rustdoc%60%20does%20not%20render%20impl-block-level%20doc%20comments%20on%20the%20individual%20methods%2C%20so%20this%20description%20will%20not%20appear%20in%20the%20generated%20docs%20for%20%60ModelRegistry%3A%3Adefault%28%29%60.%20The%20comment%20should%20be%20moved%20inside%20the%20impl%20block%2C%20directly%20above%20%60fn%20default%28%29%20-%3E%20Self%60.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Fagent%2Fsrc%2Flib.rs%3A350-360%0A**Resolution%20steps%202%20and%203%20are%20silently%20skipped%20when%20%60requested%60%20is%20%60None%60**%0A%0AThe%20doc%20lists%20steps%201%E2%80%933%20unconditionally%2C%20but%20all%20three%20are%20gated%20inside%20%60if%20let%20Some%28name%29%20%3D%20requested%20%7B%20%E2%80%A6%20%7D%60.%20When%20the%20caller%20passes%20%60requested%3A%20None%60%2C%20the%20code%20bypasses%20steps%201%E2%80%933%20entirely%20and%20falls%20directly%20to%20step%204%20%28provider%20default%29.%20A%20caller%20reading%20only%20these%20docs%20would%20expect%20step%202%20to%20be%20evaluated%20even%20without%20a%20requested%20name%2C%20which%20is%20not%20what%20happens.%20Adding%20a%20note%20such%20as%20%22steps%201%E2%80%933%20only%20apply%20when%20%60requested%60%20is%20%60Some%60%22%20%28or%20restructuring%20the%20numbered%20list%29%20would%20prevent%20this%20misunderstanding.%0A%0A&pr=2455&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs(agent): add doc comments to all pub..."](https://github.com/hmbown/codewhale/commit/1dbbcfdbc6e633ce0e0ef868569e82302b4d7665) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34803357)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->