### PR TITLE
test(shell): fix test on non posix shell

### DIFF
--- a/crates/tui/src/tools/shell/tests.rs
+++ b/crates/tui/src/tools/shell/tests.rs
@@ -119,7 +119,7 @@ fn shell_execution_scrubs_parent_env_and_keeps_explicit_env() {
 
     let result = manager
         .execute_with_options_env(
-            "printf '%s\\n%s\\n' \"${DEEPSEEK_CHILD_ENV_SHELL_SECRET-unset}\" \"${DEEPSEEK_CHILD_ENV_EXPLICIT-unset}\"",
+            "sh -c 'printf \"%s\\n%s\\n\" \"${DEEPSEEK_CHILD_ENV_SHELL_SECRET-unset}\" \"${DEEPSEEK_CHILD_ENV_EXPLICIT-unset}\"'",
             None,
             5000,
             false,


### PR DESCRIPTION
## Summary

Test "codewhale_tui::tools::shell::tests::shell_execution_scrubs_parent_env_and_keeps_explicit_env" fail on non posix shell like fish.
Use "sh -c" run command to fix it.

## Testing

- [ x ] `cargo fmt --all -- --check`
- [ x ] `cargo clippy --workspace --all-targets --all-features`
- [ x ] `cargo test --workspace --all-features`

## Checklist

- [ x ] Updated docs or comments as needed
- [ x ] Added or updated tests where relevant
- [ x ] Verified TUI behavior manually if UI changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a test failure on non-POSIX shells (e.g. fish) by wrapping the test command in `sh -c '...'`, ensuring the POSIX `${VAR-default}` parameter expansion syntax is always interpreted by a POSIX-compatible shell rather than the user's default shell.

- The original command relied on `${VAR-default}` expansion being understood by the ambient shell; wrapping in `sh -c` ensures a POSIX interpreter regardless of the configured shell dispatcher.
- The quoting is correct: the `sh -c` argument uses single quotes, which prevent the outer shell from reinterpreting the double-quoted format string and variable expansions inside.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — it is a one-line test-only change with correct quoting and no impact on production code paths.

The change is confined to a single test, replaces a shell-specific invocation with a portable `sh -c` wrapper, preserves the original test assertion, and introduces no new logic or risk.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tools/shell/tests.rs | One-line change: wraps the env-scrubbing test command in `sh -c '...'` so POSIX parameter expansion works on non-POSIX shells like fish. Quoting is correct and the test assertion logic is unchanged. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant T as Test
    participant M as ShellManager
    participant OS as OS Shell (e.g. fish)
    participant SH as sh (POSIX)

    T->>M: execute_with_options_env("sh -c 'printf ...'")
    M->>OS: spawn with scrubbed env + explicit vars
    OS->>SH: "sh -c 'printf "%s\n%s\n" "${VAR-unset}" ...'"
    SH-->>OS: "unset\nexplicit-value\n"
    OS-->>M: stdout
    M-->>T: "ShellResult { stdout: "unset\nexplicit-value\n" }"
    T->>T: assert_eq!(result.stdout, "unset\nexplicit-value\n")
```
</details>

<sub>Reviews (1): Last reviewed commit: ["test(shell): fix test on non posix shell"](https://github.com/hmbown/codewhale/commit/e973afad70146d0ed2de4915b4a88e5cfbcb5425) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34881255)</sub>

<!-- /greptile_comment -->