### PR TITLE
fix(tui): include mode in turn metadata

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -924,6 +924,7 @@ impl Engine {
 
     fn turn_metadata_block(
         &self,
+        mode: AppMode,
         routed_model: &str,
         auto_model: bool,
         reasoning_effort: Option<&str>,
@@ -937,7 +938,10 @@ impl Engine {
             .map(|s| s.trim().to_string())
             .filter(|s| !s.is_empty());
 
-        let mut lines = vec![format!("Current local date: {today}")];
+        let mut lines = vec![
+            format!("Current local date: {today}"),
+            format!("Current mode: {}", mode.as_setting()),
+        ];
         if auto_model {
             lines.push(format!("Auto model route: {routed_model}"));
         }
@@ -958,6 +962,7 @@ impl Engine {
     fn user_text_message_with_turn_metadata(&self, text: String) -> Message {
         self.user_text_message_with_turn_metadata_for_route(
             text,
+            AppMode::Agent,
             &self.session.model,
             self.session.auto_model,
             self.session.reasoning_effort.as_deref(),
@@ -968,6 +973,7 @@ impl Engine {
     fn user_text_message_with_turn_metadata_for_route(
         &self,
         text: String,
+        mode: AppMode,
         routed_model: &str,
         auto_model: bool,
         reasoning_effort: Option<&str>,
@@ -977,6 +983,7 @@ impl Engine {
             role: "user".to_string(),
             content: vec![
                 self.turn_metadata_block(
+                    mode,
                     routed_model,
                     auto_model,
                     reasoning_effort,
@@ -1091,6 +1098,7 @@ impl Engine {
         // Add user message to session
         let user_msg = self.user_text_message_with_turn_metadata_for_route(
             content,
+            mode,
             &model,
             auto_model,
             reasoning_effort.as_deref(),

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -1524,6 +1524,7 @@ fn turn_metadata_includes_auto_model_route() {
 
     let user_msg = engine.user_text_message_with_turn_metadata_for_route(
         "debug this regression".to_string(),
+        AppMode::Agent,
         "deepseek-v4-pro",
         true,
         Some("max"),
@@ -1537,6 +1538,32 @@ fn turn_metadata_includes_auto_model_route() {
     assert!(text.contains("Auto model route: deepseek-v4-pro"));
     assert!(text.contains("Auto reasoning effort: max"));
     assert!(!text.contains("debug this regression"));
+}
+
+#[test]
+fn turn_metadata_includes_current_mode() {
+    let tmp = tempdir().expect("tempdir");
+    let config = EngineConfig {
+        workspace: tmp.path().to_path_buf(),
+        ..Default::default()
+    };
+    let (engine, _handle) = Engine::new(config, &Config::default());
+
+    let user_msg = engine.user_text_message_with_turn_metadata_for_route(
+        "please run the build now".to_string(),
+        AppMode::Yolo,
+        "deepseek-v4-pro",
+        false,
+        None,
+        false,
+    );
+    let first_block = user_msg.content.first().expect("turn metadata block");
+    let ContentBlock::Text { text, .. } = first_block else {
+        panic!("expected text metadata block");
+    };
+
+    assert!(text.contains("Current mode: yolo"));
+    assert!(!text.contains("please run the build now"));
 }
 
 #[test]


### PR DESCRIPTION
Problem
- Mode changes are only reflected in the refreshed prompt/tool context, but the per-turn metadata sent with the next user message does not include the active mode.

Change
- Add the current `AppMode` to `<turn_meta>` for user turns.
- Keep the scope limited to request metadata; this does not add a `get_mode` tool or auto-retry behavior.

Verification
- `cargo test -p codewhale-tui turn_metadata_includes_current_mode --locked`
- `cargo test -p codewhale-tui turn_metadata --locked`
- `cargo fmt --all -- --check`
- `git diff --check`

Refs #2515

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds the active `AppMode` to the `<turn_meta>` block sent with each user turn, so the model can see whether it is operating in agent, plan, or yolo mode on every request. The change threads a new `mode: AppMode` parameter through `turn_metadata_block` and `user_text_message_with_turn_metadata_for_route`, and a dedicated test (`turn_metadata_includes_current_mode`) verifies the Yolo-mode path.

- The main send path (`handle_send_message` → `user_text_message_with_turn_metadata_for_route`) correctly receives and forwards the live mode value.
- The no-route wrapper `user_text_message_with_turn_metadata` hardcodes `AppMode::Agent`; it is used for mid-turn steer messages, REPL feedback, goal-continuation messages, and LSP diagnostics — all of which will incorrectly report `agent` mode during Plan or Yolo sessions.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The main user-message path works correctly, but mid-turn injected messages (steers, REPL feedback, LSP diagnostics) will silently report the wrong mode in Plan and Yolo sessions.

The wrapper `user_text_message_with_turn_metadata` hardcodes `AppMode::Agent` and is called in seven places inside the turn loop for steer/REPL/continuation/LSP messages. In any non-Agent mode session those messages will carry `Current mode: agent`, which is the opposite of what this PR sets out to fix. The `mode` parameter is already present at every affected call-site in `turn_loop.rs` so the fix is straightforward, but the current code ships incorrect metadata on a high-frequency code path.

crates/tui/src/core/engine.rs — the `user_text_message_with_turn_metadata` wrapper and all its call-sites in `turn_loop.rs` and `lsp_hooks.rs`
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/tui/src/core/engine.rs | Adds `mode: AppMode` to `turn_metadata_block` and `user_text_message_with_turn_metadata_for_route`; the main send path correctly passes the live mode, but the no-route wrapper hardcodes `AppMode::Agent`, leaving steer/REPL/LSP mid-turn messages with wrong mode metadata in Plan and Yolo sessions. |
| crates/tui/src/core/engine/tests.rs | Adds `turn_metadata_includes_current_mode` test covering the Yolo mode path; correctly updates the existing `turn_metadata_includes_auto_model_route` test to supply the new `mode` argument. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as TUI / User
    participant Engine as Engine
    participant TurnLoop as handle_deepseek_turn
    participant Meta as turn_metadata_block

    UI->>Engine: Op::SendMessage(content, mode)
    Engine->>Engine: user_text_message_with_turn_metadata_for_route(content, mode)
    Engine->>Meta: turn_metadata_block(mode, ...)
    Meta-->>Engine: "turn_meta Current mode: {mode}"
    Engine->>TurnLoop: handle_deepseek_turn(mode)

    note over TurnLoop: Mid-turn steer / REPL / LSP / continuation messages
    TurnLoop->>Engine: user_text_message_with_turn_metadata(steer)
    Engine->>Meta: turn_metadata_block(AppMode::Agent [hardcoded], ...)
    Meta-->>Engine: turn_meta Current mode: agent
    note over TurnLoop: Always agent even in Plan / Yolo sessions
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/tui/src/core/engine.rs`, line 962-971 ([link](https://github.com/hmbown/codewhale/blob/c1141eda8e1e80ece7d7ab1f34a02a5d85fe7b05/crates/tui/src/core/engine.rs#L962-L971)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Mid-turn injected messages always report agent mode**

   `user_text_message_with_turn_metadata` (the no-`_for_route` variant) hardcodes `AppMode::Agent`. This method is used in seven places inside `handle_deepseek_turn` (steer messages, REPL feedback, goal-continuation messages) and in `flush_pending_lsp_diagnostics`, all of which run while a turn is already in progress. In Plan or Yolo mode sessions those mid-turn messages will carry `Current mode: agent` in their metadata, giving the model a false picture of the active mode — exactly the problem this PR intends to fix.

   All call-sites in `turn_loop.rs` already receive `mode: AppMode` as a parameter, so the mode is available; it just isn't threaded through this helper.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22codex%2F2515-turn-meta-mode%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2F2515-turn-meta-mode%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fcore%2Fengine.rs%0ALine%3A%20962-971%0A%0AComment%3A%0A**Mid-turn%20injected%20messages%20always%20report%20agent%20mode**%0A%0A%60user_text_message_with_turn_metadata%60%20%28the%20no-%60_for_route%60%20variant%29%20hardcodes%20%60AppMode%3A%3AAgent%60.%20This%20method%20is%20used%20in%20seven%20places%20inside%20%60handle_deepseek_turn%60%20%28steer%20messages%2C%20REPL%20feedback%2C%20goal-continuation%20messages%29%20and%20in%20%60flush_pending_lsp_diagnostics%60%2C%20all%20of%20which%20run%20while%20a%20turn%20is%20already%20in%20progress.%20In%20Plan%20or%20Yolo%20mode%20sessions%20those%20mid-turn%20messages%20will%20carry%20%60Current%20mode%3A%20agent%60%20in%20their%20metadata%2C%20giving%20the%20model%20a%20false%20picture%20of%20the%20active%20mode%20%E2%80%94%20exactly%20the%20problem%20this%20PR%20intends%20to%20fix.%0A%0AAll%20call-sites%20in%20%60turn_loop.rs%60%20already%20receive%20%60mode%3A%20AppMode%60%20as%20a%20parameter%2C%20so%20the%20mode%20is%20available%3B%20it%20just%20isn't%20threaded%20through%20this%20helper.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fcore%2Fengine.rs%0ALine%3A%20962-971%0A%0AComment%3A%0A**Mid-turn%20injected%20messages%20always%20report%20agent%20mode**%0A%0A%60user_text_message_with_turn_metadata%60%20%28the%20no-%60_for_route%60%20variant%29%20hardcodes%20%60AppMode%3A%3AAgent%60.%20This%20method%20is%20used%20in%20seven%20places%20inside%20%60handle_deepseek_turn%60%20%28steer%20messages%2C%20REPL%20feedback%2C%20goal-continuation%20messages%29%20and%20in%20%60flush_pending_lsp_diagnostics%60%2C%20all%20of%20which%20run%20while%20a%20turn%20is%20already%20in%20progress.%20In%20Plan%20or%20Yolo%20mode%20sessions%20those%20mid-turn%20messages%20will%20carry%20%60Current%20mode%3A%20agent%60%20in%20their%20metadata%2C%20giving%20the%20model%20a%20false%20picture%20of%20the%20active%20mode%20%E2%80%94%20exactly%20the%20problem%20this%20PR%20intends%20to%20fix.%0A%0AAll%20call-sites%20in%20%60turn_loop.rs%60%20already%20receive%20%60mode%3A%20AppMode%60%20as%20a%20parameter%2C%20so%20the%20mode%20is%20available%3B%20it%20just%20isn't%20threaded%20through%20this%20helper.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2539&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fcore%2Fengine.rs%0ALine%3A%20962-971%0A%0AComment%3A%0A**Mid-turn%20injected%20messages%20always%20report%20agent%20mode**%0A%0A%60user_text_message_with_turn_metadata%60%20%28the%20no-%60_for_route%60%20variant%29%20hardcodes%20%60AppMode%3A%3AAgent%60.%20This%20method%20is%20used%20in%20seven%20places%20inside%20%60handle_deepseek_turn%60%20%28steer%20messages%2C%20REPL%20feedback%2C%20goal-continuation%20messages%29%20and%20in%20%60flush_pending_lsp_diagnostics%60%2C%20all%20of%20which%20run%20while%20a%20turn%20is%20already%20in%20progress.%20In%20Plan%20or%20Yolo%20mode%20sessions%20those%20mid-turn%20messages%20will%20carry%20%60Current%20mode%3A%20agent%60%20in%20their%20metadata%2C%20giving%20the%20model%20a%20false%20picture%20of%20the%20active%20mode%20%E2%80%94%20exactly%20the%20problem%20this%20PR%20intends%20to%20fix.%0A%0AAll%20call-sites%20in%20%60turn_loop.rs%60%20already%20receive%20%60mode%3A%20AppMode%60%20as%20a%20parameter%2C%20so%20the%20mode%20is%20available%3B%20it%20just%20isn't%20threaded%20through%20this%20helper.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2539&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22codex%2F2515-turn-meta-mode%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2F2515-turn-meta-mode%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine.rs%3A962-971%0A**Mid-turn%20injected%20messages%20always%20report%20agent%20mode**%0A%0A%60user_text_message_with_turn_metadata%60%20%28the%20no-%60_for_route%60%20variant%29%20hardcodes%20%60AppMode%3A%3AAgent%60.%20This%20method%20is%20used%20in%20seven%20places%20inside%20%60handle_deepseek_turn%60%20%28steer%20messages%2C%20REPL%20feedback%2C%20goal-continuation%20messages%29%20and%20in%20%60flush_pending_lsp_diagnostics%60%2C%20all%20of%20which%20run%20while%20a%20turn%20is%20already%20in%20progress.%20In%20Plan%20or%20Yolo%20mode%20sessions%20those%20mid-turn%20messages%20will%20carry%20%60Current%20mode%3A%20agent%60%20in%20their%20metadata%2C%20giving%20the%20model%20a%20false%20picture%20of%20the%20active%20mode%20%E2%80%94%20exactly%20the%20problem%20this%20PR%20intends%20to%20fix.%0A%0AAll%20call-sites%20in%20%60turn_loop.rs%60%20already%20receive%20%60mode%3A%20AppMode%60%20as%20a%20parameter%2C%20so%20the%20mode%20is%20available%3B%20it%20just%20isn't%20threaded%20through%20this%20helper.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine.rs%3A962-971%0A**Mid-turn%20injected%20messages%20always%20report%20agent%20mode**%0A%0A%60user_text_message_with_turn_metadata%60%20%28the%20no-%60_for_route%60%20variant%29%20hardcodes%20%60AppMode%3A%3AAgent%60.%20This%20method%20is%20used%20in%20seven%20places%20inside%20%60handle_deepseek_turn%60%20%28steer%20messages%2C%20REPL%20feedback%2C%20goal-continuation%20messages%29%20and%20in%20%60flush_pending_lsp_diagnostics%60%2C%20all%20of%20which%20run%20while%20a%20turn%20is%20already%20in%20progress.%20In%20Plan%20or%20Yolo%20mode%20sessions%20those%20mid-turn%20messages%20will%20carry%20%60Current%20mode%3A%20agent%60%20in%20their%20metadata%2C%20giving%20the%20model%20a%20false%20picture%20of%20the%20active%20mode%20%E2%80%94%20exactly%20the%20problem%20this%20PR%20intends%20to%20fix.%0A%0AAll%20call-sites%20in%20%60turn_loop.rs%60%20already%20receive%20%60mode%3A%20AppMode%60%20as%20a%20parameter%2C%20so%20the%20mode%20is%20available%3B%20it%20just%20isn't%20threaded%20through%20this%20helper.%0A%0A&repo=hmbown%2Fcodewhale&pr=2539&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine.rs%3A962-971%0A**Mid-turn%20injected%20messages%20always%20report%20agent%20mode**%0A%0A%60user_text_message_with_turn_metadata%60%20%28the%20no-%60_for_route%60%20variant%29%20hardcodes%20%60AppMode%3A%3AAgent%60.%20This%20method%20is%20used%20in%20seven%20places%20inside%20%60handle_deepseek_turn%60%20%28steer%20messages%2C%20REPL%20feedback%2C%20goal-continuation%20messages%29%20and%20in%20%60flush_pending_lsp_diagnostics%60%2C%20all%20of%20which%20run%20while%20a%20turn%20is%20already%20in%20progress.%20In%20Plan%20or%20Yolo%20mode%20sessions%20those%20mid-turn%20messages%20will%20carry%20%60Current%20mode%3A%20agent%60%20in%20their%20metadata%2C%20giving%20the%20model%20a%20false%20picture%20of%20the%20active%20mode%20%E2%80%94%20exactly%20the%20problem%20this%20PR%20intends%20to%20fix.%0A%0AAll%20call-sites%20in%20%60turn_loop.rs%60%20already%20receive%20%60mode%3A%20AppMode%60%20as%20a%20parameter%2C%20so%20the%20mode%20is%20available%3B%20it%20just%20isn't%20threaded%20through%20this%20helper.%0A%0A&pr=2539&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(tui): include mode in turn metadata"](https://github.com/hmbown/codewhale/commit/c1141eda8e1e80ece7d7ab1f34a02a5d85fe7b05) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34991713)</sub>

<!-- /greptile_comment -->