### PR TITLE
fix(subagent): inherit parent model in tool-agent route instead of hardcoding deepseek-v4-flash

### DIFF
--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -4697,7 +4697,7 @@ pub(crate) async fn resolve_subagent_assignment_route(
     agent_type: &SubAgentType,
 ) -> SubAgentResolvedRoute {
     if matches!(agent_type, SubAgentType::ToolAgent) {
-        return tool_agent_route();
+        return tool_agent_route(runtime);
     }
 
     let explicit_model = configured_model.is_some();
@@ -4720,9 +4720,14 @@ pub(crate) async fn resolve_subagent_assignment_route(
     route
 }
 
-fn tool_agent_route() -> SubAgentResolvedRoute {
+fn tool_agent_route(runtime: &SubAgentRuntime) -> SubAgentResolvedRoute {
     SubAgentResolvedRoute {
-        model: "deepseek-v4-flash".to_string(),
+        // Inherit the parent session's model instead of hardcoding a DeepSeek
+        // model id: the tool-agent "fast lane" semantics come from
+        // `reasoning_effort = off`, not from a specific model. Hardcoding
+        // `deepseek-v4-flash` makes tool-agent routing fail with a 404 on any
+        // backend or provider that doesn't serve that exact model id.
+        model: runtime.model.clone(),
         reasoning_effort: Some("off".to_string()),
     }
 }


### PR DESCRIPTION
## Problem

`tool_agent_route()` hardcodes `model: "deepseek-v4-flash"`. Routing a `ToolAgent` sub-agent therefore issues an API request for `deepseek-v4-flash` regardless of the parent session's model. On any backend or provider that doesn't serve that exact model id (self-hosted inference servers, non-DeepSeek providers), the call fails with a 404 and the tool-agent path is unusable.

## Fix

Inherit the parent session's model from `runtime.model`. The tool-agent "fast lane" semantics come from `reasoning_effort = off`, not from a specific model id, so dropping the hardcoded model preserves the intended behaviour.

- No-op for DeepSeek setups: the parent model is already a DeepSeek id.
- Fixes tool-agent routing on every other backend/provider.

## Scope

One function (`tool_agent_route`) + its single caller in `resolve_subagent_assignment_route`. `reasoning_effort: off` unchanged. The separate `subagent_flash_router` (auto-model router) is intentionally left untouched.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes `tool_agent_route` so that `ToolAgent` sub-agents inherit the parent session's model via `runtime.model` instead of hardcoding `"deepseek-v4-flash"`, preventing 404 errors on any backend that does not serve that exact model id.

- `tool_agent_route()` now accepts `&SubAgentRuntime` and clones `runtime.model`; `reasoning_effort = off` is preserved unchanged to maintain the fast-lane semantics.
- `resolve_subagent_assignment_route` is updated to pass `runtime` through to the new signature; all other routing paths are untouched.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The model-id fix is correct, but `reasoning_effort: Some("off")` is still sent unconditionally and will likely trigger a 400/422 on non-DeepSeek providers — the very backends this PR is meant to unblock.

The model inheritance change is straightforward and fixes the described 404. However, `reasoning_effort: Some("off")` remains hardcoded in `tool_agent_route` and is sent to every backend unconditionally. Providers that do not recognise this field (OpenAI-compatible servers, self-hosted LLMs, etc.) will still reject the request, leaving the tool-agent path broken for the general non-DeepSeek case the PR claims to fix. Additionally, the existing test `tool_agent_route_forces_flash_with_thinking_off` now passes only because the stub runtime happens to use `deepseek-v4-flash`, giving false confidence in the new behaviour.

crates/tui/src/tools/subagent/mod.rs — specifically the `tool_agent_route` function and its unconditional `reasoning_effort` field.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tools/subagent/mod.rs | Removes the hardcoded `deepseek-v4-flash` model from `tool_agent_route`, replacing it with `runtime.model`; fixes 404s on non-DeepSeek backends, but `reasoning_effort: Some("off")` is still unconditionally sent and may cause 400/422 on providers that don't recognise the field. |

</details>

</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Ftool-agent-inherit-parent-model%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Ftool-agent-inherit-parent-model%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftools%2Fsubagent%2Fmod.rs%3A4731%0A**%60reasoning_effort%20%3D%20off%60%20may%20still%20reject%20on%20non-DeepSeek%20backends**%0A%0AThe%20PR%20correctly%20fixes%20the%20404%20caused%20by%20the%20hardcoded%20model%20id%2C%20but%20%60reasoning_effort%3A%20Some%28%22off%22%29%60%20is%20still%20sent%20unconditionally.%20On%20OpenAI-compatible%20servers%20or%20other%20non-DeepSeek%20providers%20that%20do%20not%20recognise%20%60reasoning_effort%60%2C%20this%20field%20may%20cause%20a%20400%2F422%20rejection%2C%20leaving%20the%20%60ToolAgent%60%20path%20broken%20for%20the%20exact%20backends%20this%20fix%20is%20targeting.%20Since%20the%20field%20is%20already%20%60Option%3CString%3E%60%20elsewhere%20in%20the%20struct%2C%20returning%20%60None%60%20here%20%28or%20making%20it%20conditional%20on%20whether%20the%20model%20is%20known%20to%20support%20it%29%20would%20make%20the%20fix%20complete%20for%20the%20general%20backend%20case.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftools%2Fsubagent%2Fmod.rs%3A4731%0A**%60reasoning_effort%20%3D%20off%60%20may%20still%20reject%20on%20non-DeepSeek%20backends**%0A%0AThe%20PR%20correctly%20fixes%20the%20404%20caused%20by%20the%20hardcoded%20model%20id%2C%20but%20%60reasoning_effort%3A%20Some%28%22off%22%29%60%20is%20still%20sent%20unconditionally.%20On%20OpenAI-compatible%20servers%20or%20other%20non-DeepSeek%20providers%20that%20do%20not%20recognise%20%60reasoning_effort%60%2C%20this%20field%20may%20cause%20a%20400%2F422%20rejection%2C%20leaving%20the%20%60ToolAgent%60%20path%20broken%20for%20the%20exact%20backends%20this%20fix%20is%20targeting.%20Since%20the%20field%20is%20already%20%60Option%3CString%3E%60%20elsewhere%20in%20the%20struct%2C%20returning%20%60None%60%20here%20%28or%20making%20it%20conditional%20on%20whether%20the%20model%20is%20known%20to%20support%20it%29%20would%20make%20the%20fix%20complete%20for%20the%20general%20backend%20case.%0A%0A&repo=hmbown%2Fcodewhale&pr=2736&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftools%2Fsubagent%2Fmod.rs%3A4731%0A**%60reasoning_effort%20%3D%20off%60%20may%20still%20reject%20on%20non-DeepSeek%20backends**%0A%0AThe%20PR%20correctly%20fixes%20the%20404%20caused%20by%20the%20hardcoded%20model%20id%2C%20but%20%60reasoning_effort%3A%20Some%28%22off%22%29%60%20is%20still%20sent%20unconditionally.%20On%20OpenAI-compatible%20servers%20or%20other%20non-DeepSeek%20providers%20that%20do%20not%20recognise%20%60reasoning_effort%60%2C%20this%20field%20may%20cause%20a%20400%2F422%20rejection%2C%20leaving%20the%20%60ToolAgent%60%20path%20broken%20for%20the%20exact%20backends%20this%20fix%20is%20targeting.%20Since%20the%20field%20is%20already%20%60Option%3CString%3E%60%20elsewhere%20in%20the%20struct%2C%20returning%20%60None%60%20here%20%28or%20making%20it%20conditional%20on%20whether%20the%20model%20is%20known%20to%20support%20it%29%20would%20make%20the%20fix%20complete%20for%20the%20general%20backend%20case.%0A%0A&pr=2736&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(subagent): inherit parent model in t..."](https://github.com/hmbown/codewhale/commit/3b92e85f0909f49956c8cec86079d87ce00b4ae8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35542307)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->