### PR TITLE
feat(search): allow custom DuckDuckGo endpoint

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -353,6 +353,7 @@ max_subagents = 10 # optional (1-20)
 #                            # baidu:      百度 AI Search via qianfan.baidubce.com，需 api_key
 #                            # volcengine: 火山引擎 Ark web_search (免费 2 万次/月), 需 api_key
 #                            #             也回退到 VOLCENGINE_API_KEY / VOLCENGINE_ARK_API_KEY / ARK_API_KEY 环境变量
+# base_url = "https://search.example/html/" # optional DuckDuckGo-compatible HTML endpoint
 # api_key = "YOUR_SEARCH_KEY" # required for tavily, bocha, and baidu; optional for metaso
 #                             # WARNING: treat config.toml like a secret file when
 #                             # storing API keys. Prefer env vars for local smoke tests.
@@ -360,6 +361,7 @@ max_subagents = 10 # optional (1-20)
 # Env-var overrides:
 #   DEEPSEEK_SEARCH_PROVIDER → search.provider
 #   DEEPSEEK_SEARCH_API_KEY  → search.api_key
+#   DEEPSEEK_SEARCH_BASE_URL → search.base_url
 #   METASO_API_KEY           → metaso key fallback
 #   BAIDU_SEARCH_API_KEY     → baidu key fallback
 

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -931,6 +931,11 @@ pub struct SearchConfig {
     /// Search provider: `bing` | `duckduckgo` | `tavily` | `bocha` | `metaso` | `baidu` | `volcengine`. Default: `duckduckgo`.
     #[serde(default)]
     pub provider: Option<SearchProvider>,
+    /// Optional DuckDuckGo-compatible HTML endpoint. When set with the
+    /// DuckDuckGo provider, `web_search` appends the `q` query parameter to
+    /// this URL instead of using `https://html.duckduckgo.com/html/`.
+    #[serde(default)]
+    pub base_url: Option<String>,
     /// API key for Tavily, Bocha, Metaso, Baidu, or Volcengine. Not required for Bing or DuckDuckGo.
     /// Metaso also falls back to `METASO_API_KEY` env var, then a built-in default.
     /// Baidu also falls back to `BAIDU_SEARCH_API_KEY` env var.
@@ -3340,6 +3345,14 @@ fn apply_env_overrides(config: &mut Config) {
             .get_or_insert_with(SearchConfig::default)
             .api_key = Some(value);
     }
+    if let Ok(value) = std::env::var("DEEPSEEK_SEARCH_BASE_URL")
+        && !value.trim().is_empty()
+    {
+        config
+            .search
+            .get_or_insert_with(SearchConfig::default)
+            .base_url = Some(value);
+    }
     if let Ok(value) = std::env::var("DEEPSEEK_REQUIREMENTS_PATH") {
         config.requirements_path = Some(value);
     }
@@ -4869,6 +4882,25 @@ mod tests {
     }
 
     #[test]
+    fn search_config_preserves_custom_base_url() {
+        let config: Config = toml::from_str(
+            r#"
+            [search]
+            provider = "duckduckgo"
+            base_url = "https://search.internal.example/html/"
+            "#,
+        )
+        .expect("search config");
+
+        let search = config.search.expect("search table");
+        assert_eq!(search.provider, Some(SearchProvider::DuckDuckGo));
+        assert_eq!(
+            search.base_url.as_deref(),
+            Some("https://search.internal.example/html/")
+        );
+    }
+
+    #[test]
     fn explicit_baidu_search_provider_is_preserved() {
         let config: Config = toml::from_str(
             r#"
@@ -5008,6 +5040,27 @@ mod tests {
         assert_eq!(
             config.search.and_then(|search| search.api_key),
             Some("search-env-key".to_string())
+        );
+    }
+
+    #[test]
+    fn apply_env_overrides_sets_search_base_url() {
+        let _guard = lock_test_env();
+        let prev = env::var_os("DEEPSEEK_SEARCH_BASE_URL");
+        unsafe {
+            env::set_var(
+                "DEEPSEEK_SEARCH_BASE_URL",
+                "https://search.internal.example/html/",
+            )
+        };
+        let mut config = Config::default();
+
+        apply_env_overrides(&mut config);
+
+        unsafe { EnvGuard::restore_var("DEEPSEEK_SEARCH_BASE_URL", prev) };
+        assert_eq!(
+            config.search.and_then(|search| search.base_url),
+            Some("https://search.internal.example/html/".to_string())
         );
     }
 

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -3345,13 +3345,14 @@ fn apply_env_overrides(config: &mut Config) {
             .get_or_insert_with(SearchConfig::default)
             .api_key = Some(value);
     }
-    if let Ok(value) = std::env::var("DEEPSEEK_SEARCH_BASE_URL")
-        && !value.trim().is_empty()
-    {
-        config
-            .search
-            .get_or_insert_with(SearchConfig::default)
-            .base_url = Some(value);
+    match std::env::var("DEEPSEEK_SEARCH_BASE_URL") {
+        Ok(value) if !value.trim().is_empty() => {
+            config
+                .search
+                .get_or_insert_with(SearchConfig::default)
+                .base_url = Some(value);
+        }
+        _ => {}
     }
     if let Ok(value) = std::env::var("DEEPSEEK_REQUIREMENTS_PATH") {
         config.requirements_path = Some(value);

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -182,6 +182,8 @@ pub struct EngineConfig {
     /// Metaso also falls back to `METASO_API_KEY` env var, then a built-in key.
     /// Baidu also falls back to `BAIDU_SEARCH_API_KEY`.
     pub search_api_key: Option<String>,
+    /// Optional DuckDuckGo-compatible HTML endpoint override.
+    pub search_base_url: Option<String>,
     /// Per-step DeepSeek API timeout for sub-agent `create_message` requests.
     /// Resolved from `[subagents] api_timeout_secs` (clamped to 1..=1800)
     /// once at engine construction, then threaded onto every
@@ -241,6 +243,7 @@ impl Default for EngineConfig {
             workshop: None,
             search_provider: crate::config::SearchProvider::default(),
             search_api_key: None,
+            search_base_url: None,
             subagent_api_timeout: Duration::from_secs(
                 crate::config::DEFAULT_SUBAGENT_API_TIMEOUT_SECS,
             ),
@@ -1711,6 +1714,7 @@ impl Engine {
         // Wire search provider config.
         ctx.search_provider = self.config.search_provider;
         ctx.search_api_key = self.config.search_api_key.clone();
+        ctx.search_base_url = self.config.search_base_url.clone();
 
         let policy = sandbox_policy_for_mode(mode, &self.session.workspace);
         let mut ctx = ctx.with_elevated_sandbox_policy(policy);

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -5385,6 +5385,7 @@ async fn run_exec_agent(
         workshop: config.workshop.clone(),
         search_provider: config.search_provider(),
         search_api_key: config.search.as_ref().and_then(|s| s.api_key.clone()),
+        search_base_url: config.search.as_ref().and_then(|s| s.base_url.clone()),
         tools_always_load: config.tools_always_load(),
         tools: config.tools.clone(),
     };
@@ -5956,6 +5957,7 @@ mod doctor_endpoint_tests {
         let config = Config {
             search: Some(crate::config::SearchConfig {
                 provider: Some(crate::config::SearchProvider::DuckDuckGo),
+                base_url: None,
                 api_key: None,
             }),
             ..Default::default()
@@ -5995,6 +5997,7 @@ mod doctor_endpoint_tests {
         let config = Config {
             search: Some(crate::config::SearchConfig {
                 provider: Some(crate::config::SearchProvider::Bing),
+                base_url: None,
                 api_key: None,
             }),
             ..Default::default()

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -2026,6 +2026,7 @@ impl RuntimeThreadManager {
             workshop: self.config.workshop.clone(),
             search_provider: self.config.search_provider(),
             search_api_key: self.config.search.as_ref().and_then(|s| s.api_key.clone()),
+            search_base_url: self.config.search.as_ref().and_then(|s| s.base_url.clone()),
             tools_always_load: self.config.tools_always_load(),
             tools: self.config.tools.clone(),
         };

--- a/crates/tui/src/tools/spec.rs
+++ b/crates/tui/src/tools/spec.rs
@@ -169,6 +169,8 @@ pub struct ToolContext {
     /// Metaso also falls back to `METASO_API_KEY` env var, then a built-in key.
     /// Baidu also falls back to `BAIDU_SEARCH_API_KEY`.
     pub search_api_key: Option<String>,
+    /// Optional DuckDuckGo-compatible HTML endpoint override for `web_search`.
+    pub search_base_url: Option<String>,
 
     /// Per-session workshop variable store (#548). Holds the raw content of
     /// the most recent large-tool routing event so the parent can call
@@ -210,6 +212,7 @@ impl ToolContext {
             large_output_router: None,
             search_provider: crate::config::SearchProvider::default(),
             search_api_key: None,
+            search_base_url: None,
             workshop_vars: None,
         }
     }
@@ -247,6 +250,7 @@ impl ToolContext {
             large_output_router: None,
             search_provider: crate::config::SearchProvider::default(),
             search_api_key: None,
+            search_base_url: None,
             workshop_vars: None,
         }
     }
@@ -284,6 +288,7 @@ impl ToolContext {
             large_output_router: None,
             search_provider: crate::config::SearchProvider::default(),
             search_api_key: None,
+            search_base_url: None,
             workshop_vars: None,
         }
     }

--- a/crates/tui/src/tools/web_search.rs
+++ b/crates/tui/src/tools/web_search.rs
@@ -1357,7 +1357,10 @@ fn duckduckgo_search_url(
 }
 
 fn duckduckgo_allows_bing_fallback(base_url: Option<&str>) -> bool {
-    base_url.is_none_or(|value| value.trim().is_empty())
+    match base_url {
+        Some(value) => value.trim().is_empty(),
+        None => true,
+    }
 }
 
 fn normalize_text(text: &str) -> String {

--- a/crates/tui/src/tools/web_search.rs
+++ b/crates/tui/src/tools/web_search.rs
@@ -7,6 +7,7 @@
 //!
 //! Set `[search]` in config.toml to switch providers:
 //!   provider = "duckduckgo"  # or tavily/bocha/metaso/baidu/volcengine
+//!   base_url = "https://search.example/html/"  # optional DDG-compatible URL
 //!   api_key = "tvly-..."
 
 use super::spec::{
@@ -22,7 +23,7 @@ use serde_json::{Value, json};
 use std::sync::OnceLock;
 use std::time::Duration;
 
-const DUCKDUCKGO_HOST: &str = "html.duckduckgo.com";
+const DUCKDUCKGO_ENDPOINT: &str = "https://html.duckduckgo.com/html/";
 const BING_HOST: &str = "www.bing.com";
 const TAVILY_ENDPOINT: &str = "https://api.tavily.com/search";
 const BOCHA_ENDPOINT: &str = "https://api.bochaai.com/v1/ai/search";
@@ -139,7 +140,7 @@ impl ToolSpec for WebSearchTool {
     }
 
     fn description(&self) -> &'static str {
-        "Search the web and return ranked results with URLs and snippets. Default backend is DuckDuckGo with Bing fallback; set `[search] provider = \"bing\" | \"tavily\" | \"bocha\" | \"metaso\" | \"baidu\"` in config.toml to switch backends. Use this instead of scraping search engines with `curl` in `exec_shell`. For a known canonical URL, prefer `fetch_url` directly."
+        "Search the web and return ranked results with URLs and snippets. Default backend is DuckDuckGo with Bing fallback; set `[search] provider = \"bing\" | \"tavily\" | \"bocha\" | \"metaso\" | \"baidu\"` in config.toml to switch backends, or `[search] base_url` for a DuckDuckGo-compatible endpoint. Use this instead of scraping search engines with `curl` in `exec_shell`. For a known canonical URL, prefer `fetch_url` directly."
     }
 
     fn input_schema(&self) -> Value {
@@ -261,13 +262,16 @@ impl ToolSpec for WebSearchTool {
         }
 
         // Per-domain network policy gate (#135). The "host" for web search is
-        // the upstream search engine domain — DuckDuckGo first, Bing on
-        // fallback. We gate DuckDuckGo here; Bing is gated separately inside
-        // the fallback path so a deny on one engine doesn't block the other.
-        check_policy(decider, DUCKDUCKGO_HOST)?;
+        // the upstream search engine domain — DuckDuckGo-compatible first,
+        // Bing on fallback. We gate the configured endpoint here; Bing is
+        // gated separately inside the fallback path so a deny on one engine
+        // doesn't silently allow the other.
+        let (url, duckduckgo_host) =
+            duckduckgo_search_url(context.search_base_url.as_deref(), &query)?;
+        let allow_bing_fallback =
+            duckduckgo_allows_bing_fallback(context.search_base_url.as_deref());
+        check_policy(decider, &duckduckgo_host)?;
 
-        let encoded = url_encode(&query);
-        let url = format!("https://html.duckduckgo.com/html/?q={encoded}");
         let resp = client
             .get(&url)
             .header(
@@ -302,7 +306,7 @@ impl ToolSpec for WebSearchTool {
             message_suffix = Some("Bing returned no results; used DuckDuckGo fallback");
         }
 
-        if results.is_empty() {
+        if results.is_empty() && allow_bing_fallback {
             let duckduckgo_blocked = is_duckduckgo_challenge(&body);
             // Bing is a separate host — gate it independently so a deny on
             // DuckDuckGo doesn't silently let Bing through (and vice versa).
@@ -1332,6 +1336,30 @@ fn normalize_bing_url(href: &str) -> String {
     href.to_string()
 }
 
+fn duckduckgo_search_url(
+    base_url: Option<&str>,
+    query: &str,
+) -> Result<(String, String), ToolError> {
+    let raw = base_url
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(DUCKDUCKGO_ENDPOINT);
+    let mut url = reqwest::Url::parse(raw).map_err(|err| {
+        ToolError::invalid_input(format!(
+            "Invalid DuckDuckGo-compatible search base_url: {err}"
+        ))
+    })?;
+    url.query_pairs_mut().append_pair("q", query);
+    let host = url.host_str().ok_or_else(|| {
+        ToolError::invalid_input("DuckDuckGo-compatible search base_url must include a host")
+    })?;
+    Ok((url.to_string(), host.to_string()))
+}
+
+fn duckduckgo_allows_bing_fallback(base_url: Option<&str>) -> bool {
+    base_url.is_none_or(|value| value.trim().is_empty())
+}
+
 fn normalize_text(text: &str) -> String {
     let stripped = strip_html_tags(text);
     let decoded = decode_html_entities(&stripped);
@@ -1435,9 +1463,9 @@ fn extract_query_param(url: &str, key: &str) -> Option<String> {
 mod tests {
     use super::{
         ERROR_BODY_PREVIEW_BYTES, WebSearchEntry, WebSearchTool, baidu_search_payload,
-        decode_html_entities, extract_search_query, is_likely_spam_results, normalize_bing_url,
-        optional_search_max_results, parse_baidu_results, root_domain, sanitize_error_body,
-        truncate_error_body, volcengine_extract_text,
+        decode_html_entities, duckduckgo_search_url, extract_search_query, is_likely_spam_results,
+        normalize_bing_url, optional_search_max_results, parse_baidu_results, root_domain,
+        sanitize_error_body, truncate_error_body, volcengine_extract_text,
     };
     use serde_json::json;
 
@@ -1968,5 +1996,29 @@ mod tests {
             !msg.contains("API key"),
             "should not complain about missing API key (built-in default); got `{msg}`"
         );
+    }
+
+    #[test]
+    fn duckduckgo_compatible_url_uses_custom_base_url_and_preserves_query() {
+        let (url, host) = duckduckgo_search_url(
+            Some("https://search.internal.example/html/?region=us"),
+            "rust async",
+        )
+        .expect("custom duckduckgo-compatible url");
+
+        assert_eq!(host, "search.internal.example");
+        assert_eq!(
+            url,
+            "https://search.internal.example/html/?region=us&q=rust+async"
+        );
+    }
+
+    #[test]
+    fn custom_duckduckgo_endpoint_disables_public_bing_fallback() {
+        assert!(super::duckduckgo_allows_bing_fallback(None));
+        assert!(super::duckduckgo_allows_bing_fallback(Some("   ")));
+        assert!(!super::duckduckgo_allows_bing_fallback(Some(
+            "https://search.internal.example/html/"
+        )));
     }
 }

--- a/crates/tui/src/tools/web_search.rs
+++ b/crates/tui/src/tools/web_search.rs
@@ -197,6 +197,15 @@ impl ToolSpec for WebSearchTool {
         let max_results = max_results.clamp(1, MAX_RESULTS);
         let timeout_ms = optional_u64(&input, "timeout_ms", DEFAULT_TIMEOUT_MS).min(60_000);
 
+        if configured_search_base_url(context.search_base_url.as_deref()).is_some()
+            && !matches!(context.search_provider, SearchProvider::DuckDuckGo)
+        {
+            return Err(ToolError::invalid_input(format!(
+                "[search].base_url is only supported with provider = \"duckduckgo\"; current provider is \"{}\"",
+                context.search_provider.as_str()
+            )));
+        }
+
         // Dispatch to the configured API-backed search providers before
         // building the HTML-scraping client used by Bing/DuckDuckGo.
         match context.search_provider {
@@ -306,8 +315,14 @@ impl ToolSpec for WebSearchTool {
             message_suffix = Some("Bing returned no results; used DuckDuckGo fallback");
         }
 
+        let duckduckgo_blocked = is_duckduckgo_challenge(&body);
+        if results.is_empty() && duckduckgo_blocked && !allow_bing_fallback {
+            return Err(ToolError::execution_failed(format!(
+                "DuckDuckGo-compatible search endpoint at {duckduckgo_host} returned a bot challenge; check the private search service, credentials, or network policy"
+            )));
+        }
+
         if results.is_empty() && allow_bing_fallback {
-            let duckduckgo_blocked = is_duckduckgo_challenge(&body);
             // Bing is a separate host — gate it independently so a deny on
             // DuckDuckGo doesn't silently let Bing through (and vice versa).
             check_policy(decider, BING_HOST)?;
@@ -1340,10 +1355,7 @@ fn duckduckgo_search_url(
     base_url: Option<&str>,
     query: &str,
 ) -> Result<(String, String), ToolError> {
-    let raw = base_url
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .unwrap_or(DUCKDUCKGO_ENDPOINT);
+    let raw = configured_search_base_url(base_url).unwrap_or(DUCKDUCKGO_ENDPOINT);
     let mut url = reqwest::Url::parse(raw).map_err(|err| {
         ToolError::invalid_input(format!(
             "Invalid DuckDuckGo-compatible search base_url: {err}"
@@ -1356,11 +1368,12 @@ fn duckduckgo_search_url(
     Ok((url.to_string(), host.to_string()))
 }
 
+fn configured_search_base_url(base_url: Option<&str>) -> Option<&str> {
+    base_url.map(str::trim).filter(|value| !value.is_empty())
+}
+
 fn duckduckgo_allows_bing_fallback(base_url: Option<&str>) -> bool {
-    match base_url {
-        Some(value) => value.trim().is_empty(),
-        None => true,
-    }
+    configured_search_base_url(base_url).is_none()
 }
 
 fn normalize_text(text: &str) -> String {
@@ -2023,5 +2036,63 @@ mod tests {
         assert!(!super::duckduckgo_allows_bing_fallback(Some(
             "https://search.internal.example/html/"
         )));
+    }
+
+    #[tokio::test]
+    async fn custom_duckduckgo_challenge_returns_actionable_error() {
+        use crate::config::SearchProvider;
+        use crate::tools::spec::{ToolContext, ToolSpec};
+        use wiremock::matchers::{method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/html/"))
+            .and(query_param("q", "rust async"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(
+                r#"<html><body><div class="anomaly-modal">Unfortunately, bots use DuckDuckGo too</div></body></html>"#,
+            ))
+            .mount(&server)
+            .await;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut ctx = ToolContext::new(tmp.path().to_path_buf());
+        ctx.search_provider = SearchProvider::DuckDuckGo;
+        ctx.search_base_url = Some(format!("{}/html/", server.uri()));
+
+        let err = WebSearchTool
+            .execute(json!({"query": "rust async"}), &ctx)
+            .await
+            .expect_err("custom endpoint challenge should error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("DuckDuckGo-compatible search endpoint")
+                && msg.contains("bot challenge")
+                && msg.contains("private search service"),
+            "got `{msg}`"
+        );
+    }
+
+    #[tokio::test]
+    async fn search_base_url_with_non_duckduckgo_provider_is_explicit_error() {
+        use crate::config::SearchProvider;
+        use crate::tools::spec::{ToolContext, ToolSpec};
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut ctx = ToolContext::new(tmp.path().to_path_buf());
+        ctx.search_provider = SearchProvider::Tavily;
+        ctx.search_base_url = Some("https://search.internal.example/html/".to_string());
+
+        let err = WebSearchTool
+            .execute(json!({"query": "rust async"}), &ctx)
+            .await
+            .expect_err("non-duckduckgo provider with base_url should error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("[search].base_url")
+                && msg.contains("provider = \"duckduckgo\"")
+                && msg.contains("tavily"),
+            "got `{msg}`"
+        );
     }
 }

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -779,6 +779,7 @@ fn build_engine_config(app: &App, config: &Config) -> EngineConfig {
         workshop: config.workshop.clone(),
         search_provider: config.search_provider(),
         search_api_key: config.search.as_ref().and_then(|s| s.api_key.clone()),
+        search_base_url: config.search.as_ref().and_then(|s| s.base_url.clone()),
         tools_always_load: config.tools_always_load(),
         tools: config.tools.clone(),
     }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -819,6 +819,11 @@ parseable results. Bing remains selectable for users who explicitly want it,
 and Tavily, Bocha, Metaso, or Baidu can be selected when an API-backed provider
 is preferred.
 
+For a private/internal search service that serves DuckDuckGo-compatible HTML,
+keep `provider = "duckduckgo"` and set `base_url`; CodeWhale appends the `q`
+query parameter to that endpoint and applies network policy to its host.
+Custom endpoints do not fall back to public Bing.
+
 **Metaso** ([metaso.cn](https://metaso.cn)) has a 100 searches/day free quota;
 set `METASO_API_KEY` or `[search] api_key` for a higher quota.
 
@@ -830,6 +835,7 @@ only; it does not add a Baidu model provider.
 ```toml
 [search]
 provider = "baidu" # duckduckgo | bing | tavily | bocha | metaso | baidu
+# base_url = "https://search.example/html/" # optional with provider = "duckduckgo"
 # api_key = "YOUR_KEY" # required for tavily, bocha, and baidu; optional for metaso
 ```
 


### PR DESCRIPTION
Refs #2436

Problem
- Private search services that expose DuckDuckGo-compatible HTML results cannot be wired in today because DuckDuckGo always uses the public default endpoint.

Change
- Add optional `[search].base_url` / `DEEPSEEK_SEARCH_BASE_URL` for DuckDuckGo-compatible endpoints.
- Apply network policy to the configured endpoint host.
- Disable public Bing fallback when a custom endpoint is configured, so private search does not unexpectedly leak to a public provider.

Verification
- `cargo test -p codewhale-tui custom_duckduckgo --all-features --locked -- --nocapture`
- `cargo test -p codewhale-tui search_provider --all-features --locked -- --nocapture`
- `cargo check -p codewhale-tui --all-features --locked`
- `cargo fmt --all -- --check`
- `cargo clippy -p codewhale-tui --all-features --locked -- -D warnings`
- `git diff --check origin/main..HEAD`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an optional `[search].base_url` / `DEEPSEEK_SEARCH_BASE_URL` setting that lets users point the DuckDuckGo provider at any DuckDuckGo-compatible HTML search endpoint (e.g. a private SearXNG instance), applies network policy to the configured host, and disables the public Bing fallback when a custom endpoint is active.

- **`web_search.rs`**: extracts `duckduckgo_search_url`, `configured_search_base_url`, and `duckduckgo_allows_bing_fallback` helpers; bot-challenge detection now runs unconditionally and returns an actionable error for custom endpoints; non-DDG providers paired with `base_url` get an explicit `invalid_input` error instead of silent ignore.
- **Config plumbing**: `base_url: Option<String>` added to `SearchConfig`, `EngineConfig`, and `ToolContext`; propagated through all four `EngineConfig` construction sites (`main.rs`, `runtime_threads.rs`, `tui/ui.rs`, and `engine.rs`).
- **Tests**: four new tests cover URL construction, Bing-fallback flag, bot-challenge error on custom endpoints, and the incompatible-provider guard.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The new custom-endpoint path is well-isolated, network policy is correctly applied to the derived host, and the Bing-fallback suppression prevents data leaking to public search when a private endpoint is configured.

All changed code is additive and guarded: the incompatible-provider guard fires before any network activity, URL parsing errors surface as actionable tool errors, and the bot-challenge detection now runs unconditionally regardless of fallback mode. The four call sites that construct EngineConfig are consistently updated. Tests cover every new code path.

No files require special attention. The only note is a cosmetic one in web_search.rs where the source field in the JSON response stays duckduckgo for custom endpoints.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/tui/src/tools/web_search.rs | Core change: adds duckduckgo_search_url, configured_search_base_url, and duckduckgo_allows_bing_fallback helpers; wires search_base_url through execute; correctly gates network policy against the configured host; surfaces bot-challenge errors for custom endpoints; hard-errors on base_url + non-DDG provider. Well-tested. |
| crates/tui/src/config.rs | Adds base_url: Option<String> to SearchConfig and DEEPSEEK_SEARCH_BASE_URL env-var override. Two new unit tests validate TOML deserialization and env-var path. No issues found. |
| crates/tui/src/core/engine.rs | Threads search_base_url through EngineConfig and populates it in Engine::run. Straightforward plumbing, no issues. |
| crates/tui/src/tools/spec.rs | Adds search_base_url: Option<String> to ToolContext and initializes it to None in all three constructor stubs. Consistent, no issues. |
| crates/tui/src/main.rs | Propagates search_base_url into EngineConfig in run_exec_agent; adds base_url: None to two existing test structs so they compile cleanly. |
| crates/tui/src/runtime_threads.rs | Propagates search_base_url into EngineConfig in RuntimeThreadManager. Mirrors the main.rs change correctly. |
| crates/tui/src/tui/ui.rs | Propagates search_base_url into EngineConfig in build_engine_config. Consistent with other call sites. |
| docs/CONFIGURATION.md | Documents the new base_url field and its interaction with private endpoints and Bing fallback. Accurate and concise. |
| config.example.toml | Adds base_url example comment and documents the DEEPSEEK_SEARCH_BASE_URL env-var override. No issues. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[web_search execute] --> B{base_url set\n+ provider ≠ DuckDuckGo?}
    B -->|yes| ERR0[ToolError::invalid_input]
    B -->|no| C{provider?}
    C -->|Tavily/Bocha/\nMetaso/Baidu/\nVolcengine| D[API-backed search\nreturn early]
    C -->|Bing| E[run_bing_search]
    E -->|results| RET1[return bing results]
    E -->|empty| F[bing_was_empty=true\nfall through]
    C -->|DuckDuckGo| F
    F --> G[duckduckgo_search_url\nbase_url OR default DDG]
    G --> H[check_policy on host]
    H --> I[HTTP GET]
    I --> J[parse_duckduckgo_results]
    J --> K{results empty?}
    K -->|no| RET2[return results]
    K -->|yes| L{bot challenge?}
    L -->|yes + no Bing fallback| ERR1[ToolError: bot challenge\nat custom endpoint]
    L -->|yes/no + allow Bing fallback| M[run_bing_search fallback]
    M -->|results| RET3[return bing fallback results]
    M -->|empty + challenged| ERR2[ToolError: DDG challenged\nBing also empty]
    M -->|empty unchallenged| RET4[No results found]
    L -->|no + no Bing fallback| RET4
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/tui/src/tools/web_search.rs`, line 309-336 ([link](https://github.com/hmbown/codewhale/blob/c62c782d96db56554ff67d8e8dcadee7019e4121/crates/tui/src/tools/web_search.rs#L309-L336)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Bot-challenge detection bypassed for custom endpoints**

   `is_duckduckgo_challenge(&body)` is only evaluated inside the `allow_bing_fallback` branch. When a custom `base_url` is configured and the private endpoint returns a challenge/captcha page, `allow_bing_fallback` is `false`, so the check is never reached — the caller gets a generic `"No results found"` instead of an actionable error. Extracting `is_duckduckgo_challenge` before the guard, and returning a descriptive error when the custom endpoint triggers it, would make misconfigured or blocked private search endpoints much easier to diagnose.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22codex%2F2436-custom-search-url%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2F2436-custom-search-url%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftools%2Fweb_search.rs%0ALine%3A%20309-336%0A%0AComment%3A%0A**Bot-challenge%20detection%20bypassed%20for%20custom%20endpoints**%0A%0A%60is_duckduckgo_challenge%28%26body%29%60%20is%20only%20evaluated%20inside%20the%20%60allow_bing_fallback%60%20branch.%20When%20a%20custom%20%60base_url%60%20is%20configured%20and%20the%20private%20endpoint%20returns%20a%20challenge%2Fcaptcha%20page%2C%20%60allow_bing_fallback%60%20is%20%60false%60%2C%20so%20the%20check%20is%20never%20reached%20%E2%80%94%20the%20caller%20gets%20a%20generic%20%60%22No%20results%20found%22%60%20instead%20of%20an%20actionable%20error.%20Extracting%20%60is_duckduckgo_challenge%60%20before%20the%20guard%2C%20and%20returning%20a%20descriptive%20error%20when%20the%20custom%20endpoint%20triggers%20it%2C%20would%20make%20misconfigured%20or%20blocked%20private%20search%20endpoints%20much%20easier%20to%20diagnose.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftools%2Fweb_search.rs%0ALine%3A%20309-336%0A%0AComment%3A%0A**Bot-challenge%20detection%20bypassed%20for%20custom%20endpoints**%0A%0A%60is_duckduckgo_challenge%28%26body%29%60%20is%20only%20evaluated%20inside%20the%20%60allow_bing_fallback%60%20branch.%20When%20a%20custom%20%60base_url%60%20is%20configured%20and%20the%20private%20endpoint%20returns%20a%20challenge%2Fcaptcha%20page%2C%20%60allow_bing_fallback%60%20is%20%60false%60%2C%20so%20the%20check%20is%20never%20reached%20%E2%80%94%20the%20caller%20gets%20a%20generic%20%60%22No%20results%20found%22%60%20instead%20of%20an%20actionable%20error.%20Extracting%20%60is_duckduckgo_challenge%60%20before%20the%20guard%2C%20and%20returning%20a%20descriptive%20error%20when%20the%20custom%20endpoint%20triggers%20it%2C%20would%20make%20misconfigured%20or%20blocked%20private%20search%20endpoints%20much%20easier%20to%20diagnose.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2510&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftools%2Fweb_search.rs%0ALine%3A%20309-336%0A%0AComment%3A%0A**Bot-challenge%20detection%20bypassed%20for%20custom%20endpoints**%0A%0A%60is_duckduckgo_challenge%28%26body%29%60%20is%20only%20evaluated%20inside%20the%20%60allow_bing_fallback%60%20branch.%20When%20a%20custom%20%60base_url%60%20is%20configured%20and%20the%20private%20endpoint%20returns%20a%20challenge%2Fcaptcha%20page%2C%20%60allow_bing_fallback%60%20is%20%60false%60%2C%20so%20the%20check%20is%20never%20reached%20%E2%80%94%20the%20caller%20gets%20a%20generic%20%60%22No%20results%20found%22%60%20instead%20of%20an%20actionable%20error.%20Extracting%20%60is_duckduckgo_challenge%60%20before%20the%20guard%2C%20and%20returning%20a%20descriptive%20error%20when%20the%20custom%20endpoint%20triggers%20it%2C%20would%20make%20misconfigured%20or%20blocked%20private%20search%20endpoints%20much%20easier%20to%20diagnose.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2510&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22codex%2F2436-custom-search-url%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2F2436-custom-search-url%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftools%2Fweb_search.rs%3A308-310%0AWhen%20a%20custom%20%60base_url%60%20is%20configured%20and%20results%20are%20returned%2C%20the%20%60source%60%20field%20in%20the%20JSON%20response%20is%20hardcoded%20to%20%60%22duckduckgo%22%60%20rather%20than%20reflecting%20the%20custom%20host.%20Callers%20parsing%20the%20%60source%60%20field%20for%20diagnostics%20would%20see%20%60%22duckduckgo%22%60%20even%20when%20the%20results%20came%20from%2C%20say%2C%20%60search.internal.example%60.%20Using%20%60duckduckgo_host%60%20%28already%20computed%29%20as%20the%20%60source%60%20value%20makes%20the%20response%20self-describing.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20mut%20results%20%3D%20parse_duckduckgo_results%28%26body%2C%20max_results%29%3B%0A%20%20%20%20%20%20%20%20let%20mut%20source%3A%20String%20%3D%20duckduckgo_host.clone%28%29%3B%0A%20%20%20%20%20%20%20%20let%20mut%20message_suffix%3A%20Option%3C%26str%3E%20%3D%20None%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftools%2Fweb_search.rs%3A308-310%0AWhen%20a%20custom%20%60base_url%60%20is%20configured%20and%20results%20are%20returned%2C%20the%20%60source%60%20field%20in%20the%20JSON%20response%20is%20hardcoded%20to%20%60%22duckduckgo%22%60%20rather%20than%20reflecting%20the%20custom%20host.%20Callers%20parsing%20the%20%60source%60%20field%20for%20diagnostics%20would%20see%20%60%22duckduckgo%22%60%20even%20when%20the%20results%20came%20from%2C%20say%2C%20%60search.internal.example%60.%20Using%20%60duckduckgo_host%60%20%28already%20computed%29%20as%20the%20%60source%60%20value%20makes%20the%20response%20self-describing.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20mut%20results%20%3D%20parse_duckduckgo_results%28%26body%2C%20max_results%29%3B%0A%20%20%20%20%20%20%20%20let%20mut%20source%3A%20String%20%3D%20duckduckgo_host.clone%28%29%3B%0A%20%20%20%20%20%20%20%20let%20mut%20message_suffix%3A%20Option%3C%26str%3E%20%3D%20None%3B%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2510&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftools%2Fweb_search.rs%3A308-310%0AWhen%20a%20custom%20%60base_url%60%20is%20configured%20and%20results%20are%20returned%2C%20the%20%60source%60%20field%20in%20the%20JSON%20response%20is%20hardcoded%20to%20%60%22duckduckgo%22%60%20rather%20than%20reflecting%20the%20custom%20host.%20Callers%20parsing%20the%20%60source%60%20field%20for%20diagnostics%20would%20see%20%60%22duckduckgo%22%60%20even%20when%20the%20results%20came%20from%2C%20say%2C%20%60search.internal.example%60.%20Using%20%60duckduckgo_host%60%20%28already%20computed%29%20as%20the%20%60source%60%20value%20makes%20the%20response%20self-describing.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20mut%20results%20%3D%20parse_duckduckgo_results%28%26body%2C%20max_results%29%3B%0A%20%20%20%20%20%20%20%20let%20mut%20source%3A%20String%20%3D%20duckduckgo_host.clone%28%29%3B%0A%20%20%20%20%20%20%20%20let%20mut%20message_suffix%3A%20Option%3C%26str%3E%20%3D%20None%3B%0A%60%60%60%0A%0A&pr=2510&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["fix(search): surface custom endpoint con..."](https://github.com/hmbown/codewhale/commit/8b6b3e61d03b892c82e52b666001f0e7870aef18) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34924280)</sub>

<!-- /greptile_comment -->