### PR TITLE
fix(tui): correct resume command in sessions footer

### DIFF
--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -3874,7 +3874,7 @@ fn list_sessions(limit: usize, search: Option<String>) -> Result<()> {
     println!();
     println!(
         "Resume with: {} {}",
-        "codewhale --resume".truecolor(blue_r, blue_g, blue_b),
+        "codewhale resume".truecolor(blue_r, blue_g, blue_b),
         "<session-id>".dimmed()
     );
     println!(


### PR DESCRIPTION
## Summary
`codewhale sessions` showed `codewhale --resume <id>` in the footer, but --resume is not a valid top-level flag of the CLI dispatcher.
Changed to `codewhale resume <id>`, matching the actual subcommand.

Closes #2758 
## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features`
- [x] `cargo test --workspace --all-features`

## Checklist

- [x] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [x] Verified TUI behavior manually if UI changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR corrects a one-word typo in the `codewhale sessions` footer hint, changing `codewhale --resume <id>` to `codewhale resume <id>` to match the actual `Resume` subcommand defined in the CLI.

- The fix correctly uses the `Resume` subcommand form (`codewhale resume <id>`), which is the canonical entry point (line 269 of `main.rs`). The top-level `--resume` flag also exists but is less idiomatic for users to type.
- The adjacent footer line showing `codewhale --continue` remains correct, since `--continue` is defined as a top-level flag with no corresponding subcommand.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a single string correction in a display-only footer with no effect on runtime logic.

The change touches exactly one string literal in a print statement. The corrected form (codewhale resume) maps directly to the Resume subcommand defined in the CLI enum, and the rest of the footer is untouched. There is no logic, state, or control flow involved.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/main.rs | Single-character fix: footer hint string changed from `--resume` flag form to the `resume` subcommand form; no logic or behavior changes. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["codewhale sessions"] --> B["list_sessions()"]
    B --> C["Print session list"]
    C --> D["Print footer hints"]
    D --> E["'codewhale resume <session-id>'\n(fixed from --resume)"]
    D --> F["'codewhale --continue'\n(unchanged, top-level flag)"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tui): correct resume command in sess..."](https://github.com/hmbown/codewhale/commit/001bcad98cb66e5956d43469767598179ec57128) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35760179)</sub>

<!-- /greptile_comment -->