### PR TITLE
fix(tui): #2760 correct sessions resume footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dedicated hydrated status, so it is no longer indistinguishable from a real
   successful execution. A hydrated row also ranks with active work rather than
   completed successes (#2648).
+- `codewhale sessions` now shows `codewhale resume <session-id>` in the footer
+  instead of the invalid dispatcher command `codewhale --resume <session-id>`
+  (#2758, #2760).
 - TUI HTTP clients now install the Rustls ring crypto provider before building
   `reqwest` clients, covering engine, runtime API, tool, MCP, config, and skill
   download paths. This keeps the no-provider TLS build from panicking during
@@ -150,8 +153,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Community
 
-Thanks to **@cyq1017** for the restore-listing implementation (#2513) and
-pending-input delivery-mode label work (#2532, #2054),
+Thanks to **@sximelon** for reporting and fixing the saved-session resume
+footer hint (#2758, #2760), **@cyq1017** for the restore-listing implementation
+(#2513) and pending-input delivery-mode label work (#2532, #2054),
 **@wywsoor** for the broader macOS/iTerm rollback UX report (#2494),
 **@HUQIANTAO** for the `web_run` lock-splitting work (#2502), turn-metadata
 prefix-cache stability work (#2517), and project-context cache direction

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -140,6 +140,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dedicated hydrated status, so it is no longer indistinguishable from a real
   successful execution. A hydrated row also ranks with active work rather than
   completed successes (#2648).
+- `codewhale sessions` now shows `codewhale resume <session-id>` in the footer
+  instead of the invalid dispatcher command `codewhale --resume <session-id>`
+  (#2758, #2760).
 - TUI HTTP clients now install the Rustls ring crypto provider before building
   `reqwest` clients, covering engine, runtime API, tool, MCP, config, and skill
   download paths. This keeps the no-provider TLS build from panicking during
@@ -150,8 +153,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Community
 
-Thanks to **@cyq1017** for the restore-listing implementation (#2513) and
-pending-input delivery-mode label work (#2532, #2054),
+Thanks to **@sximelon** for reporting and fixing the saved-session resume
+footer hint (#2758, #2760), **@cyq1017** for the restore-listing implementation
+(#2513) and pending-input delivery-mode label work (#2532, #2054),
 **@wywsoor** for the broader macOS/iTerm rollback UX report (#2494),
 **@HUQIANTAO** for the `web_run` lock-splitting work (#2502), turn-metadata
 prefix-cache stability work (#2517), and project-context cache direction

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -3827,6 +3827,10 @@ fn rustc_version() -> String {
 }
 
 /// List saved sessions
+fn sessions_resume_command() -> &'static str {
+    "codewhale resume"
+}
+
 fn list_sessions(limit: usize, search: Option<String>) -> Result<()> {
     use crate::palette;
     use colored::Colorize;
@@ -3881,7 +3885,7 @@ fn list_sessions(limit: usize, search: Option<String>) -> Result<()> {
     println!();
     println!(
         "Resume with: {} {}",
-        "codewhale --resume".truecolor(blue_r, blue_g, blue_b),
+        sessions_resume_command().truecolor(blue_r, blue_g, blue_b),
         "<session-id>".dimmed()
     );
     println!(
@@ -6511,6 +6515,19 @@ mod terminal_mode_tests {
         };
 
         assert!(args.continue_session);
+    }
+
+    #[test]
+    fn sessions_footer_points_to_resume_subcommand() {
+        let cli = parse_cli(&["codewhale", "resume", "abc123"]);
+        let Some(Commands::Resume { session_id, last }) = cli.command else {
+            panic!("expected resume command");
+        };
+
+        assert_eq!(session_id.as_deref(), Some("abc123"));
+        assert!(!last);
+        assert_eq!(sessions_resume_command(), "codewhale resume");
+        assert!(!sessions_resume_command().contains("--resume"));
     }
 
     #[test]

--- a/docs/V0_9_0_EXECUTION_MAP.md
+++ b/docs/V0_9_0_EXECUTION_MAP.md
@@ -1,6 +1,6 @@
 # v0.9.0 Execution Map
 
-Snapshot date: 2026-06-04
+Snapshot date: 2026-06-05
 
 This map tracks the v0.9.0 integration branch and keeps the open-PR harvest
 separate from release publishing. It is a working document: update it whenever a
@@ -8,11 +8,12 @@ PR is harvested, superseded, deferred, or closed.
 
 ## Live Counts
 
-- Actual open issues: 446
-- Open PRs: 59
-- Repo API open issue count: 505, because GitHub includes PRs in that total
+- Actual open issues: 452
+- Open PRs: 71
+- Repo API open issue count: 523, because GitHub includes PRs in that total
 - Open issues labeled `v0.9.0`: 119
-- Open issues without a milestone: 102
+- Open `v0.9.0` milestone items: 135 open, 8 closed
+- Open issues without a milestone: 108
 
 ## Execution Order
 
@@ -155,6 +156,7 @@ v0.9 branch so the remaining Windows/manual checks are explicit.
 | #2755 roll back provider after auth failure | Draft / forwarded | Snapshot+rollback of provider/model on auth failure (#2754). Design is sound and tested, but author opened it as draft noting they could not reproduce the live Moonshot auth failure end-to-end. Help-forward: needs maintainer validation against a real provider auth failure (engine respawn + model restore). Credit @cyq1017. |
 | #2756 Xiaomi MiMo Token Plan region docs | Mergeable / locally harvested | Docs-only; verified accurate against branch `resolve_xiaomi_mimo_base_url` (tp- keys default to `token-plan-sgp`, pay-as-you-go to `api.xiaomimimo.com`, CN requires explicit `base_url`). Conflict on the CONFIGURATION.md provider bullet resolved by keeping the branch `path_suffix` bullet and adopting the PR's accurate base_url wording. Credit @xyuai; comment/close after branch is public. Fixes #2735. |
 | #2757 hydrated deferred-tool render | Mergeable / locally harvested | Harvested in full (6 files): deferred-tool first-use schema hydration now renders as "tool loaded — retry required" via `ToolStatus::Hydrated` instead of "run done". Local correction: hydrated rows rank with active work (rank 1) not completed successes; kept the contributor's hydration detection (sole emitter always sets `executed=false`, consistent with the engine's own check, so the missing-field default was not changed). `cargo test -p codewhale-tui --bin codewhale-tui --locked hydrat` (6 pass), clippy clean. Credit @mvanhorn; comment/close after branch is public. Fixes #2648. |
+| #2760 sessions footer resume command | Harvested on review branch `codex/harvest-2760-session-resume-footer`. | Corrects the `codewhale sessions` footer from `codewhale --resume <session-id>` to `codewhale resume <session-id>`, matching the actual CLI subcommand and fixing the repro from #2758. Added a parser/footer regression test. Credit @sximelon as both reporter and PR author; close/comment after the integration PR is merged. Fixes #2758. |
 | Local verification sweep stabilizer | Added after the full workspace verification sweep found test-only no-provider TLS panics and prompt byte instability. | Shared TUI Rustls provider helpers now wrap `reqwest` client construction across engine, runtime API, tool, MCP, config, and skill paths; the skill-installer integration include keeps its own local helper. Prompt byte-stability tests pin home and skills env under the shared test-env lock. Evidence: `cargo fmt --all -- --check`, `git diff --check`, `./scripts/release/check-versions.sh`, `cargo clippy --workspace --all-features --locked -- -D warnings`, focused skill/finance/goal/MCP reruns, and `cargo test --workspace --all-features --locked` all passed locally. |
 
 ## Issue Reduction Strategy


### PR DESCRIPTION
## Summary
- Harvests #2760 by @sximelon into the v0.9.0 integration track.
- Changes the `codewhale sessions` footer from `codewhale --resume <session-id>` to the valid `codewhale resume <session-id>` subcommand.
- Adds a focused parser/footer regression test and records credit in the changelogs/execution map.

Fixes #2758.

## Contributor credit
- Commit includes `Harvested from PR #2760 by @sximelon`.
- Commit includes `Co-authored-by: sximelon <15710511+sximelon@users.noreply.github.com>`.
- @sximelon is credited as both reporter and PR author in changelog/community notes.

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/release/check-versions.sh`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked sessions_footer_points_to_resume_subcommand -- --nocapture`
- `cargo clippy -p codewhale-tui --bin codewhale-tui --locked -- -D warnings`
- `python3 scripts/check-coauthor-trailers.py --range origin/codex/v0.9.0-stewardship..HEAD`

## Release boundary
No tag, publish, GitHub Release, version bump, or release artifact push was performed.