### PR TITLE
fix(tui): refresh prompt on model switch

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -783,10 +783,12 @@ impl Engine {
                         .send(Event::status(format!("Mode changed to: {mode:?}")))
                         .await;
                 }
-                Op::SetModel { model } => {
+                Op::SetModel { model, mode } => {
                     self.session.auto_model = model.trim().eq_ignore_ascii_case("auto");
                     self.session.model = model;
                     self.config.model.clone_from(&self.session.model);
+                    self.refresh_system_prompt(mode);
+                    self.emit_session_updated().await;
                     let _ = self
                         .tx_event
                         .send(Event::status(format!(

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -1238,6 +1238,61 @@ async fn session_update_preserves_reasoning_tool_only_turn() {
     assert_eq!(messages, vec![assistant]);
 }
 
+#[tokio::test]
+async fn set_model_reloads_instruction_sources_and_updates_session_prompt() {
+    let tmp = tempdir().expect("tempdir");
+    let instructions = tmp.path().join("instructions.md");
+    fs::write(&instructions, "FLASH_INSTRUCTIONS_MARKER").expect("write instructions");
+    let config = EngineConfig {
+        workspace: tmp.path().to_path_buf(),
+        model: "deepseek-v4-flash".to_string(),
+        instructions: vec![instructions.clone().into()],
+        ..Default::default()
+    };
+    let (engine, handle) = Engine::new(config, &Config::default());
+    fs::write(&instructions, "PRO_INSTRUCTIONS_MARKER").expect("rewrite instructions");
+
+    let run = tokio::spawn(engine.run());
+    handle
+        .send(Op::SetModel {
+            model: "deepseek-v4-pro".to_string(),
+            mode: AppMode::Agent,
+        })
+        .await
+        .expect("send set model");
+
+    let (model, prompt) = {
+        let mut rx = handle.rx_event.write().await;
+        loop {
+            let event = tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
+                .await
+                .expect("session update after model switch")
+                .expect("event");
+            if let Event::SessionUpdated {
+                model,
+                system_prompt,
+                ..
+            } = event
+            {
+                let prompt = match system_prompt.expect("system prompt") {
+                    SystemPrompt::Text(text) => text,
+                    SystemPrompt::Blocks(blocks) => blocks
+                        .into_iter()
+                        .map(|block| block.text)
+                        .collect::<Vec<_>>()
+                        .join("\n"),
+                };
+                break (model, prompt);
+            }
+        }
+    };
+    run.abort();
+
+    assert_eq!(model, "deepseek-v4-pro");
+    assert!(prompt.contains("PRO_INSTRUCTIONS_MARKER"));
+    assert!(!prompt.contains("FLASH_INSTRUCTIONS_MARKER"));
+}
+
 #[test]
 fn detects_context_length_errors_from_provider_payloads() {
     let msg = r#"SSE stream request failed: HTTP 400 Bad Request: {"error":{"message":"This model's maximum context length is 131072 tokens. However, you requested 153056 tokens (148960 in the messages, 4096 in the completion).","type":"invalid_request_error"}}"#;

--- a/crates/tui/src/core/ops.rs
+++ b/crates/tui/src/core/ops.rs
@@ -60,9 +60,9 @@ pub enum Op {
     #[allow(dead_code)]
     ChangeMode { mode: AppMode },
 
-    /// Update the model being used
+    /// Update the model being used and refresh the prompt for the current mode.
     #[allow(dead_code)]
-    SetModel { model: String },
+    SetModel { model: String, mode: AppMode },
 
     /// Update auto-compaction settings
     SetCompaction { config: CompactionConfig },

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -3412,6 +3412,7 @@ async fn run_event_loop(
                         let _ = engine_handle
                             .send(Op::SetModel {
                                 model: app.model.clone(),
+                                mode: app.mode,
                             })
                             .await;
                     }
@@ -4721,10 +4722,12 @@ async fn dispatch_user_message(
 async fn apply_model_and_compaction_update(
     engine_handle: &EngineHandle,
     compaction: crate::compaction::CompactionConfig,
+    mode: AppMode,
 ) {
     let _ = engine_handle
         .send(Op::SetModel {
             model: compaction.model.clone(),
+            mode,
         })
         .await;
     let _ = engine_handle
@@ -4752,6 +4755,7 @@ async fn drain_web_config_events(
                             apply_model_and_compaction_update(
                                 engine_handle,
                                 app.compaction_config(),
+                                app.mode,
                             )
                             .await;
                         }
@@ -4776,6 +4780,7 @@ async fn drain_web_config_events(
                             apply_model_and_compaction_update(
                                 engine_handle,
                                 app.compaction_config(),
+                                app.mode,
                             )
                             .await;
                         }
@@ -4861,7 +4866,7 @@ async fn apply_model_picker_choice(
     }
 
     if model_changed {
-        apply_model_and_compaction_update(engine_handle, app.compaction_config()).await;
+        apply_model_and_compaction_update(engine_handle, app.compaction_config(), app.mode).await;
     }
 
     let model_summary = if model_is_auto {
@@ -5210,7 +5215,7 @@ async fn apply_command_result(
                 }
             }
             AppAction::UpdateCompaction(compaction) => {
-                apply_model_and_compaction_update(engine_handle, compaction).await;
+                apply_model_and_compaction_update(engine_handle, compaction, app.mode).await;
             }
             AppAction::OpenConfigEditor(mode) => match mode {
                 ConfigUiMode::Native => {
@@ -5240,6 +5245,7 @@ async fn apply_command_result(
                                 apply_model_and_compaction_update(
                                     engine_handle,
                                     app.compaction_config(),
+                                    app.mode,
                                 )
                                 .await;
                             }
@@ -6716,7 +6722,8 @@ async fn handle_view_events(
                 if let Some(action) = result.action {
                     match action {
                         AppAction::UpdateCompaction(compaction) => {
-                            apply_model_and_compaction_update(engine_handle, compaction).await;
+                            apply_model_and_compaction_update(engine_handle, compaction, app.mode)
+                                .await;
                         }
                         AppAction::OpenConfigView => {}
                         _ => {}

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -2021,11 +2021,12 @@ async fn model_change_update_syncs_engine_model_before_compaction() {
     let compaction = app.compaction_config();
     let mut engine = crate::core::engine::mock_engine_handle();
 
-    apply_model_and_compaction_update(&engine.handle, compaction).await;
+    apply_model_and_compaction_update(&engine.handle, compaction, app.mode).await;
 
     match engine.rx_op.recv().await.expect("set model op") {
-        crate::core::ops::Op::SetModel { model } => {
+        crate::core::ops::Op::SetModel { model, mode } => {
             assert_eq!(model, "deepseek-v4-flash");
+            assert_eq!(mode, app.mode);
         }
         other => panic!("expected SetModel, got {other:?}"),
     }


### PR DESCRIPTION
Refs #2379

Problem:
- `/model` updated the engine model but only emitted a status event.
- The session system prompt stayed stale until the next turn rebuilt it.

Change:
- Carry the current mode with `Op::SetModel`.
- Refresh the engine system prompt after model switches and emit `SessionUpdated`.
- Cover configured instruction-file reload with a focused regression test.

Verification:
- `cargo test -p codewhale-tui set_model_reloads_instruction_sources_and_updates_session_prompt --locked`
- `cargo test -p codewhale-tui model_change_update_syncs_engine_model_before_compaction --locked`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug (#2379) where using `/model` to switch the AI model updated the engine state but left the session system prompt stale until the next conversation turn. The fix carries `AppMode` in `Op::SetModel`, calls `refresh_system_prompt(mode)` in the engine handler, and emits `SessionUpdated` so the UI sees the refreshed prompt immediately.

- `Op::SetModel` gains a `mode: AppMode` field; all six call sites in `ui.rs` are updated to pass `app.mode`, and the engine handler now calls `refresh_system_prompt` then `emit_session_updated` in the correct order (after the model and config are already updated).
- Two focused regression tests are added: one verifying the instruction-file is re-read from disk on model switch, the other asserting that `SetModel` is sent before `SetCompaction` and now carries the correct mode.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the model-switch stale-prompt bug is correctly fixed and all call sites are updated.

The core change is tight and correct — model, config, prompt refresh, and session event all happen in the right order. All six SetModel construction sites in ui.rs pass the current mode, and two regression tests cover both the instruction-file reload path and the op-ordering guarantee. The only gap is that Tab-cycling the mode without a model change still leaves the engine prompt stale, but that is a pre-existing limitation unrelated to the code introduced here.

No files require special attention; the one observation is in ui.rs around the Tab-cycle mode path.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/tui/src/core/engine.rs | Adds refresh_system_prompt(mode) and emit_session_updated() to the SetModel handler; ordering is correct — config.model is already updated before refresh_system_prompt reads it via model_id. |
| crates/tui/src/core/ops.rs | Adds mode: AppMode field to Op::SetModel with updated doc comment; no other changes. |
| crates/tui/src/tui/ui.rs | All six SetModel construction sites updated to pass app.mode; apply_model_and_compaction_update gains a mode parameter threaded through all callers. |
| crates/tui/src/core/engine/tests.rs | New regression test verifies instruction files are re-read from disk on model switch and the SessionUpdated event carries the refreshed prompt; loop correctly skips non-SessionUpdated events. |
| crates/tui/src/tui/ui/tests.rs | Existing test updated to pass app.mode and now also asserts the mode field on the received SetModel op. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/tui/src/tui/ui.rs`, line 3409-3418 ([link](https://github.com/hmbown/codewhale/blob/ec679a531616ed68127622fb1d7e65fe56b55435/crates/tui/src/tui/ui.rs#L3409-L3418)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Mode-only Tab-cycle leaves engine prompt stale**

   When the user presses Tab to cycle through Plan → Agent → Yolo, `cycle_mode()` changes `app.mode` but not `app.model`, so the `app.model != prior_model` guard is false and no `Op::SetModel` is ever sent. The engine's system prompt therefore stays stale until the next AI turn, even though the new mode uses different prompt content (e.g., Yolo enables auto-approval and alters the tooling section). `Op::ChangeMode` exists in the op-set but is never sent anywhere. With the `refresh_system_prompt(mode)` path now wired in `SetModel`, a sibling fix for pure mode changes would be straightforward — either send `Op::SetModel { model: app.model.clone(), mode: app.mode }` unconditionally when mode changes, or start sending `Op::ChangeMode` and call `refresh_system_prompt` there too.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22codex%2F2379-reload-instructions%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2F2379-reload-instructions%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fui.rs%0ALine%3A%203409-3418%0A%0AComment%3A%0A**Mode-only%20Tab-cycle%20leaves%20engine%20prompt%20stale**%0A%0AWhen%20the%20user%20presses%20Tab%20to%20cycle%20through%20Plan%20%E2%86%92%20Agent%20%E2%86%92%20Yolo%2C%20%60cycle_mode%28%29%60%20changes%20%60app.mode%60%20but%20not%20%60app.model%60%2C%20so%20the%20%60app.model%20!%3D%20prior_model%60%20guard%20is%20false%20and%20no%20%60Op%3A%3ASetModel%60%20is%20ever%20sent.%20The%20engine's%20system%20prompt%20therefore%20stays%20stale%20until%20the%20next%20AI%20turn%2C%20even%20though%20the%20new%20mode%20uses%20different%20prompt%20content%20%28e.g.%2C%20Yolo%20enables%20auto-approval%20and%20alters%20the%20tooling%20section%29.%20%60Op%3A%3AChangeMode%60%20exists%20in%20the%20op-set%20but%20is%20never%20sent%20anywhere.%20With%20the%20%60refresh_system_prompt%28mode%29%60%20path%20now%20wired%20in%20%60SetModel%60%2C%20a%20sibling%20fix%20for%20pure%20mode%20changes%20would%20be%20straightforward%20%E2%80%94%20either%20send%20%60Op%3A%3ASetModel%20%7B%20model%3A%20app.model.clone%28%29%2C%20mode%3A%20app.mode%20%7D%60%20unconditionally%20when%20mode%20changes%2C%20or%20start%20sending%20%60Op%3A%3AChangeMode%60%20and%20call%20%60refresh_system_prompt%60%20there%20too.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fui.rs%0ALine%3A%203409-3418%0A%0AComment%3A%0A**Mode-only%20Tab-cycle%20leaves%20engine%20prompt%20stale**%0A%0AWhen%20the%20user%20presses%20Tab%20to%20cycle%20through%20Plan%20%E2%86%92%20Agent%20%E2%86%92%20Yolo%2C%20%60cycle_mode%28%29%60%20changes%20%60app.mode%60%20but%20not%20%60app.model%60%2C%20so%20the%20%60app.model%20!%3D%20prior_model%60%20guard%20is%20false%20and%20no%20%60Op%3A%3ASetModel%60%20is%20ever%20sent.%20The%20engine's%20system%20prompt%20therefore%20stays%20stale%20until%20the%20next%20AI%20turn%2C%20even%20though%20the%20new%20mode%20uses%20different%20prompt%20content%20%28e.g.%2C%20Yolo%20enables%20auto-approval%20and%20alters%20the%20tooling%20section%29.%20%60Op%3A%3AChangeMode%60%20exists%20in%20the%20op-set%20but%20is%20never%20sent%20anywhere.%20With%20the%20%60refresh_system_prompt%28mode%29%60%20path%20now%20wired%20in%20%60SetModel%60%2C%20a%20sibling%20fix%20for%20pure%20mode%20changes%20would%20be%20straightforward%20%E2%80%94%20either%20send%20%60Op%3A%3ASetModel%20%7B%20model%3A%20app.model.clone%28%29%2C%20mode%3A%20app.mode%20%7D%60%20unconditionally%20when%20mode%20changes%2C%20or%20start%20sending%20%60Op%3A%3AChangeMode%60%20and%20call%20%60refresh_system_prompt%60%20there%20too.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2534&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fui.rs%0ALine%3A%203409-3418%0A%0AComment%3A%0A**Mode-only%20Tab-cycle%20leaves%20engine%20prompt%20stale**%0A%0AWhen%20the%20user%20presses%20Tab%20to%20cycle%20through%20Plan%20%E2%86%92%20Agent%20%E2%86%92%20Yolo%2C%20%60cycle_mode%28%29%60%20changes%20%60app.mode%60%20but%20not%20%60app.model%60%2C%20so%20the%20%60app.model%20!%3D%20prior_model%60%20guard%20is%20false%20and%20no%20%60Op%3A%3ASetModel%60%20is%20ever%20sent.%20The%20engine's%20system%20prompt%20therefore%20stays%20stale%20until%20the%20next%20AI%20turn%2C%20even%20though%20the%20new%20mode%20uses%20different%20prompt%20content%20%28e.g.%2C%20Yolo%20enables%20auto-approval%20and%20alters%20the%20tooling%20section%29.%20%60Op%3A%3AChangeMode%60%20exists%20in%20the%20op-set%20but%20is%20never%20sent%20anywhere.%20With%20the%20%60refresh_system_prompt%28mode%29%60%20path%20now%20wired%20in%20%60SetModel%60%2C%20a%20sibling%20fix%20for%20pure%20mode%20changes%20would%20be%20straightforward%20%E2%80%94%20either%20send%20%60Op%3A%3ASetModel%20%7B%20model%3A%20app.model.clone%28%29%2C%20mode%3A%20app.mode%20%7D%60%20unconditionally%20when%20mode%20changes%2C%20or%20start%20sending%20%60Op%3A%3AChangeMode%60%20and%20call%20%60refresh_system_prompt%60%20there%20too.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2534&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22codex%2F2379-reload-instructions%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2F2379-reload-instructions%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui.rs%3A3409-3418%0A**Mode-only%20Tab-cycle%20leaves%20engine%20prompt%20stale**%0A%0AWhen%20the%20user%20presses%20Tab%20to%20cycle%20through%20Plan%20%E2%86%92%20Agent%20%E2%86%92%20Yolo%2C%20%60cycle_mode%28%29%60%20changes%20%60app.mode%60%20but%20not%20%60app.model%60%2C%20so%20the%20%60app.model%20!%3D%20prior_model%60%20guard%20is%20false%20and%20no%20%60Op%3A%3ASetModel%60%20is%20ever%20sent.%20The%20engine's%20system%20prompt%20therefore%20stays%20stale%20until%20the%20next%20AI%20turn%2C%20even%20though%20the%20new%20mode%20uses%20different%20prompt%20content%20%28e.g.%2C%20Yolo%20enables%20auto-approval%20and%20alters%20the%20tooling%20section%29.%20%60Op%3A%3AChangeMode%60%20exists%20in%20the%20op-set%20but%20is%20never%20sent%20anywhere.%20With%20the%20%60refresh_system_prompt%28mode%29%60%20path%20now%20wired%20in%20%60SetModel%60%2C%20a%20sibling%20fix%20for%20pure%20mode%20changes%20would%20be%20straightforward%20%E2%80%94%20either%20send%20%60Op%3A%3ASetModel%20%7B%20model%3A%20app.model.clone%28%29%2C%20mode%3A%20app.mode%20%7D%60%20unconditionally%20when%20mode%20changes%2C%20or%20start%20sending%20%60Op%3A%3AChangeMode%60%20and%20call%20%60refresh_system_prompt%60%20there%20too.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui.rs%3A3409-3418%0A**Mode-only%20Tab-cycle%20leaves%20engine%20prompt%20stale**%0A%0AWhen%20the%20user%20presses%20Tab%20to%20cycle%20through%20Plan%20%E2%86%92%20Agent%20%E2%86%92%20Yolo%2C%20%60cycle_mode%28%29%60%20changes%20%60app.mode%60%20but%20not%20%60app.model%60%2C%20so%20the%20%60app.model%20!%3D%20prior_model%60%20guard%20is%20false%20and%20no%20%60Op%3A%3ASetModel%60%20is%20ever%20sent.%20The%20engine's%20system%20prompt%20therefore%20stays%20stale%20until%20the%20next%20AI%20turn%2C%20even%20though%20the%20new%20mode%20uses%20different%20prompt%20content%20%28e.g.%2C%20Yolo%20enables%20auto-approval%20and%20alters%20the%20tooling%20section%29.%20%60Op%3A%3AChangeMode%60%20exists%20in%20the%20op-set%20but%20is%20never%20sent%20anywhere.%20With%20the%20%60refresh_system_prompt%28mode%29%60%20path%20now%20wired%20in%20%60SetModel%60%2C%20a%20sibling%20fix%20for%20pure%20mode%20changes%20would%20be%20straightforward%20%E2%80%94%20either%20send%20%60Op%3A%3ASetModel%20%7B%20model%3A%20app.model.clone%28%29%2C%20mode%3A%20app.mode%20%7D%60%20unconditionally%20when%20mode%20changes%2C%20or%20start%20sending%20%60Op%3A%3AChangeMode%60%20and%20call%20%60refresh_system_prompt%60%20there%20too.%0A%0A&repo=hmbown%2Fcodewhale&pr=2534&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui.rs%3A3409-3418%0A**Mode-only%20Tab-cycle%20leaves%20engine%20prompt%20stale**%0A%0AWhen%20the%20user%20presses%20Tab%20to%20cycle%20through%20Plan%20%E2%86%92%20Agent%20%E2%86%92%20Yolo%2C%20%60cycle_mode%28%29%60%20changes%20%60app.mode%60%20but%20not%20%60app.model%60%2C%20so%20the%20%60app.model%20!%3D%20prior_model%60%20guard%20is%20false%20and%20no%20%60Op%3A%3ASetModel%60%20is%20ever%20sent.%20The%20engine's%20system%20prompt%20therefore%20stays%20stale%20until%20the%20next%20AI%20turn%2C%20even%20though%20the%20new%20mode%20uses%20different%20prompt%20content%20%28e.g.%2C%20Yolo%20enables%20auto-approval%20and%20alters%20the%20tooling%20section%29.%20%60Op%3A%3AChangeMode%60%20exists%20in%20the%20op-set%20but%20is%20never%20sent%20anywhere.%20With%20the%20%60refresh_system_prompt%28mode%29%60%20path%20now%20wired%20in%20%60SetModel%60%2C%20a%20sibling%20fix%20for%20pure%20mode%20changes%20would%20be%20straightforward%20%E2%80%94%20either%20send%20%60Op%3A%3ASetModel%20%7B%20model%3A%20app.model.clone%28%29%2C%20mode%3A%20app.mode%20%7D%60%20unconditionally%20when%20mode%20changes%2C%20or%20start%20sending%20%60Op%3A%3AChangeMode%60%20and%20call%20%60refresh_system_prompt%60%20there%20too.%0A%0A&pr=2534&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(tui): refresh prompt on model switch"](https://github.com/hmbown/codewhale/commit/ec679a531616ed68127622fb1d7e65fe56b55435) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34975780)</sub>

<!-- /greptile_comment -->