### PR TITLE
refs(#2264): harden PrefixFingerprint with full tool JSON hash

### DIFF
--- a/crates/tui/src/prefix_cache.rs
+++ b/crates/tui/src/prefix_cache.rs
@@ -51,18 +51,18 @@ pub struct PrefixFingerprint {
 impl PrefixFingerprint {
     /// Compute a fingerprint from system prompt text and tool list.
     ///
-    /// Tools are serialized to JSON (name + description + schema), sorted
-    /// by name for deterministic ordering, then SHA-256 hashed. This
-    /// catches schema/description drift, not just name changes (#2264).
+    /// Tools are serialized to the same JSON shape the chat API receives
+    /// (`type`, `name`, `description`, `parameters`, `strict`), sorted
+    /// lexicographically by JSON text, then SHA-256 hashed. This catches
+    /// schema/description drift that actually affects the API prefix,
+    /// while ignoring internal-only fields like `allowed_callers` (#2264).
     pub fn compute(system_text: &str, tools: Option<&[Tool]>) -> Self {
         let system_sha256 = sha256_hex(system_text.as_bytes());
 
         let tools_sha256 = match tools {
             Some(tools) if !tools.is_empty() => {
-                let mut serialized: Vec<String> = tools
-                    .iter()
-                    .filter_map(|t| serde_json::to_string(t).ok())
-                    .collect();
+                let mut serialized: Vec<String> =
+                    tools.iter().filter_map(tool_to_api_json).collect();
                 serialized.sort();
                 let joined = serialized.join("\n");
                 sha256_hex(joined.as_bytes())
@@ -308,6 +308,26 @@ impl PrefixStabilityManager {
             changes = self.change_count,
         )
     }
+}
+
+/// Serialize a tool to the same JSON shape the chat API receives,
+/// excluding internal-only fields like `allowed_callers`, `defer_loading`,
+/// `input_examples`, and `cache_control` that are never sent to DeepSeek.
+fn tool_to_api_json(tool: &Tool) -> Option<String> {
+    let mut value = serde_json::json!({
+        "type": "function",
+        "function": {
+            "name": tool.name,
+            "description": tool.description,
+            "parameters": tool.input_schema,
+        }
+    });
+    if let Some(strict) = tool.strict
+        && let Some(function) = value.get_mut("function")
+    {
+        function["strict"] = serde_json::json!(strict);
+    }
+    serde_json::to_string(&value).ok()
 }
 
 /// Compute the SHA-256 hex digest of a byte slice.

--- a/crates/tui/src/prefix_cache.rs
+++ b/crates/tui/src/prefix_cache.rs
@@ -42,7 +42,7 @@ use crate::models::{SystemPrompt, Tool};
 pub struct PrefixFingerprint {
     /// SHA-256 of the system prompt text.
     pub system_sha256: String,
-    /// SHA-256 of the concatenated, sorted tool names.
+    /// SHA-256 of the full tool catalog JSON (names, descriptions, schemas).
     pub tools_sha256: String,
     /// SHA-256 of system_sha256 ++ tools_sha256 (combined).
     pub combined_sha256: String,
@@ -50,16 +50,21 @@ pub struct PrefixFingerprint {
 
 impl PrefixFingerprint {
     /// Compute a fingerprint from system prompt text and tool list.
+    ///
+    /// Tools are serialized to JSON (name + description + schema), sorted
+    /// by name for deterministic ordering, then SHA-256 hashed. This
+    /// catches schema/description drift, not just name changes (#2264).
     pub fn compute(system_text: &str, tools: Option<&[Tool]>) -> Self {
         let system_sha256 = sha256_hex(system_text.as_bytes());
 
         let tools_sha256 = match tools {
             Some(tools) if !tools.is_empty() => {
-                // Sort tool names deterministically so the hash is
-                // stable regardless of registration order.
-                let mut tool_names: Vec<&str> = tools.iter().map(|t| t.name.as_str()).collect();
-                tool_names.sort();
-                let joined = tool_names.join(",");
+                let mut serialized: Vec<String> = tools
+                    .iter()
+                    .filter_map(|t| serde_json::to_string(t).ok())
+                    .collect();
+                serialized.sort();
+                let joined = serialized.join("\n");
                 sha256_hex(joined.as_bytes())
             }
             _ => sha256_hex(b""),
@@ -487,6 +492,19 @@ mod tests {
         assert!(mgr.check_and_update("hello", None).unwrap());
         assert!(mgr.pinned_fingerprint().is_some());
         assert_eq!(mgr.check_count(), 1);
+    }
+
+    #[test]
+    fn fingerprint_detects_schema_change_not_just_name_change() {
+        let tool_a = make_tool("my_tool");
+        let mut tool_a_v2 = make_tool("my_tool");
+        tool_a_v2.description = "updated description".to_string();
+
+        let a = PrefixFingerprint::compute("system", Some(&[tool_a]));
+        let b = PrefixFingerprint::compute("system", Some(&[tool_a_v2]));
+        // Same name, different description — must produce different hash.
+        assert_ne!(a.tools_sha256, b.tools_sha256);
+        assert_ne!(a.combined_sha256, b.combined_sha256);
     }
 
     #[test]


### PR DESCRIPTION
Refs #2264 (Phase 1.5 — conservative path).

## Summary

Upgrades `PrefixFingerprint::compute()` to hash the full tool JSON
serialization (name + description + input_schema) instead of just
tool names. Follows the same `tool_catalog_digest` approach from
the Phase 1 `prompt_zones` module.

Before: tool hash = `SHA-256("read_file,write_file")`
After:  tool hash = `SHA-256(joined sorted JSON blobs)`

## What changed

- `PrefixFingerprint::compute()`: serialize each tool via `serde_json::to_string`,
  sort by JSON text for deterministic ordering, join with `\n`
- Doc comment updated on `tools_sha256` field
- New test: `fingerprint_detects_schema_change_not_just_name_change`
  — verifies that changing a tool's description produces a different hash

## Files
| File | Change |
|---|---|
| `crates/tui/src/prefix_cache.rs` | +24 / −6 |

## Testing
- 21 prefix_cache tests pass (21/21)
- New test confirms schema change detection

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hardens `PrefixFingerprint::compute()` by replacing the tool-name-only hash with a hash over the full API-shaped tool JSON (name + description + input_schema + strict), catching schema and description drift that the old approach missed. A new private helper `tool_to_api_json` mirrors the structure of `tool_to_chat` in the client layer, and a new test confirms that changing a tool's description produces a different `tools_sha256`.

- `PrefixFingerprint::compute()` now sorts and hashes full serialized tool JSON blobs instead of just joined tool names, consistent with the `tool_catalog_digest` pattern in `prompt_zones`.
- `tool_to_api_json` intentionally excludes internal-only fields (`allowed_callers`, `defer_loading`, `input_examples`, `cache_control`) that are stripped before the API call.
- The helper does not apply the `to_api_tool_name()` encoding used by `tool_to_chat`; for tools whose names contain special characters the fingerprint JSON and wire JSON differ, though drift detection remains correct because the encoding is injective.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the change is additive and all 21 existing prefix_cache tests continue to pass alongside the new schema-change detection test.

The core drift-detection logic is correct: because to_api_tool_name is an injective transformation, hashing raw tool names still detects every change that would affect the wire bytes. The only finding is a doc comment that overstates the fidelity of the serialisation; it does not affect runtime behaviour.

No files require special attention beyond the documentation note on tool_to_api_json.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/prefix_cache.rs | Upgrades PrefixFingerprint::compute() to hash full tool JSON (name + description + input_schema) via a new tool_to_api_json helper, adds a test verifying schema-change detection; tool name is serialised raw rather than through to_api_tool_name(), so the fingerprint bytes diverge from the actual wire bytes for tools with special characters in their names. |

</details>

</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22pref%2Fprefix-full-tool-hash%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22pref%2Fprefix-full-tool-hash%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fprefix_cache.rs%3A313-320%0AThe%20doc%20comment%20says%20the%20function%20serialises%20tools%20%22to%20the%20same%20JSON%20shape%20the%20chat%20API%20receives%2C%22%20but%20it%20uses%20%60tool.name%60%20directly%20while%20the%20real%20wire%20path%20%28%60tool_to_chat%60%20in%20%60client%2Fchat.rs%60%29%20first%20passes%20the%20name%20through%20%60to_api_tool_name%28%29%60.%20For%20any%20tool%20whose%20name%20contains%20dots%2C%20hyphens%2C%20or%20other%20non-alphanumeric%2Fnon-underscore%20characters%20%28e.g.%2C%20%60web.run%60%20%E2%86%92%20%60web-x00002E-run%60%29%2C%20the%20fingerprint%20JSON%20and%20the%20actual%20API%20JSON%20diverge.%20Drift%20detection%20still%20works%20correctly%20because%20%60to_api_tool_name%60%20is%20injective%2C%20but%20the%20comment%20overpromises%20and%20the%20fingerprint%20does%20not%20hash%20the%20exact%20bytes%20that%20reach%20DeepSeek.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20Serialize%20a%20tool%20to%20an%20API-shaped%20JSON%20blob%20for%20fingerprinting.%0A%2F%2F%2F%20Covers%20the%20fields%20that%20reach%20DeepSeek%20%28name%2C%20description%2C%20parameters%2C%0A%2F%2F%2F%20strict%29%20while%20excluding%20internal-only%20fields%20like%20%60allowed_callers%60%2C%0A%2F%2F%2F%20%60defer_loading%60%2C%20%60input_examples%60%2C%20and%20%60cache_control%60.%0A%2F%2F%2F%0A%2F%2F%2F%20Note%3A%20the%20name%20is%20hashed%20as%20the%20internal%20CodeWhale%20name%2C%20not%20the%0A%2F%2F%2F%20wire-encoded%20form%20produced%20by%20%60to_api_tool_name%60.%20Drift%20detection%0A%2F%2F%2F%20remains%20correct%20because%20that%20encoding%20is%20injective.%0Afn%20tool_to_api_json%28tool%3A%20%26Tool%29%20-%3E%20Option%3CString%3E%20%7B%0A%20%20%20%20let%20mut%20value%20%3D%20serde_json%3A%3Ajson!%28%7B%0A%20%20%20%20%20%20%20%20%22type%22%3A%20%22function%22%2C%0A%20%20%20%20%20%20%20%20%22function%22%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22name%22%3A%20tool.name%2C%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fprefix_cache.rs%3A313-320%0AThe%20doc%20comment%20says%20the%20function%20serialises%20tools%20%22to%20the%20same%20JSON%20shape%20the%20chat%20API%20receives%2C%22%20but%20it%20uses%20%60tool.name%60%20directly%20while%20the%20real%20wire%20path%20%28%60tool_to_chat%60%20in%20%60client%2Fchat.rs%60%29%20first%20passes%20the%20name%20through%20%60to_api_tool_name%28%29%60.%20For%20any%20tool%20whose%20name%20contains%20dots%2C%20hyphens%2C%20or%20other%20non-alphanumeric%2Fnon-underscore%20characters%20%28e.g.%2C%20%60web.run%60%20%E2%86%92%20%60web-x00002E-run%60%29%2C%20the%20fingerprint%20JSON%20and%20the%20actual%20API%20JSON%20diverge.%20Drift%20detection%20still%20works%20correctly%20because%20%60to_api_tool_name%60%20is%20injective%2C%20but%20the%20comment%20overpromises%20and%20the%20fingerprint%20does%20not%20hash%20the%20exact%20bytes%20that%20reach%20DeepSeek.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20Serialize%20a%20tool%20to%20an%20API-shaped%20JSON%20blob%20for%20fingerprinting.%0A%2F%2F%2F%20Covers%20the%20fields%20that%20reach%20DeepSeek%20%28name%2C%20description%2C%20parameters%2C%0A%2F%2F%2F%20strict%29%20while%20excluding%20internal-only%20fields%20like%20%60allowed_callers%60%2C%0A%2F%2F%2F%20%60defer_loading%60%2C%20%60input_examples%60%2C%20and%20%60cache_control%60.%0A%2F%2F%2F%0A%2F%2F%2F%20Note%3A%20the%20name%20is%20hashed%20as%20the%20internal%20CodeWhale%20name%2C%20not%20the%0A%2F%2F%2F%20wire-encoded%20form%20produced%20by%20%60to_api_tool_name%60.%20Drift%20detection%0A%2F%2F%2F%20remains%20correct%20because%20that%20encoding%20is%20injective.%0Afn%20tool_to_api_json%28tool%3A%20%26Tool%29%20-%3E%20Option%3CString%3E%20%7B%0A%20%20%20%20let%20mut%20value%20%3D%20serde_json%3A%3Ajson!%28%7B%0A%20%20%20%20%20%20%20%20%22type%22%3A%20%22function%22%2C%0A%20%20%20%20%20%20%20%20%22function%22%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22name%22%3A%20tool.name%2C%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2477&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fprefix_cache.rs%3A313-320%0AThe%20doc%20comment%20says%20the%20function%20serialises%20tools%20%22to%20the%20same%20JSON%20shape%20the%20chat%20API%20receives%2C%22%20but%20it%20uses%20%60tool.name%60%20directly%20while%20the%20real%20wire%20path%20%28%60tool_to_chat%60%20in%20%60client%2Fchat.rs%60%29%20first%20passes%20the%20name%20through%20%60to_api_tool_name%28%29%60.%20For%20any%20tool%20whose%20name%20contains%20dots%2C%20hyphens%2C%20or%20other%20non-alphanumeric%2Fnon-underscore%20characters%20%28e.g.%2C%20%60web.run%60%20%E2%86%92%20%60web-x00002E-run%60%29%2C%20the%20fingerprint%20JSON%20and%20the%20actual%20API%20JSON%20diverge.%20Drift%20detection%20still%20works%20correctly%20because%20%60to_api_tool_name%60%20is%20injective%2C%20but%20the%20comment%20overpromises%20and%20the%20fingerprint%20does%20not%20hash%20the%20exact%20bytes%20that%20reach%20DeepSeek.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20Serialize%20a%20tool%20to%20an%20API-shaped%20JSON%20blob%20for%20fingerprinting.%0A%2F%2F%2F%20Covers%20the%20fields%20that%20reach%20DeepSeek%20%28name%2C%20description%2C%20parameters%2C%0A%2F%2F%2F%20strict%29%20while%20excluding%20internal-only%20fields%20like%20%60allowed_callers%60%2C%0A%2F%2F%2F%20%60defer_loading%60%2C%20%60input_examples%60%2C%20and%20%60cache_control%60.%0A%2F%2F%2F%0A%2F%2F%2F%20Note%3A%20the%20name%20is%20hashed%20as%20the%20internal%20CodeWhale%20name%2C%20not%20the%0A%2F%2F%2F%20wire-encoded%20form%20produced%20by%20%60to_api_tool_name%60.%20Drift%20detection%0A%2F%2F%2F%20remains%20correct%20because%20that%20encoding%20is%20injective.%0Afn%20tool_to_api_json%28tool%3A%20%26Tool%29%20-%3E%20Option%3CString%3E%20%7B%0A%20%20%20%20let%20mut%20value%20%3D%20serde_json%3A%3Ajson!%28%7B%0A%20%20%20%20%20%20%20%20%22type%22%3A%20%22function%22%2C%0A%20%20%20%20%20%20%20%20%22function%22%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22name%22%3A%20tool.name%2C%0A%60%60%60%0A%0A&pr=2477&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix: hash only API-visible tool fields, ..."](https://github.com/hmbown/codewhale/commit/60511c723c33372a1a2b2504c8233d527ba0762c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34846323)</sub>

<!-- /greptile_comment -->