### PR TITLE
  fix(tui): hide shell prompt guidance when shell is disabled

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -630,6 +630,7 @@ impl Engine {
                     translation_enabled: config.translation_enabled,
                     model_id: &config.model,
                     show_thinking: config.show_thinking,
+                    allow_shell: config.allow_shell,
                 },
                 session.approval_mode,
             );
@@ -2362,6 +2363,7 @@ In {new} mode: {policy}\n\n\
                 translation_enabled: self.config.translation_enabled,
                 model_id: &self.config.model,
                 show_thinking: self.config.show_thinking,
+                allow_shell: self.session.allow_shell,
             },
             self.session.approval_mode,
         );

--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -38,6 +38,10 @@ pub struct PromptSessionContext<'a> {
     /// When false, the prompt should not spend localization pressure on
     /// `reasoning_content` the user will never see.
     pub show_thinking: bool,
+    /// Whether shell tools are available in the runtime tool catalog for
+    /// this session. The prompt must not advertise shell-only workflows
+    /// when runtime gates have removed those tools.
+    pub allow_shell: bool,
 }
 
 impl Default for PromptSessionContext<'_> {
@@ -50,6 +54,7 @@ impl Default for PromptSessionContext<'_> {
             translation_enabled: false,
             model_id: "codewhale",
             show_thinking: true,
+            allow_shell: true,
         }
     }
 }
@@ -776,8 +781,23 @@ pub fn compose_prompt_with_approval_and_model(
     approval_mode: ApprovalMode,
     model_id: &str,
 ) -> String {
+    compose_prompt_with_approval_model_and_shell(mode, personality, approval_mode, model_id, true)
+}
+
+fn compose_prompt_with_approval_model_and_shell(
+    mode: AppMode,
+    personality: Personality,
+    approval_mode: ApprovalMode,
+    model_id: &str,
+    allow_shell: bool,
+) -> String {
     let tool_taxonomy = render_core_tool_taxonomy_block(mode);
-    let base_prompt = apply_model_template(effective_base_prompt().trim(), model_id);
+    let shell_tools_available = allow_shell && mode != AppMode::Plan;
+    let base_prompt = render_base_prompt_for_tool_availability(
+        effective_base_prompt().trim(),
+        model_id,
+        shell_tools_available,
+    );
     let parts: [&str; 5] = [
         tool_taxonomy.as_str(),
         base_prompt.as_str(),
@@ -798,6 +818,66 @@ pub fn compose_prompt_with_approval_and_model(
     out
 }
 
+fn render_base_prompt_for_tool_availability(
+    prompt: &str,
+    model_id: &str,
+    shell_tools_available: bool,
+) -> String {
+    let prompt = if shell_tools_available {
+        prompt.to_string()
+    } else {
+        remove_shell_tool_guidance(prompt)
+    };
+    apply_model_template(&prompt, model_id)
+}
+
+fn remove_shell_tool_guidance(prompt: &str) -> String {
+    let prompt = prompt
+        .lines()
+        .filter(|line| !is_shell_disabled_prompt_line(line))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let prompt = remove_markdown_section(&prompt, "### `exec_shell`");
+    let prompt = prompt.replace(
+        "; for GitHub issue/PR/release triage, prefer the native `gh ... --json` CLI through shell because it is authenticated, structured, and reproducible; `github_issue_context` / `github_pr_context` are read-only fallbacks when the CLI route is unavailable;",
+        "; for GitHub issue/PR/release triage, use `github_issue_context` / `github_pr_context` as read-only routes when shell tools are unavailable;",
+    );
+    prompt.replace(
+        "Use deterministic Python inside RLM for exact counts and structured aggregation; use `grep_files` or `exec_shell` directly when that is the clearest deterministic check.",
+        "Use deterministic Python inside RLM for exact counts and structured aggregation; use `grep_files` directly when that is the clearest deterministic check.",
+    )
+}
+
+fn is_shell_disabled_prompt_line(line: &str) -> bool {
+    line.starts_with("- Arithmetic, math, calculations → `exec_shell`")
+        || line.starts_with("- Hashes, encodings, checksums → `exec_shell`")
+        || line.starts_with("- Current time, date, timezone → `exec_shell`")
+        || line
+            .starts_with("- System state: OS, CPU, memory, disk, ports, processes → `exec_shell`")
+        || line.starts_with("- **Shell**:")
+}
+
+fn remove_markdown_section(prompt: &str, heading: &str) -> String {
+    let Some(start) = prompt.find(heading) else {
+        return prompt.to_string();
+    };
+    let after_heading = start + heading.len();
+    let end = prompt[after_heading..]
+        .find("\n### ")
+        .map(|offset| after_heading + offset)
+        .unwrap_or(prompt.len());
+
+    let before = prompt[..start].trim_end();
+    let after = prompt[end..].trim_start_matches('\n');
+    if before.is_empty() {
+        after.to_string()
+    } else if after.is_empty() {
+        before.to_string()
+    } else {
+        format!("{before}\n\n{after}")
+    }
+}
+
 /// Compose for the default personality (Calm).
 fn compose_mode_prompt(mode: AppMode) -> String {
     compose_prompt(mode, Personality::Calm)
@@ -812,7 +892,13 @@ fn compose_mode_prompt_with_approval_and_model(
     approval_mode: ApprovalMode,
     model_id: &str,
 ) -> String {
-    compose_prompt_with_approval_and_model(mode, Personality::Calm, approval_mode, model_id)
+    compose_prompt_with_approval_model_and_shell(
+        mode,
+        Personality::Calm,
+        approval_mode,
+        model_id,
+        true,
+    )
 }
 
 // ── Public API ────────────────────────────────────────────────────────
@@ -885,6 +971,7 @@ pub fn system_prompt_for_mode_with_context_and_skills(
             translation_enabled: false,
             model_id: "codewhale",
             show_thinking: true,
+            allow_shell: true,
         },
     )
 }
@@ -917,8 +1004,13 @@ pub fn system_prompt_for_mode_with_context_skills_session_and_approval(
     session_context: PromptSessionContext<'_>,
     approval_mode: ApprovalMode,
 ) -> SystemPrompt {
-    let mode_prompt =
-        compose_mode_prompt_with_approval_and_model(mode, approval_mode, session_context.model_id);
+    let mode_prompt = compose_prompt_with_approval_model_and_shell(
+        mode,
+        Personality::Calm,
+        approval_mode,
+        session_context.model_id,
+        session_context.allow_shell,
+    );
 
     // Load project context from workspace
     let project_context = load_project_context_with_parents(workspace);
@@ -1254,6 +1346,60 @@ mod tests {
     }
 
     #[test]
+    fn composed_prompt_keeps_shell_guidance_when_shell_tools_are_available() {
+        let prompt = compose_prompt_with_approval_model_and_shell(
+            AppMode::Agent,
+            Personality::Calm,
+            ApprovalMode::Suggest,
+            "deepseek-v4-pro",
+            true,
+        );
+
+        assert!(prompt.contains("- **Shell**:"));
+        assert!(prompt.contains("### `exec_shell`"));
+        assert!(prompt.contains("`task_shell_start`"));
+        assert!(prompt.contains("Arithmetic, math, calculations → `exec_shell`"));
+    }
+
+    #[test]
+    fn composed_prompt_omits_shell_guidance_when_shell_tools_are_unavailable() {
+        let prompt = compose_prompt_with_approval_model_and_shell(
+            AppMode::Agent,
+            Personality::Calm,
+            ApprovalMode::Suggest,
+            "deepseek-v4-pro",
+            false,
+        );
+
+        for shell_only in [
+            "- **Shell**:",
+            "### `exec_shell`",
+            "`task_shell_start`",
+            "exec_shell",
+            "task_shell",
+            "Arithmetic, math, calculations → `exec_shell`",
+            "Hashes, encodings, checksums → `exec_shell`",
+            "Current time, date, timezone → `exec_shell`",
+            "System state: OS, CPU, memory, disk, ports, processes → `exec_shell`",
+            "CLI through shell",
+            "or `exec_shell` directly",
+        ] {
+            assert!(
+                !prompt.contains(shell_only),
+                "shell-disabled prompt must not advertise {shell_only:?}"
+            );
+        }
+        assert!(
+            prompt.contains("actual runtime gates still determine what tools can execute"),
+            "shell-disabled prompt should keep the runtime-gates hierarchy clause"
+        );
+        assert!(
+            prompt.contains("`task_gate_run`") && prompt.contains("`github_issue_context`"),
+            "shell-disabled prompt should keep non-shell task evidence tools"
+        );
+    }
+
+    #[test]
     fn composed_prompt_starts_with_core_tool_taxonomy() {
         let prompt = compose_prompt_with_approval_and_model(
             AppMode::Agent,
@@ -1456,6 +1602,7 @@ mod tests {
                 translation_enabled: false,
                 model_id: "codewhale",
                 show_thinking: true,
+                allow_shell: true,
             },
             ApprovalMode::Suggest,
         ) {
@@ -1527,6 +1674,7 @@ mod tests {
                 translation_enabled: false,
                 model_id: "codewhale",
                 show_thinking: true,
+                allow_shell: true,
             },
             ApprovalMode::Suggest,
         ) {
@@ -1571,6 +1719,7 @@ mod tests {
                 translation_enabled: false,
                 model_id: "codewhale",
                 show_thinking: false,
+                allow_shell: true,
             },
             ApprovalMode::Suggest,
         ) {
@@ -1625,6 +1774,7 @@ mod tests {
                 translation_enabled: false,
                 model_id: "codewhale",
                 show_thinking: true,
+                allow_shell: true,
             },
             ApprovalMode::Suggest,
         ) {
@@ -1730,6 +1880,7 @@ mod tests {
                 translation_enabled: false,
                 model_id: "codewhale",
                 show_thinking: true,
+                allow_shell: true,
             },
         ) {
             SystemPrompt::Text(text) => text,
@@ -1767,6 +1918,7 @@ mod tests {
                 translation_enabled: false,
                 model_id: "codewhale",
                 show_thinking: true,
+                allow_shell: true,
             },
         ) {
             SystemPrompt::Text(text) => text,
@@ -1796,6 +1948,7 @@ mod tests {
                 translation_enabled: false,
                 model_id: "codewhale",
                 show_thinking: true,
+                allow_shell: true,
             },
         ) {
             SystemPrompt::Text(text) => text,
@@ -1854,6 +2007,7 @@ mod tests {
                 translation_enabled: false,
                 model_id: "codewhale",
                 show_thinking: true,
+                allow_shell: true,
             },
         ) {
             SystemPrompt::Text(text) => text,
@@ -1883,6 +2037,7 @@ mod tests {
                 translation_enabled: false,
                 model_id: "codewhale",
                 show_thinking: true,
+                allow_shell: true,
             },
         ) {
             SystemPrompt::Text(text) => text,
@@ -2079,6 +2234,7 @@ mod tests {
                 translation_enabled: false,
                 model_id: "codewhale",
                 show_thinking: true,
+                allow_shell: true,
             },
         ) {
             SystemPrompt::Text(text) => text,
@@ -2114,6 +2270,7 @@ mod tests {
                 translation_enabled: false,
                 model_id: "codewhale",
                 show_thinking: true,
+                allow_shell: true,
             },
         ) {
             SystemPrompt::Text(text) => text,

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -4860,6 +4860,7 @@ async fn dispatch_user_message(
                 translation_enabled: app.translation_enabled,
                 model_id: &app.model,
                 show_thinking: app.show_thinking,
+                allow_shell: app.allow_shell,
             },
         ),
     );


### PR DESCRIPTION
## Summary

  Fixes #2637.

  When `allow_shell = false`, the runtime tool catalog correctly removes shell
  tools such as `exec_shell` and `task_shell_start`, but the system prompt still
  advertised those tools in the Toolbox and mandatory tool-use guidance.

  That mismatch could cause the model to try calling shell tools that are not
  available, wasting a turn with a missing-tool error.

  This PR threads shell availability into prompt composition and removes
  shell-only guidance when shell tools are disabled, while keeping non-shell
  tool guidance intact.

## Testing

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a mismatch between the runtime tool catalog and the system prompt when `allow_shell = false`: the prompt was advertising `exec_shell` / `task_shell_start` workflows even though those tools had been removed at runtime, wasting a turn when the model tried to call them. The fix threads `allow_shell` through `PromptSessionContext` into prompt composition and strips shell-only guidance from the base prompt before serving it.

- `PromptSessionContext` gains a new `allow_shell` field (defaulting to `true`) that is populated from the active config or session state at all three call sites in `engine.rs` and `ui.rs`.
- A new private `compose_prompt_with_approval_model_and_shell` function conditionally invokes `remove_shell_tool_guidance`, which removes specific lines, the `exec_shell` markdown section, and two inline sentence fragments that reference shell tools; two new tests verify the filtering on and off.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the fix correctly threads shell availability into prompt composition and is backed by targeted tests.

The private `compose_mode_prompt_with_approval_and_model` function has no callers after the refactor and will produce an `unused` compiler warning. The string-based filtering in `remove_shell_tool_guidance` is functional and tested, but is tightly coupled to exact prompt wording — a future prompt edit could silently re-expose shell guidance without a failing build. Neither issue affects runtime correctness today.

crates/tui/src/prompts.rs — dead private function and fragile string-matching logic worth cleaning up before the prompt text evolves further.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/tui/src/prompts.rs | Core change: adds `allow_shell` to `PromptSessionContext`, introduces `remove_shell_tool_guidance` + `remove_markdown_section` helpers, and wires shell-aware prompt composition. A private helper (`compose_mode_prompt_with_approval_and_model`) is now dead code; the string-based filtering approach is tested but fragile. |
| crates/tui/src/core/engine.rs | Two call sites updated to pass `allow_shell` into `PromptSessionContext`; one uses `config.allow_shell` (initial setup) and the other uses `session.allow_shell` (prompt refresh) — both are kept in sync and are correct. |
| crates/tui/src/tui/ui.rs | Single call site in `dispatch_user_message` updated to propagate `app.allow_shell` into `PromptSessionContext`; straightforward and consistent with the other two call sites. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as ui.rs (dispatch_user_message)
    participant Engine as engine.rs
    participant Prompts as prompts.rs

    UI->>Engine: "PromptSessionContext { allow_shell: app.allow_shell }"
    Engine->>Prompts: system_prompt_for_mode_with_context_skills_session_and_approval(ctx)
    Prompts->>Prompts: compose_prompt_with_approval_model_and_shell(allow_shell)
    alt "allow_shell && mode != Plan"
        Prompts->>Prompts: "render_base_prompt_for_tool_availability(shell_available=true)"
        Note over Prompts: Full prompt with exec_shell / task_shell_start guidance
    else shell disabled or Plan mode
        Prompts->>Prompts: "render_base_prompt_for_tool_availability(shell_available=false)"
        Prompts->>Prompts: remove_shell_tool_guidance(prompt)
        Note over Prompts: Strip Shell lines, exec_shell section, inline refs
    end
    Prompts-->>Engine: SystemPrompt (shell guidance conditionally removed)
    Engine-->>UI: Updated system prompt stored in session
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/tui/src/prompts.rs`, line 890-902 ([link](https://github.com/hmbown/codewhale/blob/cdaa253fb655e692b5a1d3c5a0b99b83c63c09c7/crates/tui/src/prompts.rs#L890-L902)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Dead code after refactor**

   `compose_mode_prompt_with_approval_and_model` has no remaining call sites — the only caller (`system_prompt_for_mode_with_context_skills_session_and_approval`) was switched directly to `compose_prompt_with_approval_model_and_shell` in this PR. The private function is now unreachable and the Rust compiler will emit an `unused` warning. It can be removed entirely.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fallow-shell-prompt-gate%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fallow-shell-prompt-gate%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fprompts.rs%0ALine%3A%20890-902%0A%0AComment%3A%0A**Dead%20code%20after%20refactor**%0A%0A%60compose_mode_prompt_with_approval_and_model%60%20has%20no%20remaining%20call%20sites%20%E2%80%94%20the%20only%20caller%20%28%60system_prompt_for_mode_with_context_skills_session_and_approval%60%29%20was%20switched%20directly%20to%20%60compose_prompt_with_approval_model_and_shell%60%20in%20this%20PR.%20The%20private%20function%20is%20now%20unreachable%20and%20the%20Rust%20compiler%20will%20emit%20an%20%60unused%60%20warning.%20It%20can%20be%20removed%20entirely.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fprompts.rs%0ALine%3A%20890-902%0A%0AComment%3A%0A**Dead%20code%20after%20refactor**%0A%0A%60compose_mode_prompt_with_approval_and_model%60%20has%20no%20remaining%20call%20sites%20%E2%80%94%20the%20only%20caller%20%28%60system_prompt_for_mode_with_context_skills_session_and_approval%60%29%20was%20switched%20directly%20to%20%60compose_prompt_with_approval_model_and_shell%60%20in%20this%20PR.%20The%20private%20function%20is%20now%20unreachable%20and%20the%20Rust%20compiler%20will%20emit%20an%20%60unused%60%20warning.%20It%20can%20be%20removed%20entirely.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2638&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fprompts.rs%0ALine%3A%20890-902%0A%0AComment%3A%0A**Dead%20code%20after%20refactor**%0A%0A%60compose_mode_prompt_with_approval_and_model%60%20has%20no%20remaining%20call%20sites%20%E2%80%94%20the%20only%20caller%20%28%60system_prompt_for_mode_with_context_skills_session_and_approval%60%29%20was%20switched%20directly%20to%20%60compose_prompt_with_approval_model_and_shell%60%20in%20this%20PR.%20The%20private%20function%20is%20now%20unreachable%20and%20the%20Rust%20compiler%20will%20emit%20an%20%60unused%60%20warning.%20It%20can%20be%20removed%20entirely.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2638&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fallow-shell-prompt-gate%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fallow-shell-prompt-gate%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fprompts.rs%3A890-902%0A**Dead%20code%20after%20refactor**%0A%0A%60compose_mode_prompt_with_approval_and_model%60%20has%20no%20remaining%20call%20sites%20%E2%80%94%20the%20only%20caller%20%28%60system_prompt_for_mode_with_context_skills_session_and_approval%60%29%20was%20switched%20directly%20to%20%60compose_prompt_with_approval_model_and_shell%60%20in%20this%20PR.%20The%20private%20function%20is%20now%20unreachable%20and%20the%20Rust%20compiler%20will%20emit%20an%20%60unused%60%20warning.%20It%20can%20be%20removed%20entirely.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fprompts.rs%3A834-858%0A**Fragile%20exact-string%20filtering**%0A%0A%60remove_shell_tool_guidance%60%20relies%20on%20exact%20%60starts_with%60%20prefixes%20and%20verbatim%20%60replace%60%20substrings%20to%20strip%20shell%20references.%20If%20any%20of%20those%20strings%20in%20the%20base%20prompt%20are%20ever%20rephrased%2C%20reordered%2C%20or%20split%20across%20lines%2C%20the%20filter%20silently%20becomes%20a%20no-op%20and%20shell%20guidance%20will%20leak%20back%20into%20shell-disabled%20prompts%20without%20any%20compile-time%20or%20test%20failure%20at%20the%20point%20of%20change.%20The%20existing%20tests%20catch%20a%20regression%20today%2C%20but%20only%20if%20run%20after%20touching%20the%20prompt%20text.%20Consider%20a%20more%20structure-aware%20approach%20%28e.g.%2C%20tagging%20removable%20blocks%20at%20definition%20time%20rather%20than%20matching%20them%20at%20composition%20time%29.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fprompts.rs%3A890-902%0A**Dead%20code%20after%20refactor**%0A%0A%60compose_mode_prompt_with_approval_and_model%60%20has%20no%20remaining%20call%20sites%20%E2%80%94%20the%20only%20caller%20%28%60system_prompt_for_mode_with_context_skills_session_and_approval%60%29%20was%20switched%20directly%20to%20%60compose_prompt_with_approval_model_and_shell%60%20in%20this%20PR.%20The%20private%20function%20is%20now%20unreachable%20and%20the%20Rust%20compiler%20will%20emit%20an%20%60unused%60%20warning.%20It%20can%20be%20removed%20entirely.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fprompts.rs%3A834-858%0A**Fragile%20exact-string%20filtering**%0A%0A%60remove_shell_tool_guidance%60%20relies%20on%20exact%20%60starts_with%60%20prefixes%20and%20verbatim%20%60replace%60%20substrings%20to%20strip%20shell%20references.%20If%20any%20of%20those%20strings%20in%20the%20base%20prompt%20are%20ever%20rephrased%2C%20reordered%2C%20or%20split%20across%20lines%2C%20the%20filter%20silently%20becomes%20a%20no-op%20and%20shell%20guidance%20will%20leak%20back%20into%20shell-disabled%20prompts%20without%20any%20compile-time%20or%20test%20failure%20at%20the%20point%20of%20change.%20The%20existing%20tests%20catch%20a%20regression%20today%2C%20but%20only%20if%20run%20after%20touching%20the%20prompt%20text.%20Consider%20a%20more%20structure-aware%20approach%20%28e.g.%2C%20tagging%20removable%20blocks%20at%20definition%20time%20rather%20than%20matching%20them%20at%20composition%20time%29.%0A%0A&repo=hmbown%2Fcodewhale&pr=2638&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fprompts.rs%3A890-902%0A**Dead%20code%20after%20refactor**%0A%0A%60compose_mode_prompt_with_approval_and_model%60%20has%20no%20remaining%20call%20sites%20%E2%80%94%20the%20only%20caller%20%28%60system_prompt_for_mode_with_context_skills_session_and_approval%60%29%20was%20switched%20directly%20to%20%60compose_prompt_with_approval_model_and_shell%60%20in%20this%20PR.%20The%20private%20function%20is%20now%20unreachable%20and%20the%20Rust%20compiler%20will%20emit%20an%20%60unused%60%20warning.%20It%20can%20be%20removed%20entirely.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fprompts.rs%3A834-858%0A**Fragile%20exact-string%20filtering**%0A%0A%60remove_shell_tool_guidance%60%20relies%20on%20exact%20%60starts_with%60%20prefixes%20and%20verbatim%20%60replace%60%20substrings%20to%20strip%20shell%20references.%20If%20any%20of%20those%20strings%20in%20the%20base%20prompt%20are%20ever%20rephrased%2C%20reordered%2C%20or%20split%20across%20lines%2C%20the%20filter%20silently%20becomes%20a%20no-op%20and%20shell%20guidance%20will%20leak%20back%20into%20shell-disabled%20prompts%20without%20any%20compile-time%20or%20test%20failure%20at%20the%20point%20of%20change.%20The%20existing%20tests%20catch%20a%20regression%20today%2C%20but%20only%20if%20run%20after%20touching%20the%20prompt%20text.%20Consider%20a%20more%20structure-aware%20approach%20%28e.g.%2C%20tagging%20removable%20blocks%20at%20definition%20time%20rather%20than%20matching%20them%20at%20composition%20time%29.%0A%0A&pr=2638&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(tui): hide shell prompt guidance whe..."](https://github.com/hmbown/codewhale/commit/cdaa253fb655e692b5a1d3c5a0b99b83c63c09c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35362723)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->