### PR TITLE
feat(agent): classify model families

### DIFF
--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -3,6 +3,22 @@ use std::collections::HashMap;
 use codewhale_config::ProviderKind;
 use serde::{Deserialize, Serialize};
 
+/// High-level model family used for shared identity affordances across clients.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ModelFamily {
+    DeepSeek,
+    Anthropic,
+    OpenAI,
+    Google,
+    Meta,
+    Mistral,
+    Qwen,
+    Grok,
+    Cohere,
+    GptOss,
+    Inferencer,
+}
+
 /// Metadata for a single model entry in the registry.
 ///
 /// Each model has a canonical `id` used by the provider, a list of `aliases`
@@ -545,6 +561,58 @@ fn normalize(value: &str) -> String {
     value.trim().to_ascii_lowercase()
 }
 
+#[must_use]
+/// Classify a model identifier by its underlying model family.
+pub fn model_family(model_id: &str) -> ModelFamily {
+    let normalized = normalize(model_id);
+    if normalized.is_empty() {
+        return ModelFamily::Inferencer;
+    }
+
+    if normalized.contains("deepseek") {
+        return ModelFamily::DeepSeek;
+    }
+    if normalized.contains("claude") || normalized.contains("anthropic") {
+        return ModelFamily::Anthropic;
+    }
+    if normalized.contains("gpt-oss") || normalized.contains("gpt_oss") {
+        return ModelFamily::GptOss;
+    }
+    if normalized.starts_with("gpt-")
+        || normalized.contains("/gpt-")
+        || normalized.contains("openai/")
+    {
+        return ModelFamily::OpenAI;
+    }
+    if normalized.contains("gemini")
+        || normalized.contains("gemma")
+        || normalized.contains("google/")
+    {
+        return ModelFamily::Google;
+    }
+    if normalized.contains("llama") || normalized.contains("meta-") || normalized.contains("meta/")
+    {
+        return ModelFamily::Meta;
+    }
+    if normalized.contains("mistral")
+        || normalized.contains("mixtral")
+        || normalized.contains("codestral")
+    {
+        return ModelFamily::Mistral;
+    }
+    if normalized.contains("qwen") {
+        return ModelFamily::Qwen;
+    }
+    if normalized.contains("grok") {
+        return ModelFamily::Grok;
+    }
+    if normalized.contains("cohere") || normalized.contains("command-r") {
+        return ModelFamily::Cohere;
+    }
+
+    ModelFamily::Inferencer
+}
+
 fn model_matches(model: &ModelInfo, requested: &str) -> bool {
     let requested = normalize(requested);
     normalize(&model.id) == requested
@@ -839,5 +907,55 @@ mod tests {
 
         assert_eq!(resolved.resolved.provider, ProviderKind::Deepseek);
         assert_eq!(resolved.resolved.id, "deepseek-v4-flash");
+    }
+
+    #[test]
+    fn model_family_classifies_known_model_ids() {
+        assert_eq!(model_family("deepseek-v4-pro"), ModelFamily::DeepSeek);
+        assert_eq!(model_family("openai/gpt-5.4"), ModelFamily::OpenAI);
+        assert_eq!(
+            model_family("anthropic/claude-opus-4-7"),
+            ModelFamily::Anthropic
+        );
+        assert_eq!(
+            model_family("meta-llama/llama-3.3-70b-instruct"),
+            ModelFamily::Meta
+        );
+        assert_eq!(model_family("Qwen/Qwen3-Coder"), ModelFamily::Qwen);
+    }
+
+    #[test]
+    fn model_family_uses_underlying_model_for_router_ids() {
+        assert_eq!(
+            model_family("groq/llama-3.3-70b-versatile"),
+            ModelFamily::Meta
+        );
+        assert_eq!(
+            model_family("openrouter/openai/gpt-5.4"),
+            ModelFamily::OpenAI
+        );
+        assert_eq!(
+            model_family("fireworks/accounts/fireworks/models/deepseek-v4-pro"),
+            ModelFamily::DeepSeek
+        );
+    }
+
+    #[test]
+    fn model_family_covers_prominent_google_and_mistral_model_names() {
+        assert_eq!(model_family("google/gemma-3-27b-it"), ModelFamily::Google);
+        assert_eq!(
+            model_family("mistralai/mixtral-8x22b"),
+            ModelFamily::Mistral
+        );
+        assert_eq!(model_family("codestral-latest"), ModelFamily::Mistral);
+    }
+
+    #[test]
+    fn model_family_falls_back_to_inferencer_for_unknown_models() {
+        assert_eq!(
+            model_family("custom-gateway/my-private-model"),
+            ModelFamily::Inferencer
+        );
+        assert_eq!(model_family(""), ModelFamily::Inferencer);
     }
 }


### PR DESCRIPTION
Problem
Model-family identity needs a shared agent-crate primitive before TUI, desktop, and runtime API surfaces can render consistent model affordances.

Change
- Add `ModelFamily` to `codewhale-agent`.
- Add `model_family(model_id)` classification for common first-party, routed, and self-hosted model ids.
- Keep unknown/custom gateway ids in the inferencer bucket.

Verification
- `cargo test -p codewhale-agent model_family --locked`
- `rustfmt crates/agent/src/lib.rs --edition 2024 --check`
- `cargo test -p codewhale-agent --locked`
- `git diff --check`

Partially addresses #2081.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a `ModelFamily` enum and a `model_family()` classification function to `codewhale-agent`, providing a shared primitive for identifying model families across TUI, desktop, and runtime API surfaces. Classification is done via substring/prefix matching on a normalized (trimmed, lowercased) model ID string.

- Adds 11 `ModelFamily` variants covering major first-party and self-hosted model providers, with an `Inferencer` fallback for unknown or custom gateway IDs.
- `model_family()` applies ordered substring checks, correctly prioritising `GptOss` before the broader `gpt-`/`openai/` OpenAI check.
- Tests cover known model IDs, routed gateway forms, and the `Inferencer` fallback, but bare OpenAI o-series IDs (`o1-mini`, `o3`, `o4-mini`) are not handled and silently land in `Inferencer`.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Mostly safe to merge, but bare OpenAI o-series model IDs are silently misclassified as Inferencer rather than OpenAI, which will produce wrong affordances in any client that consumes this function.

The o1/o3/o4 classification gap is a real behavioral defect: any caller passing a bare `o1-mini`, `o3`, or `o4-mini` ID will receive `Inferencer` instead of `OpenAI`. Since this function is being introduced precisely to drive UI affordances across multiple surfaces, misclassifying a prominent and widely-used model family will have visible downstream impact the moment a client consumes it.

crates/agent/src/lib.rs — specifically the OpenAI matching block in `model_family()` and the missing o-series test coverage.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/agent/src/lib.rs | Adds `ModelFamily` enum and `model_family()` classifier with substring/prefix matching; OpenAI o-series bare IDs (o1, o3, o4) fall through to `Inferencer`, and `#[must_use]` is placed before the doc comment rather than after it. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([model_id: &str]) --> B[normalize: trim + lowercase]
    B --> C{is_empty?}
    C -- yes --> Z([Inferencer])
    C -- no --> D{contains 'deepseek'?}
    D -- yes --> E([DeepSeek])
    D -- no --> F{contains 'claude' or 'anthropic'?}
    F -- yes --> G([Anthropic])
    F -- no --> H{contains 'gpt-oss' or 'gpt_oss'?}
    H -- yes --> I([GptOss])
    H -- no --> J{starts_with 'gpt-' OR contains '/gpt-' OR 'openai/'?}
    J -- yes --> K([OpenAI])
    J -- no --> L{contains 'gemini', 'gemma', or 'google/'?}
    L -- yes --> M([Google])
    L -- no --> N{contains 'llama', 'meta-', or 'meta/'?}
    N -- yes --> O([Meta])
    N -- no --> P{contains 'mistral', 'mixtral', or 'codestral'?}
    P -- yes --> Q([Mistral])
    P -- no --> R{contains 'qwen'?}
    R -- yes --> S([Qwen])
    R -- no --> T{contains 'grok'?}
    T -- yes --> U([Grok])
    T -- no --> V{contains 'cohere' or 'command-r'?}
    V -- yes --> W([Cohere])
    V -- no --> Z
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22codex%2F2081-model-family%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2F2081-model-family%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Fagent%2Fsrc%2Flib.rs%3A564-566%0A**%60%23%5Bmust_use%5D%60%20placed%20before%20the%20doc%20comment**%0A%0AIn%20Rust%2C%20the%20conventional%20%28and%20%60rustfmt%60-enforced%29%20order%20is%20doc%20comment%20first%2C%20then%20outer%20attributes.%20Placing%20%60%23%5Bmust_use%5D%60%20before%20%60%2F%2F%2F%60%20can%20cause%20%60rustfmt%20--edition%202024%20--check%60%20to%20report%20a%20diff%20on%20some%20toolchain%20versions%20and%20diverges%20from%20the%20pattern%20used%20by%20every%20other%20documented%20item%20in%20this%20file.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Fagent%2Fsrc%2Flib.rs%3A581-586%0A**OpenAI%20o-series%20models%20not%20matched%20with%20bare%20IDs**%0A%0A%60o1-mini%60%2C%20%60o1-preview%60%2C%20%60o3%60%2C%20%60o3-mini%60%2C%20%60o4-mini%60%20and%20related%20IDs%20don't%20start%20with%20%60gpt-%60%2C%20don't%20contain%20%60%2Fgpt-%60%2C%20and%20don't%20contain%20%60openai%2F%60%2C%20so%20%60model_family%28%22o1-mini%22%29%60%20currently%20returns%20%60Inferencer%60.%20They're%20reachable%20via%20the%20%60openai%2Fo1-mini%60%20routed%20form%2C%20but%20direct%2Fbare%20invocations%20silently%20fall%20through.%20Adding%20%60normalized.starts_with%28%22o1%22%29%20%7C%7C%20normalized.starts_with%28%22o3%22%29%20%7C%7C%20normalized.starts_with%28%22o4%22%29%60%20%28or%20similar%29%20alongside%20the%20existing%20%60gpt-%60%20prefix%20check%20would%20close%20this%20gap.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Fagent%2Fsrc%2Flib.rs%3A564-566%0A**%60%23%5Bmust_use%5D%60%20placed%20before%20the%20doc%20comment**%0A%0AIn%20Rust%2C%20the%20conventional%20%28and%20%60rustfmt%60-enforced%29%20order%20is%20doc%20comment%20first%2C%20then%20outer%20attributes.%20Placing%20%60%23%5Bmust_use%5D%60%20before%20%60%2F%2F%2F%60%20can%20cause%20%60rustfmt%20--edition%202024%20--check%60%20to%20report%20a%20diff%20on%20some%20toolchain%20versions%20and%20diverges%20from%20the%20pattern%20used%20by%20every%20other%20documented%20item%20in%20this%20file.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Fagent%2Fsrc%2Flib.rs%3A581-586%0A**OpenAI%20o-series%20models%20not%20matched%20with%20bare%20IDs**%0A%0A%60o1-mini%60%2C%20%60o1-preview%60%2C%20%60o3%60%2C%20%60o3-mini%60%2C%20%60o4-mini%60%20and%20related%20IDs%20don't%20start%20with%20%60gpt-%60%2C%20don't%20contain%20%60%2Fgpt-%60%2C%20and%20don't%20contain%20%60openai%2F%60%2C%20so%20%60model_family%28%22o1-mini%22%29%60%20currently%20returns%20%60Inferencer%60.%20They're%20reachable%20via%20the%20%60openai%2Fo1-mini%60%20routed%20form%2C%20but%20direct%2Fbare%20invocations%20silently%20fall%20through.%20Adding%20%60normalized.starts_with%28%22o1%22%29%20%7C%7C%20normalized.starts_with%28%22o3%22%29%20%7C%7C%20normalized.starts_with%28%22o4%22%29%60%20%28or%20similar%29%20alongside%20the%20existing%20%60gpt-%60%20prefix%20check%20would%20close%20this%20gap.%0A%0A&repo=hmbown%2Fcodewhale&pr=2525&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Fagent%2Fsrc%2Flib.rs%3A564-566%0A**%60%23%5Bmust_use%5D%60%20placed%20before%20the%20doc%20comment**%0A%0AIn%20Rust%2C%20the%20conventional%20%28and%20%60rustfmt%60-enforced%29%20order%20is%20doc%20comment%20first%2C%20then%20outer%20attributes.%20Placing%20%60%23%5Bmust_use%5D%60%20before%20%60%2F%2F%2F%60%20can%20cause%20%60rustfmt%20--edition%202024%20--check%60%20to%20report%20a%20diff%20on%20some%20toolchain%20versions%20and%20diverges%20from%20the%20pattern%20used%20by%20every%20other%20documented%20item%20in%20this%20file.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Fagent%2Fsrc%2Flib.rs%3A581-586%0A**OpenAI%20o-series%20models%20not%20matched%20with%20bare%20IDs**%0A%0A%60o1-mini%60%2C%20%60o1-preview%60%2C%20%60o3%60%2C%20%60o3-mini%60%2C%20%60o4-mini%60%20and%20related%20IDs%20don't%20start%20with%20%60gpt-%60%2C%20don't%20contain%20%60%2Fgpt-%60%2C%20and%20don't%20contain%20%60openai%2F%60%2C%20so%20%60model_family%28%22o1-mini%22%29%60%20currently%20returns%20%60Inferencer%60.%20They're%20reachable%20via%20the%20%60openai%2Fo1-mini%60%20routed%20form%2C%20but%20direct%2Fbare%20invocations%20silently%20fall%20through.%20Adding%20%60normalized.starts_with%28%22o1%22%29%20%7C%7C%20normalized.starts_with%28%22o3%22%29%20%7C%7C%20normalized.starts_with%28%22o4%22%29%60%20%28or%20similar%29%20alongside%20the%20existing%20%60gpt-%60%20prefix%20check%20would%20close%20this%20gap.%0A%0A&pr=2525&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(agent): classify model families"](https://github.com/hmbown/codewhale/commit/bfcbe9db06992cabaf778e5fe9b6b852feecc486) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34950464)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->