### PR TITLE
docs(providers): clarify local model tool calls

### DIFF
--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -206,6 +206,26 @@ the endpoint's ability to accept OpenAI-compatible `tools` payloads. A custom
 OpenAI-compatible or local endpoint can still reject tool calls even if
 CodeWhale can send the schema.
 
+### When a Local Model Prints Tool JSON
+
+CodeWhale only executes tools when the provider returns Chat Completions
+`tool_calls` or streamed `delta.tool_calls`. If a local model prints text such
+as `{"name":"grep_files","arguments":{...}}` in the assistant message, that is
+ordinary model output, not an executable tool request.
+
+For OpenAI-compatible or local runtimes, check:
+
+- The endpoint accepts the `tools` array in `/v1/chat/completions` requests.
+- The selected model or chat template is configured for function/tool calls.
+- The server returns `tool_calls` in the response rather than plain JSON text.
+- The compatibility layer does not strip tools before forwarding the request.
+- If in doubt, test a small `read_file` or `grep_files` request against a known
+  tool-calling model before debugging CodeWhale's tool registry.
+
+Changing `provider`, `base_url`, or `model` can select a route that supports the
+OpenAI-compatible payload shape, but CodeWhale cannot convert arbitrary JSON
+text into a trusted tool call after the model has emitted it as prose.
+
 DeepSeek compatibility aliases `deepseek-chat` and `deepseek-reasoner` map to
 `deepseek-v4-flash` capability metadata and are scheduled to retire on
 2026-07-24 at 2026-07-24T15:59:00Z.


### PR DESCRIPTION
Summary:
- explain that CodeWhale executes provider-returned Chat Completions tool_calls, not JSON printed as assistant text
- add local/OpenAI-compatible troubleshooting checks for endpoints and models that do not call tools
- keep provider routing and runtime behavior unchanged

Validation:
- python3 scripts/check-provider-registry.py
- git diff --check

Refs #2361

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a new \"When a Local Model Prints Tool JSON\" subsection to `docs/PROVIDERS.md`, explaining that CodeWhale only executes tools from `tool_calls` in Chat Completions responses, not from JSON text that a model prints inline as assistant prose. No runtime or provider-routing code is changed.

- Adds a clear explanation of the `tool_calls` / `delta.tool_calls` execution contract and why arbitrary JSON text in an assistant message is not treated as a tool request.
- Adds an actionable troubleshooting checklist covering endpoint compatibility, model/template configuration, and compatibility-layer stripping of the `tools` array.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This is a documentation-only change with no modifications to provider routing, tool execution, or runtime behaviour — safe to merge.

The change adds a single new documentation subsection. The technical description of the tool_calls contract is accurate, the troubleshooting checklist is actionable, and placement in the document is coherent. Nothing in the diff touches executable code.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/PROVIDERS.md | Documentation-only addition of a local-model tool-call troubleshooting section; no logic changes, placement is logical, and the technical assertions are accurate. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CodeWhale sends /v1/chat/completions\nwith tools array] --> B{Provider response\ncontains tool_calls?}
    B -- Yes: tool_calls / delta.tool_calls --> C[CodeWhale executes tool\nand returns result]
    B -- No: plain JSON text\nin assistant message --> D[Treated as ordinary\nmodel output — ignored]
    D --> E[Troubleshooting]
    E --> F[Check endpoint accepts tools array]
    E --> G[Check model/chat template supports function calls]
    E --> H[Check server returns tool_calls not plain JSON]
    E --> I[Check compatibility layer does not strip tools]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(providers): clarify local model too..."](https://github.com/hmbown/codewhale/commit/01bc3ac8e027b911eaf52eb99bc4890513333acc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35020869)</sub>

<!-- /greptile_comment -->