### PR TITLE
docs(tui): clarify macOS keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,8 @@ ACP workflows outside the built-in Zed slice.
 | `Shift+Tab` | Cycle reasoning-effort: off → high → max |
 | `F1` | Searchable help overlay |
 | `Esc` | Back / dismiss |
+| `Alt+Enter` / `Ctrl+J` | Insert a composer newline without sending |
+| `Ctrl+C` | Cancel the active turn; press again to quit when idle |
 | `Ctrl+K` | Command palette |
 | `Ctrl+R` | Resume an earlier session |
 | `Alt+R` | Search prompt history and recover cleared drafts |
@@ -471,7 +473,8 @@ ACP workflows outside the built-in Zed slice.
 | `@path` | Attach file/directory context in composer |
 | `↑` (at composer start) | Select attachment row for removal |
 
-Full shortcut catalog: [docs/KEYBINDINGS.md](docs/KEYBINDINGS.md).
+Full shortcut catalog, including macOS/iTerm modifier notes:
+[docs/KEYBINDINGS.md](docs/KEYBINDINGS.md).
 
 ---
 

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -4,6 +4,21 @@ This is the source-of-truth catalog of every keyboard shortcut the TUI recognize
 
 Bindings are not (yet) user-configurable — tracked for a future release (#436, #437). This document is the contract that future config-file overrides will name into.
 
+## macOS and terminal notes
+
+CodeWhale receives key events after your terminal emulator translates them.
+On macOS, `Cmd` shortcuts are usually handled by the terminal application
+itself, while `Ctrl` shortcuts are sent to the TUI. `Option` may be sent as an
+`Alt`/Meta modifier depending on terminal settings. In iTerm2, set Option to
+"Esc+" if you want Option-key chords to reach terminal apps as Alt-key chords.
+
+For multi-line composer input, `Enter` submits the message. Use
+`Alt-Enter` or `Ctrl-J` to insert a newline without sending. If your terminal
+does not send `Option-Enter` as Alt-Enter, `Ctrl-J` is the portable fallback.
+
+`Ctrl-C` cancels the active turn when the model or a tool is running. When the
+TUI is idle, it arms a quit confirmation instead; press it again to exit.
+
 ## Global (any context)
 
 | Chord                | Action                                                        |


### PR DESCRIPTION
Summary
- Add macOS/iTerm terminal notes to the TUI keybinding catalog.
- Surface composer newline and Ctrl+C cancel behavior in the README shortcut table.

Validation
- git diff --check

Refs #2494

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR improves the TUI documentation by adding a macOS/iTerm terminal notes section to `docs/KEYBINDINGS.md` and surfacing two commonly-asked-about bindings (`Alt+Enter`/`Ctrl+J` for composer newline and `Ctrl+C` for turn cancellation) in the README shortcut table.

- **`docs/KEYBINDINGS.md`**: New preamble section explains how macOS terminal emulators translate modifier keys, how to configure iTerm2's Option key, and the dual-mode behavior of `Ctrl-C`; content matches the existing Global and Composer tables.
- **`README.md`**: Two new shortcut rows added to the summary table; catalog link text updated to mention the macOS/iTerm notes.
- Both files have a minor gap: the `Ctrl-C` prose/table entries omit the "dismiss modal" case that the full KEYBINDINGS Global table already documents.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Documentation-only change; no code is modified and no runtime behavior is altered.

The new prose and table rows are accurate and consistent with the existing KEYBINDINGS catalog except for one spot: `Ctrl-C`'s "dismiss modal" behavior is described in the Global table but left out of both the new KEYBINDINGS preamble and the README summary row, creating a small documentation gap. Everything else aligns correctly.

The `Ctrl-C` entry in both `README.md` and `docs/KEYBINDINGS.md` is worth a second look to ensure the modal-dismiss case is covered.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Adds `Alt+Enter`/`Ctrl+J` and `Ctrl+C` rows to the keyboard shortcut table; updates catalog link text to mention macOS/iTerm notes. `Ctrl+C` description omits the "dismiss modal" behavior documented in KEYBINDINGS.md. |
| docs/KEYBINDINGS.md | Adds a new "macOS and terminal notes" preamble section covering iTerm2 Option-key setup, multi-line input, and Ctrl-C semantics. Prose for Ctrl-C omits the "dismiss modal" case that the Global table (line 28) already lists. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User presses Ctrl-C] --> B{TUI State?}
    B -->|Model/tool running| C[Cancel active turn]
    B -->|Modal open| D[Dismiss modal]
    B -->|Idle| E[Arm quit confirmation]
    E --> F{Press Ctrl-C again?}
    F -->|Yes| G[Exit TUI]
    F -->|No / other key| H[Remain in TUI]
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22codex%2F2494-keybindings-docs%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2F2494-keybindings-docs%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Adocs%2FKEYBINDINGS.md%3A19-20%0A%60Ctrl-C%60%20also%20dismisses%20the%20topmost%20modal%20%28as%20documented%20in%20the%20Global%20table%20just%20below%2C%20line%2028%29%2C%20but%20the%20new%20prose%20section%20doesn't%20mention%20it.%20A%20user%20reading%20only%20the%20preamble%20notes%20would%20miss%20that%20behavior%20and%20might%20reach%20for%20%60Esc%60%20when%20%60Ctrl-C%60%20would%20also%20work.%20Consider%20adding%20that%20case%20to%20keep%20the%20prose%20consistent%20with%20the%20table.%0A%0A%60%60%60suggestion%0A%60Ctrl-C%60%20cancels%20the%20active%20turn%20when%20the%20model%20or%20a%20tool%20is%20running%3B%20it%20also%0Adismisses%20the%20topmost%20modal%20when%20one%20is%20open.%20When%20the%20TUI%20is%20idle%2C%20it%20arms%20a%0Aquit%20confirmation%20instead%3B%20press%20it%20again%20to%20exit.%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0AREADME.md%3A468%0AThe%20%60Ctrl%2BC%60%20entry%20in%20the%20README%20summary%20table%20doesn't%20mention%20the%20%22dismiss%20modal%22%20behavior%20that%20%60Ctrl-C%60%20also%20provides%20%28documented%20in%20%60docs%2FKEYBINDINGS.md%60%20line%2028%29.%20Users%20who%20open%20a%20modal%20and%20try%20%60Ctrl%2BC%60%20to%20close%20it%20may%20be%20surprised%20it%20works%2C%20since%20only%20%60Esc%60%20is%20listed%20under%20%22Back%20%2F%20dismiss%22.%0A%0A%60%60%60suggestion%0A%7C%20%60Ctrl%2BC%60%20%7C%20Cancel%20the%20active%20turn%3B%20dismiss%20modal%3B%20press%20again%20to%20quit%20when%20idle%20%7C%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Adocs%2FKEYBINDINGS.md%3A19-20%0A%60Ctrl-C%60%20also%20dismisses%20the%20topmost%20modal%20%28as%20documented%20in%20the%20Global%20table%20just%20below%2C%20line%2028%29%2C%20but%20the%20new%20prose%20section%20doesn't%20mention%20it.%20A%20user%20reading%20only%20the%20preamble%20notes%20would%20miss%20that%20behavior%20and%20might%20reach%20for%20%60Esc%60%20when%20%60Ctrl-C%60%20would%20also%20work.%20Consider%20adding%20that%20case%20to%20keep%20the%20prose%20consistent%20with%20the%20table.%0A%0A%60%60%60suggestion%0A%60Ctrl-C%60%20cancels%20the%20active%20turn%20when%20the%20model%20or%20a%20tool%20is%20running%3B%20it%20also%0Adismisses%20the%20topmost%20modal%20when%20one%20is%20open.%20When%20the%20TUI%20is%20idle%2C%20it%20arms%20a%0Aquit%20confirmation%20instead%3B%20press%20it%20again%20to%20exit.%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0AREADME.md%3A468%0AThe%20%60Ctrl%2BC%60%20entry%20in%20the%20README%20summary%20table%20doesn't%20mention%20the%20%22dismiss%20modal%22%20behavior%20that%20%60Ctrl-C%60%20also%20provides%20%28documented%20in%20%60docs%2FKEYBINDINGS.md%60%20line%2028%29.%20Users%20who%20open%20a%20modal%20and%20try%20%60Ctrl%2BC%60%20to%20close%20it%20may%20be%20surprised%20it%20works%2C%20since%20only%20%60Esc%60%20is%20listed%20under%20%22Back%20%2F%20dismiss%22.%0A%0A%60%60%60suggestion%0A%7C%20%60Ctrl%2BC%60%20%7C%20Cancel%20the%20active%20turn%3B%20dismiss%20modal%3B%20press%20again%20to%20quit%20when%20idle%20%7C%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2541&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Adocs%2FKEYBINDINGS.md%3A19-20%0A%60Ctrl-C%60%20also%20dismisses%20the%20topmost%20modal%20%28as%20documented%20in%20the%20Global%20table%20just%20below%2C%20line%2028%29%2C%20but%20the%20new%20prose%20section%20doesn't%20mention%20it.%20A%20user%20reading%20only%20the%20preamble%20notes%20would%20miss%20that%20behavior%20and%20might%20reach%20for%20%60Esc%60%20when%20%60Ctrl-C%60%20would%20also%20work.%20Consider%20adding%20that%20case%20to%20keep%20the%20prose%20consistent%20with%20the%20table.%0A%0A%60%60%60suggestion%0A%60Ctrl-C%60%20cancels%20the%20active%20turn%20when%20the%20model%20or%20a%20tool%20is%20running%3B%20it%20also%0Adismisses%20the%20topmost%20modal%20when%20one%20is%20open.%20When%20the%20TUI%20is%20idle%2C%20it%20arms%20a%0Aquit%20confirmation%20instead%3B%20press%20it%20again%20to%20exit.%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0AREADME.md%3A468%0AThe%20%60Ctrl%2BC%60%20entry%20in%20the%20README%20summary%20table%20doesn't%20mention%20the%20%22dismiss%20modal%22%20behavior%20that%20%60Ctrl-C%60%20also%20provides%20%28documented%20in%20%60docs%2FKEYBINDINGS.md%60%20line%2028%29.%20Users%20who%20open%20a%20modal%20and%20try%20%60Ctrl%2BC%60%20to%20close%20it%20may%20be%20surprised%20it%20works%2C%20since%20only%20%60Esc%60%20is%20listed%20under%20%22Back%20%2F%20dismiss%22.%0A%0A%60%60%60suggestion%0A%7C%20%60Ctrl%2BC%60%20%7C%20Cancel%20the%20active%20turn%3B%20dismiss%20modal%3B%20press%20again%20to%20quit%20when%20idle%20%7C%0A%60%60%60%0A%0A&pr=2541&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs(tui): clarify macOS keybindings"](https://github.com/hmbown/codewhale/commit/49a3aa3d749d3001c9e545b4529ae9c44348d677) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35003914)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->