### PR TITLE
 fix(config): allow missing tui status items

### DIFF
--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -666,7 +666,7 @@ pub struct TuiConfig {
     ///
     /// Edited interactively via `/statusline`; persisted to `tui.status_items`
     /// in `~/.deepseek/config.toml`.
-    #[serde(deserialize_with = "deser_status_items")]
+    #[serde(default, deserialize_with = "deser_status_items")]
     pub status_items: Option<Vec<StatusItem>>,
     /// Emit OSC 8 hyperlink escape sequences around URLs in the transcript so
     /// supporting terminals (iTerm2, Terminal.app 13+, Ghostty, Kitty,
@@ -8813,5 +8813,15 @@ model = "deepseek-ai/deepseek-v4-pro"
         assert_eq!(items[1], StatusItem::Model);
         assert_eq!(items[2], StatusItem::Cost);
         assert_eq!(items[3], StatusItem::Status);
+    }
+
+    #[test]
+    fn status_items_deser_allows_missing_field() {
+        let toml_str = r#"
+            locale = "zh-Hans"
+            mouse_capture = false
+        "#;
+        let tui: TuiConfig = toml::from_str(toml_str).expect("missing status_items should parse");
+        assert_eq!(tui.status_items, None);
     }
 }


### PR DESCRIPTION
## Summary

  Fixes #2483.

  Configs with a `[tui]` table failed to parse unless `status_items` was also present:

  ```text
  missing field `status_items`
```

  That broke older or hand-written configs such as:

  [tui]
  locale = "zh-Hans"
  mouse_capture = false

  status_items is intended to be optional: missing means use the default footer order, while an empty list means
  hide all footer items. The custom deserializer needed serde(default) so serde can pass missing fields through as
  None.

## Testing

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds `serde(default)` to the `status_items` field on `TuiConfig` so that configs containing a `[tui]` section without `status_items` no longer fail to parse with "missing field `status_items`".

- The one-line change is the correct, idiomatic fix: combining `serde(default)` with `deserialize_with` tells serde to produce `None` (the `Option`'s default) when the field is absent, while still routing present values through the custom `deser_status_items` deserializer.
- A new unit test validates the previously broken case directly.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is minimal and correct, fixing a parse regression without altering any existing deserialization path.

Adding serde(default) to an Option field is the idiomatic fix for this class of serde issue. When the field is absent serde now yields None directly; when it is present the custom deser_status_items function is called exactly as before. The new test exercises the previously failing case and the existing test suite continues to cover the non-missing path. No logic changed beyond the missing-field handling.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/config.rs | Adds `serde(default)` to `TuiConfig::status_items` and a regression test; the fix correctly handles the missing-field case without touching the custom deserializer logic. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A{status_items field\npresent in TOML?} -->|No - field absent| B["serde default kicks in\nfield value = None"]
    A -->|Yes - field present| C["Call deser_status_items"]
    C --> D["Deserialize as Option of Vec of String"]
    D --> E["Filter unknown variants\nvia StatusItem::from_key"]
    E --> G["Return Some Vec of StatusItem"]
    B --> H["status_items = None\nuse built-in default order"]
    G --> I["status_items = Some items\nuse configured order"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(config): allow missing tui status it..."](https://github.com/hmbown/codewhale/commit/b0e3f29bf5e506d8eee2e5d75b5a6da3604e5a50) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34875244)</sub>

<!-- /greptile_comment -->