### PR TITLE
fix(state): make fork migration parent links deterministic

### DIFF
--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -347,8 +347,15 @@ impl StateStore {
                     SET parent_entry_id = (
                         SELECT m2.id
                         FROM messages m2
-                        WHERE m2.created_at < messages.created_at AND m2.thread_id = messages.thread_id
-                        ORDER BY m2.id DESC
+                        WHERE m2.thread_id = messages.thread_id
+                            AND (
+                                m2.created_at < messages.created_at
+                                OR (
+                                    m2.created_at = messages.created_at
+                                    AND m2.id < messages.id
+                                )
+                            )
+                        ORDER BY m2.created_at DESC, m2.id DESC
                         LIMIT 1
                     );
                 CREATE INDEX idx_messages_parent_entry_id ON messages(parent_entry_id);

--- a/crates/state/tests/parity_state.rs
+++ b/crates/state/tests/parity_state.rs
@@ -117,7 +117,7 @@ fn init_schema_migration() {
         VALUES (
             'thread-test-1', 'hello', false, 'deepseek', 0, 0, 'running', '/tmp/project', '0.0.0-test', 'interactive', false
         );
-        INSERT INTO messages (thread_id, role, content, created_at) VALUES 
+        INSERT INTO messages (thread_id, role, content, created_at) VALUES
         ('thread-test-1', 'foo0', 'bar0', 0),
         ('thread-test-1', 'foo1', 'bar1', 1),
         ('thread-test-1', 'foo2', 'bar2', 2);
@@ -155,6 +155,76 @@ fn init_schema_migration() {
 
     // Test idempotent
     StateStore::open(Some(path.clone())).expect("open state store");
+}
+
+#[test]
+fn init_schema_migration_same_second_messages() {
+    let path = temp_state_path("init_schema_migration_same_second_messages");
+    let conn = Connection::open(&path).expect("open state db");
+    conn.execute_batch(
+        r#"
+        CREATE TABLE IF NOT EXISTS threads (
+            id TEXT PRIMARY KEY,
+            rollout_path TEXT,
+            preview TEXT NOT NULL,
+            ephemeral INTEGER NOT NULL,
+            model_provider TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            status TEXT NOT NULL,
+            path TEXT,
+            cwd TEXT NOT NULL,
+            cli_version TEXT NOT NULL,
+            source TEXT NOT NULL,
+            title TEXT,
+            sandbox_policy TEXT,
+            approval_mode TEXT,
+            archived INTEGER NOT NULL DEFAULT 0,
+            archived_at INTEGER,
+            git_sha TEXT,
+            git_branch TEXT,
+            git_origin_url TEXT,
+            memory_mode TEXT
+        );
+        CREATE TABLE IF NOT EXISTS messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            thread_id TEXT NOT NULL,
+            role TEXT NOT NULL,
+            content TEXT NOT NULL,
+            item_json TEXT,
+            created_at INTEGER NOT NULL,
+            FOREIGN KEY(thread_id) REFERENCES threads(id) ON DELETE CASCADE
+        );
+        INSERT INTO threads (
+            id, preview, ephemeral, model_provider, created_at, updated_at, status, cwd, cli_version, source, archived
+        )
+        VALUES (
+            'thread-test-2', 'hello', false, 'deepseek', 0, 0, 'running', '/tmp/project', '0.0.0-test', 'interactive', false
+        );
+        INSERT INTO messages (thread_id, role, content, created_at) VALUES
+            ('thread-test-2', 'foo0', 'bar0', 123),
+            ('thread-test-2', 'foo1', 'bar1', 123),
+            ('thread-test-2', 'foo2', 'bar2', 123),
+            ('thread-test-2', 'foo3', 'bar3', 123);
+        "#,
+    )
+    .expect("init schema migration");
+
+    let store = StateStore::open(Some(path.clone())).expect("open state store");
+    let messages = store
+        .list_messages("thread-test-2", None)
+        .expect("list messages");
+    assert_eq!(messages.len(), 4);
+    for (i, message) in messages.iter().enumerate() {
+        assert_eq!(message.thread_id, "thread-test-2");
+        assert_eq!(message.role, format!("foo{}", i));
+        assert_eq!(message.content, format!("bar{}", i));
+        assert_eq!(message.created_at, 123);
+    }
+    assert_eq!(messages[0].parent_entry_id, None);
+    assert_eq!(messages[1].parent_entry_id, Some(messages[0].id));
+    assert_eq!(messages[2].parent_entry_id, Some(messages[1].id));
+    assert_eq!(messages[3].parent_entry_id, Some(messages[2].id));
 }
 
 #[test]
@@ -278,6 +348,5 @@ fn test_fork() {
         .get_thread("thread-test-1")
         .expect("get thread")
         .unwrap();
-    dbg!(&thread);
     assert!(thread.current_leaf_id.is_none());
 }


### PR DESCRIPTION
## Problem

#2082's main fork support is already in place, but the follow-up review noted two remaining blockers: legacy migration can miss parent links when messages share the same second-level `created_at`, and `test_fork` still has a stray `dbg!(&thread)`.

## Change

- Reconstruct migrated `parent_entry_id` using `(created_at, id)` ordering, so same-second legacy messages keep deterministic parent links.
- Add a regression test for same-second legacy messages.
- Remove the stray debug print from `test_fork`.

Fixes #2082.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p codewhale-state --test parity_state --locked -- --nocapture`
- `cargo check -p codewhale-state --locked`
- `git diff --check HEAD~1..HEAD`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a determinism bug in the legacy schema migration: when multiple messages share the same `created_at` timestamp, the previous `ORDER BY m2.id DESC` without a matching `WHERE` filter could assign any preceding message as the parent rather than the immediately preceding one. The fix adds a compound `(created_at, id)` ordering to both the filter predicate and the `ORDER BY`, ensuring the parent link is always the closest lower-id message in the same second.

- **`crates/state/src/lib.rs`**: Updates the one-time migration UPDATE for `parent_entry_id` to use a composite `(created_at ASC, id ASC)` tiebreaker, fixing non-deterministic parent assignment for same-second messages.
- **`crates/state/tests/parity_state.rs`**: Adds `init_schema_migration_same_second_messages` to regression-test the four-message same-second scenario, and removes the stray `dbg!(&thread)` from `test_fork`.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the migration SQL fix is logically correct and the new regression test validates the happy path.

The composite (created_at, id) predicate and ORDER BY correctly handle same-second messages, and the recursive list_messages CTE will walk the resulting parent chain in the right order. The only gap is that the new test skips the idempotency re-open check that the existing migration test performs, so a double-ALTER regression on an already-migrated database would not be caught by this test alone.

crates/state/tests/parity_state.rs — the new test would benefit from an idempotency re-open check mirroring the one in init_schema_migration.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/state/src/lib.rs | One-time migration SQL updated with correct composite (created_at, id) filter and ORDER BY for deterministic parent link assignment; logic is sound. |
| crates/state/tests/parity_state.rs | New regression test covers same-second message ordering; idempotency re-open check present in original test is omitted here, and thread current_leaf_id is not asserted. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[StateStore::open - user_version = 0] --> B[Run migration SQL]
    B --> C[ALTER TABLE messages\nADD COLUMN parent_entry_id]
    C --> D{For each message M\nin thread}
    D --> E["Find predecessor:\nm2.created_at < M.created_at\nOR\n(m2.created_at = M.created_at AND m2.id < M.id)"]
    E --> F["ORDER BY m2.created_at DESC, m2.id DESC\nLIMIT 1"]
    F --> G[SET parent_entry_id = m2.id or NULL if no predecessor]
    G --> D
    D --> H[CREATE INDEX idx_messages_parent_entry_id]
    H --> I[UPDATE threads SET current_leaf_id = highest message id per thread]
    I --> J[PRAGMA user_version = 1]
    J --> K[Migration complete]
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22codex%2Ffix-2082-fork-migration%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Ffix-2082-fork-migration%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Fstate%2Ftests%2Fparity_state.rs%3A224-227%0A**Missing%20idempotency%20re-open%20check**%0A%0AThe%20original%20%60init_schema_migration%60%20test%20ends%20with%20a%20second%20%60StateStore%3A%3Aopen%60%20call%20to%20verify%20the%20migration%20is%20safe%20to%20run%20on%20an%20already-migrated%20database.%20The%20new%20same-second%20test%20omits%20this%20step%2C%20so%20a%20regression%20where%20re-opening%20a%20migrated%20store%20causes%20a%20double-%60ALTER%20TABLE%60%20or%20index%20conflict%20would%20not%20be%20caught%20here.%20Adding%20%60StateStore%3A%3Aopen%28Some%28path.clone%28%29%29%29.expect%28%22open%20state%20store%20-%20idempotent%22%29%3B%60%20after%20the%20assertions%20would%20close%20this%20gap.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Fstate%2Ftests%2Fparity_state.rs%3A224-227%0A**Missing%20idempotency%20re-open%20check**%0A%0AThe%20original%20%60init_schema_migration%60%20test%20ends%20with%20a%20second%20%60StateStore%3A%3Aopen%60%20call%20to%20verify%20the%20migration%20is%20safe%20to%20run%20on%20an%20already-migrated%20database.%20The%20new%20same-second%20test%20omits%20this%20step%2C%20so%20a%20regression%20where%20re-opening%20a%20migrated%20store%20causes%20a%20double-%60ALTER%20TABLE%60%20or%20index%20conflict%20would%20not%20be%20caught%20here.%20Adding%20%60StateStore%3A%3Aopen%28Some%28path.clone%28%29%29%29.expect%28%22open%20state%20store%20-%20idempotent%22%29%3B%60%20after%20the%20assertions%20would%20close%20this%20gap.%0A%0A&repo=hmbown%2Fcodewhale&pr=2476&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Fstate%2Ftests%2Fparity_state.rs%3A224-227%0A**Missing%20idempotency%20re-open%20check**%0A%0AThe%20original%20%60init_schema_migration%60%20test%20ends%20with%20a%20second%20%60StateStore%3A%3Aopen%60%20call%20to%20verify%20the%20migration%20is%20safe%20to%20run%20on%20an%20already-migrated%20database.%20The%20new%20same-second%20test%20omits%20this%20step%2C%20so%20a%20regression%20where%20re-opening%20a%20migrated%20store%20causes%20a%20double-%60ALTER%20TABLE%60%20or%20index%20conflict%20would%20not%20be%20caught%20here.%20Adding%20%60StateStore%3A%3Aopen%28Some%28path.clone%28%29%29%29.expect%28%22open%20state%20store%20-%20idempotent%22%29%3B%60%20after%20the%20assertions%20would%20close%20this%20gap.%0A%0A&pr=2476&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(state): stabilize fork migration par..."](https://github.com/hmbown/codewhale/commit/cb22c7b70b1eaefd93fd6404dbfb08d6edd03a43) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34843271)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->