### PR TITLE
docs(protocol): add doc comments to all public types

### DIFF
--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -190,109 +190,159 @@ pub enum ThreadRequest {
     },
 }
 
+/// Response to a [`ThreadRequest`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ThreadResponse {
+    /// The thread this response pertains to.
     pub thread_id: String,
+    /// Human-readable status string (e.g. `"ok"`, `"error"`).
     pub status: String,
+    /// The thread details, when a single thread is returned.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub thread: Option<Thread>,
+    /// List of threads, populated by `List` requests.
     #[serde(default)]
     pub threads: Vec<Thread>,
+    /// The model used for the thread, if applicable.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
+    /// The model provider used for the thread.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model_provider: Option<String>,
+    /// The working directory of the thread.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cwd: Option<PathBuf>,
+    /// The active approval policy.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub approval_policy: Option<String>,
+    /// The active sandbox configuration.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sandbox: Option<String>,
+    /// Streaming events associated with this response.
     #[serde(default)]
     pub events: Vec<EventFrame>,
+    /// Arbitrary additional response data.
     #[serde(default)]
     pub data: Value,
 }
 
+/// Application-level requests that are not tied to a specific thread.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum AppRequest {
+    /// Query the server's capabilities.
     Capabilities,
+    /// Read a configuration value by key.
     ConfigGet { key: String },
+    /// Set a configuration key to a value.
     ConfigSet { key: String, value: String },
+    /// Remove a configuration key.
     ConfigUnset { key: String },
+    /// List all configuration entries.
     ConfigList,
+    /// List available models.
     Models,
+    /// List threads that are currently loaded in memory.
     ThreadLoadedList,
 }
 
+/// Response to an [`AppRequest`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AppResponse {
+    /// Whether the request succeeded.
     pub ok: bool,
+    /// The response payload.
     pub data: Value,
+    /// Streaming events associated with this response.
     #[serde(default)]
     pub events: Vec<EventFrame>,
 }
 
+/// A simple prompt request that sends text to the model and returns output.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PromptRequest {
+    /// Optional thread context for the prompt.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub thread_id: Option<String>,
+    /// The prompt text.
     pub prompt: String,
+    /// Model override, or the default if omitted.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
 }
 
+/// Response to a [`PromptRequest`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PromptResponse {
+    /// The model's output text.
     pub output: String,
+    /// The model that produced the output.
     pub model: String,
+    /// Streaming events associated with this response.
     #[serde(default)]
     pub events: Vec<EventFrame>,
 }
 
+/// Policy controlling when the agent must ask the user for approval before acting.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum AskForApproval {
+    /// Ask for approval unless the action is on a trusted path/resource.
     UnlessTrusted,
+    /// Only ask after a tool call fails.
     OnFailure,
+    /// Ask every time a tool call is requested.
     OnRequest,
+    /// Reject the action without asking, with details on which categories are blocked.
     Reject {
         sandbox_approval: bool,
         rules: bool,
         mcp_elicitations: bool,
     },
+    /// Never ask; auto-approve all actions.
     Never,
 }
 
+/// Classification of tool invocation origin.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ToolKind {
+    /// A built-in function tool.
     Function,
+    /// An MCP (Model Context Protocol) tool.
     Mcp,
 }
 
+/// Parameters for executing a local shell command.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LocalShellParams {
+    /// The shell command to execute.
     pub command: String,
+    /// Working directory for the command.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cwd: Option<String>,
+    /// Timeout in milliseconds.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timeout_ms: Option<u64>,
 }
 
+/// The payload of a tool call, discriminated by tool type.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ToolPayload {
+    /// A built-in function call with JSON-encoded arguments.
     Function {
         arguments: String,
     },
+    /// A custom tool invocation with a free-form input string.
     Custom {
         input: String,
     },
+    /// A local shell command execution.
     LocalShell {
         params: LocalShellParams,
     },
+    /// An MCP tool invocation targeting a specific server and tool.
     Mcp {
         server: String,
         tool: String,
@@ -302,201 +352,283 @@ pub enum ToolPayload {
     },
 }
 
+/// The result of a tool call, discriminated by tool type.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ToolOutput {
+    /// Result of a built-in function call.
     Function {
+        /// The output body, if any.
         #[serde(skip_serializing_if = "Option::is_none")]
         body: Option<Value>,
+        /// Whether the call succeeded.
         success: bool,
     },
+    /// Result of an MCP tool call.
     Mcp {
+        /// The result value returned by the MCP server.
         result: Value,
     },
 }
 
+/// Action to take for a network policy rule.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum NetworkPolicyRuleAction {
+    /// Allow network access to the host.
     Allow,
+    /// Deny network access to the host.
     Deny,
 }
 
+/// A proposed amendment to the network access policy for a specific host.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct NetworkPolicyAmendment {
+    /// The host to amend the policy for.
     pub host: String,
+    /// The action to apply.
     pub action: NetworkPolicyRuleAction,
 }
 
+/// A user's decision on an approval request.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ReviewDecision {
+    /// Approve the action.
     Approved,
+    /// Approve and also amend the execution policy.
     ApprovedExecpolicyAmendment,
+    /// Approve for the remainder of this session only.
     ApprovedForSession,
+    /// Approve with a network policy amendment.
     NetworkPolicyAmendment {
         host: String,
         action: NetworkPolicyRuleAction,
     },
+    /// Deny the action.
     Denied,
+    /// Abort the entire turn.
     Abort,
 }
 
+/// Status of an MCP server during startup.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum McpStartupStatus {
+    /// The server is in the process of starting.
     Starting,
+    /// The server is ready to accept requests.
     Ready,
+    /// The server failed to start.
     Failed { error: String },
+    /// Startup was cancelled.
     Cancelled,
 }
 
+/// A progress update for a single MCP server's startup.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct McpStartupUpdateEvent {
+    /// Name of the MCP server.
     pub server_name: String,
+    /// Current startup status.
     pub status: McpStartupStatus,
 }
 
+/// Details of an MCP server that failed to start.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct McpStartupFailure {
+    /// Name of the MCP server that failed.
     pub server_name: String,
+    /// Error description.
     pub error: String,
 }
 
+/// Summary event emitted once all MCP servers have finished starting.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct McpStartupCompleteEvent {
+    /// Servers that started successfully.
     pub ready: Vec<String>,
+    /// Servers that failed to start.
     pub failed: Vec<McpStartupFailure>,
+    /// Servers whose startup was cancelled.
     pub cancelled: Vec<String>,
 }
 
+/// Context about a network access request that requires approval.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NetworkApprovalContext {
+    /// The host being accessed.
     pub host: String,
+    /// The network protocol (e.g. `"https"`, `"tcp"`).
     pub protocol: String,
 }
 
+/// An event requesting user approval for a command execution or patch application.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExecApprovalRequestEvent {
+    /// Identifier of the tool call requesting approval.
     pub call_id: String,
+    /// Unique identifier for this approval request.
     pub approval_id: String,
+    /// The turn during which the request was made.
     pub turn_id: String,
+    /// The command that would be executed.
     pub command: String,
+    /// The working directory for the command.
     pub cwd: String,
+    /// Human-readable reason why approval is needed.
     pub reason: String,
+    /// Network context if the approval involves network access.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub network_approval_context: Option<NetworkApprovalContext>,
+    /// Proposed execution policy rule amendments.
     #[serde(default)]
     pub proposed_execpolicy_amendment: Vec<String>,
+    /// Proposed network policy amendments.
     #[serde(default)]
     pub proposed_network_policy_amendments: Vec<NetworkPolicyAmendment>,
+    /// Additional permissions being requested.
     #[serde(default)]
     pub additional_permissions: Vec<String>,
+    /// The set of decisions the user can choose from.
     #[serde(default)]
     pub available_decisions: Vec<ReviewDecision>,
 }
 
+/// The channel a response delta is being written to.
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ResponseChannel {
+    /// The main visible text output.
     #[default]
     Text,
+    /// Internal reasoning / chain-of-thought output.
     Reasoning,
 }
 
 impl ResponseChannel {
+    /// Returns `true` if this is the `Text` channel.
     pub const fn is_text(&self) -> bool {
         matches!(self, ResponseChannel::Text)
     }
 }
 
+/// A user's approval decision sent in response to an approval request.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ApprovalDecisionRequest {
+    /// The decision identifier (e.g. `"approved"`, `"denied"`).
     pub decision: String,
+    /// Whether to remember this decision for future similar requests.
     #[serde(default)]
     pub remember: bool,
 }
 
+/// A single streaming event frame emitted during agent execution.
+///
+/// Events are tagged by the `event` field and cover the full lifecycle of a
+/// turn: response streaming, tool calls, MCP lifecycle, command execution,
+/// patch application, approvals, and errors.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "event", rename_all = "snake_case")]
 pub enum EventFrame {
+    /// A new model response has started.
     ResponseStart {
         response_id: String,
     },
+    /// A incremental text delta for an in-progress response.
     ResponseDelta {
         response_id: String,
         delta: String,
         #[serde(default, skip_serializing_if = "ResponseChannel::is_text")]
         channel: ResponseChannel,
     },
+    /// The model response has finished.
     ResponseEnd {
         response_id: String,
     },
+    /// A tool call has begun.
     ToolCallStart {
         response_id: String,
         tool_name: String,
         arguments: Value,
     },
+    /// A tool call has completed and produced a result.
     ToolCallResult {
         response_id: String,
         tool_name: String,
         output: Value,
     },
+    /// Progress update for an MCP server starting up.
     McpStartupUpdate {
         update: McpStartupUpdateEvent,
     },
+    /// All MCP servers have finished starting.
     McpStartupComplete {
         summary: McpStartupCompleteEvent,
     },
+    /// An MCP tool call has begun.
     McpToolCallBegin {
         server_name: String,
         tool_name: String,
     },
+    /// An MCP tool call has finished.
     McpToolCallEnd {
         server_name: String,
         tool_name: String,
         ok: bool,
     },
+    /// User approval is needed for a command execution.
     ExecApprovalRequest {
         request: ExecApprovalRequestEvent,
     },
+    /// User approval is needed for applying a patch.
     ApplyPatchApprovalRequest {
         request: ExecApprovalRequestEvent,
     },
+    /// An MCP server is requesting user input (elicitation).
     ElicitationRequest {
         server_name: String,
         request_id: String,
         prompt: String,
     },
+    /// A command has started executing.
     ExecCommandBegin {
         command: String,
         cwd: String,
     },
+    /// Incremental output from a running command.
     ExecCommandOutputDelta {
         command: String,
         delta: String,
     },
+    /// A command has finished executing.
     ExecCommandEnd {
         command: String,
         exit_code: i32,
     },
+    /// A patch has started being applied to a file.
     PatchApplyBegin {
         path: String,
     },
+    /// A patch has finished being applied.
     PatchApplyEnd {
         path: String,
         ok: bool,
     },
+    /// A new turn has started within a thread.
     TurnStarted {
         turn_id: String,
     },
+    /// A turn has completed successfully.
     TurnComplete {
         turn_id: String,
     },
+    /// A turn was aborted before completion.
     TurnAborted {
         turn_id: String,
         reason: String,
     },
+    /// An error occurred during processing.
     Error {
         response_id: String,
         message: String,

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -331,17 +331,11 @@ pub struct LocalShellParams {
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ToolPayload {
     /// A built-in function call with JSON-encoded arguments.
-    Function {
-        arguments: String,
-    },
+    Function { arguments: String },
     /// A custom tool invocation with a free-form input string.
-    Custom {
-        input: String,
-    },
+    Custom { input: String },
     /// A local shell command execution.
-    LocalShell {
-        params: LocalShellParams,
-    },
+    LocalShell { params: LocalShellParams },
     /// An MCP tool invocation targeting a specific server and tool.
     Mcp {
         server: String,
@@ -532,9 +526,7 @@ pub struct ApprovalDecisionRequest {
 #[serde(tag = "event", rename_all = "snake_case")]
 pub enum EventFrame {
     /// A new model response has started.
-    ResponseStart {
-        response_id: String,
-    },
+    ResponseStart { response_id: String },
     /// A incremental text delta for an in-progress response.
     ResponseDelta {
         response_id: String,
@@ -543,9 +535,7 @@ pub enum EventFrame {
         channel: ResponseChannel,
     },
     /// The model response has finished.
-    ResponseEnd {
-        response_id: String,
-    },
+    ResponseEnd { response_id: String },
     /// A tool call has begun.
     ToolCallStart {
         response_id: String,
@@ -559,13 +549,9 @@ pub enum EventFrame {
         output: Value,
     },
     /// Progress update for an MCP server starting up.
-    McpStartupUpdate {
-        update: McpStartupUpdateEvent,
-    },
+    McpStartupUpdate { update: McpStartupUpdateEvent },
     /// All MCP servers have finished starting.
-    McpStartupComplete {
-        summary: McpStartupCompleteEvent,
-    },
+    McpStartupComplete { summary: McpStartupCompleteEvent },
     /// An MCP tool call has begun.
     McpToolCallBegin {
         server_name: String,
@@ -578,13 +564,9 @@ pub enum EventFrame {
         ok: bool,
     },
     /// User approval is needed for a command execution.
-    ExecApprovalRequest {
-        request: ExecApprovalRequestEvent,
-    },
+    ExecApprovalRequest { request: ExecApprovalRequestEvent },
     /// User approval is needed for applying a patch.
-    ApplyPatchApprovalRequest {
-        request: ExecApprovalRequestEvent,
-    },
+    ApplyPatchApprovalRequest { request: ExecApprovalRequestEvent },
     /// An MCP server is requesting user input (elicitation).
     ElicitationRequest {
         server_name: String,
@@ -592,42 +574,21 @@ pub enum EventFrame {
         prompt: String,
     },
     /// A command has started executing.
-    ExecCommandBegin {
-        command: String,
-        cwd: String,
-    },
+    ExecCommandBegin { command: String, cwd: String },
     /// Incremental output from a running command.
-    ExecCommandOutputDelta {
-        command: String,
-        delta: String,
-    },
+    ExecCommandOutputDelta { command: String, delta: String },
     /// A command has finished executing.
-    ExecCommandEnd {
-        command: String,
-        exit_code: i32,
-    },
+    ExecCommandEnd { command: String, exit_code: i32 },
     /// A patch has started being applied to a file.
-    PatchApplyBegin {
-        path: String,
-    },
+    PatchApplyBegin { path: String },
     /// A patch has finished being applied.
-    PatchApplyEnd {
-        path: String,
-        ok: bool,
-    },
+    PatchApplyEnd { path: String, ok: bool },
     /// A new turn has started within a thread.
-    TurnStarted {
-        turn_id: String,
-    },
+    TurnStarted { turn_id: String },
     /// A turn has completed successfully.
-    TurnComplete {
-        turn_id: String,
-    },
+    TurnComplete { turn_id: String },
     /// A turn was aborted before completion.
-    TurnAborted {
-        turn_id: String,
-        reason: String,
-    },
+    TurnAborted { turn_id: String, reason: String },
     /// An error occurred during processing.
     Error {
         response_id: String,

--- a/crates/secrets/src/lib.rs
+++ b/crates/secrets/src/lib.rs
@@ -48,28 +48,57 @@ pub enum SecretsError {
     },
 }
 
-/// Abstract secret store; concrete implementations may use the OS
-/// keyring, a JSON file under `~/.deepseek/secrets/`, or an in-memory
-/// map (tests).
+/// Abstract secret store trait.
+///
+/// Concrete implementations may use the OS keyring ([`DefaultKeyringStore`]),
+/// a JSON file under `~/.deepseek/secrets/` ([`FileKeyringStore`]), or an
+/// in-memory map for tests ([`InMemoryKeyringStore`]).
+///
+/// All implementations must be [`Send`] + [`Sync`] so they can be shared
+/// across threads via [`Arc`].
 pub trait KeyringStore: Send + Sync {
-    /// Read a secret. Returns `Ok(None)` if no entry exists.
+    /// Read a secret by key.
+    ///
+    /// Returns `Ok(None)` if no entry exists for the given key. Returns
+    /// `Err` only on backend failures (I/O errors, keyring access issues).
     fn get(&self, key: &str) -> Result<Option<String>, SecretsError>;
-    /// Write a secret, replacing any existing value.
+
+    /// Write a secret, replacing any existing value for the same key.
+    ///
+    /// Creates the backing store (e.g. the JSON file) on first write if
+    /// it does not yet exist.
     fn set(&self, key: &str, value: &str) -> Result<(), SecretsError>;
-    /// Remove a secret. Should not error if the entry is absent.
+
+    /// Remove a secret by key.
+    ///
+    /// Implementations should succeed (no-op) if the entry is already absent
+    /// rather than returning an error.
     fn delete(&self, key: &str) -> Result<(), SecretsError>;
-    /// Short, human-readable name of the backend (used by `doctor`).
+
+    /// Short, human-readable label for this backend.
+    ///
+    /// Used by diagnostic output (e.g. `doctor` command) to indicate which
+    /// storage backend is active. Examples: `"file-based (~/.deepseek/secrets/)"`,
+    /// `"system keyring"`, `"in-memory (test)"`.
     fn backend_name(&self) -> &'static str;
 }
 
-/// OS keyring backend (macOS Keychain, Windows Credential Manager,
-/// Linux Secret Service / kwallet). This backend is opt-in through
-/// [`SECRET_BACKEND_ENV`]. On platforms without a configured native
-/// keyring dependency, probing this backend returns an unsupported error so
-/// [`Secrets::auto_detect`] can fall back to [`FileKeyringStore`].
+/// OS-native keyring backend.
+///
+/// Wraps the platform credential store:
+/// - **macOS**: Keychain (via `security` framework)
+/// - **Windows**: Credential Manager
+/// - **Linux**: Secret Service (GNOME Keyring / kwallet via dbus)
+///
+/// This backend is opt-in -- set the [`SECRET_BACKEND_ENV`] environment
+/// variable to `system` or `keyring` to activate it. On platforms without
+/// a configured native keyring dependency, [`probe`](DefaultKeyringStore::probe)
+/// returns an unsupported error so [`Secrets::auto_detect`] can transparently
+/// fall back to [`FileKeyringStore`].
 #[derive(Debug, Clone)]
 pub struct DefaultKeyringStore {
-    /// Keyring service name (defaults to [`DEFAULT_SERVICE`]).
+    /// Keyring service name used to namespace stored credentials.
+    /// Defaults to [`DEFAULT_SERVICE`].
     service: String,
 }
 
@@ -186,9 +215,15 @@ fn unsupported_keyring_message() -> String {
     "system keyring backend is unsupported on this platform".to_string()
 }
 
-/// In-memory keyring (tests only).
+/// In-memory keyring store for tests.
+///
+/// Stores secrets in a [`HashMap`] protected by a [`Mutex`]. Not persisted
+/// to disk -- all entries are lost when the process exits. This is the
+/// preferred store for unit tests because it requires no filesystem setup
+/// and is safe to use in parallel test threads.
 #[derive(Debug, Default)]
 pub struct InMemoryKeyringStore {
+    /// Thread-safe map of key-value pairs.
     entries: Mutex<HashMap<String, String>>,
 }
 
@@ -229,12 +264,21 @@ impl KeyringStore for InMemoryKeyringStore {
     }
 }
 
-/// JSON-on-disk fallback for headless environments without a Secret
-/// Service / dbus. Stored at `<home>/.deepseek/secrets/secrets.json`
-/// with mode `0600`.
+/// JSON-on-disk secret store for headless environments.
+///
+/// This is the default backend. Secrets are serialised as a JSON object
+/// at `<home>/.deepseek/secrets/secrets.json` with Unix file mode `0600`
+/// (owner read/write only). The parent directory is created with mode `0700`
+/// if it does not exist.
+///
+/// On Unix, the store rejects files whose permissions are more permissive
+/// than `0600` (i.e. group or world bits are set). This prevents other
+/// users on the system from reading stored credentials. On Windows, the
+/// ACL model is too different to enforce programmatically; callers are
+/// responsible for placing the file in a per-user directory.
 #[derive(Debug, Clone)]
 pub struct FileKeyringStore {
-    /// Absolute path to the JSON file.
+    /// Absolute path to the JSON secrets file.
     path: PathBuf,
 }
 
@@ -376,28 +420,43 @@ fn secret_backend_selection(value: Option<&str>) -> SecretBackendSelection {
     }
 }
 
-/// High-level façade combining a [`KeyringStore`] with environment
-/// variable fallbacks.
+/// High-level facade combining a [`KeyringStore`] with environment variable fallbacks.
 ///
-/// Lookup precedence: **secret store → env → none**. Callers that also have
-/// a TOML config layer must wire that themselves at the very end of
-/// the chain.
+/// Lookup precedence: **secret store -> env -> none**. Callers that also
+/// have a TOML config layer must wire that themselves at the very end
+/// of the chain (the config crate handles this).
+///
+/// # Examples
+///
+/// ```no_run
+/// use codewhale_secrets::Secrets;
+///
+/// let secrets = Secrets::auto_detect();
+/// if let Some(key) = secrets.resolve("deepseek") {
+///     // use the API key
+/// }
+/// ```
 #[derive(Clone)]
 pub struct Secrets {
-    /// Underlying secret store.
+    /// Underlying secret store backend.
     pub store: Arc<dyn KeyringStore>,
-    /// Owner identifier within the secret store (typically "deepseek"); the
-    /// `key` parameter passed to `resolve` is mapped to a slot in the
-    /// store as-is, while envs are looked up by canonical name.
+    /// Owner identifier within the secret store (typically `"deepseek"`).
+    /// The `key` parameter passed to [`resolve`](Secrets::resolve) is
+    /// forwarded to the store as-is, while environment variables are
+    /// looked up by canonical provider name via [`env_for`].
     service: String,
 }
 
-/// Source layer that provided a resolved secret.
+/// Identifies which layer in the resolution chain supplied a secret.
+///
+/// Returned by [`Secrets::resolve_with_source`] so callers can
+/// distinguish whether a value came from the configured store or from
+/// a process environment variable.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SecretSource {
-    /// The configured secret-store backend returned the secret.
+    /// The secret was returned by the configured [`KeyringStore`] backend.
     Keyring,
-    /// A process environment variable returned the secret.
+    /// The secret was found in a process environment variable.
     Env,
 }
 
@@ -411,7 +470,8 @@ impl std::fmt::Debug for Secrets {
 }
 
 impl Secrets {
-    /// Build a new façade around a store.
+    /// Build a new facade around the given store, using the
+    /// [`DEFAULT_SERVICE`] service name.
     #[must_use]
     pub fn new(store: Arc<dyn KeyringStore>) -> Self {
         Self {
@@ -420,10 +480,16 @@ impl Secrets {
         }
     }
 
-    /// Construct the default backend. The prompt-free default is
-    /// [`FileKeyringStore`] under `~/.deepseek/secrets/`. Set
-    /// [`SECRET_BACKEND_ENV`] to `system` or `keyring` to opt into the OS
-    /// credential store.
+    /// Auto-detect the best available backend based on the environment.
+    ///
+    /// Selection logic:
+    /// 1. If [`SECRET_BACKEND_ENV`] is set to `system`/`keyring`/`os`/`os-keyring`,
+    ///    probe the OS keyring. If the probe succeeds, use it; otherwise
+    ///    fall back to the file-based store with a warning.
+    /// 2. If the env var is unset, empty, or `file`/`local`/`json`, use
+    ///    the file-based store directly.
+    /// 3. If the env var is set to an unrecognised value, log a warning
+    ///    and use the file-based store.
     pub fn auto_detect() -> Self {
         match secret_backend_selection(std::env::var(SECRET_BACKEND_ENV).ok().as_deref()) {
             SecretBackendSelection::File => Self::file_backed_default(),
@@ -518,8 +584,32 @@ impl Secrets {
     }
 }
 
-/// Map a canonical provider name to its environment variable, returning
-/// the value if non-empty.
+/// Map a canonical provider name to its environment variable(s), returning
+/// the first non-empty value found.
+///
+/// Provider names are case-insensitive. Supported providers and their
+/// environment variables:
+///
+/// | Provider | Env var(s) |
+/// |---|---|
+/// | `deepseek` | `DEEPSEEK_API_KEY` |
+/// | `openrouter` | `OPENROUTER_API_KEY` |
+/// | `xiaomi-mimo` / `mimo` | `XIAOMI_MIMO_API_KEY`, `MIMO_API_KEY` |
+/// | `novita` | `NOVITA_API_KEY` |
+/// | `nvidia` / `nvidia-nim` / `nim` | `NVIDIA_API_KEY`, `NVIDIA_NIM_API_KEY`, `DEEPSEEK_API_KEY` |
+/// | `fireworks` | `FIREWORKS_API_KEY` |
+/// | `siliconflow` | `SILICONFLOW_API_KEY` |
+/// | `moonshot` / `kimi` | `MOONSHOT_API_KEY`, `KIMI_API_KEY` |
+/// | `sglang` | `SGLANG_API_KEY` |
+/// | `vllm` | `VLLM_API_KEY` |
+/// | `ollama` | `OLLAMA_API_KEY` |
+/// | `openai` | `OPENAI_API_KEY` |
+/// | `atlascloud` / `atlas` | `ATLASCLOUD_API_KEY` |
+/// | `volcengine` / `ark` | `VOLCENGINE_API_KEY`, `VOLCENGINE_ARK_API_KEY`, `ARK_API_KEY` |
+/// | `wanjie` / `wanjie-ark` | `WANJIE_ARK_API_KEY`, `WANJIE_API_KEY`, `WANJIE_MAAS_API_KEY` |
+///
+/// Returns `None` if the provider is not recognised or none of its
+/// candidate environment variables are set to a non-empty value.
 #[must_use]
 pub fn env_for(name: &str) -> Option<String> {
     let candidates: &[&str] = match name.to_ascii_lowercase().as_str() {


### PR DESCRIPTION
Add doc comments to all public types in the protocol crate, covering all request/response types, event frames, tool payloads, and approval model.