### PR TITLE
fix(mcp): surface invalid stdio output

### DIFF
--- a/crates/tui/src/mcp.rs
+++ b/crates/tui/src/mcp.rs
@@ -196,6 +196,22 @@ async fn bounded_body_excerpt(response: reqwest::Response, max_bytes: usize) -> 
     format!("{}{}", redact_body_preview(&one_line), suffix)
 }
 
+fn invalid_json_preview(bytes: &[u8]) -> String {
+    let body_text = String::from_utf8_lossy(bytes);
+    if body_text.is_empty() {
+        return "<empty>".to_string();
+    }
+
+    let trimmed: String = body_text.chars().take(ERROR_BODY_PREVIEW_BYTES).collect();
+    let suffix = if body_text.len() > trimmed.len() {
+        "…"
+    } else {
+        ""
+    };
+    let one_line = trimmed.replace(['\n', '\r'], " ");
+    format!("{}{}", redact_body_preview(&one_line), suffix)
+}
+
 // === Configuration Types ===
 
 /// Full MCP configuration from mcp.json
@@ -1824,7 +1840,11 @@ impl McpConnection {
                 self.state = ConnectionState::Disconnected;
             })?;
             let value: serde_json::Value = serde_json::from_slice(&bytes).with_context(|| {
-                format!("Invalid MCP JSON-RPC message from server '{}'", self.name)
+                format!(
+                    "Invalid MCP JSON-RPC message from server '{}': {}",
+                    self.name,
+                    invalid_json_preview(&bytes)
+                )
             })?;
 
             // Check if this is a response with the expected id. We emit
@@ -3377,6 +3397,25 @@ mod tests {
         assert_eq!(sent[0]["jsonrpc"], "2.0");
         assert_eq!(sent[0]["id"], "1");
         assert_eq!(sent[0]["method"], "tools/call");
+    }
+
+    #[tokio::test]
+    async fn call_method_invalid_json_includes_server_output_preview() {
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let transport = ScriptedValueTransport {
+            sent: Arc::clone(&sent),
+            responses: VecDeque::from([b"Allow Burp MCP connection? [y/N]".to_vec()]),
+        };
+        let mut conn = test_connection(Box::new(transport));
+
+        let err = conn
+            .call_method("tools/call", serde_json::json!({"name": "burp"}), 1)
+            .await
+            .expect_err("non-json MCP stdout should fail");
+        let msg = err.to_string();
+
+        assert!(msg.contains("Invalid MCP JSON-RPC message from server 'mock'"));
+        assert!(msg.contains("Allow Burp MCP connection"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Problem
- Stdio MCP servers can print a startup/connection prompt instead of JSON-RPC. The existing parse error only said the message was invalid, which hides the prompt text that explains why the run stopped.

Change
- Include a bounded, single-line preview of invalid MCP stdio output in the JSON-RPC parse error.
- Reuse the existing body preview redaction path for bearer tokens and common API key parameters.

Verification
- cargo test -p codewhale-tui call_method_invalid_json_includes_server_output_preview --locked
- cargo test -p codewhale-tui call_method_skips_notifications_and_unmatched_responses --locked
- cargo test -p codewhale-tui call_method_times_out_while_waiting_for_response --locked
- cargo test -p codewhale-tui mcp --locked
- cargo fmt --all -- --check
- git diff --check

Refs #2475

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR improves the MCP stdio error experience by embedding a bounded, redacted preview of the raw server output in the JSON-RPC parse error message, helping users diagnose connection prompts or banner text that interrupts the protocol stream.

- Adds `invalid_json_preview`, a standalone synchronous helper that lossy-decodes raw bytes, caps at `ERROR_BODY_PREVIEW_BYTES` (200) characters, collapses newlines to spaces, and pipes the result through the existing `redact_body_preview` pass before embedding it in the error.
- Threads the preview into the `serde_json::from_slice` error site in `McpConnection::recv`, and adds a targeted test (`call_method_invalid_json_includes_server_output_preview`) to verify the preview text is present in the error chain.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change is narrow and the core logic is correct.

The new `invalid_json_preview` helper is a straightforward adaptation of the existing `bounded_body_excerpt` pattern. The suffix truncation comparison is technically correct and the redaction path is reused unmodified. The only gaps are missing tests for multi-line collapsing and redaction, plus a mildly misleading byte-vs-char comparison in the suffix check.

No files require special attention; `crates/tui/src/mcp.rs` is well-contained and the change is isolated to error formatting.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/mcp.rs | Adds `invalid_json_preview` helper and wires it into the JSON-RPC parse error; logic is correct and tested for the primary case, though multi-line collapsing and redaction in this new context lack dedicated test coverage. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as Caller
    participant MC as McpConnection
    participant T as StdioTransport
    participant S as MCP Server

    C->>MC: call_method("tools/call", params, timeout)
    MC->>T: send(JSON-RPC request)
    T->>S: write bytes
    S-->>T: raw bytes (e.g. "Allow Burp MCP connection? [y/N]")
    T-->>MC: recv() returns raw bytes
    MC->>MC: serde_json::from_slice fails
    MC->>MC: "invalid_json_preview(&bytes)"
    Note over MC: from_utf8_lossy, cap 200 chars,<br/>collapse newlines, redact secrets
    MC-->>C: Err with preview embedded in message
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22codex%2F2475-mcp-stdio-invalid-json%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2F2475-mcp-stdio-invalid-json%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fmcp.rs%3A205-210%0AThe%20suffix%20truncation%20flag%20is%20computed%20by%20comparing%20byte%20lengths%20%28%60body_text.len%28%29%60%20vs%20%60trimmed.len%28%29%60%29%2C%20but%20%60ERROR_BODY_PREVIEW_BYTES%60%20is%20used%20as%20a%20**character**%20count%20via%20%60.chars%28%29.take%28%29%60.%20The%20comparison%20is%20coincidentally%20correct%20%28fewer%20chars%20always%20means%20fewer%20bytes%20in%20UTF-8%29%2C%20but%20it%20reads%20as%20a%20byte-vs-byte%20comparison%20when%20the%20intent%20is%20char-vs-char.%20Matching%20the%20idiom%20used%20elsewhere%20in%20the%20file%20would%20make%20this%20self-documenting.%0A%0A%60%60%60suggestion%0A%20%20%20%20let%20trimmed%3A%20String%20%3D%20body_text.chars%28%29.take%28ERROR_BODY_PREVIEW_BYTES%29.collect%28%29%3B%0A%20%20%20%20let%20suffix%20%3D%20if%20body_text.chars%28%29.count%28%29%20%3E%20ERROR_BODY_PREVIEW_BYTES%20%7B%0A%20%20%20%20%20%20%20%20%22%E2%80%A6%22%0A%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%22%22%0A%20%20%20%20%7D%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fmcp.rs%3A3402-3419%0A**Missing%20test%20coverage%20for%20multi-line%20collapsing%20and%20redaction**%0A%0AThe%20new%20test%20exercises%20the%20happy%20path%20%28plain%20ASCII%20prompt%20%E2%86%92%20preview%20in%20error%29%2C%20but%20two%20behaviours%20described%20in%20the%20PR%20are%20untested%3A%20%281%29%20multi-line%20server%20output%20%28e.g.%20a%20banner%20with%20%60%5Cn%60%29%20being%20collapsed%20to%20a%20single%20space-separated%20line%2C%20and%20%282%29%20a%20prompt%20that%20contains%20a%20bearer%20token%20or%20%60api_key%3D%60%20being%20redacted%20before%20surfacing.%20A%20server%20that%20prints%20%60Authorization%3A%20Bearer%20secrettoken%5CnAllow%20connection%3F%60%20would%20silently%20leak%20the%20token%20into%20logs%20if%20the%20redaction%20path%20has%20a%20latent%20bug%20%E2%80%94%20the%20test%20wouldn't%20catch%20it.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fmcp.rs%3A205-210%0AThe%20suffix%20truncation%20flag%20is%20computed%20by%20comparing%20byte%20lengths%20%28%60body_text.len%28%29%60%20vs%20%60trimmed.len%28%29%60%29%2C%20but%20%60ERROR_BODY_PREVIEW_BYTES%60%20is%20used%20as%20a%20**character**%20count%20via%20%60.chars%28%29.take%28%29%60.%20The%20comparison%20is%20coincidentally%20correct%20%28fewer%20chars%20always%20means%20fewer%20bytes%20in%20UTF-8%29%2C%20but%20it%20reads%20as%20a%20byte-vs-byte%20comparison%20when%20the%20intent%20is%20char-vs-char.%20Matching%20the%20idiom%20used%20elsewhere%20in%20the%20file%20would%20make%20this%20self-documenting.%0A%0A%60%60%60suggestion%0A%20%20%20%20let%20trimmed%3A%20String%20%3D%20body_text.chars%28%29.take%28ERROR_BODY_PREVIEW_BYTES%29.collect%28%29%3B%0A%20%20%20%20let%20suffix%20%3D%20if%20body_text.chars%28%29.count%28%29%20%3E%20ERROR_BODY_PREVIEW_BYTES%20%7B%0A%20%20%20%20%20%20%20%20%22%E2%80%A6%22%0A%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%22%22%0A%20%20%20%20%7D%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fmcp.rs%3A3402-3419%0A**Missing%20test%20coverage%20for%20multi-line%20collapsing%20and%20redaction**%0A%0AThe%20new%20test%20exercises%20the%20happy%20path%20%28plain%20ASCII%20prompt%20%E2%86%92%20preview%20in%20error%29%2C%20but%20two%20behaviours%20described%20in%20the%20PR%20are%20untested%3A%20%281%29%20multi-line%20server%20output%20%28e.g.%20a%20banner%20with%20%60%5Cn%60%29%20being%20collapsed%20to%20a%20single%20space-separated%20line%2C%20and%20%282%29%20a%20prompt%20that%20contains%20a%20bearer%20token%20or%20%60api_key%3D%60%20being%20redacted%20before%20surfacing.%20A%20server%20that%20prints%20%60Authorization%3A%20Bearer%20secrettoken%5CnAllow%20connection%3F%60%20would%20silently%20leak%20the%20token%20into%20logs%20if%20the%20redaction%20path%20has%20a%20latent%20bug%20%E2%80%94%20the%20test%20wouldn't%20catch%20it.%0A%0A&repo=hmbown%2Fcodewhale&pr=2538&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fmcp.rs%3A205-210%0AThe%20suffix%20truncation%20flag%20is%20computed%20by%20comparing%20byte%20lengths%20%28%60body_text.len%28%29%60%20vs%20%60trimmed.len%28%29%60%29%2C%20but%20%60ERROR_BODY_PREVIEW_BYTES%60%20is%20used%20as%20a%20**character**%20count%20via%20%60.chars%28%29.take%28%29%60.%20The%20comparison%20is%20coincidentally%20correct%20%28fewer%20chars%20always%20means%20fewer%20bytes%20in%20UTF-8%29%2C%20but%20it%20reads%20as%20a%20byte-vs-byte%20comparison%20when%20the%20intent%20is%20char-vs-char.%20Matching%20the%20idiom%20used%20elsewhere%20in%20the%20file%20would%20make%20this%20self-documenting.%0A%0A%60%60%60suggestion%0A%20%20%20%20let%20trimmed%3A%20String%20%3D%20body_text.chars%28%29.take%28ERROR_BODY_PREVIEW_BYTES%29.collect%28%29%3B%0A%20%20%20%20let%20suffix%20%3D%20if%20body_text.chars%28%29.count%28%29%20%3E%20ERROR_BODY_PREVIEW_BYTES%20%7B%0A%20%20%20%20%20%20%20%20%22%E2%80%A6%22%0A%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%22%22%0A%20%20%20%20%7D%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fmcp.rs%3A3402-3419%0A**Missing%20test%20coverage%20for%20multi-line%20collapsing%20and%20redaction**%0A%0AThe%20new%20test%20exercises%20the%20happy%20path%20%28plain%20ASCII%20prompt%20%E2%86%92%20preview%20in%20error%29%2C%20but%20two%20behaviours%20described%20in%20the%20PR%20are%20untested%3A%20%281%29%20multi-line%20server%20output%20%28e.g.%20a%20banner%20with%20%60%5Cn%60%29%20being%20collapsed%20to%20a%20single%20space-separated%20line%2C%20and%20%282%29%20a%20prompt%20that%20contains%20a%20bearer%20token%20or%20%60api_key%3D%60%20being%20redacted%20before%20surfacing.%20A%20server%20that%20prints%20%60Authorization%3A%20Bearer%20secrettoken%5CnAllow%20connection%3F%60%20would%20silently%20leak%20the%20token%20into%20logs%20if%20the%20redaction%20path%20has%20a%20latent%20bug%20%E2%80%94%20the%20test%20wouldn't%20catch%20it.%0A%0A&pr=2538&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(mcp): surface invalid stdio output"](https://github.com/hmbown/codewhale/commit/e46d858f970b90ddad5022d7bc34cc53e90bb5ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34987479)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->