### PR TITLE
test(shell): widen background completion wait

### DIFF
--- a/crates/tui/src/tools/shell/tests.rs
+++ b/crates/tui/src/tools/shell/tests.rs
@@ -16,6 +16,8 @@ fn env_lock() -> &'static Mutex<()> {
     LOCK.get_or_init(|| Mutex::new(()))
 }
 
+const BACKGROUND_COMPLETION_WAIT_MS: u64 = 30_000;
+
 fn echo_command(message: &str) -> String {
     format!("echo {message}")
 }
@@ -175,7 +177,7 @@ fn test_background_execution() {
 
     // Wait for completion
     let final_result = manager
-        .get_output(&task_id, true, 5000)
+        .get_output(&task_id, true, BACKGROUND_COMPLETION_WAIT_MS)
         .expect("get_output");
 
     assert_eq!(final_result.status, ShellStatus::Completed);
@@ -758,7 +760,7 @@ async fn test_completed_background_shell_releases_process_handles() {
             json!({
                 "task_id": task_id.clone(),
                 "wait": true,
-                "timeout_ms": 5_000
+                "timeout_ms": BACKGROUND_COMPLETION_WAIT_MS
             }),
             &ctx,
         )


### PR DESCRIPTION
Problem
- Windows CI failed on #2525 and #2526 in the same two background shell tests.
- Both failures reached the 5s wait path with the shell still reported as Running, while the PR diffs were unrelated to shell behavior.

Change
- Use one named 30s wait window for tests that assert a background shell eventually completes.
- Leave shell manager/runtime behavior unchanged.

Verification
- cargo test -p codewhale-tui test_background_execution --all-features --locked -- --nocapture
- cargo test -p codewhale-tui test_completed_background_shell_releases_process_handles --all-features --locked -- --nocapture
- cargo test -p codewhale-tui tools::shell::tests --all-features --locked -- --nocapture
- cargo fmt --all -- --check
- git diff --check

Refs #2525
Refs #2526

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR widens the completion-wait timeout used in two background shell tests from 5 s to a named constant `BACKGROUND_COMPLETION_WAIT_MS` (30 s) to fix recurring Windows CI flakiness where the shell was still reported as `Running` when the 5 s window expired.

- Introduces `const BACKGROUND_COMPLETION_WAIT_MS: u64 = 30_000` and applies it to `test_background_execution` and `test_completed_background_shell_releases_process_handles`, replacing magic literals with a self-documenting name.
- No shell manager or runtime code is changed; the fix is test-infrastructure only.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are confined to test infrastructure with no production code touched.

The change replaces two hardcoded 5 s magic-number timeouts with a single named 30 s constant in test code only. Both affected tests exercise lightweight commands (echo and sleep 1 && echo) whose actual runtime is well under 30 s even on slow Windows runners, so the wider window eliminates the flakiness without making the tests meaninglessly long. No shell manager or runtime logic is modified.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tools/shell/tests.rs | Adds a named 30 s timeout constant and applies it to two background-completion waits that were failing on Windows CI with the previous 5 s limit. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Start background shell command] --> B[execute returns ShellStatus::Running]
    B --> C{Wait for completion\nup to BACKGROUND_COMPLETION_WAIT_MS\n30 000 ms}
    C -- completed in time --> D[Assert ShellStatus::Completed]
    C -- timed out --> E[Test fails: still Running]
    D --> F[Assert expected output / handle cleanup]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["test(shell): widen background completion..."](https://github.com/hmbown/codewhale/commit/dc2ba3829922d790acb5d39aad11159d3bea8c0b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34955068)</sub>

<!-- /greptile_comment -->