### PR TITLE
feat(web_search): add Sofya as a web search provider (sofya.co)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -399,7 +399,7 @@ max_subagents = 10 # optional (1-20)
 # API-backed search.
 #
 # [search]
-# provider = "duckduckgo"  # duckduckgo | bing | tavily | bocha | metaso | baidu | volcengine
+# provider = "duckduckgo"  # duckduckgo | bing | tavily | bocha | metaso | baidu | volcengine | sofya
 #                            # duckduckgo: HTML scrape with Bing fallback
 #                            # bing:       HTML scrape, no API key
 #                            # tavily:     https://tavily.com — AI search, needs api_key
@@ -409,7 +409,10 @@ max_subagents = 10 # optional (1-20)
 #                            # baidu:      百度 AI Search via qianfan.baidubce.com，需 api_key
 #                            # volcengine: 火山引擎 Ark web_search (免费 2 万次/月), 需 api_key
 #                            #             也回退到 VOLCENGINE_API_KEY / VOLCENGINE_ARK_API_KEY / ARK_API_KEY 环境变量
-# api_key = "YOUR_SEARCH_KEY" # required for tavily, bocha, and baidu; optional for metaso
+#                            # sofya:      https://sofya.co — AI search returning full page
+#                            #             content (not snippets), needs api_key (ay_live_...);
+#                            #             also falls back to the SOFYA_API_KEY env var
+# api_key = "YOUR_SEARCH_KEY" # required for tavily, bocha, baidu, and sofya; optional for metaso
 #                             # WARNING: treat config.toml like a secret file when
 #                             # storing API keys. Prefer env vars for local smoke tests.
 #

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -1053,6 +1053,11 @@ pub enum SearchProvider {
         alias = "volc-ark"
     )]
     Volcengine,
+    /// Sofya web search API (<https://sofya.co>). Requires api_key
+    /// (`ay_live_...`). Returns full extracted page content rather than
+    /// snippets; falls back to the `SOFYA_API_KEY` env var when
+    /// `[search] api_key` is not set.
+    Sofya,
 }
 
 impl SearchProvider {
@@ -1068,6 +1073,7 @@ impl SearchProvider {
                 Some(Self::Baidu)
             }
             "volcengine" | "ark" | "volc" | "volcengine-ark" => Some(Self::Volcengine),
+            "sofya" => Some(Self::Sofya),
             _ => None,
         }
     }
@@ -1082,6 +1088,7 @@ impl SearchProvider {
             Self::Metaso => "metaso",
             Self::Baidu => "baidu",
             Self::Volcengine => "volcengine",
+            Self::Sofya => "sofya",
         }
     }
 }
@@ -5562,6 +5569,29 @@ mod tests {
             config.search.and_then(|search| search.provider),
             Some(SearchProvider::Volcengine)
         );
+    }
+
+    #[test]
+    fn explicit_sofya_search_provider_is_preserved() {
+        let config: Config = toml::from_str(
+            r#"
+            [search]
+            provider = "sofya"
+            "#,
+        )
+        .expect("sofya search config");
+
+        assert_eq!(
+            config.search.and_then(|search| search.provider),
+            Some(SearchProvider::Sofya)
+        );
+    }
+
+    #[test]
+    fn sofya_search_provider_parses_and_round_trips() {
+        assert_eq!(SearchProvider::parse("sofya"), Some(SearchProvider::Sofya));
+        assert_eq!(SearchProvider::parse("Sofya"), Some(SearchProvider::Sofya));
+        assert_eq!(SearchProvider::Sofya.as_str(), "sofya");
     }
 
     #[test]

--- a/crates/tui/src/tools/web_search.rs
+++ b/crates/tui/src/tools/web_search.rs
@@ -1,12 +1,13 @@
 //! Web search tool backed by multiple providers: Bing HTML scrape, DuckDuckGo
 //! (HTML scrape with Bing fallback), Tavily API, Bocha (博查) API,
-//! Metaso API (<https://metaso.cn>), Baidu AI Search, and Volcengine Ark.
+//! Metaso API (<https://metaso.cn>), Baidu AI Search, Volcengine Ark, and
+//! Sofya (<https://sofya.co>).
 //!
 //! This is the primary web search surface for agents. For browsing workflows
 //! (page open, click, screenshot) use a direct URL approach instead.
 //!
 //! Set `[search]` in config.toml to switch providers:
-//!   provider = "duckduckgo"  # or tavily/bocha/metaso/baidu/volcengine
+//!   provider = "duckduckgo"  # or tavily/bocha/metaso/baidu/volcengine/sofya
 //!   api_key = "tvly-..."
 
 use super::spec::{
@@ -29,6 +30,7 @@ const BOCHA_ENDPOINT: &str = "https://api.bochaai.com/v1/ai/search";
 const METASO_ENDPOINT: &str = "https://metaso.cn/api/v1";
 const BAIDU_ENDPOINT: &str = "https://qianfan.baidubce.com/v2/ai_search/web_search";
 const VOLCENGINE_RESPONSES_ENDPOINT: &str = "https://ark.cn-beijing.volces.com/api/v3/responses";
+const SOFYA_ENDPOINT: &str = "https://sofya.co/v1/search";
 /// Intentionally public default key provided by Metaso for open-source/community use.
 /// Last-resort fallback after config and env var. Rate-limited to ~100 searches/day.
 const METASO_DEFAULT_API_KEY: &str = "mk-E384C1DD5E8501BB7EFE27C949AFDE5B";
@@ -236,6 +238,13 @@ impl ToolSpec for WebSearchTool {
                 check_policy(decider, "ark.cn-beijing.volces.com")?;
                 return self
                     .run_volcengine_search(&query, max_results, timeout_ms, context)
+                    .await;
+            }
+            SearchProvider::Sofya => {
+                let decider = context.network_policy.as_ref();
+                check_policy(decider, "sofya.co")?;
+                return self
+                    .run_sofya_search(&query, max_results, timeout_ms, context)
                     .await;
             }
             SearchProvider::Bing | SearchProvider::DuckDuckGo => {}
@@ -454,6 +463,108 @@ impl WebSearchTool {
         let response = WebSearchResponse {
             query: query.to_string(),
             source: "tavily".to_string(),
+            count: results.len(),
+            message,
+            results,
+        };
+
+        ToolResult::json(&response).map_err(|e| ToolError::execution_failed(e.to_string()))
+    }
+
+    /// Search via Sofya web search API (<https://sofya.co>).
+    ///
+    /// Sofya returns full extracted page content rather than snippets. The API
+    /// key (`ay_live_...`) comes from `[search] api_key`, falling back to the
+    /// `SOFYA_API_KEY` env var, and is sent as a `Bearer` token.
+    async fn run_sofya_search(
+        &self,
+        query: &str,
+        max_results: usize,
+        timeout_ms: u64,
+        context: &ToolContext,
+    ) -> Result<ToolResult, ToolError> {
+        let env_key = std::env::var("SOFYA_API_KEY").ok();
+        let api_key = context
+            .search_api_key
+            .as_deref()
+            .or(env_key.as_deref())
+            .ok_or_else(|| {
+                ToolError::execution_failed(
+                    "Sofya search requires an API key. Set `[search] api_key = \"ay_live_...\"` in config.toml or the SOFYA_API_KEY env var.",
+                )
+            })?;
+
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_millis(timeout_ms))
+            .build()
+            .map_err(|e| {
+                ToolError::execution_failed(format!("Failed to build HTTP client: {e}"))
+            })?;
+
+        let payload = json!({
+            "query": query,
+            "max_results": max_results,
+        });
+
+        let resp = client
+            .post(SOFYA_ENDPOINT)
+            .header("Content-Type", "application/json")
+            .bearer_auth(api_key)
+            .json(&payload)
+            .send()
+            .await
+            .map_err(|e| {
+                ToolError::execution_failed(format!("Sofya search request failed: {e}"))
+            })?;
+
+        let status = resp.status();
+        let body = resp.text().await.map_err(|e| {
+            ToolError::execution_failed(format!("Failed to read Sofya response: {e}"))
+        })?;
+
+        if !status.is_success() {
+            let truncated = truncate_error_body(&body);
+            return Err(ToolError::execution_failed(format!(
+                "Sofya search failed: HTTP {} — {truncated}",
+                status.as_u16()
+            )));
+        }
+
+        let parsed: serde_json::Value = serde_json::from_str(&body).map_err(|e| {
+            ToolError::execution_failed(format!("Failed to parse Sofya response: {e}"))
+        })?;
+
+        let results: Vec<WebSearchEntry> = parsed
+            .get("results")
+            .and_then(|v| v.as_array())
+            .into_iter()
+            .flat_map(|arr| arr.iter())
+            .filter_map(|item| {
+                let title = item.get("title")?.as_str()?.to_string();
+                let url = item.get("url")?.as_str()?.to_string();
+                let snippet = item
+                    .get("content")
+                    .or_else(|| item.get("description"))
+                    .and_then(|s| s.as_str())
+                    .map(|s| s.to_string());
+                Some(WebSearchEntry {
+                    title,
+                    url,
+                    snippet,
+                })
+            })
+            .take(max_results)
+            .collect();
+
+        let message = if results.is_empty() {
+            "No results found".to_string()
+        } else {
+            format!("Found {} result(s)", results.len())
+        };
+
+        let response = WebSearchResponse {
+            query: query.to_string(),
+            source: "sofya".to_string(),
             count: results.len(),
             message,
             results,
@@ -1900,6 +2011,38 @@ mod tests {
         let msg = err.to_string();
         assert!(
             msg.contains("Baidu") && msg.contains("API key"),
+            "error must name the provider and missing key; got `{msg}`"
+        );
+    }
+
+    #[tokio::test]
+    async fn sofya_provider_without_api_key_surfaces_clear_error_not_silent_fallback() {
+        // Same trust-boundary pin as Tavily/Bocha: opting into Sofya without a
+        // key must surface a ToolError naming the provider, not silently fall
+        // through to DuckDuckGo.
+        use crate::config::SearchProvider;
+        use crate::tools::spec::{ToolContext, ToolSpec};
+
+        let prev = std::env::var_os("SOFYA_API_KEY");
+        unsafe { std::env::remove_var("SOFYA_API_KEY") };
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut ctx = ToolContext::new(tmp.path().to_path_buf());
+        ctx.search_provider = SearchProvider::Sofya;
+        ctx.search_api_key = None;
+        let err = WebSearchTool
+            .execute(json!({"query": "anything"}), &ctx)
+            .await
+            .expect_err("missing api_key must surface as ToolError");
+
+        match prev {
+            Some(value) => unsafe { std::env::set_var("SOFYA_API_KEY", value) },
+            None => unsafe { std::env::remove_var("SOFYA_API_KEY") },
+        }
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Sofya") && msg.contains("API key"),
             "error must name the provider and missing key; got `{msg}`"
         );
     }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -978,8 +978,8 @@ Use `codewhale-tui features list` to inspect known flags and their effective sta
 `web_search` uses DuckDuckGo by default and does not require an API key. The
 DuckDuckGo path keeps a Bing fallback when DDG returns a bot challenge or no
 parseable results. Bing remains selectable for users who explicitly want it,
-and Tavily, Bocha, Metaso, or Baidu can be selected when an API-backed provider
-is preferred.
+and Tavily, Bocha, Metaso, Baidu, Volcengine, or Sofya can be selected when an
+API-backed provider is preferred.
 
 **Metaso** ([metaso.cn](https://metaso.cn)) has a 100 searches/day free quota;
 set `METASO_API_KEY` or `[search] api_key` for a higher quota.
@@ -989,10 +989,15 @@ set `METASO_API_KEY` or `[search] api_key` for a higher quota.
 `BAIDU_SEARCH_API_KEY` or `[search] api_key`. This is a search-tool backend
 only; it does not add a Baidu model provider.
 
+**Sofya** ([sofya.co](https://sofya.co)) returns full extracted page content
+rather than snippets. Set `[search] api_key` to your `ay_live_...` key, or the
+`SOFYA_API_KEY` env var. This is a search-tool backend only; it does not add a
+Sofya model provider.
+
 ```toml
 [search]
-provider = "baidu" # duckduckgo | bing | tavily | bocha | metaso | baidu
-# api_key = "YOUR_KEY" # required for tavily, bocha, and baidu; optional for metaso
+provider = "baidu" # duckduckgo | bing | tavily | bocha | metaso | baidu | volcengine | sofya
+# api_key = "YOUR_KEY" # required for tavily, bocha, baidu, and sofya; optional for metaso
 ```
 
 ## Local Media Attachments


### PR DESCRIPTION
## Summary

Adds **Sofya** ([sofya.co](https://sofya.co)) as a new `SearchProvider` for the `web_search` tool, alongside the existing DuckDuckGo, Bing, Tavily, Bocha, Metaso, Baidu, and Volcengine backends.

Sofya is an AI web search API. Unlike snippet-based providers, it returns the full extracted page content for each result and uses site-specific parsers to keep that content clean. It is a general-purpose option in the same category as Tavily.

## How it works

- Calls `POST https://sofya.co/v1/search` with the API key sent as a `Bearer` token, and parses the response into CodeWhale's existing `WebSearchEntry` shape (`title` and `url`, with `content` mapped to `snippet` and a `description` fallback).
- The API key comes from `[search] api_key` (format `ay_live_...`), and falls back to the `SOFYA_API_KEY` environment variable. This matches the env-var fallback pattern already used by Metaso, Baidu, and Volcengine.
- When the key is missing, the tool returns a clear `ToolError` that names the provider instead of silently falling back to DuckDuckGo. This is the same trust-boundary behavior already used by Tavily and Bocha.
- Documents `provider = "sofya"` in `config.example.toml` and `docs/CONFIGURATION.md`.

## Scope

Sofya also offers `fetch`, `extract`, and `research` endpoints. Those do not have a pluggable home in CodeWhale today: the URL fetch tool is fixed direct HTTP, and there is no abstraction for extract or research. Those capabilities are also available through Sofya's native MCP server. For that reason this PR is intentionally limited to the search backend only, which is where the existing `SearchProvider` abstraction fits cleanly.

## Testing

- `cargo fmt --all -- --check` passes
- `cargo clippy -p codewhale-tui --all-targets` is clean
- New tests cover provider parsing and round-trip, explicit config preservation, and the missing-key error path (no silent fallback)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds Sofya ([sofya.co](https://sofya.co)) as a new `SearchProvider` option for the `web_search` tool, wiring it into the existing dispatch chain with bearer-token auth, an env-var fallback (`SOFYA_API_KEY`), and a clear `ToolError` when the key is absent.

- **Core implementation** (`web_search.rs`): `run_sofya_search` follows the Tavily/Bocha pattern exactly — network-policy check, client creation, bearer auth, JSON payload, status check, and response mapping into `WebSearchEntry`. The `max_results` cap is applied both in the payload and client-side.
- **Config** (`config.rs`): `Sofya` variant added with `parse()` (case-insensitive) and `as_str()`, no serde aliases needed because `#[serde(rename_all = \"snake_case\")]` already handles the mapping.
- **Docs** (`config.example.toml`, `CONFIGURATION.md`): Provider list and inline TOML examples updated consistently.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The production path is safe to merge; the only concern is a test reliability gap.

The run_sofya_search implementation and enum wiring are correct and closely mirror the established Tavily/Bocha pattern. The one issue is in the new test: it removes SOFYA_API_KEY from the process environment without holding the lock_test_env() guard that the analogous Volcengine test uses. If a parallel test sets that env variable between the remove_var and the awaited execute() call, the missing-key assertion can silently pass even though the error was never triggered — making the test unreliable as a correctness gate on CI.

The test added at the bottom of crates/tui/src/tools/web_search.rs needs the env-lock guard before the unsafe env mutations.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tools/web_search.rs | Adds run_sofya_search following the same pattern as Tavily/Bocha; network-policy check, bearer-auth, JSON parse, and max_results cap are all correct. The test for the missing-key error path is missing the lock_test_env() guard used by the analogous volcengine test, creating a potential race on parallel test runs. |
| crates/tui/src/config.rs | Adds Sofya variant to SearchProvider with correct doc-comment, parse() (case-insensitive via to_ascii_lowercase()), and as_str(). No serde aliases needed since #[serde(rename_all = "snake_case")] already maps Sofya to "sofya". Round-trip and config-preservation tests are correct. |
| config.example.toml | Updates provider list comment and adds Sofya description and env-var note; formatting is consistent with existing entries. |
| docs/CONFIGURATION.md | Adds Sofya to the provider list prose and the inline TOML example; documentation is accurate and consistent with other provider entries. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Agent
    participant WebSearchTool
    participant NetworkPolicy
    participant SofyaAPI as sofya.co/v1/search

    Agent->>WebSearchTool: "execute({ query, max_results })"
    WebSearchTool->>NetworkPolicy: check_policy("sofya.co")
    NetworkPolicy-->>WebSearchTool: OK / Err

    alt API key present (config or SOFYA_API_KEY env)
        WebSearchTool->>SofyaAPI: "POST /v1/search<br/>Authorization: Bearer ay_live_...<br/>{ query, max_results }"
        SofyaAPI-->>WebSearchTool: "{ results: [{ title, url, content, description }] }"
        WebSearchTool-->>Agent: "WebSearchResponse (source="sofya")"
    else API key missing
        WebSearchTool-->>Agent: ToolError("Sofya search requires an API key…")
    end
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fsofya-web-search%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fsofya-web-search%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftools%2Fweb_search.rs%3A2027-2047%0A**Missing%20env-lock%20guard%20causes%20potential%20test%20race**%0A%0AThe%20test%20mutates%20%60SOFYA_API_KEY%60%20via%20%60unsafe%20%7B%20std%3A%3Aenv%3A%3Aremove_var%28...%29%20%7D%60%20without%20holding%20the%20process-level%20env%20mutex%20%28%60lock_test_env%28%29%60%29.%20The%20equivalent%20volcengine%20test%20explicitly%20acquires%20that%20lock%20and%20even%20annotates%20%60%23%5Ballow%28clippy%3A%3Aawait_holding_lock%29%5D%60%2C%20with%20the%20comment%3A%20_%22Dropping%20the%20lock%20before%20await%20would%20reintroduce%20races%20with%20other%20env-mutating%20tests.%22_%20Because%20%60run_sofya_search%60%20reads%20%60SOFYA_API_KEY%60%20during%20the%20%60execute%28%29%60%20call%2C%20a%20concurrent%20test%20that%20sets%20the%20variable%20between%20the%20%60remove_var%60%20at%20line%202027%20and%20the%20awaited%20%60execute%28%29%60%20at%20line%202033%20can%20cause%20the%20assertion%20to%20spuriously%20pass%20%E2%80%94%20the%20missing-key%20error%20never%20fires%20because%20the%20key%20was%20re-injected%20mid-flight.%20Add%20%60let%20_guard%20%3D%20crate%3A%3Atest_support%3A%3Alock_test_env%28%29%3B%60%20%28and%20the%20corresponding%20%60%23%5Ballow%28clippy%3A%3Aawait_holding_lock%29%5D%60%29%20before%20the%20env%20mutation%20to%20match%20the%20established%20pattern.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftools%2Fweb_search.rs%3A2027-2047%0A**Missing%20env-lock%20guard%20causes%20potential%20test%20race**%0A%0AThe%20test%20mutates%20%60SOFYA_API_KEY%60%20via%20%60unsafe%20%7B%20std%3A%3Aenv%3A%3Aremove_var%28...%29%20%7D%60%20without%20holding%20the%20process-level%20env%20mutex%20%28%60lock_test_env%28%29%60%29.%20The%20equivalent%20volcengine%20test%20explicitly%20acquires%20that%20lock%20and%20even%20annotates%20%60%23%5Ballow%28clippy%3A%3Aawait_holding_lock%29%5D%60%2C%20with%20the%20comment%3A%20_%22Dropping%20the%20lock%20before%20await%20would%20reintroduce%20races%20with%20other%20env-mutating%20tests.%22_%20Because%20%60run_sofya_search%60%20reads%20%60SOFYA_API_KEY%60%20during%20the%20%60execute%28%29%60%20call%2C%20a%20concurrent%20test%20that%20sets%20the%20variable%20between%20the%20%60remove_var%60%20at%20line%202027%20and%20the%20awaited%20%60execute%28%29%60%20at%20line%202033%20can%20cause%20the%20assertion%20to%20spuriously%20pass%20%E2%80%94%20the%20missing-key%20error%20never%20fires%20because%20the%20key%20was%20re-injected%20mid-flight.%20Add%20%60let%20_guard%20%3D%20crate%3A%3Atest_support%3A%3Alock_test_env%28%29%3B%60%20%28and%20the%20corresponding%20%60%23%5Ballow%28clippy%3A%3Aawait_holding_lock%29%5D%60%29%20before%20the%20env%20mutation%20to%20match%20the%20established%20pattern.%0A%0A&repo=hmbown%2Fcodewhale&pr=2790&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftools%2Fweb_search.rs%3A2027-2047%0A**Missing%20env-lock%20guard%20causes%20potential%20test%20race**%0A%0AThe%20test%20mutates%20%60SOFYA_API_KEY%60%20via%20%60unsafe%20%7B%20std%3A%3Aenv%3A%3Aremove_var%28...%29%20%7D%60%20without%20holding%20the%20process-level%20env%20mutex%20%28%60lock_test_env%28%29%60%29.%20The%20equivalent%20volcengine%20test%20explicitly%20acquires%20that%20lock%20and%20even%20annotates%20%60%23%5Ballow%28clippy%3A%3Aawait_holding_lock%29%5D%60%2C%20with%20the%20comment%3A%20_%22Dropping%20the%20lock%20before%20await%20would%20reintroduce%20races%20with%20other%20env-mutating%20tests.%22_%20Because%20%60run_sofya_search%60%20reads%20%60SOFYA_API_KEY%60%20during%20the%20%60execute%28%29%60%20call%2C%20a%20concurrent%20test%20that%20sets%20the%20variable%20between%20the%20%60remove_var%60%20at%20line%202027%20and%20the%20awaited%20%60execute%28%29%60%20at%20line%202033%20can%20cause%20the%20assertion%20to%20spuriously%20pass%20%E2%80%94%20the%20missing-key%20error%20never%20fires%20because%20the%20key%20was%20re-injected%20mid-flight.%20Add%20%60let%20_guard%20%3D%20crate%3A%3Atest_support%3A%3Alock_test_env%28%29%3B%60%20%28and%20the%20corresponding%20%60%23%5Ballow%28clippy%3A%3Aawait_holding_lock%29%5D%60%29%20before%20the%20env%20mutation%20to%20match%20the%20established%20pattern.%0A%0A&pr=2790&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(web\_search): add Sofya as a web sea..."](https://github.com/hmbown/codewhale/commit/ae560da2c57324a7e245aac27177b7648943d6e6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35837520)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->