### PR TITLE
Add configurable path_suffix for OpenAI-compat endpoints

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -235,6 +235,7 @@ max_subagents = 10 # optional (1-20)
 # base_url = "https://your-provider.example/v1"
 # model = "deepseek-ai/DeepSeek-V4-Pro"
 # http_headers = { "X-Model-Provider-Id" = "your-model-provider" } # optional custom request headers
+# path_suffix = "/chat/completions" # override the API path; skips /v1 versioning when set
 
 # NVIDIA NIM-hosted DeepSeek V4 (https://build.nvidia.com)
 [providers.nvidia_nim]

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -162,6 +162,7 @@ pub struct ProviderConfigToml {
     pub auth_mode: Option<String>,
     #[serde(default)]
     pub http_headers: BTreeMap<String, String>,
+    pub path_suffix: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -1357,6 +1358,9 @@ impl ConfigToml {
 fn merge_project_provider_config(target: &mut ProviderConfigToml, source: &ProviderConfigToml) {
     if source.model.is_some() {
         target.model = source.model.clone();
+    }
+    if source.path_suffix.is_some() {
+        target.path_suffix = source.path_suffix.clone();
     }
 }
 

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -130,6 +130,7 @@ pub struct DeepSeekClient {
     default_model: String,
     connection_health: Arc<AsyncMutex<ConnectionHealth>>,
     rate_limiter: Arc<AsyncMutex<TokenBucket>>,
+    path_suffix: Option<String>,
 }
 
 const CONNECTION_FAILURE_THRESHOLD: u32 = 2;
@@ -296,6 +297,7 @@ impl Clone for DeepSeekClient {
             default_model: self.default_model.clone(),
             connection_health: self.connection_health.clone(),
             rate_limiter: self.rate_limiter.clone(),
+            path_suffix: self.path_suffix.clone(),
         }
     }
 }
@@ -391,9 +393,16 @@ fn is_version_segment(segment: &str) -> bool {
 }
 
 pub(super) fn api_url(base_url: &str, path: &str) -> String {
+    api_url_with_suffix(base_url, path, None)
+}
+
+pub(super) fn api_url_with_suffix(base_url: &str, path: &str, path_suffix: Option<&str>) -> String {
     let path = path.trim_start_matches('/');
     if path.starts_with("beta/") {
         return format!("{}/{}", unversioned_base_url(base_url), path);
+    }
+    if let Some(suffix) = path_suffix {
+        return format!("{}/{}", base_url.trim_end_matches('/'), suffix.trim_start_matches('/'));
     }
     let mut versioned = versioned_base_url(base_url);
     // The /beta suffix is not a real API version — it is an
@@ -474,9 +483,15 @@ impl DeepSeekClient {
         let retry = config.retry_policy();
         let default_model = config.default_model();
         let http_headers = config.http_headers();
+        let path_suffix = config
+            .provider_config_for(api_provider)
+            .and_then(|p| p.path_suffix.clone());
 
         logging::info(format!("API provider: {}", api_provider.as_str()));
         logging::info(format!("API base URL: {base_url}"));
+        if let Some(suffix) = &path_suffix {
+            logging::info(format!("API path suffix override: {suffix}"));
+        }
         if !http_headers.is_empty() {
             logging::info(format!(
                 "{} custom HTTP header(s) configured",
@@ -499,6 +514,7 @@ impl DeepSeekClient {
             default_model,
             connection_health: Arc::new(AsyncMutex::new(ConnectionHealth::default())),
             rate_limiter: Arc::new(AsyncMutex::new(TokenBucket::from_env())),
+            path_suffix,
         })
     }
 
@@ -585,7 +601,7 @@ impl DeepSeekClient {
         model: &str,
         target_language: &str,
     ) -> Result<String> {
-        let url = api_url(&self.base_url, "chat/completions");
+        let url = api_url_with_suffix(&self.base_url, "chat/completions", self.path_suffix.as_deref());
         let model = wire_model_for_provider(self.api_provider, model);
         let mut body = serde_json::json!({
             "model": model,
@@ -632,7 +648,7 @@ impl DeepSeekClient {
 
     /// List available models from the provider.
     pub async fn list_models(&self) -> Result<Vec<AvailableModel>> {
-        let url = api_url(&self.base_url, "models");
+        let url = api_url_with_suffix(&self.base_url, "models", self.path_suffix.as_deref());
         let response = self.send_with_retry(|| self.http_client.get(&url)).await?;
 
         let status = response.status();
@@ -679,7 +695,7 @@ impl DeepSeekClient {
         if !should_probe {
             return;
         }
-        let health_url = api_url(&self.base_url, "models");
+        let health_url = api_url_with_suffix(&self.base_url, "models", self.path_suffix.as_deref());
         let probe = self.http_client.get(health_url).send().await;
         match probe {
             Ok(resp) if resp.status().is_success() => {
@@ -790,7 +806,7 @@ impl LlmClient for DeepSeekClient {
     }
 
     async fn health_check(&self) -> Result<bool> {
-        let health_url = api_url(&self.base_url, "models");
+        let health_url = api_url_with_suffix(&self.base_url, "models", self.path_suffix.as_deref());
         self.wait_for_rate_limit().await;
         let response = self.http_client.get(health_url).send().await;
         match response {
@@ -1096,7 +1112,7 @@ impl DeepSeekClient {
         suffix: &str,
         max_tokens: u32,
     ) -> anyhow::Result<String> {
-        let url = api_url(&self.base_url, "beta/completions");
+        let url = api_url_with_suffix(&self.base_url, "beta/completions", self.path_suffix.as_deref());
         let model = wire_model_for_provider(self.api_provider, model);
         let body = json!({
             "model": model,
@@ -3117,8 +3133,40 @@ mod tests {
             unsafe { std::env::set_var("DEEPSEEK_FORCE_HTTP1", value) };
             assert!(
                 !force_http1_from_env(),
-                "{value:?} should NOT be parsed as truthy",
+                "{value:?} should NOT be parsed as truthy"
             );
         }
+    }
+
+    #[test]
+    fn api_url_with_suffix_uses_suffix_path() {
+        assert_eq!(
+            api_url_with_suffix(
+                "https://api.example.com/v1",
+                "chat/completions",
+                Some("/chat/completions")
+            ),
+            "https://api.example.com/chat/completions"
+        );
+    }
+
+    #[test]
+    fn api_url_with_suffix_handles_leading_slash() {
+        assert_eq!(
+            api_url_with_suffix(
+                "https://api.example.com/v1",
+                "chat/completions",
+                Some("chat/completions")
+            ),
+            "https://api.example.com/chat/completions"
+        );
+    }
+
+    #[test]
+    fn api_url_with_suffix_default_behavior_without_suffix() {
+        assert_eq!(
+            api_url_with_suffix("https://api.deepseek.com", "chat/completions", None),
+            "https://api.deepseek.com/v1/chat/completions"
+        );
     }
 }

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -401,8 +401,14 @@ pub(super) fn api_url_with_suffix(base_url: &str, path: &str, path_suffix: Optio
     if path.starts_with("beta/") {
         return format!("{}/{}", unversioned_base_url(base_url), path);
     }
-    if let Some(suffix) = path_suffix {
-        return format!("{}/{}", base_url.trim_end_matches('/'), suffix.trim_start_matches('/'));
+    if path == "chat/completions" {
+        if let Some(suffix) = path_suffix {
+            return format!(
+                "{}/{}",
+                unversioned_base_url(base_url),
+                suffix.trim_start_matches('/')
+            );
+        }
     }
     let mut versioned = versioned_base_url(base_url);
     // The /beta suffix is not a real API version — it is an
@@ -601,7 +607,11 @@ impl DeepSeekClient {
         model: &str,
         target_language: &str,
     ) -> Result<String> {
-        let url = api_url_with_suffix(&self.base_url, "chat/completions", self.path_suffix.as_deref());
+        let url = api_url_with_suffix(
+            &self.base_url,
+            "chat/completions",
+            self.path_suffix.as_deref(),
+        );
         let model = wire_model_for_provider(self.api_provider, model);
         let mut body = serde_json::json!({
             "model": model,
@@ -648,7 +658,7 @@ impl DeepSeekClient {
 
     /// List available models from the provider.
     pub async fn list_models(&self) -> Result<Vec<AvailableModel>> {
-        let url = api_url_with_suffix(&self.base_url, "models", self.path_suffix.as_deref());
+        let url = api_url(&self.base_url, "models");
         let response = self.send_with_retry(|| self.http_client.get(&url)).await?;
 
         let status = response.status();
@@ -695,7 +705,7 @@ impl DeepSeekClient {
         if !should_probe {
             return;
         }
-        let health_url = api_url_with_suffix(&self.base_url, "models", self.path_suffix.as_deref());
+        let health_url = api_url(&self.base_url, "models");
         let probe = self.http_client.get(health_url).send().await;
         match probe {
             Ok(resp) if resp.status().is_success() => {
@@ -806,7 +816,7 @@ impl LlmClient for DeepSeekClient {
     }
 
     async fn health_check(&self) -> Result<bool> {
-        let health_url = api_url_with_suffix(&self.base_url, "models", self.path_suffix.as_deref());
+        let health_url = api_url(&self.base_url, "models");
         self.wait_for_rate_limit().await;
         let response = self.http_client.get(health_url).send().await;
         match response {
@@ -1112,7 +1122,7 @@ impl DeepSeekClient {
         suffix: &str,
         max_tokens: u32,
     ) -> anyhow::Result<String> {
-        let url = api_url_with_suffix(&self.base_url, "beta/completions", self.path_suffix.as_deref());
+        let url = api_url_with_suffix(&self.base_url, "beta/completions", None);
         let model = wire_model_for_provider(self.api_provider, model);
         let body = json!({
             "model": model,
@@ -3139,10 +3149,18 @@ mod tests {
     }
 
     #[test]
-    fn api_url_with_suffix_uses_suffix_path() {
+    fn api_url_with_suffix_strips_version_before_chat_suffix() {
         assert_eq!(
             api_url_with_suffix(
                 "https://api.example.com/v1",
+                "chat/completions",
+                Some("/chat/completions")
+            ),
+            "https://api.example.com/chat/completions"
+        );
+        assert_eq!(
+            api_url_with_suffix(
+                "https://api.example.com/beta",
                 "chat/completions",
                 Some("/chat/completions")
             ),
@@ -3159,6 +3177,30 @@ mod tests {
                 Some("chat/completions")
             ),
             "https://api.example.com/chat/completions"
+        );
+    }
+
+    #[test]
+    fn api_url_with_suffix_ignores_suffix_for_models() {
+        assert_eq!(
+            api_url_with_suffix(
+                "https://api.example.com/v1",
+                "models",
+                Some("/chat/completions")
+            ),
+            "https://api.example.com/v1/models"
+        );
+    }
+
+    #[test]
+    fn api_url_with_suffix_ignores_suffix_for_beta_paths() {
+        assert_eq!(
+            api_url_with_suffix(
+                "https://api.example.com/v1",
+                "beta/completions",
+                Some("/chat/completions")
+            ),
+            "https://api.example.com/beta/completions"
         );
     }
 

--- a/crates/tui/src/client/chat.rs
+++ b/crates/tui/src/client/chat.rs
@@ -69,7 +69,7 @@ use crate::models::{
 
 use super::{
     DeepSeekClient, ERROR_BODY_MAX_BYTES, SSE_BACKPRESSURE_HIGH_WATERMARK,
-    SSE_BACKPRESSURE_SLEEP_MS, SSE_MAX_LINES_PER_CHUNK, acquire_stream_buffer, api_url,
+    SSE_BACKPRESSURE_SLEEP_MS, SSE_MAX_LINES_PER_CHUNK, acquire_stream_buffer, api_url_with_suffix,
     apply_reasoning_effort, bounded_error_text, from_api_tool_name, parse_usage,
     release_stream_buffer, system_to_instructions, to_api_tool_name,
 };
@@ -136,7 +136,11 @@ impl DeepSeekClient {
             self.api_provider,
         );
 
-        let url = api_url(&self.base_url, "chat/completions");
+        let url = api_url_with_suffix(
+            &self.base_url,
+            "chat/completions",
+            self.path_suffix.as_deref(),
+        );
         let open_timeout = stream_open_timeout();
         let response = match tokio_timeout(
             open_timeout,
@@ -239,7 +243,11 @@ impl DeepSeekClient {
             self.api_provider,
         );
 
-        let url = api_url(&self.base_url, "chat/completions");
+        let url = api_url_with_suffix(
+            &self.base_url,
+            "chat/completions",
+            self.path_suffix.as_deref(),
+        );
         let response = self
             .send_with_retry(|| self.http_client.post(&url).json(&body))
             .await?;

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -1666,6 +1666,7 @@ pub struct ProviderConfig {
     pub model: Option<String>,
     pub auth_mode: Option<String>,
     pub http_headers: Option<HashMap<String, String>>,
+    pub path_suffix: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -3833,6 +3834,7 @@ fn merge_provider_config(base: ProviderConfig, override_cfg: ProviderConfig) -> 
         model: override_cfg.model.or(base.model),
         auth_mode: override_cfg.auth_mode.or(base.auth_mode),
         http_headers: override_cfg.http_headers.or(base.http_headers),
+        path_suffix: override_cfg.path_suffix.or(base.path_suffix),
     }
 }
 


### PR DESCRIPTION
## Summary

Adds an optional `path_suffix` field to provider config that lets users override the API path for OpenAI-compatible endpoints. Some third-party endpoints reject `/v1/chat/completions` and only accept `/chat/completions`. This change allows users to set `path_suffix = "/chat/completions"` in their provider config to bypass the default `/v1` versioning.

## Changes

- `ProviderConfigToml` (config crate): added `path_suffix: Option<String>`
- `ProviderConfig` (tui crate): added `path_suffix: Option<String>`
- `merge_provider_config`: propagates the new field
- `merge_project_provider_config`: propagates the new field
- `api_url`: delegates to new `api_url_with_suffix`
- `api_url_with_suffix`: when suffix is set, uses base URL directly with the suffix path (skips /v1)
- `DeepSeekClient::new`: reads `path_suffix` from config
- `DeepSeekClient` methods: all URL-building calls use `api_url_with_suffix`
- `config.example.toml`: documents the new option
- Tests for the new URL building behavior

Closes #2089

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds an optional `path_suffix` field to provider config so users can override the API path for OpenAI-compatible endpoints that reject the default `/v1/chat/completions` route (e.g. providers that only accept `/chat/completions`).

- `api_url_with_suffix` correctly uses `unversioned_base_url` to strip the version segment before appending the suffix, and the suffix guard is scoped to `path == \"chat/completions\"` only — `models`, health probes, and `beta/` FIM paths are all unaffected.
- `path_suffix` is wired through `DeepSeekClient`, both chat call sites in `chat.rs`, and all three config merge paths; tests cover the main URL-building cases including the no-suffix default, version stripping, and path isolation.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with one design decision worth revisiting before shipping.

The core URL-building logic is correct and well-tested. The one open question is whether `path_suffix` should be settable from untrusted project-level config: the `merge_project_provider_config` helper is explicitly documented to exclude endpoint fields, yet `path_suffix` — which redirects chat API calls to an arbitrary path on the provider — was added to it. This doesn't cross a host boundary, so exploitation is limited, but it contradicts the function's stated security policy and may deserve a second look before the feature is released.

crates/config/src/lib.rs — specifically whether `path_suffix` belongs in `merge_project_provider_config` given that function's documented exclusion of endpoint overrides.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/client.rs | Adds `api_url_with_suffix` that correctly strips the version segment via `unversioned_base_url` and only applies the suffix for the `chat/completions` path; `path_suffix` field added to `DeepSeekClient` and read from provider config on construction. |
| crates/tui/src/client/chat.rs | Both streaming and non-streaming chat call sites updated from `api_url` to `api_url_with_suffix` with `self.path_suffix.as_deref()`; straightforward mechanical change. |
| crates/config/src/lib.rs | `path_suffix` added to `ProviderConfigToml` and propagated in `merge_project_provider_config`, but that helper is explicitly documented to exclude endpoint-related fields from untrusted project config. |
| crates/tui/src/config.rs | `path_suffix` field added to `ProviderConfig` and `merge_provider_config`; all changes are consistent with the existing field pattern. |
| config.example.toml | Adds a commented-out `path_suffix` example under the custom provider block with a clear description. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["api_url_with_suffix(base_url, path, suffix)"] --> B{path starts with 'beta/'?}
    B -- yes --> C["format: unversioned_base_url(base_url) / path"]
    B -- no --> D{path == 'chat/completions' AND suffix set?}
    D -- yes --> E["format: unversioned_base_url(base_url) / suffix.trim_start_matches('/')"]
    D -- no --> F["versioned = versioned_base_url(base_url)"]
    F --> G{versioned ends with 'beta'?}
    G -- yes --> H["versioned = unversioned_base_url / v1"]
    G -- no --> I["use versioned as-is"]
    H --> J["format: versioned / path"]
    I --> J

    subgraph Call Sites
        K["chat.rs streaming"] -->|path_suffix| A
        L["chat.rs non-streaming"] -->|path_suffix| A
        M["client.rs translate"] -->|path_suffix| A
        N["client.rs FIM beta/completions"] -->|None| A
        O["client.rs list_models"] -->|api_url wraps with None| A
        P["client.rs health probe"] -->|api_url wraps with None| A
    end
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fprovider-path-suffix%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fprovider-path-suffix%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Fconfig%2Fsrc%2Flib.rs%3A1358-1365%0A**%60path_suffix%60%20bypasses%20the%20project-config%20endpoint%20exclusion%20policy**%0A%0AThe%20%60merge_project_provider_config%60%20docstring%20%28line%20~418%29%20explicitly%20says%20this%20helper%20%22intentionally%20ignores%20%E2%80%A6%20endpoints%22%20because%20repo-local%20config%20is%20untrusted%20input.%20%60path_suffix%60%20controls%20where%20API%20requests%20are%20routed%20%28it%20overrides%20the%20path%20component%20of%20the%20chat%2Fcompletions%20URL%29%2C%20so%20it%20falls%20squarely%20in%20the%20%22endpoint%22%20category.%20Allowing%20a%20%60.codewhale%2Fconfig.toml%60%20in%20an%20untrusted%20repository%20to%20set%20this%20field%20means%20a%20malicious%20project%20could%20silently%20redirect%20chat%20completions%20to%20an%20arbitrary%20path%20on%20the%20configured%20provider%20%28e.g.%2C%20an%20admin%20or%20metering%20endpoint%29%2C%20which%20may%20not%20be%20the%20intended%20security%20posture.%20Consider%20removing%20%60path_suffix%60%20from%20%60merge_project_provider_config%60%20and%20restricting%20it%20to%20the%20user-level%20config%20only%2C%20consistent%20with%20how%20%60base_url%60%20is%20treated.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Fconfig%2Fsrc%2Flib.rs%3A1358-1365%0A**%60path_suffix%60%20bypasses%20the%20project-config%20endpoint%20exclusion%20policy**%0A%0AThe%20%60merge_project_provider_config%60%20docstring%20%28line%20~418%29%20explicitly%20says%20this%20helper%20%22intentionally%20ignores%20%E2%80%A6%20endpoints%22%20because%20repo-local%20config%20is%20untrusted%20input.%20%60path_suffix%60%20controls%20where%20API%20requests%20are%20routed%20%28it%20overrides%20the%20path%20component%20of%20the%20chat%2Fcompletions%20URL%29%2C%20so%20it%20falls%20squarely%20in%20the%20%22endpoint%22%20category.%20Allowing%20a%20%60.codewhale%2Fconfig.toml%60%20in%20an%20untrusted%20repository%20to%20set%20this%20field%20means%20a%20malicious%20project%20could%20silently%20redirect%20chat%20completions%20to%20an%20arbitrary%20path%20on%20the%20configured%20provider%20%28e.g.%2C%20an%20admin%20or%20metering%20endpoint%29%2C%20which%20may%20not%20be%20the%20intended%20security%20posture.%20Consider%20removing%20%60path_suffix%60%20from%20%60merge_project_provider_config%60%20and%20restricting%20it%20to%20the%20user-level%20config%20only%2C%20consistent%20with%20how%20%60base_url%60%20is%20treated.%0A%0A&repo=hmbown%2Fcodewhale&pr=2558&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Fconfig%2Fsrc%2Flib.rs%3A1358-1365%0A**%60path_suffix%60%20bypasses%20the%20project-config%20endpoint%20exclusion%20policy**%0A%0AThe%20%60merge_project_provider_config%60%20docstring%20%28line%20~418%29%20explicitly%20says%20this%20helper%20%22intentionally%20ignores%20%E2%80%A6%20endpoints%22%20because%20repo-local%20config%20is%20untrusted%20input.%20%60path_suffix%60%20controls%20where%20API%20requests%20are%20routed%20%28it%20overrides%20the%20path%20component%20of%20the%20chat%2Fcompletions%20URL%29%2C%20so%20it%20falls%20squarely%20in%20the%20%22endpoint%22%20category.%20Allowing%20a%20%60.codewhale%2Fconfig.toml%60%20in%20an%20untrusted%20repository%20to%20set%20this%20field%20means%20a%20malicious%20project%20could%20silently%20redirect%20chat%20completions%20to%20an%20arbitrary%20path%20on%20the%20configured%20provider%20%28e.g.%2C%20an%20admin%20or%20metering%20endpoint%29%2C%20which%20may%20not%20be%20the%20intended%20security%20posture.%20Consider%20removing%20%60path_suffix%60%20from%20%60merge_project_provider_config%60%20and%20restricting%20it%20to%20the%20user-level%20config%20only%2C%20consistent%20with%20how%20%60base_url%60%20is%20treated.%0A%0A&pr=2558&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Limit path suffix to chat completions"](https://github.com/hmbown/codewhale/commit/1c5c1212072141757e0e50bf00317543f7839d78) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35040510)</sub>

<!-- /greptile_comment -->