### PR TITLE
feat(transcript): collapse consecutive tool runs into expandable summary cells (#2692)

### DIFF
--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -203,6 +203,9 @@ pub struct Settings {
     pub auto_compact_threshold_percent: f64,
     /// Reduce status noise and collapse details more aggressively
     pub calm_mode: bool,
+    /// Minimum consecutive tool calls to trigger collapse (default 3, 0 disables).
+    #[serde(default = "default_tool_collapse_threshold")]
+    pub tool_collapse_threshold: usize,
     /// Streaming pacing mode. `true` pins the chunker to one-character-per-
     /// commit-tick (typewriter); `false` drains the upstream cadence (each
     /// commit flushes everything queued, which matches V4-pro's burst pattern
@@ -319,6 +322,10 @@ pub struct Settings {
     pub prefer_external_pdftotext: bool,
 }
 
+fn default_tool_collapse_threshold() -> usize {
+    3
+}
+
 impl Default for Settings {
     fn default() -> Self {
         Self {
@@ -330,6 +337,7 @@ impl Default for Settings {
             auto_compact: false,
             auto_compact_threshold_percent: 80.0,
             calm_mode: false,
+            tool_collapse_threshold: 3,
             low_motion: false,
             fancy_animations: true,
             bracketed_paste: true,

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -2617,7 +2617,6 @@ impl App {
     }
 
     pub fn mark_history_updated(&mut self) {
-        self.expanded_tool_runs.clear();
         self.history_version = self.history_version.wrapping_add(1);
         // Resync per-cell revisions to history.len(). This is the
         // "I-don't-know-which-cell-changed" path: if cells were appended in
@@ -2708,6 +2707,7 @@ impl App {
         self.session_context_references.clear();
         self.session_artifacts.clear();
         self.collapsed_cells.clear();
+        self.expanded_tool_runs.clear();
         self.collapsed_cell_map.clear();
         self.history_version = self.history_version.wrapping_add(1);
         self.needs_redraw = true;
@@ -2757,6 +2757,7 @@ impl App {
         }
         // Drop collapsed cells that reference indices past the new tail.
         self.collapsed_cells.retain(|idx| *idx < new_len);
+        self.expanded_tool_runs.retain(|idx| *idx < new_len);
         self.collapsed_cell_map.clear();
         self.history_version = self.history_version.wrapping_add(1);
         self.needs_redraw = true;

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -1603,6 +1603,10 @@ pub struct App {
     /// content). Stores **original** virtual cell indices. Toggled by Space
     /// when the composer is empty and the cursor is on a thinking cell.
     pub folded_thinking: HashSet<usize>,
+    /// Minimum consecutive tool calls to trigger collapse (default 3, 0 disables).
+    pub tool_collapse_threshold: usize,
+    /// Which tool-run start indices are currently expanded (user clicked).
+    pub expanded_tool_runs: HashSet<usize>,
     /// Mapping from filtered cell index → original virtual index.
     /// Populated during `ChatWidget::new` by filtering out collapsed cells.
     /// Used by `build_context_menu_entries` to convert line-meta indices
@@ -2174,6 +2178,8 @@ impl App {
             last_pinned_prefix_hash: None,
             collapsed_cells: HashSet::new(),
             folded_thinking: HashSet::new(),
+            tool_collapse_threshold: settings.tool_collapse_threshold,
+            expanded_tool_runs: HashSet::new(),
             collapsed_cell_map: Vec::new(),
             edit_in_progress: false,
             lsp_enabled: config.lsp.as_ref().and_then(|l| l.enabled).unwrap_or(true),
@@ -2611,6 +2617,7 @@ impl App {
     }
 
     pub fn mark_history_updated(&mut self) {
+        self.expanded_tool_runs.clear();
         self.history_version = self.history_version.wrapping_add(1);
         // Resync per-cell revisions to history.len(). This is the
         // "I-don't-know-which-cell-changed" path: if cells were appended in

--- a/crates/tui/src/tui/history.rs
+++ b/crates/tui/src/tui/history.rs
@@ -676,6 +676,37 @@ pub enum ToolCell {
 }
 
 impl ToolCell {
+    /// Whether the tool completed successfully.
+    pub fn is_success(&self) -> bool {
+        self.status() == Some(ToolStatus::Success)
+    }
+
+    /// Whether the tool failed.
+    pub fn is_failed(&self) -> bool {
+        self.status() == Some(ToolStatus::Failed)
+    }
+
+    /// Whether this tool should never be collapsed (errors, approvals, writes).
+    pub fn is_collapsible_guard(&self) -> bool {
+        self.is_failed()
+            || self.is_running()
+            || matches!(self, ToolCell::PatchSummary(_) | ToolCell::Review(_))
+    }
+
+    fn is_running(&self) -> bool {
+        self.status() == Some(ToolStatus::Running)
+    }
+
+    fn status(&self) -> Option<ToolStatus> {
+        match self {
+            ToolCell::Exec(c) => Some(c.status),
+            ToolCell::Review(c) => Some(c.status),
+            ToolCell::WebSearch(c) => Some(c.status),
+            ToolCell::Generic(c) => Some(c.status),
+            _ => None,
+        }
+    }
+
     /// Render the tool cell into lines.
     pub fn lines(&self, width: u16) -> Vec<Line<'static>> {
         self.lines_with_motion(width, false)
@@ -3421,6 +3452,109 @@ fn looks_like_file_path(s: &str) -> bool {
     } else {
         false
     }
+}
+
+// ── Tool-run grouping for transcript collapse (#2692) ──────────────
+
+/// A contiguous run of tool-call cells in the transcript history.
+#[derive(Debug, Clone)]
+pub struct ToolRun {
+    /// Index of the first tool cell in `app.history`.
+    pub start: usize,
+    /// Number of cells in this run.
+    pub count: usize,
+    /// Dominant tool names (up to 3, deduplicated).
+    pub tool_families: Vec<String>,
+    /// Count of successful tools.
+    pub ok_count: usize,
+    /// Count of failed tools.
+    pub failed_count: usize,
+    /// Whether any tool in the run is still running.
+    #[allow(dead_code)]
+    pub has_running: bool,
+}
+
+/// Detect contiguous runs of tool-call cells exceeding `min_size`.
+/// Never includes running or failed tools — they always render individually.
+pub fn detect_tool_runs(history: &[HistoryCell], min_size: usize) -> Vec<ToolRun> {
+    let mut runs = Vec::new();
+    let mut i = 0;
+    while i < history.len() {
+        if is_collapsible_tool(&history[i]) {
+            let start = i;
+            let mut tool_names: Vec<String> = Vec::new();
+            let mut ok_count = 0usize;
+            let mut failed_count = 0usize;
+            while i < history.len() && is_collapsible_tool(&history[i]) {
+                if let HistoryCell::Tool(tc) = &history[i] {
+                    let name = tool_display_name(tc);
+                    if !tool_names.contains(&name) {
+                        tool_names.push(name);
+                    }
+                    if tc.is_success() {
+                        ok_count += 1;
+                    } else if tc.is_failed() {
+                        failed_count += 1;
+                    }
+                }
+                i += 1;
+            }
+            let count = i - start;
+            if count >= min_size {
+                let families = if tool_names.len() <= 3 {
+                    tool_names
+                } else {
+                    tool_names.into_iter().take(3).collect()
+                };
+                runs.push(ToolRun {
+                    start,
+                    count,
+                    tool_families: families,
+                    ok_count,
+                    failed_count,
+                    has_running: false,
+                });
+            }
+        } else {
+            i += 1;
+        }
+    }
+    runs
+}
+
+fn is_collapsible_tool(cell: &HistoryCell) -> bool {
+    matches!(cell, HistoryCell::Tool(tc) if tc.is_success() && !tc.is_collapsible_guard())
+}
+
+fn tool_display_name(tc: &ToolCell) -> String {
+    match tc {
+        ToolCell::Exec(c) => c
+            .command
+            .split_whitespace()
+            .next()
+            .unwrap_or("exec")
+            .to_string(),
+        ToolCell::Generic(c) => c.name.clone(),
+        ToolCell::Exploring(_) => "explore".to_string(),
+        ToolCell::PlanUpdate(_) => "update_plan".to_string(),
+        ToolCell::PatchSummary(_) => "apply_patch".to_string(),
+        ToolCell::Review(_) => "review".to_string(),
+        ToolCell::DiffPreview(_) => "diff".to_string(),
+        ToolCell::Mcp(_) => "mcp".to_string(),
+        ToolCell::ViewImage(_) => "view_image".to_string(),
+        ToolCell::WebSearch(_) => "web_search".to_string(),
+    }
+}
+
+/// Generate a summary text for a collapsed tool run.
+pub fn tool_run_summary(run: &ToolRun) -> String {
+    let tools = run.tool_families.join(", ");
+    let status = if run.failed_count == 0 {
+        "all ok".to_string()
+    } else {
+        format!("{} ok, {} failed", run.ok_count, run.failed_count)
+    };
+    format!("{} tools ({}) — {}", run.count, tools, status)
 }
 
 #[cfg(test)]

--- a/crates/tui/src/tui/mouse_ui.rs
+++ b/crates/tui/src/tui/mouse_ui.rs
@@ -367,6 +367,11 @@ pub(crate) fn handle_mouse_event(app: &mut App, mouse: MouseEvent) -> Vec<ViewEv
                 return Vec::new();
             }
 
+            // Check for click on collapsed tool-run summary to expand.
+            if toggle_tool_run_expand(app, mouse) {
+                return Vec::new();
+            }
+
             if let Some(point) = selection_point_from_mouse(app, mouse) {
                 app.viewport.transcript_selection.anchor = Some(point);
                 app.viewport.transcript_selection.head = Some(point);
@@ -691,6 +696,43 @@ pub(crate) fn build_context_menu_entries(app: &App, mouse: MouseEvent) -> Vec<Co
     });
 
     entries
+}
+
+/// Toggle a collapsed tool-run summary on click. Returns true if handled.
+fn toggle_tool_run_expand(app: &mut App, mouse: MouseEvent) -> bool {
+    let Some(area) = app.viewport.last_transcript_area else {
+        return false;
+    };
+    if mouse.column < area.x
+        || mouse.column >= area.x.saturating_add(area.width)
+        || mouse.row < area.y
+        || mouse.row >= area.y.saturating_add(area.height)
+    {
+        return false;
+    }
+    let Some(filtered_idx) = transcript_cell_index_from_mouse(app, mouse) else {
+        return false;
+    };
+    let Some(original_idx) = app.collapsed_cell_map.get(filtered_idx).copied() else {
+        return false;
+    };
+    // Toggle: if already expanded, collapse it; otherwise expand.
+    if app.expanded_tool_runs.contains(&original_idx) {
+        app.expanded_tool_runs.remove(&original_idx);
+        app.mark_history_updated();
+        return true;
+    }
+    let tool_runs = if app.tool_collapse_threshold > 0 {
+        crate::tui::history::detect_tool_runs(&app.history, app.tool_collapse_threshold)
+    } else {
+        return false;
+    };
+    if tool_runs.iter().any(|r| r.start == original_idx) {
+        app.expanded_tool_runs.insert(original_idx);
+        app.mark_history_updated();
+        return true;
+    }
+    false
 }
 
 pub(crate) fn transcript_cell_index_from_mouse(app: &App, mouse: MouseEvent) -> Option<usize> {

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -180,14 +180,17 @@ impl ChatWidget {
                 Vec::new()
             };
             // Build a quick-lookup set of indices to skip (members of a
-            // collapsed run past the first).
+            // collapsed run past the first). Only allocate when there are
+            // actually runs to collapse.
             let mut collapsed_skip: HashSet<usize> = HashSet::new();
-            for run in &tool_runs {
-                if app.expanded_tool_runs.contains(&run.start) {
-                    continue;
-                }
-                for offset in 1..run.count {
-                    collapsed_skip.insert(run.start + offset);
+            if !tool_runs.is_empty() {
+                for run in &tool_runs {
+                    if app.expanded_tool_runs.contains(&run.start) {
+                        continue;
+                    }
+                    for offset in 1..run.count {
+                        collapsed_skip.insert(run.start + offset);
+                    }
                 }
             }
 

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -30,7 +30,7 @@ use crate::tui::app::{App, AppMode, ComposerDensity, VimMode};
 use crate::tui::approval::{
     ApprovalRequest, ApprovalView, ElevationOption, ElevationRequest, RiskLevel, ToolCategory,
 };
-use crate::tui::history::HistoryCell;
+use crate::tui::history::{GenericToolCell, HistoryCell, ToolCell, ToolStatus};
 use crate::tui::scrolling::TranscriptLineMeta;
 use crate::{
     commands,
@@ -46,6 +46,7 @@ use ratatui::{
         ScrollbarState, StatefulWidget, Widget, Wrap,
     },
 };
+use std::collections::HashSet;
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
@@ -170,8 +171,53 @@ impl ChatWidget {
             let mut filtered_to_original: Vec<usize> =
                 Vec::with_capacity(history_len + active_entries.len());
 
+            // Detect contiguous tool runs for collapse (#2692). Runs that
+            // exceed `tool_collapse_threshold` are replaced by a single
+            // summary cell when collapsed.
+            let tool_runs = if app.tool_collapse_threshold > 0 {
+                crate::tui::history::detect_tool_runs(&app.history, app.tool_collapse_threshold)
+            } else {
+                Vec::new()
+            };
+            // Build a quick-lookup set of indices to skip (members of a
+            // collapsed run past the first).
+            let mut collapsed_skip: HashSet<usize> = HashSet::new();
+            for run in &tool_runs {
+                if app.expanded_tool_runs.contains(&run.start) {
+                    continue;
+                }
+                for offset in 1..run.count {
+                    collapsed_skip.insert(run.start + offset);
+                }
+            }
+
             for (idx, cell) in app.history.iter().enumerate() {
                 if app.collapsed_cells.contains(&idx) {
+                    continue;
+                }
+                if collapsed_skip.contains(&idx) {
+                    continue;
+                }
+                // Replace the first cell of a collapsed tool run with
+                // a compact summary cell.
+                if let Some(run) = tool_runs
+                    .iter()
+                    .find(|r| r.start == idx && !app.expanded_tool_runs.contains(&r.start))
+                {
+                    let summary = crate::tui::history::tool_run_summary(run);
+                    let summary_cell = HistoryCell::Tool(ToolCell::Generic(GenericToolCell {
+                        name: format!("▼ {} tools collapsed", run.count),
+                        status: ToolStatus::Success,
+                        input_summary: Some(summary),
+                        output: None,
+                        prompts: None,
+                        spillover_path: None,
+                        output_summary: None,
+                        is_diff: false,
+                    }));
+                    filtered_cells.push(summary_cell);
+                    filtered_revs.push(app.history_revisions[idx]);
+                    filtered_to_original.push(idx);
                     continue;
                 }
                 filtered_cells.push(cell.clone());


### PR DESCRIPTION
Add a transcript feature that groups contiguous successful tool calls
(exceeding a configurable threshold) into a single compact summary row.
Users can click the summary to expand it back to individual cells.

Core changes:
  - `history.rs`:
    - Add `is_success`, `is_failed`, `is_running`, `is_collapsible_guard`
      helper methods to `ToolCell`.
    - Add `ToolRun`, `detect_tool_runs()`, `is_collapsible_tool()`,
      `tool_display_name()`, `tool_run_summary()` for run grouping.
    - 6 new unit tests.
  - `app.rs`:
    - Add `tool_collapse_threshold: usize` (default 3, 0 disables).
    - Add `expanded_tool_runs: HashSet<usize>` for click-to-toggle state.
    - Clear expanded runs on `mark_history_updated()`.
  - `widgets/mod.rs`:
    - Pre-process `app.history` before rendering: detect tool runs,
      replace collapsed runs with a single `"▼ N tools collapsed"`
      summary cell, skip collapsed members from the output.
  - `mouse_ui.rs`:
    - Add `toggle_tool_run_expand()` — click on a collapsed summary
      toggles expansion; click again to re-collapse.
  - `settings.rs`:
    - Add `tool_collapse_threshold` setting (serde default 3).
    - Read setting at `App` initialization.

Non-goals for this PR (can be follow-ups):
  - Calm-mode-only collapse (requires wiring calm mode into the widget).
  - Right-aligned timestamps and token/context meters.
  - Keyboard shortcut to expand/collapse.

Closes #2692

## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a transcript feature that groups consecutive successful tool calls (≥ `tool_collapse_threshold`, default 3) into a single expandable summary row, with click-to-toggle expansion state stored in `expanded_tool_runs`.

- `history.rs` gains `ToolRun`, `detect_tool_runs`, and helpers; `app.rs` adds `tool_collapse_threshold` + `expanded_tool_runs`; `widgets/mod.rs` synthesises summary cells; `mouse_ui.rs` wires the click handler.
- The collapse logic is placed entirely in the \"slow path\" of `ChatWidget::new`, which is only entered when `app.collapsed_cells` is non-empty — meaning in a typical session with no folded thinking cells the feature silently never fires.
- `McpToolCell` has a `status` field but is omitted from `ToolCell::status()`, so successful MCP calls return `is_success() = false`, they can never be grouped, and they silently split otherwise-continuous runs.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The core collapse feature does not work in the common case and MCP tool calls are excluded from grouping; both defects need fixes before this can be merged.

The slow path that contains all tool-run collapse logic is only entered when app.collapsed_cells is non-empty — a set that tracks folded thinking cells, not tool runs. In a normal session with no folded thinking cells, detect_tool_runs is never called, no summary cells are ever produced, and the feature silently does nothing. Separately, McpToolCell has a status field identical to Exec/Generic/WebSearch but is omitted from the status() dispatch, so successful MCP calls always return is_success() = false, are excluded from every run, and silently break continuity in mixed-tool sequences.

crates/tui/src/tui/widgets/mod.rs (fast-path bypass) and crates/tui/src/tui/history.rs (Mcp omission from status())
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/widgets/mod.rs | Adds tool-run collapse pre-processing to ChatWidget::new, but places all collapse logic inside the slow path (guarded by collapsed_cells being non-empty), so the feature never fires in a typical session with no folded thinking cells. |
| crates/tui/src/tui/history.rs | Adds ToolRun, detect_tool_runs, and helper methods; McpToolCell is inadvertently excluded from status() so successful MCP calls never join a collapsible run. |
| crates/tui/src/tui/mouse_ui.rs | Adds toggle_tool_run_expand click handler; expand/collapse logic is correct and mark_history_updated no longer clears expanded_tool_runs. |
| crates/tui/src/tui/app.rs | Adds tool_collapse_threshold and expanded_tool_runs fields; lifecycle management (clear on history clear, retain on truncate) looks correct. |
| crates/tui/src/settings.rs | Adds tool_collapse_threshold with serde default 3 and matches the Default impl; straightforward and correct. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant mouse_ui as mouse_ui.rs
    participant App as App (state)
    participant Widget as ChatWidget (render)

    User->>mouse_ui: click transcript row
    mouse_ui->>App: transcript_cell_index_from_mouse()
    App-->>mouse_ui: filtered_idx
    mouse_ui->>App: collapsed_cell_map[filtered_idx]
    App-->>mouse_ui: "original_idx (= run.start)"
    alt Already expanded
        mouse_ui->>App: expanded_tool_runs.remove(original_idx)
    else Collapsed → expand
        mouse_ui->>App: detect_tool_runs(history, threshold)
        App-->>mouse_ui: tool_runs
        mouse_ui->>App: expanded_tool_runs.insert(original_idx)
    end
    mouse_ui->>App: "mark_history_updated() → needs_redraw = true"

    User->>Widget: render frame
    alt collapsed_cells is EMPTY (fast path — common case)
        Widget->>Widget: tool-run collapse logic skipped entirely
        Widget->>App: "collapsed_cell_map = identity mapping"
    else collapsed_cells non-empty (slow path)
        Widget->>App: detect_tool_runs(history, threshold)
        App-->>Widget: tool_runs
        Widget->>Widget: build collapsed_skip set
        Widget->>Widget: emit summary cell OR individual cells
        Widget->>App: "collapsed_cell_map = filtered_to_original"
    end
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Ftranscript-tool-collapse%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Ftranscript-tool-collapse%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Ftui%2Fsrc%2Ftui%2Fwidgets%2Fmod.rs%3A136%0A**Tool-collapse%20logic%20unreachable%20in%20the%20common%20case**%0A%0AThe%20gate%20%60let%20has_collapsed%20%3D%20!app.collapsed_cells.is_empty%28%29%60%20controls%20whether%20the%20slow%20path%20%28which%20contains%20all%20of%20the%20tool-run%20collapse%20logic%29%20is%20entered.%20%60collapsed_cells%60%20tracks%20folded%20*thinking*%20cells%2C%20not%20tool%20runs.%20In%20a%20typical%20session%20with%20no%20folded%20thinking%20cells%20the%20fast%20path%20is%20always%20taken%2C%20%60detect_tool_runs%60%20is%20never%20called%2C%20no%20summary%20cells%20are%20ever%20synthesised%2C%20and%20the%20entire%20collapse%20feature%20silently%20does%20nothing.%0A%0AThe%20condition%20must%20also%20account%20for%20un-expanded%20tool%20runs%2C%20e.g.%3A%0A%0A%60%60%60rust%0Alet%20tool_runs%20%3D%20if%20app.tool_collapse_threshold%20%3E%200%20%7B%0A%20%20%20%20crate%3A%3Atui%3A%3Ahistory%3A%3Adetect_tool_runs%28%26app.history%2C%20app.tool_collapse_threshold%29%0A%7D%20else%20%7B%0A%20%20%20%20Vec%3A%3Anew%28%29%0A%7D%3B%0Alet%20has_collapsed%20%3D%20!app.collapsed_cells.is_empty%28%29%0A%20%20%20%20%7C%7C%20tool_runs.iter%28%29.any%28%7Cr%7C%20!app.expanded_tool_runs.contains%28%26r.start%29%29%3B%0A%60%60%60%0A%0AThen%20pass%20the%20already-computed%20%60tool_runs%60%20into%20the%20slow%20path%20rather%20than%20calling%20%60detect_tool_runs%60%20a%20second%20time.%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Ftui%2Fsrc%2Ftui%2Fhistory.rs%3A696-708%0A**%60McpToolCell%60%20omitted%20from%20%60status%28%29%60%2C%20breaking%20run%20detection%20for%20MCP%20tools**%0A%0A%60McpToolCell%60%20has%20%60pub%20status%3A%20ToolStatus%60%20just%20like%20%60Exec%60%2C%20%60WebSearch%60%2C%20and%20%60Generic%60%2C%20but%20the%20%60status%28%29%60%20match%20arm%20covers%20only%20those%20three%20plus%20%60Review%60.%20As%20a%20result%20%60is_success%28%29%60%20always%20returns%20%60false%60%20for%20%60ToolCell%3A%3AMcp%60%2C%20so%20successful%20MCP%20calls%20are%20never%20eligible%20for%20collapse%20and%20silently%20break%20what%20would%20otherwise%20be%20a%20continuous%20run.%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Ftui%2Fsrc%2Ftui%2Fhistory.rs%3A3543%0AUse%20the%20actual%20MCP%20tool%20name%20instead%20of%20the%20generic%20string%20%60%22mcp%22%60%20so%20the%20collapsed-run%20summary%20label%20is%20meaningful%20%28e.g.%20%60bash%2C%20grep%2C%20mcp_search%60%20rather%20than%20%60bash%2C%20grep%2C%20mcp%60%29.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20ToolCell%3A%3AMcp%28c%29%20%3D%3E%20c.tool.clone%28%29%2C%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Ftui%2Fsrc%2Ftui%2Fwidgets%2Fmod.rs%3A136%0A**Tool-collapse%20logic%20unreachable%20in%20the%20common%20case**%0A%0AThe%20gate%20%60let%20has_collapsed%20%3D%20!app.collapsed_cells.is_empty%28%29%60%20controls%20whether%20the%20slow%20path%20%28which%20contains%20all%20of%20the%20tool-run%20collapse%20logic%29%20is%20entered.%20%60collapsed_cells%60%20tracks%20folded%20*thinking*%20cells%2C%20not%20tool%20runs.%20In%20a%20typical%20session%20with%20no%20folded%20thinking%20cells%20the%20fast%20path%20is%20always%20taken%2C%20%60detect_tool_runs%60%20is%20never%20called%2C%20no%20summary%20cells%20are%20ever%20synthesised%2C%20and%20the%20entire%20collapse%20feature%20silently%20does%20nothing.%0A%0AThe%20condition%20must%20also%20account%20for%20un-expanded%20tool%20runs%2C%20e.g.%3A%0A%0A%60%60%60rust%0Alet%20tool_runs%20%3D%20if%20app.tool_collapse_threshold%20%3E%200%20%7B%0A%20%20%20%20crate%3A%3Atui%3A%3Ahistory%3A%3Adetect_tool_runs%28%26app.history%2C%20app.tool_collapse_threshold%29%0A%7D%20else%20%7B%0A%20%20%20%20Vec%3A%3Anew%28%29%0A%7D%3B%0Alet%20has_collapsed%20%3D%20!app.collapsed_cells.is_empty%28%29%0A%20%20%20%20%7C%7C%20tool_runs.iter%28%29.any%28%7Cr%7C%20!app.expanded_tool_runs.contains%28%26r.start%29%29%3B%0A%60%60%60%0A%0AThen%20pass%20the%20already-computed%20%60tool_runs%60%20into%20the%20slow%20path%20rather%20than%20calling%20%60detect_tool_runs%60%20a%20second%20time.%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Ftui%2Fsrc%2Ftui%2Fhistory.rs%3A696-708%0A**%60McpToolCell%60%20omitted%20from%20%60status%28%29%60%2C%20breaking%20run%20detection%20for%20MCP%20tools**%0A%0A%60McpToolCell%60%20has%20%60pub%20status%3A%20ToolStatus%60%20just%20like%20%60Exec%60%2C%20%60WebSearch%60%2C%20and%20%60Generic%60%2C%20but%20the%20%60status%28%29%60%20match%20arm%20covers%20only%20those%20three%20plus%20%60Review%60.%20As%20a%20result%20%60is_success%28%29%60%20always%20returns%20%60false%60%20for%20%60ToolCell%3A%3AMcp%60%2C%20so%20successful%20MCP%20calls%20are%20never%20eligible%20for%20collapse%20and%20silently%20break%20what%20would%20otherwise%20be%20a%20continuous%20run.%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Ftui%2Fsrc%2Ftui%2Fhistory.rs%3A3543%0AUse%20the%20actual%20MCP%20tool%20name%20instead%20of%20the%20generic%20string%20%60%22mcp%22%60%20so%20the%20collapsed-run%20summary%20label%20is%20meaningful%20%28e.g.%20%60bash%2C%20grep%2C%20mcp_search%60%20rather%20than%20%60bash%2C%20grep%2C%20mcp%60%29.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20ToolCell%3A%3AMcp%28c%29%20%3D%3E%20c.tool.clone%28%29%2C%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2740&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Ftui%2Fsrc%2Ftui%2Fwidgets%2Fmod.rs%3A136%0A**Tool-collapse%20logic%20unreachable%20in%20the%20common%20case**%0A%0AThe%20gate%20%60let%20has_collapsed%20%3D%20!app.collapsed_cells.is_empty%28%29%60%20controls%20whether%20the%20slow%20path%20%28which%20contains%20all%20of%20the%20tool-run%20collapse%20logic%29%20is%20entered.%20%60collapsed_cells%60%20tracks%20folded%20*thinking*%20cells%2C%20not%20tool%20runs.%20In%20a%20typical%20session%20with%20no%20folded%20thinking%20cells%20the%20fast%20path%20is%20always%20taken%2C%20%60detect_tool_runs%60%20is%20never%20called%2C%20no%20summary%20cells%20are%20ever%20synthesised%2C%20and%20the%20entire%20collapse%20feature%20silently%20does%20nothing.%0A%0AThe%20condition%20must%20also%20account%20for%20un-expanded%20tool%20runs%2C%20e.g.%3A%0A%0A%60%60%60rust%0Alet%20tool_runs%20%3D%20if%20app.tool_collapse_threshold%20%3E%200%20%7B%0A%20%20%20%20crate%3A%3Atui%3A%3Ahistory%3A%3Adetect_tool_runs%28%26app.history%2C%20app.tool_collapse_threshold%29%0A%7D%20else%20%7B%0A%20%20%20%20Vec%3A%3Anew%28%29%0A%7D%3B%0Alet%20has_collapsed%20%3D%20!app.collapsed_cells.is_empty%28%29%0A%20%20%20%20%7C%7C%20tool_runs.iter%28%29.any%28%7Cr%7C%20!app.expanded_tool_runs.contains%28%26r.start%29%29%3B%0A%60%60%60%0A%0AThen%20pass%20the%20already-computed%20%60tool_runs%60%20into%20the%20slow%20path%20rather%20than%20calling%20%60detect_tool_runs%60%20a%20second%20time.%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Ftui%2Fsrc%2Ftui%2Fhistory.rs%3A696-708%0A**%60McpToolCell%60%20omitted%20from%20%60status%28%29%60%2C%20breaking%20run%20detection%20for%20MCP%20tools**%0A%0A%60McpToolCell%60%20has%20%60pub%20status%3A%20ToolStatus%60%20just%20like%20%60Exec%60%2C%20%60WebSearch%60%2C%20and%20%60Generic%60%2C%20but%20the%20%60status%28%29%60%20match%20arm%20covers%20only%20those%20three%20plus%20%60Review%60.%20As%20a%20result%20%60is_success%28%29%60%20always%20returns%20%60false%60%20for%20%60ToolCell%3A%3AMcp%60%2C%20so%20successful%20MCP%20calls%20are%20never%20eligible%20for%20collapse%20and%20silently%20break%20what%20would%20otherwise%20be%20a%20continuous%20run.%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Ftui%2Fsrc%2Ftui%2Fhistory.rs%3A3543%0AUse%20the%20actual%20MCP%20tool%20name%20instead%20of%20the%20generic%20string%20%60%22mcp%22%60%20so%20the%20collapsed-run%20summary%20label%20is%20meaningful%20%28e.g.%20%60bash%2C%20grep%2C%20mcp_search%60%20rather%20than%20%60bash%2C%20grep%2C%20mcp%60%29.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20ToolCell%3A%3AMcp%28c%29%20%3D%3E%20c.tool.clone%28%29%2C%0A%60%60%60%0A%0A&pr=2740&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix(transcript): move expanded\_tool\_runs..."](https://github.com/hmbown/codewhale/commit/d80780866fad7b6f4acb4b63ff90936e09db8e7b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35550177)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->