### PR TITLE
docs(tui): document statusline footer items

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,12 @@ Full shortcut catalog: [docs/KEYBINDINGS.md](docs/KEYBINDINGS.md).
 
 User config: `~/.codewhale/config.toml` (legacy `~/.deepseek/config.toml` fallback). Project overlay: `<workspace>/.codewhale/config.toml` (legacy `<workspace>/.deepseek/config.toml`) (denied: `api_key`, `base_url`, `provider`, `mcp_config_path`). [config.example.toml](config.example.toml) has every option.
 
+The TUI footer can be trimmed or reordered with `/statusline`, or by setting
+`[tui].status_items` in config. Current footer customization selects from the
+built-in chips such as `mode`, `model`, `status`, `git_branch`, `tokens`, and
+`cache`; multi-line layouts, custom colors, and external command widgets are
+not part of the current statusline surface.
+
 Custom DeepSeek-compatible endpoints usually do not need a new provider. Keep
 `provider = "deepseek"` and set `[providers.deepseek].base_url` / `model`, or
 use `provider = "openai"` for generic OpenAI-compatible gateways. Keep

--- a/config.example.toml
+++ b/config.example.toml
@@ -414,6 +414,13 @@ alternate_screen = "auto"   # auto/always use the TUI screen; never uses termina
 mouse_capture = true        # true copies only transcript user/assistant text; false uses raw terminal selection/copy
 terminal_probe_timeout_ms = 500 # optional startup terminal-mode timeout (100-5000ms)
 osc8_links = true            # emit OSC 8 escapes around URLs (Cmd+click in iTerm2/Ghostty/Kitty/WezTerm/Terminal.app 13+); set false for terminals that misrender
+# Ordered footer chips shown in the TUI status line. Omit the key to use the
+# built-in default; set [] to hide all configurable chips. You can also edit
+# this interactively with `/statusline`.
+# Supported keys: mode, model, cost, balance, status, coherence, agents,
+# reasoning_replay, prefix_stability, cache, context_percent, git_branch,
+# last_tool_elapsed, rate_limit, tokens.
+# status_items = ["mode", "model", "status", "git_branch", "tokens", "cache"]
 # notification_condition = "always" # always | never — overrides [notifications].threshold_secs.
 #                                    "always" = notify on every successful turn (no threshold);
 #                                    "never"  = suppress all turn-completion notifications;

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -179,6 +179,14 @@ The interactive TUI has a few stable regions:
 - Status and footer areas: live activity, queued follow-ups, and short command
   hints.
 
+The footer status line is configurable. Run `/statusline` to choose which
+footer chips are visible, or set `[tui].status_items` in `config.toml` for a
+stable order. Supported keys currently include `mode`, `model`, `cost`,
+`balance`, `status`, `coherence`, `agents`, `reasoning_replay`,
+`prefix_stability`, `cache`, `context_percent`, `git_branch`,
+`last_tool_elapsed`, `rate_limit`, and `tokens`. Omit `status_items` to keep
+the built-in default order; set it to `[]` to hide configurable chips.
+
 The transcript is the audit trail. When CodeWhale reads files, runs commands,
 or edits code, the action appears there. If a command fails, use the visible
 failure output as part of your next instruction instead of starting over.
@@ -255,6 +263,7 @@ Common commands for first-time users:
 | `/models` | Fetch or list models from the active endpoint |
 | `/provider` | Pick the active API provider |
 | `/config` | Edit runtime and provider settings |
+| `/statusline` | Choose which footer status chips are visible |
 | `/settings` | Inspect persistent UI preferences |
 | `/compact` | Summarize long context to recover token budget |
 | `/review` | Ask for a structured review workflow |


### PR DESCRIPTION
Summary:
- document /statusline and [tui].status_items in the README and guide
- add a commented status_items example with the supported footer chip keys
- clarify that current customization is built-in footer item selection, not multi-line/custom widget layout

Validation:
- git diff --check

Refs #1916

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR documents the TUI statusline footer customization feature across `README.md`, `docs/GUIDE.md`, and `config.example.toml`, adding descriptions of the `/statusline` command and the `[tui].status_items` config key alongside a commented example and a full list of the 15 supported chip keys.

- `README.md` adds a brief paragraph on footer customization and correctly scopes what is *not* supported (multi-line layouts, custom colors, external widgets), but claims `/statusline` can "reorder" chips when the interactive picker only toggles visibility — order control requires manual `config.toml` edits.
- `config.example.toml` inserts a well-placed commented block with all supported keys and a 6-chip example; `last_tool_elapsed` and `rate_limit` are listed without noting they are currently placeholders that display nothing.
- `docs/GUIDE.md` adds an accurate paragraph to the TUI layout section and a `/statusline` row to the command table, though it also omits the placeholder caveat for two keys and the provider restriction on `balance`.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge for users who read GUIDE.md or config.example.toml, but README.md currently tells users they can reorder chips interactively when they cannot.

The README states that `/statusline` allows 'reordering' footer chips. The picker source (`status_picker.rs`) has no reorder logic — Up/Down only moves the cursor, and the saved output always follows the fixed `StatusItem::all()` order. A user who tries to reorder items in the interactive picker based on this documentation will find it has no effect and may conclude the feature is broken. The GUIDE.md addition is more careful ('choose which footer chips are visible') and avoids this mistake, but README is the primary reference most users reach first.

README.md — the 'reordered with /statusline' claim does not match what the picker actually does.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Adds a paragraph documenting /statusline and status_items, but incorrectly states that /statusline can reorder chips — the picker only toggles visibility. |
| config.example.toml | Adds a commented status_items block with a full supported-key list and a 6-item example; lists last_tool_elapsed and rate_limit without noting they are placeholders. |
| docs/GUIDE.md | Adds accurate /statusline section to the TUI layout explanation and adds /statusline row to the command table; balance provider restriction and placeholder keys not called out. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([User wants to configure footer]) --> B{Method}
    B -->|Interactive| C["/statusline command"]
    B -->|Config file| D["Edit status_items in config.toml"]

    C --> E[StatusPickerView opens]
    E --> F["Toggle chips on/off\n(Space / a / n)"]
    F --> G["Up/Down moves cursor only\n— no reordering"]
    G --> H["Enter saves in\nStatusItem::all() fixed order"]

    D --> I["Specify keys in any order\n→ that order is preserved"]

    H --> J[Footer renders selected chips]
    I --> J

    J --> K{Chip restrictions}
    K -->|balance| L["DeepSeek / DeepSeekCN only\n(hidden for other providers)"]
    K -->|last_tool_elapsed / rate_limit| M["Placeholder — accepted\nbut displays nothing"]
    K -->|All other keys| N["Fully functional"]
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22codex%2F1916-statusline-docs%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2F1916-statusline-docs%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0AREADME.md%3A492-496%0AThe%20word%20%22reordered%22%20overstates%20what%20%60%2Fstatusline%60%20can%20do.%20Looking%20at%20%60status_picker.rs%60%2C%20the%20Up%2FDown%20keys%20only%20move%20the%20cursor%3B%20there%20is%20no%20swap%2Fdrag%20logic%20in%20the%20picker.%20The%20selection%20is%20always%20written%20out%20in%20the%20fixed%20%60StatusItem%3A%3Aall%28%29%60%20order.%20Users%20who%20try%20to%20reorder%20chips%20via%20the%20interactive%20picker%20will%20find%20it%20has%20no%20effect%20on%20chip%20order%20%E2%80%94%20only%20toggling%20visibility%20works%20there.%20Reordering%20requires%20manually%20editing%20%60status_items%60%20in%20%60config.toml%60.%0A%0A%60%60%60suggestion%0AThe%20TUI%20footer%20can%20be%20trimmed%20with%20%60%2Fstatusline%60%2C%20or%20by%20setting%0A%60%5Btui%5D.status_items%60%20in%20config.%20Current%20footer%20customization%20selects%20from%20the%0Abuilt-in%20chips%20such%20as%20%60mode%60%2C%20%60model%60%2C%20%60status%60%2C%20%60git_branch%60%2C%20%60tokens%60%2C%20and%0A%60cache%60%3B%20chip%20order%20is%20controlled%20by%20the%20order%20of%20keys%20in%20%60status_items%60%20in%0A%60config.toml%60%20%28the%20interactive%20picker%20always%20writes%20in%20the%20canonical%20order%29.%0AMulti-line%20layouts%2C%20custom%20colors%2C%20and%20external%20command%20widgets%20are%20not%20part%0Aof%20the%20current%20statusline%20surface.%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Aconfig.example.toml%3A420-422%0ATwo%20keys%20in%20the%20supported%20list%20%E2%80%94%20%60last_tool_elapsed%60%20and%20%60rate_limit%60%20%E2%80%94%20are%20marked%20as%20%60%28placeholder%29%60%20in%20their%20own%20hints%20inside%20%60StatusItem%3A%3Ahint%28%29%60%20in%20%60config.rs%60.%20Including%20them%20in%20the%20supported-keys%20list%20without%20any%20caveat%20may%20lead%20users%20to%20include%20them%20in%20%60status_items%60%20and%20be%20surprised%20when%20they%20show%20nothing.%20A%20short%20note%20would%20set%20accurate%20expectations.%0A%0A%60%60%60suggestion%0A%23%20Supported%20keys%3A%20mode%2C%20model%2C%20cost%2C%20balance%2C%20status%2C%20coherence%2C%20agents%2C%0A%23%20reasoning_replay%2C%20prefix_stability%2C%20cache%2C%20context_percent%2C%20git_branch%2C%0A%23%20last_tool_elapsed%20%28placeholder%29%2C%20rate_limit%20%28placeholder%29%2C%20tokens.%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Adocs%2FGUIDE.md%3A182-188%0ASame%20placeholder%20caveat%20applies%20here%3A%20%60last_tool_elapsed%60%20and%20%60rate_limit%60%20are%20marked%20as%20%60%28placeholder%29%60%20in%20their%20source%20hints%20%E2%80%94%20they%20accept%20the%20key%20but%20display%20nothing.%20Additionally%2C%20%60balance%60%20is%20only%20available%20for%20DeepSeek%20%2F%20DeepSeekCN%20providers%20and%20is%20silently%20hidden%20for%20all%20others.%0A%0A%60%60%60suggestion%0AThe%20footer%20status%20line%20is%20configurable.%20Run%20%60%2Fstatusline%60%20to%20choose%20which%0Afooter%20chips%20are%20visible%2C%20or%20set%20%60%5Btui%5D.status_items%60%20in%20%60config.toml%60%20to%0Acontrol%20both%20selection%20and%20order.%20Supported%20keys%20currently%20include%20%60mode%60%2C%0A%60model%60%2C%20%60cost%60%2C%20%60balance%60%20%28DeepSeek%20%2F%20DeepSeekCN%20only%29%2C%20%60status%60%2C%0A%60coherence%60%2C%20%60agents%60%2C%20%60reasoning_replay%60%2C%20%60prefix_stability%60%2C%20%60cache%60%2C%0A%60context_percent%60%2C%20%60git_branch%60%2C%20%60last_tool_elapsed%60%20%28placeholder%29%2C%0A%60rate_limit%60%20%28placeholder%29%2C%20and%20%60tokens%60.%20Omit%20%60status_items%60%20to%20keep%20the%0Abuilt-in%20default%20order%3B%20set%20it%20to%20%60%5B%5D%60%20to%20hide%20configurable%20chips.%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0AREADME.md%3A492-496%0AThe%20word%20%22reordered%22%20overstates%20what%20%60%2Fstatusline%60%20can%20do.%20Looking%20at%20%60status_picker.rs%60%2C%20the%20Up%2FDown%20keys%20only%20move%20the%20cursor%3B%20there%20is%20no%20swap%2Fdrag%20logic%20in%20the%20picker.%20The%20selection%20is%20always%20written%20out%20in%20the%20fixed%20%60StatusItem%3A%3Aall%28%29%60%20order.%20Users%20who%20try%20to%20reorder%20chips%20via%20the%20interactive%20picker%20will%20find%20it%20has%20no%20effect%20on%20chip%20order%20%E2%80%94%20only%20toggling%20visibility%20works%20there.%20Reordering%20requires%20manually%20editing%20%60status_items%60%20in%20%60config.toml%60.%0A%0A%60%60%60suggestion%0AThe%20TUI%20footer%20can%20be%20trimmed%20with%20%60%2Fstatusline%60%2C%20or%20by%20setting%0A%60%5Btui%5D.status_items%60%20in%20config.%20Current%20footer%20customization%20selects%20from%20the%0Abuilt-in%20chips%20such%20as%20%60mode%60%2C%20%60model%60%2C%20%60status%60%2C%20%60git_branch%60%2C%20%60tokens%60%2C%20and%0A%60cache%60%3B%20chip%20order%20is%20controlled%20by%20the%20order%20of%20keys%20in%20%60status_items%60%20in%0A%60config.toml%60%20%28the%20interactive%20picker%20always%20writes%20in%20the%20canonical%20order%29.%0AMulti-line%20layouts%2C%20custom%20colors%2C%20and%20external%20command%20widgets%20are%20not%20part%0Aof%20the%20current%20statusline%20surface.%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Aconfig.example.toml%3A420-422%0ATwo%20keys%20in%20the%20supported%20list%20%E2%80%94%20%60last_tool_elapsed%60%20and%20%60rate_limit%60%20%E2%80%94%20are%20marked%20as%20%60%28placeholder%29%60%20in%20their%20own%20hints%20inside%20%60StatusItem%3A%3Ahint%28%29%60%20in%20%60config.rs%60.%20Including%20them%20in%20the%20supported-keys%20list%20without%20any%20caveat%20may%20lead%20users%20to%20include%20them%20in%20%60status_items%60%20and%20be%20surprised%20when%20they%20show%20nothing.%20A%20short%20note%20would%20set%20accurate%20expectations.%0A%0A%60%60%60suggestion%0A%23%20Supported%20keys%3A%20mode%2C%20model%2C%20cost%2C%20balance%2C%20status%2C%20coherence%2C%20agents%2C%0A%23%20reasoning_replay%2C%20prefix_stability%2C%20cache%2C%20context_percent%2C%20git_branch%2C%0A%23%20last_tool_elapsed%20%28placeholder%29%2C%20rate_limit%20%28placeholder%29%2C%20tokens.%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Adocs%2FGUIDE.md%3A182-188%0ASame%20placeholder%20caveat%20applies%20here%3A%20%60last_tool_elapsed%60%20and%20%60rate_limit%60%20are%20marked%20as%20%60%28placeholder%29%60%20in%20their%20source%20hints%20%E2%80%94%20they%20accept%20the%20key%20but%20display%20nothing.%20Additionally%2C%20%60balance%60%20is%20only%20available%20for%20DeepSeek%20%2F%20DeepSeekCN%20providers%20and%20is%20silently%20hidden%20for%20all%20others.%0A%0A%60%60%60suggestion%0AThe%20footer%20status%20line%20is%20configurable.%20Run%20%60%2Fstatusline%60%20to%20choose%20which%0Afooter%20chips%20are%20visible%2C%20or%20set%20%60%5Btui%5D.status_items%60%20in%20%60config.toml%60%20to%0Acontrol%20both%20selection%20and%20order.%20Supported%20keys%20currently%20include%20%60mode%60%2C%0A%60model%60%2C%20%60cost%60%2C%20%60balance%60%20%28DeepSeek%20%2F%20DeepSeekCN%20only%29%2C%20%60status%60%2C%0A%60coherence%60%2C%20%60agents%60%2C%20%60reasoning_replay%60%2C%20%60prefix_stability%60%2C%20%60cache%60%2C%0A%60context_percent%60%2C%20%60git_branch%60%2C%20%60last_tool_elapsed%60%20%28placeholder%29%2C%0A%60rate_limit%60%20%28placeholder%29%2C%20and%20%60tokens%60.%20Omit%20%60status_items%60%20to%20keep%20the%0Abuilt-in%20default%20order%3B%20set%20it%20to%20%60%5B%5D%60%20to%20hide%20configurable%20chips.%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2547&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0AREADME.md%3A492-496%0AThe%20word%20%22reordered%22%20overstates%20what%20%60%2Fstatusline%60%20can%20do.%20Looking%20at%20%60status_picker.rs%60%2C%20the%20Up%2FDown%20keys%20only%20move%20the%20cursor%3B%20there%20is%20no%20swap%2Fdrag%20logic%20in%20the%20picker.%20The%20selection%20is%20always%20written%20out%20in%20the%20fixed%20%60StatusItem%3A%3Aall%28%29%60%20order.%20Users%20who%20try%20to%20reorder%20chips%20via%20the%20interactive%20picker%20will%20find%20it%20has%20no%20effect%20on%20chip%20order%20%E2%80%94%20only%20toggling%20visibility%20works%20there.%20Reordering%20requires%20manually%20editing%20%60status_items%60%20in%20%60config.toml%60.%0A%0A%60%60%60suggestion%0AThe%20TUI%20footer%20can%20be%20trimmed%20with%20%60%2Fstatusline%60%2C%20or%20by%20setting%0A%60%5Btui%5D.status_items%60%20in%20config.%20Current%20footer%20customization%20selects%20from%20the%0Abuilt-in%20chips%20such%20as%20%60mode%60%2C%20%60model%60%2C%20%60status%60%2C%20%60git_branch%60%2C%20%60tokens%60%2C%20and%0A%60cache%60%3B%20chip%20order%20is%20controlled%20by%20the%20order%20of%20keys%20in%20%60status_items%60%20in%0A%60config.toml%60%20%28the%20interactive%20picker%20always%20writes%20in%20the%20canonical%20order%29.%0AMulti-line%20layouts%2C%20custom%20colors%2C%20and%20external%20command%20widgets%20are%20not%20part%0Aof%20the%20current%20statusline%20surface.%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Aconfig.example.toml%3A420-422%0ATwo%20keys%20in%20the%20supported%20list%20%E2%80%94%20%60last_tool_elapsed%60%20and%20%60rate_limit%60%20%E2%80%94%20are%20marked%20as%20%60%28placeholder%29%60%20in%20their%20own%20hints%20inside%20%60StatusItem%3A%3Ahint%28%29%60%20in%20%60config.rs%60.%20Including%20them%20in%20the%20supported-keys%20list%20without%20any%20caveat%20may%20lead%20users%20to%20include%20them%20in%20%60status_items%60%20and%20be%20surprised%20when%20they%20show%20nothing.%20A%20short%20note%20would%20set%20accurate%20expectations.%0A%0A%60%60%60suggestion%0A%23%20Supported%20keys%3A%20mode%2C%20model%2C%20cost%2C%20balance%2C%20status%2C%20coherence%2C%20agents%2C%0A%23%20reasoning_replay%2C%20prefix_stability%2C%20cache%2C%20context_percent%2C%20git_branch%2C%0A%23%20last_tool_elapsed%20%28placeholder%29%2C%20rate_limit%20%28placeholder%29%2C%20tokens.%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Adocs%2FGUIDE.md%3A182-188%0ASame%20placeholder%20caveat%20applies%20here%3A%20%60last_tool_elapsed%60%20and%20%60rate_limit%60%20are%20marked%20as%20%60%28placeholder%29%60%20in%20their%20source%20hints%20%E2%80%94%20they%20accept%20the%20key%20but%20display%20nothing.%20Additionally%2C%20%60balance%60%20is%20only%20available%20for%20DeepSeek%20%2F%20DeepSeekCN%20providers%20and%20is%20silently%20hidden%20for%20all%20others.%0A%0A%60%60%60suggestion%0AThe%20footer%20status%20line%20is%20configurable.%20Run%20%60%2Fstatusline%60%20to%20choose%20which%0Afooter%20chips%20are%20visible%2C%20or%20set%20%60%5Btui%5D.status_items%60%20in%20%60config.toml%60%20to%0Acontrol%20both%20selection%20and%20order.%20Supported%20keys%20currently%20include%20%60mode%60%2C%0A%60model%60%2C%20%60cost%60%2C%20%60balance%60%20%28DeepSeek%20%2F%20DeepSeekCN%20only%29%2C%20%60status%60%2C%0A%60coherence%60%2C%20%60agents%60%2C%20%60reasoning_replay%60%2C%20%60prefix_stability%60%2C%20%60cache%60%2C%0A%60context_percent%60%2C%20%60git_branch%60%2C%20%60last_tool_elapsed%60%20%28placeholder%29%2C%0A%60rate_limit%60%20%28placeholder%29%2C%20and%20%60tokens%60.%20Omit%20%60status_items%60%20to%20keep%20the%0Abuilt-in%20default%20order%3B%20set%20it%20to%20%60%5B%5D%60%20to%20hide%20configurable%20chips.%0A%60%60%60%0A%0A&pr=2547&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs(tui): document statusline footer it..."](https://github.com/hmbown/codewhale/commit/abb1147a3cba74b44382675a783629c7a5290fb8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35017740)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->