### PR TITLE
fix(tui): label pending input modes

### DIFF
--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -1439,7 +1439,7 @@ pub struct App {
     /// cancelled cleanly). Surfaced in the pending-input preview so the user
     /// knows the steer was deferred to end-of-turn. Today no engine path
     /// produces these; the field is scaffolding for a future signalling
-    /// channel and the bucket renders identically when populated.
+    /// channel and the bucket renders with its own pending-input label.
     pub rejected_steers: VecDeque<String>,
     /// Legacy resend flag for pending steer recovery.
     pub submit_pending_steers_after_interrupt: bool,

--- a/crates/tui/src/tui/widgets/pending_input_preview.rs
+++ b/crates/tui/src/tui/widgets/pending_input_preview.rs
@@ -110,13 +110,27 @@ impl PendingInputPreview {
                 Line::from(vec![Span::raw("• "), Span::raw("Pending inputs")]),
             );
             for steer in &self.pending_steers {
-                push_truncated_item(&mut lines, steer, width, dim, "  ↳ ", "    ");
+                push_truncated_item(&mut lines, steer, width, dim, "  ↳ Steer pending: ", "    ");
             }
             for steer in &self.rejected_steers {
-                push_truncated_item(&mut lines, steer, width, dim, "  ↳ ", "    ");
+                push_truncated_item(
+                    &mut lines,
+                    steer,
+                    width,
+                    dim,
+                    "  ↳ Rejected steer: ",
+                    "    ",
+                );
             }
             for message in &self.queued_messages {
-                push_truncated_item(&mut lines, message, width, dim_italic, "  ↳ ", "    ");
+                push_truncated_item(
+                    &mut lines,
+                    message,
+                    width,
+                    dim_italic,
+                    "  ↳ Queued follow-up: ",
+                    "    ",
+                );
             }
             if !self.queued_messages.is_empty() {
                 lines.push(Line::from(vec![Span::styled(
@@ -421,6 +435,32 @@ mod tests {
         assert!(rows.iter().any(|r| r.contains("rejected")));
         assert!(rows.iter().any(|r| r.contains("queued")));
         assert!(rows.iter().any(|r| r.contains("↑")));
+    }
+
+    #[test]
+    fn pending_input_rows_label_each_delivery_mode() {
+        let mut preview = PendingInputPreview::new();
+        preview.pending_steers.push("steer".to_string());
+        preview.rejected_steers.push("rejected".to_string());
+        preview.queued_messages.push("queued".to_string());
+
+        let rows = render_to_string(&preview, 80);
+
+        assert!(
+            rows.iter()
+                .any(|r| r.contains("Steer pending") && r.contains("steer")),
+            "missing pending-steer label: {rows:?}"
+        );
+        assert!(
+            rows.iter()
+                .any(|r| r.contains("Rejected steer") && r.contains("rejected")),
+            "missing rejected-steer label: {rows:?}"
+        );
+        assert!(
+            rows.iter()
+                .any(|r| r.contains("Queued follow-up") && r.contains("queued")),
+            "missing queued-follow-up label: {rows:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Problem
- The pending-input preview rendered steer and queued follow-up rows with the same prefix, making the delivery mode hard to read while a turn is running.

Change
- Label pending steer, rejected steer, and queued follow-up rows separately in the pending-input preview.
- Keep the existing unified list, truncation behavior, and queued-message edit hint.
- Update the rejected-steer field comment to match the labelled rendering.

Verification
- cargo test -p codewhale-tui pending_input_rows_label_each_delivery_mode --locked
- cargo test -p codewhale-tui pending_input_preview --locked
- cargo fmt --all -- --check
- git diff --check

Refs #2054

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds distinct labels to each delivery-mode row in the pending-input preview, replacing the generic `↳` prefix with `↳ Steer pending:`, `↳ Rejected steer:`, and `↳ Queued follow-up:` labels. A new test verifies each label is rendered correctly.

- `pending_input_preview.rs`: Three `push_truncated_item` call-sites updated with typed prefixes; a new `pending_input_rows_label_each_delivery_mode` test added alongside the existing suite.
- `app.rs`: One-line doc-comment update to `rejected_steers` to match the new labelled rendering; no logic change.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change is purely presentational and backed by new tests.

The only notable gap is that `subsequent_indent` remains `"    "` (4 spaces) while the new first-line prefixes are 19–22 characters wide. Any steer or queued message that wraps to a second display line will show content starting at column 4 rather than aligning under the label text. This is visible to end users but does not break functionality.

crates/tui/src/tui/widgets/pending_input_preview.rs — the continuation-indent values passed to `push_truncated_item` do not match the new prefix widths.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/widgets/pending_input_preview.rs | Adds distinct labels ("Steer pending:", "Rejected steer:", "Queued follow-up:") to each delivery-mode row in the pending-input preview, with a corresponding new test; continuation-line indent is unchanged at 4 spaces despite the prefix growing to 19–22 chars. |
| crates/tui/src/tui/app.rs | One-line doc-comment update to `rejected_steers` to reflect the new labelled rendering; no logic changes. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[lines] --> B{has pending inputs?}
    B -- No --> C[return empty vec]
    B -- Yes --> D[push Pending inputs header]
    D --> E[iterate pending_steers]
    E --> F[push_truncated_item with Steer pending label]
    F --> G[iterate rejected_steers]
    G --> H[push_truncated_item with Rejected steer label]
    H --> I[iterate queued_messages]
    I --> J[push_truncated_item with Queued follow-up label]
    J --> K{queued_messages non-empty?}
    K -- Yes --> L[push edit-binding hint line]
    K -- No --> M[return lines]
    L --> M
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22codex%2F2054-pending-input-labels%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2F2054-pending-input-labels%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fwidgets%2Fpending_input_preview.rs%3A112-134%0AThe%20%60subsequent_indent%60%20is%20still%20%60%22%20%20%20%20%22%60%20%284%20spaces%29%20even%20though%20the%20new%20first-line%20prefixes%20are%2019%E2%80%9322%20characters%20wide.%20If%20any%20steer%20or%20queued%20message%20wraps%20across%20multiple%20display%20lines%2C%20continuation%20lines%20will%20start%20at%20column%204%20while%20the%20first%20line's%20content%20starts%20at%20column%2019%2F21%2F22%2C%20producing%20a%20jagged%2C%20misaligned%20block.%20Matching%20the%20indent%20width%20to%20the%20prefix%20width%20keeps%20wrapped%20content%20visually%20aligned%20under%20the%20label%20text.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20for%20steer%20in%20%26self.pending_steers%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20push_truncated_item%28%26mut%20lines%2C%20steer%2C%20width%2C%20dim%2C%20%22%20%20%E2%86%B3%20Steer%20pending%3A%20%22%2C%20%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20for%20steer%20in%20%26self.rejected_steers%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20push_truncated_item%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%26mut%20lines%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20steer%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20width%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20dim%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22%20%20%E2%86%B3%20Rejected%20steer%3A%20%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20for%20message%20in%20%26self.queued_messages%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20push_truncated_item%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%26mut%20lines%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20message%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20width%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20dim_italic%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22%20%20%E2%86%B3%20Queued%20follow-up%3A%20%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fwidgets%2Fpending_input_preview.rs%3A112-134%0AThe%20%60subsequent_indent%60%20is%20still%20%60%22%20%20%20%20%22%60%20%284%20spaces%29%20even%20though%20the%20new%20first-line%20prefixes%20are%2019%E2%80%9322%20characters%20wide.%20If%20any%20steer%20or%20queued%20message%20wraps%20across%20multiple%20display%20lines%2C%20continuation%20lines%20will%20start%20at%20column%204%20while%20the%20first%20line's%20content%20starts%20at%20column%2019%2F21%2F22%2C%20producing%20a%20jagged%2C%20misaligned%20block.%20Matching%20the%20indent%20width%20to%20the%20prefix%20width%20keeps%20wrapped%20content%20visually%20aligned%20under%20the%20label%20text.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20for%20steer%20in%20%26self.pending_steers%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20push_truncated_item%28%26mut%20lines%2C%20steer%2C%20width%2C%20dim%2C%20%22%20%20%E2%86%B3%20Steer%20pending%3A%20%22%2C%20%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20for%20steer%20in%20%26self.rejected_steers%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20push_truncated_item%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%26mut%20lines%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20steer%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20width%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20dim%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22%20%20%E2%86%B3%20Rejected%20steer%3A%20%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20for%20message%20in%20%26self.queued_messages%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20push_truncated_item%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%26mut%20lines%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20message%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20width%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20dim_italic%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22%20%20%E2%86%B3%20Queued%20follow-up%3A%20%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2532&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fwidgets%2Fpending_input_preview.rs%3A112-134%0AThe%20%60subsequent_indent%60%20is%20still%20%60%22%20%20%20%20%22%60%20%284%20spaces%29%20even%20though%20the%20new%20first-line%20prefixes%20are%2019%E2%80%9322%20characters%20wide.%20If%20any%20steer%20or%20queued%20message%20wraps%20across%20multiple%20display%20lines%2C%20continuation%20lines%20will%20start%20at%20column%204%20while%20the%20first%20line's%20content%20starts%20at%20column%2019%2F21%2F22%2C%20producing%20a%20jagged%2C%20misaligned%20block.%20Matching%20the%20indent%20width%20to%20the%20prefix%20width%20keeps%20wrapped%20content%20visually%20aligned%20under%20the%20label%20text.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20for%20steer%20in%20%26self.pending_steers%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20push_truncated_item%28%26mut%20lines%2C%20steer%2C%20width%2C%20dim%2C%20%22%20%20%E2%86%B3%20Steer%20pending%3A%20%22%2C%20%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20for%20steer%20in%20%26self.rejected_steers%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20push_truncated_item%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%26mut%20lines%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20steer%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20width%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20dim%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22%20%20%E2%86%B3%20Rejected%20steer%3A%20%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20for%20message%20in%20%26self.queued_messages%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20push_truncated_item%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%26mut%20lines%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20message%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20width%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20dim_italic%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22%20%20%E2%86%B3%20Queued%20follow-up%3A%20%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A&pr=2532&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(tui): label pending input modes"](https://github.com/hmbown/codewhale/commit/3164e3fc8cff5235540f7d7a9b6490535ca23e2f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34968072)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->