### PR TITLE
feat(tui): expose current model in turn metadata

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -937,7 +937,10 @@ impl Engine {
             .map(|s| s.trim().to_string())
             .filter(|s| !s.is_empty());
 
-        let mut lines = vec![format!("Current local date: {today}")];
+        let mut lines = vec![
+            format!("Current local date: {today}"),
+            format!("Current model: {routed_model}"),
+        ];
         if auto_model {
             lines.push(format!("Auto model route: {routed_model}"));
         }

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -1492,6 +1492,7 @@ fn working_set_reaches_model_as_turn_metadata() {
 fn turn_metadata_includes_current_local_date_without_working_set() {
     let tmp = tempdir().expect("tempdir");
     let config = EngineConfig {
+        model: "deepseek-v4-flash".to_string(),
         workspace: tmp.path().to_path_buf(),
         ..Default::default()
     };
@@ -1511,6 +1512,7 @@ fn turn_metadata_includes_current_local_date_without_working_set() {
     let today = chrono::Local::now().format("%Y-%m-%d").to_string();
     assert!(text.starts_with("<turn_meta>\n"));
     assert!(text.contains(&format!("Current local date: {today}")));
+    assert!(text.contains("Current model: deepseek-v4-flash"));
 }
 
 #[test]
@@ -1534,6 +1536,7 @@ fn turn_metadata_includes_auto_model_route() {
         panic!("expected text metadata block");
     };
 
+    assert!(text.contains("Current model: deepseek-v4-pro"));
     assert!(text.contains("Auto model route: deepseek-v4-pro"));
     assert!(text.contains("Auto reasoning effort: max"));
     assert!(!text.contains("debug this regression"));

--- a/docs/MODES.md
+++ b/docs/MODES.md
@@ -9,6 +9,10 @@ Model selection is separate. `--model auto` and `/model auto` route each turn to
 a concrete model and thinking level; they are not TUI modes and are not part of
 the `Tab` cycle.
 
+Each user turn includes a small `<turn_meta>` block with the current local date
+and the concrete model sent to the provider. When `--model auto` is active, the
+same block also records that the model was auto-routed.
+
 ## TUI Modes
 
 Press `Tab` to complete composer menus, queue a draft as a next-turn follow-up


### PR DESCRIPTION
Refs #2380

Problem:
- Auto-routing visibility now records the routed model, but non-auto turns do not have the same explicit model identity in turn metadata.
- That leaves model-aware instructions without a clear per-turn identity signal.

Change:
- Add `Current model: ...` to each user turn `<turn_meta>` block.
- Keep `Auto model route: ...` for auto-routed turns.
- Document the turn metadata model signal in `docs/MODES.md`.

Verification:
- `cargo test -p codewhale-tui turn_metadata_includes_current_local_date_without_working_set --locked`
- `cargo test -p codewhale-tui turn_metadata_includes_auto_model_route --locked`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `Current model: <model>` to every user turn's `<turn_meta>` block so that model-aware system instructions can reliably read the concrete model identity per turn, regardless of whether auto-routing is active. Documentation in `MODES.md` is updated to describe the behaviour.

- **`engine.rs`**: A new `format!(\"Current model: {routed_model}\")` line is unconditionally pushed into the metadata before the existing conditional `Auto model route:` line, meaning auto-routed turns now contain both lines with the same model string.
- **`tests.rs`**: The `turn_metadata_includes_current_local_date_without_working_set` test is updated to set an explicit model in `EngineConfig` and assert the new line; `turn_metadata_includes_auto_model_route` gains an assertion that `Current model:` also appears alongside `Auto model route:`.
- **`docs/MODES.md`**: A paragraph is added explaining the `<turn_meta>` block contents and the auto-route signal.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change is minimal and additive — it appends one metadata line to every user turn and is well-covered by the updated tests.

The core logic change is a single-line addition to `turn_metadata_block` and is straightforward. The only notable gap is that `working_set_reaches_model_as_turn_metadata` does not assert the new `Current model:` line, leaving a small blind spot in test coverage for the working-set path.

`crates/tui/src/core/engine/tests.rs` — the working-set test could be tightened to assert the new metadata line, matching the pattern established by the other two updated tests.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/tui/src/core/engine.rs | Adds unconditional `Current model:` line to `turn_metadata_block`; when auto_model is true, both `Current model:` and `Auto model route:` now carry the same string — intentional per PR description but mildly redundant in the LLM prompt. |
| crates/tui/src/core/engine/tests.rs | New assertions cover both the non-auto and auto-routed cases; `working_set_reaches_model_as_turn_metadata` does not assert the new `Current model:` line but still passes — minor coverage gap. |
| docs/MODES.md | Documentation paragraph accurately describes `<turn_meta>` contents and auto-routing signal; no issues. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/tui/src/core/engine/tests.rs`, line 1465-1488 ([link](https://github.com/hmbown/codewhale/blob/1ee202f1dce5fc6da885df31b6348bf8d73fd987/crates/tui/src/core/engine/tests.rs#L1465-L1488)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `working_set_reaches_model_as_turn_metadata` test doesn't set an explicit model and never asserts on the new `Current model:` line. After this PR every `<turn_meta>` block unconditionally includes that line, so a test exercising the working-set path silently validates it with whatever `DEFAULT_TEXT_MODEL` happens to be. Adding a model to the config and asserting the line keeps the test consistent with the two tests that were explicitly updated.

   

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22codex%2F2380-active-model-turn-meta%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2F2380-active-model-turn-meta%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fcore%2Fengine%2Ftests.rs%0ALine%3A%201465-1488%0A%0AComment%3A%0AThe%20%60working_set_reaches_model_as_turn_metadata%60%20test%20doesn't%20set%20an%20explicit%20model%20and%20never%20asserts%20on%20the%20new%20%60Current%20model%3A%60%20line.%20After%20this%20PR%20every%20%60%3Cturn_meta%3E%60%20block%20unconditionally%20includes%20that%20line%2C%20so%20a%20test%20exercising%20the%20working-set%20path%20silently%20validates%20it%20with%20whatever%20%60DEFAULT_TEXT_MODEL%60%20happens%20to%20be.%20Adding%20a%20model%20to%20the%20config%20and%20asserting%20the%20line%20keeps%20the%20test%20consistent%20with%20the%20two%20tests%20that%20were%20explicitly%20updated.%0A%0A%60%60%60suggestion%0A%20%20%20%20let%20config%20%3D%20EngineConfig%20%7B%0A%20%20%20%20%20%20%20%20model%3A%20%22deepseek-v4-flash%22.to_string%28%29%2C%0A%20%20%20%20%20%20%20%20workspace%3A%20tmp.path%28%29.to_path_buf%28%29%2C%0A%20%20%20%20%20%20%20%20..Default%3A%3Adefault%28%29%0A%20%20%20%20%7D%3B%0A%20%20%20%20let%20%28mut%20engine%2C%20_handle%29%20%3D%20Engine%3A%3Anew%28config%2C%20%26Config%3A%3Adefault%28%29%29%3B%0A%20%20%20%20engine%0A%20%20%20%20%20%20%20%20.session%0A%20%20%20%20%20%20%20%20.working_set%0A%20%20%20%20%20%20%20%20.observe_user_message%28%22please%20inspect%20src%2Flib.rs%22%2C%20tmp.path%28%29%29%3B%0A%20%20%20%20let%20user_msg%20%3D%0A%20%20%20%20%20%20%20%20engine.user_text_message_with_turn_metadata%28%22please%20inspect%20src%2Flib.rs%22.to_string%28%29%29%3B%0A%20%20%20%20engine.session.add_message%28user_msg%29%3B%0A%0A%20%20%20%20let%20messages%20%3D%20engine.messages_with_turn_metadata%28%29%3B%0A%20%20%20%20let%20first_block%20%3D%20messages%0A%20%20%20%20%20%20%20%20.last%28%29%0A%20%20%20%20%20%20%20%20.and_then%28%7Cmessage%7C%20message.content.first%28%29%29%0A%20%20%20%20%20%20%20%20.expect%28%22turn%20metadata%20block%22%29%3B%0A%20%20%20%20let%20ContentBlock%3A%3AText%20%7B%20text%2C%20..%20%7D%20%3D%20first_block%20else%20%7B%0A%20%20%20%20%20%20%20%20panic!%28%22expected%20text%20metadata%20block%22%29%3B%0A%20%20%20%20%7D%3B%0A%20%20%20%20assert!%28text.starts_with%28%22%3Cturn_meta%3E%5Cn%22%29%29%3B%0A%20%20%20%20assert!%28text.contains%28%22Current%20model%3A%20deepseek-v4-flash%22%29%29%3B%0A%20%20%20%20assert!%28text.contains%28WORKING_SET_SUMMARY_MARKER%29%29%3B%0A%20%20%20%20assert!%28text.contains%28%22src%2Flib.rs%22%29%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fcore%2Fengine%2Ftests.rs%0ALine%3A%201465-1488%0A%0AComment%3A%0AThe%20%60working_set_reaches_model_as_turn_metadata%60%20test%20doesn't%20set%20an%20explicit%20model%20and%20never%20asserts%20on%20the%20new%20%60Current%20model%3A%60%20line.%20After%20this%20PR%20every%20%60%3Cturn_meta%3E%60%20block%20unconditionally%20includes%20that%20line%2C%20so%20a%20test%20exercising%20the%20working-set%20path%20silently%20validates%20it%20with%20whatever%20%60DEFAULT_TEXT_MODEL%60%20happens%20to%20be.%20Adding%20a%20model%20to%20the%20config%20and%20asserting%20the%20line%20keeps%20the%20test%20consistent%20with%20the%20two%20tests%20that%20were%20explicitly%20updated.%0A%0A%60%60%60suggestion%0A%20%20%20%20let%20config%20%3D%20EngineConfig%20%7B%0A%20%20%20%20%20%20%20%20model%3A%20%22deepseek-v4-flash%22.to_string%28%29%2C%0A%20%20%20%20%20%20%20%20workspace%3A%20tmp.path%28%29.to_path_buf%28%29%2C%0A%20%20%20%20%20%20%20%20..Default%3A%3Adefault%28%29%0A%20%20%20%20%7D%3B%0A%20%20%20%20let%20%28mut%20engine%2C%20_handle%29%20%3D%20Engine%3A%3Anew%28config%2C%20%26Config%3A%3Adefault%28%29%29%3B%0A%20%20%20%20engine%0A%20%20%20%20%20%20%20%20.session%0A%20%20%20%20%20%20%20%20.working_set%0A%20%20%20%20%20%20%20%20.observe_user_message%28%22please%20inspect%20src%2Flib.rs%22%2C%20tmp.path%28%29%29%3B%0A%20%20%20%20let%20user_msg%20%3D%0A%20%20%20%20%20%20%20%20engine.user_text_message_with_turn_metadata%28%22please%20inspect%20src%2Flib.rs%22.to_string%28%29%29%3B%0A%20%20%20%20engine.session.add_message%28user_msg%29%3B%0A%0A%20%20%20%20let%20messages%20%3D%20engine.messages_with_turn_metadata%28%29%3B%0A%20%20%20%20let%20first_block%20%3D%20messages%0A%20%20%20%20%20%20%20%20.last%28%29%0A%20%20%20%20%20%20%20%20.and_then%28%7Cmessage%7C%20message.content.first%28%29%29%0A%20%20%20%20%20%20%20%20.expect%28%22turn%20metadata%20block%22%29%3B%0A%20%20%20%20let%20ContentBlock%3A%3AText%20%7B%20text%2C%20..%20%7D%20%3D%20first_block%20else%20%7B%0A%20%20%20%20%20%20%20%20panic!%28%22expected%20text%20metadata%20block%22%29%3B%0A%20%20%20%20%7D%3B%0A%20%20%20%20assert!%28text.starts_with%28%22%3Cturn_meta%3E%5Cn%22%29%29%3B%0A%20%20%20%20assert!%28text.contains%28%22Current%20model%3A%20deepseek-v4-flash%22%29%29%3B%0A%20%20%20%20assert!%28text.contains%28WORKING_SET_SUMMARY_MARKER%29%29%3B%0A%20%20%20%20assert!%28text.contains%28%22src%2Flib.rs%22%29%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2536&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fcore%2Fengine%2Ftests.rs%0ALine%3A%201465-1488%0A%0AComment%3A%0AThe%20%60working_set_reaches_model_as_turn_metadata%60%20test%20doesn't%20set%20an%20explicit%20model%20and%20never%20asserts%20on%20the%20new%20%60Current%20model%3A%60%20line.%20After%20this%20PR%20every%20%60%3Cturn_meta%3E%60%20block%20unconditionally%20includes%20that%20line%2C%20so%20a%20test%20exercising%20the%20working-set%20path%20silently%20validates%20it%20with%20whatever%20%60DEFAULT_TEXT_MODEL%60%20happens%20to%20be.%20Adding%20a%20model%20to%20the%20config%20and%20asserting%20the%20line%20keeps%20the%20test%20consistent%20with%20the%20two%20tests%20that%20were%20explicitly%20updated.%0A%0A%60%60%60suggestion%0A%20%20%20%20let%20config%20%3D%20EngineConfig%20%7B%0A%20%20%20%20%20%20%20%20model%3A%20%22deepseek-v4-flash%22.to_string%28%29%2C%0A%20%20%20%20%20%20%20%20workspace%3A%20tmp.path%28%29.to_path_buf%28%29%2C%0A%20%20%20%20%20%20%20%20..Default%3A%3Adefault%28%29%0A%20%20%20%20%7D%3B%0A%20%20%20%20let%20%28mut%20engine%2C%20_handle%29%20%3D%20Engine%3A%3Anew%28config%2C%20%26Config%3A%3Adefault%28%29%29%3B%0A%20%20%20%20engine%0A%20%20%20%20%20%20%20%20.session%0A%20%20%20%20%20%20%20%20.working_set%0A%20%20%20%20%20%20%20%20.observe_user_message%28%22please%20inspect%20src%2Flib.rs%22%2C%20tmp.path%28%29%29%3B%0A%20%20%20%20let%20user_msg%20%3D%0A%20%20%20%20%20%20%20%20engine.user_text_message_with_turn_metadata%28%22please%20inspect%20src%2Flib.rs%22.to_string%28%29%29%3B%0A%20%20%20%20engine.session.add_message%28user_msg%29%3B%0A%0A%20%20%20%20let%20messages%20%3D%20engine.messages_with_turn_metadata%28%29%3B%0A%20%20%20%20let%20first_block%20%3D%20messages%0A%20%20%20%20%20%20%20%20.last%28%29%0A%20%20%20%20%20%20%20%20.and_then%28%7Cmessage%7C%20message.content.first%28%29%29%0A%20%20%20%20%20%20%20%20.expect%28%22turn%20metadata%20block%22%29%3B%0A%20%20%20%20let%20ContentBlock%3A%3AText%20%7B%20text%2C%20..%20%7D%20%3D%20first_block%20else%20%7B%0A%20%20%20%20%20%20%20%20panic!%28%22expected%20text%20metadata%20block%22%29%3B%0A%20%20%20%20%7D%3B%0A%20%20%20%20assert!%28text.starts_with%28%22%3Cturn_meta%3E%5Cn%22%29%29%3B%0A%20%20%20%20assert!%28text.contains%28%22Current%20model%3A%20deepseek-v4-flash%22%29%29%3B%0A%20%20%20%20assert!%28text.contains%28WORKING_SET_SUMMARY_MARKER%29%29%3B%0A%20%20%20%20assert!%28text.contains%28%22src%2Flib.rs%22%29%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2536&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22codex%2F2380-active-model-turn-meta%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2F2380-active-model-turn-meta%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine%2Ftests.rs%3A1465-1488%0AThe%20%60working_set_reaches_model_as_turn_metadata%60%20test%20doesn't%20set%20an%20explicit%20model%20and%20never%20asserts%20on%20the%20new%20%60Current%20model%3A%60%20line.%20After%20this%20PR%20every%20%60%3Cturn_meta%3E%60%20block%20unconditionally%20includes%20that%20line%2C%20so%20a%20test%20exercising%20the%20working-set%20path%20silently%20validates%20it%20with%20whatever%20%60DEFAULT_TEXT_MODEL%60%20happens%20to%20be.%20Adding%20a%20model%20to%20the%20config%20and%20asserting%20the%20line%20keeps%20the%20test%20consistent%20with%20the%20two%20tests%20that%20were%20explicitly%20updated.%0A%0A%60%60%60suggestion%0A%20%20%20%20let%20config%20%3D%20EngineConfig%20%7B%0A%20%20%20%20%20%20%20%20model%3A%20%22deepseek-v4-flash%22.to_string%28%29%2C%0A%20%20%20%20%20%20%20%20workspace%3A%20tmp.path%28%29.to_path_buf%28%29%2C%0A%20%20%20%20%20%20%20%20..Default%3A%3Adefault%28%29%0A%20%20%20%20%7D%3B%0A%20%20%20%20let%20%28mut%20engine%2C%20_handle%29%20%3D%20Engine%3A%3Anew%28config%2C%20%26Config%3A%3Adefault%28%29%29%3B%0A%20%20%20%20engine%0A%20%20%20%20%20%20%20%20.session%0A%20%20%20%20%20%20%20%20.working_set%0A%20%20%20%20%20%20%20%20.observe_user_message%28%22please%20inspect%20src%2Flib.rs%22%2C%20tmp.path%28%29%29%3B%0A%20%20%20%20let%20user_msg%20%3D%0A%20%20%20%20%20%20%20%20engine.user_text_message_with_turn_metadata%28%22please%20inspect%20src%2Flib.rs%22.to_string%28%29%29%3B%0A%20%20%20%20engine.session.add_message%28user_msg%29%3B%0A%0A%20%20%20%20let%20messages%20%3D%20engine.messages_with_turn_metadata%28%29%3B%0A%20%20%20%20let%20first_block%20%3D%20messages%0A%20%20%20%20%20%20%20%20.last%28%29%0A%20%20%20%20%20%20%20%20.and_then%28%7Cmessage%7C%20message.content.first%28%29%29%0A%20%20%20%20%20%20%20%20.expect%28%22turn%20metadata%20block%22%29%3B%0A%20%20%20%20let%20ContentBlock%3A%3AText%20%7B%20text%2C%20..%20%7D%20%3D%20first_block%20else%20%7B%0A%20%20%20%20%20%20%20%20panic!%28%22expected%20text%20metadata%20block%22%29%3B%0A%20%20%20%20%7D%3B%0A%20%20%20%20assert!%28text.starts_with%28%22%3Cturn_meta%3E%5Cn%22%29%29%3B%0A%20%20%20%20assert!%28text.contains%28%22Current%20model%3A%20deepseek-v4-flash%22%29%29%3B%0A%20%20%20%20assert!%28text.contains%28WORKING_SET_SUMMARY_MARKER%29%29%3B%0A%20%20%20%20assert!%28text.contains%28%22src%2Flib.rs%22%29%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine%2Ftests.rs%3A1465-1488%0AThe%20%60working_set_reaches_model_as_turn_metadata%60%20test%20doesn't%20set%20an%20explicit%20model%20and%20never%20asserts%20on%20the%20new%20%60Current%20model%3A%60%20line.%20After%20this%20PR%20every%20%60%3Cturn_meta%3E%60%20block%20unconditionally%20includes%20that%20line%2C%20so%20a%20test%20exercising%20the%20working-set%20path%20silently%20validates%20it%20with%20whatever%20%60DEFAULT_TEXT_MODEL%60%20happens%20to%20be.%20Adding%20a%20model%20to%20the%20config%20and%20asserting%20the%20line%20keeps%20the%20test%20consistent%20with%20the%20two%20tests%20that%20were%20explicitly%20updated.%0A%0A%60%60%60suggestion%0A%20%20%20%20let%20config%20%3D%20EngineConfig%20%7B%0A%20%20%20%20%20%20%20%20model%3A%20%22deepseek-v4-flash%22.to_string%28%29%2C%0A%20%20%20%20%20%20%20%20workspace%3A%20tmp.path%28%29.to_path_buf%28%29%2C%0A%20%20%20%20%20%20%20%20..Default%3A%3Adefault%28%29%0A%20%20%20%20%7D%3B%0A%20%20%20%20let%20%28mut%20engine%2C%20_handle%29%20%3D%20Engine%3A%3Anew%28config%2C%20%26Config%3A%3Adefault%28%29%29%3B%0A%20%20%20%20engine%0A%20%20%20%20%20%20%20%20.session%0A%20%20%20%20%20%20%20%20.working_set%0A%20%20%20%20%20%20%20%20.observe_user_message%28%22please%20inspect%20src%2Flib.rs%22%2C%20tmp.path%28%29%29%3B%0A%20%20%20%20let%20user_msg%20%3D%0A%20%20%20%20%20%20%20%20engine.user_text_message_with_turn_metadata%28%22please%20inspect%20src%2Flib.rs%22.to_string%28%29%29%3B%0A%20%20%20%20engine.session.add_message%28user_msg%29%3B%0A%0A%20%20%20%20let%20messages%20%3D%20engine.messages_with_turn_metadata%28%29%3B%0A%20%20%20%20let%20first_block%20%3D%20messages%0A%20%20%20%20%20%20%20%20.last%28%29%0A%20%20%20%20%20%20%20%20.and_then%28%7Cmessage%7C%20message.content.first%28%29%29%0A%20%20%20%20%20%20%20%20.expect%28%22turn%20metadata%20block%22%29%3B%0A%20%20%20%20let%20ContentBlock%3A%3AText%20%7B%20text%2C%20..%20%7D%20%3D%20first_block%20else%20%7B%0A%20%20%20%20%20%20%20%20panic!%28%22expected%20text%20metadata%20block%22%29%3B%0A%20%20%20%20%7D%3B%0A%20%20%20%20assert!%28text.starts_with%28%22%3Cturn_meta%3E%5Cn%22%29%29%3B%0A%20%20%20%20assert!%28text.contains%28%22Current%20model%3A%20deepseek-v4-flash%22%29%29%3B%0A%20%20%20%20assert!%28text.contains%28WORKING_SET_SUMMARY_MARKER%29%29%3B%0A%20%20%20%20assert!%28text.contains%28%22src%2Flib.rs%22%29%29%3B%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2536&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine%2Ftests.rs%3A1465-1488%0AThe%20%60working_set_reaches_model_as_turn_metadata%60%20test%20doesn't%20set%20an%20explicit%20model%20and%20never%20asserts%20on%20the%20new%20%60Current%20model%3A%60%20line.%20After%20this%20PR%20every%20%60%3Cturn_meta%3E%60%20block%20unconditionally%20includes%20that%20line%2C%20so%20a%20test%20exercising%20the%20working-set%20path%20silently%20validates%20it%20with%20whatever%20%60DEFAULT_TEXT_MODEL%60%20happens%20to%20be.%20Adding%20a%20model%20to%20the%20config%20and%20asserting%20the%20line%20keeps%20the%20test%20consistent%20with%20the%20two%20tests%20that%20were%20explicitly%20updated.%0A%0A%60%60%60suggestion%0A%20%20%20%20let%20config%20%3D%20EngineConfig%20%7B%0A%20%20%20%20%20%20%20%20model%3A%20%22deepseek-v4-flash%22.to_string%28%29%2C%0A%20%20%20%20%20%20%20%20workspace%3A%20tmp.path%28%29.to_path_buf%28%29%2C%0A%20%20%20%20%20%20%20%20..Default%3A%3Adefault%28%29%0A%20%20%20%20%7D%3B%0A%20%20%20%20let%20%28mut%20engine%2C%20_handle%29%20%3D%20Engine%3A%3Anew%28config%2C%20%26Config%3A%3Adefault%28%29%29%3B%0A%20%20%20%20engine%0A%20%20%20%20%20%20%20%20.session%0A%20%20%20%20%20%20%20%20.working_set%0A%20%20%20%20%20%20%20%20.observe_user_message%28%22please%20inspect%20src%2Flib.rs%22%2C%20tmp.path%28%29%29%3B%0A%20%20%20%20let%20user_msg%20%3D%0A%20%20%20%20%20%20%20%20engine.user_text_message_with_turn_metadata%28%22please%20inspect%20src%2Flib.rs%22.to_string%28%29%29%3B%0A%20%20%20%20engine.session.add_message%28user_msg%29%3B%0A%0A%20%20%20%20let%20messages%20%3D%20engine.messages_with_turn_metadata%28%29%3B%0A%20%20%20%20let%20first_block%20%3D%20messages%0A%20%20%20%20%20%20%20%20.last%28%29%0A%20%20%20%20%20%20%20%20.and_then%28%7Cmessage%7C%20message.content.first%28%29%29%0A%20%20%20%20%20%20%20%20.expect%28%22turn%20metadata%20block%22%29%3B%0A%20%20%20%20let%20ContentBlock%3A%3AText%20%7B%20text%2C%20..%20%7D%20%3D%20first_block%20else%20%7B%0A%20%20%20%20%20%20%20%20panic!%28%22expected%20text%20metadata%20block%22%29%3B%0A%20%20%20%20%7D%3B%0A%20%20%20%20assert!%28text.starts_with%28%22%3Cturn_meta%3E%5Cn%22%29%29%3B%0A%20%20%20%20assert!%28text.contains%28%22Current%20model%3A%20deepseek-v4-flash%22%29%29%3B%0A%20%20%20%20assert!%28text.contains%28WORKING_SET_SUMMARY_MARKER%29%29%3B%0A%20%20%20%20assert!%28text.contains%28%22src%2Flib.rs%22%29%29%3B%0A%60%60%60%0A%0A&pr=2536&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(tui): expose current model in turn ..."](https://github.com/hmbown/codewhale/commit/1ee202f1dce5fc6da885df31b6348bf8d73fd987) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34977081)</sub>

<!-- /greptile_comment -->