### PR TITLE
feat(tui): add drag-to-resize sidebar width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5233,7 +5233,8 @@ Welcome — and thank you.
 - Hooks system and config profiles
 - Example skills and launch assets
 
-[Unreleased]: https://github.com/Hmbown/CodeWhale/compare/v0.8.50...HEAD
+[Unreleased]: https://github.com/Hmbown/CodeWhale/compare/v0.8.51...HEAD
+[0.8.51]: https://github.com/Hmbown/CodeWhale/compare/v0.8.50...v0.8.51
 [0.8.50]: https://github.com/Hmbown/CodeWhale/compare/v0.8.49...v0.8.50
 [0.8.49]: https://github.com/Hmbown/CodeWhale/compare/v0.8.48...v0.8.49
 [0.8.48]: https://github.com/Hmbown/CodeWhale/compare/v0.8.47...v0.8.48

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -5233,7 +5233,8 @@ Welcome — and thank you.
 - Hooks system and config profiles
 - Example skills and launch assets
 
-[Unreleased]: https://github.com/Hmbown/CodeWhale/compare/v0.8.50...HEAD
+[Unreleased]: https://github.com/Hmbown/CodeWhale/compare/v0.8.51...HEAD
+[0.8.51]: https://github.com/Hmbown/CodeWhale/compare/v0.8.50...v0.8.51
 [0.8.50]: https://github.com/Hmbown/CodeWhale/compare/v0.8.49...v0.8.50
 [0.8.49]: https://github.com/Hmbown/CodeWhale/compare/v0.8.48...v0.8.49
 [0.8.48]: https://github.com/Hmbown/CodeWhale/compare/v0.8.47...v0.8.48

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -532,6 +532,12 @@ impl Settings {
         Ok(())
     }
 
+    /// Update and persist sidebar width percentage (10-50) — used by the
+    /// drag-to-resize handle in the TUI.
+    pub fn update_sidebar_width(&mut self, percent: u16) {
+        self.sidebar_width_percent = percent.clamp(10, 50);
+    }
+
     /// Set a single setting by key
     pub fn set(&mut self, key: &str, value: &str) -> Result<()> {
         match key {

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -1273,6 +1273,21 @@ pub struct App {
     pub sidebar_hover_tooltip: Option<String>,
     /// Last known mouse position for tooltip placement.
     pub last_mouse_pos: Option<(u16, u16)>,
+    /// Whether the user is currently dragging the sidebar resize handle.
+    pub sidebar_resizing: bool,
+    /// Mouse column at the start of a sidebar-resize drag.
+    pub sidebar_resize_anchor_x: u16,
+    /// Sidebar width in columns at the start of a sidebar-resize drag.
+    pub sidebar_resize_anchor_width: u16,
+    /// Last sidebar area rendered (for mouse hit-testing the resize handle).
+    pub last_sidebar_area: Option<Rect>,
+    /// Handle rect painted on the left edge of the sidebar (1 col).
+    pub last_sidebar_handle_area: Option<Rect>,
+    /// Total horizontal space (chat + sidebar) used to compute the percentage
+    /// during sidebar resize drag.
+    pub sidebar_resize_total_width: u16,
+    /// Sidebar width changed during this drag and needs persistence.
+    pub sidebar_width_dirty: bool,
     /// Whether the session-context panel is enabled (#504).
     pub context_panel: bool,
     /// File-tree pane state. `None` when hidden; `Some` when visible.
@@ -1989,6 +2004,13 @@ impl App {
             sidebar_hover: SidebarHoverState::default(),
             sidebar_hover_tooltip: None,
             last_mouse_pos: None,
+            sidebar_resizing: false,
+            sidebar_resize_anchor_x: 0,
+            sidebar_resize_anchor_width: 0,
+            last_sidebar_area: None,
+            last_sidebar_handle_area: None,
+            sidebar_resize_total_width: 0,
+            sidebar_width_dirty: false,
             context_panel: settings.context_panel,
             file_tree: None,
             file_tree_visible: false,

--- a/crates/tui/src/tui/mouse_ui.rs
+++ b/crates/tui/src/tui/mouse_ui.rs
@@ -42,6 +42,47 @@ pub(crate) fn should_drop_loading_mouse_motion(app: &App, mouse: MouseEvent) -> 
     }
 }
 
+/// Handle mouse events on the sidebar resize handle (the 1-col vertical bar
+/// between the chat area and the sidebar). Returns true when the event was
+/// consumed so other handlers skip it.
+fn handle_sidebar_resize_mouse(app: &mut App, mouse: MouseEvent) -> bool {
+    let Some(handle) = app.last_sidebar_handle_area else {
+        return false;
+    };
+
+    let hit = mouse.column == handle.x
+        && mouse.row >= handle.y
+        && mouse.row < handle.y.saturating_add(handle.height);
+
+    match mouse.kind {
+        MouseEventKind::Down(MouseButton::Left) if hit => {
+            app.sidebar_resizing = true;
+            app.sidebar_resize_anchor_x = mouse.column;
+            app.sidebar_resize_anchor_width = app.last_sidebar_area.map(|a| a.width).unwrap_or(28);
+            app.needs_redraw = true;
+            true
+        }
+        MouseEventKind::Drag(MouseButton::Left) if app.sidebar_resizing => {
+            let delta = app.sidebar_resize_anchor_x as i32 - mouse.column as i32;
+            let new_width = (app.sidebar_resize_anchor_width as i32 + delta).max(24) as u16;
+            let total = app.sidebar_resize_total_width.max(1);
+            let new_pct = ((new_width as u32 * 100) / total as u32).clamp(10, 50) as u16;
+            if new_pct != app.sidebar_width_percent {
+                app.sidebar_width_percent = new_pct;
+                app.needs_redraw = true;
+            }
+            true
+        }
+        MouseEventKind::Up(MouseButton::Left) if app.sidebar_resizing => {
+            app.sidebar_resizing = false;
+            app.sidebar_width_dirty = true;
+            app.needs_redraw = true;
+            true
+        }
+        _ => false,
+    }
+}
+
 /// Map a mouse (column, row) within the composer area to a char index
 /// in the composer input string. Uses the inner content rect (border-aware)
 /// for coordinate mapping, and accounts for vertical padding and scroll offset.
@@ -214,6 +255,12 @@ pub(crate) fn handle_mouse_event(app: &mut App, mouse: MouseEvent) -> Vec<ViewEv
     if !app.view_stack.is_empty() {
         app.needs_redraw = true;
         return app.view_stack.handle_mouse(mouse);
+    }
+
+    // Sidebar resize handle — check before composer so it doesn't compete
+    // with text selection / scrolling.
+    if handle_sidebar_resize_mouse(app, mouse) {
+        return Vec::new();
     }
 
     // Composer mouse events take priority over transcript.

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -60,6 +60,7 @@ use crate::session_manager::{
     OfflineQueueState, QueuedSessionMessage, SavedSession, SessionManager,
     create_saved_session_with_id_and_mode, create_saved_session_with_mode, update_session,
 };
+use crate::settings::Settings;
 use crate::task_manager::{
     NewTaskRequest, SharedTaskManager, TaskManager, TaskManagerConfig, TaskStatus, TaskSummary,
 };
@@ -2597,6 +2598,14 @@ async fn run_event_loop(
                 {
                     return Ok(());
                 }
+                // Persist sidebar width when the user finishes a drag-to-resize.
+                if app.sidebar_width_dirty {
+                    app.sidebar_width_dirty = false;
+                    if let Ok(mut settings) = Settings::load() {
+                        settings.update_sidebar_width(app.sidebar_width_percent);
+                        let _ = settings.save();
+                    }
+                }
                 continue;
             }
 
@@ -2997,6 +3006,14 @@ async fn run_event_loop(
                 .await?
                 {
                     return Ok(());
+                }
+                // Persist sidebar width when the user finishes a drag-to-resize.
+                if app.sidebar_width_dirty {
+                    app.sidebar_width_dirty = false;
+                    if let Ok(mut settings) = Settings::load() {
+                        settings.update_sidebar_width(app.sidebar_width_percent);
+                        let _ = settings.save();
+                    }
                 }
                 continue;
             }
@@ -6379,6 +6396,8 @@ fn render(f: &mut Frame, app: &mut App) {
             };
 
         if let Some(sidebar_width) = sidebar_width_for_chat_area(app, chat_area.width) {
+            // Record total width for drag-to-resize percentage calculation.
+            app.sidebar_resize_total_width = chat_area.width;
             let split = Layout::default()
                 .direction(Direction::Horizontal)
                 .constraints([Constraint::Min(1), Constraint::Length(sidebar_width)])
@@ -6392,7 +6411,53 @@ fn render(f: &mut Frame, app: &mut App) {
         chat_widget.render(chat_area, buf);
 
         if let Some(sidebar_area) = sidebar_area {
+            // Store sidebar area for mouse hit-testing (resize handle).
+            app.last_sidebar_area = Some(sidebar_area);
+
+            // Render sidebar
             super::sidebar::render_sidebar(f, sidebar_area, app);
+
+            // Paint resize handle (1-col draggable bar) on the left edge of
+            // the sidebar, over the sidebar content. Mouse drag on this strip
+            // adjusts sidebar_width_percent in real time.
+            let handle_rect = Rect {
+                x: sidebar_area.x,
+                y: sidebar_area.y,
+                width: 1,
+                height: sidebar_area.height,
+            };
+
+            // Store for mouse event handler.
+            app.last_sidebar_handle_area = Some(handle_rect);
+
+            let mouse_over = app.last_mouse_pos.is_some_and(|(col, row)| {
+                row >= handle_rect.y
+                    && row < handle_rect.y.saturating_add(handle_rect.height)
+                    && col == handle_rect.x
+            });
+
+            let handle_style = if app.sidebar_resizing {
+                Style::default()
+                    .bg(palette::DEEPSEEK_BLUE)
+                    .fg(palette::TEXT_PRIMARY)
+            } else if mouse_over {
+                Style::default()
+                    .bg(palette::STATUS_WARNING)
+                    .fg(palette::TEXT_MUTED)
+            } else {
+                Style::default()
+                    .bg(palette::DEEPSEEK_SLATE)
+                    .fg(palette::TEXT_MUTED)
+            };
+
+            let buf = f.buffer_mut();
+            for row in handle_rect.y..handle_rect.y.saturating_add(handle_rect.height) {
+                if row < buf.area().height {
+                    buf[(handle_rect.x, row)]
+                        .set_char('│')
+                        .set_style(handle_style);
+                }
+            }
 
             // Render sidebar hover tooltip if active.
             if let Some(ref tooltip_text) = app.sidebar_hover_tooltip

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -2749,6 +2749,154 @@ fn hidden_sidebar_focus_suppresses_sidebar_split_even_when_wide() {
     assert_eq!(sidebar_width_for_chat_area(&app, 120), None);
 }
 
+// ── Sidebar resize-handle mouse tests ──────────────────────────────
+
+fn setup_resize_handle(app: &mut App, handle_x: u16, sidebar_width: u16, total_width: u16) {
+    let y = 2;
+    let h = 10;
+    app.last_sidebar_handle_area = Some(Rect {
+        x: handle_x,
+        y,
+        width: 1,
+        height: h,
+    });
+    app.last_sidebar_area = Some(Rect {
+        x: handle_x,
+        y,
+        width: sidebar_width,
+        height: h,
+    });
+    app.sidebar_resize_total_width = total_width;
+    app.sidebar_width_percent = 28;
+}
+
+#[test]
+fn sidebar_resize_down_on_handle_starts_resizing() {
+    let mut app = create_test_app();
+    setup_resize_handle(&mut app, 80, 33, 120);
+
+    handle_mouse_event(
+        &mut app,
+        MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: 80,
+            row: 5,
+            modifiers: KeyModifiers::NONE,
+        },
+    );
+
+    assert!(
+        app.sidebar_resizing,
+        "should start resizing on handle click"
+    );
+    assert_eq!(app.sidebar_resize_anchor_x, 80);
+    assert_eq!(app.sidebar_resize_anchor_width, 33);
+}
+
+#[test]
+fn sidebar_resize_down_outside_handle_does_not_start_resizing() {
+    let mut app = create_test_app();
+    setup_resize_handle(&mut app, 80, 33, 120);
+
+    handle_mouse_event(
+        &mut app,
+        MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: 79, // one column left of handle
+            row: 5,
+            modifiers: KeyModifiers::NONE,
+        },
+    );
+
+    assert!(
+        !app.sidebar_resizing,
+        "should not resize on non-handle click"
+    );
+}
+
+#[test]
+fn sidebar_resize_drag_adjusts_width_percent() {
+    let mut app = create_test_app();
+    setup_resize_handle(&mut app, 80, 33, 120);
+    // 33 / 120 * 100 ≈ 27.5 → initial percent = 28 (the setup defaults to 28)
+    app.sidebar_width_percent = 28;
+    app.sidebar_resizing = true;
+    app.sidebar_resize_anchor_x = 80;
+    app.sidebar_resize_anchor_width = 33;
+
+    // Drag left by 4 cols (making sidebar wider): 33 + 4 = 37 → 37/120*100 ≈ 30
+    handle_mouse_event(
+        &mut app,
+        MouseEvent {
+            kind: MouseEventKind::Drag(MouseButton::Left),
+            column: 76,
+            row: 5,
+            modifiers: KeyModifiers::NONE,
+        },
+    );
+
+    let expected = ((37u32 * 100) / 120) as u16; // ~30
+    assert_eq!(app.sidebar_width_percent, expected);
+}
+
+#[test]
+fn sidebar_resize_drag_clamps_to_10_50_range() {
+    let mut app = create_test_app();
+    setup_resize_handle(&mut app, 80, 33, 120);
+    app.sidebar_resizing = true;
+    app.sidebar_resize_anchor_x = 80;
+    app.sidebar_resize_anchor_width = 33;
+
+    // Drag far right → sidebar should shrink but not below 10%
+    handle_mouse_event(
+        &mut app,
+        MouseEvent {
+            kind: MouseEventKind::Drag(MouseButton::Left),
+            column: 200,
+            row: 5,
+            modifiers: KeyModifiers::NONE,
+        },
+    );
+    assert!(app.sidebar_width_percent >= 10);
+
+    // Drag far left → sidebar should grow but not above 50%
+    handle_mouse_event(
+        &mut app,
+        MouseEvent {
+            kind: MouseEventKind::Drag(MouseButton::Left),
+            column: 0,
+            row: 5,
+            modifiers: KeyModifiers::NONE,
+        },
+    );
+    assert!(app.sidebar_width_percent <= 50);
+}
+
+#[test]
+fn sidebar_resize_up_ends_resizing_and_marks_dirty() {
+    let mut app = create_test_app();
+    setup_resize_handle(&mut app, 80, 33, 120);
+    app.sidebar_resizing = true;
+    app.sidebar_resize_anchor_x = 80;
+    app.sidebar_resize_anchor_width = 33;
+
+    handle_mouse_event(
+        &mut app,
+        MouseEvent {
+            kind: MouseEventKind::Up(MouseButton::Left),
+            column: 76,
+            row: 5,
+            modifiers: KeyModifiers::NONE,
+        },
+    );
+
+    assert!(!app.sidebar_resizing, "should stop resizing on mouse up");
+    assert!(
+        app.sidebar_width_dirty,
+        "should mark width dirty for persistence"
+    );
+}
+
 fn make_subagent(
     id: &str,
     status: crate::tools::subagent::SubAgentStatus,


### PR DESCRIPTION
- **What:** Add interactive mouse-drag resize support between the chat area and sidebar.  
  Previously sidebar width could only be adjusted via `/config sidebar_width <percent>`, requiring a typed percentage and guesswork.

- **How:**
  - Render a **1-column draggable handle** (`│`) on the left edge of the sidebar with three visual states:
    - **default** — dim slate background
    - **hover** — orange (warning) background
    - **drag** — blue (accent) background
  - On `MouseDown` on the handle → record anchor position (`sidebar_resize_anchor_x`, `sidebar_resize_anchor_width`).
  - On `Drag` → compute delta, convert to percentage (10–50% range), update `sidebar_width_percent` in real time.
  - On `MouseUp` → persist the new width to `~/.deepseek/settings.toml` via `Settings::save()`.
  - Store `last_sidebar_area` / `last_sidebar_handle_area` / `sidebar_resize_total_width` for mouse hit-testing and percentage calculation.

- **Files changed:**
  | File | Change |
  |------|--------|
  | `crates/tui/src/tui/app.rs` | Add 7 state fields for resize drag |
  | `crates/tui/src/tui/ui.rs` | Render handle, store layout info, persist on drag-end |
  | `crates/tui/src/tui/mouse_ui.rs` | `handle_sidebar_resize_mouse` — Down/Drag/Up logic |
  | `crates/tui/src/settings.rs` | `update_sidebar_width()` helper |
  | `crates/tui/src/tui/ui/tests.rs` | 5 unit tests |

- **Tests:** 5 new tests covering handle click, drag percentage calculation, 10–50% clamp, mouse-up finalization, and non-handle click.

- **Verification:** `cargo fmt --all` ✅ | `cargo check` ✅ | `cargo test -p codewhale-tui -- ui::tests` (337 tests) ✅

Closes #2602

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds interactive mouse-drag resizing of the TUI sidebar via a 1-column `│` handle rendered on the sidebar's left edge, replacing the previous keyboard-only `/config sidebar_width` workflow. The drag state is tracked in `App`, hit-tested in `mouse_ui.rs`, and persisted to disk on `MouseUp` using the established `Settings::load()` + `save()` pattern.

- **Handle rendering** (`ui.rs`): the handle is painted after the sidebar render pass with three visual states (default/hover/drag); layout rects are stored on `App` each frame for hit-testing.
- **Mouse handling** (`mouse_ui.rs`): `handle_sidebar_resize_mouse` manages Down/Drag/Up events; drag fires `sidebar_resizing = true` and updates `sidebar_width_percent` in real time, with `clamp(10, 50)` on the percentage.
- **Persistence** (`ui.rs` + `settings.rs`): `sidebar_width_dirty` is set on `MouseUp`; the event loop checks the flag and calls `Settings::load()` → `update_sidebar_width` → `save()`.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with one fix: the stuck-resize bug when a modal opens during a drag should be addressed before shipping.

The drag-resize logic, percentage calculation, and persistence path are all correct and well-tested. The one gap is that `sidebar_resizing` can be left permanently `true` when the view-stack intercepts `MouseUp` while a modal is open — any subsequent drag will then silently continue from a stale anchor. The scenario is narrow but reproducible whenever a keyboard shortcut opens a modal mid-drag.

`crates/tui/src/tui/mouse_ui.rs` — the `handle_sidebar_resize_mouse` function needs a recovery path for `MouseUp` when the view-stack is non-empty.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/mouse_ui.rs | Adds `handle_sidebar_resize_mouse` for Down/Drag/Up handling; the `sidebar_resizing` flag can get stuck `true` when a modal intercepts `MouseUp` while the view-stack is non-empty. |
| crates/tui/src/tui/ui.rs | Renders the drag handle and stores layout rects for hit-testing; persistence is correctly wired to the MouseUp path. |
| crates/tui/src/tui/app.rs | Adds 7 new state fields for drag-resize; initialisation is clean and consistent with existing field patterns. |
| crates/tui/src/settings.rs | Adds `update_sidebar_width` helper that clamps to [10, 50] in memory; straightforward and consistent with the codebase pattern. |
| crates/tui/src/tui/ui/tests.rs | Adds 5 focused unit tests covering handle-click, drag-percentage math, clamping, mouse-up finalisation, and non-handle click; all test the happy path correctly. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant EventLoop
    participant handle_sidebar_resize_mouse
    participant App
    participant Settings

    User->>EventLoop: MouseDown on handle col
    EventLoop->>handle_sidebar_resize_mouse: mouse event
    handle_sidebar_resize_mouse->>App: "sidebar_resizing=true, anchor_x/width set"
    App-->>EventLoop: "needs_redraw=true"

    User->>EventLoop: MouseDrag (left/right)
    EventLoop->>handle_sidebar_resize_mouse: mouse event
    handle_sidebar_resize_mouse->>App: compute delta → update sidebar_width_percent (clamped 10-50%)
    App-->>EventLoop: "needs_redraw=true"

    User->>EventLoop: MouseUp
    EventLoop->>handle_sidebar_resize_mouse: mouse event
    handle_sidebar_resize_mouse->>App: "sidebar_resizing=false, sidebar_width_dirty=true"
    EventLoop->>Settings: load() from disk
    Settings-->>EventLoop: settings struct
    EventLoop->>Settings: update_sidebar_width(app.sidebar_width_percent)
    EventLoop->>Settings: save() to ~/.deepseek/settings.toml
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feature%2Fsidebar-resize-drag%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fsidebar-resize-drag%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fmouse_ui.rs%3A76-81%0A**%60sidebar_resizing%60%20stuck%20when%20a%20modal%20intercepts%20%60MouseUp%60**%0A%0A%60handle_mouse_event%60%20returns%20early%20at%20line%20255%E2%80%93258%20%28%60!app.view_stack.is_empty%28%29%60%29%20before%20%60handle_sidebar_resize_mouse%60%20is%20ever%20reached.%20If%20a%20keyboard%20shortcut%20or%20any%20other%20event%20causes%20a%20modal%20to%20open%20while%20the%20user%20is%20mid-drag%2C%20the%20resulting%20%60MouseUp%60%20is%20routed%20to%20the%20view-stack%20handler%20and%20never%20seen%20by%20this%20function.%20%60sidebar_resizing%60%20stays%20%60true%60%20indefinitely.%20After%20the%20modal%20closes%2C%20every%20subsequent%20left-button%20drag%20silently%20continues%20resizing%20from%20the%20stale%20anchor%2C%20with%20no%20exit%20path%20short%20of%20a%20fresh%20Down%2BUp%20cycle%20on%20the%20handle.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fmouse_ui.rs%3A76-81%0A**%60sidebar_resizing%60%20stuck%20when%20a%20modal%20intercepts%20%60MouseUp%60**%0A%0A%60handle_mouse_event%60%20returns%20early%20at%20line%20255%E2%80%93258%20%28%60!app.view_stack.is_empty%28%29%60%29%20before%20%60handle_sidebar_resize_mouse%60%20is%20ever%20reached.%20If%20a%20keyboard%20shortcut%20or%20any%20other%20event%20causes%20a%20modal%20to%20open%20while%20the%20user%20is%20mid-drag%2C%20the%20resulting%20%60MouseUp%60%20is%20routed%20to%20the%20view-stack%20handler%20and%20never%20seen%20by%20this%20function.%20%60sidebar_resizing%60%20stays%20%60true%60%20indefinitely.%20After%20the%20modal%20closes%2C%20every%20subsequent%20left-button%20drag%20silently%20continues%20resizing%20from%20the%20stale%20anchor%2C%20with%20no%20exit%20path%20short%20of%20a%20fresh%20Down%2BUp%20cycle%20on%20the%20handle.%0A%0A&repo=hmbown%2Fcodewhale&pr=2604&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fmouse_ui.rs%3A76-81%0A**%60sidebar_resizing%60%20stuck%20when%20a%20modal%20intercepts%20%60MouseUp%60**%0A%0A%60handle_mouse_event%60%20returns%20early%20at%20line%20255%E2%80%93258%20%28%60!app.view_stack.is_empty%28%29%60%29%20before%20%60handle_sidebar_resize_mouse%60%20is%20ever%20reached.%20If%20a%20keyboard%20shortcut%20or%20any%20other%20event%20causes%20a%20modal%20to%20open%20while%20the%20user%20is%20mid-drag%2C%20the%20resulting%20%60MouseUp%60%20is%20routed%20to%20the%20view-stack%20handler%20and%20never%20seen%20by%20this%20function.%20%60sidebar_resizing%60%20stays%20%60true%60%20indefinitely.%20After%20the%20modal%20closes%2C%20every%20subsequent%20left-button%20drag%20silently%20continues%20resizing%20from%20the%20stale%20anchor%2C%20with%20no%20exit%20path%20short%20of%20a%20fresh%20Down%2BUp%20cycle%20on%20the%20handle.%0A%0A&pr=2604&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["## \`feat(tui): add drag-to-resize sideba..."](https://github.com/hmbown/codewhale/commit/adf3fe23ede8e39039bfcb0084e3961b6f145ca1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35296917)</sub>

<!-- /greptile_comment -->