### PR TITLE
  feat(tui): add bang shell command shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,10 @@ codewhale mcp-server                              # run dispatcher MCP stdio ser
 codewhale update                                  # check for and apply binary updates
 ```
 
+Inside the interactive TUI composer, prefix a line with `!` to run a shell
+command through the normal approval, sandbox, and output surfaces, for example
+`! cargo test -p codewhale-tui sidebar`.
+
 ### Branching Conversations
 
 Saved sessions are intentionally branchable. `codewhale fork <SESSION_ID>` copies

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -68,7 +68,7 @@ use super::capacity_memory::{
 };
 use super::coherence::{CoherenceSignal, CoherenceState, next_coherence_state};
 use super::events::{Event, TurnOutcomeStatus};
-use super::ops::Op;
+use super::ops::{Op, USER_SHELL_TOOL_ID_PREFIX};
 use super::session::Session;
 use super::tool_parser;
 use super::turn::{TurnContext, TurnToolCall, post_turn_snapshot, pre_turn_snapshot};
@@ -630,6 +630,248 @@ impl Engine {
         (engine, handle)
     }
 
+    async fn handle_run_shell_command(
+        &mut self,
+        command: String,
+        mode: AppMode,
+        trust_mode: bool,
+        auto_approve: bool,
+        approval_mode: crate::tui::approval::ApprovalMode,
+    ) {
+        self.reset_cancel_token();
+        self.turn_counter = self.turn_counter.saturating_add(1);
+        self.capacity_controller.mark_turn_start(self.turn_counter);
+
+        let turn_id = format!(
+            "{}{seq}",
+            USER_SHELL_TOOL_ID_PREFIX,
+            seq = self.turn_counter
+        );
+        let tool_id = turn_id.clone();
+        let tool_name = "exec_shell".to_string();
+        let tool_input = json!({ "command": command });
+        let snapshot_prompt = tool_input["command"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string();
+
+        self.session.trust_mode = trust_mode;
+        self.config.trust_mode = trust_mode;
+        self.session.auto_approve = auto_approve;
+        self.session.approval_mode = if auto_approve {
+            crate::tui::approval::ApprovalMode::Auto
+        } else {
+            approval_mode
+        };
+
+        let _ = self
+            .tx_event
+            .send(Event::TurnStarted {
+                turn_id: turn_id.clone(),
+            })
+            .await;
+
+        if self.config.snapshots_enabled {
+            let pre_workspace = self.session.workspace.clone();
+            let pre_seq = self.turn_counter;
+            let pre_cap = self.config.snapshots_max_workspace_bytes;
+            let pre_prompt = snapshot_prompt.clone();
+            let _ = tokio::task::spawn_blocking(move || {
+                pre_turn_snapshot(&pre_workspace, pre_seq, pre_cap, Some(&pre_prompt))
+            })
+            .await;
+        }
+
+        let _ = self
+            .tx_event
+            .send(Event::ToolCallStarted {
+                id: tool_id.clone(),
+                name: tool_name.clone(),
+                input: tool_input.clone(),
+            })
+            .await;
+
+        let tool_context = self.build_tool_context(mode, auto_approve);
+        let registry = ToolRegistryBuilder::new()
+            .with_shell_tools()
+            .build(tool_context);
+
+        let result = if mode == AppMode::Plan {
+            Err(ToolError::permission_denied(
+                "Tool 'exec_shell' is unavailable in Plan mode".to_string(),
+            ))
+        } else if !self.config.features.enabled(Feature::ShellTool) {
+            Err(ToolError::not_available(
+                "Tool 'exec_shell' is disabled by feature flag".to_string(),
+            ))
+        } else if let Some(spec) = registry.get(&tool_name) {
+            let approval_required = spec.approval_requirement() != ApprovalRequirement::Auto
+                && !registry.context().auto_approve;
+            if approval_required {
+                emit_tool_audit(json!({
+                    "event": "tool.approval_required",
+                    "tool_id": tool_id.clone(),
+                    "tool_name": tool_name.clone(),
+                    "source": "composer_bang",
+                }));
+                let approval_key =
+                    crate::tools::approval_cache::build_approval_key(&tool_name, &tool_input).0;
+                let approval_grouping_key =
+                    crate::tools::approval_cache::build_approval_grouping_key(
+                        &tool_name,
+                        &tool_input,
+                    )
+                    .0;
+                let _ = self
+                    .tx_event
+                    .send(Event::ApprovalRequired {
+                        id: tool_id.clone(),
+                        tool_name: tool_name.clone(),
+                        input: tool_input.clone(),
+                        description: spec.description().to_string(),
+                        approval_key,
+                        approval_grouping_key,
+                        intent_summary: None,
+                    })
+                    .await;
+
+                match self.await_tool_approval(&tool_id).await {
+                    Ok(ApprovalResult::Approved) => {
+                        emit_tool_audit(json!({
+                            "event": "tool.approval_decision",
+                            "tool_id": tool_id.clone(),
+                            "tool_name": tool_name.clone(),
+                            "decision": "approved",
+                            "source": "composer_bang",
+                        }));
+                        Self::execute_tool_with_lock(
+                            self.tool_exec_lock.clone(),
+                            spec.supports_parallel(),
+                            false,
+                            self.tx_event.clone(),
+                            tool_name.clone(),
+                            tool_input.clone(),
+                            Some(&registry),
+                            None,
+                            None,
+                        )
+                        .await
+                    }
+                    Ok(ApprovalResult::Denied) => {
+                        emit_tool_audit(json!({
+                            "event": "tool.approval_decision",
+                            "tool_id": tool_id.clone(),
+                            "tool_name": tool_name.clone(),
+                            "decision": "denied",
+                            "source": "composer_bang",
+                        }));
+                        Err(ToolError::permission_denied(format!(
+                            "Tool '{tool_name}' denied by user"
+                        )))
+                    }
+                    Ok(ApprovalResult::RetryWithPolicy(policy)) => {
+                        emit_tool_audit(json!({
+                            "event": "tool.approval_decision",
+                            "tool_id": tool_id.clone(),
+                            "tool_name": tool_name.clone(),
+                            "decision": "retry_with_policy",
+                            "policy": format!("{policy:?}"),
+                            "source": "composer_bang",
+                        }));
+                        let elevated_context = registry
+                            .context()
+                            .clone()
+                            .with_elevated_sandbox_policy(policy);
+                        Self::execute_tool_with_lock(
+                            self.tool_exec_lock.clone(),
+                            spec.supports_parallel(),
+                            false,
+                            self.tx_event.clone(),
+                            tool_name.clone(),
+                            tool_input.clone(),
+                            Some(&registry),
+                            None,
+                            Some(elevated_context),
+                        )
+                        .await
+                    }
+                    Err(err) => Err(err),
+                }
+            } else {
+                Self::execute_tool_with_lock(
+                    self.tool_exec_lock.clone(),
+                    spec.supports_parallel(),
+                    false,
+                    self.tx_event.clone(),
+                    tool_name.clone(),
+                    tool_input.clone(),
+                    Some(&registry),
+                    None,
+                    None,
+                )
+                .await
+            }
+        } else {
+            Err(ToolError::not_available(
+                "tool 'exec_shell' is not registered".to_string(),
+            ))
+        };
+
+        let mut result = result;
+        if let Ok(tool_result) = result.as_mut()
+            && let Some(path) = crate::tools::truncate::apply_spillover_with_artifact(
+                tool_result,
+                &tool_id,
+                &tool_name,
+                &self.session.id,
+            )
+        {
+            emit_tool_audit(json!({
+                "event": "tool.spillover",
+                "tool_id": tool_id.clone(),
+                "tool_name": tool_name.clone(),
+                "path": path.display().to_string(),
+                "source": "composer_bang",
+            }));
+        }
+
+        let status = if result.is_err() {
+            TurnOutcomeStatus::Failed
+        } else {
+            TurnOutcomeStatus::Completed
+        };
+        let error = result.as_ref().err().map(ToString::to_string);
+
+        let _ = self
+            .tx_event
+            .send(Event::ToolCallComplete {
+                id: tool_id,
+                name: tool_name,
+                result,
+            })
+            .await;
+
+        let _ = self
+            .tx_event
+            .send(Event::TurnComplete {
+                usage: Usage::default(),
+                status,
+                error,
+                tool_catalog: None,
+                base_url: None,
+            })
+            .await;
+
+        if self.config.snapshots_enabled {
+            let post_workspace = self.session.workspace.clone();
+            let post_seq = self.turn_counter;
+            let post_cap = self.config.snapshots_max_workspace_bytes;
+            crate::utils::spawn_blocking_supervised("post-shell-turn-snapshot", move || {
+                post_turn_snapshot(&post_workspace, post_seq, post_cap, Some(&snapshot_prompt));
+            });
+        }
+    }
+
     /// Run the engine event loop
     #[allow(clippy::too_many_lines)]
     pub async fn run(mut self) {
@@ -666,6 +908,22 @@ impl Engine {
                         translation_enabled,
                         show_thinking,
                         allowed_tools,
+                    )
+                    .await;
+                }
+                Op::RunShellCommand {
+                    command,
+                    mode,
+                    trust_mode,
+                    auto_approve,
+                    approval_mode,
+                } => {
+                    self.handle_run_shell_command(
+                        command,
+                        mode,
+                        trust_mode,
+                        auto_approve,
+                        approval_mode,
                     )
                     .await;
                 }

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -978,6 +978,155 @@ fn deferred_tool_preflight_guides_checklist_update_list_replacement() {
     assert!(result.content.contains("Use checklist_write"));
 }
 
+#[tokio::test]
+async fn run_shell_command_op_requests_approval_and_executes_shell() {
+    let (mut engine, handle) = Engine::new(EngineConfig::default(), &Config::default());
+    let handle_for_approval = handle.clone();
+
+    let task = tokio::spawn(async move {
+        engine
+            .handle_run_shell_command(
+                "echo bang-ok".to_string(),
+                AppMode::Agent,
+                false,
+                false,
+                crate::tui::approval::ApprovalMode::Suggest,
+            )
+            .await;
+    });
+
+    let mut saw_started = false;
+    let mut saw_approval = false;
+    let mut saw_complete = false;
+    let mut saw_turn_complete = false;
+    let mut rx = handle.rx_event.write().await;
+    while let Some(event) = rx.recv().await {
+        match event {
+            Event::TurnStarted { turn_id } => {
+                assert!(turn_id.starts_with(USER_SHELL_TOOL_ID_PREFIX));
+            }
+            Event::ToolCallStarted { id, name, input } => {
+                saw_started = true;
+                assert!(id.starts_with(USER_SHELL_TOOL_ID_PREFIX));
+                assert_eq!(name, "exec_shell");
+                assert_eq!(input["command"], json!("echo bang-ok"));
+            }
+            Event::ApprovalRequired { id, tool_name, .. } => {
+                saw_approval = true;
+                assert!(id.starts_with(USER_SHELL_TOOL_ID_PREFIX));
+                assert_eq!(tool_name, "exec_shell");
+                handle_for_approval
+                    .approve_tool_call(id)
+                    .await
+                    .expect("approve shell");
+            }
+            Event::ToolCallComplete { id, name, result } => {
+                saw_complete = true;
+                assert!(id.starts_with(USER_SHELL_TOOL_ID_PREFIX));
+                assert_eq!(name, "exec_shell");
+                let result = result.expect("shell result");
+                assert!(result.success, "{result:?}");
+                assert!(result.content.contains("bang-ok"), "{result:?}");
+            }
+            Event::TurnComplete { status, .. } => {
+                saw_turn_complete = true;
+                assert_eq!(status, TurnOutcomeStatus::Completed);
+                break;
+            }
+            _ => {}
+        }
+    }
+    drop(rx);
+    task.await.expect("shell op task");
+
+    assert!(saw_started);
+    assert!(saw_approval);
+    assert!(saw_complete);
+    assert!(saw_turn_complete);
+}
+
+#[tokio::test]
+async fn run_shell_command_op_skips_approval_when_auto_approved() {
+    let (mut engine, handle) = Engine::new(EngineConfig::default(), &Config::default());
+
+    engine
+        .handle_run_shell_command(
+            "echo bang-yolo".to_string(),
+            AppMode::Yolo,
+            true,
+            true,
+            crate::tui::approval::ApprovalMode::Auto,
+        )
+        .await;
+
+    let mut saw_complete = false;
+    let mut rx = handle.rx_event.write().await;
+    while let Some(event) = rx.recv().await {
+        match event {
+            Event::ApprovalRequired { .. } => {
+                panic!("auto-approved shell shortcut should not request approval");
+            }
+            Event::ToolCallComplete { result, .. } => {
+                saw_complete = true;
+                let result = result.expect("shell result");
+                assert!(result.success, "{result:?}");
+                assert!(result.content.contains("bang-yolo"), "{result:?}");
+            }
+            Event::TurnComplete { status, .. } => {
+                assert_eq!(status, TurnOutcomeStatus::Completed);
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    assert!(saw_complete);
+}
+
+#[tokio::test]
+async fn run_shell_command_op_preserves_plan_mode_shell_block() {
+    let (mut engine, handle) = Engine::new(EngineConfig::default(), &Config::default());
+
+    engine
+        .handle_run_shell_command(
+            "echo blocked".to_string(),
+            AppMode::Plan,
+            false,
+            false,
+            crate::tui::approval::ApprovalMode::Suggest,
+        )
+        .await;
+
+    let mut saw_complete = false;
+    let mut saw_turn_complete = false;
+    let mut rx = handle.rx_event.write().await;
+    while let Some(event) = rx.recv().await {
+        match event {
+            Event::ApprovalRequired { .. } => {
+                panic!("Plan mode shell should be blocked before approval");
+            }
+            Event::ToolCallComplete { name, result, .. } => {
+                saw_complete = true;
+                assert_eq!(name, "exec_shell");
+                let err = result.expect_err("plan shell should fail");
+                assert!(
+                    err.to_string().contains("unavailable in Plan mode"),
+                    "{err}"
+                );
+            }
+            Event::TurnComplete { status, .. } => {
+                saw_turn_complete = true;
+                assert_eq!(status, TurnOutcomeStatus::Failed);
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    assert!(saw_complete);
+    assert!(saw_turn_complete);
+}
+
 #[test]
 fn deferred_tool_preflight_skips_already_active_tools() {
     let mut tool = api_tool("deferred_tool");

--- a/crates/tui/src/core/ops.rs
+++ b/crates/tui/src/core/ops.rs
@@ -9,6 +9,9 @@ use crate::tui::app::AppMode;
 use crate::tui::approval::ApprovalMode;
 use std::path::PathBuf;
 
+/// Prefix used for tool-call ids created by local composer shell shortcuts.
+pub const USER_SHELL_TOOL_ID_PREFIX: &str = "user_shell_";
+
 /// Operations that can be submitted to the engine.
 #[derive(Debug, Clone)]
 pub enum Op {
@@ -35,6 +38,17 @@ pub enum Op {
         /// Tool restriction from custom slash command frontmatter.
         /// `None` means the current turn may use the normal tool set.
         allowed_tools: Option<Vec<String>>,
+    },
+
+    /// Execute a user-submitted composer shell command (`! <command>`) without
+    /// sending a model turn. This still routes through `exec_shell`, approval,
+    /// sandbox, and command-safety handling.
+    RunShellCommand {
+        command: String,
+        mode: AppMode,
+        trust_mode: bool,
+        auto_approve: bool,
+        approval_mode: ApprovalMode,
     },
 
     /// Cancel the current request

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -97,6 +97,17 @@ pub(crate) fn looks_like_slash_command_input(input: &str) -> bool {
     !command.contains('/')
 }
 
+pub(crate) fn shell_command_from_bang_input(input: &str) -> Result<Option<&str>, &'static str> {
+    let Some(rest) = input.trim_start().strip_prefix('!') else {
+        return Ok(None);
+    };
+    let command = rest.trim();
+    if command.is_empty() {
+        return Err("Usage: ! <shell command>");
+    }
+    Ok(Some(command))
+}
+
 fn initial_onboarding_state(
     skip_onboarding: bool,
     was_onboarded: bool,
@@ -5112,6 +5123,29 @@ mod tests {
         assert!(!looks_like_slash_command_input(
             "/usr/lib/x86_64-linux-gnu/ 是标准路径吗？"
         ));
+    }
+
+    #[test]
+    fn bang_shell_prefix_parses_compact_and_spaced_forms() {
+        assert_eq!(shell_command_from_bang_input("!pwd"), Ok(Some("pwd")));
+        assert_eq!(shell_command_from_bang_input("! pwd"), Ok(Some("pwd")));
+        assert_eq!(
+            shell_command_from_bang_input("  !  cargo test -p codewhale-tui sidebar"),
+            Ok(Some("cargo test -p codewhale-tui sidebar"))
+        );
+        assert_eq!(shell_command_from_bang_input("normal message"), Ok(None));
+    }
+
+    #[test]
+    fn bang_shell_prefix_rejects_empty_command() {
+        assert_eq!(
+            shell_command_from_bang_input("!"),
+            Err("Usage: ! <shell command>")
+        );
+        assert_eq!(
+            shell_command_from_bang_input("!   "),
+            Err("Usage: ! <shell command>")
+        );
     }
 
     #[test]

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -48,7 +48,7 @@ use crate::config::{
 use crate::config_ui::{self, ConfigUiMode, WebConfigSession, WebConfigSessionEvent};
 use crate::core::engine::{EngineConfig, EngineHandle, spawn_engine};
 use crate::core::events::Event as EngineEvent;
-use crate::core::ops::Op;
+use crate::core::ops::{Op, USER_SHELL_TOOL_ID_PREFIX};
 use crate::hooks::{HookEvent, HookExecutor};
 use crate::llm_client::LlmClient;
 use crate::models::{
@@ -115,7 +115,7 @@ use super::key_actions;
 use super::app::{
     App, AppAction, AppMode, OnboardingState, QueuedMessage, ReasoningEffort, SidebarFocus,
     StatusToastLevel, SubmitDisposition, TaskPanelEntry, TuiOptions,
-    looks_like_slash_command_input,
+    looks_like_slash_command_input, shell_command_from_bang_input,
 };
 use super::approval::{
     ApprovalMode, ApprovalRequest, ApprovalView, ElevationRequest, ElevationView, ReviewDecision,
@@ -1414,21 +1414,27 @@ async fn run_event_loop(
                         if name == "update_plan" {
                             app.plan_tool_used_in_turn = true;
                         }
-                        let tool_content = match &result {
-                            Ok(output) => sanitize_stream_chunk(
-                                &tool_result_content_for_api_message(app, &id, &name, output).await,
-                            ),
-                            Err(err) => sanitize_stream_chunk(&format!("Error: {err}")),
-                        };
-                        app.api_messages.push(Message {
-                            role: "user".to_string(),
-                            content: vec![ContentBlock::ToolResult {
-                                tool_use_id: id.clone(),
-                                content: tool_content,
-                                is_error: None,
-                                content_blocks: None,
-                            }],
-                        });
+                        if is_model_visible_tool_call(&id) {
+                            let tool_content = match &result {
+                                Ok(output) => sanitize_stream_chunk(
+                                    &tool_result_content_for_api_message(app, &id, &name, output)
+                                        .await,
+                                ),
+                                Err(err) => sanitize_stream_chunk(&format!("Error: {err}")),
+                            };
+                            app.api_messages.push(Message {
+                                role: "user".to_string(),
+                                content: vec![ContentBlock::ToolResult {
+                                    tool_use_id: id.clone(),
+                                    content: tool_content,
+                                    is_error: None,
+                                    content_blocks: None,
+                                }],
+                            });
+                        } else {
+                            app.pending_tool_uses
+                                .retain(|(tool_id, _, _)| tool_id != &id);
+                        }
                         handle_tool_call_complete(app, &id, &name, &result);
 
                         // Immediately refresh the task panel sidebar when a
@@ -3609,6 +3615,9 @@ async fn run_event_loop(
                             handle_memory_quick_add(app, &input, config);
                             continue;
                         }
+                        if handle_bang_shell_input(app, &engine_handle, &input).await? {
+                            continue;
+                        }
                         if looks_like_slash_command_input(&input) {
                             if execute_command_input(
                                 terminal,
@@ -4716,6 +4725,37 @@ async fn dispatch_user_message(
     }
 
     Ok(())
+}
+
+async fn handle_bang_shell_input(
+    app: &mut App,
+    engine_handle: &EngineHandle,
+    input: &str,
+) -> Result<bool> {
+    let command = match shell_command_from_bang_input(input) {
+        Ok(Some(command)) => command,
+        Ok(None) => return Ok(false),
+        Err(message) => {
+            app.status_message = Some(format!("Error: {message}"));
+            return Ok(true);
+        }
+    };
+
+    engine_handle
+        .send(Op::RunShellCommand {
+            command: command.to_string(),
+            mode: app.mode,
+            trust_mode: app.trust_mode,
+            auto_approve: app.mode == AppMode::Yolo,
+            approval_mode: app.approval_mode,
+        })
+        .await?;
+    app.status_message = Some(format!("Shell command submitted: {command}"));
+    Ok(true)
+}
+
+fn is_model_visible_tool_call(id: &str) -> bool {
+    !id.starts_with(USER_SHELL_TOOL_ID_PREFIX)
 }
 
 async fn apply_model_and_compaction_update(

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -2912,6 +2912,65 @@ fn event_poll_timeout_has_nonzero_floor() {
     );
 }
 
+#[tokio::test]
+async fn bang_shell_input_dispatches_shell_op_instead_of_model_message() {
+    let mut app = create_test_app();
+    app.mode = AppMode::Agent;
+    app.trust_mode = false;
+
+    let mut engine = mock_engine_handle();
+
+    let handled = handle_bang_shell_input(&mut app, &engine.handle, "! pwd")
+        .await
+        .expect("bang shell handler");
+
+    assert!(handled);
+    assert_eq!(
+        app.status_message.as_deref(),
+        Some("Shell command submitted: pwd")
+    );
+
+    let op = engine.rx_op.recv().await.expect("engine op");
+    match op {
+        Op::RunShellCommand {
+            command,
+            mode,
+            trust_mode,
+            auto_approve,
+            approval_mode,
+        } => {
+            assert_eq!(command, "pwd");
+            assert_eq!(mode, AppMode::Agent);
+            assert!(!trust_mode);
+            assert!(!auto_approve);
+            assert_eq!(approval_mode, ApprovalMode::Suggest);
+        }
+        other => panic!("expected RunShellCommand, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn empty_bang_shell_input_is_consumed_with_usage_error() {
+    let mut app = create_test_app();
+    let engine = mock_engine_handle();
+
+    let handled = handle_bang_shell_input(&mut app, &engine.handle, "!   ")
+        .await
+        .expect("bang shell handler");
+
+    assert!(handled);
+    assert_eq!(
+        app.status_message.as_deref(),
+        Some("Error: Usage: ! <shell command>")
+    );
+}
+
+#[test]
+fn local_bang_shell_tool_ids_are_not_model_visible() {
+    assert!(!is_model_visible_tool_call("user_shell_1"));
+    assert!(is_model_visible_tool_call("toolu_01abc"));
+}
+
 fn complete_release_json(tag: &str) -> serde_json::Value {
     let assets = REQUIRED_RELEASE_ASSETS
         .iter()

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -45,6 +45,7 @@ Editing the message you're about to send.
 | `Alt-R`                    | Search prompt history (Alt-R to exit)                  |
 | `Tab`                       | Slash-command / `@`-mention completion (popup-aware)    |
 | `Ctrl-O`                    | Open external editor for the composer draft when it has focus |
+| `! command`                 | Run a shell command through normal approval, sandbox, and output surfaces |
 
 ### `@` mentions
 


### PR DESCRIPTION
## Summary

Closes: #1546

Adds composer support for `! <command>` and `!command`, so users can run an explicit shell command directly from the TUI input box instead of sending it as normal model text.

The shortcut routes through the existing `exec_shell` execution path, preserving the current approval flow, sandbox policy, command safety checks, transcript tool cards, and Work/Tasks refresh behavior. It also keeps Plan mode shell execution blocked and skips extra approval prompts when running in auto-approved YOLO mode.

Local `!` shell results are rendered in the TUI but are not appended to model-visible tool-result history, because they do
not correspond to a model-issued tool call.

<img width="823" height="434" alt="image" src="https://github.com/user-attachments/assets/c50fa18c-7707-4d63-81b8-a27ebb3f1657" />


  Previous pr #1661.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a `! <command>` shortcut in the TUI composer that routes user-submitted shell commands through the existing `exec_shell` execution path, preserving approval flow, sandbox policy, and transcript rendering without appending results to the model-visible message history.

- Adds `Op::RunShellCommand` and `handle_run_shell_command` in the engine, which emits the standard `TurnStarted / ToolCallStarted / ToolCallComplete / TurnComplete` event sequence and blocks execution in Plan mode.
- Introduces `is_model_visible_tool_call` to gate `api_messages` writes on whether the tool-call ID is model-issued, and `handle_bang_shell_input` in the UI layer to parse and dispatch the new op.
- Test coverage is solid: three async engine integration tests (approval, YOLO skip, Plan-mode block) plus UI-layer unit tests for parsing and dispatch.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with one fix: the missing source field causes user-initiated shell cards to render as assistant-sourced, showing a misleading 'Ctrl+B opens shell controls' hint and suppressing the 'started by you' label.

The new code path correctly sequences events, blocks execution in Plan mode, skips model-history writes for user-shell IDs, and carries good test coverage. The one concrete rendering defect — tool_input missing 'source: user' — produces wrong visual attribution in the transcript for every ! command a user runs. The Ctrl+Enter inconsistency is minor. Everything else (approval flow, snapshot, cancel-token handling, API message isolation) is implemented correctly.

crates/tui/src/core/engine.rs — the handle_run_shell_command tool_input construction needs 'source: user' added.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/tui/src/core/engine.rs | Adds handle_run_shell_command method (~240 lines) that routes composer ! commands through exec_shell, approval, snapshot, and event system; missing source field in tool_input causes wrong ExecCell attribution in the transcript |
| crates/tui/src/core/ops.rs | Adds RunShellCommand variant and USER_SHELL_TOOL_ID_PREFIX constant; clean and straightforward |
| crates/tui/src/tui/app.rs | Adds shell_command_from_bang_input parser; bang-shell inputs fall through to input_history and composer_history since looks_like_slash_command_input returns false for ! prefixed lines |
| crates/tui/src/tui/ui.rs | Adds handle_bang_shell_input dispatch, is_model_visible_tool_call guard, and skips api_messages append for user-shell IDs; Ctrl+Enter path does not route through handle_bang_shell_input |
| crates/tui/src/core/engine/tests.rs | Adds three async integration tests covering approval, auto-approve/YOLO, and Plan-mode block — good coverage of the new code path |
| crates/tui/src/tui/ui/tests.rs | Adds unit tests for bang-shell dispatch, empty-command rejection, and model-visibility predicate |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant UI as TUI (ui.rs)
    participant Engine as Engine (engine.rs)
    participant Shell as exec_shell tool

    User->>UI: Type "! cargo test" + Enter
    UI->>UI: shell_command_from_bang_input()
    UI->>Engine: "Op::RunShellCommand { command, mode, ... }"
    UI->>UI: "status_message = "Shell command submitted""

    Engine->>Engine: handle_run_shell_command()
    Engine->>UI: "Event::TurnStarted { turn_id: "user_shell_N" }"
    Engine->>UI: "Event::ToolCallStarted { id: "user_shell_N", name: "exec_shell" }"

    alt approval required (non-YOLO, non-auto)
        Engine->>UI: Event::ApprovalRequired
        UI->>Engine: approve_tool_call()
    end

    Engine->>Shell: execute exec_shell
    Shell-->>Engine: ToolResult
    Engine->>UI: "Event::ToolCallComplete { id: "user_shell_N" }"

    UI->>UI: is_model_visible_tool_call("user_shell_N") → false
    UI->>UI: pending_tool_uses.retain() [remove entry]
    Note over UI: api_messages NOT updated

    Engine->>UI: "Event::TurnComplete { status: Completed }"
    UI->>UI: flush_active_cell() → transcript updated
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/tui/src/tui/ui.rs`, line 3540-3582 ([link](https://github.com/hmbown/codewhale/blob/11d62a4cc6a6b4a175de86c1d2e5b0612f2478bc/crates/tui/src/tui/ui.rs#L3540-L3582)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Ctrl+Enter bypasses bang-shell routing**

   The `Ctrl+Enter` branch calls `submit_input()` and checks only `looks_like_slash_command_input`, so `! ls` entered with Ctrl+Enter is steered into the current model turn as literal text rather than dispatched as a shell command. A user who types `! cmd` and presses Ctrl+Enter while a turn is in progress (expecting to queue a shell command) will instead inject that text into the model conversation.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fbang-shell-prefix-new%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fbang-shell-prefix-new%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fui.rs%0ALine%3A%203540-3582%0A%0AComment%3A%0A**Ctrl%2BEnter%20bypasses%20bang-shell%20routing**%0A%0AThe%20%60Ctrl%2BEnter%60%20branch%20calls%20%60submit_input%28%29%60%20and%20checks%20only%20%60looks_like_slash_command_input%60%2C%20so%20%60!%20ls%60%20entered%20with%20Ctrl%2BEnter%20is%20steered%20into%20the%20current%20model%20turn%20as%20literal%20text%20rather%20than%20dispatched%20as%20a%20shell%20command.%20A%20user%20who%20types%20%60!%20cmd%60%20and%20presses%20Ctrl%2BEnter%20while%20a%20turn%20is%20in%20progress%20%28expecting%20to%20queue%20a%20shell%20command%29%20will%20instead%20inject%20that%20text%20into%20the%20model%20conversation.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fui.rs%0ALine%3A%203540-3582%0A%0AComment%3A%0A**Ctrl%2BEnter%20bypasses%20bang-shell%20routing**%0A%0AThe%20%60Ctrl%2BEnter%60%20branch%20calls%20%60submit_input%28%29%60%20and%20checks%20only%20%60looks_like_slash_command_input%60%2C%20so%20%60!%20ls%60%20entered%20with%20Ctrl%2BEnter%20is%20steered%20into%20the%20current%20model%20turn%20as%20literal%20text%20rather%20than%20dispatched%20as%20a%20shell%20command.%20A%20user%20who%20types%20%60!%20cmd%60%20and%20presses%20Ctrl%2BEnter%20while%20a%20turn%20is%20in%20progress%20%28expecting%20to%20queue%20a%20shell%20command%29%20will%20instead%20inject%20that%20text%20into%20the%20model%20conversation.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2557&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fui.rs%0ALine%3A%203540-3582%0A%0AComment%3A%0A**Ctrl%2BEnter%20bypasses%20bang-shell%20routing**%0A%0AThe%20%60Ctrl%2BEnter%60%20branch%20calls%20%60submit_input%28%29%60%20and%20checks%20only%20%60looks_like_slash_command_input%60%2C%20so%20%60!%20ls%60%20entered%20with%20Ctrl%2BEnter%20is%20steered%20into%20the%20current%20model%20turn%20as%20literal%20text%20rather%20than%20dispatched%20as%20a%20shell%20command.%20A%20user%20who%20types%20%60!%20cmd%60%20and%20presses%20Ctrl%2BEnter%20while%20a%20turn%20is%20in%20progress%20%28expecting%20to%20queue%20a%20shell%20command%29%20will%20instead%20inject%20that%20text%20into%20the%20model%20conversation.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2557&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fbang-shell-prefix-new%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fbang-shell-prefix-new%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine.rs%3A652%0AThe%20%60tool_input%60%20JSON%20is%20missing%20a%20%60%22source%22%3A%20%22user%22%60%20field.%20%60exec_source_from_input%60%20in%20%60tool_routing.rs%60%20reads%20that%20field%20to%20populate%20%60ExecCell%3A%3Asource%60%3B%20without%20it%2C%20it%20falls%20through%20to%20%60ExecSource%3A%3AAssistant%60.%20This%20has%20two%20visible%20consequences%3A%20while%20the%20command%20is%20running%2C%20the%20transcript%20shows%20the%20misleading%20%22Ctrl%2BB%20opens%20shell%20controls%22%20hint%20%28gated%20on%20%60source%20%3D%3D%20ExecSource%3A%3AAssistant%60%29%2C%20and%20after%20it%20succeeds%2C%20the%20%22started%20by%20you%22%20attribution%20%28gated%20on%20%60source%20%3D%3D%20ExecSource%3A%3AUser%60%29%20is%20never%20rendered.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20tool_input%20%3D%20json!%28%7B%20%22command%22%3A%20command%2C%20%22source%22%3A%20%22user%22%20%7D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui.rs%3A3540-3582%0A**Ctrl%2BEnter%20bypasses%20bang-shell%20routing**%0A%0AThe%20%60Ctrl%2BEnter%60%20branch%20calls%20%60submit_input%28%29%60%20and%20checks%20only%20%60looks_like_slash_command_input%60%2C%20so%20%60!%20ls%60%20entered%20with%20Ctrl%2BEnter%20is%20steered%20into%20the%20current%20model%20turn%20as%20literal%20text%20rather%20than%20dispatched%20as%20a%20shell%20command.%20A%20user%20who%20types%20%60!%20cmd%60%20and%20presses%20Ctrl%2BEnter%20while%20a%20turn%20is%20in%20progress%20%28expecting%20to%20queue%20a%20shell%20command%29%20will%20instead%20inject%20that%20text%20into%20the%20model%20conversation.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine.rs%3A652%0AThe%20%60tool_input%60%20JSON%20is%20missing%20a%20%60%22source%22%3A%20%22user%22%60%20field.%20%60exec_source_from_input%60%20in%20%60tool_routing.rs%60%20reads%20that%20field%20to%20populate%20%60ExecCell%3A%3Asource%60%3B%20without%20it%2C%20it%20falls%20through%20to%20%60ExecSource%3A%3AAssistant%60.%20This%20has%20two%20visible%20consequences%3A%20while%20the%20command%20is%20running%2C%20the%20transcript%20shows%20the%20misleading%20%22Ctrl%2BB%20opens%20shell%20controls%22%20hint%20%28gated%20on%20%60source%20%3D%3D%20ExecSource%3A%3AAssistant%60%29%2C%20and%20after%20it%20succeeds%2C%20the%20%22started%20by%20you%22%20attribution%20%28gated%20on%20%60source%20%3D%3D%20ExecSource%3A%3AUser%60%29%20is%20never%20rendered.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20tool_input%20%3D%20json!%28%7B%20%22command%22%3A%20command%2C%20%22source%22%3A%20%22user%22%20%7D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui.rs%3A3540-3582%0A**Ctrl%2BEnter%20bypasses%20bang-shell%20routing**%0A%0AThe%20%60Ctrl%2BEnter%60%20branch%20calls%20%60submit_input%28%29%60%20and%20checks%20only%20%60looks_like_slash_command_input%60%2C%20so%20%60!%20ls%60%20entered%20with%20Ctrl%2BEnter%20is%20steered%20into%20the%20current%20model%20turn%20as%20literal%20text%20rather%20than%20dispatched%20as%20a%20shell%20command.%20A%20user%20who%20types%20%60!%20cmd%60%20and%20presses%20Ctrl%2BEnter%20while%20a%20turn%20is%20in%20progress%20%28expecting%20to%20queue%20a%20shell%20command%29%20will%20instead%20inject%20that%20text%20into%20the%20model%20conversation.%0A%0A&repo=hmbown%2Fcodewhale&pr=2557&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine.rs%3A652%0AThe%20%60tool_input%60%20JSON%20is%20missing%20a%20%60%22source%22%3A%20%22user%22%60%20field.%20%60exec_source_from_input%60%20in%20%60tool_routing.rs%60%20reads%20that%20field%20to%20populate%20%60ExecCell%3A%3Asource%60%3B%20without%20it%2C%20it%20falls%20through%20to%20%60ExecSource%3A%3AAssistant%60.%20This%20has%20two%20visible%20consequences%3A%20while%20the%20command%20is%20running%2C%20the%20transcript%20shows%20the%20misleading%20%22Ctrl%2BB%20opens%20shell%20controls%22%20hint%20%28gated%20on%20%60source%20%3D%3D%20ExecSource%3A%3AAssistant%60%29%2C%20and%20after%20it%20succeeds%2C%20the%20%22started%20by%20you%22%20attribution%20%28gated%20on%20%60source%20%3D%3D%20ExecSource%3A%3AUser%60%29%20is%20never%20rendered.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20tool_input%20%3D%20json!%28%7B%20%22command%22%3A%20command%2C%20%22source%22%3A%20%22user%22%20%7D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui.rs%3A3540-3582%0A**Ctrl%2BEnter%20bypasses%20bang-shell%20routing**%0A%0AThe%20%60Ctrl%2BEnter%60%20branch%20calls%20%60submit_input%28%29%60%20and%20checks%20only%20%60looks_like_slash_command_input%60%2C%20so%20%60!%20ls%60%20entered%20with%20Ctrl%2BEnter%20is%20steered%20into%20the%20current%20model%20turn%20as%20literal%20text%20rather%20than%20dispatched%20as%20a%20shell%20command.%20A%20user%20who%20types%20%60!%20cmd%60%20and%20presses%20Ctrl%2BEnter%20while%20a%20turn%20is%20in%20progress%20%28expecting%20to%20queue%20a%20shell%20command%29%20will%20instead%20inject%20that%20text%20into%20the%20model%20conversation.%0A%0A&pr=2557&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(tui): add bang shell command shortc..."](https://github.com/hmbown/codewhale/commit/11d62a4cc6a6b4a175de86c1d2e5b0612f2478bc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35039594)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->