### PR TITLE
fix(config): honor workspace shell opt-in

### DIFF
--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -2704,7 +2704,7 @@ fn expand_pathbuf(path: PathBuf) -> PathBuf {
     path
 }
 
-fn resolve_load_config_path(path: Option<PathBuf>) -> Option<PathBuf> {
+pub(crate) fn resolve_load_config_path(path: Option<PathBuf>) -> Option<PathBuf> {
     if let Some(path) = path {
         return Some(expand_pathbuf(path));
     }

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -5006,13 +5006,32 @@ fn workspace_config_path_matches(raw_path: &str, workspace: &Path) -> bool {
 
 #[cfg(windows)]
 fn paths_equal_for_config(left: &Path, right: &Path) -> bool {
-    left.to_string_lossy()
-        .eq_ignore_ascii_case(&right.to_string_lossy())
+    normalize_windows_config_path_for_compare(left)
+        == normalize_windows_config_path_for_compare(right)
 }
 
 #[cfg(not(windows))]
 fn paths_equal_for_config(left: &Path, right: &Path) -> bool {
     left == right
+}
+
+#[cfg(windows)]
+fn normalize_windows_config_path_for_compare(path: &Path) -> String {
+    normalize_windows_config_path_str(&path.to_string_lossy())
+}
+
+#[cfg(any(windows, test))]
+fn normalize_windows_config_path_str(path: &str) -> String {
+    let mut normalized = path.replace('/', "\\");
+    if let Some(rest) = normalized.strip_prefix(r"\\?\UNC\") {
+        normalized = format!("\\\\{rest}");
+    } else if let Some(rest) = normalized.strip_prefix(r"\\?\") {
+        normalized = rest.to_string();
+    }
+    while normalized.len() > 3 && normalized.ends_with('\\') {
+        normalized.pop();
+    }
+    normalized.to_ascii_lowercase()
 }
 
 async fn run_interactive(
@@ -6957,6 +6976,26 @@ allow_shell = false
         merge_user_workspace_config(&mut config, Some(config_path), &workspace);
 
         assert_eq!(config.allow_shell, Some(false));
+    }
+
+    #[test]
+    fn windows_config_path_compare_normalizes_mixed_separators() {
+        assert_eq!(
+            normalize_windows_config_path_str(r"C:\Users\me\repo"),
+            normalize_windows_config_path_str(r"C:/Users/me/repo/")
+        );
+    }
+
+    #[test]
+    fn windows_config_path_compare_normalizes_verbatim_and_unc_prefixes() {
+        assert_eq!(
+            normalize_windows_config_path_str(r"\\?\C:\Users\me\repo"),
+            normalize_windows_config_path_str(r"C:/Users/me/repo")
+        );
+        assert_eq!(
+            normalize_windows_config_path_str(r"\\?\UNC\server\share\repo"),
+            normalize_windows_config_path_str(r"\\server/share/repo/")
+        );
     }
 
     #[test]

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -898,11 +898,13 @@ async fn main() -> Result<()> {
             }
             Commands::Exec(args) => {
                 let config = load_config_from_cli(&cli)?;
-                let model = resolve_exec_model(&config, args.model.as_deref());
-                let prompt = join_prompt_parts(&args.prompt);
                 let workspace = cli.workspace.clone().unwrap_or_else(|| {
                     std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
                 });
+                let mut config = config.clone();
+                merge_user_workspace_config(&mut config, cli.config.clone(), &workspace);
+                let model = resolve_exec_model(&config, args.model.as_deref());
+                let prompt = join_prompt_parts(&args.prompt);
                 let resume_session_id = resolve_exec_resume_session_id(&args, &workspace)?;
                 // The `deepseek` launcher forwards `--yolo` to this binary via
                 // the DEEPSEEK_YOLO env var (which the config loader folds into
@@ -4952,6 +4954,67 @@ fn merge_project_config(config: &mut Config, workspace: &Path) {
     }
 }
 
+fn merge_user_workspace_config(
+    config: &mut Config,
+    config_path: Option<PathBuf>,
+    workspace: &Path,
+) {
+    if config.managed_config_path.is_some() || config.requirements_path.is_some() {
+        return;
+    }
+    let allow_shell_before = config.allow_shell;
+    let allow_shell_from_env = std::env::var_os("DEEPSEEK_ALLOW_SHELL").is_some();
+    let Some(path) = crate::config::resolve_load_config_path(config_path) else {
+        return;
+    };
+    let Ok(raw) = std::fs::read_to_string(path) else {
+        return;
+    };
+    let Ok(doc) = toml::from_str::<toml::Value>(&raw) else {
+        return;
+    };
+    merge_user_workspace_config_from_doc(config, &doc, workspace);
+    if allow_shell_from_env {
+        config.allow_shell = allow_shell_before;
+    }
+}
+
+fn merge_user_workspace_config_from_doc(config: &mut Config, doc: &toml::Value, workspace: &Path) {
+    for table_name in ["workspace", "projects"] {
+        let Some(entries) = doc.get(table_name).and_then(toml::Value::as_table) else {
+            continue;
+        };
+        for (raw_path, entry) in entries {
+            if !workspace_config_path_matches(raw_path, workspace) {
+                continue;
+            }
+            if let Some(allow_shell) = entry.get("allow_shell").and_then(toml::Value::as_bool) {
+                config.allow_shell = Some(allow_shell);
+            }
+        }
+    }
+}
+
+fn workspace_config_path_matches(raw_path: &str, workspace: &Path) -> bool {
+    let configured = crate::config::expand_path(raw_path);
+    let configured = configured.canonicalize().unwrap_or(configured);
+    let workspace = workspace
+        .canonicalize()
+        .unwrap_or_else(|_| workspace.to_path_buf());
+    paths_equal_for_config(&configured, &workspace)
+}
+
+#[cfg(windows)]
+fn paths_equal_for_config(left: &Path, right: &Path) -> bool {
+    left.to_string_lossy()
+        .eq_ignore_ascii_case(&right.to_string_lossy())
+}
+
+#[cfg(not(windows))]
+fn paths_equal_for_config(left: &Path, right: &Path) -> bool {
+    left == right
+}
+
 async fn run_interactive(
     cli: &Cli,
     config: &Config,
@@ -4967,6 +5030,7 @@ async fn run_interactive(
     // or legacy $WORKSPACE/.deepseek/config.toml
     // unless --no-project-config was passed (#485).
     let mut merged_config = config.clone();
+    merge_user_workspace_config(&mut merged_config, cli.config.clone(), &workspace);
     if !cli.no_project_config {
         merge_project_config(&mut merged_config, &workspace);
     }
@@ -6800,6 +6864,98 @@ allow_shell = false
         let mut config = Config::default();
         merge_project_config(&mut config, tmp.path());
         assert_eq!(config.max_subagents, Some(4));
+        assert_eq!(config.allow_shell, Some(false));
+    }
+
+    #[test]
+    fn user_workspace_overlay_can_enable_shell_for_matching_workspace() {
+        let tmp = tempdir().expect("tempdir");
+        let workspace = tmp.path().join("project");
+        fs::create_dir_all(&workspace).expect("mkdir workspace");
+        let raw = format!(
+            "[workspace.'{}']\nallow_shell = true\n",
+            workspace.display()
+        );
+        let doc: toml::Value = toml::from_str(&raw).expect("parse config");
+
+        let mut config = Config::default();
+        merge_user_workspace_config_from_doc(&mut config, &doc, &workspace);
+
+        assert_eq!(config.allow_shell, Some(true));
+    }
+
+    #[test]
+    fn user_workspace_overlay_ignores_non_matching_workspace() {
+        let tmp = tempdir().expect("tempdir");
+        let configured_workspace = tmp.path().join("configured");
+        let active_workspace = tmp.path().join("active");
+        fs::create_dir_all(&configured_workspace).expect("mkdir configured workspace");
+        fs::create_dir_all(&active_workspace).expect("mkdir active workspace");
+        let raw = format!(
+            "[workspace.'{}']\nallow_shell = true\n",
+            configured_workspace.display()
+        );
+        let doc: toml::Value = toml::from_str(&raw).expect("parse config");
+
+        let mut config = Config::default();
+        merge_user_workspace_config_from_doc(&mut config, &doc, &active_workspace);
+
+        assert_eq!(config.allow_shell, None);
+    }
+
+    #[test]
+    fn user_workspace_overlay_preserves_allow_shell_env_override() {
+        let _guard = crate::test_support::lock_test_env();
+        let tmp = tempdir().expect("tempdir");
+        let workspace = tmp.path().join("project");
+        fs::create_dir_all(&workspace).expect("mkdir workspace");
+        let config_path = tmp.path().join("config.toml");
+        fs::write(
+            &config_path,
+            format!(
+                "[workspace.'{}']\nallow_shell = true\n",
+                workspace.display()
+            ),
+        )
+        .expect("write config");
+
+        unsafe {
+            std::env::set_var("DEEPSEEK_ALLOW_SHELL", "false");
+        }
+        let mut config = Config {
+            allow_shell: Some(false),
+            ..Config::default()
+        };
+        merge_user_workspace_config(&mut config, Some(config_path), &workspace);
+        unsafe {
+            std::env::remove_var("DEEPSEEK_ALLOW_SHELL");
+        }
+
+        assert_eq!(config.allow_shell, Some(false));
+    }
+
+    #[test]
+    fn user_workspace_overlay_does_not_override_managed_config() {
+        let tmp = tempdir().expect("tempdir");
+        let workspace = tmp.path().join("project");
+        fs::create_dir_all(&workspace).expect("mkdir workspace");
+        let config_path = tmp.path().join("config.toml");
+        fs::write(
+            &config_path,
+            format!(
+                "[workspace.'{}']\nallow_shell = true\n",
+                workspace.display()
+            ),
+        )
+        .expect("write config");
+
+        let mut config = Config {
+            allow_shell: Some(false),
+            managed_config_path: Some("managed.toml".to_string()),
+            ..Config::default()
+        };
+        merge_user_workspace_config(&mut config, Some(config_path), &workspace);
+
         assert_eq!(config.allow_shell, Some(false));
     }
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -20,6 +20,20 @@ Overrides:
 
 If both are set, `--config` wins. Environment variable overrides are applied after the file is loaded.
 
+### User workspace entries
+
+For a shell opt-in that should live in the user's global config rather than in
+the repository, add a workspace-scoped entry:
+
+```toml
+[workspace.'/absolute/path/to/project']
+allow_shell = true
+```
+
+The entry applies only when the launched workspace path matches the table key.
+The legacy `[projects."/absolute/path/to/project"]` table is also accepted for
+this user-owned override.
+
 ### Per-project overlay (#485)
 
 When the TUI starts in a workspace that contains a
@@ -592,7 +606,7 @@ If you are upgrading from older releases:
 - `base_url` (string, optional): defaults to `https://api.deepseek.com/beta` for DeepSeek's OpenAI-compatible Chat Completions API, including legacy `provider = "deepseek-cn"` configs. Other defaults are `https://integrate.api.nvidia.com/v1` for `nvidia-nim`, `https://api.openai.com/v1` for `openai`, `https://api.atlascloud.ai/v1` for `atlascloud`, `https://maas-openapi.wanjiedata.com/api/v1` for `wanjie-ark`, `https://openrouter.ai/api/v1` for `openrouter`, `https://api.xiaomimimo.com/v1` for `xiaomi-mimo`, `https://api.novita.ai/v1` for `novita`, `https://api.fireworks.ai/inference/v1` for `fireworks`, `https://api.siliconflow.com/v1` for `siliconflow`, `https://api.moonshot.ai/v1` for `moonshot`, `http://localhost:30000/v1` for `sglang`, `http://localhost:8000/v1` for `vllm`, and `http://localhost:11434/v1` for `ollama`. Set `https://api.deepseek.com` or `https://api.deepseek.com/v1` explicitly to opt out of DeepSeek beta features.
 - `default_text_model` (string, optional): defaults to `deepseek-v4-pro` for DeepSeek and generic OpenAI-compatible endpoints, `deepseek-ai/deepseek-v4-pro` for NVIDIA NIM, `deepseek-ai/deepseek-v4-flash` for AtlasCloud, `deepseek-reasoner` for Wanjie Ark, `deepseek/deepseek-v4-pro` for OpenRouter and Novita, `mimo-v2.5-pro` for Xiaomi MiMo, `accounts/fireworks/models/deepseek-v4-pro` for Fireworks, `deepseek-ai/DeepSeek-V4-Pro` for SiliconFlow, `kimi-k2.6` for Moonshot, `deepseek-ai/DeepSeek-V4-Pro` for SGLang/vLLM, and `deepseek-coder:1.3b` for Ollama. Current public DeepSeek IDs are `deepseek-v4-pro` and `deepseek-v4-flash`, both with 1M context windows, 384K max output, and thinking mode enabled by default. Legacy `deepseek-chat` and `deepseek-reasoner` remain compatibility aliases for `deepseek-v4-flash` until July 24, 2026, except SiliconFlow maps `deepseek-reasoner` and `deepseek-r1` to its Pro model while `deepseek-chat` and `deepseek-v3` map to Flash. Provider-specific mappings translate `deepseek-v4-pro` / `deepseek-v4-flash` to each provider's model ID where supported. OpenRouter also recognizes recent large IDs such as `arcee-ai/trinity-large-thinking`, `minimax/minimax-m3`, `xiaomi/mimo-v2.5-pro`, `qwen/qwen3.6-35b-a3b`, `google/gemma-4-31b-it`, and `moonshotai/kimi-k2.6`. Generic `openai`, `atlascloud`, `wanjie-ark`, `xiaomi-mimo`, and Ollama model IDs are passed through unchanged. OpenRouter and SiliconFlow provider configs with a custom `base_url` also preserve explicit model values, which lets OpenAI-compatible gateways accept bare model IDs. Use `/models` or `codewhale models` to discover live IDs from your configured endpoint. `CODEWHALE_MODEL` overrides this for a single process; `DEEPSEEK_MODEL` is the legacy alias.
 - `reasoning_effort` (string, optional): `off`, `low`, `medium`, `high`, or `max`; defaults to the configured UI tier. DeepSeek Platform receives top-level `thinking` / `reasoning_effort` fields. NVIDIA NIM receives equivalent settings through `chat_template_kwargs`.
-- `allow_shell` (bool, optional): defaults to `true` (sandboxed).
+- `allow_shell` (bool, optional): defaults to `false`; shell tools must be explicitly enabled.
 - `approval_policy` (string, optional): `on-request`, `untrusted`, or `never`. Runtime `approval_mode` editing in `/config` also accepts `on-request` and `untrusted` aliases.
 - `sandbox_mode` (string, optional): `read-only`, `workspace-write`, `danger-full-access`, `external-sandbox`.
   Platform support is not identical. macOS uses Seatbelt for policy


### PR DESCRIPTION
Problem
- #2523 reports that shell tools stay gated even when the user config has a workspace-specific `allow_shell = true` entry.
- The TUI only merged top-level config plus project-local overlays, so user-owned workspace entries were ignored at launch.

Change
- Merge matching user config `[workspace.'...']` / legacy `[projects."..."]` entries for `allow_shell` during TUI and engine-backed exec startup.
- Preserve env and managed-config precedence.
- Document the workspace-scoped shell opt-in and correct the `allow_shell` default.

Verification
- cargo test -p codewhale-tui user_workspace_overlay --locked
- cargo test -p codewhale-tui project_config_tests --locked
- cargo fmt --all -- --check
- git diff --check

Fixes #2523

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the user-reported issue where a workspace-scoped `allow_shell = true` entry in the user's global config file was ignored at launch because the TUI only merged top-level config values and project-local overlays.

- Adds `merge_user_workspace_config` (called from both the TUI interactive path and the `exec` path) that re-reads the user config file as raw TOML and applies the `allow_shell` value from any matching `[workspace.'...']` or legacy `[projects.'...']` entry, with guards for managed-config, requirements-path, and the `DEEPSEEK_ALLOW_SHELL` environment variable.
- Widens `resolve_load_config_path` visibility to `pub(crate)` so the new helper can call it, and adds five unit tests covering path matching, env-var precedence, and managed-config bypass.
- Updates docs to document the new opt-in syntax and corrects the `allow_shell` default from `true` to `false`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The change is safe to merge — it adds a new opt-in code path guarded by managed-config and env-var precedence checks with no effect unless the user's global config explicitly contains a matching workspace entry.

The new merge function is narrow in scope (only touches `allow_shell`), all existing precedence invariants are preserved, and the five new tests cover the main branches. The open gap — no test for the legacy `[projects]` table — is low-risk given that table follows the same iteration logic.

No files require special attention; the logic in `crates/tui/src/main.rs` is straightforward and well-tested for the primary `[workspace]` path.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/config.rs | Visibility of `resolve_load_config_path` widened to `pub(crate)` so the new merge helper in main.rs can call it — a minimal, low-risk change. |
| docs/CONFIGURATION.md | Adds a 'User workspace entries' section documenting the new opt-in and corrects the `allow_shell` default to `false`. The section does not note that a project-level `config.toml` (applied after) can still override the user workspace setting, which could surprise users who rely on this opt-in. |
| crates/tui/src/main.rs | Adds `merge_user_workspace_config` (called from both TUI interactive and `exec` paths) with appropriate guards for managed-config, env-var precedence, and Windows path normalisation. Five new unit tests added; the legacy `[projects]` table branch is not covered by tests. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[launch / exec] --> B[load_config_from_cli\nuser file + env vars]
    B --> C{managed_config_path\nor requirements_path?}
    C -- yes --> G[skip workspace overlay]
    C -- no --> D[merge_user_workspace_config\nre-read raw TOML\nfind matching workspace entry\napply allow_shell]
    D --> E{DEEPSEEK_ALLOW_SHELL\nenv var set?}
    E -- yes --> F[restore pre-merge\nallow_shell value\nenv wins]
    E -- no --> H[keep merged value]
    F --> I{interactive mode?}
    H --> I
    G --> I
    I -- yes --> J[merge_project_config\n.codewhale/config.toml\napplied last — can override]
    I -- no / exec --> K[proceed with config]
    J --> K
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22codex%2F2523-workspace-shell-config%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2F2523-workspace-shell-config%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fmain.rs%3A4983-4995%0A**Legacy%20%60%5Bprojects%5D%60%20table%20not%20covered%20by%20tests**%0A%0A%60merge_user_workspace_config_from_doc%60%20iterates%20both%20%60%22workspace%22%60%20and%20%60%22projects%22%60%20tables%2C%20but%20none%20of%20the%20new%20tests%20exercise%20the%20legacy%20%60%5Bprojects.'...'%5D%60%20path%20%E2%80%94%20they%20all%20use%20%60%5Bworkspace.'...'%5D%60.%20If%20the%20TOML%20key%20lookup%20logic%20%28or%20the%20path-matching%20helper%29%20behaves%20differently%20for%20that%20branch%2C%20a%20regression%20there%20would%20go%20undetected.%0A%0A%23%23%23%20Issue%202%20of%202%0Adocs%2FCONFIGURATION.md%3A33-35%0AThe%20new%20section%20doesn't%20mention%20that%20the%20per-project%20overlay%20%28%60%24WORKSPACE%2F.codewhale%2Fconfig.toml%60%29%20is%20applied%20**after**%20the%20user%20workspace%20entry%20in%20interactive%20mode%2C%20so%20a%20project-level%20%60allow_shell%20%3D%20false%60%20will%20silently%20override%20the%20user's%20opt-in.%20Adding%20a%20brief%20note%20here%20prevents%20user%20confusion.%0A%0A%60%60%60suggestion%0AThe%20entry%20applies%20only%20when%20the%20launched%20workspace%20path%20matches%20the%20table%20key.%0AThe%20legacy%20%60%5Bprojects.%22%2Fabsolute%2Fpath%2Fto%2Fproject%22%5D%60%20table%20is%20also%20accepted%20for%0Athis%20user-owned%20override.%0A%0A%3E%20**Note%3A**%20the%20per-project%20overlay%20%28%60%3Cworkspace%3E%2F.codewhale%2Fconfig.toml%60%29%20is%0A%3E%20applied%20after%20this%20user%20entry%20in%20interactive%20mode%2C%20so%20a%20project-level%0A%3E%20%60allow_shell%20%3D%20false%60%20will%20take%20precedence.%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fmain.rs%3A4983-4995%0A**Legacy%20%60%5Bprojects%5D%60%20table%20not%20covered%20by%20tests**%0A%0A%60merge_user_workspace_config_from_doc%60%20iterates%20both%20%60%22workspace%22%60%20and%20%60%22projects%22%60%20tables%2C%20but%20none%20of%20the%20new%20tests%20exercise%20the%20legacy%20%60%5Bprojects.'...'%5D%60%20path%20%E2%80%94%20they%20all%20use%20%60%5Bworkspace.'...'%5D%60.%20If%20the%20TOML%20key%20lookup%20logic%20%28or%20the%20path-matching%20helper%29%20behaves%20differently%20for%20that%20branch%2C%20a%20regression%20there%20would%20go%20undetected.%0A%0A%23%23%23%20Issue%202%20of%202%0Adocs%2FCONFIGURATION.md%3A33-35%0AThe%20new%20section%20doesn't%20mention%20that%20the%20per-project%20overlay%20%28%60%24WORKSPACE%2F.codewhale%2Fconfig.toml%60%29%20is%20applied%20**after**%20the%20user%20workspace%20entry%20in%20interactive%20mode%2C%20so%20a%20project-level%20%60allow_shell%20%3D%20false%60%20will%20silently%20override%20the%20user's%20opt-in.%20Adding%20a%20brief%20note%20here%20prevents%20user%20confusion.%0A%0A%60%60%60suggestion%0AThe%20entry%20applies%20only%20when%20the%20launched%20workspace%20path%20matches%20the%20table%20key.%0AThe%20legacy%20%60%5Bprojects.%22%2Fabsolute%2Fpath%2Fto%2Fproject%22%5D%60%20table%20is%20also%20accepted%20for%0Athis%20user-owned%20override.%0A%0A%3E%20**Note%3A**%20the%20per-project%20overlay%20%28%60%3Cworkspace%3E%2F.codewhale%2Fconfig.toml%60%29%20is%0A%3E%20applied%20after%20this%20user%20entry%20in%20interactive%20mode%2C%20so%20a%20project-level%0A%3E%20%60allow_shell%20%3D%20false%60%20will%20take%20precedence.%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2529&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fmain.rs%3A4983-4995%0A**Legacy%20%60%5Bprojects%5D%60%20table%20not%20covered%20by%20tests**%0A%0A%60merge_user_workspace_config_from_doc%60%20iterates%20both%20%60%22workspace%22%60%20and%20%60%22projects%22%60%20tables%2C%20but%20none%20of%20the%20new%20tests%20exercise%20the%20legacy%20%60%5Bprojects.'...'%5D%60%20path%20%E2%80%94%20they%20all%20use%20%60%5Bworkspace.'...'%5D%60.%20If%20the%20TOML%20key%20lookup%20logic%20%28or%20the%20path-matching%20helper%29%20behaves%20differently%20for%20that%20branch%2C%20a%20regression%20there%20would%20go%20undetected.%0A%0A%23%23%23%20Issue%202%20of%202%0Adocs%2FCONFIGURATION.md%3A33-35%0AThe%20new%20section%20doesn't%20mention%20that%20the%20per-project%20overlay%20%28%60%24WORKSPACE%2F.codewhale%2Fconfig.toml%60%29%20is%20applied%20**after**%20the%20user%20workspace%20entry%20in%20interactive%20mode%2C%20so%20a%20project-level%20%60allow_shell%20%3D%20false%60%20will%20silently%20override%20the%20user's%20opt-in.%20Adding%20a%20brief%20note%20here%20prevents%20user%20confusion.%0A%0A%60%60%60suggestion%0AThe%20entry%20applies%20only%20when%20the%20launched%20workspace%20path%20matches%20the%20table%20key.%0AThe%20legacy%20%60%5Bprojects.%22%2Fabsolute%2Fpath%2Fto%2Fproject%22%5D%60%20table%20is%20also%20accepted%20for%0Athis%20user-owned%20override.%0A%0A%3E%20**Note%3A**%20the%20per-project%20overlay%20%28%60%3Cworkspace%3E%2F.codewhale%2Fconfig.toml%60%29%20is%0A%3E%20applied%20after%20this%20user%20entry%20in%20interactive%20mode%2C%20so%20a%20project-level%0A%3E%20%60allow_shell%20%3D%20false%60%20will%20take%20precedence.%0A%60%60%60%0A%0A&pr=2529&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix(config): normalize windows workspace..."](https://github.com/hmbown/codewhale/commit/24c128735b8107485efc36786522c9804e65286e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34959497)</sub>

<!-- /greptile_comment -->