### PR TITLE
fix(tui): clear MiMo auth state after logout

### DIFF
--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -6188,20 +6188,7 @@ async fn execute_command_input(
     // (#343). The on-disk side is handled by clear_api_key() inside
     // commands::config::logout.
     if input.trim().eq_ignore_ascii_case("/logout") {
-        config.api_key = None;
-        if let Some(providers) = config.providers.as_mut() {
-            providers.deepseek.api_key = None;
-            providers.deepseek_cn.api_key = None;
-            providers.nvidia_nim.api_key = None;
-            providers.openai.api_key = None;
-            providers.atlascloud.api_key = None;
-            providers.openrouter.api_key = None;
-            providers.novita.api_key = None;
-            providers.fireworks.api_key = None;
-            providers.sglang.api_key = None;
-            providers.vllm.api_key = None;
-            providers.ollama.api_key = None;
-        }
+        clear_in_memory_api_keys(config);
         app.api_key_env_only = crate::config::active_provider_uses_env_only_api_key(config);
     }
     apply_command_result(
@@ -6214,6 +6201,55 @@ async fn execute_command_input(
         result,
     )
     .await
+}
+
+fn clear_in_memory_api_keys(config: &mut Config) {
+    config.api_key = None;
+    if config.providers.is_none() {
+        return;
+    }
+    config
+        .provider_config_for_mut(ApiProvider::Deepseek)
+        .api_key = None;
+    config
+        .provider_config_for_mut(ApiProvider::DeepseekCN)
+        .api_key = None;
+    config
+        .provider_config_for_mut(ApiProvider::NvidiaNim)
+        .api_key = None;
+    config.provider_config_for_mut(ApiProvider::Openai).api_key = None;
+    config
+        .provider_config_for_mut(ApiProvider::Atlascloud)
+        .api_key = None;
+    config
+        .provider_config_for_mut(ApiProvider::WanjieArk)
+        .api_key = None;
+    config
+        .provider_config_for_mut(ApiProvider::Volcengine)
+        .api_key = None;
+    config
+        .provider_config_for_mut(ApiProvider::Openrouter)
+        .api_key = None;
+    config
+        .provider_config_for_mut(ApiProvider::XiaomiMimo)
+        .api_key = None;
+    config.provider_config_for_mut(ApiProvider::Novita).api_key = None;
+    config
+        .provider_config_for_mut(ApiProvider::Fireworks)
+        .api_key = None;
+    config
+        .provider_config_for_mut(ApiProvider::Siliconflow)
+        .api_key = None;
+    config
+        .provider_config_for_mut(ApiProvider::SiliconflowCn)
+        .api_key = None;
+    config.provider_config_for_mut(ApiProvider::Arcee).api_key = None;
+    config
+        .provider_config_for_mut(ApiProvider::Moonshot)
+        .api_key = None;
+    config.provider_config_for_mut(ApiProvider::Sglang).api_key = None;
+    config.provider_config_for_mut(ApiProvider::Vllm).api_key = None;
+    config.provider_config_for_mut(ApiProvider::Ollama).api_key = None;
 }
 
 async fn steer_user_message(

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -2286,6 +2286,54 @@ async fn provider_switch_model_override_updates_target_provider_model_slot() {
     );
 }
 
+#[test]
+fn logout_clears_in_memory_mimo_and_other_provider_keys_without_wiping_settings() {
+    let mut config = Config {
+        api_key: Some("deepseek-key".to_string()),
+        providers: Some(ProvidersConfig {
+            xiaomi_mimo: ProviderConfig {
+                api_key: Some("mimo-key".to_string()),
+                model: Some("mimo-v2.5-pro".to_string()),
+                base_url: Some("https://token-plan-sgp.xiaomimimo.com/v1".to_string()),
+                ..Default::default()
+            },
+            moonshot: ProviderConfig {
+                api_key: Some("moonshot-key".to_string()),
+                auth_mode: Some("kimi_oauth".to_string()),
+                ..Default::default()
+            },
+            volcengine: ProviderConfig {
+                api_key: Some("volcengine-key".to_string()),
+                model: Some("deepseek-v4-pro".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    clear_in_memory_api_keys(&mut config);
+
+    assert!(config.api_key.is_none());
+    let providers = config.providers.expect("provider config");
+    assert!(providers.xiaomi_mimo.api_key.is_none());
+    assert!(providers.moonshot.api_key.is_none());
+    assert!(providers.volcengine.api_key.is_none());
+    assert_eq!(
+        providers.xiaomi_mimo.model.as_deref(),
+        Some("mimo-v2.5-pro")
+    );
+    assert_eq!(
+        providers.xiaomi_mimo.base_url.as_deref(),
+        Some("https://token-plan-sgp.xiaomimimo.com/v1")
+    );
+    assert_eq!(providers.moonshot.auth_mode.as_deref(), Some("kimi_oauth"));
+    assert_eq!(
+        providers.volcengine.model.as_deref(),
+        Some("deepseek-v4-pro")
+    );
+}
+
 #[tokio::test]
 async fn provider_switch_to_openrouter_canonicalizes_deepseek_default_model() {
     let _home = SettingsHomeGuard::new();


### PR DESCRIPTION
## Summary
- clear the in-memory provider API-key slots after `/logout`, including Xiaomi MiMo and the newer hosted providers
- keep non-credential provider settings like model, base URL, and auth mode intact
- add a regression test covering MiMo plus other provider-scoped keys

Fixes #2661.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where in-memory API keys for several providers — most notably Xiaomi MiMo — were not cleared when the user issued `/logout`. The fix extracts a new `clear_in_memory_api_keys` helper and adds the seven previously-missing providers to the clearing logic, while keeping non-credential settings (model, base URL, auth mode) intact.

- Refactors the inline logout clearing block in `execute_command_input` into a standalone `clear_in_memory_api_keys` function, which is now exhaustive over all 18 `ApiProvider` variants.
- Adds `WanjieArk`, `Volcengine`, `XiaomiMimo`, `Siliconflow`, `SiliconflowCn`, `Arcee`, and `Moonshot` to the clearing list, fixing the regression reported in #2661.
- Adds a unit test that directly calls `clear_in_memory_api_keys` and asserts MiMo, moonshot, and volcengine keys are cleared while model/base_url/auth_mode fields are preserved.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the clearing logic is exhaustive over all provider variants and the is_none guard correctly prevents a spurious ProvidersConfig allocation.

The refactor is straightforward and the behavior for every existing provider is preserved. The only wrinkle is that both Siliconflow and SiliconflowCN are listed, but they resolve to the same storage slot — the duplicate write is harmless. All providers that were cleared before are still cleared, and seven that were previously skipped (including XiaomiMimo) are now correctly included.

crates/tui/src/tui/ui.rs — specifically the SiliconflowCn call that maps to the same field as Siliconflow.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/ui.rs | Refactors the /logout handler to call a new clear_in_memory_api_keys helper; adds 7 previously-missing providers (XiaomiMimo, WanjieArk, Volcengine, Siliconflow, SiliconflowCn, Arcee, Moonshot). One call — SiliconflowCn — is redundant because provider_config_for_mut maps both Siliconflow and SiliconflowCn to the same providers.siliconflow slot. |
| crates/tui/src/tui/ui/tests.rs | Adds a regression test that verifies api_key is cleared for xiaomi_mimo, moonshot, and volcengine while non-credential fields (model, base_url, auth_mode) are preserved after clear_in_memory_api_keys. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["/logout command detected"] --> B["clear_in_memory_api_keys(config)"]
    B --> C["config.api_key = None"]
    C --> D{"config.providers\nis None?"}
    D -- Yes --> E["return early\n(no-op for provider slots)"]
    D -- No --> F["provider_config_for_mut() for each ApiProvider variant"]
    F --> G["Deepseek / DeepseekCN / NvidiaNim\nOpenai / Atlascloud / WanjieArk\nVolcengine / Openrouter / XiaomiMimo\nNovita / Fireworks / Siliconflow\nSiliconflowCN / Arcee / Moonshot\nSglang / Vllm / Ollama"]
    G --> H["api_key = None for each slot"]
    H --> I["Back in execute_command_input"]
    I --> J["Recompute api_key_env_only flag"]
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix-2661-logout-clears-provider-state%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix-2661-logout-clears-provider-state%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui.rs%3A6240-6245%0AThe%20%60SiliconflowCn%60%20call%20is%20redundant%20%E2%80%94%20%60provider_config_for_mut%60%20routes%20both%20%60Siliconflow%60%20and%20%60SiliconflowCn%60%20to%20the%20same%20%60providers.siliconflow%60%20field%20%28there%20is%20no%20separate%20%60siliconflow_cn%60%20field%20in%20%60ProvidersConfig%60%29.%20The%20second%20call%20writes%20%60None%60%20to%20a%20slot%20already%20set%20to%20%60None%60%2C%20which%20is%20harmless%20today%20but%20can%20mislead%20a%20future%20reader%20into%20thinking%20a%20distinct%20CN%20key%20is%20being%20cleared.%0A%0A%60%60%60suggestion%0A%20%20%20%20config%0A%20%20%20%20%20%20%20%20.provider_config_for_mut%28ApiProvider%3A%3ASiliconflow%29%0A%20%20%20%20%20%20%20%20.api_key%20%3D%20None%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui.rs%3A6240-6245%0AThe%20%60SiliconflowCn%60%20call%20is%20redundant%20%E2%80%94%20%60provider_config_for_mut%60%20routes%20both%20%60Siliconflow%60%20and%20%60SiliconflowCn%60%20to%20the%20same%20%60providers.siliconflow%60%20field%20%28there%20is%20no%20separate%20%60siliconflow_cn%60%20field%20in%20%60ProvidersConfig%60%29.%20The%20second%20call%20writes%20%60None%60%20to%20a%20slot%20already%20set%20to%20%60None%60%2C%20which%20is%20harmless%20today%20but%20can%20mislead%20a%20future%20reader%20into%20thinking%20a%20distinct%20CN%20key%20is%20being%20cleared.%0A%0A%60%60%60suggestion%0A%20%20%20%20config%0A%20%20%20%20%20%20%20%20.provider_config_for_mut%28ApiProvider%3A%3ASiliconflow%29%0A%20%20%20%20%20%20%20%20.api_key%20%3D%20None%3B%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2715&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui.rs%3A6240-6245%0AThe%20%60SiliconflowCn%60%20call%20is%20redundant%20%E2%80%94%20%60provider_config_for_mut%60%20routes%20both%20%60Siliconflow%60%20and%20%60SiliconflowCn%60%20to%20the%20same%20%60providers.siliconflow%60%20field%20%28there%20is%20no%20separate%20%60siliconflow_cn%60%20field%20in%20%60ProvidersConfig%60%29.%20The%20second%20call%20writes%20%60None%60%20to%20a%20slot%20already%20set%20to%20%60None%60%2C%20which%20is%20harmless%20today%20but%20can%20mislead%20a%20future%20reader%20into%20thinking%20a%20distinct%20CN%20key%20is%20being%20cleared.%0A%0A%60%60%60suggestion%0A%20%20%20%20config%0A%20%20%20%20%20%20%20%20.provider_config_for_mut%28ApiProvider%3A%3ASiliconflow%29%0A%20%20%20%20%20%20%20%20.api_key%20%3D%20None%3B%0A%60%60%60%0A%0A&pr=2715&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(tui): clear MiMo auth state after lo..."](https://github.com/hmbown/codewhale/commit/54428295155e2614225ad08b28d1c0afe9a5480c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35494683)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->