### PR TITLE
Fix compile error by  #2615

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -749,6 +749,7 @@ fn provider_slot(provider: ProviderKind) -> &'static str {
         ProviderKind::Sglang => "sglang",
         ProviderKind::Vllm => "vllm",
         ProviderKind::Ollama => "ollama",
+        ProviderKind::SiliconflowCN => "siliconflow",
     }
 }
 
@@ -839,6 +840,7 @@ fn provider_env_vars(provider: ProviderKind) -> &'static [&'static str] {
             "WANJIE_API_KEY",
             "WANJIE_MAAS_API_KEY",
         ],
+        ProviderKind::SiliconflowCN => &["SILICONFLOW_API_KEY"],
     }
 }
 

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -2465,7 +2465,9 @@ impl EnvRuntimeOverrides {
             ProviderKind::XiaomiMimo => self.xiaomi_mimo_base_url.clone(),
             ProviderKind::Novita => self.novita_base_url.clone(),
             ProviderKind::Fireworks => self.fireworks_base_url.clone(),
-            ProviderKind::Siliconflow | ProviderKind::SiliconflowCN => self.siliconflow_base_url.clone(),
+            ProviderKind::Siliconflow | ProviderKind::SiliconflowCN => {
+                self.siliconflow_base_url.clone()
+            }
             ProviderKind::Arcee => self.arcee_base_url.clone(),
             ProviderKind::Moonshot => self.moonshot_base_url.clone(),
             ProviderKind::Sglang => self.sglang_base_url.clone(),
@@ -2478,7 +2480,9 @@ impl EnvRuntimeOverrides {
         let model = match provider {
             ProviderKind::WanjieArk => self.wanjie_ark_model.clone(),
             ProviderKind::Volcengine => self.volcengine_model.clone(),
-            ProviderKind::Siliconflow | ProviderKind::SiliconflowCN => self.siliconflow_model.clone(),
+            ProviderKind::Siliconflow | ProviderKind::SiliconflowCN => {
+                self.siliconflow_model.clone()
+            }
             ProviderKind::Arcee => self.arcee_model.clone(),
             ProviderKind::Moonshot => self.moonshot_model.clone(),
             ProviderKind::XiaomiMimo => self.xiaomi_mimo_model.clone(),

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -1092,7 +1092,8 @@ pub(super) fn apply_reasoning_effort(
             | ApiProvider::Openrouter
             | ApiProvider::XiaomiMimo
             | ApiProvider::Novita
-            | ApiProvider::Siliconflow | ApiProvider::SiliconflowCn
+            | ApiProvider::Siliconflow
+            | ApiProvider::SiliconflowCn
             | ApiProvider::Sglang
             | ApiProvider::Volcengine => {
                 body["thinking"] = json!({ "type": "disabled" });
@@ -1128,7 +1129,8 @@ pub(super) fn apply_reasoning_effort(
             // DeepSeek compatibility: low/medium both map to high
             ApiProvider::Deepseek
             | ApiProvider::DeepseekCN
-            | ApiProvider::Siliconflow | ApiProvider::SiliconflowCn
+            | ApiProvider::Siliconflow
+            | ApiProvider::SiliconflowCn
             | ApiProvider::Sglang
             | ApiProvider::Volcengine => {
                 body["reasoning_effort"] = json!("high");
@@ -1189,7 +1191,8 @@ pub(super) fn apply_reasoning_effort(
         "xhigh" | "max" | "highest" => match provider {
             ApiProvider::Deepseek
             | ApiProvider::DeepseekCN
-            | ApiProvider::Siliconflow | ApiProvider::SiliconflowCn
+            | ApiProvider::Siliconflow
+            | ApiProvider::SiliconflowCn
             | ApiProvider::Sglang
             | ApiProvider::Volcengine => {
                 body["reasoning_effort"] = json!("max");

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -178,10 +178,10 @@ impl ApiProvider {
             "novita" => Some(Self::Novita),
             "fireworks" | "fireworks-ai" => Some(Self::Fireworks),
             "siliconflow" | "silicon-flow" | "silicon_flow" => Some(Self::Siliconflow),
-            "siliconflow-cn" | "siliconflow-CN"
-            | "silicon-flow-cn" | "silicon-flow-CN"
-            | "silicon_flow_cn" | "silicon_flow_CN"
-            | "siliconflow-china" => Some(Self::SiliconflowCn),
+            "siliconflow-cn" | "siliconflow-CN" | "silicon-flow-cn" | "silicon-flow-CN"
+            | "silicon_flow_cn" | "silicon_flow_CN" | "siliconflow-china" => {
+                Some(Self::SiliconflowCn)
+            }
             "arcee" | "arcee-ai" | "arcee_ai" => Some(Self::Arcee),
             "moonshot" | "moonshot-ai" | "kimi" | "kimi-k2" => Some(Self::Moonshot),
             "sglang" | "sg-lang" => Some(Self::Sglang),
@@ -697,7 +697,10 @@ pub fn normalize_model_name_for_provider(provider: ApiProvider, model: &str) -> 
         }
         return Some(canonical.to_string());
     }
-    if matches!(provider, ApiProvider::Siliconflow | ApiProvider::SiliconflowCn) {
+    if matches!(
+        provider,
+        ApiProvider::Siliconflow | ApiProvider::SiliconflowCn
+    ) {
         let provider_model = model_for_provider(provider, normalized.clone());
         if provider_model != normalized {
             return Some(provider_model);
@@ -2311,7 +2314,8 @@ impl Config {
             | ApiProvider::XiaomiMimo
             | ApiProvider::Novita
             | ApiProvider::Fireworks
-            | ApiProvider::Siliconflow | ApiProvider::SiliconflowCn
+            | ApiProvider::Siliconflow
+            | ApiProvider::SiliconflowCn
             | ApiProvider::Arcee
             | ApiProvider::Moonshot
             | ApiProvider::Sglang
@@ -2332,7 +2336,6 @@ impl Config {
                 ApiProvider::Novita => DEFAULT_NOVITA_BASE_URL,
                 ApiProvider::Fireworks => DEFAULT_FIREWORKS_BASE_URL,
                 ApiProvider::Siliconflow => DEFAULT_SILICONFLOW_BASE_URL,
-            ApiProvider::SiliconflowCn => DEFAULT_SILICONFLOW_CN_BASE_URL,
                 ApiProvider::SiliconflowCn => DEFAULT_SILICONFLOW_CN_BASE_URL,
                 ApiProvider::Arcee => DEFAULT_ARCEE_BASE_URL,
                 ApiProvider::Moonshot => {
@@ -2387,7 +2390,6 @@ impl Config {
             ApiProvider::Novita => "novita",
             ApiProvider::Fireworks => "fireworks",
             ApiProvider::Siliconflow => "siliconflow",
-            ApiProvider::SiliconflowCn => "siliconflow-CN",
             ApiProvider::SiliconflowCn => "siliconflow-CN",
             ApiProvider::Arcee => "arcee",
             ApiProvider::Moonshot => "moonshot",
@@ -3303,8 +3305,10 @@ fn apply_env_overrides(config: &mut Config) {
             .fireworks
             .base_url = Some(value);
     }
-    if matches!(config.api_provider(), ApiProvider::Siliconflow | ApiProvider::SiliconflowCn)
-        && let Ok(value) = std::env::var("SILICONFLOW_BASE_URL")
+    if matches!(
+        config.api_provider(),
+        ApiProvider::Siliconflow | ApiProvider::SiliconflowCn
+    ) && let Ok(value) = std::env::var("SILICONFLOW_BASE_URL")
         && !value.trim().is_empty()
     {
         config
@@ -3460,8 +3464,10 @@ fn apply_env_overrides(config: &mut Config) {
             .moonshot
             .model = Some(value);
     }
-    if matches!(config.api_provider(), ApiProvider::Siliconflow | ApiProvider::SiliconflowCn)
-        && let Ok(value) = std::env::var("SILICONFLOW_MODEL")
+    if matches!(
+        config.api_provider(),
+        ApiProvider::Siliconflow | ApiProvider::SiliconflowCn
+    ) && let Ok(value) = std::env::var("SILICONFLOW_MODEL")
         && !value.trim().is_empty()
     {
         config
@@ -3829,8 +3835,7 @@ fn default_base_url_for_provider(provider: ApiProvider) -> &'static str {
         ApiProvider::Novita => DEFAULT_NOVITA_BASE_URL,
         ApiProvider::Fireworks => DEFAULT_FIREWORKS_BASE_URL,
         ApiProvider::Siliconflow => DEFAULT_SILICONFLOW_BASE_URL,
-            ApiProvider::SiliconflowCn => DEFAULT_SILICONFLOW_CN_BASE_URL,
-                ApiProvider::SiliconflowCn => DEFAULT_SILICONFLOW_CN_BASE_URL,
+        ApiProvider::SiliconflowCn => DEFAULT_SILICONFLOW_CN_BASE_URL,
         ApiProvider::Arcee => DEFAULT_ARCEE_BASE_URL,
         ApiProvider::Moonshot => DEFAULT_MOONSHOT_BASE_URL,
         ApiProvider::Sglang => DEFAULT_SGLANG_BASE_URL,
@@ -3841,7 +3846,9 @@ fn default_base_url_for_provider(provider: ApiProvider) -> &'static str {
 }
 
 fn base_url_is_custom_for_provider(provider: ApiProvider, base_url: &str) -> bool {
-    if (provider == ApiProvider::Siliconflow || provider == ApiProvider::SiliconflowCn) && siliconflow_base_url_is_official(base_url) {
+    if (provider == ApiProvider::Siliconflow || provider == ApiProvider::SiliconflowCn)
+        && siliconflow_base_url_is_official(base_url)
+    {
         return false;
     }
     normalize_base_url(base_url) != normalize_base_url(default_base_url_for_provider(provider))
@@ -4758,8 +4765,7 @@ pub fn save_api_key_for(provider: ApiProvider, api_key: &str) -> Result<PathBuf>
         ApiProvider::Novita => "novita",
         ApiProvider::Fireworks => "fireworks",
         ApiProvider::Siliconflow => "siliconflow",
-            ApiProvider::SiliconflowCn => "siliconflow-CN",
-            ApiProvider::SiliconflowCn => "siliconflow-CN",
+        ApiProvider::SiliconflowCn => "siliconflow-CN",
         ApiProvider::Arcee => "arcee",
         ApiProvider::Moonshot => "moonshot",
         ApiProvider::Sglang => "sglang",
@@ -4854,7 +4860,7 @@ fn provider_config_key(provider: ApiProvider) -> Result<&'static str> {
         ApiProvider::Novita => Ok("novita"),
         ApiProvider::Fireworks => Ok("fireworks"),
         ApiProvider::Siliconflow => Ok("siliconflow"),
-            ApiProvider::SiliconflowCn => Ok("siliconflow-CN"),
+        ApiProvider::SiliconflowCn => Ok("siliconflow-CN"),
         ApiProvider::Arcee => Ok("arcee"),
         ApiProvider::Moonshot => Ok("moonshot"),
         ApiProvider::Sglang => Ok("sglang"),

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -2000,7 +2000,8 @@ fn run_setup_status(config: &Config, workspace: &Path) -> Result<()> {
                     "FIREWORKS_API_KEY",
                     "codewhale auth set --provider fireworks --api-key \"...\"",
                 ),
-                crate::config::ApiProvider::Siliconflow | crate::config::ApiProvider::SiliconflowCn => (
+                crate::config::ApiProvider::Siliconflow
+                | crate::config::ApiProvider::SiliconflowCn => (
                     "SILICONFLOW_API_KEY",
                     "codewhale auth set --provider siliconflow --api-key \"...\"",
                 ),
@@ -2044,7 +2045,8 @@ fn run_setup_status(config: &Config, workspace: &Path) -> Result<()> {
                     crate::config::ApiProvider::XiaomiMimo => "xiaomi_mimo",
                     crate::config::ApiProvider::Novita => "novita",
                     crate::config::ApiProvider::Fireworks => "fireworks",
-                    crate::config::ApiProvider::Siliconflow | crate::config::ApiProvider::SiliconflowCn => "siliconflow",
+                    crate::config::ApiProvider::Siliconflow
+                    | crate::config::ApiProvider::SiliconflowCn => "siliconflow",
                     crate::config::ApiProvider::Arcee => "arcee",
                     crate::config::ApiProvider::Moonshot => "moonshot",
                     crate::config::ApiProvider::Sglang => "sglang",

--- a/crates/tui/src/tui/notifications.rs
+++ b/crates/tui/src/tui/notifications.rs
@@ -699,7 +699,7 @@ pub fn latest_assistant_text(messages: &[Message]) -> Option<String> {
                     | ContentBlock::ServerToolUse { .. }
                     | ContentBlock::ToolSearchToolResult { .. }
                     | ContentBlock::CodeExecutionToolResult { .. } => None,
-                    | ContentBlock::ImageUrl { .. } => None,
+                    ContentBlock::ImageUrl { .. } => None,
                 })
                 .collect::<Vec<_>>()
                 .join("\n");

--- a/crates/tui/src/tui/session_picker.rs
+++ b/crates/tui/src/tui/session_picker.rs
@@ -790,9 +790,7 @@ fn message_text_for_history(message: &crate::models::Message) -> String {
             | crate::models::ContentBlock::CodeExecutionToolResult { content, .. } => {
                 format!("tool result: {}", truncate(&content.to_string(), 220))
             }
-            crate::models::ContentBlock::ImageUrl { .. } => {
-                String::from("[image]")
-            }
+            crate::models::ContentBlock::ImageUrl { .. } => String::from("[image]"),
         };
         let part = part.trim();
         if !part.is_empty() {

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -6604,7 +6604,9 @@ fn render(f: &mut Frame, app: &mut App) {
             crate::config::ApiProvider::XiaomiMimo => Some("MiMo"),
             crate::config::ApiProvider::Novita => Some("Novita"),
             crate::config::ApiProvider::Fireworks => Some("Fireworks"),
-            crate::config::ApiProvider::Siliconflow | ApiProvider::SiliconflowCn => Some("SiliconFlow"),
+            crate::config::ApiProvider::Siliconflow | ApiProvider::SiliconflowCn => {
+                Some("SiliconFlow")
+            }
             crate::config::ApiProvider::Arcee => Some("Arcee"),
             crate::config::ApiProvider::Moonshot => Some("Kimi"),
             crate::config::ApiProvider::Sglang => Some("SGLang"),


### PR DESCRIPTION
## Summary

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features`
- [x] `cargo test --workspace --all-features`

fixing #2618 

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes compile errors introduced by #2615, which added the `SiliconflowCN`/`SiliconflowCn` provider variant. The fixes are mechanical: removing duplicate `match` arms, adding missing exhaustive arms, correcting a spurious leading `|` on a pattern, and reformatting long lines to satisfy `rustfmt`.

- **`crates/cli/src/lib.rs`**: Adds the two missing `ProviderKind::SiliconflowCN` arms in `provider_slot` and `provider_env_vars`, resolving non-exhaustive match errors.
- **`crates/tui/src/config.rs`**: Removes multiple duplicate `SiliconflowCn` arms (some at wrong indentation levels) that caused \"unreachable pattern\" compile errors.
- **`crates/tui/src/tui/notifications.rs`**: Removes the erroneous leading `|` from the `ContentBlock::ImageUrl` arm, and the remaining files receive formatting-only adjustments.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — every change is either removing a duplicate unreachable match arm, adding a missing exhaustive arm, or reformatting to meet line-length limits.

All changes are narrowly scoped to fixing the broken state left by #2615: no new logic is introduced, duplicated arms are simply deduplicated, and the new SiliconflowCN arms in the CLI mirror the pattern used by every other provider.

No files require special attention. crates/tui/src/config.rs had the most edits (three sets of duplicate arm removals) but the result is straightforwardly correct.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/cli/src/lib.rs | Adds missing ProviderKind::SiliconflowCN arms in provider_slot and provider_env_vars, fixing non-exhaustive match compile errors. |
| crates/config/src/lib.rs | Reformats two long Siliconflow | SiliconflowCN match arms into block form for rustfmt compliance; no logic change. |
| crates/tui/src/client.rs | Reformats three Siliconflow | SiliconflowCn match arms across apply_reasoning_effort to satisfy rustfmt line-length limits; no logic change. |
| crates/tui/src/config.rs | Removes duplicate SiliconflowCn match arms (some at wrong indentation), fixes rustfmt line-length violations, and deduplicates entries in save_api_key_for and provider_config_key. |
| crates/tui/src/main.rs | Reformats two long Siliconflow | SiliconflowCn match arms in run_setup_status for rustfmt compliance; no logic change. |
| crates/tui/src/tui/notifications.rs | Removes the spurious leading | on ContentBlock::ImageUrl { .. } that caused a syntax/compile error. |
| crates/tui/src/tui/session_picker.rs | Collapses a three-line ImageUrl match arm body to a single line for formatting consistency; purely cosmetic. |
| crates/tui/src/tui/ui.rs | Reformats the Siliconflow | SiliconflowCn => Some("SiliconFlow") arm into a block body to comply with line-length limits; no logic change. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SiliconflowCN provider added in #2615] --> B{Compile errors in 8 files}
    B --> C[cli/src/lib.rs\nMissing match arms]
    B --> D[tui/src/config.rs\nDuplicate SiliconflowCn arms]
    B --> E[tui/src/tui/notifications.rs\nSpurious leading pipe]
    B --> F[Other files\nLine-length violations]
    C --> G[All checks pass:\ncargo fmt / clippy / test]
    D --> G
    E --> G
    F --> G
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix compile error by  #2615"](https://github.com/hmbown/codewhale/commit/a4c4061029537aa7d2078b49285f0170ff55f5ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35307660)</sub>

<!-- /greptile_comment -->