### PR TITLE
feat(config): load typed ask permissions.toml schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,6 +866,7 @@ name = "codewhale-config"
 version = "0.8.49"
 dependencies = [
  "anyhow",
+ "codewhale-execpolicy",
  "codewhale-secrets",
  "dirs",
  "serde",

--- a/config.example.toml
+++ b/config.example.toml
@@ -133,6 +133,21 @@ allow_shell = true
 approval_policy = "on-request" # on-request | untrusted | never
 sandbox_mode = "workspace-write" # read-only | workspace-write | danger-full-access | external-sandbox
 
+# Typed permission rules live in a sibling `permissions.toml` file, not in
+# config.toml. This schema slice is ask-only and is parsed for follow-up
+# approval-flow wiring; allow/deny records and UI persistence are intentionally
+# out of scope here.
+#
+# Example ~/.codewhale/permissions.toml:
+#
+# [[rules]]
+# tool = "exec_shell"
+# command = "cargo test"
+#
+# [[rules]]
+# tool = "read_file"
+# path = "secrets/**"
+
 # ─────────────────────────────────────────────────────────────────────────────────
 # External Sandbox Backend (pluggable remote execution)
 # ─────────────────────────────────────────────────────────────────────────────────

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -8,6 +8,7 @@ description = "Config schema and precedence model for DeepSeek workspace archite
 
 [dependencies]
 anyhow.workspace = true
+codewhale-execpolicy = { path = "../execpolicy", version = "0.8.49" }
 codewhale-secrets = { path = "../secrets", version = "0.8.49" }
 dirs.workspace = true
 serde.workspace = true

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -6,6 +6,7 @@ use std::path::{Component, Path, PathBuf};
 use std::sync::OnceLock;
 
 use anyhow::{Context, Result, bail};
+pub use codewhale_execpolicy::ToolAskRule;
 use codewhale_secrets::SecretSource;
 pub use codewhale_secrets::Secrets;
 use serde::{Deserialize, Serialize};
@@ -14,6 +15,7 @@ use serde::{Deserialize, Serialize};
 use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 
 pub const CONFIG_FILE_NAME: &str = "config.toml";
+pub const PERMISSIONS_FILE_NAME: &str = "permissions.toml";
 const DEFAULT_DEEPSEEK_MODEL: &str = "deepseek-v4-pro";
 const DEFAULT_NVIDIA_NIM_MODEL: &str = "deepseek-ai/deepseek-v4-pro";
 const DEFAULT_NVIDIA_NIM_FLASH_MODEL: &str = "deepseek-ai/deepseek-v4-flash";
@@ -196,6 +198,25 @@ pub struct ProvidersToml {
     pub vllm: ProviderConfigToml,
     #[serde(default)]
     pub ollama: ProviderConfigToml,
+}
+
+/// Sibling `permissions.toml` schema.
+///
+/// This slice is intentionally ask-only: each rule is a typed condition that
+/// means "ask before this tool invocation." Typed allow/deny records and UI
+/// persistence are expected to land in follow-up PRs.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct PermissionsToml {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub rules: Vec<ToolAskRule>,
+}
+
+impl PermissionsToml {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.rules.is_empty()
+    }
 }
 
 impl ProvidersToml {
@@ -1751,26 +1772,26 @@ pub struct ResolvedRuntimeOptions {
 pub struct ConfigStore {
     path: PathBuf,
     pub config: ConfigToml,
+    permissions: PermissionsToml,
 }
 
 impl ConfigStore {
     pub fn load(path: Option<PathBuf>) -> Result<Self> {
         let path = resolve_config_path(path)?;
-        if !path.exists() {
-            return Ok(Self {
-                path,
-                config: ConfigToml::default(),
-            });
-        }
-
-        let raw = fs::read_to_string(&path)
-            .with_context(|| format!("failed to read config at {}", path.display()))?;
-        let parsed: ConfigToml = toml::from_str(&raw)
-            .with_context(|| format!("failed to parse config at {}", path.display()))?;
+        let config = if path.exists() {
+            let raw = fs::read_to_string(&path)
+                .with_context(|| format!("failed to read config at {}", path.display()))?;
+            toml::from_str(&raw)
+                .with_context(|| format!("failed to parse config at {}", path.display()))?
+        } else {
+            ConfigToml::default()
+        };
+        let permissions = load_sibling_permissions(&path)?;
 
         Ok(Self {
             path,
-            config: parsed,
+            config,
+            permissions,
         })
     }
 
@@ -1811,6 +1832,16 @@ impl ConfigStore {
     #[must_use]
     pub fn path(&self) -> &Path {
         &self.path
+    }
+
+    #[must_use]
+    pub fn permissions(&self) -> &PermissionsToml {
+        &self.permissions
+    }
+
+    #[must_use]
+    pub fn permissions_path(&self) -> PathBuf {
+        permissions_path_for_config_path(&self.path)
     }
 }
 
@@ -1947,6 +1978,37 @@ pub fn resolve_config_path(explicit: Option<PathBuf>) -> Result<PathBuf> {
         return default_config_path();
     };
     normalize_config_file_path(path)
+}
+
+#[must_use]
+pub fn permissions_path_for_config_path(config_path: &Path) -> PathBuf {
+    config_path.with_file_name(PERMISSIONS_FILE_NAME)
+}
+
+pub fn resolve_permissions_path(config_path: Option<PathBuf>) -> Result<PathBuf> {
+    Ok(permissions_path_for_config_path(&resolve_config_path(
+        config_path,
+    )?))
+}
+
+fn load_sibling_permissions(config_path: &Path) -> Result<PermissionsToml> {
+    let permissions_path = permissions_path_for_config_path(config_path);
+    if !permissions_path.exists() {
+        return Ok(PermissionsToml::default());
+    }
+
+    let raw = fs::read_to_string(&permissions_path).with_context(|| {
+        format!(
+            "failed to read permissions at {}",
+            permissions_path.display()
+        )
+    })?;
+    toml::from_str(&raw).with_context(|| {
+        format!(
+            "failed to parse permissions at {}",
+            permissions_path.display()
+        )
+    })
 }
 
 pub fn default_config_path() -> Result<PathBuf> {
@@ -2283,6 +2345,127 @@ mod tests {
         assert_eq!(policy.default, "allow");
         assert_eq!(policy.proxy, ["github.com", ".githubusercontent.com"]);
         assert!(policy.audit);
+    }
+
+    #[test]
+    fn permissions_toml_deserializes_typed_ask_rules() {
+        let permissions: PermissionsToml = toml::from_str(
+            r#"
+            [[rules]]
+            tool = "exec_shell"
+            command = "cargo test"
+
+            [[rules]]
+            tool = "read_file"
+            path = "secrets/**"
+            "#,
+        )
+        .expect("permissions toml");
+
+        assert_eq!(
+            permissions.rules,
+            vec![
+                ToolAskRule::exec_shell("cargo test"),
+                ToolAskRule::file_path("read_file", "secrets/**"),
+            ]
+        );
+    }
+
+    #[test]
+    fn permissions_toml_rejects_typed_allow_deny_shape() {
+        let err = toml::from_str::<PermissionsToml>(
+            r#"
+            [[rules]]
+            tool = "exec_shell"
+            decision = "allow"
+            command = "cargo test"
+            "#,
+        )
+        .expect_err("permissions.toml should be ask-only in this slice");
+
+        assert!(err.message().contains("unknown field"));
+    }
+
+    #[test]
+    fn config_store_loads_sibling_permissions_toml() {
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "codewhale-permissions-schema-{}-{unique}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&dir).expect("mkdir");
+        let config_path = dir.join(CONFIG_FILE_NAME);
+        fs::write(&config_path, "model = \"deepseek-v4-flash\"\n").expect("write config");
+        fs::write(
+            dir.join(PERMISSIONS_FILE_NAME),
+            r#"
+            [[rules]]
+            tool = "exec_shell"
+            command = "cargo test"
+
+            [[rules]]
+            tool = "read_file"
+            path = "secrets/**"
+            "#,
+        )
+        .expect("write permissions");
+
+        let store = ConfigStore::load(Some(config_path.clone())).expect("load config store");
+
+        assert_eq!(store.config.model.as_deref(), Some("deepseek-v4-flash"));
+        assert_eq!(
+            store.permissions().rules.as_slice(),
+            &[
+                ToolAskRule::exec_shell("cargo test"),
+                ToolAskRule::file_path("read_file", "secrets/**"),
+            ]
+        );
+        assert_eq!(
+            store.permissions_path(),
+            config_path.with_file_name(PERMISSIONS_FILE_NAME)
+        );
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn config_store_loads_permissions_even_when_config_is_absent() {
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "codewhale-permissions-only-{}-{unique}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&dir).expect("mkdir");
+        let config_path = dir.join(CONFIG_FILE_NAME);
+        fs::write(
+            dir.join(PERMISSIONS_FILE_NAME),
+            r#"
+            [[rules]]
+            tool = "exec_shell"
+            command = "cargo check"
+            "#,
+        )
+        .expect("write permissions");
+
+        let store = ConfigStore::load(Some(config_path)).expect("load config store");
+
+        assert!(store.config.model.is_none());
+        assert_eq!(
+            store.permissions().rules.as_slice(),
+            &[ToolAskRule::exec_shell("cargo check")]
+        );
+
+        let _ = fs::remove_dir_all(dir);
     }
 
     struct EnvGuard {
@@ -3143,6 +3326,7 @@ unix_socket_path = "/tmp/cw-hooks.sock"
                 api_key: Some("new-secret".to_string()),
                 ..ConfigToml::default()
             },
+            permissions: PermissionsToml::default(),
         };
         store.save().expect("save");
 

--- a/crates/execpolicy/src/lib.rs
+++ b/crates/execpolicy/src/lib.rs
@@ -75,6 +75,7 @@ impl Ruleset {
 /// prefix behavior is preserved while typed ask records can make
 /// `AskForApproval::Never` reject invocations that cannot be approved.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct ToolAskRule {
     /// Name of the tool this rule applies to (e.g. `"exec_shell"`, `"edit_file"`).
     pub tool: String,

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -601,6 +601,12 @@ If you are upgrading from older releases:
   with process-tree containment only and must not be described as read-only
   filesystem isolation, workspace-write enforcement, network blocking,
   registry isolation, or AppContainer isolation until those are implemented.
+- `permissions.toml` (sibling file, optional): ask-only typed permission rule
+  records loaded next to `config.toml`, for example
+  `~/.codewhale/permissions.toml`. This schema foundation accepts
+  `[[rules]]` entries with `tool` plus optional `command` or `path` fields.
+  It intentionally does not accept typed allow/deny records or provide approval
+  UI persistence yet.
 - `managed_config_path` (string, optional): managed config file loaded after user/env config.
 - `requirements_path` (string, optional): requirements file used to enforce allowed approval/sandbox values.
 - `max_subagents` (int, optional): defaults to `10` and is clamped to `1..=20`.


### PR DESCRIPTION
## Summary

Build on #2404 with the next small foundation slice for persistent permissions.

This PR adds config/schema-only support for a sibling `permissions.toml` file containing typed ask records:

```toml
[[rules]]
tool = "exec_shell"
command = "cargo test"

[[rules]]
tool = "read_file"
path = "secrets/**"
```

## Scope

This intentionally only covers schema and loading:

- add `PermissionsToml`
- load `permissions.toml` next to `config.toml`
- expose loaded rules through `ConfigStore`
- document the ask-only schema
- reject typed allow/deny-style records such as `decision = "allow"`

## Non-goals

- no typed allow/deny records
- no approval-flow wiring
- no TUI approval persistence UI
- no changes to existing allow/deny behavior

## Context

This is a smaller follow-up to the broader reference PR #2242. The typed ask execution-policy foundation landed in #2404, and this PR adds only the persistence schema/loading layer requested as the next safer slice.

Related discussion:
- #1186
- #2242 

## Validation

- `cargo fmt --all`
- `cargo test -p codewhale-config --all-features`
- `cargo test -p codewhale-execpolicy --all-features`
- `cargo check -p codewhale-cli -p codewhale-app-server --all-features`
- `cargo clippy -p codewhale-config -p codewhale-execpolicy --all-targets --all-features -- -D warnings`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds schema and loading support for a sibling `permissions.toml` file containing typed ask rules, building on the execpolicy foundation from #2404. It intentionally stays in schema/loading scope — no approval-flow wiring or UI persistence.

- Introduces `PermissionsToml` with `#[serde(deny_unknown_fields)]` (rejecting typed allow/deny records), loads it next to `config.toml` via `load_sibling_permissions`, and exposes it through `ConfigStore::permissions()` and `ConfigStore::permissions_path()`.
- Re-exports `ToolAskRule` from `codewhale-config` and hardens `ToolAskRule` itself with `#[serde(deny_unknown_fields)]`; tests cover happy-path deserialization, rejection of `decision = "allow"` records, and the no-config-file edge case.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge as a schema/loading-only slice; the unresolved path-matching issue will silently misfire ask rules once approval-flow wiring lands.

The loading logic and schema are correct, and the test coverage is solid. The path field does string equality against a normalized value — documented examples like `path = "secrets/**"` will never match real paths such as `secrets/api_key.txt` when the approval-flow consumer arrives. This is a pre-existing defect carried forward and now further embedded by the documentation and examples in this PR.

crates/execpolicy/src/lib.rs — `matching_ask_rule` path comparison (lines 322–328) uses equality, not glob expansion, which conflicts with the glob-style examples shipped in `config.example.toml` and `docs/CONFIGURATION.md`.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/execpolicy/src/lib.rs | Adds `#[serde(deny_unknown_fields)]` to `ToolAskRule`; path matching logic is unchanged (equality, not glob) — the documented `secrets/**` example pattern will not match real paths once approval-flow wiring lands. |
| crates/config/src/lib.rs | Adds `PermissionsToml`, `load_sibling_permissions`, and `ConfigStore::permissions()`/`permissions_path()` with clean error propagation and good test coverage including the no-config-file edge case. |
| crates/config/Cargo.toml | Adds `codewhale-execpolicy` dependency at the correct version to support the `ToolAskRule` re-export. |
| docs/CONFIGURATION.md | Documents the new `permissions.toml` sibling file with accurate scope limitations; placed correctly in the upgrade notes section. |
| config.example.toml | Adds a comment-only block showing the `permissions.toml` format; does not introduce any parsed changes to `config.toml` itself. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["ConfigStore::load(path)"] --> B["resolve_config_path()"]
    B --> C{"config.toml exists?"}
    C -- yes --> D["fs::read_to_string\n+ toml::from_str → ConfigToml"]
    C -- no --> E["ConfigToml::default()"]
    D --> F["load_sibling_permissions(config_path)"]
    E --> F
    F --> G["permissions_path_for_config_path()\n→ config_dir/permissions.toml"]
    G --> H{"permissions.toml exists?"}
    H -- no --> I["PermissionsToml::default()"]
    H -- yes --> J["fs::read_to_string\n+ toml::from_str → PermissionsToml"]
    J --> K{"parse ok?"}
    K -- no --> L["Err: propagated to caller"]
    K -- yes --> M["PermissionsToml { rules: Vec<ToolAskRule> }"]
    I --> N["ConfigStore { path, config, permissions }"]
    M --> N
    N --> O["ConfigStore::permissions() → &PermissionsToml"]
    N --> P["ConfigStore::permissions_path() → PathBuf"]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/execpolicy/src/lib.rs`, line 322-328 ([link](https://github.com/hmbown/codewhale/blob/fe0923b38b09b3aa3d8623982ff41de8ee61bdb7/crates/execpolicy/src/lib.rs#L322-L328)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Path field does equality matching, not glob matching**

   The `path` field is documented as an "Optional file path **pattern** to match against" (line 86) and the example in both `config.example.toml` and `docs/CONFIGURATION.md` shows `path = "secrets/**"`. However, the matching logic does normalized string equality (`normalize_path_value(pattern) == normalize_path_value(path)`), not glob expansion. A rule with `path = "secrets/**"` will never match a real path like `secrets/api_key.txt`; it will only match the exact string `secrets/**`.

   When the approval-flow wiring arrives in a follow-up PR, users who followed the documented examples will find their ask-rules silently never fire on any real file path. Either the matching should use a glob library (e.g. `glob` or `globset`), or the field name/documentation should be updated to reflect that only exact paths are supported.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fpermissions-toml-typed-ask-schema%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fpermissions-toml-typed-ask-schema%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fexecpolicy%2Fsrc%2Flib.rs%0ALine%3A%20322-328%0A%0AComment%3A%0A**Path%20field%20does%20equality%20matching%2C%20not%20glob%20matching**%0A%0AThe%20%60path%60%20field%20is%20documented%20as%20an%20%22Optional%20file%20path%20**pattern**%20to%20match%20against%22%20%28line%2086%29%20and%20the%20example%20in%20both%20%60config.example.toml%60%20and%20%60docs%2FCONFIGURATION.md%60%20shows%20%60path%20%3D%20%22secrets%2F**%22%60.%20However%2C%20the%20matching%20logic%20does%20normalized%20string%20equality%20%28%60normalize_path_value%28pattern%29%20%3D%3D%20normalize_path_value%28path%29%60%29%2C%20not%20glob%20expansion.%20A%20rule%20with%20%60path%20%3D%20%22secrets%2F**%22%60%20will%20never%20match%20a%20real%20path%20like%20%60secrets%2Fapi_key.txt%60%3B%20it%20will%20only%20match%20the%20exact%20string%20%60secrets%2F**%60.%0A%0AWhen%20the%20approval-flow%20wiring%20arrives%20in%20a%20follow-up%20PR%2C%20users%20who%20followed%20the%20documented%20examples%20will%20find%20their%20ask-rules%20silently%20never%20fire%20on%20any%20real%20file%20path.%20Either%20the%20matching%20should%20use%20a%20glob%20library%20%28e.g.%20%60glob%60%20or%20%60globset%60%29%2C%20or%20the%20field%20name%2Fdocumentation%20should%20be%20updated%20to%20reflect%20that%20only%20exact%20paths%20are%20supported.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fexecpolicy%2Fsrc%2Flib.rs%0ALine%3A%20322-328%0A%0AComment%3A%0A**Path%20field%20does%20equality%20matching%2C%20not%20glob%20matching**%0A%0AThe%20%60path%60%20field%20is%20documented%20as%20an%20%22Optional%20file%20path%20**pattern**%20to%20match%20against%22%20%28line%2086%29%20and%20the%20example%20in%20both%20%60config.example.toml%60%20and%20%60docs%2FCONFIGURATION.md%60%20shows%20%60path%20%3D%20%22secrets%2F**%22%60.%20However%2C%20the%20matching%20logic%20does%20normalized%20string%20equality%20%28%60normalize_path_value%28pattern%29%20%3D%3D%20normalize_path_value%28path%29%60%29%2C%20not%20glob%20expansion.%20A%20rule%20with%20%60path%20%3D%20%22secrets%2F**%22%60%20will%20never%20match%20a%20real%20path%20like%20%60secrets%2Fapi_key.txt%60%3B%20it%20will%20only%20match%20the%20exact%20string%20%60secrets%2F**%60.%0A%0AWhen%20the%20approval-flow%20wiring%20arrives%20in%20a%20follow-up%20PR%2C%20users%20who%20followed%20the%20documented%20examples%20will%20find%20their%20ask-rules%20silently%20never%20fire%20on%20any%20real%20file%20path.%20Either%20the%20matching%20should%20use%20a%20glob%20library%20%28e.g.%20%60glob%60%20or%20%60globset%60%29%2C%20or%20the%20field%20name%2Fdocumentation%20should%20be%20updated%20to%20reflect%20that%20only%20exact%20paths%20are%20supported.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2491&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fexecpolicy%2Fsrc%2Flib.rs%0ALine%3A%20322-328%0A%0AComment%3A%0A**Path%20field%20does%20equality%20matching%2C%20not%20glob%20matching**%0A%0AThe%20%60path%60%20field%20is%20documented%20as%20an%20%22Optional%20file%20path%20**pattern**%20to%20match%20against%22%20%28line%2086%29%20and%20the%20example%20in%20both%20%60config.example.toml%60%20and%20%60docs%2FCONFIGURATION.md%60%20shows%20%60path%20%3D%20%22secrets%2F**%22%60.%20However%2C%20the%20matching%20logic%20does%20normalized%20string%20equality%20%28%60normalize_path_value%28pattern%29%20%3D%3D%20normalize_path_value%28path%29%60%29%2C%20not%20glob%20expansion.%20A%20rule%20with%20%60path%20%3D%20%22secrets%2F**%22%60%20will%20never%20match%20a%20real%20path%20like%20%60secrets%2Fapi_key.txt%60%3B%20it%20will%20only%20match%20the%20exact%20string%20%60secrets%2F**%60.%0A%0AWhen%20the%20approval-flow%20wiring%20arrives%20in%20a%20follow-up%20PR%2C%20users%20who%20followed%20the%20documented%20examples%20will%20find%20their%20ask-rules%20silently%20never%20fire%20on%20any%20real%20file%20path.%20Either%20the%20matching%20should%20use%20a%20glob%20library%20%28e.g.%20%60glob%60%20or%20%60globset%60%29%2C%20or%20the%20field%20name%2Fdocumentation%20should%20be%20updated%20to%20reflect%20that%20only%20exact%20paths%20are%20supported.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2491&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["feat(config): load typed ask permissions..."](https://github.com/hmbown/codewhale/commit/fb77cf1e0946a061376e5e9a8fc9422dddd98419) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34870234)</sub>

<!-- /greptile_comment -->