### PR TITLE
test(mcp): close stale-session mock responses cleanly

### DIFF
--- a/crates/tui/src/mcp.rs
+++ b/crates/tui/src/mcp.rs
@@ -4460,6 +4460,12 @@ mod tests {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
         use tokio::net::TcpListener;
 
+        async fn write_response(socket: &mut tokio::net::TcpStream, response: &[u8]) {
+            socket.write_all(response).await.unwrap();
+            socket.flush().await.unwrap();
+            socket.shutdown().await.unwrap();
+        }
+
         let _lock = lock_mcp_loopback_tests().await;
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
@@ -4521,7 +4527,7 @@ mod tests {
                         let response = format!(
                             "HTTP/1.1 200 OK\r\nMcp-Session-Id: {session}\r\nContent-Length: 0\r\n\r\n"
                         );
-                        socket.write_all(response.as_bytes()).await.unwrap();
+                        write_response(&mut socket, response.as_bytes()).await;
                         return;
                     }
 
@@ -4537,12 +4543,11 @@ mod tests {
 
                     if method == "tools/call" && session_header.as_deref() == Some("sess-old") {
                         stale_seen.store(true, AtomicOrdering::SeqCst);
-                        socket
-                            .write_all(
-                                b"HTTP/1.1 404 Not Found\r\nContent-Type: application/json\r\nContent-Length: 27\r\n\r\n{\"error\":\"session expired\"}",
-                            )
-                            .await
-                            .unwrap();
+                        write_response(
+                            &mut socket,
+                            b"HTTP/1.1 404 Not Found\r\nContent-Type: application/json\r\nContent-Length: 27\r\n\r\n{\"error\":\"session expired\"}",
+                        )
+                        .await;
                         return;
                     }
 
@@ -4567,10 +4572,11 @@ mod tests {
                             serde_json::json!({ "content": [{ "type": "text", "text": "ok" }] })
                         }
                         _ => {
-                            socket
-                                .write_all(b"HTTP/1.1 202 Accepted\r\nContent-Length: 0\r\n\r\n")
-                                .await
-                                .unwrap();
+                            write_response(
+                                &mut socket,
+                                b"HTTP/1.1 202 Accepted\r\nContent-Length: 0\r\n\r\n",
+                            )
+                            .await;
                             return;
                         }
                     };
@@ -4585,7 +4591,7 @@ mod tests {
                         response_body.len(),
                         response_body
                     );
-                    socket.write_all(response.as_bytes()).await.unwrap();
+                    write_response(&mut socket, response.as_bytes()).await;
                 });
             }
         });


### PR DESCRIPTION
Problem
- The streamable HTTP stale-session retry test has failed on macOS CI in otherwise unrelated draft PRs with `connection closed before message completed`.
- The test mock server wrote complete HTTP responses and then let the socket drop immediately, which is sensitive to runner timing.

Change
- Flush and cleanly shut down the mock TCP stream after each response in that test.
- Keep the production MCP retry path unchanged.

Verification
- cargo fmt --check
- cargo test -p codewhale-tui --all-features --locked mcp::tests::streamable_http_stale_session_reconnects_and_retries_tool_call -- --nocapture
- Repeated the same targeted test 3 more times
- git diff --check