### PR TITLE
fix(release): harden Cargo publish ordering and crates.io checks

### DIFF
--- a/scripts/release/crates.sh
+++ b/scripts/release/crates.sh
@@ -2,19 +2,19 @@
 
 # Crates published for each codewhale release, in dependency order.
 release_crates=(
-  codewhale-secrets
-  codewhale-release
-  codewhale-config
+  codewhale-mcp
   codewhale-protocol
+  codewhale-release
+  codewhale-secrets
   codewhale-state
-  codewhale-agent
+  codewhale-tui-core
   codewhale-execpolicy
   codewhale-hooks
-  codewhale-mcp
   codewhale-tools
+  codewhale-config
+  codewhale-agent
+  codewhale-tui
   codewhale-core
   codewhale-app-server
-  codewhale-tui-core
   codewhale-cli
-  codewhale-tui
 )

--- a/scripts/release/publish-crates.sh
+++ b/scripts/release/publish-crates.sh
@@ -15,6 +15,7 @@ case "${mode}" in
 esac
 
 packages=("${release_crates[@]}")
+crates_user_agent="CodeWhale release publish check (https://github.com/Hmbown/CodeWhale)"
 
 workspace_version=""
 workspace_codewhale_packages=()
@@ -122,7 +123,7 @@ package_has_workspace_deps() {
 crate_version_exists() {
   local crate_name="$1"
   local crate_version="$2"
-  curl -fsSL "https://crates.io/api/v1/crates/${crate_name}/${crate_version}" >/dev/null 2>&1
+  curl -fsSL -A "${crates_user_agent}" "https://crates.io/api/v1/crates/${crate_name}/${crate_version}" >/dev/null 2>&1
 }
 
 wait_for_crate_version() {


### PR DESCRIPTION
## Summary

Fixes the two release-tooling problems found while publishing v0.8.52:

- reorder `release_crates` into the actual workspace dependency order, so crates like `codewhale-config` are not published before their freshly-versioned dependencies such as `codewhale-execpolicy`
- send a crates.io-compliant user agent for release visibility checks, avoiding the 403 returned by bare `curl` requests under crates.io data-access policy

Refs #2643.

## Verification

- `bash -n scripts/release/crates.sh scripts/release/publish-crates.sh`
- `bash scripts/release/publish-crates.sh publish` after v0.8.52 was fully published; all 15 crates skipped cleanly as already published
