### PR TITLE
fix(tui): define open_external_url on non-desktop targets

### DIFF
--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -5925,7 +5925,6 @@ async fn apply_command_result(
 #[cfg(test)]
 use std::process::{Command, Stdio};
 
-#[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
 fn open_external_url(url: &str) -> Result<()> {
     crate::utils::open_url(url)
 }


### PR DESCRIPTION
## Summary

`open_external_url()` in `crates/tui/src/tui/ui.rs` is called unconditionally
(line 5765, the `AppAction::OpenExternalUrl` arm), but it was only defined
behind `#[cfg(any(target_os = "macos", target_os = "linux", target_os =
"windows"))]`. On any other target the build fails with:

```
error[E0425]: cannot find function `open_external_url` in this scope
  --> crates/tui/src/tui/ui.rs:5765
```

The wrapper only forwards to `crate::utils::open_url()`, which is already
implemented for **every** platform — `browser_open_command()` has a
`#[cfg(not(any(target_os = "macos", target_os = "linux", target_os =
"windows")))]` arm that returns a graceful *"browser opening is unsupported on
this platform"* error. The narrower gate on the wrapper is therefore redundant.
Removing it lets the function compile on all targets while leaving behaviour on
macOS / Linux / Windows unchanged.

The fix is a one-line deletion (the `#[cfg(...)]` attribute above the function).

### Reproduction

Building 0.8.53 on NetBSD fails at the `codewhale-tui` crate with the E0425
above. With the gate removed, the crate builds and the binaries report `0.8.53`.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo check -p codewhale-tui` (Windows host)
- [ ] `cargo clippy --workspace --all-targets --all-features` — not run locally
- [ ] `cargo test --workspace --all-features` — not run locally

End-to-end verified on NetBSD: a full release build (via pkgsrc) succeeds and
all installed binaries — `codewhale`, `codewhale-tui`, `codewhale-app-server`,
`codew`, plus the `deepseek` / `deepseek-tui` legacy shims — run and report
`0.8.53`.

## Checklist

- [x] Updated docs or comments as needed — n/a, behaviour unchanged on supported platforms
- [ ] Added or updated tests where relevant — n/a, this is a compile-time `cfg` gate with no runtime behaviour change (a target-gated definition can't be exercised by a test run on another host)
- [x] Verified TUI behavior manually if UI changes — n/a, no UI change

---

Found while packaging CodeWhale 0.8.53 for [pkgsrc](https://www.pkgsrc.org/) on NetBSD.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a compile error on non-desktop targets (e.g. NetBSD) by removing a redundant `#[cfg(...)]` gate from the `open_external_url` wrapper in `crates/tui/src/tui/ui.rs`. The function was unconditionally called at the `AppAction::OpenExternalUrl` dispatch site but only defined for macOS/Linux/Windows, causing an `E0425` build failure everywhere else.

- Removes the `#[cfg(any(target_os = \"macos\", target_os = \"linux\", target_os = \"windows\"))]` attribute from `open_external_url`, making it available on all targets.
- Behavior on the three supported desktop platforms is unchanged; other platforms already receive a graceful `\"browser opening is unsupported on this platform\"` error from `browser_open_command`, which is surfaced to the user through the existing error-handling arm in the `AppAction::OpenExternalUrl` match.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a single-line deletion that closes a compile gap without touching any runtime logic.

The only modification is removing a #[cfg(...)] guard that was narrower than its call site. The underlying open_url utility already handles all platforms, including a graceful error path for unsupported ones, and the call site already has an error-handling arm that surfaces failures to the user. Desktop platform behaviour is entirely unchanged.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/ui.rs | Removes the #[cfg(...)] platform gate on open_external_url; one-line deletion that aligns the function's availability with its unconditional call site and delegates unsupported-platform handling to crate::utils::open_url. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[AppAction::OpenExternalUrl] --> B[open_external_url]
    B --> C[crate::utils::open_url]
    C --> D{browser_open_command}
    D -->|macOS| E[Command: open]
    D -->|Linux| F[Command: xdg-open]
    D -->|Windows| G[Command: cmd /C start]
    D -->|other targets| H[Err: unsupported platform]
    E & F & G --> I[Ok: status message shown]
    H --> J[Err: user-facing error message shown]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tui): define open\_external\_url on no..."](https://github.com/hmbown/codewhale/commit/5fe93235f75e6987f8a427ffd8751f30cc0f16a5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35835034)</sub>

<!-- /greptile_comment -->