### PR TITLE
docs(secrets): add doc comments to all public types

### DIFF
--- a/crates/secrets/src/lib.rs
+++ b/crates/secrets/src/lib.rs
@@ -48,28 +48,57 @@ pub enum SecretsError {
     },
 }
 
-/// Abstract secret store; concrete implementations may use the OS
-/// keyring, a JSON file under `~/.deepseek/secrets/`, or an in-memory
-/// map (tests).
+/// Abstract secret store trait.
+///
+/// Concrete implementations may use the OS keyring ([`DefaultKeyringStore`]),
+/// a JSON file under `~/.deepseek/secrets/` ([`FileKeyringStore`]), or an
+/// in-memory map for tests ([`InMemoryKeyringStore`]).
+///
+/// All implementations must be [`Send`] + [`Sync`] so they can be shared
+/// across threads via [`Arc`].
 pub trait KeyringStore: Send + Sync {
-    /// Read a secret. Returns `Ok(None)` if no entry exists.
+    /// Read a secret by key.
+    ///
+    /// Returns `Ok(None)` if no entry exists for the given key. Returns
+    /// `Err` only on backend failures (I/O errors, keyring access issues).
     fn get(&self, key: &str) -> Result<Option<String>, SecretsError>;
-    /// Write a secret, replacing any existing value.
+
+    /// Write a secret, replacing any existing value for the same key.
+    ///
+    /// Creates the backing store (e.g. the JSON file) on first write if
+    /// it does not yet exist.
     fn set(&self, key: &str, value: &str) -> Result<(), SecretsError>;
-    /// Remove a secret. Should not error if the entry is absent.
+
+    /// Remove a secret by key.
+    ///
+    /// Implementations should succeed (no-op) if the entry is already absent
+    /// rather than returning an error.
     fn delete(&self, key: &str) -> Result<(), SecretsError>;
-    /// Short, human-readable name of the backend (used by `doctor`).
+
+    /// Short, human-readable label for this backend.
+    ///
+    /// Used by diagnostic output (e.g. `doctor` command) to indicate which
+    /// storage backend is active. Examples: `"file-based (~/.deepseek/secrets/)"`,
+    /// `"system keyring"`, `"in-memory (test)"`.
     fn backend_name(&self) -> &'static str;
 }
 
-/// OS keyring backend (macOS Keychain, Windows Credential Manager,
-/// Linux Secret Service / kwallet). This backend is opt-in through
-/// [`SECRET_BACKEND_ENV`]. On platforms without a configured native
-/// keyring dependency, probing this backend returns an unsupported error so
-/// [`Secrets::auto_detect`] can fall back to [`FileKeyringStore`].
+/// OS-native keyring backend.
+///
+/// Wraps the platform credential store:
+/// - **macOS**: Keychain (via `security` framework)
+/// - **Windows**: Credential Manager
+/// - **Linux**: Secret Service (GNOME Keyring / kwallet via dbus)
+///
+/// This backend is opt-in -- set the [`SECRET_BACKEND_ENV`] environment
+/// variable to `system` or `keyring` to activate it. On platforms without
+/// a configured native keyring dependency, [`probe`](DefaultKeyringStore::probe)
+/// returns an unsupported error so [`Secrets::auto_detect`] can transparently
+/// fall back to [`FileKeyringStore`].
 #[derive(Debug, Clone)]
 pub struct DefaultKeyringStore {
-    /// Keyring service name (defaults to [`DEFAULT_SERVICE`]).
+    /// Keyring service name used to namespace stored credentials.
+    /// Defaults to [`DEFAULT_SERVICE`].
     service: String,
 }
 
@@ -186,9 +215,15 @@ fn unsupported_keyring_message() -> String {
     "system keyring backend is unsupported on this platform".to_string()
 }
 
-/// In-memory keyring (tests only).
+/// In-memory keyring store for tests.
+///
+/// Stores secrets in a [`HashMap`] protected by a [`Mutex`]. Not persisted
+/// to disk -- all entries are lost when the process exits. This is the
+/// preferred store for unit tests because it requires no filesystem setup
+/// and is safe to use in parallel test threads.
 #[derive(Debug, Default)]
 pub struct InMemoryKeyringStore {
+    /// Thread-safe map of key-value pairs.
     entries: Mutex<HashMap<String, String>>,
 }
 
@@ -229,12 +264,21 @@ impl KeyringStore for InMemoryKeyringStore {
     }
 }
 
-/// JSON-on-disk fallback for headless environments without a Secret
-/// Service / dbus. Stored at `<home>/.deepseek/secrets/secrets.json`
-/// with mode `0600`.
+/// JSON-on-disk secret store for headless environments.
+///
+/// This is the default backend. Secrets are serialised as a JSON object
+/// at `<home>/.deepseek/secrets/secrets.json` with Unix file mode `0600`
+/// (owner read/write only). The parent directory is created with mode `0700`
+/// if it does not exist.
+///
+/// On Unix, the store rejects files whose permissions are more permissive
+/// than `0600` (i.e. group or world bits are set). This prevents other
+/// users on the system from reading stored credentials. On Windows, the
+/// ACL model is too different to enforce programmatically; callers are
+/// responsible for placing the file in a per-user directory.
 #[derive(Debug, Clone)]
 pub struct FileKeyringStore {
-    /// Absolute path to the JSON file.
+    /// Absolute path to the JSON secrets file.
     path: PathBuf,
 }
 
@@ -376,28 +420,43 @@ fn secret_backend_selection(value: Option<&str>) -> SecretBackendSelection {
     }
 }
 
-/// High-level façade combining a [`KeyringStore`] with environment
-/// variable fallbacks.
+/// High-level facade combining a [`KeyringStore`] with environment variable fallbacks.
 ///
-/// Lookup precedence: **secret store → env → none**. Callers that also have
-/// a TOML config layer must wire that themselves at the very end of
-/// the chain.
+/// Lookup precedence: **secret store -> env -> none**. Callers that also
+/// have a TOML config layer must wire that themselves at the very end
+/// of the chain (the config crate handles this).
+///
+/// # Examples
+///
+/// ```no_run
+/// use codewhale_secrets::Secrets;
+///
+/// let secrets = Secrets::auto_detect();
+/// if let Some(key) = secrets.resolve("deepseek") {
+///     // use the API key
+/// }
+/// ```
 #[derive(Clone)]
 pub struct Secrets {
-    /// Underlying secret store.
+    /// Underlying secret store backend.
     pub store: Arc<dyn KeyringStore>,
-    /// Owner identifier within the secret store (typically "deepseek"); the
-    /// `key` parameter passed to `resolve` is mapped to a slot in the
-    /// store as-is, while envs are looked up by canonical name.
+    /// Owner identifier within the secret store (typically `"deepseek"`).
+    /// The `key` parameter passed to [`resolve`](Secrets::resolve) is
+    /// forwarded to the store as-is, while environment variables are
+    /// looked up by canonical provider name via [`env_for`].
     service: String,
 }
 
-/// Source layer that provided a resolved secret.
+/// Identifies which layer in the resolution chain supplied a secret.
+///
+/// Returned by [`Secrets::resolve_with_source`] so callers can
+/// distinguish whether a value came from the configured store or from
+/// a process environment variable.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SecretSource {
-    /// The configured secret-store backend returned the secret.
+    /// The secret was returned by the configured [`KeyringStore`] backend.
     Keyring,
-    /// A process environment variable returned the secret.
+    /// The secret was found in a process environment variable.
     Env,
 }
 
@@ -411,7 +470,8 @@ impl std::fmt::Debug for Secrets {
 }
 
 impl Secrets {
-    /// Build a new façade around a store.
+    /// Build a new facade around the given store, using the
+    /// [`DEFAULT_SERVICE`] service name.
     #[must_use]
     pub fn new(store: Arc<dyn KeyringStore>) -> Self {
         Self {
@@ -420,10 +480,16 @@ impl Secrets {
         }
     }
 
-    /// Construct the default backend. The prompt-free default is
-    /// [`FileKeyringStore`] under `~/.deepseek/secrets/`. Set
-    /// [`SECRET_BACKEND_ENV`] to `system` or `keyring` to opt into the OS
-    /// credential store.
+    /// Auto-detect the best available backend based on the environment.
+    ///
+    /// Selection logic:
+    /// 1. If [`SECRET_BACKEND_ENV`] is set to `system`/`keyring`/`os`/`os-keyring`,
+    ///    probe the OS keyring. If the probe succeeds, use it; otherwise
+    ///    fall back to the file-based store with a warning.
+    /// 2. If the env var is unset, empty, or `file`/`local`/`json`, use
+    ///    the file-based store directly.
+    /// 3. If the env var is set to an unrecognised value, log a warning
+    ///    and use the file-based store.
     pub fn auto_detect() -> Self {
         match secret_backend_selection(std::env::var(SECRET_BACKEND_ENV).ok().as_deref()) {
             SecretBackendSelection::File => Self::file_backed_default(),
@@ -518,8 +584,32 @@ impl Secrets {
     }
 }
 
-/// Map a canonical provider name to its environment variable, returning
-/// the value if non-empty.
+/// Map a canonical provider name to its environment variable(s), returning
+/// the first non-empty value found.
+///
+/// Provider names are case-insensitive. Supported providers and their
+/// environment variables:
+///
+/// | Provider | Env var(s) |
+/// |---|---|
+/// | `deepseek` | `DEEPSEEK_API_KEY` |
+/// | `openrouter` | `OPENROUTER_API_KEY` |
+/// | `xiaomi-mimo` / `mimo` | `XIAOMI_MIMO_API_KEY`, `MIMO_API_KEY` |
+/// | `novita` | `NOVITA_API_KEY` |
+/// | `nvidia` / `nvidia-nim` / `nim` | `NVIDIA_API_KEY`, `NVIDIA_NIM_API_KEY`, `DEEPSEEK_API_KEY` |
+/// | `fireworks` | `FIREWORKS_API_KEY` |
+/// | `siliconflow` | `SILICONFLOW_API_KEY` |
+/// | `moonshot` / `kimi` | `MOONSHOT_API_KEY`, `KIMI_API_KEY` |
+/// | `sglang` | `SGLANG_API_KEY` |
+/// | `vllm` | `VLLM_API_KEY` |
+/// | `ollama` | `OLLAMA_API_KEY` |
+/// | `openai` | `OPENAI_API_KEY` |
+/// | `atlascloud` / `atlas` | `ATLASCLOUD_API_KEY` |
+/// | `volcengine` / `ark` | `VOLCENGINE_API_KEY`, `VOLCENGINE_ARK_API_KEY`, `ARK_API_KEY` |
+/// | `wanjie` / `wanjie-ark` | `WANJIE_ARK_API_KEY`, `WANJIE_API_KEY`, `WANJIE_MAAS_API_KEY` |
+///
+/// Returns `None` if the provider is not recognised or none of its
+/// candidate environment variables are set to a non-empty value.
 #[must_use]
 pub fn env_for(name: &str) -> Option<String> {
     let candidates: &[&str] = match name.to_ascii_lowercase().as_str() {


### PR DESCRIPTION
Add doc comments to all public types in the secrets crate, covering the OS keyring and file-based fallback secret storage.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR is a documentation pass over `crates/secrets/src/lib.rs`, expanding terse one-line comments into full rustdoc blocks with cross-links, behaviour contracts, and an added `# Examples` section on `Secrets`. No logic is changed.

- **`KeyringStore` trait and all three concrete types** (`DefaultKeyringStore`, `FileKeyringStore`, `InMemoryKeyringStore`) receive expanded struct-level and method-level docs explaining platform behaviour, permission semantics, and fallback logic.
- **`Secrets` and `SecretSource`** gain richer docs including a runnable example (`no_run`) and an explicit description of the `secret store → env → none` resolution chain.
- **`env_for`** gains a full Markdown provider table — but the table omits many recognized aliases (e.g. `xiaomi`, `fireworks-ai`, `volc-ark`) and the `DefaultKeyringStore` type doc omits `os`/`os-keyring` as accepted env-var values.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — no production code is touched; all changes are doc comments only.

The two inaccuracies (incomplete env-var value list on DefaultKeyringStore and missing provider aliases in the env_for table) could mislead integrators but do not affect runtime behaviour. Everything else is an accurate, well-structured documentation improvement.

The env_for provider table and the DefaultKeyringStore struct-level doc both need a quick accuracy pass before merging.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/secrets/src/lib.rs | Documentation-only expansion of all public types; no logic changed. Two inaccuracies found: DefaultKeyringStore struct doc omits the os/os-keyring env-var values, and the env_for provider table omits many recognized aliases. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant Secrets
    participant KeyringStore
    participant env_for

    Caller->>Secrets: resolve(name)
    Secrets->>KeyringStore: get(name)
    alt "secret found & non-blank"
        KeyringStore-->>Secrets: Ok(Some(value))
        Secrets-->>Caller: Some((value, SecretSource::Keyring))
    else no entry or blank
        KeyringStore-->>Secrets: Ok(None) or blank
        Secrets->>env_for: env_for(name)
        alt "env var set & non-empty"
            env_for-->>Secrets: Some(value)
            Secrets-->>Caller: Some((value, SecretSource::Env))
        else
            env_for-->>Secrets: None
            Secrets-->>Caller: None
        end
    end
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22docs%2Fsecrets-crate-docs%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Fsecrets-crate-docs%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Fsecrets%2Fsrc%2Flib.rs%3A93-94%0AThe%20%60DefaultKeyringStore%60%20struct-level%20doc%20mentions%20only%20%60system%60%20or%20%60keyring%60%20as%20valid%20values%20for%20%60SECRET_BACKEND_ENV%60%2C%20but%20%60secret_backend_selection%60%20also%20accepts%20%60os%60%20and%20%60os-keyring%60.%20A%20user%20who%20reads%20this%20doc%20and%20tries%20%60DEEPSEEK_SECRET_BACKEND%3Dos%60%20would%20think%20it%20is%20unsupported.%20The%20%60auto_detect%60%20method's%20expanded%20doc%20already%20lists%20all%20four%20values%20correctly%20%E2%80%94%20this%20struct%20doc%20should%20match.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20This%20backend%20is%20opt-in%20--%20set%20the%20%5B%60SECRET_BACKEND_ENV%60%5D%20environment%0A%2F%2F%2F%20variable%20to%20%60system%60%2C%20%60keyring%60%2C%20%60os%60%2C%20or%20%60os-keyring%60%20to%20activate%20it.%0A%2F%2F%2F%20On%20platforms%20without%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Fsecrets%2Fsrc%2Flib.rs%3A593-609%0AThe%20table%20header%20says%20%22Supported%20providers%20and%20their%20environment%20variables%22%2C%20implying%20completeness%2C%20but%20several%20match%20arms'%20alternate%20aliases%20are%20silently%20omitted.%20For%20example%2C%20%60xiaomi%60%20alone%20resolves%20to%20%60XIAOMI_MIMO_API_KEY%60%2F%60MIMO_API_KEY%60%20but%20is%20absent%20from%20the%20table%3B%20%60fireworks-ai%60%2C%20%60sg-lang%60%2C%20%60v-llm%60%2C%20%60ollama-local%60%2C%20%60atlas-cloud%60%2C%20%60volc-ark%60%2C%20%60volcengineark%60%2C%20and%20several%20%60wanjie%60%20variants%20are%20also%20missing.%20A%20user%20who%20tries%20%60env_for%28%22xiaomi%22%29%60%20after%20reading%20this%20table%20would%20expect%20%60None%60.%20Either%20update%20the%20Provider%20column%20to%20enumerate%20all%20accepted%20aliases%2C%20or%20add%20a%20note%20making%20clear%20the%20table%20shows%20representative%20names%20only.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20%7C%20Provider%20%28representative%20aliases%29%20%7C%20Env%20var%28s%29%20%7C%0A%2F%2F%2F%20%7C---%7C---%7C%0A%2F%2F%2F%20%7C%20%60deepseek%60%20%7C%20%60DEEPSEEK_API_KEY%60%20%7C%0A%2F%2F%2F%20%7C%20%60openrouter%60%20%7C%20%60OPENROUTER_API_KEY%60%20%7C%0A%2F%2F%2F%20%7C%20%60xiaomi-mimo%60%20%2F%20%60xiaomi_mimo%60%20%2F%20%60xiaomimimo%60%20%2F%20%60mimo%60%20%2F%20%60xiaomi%60%20%7C%20%60XIAOMI_MIMO_API_KEY%60%2C%20%60MIMO_API_KEY%60%20%7C%0A%2F%2F%2F%20%7C%20%60novita%60%20%7C%20%60NOVITA_API_KEY%60%20%7C%0A%2F%2F%2F%20%7C%20%60nvidia%60%20%2F%20%60nvidia-nim%60%20%2F%20%60nvidia_nim%60%20%2F%20%60nim%60%20%7C%20%60NVIDIA_API_KEY%60%2C%20%60NVIDIA_NIM_API_KEY%60%2C%20%60DEEPSEEK_API_KEY%60%20%7C%0A%2F%2F%2F%20%7C%20%60fireworks%60%20%2F%20%60fireworks-ai%60%20%7C%20%60FIREWORKS_API_KEY%60%20%7C%0A%2F%2F%2F%20%7C%20%60siliconflow%60%20%2F%20%60silicon-flow%60%20%2F%20%60silicon_flow%60%20%7C%20%60SILICONFLOW_API_KEY%60%20%7C%0A%2F%2F%2F%20%7C%20%60moonshot%60%20%2F%20%60moonshot-ai%60%20%2F%20%60kimi%60%20%2F%20%60kimi-k2%60%20%7C%20%60MOONSHOT_API_KEY%60%2C%20%60KIMI_API_KEY%60%20%7C%0A%2F%2F%2F%20%7C%20%60sglang%60%20%2F%20%60sg-lang%60%20%7C%20%60SGLANG_API_KEY%60%20%7C%0A%2F%2F%2F%20%7C%20%60vllm%60%20%2F%20%60v-llm%60%20%7C%20%60VLLM_API_KEY%60%20%7C%0A%2F%2F%2F%20%7C%20%60ollama%60%20%2F%20%60ollama-local%60%20%7C%20%60OLLAMA_API_KEY%60%20%7C%0A%2F%2F%2F%20%7C%20%60openai%60%20%7C%20%60OPENAI_API_KEY%60%20%7C%0A%2F%2F%2F%20%7C%20%60atlascloud%60%20%2F%20%60atlas-cloud%60%20%2F%20%60atlas_cloud%60%20%2F%20%60atlas%60%20%7C%20%60ATLASCLOUD_API_KEY%60%20%7C%0A%2F%2F%2F%20%7C%20%60volcengine%60%20%2F%20%60volcengine-ark%60%20%2F%20%60volcengine_ark%60%20%2F%20%60ark%60%20%2F%20%60volc-ark%60%20%2F%20%60volcengineark%60%20%7C%20%60VOLCENGINE_API_KEY%60%2C%20%60VOLCENGINE_ARK_API_KEY%60%2C%20%60ARK_API_KEY%60%20%7C%0A%2F%2F%2F%20%7C%20%60wanjie%60%20%2F%20%60wanjie-ark%60%20%2F%20%60wanjie_ark%60%20%2F%20%60ark-wanjie%60%20%2F%20%60ark_wanjie%60%20%2F%20%60wanjieark%60%20%2F%20%60wanjie-maas%60%20%2F%20%60wanjie_maas%60%20%2F%20%60wanjiemaas%60%20%7C%20%60WANJIE_ARK_API_KEY%60%2C%20%60WANJIE_API_KEY%60%2C%20%60WANJIE_MAAS_API_KEY%60%20%7C%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Fsecrets%2Fsrc%2Flib.rs%3A93-94%0AThe%20%60DefaultKeyringStore%60%20struct-level%20doc%20mentions%20only%20%60system%60%20or%20%60keyring%60%20as%20valid%20values%20for%20%60SECRET_BACKEND_ENV%60%2C%20but%20%60secret_backend_selection%60%20also%20accepts%20%60os%60%20and%20%60os-keyring%60.%20A%20user%20who%20reads%20this%20doc%20and%20tries%20%60DEEPSEEK_SECRET_BACKEND%3Dos%60%20would%20think%20it%20is%20unsupported.%20The%20%60auto_detect%60%20method's%20expanded%20doc%20already%20lists%20all%20four%20values%20correctly%20%E2%80%94%20this%20struct%20doc%20should%20match.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20This%20backend%20is%20opt-in%20--%20set%20the%20%5B%60SECRET_BACKEND_ENV%60%5D%20environment%0A%2F%2F%2F%20variable%20to%20%60system%60%2C%20%60keyring%60%2C%20%60os%60%2C%20or%20%60os-keyring%60%20to%20activate%20it.%0A%2F%2F%2F%20On%20platforms%20without%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Fsecrets%2Fsrc%2Flib.rs%3A593-609%0AThe%20table%20header%20says%20%22Supported%20providers%20and%20their%20environment%20variables%22%2C%20implying%20completeness%2C%20but%20several%20match%20arms'%20alternate%20aliases%20are%20silently%20omitted.%20For%20example%2C%20%60xiaomi%60%20alone%20resolves%20to%20%60XIAOMI_MIMO_API_KEY%60%2F%60MIMO_API_KEY%60%20but%20is%20absent%20from%20the%20table%3B%20%60fireworks-ai%60%2C%20%60sg-lang%60%2C%20%60v-llm%60%2C%20%60ollama-local%60%2C%20%60atlas-cloud%60%2C%20%60volc-ark%60%2C%20%60volcengineark%60%2C%20and%20several%20%60wanjie%60%20variants%20are%20also%20missing.%20A%20user%20who%20tries%20%60env_for%28%22xiaomi%22%29%60%20after%20reading%20this%20table%20would%20expect%20%60None%60.%20Either%20update%20the%20Provider%20column%20to%20enumerate%20all%20accepted%20aliases%2C%20or%20add%20a%20note%20making%20clear%20the%20table%20shows%20representative%20names%20only.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20%7C%20Provider%20%28representative%20aliases%29%20%7C%20Env%20var%28s%29%20%7C%0A%2F%2F%2F%20%7C---%7C---%7C%0A%2F%2F%2F%20%7C%20%60deepseek%60%20%7C%20%60DEEPSEEK_API_KEY%60%20%7C%0A%2F%2F%2F%20%7C%20%60openrouter%60%20%7C%20%60OPENROUTER_API_KEY%60%20%7C%0A%2F%2F%2F%20%7C%20%60xiaomi-mimo%60%20%2F%20%60xiaomi_mimo%60%20%2F%20%60xiaomimimo%60%20%2F%20%60mimo%60%20%2F%20%60xiaomi%60%20%7C%20%60XIAOMI_MIMO_API_KEY%60%2C%20%60MIMO_API_KEY%60%20%7C%0A%2F%2F%2F%20%7C%20%60novita%60%20%7C%20%60NOVITA_API_KEY%60%20%7C%0A%2F%2F%2F%20%7C%20%60nvidia%60%20%2F%20%60nvidia-nim%60%20%2F%20%60nvidia_nim%60%20%2F%20%60nim%60%20%7C%20%60NVIDIA_API_KEY%60%2C%20%60NVIDIA_NIM_API_KEY%60%2C%20%60DEEPSEEK_API_KEY%60%20%7C%0A%2F%2F%2F%20%7C%20%60fireworks%60%20%2F%20%60fireworks-ai%60%20%7C%20%60FIREWORKS_API_KEY%60%20%7C%0A%2F%2F%2F%20%7C%20%60siliconflow%60%20%2F%20%60silicon-flow%60%20%2F%20%60silicon_flow%60%20%7C%20%60SILICONFLOW_API_KEY%60%20%7C%0A%2F%2F%2F%20%7C%20%60moonshot%60%20%2F%20%60moonshot-ai%60%20%2F%20%60kimi%60%20%2F%20%60kimi-k2%60%20%7C%20%60MOONSHOT_API_KEY%60%2C%20%60KIMI_API_KEY%60%20%7C%0A%2F%2F%2F%20%7C%20%60sglang%60%20%2F%20%60sg-lang%60%20%7C%20%60SGLANG_API_KEY%60%20%7C%0A%2F%2F%2F%20%7C%20%60vllm%60%20%2F%20%60v-llm%60%20%7C%20%60VLLM_API_KEY%60%20%7C%0A%2F%2F%2F%20%7C%20%60ollama%60%20%2F%20%60ollama-local%60%20%7C%20%60OLLAMA_API_KEY%60%20%7C%0A%2F%2F%2F%20%7C%20%60openai%60%20%7C%20%60OPENAI_API_KEY%60%20%7C%0A%2F%2F%2F%20%7C%20%60atlascloud%60%20%2F%20%60atlas-cloud%60%20%2F%20%60atlas_cloud%60%20%2F%20%60atlas%60%20%7C%20%60ATLASCLOUD_API_KEY%60%20%7C%0A%2F%2F%2F%20%7C%20%60volcengine%60%20%2F%20%60volcengine-ark%60%20%2F%20%60volcengine_ark%60%20%2F%20%60ark%60%20%2F%20%60volc-ark%60%20%2F%20%60volcengineark%60%20%7C%20%60VOLCENGINE_API_KEY%60%2C%20%60VOLCENGINE_ARK_API_KEY%60%2C%20%60ARK_API_KEY%60%20%7C%0A%2F%2F%2F%20%7C%20%60wanjie%60%20%2F%20%60wanjie-ark%60%20%2F%20%60wanjie_ark%60%20%2F%20%60ark-wanjie%60%20%2F%20%60ark_wanjie%60%20%2F%20%60wanjieark%60%20%2F%20%60wanjie-maas%60%20%2F%20%60wanjie_maas%60%20%2F%20%60wanjiemaas%60%20%7C%20%60WANJIE_ARK_API_KEY%60%2C%20%60WANJIE_API_KEY%60%2C%20%60WANJIE_MAAS_API_KEY%60%20%7C%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2457&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Fsecrets%2Fsrc%2Flib.rs%3A93-94%0AThe%20%60DefaultKeyringStore%60%20struct-level%20doc%20mentions%20only%20%60system%60%20or%20%60keyring%60%20as%20valid%20values%20for%20%60SECRET_BACKEND_ENV%60%2C%20but%20%60secret_backend_selection%60%20also%20accepts%20%60os%60%20and%20%60os-keyring%60.%20A%20user%20who%20reads%20this%20doc%20and%20tries%20%60DEEPSEEK_SECRET_BACKEND%3Dos%60%20would%20think%20it%20is%20unsupported.%20The%20%60auto_detect%60%20method's%20expanded%20doc%20already%20lists%20all%20four%20values%20correctly%20%E2%80%94%20this%20struct%20doc%20should%20match.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20This%20backend%20is%20opt-in%20--%20set%20the%20%5B%60SECRET_BACKEND_ENV%60%5D%20environment%0A%2F%2F%2F%20variable%20to%20%60system%60%2C%20%60keyring%60%2C%20%60os%60%2C%20or%20%60os-keyring%60%20to%20activate%20it.%0A%2F%2F%2F%20On%20platforms%20without%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Fsecrets%2Fsrc%2Flib.rs%3A593-609%0AThe%20table%20header%20says%20%22Supported%20providers%20and%20their%20environment%20variables%22%2C%20implying%20completeness%2C%20but%20several%20match%20arms'%20alternate%20aliases%20are%20silently%20omitted.%20For%20example%2C%20%60xiaomi%60%20alone%20resolves%20to%20%60XIAOMI_MIMO_API_KEY%60%2F%60MIMO_API_KEY%60%20but%20is%20absent%20from%20the%20table%3B%20%60fireworks-ai%60%2C%20%60sg-lang%60%2C%20%60v-llm%60%2C%20%60ollama-local%60%2C%20%60atlas-cloud%60%2C%20%60volc-ark%60%2C%20%60volcengineark%60%2C%20and%20several%20%60wanjie%60%20variants%20are%20also%20missing.%20A%20user%20who%20tries%20%60env_for%28%22xiaomi%22%29%60%20after%20reading%20this%20table%20would%20expect%20%60None%60.%20Either%20update%20the%20Provider%20column%20to%20enumerate%20all%20accepted%20aliases%2C%20or%20add%20a%20note%20making%20clear%20the%20table%20shows%20representative%20names%20only.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20%7C%20Provider%20%28representative%20aliases%29%20%7C%20Env%20var%28s%29%20%7C%0A%2F%2F%2F%20%7C---%7C---%7C%0A%2F%2F%2F%20%7C%20%60deepseek%60%20%7C%20%60DEEPSEEK_API_KEY%60%20%7C%0A%2F%2F%2F%20%7C%20%60openrouter%60%20%7C%20%60OPENROUTER_API_KEY%60%20%7C%0A%2F%2F%2F%20%7C%20%60xiaomi-mimo%60%20%2F%20%60xiaomi_mimo%60%20%2F%20%60xiaomimimo%60%20%2F%20%60mimo%60%20%2F%20%60xiaomi%60%20%7C%20%60XIAOMI_MIMO_API_KEY%60%2C%20%60MIMO_API_KEY%60%20%7C%0A%2F%2F%2F%20%7C%20%60novita%60%20%7C%20%60NOVITA_API_KEY%60%20%7C%0A%2F%2F%2F%20%7C%20%60nvidia%60%20%2F%20%60nvidia-nim%60%20%2F%20%60nvidia_nim%60%20%2F%20%60nim%60%20%7C%20%60NVIDIA_API_KEY%60%2C%20%60NVIDIA_NIM_API_KEY%60%2C%20%60DEEPSEEK_API_KEY%60%20%7C%0A%2F%2F%2F%20%7C%20%60fireworks%60%20%2F%20%60fireworks-ai%60%20%7C%20%60FIREWORKS_API_KEY%60%20%7C%0A%2F%2F%2F%20%7C%20%60siliconflow%60%20%2F%20%60silicon-flow%60%20%2F%20%60silicon_flow%60%20%7C%20%60SILICONFLOW_API_KEY%60%20%7C%0A%2F%2F%2F%20%7C%20%60moonshot%60%20%2F%20%60moonshot-ai%60%20%2F%20%60kimi%60%20%2F%20%60kimi-k2%60%20%7C%20%60MOONSHOT_API_KEY%60%2C%20%60KIMI_API_KEY%60%20%7C%0A%2F%2F%2F%20%7C%20%60sglang%60%20%2F%20%60sg-lang%60%20%7C%20%60SGLANG_API_KEY%60%20%7C%0A%2F%2F%2F%20%7C%20%60vllm%60%20%2F%20%60v-llm%60%20%7C%20%60VLLM_API_KEY%60%20%7C%0A%2F%2F%2F%20%7C%20%60ollama%60%20%2F%20%60ollama-local%60%20%7C%20%60OLLAMA_API_KEY%60%20%7C%0A%2F%2F%2F%20%7C%20%60openai%60%20%7C%20%60OPENAI_API_KEY%60%20%7C%0A%2F%2F%2F%20%7C%20%60atlascloud%60%20%2F%20%60atlas-cloud%60%20%2F%20%60atlas_cloud%60%20%2F%20%60atlas%60%20%7C%20%60ATLASCLOUD_API_KEY%60%20%7C%0A%2F%2F%2F%20%7C%20%60volcengine%60%20%2F%20%60volcengine-ark%60%20%2F%20%60volcengine_ark%60%20%2F%20%60ark%60%20%2F%20%60volc-ark%60%20%2F%20%60volcengineark%60%20%7C%20%60VOLCENGINE_API_KEY%60%2C%20%60VOLCENGINE_ARK_API_KEY%60%2C%20%60ARK_API_KEY%60%20%7C%0A%2F%2F%2F%20%7C%20%60wanjie%60%20%2F%20%60wanjie-ark%60%20%2F%20%60wanjie_ark%60%20%2F%20%60ark-wanjie%60%20%2F%20%60ark_wanjie%60%20%2F%20%60wanjieark%60%20%2F%20%60wanjie-maas%60%20%2F%20%60wanjie_maas%60%20%2F%20%60wanjiemaas%60%20%7C%20%60WANJIE_ARK_API_KEY%60%2C%20%60WANJIE_API_KEY%60%2C%20%60WANJIE_MAAS_API_KEY%60%20%7C%0A%60%60%60%0A%0A&pr=2457&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs(secrets): add doc comments to all p..."](https://github.com/hmbown/codewhale/commit/0676e58d1c3c7fbc9b848a32d9b8ddfba3547c3b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34803454)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->