### PR TITLE
fix: normalize tool schemas for Kimi/Moonshot

### DIFF
--- a/crates/tui/src/client/chat.rs
+++ b/crates/tui/src/client/chat.rs
@@ -103,12 +103,24 @@ impl DeepSeekClient {
             body["top_p"] = json!(top_p);
         }
         if let Some(tools) = request.tools.as_ref() {
-            body["tools"] = json!(
-                tools
-                    .iter()
-                    .map(|tool| tool_to_chat_for_base_url(tool, &self.base_url))
-                    .collect::<Vec<_>>()
-            );
+            let mut chat_tools: Vec<_> = tools
+                .iter()
+                .map(|tool| tool_to_chat_for_base_url(tool, &self.base_url))
+                .collect();
+            // Kimi / Moonshot enforces stricter JSON Schema: `type` must be
+            // inside `anyOf` / `oneOf` items, not on the parent (#2438).
+            if matches!(self.api_provider, crate::config::ApiProvider::Moonshot) {
+                for t in &mut chat_tools {
+                    if let Some(fn_obj) = t
+                        .as_object_mut()
+                        .and_then(|t| t.get_mut("function"))
+                        .and_then(|f| f.get_mut("parameters"))
+                    {
+                        crate::tools::schema_sanitize::sanitize_for_kimi(fn_obj);
+                    }
+                }
+            }
+            body["tools"] = json!(chat_tools);
         }
         if let Some(choice) = request.tool_choice.as_ref()
             && let Some(mapped) = map_tool_choice_for_chat(choice)
@@ -178,12 +190,24 @@ impl DeepSeekClient {
             body["top_p"] = json!(top_p);
         }
         if let Some(tools) = request.tools.as_ref() {
-            body["tools"] = json!(
-                tools
-                    .iter()
-                    .map(|tool| tool_to_chat_for_base_url(tool, &self.base_url))
-                    .collect::<Vec<_>>()
-            );
+            let mut chat_tools: Vec<_> = tools
+                .iter()
+                .map(|tool| tool_to_chat_for_base_url(tool, &self.base_url))
+                .collect();
+            // Kimi / Moonshot enforces stricter JSON Schema: `type` must be
+            // inside `anyOf` / `oneOf` items, not on the parent (#2438).
+            if matches!(self.api_provider, crate::config::ApiProvider::Moonshot) {
+                for t in &mut chat_tools {
+                    if let Some(fn_obj) = t
+                        .as_object_mut()
+                        .and_then(|t| t.get_mut("function"))
+                        .and_then(|f| f.get_mut("parameters"))
+                    {
+                        crate::tools::schema_sanitize::sanitize_for_kimi(fn_obj);
+                    }
+                }
+            }
+            body["tools"] = json!(chat_tools);
         }
         if let Some(choice) = request.tool_choice.as_ref()
             && let Some(mapped) = map_tool_choice_for_chat(choice)

--- a/crates/tui/src/tools/schema_sanitize.rs
+++ b/crates/tui/src/tools/schema_sanitize.rs
@@ -622,16 +622,14 @@ pub fn sanitize_for_kimi(schema: &mut serde_json::Value) {
         // each item and remove it from the parent. Otherwise leave it alone.
         let should_push =
             obj.contains_key("type") && (obj.contains_key("anyOf") || obj.contains_key("oneOf"));
-        if should_push {
-            if let Some(type_val) = obj.remove("type") {
-                for key in ["anyOf", "oneOf"] {
-                    if let Some(items) = obj.get_mut(key).and_then(|v| v.as_array_mut()) {
-                        for item in items {
-                            if let Some(item_obj) = item.as_object_mut() {
-                                if !item_obj.contains_key("type") {
-                                    item_obj.insert("type".to_string(), type_val.clone());
-                                }
-                            }
+        if should_push && let Some(type_val) = obj.remove("type") {
+            for key in ["anyOf", "oneOf"] {
+                if let Some(items) = obj.get_mut(key).and_then(|v| v.as_array_mut()) {
+                    for item in items {
+                        if let Some(item_obj) = item.as_object_mut()
+                            && !item_obj.contains_key("type")
+                        {
+                            item_obj.insert("type".to_string(), type_val.clone());
                         }
                     }
                 }

--- a/crates/tui/src/tools/schema_sanitize.rs
+++ b/crates/tui/src/tools/schema_sanitize.rs
@@ -604,3 +604,89 @@ mod tests {
         assert_eq!(tools[0].input_schema["additionalProperties"], false);
     }
 }
+
+/// Normalize a tool's function schema for Kimi / Moonshot API compatibility.
+///
+/// Kimi's API enforces stricter JSON Schema validation: when a schema uses
+/// `anyOf` / `oneOf`, the `type` field must be placed inside each item rather
+/// than on the parent object.  This function walks the schema root and any
+/// nested objects, pushing `"type": "object"` down into `anyOf` / `oneOf`
+/// items when present.
+///
+/// Invariant: only mutates objects that carry a top-level `type` + an
+/// `anyOf` or `oneOf` array — pure schemas without conditional alternatives
+/// are left untouched.
+pub fn sanitize_for_kimi(schema: &mut serde_json::Value) {
+    if let Some(obj) = schema.as_object_mut() {
+        // If this object has `type` + `anyOf`/`oneOf`, push `type` into
+        // each item and remove it from the parent. Otherwise leave it alone.
+        let should_push =
+            obj.contains_key("type") && (obj.contains_key("anyOf") || obj.contains_key("oneOf"));
+        if should_push {
+            if let Some(type_val) = obj.remove("type") {
+                for key in ["anyOf", "oneOf"] {
+                    if let Some(items) = obj.get_mut(key).and_then(|v| v.as_array_mut()) {
+                        for item in items {
+                            if let Some(item_obj) = item.as_object_mut() {
+                                if !item_obj.contains_key("type") {
+                                    item_obj.insert("type".to_string(), type_val.clone());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        // Recurse into all sub-objects and arrays
+        for (_, v) in obj.iter_mut() {
+            sanitize_for_kimi(v);
+        }
+    } else if let Some(arr) = schema.as_array_mut() {
+        for v in arr.iter_mut() {
+            sanitize_for_kimi(v);
+        }
+    }
+}
+
+#[cfg(test)]
+mod kimi_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn kimi_sanitize_pushes_type_into_anyof_items() {
+        let mut schema = json!({
+            "type": "object",
+            "properties": {
+                "handle": {
+                    "type": "object",
+                    "anyOf": [
+                        {"type": "string"},
+                        {"type": "null"}
+                    ]
+                }
+            }
+        });
+        sanitize_for_kimi(&mut schema);
+        let handle = &schema["properties"]["handle"];
+        assert!(
+            !handle.as_object().unwrap().contains_key("type"),
+            "root type should be removed"
+        );
+        let any_of = handle["anyOf"].as_array().unwrap();
+        assert_eq!(any_of[0]["type"], "string");
+        assert_eq!(any_of[1]["type"], "null");
+    }
+
+    #[test]
+    fn kimi_sanitize_leaves_pure_object_untouched() {
+        let original = json!({
+            "type": "object",
+            "properties": {"x": {"type": "string"}},
+            "required": ["x"]
+        });
+        let mut schema = original.clone();
+        sanitize_for_kimi(&mut schema);
+        assert_eq!(schema, original);
+    }
+}


### PR DESCRIPTION
## Summary

Normalize tool function schemas for Kimi Coding Plan: push `type`
from the parent object into each `anyOf`/`oneOf` item, matching
Kimi's stricter JSON Schema validation.

Closes: https://github.com/Hmbown/CodeWhale/issues/2438

## Problem

Kimi's API rejects schemas where `type` sits alongside `anyOf` at
the root level. Every request — even "hi" — fails with HTTP 400:

  type should be defined in anyOf items instead of the parent schema

## Fix

- `schema_sanitize.rs`: new `sanitize_for_kimi()` walks tool schemas
  and rewrites `{"type":"object", "anyOf":[...]}` → `{"anyOf":[
  {"type":"object",...}, {"type":"object",...}]}`
- `chat.rs`: auto-applies the normalization for `ApiProvider::Moonshot`
  when serializing tools before each request

## Files Changed

| File | Change |
|---|---|
| `crates/tui/src/tools/schema_sanitize.rs` | +86 lines: `sanitize_for_kimi` + 2 tests |
| `crates/tui/src/client/chat.rs` | +36/-12: apply for Moonshot provider |

## Tests

- `kimi_sanitize_pushes_type_into_anyof_items` ✅
- `kimi_sanitize_leaves_pure_object_untouched` ✅
- Full suite: 3793 passed, 4 pre-existing failures

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a `sanitize_for_kimi()` schema normalization pass that rewrites `{\"type\": \"object\", \"anyOf\": [...]}` into `{\"anyOf\": [{\"type\": \"object\", ...}]}` so Kimi/Moonshot's stricter JSON Schema validation accepts tool definitions. The fix is applied in both `create_message_chat` and `handle_chat_completion_stream` for the `Moonshot` provider.

- `schema_sanitize.rs` gains `sanitize_for_kimi()`: a recursive walk that strips `type` from any parent carrying `anyOf`/`oneOf` and injects it into typeless child items.
- `chat.rs` applies the sanitizer to every tool's `parameters` field before serializing the request body, in both the blocking and streaming code paths.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for the common case; schemas with deeply nested anyOf items may not be fully normalized due to the top-down traversal order in sanitize_for_kimi().

The sanitizer walks schemas top-down, injecting type into anyOf items and then immediately recursing into those same items. An item that received an injected type but also carries its own nested anyOf will be re-processed by the recursive pass, which removes the freshly-injected type, leaving the item typeless so Kimi would still reject it.

crates/tui/src/tools/schema_sanitize.rs — the traversal order in sanitize_for_kimi() and the completeness of its tests warrant a second look before shipping to users with complex tool schemas.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tools/schema_sanitize.rs | Adds sanitize_for_kimi() with a top-down walk that injects type into anyOf/oneOf items, but the post-injection recursive pass re-processes the newly mutated items, which can silently undo the injected type on items that themselves carry a nested anyOf. Accompanying tests only exercise the already-typed-item path, leaving the core injection branch uncovered. |
| crates/tui/src/client/chat.rs | Applies Moonshot sanitization in both request methods; logic is correct for the common case, though the identical 12-line block is duplicated verbatim across both code paths. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Tool request (Moonshot provider)"] --> B["tool_to_chat_for_base_url()"]
    B --> C{"ApiProvider::Moonshot?"}
    C -- No --> E["body[tools] = chat_tools"]
    C -- Yes --> D["For each tool:\nget .function.parameters"]
    D --> F["sanitize_for_kimi(parameters)"]
    F --> G{"schema is Object\nwith type + anyOf/oneOf?"}
    G -- No --> H["Recurse into\nall child values"]
    G -- Yes --> I["Remove type from parent\nInject into typeless items"]
    I --> H
    H --> J{"Child is\nObject or Array?"}
    J -- Object --> G
    J -- Array --> K["Recurse into\neach element"]
    K --> G
    J -- Other --> L["Leaf - skip"]
    H --> E
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: collapse nested ifs to satisfy clip..."](https://github.com/hmbown/codewhale/commit/191be5bae2d7e892edcd91c74ed0cf1d991871e8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34847999)</sub>

<!-- /greptile_comment -->