### PR TITLE
  fix(tui): use Ollama default model in completions

### DIFF
--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -788,9 +788,8 @@ pub fn model_completion_names_for_provider(provider: ApiProvider) -> Vec<&'stati
         ApiProvider::Sglang => vec![DEFAULT_SGLANG_MODEL, DEFAULT_SGLANG_FLASH_MODEL],
         ApiProvider::Vllm => vec![DEFAULT_VLLM_MODEL, DEFAULT_VLLM_FLASH_MODEL],
         ApiProvider::Volcengine => vec![DEFAULT_VOLCENGINE_MODEL, DEFAULT_VOLCENGINE_FLASH_MODEL],
-        ApiProvider::Openai | ApiProvider::Atlascloud | ApiProvider::Ollama => {
-            OFFICIAL_DEEPSEEK_MODELS.to_vec()
-        }
+        ApiProvider::Ollama => vec![DEFAULT_OLLAMA_MODEL],
+        ApiProvider::Openai | ApiProvider::Atlascloud => OFFICIAL_DEEPSEEK_MODELS.to_vec(),
     }
 }
 
@@ -7420,6 +7419,14 @@ api_key = "old-openrouter-key"
         assert_eq!(
             model_completion_names_for_provider(ApiProvider::Moonshot),
             vec![DEFAULT_MOONSHOT_MODEL]
+        );
+    }
+
+    #[test]
+    fn model_completion_names_for_ollama_include_default_local_model() {
+        assert_eq!(
+            model_completion_names_for_provider(ApiProvider::Ollama),
+            vec![DEFAULT_OLLAMA_MODEL]
         );
     }
 


### PR DESCRIPTION
## Summary

  Ollama uses `deepseek-coder:1.3b` as its default local model, but the `/model`
  picker and slash completion were still showing the DeepSeek static model list
  for the Ollama provider.

  That made Ollama's model suggestions inconsistent with the actual default
  configuration.

  This PR updates Ollama model completions to include the Ollama default model
  instead, and adds a regression test for that behavior.

## Testing

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a model-picker regression where Ollama was incorrectly grouped with the OpenAI/Atlascloud providers and therefore offered the DeepSeek official API model list (`deepseek-v4-pro`, `deepseek-v4-flash`) as slash-completions, instead of its own local default.

- `model_completion_names_for_provider` now returns `vec![DEFAULT_OLLAMA_MODEL]` (`\"deepseek-coder:1.3b\"`) for `ApiProvider::Ollama`, consistent with how `default_model()` already resolves the same constant.
- A new unit test asserts the corrected behavior and guards against future regressions.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a one-line match-arm split that aligns the completion list with the already-correct default_model() constant, and the new test covers the fixed case directly.

The diff is minimal and targeted: it separates Ollama from OpenAI/Atlascloud in a single match arm and adds a regression test. The constant being referenced (DEFAULT_OLLAMA_MODEL) is the same one already used by default_model(), so there is no divergence between what the TUI suggests and what the configuration actually defaults to.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/config.rs | Separates Ollama from the OpenAI/Atlascloud match arm in model_completion_names_for_provider so it returns [DEFAULT_OLLAMA_MODEL] instead of the DeepSeek official model list; adds a targeted regression test. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[model_completion_names_for_provider] --> B{ApiProvider?}
    B -- Ollama --> C["vec![DEFAULT_OLLAMA_MODEL]\n(deepseek-coder:1.3b)"]
    B -- "Openai | Atlascloud" --> D["OFFICIAL_DEEPSEEK_MODELS.to_vec()\n(deepseek-v4-pro, deepseek-v4-flash)"]
    B -- "Deepseek | DeepseekCN" --> E["OFFICIAL_DEEPSEEK_MODELS.to_vec()"]
    B -- "Sglang | Vllm | ..." --> F["provider-specific defaults"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tui): use Ollama default model in co..."](https://github.com/hmbown/codewhale/commit/1229add7b05a2c087ffba111277c6ec4c8ce1468) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35569574)</sub>

<!-- /greptile_comment -->