### PR TITLE
feat(web_search): enable parallel execution for read-only search tool

### DIFF
--- a/crates/tui/src/tools/web_search.rs
+++ b/crates/tui/src/tools/web_search.rs
@@ -186,6 +186,10 @@ impl ToolSpec for WebSearchTool {
         ApprovalRequirement::Auto
     }
 
+    fn supports_parallel(&self) -> bool {
+        true
+    }
+
     async fn execute(&self, input: Value, context: &ToolContext) -> Result<ToolResult, ToolError> {
         let query = extract_search_query(&input)?;
         if query.is_empty() {


### PR DESCRIPTION
## Summary

Override `supports_parallel()` to return `true` in `WebSearchTool`, allowing the engine to batch multiple concurrent `web_search` calls into a `FuturesUnordered` parallel group instead of serializing them.

The tool is already read-only, auto-approved, and non-interactive — parallel-safe by all other criteria. This change removes the final gate (`supports_parallel() -> false` default) so co-issued searches run concurrently rather than one-at-a-time.

Closes the ~55s serial wall-clock for 3 simultaneous web searches (now ~20s, the slowest individual call).

## Background

### Why parallel execution matters for Volcengine users

Volcengine's web search uses an LLM-summarized pipeline (Ark Responses API) where the model performs the search and returns structured JSON. A single call takes ~20 seconds — acceptable on its own, but when the agent issues 3 co-occurring searches, serial execution stacks them to ~55s total.

Prior to this change, observing the third search returning at ~50s led to the mistaken conclusion that individual Volcengine responses could take 50+ seconds, which drove the existing 90s timeout floor. In reality, a single call completes in ~20s; the 50s was accumulated serial latency from three sequential calls.

For users in regions where DuckDuckGo/Bing work reliably and return results quickly, this change is a nice-to-have. For Volcengine users who rely on the LLM-summarized pipeline, it is critical — without parallel execution, multi-search turns are painfully slow despite each individual call being reasonably fast.

### Root cause

`ToolSpec::supports_parallel()` defaults to `false`. `WebSearchTool` did not override it. `tool_plan_is_parallel_safe()` in `dispatch.rs` requires all four conditions:

- `read_only` (true)
- `supports_parallel` (was false — the blocker)
- `!approval_required` (true)
- `!interactive` (true)

## Changes

- `crates/tui/src/tools/web_search.rs`: add `supports_parallel() -> true` override in `impl ToolSpec for WebSearchTool` (4 lines)

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features`
- [x] `cargo test --workspace --all-features` (4101 passed, 0 failed, 8 ignored)

## Checklist

- [x] Updated docs or comments as needed — (N/A, self-documenting)
- [x] Added or updated tests where relevant — (N/A, existing tests cover the contract; `web_search` tests all pass)
- [x] Verified TUI behavior manually if UI changes — (N/A, no UI changes)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR enables parallel execution for `WebSearchTool` by overriding `supports_parallel()` to return `true`, unlocking the engine's `FuturesUnordered` batching path for concurrent `web_search` calls. The tool already satisfied the other three `tool_plan_is_parallel_safe` conditions (`read_only`, `!approval_required`, `!interactive`), making this a minimal and targeted unlock.

- Adds a 4-line `supports_parallel() -> true` override in `impl ToolSpec for WebSearchTool`; no logic changes to any provider path.
- Particularly impactful for Volcengine users, where the LLM-summarized pipeline takes ~20 s per call — three concurrent searches now resolve in ~20 s instead of ~55 s.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is a single boolean method override with no side effects on any execution path.

The change is minimal and correct: `WebSearchTool` was already read-only, auto-approved, and non-interactive, so enabling parallel execution requires no defensive guards. All providers create independent `reqwest::Client` instances per call and share no mutable state. The only open items are style-level: a missing regression test to pin the `supports_parallel` contract, and a code comment about the Volcengine 90 s timeout floor whose original motivation no longer fully applies.

No files require special attention; the single changed file touches only the `ToolSpec` trait impl.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/tui/src/tools/web_search.rs | Adds `supports_parallel() -> true` override to `WebSearchTool`; the tool is stateless, read-only, and auto-approved — all four `tool_plan_is_parallel_safe` conditions are now satisfied. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Engine as turn_loop
    participant Dispatcher as dispatch.rs
    participant S1 as WebSearch #1
    participant S2 as WebSearch #2
    participant S3 as WebSearch #3

    Engine->>Dispatcher: plan_tool_execution_batches([search1, search2, search3])
    Note over Dispatcher: tool_plan_is_parallel_safe:<br/>read_only=true, supports_parallel=true,<br/>approval_required=false, interactive=false
    Dispatcher-->>Engine: ToolExecutionBatch::Parallel([s1, s2, s3])

    par FuturesUnordered
        Engine->>S1: execute(query1)
        Engine->>S2: execute(query2)
        Engine->>S3: execute(query3)
    end

    S1-->>Engine: results (~20s)
    S2-->>Engine: results (~20s)
    S3-->>Engine: results (~20s)
    Note over Engine: Total wall-clock: ~20s (was ~55s serial)
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/tui/src/tools/web_search.rs`, line 777-779 ([link](https://github.com/hmbown/codewhale/blob/a7dcf63c556268b53ff430747ae2e141e4cd4451/crates/tui/src/tools/web_search.rs#L777-L779)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The PR description acknowledges that the 90 s floor was originally motivated by the observation that the third serial search completed at ~50 s, not because individual calls take that long. Now that calls run concurrently, the comment "is inherently slower than simple search-API round-trips" is still valid, but the floor itself is based on a premise that parallel execution removes. The value is harmlessly conservative, but the inline comment no longer explains the real reasoning. Consider revising it (or adding a note) so future readers aren't confused about why 90 s was chosen.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fweb-search-parallel%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fweb-search-parallel%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftools%2Fweb_search.rs%0ALine%3A%20777-779%0A%0AComment%3A%0AThe%20PR%20description%20acknowledges%20that%20the%2090%20s%20floor%20was%20originally%20motivated%20by%20the%20observation%20that%20the%20third%20serial%20search%20completed%20at%20~50%20s%2C%20not%20because%20individual%20calls%20take%20that%20long.%20Now%20that%20calls%20run%20concurrently%2C%20the%20comment%20%22is%20inherently%20slower%20than%20simple%20search-API%20round-trips%22%20is%20still%20valid%2C%20but%20the%20floor%20itself%20is%20based%20on%20a%20premise%20that%20parallel%20execution%20removes.%20The%20value%20is%20harmlessly%20conservative%2C%20but%20the%20inline%20comment%20no%20longer%20explains%20the%20real%20reasoning.%20Consider%20revising%20it%20%28or%20adding%20a%20note%29%20so%20future%20readers%20aren't%20confused%20about%20why%2090%20s%20was%20chosen.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftools%2Fweb_search.rs%0ALine%3A%20777-779%0A%0AComment%3A%0AThe%20PR%20description%20acknowledges%20that%20the%2090%20s%20floor%20was%20originally%20motivated%20by%20the%20observation%20that%20the%20third%20serial%20search%20completed%20at%20~50%20s%2C%20not%20because%20individual%20calls%20take%20that%20long.%20Now%20that%20calls%20run%20concurrently%2C%20the%20comment%20%22is%20inherently%20slower%20than%20simple%20search-API%20round-trips%22%20is%20still%20valid%2C%20but%20the%20floor%20itself%20is%20based%20on%20a%20premise%20that%20parallel%20execution%20removes.%20The%20value%20is%20harmlessly%20conservative%2C%20but%20the%20inline%20comment%20no%20longer%20explains%20the%20real%20reasoning.%20Consider%20revising%20it%20%28or%20adding%20a%20note%29%20so%20future%20readers%20aren't%20confused%20about%20why%2090%20s%20was%20chosen.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2509&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftools%2Fweb_search.rs%0ALine%3A%20777-779%0A%0AComment%3A%0AThe%20PR%20description%20acknowledges%20that%20the%2090%20s%20floor%20was%20originally%20motivated%20by%20the%20observation%20that%20the%20third%20serial%20search%20completed%20at%20~50%20s%2C%20not%20because%20individual%20calls%20take%20that%20long.%20Now%20that%20calls%20run%20concurrently%2C%20the%20comment%20%22is%20inherently%20slower%20than%20simple%20search-API%20round-trips%22%20is%20still%20valid%2C%20but%20the%20floor%20itself%20is%20based%20on%20a%20premise%20that%20parallel%20execution%20removes.%20The%20value%20is%20harmlessly%20conservative%2C%20but%20the%20inline%20comment%20no%20longer%20explains%20the%20real%20reasoning.%20Consider%20revising%20it%20%28or%20adding%20a%20note%29%20so%20future%20readers%20aren't%20confused%20about%20why%2090%20s%20was%20chosen.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2509&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fweb-search-parallel%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fweb-search-parallel%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftools%2Fweb_search.rs%3A189-191%0ANo%20regression%20test%20pins%20%60supports_parallel%28%29%60%20to%20%60true%60.%20A%20future%20refactor%20that%20accidentally%20removes%20or%20moves%20this%20override%20would%20silently%20re-serialize%20all%20web%20searches%20with%20no%20failing%20test%20to%20catch%20it.%20Adding%20%60assert!%28WebSearchTool.supports_parallel%28%29%29%60%20in%20the%20existing%20%60%23%5Bcfg%28test%29%5D%60%20block%20would%20lock%20the%20contract.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftools%2Fweb_search.rs%3A777-779%0AThe%20PR%20description%20acknowledges%20that%20the%2090%20s%20floor%20was%20originally%20motivated%20by%20the%20observation%20that%20the%20third%20serial%20search%20completed%20at%20~50%20s%2C%20not%20because%20individual%20calls%20take%20that%20long.%20Now%20that%20calls%20run%20concurrently%2C%20the%20comment%20%22is%20inherently%20slower%20than%20simple%20search-API%20round-trips%22%20is%20still%20valid%2C%20but%20the%20floor%20itself%20is%20based%20on%20a%20premise%20that%20parallel%20execution%20removes.%20The%20value%20is%20harmlessly%20conservative%2C%20but%20the%20inline%20comment%20no%20longer%20explains%20the%20real%20reasoning.%20Consider%20revising%20it%20%28or%20adding%20a%20note%29%20so%20future%20readers%20aren't%20confused%20about%20why%2090%20s%20was%20chosen.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftools%2Fweb_search.rs%3A189-191%0ANo%20regression%20test%20pins%20%60supports_parallel%28%29%60%20to%20%60true%60.%20A%20future%20refactor%20that%20accidentally%20removes%20or%20moves%20this%20override%20would%20silently%20re-serialize%20all%20web%20searches%20with%20no%20failing%20test%20to%20catch%20it.%20Adding%20%60assert!%28WebSearchTool.supports_parallel%28%29%29%60%20in%20the%20existing%20%60%23%5Bcfg%28test%29%5D%60%20block%20would%20lock%20the%20contract.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftools%2Fweb_search.rs%3A777-779%0AThe%20PR%20description%20acknowledges%20that%20the%2090%20s%20floor%20was%20originally%20motivated%20by%20the%20observation%20that%20the%20third%20serial%20search%20completed%20at%20~50%20s%2C%20not%20because%20individual%20calls%20take%20that%20long.%20Now%20that%20calls%20run%20concurrently%2C%20the%20comment%20%22is%20inherently%20slower%20than%20simple%20search-API%20round-trips%22%20is%20still%20valid%2C%20but%20the%20floor%20itself%20is%20based%20on%20a%20premise%20that%20parallel%20execution%20removes.%20The%20value%20is%20harmlessly%20conservative%2C%20but%20the%20inline%20comment%20no%20longer%20explains%20the%20real%20reasoning.%20Consider%20revising%20it%20%28or%20adding%20a%20note%29%20so%20future%20readers%20aren't%20confused%20about%20why%2090%20s%20was%20chosen.%0A%0A&repo=hmbown%2Fcodewhale&pr=2509&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftools%2Fweb_search.rs%3A189-191%0ANo%20regression%20test%20pins%20%60supports_parallel%28%29%60%20to%20%60true%60.%20A%20future%20refactor%20that%20accidentally%20removes%20or%20moves%20this%20override%20would%20silently%20re-serialize%20all%20web%20searches%20with%20no%20failing%20test%20to%20catch%20it.%20Adding%20%60assert!%28WebSearchTool.supports_parallel%28%29%29%60%20in%20the%20existing%20%60%23%5Bcfg%28test%29%5D%60%20block%20would%20lock%20the%20contract.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftools%2Fweb_search.rs%3A777-779%0AThe%20PR%20description%20acknowledges%20that%20the%2090%20s%20floor%20was%20originally%20motivated%20by%20the%20observation%20that%20the%20third%20serial%20search%20completed%20at%20~50%20s%2C%20not%20because%20individual%20calls%20take%20that%20long.%20Now%20that%20calls%20run%20concurrently%2C%20the%20comment%20%22is%20inherently%20slower%20than%20simple%20search-API%20round-trips%22%20is%20still%20valid%2C%20but%20the%20floor%20itself%20is%20based%20on%20a%20premise%20that%20parallel%20execution%20removes.%20The%20value%20is%20harmlessly%20conservative%2C%20but%20the%20inline%20comment%20no%20longer%20explains%20the%20real%20reasoning.%20Consider%20revising%20it%20%28or%20adding%20a%20note%29%20so%20future%20readers%20aren't%20confused%20about%20why%2090%20s%20was%20chosen.%0A%0A&pr=2509&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(web\_search): enable parallel execut..."](https://github.com/hmbown/codewhale/commit/a7dcf63c556268b53ff430747ae2e141e4cd4451) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34923874)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->