### PR TITLE
feat(tui): allow custom completion sound files

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -560,7 +560,7 @@ default_text_model = "deepseek-ai/deepseek-v4-pro"
 # threshold_secs = 30      # only notify when the turn took >= this many seconds
 # include_summary = false  # include elapsed time + cost in the notification body
 # completion_sound = "beep" # off | beep | bell | file — sound on turn completion (✅ marker)
-# sound_file = "E:\\google\\downloads\\notify.wav" # used when completion_sound = "file" (Windows)
+# sound_file = "E:\\google\\downloads\\notify.wav" # WAV used when completion_sound = "file" (Windows)
 [notifications]
 # method = "auto"
 # threshold_secs = 30

--- a/config.example.toml
+++ b/config.example.toml
@@ -553,21 +553,20 @@ default_text_model = "deepseek-ai/deepseek-v4-pro"
 # method        = "auto"   # auto | osc9 | bel | off
 #                 auto: OSC 9 for iTerm.app / Ghostty / WezTerm.
 #                       On macOS / Linux, falls back to BEL.
-#                       On Windows, falls back to "off" — BEL maps to the
-#                       system error chime (SystemAsterisk / MB_OK), which
-#                       sounds like an error popup. Set method = "bel"
-#                       explicitly to opt back in (#583).
+#                       On Windows, BEL is routed through MessageBeep(MB_OK).
 #                 osc9: \x1b]9;<msg>\x07 (iTerm2-style; shows macOS notification)
 #                 bel:  plain \x07 beep
 #                 off:  disable entirely
 # threshold_secs = 30      # only notify when the turn took >= this many seconds
 # include_summary = false  # include elapsed time + cost in the notification body
-# completion_sound = "beep" # off | beep | bell — sound on turn completion (✅ marker)
+# completion_sound = "beep" # off | beep | bell | file — sound on turn completion (✅ marker)
+# sound_file = "E:\\google\\downloads\\notify.wav" # used when completion_sound = "file" (Windows)
 [notifications]
 # method = "auto"
 # threshold_secs = 30
 # include_summary = false
 # completion_sound = "beep"
+# sound_file = "E:\\google\\downloads\\notify.wav"
 
 # ─────────────────────────────────────────────────────────────────────────────────
 # Workspace Snapshots (#137)

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -95,4 +95,4 @@ objc2 = "0.6.3"
 objc2-foundation = { version = "0.3.2", default-features = false, features = ["std", "NSArray", "NSDictionary", "NSError", "NSObject", "NSString", "NSURL"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.60", features = ["Win32_Foundation", "Win32_System_Console", "Win32_UI_WindowsAndMessaging", "Win32_System_Diagnostics_Debug", "Win32_System_Threading"] }
+windows = { version = "0.60", features = ["Win32_Foundation", "Win32_System_Console", "Win32_UI_WindowsAndMessaging", "Win32_System_Diagnostics_Debug", "Win32_System_Threading", "Win32_Media_Audio"] }

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -739,6 +739,8 @@ pub enum CompletionSound {
     Beep,
     /// Terminal BEL character (`\x07`).
     Bell,
+    /// Play a configured sound file.
+    File,
 }
 
 /// Desktop-notification configuration (OSC 9 / BEL on turn completion).
@@ -746,9 +748,9 @@ pub enum CompletionSound {
 pub struct NotificationsConfig {
     /// Delivery method: `auto` | `osc9` | `bel` | `off`. Default: `auto`.
     /// `auto` resolves to OSC 9 for iTerm.app / Ghostty / WezTerm / Cmux
-    /// (detected via `$TERM_PROGRAM` then `$LC_TERMINAL`); on macOS / Linux
-    /// it falls back to BEL, and on Windows it falls back to `Off` so the
-    /// post-turn notification doesn't ring the system error chime (#583).
+    /// (detected via `$TERM_PROGRAM` then `$LC_TERMINAL`); otherwise it
+    /// falls back to BEL. On Windows the BEL path is routed through
+    /// `MessageBeep(MB_OK)`.
     /// Use `method = "osc9"` explicitly when your terminal is OSC-9 capable
     /// but sets neither env var (e.g. Cmux without `LC_TERMINAL`).
     #[serde(default)]
@@ -761,10 +763,14 @@ pub struct NotificationsConfig {
     #[serde(default)]
     pub include_summary: bool,
 
-    /// Completion sound: `"off"` | `"beep"` | `"bell"`. Default: `"beep"`.
+    /// Completion sound: `"off"` | `"beep"` | `"bell"` | `"file"`. Default: `"beep"`.
     /// Plays a sound when every turn finishes (alongside the ✅ marker).
     #[serde(default)]
     pub completion_sound: CompletionSound,
+
+    /// Path to the sound file used when `completion_sound = "file"`.
+    #[serde(default)]
+    pub sound_file: Option<PathBuf>,
 }
 
 fn default_snapshots_enabled() -> bool {
@@ -8823,5 +8829,24 @@ model = "deepseek-ai/deepseek-v4-pro"
         "#;
         let tui: TuiConfig = toml::from_str(toml_str).expect("missing status_items should parse");
         assert_eq!(tui.status_items, None);
+    }
+
+    #[test]
+    fn notifications_parse_custom_completion_sound_file() {
+        let config: Config = toml::from_str(
+            r#"
+            [notifications]
+            completion_sound = "file"
+            sound_file = "E:\\google\\downloads\\xm4114.wav"
+            "#,
+        )
+        .expect("custom completion sound config should parse");
+
+        let notifications = config.notifications_config();
+        assert_eq!(notifications.completion_sound, CompletionSound::File);
+        assert_eq!(
+            notifications.sound_file.as_deref(),
+            Some(std::path::Path::new("E:\\google\\downloads\\xm4114.wav"))
+        );
     }
 }

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -739,7 +739,7 @@ pub enum CompletionSound {
     Beep,
     /// Terminal BEL character (`\x07`).
     Bell,
-    /// Play a configured sound file.
+    /// Play a configured WAV sound file.
     File,
 }
 
@@ -768,7 +768,7 @@ pub struct NotificationsConfig {
     #[serde(default)]
     pub completion_sound: CompletionSound,
 
-    /// Path to the sound file used when `completion_sound = "file"`.
+    /// Path to the WAV sound file used when `completion_sound = "file"`.
     #[serde(default)]
     pub sound_file: Option<PathBuf>,
 }

--- a/crates/tui/src/tui/notifications.rs
+++ b/crates/tui/src/tui/notifications.rs
@@ -366,6 +366,9 @@ pub fn reset_title_on_interaction() {
 /// Completion sound mode (0 = off, 1 = beep, 2 = bell, 3 = file).
 static COMPLETION_SOUND_MODE: AtomicU8 = AtomicU8::new(1);
 static COMPLETION_SOUND_FILE: OnceLock<Mutex<Option<PathBuf>>> = OnceLock::new();
+#[cfg(not(target_os = "windows"))]
+static COMPLETION_SOUND_FILE_UNSUPPORTED_WARNED: AtomicBool = AtomicBool::new(false);
+static COMPLETION_SOUND_FILE_MISSING_WARNED: AtomicBool = AtomicBool::new(false);
 
 fn completion_sound_file_slot() -> &'static Mutex<Option<PathBuf>> {
     COMPLETION_SOUND_FILE.get_or_init(|| Mutex::new(None))
@@ -444,13 +447,15 @@ fn play_sound_file(path: &Path) {
 
 #[cfg(not(target_os = "windows"))]
 fn play_sound_file(_path: &Path) {
-    tracing::warn!("completion_sound = \"file\" is currently supported on Windows only");
+    if !COMPLETION_SOUND_FILE_UNSUPPORTED_WARNED.swap(true, Ordering::SeqCst) {
+        tracing::warn!("completion_sound = \"file\" is currently supported on Windows only");
+    }
 }
 
 fn file_sound() {
     if let Some(path) = configured_sound_file() {
         play_sound_file(&path);
-    } else {
+    } else if !COMPLETION_SOUND_FILE_MISSING_WARNED.swap(true, Ordering::SeqCst) {
         tracing::warn!("completion_sound = \"file\" requires [notifications].sound_file");
     }
 }

--- a/crates/tui/src/tui/notifications.rs
+++ b/crates/tui/src/tui/notifications.rs
@@ -17,9 +17,18 @@ use windows::Win32::System::Diagnostics::Debug::MessageBeep;
 use windows::Win32::UI::WindowsAndMessaging::MESSAGEBOX_STYLE;
 
 use std::io::{self, Write};
+use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicU8;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
+
+#[cfg(target_os = "windows")]
+use std::os::windows::ffi::OsStrExt;
+#[cfg(target_os = "windows")]
+use windows::Win32::Media::Audio::{PlaySoundW, SND_ASYNC, SND_FILENAME, SND_NODEFAULT};
+#[cfg(target_os = "windows")]
+use windows::core::PCWSTR;
 
 /// Notification delivery method.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -354,18 +363,25 @@ pub fn reset_title_on_interaction() {
     }
 }
 
-/// Completion sound mode (0 = off, 1 = beep, 2 = bell).
+/// Completion sound mode (0 = off, 1 = beep, 2 = bell, 3 = file).
 static COMPLETION_SOUND_MODE: AtomicU8 = AtomicU8::new(1);
+static COMPLETION_SOUND_FILE: OnceLock<Mutex<Option<PathBuf>>> = OnceLock::new();
 
-/// Set the completion sound mode from config.
-/// Call once at startup or on `/settings` change.
-pub fn set_completion_sound_mode(mode: crate::config::CompletionSound) {
+fn completion_sound_file_slot() -> &'static Mutex<Option<PathBuf>> {
+    COMPLETION_SOUND_FILE.get_or_init(|| Mutex::new(None))
+}
+
+fn set_completion_sound(mode: crate::config::CompletionSound, sound_file: Option<PathBuf>) {
     let val = match mode {
         crate::config::CompletionSound::Off => 0u8,
         crate::config::CompletionSound::Beep => 1u8,
         crate::config::CompletionSound::Bell => 2u8,
+        crate::config::CompletionSound::File => 3u8,
     };
     COMPLETION_SOUND_MODE.store(val, Ordering::SeqCst);
+    if let Ok(mut slot) = completion_sound_file_slot().lock() {
+        *slot = sound_file;
+    }
 }
 
 /// Play the configured completion sound (if not `Off`).
@@ -377,6 +393,9 @@ pub fn play_completion_sound() {
         }
         2 => {
             bell_sound();
+        }
+        3 => {
+            file_sound();
         }
         _ => {}
     }
@@ -400,6 +419,52 @@ fn beep_sound() {
 /// Pure terminal BEL character.
 fn bell_sound() {
     let _ = io::stdout().write_all(b"\x07");
+}
+
+fn configured_sound_file() -> Option<PathBuf> {
+    completion_sound_file_slot()
+        .lock()
+        .ok()
+        .and_then(|slot| slot.clone())
+}
+
+#[cfg(target_os = "windows")]
+fn play_sound_file(path: &Path) {
+    let wide: Vec<u16> = path.as_os_str().encode_wide().chain(Some(0)).collect();
+    // Best-effort and async: notification sound failure should not block or
+    // fail a completed agent turn.
+    unsafe {
+        let _ = PlaySoundW(
+            PCWSTR(wide.as_ptr()),
+            None,
+            SND_FILENAME | SND_ASYNC | SND_NODEFAULT,
+        );
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn play_sound_file(_path: &Path) {
+    tracing::warn!("completion_sound = \"file\" is currently supported on Windows only");
+}
+
+fn file_sound() {
+    if let Some(path) = configured_sound_file() {
+        play_sound_file(&path);
+    } else {
+        tracing::warn!("completion_sound = \"file\" requires [notifications].sound_file");
+    }
+}
+
+#[cfg(test)]
+fn completion_sound_state_for_tests() -> (crate::config::CompletionSound, Option<PathBuf>) {
+    let mode = match COMPLETION_SOUND_MODE.load(Ordering::SeqCst) {
+        0 => crate::config::CompletionSound::Off,
+        1 => crate::config::CompletionSound::Beep,
+        2 => crate::config::CompletionSound::Bell,
+        3 => crate::config::CompletionSound::File,
+        _ => crate::config::CompletionSound::Off,
+    };
+    (mode, configured_sound_file())
 }
 
 /// Show a macOS Notification Center alert via `osascript`.
@@ -585,7 +650,7 @@ use crate::tui::app::App;
 pub fn settings(config: &crate::config::Config) -> Option<(Method, Duration, bool)> {
     let notif = config.notifications_config();
     // Initialize completion sound mode from config.
-    set_completion_sound_mode(notif.completion_sound);
+    set_completion_sound(notif.completion_sound, notif.sound_file);
     let method = match notif.method {
         crate::config::NotificationMethod::Auto => Method::Auto,
         crate::config::NotificationMethod::Osc9 => Method::Osc9,
@@ -1184,6 +1249,27 @@ mod tests {
         assert_eq!(
             humanize_duration(Duration::from_secs(3 * 604_800 + 2 * 86_400 + 17 * 3600)),
             "3w 2d"
+        );
+    }
+
+    #[test]
+    fn settings_installs_custom_completion_sound_file() {
+        let config: crate::config::Config = toml::from_str(
+            r#"
+            [notifications]
+            completion_sound = "file"
+            sound_file = "E:\\google\\downloads\\xm4114.wav"
+            "#,
+        )
+        .expect("custom completion sound config should parse");
+
+        let _ = settings(&config);
+
+        let (mode, file) = completion_sound_state_for_tests();
+        assert_eq!(mode, crate::config::CompletionSound::File);
+        assert_eq!(
+            file.as_deref(),
+            Some(std::path::Path::new("E:\\google\\downloads\\xm4114.wav"))
         );
     }
 }

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -7299,6 +7299,7 @@ fn notification_settings_tui_always_keeps_configured_method_no_threshold() {
             method: crate::config::NotificationMethod::Bel,
             threshold_secs: 120,
             completion_sound: crate::config::CompletionSound::Beep,
+            sound_file: None,
             include_summary: true,
         }),
         ..Config::default()
@@ -7331,6 +7332,7 @@ fn notification_settings_no_tui_override_uses_notifications_block() {
             method: crate::config::NotificationMethod::Osc9,
             threshold_secs: 45,
             completion_sound: crate::config::CompletionSound::Beep,
+            sound_file: None,
             include_summary: false,
         }),
         ..Config::default()

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -697,9 +697,9 @@ If you are upgrading from older releases:
   `false`. When `true`, the notification body includes the elapsed
   duration and the turn's cost in the configured display currency.
 - `[notifications].completion_sound` (string, optional): `off`, `beep`,
-  `bell`, or `file`. Defaults to `beep`. `file` plays the path from
+  `bell`, or `file`. Defaults to `beep`. `file` plays the WAV path from
   `[notifications].sound_file` on Windows.
-- `[notifications].sound_file` (path, optional): path to a custom sound file
+- `[notifications].sound_file` (path, optional): path to a custom WAV file
   used when `completion_sound = "file"`.
 - `tui.alternate_screen` (string, optional): `auto`, `always`, or `never`. This is retained for config compatibility, but interactive sessions now always use the TUI-owned alternate screen so host terminal scrollback cannot hijack the viewport.
 - `tui.mouse_capture` (bool, optional, default `true` on non-Windows terminals and on Windows Terminal/ConEmu/Cmder when the alternate screen is active; `false` on legacy Windows console and inside JetBrains JediTerm — PyCharm/IDEA/CLion/etc. — where mouse-event escapes leak into the input stream as garbled text, see #878 / #898): enable internal mouse scrolling, transcript selection, right-click context actions, and transcript scrollbar dragging. TUI-owned drag selection copies only transcript text, removes visual wrap-column line breaks from paragraphs, and keeps selection scoped to the transcript pane. Set this to `false` or run with `--no-mouse-capture` for raw terminal selection; set it to `true` or run with `--mouse-capture` to opt in anywhere it's defaulted off. On raw terminal selection, especially on legacy Windows console or when mouse capture is disabled, selection may cross the right sidebar and include visual wraps because the terminal, not the TUI, owns the selection.
@@ -778,7 +778,7 @@ Windows users who run inside a known OSC-9 terminal (e.g. WezTerm on Windows) ke
 
 `completion_sound = "file"` is for Windows users who want a per-application
 completion sound without changing the global Windows sound scheme. It plays the
-configured `sound_file` asynchronously via the native Windows audio API.
+configured WAV `sound_file` asynchronously via the native Windows audio API.
 
 ### Parsed but currently unused (reserved for future versions)
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -689,15 +689,18 @@ If you are upgrading from older releases:
   turns whose elapsed time meets `threshold_secs`; failed and cancelled
   turns are silent. `auto` resolves to `osc9` for `iTerm.app`, `Ghostty`,
   and `WezTerm` (detected via `$TERM_PROGRAM`). Otherwise the fallback is
-  `bel` on macOS / Linux and `off` on Windows (where BEL maps to the
-  system error chime — see the [Notifications](#notifications) section
-  for the full rationale, #583).
+  `bel`; on Windows the BEL path is routed through `MessageBeep(MB_OK)`.
 - `[notifications].threshold_secs` (int, optional): defaults to `30`.
   Only completed turns whose elapsed time meets or exceeds this fire a
   notification.
 - `[notifications].include_summary` (bool, optional): defaults to
   `false`. When `true`, the notification body includes the elapsed
   duration and the turn's cost in the configured display currency.
+- `[notifications].completion_sound` (string, optional): `off`, `beep`,
+  `bell`, or `file`. Defaults to `beep`. `file` plays the path from
+  `[notifications].sound_file` on Windows.
+- `[notifications].sound_file` (path, optional): path to a custom sound file
+  used when `completion_sound = "file"`.
 - `tui.alternate_screen` (string, optional): `auto`, `always`, or `never`. This is retained for config compatibility, but interactive sessions now always use the TUI-owned alternate screen so host terminal scrollback cannot hijack the viewport.
 - `tui.mouse_capture` (bool, optional, default `true` on non-Windows terminals and on Windows Terminal/ConEmu/Cmder when the alternate screen is active; `false` on legacy Windows console and inside JetBrains JediTerm — PyCharm/IDEA/CLion/etc. — where mouse-event escapes leak into the input stream as garbled text, see #878 / #898): enable internal mouse scrolling, transcript selection, right-click context actions, and transcript scrollbar dragging. TUI-owned drag selection copies only transcript text, removes visual wrap-column line breaks from paragraphs, and keeps selection scoped to the transcript pane. Set this to `false` or run with `--no-mouse-capture` for raw terminal selection; set it to `true` or run with `--mouse-capture` to opt in anywhere it's defaulted off. On raw terminal selection, especially on legacy Windows console or when mouse capture is disabled, selection may cross the right sidebar and include visual wraps because the terminal, not the TUI, owns the selection.
 - `tui.terminal_probe_timeout_ms` (int, optional, default `500`): startup terminal-mode probe timeout in milliseconds. Values are clamped to `100..=5000`; timeout emits a warning and aborts startup instead of hanging indefinitely.
@@ -760,16 +763,22 @@ The TUI can emit a desktop notification (OSC 9 escape or plain BEL) when a turn 
 method          = "auto"  # auto | osc9 | bel | off
 threshold_secs  = 30      # only notify when the turn took >= this many seconds
 include_summary = false   # include elapsed time + cost in the notification body
+completion_sound = "beep" # off | beep | bell | file
+sound_file = "E:\\google\\downloads\\notify.wav" # for completion_sound = "file"
 ```
 
 Method semantics:
 
-- `auto` (default) — picks `osc9` for `iTerm.app`, `Ghostty`, and `WezTerm` (detected via `$TERM_PROGRAM`). On macOS and Linux it falls back to `bel`. **On Windows the fallback is `off`** instead of `bel`, because the Windows audio stack maps `\x07` to the `SystemAsterisk` / `MB_OK` chime — the same sound application error popups use, so a successful-turn notification ends up sounding like an error (#583).
+- `auto` (default) — picks `osc9` for `iTerm.app`, `Ghostty`, and `WezTerm` (detected via `$TERM_PROGRAM`). Otherwise it falls back to `bel`; on Windows that BEL path is routed through `MessageBeep(MB_OK)`.
 - `osc9` — emit `\x1b]9;<msg>\x07`. Inside tmux the sequence is wrapped in DCS passthrough so it reaches the outer terminal.
 - `bel` — emit a single `\x07` byte. Use this on Windows only if you actively want the chime back.
 - `off` — disable post-turn notifications entirely.
 
-Windows users who run inside a known OSC-9 terminal (e.g. WezTerm on Windows) keep getting OSC-9 notifications; the `off` fallback only applies when no recognised `TERM_PROGRAM` is detected.
+Windows users who run inside a known OSC-9 terminal (e.g. WezTerm on Windows) keep getting OSC-9 notifications. Set `method = "off"` to disable threshold-based desktop notifications entirely.
+
+`completion_sound = "file"` is for Windows users who want a per-application
+completion sound without changing the global Windows sound scheme. It plays the
+configured `sound_file` asynchronously via the native Windows audio API.
 
 ### Parsed but currently unused (reserved for future versions)
 


### PR DESCRIPTION
Refs #2484

## Problem
`completion_sound` supports the built-in modes, but Windows users cannot point CodeWhale at a custom notification sound file from config.

## Change
- add `completion_sound = "file"` and `[notifications].sound_file`
- play the configured file asynchronously through the native Windows audio API
- warn and no-op when the file mode is missing a path or running on an unsupported platform
- document the new option in the example config and configuration guide

## Verification
- `cargo test -p codewhale-tui custom_completion_sound --all-features --locked -- --nocapture`
- `cargo test -p codewhale-tui tui::notifications::tests --all-features --locked -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo check -p codewhale-tui --all-features --locked`
- `cargo clippy -p codewhale-tui --all-features --locked -- -D warnings`
- `git diff --check origin/main..HEAD`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `completion_sound = "file"` as a new option that lets Windows users specify a custom WAV file path (`[notifications].sound_file`) that is played asynchronously via `PlaySoundW` at turn completion.

- Adds the `CompletionSound::File` variant, the `sound_file: Option<PathBuf>` config field, and Windows-only `play_sound_file` backed by `PlaySoundW(SND_FILENAME | SND_ASYNC | SND_NODEFAULT)`.
- Adds "warn once" `AtomicBool` flags to limit log noise when the feature is misconfigured (missing path, or used on a non-Windows platform), along with corresponding unit tests and documentation updates.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the change is additive and self-contained, with no impact on existing sound modes or notification delivery paths.

The Windows PlaySoundW path is correctly wired with SND_FILENAME | SND_ASYNC | SND_NODEFAULT, the once-fire warning guards prevent log spam, and the new config field degrades gracefully on unsupported platforms. The only notable concern is that the warn-once flags are never reset after the user repairs and then re-breaks the configuration, which could silently suppress a useful diagnostic but does not affect correctness or stability.

crates/tui/src/tui/notifications.rs — specifically the interaction between set_completion_sound and the COMPLETION_SOUND_FILE_MISSING_WARNED flag across config reloads.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/notifications.rs | Adds File sound mode with OnceLock+Mutex for the path, SND_ASYNC PlaySoundW on Windows, and once-fire AtomicBool warning guards; the MISSING/UNSUPPORTED_WARNED flags are never reset when settings change, which can silently suppress subsequent misconfiguration warnings. |
| crates/tui/src/config.rs | Adds CompletionSound::File variant and sound_file: Option<PathBuf> to NotificationsConfig; clean serde deserialization with a new round-trip parse test. |
| crates/tui/Cargo.toml | Adds Win32_Media_Audio feature to the windows crate dependency to unlock PlaySoundW. |
| crates/tui/src/tui/ui/tests.rs | Adds sound_file: None to two existing NotificationsConfig struct literals to keep them compiling after the new field was added. |
| config.example.toml | Documents the new file mode and sound_file option; also updates the Windows BEL fallback description to reflect the current code behaviour. |
| docs/CONFIGURATION.md | Adds documentation for completion_sound = "file" and sound_file; corrects the Windows auto-fallback description from "off" to "bel via MessageBeep". |

</details>

</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22codex%2F2484-notification-sound%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2F2484-notification-sound%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fnotifications.rs%3A377-388%0AThe%20%22warn%20once%22%20flags%20%28%60COMPLETION_SOUND_FILE_MISSING_WARNED%60%20and%20%60COMPLETION_SOUND_FILE_UNSUPPORTED_WARNED%60%29%20are%20static%20%60AtomicBool%60s%20that%20are%20set%20to%20%60true%60%20on%20first%20warning%20and%20never%20reset.%20If%20a%20user%20first%20runs%20with%20%60completion_sound%20%3D%20%22file%22%60%20but%20no%20%60sound_file%60%20%28triggering%20the%20warning%29%2C%20then%20later%20configures%20a%20valid%20path%20%28sound%20works%29%2C%20then%20removes%20the%20path%20again%20via%20%60%2Fsettings%60%2C%20no%20further%20warning%20ever%20fires.%20The%20misconfiguration%20becomes%20silently%20invisible.%20Resetting%20the%20flag%20inside%20%60set_completion_sound%60%20whenever%20a%20valid%20%60Some%28path%29%60%20is%20stored%20would%20allow%20the%20warning%20to%20reappear%20after%20a%20subsequent%20breakage.%0A%0A%60%60%60suggestion%0Afn%20set_completion_sound%28mode%3A%20crate%3A%3Aconfig%3A%3ACompletionSound%2C%20sound_file%3A%20Option%3CPathBuf%3E%29%20%7B%0A%20%20%20%20let%20val%20%3D%20match%20mode%20%7B%0A%20%20%20%20%20%20%20%20crate%3A%3Aconfig%3A%3ACompletionSound%3A%3AOff%20%3D%3E%200u8%2C%0A%20%20%20%20%20%20%20%20crate%3A%3Aconfig%3A%3ACompletionSound%3A%3ABeep%20%3D%3E%201u8%2C%0A%20%20%20%20%20%20%20%20crate%3A%3Aconfig%3A%3ACompletionSound%3A%3ABell%20%3D%3E%202u8%2C%0A%20%20%20%20%20%20%20%20crate%3A%3Aconfig%3A%3ACompletionSound%3A%3AFile%20%3D%3E%203u8%2C%0A%20%20%20%20%7D%3B%0A%20%20%20%20COMPLETION_SOUND_MODE.store%28val%2C%20Ordering%3A%3ASeqCst%29%3B%0A%20%20%20%20if%20let%20Ok%28mut%20slot%29%20%3D%20completion_sound_file_slot%28%29.lock%28%29%20%7B%0A%20%20%20%20%20%20%20%20%2F%2F%20If%20a%20valid%20path%20is%20now%20configured%2C%20reset%20the%20missing-file%20warning%20flag%0A%20%20%20%20%20%20%20%20%2F%2F%20so%20a%20subsequent%20removal%20of%20the%20path%20produces%20a%20fresh%20diagnostic.%0A%20%20%20%20%20%20%20%20if%20sound_file.is_some%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20COMPLETION_SOUND_FILE_MISSING_WARNED.store%28false%2C%20Ordering%3A%3ASeqCst%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20*slot%20%3D%20sound_file%3B%0A%20%20%20%20%7D%0A%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fnotifications.rs%3A377-388%0AThe%20%22warn%20once%22%20flags%20%28%60COMPLETION_SOUND_FILE_MISSING_WARNED%60%20and%20%60COMPLETION_SOUND_FILE_UNSUPPORTED_WARNED%60%29%20are%20static%20%60AtomicBool%60s%20that%20are%20set%20to%20%60true%60%20on%20first%20warning%20and%20never%20reset.%20If%20a%20user%20first%20runs%20with%20%60completion_sound%20%3D%20%22file%22%60%20but%20no%20%60sound_file%60%20%28triggering%20the%20warning%29%2C%20then%20later%20configures%20a%20valid%20path%20%28sound%20works%29%2C%20then%20removes%20the%20path%20again%20via%20%60%2Fsettings%60%2C%20no%20further%20warning%20ever%20fires.%20The%20misconfiguration%20becomes%20silently%20invisible.%20Resetting%20the%20flag%20inside%20%60set_completion_sound%60%20whenever%20a%20valid%20%60Some%28path%29%60%20is%20stored%20would%20allow%20the%20warning%20to%20reappear%20after%20a%20subsequent%20breakage.%0A%0A%60%60%60suggestion%0Afn%20set_completion_sound%28mode%3A%20crate%3A%3Aconfig%3A%3ACompletionSound%2C%20sound_file%3A%20Option%3CPathBuf%3E%29%20%7B%0A%20%20%20%20let%20val%20%3D%20match%20mode%20%7B%0A%20%20%20%20%20%20%20%20crate%3A%3Aconfig%3A%3ACompletionSound%3A%3AOff%20%3D%3E%200u8%2C%0A%20%20%20%20%20%20%20%20crate%3A%3Aconfig%3A%3ACompletionSound%3A%3ABeep%20%3D%3E%201u8%2C%0A%20%20%20%20%20%20%20%20crate%3A%3Aconfig%3A%3ACompletionSound%3A%3ABell%20%3D%3E%202u8%2C%0A%20%20%20%20%20%20%20%20crate%3A%3Aconfig%3A%3ACompletionSound%3A%3AFile%20%3D%3E%203u8%2C%0A%20%20%20%20%7D%3B%0A%20%20%20%20COMPLETION_SOUND_MODE.store%28val%2C%20Ordering%3A%3ASeqCst%29%3B%0A%20%20%20%20if%20let%20Ok%28mut%20slot%29%20%3D%20completion_sound_file_slot%28%29.lock%28%29%20%7B%0A%20%20%20%20%20%20%20%20%2F%2F%20If%20a%20valid%20path%20is%20now%20configured%2C%20reset%20the%20missing-file%20warning%20flag%0A%20%20%20%20%20%20%20%20%2F%2F%20so%20a%20subsequent%20removal%20of%20the%20path%20produces%20a%20fresh%20diagnostic.%0A%20%20%20%20%20%20%20%20if%20sound_file.is_some%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20COMPLETION_SOUND_FILE_MISSING_WARNED.store%28false%2C%20Ordering%3A%3ASeqCst%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20*slot%20%3D%20sound_file%3B%0A%20%20%20%20%7D%0A%7D%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2512&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fnotifications.rs%3A377-388%0AThe%20%22warn%20once%22%20flags%20%28%60COMPLETION_SOUND_FILE_MISSING_WARNED%60%20and%20%60COMPLETION_SOUND_FILE_UNSUPPORTED_WARNED%60%29%20are%20static%20%60AtomicBool%60s%20that%20are%20set%20to%20%60true%60%20on%20first%20warning%20and%20never%20reset.%20If%20a%20user%20first%20runs%20with%20%60completion_sound%20%3D%20%22file%22%60%20but%20no%20%60sound_file%60%20%28triggering%20the%20warning%29%2C%20then%20later%20configures%20a%20valid%20path%20%28sound%20works%29%2C%20then%20removes%20the%20path%20again%20via%20%60%2Fsettings%60%2C%20no%20further%20warning%20ever%20fires.%20The%20misconfiguration%20becomes%20silently%20invisible.%20Resetting%20the%20flag%20inside%20%60set_completion_sound%60%20whenever%20a%20valid%20%60Some%28path%29%60%20is%20stored%20would%20allow%20the%20warning%20to%20reappear%20after%20a%20subsequent%20breakage.%0A%0A%60%60%60suggestion%0Afn%20set_completion_sound%28mode%3A%20crate%3A%3Aconfig%3A%3ACompletionSound%2C%20sound_file%3A%20Option%3CPathBuf%3E%29%20%7B%0A%20%20%20%20let%20val%20%3D%20match%20mode%20%7B%0A%20%20%20%20%20%20%20%20crate%3A%3Aconfig%3A%3ACompletionSound%3A%3AOff%20%3D%3E%200u8%2C%0A%20%20%20%20%20%20%20%20crate%3A%3Aconfig%3A%3ACompletionSound%3A%3ABeep%20%3D%3E%201u8%2C%0A%20%20%20%20%20%20%20%20crate%3A%3Aconfig%3A%3ACompletionSound%3A%3ABell%20%3D%3E%202u8%2C%0A%20%20%20%20%20%20%20%20crate%3A%3Aconfig%3A%3ACompletionSound%3A%3AFile%20%3D%3E%203u8%2C%0A%20%20%20%20%7D%3B%0A%20%20%20%20COMPLETION_SOUND_MODE.store%28val%2C%20Ordering%3A%3ASeqCst%29%3B%0A%20%20%20%20if%20let%20Ok%28mut%20slot%29%20%3D%20completion_sound_file_slot%28%29.lock%28%29%20%7B%0A%20%20%20%20%20%20%20%20%2F%2F%20If%20a%20valid%20path%20is%20now%20configured%2C%20reset%20the%20missing-file%20warning%20flag%0A%20%20%20%20%20%20%20%20%2F%2F%20so%20a%20subsequent%20removal%20of%20the%20path%20produces%20a%20fresh%20diagnostic.%0A%20%20%20%20%20%20%20%20if%20sound_file.is_some%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20COMPLETION_SOUND_FILE_MISSING_WARNED.store%28false%2C%20Ordering%3A%3ASeqCst%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20*slot%20%3D%20sound_file%3B%0A%20%20%20%20%7D%0A%7D%0A%60%60%60%0A%0A&pr=2512&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix(tui): clarify custom completion soun..."](https://github.com/hmbown/codewhale/commit/3d6f1eb83159bad416bb2e9ed87d67fb2b5411be) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34932254)</sub>

<!-- /greptile_comment -->