### PR TITLE
docs(tui-core): add doc comments to all public types

### DIFF
--- a/crates/tui-core/src/lib.rs
+++ b/crates/tui-core/src/lib.rs
@@ -1,47 +1,82 @@
+/// Identifies which pane is currently focused in the TUI layout.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Pane {
+    /// Main chat/conversation pane.
     Chat,
+    /// Diff viewer pane.
     Diff,
+    /// Task list pane.
     Tasks,
+    /// Sub-agent list pane.
     Agents,
+    /// Status overview pane.
     Status,
+    /// Background jobs pane.
     Jobs,
 }
 
+/// Events fed into the UI state machine from user input or runtime updates.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum UiEvent {
+    /// A key was pressed by the user.
     KeyPressed(char),
+    /// The user submitted a prompt string.
     PromptSubmitted(String),
+    /// A partial response arrived from the model.
     ResponseDelta(String),
+    /// A tool began executing.
     ToolStarted(String),
+    /// A tool finished executing.
     ToolFinished(String),
+    /// A background job was queued.
     JobQueued(String),
+    /// A background job reported progress.
     JobProgress { job_id: String, progress: u8 },
+    /// A background job completed.
     JobCompleted(String),
+    /// An exec approval was requested from the user.
     ApprovalRequested(String),
+    /// An exec approval was resolved.
     ApprovalResolved(String),
+    /// The user requested a pause.
     PauseRequested,
+    /// The user requested a resume.
     ResumeRequested,
+    /// Periodic tick for background work scheduling.
     Tick,
 }
 
+/// Side effects emitted by the state machine in response to events.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum UiEffect {
+    /// The UI should re-render.
     Render,
+    /// A checkpoint should be persisted to the state store.
     PersistCheckpoint,
+    /// A background refresh should be scheduled.
     ScheduleBackgroundRefresh,
+    /// A status line message should be emitted to the footer.
     EmitStatusLine(String),
 }
 
+/// The complete UI state, driven by [`UiEvent`] via [`UiState::reduce`].
 #[derive(Debug, Clone)]
 pub struct UiState {
+    /// Currently active/focused pane.
     pub active_pane: Pane,
+    /// Whether the UI is paused (no new work dispatched).
     pub paused: bool,
+    /// Most recent partial response delta from the model.
     pub last_response_delta: Option<String>,
+    /// Name of the currently executing tool, if any.
     pub active_tool: Option<String>,
+    /// Number of tasks waiting to be processed.
     pub pending_tasks: usize,
+    /// Number of active background jobs.
     pub active_jobs: usize,
+    /// Number of pending approval requests.
     pub pending_approvals: usize,
+    /// Current status line text shown in the footer.
     pub status_line: String,
 }
 
@@ -61,6 +96,7 @@ impl Default for UiState {
 }
 
 impl UiState {
+    /// Process a UI event, updating internal state and returning side effects.
     pub fn reduce(&mut self, event: UiEvent) -> Vec<UiEffect> {
         match event {
             UiEvent::KeyPressed('1') => {
@@ -177,6 +213,7 @@ impl UiState {
         }
     }
 
+    /// Produce a human-readable summary of the current state for debugging.
     pub fn snapshot(&self) -> String {
         format!(
             "pane={:?};paused={};pending_tasks={};active_jobs={};pending_approvals={};active_tool={};status={}",


### PR DESCRIPTION
Add doc comments to all public types in the tui-core crate:

- **Pane** enum: Chat, Diff, Tasks, Agents, Status, Jobs
- **UiEvent** enum: all 13 event variants (key, prompt, response, tool, job, approval, pause/resume, tick)
- **UiEffect** enum: Render, PersistCheckpoint, ScheduleBackgroundRefresh, EmitStatusLine
- **UiState** struct: all 8 fields
- **UiState::reduce**: event processing method
- **UiState::snapshot**: debug summary method

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This is a documentation-only PR that adds `///` doc comments to every public item in `crates/tui-core/src/lib.rs` — the `Pane`, `UiEvent`, and `UiEffect` enums, the `UiState` struct and all its fields, and the `reduce`/`snapshot` methods. No logic is changed.

- All 6 `Pane` variants, all 13 `UiEvent` variants, all 4 `UiEffect` variants, and all 8 `UiState` fields now have prose descriptions.
- The `UiState` type-level comment uses intra-doc links (`[UiEvent]`, `[UiState::reduce]`) which are syntactically correct and will resolve under `rustdoc`.
- The one minor gap: the `JobProgress` struct-variant's named fields (`job_id`, `progress`) are the only fields in the file left without individual doc comments.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — purely additive documentation, no logic or API surface changes.

Every change is a `///` doc comment insertion; the compiled output is identical to the base branch. The comments are accurate representations of the existing behavior (e.g., `reduce` does update internal state and return effects; `snapshot` is indeed debug-oriented). The only gap is that the named fields inside the `JobProgress` struct-variant are undocumented while everything else received comments.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui-core/src/lib.rs | Adds `///` doc comments to all public types, enum variants, struct fields, and methods — documentation-only, no logic changes. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([UiEvent]) --> B{reduce}

    B -->|KeyPressed 1-5| C[active_pane = Chat/Diff/Tasks/Agents/Jobs]
    B -->|PromptSubmitted| D[pending_tasks++]
    B -->|ResponseDelta| E[last_response_delta = Some]
    B -->|ToolStarted| F[active_tool = Some]
    B -->|ToolFinished| G[active_tool = None, pending_tasks--]
    B -->|JobQueued| H[active_jobs++]
    B -->|JobProgress| I[status updated]
    B -->|JobCompleted| J[active_jobs--]
    B -->|ApprovalRequested| K[pending_approvals++]
    B -->|ApprovalResolved| L[pending_approvals--]
    B -->|PauseRequested| M[paused = true]
    B -->|ResumeRequested| N[paused = false]
    B -->|Tick| O[background refresh]

    C --> P([Render])
    D --> Q([Render + PersistCheckpoint + EmitStatusLine])
    E --> R([Render + EmitStatusLine])
    F --> R
    G --> Q
    H --> S([Render + PersistCheckpoint])
    I --> R
    J --> Q
    K --> R
    L --> Q
    M --> R
    N --> R
    O --> T([ScheduleBackgroundRefresh])
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22docs%2Ftui-core-crate-docs%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Ftui-core-crate-docs%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui-core%2Fsrc%2Flib.rs%3A33-34%0AThe%20%60JobProgress%60%20variant%20is%20the%20only%20struct-variant%20in%20the%20enum%20and%20the%20only%20one%20with%20named%20fields%20%28%60job_id%60%2C%20%60progress%60%29%2C%20yet%20those%20fields%20have%20no%20individual%20doc%20comments%20while%20every%20other%20variant%20and%20struct%20field%20in%20this%20PR%20received%20one.%20Readers%20looking%20at%20the%20generated%20docs%20won't%20know%20what%20the%20%60u8%60%20range%20means%20%280%E2%80%93100%3F%200%E2%80%93255%3F%29%20or%20whether%20%60job_id%60%20correlates%20to%20the%20payload%20of%20%60JobQueued%60%2F%60JobCompleted%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20A%20background%20job%20reported%20progress.%0A%20%20%20%20JobProgress%20%7B%0A%20%20%20%20%20%20%20%20%2F%2F%2F%20Identifier%20of%20the%20job%2C%20matching%20the%20payload%20of%20%5B%60UiEvent%3A%3AJobQueued%60%5D.%0A%20%20%20%20%20%20%20%20job_id%3A%20String%2C%0A%20%20%20%20%20%20%20%20%2F%2F%2F%20Completion%20percentage%20in%20the%20range%200%E2%80%93100.%0A%20%20%20%20%20%20%20%20progress%3A%20u8%2C%0A%20%20%20%20%7D%2C%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui-core%2Fsrc%2Flib.rs%3A33-34%0AThe%20%60JobProgress%60%20variant%20is%20the%20only%20struct-variant%20in%20the%20enum%20and%20the%20only%20one%20with%20named%20fields%20%28%60job_id%60%2C%20%60progress%60%29%2C%20yet%20those%20fields%20have%20no%20individual%20doc%20comments%20while%20every%20other%20variant%20and%20struct%20field%20in%20this%20PR%20received%20one.%20Readers%20looking%20at%20the%20generated%20docs%20won't%20know%20what%20the%20%60u8%60%20range%20means%20%280%E2%80%93100%3F%200%E2%80%93255%3F%29%20or%20whether%20%60job_id%60%20correlates%20to%20the%20payload%20of%20%60JobQueued%60%2F%60JobCompleted%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20A%20background%20job%20reported%20progress.%0A%20%20%20%20JobProgress%20%7B%0A%20%20%20%20%20%20%20%20%2F%2F%2F%20Identifier%20of%20the%20job%2C%20matching%20the%20payload%20of%20%5B%60UiEvent%3A%3AJobQueued%60%5D.%0A%20%20%20%20%20%20%20%20job_id%3A%20String%2C%0A%20%20%20%20%20%20%20%20%2F%2F%2F%20Completion%20percentage%20in%20the%20range%200%E2%80%93100.%0A%20%20%20%20%20%20%20%20progress%3A%20u8%2C%0A%20%20%20%20%7D%2C%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2456&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui-core%2Fsrc%2Flib.rs%3A33-34%0AThe%20%60JobProgress%60%20variant%20is%20the%20only%20struct-variant%20in%20the%20enum%20and%20the%20only%20one%20with%20named%20fields%20%28%60job_id%60%2C%20%60progress%60%29%2C%20yet%20those%20fields%20have%20no%20individual%20doc%20comments%20while%20every%20other%20variant%20and%20struct%20field%20in%20this%20PR%20received%20one.%20Readers%20looking%20at%20the%20generated%20docs%20won't%20know%20what%20the%20%60u8%60%20range%20means%20%280%E2%80%93100%3F%200%E2%80%93255%3F%29%20or%20whether%20%60job_id%60%20correlates%20to%20the%20payload%20of%20%60JobQueued%60%2F%60JobCompleted%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20A%20background%20job%20reported%20progress.%0A%20%20%20%20JobProgress%20%7B%0A%20%20%20%20%20%20%20%20%2F%2F%2F%20Identifier%20of%20the%20job%2C%20matching%20the%20payload%20of%20%5B%60UiEvent%3A%3AJobQueued%60%5D.%0A%20%20%20%20%20%20%20%20job_id%3A%20String%2C%0A%20%20%20%20%20%20%20%20%2F%2F%2F%20Completion%20percentage%20in%20the%20range%200%E2%80%93100.%0A%20%20%20%20%20%20%20%20progress%3A%20u8%2C%0A%20%20%20%20%7D%2C%0A%60%60%60%0A%0A&pr=2456&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs(tui-core): add doc comments to all ..."](https://github.com/hmbown/codewhale/commit/1b4719a53616d1ac52f862b2e9a4e338322c5bc5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34803414)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->