### PR TITLE
fix(diff-render): preserve leading whitespace in patch content lines

### DIFF
--- a/crates/tui/src/tui/diff_render.rs
+++ b/crates/tui/src/tui/diff_render.rs
@@ -342,10 +342,19 @@ fn wrap_text(text: &str, width: usize) -> Vec<String> {
         return vec![text.to_string()];
     }
     let mut lines = Vec::new();
-    let mut current = String::new();
-    let mut current_width = 0;
 
-    for word in text.split_whitespace() {
+    // Preserve leading whitespace (indentation is semantic in diffs)
+    let lead: String = text.chars().take_while(|c| c.is_whitespace()).collect();
+    let trimmed = text.trim_start();
+
+    if trimmed.is_empty() {
+        return vec![text.to_string()];
+    }
+
+    let mut current = lead.clone();
+    let mut current_width = current.width();
+
+    for word in trimmed.split_whitespace() {
         let word_width = word.width();
         if word_width > width {
             if !current.is_empty() {
@@ -464,6 +473,86 @@ diff --git a/src/a.rs b/src/a.rs
         assert!(
             text.iter().any(|line| line.contains(" - old")),
             "deleted line should carry - gutter: {text:?}"
+        );
+    }
+
+    #[test]
+    fn render_diff_preserves_leading_whitespace() {
+        let diff = "\
+diff --git a/src/main.rs b/src/main.rs
+--- a/src/main.rs
++++ b/src/main.rs
+@@ -1,5 +1,11 @@
+ fn main() {
+     let x = 1;
++    let y = 2;
++    if x > 0 {
++        println!(\"positive\");
++    }
+     do_work();
+-    cleanup();
++    finalize();
+ }
+";
+
+        let rendered = render_diff(diff, 80);
+        let text = rendered.iter().map(line_text).collect::<Vec<_>>();
+
+        // Added lines must preserve leading whitespace
+        assert!(
+            text.iter().any(|line| line.contains("    let y = 2;")),
+            "added indented line should keep 4-space indent: {text:?}"
+        );
+        assert!(
+            text.iter().any(|line| line.contains("        println!")),
+            "added double-indented line should keep 8-space indent: {text:?}"
+        );
+        // Modified line preserves its indentation
+        assert!(
+            text.iter().any(|line| line.contains("    finalize();")),
+            "modified line should keep indent: {text:?}"
+        );
+    }
+
+    #[test]
+    fn render_diff_preserves_indent_with_existing_context() {
+        let diff = "\
+diff --git a/src/lib.rs b/src/lib.rs
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -10,7 +10,9 @@
+ impl Foo {
+     fn bar(&self) {
+         let items = vec![1, 2, 3];
+-        old_thing();
++        for item in &items {
++            process(item);
++        }
+         more_stuff();
+     }
+ }
+";
+        let rendered = render_diff(diff, 80);
+        let text = rendered.iter().map(line_text).collect::<Vec<_>>();
+
+        // Context lines (space-prefixed in diff) keep leading whitespace
+        assert!(
+            text.iter().any(|line| line.contains("impl Foo {")),
+            "context header should be visible in rendered output"
+        );
+        // Added block preserves nested indentation
+        assert!(
+            text.iter().any(|line| line.contains("        for item")),
+            "added line with 8-space indent: {text:?}"
+        );
+        assert!(
+            text.iter().any(|line| line.contains("            process")),
+            "added line with 12-space indent: {text:?}"
+        );
+        // Deleted line keeps its indentation
+        assert!(
+            text.iter().any(|line| line.contains("        old_thing")),
+            "deleted line keeps indent: {text:?}"
         );
     }
 


### PR DESCRIPTION
## Description

Fixed a bug where patch content lines in the Diff Preview card lost all leading whitespace, causing indented code to appear left-aligned.

### Root Cause

`diff_render::wrap_text` used `text.split_whitespace()` for word-wrapping, which discards all leading whitespace. When displaying diff content like `+    let x = foo();`, the 4-space indentation was completely stripped, resulting in `let x = foo();`.

### Fix

Modified `wrap_text` in `diff_render.rs` to extract and preserve leading whitespace before word-wrapping:

1. Capture leading whitespace characters from the input text
2. Use the preserved whitespace as the starting content of the first wrapped line
3. Only apply word-wrapping (`split_whitespace`) to the trimmed non-whitespace portion

This ensures that indented diff content lines retain their semantic indentation after wrapping.

### Testing

- `render_diff_preserves_leading_whitespace` — verifies 4-space and 8-space indentation on added/modified lines
- `render_diff_preserves_indent_with_existing_context` — verifies context lines and deleted lines also preserve indentation (8-space, 12-space)
- All 5 diff_render tests pass
- `cargo clippy -p codewhale-tui` clean
- `cargo fmt` clean

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes lost indentation in diff preview by preserving leading whitespace in `wrap_text` before the word-wrap loop. The approach is correct in intent but introduces a new off-by-one error: initialising `current` with the indentation string while keeping the old `!current.is_empty()` space-insertion guard causes one extra space to be prepended to the first word on every indented line.

- `wrap_text` now captures leading whitespace into `lead` and seeds `current` with it, but the unchanged `!current.is_empty()` guard fires for the first word and inserts a spurious space, turning a 4-space indent into 5 spaces (and so on for every indent depth).
- Two new tests exercise the new behaviour, but both rely on `str::contains` substring matching, which silently accepts the extra space (`\"     let\"` passes `contains(\"    let\")`), so neither test catches the regression.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The fix partially addresses the original bug but introduces a new indentation error on every wrapped line; the accompanying tests pass despite the regression because they use substring matching.

The indentation fix is logically sound in structure but has a concrete defect in the word-loop: seeding `current` with the indentation string while relying on the old `is_empty()` guard causes one spurious space before every first word on an indented line. The two new tests pass today only because they use substring matching, masking the regression they were written to prevent.

crates/tui/src/tui/diff_render.rs — specifically the `wrap_text` word-loop initialisation and the assertion predicates in both new tests.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/diff_render.rs | Adds leading-whitespace preservation to `wrap_text` and two new tests, but the implementation inserts an extra space before the first word on any indented line, and the tests use substring matching that cannot detect this regression. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["wrap_text(text, width)"] --> B{width == 0?}
    B -->|yes| C["return vec![text]"]
    B -->|no| D["lead = leading whitespace\ntrimmed = text.trim_start()"]
    D --> E{trimmed empty?}
    E -->|yes| F["return vec![text]"]
    E -->|no| G["current = lead\ncurrent_width = lead.width()"]
    G --> H["iterate: trimmed.split_whitespace()"]
    H --> I{word_width > width?}
    I -->|yes| J["push current, push_word_breaking_chars"]
    I -->|no| K{"current.is_empty()"}
    K -->|empty| L["additional = word_width"]
    K -->|"not empty - bug: lead counts"| M["additional = word_width + 1"]
    L --> N{fits in width?}
    M --> N
    N -->|no| O["wrap: push current, current = word"]
    N -->|yes| P{"!current.is_empty()"}
    P -->|"true - bug: lead is non-empty"| Q["push EXTRA space then push word"]
    P -->|false| R["push word directly"]
    Q --> H
    R --> H
    O --> H
    H --> S["push final current, return lines"]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/tui/src/tui/diff_render.rs`, line 354-384 ([link](https://github.com/hmbown/codewhale/blob/fd4bb6484d66bb816485ef3fa3060b6fd974b219/crates/tui/src/tui/diff_render.rs#L354-L384)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> Extra space injected between preserved indentation and first word. Because `current` is initialised with `lead` (non-empty when there is leading whitespace), the `!current.is_empty()` guard at line 377 fires for the very first word and calls `current.push(' ')`, adding one spurious space. For example, `"    let y = 2;"` (4-space indent) is rendered as `"     let y = 2;"` (5-space indent). The fix is to defer the space-insertion check until at least one actual word has been appended, e.g. via a `has_word` flag.

   

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fdiff-whitespace-preserve%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fdiff-whitespace-preserve%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fdiff_render.rs%0ALine%3A%20354-384%0A%0AComment%3A%0AExtra%20space%20injected%20between%20preserved%20indentation%20and%20first%20word.%20Because%20%60current%60%20is%20initialised%20with%20%60lead%60%20%28non-empty%20when%20there%20is%20leading%20whitespace%29%2C%20the%20%60!current.is_empty%28%29%60%20guard%20at%20line%20377%20fires%20for%20the%20very%20first%20word%20and%20calls%20%60current.push%28'%20'%29%60%2C%20adding%20one%20spurious%20space.%20For%20example%2C%20%60%22%20%20%20%20let%20y%20%3D%202%3B%22%60%20%284-space%20indent%29%20is%20rendered%20as%20%60%22%20%20%20%20%20let%20y%20%3D%202%3B%22%60%20%285-space%20indent%29.%20The%20fix%20is%20to%20defer%20the%20space-insertion%20check%20until%20at%20least%20one%20actual%20word%20has%20been%20appended%2C%20e.g.%20via%20a%20%60has_word%60%20flag.%0A%0A%60%60%60suggestion%0A%20%20%20%20let%20mut%20current%20%3D%20lead.clone%28%29%3B%0A%20%20%20%20let%20mut%20current_width%20%3D%20current.width%28%29%3B%0A%20%20%20%20let%20mut%20has_word%20%3D%20false%3B%0A%0A%20%20%20%20for%20word%20in%20trimmed.split_whitespace%28%29%20%7B%0A%20%20%20%20%20%20%20%20let%20word_width%20%3D%20word.width%28%29%3B%0A%20%20%20%20%20%20%20%20if%20word_width%20%3E%20width%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20!current.is_empty%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20lines.push%28std%3A%3Amem%3A%3Atake%28%26mut%20current%29%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20current_width%20%3D%200%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20has_word%20%3D%20false%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20push_word_breaking_chars%28word%2C%20width%2C%20%26mut%20current%2C%20%26mut%20current_width%2C%20%26mut%20lines%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20has_word%20%3D%20true%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20continue%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20let%20additional%20%3D%20if%20has_word%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20word_width%20%2B%201%0A%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20word_width%0A%20%20%20%20%20%20%20%20%7D%3B%0A%20%20%20%20%20%20%20%20if%20current_width%20%2B%20additional%20%3E%20width%20%26%26%20has_word%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20lines.push%28current%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20current%20%3D%20word.to_string%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20current_width%20%3D%20word_width%3B%0A%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20has_word%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20current.push%28'%20'%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20current_width%20%2B%3D%201%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20current.push_str%28word%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20current_width%20%2B%3D%20word_width%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20has_word%20%3D%20true%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fdiff_render.rs%0ALine%3A%20354-384%0A%0AComment%3A%0AExtra%20space%20injected%20between%20preserved%20indentation%20and%20first%20word.%20Because%20%60current%60%20is%20initialised%20with%20%60lead%60%20%28non-empty%20when%20there%20is%20leading%20whitespace%29%2C%20the%20%60!current.is_empty%28%29%60%20guard%20at%20line%20377%20fires%20for%20the%20very%20first%20word%20and%20calls%20%60current.push%28'%20'%29%60%2C%20adding%20one%20spurious%20space.%20For%20example%2C%20%60%22%20%20%20%20let%20y%20%3D%202%3B%22%60%20%284-space%20indent%29%20is%20rendered%20as%20%60%22%20%20%20%20%20let%20y%20%3D%202%3B%22%60%20%285-space%20indent%29.%20The%20fix%20is%20to%20defer%20the%20space-insertion%20check%20until%20at%20least%20one%20actual%20word%20has%20been%20appended%2C%20e.g.%20via%20a%20%60has_word%60%20flag.%0A%0A%60%60%60suggestion%0A%20%20%20%20let%20mut%20current%20%3D%20lead.clone%28%29%3B%0A%20%20%20%20let%20mut%20current_width%20%3D%20current.width%28%29%3B%0A%20%20%20%20let%20mut%20has_word%20%3D%20false%3B%0A%0A%20%20%20%20for%20word%20in%20trimmed.split_whitespace%28%29%20%7B%0A%20%20%20%20%20%20%20%20let%20word_width%20%3D%20word.width%28%29%3B%0A%20%20%20%20%20%20%20%20if%20word_width%20%3E%20width%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20!current.is_empty%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20lines.push%28std%3A%3Amem%3A%3Atake%28%26mut%20current%29%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20current_width%20%3D%200%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20has_word%20%3D%20false%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20push_word_breaking_chars%28word%2C%20width%2C%20%26mut%20current%2C%20%26mut%20current_width%2C%20%26mut%20lines%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20has_word%20%3D%20true%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20continue%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20let%20additional%20%3D%20if%20has_word%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20word_width%20%2B%201%0A%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20word_width%0A%20%20%20%20%20%20%20%20%7D%3B%0A%20%20%20%20%20%20%20%20if%20current_width%20%2B%20additional%20%3E%20width%20%26%26%20has_word%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20lines.push%28current%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20current%20%3D%20word.to_string%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20current_width%20%3D%20word_width%3B%0A%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20has_word%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20current.push%28'%20'%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20current_width%20%2B%3D%201%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20current.push_str%28word%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20current_width%20%2B%3D%20word_width%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20has_word%20%3D%20true%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2591&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fdiff_render.rs%0ALine%3A%20354-384%0A%0AComment%3A%0AExtra%20space%20injected%20between%20preserved%20indentation%20and%20first%20word.%20Because%20%60current%60%20is%20initialised%20with%20%60lead%60%20%28non-empty%20when%20there%20is%20leading%20whitespace%29%2C%20the%20%60!current.is_empty%28%29%60%20guard%20at%20line%20377%20fires%20for%20the%20very%20first%20word%20and%20calls%20%60current.push%28'%20'%29%60%2C%20adding%20one%20spurious%20space.%20For%20example%2C%20%60%22%20%20%20%20let%20y%20%3D%202%3B%22%60%20%284-space%20indent%29%20is%20rendered%20as%20%60%22%20%20%20%20%20let%20y%20%3D%202%3B%22%60%20%285-space%20indent%29.%20The%20fix%20is%20to%20defer%20the%20space-insertion%20check%20until%20at%20least%20one%20actual%20word%20has%20been%20appended%2C%20e.g.%20via%20a%20%60has_word%60%20flag.%0A%0A%60%60%60suggestion%0A%20%20%20%20let%20mut%20current%20%3D%20lead.clone%28%29%3B%0A%20%20%20%20let%20mut%20current_width%20%3D%20current.width%28%29%3B%0A%20%20%20%20let%20mut%20has_word%20%3D%20false%3B%0A%0A%20%20%20%20for%20word%20in%20trimmed.split_whitespace%28%29%20%7B%0A%20%20%20%20%20%20%20%20let%20word_width%20%3D%20word.width%28%29%3B%0A%20%20%20%20%20%20%20%20if%20word_width%20%3E%20width%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20!current.is_empty%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20lines.push%28std%3A%3Amem%3A%3Atake%28%26mut%20current%29%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20current_width%20%3D%200%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20has_word%20%3D%20false%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20push_word_breaking_chars%28word%2C%20width%2C%20%26mut%20current%2C%20%26mut%20current_width%2C%20%26mut%20lines%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20has_word%20%3D%20true%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20continue%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20let%20additional%20%3D%20if%20has_word%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20word_width%20%2B%201%0A%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20word_width%0A%20%20%20%20%20%20%20%20%7D%3B%0A%20%20%20%20%20%20%20%20if%20current_width%20%2B%20additional%20%3E%20width%20%26%26%20has_word%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20lines.push%28current%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20current%20%3D%20word.to_string%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20current_width%20%3D%20word_width%3B%0A%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20has_word%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20current.push%28'%20'%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20current_width%20%2B%3D%201%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20current.push_str%28word%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20current_width%20%2B%3D%20word_width%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20has_word%20%3D%20true%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2591&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fdiff-whitespace-preserve%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fdiff-whitespace-preserve%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fdiff_render.rs%3A354-384%0AExtra%20space%20injected%20between%20preserved%20indentation%20and%20first%20word.%20Because%20%60current%60%20is%20initialised%20with%20%60lead%60%20%28non-empty%20when%20there%20is%20leading%20whitespace%29%2C%20the%20%60!current.is_empty%28%29%60%20guard%20at%20line%20377%20fires%20for%20the%20very%20first%20word%20and%20calls%20%60current.push%28'%20'%29%60%2C%20adding%20one%20spurious%20space.%20For%20example%2C%20%60%22%20%20%20%20let%20y%20%3D%202%3B%22%60%20%284-space%20indent%29%20is%20rendered%20as%20%60%22%20%20%20%20%20let%20y%20%3D%202%3B%22%60%20%285-space%20indent%29.%20The%20fix%20is%20to%20defer%20the%20space-insertion%20check%20until%20at%20least%20one%20actual%20word%20has%20been%20appended%2C%20e.g.%20via%20a%20%60has_word%60%20flag.%0A%0A%60%60%60suggestion%0A%20%20%20%20let%20mut%20current%20%3D%20lead.clone%28%29%3B%0A%20%20%20%20let%20mut%20current_width%20%3D%20current.width%28%29%3B%0A%20%20%20%20let%20mut%20has_word%20%3D%20false%3B%0A%0A%20%20%20%20for%20word%20in%20trimmed.split_whitespace%28%29%20%7B%0A%20%20%20%20%20%20%20%20let%20word_width%20%3D%20word.width%28%29%3B%0A%20%20%20%20%20%20%20%20if%20word_width%20%3E%20width%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20!current.is_empty%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20lines.push%28std%3A%3Amem%3A%3Atake%28%26mut%20current%29%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20current_width%20%3D%200%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20has_word%20%3D%20false%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20push_word_breaking_chars%28word%2C%20width%2C%20%26mut%20current%2C%20%26mut%20current_width%2C%20%26mut%20lines%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20has_word%20%3D%20true%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20continue%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20let%20additional%20%3D%20if%20has_word%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20word_width%20%2B%201%0A%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20word_width%0A%20%20%20%20%20%20%20%20%7D%3B%0A%20%20%20%20%20%20%20%20if%20current_width%20%2B%20additional%20%3E%20width%20%26%26%20has_word%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20lines.push%28current%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20current%20%3D%20word.to_string%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20current_width%20%3D%20word_width%3B%0A%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20has_word%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20current.push%28'%20'%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20current_width%20%2B%3D%201%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20current.push_str%28word%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20current_width%20%2B%3D%20word_width%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20has_word%20%3D%20true%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fdiff_render.rs%3A501-514%0AThe%20test%20assertions%20use%20%60contains%28%29%60%20%28substring%20match%29%2C%20which%20lets%20the%20extra-space%20bug%20go%20undetected%3A%20%60%22%20%20%20%20%20let%20y%20%3D%202%3B%22%60%20%285%20spaces%29%20passes%20%60contains%28%22%20%20%20%20let%20y%20%3D%202%3B%22%29%60%20because%20the%204-space%20substring%20appears%20inside%20it.%20Anchoring%20the%20check%20with%20%60str%3A%3Afind%60%20to%20verify%20the%20exact%20indentation%20prefix%20would%20catch%20indentation-width%20regressions.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Added%20lines%20must%20preserve%20leading%20whitespace%0A%20%20%20%20%20%20%20%20assert!%28%0A%20%20%20%20%20%20%20%20%20%20%20%20text.iter%28%29.any%28%7Cline%7C%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20let%20idx%20%3D%20line.find%28%22let%20y%20%3D%202%3B%22%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20idx.map_or%28false%2C%20%7Ci%7C%20%26line%5B..i%5D%20%3D%3D%20%22%20%20%20%20%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22added%20indented%20line%20should%20keep%20exact%204-space%20indent%3A%20%7Btext%3A%3F%7D%22%0A%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%20%20assert!%28%0A%20%20%20%20%20%20%20%20%20%20%20%20text.iter%28%29.any%28%7Cline%7C%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20let%20idx%20%3D%20line.find%28%22println!%22%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20idx.map_or%28false%2C%20%7Ci%7C%20%26line%5B..i%5D%20%3D%3D%20%22%20%20%20%20%20%20%20%20%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22added%20double-indented%20line%20should%20keep%20exact%208-space%20indent%3A%20%7Btext%3A%3F%7D%22%0A%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%20%20%2F%2F%20Modified%20line%20preserves%20its%20indentation%0A%20%20%20%20%20%20%20%20assert!%28%0A%20%20%20%20%20%20%20%20%20%20%20%20text.iter%28%29.any%28%7Cline%7C%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20let%20idx%20%3D%20line.find%28%22finalize%28%29%3B%22%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20idx.map_or%28false%2C%20%7Ci%7C%20%26line%5B..i%5D%20%3D%3D%20%22%20%20%20%20%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22modified%20line%20should%20keep%20exact%204-space%20indent%3A%20%7Btext%3A%3F%7D%22%0A%20%20%20%20%20%20%20%20%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fdiff_render.rs%3A354-384%0AExtra%20space%20injected%20between%20preserved%20indentation%20and%20first%20word.%20Because%20%60current%60%20is%20initialised%20with%20%60lead%60%20%28non-empty%20when%20there%20is%20leading%20whitespace%29%2C%20the%20%60!current.is_empty%28%29%60%20guard%20at%20line%20377%20fires%20for%20the%20very%20first%20word%20and%20calls%20%60current.push%28'%20'%29%60%2C%20adding%20one%20spurious%20space.%20For%20example%2C%20%60%22%20%20%20%20let%20y%20%3D%202%3B%22%60%20%284-space%20indent%29%20is%20rendered%20as%20%60%22%20%20%20%20%20let%20y%20%3D%202%3B%22%60%20%285-space%20indent%29.%20The%20fix%20is%20to%20defer%20the%20space-insertion%20check%20until%20at%20least%20one%20actual%20word%20has%20been%20appended%2C%20e.g.%20via%20a%20%60has_word%60%20flag.%0A%0A%60%60%60suggestion%0A%20%20%20%20let%20mut%20current%20%3D%20lead.clone%28%29%3B%0A%20%20%20%20let%20mut%20current_width%20%3D%20current.width%28%29%3B%0A%20%20%20%20let%20mut%20has_word%20%3D%20false%3B%0A%0A%20%20%20%20for%20word%20in%20trimmed.split_whitespace%28%29%20%7B%0A%20%20%20%20%20%20%20%20let%20word_width%20%3D%20word.width%28%29%3B%0A%20%20%20%20%20%20%20%20if%20word_width%20%3E%20width%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20!current.is_empty%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20lines.push%28std%3A%3Amem%3A%3Atake%28%26mut%20current%29%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20current_width%20%3D%200%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20has_word%20%3D%20false%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20push_word_breaking_chars%28word%2C%20width%2C%20%26mut%20current%2C%20%26mut%20current_width%2C%20%26mut%20lines%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20has_word%20%3D%20true%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20continue%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20let%20additional%20%3D%20if%20has_word%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20word_width%20%2B%201%0A%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20word_width%0A%20%20%20%20%20%20%20%20%7D%3B%0A%20%20%20%20%20%20%20%20if%20current_width%20%2B%20additional%20%3E%20width%20%26%26%20has_word%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20lines.push%28current%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20current%20%3D%20word.to_string%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20current_width%20%3D%20word_width%3B%0A%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20has_word%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20current.push%28'%20'%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20current_width%20%2B%3D%201%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20current.push_str%28word%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20current_width%20%2B%3D%20word_width%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20has_word%20%3D%20true%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%281%20more%20issue%20omitted%20due%20to%20length%20limits.%20Use%20individual%20%22Fix%20in%20Claude%20Code%22%20links%20for%20remaining%20issues.%29%0A&repo=hmbown%2Fcodewhale&pr=2591&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fdiff_render.rs%3A354-384%0AExtra%20space%20injected%20between%20preserved%20indentation%20and%20first%20word.%20Because%20%60current%60%20is%20initialised%20with%20%60lead%60%20%28non-empty%20when%20there%20is%20leading%20whitespace%29%2C%20the%20%60!current.is_empty%28%29%60%20guard%20at%20line%20377%20fires%20for%20the%20very%20first%20word%20and%20calls%20%60current.push%28'%20'%29%60%2C%20adding%20one%20spurious%20space.%20For%20example%2C%20%60%22%20%20%20%20let%20y%20%3D%202%3B%22%60%20%284-space%20indent%29%20is%20rendered%20as%20%60%22%20%20%20%20%20let%20y%20%3D%202%3B%22%60%20%285-space%20indent%29.%20The%20fix%20is%20to%20defer%20the%20space-insertion%20check%20until%20at%20least%20one%20actual%20word%20has%20been%20appended%2C%20e.g.%20via%20a%20%60has_word%60%20flag.%0A%0A%60%60%60suggestion%0A%20%20%20%20let%20mut%20current%20%3D%20lead.clone%28%29%3B%0A%20%20%20%20let%20mut%20current_width%20%3D%20current.width%28%29%3B%0A%20%20%20%20let%20mut%20has_word%20%3D%20false%3B%0A%0A%20%20%20%20for%20word%20in%20trimmed.split_whitespace%28%29%20%7B%0A%20%20%20%20%20%20%20%20let%20word_width%20%3D%20word.width%28%29%3B%0A%20%20%20%20%20%20%20%20if%20word_width%20%3E%20width%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20!current.is_empty%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20lines.push%28std%3A%3Amem%3A%3Atake%28%26mut%20current%29%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20current_width%20%3D%200%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20has_word%20%3D%20false%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20push_word_breaking_chars%28word%2C%20width%2C%20%26mut%20current%2C%20%26mut%20current_width%2C%20%26mut%20lines%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20has_word%20%3D%20true%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20continue%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20let%20additional%20%3D%20if%20has_word%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20word_width%20%2B%201%0A%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20word_width%0A%20%20%20%20%20%20%20%20%7D%3B%0A%20%20%20%20%20%20%20%20if%20current_width%20%2B%20additional%20%3E%20width%20%26%26%20has_word%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20lines.push%28current%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20current%20%3D%20word.to_string%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20current_width%20%3D%20word_width%3B%0A%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20has_word%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20current.push%28'%20'%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20current_width%20%2B%3D%201%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20current.push_str%28word%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20current_width%20%2B%3D%20word_width%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20has_word%20%3D%20true%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fdiff_render.rs%3A501-514%0AThe%20test%20assertions%20use%20%60contains%28%29%60%20%28substring%20match%29%2C%20which%20lets%20the%20extra-space%20bug%20go%20undetected%3A%20%60%22%20%20%20%20%20let%20y%20%3D%202%3B%22%60%20%285%20spaces%29%20passes%20%60contains%28%22%20%20%20%20let%20y%20%3D%202%3B%22%29%60%20because%20the%204-space%20substring%20appears%20inside%20it.%20Anchoring%20the%20check%20with%20%60str%3A%3Afind%60%20to%20verify%20the%20exact%20indentation%20prefix%20would%20catch%20indentation-width%20regressions.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Added%20lines%20must%20preserve%20leading%20whitespace%0A%20%20%20%20%20%20%20%20assert!%28%0A%20%20%20%20%20%20%20%20%20%20%20%20text.iter%28%29.any%28%7Cline%7C%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20let%20idx%20%3D%20line.find%28%22let%20y%20%3D%202%3B%22%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20idx.map_or%28false%2C%20%7Ci%7C%20%26line%5B..i%5D%20%3D%3D%20%22%20%20%20%20%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22added%20indented%20line%20should%20keep%20exact%204-space%20indent%3A%20%7Btext%3A%3F%7D%22%0A%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%20%20assert!%28%0A%20%20%20%20%20%20%20%20%20%20%20%20text.iter%28%29.any%28%7Cline%7C%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20let%20idx%20%3D%20line.find%28%22println!%22%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20idx.map_or%28false%2C%20%7Ci%7C%20%26line%5B..i%5D%20%3D%3D%20%22%20%20%20%20%20%20%20%20%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22added%20double-indented%20line%20should%20keep%20exact%208-space%20indent%3A%20%7Btext%3A%3F%7D%22%0A%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%20%20%2F%2F%20Modified%20line%20preserves%20its%20indentation%0A%20%20%20%20%20%20%20%20assert!%28%0A%20%20%20%20%20%20%20%20%20%20%20%20text.iter%28%29.any%28%7Cline%7C%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20let%20idx%20%3D%20line.find%28%22finalize%28%29%3B%22%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20idx.map_or%28false%2C%20%7Ci%7C%20%26line%5B..i%5D%20%3D%3D%20%22%20%20%20%20%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22modified%20line%20should%20keep%20exact%204-space%20indent%3A%20%7Btext%3A%3F%7D%22%0A%20%20%20%20%20%20%20%20%29%3B%0A%60%60%60%0A%0A&pr=2591&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(diff-render): preserve leading white..."](https://github.com/hmbown/codewhale/commit/fd4bb6484d66bb816485ef3fa3060b6fd974b219) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35155607)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->