### PR TITLE
fix(skills): union configured skills_dir with workspace skills instead of or_else fallback

### DIFF
--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -1073,8 +1073,16 @@ pub fn system_prompt_for_mode_with_context_skills_session_and_approval(
     // honoured as a fallback for callers that don't supply a
     // workspace-aware view; it falls through to the same merged
     // registry when available.
-    let skills_block = crate::skills::render_available_skills_context_for_workspace(workspace)
-        .or_else(|| skills_dir.and_then(crate::skills::render_available_skills_context));
+    // When an explicit `skills_dir` is configured, union it with the
+    // workspace view rather than treating it as an `or_else` fallback: the
+    // workspace view almost always returns Some (any cross-tool skill folder),
+    // which would otherwise shadow the configured `skills_dir` entirely.
+    let skills_block = match skills_dir {
+        Some(dir) => {
+            crate::skills::render_available_skills_context_for_workspace_and_dir(workspace, dir)
+        }
+        None => crate::skills::render_available_skills_context_for_workspace(workspace),
+    };
     if let Some(block) = skills_block {
         full_prompt = format!("{full_prompt}\n\n{block}");
     }

--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -1068,21 +1068,15 @@ pub fn system_prompt_for_mode_with_context_skills_session_and_approval(
     // skills directory (`.agents/skills`, `skills`,
     // `.opencode/skills`, `.claude/skills`, `.cursor/skills`) plus global
     // `~/.agents/skills` / `~/.deepseek/skills` so skills installed for any
-    // AI-tool convention show up in the catalogue. The legacy
-    // single-`skills_dir` path is
-    // honoured as a fallback for callers that don't supply a
-    // workspace-aware view; it falls through to the same merged
-    // registry when available.
+    // AI-tool convention show up in the catalogue.
     // When an explicit `skills_dir` is configured, union it with the
     // workspace view rather than treating it as an `or_else` fallback: the
     // workspace view almost always returns Some (any cross-tool skill folder),
     // which would otherwise shadow the configured `skills_dir` entirely.
-    let skills_block = match skills_dir {
-        Some(dir) => {
-            crate::skills::render_available_skills_context_for_workspace_and_dir(workspace, dir)
-        }
-        None => crate::skills::render_available_skills_context_for_workspace(workspace),
-    };
+    let skills_block = skills_dir.map_or_else(
+        || crate::skills::render_available_skills_context_for_workspace(workspace),
+        |dir| crate::skills::render_available_skills_context_for_workspace_and_dir(workspace, dir),
+    );
     if let Some(block) = skills_block {
         full_prompt = format!("{full_prompt}\n\n{block}");
     }

--- a/crates/tui/src/skills/mod.rs
+++ b/crates/tui/src/skills/mod.rs
@@ -619,19 +619,6 @@ pub fn render_available_skills_context_for_workspace(workspace: &Path) -> Option
     render_skills_block(&registry)
 }
 
-/// Codex's progressive-disclosure contract: the model sees skill names,
-/// descriptions, and paths up front, then opens the specific `SKILL.md` only
-/// when a skill is relevant.
-///
-/// Single-directory variant — use
-/// [`render_available_skills_context_for_workspace`] when scanning
-/// a workspace for cross-tool skill folders (#432).
-#[must_use]
-pub fn render_available_skills_context(skills_dir: &Path) -> Option<String> {
-    let registry = SkillRegistry::discover(skills_dir);
-    render_skills_block(&registry)
-}
-
 /// Union variant: merge skills discovered in the `workspace` (cross-tool skill
 /// folders) **and** an explicitly-configured `skills_dir`. Use this when an
 /// embedder injects a dedicated `skills_dir` that must stay visible even when
@@ -648,6 +635,9 @@ pub fn render_available_skills_context_for_workspace_and_dir(
     render_skills_block(&registry)
 }
 
+/// Codex's progressive-disclosure contract: the model sees skill names,
+/// descriptions, and paths up front, then opens the specific `SKILL.md` only
+/// when a skill is relevant.
 fn render_skills_block(registry: &SkillRegistry) -> Option<String> {
     if registry.is_empty() {
         return None;
@@ -776,6 +766,14 @@ mod tests {
         std::fs::write(skill_dir.join("SKILL.md"), skill_content).unwrap();
     }
 
+    /// Single-directory render used by the rendering-behaviour tests below.
+    /// Mirrors the retired `render_available_skills_context` entry point —
+    /// prompts.rs now goes through the workspace/union variants, which share
+    /// this same discover + render path.
+    fn render_dir_context(skills_dir: &std::path::Path) -> Option<String> {
+        super::render_skills_block(&super::SkillRegistry::discover(skills_dir))
+    }
+
     #[test]
     fn render_available_skills_context_lists_paths_and_usage() {
         let tmpdir = TempDir::new().unwrap();
@@ -785,9 +783,7 @@ mod tests {
             "---\nname: test-skill\ndescription: A test skill\n---\nDo something special",
         );
 
-        let rendered =
-            crate::skills::render_available_skills_context(&tmpdir.path().join("skills"))
-                .expect("skill context");
+        let rendered = render_dir_context(&tmpdir.path().join("skills")).expect("skill context");
 
         let expected_path = tmpdir
             .path()
@@ -820,9 +816,7 @@ mod tests {
             "---\nname: friendly-name\ndescription: drift case\n---\nbody",
         );
 
-        let rendered =
-            crate::skills::render_available_skills_context(&tmpdir.path().join("skills"))
-                .expect("skill context");
+        let rendered = render_dir_context(&tmpdir.path().join("skills")).expect("skill context");
 
         let real_path = tmpdir
             .path()
@@ -854,10 +848,10 @@ mod tests {
         let tmpdir = TempDir::new().unwrap();
         let empty = tmpdir.path().join("skills");
         std::fs::create_dir_all(&empty).unwrap();
-        assert!(crate::skills::render_available_skills_context(&empty).is_none());
+        assert!(render_dir_context(&empty).is_none());
 
         let missing = tmpdir.path().join("does-not-exist");
-        assert!(crate::skills::render_available_skills_context(&missing).is_none());
+        assert!(render_dir_context(&missing).is_none());
     }
 
     #[test]
@@ -867,9 +861,7 @@ mod tests {
         let body = format!("---\nname: bigdesc\ndescription: {long_desc}\n---\nbody");
         create_skill_dir(&tmpdir, "bigdesc", &body);
 
-        let rendered =
-            crate::skills::render_available_skills_context(&tmpdir.path().join("skills"))
-                .expect("skill context");
+        let rendered = render_dir_context(&tmpdir.path().join("skills")).expect("skill context");
 
         let max = super::MAX_SKILL_DESCRIPTION_CHARS;
         assert!(rendered.contains('…'), "expected truncation marker");
@@ -888,9 +880,7 @@ mod tests {
             "---\nname: spaced-skill\ndescription: alpha  \t  beta   gamma\n---\nbody",
         );
 
-        let rendered =
-            crate::skills::render_available_skills_context(&tmpdir.path().join("skills"))
-                .expect("skill context");
+        let rendered = render_dir_context(&tmpdir.path().join("skills")).expect("skill context");
 
         let line = rendered
             .lines()
@@ -908,9 +898,7 @@ mod tests {
             create_skill_dir(&tmpdir, &format!("skill-{i:03}"), &body);
         }
 
-        let rendered =
-            crate::skills::render_available_skills_context(&tmpdir.path().join("skills"))
-                .expect("skill context");
+        let rendered = render_dir_context(&tmpdir.path().join("skills")).expect("skill context");
 
         assert!(
             rendered.contains("additional skills omitted from this prompt budget"),
@@ -1451,9 +1439,7 @@ mod tests {
             "folded-skill",
             "---\nname: folded-skill\ndescription: >\n  line one chinese\n  line two chinese\n---\nbody",
         );
-        let rendered =
-            crate::skills::render_available_skills_context(&tmpdir.path().join("skills"))
-                .expect("skill context");
+        let rendered = render_dir_context(&tmpdir.path().join("skills")).expect("skill context");
         assert!(
             rendered.contains("line one chinese line two chinese"),
             "folded block scalar should join lines with space, got:\n{rendered}"
@@ -1470,9 +1456,7 @@ mod tests {
             "literal-skill",
             "---\nname: literal-skill\ndescription: |\n  line one\n  line two\n---\nbody",
         );
-        let rendered =
-            crate::skills::render_available_skills_context(&tmpdir.path().join("skills"))
-                .expect("skill context");
+        let rendered = render_dir_context(&tmpdir.path().join("skills")).expect("skill context");
         // `truncate_for_prompt` collapses whitespace, so the newlines
         // become spaces. The key assertion is that the content is
         // captured (not just `|`).
@@ -1492,9 +1476,7 @@ mod tests {
             "strip-skill",
             "---\nname: strip-skill\ndescription: >-\n  alpha\n  beta\n\n---\nbody",
         );
-        let rendered =
-            crate::skills::render_available_skills_context(&tmpdir.path().join("skills"))
-                .expect("skill context");
+        let rendered = render_dir_context(&tmpdir.path().join("skills")).expect("skill context");
         assert!(
             rendered.contains("alpha beta"),
             "strip-chomped folded block should join lines, got:\n{rendered}"
@@ -1511,9 +1493,7 @@ mod tests {
             "plain-skill",
             "---\nname: plain-skill\ndescription: A simple description\n---\nbody",
         );
-        let rendered =
-            crate::skills::render_available_skills_context(&tmpdir.path().join("skills"))
-                .expect("skill context");
+        let rendered = render_dir_context(&tmpdir.path().join("skills")).expect("skill context");
         assert!(
             rendered.contains("- plain-skill: A simple description"),
             "single-line description should still work, got:\n{rendered}"

--- a/crates/tui/src/skills/mod.rs
+++ b/crates/tui/src/skills/mod.rs
@@ -632,6 +632,22 @@ pub fn render_available_skills_context(skills_dir: &Path) -> Option<String> {
     render_skills_block(&registry)
 }
 
+/// Union variant: merge skills discovered in the `workspace` (cross-tool skill
+/// folders) **and** an explicitly-configured `skills_dir`. Use this when an
+/// embedder injects a dedicated `skills_dir` that must stay visible even when
+/// the workspace already contains skills of its own — a plain `or_else` between
+/// the workspace view and the dir view shadows the configured `skills_dir`
+/// whenever `discover_in_workspace` returns any skill, so embedder-provided
+/// skills silently disappear.
+#[must_use]
+pub fn render_available_skills_context_for_workspace_and_dir(
+    workspace: &Path,
+    skills_dir: &Path,
+) -> Option<String> {
+    let registry = discover_for_workspace_and_dir(workspace, skills_dir);
+    render_skills_block(&registry)
+}
+
 fn render_skills_block(registry: &SkillRegistry) -> Option<String> {
     if registry.is_empty() {
         return None;


### PR DESCRIPTION
## Problem

The system-prompt skills block is built as:

```rust
render_available_skills_context_for_workspace(workspace)
    .or_else(|| skills_dir.and_then(render_available_skills_context))
```

`discover_in_workspace` returns `Some` whenever the workspace contains **any** skill (very common when the workspace is broad). The `or_else` fallback then never runs, so a `skills_dir` configured via `EngineConfig.skills_dir` is silently shadowed and embedder-provided skills never reach the model.

## Fix

Add `render_available_skills_context_for_workspace_and_dir`, built on the existing `discover_for_workspace_and_dir` union, and call it when `skills_dir` is set so the workspace view and the configured dir **merge** instead of one shadowing the other.

- No behaviour change when `skills_dir` is `None` (still the workspace-only view).
- Reuses the existing union discovery; no new discovery logic.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a silent skill-shadowing bug: when the workspace contained any skills, the `or_else` chain caused an embedder-configured `skills_dir` to be completely ignored. The fix replaces that chain with `map_or_else` so the two sources are always merged when `skills_dir` is set.

- **`prompts.rs`**: Switches from `render_available_skills_context_for_workspace(...).or_else(|| skills_dir.and_then(...))` to `skills_dir.map_or_else(|| workspace-only, |dir| union)`, ensuring the configured dir is never shadowed.
- **`skills/mod.rs`**: Adds `render_available_skills_context_for_workspace_and_dir`, a thin wrapper over the already-tested `discover_for_workspace_and_dir` union; retires the old single-dir public entry point and introduces a private `render_dir_context` test helper so all existing render-level unit tests continue to exercise the same code paths.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted, well-scoped fix with no behavior change when skills_dir is absent and correct union semantics when it is set.

The fix is structurally simple: a two-branch map_or_else dispatch whose 'no skills_dir' branch is unchanged from before, and whose union branch delegates entirely to discover_for_workspace_and_dir, which is already exercised by existing tests. The retired render_available_skills_context single-dir public function had no callers outside this crate, so removing it introduces no breakage. Discovery-layer deduplication and the is_dir() guard are both preserved. No new logic is introduced.

No files require special attention.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/tui/src/skills/mod.rs | Replaces the removed single-dir render_available_skills_context with the new render_available_skills_context_for_workspace_and_dir union function; updates tests to use the private render_dir_context helper so unit coverage is preserved without re-exporting the old entrypoint. |
| crates/tui/src/prompts.rs | Rewrites the skills-block construction from or_else fallback semantics to map_or_else union semantics: when skills_dir is set, the configured directory is always merged with workspace discovery instead of being silently shadowed. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[system_prompt_for_mode_with_context_skills_session_and_approval] --> B{skills_dir set?}
    B -- No --> C[render_available_skills_context_for_workspace\nworkspace-only discovery]
    B -- Yes --> D[render_available_skills_context_for_workspace_and_dir\nunion discovery]
    D --> E[discover_for_workspace_and_dir]
    E --> F[skills_directories workspace\n.agents/skills, .claude/skills, etc.]
    E --> G{skills_dir already\nin dirs list?}
    G -- No --> H[Append skills_dir to dirs]
    G -- Yes --> I[Skip duplicate]
    H --> J[discover_from_directories\nfirst-match-wins merge]
    I --> J
    F --> J
    C --> K[discover_in_workspace]
    K --> J
    J --> L[render_skills_block]
    L --> M{registry empty?}
    M -- Yes --> N[None — no block appended]
    M -- No --> O[Some — block appended to system prompt]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/tui/src/prompts.rs`, line 1067-1076 ([link](https://github.com/hmbown/codewhale/blob/38f6040ce8f343ff192fd6ce57ed672648e662a0/crates/tui/src/prompts.rs#L1067-L1076)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The sentence "The legacy single-`skills_dir` path is honoured as a fallback…" directly contradicts the paragraph that immediately follows it, which explains that `skills_dir` is no longer a fallback. The old description should be removed so only the accurate explanation remains.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fskills-dir-union-not-shadowed%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fskills-dir-union-not-shadowed%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fprompts.rs%0ALine%3A%201067-1076%0A%0AComment%3A%0AThe%20sentence%20%22The%20legacy%20single-%60skills_dir%60%20path%20is%20honoured%20as%20a%20fallback%E2%80%A6%22%20directly%20contradicts%20the%20paragraph%20that%20immediately%20follows%20it%2C%20which%20explains%20that%20%60skills_dir%60%20is%20no%20longer%20a%20fallback.%20The%20old%20description%20should%20be%20removed%20so%20only%20the%20accurate%20explanation%20remains.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%203.%20Skills%20block.%20%23432%3A%20walks%20every%20candidate%20workspace%0A%20%20%20%20%2F%2F%20skills%20directory%20%28%60.agents%2Fskills%60%2C%20%60skills%60%2C%0A%20%20%20%20%2F%2F%20%60.opencode%2Fskills%60%2C%20%60.claude%2Fskills%60%2C%20%60.cursor%2Fskills%60%29%20plus%20global%0A%20%20%20%20%2F%2F%20%60~%2F.agents%2Fskills%60%20%2F%20%60~%2F.deepseek%2Fskills%60%20so%20skills%20installed%20for%20any%0A%20%20%20%20%2F%2F%20AI-tool%20convention%20show%20up%20in%20the%20catalogue.%0A%20%20%20%20%2F%2F%20When%20an%20explicit%20%60skills_dir%60%20is%20configured%2C%20union%20it%20with%20the%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fprompts.rs%0ALine%3A%201067-1076%0A%0AComment%3A%0AThe%20sentence%20%22The%20legacy%20single-%60skills_dir%60%20path%20is%20honoured%20as%20a%20fallback%E2%80%A6%22%20directly%20contradicts%20the%20paragraph%20that%20immediately%20follows%20it%2C%20which%20explains%20that%20%60skills_dir%60%20is%20no%20longer%20a%20fallback.%20The%20old%20description%20should%20be%20removed%20so%20only%20the%20accurate%20explanation%20remains.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%203.%20Skills%20block.%20%23432%3A%20walks%20every%20candidate%20workspace%0A%20%20%20%20%2F%2F%20skills%20directory%20%28%60.agents%2Fskills%60%2C%20%60skills%60%2C%0A%20%20%20%20%2F%2F%20%60.opencode%2Fskills%60%2C%20%60.claude%2Fskills%60%2C%20%60.cursor%2Fskills%60%29%20plus%20global%0A%20%20%20%20%2F%2F%20%60~%2F.agents%2Fskills%60%20%2F%20%60~%2F.deepseek%2Fskills%60%20so%20skills%20installed%20for%20any%0A%20%20%20%20%2F%2F%20AI-tool%20convention%20show%20up%20in%20the%20catalogue.%0A%20%20%20%20%2F%2F%20When%20an%20explicit%20%60skills_dir%60%20is%20configured%2C%20union%20it%20with%20the%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2737&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Fprompts.rs%0ALine%3A%201067-1076%0A%0AComment%3A%0AThe%20sentence%20%22The%20legacy%20single-%60skills_dir%60%20path%20is%20honoured%20as%20a%20fallback%E2%80%A6%22%20directly%20contradicts%20the%20paragraph%20that%20immediately%20follows%20it%2C%20which%20explains%20that%20%60skills_dir%60%20is%20no%20longer%20a%20fallback.%20The%20old%20description%20should%20be%20removed%20so%20only%20the%20accurate%20explanation%20remains.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%203.%20Skills%20block.%20%23432%3A%20walks%20every%20candidate%20workspace%0A%20%20%20%20%2F%2F%20skills%20directory%20%28%60.agents%2Fskills%60%2C%20%60skills%60%2C%0A%20%20%20%20%2F%2F%20%60.opencode%2Fskills%60%2C%20%60.claude%2Fskills%60%2C%20%60.cursor%2Fskills%60%29%20plus%20global%0A%20%20%20%20%2F%2F%20%60~%2F.agents%2Fskills%60%20%2F%20%60~%2F.deepseek%2Fskills%60%20so%20skills%20installed%20for%20any%0A%20%20%20%20%2F%2F%20AI-tool%20convention%20show%20up%20in%20the%20catalogue.%0A%20%20%20%20%2F%2F%20When%20an%20explicit%20%60skills_dir%60%20is%20configured%2C%20union%20it%20with%20the%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2737&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(skills): remove dead render\_availabl..."](https://github.com/hmbown/codewhale/commit/f93be569caa7cf7ca6490977acd9862561106c89) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35542499)</sub>

<!-- /greptile_comment -->