### PR TITLE
fix: detect engine task death mid-turn and recover UI immediately

### DIFF
--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -2242,9 +2242,7 @@ async fn run_event_loop(
             // UI state immediately instead of waiting for the 300-second
             // TURN_STALL_WATCHDOG_TIMEOUT.  Use is_closed() rather than
             // try_recv() so the probe never consumes a valid event.
-            if (app.is_loading || app.is_compacting || app.is_purging)
-                && rx.is_closed()
-            {
+            if (app.is_loading || app.is_compacting || app.is_purging) && rx.is_closed() {
                 streaming_thinking::finalize_current(app);
                 app.finalize_streaming_assistant_as_interrupted();
                 app.finalize_active_cell_as_interrupted();

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -2262,6 +2262,14 @@ async fn run_event_loop(
                 app.runtime_turn_id = None;
                 app.dispatch_started_at = None;
                 app.user_scrolled_during_stream = false;
+
+                // Preserve pending steers: same hard-fail recovery as
+                // TurnComplete::Failed — surface them in the visible queue
+                // so they are not silently lost.
+                for msg in app.drain_pending_steers() {
+                    app.queue_message(msg);
+                }
+
                 app.push_status_toast(
                     "Engine process has terminated unexpectedly.",
                     StatusToastLevel::Error,

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -33,8 +33,6 @@ use tracing;
 #[cfg(target_os = "windows")]
 use windows::Win32::System::Console::{GetConsoleMode, GetStdHandle, SetConsoleMode};
 
-use tokio::sync::mpsc::error::TryRecvError;
-
 use crate::audit::log_sensitive_event;
 use crate::automation_manager::{AutomationManager, AutomationSchedulerConfig, spawn_scheduler};
 use crate::client::{
@@ -2239,12 +2237,13 @@ async fn run_event_loop(
             // Detect engine task death mid-turn.  When the engine task
             // panics (caught by spawn_supervised's catch_unwind) or exits
             // unexpectedly between TurnStarted and TurnComplete, the event
-            // channel's sender is dropped and try_recv returns Disconnected.
-            // The while-let loop above exits silently on Err, so we must
-            // check post-loop and recover the UI state immediately instead
-            // of waiting for the 300-second TURN_STALL_WATCHDOG_TIMEOUT.
+            // channel's sender is dropped.  The while-let loop above exits
+            // silently on Err, so we must check post-loop and recover the
+            // UI state immediately instead of waiting for the 300-second
+            // TURN_STALL_WATCHDOG_TIMEOUT.  Use is_closed() rather than
+            // try_recv() so the probe never consumes a valid event.
             if (app.is_loading || app.is_compacting || app.is_purging)
-                && matches!(rx.try_recv(), Err(TryRecvError::Disconnected))
+                && rx.is_closed()
             {
                 streaming_thinking::finalize_current(app);
                 app.finalize_streaming_assistant_as_interrupted();

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -89,6 +89,7 @@ use crate::tui::pager::PagerView;
 use crate::tui::persistence_actor::{self, PersistRequest};
 use crate::tui::plan_prompt::PlanPromptView;
 use crate::tui::scrolling::TranscriptScroll;
+use tokio::sync::mpsc::error::TryRecvError;
 // SelectionAutoscroll unused
 use crate::tui::session_picker::SessionPickerView;
 use crate::tui::shell_job_routing::{
@@ -2233,6 +2234,34 @@ async fn run_event_loop(
                         }
                     }
                 }
+            }
+            // Detect engine task death mid-turn.  When the engine task
+            // panics (caught by spawn_supervised's catch_unwind) or exits
+            // unexpectedly between TurnStarted and TurnComplete, the event
+            // channel's sender is dropped and try_recv returns Disconnected.
+            // The while-let loop above exits silently on Err, so we must
+            // check post-loop and recover the UI state immediately instead
+            // of waiting for the 300-second TURN_STALL_WATCHDOG_TIMEOUT.
+            if app.is_loading && matches!(rx.try_recv(), Err(TryRecvError::Disconnected)) {
+                streaming_thinking::finalize_current(app);
+                app.finalize_streaming_assistant_as_interrupted();
+                app.finalize_active_cell_as_interrupted();
+                app.streaming_state.reset();
+                app.streaming_message_index = None;
+                app.streaming_thinking_active_entry = None;
+
+                app.is_loading = false;
+                app.turn_started_at = None;
+                app.turn_last_activity_at = None;
+                app.runtime_turn_status = None;
+                app.runtime_turn_id = None;
+                app.dispatch_started_at = None;
+                app.user_scrolled_during_stream = false;
+                app.push_status_toast(
+                    "Engine process has terminated unexpectedly.",
+                    StatusToastLevel::Error,
+                    None,
+                );
             }
         }
         if let Some(index) = app.streaming_message_index {

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -33,6 +33,8 @@ use tracing;
 #[cfg(target_os = "windows")]
 use windows::Win32::System::Console::{GetConsoleMode, GetStdHandle, SetConsoleMode};
 
+use tokio::sync::mpsc::error::TryRecvError;
+
 use crate::audit::log_sensitive_event;
 use crate::automation_manager::{AutomationManager, AutomationSchedulerConfig, spawn_scheduler};
 use crate::client::{
@@ -89,7 +91,6 @@ use crate::tui::pager::PagerView;
 use crate::tui::persistence_actor::{self, PersistRequest};
 use crate::tui::plan_prompt::PlanPromptView;
 use crate::tui::scrolling::TranscriptScroll;
-use tokio::sync::mpsc::error::TryRecvError;
 // SelectionAutoscroll unused
 use crate::tui::session_picker::SessionPickerView;
 use crate::tui::shell_job_routing::{
@@ -2242,7 +2243,9 @@ async fn run_event_loop(
             // The while-let loop above exits silently on Err, so we must
             // check post-loop and recover the UI state immediately instead
             // of waiting for the 300-second TURN_STALL_WATCHDOG_TIMEOUT.
-            if app.is_loading && matches!(rx.try_recv(), Err(TryRecvError::Disconnected)) {
+            if (app.is_loading || app.is_compacting || app.is_purging)
+                && matches!(rx.try_recv(), Err(TryRecvError::Disconnected))
+            {
                 streaming_thinking::finalize_current(app);
                 app.finalize_streaming_assistant_as_interrupted();
                 app.finalize_active_cell_as_interrupted();
@@ -2251,6 +2254,11 @@ async fn run_event_loop(
                 app.streaming_thinking_active_entry = None;
 
                 app.is_loading = false;
+                app.is_compacting = false;
+                app.is_purging = false;
+                app.active_allowed_tools = None;
+                app.agent_progress.clear();
+                app.agent_activity_started_at = None;
                 app.turn_started_at = None;
                 app.turn_last_activity_at = None;
                 app.runtime_turn_status = None;
@@ -2262,6 +2270,7 @@ async fn run_event_loop(
                     StatusToastLevel::Error,
                     None,
                 );
+                app.needs_redraw = true;
             }
         }
         if let Some(index) = app.streaming_message_index {

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -2613,7 +2613,7 @@ fn engine_event_channel_disconnect_recovers_mid_turn_ui_state() {
     // Creates a real mpsc channel, sets up app as if a turn is in progress,
     // drops the sender (mirroring engine task exit in spawn_supervised),
     // and verifies the post-loop recovery logic cleans up the UI state.
-    let (tx_event, mut rx) = tokio::sync::mpsc::channel::<EngineEvent>(256);
+    let (tx_event, rx) = tokio::sync::mpsc::channel::<EngineEvent>(256);
     drop(tx_event);
 
     // Confirm the channel is closed

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -2628,6 +2628,14 @@ fn engine_event_channel_disconnect_recovers_mid_turn_ui_state() {
     app.streaming_message_index = Some(0);
     app.user_scrolled_during_stream = true;
 
+    // Verify pending steers are surfaced to the visible queue on reconnect
+    app.pending_steers.push_back(QueuedMessage {
+        display: "steer content".to_string(),
+        skill_instruction: None,
+    });
+    assert_eq!(app.pending_steers.len(), 1);
+    assert_eq!(app.queued_message_count(), 0);
+
     // Apply the same post-loop logic from ui.rs
     if (app.is_loading || app.is_compacting || app.is_purging) && rx.is_closed() {
         streaming_thinking::finalize_current(&mut app);
@@ -2649,6 +2657,11 @@ fn engine_event_channel_disconnect_recovers_mid_turn_ui_state() {
         app.runtime_turn_id = None;
         app.dispatch_started_at = None;
         app.user_scrolled_during_stream = false;
+
+        for msg in app.drain_pending_steers() {
+            app.queue_message(msg);
+        }
+
         app.push_status_toast(
             "Engine process has terminated unexpectedly.",
             StatusToastLevel::Error,
@@ -2672,6 +2685,12 @@ fn engine_event_channel_disconnect_recovers_mid_turn_ui_state() {
     let toast = app.status_toasts.back().expect("error toast pushed");
     assert_eq!(toast.level, StatusToastLevel::Error);
     assert!(toast.text.contains("Engine process has terminated"));
+
+    // Verify pending steers were preserved in the visible queue
+    assert!(app.pending_steers.is_empty(), "pending_steers drained");
+    assert_eq!(app.queued_message_count(), 1, "steer requeued");
+    let queued = app.pop_queued_message().expect("queued steer available");
+    assert_eq!(queued.display, "steer content");
 }
 
 #[test]

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -2608,6 +2608,59 @@ fn turn_liveness_recovers_stalled_in_progress_turn() {
 }
 
 #[test]
+fn engine_event_channel_disconnect_recovers_mid_turn_ui_state() {
+    // Simulate the event-loop post-check that detects engine task death.
+    // Creates a real mpsc channel, sets up app as if a turn is in progress,
+    // drops the sender (mirroring engine task exit in spawn_supervised),
+    // and verifies the post-loop recovery logic cleans up the UI state.
+    let (tx_event, mut rx) = tokio::sync::mpsc::channel::<EngineEvent>(256);
+    drop(tx_event);
+
+    // Confirm the channel is disconnected
+    assert!(matches!(rx.try_recv(), Err(TryRecvError::Disconnected)));
+
+    let mut app = create_test_app();
+    app.is_loading = true;
+    app.runtime_turn_status = Some("in_progress".to_string());
+    app.runtime_turn_id = Some("turn-42".to_string());
+    app.streaming_message_index = Some(0);
+    app.user_scrolled_during_stream = true;
+
+    // Apply the same post-loop logic from ui.rs
+    if app.is_loading && matches!(rx.try_recv(), Err(TryRecvError::Disconnected)) {
+        streaming_thinking::finalize_current(&mut app);
+        app.finalize_streaming_assistant_as_interrupted();
+        app.finalize_active_cell_as_interrupted();
+        app.streaming_state.reset();
+        app.streaming_message_index = None;
+        app.streaming_thinking_active_entry = None;
+
+        app.is_loading = false;
+        app.turn_started_at = None;
+        app.turn_last_activity_at = None;
+        app.runtime_turn_status = None;
+        app.runtime_turn_id = None;
+        app.dispatch_started_at = None;
+        app.user_scrolled_during_stream = false;
+        app.push_status_toast(
+            "Engine process has terminated unexpectedly.",
+            StatusToastLevel::Error,
+            None,
+        );
+    }
+
+    // Verify the fix: UI state is fully recovered
+    assert!(!app.is_loading, "loading must be cleared");
+    assert!(app.runtime_turn_status.is_none(), "turn status cleared");
+    assert!(app.runtime_turn_id.is_none(), "turn id cleared");
+    assert!(app.streaming_message_index.is_none());
+    assert!(!app.user_scrolled_during_stream);
+    let toast = app.status_toasts.back().expect("error toast pushed");
+    assert_eq!(toast.level, StatusToastLevel::Error);
+    assert!(toast.text.contains("Engine process has terminated"));
+}
+
+#[test]
 fn fixed_model_auto_thinking_skips_auto_model_router() {
     let mut app = create_test_app();
     app.auto_model = false;

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -2616,18 +2616,20 @@ fn engine_event_channel_disconnect_recovers_mid_turn_ui_state() {
     let (tx_event, mut rx) = tokio::sync::mpsc::channel::<EngineEvent>(256);
     drop(tx_event);
 
-    // Confirm the channel is disconnected
-    assert!(matches!(rx.try_recv(), Err(TryRecvError::Disconnected)));
+    // Confirm the channel is closed
+    assert!(rx.is_closed());
 
     let mut app = create_test_app();
     app.is_loading = true;
+    app.is_compacting = false;
+    app.is_purging = false;
     app.runtime_turn_status = Some("in_progress".to_string());
     app.runtime_turn_id = Some("turn-42".to_string());
     app.streaming_message_index = Some(0);
     app.user_scrolled_during_stream = true;
 
     // Apply the same post-loop logic from ui.rs
-    if app.is_loading && matches!(rx.try_recv(), Err(TryRecvError::Disconnected)) {
+    if (app.is_loading || app.is_compacting || app.is_purging) && rx.is_closed() {
         streaming_thinking::finalize_current(&mut app);
         app.finalize_streaming_assistant_as_interrupted();
         app.finalize_active_cell_as_interrupted();
@@ -2636,6 +2638,11 @@ fn engine_event_channel_disconnect_recovers_mid_turn_ui_state() {
         app.streaming_thinking_active_entry = None;
 
         app.is_loading = false;
+        app.is_compacting = false;
+        app.is_purging = false;
+        app.active_allowed_tools = None;
+        app.agent_progress.clear();
+        app.agent_activity_started_at = None;
         app.turn_started_at = None;
         app.turn_last_activity_at = None;
         app.runtime_turn_status = None;
@@ -2647,14 +2654,21 @@ fn engine_event_channel_disconnect_recovers_mid_turn_ui_state() {
             StatusToastLevel::Error,
             None,
         );
+        app.needs_redraw = true;
     }
 
     // Verify the fix: UI state is fully recovered
     assert!(!app.is_loading, "loading must be cleared");
+    assert!(!app.is_compacting, "compacting must be cleared");
+    assert!(!app.is_purging, "purging must be cleared");
+    assert!(app.active_allowed_tools.is_none());
+    assert!(app.agent_progress.is_empty());
+    assert!(app.agent_activity_started_at.is_none());
     assert!(app.runtime_turn_status.is_none(), "turn status cleared");
     assert!(app.runtime_turn_id.is_none(), "turn id cleared");
     assert!(app.streaming_message_index.is_none());
     assert!(!app.user_scrolled_during_stream);
+    assert!(app.needs_redraw, "needs_redraw must be set");
     let toast = app.status_toasts.back().expect("error toast pushed");
     assert_eq!(toast.level, StatusToastLevel::Error);
     assert!(toast.text.contains("Engine process has terminated"));


### PR DESCRIPTION
## Problem

When the engine task panics (or exits unexpectedly) between `TurnStarted` and `TurnComplete`, the event channel `tx_event` is dropped and the mpsc channel closes silently. The UI's event loop uses `while let Ok(event) = rx.try_recv()` — on `Err(TryRecvError::Disconnected)` the loop simply exits without any recovery. The turn remains stuck with `is_loading=true` and `runtime_turn_status=Some("in_progress")` until the 300-second `TURN_STALL_WATCHDOG_TIMEOUT` fires in `reconcile_turn_liveness()`.

The root cause is in `spawn_supervised` (`utils.rs`): it wraps the future in `catch_unwind`, logs the panic, writes a dump file, and exits — but never sends an `EngineEvent::Error` over the channel. The UI has no way to know the engine died.

## Fix

Add a post-loop check for `TryRecvError::Disconnected` after the existing `while let Ok(event)` event processing loop (`ui.rs`). If the channel is disconnected while `app.is_loading` is true, the UI immediately:
- Finalizes in-flight streaming thinking / assistant / tool cells
- Resets `is_loading`, `runtime_turn_status`, `turn_started_at`, `dispatch_started_at`, etc.
- Pushes an error toast: "Engine process has terminated unexpectedly."

This reduces the recovery window from **300 seconds to ~1 frame** (~16ms).

## Testing

`engine_event_channel_disconnect_recovers_mid_turn_ui_state` — creates a real mpsc channel, drops the sender to simulate engine death, sets up the app in mid-turn state, applies the recovery logic, and verifies the UI state is fully cleaned up.

## Related

Fixes the symptom described in #2583. The root cause of *why* the engine panics can be diagnosed via crash dumps in `~/.codewhale/crashes/`.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an immediate recovery path for when the engine task dies (panics or exits) mid-turn, eliminating the previous 300-second stall window. It hooks into the existing event-loop tick by checking `rx.is_closed()` after the `try_recv` drain loop and resets all in-flight UI state when a disconnect is detected while the app is in a loading/compacting/purging state.

- **`ui.rs`**: Adds a post-drain-loop disconnect guard inside the engine-event read scope; clears all per-turn app flags (`is_loading`, `is_compacting`, `is_purging`, streaming indices, agent progress, etc.), drains pending steers into the visible queue, pushes an error toast, and sets `needs_redraw`.
- **`tests.rs`**: Adds `engine_event_channel_disconnect_recovers_mid_turn_ui_state` which creates a real mpsc channel, drops the sender to simulate engine death, and verifies the resulting app state matches expectations.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the disconnect check is one-shot and self-disabling, uses no await points inside the recovery block, and the guard condition prevents re-firing after cleanup.

The recovery block is logically correct: `rx.is_closed()` reliably returns `true` when all senders are dropped (confirmed by tokio 1.49 docs), the while-drain loop runs first so no buffered events are skipped, and the guard `(is_loading || is_compacting || is_purging)` ensures the block only fires when there is actually live turn state to clean up. Previously-flagged concerns around `needs_redraw` and pending-steer loss are addressed in this version.

No files require special attention beyond what was already discussed in prior review threads.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/ui.rs | Adds a one-shot post-drain disconnect check using `rx.is_closed()`; correctly clears all per-turn UI state, drains pending steers, and triggers an immediate redraw. Guard condition prevents re-firing after the first recovery. |
| crates/tui/src/tui/ui/tests.rs | New test verifies the disconnect recovery behavior end-to-end. The test body inlines the production recovery logic verbatim rather than calling an extracted function, so future divergence won't be caught by the test. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant E as Engine Task
    participant CH as mpsc Channel
    participant UI as UI Event Loop
    participant APP as App State

    E->>CH: TurnStarted
    UI->>CH: try_recv() loop processes TurnStarted
    UI->>APP: "is_loading = true"

    Note over E: Panic / unexpected exit
    E--xCH: tx_event dropped (channel closed)

    loop Each UI tick
        UI->>CH: try_recv() drain loop exits
        UI->>CH: rx.is_closed()?
        CH-->>UI: true
        alt is_loading or is_compacting or is_purging
            UI->>APP: finalize streaming cells
            UI->>APP: reset all per-turn flags
            UI->>APP: drain pending_steers to queue
            UI->>APP: push error toast
            UI->>APP: "needs_redraw = true"
        end
    end
```
</details>

<sub>Reviews (6): Last reviewed commit: ["fix: preserve pending steers on engine d..."](https://github.com/hmbown/codewhale/commit/649d7bc9ab12f10a53edecd866f670bb180ff7c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35105260)</sub>

<!-- /greptile_comment -->