### PR TITLE
feat(config): collapse ProviderKind/ApiProvider dual enums behind Provider trait

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod provider;
+
 use std::collections::BTreeMap;
 use std::fs;
 #[cfg(unix)]
@@ -188,6 +190,12 @@ impl ProviderKind {
     #[must_use]
     pub fn is_siliconflow(self) -> bool {
         matches!(self, Self::Siliconflow | Self::SiliconflowCN)
+    }
+
+    /// Return the concrete [`provider::Provider`] trait object for this provider kind.
+    #[must_use]
+    pub fn provider(self) -> &'static dyn provider::Provider {
+        provider::resolve_provider(self.as_str()).unwrap_or_else(provider::default_provider)
     }
 }
 

--- a/crates/config/src/provider.rs
+++ b/crates/config/src/provider.rs
@@ -1,0 +1,907 @@
+//! Provider trait and concrete provider implementations.
+//!
+//! Each provider is a zero-sized struct that implements [`Provider`].
+//! The global [`PROVIDER_REGISTRY`] maps canonical provider ids to trait objects.
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+use serde::Serialize;
+use serde_json::Value;
+
+// ---------------------------------------------------------------------------
+// Wire format
+// ---------------------------------------------------------------------------
+
+/// Which wire protocol the provider speaks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WireFormat {
+    /// OpenAI-compatible `/v1/chat/completions` (Bearer auth).
+    ChatCompletions,
+    /// Anthropic Messages API `/v1/messages` (`x-api-key` auth).
+    AnthropicMessages,
+}
+
+// ---------------------------------------------------------------------------
+// Provider trait
+// ---------------------------------------------------------------------------
+
+/// A model provider — its identity, defaults, wire format, and per-provider
+/// behaviour such as reasoning-effort mapping.
+///
+/// Implementations are zero-sized structs registered in [`PROVIDER_REGISTRY`].
+pub trait Provider: Send + Sync {
+    /// Canonical identifier (e.g. `"deepseek"`, `"openrouter"`).
+    fn id(&self) -> &'static str;
+
+    /// Human-readable label for UIs / status chips.
+    fn display_name(&self) -> &'static str;
+
+    /// Default base URL when none is configured.
+    fn default_base_url(&self) -> &'static str;
+
+    /// Environment variable names that supply the API key for this provider.
+    fn env_vars(&self) -> &[&'static str];
+
+    /// Default model when the user has not picked one.
+    fn default_model(&self) -> &'static str;
+
+    /// Which wire format this provider speaks.
+    fn wire(&self) -> WireFormat;
+
+    /// Key used in `[providers.<key>]` TOML sections.
+    fn provider_config_key(&self) -> &'static str;
+
+    /// Whether the provider supports thinking / reasoning mode.
+    fn thinking_supported(&self) -> bool {
+        false
+    }
+
+    /// Whether the provider returns prompt-cache telemetry fields.
+    fn cache_telemetry_supported(&self) -> bool {
+        false
+    }
+
+    /// Apply per-provider reasoning-effort fields to the outgoing request body.
+    fn apply_reasoning_effort(&self, body: &mut Value, effort: Option<&str>);
+}
+
+// ---------------------------------------------------------------------------
+// Concrete providers
+// ---------------------------------------------------------------------------
+
+macro_rules! wire {
+    (chat_completions) => {
+        WireFormat::ChatCompletions
+    };
+}
+
+// --- DeepSeek ---
+
+pub struct Deepseek;
+
+impl Provider for Deepseek {
+    fn id(&self) -> &'static str {
+        "deepseek"
+    }
+    fn display_name(&self) -> &'static str {
+        "DeepSeek"
+    }
+    fn default_base_url(&self) -> &'static str {
+        "https://api.deepseek.com/beta"
+    }
+    fn env_vars(&self) -> &[&'static str] {
+        &["DEEPSEEK_API_KEY"]
+    }
+    fn default_model(&self) -> &'static str {
+        "deepseek-v4-pro"
+    }
+    fn wire(&self) -> WireFormat {
+        wire!(chat_completions)
+    }
+    fn provider_config_key(&self) -> &'static str {
+        "deepseek"
+    }
+    fn thinking_supported(&self) -> bool {
+        true
+    }
+    fn cache_telemetry_supported(&self) -> bool {
+        true
+    }
+    fn apply_reasoning_effort(&self, body: &mut Value, effort: Option<&str>) {
+        let Some(effort) = effort else { return };
+        let normalized = effort.trim().to_ascii_lowercase();
+        match normalized.as_str() {
+            "off" | "disabled" | "none" | "false" => {
+                body["thinking"] = serde_json::json!({"type": "disabled"});
+            }
+            "low" | "minimal" | "medium" | "mid" | "high" | "" => {
+                body["reasoning_effort"] = serde_json::json!("high");
+                body["thinking"] = serde_json::json!({"type": "enabled"});
+            }
+            "xhigh" | "max" | "highest" => {
+                body["reasoning_effort"] = serde_json::json!("max");
+                body["thinking"] = serde_json::json!({"type": "enabled"});
+            }
+            _ => {}
+        }
+    }
+}
+
+// --- NVIDIA NIM ---
+
+pub struct NvidiaNim;
+
+impl Provider for NvidiaNim {
+    fn id(&self) -> &'static str {
+        "nvidia-nim"
+    }
+    fn display_name(&self) -> &'static str {
+        "NVIDIA NIM"
+    }
+    fn default_base_url(&self) -> &'static str {
+        "https://integrate.api.nvidia.com/v1"
+    }
+    fn env_vars(&self) -> &[&'static str] {
+        &["NVIDIA_API_KEY", "NVIDIA_NIM_API_KEY", "DEEPSEEK_API_KEY"]
+    }
+    fn default_model(&self) -> &'static str {
+        "deepseek-ai/deepseek-v4-pro"
+    }
+    fn wire(&self) -> WireFormat {
+        wire!(chat_completions)
+    }
+    fn provider_config_key(&self) -> &'static str {
+        "nvidia_nim"
+    }
+    fn thinking_supported(&self) -> bool {
+        true
+    }
+    fn cache_telemetry_supported(&self) -> bool {
+        true
+    }
+    fn apply_reasoning_effort(&self, body: &mut Value, effort: Option<&str>) {
+        let Some(effort) = effort else { return };
+        let normalized = effort.trim().to_ascii_lowercase();
+        match normalized.as_str() {
+            "off" | "disabled" | "none" | "false" => {
+                body["chat_template_kwargs"] = serde_json::json!({"thinking": false});
+            }
+            "low" | "minimal" | "medium" | "mid" | "high" | "" => {
+                body["chat_template_kwargs"] = serde_json::json!({
+                    "thinking": true,
+                    "reasoning_effort": "high",
+                });
+            }
+            "xhigh" | "max" | "highest" => {
+                body["chat_template_kwargs"] = serde_json::json!({
+                    "thinking": true,
+                    "reasoning_effort": "max",
+                });
+            }
+            _ => {}
+        }
+    }
+}
+
+// --- OpenAI-compatible ---
+
+pub struct Openai;
+
+impl Provider for Openai {
+    fn id(&self) -> &'static str {
+        "openai"
+    }
+    fn display_name(&self) -> &'static str {
+        "OpenAI-compatible"
+    }
+    fn default_base_url(&self) -> &'static str {
+        "https://api.openai.com/v1"
+    }
+    fn env_vars(&self) -> &[&'static str] {
+        &["OPENAI_API_KEY"]
+    }
+    fn default_model(&self) -> &'static str {
+        "deepseek-v4-pro"
+    }
+    fn wire(&self) -> WireFormat {
+        wire!(chat_completions)
+    }
+    fn provider_config_key(&self) -> &'static str {
+        "openai"
+    }
+    fn apply_reasoning_effort(&self, _body: &mut Value, _effort: Option<&str>) {
+        // No-op: reasoning effort is not supported.
+    }
+}
+
+// --- AtlasCloud ---
+
+pub struct Atlascloud;
+
+impl Provider for Atlascloud {
+    fn id(&self) -> &'static str {
+        "atlascloud"
+    }
+    fn display_name(&self) -> &'static str {
+        "AtlasCloud"
+    }
+    fn default_base_url(&self) -> &'static str {
+        "https://api.atlascloud.ai/v1"
+    }
+    fn env_vars(&self) -> &[&'static str] {
+        &["ATLASCLOUD_API_KEY"]
+    }
+    fn default_model(&self) -> &'static str {
+        "deepseek-ai/deepseek-v4-flash"
+    }
+    fn wire(&self) -> WireFormat {
+        wire!(chat_completions)
+    }
+    fn provider_config_key(&self) -> &'static str {
+        "atlascloud"
+    }
+    fn apply_reasoning_effort(&self, _body: &mut Value, _effort: Option<&str>) {}
+}
+
+// --- Wanjie Ark ---
+
+pub struct WanjieArk;
+
+impl Provider for WanjieArk {
+    fn id(&self) -> &'static str {
+        "wanjie-ark"
+    }
+    fn display_name(&self) -> &'static str {
+        "Wanjie Ark"
+    }
+    fn default_base_url(&self) -> &'static str {
+        "https://maas-openapi.wanjiedata.com/api/v1"
+    }
+    fn env_vars(&self) -> &[&'static str] {
+        &[
+            "WANJIE_ARK_API_KEY",
+            "WANJIE_API_KEY",
+            "WANJIE_MAAS_API_KEY",
+        ]
+    }
+    fn default_model(&self) -> &'static str {
+        "deepseek-reasoner"
+    }
+    fn wire(&self) -> WireFormat {
+        wire!(chat_completions)
+    }
+    fn provider_config_key(&self) -> &'static str {
+        "wanjie_ark"
+    }
+    fn apply_reasoning_effort(&self, _body: &mut Value, _effort: Option<&str>) {}
+}
+
+// --- OpenRouter ---
+
+pub struct Openrouter;
+
+impl Provider for Openrouter {
+    fn id(&self) -> &'static str {
+        "openrouter"
+    }
+    fn display_name(&self) -> &'static str {
+        "OpenRouter"
+    }
+    fn default_base_url(&self) -> &'static str {
+        "https://openrouter.ai/api/v1"
+    }
+    fn env_vars(&self) -> &[&'static str] {
+        &["OPENROUTER_API_KEY"]
+    }
+    fn default_model(&self) -> &'static str {
+        "deepseek/deepseek-v4-pro"
+    }
+    fn wire(&self) -> WireFormat {
+        wire!(chat_completions)
+    }
+    fn provider_config_key(&self) -> &'static str {
+        "openrouter"
+    }
+    fn thinking_supported(&self) -> bool {
+        true
+    }
+    fn apply_reasoning_effort(&self, body: &mut Value, effort: Option<&str>) {
+        let Some(effort) = effort else { return };
+        let normalized = effort.trim().to_ascii_lowercase();
+        match normalized.as_str() {
+            "off" | "disabled" | "none" | "false" => {
+                body["thinking"] = serde_json::json!({"type": "disabled"});
+            }
+            "low" | "minimal" | "medium" | "mid" | "high" | "" => {
+                let value = match normalized.as_str() {
+                    "low" | "minimal" => "low",
+                    "medium" | "mid" => "medium",
+                    _ => "high",
+                };
+                body["reasoning_effort"] = serde_json::json!(value);
+                body["thinking"] = serde_json::json!({"type": "enabled"});
+            }
+            "xhigh" | "max" | "highest" => {
+                body["reasoning_effort"] = serde_json::json!("xhigh");
+                body["thinking"] = serde_json::json!({"type": "enabled"});
+            }
+            _ => {}
+        }
+    }
+}
+
+// --- Novita ---
+
+pub struct Novita;
+
+impl Provider for Novita {
+    fn id(&self) -> &'static str {
+        "novita"
+    }
+    fn display_name(&self) -> &'static str {
+        "Novita AI"
+    }
+    fn default_base_url(&self) -> &'static str {
+        "https://api.novita.ai/v1"
+    }
+    fn env_vars(&self) -> &[&'static str] {
+        &["NOVITA_API_KEY"]
+    }
+    fn default_model(&self) -> &'static str {
+        "deepseek/deepseek-v4-pro"
+    }
+    fn wire(&self) -> WireFormat {
+        wire!(chat_completions)
+    }
+    fn provider_config_key(&self) -> &'static str {
+        "novita"
+    }
+    fn thinking_supported(&self) -> bool {
+        true
+    }
+    fn apply_reasoning_effort(&self, body: &mut Value, effort: Option<&str>) {
+        // Same behaviour as OpenRouter.
+        Openrouter.apply_reasoning_effort(body, effort);
+    }
+}
+
+// --- Fireworks ---
+
+pub struct Fireworks;
+
+impl Provider for Fireworks {
+    fn id(&self) -> &'static str {
+        "fireworks"
+    }
+    fn display_name(&self) -> &'static str {
+        "Fireworks AI"
+    }
+    fn default_base_url(&self) -> &'static str {
+        "https://api.fireworks.ai/inference/v1"
+    }
+    fn env_vars(&self) -> &[&'static str] {
+        &["FIREWORKS_API_KEY"]
+    }
+    fn default_model(&self) -> &'static str {
+        "accounts/fireworks/models/deepseek-v4-pro"
+    }
+    fn wire(&self) -> WireFormat {
+        wire!(chat_completions)
+    }
+    fn provider_config_key(&self) -> &'static str {
+        "fireworks"
+    }
+    fn apply_reasoning_effort(&self, body: &mut Value, effort: Option<&str>) {
+        let Some(effort) = effort else { return };
+        let normalized = effort.trim().to_ascii_lowercase();
+        match normalized.as_str() {
+            "off" | "disabled" | "none" | "false" => {
+                // no-op
+            }
+            "low" | "minimal" | "medium" | "mid" | "high" | "" => {
+                body["reasoning_effort"] = serde_json::json!("high");
+            }
+            "xhigh" | "max" | "highest" => {
+                body["reasoning_effort"] = serde_json::json!("max");
+            }
+            _ => {}
+        }
+    }
+}
+
+// --- Moonshot / Kimi ---
+
+pub struct Moonshot;
+
+impl Provider for Moonshot {
+    fn id(&self) -> &'static str {
+        "moonshot"
+    }
+    fn display_name(&self) -> &'static str {
+        "Moonshot/Kimi"
+    }
+    fn default_base_url(&self) -> &'static str {
+        "https://api.moonshot.ai/v1"
+    }
+    fn env_vars(&self) -> &[&'static str] {
+        &["MOONSHOT_API_KEY", "KIMI_API_KEY"]
+    }
+    fn default_model(&self) -> &'static str {
+        "kimi-k2.6"
+    }
+    fn wire(&self) -> WireFormat {
+        wire!(chat_completions)
+    }
+    fn provider_config_key(&self) -> &'static str {
+        "moonshot"
+    }
+    fn apply_reasoning_effort(&self, _body: &mut Value, _effort: Option<&str>) {}
+}
+
+// --- SGLang ---
+
+pub struct Sglang;
+
+impl Provider for Sglang {
+    fn id(&self) -> &'static str {
+        "sglang"
+    }
+    fn display_name(&self) -> &'static str {
+        "SGLang"
+    }
+    fn default_base_url(&self) -> &'static str {
+        "http://localhost:30000/v1"
+    }
+    fn env_vars(&self) -> &[&'static str] {
+        &["SGLANG_API_KEY"]
+    }
+    fn default_model(&self) -> &'static str {
+        "deepseek-ai/DeepSeek-V4-Pro"
+    }
+    fn wire(&self) -> WireFormat {
+        wire!(chat_completions)
+    }
+    fn provider_config_key(&self) -> &'static str {
+        "sglang"
+    }
+    fn thinking_supported(&self) -> bool {
+        true
+    }
+    fn apply_reasoning_effort(&self, body: &mut Value, effort: Option<&str>) {
+        // Same behaviour as Deepseek for reasoning_effort/thinking.
+        Deepseek.apply_reasoning_effort(body, effort);
+    }
+}
+
+// --- vLLM ---
+
+pub struct Vllm;
+
+impl Provider for Vllm {
+    fn id(&self) -> &'static str {
+        "vllm"
+    }
+    fn display_name(&self) -> &'static str {
+        "vLLM"
+    }
+    fn default_base_url(&self) -> &'static str {
+        "http://localhost:8000/v1"
+    }
+    fn env_vars(&self) -> &[&'static str] {
+        &["VLLM_API_KEY"]
+    }
+    fn default_model(&self) -> &'static str {
+        "deepseek-ai/DeepSeek-V4-Pro"
+    }
+    fn wire(&self) -> WireFormat {
+        wire!(chat_completions)
+    }
+    fn provider_config_key(&self) -> &'static str {
+        "vllm"
+    }
+    fn thinking_supported(&self) -> bool {
+        true
+    }
+    fn apply_reasoning_effort(&self, body: &mut Value, effort: Option<&str>) {
+        let Some(effort) = effort else { return };
+        let normalized = effort.trim().to_ascii_lowercase();
+        match normalized.as_str() {
+            "off" | "disabled" | "none" | "false" => {
+                body["chat_template_kwargs"] = serde_json::json!({
+                    "enable_thinking": false,
+                });
+            }
+            "low" | "minimal" | "medium" | "mid" | "high" | "" => {
+                body["chat_template_kwargs"] = serde_json::json!({
+                    "enable_thinking": true,
+                });
+                let value = match normalized.as_str() {
+                    "low" | "minimal" => "low",
+                    "medium" | "mid" => "medium",
+                    _ => "high",
+                };
+                body["reasoning_effort"] = serde_json::json!(value);
+            }
+            "xhigh" | "max" | "highest" => {
+                body["chat_template_kwargs"] = serde_json::json!({
+                    "enable_thinking": true,
+                });
+                // vLLM doesn't support "max" — downgrade to "high".
+                body["reasoning_effort"] = serde_json::json!("high");
+            }
+            _ => {}
+        }
+    }
+}
+
+// --- Ollama ---
+
+pub struct Ollama;
+
+impl Provider for Ollama {
+    fn id(&self) -> &'static str {
+        "ollama"
+    }
+    fn display_name(&self) -> &'static str {
+        "Ollama"
+    }
+    fn default_base_url(&self) -> &'static str {
+        "http://localhost:11434/v1"
+    }
+    fn env_vars(&self) -> &[&'static str] {
+        &["OLLAMA_API_KEY"]
+    }
+    fn default_model(&self) -> &'static str {
+        "deepseek-coder:1.3b"
+    }
+    fn wire(&self) -> WireFormat {
+        wire!(chat_completions)
+    }
+    fn provider_config_key(&self) -> &'static str {
+        "ollama"
+    }
+    fn apply_reasoning_effort(&self, _body: &mut Value, _effort: Option<&str>) {}
+}
+
+// --- Volcengine ---
+
+pub struct Volcengine;
+
+impl Provider for Volcengine {
+    fn id(&self) -> &'static str {
+        "volcengine"
+    }
+    fn display_name(&self) -> &'static str {
+        "Volcengine Ark"
+    }
+    fn default_base_url(&self) -> &'static str {
+        "https://ark.cn-beijing.volces.com/api/coding/v3"
+    }
+    fn env_vars(&self) -> &[&'static str] {
+        &[
+            "VOLCENGINE_API_KEY",
+            "VOLCENGINE_ARK_API_KEY",
+            "ARK_API_KEY",
+        ]
+    }
+    fn default_model(&self) -> &'static str {
+        "DeepSeek-V4-Pro"
+    }
+    fn wire(&self) -> WireFormat {
+        wire!(chat_completions)
+    }
+    fn provider_config_key(&self) -> &'static str {
+        "volcengine"
+    }
+    fn thinking_supported(&self) -> bool {
+        true
+    }
+    fn apply_reasoning_effort(&self, body: &mut Value, effort: Option<&str>) {
+        Deepseek.apply_reasoning_effort(body, effort);
+    }
+}
+
+// --- Xiaomi Mimo ---
+
+pub struct XiaomiMimo;
+
+impl Provider for XiaomiMimo {
+    fn id(&self) -> &'static str {
+        "xiaomi-mimo"
+    }
+    fn display_name(&self) -> &'static str {
+        "Xiaomi Mimo"
+    }
+    fn default_base_url(&self) -> &'static str {
+        "https://token-plan-sgp.xiaomimimo.com/v1"
+    }
+    fn env_vars(&self) -> &[&'static str] {
+        &["XIAOMI_MIMO_API_KEY", "XIAOMI_API_KEY", "MIMO_API_KEY"]
+    }
+    fn default_model(&self) -> &'static str {
+        "mimo-v2.5-pro"
+    }
+    fn wire(&self) -> WireFormat {
+        wire!(chat_completions)
+    }
+    fn provider_config_key(&self) -> &'static str {
+        "xiaomi_mimo"
+    }
+    fn thinking_supported(&self) -> bool {
+        true
+    }
+    fn apply_reasoning_effort(&self, body: &mut Value, effort: Option<&str>) {
+        let Some(effort) = effort else { return };
+        let normalized = effort.trim().to_ascii_lowercase();
+        match normalized.as_str() {
+            "off" | "disabled" | "none" | "false" => {
+                body["thinking"] = serde_json::json!({"type": "disabled"});
+            }
+            "low" | "minimal" | "medium" | "mid" | "high" | "" | "xhigh" | "max" | "highest" => {
+                body["thinking"] = serde_json::json!({"type": "enabled"});
+            }
+            _ => {}
+        }
+    }
+}
+
+// --- SiliconFlow ---
+
+pub struct Siliconflow;
+
+impl Provider for Siliconflow {
+    fn id(&self) -> &'static str {
+        "siliconflow"
+    }
+    fn display_name(&self) -> &'static str {
+        "SiliconFlow"
+    }
+    fn default_base_url(&self) -> &'static str {
+        "https://api.siliconflow.com/v1"
+    }
+    fn env_vars(&self) -> &[&'static str] {
+        &["SILICONFLOW_API_KEY"]
+    }
+    fn default_model(&self) -> &'static str {
+        "deepseek-ai/DeepSeek-V4-Pro"
+    }
+    fn wire(&self) -> WireFormat {
+        wire!(chat_completions)
+    }
+    fn provider_config_key(&self) -> &'static str {
+        "siliconflow"
+    }
+    fn thinking_supported(&self) -> bool {
+        true
+    }
+    fn apply_reasoning_effort(&self, body: &mut Value, effort: Option<&str>) {
+        Deepseek.apply_reasoning_effort(body, effort);
+    }
+}
+
+// --- Arcee ---
+
+pub struct Arcee;
+
+impl Provider for Arcee {
+    fn id(&self) -> &'static str {
+        "arcee"
+    }
+    fn display_name(&self) -> &'static str {
+        "Arcee AI"
+    }
+    fn default_base_url(&self) -> &'static str {
+        "https://api.arcee.ai/api/v1"
+    }
+    fn env_vars(&self) -> &[&'static str] {
+        &["ARCEE_API_KEY"]
+    }
+    fn default_model(&self) -> &'static str {
+        "trinity-large-thinking"
+    }
+    fn wire(&self) -> WireFormat {
+        wire!(chat_completions)
+    }
+    fn provider_config_key(&self) -> &'static str {
+        "arcee"
+    }
+    fn thinking_supported(&self) -> bool {
+        true
+    }
+    fn apply_reasoning_effort(&self, body: &mut Value, effort: Option<&str>) {
+        let Some(effort) = effort else { return };
+        let normalized = effort.trim().to_ascii_lowercase();
+        match normalized.as_str() {
+            "off" | "disabled" | "none" | "false" => {
+                // no-op
+            }
+            "low" | "minimal" | "medium" | "mid" | "high" | "" => {
+                let value = match normalized.as_str() {
+                    "minimal" => "minimal",
+                    "low" => "low",
+                    "medium" | "mid" => "medium",
+                    _ => "high",
+                };
+                body["reasoning_effort"] = serde_json::json!(value);
+            }
+            "xhigh" | "max" | "highest" => {
+                body["reasoning_effort"] = serde_json::json!("high");
+            }
+            _ => {}
+        }
+    }
+}
+
+// --- SiliconFlow CN ---
+
+pub struct SiliconflowCn;
+
+impl Provider for SiliconflowCn {
+    fn id(&self) -> &'static str {
+        "siliconflow-cn"
+    }
+    fn display_name(&self) -> &'static str {
+        "SiliconFlow (China)"
+    }
+    fn default_base_url(&self) -> &'static str {
+        "https://api.siliconflow.cn/v1"
+    }
+    fn env_vars(&self) -> &[&'static str] {
+        &["SILICONFLOW_API_KEY"]
+    }
+    fn default_model(&self) -> &'static str {
+        "deepseek-ai/DeepSeek-V4-Pro"
+    }
+    fn wire(&self) -> WireFormat {
+        wire!(chat_completions)
+    }
+    fn provider_config_key(&self) -> &'static str {
+        "siliconflow_cn"
+    }
+    fn thinking_supported(&self) -> bool {
+        true
+    }
+    fn apply_reasoning_effort(&self, body: &mut Value, effort: Option<&str>) {
+        Deepseek.apply_reasoning_effort(body, effort);
+    }
+}
+
+// --- Hugging Face ---
+
+pub struct Huggingface;
+
+impl Provider for Huggingface {
+    fn id(&self) -> &'static str {
+        "huggingface"
+    }
+    fn display_name(&self) -> &'static str {
+        "Hugging Face"
+    }
+    fn default_base_url(&self) -> &'static str {
+        "https://router.huggingface.co/v1"
+    }
+    fn env_vars(&self) -> &[&'static str] {
+        &["HUGGINGFACE_API_KEY", "HF_TOKEN"]
+    }
+    fn default_model(&self) -> &'static str {
+        "deepseek-ai/DeepSeek-V4-Pro"
+    }
+    fn wire(&self) -> WireFormat {
+        wire!(chat_completions)
+    }
+    fn provider_config_key(&self) -> &'static str {
+        "huggingface"
+    }
+    fn apply_reasoning_effort(&self, _body: &mut Value, _effort: Option<&str>) {}
+}
+
+// ---------------------------------------------------------------------------
+// Global registry
+// ---------------------------------------------------------------------------
+
+static PROVIDER_REGISTRY: OnceLock<HashMap<&'static str, &'static dyn Provider>> = OnceLock::new();
+
+fn registry() -> &'static HashMap<&'static str, &'static dyn Provider> {
+    PROVIDER_REGISTRY.get_or_init(|| {
+        let providers: [(&str, &dyn Provider); 18] = [
+            ("deepseek", &Deepseek),
+            ("nvidia-nim", &NvidiaNim),
+            ("openai", &Openai),
+            ("atlascloud", &Atlascloud),
+            ("wanjie-ark", &WanjieArk),
+            ("volcengine", &Volcengine),
+            ("openrouter", &Openrouter),
+            ("xiaomi-mimo", &XiaomiMimo),
+            ("novita", &Novita),
+            ("fireworks", &Fireworks),
+            ("siliconflow", &Siliconflow),
+            ("arcee", &Arcee),
+            ("siliconflow-cn", &SiliconflowCn),
+            ("moonshot", &Moonshot),
+            ("sglang", &Sglang),
+            ("vllm", &Vllm),
+            ("ollama", &Ollama),
+            ("huggingface", &Huggingface),
+        ];
+        let mut map = HashMap::with_capacity(providers.len());
+        for (key, provider) in providers {
+            map.insert(key, provider);
+        }
+        map
+    })
+}
+
+/// Look up a provider by its canonical id.
+#[must_use]
+pub fn lookup_provider(id: &str) -> Option<&'static dyn Provider> {
+    registry().get(id).copied()
+}
+
+/// Look up a provider by id string (with canonicalization for legacy aliases).
+/// Returns `None` when the id is not recognised.
+#[must_use]
+pub fn resolve_provider(id: &str) -> Option<&'static dyn Provider> {
+    let normalized = match id.trim().to_ascii_lowercase().as_str() {
+        "deepseek" | "deep-seek" => "deepseek",
+        "deepseek-cn" | "deepseek_china" | "deepseekcn" | "deepseek-china" => "deepseek",
+        "nvidia" | "nvidia-nim" | "nvidia_nim" | "nim" => "nvidia-nim",
+        "openai" | "open-ai" => "openai",
+        "atlascloud" | "atlas-cloud" | "atlas_cloud" | "atlas" => "atlascloud",
+        "wanjie" | "wanjie-ark" | "wanjie_ark" | "ark-wanjie" | "ark_wanjie" | "wanjieark"
+        | "wanjie-maas" | "wanjie_maas" | "wanjiemaas" => "wanjie-ark",
+        "volcengine" | "volcengine-ark" | "volcengine_ark" | "ark" | "volc-ark"
+        | "volcengineark" => "volcengine",
+        "openrouter" | "open_router" => "openrouter",
+        "xiaomi-mimo" | "xiaomi_mimo" | "xiaomimimo" | "mimo" | "xiaomi" => "xiaomi-mimo",
+        "novita" => "novita",
+        "fireworks" | "fireworks-ai" => "fireworks",
+        "siliconflow" | "silicon-flow" | "silicon_flow" => "siliconflow",
+        "siliconflow-cn" | "siliconflow-CN" | "siliconflow_cn" => "siliconflow-cn",
+        "arcee" | "arcee-ai" | "arcee_ai" => "arcee",
+        "moonshot" | "moonshot-ai" | "kimi" | "kimi-k2" => "moonshot",
+        "sglang" | "sg-lang" => "sglang",
+        "vllm" | "v-llm" => "vllm",
+        "ollama" | "ollama-local" => "ollama",
+        "huggingface" | "hugging-face" | "hugging_face" | "hf" => "huggingface",
+        _ => return None,
+    };
+    lookup_provider(normalized)
+}
+
+/// Default provider (DeepSeek).
+#[must_use]
+pub fn default_provider() -> &'static dyn Provider {
+    &Deepseek
+}
+
+/// All providers, in the canonical order shown in picker UIs.
+/// Does not include `deepseek-cn` — that's a legacy alias that resolves to
+/// the same `Deepseek` trait object.
+#[must_use]
+pub fn all_providers() -> &'static [&'static dyn Provider] {
+    static ALL: OnceLock<Vec<&'static dyn Provider>> = OnceLock::new();
+    ALL.get_or_init(|| {
+        vec![
+            &Deepseek,
+            &NvidiaNim,
+            &Openai,
+            &Atlascloud,
+            &WanjieArk,
+            &Volcengine,
+            &Openrouter,
+            &XiaomiMimo,
+            &Novita,
+            &Fireworks,
+            &Siliconflow,
+            &Arcee,
+            &SiliconflowCn,
+            &Moonshot,
+            &Sglang,
+            &Vllm,
+            &Ollama,
+            &Huggingface,
+        ]
+    })
+}


### PR DESCRIPTION
## Summary
Introduce a `Provider` trait and 18 concrete provider structs in a new `crates/config/src/provider.rs` module, replacing the scattered match-arm duplication that every provider addition currently requires.

### What's in this PR

- **`Provider` trait** — `id`, `display_name`, `default_base_url`, `env_vars`, `default_model`, `wire`, `provider_config_key`, `thinking_supported`, `cache_telemetry_supported`, `apply_reasoning_effort`.
- **18 zero-sized provider structs**: Deepseek, NvidiaNim, Openai, Atlascloud, WanjieArk, Volcengine, Openrouter, XiaomiMimo, Novita, Fireworks, Siliconflow, Arcee, SiliconflowCn, Moonshot, Sglang, Vllm, Ollama, Huggingface.
- **Global `PROVIDER_REGISTRY`** — `lookup_provider()`, `resolve_provider()` (with alias normalization), `default_provider()`, `all_providers()`.
- **`ProviderKind::provider()`** — bridge method that resolves a `ProviderKind` enum variant to its `&'static dyn Provider` trait object via the registry.

### What's NOT in this PR (intentionally deferred)

This is the foundation. The existing `ProviderKind` enum, `ApiProvider` enum, and all their match arms in `lib.rs`, `tui/src/config.rs`, `cli/src/lib.rs`, and `tui/src/client.rs` are **not yet migrated**. 
They remain the source of truth for the runtime. 
The trait and registry are additive — callers can start migrating piecemeal in follow-up PRs.

Closes #2075
## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features`
- [x] `cargo test --workspace --all-features`

## Checklist

- [x] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR centralizes provider metadata into a new `Provider` trait with 18 concrete zero-sized struct implementations in `crates/config/src/provider.rs`, and adds a `ProviderKind::provider()` bridge method so the existing enums can delegate to trait objects without a full enum migration.

- **New `provider.rs` module**: defines `WireFormat`, the `Provider` trait (id, display name, base URL, env vars, default model, wire format, config key, reasoning-effort application), 18 concrete structs, a `OnceLock`-backed `PROVIDER_REGISTRY`, and public helpers `resolve_provider`, `lookup_provider`, `all_providers`, and `default_provider`.
- **`ProviderKind::provider()` bridge** (`lib.rs`): resolves the enum variant to a `&'static dyn Provider` by calling `resolve_provider(self.as_str())`, falling back to `default_provider()` (DeepSeek) if the ID is unrecognised.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Mostly safe to merge; the new trait layer is correct for all current providers, but the SiliconflowCN config-routing disconnect from prior rounds remains unresolved.

The new trait and registry are internally consistent for all 18 providers. The unresolved SiliconflowCN mismatch means callers using provider_config_key() for TOML lookups will read the wrong config section for that provider. New findings here are minor cleanup items.

crates/config/src/lib.rs and crates/config/src/provider.rs — the SiliconflowCN provider_config_key vs for_provider mismatch needs resolution before the new trait API is used for config lookups.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/config/src/provider.rs | New module introducing the `Provider` trait and 18 concrete zero-sized struct implementations, plus a global `OnceLock`-backed registry with `resolve_provider` and `all_providers` helpers. One dead match arm (`"siliconflow-CN"` after lowercase normalization) is the only new finding here. |
| crates/config/src/lib.rs | Adds `pub mod provider` and a `ProviderKind::provider()` bridge method. The `unwrap_or_else(default_provider)` fallback creates a silent-failure risk for future variants not registered in `resolve_provider`. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ProviderKind variant] -->|".as_str()"| B["&'static str ID"]
    B -->|"resolve_provider(id)"| C{ID in registry?}
    C -->|Yes| D["&'static dyn Provider"]
    C -->|No| E["default_provider() → &Deepseek"]
    D --> F["provider_config_key()"]
    D --> G["default_base_url()"]
    D --> H["env_vars()"]
    D --> I["apply_reasoning_effort()"]
    F -->|"used by TUI"| J["[providers.key] TOML lookup"]
    J -.->|"SiliconflowCN: key=siliconflow_cn but reads self.siliconflow"| K["⚠ Config mismatch (prior rounds)"]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (6)</h3></summary>

1. `crates/config/src/provider.rs`, line 898-921 ([link](https://github.com/hmbown/codewhale/blob/7a48800831b797bce0bb1d89868d8125ee17808f/crates/config/src/provider.rs#L898-L921)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Alias mapping maintained in three separate places**

   The canonical-alias table now lives in `ProviderKind::parse`, the serde `#[serde(alias = …)]` attributes on each enum variant, and `resolve_provider` here — three independent copies of the same information. If a new alias is added in one place it must be remembered in the other two. A single source of truth (e.g., a `const ALIASES: &[(&str, &str)]` array consumed by all three sites) would prevent the lists from drifting.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat-2075%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat-2075%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fconfig%2Fsrc%2Fprovider.rs%0ALine%3A%20898-921%0A%0AComment%3A%0A**Alias%20mapping%20maintained%20in%20three%20separate%20places**%0A%0AThe%20canonical-alias%20table%20now%20lives%20in%20%60ProviderKind%3A%3Aparse%60%2C%20the%20serde%20%60%23%5Bserde%28alias%20%3D%20%E2%80%A6%29%5D%60%20attributes%20on%20each%20enum%20variant%2C%20and%20%60resolve_provider%60%20here%20%E2%80%94%20three%20independent%20copies%20of%20the%20same%20information.%20If%20a%20new%20alias%20is%20added%20in%20one%20place%20it%20must%20be%20remembered%20in%20the%20other%20two.%20A%20single%20source%20of%20truth%20%28e.g.%2C%20a%20%60const%20ALIASES%3A%20%26%5B%28%26str%2C%20%26str%29%5D%60%20array%20consumed%20by%20all%20three%20sites%29%20would%20prevent%20the%20lists%20from%20drifting.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fconfig%2Fsrc%2Fprovider.rs%0ALine%3A%20898-921%0A%0AComment%3A%0A**Alias%20mapping%20maintained%20in%20three%20separate%20places**%0A%0AThe%20canonical-alias%20table%20now%20lives%20in%20%60ProviderKind%3A%3Aparse%60%2C%20the%20serde%20%60%23%5Bserde%28alias%20%3D%20%E2%80%A6%29%5D%60%20attributes%20on%20each%20enum%20variant%2C%20and%20%60resolve_provider%60%20here%20%E2%80%94%20three%20independent%20copies%20of%20the%20same%20information.%20If%20a%20new%20alias%20is%20added%20in%20one%20place%20it%20must%20be%20remembered%20in%20the%20other%20two.%20A%20single%20source%20of%20truth%20%28e.g.%2C%20a%20%60const%20ALIASES%3A%20%26%5B%28%26str%2C%20%26str%29%5D%60%20array%20consumed%20by%20all%20three%20sites%29%20would%20prevent%20the%20lists%20from%20drifting.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2479&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fconfig%2Fsrc%2Fprovider.rs%0ALine%3A%20898-921%0A%0AComment%3A%0A**Alias%20mapping%20maintained%20in%20three%20separate%20places**%0A%0AThe%20canonical-alias%20table%20now%20lives%20in%20%60ProviderKind%3A%3Aparse%60%2C%20the%20serde%20%60%23%5Bserde%28alias%20%3D%20%E2%80%A6%29%5D%60%20attributes%20on%20each%20enum%20variant%2C%20and%20%60resolve_provider%60%20here%20%E2%80%94%20three%20independent%20copies%20of%20the%20same%20information.%20If%20a%20new%20alias%20is%20added%20in%20one%20place%20it%20must%20be%20remembered%20in%20the%20other%20two.%20A%20single%20source%20of%20truth%20%28e.g.%2C%20a%20%60const%20ALIASES%3A%20%26%5B%28%26str%2C%20%26str%29%5D%60%20array%20consumed%20by%20all%20three%20sites%29%20would%20prevent%20the%20lists%20from%20drifting.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2479&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

2. `crates/cli/src/lib.rs`, line 1473-1493 ([link](https://github.com/hmbown/codewhale/blob/f0e7882b333c7c91f528b1dd1619e1236922b330/crates/cli/src/lib.rs#L1473-L1493)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`ProviderKind::DeepseekCN` missing from TUI provider whitelist**

   Before this PR, `"deepseek-cn"` parsed to `ProviderKind::Deepseek`, which passes the `matches!` guard. After this PR, it parses to the new `ProviderKind::DeepseekCN` variant, which is absent from the guard. Any user whose config file contains `provider = "deepseek-cn"` — or who passes `--provider deepseek-cn` — will hit the bail and be completely unable to launch the interactive TUI after upgrading.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat-2075%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat-2075%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fcli%2Fsrc%2Flib.rs%0ALine%3A%201473-1493%0A%0AComment%3A%0A**%60ProviderKind%3A%3ADeepseekCN%60%20missing%20from%20TUI%20provider%20whitelist**%0A%0ABefore%20this%20PR%2C%20%60%22deepseek-cn%22%60%20parsed%20to%20%60ProviderKind%3A%3ADeepseek%60%2C%20which%20passes%20the%20%60matches!%60%20guard.%20After%20this%20PR%2C%20it%20parses%20to%20the%20new%20%60ProviderKind%3A%3ADeepseekCN%60%20variant%2C%20which%20is%20absent%20from%20the%20guard.%20Any%20user%20whose%20config%20file%20contains%20%60provider%20%3D%20%22deepseek-cn%22%60%20%E2%80%94%20or%20who%20passes%20%60--provider%20deepseek-cn%60%20%E2%80%94%20will%20hit%20the%20bail%20and%20be%20completely%20unable%20to%20launch%20the%20interactive%20TUI%20after%20upgrading.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fcli%2Fsrc%2Flib.rs%0ALine%3A%201473-1493%0A%0AComment%3A%0A**%60ProviderKind%3A%3ADeepseekCN%60%20missing%20from%20TUI%20provider%20whitelist**%0A%0ABefore%20this%20PR%2C%20%60%22deepseek-cn%22%60%20parsed%20to%20%60ProviderKind%3A%3ADeepseek%60%2C%20which%20passes%20the%20%60matches!%60%20guard.%20After%20this%20PR%2C%20it%20parses%20to%20the%20new%20%60ProviderKind%3A%3ADeepseekCN%60%20variant%2C%20which%20is%20absent%20from%20the%20guard.%20Any%20user%20whose%20config%20file%20contains%20%60provider%20%3D%20%22deepseek-cn%22%60%20%E2%80%94%20or%20who%20passes%20%60--provider%20deepseek-cn%60%20%E2%80%94%20will%20hit%20the%20bail%20and%20be%20completely%20unable%20to%20launch%20the%20interactive%20TUI%20after%20upgrading.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2479&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fcli%2Fsrc%2Flib.rs%0ALine%3A%201473-1493%0A%0AComment%3A%0A**%60ProviderKind%3A%3ADeepseekCN%60%20missing%20from%20TUI%20provider%20whitelist**%0A%0ABefore%20this%20PR%2C%20%60%22deepseek-cn%22%60%20parsed%20to%20%60ProviderKind%3A%3ADeepseek%60%2C%20which%20passes%20the%20%60matches!%60%20guard.%20After%20this%20PR%2C%20it%20parses%20to%20the%20new%20%60ProviderKind%3A%3ADeepseekCN%60%20variant%2C%20which%20is%20absent%20from%20the%20guard.%20Any%20user%20whose%20config%20file%20contains%20%60provider%20%3D%20%22deepseek-cn%22%60%20%E2%80%94%20or%20who%20passes%20%60--provider%20deepseek-cn%60%20%E2%80%94%20will%20hit%20the%20bail%20and%20be%20completely%20unable%20to%20launch%20the%20interactive%20TUI%20after%20upgrading.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2479&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

3. `crates/cli/src/lib.rs`, line 788-790 ([link](https://github.com/hmbown/codewhale/blob/fa3d4d1bb944895e01252a23ad8c8217cecd8019/crates/cli/src/lib.rs#L788-L790)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> `auth login deepseek-cn` silently fails to refresh the root `api_key` after this PR. Before the PR `"deepseek-cn"` parsed to `ProviderKind::Deepseek`, so this branch ran and updated `store.config.api_key`. Now it parses to `ProviderKind::DeepseekCN` and misses the branch entirely — the new credential is written only to `providers.deepseek_cn.api_key`. Because the TUI's `deepseek_api_key` checks `self.api_key` (root) before the provider-scoped entry, any pre-existing root key silently shadows the newly saved one, making the login effectively a no-op for those users.

   

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat-2075%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat-2075%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fcli%2Fsrc%2Flib.rs%0ALine%3A%20788-790%0A%0AComment%3A%0A%60auth%20login%20deepseek-cn%60%20silently%20fails%20to%20refresh%20the%20root%20%60api_key%60%20after%20this%20PR.%20Before%20the%20PR%20%60%22deepseek-cn%22%60%20parsed%20to%20%60ProviderKind%3A%3ADeepseek%60%2C%20so%20this%20branch%20ran%20and%20updated%20%60store.config.api_key%60.%20Now%20it%20parses%20to%20%60ProviderKind%3A%3ADeepseekCN%60%20and%20misses%20the%20branch%20entirely%20%E2%80%94%20the%20new%20credential%20is%20written%20only%20to%20%60providers.deepseek_cn.api_key%60.%20Because%20the%20TUI's%20%60deepseek_api_key%60%20checks%20%60self.api_key%60%20%28root%29%20before%20the%20provider-scoped%20entry%2C%20any%20pre-existing%20root%20key%20silently%20shadows%20the%20newly%20saved%20one%2C%20making%20the%20login%20effectively%20a%20no-op%20for%20those%20users.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20matches!%28provider%2C%20ProviderKind%3A%3ADeepseek%20%7C%20ProviderKind%3A%3ADeepseekCN%29%20%7B%0A%20%20%20%20%20%20%20%20store.config.api_key%20%3D%20Some%28api_key.to_string%28%29%29%3B%0A%20%20%20%20%20%20%20%20if%20store.config.default_text_model.is_none%28%29%20%7B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fcli%2Fsrc%2Flib.rs%0ALine%3A%20788-790%0A%0AComment%3A%0A%60auth%20login%20deepseek-cn%60%20silently%20fails%20to%20refresh%20the%20root%20%60api_key%60%20after%20this%20PR.%20Before%20the%20PR%20%60%22deepseek-cn%22%60%20parsed%20to%20%60ProviderKind%3A%3ADeepseek%60%2C%20so%20this%20branch%20ran%20and%20updated%20%60store.config.api_key%60.%20Now%20it%20parses%20to%20%60ProviderKind%3A%3ADeepseekCN%60%20and%20misses%20the%20branch%20entirely%20%E2%80%94%20the%20new%20credential%20is%20written%20only%20to%20%60providers.deepseek_cn.api_key%60.%20Because%20the%20TUI's%20%60deepseek_api_key%60%20checks%20%60self.api_key%60%20%28root%29%20before%20the%20provider-scoped%20entry%2C%20any%20pre-existing%20root%20key%20silently%20shadows%20the%20newly%20saved%20one%2C%20making%20the%20login%20effectively%20a%20no-op%20for%20those%20users.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20matches!%28provider%2C%20ProviderKind%3A%3ADeepseek%20%7C%20ProviderKind%3A%3ADeepseekCN%29%20%7B%0A%20%20%20%20%20%20%20%20store.config.api_key%20%3D%20Some%28api_key.to_string%28%29%29%3B%0A%20%20%20%20%20%20%20%20if%20store.config.default_text_model.is_none%28%29%20%7B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2479&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fcli%2Fsrc%2Flib.rs%0ALine%3A%20788-790%0A%0AComment%3A%0A%60auth%20login%20deepseek-cn%60%20silently%20fails%20to%20refresh%20the%20root%20%60api_key%60%20after%20this%20PR.%20Before%20the%20PR%20%60%22deepseek-cn%22%60%20parsed%20to%20%60ProviderKind%3A%3ADeepseek%60%2C%20so%20this%20branch%20ran%20and%20updated%20%60store.config.api_key%60.%20Now%20it%20parses%20to%20%60ProviderKind%3A%3ADeepseekCN%60%20and%20misses%20the%20branch%20entirely%20%E2%80%94%20the%20new%20credential%20is%20written%20only%20to%20%60providers.deepseek_cn.api_key%60.%20Because%20the%20TUI's%20%60deepseek_api_key%60%20checks%20%60self.api_key%60%20%28root%29%20before%20the%20provider-scoped%20entry%2C%20any%20pre-existing%20root%20key%20silently%20shadows%20the%20newly%20saved%20one%2C%20making%20the%20login%20effectively%20a%20no-op%20for%20those%20users.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20matches!%28provider%2C%20ProviderKind%3A%3ADeepseek%20%7C%20ProviderKind%3A%3ADeepseekCN%29%20%7B%0A%20%20%20%20%20%20%20%20store.config.api_key%20%3D%20Some%28api_key.to_string%28%29%29%3B%0A%20%20%20%20%20%20%20%20if%20store.config.default_text_model.is_none%28%29%20%7B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2479&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

4. `crates/cli/src/lib.rs`, line 804-809 ([link](https://github.com/hmbown/codewhale/blob/fa3d4d1bb944895e01252a23ad8c8217cecd8019/crates/cli/src/lib.rs#L804-L809)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> `auth logout deepseek-cn` no longer clears the root `api_key` after this PR's enum split. If a user previously ran `auth login deepseek` (which sets `api_key` at the root), switching to `deepseek-cn` and later logging out leaves the root key intact. The TUI checks the root `api_key` first for `DeepseekCN`, so the credential persists after logout.

   

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat-2075%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat-2075%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fcli%2Fsrc%2Flib.rs%0ALine%3A%20804-809%0A%0AComment%3A%0A%60auth%20logout%20deepseek-cn%60%20no%20longer%20clears%20the%20root%20%60api_key%60%20after%20this%20PR's%20enum%20split.%20If%20a%20user%20previously%20ran%20%60auth%20login%20deepseek%60%20%28which%20sets%20%60api_key%60%20at%20the%20root%29%2C%20switching%20to%20%60deepseek-cn%60%20and%20later%20logging%20out%20leaves%20the%20root%20key%20intact.%20The%20TUI%20checks%20the%20root%20%60api_key%60%20first%20for%20%60DeepseekCN%60%2C%20so%20the%20credential%20persists%20after%20logout.%0A%0A%60%60%60suggestion%0Afn%20clear_provider_api_key_from_config%28store%3A%20%26mut%20ConfigStore%2C%20provider%3A%20ProviderKind%29%20%7B%0A%20%20%20%20store.config.providers.for_provider_mut%28provider%29.api_key%20%3D%20None%3B%0A%20%20%20%20if%20matches!%28provider%2C%20ProviderKind%3A%3ADeepseek%20%7C%20ProviderKind%3A%3ADeepseekCN%29%20%7B%0A%20%20%20%20%20%20%20%20store.config.api_key%20%3D%20None%3B%0A%20%20%20%20%7D%0A%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fcli%2Fsrc%2Flib.rs%0ALine%3A%20804-809%0A%0AComment%3A%0A%60auth%20logout%20deepseek-cn%60%20no%20longer%20clears%20the%20root%20%60api_key%60%20after%20this%20PR's%20enum%20split.%20If%20a%20user%20previously%20ran%20%60auth%20login%20deepseek%60%20%28which%20sets%20%60api_key%60%20at%20the%20root%29%2C%20switching%20to%20%60deepseek-cn%60%20and%20later%20logging%20out%20leaves%20the%20root%20key%20intact.%20The%20TUI%20checks%20the%20root%20%60api_key%60%20first%20for%20%60DeepseekCN%60%2C%20so%20the%20credential%20persists%20after%20logout.%0A%0A%60%60%60suggestion%0Afn%20clear_provider_api_key_from_config%28store%3A%20%26mut%20ConfigStore%2C%20provider%3A%20ProviderKind%29%20%7B%0A%20%20%20%20store.config.providers.for_provider_mut%28provider%29.api_key%20%3D%20None%3B%0A%20%20%20%20if%20matches!%28provider%2C%20ProviderKind%3A%3ADeepseek%20%7C%20ProviderKind%3A%3ADeepseekCN%29%20%7B%0A%20%20%20%20%20%20%20%20store.config.api_key%20%3D%20None%3B%0A%20%20%20%20%7D%0A%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2479&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fcli%2Fsrc%2Flib.rs%0ALine%3A%20804-809%0A%0AComment%3A%0A%60auth%20logout%20deepseek-cn%60%20no%20longer%20clears%20the%20root%20%60api_key%60%20after%20this%20PR's%20enum%20split.%20If%20a%20user%20previously%20ran%20%60auth%20login%20deepseek%60%20%28which%20sets%20%60api_key%60%20at%20the%20root%29%2C%20switching%20to%20%60deepseek-cn%60%20and%20later%20logging%20out%20leaves%20the%20root%20key%20intact.%20The%20TUI%20checks%20the%20root%20%60api_key%60%20first%20for%20%60DeepseekCN%60%2C%20so%20the%20credential%20persists%20after%20logout.%0A%0A%60%60%60suggestion%0Afn%20clear_provider_api_key_from_config%28store%3A%20%26mut%20ConfigStore%2C%20provider%3A%20ProviderKind%29%20%7B%0A%20%20%20%20store.config.providers.for_provider_mut%28provider%29.api_key%20%3D%20None%3B%0A%20%20%20%20if%20matches!%28provider%2C%20ProviderKind%3A%3ADeepseek%20%7C%20ProviderKind%3A%3ADeepseekCN%29%20%7B%0A%20%20%20%20%20%20%20%20store.config.api_key%20%3D%20None%3B%0A%20%20%20%20%7D%0A%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2479&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

5. `crates/tui/src/config.rs`, line 4863-4869 ([link](https://github.com/hmbown/codewhale/blob/3840f9ba4776be5dd7bb704aa0a2c237b07d0c65/crates/tui/src/config.rs#L4863-L4869)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`provider_config_key` returns wrong TOML section for `SiliconflowCn` after delegation**

   `ApiProvider::SiliconflowCn.provider().provider_config_key()` now resolves through `ProviderKind::SiliconflowCN → &provider::Siliconflow → "siliconflow"`. The old explicit arm returned `"siliconflow-CN"`. Because `save_provider_auth_mode_for` calls this function to determine the TOML key it writes to, any auth-mode entry it creates for `SiliconflowCn` will now land in `[providers.siliconflow]` instead of `[providers.siliconflow-CN]`, diverging from any existing config that users saved under the old key name.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat-2075%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat-2075%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fconfig.rs%0ALine%3A%204863-4869%0A%0AComment%3A%0A**%60provider_config_key%60%20returns%20wrong%20TOML%20section%20for%20%60SiliconflowCn%60%20after%20delegation**%0A%0A%60ApiProvider%3A%3ASiliconflowCn.provider%28%29.provider_config_key%28%29%60%20now%20resolves%20through%20%60ProviderKind%3A%3ASiliconflowCN%20%E2%86%92%20%26provider%3A%3ASiliconflow%20%E2%86%92%20%22siliconflow%22%60.%20The%20old%20explicit%20arm%20returned%20%60%22siliconflow-CN%22%60.%20Because%20%60save_provider_auth_mode_for%60%20calls%20this%20function%20to%20determine%20the%20TOML%20key%20it%20writes%20to%2C%20any%20auth-mode%20entry%20it%20creates%20for%20%60SiliconflowCn%60%20will%20now%20land%20in%20%60%5Bproviders.siliconflow%5D%60%20instead%20of%20%60%5Bproviders.siliconflow-CN%5D%60%2C%20diverging%20from%20any%20existing%20config%20that%20users%20saved%20under%20the%20old%20key%20name.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fconfig.rs%0ALine%3A%204863-4869%0A%0AComment%3A%0A**%60provider_config_key%60%20returns%20wrong%20TOML%20section%20for%20%60SiliconflowCn%60%20after%20delegation**%0A%0A%60ApiProvider%3A%3ASiliconflowCn.provider%28%29.provider_config_key%28%29%60%20now%20resolves%20through%20%60ProviderKind%3A%3ASiliconflowCN%20%E2%86%92%20%26provider%3A%3ASiliconflow%20%E2%86%92%20%22siliconflow%22%60.%20The%20old%20explicit%20arm%20returned%20%60%22siliconflow-CN%22%60.%20Because%20%60save_provider_auth_mode_for%60%20calls%20this%20function%20to%20determine%20the%20TOML%20key%20it%20writes%20to%2C%20any%20auth-mode%20entry%20it%20creates%20for%20%60SiliconflowCn%60%20will%20now%20land%20in%20%60%5Bproviders.siliconflow%5D%60%20instead%20of%20%60%5Bproviders.siliconflow-CN%5D%60%2C%20diverging%20from%20any%20existing%20config%20that%20users%20saved%20under%20the%20old%20key%20name.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2479&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fconfig.rs%0ALine%3A%204863-4869%0A%0AComment%3A%0A**%60provider_config_key%60%20returns%20wrong%20TOML%20section%20for%20%60SiliconflowCn%60%20after%20delegation**%0A%0A%60ApiProvider%3A%3ASiliconflowCn.provider%28%29.provider_config_key%28%29%60%20now%20resolves%20through%20%60ProviderKind%3A%3ASiliconflowCN%20%E2%86%92%20%26provider%3A%3ASiliconflow%20%E2%86%92%20%22siliconflow%22%60.%20The%20old%20explicit%20arm%20returned%20%60%22siliconflow-CN%22%60.%20Because%20%60save_provider_auth_mode_for%60%20calls%20this%20function%20to%20determine%20the%20TOML%20key%20it%20writes%20to%2C%20any%20auth-mode%20entry%20it%20creates%20for%20%60SiliconflowCn%60%20will%20now%20land%20in%20%60%5Bproviders.siliconflow%5D%60%20instead%20of%20%60%5Bproviders.siliconflow-CN%5D%60%2C%20diverging%20from%20any%20existing%20config%20that%20users%20saved%20under%20the%20old%20key%20name.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2479&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

6. `crates/config/src/lib.rs`, line 302-305 ([link](https://github.com/hmbown/codewhale/blob/b37c0a9a8ab0d4cfd3763d962859349d9469c6db/crates/config/src/lib.rs#L302-L305)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`siliconflow_cn` config field is never read**

   `ProvidersToml` gains a new `pub siliconflow_cn: ProviderConfigToml` field that serde will happily populate from `[providers.siliconflow_cn]`, but `for_provider(ProviderKind::SiliconflowCN)` still returns `&self.siliconflow`. Any user who follows the new docs row — which lists `[providers.siliconflow_cn]` as the config table for `siliconflow-cn` — and sets `api_key`, `base_url`, or `model` there will have those values silently discarded at runtime; the CLI reads from `[providers.siliconflow]` instead. Either change `for_provider(SiliconflowCN)` to return `&self.siliconflow_cn` (making the field live and the docs accurate) or remove the dead field and update the docs to show `[providers.siliconflow]`.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat-2075%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat-2075%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fconfig%2Fsrc%2Flib.rs%0ALine%3A%20302-305%0A%0AComment%3A%0A**%60siliconflow_cn%60%20config%20field%20is%20never%20read**%0A%0A%60ProvidersToml%60%20gains%20a%20new%20%60pub%20siliconflow_cn%3A%20ProviderConfigToml%60%20field%20that%20serde%20will%20happily%20populate%20from%20%60%5Bproviders.siliconflow_cn%5D%60%2C%20but%20%60for_provider%28ProviderKind%3A%3ASiliconflowCN%29%60%20still%20returns%20%60%26self.siliconflow%60.%20Any%20user%20who%20follows%20the%20new%20docs%20row%20%E2%80%94%20which%20lists%20%60%5Bproviders.siliconflow_cn%5D%60%20as%20the%20config%20table%20for%20%60siliconflow-cn%60%20%E2%80%94%20and%20sets%20%60api_key%60%2C%20%60base_url%60%2C%20or%20%60model%60%20there%20will%20have%20those%20values%20silently%20discarded%20at%20runtime%3B%20the%20CLI%20reads%20from%20%60%5Bproviders.siliconflow%5D%60%20instead.%20Either%20change%20%60for_provider%28SiliconflowCN%29%60%20to%20return%20%60%26self.siliconflow_cn%60%20%28making%20the%20field%20live%20and%20the%20docs%20accurate%29%20or%20remove%20the%20dead%20field%20and%20update%20the%20docs%20to%20show%20%60%5Bproviders.siliconflow%5D%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fconfig%2Fsrc%2Flib.rs%0ALine%3A%20302-305%0A%0AComment%3A%0A**%60siliconflow_cn%60%20config%20field%20is%20never%20read**%0A%0A%60ProvidersToml%60%20gains%20a%20new%20%60pub%20siliconflow_cn%3A%20ProviderConfigToml%60%20field%20that%20serde%20will%20happily%20populate%20from%20%60%5Bproviders.siliconflow_cn%5D%60%2C%20but%20%60for_provider%28ProviderKind%3A%3ASiliconflowCN%29%60%20still%20returns%20%60%26self.siliconflow%60.%20Any%20user%20who%20follows%20the%20new%20docs%20row%20%E2%80%94%20which%20lists%20%60%5Bproviders.siliconflow_cn%5D%60%20as%20the%20config%20table%20for%20%60siliconflow-cn%60%20%E2%80%94%20and%20sets%20%60api_key%60%2C%20%60base_url%60%2C%20or%20%60model%60%20there%20will%20have%20those%20values%20silently%20discarded%20at%20runtime%3B%20the%20CLI%20reads%20from%20%60%5Bproviders.siliconflow%5D%60%20instead.%20Either%20change%20%60for_provider%28SiliconflowCN%29%60%20to%20return%20%60%26self.siliconflow_cn%60%20%28making%20the%20field%20live%20and%20the%20docs%20accurate%29%20or%20remove%20the%20dead%20field%20and%20update%20the%20docs%20to%20show%20%60%5Bproviders.siliconflow%5D%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2479&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fconfig%2Fsrc%2Flib.rs%0ALine%3A%20302-305%0A%0AComment%3A%0A**%60siliconflow_cn%60%20config%20field%20is%20never%20read**%0A%0A%60ProvidersToml%60%20gains%20a%20new%20%60pub%20siliconflow_cn%3A%20ProviderConfigToml%60%20field%20that%20serde%20will%20happily%20populate%20from%20%60%5Bproviders.siliconflow_cn%5D%60%2C%20but%20%60for_provider%28ProviderKind%3A%3ASiliconflowCN%29%60%20still%20returns%20%60%26self.siliconflow%60.%20Any%20user%20who%20follows%20the%20new%20docs%20row%20%E2%80%94%20which%20lists%20%60%5Bproviders.siliconflow_cn%5D%60%20as%20the%20config%20table%20for%20%60siliconflow-cn%60%20%E2%80%94%20and%20sets%20%60api_key%60%2C%20%60base_url%60%2C%20or%20%60model%60%20there%20will%20have%20those%20values%20silently%20discarded%20at%20runtime%3B%20the%20CLI%20reads%20from%20%60%5Bproviders.siliconflow%5D%60%20instead.%20Either%20change%20%60for_provider%28SiliconflowCN%29%60%20to%20return%20%60%26self.siliconflow_cn%60%20%28making%20the%20field%20live%20and%20the%20docs%20accurate%29%20or%20remove%20the%20dead%20field%20and%20update%20the%20docs%20to%20show%20%60%5Bproviders.siliconflow%5D%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2479&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat-2075%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat-2075%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Fconfig%2Fsrc%2Fprovider.rs%3A861%0AThe%20%60%22siliconflow-CN%22%60%20arm%20in%20the%20pattern%20is%20unreachable.%20The%20function%20calls%20%60id.trim%28%29.to_ascii_lowercase%28%29%60%20before%20the%20%60match%60%2C%20so%20by%20the%20time%20the%20match%20runs%20the%20string%20is%20guaranteed%20to%20be%20all-lowercase%3B%20%60%22siliconflow-CN%22%60%20%28with%20an%20uppercase%20%60CN%60%29%20can%20never%20be%20the%20value%20being%20matched.%20Only%20%60%22siliconflow-cn%22%60%20and%20%60%22siliconflow_cn%22%60%20are%20reachable%20arms%20for%20this%20provider.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%22siliconflow-cn%22%20%7C%20%22siliconflow_cn%22%20%3D%3E%20%22siliconflow-cn%22%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Fconfig%2Fsrc%2Flib.rs%3A197-199%0A**Silent%20DeepSeek%20fallback%20for%20future%20unregistered%20variants**%0A%0A%60unwrap_or_else%28provider%3A%3Adefault_provider%29%60%20means%20any%20%60ProviderKind%60%20variant%20whose%20%60as_str%28%29%60%20return%20value%20is%20absent%20from%20%60resolve_provider%60's%20match%20arms%20will%20silently%20resolve%20to%20%60Deepseek%60%20at%20runtime%20%E2%80%94%20using%20DeepSeek's%20base%20URL%2C%20API%20key%20env%20vars%2C%20and%20model%20defaults%20%E2%80%94%20rather%20than%20failing%20visibly.%20Because%20%60as_str%28%29%60%20and%20%60resolve_provider%60%20are%20two%20independent%20tables%20that%20must%20be%20kept%20in%20sync%2C%20a%20new%20variant%20added%20to%20the%20enum%20could%20compile%20and%20appear%20to%20work%20while%20silently%20routing%20all%20requests%20through%20the%20wrong%20provider.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Fconfig%2Fsrc%2Fprovider.rs%3A861%0AThe%20%60%22siliconflow-CN%22%60%20arm%20in%20the%20pattern%20is%20unreachable.%20The%20function%20calls%20%60id.trim%28%29.to_ascii_lowercase%28%29%60%20before%20the%20%60match%60%2C%20so%20by%20the%20time%20the%20match%20runs%20the%20string%20is%20guaranteed%20to%20be%20all-lowercase%3B%20%60%22siliconflow-CN%22%60%20%28with%20an%20uppercase%20%60CN%60%29%20can%20never%20be%20the%20value%20being%20matched.%20Only%20%60%22siliconflow-cn%22%60%20and%20%60%22siliconflow_cn%22%60%20are%20reachable%20arms%20for%20this%20provider.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%22siliconflow-cn%22%20%7C%20%22siliconflow_cn%22%20%3D%3E%20%22siliconflow-cn%22%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Fconfig%2Fsrc%2Flib.rs%3A197-199%0A**Silent%20DeepSeek%20fallback%20for%20future%20unregistered%20variants**%0A%0A%60unwrap_or_else%28provider%3A%3Adefault_provider%29%60%20means%20any%20%60ProviderKind%60%20variant%20whose%20%60as_str%28%29%60%20return%20value%20is%20absent%20from%20%60resolve_provider%60's%20match%20arms%20will%20silently%20resolve%20to%20%60Deepseek%60%20at%20runtime%20%E2%80%94%20using%20DeepSeek's%20base%20URL%2C%20API%20key%20env%20vars%2C%20and%20model%20defaults%20%E2%80%94%20rather%20than%20failing%20visibly.%20Because%20%60as_str%28%29%60%20and%20%60resolve_provider%60%20are%20two%20independent%20tables%20that%20must%20be%20kept%20in%20sync%2C%20a%20new%20variant%20added%20to%20the%20enum%20could%20compile%20and%20appear%20to%20work%20while%20silently%20routing%20all%20requests%20through%20the%20wrong%20provider.%0A%0A&repo=hmbown%2Fcodewhale&pr=2479&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Fconfig%2Fsrc%2Fprovider.rs%3A861%0AThe%20%60%22siliconflow-CN%22%60%20arm%20in%20the%20pattern%20is%20unreachable.%20The%20function%20calls%20%60id.trim%28%29.to_ascii_lowercase%28%29%60%20before%20the%20%60match%60%2C%20so%20by%20the%20time%20the%20match%20runs%20the%20string%20is%20guaranteed%20to%20be%20all-lowercase%3B%20%60%22siliconflow-CN%22%60%20%28with%20an%20uppercase%20%60CN%60%29%20can%20never%20be%20the%20value%20being%20matched.%20Only%20%60%22siliconflow-cn%22%60%20and%20%60%22siliconflow_cn%22%60%20are%20reachable%20arms%20for%20this%20provider.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%22siliconflow-cn%22%20%7C%20%22siliconflow_cn%22%20%3D%3E%20%22siliconflow-cn%22%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Fconfig%2Fsrc%2Flib.rs%3A197-199%0A**Silent%20DeepSeek%20fallback%20for%20future%20unregistered%20variants**%0A%0A%60unwrap_or_else%28provider%3A%3Adefault_provider%29%60%20means%20any%20%60ProviderKind%60%20variant%20whose%20%60as_str%28%29%60%20return%20value%20is%20absent%20from%20%60resolve_provider%60's%20match%20arms%20will%20silently%20resolve%20to%20%60Deepseek%60%20at%20runtime%20%E2%80%94%20using%20DeepSeek's%20base%20URL%2C%20API%20key%20env%20vars%2C%20and%20model%20defaults%20%E2%80%94%20rather%20than%20failing%20visibly.%20Because%20%60as_str%28%29%60%20and%20%60resolve_provider%60%20are%20two%20independent%20tables%20that%20must%20be%20kept%20in%20sync%2C%20a%20new%20variant%20added%20to%20the%20enum%20could%20compile%20and%20appear%20to%20work%20while%20silently%20routing%20all%20requests%20through%20the%20wrong%20provider.%0A%0A&pr=2479&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (13): Last reviewed commit: ["feat(config): collapse ProviderKind/ApiP..."](https://github.com/hmbown/codewhale/commit/4588c9141e0fd6782763f8ce900018cf77bcb2ff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34847630)</sub>

<!-- /greptile_comment -->