### PR TITLE
fix(tui): gate shell child kill helper off Windows

### DIFF
--- a/crates/tui/src/tools/shell.rs
+++ b/crates/tui/src/tools/shell.rs
@@ -396,6 +396,7 @@ impl ShellChild {
         }
     }
 
+    #[cfg(not(windows))]
     fn kill(&mut self) -> std::io::Result<()> {
         match self {
             #[cfg(unix)]


### PR DESCRIPTION
## Summary
- fixes the Windows CI `-D warnings` failure from PR #2762 by compiling `ShellChild::kill` only on non-Windows
- keeps Windows cleanup on the existing job-object/direct child paths
- leaves runtime shell behavior unchanged

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked test_completed_background_shell_releases_process_handles -- --nocapture`
- `cargo clippy -p codewhale-tui --bin codewhale-tui --locked -- -D warnings`
- `git diff --check`
- `./scripts/release/check-versions.sh`
- `python3 scripts/check-coauthor-trailers.py --range origin/codex/v0.9.0-stewardship..HEAD`

## Windows note
Attempted `RUSTFLAGS='-Dwarnings' cargo check -p codewhale-tui --bin codewhale-tui --locked --target x86_64-pc-windows-msvc` locally, but this macOS host lacks the required Windows C target headers/toolchain for `ring`; the command failed before reaching `codewhale-tui`. GitHub Windows CI should validate the actual failure mode.
