### PR TITLE
docs: clarify shell tool mode availability

### DIFF
--- a/docs/MODES.md
+++ b/docs/MODES.md
@@ -25,7 +25,7 @@ Run `/mode` to open the mode picker, or switch directly with `/mode agent`,
 ### Tool availability by mode
 
 | Tool family | Plan | Agent | YOLO |
-|---|---:|---:|---:|
+|:---|:---:|:---:|:---:|
 | Read-only file, search, and diagnostic tools | yes | yes | yes |
 | File write and patch tools | no | yes | yes |
 | Shell tools (`exec_shell`, `task_shell_start`, waits, interact, cancel) | no | yes, when `allow_shell = true` | yes |
@@ -34,7 +34,7 @@ Run `/mode` to open the mode picker, or switch directly with `/mode agent`,
 
 If a shell tool is missing from the model-visible catalog in Agent mode, check
 `allow_shell` first. The setting can come from the active config/profile or from
-the runtime session. YOLO mode turns shell access on together with trust mode and
+the runtime session. YOLO turns shell access on together with trust mode and
 auto-approval, which is why shell commands may work there even when the Agent
 mode catalog does not list them.
 

--- a/docs/MODES.md
+++ b/docs/MODES.md
@@ -22,6 +22,22 @@ Run `/mode` to open the mode picker, or switch directly with `/mode agent`,
 - **Agent**: multi-step tool use. Shell execution (`exec_shell`, `task_shell_start`, `task_shell_wait`) requires `allow_shell = true` in config; approval prompts gate each call. File writes are allowed without a prompt.
 - **YOLO**: enables shell + trust mode and auto-approves all tools. Use only in trusted repos.
 
+### Tool availability by mode
+
+| Tool family | Plan | Agent | YOLO |
+|---|---:|---:|---:|
+| Read-only file, search, and diagnostic tools | yes | yes | yes |
+| File write and patch tools | no | yes | yes |
+| Shell tools (`exec_shell`, `task_shell_start`, waits, interact, cancel) | no | yes, when `allow_shell = true` | yes |
+| Paid or external-service tools | approval-gated | approval-gated | auto-approved |
+| Access outside the workspace root | no | only with trust mode | yes |
+
+If a shell tool is missing from the model-visible catalog in Agent mode, check
+`allow_shell` first. The setting can come from the active config/profile or from
+the runtime session. YOLO mode turns shell access on together with trust mode and
+auto-approval, which is why shell commands may work there even when the Agent
+mode catalog does not list them.
+
 All action-capable modes have access to persistent RLM sessions through `rlm_open`, `rlm_eval`, `rlm_configure`, and `rlm_close`. Inside an RLM Python REPL, `sub_query_batch` fans out 1-16 cheap parallel child calls pinned to `deepseek-v4-flash`. The model reaches for it when work is too large or repetitive for the parent transcript.
 
 The fast `deepseek-v4-flash` / thinking-off path is called Fin in the product

--- a/docs/TOOL_SURFACE.md
+++ b/docs/TOOL_SURFACE.md
@@ -40,6 +40,11 @@ chosen over the available shell equivalent. Companion to `crates/tui/src/prompts
 
 ### Shell
 
+Shell tools are part of the model-visible tool catalog only when shell access is
+enabled for the active session or profile. In Agent mode that usually means
+`allow_shell = true`; YOLO enables shell access automatically. Plan mode keeps
+shell execution off.
+
 | Tool | Niche |
 |---|---|
 | `exec_shell` | Run a shell command. Foreground runs are cancellable, but use them only for bounded commands; timeout kills the process and returns a background-rerun hint. |

--- a/docs/TOOL_SURFACE.md
+++ b/docs/TOOL_SURFACE.md
@@ -40,7 +40,7 @@ chosen over the available shell equivalent. Companion to `crates/tui/src/prompts
 
 ### Shell
 
-Shell tools are part of the model-visible tool catalog only when shell access is
+Shell tools appear in the model-visible tool catalog only when shell access is
 enabled for the active session or profile. In Agent mode that usually means
 `allow_shell = true`; YOLO enables shell access automatically. Plan mode keeps
 shell execution off.


### PR DESCRIPTION
Problem
- #2328 reports that shell tools appear available in YOLO but not Agent mode, and the docs did not show the mode/config boundary in one place.

Change
- Add a compact mode/tool availability matrix to docs/MODES.md.
- Note in docs/TOOL_SURFACE.md that shell tools are catalog-visible only when shell access is enabled, with YOLO enabling shell automatically.

Verification
- git diff --check

Refs #2328

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This documentation-only PR adds a compact mode/tool-availability matrix to `docs/MODES.md` and a shell-access preamble to `docs/TOOL_SURFACE.md`, directly addressing the confusion reported in #2328 about shell tools being visible in YOLO but not Agent mode.

- **`docs/MODES.md`**: A new "Tool availability by mode" table maps five tool families across Plan / Agent / YOLO, followed by an explanatory paragraph that ties the `allow_shell` config key to catalog visibility and contrasts it with YOLO's automatic enablement.
- **`docs/TOOL_SURFACE.md`**: A four-line note is inserted above the Shell section explaining when shell tools appear in the model-visible catalog, referencing `allow_shell = true`, YOLO's automatic activation, and Plan mode's exclusion.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change with no runtime code modified; safe to merge.

Both changed files are pure documentation. The matrix and prose accurately reflect the existing runtime behaviour described in the surrounding text. One minor omission (missing approval-gate label in the Shell/Agent cell) is called out but does not introduce incorrect information — the correct description remains visible immediately above the table.

No files require special attention; both changes are documentation additions.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/MODES.md | Added a "Tool availability by mode" matrix table and explanatory paragraph; the Shell tools row omits the per-call approval gate that the surrounding prose still describes for Agent mode. |
| docs/TOOL_SURFACE.md | Added a shell-availability preamble before the Shell tool table; accurately describes the allow_shell / YOLO / Plan mode conditions with no factual issues. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User requests shell tool] --> B{Active TUI mode?}
    B -->|Plan| C[Shell access OFF\nTool not in catalog]
    B -->|Agent| D{allow_shell = true?}
    B -->|YOLO| G[Shell access ON\nTrust mode ON\nAuto-approved]
    D -->|No| E[Shell tools absent\nfrom model catalog]
    D -->|Yes, via config/profile\nor runtime session| F[Shell tools in catalog\nApproval prompt per call]
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22codex%2F2328-tool-availability-docs%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2F2328-tool-availability-docs%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2FMODES.md%3A31%0AThe%20Shell%20tools%20cell%20for%20Agent%20mode%20says%20%60yes%2C%20when%20%5C%60allow_shell%20%3D%20true%5C%60%60%20but%20silently%20drops%20the%20per-call%20approval%20requirement%20that%20the%20prose%20immediately%20above%20states%20explicitly%20%28%22approval%20prompts%20gate%20each%20call%22%29.%20Every%20other%20conditional%20row%20in%20the%20table%20%28e.g.%20%22Paid%20or%20external-service%20tools%22%29%20captures%20the%20approval%20status.%20A%20reader%20who%20skips%20the%20prose%20and%20relies%20on%20the%20matrix%20will%20think%20shell%20tools%20in%20Agent%20mode%20are%20freely%20usable%20once%20the%20flag%20is%20set%2C%20with%20no%20further%20gates.%0A%0A%60%60%60suggestion%0A%7C%20Shell%20tools%20%28%60exec_shell%60%2C%20%60task_shell_start%60%2C%20waits%2C%20interact%2C%20cancel%29%20%7C%20no%20%7C%20approval-gated%2C%20when%20%60allow_shell%20%3D%20true%60%20%7C%20yes%20%7C%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2FMODES.md%3A31%0AThe%20Shell%20tools%20cell%20for%20Agent%20mode%20says%20%60yes%2C%20when%20%5C%60allow_shell%20%3D%20true%5C%60%60%20but%20silently%20drops%20the%20per-call%20approval%20requirement%20that%20the%20prose%20immediately%20above%20states%20explicitly%20%28%22approval%20prompts%20gate%20each%20call%22%29.%20Every%20other%20conditional%20row%20in%20the%20table%20%28e.g.%20%22Paid%20or%20external-service%20tools%22%29%20captures%20the%20approval%20status.%20A%20reader%20who%20skips%20the%20prose%20and%20relies%20on%20the%20matrix%20will%20think%20shell%20tools%20in%20Agent%20mode%20are%20freely%20usable%20once%20the%20flag%20is%20set%2C%20with%20no%20further%20gates.%0A%0A%60%60%60suggestion%0A%7C%20Shell%20tools%20%28%60exec_shell%60%2C%20%60task_shell_start%60%2C%20waits%2C%20interact%2C%20cancel%29%20%7C%20no%20%7C%20approval-gated%2C%20when%20%60allow_shell%20%3D%20true%60%20%7C%20yes%20%7C%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2526&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2FMODES.md%3A31%0AThe%20Shell%20tools%20cell%20for%20Agent%20mode%20says%20%60yes%2C%20when%20%5C%60allow_shell%20%3D%20true%5C%60%60%20but%20silently%20drops%20the%20per-call%20approval%20requirement%20that%20the%20prose%20immediately%20above%20states%20explicitly%20%28%22approval%20prompts%20gate%20each%20call%22%29.%20Every%20other%20conditional%20row%20in%20the%20table%20%28e.g.%20%22Paid%20or%20external-service%20tools%22%29%20captures%20the%20approval%20status.%20A%20reader%20who%20skips%20the%20prose%20and%20relies%20on%20the%20matrix%20will%20think%20shell%20tools%20in%20Agent%20mode%20are%20freely%20usable%20once%20the%20flag%20is%20set%2C%20with%20no%20further%20gates.%0A%0A%60%60%60suggestion%0A%7C%20Shell%20tools%20%28%60exec_shell%60%2C%20%60task_shell_start%60%2C%20waits%2C%20interact%2C%20cancel%29%20%7C%20no%20%7C%20approval-gated%2C%20when%20%60allow_shell%20%3D%20true%60%20%7C%20yes%20%7C%0A%60%60%60%0A%0A&pr=2526&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["docs: polish mode availability table"](https://github.com/hmbown/codewhale/commit/3d07f15b0846a60db85450b51136ec9943f25007) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34953026)</sub>

<!-- /greptile_comment -->