### PR TITLE
fix(tui): cache Work panel summary to survive transient mutex misses &&  fix compile error

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -34,6 +34,7 @@ enum ProviderArg {
     Novita,
     Fireworks,
     Siliconflow,
+    SiliconflowCN,
     Arcee,
     Moonshot,
     Sglang,
@@ -55,6 +56,7 @@ impl From<ProviderArg> for ProviderKind {
             ProviderArg::Novita => ProviderKind::Novita,
             ProviderArg::Fireworks => ProviderKind::Fireworks,
             ProviderArg::Siliconflow => ProviderKind::Siliconflow,
+            ProviderArg::SiliconflowCN => ProviderKind::SiliconflowCN,
             ProviderArg::Arcee => ProviderKind::Arcee,
             ProviderArg::Moonshot => ProviderKind::Moonshot,
             ProviderArg::Sglang => ProviderKind::Sglang,
@@ -749,11 +751,12 @@ fn provider_slot(provider: ProviderKind) -> &'static str {
         ProviderKind::Sglang => "sglang",
         ProviderKind::Vllm => "vllm",
         ProviderKind::Ollama => "ollama",
+        ProviderKind::SiliconflowCN => "siliconflow-cn",
     }
 }
 
 /// Provider order used by the `auth list` and `auth status` outputs.
-const PROVIDER_LIST: [ProviderKind; 16] = [
+const PROVIDER_LIST: [ProviderKind; 17] = [
     ProviderKind::Deepseek,
     ProviderKind::NvidiaNim,
     ProviderKind::Openai,
@@ -765,6 +768,7 @@ const PROVIDER_LIST: [ProviderKind; 16] = [
     ProviderKind::Novita,
     ProviderKind::Fireworks,
     ProviderKind::Siliconflow,
+    ProviderKind::SiliconflowCN,
     ProviderKind::Arcee,
     ProviderKind::Moonshot,
     ProviderKind::Sglang,
@@ -839,6 +843,7 @@ fn provider_env_vars(provider: ProviderKind) -> &'static [&'static str] {
             "WANJIE_API_KEY",
             "WANJIE_MAAS_API_KEY",
         ],
+        ProviderKind::SiliconflowCN => &["SILICONFLOW_API_KEY"],
     }
 }
 
@@ -1519,9 +1524,10 @@ fn build_tui_command(
             | ProviderKind::Sglang
             | ProviderKind::Vllm
             | ProviderKind::Ollama
+            | ProviderKind::SiliconflowCN
     ) {
         bail!(
-            "The interactive TUI supports DeepSeek, NVIDIA NIM, OpenAI-compatible, AtlasCloud, Wanjie Ark, OpenRouter, Xiaomi MiMo, Novita, Fireworks, SiliconFlow, Arcee AI, Moonshot/Kimi, SGLang, vLLM, and Ollama providers. Remove --provider {} or use `codewhale model ...` for provider registry inspection.",
+            "The interactive TUI supports DeepSeek, NVIDIA NIM, OpenAI-compatible, AtlasCloud, Wanjie Ark, OpenRouter, Xiaomi MiMo, Novita, Fireworks, SiliconFlow, SiliconFlow CN, Arcee AI, Moonshot/Kimi, SGLang, vLLM, and Ollama providers. Remove --provider {} or use `codewhale model ...` for provider registry inspection.",
             resolved_runtime.provider.as_str()
         );
     }
@@ -3029,6 +3035,11 @@ mod tests {
             (
                 ProviderKind::Siliconflow,
                 "siliconflow",
+                &["SILICONFLOW_API_KEY"],
+            ),
+            (
+                ProviderKind::SiliconflowCN,
+                "siliconflow-cn",
                 &["SILICONFLOW_API_KEY"],
             ),
             (ProviderKind::Arcee, "arcee", &["ARCEE_API_KEY"]),

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -194,6 +194,7 @@ pub struct ProviderConfigToml {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[allow(non_snake_case)]
 pub struct ProvidersToml {
     #[serde(default)]
     pub deepseek: ProviderConfigToml,
@@ -217,6 +218,9 @@ pub struct ProvidersToml {
     pub fireworks: ProviderConfigToml,
     #[serde(default)]
     pub siliconflow: ProviderConfigToml,
+    #[serde(default)]
+    #[allow(non_snake_case)]
+    pub siliconflow_CN: ProviderConfigToml,
     #[serde(default)]
     pub arcee: ProviderConfigToml,
     #[serde(default)]
@@ -262,7 +266,8 @@ impl ProvidersToml {
             ProviderKind::XiaomiMimo => &self.xiaomi_mimo,
             ProviderKind::Novita => &self.novita,
             ProviderKind::Fireworks => &self.fireworks,
-            ProviderKind::Siliconflow | ProviderKind::SiliconflowCN => &self.siliconflow,
+            ProviderKind::Siliconflow => &self.siliconflow,
+            ProviderKind::SiliconflowCN => &self.siliconflow_CN,
             ProviderKind::Arcee => &self.arcee,
             ProviderKind::Moonshot => &self.moonshot,
             ProviderKind::Sglang => &self.sglang,
@@ -283,7 +288,8 @@ impl ProvidersToml {
             ProviderKind::XiaomiMimo => &mut self.xiaomi_mimo,
             ProviderKind::Novita => &mut self.novita,
             ProviderKind::Fireworks => &mut self.fireworks,
-            ProviderKind::Siliconflow | ProviderKind::SiliconflowCN => &mut self.siliconflow,
+            ProviderKind::Siliconflow => &mut self.siliconflow,
+            ProviderKind::SiliconflowCN => &mut self.siliconflow_CN,
             ProviderKind::Arcee => &mut self.arcee,
             ProviderKind::Moonshot => &mut self.moonshot,
             ProviderKind::Sglang => &mut self.sglang,
@@ -2465,7 +2471,9 @@ impl EnvRuntimeOverrides {
             ProviderKind::XiaomiMimo => self.xiaomi_mimo_base_url.clone(),
             ProviderKind::Novita => self.novita_base_url.clone(),
             ProviderKind::Fireworks => self.fireworks_base_url.clone(),
-            ProviderKind::Siliconflow | ProviderKind::SiliconflowCN => self.siliconflow_base_url.clone(),
+            ProviderKind::Siliconflow | ProviderKind::SiliconflowCN => {
+                self.siliconflow_base_url.clone()
+            }
             ProviderKind::Arcee => self.arcee_base_url.clone(),
             ProviderKind::Moonshot => self.moonshot_base_url.clone(),
             ProviderKind::Sglang => self.sglang_base_url.clone(),
@@ -2478,7 +2486,9 @@ impl EnvRuntimeOverrides {
         let model = match provider {
             ProviderKind::WanjieArk => self.wanjie_ark_model.clone(),
             ProviderKind::Volcengine => self.volcengine_model.clone(),
-            ProviderKind::Siliconflow | ProviderKind::SiliconflowCN => self.siliconflow_model.clone(),
+            ProviderKind::Siliconflow | ProviderKind::SiliconflowCN => {
+                self.siliconflow_model.clone()
+            }
             ProviderKind::Arcee => self.arcee_model.clone(),
             ProviderKind::Moonshot => self.moonshot_model.clone(),
             ProviderKind::XiaomiMimo => self.xiaomi_mimo_model.clone(),

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -66,10 +66,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Assistant turns no longer leave an orphaned role glyph (the stray "blue dot")
   when a turn streams only whitespace between reasoning and a tool call.
-- Scrolling the mouse wheel over the right-hand sidebar no longer leaks into
-  the transcript scroll.
-- The sidebar hover tooltip now appears only for truncated lines, sits below
-  the cursor, and uses a neutral surface color instead of the warning-orange
+- Scrolling the mouse wheel over the right-hand sidebar no longer leaks into the
+  transcript scroll.
+- The sidebar hover tooltip now appears only for truncated lines, sits below the
+  cursor, and uses a neutral surface color instead of the warning-orange
   highlight that overlapped neighbouring rows.
 - Corrected the README's description of the Constitution (Article VII is the
   hierarchy itself; Article II's truth duty overrides even a user request) to
@@ -77,6 +77,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Repaired release-blocking unit and integration tests left failing by the
   cycle-removal and compaction-threshold refactors (relay instruction,
   model-reject message, compaction budget, mock-LLM threshold helper).
+- Fixed DEC private-mode CSI fragment leakage into composer text after
+  terminal resets, restoring clean prompt editing (#2592).
+- The engine now recovers from turn-level panics instead of killing the
+  main event loop, keeping the session alive through transient failures
+  (#2583, #1269).
+- Deeply nested files are now discoverable via @-mention and Ctrl+P file
+  picker; the default walk depth was relaxed to handle monorepo layouts (#2488).
+- Command-palette selection stays visible when scrolling through long lists
+  instead of scrolling off-screen (#2590).
+- exec_shell child processes now inherit .NET/NuGet and Windows app-data
+  environment variables, fixing toolchain resolution on Windows (#1857).
+- A warning is emitted when shell/sandbox config keys are nested under
+  unknown top-level sections instead of being silently ignored (#2589).
+- Diff-render now preserves leading whitespace in patch content lines,
+  fixing an extra-space regression in PR previews (#2591). Thanks @zlh124.
+- Model selection from the /model command now persists per-provider across
+  restarts, with a warning when persistence fails.
+
+### Community
+
+Thanks to **@zlh124** (#2591) and **@reidliu41** (#2601) for the fixes
+harvested into this release. Thanks also to **@idling11** (#2602),
+**@gordonlu** (#2585), **@cyq1017** (#2593), **@xyuai** (#2587, #2584),
+and **@IcedOranges** (#2584) for reports, drafts, and investigations
+that shaped this release cycle.
 
 ## [0.8.50] - 2026-06-02
 

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -1092,7 +1092,8 @@ pub(super) fn apply_reasoning_effort(
             | ApiProvider::Openrouter
             | ApiProvider::XiaomiMimo
             | ApiProvider::Novita
-            | ApiProvider::Siliconflow | ApiProvider::SiliconflowCn
+            | ApiProvider::Siliconflow
+            | ApiProvider::SiliconflowCn
             | ApiProvider::Sglang
             | ApiProvider::Volcengine => {
                 body["thinking"] = json!({ "type": "disabled" });
@@ -1128,7 +1129,8 @@ pub(super) fn apply_reasoning_effort(
             // DeepSeek compatibility: low/medium both map to high
             ApiProvider::Deepseek
             | ApiProvider::DeepseekCN
-            | ApiProvider::Siliconflow | ApiProvider::SiliconflowCn
+            | ApiProvider::Siliconflow
+            | ApiProvider::SiliconflowCn
             | ApiProvider::Sglang
             | ApiProvider::Volcengine => {
                 body["reasoning_effort"] = json!("high");
@@ -1189,7 +1191,8 @@ pub(super) fn apply_reasoning_effort(
         "xhigh" | "max" | "highest" => match provider {
             ApiProvider::Deepseek
             | ApiProvider::DeepseekCN
-            | ApiProvider::Siliconflow | ApiProvider::SiliconflowCn
+            | ApiProvider::Siliconflow
+            | ApiProvider::SiliconflowCn
             | ApiProvider::Sglang
             | ApiProvider::Volcengine => {
                 body["reasoning_effort"] = json!("max");

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -178,10 +178,10 @@ impl ApiProvider {
             "novita" => Some(Self::Novita),
             "fireworks" | "fireworks-ai" => Some(Self::Fireworks),
             "siliconflow" | "silicon-flow" | "silicon_flow" => Some(Self::Siliconflow),
-            "siliconflow-cn" | "siliconflow-CN"
-            | "silicon-flow-cn" | "silicon-flow-CN"
-            | "silicon_flow_cn" | "silicon_flow_CN"
-            | "siliconflow-china" => Some(Self::SiliconflowCn),
+            "siliconflow-cn" | "siliconflow-CN" | "silicon-flow-cn" | "silicon-flow-CN"
+            | "silicon_flow_cn" | "silicon_flow_CN" | "siliconflow-china" => {
+                Some(Self::SiliconflowCn)
+            }
             "arcee" | "arcee-ai" | "arcee_ai" => Some(Self::Arcee),
             "moonshot" | "moonshot-ai" | "kimi" | "kimi-k2" => Some(Self::Moonshot),
             "sglang" | "sg-lang" => Some(Self::Sglang),
@@ -697,7 +697,10 @@ pub fn normalize_model_name_for_provider(provider: ApiProvider, model: &str) -> 
         }
         return Some(canonical.to_string());
     }
-    if matches!(provider, ApiProvider::Siliconflow | ApiProvider::SiliconflowCn) {
+    if matches!(
+        provider,
+        ApiProvider::Siliconflow | ApiProvider::SiliconflowCn
+    ) {
         let provider_model = model_for_provider(provider, normalized.clone());
         if provider_model != normalized {
             return Some(provider_model);
@@ -2311,7 +2314,8 @@ impl Config {
             | ApiProvider::XiaomiMimo
             | ApiProvider::Novita
             | ApiProvider::Fireworks
-            | ApiProvider::Siliconflow | ApiProvider::SiliconflowCn
+            | ApiProvider::Siliconflow
+            | ApiProvider::SiliconflowCn
             | ApiProvider::Arcee
             | ApiProvider::Moonshot
             | ApiProvider::Sglang
@@ -2332,7 +2336,6 @@ impl Config {
                 ApiProvider::Novita => DEFAULT_NOVITA_BASE_URL,
                 ApiProvider::Fireworks => DEFAULT_FIREWORKS_BASE_URL,
                 ApiProvider::Siliconflow => DEFAULT_SILICONFLOW_BASE_URL,
-            ApiProvider::SiliconflowCn => DEFAULT_SILICONFLOW_CN_BASE_URL,
                 ApiProvider::SiliconflowCn => DEFAULT_SILICONFLOW_CN_BASE_URL,
                 ApiProvider::Arcee => DEFAULT_ARCEE_BASE_URL,
                 ApiProvider::Moonshot => {
@@ -2387,7 +2390,6 @@ impl Config {
             ApiProvider::Novita => "novita",
             ApiProvider::Fireworks => "fireworks",
             ApiProvider::Siliconflow => "siliconflow",
-            ApiProvider::SiliconflowCn => "siliconflow-CN",
             ApiProvider::SiliconflowCn => "siliconflow-CN",
             ApiProvider::Arcee => "arcee",
             ApiProvider::Moonshot => "moonshot",
@@ -3303,8 +3305,10 @@ fn apply_env_overrides(config: &mut Config) {
             .fireworks
             .base_url = Some(value);
     }
-    if matches!(config.api_provider(), ApiProvider::Siliconflow | ApiProvider::SiliconflowCn)
-        && let Ok(value) = std::env::var("SILICONFLOW_BASE_URL")
+    if matches!(
+        config.api_provider(),
+        ApiProvider::Siliconflow | ApiProvider::SiliconflowCn
+    ) && let Ok(value) = std::env::var("SILICONFLOW_BASE_URL")
         && !value.trim().is_empty()
     {
         config
@@ -3460,8 +3464,10 @@ fn apply_env_overrides(config: &mut Config) {
             .moonshot
             .model = Some(value);
     }
-    if matches!(config.api_provider(), ApiProvider::Siliconflow | ApiProvider::SiliconflowCn)
-        && let Ok(value) = std::env::var("SILICONFLOW_MODEL")
+    if matches!(
+        config.api_provider(),
+        ApiProvider::Siliconflow | ApiProvider::SiliconflowCn
+    ) && let Ok(value) = std::env::var("SILICONFLOW_MODEL")
         && !value.trim().is_empty()
     {
         config
@@ -3829,8 +3835,7 @@ fn default_base_url_for_provider(provider: ApiProvider) -> &'static str {
         ApiProvider::Novita => DEFAULT_NOVITA_BASE_URL,
         ApiProvider::Fireworks => DEFAULT_FIREWORKS_BASE_URL,
         ApiProvider::Siliconflow => DEFAULT_SILICONFLOW_BASE_URL,
-            ApiProvider::SiliconflowCn => DEFAULT_SILICONFLOW_CN_BASE_URL,
-                ApiProvider::SiliconflowCn => DEFAULT_SILICONFLOW_CN_BASE_URL,
+        ApiProvider::SiliconflowCn => DEFAULT_SILICONFLOW_CN_BASE_URL,
         ApiProvider::Arcee => DEFAULT_ARCEE_BASE_URL,
         ApiProvider::Moonshot => DEFAULT_MOONSHOT_BASE_URL,
         ApiProvider::Sglang => DEFAULT_SGLANG_BASE_URL,
@@ -3841,7 +3846,9 @@ fn default_base_url_for_provider(provider: ApiProvider) -> &'static str {
 }
 
 fn base_url_is_custom_for_provider(provider: ApiProvider, base_url: &str) -> bool {
-    if (provider == ApiProvider::Siliconflow || provider == ApiProvider::SiliconflowCn) && siliconflow_base_url_is_official(base_url) {
+    if (provider == ApiProvider::Siliconflow || provider == ApiProvider::SiliconflowCn)
+        && siliconflow_base_url_is_official(base_url)
+    {
         return false;
     }
     normalize_base_url(base_url) != normalize_base_url(default_base_url_for_provider(provider))
@@ -4758,8 +4765,7 @@ pub fn save_api_key_for(provider: ApiProvider, api_key: &str) -> Result<PathBuf>
         ApiProvider::Novita => "novita",
         ApiProvider::Fireworks => "fireworks",
         ApiProvider::Siliconflow => "siliconflow",
-            ApiProvider::SiliconflowCn => "siliconflow-CN",
-            ApiProvider::SiliconflowCn => "siliconflow-CN",
+        ApiProvider::SiliconflowCn => "siliconflow-CN",
         ApiProvider::Arcee => "arcee",
         ApiProvider::Moonshot => "moonshot",
         ApiProvider::Sglang => "sglang",
@@ -4854,7 +4860,7 @@ fn provider_config_key(provider: ApiProvider) -> Result<&'static str> {
         ApiProvider::Novita => Ok("novita"),
         ApiProvider::Fireworks => Ok("fireworks"),
         ApiProvider::Siliconflow => Ok("siliconflow"),
-            ApiProvider::SiliconflowCn => Ok("siliconflow-CN"),
+        ApiProvider::SiliconflowCn => Ok("siliconflow-CN"),
         ApiProvider::Arcee => Ok("arcee"),
         ApiProvider::Moonshot => Ok("moonshot"),
         ApiProvider::Sglang => Ok("sglang"),

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -2000,7 +2000,8 @@ fn run_setup_status(config: &Config, workspace: &Path) -> Result<()> {
                     "FIREWORKS_API_KEY",
                     "codewhale auth set --provider fireworks --api-key \"...\"",
                 ),
-                crate::config::ApiProvider::Siliconflow | crate::config::ApiProvider::SiliconflowCn => (
+                crate::config::ApiProvider::Siliconflow
+                | crate::config::ApiProvider::SiliconflowCn => (
                     "SILICONFLOW_API_KEY",
                     "codewhale auth set --provider siliconflow --api-key \"...\"",
                 ),
@@ -2044,7 +2045,8 @@ fn run_setup_status(config: &Config, workspace: &Path) -> Result<()> {
                     crate::config::ApiProvider::XiaomiMimo => "xiaomi_mimo",
                     crate::config::ApiProvider::Novita => "novita",
                     crate::config::ApiProvider::Fireworks => "fireworks",
-                    crate::config::ApiProvider::Siliconflow | crate::config::ApiProvider::SiliconflowCn => "siliconflow",
+                    crate::config::ApiProvider::Siliconflow
+                    | crate::config::ApiProvider::SiliconflowCn => "siliconflow",
                     crate::config::ApiProvider::Arcee => "arcee",
                     crate::config::ApiProvider::Moonshot => "moonshot",
                     crate::config::ApiProvider::Sglang => "sglang",

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -40,6 +40,7 @@ use crate::tui::history::{HistoryCell, TranscriptRenderOptions};
 use crate::tui::paste_burst::{FlushResult, PasteBurst};
 use crate::tui::scrolling::{MouseScrollState, TranscriptLineMeta, TranscriptScroll};
 use crate::tui::selection::{SelectionAutoscroll, TranscriptSelection};
+use crate::tui::sidebar::SidebarWorkSummary;
 use crate::tui::streaming::StreamingState;
 use crate::tui::transcript::TranscriptViewCache;
 use crate::tui::views::ViewStack;
@@ -1297,6 +1298,9 @@ pub struct App {
     pub sidebar_hover: SidebarHoverState,
     /// Current hover tooltip text, if any.
     pub sidebar_hover_tooltip: Option<String>,
+    /// Cached Work panel summary — used as fallback when `try_lock()` on
+    /// the shared todo/plan mutexes fails during a frame render.
+    pub cached_work_summary: Option<SidebarWorkSummary>,
     /// Last known mouse position for tooltip placement.
     pub last_mouse_pos: Option<(u16, u16)>,
     /// Whether the user is currently dragging the sidebar resize handle.
@@ -2034,6 +2038,7 @@ impl App {
             sidebar_focus,
             sidebar_hover: SidebarHoverState::default(),
             sidebar_hover_tooltip: None,
+            cached_work_summary: None,
             last_mouse_pos: None,
             sidebar_resizing: false,
             sidebar_resize_anchor_x: 0,

--- a/crates/tui/src/tui/notifications.rs
+++ b/crates/tui/src/tui/notifications.rs
@@ -699,7 +699,7 @@ pub fn latest_assistant_text(messages: &[Message]) -> Option<String> {
                     | ContentBlock::ServerToolUse { .. }
                     | ContentBlock::ToolSearchToolResult { .. }
                     | ContentBlock::CodeExecutionToolResult { .. } => None,
-                    | ContentBlock::ImageUrl { .. } => None,
+                    ContentBlock::ImageUrl { .. } => None,
                 })
                 .collect::<Vec<_>>()
                 .join("\n");

--- a/crates/tui/src/tui/session_picker.rs
+++ b/crates/tui/src/tui/session_picker.rs
@@ -790,9 +790,7 @@ fn message_text_for_history(message: &crate::models::Message) -> String {
             | crate::models::ContentBlock::CodeExecutionToolResult { content, .. } => {
                 format!("tool result: {}", truncate(&content.to_string(), 220))
             }
-            crate::models::ContentBlock::ImageUrl { .. } => {
-                String::from("[image]")
-            }
+            crate::models::ContentBlock::ImageUrl { .. } => String::from("[image]"),
         };
         let part = part.trim();
         if !part.is_empty() {

--- a/crates/tui/src/tui/sidebar.rs
+++ b/crates/tui/src/tui/sidebar.rs
@@ -154,21 +154,21 @@ fn auto_sidebar_panels(state: AutoSidebarState) -> Vec<AutoSidebarPanel> {
 }
 
 #[derive(Debug, Clone)]
-struct SidebarWorkChecklistItem {
-    id: u32,
-    content: String,
-    status: TodoStatus,
+pub(crate) struct SidebarWorkChecklistItem {
+    pub(crate) id: u32,
+    pub(crate) content: String,
+    pub(crate) status: TodoStatus,
 }
 
 #[derive(Debug, Clone)]
-struct SidebarWorkStrategyStep {
-    text: String,
-    status: StepStatus,
-    elapsed: String,
+pub(crate) struct SidebarWorkStrategyStep {
+    pub(crate) text: String,
+    pub(crate) status: StepStatus,
+    pub(crate) elapsed: String,
 }
 
 #[derive(Debug, Clone, Default)]
-struct SidebarWorkSummary {
+pub(crate) struct SidebarWorkSummary {
     goal_objective: Option<String>,
     goal_token_budget: Option<u32>,
     goal_completed: bool,
@@ -226,56 +226,83 @@ impl SidebarWorkSummary {
     }
 }
 
-fn sidebar_work_summary(app: &App) -> SidebarWorkSummary {
-    let mut summary = SidebarWorkSummary {
-        goal_objective: app.hunt.quarry.clone(),
-        goal_token_budget: app.hunt.token_budget,
-        goal_completed: app.hunt.verdict == HuntVerdict::Hunted,
-        goal_started_at: app.hunt.started_at,
-        tokens_used: app.session.total_conversation_tokens,
-        ..SidebarWorkSummary::default()
-    };
+fn sidebar_work_summary(app: &mut App) -> SidebarWorkSummary {
+    // Try to build a fresh summary from the shared mutexes. When either
+    // lock is busy (engine is updating state in another tokio task),
+    // fall back to the last cached snapshot instead of wiping the panel.
+    let fresh = (|| {
+        let todos = app.todos.try_lock().ok()?;
+        let plan = app.plan_state.try_lock().ok()?;
 
-    match app.todos.try_lock() {
-        Ok(todos) => {
-            let snapshot = todos.snapshot();
-            summary.checklist_completion_pct = snapshot.completion_pct;
-            summary.checklist_items = snapshot
-                .items
-                .into_iter()
-                .map(|item| SidebarWorkChecklistItem {
-                    id: item.id,
-                    content: item.content,
-                    status: item.status,
-                })
-                .collect();
-        }
-        Err(_) => {
-            summary.state_updating = true;
-        }
-    }
+        let todos_snapshot = todos.snapshot();
+        let checklist_completion_pct = todos_snapshot.completion_pct;
+        let checklist_items: Vec<SidebarWorkChecklistItem> = todos_snapshot
+            .items
+            .into_iter()
+            .map(|item| SidebarWorkChecklistItem {
+                id: item.id,
+                content: item.content,
+                status: item.status,
+            })
+            .collect();
 
-    match app.plan_state.try_lock() {
-        Ok(plan) => {
-            if !plan.is_empty() {
-                summary.strategy_explanation = plan.explanation().map(str::to_string);
-                summary.strategy_steps = plan
-                    .steps()
+        let (strategy_explanation, strategy_steps) = if plan.is_empty() {
+            (None, Vec::new())
+        } else {
+            (
+                plan.explanation().map(str::to_string),
+                plan.steps()
                     .iter()
                     .map(|step| SidebarWorkStrategyStep {
                         text: step.text.clone(),
                         status: step.status.clone(),
                         elapsed: step.elapsed_str(),
                     })
-                    .collect();
-            }
-        }
-        Err(_) => {
-            summary.state_updating = true;
-        }
+                    .collect(),
+            )
+        };
+
+        Some(SidebarWorkSummary {
+            goal_objective: app.hunt.quarry.clone(),
+            goal_token_budget: app.hunt.token_budget,
+            goal_completed: app.hunt.verdict == HuntVerdict::Hunted,
+            goal_started_at: app.hunt.started_at,
+            tokens_used: app.session.total_conversation_tokens,
+            checklist_completion_pct,
+            checklist_items,
+            strategy_explanation,
+            strategy_steps,
+            state_updating: false,
+        })
+    })();
+
+    if let Some(summary) = fresh {
+        app.cached_work_summary = Some(summary.clone());
+        return summary;
     }
 
-    summary
+    // Fall back to cached snapshot. Only emit "updating" when there is
+    // genuinely nothing to show (first render before any todos exist).
+    if let Some(ref cached) = app.cached_work_summary {
+        let mut summary = cached.clone();
+        // Keep hunt/goal fields live even when locks are busy.
+        summary.goal_objective = app.hunt.quarry.clone();
+        summary.goal_token_budget = app.hunt.token_budget;
+        summary.goal_completed = app.hunt.verdict == HuntVerdict::Hunted;
+        summary.goal_started_at = app.hunt.started_at;
+        summary.tokens_used = app.session.total_conversation_tokens;
+        return summary;
+    }
+
+    SidebarWorkSummary {
+        goal_objective: app.hunt.quarry.clone(),
+        goal_token_budget: app.hunt.token_budget,
+        goal_completed: app.hunt.verdict == HuntVerdict::Hunted,
+        goal_started_at: app.hunt.started_at,
+        tokens_used: app.session.total_conversation_tokens,
+        state_updating: true,
+        ..SidebarWorkSummary::default()
+    }
 }
 
 fn work_panel_lines(
@@ -1946,8 +1973,8 @@ mod tests {
         AutoSidebarState, SidebarAgentRow, SidebarHoverSection, SidebarHoverState,
         SidebarSubagentSummary, SidebarToolRow, SidebarWorkChecklistItem, SidebarWorkStrategyStep,
         SidebarWorkSummary, ToolRowOrder, auto_sidebar_panels, editorial_tool_rows,
-        normalize_activity_text, subagent_panel_lines, task_panel_lines, work_panel_empty_hint,
-        work_panel_lines,
+        normalize_activity_text, sidebar_work_summary, subagent_panel_lines, task_panel_lines,
+        work_panel_empty_hint, work_panel_lines,
     };
     use crate::config::Config;
     use crate::palette;
@@ -1955,7 +1982,7 @@ mod tests {
     use crate::tools::plan::StepStatus;
     use crate::tools::todo::TodoStatus;
     use crate::tui::active_cell::ActiveCell;
-    use crate::tui::app::{App, TaskPanelEntry, TuiOptions};
+    use crate::tui::app::{App, HuntVerdict, TaskPanelEntry, TuiOptions};
     use crate::tui::history::{
         ExecCell, ExecSource, GenericToolCell, HistoryCell, ToolCell, ToolStatus,
     };
@@ -2243,6 +2270,82 @@ mod tests {
                 .any(|line| line.contains("High-level sequencing")),
             "non-empty plan explanation should render: {text:?}"
         );
+    }
+
+    // ── SidebarWorkSummary cache tests ──────────────────────────────
+
+    #[test]
+    fn sidebar_work_summary_caches_on_success() {
+        let mut app = create_test_app();
+        {
+            let mut todos = app.todos.try_lock().expect("todos lock");
+            todos.add("cache test".to_string(), TodoStatus::InProgress);
+        }
+
+        let summary = sidebar_work_summary(&mut app);
+        assert!(!summary.state_updating, "should not be updating");
+        assert_eq!(summary.checklist_items.len(), 1);
+        assert!(
+            app.cached_work_summary.is_some(),
+            "cache should be populated"
+        );
+    }
+
+    #[test]
+    fn sidebar_work_summary_falls_back_to_cache_when_todos_lock_busy() {
+        let mut app = create_test_app();
+        {
+            let mut todos = app.todos.try_lock().expect("todos lock");
+            todos.add("will be cached".to_string(), TodoStatus::Completed);
+        }
+        let _first = sidebar_work_summary(&mut app);
+        assert!(app.cached_work_summary.is_some());
+
+        let held_arc = app.todos.clone();
+        let _held = held_arc.try_lock().expect("hold todos lock");
+
+        let summary = sidebar_work_summary(&mut app);
+        assert!(!summary.state_updating, "should fall back to cache");
+        assert!(
+            summary
+                .checklist_items
+                .iter()
+                .any(|i| i.content == "will be cached"),
+            "cached item should be present"
+        );
+    }
+
+    #[test]
+    fn sidebar_work_summary_returns_updating_when_no_cache_and_locks_busy() {
+        let mut app = create_test_app();
+        let held_arc = app.todos.clone();
+        let _held = held_arc.try_lock().expect("hold todos lock");
+
+        let summary = sidebar_work_summary(&mut app);
+        assert!(summary.state_updating, "should be updating without cache");
+    }
+
+    #[test]
+    fn sidebar_work_summary_keeps_live_fields_on_cache_fallback() {
+        let mut app = create_test_app();
+        app.hunt.quarry = Some("test quarry".to_string());
+        app.hunt.verdict = HuntVerdict::Hunted;
+
+        {
+            let mut todos = app.todos.try_lock().expect("todos lock");
+            todos.add("item".to_string(), TodoStatus::Pending);
+        }
+        let _first = sidebar_work_summary(&mut app);
+
+        app.hunt.quarry = Some("updated quarry".to_string());
+        app.hunt.verdict = HuntVerdict::Hunting;
+
+        let held_arc = app.todos.clone();
+        let _held = held_arc.try_lock().expect("hold todos lock");
+
+        let summary = sidebar_work_summary(&mut app);
+        assert_eq!(summary.goal_objective.as_deref(), Some("updated quarry"));
+        assert!(!summary.goal_completed, "verdict should be live (Hunting)");
     }
 
     #[test]

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -6604,7 +6604,9 @@ fn render(f: &mut Frame, app: &mut App) {
             crate::config::ApiProvider::XiaomiMimo => Some("MiMo"),
             crate::config::ApiProvider::Novita => Some("Novita"),
             crate::config::ApiProvider::Fireworks => Some("Fireworks"),
-            crate::config::ApiProvider::Siliconflow | ApiProvider::SiliconflowCn => Some("SiliconFlow"),
+            crate::config::ApiProvider::Siliconflow | ApiProvider::SiliconflowCn => {
+                Some("SiliconFlow")
+            }
             crate::config::ApiProvider::Arcee => Some("Arcee"),
             crate::config::ApiProvider::Moonshot => Some("Kimi"),
             crate::config::ApiProvider::Sglang => Some("SGLang"),

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -6,7 +6,7 @@ limited to provider IDs, config keys, auth paths, base URLs, model resolution,
 and capability metadata that the code already knows about.
 
 DeepSeek remains the first-class default provider. NVIDIA NIM, OpenRouter,
-Volcengine Ark, Xiaomi MiMo, Novita, Fireworks, SiliconFlow, Arcee AI, generic
+Volcengine Ark, Xiaomi MiMo, Novita, Fireworks, SiliconFlow, SiliconFlow CN, Arcee AI, generic
 OpenAI-compatible endpoints, self-hosted runtimes, and Moonshot/Kimi are
 additive routes for running the same terminal harness against other hosted or
 local model endpoints. Hugging Face Inference Providers are a planned additive
@@ -30,7 +30,7 @@ Sources to keep in sync:
 The canonical provider IDs are:
 
 `deepseek`, `nvidia-nim`, `openai`, `atlascloud`, `wanjie-ark`, `volcengine`,
-`openrouter`, `xiaomi-mimo`, `novita`, `fireworks`, `siliconflow`, `arcee`,
+`openrouter`, `xiaomi-mimo`, `novita`, `fireworks`, `siliconflow`, `siliconflow-CN`, `arcee`,
 `moonshot`, `sglang`, `vllm`, and `ollama`.
 
 Use any of these surfaces to select a provider:
@@ -122,6 +122,7 @@ endpoint.
 | `novita` | `[providers.novita]` | `NOVITA_API_KEY` | `NOVITA_BASE_URL`; default `https://api.novita.ai/v1` | `deepseek/deepseek-v4-pro`, `deepseek/deepseek-v4-flash` | OpenAI-compatible hosted route for DeepSeek model IDs. Use config or `CODEWHALE_MODEL` / `DEEPSEEK_MODEL` for model overrides. |
 | `fireworks` | `[providers.fireworks]` | `FIREWORKS_API_KEY` | `FIREWORKS_BASE_URL`; default `https://api.fireworks.ai/inference/v1` | `accounts/fireworks/models/deepseek-v4-pro` | OpenAI-compatible hosted route. Use config or `CODEWHALE_MODEL` / `DEEPSEEK_MODEL` for model overrides. |
 | `siliconflow` | `[providers.siliconflow]` | `SILICONFLOW_API_KEY` | `SILICONFLOW_BASE_URL`; default `https://api.siliconflow.com/v1` | `deepseek-ai/DeepSeek-V4-Pro`, `deepseek-ai/DeepSeek-V4-Flash` | OpenAI-compatible hosted route. Official docs use the `.com` endpoint; users who need the regional endpoint can set `https://api.siliconflow.cn/v1` explicitly. `SILICONFLOW_MODEL` is accepted. Reasoning aliases `deepseek-reasoner` and `deepseek-r1` map to Pro; `deepseek-chat` and `deepseek-v3` map to Flash. |
+| `siliconflow-CN` | `[providers.siliconflow_CN]` | `SILICONFLOW_API_KEY` | `SILICONFLOW_BASE_URL`; default `https://api.siliconflow.cn/v1` | `deepseek-ai/DeepSeek-V4-Pro`, `deepseek-ai/DeepSeek-V4-Flash` | SiliconFlow China regional endpoint (`.cn`). Shares API key env var with the global `siliconflow` provider. |
 | `arcee` | `[providers.arcee]` | `ARCEE_API_KEY` | `ARCEE_BASE_URL`; default `https://api.arcee.ai/api/v1` | `trinity-large-thinking`, `trinity-large-preview` | Arcee AI direct OpenAI-compatible route, tracked as 256K-context BF16 serving. `ARCEE_MODEL` is accepted. OpenRouter's `arcee-ai/trinity-large-thinking` remains the OpenRouter namespaced model ID; direct Arcee uses the bare `trinity-large-thinking` ID. |
 | `moonshot` | `[providers.moonshot]` | `MOONSHOT_API_KEY`, `KIMI_API_KEY` | `MOONSHOT_BASE_URL`, `KIMI_BASE_URL`; default `https://api.moonshot.ai/v1` | `kimi-k2.6`; Kimi Code path uses `kimi-for-coding` at `https://api.kimi.com/coding/v1` | Moonshot/Kimi route. `MOONSHOT_MODEL`, `KIMI_MODEL_NAME`, and `KIMI_MODEL` are accepted. `[providers.moonshot] auth_mode = "kimi_oauth"` reads Kimi CLI OAuth credentials when present. |
 | `sglang` | `[providers.sglang]` | Optional `SGLANG_API_KEY` | `SGLANG_BASE_URL`; default `http://localhost:30000/v1` | `deepseek-ai/DeepSeek-V4-Pro`, `deepseek-ai/DeepSeek-V4-Flash` | Self-hosted OpenAI-compatible route. Localhost deployments commonly omit auth. `SGLANG_MODEL` is accepted. |

--- a/scripts/check-provider-registry.py
+++ b/scripts/check-provider-registry.py
@@ -103,7 +103,7 @@ def provider_tables(config_rs: str) -> set[str]:
     )
     struct_end = require_index(config_rs, "\n}", "ProvidersToml struct", struct_start)
     fields = re.findall(
-        r"pub\s+([a-z0-9_]+)\s*:\s*ProviderConfigToml",
+        r"pub\s+([a-zA-Z0-9_]+)\s*:\s*ProviderConfigToml",
         config_rs[struct_start:struct_end],
     )
     if not fields:
@@ -118,7 +118,7 @@ def shipped_provider_rows(providers_md: str) -> set[str]:
 
 def shipped_provider_tables(providers_md: str) -> set[str]:
     table = markdown_section(providers_md, "## Shipped Providers")
-    return set(re.findall(r"\|\s*`\[providers\.([a-z0-9_]+)\]`\s*\|", table))
+    return set(re.findall(r"\|\s*`\[providers\.([a-zA-Z0-9_]+)\]`\s*\|", table))
 
 
 def static_registry_provider_rows(providers_md: str) -> set[str]:


### PR DESCRIPTION
The sidebar Work panel reads checklist data from `app.todos` (`tokio::sync::Mutex`) via non-blocking `try_lock()`. When the engine holds the lock (executing `checklist_write` in a tokio task), the panel silently resets to "Work state updating..." and discards all prior data. The Tasks panel does not suffer from this because it reads plain App fields (no lock needed).

Fix: cache the last successful `SidebarWorkSummary` in `App` and return it when `try_lock()` fails. Live hunt/goal fields (quarry, verdict, cycle count, token usage) are still refreshed from the current App state on every frame, even during cache fallback.

- Make `SidebarWorkSummary`, `SidebarWorkChecklistItem`, `SidebarWorkStrategyStep` pub(crate) so App can store them.
- Add `cached_work_summary: Option<SidebarWorkSummary>` to App.
- Rewrite `sidebar_work_summary(&mut App)` to use a fallback chain: fresh locks → cache → state_updating empty state.
- Add 4 unit tests covering cache populate, lock-busy fallback, no-cache+lock fallback, and live-field refresh during fallback.

Closes #2606

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes Work panel flickering in the TUI sidebar by caching the last successful `SidebarWorkSummary` in `App` and returning it as a fallback when the `todos`/`plan_state` mutexes are held by the engine, instead of resetting to "Work state updating…". It also adds `SiliconflowCN` as a distinct provider alongside the existing `Siliconflow`.

- `sidebar_work_summary` is rewritten to use a three-tier fallback chain (fresh lock → cached snapshot → empty updating state), with live hunt/goal fields refreshed on every frame even during fallback. Four unit tests cover all branches.
- `SiliconflowCN` is wired into the CLI enum, TUI config, `ProvidersToml`, env-var mapping, and documentation. Several duplicated match arms introduced in an earlier commit are also removed.
- Code-formatting-only cleanups (long match arm line-wrapping) are spread across `config.rs`, `client.rs`, `main.rs`, and `ui.rs`.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after fixing the SiliconflowCN credential write/read key mismatch in config.rs; the sidebar caching change is correct.

The sidebar caching logic, tests, and App field addition are all correct. The SiliconflowCN wiring has one concrete defect: `save_api_key_for` and `provider_config_key` both use `"siliconflow-CN"` (hyphen) as the TOML table key, but `ProvidersToml.siliconflow_CN` (underscore) is what serde will read — so any credential written via `codewhale auth set --provider siliconflow-cn` is immediately orphaned and authentication for SiliconflowCN will always fall back to the default (empty) config.

crates/tui/src/config.rs — `save_api_key_for` and `provider_config_key` use the wrong separator for the SiliconflowCN TOML key.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/sidebar.rs | Core of the PR: rewrites `sidebar_work_summary` to cache the last successful `SidebarWorkSummary` in `App`, falling back to it when `try_lock()` misses. Logic and fallback chain are correct; live hunt/goal fields are refreshed even on cache fallback. Four unit tests cover the main scenarios. |
| crates/tui/src/config.rs | Two functions (`save_api_key_for` and `provider_config_key`) use `"siliconflow-CN"` (hyphen) as the TOML key for SiliconflowCN, but `ProvidersToml.siliconflow_CN` (underscore) is what serde deserializes — the written credential is silently orphaned and never read back. The rest of the SiliconflowCN match-arm deduplication and formatting cleanups are correct. |
| crates/tui/src/tui/app.rs | Adds `cached_work_summary: Option<SidebarWorkSummary>` field to `App`, initialized to `None`. Clean, minimal change to support the caching fix in sidebar.rs. |
| crates/config/src/lib.rs | Adds `siliconflow_CN: ProviderConfigToml` field (with `#[allow(non_snake_case)]`) and splits SiliconflowCN from Siliconflow in `get`/`get_mut`. The field name `siliconflow_CN` (underscore) correctly reflects what serde will read from TOML, but callers in `config.rs` write the hyphenated form, causing the read/write mismatch flagged above. |
| crates/cli/src/lib.rs | Adds `SiliconflowCN` to the CLI provider enum, slot function (returning `"siliconflow-cn"`), env-var list, and provider list. Straightforward additions with a matching test case. |
| crates/tui/src/tui/notifications.rs | Removes a spurious leading `|` on the `ContentBlock::ImageUrl` match arm — trivial correctness fix. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[render frame - sidebar_work_summary called] --> B{try_lock todos AND plan_state}
    B -- both succeed --> C[Build fresh SidebarWorkSummary\nstate_updating = false]
    C --> D[Store clone in app.cached_work_summary]
    D --> E[Return fresh summary]
    B -- either lock busy --> F{app.cached_work_summary is Some?}
    F -- yes --> G[Clone cached summary]
    G --> H[Overwrite live fields:\nquarry, token_budget,\nverdict, tokens_used]
    H --> I[Return updated cache\nstate_updating stays false]
    F -- no --> J[Return empty SidebarWorkSummary\nstate_updating = true]
    E --> K[Render Work panel]
    I --> K
    J --> K
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/tui/src/tui/sidebar.rs`, line 68 ([link](https://github.com/hmbown/codewhale/blob/d9544d22ee3b01a4877a3d3ee2b53bf3ad83f813/crates/tui/src/tui/sidebar.rs#L68)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Double invocation of `sidebar_work_summary` per frame**

   `sidebar_work_summary(app)` is called here just to compute `has_useful_content()`, and then called again at line 587 inside `render_sidebar_work` for actual rendering. Each call now acquires both mutexes, builds a full `SidebarWorkSummary`, and writes a `clone()` into the cache — so every frame where the Work panel is visible pays for two mutex acquisitions, two snapshot copies, and two heap allocations.

   This double-call pattern predates this PR, but the added `clone()` on every successful path makes it marginally more expensive. A straightforward fix would be to compute the summary once in `render_sidebar_auto` and pass it by reference to `render_sidebar_work`, eliminating the redundant invocation.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fsidebar-work-stale-cache-v2%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fsidebar-work-stale-cache-v2%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fsidebar.rs%0ALine%3A%2068%0A%0AComment%3A%0A**Double%20invocation%20of%20%60sidebar_work_summary%60%20per%20frame**%0A%0A%60sidebar_work_summary%28app%29%60%20is%20called%20here%20just%20to%20compute%20%60has_useful_content%28%29%60%2C%20and%20then%20called%20again%20at%20line%20587%20inside%20%60render_sidebar_work%60%20for%20actual%20rendering.%20Each%20call%20now%20acquires%20both%20mutexes%2C%20builds%20a%20full%20%60SidebarWorkSummary%60%2C%20and%20writes%20a%20%60clone%28%29%60%20into%20the%20cache%20%E2%80%94%20so%20every%20frame%20where%20the%20Work%20panel%20is%20visible%20pays%20for%20two%20mutex%20acquisitions%2C%20two%20snapshot%20copies%2C%20and%20two%20heap%20allocations.%0A%0AThis%20double-call%20pattern%20predates%20this%20PR%2C%20but%20the%20added%20%60clone%28%29%60%20on%20every%20successful%20path%20makes%20it%20marginally%20more%20expensive.%20A%20straightforward%20fix%20would%20be%20to%20compute%20the%20summary%20once%20in%20%60render_sidebar_auto%60%20and%20pass%20it%20by%20reference%20to%20%60render_sidebar_work%60%2C%20eliminating%20the%20redundant%20invocation.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fsidebar.rs%0ALine%3A%2068%0A%0AComment%3A%0A**Double%20invocation%20of%20%60sidebar_work_summary%60%20per%20frame**%0A%0A%60sidebar_work_summary%28app%29%60%20is%20called%20here%20just%20to%20compute%20%60has_useful_content%28%29%60%2C%20and%20then%20called%20again%20at%20line%20587%20inside%20%60render_sidebar_work%60%20for%20actual%20rendering.%20Each%20call%20now%20acquires%20both%20mutexes%2C%20builds%20a%20full%20%60SidebarWorkSummary%60%2C%20and%20writes%20a%20%60clone%28%29%60%20into%20the%20cache%20%E2%80%94%20so%20every%20frame%20where%20the%20Work%20panel%20is%20visible%20pays%20for%20two%20mutex%20acquisitions%2C%20two%20snapshot%20copies%2C%20and%20two%20heap%20allocations.%0A%0AThis%20double-call%20pattern%20predates%20this%20PR%2C%20but%20the%20added%20%60clone%28%29%60%20on%20every%20successful%20path%20makes%20it%20marginally%20more%20expensive.%20A%20straightforward%20fix%20would%20be%20to%20compute%20the%20summary%20once%20in%20%60render_sidebar_auto%60%20and%20pass%20it%20by%20reference%20to%20%60render_sidebar_work%60%2C%20eliminating%20the%20redundant%20invocation.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2616&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fsidebar.rs%0ALine%3A%2068%0A%0AComment%3A%0A**Double%20invocation%20of%20%60sidebar_work_summary%60%20per%20frame**%0A%0A%60sidebar_work_summary%28app%29%60%20is%20called%20here%20just%20to%20compute%20%60has_useful_content%28%29%60%2C%20and%20then%20called%20again%20at%20line%20587%20inside%20%60render_sidebar_work%60%20for%20actual%20rendering.%20Each%20call%20now%20acquires%20both%20mutexes%2C%20builds%20a%20full%20%60SidebarWorkSummary%60%2C%20and%20writes%20a%20%60clone%28%29%60%20into%20the%20cache%20%E2%80%94%20so%20every%20frame%20where%20the%20Work%20panel%20is%20visible%20pays%20for%20two%20mutex%20acquisitions%2C%20two%20snapshot%20copies%2C%20and%20two%20heap%20allocations.%0A%0AThis%20double-call%20pattern%20predates%20this%20PR%2C%20but%20the%20added%20%60clone%28%29%60%20on%20every%20successful%20path%20makes%20it%20marginally%20more%20expensive.%20A%20straightforward%20fix%20would%20be%20to%20compute%20the%20summary%20once%20in%20%60render_sidebar_auto%60%20and%20pass%20it%20by%20reference%20to%20%60render_sidebar_work%60%2C%20eliminating%20the%20redundant%20invocation.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2616&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fsidebar-work-stale-cache-v2%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fsidebar-work-stale-cache-v2%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fconfig.rs%3A4768-4776%0A%60save_api_key_for%60%20uses%20%60%22siliconflow-CN%22%60%20%28hyphen%29%20as%20the%20TOML%20table%20key%2C%20but%20%60ProvidersToml%60%20exposes%20the%20field%20as%20%60siliconflow_CN%60%20%28underscore%29.%20In%20TOML%20these%20are%20distinct%20keys.%20Every%20other%20multi-word%20provider%20consistently%20uses%20underscores%20here%20%28%60nvidia_nim%60%2C%20%60wanjie_ark%60%2C%20%60xiaomi_mimo%60%29.%20As%20a%20result%2C%20%60codewhale%20auth%20set%20--provider%20siliconflow-cn%20--api-key%20%22...%22%60%20writes%20to%20%60%5Bproviders.siliconflow-CN%5D%60%2C%20which%20is%20silently%20ignored%20when%20the%20file%20is%20deserialized%20%E2%80%94%20%60ProvidersToml.siliconflow_CN%60%20stays%20at%20its%20default%20and%20the%20credential%20is%20never%20read%20back.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20ApiProvider%3A%3ASiliconflowCn%20%3D%3E%20%22siliconflow_CN%22%2C%0A%20%20%20%20%20%20%20%20ApiProvider%3A%3AArcee%20%3D%3E%20%22arcee%22%2C%0A%20%20%20%20%20%20%20%20ApiProvider%3A%3AMoonshot%20%3D%3E%20%22moonshot%22%2C%0A%20%20%20%20%20%20%20%20ApiProvider%3A%3ASglang%20%3D%3E%20%22sglang%22%2C%0A%20%20%20%20%20%20%20%20ApiProvider%3A%3AVllm%20%3D%3E%20%22vllm%22%2C%0A%20%20%20%20%20%20%20%20ApiProvider%3A%3AOllama%20%3D%3E%20%22ollama%22%2C%0A%20%20%20%20%20%20%20%20ApiProvider%3A%3AVolcengine%20%3D%3E%20%22volcengine%22%2C%0A%20%20%20%20%7D%3B%0A%20%20%20%20let%20entry%20%3D%20providers%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fconfig.rs%3A4863-4870%0A%60provider_config_key%60%20also%20returns%20%60%22siliconflow-CN%22%60%20%28hyphen%29%2C%20creating%20the%20same%20mismatch.%20Any%20code%20that%20uses%20this%20function%20to%20locate%20the%20provider's%20TOML%20section%20will%20look%20for%20%60%5Bproviders.siliconflow-CN%5D%60%20rather%20than%20%60%5Bproviders.siliconflow_CN%5D%60%20and%20find%20nothing.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20ApiProvider%3A%3ASiliconflowCn%20%3D%3E%20Ok%28%22siliconflow_CN%22%29%2C%0A%20%20%20%20%20%20%20%20ApiProvider%3A%3AArcee%20%3D%3E%20Ok%28%22arcee%22%29%2C%0A%20%20%20%20%20%20%20%20ApiProvider%3A%3AMoonshot%20%3D%3E%20Ok%28%22moonshot%22%29%2C%0A%20%20%20%20%20%20%20%20ApiProvider%3A%3ASglang%20%3D%3E%20Ok%28%22sglang%22%29%2C%0A%20%20%20%20%20%20%20%20ApiProvider%3A%3AVllm%20%3D%3E%20Ok%28%22vllm%22%29%2C%0A%20%20%20%20%20%20%20%20ApiProvider%3A%3AOllama%20%3D%3E%20Ok%28%22ollama%22%29%2C%0A%20%20%20%20%7D%0A%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fconfig.rs%3A4768-4776%0A%60save_api_key_for%60%20uses%20%60%22siliconflow-CN%22%60%20%28hyphen%29%20as%20the%20TOML%20table%20key%2C%20but%20%60ProvidersToml%60%20exposes%20the%20field%20as%20%60siliconflow_CN%60%20%28underscore%29.%20In%20TOML%20these%20are%20distinct%20keys.%20Every%20other%20multi-word%20provider%20consistently%20uses%20underscores%20here%20%28%60nvidia_nim%60%2C%20%60wanjie_ark%60%2C%20%60xiaomi_mimo%60%29.%20As%20a%20result%2C%20%60codewhale%20auth%20set%20--provider%20siliconflow-cn%20--api-key%20%22...%22%60%20writes%20to%20%60%5Bproviders.siliconflow-CN%5D%60%2C%20which%20is%20silently%20ignored%20when%20the%20file%20is%20deserialized%20%E2%80%94%20%60ProvidersToml.siliconflow_CN%60%20stays%20at%20its%20default%20and%20the%20credential%20is%20never%20read%20back.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20ApiProvider%3A%3ASiliconflowCn%20%3D%3E%20%22siliconflow_CN%22%2C%0A%20%20%20%20%20%20%20%20ApiProvider%3A%3AArcee%20%3D%3E%20%22arcee%22%2C%0A%20%20%20%20%20%20%20%20ApiProvider%3A%3AMoonshot%20%3D%3E%20%22moonshot%22%2C%0A%20%20%20%20%20%20%20%20ApiProvider%3A%3ASglang%20%3D%3E%20%22sglang%22%2C%0A%20%20%20%20%20%20%20%20ApiProvider%3A%3AVllm%20%3D%3E%20%22vllm%22%2C%0A%20%20%20%20%20%20%20%20ApiProvider%3A%3AOllama%20%3D%3E%20%22ollama%22%2C%0A%20%20%20%20%20%20%20%20ApiProvider%3A%3AVolcengine%20%3D%3E%20%22volcengine%22%2C%0A%20%20%20%20%7D%3B%0A%20%20%20%20let%20entry%20%3D%20providers%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fconfig.rs%3A4863-4870%0A%60provider_config_key%60%20also%20returns%20%60%22siliconflow-CN%22%60%20%28hyphen%29%2C%20creating%20the%20same%20mismatch.%20Any%20code%20that%20uses%20this%20function%20to%20locate%20the%20provider's%20TOML%20section%20will%20look%20for%20%60%5Bproviders.siliconflow-CN%5D%60%20rather%20than%20%60%5Bproviders.siliconflow_CN%5D%60%20and%20find%20nothing.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20ApiProvider%3A%3ASiliconflowCn%20%3D%3E%20Ok%28%22siliconflow_CN%22%29%2C%0A%20%20%20%20%20%20%20%20ApiProvider%3A%3AArcee%20%3D%3E%20Ok%28%22arcee%22%29%2C%0A%20%20%20%20%20%20%20%20ApiProvider%3A%3AMoonshot%20%3D%3E%20Ok%28%22moonshot%22%29%2C%0A%20%20%20%20%20%20%20%20ApiProvider%3A%3ASglang%20%3D%3E%20Ok%28%22sglang%22%29%2C%0A%20%20%20%20%20%20%20%20ApiProvider%3A%3AVllm%20%3D%3E%20Ok%28%22vllm%22%29%2C%0A%20%20%20%20%20%20%20%20ApiProvider%3A%3AOllama%20%3D%3E%20Ok%28%22ollama%22%29%2C%0A%20%20%20%20%7D%0A%7D%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2616&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fconfig.rs%3A4768-4776%0A%60save_api_key_for%60%20uses%20%60%22siliconflow-CN%22%60%20%28hyphen%29%20as%20the%20TOML%20table%20key%2C%20but%20%60ProvidersToml%60%20exposes%20the%20field%20as%20%60siliconflow_CN%60%20%28underscore%29.%20In%20TOML%20these%20are%20distinct%20keys.%20Every%20other%20multi-word%20provider%20consistently%20uses%20underscores%20here%20%28%60nvidia_nim%60%2C%20%60wanjie_ark%60%2C%20%60xiaomi_mimo%60%29.%20As%20a%20result%2C%20%60codewhale%20auth%20set%20--provider%20siliconflow-cn%20--api-key%20%22...%22%60%20writes%20to%20%60%5Bproviders.siliconflow-CN%5D%60%2C%20which%20is%20silently%20ignored%20when%20the%20file%20is%20deserialized%20%E2%80%94%20%60ProvidersToml.siliconflow_CN%60%20stays%20at%20its%20default%20and%20the%20credential%20is%20never%20read%20back.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20ApiProvider%3A%3ASiliconflowCn%20%3D%3E%20%22siliconflow_CN%22%2C%0A%20%20%20%20%20%20%20%20ApiProvider%3A%3AArcee%20%3D%3E%20%22arcee%22%2C%0A%20%20%20%20%20%20%20%20ApiProvider%3A%3AMoonshot%20%3D%3E%20%22moonshot%22%2C%0A%20%20%20%20%20%20%20%20ApiProvider%3A%3ASglang%20%3D%3E%20%22sglang%22%2C%0A%20%20%20%20%20%20%20%20ApiProvider%3A%3AVllm%20%3D%3E%20%22vllm%22%2C%0A%20%20%20%20%20%20%20%20ApiProvider%3A%3AOllama%20%3D%3E%20%22ollama%22%2C%0A%20%20%20%20%20%20%20%20ApiProvider%3A%3AVolcengine%20%3D%3E%20%22volcengine%22%2C%0A%20%20%20%20%7D%3B%0A%20%20%20%20let%20entry%20%3D%20providers%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fconfig.rs%3A4863-4870%0A%60provider_config_key%60%20also%20returns%20%60%22siliconflow-CN%22%60%20%28hyphen%29%2C%20creating%20the%20same%20mismatch.%20Any%20code%20that%20uses%20this%20function%20to%20locate%20the%20provider's%20TOML%20section%20will%20look%20for%20%60%5Bproviders.siliconflow-CN%5D%60%20rather%20than%20%60%5Bproviders.siliconflow_CN%5D%60%20and%20find%20nothing.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20ApiProvider%3A%3ASiliconflowCn%20%3D%3E%20Ok%28%22siliconflow_CN%22%29%2C%0A%20%20%20%20%20%20%20%20ApiProvider%3A%3AArcee%20%3D%3E%20Ok%28%22arcee%22%29%2C%0A%20%20%20%20%20%20%20%20ApiProvider%3A%3AMoonshot%20%3D%3E%20Ok%28%22moonshot%22%29%2C%0A%20%20%20%20%20%20%20%20ApiProvider%3A%3ASglang%20%3D%3E%20Ok%28%22sglang%22%29%2C%0A%20%20%20%20%20%20%20%20ApiProvider%3A%3AVllm%20%3D%3E%20Ok%28%22vllm%22%29%2C%0A%20%20%20%20%20%20%20%20ApiProvider%3A%3AOllama%20%3D%3E%20Ok%28%22ollama%22%29%2C%0A%20%20%20%20%7D%0A%7D%0A%60%60%60%0A%0A&pr=2616&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (7): Last reviewed commit: ["fix(tui): cache Work panel summary to su..."](https://github.com/hmbown/codewhale/commit/f134267fd85c4a9dfddb4fda0cccff2e2257a586) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35302706)</sub>

<!-- /greptile_comment -->