### PR TITLE
  fix(tui): allow unused schema migration registry

### DIFF
--- a/crates/tui/src/schema_migration.rs
+++ b/crates/tui/src/schema_migration.rs
@@ -205,6 +205,7 @@ pub fn backup_before_migrate(path: &Path, domain: &str) -> PathBuf {
 /// 3. Bump `CURRENT_VERSION` to match.
 /// 4. Wire `<Domain>Migration::migrate(...)` into the load function in
 ///    the owning module.
+#[allow(dead_code)]
 pub mod registry {
     use super::{MigrationFn, SchemaMigration};
 


### PR DESCRIPTION
## Summary

  `schema_migration::registry` declares marker types for future persisted-schema
  migrations, but the current schema versions do not need any migration functions
  yet. Because these marker types are intentionally unused today, CI can fail under
  `RUSTFLAGS=-Dwarnings` with `dead_code` errors.

  This scopes `#[allow(dead_code)]` to the registry module only, preserving the
  future migration registration structure without changing runtime behavior.

## Testing

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `#[allow(dead_code)]` to the `pub mod registry` block in `schema_migration.rs`, preventing CI failures under `RUSTFLAGS=-Dwarnings` caused by unused migration marker types. The change is consistent with existing `#[allow(dead_code)]` annotations already present on `MigrationFn`, `SchemaMigration`, and `backup_before_migrate`.

- The one-line attribute addition has no runtime effect and correctly scopes suppression to the `registry` module only.
- `RuntimeMigration` and `TaskMigration` declare `CURRENT_VERSION = 2` with empty `MIGRATIONS` slices — this is pre-existing, but if either type is wired into a load path before a v1→v2 migration function is added, any v1 records on disk will produce a `MigrationError` at load time.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a single lint-suppression attribute with no runtime effect.

The only changed line adds `#[allow(dead_code)]` to the `registry` module, which already carries a doc comment explaining why the contents are intentionally unused. The attribute is scoped narrowly, the rest of the file is untouched, and there are no behavioral changes to review.

No files require special attention; the one pre-existing concern about `RuntimeMigration`/`TaskMigration` having `CURRENT_VERSION = 2` with empty migration lists should be resolved before those types are wired into load paths.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/tui/src/schema_migration.rs | Adds `#[allow(dead_code)]` to the `pub mod registry` block, silencing Rust dead-code warnings for placeholder migration structs that have no call sites yet; one-line attribute change with no runtime effect. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[schema_migration.rs] --> B["MigrationFn — #allow dead_code"]
    A --> C["SchemaMigration trait — #allow dead_code"]
    A --> D["backup_before_migrate — #allow dead_code"]
    A --> E["pub mod registry — #allow dead_code  NEW in this PR"]

    E --> F["SessionMigration — v1, no migrations"]
    E --> G["OfflineQueueMigration — v1, no migrations"]
    E --> H["RuntimeMigration — v2, no migrations"]
    E --> I["TaskMigration — v2, no migrations"]
    E --> J["AutomationMigration — v1, no migrations"]
    E --> K["AutomationRunMigration — v1, no migrations"]

    H --> L["If migrate called with v1 record → Err\npre-existing issue, not yet wired in"]
    I --> L
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/tui/src/schema_migration.rs`, line 232-236 ([link](https://github.com/hmbown/codewhale/blob/6b8866a6c4bbe38074d18959f67b1d4ccd187bce/crates/tui/src/schema_migration.rs#L232-L236)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`CURRENT_VERSION = 2` with empty `MIGRATIONS` will fail at runtime when wired in**

   `RuntimeMigration` and `TaskMigration` both declare `CURRENT_VERSION = 2` but leave `MIGRATIONS = &[]`. If a v1 record is ever passed to `SchemaMigration::migrate()` for either of these domains, the loop runs zero iterations, `current` stays at `1`, and the final check (`1 != 2`) returns a `MigrationError`. Any v1 record already on disk will be permanently unreadable once these types are wired into the load path, without adding a migration function first. This is pre-existing code not touched by this PR, but the gap between the declared version and the empty migration list is worth resolving before wiring in.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fschema-migration-warnings%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fschema-migration-warnings%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fschema_migration.rs%0ALine%3A%20232-236%0A%0AComment%3A%0A**%60CURRENT_VERSION%20%3D%202%60%20with%20empty%20%60MIGRATIONS%60%20will%20fail%20at%20runtime%20when%20wired%20in**%0A%0A%60RuntimeMigration%60%20and%20%60TaskMigration%60%20both%20declare%20%60CURRENT_VERSION%20%3D%202%60%20but%20leave%20%60MIGRATIONS%20%3D%20%26%5B%5D%60.%20If%20a%20v1%20record%20is%20ever%20passed%20to%20%60SchemaMigration%3A%3Amigrate%28%29%60%20for%20either%20of%20these%20domains%2C%20the%20loop%20runs%20zero%20iterations%2C%20%60current%60%20stays%20at%20%601%60%2C%20and%20the%20final%20check%20%28%601%20!%3D%202%60%29%20returns%20a%20%60MigrationError%60.%20Any%20v1%20record%20already%20on%20disk%20will%20be%20permanently%20unreadable%20once%20these%20types%20are%20wired%20into%20the%20load%20path%2C%20without%20adding%20a%20migration%20function%20first.%20This%20is%20pre-existing%20code%20not%20touched%20by%20this%20PR%2C%20but%20the%20gap%20between%20the%20declared%20version%20and%20the%20empty%20migration%20list%20is%20worth%20resolving%20before%20wiring%20in.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fschema_migration.rs%0ALine%3A%20232-236%0A%0AComment%3A%0A**%60CURRENT_VERSION%20%3D%202%60%20with%20empty%20%60MIGRATIONS%60%20will%20fail%20at%20runtime%20when%20wired%20in**%0A%0A%60RuntimeMigration%60%20and%20%60TaskMigration%60%20both%20declare%20%60CURRENT_VERSION%20%3D%202%60%20but%20leave%20%60MIGRATIONS%20%3D%20%26%5B%5D%60.%20If%20a%20v1%20record%20is%20ever%20passed%20to%20%60SchemaMigration%3A%3Amigrate%28%29%60%20for%20either%20of%20these%20domains%2C%20the%20loop%20runs%20zero%20iterations%2C%20%60current%60%20stays%20at%20%601%60%2C%20and%20the%20final%20check%20%28%601%20!%3D%202%60%29%20returns%20a%20%60MigrationError%60.%20Any%20v1%20record%20already%20on%20disk%20will%20be%20permanently%20unreadable%20once%20these%20types%20are%20wired%20into%20the%20load%20path%2C%20without%20adding%20a%20migration%20function%20first.%20This%20is%20pre-existing%20code%20not%20touched%20by%20this%20PR%2C%20but%20the%20gap%20between%20the%20declared%20version%20and%20the%20empty%20migration%20list%20is%20worth%20resolving%20before%20wiring%20in.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2601&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fschema_migration.rs%0ALine%3A%20232-236%0A%0AComment%3A%0A**%60CURRENT_VERSION%20%3D%202%60%20with%20empty%20%60MIGRATIONS%60%20will%20fail%20at%20runtime%20when%20wired%20in**%0A%0A%60RuntimeMigration%60%20and%20%60TaskMigration%60%20both%20declare%20%60CURRENT_VERSION%20%3D%202%60%20but%20leave%20%60MIGRATIONS%20%3D%20%26%5B%5D%60.%20If%20a%20v1%20record%20is%20ever%20passed%20to%20%60SchemaMigration%3A%3Amigrate%28%29%60%20for%20either%20of%20these%20domains%2C%20the%20loop%20runs%20zero%20iterations%2C%20%60current%60%20stays%20at%20%601%60%2C%20and%20the%20final%20check%20%28%601%20!%3D%202%60%29%20returns%20a%20%60MigrationError%60.%20Any%20v1%20record%20already%20on%20disk%20will%20be%20permanently%20unreadable%20once%20these%20types%20are%20wired%20into%20the%20load%20path%2C%20without%20adding%20a%20migration%20function%20first.%20This%20is%20pre-existing%20code%20not%20touched%20by%20this%20PR%2C%20but%20the%20gap%20between%20the%20declared%20version%20and%20the%20empty%20migration%20list%20is%20worth%20resolving%20before%20wiring%20in.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2601&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fschema-migration-warnings%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fschema-migration-warnings%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fschema_migration.rs%3A232-236%0A**%60CURRENT_VERSION%20%3D%202%60%20with%20empty%20%60MIGRATIONS%60%20will%20fail%20at%20runtime%20when%20wired%20in**%0A%0A%60RuntimeMigration%60%20and%20%60TaskMigration%60%20both%20declare%20%60CURRENT_VERSION%20%3D%202%60%20but%20leave%20%60MIGRATIONS%20%3D%20%26%5B%5D%60.%20If%20a%20v1%20record%20is%20ever%20passed%20to%20%60SchemaMigration%3A%3Amigrate%28%29%60%20for%20either%20of%20these%20domains%2C%20the%20loop%20runs%20zero%20iterations%2C%20%60current%60%20stays%20at%20%601%60%2C%20and%20the%20final%20check%20%28%601%20!%3D%202%60%29%20returns%20a%20%60MigrationError%60.%20Any%20v1%20record%20already%20on%20disk%20will%20be%20permanently%20unreadable%20once%20these%20types%20are%20wired%20into%20the%20load%20path%2C%20without%20adding%20a%20migration%20function%20first.%20This%20is%20pre-existing%20code%20not%20touched%20by%20this%20PR%2C%20but%20the%20gap%20between%20the%20declared%20version%20and%20the%20empty%20migration%20list%20is%20worth%20resolving%20before%20wiring%20in.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fschema_migration.rs%3A232-236%0A**%60CURRENT_VERSION%20%3D%202%60%20with%20empty%20%60MIGRATIONS%60%20will%20fail%20at%20runtime%20when%20wired%20in**%0A%0A%60RuntimeMigration%60%20and%20%60TaskMigration%60%20both%20declare%20%60CURRENT_VERSION%20%3D%202%60%20but%20leave%20%60MIGRATIONS%20%3D%20%26%5B%5D%60.%20If%20a%20v1%20record%20is%20ever%20passed%20to%20%60SchemaMigration%3A%3Amigrate%28%29%60%20for%20either%20of%20these%20domains%2C%20the%20loop%20runs%20zero%20iterations%2C%20%60current%60%20stays%20at%20%601%60%2C%20and%20the%20final%20check%20%28%601%20!%3D%202%60%29%20returns%20a%20%60MigrationError%60.%20Any%20v1%20record%20already%20on%20disk%20will%20be%20permanently%20unreadable%20once%20these%20types%20are%20wired%20into%20the%20load%20path%2C%20without%20adding%20a%20migration%20function%20first.%20This%20is%20pre-existing%20code%20not%20touched%20by%20this%20PR%2C%20but%20the%20gap%20between%20the%20declared%20version%20and%20the%20empty%20migration%20list%20is%20worth%20resolving%20before%20wiring%20in.%0A%0A&repo=hmbown%2Fcodewhale&pr=2601&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fschema_migration.rs%3A232-236%0A**%60CURRENT_VERSION%20%3D%202%60%20with%20empty%20%60MIGRATIONS%60%20will%20fail%20at%20runtime%20when%20wired%20in**%0A%0A%60RuntimeMigration%60%20and%20%60TaskMigration%60%20both%20declare%20%60CURRENT_VERSION%20%3D%202%60%20but%20leave%20%60MIGRATIONS%20%3D%20%26%5B%5D%60.%20If%20a%20v1%20record%20is%20ever%20passed%20to%20%60SchemaMigration%3A%3Amigrate%28%29%60%20for%20either%20of%20these%20domains%2C%20the%20loop%20runs%20zero%20iterations%2C%20%60current%60%20stays%20at%20%601%60%2C%20and%20the%20final%20check%20%28%601%20!%3D%202%60%29%20returns%20a%20%60MigrationError%60.%20Any%20v1%20record%20already%20on%20disk%20will%20be%20permanently%20unreadable%20once%20these%20types%20are%20wired%20into%20the%20load%20path%2C%20without%20adding%20a%20migration%20function%20first.%20This%20is%20pre-existing%20code%20not%20touched%20by%20this%20PR%2C%20but%20the%20gap%20between%20the%20declared%20version%20and%20the%20empty%20migration%20list%20is%20worth%20resolving%20before%20wiring%20in.%0A%0A&pr=2601&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(tui): allow unused schema migration ..."](https://github.com/hmbown/codewhale/commit/6b8866a6c4bbe38074d18959f67b1d4ccd187bce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35292006)</sub>

<!-- /greptile_comment -->