### PR TITLE
feat(tui): add user-defined custom theme system with disk persistence

### DIFF
--- a/crates/tui/src/commands/config.rs
+++ b/crates/tui/src/commands/config.rs
@@ -755,14 +755,212 @@ fn mode_display_name(mode: AppMode) -> &'static str {
     }
 }
 
-/// `/theme [name]` — with no argument, open the interactive picker (arrow
-/// keys, live preview, Enter to persist, Esc to revert). With an argument,
-/// route through `set_config_value("theme", ...)` so the apply + save flow is
-/// shared with `/config`.
+/// `/theme [name|new|delete]` — with no argument, open the interactive
+/// picker (arrow keys, live preview, Enter to persist, Esc to revert).
+/// With a known theme name, route through `set_config_value("theme", ...)`
+/// so the apply + save flow is shared with `/config`.
+///
+/// Subcommands:
+/// - `/theme new` — guided custom-theme creation flow
+/// - `/theme delete <name>` — remove a custom theme from disk and registry
 pub fn theme(app: &mut App, arg: Option<&str>) -> CommandResult {
     match arg.map(str::trim).filter(|s| !s.is_empty()) {
         None => CommandResult::action(AppAction::OpenThemePicker),
+        Some("new") | Some("create") | Some("custom") => {
+            // Guided custom-theme creation flow. Redirect to /theme-describe.
+            CommandResult::message(
+                "Use /theme-describe to generate a custom theme from a natural-language \
+                 description.\nExamples:\n  /theme-describe A warm amber library theme \
+                 with brown accents, cream text, moderate contrast dark mode\n  \
+                 /theme-describe A minimalist light theme with soft blue accents, \
+                 high contrast, clean and modern"
+                    .to_string(),
+            )
+        }
+        Some(arg) if arg.starts_with("delete ") || arg.starts_with("remove ") => {
+            let name = arg.split_once(' ').map(|(_, n)| n.trim()).unwrap_or("");
+            if name.is_empty() {
+                return CommandResult::error(
+                    "Usage: /theme delete <name>. Use /theme to see deletable themes.",
+                );
+            }
+            delete_custom_theme(app, name)
+        }
         Some(name) => set_config_value(app, "theme", name, true),
+    }
+}
+
+/// `/theme-describe <description>` — generate a custom CodeWhale TUI theme
+/// from a natural-language description. Constructs a structured prompt with
+/// the full `UiTheme` field reference so the AI knows exactly which 40 color
+/// slots to populate. The AI's response is the theme JSON, which the user
+/// can review and save to `~/.codewhale/themes/<name>.json`.
+pub fn theme_describe(_app: &mut App, arg: Option<&str>) -> CommandResult {
+    let description = arg.map(str::trim).unwrap_or("");
+    if description.is_empty() {
+        return CommandResult::error(
+            "Usage: /theme-describe <description>\n\
+             Example: /theme-describe A warm amber library theme with brown accents, \
+             cream text, moderate contrast dark mode",
+        );
+    }
+
+    let prompt = format!(
+        "Generate a custom CodeWhale TUI theme based on this description: \"{description}\"\n\n\
+         The theme is a JSON object. All colors are 6-digit hex strings \
+         (e.g. \"#1a1410\"). mode is one of: dark, light, grayscale, \
+         solarized-light.\n\n\
+         Fields (2 meta + 38 color = 40 total):\n\
+         Meta: name (kebab-case identifier), mode (dark|light|grayscale|solarized-light)\n\
+         Colors (38):\n\
+         - Surface: surface_bg, panel_bg, elevated_bg, composer_bg, \
+         selection_bg, header_bg, footer_bg\n\
+         - Text: text_dim, text_hint, text_muted, text_body, text_soft, border\n\
+         - Accent: accent_primary, accent_secondary, accent_action\n\
+         - Error: error_fg, error_hover, error_surface, error_border, error_text\n\
+         - Status: warning, success, info\n\
+         - Mode badges: mode_agent, mode_yolo, mode_plan, mode_goal\n\
+         - Statusline: status_ready, status_working, status_warning\n\
+         - Diff: diff_added_fg, diff_deleted_fg, diff_added_bg, diff_deleted_bg\n\
+         - Tool cells: tool_running, tool_success, tool_failed\n\n\
+         IMPORTANT: Output ONLY the JSON inside a markdown code fence ```json \
+         block. No explanation before or after. The user will then use \
+         /theme-save <name> to persist it. The name field in the JSON must match."
+    );
+
+    CommandResult::action(AppAction::SendMessage(prompt))
+}
+
+/// `/theme-save <name>` — persist the most recently generated theme JSON
+/// from the conversation history to `~/.codewhale/themes/<name>.json` and
+/// register it in-memory so it appears immediately in the picker.
+///
+/// Aliases: `/theme-write`, `/theme-install`.
+///
+/// This command solves the workspace-boundary problem: CodeWhale AI tools
+/// are scoped to the workspace directory and cannot write to `~/.codewhale/`,
+/// but this Rust-side command runs with full filesystem access inside the
+/// CodeWhale process itself.
+pub fn theme_save(app: &mut App, arg: Option<&str>) -> CommandResult {
+    let name = arg.map(str::trim).unwrap_or("");
+    if name.is_empty() || name.len() > 64 {
+        return CommandResult::error(
+            "Usage: /theme-save <name>\n\
+             Example: /theme-save amber-library\n\n\
+             The name must be 1-64 characters. Use lowercase, digits, and hyphens.",
+        );
+    }
+
+    // Scan conversation history backwards for the most recent assistant
+    // message containing a JSON block with UiTheme fields. This finds the
+    // output of a recent /theme-describe command.
+    let json_text = match find_recent_theme_json(&app.history) {
+        Some(j) => j,
+        None => {
+            return CommandResult::error(
+                "No theme JSON found in the recent conversation. \
+                 Use /theme-describe first to generate a theme, then \
+                 /theme-save <name> to persist it.",
+            );
+        }
+    };
+
+    // Parse as UiThemeCustom, which handles defaults for missing fields
+    let custom: crate::custom_theme::UiThemeCustom = match serde_json::from_str(&json_text) {
+        Ok(c) => c,
+        Err(e) => {
+            return CommandResult::error(format!(
+                "Failed to parse theme JSON: {e}. Ensure the AI output is complete \
+                 and try running /theme-describe again."
+            ));
+        }
+    };
+
+    // Persist to disk
+    match crate::custom_theme::save_custom_theme(name, &custom) {
+        Ok(path) => {
+            let ui_theme = custom.to_ui_theme();
+            crate::palette::register_custom_theme(name, ui_theme);
+            CommandResult::message(format!(
+                "Theme '{name}' saved to {} and ready to use. Open /theme to select it.",
+                path.display()
+            ))
+        }
+        Err(e) => CommandResult::error(format!("Failed to save theme '{name}': {e}")),
+    }
+}
+
+/// Extract the text of the most recent JSON block containing theme fields
+/// from the conversation history. Scans backwards so the most recent
+/// /theme-describe output is found first.
+fn find_recent_theme_json(history: &[crate::tui::history::HistoryCell]) -> Option<String> {
+    for cell in history.iter().rev() {
+        let text = match cell {
+            crate::tui::history::HistoryCell::Assistant { content, .. } => content.clone(),
+            _ => continue,
+        };
+        // Look for a JSON object containing core theme keys
+        if text.contains("\"surface_bg\"")
+            && text.contains("\"text_body\"")
+            && text.contains("\"accent_primary\"")
+        {
+            // Try to extract just the JSON object
+            if let Some(json) = extract_json_object(&text) {
+                return Some(json);
+            }
+        }
+    }
+    None
+}
+
+/// Extract the first balanced JSON object from text.
+fn extract_json_object(text: &str) -> Option<String> {
+    let start = text.find('{')?;
+    let mut depth = 0;
+    let bytes = text.as_bytes();
+    for (i, &b) in bytes.iter().enumerate().skip(start) {
+        match b {
+            b'{' => depth += 1,
+            b'}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(text[start..=i].to_string());
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Delete a custom theme: remove from disk, unregister from memory, and
+/// if it was the active theme, fall back to System.
+fn delete_custom_theme(app: &mut App, name: &str) -> CommandResult {
+    let id = match crate::palette::ThemeId::from_name(name) {
+        Some(id) => id,
+        None => return CommandResult::error(format!("Theme '{name}' not found.")),
+    };
+    if !id.is_custom() {
+        return CommandResult::error(format!(
+            "'{name}' is a built-in theme and cannot be deleted. Only custom themes \
+             (under ~/.codewhale/themes/) can be removed."
+        ));
+    }
+    match crate::custom_theme::delete_custom_theme(name) {
+        Ok(()) => {
+            crate::palette::unregister_custom_theme(name);
+
+            // If the deleted theme is currently active, fall back to System
+            if app.theme_id.name().eq_ignore_ascii_case(name) {
+                app.theme_id = crate::palette::ThemeId::System;
+                app.ui_theme = crate::palette::UiTheme::detect();
+                app.needs_redraw = true;
+            }
+            CommandResult::message(format!(
+                "Custom theme '{name}' deleted. Use /theme to open the picker."
+            ))
+        }
+        Err(e) => CommandResult::error(format!("Failed to delete custom theme '{name}': {e}")),
     }
 }
 

--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -384,6 +384,18 @@ pub const COMMANDS: &[CommandInfo] = &[
         description_id: MessageId::CmdThemeDescription,
     },
     CommandInfo {
+        name: "theme-describe",
+        aliases: &["theme-create", "theme-new", "theme-generate"],
+        usage: "/theme-describe <natural-language description>",
+        description_id: MessageId::CmdThemeDescribe,
+    },
+    CommandInfo {
+        name: "theme-save",
+        aliases: &["theme-write", "theme-install"],
+        usage: "/theme-save <name>",
+        description_id: MessageId::CmdThemeSave,
+    },
+    CommandInfo {
         name: "verbose",
         aliases: &[],
         usage: "/verbose [on|off]",
@@ -624,6 +636,10 @@ pub fn execute(cmd: &str, app: &mut App) -> CommandResult {
         "jihua" => config::mode(app, Some("plan")),
         "zidong" => config::mode(app, Some("yolo")),
         "theme" => config::theme(app, arg),
+        "theme-describe" | "theme-create" | "theme-new" | "theme-generate" => {
+            config::theme_describe(app, arg)
+        }
+        "theme-save" | "theme-write" | "theme-install" => config::theme_save(app, arg),
         "verbose" => config::verbose(app, arg),
         "trust" | "xinren" => config::trust(app, arg),
         "logout" => config::logout(app),

--- a/crates/tui/src/config_ui.rs
+++ b/crates/tui/src/config_ui.rs
@@ -175,10 +175,11 @@ pub enum UiLocale {
     Es419,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub enum UiThemeValue {
     System,
+    Terminal,
     Dark,
     Light,
     Grayscale,
@@ -186,7 +187,11 @@ pub enum UiThemeValue {
     TokyoNight,
     Dracula,
     GruvboxDark,
+    Claude,
     Matrix,
+    SolarizedLight,
+    /// Custom theme identified by file-name stem
+    Custom(String),
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -491,7 +496,7 @@ pub fn apply_document(
             bool_str(doc.settings.show_tool_details),
         ),
         ("locale", doc.settings.locale.as_setting()),
-        ("theme", doc.settings.theme.as_setting()),
+        ("theme", &doc.settings.theme.as_setting()),
         (
             "background_color",
             doc.settings
@@ -723,23 +728,28 @@ impl UiLocale {
 }
 
 impl UiThemeValue {
-    fn as_setting(self) -> &'static str {
+    fn as_setting(&self) -> String {
         match self {
-            Self::System => "system",
-            Self::Dark => "dark",
-            Self::Light => "light",
-            Self::Grayscale => "grayscale",
-            Self::CatppuccinMocha => "catppuccin-mocha",
-            Self::TokyoNight => "tokyo-night",
-            Self::Dracula => "dracula",
-            Self::GruvboxDark => "gruvbox-dark",
-            Self::Matrix => "matrix",
+            Self::System => "system".to_string(),
+            Self::Terminal => "terminal".to_string(),
+            Self::Dark => "dark".to_string(),
+            Self::Light => "light".to_string(),
+            Self::Grayscale => "grayscale".to_string(),
+            Self::CatppuccinMocha => "catppuccin-mocha".to_string(),
+            Self::TokyoNight => "tokyo-night".to_string(),
+            Self::Dracula => "dracula".to_string(),
+            Self::GruvboxDark => "gruvbox-dark".to_string(),
+            Self::Claude => "claude".to_string(),
+            Self::Matrix => "matrix".to_string(),
+            Self::SolarizedLight => "solarized-light".to_string(),
+            Self::Custom(name) => name.clone(),
         }
     }
 
     fn from_setting(value: &str) -> Result<Self> {
         match crate::palette::normalize_theme_name(value) {
             Some("system") => Ok(Self::System),
+            Some("terminal") => Ok(Self::Terminal),
             Some("dark") => Ok(Self::Dark),
             Some("light") => Ok(Self::Light),
             Some("grayscale") => Ok(Self::Grayscale),
@@ -747,9 +757,19 @@ impl UiThemeValue {
             Some("tokyo-night") => Ok(Self::TokyoNight),
             Some("dracula") => Ok(Self::Dracula),
             Some("gruvbox-dark") => Ok(Self::GruvboxDark),
+            Some("claude") => Ok(Self::Claude),
             Some("matrix") => Ok(Self::Matrix),
-            Some(other) => bail!("unsupported theme '{other}'"),
-            None => bail!("invalid theme '{value}'"),
+            Some("solarized-light") => Ok(Self::SolarizedLight),
+            // Unknown names are accepted as custom themes
+            None | Some(_) => {
+                let name = value.trim().to_ascii_lowercase();
+                if name.is_empty() || name.len() > 64 {
+                    bail!(
+                        "invalid theme '{value}': expected a known theme or a custom theme name (1-64 characters)"
+                    );
+                }
+                Ok(Self::Custom(name))
+            }
         }
     }
 }
@@ -1178,21 +1198,20 @@ background_color = "#1A1B26"
             locale,
             &serde_json::json!(["auto", "en", "ja", "zh-Hans", "pt-BR", "es-419"])
         );
-        let theme = &schema["$defs"]["UiThemeValue"]["enum"];
-        assert_eq!(
-            theme,
-            &serde_json::json!([
-                "system",
-                "dark",
-                "light",
-                "grayscale",
-                "catppuccin-mocha",
-                "tokyo-night",
-                "dracula",
-                "gruvbox-dark",
-                "matrix"
-            ])
+        // UiThemeValue now includes a Custom(String) variant so the schema
+        // is a oneOf rather than a flat enum list.
+        let theme_schema = &schema["$defs"]["UiThemeValue"];
+        assert!(
+            theme_schema.is_object(),
+            "UiThemeValue schema should be an object (oneOf)"
         );
+        // Verify that known built-in values appear somewhere in the schema.
+        let schema_str = serde_json::to_string(theme_schema).unwrap();
+        assert!(schema_str.contains("system"));
+        assert!(schema_str.contains("dark"));
+        assert!(schema_str.contains("grayscale"));
+        assert!(schema_str.contains("catppuccin-mocha"));
+        assert!(schema_str.contains("solarized-light"));
     }
 
     #[test]

--- a/crates/tui/src/custom_theme.rs
+++ b/crates/tui/src/custom_theme.rs
@@ -1,0 +1,612 @@
+//! User-defined custom theme persistence layer.
+//!
+//! Custom themes live as JSON files under `~/.codewhale/themes/<name>.json`.
+//! Each file is a complete `UiTheme` definition serialized with hex colour
+//! strings for every field. The JSON format is human-readable and editable,
+//! but the primary creation path is through the guided `/theme new` flow
+//! which asks CodeWhale to generate a theme from a natural-language description.
+//!
+//! ## File format (example)
+//!
+//! ```json
+//! {
+//!   "name": "amber-library",
+//!   "mode": "dark",
+//!   "surface_bg": "#1a1410",
+//!   "panel_bg": "#241e18",
+//!   ...
+//! }
+//! ```
+//!
+//! ## Resilience
+//!
+//! - Missing colour keys in the JSON default to the Whale dark palette value,
+//!   so a theme file written by an older version of CodeWhale remains valid
+//!   after a new version adds fields to `UiTheme`.
+//! - Invalid hex strings or unparseable JSON are rejected at load time with a
+//!   warning logged to stderr; the offending file is skipped, not loaded.
+//! - The themes directory is never touched by the updater or installer, so
+//!   custom themes survive version upgrades without user intervention.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+
+use ratatui::style::Color;
+use serde::{Deserialize, Serialize};
+
+use crate::palette::{PaletteMode, UI_THEME};
+
+/// Directory name under the CodeWhale config root where custom theme
+/// JSON files are stored.
+const CUSTOM_THEMES_DIR_NAME: &str = "themes";
+
+/// Default fallback values used when a JSON key is missing so that
+/// older theme files remain loadable after new `UiTheme` fields are added.
+fn default_surface_bg() -> String {
+    color_to_hex(UI_THEME.surface_bg)
+}
+fn default_panel_bg() -> String {
+    color_to_hex(UI_THEME.panel_bg)
+}
+fn default_elevated_bg() -> String {
+    color_to_hex(UI_THEME.elevated_bg)
+}
+fn default_composer_bg() -> String {
+    color_to_hex(UI_THEME.composer_bg)
+}
+fn default_selection_bg() -> String {
+    color_to_hex(UI_THEME.selection_bg)
+}
+fn default_header_bg() -> String {
+    color_to_hex(UI_THEME.header_bg)
+}
+fn default_footer_bg() -> String {
+    color_to_hex(UI_THEME.footer_bg)
+}
+fn default_text_dim() -> String {
+    color_to_hex(UI_THEME.text_dim)
+}
+fn default_text_hint() -> String {
+    color_to_hex(UI_THEME.text_hint)
+}
+fn default_text_muted() -> String {
+    color_to_hex(UI_THEME.text_muted)
+}
+fn default_text_body() -> String {
+    color_to_hex(UI_THEME.text_body)
+}
+fn default_text_soft() -> String {
+    color_to_hex(UI_THEME.text_soft)
+}
+fn default_border() -> String {
+    color_to_hex(UI_THEME.border)
+}
+fn default_accent_primary() -> String {
+    color_to_hex(UI_THEME.accent_primary)
+}
+fn default_accent_secondary() -> String {
+    color_to_hex(UI_THEME.accent_secondary)
+}
+fn default_accent_action() -> String {
+    color_to_hex(UI_THEME.accent_action)
+}
+fn default_error_fg() -> String {
+    color_to_hex(UI_THEME.error_fg)
+}
+fn default_error_hover() -> String {
+    color_to_hex(UI_THEME.error_hover)
+}
+fn default_error_surface() -> String {
+    color_to_hex(UI_THEME.error_surface)
+}
+fn default_error_border() -> String {
+    color_to_hex(UI_THEME.error_border)
+}
+fn default_error_text() -> String {
+    color_to_hex(UI_THEME.error_text)
+}
+fn default_warning() -> String {
+    color_to_hex(UI_THEME.warning)
+}
+fn default_success() -> String {
+    color_to_hex(UI_THEME.success)
+}
+fn default_info() -> String {
+    color_to_hex(UI_THEME.info)
+}
+fn default_mode_agent() -> String {
+    color_to_hex(UI_THEME.mode_agent)
+}
+fn default_mode_yolo() -> String {
+    color_to_hex(UI_THEME.mode_yolo)
+}
+fn default_mode_plan() -> String {
+    color_to_hex(UI_THEME.mode_plan)
+}
+fn default_mode_goal() -> String {
+    color_to_hex(UI_THEME.mode_goal)
+}
+fn default_status_ready() -> String {
+    color_to_hex(UI_THEME.status_ready)
+}
+fn default_status_working() -> String {
+    color_to_hex(UI_THEME.status_working)
+}
+fn default_status_warning() -> String {
+    color_to_hex(UI_THEME.status_warning)
+}
+fn default_diff_added_fg() -> String {
+    color_to_hex(UI_THEME.diff_added_fg)
+}
+fn default_diff_deleted_fg() -> String {
+    color_to_hex(UI_THEME.diff_deleted_fg)
+}
+fn default_diff_added_bg() -> String {
+    color_to_hex(UI_THEME.diff_added_bg)
+}
+fn default_diff_deleted_bg() -> String {
+    color_to_hex(UI_THEME.diff_deleted_bg)
+}
+fn default_tool_running() -> String {
+    color_to_hex(UI_THEME.tool_running)
+}
+fn default_tool_success() -> String {
+    color_to_hex(UI_THEME.tool_success)
+}
+fn default_tool_failed() -> String {
+    color_to_hex(UI_THEME.tool_failed)
+}
+
+/// Serializable representation of a complete custom theme. Every colour
+/// is a `"#RRGGBB"` hex string. `mode` is one of `"dark"`, `"light"`,
+/// `"grayscale"`, or `"solarized-light"`.
+///
+/// All colour fields have a serde default of the Whale dark palette value
+/// so that a partial JSON file (written by an older CodeWhale version)
+/// still deserializes into a usable theme.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UiThemeCustom {
+    pub name: String,
+    #[serde(default = "default_mode")]
+    pub mode: String,
+    // Surface hierarchy
+    #[serde(default = "default_surface_bg")]
+    pub surface_bg: String,
+    #[serde(default = "default_panel_bg")]
+    pub panel_bg: String,
+    #[serde(default = "default_elevated_bg")]
+    pub elevated_bg: String,
+    #[serde(default = "default_composer_bg")]
+    pub composer_bg: String,
+    #[serde(default = "default_selection_bg")]
+    pub selection_bg: String,
+    #[serde(default = "default_header_bg")]
+    pub header_bg: String,
+    #[serde(default = "default_footer_bg")]
+    pub footer_bg: String,
+    // Text hierarchy
+    #[serde(default = "default_text_dim")]
+    pub text_dim: String,
+    #[serde(default = "default_text_hint")]
+    pub text_hint: String,
+    #[serde(default = "default_text_muted")]
+    pub text_muted: String,
+    #[serde(default = "default_text_body")]
+    pub text_body: String,
+    #[serde(default = "default_text_soft")]
+    pub text_soft: String,
+    #[serde(default = "default_border")]
+    pub border: String,
+    // Accent roles
+    #[serde(default = "default_accent_primary")]
+    pub accent_primary: String,
+    #[serde(default = "default_accent_secondary")]
+    pub accent_secondary: String,
+    #[serde(default = "default_accent_action")]
+    pub accent_action: String,
+    // Error / destructive
+    #[serde(default = "default_error_fg")]
+    pub error_fg: String,
+    #[serde(default = "default_error_hover")]
+    pub error_hover: String,
+    #[serde(default = "default_error_surface")]
+    pub error_surface: String,
+    #[serde(default = "default_error_border")]
+    pub error_border: String,
+    #[serde(default = "default_error_text")]
+    pub error_text: String,
+    // Status roles
+    #[serde(default = "default_warning")]
+    pub warning: String,
+    #[serde(default = "default_success")]
+    pub success: String,
+    #[serde(default = "default_info")]
+    pub info: String,
+    // Mode badge colors
+    #[serde(default = "default_mode_agent")]
+    pub mode_agent: String,
+    #[serde(default = "default_mode_yolo")]
+    pub mode_yolo: String,
+    #[serde(default = "default_mode_plan")]
+    pub mode_plan: String,
+    #[serde(default = "default_mode_goal")]
+    pub mode_goal: String,
+    // Footer statusline
+    #[serde(default = "default_status_ready")]
+    pub status_ready: String,
+    #[serde(default = "default_status_working")]
+    pub status_working: String,
+    #[serde(default = "default_status_warning")]
+    pub status_warning: String,
+    // Diff colors
+    #[serde(default = "default_diff_added_fg")]
+    pub diff_added_fg: String,
+    #[serde(default = "default_diff_deleted_fg")]
+    pub diff_deleted_fg: String,
+    #[serde(default = "default_diff_added_bg")]
+    pub diff_added_bg: String,
+    #[serde(default = "default_diff_deleted_bg")]
+    pub diff_deleted_bg: String,
+    // Tool cell colors
+    #[serde(default = "default_tool_running")]
+    pub tool_running: String,
+    #[serde(default = "default_tool_success")]
+    pub tool_success: String,
+    #[serde(default = "default_tool_failed")]
+    pub tool_failed: String,
+}
+
+fn default_mode() -> String {
+    "dark".to_string()
+}
+
+// ---- Conversions -------------------------------------------------------
+
+/// Convert a `ratatui::style::Color` to a `"#RRGGBB"` hex string.
+/// `Color::Reset` and named ANSI colours are mapped to a neutral dark grey
+/// (`"#222222"`) since custom themes use RGB exclusively.
+pub fn color_to_hex(c: Color) -> String {
+    match c {
+        Color::Rgb(r, g, b) => format!("#{r:02x}{g:02x}{b:02x}"),
+        _ => "#222222".to_string(),
+    }
+}
+
+/// Parse a `"#RRGGBB"` or `"RRGGBB"` hex string into a `Color::Rgb`.
+/// Returns `None` on malformed input.
+pub fn hex_to_color(hex: &str) -> Option<Color> {
+    let hex = hex.trim().strip_prefix('#').unwrap_or(hex.trim());
+    if hex.len() != 6 || !hex.chars().all(|ch| ch.is_ascii_hexdigit()) {
+        return None;
+    }
+    let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
+    let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
+    let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
+    Some(Color::Rgb(r, g, b))
+}
+
+/// Parse a mode string into `PaletteMode`. Unrecognised strings fall back
+/// to `Dark`.
+pub fn parse_mode(s: &str) -> PaletteMode {
+    match s.trim().to_ascii_lowercase().as_str() {
+        "light" | "whale-light" => PaletteMode::Light,
+        "grayscale" | "greyscale" | "gray" | "grey" | "mono" => PaletteMode::Grayscale,
+        "solarized-light" | "solarized" => PaletteMode::SolarizedLight,
+        _ => PaletteMode::Dark,
+    }
+}
+
+pub fn mode_to_string(mode: PaletteMode) -> &'static str {
+    match mode {
+        PaletteMode::Dark => "dark",
+        PaletteMode::Light => "light",
+        PaletteMode::Grayscale => "grayscale",
+        PaletteMode::SolarizedLight => "solarized-light",
+    }
+}
+
+impl UiThemeCustom {
+    /// Build a `UiThemeCustom` by extracting every field from a `UiTheme`
+    /// into its hex-string representation. The `name` field is set from the
+    /// provided display name.
+    #[allow(dead_code)]
+    pub fn from_ui_theme(ui_theme: &crate::palette::UiTheme, name: String) -> Self {
+        Self {
+            name,
+            mode: mode_to_string(ui_theme.mode).to_string(),
+            surface_bg: color_to_hex(ui_theme.surface_bg),
+            panel_bg: color_to_hex(ui_theme.panel_bg),
+            elevated_bg: color_to_hex(ui_theme.elevated_bg),
+            composer_bg: color_to_hex(ui_theme.composer_bg),
+            selection_bg: color_to_hex(ui_theme.selection_bg),
+            header_bg: color_to_hex(ui_theme.header_bg),
+            footer_bg: color_to_hex(ui_theme.footer_bg),
+            text_dim: color_to_hex(ui_theme.text_dim),
+            text_hint: color_to_hex(ui_theme.text_hint),
+            text_muted: color_to_hex(ui_theme.text_muted),
+            text_body: color_to_hex(ui_theme.text_body),
+            text_soft: color_to_hex(ui_theme.text_soft),
+            border: color_to_hex(ui_theme.border),
+            accent_primary: color_to_hex(ui_theme.accent_primary),
+            accent_secondary: color_to_hex(ui_theme.accent_secondary),
+            accent_action: color_to_hex(ui_theme.accent_action),
+            error_fg: color_to_hex(ui_theme.error_fg),
+            error_hover: color_to_hex(ui_theme.error_hover),
+            error_surface: color_to_hex(ui_theme.error_surface),
+            error_border: color_to_hex(ui_theme.error_border),
+            error_text: color_to_hex(ui_theme.error_text),
+            warning: color_to_hex(ui_theme.warning),
+            success: color_to_hex(ui_theme.success),
+            info: color_to_hex(ui_theme.info),
+            mode_agent: color_to_hex(ui_theme.mode_agent),
+            mode_yolo: color_to_hex(ui_theme.mode_yolo),
+            mode_plan: color_to_hex(ui_theme.mode_plan),
+            mode_goal: color_to_hex(ui_theme.mode_goal),
+            status_ready: color_to_hex(ui_theme.status_ready),
+            status_working: color_to_hex(ui_theme.status_working),
+            status_warning: color_to_hex(ui_theme.status_warning),
+            diff_added_fg: color_to_hex(ui_theme.diff_added_fg),
+            diff_deleted_fg: color_to_hex(ui_theme.diff_deleted_fg),
+            diff_added_bg: color_to_hex(ui_theme.diff_added_bg),
+            diff_deleted_bg: color_to_hex(ui_theme.diff_deleted_bg),
+            tool_running: color_to_hex(ui_theme.tool_running),
+            tool_success: color_to_hex(ui_theme.tool_success),
+            tool_failed: color_to_hex(ui_theme.tool_failed),
+        }
+    }
+
+    /// Convert to an internal `UiTheme`. Colour strings that fail to parse
+    /// fall back to the Whale dark palette value so a single malformed hex
+    /// key does not break the whole theme.
+    pub fn to_ui_theme(&self) -> crate::palette::UiTheme {
+        crate::palette::UiTheme {
+            name: Box::leak(self.name.clone().into_boxed_str()),
+            mode: parse_mode(&self.mode),
+            surface_bg: hex_to_color(&self.surface_bg).unwrap_or(UI_THEME.surface_bg),
+            panel_bg: hex_to_color(&self.panel_bg).unwrap_or(UI_THEME.panel_bg),
+            elevated_bg: hex_to_color(&self.elevated_bg).unwrap_or(UI_THEME.elevated_bg),
+            composer_bg: hex_to_color(&self.composer_bg).unwrap_or(UI_THEME.composer_bg),
+            selection_bg: hex_to_color(&self.selection_bg).unwrap_or(UI_THEME.selection_bg),
+            header_bg: hex_to_color(&self.header_bg).unwrap_or(UI_THEME.header_bg),
+            footer_bg: hex_to_color(&self.footer_bg).unwrap_or(UI_THEME.footer_bg),
+            text_dim: hex_to_color(&self.text_dim).unwrap_or(UI_THEME.text_dim),
+            text_hint: hex_to_color(&self.text_hint).unwrap_or(UI_THEME.text_hint),
+            text_muted: hex_to_color(&self.text_muted).unwrap_or(UI_THEME.text_muted),
+            text_body: hex_to_color(&self.text_body).unwrap_or(UI_THEME.text_body),
+            text_soft: hex_to_color(&self.text_soft).unwrap_or(UI_THEME.text_soft),
+            border: hex_to_color(&self.border).unwrap_or(UI_THEME.border),
+            accent_primary: hex_to_color(&self.accent_primary).unwrap_or(UI_THEME.accent_primary),
+            accent_secondary: hex_to_color(&self.accent_secondary)
+                .unwrap_or(UI_THEME.accent_secondary),
+            accent_action: hex_to_color(&self.accent_action).unwrap_or(UI_THEME.accent_action),
+            error_fg: hex_to_color(&self.error_fg).unwrap_or(UI_THEME.error_fg),
+            error_hover: hex_to_color(&self.error_hover).unwrap_or(UI_THEME.error_hover),
+            error_surface: hex_to_color(&self.error_surface).unwrap_or(UI_THEME.error_surface),
+            error_border: hex_to_color(&self.error_border).unwrap_or(UI_THEME.error_border),
+            error_text: hex_to_color(&self.error_text).unwrap_or(UI_THEME.error_text),
+            warning: hex_to_color(&self.warning).unwrap_or(UI_THEME.warning),
+            success: hex_to_color(&self.success).unwrap_or(UI_THEME.success),
+            info: hex_to_color(&self.info).unwrap_or(UI_THEME.info),
+            mode_agent: hex_to_color(&self.mode_agent).unwrap_or(UI_THEME.mode_agent),
+            mode_yolo: hex_to_color(&self.mode_yolo).unwrap_or(UI_THEME.mode_yolo),
+            mode_plan: hex_to_color(&self.mode_plan).unwrap_or(UI_THEME.mode_plan),
+            mode_goal: hex_to_color(&self.mode_goal).unwrap_or(UI_THEME.mode_goal),
+            status_ready: hex_to_color(&self.status_ready).unwrap_or(UI_THEME.status_ready),
+            status_working: hex_to_color(&self.status_working).unwrap_or(UI_THEME.status_working),
+            status_warning: hex_to_color(&self.status_warning).unwrap_or(UI_THEME.status_warning),
+            diff_added_fg: hex_to_color(&self.diff_added_fg).unwrap_or(UI_THEME.diff_added_fg),
+            diff_deleted_fg: hex_to_color(&self.diff_deleted_fg)
+                .unwrap_or(UI_THEME.diff_deleted_fg),
+            diff_added_bg: hex_to_color(&self.diff_added_bg).unwrap_or(UI_THEME.diff_added_bg),
+            diff_deleted_bg: hex_to_color(&self.diff_deleted_bg)
+                .unwrap_or(UI_THEME.diff_deleted_bg),
+            tool_running: hex_to_color(&self.tool_running).unwrap_or(UI_THEME.tool_running),
+            tool_success: hex_to_color(&self.tool_success).unwrap_or(UI_THEME.tool_success),
+            tool_failed: hex_to_color(&self.tool_failed).unwrap_or(UI_THEME.tool_failed),
+        }
+    }
+}
+
+// ---- File I/O ----------------------------------------------------------
+
+/// Resolve the `~/.codewhale/themes/` directory path. Creates it if absent.
+pub fn ensure_themes_dir() -> std::io::Result<PathBuf> {
+    let home = dirs_next().ok_or_else(|| {
+        std::io::Error::new(std::io::ErrorKind::NotFound, "home directory not found")
+    })?;
+    let dir = home.join(".codewhale").join(CUSTOM_THEMES_DIR_NAME);
+    fs::create_dir_all(&dir)?;
+    Ok(dir)
+}
+
+/// Resolve the directory path without creating it (used during app init
+/// to check whether any custom themes exist without creating the dir).
+pub fn themes_dir() -> Option<PathBuf> {
+    let home = dirs_next()?;
+    let dir = home.join(".codewhale").join(CUSTOM_THEMES_DIR_NAME);
+    if dir.is_dir() { Some(dir) } else { None }
+}
+
+fn dirs_next() -> Option<PathBuf> {
+    std::env::var("HOME")
+        .or_else(|_| {
+            std::env::var("USERPROFILE").or_else(|_| {
+                std::env::var("HOMEDRIVE")
+                    .and_then(|hd| std::env::var("HOMEPATH").map(|hp| format!("{hd}{hp}")))
+            })
+        })
+        .ok()
+        .map(PathBuf::from)
+}
+
+/// Scan `~/.codewhale/themes/` for `*.json` files and return a map of
+/// theme-name → `UiTheme`. Files that fail to parse are skipped with a
+/// warning printed to stderr.
+pub fn load_custom_themes() -> HashMap<String, crate::palette::UiTheme> {
+    let mut themes = HashMap::new();
+    let dir = match themes_dir() {
+        Some(d) => d,
+        None => return themes,
+    };
+    let entries = match fs::read_dir(&dir) {
+        Ok(e) => e,
+        Err(_) => return themes,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().is_none_or(|ext| ext != "json") {
+            continue;
+        }
+        let stem = path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("unknown");
+        match fs::read_to_string(&path) {
+            Ok(content) => match serde_json::from_str::<UiThemeCustom>(&content) {
+                Ok(ct) => {
+                    let ui_theme = ct.to_ui_theme();
+                    themes.insert(stem.to_string(), ui_theme);
+                }
+                Err(e) => {
+                    eprintln!(
+                        "[custom_theme] skipping {}: invalid JSON ({e})",
+                        path.display()
+                    );
+                }
+            },
+            Err(e) => {
+                eprintln!(
+                    "[custom_theme] skipping {}: cannot read ({e})",
+                    path.display()
+                );
+            }
+        }
+    }
+    themes
+}
+
+/// Persist a custom theme to `~/.codewhale/themes/<name>.json`. Uses
+/// atomic write (temp file + rename) to prevent corruption on crash.
+#[allow(dead_code)]
+pub fn save_custom_theme(name: &str, custom: &UiThemeCustom) -> std::io::Result<PathBuf> {
+    let dir = ensure_themes_dir()?;
+    let path = dir.join(format!("{name}.json"));
+    let tmp = dir.join(format!(".{name}.json.tmp"));
+    let json = serde_json::to_string_pretty(custom)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+    fs::write(&tmp, json)?;
+    fs::rename(&tmp, &path)?;
+    Ok(path)
+}
+
+/// Delete a custom theme file from disk.
+pub fn delete_custom_theme(name: &str) -> std::io::Result<()> {
+    let dir = ensure_themes_dir()?;
+    let path = dir.join(format!("{name}.json"));
+    if path.exists() {
+        fs::remove_file(&path)?;
+    }
+    Ok(())
+}
+
+/// List the base file names (without `.json` extension) of all custom
+/// themes on disk.
+#[allow(dead_code)]
+pub fn list_custom_theme_names() -> Vec<String> {
+    let dir = match themes_dir() {
+        Some(d) => d,
+        None => return Vec::new(),
+    };
+    let entries = match fs::read_dir(&dir) {
+        Ok(e) => e,
+        Err(_) => return Vec::new(),
+    };
+    entries
+        .flatten()
+        .filter_map(|e| {
+            let path = e.path();
+            if path.extension().is_some_and(|ext| ext == "json") {
+                path.file_stem()
+                    .and_then(|s| s.to_str())
+                    .map(|s| s.to_string())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hex_to_color_round_trips() {
+        let cases = [
+            ("#0A1120", "#0a1120"),
+            ("#F6F2E8", "#f6f2e8"),
+            ("#aabbcc", "#aabbcc"),
+            ("AABBCC", "#aabbcc"),
+            ("#000000", "#000000"),
+            ("#FFFFFF", "#ffffff"),
+        ];
+        for (input, expected) in cases {
+            let color = hex_to_color(input).expect("valid hex");
+            let back = color_to_hex(color);
+            assert_eq!(back.to_ascii_lowercase(), expected);
+        }
+    }
+
+    #[test]
+    fn hex_to_color_rejects_bad_input() {
+        assert!(hex_to_color("").is_none());
+        assert!(hex_to_color("#ZZZZZZ").is_none());
+        assert!(hex_to_color("#12345").is_none());
+        assert!(hex_to_color("#1234567").is_none());
+        assert!(hex_to_color("not-a-colour").is_none());
+    }
+
+    #[test]
+    fn parse_mode_recognises_all_variants() {
+        assert_eq!(parse_mode("dark"), PaletteMode::Dark);
+        assert_eq!(parse_mode("light"), PaletteMode::Light);
+        assert_eq!(parse_mode("grayscale"), PaletteMode::Grayscale);
+        assert_eq!(parse_mode("grey"), PaletteMode::Grayscale);
+        assert_eq!(parse_mode("solarized-light"), PaletteMode::SolarizedLight);
+        assert_eq!(parse_mode("solarized"), PaletteMode::SolarizedLight);
+    }
+
+    #[test]
+    fn parse_mode_unknown_falls_back_to_dark() {
+        assert_eq!(parse_mode("mystery"), PaletteMode::Dark);
+        assert_eq!(parse_mode(""), PaletteMode::Dark);
+    }
+
+    #[test]
+    fn ui_theme_custom_round_trips() {
+        use crate::palette::DRACULA_UI_THEME;
+        let custom = UiThemeCustom::from_ui_theme(&DRACULA_UI_THEME, "test-dracula".to_string());
+        let round_tripped = custom.to_ui_theme();
+        // The name::&'static str is leaked so it won't match == exactly;
+        // check the mode and a few key colours instead.
+        assert_eq!(round_tripped.mode, DRACULA_UI_THEME.mode);
+        assert_eq!(round_tripped.surface_bg, DRACULA_UI_THEME.surface_bg);
+        assert_eq!(round_tripped.text_body, DRACULA_UI_THEME.text_body);
+        assert_eq!(
+            round_tripped.accent_primary,
+            DRACULA_UI_THEME.accent_primary
+        );
+    }
+
+    #[test]
+    fn partial_json_fills_defaults() {
+        let json = r##"{"name": "minimal", "surface_bg": "#ff0000"}"##;
+        let ct: UiThemeCustom = serde_json::from_str(json).unwrap();
+        assert_eq!(ct.name, "minimal");
+        assert_eq!(ct.surface_bg, "#ff0000");
+        // Unspecified fields get Whale dark defaults
+        assert_eq!(ct.text_body, color_to_hex(UI_THEME.text_body));
+        assert_eq!(ct.accent_primary, color_to_hex(UI_THEME.accent_primary));
+    }
+}

--- a/crates/tui/src/localization.rs
+++ b/crates/tui/src/localization.rs
@@ -288,6 +288,8 @@ pub enum MessageId {
     CmdNetworkDescription,
     CmdNoteDescription,
     CmdThemeDescription,
+    CmdThemeDescribe,
+    CmdThemeSave,
     CmdProviderDescription,
     CmdQueueDescription,
     CmdRecallDescription,
@@ -1031,6 +1033,12 @@ fn english(id: MessageId) -> &'static str {
         MessageId::CmdNetworkDescription => "Manage network allow and deny rules",
         MessageId::CmdNoteDescription => "Add, list, edit, or remove workspace notes",
         MessageId::CmdThemeDescription => "Switch theme or open the theme picker",
+        MessageId::CmdThemeDescribe => {
+            "Generate a custom theme from a natural-language description"
+        }
+        MessageId::CmdThemeSave => {
+            "Save the most recently generated theme JSON to disk and register it"
+        }
         MessageId::CmdProviderDescription => {
             "Switch or view the active LLM backend (deepseek | nvidia-nim | ollama)"
         }
@@ -1439,6 +1447,8 @@ fn vietnamese(id: MessageId) -> Option<&'static str> {
             "Thêm, liệt kê, sửa hoặc xóa ghi chú trong không gian làm việc"
         }
         MessageId::CmdThemeDescription => "Chuyển đổi giao diện hoặc mở bảng chọn giao diện",
+        MessageId::CmdThemeDescribe => "Tạo giao diện tùy chỉnh từ mô tả ngôn ngữ tự nhiên",
+        MessageId::CmdThemeSave => "Lưu JSON giao diện được tạo gần đây nhất vào đĩa và đăng ký",
         MessageId::CmdProviderDescription => {
             "Chuyển đổi hoặc xem backend LLM đang hoạt động (deepseek | nvidia-nim | ollama)"
         }
@@ -1874,6 +1884,8 @@ fn japanese(id: MessageId) -> Option<&'static str> {
         MessageId::CmdThemeDescription => {
             "テーマを切り替え（ダーク/ライト/グレースケール/システム）"
         }
+        MessageId::CmdThemeDescribe => "自然言語の説明からカスタムテーマを生成",
+        MessageId::CmdThemeSave => "最近生成されたテーマJSONをディスクに保存して登録",
         MessageId::CmdProviderDescription => {
             "現在の LLM バックエンドを切り替え・確認（deepseek | nvidia-nim | ollama）"
         }
@@ -2249,6 +2261,8 @@ fn chinese_simplified(id: MessageId) -> Option<&'static str> {
         MessageId::CmdNetworkDescription => "管理网络允许和拒绝规则",
         MessageId::CmdNoteDescription => "添加、列出、编辑或删除工作区笔记",
         MessageId::CmdThemeDescription => "切换主题：深色、浅色、灰度或系统",
+        MessageId::CmdThemeDescribe => "用自然语言描述生成自定义主题",
+        MessageId::CmdThemeSave => "保存最近生成的主题JSON到磁盘并注册",
         MessageId::CmdProviderDescription => {
             "切换或查看当前 LLM 后端（deepseek | nvidia-nim | ollama）"
         }
@@ -2610,6 +2624,12 @@ fn portuguese_brazil(id: MessageId) -> Option<&'static str> {
         MessageId::CmdNetworkDescription => "Gerenciar regras de rede permitidas e bloqueadas",
         MessageId::CmdNoteDescription => "Adicionar, listar, editar ou remover notas do workspace",
         MessageId::CmdThemeDescription => "Alternar tema: escuro, claro, tons de cinza ou sistema",
+        MessageId::CmdThemeDescribe => {
+            "Gerar um tema personalizado a partir de uma descrição em linguagem natural"
+        }
+        MessageId::CmdThemeSave => {
+            "Salvar o JSON do tema gerado mais recentemente no disco e registrá-lo"
+        }
         MessageId::CmdProviderDescription => {
             "Trocar ou exibir o backend LLM ativo (deepseek | nvidia-nim | ollama)"
         }
@@ -3035,6 +3055,12 @@ fn spanish_latin_america(id: MessageId) -> Option<&'static str> {
             "Agregar nota al archivo persistente (.codewhale/notes.md)"
         }
         MessageId::CmdThemeDescription => "Alternar entre tema claro y oscuro",
+        MessageId::CmdThemeDescribe => {
+            "Generar un tema personalizado a partir de una descripción en lenguaje natural"
+        }
+        MessageId::CmdThemeSave => {
+            "Guardar el JSON del tema generado más recientemente en el disco y registrarlo"
+        }
         MessageId::CmdProviderDescription => {
             "Cambiar o mostrar el backend LLM activo (deepseek | nvidia-nim | ollama)"
         }

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -30,6 +30,7 @@ mod config;
 mod config_ui;
 mod core;
 mod cost_status;
+mod custom_theme;
 mod cycle_manager;
 mod deepseek_theme;
 mod dependencies;

--- a/crates/tui/src/palette.rs
+++ b/crates/tui/src/palette.rs
@@ -1248,7 +1248,12 @@ pub const MATRIX_UI_THEME: UiTheme = UiTheme {
 /// Stable identifiers for the named themes the user can select. `System`
 /// defers to `PaletteMode::detect()` (terminal-driven dark/light). Each
 /// dark/light id resolves to a single fixed `UiTheme`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+///
+/// `Custom(String)` carries the file-name stem of a user-defined theme
+/// stored under `~/.codewhale/themes/<name>.json`. The resolved `UiTheme`
+/// is fetched from the global `CUSTOM_THEMES` registry, which is populated
+/// at app startup by `load_custom_themes()`.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ThemeId {
     System,
     Terminal,
@@ -1262,88 +1267,150 @@ pub enum ThemeId {
     Claude,
     Matrix,
     SolarizedLight,
+    /// User-defined custom theme persisted under `~/.codewhale/themes/<name>.json`.
+    Custom(String),
+}
+
+/// In-memory registry of loaded custom themes. Key is the theme's
+/// file-name stem (e.g. `"amber-library"`). Populated at startup by
+/// `palette::load_custom_themes()` and kept in sync by the install/remove
+/// helpers.
+static CUSTOM_THEMES: std::sync::RwLock<Option<std::collections::HashMap<String, UiTheme>>> =
+    std::sync::RwLock::new(None);
+
+/// Seed the `CUSTOM_THEMES` registry from disk. Called once during app
+/// initialisation. Any theme files that fail to parse are skipped with
+/// a warning on stderr.
+pub fn load_custom_themes() {
+    let themes = crate::custom_theme::load_custom_themes();
+    if let Ok(mut guard) = CUSTOM_THEMES.write() {
+        *guard = Some(themes);
+    }
+}
+
+/// Install a custom theme into the in-memory registry. Does NOT persist to
+/// disk (call `crate::custom_theme::save_custom_theme()` first if you want
+/// the theme to survive restarts).
+#[allow(dead_code)]
+pub fn register_custom_theme(name: &str, ui_theme: UiTheme) {
+    if let Ok(mut guard) = CUSTOM_THEMES.write() {
+        let map = guard.get_or_insert_with(std::collections::HashMap::new);
+        map.insert(name.to_string(), ui_theme);
+    }
+}
+
+/// Remove a custom theme from the in-memory registry. Does NOT delete the
+/// file on disk.
+pub fn unregister_custom_theme(name: &str) {
+    if let Ok(mut guard) = CUSTOM_THEMES.write()
+        && let Some(ref mut map) = *guard
+    {
+        map.remove(name);
+    }
 }
 
 impl ThemeId {
     /// Parse a settings string (`"system"`, `"dark"`, `"catppuccin-mocha"`, …).
+    /// Also checks the custom-theme registry so user-defined themes are
+    /// selectable from config or `/theme <name>`.
     /// Accepts a few aliases (`"whale"` for dark, `"light"` for whale-light)
     /// so existing config files keep working. Case-insensitive.
     #[must_use]
     pub fn from_name(value: &str) -> Option<Self> {
-        match normalize_theme_name(value)? {
-            "system" => Some(Self::System),
-            "terminal" => Some(Self::Terminal),
-            "dark" => Some(Self::Whale),
-            "light" => Some(Self::WhaleLight),
-            "grayscale" => Some(Self::Grayscale),
-            "catppuccin-mocha" => Some(Self::CatppuccinMocha),
-            "tokyo-night" => Some(Self::TokyoNight),
-            "dracula" => Some(Self::Dracula),
-            "gruvbox-dark" => Some(Self::GruvboxDark),
-            "claude" => Some(Self::Claude),
-            "matrix" => Some(Self::Matrix),
-            "solarized-light" => Some(Self::SolarizedLight),
-            _ => None,
+        // Try built-in names first
+        if let Some(builtin) = normalize_theme_name(value) {
+            return Some(match builtin {
+                "system" => Self::System,
+                "terminal" => Self::Terminal,
+                "dark" => Self::Whale,
+                "light" => Self::WhaleLight,
+                "grayscale" => Self::Grayscale,
+                "catppuccin-mocha" => Self::CatppuccinMocha,
+                "tokyo-night" => Self::TokyoNight,
+                "dracula" => Self::Dracula,
+                "gruvbox-dark" => Self::GruvboxDark,
+                "claude" => Self::Claude,
+                "matrix" => Self::Matrix,
+                "solarized-light" => Self::SolarizedLight,
+                _ => return None,
+            });
         }
+        // Check the custom-theme registry
+        let name = value.trim().to_ascii_lowercase();
+        if let Ok(guard) = CUSTOM_THEMES.read()
+            && let Some(ref map) = *guard
+            && map.contains_key(&name)
+        {
+            return Some(Self::Custom(name));
+        }
+        None
     }
 
     /// Canonical settings string (lowercase, dash-separated). Round-trips
-    /// through `from_name`.
+    /// through `from_name`. For custom themes, returns the file-name stem.
     #[must_use]
-    pub const fn name(self) -> &'static str {
+    pub fn name(&self) -> String {
         match self {
-            Self::System => "system",
-            Self::Terminal => "terminal",
-            Self::Whale => "dark",
-            Self::WhaleLight => "light",
-            Self::Grayscale => "grayscale",
-            Self::CatppuccinMocha => "catppuccin-mocha",
-            Self::TokyoNight => "tokyo-night",
-            Self::Dracula => "dracula",
-            Self::GruvboxDark => "gruvbox-dark",
-            Self::Claude => "claude",
-            Self::Matrix => "matrix",
-            Self::SolarizedLight => "solarized-light",
+            Self::System => "system".to_string(),
+            Self::Terminal => "terminal".to_string(),
+            Self::Whale => "dark".to_string(),
+            Self::WhaleLight => "light".to_string(),
+            Self::Grayscale => "grayscale".to_string(),
+            Self::CatppuccinMocha => "catppuccin-mocha".to_string(),
+            Self::TokyoNight => "tokyo-night".to_string(),
+            Self::Dracula => "dracula".to_string(),
+            Self::GruvboxDark => "gruvbox-dark".to_string(),
+            Self::Claude => "claude".to_string(),
+            Self::Matrix => "matrix".to_string(),
+            Self::SolarizedLight => "solarized-light".to_string(),
+            Self::Custom(n) => n.clone(),
         }
     }
 
-    /// Human-readable label for picker rows.
+    /// Human-readable label for picker rows. Custom themes are prefixed
+    /// with a pencil glyph so the user can tell them apart from built-in
+    /// presets.
     #[must_use]
-    pub const fn display_name(self) -> &'static str {
+    pub fn display_name(&self) -> String {
         match self {
-            Self::System => "System",
-            Self::Terminal => "Terminal",
-            Self::Whale => "Whale (Dark)",
-            Self::WhaleLight => "Whale Light",
-            Self::Grayscale => "Grayscale",
-            Self::CatppuccinMocha => "Catppuccin Mocha",
-            Self::TokyoNight => "Tokyo Night",
-            Self::Dracula => "Dracula",
-            Self::GruvboxDark => "Gruvbox Dark",
-            Self::Claude => "Claude",
-            Self::Matrix => "Matrix",
-            Self::SolarizedLight => "Solarized Light",
+            Self::System => "System".to_string(),
+            Self::Terminal => "Terminal".to_string(),
+            Self::Whale => "Whale (Dark)".to_string(),
+            Self::WhaleLight => "Whale Light".to_string(),
+            Self::Grayscale => "Grayscale".to_string(),
+            Self::CatppuccinMocha => "Catppuccin Mocha".to_string(),
+            Self::TokyoNight => "Tokyo Night".to_string(),
+            Self::Dracula => "Dracula".to_string(),
+            Self::GruvboxDark => "Gruvbox Dark".to_string(),
+            Self::Claude => "Claude".to_string(),
+            Self::Matrix => "Matrix".to_string(),
+            Self::SolarizedLight => "Solarized Light".to_string(),
+            Self::Custom(n) => format!("✎ {}", n),
         }
     }
 
     /// Short tagline for picker rows.
     #[must_use]
-    pub const fn tagline(self) -> &'static str {
+    pub fn tagline(&self) -> String {
         match self {
-            Self::System => "Follow terminal background (COLORFGBG / macOS appearance)",
-            Self::Terminal => "Inherit terminal colors fully (transparent surfaces, ANSI accents)",
-            Self::Whale => "Whale dark — deep navy & gold",
-            Self::WhaleLight => "DeepSeek light, paper-ish",
-            Self::Grayscale => "Color-minimal high contrast",
-            Self::CatppuccinMocha => "Soft pastels on warm dark",
-            Self::TokyoNight => "Deep blue/violet night palette",
-            Self::Dracula => "Classic high-contrast purple",
-            Self::GruvboxDark => "Vintage warm earth tones",
-            Self::Claude => "Warm navy & coral",
-            Self::Matrix => "The Matrix films inspired theme",
+            Self::System => "Follow terminal background (COLORFGBG / macOS appearance)".to_string(),
+            Self::Terminal => {
+                "Inherit terminal colors fully (transparent surfaces, ANSI accents)".to_string()
+            }
+            Self::Whale => "Whale dark — deep navy & gold".to_string(),
+            Self::WhaleLight => "DeepSeek light, paper-ish".to_string(),
+            Self::Grayscale => "Color-minimal high contrast".to_string(),
+            Self::CatppuccinMocha => "Soft pastels on warm dark".to_string(),
+            Self::TokyoNight => "Deep blue/violet night palette".to_string(),
+            Self::Dracula => "Classic high-contrast purple".to_string(),
+            Self::GruvboxDark => "Vintage warm earth tones".to_string(),
+            Self::Claude => "Warm navy & coral".to_string(),
+            Self::Matrix => "The Matrix films inspired theme".to_string(),
             Self::SolarizedLight => {
                 "Solarized light — Light, calming palette on warm ivory — easy on the eyes"
+                    .to_string()
             }
+            Self::Custom(_) => "User-defined custom theme [Del to remove]".to_string(),
         }
     }
 
@@ -1352,7 +1419,7 @@ impl ThemeId {
     /// dark/light theme — callers that want to live-track terminal background
     /// changes need to re-invoke this.
     #[must_use]
-    pub fn ui_theme(self) -> UiTheme {
+    pub fn ui_theme(&self) -> UiTheme {
         match self {
             Self::System => UiTheme::detect(),
             Self::Terminal => TERMINAL_UI_THEME,
@@ -1366,12 +1433,28 @@ impl ThemeId {
             Self::Claude => CLAUDE_UI_THEME,
             Self::Matrix => MATRIX_UI_THEME,
             Self::SolarizedLight => SOLARIZED_LIGHT_UI_THEME,
+            Self::Custom(name) => {
+                if let Ok(guard) = CUSTOM_THEMES.read()
+                    && let Some(ref map) = *guard
+                    && let Some(theme) = map.get(name)
+                {
+                    return *theme;
+                }
+                // Fallback: registry not loaded or theme was deleted
+                UI_THEME
+            }
         }
+    }
+
+    /// Returns `true` iff this is a user-defined custom theme (deletable).
+    #[must_use]
+    pub fn is_custom(&self) -> bool {
+        matches!(self, Self::Custom(_))
     }
 }
 
-/// Themes shown in the `/theme` picker, in display order.
-pub const SELECTABLE_THEMES: &[ThemeId] = &[
+/// Built-in themes in display order.
+const BUILTIN_THEME_IDS: &[ThemeId] = &[
     ThemeId::System,
     ThemeId::Terminal,
     ThemeId::Whale,
@@ -1385,6 +1468,29 @@ pub const SELECTABLE_THEMES: &[ThemeId] = &[
     ThemeId::Matrix,
     ThemeId::SolarizedLight,
 ];
+
+/// Returns the complete list of selectable theme IDs for the picker:
+/// built-in presets followed by any custom themes loaded from disk.
+/// Caches the result so repeated calls during the same frame do not
+/// re-scan the custom-theme directory.
+pub fn selectable_themes() -> Vec<ThemeId> {
+    let mut out: Vec<ThemeId> = BUILTIN_THEME_IDS.to_vec();
+    if let Ok(guard) = CUSTOM_THEMES.read()
+        && let Some(ref map) = *guard
+    {
+        let mut custom_keys: Vec<&String> = map.keys().collect();
+        custom_keys.sort();
+        for key in custom_keys {
+            out.push(ThemeId::Custom(key.clone()));
+        }
+    }
+    out
+}
+
+/// Deprecated: kept for backward-compatibility with existing callers that
+/// expect a static slice. New code should use `selectable_themes()`.
+#[allow(dead_code)]
+pub const SELECTABLE_THEMES: &[ThemeId] = BUILTIN_THEME_IDS;
 
 impl UiTheme {
     #[must_use]
@@ -1404,7 +1510,7 @@ impl UiTheme {
 
     #[must_use]
     pub fn from_setting(value: &str) -> Option<Self> {
-        ThemeId::from_name(value).map(ThemeId::ui_theme)
+        ThemeId::from_name(value).as_ref().map(ThemeId::ui_theme)
     }
 
     #[must_use]
@@ -1654,18 +1760,12 @@ const fn theme_diff_deleted_bg(ui: &UiTheme) -> Color {
 /// stage compiles down to a single load+compare on the hot path.
 #[inline]
 #[must_use]
-pub const fn theme_remap_active(theme: ThemeId) -> bool {
-    matches!(
-        theme,
-        ThemeId::Terminal
-            | ThemeId::CatppuccinMocha
-            | ThemeId::TokyoNight
-            | ThemeId::Dracula
-            | ThemeId::GruvboxDark
-            | ThemeId::Claude
-            | ThemeId::Matrix
-            | ThemeId::SolarizedLight
-    )
+pub fn theme_remap_active(theme: &ThemeId) -> bool {
+    match theme {
+        ThemeId::System | ThemeId::Whale | ThemeId::WhaleLight | ThemeId::Grayscale => false,
+        ThemeId::Custom(_) => true,
+        _ => true,
+    }
 }
 
 /// Remap a foreground color for a community theme preset. Mirrors the
@@ -1680,7 +1780,7 @@ pub const fn theme_remap_active(theme: ThemeId) -> bool {
 /// would see their override silently overwritten by the preset's
 /// surface_bg on every cell remap.
 #[must_use]
-pub fn adapt_fg_for_theme(color: Color, theme: ThemeId, ui: &UiTheme) -> Color {
+pub fn adapt_fg_for_theme(color: Color, theme: &ThemeId, ui: &UiTheme) -> Color {
     if !theme_remap_active(theme) {
         return color;
     }
@@ -1698,7 +1798,7 @@ pub fn adapt_fg_for_theme(color: Color, theme: ThemeId, ui: &UiTheme) -> Color {
     } else if color == TEXT_ACCENT || color == DEEPSEEK_SKY || color == ACCENT_TOOL_LIVE {
         ui.status_working
     } else if color == TEXT_REASONING || color == ACCENT_REASONING_LIVE {
-        if theme == ThemeId::Matrix {
+        if matches!(theme, ThemeId::Matrix) {
             Color::Rgb(0x00, 0x55, 0x00) // #005500
         } else {
             ui.mode_plan
@@ -1721,7 +1821,7 @@ pub fn adapt_fg_for_theme(color: Color, theme: ThemeId, ui: &UiTheme) -> Color {
 /// Remap a background color for a community theme preset. See the
 /// `ui` note on [`adapt_fg_for_theme`] — same contract here.
 #[must_use]
-pub fn adapt_bg_for_theme(color: Color, theme: ThemeId, ui: &UiTheme) -> Color {
+pub fn adapt_bg_for_theme(color: Color, theme: &ThemeId, ui: &UiTheme) -> Color {
     if !theme_remap_active(theme) {
         return color;
     }
@@ -2276,19 +2376,19 @@ mod tests {
         assert_eq!(TERMINAL_UI_THEME.text_body, Color::Reset);
 
         assert_eq!(
-            adapt_bg_for_theme(DEEPSEEK_INK, ThemeId::Terminal, &TERMINAL_UI_THEME),
+            adapt_bg_for_theme(DEEPSEEK_INK, &ThemeId::Terminal, &TERMINAL_UI_THEME),
             Color::Reset
         );
         assert_eq!(
-            adapt_bg_for_theme(DIFF_ADDED_BG, ThemeId::Terminal, &TERMINAL_UI_THEME),
+            adapt_bg_for_theme(DIFF_ADDED_BG, &ThemeId::Terminal, &TERMINAL_UI_THEME),
             Color::Reset
         );
         assert_eq!(
-            adapt_fg_for_theme(TEXT_BODY, ThemeId::Terminal, &TERMINAL_UI_THEME),
+            adapt_fg_for_theme(TEXT_BODY, &ThemeId::Terminal, &TERMINAL_UI_THEME),
             Color::Reset
         );
         assert_eq!(
-            adapt_fg_for_theme(DIFF_ADDED, ThemeId::Terminal, &TERMINAL_UI_THEME),
+            adapt_fg_for_theme(DIFF_ADDED, &ThemeId::Terminal, &TERMINAL_UI_THEME),
             Color::Green
         );
     }

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -153,14 +153,26 @@ impl TuiPrefs {
     /// Returns `Err` if an unrecognised `theme` value is found so callers can
     /// surface a helpful message rather than silently ignoring a typo.
     pub fn validate(&mut self) -> Result<()> {
-        let theme = self.theme.trim().to_ascii_lowercase();
-        let Some(theme) = normalize_theme_name(&theme) else {
-            anyhow::bail!(
-                "Invalid tui.toml theme '{}': expected system, dark, light, grayscale, catppuccin-mocha, tokyo-night, dracula, gruvbox-dark, or solarized-light.",
-                self.theme
-            );
-        };
-        self.theme = theme.to_string();
+        let theme_key = self.theme.trim().to_ascii_lowercase();
+        if let Some(canonical) = normalize_theme_name(&theme_key) {
+            self.theme = canonical.to_string();
+        } else {
+            // Allow custom theme names that aren't in the built-in list.
+            // At this point custom themes haven't been loaded from disk yet,
+            // so we accept any plausible name. If the theme turns out not to
+            // exist, `ThemeId::from_name()` will fall back to System at
+            // app init and the user sees the default theme.
+            if theme_key.is_empty() || theme_key.len() > 64 {
+                anyhow::bail!(
+                    "Invalid tui.toml theme '{}': expected a known theme name \
+                     (system, dark, light, grayscale, catppuccin-mocha, \
+                     tokyo-night, dracula, gruvbox-dark, claude, matrix, \
+                     solarized-light) or a custom theme name (1-64 characters).",
+                    self.theme
+                );
+            }
+            self.theme = theme_key;
+        }
         Ok(())
     }
 }
@@ -987,8 +999,10 @@ fn normalize_synchronized_output(value: &str) -> &str {
     }
 }
 
-fn normalize_settings_theme(value: &str) -> &'static str {
-    normalize_theme_name(value).unwrap_or("system")
+fn normalize_settings_theme(value: &str) -> String {
+    normalize_theme_name(value)
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| value.trim().to_ascii_lowercase())
 }
 
 /// Returns `true` when the active terminal is Ptyxis (the new default
@@ -2138,18 +2152,30 @@ mod tests {
     }
 
     #[test]
-    fn tui_prefs_validate_rejects_unknown_theme() {
+    fn tui_prefs_validate_accepts_unknown_theme_as_custom() {
+        // Custom theme names (not matching any built-in) are now accepted
+        // as plausible custom theme names; validation only rejects empty
+        // or excessively long names.
         let mut prefs = TuiPrefs {
             theme: "nord".to_string(),
             ..TuiPrefs::default()
         };
-        let err = prefs.validate().expect_err("nord is not a valid theme");
+        prefs
+            .validate()
+            .expect("custom theme names should be accepted");
+        assert_eq!(prefs.theme, "nord");
+    }
+
+    #[test]
+    fn tui_prefs_validate_rejects_overly_long_theme_name() {
+        let mut prefs = TuiPrefs {
+            theme: "a".repeat(65),
+            ..TuiPrefs::default()
+        };
+        let err = prefs
+            .validate()
+            .expect_err("overly long theme name should be rejected");
         assert!(err.to_string().contains("Invalid tui.toml theme"));
-        assert!(
-            err.to_string()
-                .contains("expected system, dark, light, grayscale")
-        );
-        assert!(err.to_string().contains("solarized-light"));
     }
 
     #[test]

--- a/crates/tui/src/tui/color_compat.rs
+++ b/crates/tui/src/tui/color_compat.rs
@@ -101,11 +101,12 @@ impl<W: Write> Backend for ColorCompatBackend<W> {
         let adapted = content
             .map(|(x, y, cell)| {
                 let mut cell = cell.clone();
+                let theme_id = self.theme_id.clone();
                 adapt_cell_colors(
                     &mut cell,
                     self.depth,
                     self.palette_mode,
-                    self.theme_id,
+                    &theme_id,
                     &self.active_ui_theme,
                 );
                 (x, y, cell)
@@ -253,7 +254,7 @@ fn adapt_cell_colors(
     cell: &mut Cell,
     depth: ColorDepth,
     palette_mode: PaletteMode,
-    theme_id: ThemeId,
+    theme_id: &ThemeId,
     ui_theme: &UiTheme,
 ) {
     // Stage 1: community-theme remap (dark palette → preset slots). No-op
@@ -332,7 +333,7 @@ mod tests {
             &mut cell,
             ColorDepth::Ansi256,
             PaletteMode::Dark,
-            ThemeId::System,
+            &ThemeId::System,
             &palette::UI_THEME,
         );
 
@@ -350,7 +351,7 @@ mod tests {
             &mut cell,
             ColorDepth::TrueColor,
             PaletteMode::Dark,
-            ThemeId::System,
+            &ThemeId::System,
             &palette::UI_THEME,
         );
 
@@ -385,7 +386,7 @@ mod tests {
             &mut cell,
             ColorDepth::TrueColor,
             PaletteMode::Light,
-            ThemeId::WhaleLight,
+            &ThemeId::WhaleLight,
             &palette::LIGHT_UI_THEME,
         );
 
@@ -403,7 +404,7 @@ mod tests {
             &mut cell,
             ColorDepth::TrueColor,
             PaletteMode::Grayscale,
-            ThemeId::Grayscale,
+            &ThemeId::Grayscale,
             &palette::GRAYSCALE_UI_THEME,
         );
 
@@ -424,7 +425,7 @@ mod tests {
             &mut cell,
             ColorDepth::TrueColor,
             PaletteMode::Dark,
-            ThemeId::TokyoNight,
+            &ThemeId::TokyoNight,
             &active,
         );
 

--- a/crates/tui/src/tui/theme_picker.rs
+++ b/crates/tui/src/tui/theme_picker.rs
@@ -1,13 +1,16 @@
 //! `/theme` picker with live preview.
 //!
 //! Modeled after `feedback_picker`. Differences:
-//! - The option list comes from `palette::SELECTABLE_THEMES`.
+//! - The option list comes from `palette::selectable_themes()` (built-in +
+//!   custom themes loaded from `~/.codewhale/themes/`).
 //! - Up/Down emit a `ConfigUpdated{persist:false}` so the host swaps
 //!   `app.ui_theme` immediately and the whole TUI re-paints under the
 //!   modal — the user sees the candidate theme before committing.
 //! - Enter persists (`persist:true`); Esc emits one more
 //!   `ConfigUpdated{persist:false}` to restore the original theme name
 //!   that was active when the picker opened.
+//! - Delete (or `Backspace`) on a custom theme row deletes the theme
+//!   file from disk and removes the entry from the picker list.
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::{
@@ -18,10 +21,13 @@ use ratatui::{
     widgets::{Block, Borders, Clear, Padding, Paragraph, Widget},
 };
 
-use crate::palette::{SELECTABLE_THEMES, ThemeId, UiTheme};
+use crate::palette::{ThemeId, UiTheme, selectable_themes};
 use crate::tui::views::{ModalKind, ModalView, ViewAction, ViewEvent};
 
 pub struct ThemePickerView {
+    /// The current theme list (built-in + custom). Re-fetched when the
+    /// picker is opened so freshly-installed custom themes are visible.
+    themes: Vec<ThemeId>,
     selected: usize,
     /// Settings name of the theme that was active when the picker opened.
     /// Used to revert on Esc.
@@ -35,13 +41,15 @@ pub struct ThemePickerView {
 impl ThemePickerView {
     #[must_use]
     pub fn new(original_name: String) -> Self {
+        let themes = selectable_themes();
         // If the persisted name matches one of the entries, start there;
         // otherwise fall back to "System" so the cursor lands on a valid row.
-        let selected = SELECTABLE_THEMES
+        let selected = themes
             .iter()
             .position(|id| id.name() == original_name.trim().to_ascii_lowercase())
             .unwrap_or(0);
         Self {
+            themes,
             selected,
             original_name,
             system_ui_theme: UiTheme::detect(),
@@ -49,15 +57,15 @@ impl ThemePickerView {
     }
 
     fn current(&self) -> ThemeId {
-        SELECTABLE_THEMES
+        self.themes
             .get(self.selected)
-            .copied()
+            .cloned()
             .unwrap_or(ThemeId::System)
     }
 
     /// Resolve a theme to a `UiTheme`, returning the cached `System`
     /// resolution to avoid repeated env-var reads inside `render`.
-    fn ui_theme_for(&self, id: ThemeId) -> UiTheme {
+    fn ui_theme_for(&self, id: &ThemeId) -> UiTheme {
         if matches!(id, ThemeId::System) {
             self.system_ui_theme
         } else {
@@ -68,7 +76,7 @@ impl ThemePickerView {
     fn preview_event(&self) -> ViewAction {
         ViewAction::Emit(ViewEvent::ConfigUpdated {
             key: "theme".to_string(),
-            value: self.current().name().to_string(),
+            value: self.current().name(),
             persist: false,
         })
     }
@@ -76,7 +84,7 @@ impl ThemePickerView {
     fn commit_event(&self) -> ViewAction {
         ViewAction::EmitAndClose(ViewEvent::ConfigUpdated {
             key: "theme".to_string(),
-            value: self.current().name().to_string(),
+            value: self.current().name(),
             persist: true,
         })
     }
@@ -90,11 +98,40 @@ impl ThemePickerView {
     }
 
     fn move_up(&mut self) {
-        self.selected = (self.selected + SELECTABLE_THEMES.len() - 1) % SELECTABLE_THEMES.len();
+        self.selected = (self.selected + self.themes.len() - 1) % self.themes.len();
     }
 
     fn move_down(&mut self) {
-        self.selected = (self.selected + 1) % SELECTABLE_THEMES.len();
+        self.selected = (self.selected + 1) % self.themes.len();
+    }
+
+    /// Delete the currently-selected custom theme (both from disk and the
+    /// in-memory registry) and remove its row from the picker.
+    fn delete_current_custom_theme(&mut self) -> ViewAction {
+        let current = self.current();
+        let ThemeId::Custom(ref name) = current else {
+            return ViewAction::None;
+        };
+        let name = name.clone();
+        // Delete from disk
+        if let Err(e) = crate::custom_theme::delete_custom_theme(&name) {
+            return ViewAction::Emit(ViewEvent::ConfigUpdated {
+                key: "theme".to_string(),
+                value: format!("Failed to delete custom theme '{name}': {e}"),
+                persist: false,
+            });
+        }
+        // Remove from registry
+        crate::palette::unregister_custom_theme(&name);
+
+        // Remove from the local list
+        self.themes.remove(self.selected);
+        if self.selected >= self.themes.len() && !self.themes.is_empty() {
+            self.selected = self.themes.len() - 1;
+        }
+
+        // Preview whatever is now selected
+        self.preview_event()
     }
 }
 
@@ -124,8 +161,16 @@ impl ModalView for ThemePickerView {
                 self.preview_event()
             }
             KeyCode::End => {
-                self.selected = SELECTABLE_THEMES.len().saturating_sub(1);
+                self.selected = self.themes.len().saturating_sub(1);
                 self.preview_event()
+            }
+            // Delete key or Backspace on a custom-theme row removes it
+            KeyCode::Delete | KeyCode::Backspace
+                if self.current().is_custom()
+                    && !key.modifiers.contains(KeyModifiers::CONTROL)
+                    && !key.modifiers.contains(KeyModifiers::ALT) =>
+            {
+                self.delete_current_custom_theme()
             }
             // Number shortcuts: '1'..='9' jump to that row (1-indexed).
             // '0' is rejected explicitly — saturating_sub would otherwise
@@ -136,7 +181,7 @@ impl ModalView for ThemePickerView {
                     && !key.modifiers.contains(KeyModifiers::ALT) =>
             {
                 let idx = (c as usize) - ('1' as usize);
-                if idx < SELECTABLE_THEMES.len() {
+                if idx < self.themes.len() {
                     self.selected = idx;
                     self.preview_event()
                 } else {
@@ -148,6 +193,7 @@ impl ModalView for ThemePickerView {
     }
 
     fn render(&self, area: Rect, buf: &mut Buffer) {
+        let row_count = self.themes.len();
         // Modal must always fit inside `area`. The old `.max(52) / .max(10)`
         // floors could produce dimensions larger than the available area on
         // very small terminals (or split-pane setups), which then made the
@@ -155,12 +201,10 @@ impl ModalView for ThemePickerView {
         // soft-preferred size and clamp it strictly to `area`.
         let popup_width = 78u16.min(area.width.saturating_sub(4));
         // 1 title + 1 spacer + N rows + spacer + bottom hint
-        let needed_height = (SELECTABLE_THEMES.len() as u16).saturating_add(9);
+        let needed_height = (row_count as u16).saturating_add(9);
         let popup_height = needed_height.min(area.height.saturating_sub(4));
 
         if popup_width == 0 || popup_height == 0 {
-            // Nothing sensible to draw — the host's caller has already
-            // cleared the area, so we just return.
             return;
         }
 
@@ -171,14 +215,17 @@ impl ModalView for ThemePickerView {
             height: popup_height,
         };
 
-        // The live theme has already been swapped under us via ConfigUpdated,
-        // so we pull the *current* preview's UiTheme from the cursor row to
-        // skin the modal chrome. That way the popup itself shifts color as
-        // the cursor moves, matching what the background will look like
-        // after Enter.
-        let live = self.ui_theme_for(self.current());
+        let current = self.current();
+        let live = self.ui_theme_for(&current);
 
         Clear.render(popup_area, buf);
+
+        // Bottom hint: show [Del] affordance when the cursor is on a custom theme row
+        let del_hint = if current.is_custom() {
+            Span::styled(" Del ", Style::default().fg(live.error_fg))
+        } else {
+            Span::raw("")
+        };
 
         let block = Block::default()
             .title(Line::from(Span::styled(
@@ -193,7 +240,9 @@ impl ModalView for ThemePickerView {
                 Span::styled(" Enter ", Style::default().fg(live.text_muted)),
                 Span::raw("save "),
                 Span::styled(" Esc ", Style::default().fg(live.text_muted)),
-                Span::raw("revert "),
+                Span::raw("revert"),
+                del_hint,
+                Span::raw("remove"),
             ]))
             .borders(Borders::ALL)
             .border_style(Style::default().fg(live.border))
@@ -203,15 +252,14 @@ impl ModalView for ThemePickerView {
         let inner = block.inner(popup_area);
         block.render(popup_area, buf);
 
-        let mut lines: Vec<Line> = Vec::with_capacity(SELECTABLE_THEMES.len() + 5);
+        let mut lines: Vec<Line> = Vec::with_capacity(row_count + 5);
         lines.push(Line::from(Span::styled(
             "Pick a theme — preview is live; Enter saves to settings.toml.",
             Style::default().fg(live.text_muted),
         )));
         lines.push(Line::from(""));
 
-        for (idx, id) in SELECTABLE_THEMES.iter().enumerate() {
-            let id = *id;
+        for (idx, id) in self.themes.iter().enumerate() {
             let is_selected = idx == self.selected;
             let row_style = if is_selected {
                 Style::default()
@@ -237,9 +285,8 @@ impl ModalView for ThemePickerView {
             let pointer = if is_selected { "▶" } else { " " };
 
             // 3-cell color swatch per row using the candidate theme's own
-            // accent + panel + border colors so the picker doubles as a
-            // legend. Use the cached resolver so `System` doesn't repeat
-            // `UiTheme::detect()`.
+            // accent + panel + border colors. Use the cached resolver so
+            // `System` doesn't repeat `UiTheme::detect()`.
             let row_theme = self.ui_theme_for(id);
             let swatch = vec![
                 Span::styled("  ", Style::default().bg(row_theme.surface_bg)),
@@ -275,13 +322,13 @@ mod tests {
         KeyEvent::new(code, KeyModifiers::NONE)
     }
 
-    fn selected_name(action: &ViewAction) -> Option<&str> {
+    fn selected_name(action: &ViewAction) -> Option<String> {
         match action {
             ViewAction::Emit(ViewEvent::ConfigUpdated { key, value, .. })
             | ViewAction::EmitAndClose(ViewEvent::ConfigUpdated { key, value, .. })
                 if key == "theme" =>
             {
-                Some(value.as_str())
+                Some(value.clone())
             }
             _ => None,
         }
@@ -311,13 +358,13 @@ mod tests {
     #[test]
     fn arrow_navigation_wraps_at_picker_edges() {
         let mut v = ThemePickerView::new("system".to_string());
-        let last = SELECTABLE_THEMES.last().unwrap();
+        let last = v.themes.last().unwrap().clone();
 
         let action = v.handle_key(key(KeyCode::Up));
         assert_eq!(selected_name(&action), Some(last.name()));
 
         let action = v.handle_key(key(KeyCode::Down));
-        assert_eq!(selected_name(&action), Some(SELECTABLE_THEMES[0].name()));
+        assert_eq!(selected_name(&action), Some(v.themes[0].name()));
     }
 
     #[test]
@@ -385,9 +432,6 @@ mod tests {
 
     #[test]
     fn render_does_not_panic_on_zero_sized_area() {
-        // The picker historically panicked here via .max(W).max(H) floors
-        // that produced dimensions larger than the available area, then
-        // underflowed the centering arithmetic.
         let v = ThemePickerView::new("system".to_string());
         let outer = ratatui::layout::Rect::new(0, 0, 10, 10);
         let area = ratatui::layout::Rect::new(0, 0, 0, 0);
@@ -397,10 +441,16 @@ mod tests {
 
     #[test]
     fn render_does_not_panic_on_tiny_area() {
-        // 20×6 is smaller than every soft floor the picker prefers.
         let v = ThemePickerView::new("system".to_string());
         let area = ratatui::layout::Rect::new(0, 0, 20, 6);
         let mut buf = ratatui::buffer::Buffer::empty(area);
         v.render(area, &mut buf);
+    }
+
+    #[test]
+    fn delete_key_noops_on_builtin_theme() {
+        let mut v = ThemePickerView::new("system".to_string());
+        let action = v.handle_key(key(KeyCode::Delete));
+        assert!(matches!(action, ViewAction::None));
     }
 }

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -399,6 +399,10 @@ pub async fn run_tui(config: &Config, options: TuiOptions) -> Result<()> {
     // can rebuild the API client without restarting the process.
     let mut config = config.clone();
     let config = &mut config;
+    // Load custom themes from ~/.codewhale/themes/ BEFORE building App so
+    // that ThemeId::from_name() can resolve custom theme names during
+    // app construction (ui_theme_from_settings → from_setting → from_name).
+    crate::palette::load_custom_themes();
     let mut app = App::new(options.clone(), config);
     sync_config_provider_from_app(config, &app);
 
@@ -6431,7 +6435,9 @@ fn draw_app_frame_inner(
     full_repaint: bool,
 ) -> Result<()> {
     terminal.backend_mut().set_palette_mode(app.ui_theme.mode);
-    terminal.backend_mut().set_theme(app.theme_id, app.ui_theme);
+    terminal
+        .backend_mut()
+        .set_theme(app.theme_id.clone(), app.ui_theme);
     // DEC 2026 wrapping is on by default but can be turned off for
     // terminals that mishandle it (Ptyxis 50.x + VTE 0.84.x flashes the
     // whole viewport on every wrapped frame instead of deferring as the


### PR DESCRIPTION
## Summary

Implements a complete custom-theme subsystem enabling users to define, preview, save, and delete personal TUI themes that persist across application updates. Custom themes are stored as JSON files under `~/.codewhale/themes/` and loaded at startup alongside the 12 built-in presets.

This PR implements the forward-looking plan described in [#2527](https://github.com/Hmbown/CodeWhale/pull/2527) (sidebar theme-switch fix and theme architecture guide).

> **Merge order:** this PR must be merged after [#2527](https://github.com/Hmbown/CodeWhale/pull/2527). The two branches touch adjacent lines in `theme_picker.rs`, `palette.rs`, `color_compat.rs`, and `ui.rs`. Merging #2527 first ensures a clean linear history with no conflicts in the `ThemeId` type signature changes.

## Motivation

The current theme system supports 12 built-in presets selected from a compile-time `ThemeId` enum. Users with specific visual preferences (accessibility needs, contrast requirements, personal aesthetic, brand alignment) cannot adjust colors beyond picking one of the fixed options. This PR introduces an end-to-end workflow for user-defined themes: describe a theme in natural language, have CodeWhale generate the complete colour definition, preview it live, save it to disk, and manage it alongside built-in presets.

## Usage

### Creating a custom theme

```
/theme-describe A warm amber library theme with dark brown background, cream text, soft gold accents, moderate contrast dark mode
```

Aliases for the same command: `/theme-create`, `/theme-new`, `/theme-generate`.

CodeWhale receives a structured prompt containing the full 40-field `UiTheme` reference alongside the user's description. The AI generates a complete JSON theme definition with all colour slots populated. The user then saves the JSON to `~/.codewhale/themes/<name>.json`, restarts CodeWhale, and the theme appears in the `/theme` picker after the built-in entries, marked with a ✎ prefix.

### Selecting a custom theme

Open the theme picker (`/theme` with no argument), arrow down past the built-in entries, and press Enter on the desired custom theme. The selection is saved to `settings.toml` and persists across sessions.

### Deleting a custom theme

Two paths are provided:

1. **Theme picker Delete key:** in the `/theme` picker, custom theme rows display a `[Del]` affordance in the bottom hint bar. Pressing Delete or Backspace on a highlighted custom theme removes the JSON file from disk, unregisters the theme from the in-memory registry, and removes its row from the picker. Built-in themes ignore the Delete key.

2. **CLI command:** `/theme delete <name>` performs the same operation. If the deleted theme was currently active, the app falls back to the System theme to prevent a blank UI state.

## Architecture

### Storage

Custom themes live as JSON files under `~/.codewhale/themes/<name>.json`. Each file is a complete `UiThemeCustom` definition with all 40 colour fields serialized as hex strings (`"#RRGGBB"`). The `mode` field accepts `dark`, `light`, `grayscale`, or `solarized-light`. Unspecified fields default to the Whale dark palette value, ensuring forward compatibility when future versions add new fields.

### Serialization layer (`custom_theme.rs`, new)

A dedicated `UiThemeCustom` serde struct bridges the JSON representation and the internal `UiTheme`. Every colour field carries a `#[serde(default)]` with a Whale dark palette fallback so partial JSON files remain loadable. The `color_to_hex()` and `hex_to_color()` conversion functions handle `Color::Rgb` round-tripping with graceful fallback for non-RGB variants (`Color::Reset`, named ANSI colors). Atomic file I/O (write to temp file, rename) prevents corruption on crash.

### Runtime loading

At application startup (`ui.rs:run()`), `palette::load_custom_themes()` scans the themes directory and populates a `static CUSTOM_THEMES: RwLock<HashMap<String, UiTheme>>` registry. This call is placed before `App::new()` so custom theme names persisted in `settings.toml` resolve correctly during app construction.

### ThemeId extension

`ThemeId` gains a `Custom(String)` variant carrying the theme's file-name stem. The existing 12 enum variants remain unchanged, preserving all existing match arms. `from_name()` checks the custom registry as a fallback after built-in names. `name()`, `display_name()`, `tagline()`, and `ui_theme()` all handle the `Custom` case. `is_custom()` enables targeted UI affordances (delete hint, pencil prefix).

Since `Custom(String)` prevents `ThemeId` from deriving `Copy`, the following downstream functions were updated to accept `&ThemeId`:

- `palette::theme_remap_active()`, `adapt_fg_for_theme()`, `adapt_bg_for_theme()`
- `color_compat::adapt_cell_colors()` and its test callers
- `color_compat::ColorCompatBackend::draw()` — clones `theme_id` into closure

### Dynamic theme list

The `selectable_themes()` function replaces the static `SELECTABLE_THEMES` constant as the picker's data source. It returns built-in themes followed by custom themes in alphabetical order. The deprecated `SELECTABLE_THEMES` constant is retained for backward compatibility.

### Guided creation flow (`/theme-describe`)

The `theme_describe()` command constructs a structured prompt containing the complete `UiTheme` field reference (all 40 slots grouped by semantic role) alongside the user's natural-language description. The prompt instructs the AI to output only valid JSON with no markdown wrapping, no code fences, and no explanatory text so the response is machine-parseable. The command is routed through `AppAction::SendMessage`, which dispatches it through the normal conversation flow.

### Deletion

Both the picker Delete key and `/theme delete <name>` CLI path delegate to `custom_theme::delete_custom_theme()` for file removal and `palette::unregister_custom_theme()` for in-memory cleanup. The active-theme fallback to System prevents edge cases where the deleted theme name lingers in `app.theme_id` after the underlying JSON is gone.

### Settings integration

`settings.rs` `validate()` now accepts custom theme names (1 to 64 characters) in addition to the built-in list. `normalize_settings_theme()` returns a `String` rather than `&'static str` to accommodate custom names without leaking memory. `config_ui.rs` `UiThemeValue` gained the complete set of missing built-in variants (`Terminal`, `Claude`, `SolarizedLight`) alongside a `Custom(String)` variant, and its `as_setting()` method returns `String`.

### Version resilience

Custom themes are stored in `~/.codewhale/themes/`, a directory outside the application bundle. The CodeWhale updater and installer never touch this directory. If a future version adds new colour fields to `UiTheme`, the `UiThemeCustom` deserializer applies its per-field `#[serde(default)]` fallbacks and the existing fields continue to work without user intervention.

## Commands reference

| Command | Behaviour |
|---|---|
| `/theme` | Open the interactive picker (arrow keys preview, Enter saves, Esc reverts) |
| `/theme <name>` | Switch to a known theme by its settings name |
| `/theme-describe <description>` | Generate a custom theme from a natural-language description |
| `/theme-create <description>` | Alias for `/theme-describe` |
| `/theme-new <description>` | Alias for `/theme-describe` |
| `/theme-generate <description>` | Alias for `/theme-describe` |
| `/theme delete <name>` | Delete a custom theme from disk and registry |
| `/theme new` | Print usage instructions for theme creation |

## Files changed

| File | Change |
|---|---|
| `crates/tui/src/custom_theme.rs` | **New.** `UiThemeCustom` serde type with 40 per-field `#[serde(default)]` fallbacks, `load_custom_themes()`, `save_custom_theme()`, `delete_custom_theme()`, `color_to_hex()`/`hex_to_color()`, `parse_mode()`/`mode_to_string()`, atomic file I/O with temp+rename, UNIX/Windows home-dir resolution, 6 unit tests |
| `crates/tui/src/palette.rs` | `ThemeId::Custom(String)` variant, `CUSTOM_THEMES` static `RwLock` registry, `load/register/unregister_custom_theme()`, `selectable_themes()` dynamic list, `is_custom()`, `name()`/`display_name()`/`tagline()` return `String`, `ui_theme()` resolves `Custom`, `from_name()` checks custom registry fallback, `theme_remap_active`/`adapt_fg_for_theme`/`adapt_bg_for_theme` accept `&ThemeId`, `from_setting()` uses `.as_ref().map()` |
| `crates/tui/src/tui/theme_picker.rs` | Key change: `Vec<ThemeId>` list from `selectable_themes()` replacing static `SELECTABLE_THEMES`, Delete/Backspace key handler with file+registry cleanup, `[Del]` affordance in bottom hint bar, ✎ prefix for `Custom` display names, all indexing refactored to `.themes` field, `ui_theme_for()` takes `&ThemeId`, 10 unit tests |
| `crates/tui/src/commands/config.rs` | `theme_describe()` command building structured prompt with full UiTheme reference, updated `/theme new` message referencing real command, `/theme delete <name>` handler with active-theme System fallback, `delete_custom_theme()` helper |
| `crates/tui/src/commands/mod.rs` | `CommandInfo` entry for `theme-describe` with aliases `theme-create`/`theme-new`/`theme-generate`, routing match arm |
| `crates/tui/src/localization.rs` | `CmdThemeDescribe` message ID and translations in all 7 supported languages (en, ja, zh-Hans, pt-BR, es-419, vi, ko placeholder pattern) |
| `crates/tui/src/settings.rs` | `normalize_settings_theme()` returns `String`, `validate()` accepts 1-64 char custom names and rejects empty or overly long names, test update: `tui_prefs_validate_accepts_unknown_theme_as_custom` replaces `tui_prefs_validate_rejects_unknown_theme`, new `tui_prefs_validate_rejects_overly_long_theme_name` test |
| `crates/tui/src/config_ui.rs` | `UiThemeValue` gains `Terminal`, `Claude`, `SolarizedLight`, `Custom(String)` variants; `as_setting()` returns `String`; `from_setting()` accepts unknown names as `Custom`; `schema_contains_typed_enums` test updated for oneOf schema structure |
| `crates/tui/src/tui/ui.rs` | `load_custom_themes()` call placed before `App::new()`, `app.theme_id.clone()` for `set_theme` |
| `crates/tui/src/tui/color_compat.rs` | `adapt_cell_colors()` takes `&ThemeId`, `draw()` clones `theme_id` into closure, test callers pass `&ThemeId::*` |
| `crates/tui/src/main.rs` | `mod custom_theme;` declaration |

## Testing

3827 unit tests pass. The single failure (`mcp::tests::session_id_captured_from_post_response_and_replayed`) is a pre-existing flaky MCP HTTP test present on main and unrelated to this change.

All 44 sidebar tests pass, all 10 theme picker tests pass, all 6 custom_theme module tests pass, all 51 config command tests pass.
