### PR TITLE
chore(release): prep v0.8.48

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,55 +7,134 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.48] - 2026-05-31
+
 ### Added
 
-- **Composer text selection with copy/cut.** Mouse drag and Shift+Arrow
-  selection in the composer input box, with Ctrl+C copy and Ctrl+X cut
-  support. Home, End, Ctrl+A, and Ctrl+E now clear the selection (#2228).
-- **Copy transcript without visual-wrap newlines.** Transcript copy now
-  strips visual-wrap column line breaks from paragraphs, producing clean
-  text for pasting into editors or prompts (#1906).
-- **Configurable base URL in /config view.** The `/config` panel now
-  displays the effective DeepSeek base URL (#1967).
-- **CNB mirror support for China-friendly downloads.** Added
-  `CODEWHALE_RELEASE_BASE_URL` and `CODEWHALE_USE_CNB_MIRROR` to
-  both npm install scripts and Rust self-updater (#2222).
-- **[✓] completion markers.** Checklist, plan, and tool completion
-  markers now render as `[✓]` instead of `[x]` (#1935).
+- **Recent large OpenRouter model presets.** Added completions, aliases,
+  routing metadata, and docs for Arcee Trinity Large Thinking, Qwen 3.7
+  Max, Xiaomi MiMo v2.5, Qwen 3.6 open-weight models, Kimi K2.6,
+  GLM 5.1, Tencent Hy3, Gemma 4, and Nemotron (#2461).
+- **Provider and web-search expansion.** Added Xiaomi MiMo provider support,
+  SiliconFlow, AtlasCloud static models, Volcengine Ark search, Baidu AI
+  Search, provider-picker coverage, and richer custom-provider docs
+  (#2246, #1868, #2421, #2429, #2371, #2394, #2287).
+- **Workflow and tool ergonomics.** Added the external-tool abstraction,
+  pluggable TUI tool registry, custom slash-command allowed-tools enforcement,
+  opt-in Unix socket hook sink, message-submit transform hooks, tool-cache
+  introspection, and cache warmup-key tracking (#2294, #2420, #2326, #2430,
+  #2434, #2423, #2424).
+- **TUI workflow features.** Added `/purge`, `/hunt`, thinking fold/unfold,
+  terminal-transparent/Solarized Light/Claude themes, footer branch display,
+  macOS notifications, intent summaries before approval prompts, and the
+  mobile runtime smoke/QR workflow (#2387, #2306, #2385, #2276, #2270, #2267,
+  #2347, #2260, #2389, #2403).
+- **Platform and localization coverage.** Added RISC-V prebuilt-binary
+  support, Vietnamese localization, Java/Vue language-server defaults, runtime
+  event envelopes, task migration/env isolation fixes, and state-message
+  parent IDs for future forks (#2383, #2358, #2367, #2252, #2272, #2308).
 
 ### Changed
 
-- **Project context loading now logs the source file.** (#2227)
-- **macOS onboarding and empty-state layout pinned to top** instead
-  of vertically centered (#1837).
-- **State-root migration continues.** Migrated 15+ storage paths to
-  prefer `~/.codewhale` with `~/.deepseek` fallback (#2231).
-- **READMEs updated for the CodeWhale rename.** All three READMEs now
-  reference canonical `~/.codewhale` paths.
+- **Release hardening.** CI now runs clippy/docs checks, web frontend lint and
+  type checks, provider-registry drift checks, broader crate docs, and a large
+  unit-test pass across core, MCP, TUI core, app-server, and web helpers
+  (#2443, #2444, #2274, #2446-#2460, #2440, #2441, #2450, #2448, #2454).
+- **Prompt, context, and model routing behavior.** Stabilized project-context
+  pack ordering, exposed the auto route in turn metadata, allowed embedders to
+  override or inline constitutional instructions, moved volatile environment
+  context below the prompt boundary, and used the effective model for
+  compaction budgeting (#2418, #2410, #2356, #2311, #2314, #2437).
+- **Execution policy foundation.** Added typed ask-rule groundwork and kept
+  `task_shell_start` gated behind `allow_shell`, preparing the permission UI
+  path without broadening default shell access (#2404, #2384).
 
 ### Fixed
 
-- **Deadlock when spawning multiple concurrent sub-agents.** Replaced
-  `RwLock`-based serialisation with a `Semaphore(1)` (#1856).
-- **Steered/queued messages now render in correct transcript order.**
-  `steer_user_message` now flushes the active cell before inserting (#2225).
-- **Session save test updated for managed sessions directory.** (#2223).
-- **Loop guard reports Failed on halt.** Turn outcome correctly reports
-  `Failed` instead of `Completed` when the loop guard trips (#1859).
-- **DEEPSEEK_YOLO env honoured on startup.** The `--yolo` flag is now
-  correctly merged with the `DEEPSEEK_YOLO` environment variable (#1870).
+- **Windows and shell reliability.** Suppressed alt-screen logging on Windows,
+  added the Windows batch launcher path, kept task shell tools eagerly loaded,
+  loaded exec-shell companion tools consistently, covered controlling-terminal
+  behavior, and improved shell tool availability errors (#2259, #2295, #1861,
+  #2271, #2331, #2414, #2412).
+- **Session and transcript durability.** Fixed hidden-worktree discovery
+  saturation, stalled in-progress turn recovery, session persistence
+  truncation, cached-transcript user-message highlighting, large tool-output
+  receipting, session-detail block serialization, and deterministic composer
+  history flushing (#2273, #2329, #2283, #2395, #2386, #2297, #2265, #2375).
+- **Provider and UI polish.** Accepted custom model IDs in `/model` for
+  non-DeepSeek providers, fixed Feishu per-chat model switching, localized
+  context-menu labels, updated terminal tab naming, kept picker selections
+  visible, allowed slash-space composer messages, and improved PDF text
+  cleanup (#2280, #2149, #2320, #2319, #2324, #2316, #2266).
+- **Security and dependency hygiene.** Bumped `tar` and `qs`, trusted fake-IP
+  placeholder ranges only when explicitly configured, decoded Bing result URL
+  entities, fixed legacy MCP SSE connections, and replaced manual tool error
+  display code with `thiserror` derives (#2364, #2425, #2355, #2245, #2301,
+  #2442).
 
 ### Community
 
-Thanks to contributors whose PRs landed in this release:
-**@Fire-dtx** (#1856),
-**@imkingjh999** (#2228),
-**@harvey2011888** (#1859),
-**@victorcheng2333** (#1870),
-**@IIzzaya** (#1935),
-**@PurplePulse** (#1837),
-**@cyq1017** (#1967),
-**@knqiufan** (#1906).
+Thanks to contributors whose PRs landed or were harvested in this release:
+**@HUQIANTAO** (#2246, #2257, #2267, #2384, #2385, #2389, #2403, #2440-#2460),
+**@h3c-hexin** (#2311, #2313, #2314, #2354, #2355, #2356),
+**@reidliu41** (#2291, #2316, #2324, #2357, #2366, #2386, #2431),
+**@aboimpinto** (#2290, #2294, #2295, #2326, #2433),
+**@donglovejava** (#2302, #2329, #2330, #2331),
+**@cyq1017** (#2252, #2332, #2375),
+**@nightt5879** (#2274, #2344, #2347, #2373),
+**@idling11** (#2161, #2266, #2306),
+**@zlh124** (#2320, #2325),
+**@AresNing** (#2278, #2318/#2434),
+**@Implementist** (#2426/#2429, #2439),
+**@lihuan215** (#2333/#2430),
+**@AdityaVG13** (#2246),
+**@AiurArtanis** (#2270),
+**@Lee-take** (#2272),
+**@LeoAlex0** (#2388, #2395),
+**@gaord** (#2265, #2285),
+**@jimmyzhuu** (#2371),
+**@rockyzhang** (#2383),
+**@mo-vic** (#2387),
+**@hufanexplore** (#2367),
+**@hoclaptrinh33** (#2358),
+**@zhuangbiaowei** (#2301),
+**@axobase001** (#2296, #2297, #2298),
+**@Sskift** (#2248),
+**@AccMoment** (#2281),
+**@LING71671** (#2287, #2292),
+**@mvanhorn** (#2236),
+and **@encyc** (#2336, #2338).
+
+## [0.8.47] - 2026-05-26
+
+### Added
+
+- **Closed-loop verification gate, runtime goal tools, DuckDuckGo default
+  web search, Xiaomi MiMo, global AGENTS.md fallback, `/new`, composer
+  selection, transcript copy cleanup, CNB mirror support, and Docker toolbox
+  docs** shipped in the published v0.8.47 release.
+
+### Changed
+
+- **DeepSeek-first release framing, project-context logging, state-root
+  migration, CodeWhale README paths, and reasoning-locale behavior** were
+  finalized for the v0.8.47 release.
+
+### Fixed
+
+- **Provider picker scrolling, auto model restore, cache-inspect hashing,
+  insecure LAN provider guard, large tool-output compaction, queued-message
+  ordering, shell/Yolo startup handling, Windows alt-screen logging, and
+  tooltip contrast** were fixed in the v0.8.47 release.
+
+### Community
+
+Thanks to contributors credited in the v0.8.47 GitHub Release, including
+**@Fire-dtx**, **@imkingjh999**, **@harvey2011888**, **@victorcheng2333**,
+**@IIzzaya**, **@PurplePulse**, **@cyq1017**, **@knqiufan**,
+**@Colorful-glassblock**, **@hongqitai**, **@EmiyaKiritsugu3**,
+**@aboimpinto**, **@HUQIANTAO**, **@mvanhorn**, **@LING71671**, and
+**@reidliu41**.
 
 ## [0.8.46] - 2026-05-26
 
@@ -5018,7 +5097,9 @@ Welcome — and thank you.
 - Hooks system and config profiles
 - Example skills and launch assets
 
-[Unreleased]: https://github.com/Hmbown/CodeWhale/compare/v0.8.46...HEAD
+[Unreleased]: https://github.com/Hmbown/CodeWhale/compare/v0.8.48...HEAD
+[0.8.48]: https://github.com/Hmbown/CodeWhale/compare/v0.8.47...v0.8.48
+[0.8.47]: https://github.com/Hmbown/CodeWhale/compare/v0.8.46...v0.8.47
 [0.8.46]: https://github.com/Hmbown/CodeWhale/compare/v0.8.45...v0.8.46
 [0.8.45]: https://github.com/Hmbown/CodeWhale/compare/v0.8.44...v0.8.45
 [0.8.44]: https://github.com/Hmbown/CodeWhale/compare/v0.8.43...v0.8.44

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,7 +803,7 @@ checksum = "e9b18233253483ce2f65329a24072ec414db782531bdbb7d0bbc4bd2ce6b7e21"
 
 [[package]]
 name = "codewhale-agent"
-version = "0.8.46"
+version = "0.8.48"
 dependencies = [
  "codewhale-config",
  "serde",
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-app-server"
-version = "0.8.46"
+version = "0.8.48"
 dependencies = [
  "anyhow",
  "axum",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-cli"
-version = "0.8.46"
+version = "0.8.48"
 dependencies = [
  "anyhow",
  "chrono",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-config"
-version = "0.8.46"
+version = "0.8.48"
 dependencies = [
  "anyhow",
  "codewhale-secrets",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-core"
-version = "0.8.46"
+version = "0.8.48"
 dependencies = [
  "anyhow",
  "chrono",
@@ -894,7 +894,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-execpolicy"
-version = "0.8.46"
+version = "0.8.48"
 dependencies = [
  "anyhow",
  "codewhale-protocol",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-hooks"
-version = "0.8.46"
+version = "0.8.48"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-mcp"
-version = "0.8.46"
+version = "0.8.48"
 dependencies = [
  "anyhow",
  "serde",
@@ -926,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-protocol"
-version = "0.8.46"
+version = "0.8.48"
 dependencies = [
  "serde",
  "serde_json",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-release"
-version = "0.8.46"
+version = "0.8.48"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-secrets"
-version = "0.8.46"
+version = "0.8.48"
 dependencies = [
  "dirs",
  "keyring",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-state"
-version = "0.8.46"
+version = "0.8.48"
 dependencies = [
  "anyhow",
  "chrono",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-tools"
-version = "0.8.46"
+version = "0.8.48"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -984,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-tui"
-version = "0.8.46"
+version = "0.8.48"
 dependencies = [
  "anyhow",
  "arboard",
@@ -1053,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-tui-core"
-version = "0.8.46"
+version = "0.8.48"
 
 [[package]]
 name = "colorchoice"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = ["crates/cli", "crates/app-server", "crates/tui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.8.46"
+version = "0.8.48"
 edition = "2024"
 # Rust 1.88 stabilized `let_chains` in `if`/`while` conditions, which the
 # codebase relies on extensively. Cargo enforces this so users on older

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -7,5 +7,5 @@ repository.workspace = true
 description = "Model/provider registry and fallback strategy for DeepSeek workspace architecture"
 
 [dependencies]
-codewhale-config = { path = "../config", version = "0.8.46" }
+codewhale-config = { path = "../config", version = "0.8.48" }
 serde.workspace = true

--- a/crates/app-server/Cargo.toml
+++ b/crates/app-server/Cargo.toml
@@ -10,15 +10,15 @@ description = "Codex-style app-server transport for DeepSeek workspace architect
 anyhow.workspace = true
 axum.workspace = true
 clap.workspace = true
-codewhale-agent = { path = "../agent", version = "0.8.46" }
-codewhale-config = { path = "../config", version = "0.8.46" }
-codewhale-core = { path = "../core", version = "0.8.46" }
-codewhale-execpolicy = { path = "../execpolicy", version = "0.8.46" }
-codewhale-hooks = { path = "../hooks", version = "0.8.46" }
-codewhale-mcp = { path = "../mcp", version = "0.8.46" }
-codewhale-protocol = { path = "../protocol", version = "0.8.46" }
-codewhale-state = { path = "../state", version = "0.8.46" }
-codewhale-tools = { path = "../tools", version = "0.8.46" }
+codewhale-agent = { path = "../agent", version = "0.8.48" }
+codewhale-config = { path = "../config", version = "0.8.48" }
+codewhale-core = { path = "../core", version = "0.8.48" }
+codewhale-execpolicy = { path = "../execpolicy", version = "0.8.48" }
+codewhale-hooks = { path = "../hooks", version = "0.8.48" }
+codewhale-mcp = { path = "../mcp", version = "0.8.48" }
+codewhale-protocol = { path = "../protocol", version = "0.8.48" }
+codewhale-state = { path = "../state", version = "0.8.48" }
+codewhale-tools = { path = "../tools", version = "0.8.48" }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -25,14 +25,14 @@ path = "src/bin/deepseek_legacy_shim.rs"
 anyhow.workspace = true
 clap.workspace = true
 clap_complete.workspace = true
-codewhale-agent = { path = "../agent", version = "0.8.46" }
-codewhale-app-server = { path = "../app-server", version = "0.8.46" }
-codewhale-config = { path = "../config", version = "0.8.46" }
-codewhale-execpolicy = { path = "../execpolicy", version = "0.8.46" }
-codewhale-mcp = { path = "../mcp", version = "0.8.46" }
-codewhale-release = { path = "../release", version = "0.8.46" }
-codewhale-secrets = { path = "../secrets", version = "0.8.46" }
-codewhale-state = { path = "../state", version = "0.8.46" }
+codewhale-agent = { path = "../agent", version = "0.8.48" }
+codewhale-app-server = { path = "../app-server", version = "0.8.48" }
+codewhale-config = { path = "../config", version = "0.8.48" }
+codewhale-execpolicy = { path = "../execpolicy", version = "0.8.48" }
+codewhale-mcp = { path = "../mcp", version = "0.8.48" }
+codewhale-release = { path = "../release", version = "0.8.48" }
+codewhale-secrets = { path = "../secrets", version = "0.8.48" }
+codewhale-state = { path = "../state", version = "0.8.48" }
 chrono.workspace = true
 dirs.workspace = true
 serde.workspace = true

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -8,7 +8,7 @@ description = "Config schema and precedence model for DeepSeek workspace archite
 
 [dependencies]
 anyhow.workspace = true
-codewhale-secrets = { path = "../secrets", version = "0.8.46" }
+codewhale-secrets = { path = "../secrets", version = "0.8.48" }
 dirs.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -9,13 +9,13 @@ description = "Core runtime boundaries for DeepSeek workspace architecture"
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true
-codewhale-agent = { path = "../agent", version = "0.8.46" }
-codewhale-config = { path = "../config", version = "0.8.46" }
-codewhale-execpolicy = { path = "../execpolicy", version = "0.8.46" }
-codewhale-hooks = { path = "../hooks", version = "0.8.46" }
-codewhale-mcp = { path = "../mcp", version = "0.8.46" }
-codewhale-protocol = { path = "../protocol", version = "0.8.46" }
-codewhale-state = { path = "../state", version = "0.8.46" }
-codewhale-tools = { path = "../tools", version = "0.8.46" }
+codewhale-agent = { path = "../agent", version = "0.8.48" }
+codewhale-config = { path = "../config", version = "0.8.48" }
+codewhale-execpolicy = { path = "../execpolicy", version = "0.8.48" }
+codewhale-hooks = { path = "../hooks", version = "0.8.48" }
+codewhale-mcp = { path = "../mcp", version = "0.8.48" }
+codewhale-protocol = { path = "../protocol", version = "0.8.48" }
+codewhale-state = { path = "../state", version = "0.8.48" }
+codewhale-tools = { path = "../tools", version = "0.8.48" }
 serde_json.workspace = true
 uuid.workspace = true

--- a/crates/execpolicy/Cargo.toml
+++ b/crates/execpolicy/Cargo.toml
@@ -8,5 +8,5 @@ description = "Execution policy and approval model parity for DeepSeek workspace
 
 [dependencies]
 anyhow.workspace = true
-codewhale-protocol = { path = "../protocol", version = "0.8.46" }
+codewhale-protocol = { path = "../protocol", version = "0.8.48" }
 serde.workspace = true

--- a/crates/hooks/Cargo.toml
+++ b/crates/hooks/Cargo.toml
@@ -10,7 +10,7 @@ description = "Hook dispatch and notifications parity for DeepSeek workspace arc
 anyhow.workspace = true
 async-trait.workspace = true
 chrono.workspace = true
-codewhale-protocol = { path = "../protocol", version = "0.8.46" }
+codewhale-protocol = { path = "../protocol", version = "0.8.48" }
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -9,7 +9,7 @@ description = "Tool invocation lifecycle, schema validation, and scheduler paral
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
-codewhale-protocol = { path = "../protocol", version = "0.8.46" }
+codewhale-protocol = { path = "../protocol", version = "0.8.48" }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -7,55 +7,134 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.48] - 2026-05-31
+
 ### Added
 
-- **Composer text selection with copy/cut.** Mouse drag and Shift+Arrow
-  selection in the composer input box, with Ctrl+C copy and Ctrl+X cut
-  support. Home, End, Ctrl+A, and Ctrl+E now clear the selection (#2228).
-- **Copy transcript without visual-wrap newlines.** Transcript copy now
-  strips visual-wrap column line breaks from paragraphs, producing clean
-  text for pasting into editors or prompts (#1906).
-- **Configurable base URL in /config view.** The `/config` panel now
-  displays the effective DeepSeek base URL (#1967).
-- **CNB mirror support for China-friendly downloads.** Added
-  `CODEWHALE_RELEASE_BASE_URL` and `CODEWHALE_USE_CNB_MIRROR` to
-  both npm install scripts and Rust self-updater (#2222).
-- **[✓] completion markers.** Checklist, plan, and tool completion
-  markers now render as `[✓]` instead of `[x]` (#1935).
+- **Recent large OpenRouter model presets.** Added completions, aliases,
+  routing metadata, and docs for Arcee Trinity Large Thinking, Qwen 3.7
+  Max, Xiaomi MiMo v2.5, Qwen 3.6 open-weight models, Kimi K2.6,
+  GLM 5.1, Tencent Hy3, Gemma 4, and Nemotron (#2461).
+- **Provider and web-search expansion.** Added Xiaomi MiMo provider support,
+  SiliconFlow, AtlasCloud static models, Volcengine Ark search, Baidu AI
+  Search, provider-picker coverage, and richer custom-provider docs
+  (#2246, #1868, #2421, #2429, #2371, #2394, #2287).
+- **Workflow and tool ergonomics.** Added the external-tool abstraction,
+  pluggable TUI tool registry, custom slash-command allowed-tools enforcement,
+  opt-in Unix socket hook sink, message-submit transform hooks, tool-cache
+  introspection, and cache warmup-key tracking (#2294, #2420, #2326, #2430,
+  #2434, #2423, #2424).
+- **TUI workflow features.** Added `/purge`, `/hunt`, thinking fold/unfold,
+  terminal-transparent/Solarized Light/Claude themes, footer branch display,
+  macOS notifications, intent summaries before approval prompts, and the
+  mobile runtime smoke/QR workflow (#2387, #2306, #2385, #2276, #2270, #2267,
+  #2347, #2260, #2389, #2403).
+- **Platform and localization coverage.** Added RISC-V prebuilt-binary
+  support, Vietnamese localization, Java/Vue language-server defaults, runtime
+  event envelopes, task migration/env isolation fixes, and state-message
+  parent IDs for future forks (#2383, #2358, #2367, #2252, #2272, #2308).
 
 ### Changed
 
-- **Project context loading now logs the source file.** (#2227)
-- **macOS onboarding and empty-state layout pinned to top** instead
-  of vertically centered (#1837).
-- **State-root migration continues.** Migrated 15+ storage paths to
-  prefer `~/.codewhale` with `~/.deepseek` fallback (#2231).
-- **READMEs updated for the CodeWhale rename.** All three READMEs now
-  reference canonical `~/.codewhale` paths.
+- **Release hardening.** CI now runs clippy/docs checks, web frontend lint and
+  type checks, provider-registry drift checks, broader crate docs, and a large
+  unit-test pass across core, MCP, TUI core, app-server, and web helpers
+  (#2443, #2444, #2274, #2446-#2460, #2440, #2441, #2450, #2448, #2454).
+- **Prompt, context, and model routing behavior.** Stabilized project-context
+  pack ordering, exposed the auto route in turn metadata, allowed embedders to
+  override or inline constitutional instructions, moved volatile environment
+  context below the prompt boundary, and used the effective model for
+  compaction budgeting (#2418, #2410, #2356, #2311, #2314, #2437).
+- **Execution policy foundation.** Added typed ask-rule groundwork and kept
+  `task_shell_start` gated behind `allow_shell`, preparing the permission UI
+  path without broadening default shell access (#2404, #2384).
 
 ### Fixed
 
-- **Deadlock when spawning multiple concurrent sub-agents.** Replaced
-  `RwLock`-based serialisation with a `Semaphore(1)` (#1856).
-- **Steered/queued messages now render in correct transcript order.**
-  `steer_user_message` now flushes the active cell before inserting (#2225).
-- **Session save test updated for managed sessions directory.** (#2223).
-- **Loop guard reports Failed on halt.** Turn outcome correctly reports
-  `Failed` instead of `Completed` when the loop guard trips (#1859).
-- **DEEPSEEK_YOLO env honoured on startup.** The `--yolo` flag is now
-  correctly merged with the `DEEPSEEK_YOLO` environment variable (#1870).
+- **Windows and shell reliability.** Suppressed alt-screen logging on Windows,
+  added the Windows batch launcher path, kept task shell tools eagerly loaded,
+  loaded exec-shell companion tools consistently, covered controlling-terminal
+  behavior, and improved shell tool availability errors (#2259, #2295, #1861,
+  #2271, #2331, #2414, #2412).
+- **Session and transcript durability.** Fixed hidden-worktree discovery
+  saturation, stalled in-progress turn recovery, session persistence
+  truncation, cached-transcript user-message highlighting, large tool-output
+  receipting, session-detail block serialization, and deterministic composer
+  history flushing (#2273, #2329, #2283, #2395, #2386, #2297, #2265, #2375).
+- **Provider and UI polish.** Accepted custom model IDs in `/model` for
+  non-DeepSeek providers, fixed Feishu per-chat model switching, localized
+  context-menu labels, updated terminal tab naming, kept picker selections
+  visible, allowed slash-space composer messages, and improved PDF text
+  cleanup (#2280, #2149, #2320, #2319, #2324, #2316, #2266).
+- **Security and dependency hygiene.** Bumped `tar` and `qs`, trusted fake-IP
+  placeholder ranges only when explicitly configured, decoded Bing result URL
+  entities, fixed legacy MCP SSE connections, and replaced manual tool error
+  display code with `thiserror` derives (#2364, #2425, #2355, #2245, #2301,
+  #2442).
 
 ### Community
 
-Thanks to contributors whose PRs landed in this release:
-**@Fire-dtx** (#1856),
-**@imkingjh999** (#2228),
-**@harvey2011888** (#1859),
-**@victorcheng2333** (#1870),
-**@IIzzaya** (#1935),
-**@PurplePulse** (#1837),
-**@cyq1017** (#1967),
-**@knqiufan** (#1906).
+Thanks to contributors whose PRs landed or were harvested in this release:
+**@HUQIANTAO** (#2246, #2257, #2267, #2384, #2385, #2389, #2403, #2440-#2460),
+**@h3c-hexin** (#2311, #2313, #2314, #2354, #2355, #2356),
+**@reidliu41** (#2291, #2316, #2324, #2357, #2366, #2386, #2431),
+**@aboimpinto** (#2290, #2294, #2295, #2326, #2433),
+**@donglovejava** (#2302, #2329, #2330, #2331),
+**@cyq1017** (#2252, #2332, #2375),
+**@nightt5879** (#2274, #2344, #2347, #2373),
+**@idling11** (#2161, #2266, #2306),
+**@zlh124** (#2320, #2325),
+**@AresNing** (#2278, #2318/#2434),
+**@Implementist** (#2426/#2429, #2439),
+**@lihuan215** (#2333/#2430),
+**@AdityaVG13** (#2246),
+**@AiurArtanis** (#2270),
+**@Lee-take** (#2272),
+**@LeoAlex0** (#2388, #2395),
+**@gaord** (#2265, #2285),
+**@jimmyzhuu** (#2371),
+**@rockyzhang** (#2383),
+**@mo-vic** (#2387),
+**@hufanexplore** (#2367),
+**@hoclaptrinh33** (#2358),
+**@zhuangbiaowei** (#2301),
+**@axobase001** (#2296, #2297, #2298),
+**@Sskift** (#2248),
+**@AccMoment** (#2281),
+**@LING71671** (#2287, #2292),
+**@mvanhorn** (#2236),
+and **@encyc** (#2336, #2338).
+
+## [0.8.47] - 2026-05-26
+
+### Added
+
+- **Closed-loop verification gate, runtime goal tools, DuckDuckGo default
+  web search, Xiaomi MiMo, global AGENTS.md fallback, `/new`, composer
+  selection, transcript copy cleanup, CNB mirror support, and Docker toolbox
+  docs** shipped in the published v0.8.47 release.
+
+### Changed
+
+- **DeepSeek-first release framing, project-context logging, state-root
+  migration, CodeWhale README paths, and reasoning-locale behavior** were
+  finalized for the v0.8.47 release.
+
+### Fixed
+
+- **Provider picker scrolling, auto model restore, cache-inspect hashing,
+  insecure LAN provider guard, large tool-output compaction, queued-message
+  ordering, shell/Yolo startup handling, Windows alt-screen logging, and
+  tooltip contrast** were fixed in the v0.8.47 release.
+
+### Community
+
+Thanks to contributors credited in the v0.8.47 GitHub Release, including
+**@Fire-dtx**, **@imkingjh999**, **@harvey2011888**, **@victorcheng2333**,
+**@IIzzaya**, **@PurplePulse**, **@cyq1017**, **@knqiufan**,
+**@Colorful-glassblock**, **@hongqitai**, **@EmiyaKiritsugu3**,
+**@aboimpinto**, **@HUQIANTAO**, **@mvanhorn**, **@LING71671**, and
+**@reidliu41**.
 
 ## [0.8.46] - 2026-05-26
 
@@ -5018,7 +5097,9 @@ Welcome — and thank you.
 - Hooks system and config profiles
 - Example skills and launch assets
 
-[Unreleased]: https://github.com/Hmbown/CodeWhale/compare/v0.8.46...HEAD
+[Unreleased]: https://github.com/Hmbown/CodeWhale/compare/v0.8.48...HEAD
+[0.8.48]: https://github.com/Hmbown/CodeWhale/compare/v0.8.47...v0.8.48
+[0.8.47]: https://github.com/Hmbown/CodeWhale/compare/v0.8.46...v0.8.47
 [0.8.46]: https://github.com/Hmbown/CodeWhale/compare/v0.8.45...v0.8.46
 [0.8.45]: https://github.com/Hmbown/CodeWhale/compare/v0.8.44...v0.8.45
 [0.8.44]: https://github.com/Hmbown/CodeWhale/compare/v0.8.43...v0.8.44

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -27,11 +27,11 @@ path = "src/bin/deepseek_tui_legacy_shim.rs"
 [dependencies]
 anyhow = "1.0.100"
 arboard = "3.4"
-codewhale-config = { path = "../config", version = "0.8.46" }
-codewhale-protocol = { path = "../protocol", version = "0.8.46" }
-codewhale-release = { path = "../release", version = "0.8.46" }
-codewhale-secrets = { path = "../secrets", version = "0.8.46" }
-codewhale-tools = { path = "../tools", version = "0.8.46" }
+codewhale-config = { path = "../config", version = "0.8.48" }
+codewhale-protocol = { path = "../protocol", version = "0.8.48" }
+codewhale-release = { path = "../release", version = "0.8.48" }
+codewhale-secrets = { path = "../secrets", version = "0.8.48" }
+codewhale-tools = { path = "../tools", version = "0.8.48" }
 schemaui = { version = "0.12.0", default-features = false, optional = true }
 async-stream = "0.3.6"
 async-trait = "0.1"

--- a/npm/codewhale/package.json
+++ b/npm/codewhale/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codewhale",
-  "version": "0.8.46",
-  "codewhaleBinaryVersion": "0.8.46",
+  "version": "0.8.48",
+  "codewhaleBinaryVersion": "0.8.48",
   "description": "Install and run CodeWhale, the agentic terminal for open-source and open-weight coding models, from GitHub release artifacts.",
   "author": "Hmbown",
   "license": "MIT",

--- a/npm/deepseek-tui/package.json
+++ b/npm/deepseek-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepseek-tui",
-  "version": "0.8.46",
+  "version": "0.8.48",
   "description": "Legacy compatibility package. Renamed to `codewhale`; run `npm install -g codewhale` for new installs.",
   "author": "Hmbown",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- bump workspace, internal path dependency pins, npm wrappers, and Cargo.lock package versions to 0.8.48
- add v0.8.48 changelog notes with contributor credit for merged and harvested PRs
- backfill a concise v0.8.47 changelog marker so main reflects the published release lineage

## Verification
- cargo fmt --all --check
- scripts/release/check-versions.sh
- git diff --check HEAD~1..HEAD
- CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target/release-0.8.48 cargo build --release --locked -p codewhale-cli -p codewhale-tui
- built codewhale/codewhale-tui --version => 0.8.48 (6210914cc29f)
- offline smoke: model resolve/list for DeepSeek, Xiaomi MiMo, Arcee Trinity, and Qwen 3.7

No tag, GitHub Release, npm publish, or release artifacts are created in this PR.