### PR TITLE
fix(tui): #2742 avoid static Ollama model suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a PR gate marker guard so reopened unapproved PRs do not get duplicate
   intake comments, and clarified that PR reopening should happen after
   allowlist approval is merged.
+- Ollama `/model` completions no longer show hosted DeepSeek API model IDs.
+  The picker preserves the current or saved local Ollama tag, and users can
+  still fetch installed model IDs through `/models` instead of relying on a
+  stale static default (#2742). Thanks @reidliu41 for the focused report and
+  draft fix.
 - Documented the agent and sub-agent stewardship ethos so future automation
   preserves human issue intake, careful PR review, and contributor credit.
 - Moved the TUI Starlark execpolicy parser and PTY support behind non-OHOS

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -78,6 +78,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a PR gate marker guard so reopened unapproved PRs do not get duplicate
   intake comments, and clarified that PR reopening should happen after
   allowlist approval is merged.
+- Ollama `/model` completions no longer show hosted DeepSeek API model IDs.
+  The picker preserves the current or saved local Ollama tag, and users can
+  still fetch installed model IDs through `/models` instead of relying on a
+  stale static default (#2742). Thanks @reidliu41 for the focused report and
+  draft fix.
 - Documented the agent and sub-agent stewardship ethos so future automation
   preserves human issue intake, careful PR review, and contributor credit.
 - Moved the TUI Starlark execpolicy parser and PTY support behind non-OHOS

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -788,9 +788,8 @@ pub fn model_completion_names_for_provider(provider: ApiProvider) -> Vec<&'stati
         ApiProvider::Sglang => vec![DEFAULT_SGLANG_MODEL, DEFAULT_SGLANG_FLASH_MODEL],
         ApiProvider::Vllm => vec![DEFAULT_VLLM_MODEL, DEFAULT_VLLM_FLASH_MODEL],
         ApiProvider::Volcengine => vec![DEFAULT_VOLCENGINE_MODEL, DEFAULT_VOLCENGINE_FLASH_MODEL],
-        ApiProvider::Openai | ApiProvider::Atlascloud | ApiProvider::Ollama => {
-            OFFICIAL_DEEPSEEK_MODELS.to_vec()
-        }
+        ApiProvider::Ollama => Vec::new(),
+        ApiProvider::Openai | ApiProvider::Atlascloud => OFFICIAL_DEEPSEEK_MODELS.to_vec(),
     }
 }
 
@@ -7497,6 +7496,13 @@ api_key = "old-openrouter-key"
             model_completion_names_for_provider(ApiProvider::Deepseek),
             vec!["deepseek-v4-pro", "deepseek-v4-flash"]
         );
+    }
+
+    #[test]
+    fn model_completion_names_for_ollama_do_not_promote_static_remote_models() {
+        let models = model_completion_names_for_provider(ApiProvider::Ollama);
+
+        assert!(models.is_empty());
     }
 
     #[test]

--- a/crates/tui/src/tui/model_picker.rs
+++ b/crates/tui/src/tui/model_picker.rs
@@ -778,6 +778,22 @@ mod tests {
     }
 
     #[test]
+    fn picker_for_ollama_preserves_current_local_tag_without_hosted_static_rows() {
+        let (mut app, _lock) = create_test_app();
+        app.api_provider = crate::config::ApiProvider::Ollama;
+        app.model_ids_passthrough = true;
+        app.model = "qwen2.5-coder:7b".to_string();
+        app.auto_model = false;
+
+        let view = ModelPickerView::new(&app);
+        let model_ids = view.visible_model_ids();
+
+        assert_eq!(model_ids, vec!["auto"]);
+        assert!(view.show_custom_model_row);
+        assert_eq!(view.resolved_model(), "qwen2.5-coder:7b");
+    }
+
+    #[test]
     fn visible_row_window_tracks_selection_in_short_panes() {
         assert_eq!(visible_row_window(0, 16, 8), (0, 8));
         assert_eq!(visible_row_window(7, 16, 8), (3, 11));

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -3304,6 +3304,21 @@ mod tests {
     }
 
     #[test]
+    fn slash_completion_hints_model_ollama_has_no_static_remote_models() {
+        let hints =
+            slash_completion_hints("/model", 128, &[], Locale::En, None, ApiProvider::Ollama);
+        let names = hints
+            .iter()
+            .map(|hint| hint.name.as_str())
+            .collect::<Vec<_>>();
+
+        assert!(names.contains(&"/model"));
+        assert!(!names.contains(&"/model deepseek-v4-pro"));
+        assert!(!names.contains(&"/model deepseek-v4-flash"));
+        assert!(!names.contains(&"/model deepseek-coder:1.3b"));
+    }
+
+    #[test]
     fn selection_style_uses_explicit_selection_text_role() {
         let line = Line::from(Span::styled(
             "hello world",


### PR DESCRIPTION
## Summary
- Harvests the useful intent from #2742 by @reidliu41 without adding the stale `deepseek-coder:1.3b` default to another UI surface.
- Stops Ollama `/model` static completions from suggesting hosted DeepSeek API IDs.
- Keeps the model picker on `auto` plus the current/saved local Ollama tag; installed tags still come from the existing live `/models` path.

## Contributor credit
- Commit includes `Harvested from PR #2742 by @reidliu41`.
- Commit includes `Co-authored-by: reidliu41 <61492567+reidliu41@users.noreply.github.com>`.
- Changelog credits @reidliu41 for the focused report and draft fix.

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/release/check-versions.sh`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked ollama -- --nocapture`
- `cargo clippy -p codewhale-tui --bin codewhale-tui --locked -- -D warnings`
- `python3 scripts/check-coauthor-trailers.py --author-map .github/AUTHOR_MAP --range origin/codex/v0.9.0-stewardship..HEAD --check-authors`

## Release boundary
No tag, publish, GitHub Release, version bump, or release artifact push was performed.
