### PR TITLE
fix: parse MCP server names with underscores

### DIFF
--- a/crates/tui/src/mcp.rs
+++ b/crates/tui/src/mcp.rs
@@ -2245,6 +2245,21 @@ impl McpPool {
             anyhow::bail!("Invalid MCP tool name: {prefixed_name}");
         }
         let rest = &prefixed_name[4..];
+        let mut resolved = None;
+        for (idx, _) in rest.match_indices('_') {
+            let server = &rest[..idx];
+            let tool = &rest[idx + 1..];
+            if server.is_empty() || tool.is_empty() {
+                continue;
+            }
+            if self.connections.contains_key(server) || self.config.servers.contains_key(server) {
+                resolved = Some((server, tool));
+            }
+        }
+        if let Some((server, tool)) = resolved {
+            return Ok((server, tool));
+        }
+
         let Some((server, tool)) = rest.split_once('_') else {
             anyhow::bail!("Invalid MCP tool name format: {prefixed_name}");
         };
@@ -3635,6 +3650,49 @@ mod tests {
         assert_eq!(
             sent[0]["params"]["arguments"],
             serde_json::json!({"query": "dephy"})
+        );
+    }
+
+    #[tokio::test]
+    async fn mcp_pool_call_tool_preserves_server_names_with_underscores() {
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let transport = ScriptedValueTransport {
+            sent: Arc::clone(&sent),
+            responses: VecDeque::from([json_frame(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {"ok": true}
+            }))]),
+        };
+        let mut conn = test_connection(Box::new(transport));
+        conn.name = "my_db".to_string();
+        conn.tools = vec![McpTool {
+            name: "execute_sql".to_string(),
+            description: None,
+            input_schema: serde_json::json!({}),
+        }];
+
+        let mut pool = McpPool::new(McpConfig {
+            timeouts: McpTimeouts::default(),
+            servers: HashMap::new(),
+        });
+        pool.connections.insert("my_db".to_string(), conn);
+
+        let result = pool
+            .call_tool(
+                "mcp_my_db_execute_sql",
+                serde_json::json!({"query": "select 1"}),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result, serde_json::json!({"ok": true}));
+        let sent = sent.lock().unwrap();
+        assert_eq!(sent[0]["method"], "tools/call");
+        assert_eq!(sent[0]["params"]["name"], "execute_sql");
+        assert_eq!(
+            sent[0]["params"]["arguments"],
+            serde_json::json!({"query": "select 1"})
         );
     }
 


### PR DESCRIPTION
Closes #2744.

This resolves prefixed MCP tool names against the longest known server-name prefix before falling back to the legacy single-underscore split. That keeps existing `mcp_server_tool` names working while allowing servers like `my_db` to route `mcp_my_db_execute_sql` to server `my_db` and tool `execute_sql`.

AI-assisted with human review.

## Verification
- Red before fix: `CARGO_HOME=/tmp/codewhale-2744-cargo-home CARGO_TARGET_DIR=/tmp/codewhale-2744-target cargo test -p codewhale-tui mcp_pool_call_tool_preserves_server_names_with_underscores -- --nocapture` failed with `Failed to find MCP server: my`
- `CARGO_HOME=/tmp/codewhale-2744-cargo-home CARGO_TARGET_DIR=/tmp/codewhale-2744-target cargo test -p codewhale-tui mcp_pool_call_tool_preserves_server_names_with_underscores -- --nocapture`
- `CARGO_HOME=/tmp/codewhale-2744-cargo-home CARGO_TARGET_DIR=/tmp/codewhale-2744-target cargo test -p codewhale-tui mcp_pool_call_tool_preserves -- --nocapture`
- `CARGO_HOME=/tmp/codewhale-2744-cargo-home CARGO_TARGET_DIR=/tmp/codewhale-2744-target cargo fmt --check`
- `git diff --check`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes MCP tool routing for server names that contain underscores (e.g. `my_db`) by replacing the naive first-underscore split with a loop that matches the longest known server-name prefix before falling back to the legacy behaviour.

- `parse_prefixed_name` now iterates every `_` position in the suffix, checks each candidate prefix against `self.connections` and `self.config.servers`, and keeps the last (longest) match — making `mcp_my_db_execute_sql` route to server `my_db` and tool `execute_sql` rather than server `my`.
- An integration test (`mcp_pool_call_tool_preserves_server_names_with_underscores`) exercises the new path end-to-end with a scripted transport.
- The legacy single-underscore fallback is preserved for server names not found in the pool, keeping backward compatibility.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the core logic correctly implements longest-prefix matching and the existing test suite exercises the primary scenario.

The fix handles the target case correctly and preserves backward compatibility through the legacy fallback. The main gap is that no test covers the overlapping-server-name scenario (both `my` and `my_db` registered simultaneously), so the longest-prefix tie-breaking is untested and could be broken by a future refactor without a test failure. The silent re-routing risk when server names share a prefix is also undocumented.

crates/tui/src/mcp.rs — specifically the new loop in parse_prefixed_name and its interaction with overlapping server-name prefixes.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/mcp.rs | Adds longest-prefix server-name resolution to parse_prefixed_name, with a companion integration test; logic is correct but silent re-routing when overlapping server names exist is undocumented |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["parse_prefixed_name(prefixed_name)"] --> B{"starts_with('mcp_')?"}
    B -- No --> ERR1["bail! Invalid MCP tool name"]
    B -- Yes --> C["rest = prefixed_name[4..]"]
    C --> D["resolved = None"]
    D --> E["for each '_' position idx in rest"]
    E --> F["server = rest[..idx], tool = rest[idx+1..]"]
    F --> G{"server or tool empty?"}
    G -- Yes --> E
    G -- No --> H{"server in connections or config?"}
    H -- No --> E
    H -- Yes --> I["resolved = Some((server, tool)) // overwrites: longest prefix wins"]
    I --> E
    E -- done --> J{"resolved is Some?"}
    J -- Yes --> K["return Ok((server, tool)) // longest-prefix match"]
    J -- No --> L["rest.split_once('_')"]
    L -- None --> ERR2["bail! Invalid MCP tool name format"]
    L -- Some --> M["return Ok((server, tool)) // legacy first-underscore fallback"]
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix-mcp-underscore-server-names%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix-mcp-underscore-server-names%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fmcp.rs%3A3656-3657%0AThe%20loop%20overwrites%20%60resolved%60%20on%20every%20match%2C%20so%20the%20last%20%28longest-prefix%29%20match%20wins.%20This%20is%20the%20stated%20intent%2C%20but%20there%20is%20no%20test%20that%20verifies%20the%20tie-breaking%20when%20*two%20registered%20servers*%20share%20an%20underscore%20prefix%20%28e.g.%20both%20%60my%60%20and%20%60my_db%60%20are%20in%20the%20pool%20and%20the%20call%20is%20%60mcp_my_db_execute_sql%60%29.%20Without%20that%20test%2C%20a%20future%20refactor%20that%20switches%20the%20loop%20to%20pick%20the%20first%20match%20would%20silently%20change%20routing%20for%20users%20with%20overlapping%20server%20names.%20Consider%20adding%20a%20dedicated%20test%20for%20this%20boundary.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Verify%20longest-prefix%20wins%20when%20two%20server%20names%20overlap.%0A%20%20%20%20%23%5Btokio%3A%3Atest%5D%0A%20%20%20%20async%20fn%20mcp_pool_parse_prefixed_name_longest_prefix_wins%28%29%20%7B%0A%20%20%20%20%20%20%20%20%2F%2F%20Server%20%22my%22%20is%20registered%3B%20%22my_db%22%20is%20also%20registered.%0A%20%20%20%20%20%20%20%20%2F%2F%20mcp_my_db_execute_sql%20must%20route%20to%20%22my_db%22%2C%20not%20%22my%22.%0A%20%20%20%20%20%20%20%20let%20pool%20%3D%20McpPool%3A%3Anew%28McpConfig%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20timeouts%3A%20McpTimeouts%3A%3Adefault%28%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20servers%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20let%20mut%20m%20%3D%20HashMap%3A%3Anew%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20m.insert%28%22my%22.to_string%28%29%2C%20Default%3A%3Adefault%28%29%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20m.insert%28%22my_db%22.to_string%28%29%2C%20Default%3A%3Adefault%28%29%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20m%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%20%20%7D%29%3B%0A%20%20%20%20%20%20%20%20let%20%28server%2C%20tool%29%20%3D%20pool.parse_prefixed_name%28%22mcp_my_db_execute_sql%22%29.unwrap%28%29%3B%0A%20%20%20%20%20%20%20%20assert_eq!%28server%2C%20%22my_db%22%29%3B%0A%20%20%20%20%20%20%20%20assert_eq!%28tool%2C%20%22execute_sql%22%29%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20%23%5Btokio%3A%3Atest%5D%0A%20%20%20%20async%20fn%20mcp_pool_call_tool_preserves_server_names_with_underscores%28%29%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fmcp.rs%3A2248-2261%0A**Silent%20re-routing%20when%20server%20names%20share%20a%20prefix**%0A%0AAdding%20a%20new%20server%20whose%20name%20is%20a%20prefix-extension%20of%20an%20existing%20one%20%28e.g.%20registering%20%60my_db%60%20after%20%60my%60%20already%20exists%29%20silently%20re-routes%20any%20%60mcp_my_db_*%60%20tool%20call%20that%20was%20previously%20landing%20on%20server%20%60my%60.%20The%20tool%20on%20%60my%60%20named%20%60db_%3Canything%3E%60%20becomes%20unreachable%20through%20the%20prefixed%20name%20the%20moment%20%60my_db%60%20is%20added%20to%20the%20pool.%20The%20longest-match%20semantics%20are%20correct%20per%20the%20PR%20description%2C%20but%20this%20behavioral%20change%20is%20invisible%20at%20the%20call%20site%20%E2%80%94%20callers%20get%20a%20successful%20response%20from%20a%20different%20server%2C%20or%20an%20%22unknown%20tool%22%20error%20if%20%60my_db%60%20doesn't%20expose%20that%20tool.%20A%20doc%20comment%20on%20%60parse_prefixed_name%60%20stating%20the%20longest-prefix%20rule%20and%20its%20consequence%20for%20overlapping%20server%20names%20would%20help%20future%20maintainers.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fmcp.rs%3A3656-3657%0AThe%20loop%20overwrites%20%60resolved%60%20on%20every%20match%2C%20so%20the%20last%20%28longest-prefix%29%20match%20wins.%20This%20is%20the%20stated%20intent%2C%20but%20there%20is%20no%20test%20that%20verifies%20the%20tie-breaking%20when%20*two%20registered%20servers*%20share%20an%20underscore%20prefix%20%28e.g.%20both%20%60my%60%20and%20%60my_db%60%20are%20in%20the%20pool%20and%20the%20call%20is%20%60mcp_my_db_execute_sql%60%29.%20Without%20that%20test%2C%20a%20future%20refactor%20that%20switches%20the%20loop%20to%20pick%20the%20first%20match%20would%20silently%20change%20routing%20for%20users%20with%20overlapping%20server%20names.%20Consider%20adding%20a%20dedicated%20test%20for%20this%20boundary.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Verify%20longest-prefix%20wins%20when%20two%20server%20names%20overlap.%0A%20%20%20%20%23%5Btokio%3A%3Atest%5D%0A%20%20%20%20async%20fn%20mcp_pool_parse_prefixed_name_longest_prefix_wins%28%29%20%7B%0A%20%20%20%20%20%20%20%20%2F%2F%20Server%20%22my%22%20is%20registered%3B%20%22my_db%22%20is%20also%20registered.%0A%20%20%20%20%20%20%20%20%2F%2F%20mcp_my_db_execute_sql%20must%20route%20to%20%22my_db%22%2C%20not%20%22my%22.%0A%20%20%20%20%20%20%20%20let%20pool%20%3D%20McpPool%3A%3Anew%28McpConfig%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20timeouts%3A%20McpTimeouts%3A%3Adefault%28%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20servers%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20let%20mut%20m%20%3D%20HashMap%3A%3Anew%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20m.insert%28%22my%22.to_string%28%29%2C%20Default%3A%3Adefault%28%29%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20m.insert%28%22my_db%22.to_string%28%29%2C%20Default%3A%3Adefault%28%29%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20m%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%20%20%7D%29%3B%0A%20%20%20%20%20%20%20%20let%20%28server%2C%20tool%29%20%3D%20pool.parse_prefixed_name%28%22mcp_my_db_execute_sql%22%29.unwrap%28%29%3B%0A%20%20%20%20%20%20%20%20assert_eq!%28server%2C%20%22my_db%22%29%3B%0A%20%20%20%20%20%20%20%20assert_eq!%28tool%2C%20%22execute_sql%22%29%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20%23%5Btokio%3A%3Atest%5D%0A%20%20%20%20async%20fn%20mcp_pool_call_tool_preserves_server_names_with_underscores%28%29%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fmcp.rs%3A2248-2261%0A**Silent%20re-routing%20when%20server%20names%20share%20a%20prefix**%0A%0AAdding%20a%20new%20server%20whose%20name%20is%20a%20prefix-extension%20of%20an%20existing%20one%20%28e.g.%20registering%20%60my_db%60%20after%20%60my%60%20already%20exists%29%20silently%20re-routes%20any%20%60mcp_my_db_*%60%20tool%20call%20that%20was%20previously%20landing%20on%20server%20%60my%60.%20The%20tool%20on%20%60my%60%20named%20%60db_%3Canything%3E%60%20becomes%20unreachable%20through%20the%20prefixed%20name%20the%20moment%20%60my_db%60%20is%20added%20to%20the%20pool.%20The%20longest-match%20semantics%20are%20correct%20per%20the%20PR%20description%2C%20but%20this%20behavioral%20change%20is%20invisible%20at%20the%20call%20site%20%E2%80%94%20callers%20get%20a%20successful%20response%20from%20a%20different%20server%2C%20or%20an%20%22unknown%20tool%22%20error%20if%20%60my_db%60%20doesn't%20expose%20that%20tool.%20A%20doc%20comment%20on%20%60parse_prefixed_name%60%20stating%20the%20longest-prefix%20rule%20and%20its%20consequence%20for%20overlapping%20server%20names%20would%20help%20future%20maintainers.%0A%0A&repo=hmbown%2Fcodewhale&pr=2746&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fmcp.rs%3A3656-3657%0AThe%20loop%20overwrites%20%60resolved%60%20on%20every%20match%2C%20so%20the%20last%20%28longest-prefix%29%20match%20wins.%20This%20is%20the%20stated%20intent%2C%20but%20there%20is%20no%20test%20that%20verifies%20the%20tie-breaking%20when%20*two%20registered%20servers*%20share%20an%20underscore%20prefix%20%28e.g.%20both%20%60my%60%20and%20%60my_db%60%20are%20in%20the%20pool%20and%20the%20call%20is%20%60mcp_my_db_execute_sql%60%29.%20Without%20that%20test%2C%20a%20future%20refactor%20that%20switches%20the%20loop%20to%20pick%20the%20first%20match%20would%20silently%20change%20routing%20for%20users%20with%20overlapping%20server%20names.%20Consider%20adding%20a%20dedicated%20test%20for%20this%20boundary.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Verify%20longest-prefix%20wins%20when%20two%20server%20names%20overlap.%0A%20%20%20%20%23%5Btokio%3A%3Atest%5D%0A%20%20%20%20async%20fn%20mcp_pool_parse_prefixed_name_longest_prefix_wins%28%29%20%7B%0A%20%20%20%20%20%20%20%20%2F%2F%20Server%20%22my%22%20is%20registered%3B%20%22my_db%22%20is%20also%20registered.%0A%20%20%20%20%20%20%20%20%2F%2F%20mcp_my_db_execute_sql%20must%20route%20to%20%22my_db%22%2C%20not%20%22my%22.%0A%20%20%20%20%20%20%20%20let%20pool%20%3D%20McpPool%3A%3Anew%28McpConfig%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20timeouts%3A%20McpTimeouts%3A%3Adefault%28%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20servers%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20let%20mut%20m%20%3D%20HashMap%3A%3Anew%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20m.insert%28%22my%22.to_string%28%29%2C%20Default%3A%3Adefault%28%29%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20m.insert%28%22my_db%22.to_string%28%29%2C%20Default%3A%3Adefault%28%29%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20m%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%20%20%7D%29%3B%0A%20%20%20%20%20%20%20%20let%20%28server%2C%20tool%29%20%3D%20pool.parse_prefixed_name%28%22mcp_my_db_execute_sql%22%29.unwrap%28%29%3B%0A%20%20%20%20%20%20%20%20assert_eq!%28server%2C%20%22my_db%22%29%3B%0A%20%20%20%20%20%20%20%20assert_eq!%28tool%2C%20%22execute_sql%22%29%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20%23%5Btokio%3A%3Atest%5D%0A%20%20%20%20async%20fn%20mcp_pool_call_tool_preserves_server_names_with_underscores%28%29%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fmcp.rs%3A2248-2261%0A**Silent%20re-routing%20when%20server%20names%20share%20a%20prefix**%0A%0AAdding%20a%20new%20server%20whose%20name%20is%20a%20prefix-extension%20of%20an%20existing%20one%20%28e.g.%20registering%20%60my_db%60%20after%20%60my%60%20already%20exists%29%20silently%20re-routes%20any%20%60mcp_my_db_*%60%20tool%20call%20that%20was%20previously%20landing%20on%20server%20%60my%60.%20The%20tool%20on%20%60my%60%20named%20%60db_%3Canything%3E%60%20becomes%20unreachable%20through%20the%20prefixed%20name%20the%20moment%20%60my_db%60%20is%20added%20to%20the%20pool.%20The%20longest-match%20semantics%20are%20correct%20per%20the%20PR%20description%2C%20but%20this%20behavioral%20change%20is%20invisible%20at%20the%20call%20site%20%E2%80%94%20callers%20get%20a%20successful%20response%20from%20a%20different%20server%2C%20or%20an%20%22unknown%20tool%22%20error%20if%20%60my_db%60%20doesn't%20expose%20that%20tool.%20A%20doc%20comment%20on%20%60parse_prefixed_name%60%20stating%20the%20longest-prefix%20rule%20and%20its%20consequence%20for%20overlapping%20server%20names%20would%20help%20future%20maintainers.%0A%0A&pr=2746&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix: parse MCP server names with undersc..."](https://github.com/hmbown/codewhale/commit/f19e03b3fa2d126c56a58ec0a23333c198d78ec0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35582557)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->