### PR TITLE
feat(hf): add /hf command with MCP detection, Hub search, and docs (#2709)

### DIFF
--- a/crates/tui/src/commands/hf.rs
+++ b/crates/tui/src/commands/hf.rs
@@ -1,0 +1,110 @@
+//! `/hf` — Hugging Face Hub and MCP integration helpers (#2709).
+
+use crate::tui::app::App;
+
+use super::CommandResult;
+
+/// `/hf mcp status` — checks whether the Hugging Face MCP server is configured.
+/// `/hf mcp setup` — prints a safe config skeleton (no secrets).
+pub fn hf(app: &mut App, args: Option<&str>) -> CommandResult {
+    let raw = args.unwrap_or("").trim();
+    if raw.is_empty() {
+        return CommandResult::message(
+            "Usage: /hf mcp <status|setup>\n\
+             /hf docs   — open Hugging Face MCP documentation",
+        );
+    }
+
+    let mut parts = raw.split_whitespace();
+    let sub = parts.next().unwrap_or("").to_ascii_lowercase();
+
+    match sub.as_str() {
+        "mcp" => hf_mcp(app, parts.next()),
+        "docs" => CommandResult::message(
+            "Hugging Face MCP server docs: https://huggingface.co/docs/hub/hf-mcp-server\n\
+             Hugging Face Hub MCP client docs: https://huggingface.co/docs/huggingface_hub/main/package_reference/mcp",
+        ),
+        _ => CommandResult::error(format!(
+            "Unknown subcommand: '{sub}'. Use: /hf mcp <status|setup>"
+        )),
+    }
+}
+
+fn hf_mcp(app: &mut App, action: Option<&str>) -> CommandResult {
+    match action.unwrap_or("status") {
+        "status" => {
+            let configured = hf_mcp_configured(app);
+            if configured {
+                CommandResult::message(
+                    "✅ Hugging Face MCP server is configured.\n\
+                     Use /mcp status to see all configured MCP servers.",
+                )
+            } else {
+                CommandResult::message(
+                    "❌ Hugging Face MCP server is not configured.\n\
+                     Run /hf mcp setup to see a config skeleton, or visit\n\
+                     https://huggingface.co/docs/hub/hf-mcp-server for setup docs.",
+                )
+            }
+        }
+        "setup" => {
+            let skeleton = hf_mcp_config_skeleton();
+            CommandResult::message(format!(
+                "Add this to your MCP config (mcp.json or CodeWhale MCP config):\n\n{skeleton}\n\n\
+                 ⚠️  Replace ${{HF_TOKEN}} with your Hugging Face token.\n\
+                 Never commit your token to version control."
+            ))
+        }
+        other => CommandResult::error(format!(
+            "Unknown /hf mcp subcommand: '{other}'. Use: status | setup"
+        )),
+    }
+}
+
+/// Check whether a Hugging Face MCP server is present in the current MCP config.
+fn hf_mcp_configured(app: &App) -> bool {
+    crate::mcp::load_config(&app.mcp_config_path)
+        .map(|cfg| cfg.servers.contains_key("huggingface"))
+        .unwrap_or(false)
+}
+
+/// Return a safe config skeleton for the Hugging Face MCP server with secrets
+/// replaced by placeholder variables.
+fn hf_mcp_config_skeleton() -> String {
+    r#"```jsonc
+{
+  "servers": {
+    "huggingface": {
+      "url": "https://huggingface.co/api/mcp",
+      "headers": {
+        "Authorization": "Bearer ${HF_TOKEN}"
+      }
+    }
+  }
+}
+```"#
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hf_mcp_config_skeleton_does_not_contain_real_tokens() {
+        let skeleton = hf_mcp_config_skeleton();
+        // The skeleton must contain a placeholder, not a real token.
+        assert!(skeleton.contains("${HF_TOKEN}"));
+        assert!(!skeleton.contains("hf_"));
+        assert!(!skeleton.contains("Bearer hf_"));
+    }
+
+    #[test]
+    fn hf_mcp_config_skeleton_is_valid_jsonc_structure() {
+        let skeleton = hf_mcp_config_skeleton();
+        assert!(skeleton.contains("\"huggingface\""));
+        assert!(skeleton.contains("\"url\""));
+        assert!(skeleton.contains("\"headers\""));
+        assert!(skeleton.contains("\"Authorization\""));
+    }
+}

--- a/crates/tui/src/commands/hf.rs
+++ b/crates/tui/src/commands/hf.rs
@@ -4,8 +4,6 @@ use crate::tui::app::App;
 
 use super::CommandResult;
 
-use serde_json;
-
 /// Explainer shown by `/hf concepts` — distinguishes the three Hugging Face
 /// integration surfaces so users understand which one they're configuring.
 const HF_CONCEPTS: &str = "\
@@ -55,7 +53,7 @@ pub fn hf(app: &mut App, args: Option<&str>) -> CommandResult {
 
     match sub.as_str() {
         "mcp" => hf_mcp(app, parts.next()),
-        "search" | "find" => hf_search(&raw[sub.len()..].trim()),
+        "search" | "find" => hf_search(raw[sub.len()..].trim()),
         "concepts" | "explain" => CommandResult::message(HF_CONCEPTS),
         "docs" => CommandResult::message(
             "Hugging Face MCP server docs: https://huggingface.co/docs/hub/hf-mcp-server\n\

--- a/crates/tui/src/commands/hf.rs
+++ b/crates/tui/src/commands/hf.rs
@@ -4,6 +4,8 @@ use crate::tui::app::App;
 
 use super::CommandResult;
 
+use serde_json;
+
 /// Explainer shown by `/hf concepts` — distinguishes the three Hugging Face
 /// integration surfaces so users understand which one they're configuring.
 const HF_CONCEPTS: &str = "\
@@ -42,8 +44,9 @@ pub fn hf(app: &mut App, args: Option<&str>) -> CommandResult {
     if raw.is_empty() {
         return CommandResult::message(
             "Usage: /hf mcp <status|setup>\n\
-             /hf docs   — open Hugging Face MCP documentation\n\
-             /hf concepts — HF provider vs MCP vs Hub explained",
+             /hf search <query> — search Hugging Face Hub\n\
+             /hf docs           — HF MCP documentation\n\
+             /hf concepts       — HF provider vs MCP vs Hub",
         );
     }
 
@@ -52,6 +55,7 @@ pub fn hf(app: &mut App, args: Option<&str>) -> CommandResult {
 
     match sub.as_str() {
         "mcp" => hf_mcp(app, parts.next()),
+        "search" | "find" => hf_search(&raw[sub.len()..].trim()),
         "concepts" | "explain" => CommandResult::message(HF_CONCEPTS),
         "docs" => CommandResult::message(
             "Hugging Face MCP server docs: https://huggingface.co/docs/hub/hf-mcp-server\n\
@@ -92,6 +96,89 @@ fn hf_mcp(app: &mut App, action: Option<&str>) -> CommandResult {
             "Unknown /hf mcp subcommand: '{other}'. Use: status | setup"
         )),
     }
+}
+
+/// `/hf search <query>` — query the Hugging Face Hub API for models.
+/// Falls back gracefully when the network is unavailable.
+fn hf_search(query: &str) -> CommandResult {
+    if query.is_empty() {
+        return CommandResult::error("Usage: /hf search <query>");
+    }
+    match hf_hub_search(query) {
+        Ok(results) => CommandResult::message(results),
+        Err(e) => CommandResult::message(format!(
+            "HF Hub API unavailable: {e}\n\
+             Tip: use /hf mcp status to check whether HF MCP is configured,\n\
+             or /hf docs for manual search links."
+        )),
+    }
+}
+
+/// Call the Hugging Face Hub models API and format the top 5 results.
+fn hf_hub_search(query: &str) -> Result<String, String> {
+    let url = format!(
+        "https://huggingface.co/api/models?search={}&limit=5&full=false",
+        urlencoding(query)
+    );
+    let client = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(8))
+        .build()
+        .map_err(|e| format!("client error: {e}"))?;
+    let resp = client
+        .get(&url)
+        .header("User-Agent", "CodeWhale/0.9.0 HF MCP integration")
+        .send()
+        .map_err(|e| format!("request failed: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("HTTP {}", resp.status()));
+    }
+    let body: serde_json::Value = resp.json().map_err(|e| format!("parse error: {e}"))?;
+    let models = body.as_array().ok_or("unexpected response format")?;
+    if models.is_empty() {
+        return Ok("No models found on Hugging Face Hub.".into());
+    }
+    let mut lines = vec![format!(
+        "HF Hub search: \"{query}\" — top {} of {} results:\n",
+        models.len().min(5),
+        models.len()
+    )];
+    for (i, m) in models.iter().take(5).enumerate() {
+        let id = m["id"].as_str().unwrap_or("?");
+        let likes = m["likes"].as_u64().unwrap_or(0);
+        let downloads = m["downloads"].as_u64().unwrap_or(0);
+        let author = m["author"].as_str().unwrap_or("");
+        let pipeline = m["pipeline_tag"].as_str().unwrap_or("");
+        let url = format!("https://huggingface.co/{id}");
+        lines.push(format!("{}. {id}", i + 1));
+        if !author.is_empty() {
+            lines.push(format!("   by {author}"));
+        }
+        let mut tags = Vec::new();
+        if likes > 0 {
+            tags.push(format!("♥ {likes}"));
+        }
+        if downloads > 0 {
+            tags.push(format!("↓ {downloads}"));
+        }
+        if !pipeline.is_empty() {
+            tags.push(pipeline.to_string());
+        }
+        if !tags.is_empty() {
+            lines.push(format!("   {}", tags.join(" · ")));
+        }
+        lines.push(format!("   {url}"));
+    }
+    Ok(lines.join("\n"))
+}
+
+/// Simple URL encoding for search queries.
+fn urlencoding(s: &str) -> String {
+    s.replace(' ', "%20")
+        .replace(':', "%3A")
+        .replace('/', "%2F")
+        .replace('?', "%3F")
+        .replace('&', "%26")
+        .replace('=', "%3D")
 }
 
 /// Check whether a Hugging Face MCP server is present in the current MCP config.

--- a/crates/tui/src/commands/hf.rs
+++ b/crates/tui/src/commands/hf.rs
@@ -4,14 +4,46 @@ use crate::tui::app::App;
 
 use super::CommandResult;
 
-/// `/hf mcp status` — checks whether the Hugging Face MCP server is configured.
-/// `/hf mcp setup` — prints a safe config skeleton (no secrets).
+/// Explainer shown by `/hf concepts` — distinguishes the three Hugging Face
+/// integration surfaces so users understand which one they're configuring.
+const HF_CONCEPTS: &str = "\
+CodeWhale has three distinct Hugging Face integration surfaces:
+
+1. HF Provider Route — chat inference
+   Switch your LLM backend to Hugging Face Inference Providers.
+   Use: /provider huggingface
+   Config: [providers.huggingface] in config.toml
+   Needs: HF_TOKEN or HUGGINGFACE_API_KEY
+
+2. HF MCP — Hub search, resources, community tools
+   Connect to Hugging Face's MCP server for model-card/docs search,
+   dataset discovery, and community tooling.
+   Use: /hf mcp status | /hf mcp setup
+   Config: {\"huggingface\": {...}} in mcp.json
+   Needs: HF_TOKEN (passed as Authorization header)
+
+3. HF Hub — upload / export workflows
+   Publish models, datasets, or Spaces to the Hub.
+   This always requires explicit user action — CodeWhale never
+   uploads to the Hub without your approval.
+   Use: huggingface_hub Python package or git-based workflow";
+
+// ── /hf command ──────────────────────────────────────────────────
+
+/// `/hf` — Hugging Face Hub, MCP, and Inference integration helpers (#2709).
+///
+/// Commands:
+///   `/hf mcp status`   — check whether HF MCP server is configured
+///   `/hf mcp setup`    — print a safe config skeleton (`${HF_TOKEN}`)
+///   `/hf docs`         — links to HF MCP and Hub documentation
+///   `/hf concepts`     — explain HF provider vs MCP vs Hub
 pub fn hf(app: &mut App, args: Option<&str>) -> CommandResult {
     let raw = args.unwrap_or("").trim();
     if raw.is_empty() {
         return CommandResult::message(
             "Usage: /hf mcp <status|setup>\n\
-             /hf docs   — open Hugging Face MCP documentation",
+             /hf docs   — open Hugging Face MCP documentation\n\
+             /hf concepts — HF provider vs MCP vs Hub explained",
         );
     }
 
@@ -20,6 +52,7 @@ pub fn hf(app: &mut App, args: Option<&str>) -> CommandResult {
 
     match sub.as_str() {
         "mcp" => hf_mcp(app, parts.next()),
+        "concepts" | "explain" => CommandResult::message(HF_CONCEPTS),
         "docs" => CommandResult::message(
             "Hugging Face MCP server docs: https://huggingface.co/docs/hub/hf-mcp-server\n\
              Hugging Face Hub MCP client docs: https://huggingface.co/docs/huggingface_hub/main/package_reference/mcp",
@@ -106,5 +139,15 @@ mod tests {
         assert!(skeleton.contains("\"url\""));
         assert!(skeleton.contains("\"headers\""));
         assert!(skeleton.contains("\"Authorization\""));
+    }
+
+    #[test]
+    fn hf_concepts_explains_three_surfaces() {
+        assert!(HF_CONCEPTS.contains("HF Provider Route"));
+        assert!(HF_CONCEPTS.contains("HF MCP"));
+        assert!(HF_CONCEPTS.contains("HF Hub"));
+        assert!(HF_CONCEPTS.contains("/provider huggingface"));
+        assert!(HF_CONCEPTS.contains("/hf mcp"));
+        assert!(HF_CONCEPTS.contains("HF_TOKEN"));
     }
 }

--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -12,6 +12,7 @@ mod core;
 mod debug;
 mod feedback;
 mod goal;
+mod hf;
 mod hooks;
 mod init;
 mod jobs;
@@ -579,6 +580,7 @@ pub fn execute(cmd: &str, app: &mut App) -> CommandResult {
         "task" | "tasks" => task::task(app, arg),
         "jobs" | "job" | "zuoye" => jobs::jobs(app, arg),
         "mcp" => mcp::mcp(app, arg),
+        "hf" | "huggingface" => hf::hf(app, arg),
         "network" => network::network(app, arg),
 
         // Session commands

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -218,6 +218,34 @@ MCP tools now flow through the same tool-approval framework as built-in tools. R
 
 You should still only configure MCP servers you trust, and treat MCP server configuration as equivalent to running code on your machine.
 
+## Hugging Face MCP Server
+
+Hugging Face provides an MCP server for Hub search, model-card lookups,
+dataset discovery, and community tools. Configure it by adding a `"huggingface"`
+entry to your MCP config:
+
+```jsonc
+{
+  "servers": {
+    "huggingface": {
+      "url": "https://huggingface.co/api/mcp",
+      "headers": {
+        "Authorization": "Bearer ${HF_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+- Replace `${HF_TOKEN}` with a [Hugging Face access token](https://huggingface.co/settings/tokens) that has read access.
+- Never commit or share your real token.
+- The TUI `/hf` command can detect whether this server is configured:
+  - `/hf mcp status` — check configuration status
+  - `/hf mcp setup` — print this skeleton
+  - `/hf concepts` — explain HF provider vs MCP vs Hub
+
+For more details: https://huggingface.co/docs/hub/hf-mcp-server
+
 ## Troubleshooting
 
 - Run `codewhale-tui doctor` to confirm the MCP config path it resolved and whether it exists.

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -130,6 +130,44 @@ endpoint.
 | `ollama` | `[providers.ollama]` | Optional `OLLAMA_API_KEY` | `OLLAMA_BASE_URL`; default `http://localhost:11434/v1` | `deepseek-coder:1.3b`; provider-hinted custom tags pass through | Self-hosted Ollama OpenAI-compatible route. Localhost deployments commonly omit auth. `OLLAMA_MODEL` is accepted. |
 | `huggingface` | `[providers.huggingface]` | `HUGGINGFACE_API_KEY`, `HF_TOKEN` | `HUGGINGFACE_BASE_URL`; default `https://router.huggingface.co/v1` | `deepseek-ai/DeepSeek-V4-Pro`, `deepseek-ai/DeepSeek-V4-Flash` | Hugging Face Inference Providers OpenAI-compatible route. Org-prefixed model IDs pass through. |
 
+### Hugging Face MCP (Model Context Protocol)
+
+Hugging Face provides an MCP server for Hub search, model-card lookups,
+dataset discovery, and community tools — separate from the inference provider
+route above. CodeWhale can detect whether it is configured and print a safe
+config skeleton via the `/hf` command:
+
+- `/hf mcp status` — check whether the HF MCP server is configured
+- `/hf mcp setup` — print a config skeleton with placeholder tokens
+- `/hf concepts` — explain HF provider vs MCP vs Hub
+
+Add the following to your MCP config (`mcp.json` or the CodeWhale MCP config
+file) to enable HF MCP:
+
+```jsonc
+{
+  "servers": {
+    "huggingface": {
+      "url": "https://huggingface.co/api/mcp",
+      "headers": {
+        "Authorization": "Bearer ${HF_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+`${HF_TOKEN}` is a placeholder — replace it with your Hugging Face token.
+Never commit your real token.
+
+Once configured, the HF MCP server provides tools for:
+
+- Searching the Hub for models, datasets, and Spaces
+- Inspecting model cards and documentation
+- Accessing community tools and resources
+
+For more details, see https://huggingface.co/docs/hub/hf-mcp-server.
+
 ### Xiaomi MiMo Notes
 
 `xiaomi-mimo` defaults to `mimo-v2.5-pro` for long-context reasoning and coding

--- a/docs/RLM_BRANCHING_ROADMAP.md
+++ b/docs/RLM_BRANCHING_ROADMAP.md
@@ -10,10 +10,10 @@ CodeWhale uses the same branching primitive at three scales:
 1. Release tracks. Each milestone fans into named tracks. A track must stay
    independently reviewable, mergeable, and slippable. Unfinished work rolls
    forward instead of blocking the release.
-2. Capability worksets. Model Lab capabilities such as Hugging Face,
-   observability, evals, serving, DSPy, GEPA, and training infrastructure ship
-   as opt-in worksets with their own feature flag, install path, license note,
-   and telemetry posture.
+2. Capability worksets. Model Lab capabilities such as Hugging Face
+   (Inference, MCP, Hub), observability, evals, serving, DSPy, GEPA, and
+   training infrastructure ship as opt-in worksets with their own feature
+   flag, install path, license note, and telemetry posture.
 3. Pareto compile branches. Optimizable modules keep candidate
    `(instructions, demos, score)` triples. Branches that violate pinned
    constitution clauses are pruned; branches that win at least one eval remain


### PR DESCRIPTION
Full Hugging Face MCP and Hub integration for CodeWhale.

### Commands

/hf mcp status   — detect whether HF MCP server is configured
/hf mcp setup    — print safe config skeleton (${HF_TOKEN}, never real secrets)
/hf search <q>   — query Hugging Face Hub models API (top 5, ♥/↓/pipeline)
/hf concepts     — explain HF provider vs MCP vs Hub distinction
/hf docs         — links to HF MCP documentation

### Implementation

crates/tui/src/commands/hf.rs (new, ~220 lines):
  - hf() dispatcher: mcp | search | concepts | docs
  - hf_mcp_configured(): checks McpConfig.servers for "huggingface"
  - hf_mcp_config_skeleton(): JSONC snippet with ${HF_TOKEN} placeholder
  - hf_search(): calls huggingface.co/api/models via reqwest::blocking
  - hf_hub_search(): parses response, formats top 5 with likes/downloads/pipeline
  - HF_CONCEPTS constant: explainer text for the three HF surfaces
  - urlencoding() helper

crates/tui/src/commands/mod.rs:
  - Register /hf and /huggingface in command dispatch

### Documentation

docs/PROVIDERS.md:
  - New "Hugging Face MCP (Model Context Protocol)" section with
    JSONC config skeleton, /hf command reference, and tool listing

docs/MCP.md:
  - New "Hugging Face MCP Server" section with config example and
    /hf command reference

docs/RLM_BRANCHING_ROADMAP.md:
  - Model Lab workset entry updated to "(Inference, MCP, Hub)"

### Tests (3 new)

  - hf_mcp_config_skeleton_does_not_contain_real_tokens
  - hf_mcp_config_skeleton_is_valid_jsonc_structure
  - hf_concepts_explains_three_surfaces

### Non-goals

  - PlanReview citing HF MCP results (PlanReview module is #2689, not yet merged)

Refs: #2709, #2705

## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
