### PR TITLE
docs(rebrand): clarify state migration paths

### DIFF
--- a/docs/REBRAND.md
+++ b/docs/REBRAND.md
@@ -23,8 +23,10 @@ codewhale doctor
 codewhale
 ```
 
-Your `~/.deepseek/config.toml`, `~/.deepseek/sessions/`, `~/.deepseek/skills/`,
-`~/.deepseek/tasks/`, and `~/.deepseek/mcp.json` are untouched. Existing
+Your existing `~/.deepseek/config.toml`, `~/.deepseek/sessions/`,
+`~/.deepseek/skills/`, `~/.deepseek/tasks/`, and `~/.deepseek/mcp.json` are
+not deleted. New CodeWhale installs prefer `~/.codewhale/`, and legacy
+`~/.deepseek/` state remains a read fallback while you migrate. Existing
 `DEEPSEEK_*` environment variables continue to work.
 
 ## What got renamed
@@ -52,9 +54,10 @@ Anything that targets the DeepSeek provider API stays exactly as it was:
   aliases `deepseek-chat` and `deepseek-reasoner`.
 - **Hosts**: `api.deepseek.com` (global) and `api.deepseeki.com` (China
   fallback).
-- **Config directory**: `~/.deepseek/`. Renaming this would invalidate
-  every existing install's saved API key, sessions, skills, MCP config,
-  and audit log.
+- **Legacy state compatibility**: existing `~/.deepseek/` config, sessions,
+  skills, tasks, MCP config, memory, and notes remain readable. New writes use
+  the CodeWhale state root (`~/.codewhale/`) unless you explicitly point a
+  setting at another path.
 - **GitHub repository URL**: `https://github.com/Hmbown/CodeWhale`.
   The old `Hmbown/DeepSeek-TUI` URL redirects there during the transition.
 - **Homebrew tap and formula** (`Hmbown/homebrew-deepseek-tui`): still
@@ -116,6 +119,35 @@ they land you on the deprecation shim, which then prompts the install of
 A second checksum manifest, `deepseek-artifacts-sha256.txt`, is attached as
 an alias of `codewhale-artifacts-sha256.txt` so v0.8.40's hardcoded lookup
 still verifies.
+
+### Sessions, skills, and manual workspaces
+
+Renaming the binary does not require starting over:
+
+- **Config**: on first launch, CodeWhale copies `~/.deepseek/config.toml` to
+  `~/.codewhale/config.toml` if the CodeWhale file does not already exist.
+  It never overwrites a newer CodeWhale config. You can inspect the active path
+  with `codewhale doctor`.
+- **Sessions and tasks**: managed state is read from `~/.codewhale/...` when
+  present, with `~/.deepseek/...` used as the legacy fallback when only the old
+  directory exists. Existing saved sessions still appear in `codewhale sessions`
+  and the TUI resume picker.
+- **Skills**: CodeWhale discovers workspace skills first, then global skills,
+  including both `~/.codewhale/skills` and legacy `~/.deepseek/skills`. Existing
+  skill directories with `SKILL.md` do not need to be rewritten.
+- **Manual binary installs**: keep the dispatcher and TUI binaries as siblings
+  on your `PATH`: `codewhale` plus `codewhale-tui`. On Windows, the recommended
+  user-local location is `%LOCALAPPDATA%\Programs\CodeWhale\bin`. On Unix-like
+  systems, any user-writable `PATH` directory is fine as long as both binaries
+  are present.
+- **Specified work directories**: running `codewhale` from a project directory,
+  or launching it with a specific workspace path, does not move project files.
+  CodeWhale reads `<workspace>/.codewhale/config.toml` first and falls back to
+  legacy `<workspace>/.deepseek/config.toml` when the new path is absent.
+
+If both `~/.codewhale/...` and `~/.deepseek/...` copies exist, the CodeWhale
+path wins. Keep the legacy directory until you have confirmed `codewhale
+doctor`, `codewhale sessions`, and your expected skills all show the same state.
 
 ## Why the name change
 

--- a/docs/REBRAND.md
+++ b/docs/REBRAND.md
@@ -40,6 +40,13 @@ not deleted. New CodeWhale installs prefer `~/.codewhale/`, and legacy
 | Release assets | `deepseek-<platform>` / `deepseek-tui-<platform>` | `codewhale-<platform>` / `codewhale-tui-<platform>` |
 | Checksum manifest | `deepseek-artifacts-sha256.txt` | `codewhale-artifacts-sha256.txt` |
 
+## What changed for local state
+
+New installs write product-owned state under `~/.codewhale/`. Existing
+`~/.deepseek/` config, sessions, skills, tasks, MCP config, memory, and notes
+remain readable as legacy fallbacks while you migrate. CodeWhale never deletes
+the legacy directory automatically.
+
 ## What did NOT change
 
 Anything that targets the DeepSeek provider API stays exactly as it was:
@@ -54,10 +61,6 @@ Anything that targets the DeepSeek provider API stays exactly as it was:
   aliases `deepseek-chat` and `deepseek-reasoner`.
 - **Hosts**: `api.deepseek.com` (global) and `api.deepseeki.com` (China
   fallback).
-- **Legacy state compatibility**: existing `~/.deepseek/` config, sessions,
-  skills, tasks, MCP config, memory, and notes remain readable. New writes use
-  the CodeWhale state root (`~/.codewhale/`) unless you explicitly point a
-  setting at another path.
 - **GitHub repository URL**: `https://github.com/Hmbown/CodeWhale`.
   The old `Hmbown/DeepSeek-TUI` URL redirects there during the transition.
 - **Homebrew tap and formula** (`Hmbown/homebrew-deepseek-tui`): still
@@ -135,6 +138,10 @@ Renaming the binary does not require starting over:
 - **Skills**: CodeWhale discovers workspace skills first, then global skills,
   including both `~/.codewhale/skills` and legacy `~/.deepseek/skills`. Existing
   skill directories with `SKILL.md` do not need to be rewritten.
+- **MCP config**: the default path is `~/.codewhale/mcp.json`. If that file is
+  absent, CodeWhale still reads legacy `~/.deepseek/mcp.json`. To use a custom
+  MCP config file, set `mcp_config_path` in `config.toml` or
+  `DEEPSEEK_MCP_CONFIG`.
 - **Manual binary installs**: keep the dispatcher and TUI binaries as siblings
   on your `PATH`: `codewhale` plus `codewhale-tui`. On Windows, the recommended
   user-local location is `%LOCALAPPDATA%\Programs\CodeWhale\bin`. On Unix-like


### PR DESCRIPTION
Summary:
- update the rebrand guide for the current .codewhale primary / .deepseek fallback behavior
- explain what happens to sessions, tasks, skills, MCP config, and manual binary installs
- call out workspace-local .codewhale config with legacy .deepseek fallback

Validation:
- git diff --check

Refs #1969

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates `docs/REBRAND.md` to explain the `.codewhale/` primary / `.deepseek/` fallback state layout introduced by the rebrand, covering config copy-on-first-launch, session/task/skill fallback resolution, workspace-local config lookup, and manual binary placement.

- A new "Sessions, skills, and manual workspaces" subsection details each migration path, but omits MCP config despite it being called out in the TL;DR.
- The replaced "Config directory" bullet is now "Legacy state compatibility" sitting under **"What did NOT change"**, even though the primary config directory actually moved — this framing may mislead readers scanning for what changed vs. what stayed the same.
- One sentence alludes to a user-overridable state root path but never names the controlling setting.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Documentation-only change; no executable code is modified, so there is no runtime risk from merging.

The new section accurately documents the migration paths, but the 'Legacy state compatibility' bullet is placed under 'What did NOT change' even though the primary config directory moved — a reader scanning that section will get a misleading picture. The unnamed state-root override setting and the missing MCP bullet are smaller gaps. None of these affect running software, but they could cause user confusion during migration.

docs/REBRAND.md — specifically the placement of the 'Legacy state compatibility' bullet and the completeness of the new migration section.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/REBRAND.md | Documentation update clarifying state migration paths (config copy, session/task/skill fallback, workspace-local config); "Legacy state compatibility" bullet is misplaced under "What did NOT change" since the primary config directory moved; MCP config migration is mentioned in the TL;DR but omitted from the new detailed section; one setting referenced as a path override is unnamed. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[codewhale first launch] --> B{~/.codewhale/config.toml exists?}
    B -- Yes --> C[Use ~/.codewhale/config.toml]
    B -- No --> D{~/.deepseek/config.toml exists?}
    D -- Yes --> E[Copy to ~/.codewhale/config.toml]
    E --> C
    D -- No --> F[Start fresh / no config]

    C --> G[State reads: ~/.codewhale/ primary]
    G --> H{State found in ~/.codewhale/?}
    H -- Yes --> I[Use ~/.codewhale/ state]
    H -- No --> J[Fallback: ~/.deepseek/ state]

    subgraph Skills discovery
        K[Workspace skills] --> L[~/.codewhale/skills]
        L --> M[~/.deepseek/skills]
    end

    subgraph Workspace config
        N[workspace/.codewhale/config.toml] --> O[Fallback: workspace/.deepseek/config.toml]
    end
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22codex%2F1969-rebrand-migration-docs%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2F1969-rebrand-migration-docs%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Adocs%2FREBRAND.md%3A57-60%0A**Misplaced%20bullet%20under%20%22What%20did%20NOT%20change%22**%0A%0AThe%20replaced%20bullet%20explicitly%20stated%20that%20%60~%2F.deepseek%2F%60%20was%20staying%20as%20the%20primary%20config%20directory.%20The%20new%20%22Legacy%20state%20compatibility%22%20bullet%20describes%20the%20opposite%20%E2%80%94%20the%20primary%20directory%20moved%20to%20%60~%2F.codewhale%2F%60%2C%20and%20%60~%2F.deepseek%2F%60%20is%20now%20only%20a%20read%20fallback.%20That%20*is*%20a%20change%2C%20so%20placing%20this%20bullet%20under%20**%22What%20did%20NOT%20change%22**%20contradicts%20the%20section%20heading%20and%20may%20confuse%20readers%20scanning%20to%20understand%20what%20actually%20changed%20vs.%20what%20stayed%20the%20same.%20Consider%20moving%20it%20to%20a%20new%20%22What%20changed%22%20section%20or%20at%20least%20adding%20a%20clarifying%20note%20that%20this%20represents%20new%20fallback%20behavior%20introduced%20in%20v0.8.41.%0A%0A%23%23%23%20Issue%202%20of%203%0Adocs%2FREBRAND.md%3A58-60%0A**Undocumented%20setting%20for%20overriding%20the%20state%20root%20path**%0A%0AThe%20sentence%20%22New%20writes%20use%20the%20CodeWhale%20state%20root%20%28%60~%2F.codewhale%2F%60%29%20unless%20you%20explicitly%20point%20a%20setting%20at%20another%20path%22%20implies%20there%20is%20a%20user-facing%20config%20key%20or%20flag%20that%20controls%20the%20state%20root%2C%20but%20the%20document%20never%20names%20it.%20A%20user%20who%20wants%20to%20keep%20state%20in%20a%20custom%20location%20has%20no%20way%20to%20discover%20which%20setting%20to%20change%20without%20digging%20through%20source%20or%20other%20docs.%20Please%20name%20the%20specific%20setting%20%28e.g.%2C%20%60state_dir%60%20in%20%60config.toml%60%2C%20or%20a%20%60CODEWHALE_STATE_DIR%60%20env%20var%29%20or%20remove%20the%20qualifying%20clause%20if%20no%20such%20override%20exists.%0A%0A%23%23%23%20Issue%203%20of%203%0Adocs%2FREBRAND.md%3A123-150%0A**MCP%20config%20migration%20path%20not%20covered%20in%20the%20new%20section**%0A%0AThe%20TL%3BDR%20%28line%2027%29%20and%20the%20%22Legacy%20state%20compatibility%22%20bullet%20both%20mention%20%60~%2F.deepseek%2Fmcp.json%60%20as%20a%20fallback%2C%20but%20the%20new%20%22Sessions%2C%20skills%2C%20and%20manual%20workspaces%22%20section%20%E2%80%94%20which%20otherwise%20carefully%20enumerates%20config%2C%20sessions%2C%20tasks%2C%20skills%2C%20binaries%2C%20and%20workspace%20configs%20%E2%80%94%20omits%20MCP%20config%20entirely.%20Users%20who%20rely%20on%20custom%20MCP%20servers%20will%20notice%20the%20gap.%20Adding%20a%20short%20bullet%20for%20MCP%20%28similar%20in%20style%20to%20the%20Skills%20bullet%29%20would%20make%20the%20section%20complete.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Adocs%2FREBRAND.md%3A57-60%0A**Misplaced%20bullet%20under%20%22What%20did%20NOT%20change%22**%0A%0AThe%20replaced%20bullet%20explicitly%20stated%20that%20%60~%2F.deepseek%2F%60%20was%20staying%20as%20the%20primary%20config%20directory.%20The%20new%20%22Legacy%20state%20compatibility%22%20bullet%20describes%20the%20opposite%20%E2%80%94%20the%20primary%20directory%20moved%20to%20%60~%2F.codewhale%2F%60%2C%20and%20%60~%2F.deepseek%2F%60%20is%20now%20only%20a%20read%20fallback.%20That%20*is*%20a%20change%2C%20so%20placing%20this%20bullet%20under%20**%22What%20did%20NOT%20change%22**%20contradicts%20the%20section%20heading%20and%20may%20confuse%20readers%20scanning%20to%20understand%20what%20actually%20changed%20vs.%20what%20stayed%20the%20same.%20Consider%20moving%20it%20to%20a%20new%20%22What%20changed%22%20section%20or%20at%20least%20adding%20a%20clarifying%20note%20that%20this%20represents%20new%20fallback%20behavior%20introduced%20in%20v0.8.41.%0A%0A%23%23%23%20Issue%202%20of%203%0Adocs%2FREBRAND.md%3A58-60%0A**Undocumented%20setting%20for%20overriding%20the%20state%20root%20path**%0A%0AThe%20sentence%20%22New%20writes%20use%20the%20CodeWhale%20state%20root%20%28%60~%2F.codewhale%2F%60%29%20unless%20you%20explicitly%20point%20a%20setting%20at%20another%20path%22%20implies%20there%20is%20a%20user-facing%20config%20key%20or%20flag%20that%20controls%20the%20state%20root%2C%20but%20the%20document%20never%20names%20it.%20A%20user%20who%20wants%20to%20keep%20state%20in%20a%20custom%20location%20has%20no%20way%20to%20discover%20which%20setting%20to%20change%20without%20digging%20through%20source%20or%20other%20docs.%20Please%20name%20the%20specific%20setting%20%28e.g.%2C%20%60state_dir%60%20in%20%60config.toml%60%2C%20or%20a%20%60CODEWHALE_STATE_DIR%60%20env%20var%29%20or%20remove%20the%20qualifying%20clause%20if%20no%20such%20override%20exists.%0A%0A%23%23%23%20Issue%203%20of%203%0Adocs%2FREBRAND.md%3A123-150%0A**MCP%20config%20migration%20path%20not%20covered%20in%20the%20new%20section**%0A%0AThe%20TL%3BDR%20%28line%2027%29%20and%20the%20%22Legacy%20state%20compatibility%22%20bullet%20both%20mention%20%60~%2F.deepseek%2Fmcp.json%60%20as%20a%20fallback%2C%20but%20the%20new%20%22Sessions%2C%20skills%2C%20and%20manual%20workspaces%22%20section%20%E2%80%94%20which%20otherwise%20carefully%20enumerates%20config%2C%20sessions%2C%20tasks%2C%20skills%2C%20binaries%2C%20and%20workspace%20configs%20%E2%80%94%20omits%20MCP%20config%20entirely.%20Users%20who%20rely%20on%20custom%20MCP%20servers%20will%20notice%20the%20gap.%20Adding%20a%20short%20bullet%20for%20MCP%20%28similar%20in%20style%20to%20the%20Skills%20bullet%29%20would%20make%20the%20section%20complete.%0A%0A&repo=hmbown%2Fcodewhale&pr=2549&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Adocs%2FREBRAND.md%3A57-60%0A**Misplaced%20bullet%20under%20%22What%20did%20NOT%20change%22**%0A%0AThe%20replaced%20bullet%20explicitly%20stated%20that%20%60~%2F.deepseek%2F%60%20was%20staying%20as%20the%20primary%20config%20directory.%20The%20new%20%22Legacy%20state%20compatibility%22%20bullet%20describes%20the%20opposite%20%E2%80%94%20the%20primary%20directory%20moved%20to%20%60~%2F.codewhale%2F%60%2C%20and%20%60~%2F.deepseek%2F%60%20is%20now%20only%20a%20read%20fallback.%20That%20*is*%20a%20change%2C%20so%20placing%20this%20bullet%20under%20**%22What%20did%20NOT%20change%22**%20contradicts%20the%20section%20heading%20and%20may%20confuse%20readers%20scanning%20to%20understand%20what%20actually%20changed%20vs.%20what%20stayed%20the%20same.%20Consider%20moving%20it%20to%20a%20new%20%22What%20changed%22%20section%20or%20at%20least%20adding%20a%20clarifying%20note%20that%20this%20represents%20new%20fallback%20behavior%20introduced%20in%20v0.8.41.%0A%0A%23%23%23%20Issue%202%20of%203%0Adocs%2FREBRAND.md%3A58-60%0A**Undocumented%20setting%20for%20overriding%20the%20state%20root%20path**%0A%0AThe%20sentence%20%22New%20writes%20use%20the%20CodeWhale%20state%20root%20%28%60~%2F.codewhale%2F%60%29%20unless%20you%20explicitly%20point%20a%20setting%20at%20another%20path%22%20implies%20there%20is%20a%20user-facing%20config%20key%20or%20flag%20that%20controls%20the%20state%20root%2C%20but%20the%20document%20never%20names%20it.%20A%20user%20who%20wants%20to%20keep%20state%20in%20a%20custom%20location%20has%20no%20way%20to%20discover%20which%20setting%20to%20change%20without%20digging%20through%20source%20or%20other%20docs.%20Please%20name%20the%20specific%20setting%20%28e.g.%2C%20%60state_dir%60%20in%20%60config.toml%60%2C%20or%20a%20%60CODEWHALE_STATE_DIR%60%20env%20var%29%20or%20remove%20the%20qualifying%20clause%20if%20no%20such%20override%20exists.%0A%0A%23%23%23%20Issue%203%20of%203%0Adocs%2FREBRAND.md%3A123-150%0A**MCP%20config%20migration%20path%20not%20covered%20in%20the%20new%20section**%0A%0AThe%20TL%3BDR%20%28line%2027%29%20and%20the%20%22Legacy%20state%20compatibility%22%20bullet%20both%20mention%20%60~%2F.deepseek%2Fmcp.json%60%20as%20a%20fallback%2C%20but%20the%20new%20%22Sessions%2C%20skills%2C%20and%20manual%20workspaces%22%20section%20%E2%80%94%20which%20otherwise%20carefully%20enumerates%20config%2C%20sessions%2C%20tasks%2C%20skills%2C%20binaries%2C%20and%20workspace%20configs%20%E2%80%94%20omits%20MCP%20config%20entirely.%20Users%20who%20rely%20on%20custom%20MCP%20servers%20will%20notice%20the%20gap.%20Adding%20a%20short%20bullet%20for%20MCP%20%28similar%20in%20style%20to%20the%20Skills%20bullet%29%20would%20make%20the%20section%20complete.%0A%0A&pr=2549&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs(rebrand): clarify state migration p..."](https://github.com/hmbown/codewhale/commit/c8b440d34b64d4640841988ccec33786a983b895) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35019160)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->