### PR TITLE
docs(providers): document OpenRouter-compatible endpoints

### DIFF
--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -148,6 +148,18 @@ large models verified through OpenRouter's model metadata:
 `minimax/minimax-m3` was added from OpenRouter's May 31, 2026 listing as a 1M
 context multimodal model for coding, tool use, and long-horizon agentic work.
 
+### OpenRouter-Compatible Endpoints
+
+Use `provider = "openrouter"` for gateways that intentionally match
+OpenRouter's response shape, including `message.reasoning`, streamed
+`delta.reasoning`, `completion_tokens_details.reasoning_tokens`, and optional
+prompt-cache fields. Set the endpoint with `[providers.openrouter].base_url` or
+`OPENROUTER_BASE_URL`.
+
+Keep this route generic. CodeWhale does not ship proxy-specific branding,
+default hosts, or badges for OpenRouter-compatible gateways; the configured
+`base_url` decides which endpoint receives the request.
+
 ## Static Model Registry
 
 `codewhale model list` and `codewhale model resolve` use the static registry in
@@ -200,6 +212,11 @@ All shipped providers use the Chat Completions request payload mode today.
 | Generic `openai`, AtlasCloud, and Moonshot/Kimi | 128,000 | 4,096 | no in doctor capability metadata | no | not documented in code |
 | Ollama | 8,192 | 4,096 | no | no | not documented in code |
 | Other recognized DeepSeek model IDs | 128,000 unless the model name carries an explicit `Nk` hint | 4,096 | no unless V4/reasoner logic matches | DeepSeek/NIM only | DeepSeek beta only |
+
+The cache telemetry column is static capability metadata, not a live endpoint
+probe. OpenRouter-compatible responses can still include parser-supported cache
+fields such as `prompt_cache_hit_tokens`, `prompt_cache_miss_tokens`, or
+`prompt_tokens_details.cached_tokens`; CodeWhale records them when present.
 
 Tool-call support is tracked separately by the static `ModelRegistry` and by
 the endpoint's ability to accept OpenAI-compatible `tools` payloads. A custom


### PR DESCRIPTION
Summary
- Document how to use the OpenRouter provider with OpenRouter-compatible gateways via custom base_url.
- Clarify the difference between static cache capability metadata and parser-supported cache fields.

Validation
- python3 scripts/check-provider-registry.py
- git diff --check

Refs #1978

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR is a documentation-only change to `docs/PROVIDERS.md`. It adds guidance on using the existing `openrouter` provider with non-OpenRouter compatible gateways via a custom `base_url`, and appends a paragraph clarifying that the \"cache telemetry\" column in the capability table reflects static metadata rather than a live probe.

- **New \"OpenRouter-Compatible Endpoints\" subsection**: documents `provider = \"openrouter\"` with a custom `base_url` for gateways that match OpenRouter's response shape (reasoning fields, cache fields), and explicitly states CodeWhale adds no gateway-specific branding.
- **Cache telemetry clarification paragraph**: explains the gap between the static `cache_telemetry_supported = false` metadata entry for OpenRouter and the parser's ability to record `prompt_cache_hit_tokens`, `prompt_cache_miss_tokens`, and `prompt_tokens_details.cached_tokens` when a response includes them.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Documentation-only change with no code impact; safe to merge with the noted prose gaps addressed or accepted as-is.

The content is technically accurate and consistent with the existing shipped-providers table. The two gaps — no TOML example for the new subsection, and no explicit criterion for choosing `openrouter` over `openai` for a compatible gateway — could leave users confused but do not describe incorrect behavior.

Only `docs/PROVIDERS.md` is changed; the new subsection and cache-clarification paragraph are the areas worth a second read.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/PROVIDERS.md | Adds a new "OpenRouter-Compatible Endpoints" subsection and a clarifying paragraph on cache telemetry. The content is accurate and internally consistent, but the new subsection is missing a TOML config example that the rest of the doc provides for similar patterns, and the guidance on when to choose `openrouter` vs `openai` for a non-OpenRouter gateway could be more explicit. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User wants OpenRouter-shape endpoint] --> B{Is it openrouter.ai itself?}
    B -- Yes --> C[provider = openrouter\nDefault base_url used]
    B -- No, it is a compatible gateway --> D[provider = openrouter\nSet base_url to gateway URL]
    D --> E{Config method}
    E -- TOML --> F["[providers.openrouter]\nbase_url = 'https://gateway.example/v1'"]
    E -- Env --> G["OPENROUTER_BASE_URL=https://gateway.example/v1"]
    C --> H[Request sent with OpenRouter response shape]
    F --> H
    G --> H
    H --> I{Response contains cache fields?}
    I -- Yes --> J[CodeWhale records cache telemetry\nEven though static metadata shows 'no']
    I -- No --> K[No cache telemetry recorded]
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22codex%2F1978-openrouter-docs%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2F1978-openrouter-docs%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Adocs%2FPROVIDERS.md%3A151-161%0A**Missing%20TOML%20config%20example**%0A%0AEvery%20analogous%20section%20in%20this%20file%20%28Custom%20DeepSeek-Compatible%20Endpoints%2C%20and%20the%20provider%20table%20itself%29%20follows%20the%20explanation%20with%20a%20concrete%20TOML%20block.%20A%20user%20landing%20on%20the%20%22OpenRouter-Compatible%20Endpoints%22%20section%20will%20need%20to%20know%20that%20the%20%60openrouter%60%20TOML%20table%20key%20and%20%60OPENROUTER_BASE_URL%60%20env%20var%20already%20exist%3B%20without%20an%20example%20they%20may%20try%20to%20invent%20a%20new%20%60%5Bproviders.openrouter_compat%5D%60%20table%2C%20which%20the%20drift-check%20will%20reject.%20Adding%20a%20short%20snippet%20%28mirroring%20the%20deepseek-compatible%20example%20at%20line%2085%29%20would%20close%20that%20gap.%0A%0A%23%23%23%20Issue%202%20of%202%0Adocs%2FPROVIDERS.md%3A153-157%0A**%60openrouter%60%20vs%20%60openai%60%20selection%20guidance%20is%20ambiguous**%0A%0AThe%20existing%20doc%20already%20recommends%20%60provider%20%3D%20%22openai%22%60%20for%20%22explicit%20third-party%20OpenAI-compatible%20routes%22%20%28line%20116%29.%20The%20new%20section%20recommends%20%60provider%20%3D%20%22openrouter%22%60%20for%20gateways%20that%20match%20OpenRouter's%20response%20shape%2C%20but%20the%20distinguishing%20criterion%20%E2%80%94%20presence%20of%20%60message.reasoning%60%2C%20%60delta.reasoning%60%2C%20and%20%60completion_tokens_details.reasoning_tokens%60%20%E2%80%94%20is%20not%20stated.%20A%20reader%20whose%20gateway%20happens%20to%20be%20OpenAI-compatible%20but%20also%20surfaces%20reasoning%20fields%20will%20not%20know%20which%20provider%20to%20choose.%20A%20single%20sentence%20naming%20the%20differentiator%20%28the%20OpenRouter-specific%20reasoning%20and%20cache%20fields%29%20would%20prevent%20mis-configuration.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Adocs%2FPROVIDERS.md%3A151-161%0A**Missing%20TOML%20config%20example**%0A%0AEvery%20analogous%20section%20in%20this%20file%20%28Custom%20DeepSeek-Compatible%20Endpoints%2C%20and%20the%20provider%20table%20itself%29%20follows%20the%20explanation%20with%20a%20concrete%20TOML%20block.%20A%20user%20landing%20on%20the%20%22OpenRouter-Compatible%20Endpoints%22%20section%20will%20need%20to%20know%20that%20the%20%60openrouter%60%20TOML%20table%20key%20and%20%60OPENROUTER_BASE_URL%60%20env%20var%20already%20exist%3B%20without%20an%20example%20they%20may%20try%20to%20invent%20a%20new%20%60%5Bproviders.openrouter_compat%5D%60%20table%2C%20which%20the%20drift-check%20will%20reject.%20Adding%20a%20short%20snippet%20%28mirroring%20the%20deepseek-compatible%20example%20at%20line%2085%29%20would%20close%20that%20gap.%0A%0A%23%23%23%20Issue%202%20of%202%0Adocs%2FPROVIDERS.md%3A153-157%0A**%60openrouter%60%20vs%20%60openai%60%20selection%20guidance%20is%20ambiguous**%0A%0AThe%20existing%20doc%20already%20recommends%20%60provider%20%3D%20%22openai%22%60%20for%20%22explicit%20third-party%20OpenAI-compatible%20routes%22%20%28line%20116%29.%20The%20new%20section%20recommends%20%60provider%20%3D%20%22openrouter%22%60%20for%20gateways%20that%20match%20OpenRouter's%20response%20shape%2C%20but%20the%20distinguishing%20criterion%20%E2%80%94%20presence%20of%20%60message.reasoning%60%2C%20%60delta.reasoning%60%2C%20and%20%60completion_tokens_details.reasoning_tokens%60%20%E2%80%94%20is%20not%20stated.%20A%20reader%20whose%20gateway%20happens%20to%20be%20OpenAI-compatible%20but%20also%20surfaces%20reasoning%20fields%20will%20not%20know%20which%20provider%20to%20choose.%20A%20single%20sentence%20naming%20the%20differentiator%20%28the%20OpenRouter-specific%20reasoning%20and%20cache%20fields%29%20would%20prevent%20mis-configuration.%0A%0A&repo=hmbown%2Fcodewhale&pr=2543&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Adocs%2FPROVIDERS.md%3A151-161%0A**Missing%20TOML%20config%20example**%0A%0AEvery%20analogous%20section%20in%20this%20file%20%28Custom%20DeepSeek-Compatible%20Endpoints%2C%20and%20the%20provider%20table%20itself%29%20follows%20the%20explanation%20with%20a%20concrete%20TOML%20block.%20A%20user%20landing%20on%20the%20%22OpenRouter-Compatible%20Endpoints%22%20section%20will%20need%20to%20know%20that%20the%20%60openrouter%60%20TOML%20table%20key%20and%20%60OPENROUTER_BASE_URL%60%20env%20var%20already%20exist%3B%20without%20an%20example%20they%20may%20try%20to%20invent%20a%20new%20%60%5Bproviders.openrouter_compat%5D%60%20table%2C%20which%20the%20drift-check%20will%20reject.%20Adding%20a%20short%20snippet%20%28mirroring%20the%20deepseek-compatible%20example%20at%20line%2085%29%20would%20close%20that%20gap.%0A%0A%23%23%23%20Issue%202%20of%202%0Adocs%2FPROVIDERS.md%3A153-157%0A**%60openrouter%60%20vs%20%60openai%60%20selection%20guidance%20is%20ambiguous**%0A%0AThe%20existing%20doc%20already%20recommends%20%60provider%20%3D%20%22openai%22%60%20for%20%22explicit%20third-party%20OpenAI-compatible%20routes%22%20%28line%20116%29.%20The%20new%20section%20recommends%20%60provider%20%3D%20%22openrouter%22%60%20for%20gateways%20that%20match%20OpenRouter's%20response%20shape%2C%20but%20the%20distinguishing%20criterion%20%E2%80%94%20presence%20of%20%60message.reasoning%60%2C%20%60delta.reasoning%60%2C%20and%20%60completion_tokens_details.reasoning_tokens%60%20%E2%80%94%20is%20not%20stated.%20A%20reader%20whose%20gateway%20happens%20to%20be%20OpenAI-compatible%20but%20also%20surfaces%20reasoning%20fields%20will%20not%20know%20which%20provider%20to%20choose.%20A%20single%20sentence%20naming%20the%20differentiator%20%28the%20OpenRouter-specific%20reasoning%20and%20cache%20fields%29%20would%20prevent%20mis-configuration.%0A%0A&pr=2543&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs(providers): document OpenRouter-com..."](https://github.com/hmbown/codewhale/commit/64d8a20df05e0854fbc495edbe6de91ad9da8ecc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35007695)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->