### PR TITLE
fix: Windows sub-agent completion halves TUI render width

### DIFF
--- a/crates/tui/src/tools/shell.rs
+++ b/crates/tui/src/tools/shell.rs
@@ -269,7 +269,7 @@ impl WindowsJob {
             )
             .map_err(windows_io_error)?;
 
-            let process_handle = HANDLE(child.as_raw_handle() as *mut core::ffi::c_void);
+            let process_handle = HANDLE(child.as_raw_handle());
             AssignProcessToJobObject(job.handle, process_handle).map_err(windows_io_error)?;
         }
 

--- a/crates/tui/src/tui/color_compat.rs
+++ b/crates/tui/src/tui/color_compat.rs
@@ -43,6 +43,11 @@ pub(crate) struct ColorCompatBackend<W: Write> {
     /// Forcing the expected size prevents ratatui's internal `autoresize` from
     /// shrinking the viewport back to the stale dimension inside `draw()`.
     forced_size: Option<Size>,
+    /// Cached terminal size from `crossterm::terminal::size()`, set after
+    /// re-entering alt-screen to avoid stale buffer dimensions on Windows.
+    /// Used as the primary fallback in `size()` before falling through to
+    /// the live crossterm query.
+    terminal_size: Option<Size>,
     render_debug: Option<RenderDebugLog>,
 }
 
@@ -59,6 +64,7 @@ impl<W: Write> ColorCompatBackend<W> {
             // to a community preset.
             active_ui_theme: UiTheme::detect(),
             forced_size: None,
+            terminal_size: None,
             render_debug: RenderDebugLog::from_env(),
         }
     }
@@ -69,6 +75,10 @@ impl<W: Write> ColorCompatBackend<W> {
 
     pub(crate) fn clear_forced_size(&mut self) {
         self.forced_size = None;
+    }
+
+    pub(crate) fn set_terminal_size(&mut self, size: Size) {
+        self.terminal_size = Some(size);
     }
 
     pub(crate) fn set_palette_mode(&mut self, palette_mode: PaletteMode) {
@@ -152,10 +162,14 @@ impl<W: Write> Backend for ColorCompatBackend<W> {
     }
 
     fn size(&self) -> io::Result<Size> {
-        match self.forced_size {
-            Some(size) => Ok(size),
-            None => self.inner.size(),
+        // forced_size takes priority: it is set during resize events to prevent
+        // ratatui's autoresize from shrinking the viewport back to a stale
+        // dimension. terminal_size is the cached real terminal size used as a
+        // fallback after alt-screen re-entry (Windows buffer width workaround).
+        if let Some(size) = self.forced_size.or(self.terminal_size) {
+            return Ok(size);
         }
+        self.inner.size()
     }
 
     fn window_size(&mut self) -> io::Result<WindowSize> {
@@ -495,5 +509,35 @@ mod tests {
         assert!(body.contains("frame=1"), "{body}");
         assert!(body.contains("diff_cells=1"), "{body}");
         assert!(body.contains("sample=3:4"), "{body}");
+    }
+
+    #[test]
+    fn size_returns_terminal_size_when_set() {
+        let writer = SharedWriter::default();
+        let mut backend = ColorCompatBackend::new(writer, ColorDepth::TrueColor, PaletteMode::Dark);
+
+        backend.set_terminal_size(Size::new(120, 40));
+        assert_eq!(backend.size().unwrap(), Size::new(120, 40));
+    }
+
+    #[test]
+    fn forced_size_takes_priority_over_terminal_size() {
+        let writer = SharedWriter::default();
+        let mut backend = ColorCompatBackend::new(writer, ColorDepth::TrueColor, PaletteMode::Dark);
+
+        // forced_size is set during resize events to temporarily override the
+        // cached terminal_size — it must win to prevent viewport shrinking.
+        backend.set_terminal_size(Size::new(120, 40));
+        backend.force_size(Size::new(80, 25));
+        assert_eq!(backend.size().unwrap(), Size::new(80, 25));
+    }
+
+    #[test]
+    fn size_falls_back_to_forced_size_when_terminal_size_unset() {
+        let writer = SharedWriter::default();
+        let mut backend = ColorCompatBackend::new(writer, ColorDepth::TrueColor, PaletteMode::Dark);
+
+        backend.force_size(Size::new(80, 25));
+        assert_eq!(backend.size().unwrap(), Size::new(80, 25));
     }
 }

--- a/crates/tui/src/tui/subagent_routing.rs
+++ b/crates/tui/src/tui/subagent_routing.rs
@@ -113,7 +113,7 @@ pub(super) fn handle_subagent_mailbox(app: &mut App, seq: u64, message: &Mailbox
     {
         apply_to_fanout(card, message);
         app.subagent_card_index.insert(agent_id, idx);
-        app.mark_history_updated();
+        app.bump_history_cell(idx);
         return;
     }
 
@@ -129,7 +129,9 @@ pub(super) fn handle_subagent_mailbox(app: &mut App, seq: u64, message: &Mailbox
             _ => false,
         };
         if updated {
-            app.mark_history_updated();
+            // idx is already in scope from the outer
+            // `if let Some(&idx) = app.subagent_card_index.get(&agent_id)`.
+            app.bump_history_cell(idx);
         }
         return;
     }
@@ -168,13 +170,13 @@ pub(super) fn handle_subagent_mailbox(app: &mut App, seq: u64, message: &Mailbox
         let card = DelegateCard::new(agent_id.clone(), agent_type.clone());
         app.add_message(HistoryCell::SubAgent(SubAgentCell::Delegate(card)));
         let idx = app.history.len().saturating_sub(1);
-        app.subagent_card_index.insert(agent_id, idx);
+        app.subagent_card_index.insert(agent_id.clone(), idx);
         // Single delegate consumes the pending dispatch label so a follow-on
         // tool call doesn't accidentally inherit it.
         app.pending_subagent_dispatch = None;
+        // idx was just inserted on the line above — no need to re-query.
+        app.bump_history_cell(idx);
     }
-
-    app.mark_history_updated();
 }
 
 pub(super) fn task_mode_label(mode: AppMode) -> &'static str {

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -2161,7 +2161,7 @@ async fn run_event_loop(
                                 subagent_elapsed,
                             );
                         }
-                        if should_recapture_terminal {
+                        if should_recapture_terminal && event_broker.is_paused() {
                             resume_terminal(
                                 terminal,
                                 app.use_alt_screen,
@@ -2694,7 +2694,9 @@ async fn run_event_loop(
                 // this single draw so the buffer matches the real viewport.
                 {
                     let backend = terminal.backend_mut();
-                    backend.force_size(Size::new(final_w, final_h));
+                    let new_size = Size::new(final_w, final_h);
+                    backend.force_size(new_size);
+                    backend.set_terminal_size(new_size);
                 }
                 draw_app_frame_inner(terminal, app, true)?;
                 draws_since_last_full_repaint = 0;
@@ -7915,6 +7917,16 @@ fn resume_terminal(
         use_mouse_capture,
         use_bracketed_paste,
     );
+    // Cache the real terminal size *before* resetting the viewport, so that
+    // reset_terminal_viewport → terminal.clear() → autoresize() → backend.size()
+    // picks up the cached size instead of falling through to
+    // crossterm::terminal::size() which may return stale buffer metadata
+    // (especially on Windows after a secondary EnterAlternateScreen).
+    if let Ok((cols, rows)) = crossterm::terminal::size() {
+        terminal
+            .backend_mut()
+            .set_terminal_size(Size::new(cols, rows));
+    }
     reset_terminal_viewport(terminal, sync_output_enabled)?;
     Ok(())
 }


### PR DESCRIPTION
Root cause: AgentComplete unconditionally calls resume_terminal() even when the terminal was never paused, causing a secondary EnterAlternateScreen on Windows that creates a new buffer whose width may differ from the window width. Additionally, ColorCompatBackend had no terminal_size cache, so size() fell through to crossterm::terminal::size() which on Windows returns the WinAPI buffer width rather than the window width.

Changes:
- AgentComplete: add event_broker.is_paused() guard
- resume_terminal(): cache real terminal size after re-entering alt-screen
- Resize handler: also set terminal_size alongside forced_size
- subagent_routing: 3x mark_history_updated -> bump_history_cell(idx)
- color_compat: add terminal_size field + set_terminal_size() + size() fallback
- tests: 3 unit tests for size() fallback chain

## Summary

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features`
- [x] `cargo test --workspace --all-features`

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [x] Verified TUI behavior manually if UI changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes Windows TUI render width halving caused by a spurious second `EnterAlternateScreen` emitted by `AgentComplete` when the terminal was never paused, and by `ColorCompatBackend` falling through to the WinAPI buffer width instead of the real window width.

- **`ui.rs`**: Guards `resume_terminal()` behind `event_broker.is_paused()` to prevent the double alt-screen entry; caches `crossterm::terminal::size()` into the backend before `reset_terminal_viewport` so ratatui's `autoresize` sees the correct width; also propagates the resize-event size into `terminal_size` alongside `forced_size`.
- **`color_compat.rs`**: Adds `terminal_size` field with `set_terminal_size()` accessor and a three-tier `size()` priority chain (`forced_size` > `terminal_size` > live crossterm query), with three unit tests covering the fallback logic.
- **`subagent_routing.rs`**: Replaces `mark_history_updated()` calls with targeted `bump_history_cell(idx)`, but the `if is_fanout { … }` block is missing the redraw signal on both sub-paths (see inline comment).
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for the Windows width fix; the fanout card mutation path will not trigger a repaint until an unrelated event fires.

The terminal size caching and is_paused guard are correct. However, removing the unconditional mark_history_updated at the end of handle_subagent_mailbox left both fanout sub-paths without a needs_redraw signal: card mutations via claim_pending_worker become invisible until the next unrelated event, and the add_message path (confirmed to not set needs_redraw) is similarly affected.

crates/tui/src/tui/subagent_routing.rs — the if is_fanout block needs bump_history_cell calls in both its sub-paths.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/subagent_routing.rs | Replaces mark_history_updated with bump_history_cell in delegate/ChildSpawned paths, but the if-is_fanout block never calls bump_history_cell or sets needs_redraw, dropping the redraw signal for all fanout card mutations. |
| crates/tui/src/tui/color_compat.rs | Adds terminal_size cache field with set_terminal_size() and three-tier priority in size(): forced_size > terminal_size > live crossterm query. Logic and tests are correct. |
| crates/tui/src/tui/ui.rs | Adds event_broker.is_paused() guard to prevent double EnterAlternateScreen; caches terminal size before reset_terminal_viewport in resume_terminal(); also sets terminal_size alongside forced_size in the resize handler. |
| crates/tui/src/tools/shell.rs | Removes a redundant cast from as_raw_handle() to *mut c_void since RawHandle is already that type on Windows. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant EB as EventBroker
    participant UI as run_event_loop
    participant RT as resume_terminal()
    participant BE as ColorCompatBackend
    participant CT as crossterm::terminal

    Note over UI: AgentComplete received
    UI->>EB: is_paused()?
    alt terminal is paused
        EB-->>UI: true
        UI->>RT: resume_terminal()
        RT->>CT: terminal::size()
        CT-->>RT: (cols, rows)
        RT->>BE: set_terminal_size(cols, rows)
        RT->>BE: reset_terminal_viewport → clear() → autoresize()
        BE->>BE: size() → terminal_size cache hit ✓
    else terminal was never paused
        EB-->>UI: false
        Note over UI: skip resume_terminal() (no double EnterAlternateScreen)
    end

    Note over UI: Resize event
    UI->>BE: force_size(new_size)
    UI->>BE: set_terminal_size(new_size)
    UI->>UI: draw_app_frame_inner()
    UI->>BE: clear_forced_size()
    BE->>BE: size() → terminal_size cache hit ✓
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/tui/src/tui/subagent_routing.rs`, line 149-168 ([link](https://github.com/hmbown/codewhale/blob/4463c46644a6e485e7e20dc2b19c29c2e8eb3c5c/crates/tui/src/tui/subagent_routing.rs#L149-L168)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Fanout branch silently drops the redraw signal**

   Before this PR, `app.mark_history_updated()` was called unconditionally at the end of the function, covering every code path that didn't `return` early — including both fanout sub-paths. The PR replaces it with `app.bump_history_cell(idx)` inside only the `else` (delegate) branch. The entire `if is_fanout { … }` block exits without calling either `bump_history_cell` or `mark_history_updated`, so `needs_redraw` is never set to `true`.

   Concretely:
   - "Reuse existing fanout card" path (line 156–157): mutates the card via `claim_pending_worker` but neither increments `history_version` nor sets `needs_redraw`. The updated card is invisible until the next unrelated event forces a redraw.
   - "Create new fanout card" path (line 159–167): `add_message` does increment `history_version`, but it does not set `needs_redraw = true` (see `add_message` impl in `app.rs`), so the render loop may not pick up the new cell.

   Both sub-paths need a `bump_history_cell(idx)` call to restore the behaviour that was present before this change.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22windows-half-width-fix%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22windows-half-width-fix%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fsubagent_routing.rs%0ALine%3A%20149-168%0A%0AComment%3A%0A**Fanout%20branch%20silently%20drops%20the%20redraw%20signal**%0A%0ABefore%20this%20PR%2C%20%60app.mark_history_updated%28%29%60%20was%20called%20unconditionally%20at%20the%20end%20of%20the%20function%2C%20covering%20every%20code%20path%20that%20didn't%20%60return%60%20early%20%E2%80%94%20including%20both%20fanout%20sub-paths.%20The%20PR%20replaces%20it%20with%20%60app.bump_history_cell%28idx%29%60%20inside%20only%20the%20%60else%60%20%28delegate%29%20branch.%20The%20entire%20%60if%20is_fanout%20%7B%20%E2%80%A6%20%7D%60%20block%20exits%20without%20calling%20either%20%60bump_history_cell%60%20or%20%60mark_history_updated%60%2C%20so%20%60needs_redraw%60%20is%20never%20set%20to%20%60true%60.%0A%0AConcretely%3A%0A-%20%22Reuse%20existing%20fanout%20card%22%20path%20%28line%20156%E2%80%93157%29%3A%20mutates%20the%20card%20via%20%60claim_pending_worker%60%20but%20neither%20increments%20%60history_version%60%20nor%20sets%20%60needs_redraw%60.%20The%20updated%20card%20is%20invisible%20until%20the%20next%20unrelated%20event%20forces%20a%20redraw.%0A-%20%22Create%20new%20fanout%20card%22%20path%20%28line%20159%E2%80%93167%29%3A%20%60add_message%60%20does%20increment%20%60history_version%60%2C%20but%20it%20does%20not%20set%20%60needs_redraw%20%3D%20true%60%20%28see%20%60add_message%60%20impl%20in%20%60app.rs%60%29%2C%20so%20the%20render%20loop%20may%20not%20pick%20up%20the%20new%20cell.%0A%0ABoth%20sub-paths%20need%20a%20%60bump_history_cell%28idx%29%60%20call%20to%20restore%20the%20behaviour%20that%20was%20present%20before%20this%20change.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fsubagent_routing.rs%0ALine%3A%20149-168%0A%0AComment%3A%0A**Fanout%20branch%20silently%20drops%20the%20redraw%20signal**%0A%0ABefore%20this%20PR%2C%20%60app.mark_history_updated%28%29%60%20was%20called%20unconditionally%20at%20the%20end%20of%20the%20function%2C%20covering%20every%20code%20path%20that%20didn't%20%60return%60%20early%20%E2%80%94%20including%20both%20fanout%20sub-paths.%20The%20PR%20replaces%20it%20with%20%60app.bump_history_cell%28idx%29%60%20inside%20only%20the%20%60else%60%20%28delegate%29%20branch.%20The%20entire%20%60if%20is_fanout%20%7B%20%E2%80%A6%20%7D%60%20block%20exits%20without%20calling%20either%20%60bump_history_cell%60%20or%20%60mark_history_updated%60%2C%20so%20%60needs_redraw%60%20is%20never%20set%20to%20%60true%60.%0A%0AConcretely%3A%0A-%20%22Reuse%20existing%20fanout%20card%22%20path%20%28line%20156%E2%80%93157%29%3A%20mutates%20the%20card%20via%20%60claim_pending_worker%60%20but%20neither%20increments%20%60history_version%60%20nor%20sets%20%60needs_redraw%60.%20The%20updated%20card%20is%20invisible%20until%20the%20next%20unrelated%20event%20forces%20a%20redraw.%0A-%20%22Create%20new%20fanout%20card%22%20path%20%28line%20159%E2%80%93167%29%3A%20%60add_message%60%20does%20increment%20%60history_version%60%2C%20but%20it%20does%20not%20set%20%60needs_redraw%20%3D%20true%60%20%28see%20%60add_message%60%20impl%20in%20%60app.rs%60%29%2C%20so%20the%20render%20loop%20may%20not%20pick%20up%20the%20new%20cell.%0A%0ABoth%20sub-paths%20need%20a%20%60bump_history_cell%28idx%29%60%20call%20to%20restore%20the%20behaviour%20that%20was%20present%20before%20this%20change.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2708&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fsubagent_routing.rs%0ALine%3A%20149-168%0A%0AComment%3A%0A**Fanout%20branch%20silently%20drops%20the%20redraw%20signal**%0A%0ABefore%20this%20PR%2C%20%60app.mark_history_updated%28%29%60%20was%20called%20unconditionally%20at%20the%20end%20of%20the%20function%2C%20covering%20every%20code%20path%20that%20didn't%20%60return%60%20early%20%E2%80%94%20including%20both%20fanout%20sub-paths.%20The%20PR%20replaces%20it%20with%20%60app.bump_history_cell%28idx%29%60%20inside%20only%20the%20%60else%60%20%28delegate%29%20branch.%20The%20entire%20%60if%20is_fanout%20%7B%20%E2%80%A6%20%7D%60%20block%20exits%20without%20calling%20either%20%60bump_history_cell%60%20or%20%60mark_history_updated%60%2C%20so%20%60needs_redraw%60%20is%20never%20set%20to%20%60true%60.%0A%0AConcretely%3A%0A-%20%22Reuse%20existing%20fanout%20card%22%20path%20%28line%20156%E2%80%93157%29%3A%20mutates%20the%20card%20via%20%60claim_pending_worker%60%20but%20neither%20increments%20%60history_version%60%20nor%20sets%20%60needs_redraw%60.%20The%20updated%20card%20is%20invisible%20until%20the%20next%20unrelated%20event%20forces%20a%20redraw.%0A-%20%22Create%20new%20fanout%20card%22%20path%20%28line%20159%E2%80%93167%29%3A%20%60add_message%60%20does%20increment%20%60history_version%60%2C%20but%20it%20does%20not%20set%20%60needs_redraw%20%3D%20true%60%20%28see%20%60add_message%60%20impl%20in%20%60app.rs%60%29%2C%20so%20the%20render%20loop%20may%20not%20pick%20up%20the%20new%20cell.%0A%0ABoth%20sub-paths%20need%20a%20%60bump_history_cell%28idx%29%60%20call%20to%20restore%20the%20behaviour%20that%20was%20present%20before%20this%20change.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2708&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22windows-half-width-fix%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22windows-half-width-fix%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fsubagent_routing.rs%3A149-168%0A**Fanout%20branch%20silently%20drops%20the%20redraw%20signal**%0A%0ABoth%20sub-paths%20of%20%60if%20is_fanout%20%7B%20%E2%80%A6%20%7D%60%20exit%20without%20calling%20%60bump_history_cell%60%20or%20setting%20%60needs_redraw%60.%20Before%20this%20PR%2C%20the%20unconditional%20%60app.mark_history_updated%28%29%60%20at%20the%20end%20of%20the%20function%20covered%20every%20code%20path%3B%20removing%20it%20and%20placing%20%60bump_history_cell%28idx%29%60%20only%20in%20the%20%60else%60%20%28delegate%29%20branch%20leaves%20fanout%20updates%20invisible%20until%20an%20unrelated%20event%20triggers%20a%20redraw.%0A%0AConcretely%3A%20the%20%22reuse%20existing%22%20arm%20%28line%20156%29%20mutates%20a%20card%20via%20%60claim_pending_worker%60%20with%20no%20redraw%20signal%20at%20all.%20The%20%22create%20new%22%20arm%20calls%20%60add_message%60%2C%20which%20increments%20%60history_version%60%20but%20does%20**not**%20set%20%60needs_redraw%20%3D%20true%60%20%28confirmed%20by%20reading%20%60add_message%60%20at%20%60app.rs%3A2364%60%29.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fsubagent_routing.rs%3A149-168%0A**Fanout%20branch%20silently%20drops%20the%20redraw%20signal**%0A%0ABoth%20sub-paths%20of%20%60if%20is_fanout%20%7B%20%E2%80%A6%20%7D%60%20exit%20without%20calling%20%60bump_history_cell%60%20or%20setting%20%60needs_redraw%60.%20Before%20this%20PR%2C%20the%20unconditional%20%60app.mark_history_updated%28%29%60%20at%20the%20end%20of%20the%20function%20covered%20every%20code%20path%3B%20removing%20it%20and%20placing%20%60bump_history_cell%28idx%29%60%20only%20in%20the%20%60else%60%20%28delegate%29%20branch%20leaves%20fanout%20updates%20invisible%20until%20an%20unrelated%20event%20triggers%20a%20redraw.%0A%0AConcretely%3A%20the%20%22reuse%20existing%22%20arm%20%28line%20156%29%20mutates%20a%20card%20via%20%60claim_pending_worker%60%20with%20no%20redraw%20signal%20at%20all.%20The%20%22create%20new%22%20arm%20calls%20%60add_message%60%2C%20which%20increments%20%60history_version%60%20but%20does%20**not**%20set%20%60needs_redraw%20%3D%20true%60%20%28confirmed%20by%20reading%20%60add_message%60%20at%20%60app.rs%3A2364%60%29.%0A%0A&repo=hmbown%2Fcodewhale&pr=2708&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fsubagent_routing.rs%3A149-168%0A**Fanout%20branch%20silently%20drops%20the%20redraw%20signal**%0A%0ABoth%20sub-paths%20of%20%60if%20is_fanout%20%7B%20%E2%80%A6%20%7D%60%20exit%20without%20calling%20%60bump_history_cell%60%20or%20setting%20%60needs_redraw%60.%20Before%20this%20PR%2C%20the%20unconditional%20%60app.mark_history_updated%28%29%60%20at%20the%20end%20of%20the%20function%20covered%20every%20code%20path%3B%20removing%20it%20and%20placing%20%60bump_history_cell%28idx%29%60%20only%20in%20the%20%60else%60%20%28delegate%29%20branch%20leaves%20fanout%20updates%20invisible%20until%20an%20unrelated%20event%20triggers%20a%20redraw.%0A%0AConcretely%3A%20the%20%22reuse%20existing%22%20arm%20%28line%20156%29%20mutates%20a%20card%20via%20%60claim_pending_worker%60%20with%20no%20redraw%20signal%20at%20all.%20The%20%22create%20new%22%20arm%20calls%20%60add_message%60%2C%20which%20increments%20%60history_version%60%20but%20does%20**not**%20set%20%60needs_redraw%20%3D%20true%60%20%28confirmed%20by%20reading%20%60add_message%60%20at%20%60app.rs%3A2364%60%29.%0A%0A&pr=2708&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["fix: Windows sub-agent completion halves..."](https://github.com/hmbown/codewhale/commit/f8387d6d689105a30ea60daf309f1fe833dcd10b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35491868)</sub>

<!-- /greptile_comment -->