### PR TITLE
fix(settings): prefer canonical codewhale settings path

### DIFF
--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -5,7 +5,7 @@
 //! TUI-specific preferences (theme, keybinds, font_size) that survive project
 //! switches are stored separately in tui.toml. See [`TuiPrefs`].
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -364,43 +364,40 @@ impl Default for Settings {
 }
 
 impl Settings {
-    /// Get the settings file path
+    /// Get the canonical settings file path.
+    ///
+    /// New writes should target `~/.codewhale/settings.toml`. Legacy
+    /// DeepSeek-branded paths remain readable as fallbacks during load, but we
+    /// no longer surface them as the primary path in `/config`.
     pub fn path() -> Result<PathBuf> {
-        // Allow tests to override the settings directory via the same env var
-        // used for config (DEEPSEEK_CONFIG_PATH points at config.toml; the
-        // settings file lives as a sibling in the same directory).
-        if let Ok(config_path) = std::env::var("DEEPSEEK_CONFIG_PATH") {
-            let config_path = config_path.trim();
-            if !config_path.is_empty() {
-                let p = expand_path(config_path);
-                if let Some(parent) = p.parent() {
-                    return Ok(parent.join(SETTINGS_FILE_NAME));
-                }
-            }
-        }
-
-        let primary = codewhale_config::codewhale_home()
-            .ok()
-            .map(|home| home.join(SETTINGS_FILE_NAME));
-        let legacy_home = codewhale_config::legacy_deepseek_home()
-            .ok()
-            .map(|home| home.join(SETTINGS_FILE_NAME));
-        let legacy_config_dir =
-            dirs::config_dir().map(|dir| dir.join("deepseek").join(SETTINGS_FILE_NAME));
-
-        resolve_settings_path_from_candidates(primary, legacy_home, legacy_config_dir)
+        let (primary, _legacy_home, legacy_config_dir) = settings_path_candidates();
+        primary.or(legacy_config_dir).ok_or_else(|| {
+            anyhow::anyhow!("Failed to resolve settings path: no config directory found.")
+        })
     }
 
     /// Load settings from disk, or return defaults if not found
     pub fn load() -> Result<Self> {
-        let path = Self::path()?;
-        let mut settings = if !path.exists() {
+        let (primary, legacy_home, legacy_config_dir) = settings_path_candidates();
+        let write_path = primary
+            .as_ref()
+            .cloned()
+            .or_else(|| legacy_config_dir.clone())
+            .ok_or_else(|| {
+                anyhow::anyhow!("Failed to resolve settings path: no config directory found.")
+            })?;
+        let read_path =
+            resolve_settings_path_from_candidates(primary, legacy_home, legacy_config_dir)
+                .unwrap_or_else(|_| write_path.clone());
+
+        let mut settings = if !read_path.exists() {
             Self::default()
         } else {
-            let content = std::fs::read_to_string(&path)
-                .with_context(|| format!("Failed to read settings from {}", path.display()))?;
-            let mut s: Settings = toml::from_str(&content)
-                .with_context(|| format!("Failed to parse settings from {}", path.display()))?;
+            let content = std::fs::read_to_string(&read_path)
+                .with_context(|| format!("Failed to read settings from {}", read_path.display()))?;
+            let mut s: Settings = toml::from_str(&content).with_context(|| {
+                format!("Failed to parse settings from {}", read_path.display())
+            })?;
             s.default_mode = normalize_mode(&s.default_mode).to_string();
             s.composer_density = normalize_composer_density(&s.composer_density).to_string();
             s.transcript_spacing = normalize_transcript_spacing(&s.transcript_spacing).to_string();
@@ -420,6 +417,7 @@ impl Settings {
                 .and_then(|value| normalize_reasoning_effort_setting(value).ok().flatten());
             s
         };
+        migrate_settings_file_to_primary_if_needed(&write_path, &read_path);
         settings.apply_env_overrides();
         Ok(settings)
     }
@@ -427,7 +425,10 @@ impl Settings {
     /// Whether the user explicitly persisted an `auto_compact` preference.
     /// When absent, callers may choose a model-aware default.
     pub fn auto_compact_explicitly_configured() -> bool {
-        let Ok(path) = Self::path() else {
+        let (primary, legacy_home, legacy_config_dir) = settings_path_candidates();
+        let Ok(path) =
+            resolve_settings_path_from_candidates(primary, legacy_home, legacy_config_dir)
+        else {
             return false;
         };
         let Ok(content) = std::fs::read_to_string(path) else {
@@ -1012,6 +1013,58 @@ fn resolve_settings_path_from_candidates(
     primary.or(legacy_config_dir).ok_or_else(|| {
         anyhow::anyhow!("Failed to resolve settings path: no config directory found.")
     })
+}
+
+fn settings_path_candidates() -> (Option<PathBuf>, Option<PathBuf>, Option<PathBuf>) {
+    // Allow tests to override the settings directory via the same env var
+    // used for config (DEEPSEEK_CONFIG_PATH points at config.toml; the
+    // settings file lives as a sibling in the same directory).
+    if let Ok(config_path) = std::env::var("DEEPSEEK_CONFIG_PATH") {
+        let config_path = config_path.trim();
+        if !config_path.is_empty() {
+            let p = expand_path(config_path);
+            if let Some(parent) = p.parent() {
+                return (Some(parent.join(SETTINGS_FILE_NAME)), None, None);
+            }
+        }
+    }
+
+    let primary = codewhale_config::codewhale_home()
+        .ok()
+        .map(|home| home.join(SETTINGS_FILE_NAME));
+    let legacy_home = codewhale_config::legacy_deepseek_home()
+        .ok()
+        .map(|home| home.join(SETTINGS_FILE_NAME));
+    let legacy_config_dir =
+        dirs::config_dir().map(|dir| dir.join("deepseek").join(SETTINGS_FILE_NAME));
+
+    (primary, legacy_home, legacy_config_dir)
+}
+
+fn migrate_settings_file_to_primary_if_needed(primary: &Path, active_read_path: &Path) {
+    if primary == active_read_path || primary.exists() || !active_read_path.exists() {
+        return;
+    }
+
+    let Some(parent) = primary.parent() else {
+        return;
+    };
+
+    if let Err(err) = std::fs::create_dir_all(parent) {
+        tracing::warn!(
+            "failed to create settings migration directory {}: {err}",
+            parent.display()
+        );
+        return;
+    }
+
+    if let Err(err) = std::fs::copy(active_read_path, primary) {
+        tracing::warn!(
+            "failed to migrate settings from {} to {}: {err}",
+            active_read_path.display(),
+            primary.display()
+        );
+    }
 }
 
 fn normalize_default_model(value: &str) -> Option<String> {
@@ -2329,69 +2382,75 @@ mod tests {
     }
 
     #[test]
-    fn settings_path_reads_legacy_deepseek_home_when_present() {
+    fn settings_path_prefers_codewhale_home_even_when_legacy_exists() {
+        let _g = config_path_test_guard();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let legacy_dir = tmp.path().join(".deepseek");
+        std::fs::create_dir_all(&legacy_dir).expect("legacy dir");
+        std::fs::write(legacy_dir.join("settings.toml"), "low_motion = true\n")
+            .expect("legacy settings");
+        let _config_override = EnvVarRestore::remove("DEEPSEEK_CONFIG_PATH");
+        let _codewhale_home = EnvVarRestore::set("CODEWHALE_HOME", tmp.path().join(".codewhale"));
+        let _home = EnvVarRestore::set("HOME", tmp.path());
+
+        let got = Settings::path().expect("settings path");
+
+        assert_eq!(got, tmp.path().join(".codewhale").join("settings.toml"));
+    }
+
+    #[test]
+    fn settings_load_migrates_legacy_deepseek_home_into_codewhale_home() {
         let _g = config_path_test_guard();
         let tmp = tempfile::tempdir().expect("tempdir");
         let primary = tmp.path().join(".codewhale").join("settings.toml");
         let legacy_dir = tmp.path().join(".deepseek");
-        std::fs::create_dir_all(&legacy_dir).expect("legacy dir");
         let legacy_home = legacy_dir.join("settings.toml");
+        std::fs::create_dir_all(&legacy_dir).expect("legacy dir");
         std::fs::write(&legacy_home, "low_motion = true\n").expect("legacy settings");
-        let legacy_config_dir = tmp
-            .path()
-            .join("platform-config")
-            .join("deepseek")
-            .join("settings.toml");
-        std::fs::create_dir_all(legacy_config_dir.parent().expect("parent"))
-            .expect("legacy config dir");
-        std::fs::write(&legacy_config_dir, "low_motion = false\n")
-            .expect("platform legacy settings");
+        let _config_override = EnvVarRestore::remove("DEEPSEEK_CONFIG_PATH");
+        let _codewhale_home = EnvVarRestore::set("CODEWHALE_HOME", tmp.path().join(".codewhale"));
+        let _home = EnvVarRestore::set("HOME", tmp.path());
 
-        let got = resolve_settings_path_from_candidates(
-            Some(primary),
-            Some(legacy_home.clone()),
-            Some(legacy_config_dir),
-        )
-        .expect("settings path");
+        let loaded = Settings::load().expect("load settings");
 
-        assert_eq!(got, legacy_home);
+        assert!(loaded.low_motion, "legacy settings should still be read");
+        assert!(
+            primary.exists(),
+            "settings load should migrate to primary path"
+        );
+        let display = loaded.display(crate::localization::Locale::En);
+        assert!(
+            display.contains(&format!("Config file: {}", primary.display())),
+            "settings display should surface the canonical codewhale path:\n{display}"
+        );
     }
 
     #[test]
-    fn settings_path_keeps_platform_config_dir_as_last_legacy_fallback() {
+    fn settings_load_migrates_platform_legacy_fallback_into_codewhale_home() {
         let _g = config_path_test_guard();
         let tmp = tempfile::tempdir().expect("tempdir");
         let primary = tmp.path().join(".codewhale").join("settings.toml");
-        let legacy_home = tmp.path().join(".deepseek").join("settings.toml");
-        let legacy_config_dir = tmp
-            .path()
-            .join("platform-config")
+        let _config_override = EnvVarRestore::remove("DEEPSEEK_CONFIG_PATH");
+        let _codewhale_home = EnvVarRestore::set("CODEWHALE_HOME", tmp.path().join(".codewhale"));
+        let _home = EnvVarRestore::set("HOME", tmp.path());
+        let _xdg = EnvVarRestore::set("XDG_CONFIG_HOME", tmp.path().join("platform-config"));
+        #[cfg(windows)]
+        let _appdata = EnvVarRestore::set("APPDATA", tmp.path().join("platform-config"));
+        let legacy_config_dir = dirs::config_dir()
+            .expect("config dir")
             .join("deepseek")
             .join("settings.toml");
         std::fs::create_dir_all(legacy_config_dir.parent().expect("parent"))
             .expect("legacy config dir");
         std::fs::write(&legacy_config_dir, "low_motion = true\n").expect("legacy settings");
 
-        let got = resolve_settings_path_from_candidates(
-            Some(primary),
-            Some(legacy_home),
-            Some(legacy_config_dir.clone()),
-        )
-        .expect("settings path");
+        let loaded = Settings::load().expect("load settings");
 
-        assert_eq!(got, legacy_config_dir);
-    }
-
-    #[test]
-    fn settings_path_uses_primary_when_platform_config_dir_is_unavailable() {
-        let _g = config_path_test_guard();
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let primary = tmp.path().join(".codewhale").join("settings.toml");
-
-        let got = resolve_settings_path_from_candidates(Some(primary.clone()), None, None)
-            .expect("settings path");
-
-        assert_eq!(got, primary);
+        assert!(loaded.low_motion, "legacy settings should still be read");
+        assert!(
+            primary.exists(),
+            "legacy fallback should be copied into primary"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- keep `/config` and other settings surfaces pointed at the canonical `~/.codewhale/settings.toml` path
- continue reading legacy DeepSeek-branded settings paths as fallbacks, then copy them into the CodeWhale home on load
- add regression tests covering legacy-home and platform-config fallback migration

## Testing
- cargo fmt --all
- cargo test -p codewhale-tui --bin codewhale-tui settings_ -- --nocapture
- cargo test -p codewhale-tui --bin codewhale-tui display_localizes_header_and_config_file_label -- --nocapture

Closes #2664.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refactors `Settings::path()` to always return the canonical `~/.codewhale/settings.toml` path for display and writes, while preserving backward-compatible reading from legacy DeepSeek-branded locations (`~/.deepseek/` and the platform `config_dir/deepseek/`). A new `migrate_settings_file_to_primary_if_needed` helper silently copies any legacy settings file into the canonical home on the first `load()`.

- **`settings_path_candidates()`** extracts the shared logic for building the three candidate paths, replacing duplicated env-var and directory-resolution code that was scattered across `path()`, `load()`, and `auto_compact_explicitly_configured()`.
- **`Settings::path()`** now skips `legacy_home` entirely, returning `primary` (or `legacy_config_dir` when `codewhale_home()` fails) so the `/config` surface always advertises the canonical write target.
- **Migration** is performed inside `load()` after a successful read: if settings were read from any legacy location and the primary path doesn't yet exist, the raw file is copied to `~/.codewhale/settings.toml`, with failures degraded to `tracing::warn` so a transient I/O error cannot crash the TUI.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the refactor is narrowly scoped to path resolution and the migration helper, with no changes to how settings are parsed, normalized, or persisted beyond directing writes to the canonical location.

The logic in settings_path_candidates, Settings::path, and migrate_settings_file_to_primary_if_needed is internally consistent: reads still fall through all three candidate locations in priority order, writes always target the canonical path, and migration is gated on the primary not yet existing so it cannot overwrite user-intentional edits. Migration failures are soft-degraded to warnings rather than propagated as errors, which is appropriate for a first-run copy.

No files require special attention beyond the single note on the platform-config migration test.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/settings.rs | Core settings path and migration logic refactored; new helpers `settings_path_candidates()` and `migrate_settings_file_to_primary_if_needed()` extracted; tests updated to exercise `Settings::load()` end-to-end for both legacy-home and platform-config migration paths. |

</details>

</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22cw2664%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cw2664%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fsettings.rs%3A2449-2454%0A**Missing%20display%20assertion%20in%20platform-config%20migration%20test**%0A%0AThe%20%60legacy_home%60%20migration%20test%20verifies%20that%20%60settings.display%28%29%60%20surfaces%20the%20canonical%20path%2C%20but%20this%20test%20does%20not.%20After%20%60Settings%3A%3Aload%28%29%60%20migrates%20%60legacy_config_dir%60%20to%20%60primary%60%2C%20%60Settings%3A%3Apath%28%29%60%20%28and%20therefore%20%60display%28%29%60%29%20should%20advertise%20%60primary%60.%20Without%20the%20assertion%20the%20test%20would%20pass%20even%20if%20%60display%28%29%60%20still%20showed%20the%20legacy%20%60deepseek%60%20directory.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20assert!%28loaded.low_motion%2C%20%22legacy%20settings%20should%20still%20be%20read%22%29%3B%0A%20%20%20%20%20%20%20%20assert!%28%0A%20%20%20%20%20%20%20%20%20%20%20%20primary.exists%28%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22legacy%20fallback%20should%20be%20copied%20into%20primary%22%0A%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%20%20let%20display%20%3D%20loaded.display%28crate%3A%3Alocalization%3A%3ALocale%3A%3AEn%29%3B%0A%20%20%20%20%20%20%20%20assert!%28%0A%20%20%20%20%20%20%20%20%20%20%20%20display.contains%28%26format!%28%22Config%20file%3A%20%7B%7D%22%2C%20primary.display%28%29%29%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22settings%20display%20should%20surface%20the%20canonical%20codewhale%20path%3A%5Cn%7Bdisplay%7D%22%0A%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fsettings.rs%3A2449-2454%0A**Missing%20display%20assertion%20in%20platform-config%20migration%20test**%0A%0AThe%20%60legacy_home%60%20migration%20test%20verifies%20that%20%60settings.display%28%29%60%20surfaces%20the%20canonical%20path%2C%20but%20this%20test%20does%20not.%20After%20%60Settings%3A%3Aload%28%29%60%20migrates%20%60legacy_config_dir%60%20to%20%60primary%60%2C%20%60Settings%3A%3Apath%28%29%60%20%28and%20therefore%20%60display%28%29%60%29%20should%20advertise%20%60primary%60.%20Without%20the%20assertion%20the%20test%20would%20pass%20even%20if%20%60display%28%29%60%20still%20showed%20the%20legacy%20%60deepseek%60%20directory.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20assert!%28loaded.low_motion%2C%20%22legacy%20settings%20should%20still%20be%20read%22%29%3B%0A%20%20%20%20%20%20%20%20assert!%28%0A%20%20%20%20%20%20%20%20%20%20%20%20primary.exists%28%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22legacy%20fallback%20should%20be%20copied%20into%20primary%22%0A%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%20%20let%20display%20%3D%20loaded.display%28crate%3A%3Alocalization%3A%3ALocale%3A%3AEn%29%3B%0A%20%20%20%20%20%20%20%20assert!%28%0A%20%20%20%20%20%20%20%20%20%20%20%20display.contains%28%26format!%28%22Config%20file%3A%20%7B%7D%22%2C%20primary.display%28%29%29%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22settings%20display%20should%20surface%20the%20canonical%20codewhale%20path%3A%5Cn%7Bdisplay%7D%22%0A%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2730&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Fsettings.rs%3A2449-2454%0A**Missing%20display%20assertion%20in%20platform-config%20migration%20test**%0A%0AThe%20%60legacy_home%60%20migration%20test%20verifies%20that%20%60settings.display%28%29%60%20surfaces%20the%20canonical%20path%2C%20but%20this%20test%20does%20not.%20After%20%60Settings%3A%3Aload%28%29%60%20migrates%20%60legacy_config_dir%60%20to%20%60primary%60%2C%20%60Settings%3A%3Apath%28%29%60%20%28and%20therefore%20%60display%28%29%60%29%20should%20advertise%20%60primary%60.%20Without%20the%20assertion%20the%20test%20would%20pass%20even%20if%20%60display%28%29%60%20still%20showed%20the%20legacy%20%60deepseek%60%20directory.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20assert!%28loaded.low_motion%2C%20%22legacy%20settings%20should%20still%20be%20read%22%29%3B%0A%20%20%20%20%20%20%20%20assert!%28%0A%20%20%20%20%20%20%20%20%20%20%20%20primary.exists%28%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22legacy%20fallback%20should%20be%20copied%20into%20primary%22%0A%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%20%20let%20display%20%3D%20loaded.display%28crate%3A%3Alocalization%3A%3ALocale%3A%3AEn%29%3B%0A%20%20%20%20%20%20%20%20assert!%28%0A%20%20%20%20%20%20%20%20%20%20%20%20display.contains%28%26format!%28%22Config%20file%3A%20%7B%7D%22%2C%20primary.display%28%29%29%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22settings%20display%20should%20surface%20the%20canonical%20codewhale%20path%3A%5Cn%7Bdisplay%7D%22%0A%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%7D%0A%60%60%60%0A%0A&pr=2730&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix(settings): tighten legacy path migra..."](https://github.com/hmbown/codewhale/commit/d041425797ad5c28150b97ee474df5e30af2f5cd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35514437)</sub>

<!-- /greptile_comment -->