### PR TITLE
fix(tui): contain Windows shell process trees

### DIFF
--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -95,4 +95,4 @@ objc2 = "0.6.3"
 objc2-foundation = { version = "0.3.2", default-features = false, features = ["std", "NSArray", "NSDictionary", "NSError", "NSObject", "NSString", "NSURL"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.60", features = ["Win32_Foundation", "Win32_System_Console", "Win32_UI_WindowsAndMessaging", "Win32_System_Diagnostics_Debug", "Win32_System_Threading"] }
+windows = { version = "0.60", features = ["Win32_Foundation", "Win32_Security", "Win32_System_Console", "Win32_System_Diagnostics_Debug", "Win32_System_JobObjects", "Win32_System_Threading", "Win32_UI_WindowsAndMessaging"] }

--- a/crates/tui/src/tools/shell.rs
+++ b/crates/tui/src/tools/shell.rs
@@ -488,6 +488,13 @@ impl BackgroundShell {
         if let Some(job) = self.windows_job.as_ref() {
             let _ = job.terminate();
         }
+        #[cfg(windows)]
+        {
+            // Close the job handle before joining reader threads so
+            // JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE can still release inherited
+            // pipe handles if explicit termination failed.
+            self.windows_job = None;
+        }
         if let Some(handle) = self.stdout_thread.take() {
             let _ = handle.join();
         }
@@ -495,10 +502,6 @@ impl BackgroundShell {
             let _ = handle.join();
         }
         self.stdin = None;
-        #[cfg(windows)]
-        {
-            self.windows_job = None;
-        }
         self.child = None;
     }
 

--- a/crates/tui/src/tools/shell.rs
+++ b/crates/tui/src/tools/shell.rs
@@ -21,6 +21,18 @@ use wait_timeout::ChildExt;
 
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
+#[cfg(windows)]
+use std::os::windows::io::AsRawHandle;
+#[cfg(windows)]
+use windows::Win32::Foundation::{CloseHandle, HANDLE};
+#[cfg(windows)]
+use windows::Win32::System::JobObjects::{
+    AssignProcessToJobObject, CreateJobObjectW, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+    JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectExtendedLimitInformation,
+    SetInformationJobObject, TerminateJobObject,
+};
+#[cfg(windows)]
+use windows::core::PCWSTR;
 
 use portable_pty::{CommandBuilder, PtySize, native_pty_system};
 
@@ -223,6 +235,75 @@ fn install_parent_death_signal(_cmd: &mut Command) {
     // leak children on those platforms — tracked as a follow-up.
 }
 
+#[cfg(windows)]
+#[derive(Debug)]
+struct WindowsJob {
+    handle: HANDLE,
+}
+
+#[cfg(windows)]
+// SAFETY: Windows job handles are process-wide kernel handles. Moving the
+// wrapper between threads does not invalidate the handle, and access is
+// externally synchronized by ShellManager's mutex.
+unsafe impl Send for WindowsJob {}
+#[cfg(windows)]
+// SAFETY: The wrapper exposes only terminate/drop operations around a kernel
+// handle; concurrent use is guarded by ShellManager.
+unsafe impl Sync for WindowsJob {}
+
+#[cfg(windows)]
+impl WindowsJob {
+    fn attach_to_child(child: &Child) -> std::io::Result<Self> {
+        let handle = unsafe { CreateJobObjectW(None, PCWSTR::null()).map_err(windows_io_error)? };
+        let job = Self { handle };
+
+        let mut limits = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+        limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+
+        unsafe {
+            SetInformationJobObject(
+                job.handle,
+                JobObjectExtendedLimitInformation,
+                &limits as *const _ as *const core::ffi::c_void,
+                std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+            )
+            .map_err(windows_io_error)?;
+
+            let process_handle = HANDLE(child.as_raw_handle() as *mut core::ffi::c_void);
+            AssignProcessToJobObject(job.handle, process_handle).map_err(windows_io_error)?;
+        }
+
+        Ok(job)
+    }
+
+    fn terminate(&self) -> std::io::Result<()> {
+        unsafe { TerminateJobObject(self.handle, 1).map_err(windows_io_error) }
+    }
+}
+
+#[cfg(windows)]
+impl Drop for WindowsJob {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = CloseHandle(self.handle);
+        }
+    }
+}
+
+#[cfg(windows)]
+fn windows_io_error(error: windows::core::Error) -> std::io::Error {
+    std::io::Error::other(error)
+}
+
+#[cfg(windows)]
+fn terminate_windows_job(job: Option<&WindowsJob>, child: &mut Child) -> std::io::Result<()> {
+    if let Some(job) = job {
+        job.terminate()
+    } else {
+        child.kill()
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 struct ShellExitStatus {
     code: Option<i32>,
@@ -333,6 +414,8 @@ pub struct BackgroundShell {
     stderr_cursor: usize,
     stdin: Option<StdinWriter>,
     child: Option<ShellChild>,
+    #[cfg(windows)]
+    windows_job: Option<WindowsJob>,
     stdout_thread: Option<std::thread::JoinHandle<()>>,
     stderr_thread: Option<std::thread::JoinHandle<()>>,
 }
@@ -379,6 +462,10 @@ impl BackgroundShell {
         if let Some(ShellChild::Process(ref mut proc)) = self.child {
             let _ = kill_child_process_group(proc);
         }
+        #[cfg(windows)]
+        if let Some(job) = self.windows_job.as_ref() {
+            let _ = job.terminate();
+        }
         if let Some(handle) = self.stdout_thread.take() {
             let _ = handle.join();
         }
@@ -386,6 +473,10 @@ impl BackgroundShell {
             let _ = handle.join();
         }
         self.stdin = None;
+        #[cfg(windows)]
+        {
+            self.windows_job = None;
+        }
         self.child = None;
     }
 
@@ -470,8 +561,22 @@ impl BackgroundShell {
     /// Kill the process
     fn kill(&mut self) -> Result<()> {
         if let Some(ref mut child) = self.child {
-            child.kill().context("Failed to kill process")?;
-            let _ = child.wait();
+            if let ShellChild::Process(proc) = child {
+                #[cfg(windows)]
+                {
+                    terminate_windows_job(self.windows_job.as_ref(), proc)
+                        .context("Failed to kill process tree")?;
+                    let _ = proc.wait();
+                }
+                #[cfg(not(windows))]
+                {
+                    proc.kill().context("Failed to kill process")?;
+                    let _ = proc.wait();
+                }
+            } else {
+                child.kill().context("Failed to kill process")?;
+                let _ = child.wait();
+            }
         }
         self.status = ShellStatus::Killed;
         self.collect_output();
@@ -553,6 +658,13 @@ impl Drop for BackgroundShell {
         if self.status == ShellStatus::Running
             && let Some(ref mut child) = self.child
         {
+            #[cfg(windows)]
+            if let ShellChild::Process(proc) = child {
+                let _ = terminate_windows_job(self.windows_job.as_ref(), proc);
+            } else {
+                let _ = child.kill();
+            }
+            #[cfg(not(windows))]
             let _ = child.kill();
             let _ = child.wait();
         }
@@ -869,6 +981,8 @@ impl ShellManager {
         let mut child = cmd
             .spawn()
             .with_context(|| format!("Failed to execute: {original_command}"))?;
+        #[cfg(windows)]
+        let windows_job = WindowsJob::attach_to_child(&child).ok();
 
         if let Some(input) = stdin_data
             && let Some(mut stdin) = child.stdin.take()
@@ -899,6 +1013,10 @@ impl ShellManager {
 
         // Wait with timeout
         if let Some(status) = child.wait_timeout(timeout)? {
+            #[cfg(windows)]
+            if let Some(job) = windows_job.as_ref() {
+                let _ = job.terminate();
+            }
             let stdout = stdout_thread.join().unwrap_or_default();
             let stderr = stderr_thread.join().unwrap_or_default();
             let stdout_str = String::from_utf8_lossy(&stdout).to_string();
@@ -939,7 +1057,9 @@ impl ShellManager {
             // Timeout - kill the process
             #[cfg(unix)]
             let _ = kill_child_process_group(&mut child);
-            #[cfg(not(unix))]
+            #[cfg(windows)]
+            let _ = terminate_windows_job(windows_job.as_ref(), &mut child);
+            #[cfg(all(not(unix), not(windows)))]
             let _ = child.kill();
             let status = child.wait().ok();
             let stdout = stdout_thread.join().unwrap_or_default();
@@ -1025,8 +1145,14 @@ impl ShellManager {
         let mut child = cmd
             .spawn()
             .with_context(|| format!("Failed to execute: {original_command}"))?;
+        #[cfg(windows)]
+        let windows_job = WindowsJob::attach_to_child(&child).ok();
 
         if let Some(status) = child.wait_timeout(timeout)? {
+            #[cfg(windows)]
+            if let Some(job) = windows_job.as_ref() {
+                let _ = job.terminate();
+            }
             Ok(ShellResult {
                 task_id: None,
                 status: if status.success() {
@@ -1055,7 +1181,9 @@ impl ShellManager {
         } else {
             #[cfg(unix)]
             let _ = kill_child_process_group(&mut child);
-            #[cfg(not(unix))]
+            #[cfg(windows)]
+            let _ = terminate_windows_job(windows_job.as_ref(), &mut child);
+            #[cfg(all(not(unix), not(windows)))]
             let _ = child.kill();
             let status = child.wait().ok();
 
@@ -1107,6 +1235,9 @@ impl ShellManager {
         } else {
             Some(Arc::new(Mutex::new(Vec::new())))
         };
+
+        #[cfg(windows)]
+        let mut windows_job = None;
 
         let (child, stdin, stdout_thread, stderr_thread) = if tty {
             let pty_system = native_pty_system();
@@ -1165,6 +1296,10 @@ impl ShellManager {
             let mut child = cmd
                 .spawn()
                 .with_context(|| format!("Failed to spawn background: {original_command}"))?;
+            #[cfg(windows)]
+            {
+                windows_job = WindowsJob::attach_to_child(&child).ok();
+            }
 
             let stdout_handle = child.stdout.take().context("Failed to capture stdout")?;
             let stderr_handle = child.stderr.take().context("Failed to capture stderr")?;
@@ -1201,6 +1336,8 @@ impl ShellManager {
             stderr_cursor: 0,
             stdin,
             child: Some(child),
+            #[cfg(windows)]
+            windows_job,
             stdout_thread,
             stderr_thread,
         };

--- a/crates/tui/src/tools/shell.rs
+++ b/crates/tui/src/tools/shell.rs
@@ -312,6 +312,29 @@ fn terminate_windows_job(job: Option<&WindowsJob>, child: &mut Child) -> std::io
 }
 
 #[cfg(windows)]
+fn terminate_and_close_windows_job(windows_job: Option<WindowsJob>) {
+    if let Some(job) = windows_job.as_ref()
+        && let Err(err) = job.terminate()
+    {
+        tracing::warn!(
+            ?err,
+            "failed to terminate Windows shell job before closing job handle"
+        );
+    }
+    drop(windows_job);
+}
+
+#[cfg(windows)]
+fn terminate_child_and_close_windows_job(
+    windows_job: Option<WindowsJob>,
+    child: &mut Child,
+) -> std::io::Result<()> {
+    let result = terminate_windows_job(windows_job.as_ref(), child);
+    drop(windows_job);
+    result
+}
+
+#[cfg(windows)]
 fn attach_windows_job(child: &Child, command: &str) -> Option<WindowsJob> {
     match WindowsJob::attach_to_child(child) {
         Ok(job) => Some(job),
@@ -485,16 +508,7 @@ impl BackgroundShell {
             let _ = kill_child_process_group(proc);
         }
         #[cfg(windows)]
-        if let Some(job) = self.windows_job.as_ref() {
-            let _ = job.terminate();
-        }
-        #[cfg(windows)]
-        {
-            // Close the job handle before joining reader threads so
-            // JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE can still release inherited
-            // pipe handles if explicit termination failed.
-            self.windows_job = None;
-        }
+        terminate_and_close_windows_job(self.windows_job.take());
         if let Some(handle) = self.stdout_thread.take() {
             let _ = handle.join();
         }
@@ -1039,9 +1053,7 @@ impl ShellManager {
         // Wait with timeout
         if let Some(status) = child.wait_timeout(timeout)? {
             #[cfg(windows)]
-            if let Some(job) = windows_job.as_ref() {
-                let _ = job.terminate();
-            }
+            terminate_and_close_windows_job(windows_job);
             let stdout = stdout_thread.join().unwrap_or_default();
             let stderr = stderr_thread.join().unwrap_or_default();
             let stdout_str = String::from_utf8_lossy(&stdout).to_string();
@@ -1083,7 +1095,7 @@ impl ShellManager {
             #[cfg(unix)]
             let _ = kill_child_process_group(&mut child);
             #[cfg(windows)]
-            let _ = terminate_windows_job(windows_job.as_ref(), &mut child);
+            let _ = terminate_child_and_close_windows_job(windows_job, &mut child);
             #[cfg(all(not(unix), not(windows)))]
             let _ = child.kill();
             let status = child.wait().ok();
@@ -1175,9 +1187,7 @@ impl ShellManager {
 
         if let Some(status) = child.wait_timeout(timeout)? {
             #[cfg(windows)]
-            if let Some(job) = windows_job.as_ref() {
-                let _ = job.terminate();
-            }
+            terminate_and_close_windows_job(windows_job);
             Ok(ShellResult {
                 task_id: None,
                 status: if status.success() {
@@ -1207,7 +1217,7 @@ impl ShellManager {
             #[cfg(unix)]
             let _ = kill_child_process_group(&mut child);
             #[cfg(windows)]
-            let _ = terminate_windows_job(windows_job.as_ref(), &mut child);
+            let _ = terminate_child_and_close_windows_job(windows_job, &mut child);
             #[cfg(all(not(unix), not(windows)))]
             let _ = child.kill();
             let status = child.wait().ok();

--- a/crates/tui/src/tools/shell.rs
+++ b/crates/tui/src/tools/shell.rs
@@ -298,9 +298,31 @@ fn windows_io_error(error: windows::core::Error) -> std::io::Error {
 #[cfg(windows)]
 fn terminate_windows_job(job: Option<&WindowsJob>, child: &mut Child) -> std::io::Result<()> {
     if let Some(job) = job {
-        job.terminate()
-    } else {
-        child.kill()
+        match job.terminate() {
+            Ok(()) => return Ok(()),
+            Err(error) => {
+                tracing::warn!(
+                    ?error,
+                    "failed to terminate Windows job object; falling back to immediate child kill"
+                );
+            }
+        }
+    }
+    child.kill()
+}
+
+#[cfg(windows)]
+fn attach_windows_job(child: &Child, command: &str) -> Option<WindowsJob> {
+    match WindowsJob::attach_to_child(child) {
+        Ok(job) => Some(job),
+        Err(error) => {
+            tracing::warn!(
+                ?error,
+                command,
+                "failed to attach Windows shell process to job object; descendant cleanup degraded"
+            );
+            None
+        }
     }
 }
 
@@ -982,7 +1004,7 @@ impl ShellManager {
             .spawn()
             .with_context(|| format!("Failed to execute: {original_command}"))?;
         #[cfg(windows)]
-        let windows_job = WindowsJob::attach_to_child(&child).ok();
+        let windows_job = attach_windows_job(&child, original_command);
 
         if let Some(input) = stdin_data
             && let Some(mut stdin) = child.stdin.take()
@@ -1146,7 +1168,7 @@ impl ShellManager {
             .spawn()
             .with_context(|| format!("Failed to execute: {original_command}"))?;
         #[cfg(windows)]
-        let windows_job = WindowsJob::attach_to_child(&child).ok();
+        let windows_job = attach_windows_job(&child, original_command);
 
         if let Some(status) = child.wait_timeout(timeout)? {
             #[cfg(windows)]
@@ -1298,7 +1320,7 @@ impl ShellManager {
                 .with_context(|| format!("Failed to spawn background: {original_command}"))?;
             #[cfg(windows)]
             {
-                windows_job = WindowsJob::attach_to_child(&child).ok();
+                windows_job = attach_windows_job(&child, original_command);
             }
 
             let stdout_handle = child.stdout.take().context("Failed to capture stdout")?;

--- a/crates/tui/src/tools/shell/tests.rs
+++ b/crates/tui/src/tools/shell/tests.rs
@@ -4,6 +4,11 @@ use crate::tools::spec::ToolContext;
 use serde_json::{Value, json};
 use tempfile::tempdir;
 
+#[cfg(windows)]
+use windows::Win32::Foundation::{DUPLICATE_HANDLE_OPTIONS, DuplicateHandle, HANDLE};
+#[cfg(windows)]
+use windows::Win32::System::Threading::GetCurrentProcess;
+
 // `env_lock` exists only to serialize Unix-only env-mutating tests.
 // Windows builds gate that test out, so the helper would be dead code
 // under `-Dwarnings` if the import + helper were unconditional.
@@ -14,6 +19,33 @@ use std::sync::{Mutex, OnceLock};
 fn env_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     LOCK.get_or_init(|| Mutex::new(()))
+}
+
+#[cfg(windows)]
+const JOB_OBJECT_QUERY_ACCESS: u32 = 0x0004;
+
+#[cfg(windows)]
+fn duplicate_job_without_terminate_access(job: WindowsJob) -> WindowsJob {
+    let process = unsafe { GetCurrentProcess() };
+    let mut limited_handle = HANDLE::default();
+
+    unsafe {
+        DuplicateHandle(
+            process,
+            job.handle,
+            process,
+            &mut limited_handle,
+            JOB_OBJECT_QUERY_ACCESS,
+            false,
+            DUPLICATE_HANDLE_OPTIONS(0),
+        )
+        .expect("duplicate job handle without terminate access");
+    }
+
+    drop(job);
+    WindowsJob {
+        handle: limited_handle,
+    }
 }
 
 fn echo_command(message: &str) -> String {
@@ -950,6 +982,78 @@ fn background_collection_does_not_block_on_detached_descendant_pipe() {
     assert!(
         started.elapsed() < std::time::Duration::from_secs(6),
         "get_output blocked on descendant pipe handles"
+    );
+    assert_eq!(done.status, ShellStatus::Completed);
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_job_terminate_denied_falls_back_to_child_kill() {
+    let mut child = Command::new("ping")
+        .args(["127.0.0.1", "-n", "20"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn ping");
+
+    let job = WindowsJob::attach_to_child(&child).expect("attach job");
+    let limited_job = duplicate_job_without_terminate_access(job);
+
+    assert!(
+        limited_job.terminate().is_err(),
+        "limited job handle should not allow TerminateJobObject"
+    );
+
+    terminate_windows_job(Some(&limited_job), &mut child).expect("fallback child kill");
+
+    let status = child
+        .wait_timeout(std::time::Duration::from_secs(3))
+        .expect("wait after fallback kill");
+    assert!(
+        status.is_some(),
+        "fallback child kill should terminate child"
+    );
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_job_kill_on_close_releases_reader_threads_when_terminate_denied() {
+    let tmp = tempdir().expect("tempdir");
+    let mut manager = ShellManager::new(tmp.path().to_path_buf());
+
+    let result = manager
+        .execute(
+            r#"cmd /c start "" /b ping 127.0.0.1 -n 8"#,
+            None,
+            5000,
+            true,
+        )
+        .expect("execute");
+    let task_id = result.task_id.expect("task id");
+
+    {
+        let shell = manager
+            .processes
+            .get_mut(&task_id)
+            .expect("background shell");
+        let job = shell.windows_job.take().expect("windows job attached");
+        let limited_job = duplicate_job_without_terminate_access(job);
+        assert!(
+            limited_job.terminate().is_err(),
+            "limited job handle should not allow TerminateJobObject"
+        );
+        shell.windows_job = Some(limited_job);
+    }
+
+    let started = std::time::Instant::now();
+    let done = manager
+        .get_output(&task_id, true, 3000)
+        .expect("get_output must complete via kill-on-close fallback");
+
+    assert!(
+        started.elapsed() < std::time::Duration::from_secs(4),
+        "get_output waited for natural descendant exit instead of kill-on-close"
     );
     assert_eq!(done.status, ShellStatus::Completed);
 }

--- a/crates/tui/src/tools/shell/tests.rs
+++ b/crates/tui/src/tools/shell/tests.rs
@@ -922,6 +922,38 @@ fn test_orphaned_subprocess_does_not_block_collect_output() {
     assert_eq!(done.status, ShellStatus::Completed);
 }
 
+// Windows equivalent of the orphaned pipe-handle regression. `cmd /c start /b`
+// launches a descendant process that inherits stdout/stderr and outlives the
+// shell. Job-object cleanup must terminate that descendant before reader-thread
+// joins, otherwise get_output() blocks until ping exits.
+#[cfg(windows)]
+#[test]
+fn background_collection_does_not_block_on_detached_descendant_pipe() {
+    let tmp = tempdir().expect("tempdir");
+    let mut manager = ShellManager::new(tmp.path().to_path_buf());
+
+    let result = manager
+        .execute(
+            r#"cmd /c start "" /b ping 127.0.0.1 -n 8"#,
+            None,
+            5000,
+            true,
+        )
+        .expect("execute");
+    let task_id = result.task_id.expect("task id");
+
+    let started = std::time::Instant::now();
+    let done = manager
+        .get_output(&task_id, true, 3000)
+        .expect("get_output must complete, not hang");
+
+    assert!(
+        started.elapsed() < std::time::Duration::from_secs(3),
+        "get_output blocked on descendant pipe handles"
+    );
+    assert_eq!(done.status, ShellStatus::Completed);
+}
+
 #[test]
 fn test_list_jobs_cleans_up_completed_old_processes() {
     let tmp = tempdir().expect("tempdir");

--- a/crates/tui/src/tools/shell/tests.rs
+++ b/crates/tui/src/tools/shell/tests.rs
@@ -934,7 +934,7 @@ fn background_collection_does_not_block_on_detached_descendant_pipe() {
 
     let result = manager
         .execute(
-            r#"cmd /c start "" /b ping 127.0.0.1 -n 8"#,
+            r#"cmd /c start "" /b ping 127.0.0.1 -n 4"#,
             None,
             5000,
             true,
@@ -948,7 +948,7 @@ fn background_collection_does_not_block_on_detached_descendant_pipe() {
         .expect("get_output must complete, not hang");
 
     assert!(
-        started.elapsed() < std::time::Duration::from_secs(3),
+        started.elapsed() < std::time::Duration::from_secs(6),
         "get_output blocked on descendant pipe handles"
     );
     assert_eq!(done.status, ShellStatus::Completed);

--- a/crates/tui/src/tools/shell/tests.rs
+++ b/crates/tui/src/tools/shell/tests.rs
@@ -1005,7 +1005,8 @@ fn windows_job_terminate_denied_falls_back_to_child_kill() {
         "limited job handle should not allow TerminateJobObject"
     );
 
-    terminate_windows_job(Some(&limited_job), &mut child).expect("fallback child kill");
+    terminate_child_and_close_windows_job(Some(limited_job), &mut child)
+        .expect("fallback child kill");
 
     let status = child
         .wait_timeout(std::time::Duration::from_secs(3))
@@ -1014,6 +1015,54 @@ fn windows_job_terminate_denied_falls_back_to_child_kill() {
         status.is_some(),
         "fallback child kill should terminate child"
     );
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_job_close_releases_foreground_reader_threads_when_terminate_denied() {
+    let mut child = Command::new("ping")
+        .args(["127.0.0.1", "-n", "8"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn ping");
+
+    let job = WindowsJob::attach_to_child(&child).expect("attach job");
+    let limited_job = duplicate_job_without_terminate_access(job);
+    assert!(
+        limited_job.terminate().is_err(),
+        "limited job handle should not allow TerminateJobObject"
+    );
+
+    let stdout_handle = child.stdout.take().expect("stdout pipe");
+    let stderr_handle = child.stderr.take().expect("stderr pipe");
+    let stdout_thread = std::thread::spawn(move || {
+        let mut reader = stdout_handle;
+        let mut buf = Vec::new();
+        let _ = reader.read_to_end(&mut buf);
+        buf
+    });
+    let stderr_thread = std::thread::spawn(move || {
+        let mut reader = stderr_handle;
+        let mut buf = Vec::new();
+        let _ = reader.read_to_end(&mut buf);
+        buf
+    });
+
+    let started = std::time::Instant::now();
+    terminate_and_close_windows_job(Some(limited_job));
+    let _ = stdout_thread.join().unwrap_or_default();
+    let _ = stderr_thread.join().unwrap_or_default();
+    let status = child
+        .wait_timeout(std::time::Duration::from_secs(3))
+        .expect("wait after kill-on-close");
+
+    assert!(
+        started.elapsed() < std::time::Duration::from_secs(4),
+        "reader joins waited for natural descendant exit instead of kill-on-close"
+    );
+    assert!(status.is_some(), "kill-on-close should terminate child");
 }
 
 #[cfg(windows)]


### PR DESCRIPTION
## Summary

Partial #1812.

This PR contains Windows shell process trees with a Job Object so `exec_shell` output collection cannot block forever when a descendant process outlives the immediate shell and keeps inherited stdout/stderr pipe handles open.

## Why

I captured a live Windows freeze where CodeWhale was stuck after starting this foreground shell command:

```text
findstr /s /m "019e65ab-22c2-7cc0-ab61-bd8411e3e7c4" C:\myWork\AboimPintoConsulting\*
```

The immediate shell process had already exited, but an orphaned `findstr.exe` descendant was still alive and holding inherited pipe handles. `BackgroundShell::collect_output()` then joined the stdout/stderr reader threads, but those readers never saw EOF until the descendant was killed. Killing only `findstr.exe` immediately released the frozen TUI and the log emitted the delayed `tool.exec.end` after about 18.8 minutes.

This is a separate freeze mode from the crossterm input-poll freeze discussed in #1812. It is still in the same Windows/shell family, but the blocking point here is shell output collection after process-tree leakage.

## What changed

- Adds a Windows-only `WindowsJob` wrapper around Job Objects.
- Sets `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`.
- Assigns spawned non-PTY shell children to the job immediately after spawn.
- Terminates the job before joining shell output reader threads.
- Uses the same job termination path for normal completion, timeout, cancellation, and drop cleanup.
- Adds a Windows regression test that starts a detached descendant with inherited pipes and verifies `get_output` returns quickly.

## Scope

This should fix the observed `exec_shell` hang where a descendant process keeps stdout/stderr pipes open after the shell exits.

It does not claim to solve every Windows TUI freeze. In particular, it does not replace the crossterm `event::poll(timeout)` investigation/mitigation, and it does not address context-pressure or model-streaming stalls.

## Validation

```powershell
cargo fmt --check
git diff --check
cargo check -p codewhale-tui
cargo test -p codewhale-tui background_collection_does_not_block_on_detached_descendant_pipe -- --nocapture
```

Local Windows note: the GNU toolchain needed `C:\msys64\mingw64\bin` on PATH for `dlltool.exe`. The test command was also run with `CARGO_INCREMENTAL=0` and `RUSTFLAGS="-C debuginfo=0"` after the local disk filled during test binary linking.

Paulo Aboim Pinto

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a `WindowsJob` RAII wrapper around Windows Job Objects to contain shell process trees during non-PTY `exec_shell` runs. The immediate child is assigned to a job with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` set so that descendants holding inherited pipe handles are reliably killed before stdout/stderr reader threads are joined, eliminating the hang observed with orphaned `findstr.exe` and similar detached descendants.

- Adds `WindowsJob` wrapper with `attach_to_child`, `terminate`, and `Drop` (via `CloseHandle`) covering all three execution paths: `execute_sync_sandboxed`, `execute_interactive_sandboxed`, and `start_background` / `collect_output`.
- Introduces layered cleanup: explicit `TerminateJobObject` first, `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` as an automatic fallback when the handle is closed, and a per-child `kill()` fallback when termination access is denied.
- Adds four Windows-only regression tests covering the detached-descendant hang, the `TerminateJobObject`-denied fallback, kill-on-close as a secondary defence, and the end-to-end `get_output` non-block scenario.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the Windows-only job-object path is well-isolated behind cfg(windows) guards, all three execution paths drop the job handle before joining reader threads, and the KILL_ON_JOB_CLOSE fallback fires correctly even when explicit TerminateJobObject is denied.

All three shell execution paths (sync sandboxed, interactive sandboxed, background) now drop the WindowsJob handle before joining stdout/stderr reader threads, making KILL_ON_JOB_CLOSE an effective second-line defence. Attach failures are surfaced via tracing::warn rather than silently swallowed. The drop ordering fix from a prior review round has been applied consistently. Four targeted regression tests, including a deny-terminate scenario via DuplicateHandle, give good confidence the fix holds under access-constrained environments.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tools/shell.rs | Core implementation of WindowsJob wrapper and all three cleanup paths; job handle is correctly dropped before thread joins in every code path, and attach failures produce a tracing::warn rather than silently degrading. |
| crates/tui/src/tools/shell/tests.rs | Adds four Windows-only tests including a duplicate-handle helper to simulate TerminateJobObject access denial; timing assertions use a 6 s bound against a 3 s get_output timeout providing adequate slack. |
| crates/tui/Cargo.toml | Adds Win32_Security and Win32_System_JobObjects feature flags to the windows crate dependency; no version bump required. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant SM as ShellManager
    participant CH as Child Process
    participant WJ as WindowsJob (KILL_ON_JOB_CLOSE)
    participant RT as Reader Threads
    participant DC as Descendant Processes

    SM->>CH: spawn()
    SM->>WJ: CreateJobObjectW + SetInformationJobObject
    SM->>WJ: AssignProcessToJobObject(child)
    CH-->>DC: spawns descendants (inherit pipes)
    CH->>CH: exits (immediate shell)
    DC-->>RT: hold pipe write-ends open

    Note over SM: poll() detects shell exit

    SM->>WJ: TerminateJobObject (explicit)
    WJ->>DC: kill all job processes
    SM->>WJ: drop handle (CloseHandle)
    Note over WJ: KILL_ON_JOB_CLOSE fires as fallback

    WJ-->>DC: kill remaining descendants
    DC-->>RT: pipe write-ends closed, EOF
    SM->>RT: join stdout_thread
    SM->>RT: join stderr_thread
    RT-->>SM: output collected (no hang)
```
</details>

<sub>Reviews (7): Last reviewed commit: ["fix(tui): close Windows job before foreg..."](https://github.com/hmbown/codewhale/commit/96adffb243801dcef6c6332611728930e438f1a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34888870)</sub>

<!-- /greptile_comment -->