### PR TITLE
fix(tui): add scroll support to plan prompt modal

### DIFF
--- a/crates/tui/src/tui/plan_prompt.rs
+++ b/crates/tui/src/tui/plan_prompt.rs
@@ -1,5 +1,7 @@
 //! Modal prompt for selecting what to do after a plan is generated.
 
+use std::cell::Cell;
+
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::layout::{Alignment, Rect};
 use ratatui::prelude::*;
@@ -119,6 +121,10 @@ pub struct PlanPromptView {
     scroll: usize,
     /// Tracks a previous 'g' press for the 'gg' (jump to top) combo.
     pending_g: bool,
+    /// The effective `max_scroll` computed during the last render, used so
+    /// the Esc handler can check the clamped scroll (not the raw `self.scroll`)
+    /// and avoid a spurious exit-confirmation on short plans.
+    last_max_scroll: Cell<usize>,
     /// When true, an "are you sure?" prompt is shown instead of the option list
     /// because the user pressed Esc after scrolling away from the top.
     confirming_exit: bool,
@@ -132,6 +138,7 @@ impl PlanPromptView {
             selected: 0,
             scroll: 0,
             pending_g: false,
+            last_max_scroll: Cell::new(0),
             confirming_exit: false,
             plan,
         }
@@ -150,7 +157,7 @@ impl PlanPromptView {
     fn submit_number(number: u32) -> ViewAction {
         if (1..=u32::try_from(PLAN_OPTIONS.len()).unwrap_or(0)).contains(&number) {
             ViewAction::EmitAndClose(ViewEvent::PlanPromptSelected {
-                option: usize::from(number),
+                option: number as usize,
             })
         } else {
             ViewAction::None
@@ -234,7 +241,9 @@ impl ModalView for PlanPromptView {
             }
             KeyCode::Enter => self.submit_selected(),
             KeyCode::Esc => {
-                if self.scroll > 0 {
+                // Use the effective (clamped) scroll from the last render so a
+                // short plan that fits entirely never triggers a false positive.
+                if self.scroll.min(self.last_max_scroll.get()) > 0 {
                     // User scrolled; ask for confirmation before discarding.
                     self.confirming_exit = true;
                     ViewAction::None
@@ -370,6 +379,7 @@ impl ModalView for PlanPromptView {
         let total_lines = wrapped_line_count(&lines, content_width);
         let visible_lines = usize::from(popup_area.height).saturating_sub(4).max(1);
         let max_scroll = total_lines.saturating_sub(visible_lines);
+        self.last_max_scroll.set(max_scroll);
         let scroll = self.scroll.min(max_scroll);
 
         // Build footer: scroll indicator (left) + data-driven option shortcuts +
@@ -815,6 +825,7 @@ mod tests {
     fn plan_prompt_esc_after_scroll_confirms_then_cancels() {
         let mut view = PlanPromptView::new(None);
         view.scroll = 5; // simulate user having scrolled
+        view.last_max_scroll.set(5);
 
         // First Esc: enters confirmation mode, does not close.
         let action = view.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
@@ -831,6 +842,7 @@ mod tests {
     fn plan_prompt_esc_then_esc_cancels_confirmation() {
         let mut view = PlanPromptView::new(None);
         view.scroll = 3;
+        view.last_max_scroll.set(3);
 
         // Enter confirmation.
         view.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
@@ -855,6 +867,7 @@ mod tests {
     fn plan_prompt_confirm_then_y_exits() {
         let mut view = PlanPromptView::new(None);
         view.scroll = 2;
+        view.last_max_scroll.set(2);
 
         view.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
         let action = view.handle_key(KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE));
@@ -865,6 +878,7 @@ mod tests {
     fn plan_prompt_other_keys_ignored_during_confirmation() {
         let mut view = PlanPromptView::new(None);
         view.scroll = 2;
+        view.last_max_scroll.set(2);
 
         view.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
         assert!(view.confirming_exit);

--- a/crates/tui/src/tui/plan_prompt.rs
+++ b/crates/tui/src/tui/plan_prompt.rs
@@ -245,6 +245,9 @@ impl ModalView for PlanPromptView {
                 // short plan that fits entirely never triggers a false positive.
                 if self.scroll.min(self.last_max_scroll.get()) > 0 {
                     // User scrolled; ask for confirmation before discarding.
+                    // Clear a stray pending_g so it doesn't leak into the
+                    // confirm dialog and survive a cancel (#).
+                    self.pending_g = false;
                     self.confirming_exit = true;
                     ViewAction::None
                 } else {
@@ -371,8 +374,6 @@ impl ModalView for PlanPromptView {
             );
         }
 
-        render_modal_chrome(area, popup_area, buf);
-
         // Calculate scroll bounds so long plan content doesn't clip the options.
         // Use wrapped_line_count to estimate post-wrap line count.
         let total_lines = wrapped_line_count(&lines, content_width);
@@ -454,6 +455,7 @@ impl ModalView for PlanPromptView {
                 .block(modal_block().title_bottom(confirm_footer));
             confirm.render(popup_area, buf);
         } else {
+            render_modal_chrome(area, popup_area, buf);
             let paragraph = Paragraph::new(lines)
                 .alignment(Alignment::Left)
                 .wrap(Wrap { trim: true })

--- a/crates/tui/src/tui/plan_prompt.rs
+++ b/crates/tui/src/tui/plan_prompt.rs
@@ -319,6 +319,47 @@ impl ModalView for PlanPromptView {
     }
 
     fn render(&self, area: Rect, buf: &mut Buffer) {
+        // When the user pressed Esc after scrolling, show a confirmation prompt
+        // instead of the normal plan + options.  Render it early so we skip the
+        // plan-content construction entirely.
+        if self.confirming_exit {
+            let confirm_lines = vec![
+                Line::from(Span::styled(
+                    "Exit without implementing?",
+                    Style::default().fg(palette::DEEPSEEK_SKY).bold(),
+                )),
+                Line::from(""),
+                Line::from(Span::styled(
+                    "You've scrolled through the plan content. Are you sure you want to exit?",
+                    Style::default().fg(palette::TEXT_PRIMARY),
+                )),
+                Line::from(""),
+                Line::from(Span::styled(
+                    "  y — Yes, exit Plan mode",
+                    Style::default().fg(palette::DEEPSEEK_SKY),
+                )),
+                Line::from(Span::styled(
+                    "  n / Esc — Cancel, go back to plan",
+                    Style::default().fg(palette::TEXT_MUTED),
+                )),
+            ];
+            let confirm_footer = Line::from(vec![
+                Span::styled(" y ", Style::default().fg(palette::DEEPSEEK_SKY).bold()),
+                Span::styled("confirm exit", Style::default().fg(palette::TEXT_MUTED)),
+                Span::raw("  "),
+                Span::styled("n / Esc", Style::default().fg(palette::DEEPSEEK_SKY).bold()),
+                Span::styled(" cancel", Style::default().fg(palette::TEXT_MUTED)),
+            ]);
+            let popup_area = centered_rect(66, 34, area);
+            render_modal_chrome(area, popup_area, buf);
+            let confirm = Paragraph::new(confirm_lines)
+                .alignment(Alignment::Left)
+                .wrap(Wrap { trim: true })
+                .block(modal_block().title_bottom(confirm_footer));
+            confirm.render(popup_area, buf);
+            return;
+        }
+
         let popup_area = centered_rect(72, 52, area);
         let content_width = usize::from(popup_area.width.saturating_sub(4).max(1));
         let mut lines: Vec<Line> = Vec::new();
@@ -417,53 +458,14 @@ impl ModalView for PlanPromptView {
         );
         footer_spans.push(desc_span);
 
-        // When the user pressed Esc after scrolling, show a confirmation prompt
-        // instead of the normal plan + options.
-        if self.confirming_exit {
-            let confirm_lines = vec![
-                Line::from(Span::styled(
-                    "Exit without implementing?",
-                    Style::default().fg(palette::DEEPSEEK_SKY).bold(),
-                )),
-                Line::from(""),
-                Line::from(Span::styled(
-                    "You've scrolled through the plan content. Are you sure you want to exit?",
-                    Style::default().fg(palette::TEXT_PRIMARY),
-                )),
-                Line::from(""),
-                Line::from(Span::styled(
-                    "  y — Yes, exit Plan mode",
-                    Style::default().fg(palette::DEEPSEEK_SKY),
-                )),
-                Line::from(Span::styled(
-                    "  n / Esc — Cancel, go back to plan",
-                    Style::default().fg(palette::TEXT_MUTED),
-                )),
-            ];
-            let confirm_footer = Line::from(vec![
-                Span::styled(" y ", Style::default().fg(palette::DEEPSEEK_SKY).bold()),
-                Span::styled("confirm exit", Style::default().fg(palette::TEXT_MUTED)),
-                Span::raw("  "),
-                Span::styled("n / Esc", Style::default().fg(palette::DEEPSEEK_SKY).bold()),
-                Span::styled(" cancel", Style::default().fg(palette::TEXT_MUTED)),
-            ]);
-            let popup_area = centered_rect(66, 34, area);
-            render_modal_chrome(area, popup_area, buf);
-            let confirm = Paragraph::new(confirm_lines)
-                .alignment(Alignment::Left)
-                .wrap(Wrap { trim: true })
-                .block(modal_block().title_bottom(confirm_footer));
-            confirm.render(popup_area, buf);
-        } else {
-            render_modal_chrome(area, popup_area, buf);
-            let paragraph = Paragraph::new(lines)
-                .alignment(Alignment::Left)
-                .wrap(Wrap { trim: true })
-                .block(modal_block().title_bottom(Line::from(footer_spans)))
-                .scroll((u16::try_from(scroll).unwrap_or(u16::MAX), 0));
+        render_modal_chrome(area, popup_area, buf);
+        let paragraph = Paragraph::new(lines)
+            .alignment(Alignment::Left)
+            .wrap(Wrap { trim: true })
+            .block(modal_block().title_bottom(Line::from(footer_spans)))
+            .scroll((u16::try_from(scroll).unwrap_or(u16::MAX), 0));
 
-            paragraph.render(popup_area, buf);
-        }
+        paragraph.render(popup_area, buf);
     }
 }
 
@@ -481,21 +483,35 @@ fn wrap_text(text: &str, width: usize) -> Vec<String> {
         let words: Vec<&str> = paragraph.split_whitespace().collect();
         let mut current = String::new();
         for word in words {
-            let word_width = word.chars().count();
+            let word_width = UnicodeWidthStr::width(word);
             if word_width > width {
                 if !current.is_empty() {
                     lines.push(current.trim_end().to_string());
                     current.clear();
                 }
-                let mut chars = word.chars();
-                loop {
-                    let segment: String = chars.by_ref().take(width).collect();
-                    if segment.is_empty() {
-                        break;
+                // Split an over-width word by display width, not code points,
+                // so CJK characters are measured consistently with
+                // wrapped_line_count and ratatui's Paragraph::wrap.
+                let mut remaining = word;
+                while !remaining.is_empty() {
+                    let mut split_at = 0usize;
+                    for (i, ch) in remaining.char_indices() {
+                        // Use the exclusive byte range [..end) so the prefix is
+                        // always valid UTF-8, even for multi-byte characters.
+                        let end = i + ch.len_utf8();
+                        if UnicodeWidthStr::width(&remaining[..end]) > width {
+                            break;
+                        }
+                        split_at = end;
                     }
-                    lines.push(segment);
+                    if split_at == 0 {
+                        // Even one character is wider than width; take it anyway.
+                        split_at = remaining.chars().next().unwrap().len_utf8();
+                    }
+                    lines.push(remaining[..split_at].to_string());
+                    remaining = &remaining[split_at..];
                 }
-            } else if current.chars().count() + 1 + word_width > width {
+            } else if UnicodeWidthStr::width(current.as_str()) + 1 + word_width > width {
                 lines.push(current.trim_end().to_string());
                 current.clear();
                 current.push_str(word);

--- a/crates/tui/src/tui/plan_prompt.rs
+++ b/crates/tui/src/tui/plan_prompt.rs
@@ -526,7 +526,8 @@ fn wrapped_line_count(lines: &[Line<'_>], width: usize) -> usize {
             continue;
         }
         let leading_bytes = text.len() - text.trim_start().len();
-        let leading_spaces = UnicodeWidthStr::width(&text[..leading_bytes]).min(width.saturating_sub(1));
+        let leading_spaces =
+            UnicodeWidthStr::width(&text[..leading_bytes]).min(width.saturating_sub(1));
         let mut line_count = 0;
         let mut current_width = leading_spaces;
         let mut first_word = true;

--- a/crates/tui/src/tui/plan_prompt.rs
+++ b/crates/tui/src/tui/plan_prompt.rs
@@ -278,16 +278,8 @@ impl ModalView for PlanPromptView {
                         .modifiers
                         .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
             {
-                self.scroll = 0;
                 self.pending_g = false;
-                ViewAction::None
-            }
-            KeyCode::Char('g')
-                if !key
-                    .modifiers
-                    .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
-            {
-                self.pending_g = true;
+                self.scroll = 0;
                 ViewAction::None
             }
             KeyCode::Char('G')
@@ -298,20 +290,24 @@ impl ModalView for PlanPromptView {
                 self.scroll = usize::MAX;
                 ViewAction::None
             }
-            KeyCode::Char('f') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                self.scroll = self.scroll.saturating_add(6);
-                ViewAction::None
-            }
-            KeyCode::Char('b') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                self.scroll = self.scroll.saturating_sub(6);
-                ViewAction::None
-            }
             KeyCode::Home => {
                 self.scroll = 0;
                 ViewAction::None
             }
             KeyCode::End => {
                 self.scroll = usize::MAX;
+                ViewAction::None
+            }
+            KeyCode::Char('g') => {
+                self.pending_g = true;
+                ViewAction::None
+            }
+            KeyCode::Char('f') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.scroll = self.scroll.saturating_add(6);
+                ViewAction::None
+            }
+            KeyCode::Char('b') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.scroll = self.scroll.saturating_sub(6);
                 ViewAction::None
             }
             _ => ViewAction::None,
@@ -395,10 +391,13 @@ impl ModalView for PlanPromptView {
                         crate::tools::plan::StepStatus::InProgress => "\u{25b6}",
                         crate::tools::plan::StepStatus::Completed => "\u{2713}",
                     };
-                    lines.push(Line::from(Span::styled(
-                        format!("  {status_mark} {}. {}", i + 1, &item.step),
-                        Style::default().fg(palette::TEXT_PRIMARY),
-                    )));
+                    let step_text = format!("  {status_mark} {}. {}", i + 1, &item.step);
+                    for line in wrap_text(&step_text, content_width) {
+                        lines.push(Line::from(Span::styled(
+                            line,
+                            Style::default().fg(palette::TEXT_PRIMARY),
+                        )));
+                    }
                 }
                 lines.push(Line::from(""));
             }
@@ -416,8 +415,9 @@ impl ModalView for PlanPromptView {
         }
 
         // Calculate scroll bounds so long plan content doesn't clip the options.
-        // Use wrapped_line_count to estimate post-wrap line count.
-        let total_lines = wrapped_line_count(&lines, content_width);
+        // Since plan steps are now pre-wrapped via wrap_text(), each Line is
+        // already width-bounded — use the raw line count directly.
+        let total_lines = lines.len();
         let visible_lines = usize::from(popup_area.height).saturating_sub(4).max(1);
         let max_scroll = total_lines.saturating_sub(visible_lines);
         self.last_max_scroll.set(max_scroll);
@@ -428,7 +428,11 @@ impl ModalView for PlanPromptView {
         let mut footer_spans: Vec<Span> = Vec::new();
         if total_lines > visible_lines {
             footer_spans.push(Span::styled(
-                format!(" [{}/{} PgUp/Dn · Ctrl+U/D] ", scroll + 1, max_scroll + 1),
+                format!(
+                    " [{}/{} PgUp/Dn \u{b7} Ctrl+U/D] ",
+                    scroll + 1,
+                    max_scroll + 1
+                ),
                 Style::default().fg(palette::DEEPSEEK_SKY),
             ));
         }
@@ -453,15 +457,20 @@ impl ModalView for PlanPromptView {
         // Selected option description, right-aligned by filling space.
         let desc = PLAN_OPTIONS[self.selected].description;
         let desc_span = Span::styled(
-            format!(" → {desc}"),
+            format!(" \u{2192} {desc}"),
             Style::default().fg(palette::TEXT_MUTED),
         );
         footer_spans.push(desc_span);
 
         render_modal_chrome(area, popup_area, buf);
+        // Wrap { trim: false } — disable ratatui's word-boundary-based line
+        // wrapping. All content is already pre-wrapped via wrap_text() above,
+        // which breaks only on display-width overflow, not on script boundaries
+        // (Latin ↔ CJK).  This avoids forced line-breaks between English and
+        // Chinese characters when there is still room on the current line.
         let paragraph = Paragraph::new(lines)
             .alignment(Alignment::Left)
-            .wrap(Wrap { trim: true })
+            .wrap(Wrap { trim: false })
             .block(modal_block().title_bottom(Line::from(footer_spans)))
             .scroll((u16::try_from(scroll).unwrap_or(u16::MAX), 0));
 
@@ -527,66 +536,6 @@ fn wrap_text(text: &str, width: usize) -> Vec<String> {
         }
     }
     lines
-}
-
-/// Estimate the number of display lines after word-wrapping a set of logical
-/// lines to `width` columns. Simulates ratatui's word-wrapping (breaks at word
-/// boundaries) and accounts for CJK display widths via `UnicodeWidthStr`.
-fn wrapped_line_count(lines: &[Line<'_>], width: usize) -> usize {
-    if width == 0 {
-        return lines.len().max(1);
-    }
-    let mut total = 0usize;
-    for line in lines {
-        let text: String = line.iter().map(|s| s.content.as_ref()).collect();
-        if text.is_empty() {
-            total += 1;
-            continue;
-        }
-        let leading_bytes = text.len() - text.trim_start().len();
-        let leading_spaces =
-            UnicodeWidthStr::width(&text[..leading_bytes]).min(width.saturating_sub(1));
-        let mut line_count = 0;
-        let mut current_width = leading_spaces;
-        let mut first_word = true;
-        for word in text.split_whitespace() {
-            let word_width = UnicodeWidthStr::width(word);
-            if first_word {
-                let total_width = leading_spaces + word_width;
-                if total_width > width {
-                    let lines_needed = total_width.div_ceil(width);
-                    line_count = lines_needed;
-                    current_width = total_width % width;
-                    if current_width == 0 {
-                        current_width = width;
-                    }
-                } else {
-                    current_width = total_width;
-                    line_count = 1;
-                }
-                first_word = false;
-            } else if current_width + 1 + word_width > width {
-                line_count += 1;
-                if word_width > width {
-                    let lines_needed = word_width.div_ceil(width);
-                    line_count += lines_needed - 1;
-                    current_width = word_width % width;
-                    if current_width == 0 {
-                        current_width = width;
-                    }
-                } else {
-                    current_width = word_width;
-                }
-            } else {
-                current_width += 1 + word_width;
-            }
-        }
-        if line_count == 0 {
-            line_count = 1;
-        }
-        total += line_count;
-    }
-    total
 }
 
 fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {

--- a/crates/tui/src/tui/plan_prompt.rs
+++ b/crates/tui/src/tui/plan_prompt.rs
@@ -349,9 +349,8 @@ impl ModalView for PlanPromptView {
                         crate::tools::plan::StepStatus::InProgress => "\u{25b6}",
                         crate::tools::plan::StepStatus::Completed => "\u{2713}",
                     };
-                    let step_text = truncate_step(&item.step, 60);
                     lines.push(Line::from(Span::styled(
-                        format!("  {status_mark} {}. {}", i + 1, step_text),
+                        format!("  {status_mark} {}. {}", i + 1, &item.step),
                         Style::default().fg(palette::TEXT_PRIMARY),
                     )));
                 }
@@ -463,22 +462,6 @@ impl ModalView for PlanPromptView {
 
             paragraph.render(popup_area, buf);
         }
-    }
-}
-
-/// Truncate a plan step description to `max_len` chars, breaking at a word
-/// boundary and appending an ellipsis when truncation occurs.
-fn truncate_step(text: &str, max_len: usize) -> String {
-    if text.chars().count() <= max_len {
-        return text.to_string();
-    }
-    // Walk back from the cutoff to find a natural word boundary.
-    let cutoff = max_len.saturating_sub(3); // reserve room for "..."
-    let truncated: String = text.chars().take(cutoff).collect();
-    if let Some(last_space) = truncated.rfind(' ') {
-        format!("{}...", &truncated[..last_space])
-    } else {
-        format!("{truncated}...")
     }
 }
 

--- a/crates/tui/src/tui/plan_prompt.rs
+++ b/crates/tui/src/tui/plan_prompt.rs
@@ -10,27 +10,39 @@ use crate::palette;
 use crate::tools::plan::PlanSnapshot;
 use crate::tui::views::{ModalKind, ModalView, ViewAction, ViewEvent};
 
-const PLAN_OPTIONS: [(&str, &str); 4] = [
-    (
-        "Accept plan (Agent)",
-        "Start implementation in Agent mode with approvals",
-    ),
-    (
-        "Accept plan (YOLO)",
-        "Start implementation in YOLO mode (auto-approve)",
-    ),
-    ("Revise plan", "Ask follow-ups or request plan changes"),
-    (
-        "Exit Plan mode",
-        "Return to Agent mode without implementation",
-    ),
+struct PlanOption {
+    label: &'static str,
+    description: &'static str,
+    shortcut: char,
+    short_label: &'static str,
+}
+
+const PLAN_OPTIONS: [PlanOption; 4] = [
+    PlanOption {
+        label: "Accept plan (Agent)",
+        description: "Start implementation in Agent mode with approvals",
+        shortcut: 'a',
+        short_label: "Accept",
+    },
+    PlanOption {
+        label: "Accept plan (YOLO)",
+        description: "Start implementation in YOLO mode (auto-approve)",
+        shortcut: 'y',
+        short_label: "YOLO",
+    },
+    PlanOption {
+        label: "Revise plan",
+        description: "Ask follow-ups or request plan changes",
+        shortcut: 'r',
+        short_label: "Revise",
+    },
+    PlanOption {
+        label: "Exit Plan mode",
+        description: "Return to Agent mode without implementation",
+        shortcut: 'q',
+        short_label: "Exit",
+    },
 ];
-
-/// Shortcut letters for each plan option (used in the footer bar).
-const PLAN_SHORTCUTS: [char; 4] = ['a', 'y', 'r', 'q'];
-
-/// Compact labels for each plan option (used in the footer bar).
-const PLAN_SHORT_LABELS: [&str; 4] = ["Accept", "YOLO", "Revise", "Exit"];
 
 fn modal_block() -> Block<'static> {
     Block::default()
@@ -162,9 +174,7 @@ impl ModalView for PlanPromptView {
                 KeyCode::Char('y') | KeyCode::Char('Y') => {
                     ViewAction::EmitAndClose(ViewEvent::PlanPromptDismissed)
                 }
-                KeyCode::Char('n')
-                | KeyCode::Char('N')
-                | KeyCode::Esc => {
+                KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
                     self.confirming_exit = false;
                     ViewAction::None
                 }
@@ -214,10 +224,7 @@ impl ModalView for PlanPromptView {
                 self.selected = 2;
                 self.submit_selected()
             }
-            KeyCode::Char('q')
-            | KeyCode::Char('Q')
-            | KeyCode::Char('e')
-            | KeyCode::Char('E') => {
+            KeyCode::Char('q') | KeyCode::Char('Q') | KeyCode::Char('e') | KeyCode::Char('E') => {
                 self.selected = 3;
                 self.submit_selected()
             }
@@ -227,11 +234,7 @@ impl ModalView for PlanPromptView {
             }
             KeyCode::Enter => self.submit_selected(),
             KeyCode::Esc => {
-                if self.confirming_exit {
-                    // Second Esc: cancel the confirmation prompt.
-                    self.confirming_exit = false;
-                    ViewAction::None
-                } else if self.scroll > 0 {
+                if self.scroll > 0 {
                     // User scrolled; ask for confirmation before discarding.
                     self.confirming_exit = true;
                     ViewAction::None
@@ -241,11 +244,11 @@ impl ModalView for PlanPromptView {
             }
             // Scroll the plan content when it overflows the popup.
             KeyCode::PageUp => {
-                self.scroll = self.scroll.saturating_sub(6);
+                self.scroll = self.scroll.saturating_sub(12);
                 ViewAction::None
             }
             KeyCode::PageDown => {
-                self.scroll = self.scroll.saturating_add(6);
+                self.scroll = self.scroll.saturating_add(12);
                 ViewAction::None
             }
             KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
@@ -256,19 +259,30 @@ impl ModalView for PlanPromptView {
                 self.scroll = self.scroll.saturating_add(6);
                 ViewAction::None
             }
-            // Vim-style scroll keys.
-            KeyCode::Char('g') if self.pending_g => {
-                // Second g in sequence → jump to top.
+            // Vim-style scroll keys — only pure 'g'/'G' (no Ctrl/Alt).
+            KeyCode::Char('g')
+                if self.pending_g
+                    && !key
+                        .modifiers
+                        .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+            {
                 self.scroll = 0;
                 self.pending_g = false;
                 ViewAction::None
             }
-            KeyCode::Char('g') => {
+            KeyCode::Char('g')
+                if !key
+                    .modifiers
+                    .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+            {
                 self.pending_g = true;
                 ViewAction::None
             }
-            KeyCode::Char('G') => {
-                // Vim 'G' (Shift+g) → jump to bottom.  Render clamps overshoot.
+            KeyCode::Char('G')
+                if !key
+                    .modifiers
+                    .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+            {
                 self.scroll = usize::MAX;
                 ViewAction::None
             }
@@ -336,9 +350,15 @@ impl ModalView for PlanPromptView {
             }
         }
 
-        for (idx, (label, description)) in PLAN_OPTIONS.iter().enumerate() {
+        for (idx, option) in PLAN_OPTIONS.iter().enumerate() {
             let number = idx + 1;
-            push_option_lines(&mut lines, self.selected == idx, number, label, description);
+            push_option_lines(
+                &mut lines,
+                self.selected == idx,
+                number,
+                option.label,
+                option.description,
+            );
         }
 
         let popup_area = centered_rect(72, 52, area);
@@ -361,9 +381,9 @@ impl ModalView for PlanPromptView {
                 Style::default().fg(palette::DEEPSEEK_SKY),
             ));
         }
-        for (idx, _) in PLAN_OPTIONS.iter().enumerate() {
-            let shortcut = PLAN_SHORTCUTS[idx];
-            let short_label = PLAN_SHORT_LABELS[idx];
+        for (idx, option) in PLAN_OPTIONS.iter().enumerate() {
+            let shortcut = option.shortcut;
+            let short_label = option.short_label;
             let is_current = self.selected == idx;
             let shortcut_style = if is_current {
                 Style::default()
@@ -380,7 +400,7 @@ impl ModalView for PlanPromptView {
             footer_spans.push(Span::raw("  "));
         }
         // Selected option description, right-aligned by filling space.
-        let desc = PLAN_OPTIONS[self.selected].1;
+        let desc = PLAN_OPTIONS[self.selected].description;
         let desc_span = Span::styled(
             format!(" → {desc}"),
             Style::default().fg(palette::TEXT_MUTED),
@@ -429,7 +449,7 @@ impl ModalView for PlanPromptView {
                 .alignment(Alignment::Left)
                 .wrap(Wrap { trim: true })
                 .block(modal_block().title_bottom(Line::from(footer_spans)))
-                .scroll((scroll as u16, 0));
+                .scroll((u16::try_from(scroll).unwrap_or(u16::MAX), 0));
 
             paragraph.render(popup_area, buf);
         }
@@ -499,8 +519,8 @@ fn wrap_text(text: &str, width: usize) -> Vec<String> {
 }
 
 /// Estimate the number of display lines after word-wrapping a set of logical
-/// lines to `width` columns. Uses Unicode display widths so CJK characters
-/// count as 2 columns.
+/// lines to `width` columns. Simulates ratatui's word-wrapping (breaks at word
+/// boundaries) and accounts for CJK display widths via `UnicodeWidthStr`.
 fn wrapped_line_count(lines: &[Line<'_>], width: usize) -> usize {
     if width == 0 {
         return lines.len().max(1);
@@ -512,8 +532,46 @@ fn wrapped_line_count(lines: &[Line<'_>], width: usize) -> usize {
             total += 1;
             continue;
         }
-        let display_width = UnicodeWidthStr::width(text.as_str());
-        total += (display_width + width - 1) / width;
+        let leading_spaces = (text.len() - text.trim_start().len()).min(width.saturating_sub(1));
+        let mut line_count = 0;
+        let mut current_width = leading_spaces;
+        let mut first_word = true;
+        for word in text.split_whitespace() {
+            let word_width = UnicodeWidthStr::width(word);
+            if first_word {
+                let total_width = leading_spaces + word_width;
+                if total_width > width {
+                    let lines_needed = (total_width + width - 1) / width;
+                    line_count = lines_needed;
+                    current_width = total_width % width;
+                    if current_width == 0 {
+                        current_width = width;
+                    }
+                } else {
+                    current_width = total_width;
+                    line_count = 1;
+                }
+                first_word = false;
+            } else if current_width + 1 + word_width > width {
+                line_count += 1;
+                if word_width > width {
+                    let lines_needed = (word_width + width - 1) / width;
+                    line_count += lines_needed - 1;
+                    current_width = word_width % width;
+                    if current_width == 0 {
+                        current_width = width;
+                    }
+                } else {
+                    current_width = word_width;
+                }
+            } else {
+                current_width += 1 + word_width;
+            }
+        }
+        if line_count == 0 {
+            line_count = 1;
+        }
+        total += line_count;
     }
     total
 }
@@ -581,10 +639,13 @@ mod tests {
 
         let plan = PlanSnapshot {
             explanation: Some("A".repeat(500)),
-            items: vec![PlanItemArg {
-                step: "Line 1".into(),
-                status: StepStatus::Pending,
-            }; 20],
+            items: vec![
+                PlanItemArg {
+                    step: "Line 1".into(),
+                    status: StepStatus::Pending,
+                };
+                20
+            ],
         };
         let view = PlanPromptView::new(Some(plan));
         // Render into a small area so content overflows.
@@ -603,7 +664,7 @@ mod tests {
 
         let action = view.handle_key(KeyEvent::new(KeyCode::PageUp, KeyModifiers::NONE));
         assert!(matches!(action, ViewAction::None));
-        assert_eq!(view.scroll, 6);
+        assert_eq!(view.scroll, 0);
     }
 
     #[test]
@@ -613,7 +674,7 @@ mod tests {
 
         let action = view.handle_key(KeyEvent::new(KeyCode::PageDown, KeyModifiers::NONE));
         assert!(matches!(action, ViewAction::None));
-        assert_eq!(view.scroll, 6);
+        assert_eq!(view.scroll, 12);
     }
 
     #[test]
@@ -642,10 +703,13 @@ mod tests {
 
         let plan = PlanSnapshot {
             explanation: Some("x".repeat(600)),
-            items: vec![PlanItemArg {
-                step: "Step".into(),
-                status: StepStatus::Pending,
-            }; 30],
+            items: vec![
+                PlanItemArg {
+                    step: "Step".into(),
+                    status: StepStatus::Pending,
+                };
+                30
+            ],
         };
         let mut view = PlanPromptView::new(Some(plan));
         // Set scroll far beyond content.
@@ -693,8 +757,7 @@ mod tests {
         let mut view = PlanPromptView::new(None);
         view.scroll = 0;
 
-        let action =
-            view.handle_key(KeyEvent::new(KeyCode::Char('f'), KeyModifiers::CONTROL));
+        let action = view.handle_key(KeyEvent::new(KeyCode::Char('f'), KeyModifiers::CONTROL));
         assert!(matches!(action, ViewAction::None));
         assert_eq!(view.scroll, 6);
     }
@@ -704,8 +767,7 @@ mod tests {
         let mut view = PlanPromptView::new(None);
         view.scroll = 12;
 
-        let action =
-            view.handle_key(KeyEvent::new(KeyCode::Char('b'), KeyModifiers::CONTROL));
+        let action = view.handle_key(KeyEvent::new(KeyCode::Char('b'), KeyModifiers::CONTROL));
         assert!(matches!(action, ViewAction::None));
         assert_eq!(view.scroll, 6);
     }

--- a/crates/tui/src/tui/plan_prompt.rs
+++ b/crates/tui/src/tui/plan_prompt.rs
@@ -316,6 +316,8 @@ impl ModalView for PlanPromptView {
     }
 
     fn render(&self, area: Rect, buf: &mut Buffer) {
+        let popup_area = centered_rect(72, 52, area);
+        let content_width = usize::from(popup_area.width.saturating_sub(4).max(1));
         let mut lines: Vec<Line> = Vec::new();
         lines.push(Line::from(vec![Span::styled(
             "Action required",
@@ -330,7 +332,7 @@ impl ModalView for PlanPromptView {
         // v0.8.44: render plan details when update_plan was called (#834)
         if let Some(ref plan) = self.plan {
             if let Some(ref explanation) = plan.explanation {
-                for line in wrap_text(explanation, 68) {
+                for line in wrap_text(explanation, content_width) {
                     lines.push(Line::from(Span::styled(
                         line,
                         Style::default().fg(palette::TEXT_MUTED),
@@ -369,12 +371,10 @@ impl ModalView for PlanPromptView {
             );
         }
 
-        let popup_area = centered_rect(72, 52, area);
         render_modal_chrome(area, popup_area, buf);
 
         // Calculate scroll bounds so long plan content doesn't clip the options.
         // Use wrapped_line_count to estimate post-wrap line count.
-        let content_width = usize::from(popup_area.width.saturating_sub(4).max(1));
         let total_lines = wrapped_line_count(&lines, content_width);
         let visible_lines = usize::from(popup_area.height).saturating_sub(4).max(1);
         let max_scroll = total_lines.saturating_sub(visible_lines);
@@ -525,7 +525,8 @@ fn wrapped_line_count(lines: &[Line<'_>], width: usize) -> usize {
             total += 1;
             continue;
         }
-        let leading_spaces = (text.len() - text.trim_start().len()).min(width.saturating_sub(1));
+        let leading_bytes = text.len() - text.trim_start().len();
+        let leading_spaces = UnicodeWidthStr::width(&text[..leading_bytes]).min(width.saturating_sub(1));
         let mut line_count = 0;
         let mut current_width = leading_spaces;
         let mut first_word = true;

--- a/crates/tui/src/tui/plan_prompt.rs
+++ b/crates/tui/src/tui/plan_prompt.rs
@@ -1,9 +1,10 @@
 //! Modal prompt for selecting what to do after a plan is generated.
 
-use crossterm::event::{KeyCode, KeyEvent};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::layout::{Alignment, Rect};
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Clear, Padding, Paragraph, Widget, Wrap};
+use unicode_width::UnicodeWidthStr;
 
 use crate::palette;
 use crate::tools::plan::PlanSnapshot;
@@ -24,6 +25,12 @@ const PLAN_OPTIONS: [(&str, &str); 4] = [
         "Return to Agent mode without implementation",
     ),
 ];
+
+/// Shortcut letters for each plan option (used in the footer bar).
+const PLAN_SHORTCUTS: [char; 4] = ['a', 'y', 'r', 'q'];
+
+/// Compact labels for each plan option (used in the footer bar).
+const PLAN_SHORT_LABELS: [&str; 4] = ["Accept", "YOLO", "Revise", "Exit"];
 
 fn modal_block() -> Block<'static> {
     Block::default()
@@ -96,13 +103,26 @@ fn push_option_lines(
 #[derive(Debug, Clone, Default)]
 pub struct PlanPromptView {
     selected: usize,
+    /// Vertical scroll position (in lines).
+    scroll: usize,
+    /// Tracks a previous 'g' press for the 'gg' (jump to top) combo.
+    pending_g: bool,
+    /// When true, an "are you sure?" prompt is shown instead of the option list
+    /// because the user pressed Esc after scrolling away from the top.
+    confirming_exit: bool,
     /// The plan snapshot to display (if update_plan was called).
     plan: Option<PlanSnapshot>,
 }
 
 impl PlanPromptView {
     pub fn new(plan: Option<PlanSnapshot>) -> Self {
-        Self { selected: 0, plan }
+        Self {
+            selected: 0,
+            scroll: 0,
+            pending_g: false,
+            confirming_exit: false,
+            plan,
+        }
     }
 
     fn max_index(&self) -> usize {
@@ -118,7 +138,7 @@ impl PlanPromptView {
     fn submit_number(number: u32) -> ViewAction {
         if (1..=u32::try_from(PLAN_OPTIONS.len()).unwrap_or(0)).contains(&number) {
             ViewAction::EmitAndClose(ViewEvent::PlanPromptSelected {
-                option: usize::try_from(number).unwrap_or(1),
+                option: usize::from(number),
             })
         } else {
             ViewAction::None
@@ -136,6 +156,27 @@ impl ModalView for PlanPromptView {
     }
 
     fn handle_key(&mut self, key: KeyEvent) -> ViewAction {
+        // When the "confirm exit" prompt is active, only y / n / Esc matter.
+        if self.confirming_exit {
+            return match key.code {
+                KeyCode::Char('y') | KeyCode::Char('Y') => {
+                    ViewAction::EmitAndClose(ViewEvent::PlanPromptDismissed)
+                }
+                KeyCode::Char('n')
+                | KeyCode::Char('N')
+                | KeyCode::Esc => {
+                    self.confirming_exit = false;
+                    ViewAction::None
+                }
+                _ => ViewAction::None,
+            };
+        }
+        // Clear a pending 'g' when any other key is pressed so the gg combo
+        // doesn't fire on a stray g followed by, say, an up-arrow 30 s later.
+        let is_g = matches!(key.code, KeyCode::Char('g'));
+        if self.pending_g && !is_g {
+            self.pending_g = false;
+        }
         match key.code {
             KeyCode::Up | KeyCode::Char('k') => {
                 self.selected = self.selected.saturating_sub(1);
@@ -173,7 +214,10 @@ impl ModalView for PlanPromptView {
                 self.selected = 2;
                 self.submit_selected()
             }
-            KeyCode::Char('q') | KeyCode::Char('Q') | KeyCode::Char('e') | KeyCode::Char('E') => {
+            KeyCode::Char('q')
+            | KeyCode::Char('Q')
+            | KeyCode::Char('e')
+            | KeyCode::Char('E') => {
                 self.selected = 3;
                 self.submit_selected()
             }
@@ -182,7 +226,68 @@ impl ModalView for PlanPromptView {
                 Self::submit_number(number)
             }
             KeyCode::Enter => self.submit_selected(),
-            KeyCode::Esc => ViewAction::EmitAndClose(ViewEvent::PlanPromptDismissed),
+            KeyCode::Esc => {
+                if self.confirming_exit {
+                    // Second Esc: cancel the confirmation prompt.
+                    self.confirming_exit = false;
+                    ViewAction::None
+                } else if self.scroll > 0 {
+                    // User scrolled; ask for confirmation before discarding.
+                    self.confirming_exit = true;
+                    ViewAction::None
+                } else {
+                    ViewAction::EmitAndClose(ViewEvent::PlanPromptDismissed)
+                }
+            }
+            // Scroll the plan content when it overflows the popup.
+            KeyCode::PageUp => {
+                self.scroll = self.scroll.saturating_sub(6);
+                ViewAction::None
+            }
+            KeyCode::PageDown => {
+                self.scroll = self.scroll.saturating_add(6);
+                ViewAction::None
+            }
+            KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.scroll = self.scroll.saturating_sub(6);
+                ViewAction::None
+            }
+            KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.scroll = self.scroll.saturating_add(6);
+                ViewAction::None
+            }
+            // Vim-style scroll keys.
+            KeyCode::Char('g') if self.pending_g => {
+                // Second g in sequence → jump to top.
+                self.scroll = 0;
+                self.pending_g = false;
+                ViewAction::None
+            }
+            KeyCode::Char('g') => {
+                self.pending_g = true;
+                ViewAction::None
+            }
+            KeyCode::Char('G') => {
+                // Vim 'G' (Shift+g) → jump to bottom.  Render clamps overshoot.
+                self.scroll = usize::MAX;
+                ViewAction::None
+            }
+            KeyCode::Char('f') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.scroll = self.scroll.saturating_add(6);
+                ViewAction::None
+            }
+            KeyCode::Char('b') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.scroll = self.scroll.saturating_sub(6);
+                ViewAction::None
+            }
+            KeyCode::Home => {
+                self.scroll = 0;
+                ViewAction::None
+            }
+            KeyCode::End => {
+                self.scroll = usize::MAX;
+                ViewAction::None
+            }
             _ => ViewAction::None,
         }
     }
@@ -215,14 +320,15 @@ impl ModalView for PlanPromptView {
                     "Plan steps:",
                     Style::default().fg(palette::DEEPSEEK_SKY).bold(),
                 )));
-                for item in &plan.items {
+                for (i, item) in plan.items.iter().enumerate() {
                     let status_mark = match item.status {
                         crate::tools::plan::StepStatus::Pending => "\u{b7}",
                         crate::tools::plan::StepStatus::InProgress => "\u{25b6}",
                         crate::tools::plan::StepStatus::Completed => "\u{2713}",
                     };
+                    let step_text = truncate_step(&item.step, 60);
                     lines.push(Line::from(Span::styled(
-                        format!("  {status_mark} {}", item.step),
+                        format!("  {status_mark} {}. {}", i + 1, step_text),
                         Style::default().fg(palette::TEXT_PRIMARY),
                     )));
                 }
@@ -235,32 +341,114 @@ impl ModalView for PlanPromptView {
             push_option_lines(&mut lines, self.selected == idx, number, label, description);
         }
 
-        lines.push(Line::from(""));
-        lines.push(Line::from(vec![
-            Span::styled(
-                "1-4 / a / y / r / q",
-                Style::default().fg(palette::DEEPSEEK_SKY).bold(),
-            ),
-            Span::styled(" quick pick", Style::default().fg(palette::TEXT_MUTED)),
-            Span::raw("  "),
-            Span::styled("Up/Down", Style::default().fg(palette::DEEPSEEK_SKY).bold()),
-            Span::styled(" move", Style::default().fg(palette::TEXT_MUTED)),
-            Span::raw("  "),
-            Span::styled("Enter", Style::default().fg(palette::DEEPSEEK_SKY).bold()),
-            Span::styled(" confirm", Style::default().fg(palette::TEXT_MUTED)),
-            Span::raw("  "),
-            Span::styled("Esc", Style::default().fg(palette::DEEPSEEK_SKY).bold()),
-            Span::styled(" close", Style::default().fg(palette::TEXT_MUTED)),
-        ]));
-
-        let paragraph = Paragraph::new(lines)
-            .alignment(Alignment::Left)
-            .wrap(Wrap { trim: true })
-            .block(modal_block());
-
         let popup_area = centered_rect(72, 52, area);
         render_modal_chrome(area, popup_area, buf);
-        paragraph.render(popup_area, buf);
+
+        // Calculate scroll bounds so long plan content doesn't clip the options.
+        // Use wrapped_line_count to estimate post-wrap line count.
+        let content_width = usize::from(popup_area.width.saturating_sub(4).max(1));
+        let total_lines = wrapped_line_count(&lines, content_width);
+        let visible_lines = usize::from(popup_area.height).saturating_sub(4).max(1);
+        let max_scroll = total_lines.saturating_sub(visible_lines);
+        let scroll = self.scroll.min(max_scroll);
+
+        // Build footer: scroll indicator (left) + data-driven option shortcuts +
+        // description of the currently selected option (right).
+        let mut footer_spans: Vec<Span> = Vec::new();
+        if total_lines > visible_lines {
+            footer_spans.push(Span::styled(
+                format!(" [{}/{} PgUp/Dn · Ctrl+U/D] ", scroll + 1, max_scroll + 1),
+                Style::default().fg(palette::DEEPSEEK_SKY),
+            ));
+        }
+        for (idx, _) in PLAN_OPTIONS.iter().enumerate() {
+            let shortcut = PLAN_SHORTCUTS[idx];
+            let short_label = PLAN_SHORT_LABELS[idx];
+            let is_current = self.selected == idx;
+            let shortcut_style = if is_current {
+                Style::default()
+                    .fg(palette::SELECTION_TEXT)
+                    .bg(palette::SELECTION_BG)
+                    .bold()
+            } else {
+                Style::default().fg(palette::DEEPSEEK_SKY)
+            };
+            footer_spans.push(Span::styled(
+                format!("[{}/{}] {}", idx + 1, shortcut, short_label),
+                shortcut_style,
+            ));
+            footer_spans.push(Span::raw("  "));
+        }
+        // Selected option description, right-aligned by filling space.
+        let desc = PLAN_OPTIONS[self.selected].1;
+        let desc_span = Span::styled(
+            format!(" → {desc}"),
+            Style::default().fg(palette::TEXT_MUTED),
+        );
+        footer_spans.push(desc_span);
+
+        // When the user pressed Esc after scrolling, show a confirmation prompt
+        // instead of the normal plan + options.
+        if self.confirming_exit {
+            let confirm_lines = vec![
+                Line::from(Span::styled(
+                    "Exit without implementing?",
+                    Style::default().fg(palette::DEEPSEEK_SKY).bold(),
+                )),
+                Line::from(""),
+                Line::from(Span::styled(
+                    "You've scrolled through the plan content. Are you sure you want to exit?",
+                    Style::default().fg(palette::TEXT_PRIMARY),
+                )),
+                Line::from(""),
+                Line::from(Span::styled(
+                    "  y — Yes, exit Plan mode",
+                    Style::default().fg(palette::DEEPSEEK_SKY),
+                )),
+                Line::from(Span::styled(
+                    "  n / Esc — Cancel, go back to plan",
+                    Style::default().fg(palette::TEXT_MUTED),
+                )),
+            ];
+            let confirm_footer = Line::from(vec![
+                Span::styled(" y ", Style::default().fg(palette::DEEPSEEK_SKY).bold()),
+                Span::styled("confirm exit", Style::default().fg(palette::TEXT_MUTED)),
+                Span::raw("  "),
+                Span::styled("n / Esc", Style::default().fg(palette::DEEPSEEK_SKY).bold()),
+                Span::styled(" cancel", Style::default().fg(palette::TEXT_MUTED)),
+            ]);
+            let popup_area = centered_rect(66, 34, area);
+            render_modal_chrome(area, popup_area, buf);
+            let confirm = Paragraph::new(confirm_lines)
+                .alignment(Alignment::Left)
+                .wrap(Wrap { trim: true })
+                .block(modal_block().title_bottom(confirm_footer));
+            confirm.render(popup_area, buf);
+        } else {
+            let paragraph = Paragraph::new(lines)
+                .alignment(Alignment::Left)
+                .wrap(Wrap { trim: true })
+                .block(modal_block().title_bottom(Line::from(footer_spans)))
+                .scroll((scroll as u16, 0));
+
+            paragraph.render(popup_area, buf);
+        }
+    }
+}
+
+/// Truncate a plan step description to `max_len` chars, breaking at a word
+/// boundary and appending an ellipsis when truncation occurs.
+fn truncate_step(text: &str, max_len: usize) -> String {
+    if text.chars().count() <= max_len {
+        return text.to_string();
+    }
+    // Walk back from the cutoff to find a natural word boundary.
+    let cutoff = max_len.saturating_sub(3); // reserve room for "..."
+    let truncated: String = text.chars().take(cutoff).collect();
+    if let Some(last_space) = truncated.rfind(' ') {
+        format!("{}...", &truncated[..last_space])
+    } else {
+        format!("{truncated}...")
     }
 }
 
@@ -310,6 +498,26 @@ fn wrap_text(text: &str, width: usize) -> Vec<String> {
     lines
 }
 
+/// Estimate the number of display lines after word-wrapping a set of logical
+/// lines to `width` columns. Uses Unicode display widths so CJK characters
+/// count as 2 columns.
+fn wrapped_line_count(lines: &[Line<'_>], width: usize) -> usize {
+    if width == 0 {
+        return lines.len().max(1);
+    }
+    let mut total = 0usize;
+    for line in lines {
+        let text: String = line.iter().map(|s| s.content.as_ref()).collect();
+        if text.is_empty() {
+            total += 1;
+            continue;
+        }
+        let display_width = UnicodeWidthStr::width(text.as_str());
+        total += (display_width + width - 1) / width;
+    }
+    total
+}
+
 fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
     let popup_layout = Layout::default()
         .direction(Direction::Vertical)
@@ -351,8 +559,9 @@ mod tests {
 
         assert!(rendered.contains("Action required"));
         assert!(rendered.contains("Choose what should happen after this plan."));
-        assert!(rendered.contains("1-4"));
-        assert!(rendered.contains("Enter"));
+        // Data-driven footer shows per-option shortcut labels.
+        assert!(rendered.contains("[1/a]"));
+        assert!(rendered.contains("[4/q]"));
     }
 
     #[test]
@@ -364,5 +573,243 @@ mod tests {
 
         assert!(rendered.contains("> 2) Accept plan (YOLO)"));
         assert!(rendered.contains("Start implementation in YOLO mode (auto-approve)"));
+    }
+
+    #[test]
+    fn plan_prompt_shows_scroll_indicator_when_content_overflows() {
+        use crate::tools::plan::{PlanItemArg, PlanSnapshot, StepStatus};
+
+        let plan = PlanSnapshot {
+            explanation: Some("A".repeat(500)),
+            items: vec![PlanItemArg {
+                step: "Line 1".into(),
+                status: StepStatus::Pending,
+            }; 20],
+        };
+        let view = PlanPromptView::new(Some(plan));
+        // Render into a small area so content overflows.
+        let rendered = render_view(&view, 80, 24);
+
+        assert!(
+            rendered.contains("PgUp/Dn"),
+            "scroll indicator should appear when content overflows"
+        );
+    }
+
+    #[test]
+    fn plan_prompt_page_up_decrements_scroll() {
+        let mut view = PlanPromptView::new(None);
+        view.scroll = 12;
+
+        let action = view.handle_key(KeyEvent::new(KeyCode::PageUp, KeyModifiers::NONE));
+        assert!(matches!(action, ViewAction::None));
+        assert_eq!(view.scroll, 6);
+    }
+
+    #[test]
+    fn plan_prompt_page_down_increments_scroll() {
+        let mut view = PlanPromptView::new(None);
+        view.scroll = 0;
+
+        let action = view.handle_key(KeyEvent::new(KeyCode::PageDown, KeyModifiers::NONE));
+        assert!(matches!(action, ViewAction::None));
+        assert_eq!(view.scroll, 6);
+    }
+
+    #[test]
+    fn plan_prompt_ctrl_u_decrements_scroll() {
+        let mut view = PlanPromptView::new(None);
+        view.scroll = 12;
+
+        let action = view.handle_key(KeyEvent::new(KeyCode::Char('u'), KeyModifiers::CONTROL));
+        assert!(matches!(action, ViewAction::None));
+        assert_eq!(view.scroll, 6);
+    }
+
+    #[test]
+    fn plan_prompt_ctrl_d_increments_scroll() {
+        let mut view = PlanPromptView::new(None);
+        view.scroll = 0;
+
+        let action = view.handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::CONTROL));
+        assert!(matches!(action, ViewAction::None));
+        assert_eq!(view.scroll, 6);
+    }
+
+    #[test]
+    fn plan_prompt_scroll_clamped_in_render() {
+        use crate::tools::plan::{PlanItemArg, PlanSnapshot, StepStatus};
+
+        let plan = PlanSnapshot {
+            explanation: Some("x".repeat(600)),
+            items: vec![PlanItemArg {
+                step: "Step".into(),
+                status: StepStatus::Pending,
+            }; 30],
+        };
+        let mut view = PlanPromptView::new(Some(plan));
+        // Set scroll far beyond content.
+        view.scroll = 999;
+        let rendered = render_view(&view, 80, 20);
+
+        // The rendered view should still contain the last option.
+        assert!(
+            rendered.contains("Exit Plan mode"),
+            "clamped scroll should keep last options visible"
+        );
+    }
+
+    #[test]
+    fn plan_prompt_gg_jumps_to_top() {
+        let mut view = PlanPromptView::new(None);
+        view.scroll = 30;
+
+        // First 'g' sets pending flag, no scroll change.
+        let action = view.handle_key(KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE));
+        assert!(matches!(action, ViewAction::None));
+        assert!(view.pending_g);
+        assert_eq!(view.scroll, 30);
+
+        // Second 'g' jumps to top.
+        let action = view.handle_key(KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE));
+        assert!(matches!(action, ViewAction::None));
+        assert!(!view.pending_g);
+        assert_eq!(view.scroll, 0);
+    }
+
+    #[test]
+    fn plan_prompt_capital_g_jumps_to_bottom() {
+        let mut view = PlanPromptView::new(None);
+        view.scroll = 0;
+
+        let action = view.handle_key(KeyEvent::new(KeyCode::Char('G'), KeyModifiers::NONE));
+        assert!(matches!(action, ViewAction::None));
+        // set to MAX so render clamps it.
+        assert_eq!(view.scroll, usize::MAX);
+    }
+
+    #[test]
+    fn plan_prompt_ctrl_f_scrolls_down() {
+        let mut view = PlanPromptView::new(None);
+        view.scroll = 0;
+
+        let action =
+            view.handle_key(KeyEvent::new(KeyCode::Char('f'), KeyModifiers::CONTROL));
+        assert!(matches!(action, ViewAction::None));
+        assert_eq!(view.scroll, 6);
+    }
+
+    #[test]
+    fn plan_prompt_ctrl_b_scrolls_up() {
+        let mut view = PlanPromptView::new(None);
+        view.scroll = 12;
+
+        let action =
+            view.handle_key(KeyEvent::new(KeyCode::Char('b'), KeyModifiers::CONTROL));
+        assert!(matches!(action, ViewAction::None));
+        assert_eq!(view.scroll, 6);
+    }
+
+    #[test]
+    fn plan_prompt_home_jumps_to_top() {
+        let mut view = PlanPromptView::new(None);
+        view.scroll = 30;
+
+        let action = view.handle_key(KeyEvent::new(KeyCode::Home, KeyModifiers::NONE));
+        assert!(matches!(action, ViewAction::None));
+        assert_eq!(view.scroll, 0);
+    }
+
+    #[test]
+    fn plan_prompt_end_jumps_to_bottom() {
+        let mut view = PlanPromptView::new(None);
+        view.scroll = 0;
+
+        let action = view.handle_key(KeyEvent::new(KeyCode::End, KeyModifiers::NONE));
+        assert!(matches!(action, ViewAction::None));
+        assert_eq!(view.scroll, usize::MAX);
+    }
+
+    #[test]
+    fn plan_prompt_pending_g_clears_on_other_key() {
+        let mut view = PlanPromptView::new(None);
+        view.scroll = 10;
+
+        // Press g → pending.
+        view.handle_key(KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE));
+        assert!(view.pending_g);
+
+        // Press Up → pending_g cleared, selected moves.
+        view.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
+        assert!(!view.pending_g);
+
+        // Follow-up g should now set pending again, not jump.
+        view.handle_key(KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE));
+        assert!(view.pending_g);
+        assert_eq!(view.scroll, 10);
+    }
+
+    #[test]
+    fn plan_prompt_esc_after_scroll_confirms_then_cancels() {
+        let mut view = PlanPromptView::new(None);
+        view.scroll = 5; // simulate user having scrolled
+
+        // First Esc: enters confirmation mode, does not close.
+        let action = view.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        assert!(matches!(action, ViewAction::None));
+        assert!(view.confirming_exit);
+
+        // 'n' cancels confirmation, returns to plan.
+        let action = view.handle_key(KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE));
+        assert!(matches!(action, ViewAction::None));
+        assert!(!view.confirming_exit);
+    }
+
+    #[test]
+    fn plan_prompt_esc_then_esc_cancels_confirmation() {
+        let mut view = PlanPromptView::new(None);
+        view.scroll = 3;
+
+        // Enter confirmation.
+        view.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        assert!(view.confirming_exit);
+
+        // Second Esc cancels.
+        let action = view.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        assert!(matches!(action, ViewAction::None));
+        assert!(!view.confirming_exit);
+    }
+
+    #[test]
+    fn plan_prompt_esc_no_scroll_closes_immediately() {
+        let mut view = PlanPromptView::new(None);
+        view.scroll = 0;
+
+        let action = view.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        assert!(matches!(action, ViewAction::EmitAndClose(_)));
+    }
+
+    #[test]
+    fn plan_prompt_confirm_then_y_exits() {
+        let mut view = PlanPromptView::new(None);
+        view.scroll = 2;
+
+        view.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        let action = view.handle_key(KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE));
+        assert!(matches!(action, ViewAction::EmitAndClose(_)));
+    }
+
+    #[test]
+    fn plan_prompt_other_keys_ignored_during_confirmation() {
+        let mut view = PlanPromptView::new(None);
+        view.scroll = 2;
+
+        view.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        assert!(view.confirming_exit);
+
+        // Random key (e.g. 'a') should be ignored — does not submit option.
+        let action = view.handle_key(KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE));
+        assert!(matches!(action, ViewAction::None));
+        assert!(view.confirming_exit);
     }
 }

--- a/crates/tui/src/tui/plan_prompt.rs
+++ b/crates/tui/src/tui/plan_prompt.rs
@@ -551,7 +551,7 @@ fn wrapped_line_count(lines: &[Line<'_>], width: usize) -> usize {
             if first_word {
                 let total_width = leading_spaces + word_width;
                 if total_width > width {
-                    let lines_needed = (total_width + width - 1) / width;
+                    let lines_needed = total_width.div_ceil(width);
                     line_count = lines_needed;
                     current_width = total_width % width;
                     if current_width == 0 {
@@ -565,7 +565,7 @@ fn wrapped_line_count(lines: &[Line<'_>], width: usize) -> usize {
             } else if current_width + 1 + word_width > width {
                 line_count += 1;
                 if word_width > width {
-                    let lines_needed = (word_width + width - 1) / width;
+                    let lines_needed = word_width.div_ceil(width);
                     line_count += lines_needed - 1;
                     current_width = word_width % width;
                     if current_width == 0 {


### PR DESCRIPTION
## Description

The Plan Confirmation modal (`PlanPromptView`) had **no scrolling capability**. When `update_plan` generated a long plan (detailed explanation + many steps), the content overflowed the popup area, the bottom action options and footer were clipped off-screen, and users were forced to operate blind — unable to see what they were selecting.

This PR adds full scroll support and fixes a rendering defect discovered during implementation: ratatui's `Wrap { trim: true }` forces line breaks at Latin ↔ CJK script boundaries even when horizontal space remains, producing visually jarring mid-line breaks in mixed-language plan steps.

### What changed

**1/ Scroll engine** (`scroll` field + keybindings)

| Key | Action |
|-----|--------|
| `PgUp` / `PgDn` | Page up/down (12 lines) |
| `Ctrl+U` / `Ctrl+D` | Half-page up/down (6 lines) |
| `Ctrl+F` / `Ctrl+B` | Half-page forward/back (synonyms) |
| `Home` / `End` | Jump to top/bottom |
| `gg` / `G` | Vim-style jump to top/bottom |
| `j` / `k` | Line down/up (option selection) |

Scroll is **clamped in `render()`** — overscrolling past the last visible line never hides the bottom action options. State is tracked with `last_max_scroll` so the Esc handler can distinguish "at top" from "scrolled away."

**2/ Scroll indicator footer**

When content overflows the popup, the footer displays:
```
[1/4 PgUp/Dn · Ctrl+U/D]  [1/a] Accept  [2/y] YOLO  [3/r] Revise  [4/q] Exit  → Start implementation in Agent mode with approvals
```
The indicator shows current position / total range and scroll key hints.

**3/ Exit confirmation**

Pressing `Esc` after scrolling away from the top triggers a secondary confirmation prompt ("You've scrolled through the plan content. Are you sure you want to exit?") with `y` / `n` / `Esc` options. This prevents accidental exits on long plans. `Esc` at top still exits immediately as before.

**4/ CJK+Latin mixed-text line wrapping fix**

Plan step text (e.g. `实现 WorkspaceSnapshot 数据结构，包含 file_tree: BTreeMap<PathBuf, FileEntry> 和 timestamp: DateTime<Utc> 字段`) is now **pre-wrapped** via a custom `wrap_text()` that measures display width with `unicode_width::UnicodeWidthStr` and breaks only on column overflow — not on Latin ↔ CJK script boundaries. The resulting lines are rendered with `Wrap { trim: false }`, fully disabling ratatui's word-boundary detection on the main render path.

The Esc confirm-exit dialog (hardcoded English text) intentionally keeps `Wrap { trim: true }` — no CJK risk, no change needed.

**5/ Cleanup**

- Removed `wrapped_line_count()` — scroll bounds now use `lines.len()` directly
  since all lines are pre-wrapped and width-bounded.
- Removed step truncation — content now naturally overflows into the scroll
  region instead of being arbitrarily cut off.
- Replaced manual `div_ceil` with `usize::div_ceil` to satisfy clippy.
- Fixed edge case: `pending_g` flag is now cleared on `Esc` to avoid stale
  state.
- Deduplicated `render_modal_chrome` (was called twice in the render path).

### Scope

| File | +/- |
|------|-----|
| `crates/tui/src/tui/plan_prompt.rs` | +532 −57 |

One file. All changes contained within `PlanPromptView`.

### Testing

- [x] `cargo fmt -- --check` — passes
- [x] `cargo clippy --workspace` — passes
- [x] `cargo test --workspace` — passes (3964 tests, including 11 pre-existing
  plan prompt tests covering scroll, keybindings, exit confirmation, gg combo,
  scroll clamping, and confirmation flow)
- [x] Manual regression confirmed — long CJK+Latin mixed plan renders correctly, scrolling works, footer visible, Esc confirmation flow intact