### PR TITLE
feat(i18n): localize all queue command messages across 7 locales

### DIFF
--- a/crates/tui/src/commands/queue.rs
+++ b/crates/tui/src/commands/queue.rs
@@ -1,5 +1,6 @@
 //! Queue commands: queue list/edit/drop/clear
 
+use crate::localization::{Locale, MessageId, tr};
 use crate::tui::app::App;
 
 use super::CommandResult;
@@ -7,6 +8,7 @@ use super::CommandResult;
 const PREVIEW_LIMIT: usize = 120;
 
 pub fn queue(app: &mut App, args: Option<&str>) -> CommandResult {
+    let locale = app.ui_locale;
     let arg = args.unwrap_or("").trim();
     if arg.is_empty() || arg.eq_ignore_ascii_case("list") {
         return list_queue(app);
@@ -19,27 +21,28 @@ pub fn queue(app: &mut App, args: Option<&str>) -> CommandResult {
         "edit" => edit_queue(app, parts.next()),
         "drop" | "remove" | "rm" => drop_queue(app, parts.next()),
         "clear" => clear_queue(app),
-        _ => CommandResult::error("Usage: /queue [list|edit <n>|drop <n>|clear]"),
+        _ => CommandResult::error(tr(locale, MessageId::CmdQueueUsage)),
     }
 }
 
 fn list_queue(app: &mut App) -> CommandResult {
+    let locale = app.ui_locale;
     let mut lines = Vec::new();
     let queued = app.queued_message_count();
 
     if let Some(draft) = app.queued_draft.as_ref() {
-        lines.push("Editing queued message:".to_string());
-        lines.push(format!("- {}", truncate_preview(&draft.display)));
+        let header = tr(locale, MessageId::CmdQueueDraftHeader);
+        lines.push(format!("{} {}", header, truncate_preview(&draft.display)));
     }
 
     if queued == 0 {
         if lines.is_empty() {
-            return CommandResult::message("No queued messages");
+            return CommandResult::message(tr(locale, MessageId::CmdQueueNoMessages));
         }
         return CommandResult::message(lines.join("\n"));
     }
 
-    lines.push(format!("Queued messages ({queued}):"));
+    lines.push(tr(locale, MessageId::CmdQueueListHeader).replace("{count}", &queued.to_string()));
     for (idx, message) in app.queued_messages.iter().enumerate() {
         lines.push(format!(
             "{}. {}",
@@ -48,70 +51,74 @@ fn list_queue(app: &mut App) -> CommandResult {
         ));
     }
 
-    lines.push("Tip: /queue edit <n> to edit, /queue drop <n> to remove".to_string());
+    lines.push(tr(locale, MessageId::CmdQueueTip).to_string());
 
     CommandResult::message(lines.join("\n"))
 }
 
 fn edit_queue(app: &mut App, index: Option<&str>) -> CommandResult {
+    let locale = app.ui_locale;
     if app.queued_draft.is_some() {
-        return CommandResult::error(
-            "Already editing a queued message. Send it or /queue clear to discard.",
-        );
+        return CommandResult::error(tr(locale, MessageId::CmdQueueAlreadyEditing));
     }
-    let index = match parse_index(index) {
+    let index = match parse_index(index, locale) {
         Ok(index) => index,
         Err(err) => return CommandResult::error(err),
     };
 
     let Some(message) = app.remove_queued_message(index) else {
-        return CommandResult::error("Queued message not found");
+        return CommandResult::error(tr(locale, MessageId::CmdQueueNotFound));
     };
 
     app.input = message.display.clone();
     app.cursor_position = app.input.len();
     app.queued_draft = Some(message);
-    app.status_message = Some(format!("Editing queued message {}", index + 1));
+    let status =
+        tr(locale, MessageId::CmdQueueEditingStatus).replace("{index}", &(index + 1).to_string());
+    app.status_message = Some(status);
 
-    CommandResult::message(format!(
-        "Editing queued message {} (press Enter to re-queue/send)",
-        index + 1
-    ))
+    CommandResult::message(
+        tr(locale, MessageId::CmdQueueEditingMessage).replace("{index}", &(index + 1).to_string()),
+    )
 }
 
 fn drop_queue(app: &mut App, index: Option<&str>) -> CommandResult {
-    let index = match parse_index(index) {
+    let locale = app.ui_locale;
+    let index = match parse_index(index, locale) {
         Ok(index) => index,
         Err(err) => return CommandResult::error(err),
     };
 
     if app.remove_queued_message(index).is_none() {
-        return CommandResult::error("Queued message not found");
+        return CommandResult::error(tr(locale, MessageId::CmdQueueNotFound));
     }
 
-    CommandResult::message(format!("Dropped queued message {}", index + 1))
+    CommandResult::message(
+        tr(locale, MessageId::CmdQueueDropped).replace("{index}", &(index + 1).to_string()),
+    )
 }
 
 fn clear_queue(app: &mut App) -> CommandResult {
+    let locale = app.ui_locale;
     let queued = app.queued_message_count();
     let had_draft = app.queued_draft.take().is_some();
     app.queued_messages.clear();
     if queued == 0 && !had_draft {
-        return CommandResult::message("Queue already empty");
+        return CommandResult::message(tr(locale, MessageId::CmdQueueAlreadyEmpty));
     }
 
-    CommandResult::message("Queue cleared")
+    CommandResult::message(tr(locale, MessageId::CmdQueueCleared))
 }
 
-fn parse_index(input: Option<&str>) -> Result<usize, &'static str> {
+fn parse_index(input: Option<&str>, locale: Locale) -> Result<usize, String> {
     let Some(input) = input else {
-        return Err("Missing index. Usage: /queue edit <n> or /queue drop <n>");
+        return Err(tr(locale, MessageId::CmdQueueMissingIndex).to_string());
     };
     let raw = input
         .parse::<usize>()
-        .map_err(|_| "Index must be a positive number")?;
+        .map_err(|_| tr(locale, MessageId::CmdQueueIndexPositive).to_string())?;
     if raw == 0 {
-        return Err("Index must be >= 1");
+        return Err(tr(locale, MessageId::CmdQueueIndexMin).to_string());
     }
     Ok(raw - 1)
 }
@@ -164,16 +171,18 @@ mod tests {
     fn test_queue_list_empty() {
         let tmpdir = TempDir::new().unwrap();
         let mut app = create_test_app_with_tmpdir(&tmpdir);
+        app.ui_locale = Locale::En;
         let result = queue(&mut app, None);
         assert!(result.message.is_some());
         let msg = result.message.unwrap();
-        assert!(msg.contains("No queued messages"));
+        assert!(msg.contains(tr(app.ui_locale, MessageId::CmdQueueNoMessages)));
     }
 
     #[test]
     fn test_queue_list_with_messages() {
         let tmpdir = TempDir::new().unwrap();
         let mut app = create_test_app_with_tmpdir(&tmpdir);
+        app.ui_locale = Locale::En;
         app.queued_messages
             .push_back(QueuedMessage::new("First message".to_string(), None));
         app.queued_messages
@@ -181,7 +190,9 @@ mod tests {
         let result = queue(&mut app, Some("list"));
         assert!(result.message.is_some());
         let msg = result.message.unwrap();
-        assert!(msg.contains("Queued messages (2)"));
+        assert!(
+            msg.contains(&tr(app.ui_locale, MessageId::CmdQueueListHeader).replace("{count}", "2"))
+        );
         assert!(msg.contains("1. First message"));
         assert!(msg.contains("2. Second message"));
     }
@@ -190,24 +201,29 @@ mod tests {
     fn test_queue_edit_missing_index() {
         let tmpdir = TempDir::new().unwrap();
         let mut app = create_test_app_with_tmpdir(&tmpdir);
+        app.ui_locale = Locale::En;
         app.queued_messages
             .push_back(QueuedMessage::new("Test".to_string(), None));
         let result = queue(&mut app, Some("edit"));
         assert!(result.message.is_some());
-        assert!(result.message.unwrap().contains("Missing index"));
+        let msg = result.message.unwrap();
+        assert!(
+            msg.contains(tr(Locale::En, MessageId::CmdQueueMissingIndex)),
+            "msg={msg:?}"
+        );
     }
 
     #[test]
     fn test_queue_edit_invalid_index() {
         let tmpdir = TempDir::new().unwrap();
         let mut app = create_test_app_with_tmpdir(&tmpdir);
+        app.ui_locale = Locale::En;
         let result = queue(&mut app, Some("edit abc"));
         assert!(result.message.is_some());
+        let msg = result.message.unwrap();
         assert!(
-            result
-                .message
-                .unwrap()
-                .contains("must be a positive number")
+            msg.contains(tr(Locale::En, MessageId::CmdQueueIndexPositive)),
+            "msg={msg:?}"
         );
     }
 
@@ -215,15 +231,21 @@ mod tests {
     fn test_queue_edit_not_found() {
         let tmpdir = TempDir::new().unwrap();
         let mut app = create_test_app_with_tmpdir(&tmpdir);
+        app.ui_locale = Locale::En;
         let result = queue(&mut app, Some("edit 1"));
         assert!(result.message.is_some());
-        assert!(result.message.unwrap().contains("not found"));
+        let msg = result.message.unwrap();
+        assert!(
+            msg.contains(tr(Locale::En, MessageId::CmdQueueNotFound)),
+            "msg={msg:?}"
+        );
     }
 
     #[test]
     fn test_queue_edit_already_editing() {
         let tmpdir = TempDir::new().unwrap();
         let mut app = create_test_app_with_tmpdir(&tmpdir);
+        app.ui_locale = Locale::En;
         app.queued_messages
             .push_back(QueuedMessage::new("First".to_string(), None));
         app.queued_messages
@@ -233,13 +255,18 @@ mod tests {
         // Try to edit another
         let result = queue(&mut app, Some("edit 2"));
         assert!(result.message.is_some());
-        assert!(result.message.unwrap().contains("Already editing"));
+        let msg = result.message.unwrap();
+        assert!(
+            msg.contains(tr(Locale::En, MessageId::CmdQueueAlreadyEditing)),
+            "msg={msg:?}"
+        );
     }
 
     #[test]
     fn test_queue_edit_success() {
         let tmpdir = TempDir::new().unwrap();
         let mut app = create_test_app_with_tmpdir(&tmpdir);
+        app.ui_locale = Locale::En;
         app.queued_messages
             .push_back(QueuedMessage::new("Original message".to_string(), None));
         let result = queue(&mut app, Some("edit 1"));
@@ -253,12 +280,17 @@ mod tests {
     fn test_queue_drop_success() {
         let tmpdir = TempDir::new().unwrap();
         let mut app = create_test_app_with_tmpdir(&tmpdir);
+        app.ui_locale = Locale::En;
         app.queued_messages
             .push_back(QueuedMessage::new("To drop".to_string(), None));
         let initial_count = app.queued_messages.len();
         let result = queue(&mut app, Some("drop 1"));
         assert!(result.message.is_some());
-        assert!(result.message.unwrap().contains("Dropped queued message"));
+        let msg = result.message.unwrap();
+        assert!(
+            msg.contains(&tr(Locale::En, MessageId::CmdQueueDropped).replace("{index}", "1")),
+            "msg={msg:?}"
+        );
         assert_eq!(app.queued_messages.len(), initial_count - 1);
     }
 
@@ -266,13 +298,18 @@ mod tests {
     fn test_queue_clear() {
         let tmpdir = TempDir::new().unwrap();
         let mut app = create_test_app_with_tmpdir(&tmpdir);
+        app.ui_locale = Locale::En;
         app.queued_messages
             .push_back(QueuedMessage::new("Message 1".to_string(), None));
         app.queued_messages
             .push_back(QueuedMessage::new("Message 2".to_string(), None));
         let result = queue(&mut app, Some("clear"));
         assert!(result.message.is_some());
-        assert!(result.message.unwrap().contains("Queue cleared"));
+        let msg = result.message.unwrap();
+        assert!(
+            msg.contains(tr(Locale::En, MessageId::CmdQueueCleared)),
+            "msg={msg:?}"
+        );
         assert!(app.queued_messages.is_empty());
     }
 
@@ -280,9 +317,29 @@ mod tests {
     fn test_queue_clear_already_empty() {
         let tmpdir = TempDir::new().unwrap();
         let mut app = create_test_app_with_tmpdir(&tmpdir);
+        app.ui_locale = Locale::En;
         let result = queue(&mut app, Some("clear"));
         assert!(result.message.is_some());
-        assert!(result.message.unwrap().contains("Queue already empty"));
+        let msg = result.message.unwrap();
+        assert!(
+            msg.contains(tr(Locale::En, MessageId::CmdQueueAlreadyEmpty)),
+            "msg={msg:?}"
+        );
+    }
+
+    #[test]
+    fn queue_messages_are_localized() {
+        let tmpdir = TempDir::new().unwrap();
+        let mut app = create_test_app_with_tmpdir(&tmpdir);
+        app.ui_locale = Locale::ZhHans;
+        app.queued_messages
+            .push_back(QueuedMessage::new("M1".to_string(), None));
+        app.queued_messages
+            .push_back(QueuedMessage::new("M2".to_string(), None));
+        let result = queue(&mut app, Some("list"));
+        let msg = result.message.unwrap();
+        assert!(msg.contains("已排队的消息"), "zh list header: {msg}");
+        assert!(msg.contains("提示"), "zh tip: {msg}");
     }
 
     #[test]

--- a/crates/tui/src/commands/queue.rs
+++ b/crates/tui/src/commands/queue.rs
@@ -31,8 +31,8 @@ fn list_queue(app: &mut App) -> CommandResult {
     let queued = app.queued_message_count();
 
     if let Some(draft) = app.queued_draft.as_ref() {
-        let header = tr(locale, MessageId::CmdQueueDraftHeader);
-        lines.push(format!("{} {}", header, truncate_preview(&draft.display)));
+        lines.push(tr(locale, MessageId::CmdQueueDraftHeader).to_string());
+        lines.push(format!("- {}", truncate_preview(&draft.display)));
     }
 
     if queued == 0 {

--- a/crates/tui/src/localization.rs
+++ b/crates/tui/src/localization.rs
@@ -290,6 +290,21 @@ pub enum MessageId {
     CmdThemeDescription,
     CmdProviderDescription,
     CmdQueueDescription,
+    CmdQueueUsage,
+    CmdQueueDraftHeader,
+    CmdQueueNoMessages,
+    CmdQueueListHeader,
+    CmdQueueTip,
+    CmdQueueAlreadyEditing,
+    CmdQueueNotFound,
+    CmdQueueEditingStatus,
+    CmdQueueEditingMessage,
+    CmdQueueDropped,
+    CmdQueueAlreadyEmpty,
+    CmdQueueCleared,
+    CmdQueueMissingIndex,
+    CmdQueueIndexPositive,
+    CmdQueueIndexMin,
     CmdRecallDescription,
     CmdRelayDescription,
     CmdRenameDescription,
@@ -554,6 +569,21 @@ pub const ALL_MESSAGE_IDS: &[MessageId] = &[
     MessageId::CmdNoteDescription,
     MessageId::CmdProviderDescription,
     MessageId::CmdQueueDescription,
+    MessageId::CmdQueueUsage,
+    MessageId::CmdQueueDraftHeader,
+    MessageId::CmdQueueNoMessages,
+    MessageId::CmdQueueListHeader,
+    MessageId::CmdQueueTip,
+    MessageId::CmdQueueAlreadyEditing,
+    MessageId::CmdQueueNotFound,
+    MessageId::CmdQueueEditingStatus,
+    MessageId::CmdQueueEditingMessage,
+    MessageId::CmdQueueDropped,
+    MessageId::CmdQueueAlreadyEmpty,
+    MessageId::CmdQueueCleared,
+    MessageId::CmdQueueMissingIndex,
+    MessageId::CmdQueueIndexPositive,
+    MessageId::CmdQueueIndexMin,
     MessageId::CmdRecallDescription,
     MessageId::CmdRelayDescription,
     MessageId::CmdRenameDescription,
@@ -1035,6 +1065,27 @@ fn english(id: MessageId) -> &'static str {
             "Switch or view the active LLM backend (deepseek | nvidia-nim | ollama)"
         }
         MessageId::CmdQueueDescription => "View or edit queued messages",
+        MessageId::CmdQueueUsage => "Usage: /queue [list|edit <n>|drop <n>|clear]",
+        MessageId::CmdQueueDraftHeader => "Editing queued message:",
+        MessageId::CmdQueueNoMessages => "No queued messages",
+        MessageId::CmdQueueListHeader => "Queued messages ({count}):",
+        MessageId::CmdQueueTip => "Tip: /queue edit <n> to edit, /queue drop <n> to remove",
+        MessageId::CmdQueueAlreadyEditing => {
+            "Already editing a queued message. Send it or /queue clear to discard."
+        }
+        MessageId::CmdQueueNotFound => "Queued message not found",
+        MessageId::CmdQueueEditingStatus => "Editing queued message {index}",
+        MessageId::CmdQueueEditingMessage => {
+            "Editing queued message {index} (press Enter to re-queue/send)"
+        }
+        MessageId::CmdQueueDropped => "Dropped queued message {index}",
+        MessageId::CmdQueueAlreadyEmpty => "Queue already empty",
+        MessageId::CmdQueueCleared => "Queue cleared",
+        MessageId::CmdQueueMissingIndex => {
+            "Missing index. Usage: /queue edit <n> or /queue drop <n>"
+        }
+        MessageId::CmdQueueIndexPositive => "Index must be a positive number",
+        MessageId::CmdQueueIndexMin => "Index must be >= 1",
         MessageId::CmdRecallDescription => "Search prior cycle archives (BM25 over message text)",
         MessageId::CmdRelayDescription => "Create a session relay (接力) for a fresh thread",
         MessageId::CmdRenameDescription => "Rename the current session",
@@ -1443,6 +1494,27 @@ fn vietnamese(id: MessageId) -> Option<&'static str> {
             "Chuyển đổi hoặc xem backend LLM đang hoạt động (deepseek | nvidia-nim | ollama)"
         }
         MessageId::CmdQueueDescription => "Xem hoặc chỉnh sửa các tin nhắn đang chờ xử lý",
+        MessageId::CmdQueueUsage => "Cách dùng: /queue [list|edit <n>|drop <n>|clear]",
+        MessageId::CmdQueueDraftHeader => "Đang chỉnh sửa tin nhắn đang chờ:",
+        MessageId::CmdQueueNoMessages => "Không có tin nhắn đang chờ",
+        MessageId::CmdQueueListHeader => "Tin nhắn đang chờ ({count}):",
+        MessageId::CmdQueueTip => "Mẹo: /queue edit <n> để sửa, /queue drop <n> để xóa",
+        MessageId::CmdQueueAlreadyEditing => {
+            "Đã đang chỉnh sửa một tin nhắn đang chờ. Hãy gửi nó hoặc dùng /queue clear để hủy."
+        }
+        MessageId::CmdQueueNotFound => "Không tìm thấy tin nhắn đang chờ",
+        MessageId::CmdQueueEditingStatus => "Đang chỉnh sửa tin nhắn đang chờ {index}",
+        MessageId::CmdQueueEditingMessage => {
+            "Đang chỉnh sửa tin nhắn đang chờ {index} (nhấn Enter để xếp lại hàng/gửi)"
+        }
+        MessageId::CmdQueueDropped => "Đã xóa tin nhắn đang chờ {index}",
+        MessageId::CmdQueueAlreadyEmpty => "Hàng đợi đã trống",
+        MessageId::CmdQueueCleared => "Đã xóa hàng đợi",
+        MessageId::CmdQueueMissingIndex => {
+            "Thiếu chỉ mục. Cách dùng: /queue edit <n> hoặc /queue drop <n>"
+        }
+        MessageId::CmdQueueIndexPositive => "Chỉ mục phải là số dương",
+        MessageId::CmdQueueIndexMin => "Chỉ mục phải >= 1",
         MessageId::CmdRecallDescription => {
             "Tìm kiếm kho lưu trữ chu kỳ trước (BM25 trên văn bản tin nhắn)"
         }
@@ -1878,6 +1950,27 @@ fn japanese(id: MessageId) -> Option<&'static str> {
             "現在の LLM バックエンドを切り替え・確認（deepseek | nvidia-nim | ollama）"
         }
         MessageId::CmdQueueDescription => "キューされたメッセージを確認・編集",
+        MessageId::CmdQueueUsage => "使用方法: /queue [list|edit <n>|drop <n>|clear]",
+        MessageId::CmdQueueDraftHeader => "キューされたメッセージを編集中:",
+        MessageId::CmdQueueNoMessages => "キューされたメッセージはありません",
+        MessageId::CmdQueueListHeader => "キューされたメッセージ ({count}):",
+        MessageId::CmdQueueTip => "ヒント: /queue edit <n> で編集、/queue drop <n> で削除",
+        MessageId::CmdQueueAlreadyEditing => {
+            "すでにキューされたメッセージを編集中です。送信するか /queue clear で破棄してください。"
+        }
+        MessageId::CmdQueueNotFound => "キューされたメッセージが見つかりません",
+        MessageId::CmdQueueEditingStatus => "キューされたメッセージ {index} を編集中",
+        MessageId::CmdQueueEditingMessage => {
+            "キューされたメッセージ {index} を編集中（Enter で再キュー/送信）"
+        }
+        MessageId::CmdQueueDropped => "キューされたメッセージ {index} を削除しました",
+        MessageId::CmdQueueAlreadyEmpty => "キューはすでに空です",
+        MessageId::CmdQueueCleared => "キューをクリアしました",
+        MessageId::CmdQueueMissingIndex => {
+            "インデックスが指定されていません。使用方法: /queue edit <n> または /queue drop <n>"
+        }
+        MessageId::CmdQueueIndexPositive => "インデックスは正の数値である必要があります",
+        MessageId::CmdQueueIndexMin => "インデックスは 1 以上である必要があります",
         MessageId::CmdRecallDescription => {
             "過去のサイクルアーカイブを検索（メッセージ本文への BM25 検索）"
         }
@@ -2253,6 +2346,25 @@ fn chinese_simplified(id: MessageId) -> Option<&'static str> {
             "切换或查看当前 LLM 后端（deepseek | nvidia-nim | ollama）"
         }
         MessageId::CmdQueueDescription => "查看或编辑已排队的消息",
+        MessageId::CmdQueueUsage => "用法: /queue [list|edit <n>|drop <n>|clear]",
+        MessageId::CmdQueueDraftHeader => "正在编辑已排队的消息:",
+        MessageId::CmdQueueNoMessages => "没有已排队的消息",
+        MessageId::CmdQueueListHeader => "已排队的消息 ({count}):",
+        MessageId::CmdQueueTip => "提示: /queue edit <n> 编辑, /queue drop <n> 删除",
+        MessageId::CmdQueueAlreadyEditing => {
+            "已在编辑一条已排队的消息。请先发送或使用 /queue clear 放弃。"
+        }
+        MessageId::CmdQueueNotFound => "未找到已排队的消息",
+        MessageId::CmdQueueEditingStatus => "正在编辑已排队的消息 {index}",
+        MessageId::CmdQueueEditingMessage => {
+            "正在编辑已排队的消息 {index}（按 Enter 重新排队/发送）"
+        }
+        MessageId::CmdQueueDropped => "已删除已排队的消息 {index}",
+        MessageId::CmdQueueAlreadyEmpty => "队列已空",
+        MessageId::CmdQueueCleared => "队列已清空",
+        MessageId::CmdQueueMissingIndex => "缺少索引。用法: /queue edit <n> 或 /queue drop <n>",
+        MessageId::CmdQueueIndexPositive => "索引必须为正数",
+        MessageId::CmdQueueIndexMin => "索引必须 >= 1",
         MessageId::CmdRecallDescription => "搜索此前的循环归档（基于消息文本的 BM25 检索）",
         MessageId::CmdRelayDescription => "为新线程创建会话接力摘要",
         MessageId::CmdRenameDescription => "重命名当前会话",
@@ -2614,6 +2726,27 @@ fn portuguese_brazil(id: MessageId) -> Option<&'static str> {
             "Trocar ou exibir o backend LLM ativo (deepseek | nvidia-nim | ollama)"
         }
         MessageId::CmdQueueDescription => "Ver ou editar mensagens enfileiradas",
+        MessageId::CmdQueueUsage => "Uso: /queue [list|edit <n>|drop <n>|clear]",
+        MessageId::CmdQueueDraftHeader => "Editando mensagem enfileirada:",
+        MessageId::CmdQueueNoMessages => "Nenhuma mensagem enfileirada",
+        MessageId::CmdQueueListHeader => "Mensagens enfileiradas ({count}):",
+        MessageId::CmdQueueTip => "Dica: /queue edit <n> para editar, /queue drop <n> para remover",
+        MessageId::CmdQueueAlreadyEditing => {
+            "Já está editando uma mensagem enfileirada. Envie-a ou use /queue clear para descartar."
+        }
+        MessageId::CmdQueueNotFound => "Mensagem enfileirada não encontrada",
+        MessageId::CmdQueueEditingStatus => "Editando mensagem enfileirada {index}",
+        MessageId::CmdQueueEditingMessage => {
+            "Editando mensagem enfileirada {index} (pressione Enter para re-enfileirar/enviar)"
+        }
+        MessageId::CmdQueueDropped => "Mensagem enfileirada {index} removida",
+        MessageId::CmdQueueAlreadyEmpty => "Fila já está vazia",
+        MessageId::CmdQueueCleared => "Fila limpa",
+        MessageId::CmdQueueMissingIndex => {
+            "Índice ausente. Uso: /queue edit <n> ou /queue drop <n>"
+        }
+        MessageId::CmdQueueIndexPositive => "O índice deve ser um número positivo",
+        MessageId::CmdQueueIndexMin => "O índice deve ser >= 1",
         MessageId::CmdRecallDescription => {
             "Buscar arquivos de ciclos anteriores (BM25 sobre o texto das mensagens)"
         }
@@ -3039,6 +3172,29 @@ fn spanish_latin_america(id: MessageId) -> Option<&'static str> {
             "Cambiar o mostrar el backend LLM activo (deepseek | nvidia-nim | ollama)"
         }
         MessageId::CmdQueueDescription => "Ver o editar mensajes en cola",
+        MessageId::CmdQueueUsage => "Uso: /queue [list|edit <n>|drop <n>|clear]",
+        MessageId::CmdQueueDraftHeader => "Editando mensaje en cola:",
+        MessageId::CmdQueueNoMessages => "No hay mensajes en cola",
+        MessageId::CmdQueueListHeader => "Mensajes en cola ({count}):",
+        MessageId::CmdQueueTip => {
+            "Consejo: /queue edit <n> para editar, /queue drop <n> para eliminar"
+        }
+        MessageId::CmdQueueAlreadyEditing => {
+            "Ya estás editando un mensaje en cola. Envíalo o usa /queue clear para descartarlo."
+        }
+        MessageId::CmdQueueNotFound => "Mensaje en cola no encontrado",
+        MessageId::CmdQueueEditingStatus => "Editando mensaje en cola {index}",
+        MessageId::CmdQueueEditingMessage => {
+            "Editando mensaje en cola {index} (presiona Enter para re-encolar/enviar)"
+        }
+        MessageId::CmdQueueDropped => "Mensaje en cola {index} eliminado",
+        MessageId::CmdQueueAlreadyEmpty => "La cola ya está vacía",
+        MessageId::CmdQueueCleared => "Cola limpiada",
+        MessageId::CmdQueueMissingIndex => {
+            "Índice faltante. Uso: /queue edit <n> o /queue drop <n>"
+        }
+        MessageId::CmdQueueIndexPositive => "El índice debe ser un número positivo",
+        MessageId::CmdQueueIndexMin => "El índice debe ser >= 1",
         MessageId::CmdRecallDescription => {
             "Buscar archivos de ciclos anteriores (BM25 sobre el texto de los mensajes)"
         }

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -2512,11 +2512,15 @@ fn turn_liveness_leaves_active_turn_running() {
 #[test]
 fn turn_liveness_uses_recent_turn_activity_not_turn_start() {
     let mut app = create_test_app();
-    let now = Instant::now();
     app.is_loading = true;
     app.runtime_turn_status = Some("in_progress".to_string());
-    app.turn_started_at = Some(now - TURN_STALL_WATCHDOG_TIMEOUT - Duration::from_secs(30));
-    app.turn_last_activity_at = Some(now - Duration::from_secs(1));
+    app.turn_started_at = Some(Instant::now());
+    app.turn_last_activity_at = Some(
+        app.turn_started_at.unwrap()
+            + TURN_STALL_WATCHDOG_TIMEOUT
+            + Duration::from_secs(29),
+    );
+    let now = app.turn_last_activity_at.unwrap() + Duration::from_secs(1);
 
     let recovered = reconcile_turn_liveness(&mut app, now, false);
 
@@ -2529,11 +2533,14 @@ fn turn_liveness_uses_recent_turn_activity_not_turn_start() {
 #[test]
 fn turn_liveness_does_not_abort_running_tool() {
     let mut app = create_test_app();
-    let now = Instant::now();
     app.is_loading = true;
     app.runtime_turn_status = Some("in_progress".to_string());
-    app.turn_started_at = Some(now - TURN_STALL_WATCHDOG_TIMEOUT - Duration::from_secs(30));
+    app.turn_started_at = Some(Instant::now());
     app.turn_last_activity_at = app.turn_started_at;
+    let now = app.turn_started_at.unwrap()
+        + TURN_STALL_WATCHDOG_TIMEOUT
+        + Duration::from_secs(30)
+        + Duration::from_secs(1);
     let mut active = ActiveCell::new();
     active.push_tool(
         "tool-1",

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -2515,11 +2515,8 @@ fn turn_liveness_uses_recent_turn_activity_not_turn_start() {
     app.is_loading = true;
     app.runtime_turn_status = Some("in_progress".to_string());
     app.turn_started_at = Some(Instant::now());
-    app.turn_last_activity_at = Some(
-        app.turn_started_at.unwrap()
-            + TURN_STALL_WATCHDOG_TIMEOUT
-            + Duration::from_secs(29),
-    );
+    app.turn_last_activity_at =
+        Some(app.turn_started_at.unwrap() + TURN_STALL_WATCHDOG_TIMEOUT + Duration::from_secs(29));
     let now = app.turn_last_activity_at.unwrap() + Duration::from_secs(1);
 
     let recovered = reconcile_turn_liveness(&mut app, now, false);


### PR DESCRIPTION
## Summary

Localize all 15 user-facing strings in the `/queue` command (list/edit/drop/clear) across all 7 shipped locales.

## Changes

- **`localization.rs`** — 15 new `CmdQueue*` MessageId variants with translations in En, Ja, ZhHans, Vi, PtBr, Es419 (ZhHant falls through to ZhHans)
- **`queue.rs`** — wire `queue()` / `list_queue()` / `edit_queue()` / `drop_queue()` / `clear_queue()` / `parse_index()` through `tr(locale, MessageId)` with named placeholders (`{count}`, `{index}`)

## Testing

- All 14 existing queue tests pass (set `app.ui_locale = Locale::En` for deterministic assertions)
- New `queue_messages_are_localized` smokes ZhHans output for `已排队的消息` / `提示`
- fmt + clippy clean

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR localizes all 15 user-facing strings in the `/queue` command family across 7 shipped locales by adding `CmdQueue*` MessageId variants to `localization.rs` and threading `tr(locale, …)` calls through `queue.rs`. Existing tests are updated to pin `Locale::En` for deterministic assertions and one ZhHans smoke test is added; two unrelated stall-watchdog timing tests in `tests.rs` are also refactored to avoid potentially panicking `Instant` subtraction, but these changes are bundled into the i18n PR.

- **`localization.rs`**: 15 new enum variants added to both `MessageId` and `ALL_MESSAGE_IDS`; translations provided for En, Ja, ZhHans, Vi, PtBr, Es419 with ZhHant delegating to Simplified Chinese via the existing `other => chinese_simplified(other)?` catch-all in `traditional_chinese()`.
- **`queue.rs`**: Each sub-function now reads `app.ui_locale` and substitutes named placeholders (`{count}`, `{index}`) via `.replace()`; `parse_index` return type widened from `Result<usize, &'static str>` to `Result<usize, String>` to accommodate owned translated error strings.
- **`tests.rs`**: Timing tests for `reconcile_turn_liveness` rewritten to compute all `Instant` values as forward offsets from `Instant::now()` rather than subtracting large durations, which is the correct approach for cross-platform stability.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The queue command localization is mechanical and complete — all 15 strings are covered in every translation function, placeholder substitution is straightforward `.replace()` calls on static strings, and the fallback chain to English is preserved. No behavioural changes to queue logic.

The change is purely additive: new enum variants, new match arms in translation functions, and call-site wiring. The queue logic itself is unchanged; the only risk surface is a missing or mismatched placeholder (`{count}`, `{index}`), and a quick check shows every locale's strings contain the expected placeholder tokens. ZhHant intentionally delegates to Simplified Chinese via the existing catch-all. The two timing test rewrites are correct and logically equivalent to what they replace.

No files require special attention. The `tests.rs` timing changes are unrelated but harmless.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/commands/queue.rs | All queue subcommands (list/edit/drop/clear) wired through `tr(locale, MessageId::*)`, `parse_index` return type updated to `Result<usize, String>`, existing tests updated to fix locale and assert against translated strings, and a new ZhHans smoke test added. |
| crates/tui/src/localization.rs | 15 new `CmdQueue*` MessageId variants added to the enum and `ALL_MESSAGE_IDS` slice; English strings defined in `english()` and all 6 non-English translation functions updated; ZhHant falls through to `chinese_simplified` via the existing catch-all. |
| crates/tui/src/tui/ui/tests.rs | Two unrelated stall-watchdog timing tests refactored to avoid subtracting a large Duration from `Instant::now()` (which can panic on Windows near boot); the arithmetic is logically equivalent but bundled into this i18n PR. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["queue(app, args)"] --> B{arg}
    B -->|empty / list| C["list_queue(app)"]
    B -->|edit| D["edit_queue(app, index)"]
    B -->|drop/remove/rm| E["drop_queue(app, index)"]
    B -->|clear| F["clear_queue(app)"]
    B -->|other| G["tr(locale, CmdQueueUsage)\nCommandResult::error"]

    C --> C1["tr(locale, CmdQueueDraftHeader)"]
    C --> C2["tr(locale, CmdQueueNoMessages)"]
    C --> C3["tr(locale, CmdQueueListHeader)\n.replace('{count}', n)"]
    C --> C4["tr(locale, CmdQueueTip)"]

    D --> P["parse_index(index, locale)"]
    E --> P
    P -->|Err| PE["tr(locale, CmdQueueMissingIndex\n/ CmdQueueIndexPositive\n/ CmdQueueIndexMin)"]
    P -->|Ok| D2["tr(locale, CmdQueueEditingMessage)\n.replace('{index}', n)"]
    P -->|Ok| E2["tr(locale, CmdQueueDropped)\n.replace('{index}', n)"]

    F --> F1["tr(locale, CmdQueueAlreadyEmpty\n/ CmdQueueCleared)"]

    subgraph Localization
        TR["tr(locale, id)\n→ translation(locale,id)\n  or english(id)"]
        En["english()"]
        Ja["japanese()"]
        ZhHans["chinese_simplified()"]
        ZhHant["traditional_chinese()\n→ falls through to ZhHans"]
        PtBr["portuguese_brazil()"]
        Es419["spanish_latin_america()"]
        Vi["vietnamese()"]
        TR --> En & Ja & ZhHans & ZhHant & PtBr & Es419 & Vi
    end
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fi18n-queue-surface%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fi18n-queue-surface%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui%2Ftests.rs%3A2512-2563%0A**Unrelated%20test%20refactor%20bundled%20into%20i18n%20PR**%0A%0AThe%20two%20%60turn_liveness_*%60%20test%20rewrites%20%E2%80%94%20moving%20from%20%60Instant%3A%3Anow%28%29%20-%20large_duration%60%20to%20forward-offset%20arithmetic%20%E2%80%94%20are%20not%20related%20to%20queue%20command%20localization.%20The%20change%20is%20itself%20reasonable%20%28avoids%20a%20potential%20panic%20on%20platforms%20where%20%60Instant%60%20doesn't%20support%20subtraction%20that%20would%20underflow%20near%20boot%29%2C%20but%20it%20makes%20the%20commit%20history%20harder%20to%20bisect%20if%20either%20set%20of%20changes%20needs%20to%20be%20reverted.%20Consider%20splitting%20this%20into%20a%20separate%20commit%20or%20PR.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui%2Ftests.rs%3A2512-2563%0A**Unrelated%20test%20refactor%20bundled%20into%20i18n%20PR**%0A%0AThe%20two%20%60turn_liveness_*%60%20test%20rewrites%20%E2%80%94%20moving%20from%20%60Instant%3A%3Anow%28%29%20-%20large_duration%60%20to%20forward-offset%20arithmetic%20%E2%80%94%20are%20not%20related%20to%20queue%20command%20localization.%20The%20change%20is%20itself%20reasonable%20%28avoids%20a%20potential%20panic%20on%20platforms%20where%20%60Instant%60%20doesn't%20support%20subtraction%20that%20would%20underflow%20near%20boot%29%2C%20but%20it%20makes%20the%20commit%20history%20harder%20to%20bisect%20if%20either%20set%20of%20changes%20needs%20to%20be%20reverted.%20Consider%20splitting%20this%20into%20a%20separate%20commit%20or%20PR.%0A%0A&repo=hmbown%2Fcodewhale&pr=2568&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui%2Ftests.rs%3A2512-2563%0A**Unrelated%20test%20refactor%20bundled%20into%20i18n%20PR**%0A%0AThe%20two%20%60turn_liveness_*%60%20test%20rewrites%20%E2%80%94%20moving%20from%20%60Instant%3A%3Anow%28%29%20-%20large_duration%60%20to%20forward-offset%20arithmetic%20%E2%80%94%20are%20not%20related%20to%20queue%20command%20localization.%20The%20change%20is%20itself%20reasonable%20%28avoids%20a%20potential%20panic%20on%20platforms%20where%20%60Instant%60%20doesn't%20support%20subtraction%20that%20would%20underflow%20near%20boot%29%2C%20but%20it%20makes%20the%20commit%20history%20harder%20to%20bisect%20if%20either%20set%20of%20changes%20needs%20to%20be%20reverted.%20Consider%20splitting%20this%20into%20a%20separate%20commit%20or%20PR.%0A%0A&pr=2568&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix: restore two-line draft header layou..."](https://github.com/hmbown/codewhale/commit/f462524ff43f9a8fd6a672547ea596b58abec65f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35054804)</sub>

<!-- /greptile_comment -->