### PR TITLE
feat(sidebar): multi-line detail popover on truncated rows (#2694)

### DIFF
--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -1103,13 +1103,28 @@ pub struct SidebarHoverState {
     pub sections: Vec<SidebarHoverSection>,
 }
 
+/// Per-row metadata for rich sidebar popovers.
+#[derive(Debug, Clone)]
+pub struct SidebarHoverRow {
+    /// Absolute row position in the terminal.
+    pub row_y: u16,
+    /// Full untruncated line text.
+    pub full_text: String,
+    /// Extra detail line (status, timing, sub-step info).
+    pub detail: Option<String>,
+    /// Whether the rendered text was truncated.
+    pub is_truncated: bool,
+}
+
 /// Per-section metadata for sidebar hover detection.
 #[derive(Debug, Clone)]
 pub struct SidebarHoverSection {
     /// Content area within the section (inside border + padding).
     pub content_area: Rect,
-    /// Full original text for each content line rendered.
+    /// Full original text for each content line rendered (legacy flat format).
     pub lines: Vec<String>,
+    /// Per-row metadata for popover detail (new v0.9.0 rich format).
+    pub rows: Vec<SidebarHoverRow>,
 }
 
 impl Default for SessionState {

--- a/crates/tui/src/tui/mouse_ui.rs
+++ b/crates/tui/src/tui/mouse_ui.rs
@@ -289,11 +289,7 @@ pub(crate) fn handle_mouse_event(app: &mut App, mouse: MouseEvent) -> Vec<ViewEv
             // Update last mouse position for tooltip rendering.
             app.last_mouse_pos = Some((mouse.column, mouse.row));
 
-            // Check sidebar sections for hover tooltip. Only surface a tooltip
-            // when the hovered line was actually truncated to fit the panel
-            // width — otherwise it just paints a redundant copy of
-            // already-visible text over the neighbouring row, which reads as
-            // visual corruption.
+            // Check sidebar section rows for hover popover.
             let mut found = false;
             for section in &app.sidebar_hover.sections {
                 if mouse.column >= section.content_area.x
@@ -309,6 +305,28 @@ pub(crate) fn handle_mouse_event(app: &mut App, mouse: MouseEvent) -> Vec<ViewEv
                             .y
                             .saturating_add(section.content_area.height)
                 {
+                    // Prefer per-row metadata (new) over flat lines (legacy).
+                    if !section.rows.is_empty() {
+                        for row in &section.rows {
+                            if row.row_y == mouse.row && row.is_truncated {
+                                let tooltip = if let Some(ref detail) = row.detail {
+                                    format!("{}\n{}", row.full_text, detail)
+                                } else {
+                                    row.full_text.clone()
+                                };
+                                if app.sidebar_hover_tooltip.as_deref() != Some(&tooltip) {
+                                    app.sidebar_hover_tooltip = Some(tooltip);
+                                    app.needs_redraw = true;
+                                }
+                                found = true;
+                                break;
+                            }
+                        }
+                        if found {
+                            break;
+                        }
+                    }
+                    // Fall back to flat lines for sections without rows.
                     let line_idx = (mouse.row.saturating_sub(section.content_area.y)) as usize;
                     if let Some(full) = section.lines.get(line_idx) {
                         let truncated = UnicodeWidthStr::width(full.as_str())

--- a/crates/tui/src/tui/sidebar.rs
+++ b/crates/tui/src/tui/sidebar.rs
@@ -1984,7 +1984,7 @@ mod tests {
         ACTIVE_TOOL_COMPLETED_ROW_TTL, ACTIVE_TOOL_STALE_RUNNING_ROW_TTL, AutoSidebarPanel,
         AutoSidebarState, SidebarAgentRow, SidebarHoverSection, SidebarHoverState,
         SidebarSubagentSummary, SidebarToolRow, SidebarWorkChecklistItem, SidebarWorkStrategyStep,
-        SidebarWorkSummary, ToolRowOrder, auto_sidebar_panels, editorial_tool_rows,
+        SidebarHoverRow, SidebarWorkSummary, ToolRowOrder, auto_sidebar_panels, editorial_tool_rows,
         normalize_activity_text, sidebar_work_summary, subagent_panel_lines, task_panel_lines,
         work_panel_empty_hint, work_panel_lines,
     };
@@ -3035,5 +3035,57 @@ mod tests {
 
         // Mouse outside content area (above) — row < content_area.y
         assert!((1u16) < section.content_area.y);
+    }
+
+    // ── Sidebar hover row tests (#2694) ──────────────────────────
+
+    #[test]
+    fn sidebar_hover_section_populates_rows() {
+        use ratatui::layout::Rect;
+        // Simulate what `render_sidebar_section` does.
+        let full_texts = vec!["short".to_string(), "very long line that exceeds width".to_string()];
+        let content_width = 20u16;
+        let content_area = Rect::new(62, 2, content_width, 6);
+        let rows: Vec<SidebarHoverRow> = full_texts
+            .iter()
+            .enumerate()
+            .map(|(idx, text)| {
+                let row_y = content_area.y.saturating_add(idx as u16);
+                let is_truncated =
+                    unicode_width::UnicodeWidthStr::width(text.as_str()) > content_width as usize;
+                SidebarHoverRow {
+                    row_y,
+                    full_text: text.clone(),
+                    detail: None,
+                    is_truncated,
+                }
+            })
+            .collect();
+
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].row_y, 2);
+        assert!(!rows[0].is_truncated, "short text should not be truncated");
+        assert!(rows[1].is_truncated, "long text should be truncated");
+        assert_eq!(rows[1].full_text, "very long line that exceeds width");
+    }
+
+    #[test]
+    fn sidebar_hover_row_y_positions_are_sequential() {
+        use ratatui::layout::Rect;
+        let area = Rect::new(0, 5, 30, 10);
+        let texts = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        let rows: Vec<SidebarHoverRow> = texts
+            .iter()
+            .enumerate()
+            .map(|(idx, text)| SidebarHoverRow {
+                row_y: area.y.saturating_add(idx as u16),
+                full_text: text.clone(),
+                detail: None,
+                is_truncated: false,
+            })
+            .collect();
+        assert_eq!(rows[0].row_y, 5);
+        assert_eq!(rows[1].row_y, 6);
+        assert_eq!(rows[2].row_y, 7);
     }
 }

--- a/crates/tui/src/tui/sidebar.rs
+++ b/crates/tui/src/tui/sidebar.rs
@@ -1982,9 +1982,9 @@ fn render_sidebar_section(
 mod tests {
     use super::{
         ACTIVE_TOOL_COMPLETED_ROW_TTL, ACTIVE_TOOL_STALE_RUNNING_ROW_TTL, AutoSidebarPanel,
-        AutoSidebarState, SidebarAgentRow, SidebarHoverSection, SidebarHoverState,
+        AutoSidebarState, SidebarAgentRow, SidebarHoverRow, SidebarHoverSection, SidebarHoverState,
         SidebarSubagentSummary, SidebarToolRow, SidebarWorkChecklistItem, SidebarWorkStrategyStep,
-        SidebarHoverRow, SidebarWorkSummary, ToolRowOrder, auto_sidebar_panels, editorial_tool_rows,
+        SidebarWorkSummary, ToolRowOrder, auto_sidebar_panels, editorial_tool_rows,
         normalize_activity_text, sidebar_work_summary, subagent_panel_lines, task_panel_lines,
         work_panel_empty_hint, work_panel_lines,
     };
@@ -3043,7 +3043,10 @@ mod tests {
     fn sidebar_hover_section_populates_rows() {
         use ratatui::layout::Rect;
         // Simulate what `render_sidebar_section` does.
-        let full_texts = vec!["short".to_string(), "very long line that exceeds width".to_string()];
+        let full_texts = vec![
+            "short".to_string(),
+            "very long line that exceeds width".to_string(),
+        ];
         let content_width = 20u16;
         let content_area = Rect::new(62, 2, content_width, 6);
         let rows: Vec<SidebarHoverRow> = full_texts

--- a/crates/tui/src/tui/sidebar.rs
+++ b/crates/tui/src/tui/sidebar.rs
@@ -24,7 +24,9 @@ use crate::tools::plan::StepStatus;
 use crate::tools::subagent::SubAgentStatus;
 use crate::tools::todo::TodoStatus;
 
-use super::app::{App, SidebarFocus, SidebarHoverSection, SidebarHoverState, TaskPanelEntry};
+use super::app::{
+    App, SidebarFocus, SidebarHoverRow, SidebarHoverSection, SidebarHoverState, TaskPanelEntry,
+};
 use super::history::{GenericToolCell, HistoryCell, ToolCell, ToolStatus, summarize_tool_output};
 use super::subagent_routing::active_fanout_counts;
 use super::ui_text::{concise_shell_command_label, truncate_line_to_width};
@@ -1918,9 +1920,25 @@ fn render_sidebar_section(
         width: area.width.saturating_sub(2 + padding.left + padding.right),
         height: area.height.saturating_sub(2 + padding.top + padding.bottom),
     };
+    let rows: Vec<SidebarHoverRow> = full_texts
+        .iter()
+        .enumerate()
+        .map(|(idx, text)| {
+            let row_y = content_area.y.saturating_add(idx as u16);
+            let is_truncated =
+                unicode_width::UnicodeWidthStr::width(text.as_str()) > content_area.width as usize;
+            SidebarHoverRow {
+                row_y,
+                full_text: text.clone(),
+                detail: None,
+                is_truncated,
+            }
+        })
+        .collect();
     app.sidebar_hover.sections.push(SidebarHoverSection {
         content_area,
         lines: full_texts,
+        rows,
     });
     // Truncate the panel title so it always fits within the section width
     // even after a resize. The title occupies up to 4 chars of border chrome
@@ -2987,6 +3005,7 @@ mod tests {
         let section = SidebarHoverSection {
             content_area: Rect::new(1, 1, 38, 8),
             lines: vec!["line 1".to_string(), "line 2".to_string()],
+            rows: vec![],
         };
         assert_eq!(section.lines.len(), 2);
         assert_eq!(section.lines[0], "line 1");
@@ -3003,6 +3022,7 @@ mod tests {
                 "second".to_string(),
                 "third".to_string(),
             ],
+            rows: vec![],
         };
 
         // Mouse within content area, first line

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -3434,6 +3434,10 @@ async fn run_event_loop(
                     app.mention_menu_hidden = true;
                     app.mention_menu_selected = 0;
                 }
+                KeyCode::Esc if app.sidebar_hover_tooltip.is_some() => {
+                    app.sidebar_hover_tooltip = None;
+                    app.needs_redraw = true;
+                }
                 KeyCode::Esc => {
                     match next_escape_action(app, slash_menu_open) {
                         EscapeAction::CloseSlashMenu => {

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -6764,35 +6764,47 @@ fn render(f: &mut Frame, app: &mut App) {
                 }
             }
 
-            // Render sidebar hover tooltip if active.
+            // Render sidebar hover popover if active.
             if let Some(ref tooltip_text) = app.sidebar_hover_tooltip
                 && let Some((mouse_col, mouse_row)) = app.last_mouse_pos
             {
-                let text_width = (tooltip_text.len() as u16).clamp(10, 60);
-                let tooltip_height = 1u16;
+                let popup_width = (72u16.min(size.width.saturating_sub(4))).max(30);
+
+                // Rough height: count newlines + estimate wrapped lines.
+                let raw_lines = tooltip_text.lines().count() as u16;
+                let est_wrapped = raw_lines
+                    .saturating_add((tooltip_text.len() as u16).saturating_div(popup_width.max(1)));
+                let popup_content_height = est_wrapped.clamp(1, 10);
+                let popup_height = popup_content_height + 2; // +2 for border
+
                 let x = mouse_col
                     .saturating_add(2)
-                    .min(size.width.saturating_sub(text_width));
-                // Sit one row BELOW the cursor so the tooltip never paints over
-                // the row above the hovered line (which read as corruption).
+                    .min(size.width.saturating_sub(popup_width));
                 let y = mouse_row
                     .saturating_add(1)
-                    .min(size.height.saturating_sub(tooltip_height));
-                if text_width > 0 && tooltip_height > 0 {
-                    let tooltip_area = Rect {
+                    .min(size.height.saturating_sub(popup_height));
+
+                if popup_width > 4 {
+                    let popup_area = Rect {
                         x,
                         y,
-                        width: text_width,
-                        height: tooltip_height,
+                        width: popup_width,
+                        height: popup_height,
                     };
-                    // Neutral elevated-surface styling so the tooltip reads as a
-                    // tooltip, not a warning highlight (was STATUS_WARNING).
-                    let tooltip = ratatui::widgets::Paragraph::new(tooltip_text.as_str()).style(
-                        Style::default()
-                            .bg(palette::SURFACE_ELEVATED)
-                            .fg(palette::TEXT_PRIMARY),
-                    );
-                    f.render_widget(tooltip, tooltip_area);
+
+                    let popup = ratatui::widgets::Paragraph::new(tooltip_text.as_str())
+                        .wrap(ratatui::widgets::Wrap { trim: false })
+                        .block(
+                            ratatui::widgets::Block::default()
+                                .borders(ratatui::widgets::Borders::ALL)
+                                .border_style(Style::default().fg(palette::DEEPSEEK_BLUE))
+                                .style(
+                                    Style::default()
+                                        .bg(palette::SURFACE_ELEVATED)
+                                        .fg(palette::TEXT_PRIMARY),
+                                ),
+                        );
+                    f.render_widget(popup, popup_area);
                 }
             }
         }


### PR DESCRIPTION
Replace the single-line sidebar hover tooltip with a bordered, auto-wrapping popover that shows the full text of any truncated Work/Tasks/Agents row on mouse hover. Theme-safe styling uses `DEEPSEEK_BLUE` border on `SURFACE_ELEVATED` background.

Changes:
- `crates/tui/src/tui/app.rs`:
  - Add `SidebarHoverRow` with `row_y`, `full_text`, `detail`, `is_truncated`
  - Extend `SidebarHoverSection` with `rows: Vec<SidebarHoverRow>` for per-row metadata
- `crates/tui/src/tui/sidebar.rs`:
  - `render_sidebar_section` now builds `rows` from `full_texts` with per-line `is_truncated` detection based on content_area width
  - Update test struct literals with `rows: vec![]`
- `crates/tui/src/tui/mouse_ui.rs`:
  - Hover detection prefers `rows` over flat `lines`. When a row has `detail`, the popover shows `full_text + detail` (newline-separated). Falls back to legacy `lines` for sections without row metadata.
- `crates/tui/src/tui/ui.rs`:
  - Popover rendering: multi-line bordered block with auto-wrap, positioned below cursor, clamped to terminal bounds

Closes #2694

## Summary

## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces the single-line sidebar hover tooltip with a bordered, auto-wrapping multi-line popover that displays the full text of truncated Work/Tasks/Agents rows. It introduces `SidebarHoverRow` for per-row metadata, builds row data inside `render_sidebar_section`, updates mouse hover detection to prefer the new rows path, and renders a `DEEPSEEK_BLUE`-bordered `Paragraph` block positioned below the cursor.

- `SidebarHoverRow` adds `row_y`, `full_text`, `detail`, and `is_truncated` fields; `SidebarHoverSection` gains a parallel `rows` vector alongside the legacy `lines` field for backward compatibility.
- The `is_truncated` detection in `sidebar.rs` is broken for the Work and Tasks panels: `full_texts` is derived from `spans_to_text` on already-rendered (pre-truncated) `Line` objects, so the truncation check always evaluates `false` and the popover never fires for goal/objective rows.
- `mouse_ui.rs` fall-through logic, height estimation, ESC priority, and the `detail: None` stub were flagged in a prior review pass.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The popover renders and the new data structures are sound, but the truncation detection in the Work and Tasks panels will always return false for pre-truncated rows, meaning the visible-on-hover feature does not actually trigger for the rows it was designed for.

The callers of render_sidebar_section derive full_texts from spans_to_text on already-rendered, pre-truncated Line objects. Because content_width used by the panel functions equals content_area.width in render_sidebar_section, the is_truncated comparison always evaluates to false for goal, objective, and most task rows.

crates/tui/src/tui/sidebar.rs — the full_texts construction at the render_sidebar_work and render_sidebar_tasks call sites needs to capture original untruncated strings before truncate_line_to_width is applied.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/app.rs | Adds `SidebarHoverRow` struct and `rows` field to `SidebarHoverSection`; structs are well-defined and cleanly integrate with the existing hover state. |
| crates/tui/src/tui/sidebar.rs | Builds `rows` from `full_texts`, but `full_texts` is derived from already-truncated rendered spans; `is_truncated` is always false for the key Work/Tasks rows, making the popover feature inoperative on those rows. |
| crates/tui/src/tui/mouse_ui.rs | Adds rows-first detection path with correct fallback to legacy `lines`; non-truncated rows in a rows-populated section fall through to the `lines` path unnecessarily. |
| crates/tui/src/tui/ui.rs | Replaces single-line tooltip with a bordered, auto-wrapping `Paragraph` popover; height estimation over-counts line lengths and the `popup_width > 4` guard is dead code. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/tui/src/tui/mouse_ui.rs`, line 308-342 ([link](https://github.com/hmbown/codewhale/blob/e151ec3ac0a87e1703f2cc594573d9a149d0f4b6/crates/tui/src/tui/mouse_ui.rs#L308-L342)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Rows path falls through to legacy `lines` on non-truncated rows**

   The comment says "Prefer per-row metadata (new) over flat lines (legacy)", but when the hovered row is found in `section.rows` with `is_truncated = false`, neither `found` is set nor do we break — so execution falls into the `lines` path for that same row. Today both paths use an identical `UnicodeWidthStr` width comparison so the observable behaviour is the same, but the intent is violated: a section that has `rows` populated should be handled exclusively by the rows path. Any future divergence between `rows[i].is_truncated` and the re-computed value in the `lines` branch (e.g. after a resize race or a detail-augmented text) will silently show or hide the wrong tooltip.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fsidebar-detail-popovers%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fsidebar-detail-popovers%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fmouse_ui.rs%0ALine%3A%20308-342%0A%0AComment%3A%0A**Rows%20path%20falls%20through%20to%20legacy%20%60lines%60%20on%20non-truncated%20rows**%0A%0AThe%20comment%20says%20%22Prefer%20per-row%20metadata%20%28new%29%20over%20flat%20lines%20%28legacy%29%22%2C%20but%20when%20the%20hovered%20row%20is%20found%20in%20%60section.rows%60%20with%20%60is_truncated%20%3D%20false%60%2C%20neither%20%60found%60%20is%20set%20nor%20do%20we%20break%20%E2%80%94%20so%20execution%20falls%20into%20the%20%60lines%60%20path%20for%20that%20same%20row.%20Today%20both%20paths%20use%20an%20identical%20%60UnicodeWidthStr%60%20width%20comparison%20so%20the%20observable%20behaviour%20is%20the%20same%2C%20but%20the%20intent%20is%20violated%3A%20a%20section%20that%20has%20%60rows%60%20populated%20should%20be%20handled%20exclusively%20by%20the%20rows%20path.%20Any%20future%20divergence%20between%20%60rows%5Bi%5D.is_truncated%60%20and%20the%20re-computed%20value%20in%20the%20%60lines%60%20branch%20%28e.g.%20after%20a%20resize%20race%20or%20a%20detail-augmented%20text%29%20will%20silently%20show%20or%20hide%20the%20wrong%20tooltip.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fmouse_ui.rs%0ALine%3A%20308-342%0A%0AComment%3A%0A**Rows%20path%20falls%20through%20to%20legacy%20%60lines%60%20on%20non-truncated%20rows**%0A%0AThe%20comment%20says%20%22Prefer%20per-row%20metadata%20%28new%29%20over%20flat%20lines%20%28legacy%29%22%2C%20but%20when%20the%20hovered%20row%20is%20found%20in%20%60section.rows%60%20with%20%60is_truncated%20%3D%20false%60%2C%20neither%20%60found%60%20is%20set%20nor%20do%20we%20break%20%E2%80%94%20so%20execution%20falls%20into%20the%20%60lines%60%20path%20for%20that%20same%20row.%20Today%20both%20paths%20use%20an%20identical%20%60UnicodeWidthStr%60%20width%20comparison%20so%20the%20observable%20behaviour%20is%20the%20same%2C%20but%20the%20intent%20is%20violated%3A%20a%20section%20that%20has%20%60rows%60%20populated%20should%20be%20handled%20exclusively%20by%20the%20rows%20path.%20Any%20future%20divergence%20between%20%60rows%5Bi%5D.is_truncated%60%20and%20the%20re-computed%20value%20in%20the%20%60lines%60%20branch%20%28e.g.%20after%20a%20resize%20race%20or%20a%20detail-augmented%20text%29%20will%20silently%20show%20or%20hide%20the%20wrong%20tooltip.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2734&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fmouse_ui.rs%0ALine%3A%20308-342%0A%0AComment%3A%0A**Rows%20path%20falls%20through%20to%20legacy%20%60lines%60%20on%20non-truncated%20rows**%0A%0AThe%20comment%20says%20%22Prefer%20per-row%20metadata%20%28new%29%20over%20flat%20lines%20%28legacy%29%22%2C%20but%20when%20the%20hovered%20row%20is%20found%20in%20%60section.rows%60%20with%20%60is_truncated%20%3D%20false%60%2C%20neither%20%60found%60%20is%20set%20nor%20do%20we%20break%20%E2%80%94%20so%20execution%20falls%20into%20the%20%60lines%60%20path%20for%20that%20same%20row.%20Today%20both%20paths%20use%20an%20identical%20%60UnicodeWidthStr%60%20width%20comparison%20so%20the%20observable%20behaviour%20is%20the%20same%2C%20but%20the%20intent%20is%20violated%3A%20a%20section%20that%20has%20%60rows%60%20populated%20should%20be%20handled%20exclusively%20by%20the%20rows%20path.%20Any%20future%20divergence%20between%20%60rows%5Bi%5D.is_truncated%60%20and%20the%20re-computed%20value%20in%20the%20%60lines%60%20branch%20%28e.g.%20after%20a%20resize%20race%20or%20a%20detail-augmented%20text%29%20will%20silently%20show%20or%20hide%20the%20wrong%20tooltip.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2734&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fsidebar-detail-popovers%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fsidebar-detail-popovers%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fsidebar.rs%3A592-606%0A**%60full_texts%60%20captures%20already-truncated%20span%20text%2C%20so%20%60is_truncated%60%20is%20always%20%60false%60%20for%20goal%2Ftask%20rows**%0A%0A%60full_texts%60%20is%20built%20by%20calling%20%60spans_to_text%60%20on%20the%20rendered%20%60Line%60%20objects.%20Those%20lines%20were%20already%20passed%20through%20%60truncate_line_to_width%60%20inside%20%60work_panel_lines%60%20%2F%20%60task_panel_lines%60%2C%20where%20%60content_width%20%3D%20area.width.saturating_sub%284%29%60.%20That%20value%20is%20identical%20to%20%60content_area.width%60%20computed%20in%20%60render_sidebar_section%60%20%28%60Padding%3A%3Ahorizontal%281%29%60%20means%20%602%20%2B%201%20%2B%201%20%3D%204%60%29.%20The%20resulting%20%60is_truncated%60%20check%20therefore%20compares%20%60width%28already_truncated_text%29%20%3E%20content_area.width%60%2C%20which%20is%20always%20%60false%60%20%E2%80%94%20so%20the%20popover%20never%20fires%20for%20objective%2Ftask%20rows%2C%20and%20even%20on%20rows%20where%20it%20would%20fire%20the%20%60full_text%60%20contains%20the%20same%20truncated%20string%20already%20visible%20in%20the%20sidebar.%20The%20original%20untruncated%20strings%20need%20to%20be%20captured%20before%20%60truncate_line_to_width%60%20is%20applied%20and%20passed%20as%20%60full_texts%60%20separately%20from%20the%20rendered%20%60lines%60.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fsidebar.rs%3A592-606%0A**%60full_texts%60%20captures%20already-truncated%20span%20text%2C%20so%20%60is_truncated%60%20is%20always%20%60false%60%20for%20goal%2Ftask%20rows**%0A%0A%60full_texts%60%20is%20built%20by%20calling%20%60spans_to_text%60%20on%20the%20rendered%20%60Line%60%20objects.%20Those%20lines%20were%20already%20passed%20through%20%60truncate_line_to_width%60%20inside%20%60work_panel_lines%60%20%2F%20%60task_panel_lines%60%2C%20where%20%60content_width%20%3D%20area.width.saturating_sub%284%29%60.%20That%20value%20is%20identical%20to%20%60content_area.width%60%20computed%20in%20%60render_sidebar_section%60%20%28%60Padding%3A%3Ahorizontal%281%29%60%20means%20%602%20%2B%201%20%2B%201%20%3D%204%60%29.%20The%20resulting%20%60is_truncated%60%20check%20therefore%20compares%20%60width%28already_truncated_text%29%20%3E%20content_area.width%60%2C%20which%20is%20always%20%60false%60%20%E2%80%94%20so%20the%20popover%20never%20fires%20for%20objective%2Ftask%20rows%2C%20and%20even%20on%20rows%20where%20it%20would%20fire%20the%20%60full_text%60%20contains%20the%20same%20truncated%20string%20already%20visible%20in%20the%20sidebar.%20The%20original%20untruncated%20strings%20need%20to%20be%20captured%20before%20%60truncate_line_to_width%60%20is%20applied%20and%20passed%20as%20%60full_texts%60%20separately%20from%20the%20rendered%20%60lines%60.%0A%0A&repo=hmbown%2Fcodewhale&pr=2734&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fsidebar.rs%3A592-606%0A**%60full_texts%60%20captures%20already-truncated%20span%20text%2C%20so%20%60is_truncated%60%20is%20always%20%60false%60%20for%20goal%2Ftask%20rows**%0A%0A%60full_texts%60%20is%20built%20by%20calling%20%60spans_to_text%60%20on%20the%20rendered%20%60Line%60%20objects.%20Those%20lines%20were%20already%20passed%20through%20%60truncate_line_to_width%60%20inside%20%60work_panel_lines%60%20%2F%20%60task_panel_lines%60%2C%20where%20%60content_width%20%3D%20area.width.saturating_sub%284%29%60.%20That%20value%20is%20identical%20to%20%60content_area.width%60%20computed%20in%20%60render_sidebar_section%60%20%28%60Padding%3A%3Ahorizontal%281%29%60%20means%20%602%20%2B%201%20%2B%201%20%3D%204%60%29.%20The%20resulting%20%60is_truncated%60%20check%20therefore%20compares%20%60width%28already_truncated_text%29%20%3E%20content_area.width%60%2C%20which%20is%20always%20%60false%60%20%E2%80%94%20so%20the%20popover%20never%20fires%20for%20objective%2Ftask%20rows%2C%20and%20even%20on%20rows%20where%20it%20would%20fire%20the%20%60full_text%60%20contains%20the%20same%20truncated%20string%20already%20visible%20in%20the%20sidebar.%20The%20original%20untruncated%20strings%20need%20to%20be%20captured%20before%20%60truncate_line_to_width%60%20is%20applied%20and%20passed%20as%20%60full_texts%60%20separately%20from%20the%20rendered%20%60lines%60.%0A%0A&pr=2734&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (4): Last reviewed commit: ["style: cargo fmt --all"](https://github.com/hmbown/codewhale/commit/23f964f62f755f0f926e1437d666301c19ce0aee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35536999)</sub>

<!-- /greptile_comment -->