### PR TITLE
feat(api): add POST /v1/sessions endpoint to save thread as session

### DIFF
--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -41,6 +41,7 @@ use crate::runtime_threads::{
     ThreadDetail, ThreadListFilter, ThreadRecord, TurnItemKind, TurnRecord, UpdateThreadRequest,
     UsageGroupBy,
 };
+use crate::models::{ContentBlock, Message};
 use crate::session_manager::{SavedSession, SessionManager, SessionMetadata, default_sessions_dir};
 use crate::skill_state::SkillStateStore;
 use crate::task_manager::{
@@ -514,7 +515,7 @@ pub async fn run_http_server(
 
 pub fn build_router(state: RuntimeApiState) -> Router {
     let api_routes = Router::new()
-        .route("/v1/sessions", get(list_sessions))
+        .route("/v1/sessions", get(list_sessions).post(create_session_from_thread))
         .route("/v1/sessions/{id}", get(get_session).delete(delete_session))
         .route(
             "/v1/sessions/{id}/resume-thread",
@@ -855,6 +856,151 @@ async fn delete_session(
         .delete_session(&id)
         .map_err(|e| map_session_err(&id, e, "delete"))?;
     Ok(StatusCode::NO_CONTENT)
+}
+
+/// Request body for creating a session from a thread
+#[derive(Debug, Deserialize)]
+struct CreateSessionRequest {
+    /// Thread ID to save as session
+    thread_id: String,
+    /// Optional custom title (defaults to thread title or first message)
+    #[serde(default)]
+    title: Option<String>,
+}
+
+/// Response for session creation
+#[derive(Debug, Serialize)]
+struct CreateSessionResponse {
+    session_id: String,
+    thread_id: String,
+    message_count: usize,
+    title: String,
+}
+
+/// Save a thread as a session for cross-workspace resumption
+async fn create_session_from_thread(
+    State(state): State<RuntimeApiState>,
+    Json(req): Json<CreateSessionRequest>,
+) -> Result<(StatusCode, Json<CreateSessionResponse>), ApiError> {
+    // Get thread detail
+    let detail = state
+        .runtime_threads
+        .get_thread_detail(&req.thread_id)
+        .await
+        .map_err(|e| ApiError::not_found(format!("Thread {} not found: {}", req.thread_id, e)))?;
+
+    let thread = detail.thread;
+
+    // Extract messages from items (UserMessage and AgentMessage items)
+    let mut messages: Vec<Message> = Vec::new();
+
+    // Group items by turn, then extract user/agent messages
+    for turn in &detail.turns {
+        let turn_items: Vec<_> = detail
+            .items
+            .iter()
+            .filter(|item| item.turn_id == turn.id)
+            .collect();
+
+        // Find user message item
+        let user_item = turn_items.iter().find(|item| item.kind == TurnItemKind::UserMessage);
+        // Find agent message item
+        let agent_item = turn_items.iter().find(|item| item.kind == TurnItemKind::AgentMessage);
+
+        // Create user message if present
+        if let Some(user) = user_item {
+            let text = user.detail.clone().unwrap_or_else(|| user.summary.clone());
+            if !text.trim().is_empty() {
+                messages.push(Message {
+                    role: "user".to_string(),
+                    content: vec![ContentBlock::Text { text, cache_control: None }],
+                });
+            }
+        }
+
+        // Create assistant message if present
+        if let Some(agent) = agent_item {
+            let text = agent.detail.clone().unwrap_or_else(|| agent.summary.clone());
+            if !text.trim().is_empty() {
+                messages.push(Message {
+                    role: "assistant".to_string(),
+                    content: vec![ContentBlock::Text { text, cache_control: None }],
+                });
+            }
+        }
+    }
+
+    // Calculate total tokens from turns
+    let total_tokens: u64 = detail
+        .turns
+        .iter()
+        .filter_map(|t| t.usage.as_ref())
+        .map(|u| u.input_tokens as u64 + u.output_tokens as u64)
+        .sum();
+
+    // Determine title
+    let title = req.title.clone().unwrap_or_else(|| {
+        thread
+            .title
+            .clone()
+            .unwrap_or_else(|| {
+                // Fallback: first user message
+                messages
+                    .iter()
+                    .find(|m| m.role == "user")
+                    .and_then(|m| {
+                        m.content.iter().find_map(|block| match block {
+                            ContentBlock::Text { text, .. } => {
+                                let truncated = if text.len() > 50 {
+                                    text.chars().take(50).collect::<String>() + "..."
+                                } else {
+                                    text.clone()
+                                };
+                                Some(truncated)
+                            }
+                            _ => None,
+                        })
+                    })
+                    .unwrap_or_else(|| "Saved Session".to_string())
+            })
+    });
+
+    // Create session using session_manager helper
+    let manager = SessionManager::new(state.sessions_dir.clone())
+        .map_err(|e| ApiError::internal(format!("Failed to open sessions dir: {e}")))?;
+
+    let session_id = uuid::Uuid::new_v4().to_string();
+    // Convert thread system_prompt (String) to SystemPrompt enum
+    let system_prompt = thread.system_prompt.as_ref().map(|s| crate::models::SystemPrompt::Text(s.clone()));
+    
+    let session = crate::session_manager::create_saved_session_with_id_and_mode(
+        session_id.clone(),
+        &messages,
+        &thread.model,
+        &thread.workspace,
+        total_tokens,
+        system_prompt.as_ref(),
+        Some(&thread.mode),
+    );
+
+    // Override title if provided
+    let mut session = session;
+    session.metadata.title = title.clone();
+
+    // Save session
+    manager
+        .save_session(&session)
+        .map_err(|e| ApiError::internal(format!("Failed to save session: {e}")))?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(CreateSessionResponse {
+            session_id,
+            thread_id: thread.id,
+            message_count: messages.len(),
+            title,
+        }),
+    ))
 }
 
 fn session_to_detail(session: SavedSession) -> SessionDetailResponse {

--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -35,13 +35,13 @@ use crate::automation_manager::{
 };
 use crate::config::{Config, DEFAULT_TEXT_MODEL};
 use crate::mcp::{McpConfig, McpPool};
+use crate::models::{ContentBlock, Message};
 use crate::runtime_threads::{
     CompactThreadRequest, CreateThreadRequest, ExternalApprovalDecision, RuntimeThreadManager,
     RuntimeThreadManagerConfig, SharedRuntimeThreadManager, StartTurnRequest, SteerTurnRequest,
     ThreadDetail, ThreadListFilter, ThreadRecord, TurnItemKind, TurnRecord, UpdateThreadRequest,
     UsageGroupBy,
 };
-use crate::models::{ContentBlock, Message};
 use crate::session_manager::{SavedSession, SessionManager, SessionMetadata, default_sessions_dir};
 use crate::skill_state::SkillStateStore;
 use crate::task_manager::{
@@ -515,7 +515,10 @@ pub async fn run_http_server(
 
 pub fn build_router(state: RuntimeApiState) -> Router {
     let api_routes = Router::new()
-        .route("/v1/sessions", get(list_sessions).post(create_session_from_thread))
+        .route(
+            "/v1/sessions",
+            get(list_sessions).post(create_session_from_thread),
+        )
         .route("/v1/sessions/{id}", get(get_session).delete(delete_session))
         .route(
             "/v1/sessions/{id}/resume-thread",
@@ -911,7 +914,10 @@ async fn create_session_from_thread(
                 if !text.trim().is_empty() {
                     messages.push(Message {
                         role: "user".to_string(),
-                        content: vec![ContentBlock::Text { text, cache_control: None }],
+                        content: vec![ContentBlock::Text {
+                            text,
+                            cache_control: None,
+                        }],
                     });
                 }
             }
@@ -920,7 +926,10 @@ async fn create_session_from_thread(
                 if !text.trim().is_empty() {
                     messages.push(Message {
                         role: "assistant".to_string(),
-                        content: vec![ContentBlock::Text { text, cache_control: None }],
+                        content: vec![ContentBlock::Text {
+                            text,
+                            cache_control: None,
+                        }],
                     });
                 }
             }
@@ -938,22 +947,19 @@ async fn create_session_from_thread(
 
     // Determine title
     let title = req.title.clone().unwrap_or_else(|| {
-        thread
-            .title
-            .clone()
-            .unwrap_or_else(|| {
-                // Fallback: first user message
-                messages
-                    .iter()
-                    .find(|m| m.role == "user")
-                    .and_then(|m| {
-                        m.content.iter().find_map(|block| match block {
-                            ContentBlock::Text { text, .. } => Some(truncate_text(text, 50)),
-                            _ => None,
-                        })
+        thread.title.clone().unwrap_or_else(|| {
+            // Fallback: first user message
+            messages
+                .iter()
+                .find(|m| m.role == "user")
+                .and_then(|m| {
+                    m.content.iter().find_map(|block| match block {
+                        ContentBlock::Text { text, .. } => Some(truncate_text(text, 50)),
+                        _ => None,
                     })
-                    .unwrap_or_else(|| "Saved Session".to_string())
-            })
+                })
+                .unwrap_or_else(|| "Saved Session".to_string())
+        })
     });
 
     // Create session using session_manager helper
@@ -962,8 +968,11 @@ async fn create_session_from_thread(
 
     let session_id = uuid::Uuid::new_v4().to_string();
     // Convert thread system_prompt (String) to SystemPrompt enum
-    let system_prompt = thread.system_prompt.as_ref().map(|s| crate::models::SystemPrompt::Text(s.clone()));
-    
+    let system_prompt = thread
+        .system_prompt
+        .as_ref()
+        .map(|s| crate::models::SystemPrompt::Text(s.clone()));
+
     let session = crate::session_manager::create_saved_session_with_id_and_mode(
         session_id.clone(),
         &messages,

--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -887,46 +887,44 @@ async fn create_session_from_thread(
         .runtime_threads
         .get_thread_detail(&req.thread_id)
         .await
-        .map_err(|e| ApiError::not_found(format!("Thread {} not found: {}", req.thread_id, e)))?;
+        .map_err(|e| {
+            // Distinguish between "not found" and internal errors
+            let msg = e.to_string();
+            if msg.contains("not found") || msg.contains("no rows") {
+                ApiError::not_found(format!("Thread {} not found", req.thread_id))
+            } else {
+                ApiError::internal(format!("Failed to get thread {}: {}", req.thread_id, e))
+            }
+        })?;
 
     let thread = detail.thread;
 
     // Extract messages from items (UserMessage and AgentMessage items)
+    // Iterate directly over items to preserve all messages, including
+    // multiple user/agent messages within a single turn (e.g. steered turns)
     let mut messages: Vec<Message> = Vec::new();
 
-    // Group items by turn, then extract user/agent messages
-    for turn in &detail.turns {
-        let turn_items: Vec<_> = detail
-            .items
-            .iter()
-            .filter(|item| item.turn_id == turn.id)
-            .collect();
-
-        // Find user message item
-        let user_item = turn_items.iter().find(|item| item.kind == TurnItemKind::UserMessage);
-        // Find agent message item
-        let agent_item = turn_items.iter().find(|item| item.kind == TurnItemKind::AgentMessage);
-
-        // Create user message if present
-        if let Some(user) = user_item {
-            let text = user.detail.clone().unwrap_or_else(|| user.summary.clone());
-            if !text.trim().is_empty() {
-                messages.push(Message {
-                    role: "user".to_string(),
-                    content: vec![ContentBlock::Text { text, cache_control: None }],
-                });
+    for item in &detail.items {
+        match item.kind {
+            TurnItemKind::UserMessage => {
+                let text = item.detail.clone().unwrap_or_else(|| item.summary.clone());
+                if !text.trim().is_empty() {
+                    messages.push(Message {
+                        role: "user".to_string(),
+                        content: vec![ContentBlock::Text { text, cache_control: None }],
+                    });
+                }
             }
-        }
-
-        // Create assistant message if present
-        if let Some(agent) = agent_item {
-            let text = agent.detail.clone().unwrap_or_else(|| agent.summary.clone());
-            if !text.trim().is_empty() {
-                messages.push(Message {
-                    role: "assistant".to_string(),
-                    content: vec![ContentBlock::Text { text, cache_control: None }],
-                });
+            TurnItemKind::AgentMessage => {
+                let text = item.detail.clone().unwrap_or_else(|| item.summary.clone());
+                if !text.trim().is_empty() {
+                    messages.push(Message {
+                        role: "assistant".to_string(),
+                        content: vec![ContentBlock::Text { text, cache_control: None }],
+                    });
+                }
             }
+            _ => {}
         }
     }
 
@@ -950,14 +948,7 @@ async fn create_session_from_thread(
                     .find(|m| m.role == "user")
                     .and_then(|m| {
                         m.content.iter().find_map(|block| match block {
-                            ContentBlock::Text { text, .. } => {
-                                let truncated = if text.len() > 50 {
-                                    text.chars().take(50).collect::<String>() + "..."
-                                } else {
-                                    text.clone()
-                                };
-                                Some(truncated)
-                            }
+                            ContentBlock::Text { text, .. } => Some(truncate_text(text, 50)),
                             _ => None,
                         })
                     })


### PR DESCRIPTION
## Summary

Add a new `POST /v1/sessions` API endpoint that allows saving an existing thread as a session for cross-workspace resumption.

## Motivation

When using the GUI (VSCode extension), conversations are managed as threads. However, sessions are the primary mechanism for persisting and resuming conversations across workspaces in the TUI. This API bridges the gap by allowing the GUI to save thread state as a session, enabling:

1. **Cross-workspace resumption**: Sessions saved from one workspace can be resumed in another
2. **GUI-TUI consistency**: Both interfaces share the same session storage format
3. **Automatic persistence**: GUI clients can auto-save threads as sessions on turn completion

## Changes

- Add `POST /v1/sessions` route alongside existing `GET /v1/sessions`
- Add `CreateSessionRequest` struct with `thread_id` and optional `title`
- Add `CreateSessionResponse` struct with `session_id`, `thread_id`, `message_count`, `title`
- Implement `create_session_from_thread()` handler that:
  - Extracts messages from thread turns (user and agent messages)
  - Calculates total tokens from turn usage
  - Creates a session using the existing `SessionManager`
  - Supports optional custom title (falls back to thread title or first user message)

## API Contract

```
POST /v1/sessions
Content-Type: application/json

Request:
{
  "thread_id": "uuid-of-thread",
  "title": "Optional custom title"
}

Response (201 Created):
{
  "session_id": "newly-generated-uuid",
  "thread_id": "original-thread-uuid",
  "message_count": 6,
  "title": "My Conversation"
}
```

## Testing

- Manually tested with GUI client: threads are correctly saved as sessions
- Session files are created in sessions directory and can be listed via `GET /v1/sessions`
- Resuming saved sessions via `POST /v1/sessions/{id}/resume` works correctly

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds `POST /v1/sessions` to the existing `/v1/sessions` route so GUI clients can persist a thread as a resumable session. The handler fetches thread details, converts `TurnItemKind::UserMessage` and `AgentMessage` items into `Message` objects, sums token usage, derives a title, and delegates to the existing `SessionManager`.

- New `CreateSessionRequest` / `CreateSessionResponse` structs; route wiring alongside the existing `GET /v1/sessions`.
- Message extraction correctly iterates all items (including steered turns) and skips empty text, but there is no guard against calling the endpoint while a turn is still active, which can produce an inconsistent session.
- Error handling for `get_thread_detail` distinguishes 404 from 500 via substring matching on the error string, which is fragile if error messages change.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Not safe to merge as-is: calling the endpoint during an active turn writes a broken session (partial or unanswered agent message) that will produce confusing behavior on resume.

The handler snapshots thread state without first verifying that no turn is currently running. A turn in flight writes its AgentMessage detail incrementally; if the endpoint is called mid-stream the partial text is captured verbatim, and if called before any content arrives the assistant message is silently dropped, leaving an unanswered user message as the last entry. Either case produces a session whose conversation history is structurally invalid for resumption.

crates/tui/src/runtime_api.rs — specifically the create_session_from_thread handler, which needs an in-progress turn guard before message extraction.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/runtime_api.rs | Adds POST /v1/sessions handler that snapshots a thread as a session; missing guard for in-progress turns means saving during an active turn produces an inconsistent session (partial or missing agent message). |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant API as POST /v1/sessions
    participant RTM as RuntimeThreadManager
    participant SM as SessionManager

    Client->>API: "POST /v1/sessions {thread_id, title?}"
    API->>RTM: get_thread_detail(thread_id)
    RTM-->>API: ThreadDetail (thread, turns, items)
    Note over API: Iterate items for UserMessage/AgentMessage
    Note over API: Sum input+output tokens across turns
    Note over API: Determine title (req.title → thread.title → first user msg)
    API->>SM: SessionManager::new(sessions_dir)
    SM-->>API: manager
    API->>API: create_saved_session_with_id_and_mode(...)
    API->>SM: "save_session(&session)"
    SM->>SM: "cleanup_old_sessions() [MAX=50]"
    SM-->>API: Ok(path)
    API-->>Client: "201 Created {session_id, thread_id, message_count, title}"
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fsession-save-api%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fsession-save-api%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fruntime_api.rs%3A884-1003%0A**Session%20saved%20during%20active%20turn%20is%20inconsistent**%0A%0AThe%20handler%20never%20checks%20whether%20the%20thread%20has%20an%20in-progress%20turn%20before%20snapshotting%20it.%20If%20a%20turn%20is%20still%20running%2C%20the%20in-flight%20%60AgentMessage%60%20item%20is%20being%20streamed%3A%20its%20%60detail%60%20field%20starts%20as%20%60Some%28%22%22%29%60%20and%20is%20updated%20in%20place.%20If%20the%20endpoint%20is%20called%20while%20content%20has%20started%20arriving%2C%20the%20partial%20text%20passes%20the%20%60!text.trim%28%29.is_empty%28%29%60%20guard%20and%20is%20written%20into%20the%20session%20as%20the%20final%20assistant%20message.%20If%20the%20endpoint%20is%20called%20before%20any%20content%20arrives%2C%20the%20empty%20assistant%20message%20is%20silently%20dropped%2C%20so%20the%20session%20ends%20with%20an%20unanswered%20user%20message.%20Either%20way%20the%20resumed%20session%20presents%20the%20LLM%20with%20a%20broken%20turn%20boundary.%0A%0AAdd%20a%20check%20over%20%60detail.turns%60%20before%20building%20the%20message%20list%20and%20return%20%60409%20Conflict%60%20if%20any%20turn%20has%20%60RuntimeTurnStatus%3A%3AInProgress%60.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fruntime_api.rs%3A893-901%0A**Fragile%20string-matching%20for%20error%20classification**%0A%0A%60get_thread_detail%60%20can%20fail%20for%20many%20reasons%20%28I%2FO%20error%2C%20JSON%20parse%20failure%2C%20schema%20version%20mismatch%2C%20lock%20poisoning%29.%20The%20classifier%20relies%20on%20the%20error's%20%60Display%60%20output%20containing%20the%20literal%20substring%20%60%22not%20found%22%60%20or%20%60%22no%20rows%22%60.%20Any%20future%20rewording%20of%20an%20error%20message%2C%20or%20a%20coincidental%20match%20in%20an%20unrelated%20message%20%28e.g.%2C%20%22thread%20pool%20running%20out%20of%20rows%22%29%2C%20silently%20misroutes%20the%20status%20code.%20Consider%20returning%20a%20typed%20error%20from%20%60get_thread_detail%60%20instead%20of%20parsing%20its%20string%20representation.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20.map_err%28%7Ce%7C%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Distinguish%20between%20%22not%20found%22%20and%20internal%20errors%20by%20inspecting%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20the%20error%20chain%20rather%20than%20the%20formatted%20string.%0A%20%20%20%20%20%20%20%20%20%20%20%20let%20msg%20%3D%20e.to_string%28%29.to_lowercase%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20msg.contains%28%22not%20found%22%29%20%7C%7C%20msg.contains%28%22no%20rows%22%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20ApiError%3A%3Anot_found%28format!%28%22Thread%20%7B%7D%20not%20found%22%2C%20req.thread_id%29%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20ApiError%3A%3Ainternal%28format!%28%22Failed%20to%20get%20thread%20%7B%7D%3A%20%7B%7D%22%2C%20req.thread_id%2C%20e%29%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%29%3F%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fruntime_api.rs%3A884-1003%0A**Session%20saved%20during%20active%20turn%20is%20inconsistent**%0A%0AThe%20handler%20never%20checks%20whether%20the%20thread%20has%20an%20in-progress%20turn%20before%20snapshotting%20it.%20If%20a%20turn%20is%20still%20running%2C%20the%20in-flight%20%60AgentMessage%60%20item%20is%20being%20streamed%3A%20its%20%60detail%60%20field%20starts%20as%20%60Some%28%22%22%29%60%20and%20is%20updated%20in%20place.%20If%20the%20endpoint%20is%20called%20while%20content%20has%20started%20arriving%2C%20the%20partial%20text%20passes%20the%20%60!text.trim%28%29.is_empty%28%29%60%20guard%20and%20is%20written%20into%20the%20session%20as%20the%20final%20assistant%20message.%20If%20the%20endpoint%20is%20called%20before%20any%20content%20arrives%2C%20the%20empty%20assistant%20message%20is%20silently%20dropped%2C%20so%20the%20session%20ends%20with%20an%20unanswered%20user%20message.%20Either%20way%20the%20resumed%20session%20presents%20the%20LLM%20with%20a%20broken%20turn%20boundary.%0A%0AAdd%20a%20check%20over%20%60detail.turns%60%20before%20building%20the%20message%20list%20and%20return%20%60409%20Conflict%60%20if%20any%20turn%20has%20%60RuntimeTurnStatus%3A%3AInProgress%60.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fruntime_api.rs%3A893-901%0A**Fragile%20string-matching%20for%20error%20classification**%0A%0A%60get_thread_detail%60%20can%20fail%20for%20many%20reasons%20%28I%2FO%20error%2C%20JSON%20parse%20failure%2C%20schema%20version%20mismatch%2C%20lock%20poisoning%29.%20The%20classifier%20relies%20on%20the%20error's%20%60Display%60%20output%20containing%20the%20literal%20substring%20%60%22not%20found%22%60%20or%20%60%22no%20rows%22%60.%20Any%20future%20rewording%20of%20an%20error%20message%2C%20or%20a%20coincidental%20match%20in%20an%20unrelated%20message%20%28e.g.%2C%20%22thread%20pool%20running%20out%20of%20rows%22%29%2C%20silently%20misroutes%20the%20status%20code.%20Consider%20returning%20a%20typed%20error%20from%20%60get_thread_detail%60%20instead%20of%20parsing%20its%20string%20representation.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20.map_err%28%7Ce%7C%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Distinguish%20between%20%22not%20found%22%20and%20internal%20errors%20by%20inspecting%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20the%20error%20chain%20rather%20than%20the%20formatted%20string.%0A%20%20%20%20%20%20%20%20%20%20%20%20let%20msg%20%3D%20e.to_string%28%29.to_lowercase%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20msg.contains%28%22not%20found%22%29%20%7C%7C%20msg.contains%28%22no%20rows%22%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20ApiError%3A%3Anot_found%28format!%28%22Thread%20%7B%7D%20not%20found%22%2C%20req.thread_id%29%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20ApiError%3A%3Ainternal%28format!%28%22Failed%20to%20get%20thread%20%7B%7D%3A%20%7B%7D%22%2C%20req.thread_id%2C%20e%29%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%29%3F%3B%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2639&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fruntime_api.rs%3A884-1003%0A**Session%20saved%20during%20active%20turn%20is%20inconsistent**%0A%0AThe%20handler%20never%20checks%20whether%20the%20thread%20has%20an%20in-progress%20turn%20before%20snapshotting%20it.%20If%20a%20turn%20is%20still%20running%2C%20the%20in-flight%20%60AgentMessage%60%20item%20is%20being%20streamed%3A%20its%20%60detail%60%20field%20starts%20as%20%60Some%28%22%22%29%60%20and%20is%20updated%20in%20place.%20If%20the%20endpoint%20is%20called%20while%20content%20has%20started%20arriving%2C%20the%20partial%20text%20passes%20the%20%60!text.trim%28%29.is_empty%28%29%60%20guard%20and%20is%20written%20into%20the%20session%20as%20the%20final%20assistant%20message.%20If%20the%20endpoint%20is%20called%20before%20any%20content%20arrives%2C%20the%20empty%20assistant%20message%20is%20silently%20dropped%2C%20so%20the%20session%20ends%20with%20an%20unanswered%20user%20message.%20Either%20way%20the%20resumed%20session%20presents%20the%20LLM%20with%20a%20broken%20turn%20boundary.%0A%0AAdd%20a%20check%20over%20%60detail.turns%60%20before%20building%20the%20message%20list%20and%20return%20%60409%20Conflict%60%20if%20any%20turn%20has%20%60RuntimeTurnStatus%3A%3AInProgress%60.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fruntime_api.rs%3A893-901%0A**Fragile%20string-matching%20for%20error%20classification**%0A%0A%60get_thread_detail%60%20can%20fail%20for%20many%20reasons%20%28I%2FO%20error%2C%20JSON%20parse%20failure%2C%20schema%20version%20mismatch%2C%20lock%20poisoning%29.%20The%20classifier%20relies%20on%20the%20error's%20%60Display%60%20output%20containing%20the%20literal%20substring%20%60%22not%20found%22%60%20or%20%60%22no%20rows%22%60.%20Any%20future%20rewording%20of%20an%20error%20message%2C%20or%20a%20coincidental%20match%20in%20an%20unrelated%20message%20%28e.g.%2C%20%22thread%20pool%20running%20out%20of%20rows%22%29%2C%20silently%20misroutes%20the%20status%20code.%20Consider%20returning%20a%20typed%20error%20from%20%60get_thread_detail%60%20instead%20of%20parsing%20its%20string%20representation.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20.map_err%28%7Ce%7C%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Distinguish%20between%20%22not%20found%22%20and%20internal%20errors%20by%20inspecting%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20the%20error%20chain%20rather%20than%20the%20formatted%20string.%0A%20%20%20%20%20%20%20%20%20%20%20%20let%20msg%20%3D%20e.to_string%28%29.to_lowercase%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20msg.contains%28%22not%20found%22%29%20%7C%7C%20msg.contains%28%22no%20rows%22%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20ApiError%3A%3Anot_found%28format!%28%22Thread%20%7B%7D%20not%20found%22%2C%20req.thread_id%29%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20ApiError%3A%3Ainternal%28format!%28%22Failed%20to%20get%20thread%20%7B%7D%3A%20%7B%7D%22%2C%20req.thread_id%2C%20e%29%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%29%3F%3B%0A%60%60%60%0A%0A&pr=2639&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["style: apply cargo fmt formatting fixes"](https://github.com/hmbown/codewhale/commit/bf8f81873a896bae5b322db905981bca825b6e15) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35371544)</sub>

<!-- /greptile_comment -->