### PR TITLE
fix(mcp): #2744 preserve underscored names in displays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   still fetch installed model IDs through `/models` instead of relying on a
   stale static default (#2742). Thanks @reidliu41 for the focused report and
   draft fix.
+- MCP runtime API tool listings and approval summaries no longer split
+  underscored MCP server names at the first `_`. Tool-call routing already used
+  the longest registered server name; the list endpoint now reuses that parser,
+  and approval cards show the full MCP target route instead of a guessed server
+  segment (#2744). Thanks @lioryx, @cyq1017, and @puneetdixit200 for the report
+  and matching fixes.
 - Documented the agent and sub-agent stewardship ethos so future automation
   preserves human issue intake, careful PR review, and contributor credit.
 - Moved the TUI Starlark execpolicy parser and PTY support behind non-OHOS

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -83,6 +83,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   still fetch installed model IDs through `/models` instead of relying on a
   stale static default (#2742). Thanks @reidliu41 for the focused report and
   draft fix.
+- MCP runtime API tool listings and approval summaries no longer split
+  underscored MCP server names at the first `_`. Tool-call routing already used
+  the longest registered server name; the list endpoint now reuses that parser,
+  and approval cards show the full MCP target route instead of a guessed server
+  segment (#2744). Thanks @lioryx, @cyq1017, and @puneetdixit200 for the report
+  and matching fixes.
 - Documented the agent and sub-agent stewardship ethos so future automation
   preserves human issue intake, careful PR review, and contributor credit.
 - Moved the TUI Starlark execpolicy parser and PTY support behind non-OHOS

--- a/crates/tui/src/mcp.rs
+++ b/crates/tui/src/mcp.rs
@@ -2261,7 +2261,10 @@ impl McpPool {
     }
 
     /// Parse a prefixed name into (server_name, tool_name)
-    fn parse_prefixed_name<'a>(&self, prefixed_name: &'a str) -> Result<(&'a str, &'a str)> {
+    pub(crate) fn parse_prefixed_name<'a>(
+        &self,
+        prefixed_name: &'a str,
+    ) -> Result<(&'a str, &'a str)> {
         let Some(rest) = prefixed_name.strip_prefix("mcp_") else {
             anyhow::bail!("Invalid MCP tool name: {prefixed_name}");
         };
@@ -3149,6 +3152,27 @@ mod tests {
         assert_eq!(server.command, Some("node".to_string()));
         assert_eq!(server.args, vec!["server.js"]);
         assert_eq!(server.env.get("FOO"), Some(&"bar".to_string()));
+    }
+
+    #[test]
+    fn mcp_pool_parse_prefixed_name_preserves_registered_underscored_server() {
+        let config: McpConfig = serde_json::from_str(
+            r#"{
+                "servers": {
+                    "my": {"command": "node"},
+                    "my_db": {"command": "node"}
+                }
+            }"#,
+        )
+        .unwrap();
+        let pool = McpPool::new(config);
+
+        let (server, tool) = pool
+            .parse_prefixed_name("mcp_my_db_execute_sql")
+            .expect("registered underscored server should parse");
+
+        assert_eq!(server, "my_db");
+        assert_eq!(tool, "execute_sql");
     }
 
     #[test]

--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -1427,10 +1427,7 @@ async fn list_mcp_tools(
 
     let mut tools = Vec::new();
     for (prefixed_name, tool) in pool.all_tools() {
-        let Some(rest) = prefixed_name.strip_prefix("mcp_") else {
-            continue;
-        };
-        let Some((server, name)) = rest.split_once('_') else {
+        let Ok((server, name)) = pool.parse_prefixed_name(&prefixed_name) else {
             continue;
         };
 

--- a/crates/tui/src/tui/approval.rs
+++ b/crates/tui/src/tui/approval.rs
@@ -344,13 +344,12 @@ fn param_preview(params: &Value, keys: &[&str], max_len: usize) -> Option<String
     None
 }
 
-fn mcp_server_hint(tool_name: &str) -> Option<String> {
+fn mcp_target_hint(tool_name: &str) -> Option<String> {
     let remainder = tool_name.strip_prefix("mcp_")?;
-    let (server, _) = remainder.split_once('_')?;
-    if server.is_empty() {
+    if remainder.is_empty() {
         None
     } else {
-        Some(server.to_string())
+        Some(remainder.to_string())
     }
 }
 
@@ -393,16 +392,16 @@ fn build_impact_summary(tool_name: &str, category: ToolCategory, params: &Value)
         ToolCategory::McpRead => {
             let mut impacts =
                 vec!["Reads from an MCP server without an obvious local write.".to_string()];
-            if let Some(server) = mcp_server_hint(tool_name) {
-                impacts.push(format!("Server: {server}"));
+            if let Some(target) = mcp_target_hint(tool_name) {
+                impacts.push(format!("MCP target: {target}"));
             }
             impacts
         }
         ToolCategory::McpAction => {
             let mut impacts =
                 vec!["Calls an MCP server action that may have side effects.".to_string()];
-            if let Some(server) = mcp_server_hint(tool_name) {
-                impacts.push(format!("Server: {server}"));
+            if let Some(target) = mcp_target_hint(tool_name) {
+                impacts.push(format!("MCP target: {target}"));
             }
             impacts
         }
@@ -475,15 +474,15 @@ fn build_impact_summary_zh_hans(
         }
         ToolCategory::McpRead => {
             let mut impacts = vec!["从 MCP 服务器读取信息，不应产生本地写入。".to_string()];
-            if let Some(server) = mcp_server_hint(tool_name) {
-                impacts.push(format!("服务器：{server}"));
+            if let Some(target) = mcp_target_hint(tool_name) {
+                impacts.push(format!("MCP 目标：{target}"));
             }
             impacts
         }
         ToolCategory::McpAction => {
             let mut impacts = vec!["调用可能产生副作用的 MCP 服务器操作。".to_string()];
-            if let Some(server) = mcp_server_hint(tool_name) {
-                impacts.push(format!("服务器：{server}"));
+            if let Some(target) = mcp_target_hint(tool_name) {
+                impacts.push(format!("MCP 目标：{target}"));
             }
             impacts
         }
@@ -1445,6 +1444,33 @@ mod tests {
                 .iter()
                 .any(|line| line.contains("cargo test"))
         );
+    }
+
+    #[test]
+    fn mcp_impact_summary_preserves_full_target_for_underscored_names() {
+        let request = ApprovalRequest::new(
+            "test-id",
+            "mcp_my_db_execute_sql",
+            "Call an MCP tool",
+            &json!({}),
+            "tool:mcp_my_db_execute_sql",
+        );
+
+        assert!(
+            request
+                .impacts
+                .iter()
+                .any(|line| line == "MCP target: my_db_execute_sql")
+        );
+        assert!(!request.impacts.iter().any(|line| line == "Server: my"));
+
+        let zh_impacts = request.impacts_for_locale(Locale::ZhHans);
+        assert!(
+            zh_impacts
+                .iter()
+                .any(|line| line == "MCP 目标：my_db_execute_sql")
+        );
+        assert!(!zh_impacts.iter().any(|line| line == "服务器：my"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Follows up the #2744 MCP underscore harvest by aligning display/metadata paths with the fixed routing parser.
- Runtime API `/v1/apps/mcp/tools` now reuses `McpPool::parse_prefixed_name`, so underscored server names are listed and filtered correctly.
- Approval summaries now show the full MCP target route instead of guessing a server from the first `_`, which avoids misleading `Server: my` copy for `mcp_my_db_execute_sql`.

## Contributor credit
- Credits #2744 reporter @lioryx in the changelog/PR text.
- Commit includes co-author trailers for the two matching implementation PR authors: @cyq1017 (#2747) and @puneetdixit200 (#2746).

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/release/check-versions.sh`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked underscored -- --nocapture`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked mcp_pool_call_tool -- --nocapture`
- `cargo clippy -p codewhale-tui --bin codewhale-tui --locked -- -D warnings`
- `python3 scripts/check-coauthor-trailers.py --author-map .github/AUTHOR_MAP --range origin/codex/v0.9.0-stewardship..HEAD --check-authors`

## Release boundary
No tag, publish, GitHub Release, version bump, or release artifact push was performed.
