### PR TITLE
fix(tui): prefer codewhale settings path

### DIFF
--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -353,30 +353,13 @@ impl Settings {
         let primary = codewhale_config::codewhale_home()
             .ok()
             .map(|home| home.join(SETTINGS_FILE_NAME));
-        if let Some(path) = primary.as_ref()
-            && path.exists()
-        {
-            return Ok(path.clone());
-        }
-
         let legacy_home = codewhale_config::legacy_deepseek_home()
             .ok()
             .map(|home| home.join(SETTINGS_FILE_NAME));
-        if let Some(path) = legacy_home
-            && path.exists()
-        {
-            return Ok(path);
-        }
+        let legacy_config_dir =
+            dirs::config_dir().map(|dir| dir.join("deepseek").join(SETTINGS_FILE_NAME));
 
-        let legacy_config_dir = dirs::config_dir()
-            .context("Failed to resolve config directory: not found.")?
-            .join("deepseek")
-            .join(SETTINGS_FILE_NAME);
-        if legacy_config_dir.exists() {
-            return Ok(legacy_config_dir);
-        }
-
-        Ok(primary.unwrap_or(legacy_config_dir))
+        resolve_settings_path_from_candidates(primary, legacy_home, legacy_config_dir)
     }
 
     /// Load settings from disk, or return defaults if not found
@@ -900,6 +883,34 @@ impl Settings {
     pub fn synchronized_output_enabled(&self) -> bool {
         !self.synchronized_output.eq_ignore_ascii_case("off")
     }
+}
+
+fn resolve_settings_path_from_candidates(
+    primary: Option<PathBuf>,
+    legacy_home: Option<PathBuf>,
+    legacy_config_dir: Option<PathBuf>,
+) -> Result<PathBuf> {
+    if let Some(path) = primary.as_ref()
+        && path.exists()
+    {
+        return Ok(path.clone());
+    }
+
+    if let Some(path) = legacy_home
+        && path.exists()
+    {
+        return Ok(path);
+    }
+
+    if let Some(path) = legacy_config_dir.as_ref()
+        && path.exists()
+    {
+        return Ok(path.clone());
+    }
+
+    primary.or(legacy_config_dir).ok_or_else(|| {
+        anyhow::anyhow!("Failed to resolve settings path: no config directory found.")
+    })
 }
 
 fn normalize_default_model(value: &str) -> Option<String> {
@@ -2171,36 +2182,66 @@ mod tests {
     fn settings_path_reads_legacy_deepseek_home_when_present() {
         let _g = config_path_test_guard();
         let tmp = tempfile::tempdir().expect("tempdir");
+        let primary = tmp.path().join(".codewhale").join("settings.toml");
         let legacy_dir = tmp.path().join(".deepseek");
         std::fs::create_dir_all(&legacy_dir).expect("legacy dir");
-        std::fs::write(legacy_dir.join("settings.toml"), "low_motion = true\n")
-            .expect("legacy settings");
-        let _config_override = EnvVarRestore::remove("DEEPSEEK_CONFIG_PATH");
-        let _codewhale_home = EnvVarRestore::set("CODEWHALE_HOME", tmp.path().join(".codewhale"));
-        let _home = EnvVarRestore::set("HOME", tmp.path());
+        let legacy_home = legacy_dir.join("settings.toml");
+        std::fs::write(&legacy_home, "low_motion = true\n").expect("legacy settings");
+        let legacy_config_dir = tmp
+            .path()
+            .join("platform-config")
+            .join("deepseek")
+            .join("settings.toml");
+        std::fs::create_dir_all(legacy_config_dir.parent().expect("parent"))
+            .expect("legacy config dir");
+        std::fs::write(&legacy_config_dir, "low_motion = false\n")
+            .expect("platform legacy settings");
 
-        let got = Settings::path().expect("settings path");
+        let got = resolve_settings_path_from_candidates(
+            Some(primary),
+            Some(legacy_home.clone()),
+            Some(legacy_config_dir),
+        )
+        .expect("settings path");
 
-        assert_eq!(got, legacy_dir.join("settings.toml"));
+        assert_eq!(got, legacy_home);
     }
 
     #[test]
     fn settings_path_keeps_platform_config_dir_as_last_legacy_fallback() {
         let _g = config_path_test_guard();
         let tmp = tempfile::tempdir().expect("tempdir");
-        let _config_override = EnvVarRestore::remove("DEEPSEEK_CONFIG_PATH");
-        let _codewhale_home = EnvVarRestore::set("CODEWHALE_HOME", tmp.path().join(".codewhale"));
-        let _home = EnvVarRestore::set("HOME", tmp.path());
-
-        let config_dir = dirs::config_dir().expect("config dir");
-        let legacy_settings = config_dir.join("deepseek").join("settings.toml");
-        std::fs::create_dir_all(legacy_settings.parent().expect("parent"))
+        let primary = tmp.path().join(".codewhale").join("settings.toml");
+        let legacy_home = tmp.path().join(".deepseek").join("settings.toml");
+        let legacy_config_dir = tmp
+            .path()
+            .join("platform-config")
+            .join("deepseek")
+            .join("settings.toml");
+        std::fs::create_dir_all(legacy_config_dir.parent().expect("parent"))
             .expect("legacy config dir");
-        std::fs::write(&legacy_settings, "low_motion = true\n").expect("legacy settings");
+        std::fs::write(&legacy_config_dir, "low_motion = true\n").expect("legacy settings");
 
-        let got = Settings::path().expect("settings path");
+        let got = resolve_settings_path_from_candidates(
+            Some(primary),
+            Some(legacy_home),
+            Some(legacy_config_dir.clone()),
+        )
+        .expect("settings path");
 
-        assert_eq!(got, legacy_settings);
+        assert_eq!(got, legacy_config_dir);
+    }
+
+    #[test]
+    fn settings_path_uses_primary_when_platform_config_dir_is_unavailable() {
+        let _g = config_path_test_guard();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let primary = tmp.path().join(".codewhale").join("settings.toml");
+
+        let got = resolve_settings_path_from_candidates(Some(primary.clone()), None, None)
+            .expect("settings path");
+
+        assert_eq!(got, primary);
     }
 
     #[test]

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -1,9 +1,9 @@
 //! Settings system - Persistent user preferences
 //!
-//! Settings are stored at ~/.config/deepseek/settings.toml
+//! Settings are stored at ~/.codewhale/settings.toml, with legacy fallbacks.
 //!
 //! TUI-specific preferences (theme, keybinds, font_size) that survive project
-//! switches are stored separately at ~/.deepseek/tui.toml. See [`TuiPrefs`].
+//! switches are stored separately in tui.toml. See [`TuiPrefs`].
 
 use std::path::PathBuf;
 
@@ -13,6 +13,8 @@ use serde::{Deserialize, Serialize};
 use crate::config::{expand_path, normalize_model_name};
 use crate::localization::normalize_configured_locale;
 use crate::palette::{normalize_hex_rgb_color, normalize_theme_name};
+
+const SETTINGS_FILE_NAME: &str = "settings.toml";
 
 // ============================================================================
 // TuiPrefs — ~/.deepseek/tui.toml
@@ -343,15 +345,38 @@ impl Settings {
             if !config_path.is_empty() {
                 let p = expand_path(config_path);
                 if let Some(parent) = p.parent() {
-                    return Ok(parent.join("settings.toml"));
+                    return Ok(parent.join(SETTINGS_FILE_NAME));
                 }
             }
         }
 
-        let config_dir = dirs::config_dir()
+        let primary = codewhale_config::codewhale_home()
+            .ok()
+            .map(|home| home.join(SETTINGS_FILE_NAME));
+        if let Some(path) = primary.as_ref()
+            && path.exists()
+        {
+            return Ok(path.clone());
+        }
+
+        let legacy_home = codewhale_config::legacy_deepseek_home()
+            .ok()
+            .map(|home| home.join(SETTINGS_FILE_NAME));
+        if let Some(path) = legacy_home
+            && path.exists()
+        {
+            return Ok(path);
+        }
+
+        let legacy_config_dir = dirs::config_dir()
             .context("Failed to resolve config directory: not found.")?
-            .join("deepseek");
-        Ok(config_dir.join("settings.toml"))
+            .join("deepseek")
+            .join(SETTINGS_FILE_NAME);
+        if legacy_config_dir.exists() {
+            return Ok(legacy_config_dir);
+        }
+
+        Ok(primary.unwrap_or(legacy_config_dir))
     }
 
     /// Load settings from disk, or return defaults if not found
@@ -467,8 +492,8 @@ impl Settings {
         //
         // Only flip `auto` to `off`; respect an explicit `"on"` so users
         // who upgrade Ptyxis or want to confirm the fix landed upstream
-        // can override the heuristic from `~/.config/deepseek/settings.toml`
-        // or `/set synchronized_output on`.
+        // can override the heuristic from the persisted settings.toml or
+        // `/set synchronized_output on`.
         if self.synchronized_output.eq_ignore_ascii_case("auto") && detected_ptyxis_terminal() {
             self.synchronized_output = "off".to_string();
         }
@@ -2090,6 +2115,92 @@ mod tests {
     /// so the parallel test runner doesn't observe interleaved env values.
     fn config_path_test_guard() -> std::sync::MutexGuard<'static, ()> {
         crate::test_support::lock_test_env()
+    }
+
+    struct EnvVarRestore {
+        key: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl EnvVarRestore {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let previous = std::env::var_os(key);
+            // SAFETY: tests using this helper hold config_path_test_guard.
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            Self { key, previous }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let previous = std::env::var_os(key);
+            // SAFETY: tests using this helper hold config_path_test_guard.
+            unsafe {
+                std::env::remove_var(key);
+            }
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarRestore {
+        fn drop(&mut self) {
+            // SAFETY: tests using this helper hold config_path_test_guard.
+            unsafe {
+                match &self.previous {
+                    Some(value) => std::env::set_var(self.key, value),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn settings_path_defaults_to_codewhale_home_for_new_writes() {
+        let _g = config_path_test_guard();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _config_override = EnvVarRestore::remove("DEEPSEEK_CONFIG_PATH");
+        let _codewhale_home = EnvVarRestore::set("CODEWHALE_HOME", tmp.path().join(".codewhale"));
+        let _home = EnvVarRestore::set("HOME", tmp.path());
+
+        let got = Settings::path().expect("settings path");
+
+        assert_eq!(got, tmp.path().join(".codewhale").join("settings.toml"));
+    }
+
+    #[test]
+    fn settings_path_reads_legacy_deepseek_home_when_present() {
+        let _g = config_path_test_guard();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let legacy_dir = tmp.path().join(".deepseek");
+        std::fs::create_dir_all(&legacy_dir).expect("legacy dir");
+        std::fs::write(legacy_dir.join("settings.toml"), "low_motion = true\n")
+            .expect("legacy settings");
+        let _config_override = EnvVarRestore::remove("DEEPSEEK_CONFIG_PATH");
+        let _codewhale_home = EnvVarRestore::set("CODEWHALE_HOME", tmp.path().join(".codewhale"));
+        let _home = EnvVarRestore::set("HOME", tmp.path());
+
+        let got = Settings::path().expect("settings path");
+
+        assert_eq!(got, legacy_dir.join("settings.toml"));
+    }
+
+    #[test]
+    fn settings_path_keeps_platform_config_dir_as_last_legacy_fallback() {
+        let _g = config_path_test_guard();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _config_override = EnvVarRestore::remove("DEEPSEEK_CONFIG_PATH");
+        let _codewhale_home = EnvVarRestore::set("CODEWHALE_HOME", tmp.path().join(".codewhale"));
+        let _home = EnvVarRestore::set("HOME", tmp.path());
+
+        let config_dir = dirs::config_dir().expect("config dir");
+        let legacy_settings = config_dir.join("deepseek").join("settings.toml");
+        std::fs::create_dir_all(legacy_settings.parent().expect("parent"))
+            .expect("legacy config dir");
+        std::fs::write(&legacy_settings, "low_motion = true\n").expect("legacy settings");
+
+        let got = Settings::path().expect("settings path");
+
+        assert_eq!(got, legacy_settings);
     }
 
     #[test]

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -50,7 +50,7 @@ pub enum OnboardingState {
     Welcome,
     /// Pick the UI locale before any other config decisions (#566).
     /// Defaults to auto-detection from `LC_ALL` / `LANG`; explicit picks
-    /// land in `~/.deepseek/settings.toml` via `Settings::set("locale", …)`.
+    /// land in the persisted settings.toml via `Settings::set("locale", …)`.
     Language,
     ApiKey,
     TrustDirectory,
@@ -2153,7 +2153,7 @@ impl App {
     }
 
     /// Apply a locale tag selected from the onboarding language picker (#566).
-    /// Persists the value to `~/.deepseek/settings.toml` and immediately
+    /// Persists the value to settings.toml and immediately
     /// re-resolves `ui_locale` so the rest of onboarding renders in the new
     /// language. `App` doesn't keep `Settings` resident — it loads on entry
     /// and rewrites on exit, mirroring the pattern used by the `/config`
@@ -2167,7 +2167,7 @@ impl App {
         Ok(())
     }
 
-    /// Locale tag currently persisted in `~/.deepseek/settings.toml` (or
+    /// Locale tag currently persisted in settings.toml (or
     /// `"auto"` when no settings file exists). Used by the onboarding
     /// language picker to highlight the current selection without `App`
     /// having to keep `Settings` resident.

--- a/crates/tui/src/tui/model_picker.rs
+++ b/crates/tui/src/tui/model_picker.rs
@@ -543,8 +543,7 @@ mod tests {
             initial_input: None,
         };
         let mut app = App::new(options, &Config::default());
-        // App::new merges in `~/.config/deepseek/settings.toml` /
-        // `Application Support/deepseek/settings.toml`, which can override
+        // App::new merges in the user's persisted settings.toml, which can override
         // the model, effort, and provider with whatever the developer
         // happens to have saved. Pin all three back to known values so
         // the picker tests below exercise the picker logic, not the

--- a/docs/ACCESSIBILITY.md
+++ b/docs/ACCESSIBILITY.md
@@ -46,7 +46,9 @@ The same toggles are reachable from the command palette:
 * `/settings set calm_mode on`
 * `/settings set status_indicator off`
 
-Settings written this way persist to `~/.config/deepseek/settings.toml`.
+Settings written this way persist to `~/.codewhale/settings.toml` on new
+installs, with legacy `~/.deepseek/settings.toml` and platform config-dir
+settings kept as compatibility fallbacks.
 The `NO_ANIMATIONS` env var still wins at startup if it's set, so
 unsetting the env var is the way to honor your saved choice.
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -479,7 +479,9 @@ round-trip intact.
 
 codewhale also stores user preferences in:
 
-- `~/.config/deepseek/settings.toml`
+- `~/.codewhale/settings.toml` on new installs
+- `~/.deepseek/settings.toml` or the legacy platform config-dir
+  `deepseek/settings.toml` when an existing settings file is present
 
 Notable settings include `auto_compact` (default `false`), which opts into
 replacement-style summarization only near the active model limit. The default


### PR DESCRIPTION
Refs #2369

## Problem
`settings.toml` still uses the legacy DeepSeek config locations even after the broader config home moved toward `.codewhale`, which leaves user preferences split across old and new homes.

## Change
- prefer `~/.codewhale/settings.toml` for new settings writes
- keep existing `~/.deepseek/settings.toml` as the first legacy read fallback
- keep the old platform config-dir `deepseek/settings.toml` as the last compatibility fallback
- update nearby settings docs/comments to describe the current resolver behavior

## Verification
- `cargo test -p codewhale-tui settings_path_ --all-features --locked -- --nocapture`
- `cargo test -p codewhale-tui settings::tests --all-features --locked -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo check -p codewhale-tui --all-features --locked`
- `cargo clippy -p codewhale-tui --all-features --locked -- -D warnings`
- `git diff --check origin/main..HEAD`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR migrates `Settings::path()` from the old `~/.config/deepseek/settings.toml` location to prefer `~/.codewhale/settings.toml` for new installs, while preserving backward-compatibility for users with existing `~/.deepseek/settings.toml` or platform config-dir files. The change introduces a dedicated `resolve_settings_path_from_candidates` helper, four new unit tests with an `EnvVarRestore` RAII helper, and matching doc/comment updates across the TUI and docs.

- **Three-tier path resolver** (`codewhale_home → legacy_deepseek_home → platform config_dir`): existing files are read from their current location; new writes land in `~/.codewhale/settings.toml`.
- **`TuiPrefs::path()`** (dead code, wired in #657) still falls back to `~/.deepseek/tui.toml` for new installs, which will split the config home across `~/.codewhale/` and `~/.deepseek/` once that wiring lands.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the three-tier resolver correctly handles new installs, legacy deepseek home, and platform config-dir fallback without data loss.

The path resolution logic is correct and well-tested. The only finding is that TuiPrefs::path() — currently dead code — will write tui.toml to ~/.deepseek/ while settings.toml now goes to ~/.codewhale/, creating a split config home when the TuiPrefs wiring (#657) lands. That inconsistency does not affect live users today.

crates/tui/src/settings.rs — specifically the TuiPrefs::path() fallback and its save() doc comment, which will matter once #657 wires up TuiPrefs.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/settings.rs | Core change: replaces single-path config_dir resolution with a three-tier resolver. TuiPrefs::path() (not in this diff) still targets ~/.deepseek/tui.toml for new installs, creating a split config home once TuiPrefs is wired up. |
| crates/tui/src/tui/app.rs | Doc comment updates only: replaces hardcoded ~/.deepseek/settings.toml references with generic phrasing. No logic changes. |
| crates/tui/src/tui/model_picker.rs | Single test comment updated to remove hardcoded config path references. No logic changes. |
| docs/ACCESSIBILITY.md | Documentation updated to describe the new three-tier path resolver accurately. |
| docs/CONFIGURATION.md | Documentation updated to list all three settings.toml resolution tiers. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Settings::path() called"] --> B{DEEPSEEK_CONFIG_PATH set?}
    B -- Yes --> C["Return parent(config_path)/settings.toml"]
    B -- No --> D["codewhale_home() → primary\nlegacy_deepseek_home() → legacy_home\ndirs::config_dir() → legacy_config_dir"]
    D --> E["resolve_settings_path_from_candidates(...)"]
    E --> F{primary exists on disk?}
    F -- Yes --> G["Return ~/.codewhale/settings.toml"]
    F -- No --> H{legacy_home exists on disk?}
    H -- Yes --> I["Return ~/.deepseek/settings.toml"]
    H -- No --> J{legacy_config_dir exists on disk?}
    J -- Yes --> K["Return config_dir/deepseek/settings.toml"]
    J -- No --> L{primary is Some?}
    L -- Yes --> M["Return ~/.codewhale/settings.toml (new write)"]
    L -- No --> N{legacy_config_dir is Some?}
    N -- Yes --> O["Return config_dir/deepseek/settings.toml (new write)"]
    N -- No --> P["Error: no config directory found"]
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22codex%2F2369-settings-path%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2F2369-settings-path%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fsettings.rs%3A112-118%0A%60TuiPrefs%3A%3Apath%28%29%60%20falls%20back%20to%20%60~%2F.deepseek%2Ftui.toml%60%20for%20new%20installs%20while%20%60Settings%3A%3Apath%28%29%60%20now%20targets%20%60~%2F.codewhale%2Fsettings.toml%60.%20When%20%23657%20wires%20up%20%60TuiPrefs%3A%3Asave%28%29%60%2C%20fresh%20installs%20will%20silently%20split%20their%20config%20home%3A%20%60settings.toml%60%20lands%20in%20%60~%2F.codewhale%2F%60%20and%20%60tui.toml%60%20lands%20in%20%60~%2F.deepseek%2F%60.%20Applying%20the%20same%20primary-first%20fallback%20logic%20that%20this%20PR%20introduces%20for%20%60Settings%60%20would%20keep%20the%20two%20files%20colocated.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20home%20%3D%20dirs%3A%3Ahome_dir%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20.context%28%22Failed%20to%20resolve%20home%20directory%3A%20cannot%20determine%20tui.toml%20path.%22%29%3F%3B%0A%20%20%20%20%20%20%20%20let%20primary%20%3D%20home.join%28%22.codewhale%22%29.join%28%22tui.toml%22%29%3B%0A%20%20%20%20%20%20%20%20if%20primary.exists%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20Ok%28primary%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20let%20legacy_home%20%3D%20home.join%28%22.deepseek%22%29.join%28%22tui.toml%22%29%3B%0A%20%20%20%20%20%20%20%20if%20legacy_home.exists%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20Ok%28legacy_home%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20Ok%28primary%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fsettings.rs%3A138-139%0AThe%20doc%20comment%20on%20%60TuiPrefs%3A%3Asave%60%20still%20advertises%20%60~%2F.deepseek%2Ftui.toml%60%20as%20the%20write%20destination.%20After%20this%20PR%2C%20%60Settings%3A%3Asave%60%20targets%20%60~%2F.codewhale%2F%60%20for%20new%20installs%2C%20so%20this%20comment%20is%20misleading%20about%20where%20%60tui.toml%60%20will%20eventually%20land%20once%20the%20%60TuiPrefs%60%20wiring%20%28%23657%29%20is%20complete.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Save%20TUI%20preferences%20to%20%60~%2F.codewhale%2Ftui.toml%60%20%28or%20the%20legacy%0A%20%20%20%20%2F%2F%2F%20%60~%2F.deepseek%2Ftui.toml%60%20when%20that%20file%20already%20exists%29%2C%20creating%20the%0A%20%20%20%20%2F%2F%2F%20target%20directory%20if%20needed.%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fsettings.rs%3A112-118%0A%60TuiPrefs%3A%3Apath%28%29%60%20falls%20back%20to%20%60~%2F.deepseek%2Ftui.toml%60%20for%20new%20installs%20while%20%60Settings%3A%3Apath%28%29%60%20now%20targets%20%60~%2F.codewhale%2Fsettings.toml%60.%20When%20%23657%20wires%20up%20%60TuiPrefs%3A%3Asave%28%29%60%2C%20fresh%20installs%20will%20silently%20split%20their%20config%20home%3A%20%60settings.toml%60%20lands%20in%20%60~%2F.codewhale%2F%60%20and%20%60tui.toml%60%20lands%20in%20%60~%2F.deepseek%2F%60.%20Applying%20the%20same%20primary-first%20fallback%20logic%20that%20this%20PR%20introduces%20for%20%60Settings%60%20would%20keep%20the%20two%20files%20colocated.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20home%20%3D%20dirs%3A%3Ahome_dir%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20.context%28%22Failed%20to%20resolve%20home%20directory%3A%20cannot%20determine%20tui.toml%20path.%22%29%3F%3B%0A%20%20%20%20%20%20%20%20let%20primary%20%3D%20home.join%28%22.codewhale%22%29.join%28%22tui.toml%22%29%3B%0A%20%20%20%20%20%20%20%20if%20primary.exists%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20Ok%28primary%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20let%20legacy_home%20%3D%20home.join%28%22.deepseek%22%29.join%28%22tui.toml%22%29%3B%0A%20%20%20%20%20%20%20%20if%20legacy_home.exists%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20Ok%28legacy_home%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20Ok%28primary%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fsettings.rs%3A138-139%0AThe%20doc%20comment%20on%20%60TuiPrefs%3A%3Asave%60%20still%20advertises%20%60~%2F.deepseek%2Ftui.toml%60%20as%20the%20write%20destination.%20After%20this%20PR%2C%20%60Settings%3A%3Asave%60%20targets%20%60~%2F.codewhale%2F%60%20for%20new%20installs%2C%20so%20this%20comment%20is%20misleading%20about%20where%20%60tui.toml%60%20will%20eventually%20land%20once%20the%20%60TuiPrefs%60%20wiring%20%28%23657%29%20is%20complete.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Save%20TUI%20preferences%20to%20%60~%2F.codewhale%2Ftui.toml%60%20%28or%20the%20legacy%0A%20%20%20%20%2F%2F%2F%20%60~%2F.deepseek%2Ftui.toml%60%20when%20that%20file%20already%20exists%29%2C%20creating%20the%0A%20%20%20%20%2F%2F%2F%20target%20directory%20if%20needed.%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2516&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fsettings.rs%3A112-118%0A%60TuiPrefs%3A%3Apath%28%29%60%20falls%20back%20to%20%60~%2F.deepseek%2Ftui.toml%60%20for%20new%20installs%20while%20%60Settings%3A%3Apath%28%29%60%20now%20targets%20%60~%2F.codewhale%2Fsettings.toml%60.%20When%20%23657%20wires%20up%20%60TuiPrefs%3A%3Asave%28%29%60%2C%20fresh%20installs%20will%20silently%20split%20their%20config%20home%3A%20%60settings.toml%60%20lands%20in%20%60~%2F.codewhale%2F%60%20and%20%60tui.toml%60%20lands%20in%20%60~%2F.deepseek%2F%60.%20Applying%20the%20same%20primary-first%20fallback%20logic%20that%20this%20PR%20introduces%20for%20%60Settings%60%20would%20keep%20the%20two%20files%20colocated.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20home%20%3D%20dirs%3A%3Ahome_dir%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20.context%28%22Failed%20to%20resolve%20home%20directory%3A%20cannot%20determine%20tui.toml%20path.%22%29%3F%3B%0A%20%20%20%20%20%20%20%20let%20primary%20%3D%20home.join%28%22.codewhale%22%29.join%28%22tui.toml%22%29%3B%0A%20%20%20%20%20%20%20%20if%20primary.exists%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20Ok%28primary%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20let%20legacy_home%20%3D%20home.join%28%22.deepseek%22%29.join%28%22tui.toml%22%29%3B%0A%20%20%20%20%20%20%20%20if%20legacy_home.exists%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20Ok%28legacy_home%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20Ok%28primary%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fsettings.rs%3A138-139%0AThe%20doc%20comment%20on%20%60TuiPrefs%3A%3Asave%60%20still%20advertises%20%60~%2F.deepseek%2Ftui.toml%60%20as%20the%20write%20destination.%20After%20this%20PR%2C%20%60Settings%3A%3Asave%60%20targets%20%60~%2F.codewhale%2F%60%20for%20new%20installs%2C%20so%20this%20comment%20is%20misleading%20about%20where%20%60tui.toml%60%20will%20eventually%20land%20once%20the%20%60TuiPrefs%60%20wiring%20%28%23657%29%20is%20complete.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Save%20TUI%20preferences%20to%20%60~%2F.codewhale%2Ftui.toml%60%20%28or%20the%20legacy%0A%20%20%20%20%2F%2F%2F%20%60~%2F.deepseek%2Ftui.toml%60%20when%20that%20file%20already%20exists%29%2C%20creating%20the%0A%20%20%20%20%2F%2F%2F%20target%20directory%20if%20needed.%0A%60%60%60%0A%0A&pr=2516&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix(tui): isolate settings path fallback..."](https://github.com/hmbown/codewhale/commit/5f4ea0f47f5c2b5313472e9a364178c7b20e2bdf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34936632)</sub>

<!-- /greptile_comment -->