### PR TITLE
fix(tui): persist provider switches to config

### DIFF
--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -5361,28 +5361,43 @@ async fn switch_provider(
         })
         .await;
 
-    app.add_message(HistoryCell::System {
-        content: format!(
-            "Provider switched: {} → {}\nModel: {} → {}",
-            previous_provider.as_str(),
-            target.as_str(),
-            previous_model,
-            new_model
-        ),
-    });
-    app.status_message = Some(format!("Provider: {}", target.as_str()));
+    let persist_warning = (|| -> anyhow::Result<()> {
+        commands::persist_root_string_key(app.config_path.as_deref(), "provider", target.as_str())?;
 
-    // Persist the provider choice so it survives restarts.
-    if let Ok(mut settings) = crate::settings::Settings::load() {
+        let mut settings = crate::settings::Settings::load()?;
         settings.default_provider = Some(target.as_str().to_string());
         if model_override.is_some() {
             settings.set_model_for_provider(target.as_str(), &new_model);
             if matches!(target, ApiProvider::Deepseek | ApiProvider::DeepseekCN) {
-                let _ = settings.set("default_model", &new_model);
+                settings.set("default_model", &new_model)?;
             }
         }
-        let _ = settings.save();
+        settings.save()?;
+        Ok(())
+    })()
+    .err()
+    .map(|err| format!("Provider selection was not fully persisted: {err}"));
+
+    let mut switch_summary = format!(
+        "Provider switched: {} -> {}",
+        previous_provider.as_str(),
+        target.as_str(),
+    );
+    switch_summary.push(char::from(10));
+    switch_summary.push_str(&format!("Model: {} -> {}", previous_model, new_model));
+    if let Some(ref warning) = persist_warning {
+        switch_summary.push(char::from(10));
+        switch_summary.push_str(warning);
     }
+    app.add_message(HistoryCell::System {
+        content: switch_summary,
+    });
+
+    let mut status_message = format!("Provider: {}", target.as_str());
+    if persist_warning.is_some() {
+        status_message.push_str(" (not fully persisted)");
+    }
+    app.status_message = Some(status_message);
 }
 
 fn root_base_url_belongs_to_non_deepseek_provider(base_url: &str) -> bool {

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -2238,6 +2238,57 @@ async fn provider_switch_to_deepseek_drops_stale_xiaomi_root_base_url() {
 }
 
 #[tokio::test]
+async fn provider_switch_persists_provider_to_config_for_restart() {
+    let _home = SettingsHomeGuard::new();
+    let tmp = TempDir::new().expect("config tempdir");
+    let config_path = tmp.path().join("config.toml");
+    std::fs::write(
+        &config_path,
+        r#"provider = "arcee"
+
+[providers.xiaomi_mimo]
+base_url = "https://token-plan-sgp.xiaomimimo.com/v1"
+model = "mimo-v2.5-pro"
+api_key = "mimo-key"
+
+[providers.arcee]
+api_key = "arcee-key"
+"#,
+    )
+    .expect("write config");
+
+    let mut app = create_test_app();
+    app.api_provider = ApiProvider::Arcee;
+    app.model = "auto".to_string();
+    app.config_path = Some(config_path.clone());
+
+    let mut engine = mock_engine_handle();
+    let mut config = Config::load(Some(config_path.clone()), None).expect("load config");
+
+    switch_provider(
+        &mut app,
+        &mut engine.handle,
+        &mut config,
+        ApiProvider::XiaomiMimo,
+        None,
+    )
+    .await;
+
+    assert_eq!(app.api_provider, ApiProvider::XiaomiMimo);
+    assert_eq!(config.provider.as_deref(), Some("xiaomi-mimo"));
+
+    let reloaded = Config::load(Some(config_path.clone()), None).expect("reload config");
+    assert_eq!(reloaded.api_provider(), ApiProvider::XiaomiMimo);
+    assert_eq!(
+        reloaded.deepseek_base_url(),
+        "https://token-plan-sgp.xiaomimimo.com/v1"
+    );
+
+    let settings = crate::settings::Settings::load().expect("load settings");
+    assert_eq!(settings.default_provider.as_deref(), Some("xiaomi-mimo"));
+}
+
+#[tokio::test]
 async fn provider_switch_model_override_updates_target_provider_model_slot() {
     let _home = SettingsHomeGuard::new();
     let mut app = create_test_app();


### PR DESCRIPTION
## Summary
- persist `/provider` switches back to `config.toml` so restart behavior matches the active provider
- keep the saved settings provider in sync and surface a warning if persistence fails
- add a regression test covering the Arcee -> Xiaomi MiMo split-state path from #2663

Fixes #2663.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a stale-restart bug (#2663) where switching providers via `/provider` in the TUI was not written back to `config.toml`, so the next launch would revert to the previously configured provider. The fix wraps both `persist_root_string_key` (config.toml write) and `Settings::load/save` in a single closure; on any error the switch still takes effect in memory but a visible warning is appended to the chat and status bar.

- **`ui.rs`**: `switch_provider` now always calls `commands::persist_root_string_key` to update `config.toml` and separately updates `Settings`, surfacing a non-fatal warning instead of silently ignoring persistence failures.
- **`tests.rs`**: New regression test `provider_switch_persists_provider_to_config_for_restart` covers the Arcee → XiaomiMimo split-state path from #2663, asserting both the in-memory `config` and the file reloaded from disk agree on the new provider.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the persistence logic is correct and failures are surfaced as a user-visible warning rather than crashing or silently dropping the switch.

The core fix is straightforward and well-tested: the new regression test verifies the on-disk config, in-memory state, and settings all agree after a switch. The only findings are cosmetic — non-idiomatic newline literals and an arrow character that diverges from the style used by adjacent messages.

No files require special attention; the two style issues are both confined to the new lines in ui.rs.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/ui.rs | Adds config.toml persistence to switch_provider via persist_root_string_key; logic is correct but uses non-idiomatic char::from(10) for newlines and ASCII -> instead of the Unicode → used by adjacent messages. |
| crates/tui/src/tui/ui/tests.rs | New regression test covers the Arcee → XiaomiMimo split-state path, asserting in-memory config, on-disk config, and settings all agree on the switched provider; test structure and assertions look correct. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant TUI as TUI (switch_provider)
    participant Engine
    participant ConfigTOML as config.toml
    participant Settings as settings.json

    User->>TUI: /provider xiaomi-mimo
    TUI->>TUI: "Update in-memory Config & App state"
    TUI->>Engine: Op::Shutdown
    TUI->>Engine: spawn_engine (new provider)
    TUI->>Engine: Op::SyncSession / Op::SetCompaction

    note over TUI,Settings: Persistence closure (errors become a warning, never block the switch)
    TUI->>ConfigTOML: persist_root_string_key("provider", "xiaomi-mimo")
    alt write succeeds
        ConfigTOML-->>TUI: Ok(path)
        TUI->>Settings: Settings::load()
        Settings-->>TUI: settings
        TUI->>TUI: "settings.default_provider = "xiaomi-mimo""
        TUI->>Settings: settings.save()
        TUI->>User: "Provider switched: Arcee → XiaomiMimo" (no warning)
    else any step fails
        TUI->>User: "Provider switched … (not fully persisted)"
    end
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix-2663-provider-persist-config%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix-2663-provider-persist-config%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui.rs%3A5386-5389%0A%60char%3A%3Afrom%2810%29%60%20is%20a%20non-idiomatic%20way%20to%20express%20a%20newline%20in%20Rust%20and%20makes%20the%20intent%20harder%20to%20read%20at%20a%20glance.%20The%20idiomatic%20form%20is%20the%20%60'%0A'%60%20literal%2C%20which%20the%20rest%20of%20the%20codebase%20already%20uses%20in%20format%20strings.%0A%0A%60%60%60suggestion%0A%20%20%20%20switch_summary.push%28'%5Cn'%29%3B%0A%20%20%20%20switch_summary.push_str%28%26format!%28%22Model%3A%20%7B%7D%20-%3E%20%7B%7D%22%2C%20previous_model%2C%20new_model%29%29%3B%0A%20%20%20%20if%20let%20Some%28ref%20warning%29%20%3D%20persist_warning%20%7B%0A%20%20%20%20%20%20%20%20switch_summary.push%28'%5Cn'%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui.rs%3A5381-5387%0AThe%20adjacent%20model%2Fthinking%20change%20messages%20%28lines%205215%E2%80%935257%29%20consistently%20use%20the%20Unicode%20right%20arrow%20%60%E2%86%92%60%2C%20but%20the%20new%20provider-switch%20message%20uses%20the%20ASCII%20two-character%20sequence%20%60-%3E%60.%20The%20inconsistency%20is%20visible%20to%20users%20who%20see%20both%20types%20of%20messages%20in%20the%20same%20session.%0A%0A%60%60%60suggestion%0A%20%20%20%20let%20mut%20switch_summary%20%3D%20format!%28%0A%20%20%20%20%20%20%20%20%22Provider%20switched%3A%20%7B%7D%20%E2%86%92%20%7B%7D%22%2C%0A%20%20%20%20%20%20%20%20previous_provider.as_str%28%29%2C%0A%20%20%20%20%20%20%20%20target.as_str%28%29%2C%0A%20%20%20%20%29%3B%0A%20%20%20%20switch_summary.push%28'%5Cn'%29%3B%0A%20%20%20%20switch_summary.push_str%28%26format!%28%22Model%3A%20%7B%7D%20%E2%86%92%20%7B%7D%22%2C%20previous_model%2C%20new_model%29%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui.rs%3A5386-5389%0A%60char%3A%3Afrom%2810%29%60%20is%20a%20non-idiomatic%20way%20to%20express%20a%20newline%20in%20Rust%20and%20makes%20the%20intent%20harder%20to%20read%20at%20a%20glance.%20The%20idiomatic%20form%20is%20the%20%60'%0A'%60%20literal%2C%20which%20the%20rest%20of%20the%20codebase%20already%20uses%20in%20format%20strings.%0A%0A%60%60%60suggestion%0A%20%20%20%20switch_summary.push%28'%5Cn'%29%3B%0A%20%20%20%20switch_summary.push_str%28%26format!%28%22Model%3A%20%7B%7D%20-%3E%20%7B%7D%22%2C%20previous_model%2C%20new_model%29%29%3B%0A%20%20%20%20if%20let%20Some%28ref%20warning%29%20%3D%20persist_warning%20%7B%0A%20%20%20%20%20%20%20%20switch_summary.push%28'%5Cn'%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui.rs%3A5381-5387%0AThe%20adjacent%20model%2Fthinking%20change%20messages%20%28lines%205215%E2%80%935257%29%20consistently%20use%20the%20Unicode%20right%20arrow%20%60%E2%86%92%60%2C%20but%20the%20new%20provider-switch%20message%20uses%20the%20ASCII%20two-character%20sequence%20%60-%3E%60.%20The%20inconsistency%20is%20visible%20to%20users%20who%20see%20both%20types%20of%20messages%20in%20the%20same%20session.%0A%0A%60%60%60suggestion%0A%20%20%20%20let%20mut%20switch_summary%20%3D%20format!%28%0A%20%20%20%20%20%20%20%20%22Provider%20switched%3A%20%7B%7D%20%E2%86%92%20%7B%7D%22%2C%0A%20%20%20%20%20%20%20%20previous_provider.as_str%28%29%2C%0A%20%20%20%20%20%20%20%20target.as_str%28%29%2C%0A%20%20%20%20%29%3B%0A%20%20%20%20switch_summary.push%28'%5Cn'%29%3B%0A%20%20%20%20switch_summary.push_str%28%26format!%28%22Model%3A%20%7B%7D%20%E2%86%92%20%7B%7D%22%2C%20previous_model%2C%20new_model%29%29%3B%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2718&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui.rs%3A5386-5389%0A%60char%3A%3Afrom%2810%29%60%20is%20a%20non-idiomatic%20way%20to%20express%20a%20newline%20in%20Rust%20and%20makes%20the%20intent%20harder%20to%20read%20at%20a%20glance.%20The%20idiomatic%20form%20is%20the%20%60'%0A'%60%20literal%2C%20which%20the%20rest%20of%20the%20codebase%20already%20uses%20in%20format%20strings.%0A%0A%60%60%60suggestion%0A%20%20%20%20switch_summary.push%28'%5Cn'%29%3B%0A%20%20%20%20switch_summary.push_str%28%26format!%28%22Model%3A%20%7B%7D%20-%3E%20%7B%7D%22%2C%20previous_model%2C%20new_model%29%29%3B%0A%20%20%20%20if%20let%20Some%28ref%20warning%29%20%3D%20persist_warning%20%7B%0A%20%20%20%20%20%20%20%20switch_summary.push%28'%5Cn'%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fui.rs%3A5381-5387%0AThe%20adjacent%20model%2Fthinking%20change%20messages%20%28lines%205215%E2%80%935257%29%20consistently%20use%20the%20Unicode%20right%20arrow%20%60%E2%86%92%60%2C%20but%20the%20new%20provider-switch%20message%20uses%20the%20ASCII%20two-character%20sequence%20%60-%3E%60.%20The%20inconsistency%20is%20visible%20to%20users%20who%20see%20both%20types%20of%20messages%20in%20the%20same%20session.%0A%0A%60%60%60suggestion%0A%20%20%20%20let%20mut%20switch_summary%20%3D%20format!%28%0A%20%20%20%20%20%20%20%20%22Provider%20switched%3A%20%7B%7D%20%E2%86%92%20%7B%7D%22%2C%0A%20%20%20%20%20%20%20%20previous_provider.as_str%28%29%2C%0A%20%20%20%20%20%20%20%20target.as_str%28%29%2C%0A%20%20%20%20%29%3B%0A%20%20%20%20switch_summary.push%28'%5Cn'%29%3B%0A%20%20%20%20switch_summary.push_str%28%26format!%28%22Model%3A%20%7B%7D%20%E2%86%92%20%7B%7D%22%2C%20previous_model%2C%20new_model%29%29%3B%0A%60%60%60%0A%0A&pr=2718&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(tui): persist provider switches to c..."](https://github.com/hmbown/codewhale/commit/f0fdd2b27eca894a8c6cf74bd51d058b7a21c675) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35501497)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->