### PR TITLE
fix(tui): send /attach images as multimodal content

### DIFF
--- a/crates/tui/src/client/chat.rs
+++ b/crates/tui/src/client/chat.rs
@@ -767,6 +767,31 @@ fn message_content_for_inspect(message: &Value) -> String {
     {
         parts.push(content.to_string());
     }
+    if let Some(content) = message.get("content").and_then(Value::as_array) {
+        for part in content {
+            match part.get("type").and_then(Value::as_str) {
+                Some("text") => {
+                    if let Some(text) = part.get("text").and_then(Value::as_str)
+                        && !text.is_empty()
+                    {
+                        parts.push(text.to_string());
+                    }
+                }
+                Some("image_url") => {
+                    let url = part
+                        .get("image_url")
+                        .and_then(|image_url| image_url.get("url"))
+                        .and_then(Value::as_str)
+                        .unwrap_or("");
+                    parts.push(format!(
+                        "[image_url:{}]",
+                        summarize_image_url_for_inspect(url)
+                    ));
+                }
+                _ => {}
+            }
+        }
+    }
     if let Some(reasoning) = message.get("reasoning_content").and_then(Value::as_str)
         && !reasoning.is_empty()
     {
@@ -776,6 +801,13 @@ fn message_content_for_inspect(message: &Value) -> String {
         parts.push(tool_calls.to_string());
     }
     parts.join("\n")
+}
+
+fn summarize_image_url_for_inspect(url: &str) -> String {
+    let Some((prefix, encoded)) = url.split_once(";base64,") else {
+        return first_chars(url, 96);
+    };
+    format!("{prefix};base64,<{} chars>", encoded.len())
 }
 
 fn tool_result_inspection_for_message(message: &Value) -> Option<ToolResultInspection> {
@@ -1264,6 +1296,7 @@ fn build_chat_messages_with_reasoning(
     for (message_index, message) in messages.iter().enumerate() {
         let role = message.role.as_str();
         let mut text_parts = Vec::new();
+        let mut image_parts = Vec::new();
         let mut thinking_parts = Vec::new();
         let mut tool_calls = Vec::new();
         let mut tool_call_infos = Vec::new();
@@ -1281,6 +1314,14 @@ fn build_chat_messages_with_reasoning(
                     } else {
                         text_parts.push(text.clone());
                     }
+                }
+                ContentBlock::ImageUrl { image_url } => {
+                    image_parts.push(json!({
+                        "type": "image_url",
+                        "image_url": {
+                            "url": image_url.url.clone(),
+                        },
+                    }));
                 }
                 ContentBlock::Thinking { thinking } => thinking_parts.push(thinking.clone()),
                 ContentBlock::ToolUse {
@@ -1395,10 +1436,25 @@ fn build_chat_messages_with_reasoning(
             }
         } else if role == "user" {
             let content = text_parts.join("\n");
-            if !content.trim().is_empty() {
+            let has_text = !content.trim().is_empty();
+            let has_images = !image_parts.is_empty();
+            if has_text || has_images {
+                let wire_content = if has_images {
+                    let mut parts = Vec::new();
+                    if has_text {
+                        parts.push(json!({
+                            "type": "text",
+                            "text": content,
+                        }));
+                    }
+                    parts.extend(image_parts);
+                    json!(parts)
+                } else {
+                    json!(content)
+                };
                 let mut msg = json!({
                     "role": "user",
-                    "content": content,
+                    "content": wire_content,
                 });
                 if include_tool_budget_metadata && let Some(turn_meta) = &turn_meta_budget {
                     msg["_turn_meta_budget"] = turn_meta_budget_json(turn_meta);
@@ -2011,6 +2067,7 @@ fn build_stream_events(response: &MessageResponse) -> Vec<StreamEvent> {
                 events.push(StreamEvent::ContentBlockStop { index });
             }
             ContentBlock::ToolResult { .. } => {}
+            ContentBlock::ImageUrl { .. } => {}
             ContentBlock::ServerToolUse { id, name, input } => {
                 events.push(StreamEvent::ContentBlockStart {
                     index,
@@ -2791,6 +2848,40 @@ mod stream_decoder_tests {
         assert_eq!(built.len(), 1);
         assert_eq!(built[0]["role"], "system");
         assert_eq!(built[0]["content"], "internal runtime event");
+    }
+
+    #[test]
+    fn request_builder_emits_openai_image_url_parts_for_user_images() {
+        let messages = vec![Message {
+            role: "user".to_string(),
+            content: vec![
+                ContentBlock::Text {
+                    text: "what is in this image?".to_string(),
+                    cache_control: None,
+                },
+                ContentBlock::ImageUrl {
+                    image_url: crate::models::ImageUrlContent {
+                        url: "data:image/png;base64,YWJj".to_string(),
+                    },
+                },
+            ],
+        }];
+
+        let built = build_chat_messages(None, &messages, "mimo-v2.5");
+
+        assert_eq!(built.len(), 1);
+        assert_eq!(built[0]["role"], "user");
+        let content = built[0]["content"].as_array().expect("content parts");
+        assert_eq!(
+            content,
+            &vec![
+                json!({"type": "text", "text": "what is in this image?"}),
+                json!({
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/png;base64,YWJj"}
+                }),
+            ]
+        );
     }
 
     fn tool_use_message(id: &str, name: &str, input: Value) -> Message {

--- a/crates/tui/src/compaction.rs
+++ b/crates/tui/src/compaction.rs
@@ -288,12 +288,26 @@ fn message_text(msg: &Message) -> String {
             ContentBlock::ToolResult { content, .. } => {
                 let _ = writeln!(text, "{content}");
             }
+            ContentBlock::ImageUrl { image_url } => {
+                let _ = writeln!(
+                    text,
+                    "[image_url:{}]",
+                    image_url_summary_for_compaction(&image_url.url)
+                );
+            }
             ContentBlock::ServerToolUse { .. }
             | ContentBlock::ToolSearchToolResult { .. }
             | ContentBlock::CodeExecutionToolResult { .. } => {}
         }
     }
     text
+}
+
+fn image_url_summary_for_compaction(url: &str) -> String {
+    let Some((prefix, encoded)) = url.split_once(";base64,") else {
+        return truncate_chars(url, 96).to_string();
+    };
+    format!("{prefix};base64,<{} chars>", encoded.len())
 }
 
 fn is_user_text_query(msg: &Message) -> bool {
@@ -312,6 +326,7 @@ fn extract_paths_from_message(message: &Message, workspace: Option<&Path>) -> Ve
             ContentBlock::ToolResult { content, .. } => extract_paths_from_text(content, workspace),
             ContentBlock::ToolUse { input, .. } => extract_paths_from_tool_input(input, workspace),
             ContentBlock::Thinking { .. } => Vec::new(),
+            ContentBlock::ImageUrl { .. } => Vec::new(),
             ContentBlock::ServerToolUse { .. }
             | ContentBlock::ToolSearchToolResult { .. }
             | ContentBlock::CodeExecutionToolResult { .. } => Vec::new(),
@@ -585,6 +600,7 @@ fn estimate_tokens_for_message(message: &Message, include_thinking: bool) -> usi
                 .map(|s| s.len() / 4)
                 .unwrap_or(100),
             ContentBlock::ToolResult { content, .. } => content.len() / 4,
+            ContentBlock::ImageUrl { image_url } => (image_url.url.len() / 4).max(1),
             ContentBlock::ServerToolUse { .. }
             | ContentBlock::ToolSearchToolResult { .. }
             | ContentBlock::CodeExecutionToolResult { .. } => 0,
@@ -1380,6 +1396,13 @@ fn build_formatted_summary_request(
                 ContentBlock::ToolResult { content, .. } => {
                     let snippet = truncate_chars(content, limits.tool_result_snippet_chars);
                     let _ = write!(conversation_text, "Tool result: {snippet}\n\n");
+                }
+                ContentBlock::ImageUrl { image_url } => {
+                    let _ = write!(
+                        conversation_text,
+                        "{role}: [Attached image: {}]\n\n",
+                        image_url_summary_for_compaction(&image_url.url)
+                    );
                 }
                 ContentBlock::Thinking { .. } => {
                     // Skip thinking blocks in summary

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -1249,20 +1249,25 @@ impl Engine {
         reasoning_effort: Option<&str>,
         reasoning_effort_auto: bool,
     ) -> Message {
+        let mut content = vec![
+            self.turn_metadata_block(
+                routed_model,
+                auto_model,
+                reasoning_effort,
+                reasoning_effort_auto,
+            ),
+            ContentBlock::Text {
+                text: text.clone(),
+                cache_control: None,
+            },
+        ];
+        content.extend(crate::tui::file_mention::media_attachment_content_blocks(
+            &text,
+        ));
+
         Message {
             role: "user".to_string(),
-            content: vec![
-                self.turn_metadata_block(
-                    routed_model,
-                    auto_model,
-                    reasoning_effort,
-                    reasoning_effort_auto,
-                ),
-                ContentBlock::Text {
-                    text,
-                    cache_control: None,
-                },
-            ],
+            content,
         }
     }
 

--- a/crates/tui/src/core/engine/capacity_flow.rs
+++ b/crates/tui/src/core/engine/capacity_flow.rs
@@ -224,6 +224,7 @@ impl Engine {
                         }
                     }
                     ContentBlock::Thinking { .. }
+                    | ContentBlock::ImageUrl { .. }
                     | ContentBlock::ServerToolUse { .. }
                     | ContentBlock::ToolSearchToolResult { .. }
                     | ContentBlock::CodeExecutionToolResult { .. } => {}

--- a/crates/tui/src/models.rs
+++ b/crates/tui/src/models.rs
@@ -71,6 +71,12 @@ pub struct Message {
     pub content: Vec<ContentBlock>,
 }
 
+/// OpenAI-compatible image URL payload inside a multimodal message.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct ImageUrlContent {
+    pub url: String,
+}
+
 /// A single content block inside a message.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(tag = "type")]
@@ -81,6 +87,8 @@ pub enum ContentBlock {
         #[serde(skip_serializing_if = "Option::is_none")]
         cache_control: Option<CacheControl>,
     },
+    #[serde(rename = "image_url")]
+    ImageUrl { image_url: ImageUrlContent },
     #[serde(rename = "thinking")]
     Thinking { thinking: String },
     #[serde(rename = "tool_use")]

--- a/crates/tui/src/purge.rs
+++ b/crates/tui/src/purge.rs
@@ -192,6 +192,13 @@ fn format_content_block(buf: &mut String, blk_idx: usize, block: &ContentBlock) 
             // Omit thinking blocks — API-mandated on tool-call messages;
             // the agent cannot remove them, so listing them only adds noise.
         }
+        ContentBlock::ImageUrl { image_url } => {
+            let _ = writeln!(
+                buf,
+                "  [{blk_idx}] ImageUrl ({len} chars)",
+                len = image_url.url.len(),
+            );
+        }
         ContentBlock::ToolUse {
             name, input, id, ..
         } => {

--- a/crates/tui/src/rlm/session.rs
+++ b/crates/tui/src/rlm/session.rs
@@ -385,6 +385,11 @@ fn compact_content_block(block: &ContentBlock) -> Value {
                 "content_blocks": content_blocks,
             })
         }
+        ContentBlock::ImageUrl { image_url } => json!({
+            "type": "image_url",
+            "url_chars": image_url.url.chars().count(),
+            "url_sha256": sha256_hex(image_url.url.as_bytes()),
+        }),
         ContentBlock::ServerToolUse { id, name, input } => json!({
             "type": "server_tool_use",
             "id": id,

--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -895,6 +895,14 @@ fn session_to_detail(session: SavedSession) -> SessionDetailResponse {
                         }
                         obj
                     }
+                    crate::models::ContentBlock::ImageUrl { image_url } => {
+                        json!({
+                            "type": "image_url",
+                            "image_url": {
+                                "url": image_url.url.clone(),
+                            }
+                        })
+                    }
                     crate::models::ContentBlock::ServerToolUse { id, name, input } => {
                         json!({ "type": "tool_use", "id": id, "name": name, "input": input })
                     }

--- a/crates/tui/src/seam_manager.rs
+++ b/crates/tui/src/seam_manager.rs
@@ -476,6 +476,9 @@ impl SeamManager {
                     ContentBlock::Thinking { .. } => {
                         // Skip thinking in seam summaries.
                     }
+                    ContentBlock::ImageUrl { .. } => {
+                        let _ = write!(conversation, "{role}: [Attached image]\n\n");
+                    }
                     ContentBlock::ServerToolUse { .. }
                     | ContentBlock::ToolSearchToolResult { .. }
                     | ContentBlock::CodeExecutionToolResult { .. } => {}

--- a/crates/tui/src/tools/recall_archive.rs
+++ b/crates/tui/src/tools/recall_archive.rs
@@ -250,6 +250,9 @@ fn message_text(message: &Message) -> String {
             ContentBlock::Thinking { thinking } => {
                 push(&format!("[thinking] {thinking}"));
             }
+            ContentBlock::ImageUrl { .. } => {
+                push("[image_url]");
+            }
             ContentBlock::ServerToolUse { name, input, .. } => {
                 push(&format!("[server_tool_use {name}] {input}"));
             }

--- a/crates/tui/src/tui/file_mention.rs
+++ b/crates/tui/src/tui/file_mention.rs
@@ -25,8 +25,10 @@ use std::fmt::Write;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 use serde::{Deserialize, Serialize};
 
+use crate::models::{ContentBlock, ImageUrlContent};
 use crate::tui::app::{App, MentionCompletionCache};
 use crate::working_set::Workspace;
 
@@ -611,6 +613,69 @@ pub fn media_attachment_references(input: &str) -> Vec<MediaAttachmentReference>
     out
 }
 
+/// Convert `/attach` image placeholders in composer text into multimodal
+/// content blocks for OpenAI-compatible chat-completions payloads.
+///
+/// The visible transcript intentionally stays compact (`[Attached image: ...]`),
+/// but the model request must carry the actual image bytes as a `data:` URL.
+#[must_use]
+pub fn media_attachment_content_blocks(input: &str) -> Vec<ContentBlock> {
+    let mut blocks = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+
+    for reference in extract_media_attachment_references(input) {
+        if !reference.kind.eq_ignore_ascii_case("image") {
+            continue;
+        }
+        if !seen.insert(reference.path.clone()) {
+            continue;
+        }
+
+        let path = Path::new(&reference.path);
+        let Some(mime_type) = image_mime_type_for_path(path) else {
+            blocks.push(ContentBlock::Text {
+                text: format!(
+                    "<unsupported-attachment kind=\"image\" path=\"{}\" />",
+                    reference.path
+                ),
+                cache_control: None,
+            });
+            continue;
+        };
+
+        match std::fs::read(path) {
+            Ok(bytes) => blocks.push(ContentBlock::ImageUrl {
+                image_url: ImageUrlContent {
+                    url: format!("data:{mime_type};base64,{}", BASE64.encode(bytes)),
+                },
+            }),
+            Err(err) => blocks.push(ContentBlock::Text {
+                text: format!(
+                    "<unreadable-attachment kind=\"image\" path=\"{}\">\n{err}\n</unreadable-attachment>",
+                    reference.path
+                ),
+                cache_control: None,
+            }),
+        }
+    }
+
+    blocks
+}
+
+fn image_mime_type_for_path(path: &Path) -> Option<&'static str> {
+    let ext = path.extension()?.to_str()?.to_ascii_lowercase();
+    match ext.as_str() {
+        "png" => Some("image/png"),
+        "jpg" | "jpeg" => Some("image/jpeg"),
+        "gif" => Some("image/gif"),
+        "webp" => Some("image/webp"),
+        "bmp" => Some("image/bmp"),
+        "tif" | "tiff" => Some("image/tiff"),
+        "ppm" => Some("image/x-portable-pixmap"),
+        _ => None,
+    }
+}
+
 fn extract_media_attachment_references(input: &str) -> Vec<MediaAttachmentReference> {
     media_attachment_references(input)
 }
@@ -1045,6 +1110,22 @@ mod tests {
             &input[reference.start_byte..reference.end_byte],
             "[Attached image: 8x4 PNG at /tmp/pasted.png]\n"
         );
+    }
+
+    #[test]
+    fn media_attachment_content_blocks_embed_image_as_data_url() {
+        let tmp = TempDir::new().expect("tempdir");
+        let image_path = tmp.path().join("photo.png");
+        std::fs::write(&image_path, b"abc").expect("write png fixture");
+        let input = format!("what is this?\n[Attached image: {}]", image_path.display());
+
+        let blocks = media_attachment_content_blocks(&input);
+
+        assert_eq!(blocks.len(), 1);
+        let ContentBlock::ImageUrl { image_url } = &blocks[0] else {
+            panic!("expected image_url block, got {blocks:?}");
+        };
+        assert_eq!(image_url.url, "data:image/png;base64,YWJj");
     }
 
     #[test]

--- a/crates/tui/src/tui/notifications.rs
+++ b/crates/tui/src/tui/notifications.rs
@@ -694,6 +694,7 @@ pub fn latest_assistant_text(messages: &[Message]) -> Option<String> {
                 .filter_map(|block| match block {
                     ContentBlock::Text { text, .. } => Some(text.as_str()),
                     ContentBlock::Thinking { .. }
+                    | ContentBlock::ImageUrl { .. }
                     | ContentBlock::ToolUse { .. }
                     | ContentBlock::ToolResult { .. }
                     | ContentBlock::ServerToolUse { .. }

--- a/crates/tui/src/tui/session_picker.rs
+++ b/crates/tui/src/tui/session_picker.rs
@@ -770,6 +770,7 @@ fn message_text_for_history(message: &crate::models::Message) -> String {
                 }
             }
             crate::models::ContentBlock::Thinking { .. } => String::new(),
+            crate::models::ContentBlock::ImageUrl { .. } => "[Attached image]".to_string(),
             crate::models::ContentBlock::ToolUse { name, input, .. } => {
                 format!("tool call: {name} {}", truncate(&input.to_string(), 180))
             }

--- a/crates/tui/src/utils.rs
+++ b/crates/tui/src/utils.rs
@@ -483,6 +483,7 @@ pub fn estimate_message_chars(messages: &[Message]) -> usize {
                 ContentBlock::Thinking { thinking } => total += thinking.len(),
                 ContentBlock::ToolUse { input, .. } => total += input.to_string().len(),
                 ContentBlock::ToolResult { content, .. } => total += content.len(),
+                ContentBlock::ImageUrl { image_url } => total += image_url.url.len(),
                 ContentBlock::ServerToolUse { .. }
                 | ContentBlock::ToolSearchToolResult { .. }
                 | ContentBlock::CodeExecutionToolResult { .. } => {}

--- a/crates/tui/src/working_set.rs
+++ b/crates/tui/src/working_set.rs
@@ -1042,6 +1042,7 @@ fn extract_paths_from_message(message: &Message) -> Vec<String> {
                 paths.extend(extract_paths_from_text(content));
             }
             ContentBlock::Thinking { .. }
+            | ContentBlock::ImageUrl { .. }
             | ContentBlock::ServerToolUse { .. }
             | ContentBlock::ToolSearchToolResult { .. }
             | ContentBlock::CodeExecutionToolResult { .. } => {}
@@ -1207,6 +1208,7 @@ fn message_mentions_any_path(message: &Message, needles: &[String], max_scan_cha
                 }
             }
             ContentBlock::Thinking { .. }
+            | ContentBlock::ImageUrl { .. }
             | ContentBlock::ServerToolUse { .. }
             | ContentBlock::ToolSearchToolResult { .. }
             | ContentBlock::CodeExecutionToolResult { .. } => {}


### PR DESCRIPTION
## Summary
- convert `/attach` image placeholders into OpenAI-compatible multimodal `image_url` content blocks
- read local image files and send them as `data:image/...;base64,...` URLs while keeping the transcript placeholder readable
- add regression tests for attachment base64 conversion and chat request image parts

Fixes #2584.

## Verification
- `cargo fmt`
- `CARGO_TARGET_DIR=C:\Users\ky\AppData\Local\Temp\codewhale-target cargo check -p codewhale-tui`
- `CARGO_TARGET_DIR=C:\Users\ky\AppData\Local\Temp\codewhale-target cargo test -p codewhale-tui --bin codewhale-tui media_attachment_content_blocks_embed_image_as_data_url -- --nocapture`
- `CARGO_TARGET_DIR=C:\Users\ky\AppData\Local\Temp\codewhale-target cargo test -p codewhale-tui --bin codewhale-tui request_builder_emits_openai_image_url_parts_for_user_images -- --nocapture`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR wires `/attach` image placeholders into OpenAI-compatible multimodal requests by adding a `ContentBlock::ImageUrl` variant and a new `media_attachment_content_blocks` helper that reads local image files and encodes them as `data:image/…;base64,…` URLs.

- **New `ContentBlock::ImageUrl` in `models.rs`**: adds `ImageUrlContent` struct and updates every `match` across `compaction.rs`, `purge.rs`, `working_set.rs`, and `client/chat.rs`; most non-chat files just emit a compact placeholder or skip the block.
- **`file_mention.rs` — `media_attachment_content_blocks`**: parses `[Attached image: … at <path>]` lines, resolves the extension to a MIME type, and encodes the file as base64; unsupported types and I/O errors produce informative `<Text>` blocks instead of panicking.
- **`client/chat.rs` — `build_chat_messages_with_reasoning`**: when `image_parts` is non-empty, user message content is serialised as a JSON array with separate `text` and `image_url` parts instead of a bare string; the bulk of the diff in several other files is whitespace-only reformatting.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to review but needs the unbounded file-read fixed before merging — a large attached image will block the event loop and send an oversized payload.

The core multimodal wiring in chat.rs and models.rs is correct and the tests pass. The main concern is in media_attachment_content_blocks: it reads image files with no byte ceiling, while the analogous text-mention code explicitly caps reads at 128 KiB. On a system where a user attaches a large raw image (or accidentally attaches a non-image large file whose extension maps to a known MIME type), the entire file is read synchronously inside the async send-message handler, base64-encoded in memory, and forwarded to the API — with no guard against OOM or a payload the API will reject.

crates/tui/src/tui/file_mention.rs — the new media_attachment_content_blocks function needs a file-size cap matching the existing MAX_MENTION_FILE_BYTES pattern.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/file_mention.rs | Adds `media_attachment_content_blocks` which reads image files and emits `ContentBlock::ImageUrl` — no file-size cap, unlike the existing text-mention path that enforces MAX_MENTION_FILE_BYTES. |
| crates/tui/src/client/chat.rs | Correctly routes `ContentBlock::ImageUrl` blocks into OpenAI multimodal array content for user messages; adds `summarize_image_url_for_inspect` which duplicates `image_url_summary_for_compaction` from compaction.rs. |
| crates/tui/src/core/engine.rs | Calls `media_attachment_content_blocks` (which performs blocking fs::read) from within the async `handle_send_message`, inconsistent with the codebase's pattern of offloading blocking I/O to the blocking pool. |
| crates/tui/src/models.rs | Adds `ImageUrlContent` struct and `ContentBlock::ImageUrl` variant; straightforward, well-typed additions with correct serde rename attributes. |
| crates/tui/src/compaction.rs | Adds `ContentBlock::ImageUrl` arm to all match statements; bulk of diff is whitespace reformatting with no logic changes. The new arms correctly emit a placeholder summary and return an empty path list. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Engine as engine.rs
    participant FM as file_mention.rs
    participant FS as Filesystem
    participant Chat as client/chat.rs
    participant API as LLM API

    User->>Engine: handle_send_message(content)
    Engine->>FM: media_attachment_content_blocks(text)
    FM->>FM: extract_media_attachment_references(input)
    FM->>FM: image_mime_type_for_path(path)
    FM->>FS: fs::read(path) blocking, no size cap
    FS-->>FM: bytes
    FM-->>Engine: Vec ContentBlock::ImageUrl
    Engine->>Engine: push ImageUrl blocks into user Message
    Engine->>Chat: build_chat_messages(messages)
    Chat->>Chat: collect image_parts from ContentBlock::ImageUrl
    Chat->>Chat: wrap as multimodal array with text and image_url parts
    Chat-->>API: POST /chat/completions with content array
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix-attach-image-base64-2584%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix-attach-image-base64-2584%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Ftui%2Fsrc%2Ftui%2Ffile_mention.rs%3A646-651%0A**Unbounded%20image%20file%20read%20%E2%80%94%20no%20size%20cap**%0A%0A%60std%3A%3Afs%3A%3Aread%28path%29%60%20loads%20the%20entire%20file%20into%20memory%20with%20no%20ceiling.%20The%20text-mention%20path%20enforces%20%60MAX_MENTION_FILE_BYTES%20%3D%20128%20KiB%60%20via%20%60take%28%29%60%2C%20but%20this%20image%20path%20has%20no%20equivalent%20guard.%20A%20user%20who%20accidentally%20attaches%20a%20multi-hundred-MB%20raw%20image%20%28or%20a%20file%20masquerading%20as%20one%20via%20its%20path%29%20will%20fully%20base64-encode%20it%20in%20memory%2C%20blocking%20the%20async%20runtime%20and%20potentially%20sending%20a%20payload%20large%20enough%20to%20be%20rejected%20by%20the%20API%20or%20exhaust%20process%20memory.%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine.rs%3A1264-1266%0A**Blocking%20file%20I%2FO%20on%20the%20async%20executor%20thread**%0A%0A%60media_attachment_content_blocks%60%20calls%20%60std%3A%3Afs%3A%3Aread%60%20synchronously%20from%20a%20non-async%20function%20that%20is%20itself%20called%20from%20the%20%60async%20fn%20handle_send_message%60.%20The%20codebase's%20own%20comment%20at%20line%20~1316%20%28%22Run%20the%20git%20work%20on%20the%20blocking%20pool%20so%20the%20async%20runtime%20stays%20responsive%22%29%20documents%20why%20this%20pattern%20is%20avoided%20elsewhere.%20For%20small%20images%20the%20impact%20is%20negligible%2C%20but%20the%20same%20call%20path%20is%20now%20used%20unconditionally%20on%20every%20message%20send%20that%20contains%20any%20%60%5BAttached%20image%3A%20%E2%80%A6%5D%60%20placeholder%2C%20including%20messages%20with%20large%20files.%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Ftui%2Fsrc%2Fclient%2Fchat.rs%3A806-812%0A**Duplicate%20summarisation%20helper**%0A%0A%60summarize_image_url_for_inspect%60%20here%20and%20%60image_url_summary_for_compaction%60%20in%20%60compaction.rs%60%20%28line%20306%29%20are%20byte-for-byte%20identical.%20If%20the%20truncation%20length%20%2896%20chars%29%20or%20the%20format%20string%20ever%20needs%20to%20change%2C%20both%20copies%20must%20be%20updated.%20Extracting%20a%20shared%20helper%20to%20%60utils.rs%60%20or%20%60models.rs%60%20would%20eliminate%20the%20divergence%20risk.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Ftui%2Fsrc%2Ftui%2Ffile_mention.rs%3A646-651%0A**Unbounded%20image%20file%20read%20%E2%80%94%20no%20size%20cap**%0A%0A%60std%3A%3Afs%3A%3Aread%28path%29%60%20loads%20the%20entire%20file%20into%20memory%20with%20no%20ceiling.%20The%20text-mention%20path%20enforces%20%60MAX_MENTION_FILE_BYTES%20%3D%20128%20KiB%60%20via%20%60take%28%29%60%2C%20but%20this%20image%20path%20has%20no%20equivalent%20guard.%20A%20user%20who%20accidentally%20attaches%20a%20multi-hundred-MB%20raw%20image%20%28or%20a%20file%20masquerading%20as%20one%20via%20its%20path%29%20will%20fully%20base64-encode%20it%20in%20memory%2C%20blocking%20the%20async%20runtime%20and%20potentially%20sending%20a%20payload%20large%20enough%20to%20be%20rejected%20by%20the%20API%20or%20exhaust%20process%20memory.%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine.rs%3A1264-1266%0A**Blocking%20file%20I%2FO%20on%20the%20async%20executor%20thread**%0A%0A%60media_attachment_content_blocks%60%20calls%20%60std%3A%3Afs%3A%3Aread%60%20synchronously%20from%20a%20non-async%20function%20that%20is%20itself%20called%20from%20the%20%60async%20fn%20handle_send_message%60.%20The%20codebase's%20own%20comment%20at%20line%20~1316%20%28%22Run%20the%20git%20work%20on%20the%20blocking%20pool%20so%20the%20async%20runtime%20stays%20responsive%22%29%20documents%20why%20this%20pattern%20is%20avoided%20elsewhere.%20For%20small%20images%20the%20impact%20is%20negligible%2C%20but%20the%20same%20call%20path%20is%20now%20used%20unconditionally%20on%20every%20message%20send%20that%20contains%20any%20%60%5BAttached%20image%3A%20%E2%80%A6%5D%60%20placeholder%2C%20including%20messages%20with%20large%20files.%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Ftui%2Fsrc%2Fclient%2Fchat.rs%3A806-812%0A**Duplicate%20summarisation%20helper**%0A%0A%60summarize_image_url_for_inspect%60%20here%20and%20%60image_url_summary_for_compaction%60%20in%20%60compaction.rs%60%20%28line%20306%29%20are%20byte-for-byte%20identical.%20If%20the%20truncation%20length%20%2896%20chars%29%20or%20the%20format%20string%20ever%20needs%20to%20change%2C%20both%20copies%20must%20be%20updated.%20Extracting%20a%20shared%20helper%20to%20%60utils.rs%60%20or%20%60models.rs%60%20would%20eliminate%20the%20divergence%20risk.%0A%0A&repo=hmbown%2Fcodewhale&pr=2587&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Ftui%2Fsrc%2Ftui%2Ffile_mention.rs%3A646-651%0A**Unbounded%20image%20file%20read%20%E2%80%94%20no%20size%20cap**%0A%0A%60std%3A%3Afs%3A%3Aread%28path%29%60%20loads%20the%20entire%20file%20into%20memory%20with%20no%20ceiling.%20The%20text-mention%20path%20enforces%20%60MAX_MENTION_FILE_BYTES%20%3D%20128%20KiB%60%20via%20%60take%28%29%60%2C%20but%20this%20image%20path%20has%20no%20equivalent%20guard.%20A%20user%20who%20accidentally%20attaches%20a%20multi-hundred-MB%20raw%20image%20%28or%20a%20file%20masquerading%20as%20one%20via%20its%20path%29%20will%20fully%20base64-encode%20it%20in%20memory%2C%20blocking%20the%20async%20runtime%20and%20potentially%20sending%20a%20payload%20large%20enough%20to%20be%20rejected%20by%20the%20API%20or%20exhaust%20process%20memory.%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine.rs%3A1264-1266%0A**Blocking%20file%20I%2FO%20on%20the%20async%20executor%20thread**%0A%0A%60media_attachment_content_blocks%60%20calls%20%60std%3A%3Afs%3A%3Aread%60%20synchronously%20from%20a%20non-async%20function%20that%20is%20itself%20called%20from%20the%20%60async%20fn%20handle_send_message%60.%20The%20codebase's%20own%20comment%20at%20line%20~1316%20%28%22Run%20the%20git%20work%20on%20the%20blocking%20pool%20so%20the%20async%20runtime%20stays%20responsive%22%29%20documents%20why%20this%20pattern%20is%20avoided%20elsewhere.%20For%20small%20images%20the%20impact%20is%20negligible%2C%20but%20the%20same%20call%20path%20is%20now%20used%20unconditionally%20on%20every%20message%20send%20that%20contains%20any%20%60%5BAttached%20image%3A%20%E2%80%A6%5D%60%20placeholder%2C%20including%20messages%20with%20large%20files.%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Ftui%2Fsrc%2Fclient%2Fchat.rs%3A806-812%0A**Duplicate%20summarisation%20helper**%0A%0A%60summarize_image_url_for_inspect%60%20here%20and%20%60image_url_summary_for_compaction%60%20in%20%60compaction.rs%60%20%28line%20306%29%20are%20byte-for-byte%20identical.%20If%20the%20truncation%20length%20%2896%20chars%29%20or%20the%20format%20string%20ever%20needs%20to%20change%2C%20both%20copies%20must%20be%20updated.%20Extracting%20a%20shared%20helper%20to%20%60utils.rs%60%20or%20%60models.rs%60%20would%20eliminate%20the%20divergence%20risk.%0A%0A&pr=2587&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(tui): send attached images as multim..."](https://github.com/hmbown/codewhale/commit/5534c5a1f9aba6032082523766b234db28d365a3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35127120)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->