### PR TITLE
refs(#2264): Phase 3 — emit PrefixCacheChange events from FrozenPrefix layer

### DIFF
--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -314,7 +314,7 @@ impl Engine {
             // Three-zone prefix contract (#2264): freeze baseline on first
             // turn, verify against it on subsequent turns. Operates alongside
             // PrefixStabilityManager as an independent diagnostic layer.
-            // Phase 2: warn-only, auto-re-freeze on drift.
+            // Phase 3: emit PrefixCacheChange events for user visibility.
             let system_text =
                 crate::prefix_cache::system_prompt_text(self.session.system_prompt.as_ref());
             let current_tools: &[crate::models::Tool] = active_tools.as_deref().unwrap_or_default();
@@ -326,6 +326,17 @@ impl Engine {
                             target: "prefix_cache",
                             "three-zone drift: {drift}"
                         );
+                        let _ = self
+                            .tx_event
+                            .send(Event::PrefixCacheChange {
+                                description: drift.to_string(),
+                                system_prompt_changed: drift.system_changed,
+                                tools_changed: drift.tools_changed,
+                                stability_pct: 0,
+                                changed: true,
+                                pinned_combined_hash: frozen.hash().to_string(),
+                            })
+                            .await;
                         let pinned = PinnedPrefix::new(
                             self.session.system_prompt.as_ref(),
                             current_tools.to_vec(),
@@ -338,7 +349,19 @@ impl Engine {
                         self.session.system_prompt.as_ref(),
                         current_tools.to_vec(),
                     );
-                    self.session.frozen_prefix = Some(pinned.freeze());
+                    let frozen = pinned.freeze();
+                    let _ = self
+                        .tx_event
+                        .send(Event::PrefixCacheChange {
+                            description: format!("frozen: {}", frozen.short_id()),
+                            system_prompt_changed: false,
+                            tools_changed: false,
+                            stability_pct: 100,
+                            changed: false,
+                            pinned_combined_hash: frozen.hash().to_string(),
+                        })
+                        .await;
+                    self.session.frozen_prefix = Some(frozen);
                 }
             }
 

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -314,7 +314,9 @@ impl Engine {
             // Three-zone prefix contract (#2264): freeze baseline on first
             // turn, verify against it on subsequent turns. Operates alongside
             // PrefixStabilityManager as an independent diagnostic layer.
-            // Phase 3: emit PrefixCacheChange events for user visibility.
+            // Phase 3: emit a one-shot 'frozen' event on first turn.
+            // Drift is logged (tracing::debug!) but not re-emitted —
+            // PrefixStabilityManager already reports the change above.
             let system_text =
                 crate::prefix_cache::system_prompt_text(self.session.system_prompt.as_ref());
             let current_tools: &[crate::models::Tool] = active_tools.as_deref().unwrap_or_default();
@@ -326,17 +328,6 @@ impl Engine {
                             target: "prefix_cache",
                             "three-zone drift: {drift}"
                         );
-                        let _ = self
-                            .tx_event
-                            .send(Event::PrefixCacheChange {
-                                description: drift.to_string(),
-                                system_prompt_changed: drift.system_changed,
-                                tools_changed: drift.tools_changed,
-                                stability_pct: 0,
-                                changed: true,
-                                pinned_combined_hash: frozen.hash().to_string(),
-                            })
-                            .await;
                         let pinned = PinnedPrefix::new(
                             self.session.system_prompt.as_ref(),
                             current_tools.to_vec(),


### PR DESCRIPTION
Refs #2264 (Phase 3 — user-visible events).

## Summary

Upgrades the three-zone diagnostic layer from silent `tracing::debug!`
to user-visible `Event::PrefixCacheChange` events. The TUI footer now
shows three-zone prefix status alongside the existing PrefixStabilityManager
data.

| Turn | Event |
|---|---|
| First | `"frozen: a1b2c3d4e5f6"` (stability 100%, not a change) |
| Drift | `"prefix drift: system prompt changed (frozen=..., current=...)"` |
| Stable | no event (existing PrefixStabilityManager handles this) |

## Files

| File | Change |
|---|---|
| `crates/tui/src/core/engine/turn_loop.rs` | +25 / −2 |

## Testing
- cargo check: clean
- 37 prompt_zones + prefix_cache tests pass

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Phase 3 upgrades the three-zone diagnostic layer to emit a one-shot `PrefixCacheChange` event when the frozen baseline is first established, and correctly silences the duplicate drift event (relying on `PrefixStabilityManager` for drift reporting from that point on).

- The frozen-init event (turn 1, `None` branch) computes `pinned_combined_hash` via `FrozenPrefix::combined_hash`, which hashes tools using full `serde_json` serialization. All subsequent PM events use `PrefixFingerprint::combined_sha256`, which hashes only API-visible fields via `tool_to_api_json`. These two algorithms produce different digests for the same tool set, so `last_pinned_prefix_hash` silently flips to a new value on turn 2, making `/cache stats` output inconsistent.
- The drift path no longer emits a redundant event, which removes the per-drift double-counting of `prefix_change_count` that would have occurred in Phase 2.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The frozen-init event introduces a hash computed with a different tool-serialization algorithm than all subsequent PM events, causing `last_pinned_prefix_hash` to show an inconsistent value between turn 1 and turn 2 even when nothing has changed.

The `pinned_combined_hash` field in the frozen-init event is computed by `FrozenPrefix::combined_hash` (full `serde_json` serialization of every tool field), while every subsequent `PrefixCacheChange` event from `PrefixStabilityManager` uses `PrefixFingerprint::combined_sha256` (API-only fields via `tool_to_api_json`). These two digests diverge for the same tool set, so `/cache stats` shows a hash on turn 1 that never matches what PM reports from turn 2 onward.

crates/tui/src/core/engine/turn_loop.rs — the frozen-init event block (None branch, ~line 352) needs `pinned_combined_hash` computed via `PrefixFingerprint::compute` (the same path PM uses) rather than `FrozenPrefix::hash()`.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/core/engine/turn_loop.rs | Phase 3 adds a one-shot frozen-init event on the first turn; drift now stays silent (just tracing::debug!). The init event's `pinned_combined_hash` is computed with a different tool-serialization algorithm than all subsequent PM events, causing `last_pinned_prefix_hash` to show an inconsistent hash between turn 1 and turn 2. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant TL as TurnLoop
    participant PM as PrefixStabilityManager
    participant TZ as ThreeZoneLayer
    participant TX as tx_event
    participant UI as TUI (ui.rs)

    Note over TL: Turn 1 (frozen_prefix = None)
    TL->>PM: check_and_update(system, tools)
    PM-->>TX: "PrefixCacheChange { changed:false, stability_pct:X%, hash:PM_hash }"
    TX-->>UI: "prefix_checks_total++, prefix_stability_pct=X%"
    TL->>TZ: frozen_prefix is None, freeze()
    TZ-->>TX: "PrefixCacheChange { changed:false, stability_pct:100, hash:FrozenPrefix_hash }"
    TX-->>UI: "prefix_checks_total++ now 2, prefix_stability_pct=100 overwritten"
    Note right of UI: PM_hash != FrozenPrefix_hash different tool serialization

    Note over TL: Turn 2+ stable
    TL->>PM: check_and_update Ok
    PM-->>TX: "PrefixCacheChange { changed:false, stability_pct:Y%, hash:PM_hash }"
    TX-->>UI: "prefix_checks_total++, prefix_stability_pct=Y%"
    Note over TZ: No event emitted

    Note over TL: Turn N drift
    TL->>PM: check_and_update Err
    PM-->>TX: "PrefixCacheChange { changed:true, stability_pct:Z%, hash:PM_hash }"
    TX-->>UI: prefix_checks_total++, prefix_change_count++
    TL->>TZ: frozen.verify() Err drift
    TZ->>TZ: tracing debug only, re-freeze silently
    Note over TZ: No duplicate event Phase 3 fix
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fphase3-visible-events%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fphase3-visible-events%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine%2Fturn_loop.rs%3A352%0A**%60pinned_combined_hash%60%20uses%20a%20different%20hashing%20algorithm%20than%20%60PrefixStabilityManager%60**%0A%0A%60frozen.hash%28%29%60%20is%20computed%20by%20%60FrozenPrefix%3A%3Acombined_hash%60%20%28in%20%60prompt_zones.rs%60%29%2C%20which%20serializes%20tools%20with%20%60serde_json%3A%3Ato_string%28t%29%60%20%E2%80%94%20full%20serialization%20including%20internal%20fields%20like%20%60allowed_callers%60.%20Every%20subsequent%20%60PrefixCacheChange%60%20event%20from%20the%20PM%20block%20uses%20%60PrefixFingerprint%3A%3Acombined_sha256%60%2C%20which%20serializes%20tools%20with%20%60tool_to_api_json%60%20%28API-only%20fields%29.%20Because%20these%20two%20algorithms%20produce%20different%20digests%20for%20the%20same%20tool%20set%2C%20%60last_pinned_prefix_hash%60%20in%20the%20TUI%20will%20flip%20to%20a%20new%20value%20between%20turn%201%20and%20turn%202%20even%20when%20nothing%20visible%20has%20changed.%20%60%2Fcache%20stats%60%20%28the%20stated%20consumer%20of%20this%20field%29%20would%20show%20a%20hash%20on%20turn%201%20that%20is%20never%20reproducible%20from%20PM%20output%2C%20making%20cache-hit%20debugging%20actively%20misleading.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine%2Fturn_loop.rs%3A352%0A**%60pinned_combined_hash%60%20uses%20a%20different%20hashing%20algorithm%20than%20%60PrefixStabilityManager%60**%0A%0A%60frozen.hash%28%29%60%20is%20computed%20by%20%60FrozenPrefix%3A%3Acombined_hash%60%20%28in%20%60prompt_zones.rs%60%29%2C%20which%20serializes%20tools%20with%20%60serde_json%3A%3Ato_string%28t%29%60%20%E2%80%94%20full%20serialization%20including%20internal%20fields%20like%20%60allowed_callers%60.%20Every%20subsequent%20%60PrefixCacheChange%60%20event%20from%20the%20PM%20block%20uses%20%60PrefixFingerprint%3A%3Acombined_sha256%60%2C%20which%20serializes%20tools%20with%20%60tool_to_api_json%60%20%28API-only%20fields%29.%20Because%20these%20two%20algorithms%20produce%20different%20digests%20for%20the%20same%20tool%20set%2C%20%60last_pinned_prefix_hash%60%20in%20the%20TUI%20will%20flip%20to%20a%20new%20value%20between%20turn%201%20and%20turn%202%20even%20when%20nothing%20visible%20has%20changed.%20%60%2Fcache%20stats%60%20%28the%20stated%20consumer%20of%20this%20field%29%20would%20show%20a%20hash%20on%20turn%201%20that%20is%20never%20reproducible%20from%20PM%20output%2C%20making%20cache-hit%20debugging%20actively%20misleading.%0A%0A&repo=hmbown%2Fcodewhale&pr=2576&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine%2Fturn_loop.rs%3A352%0A**%60pinned_combined_hash%60%20uses%20a%20different%20hashing%20algorithm%20than%20%60PrefixStabilityManager%60**%0A%0A%60frozen.hash%28%29%60%20is%20computed%20by%20%60FrozenPrefix%3A%3Acombined_hash%60%20%28in%20%60prompt_zones.rs%60%29%2C%20which%20serializes%20tools%20with%20%60serde_json%3A%3Ato_string%28t%29%60%20%E2%80%94%20full%20serialization%20including%20internal%20fields%20like%20%60allowed_callers%60.%20Every%20subsequent%20%60PrefixCacheChange%60%20event%20from%20the%20PM%20block%20uses%20%60PrefixFingerprint%3A%3Acombined_sha256%60%2C%20which%20serializes%20tools%20with%20%60tool_to_api_json%60%20%28API-only%20fields%29.%20Because%20these%20two%20algorithms%20produce%20different%20digests%20for%20the%20same%20tool%20set%2C%20%60last_pinned_prefix_hash%60%20in%20the%20TUI%20will%20flip%20to%20a%20new%20value%20between%20turn%201%20and%20turn%202%20even%20when%20nothing%20visible%20has%20changed.%20%60%2Fcache%20stats%60%20%28the%20stated%20consumer%20of%20this%20field%29%20would%20show%20a%20hash%20on%20turn%201%20that%20is%20never%20reproducible%20from%20PM%20output%2C%20making%20cache-hit%20debugging%20actively%20misleading.%0A%0A&pr=2576&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix: don&#39;t double-count drift — only emi..."](https://github.com/hmbown/codewhale/commit/21721a45898d102faf0097b8b0252f004289d7e3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35072759)</sub>

<!-- /greptile_comment -->