### PR TITLE
feat(config): add HarnessPosture data model for per-model behavior profiles (#2693)

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -306,6 +306,118 @@ impl ProvidersToml {
     }
 }
 
+// ── Harness Posture (#2693) ────────────────────────────────────────
+// Per-model behavior profiles that tune prompt layering, tool surface,
+// sub-agent fan-out, compaction strategy, and safety posture.
+// Each profile encodes observed model-specific idioms and failure modes
+// as a falsifiable contract; promotion requires replay/eval evidence.
+
+/// Kinds of built-in harness postures.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum HarnessPostureKind {
+    /// Full-featured: rich constitution, prefix-cache-oriented prompts,
+    /// broad tool catalog, async sub-agent fan-out.
+    #[default]
+    Standard,
+    /// Cache-heavy: deep constitution, layered prompts, aggressive
+    /// prefix-cache staging. Best for DeepSeek V4 / MiMo-style models.
+    CacheHeavy,
+    /// Lean: minimal constitution, aggressive sub-agent delegation,
+    /// fast compaction, reduced always-on context. Best for small-
+    /// context or weak tool-use models.
+    Lean,
+    /// Custom posture defined by the user in `harness.toml`.
+    #[serde(other)]
+    Custom,
+}
+
+/// A concrete harness posture with policy knobs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HarnessPosture {
+    /// Named posture kind.
+    #[serde(default)]
+    pub kind: HarnessPostureKind,
+    /// Maximum number of concurrent sub-agents (0 = default).
+    #[serde(default)]
+    pub max_subagents: usize,
+    /// Prefer search-based context over always-on documentation.
+    #[serde(default)]
+    pub prefer_codebase_search: bool,
+    /// Compaction strategy: "prefix-cache" | "aggressive" | "default".
+    #[serde(default = "default_compaction_strategy")]
+    pub compaction_strategy: String,
+    /// Tool surface mode: "full" | "read-only" | "auto".
+    #[serde(default = "default_tool_surface")]
+    pub tool_surface: String,
+    /// Safety posture: "standard" | "strict" | "permissive".
+    #[serde(default = "default_safety_posture")]
+    pub safety_posture: String,
+}
+
+fn default_compaction_strategy() -> String {
+    "default".into()
+}
+fn default_tool_surface() -> String {
+    "full".into()
+}
+fn default_safety_posture() -> String {
+    "standard".into()
+}
+
+impl Default for HarnessPosture {
+    fn default() -> Self {
+        Self {
+            kind: HarnessPostureKind::Standard,
+            max_subagents: 0,
+            prefer_codebase_search: false,
+            compaction_strategy: "default".into(),
+            tool_surface: "full".into(),
+            safety_posture: "standard".into(),
+        }
+    }
+}
+
+impl HarnessPosture {
+    /// A cache-heavy posture tuned for DeepSeek V4 / MiMo models.
+    #[must_use]
+    pub fn cache_heavy() -> Self {
+        Self {
+            kind: HarnessPostureKind::CacheHeavy,
+            max_subagents: 10,
+            prefer_codebase_search: false,
+            compaction_strategy: "prefix-cache".into(),
+            tool_surface: "full".into(),
+            safety_posture: "standard".into(),
+        }
+    }
+
+    /// A lean posture for small-context / weak tool-use models.
+    #[must_use]
+    pub fn lean() -> Self {
+        Self {
+            kind: HarnessPostureKind::Lean,
+            max_subagents: 20,
+            prefer_codebase_search: true,
+            compaction_strategy: "aggressive".into(),
+            tool_surface: "full".into(),
+            safety_posture: "standard".into(),
+        }
+    }
+}
+
+/// A harness profile binds a posture to a provider route + model pattern.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct HarnessProfile {
+    /// Provider route this profile applies to (e.g. "deepseek", "xiaomi-mimo").
+    pub provider_route: String,
+    /// Regex or glob pattern for model names (e.g. "deepseek-v4.*").
+    pub model_pattern: String,
+    /// The posture to apply.
+    #[serde(default)]
+    pub posture: HarnessPosture,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ConfigToml {
     /// TUI-compatible DeepSeek API key. Kept at the root so both `deepseek`
@@ -349,6 +461,10 @@ pub struct ConfigToml {
     /// applies the defaults documented in [`LspConfigToml`].
     #[serde(default)]
     pub lsp: Option<LspConfigToml>,
+    /// Per-model harness profiles (#2693). When present, the active profile
+    /// matching the current provider route and model name is applied.
+    #[serde(default)]
+    pub harness_profiles: Vec<HarnessProfile>,
     /// App-server hook sink configuration. Kept separate from the TUI
     /// lifecycle `[hooks]` table so config rewrites preserve existing hooks.
     #[serde(default)]
@@ -5086,5 +5202,80 @@ model = "mimo-v2.5-pro"
         let resolved = ConfigToml::default().resolve_runtime_options_with_secrets(&cli, &secrets);
         assert_eq!(resolved.api_key.as_deref(), Some("cli-key"));
         assert_eq!(resolved.api_key_source, Some(RuntimeApiKeySource::Cli));
+    }
+
+    // ── HarnessPosture tests (#2693) ─────────────────────────────
+
+    #[test]
+    fn harness_posture_default_is_standard() {
+        let posture = HarnessPosture::default();
+        assert_eq!(posture.kind, HarnessPostureKind::Standard);
+        assert_eq!(posture.max_subagents, 0);
+        assert!(!posture.prefer_codebase_search);
+        assert_eq!(posture.compaction_strategy, "default");
+        assert_eq!(posture.tool_surface, "full");
+        assert_eq!(posture.safety_posture, "standard");
+    }
+
+    #[test]
+    fn harness_posture_cache_heavy_is_correct() {
+        let posture = HarnessPosture::cache_heavy();
+        assert_eq!(posture.kind, HarnessPostureKind::CacheHeavy);
+        assert_eq!(posture.max_subagents, 10);
+        assert!(!posture.prefer_codebase_search);
+        assert_eq!(posture.compaction_strategy, "prefix-cache");
+        assert_eq!(posture.tool_surface, "full");
+        assert_eq!(posture.safety_posture, "standard");
+    }
+
+    #[test]
+    fn harness_posture_lean_is_correct() {
+        let posture = HarnessPosture::lean();
+        assert_eq!(posture.kind, HarnessPostureKind::Lean);
+        assert_eq!(posture.max_subagents, 20);
+        assert!(posture.prefer_codebase_search);
+        assert_eq!(posture.compaction_strategy, "aggressive");
+        assert_eq!(posture.tool_surface, "full");
+        assert_eq!(posture.safety_posture, "standard");
+    }
+
+    #[test]
+    fn harness_profile_serde_round_trip() {
+        let profile = HarnessProfile {
+            provider_route: "deepseek".into(),
+            model_pattern: "deepseek-v4.*".into(),
+            posture: HarnessPosture::cache_heavy(),
+        };
+        let json = serde_json::to_string(&profile).unwrap();
+        let round_tripped: HarnessProfile = serde_json::from_str(&json).unwrap();
+        assert_eq!(round_tripped.provider_route, "deepseek");
+        assert_eq!(round_tripped.model_pattern, "deepseek-v4.*");
+        assert_eq!(round_tripped.posture.kind, HarnessPostureKind::CacheHeavy);
+        assert_eq!(round_tripped.posture.max_subagents, 10);
+    }
+
+    #[test]
+    fn config_toml_accepts_harness_profiles() {
+        let toml_str = r#"
+provider = "deepseek"
+model = "deepseek-v4-pro"
+
+[[harness_profiles]]
+provider_route = "deepseek"
+model_pattern = "deepseek-v4.*"
+
+[harness_profiles.posture]
+kind = "cache-heavy"
+max_subagents = 10
+compaction_strategy = "prefix-cache"
+"#;
+        let config: ConfigToml = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.harness_profiles.len(), 1);
+        let profile = &config.harness_profiles[0];
+        assert_eq!(profile.provider_route, "deepseek");
+        assert_eq!(profile.model_pattern, "deepseek-v4.*");
+        assert_eq!(profile.posture.kind, HarnessPostureKind::CacheHeavy);
+        assert_eq!(profile.posture.max_subagents, 10);
+        assert_eq!(profile.posture.compaction_strategy, "prefix-cache");
     }
 }


### PR DESCRIPTION
Introduce the data model for per-model behavior profiles (harness
postures). A posture encodes model-specific idioms and failure modes as
a falsifiable contract that configures prompt layering, tool surface,
sub-agent fan-out, compaction strategy, and safety posture.

Changes:
  - `crates/config/src/lib.rs`:
    - `HarnessPostureKind` enum: Standard, CacheHeavy, Lean, Custom
    - `HarnessPosture` struct: kind + max_subagents,
      prefer_codebase_search, compaction_strategy, tool_surface,
      safety_posture
    - `HarnessPosture::cache_heavy()` — tuned for DeepSeek V4 / MiMo
    - `HarnessPosture::lean()` — tuned for small-context / weak models
    - `HarnessProfile` struct: binds posture to provider route +
      model pattern
    - `ConfigToml.harness_profiles: Vec<HarnessProfile>` — TOML
      integration
  - 5 new unit tests covering defaults, factory constructors,
    serde round-trip, and TOML deserialisation

Non-goals for this PR:
  - Wiring posture into the runtime (will be in follow-up PRs)
  - /config CLI integration
  - Sidebar/tray posture display

Closes #2693

## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Introduces the `HarnessPosture` and `HarnessProfile` data model for per-model behavior profiles, wiring it into `ConfigToml.harness_profiles` and covering it with 5 unit tests. No runtime wiring is included in this PR.

- `HarnessPostureKind` is an enum with four variants (`Standard`, `CacheHeavy`, `Lean`, `Custom`); `#[serde(other)]` on `Custom` silently absorbs any unknown or misspelled string instead of returning a deserialization error.
- `HarnessPosture` carries six policy knobs (`max_subagents`, `prefer_codebase_search`, `compaction_strategy`, `tool_surface`, `safety_posture`); three string fields accept arbitrary values with no enum-level validation.
- The manual `Default` impl for `HarnessPosture` duplicates the string literals already defined in the `default_*` serde helper functions, creating two sources of truth that can drift.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge as a data-model-only change, but the silent catch-all on unknown posture kinds should be addressed before the runtime wiring lands.

The `#[serde(other)]` catch-all on `Custom` means a misspelled `kind` in a user's config file will silently apply the wrong posture instead of surfacing an error. Because this is still an unreferenced data model with no runtime wiring, the blast radius is currently zero — but the defect will be live the moment the follow-up PR consumes these profiles.

crates/config/src/lib.rs — the `HarnessPostureKind` enum's `#[serde(other)]` attribute and the duplicated default string literals in the `Default` impl.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/config/src/lib.rs | Adds HarnessPosture/HarnessProfile data model with serde support and 5 unit tests; `#[serde(other)]` on `Custom` silently swallows unknown/misspelled kind values, and default string values are duplicated between the manual `Default` impl and the serde default functions. |

</details>

</details>

<details open><summary><h3>Class Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
classDiagram
    class ConfigToml {
        +harness_profiles: Vec~HarnessProfile~
    }

    class HarnessProfile {
        +provider_route: String
        +model_pattern: String
        +posture: HarnessPosture
    }

    class HarnessPosture {
        +kind: HarnessPostureKind
        +max_subagents: usize
        +prefer_codebase_search: bool
        +compaction_strategy: String
        +tool_surface: String
        +safety_posture: String
        +cache_heavy()$ HarnessPosture
        +lean()$ HarnessPosture
        +default()$ HarnessPosture
    }

    class HarnessPostureKind {
        <<enumeration>>
        Standard
        CacheHeavy
        Lean
        Custom
    }

    ConfigToml "1" o-- "0..*" HarnessProfile
    HarnessProfile "1" *-- "1" HarnessPosture
    HarnessPosture "1" *-- "1" HarnessPostureKind
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fharness-posture%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fharness-posture%22.%0A%0AFix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Acrates%2Fconfig%2Fsrc%2Flib.rs%3A331-332%0A**Silent%20catch-all%20hides%20typos%20in%20%60kind%60%20values**%0A%0A%60%23%5Bserde%28other%29%5D%60%20on%20%60Custom%60%20means%20any%20unrecognized%20string%20%E2%80%94%20including%20typos%20like%20%60%22cahce-heavy%22%60%20or%20%60%22standard%20%22%60%20%28trailing%20space%29%20%E2%80%94%20silently%20deserializes%20as%20%60Custom%60%20instead%20of%20returning%20a%20%60DeserializeError%60.%20A%20user%20who%20misspells%20their%20posture%20kind%20will%20get%20silently%20wrong%20behavior%2C%20with%20no%20indication%20that%20their%20config%20was%20misread.%0A%0A%23%23%23%20Issue%202%20of%204%0Acrates%2Fconfig%2Fsrc%2Flib.rs%3A368-379%0ADefault%20value%20duplication%20risk%20%E2%80%94%20%60Default%3A%3Adefault%28%29%60%20repeats%20the%20same%20string%20literals%20already%20defined%20in%20%60default_compaction_strategy%60%2C%20%60default_tool_surface%60%2C%20and%20%60default_safety_posture%60.%20If%20either%20side%20is%20updated%20without%20changing%20the%20other%20the%20two%20sources%20of%20truth%20diverge.%20Call%20the%20default%20functions%20directly%20to%20keep%20a%20single%20source%20of%20truth.%0A%0A%60%60%60suggestion%0Aimpl%20Default%20for%20HarnessPosture%20%7B%0A%20%20%20%20fn%20default%28%29%20-%3E%20Self%20%7B%0A%20%20%20%20%20%20%20%20Self%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20kind%3A%20HarnessPostureKind%3A%3AStandard%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20max_subagents%3A%200%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20prefer_codebase_search%3A%20false%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20compaction_strategy%3A%20default_compaction_strategy%28%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20tool_surface%3A%20default_tool_surface%28%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20safety_posture%3A%20default_safety_posture%28%29%2C%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Acrates%2Fconfig%2Fsrc%2Flib.rs%3A335-337%0A%60HarnessPosture%60%20and%20%60HarnessProfile%60%20are%20missing%20%60PartialEq%60%20derives%2C%20even%20though%20%60HarnessPostureKind%60%20already%20has%20it.%20The%20round-trip%20test%20manually%20checks%20individual%20fields%20because%20whole-struct%20comparison%20is%20unavailable.%20Adding%20%60PartialEq%60%20makes%20future%20tests%20and%20runtime%20equality%20checks%20%28e.g.%20detecting%20whether%20a%20reload%20changed%20the%20active%20profile%29%20straightforward.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20A%20concrete%20harness%20posture%20with%20policy%20knobs.%0A%23%5Bderive%28Debug%2C%20Clone%2C%20Serialize%2C%20Deserialize%2C%20PartialEq%29%5D%0Apub%20struct%20HarnessPosture%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%204%0Acrates%2Fconfig%2Fsrc%2Flib.rs%3A409-411%0A%60HarnessProfile%60%20is%20also%20missing%20%60PartialEq%60.%20Since%20%60HarnessPosture%60%20is%20a%20field%20of%20%60HarnessProfile%60%2C%20both%20should%20derive%20it%20together%20to%20allow%20whole-profile%20equality%20comparisons.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20A%20harness%20profile%20binds%20a%20posture%20to%20a%20provider%20route%20%2B%20model%20pattern.%0A%23%5Bderive%28Debug%2C%20Clone%2C%20Serialize%2C%20Deserialize%2C%20Default%2C%20PartialEq%29%5D%0Apub%20struct%20HarnessProfile%20%7B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Acrates%2Fconfig%2Fsrc%2Flib.rs%3A331-332%0A**Silent%20catch-all%20hides%20typos%20in%20%60kind%60%20values**%0A%0A%60%23%5Bserde%28other%29%5D%60%20on%20%60Custom%60%20means%20any%20unrecognized%20string%20%E2%80%94%20including%20typos%20like%20%60%22cahce-heavy%22%60%20or%20%60%22standard%20%22%60%20%28trailing%20space%29%20%E2%80%94%20silently%20deserializes%20as%20%60Custom%60%20instead%20of%20returning%20a%20%60DeserializeError%60.%20A%20user%20who%20misspells%20their%20posture%20kind%20will%20get%20silently%20wrong%20behavior%2C%20with%20no%20indication%20that%20their%20config%20was%20misread.%0A%0A%23%23%23%20Issue%202%20of%204%0Acrates%2Fconfig%2Fsrc%2Flib.rs%3A368-379%0ADefault%20value%20duplication%20risk%20%E2%80%94%20%60Default%3A%3Adefault%28%29%60%20repeats%20the%20same%20string%20literals%20already%20defined%20in%20%60default_compaction_strategy%60%2C%20%60default_tool_surface%60%2C%20and%20%60default_safety_posture%60.%20If%20either%20side%20is%20updated%20without%20changing%20the%20other%20the%20two%20sources%20of%20truth%20diverge.%20Call%20the%20default%20functions%20directly%20to%20keep%20a%20single%20source%20of%20truth.%0A%0A%60%60%60suggestion%0Aimpl%20Default%20for%20HarnessPosture%20%7B%0A%20%20%20%20fn%20default%28%29%20-%3E%20Self%20%7B%0A%20%20%20%20%20%20%20%20Self%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20kind%3A%20HarnessPostureKind%3A%3AStandard%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20max_subagents%3A%200%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20prefer_codebase_search%3A%20false%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20compaction_strategy%3A%20default_compaction_strategy%28%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20tool_surface%3A%20default_tool_surface%28%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20safety_posture%3A%20default_safety_posture%28%29%2C%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Acrates%2Fconfig%2Fsrc%2Flib.rs%3A335-337%0A%60HarnessPosture%60%20and%20%60HarnessProfile%60%20are%20missing%20%60PartialEq%60%20derives%2C%20even%20though%20%60HarnessPostureKind%60%20already%20has%20it.%20The%20round-trip%20test%20manually%20checks%20individual%20fields%20because%20whole-struct%20comparison%20is%20unavailable.%20Adding%20%60PartialEq%60%20makes%20future%20tests%20and%20runtime%20equality%20checks%20%28e.g.%20detecting%20whether%20a%20reload%20changed%20the%20active%20profile%29%20straightforward.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20A%20concrete%20harness%20posture%20with%20policy%20knobs.%0A%23%5Bderive%28Debug%2C%20Clone%2C%20Serialize%2C%20Deserialize%2C%20PartialEq%29%5D%0Apub%20struct%20HarnessPosture%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%204%0Acrates%2Fconfig%2Fsrc%2Flib.rs%3A409-411%0A%60HarnessProfile%60%20is%20also%20missing%20%60PartialEq%60.%20Since%20%60HarnessPosture%60%20is%20a%20field%20of%20%60HarnessProfile%60%2C%20both%20should%20derive%20it%20together%20to%20allow%20whole-profile%20equality%20comparisons.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20A%20harness%20profile%20binds%20a%20posture%20to%20a%20provider%20route%20%2B%20model%20pattern.%0A%23%5Bderive%28Debug%2C%20Clone%2C%20Serialize%2C%20Deserialize%2C%20Default%2C%20PartialEq%29%5D%0Apub%20struct%20HarnessProfile%20%7B%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2741&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Acrates%2Fconfig%2Fsrc%2Flib.rs%3A331-332%0A**Silent%20catch-all%20hides%20typos%20in%20%60kind%60%20values**%0A%0A%60%23%5Bserde%28other%29%5D%60%20on%20%60Custom%60%20means%20any%20unrecognized%20string%20%E2%80%94%20including%20typos%20like%20%60%22cahce-heavy%22%60%20or%20%60%22standard%20%22%60%20%28trailing%20space%29%20%E2%80%94%20silently%20deserializes%20as%20%60Custom%60%20instead%20of%20returning%20a%20%60DeserializeError%60.%20A%20user%20who%20misspells%20their%20posture%20kind%20will%20get%20silently%20wrong%20behavior%2C%20with%20no%20indication%20that%20their%20config%20was%20misread.%0A%0A%23%23%23%20Issue%202%20of%204%0Acrates%2Fconfig%2Fsrc%2Flib.rs%3A368-379%0ADefault%20value%20duplication%20risk%20%E2%80%94%20%60Default%3A%3Adefault%28%29%60%20repeats%20the%20same%20string%20literals%20already%20defined%20in%20%60default_compaction_strategy%60%2C%20%60default_tool_surface%60%2C%20and%20%60default_safety_posture%60.%20If%20either%20side%20is%20updated%20without%20changing%20the%20other%20the%20two%20sources%20of%20truth%20diverge.%20Call%20the%20default%20functions%20directly%20to%20keep%20a%20single%20source%20of%20truth.%0A%0A%60%60%60suggestion%0Aimpl%20Default%20for%20HarnessPosture%20%7B%0A%20%20%20%20fn%20default%28%29%20-%3E%20Self%20%7B%0A%20%20%20%20%20%20%20%20Self%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20kind%3A%20HarnessPostureKind%3A%3AStandard%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20max_subagents%3A%200%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20prefer_codebase_search%3A%20false%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20compaction_strategy%3A%20default_compaction_strategy%28%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20tool_surface%3A%20default_tool_surface%28%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20safety_posture%3A%20default_safety_posture%28%29%2C%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Acrates%2Fconfig%2Fsrc%2Flib.rs%3A335-337%0A%60HarnessPosture%60%20and%20%60HarnessProfile%60%20are%20missing%20%60PartialEq%60%20derives%2C%20even%20though%20%60HarnessPostureKind%60%20already%20has%20it.%20The%20round-trip%20test%20manually%20checks%20individual%20fields%20because%20whole-struct%20comparison%20is%20unavailable.%20Adding%20%60PartialEq%60%20makes%20future%20tests%20and%20runtime%20equality%20checks%20%28e.g.%20detecting%20whether%20a%20reload%20changed%20the%20active%20profile%29%20straightforward.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20A%20concrete%20harness%20posture%20with%20policy%20knobs.%0A%23%5Bderive%28Debug%2C%20Clone%2C%20Serialize%2C%20Deserialize%2C%20PartialEq%29%5D%0Apub%20struct%20HarnessPosture%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%204%0Acrates%2Fconfig%2Fsrc%2Flib.rs%3A409-411%0A%60HarnessProfile%60%20is%20also%20missing%20%60PartialEq%60.%20Since%20%60HarnessPosture%60%20is%20a%20field%20of%20%60HarnessProfile%60%2C%20both%20should%20derive%20it%20together%20to%20allow%20whole-profile%20equality%20comparisons.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20A%20harness%20profile%20binds%20a%20posture%20to%20a%20provider%20route%20%2B%20model%20pattern.%0A%23%5Bderive%28Debug%2C%20Clone%2C%20Serialize%2C%20Deserialize%2C%20Default%2C%20PartialEq%29%5D%0Apub%20struct%20HarnessProfile%20%7B%0A%60%60%60%0A%0A&pr=2741&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(config): add HarnessPosture data mo..."](https://github.com/hmbown/codewhale/commit/d38eea33923aa0051dffba55c9d332bedec35948) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35562596)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->