### PR TITLE
feat(engine): inject mode-change runtime message and include mode in turn metadata

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -1217,8 +1217,8 @@ impl Engine {
             AppMode::Agent => (
                 "read-only operations run silently; writes, patches, and shell \
                  commands require user approval",
-                "If you previously deferred operations because of YOLO-mode hesitation, \
-                 those operations now require approval before executing.",
+                "Any operations you ran automatically under YOLO mode now require \
+                 explicit user approval before executing.",
             ),
             AppMode::Plan => (
                 "all writes and patches are blocked; shell and code execution are unavailable",

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -375,6 +375,8 @@ pub struct Engine {
     /// This keeps prompt refreshes cheap while still noticing append/update
     /// writes from slop ledger tools during the same session.
     slop_ledger_gate_cache: Option<(Option<SystemTime>, Option<String>)>,
+    /// Current operating mode. Updated on `ChangeMode` and `SendMessage`.
+    current_mode: AppMode,
 }
 
 // === Internal tool helpers ===
@@ -621,6 +623,7 @@ impl Engine {
             slop_ledger_gate_cache: None,
             workshop_vars,
             sandbox_backend,
+            current_mode: AppMode::Agent,
         };
         engine.rehydrate_latest_canonical_state();
 
@@ -1046,11 +1049,23 @@ impl Engine {
                     let _ = self.tx_event.send(Event::AgentList { agents }).await;
                 }
                 Op::ChangeMode { mode } => {
+                    let previous_mode = self.current_mode;
+                    self.current_mode = mode;
                     self.refresh_system_prompt(mode);
                     self.emit_session_updated().await;
+                    // Notify the agent that the mode has changed so it can re-evaluate
+                    // any operations that were blocked by the previous mode's policy.
+                    if previous_mode != mode {
+                        let msg = Self::mode_change_runtime_message(previous_mode, mode);
+                        self.session.add_message(msg);
+                        self.emit_session_updated().await;
+                    }
                     let _ = self
                         .tx_event
-                        .send(Event::status(format!("Mode changed to: {mode:?}")))
+                        .send(Event::status(format!(
+                            "Mode changed to: {}",
+                            mode.description()
+                        )))
                         .await;
                 }
                 Op::SetModel { model, mode } => {
@@ -1190,6 +1205,47 @@ impl Engine {
             .await;
     }
 
+    /// Build a runtime event message notifying the agent that the operating mode has changed.
+    /// This lets the agent re-evaluate any operations that were blocked by the previous mode.
+    fn mode_change_runtime_message(previous_mode: AppMode, new_mode: AppMode) -> Message {
+        let (policy_note, re_eval_hint) = match new_mode {
+            AppMode::Yolo => (
+                "all operations run automatically without requiring user approval",
+                "Re-evaluate any previously blocked write, patch, or shell operations \
+                 — they are now auto-approved.",
+            ),
+            AppMode::Agent => (
+                "read-only operations run silently; writes, patches, and shell \
+                 commands require user approval",
+                "If you previously deferred operations because of YOLO-mode hesitation, \
+                 those operations now require approval before executing.",
+            ),
+            AppMode::Plan => (
+                "all writes and patches are blocked; shell and code execution are unavailable",
+                "Any previously planned operations that require writes or shell access \
+                 must wait until the mode changes back to Agent or YOLO.",
+            ),
+        };
+        Message {
+            role: "user".to_string(),
+            content: vec![ContentBlock::Text {
+                text: format!(
+                    "<codewhale:runtime_event kind=\"mode_change\" visibility=\"internal\">\n\
+This is an internal runtime event, not user input. The operating mode has changed \
+from {previous} mode to {new} mode.\n\n\
+In {new} mode: {policy}\n\n\
+{re_eval}\n\
+</codewhale:runtime_event>",
+                    previous = previous_mode.description(),
+                    new = new_mode.description(),
+                    policy = policy_note,
+                    re_eval = re_eval_hint,
+                ),
+                cache_control: None,
+            }],
+        }
+    }
+
     async fn add_session_message(&mut self, message: Message) {
         self.session.add_message(message);
         self.emit_session_updated().await;
@@ -1198,11 +1254,13 @@ impl Engine {
     fn turn_metadata_block(
         &self,
         routed_model: &str,
+        mode: AppMode,
         auto_model: bool,
         reasoning_effort: Option<&str>,
         reasoning_effort_auto: bool,
     ) -> ContentBlock {
         let today = chrono::Local::now().format("%Y-%m-%d").to_string();
+        let mode_label = mode.description();
         let working_set_summary = self
             .session
             .working_set
@@ -1212,6 +1270,7 @@ impl Engine {
 
         let mut lines = vec![
             format!("Current local date: {today}"),
+            format!("Current mode: {mode_label}"),
             format!("Current model: {routed_model}"),
         ];
         if auto_model {
@@ -1234,6 +1293,7 @@ impl Engine {
     fn user_text_message_with_turn_metadata(&self, text: String) -> Message {
         self.user_text_message_with_turn_metadata_for_route(
             text,
+            self.current_mode,
             &self.session.model,
             self.session.auto_model,
             self.session.reasoning_effort.as_deref(),
@@ -1244,6 +1304,7 @@ impl Engine {
     fn user_text_message_with_turn_metadata_for_route(
         &self,
         text: String,
+        mode: AppMode,
         routed_model: &str,
         auto_model: bool,
         reasoning_effort: Option<&str>,
@@ -1254,6 +1315,7 @@ impl Engine {
             content: vec![
                 self.turn_metadata_block(
                     routed_model,
+                    mode,
                     auto_model,
                     reasoning_effort,
                     reasoning_effort_auto,
@@ -1288,6 +1350,9 @@ impl Engine {
     ) {
         // Reset cancel token for fresh turn (in case previous was cancelled)
         self.reset_cancel_token();
+
+        // Track current mode so mid-turn messages include the right mode in turn metadata.
+        self.current_mode = mode;
 
         // Drain stale steer messages from previous turns.
         while self.rx_steer.try_recv().is_ok() {}
@@ -1368,6 +1433,7 @@ impl Engine {
         // Add user message to session
         let user_msg = self.user_text_message_with_turn_metadata_for_route(
             content,
+            mode,
             &model,
             auto_model,
             reasoning_effort.as_deref(),

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -1617,6 +1617,61 @@ async fn change_mode_refreshes_session_prompt_and_updates_session() {
     assert!(prompt.contains("Approval Policy: Auto"));
 }
 
+#[tokio::test]
+async fn change_mode_op_injects_runtime_event_into_session_messages() {
+    let tmp = tempdir().expect("tempdir");
+    let config = EngineConfig {
+        workspace: tmp.path().to_path_buf(),
+        model: "deepseek-v4-pro".to_string(),
+        ..Default::default()
+    };
+    let (engine, handle) = Engine::new(config, &Config::default());
+
+    let run = tokio::spawn(engine.run());
+    // Switch from default Agent → YOLO
+    handle
+        .send(Op::ChangeMode {
+            mode: AppMode::Yolo,
+        })
+        .await
+        .expect("send change mode");
+
+    // Collect session-updated events until we see the injected message
+    let messages = {
+        let mut rx = handle.rx_event.write().await;
+        loop {
+            let event = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+                .await
+                .expect("session update after mode switch")
+                .expect("event");
+            if let Event::SessionUpdated { messages, .. } = event {
+                // The last message should be our runtime event
+                if let Some(last) = messages.last()
+                    && let ContentBlock::Text { text, .. } =
+                        last.content.first().expect("text block")
+                    && text.contains("kind=\"mode_change\"")
+                {
+                    break messages;
+                }
+            }
+        }
+    };
+    run.abort();
+
+    let last = messages.last().expect("at least one message");
+    let ContentBlock::Text { text, .. } = last.content.first().expect("text block") else {
+        panic!("expected text block");
+    };
+    assert!(
+        text.contains("Agent mode") && text.contains("YOLO mode"),
+        "should contain both previous and new mode: {text}"
+    );
+    assert!(
+        text.contains("Re-evaluate"),
+        "should tell agent to re-evaluate: {text}"
+    );
+}
+
 #[test]
 fn detects_context_length_errors_from_provider_payloads() {
     let msg = r#"SSE stream request failed: HTTP 400 Bad Request: {"error":{"message":"This model's maximum context length is 131072 tokens. However, you requested 153056 tokens (148960 in the messages, 4096 in the completion).","type":"invalid_request_error"}}"#;

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -2042,6 +2042,7 @@ fn turn_metadata_includes_auto_model_route() {
 
     let user_msg = engine.user_text_message_with_turn_metadata_for_route(
         "debug this regression".to_string(),
+        AppMode::Agent,
         "deepseek-v4-pro",
         true,
         Some("max"),
@@ -2056,6 +2057,94 @@ fn turn_metadata_includes_auto_model_route() {
     assert!(text.contains("Auto model route: deepseek-v4-pro"));
     assert!(text.contains("Auto reasoning effort: max"));
     assert!(!text.contains("debug this regression"));
+}
+
+#[test]
+fn turn_metadata_includes_current_mode() {
+    let tmp = tempdir().expect("tempdir");
+    let config = EngineConfig {
+        workspace: tmp.path().to_path_buf(),
+        ..Default::default()
+    };
+    let (engine, _handle) = Engine::new(config, &Config::default());
+
+    let user_msg = engine.user_text_message_with_turn_metadata_for_route(
+        "test mode metadata".to_string(),
+        AppMode::Yolo,
+        "deepseek-v4-flash",
+        false,
+        None,
+        false,
+    );
+    let first_block = user_msg.content.first().expect("turn metadata block");
+    let ContentBlock::Text { text, .. } = first_block else {
+        panic!("expected text metadata block");
+    };
+
+    assert!(
+        text.contains("Current mode: YOLO mode - full tool access without approvals"),
+        "turn metadata should include the current mode label, got: {text}"
+    );
+}
+
+#[test]
+fn turn_metadata_mode_updates_with_change_mode_op() {
+    let tmp = tempdir().expect("tempdir");
+    let config = EngineConfig {
+        workspace: tmp.path().to_path_buf(),
+        ..Default::default()
+    };
+    let (mut engine, _handle) = Engine::new(config, &Config::default());
+
+    // In agent mode by default
+    let msg = engine.user_text_message_with_turn_metadata("hello".to_string());
+    let first_block = msg.content.first().expect("turn metadata block");
+    let ContentBlock::Text { text, .. } = first_block else {
+        panic!("expected text metadata block");
+    };
+    assert!(
+        text.contains("Agent mode"),
+        "initial mode should be Agent, got: {text}"
+    );
+
+    // Switch to YOLO — user_text_message_with_turn_metadata should reflect the new mode
+    engine.current_mode = AppMode::Yolo;
+    let msg = engine.user_text_message_with_turn_metadata("hello again".to_string());
+    let first_block = msg.content.first().expect("turn metadata block");
+    let ContentBlock::Text { text, .. } = first_block else {
+        panic!("expected text metadata block");
+    };
+    assert!(
+        text.contains("YOLO mode"),
+        "mode after change should be YOLO, got: {text}"
+    );
+}
+
+#[test]
+fn mode_change_runtime_message_format() {
+    let msg = Engine::mode_change_runtime_message(AppMode::Agent, AppMode::Yolo);
+
+    assert_eq!(msg.role, "user");
+    let ContentBlock::Text { text, .. } = msg.content.first().expect("text block") else {
+        panic!("expected text block");
+    };
+
+    assert!(
+        text.contains("codewhale:runtime_event"),
+        "should be a runtime event message"
+    );
+    assert!(
+        text.contains("kind=\"mode_change\""),
+        "should have mode_change kind"
+    );
+    assert!(
+        text.contains("Agent mode") && text.contains("YOLO mode"),
+        "should mention both previous and new mode: {text}"
+    );
+    assert!(
+        text.contains("Re-evaluate"),
+        "should tell agent to re-evaluate blocked operations: {text}"
+    );
 }
 
 #[test]

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -314,7 +314,7 @@ impl Engine {
             // Three-zone prefix contract (#2264): freeze baseline on first
             // turn, verify against it on subsequent turns. Operates alongside
             // PrefixStabilityManager as an independent diagnostic layer.
-            // Phase 2: warn-only, auto-re-freeze on drift.
+            // Phase 3: emit PrefixCacheChange events for user visibility.
             let system_text =
                 crate::prefix_cache::system_prompt_text(self.session.system_prompt.as_ref());
             let current_tools: &[crate::models::Tool] = active_tools.as_deref().unwrap_or_default();
@@ -326,6 +326,17 @@ impl Engine {
                             target: "prefix_cache",
                             "three-zone drift: {drift}"
                         );
+                        let _ = self
+                            .tx_event
+                            .send(Event::PrefixCacheChange {
+                                description: drift.to_string(),
+                                system_prompt_changed: drift.system_changed,
+                                tools_changed: drift.tools_changed,
+                                stability_pct: 0,
+                                changed: true,
+                                pinned_combined_hash: frozen.hash().to_string(),
+                            })
+                            .await;
                         let pinned = PinnedPrefix::new(
                             self.session.system_prompt.as_ref(),
                             current_tools.to_vec(),
@@ -338,7 +349,19 @@ impl Engine {
                         self.session.system_prompt.as_ref(),
                         current_tools.to_vec(),
                     );
-                    self.session.frozen_prefix = Some(pinned.freeze());
+                    let frozen = pinned.freeze();
+                    let _ = self
+                        .tx_event
+                        .send(Event::PrefixCacheChange {
+                            description: format!("frozen: {}", frozen.short_id()),
+                            system_prompt_changed: false,
+                            tools_changed: false,
+                            stability_pct: 100,
+                            changed: false,
+                            pinned_combined_hash: frozen.hash().to_string(),
+                        })
+                        .await;
+                    self.session.frozen_prefix = Some(frozen);
                 }
             }
 

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -314,7 +314,9 @@ impl Engine {
             // Three-zone prefix contract (#2264): freeze baseline on first
             // turn, verify against it on subsequent turns. Operates alongside
             // PrefixStabilityManager as an independent diagnostic layer.
-            // Phase 3: emit PrefixCacheChange events for user visibility.
+            // Phase 3: emit a one-shot 'frozen' event on first turn.
+            // Drift is logged (tracing::debug!) but not re-emitted —
+            // PrefixStabilityManager already reports the change above.
             let system_text =
                 crate::prefix_cache::system_prompt_text(self.session.system_prompt.as_ref());
             let current_tools: &[crate::models::Tool] = active_tools.as_deref().unwrap_or_default();
@@ -326,17 +328,6 @@ impl Engine {
                             target: "prefix_cache",
                             "three-zone drift: {drift}"
                         );
-                        let _ = self
-                            .tx_event
-                            .send(Event::PrefixCacheChange {
-                                description: drift.to_string(),
-                                system_prompt_changed: drift.system_changed,
-                                tools_changed: drift.tools_changed,
-                                stability_pct: 0,
-                                changed: true,
-                                pinned_combined_hash: frozen.hash().to_string(),
-                            })
-                            .await;
                         let pinned = PinnedPrefix::new(
                             self.session.system_prompt.as_ref(),
                             current_tools.to_vec(),


### PR DESCRIPTION
## What

When the user switches modes mid-session (Agent → YOLO → Plan), the agent now receives a `<codewhale:runtime_event kind="mode_change">` message in the conversation. This lets the agent **re-evaluate any operations that were blocked by the previous mode approval policy**.

Additionally, the current `AppMode` is now included in every turn `<turn_meta>` block so **mid-turn messages** (steer, REPL, LSP diagnostics) correctly report the active mode instead of always showing "Agent".

## Why

Closes #2515. The core problem: users switch from Agent → YOLO mode with Alt+y, but the agent still says "I cannot do shell operations, you need to run them manually" — because it never received any signal that the mode changed.

## Changes

### `engine.rs`
- **New `current_mode: AppMode` field** on `Engine` struct — tracks the active mode
- **`Op::ChangeMode` handling** — injects a `mode_change_runtime_message` into `session.messages`, which uses `<codewhale:runtime_event kind="mode_change">` XML (same pattern as sub-agent completion events). The message includes:
  - Policy description for the new mode
  - Explicit re-evaluation hint ("Re-evaluate any previously blocked operations")
- **`turn_metadata_block`** — now includes `Current mode: {mode_label}` line
- **`user_text_message_with_turn_metadata`** — uses `self.current_mode` instead of hardcoded `AppMode::Agent`
- **`user_text_message_with_turn_metadata_for_route`** — accepts `mode: AppMode` parameter
- **`handle_send_message`** — stores `self.current_mode = mode` early

### `engine/tests.rs`
- `turn_metadata_includes_current_mode` — verifies mode appears in turn_meta
- `turn_metadata_mode_updates_with_change_mode_op` — verifies mid-turn messages pick up mode changes
- `mode_change_runtime_message_format` — verifies runtime event format
- Updated `turn_metadata_includes_auto_model_route` to pass `AppMode::Agent`

## Verification
```
cargo test -p codewhale-tui  # 3356 passed, 0 failed
cargo fmt --all -- --check    # clean
```

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR injects a `<codewhale:runtime_event kind=\"mode_change\">` message into the conversation when the user switches modes mid-session, and adds the active `AppMode` to every turn's `<turn_meta>` block so the agent always has accurate context about its operating policy.

- `Engine` gains a `current_mode: AppMode` field updated on both `Op::ChangeMode` and `Op::SendMessage`; `mode_change_runtime_message` constructs the runtime event using the same XML pattern as sub-agent completion events.
- `turn_metadata_block` now accepts a `mode: AppMode` parameter and emits a `Current mode:` line; `user_text_message_with_turn_metadata` threads `self.current_mode` through automatically.
- `turn_loop.rs` upgrades the prefix-freeze diagnostic from Phase 2 (warn-only) to Phase 3 (emitting a one-shot `PrefixCacheChange` event on the first turn freeze).
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with one fix: `Op::EditLastTurn` hardcodes `AppMode::Agent` instead of `self.current_mode`, silently overwriting the engine's tracked mode and re-dispatching the edited turn under the wrong approval policy.

The `Op::EditLastTurn` handler passes a hardcoded `AppMode::Agent` to `handle_send_message`, which immediately writes it back to `self.current_mode`. A YOLO or Plan user who runs `/edit` will have their re-sent message processed with Agent-level approval restrictions, and the engine's mode state will be permanently overwritten to Agent for all subsequent turns until the next `SendMessage` or `ChangeMode` — directly contradicting the purpose of this PR.

crates/tui/src/core/engine.rs — the `Op::EditLastTurn` arm at line 1158
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/tui/src/core/engine.rs | Adds `current_mode` tracking, `Op::ChangeMode` runtime message injection, and mode in turn metadata — but `Op::EditLastTurn` hardcodes `AppMode::Agent` instead of `self.current_mode`, silently overwriting the active mode on `/edit` and causing wrong approval policy for YOLO/Plan users. |
| crates/tui/src/core/engine/tests.rs | Adds integration test `change_mode_op_injects_runtime_event_into_session_messages` (exercises the full Op dispatch path) plus three unit tests covering mode in turn metadata and message format; `turn_metadata_mode_updates_with_change_mode_op` still sets `engine.current_mode` directly rather than via Op dispatch, but the new async test compensates for the most critical path. |
| crates/tui/src/core/engine/turn_loop.rs | Upgrades prefix-freeze from Phase 2 (warn-only) to Phase 3 (emit one-shot `PrefixCacheChange` event on first freeze); straightforward and self-contained. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI
    participant Engine
    participant Session
    participant Agent

    UI->>Engine: "Op::ChangeMode { mode: Yolo }"
    Engine->>Engine: "previous_mode = current_mode (Agent)"
    Engine->>Engine: "current_mode = Yolo"
    Engine->>Session: refresh_system_prompt(Yolo)
    Engine->>UI: emit_session_updated()
    Engine->>Session: add_message(mode_change_runtime_event)
    Engine->>UI: emit_session_updated()
    Engine->>UI: Event::status("Mode changed to: YOLO mode")

    UI->>Engine: "Op::SendMessage { mode: Yolo, ... }"
    Engine->>Engine: "current_mode = Yolo"
    Engine->>Session: add user_msg with turn_meta (Current mode: YOLO mode)
    Engine->>Agent: MessageRequest (messages including mode_change event + turn_meta)
    Agent-->>Engine: response (re-evaluates blocked operations)

    Note over Engine: Op::EditLastTurn bypasses current_mode
    UI->>Engine: "Op::EditLastTurn { new_message }"
    Engine->>Session: truncate to last user message
    Engine->>Engine: "mode = AppMode::Agent (hardcoded!)"
    Engine->>Engine: "handle_send_message(mode=Agent) overwriting current_mode"
    Engine->>Agent: MessageRequest (turn_meta shows Agent, YOLO ops blocked)
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/tui/src/core/engine.rs`, line 1158-1161 ([link](https://github.com/hmbown/codewhale/blob/29c745c273c03e543c244fe7413030216cbf47af/crates/tui/src/core/engine.rs#L1158-L1161)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`EditLastTurn` silently resets active mode to Agent**

   `Op::EditLastTurn` passes `AppMode::Agent` to `handle_send_message`, which immediately overwrites `self.current_mode = mode`. A user who has switched to YOLO or Plan mode and then uses `/edit` will have their turn re-dispatched under Agent restrictions — and the engine's tracked mode will be permanently downgraded to Agent for all subsequent mid-turn messages too. The comment on the same line says "reusing the engine's stored mode/model config", but the mode is not reused at all. Using `self.current_mode` in place of the hardcoded `AppMode::Agent` would match the intent.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fmode-change-system-message%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fmode-change-system-message%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fcore%2Fengine.rs%0ALine%3A%201158-1161%0A%0AComment%3A%0A**%60EditLastTurn%60%20silently%20resets%20active%20mode%20to%20Agent**%0A%0A%60Op%3A%3AEditLastTurn%60%20passes%20%60AppMode%3A%3AAgent%60%20to%20%60handle_send_message%60%2C%20which%20immediately%20overwrites%20%60self.current_mode%20%3D%20mode%60.%20A%20user%20who%20has%20switched%20to%20YOLO%20or%20Plan%20mode%20and%20then%20uses%20%60%2Fedit%60%20will%20have%20their%20turn%20re-dispatched%20under%20Agent%20restrictions%20%E2%80%94%20and%20the%20engine's%20tracked%20mode%20will%20be%20permanently%20downgraded%20to%20Agent%20for%20all%20subsequent%20mid-turn%20messages%20too.%20The%20comment%20on%20the%20same%20line%20says%20%22reusing%20the%20engine's%20stored%20mode%2Fmodel%20config%22%2C%20but%20the%20mode%20is%20not%20reused%20at%20all.%20Using%20%60self.current_mode%60%20in%20place%20of%20the%20hardcoded%20%60AppMode%3A%3AAgent%60%20would%20match%20the%20intent.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fcore%2Fengine.rs%0ALine%3A%201158-1161%0A%0AComment%3A%0A**%60EditLastTurn%60%20silently%20resets%20active%20mode%20to%20Agent**%0A%0A%60Op%3A%3AEditLastTurn%60%20passes%20%60AppMode%3A%3AAgent%60%20to%20%60handle_send_message%60%2C%20which%20immediately%20overwrites%20%60self.current_mode%20%3D%20mode%60.%20A%20user%20who%20has%20switched%20to%20YOLO%20or%20Plan%20mode%20and%20then%20uses%20%60%2Fedit%60%20will%20have%20their%20turn%20re-dispatched%20under%20Agent%20restrictions%20%E2%80%94%20and%20the%20engine's%20tracked%20mode%20will%20be%20permanently%20downgraded%20to%20Agent%20for%20all%20subsequent%20mid-turn%20messages%20too.%20The%20comment%20on%20the%20same%20line%20says%20%22reusing%20the%20engine's%20stored%20mode%2Fmodel%20config%22%2C%20but%20the%20mode%20is%20not%20reused%20at%20all.%20Using%20%60self.current_mode%60%20in%20place%20of%20the%20hardcoded%20%60AppMode%3A%3AAgent%60%20would%20match%20the%20intent.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2577&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fcore%2Fengine.rs%0ALine%3A%201158-1161%0A%0AComment%3A%0A**%60EditLastTurn%60%20silently%20resets%20active%20mode%20to%20Agent**%0A%0A%60Op%3A%3AEditLastTurn%60%20passes%20%60AppMode%3A%3AAgent%60%20to%20%60handle_send_message%60%2C%20which%20immediately%20overwrites%20%60self.current_mode%20%3D%20mode%60.%20A%20user%20who%20has%20switched%20to%20YOLO%20or%20Plan%20mode%20and%20then%20uses%20%60%2Fedit%60%20will%20have%20their%20turn%20re-dispatched%20under%20Agent%20restrictions%20%E2%80%94%20and%20the%20engine's%20tracked%20mode%20will%20be%20permanently%20downgraded%20to%20Agent%20for%20all%20subsequent%20mid-turn%20messages%20too.%20The%20comment%20on%20the%20same%20line%20says%20%22reusing%20the%20engine's%20stored%20mode%2Fmodel%20config%22%2C%20but%20the%20mode%20is%20not%20reused%20at%20all.%20Using%20%60self.current_mode%60%20in%20place%20of%20the%20hardcoded%20%60AppMode%3A%3AAgent%60%20would%20match%20the%20intent.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2577&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fmode-change-system-message%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fmode-change-system-message%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine.rs%3A1158-1161%0A**%60EditLastTurn%60%20silently%20resets%20active%20mode%20to%20Agent**%0A%0A%60Op%3A%3AEditLastTurn%60%20passes%20%60AppMode%3A%3AAgent%60%20to%20%60handle_send_message%60%2C%20which%20immediately%20overwrites%20%60self.current_mode%20%3D%20mode%60.%20A%20user%20who%20has%20switched%20to%20YOLO%20or%20Plan%20mode%20and%20then%20uses%20%60%2Fedit%60%20will%20have%20their%20turn%20re-dispatched%20under%20Agent%20restrictions%20%E2%80%94%20and%20the%20engine's%20tracked%20mode%20will%20be%20permanently%20downgraded%20to%20Agent%20for%20all%20subsequent%20mid-turn%20messages%20too.%20The%20comment%20on%20the%20same%20line%20says%20%22reusing%20the%20engine's%20stored%20mode%2Fmodel%20config%22%2C%20but%20the%20mode%20is%20not%20reused%20at%20all.%20Using%20%60self.current_mode%60%20in%20place%20of%20the%20hardcoded%20%60AppMode%3A%3AAgent%60%20would%20match%20the%20intent.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine.rs%3A1217-1222%0AThe%20%60Agent%60%20arm's%20re-eval%20hint%20is%20specific%20to%20a%20YOLO%20%E2%86%92%20Agent%20transition%20%28%22operations%20you%20ran%20automatically%20under%20YOLO%20mode%22%29.%20When%20the%20user%20goes%20Plan%20%E2%86%92%20Agent%2C%20the%20agent%20ran%20nothing%20automatically%20under%20Plan%20mode%20%E2%80%94%20the%20hint%20misleads%20it%20into%20believing%20there%20is%20pending%20YOLO-style%20auto-execution%20that%20now%20needs%20approval.%20A%20generic%20hint%20covering%20both%20predecessor%20modes%20would%20be%20accurate%20for%20all%20callers.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20AppMode%3A%3AAgent%20%3D%3E%20%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22read-only%20operations%20run%20silently%3B%20writes%2C%20patches%2C%20and%20shell%20%5C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20commands%20require%20user%20approval%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22Any%20operations%20that%20were%20previously%20blocked%20or%20auto-executed%20without%20%5C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20approval%20now%20require%20explicit%20user%20approval%20before%20executing.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%2C%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine.rs%3A1158-1161%0A**%60EditLastTurn%60%20silently%20resets%20active%20mode%20to%20Agent**%0A%0A%60Op%3A%3AEditLastTurn%60%20passes%20%60AppMode%3A%3AAgent%60%20to%20%60handle_send_message%60%2C%20which%20immediately%20overwrites%20%60self.current_mode%20%3D%20mode%60.%20A%20user%20who%20has%20switched%20to%20YOLO%20or%20Plan%20mode%20and%20then%20uses%20%60%2Fedit%60%20will%20have%20their%20turn%20re-dispatched%20under%20Agent%20restrictions%20%E2%80%94%20and%20the%20engine's%20tracked%20mode%20will%20be%20permanently%20downgraded%20to%20Agent%20for%20all%20subsequent%20mid-turn%20messages%20too.%20The%20comment%20on%20the%20same%20line%20says%20%22reusing%20the%20engine's%20stored%20mode%2Fmodel%20config%22%2C%20but%20the%20mode%20is%20not%20reused%20at%20all.%20Using%20%60self.current_mode%60%20in%20place%20of%20the%20hardcoded%20%60AppMode%3A%3AAgent%60%20would%20match%20the%20intent.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine.rs%3A1217-1222%0AThe%20%60Agent%60%20arm's%20re-eval%20hint%20is%20specific%20to%20a%20YOLO%20%E2%86%92%20Agent%20transition%20%28%22operations%20you%20ran%20automatically%20under%20YOLO%20mode%22%29.%20When%20the%20user%20goes%20Plan%20%E2%86%92%20Agent%2C%20the%20agent%20ran%20nothing%20automatically%20under%20Plan%20mode%20%E2%80%94%20the%20hint%20misleads%20it%20into%20believing%20there%20is%20pending%20YOLO-style%20auto-execution%20that%20now%20needs%20approval.%20A%20generic%20hint%20covering%20both%20predecessor%20modes%20would%20be%20accurate%20for%20all%20callers.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20AppMode%3A%3AAgent%20%3D%3E%20%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22read-only%20operations%20run%20silently%3B%20writes%2C%20patches%2C%20and%20shell%20%5C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20commands%20require%20user%20approval%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22Any%20operations%20that%20were%20previously%20blocked%20or%20auto-executed%20without%20%5C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20approval%20now%20require%20explicit%20user%20approval%20before%20executing.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%2C%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2577&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine.rs%3A1158-1161%0A**%60EditLastTurn%60%20silently%20resets%20active%20mode%20to%20Agent**%0A%0A%60Op%3A%3AEditLastTurn%60%20passes%20%60AppMode%3A%3AAgent%60%20to%20%60handle_send_message%60%2C%20which%20immediately%20overwrites%20%60self.current_mode%20%3D%20mode%60.%20A%20user%20who%20has%20switched%20to%20YOLO%20or%20Plan%20mode%20and%20then%20uses%20%60%2Fedit%60%20will%20have%20their%20turn%20re-dispatched%20under%20Agent%20restrictions%20%E2%80%94%20and%20the%20engine's%20tracked%20mode%20will%20be%20permanently%20downgraded%20to%20Agent%20for%20all%20subsequent%20mid-turn%20messages%20too.%20The%20comment%20on%20the%20same%20line%20says%20%22reusing%20the%20engine's%20stored%20mode%2Fmodel%20config%22%2C%20but%20the%20mode%20is%20not%20reused%20at%20all.%20Using%20%60self.current_mode%60%20in%20place%20of%20the%20hardcoded%20%60AppMode%3A%3AAgent%60%20would%20match%20the%20intent.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine.rs%3A1217-1222%0AThe%20%60Agent%60%20arm's%20re-eval%20hint%20is%20specific%20to%20a%20YOLO%20%E2%86%92%20Agent%20transition%20%28%22operations%20you%20ran%20automatically%20under%20YOLO%20mode%22%29.%20When%20the%20user%20goes%20Plan%20%E2%86%92%20Agent%2C%20the%20agent%20ran%20nothing%20automatically%20under%20Plan%20mode%20%E2%80%94%20the%20hint%20misleads%20it%20into%20believing%20there%20is%20pending%20YOLO-style%20auto-execution%20that%20now%20needs%20approval.%20A%20generic%20hint%20covering%20both%20predecessor%20modes%20would%20be%20accurate%20for%20all%20callers.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20AppMode%3A%3AAgent%20%3D%3E%20%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22read-only%20operations%20run%20silently%3B%20writes%2C%20patches%2C%20and%20shell%20%5C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20commands%20require%20user%20approval%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22Any%20operations%20that%20were%20previously%20blocked%20or%20auto-executed%20without%20%5C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20approval%20now%20require%20explicit%20user%20approval%20before%20executing.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%2C%0A%60%60%60%0A%0A&pr=2577&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix(engine): address review feedback — i..."](https://github.com/hmbown/codewhale/commit/29c745c273c03e543c244fe7413030216cbf47af) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35073674)</sub>

<!-- /greptile_comment -->