### PR TITLE
refs(#2264): Phase 2 — wire FrozenPrefix::verify() into turn_loop

### DIFF
--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -6,6 +6,7 @@
 //! checkpoints, and loop termination.
 
 use super::*;
+use crate::prompt_zones::PinnedPrefix;
 
 fn loop_guard_block_tool_result(message: String) -> ToolResult {
     ToolResult::error(message).with_metadata(json!({"loop_guard": "identical_tool_call"}))
@@ -307,6 +308,34 @@ impl Engine {
                             })
                             .await;
                     }
+                }
+            }
+
+            // Three-zone prefix contract (#2264): freeze baseline on first
+            // turn, verify against frozen baseline on subsequent turns.
+            // Operates alongside PrefixStabilityManager — this is the
+            // diagnostic layer that never auto-re-pins (unlike check_and_update).
+            // Phase 2: warn-only, no request refusal.
+            let system_text =
+                crate::prefix_cache::system_prompt_text(self.session.system_prompt.as_ref());
+            let current_tools: Vec<crate::models::Tool> = active_tools.clone().unwrap_or_default();
+
+            match &self.session.frozen_prefix {
+                Some(frozen) => {
+                    if let Err(drift) = frozen.verify(&system_text, &current_tools) {
+                        tracing::debug!(
+                            target: "prefix_cache",
+                            "three-zone drift: {drift}"
+                        );
+                        let pinned =
+                            PinnedPrefix::new(self.session.system_prompt.as_ref(), current_tools);
+                        self.session.frozen_prefix = Some(pinned.freeze());
+                    }
+                }
+                None => {
+                    let pinned =
+                        PinnedPrefix::new(self.session.system_prompt.as_ref(), current_tools);
+                    self.session.frozen_prefix = Some(pinned.freeze());
                 }
             }
 

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -312,29 +312,32 @@ impl Engine {
             }
 
             // Three-zone prefix contract (#2264): freeze baseline on first
-            // turn, verify against frozen baseline on subsequent turns.
-            // Operates alongside PrefixStabilityManager — this is the
-            // diagnostic layer that never auto-re-pins (unlike check_and_update).
-            // Phase 2: warn-only, no request refusal.
+            // turn, verify against it on subsequent turns. Operates alongside
+            // PrefixStabilityManager as an independent diagnostic layer.
+            // Phase 2: warn-only, auto-re-freeze on drift.
             let system_text =
                 crate::prefix_cache::system_prompt_text(self.session.system_prompt.as_ref());
-            let current_tools: Vec<crate::models::Tool> = active_tools.clone().unwrap_or_default();
+            let current_tools: &[crate::models::Tool] = active_tools.as_deref().unwrap_or_default();
 
             match &self.session.frozen_prefix {
                 Some(frozen) => {
-                    if let Err(drift) = frozen.verify(&system_text, &current_tools) {
+                    if let Err(drift) = frozen.verify(&system_text, current_tools) {
                         tracing::debug!(
                             target: "prefix_cache",
                             "three-zone drift: {drift}"
                         );
-                        let pinned =
-                            PinnedPrefix::new(self.session.system_prompt.as_ref(), current_tools);
+                        let pinned = PinnedPrefix::new(
+                            self.session.system_prompt.as_ref(),
+                            current_tools.to_vec(),
+                        );
                         self.session.frozen_prefix = Some(pinned.freeze());
                     }
                 }
                 None => {
-                    let pinned =
-                        PinnedPrefix::new(self.session.system_prompt.as_ref(), current_tools);
+                    let pinned = PinnedPrefix::new(
+                        self.session.system_prompt.as_ref(),
+                        current_tools.to_vec(),
+                    );
                     self.session.frozen_prefix = Some(pinned.freeze());
                 }
             }

--- a/crates/tui/src/core/session.rs
+++ b/crates/tui/src/core/session.rs
@@ -6,6 +6,7 @@ use crate::cycle_manager::CycleBriefing;
 use crate::models::{Message, SystemPrompt, Usage};
 use crate::prefix_cache::PrefixStabilityManager;
 use crate::project_context::{ProjectContext, load_project_context_with_parents};
+use crate::prompt_zones::FrozenPrefix;
 use crate::tui::approval::ApprovalMode;
 use crate::working_set::WorkingSet;
 use chrono::{DateTime, Utc};
@@ -91,6 +92,11 @@ pub struct Session {
     /// Tracks the immutable prefix fingerprint and detects drift across turns.
     /// Set during engine construction; None until the first system prompt assembly.
     pub prefix_stability: Option<PrefixStabilityManager>,
+
+    /// Three-zone immutable prefix baseline (#2264). Frozen on the first
+    /// request of the session; verified against the current system+tool
+    /// state before every subsequent request. None until the first turn.
+    pub frozen_prefix: Option<FrozenPrefix>,
 }
 
 /// Cumulative usage statistics for a session.
@@ -166,6 +172,7 @@ impl Session {
             current_cycle_started: Utc::now(),
             cycle_briefings: Vec::new(),
             prefix_stability: None,
+            frozen_prefix: None,
         }
     }
 


### PR DESCRIPTION
Refs #2264 (Phase 2 — conservative path, warn-only).

## Summary

Wires the Phase 1 `FrozenPrefix` type into the request path for the first
time. Adds a three-zone diagnostic layer alongside the existing
`PrefixStabilityManager::check_and_update()`. No behavioral change to
existing prefix-cache monitoring — this is an additional, independent
observation layer.

**First turn**: freeze baseline via `PinnedPrefix::freeze()`
**Subsequent turns**: `FrozenPrefix::verify()` against current system+tools,
  log drift via `tracing::debug!`, auto-re-freeze

## Files

| File | Change |
|---|---|
| `crates/tui/src/core/session.rs` | +4: import FrozenPrefix, add frozen_prefix field + default |
| `crates/tui/src/core/engine/turn_loop.rs` | +32: import PinnedPrefix, insert verify block |

## What this does NOT do
- No request blocking
- No user-visible events (yet — Phase 3)
- No interaction with existing `PrefixStabilityManager` or `/cache stats`
- No `/cache zones` changes

## Testing
- cargo check: clean (6 pre-existing schema_migration warnings only)
- 37 prompt_zones + prefix_cache tests pass

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Wires the Phase 1 `FrozenPrefix` type into the turn loop as a second, independent prefix-drift diagnostic layer. On the first turn it freezes a baseline; on subsequent turns it calls `FrozenPrefix::verify()`, logs any drift at `debug` level, and auto-re-freezes. No user-visible events or request blocking are introduced.

- **`turn_loop.rs`**: Adds a ~32-line block after `PrefixStabilityManager::check_and_update` that freezes/verifies the `FrozenPrefix` baseline using `PinnedPrefix::new` + `freeze()`.
- **`session.rs`**: Adds `frozen_prefix: Option<FrozenPrefix>` to the `Session` struct, defaulting to `None`, imported from `prompt_zones`.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The change is warn-only with no request blocking, but it introduces a tool-hashing approach that diverges from the established PrefixStabilityManager — any tool carrying a cache_control or allowed_callers field will cause the two layers to disagree, producing false-positive drift signals that will become user-visible in Phase 3.

The tool digest function in prompt_zones uses full serde serialization while prefix_cache intentionally strips internal-only fields for the same hashing purpose. This divergence is baked in from the first freeze, making the FrozenPrefix baseline unreliable for any session with tools that have non-None internal fields. Fixing it before Phase 3 is significantly cheaper than after.

crates/tui/src/core/engine/turn_loop.rs — the verify block, and by extension prompt_zones::tool_catalog_digest which should align its serialization with prefix_cache::tool_to_api_json.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/core/engine/turn_loop.rs | Wires FrozenPrefix verification into the turn loop; the tool-hashing logic diverges from PrefixStabilityManager (full serde serialization vs. API-shape-only), which will produce false-positive drift events for any tool with internal-only fields (e.g. cache_control). |
| crates/tui/src/core/session.rs | Adds frozen_prefix: Option<FrozenPrefix> field to Session with a None default; straightforward struct addition with correct initialization. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant TL as turn_loop
    participant PSM as PrefixStabilityManager
    participant FP as FrozenPrefix (new)
    participant Sess as Session

    TL->>PSM: check_and_update(system_text, active_tools)
    alt drift detected
        PSM-->>TL: Err(PrefixChange)
        TL->>TL: emit PrefixCacheChange event
    else stable
        PSM-->>TL: Ok(true)
    end

    TL->>TL: "system_text = prefix_cache::system_prompt_text(...)"
    TL->>TL: "current_tools = active_tools.as_deref()"

    alt session.frozen_prefix is None (first turn)
        TL->>TL: PinnedPrefix::new(system_prompt, tools.to_vec())
        TL->>FP: pinned.freeze()
        TL->>Sess: "frozen_prefix = Some(frozen)"
    else session.frozen_prefix is Some(frozen)
        TL->>FP: frozen.verify(system_text, current_tools)
        alt verify Err(drift)
            FP-->>TL: PrefixDrift
            TL->>TL: tracing::debug!(drift)
            TL->>TL: PinnedPrefix::new(...) — auto-re-freeze
            TL->>Sess: "frozen_prefix = Some(new_frozen)"
        else verify Ok
            FP-->>TL: ()
        end
    end

    TL->>TL: build MessageRequest and send
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fphase2-frozen-verify%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fphase2-frozen-verify%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine%2Fturn_loop.rs%3A320-343%0A**%60FrozenPrefix%60%20tool%20hash%20diverges%20from%20%60PrefixStabilityManager%60%20%E2%80%94%20false-positive%20drift%20guaranteed%20for%20any%20tool%20with%20internal-only%20fields**%0A%0A%60prompt_zones%3A%3Atool_catalog_digest%60%20serializes%20tools%20with%20%60serde_json%3A%3Ato_string%28t%29%60%2C%20which%20includes%20every%20field%20on%20the%20%60Tool%60%20struct%20%E2%80%94%20%60cache_control%60%2C%20%60allowed_callers%60%2C%20%60defer_loading%60%2C%20%60input_examples%60%2C%20%60tool_type%60%2C%20etc.%20%60PrefixStabilityManager%3A%3APrefixFingerprint%3A%3Acompute%60%20intentionally%20uses%20%60tool_to_api_json%28%29%60%20to%20strip%20those%20same%20fields%2C%20citing%20issue%20%232264%20explicitly.%20Any%20tool%20with%20a%20non-%60None%60%20%60cache_control%60%20will%20produce%20a%20different%20%60tool_catalog%60%20digest%20in%20%60FrozenPrefix%60%20than%20in%20%60PrefixFingerprint%60%2C%20making%20the%20two%20monitoring%20layers%20permanently%20disagree.%20In%20Phase%203%2C%20when%20%60frozen_prefix%60%20drift%20drives%20user-visible%20events%2C%20every%20session%20using%20tools%20with%20%60cache_control%60%20set%20will%20fire%20spurious%20invalidation%20notifications%20from%20the%20first%20turn.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine%2Fturn_loop.rs%3A320-343%0A**%60FrozenPrefix%60%20tool%20hash%20diverges%20from%20%60PrefixStabilityManager%60%20%E2%80%94%20false-positive%20drift%20guaranteed%20for%20any%20tool%20with%20internal-only%20fields**%0A%0A%60prompt_zones%3A%3Atool_catalog_digest%60%20serializes%20tools%20with%20%60serde_json%3A%3Ato_string%28t%29%60%2C%20which%20includes%20every%20field%20on%20the%20%60Tool%60%20struct%20%E2%80%94%20%60cache_control%60%2C%20%60allowed_callers%60%2C%20%60defer_loading%60%2C%20%60input_examples%60%2C%20%60tool_type%60%2C%20etc.%20%60PrefixStabilityManager%3A%3APrefixFingerprint%3A%3Acompute%60%20intentionally%20uses%20%60tool_to_api_json%28%29%60%20to%20strip%20those%20same%20fields%2C%20citing%20issue%20%232264%20explicitly.%20Any%20tool%20with%20a%20non-%60None%60%20%60cache_control%60%20will%20produce%20a%20different%20%60tool_catalog%60%20digest%20in%20%60FrozenPrefix%60%20than%20in%20%60PrefixFingerprint%60%2C%20making%20the%20two%20monitoring%20layers%20permanently%20disagree.%20In%20Phase%203%2C%20when%20%60frozen_prefix%60%20drift%20drives%20user-visible%20events%2C%20every%20session%20using%20tools%20with%20%60cache_control%60%20set%20will%20fire%20spurious%20invalidation%20notifications%20from%20the%20first%20turn.%0A%0A&repo=hmbown%2Fcodewhale&pr=2514&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine%2Fturn_loop.rs%3A320-343%0A**%60FrozenPrefix%60%20tool%20hash%20diverges%20from%20%60PrefixStabilityManager%60%20%E2%80%94%20false-positive%20drift%20guaranteed%20for%20any%20tool%20with%20internal-only%20fields**%0A%0A%60prompt_zones%3A%3Atool_catalog_digest%60%20serializes%20tools%20with%20%60serde_json%3A%3Ato_string%28t%29%60%2C%20which%20includes%20every%20field%20on%20the%20%60Tool%60%20struct%20%E2%80%94%20%60cache_control%60%2C%20%60allowed_callers%60%2C%20%60defer_loading%60%2C%20%60input_examples%60%2C%20%60tool_type%60%2C%20etc.%20%60PrefixStabilityManager%3A%3APrefixFingerprint%3A%3Acompute%60%20intentionally%20uses%20%60tool_to_api_json%28%29%60%20to%20strip%20those%20same%20fields%2C%20citing%20issue%20%232264%20explicitly.%20Any%20tool%20with%20a%20non-%60None%60%20%60cache_control%60%20will%20produce%20a%20different%20%60tool_catalog%60%20digest%20in%20%60FrozenPrefix%60%20than%20in%20%60PrefixFingerprint%60%2C%20making%20the%20two%20monitoring%20layers%20permanently%20disagree.%20In%20Phase%203%2C%20when%20%60frozen_prefix%60%20drift%20drives%20user-visible%20events%2C%20every%20session%20using%20tools%20with%20%60cache_control%60%20set%20will%20fire%20spurious%20invalidation%20notifications%20from%20the%20first%20turn.%0A%0A&pr=2514&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix: clarify comment, avoid per-turn too..."](https://github.com/hmbown/codewhale/commit/9ba6045defbb43a6a14b82cb2dc463654121815e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34935190)</sub>

<!-- /greptile_comment -->