### PR TITLE
fix(sandbox): allow tty device in seatbelt profile

### DIFF
--- a/crates/tui/src/sandbox/seatbelt.rs
+++ b/crates/tui/src/sandbox/seatbelt.rs
@@ -69,6 +69,7 @@ const SEATBELT_BASE_POLICY: &str = r#"
 ; Terminal support (essential for shell commands)
 (allow pseudo-tty)
 (allow file-read* file-write* file-ioctl (literal "/dev/ptmx"))
+(allow file-read* file-write* file-ioctl (literal "/dev/tty"))
 (allow file-read* file-write* file-ioctl (regex #"^/dev/ttys[0-9]+$"))
 
 ; macOS-specific device access
@@ -649,6 +650,19 @@ mod tests {
                 None => std::env::remove_var("NPM_CONFIG_CACHE"),
             }
         }
+    }
+
+    #[test]
+    fn test_generate_policy_allows_dev_tty() {
+        let policy = SandboxPolicy::default();
+        let cwd = Path::new("/tmp/test");
+        let policy_text = generate_policy(&policy, cwd);
+
+        assert!(
+            policy_text
+                .contains(r#"(allow file-read* file-write* file-ioctl (literal "/dev/tty"))"#),
+            "TTY-mode shells need /dev/tty access for sshpass/sudo prompts"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Refs #2372

Problem:
- macOS seatbelt currently allows PTY allocation and `/dev/ptmx`/`/dev/ttysN`, but not `/dev/tty`.
- Tools such as ssh/sshpass/sudo can open `/dev/tty` directly when running inside a TTY-backed shell task.

Change:
- Allow read/write/ioctl access to `/dev/tty` in the base seatbelt profile.
- Add a focused policy test so this path stays covered.

Verification:
- `rustfmt crates/tui/src/sandbox/seatbelt.rs --edition 2024 --check`
- `cargo test -p codewhale-tui --all-features --locked seatbelt::tests`
- `git diff --check`

Note:
- This intentionally stays scoped to the macOS seatbelt path and does not claim to close the broader controlling-terminal issue.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds `/dev/tty` (the controlling terminal device) to the macOS seatbelt sandbox base policy so tools like `ssh`, `sshpass`, and `sudo` can open it for password/passphrase prompts when running inside a TTY-backed shell task.

- One line added to `SEATBELT_BASE_POLICY` granting `file-read*`, `file-write*`, and `file-ioctl` on the literal path `/dev/tty`, consistent with the already-allowed `/dev/ptmx` and `/dev/ttys[0-9]+` entries.
- A focused unit test verifies the generated policy string contains the new rule.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a single-line policy addition with a matching test, and does not alter any logic paths.

The diff is two additions: one SBPL rule and one assertion-only test. The new /dev/tty rule is the natural complement to the already-present /dev/ptmx and /dev/ttys[0-9]+ allowances, so no policy surface is opened unexpectedly. The test is a straightforward string-contains check on the generated policy, which is sufficient given that the policy is a static constant — any future edit that removes the line will immediately break the test.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/sandbox/seatbelt.rs | Adds /dev/tty to the base seatbelt policy (line 72) and a corresponding string-based test (lines 655-666); the change is minimal, correctly scoped, and consistent with adjacent PTY permissions. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[sandbox-exec invoked] --> B[SEATBELT_BASE_POLICY applied]
    B --> C{Device opened?}
    C -->|/dev/ptmx| D[Allowed: PTY master]
    C -->|/dev/ttysN| E[Allowed: PTY slave via regex]
    C -->|/dev/tty NEW| F[Allowed: controlling terminal]
    C -->|other /dev/*| G[Denied by default]
    F --> H[ssh / sshpass / sudo password prompt works]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(sandbox): allow tty device in seatbe..."](https://github.com/hmbown/codewhale/commit/8a4bd699531ea6cb6f386343e74ec24a7a61129a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34947551)</sub>

<!-- /greptile_comment -->