### PR TITLE
fix(tui): read Wayland clipboard via wl-paste

### DIFF
--- a/crates/tui/src/tui/clipboard.rs
+++ b/crates/tui/src/tui/clipboard.rs
@@ -10,9 +10,12 @@
 #[cfg(not(test))]
 use std::io::{self, IsTerminal, Write};
 use std::path::{Path, PathBuf};
-#[cfg(all(
-    any(target_os = "macos", target_os = "windows", target_os = "linux"),
-    not(test)
+#[cfg(any(
+    all(test, unix),
+    all(
+        any(target_os = "macos", target_os = "windows", target_os = "linux"),
+        not(test)
+    )
 ))]
 use std::process::{Command, Stdio};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -107,6 +110,11 @@ impl ClipboardHandler {
     /// `workspace` is used as a fallback location when `~/.codewhale/` cannot
     /// be resolved (e.g. running with a stripped HOME in CI sandboxes).
     pub fn read(&mut self, workspace: &Path) -> Option<ClipboardContent> {
+        #[cfg(all(target_os = "linux", not(test)))]
+        if let Ok(text) = read_text_with_wlpaste() {
+            return Some(ClipboardContent::Text(text));
+        }
+
         self.ensure_clipboard();
         let clipboard = self.clipboard.as_mut()?;
         if let Ok(text) = clipboard.get_text() {
@@ -210,6 +218,26 @@ fn write_text_with_stdin_command(
 #[cfg(all(target_os = "linux", not(test)))]
 fn write_text_with_wlcopy(text: &str) -> Result<()> {
     write_text_with_wlcopy_using_argv("wl-copy", text)
+}
+
+#[cfg(all(target_os = "linux", not(test)))]
+fn read_text_with_wlpaste() -> Result<String> {
+    read_text_with_wlpaste_using_argv("wl-paste")
+}
+
+#[cfg(any(all(test, unix), target_os = "linux"))]
+fn read_text_with_wlpaste_using_argv(program: &str) -> Result<String> {
+    let output = Command::new(program)
+        .arg("--type")
+        .arg("text/plain")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output()
+        .map_err(|e| anyhow::anyhow!("Failed to run {program}: {e}"))?;
+    if !output.status.success() {
+        bail!("{program} exited with {}", output.status);
+    }
+    String::from_utf8(output.stdout).context("wl-paste returned non-UTF-8 text")
 }
 
 #[cfg(all(target_os = "linux", not(test)))]
@@ -332,6 +360,8 @@ fn save_image_as_png_in(dir: &Path, image: &ImageData) -> Result<PastedImage> {
 mod tests {
     use super::*;
     use std::borrow::Cow;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
 
     fn solid_rgba(width: u16, height: u16, rgba: [u8; 4]) -> ImageData<'static> {
         let mut bytes = Vec::with_capacity((width as usize) * (height as usize) * 4);
@@ -418,5 +448,21 @@ mod tests {
             err.to_string().contains("too large"),
             "unexpected error: {err}"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn wl_paste_helper_reads_text_from_stdout() {
+        let dir = tempfile::tempdir().unwrap();
+        let script = dir.path().join("wl-paste");
+        std::fs::write(&script, "#!/bin/sh\nprintf 'from-wayland'\n").unwrap();
+        let mut perms = std::fs::metadata(&script).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script, perms).unwrap();
+
+        let text = read_text_with_wlpaste_using_argv(script.to_str().unwrap())
+            .expect("read text through wl-paste helper");
+
+        assert_eq!(text, "from-wayland");
     }
 }


### PR DESCRIPTION
Summary:
- try `wl-paste` before arboard on Linux clipboard reads
- keep the existing arboard text/image path as the fallback
- cover the new helper with a focused stdout-based test

Issue:
Refs #1920

Validation:
- `cargo test -p codewhale-tui wl_paste_helper_reads_text_from_stdout --locked`
- `cargo test -p codewhale-tui clipboard --locked`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a `wl-paste` read path for the Wayland clipboard on Linux, invoked before the existing `arboard` fallback in `ClipboardHandler::read`. A focused unit test covers the new helper by stubbing the binary with a temporary shell script.

- **New `read_text_with_wlpaste_using_argv` helper** runs `wl-paste --type text/plain` and returns its stdout as a UTF-8 string; cfg attributes are correct and the fallback order (wl-paste → arboard text → arboard image) is appropriate.
- **`--no-newline` is missing from the `wl-paste` invocation** — `wl-paste` appends a trailing `\
` by default for text MIME types; the test mock uses `printf` without a newline so it doesn't catch this, meaning Wayland pastes always carry an extra newline that arboard (and macOS/Windows paths) do not produce.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The Wayland read path is functional but will silently corrupt pasted text by appending a trailing newline on every paste, producing output that differs from the arboard path on the same machine.

The missing `--no-newline` flag means that on any Wayland session, copied text is returned with a trailing `
` that arboard (X11, macOS, Windows) never adds. This is a consistent, reproducible behavioral difference that would affect every paste on the new code path. The test mock uses `printf` without a newline so it doesn't exercise or catch this divergence.

crates/tui/src/tui/clipboard.rs — the wl-paste invocation and its accompanying test
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/clipboard.rs | Adds wl-paste read path for Wayland on Linux (before arboard fallback); missing --no-newline flag causes every Wayland paste to include an extra trailing newline not present via arboard/macOS/Windows paths. Test mock doesn't simulate this behavior. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["ClipboardHandler::read()"] --> B{Linux non-test?}
    B -- Yes --> C["read_text_with_wlpaste()\nwl-paste --type text/plain"]
    C -- Ok(text) --> D["return ClipboardContent::Text(text)"]
    C -- Err --> E["ensure_clipboard() / arboard"]
    B -- No --> E
    E --> F{arboard available?}
    F -- Yes --> G["clipboard.get_text()"]
    G -- Ok --> D
    G -- Err --> H["clipboard.get_image()"]
    H -- Ok --> I["save_image_as_png()"]
    I --> J["return ClipboardContent::Image(pasted)"]
    H -- Err --> K["return None"]
    F -- No --> K
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22codex%2F1920-wlpaste-read%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2F1920-wlpaste-read%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fclipboard.rs%3A230-235%0A%60wl-paste%60%20appends%20a%20trailing%20newline%20to%20text%20output%20by%20default%20%28from%20the%20man%20page%3A%20*%22Do%20not%20append%20a%20newline%20character%20after%20the%20pasted%20clipboard%20content%22*%20is%20what%20%60--no-newline%60%20%2F%20%60-n%60%20suppresses%29.%20Without%20this%20flag%2C%20every%20paste%20on%20a%20Wayland%20session%20will%20include%20an%20extra%20%60%0A%60%20that%20arboard%20%E2%80%94%20used%20on%20X11%2C%20macOS%2C%20and%20Windows%20%E2%80%94%20does%20not%20add.%20The%20test%20doesn't%20catch%20this%20because%20its%20mock%20script%20uses%20%60printf%60%20which%20emits%20no%20newline%20of%20its%20own.%0A%0A%60%60%60suggestion%0A%20%20%20%20let%20output%20%3D%20Command%3A%3Anew%28program%29%0A%20%20%20%20%20%20%20%20.arg%28%22--no-newline%22%29%0A%20%20%20%20%20%20%20%20.arg%28%22--type%22%29%0A%20%20%20%20%20%20%20%20.arg%28%22text%2Fplain%22%29%0A%20%20%20%20%20%20%20%20.stdout%28Stdio%3A%3Apiped%28%29%29%0A%20%20%20%20%20%20%20%20.stderr%28Stdio%3A%3Anull%28%29%29%0A%20%20%20%20%20%20%20%20.output%28%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fclipboard.rs%3A458%0AThe%20mock%20script%20uses%20%60printf%20'from-wayland'%60%20which%20never%20appends%20a%20newline%2C%20so%20the%20test%20doesn't%20exercise%20the%20trailing-newline%20path%20that%20real%20%60wl-paste%60%20always%20emits.%20Once%20%60--no-newline%60%20is%20added%20to%20the%20command%2C%20consider%20updating%20the%20mock%20to%20emit%20a%20trailing%20newline%20to%20verify%20the%20flag%20is%20actually%20in%20effect.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Real%20wl-paste%20appends%20a%20newline%20unless%20--no-newline%20is%20passed%3B%20the%0A%20%20%20%20%20%20%20%20%2F%2F%20mock%20simulates%20that%20so%20the%20test%20verifies%20the%20flag%20is%20actually%20wired%20up.%0A%20%20%20%20%20%20%20%20std%3A%3Afs%3A%3Awrite%28%26script%2C%20%22%23!%2Fbin%2Fsh%5Cnprintf%20'from-wayland%5C%5Cn'%5Cn%22%29.unwrap%28%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fclipboard.rs%3A230-235%0A%60wl-paste%60%20appends%20a%20trailing%20newline%20to%20text%20output%20by%20default%20%28from%20the%20man%20page%3A%20*%22Do%20not%20append%20a%20newline%20character%20after%20the%20pasted%20clipboard%20content%22*%20is%20what%20%60--no-newline%60%20%2F%20%60-n%60%20suppresses%29.%20Without%20this%20flag%2C%20every%20paste%20on%20a%20Wayland%20session%20will%20include%20an%20extra%20%60%0A%60%20that%20arboard%20%E2%80%94%20used%20on%20X11%2C%20macOS%2C%20and%20Windows%20%E2%80%94%20does%20not%20add.%20The%20test%20doesn't%20catch%20this%20because%20its%20mock%20script%20uses%20%60printf%60%20which%20emits%20no%20newline%20of%20its%20own.%0A%0A%60%60%60suggestion%0A%20%20%20%20let%20output%20%3D%20Command%3A%3Anew%28program%29%0A%20%20%20%20%20%20%20%20.arg%28%22--no-newline%22%29%0A%20%20%20%20%20%20%20%20.arg%28%22--type%22%29%0A%20%20%20%20%20%20%20%20.arg%28%22text%2Fplain%22%29%0A%20%20%20%20%20%20%20%20.stdout%28Stdio%3A%3Apiped%28%29%29%0A%20%20%20%20%20%20%20%20.stderr%28Stdio%3A%3Anull%28%29%29%0A%20%20%20%20%20%20%20%20.output%28%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fclipboard.rs%3A458%0AThe%20mock%20script%20uses%20%60printf%20'from-wayland'%60%20which%20never%20appends%20a%20newline%2C%20so%20the%20test%20doesn't%20exercise%20the%20trailing-newline%20path%20that%20real%20%60wl-paste%60%20always%20emits.%20Once%20%60--no-newline%60%20is%20added%20to%20the%20command%2C%20consider%20updating%20the%20mock%20to%20emit%20a%20trailing%20newline%20to%20verify%20the%20flag%20is%20actually%20in%20effect.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Real%20wl-paste%20appends%20a%20newline%20unless%20--no-newline%20is%20passed%3B%20the%0A%20%20%20%20%20%20%20%20%2F%2F%20mock%20simulates%20that%20so%20the%20test%20verifies%20the%20flag%20is%20actually%20wired%20up.%0A%20%20%20%20%20%20%20%20std%3A%3Afs%3A%3Awrite%28%26script%2C%20%22%23!%2Fbin%2Fsh%5Cnprintf%20'from-wayland%5C%5Cn'%5Cn%22%29.unwrap%28%29%3B%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2540&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fclipboard.rs%3A230-235%0A%60wl-paste%60%20appends%20a%20trailing%20newline%20to%20text%20output%20by%20default%20%28from%20the%20man%20page%3A%20*%22Do%20not%20append%20a%20newline%20character%20after%20the%20pasted%20clipboard%20content%22*%20is%20what%20%60--no-newline%60%20%2F%20%60-n%60%20suppresses%29.%20Without%20this%20flag%2C%20every%20paste%20on%20a%20Wayland%20session%20will%20include%20an%20extra%20%60%0A%60%20that%20arboard%20%E2%80%94%20used%20on%20X11%2C%20macOS%2C%20and%20Windows%20%E2%80%94%20does%20not%20add.%20The%20test%20doesn't%20catch%20this%20because%20its%20mock%20script%20uses%20%60printf%60%20which%20emits%20no%20newline%20of%20its%20own.%0A%0A%60%60%60suggestion%0A%20%20%20%20let%20output%20%3D%20Command%3A%3Anew%28program%29%0A%20%20%20%20%20%20%20%20.arg%28%22--no-newline%22%29%0A%20%20%20%20%20%20%20%20.arg%28%22--type%22%29%0A%20%20%20%20%20%20%20%20.arg%28%22text%2Fplain%22%29%0A%20%20%20%20%20%20%20%20.stdout%28Stdio%3A%3Apiped%28%29%29%0A%20%20%20%20%20%20%20%20.stderr%28Stdio%3A%3Anull%28%29%29%0A%20%20%20%20%20%20%20%20.output%28%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fclipboard.rs%3A458%0AThe%20mock%20script%20uses%20%60printf%20'from-wayland'%60%20which%20never%20appends%20a%20newline%2C%20so%20the%20test%20doesn't%20exercise%20the%20trailing-newline%20path%20that%20real%20%60wl-paste%60%20always%20emits.%20Once%20%60--no-newline%60%20is%20added%20to%20the%20command%2C%20consider%20updating%20the%20mock%20to%20emit%20a%20trailing%20newline%20to%20verify%20the%20flag%20is%20actually%20in%20effect.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Real%20wl-paste%20appends%20a%20newline%20unless%20--no-newline%20is%20passed%3B%20the%0A%20%20%20%20%20%20%20%20%2F%2F%20mock%20simulates%20that%20so%20the%20test%20verifies%20the%20flag%20is%20actually%20wired%20up.%0A%20%20%20%20%20%20%20%20std%3A%3Afs%3A%3Awrite%28%26script%2C%20%22%23!%2Fbin%2Fsh%5Cnprintf%20'from-wayland%5C%5Cn'%5Cn%22%29.unwrap%28%29%3B%0A%60%60%60%0A%0A&pr=2540&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(tui): read Wayland clipboard via wl-..."](https://github.com/hmbown/codewhale/commit/83f8795867990f1329a68d69c79532b8567e8742) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35001436)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->