### PR TITLE
feat(prompts): add static prompt composer override for embedders

### DIFF
--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -351,6 +351,57 @@ pub fn set_authority_recap_override(s: String) -> Result<(), String> {
     set_prompt_override(&AUTHORITY_RECAP_OVERRIDE, s)
 }
 
+// ── Static-layer composer override ──
+// Per-constant overrides above let an embedder swap individual blocks, but
+// any block upstream adds later still leaks into the embedder's prompt.
+// The composer override is the sealing variant: when set, the embedder
+// takes over ALL compile-time static doctrine — tool taxonomy, base
+// prompt, personality, mode delta, approval policy, `## Context
+// Management`, and the compaction relay template — and upstream additions
+// to those layers only affect the default composition. Dynamic structural
+// blocks (project context, skills, environment, instructions, memory,
+// goal, handoff relay, locale bookends, authority recap) keep their
+// existing rendering and hooks.
+
+/// Inputs handed to a [`set_static_prompt_composer_override`] composer.
+///
+/// `#[non_exhaustive]` so upstream can add fields without breaking
+/// embedders; construct only via the composition pipeline.
+#[non_exhaustive]
+#[derive(Debug)]
+pub struct StaticPromptCtx<'a> {
+    /// Active app mode (Agent / Plan / Yolo).
+    pub mode: crate::tui::app::AppMode,
+    /// Effective approval mode for this session.
+    pub approval_mode: crate::tui::approval::ApprovalMode,
+    /// Active model identifier (replaces `{model_id}` in base prompts).
+    pub model_id: &'a str,
+    /// Whether shell tools are exposed to the model this session.
+    pub allow_shell: bool,
+    /// The static layers the default composition would have produced —
+    /// for reference or partial reuse by the composer.
+    pub default_layers: &'a str,
+}
+
+/// A composer that replaces the compile-time static prompt layers.
+pub type StaticPromptComposer = dyn Fn(&StaticPromptCtx<'_>) -> String + Send + Sync;
+
+static STATIC_PROMPT_COMPOSER: std::sync::OnceLock<Box<StaticPromptComposer>> =
+    std::sync::OnceLock::new();
+
+/// Install a composer that replaces ALL compile-time static prompt layers
+/// (taxonomy, base, personality, mode, approval, context management,
+/// compaction relay template). First call wins; later calls return
+/// `Err(())`. Set before spawning any engine. When set, the per-constant
+/// overrides for those layers are bypassed entirely.
+pub fn set_static_prompt_composer_override(f: Box<StaticPromptComposer>) -> Result<(), ()> {
+    STATIC_PROMPT_COMPOSER.set(f).map_err(|_| ())
+}
+
+fn static_prompt_composer() -> Option<&'static StaticPromptComposer> {
+    STATIC_PROMPT_COMPOSER.get().map(Box::as_ref)
+}
+
 fn set_prompt_override(cell: &std::sync::OnceLock<String>, s: String) -> Result<(), String> {
     cell.set(s)
 }
@@ -791,6 +842,48 @@ fn compose_prompt_with_approval_model_and_shell(
     model_id: &str,
     allow_shell: bool,
 ) -> String {
+    let default_layers =
+        compose_default_static_layers(mode, personality, approval_mode, model_id, allow_shell);
+    apply_static_prompt_composer(
+        static_prompt_composer(),
+        mode,
+        approval_mode,
+        model_id,
+        allow_shell,
+        default_layers,
+    )
+}
+
+/// Apply a static-layer composer over the default composition. Split out
+/// from the global-`OnceLock` lookup so tests can inject a composer
+/// without poisoning process-global state.
+fn apply_static_prompt_composer(
+    composer: Option<&StaticPromptComposer>,
+    mode: AppMode,
+    approval_mode: ApprovalMode,
+    model_id: &str,
+    allow_shell: bool,
+    default_layers: String,
+) -> String {
+    match composer {
+        Some(compose) => compose(&StaticPromptCtx {
+            mode,
+            approval_mode,
+            model_id,
+            allow_shell,
+            default_layers: &default_layers,
+        }),
+        None => default_layers,
+    }
+}
+
+fn compose_default_static_layers(
+    mode: AppMode,
+    personality: Personality,
+    approval_mode: ApprovalMode,
+    model_id: &str,
+    allow_shell: bool,
+) -> String {
     let tool_taxonomy = render_core_tool_taxonomy_block(mode);
     let shell_tools_available = allow_shell && mode != AppMode::Plan;
     let base_prompt = render_base_prompt_for_tool_availability(
@@ -1079,8 +1172,11 @@ pub fn system_prompt_for_mode_with_context_skills_session_and_approval(
         full_prompt = format!("{full_prompt}\n\n{block}");
     }
 
-    // 4. Context Management (Agent / Yolo only).
-    if matches!(mode, AppMode::Agent | AppMode::Yolo) {
+    // 4. Context Management (Agent / Yolo only). Suppressed when a
+    // static-prompt composer is installed — the composer owns ALL
+    // compile-time static doctrine (see
+    // `set_static_prompt_composer_override`).
+    if static_prompt_composer().is_none() && matches!(mode, AppMode::Agent | AppMode::Yolo) {
         full_prompt.push_str(
             "\n\n## Context Management\n\n\
              When the conversation gets long (you'll see a context usage indicator), you can:\n\
@@ -1101,8 +1197,13 @@ pub fn system_prompt_for_mode_with_context_skills_session_and_approval(
 
     // 5. Compaction relay template — so the model knows the format to use
     //    when writing `.codewhale/handoff.md` on exit / `/compact`.
-    full_prompt.push_str("\n\n");
-    full_prompt.push_str(COMPACT_TEMPLATE);
+    //    Also composer-owned static doctrine: a static-prompt composer
+    //    that wants the template (or a trimmed variant) includes it in
+    //    its own output.
+    if static_prompt_composer().is_none() {
+        full_prompt.push_str("\n\n");
+        full_prompt.push_str(COMPACT_TEMPLATE);
+    }
 
     // ── Volatile-content boundary ─────────────────────────────────────────
     // Everything below drifts mid-session and busts the prefix cache for
@@ -1233,6 +1334,60 @@ mod tests {
             Err("second".to_string())
         );
         assert_eq!(effective_prompt_override(&cell, "fallback"), "first");
+    }
+
+    // NOTE: these tests inject the composer as a parameter instead of
+    // calling `set_static_prompt_composer_override` — the global is a
+    // process-wide OnceLock and setting it here would poison every other
+    // prompt test in this binary.
+    #[test]
+    fn static_prompt_composer_replaces_default_layers() {
+        let default_layers = compose_default_static_layers(
+            AppMode::Agent,
+            Personality::Calm,
+            ApprovalMode::Suggest,
+            "test-model",
+            true,
+        );
+        assert!(default_layers.contains("Personality: Calm"));
+
+        let composer = |ctx: &StaticPromptCtx<'_>| -> String {
+            assert_eq!(ctx.mode, AppMode::Agent);
+            assert_eq!(ctx.approval_mode, ApprovalMode::Suggest);
+            assert_eq!(ctx.model_id, "test-model");
+            assert!(ctx.allow_shell);
+            assert!(ctx.default_layers.contains("Personality: Calm"));
+            "EMBEDDER STATIC LAYERS".to_string()
+        };
+        let composed = apply_static_prompt_composer(
+            Some(&composer),
+            AppMode::Agent,
+            ApprovalMode::Suggest,
+            "test-model",
+            true,
+            default_layers,
+        );
+        assert_eq!(composed, "EMBEDDER STATIC LAYERS");
+    }
+
+    #[test]
+    fn static_prompt_composer_unset_keeps_default_layers_byte_identical() {
+        let default_layers = compose_default_static_layers(
+            AppMode::Agent,
+            Personality::Calm,
+            ApprovalMode::Suggest,
+            "test-model",
+            true,
+        );
+        let composed = apply_static_prompt_composer(
+            None,
+            AppMode::Agent,
+            ApprovalMode::Suggest,
+            "test-model",
+            true,
+            default_layers.clone(),
+        );
+        assert_eq!(composed, default_layers);
     }
 
     fn contains_cjk(text: &str) -> bool {


### PR DESCRIPTION
## What

Adds `set_static_prompt_composer_override` — an opt-in hook letting an embedder take over ALL compile-time static prompt doctrine (tool taxonomy, base prompt, personality, mode delta, approval policy, `## Context Management`, compaction relay template) in one place, while keeping the runtime's dynamic assembly (environment, skills catalogue, instructions, memory, compaction-summary merge) intact.

The composer receives a `#[non_exhaustive] StaticPromptCtx` carrying `mode`, `approval_mode`, `model_id`, `allow_shell`, and `default_layers` (what the default composition would have produced, for reference or partial reuse).

## Why — the gap between existing mechanisms

| mechanism | granularity | problem for embedders |
|---|---|---|
| per-block hooks (`set_base_prompt_override`, locale, authority recap) | one constant | any **newly added** static block still lands in the embedder's prompt unseen — per-block hooks can't seal the static surface |
| `Op::SyncSession` `system_prompt_override` | whole prompt | `refresh_system_prompt` short-circuits entirely: the embedder forfeits environment, skills, instructions, memory, and compaction-summary merge, and must re-implement half of prompts.rs |

This hook fills the middle tier, and is the logical completion of the per-block override family that landed in v0.8.49.

## Trust-boundary note (prompts content)

This PR does **not** change any prompt content. With the hook unset, output is **byte-identical** to current main — covered by a dedicated test (`static_prompt_composer_unset_keeps_default_layers_byte_identical`). The change is mechanism-only: an `OnceLock` hook in the same style as the existing `set_*_override` family, plus two `is_none()` gates so an installed composer also owns the Context Management and compaction-template appends.

Embedder evolution stays available: `ctx.default_layers` hands the full default composition to the composer, so an embedder can diff/reuse upstream improvements rather than being frozen out of them.

## Scope

- In scope: the hook, `StaticPromptCtx`, gating of the two static appends, tests.
- Out of scope: any prompt wording changes; any new prompt blocks; per-block hook behavior (unchanged).

## Tests / local commands run

- `cargo fmt` — clean
- `cargo clippy -p codewhale-tui` — no warnings from this change
- `cargo test --workspace --all-features` — 4609 passed, 0 failed
- New tests inject the composer as a parameter (not the global `OnceLock`) to avoid poisoning process-global state for sibling tests.

## Motivation context

We embed codewhale as a library inside a Tauri GUI product targeting a small local model (Qwen3.6-35B on vLLM). The default static doctrine is written for the terminal TUI + DeepSeek V4 (approval walkthroughs, sub-agent fan-out advice, `/compact` + prompt-cache guidance) — much of it doesn't apply in an embedded GUI and measurably distracts a 35B model. Per-block hooks got us partway (thanks for landing those!), but every upstream release that adds a static block leaks it into our prompt; this hook closes that gap for any embedder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds `set_static_prompt_composer_override` — a new opt-in hook that lets embedders replace all compile-time static prompt layers in one callback, sitting between the existing per-block overrides and the full `system_prompt_override`. The runtime dynamic assembly (environment, skills, instructions, memory, compaction-summary merge) is preserved unchanged; only the static doctrine surface is handed to the composer.

- A `#[non_exhaustive] StaticPromptCtx` carries `mode`, `approval_mode`, `model_id`, `allow_shell`, and `default_layers` to the composer, with `OnceLock` registration consistent with the existing `set_*_override` family.
- When a composer is installed, sections 4 (Context Management) and 5 (COMPACT_TEMPLATE) in `system_prompt_for_mode_with_context_skills_session_and_approval` are suppressed via `static_prompt_composer().is_none()` guards, avoiding duplicate static content.
- Tests avoid global OnceLock poisoning by injecting the composer through `apply_static_prompt_composer` directly, and a byte-identity test confirms zero output change when no composer is set.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge: the default code path is byte-identical to main (verified by a dedicated test), and the new hook is only active when an embedder explicitly calls set_static_prompt_composer_override.

The refactoring is clean and the byte-identity test gives strong confidence that unset behavior is unchanged. The two findings are both API design concerns: personality is missing from StaticPromptCtx (embedders must string-scan default_layers to detect it), and the registration function returns an opaque unit error instead of giving back the rejected closure, inconsistent with the rest of the override family. Neither affects the default code path or the correctness of the composer mechanism.

crates/tui/src/prompts.rs — the StaticPromptCtx struct and set_static_prompt_composer_override signature.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/prompts.rs | New StaticPromptComposer hook and StaticPromptCtx struct added; compose_prompt_with_approval_model_and_shell refactored into compose_default_static_layers + apply_static_prompt_composer; two is_none() gates added in system_prompt_for_mode_with_context_skills_session_and_approval. Two minor API design gaps: personality absent from StaticPromptCtx, and the registration function returns Result<(), ()> inconsistently with the rest of the override family. |

</details>

</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22pr%2Fstatic-prompt-composer%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22pr%2Fstatic-prompt-composer%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fprompts.rs%3A397-399%0A%60set_static_prompt_composer_override%60%20returns%20%60Result%3C%28%29%2C%20%28%29%3E%60%20while%20every%20other%20%60set_*_override%60%20in%20this%20file%20returns%20%60Result%3C%28%29%2C%20String%3E%60.%20The%20unit%20error%20gives%20callers%20no%20diagnostic%20information%20%E2%80%94%20they%20can't%20even%20log%20%22already%20set%20by%20X%22.%20The%20OnceLock%20gives%20back%20the%20rejected%20value%20on%20%60Err%60%3B%20mapping%20it%20to%20%60%28%29%60%20discards%20the%20only%20actionable%20detail.%20Returning%20%60Err%28%28%29%29%60%20is%20also%20a%20departure%20from%20the%20rest%20of%20the%20override%20family's%20contract%2C%20which%20may%20surprise%20embedders%20who%20rely%20on%20the%20common%20signature.%0A%0A%60%60%60suggestion%0Apub%20fn%20set_static_prompt_composer_override%28%0A%20%20%20%20f%3A%20Box%3CStaticPromptComposer%3E%2C%0A%29%20-%3E%20Result%3C%28%29%2C%20Box%3CStaticPromptComposer%3E%3E%20%7B%0A%20%20%20%20STATIC_PROMPT_COMPOSER.set%28f%29%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fprompts.rs%3A375-383%0A%60personality%60%20is%20absent%20from%20%60StaticPromptCtx%60.%20It%20is%20one%20of%20the%20five%20parameters%20that%20reach%20%60compose_default_static_layers%60%20and%20directly%20affects%20%60ctx.default_layers%60%20content%20%28the%20%60personality.prompt%28%29.trim%28%29%60%20slot%29.%20An%20embedder%20who%20calls%20the%20public%20%60compose_prompt%28mode%2C%20Personality%3A%3ALively%29%60%20path%20with%20a%20composer%20installed%20receives%20%60default_layers%60%20shaped%20by%20%60Personality%3A%3ALively%60%20but%20has%20no%20%60ctx.personality%60%20field%20to%20branch%20on%20%E2%80%94%20they%20must%20resort%20to%20string-scanning%20%60ctx.default_layers%60%20to%20detect%20it.%20The%20struct%20is%20already%20%60%23%5Bnon_exhaustive%5D%60%2C%20so%20adding%20a%20%60pub%20personality%3A%20crate%3A%3Atui%3A%3Aapp%3A%3APersonality%60%20field%20is%20non-breaking%20and%20completes%20the%20contract%20of%20%22all%20inputs%20that%20shaped%20%60default_layers%60%20are%20visible%20to%20the%20composer%22.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fprompts.rs%3A397-399%0A%60set_static_prompt_composer_override%60%20returns%20%60Result%3C%28%29%2C%20%28%29%3E%60%20while%20every%20other%20%60set_*_override%60%20in%20this%20file%20returns%20%60Result%3C%28%29%2C%20String%3E%60.%20The%20unit%20error%20gives%20callers%20no%20diagnostic%20information%20%E2%80%94%20they%20can't%20even%20log%20%22already%20set%20by%20X%22.%20The%20OnceLock%20gives%20back%20the%20rejected%20value%20on%20%60Err%60%3B%20mapping%20it%20to%20%60%28%29%60%20discards%20the%20only%20actionable%20detail.%20Returning%20%60Err%28%28%29%29%60%20is%20also%20a%20departure%20from%20the%20rest%20of%20the%20override%20family's%20contract%2C%20which%20may%20surprise%20embedders%20who%20rely%20on%20the%20common%20signature.%0A%0A%60%60%60suggestion%0Apub%20fn%20set_static_prompt_composer_override%28%0A%20%20%20%20f%3A%20Box%3CStaticPromptComposer%3E%2C%0A%29%20-%3E%20Result%3C%28%29%2C%20Box%3CStaticPromptComposer%3E%3E%20%7B%0A%20%20%20%20STATIC_PROMPT_COMPOSER.set%28f%29%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fprompts.rs%3A375-383%0A%60personality%60%20is%20absent%20from%20%60StaticPromptCtx%60.%20It%20is%20one%20of%20the%20five%20parameters%20that%20reach%20%60compose_default_static_layers%60%20and%20directly%20affects%20%60ctx.default_layers%60%20content%20%28the%20%60personality.prompt%28%29.trim%28%29%60%20slot%29.%20An%20embedder%20who%20calls%20the%20public%20%60compose_prompt%28mode%2C%20Personality%3A%3ALively%29%60%20path%20with%20a%20composer%20installed%20receives%20%60default_layers%60%20shaped%20by%20%60Personality%3A%3ALively%60%20but%20has%20no%20%60ctx.personality%60%20field%20to%20branch%20on%20%E2%80%94%20they%20must%20resort%20to%20string-scanning%20%60ctx.default_layers%60%20to%20detect%20it.%20The%20struct%20is%20already%20%60%23%5Bnon_exhaustive%5D%60%2C%20so%20adding%20a%20%60pub%20personality%3A%20crate%3A%3Atui%3A%3Aapp%3A%3APersonality%60%20field%20is%20non-breaking%20and%20completes%20the%20contract%20of%20%22all%20inputs%20that%20shaped%20%60default_layers%60%20are%20visible%20to%20the%20composer%22.%0A%0A&repo=hmbown%2Fcodewhale&pr=2786&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fprompts.rs%3A397-399%0A%60set_static_prompt_composer_override%60%20returns%20%60Result%3C%28%29%2C%20%28%29%3E%60%20while%20every%20other%20%60set_*_override%60%20in%20this%20file%20returns%20%60Result%3C%28%29%2C%20String%3E%60.%20The%20unit%20error%20gives%20callers%20no%20diagnostic%20information%20%E2%80%94%20they%20can't%20even%20log%20%22already%20set%20by%20X%22.%20The%20OnceLock%20gives%20back%20the%20rejected%20value%20on%20%60Err%60%3B%20mapping%20it%20to%20%60%28%29%60%20discards%20the%20only%20actionable%20detail.%20Returning%20%60Err%28%28%29%29%60%20is%20also%20a%20departure%20from%20the%20rest%20of%20the%20override%20family's%20contract%2C%20which%20may%20surprise%20embedders%20who%20rely%20on%20the%20common%20signature.%0A%0A%60%60%60suggestion%0Apub%20fn%20set_static_prompt_composer_override%28%0A%20%20%20%20f%3A%20Box%3CStaticPromptComposer%3E%2C%0A%29%20-%3E%20Result%3C%28%29%2C%20Box%3CStaticPromptComposer%3E%3E%20%7B%0A%20%20%20%20STATIC_PROMPT_COMPOSER.set%28f%29%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fprompts.rs%3A375-383%0A%60personality%60%20is%20absent%20from%20%60StaticPromptCtx%60.%20It%20is%20one%20of%20the%20five%20parameters%20that%20reach%20%60compose_default_static_layers%60%20and%20directly%20affects%20%60ctx.default_layers%60%20content%20%28the%20%60personality.prompt%28%29.trim%28%29%60%20slot%29.%20An%20embedder%20who%20calls%20the%20public%20%60compose_prompt%28mode%2C%20Personality%3A%3ALively%29%60%20path%20with%20a%20composer%20installed%20receives%20%60default_layers%60%20shaped%20by%20%60Personality%3A%3ALively%60%20but%20has%20no%20%60ctx.personality%60%20field%20to%20branch%20on%20%E2%80%94%20they%20must%20resort%20to%20string-scanning%20%60ctx.default_layers%60%20to%20detect%20it.%20The%20struct%20is%20already%20%60%23%5Bnon_exhaustive%5D%60%2C%20so%20adding%20a%20%60pub%20personality%3A%20crate%3A%3Atui%3A%3Aapp%3A%3APersonality%60%20field%20is%20non-breaking%20and%20completes%20the%20contract%20of%20%22all%20inputs%20that%20shaped%20%60default_layers%60%20are%20visible%20to%20the%20composer%22.%0A%0A&pr=2786&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(prompts): add static prompt compose..."](https://github.com/hmbown/codewhale/commit/f597d40622b6dc0d059e879911514924114943a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35811753)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->