### PR TITLE
Resolve qwen3.7 OpenRouter shorthand

### DIFF
--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -200,7 +200,13 @@ impl Default for ModelRegistry {
             ModelInfo {
                 id: "qwen/qwen3.7-max".to_string(),
                 provider: ProviderKind::Openrouter,
-                aliases: vec!["qwen3.7-max".to_string(), "qwen-3.7-max".to_string()],
+                aliases: vec![
+                    "qwen3.7".to_string(),
+                    "qwen-3.7".to_string(),
+                    "qwen3-7".to_string(),
+                    "qwen3.7-max".to_string(),
+                    "qwen-3.7-max".to_string(),
+                ],
                 supports_tools: true,
                 supports_reasoning: true,
             },
@@ -728,6 +734,7 @@ mod tests {
 
         for (alias, expected) in [
             ("trinity-large-thinking", "arcee-ai/trinity-large-thinking"),
+            ("qwen3.7", "qwen/qwen3.7-max"),
             ("qwen3.7-max", "qwen/qwen3.7-max"),
             ("qwen3.6-35b-a3b", "qwen/qwen3.6-35b-a3b"),
             ("gemma-4-31b-it", "google/gemma-4-31b-it"),

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1525,9 +1525,13 @@ fn canonical_openrouter_recent_model_id(model: &str) -> Option<&'static str> {
         OPENROUTER_NEMOTRON_3_NANO_OMNI_MODEL
         | "nemotron-3-nano-omni"
         | "nemotron-3-nano-omni-reasoning" => Some(OPENROUTER_NEMOTRON_3_NANO_OMNI_MODEL),
-        OPENROUTER_QWEN_3_7_MAX_MODEL | "qwen3.7-max" | "qwen-3.7-max" | "qwen3-7-max" => {
-            Some(OPENROUTER_QWEN_3_7_MAX_MODEL)
-        }
+        OPENROUTER_QWEN_3_7_MAX_MODEL
+        | "qwen3.7"
+        | "qwen-3.7"
+        | "qwen3-7"
+        | "qwen3.7-max"
+        | "qwen-3.7-max"
+        | "qwen3-7-max" => Some(OPENROUTER_QWEN_3_7_MAX_MODEL),
         OPENROUTER_QWEN_3_6_35B_A3B_MODEL
         | "qwen3.6-35b-a3b"
         | "qwen-3.6-35b-a3b"
@@ -3841,6 +3845,7 @@ unix_socket_path = "/tmp/cw-hooks.sock"
                 "trinity-large-thinking",
                 OPENROUTER_ARCEE_TRINITY_LARGE_THINKING_MODEL,
             ),
+            ("qwen3.7", OPENROUTER_QWEN_3_7_MAX_MODEL),
             ("qwen3.7-max", OPENROUTER_QWEN_3_7_MAX_MODEL),
             ("qwen3.6-35b-a3b", OPENROUTER_QWEN_3_6_35B_A3B_MODEL),
             ("mimo-v2.5-pro", OPENROUTER_XIAOMI_MIMO_V2_5_PRO_MODEL),

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -511,9 +511,13 @@ fn canonical_openrouter_recent_model_id(model: &str) -> Option<&'static str> {
         OPENROUTER_NEMOTRON_3_NANO_OMNI_MODEL
         | "nemotron-3-nano-omni"
         | "nemotron-3-nano-omni-reasoning" => Some(OPENROUTER_NEMOTRON_3_NANO_OMNI_MODEL),
-        OPENROUTER_QWEN_3_7_MAX_MODEL | "qwen3.7-max" | "qwen-3.7-max" | "qwen3-7-max" => {
-            Some(OPENROUTER_QWEN_3_7_MAX_MODEL)
-        }
+        OPENROUTER_QWEN_3_7_MAX_MODEL
+        | "qwen3.7"
+        | "qwen-3.7"
+        | "qwen3-7"
+        | "qwen3.7-max"
+        | "qwen-3.7-max"
+        | "qwen3-7-max" => Some(OPENROUTER_QWEN_3_7_MAX_MODEL),
         OPENROUTER_QWEN_3_6_35B_A3B_MODEL
         | "qwen3.6-35b-a3b"
         | "qwen-3.6-35b-a3b"
@@ -6230,6 +6234,7 @@ api_key = "old-openrouter-key"
                 "trinity-large-thinking",
                 OPENROUTER_ARCEE_TRINITY_LARGE_THINKING_MODEL,
             ),
+            ("qwen3.7", OPENROUTER_QWEN_3_7_MAX_MODEL),
             ("qwen3.7-max", OPENROUTER_QWEN_3_7_MAX_MODEL),
             ("qwen3.6-35b-a3b", OPENROUTER_QWEN_3_6_35B_A3B_MODEL),
             ("mimo-v2.5-pro", OPENROUTER_XIAOMI_MIMO_V2_5_PRO_MODEL),


### PR DESCRIPTION
## Summary\n- resolve qwen3.7/qwen-3.7/qwen3-7 to qwen/qwen3.7-max for the OpenRouter model registry\n- keep CLI, config, and TUI model normalization paths in sync\n\n## Verification\n- cargo fmt --check\n- cargo test -p codewhale-config openrouter_provider_normalizes_recent_large_model_aliases\n- cargo test -p codewhale-agent recent_openrouter_large_model_aliases_resolve_when_provider_hinted\n- cargo test -p codewhale-tui normalize_model_name_for_provider_maps_recent_openrouter_aliases\n- cargo run -p codewhale-cli --bin codewhale -- model resolve qwen3.7 --provider openrouter