### PR TITLE
feat: add subagent lifecycle hooks

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -709,7 +709,8 @@ default_text_model = "deepseek-ai/deepseek-v4-pro"
 #
 # # Observe sub-agent lifecycle events. These hooks receive bounded JSON
 # # metadata on stdin and are warn-only: failures do not affect sub-agent
-# # scheduling, prompts, or results.
+# # scheduling, prompts, or results. continue_on_error has no effect for
+# # these observer events; later matching hooks always continue.
 # [[hooks.hooks]]
 # name = "subagent-audit"
 # event = "subagent_complete"

--- a/config.example.toml
+++ b/config.example.toml
@@ -678,7 +678,8 @@ default_text_model = "deepseek-ai/deepseek-v4-pro"
 # Configure as `[[hooks.hooks]]` under a `[hooks]` table.
 #
 # Available events: session_start, session_end, message_submit,
-# tool_call_before, tool_call_after, mode_change, on_error, shell_env.
+# tool_call_before, tool_call_after, mode_change, on_error,
+# subagent_spawn, subagent_complete, shell_env.
 #
 # `shell_env` (#456) is special: the hook runs immediately before each
 # `exec_shell` invocation and its stdout is parsed as `KEY=VALUE\n` lines.
@@ -705,6 +706,14 @@ default_text_model = "deepseek-ai/deepseek-v4-pro"
 # command = "aws-vault export my-profile --format=env"
 # # Optionally limit to specific tool names / categories:
 # # condition = { type = "tool_category", category = "shell" }
+#
+# # Observe sub-agent lifecycle events. These hooks receive bounded JSON
+# # metadata on stdin and are warn-only: failures do not affect sub-agent
+# # scheduling, prompts, or results.
+# [[hooks.hooks]]
+# name = "subagent-audit"
+# event = "subagent_complete"
+# command = "~/.codewhale/hooks/subagent-audit.sh"
 
 # ─────────────────────────────────────────────────────────────────────────────────
 # Runtime API (`deepseek serve --http`) (#561)

--- a/crates/tui/src/commands/hooks.rs
+++ b/crates/tui/src/commands/hooks.rs
@@ -63,6 +63,14 @@ fn events() -> CommandResult {
             HookEvent::OnError,
             "fires on transport / capacity / tool errors",
         ),
+        (
+            HookEvent::SubagentSpawn,
+            "fires when a sub-agent starts (observer-only)",
+        ),
+        (
+            HookEvent::SubagentComplete,
+            "fires when a sub-agent completes, fails, or is cancelled (observer-only)",
+        ),
     ];
     for (event, desc) in ordered {
         out.push_str(&format!("  - `{}` — {desc}\n", event_label(event)));
@@ -138,6 +146,8 @@ fn event_label(event: HookEvent) -> &'static str {
         HookEvent::ToolCallAfter => "tool_call_after",
         HookEvent::ModeChange => "mode_change",
         HookEvent::OnError => "on_error",
+        HookEvent::SubagentSpawn => "subagent_spawn",
+        HookEvent::SubagentComplete => "subagent_complete",
         HookEvent::ShellEnv => "shell_env",
     }
 }
@@ -261,6 +271,8 @@ mod tests {
             "tool_call_after",
             "mode_change",
             "on_error",
+            "subagent_spawn",
+            "subagent_complete",
         ]
         .iter()
         .map(|name| {
@@ -298,6 +310,11 @@ mod tests {
         assert_eq!(event_label(HookEvent::MessageSubmit), "message_submit");
         assert_eq!(event_label(HookEvent::ModeChange), "mode_change");
         assert_eq!(event_label(HookEvent::OnError), "on_error");
+        assert_eq!(event_label(HookEvent::SubagentSpawn), "subagent_spawn");
+        assert_eq!(
+            event_label(HookEvent::SubagentComplete),
+            "subagent_complete"
+        );
     }
 
     #[test]

--- a/crates/tui/src/hooks.rs
+++ b/crates/tui/src/hooks.rs
@@ -41,6 +41,10 @@ pub enum HookEvent {
     ModeChange,
     /// Triggered when an error occurs
     OnError,
+    /// Triggered when a sub-agent is spawned
+    SubagentSpawn,
+    /// Triggered when a sub-agent reaches a terminal state
+    SubagentComplete,
     /// Triggered immediately before each `exec_shell` invocation. The hook's
     /// stdout is parsed as `KEY=VALUE\n` lines and merged on top of the
     /// shell command's environment — useful for ephemeral credentials,
@@ -62,6 +66,8 @@ impl HookEvent {
             HookEvent::ToolCallAfter => "tool_call_after",
             HookEvent::ModeChange => "mode_change",
             HookEvent::OnError => "on_error",
+            HookEvent::SubagentSpawn => "subagent_spawn",
+            HookEvent::SubagentComplete => "subagent_complete",
             HookEvent::ShellEnv => "shell_env",
         }
     }
@@ -777,6 +783,59 @@ impl HookExecutor {
         results
     }
 
+    /// Execute observer hooks with a structured JSON stdin payload.
+    ///
+    /// Unlike `message_submit`, stdout is deliberately ignored by callers:
+    /// these hooks are lifecycle observers and cannot mutate or block the
+    /// underlying action.
+    pub fn execute_json_observer(
+        &self,
+        event: HookEvent,
+        context: &HookContext,
+        payload: &serde_json::Value,
+    ) -> Vec<HookResult> {
+        if !self.config.enabled {
+            return Vec::new();
+        }
+
+        let hooks = self.config.hooks_for_event(event);
+        if hooks.is_empty() {
+            return Vec::new();
+        }
+
+        let env_vars = context.to_env_vars();
+        let mut results = Vec::new();
+        for hook in hooks {
+            if !self.matches_condition(hook, context) {
+                continue;
+            }
+
+            let result = if hook.background {
+                self.execute_background_with_stdin(hook, &env_vars, payload)
+            } else {
+                self.execute_sync_with_stdin(hook, &env_vars, payload)
+            };
+
+            if !result.success {
+                let label = result.name.as_deref().unwrap_or("(unnamed)");
+                tracing::warn!(
+                    target: "hooks",
+                    hook = label,
+                    event = event.as_str(),
+                    exit_code = ?result.exit_code,
+                    duration_ms = result.duration.as_millis() as u64,
+                    error = result.error.as_deref().unwrap_or(""),
+                    stderr_head = %result.stderr.lines().next().unwrap_or(""),
+                    "observer hook failed"
+                );
+            }
+
+            results.push(result);
+        }
+
+        results
+    }
+
     /// Check if a hook's condition matches the context
     #[allow(clippy::only_used_in_recursion)]
     fn matches_condition(&self, hook: &Hook, context: &HookContext) -> bool {
@@ -949,6 +1008,24 @@ impl HookExecutor {
 
     /// Execute a hook in the background (non-blocking)
     fn execute_background(&self, hook: &Hook, env_vars: &HashMap<String, String>) -> HookResult {
+        self.execute_background_inner(hook, env_vars, None)
+    }
+
+    fn execute_background_with_stdin(
+        &self,
+        hook: &Hook,
+        env_vars: &HashMap<String, String>,
+        stdin_json: &serde_json::Value,
+    ) -> HookResult {
+        self.execute_background_inner(hook, env_vars, Some(stdin_json))
+    }
+
+    fn execute_background_inner(
+        &self,
+        hook: &Hook,
+        env_vars: &HashMap<String, String>,
+        stdin_json: Option<&serde_json::Value>,
+    ) -> HookResult {
         let started = Instant::now();
         let working_dir = self
             .config
@@ -956,16 +1033,45 @@ impl HookExecutor {
             .clone()
             .unwrap_or_else(|| self.default_working_dir.clone());
 
+        let stdin_bytes = match stdin_json.map(serde_json::to_vec).transpose() {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                return HookResult {
+                    name: hook.name.clone(),
+                    success: false,
+                    exit_code: None,
+                    stdout: String::new(),
+                    stderr: String::new(),
+                    duration: started.elapsed(),
+                    error: Some(format!("Failed to encode hook stdin: {e}")),
+                };
+            }
+        };
         let cmd = hook.command.clone();
         let env = env_vars.clone();
         let wd = working_dir.clone();
 
         // Spawn in a detached thread
         std::thread::spawn(move || {
-            let _ = HookExecutor::build_shell_command(&cmd)
+            let mut command = HookExecutor::build_shell_command(&cmd);
+            command
                 .current_dir(&wd)
                 .envs(&env)
-                .output();
+                .stdout(Stdio::null())
+                .stderr(Stdio::null());
+            if stdin_bytes.is_some() {
+                command.stdin(Stdio::piped());
+            }
+
+            let Ok(mut child) = command.spawn() else {
+                return;
+            };
+            if let (Some(mut bytes), Some(mut stdin)) = (stdin_bytes, child.stdin.take()) {
+                bytes.push(b'\n');
+                let _ = stdin.write_all(&bytes);
+                let _ = stdin.flush();
+            }
+            let _ = child.wait();
         });
 
         // Return immediately with success (background execution is fire-and-forget)
@@ -1237,6 +1343,8 @@ NOEQUAL line dropped
         assert_eq!(HookEvent::SessionStart.as_str(), "session_start");
         assert_eq!(HookEvent::ToolCallAfter.as_str(), "tool_call_after");
         assert_eq!(HookEvent::ModeChange.as_str(), "mode_change");
+        assert_eq!(HookEvent::SubagentSpawn.as_str(), "subagent_spawn");
+        assert_eq!(HookEvent::SubagentComplete.as_str(), "subagent_complete");
     }
 
     #[test]
@@ -1421,6 +1529,107 @@ printf '\ndone:%s\n' "${#payload}"
             .with_mode("agent")
             .with_model("deepseek-test")
             .with_tokens(42)
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn json_observer_hook_receives_structured_stdin() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let out = dir.path().join("payload.json");
+        let command = write_hook_script(
+            &dir,
+            "capture_observer.sh",
+            &format!(
+                r#"#!/bin/sh
+cat > "{}"
+"#,
+                out.display()
+            ),
+        );
+        let executor = HookExecutor::new(
+            HooksConfig {
+                enabled: true,
+                hooks: vec![Hook::new(HookEvent::SubagentSpawn, &command)],
+                ..Default::default()
+            },
+            dir.path().to_path_buf(),
+        );
+        let payload = json!({
+            "event": "subagent_spawn",
+            "agent_id": "agent_123",
+            "prompt_preview": "inspect this",
+            "prompt_truncated": false,
+        });
+
+        let results = executor.execute_json_observer(
+            HookEvent::SubagentSpawn,
+            &submit_context(&dir),
+            &payload,
+        );
+
+        assert_eq!(results.len(), 1);
+        assert!(results[0].success);
+        let captured: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(out).expect("payload written"))
+                .expect("valid JSON payload");
+        assert_eq!(captured["event"], "subagent_spawn");
+        assert_eq!(captured["agent_id"], "agent_123");
+        assert_eq!(captured["prompt_preview"], "inspect this");
+        assert_eq!(captured["prompt_truncated"], false);
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn json_observer_hook_failure_does_not_stop_later_hooks() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let marker = dir.path().join("later-ran");
+        let failing = write_hook_script(
+            &dir,
+            "failing_observer.sh",
+            r#"#!/bin/sh
+echo boom >&2
+exit 1
+"#,
+        );
+        let later = write_hook_script(
+            &dir,
+            "later_observer.sh",
+            &format!(
+                r#"#!/bin/sh
+cat > "{}"
+"#,
+                marker.display()
+            ),
+        );
+        let mut first = Hook::new(HookEvent::SubagentComplete, &failing);
+        first.continue_on_error = false;
+        let executor = HookExecutor::new(
+            HooksConfig {
+                enabled: true,
+                hooks: vec![first, Hook::new(HookEvent::SubagentComplete, &later)],
+                ..Default::default()
+            },
+            dir.path().to_path_buf(),
+        );
+        let payload = json!({
+            "event": "subagent_complete",
+            "agent_id": "agent_456",
+            "status": "completed",
+        });
+
+        let results = executor.execute_json_observer(
+            HookEvent::SubagentComplete,
+            &submit_context(&dir),
+            &payload,
+        );
+
+        assert_eq!(results.len(), 2);
+        assert!(!results[0].success);
+        assert!(results[1].success);
+        assert!(
+            marker.exists(),
+            "observer failures must be warn-only and non-blocking"
+        );
     }
 
     #[cfg(not(windows))]
@@ -1703,6 +1912,8 @@ exit 7
             HookEvent::ToolCallAfter,
             HookEvent::ModeChange,
             HookEvent::OnError,
+            HookEvent::SubagentSpawn,
+            HookEvent::SubagentComplete,
         ] {
             assert!(
                 !executor.has_hooks_for_event(event),

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -687,7 +687,12 @@ fn execute_subagent_observer_hook(
         );
     }
 
-    let _ = app.hooks.execute_json_observer(event, &context, &payload);
+    let hooks = app.hooks.clone();
+    let _ = std::thread::Builder::new()
+        .name(format!("{}-observer-hook", event.as_str()))
+        .spawn(move || {
+            let _ = hooks.execute_json_observer(event, &context, &payload);
+        });
 }
 
 fn bounded_subagent_hook_preview(text: &str) -> (String, bool) {
@@ -707,16 +712,31 @@ fn subagent_completion_status(result: &str) -> Option<String> {
     const START: &str = "<codewhale:subagent.done>";
     const END: &str = "</codewhale:subagent.done>";
 
-    let start = result.find(START)? + START.len();
-    let end = result[start..].find(END)? + start;
-    serde_json::from_str::<serde_json::Value>(&result[start..end])
-        .ok()
-        .and_then(|value| {
-            value
-                .get("status")
-                .and_then(serde_json::Value::as_str)
-                .map(str::to_string)
-        })
+    if let Some(start) = result.find(START).map(|idx| idx + START.len())
+        && let Some(end) = result[start..].find(END).map(|idx| idx + start)
+        && let Ok(value) = serde_json::from_str::<serde_json::Value>(&result[start..end])
+        && let Some(status) = value.get("status").and_then(serde_json::Value::as_str)
+    {
+        return Some(status.to_string());
+    }
+
+    let summary = result.lines().find_map(|line| {
+        let trimmed = line.trim();
+        (!trimmed.is_empty()).then_some(trimmed)
+    })?;
+    let summary = summary.to_ascii_lowercase();
+    if matches!(summary.as_str(), "cancelled" | "canceled")
+        || summary.starts_with("cancelled:")
+        || summary.starts_with("canceled:")
+    {
+        Some("cancelled".to_string())
+    } else if summary == "failed" || summary.starts_with("failed:") {
+        Some("failed".to_string())
+    } else if summary == "interrupted" || summary.starts_with("interrupted:") {
+        Some("interrupted".to_string())
+    } else {
+        None
+    }
 }
 
 struct TerminalCleanupGuard {

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -148,6 +148,7 @@ const CONTEXT_CRITICAL_THRESHOLD_PERCENT: f64 = 95.0;
 const CONTEXT_SUGGEST_COMPACT_THRESHOLD_PERCENT: f64 = 60.0;
 const UI_IDLE_POLL_MS: u64 = 48;
 const UI_ACTIVE_POLL_MS: u64 = 24;
+const SUBAGENT_HOOK_PREVIEW_LIMIT: usize = 2_048;
 const WEB_CONFIG_POLL_MS: u64 = 16;
 const DISPATCH_WATCHDOG_TIMEOUT: Duration = Duration::from_secs(30);
 /// Maximum wall-clock time a turn may stay in `"in_progress"` before the UI
@@ -645,6 +646,77 @@ fn terminal_probe_timeout(config: &Config) -> Duration {
         .unwrap_or(DEFAULT_TERMINAL_PROBE_TIMEOUT_MS)
         .clamp(100, 5_000);
     Duration::from_millis(timeout_ms)
+}
+
+fn execute_subagent_observer_hook(
+    app: &App,
+    event: HookEvent,
+    agent_id: &str,
+    text_field: &str,
+    text: &str,
+) {
+    if !app.hooks.has_hooks_for_event(event) {
+        return;
+    }
+
+    let (preview, truncated) = bounded_subagent_hook_preview(text);
+    let context = app.base_hook_context().with_message(&preview);
+    let mut payload = serde_json::json!({
+        "event": event.as_str(),
+        "agent_id": agent_id,
+        "session_id": context.session_id.as_deref(),
+        "workspace": context.workspace.as_ref().map(|path| path.display().to_string()),
+        "mode": context.mode.as_deref(),
+        "model": context.model.as_deref(),
+        "total_tokens": context.total_tokens,
+    });
+    if let Some(object) = payload.as_object_mut() {
+        object.insert(
+            format!("{text_field}_preview"),
+            serde_json::Value::String(preview),
+        );
+        object.insert(
+            format!("{text_field}_truncated"),
+            serde_json::Value::Bool(truncated),
+        );
+    }
+
+    if event == HookEvent::SubagentComplete {
+        payload["status"] = serde_json::Value::String(
+            subagent_completion_status(text).unwrap_or_else(|| "unknown".to_string()),
+        );
+    }
+
+    let _ = app.hooks.execute_json_observer(event, &context, &payload);
+}
+
+fn bounded_subagent_hook_preview(text: &str) -> (String, bool) {
+    if text.len() <= SUBAGENT_HOOK_PREVIEW_LIMIT {
+        return (text.to_string(), false);
+    }
+    let safe_end = text
+        .char_indices()
+        .take_while(|(idx, ch)| idx + ch.len_utf8() <= SUBAGENT_HOOK_PREVIEW_LIMIT)
+        .last()
+        .map(|(idx, ch)| idx + ch.len_utf8())
+        .unwrap_or(0);
+    (format!("{}...[truncated]", &text[..safe_end]), true)
+}
+
+fn subagent_completion_status(result: &str) -> Option<String> {
+    const START: &str = "<codewhale:subagent.done>";
+    const END: &str = "</codewhale:subagent.done>";
+
+    let start = result.find(START)? + START.len();
+    let end = result[start..].find(END)? + start;
+    serde_json::from_str::<serde_json::Value>(&result[start..end])
+        .ok()
+        .and_then(|value| {
+            value
+                .get("status")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string)
+        })
 }
 
 struct TerminalCleanupGuard {
@@ -1969,6 +2041,13 @@ async fn run_event_loop(
                     }
                     EngineEvent::AgentSpawned { id, prompt } => {
                         let prompt_summary = summarize_tool_output(&prompt);
+                        execute_subagent_observer_hook(
+                            app,
+                            HookEvent::SubagentSpawn,
+                            &id,
+                            "prompt",
+                            &prompt,
+                        );
                         app.agent_progress
                             .insert(id.clone(), format!("starting: {prompt_summary}"));
                         if app.agent_activity_started_at.is_none() {
@@ -1993,6 +2072,13 @@ async fn run_event_loop(
                         app.status_message = Some(format!("Sub-agent {id}: {display}"));
                     }
                     EngineEvent::AgentComplete { id, result } => {
+                        execute_subagent_observer_hook(
+                            app,
+                            HookEvent::SubagentComplete,
+                            &id,
+                            "result",
+                            &result,
+                        );
                         let subagent_elapsed = app
                             .agent_activity_started_at
                             .or(app.turn_started_at)

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -2816,6 +2816,22 @@ fn subagent_completion_status_reads_done_sentinel() {
 }
 
 #[test]
+fn subagent_completion_status_reads_summary_fallbacks() {
+    assert_eq!(
+        subagent_completion_status("Cancelled").as_deref(),
+        Some("cancelled")
+    );
+    assert_eq!(
+        subagent_completion_status("Failed: tool timed out").as_deref(),
+        Some("failed")
+    );
+    assert_eq!(
+        subagent_completion_status("Interrupted: process restarted").as_deref(),
+        Some("interrupted")
+    );
+}
+
+#[test]
 fn running_agent_count_unions_cache_and_progress() {
     let mut app = create_test_app();
     app.subagent_cache = vec![

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -2792,6 +2792,30 @@ fn sort_subagents_orders_running_before_terminal_statuses() {
 }
 
 #[test]
+fn subagent_hook_preview_is_bounded_on_char_boundaries() {
+    let text = format!("{}{}", "鲸".repeat(900), "tail");
+
+    let (preview, truncated) = bounded_subagent_hook_preview(&text);
+
+    assert!(truncated);
+    assert!(preview.ends_with("...[truncated]"));
+    assert!(preview.len() <= SUBAGENT_HOOK_PREVIEW_LIMIT + "...[truncated]".len());
+    assert!(preview.is_char_boundary(preview.len()));
+}
+
+#[test]
+fn subagent_completion_status_reads_done_sentinel() {
+    let result = r#"done
+<codewhale:subagent.done>{"agent_id":"agent_x","status":"completed"}</codewhale:subagent.done>"#;
+
+    assert_eq!(
+        subagent_completion_status(result).as_deref(),
+        Some("completed")
+    );
+    assert_eq!(subagent_completion_status("no sentinel"), None);
+}
+
+#[test]
 fn running_agent_count_unions_cache_and_progress() {
     let mut app = create_test_app();
     app.subagent_cache = vec![

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -484,6 +484,58 @@ the message. Existing environment variables remain available.
 `shell_env` hooks keep their existing `KEY=VALUE` stdout contract;
 the JSON stdout contract applies only to `message_submit`.
 
+### Sub-agent lifecycle hooks
+
+`subagent_spawn` and `subagent_complete` hooks observe sub-agent lifecycle
+events. They receive bounded JSON metadata on stdin and are observer-only:
+hook failures are logged as warnings and do not block sub-agent scheduling,
+change prompts, or change results.
+
+```toml
+[[hooks.hooks]]
+event = "subagent_complete"
+command = "~/.codewhale/hooks/subagent-audit.sh"
+timeout_secs = 2
+continue_on_error = true
+```
+
+`subagent_spawn` receives:
+
+```json
+{
+  "event": "subagent_spawn",
+  "agent_id": "agent_12345678",
+  "session_id": "sess_12345678",
+  "workspace": "/path/to/workspace",
+  "mode": "agent",
+  "model": "deepseek-chat",
+  "total_tokens": 1234,
+  "prompt_preview": "bounded prompt preview",
+  "prompt_truncated": false
+}
+```
+
+`subagent_complete` receives the same common fields plus terminal metadata:
+
+```json
+{
+  "event": "subagent_complete",
+  "agent_id": "agent_12345678",
+  "session_id": "sess_12345678",
+  "workspace": "/path/to/workspace",
+  "mode": "agent",
+  "model": "deepseek-chat",
+  "total_tokens": 1234,
+  "status": "completed",
+  "result_preview": "bounded result preview",
+  "result_truncated": false
+}
+```
+
+Previews are capped before delivery so lifecycle hooks do not receive full
+sub-agent prompts, transcripts, or unbounded results. Use `agent_eval` from a
+normal model/tool flow when full sub-agent details are needed.
+
 ### Composer stash (`/stash`, Ctrl+S)
 
 Press **Ctrl+S** in the composer to park the current draft to

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -489,7 +489,9 @@ the JSON stdout contract applies only to `message_submit`.
 `subagent_spawn` and `subagent_complete` hooks observe sub-agent lifecycle
 events. They receive bounded JSON metadata on stdin and are observer-only:
 hook failures are logged as warnings and do not block sub-agent scheduling,
-change prompts, or change results.
+change prompts, or change results. For these observer events,
+`continue_on_error` has no effect: later matching hooks still run even when an
+earlier hook exits non-zero.
 
 ```toml
 [[hooks.hooks]]


### PR DESCRIPTION
## Summary

- Add `subagent_spawn` and `subagent_complete` lifecycle hook events.
- Execute sub-agent lifecycle hooks as observer-only JSON-stdin hooks with bounded prompt/result previews.
- Document the new hook payloads and expose the events in `/hooks events`.

Refs #1364 (partial: Phase 3 sub-agent observer hooks only).

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features`
- [x] `cargo check`
- [x] `cargo test -p codewhale-tui hooks --all-features`
- [x] `cargo test -p codewhale-tui subagent_hook --all-features`
- [x] `cargo test -p codewhale-tui subagent_completion_status --all-features`
- [ ] `cargo test --workspace --all-features` attempted with `HOME=/private/tmp/codewhale-test-home CARGO_HOME=/Users/aresning/.cargo`; failed in existing environment-dependent TUI tests unrelated to this change:
  - `sandbox::tests::test_parity_macos_seatbelt_available`
  - `tools::file::tests::read_file_ocr_extracts_text_from_image_when_backend_exists`
  - `tools::image_ocr::tests::image_ocr_recovers_hello_from_fixture_image`
  - `tools::shell::tests::background_tty_command_has_controlling_terminal`

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes

## Scope

Observer-only sub-agent hook exposure. This does not gate sub-agent spawn, mutate sub-agent prompts/results, or change sub-agent scheduling.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces `subagent_spawn` and `subagent_complete` as observer-only lifecycle hook events. Hooks receive a bounded JSON stdin payload, hook failures are warn-logged but never block sub-agent scheduling, and `continue_on_error` is explicitly documented as a no-op for these events.

- `execute_json_observer` is added to `HookExecutor` as a new execution path that always continues past failures; `execute_background` is refactored into an inner function that accepts optional JSON stdin to avoid code duplication.
- `execute_subagent_observer_hook` in `ui.rs` wires into `AgentSpawned`/`AgentComplete` engine events, previews the prompt/result to a 2 048-byte boundary-safe limit, derives completion status from the `<codewhale:subagent.done>` sentinel (or keyword fallbacks), and fans out to a background thread per event.
- Documentation and the example config are updated with payload schemas and a clear note that `continue_on_error` has no effect on observer events.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The new hook events are observer-only and cannot affect sub-agent scheduling, prompts, or results.

The implementation is well-isolated: execute_json_observer never blocks the calling code, hook failures are demoted to warnings, and the bounded preview logic is verified against UTF-8 char boundaries. The completion-status parser correctly uses the full result string so sentinel detection works regardless of where the sentinel falls. Test coverage is thorough. The only cosmetic gap is thread names that exceed the Linux 15-char limit, which silently truncates without affecting behaviour.

No files require special attention. The thread-name truncation in crates/tui/src/tui/ui.rs is cosmetic and does not affect runtime behaviour.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/hooks.rs | Adds SubagentSpawn/SubagentComplete enum variants, their as_str() mappings, and execute_json_observer() — a warn-only hook runner that always continues past failures; also refactors execute_background into an inner function accepting optional JSON stdin. Well-structured with good test coverage. |
| crates/tui/src/tui/ui.rs | Adds execute_subagent_observer_hook(), bounded_subagent_hook_preview(), and subagent_completion_status(); hooks into AgentSpawned/AgentComplete events in the event loop. Thread names exceed the Linux 15-char POSIX limit (28–31 chars), though the thread still spawns with a silently truncated name. |
| crates/tui/src/tui/ui/tests.rs | New tests cover: preview truncation on UTF-8 char boundaries, sentinel-based status parsing, and text-based fallback status detection. Coverage is thorough for the added helpers. |
| crates/tui/src/commands/hooks.rs | Adds SubagentSpawn and SubagentComplete to the /hooks events listing and event_label(); tests updated to match. Straightforward extension of the existing pattern. |
| docs/CONFIGURATION.md | Documents the two new observer events, their JSON payloads, and the observer-only semantics including the note that continue_on_error has no effect. Clear and accurate. |
| config.example.toml | Updates the event list comment and adds an annotated example for subagent_complete, explicitly calling out the observer-only semantics and the continue_on_error no-op behaviour. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant EL as Event Loop (async)
    participant OH as execute_subagent_observer_hook
    participant OT as observer thread
    participant HE as HookExecutor::execute_json_observer
    participant BT as background hook thread (optional)
    participant HP as hook process

    EL->>OH: "AgentSpawned { id, prompt }"
    OH->>OH: bounded_subagent_hook_preview(prompt)
    OH->>OH: build JSON payload
    OH->>OT: std::thread::spawn
    EL-->>EL: continues immediately

    OT->>HE: execute_json_observer(SubagentSpawn, ctx, payload)
    alt "hook.background = false"
        HE->>HP: spawn + write JSON stdin + wait
        HP-->>HE: exit code
        HE-->>OT: HookResult
    else "hook.background = true"
        HE->>BT: std::thread::spawn
        BT->>HP: spawn + write JSON stdin + wait
        HE-->>OT: "HookResult { success: true }"
    end

    EL->>OH: "AgentComplete { id, result }"
    OH->>OH: bounded_subagent_hook_preview(result)
    OH->>OH: subagent_completion_status(result)
    OH->>OH: build JSON payload
    OH->>OT: std::thread::spawn
    EL-->>EL: continues immediately
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%221364-phase3-subagent-hooks%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%221364-phase3-subagent-hooks%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui.rs%3A691-693%0AThread%20names%20%60%22subagent_spawn-observer-hook%22%60%20%2828%20chars%29%20and%20%60%22subagent_complete-observer-hook%22%60%20%2831%20chars%29%20exceed%20the%2015-character%20limit%20imposed%20by%20Linux's%20%60PR_SET_NAME%60%20%2F%20%60pthread_setname_np%60.%20Rust's%20stdlib%20silently%20truncates%20to%2015%20chars%2C%20so%20in%20%60%2Fproc%60%2C%20%60htop%60%2C%20or%20a%20debugger%20these%20threads%20both%20appear%20as%20the%20indistinguishable%20%60%22subagent_spawn-%22%60.%20Keeping%20names%20at%20or%20under%2015%20characters%20makes%20them%20readable%20without%20abbreviation.%0A%0A%60%60%60suggestion%0A%20%20%20%20let%20_%20%3D%20std%3A%3Athread%3A%3ABuilder%3A%3Anew%28%29%0A%20%20%20%20%20%20%20%20.name%28format!%28%22%7B%7D-obs%22%2C%20event.as_str%28%29%29%29%0A%20%20%20%20%20%20%20%20.spawn%28move%20%7C%7C%20%7B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui.rs%3A691-693%0AThread%20names%20%60%22subagent_spawn-observer-hook%22%60%20%2828%20chars%29%20and%20%60%22subagent_complete-observer-hook%22%60%20%2831%20chars%29%20exceed%20the%2015-character%20limit%20imposed%20by%20Linux's%20%60PR_SET_NAME%60%20%2F%20%60pthread_setname_np%60.%20Rust's%20stdlib%20silently%20truncates%20to%2015%20chars%2C%20so%20in%20%60%2Fproc%60%2C%20%60htop%60%2C%20or%20a%20debugger%20these%20threads%20both%20appear%20as%20the%20indistinguishable%20%60%22subagent_spawn-%22%60.%20Keeping%20names%20at%20or%20under%2015%20characters%20makes%20them%20readable%20without%20abbreviation.%0A%0A%60%60%60suggestion%0A%20%20%20%20let%20_%20%3D%20std%3A%3Athread%3A%3ABuilder%3A%3Anew%28%29%0A%20%20%20%20%20%20%20%20.name%28format!%28%22%7B%7D-obs%22%2C%20event.as_str%28%29%29%29%0A%20%20%20%20%20%20%20%20.spawn%28move%20%7C%7C%20%7B%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2586&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui.rs%3A691-693%0AThread%20names%20%60%22subagent_spawn-observer-hook%22%60%20%2828%20chars%29%20and%20%60%22subagent_complete-observer-hook%22%60%20%2831%20chars%29%20exceed%20the%2015-character%20limit%20imposed%20by%20Linux's%20%60PR_SET_NAME%60%20%2F%20%60pthread_setname_np%60.%20Rust's%20stdlib%20silently%20truncates%20to%2015%20chars%2C%20so%20in%20%60%2Fproc%60%2C%20%60htop%60%2C%20or%20a%20debugger%20these%20threads%20both%20appear%20as%20the%20indistinguishable%20%60%22subagent_spawn-%22%60.%20Keeping%20names%20at%20or%20under%2015%20characters%20makes%20them%20readable%20without%20abbreviation.%0A%0A%60%60%60suggestion%0A%20%20%20%20let%20_%20%3D%20std%3A%3Athread%3A%3ABuilder%3A%3Anew%28%29%0A%20%20%20%20%20%20%20%20.name%28format!%28%22%7B%7D-obs%22%2C%20event.as_str%28%29%29%29%0A%20%20%20%20%20%20%20%20.spawn%28move%20%7C%7C%20%7B%0A%60%60%60%0A%0A&pr=2586&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix: address subagent hook review feedba..."](https://github.com/hmbown/codewhale/commit/3c75cdfa8aa7f6caaefc98eeb30a753c363b0581) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35116500)</sub>

<!-- /greptile_comment -->