### PR TITLE
fix(tui): hint mention depth cap on misses

### DIFF
--- a/crates/tui/src/tui/file_mention.rs
+++ b/crates/tui/src/tui/file_mention.rs
@@ -270,7 +270,10 @@ pub fn try_autocomplete_file_mention(app: &mut App) -> bool {
     let ws = workspace_for_app(app);
     let candidates = find_file_mention_completions(&ws, &partial, FILE_MENTION_COMPLETION_LIMIT);
     if candidates.is_empty() {
-        app.status_message = Some(format!("No files match @{partial}"));
+        app.status_message = Some(no_file_mention_matches_status(
+            &partial,
+            app.mention_walk_depth,
+        ));
         return true;
     }
     if candidates.len() == 1 {
@@ -295,6 +298,16 @@ pub fn try_autocomplete_file_mention(app: &mut App) -> bool {
         .join(", ");
     app.status_message = Some(format!("Matches: {preview}"));
     true
+}
+
+fn no_file_mention_matches_status(partial: &str, walk_depth: usize) -> String {
+    if walk_depth > 0 && (partial.contains('/') || partial.contains('\\')) {
+        format!(
+            "No files match @{partial} (mention_walk_depth={walk_depth}; use /config set mention_walk_depth 0 to search deeper)"
+        )
+    } else {
+        format!("No files match @{partial}")
+    }
 }
 
 /// Splice a completion into the input, replacing the `@<partial>` token at

--- a/crates/tui/src/tui/file_mention.rs
+++ b/crates/tui/src/tui/file_mention.rs
@@ -301,13 +301,24 @@ pub fn try_autocomplete_file_mention(app: &mut App) -> bool {
 }
 
 fn no_file_mention_matches_status(partial: &str, walk_depth: usize) -> String {
-    if walk_depth > 0 && (partial.contains('/') || partial.contains('\\')) {
+    if path_partial_reaches_walk_depth(partial, walk_depth) {
         format!(
             "No files match @{partial} (mention_walk_depth={walk_depth}; use /config set mention_walk_depth 0 to search deeper)"
         )
     } else {
         format!("No files match @{partial}")
     }
+}
+
+fn path_partial_reaches_walk_depth(partial: &str, walk_depth: usize) -> bool {
+    if walk_depth == 0 {
+        return false;
+    }
+    let component_count = partial
+        .split(['/', '\\'])
+        .filter(|component| !component.is_empty())
+        .count();
+    component_count >= walk_depth
 }
 
 /// Splice a completion into the input, replacing the `@<partial>` token at

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -4695,6 +4695,25 @@ fn try_autocomplete_file_mention_no_match_reports_status() {
 }
 
 #[test]
+fn try_autocomplete_file_mention_no_match_mentions_depth_cap_for_path_like_partial() {
+    let tmpdir = TempDir::new().expect("tempdir");
+
+    let mut app = create_test_app();
+    app.workspace = tmpdir.path().to_path_buf();
+    app.mention_walk_depth = 6;
+    app.input = "@a/b/c/d/e/f/g/target".to_string();
+    app.cursor_position = app.input.chars().count();
+
+    assert!(try_autocomplete_file_mention(&mut app));
+    assert_eq!(
+        app.status_message.as_deref(),
+        Some(
+            "No files match @a/b/c/d/e/f/g/target (mention_walk_depth=6; use /config set mention_walk_depth 0 to search deeper)"
+        )
+    );
+}
+
+#[test]
 fn try_autocomplete_file_mention_returns_false_outside_mention() {
     let mut app = create_test_app();
     app.input = "no mention here".to_string();

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -4714,6 +4714,40 @@ fn try_autocomplete_file_mention_no_match_mentions_depth_cap_for_path_like_parti
 }
 
 #[test]
+fn try_autocomplete_file_mention_no_match_skips_depth_hint_for_shallow_path() {
+    let tmpdir = TempDir::new().expect("tempdir");
+
+    let mut app = create_test_app();
+    app.workspace = tmpdir.path().to_path_buf();
+    app.mention_walk_depth = 6;
+    app.input = "@shallow_missing/main.rs".to_string();
+    app.cursor_position = app.input.chars().count();
+
+    assert!(try_autocomplete_file_mention(&mut app));
+    assert_eq!(
+        app.status_message.as_deref(),
+        Some("No files match @shallow_missing/main.rs")
+    );
+}
+
+#[test]
+fn try_autocomplete_file_mention_no_match_skips_depth_hint_when_unlimited() {
+    let tmpdir = TempDir::new().expect("tempdir");
+
+    let mut app = create_test_app();
+    app.workspace = tmpdir.path().to_path_buf();
+    app.mention_walk_depth = 0;
+    app.input = "@a/b/c/d/e/f/g/target".to_string();
+    app.cursor_position = app.input.chars().count();
+
+    assert!(try_autocomplete_file_mention(&mut app));
+    assert_eq!(
+        app.status_message.as_deref(),
+        Some("No files match @a/b/c/d/e/f/g/target")
+    );
+}
+
+#[test]
 fn try_autocomplete_file_mention_returns_false_outside_mention() {
     let mut app = create_test_app();
     app.input = "no mention here".to_string();


### PR DESCRIPTION
## Summary
- add a status hint when path-like @-mention completion misses under a nonzero walk depth
- keep ordinary filename misses unchanged
- keep the default walk depth and completion behavior unchanged

Refs #2488

## Verification
- cargo test -p codewhale-tui try_autocomplete_file_mention_no_match --locked
- cargo fmt --all -- --check
- git diff --check

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refines the `@`-mention autocomplete miss experience by showing a contextual depth-limit hint only when the typed path is plausibly too deep for the current `mention_walk_depth` setting.

- Adds `no_file_mention_matches_status` and `path_partial_reaches_walk_depth` helpers to `file_mention.rs`; the hint fires only when the component count of the partial is at or above `walk_depth`, and is suppressed entirely when `walk_depth == 0` (unlimited).
- Adds three targeted tests: deep-path hint fires, shallow-path hint suppressed, and unlimited-depth hint suppressed — the last of which directly covers the previously-flagged missing negative case.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The change is narrowly scoped to status-message text generation and has no effect on autocomplete logic, file I/O, or app state beyond status_message.

Both helpers are pure functions with no side effects. The guard for walk_depth == 0 and the component-count comparison are straightforward. Previous review feedback (depth-component counting and the missing unlimited-depth negative test) has been fully addressed. The three new tests cover all meaningful branches.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/file_mention.rs | Extracts status-message logic into two well-scoped private helpers; handles walk_depth==0, cross-platform path separators, and empty components correctly. |
| crates/tui/src/tui/ui/tests.rs | Adds three new unit tests covering the positive case (hint fires for deep partial), negative case (shallow partial, no hint), and unlimited-depth case (walk_depth=0, no hint). |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[try_autocomplete_file_mention] --> B{candidates empty?}
    B -- Yes --> C[no_file_mention_matches_status\npartial, walk_depth]
    C --> D{path_partial_reaches_walk_depth?}
    D -- walk_depth == 0 --> E["No files match @{partial}"]
    D -- component_count < walk_depth --> E
    D -- component_count >= walk_depth --> F["No files match @{partial}\n(mention_walk_depth=N; use /config set\nmention_walk_depth 0 to search deeper)"]
    B -- No, single match --> G[replace + attach]
    B -- No, multiple --> H{shared prefix longer?}
    H -- Yes --> I[extend partial]
    H -- No --> J[show top 5 candidates]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(tui): narrow mention depth hint"](https://github.com/hmbown/codewhale/commit/637b2f40770e65924eb28cccac12c8b1c9a43e70) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34963526)</sub>

<!-- /greptile_comment -->