### PR TITLE
test(shell): #2528 widen background completion wait

### DIFF
--- a/crates/tui/src/tools/shell/tests.rs
+++ b/crates/tui/src/tools/shell/tests.rs
@@ -21,6 +21,8 @@ fn env_lock() -> &'static Mutex<()> {
     LOCK.get_or_init(|| Mutex::new(()))
 }
 
+const BACKGROUND_COMPLETION_WAIT_MS: u64 = 30_000;
+
 #[cfg(windows)]
 const JOB_OBJECT_QUERY_ACCESS: u32 = 0x0004;
 
@@ -133,7 +135,7 @@ fn failed_network_shell_result(stdout: &str, stderr: &str) -> ShellResult {
 }
 
 fn wait_for_completed_shell(manager: &mut ShellManager, task_id: &str) -> ShellResult {
-    let deadline = Instant::now() + Duration::from_secs(20);
+    let deadline = Instant::now() + Duration::from_millis(BACKGROUND_COMPLETION_WAIT_MS);
 
     loop {
         let result = manager
@@ -801,7 +803,7 @@ async fn test_completed_background_shell_releases_process_handles() {
             json!({
                 "task_id": task_id.clone(),
                 "wait": true,
-                "timeout_ms": 5_000
+                "timeout_ms": BACKGROUND_COMPLETION_WAIT_MS
             }),
             &ctx,
         )


### PR DESCRIPTION
## Summary
- harvests #2528 by @cyq1017 as a focused test-only maintainer PR
- names the background shell completion wait and widens it to 30s for slower runners
- applies the same timeout to the background process-handle release regression

## Credit
- Harvested from PR #2528 by @cyq1017
- Co-authored-by trailer included from `.github/AUTHOR_MAP`

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked test_background_execution -- --nocapture`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked test_completed_background_shell_releases_process_handles -- --nocapture`
- `cargo clippy -p codewhale-tui --bin codewhale-tui --locked -- -D warnings`
- `git diff --check`
- `./scripts/release/check-versions.sh`
- `python3 scripts/check-coauthor-trailers.py --range origin/codex/v0.9.0-stewardship..HEAD`
