### PR TITLE
fix(tui): make provider key replacement discoverable

### DIFF
--- a/crates/tui/src/tui/provider_picker.rs
+++ b/crates/tui/src/tui/provider_picker.rs
@@ -8,7 +8,8 @@
 //!    and an "API key configured" / "needs API key" hint. Enter on a
 //!    configured provider applies the switch immediately
 //!    ([`ViewEvent::ProviderPickerApplied`]). Enter on an un-configured one
-//!    transitions the same modal into the key-entry state.
+//!    transitions the same modal into the key-entry state. Press `r` on any
+//!    selected provider to edit / replace its API key inline.
 //! 2. **Key entry** — masked input box pre-filled with the provider's
 //!    canonical env-var name as a hint. Enter submits
 //!    [`ViewEvent::ProviderPickerApiKeySubmitted`], which the UI handler
@@ -94,6 +95,11 @@ impl ProviderPickerView {
         self.providers[self.selected_idx].1
     }
 
+    fn enter_key_entry(&mut self) {
+        self.stage = Stage::KeyEntry;
+        self.api_key_input.clear();
+    }
+
     fn env_var_for(provider: ApiProvider) -> &'static str {
         match provider {
             ApiProvider::Deepseek | ApiProvider::DeepseekCN => "DEEPSEEK_API_KEY",
@@ -153,6 +159,11 @@ impl ProviderPickerView {
     }
 
     fn render_list(&self, area: Rect, buf: &mut Buffer) {
+        let enter_action = if self.selected_has_key() {
+            "apply"
+        } else {
+            "set key"
+        };
         let outer = Block::default()
             .title(Line::from(Span::styled(
                 " Provider ",
@@ -164,7 +175,9 @@ impl ProviderPickerView {
                 Span::styled(" ↑↓ ", Style::default().fg(palette::TEXT_MUTED)),
                 Span::raw("move "),
                 Span::styled(" Enter ", Style::default().fg(palette::TEXT_MUTED)),
-                Span::raw("apply "),
+                Span::raw(format!("{enter_action} ")),
+                Span::styled(" R ", Style::default().fg(palette::TEXT_MUTED)),
+                Span::raw("edit key "),
                 Span::styled(" Esc ", Style::default().fg(palette::TEXT_MUTED)),
                 Span::raw("cancel "),
             ]))
@@ -357,10 +370,13 @@ impl ModalView for ProviderPickerView {
                             provider,
                         })
                     } else {
-                        self.stage = Stage::KeyEntry;
-                        self.api_key_input.clear();
+                        self.enter_key_entry();
                         ViewAction::None
                     }
+                }
+                KeyCode::Char(c) if c.eq_ignore_ascii_case(&'r') => {
+                    self.enter_key_entry();
+                    ViewAction::None
                 }
                 _ => ViewAction::None,
             },
@@ -541,6 +557,28 @@ mod tests {
     }
 
     #[test]
+    fn configured_provider_can_reenter_key_entry_with_r() {
+        let config = Config {
+            providers: Some(crate::config::ProvidersConfig {
+                xiaomi_mimo: crate::config::ProviderConfig {
+                    api_key: Some("mimo-key".to_string()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+            ..Config::default()
+        };
+        let mut picker = ProviderPickerView::new(ApiProvider::Deepseek, &config);
+        move_to_provider(&mut picker, ApiProvider::XiaomiMimo);
+
+        let action = picker.handle_key(key(KeyCode::Char('r')));
+
+        assert!(matches!(action, ViewAction::None));
+        assert_eq!(picker.stage, Stage::KeyEntry);
+        assert!(picker.api_key_input.is_empty());
+    }
+
+    #[test]
     fn enter_with_existing_key_emits_apply_and_closes() {
         let config = Config {
             api_key: Some("existing-deepseek-key".to_string()),
@@ -648,6 +686,21 @@ mod tests {
 
         assert!(rendered.contains("DeepSeek *"));
         assert!(rendered.contains("Ollama"));
+    }
+
+    #[test]
+    fn configured_provider_footer_mentions_edit_key() {
+        let config = Config {
+            api_key: Some("existing-deepseek-key".to_string()),
+            ..Config::default()
+        };
+        let picker = ProviderPickerView::new(ApiProvider::Deepseek, &config);
+
+        let rendered = render_text(&picker, 80, 12);
+
+        assert!(rendered.contains("Enter"));
+        assert!(rendered.contains("apply"));
+        assert!(rendered.contains("edit key"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add an inline `r` shortcut in the provider picker so configured providers can reopen API-key entry without leaving `/provider`
- update the picker footer to advertise the edit flow and show when Enter will apply vs set a key
- add provider-picker regression tests for the new shortcut and footer hint

Fixes #2662.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an `r` shortcut in the provider picker's list stage so users can re-enter the API-key input for an already-configured provider without closing the modal, complemented by a dynamic footer hint that shows "apply" or "set key" depending on whether the selection has a key.

- Extracts duplicated key-entry transition logic into `enter_key_entry()` and wires it to `KeyCode::Char(c)` matching `r`/`R` in the list stage.
- Changes the footer's Enter label from the static "apply" to a dynamic "apply" / "set key" string, and adds a new `R  edit key` hint.
- Adds two regression tests covering the new shortcut and the updated footer text.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; all changes are confined to the provider picker UI and its unit tests, with no persistence logic touched.

The `r` shortcut and refactored `enter_key_entry()` helper are clean and well-tested for the common cases. The one gap is the dynamic footer label: it reads `selected_has_key()` to pick between "apply" and "set key", but the Enter handler has a third branch for Moonshot + Kimi CLI OAuth that neither of those labels describes accurately. In that specific state the footer says "Enter set key" while Enter actually activates OAuth, creating a misleading hint. This is a narrow edge case (Moonshot + Kimi CLI only), limited to UI text, and does not affect any persisted state or key-submission logic.

crates/tui/src/tui/provider_picker.rs — the `enter_action` label logic near `render_list` line 162
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/provider_picker.rs | Adds `r`-key shortcut and dynamic footer; the `enter_action` computation is based solely on `selected_has_key()`, which produces a misleading "set key" hint for Moonshot when Kimi CLI OAuth is present but no API key is set (Enter triggers OAuth in that state, not key-entry). |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    List["Stage::List"] -->|"Enter (has key)"| Apply["EmitAndClose: ProviderPickerApplied"]
    List -->|"Enter (Moonshot + Kimi OAuth, no key)"| OAuth["EmitAndClose: ProviderPickerKimiOAuthEnabled"]
    List -->|"Enter (no key)"| KeyEntry["Stage::KeyEntry"]
    List -->|"r / R"| KeyEntry
    List -->|Esc| Close["ViewAction::Close"]

    KeyEntry -->|"Enter (non-empty input)"| Submit["EmitAndClose: ProviderPickerApiKeySubmitted"]
    KeyEntry -->|"Enter (empty input)"| KeyEntry
    KeyEntry -->|Esc| List
    KeyEntry -->|Backspace / Ctrl+H| KeyEntry
    KeyEntry -->|"Char (non-whitespace)"| KeyEntry

    Footer["Footer hint (render_list)"] -->|"selected_has_key() = true"| FApply["'Enter apply'"]
    Footer -->|"selected_has_key() = false"| FSetKey["'Enter set key'"]
    FSetKey -.->|"misleading when Moonshot + Kimi OAuth active"| OAuth
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix-2662-provider-picker-key-edit%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix-2662-provider-picker-key-edit%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fprovider_picker.rs%3A162-166%0AThe%20%60enter_action%60%20label%20is%20derived%20from%20%60selected_has_key%28%29%60%20alone%2C%20but%20the%20Enter%20handler%20has%20a%20third%20branch%3A%20when%20Moonshot%20is%20selected%20with%20Kimi%20CLI%20OAuth%20credentials%20present%20but%20no%20explicit%20API%20key%2C%20Enter%20emits%20%60ProviderPickerKimiOAuthEnabled%60%20%E2%80%94%20it%20does%20**not**%20go%20to%20key-entry.%20In%20that%20state%20the%20footer%20will%20say%20%22Enter%20set%20key%22%2C%20which%20is%20incorrect%20and%20could%20confuse%20users%20expecting%20the%20OAuth%20activation%20path.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20enter_action%20%3D%20if%20self.selected_has_key%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22apply%22%0A%20%20%20%20%20%20%20%20%7D%20else%20if%20self.selected_provider%28%29%20%3D%3D%20ApiProvider%3A%3AMoonshot%0A%20%20%20%20%20%20%20%20%20%20%20%20%26%26%20kimi_cli_credentials_present%28%29%0A%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22oauth%22%0A%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22set%20key%22%0A%20%20%20%20%20%20%20%20%7D%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fprovider_picker.rs%3A559-579%0A**%60r%60%20shortcut%20not%20tested%20for%20Moonshot%20%2B%20Kimi%20OAuth%20path**%0A%0AThe%20new%20test%20covers%20%60r%60%20on%20a%20configured%20provider%20%28XiaomiMimo%20with%20an%20API%20key%29%20and%20the%20Enter-key%20OAuth%20branch%20is%20unchanged%2C%20but%20there%20is%20no%20test%20for%20pressing%20%60r%60%20when%20Moonshot%20is%20selected%20and%20%60kimi_cli_credentials_present%28%29%60%20is%20true.%20In%20that%20case%20%60r%60%20bypasses%20the%20OAuth%20flow%20entirely%20and%20drops%20the%20user%20into%20key-entry%20%E2%80%94%20a%20distinct%20behaviour%20from%20what%20Enter%20does%20in%20the%20same%20selection%20state.%20A%20test%20covering%20this%20divergence%20would%20help%20catch%20any%20future%20regression.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fprovider_picker.rs%3A162-166%0AThe%20%60enter_action%60%20label%20is%20derived%20from%20%60selected_has_key%28%29%60%20alone%2C%20but%20the%20Enter%20handler%20has%20a%20third%20branch%3A%20when%20Moonshot%20is%20selected%20with%20Kimi%20CLI%20OAuth%20credentials%20present%20but%20no%20explicit%20API%20key%2C%20Enter%20emits%20%60ProviderPickerKimiOAuthEnabled%60%20%E2%80%94%20it%20does%20**not**%20go%20to%20key-entry.%20In%20that%20state%20the%20footer%20will%20say%20%22Enter%20set%20key%22%2C%20which%20is%20incorrect%20and%20could%20confuse%20users%20expecting%20the%20OAuth%20activation%20path.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20enter_action%20%3D%20if%20self.selected_has_key%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22apply%22%0A%20%20%20%20%20%20%20%20%7D%20else%20if%20self.selected_provider%28%29%20%3D%3D%20ApiProvider%3A%3AMoonshot%0A%20%20%20%20%20%20%20%20%20%20%20%20%26%26%20kimi_cli_credentials_present%28%29%0A%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22oauth%22%0A%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22set%20key%22%0A%20%20%20%20%20%20%20%20%7D%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fprovider_picker.rs%3A559-579%0A**%60r%60%20shortcut%20not%20tested%20for%20Moonshot%20%2B%20Kimi%20OAuth%20path**%0A%0AThe%20new%20test%20covers%20%60r%60%20on%20a%20configured%20provider%20%28XiaomiMimo%20with%20an%20API%20key%29%20and%20the%20Enter-key%20OAuth%20branch%20is%20unchanged%2C%20but%20there%20is%20no%20test%20for%20pressing%20%60r%60%20when%20Moonshot%20is%20selected%20and%20%60kimi_cli_credentials_present%28%29%60%20is%20true.%20In%20that%20case%20%60r%60%20bypasses%20the%20OAuth%20flow%20entirely%20and%20drops%20the%20user%20into%20key-entry%20%E2%80%94%20a%20distinct%20behaviour%20from%20what%20Enter%20does%20in%20the%20same%20selection%20state.%20A%20test%20covering%20this%20divergence%20would%20help%20catch%20any%20future%20regression.%0A%0A&repo=hmbown%2Fcodewhale&pr=2717&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fprovider_picker.rs%3A162-166%0AThe%20%60enter_action%60%20label%20is%20derived%20from%20%60selected_has_key%28%29%60%20alone%2C%20but%20the%20Enter%20handler%20has%20a%20third%20branch%3A%20when%20Moonshot%20is%20selected%20with%20Kimi%20CLI%20OAuth%20credentials%20present%20but%20no%20explicit%20API%20key%2C%20Enter%20emits%20%60ProviderPickerKimiOAuthEnabled%60%20%E2%80%94%20it%20does%20**not**%20go%20to%20key-entry.%20In%20that%20state%20the%20footer%20will%20say%20%22Enter%20set%20key%22%2C%20which%20is%20incorrect%20and%20could%20confuse%20users%20expecting%20the%20OAuth%20activation%20path.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20enter_action%20%3D%20if%20self.selected_has_key%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22apply%22%0A%20%20%20%20%20%20%20%20%7D%20else%20if%20self.selected_provider%28%29%20%3D%3D%20ApiProvider%3A%3AMoonshot%0A%20%20%20%20%20%20%20%20%20%20%20%20%26%26%20kimi_cli_credentials_present%28%29%0A%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22oauth%22%0A%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22set%20key%22%0A%20%20%20%20%20%20%20%20%7D%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fprovider_picker.rs%3A559-579%0A**%60r%60%20shortcut%20not%20tested%20for%20Moonshot%20%2B%20Kimi%20OAuth%20path**%0A%0AThe%20new%20test%20covers%20%60r%60%20on%20a%20configured%20provider%20%28XiaomiMimo%20with%20an%20API%20key%29%20and%20the%20Enter-key%20OAuth%20branch%20is%20unchanged%2C%20but%20there%20is%20no%20test%20for%20pressing%20%60r%60%20when%20Moonshot%20is%20selected%20and%20%60kimi_cli_credentials_present%28%29%60%20is%20true.%20In%20that%20case%20%60r%60%20bypasses%20the%20OAuth%20flow%20entirely%20and%20drops%20the%20user%20into%20key-entry%20%E2%80%94%20a%20distinct%20behaviour%20from%20what%20Enter%20does%20in%20the%20same%20selection%20state.%20A%20test%20covering%20this%20divergence%20would%20help%20catch%20any%20future%20regression.%0A%0A&pr=2717&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(tui): let provider picker edit save..."](https://github.com/hmbown/codewhale/commit/7b254281d5bd81052aab71ede64594d354576f5a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35496379)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->