### PR TITLE
feat(plan): richer PlanArtifact schema for v0.9.0 (#2691)

### DIFF
--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -1171,6 +1171,7 @@ mod tests {
                     step: "keep checklist primary".to_string(),
                     status: StepStatus::InProgress,
                 }],
+                ..Default::default()
             });
         }
 

--- a/crates/tui/src/prompts/modes/plan.md
+++ b/crates/tui/src/prompts/modes/plan.md
@@ -8,6 +8,22 @@ the final plan; that is the handoff signal that lets the UI show the accept / re
 All writes and patches are blocked — you can read the world but you
 can't change it. Shell and code execution are unavailable.
 
+Produce a grounded plan artifact through `update_plan`, not just a step list. Include what you
+discovered during investigation so the user can make an informed decision:
+
+- `title` — short summary
+- `objective` — what this plan aims to achieve
+- `context_summary` — what you found during investigation
+- `sources_used` — files, docs, commands, or sub-agents consulted
+- `constraints` — user rules, repo constitution, mode limits, safety constraints
+- `recommended_approach` — high-level approach and rationale
+- `plan` — ordered execution steps with statuses (required)
+- `verification_plan` — how to verify correctness
+- `risks_and_unknowns` — known risks, assumptions, open questions
+- `handoff_packet` — compact summary for Agent-mode execution
+
+All fields except `plan` are optional — only include what you actually discovered.
+
 Use this mode to build a thorough plan. Spawn read-only sub-agents for parallel investigation.
 After `update_plan` presents the plan, wait for the user's next action instead of continuing to
 tool around in Plan mode.

--- a/crates/tui/src/tools/plan.rs
+++ b/crates/tui/src/tools/plan.rs
@@ -84,6 +84,14 @@ pub struct UpdatePlanArgs {
     pub explanation: Option<String>,
 }
 
+/// Discriminant for plan artifacts serialised into the transcript.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PlanKind {
+    /// Standard `update_plan` outcome (plan mode, hunt protocol, etc.).
+    Update,
+}
+
 // === Plan State ===
 
 /// A plan step with timing information
@@ -140,6 +148,7 @@ impl PlanStep {
 /// Serializable snapshot for display
 #[derive(Debug, Clone, Serialize)]
 pub struct PlanSnapshot {
+    pub kind: PlanKind,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -193,6 +202,11 @@ impl PlanState {
                 .as_deref()
                 .unwrap_or("")
                 .is_empty()
+            && self.verification_plan.as_deref().unwrap_or("").is_empty()
+            && self.risks_and_unknowns.as_deref().unwrap_or("").is_empty()
+            && self.handoff_packet.as_deref().unwrap_or("").is_empty()
+            && self.sources_used.is_empty()
+            && self.constraints.is_empty()
     }
 
     pub fn update(&mut self, args: UpdatePlanArgs) {
@@ -255,6 +269,7 @@ impl PlanState {
 
     pub fn snapshot(&self) -> PlanSnapshot {
         PlanSnapshot {
+            kind: PlanKind::Update,
             title: self.title.clone(),
             objective: self.objective.clone(),
             context_summary: self.context_summary.clone(),
@@ -498,7 +513,18 @@ impl ToolSpec for UpdatePlanTool {
                     "description": "Optional high-level explanation (legacy, prefer recommended_approach)"
                 }
             },
-            "required": ["plan"]
+            "required": [
+                "title",
+                "objective",
+                "context_summary",
+                "sources_used",
+                "constraints",
+                "recommended_approach",
+                "plan",
+                "verification_plan",
+                "risks_and_unknowns",
+                "handoff_packet"
+            ]
         })
     }
 

--- a/crates/tui/src/tools/plan.rs
+++ b/crates/tui/src/tools/plan.rs
@@ -54,11 +54,34 @@ pub struct PlanItemArg {
 }
 
 /// Update payload used by the plan tool.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// Backward-compatible: legacy callers that only send `plan` + optional
+/// `explanation` still work. New v0.9.0 fields are all `Option` and
+/// default to `None` / empty.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct UpdatePlanArgs {
     #[serde(default)]
-    pub explanation: Option<String>,
+    pub title: Option<String>,
+    #[serde(default)]
+    pub objective: Option<String>,
+    #[serde(default)]
+    pub context_summary: Option<String>,
+    #[serde(default)]
+    pub sources_used: Vec<String>,
+    #[serde(default)]
+    pub constraints: Vec<String>,
+    #[serde(default)]
+    pub recommended_approach: Option<String>,
+    #[serde(default)]
     pub plan: Vec<PlanItemArg>,
+    #[serde(default)]
+    pub verification_plan: Option<String>,
+    #[serde(default)]
+    pub risks_and_unknowns: Option<String>,
+    #[serde(default)]
+    pub handoff_packet: Option<String>,
+    #[serde(default)]
+    pub explanation: Option<String>,
 }
 
 // === Plan State ===
@@ -117,25 +140,71 @@ impl PlanStep {
 /// Serializable snapshot for display
 #[derive(Debug, Clone, Serialize)]
 pub struct PlanSnapshot {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub objective: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_summary: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub sources_used: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub constraints: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recommended_approach: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub explanation: Option<String>,
     pub items: Vec<PlanItemArg>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verification_plan: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub risks_and_unknowns: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub handoff_packet: Option<String>,
 }
 
 /// State tracking for the current plan
 #[derive(Debug, Clone, Default)]
 pub struct PlanState {
-    explanation: Option<String>,
+    title: Option<String>,
+    objective: Option<String>,
+    context_summary: Option<String>,
+    sources_used: Vec<String>,
+    constraints: Vec<String>,
+    recommended_approach: Option<String>,
     steps: Vec<PlanStep>,
+    verification_plan: Option<String>,
+    risks_and_unknowns: Option<String>,
+    handoff_packet: Option<String>,
+    explanation: Option<String>,
 }
 
 impl PlanState {
     /// Check whether the plan is empty.
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.steps.is_empty() && self.explanation.as_deref().unwrap_or("").is_empty()
+        self.steps.is_empty()
+            && self.explanation.as_deref().unwrap_or("").is_empty()
+            && self.title.as_deref().unwrap_or("").is_empty()
+            && self.objective.as_deref().unwrap_or("").is_empty()
+            && self.context_summary.as_deref().unwrap_or("").is_empty()
+            && self
+                .recommended_approach
+                .as_deref()
+                .unwrap_or("")
+                .is_empty()
     }
 
     pub fn update(&mut self, args: UpdatePlanArgs) {
+        self.title = args.title.filter(|s| !s.trim().is_empty());
+        self.objective = args.objective.filter(|s| !s.trim().is_empty());
+        self.context_summary = args.context_summary.filter(|s| !s.trim().is_empty());
+        self.sources_used = args.sources_used;
+        self.constraints = args.constraints;
+        self.recommended_approach = args.recommended_approach.filter(|s| !s.trim().is_empty());
+        self.verification_plan = args.verification_plan.filter(|s| !s.trim().is_empty());
+        self.risks_and_unknowns = args.risks_and_unknowns.filter(|s| !s.trim().is_empty());
+        self.handoff_packet = args.handoff_packet.filter(|s| !s.trim().is_empty());
         self.explanation = args.explanation.filter(|s| !s.trim().is_empty());
 
         let now = Instant::now();
@@ -186,6 +255,12 @@ impl PlanState {
 
     pub fn snapshot(&self) -> PlanSnapshot {
         PlanSnapshot {
+            title: self.title.clone(),
+            objective: self.objective.clone(),
+            context_summary: self.context_summary.clone(),
+            sources_used: self.sources_used.clone(),
+            constraints: self.constraints.clone(),
+            recommended_approach: self.recommended_approach.clone(),
             explanation: self.explanation.clone(),
             items: self
                 .steps
@@ -195,7 +270,40 @@ impl PlanState {
                     status: s.status.clone(),
                 })
                 .collect(),
+            verification_plan: self.verification_plan.clone(),
+            risks_and_unknowns: self.risks_and_unknowns.clone(),
+            handoff_packet: self.handoff_packet.clone(),
         }
+    }
+
+    #[allow(dead_code)]
+    pub fn title(&self) -> Option<&str> {
+        self.title.as_deref()
+    }
+
+    #[allow(dead_code)]
+    pub fn objective(&self) -> Option<&str> {
+        self.objective.as_deref()
+    }
+
+    #[allow(dead_code)]
+    pub fn context_summary(&self) -> Option<&str> {
+        self.context_summary.as_deref()
+    }
+
+    #[allow(dead_code)]
+    pub fn sources_used(&self) -> &[String] {
+        &self.sources_used
+    }
+
+    #[allow(dead_code)]
+    pub fn constraints(&self) -> &[String] {
+        &self.constraints
+    }
+
+    #[allow(dead_code)]
+    pub fn recommended_approach(&self) -> Option<&str> {
+        self.recommended_approach.as_deref()
     }
 
     pub fn explanation(&self) -> Option<&str> {
@@ -204,6 +312,21 @@ impl PlanState {
 
     pub fn steps(&self) -> &[PlanStep] {
         &self.steps
+    }
+
+    #[allow(dead_code)]
+    pub fn verification_plan(&self) -> Option<&str> {
+        self.verification_plan.as_deref()
+    }
+
+    #[allow(dead_code)]
+    pub fn risks_and_unknowns(&self) -> Option<&str> {
+        self.risks_and_unknowns.as_deref()
+    }
+
+    #[allow(dead_code)]
+    pub fn handoff_packet(&self) -> Option<&str> {
+        self.handoff_packet.as_deref()
     }
 
     /// Get counts of steps by status
@@ -306,20 +429,42 @@ impl ToolSpec for UpdatePlanTool {
     }
 
     fn description(&self) -> &'static str {
-        "Update optional high-level strategy metadata for complex initiatives. Use checklist_write for primary Work progress; update_plan should capture phase-level approach changes, not duplicate checklist items. Each strategy step has a description and status (pending, in_progress, completed). Optionally include an explanation of the overall approach."
+        "Publish a structured implementation plan as a reviewable artifact. Include the investigation findings (sources, constraints, risks) so the user can make an informed decision. All fields except `plan` are optional — only provide what you actually discovered."
     }
 
     fn input_schema(&self) -> serde_json::Value {
         json!({
             "type": "object",
             "properties": {
-                "explanation": {
+                "title": {
                     "type": "string",
-                    "description": "Optional high-level explanation of the plan or approach"
+                    "description": "Short title summarizing the plan"
+                },
+                "objective": {
+                    "type": "string",
+                    "description": "What this plan aims to achieve"
+                },
+                "context_summary": {
+                    "type": "string",
+                    "description": "Brief summary of the investigation context"
+                },
+                "sources_used": {
+                    "type": "array",
+                    "description": "Files, docs, commands, or sub-agents consulted",
+                    "items": { "type": "string" }
+                },
+                "constraints": {
+                    "type": "array",
+                    "description": "User rules, repo constitution, mode limits, safety constraints",
+                    "items": { "type": "string" }
+                },
+                "recommended_approach": {
+                    "type": "string",
+                    "description": "High-level approach and rationale"
                 },
                 "plan": {
                     "type": "array",
-                    "description": "List of plan steps",
+                    "description": "Ordered execution steps",
                     "items": {
                         "type": "object",
                         "properties": {
@@ -335,6 +480,22 @@ impl ToolSpec for UpdatePlanTool {
                         },
                         "required": ["step", "status"]
                     }
+                },
+                "verification_plan": {
+                    "type": "string",
+                    "description": "How to verify the plan was executed correctly"
+                },
+                "risks_and_unknowns": {
+                    "type": "string",
+                    "description": "Known risks, assumptions, and open questions"
+                },
+                "handoff_packet": {
+                    "type": "string",
+                    "description": "Compact execution-ready summary for handoff to Agent mode"
+                },
+                "explanation": {
+                    "type": "string",
+                    "description": "Optional high-level explanation (legacy, prefer recommended_approach)"
                 }
             },
             "required": ["plan"]
@@ -354,10 +515,23 @@ impl ToolSpec for UpdatePlanTool {
         input: serde_json::Value,
         _context: &ToolContext,
     ) -> Result<ToolResult, ToolError> {
-        let explanation = input
-            .get("explanation")
-            .and_then(|v| v.as_str())
-            .map(std::string::ToString::to_string);
+        let opt_str = |key: &str| -> Option<String> {
+            input
+                .get(key)
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+        };
+        let opt_strs = |key: &str| -> Vec<String> {
+            input
+                .get(key)
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                        .collect()
+                })
+                .unwrap_or_default()
+        };
 
         let plan_items = input
             .get("plan")
@@ -385,8 +559,17 @@ impl ToolSpec for UpdatePlanTool {
         }
 
         let args = UpdatePlanArgs {
-            explanation,
+            title: opt_str("title"),
+            objective: opt_str("objective"),
+            context_summary: opt_str("context_summary"),
+            sources_used: opt_strs("sources_used"),
+            constraints: opt_strs("constraints"),
+            recommended_approach: opt_str("recommended_approach"),
             plan: plan_args,
+            verification_plan: opt_str("verification_plan"),
+            risks_and_unknowns: opt_str("risks_and_unknowns"),
+            handoff_packet: opt_str("handoff_packet"),
+            explanation: opt_str("explanation"),
         };
 
         let mut state = self.plan_state.lock().await;
@@ -402,5 +585,119 @@ impl ToolSpec for UpdatePlanTool {
         Ok(ToolResult::success(format!(
             "Plan updated: {pending} pending, {in_progress} in progress, {completed} completed ({progress}% done)\n{result}"
         )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_update_plan_still_works() {
+        let mut state = PlanState::default();
+        state.update(UpdatePlanArgs {
+            explanation: Some("legacy plan".into()),
+            plan: vec![PlanItemArg {
+                step: "step one".into(),
+                status: StepStatus::Pending,
+            }],
+            ..Default::default()
+        });
+        assert_eq!(state.explanation(), Some("legacy plan"));
+        assert_eq!(state.steps().len(), 1);
+        assert!(state.title().is_none());
+    }
+
+    #[test]
+    fn full_artifact_fields_parsed_and_stored() {
+        let mut state = PlanState::default();
+        state.update(UpdatePlanArgs {
+            title: Some("Test Plan".into()),
+            objective: Some("Test objective".into()),
+            context_summary: Some("Investigated X".into()),
+            sources_used: vec!["file_a.rs".into(), "docs/guide.md".into()],
+            constraints: vec!["no shell access".into()],
+            recommended_approach: Some("Use incremental refactor".into()),
+            plan: vec![PlanItemArg {
+                step: "step one".into(),
+                status: StepStatus::InProgress,
+            }],
+            verification_plan: Some("Run tests".into()),
+            risks_and_unknowns: Some("Might break old API".into()),
+            handoff_packet: Some("Compact summary".into()),
+            ..Default::default()
+        });
+
+        assert_eq!(state.title(), Some("Test Plan"));
+        assert_eq!(state.objective(), Some("Test objective"));
+        assert_eq!(state.context_summary(), Some("Investigated X"));
+        assert_eq!(state.sources_used(), &["file_a.rs", "docs/guide.md"]);
+        assert_eq!(state.constraints(), &["no shell access"]);
+        assert_eq!(
+            state.recommended_approach(),
+            Some("Use incremental refactor")
+        );
+        assert_eq!(state.steps().len(), 1);
+        assert_eq!(state.verification_plan(), Some("Run tests"));
+        assert_eq!(state.risks_and_unknowns(), Some("Might break old API"));
+        assert_eq!(state.handoff_packet(), Some("Compact summary"));
+    }
+
+    #[test]
+    fn snapshot_skips_empty_fields() {
+        let mut state = PlanState::default();
+        state.update(UpdatePlanArgs {
+            plan: vec![PlanItemArg {
+                step: "only step".into(),
+                status: StepStatus::Completed,
+            }],
+            ..Default::default()
+        });
+
+        let snapshot = state.snapshot();
+        let json = serde_json::to_string(&snapshot).unwrap();
+        // Verify that only non-empty fields appear.
+        assert!(json.contains("\"items\""));
+        assert!(json.contains("\"step\""));
+        // Empty/Optional fields should be absent.
+        assert!(!json.contains("\"title\""));
+        assert!(!json.contains("\"sources_used\""));
+    }
+
+    #[test]
+    fn snapshot_includes_new_fields_when_present() {
+        let mut state = PlanState::default();
+        state.update(UpdatePlanArgs {
+            title: Some("Rich Plan".into()),
+            verification_plan: Some("Verify with CI".into()),
+            plan: vec![],
+            ..Default::default()
+        });
+
+        let snapshot = state.snapshot();
+        let json = serde_json::to_string(&snapshot).unwrap();
+        assert!(json.contains("\"title\""));
+        assert!(json.contains("Rich Plan"));
+        assert!(json.contains("\"verification_plan\""));
+    }
+
+    #[test]
+    fn is_empty_respects_new_fields() {
+        let mut state = PlanState::default();
+        assert!(state.is_empty());
+
+        state.update(UpdatePlanArgs {
+            title: Some("Non-empty".into()),
+            ..Default::default()
+        });
+        assert!(!state.is_empty(), "title should make plan non-empty");
+    }
+
+    #[test]
+    fn default_update_plan_args_is_usable() {
+        let args = UpdatePlanArgs::default();
+        assert!(args.plan.is_empty());
+        assert!(args.title.is_none());
+        assert!(args.sources_used.is_empty());
     }
 }

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -5918,6 +5918,7 @@ mod tests {
                     step: "step 1".to_string(),
                     status: StepStatus::InProgress,
                 }],
+                ..Default::default()
             });
             assert!(!plan.is_empty());
         }


### PR DESCRIPTION
Extend `update_plan` and `PlanState` with structured fields so Plan mode produces a grounded, reviewable artifact instead of just a step list. Backward-compatible: legacy callers sending only `plan` + `explanation` still work.

New fields (all optional, all default to None/empty):
- `title`, `objective`, `context_summary`
- `sources_used`, `constraints` (Vec<String>)
- `recommended_approach`
- `verification_plan`, `risks_and_unknowns`
- `handoff_packet`

Changes:
- `crates/tui/src/tools/plan.rs`:
  - Extend `UpdatePlanArgs` with 9 new optional fields + Default derive
  - Extend `PlanState` to store all new fields
  - Extend `PlanSnapshot` with skip-serializing-when-empty annotations
  - Add accessor methods for all fields
  - Update tool schema, description, and execute to parse new fields
  - 6 new unit tests covering legacy compat, full artifact parse, snapshot serialization, is_empty, and Default
- `crates/tui/src/prompts/modes/plan.md`:
  - Prompt now asks for grounded artifact fields
- `crates/tui/src/tui/app.rs`, `crates/tui/src/commands/mod.rs`:
  - Update test struct literals with `..Default::default()`

Closes #2691

## Summary

## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends `update_plan` and `PlanState` with nine new optional fields (`title`, `objective`, `context_summary`, `sources_used`, `constraints`, `recommended_approach`, `verification_plan`, `risks_and_unknowns`, `handoff_packet`) to produce a richer, reviewable plan artifact instead of just a step list.

- `plan.rs`: `UpdatePlanArgs`, `PlanState`, and `PlanSnapshot` are all extended with the new fields; `is_empty()`, `update()`, `snapshot()`, and the accessor methods are correctly updated; six new unit tests cover legacy compat, full artifact parsing, snapshot serialization, and `Default`.
- `plan.md`: Prompt is updated to describe the new fields and correctly marks all but `plan` as optional.
- `commands/mod.rs` and `app.rs`: Test struct literals are updated with `..Default::default()` to compile against the expanded struct.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after fixing the required-fields mismatch in the JSON schema.

The input_schema() declares all nine new fields as required, but both the tool description and plan.md state they are optional, and the execute path treats them as optional. A model strictly following the schema will feel compelled to populate every field on every invocation rather than including only what was discovered, defeating the design intent and breaking the stated legacy compatibility path.

crates/tui/src/tools/plan.rs — the required array in input_schema() needs to be reduced to ["plan"].
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/tui/src/tools/plan.rs | Core plan schema extension: adds 9 new optional fields to UpdatePlanArgs, PlanState, and PlanSnapshot. is_empty() and snapshot() are correctly updated, but input_schema() lists all new fields as required, contradicting the tool description and plan.md which both say these fields are optional. |
| crates/tui/src/prompts/modes/plan.md | Prompt updated to describe all new plan artifact fields; correctly states all fields except plan are optional. |
| crates/tui/src/commands/mod.rs | Test struct literal updated with ..Default::default() for backward compatibility; the /status output block still only reads explanation and items, silently dropping the new fields. |
| crates/tui/src/tui/app.rs | Test struct literal updated with ..Default::default() — minimal mechanical change, no issues. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[LLM calls update_plan] --> B{Schema required check}
    B -->|Schema lists ALL 10 fields as required| C[LLM populates every field]
    B -->|Description and plan.md say only plan is required| D[LLM includes only discovered fields]
    C --> E[execute: opt_str / opt_strs parse input]
    D --> E
    E --> F[UpdatePlanArgs all new fields are Option or Vec]
    F --> G[PlanState.update]
    G --> H[Optional string fields stored as Option]
    G --> I[sources_used and constraints stored as Vec]
    H --> J[PlanState.snapshot]
    I --> J
    J --> K[PlanSnapshot with skip_serializing_if annotations]
    K --> L[Sidebar display]
    K --> M[status command only reads explanation and items]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/tui/src/commands/mod.rs`, line 855-865 ([link](https://github.com/hmbown/codewhale/blob/544b2f04800b14978e435fda04567b3c62bb1a6d/crates/tui/src/commands/mod.rs#L855-L865)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Status dump not updated for new plan fields**

   This block still only reads `snapshot.explanation` and `snapshot.items`. The new fields (`title`, `objective`, `sources_used`, `constraints`, `recommended_approach`, `verification_plan`, `risks_and_unknowns`, `handoff_packet`) are silently dropped when this status output is produced. If the status command is used as context during an Agent-mode handoff or review, none of the richer artifact data will appear.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fplan-artifact-schema%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fplan-artifact-schema%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fcommands%2Fmod.rs%0ALine%3A%20855-865%0A%0AComment%3A%0A**Status%20dump%20not%20updated%20for%20new%20plan%20fields**%0A%0AThis%20block%20still%20only%20reads%20%60snapshot.explanation%60%20and%20%60snapshot.items%60.%20The%20new%20fields%20%28%60title%60%2C%20%60objective%60%2C%20%60sources_used%60%2C%20%60constraints%60%2C%20%60recommended_approach%60%2C%20%60verification_plan%60%2C%20%60risks_and_unknowns%60%2C%20%60handoff_packet%60%29%20are%20silently%20dropped%20when%20this%20status%20output%20is%20produced.%20If%20the%20status%20command%20is%20used%20as%20context%20during%20an%20Agent-mode%20handoff%20or%20review%2C%20none%20of%20the%20richer%20artifact%20data%20will%20appear.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fcommands%2Fmod.rs%0ALine%3A%20855-865%0A%0AComment%3A%0A**Status%20dump%20not%20updated%20for%20new%20plan%20fields**%0A%0AThis%20block%20still%20only%20reads%20%60snapshot.explanation%60%20and%20%60snapshot.items%60.%20The%20new%20fields%20%28%60title%60%2C%20%60objective%60%2C%20%60sources_used%60%2C%20%60constraints%60%2C%20%60recommended_approach%60%2C%20%60verification_plan%60%2C%20%60risks_and_unknowns%60%2C%20%60handoff_packet%60%29%20are%20silently%20dropped%20when%20this%20status%20output%20is%20produced.%20If%20the%20status%20command%20is%20used%20as%20context%20during%20an%20Agent-mode%20handoff%20or%20review%2C%20none%20of%20the%20richer%20artifact%20data%20will%20appear.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2733&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fcommands%2Fmod.rs%0ALine%3A%20855-865%0A%0AComment%3A%0A**Status%20dump%20not%20updated%20for%20new%20plan%20fields**%0A%0AThis%20block%20still%20only%20reads%20%60snapshot.explanation%60%20and%20%60snapshot.items%60.%20The%20new%20fields%20%28%60title%60%2C%20%60objective%60%2C%20%60sources_used%60%2C%20%60constraints%60%2C%20%60recommended_approach%60%2C%20%60verification_plan%60%2C%20%60risks_and_unknowns%60%2C%20%60handoff_packet%60%29%20are%20silently%20dropped%20when%20this%20status%20output%20is%20produced.%20If%20the%20status%20command%20is%20used%20as%20context%20during%20an%20Agent-mode%20handoff%20or%20review%2C%20none%20of%20the%20richer%20artifact%20data%20will%20appear.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2733&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fplan-artifact-schema%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fplan-artifact-schema%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftools%2Fplan.rs%3A516-527%0AThe%20%60required%60%20array%20in%20the%20JSON%20schema%20lists%20all%209%20new%20fields%20as%20mandatory%2C%20directly%20contradicting%20the%20tool%20description%20%28%22All%20fields%20except%20%60plan%60%20are%20optional%22%29%2C%20the%20plan.md%20prompt%20%28%22All%20fields%20except%20%60plan%60%20are%20optional%22%29%2C%20and%20the%20PR's%20backward-compatibility%20claim.%20Because%20LLMs%20treat%20%60required%60%20as%20binding%2C%20the%20model%20will%20attempt%20to%20populate%20every%20field%20on%20every%20call%20%E2%80%94%20even%20when%20it%20has%20nothing%20meaningful%20to%20say%20%E2%80%94%20rather%20than%20only%20including%20what%20was%20actually%20discovered.%20A%20caller%20that%20sends%20only%20%60plan%60%20%2B%20%60explanation%60%20would%20also%20violate%20this%20schema%2C%20breaking%20the%20promised%20legacy%20path.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%22required%22%3A%20%5B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22plan%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%5D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftools%2Fplan.rs%3A516-527%0AThe%20%60required%60%20array%20in%20the%20JSON%20schema%20lists%20all%209%20new%20fields%20as%20mandatory%2C%20directly%20contradicting%20the%20tool%20description%20%28%22All%20fields%20except%20%60plan%60%20are%20optional%22%29%2C%20the%20plan.md%20prompt%20%28%22All%20fields%20except%20%60plan%60%20are%20optional%22%29%2C%20and%20the%20PR's%20backward-compatibility%20claim.%20Because%20LLMs%20treat%20%60required%60%20as%20binding%2C%20the%20model%20will%20attempt%20to%20populate%20every%20field%20on%20every%20call%20%E2%80%94%20even%20when%20it%20has%20nothing%20meaningful%20to%20say%20%E2%80%94%20rather%20than%20only%20including%20what%20was%20actually%20discovered.%20A%20caller%20that%20sends%20only%20%60plan%60%20%2B%20%60explanation%60%20would%20also%20violate%20this%20schema%2C%20breaking%20the%20promised%20legacy%20path.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%22required%22%3A%20%5B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22plan%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%5D%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2733&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftools%2Fplan.rs%3A516-527%0AThe%20%60required%60%20array%20in%20the%20JSON%20schema%20lists%20all%209%20new%20fields%20as%20mandatory%2C%20directly%20contradicting%20the%20tool%20description%20%28%22All%20fields%20except%20%60plan%60%20are%20optional%22%29%2C%20the%20plan.md%20prompt%20%28%22All%20fields%20except%20%60plan%60%20are%20optional%22%29%2C%20and%20the%20PR's%20backward-compatibility%20claim.%20Because%20LLMs%20treat%20%60required%60%20as%20binding%2C%20the%20model%20will%20attempt%20to%20populate%20every%20field%20on%20every%20call%20%E2%80%94%20even%20when%20it%20has%20nothing%20meaningful%20to%20say%20%E2%80%94%20rather%20than%20only%20including%20what%20was%20actually%20discovered.%20A%20caller%20that%20sends%20only%20%60plan%60%20%2B%20%60explanation%60%20would%20also%20violate%20this%20schema%2C%20breaking%20the%20promised%20legacy%20path.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%22required%22%3A%20%5B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22plan%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%5D%0A%60%60%60%0A%0A&pr=2733&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["fix(plan): check all new fields in PlanS..."](https://github.com/hmbown/codewhale/commit/546265abe41897dc5726b9618889d212743bdcc6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35535815)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->