### PR TITLE
fix(npm): prefer binary version output

### DIFF
--- a/npm/codewhale/scripts/run.js
+++ b/npm/codewhale/scripts/run.js
@@ -7,31 +7,43 @@ function isVersionFlag(args = process.argv.slice(2)) {
   return args.includes("--version") || args.includes("-V");
 }
 
-function handleVersionFallback(binaryName) {
-  if (isVersionFlag()) {
-    const binVersion =
-      pkg.codewhaleBinaryVersion || pkg.deepseekBinaryVersion || pkg.version;
-    console.log(`${binaryName} (npm wrapper) v${pkg.version}`);
-    console.log(`binary version: v${binVersion}`);
-    console.log(`repo: ${pkg.repository?.url || "N/A"}`);
-    process.exit(0);
-  }
+function printVersionFallback(binaryName) {
+  const binVersion =
+    pkg.codewhaleBinaryVersion || pkg.deepseekBinaryVersion || pkg.version;
+  console.log(`${binaryName} (npm wrapper) v${pkg.version}`);
+  console.log(`binary version: v${binVersion}`);
+  console.log(`repo: ${pkg.repository?.url || "N/A"}`);
 }
 
-async function run(binaryName) {
-  // Intercept --version before attempting binary download/launch
-  handleVersionFallback(binaryName);
+async function run(binaryName, options = {}) {
+  const args = options.args || process.argv.slice(2);
+  const resolveBinaryPath = options.getBinaryPath || getBinaryPath;
+  const spawn = options.spawnSync || spawnSync;
+  const exit = options.exit || process.exit;
+  const versionFlag = isVersionFlag(args);
 
-  const binaryPath = await getBinaryPath(binaryName);
-  const result = spawnSync(binaryPath, process.argv.slice(2), {
+  let binaryPath;
+  try {
+    binaryPath = await resolveBinaryPath(binaryName);
+  } catch (error) {
+    if (versionFlag) {
+      printVersionFallback(binaryName);
+      return exit(0);
+    }
+    throw error;
+  }
+
+  const result = spawn(binaryPath, args, {
     stdio: "inherit",
   });
   if (result.error) {
-    // If binary fails and user asked for --version, show npm version instead
-    handleVersionFallback(binaryName);
+    if (versionFlag) {
+      printVersionFallback(binaryName);
+      return exit(0);
+    }
     throw result.error;
   }
-  process.exit(result.status ?? 1);
+  return exit(result.status ?? 1);
 }
 
 async function runCodeWhale() {
@@ -46,7 +58,7 @@ module.exports = {
   run,
   runCodeWhale,
   runCodeWhaleTui,
-  _internal: { isVersionFlag },
+  _internal: { isVersionFlag, printVersionFallback },
 };
 
 if (require.main === module) {

--- a/npm/codewhale/test/run.test.js
+++ b/npm/codewhale/test/run.test.js
@@ -1,11 +1,61 @@
 const assert = require("node:assert/strict");
 const test = require("node:test");
 
-const { _internal } = require("../scripts/run");
+const { run, _internal } = require("../scripts/run");
 
 test("version fallback handles only version flags", () => {
   assert.equal(_internal.isVersionFlag(["--version"]), true);
   assert.equal(_internal.isVersionFlag(["-V"]), true);
   assert.equal(_internal.isVersionFlag(["-v"]), false);
   assert.equal(_internal.isVersionFlag(["--verbose"]), false);
+});
+
+test("version flags prefer the installed binary over package metadata", async () => {
+  let spawned = false;
+  const exits = [];
+
+  await run("codewhale", {
+    args: ["--version"],
+    getBinaryPath: async () => "/tmp/codewhale-test-binary",
+    spawnSync: (binary, args, options) => {
+      spawned = true;
+      assert.equal(binary, "/tmp/codewhale-test-binary");
+      assert.deepEqual(args, ["--version"]);
+      assert.deepEqual(options, { stdio: "inherit" });
+      return { status: 0 };
+    },
+    exit: (status) => {
+      exits.push(status);
+    },
+  });
+
+  assert.equal(spawned, true);
+  assert.deepEqual(exits, [0]);
+});
+
+test("version flags fall back to package metadata when the binary is unavailable", async () => {
+  const originalLog = console.log;
+  const lines = [];
+  const exits = [];
+  console.log = (line) => lines.push(line);
+  try {
+    await run("codewhale", {
+      args: ["--version"],
+      getBinaryPath: async () => {
+        throw new Error("download unavailable");
+      },
+      spawnSync: () => {
+        throw new Error("spawn should not run without a binary");
+      },
+      exit: (status) => {
+        exits.push(status);
+      },
+    });
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.deepEqual(exits, [0]);
+  assert.match(lines.join("\n"), /codewhale \(npm wrapper\) v/);
+  assert.match(lines.join("\n"), /binary version: v/);
 });


### PR DESCRIPTION
Fixes #2561.

Problem:
- The npm wrapper handled `--version` / `-V` before launching the installed binary.
- If the wrapper package metadata lagged behind a locally updated binary, `codew -V` could report an older version while the TUI showed the newer binary version.

Change:
- Run the installed binary for version flags when it is available.
- Keep the existing package metadata fallback when the binary cannot be resolved or spawned.
- Add wrapper tests for both paths.

Verification:
- `node --test npm/codewhale/test/run.test.js`
- `node --test npm/codewhale/test/*.test.js`
- `node npm/codewhale/bin/codew.js --version`
- `scripts/release/check-versions.sh`
- `git diff --check`