### PR TITLE
fix(subagent): guard truncated tool calls

### DIFF
--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -28,7 +28,7 @@ use crate::client::DeepSeekClient;
 use crate::config::MAX_SUBAGENTS;
 use crate::core::events::Event;
 use crate::llm_client::LlmClient;
-use crate::models::{ContentBlock, Message, MessageRequest, SystemPrompt, Tool};
+use crate::models::{ContentBlock, Message, MessageRequest, MessageResponse, SystemPrompt, Tool};
 use crate::tools::handle::VarHandle;
 use crate::tools::plan::{PlanState, SharedPlanState};
 use crate::tools::registry::{ToolRegistry, ToolRegistryBuilder};
@@ -69,6 +69,10 @@ fn release_resident_leases_for(agent_id: &str) {
 /// the `SubAgentManager`.
 const DEFAULT_MAX_STEPS: u32 = u32::MAX;
 const TOOL_TIMEOUT: Duration = Duration::from_secs(30);
+// Non-streaming sub-agents need enough response budget to carry large tool-call
+// arguments, especially write_file content. The API bills generated tokens, not
+// the requested ceiling.
+const SUBAGENT_RESPONSE_MAX_TOKENS: u32 = 16_384;
 /// Per-step LLM API call timeout. Each `create_message` request must complete
 /// within this window or the step is treated as timed out. Prevents a single
 /// stuck API call from blocking the sub-agent indefinitely.
@@ -3644,6 +3648,24 @@ fn subagent_failed_sentinel(agent_id: &str, _err: &str) -> String {
     format!("<codewhale:subagent.done>{payload}</codewhale:subagent.done>")
 }
 
+fn response_was_truncated(response: &MessageResponse) -> bool {
+    response.stop_reason.as_deref() == Some("length")
+}
+
+fn truncated_response_tool_results(tool_uses: &[(String, String, Value)]) -> Vec<ContentBlock> {
+    tool_uses
+        .iter()
+        .map(|(tool_id, tool_name, _)| ContentBlock::ToolResult {
+            tool_use_id: tool_id.clone(),
+            content: format!(
+                "Error: the model response was truncated by max_tokens before the tool call arguments for '{tool_name}' could be fully generated. Split large content into smaller writes and retry."
+            ),
+            is_error: Some(true),
+            content_blocks: None,
+        })
+        .collect()
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn insert_subagent_full_transcript_handle(
     runtime: &SubAgentRuntime,
@@ -3812,7 +3834,7 @@ async fn run_subagent(
         let request = MessageRequest {
             model: runtime.model.clone(),
             messages: messages.clone(),
-            max_tokens: 4096,
+            max_tokens: SUBAGENT_RESPONSE_MAX_TOKENS,
             system: Some(request_system.clone()),
             tools: Some(tools.clone()),
             tool_choice: Some(json!({ "type": "auto" })),
@@ -3923,6 +3945,23 @@ async fn run_subagent(
                 );
                 break;
             }
+            continue;
+        }
+
+        if response_was_truncated(&response) {
+            emit_agent_progress(
+                runtime.event_tx.as_ref(),
+                runtime.mailbox.as_ref(),
+                &agent_id,
+                format!(
+                    "step {steps}/{max_steps}: response truncated, returning {} tool error(s)",
+                    tool_uses.len()
+                ),
+            );
+            messages.push(Message {
+                role: "user".to_string(),
+                content: truncated_response_tool_results(&tool_uses),
+            });
             continue;
         }
 

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -73,6 +73,7 @@ const TOOL_TIMEOUT: Duration = Duration::from_secs(30);
 // arguments, especially write_file content. The API bills generated tokens, not
 // the requested ceiling.
 const SUBAGENT_RESPONSE_MAX_TOKENS: u32 = 16_384;
+const MAX_CONSECUTIVE_TRUNCATED_SUBAGENT_RESPONSES: u32 = 5;
 /// Per-step LLM API call timeout. Each `create_message` request must complete
 /// within this window or the step is treated as timed out. Prevents a single
 /// stuck API call from blocking the sub-agent indefinitely.
@@ -3666,6 +3667,28 @@ fn truncated_response_tool_results(tool_uses: &[(String, String, Value)]) -> Vec
         .collect()
 }
 
+fn truncated_response_text_retry_message() -> Vec<ContentBlock> {
+    vec![ContentBlock::Text {
+        text: "Error: the model response was truncated by max_tokens. No complete tool call was available, so the partial response was not accepted as the sub-agent result. Retry with a shorter response or split the work into smaller steps.".to_string(),
+        cache_control: None,
+    }]
+}
+
+fn record_truncated_subagent_response(consecutive: &mut u32) -> Result<()> {
+    *consecutive = consecutive.saturating_add(1);
+    if *consecutive > MAX_CONSECUTIVE_TRUNCATED_SUBAGENT_RESPONSES {
+        return Err(anyhow!(
+            "Sub-agent response was truncated by max_tokens {count} consecutive times; stopping to avoid an unbounded retry loop.",
+            count = *consecutive
+        ));
+    }
+    Ok(())
+}
+
+fn reset_truncated_subagent_responses(consecutive: &mut u32) {
+    *consecutive = 0;
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn insert_subagent_full_transcript_handle(
     runtime: &SubAgentRuntime,
@@ -3750,6 +3773,7 @@ async fn run_subagent(
     let mut steps = 0;
     let mut final_result: Option<String> = None;
     let mut pending_inputs: VecDeque<SubAgentInput> = VecDeque::new();
+    let mut consecutive_truncated_responses = 0;
 
     for _step in 0..max_steps {
         // Cooperative cancellation: bail if this session's token was cancelled
@@ -3929,6 +3953,35 @@ async fn run_subagent(
             content: response.content.clone(),
         });
 
+        if response_was_truncated(&response) {
+            final_result = None;
+            record_truncated_subagent_response(&mut consecutive_truncated_responses)?;
+            let progress = if tool_uses.is_empty() {
+                "response truncated, returning retry instruction".to_string()
+            } else {
+                format!(
+                    "response truncated, returning {} tool error(s)",
+                    tool_uses.len()
+                )
+            };
+            emit_agent_progress(
+                runtime.event_tx.as_ref(),
+                runtime.mailbox.as_ref(),
+                &agent_id,
+                format!("step {steps}/{max_steps}: {progress}"),
+            );
+            messages.push(Message {
+                role: "user".to_string(),
+                content: if tool_uses.is_empty() {
+                    truncated_response_text_retry_message()
+                } else {
+                    truncated_response_tool_results(&tool_uses)
+                },
+            });
+            continue;
+        }
+        reset_truncated_subagent_responses(&mut consecutive_truncated_responses);
+
         if tool_uses.is_empty() {
             while let Ok(input) = input_rx.try_recv() {
                 if input.interrupt {
@@ -3945,23 +3998,6 @@ async fn run_subagent(
                 );
                 break;
             }
-            continue;
-        }
-
-        if response_was_truncated(&response) {
-            emit_agent_progress(
-                runtime.event_tx.as_ref(),
-                runtime.mailbox.as_ref(),
-                &agent_id,
-                format!(
-                    "step {steps}/{max_steps}: response truncated, returning {} tool error(s)",
-                    tool_uses.len()
-                ),
-            );
-            messages.push(Message {
-                role: "user".to_string(),
-                content: truncated_response_tool_results(&tool_uses),
-            });
             continue;
         }
 

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -1503,6 +1503,42 @@ async fn auto_approved_parent_runs_required_tools_in_subagent() {
 }
 
 #[test]
+fn subagent_request_budget_allows_large_write_file_arguments() {
+    assert_eq!(
+        SUBAGENT_RESPONSE_MAX_TOKENS, 16_384,
+        "non-streaming sub-agent tool calls need enough output budget for large write_file arguments"
+    );
+}
+
+#[test]
+fn truncated_subagent_tool_calls_return_model_visible_errors() {
+    let tool_uses = vec![(
+        "toolu_write".to_string(),
+        "write_file".to_string(),
+        json!({"path": "report.md", "content": "partial"}),
+    )];
+
+    let results = truncated_response_tool_results(&tool_uses);
+
+    assert_eq!(results.len(), 1);
+    match &results[0] {
+        ContentBlock::ToolResult {
+            tool_use_id,
+            content,
+            is_error,
+            ..
+        } => {
+            assert_eq!(tool_use_id, "toolu_write");
+            assert_eq!(is_error, &Some(true));
+            assert!(content.contains("truncated by max_tokens"));
+            assert!(content.contains("write_file"));
+            assert!(content.contains("smaller writes"));
+        }
+        other => panic!("expected tool error result, got {other:?}"),
+    }
+}
+
+#[test]
 fn child_cancellation_cascades_from_parent() {
     let parent = stub_runtime();
     let child = parent.child_runtime();

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -1539,6 +1539,39 @@ fn truncated_subagent_tool_calls_return_model_visible_errors() {
 }
 
 #[test]
+fn truncated_subagent_text_response_returns_model_visible_error() {
+    let results = truncated_response_text_retry_message();
+
+    assert_eq!(results.len(), 1);
+    match &results[0] {
+        ContentBlock::Text { text, .. } => {
+            assert!(text.contains("truncated by max_tokens"));
+            assert!(text.contains("No complete tool call was available"));
+            assert!(text.contains("Retry with a shorter response"));
+        }
+        other => panic!("expected text retry message, got {other:?}"),
+    }
+}
+
+#[test]
+fn consecutive_truncated_subagent_responses_are_capped() {
+    let mut consecutive = 0;
+
+    for _ in 0..MAX_CONSECUTIVE_TRUNCATED_SUBAGENT_RESPONSES {
+        record_truncated_subagent_response(&mut consecutive).expect("within truncation cap");
+    }
+
+    let err = record_truncated_subagent_response(&mut consecutive)
+        .expect_err("one more truncation should stop the sub-agent");
+    assert!(err.to_string().contains("truncated by max_tokens"));
+    assert!(err.to_string().contains("consecutive"));
+
+    reset_truncated_subagent_responses(&mut consecutive);
+    record_truncated_subagent_response(&mut consecutive).expect("reset should allow recovery");
+    assert_eq!(consecutive, 1);
+}
+
+#[test]
 fn child_cancellation_cascades_from_parent() {
     let parent = stub_runtime();
     let child = parent.child_runtime();


### PR DESCRIPTION
Problem
- Sub-agents use non-streaming model calls, so large write_file arguments can hit the response token ceiling and arrive as truncated tool calls.
- Executing those partial calls turns the real truncation into missing/empty tool arguments.

Change
- Raise the sub-agent response budget from 4096 to 16384 tokens.
- When the API reports finish_reason=length with tool calls, return model-visible tool errors instead of executing the likely-corrupt calls.

Verification
- cargo test -p codewhale-tui subagent_request_budget_allows_large_write_file_arguments --locked
- cargo test -p codewhale-tui truncated_subagent_tool_calls_return_model_visible_errors --locked
- cargo test -p codewhale-tui implementer_delegation_allows_suggest_write_without_parent_auto_approve --locked
- cargo test -p codewhale-tui tools::subagent::tests --locked
- cargo fmt --all -- --check
- git diff --check

Fixes #2533

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR addresses a real defect where non-streaming sub-agent calls could receive truncated tool-call arguments (e.g. large `write_file` payloads) and then silently execute them with corrupt/empty inputs. The fix has two parts: raising the response token budget from 4096 to 16384, and detecting `stop_reason = "length"` with pending tool uses, returning model-visible errors instead of executing the partial calls.

- Raises `SUBAGENT_RESPONSE_MAX_TOKENS` from 4096 → 16 384 and adds the truncation guard in `run_subagent`, skipping tool execution and feeding back structured `ToolResult` errors that instruct the model to use smaller writes.
- Adds `response_was_truncated` and `truncated_response_tool_results` helpers and covers them with two unit tests.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the truncation guard correctly prevents corrupt tool-call execution and message-history invariants are maintained in all branches.

The core fix is sound: the new helpers are simple, the check placement (after tool_uses.is_empty()) is intentional and correct for the tool-call case, and the new tests cover both helpers. Two gaps are worth tracking: text-only responses that exceed the budget still exit silently as success, and there is no retry cap if the model persistently generates oversized tool calls. Neither gap is a regression introduced by this PR, but neither is addressed by it either.

crates/tui/src/tools/subagent/mod.rs — specifically the interaction between the tool_uses.is_empty() early-exit and the new truncation check, and the absence of a consecutive-truncation retry limit.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/tui/src/tools/subagent/mod.rs | Raises SUBAGENT_RESPONSE_MAX_TOKENS to 16384 and adds a truncation guard that converts partial tool-use blocks into model-visible errors; check ordering means text-only truncation still silently exits as success, and there is no retry cap for consecutive truncations. |
| crates/tui/src/tools/subagent/tests.rs | Adds two unit tests: one asserting the constant value of SUBAGENT_RESPONSE_MAX_TOKENS and one verifying the shape of truncated_response_tool_results output; both are correct and cover the new helpers. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Loop iteration start\nsteps += 1] --> B[Build MessageRequest\nmax_tokens = 16384]
    B --> C[API call via create_message]
    C --> D{Cancelled?}
    D -- Yes --> E[Return Cancelled]
    D -- No --> F[Parse response\ncollect tool_uses]
    F --> G[Push assistant msg\nto messages]
    G --> H{tool_uses\nempty?}
    H -- Yes, no pending inputs --> I[break — agent complete]
    H -- Yes, pending inputs --> A
    H -- No --> J{stop_reason\n== 'length'?}
    J -- Yes --> K[Push ToolResult errors\nto messages]
    K --> A
    J -- No --> L[Execute tool calls\ncollect tool_results]
    L --> M[Push ToolResult blocks\nto messages]
    M --> A
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/tui/src/tools/subagent/mod.rs`, line 3932-3949 ([link](https://github.com/hmbown/codewhale/blob/21488ff8cd3bb1d6a436f87c9a503eadf3f6a0b2/crates/tui/src/tools/subagent/mod.rs#L3932-L3949)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Text-only truncation silently completes as success**

   The `response_was_truncated` guard is only reachable when `tool_uses` is non-empty — the `tool_uses.is_empty()` branch above it calls `break` (or `continue`) first. If `stop_reason = "length"` fires while the model is generating a long text answer (no tool calls started yet), `tool_uses` is empty, the loop exits via `break`, and `final_result` is set to a silently truncated string. The caller receives a successful `SubAgentResult` with incomplete output and no indication that the response was cut short. Raising `max_tokens` to 16 384 makes the scenario less common, but it still applies whenever a sub-agent produces a text-only response that exceeds the budget.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22codex%2F2533-subagent-truncation%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2F2533-subagent-truncation%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftools%2Fsubagent%2Fmod.rs%0ALine%3A%203932-3949%0A%0AComment%3A%0A**Text-only%20truncation%20silently%20completes%20as%20success**%0A%0AThe%20%60response_was_truncated%60%20guard%20is%20only%20reachable%20when%20%60tool_uses%60%20is%20non-empty%20%E2%80%94%20the%20%60tool_uses.is_empty%28%29%60%20branch%20above%20it%20calls%20%60break%60%20%28or%20%60continue%60%29%20first.%20If%20%60stop_reason%20%3D%20%22length%22%60%20fires%20while%20the%20model%20is%20generating%20a%20long%20text%20answer%20%28no%20tool%20calls%20started%20yet%29%2C%20%60tool_uses%60%20is%20empty%2C%20the%20loop%20exits%20via%20%60break%60%2C%20and%20%60final_result%60%20is%20set%20to%20a%20silently%20truncated%20string.%20The%20caller%20receives%20a%20successful%20%60SubAgentResult%60%20with%20incomplete%20output%20and%20no%20indication%20that%20the%20response%20was%20cut%20short.%20Raising%20%60max_tokens%60%20to%2016%20384%20makes%20the%20scenario%20less%20common%2C%20but%20it%20still%20applies%20whenever%20a%20sub-agent%20produces%20a%20text-only%20response%20that%20exceeds%20the%20budget.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftools%2Fsubagent%2Fmod.rs%0ALine%3A%203932-3949%0A%0AComment%3A%0A**Text-only%20truncation%20silently%20completes%20as%20success**%0A%0AThe%20%60response_was_truncated%60%20guard%20is%20only%20reachable%20when%20%60tool_uses%60%20is%20non-empty%20%E2%80%94%20the%20%60tool_uses.is_empty%28%29%60%20branch%20above%20it%20calls%20%60break%60%20%28or%20%60continue%60%29%20first.%20If%20%60stop_reason%20%3D%20%22length%22%60%20fires%20while%20the%20model%20is%20generating%20a%20long%20text%20answer%20%28no%20tool%20calls%20started%20yet%29%2C%20%60tool_uses%60%20is%20empty%2C%20the%20loop%20exits%20via%20%60break%60%2C%20and%20%60final_result%60%20is%20set%20to%20a%20silently%20truncated%20string.%20The%20caller%20receives%20a%20successful%20%60SubAgentResult%60%20with%20incomplete%20output%20and%20no%20indication%20that%20the%20response%20was%20cut%20short.%20Raising%20%60max_tokens%60%20to%2016%20384%20makes%20the%20scenario%20less%20common%2C%20but%20it%20still%20applies%20whenever%20a%20sub-agent%20produces%20a%20text-only%20response%20that%20exceeds%20the%20budget.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2537&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftools%2Fsubagent%2Fmod.rs%0ALine%3A%203932-3949%0A%0AComment%3A%0A**Text-only%20truncation%20silently%20completes%20as%20success**%0A%0AThe%20%60response_was_truncated%60%20guard%20is%20only%20reachable%20when%20%60tool_uses%60%20is%20non-empty%20%E2%80%94%20the%20%60tool_uses.is_empty%28%29%60%20branch%20above%20it%20calls%20%60break%60%20%28or%20%60continue%60%29%20first.%20If%20%60stop_reason%20%3D%20%22length%22%60%20fires%20while%20the%20model%20is%20generating%20a%20long%20text%20answer%20%28no%20tool%20calls%20started%20yet%29%2C%20%60tool_uses%60%20is%20empty%2C%20the%20loop%20exits%20via%20%60break%60%2C%20and%20%60final_result%60%20is%20set%20to%20a%20silently%20truncated%20string.%20The%20caller%20receives%20a%20successful%20%60SubAgentResult%60%20with%20incomplete%20output%20and%20no%20indication%20that%20the%20response%20was%20cut%20short.%20Raising%20%60max_tokens%60%20to%2016%20384%20makes%20the%20scenario%20less%20common%2C%20but%20it%20still%20applies%20whenever%20a%20sub-agent%20produces%20a%20text-only%20response%20that%20exceeds%20the%20budget.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2537&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22codex%2F2533-subagent-truncation%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2F2533-subagent-truncation%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftools%2Fsubagent%2Fmod.rs%3A3932-3949%0A**Text-only%20truncation%20silently%20completes%20as%20success**%0A%0AThe%20%60response_was_truncated%60%20guard%20is%20only%20reachable%20when%20%60tool_uses%60%20is%20non-empty%20%E2%80%94%20the%20%60tool_uses.is_empty%28%29%60%20branch%20above%20it%20calls%20%60break%60%20%28or%20%60continue%60%29%20first.%20If%20%60stop_reason%20%3D%20%22length%22%60%20fires%20while%20the%20model%20is%20generating%20a%20long%20text%20answer%20%28no%20tool%20calls%20started%20yet%29%2C%20%60tool_uses%60%20is%20empty%2C%20the%20loop%20exits%20via%20%60break%60%2C%20and%20%60final_result%60%20is%20set%20to%20a%20silently%20truncated%20string.%20The%20caller%20receives%20a%20successful%20%60SubAgentResult%60%20with%20incomplete%20output%20and%20no%20indication%20that%20the%20response%20was%20cut%20short.%20Raising%20%60max_tokens%60%20to%2016%20384%20makes%20the%20scenario%20less%20common%2C%20but%20it%20still%20applies%20whenever%20a%20sub-agent%20produces%20a%20text-only%20response%20that%20exceeds%20the%20budget.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftools%2Fsubagent%2Fmod.rs%3A3951-3966%0A**No%20cap%20on%20consecutive%20truncation%20retries**%0A%0AWhen%20the%20model%20repeatedly%20generates%20tool-call%20arguments%20larger%20than%20the%2016%20384-token%20budget%2C%20each%20iteration%3A%20returns%20errors%20%E2%86%92%20model%20retries%20%E2%86%92%20truncates%20again%20%E2%86%92%20%60continue%60.%20The%20only%20outer%20bound%20is%20%60DEFAULT_MAX_STEPS%20%3D%20u32%3A%3AMAX%60%2C%20which%20is%20functionally%20unlimited.%20A%20stubborn%20or%20confused%20model%20could%20spin%20through%20many%20API%20calls%20burning%20significant%20token%20budget%20before%20an%20external%20cancel%20arrives.%20A%20small%20dedicated%20counter%20%28e.g.%20%60consecutive_truncations%60%29%20reset%20on%20any%20successful%20step%2C%20combined%20with%20a%20hard%20limit%20%28say%2C%205%29%2C%20would%20bound%20the%20blast%20radius%20without%20affecting%20normal%20recovery.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftools%2Fsubagent%2Fmod.rs%3A3932-3949%0A**Text-only%20truncation%20silently%20completes%20as%20success**%0A%0AThe%20%60response_was_truncated%60%20guard%20is%20only%20reachable%20when%20%60tool_uses%60%20is%20non-empty%20%E2%80%94%20the%20%60tool_uses.is_empty%28%29%60%20branch%20above%20it%20calls%20%60break%60%20%28or%20%60continue%60%29%20first.%20If%20%60stop_reason%20%3D%20%22length%22%60%20fires%20while%20the%20model%20is%20generating%20a%20long%20text%20answer%20%28no%20tool%20calls%20started%20yet%29%2C%20%60tool_uses%60%20is%20empty%2C%20the%20loop%20exits%20via%20%60break%60%2C%20and%20%60final_result%60%20is%20set%20to%20a%20silently%20truncated%20string.%20The%20caller%20receives%20a%20successful%20%60SubAgentResult%60%20with%20incomplete%20output%20and%20no%20indication%20that%20the%20response%20was%20cut%20short.%20Raising%20%60max_tokens%60%20to%2016%20384%20makes%20the%20scenario%20less%20common%2C%20but%20it%20still%20applies%20whenever%20a%20sub-agent%20produces%20a%20text-only%20response%20that%20exceeds%20the%20budget.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftools%2Fsubagent%2Fmod.rs%3A3951-3966%0A**No%20cap%20on%20consecutive%20truncation%20retries**%0A%0AWhen%20the%20model%20repeatedly%20generates%20tool-call%20arguments%20larger%20than%20the%2016%20384-token%20budget%2C%20each%20iteration%3A%20returns%20errors%20%E2%86%92%20model%20retries%20%E2%86%92%20truncates%20again%20%E2%86%92%20%60continue%60.%20The%20only%20outer%20bound%20is%20%60DEFAULT_MAX_STEPS%20%3D%20u32%3A%3AMAX%60%2C%20which%20is%20functionally%20unlimited.%20A%20stubborn%20or%20confused%20model%20could%20spin%20through%20many%20API%20calls%20burning%20significant%20token%20budget%20before%20an%20external%20cancel%20arrives.%20A%20small%20dedicated%20counter%20%28e.g.%20%60consecutive_truncations%60%29%20reset%20on%20any%20successful%20step%2C%20combined%20with%20a%20hard%20limit%20%28say%2C%205%29%2C%20would%20bound%20the%20blast%20radius%20without%20affecting%20normal%20recovery.%0A%0A&repo=hmbown%2Fcodewhale&pr=2537&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftools%2Fsubagent%2Fmod.rs%3A3932-3949%0A**Text-only%20truncation%20silently%20completes%20as%20success**%0A%0AThe%20%60response_was_truncated%60%20guard%20is%20only%20reachable%20when%20%60tool_uses%60%20is%20non-empty%20%E2%80%94%20the%20%60tool_uses.is_empty%28%29%60%20branch%20above%20it%20calls%20%60break%60%20%28or%20%60continue%60%29%20first.%20If%20%60stop_reason%20%3D%20%22length%22%60%20fires%20while%20the%20model%20is%20generating%20a%20long%20text%20answer%20%28no%20tool%20calls%20started%20yet%29%2C%20%60tool_uses%60%20is%20empty%2C%20the%20loop%20exits%20via%20%60break%60%2C%20and%20%60final_result%60%20is%20set%20to%20a%20silently%20truncated%20string.%20The%20caller%20receives%20a%20successful%20%60SubAgentResult%60%20with%20incomplete%20output%20and%20no%20indication%20that%20the%20response%20was%20cut%20short.%20Raising%20%60max_tokens%60%20to%2016%20384%20makes%20the%20scenario%20less%20common%2C%20but%20it%20still%20applies%20whenever%20a%20sub-agent%20produces%20a%20text-only%20response%20that%20exceeds%20the%20budget.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftools%2Fsubagent%2Fmod.rs%3A3951-3966%0A**No%20cap%20on%20consecutive%20truncation%20retries**%0A%0AWhen%20the%20model%20repeatedly%20generates%20tool-call%20arguments%20larger%20than%20the%2016%20384-token%20budget%2C%20each%20iteration%3A%20returns%20errors%20%E2%86%92%20model%20retries%20%E2%86%92%20truncates%20again%20%E2%86%92%20%60continue%60.%20The%20only%20outer%20bound%20is%20%60DEFAULT_MAX_STEPS%20%3D%20u32%3A%3AMAX%60%2C%20which%20is%20functionally%20unlimited.%20A%20stubborn%20or%20confused%20model%20could%20spin%20through%20many%20API%20calls%20burning%20significant%20token%20budget%20before%20an%20external%20cancel%20arrives.%20A%20small%20dedicated%20counter%20%28e.g.%20%60consecutive_truncations%60%29%20reset%20on%20any%20successful%20step%2C%20combined%20with%20a%20hard%20limit%20%28say%2C%205%29%2C%20would%20bound%20the%20blast%20radius%20without%20affecting%20normal%20recovery.%0A%0A&pr=2537&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(subagent): guard truncated tool call..."](https://github.com/hmbown/codewhale/commit/21488ff8cd3bb1d6a436f87c9a503eadf3f6a0b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34981859)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->