### PR TITLE
fix(tui): use effective model window in context inspector

### DIFF
--- a/crates/tui/src/tui/context_inspector.rs
+++ b/crates/tui/src/tui/context_inspector.rs
@@ -133,7 +133,8 @@ pub fn build_context_inspector_text(app: &App) -> String {
 }
 
 fn context_usage(app: &App) -> (usize, u32, f64) {
-    let max = context_window_for_model(&app.model).unwrap_or(LEGACY_DEEPSEEK_CONTEXT_WINDOW_TOKENS);
+    let max = context_window_for_model(app.effective_model_for_budget())
+        .unwrap_or(LEGACY_DEEPSEEK_CONTEXT_WINDOW_TOKENS);
     let estimated =
         estimate_input_tokens_conservative(&app.api_messages, app.system_prompt.as_ref());
     let total_chars = estimate_message_chars(&app.api_messages);
@@ -493,6 +494,18 @@ mod tests {
 
         let text = build_context_inspector_text(&app);
         assert!(text.contains("Context: critical"), "{text}");
+    }
+
+    #[test]
+    fn inspector_uses_effective_auto_model_context_window() {
+        let mut app = test_app();
+        app.model = "auto".to_string();
+        app.auto_model = true;
+        app.last_effective_model = Some("deepseek-v4-pro".to_string());
+
+        let text = build_context_inspector_text(&app);
+        assert!(text.contains("Model: auto"), "{text}");
+        assert!(text.contains("/1000000 tokens"), "{text}");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`/context` estimates its max context window from the literal UI model string. In auto mode that string is `auto`, so the inspector falls back to the legacy DeepSeek 128k window even after routing has resolved the turn to a concrete V4 model.

## Change

Use the app effective model for the context-window lookup while keeping the displayed model label unchanged.

Refs #2487. This only addresses the `/context` window display slice from the stalled-turn investigation; it does not claim to fix stalled turn dispatch/liveness.

## Verification

- `cargo test -p codewhale-tui inspector_uses_effective_auto_model_context_window --all-features --locked -- --nocapture`
- `cargo test -p codewhale-tui context_inspector --all-features --locked -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo check -p codewhale-tui --all-features --locked`
- `cargo clippy -p codewhale-tui --all-features --locked -- -D warnings`
- `git diff --check origin/main..HEAD`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the `/context` inspector displaying an incorrect (128K) context window when the app is in `auto` model mode, by switching the window-size lookup from `app.model` (the literal `"auto"` string) to `app.effective_model_for_budget()` (which resolves to the last concrete model the router used). The display label is unchanged.

- The one-line change in `context_usage` is correct: `effective_model_for_budget()` already handles the `None`/`"auto"` fallback case by returning `DEFAULT_TEXT_MODEL` (`deepseek-v4-pro`).
- A new focused test verifies both the label invariant (`Model: auto`) and the resolved window size (`/1000000 tokens`) after a concrete V4 routing.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change is minimal and well-tested, and the only note is a pre-existing inconsistency in sibling commands that was intentionally left out of scope.

The one-line fix correctly delegates to `effective_model_for_budget()`, the new test covers both the display-label invariant and the resolved window size, and the fallback path (`DEFAULT_TEXT_MODEL` → `deepseek-v4-pro`) is coherent. The only observation is that `commands/status.rs` and `sidebar.rs` carry the same old pattern, meaning those surfaces will still display 128K for auto mode — but the PR explicitly scopes itself to the `/context` inspector.

`commands/status.rs` and `sidebar.rs` have the same `&app.model` pattern and would benefit from a follow-up pass.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/context_inspector.rs | Core fix: `context_usage` now calls `effective_model_for_budget()` instead of reading `app.model` directly, correctly resolving auto-mode to the last dispatched concrete model. New test covers the happy path. Two sibling usages of `&app.model` in `commands/status.rs` and `sidebar.rs` remain unfixed (pre-existing, out of scope per PR description). |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant TUI as TUI /context
    participant Inspector as context_inspector
    participant App
    participant Models as models::context_window_for_model

    User->>TUI: types /context
    TUI->>Inspector: "build_context_inspector_text(&app)"
    Inspector->>App: app.model (display label only)
    Note over Inspector,App: "auto" string used for display
    Inspector->>App: app.effective_model_for_budget()
    App-->>Inspector: "deepseek-v4-pro" (resolved from last_effective_model)
    Inspector->>Models: context_window_for_model("deepseek-v4-pro")
    Models-->>Inspector: Some(1_000_000)
    Inspector-->>TUI: "Model: auto ... ~X/1000000 tokens"
    TUI-->>User: shows correct 1M window
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tui): use effective model window in ..."](https://github.com/hmbown/codewhale/commit/b3471c500871538e0c42c6c7465f86f90a531338) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34943675)</sub>

<!-- /greptile_comment -->