### PR TITLE
fix(tui): clarify /logout credential scope

### DIFF
--- a/crates/tui/src/commands/config.rs
+++ b/crates/tui/src/commands/config.rs
@@ -1364,7 +1364,7 @@ pub fn lsp_command(app: &mut App, arg: Option<&str>) -> CommandResult {
     }
 }
 
-/// Logout - clear API key and return to onboarding
+/// Logout - clear saved config API keys and return to onboarding
 pub fn logout(app: &mut App) -> CommandResult {
     match clear_api_key() {
         Ok(()) => {
@@ -1372,7 +1372,12 @@ pub fn logout(app: &mut App) -> CommandResult {
             app.onboarding_needs_api_key = true;
             app.api_key_input.clear();
             app.api_key_cursor = 0;
-            CommandResult::message("Logged out. Enter a new API key to continue.")
+            CommandResult::message(
+                "Cleared saved config API keys and returned to setup.\n\
+                 `/logout` is not provider-scoped. To replace one provider key, run \
+                 `codewhale auth clear --provider <id>` then \
+                 `codewhale auth set --provider <id>`.",
+            )
         }
         Err(e) => CommandResult::error(format!("Failed to clear API key: {e}")),
     }
@@ -2183,7 +2188,10 @@ mod tests {
 
         let mut app = create_test_app();
         let result = logout(&mut app);
-        assert!(result.message.is_some());
+        let message = result.message.expect("logout message");
+        assert!(message.contains("Cleared saved config API keys"));
+        assert!(message.contains("not provider-scoped"));
+        assert!(message.contains("codewhale auth clear --provider <id>"));
         assert_eq!(app.onboarding, OnboardingState::ApiKey);
         assert!(app.onboarding_needs_api_key);
         assert!(app.api_key_input.is_empty());

--- a/crates/tui/src/localization.rs
+++ b/crates/tui/src/localization.rs
@@ -1134,7 +1134,7 @@ fn english(id: MessageId) -> &'static str {
         MessageId::CmdJobsDescription => "Inspect and control background commands",
         MessageId::CmdLinksDescription => "Show DeepSeek dashboard and docs links",
         MessageId::CmdLoadDescription => "Load session from file",
-        MessageId::CmdLogoutDescription => "Clear API key and return to setup",
+        MessageId::CmdLogoutDescription => "Clear saved config API keys and return to setup",
         MessageId::CmdMcpDescription => "Open or manage MCP servers",
         MessageId::CmdMemoryDescription => "Inspect or manage the persistent user-memory file",
         MessageId::CmdModeDescription => {
@@ -1606,7 +1606,9 @@ fn vietnamese(id: MessageId) -> Option<&'static str> {
             "Hiển thị các liên kết đến bảng điều khiển và tài liệu của DeepSeek"
         }
         MessageId::CmdLoadDescription => "Tải phiên làm việc từ tệp",
-        MessageId::CmdLogoutDescription => "Xóa khóa API và quay lại bước thiết lập",
+        MessageId::CmdLogoutDescription => {
+            "Xóa các khóa API đã lưu trong config và quay lại bước thiết lập"
+        }
         MessageId::CmdMcpDescription => "Mở hoặc quản lý các máy chủ MCP",
         MessageId::CmdMemoryDescription => "Kiểm tra hoặc quản lý tệp bộ nhớ người dùng liên tục",
         MessageId::CmdModeDescription => {
@@ -2155,7 +2157,7 @@ fn japanese(id: MessageId) -> Option<&'static str> {
         MessageId::CmdJobsDescription => "バックグラウンドのシェルジョブを確認・制御",
         MessageId::CmdLinksDescription => "DeepSeek ダッシュボードとドキュメントへのリンクを表示",
         MessageId::CmdLoadDescription => "ファイルからセッションを読み込み",
-        MessageId::CmdLogoutDescription => "API キーを消去してセットアップに戻る",
+        MessageId::CmdLogoutDescription => "保存済みの config API キーを消去してセットアップに戻る",
         MessageId::CmdMcpDescription => "MCP サーバを開く・管理する",
         MessageId::CmdMemoryDescription => "永続ユーザーメモリファイルを確認・管理",
         MessageId::CmdModeDescription => {
@@ -2601,7 +2603,7 @@ fn chinese_simplified(id: MessageId) -> Option<&'static str> {
         MessageId::CmdJobsDescription => "查看并管理后台 shell 作业",
         MessageId::CmdLinksDescription => "显示 DeepSeek 控制台与文档链接",
         MessageId::CmdLoadDescription => "从文件加载会话",
-        MessageId::CmdLogoutDescription => "清除 API 密钥并返回设置",
+        MessageId::CmdLogoutDescription => "清除已保存的 config API 密钥并返回设置",
         MessageId::CmdMcpDescription => "打开或管理 MCP 服务器",
         MessageId::CmdMemoryDescription => "查看或管理持久用户记忆文件",
         MessageId::CmdModeDescription => "切换运行模式或打开选择器：/mode [agent|plan|yolo|1|2|3]",
@@ -3019,7 +3021,9 @@ fn portuguese_brazil(id: MessageId) -> Option<&'static str> {
         MessageId::CmdJobsDescription => "Inspecionar e controlar jobs de shell em segundo plano",
         MessageId::CmdLinksDescription => "Exibir links do painel e da documentação do DeepSeek",
         MessageId::CmdLoadDescription => "Carregar a sessão de um arquivo",
-        MessageId::CmdLogoutDescription => "Limpar a chave de API e voltar à configuração",
+        MessageId::CmdLogoutDescription => {
+            "Limpar as chaves de API salvas no config e voltar à configuração"
+        }
         MessageId::CmdMcpDescription => "Abrir ou gerenciar servidores MCP",
         MessageId::CmdMemoryDescription => {
             "Inspecionar ou gerenciar o arquivo persistente de memória do usuário"
@@ -3507,7 +3511,9 @@ fn spanish_latin_america(id: MessageId) -> Option<&'static str> {
         }
         MessageId::CmdLinksDescription => "Mostrar enlaces del panel y documentación de DeepSeek",
         MessageId::CmdLoadDescription => "Cargar la sesión desde un archivo",
-        MessageId::CmdLogoutDescription => "Limpiar la clave de API y volver a la configuración",
+        MessageId::CmdLogoutDescription => {
+            "Limpiar las claves de API guardadas en config y volver a la configuración"
+        }
         MessageId::CmdMcpDescription => "Abrir o gestionar servidores MCP",
         MessageId::CmdMemoryDescription => {
             "Inspeccionar o gestionar el archivo persistente de memoria del usuario"


### PR DESCRIPTION
## Summary
- clarify the `/logout` command description so it no longer reads like a single-provider logout flow
- make the success message explicit that `/logout` clears saved config API keys and is not provider-scoped
- point users to `codewhale auth clear --provider <id>` and `codewhale auth set --provider <id>` for one-provider key replacement
- add a regression test for the new guidance

Fixes #2660.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR clarifies that `/logout` clears *all* saved config API keys rather than a single provider's key, and guides users to `codewhale auth clear/set --provider <id>` for per-provider replacement. The change updates the command description in 6 locales and tightens the test to assert on the new message content.

- **`config.rs`**: Doc comment, success message, and test updated to use "saved config API keys" wording and include the provider-scoped CLI guidance.
- **`localization.rs`**: `CmdLogoutDescription` updated consistently across all supported locales (English, Vietnamese, Japanese, Chinese Simplified, Portuguese Brazil, Spanish Latin America).
- The error path (`"Failed to clear API key: {e}"`) retains the old singular phrasing, which is now inconsistent with the success path.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; changes are limited to user-facing strings and a test assertion — no logic is altered.

The success message, doc comment, localization strings, and test are all updated correctly. The only rough edge is that the error-path message still says "API key" (singular) while everything else now says "API keys" (plural), leaving a small inconsistency visible to users on failure.

No files require special attention; the minor wording inconsistency is in the Err branch of logout in config.rs.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/commands/config.rs | Updated logout doc comment and success message to clarify that /logout clears all saved config API keys (not a single provider); regression test updated to assert on the new message strings. The error-path message ("Failed to clear API key") was not updated and is now inconsistent with the success path. |
| crates/tui/src/localization.rs | Updated CmdLogoutDescription in all 6 supported locales (English, Vietnamese, Japanese, Chinese Simplified, Portuguese Brazil, Spanish Latin America) to reflect the new "saved config API keys" wording. Updates appear accurate and consistent. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User runs /logout] --> B[clear_api_key called]
    B --> C{Result}
    C -- Ok --> D["Success message:\n'Cleared saved config API keys\nand returned to setup.\n/logout is not provider-scoped.\nUse codewhale auth clear/set\n--provider id for one provider.'"]
    D --> E[app.onboarding = ApiKey\nonboarding_needs_api_key = true\napi_key_input cleared]
    C -- Err --> F["Error: 'Failed to clear API key: e'\n(singular — inconsistent with success path)"]
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix-2660-logout-scope%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix-2660-logout-scope%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fcommands%2Fconfig.rs%3A1382%0AThe%20error%20message%20still%20uses%20singular%20%22API%20key%22%20while%20the%20success%20message%20and%20all%20updated%20descriptions%20now%20use%20plural%20%22API%20keys%22.%20These%20should%20be%20consistent%20so%20users%20get%20the%20same%20framing%20regardless%20of%20whether%20the%20operation%20succeeds%20or%20fails.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20Err%28e%29%20%3D%3E%20CommandResult%3A%3Aerror%28format!%28%22Failed%20to%20clear%20saved%20config%20API%20keys%3A%20%7Be%7D%22%29%29%2C%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fcommands%2Fconfig.rs%3A1382%0AThe%20error%20message%20still%20uses%20singular%20%22API%20key%22%20while%20the%20success%20message%20and%20all%20updated%20descriptions%20now%20use%20plural%20%22API%20keys%22.%20These%20should%20be%20consistent%20so%20users%20get%20the%20same%20framing%20regardless%20of%20whether%20the%20operation%20succeeds%20or%20fails.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20Err%28e%29%20%3D%3E%20CommandResult%3A%3Aerror%28format!%28%22Failed%20to%20clear%20saved%20config%20API%20keys%3A%20%7Be%7D%22%29%29%2C%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2714&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fcommands%2Fconfig.rs%3A1382%0AThe%20error%20message%20still%20uses%20singular%20%22API%20key%22%20while%20the%20success%20message%20and%20all%20updated%20descriptions%20now%20use%20plural%20%22API%20keys%22.%20These%20should%20be%20consistent%20so%20users%20get%20the%20same%20framing%20regardless%20of%20whether%20the%20operation%20succeeds%20or%20fails.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20Err%28e%29%20%3D%3E%20CommandResult%3A%3Aerror%28format!%28%22Failed%20to%20clear%20saved%20config%20API%20keys%3A%20%7Be%7D%22%29%29%2C%0A%60%60%60%0A%0A&pr=2714&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(tui): clarify /logout credential sco..."](https://github.com/hmbown/codewhale/commit/9df986bd084e3888b6a0b22d8a145a3bf7a87d90) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35492889)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->