### PR TITLE
feat(transcript): collapse dense tool-call runs into expandable summaries (#2692)

### DIFF
--- a/crates/tui/src/commands/config.rs
+++ b/crates/tui/src/commands/config.rs
@@ -204,6 +204,9 @@ fn show_single_setting(app: &App, key: &str) -> CommandResult {
         "max_history" | "history" => Some(app.max_input_history.to_string()),
         "sidebar_width" | "sidebar" => Some(app.sidebar_width_percent.to_string()),
         "sidebar_focus" | "focus" => Some(app.sidebar_focus.as_setting().to_string()),
+        "tool_collapse" | "collapse" => {
+            Some(format!("{:?}", app.tool_collapse_mode).to_lowercase())
+        }
         "context_panel" | "context" | "session_panel" => {
             Some(if app.context_panel { "true" } else { "false" }.to_string())
         }
@@ -882,6 +885,11 @@ pub fn set_config_value(app: &mut App, key: &str, value: &str, persist: bool) ->
         }
         "sidebar_width" | "sidebar" => {
             app.sidebar_width_percent = settings.sidebar_width_percent;
+            app.mark_history_updated();
+        }
+        "tool_collapse" | "collapse" => {
+            app.tool_collapse_mode =
+                crate::tui::app::ToolCollapseMode::from_setting(&settings.tool_collapse_mode);
             app.mark_history_updated();
         }
         "sidebar_focus" | "focus" => {

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -203,6 +203,8 @@ pub struct Settings {
     pub auto_compact_threshold_percent: f64,
     /// Reduce status noise and collapse details more aggressively
     pub calm_mode: bool,
+    /// Tool run collapse mode: expanded, compact, or calm.
+    pub tool_collapse_mode: String,
     /// Streaming pacing mode. `true` pins the chunker to one-character-per-
     /// commit-tick (typewriter); `false` drains the upstream cadence (each
     /// commit flushes everything queued, which matches V4-pro's burst pattern
@@ -330,6 +332,7 @@ impl Default for Settings {
             auto_compact: false,
             auto_compact_threshold_percent: 80.0,
             calm_mode: false,
+            tool_collapse_mode: "expanded".to_string(),
             low_motion: false,
             fancy_animations: true,
             bracketed_paste: true,

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -327,6 +327,28 @@ impl SidebarFocus {
     }
 }
 
+/// Controls how contiguous tool-call runs are collapsed in the transcript.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolCollapseMode {
+    /// Never collapse; all tool cells rendered individually.
+    Expanded,
+    /// Collapse runs exceeding the threshold into a single summary row.
+    Compact,
+    /// Collapse only when calm_mode is active.
+    Calm,
+}
+
+impl ToolCollapseMode {
+    #[must_use]
+    pub fn from_setting(value: &str) -> Self {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "compact" => Self::Compact,
+            "calm" => Self::Calm,
+            _ => Self::Expanded,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StatusToastLevel {
     Info,
@@ -1320,10 +1342,12 @@ pub struct App {
     pub sidebar_width_dirty: bool,
     /// Whether the session-context panel is enabled (#504).
     pub context_panel: bool,
-    /// Indices of tool runs currently collapsed (group start positions).
-    pub collapsed_tool_runs: HashSet<usize>,
     /// Minimum consecutive tool calls to trigger collapse (default 3).
     pub tool_collapse_threshold: usize,
+    /// Which tool runs are currently expanded (clicked open by user).
+    pub expanded_tool_runs: HashSet<usize>,
+    /// Current tool collapse mode.
+    pub tool_collapse_mode: ToolCollapseMode,
     /// File-tree pane state. `None` when hidden; `Some` when visible.
     pub file_tree: Option<crate::tui::file_tree::FileTreeState>,
     /// Whether the file-tree pane was actually rendered in the last frame.
@@ -2052,8 +2076,9 @@ impl App {
             sidebar_resize_total_width: 0,
             sidebar_width_dirty: false,
             context_panel: settings.context_panel,
-            collapsed_tool_runs: HashSet::new(),
             tool_collapse_threshold: 3,
+            expanded_tool_runs: HashSet::new(),
+            tool_collapse_mode: ToolCollapseMode::from_setting(&settings.tool_collapse_mode),
             file_tree: None,
             file_tree_visible: false,
             compact_threshold,

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -1320,6 +1320,10 @@ pub struct App {
     pub sidebar_width_dirty: bool,
     /// Whether the session-context panel is enabled (#504).
     pub context_panel: bool,
+    /// Indices of tool runs currently collapsed (group start positions).
+    pub collapsed_tool_runs: HashSet<usize>,
+    /// Minimum consecutive tool calls to trigger collapse (default 3).
+    pub tool_collapse_threshold: usize,
     /// File-tree pane state. `None` when hidden; `Some` when visible.
     pub file_tree: Option<crate::tui::file_tree::FileTreeState>,
     /// Whether the file-tree pane was actually rendered in the last frame.
@@ -2048,6 +2052,8 @@ impl App {
             sidebar_resize_total_width: 0,
             sidebar_width_dirty: false,
             context_panel: settings.context_panel,
+            collapsed_tool_runs: HashSet::new(),
+            tool_collapse_threshold: 3,
             file_tree: None,
             file_tree_visible: false,
             compact_threshold,

--- a/crates/tui/src/tui/history.rs
+++ b/crates/tui/src/tui/history.rs
@@ -676,6 +676,41 @@ pub enum ToolCell {
 }
 
 impl ToolCell {
+    /// Whether the tool completed successfully.
+    pub fn is_success(&self) -> bool {
+        self.status() == Some(ToolStatus::Success)
+    }
+
+    /// Whether the tool failed.
+    pub fn is_failed(&self) -> bool {
+        self.status() == Some(ToolStatus::Failed)
+    }
+
+    /// Whether this tool should never be collapsed (errors, approvals, writes).
+    pub fn is_collapsible_guard(&self) -> bool {
+        // Never collapse failed tools, running tools, or destructive actions.
+        self.is_failed()
+            || self.is_running()
+            || matches!(self, ToolCell::PatchSummary(_) | ToolCell::Review(_))
+    }
+
+    fn is_running(&self) -> bool {
+        self.status() == Some(ToolStatus::Running)
+    }
+
+    fn status(&self) -> Option<ToolStatus> {
+        match self {
+            ToolCell::Exec(c) => Some(c.status),
+            ToolCell::Review(c) => Some(c.status),
+            ToolCell::WebSearch(c) => Some(c.status),
+            ToolCell::Generic(c) => Some(c.status),
+            // Variants without a status field naturally resolve to None,
+            // so they will never match is_success/is_failed and will not
+            // be collapsed.
+            _ => None,
+        }
+    }
+
     /// Render the tool cell into lines.
     pub fn lines(&self, width: u16) -> Vec<Line<'static>> {
         self.lines_with_motion(width, false)
@@ -3421,6 +3456,109 @@ fn looks_like_file_path(s: &str) -> bool {
     } else {
         false
     }
+}
+
+// ── Tool-run grouping for transcript collapse (#2692) ──────────────
+
+/// A contiguous run of tool-call cells in the transcript history.
+#[derive(Debug, Clone)]
+pub struct ToolRun {
+    /// Index of the first tool cell in `app.history`.
+    pub start: usize,
+    /// Number of cells in this run.
+    pub count: usize,
+    /// Dominant tool names (up to 3, deduplicated).
+    pub tool_families: Vec<String>,
+    /// Count of successful tools.
+    pub ok_count: usize,
+    /// Count of failed tools.
+    pub failed_count: usize,
+    /// Whether any tool in the run is still running.
+    #[allow(dead_code)]
+    pub has_running: bool,
+}
+
+/// Detect contiguous runs of tool-call cells exceeding `min_size`.
+/// Never includes running or failed tools — they always render individually.
+pub fn detect_tool_runs(history: &[HistoryCell], min_size: usize) -> Vec<ToolRun> {
+    let mut runs = Vec::new();
+    let mut i = 0;
+    while i < history.len() {
+        if is_collapsible_tool(&history[i]) {
+            let start = i;
+            let mut tool_names: Vec<String> = Vec::new();
+            let mut ok_count = 0usize;
+            let mut failed_count = 0usize;
+            while i < history.len() && is_collapsible_tool(&history[i]) {
+                if let HistoryCell::Tool(tc) = &history[i] {
+                    let name = tool_display_name(tc);
+                    if !tool_names.contains(&name) {
+                        tool_names.push(name);
+                    }
+                    if tc.is_success() {
+                        ok_count += 1;
+                    } else if tc.is_failed() {
+                        failed_count += 1;
+                    }
+                }
+                i += 1;
+            }
+            let count = i - start;
+            if count >= min_size {
+                let families = if tool_names.len() <= 3 {
+                    tool_names
+                } else {
+                    tool_names.into_iter().take(3).collect()
+                };
+                runs.push(ToolRun {
+                    start,
+                    count,
+                    tool_families: families,
+                    ok_count,
+                    failed_count,
+                    has_running: false, // we never include running tools
+                });
+            }
+        } else {
+            i += 1;
+        }
+    }
+    runs
+}
+
+fn is_collapsible_tool(cell: &HistoryCell) -> bool {
+    matches!(cell, HistoryCell::Tool(tc) if tc.is_success() && !tc.is_collapsible_guard())
+}
+
+fn tool_display_name(tc: &ToolCell) -> String {
+    match tc {
+        ToolCell::Exec(c) => c
+            .command
+            .split_whitespace()
+            .next()
+            .unwrap_or("exec")
+            .to_string(),
+        ToolCell::Generic(c) => c.name.clone(),
+        ToolCell::Exploring(_) => "explore".to_string(),
+        ToolCell::PlanUpdate(_) => "update_plan".to_string(),
+        ToolCell::PatchSummary(_) => "apply_patch".to_string(),
+        ToolCell::Review(_) => "review".to_string(),
+        ToolCell::DiffPreview(_) => "diff".to_string(),
+        ToolCell::Mcp(_) => "mcp".to_string(),
+        ToolCell::ViewImage(_) => "view_image".to_string(),
+        ToolCell::WebSearch(_) => "web_search".to_string(),
+    }
+}
+
+/// Generate a summary text for a collapsed tool run.
+pub fn tool_run_summary(run: &ToolRun) -> String {
+    let tools = run.tool_families.join(", ");
+    let status = if run.failed_count == 0 {
+        format!("all ok")
+    } else {
+        format!("{} ok, {} failed", run.ok_count, run.failed_count)
+    };
+    format!("{} tools ({}) — {}", run.count, tools, status)
 }
 
 #[cfg(test)]

--- a/crates/tui/src/tui/history.rs
+++ b/crates/tui/src/tui/history.rs
@@ -3564,12 +3564,11 @@ pub fn tool_run_summary(run: &ToolRun) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        ASSISTANT_GLYPH, ExecCell, ExecSource, GenericToolCell, HistoryCell, PlanStep, ToolRun,
-        detect_tool_runs, tool_run_summary,
+        ASSISTANT_GLYPH, ExecCell, ExecSource, GenericToolCell, HistoryCell, PlanStep,
         PlanUpdateCell, REASONING_CURSOR, REASONING_OPENER, REASONING_RAIL, TOOL_RUNNING_SYMBOLS,
-        TOOL_STATUS_SYMBOL_MS, ToolCell, ToolStatus, TranscriptRenderOptions, USER_GLYPH,
-        assistant_label_style_for, extract_reasoning_summary, render_thinking,
-        running_status_label_with_elapsed,
+        TOOL_STATUS_SYMBOL_MS, ToolCell, ToolRun, ToolStatus, TranscriptRenderOptions, USER_GLYPH,
+        assistant_label_style_for, detect_tool_runs, extract_reasoning_summary, render_thinking,
+        running_status_label_with_elapsed, tool_run_summary,
     };
     use crate::deepseek_theme::Theme;
     use crate::models::{ContentBlock, Message};
@@ -5476,7 +5475,11 @@ mod tests {
         ];
         // Failed tool should split the run.
         let runs = detect_tool_runs(&history, 2);
-        assert_eq!(runs.len(), 1, "only one run should be detected (the first 2)");
+        assert_eq!(
+            runs.len(),
+            1,
+            "only one run should be detected (the first 2)"
+        );
         assert_eq!(runs[0].count, 2);
     }
 

--- a/crates/tui/src/tui/history.rs
+++ b/crates/tui/src/tui/history.rs
@@ -3564,7 +3564,8 @@ pub fn tool_run_summary(run: &ToolRun) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        ASSISTANT_GLYPH, ExecCell, ExecSource, GenericToolCell, HistoryCell, PlanStep,
+        ASSISTANT_GLYPH, ExecCell, ExecSource, GenericToolCell, HistoryCell, PlanStep, ToolRun,
+        detect_tool_runs, tool_run_summary,
         PlanUpdateCell, REASONING_CURSOR, REASONING_OPENER, REASONING_RAIL, TOOL_RUNNING_SYMBOLS,
         TOOL_STATUS_SYMBOL_MS, ToolCell, ToolStatus, TranscriptRenderOptions, USER_GLYPH,
         assistant_label_style_for, extract_reasoning_summary, render_thinking,
@@ -5404,5 +5405,124 @@ mod tests {
         let label_span = &lines[0].spans[0];
         assert_eq!(label_span.content.as_ref(), "Info");
         assert_eq!(label_span.style.fg, Some(palette::TEXT_DIM));
+    }
+
+    // ── Tool run detection tests (#2692) ──────────────────────────
+
+    fn make_success_tool(name: &str) -> HistoryCell {
+        HistoryCell::Tool(ToolCell::Generic(GenericToolCell {
+            name: name.to_string(),
+            status: ToolStatus::Success,
+            input_summary: Some(format!("args for {name}")),
+            output: Some(format!("output for {name}")),
+            prompts: None,
+            spillover_path: None,
+            output_summary: None,
+            is_diff: false,
+        }))
+    }
+
+    fn make_failed_tool(name: &str) -> HistoryCell {
+        HistoryCell::Tool(ToolCell::Generic(GenericToolCell {
+            name: name.to_string(),
+            status: ToolStatus::Failed,
+            input_summary: None,
+            output: Some("error output".to_string()),
+            prompts: None,
+            spillover_path: None,
+            output_summary: None,
+            is_diff: false,
+        }))
+    }
+
+    #[test]
+    fn detect_tool_runs_finds_contiguous_success_run() {
+        let history = vec![
+            HistoryCell::User {
+                content: "hi".into(),
+            },
+            make_success_tool("read_file"),
+            make_success_tool("grep_files"),
+            make_success_tool("file_search"),
+            HistoryCell::User {
+                content: "ok".into(),
+            },
+        ];
+        let runs = detect_tool_runs(&history, 2);
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].start, 1);
+        assert_eq!(runs[0].count, 3);
+        assert!(runs[0].tool_families.contains(&"read_file".to_string()));
+    }
+
+    #[test]
+    fn detect_tool_runs_skips_short_runs() {
+        let history = vec![
+            make_success_tool("read_file"),
+            make_success_tool("grep_files"),
+        ];
+        // With threshold 3, a run of 2 should not be detected.
+        let runs = detect_tool_runs(&history, 3);
+        assert!(runs.is_empty());
+    }
+
+    #[test]
+    fn detect_tool_runs_splits_on_failed_tool() {
+        let history = vec![
+            make_success_tool("read_file"),
+            make_success_tool("grep_files"),
+            make_failed_tool("exec_shell"),
+            make_success_tool("file_search"),
+        ];
+        // Failed tool should split the run.
+        let runs = detect_tool_runs(&history, 2);
+        assert_eq!(runs.len(), 1, "only one run should be detected (the first 2)");
+        assert_eq!(runs[0].count, 2);
+    }
+
+    #[test]
+    fn detect_tool_runs_skips_non_tool_cells() {
+        let history = vec![
+            make_success_tool("read_file"),
+            HistoryCell::Assistant {
+                content: "thinking...".into(),
+                streaming: false,
+            },
+            make_success_tool("grep_files"),
+        ];
+        let runs = detect_tool_runs(&history, 2);
+        assert!(runs.is_empty(), "assistant cell should break the run");
+    }
+
+    #[test]
+    fn tool_run_summary_format() {
+        let run = ToolRun {
+            start: 0,
+            count: 5,
+            tool_families: vec!["read_file".into(), "grep_files".into()],
+            ok_count: 5,
+            failed_count: 0,
+            has_running: false,
+        };
+        let summary = tool_run_summary(&run);
+        assert!(summary.contains("5 tools"));
+        assert!(summary.contains("read_file"));
+        assert!(summary.contains("grep_files"));
+        assert!(summary.contains("all ok"));
+    }
+
+    #[test]
+    fn tool_run_summary_shows_failures() {
+        let run = ToolRun {
+            start: 0,
+            count: 4,
+            tool_families: vec!["exec_shell".into()],
+            ok_count: 3,
+            failed_count: 1,
+            has_running: false,
+        };
+        let summary = tool_run_summary(&run);
+        assert!(summary.contains("3 ok"));
+        assert!(summary.contains("1 failed"));
     }
 }

--- a/crates/tui/src/tui/mouse_ui.rs
+++ b/crates/tui/src/tui/mouse_ui.rs
@@ -42,6 +42,47 @@ pub(crate) fn should_drop_loading_mouse_motion(app: &App, mouse: MouseEvent) -> 
     }
 }
 
+/// Toggle a collapsed tool-run summary on click. Returns true if handled.
+fn toggle_tool_run_expand(app: &mut App, mouse: MouseEvent) -> bool {
+    let Some(area) = app.viewport.last_transcript_area else {
+        return false;
+    };
+    if mouse.column < area.x
+        || mouse.column >= area.x.saturating_add(area.width)
+        || mouse.row < area.y
+        || mouse.row >= area.y.saturating_add(area.height)
+    {
+        return false;
+    }
+    // Walk the collapsed_cell_map to find the original history index that
+    // the click maps to, then check if it's a collapsed tool run start.
+    let Some(filtered_idx) = transcript_cell_index_from_mouse(app, mouse) else {
+        return false;
+    };
+    let Some(original_idx) = app.collapsed_cell_map.get(filtered_idx).copied() else {
+        return false;
+    };
+    // If this index is a collapsed tool run start, toggle its expansion.
+    if app.expanded_tool_runs.contains(&original_idx) {
+        app.expanded_tool_runs.remove(&original_idx);
+        app.mark_history_updated();
+        return true;
+    }
+    // Check tool runs: if the original_idx is a detected run start and
+    // not expanded, expand it (this means it was collapsed).
+    let tool_runs = if app.tool_collapse_threshold > 0 {
+        crate::tui::history::detect_tool_runs(&app.history, app.tool_collapse_threshold)
+    } else {
+        return false;
+    };
+    if tool_runs.iter().any(|r| r.start == original_idx) {
+        app.expanded_tool_runs.insert(original_idx);
+        app.mark_history_updated();
+        return true;
+    }
+    false
+}
+
 /// Handle mouse events on the sidebar resize handle (the 1-col vertical bar
 /// between the chat area and the sidebar). Returns true when the event was
 /// consumed so other handlers skip it.
@@ -364,6 +405,11 @@ pub(crate) fn handle_mouse_event(app: &mut App, mouse: MouseEvent) -> Vec<ViewEv
 
             if mouse_hits_rect(mouse, app.viewport.jump_to_latest_button_area) {
                 app.scroll_to_bottom();
+                return Vec::new();
+            }
+
+            // Check for click on collapsed tool run summary to expand.
+            if toggle_tool_run_expand(app, mouse) {
                 return Vec::new();
             }
 

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -22,6 +22,7 @@ pub use footer::{
 pub use header::{HeaderData, HeaderWidget, header_status_indicator_frame};
 pub use renderable::Renderable;
 
+use std::collections::HashSet;
 use std::time::Duration;
 
 use crate::localization::Locale;
@@ -30,7 +31,7 @@ use crate::tui::app::{App, AppMode, ComposerDensity, VimMode};
 use crate::tui::approval::{
     ApprovalRequest, ApprovalView, ElevationOption, ElevationRequest, RiskLevel, ToolCategory,
 };
-use crate::tui::history::HistoryCell;
+use crate::tui::history::{GenericToolCell, HistoryCell, ToolCell, ToolStatus};
 use crate::tui::scrolling::TranscriptLineMeta;
 use crate::{
     commands,
@@ -170,8 +171,52 @@ impl ChatWidget {
             let mut filtered_to_original: Vec<usize> =
                 Vec::with_capacity(history_len + active_entries.len());
 
+            // Detect contiguous tool runs for collapse (#2692). Runs that
+            // exceed `tool_collapse_threshold` are replaced by a single
+            // summary cell when collapsed.
+            let tool_runs = if app.tool_collapse_threshold > 0 {
+                crate::tui::history::detect_tool_runs(&app.history, app.tool_collapse_threshold)
+            } else {
+                Vec::new()
+            };
+            // Build a quick-lookup set of indices to skip.
+            let mut collapsed_skip: HashSet<usize> = HashSet::new();
+            for run in &tool_runs {
+                if !app.collapsed_tool_runs.contains(&run.start) {
+                    continue;
+                }
+                for offset in 1..run.count {
+                    collapsed_skip.insert(run.start + offset);
+                }
+            }
+
             for (idx, cell) in app.history.iter().enumerate() {
                 if app.collapsed_cells.contains(&idx) {
+                    continue;
+                }
+                if collapsed_skip.contains(&idx) {
+                    continue;
+                }
+                // Replace the first cell of a collapsed tool run with
+                // a compact summary cell.
+                if let Some(run) = tool_runs
+                    .iter()
+                    .find(|r| r.start == idx && app.collapsed_tool_runs.contains(&r.start))
+                {
+                    let summary = crate::tui::history::tool_run_summary(run);
+                    let summary_cell = HistoryCell::Tool(ToolCell::Generic(GenericToolCell {
+                        name: format!("▼ {} tools collapsed", run.count),
+                        status: ToolStatus::Success,
+                        input_summary: Some(summary),
+                        output: None,
+                        prompts: None,
+                        spillover_path: None,
+                        output_summary: None,
+                        is_diff: false,
+                    }));
+                    filtered_cells.push(summary_cell);
+                    filtered_revs.push(app.history_revisions[idx]);
+                    filtered_to_original.push(idx);
                     continue;
                 }
                 filtered_cells.push(cell.clone());

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -171,10 +171,15 @@ impl ChatWidget {
             let mut filtered_to_original: Vec<usize> =
                 Vec::with_capacity(history_len + active_entries.len());
 
-            // Detect contiguous tool runs for collapse (#2692). Runs that
-            // exceed `tool_collapse_threshold` are replaced by a single
-            // summary cell when collapsed.
-            let tool_runs = if app.tool_collapse_threshold > 0 {
+            // Detect contiguous tool runs for collapse (#2692).
+            let collapse_active = match app.tool_collapse_mode {
+                crate::tui::app::ToolCollapseMode::Compact => true,
+                crate::tui::app::ToolCollapseMode::Calm => {
+                    app.transcript_render_options().calm_mode
+                }
+                crate::tui::app::ToolCollapseMode::Expanded => false,
+            };
+            let tool_runs = if collapse_active && app.tool_collapse_threshold > 0 {
                 crate::tui::history::detect_tool_runs(&app.history, app.tool_collapse_threshold)
             } else {
                 Vec::new()
@@ -182,7 +187,7 @@ impl ChatWidget {
             // Build a quick-lookup set of indices to skip.
             let mut collapsed_skip: HashSet<usize> = HashSet::new();
             for run in &tool_runs {
-                if !app.collapsed_tool_runs.contains(&run.start) {
+                if app.expanded_tool_runs.contains(&run.start) {
                     continue;
                 }
                 for offset in 1..run.count {
@@ -201,7 +206,7 @@ impl ChatWidget {
                 // a compact summary cell.
                 if let Some(run) = tool_runs
                     .iter()
-                    .find(|r| r.start == idx && app.collapsed_tool_runs.contains(&r.start))
+                    .find(|r| r.start == idx && !app.expanded_tool_runs.contains(&r.start))
                 {
                     let summary = crate::tui::history::tool_run_summary(run);
                     let summary_cell = HistoryCell::Tool(ToolCell::Generic(GenericToolCell {


### PR DESCRIPTION
hen many consecutive tool calls appear in the transcript, collapse
them into a compact summary row showing count, dominant tool families,
and success/failure state. Full details are preserved behind expansion.

Changes:
- `crates/tui/src/tui/history.rs`:
  - Add `ToolRun` struct and `detect_tool_runs()` grouping function
  - Add `is_success()`, `is_failed()`, `is_collapsible_guard()` to ToolCell
  - Add `tool_display_name()` and `tool_run_summary()` helpers
  - Tools that are running, failed, or destructive (patches, reviews)
    are never collapsed
- `crates/tui/src/tui/app.rs`:
  - Add `collapsed_tool_runs: HashSet<usize>` and
    `tool_collapse_threshold: usize` (default 3)
- `crates/tui/src/tui/widgets/mod.rs`:
  - Pre-process tool runs before rendering: when collapsed, replace N
    individual tool cells with one summary cell

Closes #2692

## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces collapsible tool-call runs in the transcript: consecutive successful tool cells are detected, grouped, and replaced with a single expandable summary row showing count, dominant tool families, and success state. A new `ToolCollapseMode` enum (`Expanded` / `Compact` / `Calm`) controls behaviour, wired through settings and the `/config tool_collapse` command.

- `detect_tool_runs()` in `history.rs` scans history for contiguous collapsible cells and produces `ToolRun` descriptors; `widgets/mod.rs` consumes these to substitute synthetic summary cells before rendering.
- `toggle_tool_run_expand` in `mouse_ui.rs` handles click-to-toggle by mutating `expanded_tool_runs`, but is missing a `tool_collapse_mode` guard — in the default `Expanded` mode it still calls `detect_tool_runs` on every left-click and may silently consume the event, blocking text-selection starts on run-boundary cells.
- `detect_tool_runs` gates entry via `is_success() && !is_collapsible_guard()`, which means `failed_count` in `ToolRun` is structurally always zero, making the `"{N} ok, {N} failed"` branch of `tool_run_summary` unreachable. The same gate also makes `ToolCell::Exploring`, `Mcp`, `DiffPreview`, `PlanUpdate`, and `ViewImage` variants (which have no `status` field) permanently ineligible for collapsing.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The feature ships with several interacting correctness gaps that affect default-mode users and the accuracy of the summary display.

Three independent defects exist in the changed code: the mouse handler runs and mutates state (and consumes clicks) even when collapsing is completely disabled; `expanded_tool_runs` is never pruned when history is truncated, leaving stale indices that force runs open after a backtrack; and the `failed_count` field plus the failure-summary branch are structurally unreachable because the run-detection gate already excludes failed cells.

mouse_ui.rs (missing mode guard in toggle_tool_run_expand) and app.rs (truncate_history_to does not retain expanded_tool_runs) need the most attention before this is merged.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/history.rs | Adds ToolRun struct, detect_tool_runs(), is_success/is_failed/is_collapsible_guard helpers, and tool_run_summary(). The failed_count field and the "{N} ok, {N} failed" summary branch are structurally unreachable because is_collapsible_tool gates on is_success(), excluding any cell that could set failed_count > 0. The format!("all ok") call is a Clippy lint. |
| crates/tui/src/tui/app.rs | Adds tool_collapse_threshold, expanded_tool_runs, and tool_collapse_mode fields. expanded_tool_runs is correctly mutated by toggle_tool_run_expand, but truncate_history_to cleans up collapsed_cells without a matching retain on expanded_tool_runs, leaving stale indices that can cause incorrect expansion state after history truncation. |
| crates/tui/src/tui/mouse_ui.rs | Adds toggle_tool_run_expand() to handle click-to-expand collapsed summaries. Missing tool_collapse_mode guard: in the default Expanded mode the function still calls detect_tool_runs on every Left-Down event and may insert into expanded_tool_runs and consume the click, silently preventing text-selection starts on run-boundary cells. |
| crates/tui/src/tui/widgets/mod.rs | Pre-render collapse pass correctly builds collapsed_skip and replaces run-start cells with synthetic GenericToolCell summaries. collapse_active guard properly gates on tool_collapse_mode, which toggle_tool_run_expand in mouse_ui.rs lacks. |
| crates/tui/src/settings.rs | Adds tool_collapse_mode String field defaulting to "expanded". Straightforward and correct. |
| crates/tui/src/commands/config.rs | Wires /config tool_collapse show and set commands. The set branch falls through to the default display_value arm, so the echo back shows the raw user input rather than the normalised stored value (e.g. "COMPACT" instead of "compact"), but this is cosmetic only. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ChatWidget render] --> B{collapse_active?}
    B -- Compact / Calm+calm_mode --> C[detect_tool_runs app.history]
    B -- Expanded --> D[tool_runs = empty]
    C --> E[Build collapsed_skip set]
    E --> F{For each history cell}
    F -- in collapsed_cells --> G[skip]
    F -- in collapsed_skip --> G
    F -- run.start AND not expanded --> H[Push synthetic summary cell]
    F -- normal cell --> I[Push original cell]
    H --> J[filtered_to_original → collapsed_cell_map]
    I --> J
    K[Left mouse Down in transcript] --> L[toggle_tool_run_expand]
    L --> M{No mode guard!}
    M --> N[transcript_cell_index_from_mouse]
    N --> O[collapsed_cell_map → original_idx]
    O --> P{in expanded_tool_runs?}
    P -- yes --> Q[Remove → collapse → consume click]
    P -- no --> R[detect_tool_runs again]
    R --> S{is a run start?}
    S -- yes --> T[Insert → expand → consume click]
    S -- no --> U[return false → text selection proceeds]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/tui/src/tui/app.rs`, line 2782-2784 ([link](https://github.com/hmbown/codewhale/blob/0a9a5d7c6ab62b3df713e7a18ca2bf18ad09ea43/crates/tui/src/tui/app.rs#L2782-L2784)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`expanded_tool_runs` not pruned in tail-truncation path**

   `truncate_history_to_n` calls `self.collapsed_cells.retain(|idx| *idx < new_len)` to drop cells that now point past the new tail, but `expanded_tool_runs` has no corresponding `retain`. After truncation, stale run-start indices remain in the set. If new tool runs are appended that coincidentally reuse those indices, they will render as already expanded, bypassing the collapsed summary row unexpectedly.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Ftranscript-tool-collapse%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Ftranscript-tool-collapse%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%0ALine%3A%202782-2784%0A%0AComment%3A%0A**%60expanded_tool_runs%60%20not%20pruned%20in%20tail-truncation%20path**%0A%0A%60truncate_history_to_n%60%20calls%20%60self.collapsed_cells.retain%28%7Cidx%7C%20*idx%20%3C%20new_len%29%60%20to%20drop%20cells%20that%20now%20point%20past%20the%20new%20tail%2C%20but%20%60expanded_tool_runs%60%20has%20no%20corresponding%20%60retain%60.%20After%20truncation%2C%20stale%20run-start%20indices%20remain%20in%20the%20set.%20If%20new%20tool%20runs%20are%20appended%20that%20coincidentally%20reuse%20those%20indices%2C%20they%20will%20render%20as%20already%20expanded%2C%20bypassing%20the%20collapsed%20summary%20row%20unexpectedly.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%0ALine%3A%202782-2784%0A%0AComment%3A%0A**%60expanded_tool_runs%60%20not%20pruned%20in%20tail-truncation%20path**%0A%0A%60truncate_history_to_n%60%20calls%20%60self.collapsed_cells.retain%28%7Cidx%7C%20*idx%20%3C%20new_len%29%60%20to%20drop%20cells%20that%20now%20point%20past%20the%20new%20tail%2C%20but%20%60expanded_tool_runs%60%20has%20no%20corresponding%20%60retain%60.%20After%20truncation%2C%20stale%20run-start%20indices%20remain%20in%20the%20set.%20If%20new%20tool%20runs%20are%20appended%20that%20coincidentally%20reuse%20those%20indices%2C%20they%20will%20render%20as%20already%20expanded%2C%20bypassing%20the%20collapsed%20summary%20row%20unexpectedly.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2738&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fapp.rs%0ALine%3A%202782-2784%0A%0AComment%3A%0A**%60expanded_tool_runs%60%20not%20pruned%20in%20tail-truncation%20path**%0A%0A%60truncate_history_to_n%60%20calls%20%60self.collapsed_cells.retain%28%7Cidx%7C%20*idx%20%3C%20new_len%29%60%20to%20drop%20cells%20that%20now%20point%20past%20the%20new%20tail%2C%20but%20%60expanded_tool_runs%60%20has%20no%20corresponding%20%60retain%60.%20After%20truncation%2C%20stale%20run-start%20indices%20remain%20in%20the%20set.%20If%20new%20tool%20runs%20are%20appended%20that%20coincidentally%20reuse%20those%20indices%2C%20they%20will%20render%20as%20already%20expanded%2C%20bypassing%20the%20collapsed%20summary%20row%20unexpectedly.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2738&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Ftranscript-tool-collapse%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Ftranscript-tool-collapse%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fhistory.rs%3A3533-3550%0A**Dead%20match%20arms%20for%20status-less%20%60ToolCell%60%20variants**%0A%0A%60ToolCell%3A%3AExploring%60%2C%20%60PlanUpdate%60%2C%20%60DiffPreview%60%2C%20%60Mcp%60%2C%20and%20%60ViewImage%60%20all%20return%20%60None%60%20from%20%60status%28%29%60%2C%20so%20%60is_success%28%29%60%20is%20always%20%60false%60%20for%20them%2C%20and%20%60is_collapsible_tool%60%20is%20therefore%20also%20always%20%60false%60.%20The%20arms%20for%20those%20variants%20in%20%60tool_display_name%60%20are%20dead%20code%20and%20will%20never%20be%20reached%20from%20%60detect_tool_runs%60.%20A%20practical%20consequence%20is%20that%20long%20consecutive%20runs%20of%20MCP%20calls%2C%20file%20explorations%2C%20or%20diff%20previews%20are%20never%20collapsed%20regardless%20of%20the%20mode%20setting%2C%20which%20may%20surprise%20users%20given%20the%20function%20hints%20they%20were%20meant%20to%20be%20displayable%20in%20summaries.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fhistory.rs%3A3556-3558%0A%60format!%28%22all%20ok%22%29%60%20with%20no%20interpolation%20arguments%20is%20flagged%20by%20%60clippy%3A%3Auseless_format%60.%20Use%20%60%22all%20ok%22.to_string%28%29%60%20instead.%0A%0A%60%60%60suggestion%0A%20%20%20%20let%20status%20%3D%20if%20run.failed_count%20%3D%3D%200%20%7B%0A%20%20%20%20%20%20%20%20%22all%20ok%22.to_string%28%29%0A%20%20%20%20%7D%20else%20%7B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fhistory.rs%3A3533-3550%0A**Dead%20match%20arms%20for%20status-less%20%60ToolCell%60%20variants**%0A%0A%60ToolCell%3A%3AExploring%60%2C%20%60PlanUpdate%60%2C%20%60DiffPreview%60%2C%20%60Mcp%60%2C%20and%20%60ViewImage%60%20all%20return%20%60None%60%20from%20%60status%28%29%60%2C%20so%20%60is_success%28%29%60%20is%20always%20%60false%60%20for%20them%2C%20and%20%60is_collapsible_tool%60%20is%20therefore%20also%20always%20%60false%60.%20The%20arms%20for%20those%20variants%20in%20%60tool_display_name%60%20are%20dead%20code%20and%20will%20never%20be%20reached%20from%20%60detect_tool_runs%60.%20A%20practical%20consequence%20is%20that%20long%20consecutive%20runs%20of%20MCP%20calls%2C%20file%20explorations%2C%20or%20diff%20previews%20are%20never%20collapsed%20regardless%20of%20the%20mode%20setting%2C%20which%20may%20surprise%20users%20given%20the%20function%20hints%20they%20were%20meant%20to%20be%20displayable%20in%20summaries.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fhistory.rs%3A3556-3558%0A%60format!%28%22all%20ok%22%29%60%20with%20no%20interpolation%20arguments%20is%20flagged%20by%20%60clippy%3A%3Auseless_format%60.%20Use%20%60%22all%20ok%22.to_string%28%29%60%20instead.%0A%0A%60%60%60suggestion%0A%20%20%20%20let%20status%20%3D%20if%20run.failed_count%20%3D%3D%200%20%7B%0A%20%20%20%20%20%20%20%20%22all%20ok%22.to_string%28%29%0A%20%20%20%20%7D%20else%20%7B%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2738&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fhistory.rs%3A3533-3550%0A**Dead%20match%20arms%20for%20status-less%20%60ToolCell%60%20variants**%0A%0A%60ToolCell%3A%3AExploring%60%2C%20%60PlanUpdate%60%2C%20%60DiffPreview%60%2C%20%60Mcp%60%2C%20and%20%60ViewImage%60%20all%20return%20%60None%60%20from%20%60status%28%29%60%2C%20so%20%60is_success%28%29%60%20is%20always%20%60false%60%20for%20them%2C%20and%20%60is_collapsible_tool%60%20is%20therefore%20also%20always%20%60false%60.%20The%20arms%20for%20those%20variants%20in%20%60tool_display_name%60%20are%20dead%20code%20and%20will%20never%20be%20reached%20from%20%60detect_tool_runs%60.%20A%20practical%20consequence%20is%20that%20long%20consecutive%20runs%20of%20MCP%20calls%2C%20file%20explorations%2C%20or%20diff%20previews%20are%20never%20collapsed%20regardless%20of%20the%20mode%20setting%2C%20which%20may%20surprise%20users%20given%20the%20function%20hints%20they%20were%20meant%20to%20be%20displayable%20in%20summaries.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fhistory.rs%3A3556-3558%0A%60format!%28%22all%20ok%22%29%60%20with%20no%20interpolation%20arguments%20is%20flagged%20by%20%60clippy%3A%3Auseless_format%60.%20Use%20%60%22all%20ok%22.to_string%28%29%60%20instead.%0A%0A%60%60%60suggestion%0A%20%20%20%20let%20status%20%3D%20if%20run.failed_count%20%3D%3D%200%20%7B%0A%20%20%20%20%20%20%20%20%22all%20ok%22.to_string%28%29%0A%20%20%20%20%7D%20else%20%7B%0A%60%60%60%0A%0A&pr=2738&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["feat(transcript): add /config tool\_colla..."](https://github.com/hmbown/codewhale/commit/c09d476069d2c589cfd55b19fd2753c3fc0e1db6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35544316)</sub>

<!-- /greptile_comment -->