### PR TITLE
docs(providers): clarify OpenAI-compatible routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,8 @@ Both binaries are required. Cross-compilation and platform-specific notes: [docs
 
 For the full shipped provider registry, including model IDs, auth variables,
 base URLs, and capability boundaries, see [docs/PROVIDERS.md](docs/PROVIDERS.md).
+That page also covers when to choose `openai` versus self-hosted `vllm`,
+`sglang`, or `ollama`, and notes the current Chat Completions API boundary.
 
 ```bash
 # NVIDIA NIM

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -107,6 +107,29 @@ environment. Project-local config overlays intentionally cannot set those keys,
 so a repository cannot silently redirect prompts or credentials to another
 endpoint.
 
+## Choosing Between `openai`, `vllm`, `sglang`, And `ollama`
+
+Use the provider ID that describes the service boundary you are actually
+calling. All four routes speak an OpenAI-compatible Chat Completions shape, but
+CodeWhale applies different defaults, auth expectations, and reasoning-control
+metadata per provider.
+
+| Situation | Provider ID | Why |
+| --- | --- | --- |
+| A hosted gateway or proxy exposes an OpenAI-compatible `/v1/chat/completions` endpoint | `openai` | Generic route for third-party gateways. Set `[providers.openai].base_url` and `model`, or `OPENAI_BASE_URL` / `OPENAI_MODEL`. |
+| A local or private vLLM server exposes OpenAI-compatible chat completions | `vllm` | Uses vLLM defaults, optional auth, loopback HTTP allowance, and vLLM-specific reasoning toggles. |
+| A local or private SGLang server exposes OpenAI-compatible chat completions | `sglang` | Uses SGLang defaults and model aliases for self-hosted DeepSeek-compatible serving. |
+| An Ollama server exposes its OpenAI-compatible endpoint | `ollama` | Sends Ollama model tags through unchanged and defaults to `http://localhost:11434/v1`. |
+
+If a hosted service says it is "OpenAI-compatible" but is not specifically a
+vLLM, SGLang, or Ollama deployment you control, start with `provider = "openai"`.
+If you are pointing directly at your own local vLLM or SGLang server, use the
+dedicated provider so diagnostics and reasoning metadata match that runtime.
+
+CodeWhale's LLM provider paths do not send OpenAI Responses API payloads today.
+They use Chat Completions endpoints; a service that only exposes
+`/v1/responses` needs an adapter or gateway that accepts Chat Completions.
+
 ## Shipped Providers
 
 | Provider ID | TOML table | Auth env | Base URL env and default | Default or static models | Notes |


### PR DESCRIPTION
Summary
- Add provider-selection guidance for generic OpenAI-compatible gateways versus self-hosted vLLM/SGLang/Ollama.
- Document the current Chat Completions boundary for LLM provider endpoints.

Validation
- python3 scripts/check-provider-registry.py
- git diff --check

Refs #2300

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This docs-only PR adds a provider-selection decision guide to `docs/PROVIDERS.md` and a two-line teaser to `README.md`. No code is changed.

- Adds a new "Choosing Between `openai`, `vllm`, `sglang`, And `ollama`" section with a decision table and prose guidance that helps users pick the right provider ID for hosted gateways versus self-hosted runtimes.
- Appends a note clarifying that CodeWhale uses Chat Completions endpoints (not the OpenAI Responses API), and that services exposing only `/v1/responses` need an adapter.
- The new content is factually consistent with the existing "Shipped Providers" table (default URLs, env vars, and auth expectations all match).
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change with no code modifications; safe to merge.

Both files changed are purely documentation. The new decision table and prose in PROVIDERS.md cross-check cleanly against the existing Shipped Providers table — default URLs, env var names, and auth flags are all consistent. The README teaser accurately summarizes the new section.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/PROVIDERS.md | Adds a 29-line decision-guide section between "Custom DeepSeek-Compatible Endpoints" and "Shipped Providers". Content is accurate and consistent with existing Shipped Providers table entries (URLs, env vars, auth flags). |
| README.md | Two-line teaser appended after the existing PROVIDERS.md link; accurately describes the new section's content. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Need an OpenAI-compatible provider] --> B{Is it a service you control?}
    B -- No --> C[Hosted gateway or third-party proxy]
    B -- Yes --> D{Which runtime?}
    C --> E[provider = openai\nSet base_url + model or\nOPENAI_BASE_URL / OPENAI_MODEL]
    D -- vLLM --> F[provider = vllm\nDefault: http://localhost:8000/v1\nVLLM_API_KEY optional]
    D -- SGLang --> G[provider = sglang\nDefault: http://localhost:30000/v1\nSGLANG_API_KEY optional]
    D -- Ollama --> H[provider = ollama\nDefault: http://localhost:11434/v1\nOLLAMA_API_KEY optional]
    E --> I{Endpoint type?}
    F --> J[Chat Completions /v1/chat/completions]
    G --> J
    H --> J
    I -- /v1/chat/completions --> J
    I -- /v1/responses only --> K[Needs adapter or gateway\nthat accepts Chat Completions]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(providers): clarify OpenAI-compatib..."](https://github.com/hmbown/codewhale/commit/21ce34f4827167258d8f9bc0035572bf1d8cdfd9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35006068)</sub>

<!-- /greptile_comment -->