### PR TITLE
docs(runtime): clarify backend integration modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,9 @@ The first ACP slice supports new sessions and prompt responses through your
 existing DeepSeek config/API key. Tool-backed editing and checkpoint replay are
 not exposed through ACP yet.
 
+For backend wrappers that need tools, streaming, or structured conversation
+state, see the integration mode matrix in [docs/RUNTIME_API.md](docs/RUNTIME_API.md).
+
 Community-maintained adapter: [acp-codewhale-adapter](https://github.com/rockeverm3m/acp-codewhale-adapter)
 bridges `codewhale exec --auto` to `cc-connect` for users who need tool-backed
 ACP workflows outside the built-in Zed slice.

--- a/docs/RUNTIME_API.md
+++ b/docs/RUNTIME_API.md
@@ -31,7 +31,7 @@ Use the mode that matches the surface your wrapper needs:
 | `codewhale serve --http` | Local apps, web/chat backends, mobile or desktop supervisors | Tools run through normal thread/turn execution under the configured policy, with approval APIs for gated calls | SSE events via `/v1/threads/{id}/events` and compatibility streaming via `/v1/stream` | Structured thread, turn, task, approval, and event records |
 | `codewhale exec --auto --output-format stream-json` | Non-interactive CLI wrappers and harnesses that need tool-backed output without running a daemon | Built-in tools plus configured MCP tools available to the non-interactive agent | Newline-delimited JSON on stdout | A single prompt string for the turn; role/history separation must be encoded by the caller |
 | `codewhale serve --acp` | Editors and ACP-compatible clients such as Zed | Not yet exposed through ACP | ACP `session/update` chunks | ACP session prompt/update messages |
-| `codewhale serve --mcp` | Other MCP clients that want to call CodeWhale as a tool server | Exposes CodeWhale tools to the external MCP client | MCP request/response over stdio | MCP tool-call payloads |
+| `codewhale serve --mcp` | Other MCP clients that want to call CodeWhale as a tool server | Exposes CodeWhale tools to the external MCP client | No streaming; single synchronous request/response over stdio | MCP tool-call payloads |
 
 For Feishu/Lark bots, custom web chats, or other long-running chat backends,
 prefer `serve --http` when the client needs structured conversations,

--- a/docs/RUNTIME_API.md
+++ b/docs/RUNTIME_API.md
@@ -22,6 +22,26 @@ macOS workbench (or any local supervisor)
 The engine runs as a local-only process. All APIs bind to `localhost` by
 default. No hosted relay, no provider-token custody, no secret leakage.
 
+## Choosing an integration mode
+
+Use the mode that matches the surface your wrapper needs:
+
+| Mode | Best fit | Tool access | Streaming | Message shape |
+|---|---|---|---|---|
+| `codewhale serve --http` | Local apps, web/chat backends, mobile or desktop supervisors | Tools run through normal thread/turn execution under the configured policy, with approval APIs for gated calls | SSE events via `/v1/threads/{id}/events` and compatibility streaming via `/v1/stream` | Structured thread, turn, task, approval, and event records |
+| `codewhale exec --auto --output-format stream-json` | Non-interactive CLI wrappers and harnesses that need tool-backed output without running a daemon | Built-in tools plus configured MCP tools available to the non-interactive agent | Newline-delimited JSON on stdout | A single prompt string for the turn; role/history separation must be encoded by the caller |
+| `codewhale serve --acp` | Editors and ACP-compatible clients such as Zed | Not yet exposed through ACP | ACP `session/update` chunks | ACP session prompt/update messages |
+| `codewhale serve --mcp` | Other MCP clients that want to call CodeWhale as a tool server | Exposes CodeWhale tools to the external MCP client | MCP request/response over stdio | MCP tool-call payloads |
+
+For Feishu/Lark bots, custom web chats, or other long-running chat backends,
+prefer `serve --http` when the client needs structured conversations,
+approvals, interrupt/steer controls, event replay, or separate system prompt
+state. Use `exec --auto --output-format stream-json` for simpler wrappers that
+can encode their own context into one prompt and only need a tool-backed NDJSON
+stream. Use ACP when the host already speaks Agent Client Protocol; the current
+ACP adapter is deliberately chat-only and does not load MCP tools into the ACP
+session.
+
 ## ACP stdio adapter: `codewhale serve --acp`
 
 `codewhale serve --acp` speaks JSON-RPC 2.0 over newline-delimited stdio for


### PR DESCRIPTION
Summary
- Add a runtime integration mode matrix covering HTTP, exec stream-json, ACP, and MCP server modes.
- Clarify that ACP is currently chat-only while exec stream-json is the tool-backed non-daemon path.
- Link the README ACP section to the runtime integration contract.

Validation
- git diff --check
- diff secret scan

Refs #2535

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR is a documentation-only change that adds a backend integration mode matrix to `docs/RUNTIME_API.md` and cross-links it from the ACP section of `README.md`.

- Adds a new \"Choosing an integration mode\" section with a four-row table comparing `serve --http`, `exec --auto --output-format stream-json`, `serve --acp`, and `serve --mcp` across tool access, streaming, and message shape dimensions, followed by a narrative paragraph with use-case guidance.
- Adds one sentence to `README.md` pointing readers who need tools, streaming, or structured conversation state toward the new matrix.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — documentation only with no code changes; one clarification to the MCP streaming cell would improve accuracy.

The changes are entirely documentation. The MCP row's "Streaming" column currently says "MCP request/response over stdio", which describes the transport mechanism rather than the streaming behaviour; readers scanning that column alongside SSE events and NDJSON entries will get the impression MCP streams, which it does not. All other content is internally consistent and matches the adjacent prose in the document.

docs/RUNTIME_API.md — the MCP streaming cell warrants a small wording fix before the matrix is used as a reference by integrators.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/RUNTIME_API.md | Adds a new "Choosing an integration mode" section with a comparison table and narrative guidance; MCP "Streaming" cell describes transport rather than streaming behaviour, which is slightly misleading compared to the other rows |
| README.md | Adds a cross-reference link from the ACP section to the new integration mode matrix in docs/RUNTIME_API.md; link path is correct relative to the repo root |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Backend wrapper / client] --> B{What does the client need?}
    B -->|Structured conversations,\napprovals, event replay| C[codewhale serve --http\nSSE streaming · full tool access]
    B -->|Tool-backed CLI output,\nno daemon| D[codewhale exec --auto\n--output-format stream-json\nNDJSON on stdout]
    B -->|Already speaks ACP\ne.g. Zed editor| E[codewhale serve --acp\nACP chunks · chat-only, no MCP tools]
    B -->|External MCP client\nneeds CodeWhale as tool server| F[codewhale serve --mcp\nRequest/response over stdio]
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22codex%2F2535-backend-mode-docs%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2F2535-backend-mode-docs%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2FRUNTIME_API.md%3A34%0AThe%20%22Streaming%22%20cell%20for%20%60serve%20--mcp%60%20says%20%22MCP%20request%2Fresponse%20over%20stdio%22%2C%20which%20describes%20the%20transport%20rather%20than%20any%20streaming%20behaviour.%20Every%20other%20row%20in%20this%20column%20answers%20the%20question%20%22how%20does%20data%20flow%20back%20to%20the%20caller%20in%20a%20streaming%20way%3F%22%20%E2%80%94%20SSE%20events%2C%20newline-delimited%20JSON%2C%20and%20ACP%20chunks%20all%20convey%20incremental%20output.%20MCP%20is%20a%20synchronous%20request%2Fresponse%20protocol%20with%20no%20equivalent%20streaming%20primitive%2C%20so%20a%20reader%20scanning%20this%20column%20will%20get%20a%20misleading%20impression%20that%20MCP%20provides%20streaming.%20The%20cell%20should%20note%20the%20absence%20of%20streaming%20explicitly.%0A%0A%60%60%60suggestion%0A%7C%20%60codewhale%20serve%20--mcp%60%20%7C%20Other%20MCP%20clients%20that%20want%20to%20call%20CodeWhale%20as%20a%20tool%20server%20%7C%20Exposes%20CodeWhale%20tools%20to%20the%20external%20MCP%20client%20%7C%20No%20streaming%3B%20single%20synchronous%20request%2Fresponse%20over%20stdio%20%7C%20MCP%20tool-call%20payloads%20%7C%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2FRUNTIME_API.md%3A34%0AThe%20%22Streaming%22%20cell%20for%20%60serve%20--mcp%60%20says%20%22MCP%20request%2Fresponse%20over%20stdio%22%2C%20which%20describes%20the%20transport%20rather%20than%20any%20streaming%20behaviour.%20Every%20other%20row%20in%20this%20column%20answers%20the%20question%20%22how%20does%20data%20flow%20back%20to%20the%20caller%20in%20a%20streaming%20way%3F%22%20%E2%80%94%20SSE%20events%2C%20newline-delimited%20JSON%2C%20and%20ACP%20chunks%20all%20convey%20incremental%20output.%20MCP%20is%20a%20synchronous%20request%2Fresponse%20protocol%20with%20no%20equivalent%20streaming%20primitive%2C%20so%20a%20reader%20scanning%20this%20column%20will%20get%20a%20misleading%20impression%20that%20MCP%20provides%20streaming.%20The%20cell%20should%20note%20the%20absence%20of%20streaming%20explicitly.%0A%0A%60%60%60suggestion%0A%7C%20%60codewhale%20serve%20--mcp%60%20%7C%20Other%20MCP%20clients%20that%20want%20to%20call%20CodeWhale%20as%20a%20tool%20server%20%7C%20Exposes%20CodeWhale%20tools%20to%20the%20external%20MCP%20client%20%7C%20No%20streaming%3B%20single%20synchronous%20request%2Fresponse%20over%20stdio%20%7C%20MCP%20tool-call%20payloads%20%7C%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2544&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2FRUNTIME_API.md%3A34%0AThe%20%22Streaming%22%20cell%20for%20%60serve%20--mcp%60%20says%20%22MCP%20request%2Fresponse%20over%20stdio%22%2C%20which%20describes%20the%20transport%20rather%20than%20any%20streaming%20behaviour.%20Every%20other%20row%20in%20this%20column%20answers%20the%20question%20%22how%20does%20data%20flow%20back%20to%20the%20caller%20in%20a%20streaming%20way%3F%22%20%E2%80%94%20SSE%20events%2C%20newline-delimited%20JSON%2C%20and%20ACP%20chunks%20all%20convey%20incremental%20output.%20MCP%20is%20a%20synchronous%20request%2Fresponse%20protocol%20with%20no%20equivalent%20streaming%20primitive%2C%20so%20a%20reader%20scanning%20this%20column%20will%20get%20a%20misleading%20impression%20that%20MCP%20provides%20streaming.%20The%20cell%20should%20note%20the%20absence%20of%20streaming%20explicitly.%0A%0A%60%60%60suggestion%0A%7C%20%60codewhale%20serve%20--mcp%60%20%7C%20Other%20MCP%20clients%20that%20want%20to%20call%20CodeWhale%20as%20a%20tool%20server%20%7C%20Exposes%20CodeWhale%20tools%20to%20the%20external%20MCP%20client%20%7C%20No%20streaming%3B%20single%20synchronous%20request%2Fresponse%20over%20stdio%20%7C%20MCP%20tool-call%20payloads%20%7C%0A%60%60%60%0A%0A&pr=2544&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs(runtime): clarify backend integrati..."](https://github.com/hmbown/codewhale/commit/2a6219583f3b49ce717ce99c6cad4a7992fc1a67) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35011852)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->