### PR TITLE
feat(tui): expand restore snapshot listing

### DIFF
--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -514,7 +514,7 @@ pub const COMMANDS: &[CommandInfo] = &[
     CommandInfo {
         name: "restore",
         aliases: &[],
-        usage: "/restore [N]",
+        usage: "/restore [N|list [N]]",
         description_id: MessageId::CmdRestoreDescription,
     },
     // RLM command

--- a/crates/tui/src/commands/restore.rs
+++ b/crates/tui/src/commands/restore.rs
@@ -15,6 +15,7 @@ use chrono::TimeZone;
 
 const DEFAULT_LIST_LIMIT: usize = 20;
 const MAX_LIST_LIMIT: usize = 100;
+const MAX_RESTORE_INDEX: usize = 1000;
 
 /// Entry point for `/restore [N|list [N]]`.
 pub fn restore(app: &mut App, arg: Option<&str>) -> CommandResult {
@@ -55,7 +56,12 @@ pub fn restore(app: &mut App, arg: Option<&str>) -> CommandResult {
     }
 
     let n: usize = match arg.parse() {
-        Ok(n) if n >= 1 => n,
+        Ok(n) if (1..=MAX_RESTORE_INDEX).contains(&n) => n,
+        Ok(n) if n > MAX_RESTORE_INDEX => {
+            return CommandResult::error(format!(
+                "Restore index must be <= {MAX_RESTORE_INDEX}; got {n}. Use /restore list [N] to inspect snapshots first.",
+            ));
+        }
         _ => {
             return CommandResult::error(format!(
                 "Usage: /restore <N> or /restore list [N]  (N is 1-based; got '{arg}')",
@@ -335,6 +341,23 @@ mod tests {
         let result = restore(&mut app, Some("12"));
         assert!(result.message.unwrap().contains("Restored"));
         assert_eq!(std::fs::read_to_string(&f).unwrap(), "v0");
+    }
+
+    #[test]
+    fn restore_numeric_index_rejects_unbounded_query() {
+        let tmp = TempDir::new().unwrap();
+        let _home = scoped_home(&tmp);
+        let mut app = make_app(&tmp, true);
+
+        let result = restore(&mut app, Some("1001"));
+
+        assert!(result.is_error);
+        assert!(
+            result
+                .message
+                .unwrap()
+                .contains("Restore index must be <= 1000")
+        );
     }
 
     #[test]

--- a/crates/tui/src/commands/restore.rs
+++ b/crates/tui/src/commands/restore.rs
@@ -1,19 +1,22 @@
 //! `/restore` slash command — roll back the workspace to a prior snapshot.
 //!
-//! `/restore` (no arg) lists the most recent snapshots so the user can
-//! see what's available. `/restore <N>` restores the *N*th-most-recent
-//! snapshot, where `N=1` is the newest. In non-YOLO mode we refuse to
-//! mutate files unless the user has explicitly trusted the workspace
-//! (`/trust on` or YOLO) — the user can always view the list, just not
-//! one-shot revert without a safety net.
+//! `/restore` (no arg) lists the 20 most recent snapshots so the user can
+//! see what's available. `/restore list [N]` lists more snapshots, capped
+//! at 100. `/restore <N>` restores the *N*th-most-recent snapshot, where
+//! `N=1` is the newest. In non-YOLO mode we refuse to mutate files unless
+//! the user has explicitly trusted the workspace (`/trust on` or YOLO) —
+//! the user can always view the list, just not one-shot revert without a
+//! safety net.
 
 use super::CommandResult;
-use crate::snapshot::SnapshotRepo;
+use crate::snapshot::{Snapshot, SnapshotRepo};
 use crate::tui::app::App;
+use chrono::TimeZone;
 
-const LIST_LIMIT: usize = 10;
+const DEFAULT_LIST_LIMIT: usize = 20;
+const MAX_LIST_LIMIT: usize = 100;
 
-/// Entry point for `/restore [N]`.
+/// Entry point for `/restore [N|list [N]]`.
 pub fn restore(app: &mut App, arg: Option<&str>) -> CommandResult {
     let workspace = app.workspace.clone();
     let repo = match SnapshotRepo::open_or_init(&workspace) {
@@ -26,29 +29,46 @@ pub fn restore(app: &mut App, arg: Option<&str>) -> CommandResult {
         }
     };
 
-    let snapshots = match repo.list(LIST_LIMIT) {
-        Ok(s) => s,
-        Err(e) => return CommandResult::error(format!("Failed to list snapshots: {e}")),
-    };
-
-    if snapshots.is_empty() {
-        return CommandResult::message(
-            "No snapshots yet. Send a message to create the first pre-turn snapshot.",
-        );
-    }
-
     let Some(arg) = arg.map(str::trim).filter(|s| !s.is_empty()) else {
+        let snapshots = match repo.list(DEFAULT_LIST_LIMIT) {
+            Ok(s) => s,
+            Err(e) => return CommandResult::error(format!("Failed to list snapshots: {e}")),
+        };
+        if snapshots.is_empty() {
+            return no_snapshots_message();
+        }
         return CommandResult::message(format_listing(&snapshots));
     };
+
+    if let Some(limit) = match parse_list_arg(arg) {
+        Ok(limit) => limit,
+        Err(message) => return CommandResult::error(message),
+    } {
+        let snapshots = match repo.list(limit) {
+            Ok(s) => s,
+            Err(e) => return CommandResult::error(format!("Failed to list snapshots: {e}")),
+        };
+        if snapshots.is_empty() {
+            return no_snapshots_message();
+        }
+        return CommandResult::message(format_listing(&snapshots));
+    }
 
     let n: usize = match arg.parse() {
         Ok(n) if n >= 1 => n,
         _ => {
             return CommandResult::error(format!(
-                "Usage: /restore <N>  (N is 1-based; got '{arg}')",
+                "Usage: /restore <N> or /restore list [N]  (N is 1-based; got '{arg}')",
             ));
         }
     };
+    let snapshots = match repo.list(n.max(DEFAULT_LIST_LIMIT)) {
+        Ok(s) => s,
+        Err(e) => return CommandResult::error(format!("Failed to list snapshots: {e}")),
+    };
+    if snapshots.is_empty() {
+        return no_snapshots_message();
+    }
 
     if n > snapshots.len() {
         return CommandResult::error(format!(
@@ -81,17 +101,61 @@ pub fn restore(app: &mut App, arg: Option<&str>) -> CommandResult {
     ))
 }
 
-fn format_listing(snapshots: &[crate::snapshot::Snapshot]) -> String {
-    let mut out = String::from("Recent snapshots (newest first; pass /restore <N> to revert):\n");
+fn parse_list_arg(arg: &str) -> Result<Option<usize>, String> {
+    let mut parts = arg.split_whitespace();
+    let action = match parts.next() {
+        Some(action) => action,
+        None => return Ok(None),
+    };
+    if action != "list" {
+        return Ok(None);
+    }
+    let Some(value) = parts.next() else {
+        return Ok(Some(DEFAULT_LIST_LIMIT));
+    };
+    if parts.next().is_some() {
+        return Err(format!(
+            "Usage: /restore list [N]  (got extra arguments in '{arg}')",
+        ));
+    }
+    let limit = match value.parse::<usize>() {
+        Ok(limit) if limit >= 1 => limit.min(MAX_LIST_LIMIT),
+        _ => {
+            return Err(format!(
+                "Usage: /restore list [N]  (N must be >= 1; got '{value}')",
+            ));
+        }
+    };
+    Ok(Some(limit))
+}
+
+fn no_snapshots_message() -> CommandResult {
+    CommandResult::message(
+        "No snapshots yet. Send a message to create the first pre-turn snapshot.",
+    )
+}
+
+fn format_listing(snapshots: &[Snapshot]) -> String {
+    let mut out = String::from(
+        "Recent snapshots (newest first; pass /restore <N> to revert; /restore list 50 shows more):\n",
+    );
     for (i, s) in snapshots.iter().enumerate() {
         out.push_str(&format!(
-            "  #{:<2}  {}  {}\n",
+            "  #{:<2}  {}  {}  {}\n",
             i + 1,
+            format_snapshot_time(s.timestamp),
             short_sha(s.id.as_str()),
             s.label,
         ));
     }
     out
+}
+
+fn format_snapshot_time(timestamp: i64) -> String {
+    match chrono::Utc.timestamp_opt(timestamp, 0).single() {
+        Some(dt) => dt.format("%Y-%m-%d %H:%M UTC").to_string(),
+        None => "unknown time".to_string(),
+    }
 }
 
 fn short_sha(sha: &str) -> &str {
@@ -193,6 +257,84 @@ mod tests {
         assert!(msg.contains("pre-turn:1"));
         assert!(msg.contains("#1"));
         assert!(msg.contains("#2"));
+    }
+
+    #[test]
+    fn restore_lists_more_than_ten_snapshots_by_default() {
+        let tmp = TempDir::new().unwrap();
+        let _home = scoped_home(&tmp);
+        let mut app = make_app(&tmp, true);
+        let repo = SnapshotRepo::open_or_init(&app.workspace).unwrap();
+        for i in 0..12 {
+            std::fs::write(app.workspace.join("a.txt"), format!("v{i}")).unwrap();
+            repo.snapshot(&format!("turn:{i}")).unwrap();
+        }
+
+        let result = restore(&mut app, None);
+        let msg = result.message.expect("expected message");
+        assert!(msg.contains("#12"), "{msg}");
+        assert!(msg.contains("turn:0"), "{msg}");
+    }
+
+    #[test]
+    fn restore_listing_includes_snapshot_utc_time() {
+        let snapshots = [Snapshot {
+            id: crate::snapshot::SnapshotId("abcdef123456".to_string()),
+            label: "turn:demo".to_string(),
+            timestamp: 1_700_000_000,
+        }];
+
+        let msg = format_listing(&snapshots);
+
+        assert!(msg.contains("2023-11-14 22:13 UTC"), "{msg}");
+        assert!(msg.contains("abcdef12"), "{msg}");
+        assert!(msg.contains("turn:demo"), "{msg}");
+    }
+
+    #[test]
+    fn restore_list_subcommand_accepts_explicit_limit() {
+        let tmp = TempDir::new().unwrap();
+        let _home = scoped_home(&tmp);
+        let mut app = make_app(&tmp, true);
+        let repo = SnapshotRepo::open_or_init(&app.workspace).unwrap();
+        for i in 0..15 {
+            std::fs::write(app.workspace.join("a.txt"), format!("v{i}")).unwrap();
+            repo.snapshot(&format!("turn:{i}")).unwrap();
+        }
+
+        let result = restore(&mut app, Some("list 12"));
+        let msg = result.message.expect("expected message");
+        assert!(msg.contains("#12"), "{msg}");
+        assert!(!msg.contains("#13"), "{msg}");
+    }
+
+    #[test]
+    fn restore_list_subcommand_rejects_invalid_limit() {
+        let tmp = TempDir::new().unwrap();
+        let _home = scoped_home(&tmp);
+        let mut app = make_app(&tmp, true);
+
+        let result = restore(&mut app, Some("list nope"));
+        assert!(result.is_error);
+        assert!(result.message.unwrap().contains("Usage: /restore list [N]"));
+    }
+
+    #[test]
+    fn restore_numeric_index_can_target_beyond_default_listing() {
+        let tmp = TempDir::new().unwrap();
+        let _home = scoped_home(&tmp);
+        let mut app = make_app(&tmp, true);
+        let repo = SnapshotRepo::open_or_init(&app.workspace).unwrap();
+        let f = app.workspace.join("a.txt");
+        for i in 0..12 {
+            std::fs::write(&f, format!("v{i}")).unwrap();
+            repo.snapshot(&format!("turn:{i}")).unwrap();
+        }
+        std::fs::write(&f, "changed").unwrap();
+
+        let result = restore(&mut app, Some("12"));
+        assert!(result.message.unwrap().contains("Restored"));
+        assert_eq!(std::fs::read_to_string(&f).unwrap(), "v0");
     }
 
     #[test]

--- a/docs/MODES.md
+++ b/docs/MODES.md
@@ -117,7 +117,8 @@ DeepSeek-TUI has three related but intentionally separate recovery paths:
 - Esc-Esc backtrack rewinds the live transcript to a previous user prompt and
   restores that prompt into the composer for editing.
 - `/restore` and the `revert_turn` tool restore workspace files from side-git
-  snapshots. They do not rewrite conversation history.
+  snapshots. `/restore list [N]` lists more snapshot options before choosing a
+  rollback point. They do not rewrite conversation history.
 
 A Pi-style in-file tree browser is a larger UI/data-model project. v0.8.40
 ships the bounded fork/backtrack primitives and explicit lineage metadata.


### PR DESCRIPTION
Refs #2494

## Problem
The `/restore` list can be too shallow when a user has many recent checkpoints, and the entries do not show when a checkpoint was created.

## Change
- make `/restore` show the 20 most recent snapshots by default
- add `/restore list [N]`, capped at 100, to inspect more rollback points
- include each snapshot's UTC timestamp in the listing
- allow `/restore <N>` to target entries beyond the default list size

## Verification
- `cargo test -p codewhale-tui restore_ --all-features --locked -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo check -p codewhale-tui --all-features --locked`
- `cargo clippy -p codewhale-tui --all-features --locked -- -D warnings`
- `git diff --check origin/main..HEAD`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR expands the `/restore` command by bumping the default listing from 10 to 20 snapshots, adding a `/restore list [N]` subcommand (capped at 100), and including UTC timestamps in each listing row.

- **Expanded listing & new subcommand**: `DEFAULT_LIST_LIMIT` raised to 20; `parse_list_arg` routes `list [N]` through a separate fetch path capped at `MAX_LIST_LIMIT = 100`, while plain numeric args are guarded by a new `MAX_RESTORE_INDEX = 1000` ceiling.
- **Timestamp display**: `format_snapshot_time` converts the stored Unix timestamp via `chrono::Utc` and formats it as `YYYY-MM-DD HH:MM UTC`, with `\"unknown time\"` as a safe fallback for invalid values.
- **Tests**: Six new integration tests cover the expanded default count, timestamp rendering, explicit-limit filtering, invalid-limit rejection, out-of-default-range restoration, and the new upper-bound guard.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changed paths are additive and well-tested; the only rough edge is a silent truncation of oversized list requests.

The restore command logic is straightforward and all new branches are exercised by the six added tests. Snapshot fetching, timestamp formatting, and the trust-mode gate are unchanged. The silent capping of `/restore list N` when N > 100 is a UX nit rather than a data-correctness problem.

crates/tui/src/commands/restore.rs — specifically the silent cap in parse_list_arg
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/commands/restore.rs | Core logic for the expanded restore listing: adds DEFAULT_LIST_LIMIT/MAX_LIST_LIMIT/MAX_RESTORE_INDEX constants, parse_list_arg() for the new list subcommand, UTC timestamp formatting, and comprehensive tests. One minor issue: limits exceeding MAX_LIST_LIMIT are silently capped without user feedback. |
| crates/tui/src/commands/mod.rs | Usage string updated from `/restore [N]` to `/restore [N|list [N]]` to reflect the new subcommand syntax. Trivial change, correct. |
| docs/MODES.md | Documentation updated to mention `/restore list [N]` alongside the existing restore description. Accurate and concise. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["/restore [arg]"] --> B{arg present?}
    B -- No --> C["repo.list(DEFAULT_LIST_LIMIT=20)"]
    C --> D{empty?}
    D -- Yes --> E["'No snapshots yet'"]
    D -- No --> F["format_listing()"]

    B -- Yes --> G["parse_list_arg(arg)"]
    G -- "Err" --> H["CommandResult::error"]
    G -- "Ok(Some(limit))" --> I["repo.list(limit ≤ 100)"]
    I --> D2{empty?}
    D2 -- Yes --> E
    D2 -- No --> F

    G -- "Ok(None)" --> J["parse arg as usize N"]
    J -- "0 or parse fail" --> K["Usage error"]
    J -- "N > MAX_RESTORE_INDEX(1000)" --> L["'index must be ≤ 1000' error"]
    J -- "1 ≤ N ≤ 1000" --> M["repo.list(max(N, 20))"]
    M --> N{empty?}
    N -- Yes --> E
    N -- No --> O{N > snapshots.len?}
    O -- Yes --> P["'Only X available' error"]
    O -- No --> Q{yolo or trust_mode?}
    Q -- No --> R["'Refusing to restore' message"]
    Q -- Yes --> S["repo.restore(target.id)"]
    S -- Err --> T["'Restore failed' error"]
    S -- Ok --> U["'Restored snapshot #N' message"]
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22codex%2F2494-restore-list%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2F2494-restore-list%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fcommands%2Frestore.rs%3A127-134%0AWhen%20a%20user%20requests%20more%20entries%20than%20%60MAX_LIST_LIMIT%60%20allows%20%28e.g.%20%60%2Frestore%20list%20200%60%29%2C%20the%20limit%20is%20silently%20capped%20to%20100.%20The%20user%20sees%20100%20results%20but%20has%20no%20indication%20their%20request%20was%20truncated%20%E2%80%94%20they%20may%20believe%20they%20have%20the%20complete%20picture%20when%20they%20only%20have%20the%20first%20100.%0A%0A%60%60%60suggestion%0A%20%20%20%20let%20limit%20%3D%20match%20value.parse%3A%3A%3Cusize%3E%28%29%20%7B%0A%20%20%20%20%20%20%20%20Ok%28limit%29%20if%20limit%20%3E%3D%201%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20limit%20%3E%20MAX_LIST_LIMIT%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%20Err%28format!%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22Usage%3A%20%2Frestore%20list%20%5BN%5D%20%20%28N%20must%20be%20%3C%3D%20%7BMAX_LIST_LIMIT%7D%3B%20got%20'%7Bvalue%7D'%29%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20limit%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20_%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20Err%28format!%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22Usage%3A%20%2Frestore%20list%20%5BN%5D%20%20%28N%20must%20be%20%3E%3D%201%3B%20got%20'%7Bvalue%7D'%29%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fcommands%2Frestore.rs%3A127-134%0AWhen%20a%20user%20requests%20more%20entries%20than%20%60MAX_LIST_LIMIT%60%20allows%20%28e.g.%20%60%2Frestore%20list%20200%60%29%2C%20the%20limit%20is%20silently%20capped%20to%20100.%20The%20user%20sees%20100%20results%20but%20has%20no%20indication%20their%20request%20was%20truncated%20%E2%80%94%20they%20may%20believe%20they%20have%20the%20complete%20picture%20when%20they%20only%20have%20the%20first%20100.%0A%0A%60%60%60suggestion%0A%20%20%20%20let%20limit%20%3D%20match%20value.parse%3A%3A%3Cusize%3E%28%29%20%7B%0A%20%20%20%20%20%20%20%20Ok%28limit%29%20if%20limit%20%3E%3D%201%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20limit%20%3E%20MAX_LIST_LIMIT%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%20Err%28format!%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22Usage%3A%20%2Frestore%20list%20%5BN%5D%20%20%28N%20must%20be%20%3C%3D%20%7BMAX_LIST_LIMIT%7D%3B%20got%20'%7Bvalue%7D'%29%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20limit%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20_%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20Err%28format!%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22Usage%3A%20%2Frestore%20list%20%5BN%5D%20%20%28N%20must%20be%20%3E%3D%201%3B%20got%20'%7Bvalue%7D'%29%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%3B%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2513&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fcommands%2Frestore.rs%3A127-134%0AWhen%20a%20user%20requests%20more%20entries%20than%20%60MAX_LIST_LIMIT%60%20allows%20%28e.g.%20%60%2Frestore%20list%20200%60%29%2C%20the%20limit%20is%20silently%20capped%20to%20100.%20The%20user%20sees%20100%20results%20but%20has%20no%20indication%20their%20request%20was%20truncated%20%E2%80%94%20they%20may%20believe%20they%20have%20the%20complete%20picture%20when%20they%20only%20have%20the%20first%20100.%0A%0A%60%60%60suggestion%0A%20%20%20%20let%20limit%20%3D%20match%20value.parse%3A%3A%3Cusize%3E%28%29%20%7B%0A%20%20%20%20%20%20%20%20Ok%28limit%29%20if%20limit%20%3E%3D%201%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20limit%20%3E%20MAX_LIST_LIMIT%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%20Err%28format!%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22Usage%3A%20%2Frestore%20list%20%5BN%5D%20%20%28N%20must%20be%20%3C%3D%20%7BMAX_LIST_LIMIT%7D%3B%20got%20'%7Bvalue%7D'%29%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20limit%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20_%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20Err%28format!%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22Usage%3A%20%2Frestore%20list%20%5BN%5D%20%20%28N%20must%20be%20%3E%3D%201%3B%20got%20'%7Bvalue%7D'%29%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%3B%0A%60%60%60%0A%0A&pr=2513&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix(tui): bound restore snapshot lookup"](https://github.com/hmbown/codewhale/commit/7e251aafe15bda3a1692bbea4c0c7f6d30776d40) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34934855)</sub>

<!-- /greptile_comment -->