### PR TITLE
fix: Prevent exec_shell timeout deadlock on Windows

### DIFF
--- a/crates/tui/src/tools/shell.rs
+++ b/crates/tui/src/tools/shell.rs
@@ -900,15 +900,22 @@ impl ShellManager {
             stderr_tx.send(buf).ok();
         });
 
-        /// Upper bound on how long we wait for reader threads after the
-        /// process has been killed. Prevents a hung read_to_end from
-        /// deadlocking the global tool_exec_lock.
+        // Upper bound on how long we wait for reader threads after the
+        // process has been killed (or after the process exited but a
+        // grandchild still holds a pipe handle). Prevents a hung
+        // read_to_end from deadlocking the global tool_exec_lock.
+        // Two sequential recv_timeout calls cap worst-case extra latency
+        // at 2 × READER_JOIN_TIMEOUT (10 s).
         const READER_JOIN_TIMEOUT: Duration = Duration::from_secs(5);
 
         // Wait with timeout
         if let Some(status) = child.wait_timeout(timeout)? {
-            let stdout = stdout_rx.recv().unwrap_or_default();
-            let stderr = stderr_rx.recv().unwrap_or_default();
+            let stdout = stdout_rx
+                .recv_timeout(READER_JOIN_TIMEOUT)
+                .unwrap_or_default();
+            let stderr = stderr_rx
+                .recv_timeout(READER_JOIN_TIMEOUT)
+                .unwrap_or_default();
             let stdout_str = String::from_utf8_lossy(&stdout).to_string();
             let stderr_str = String::from_utf8_lossy(&stderr).to_string();
             let exit_code = status.code().unwrap_or(-1);

--- a/crates/tui/src/tools/shell.rs
+++ b/crates/tui/src/tools/shell.rs
@@ -882,25 +882,33 @@ impl ShellManager {
         let stdout_handle = child.stdout.take().context("Failed to capture stdout")?;
         let stderr_handle = child.stderr.take().context("Failed to capture stderr")?;
 
-        // Spawn threads to read output
-        let stdout_thread = std::thread::spawn(move || {
+        // Spawn threads to read output, using channels so the main thread
+        // can apply a bounded join timeout on Windows where killed-process
+        // pipes may not close promptly (#2571).
+        let (stdout_tx, stdout_rx) = std::sync::mpsc::channel();
+        let (stderr_tx, stderr_rx) = std::sync::mpsc::channel();
+        let _stdout_thread = std::thread::spawn(move || {
             let mut reader = stdout_handle;
             let mut buf = Vec::new();
             let _ = reader.read_to_end(&mut buf);
-            buf
+            stdout_tx.send(buf).ok();
         });
-
-        let stderr_thread = std::thread::spawn(move || {
+        let _stderr_thread = std::thread::spawn(move || {
             let mut reader = stderr_handle;
             let mut buf = Vec::new();
             let _ = reader.read_to_end(&mut buf);
-            buf
+            stderr_tx.send(buf).ok();
         });
+
+        /// Upper bound on how long we wait for reader threads after the
+        /// process has been killed. Prevents a hung read_to_end from
+        /// deadlocking the global tool_exec_lock.
+        const READER_JOIN_TIMEOUT: Duration = Duration::from_secs(5);
 
         // Wait with timeout
         if let Some(status) = child.wait_timeout(timeout)? {
-            let stdout = stdout_thread.join().unwrap_or_default();
-            let stderr = stderr_thread.join().unwrap_or_default();
+            let stdout = stdout_rx.recv().unwrap_or_default();
+            let stderr = stderr_rx.recv().unwrap_or_default();
             let stdout_str = String::from_utf8_lossy(&stdout).to_string();
             let stderr_str = String::from_utf8_lossy(&stderr).to_string();
             let exit_code = status.code().unwrap_or(-1);
@@ -942,8 +950,12 @@ impl ShellManager {
             #[cfg(not(unix))]
             let _ = child.kill();
             let status = child.wait().ok();
-            let stdout = stdout_thread.join().unwrap_or_default();
-            let stderr = stderr_thread.join().unwrap_or_default();
+            let stdout = stdout_rx
+                .recv_timeout(READER_JOIN_TIMEOUT)
+                .unwrap_or_default();
+            let stderr = stderr_rx
+                .recv_timeout(READER_JOIN_TIMEOUT)
+                .unwrap_or_default();
             let stdout_str = String::from_utf8_lossy(&stdout).to_string();
             let stderr_str = String::from_utf8_lossy(&stderr).to_string();
             let (stdout, stdout_meta) = truncate_with_meta(&stdout_str);


### PR DESCRIPTION
## Summary

Replace `thread.join()` with bounded channel receive in the shell
timeout path so a hung `read_to_end` on a killed-process pipe does
not deadlock the global `tool_exec_lock`.

Closes: https://github.com/Hmbown/CodeWhale/issues/2571

## Problem

`execute_sync_sandboxed` spawned reader threads that called
`read_to_end` on stdout/stderr pipes. When the child process timed
out and was killed on Windows, the pipe handles were not always
closed promptly, causing `read_to_end` to hang indefinitely.
`thread.join()` waited forever, the function never returned, and
the `tool_exec_lock` write-guard was never dropped — deadlocking
all subsequent tool calls across the entire session.

## Fix

Reader threads now send results through `std::sync::mpsc::channel`
instead of returning from `thread::spawn`. In the normal path we
use `recv()` (equivalent to the old `join()`). In the timeout path
we use `recv_timeout(READER_JOIN_TIMEOUT)` (5 seconds) — if the
reader doesn't finish within 5s after the child is killed, we
proceed with empty output and the orphaned thread eventually
completes on its own.

## Files Changed

| File | Change |
|---|---|
| `crates/tui/src/tools/shell.rs` | +22/-10 |

## Tests

Full suite: 3815 passed, 5 pre-existing failures

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces `thread.join()` with `mpsc::channel` + `recv_timeout` in `execute_sync_sandboxed` to prevent a Windows deadlock where a killed process's pipe handles weren't closed promptly, leaving `read_to_end` — and therefore the `tool_exec_lock` — hung indefinitely.

- Both the **timeout branch** and the **success branch** now use `recv_timeout(5 s)` for each reader thread, with `unwrap_or_default()` returning empty output if the timeout is hit; detached threads continue in the background.
- In the **success branch**, if `recv_timeout` expires (e.g. a grandchild process still holds the pipe), the caller receives `ShellStatus::Completed` with empty `stdout`/`stderr` and no indicator in `ShellResult` that the output was silently discarded — distinguishable from a command that genuinely produced no output only by adding an explicit flag or log.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The deadlock fix is correct and meaningfully improves Windows reliability, but the success path silently discards stdout/stderr when recv_timeout expires, which could confuse callers that trust a Completed status to mean they have full output.

The core deadlock fix works as described. The remaining concern is in the normal (non-timeout) branch: if recv_timeout fires there, the function returns Completed with empty output and no way for callers to detect the data was dropped. This is a real data-loss scenario for users running commands that spawn background children holding the pipe open.

crates/tui/src/tools/shell.rs — specifically the success-exit branch where recv_timeout can silently drop output without setting any flag in ShellResult.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tools/shell.rs | Replaces thread join with mpsc channels and recv_timeout in both the success and timeout branches; fixes the Windows pipe-hang deadlock but introduces silent output loss when recv_timeout expires in the success-exit path. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Main as Main Thread
    participant Child as Child Process
    participant SOut as stdout_thread
    participant SErr as stderr_thread

    Main->>Child: spawn()
    Main->>SOut: thread::spawn (read_to_end → stdout_tx)
    Main->>SErr: thread::spawn (read_to_end → stderr_tx)
    Main->>Child: wait_timeout(timeout)

    alt Process exits in time
        Child-->>Main: Some(status)
        Main->>Main: recv_timeout(5s) on stdout_rx
        Main->>Main: recv_timeout(5s) on stderr_rx
        Note over Main: unwrap_or_default() on timeout<br/>silent empty output if pipe hangs
        Main-->>Main: return ShellStatus::Completed
    else Timeout
        Child-->>Main: None
        Main->>Child: kill()
        Child-->>Main: wait()
        Main->>Main: recv_timeout(5s) on stdout_rx
        Main->>Main: recv_timeout(5s) on stderr_rx
        Note over Main: unwrap_or_default() on timeout<br/>orphan threads continue in background
        Main-->>Main: return ShellStatus::TimedOut
    end
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fexec-shell-timeout-deadlock%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fexec-shell-timeout-deadlock%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftools%2Fshell.rs%3A912-918%0A**Silent%20output%20loss%20on%20the%20success%20path**%0A%0AWhen%20a%20process%20exits%20cleanly%20but%20a%20grandchild%20holds%20onto%20the%20pipe%20write-handle%20%28common%20in%20shell%20scripts%20that%20launch%20background%20jobs%29%2C%20%60read_to_end%60%20in%20the%20reader%20thread%20never%20returns%2C%20%60recv_timeout%60%20expires%20after%205%20s%2C%20and%20%60unwrap_or_default%28%29%60%20silently%20substitutes%20an%20empty%20%60Vec%3Cu8%3E%60.%20The%20caller%20receives%20%60ShellStatus%3A%3ACompleted%60%20with%20empty%20%60stdout%60%2F%60stderr%60%20%E2%80%94%20indistinguishable%20from%20a%20command%20that%20genuinely%20produced%20no%20output.%20Unlike%20the%20timeout%20branch%20%28which%20sets%20%60ShellStatus%3A%3ATimedOut%60%29%2C%20there%20is%20no%20field%20in%20%60ShellResult%60%20to%20signal%20that%20output%20was%20discarded%2C%20so%20the%20data%20loss%20is%20invisible%20to%20both%20the%20tool%20layer%20and%20the%20end%20user.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftools%2Fshell.rs%3A912-918%0A**Silent%20output%20loss%20on%20the%20success%20path**%0A%0AWhen%20a%20process%20exits%20cleanly%20but%20a%20grandchild%20holds%20onto%20the%20pipe%20write-handle%20%28common%20in%20shell%20scripts%20that%20launch%20background%20jobs%29%2C%20%60read_to_end%60%20in%20the%20reader%20thread%20never%20returns%2C%20%60recv_timeout%60%20expires%20after%205%20s%2C%20and%20%60unwrap_or_default%28%29%60%20silently%20substitutes%20an%20empty%20%60Vec%3Cu8%3E%60.%20The%20caller%20receives%20%60ShellStatus%3A%3ACompleted%60%20with%20empty%20%60stdout%60%2F%60stderr%60%20%E2%80%94%20indistinguishable%20from%20a%20command%20that%20genuinely%20produced%20no%20output.%20Unlike%20the%20timeout%20branch%20%28which%20sets%20%60ShellStatus%3A%3ATimedOut%60%29%2C%20there%20is%20no%20field%20in%20%60ShellResult%60%20to%20signal%20that%20output%20was%20discarded%2C%20so%20the%20data%20loss%20is%20invisible%20to%20both%20the%20tool%20layer%20and%20the%20end%20user.%0A%0A&repo=hmbown%2Fcodewhale&pr=2573&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftools%2Fshell.rs%3A912-918%0A**Silent%20output%20loss%20on%20the%20success%20path**%0A%0AWhen%20a%20process%20exits%20cleanly%20but%20a%20grandchild%20holds%20onto%20the%20pipe%20write-handle%20%28common%20in%20shell%20scripts%20that%20launch%20background%20jobs%29%2C%20%60read_to_end%60%20in%20the%20reader%20thread%20never%20returns%2C%20%60recv_timeout%60%20expires%20after%205%20s%2C%20and%20%60unwrap_or_default%28%29%60%20silently%20substitutes%20an%20empty%20%60Vec%3Cu8%3E%60.%20The%20caller%20receives%20%60ShellStatus%3A%3ACompleted%60%20with%20empty%20%60stdout%60%2F%60stderr%60%20%E2%80%94%20indistinguishable%20from%20a%20command%20that%20genuinely%20produced%20no%20output.%20Unlike%20the%20timeout%20branch%20%28which%20sets%20%60ShellStatus%3A%3ATimedOut%60%29%2C%20there%20is%20no%20field%20in%20%60ShellResult%60%20to%20signal%20that%20output%20was%20discarded%2C%20so%20the%20data%20loss%20is%20invisible%20to%20both%20the%20tool%20layer%20and%20the%20end%20user.%0A%0A&pr=2573&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix: apply recv\_timeout to success path ..."](https://github.com/hmbown/codewhale/commit/73bc393aff96d30a994c56adab2a544bfd9b5b9b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35060073)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->