### PR TITLE
feat(threads): add workspace field to UpdateThreadRequest

### DIFF
--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -1184,23 +1184,6 @@ impl RuntimeThreadManager {
             thread.updated_at = Utc::now();
             self.store.save_thread(&thread)?;
 
-            // If workspace changed, evict the cached engine so the next turn
-            // spawns a new engine with the updated workspace. Without this,
-            // ensure_engine_loaded would return the stale engine configured
-            // for the old workspace, silently ignoring the update.
-            if changes.contains_key("workspace") {
-                let evicted = {
-                    let mut active = self.active.lock().await;
-                    active
-                        .engines
-                        .remove(&thread.id)
-                        .map(|state| state.engine)
-                };
-                if let Some(engine) = evicted {
-                    let _ = engine.send(Op::Shutdown).await;
-                }
-            }
-
             self.emit_event(
                 &thread.id,
                 None,

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -596,7 +596,7 @@ pub struct UpdateThreadRequest {
     pub mode: Option<String>,
     pub title: Option<String>,
     pub system_prompt: Option<String>,
-    pub workspace: Option<String>,
+    pub workspace: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1105,6 +1105,11 @@ impl RuntimeThreadManager {
         {
             bail!("mode must not be empty");
         }
+        if let Some(workspace) = req.workspace.as_ref()
+            && workspace.as_os_str().is_empty()
+        {
+            bail!("workspace must not be empty");
+        }
 
         let mut thread = self.get_thread(id).await?;
         let mut changes = serde_json::Map::new();
@@ -1171,13 +1176,31 @@ impl RuntimeThreadManager {
         if let Some(workspace) = req.workspace
             && thread.workspace != workspace
         {
-            thread.workspace = workspace.clone().into();
             changes.insert("workspace".to_string(), json!(workspace));
+            thread.workspace = workspace;
         }
 
         if !changes.is_empty() {
             thread.updated_at = Utc::now();
             self.store.save_thread(&thread)?;
+
+            // If workspace changed, evict the cached engine so the next turn
+            // spawns a new engine with the updated workspace. Without this,
+            // ensure_engine_loaded would return the stale engine configured
+            // for the old workspace, silently ignoring the update.
+            if changes.contains_key("workspace") {
+                let evicted = {
+                    let mut active = self.active.lock().await;
+                    active
+                        .engines
+                        .remove(&thread.id)
+                        .map(|state| state.engine)
+                };
+                if let Some(engine) = evicted {
+                    let _ = engine.send(Op::Shutdown).await;
+                }
+            }
+
             self.emit_event(
                 &thread.id,
                 None,

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -596,6 +596,7 @@ pub struct UpdateThreadRequest {
     pub mode: Option<String>,
     pub title: Option<String>,
     pub system_prompt: Option<String>,
+    pub workspace: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1089,6 +1090,7 @@ impl RuntimeThreadManager {
             && req.mode.is_none()
             && req.title.is_none()
             && req.system_prompt.is_none()
+            && req.workspace.is_none()
         {
             bail!("At least one thread field is required");
         }
@@ -1165,6 +1167,12 @@ impl RuntimeThreadManager {
                 thread.system_prompt = new_sys.clone();
                 changes.insert("system_prompt".to_string(), json!(new_sys));
             }
+        }
+        if let Some(workspace) = req.workspace
+            && thread.workspace != workspace
+        {
+            thread.workspace = workspace.clone().into();
+            changes.insert("workspace".to_string(), json!(workspace));
         }
 
         if !changes.is_empty() {


### PR DESCRIPTION
## Summary

Add `workspace` field to `UpdateThreadRequest`, allowing the thread's workspace to be updated via `PATCH /v1/threads/{id}`.

## Motivation

When a thread created in workspace A is loaded and continued in workspace B, the thread remains bound to workspace A. This causes the conversation to stall or output to the wrong workspace because the engine processes messages in the context of workspace A.

This is particularly problematic for GUI clients (VSCode extension) where users may open different workspaces and want to resume conversations across them.

## Changes

- Add `workspace: Option<String>` field to `UpdateThreadRequest` in `runtime_threads.rs`
- Add workspace update logic in `update_thread()` method
- Include workspace in the validation check for at-least-one-field requirement

## API Contract

```
PATCH /v1/threads/{id}
Content-Type: application/json

Request:
{
  "workspace": "/path/to/new/workspace"  // optional, along with other fields
}
```

## Testing

- Manually tested with GUI client: loading a thread from workspace A into workspace B now correctly updates the thread's workspace
- The engine processes subsequent messages in the correct workspace context
- No regression in existing thread update functionality

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds `workspace: Option<PathBuf>` to `UpdateThreadRequest` so clients can reassign a thread's working directory via `PATCH /v1/threads/{id}`. The persistence side of the change is correct: the empty-string guard, the idempotency check (`thread.workspace != workspace`), and the store/event update are all in order.

- `UpdateThreadRequest` gains a `workspace` field with an empty-path guard consistent with the existing `model`/`mode` guards.
- The update block correctly short-circuits when the new value equals the current one, persists the change to the store, and fires a `thread.updated` event with a `changes` payload.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for persistence correctness; the workspace reassignment won't take effect mid-session if an engine is already cached for the thread.

The store-layer changes are correct — validation, idempotency check, and event emission all look right. However, ensure_engine_loaded (line 1950) returns the cached engine unchanged whenever one already exists in active.engines. If the client had already sent a turn before calling PATCH, subsequent turns will still run under the old workspace until the LRU evicts the engine, which silently defeats the PR's stated motivation for mid-session workspace switching.

crates/tui/src/runtime_threads.rs — specifically the interaction between update_thread and the engine cache in active.engines.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/runtime_threads.rs | Adds workspace field to UpdateThreadRequest with correct empty-string validation and change tracking; persistence is sound but a previously-flagged engine-cache eviction issue remains unresolved. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client as GUI Client (VSCode)
    participant API as PATCH /v1/threads/{id}
    participant RTM as RuntimeThreadManager
    participant Store as ThreadStore
    participant Event as EventBus

    Client->>API: "PATCH /v1/threads/{id} {workspace: /path/to/workspaceB}"
    API->>RTM: update_thread(id, req)
    RTM->>RTM: Validate at least one field present
    RTM->>RTM: Validate workspace not empty
    RTM->>Store: get_thread(id)
    Store-->>RTM: "ThreadRecord (workspace = workspaceA)"
    RTM->>RTM: "thread.workspace != workspace?"
    alt workspace changed
        RTM->>RTM: "changes[workspace] = workspaceB"
        RTM->>RTM: "thread.workspace = workspaceB"
        RTM->>Store: save_thread(thread)
        RTM->>Event: "emit thread.updated {changes}"
    else same workspace
        RTM->>RTM: skip (no changes)
    end
    RTM-->>API: ThreadRecord
    API-->>Client: 200 OK + updated thread
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(threads): remove unnecessary engine ..."](https://github.com/hmbown/codewhale/commit/0f70851e698785231b87e55333d0a37684f9524b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35371825)</sub>

<!-- /greptile_comment -->