### PR TITLE
feat(tui): show routed whale label in footer

### DIFF
--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -4735,6 +4735,30 @@ impl App {
         self.model.clone()
     }
 
+    pub fn route_display_label(&self) -> String {
+        let should_show_route = self.auto_model || self.reasoning_effort == ReasoningEffort::Auto;
+        if !should_show_route {
+            return self.model_display_label();
+        }
+
+        let model = if self.auto_model {
+            self.last_effective_model
+                .as_deref()
+                .filter(|model| *model != "auto")
+        } else {
+            Some(self.model.as_str())
+        };
+        let effort = self.last_effective_reasoning_effort;
+
+        if let (Some(model), Some(effort)) = (model, effort)
+            && let Some(label) = whale_route_label(model, effort)
+        {
+            return format!("auto: {label} ({model}/{})", effort.short_label());
+        }
+
+        self.model_display_label()
+    }
+
     pub fn reasoning_effort_display_label(&self) -> String {
         if self.auto_model || self.reasoning_effort == ReasoningEffort::Auto {
             if let Some(effective) = self.last_effective_reasoning_effort {
@@ -4758,6 +4782,25 @@ impl App {
     /// engine has its own copy to mutate per-session.
     pub fn cycle_config(&self) -> CycleConfig {
         self.cycle.clone()
+    }
+}
+
+fn whale_route_label(model: &str, effort: ReasoningEffort) -> Option<&'static str> {
+    let model = model.to_ascii_lowercase();
+    let is_pro = model.contains("deepseek-v4-pro") || model.contains("deepseek_v4_pro");
+    let is_flash = model.contains("deepseek-v4-flash") || model.contains("deepseek_v4_flash");
+    match (is_pro, is_flash, effort) {
+        (true, false, ReasoningEffort::Max) => Some("Blue Whale"),
+        (true, false, ReasoningEffort::High | ReasoningEffort::Medium | ReasoningEffort::Low) => {
+            Some("Fin Whale")
+        }
+        (true, false, ReasoningEffort::Off) => Some("Sperm Whale"),
+        (false, true, ReasoningEffort::Max) => Some("Humpback Whale"),
+        (false, true, ReasoningEffort::High | ReasoningEffort::Medium | ReasoningEffort::Low) => {
+            Some("Minke Whale")
+        }
+        (false, true, ReasoningEffort::Off) => Some("Dwarf Sperm Whale"),
+        _ => None,
     }
 }
 

--- a/crates/tui/src/tui/footer_ui.rs
+++ b/crates/tui/src/tui/footer_ui.rs
@@ -830,7 +830,8 @@ pub(crate) fn footer_status_line_spans(app: &App, max_width: usize) -> Vec<Span<
     }
 
     let model_budget = max_width.saturating_sub(fixed_width).max(1);
-    let model_label = truncate_line_to_width(&app.model, model_budget);
+    let model_display = app.route_display_label();
+    let model_label = truncate_line_to_width(&model_display, model_budget);
 
     let mut spans = vec![
         Span::styled(mode_label.to_string(), Style::default().fg(mode_color)),

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -6585,10 +6585,34 @@ fn render_footer_from_with_default_items_renders_mode_and_model() {
     let items = crate::config::StatusItem::default_footer();
     let props = render_footer_from(&app, &items, None);
     assert_eq!(props.mode_label, "agent");
-    assert!(!props.model.is_empty(), "footer should show a model name");
+    assert_eq!(props.model, "deepseek-v4-pro");
     // Tiny but real costs should render instead of disappearing as "$0.00".
     assert!(!props.cost.is_empty());
     assert_eq!(spans_text(&props.cost), "<$0.0001");
+}
+
+#[test]
+fn render_footer_from_auto_route_shows_whale_label_and_exact_choice() {
+    let mut app = create_test_app();
+    app.set_model_selection("auto".to_string());
+    app.last_effective_model = Some("deepseek-v4-pro".to_string());
+    app.last_effective_reasoning_effort = Some(ReasoningEffort::Max);
+
+    let props = render_footer_from(&app, &crate::config::StatusItem::default_footer(), None);
+
+    assert_eq!(props.model, "auto: Blue Whale (deepseek-v4-pro/max)");
+}
+
+#[test]
+fn render_footer_from_unknown_auto_route_keeps_exact_model_only() {
+    let mut app = create_test_app();
+    app.set_model_selection("auto".to_string());
+    app.last_effective_model = Some("custom-model-9b".to_string());
+    app.last_effective_reasoning_effort = Some(ReasoningEffort::Max);
+
+    let props = render_footer_from(&app, &crate::config::StatusItem::default_footer(), None);
+
+    assert_eq!(props.model, "auto: custom-model-9b");
 }
 
 #[test]

--- a/crates/tui/src/tui/widgets/footer.rs
+++ b/crates/tui/src/tui/widgets/footer.rs
@@ -281,7 +281,7 @@ impl FooterProps {
         // to cross the 60s threshold inside `footer_worked_chip`.
         let worked = footer_worked_chip(app.cumulative_turn_duration);
         Self {
-            model: app.model_display_label(),
+            model: app.route_display_label(),
             mode_label,
             mode_color,
             text_dim_color: app.ui_theme.text_dim,


### PR DESCRIPTION
Summary
- Show the concrete auto-routed whale label in the footer once a route has been selected.
- Keep the exact model id and reasoning effort visible next to the friendly label.
- Fall back to the exact model id for unknown routes instead of inventing a whale label.

Validation
- cargo check -p codewhale-tui --all-features --locked
- cargo test -p codewhale-tui --all-features --locked render_footer_from_
- cargo test -p codewhale-tui --all-features --locked footer_status_line_spans_show_mode_and_model_idle_and_active
- git diff --check
- diff secret scan

Refs #2026

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR surfaces the auto-routed whale tier label (e.g. "auto: Blue Whale (deepseek-v4-pro/max)") in the TUI footer by replacing `model_display_label()` with a new `route_display_label()` that consults a static `whale_route_label` lookup keyed on model substring and resolved reasoning effort.

- `route_display_label` and the private `whale_route_label` matcher are added to `app.rs`; unknown model+effort combinations fall back to `model_display_label()` rather than fabricating a whale name.
- Both `FooterProps::new` and `footer_status_line_spans` are updated to call the new method, and two new render tests validate the whale-label and unknown-model paths.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change is display-only with no effect on routing or model selection logic.

The core whale-label lookup and both footer call sites are correct. The one rough edge is in the reasoning_effort == Auto + explicit non-whale-model path: the auto effort indicator is dropped silently in the fallback to model_display_label, so those users see no auto signal in the footer. That inconsistency exists alongside a missing test for this exact code path.

crates/tui/src/tui/app.rs — the reasoning_effort == Auto branch of route_display_label and its interaction with the model_display_label fallback for non-whale models.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/app.rs | Adds route_display_label and private whale_route_label to map model+effort pairs to named whale tiers. The reasoning_effort == Auto fallback path has an inconsistent display: whale-matched models get an 'auto: ' prefix, but non-whale models silently drop the auto-effort indicator. |
| crates/tui/src/tui/footer_ui.rs | One-line change: replaces app.model with app.route_display_label() for the footer status line model text. Correct and straightforward. |
| crates/tui/src/tui/widgets/footer.rs | One-line change in FooterProps constructor: switches from model_display_label() to route_display_label(). Clean and consistent with the footer_ui.rs change. |
| crates/tui/src/tui/ui/tests.rs | Adds two new tests for auto-routed whale label and unknown-model fallback. Missing coverage for the reasoning_effort == Auto + explicit model branch of route_display_label. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[route_display_label] --> B{auto_model OR\nreasoning_effort == Auto?}
    B -- No --> C[model_display_label\nreturns bare model string]
    B -- Yes --> D{auto_model?}
    D -- Yes --> E[model = last_effective_model\nfilter out 'auto' sentinel]
    D -- No --> F[model = self.model\nexplicit selection]
    E --> G{model AND effort\nboth Some?}
    F --> G
    G -- No --> H[model_display_label\nauto: effective or 'auto']
    G -- Yes --> I{whale_route_label\nmodel + effort}
    I -- Some label --> J["auto: {label} ({model}/{effort.short_label()})"]
    I -- None --> K[model_display_label\nfallback]
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22codex%2F2026-route-footer%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2F2026-route-footer%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%3A4738-4760%0A**Inconsistent%20auto-effort%20display%20for%20non-whale%20models**%0A%0AWhen%20%60reasoning_effort%20%3D%3D%20ReasoningEffort%3A%3AAuto%60%20but%20%60auto_model%60%20is%20false%2C%20the%20function%20sets%20%60model%20%3D%20Some%28self.model.as_str%28%29%29%60%20and%20tries%20to%20find%20a%20whale%20label.%20If%20a%20whale%20label%20is%20found%20it%20returns%20%60%22auto%3A%20%7Blabel%7D%20%28%7Bmodel%7D%2Feffort%29%22%60%20with%20the%20%22auto%3A%20%22%20prefix%2C%20but%20if%20no%20whale%20label%20matches%20%28i.e.%20a%20custom%2Fnon-whale%20model%29%2C%20the%20fallback%20%60self.model_display_label%28%29%60%20returns%20just%20the%20bare%20model%20string%20with%20no%20%22auto%22%20indicator%20at%20all.%20A%20user%20running%20a%20non-whale%20model%20with%20%60reasoning_effort%20%3D%20Auto%60%20will%20see%20no%20signal%20in%20the%20footer%20that%20effort%20is%20being%20auto-selected%2C%20while%20an%20identical%20setup%20with%20a%20whale%20model%20does%20show%20the%20%22auto%3A%20%22%20prefix%20%E2%80%94%20the%20information%20gap%20depends%20entirely%20on%20whether%20the%20model%20happens%20to%20match%20a%20whale%20pattern.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui%2Ftests.rs%3A6594-6616%0A**Missing%20test%20for%20%60reasoning_effort%20%3D%3D%20Auto%60%20with%20explicit%20%28non-auto%29%20model**%0A%0AThe%20two%20new%20tests%20only%20exercise%20the%20%60auto_model%20%3D%20true%60%20branch%20of%20%60route_display_label%60.%20The%20other%20branch%20%E2%80%94%20%60reasoning_effort%20%3D%3D%20Auto%60%20with%20an%20explicit%2C%20non-auto%20model%20%E2%80%94%20is%20also%20entered%20via%20%60should_show_route%60%20but%20has%20no%20coverage.%20A%20test%20covering%20both%20a%20whale%20model%20%28e.g.%20%22deepseek-v4-flash%22%20%2B%20Auto%20effort%20that%20resolves%20to%20Max%2C%20expecting%20%60%22auto%3A%20Humpback%20Whale%20%28...%29%22%60%29%20and%20a%20non-whale%20model%20%28expecting%20just%20the%20bare%20model%20name%29%20would%20catch%20regressions%20there%2C%20including%20the%20display%20inconsistency%20noted%20above.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%3A4738-4760%0A**Inconsistent%20auto-effort%20display%20for%20non-whale%20models**%0A%0AWhen%20%60reasoning_effort%20%3D%3D%20ReasoningEffort%3A%3AAuto%60%20but%20%60auto_model%60%20is%20false%2C%20the%20function%20sets%20%60model%20%3D%20Some%28self.model.as_str%28%29%29%60%20and%20tries%20to%20find%20a%20whale%20label.%20If%20a%20whale%20label%20is%20found%20it%20returns%20%60%22auto%3A%20%7Blabel%7D%20%28%7Bmodel%7D%2Feffort%29%22%60%20with%20the%20%22auto%3A%20%22%20prefix%2C%20but%20if%20no%20whale%20label%20matches%20%28i.e.%20a%20custom%2Fnon-whale%20model%29%2C%20the%20fallback%20%60self.model_display_label%28%29%60%20returns%20just%20the%20bare%20model%20string%20with%20no%20%22auto%22%20indicator%20at%20all.%20A%20user%20running%20a%20non-whale%20model%20with%20%60reasoning_effort%20%3D%20Auto%60%20will%20see%20no%20signal%20in%20the%20footer%20that%20effort%20is%20being%20auto-selected%2C%20while%20an%20identical%20setup%20with%20a%20whale%20model%20does%20show%20the%20%22auto%3A%20%22%20prefix%20%E2%80%94%20the%20information%20gap%20depends%20entirely%20on%20whether%20the%20model%20happens%20to%20match%20a%20whale%20pattern.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui%2Ftests.rs%3A6594-6616%0A**Missing%20test%20for%20%60reasoning_effort%20%3D%3D%20Auto%60%20with%20explicit%20%28non-auto%29%20model**%0A%0AThe%20two%20new%20tests%20only%20exercise%20the%20%60auto_model%20%3D%20true%60%20branch%20of%20%60route_display_label%60.%20The%20other%20branch%20%E2%80%94%20%60reasoning_effort%20%3D%3D%20Auto%60%20with%20an%20explicit%2C%20non-auto%20model%20%E2%80%94%20is%20also%20entered%20via%20%60should_show_route%60%20but%20has%20no%20coverage.%20A%20test%20covering%20both%20a%20whale%20model%20%28e.g.%20%22deepseek-v4-flash%22%20%2B%20Auto%20effort%20that%20resolves%20to%20Max%2C%20expecting%20%60%22auto%3A%20Humpback%20Whale%20%28...%29%22%60%29%20and%20a%20non-whale%20model%20%28expecting%20just%20the%20bare%20model%20name%29%20would%20catch%20regressions%20there%2C%20including%20the%20display%20inconsistency%20noted%20above.%0A%0A&repo=hmbown%2Fcodewhale&pr=2545&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%3A4738-4760%0A**Inconsistent%20auto-effort%20display%20for%20non-whale%20models**%0A%0AWhen%20%60reasoning_effort%20%3D%3D%20ReasoningEffort%3A%3AAuto%60%20but%20%60auto_model%60%20is%20false%2C%20the%20function%20sets%20%60model%20%3D%20Some%28self.model.as_str%28%29%29%60%20and%20tries%20to%20find%20a%20whale%20label.%20If%20a%20whale%20label%20is%20found%20it%20returns%20%60%22auto%3A%20%7Blabel%7D%20%28%7Bmodel%7D%2Feffort%29%22%60%20with%20the%20%22auto%3A%20%22%20prefix%2C%20but%20if%20no%20whale%20label%20matches%20%28i.e.%20a%20custom%2Fnon-whale%20model%29%2C%20the%20fallback%20%60self.model_display_label%28%29%60%20returns%20just%20the%20bare%20model%20string%20with%20no%20%22auto%22%20indicator%20at%20all.%20A%20user%20running%20a%20non-whale%20model%20with%20%60reasoning_effort%20%3D%20Auto%60%20will%20see%20no%20signal%20in%20the%20footer%20that%20effort%20is%20being%20auto-selected%2C%20while%20an%20identical%20setup%20with%20a%20whale%20model%20does%20show%20the%20%22auto%3A%20%22%20prefix%20%E2%80%94%20the%20information%20gap%20depends%20entirely%20on%20whether%20the%20model%20happens%20to%20match%20a%20whale%20pattern.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui%2Ftests.rs%3A6594-6616%0A**Missing%20test%20for%20%60reasoning_effort%20%3D%3D%20Auto%60%20with%20explicit%20%28non-auto%29%20model**%0A%0AThe%20two%20new%20tests%20only%20exercise%20the%20%60auto_model%20%3D%20true%60%20branch%20of%20%60route_display_label%60.%20The%20other%20branch%20%E2%80%94%20%60reasoning_effort%20%3D%3D%20Auto%60%20with%20an%20explicit%2C%20non-auto%20model%20%E2%80%94%20is%20also%20entered%20via%20%60should_show_route%60%20but%20has%20no%20coverage.%20A%20test%20covering%20both%20a%20whale%20model%20%28e.g.%20%22deepseek-v4-flash%22%20%2B%20Auto%20effort%20that%20resolves%20to%20Max%2C%20expecting%20%60%22auto%3A%20Humpback%20Whale%20%28...%29%22%60%29%20and%20a%20non-whale%20model%20%28expecting%20just%20the%20bare%20model%20name%29%20would%20catch%20regressions%20there%2C%20including%20the%20display%20inconsistency%20noted%20above.%0A%0A&pr=2545&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(tui): show routed whale label in fo..."](https://github.com/hmbown/codewhale/commit/de1112f85f5e04702f1b22ed58a2eb5916cf52ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35015453)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->