### PR TITLE
feat(tui): ghost-text follow-up prompt suggestion

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -144,6 +144,7 @@ memory_path = "~/.codewhale/memory.md"
 allow_shell = true
 approval_policy = "on-request" # on-request | untrusted | never
 sandbox_mode = "workspace-write" # read-only | workspace-write | danger-full-access | external-sandbox
+# prompt_suggestion = true  # opt-in: show ghost-text follow-up question in composer after each turn
 
 # Typed permission rules live in a sibling `permissions.toml` file, not in
 # config.toml. This schema slice is ask-only and is parsed for follow-up

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -1550,6 +1550,9 @@ pub struct Config {
     /// missing optional file doesn't fail the launch.
     pub instructions: Option<Vec<String>>,
     pub allow_shell: Option<bool>,
+    /// Opt-in ghost-text follow-up prompt suggestion after each completed turn.
+    /// Default: false — the user must explicitly set this to true to enable.
+    pub prompt_suggestion: Option<bool>,
     pub approval_policy: Option<String>,
     pub sandbox_mode: Option<String>,
     pub yolo: Option<bool>,
@@ -2705,6 +2708,11 @@ impl Config {
     #[must_use]
     pub fn allow_shell(&self) -> bool {
         self.allow_shell.unwrap_or(false)
+    }
+
+    /// Whether ghost-text prompt suggestion is enabled (opt-in, default off).
+    pub fn prompt_suggestion_enabled(&self) -> bool {
+        self.prompt_suggestion.unwrap_or(false)
     }
 
     /// Return the maximum number of concurrent sub-agents.
@@ -4253,6 +4261,7 @@ fn merge_config(base: Config, override_cfg: Config) -> Config {
         // both — they list `~/global.md` inside the project array.
         instructions: override_cfg.instructions.or(base.instructions),
         allow_shell: override_cfg.allow_shell.or(base.allow_shell),
+        prompt_suggestion: override_cfg.prompt_suggestion.or(base.prompt_suggestion),
         yolo: override_cfg.yolo.or(base.yolo),
         approval_policy: override_cfg.approval_policy.or(base.approval_policy),
         sandbox_mode: override_cfg.sandbox_mode.or(base.sandbox_mode),

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -5416,6 +5416,28 @@ mod tests {
     }
 
     #[test]
+    fn prompt_suggestion_defaults_to_false() {
+        let config = Config::default();
+        assert_eq!(
+            config.prompt_suggestion, None,
+            "default Config must not opt in"
+        );
+        assert!(
+            !config.prompt_suggestion_enabled(),
+            "prompt_suggestion must be opt-in (default off)"
+        );
+    }
+
+    #[test]
+    fn prompt_suggestion_enabled_when_set_true() {
+        let config = Config {
+            prompt_suggestion: Some(true),
+            ..Default::default()
+        };
+        assert!(config.prompt_suggestion_enabled());
+    }
+
+    #[test]
     fn warns_when_allow_shell_nested_under_general_section() {
         // #2589: the reporter's config nested top-level keys under sections that
         // do not exist, so they were silently dropped and shell tools vanished.

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -1185,6 +1185,10 @@ pub struct App {
     /// Ghost-text follow-up suggestion shown in the composer when empty.
     /// Generated asynchronously after each completed turn; cleared on new input.
     pub prompt_suggestion: Option<String>,
+    /// Monotonic turn counter for stale-suggestion protection. Incremented on
+    /// each TurnStarted; background suggestion tasks capture the token and
+    /// discard their result if the token no longer matches.
+    pub prompt_suggestion_gen: std::sync::atomic::AtomicU64,
     /// Degraded connectivity mode; new user inputs are queued for later retry.
     pub offline_mode: bool,
     /// Whether an `EngineEvent::Error` has already been posted for the
@@ -1525,7 +1529,7 @@ pub struct App {
     /// Shared cell updated by background fetch tasks; read lock in the UI thread.
     pub balance_cell: std::sync::Arc<std::sync::Mutex<Option<crate::pricing::BalanceInfo>>>,
     /// Shared cell for async prompt suggestion delivery from background task.
-    pub prompt_suggestion_cell: std::sync::Arc<std::sync::Mutex<Option<String>>>,
+    pub prompt_suggestion_cell: std::sync::Arc<std::sync::Mutex<Option<(u64, String)>>>,
     /// Tracks whether the initial balance fetch has been attempted for this session.
     pub balance_initiated: bool,
     /// Timestamp of the last balance fetch, used to debounce rapid requests.
@@ -1997,6 +2001,7 @@ impl App {
             api_messages: Vec::new(),
             is_loading: false,
             prompt_suggestion: None,
+            prompt_suggestion_gen: std::sync::atomic::AtomicU64::new(0),
             offline_mode: false,
             turn_error_posted: false,
             status_message: None,

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -1182,6 +1182,9 @@ pub struct App {
     pub next_history_revision: u64,
     pub api_messages: Vec<Message>,
     pub is_loading: bool,
+    /// Ghost-text follow-up suggestion shown in the composer when empty.
+    /// Generated asynchronously after each completed turn; cleared on new input.
+    pub prompt_suggestion: Option<String>,
     /// Degraded connectivity mode; new user inputs are queued for later retry.
     pub offline_mode: bool,
     /// Whether an `EngineEvent::Error` has already been posted for the
@@ -1521,6 +1524,8 @@ pub struct App {
     /// DeepSeek account balance, refreshed once per turn completion.
     /// Shared cell updated by background fetch tasks; read lock in the UI thread.
     pub balance_cell: std::sync::Arc<std::sync::Mutex<Option<crate::pricing::BalanceInfo>>>,
+    /// Shared cell for async prompt suggestion delivery from background task.
+    pub prompt_suggestion_cell: std::sync::Arc<std::sync::Mutex<Option<String>>>,
     /// Tracks whether the initial balance fetch has been attempted for this session.
     pub balance_initiated: bool,
     /// Timestamp of the last balance fetch, used to debounce rapid requests.
@@ -1991,6 +1996,7 @@ impl App {
             next_history_revision: 1,
             api_messages: Vec::new(),
             is_loading: false,
+            prompt_suggestion: None,
             offline_mode: false,
             turn_error_posted: false,
             status_message: None,
@@ -2145,6 +2151,7 @@ impl App {
             turn_last_activity_at: None,
             cumulative_turn_duration: std::time::Duration::ZERO,
             balance_cell: std::sync::Arc::new(std::sync::Mutex::new(None)),
+            prompt_suggestion_cell: std::sync::Arc::new(std::sync::Mutex::new(None)),
             balance_initiated: false,
             last_balance_fetch: None,
             runtime_turn_id: None,

--- a/crates/tui/src/tui/mod.rs
+++ b/crates/tui/src/tui/mod.rs
@@ -51,6 +51,7 @@ pub mod paste;
 pub mod paste_burst;
 pub mod persistence_actor;
 pub mod plan_prompt;
+pub mod prompt_suggestion;
 pub mod provider_picker;
 pub mod scrolling;
 pub mod selection;

--- a/crates/tui/src/tui/prompt_suggestion.rs
+++ b/crates/tui/src/tui/prompt_suggestion.rs
@@ -4,9 +4,17 @@
 //! follow-up question the user might want to ask next. The suggestion is
 //! rendered as dimmed ghost text in the composer when the input is empty.
 
+use std::sync::OnceLock;
+
 use reqwest::header::{AUTHORIZATION, CONTENT_TYPE};
 use serde_json::Value;
 use tracing::debug;
+
+/// Reusable static client — avoids creating a new connection pool per request.
+fn suggestion_client() -> &'static reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT.get_or_init(reqwest::Client::new)
+}
 
 /// Generate a follow-up prompt suggestion based on recent messages.
 ///
@@ -19,7 +27,7 @@ pub async fn generate_suggestion(
     model: &str,
     recent_messages: &str,
 ) -> Option<String> {
-    let client = reqwest::Client::new();
+    let client = suggestion_client();
     let body = serde_json::json!({
         "model": model,
         "messages": [

--- a/crates/tui/src/tui/prompt_suggestion.rs
+++ b/crates/tui/src/tui/prompt_suggestion.rs
@@ -1,0 +1,117 @@
+//! Ghost-text follow-up prompt suggestion.
+//!
+//! After each completed turn, a lightweight API call generates ONE short
+//! follow-up question the user might want to ask next. The suggestion is
+//! rendered as dimmed ghost text in the composer when the input is empty.
+
+use reqwest::header::{AUTHORIZATION, CONTENT_TYPE};
+use serde_json::Value;
+use tracing::debug;
+
+/// Generate a follow-up prompt suggestion based on recent messages.
+///
+/// Sends the conversation summary to the API with a system prompt that
+/// asks for a single short follow-up question. Returns `None` on failure
+/// or empty result — callers treat this as best-effort.
+pub async fn generate_suggestion(
+    api_key: &str,
+    base_url: &str,
+    model: &str,
+    recent_messages: &str,
+) -> Option<String> {
+    let client = reqwest::Client::new();
+    let body = serde_json::json!({
+        "model": model,
+        "messages": [
+            {
+                "role": "system",
+                "content": "\
+    You are a helpful assistant. Based on the recent conversation context, generate \
+    ONE short follow-up question (under 60 characters) the user might want to ask \
+    next. Reply with ONLY the question text, nothing else — no quotes, no explanations, \
+    no prefixes."
+            },
+            {
+                "role": "user",
+                "content": format!(
+                    "Recent conversation:\n{recent_messages}\n\n\
+                     Generate ONE short follow-up question the user might ask next:"
+                )
+            }
+        ],
+        "max_tokens": 64,
+        "temperature": 0.3,
+        "stream": false
+    });
+
+    let url = format!("{}/chat/completions", base_url.trim_end_matches('/'));
+    debug!(%url, %model, "generating prompt suggestion");
+    let response = match client
+        .post(&url)
+        .header(AUTHORIZATION, format!("Bearer {api_key}"))
+        .header(CONTENT_TYPE, "application/json")
+        .timeout(std::time::Duration::from_secs(10))
+        .json(&body)
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(_) => return None,
+    };
+
+    let value: Value = match response.json().await {
+        Ok(v) => v,
+        Err(_) => return None,
+    };
+
+    let suggestion = value["choices"][0]["message"]["content"]
+        .as_str()
+        .map(|s| s.trim().trim_matches('"').to_string())
+        .filter(|s| !s.is_empty() && s.len() <= 200)?;
+
+    debug!(text = %suggestion, "prompt suggestion generated");
+    Some(suggestion)
+}
+
+/// Extract the first text line from a single message.
+fn message_summary(m: &crate::models::Message) -> Option<String> {
+    let role = match m.role.as_str() {
+        "user" => "User",
+        "assistant" => "Assistant",
+        _ => return None,
+    };
+    let text = m
+        .content
+        .iter()
+        .filter_map(|block| match block {
+            crate::models::ContentBlock::Text { text, .. } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+    let first_line = text.lines().next().unwrap_or("").trim();
+    if first_line.is_empty() {
+        return None;
+    }
+    let truncated: String = first_line
+        .chars()
+        .take(120)
+        .chain(if first_line.chars().count() > 120 {
+            Some('…')
+        } else {
+            None
+        })
+        .collect();
+    Some(format!("{role}: {truncated}"))
+}
+
+/// Build a one-line-per-message summary of recent conversation context.
+/// Takes the last N messages, skipping tool-only messages.
+pub fn summarize_recent_messages(messages: &[crate::models::Message], limit: usize) -> String {
+    let start = messages.len().saturating_sub(limit);
+    messages[start..]
+        .iter()
+        .filter_map(message_summary)
+        .collect::<Vec<_>>()
+        .join("\n")
+}

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -1115,6 +1115,7 @@ async fn run_event_loop(
     // codex's frame coalescing that maps cleanly onto our poll-based loop.
     let mut frame_rate_limiter = crate::tui::frame_rate_limiter::FrameRateLimiter::default();
     let mut web_config_session: Option<WebConfigSession> = None;
+    let mut prev_input_snapshot = String::new();
     let mut terminal_paused_at: Option<Instant> = None;
     let mut force_terminal_repaint = false;
     let mut draws_since_last_full_repaint: u64 = 0;
@@ -1265,11 +1266,22 @@ async fn run_event_loop(
             app.needs_redraw = true;
         }
 
+        // Clear suggestion when the user modifies the input.
+        if app.input != prev_input_snapshot {
+            app.prompt_suggestion = None;
+            prev_input_snapshot = app.input.clone();
+        }
+
         // Poll prompt suggestion cell from background generation task.
-        if let Ok(mut guard) = app.prompt_suggestion_cell.lock() {
-            if let Some(suggestion) = guard.take() {
-                app.prompt_suggestion = Some(suggestion);
-            }
+        // Discard stale results whose generation token no longer matches.
+        if let Ok(mut guard) = app.prompt_suggestion_cell.try_lock()
+            && let Some((gen_token, suggestion)) = guard.take()
+            && gen_token
+                == app
+                    .prompt_suggestion_gen
+                    .load(std::sync::atomic::Ordering::Relaxed)
+        {
+            app.prompt_suggestion = Some(suggestion);
         }
 
         // First, poll for engine events (non-blocking)
@@ -1626,6 +1638,8 @@ async fn run_event_loop(
                         app.offline_mode = false;
                         app.turn_error_posted = false;
                         app.prompt_suggestion = None;
+                        app.prompt_suggestion_gen
+                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                         app.dispatch_started_at = None;
                         current_streaming_text.clear();
                         app.streaming_state.reset();
@@ -1834,9 +1848,10 @@ async fn run_event_loop(
                             let suggestion_cell = app.prompt_suggestion_cell.clone();
                             let api_key = config.deepseek_api_key().unwrap_or_default();
                             let base_url = config.deepseek_base_url();
-                            let model = config.default_model();
-                            let messages: Vec<crate::models::Message> =
-                                app.api_messages.clone();
+                            let messages: Vec<crate::models::Message> = app.api_messages.clone();
+                            let gen_token = app
+                                .prompt_suggestion_gen
+                                .load(std::sync::atomic::Ordering::Relaxed);
                             if !api_key.is_empty() {
                                 tokio::spawn(async move {
                                     let summary =
@@ -1847,13 +1862,13 @@ async fn run_event_loop(
                                         crate::tui::prompt_suggestion::generate_suggestion(
                                             &api_key,
                                             &base_url,
-                                            &model,
+                                            "deepseek-v4-flash",
                                             &summary,
                                         )
                                         .await
                                         && let Ok(mut guard) = suggestion_cell.lock()
                                     {
-                                        *guard = Some(suggestion);
+                                        *guard = Some((gen_token, suggestion));
                                     }
                                 });
                             }

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -1843,11 +1843,13 @@ async fn run_event_loop(
 
                         // Generate ghost-text follow-up suggestion asynchronously.
                         if status == crate::core::events::TurnOutcomeStatus::Completed
+                            && config.prompt_suggestion_enabled()
                             && app.api_messages.len() >= 2
                         {
                             let suggestion_cell = app.prompt_suggestion_cell.clone();
                             let api_key = config.deepseek_api_key().unwrap_or_default();
                             let base_url = config.deepseek_base_url();
+                            let model = config.default_model();
                             let messages: Vec<crate::models::Message> = app.api_messages.clone();
                             let gen_token = app
                                 .prompt_suggestion_gen
@@ -1860,10 +1862,7 @@ async fn run_event_loop(
                                         );
                                     if let Some(suggestion) =
                                         crate::tui::prompt_suggestion::generate_suggestion(
-                                            &api_key,
-                                            &base_url,
-                                            "deepseek-v4-flash",
-                                            &summary,
+                                            &api_key, &base_url, &model, &summary,
                                         )
                                         .await
                                         && let Ok(mut guard) = suggestion_cell.lock()

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -1265,6 +1265,13 @@ async fn run_event_loop(
             app.needs_redraw = true;
         }
 
+        // Poll prompt suggestion cell from background generation task.
+        if let Ok(mut guard) = app.prompt_suggestion_cell.lock() {
+            if let Some(suggestion) = guard.take() {
+                app.prompt_suggestion = Some(suggestion);
+            }
+        }
+
         // First, poll for engine events (non-blocking)
         let mut received_engine_event = false;
         let mut transcript_batch_updated = false;
@@ -1618,6 +1625,7 @@ async fn run_event_loop(
                         app.is_loading = true;
                         app.offline_mode = false;
                         app.turn_error_posted = false;
+                        app.prompt_suggestion = None;
                         app.dispatch_started_at = None;
                         current_streaming_text.clear();
                         app.streaming_state.reset();
@@ -1816,6 +1824,38 @@ async fn run_event_loop(
                                 crate::tui::notifications::stop_title_animation();
                             } else {
                                 crate::tui::notifications::stop_title_animation_quietly();
+                            }
+                        }
+
+                        // Generate ghost-text follow-up suggestion asynchronously.
+                        if status == crate::core::events::TurnOutcomeStatus::Completed
+                            && app.api_messages.len() >= 2
+                        {
+                            let suggestion_cell = app.prompt_suggestion_cell.clone();
+                            let api_key = config.deepseek_api_key().unwrap_or_default();
+                            let base_url = config.deepseek_base_url();
+                            let model = config.default_model();
+                            let messages: Vec<crate::models::Message> =
+                                app.api_messages.clone();
+                            if !api_key.is_empty() {
+                                tokio::spawn(async move {
+                                    let summary =
+                                        crate::tui::prompt_suggestion::summarize_recent_messages(
+                                            &messages, 8,
+                                        );
+                                    if let Some(suggestion) =
+                                        crate::tui::prompt_suggestion::generate_suggestion(
+                                            &api_key,
+                                            &base_url,
+                                            &model,
+                                            &summary,
+                                        )
+                                        .await
+                                        && let Ok(mut guard) = suggestion_cell.lock()
+                                    {
+                                        *guard = Some(suggestion);
+                                    }
+                                });
                             }
                         }
 
@@ -3589,6 +3629,14 @@ async fn run_event_loop(
                         continue;
                     }
                     if app.is_loading && queue_current_draft_for_next_turn(app) {
+                        continue;
+                    }
+                    if app.input.is_empty()
+                        && let Some(suggestion) = app.prompt_suggestion.take()
+                    {
+                        app.input = suggestion;
+                        app.cursor_position = app.input.chars().count();
+                        app.needs_redraw = true;
                         continue;
                     }
                     let prior_model = app.model.clone();

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -659,7 +659,9 @@ impl Renderable for ComposerWidget<'_> {
 
         let mut input_lines = Vec::new();
         if input_text.is_empty() {
-            if let Some(ref suggestion) = self.app.prompt_suggestion {
+            if let Some(ref suggestion) = self.app.prompt_suggestion
+                && !self.app.is_history_search_active()
+            {
                 input_lines.push(Line::from(Span::styled(
                     suggestion.as_str(),
                     Style::default().fg(palette::TEXT_HINT),
@@ -711,16 +713,14 @@ impl Renderable for ComposerWidget<'_> {
         // wrap the single Line at render time, so we must estimate the wrapped
         // row count ourselves to keep padding accurate on narrow widths.
         let visual_rows = if input_text.is_empty() {
-            let placeholder = if let Some(ref suggestion) = self.app.prompt_suggestion {
+            let placeholder: &str = if let Some(ref suggestion) = self.app.prompt_suggestion {
                 suggestion.as_str()
             } else if self.app.is_history_search_active() {
                 self.app
                     .tr(crate::localization::MessageId::HistorySearchPlaceholder)
-                    .as_ref()
             } else {
                 self.app
                     .tr(crate::localization::MessageId::ComposerPlaceholder)
-                    .as_ref()
             };
             placeholder_visual_lines_for(placeholder, content_width)
         } else {
@@ -1020,16 +1020,14 @@ impl Renderable for ComposerWidget<'_> {
         let (visible_lines, cursor_row, cursor_col) =
             layout_input(input_text, input_cursor, content_width, input_rows_budget);
         let visual_rows = if input_text.is_empty() {
-            let placeholder = if let Some(ref suggestion) = self.app.prompt_suggestion {
+            let placeholder: &str = if let Some(ref suggestion) = self.app.prompt_suggestion {
                 suggestion.as_str()
             } else if self.app.is_history_search_active() {
                 self.app
                     .tr(crate::localization::MessageId::HistorySearchPlaceholder)
-                    .as_ref()
             } else {
                 self.app
                     .tr(crate::localization::MessageId::ComposerPlaceholder)
-                    .as_ref()
             };
             placeholder_visual_lines_for(placeholder, content_width)
         } else {

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -659,17 +659,24 @@ impl Renderable for ComposerWidget<'_> {
 
         let mut input_lines = Vec::new();
         if input_text.is_empty() {
-            let placeholder = if self.app.is_history_search_active() {
-                self.app
-                    .tr(crate::localization::MessageId::HistorySearchPlaceholder)
+            if let Some(ref suggestion) = self.app.prompt_suggestion {
+                input_lines.push(Line::from(Span::styled(
+                    suggestion.as_str(),
+                    Style::default().fg(palette::TEXT_HINT),
+                )));
             } else {
-                self.app
-                    .tr(crate::localization::MessageId::ComposerPlaceholder)
-            };
-            input_lines.push(Line::from(Span::styled(
-                placeholder,
-                Style::default().fg(palette::TEXT_MUTED).italic(),
-            )));
+                let placeholder = if self.app.is_history_search_active() {
+                    self.app
+                        .tr(crate::localization::MessageId::HistorySearchPlaceholder)
+                } else {
+                    self.app
+                        .tr(crate::localization::MessageId::ComposerPlaceholder)
+                };
+                input_lines.push(Line::from(Span::styled(
+                    placeholder,
+                    Style::default().fg(palette::TEXT_MUTED).italic(),
+                )));
+            }
         } else if let Some((sel_start, sel_end)) = self.app.selection_range() {
             let line_ranges: Vec<(usize, usize)> =
                 wrap_input_lines_for_mouse(&self.app.input, content_width)
@@ -704,12 +711,16 @@ impl Renderable for ComposerWidget<'_> {
         // wrap the single Line at render time, so we must estimate the wrapped
         // row count ourselves to keep padding accurate on narrow widths.
         let visual_rows = if input_text.is_empty() {
-            let placeholder = if self.app.is_history_search_active() {
+            let placeholder = if let Some(ref suggestion) = self.app.prompt_suggestion {
+                suggestion.as_str()
+            } else if self.app.is_history_search_active() {
                 self.app
                     .tr(crate::localization::MessageId::HistorySearchPlaceholder)
+                    .as_ref()
             } else {
                 self.app
                     .tr(crate::localization::MessageId::ComposerPlaceholder)
+                    .as_ref()
             };
             placeholder_visual_lines_for(placeholder, content_width)
         } else {
@@ -1009,12 +1020,16 @@ impl Renderable for ComposerWidget<'_> {
         let (visible_lines, cursor_row, cursor_col) =
             layout_input(input_text, input_cursor, content_width, input_rows_budget);
         let visual_rows = if input_text.is_empty() {
-            let placeholder = if self.app.is_history_search_active() {
+            let placeholder = if let Some(ref suggestion) = self.app.prompt_suggestion {
+                suggestion.as_str()
+            } else if self.app.is_history_search_active() {
                 self.app
                     .tr(crate::localization::MessageId::HistorySearchPlaceholder)
+                    .as_ref()
             } else {
                 self.app
                     .tr(crate::localization::MessageId::ComposerPlaceholder)
+                    .as_ref()
             };
             placeholder_visual_lines_for(placeholder, content_width)
         } else {

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -4052,4 +4052,88 @@ mod tests {
             );
         }
     }
+
+    // ── Ghost-text prompt suggestion rendering ────────────────────────
+
+    #[test]
+    fn ghost_text_renders_when_suggestion_set_and_input_empty() {
+        let mut app = create_test_app();
+        app.prompt_suggestion = Some("What about error handling?".to_string());
+        let slash_menu_entries = Vec::<SlashMenuEntry>::new();
+        let mention_menu_entries = Vec::<String>::new();
+        let widget = ComposerWidget::new(&app, 5, &slash_menu_entries, &mention_menu_entries);
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 5,
+        };
+        let mut buf = Buffer::empty(area);
+        widget.render(area, &mut buf);
+
+        let rendered: String = buf
+            .content
+            .iter()
+            .map(|c| c.symbol())
+            .collect::<Vec<_>>()
+            .join("");
+        assert!(
+            rendered.contains("What about error handling?"),
+            "ghost text should render the suggestion. Got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn ghost_text_hidden_when_input_not_empty() {
+        let mut app = create_test_app();
+        app.prompt_suggestion = Some("A suggestion".to_string());
+        app.input = "hello".to_string();
+        app.cursor_position = 5;
+        let slash_menu_entries = Vec::<SlashMenuEntry>::new();
+        let mention_menu_entries = Vec::<String>::new();
+        let widget = ComposerWidget::new(&app, 5, &slash_menu_entries, &mention_menu_entries);
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 5,
+        };
+        let mut buf = Buffer::empty(area);
+        widget.render(area, &mut buf);
+
+        let has_suggestion = buf
+            .content
+            .iter()
+            .any(|c| c.symbol().contains("A suggestion"));
+        assert!(
+            !has_suggestion,
+            "suggestion should not render when input is non-empty"
+        );
+    }
+
+    #[test]
+    fn ghost_text_hidden_when_no_suggestion() {
+        let mut app = create_test_app();
+        app.prompt_suggestion = None;
+        let slash_menu_entries = Vec::<SlashMenuEntry>::new();
+        let mention_menu_entries = Vec::<String>::new();
+        let widget = ComposerWidget::new(&app, 5, &slash_menu_entries, &mention_menu_entries);
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 5,
+        };
+        let mut buf = Buffer::empty(area);
+        widget.render(area, &mut buf);
+
+        // When no suggestion and input is empty, placeholder text should appear
+        // instead. The exact placeholder text is locale-dependent, so we check
+        // that the suggestion text is NOT present.
+        let has_placeholder_like_text = buf.content.iter().any(|c| !c.symbol().trim().is_empty());
+        assert!(
+            has_placeholder_like_text,
+            "some non-empty text should render as placeholder"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

After each completed turn, a lightweight API call (v4-flash, max_tokens=64) generates a short follow-up question rendered as dimmed ghost text in the composer. Tab accepts the suggestion, typing dismisses it.

Mirrors Claude Code's prompt suggestion behavior.

## How it works

1. On `TurnComplete`, summarizes last 8 messages and sends a one-shot API call to generate a follow-up question
2. Result delivered via `Arc<Mutex<Option<String>>>` cross-thread cell (same pattern as `balance_cell`)
3. Composer renders ghost text with `TEXT_HINT` color when input is empty and suggestion exists
4. Tab inserts the suggestion; any keystroke dismisses it
5. Cleared on `TurnStarted`

## Cost

Each suggestion costs ~64 tokens (one-shot, non-streaming). `/init` won't trigger this since API key config is separate.

## Test plan

- [x] `cargo build -p codewhale-tui` — compiles
- [x] `cargo clippy -p codewhale-tui --all-targets --all-features` — clean
- [x] 3984/3985 tests pass (1 pre-existing failure: `empty_composer_cursor_accounts_for_placeholder_wrapping`)
- [ ] Manual: 2+ turns conversation, verify ghost text renders and Tab accepts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an opt-in ghost-text follow-up prompt suggestion feature to the TUI composer. After each completed turn, a background task calls the configured API with a lightweight prompt and delivers the result via an `Arc<Mutex>` cell guarded by a monotonic generation token; the suggestion renders as dimmed text when the composer is empty and Tab accepts it.

- **`prompt_suggestion.rs`**: new module with a static shared `reqwest::Client` (via `OnceLock`), OpenAI-compatible one-shot API call, and a message-summarization helper.
- **`ui.rs`**: spawns the background task on `TurnComplete`, increments `prompt_suggestion_gen` on `TurnStarted` to discard stale results, and polls the shared cell each event-loop tick.
- **`widgets/mod.rs`**: renders ghost text in the composer's empty-input branch, but both `visual_rows` calculations omit the `!is_history_search_active()` guard that the render path uses, causing wrong vertical padding when history search is active while a suggestion exists.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with a small fix: the two `visual_rows` branches in the composer widget don't mirror the render guard for history-search mode, producing incorrect vertical padding in that specific state.

The core async machinery (gen-token staleness protection, static shared HTTP client, opt-in config flag) is well-designed and correct. The one concrete defect is in `widgets/mod.rs`: both `visual_rows` calculations pick the suggestion text as the placeholder size even when history search is active, while the render path correctly suppresses the suggestion in that state. The padding mismatch is visible and reproducible whenever a suggestion is live and the user opens history search.

crates/tui/src/tui/widgets/mod.rs — both `visual_rows` calculations need the `!is_history_search_active()` guard added to match the render path.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/widgets/mod.rs | Ghost-text rendering added to the composer widget. Both `visual_rows` calculations fail to mirror the render guard (`!is_history_search_active()`), causing wrong vertical padding when history search is active with a live suggestion. |
| crates/tui/src/tui/ui.rs | Event-loop wiring for background suggestion tasks, gen-token stale-suggestion protection, Tab-to-accept handler, and TurnStarted/cell-poll ordering. Gen-token mechanism correctly prevents stale suggestions from appearing after a new turn starts. |
| crates/tui/src/tui/prompt_suggestion.rs | New module implementing the ghost-text suggestion backend: static shared `reqwest::Client`, OpenAI-compatible API call, and message summarization. Well-structured with proper error handling and OnceLock client reuse. |
| crates/tui/src/tui/app.rs | Adds `prompt_suggestion`, `prompt_suggestion_gen` (AtomicU64), and `prompt_suggestion_cell` fields to `App`. Straightforward struct additions with correct initialization. |
| crates/tui/src/config.rs | Adds opt-in `prompt_suggestion: Option<bool>` config field with correct default-off semantics, accessor, merge logic, and unit tests. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Engine
    participant EventLoop
    participant BgTask as Background Task
    participant Cell as prompt_suggestion_cell
    participant Composer

    Engine->>EventLoop: TurnComplete (Completed)
    EventLoop->>EventLoop: "capture gen_token = prompt_suggestion_gen"
    EventLoop->>BgTask: tokio::spawn(generate_suggestion)
    BgTask->>BgTask: summarize_recent_messages
    BgTask->>BgTask: HTTP POST /chat/completions
    BgTask->>Cell: lock → write (gen_token, suggestion)

    loop Every event-loop tick
        EventLoop->>Cell: try_lock → take (gen_token, suggestion)
        EventLoop->>EventLoop: "if gen_token == current → set prompt_suggestion"
    end

    Engine->>EventLoop: TurnStarted
    EventLoop->>EventLoop: "prompt_suggestion = None"
    EventLoop->>EventLoop: "prompt_suggestion_gen += 1 (invalidates in-flight task)"

    EventLoop->>Composer: render with app.prompt_suggestion
    Composer->>Composer: "if empty input && suggestion → show ghost text"
    Composer-->>EventLoop: Tab pressed → insert suggestion into input
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/tui/src/tui/ui.rs`, line 4181-4183 ([link](https://github.com/hmbown/codewhale/blob/02c3579be1192c40a6bc2619cf8b56b47c14c8e4/crates/tui/src/tui/ui.rs#L4181-L4183)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Typing doesn't dismiss the suggestion — old ghost text re-appears on backspace**

   The PR description says "any keystroke dismisses it," but `app.prompt_suggestion` is never cleared in the character-insertion handler. When the input is non-empty the ghost text is just visually hidden; if the user types a character and then deletes it, the suggestion reappears with the same stale text. Clearing `prompt_suggestion` on the first character typed matches the stated behaviour and avoids the surprising re-appearance.

   

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fprompt-suggestion%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fprompt-suggestion%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fui.rs%0ALine%3A%204181-4183%0A%0AComment%3A%0A**Typing%20doesn't%20dismiss%20the%20suggestion%20%E2%80%94%20old%20ghost%20text%20re-appears%20on%20backspace**%0A%0AThe%20PR%20description%20says%20%22any%20keystroke%20dismisses%20it%2C%22%20but%20%60app.prompt_suggestion%60%20is%20never%20cleared%20in%20the%20character-insertion%20handler.%20When%20the%20input%20is%20non-empty%20the%20ghost%20text%20is%20just%20visually%20hidden%3B%20if%20the%20user%20types%20a%20character%20and%20then%20deletes%20it%2C%20the%20suggestion%20reappears%20with%20the%20same%20stale%20text.%20Clearing%20%60prompt_suggestion%60%20on%20the%20first%20character%20typed%20matches%20the%20stated%20behaviour%20and%20avoids%20the%20surprising%20re-appearance.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20KeyCode%3A%3AChar%28c%29%20if%20is_plain_char%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20app.prompt_suggestion%20%3D%20None%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20app.insert_char%28c%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fui.rs%0ALine%3A%204181-4183%0A%0AComment%3A%0A**Typing%20doesn't%20dismiss%20the%20suggestion%20%E2%80%94%20old%20ghost%20text%20re-appears%20on%20backspace**%0A%0AThe%20PR%20description%20says%20%22any%20keystroke%20dismisses%20it%2C%22%20but%20%60app.prompt_suggestion%60%20is%20never%20cleared%20in%20the%20character-insertion%20handler.%20When%20the%20input%20is%20non-empty%20the%20ghost%20text%20is%20just%20visually%20hidden%3B%20if%20the%20user%20types%20a%20character%20and%20then%20deletes%20it%2C%20the%20suggestion%20reappears%20with%20the%20same%20stale%20text.%20Clearing%20%60prompt_suggestion%60%20on%20the%20first%20character%20typed%20matches%20the%20stated%20behaviour%20and%20avoids%20the%20surprising%20re-appearance.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20KeyCode%3A%3AChar%28c%29%20if%20is_plain_char%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20app.prompt_suggestion%20%3D%20None%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20app.insert_char%28c%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2781&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fui.rs%0ALine%3A%204181-4183%0A%0AComment%3A%0A**Typing%20doesn't%20dismiss%20the%20suggestion%20%E2%80%94%20old%20ghost%20text%20re-appears%20on%20backspace**%0A%0AThe%20PR%20description%20says%20%22any%20keystroke%20dismisses%20it%2C%22%20but%20%60app.prompt_suggestion%60%20is%20never%20cleared%20in%20the%20character-insertion%20handler.%20When%20the%20input%20is%20non-empty%20the%20ghost%20text%20is%20just%20visually%20hidden%3B%20if%20the%20user%20types%20a%20character%20and%20then%20deletes%20it%2C%20the%20suggestion%20reappears%20with%20the%20same%20stale%20text.%20Clearing%20%60prompt_suggestion%60%20on%20the%20first%20character%20typed%20matches%20the%20stated%20behaviour%20and%20avoids%20the%20surprising%20re-appearance.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20KeyCode%3A%3AChar%28c%29%20if%20is_plain_char%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20app.prompt_suggestion%20%3D%20None%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20app.insert_char%28c%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2781&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fprompt-suggestion%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fprompt-suggestion%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fwidgets%2Fmod.rs%3A715-724%0A**%60visual_rows%60%20calculation%20diverges%20from%20the%20render%20path%20during%20history%20search**%0A%0AThe%20render%20code%20%28line%20662%29%20shows%20the%20ghost%20text%20only%20when%20%60!is_history_search_active%28%29%60%2C%20but%20both%20%60visual_rows%60%20calculations%20%28here%20and%20at%20line%201022%29%20choose%20the%20suggestion%20string%20unconditionally%20whenever%20%60prompt_suggestion.is_some%28%29%60%20%E2%80%94%20they%20never%20check%20%60is_history_search_active%28%29%60.%20When%20the%20user%20enters%20history%20search%20while%20a%20suggestion%20is%20active%2C%20%60placeholder_visual_lines_for%60%20is%20called%20with%20the%20suggestion%20text%20even%20though%20the%20rendered%20content%20is%20the%20shorter%20history-search%20placeholder.%20The%20resulting%20%60top_padding%60%20doesn't%20match%20the%20actual%20rendered%20height%2C%20so%20the%20composer%20text%20appears%20at%20the%20wrong%20vertical%20position.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20visual_rows%20%3D%20if%20input_text.is_empty%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20let%20placeholder%3A%20%26str%20%3D%20if%20let%20Some%28ref%20suggestion%29%20%3D%20self.app.prompt_suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%26%26%20!self.app.is_history_search_active%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20suggestion.as_str%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%20else%20if%20self.app.is_history_search_active%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20self.app%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.tr%28crate%3A%3Alocalization%3A%3AMessageId%3A%3AHistorySearchPlaceholder%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20self.app%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.tr%28crate%3A%3Alocalization%3A%3AMessageId%3A%3AComposerPlaceholder%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20placeholder_visual_lines_for%28placeholder%2C%20content_width%29%0A%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20input_lines.len%28%29%0A%20%20%20%20%20%20%20%20%7D%3B%0A%20%20%20%20%20%20%20%20let%20top_padding%20%3D%20composer_top_padding%28visual_rows%2C%20input_rows_budget%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fwidgets%2Fmod.rs%3A1022-1036%0ASame%20mismatch%20as%20the%20first%20%60visual_rows%60%20block%3A%20the%20cursor-position%20path%20should%20also%20skip%20the%20suggestion%20when%20history%20search%20is%20active%2C%20to%20stay%20consistent%20with%20what%20is%20actually%20rendered.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20visual_rows%20%3D%20if%20input_text.is_empty%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20let%20placeholder%3A%20%26str%20%3D%20if%20let%20Some%28ref%20suggestion%29%20%3D%20self.app.prompt_suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%26%26%20!self.app.is_history_search_active%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20suggestion.as_str%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%20else%20if%20self.app.is_history_search_active%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20self.app%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.tr%28crate%3A%3Alocalization%3A%3AMessageId%3A%3AHistorySearchPlaceholder%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20self.app%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.tr%28crate%3A%3Alocalization%3A%3AMessageId%3A%3AComposerPlaceholder%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20placeholder_visual_lines_for%28placeholder%2C%20content_width%29%0A%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20visible_lines.len%28%29%0A%20%20%20%20%20%20%20%20%7D%3B%0A%20%20%20%20%20%20%20%20let%20top_padding%20%3D%20composer_top_padding%28visual_rows%2C%20input_rows_budget%29%3B%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2781&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fwidgets%2Fmod.rs%3A715-724%0A**%60visual_rows%60%20calculation%20diverges%20from%20the%20render%20path%20during%20history%20search**%0A%0AThe%20render%20code%20%28line%20662%29%20shows%20the%20ghost%20text%20only%20when%20%60!is_history_search_active%28%29%60%2C%20but%20both%20%60visual_rows%60%20calculations%20%28here%20and%20at%20line%201022%29%20choose%20the%20suggestion%20string%20unconditionally%20whenever%20%60prompt_suggestion.is_some%28%29%60%20%E2%80%94%20they%20never%20check%20%60is_history_search_active%28%29%60.%20When%20the%20user%20enters%20history%20search%20while%20a%20suggestion%20is%20active%2C%20%60placeholder_visual_lines_for%60%20is%20called%20with%20the%20suggestion%20text%20even%20though%20the%20rendered%20content%20is%20the%20shorter%20history-search%20placeholder.%20The%20resulting%20%60top_padding%60%20doesn't%20match%20the%20actual%20rendered%20height%2C%20so%20the%20composer%20text%20appears%20at%20the%20wrong%20vertical%20position.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20visual_rows%20%3D%20if%20input_text.is_empty%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20let%20placeholder%3A%20%26str%20%3D%20if%20let%20Some%28ref%20suggestion%29%20%3D%20self.app.prompt_suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%26%26%20!self.app.is_history_search_active%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20suggestion.as_str%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%20else%20if%20self.app.is_history_search_active%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20self.app%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.tr%28crate%3A%3Alocalization%3A%3AMessageId%3A%3AHistorySearchPlaceholder%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20self.app%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.tr%28crate%3A%3Alocalization%3A%3AMessageId%3A%3AComposerPlaceholder%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20placeholder_visual_lines_for%28placeholder%2C%20content_width%29%0A%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20input_lines.len%28%29%0A%20%20%20%20%20%20%20%20%7D%3B%0A%20%20%20%20%20%20%20%20let%20top_padding%20%3D%20composer_top_padding%28visual_rows%2C%20input_rows_budget%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fwidgets%2Fmod.rs%3A1022-1036%0ASame%20mismatch%20as%20the%20first%20%60visual_rows%60%20block%3A%20the%20cursor-position%20path%20should%20also%20skip%20the%20suggestion%20when%20history%20search%20is%20active%2C%20to%20stay%20consistent%20with%20what%20is%20actually%20rendered.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20visual_rows%20%3D%20if%20input_text.is_empty%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20let%20placeholder%3A%20%26str%20%3D%20if%20let%20Some%28ref%20suggestion%29%20%3D%20self.app.prompt_suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%26%26%20!self.app.is_history_search_active%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20suggestion.as_str%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%20else%20if%20self.app.is_history_search_active%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20self.app%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.tr%28crate%3A%3Alocalization%3A%3AMessageId%3A%3AHistorySearchPlaceholder%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20self.app%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.tr%28crate%3A%3Alocalization%3A%3AMessageId%3A%3AComposerPlaceholder%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20placeholder_visual_lines_for%28placeholder%2C%20content_width%29%0A%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20visible_lines.len%28%29%0A%20%20%20%20%20%20%20%20%7D%3B%0A%20%20%20%20%20%20%20%20let%20top_padding%20%3D%20composer_top_padding%28visual_rows%2C%20input_rows_budget%29%3B%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2781&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fwidgets%2Fmod.rs%3A715-724%0A**%60visual_rows%60%20calculation%20diverges%20from%20the%20render%20path%20during%20history%20search**%0A%0AThe%20render%20code%20%28line%20662%29%20shows%20the%20ghost%20text%20only%20when%20%60!is_history_search_active%28%29%60%2C%20but%20both%20%60visual_rows%60%20calculations%20%28here%20and%20at%20line%201022%29%20choose%20the%20suggestion%20string%20unconditionally%20whenever%20%60prompt_suggestion.is_some%28%29%60%20%E2%80%94%20they%20never%20check%20%60is_history_search_active%28%29%60.%20When%20the%20user%20enters%20history%20search%20while%20a%20suggestion%20is%20active%2C%20%60placeholder_visual_lines_for%60%20is%20called%20with%20the%20suggestion%20text%20even%20though%20the%20rendered%20content%20is%20the%20shorter%20history-search%20placeholder.%20The%20resulting%20%60top_padding%60%20doesn't%20match%20the%20actual%20rendered%20height%2C%20so%20the%20composer%20text%20appears%20at%20the%20wrong%20vertical%20position.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20visual_rows%20%3D%20if%20input_text.is_empty%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20let%20placeholder%3A%20%26str%20%3D%20if%20let%20Some%28ref%20suggestion%29%20%3D%20self.app.prompt_suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%26%26%20!self.app.is_history_search_active%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20suggestion.as_str%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%20else%20if%20self.app.is_history_search_active%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20self.app%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.tr%28crate%3A%3Alocalization%3A%3AMessageId%3A%3AHistorySearchPlaceholder%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20self.app%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.tr%28crate%3A%3Alocalization%3A%3AMessageId%3A%3AComposerPlaceholder%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20placeholder_visual_lines_for%28placeholder%2C%20content_width%29%0A%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20input_lines.len%28%29%0A%20%20%20%20%20%20%20%20%7D%3B%0A%20%20%20%20%20%20%20%20let%20top_padding%20%3D%20composer_top_padding%28visual_rows%2C%20input_rows_budget%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Ftui%2Fwidgets%2Fmod.rs%3A1022-1036%0ASame%20mismatch%20as%20the%20first%20%60visual_rows%60%20block%3A%20the%20cursor-position%20path%20should%20also%20skip%20the%20suggestion%20when%20history%20search%20is%20active%2C%20to%20stay%20consistent%20with%20what%20is%20actually%20rendered.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20visual_rows%20%3D%20if%20input_text.is_empty%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20let%20placeholder%3A%20%26str%20%3D%20if%20let%20Some%28ref%20suggestion%29%20%3D%20self.app.prompt_suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%26%26%20!self.app.is_history_search_active%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20suggestion.as_str%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%20else%20if%20self.app.is_history_search_active%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20self.app%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.tr%28crate%3A%3Alocalization%3A%3AMessageId%3A%3AHistorySearchPlaceholder%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20self.app%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.tr%28crate%3A%3Alocalization%3A%3AMessageId%3A%3AComposerPlaceholder%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20placeholder_visual_lines_for%28placeholder%2C%20content_width%29%0A%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20visible_lines.len%28%29%0A%20%20%20%20%20%20%20%20%7D%3B%0A%20%20%20%20%20%20%20%20let%20top_padding%20%3D%20composer_top_padding%28visual_rows%2C%20input_rows_budget%29%3B%0A%60%60%60%0A%0A&pr=2781&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["test(tui): add prompt suggestion config ..."](https://github.com/hmbown/codewhale/commit/80246f0591afbd75a6274600771d2c7f7f94f91a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35785661)</sub>

<!-- /greptile_comment -->