### PR TITLE
fix(tui): enrich auth errors with provider, base URL, model, and redacted key fingerprint

### DIFF
--- a/crates/tui/src/error_taxonomy.rs
+++ b/crates/tui/src/error_taxonomy.rs
@@ -234,12 +234,12 @@ impl From<LlmError> for ErrorEnvelope {
                 "llm_timeout",
                 format!("Request timed out after {duration:?}"),
             ),
-            LlmError::AuthenticationError(message) => Self::new(
+            LlmError::AuthenticationError(auth) => Self::new(
                 ErrorCategory::Authentication,
                 ErrorSeverity::Critical,
                 false,
                 "llm_auth_error",
-                message,
+                auth.to_user_message(),
             ),
             LlmError::AuthorizationError(message) => Self::new(
                 ErrorCategory::Authorization,
@@ -564,6 +564,35 @@ mod tests {
                 "expected Authentication for `{msg}`",
             );
         }
+    }
+
+    #[test]
+    fn llm_auth_error_envelope_renders_context_without_secret() {
+        let api_key = "tp-secret-token-plan-value";
+        let env = ErrorEnvelope::from(LlmError::from_http_response_with_request_context(
+            401,
+            &format!("Invalid API Key: {api_key}"),
+            Some("Xiaomi MiMo"),
+            Some("https://token-plan-sgp.xiaomimimo.com/v1"),
+            Some("mimo-v2.5"),
+            Some("env"),
+            Some(api_key),
+        ));
+
+        assert_eq!(env.category, ErrorCategory::Authentication);
+        assert_eq!(env.severity, ErrorSeverity::Critical);
+        assert!(!env.recoverable);
+        assert!(env.message.contains("provider: Xiaomi MiMo"));
+        assert!(
+            env.message
+                .contains("base URL host: token-plan-sgp.xiaomimimo.com")
+        );
+        assert!(env.message.contains("model: mimo-v2.5"));
+        assert!(env.message.contains("key source: env"));
+        assert!(env.message.contains("key fingerprint: tp-... (len=26)"));
+        assert!(env.message.contains("key type: Xiaomi MiMo Token Plan key"));
+        assert!(!env.message.contains(api_key));
+        assert!(!env.message.contains("secret-token-plan-value"));
     }
 
     #[test]

--- a/crates/tui/src/llm_client/mod.rs
+++ b/crates/tui/src/llm_client/mod.rs
@@ -82,6 +82,197 @@ pub trait RetryConfigurable {
     fn set_retry_config(&mut self, config: RetryConfig);
 }
 
+// === Authentication diagnostics ===
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct AuthenticationErrorContext {
+    pub provider: Option<String>,
+    pub base_url_host: Option<String>,
+    pub model: Option<String>,
+    pub key_source: Option<String>,
+    pub key_fingerprint: Option<String>,
+    pub key_kind: Option<String>,
+}
+
+impl AuthenticationErrorContext {
+    #[must_use]
+    pub fn new(
+        provider: &str,
+        base_url: &str,
+        model: &str,
+        key_source: &str,
+        api_key: &str,
+    ) -> Self {
+        Self::from_parts(
+            Some(provider),
+            Some(base_url),
+            Some(model),
+            Some(key_source),
+            Some(api_key),
+        )
+    }
+
+    #[must_use]
+    pub fn from_parts(
+        provider: Option<&str>,
+        base_url: Option<&str>,
+        model: Option<&str>,
+        key_source: Option<&str>,
+        api_key: Option<&str>,
+    ) -> Self {
+        let api_key = api_key.and_then(non_empty_trimmed);
+        Self {
+            provider: provider.and_then(non_empty_trimmed).map(str::to_string),
+            base_url_host: base_url.and_then(base_url_host),
+            model: model.and_then(non_empty_trimmed).map(str::to_string),
+            key_source: key_source.and_then(non_empty_trimmed).map(str::to_string),
+            key_fingerprint: api_key.map(redacted_key_fingerprint),
+            key_kind: api_key.map(classify_api_key_prefix).map(str::to_string),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.provider.is_none()
+            && self.base_url_host.is_none()
+            && self.model.is_none()
+            && self.key_source.is_none()
+            && self.key_fingerprint.is_none()
+            && self.key_kind.is_none()
+    }
+
+    fn detail_segments(&self) -> Vec<String> {
+        let mut segments = Vec::new();
+        if let Some(provider) = self.provider.as_deref() {
+            segments.push(format!("provider: {provider}"));
+        }
+        if let Some(host) = self.base_url_host.as_deref() {
+            segments.push(format!("base URL host: {host}"));
+        }
+        if let Some(model) = self.model.as_deref() {
+            segments.push(format!("model: {model}"));
+        }
+        if let Some(source) = self.key_source.as_deref() {
+            segments.push(format!("key source: {source}"));
+        }
+        if let Some(fingerprint) = self.key_fingerprint.as_deref() {
+            segments.push(format!("key fingerprint: {fingerprint}"));
+        }
+        if let Some(kind) = self.key_kind.as_deref() {
+            segments.push(format!("key type: {kind}"));
+        }
+        segments
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthenticationErrorDetail {
+    message: String,
+    context: Option<AuthenticationErrorContext>,
+}
+
+impl AuthenticationErrorDetail {
+    #[must_use]
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            context: None,
+        }
+    }
+
+    #[must_use]
+    pub fn with_context(
+        message: impl Into<String>,
+        context: Option<AuthenticationErrorContext>,
+    ) -> Self {
+        let context = context.filter(|context| !context.is_empty());
+        Self {
+            message: message.into(),
+            context,
+        }
+    }
+
+    #[must_use]
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    #[must_use]
+    pub fn to_user_message(&self) -> String {
+        let Some(context) = self.context.as_ref() else {
+            return self.message.clone();
+        };
+        let segments = context.detail_segments();
+        if segments.is_empty() {
+            self.message.clone()
+        } else {
+            format!("{} ({})", self.message, segments.join(", "))
+        }
+    }
+}
+
+impl From<String> for AuthenticationErrorDetail {
+    fn from(message: String) -> Self {
+        Self::new(message)
+    }
+}
+
+impl From<&str> for AuthenticationErrorDetail {
+    fn from(message: &str) -> Self {
+        Self::new(message)
+    }
+}
+
+#[must_use]
+pub fn classify_api_key_prefix(api_key: &str) -> &'static str {
+    if api_key.trim_start().starts_with("tp-") {
+        "Xiaomi MiMo Token Plan key"
+    } else {
+        "API key"
+    }
+}
+
+fn non_empty_trimmed(value: &str) -> Option<&str> {
+    let value = value.trim();
+    if value.is_empty() { None } else { Some(value) }
+}
+
+fn base_url_host(base_url: &str) -> Option<String> {
+    let base_url = non_empty_trimmed(base_url)?;
+    let without_scheme = base_url
+        .split_once("://")
+        .map_or(base_url, |(_, rest)| rest);
+    let authority = without_scheme.split('/').next().unwrap_or(without_scheme);
+    let host = authority
+        .rsplit_once('@')
+        .map_or(authority, |(_, host)| host);
+    non_empty_trimmed(host).map(str::to_string)
+}
+
+fn redacted_key_fingerprint(api_key: &str) -> String {
+    let api_key = api_key.trim();
+    let len = api_key.chars().count();
+    match public_key_prefix(api_key) {
+        Some(prefix) => format!("{prefix}... (len={len})"),
+        None => format!("unprefixed (len={len})"),
+    }
+}
+
+fn public_key_prefix(api_key: &str) -> Option<&str> {
+    for prefix in ["tp-", "sk-", "hf_", "hf-", "ak-", "rk-"] {
+        if api_key.starts_with(prefix) {
+            return Some(prefix);
+        }
+    }
+    None
+}
+
+fn redact_api_key_from_message(message: &str, api_key: Option<&str>) -> String {
+    let Some(api_key) = api_key.and_then(non_empty_trimmed) else {
+        return message.to_string();
+    };
+    message.replace(api_key, "[redacted API key]")
+}
+
 // === LlmError - Classified Error Types ===
 
 /// Classified LLM errors with retryability information.
@@ -107,8 +298,8 @@ pub enum LlmError {
     /// Request timed out
     Timeout(Duration),
 
-    /// Authentication failed (HTTP 401, 403)
-    AuthenticationError(String),
+    /// Authentication failed (HTTP 401, selected HTTP 403)
+    AuthenticationError(AuthenticationErrorDetail),
 
     /// Authorization or provider-side blocking failed (HTTP 403)
     AuthorizationError(String),
@@ -141,7 +332,9 @@ impl std::fmt::Display for LlmError {
             }
             LlmError::NetworkError(msg) => write!(f, "Network error: {msg}"),
             LlmError::Timeout(d) => write!(f, "Request timed out after {d:?}"),
-            LlmError::AuthenticationError(msg) => write!(f, "Authentication failed: {msg}"),
+            LlmError::AuthenticationError(auth) => {
+                write!(f, "Authentication failed: {}", auth.to_user_message())
+            }
             LlmError::AuthorizationError(msg) => write!(f, "Authorization failed: {msg}"),
             LlmError::InvalidRequest { status, message } => {
                 write!(f, "Invalid request ({status}): {message}")
@@ -203,10 +396,10 @@ impl LlmError {
                 message: body.to_string(),
                 retry_after: None,
             },
-            401 => LlmError::AuthenticationError(body.to_string()),
+            401 => Self::authentication_error(body),
             403 => {
                 if looks_like_authentication_failure(body) {
-                    LlmError::AuthenticationError(body.to_string())
+                    Self::authentication_error(body)
                 } else {
                     LlmError::AuthorizationError(body.to_string())
                 }
@@ -259,6 +452,58 @@ impl LlmError {
                 message: body.to_string(),
             },
             _ => LlmError::Other(format!("HTTP {status}: {body}")),
+        }
+    }
+
+    #[must_use]
+    pub fn authentication_error(message: impl Into<String>) -> Self {
+        LlmError::AuthenticationError(AuthenticationErrorDetail::new(message))
+    }
+
+    #[must_use]
+    pub fn authentication_error_with_context(
+        message: impl Into<String>,
+        context: Option<AuthenticationErrorContext>,
+    ) -> Self {
+        LlmError::AuthenticationError(AuthenticationErrorDetail::with_context(message, context))
+    }
+
+    /// Constructs an `LlmError` from HTTP response data plus request context
+    /// that is safe to display when authentication fails.
+    #[must_use]
+    pub fn from_http_response_with_request_context(
+        status: u16,
+        body: &str,
+        provider: Option<&str>,
+        base_url: Option<&str>,
+        model: Option<&str>,
+        key_source: Option<&str>,
+        api_key: Option<&str>,
+    ) -> Self {
+        let body = redact_api_key_from_message(body, api_key);
+        let context =
+            AuthenticationErrorContext::from_parts(provider, base_url, model, key_source, api_key);
+        Self::from_http_response_with_auth_context(status, &body, Some(context))
+    }
+
+    /// Constructs an `LlmError` from HTTP status code and response body, with
+    /// optional structured details for authentication failures.
+    #[must_use]
+    pub fn from_http_response_with_auth_context(
+        status: u16,
+        body: &str,
+        auth_context: Option<AuthenticationErrorContext>,
+    ) -> Self {
+        match status {
+            401 => Self::authentication_error_with_context(body, auth_context),
+            403 => {
+                if looks_like_authentication_failure(body) {
+                    Self::authentication_error_with_context(body, auth_context)
+                } else {
+                    LlmError::AuthorizationError(body.to_string())
+                }
+            }
+            _ => Self::from_http_response(status, body),
         }
     }
 
@@ -898,6 +1143,13 @@ mod tests {
         );
     }
 
+    fn auth_user_message(error: LlmError) -> String {
+        match error {
+            LlmError::AuthenticationError(auth) => auth.to_user_message(),
+            other => panic!("expected authentication error, got {other}"),
+        }
+    }
+
     #[test]
     fn test_retry_config_defaults() {
         let config = RetryConfig::default();
@@ -1014,7 +1266,7 @@ mod tests {
         assert!(LlmError::Timeout(Duration::from_secs(30)).is_retryable());
 
         // Non-retryable errors
-        assert!(!LlmError::AuthenticationError("invalid key".to_string()).is_retryable());
+        assert!(!LlmError::authentication_error("invalid key").is_retryable());
         assert!(!LlmError::AuthorizationError("blocked".to_string()).is_retryable());
         assert!(
             !LlmError::InvalidRequest {
@@ -1069,6 +1321,109 @@ mod tests {
         // Generic 400
         let err = LlmError::from_http_response(400, "invalid json");
         assert!(matches!(err, LlmError::InvalidRequest { status: 400, .. }));
+    }
+
+    #[test]
+    fn auth_error_with_context_includes_provider_host_model_and_key_source() {
+        let err = LlmError::from_http_response_with_request_context(
+            401,
+            "Invalid API Key",
+            Some("Xiaomi MiMo"),
+            Some("https://token-plan-sgp.xiaomimimo.com/v1"),
+            Some("mimo-v2.5"),
+            Some("env"),
+            Some("tp-secret-token-plan-value"),
+        );
+        let message = auth_user_message(err);
+
+        assert!(message.contains("Invalid API Key"));
+        assert!(message.contains("provider: Xiaomi MiMo"));
+        assert!(message.contains("base URL host: token-plan-sgp.xiaomimimo.com"));
+        assert!(message.contains("model: mimo-v2.5"));
+        assert!(message.contains("key source: env"));
+        assert!(message.contains("key fingerprint: tp-... (len=26)"));
+    }
+
+    #[test]
+    fn auth_error_redacts_full_api_key_from_body_and_context() {
+        let api_key = "tp-secret-token-plan-value";
+        let err = LlmError::from_http_response_with_request_context(
+            401,
+            &format!("Invalid API Key: {api_key}"),
+            Some("Xiaomi MiMo"),
+            Some("https://token-plan-sgp.xiaomimimo.com/v1"),
+            Some("mimo-v2.5"),
+            Some("config-file"),
+            Some(api_key),
+        );
+        let message = auth_user_message(err);
+
+        assert!(!message.contains(api_key));
+        assert!(!message.contains("secret-token-plan-value"));
+        assert!(message.contains("[redacted API key]"));
+        assert!(message.contains("key fingerprint: tp-... (len=26)"));
+    }
+
+    #[test]
+    fn auth_error_classifies_xiaomi_token_plan_key_prefix() {
+        let token_plan = AuthenticationErrorContext::from_parts(
+            None,
+            None,
+            None,
+            Some("session"),
+            Some("tp-secret-token-plan-value"),
+        );
+        let generic = AuthenticationErrorContext::from_parts(
+            None,
+            None,
+            None,
+            Some("session"),
+            Some("sk-other"),
+        );
+        let unprefixed = AuthenticationErrorContext::from_parts(
+            None,
+            None,
+            None,
+            Some("session"),
+            Some("plainsecretvalue"),
+        );
+
+        assert_eq!(
+            token_plan.key_kind.as_deref(),
+            Some("Xiaomi MiMo Token Plan key")
+        );
+        assert_eq!(generic.key_kind.as_deref(), Some("API key"));
+        assert_eq!(unprefixed.key_kind.as_deref(), Some("API key"));
+        assert_eq!(
+            unprefixed.key_fingerprint.as_deref(),
+            Some("unprefixed (len=16)")
+        );
+    }
+
+    #[test]
+    fn authorization_403_is_not_reclassified_by_auth_context() {
+        let err = LlmError::from_http_response_with_request_context(
+            403,
+            "forbidden",
+            Some("Arcee AI"),
+            Some("https://api.arcee.ai/v1"),
+            Some("auto"),
+            Some("env"),
+            Some("sk-arcee-secret"),
+        );
+
+        assert!(matches!(err, LlmError::AuthorizationError(_)));
+    }
+
+    #[test]
+    fn auth_error_without_context_preserves_bare_message() {
+        let err = LlmError::from_http_response_with_auth_context(
+            401,
+            "Invalid API Key",
+            Some(AuthenticationErrorContext::default()),
+        );
+
+        assert_eq!(auth_user_message(err), "Invalid API Key");
     }
 
     #[test]
@@ -1247,7 +1602,7 @@ mod tests {
             &config,
             || {
                 call_count += 1;
-                async { Err(LlmError::AuthenticationError("bad key".to_string())) }
+                async { Err(LlmError::authentication_error("bad key")) }
             },
             None,
         )


### PR DESCRIPTION
## Summary

Closes #2665.

Invalid-API-key errors surface as a bare `Invalid API Key`, which gives no way to tell which provider, endpoint, or key the client actually used - the exact diagnosis pain described in #2665. `LlmError::AuthenticationError` now carries an `AuthenticationErrorContext`, and the rendered message appends the provider, base URL host, model, key source, a redacted key fingerprint, and a key-type classification.

Redaction is the load-bearing choice: the fingerprint is prefix-plus-length only (`tp-... (len=26)`), the base URL is reduced to its host so no path or query leaks, and tests assert the secret never appears anywhere in a rendered message. Key-type classification by prefix includes `tp-` mapping to a Xiaomi MiMo Token Plan key, display-only as requested in the issue thread. When no context is available the original bare message renders unchanged, so existing callers and tests are unaffected.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-features`
- [x] `cargo test --workspace --all-features`

Workspace suite: 4613 passed, 0 failed. New tests cover the enriched envelope rendering without secret leakage, `tp-` prefix classification, host-only base URL reduction, and the no-context fallback.

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [x] Verified TUI behavior manually if UI changes (error-message content only, no layout changes; covered by taxonomy rendering tests)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR enriches `LlmError::AuthenticationError` with an `AuthenticationErrorContext` so that rendered error messages include the provider name, base URL host, model, key source, and a redacted key fingerprint — giving users enough signal to diagnose auth failures without leaking the raw secret.

- `AuthenticationErrorContext` and `AuthenticationErrorDetail` are introduced in `llm_client/mod.rs`; redaction is handled in `from_http_response_with_request_context` (body scrubbed via `str::replace`) while the fingerprint is stored as prefix-plus-length only.
- The `ErrorEnvelope` conversion in `error_taxonomy.rs` is updated to call `to_user_message()`, and five new tests cover enriched rendering, redaction, key-type classification, port-stripped host extraction, and the no-context fallback.
- Two public constructors with different redaction contracts (`from_http_response_with_request_context` vs. `from_http_response_with_auth_context`) are added; the lower-level one lacks a doc note clarifying that callers are responsible for body redaction.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; all changes are additive and backward-compatible, existing callers are updated correctly, and the redaction path is exercised by tests.

The enrichment logic is well-contained and the test suite thoroughly covers the happy path and edge cases. The main gap is that `from_http_response_with_auth_context` is public but carries no documentation warning that `body` must be pre-redacted — a future caller who passes an unredacted response body would silently expose key material, directly undermining this PR's purpose. The `base_url_host` helper also retains the port number despite being named and labeled as "host", creating a minor user-visible inconsistency.

The new public API surface in `crates/tui/src/llm_client/mod.rs` — specifically `from_http_response_with_auth_context` and the distinction between it and `from_http_response_with_request_context` — deserves a second look for documentation clarity.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/llm_client/mod.rs | Introduces AuthenticationErrorContext and AuthenticationErrorDetail to enrich auth error messages with provider, URL host, model, key source, and redacted fingerprint; adds two new public constructors with subtly different redaction contracts |
| crates/tui/src/error_taxonomy.rs | Updates AuthenticationError arm to call auth.to_user_message() and adds a test asserting enriched context renders without secret leakage; change is minimal and correct |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[HTTP 401/403 response received] --> B{from_http_response_with_request_context}
    B --> C[redact_api_key_from_message\nbody]
    B --> D[AuthenticationErrorContext::from_parts\nprovider, base_url_host, model,\nkey_source, fingerprint, key_kind]
    C --> E[from_http_response_with_auth_context\nstatus, redacted_body, Some context]
    D --> E
    E --> F{status?}
    F -->|401| G[authentication_error_with_context]
    F -->|403 + looks_like_auth_failure| G
    F -->|403 non-auth| H[AuthorizationError\nauth_context silently dropped]
    F -->|other| I[from_http_response\nauth_context silently dropped]
    G --> J[AuthenticationErrorDetail\nmessage + context]
    J --> K[to_user_message\nmessage + provider, host, model,\nkey source, fingerprint, key type]
    K --> L[ErrorEnvelope / Display]
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2F2665-auth-error-provider-context%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F2665-auth-error-provider-context%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Ftui%2Fsrc%2Fllm_client%2Fmod.rs%3A489-492%0A%60from_http_response_with_auth_context%60%20is%20%60pub%60%20but%20does%20not%20document%20that%20the%20caller%20is%20responsible%20for%20redacting%20API%20key%20material%20from%20%60body%60%20before%20passing%20it%20in.%20The%20peer%20method%20%60from_http_response_with_request_context%60%20does%20this%20automatically%20%E2%80%94%20but%20a%20future%20caller%20of%20the%20lower-level%20method%20who%20passes%20an%20unredacted%20response%20body%20%28e.g.%20one%20that%20contains%20a%20reflected%20key%20in%20the%20error%20text%29%20would%20silently%20expose%20the%20raw%20key%20in%20every%20rendered%20error%20message%2C%20which%20is%20exactly%20the%20leak%20this%20PR%20was%20designed%20to%20prevent.%20A%20doc%20note%20makes%20the%20contract%20explicit.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Constructs%20an%20%60LlmError%60%20from%20HTTP%20status%20code%20and%20response%20body%2C%20with%0A%20%20%20%20%2F%2F%2F%20optional%20structured%20details%20for%20authentication%20failures.%0A%20%20%20%20%2F%2F%2F%0A%20%20%20%20%2F%2F%2F%20%23%20Security%20note%0A%20%20%20%20%2F%2F%2F%20%60body%60%20is%20stored%20verbatim%20in%20the%20error%20message.%20Callers%20must%20ensure%20any%0A%20%20%20%20%2F%2F%2F%20API%20key%20material%20has%20been%20removed%20from%20it%20before%20calling%20this%20method.%0A%20%20%20%20%2F%2F%2F%20Prefer%20%5B%60Self%3A%3Afrom_http_response_with_request_context%60%5D%20when%20the%20raw%0A%20%20%20%20%2F%2F%2F%20API%20key%20is%20available%20%E2%80%94%20it%20performs%20redaction%20automatically.%0A%20%20%20%20%23%5Bmust_use%5D%0A%20%20%20%20pub%20fn%20from_http_response_with_auth_context%28%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Ftui%2Fsrc%2Fllm_client%2Fmod.rs%3A239-249%0A%60base_url_host%60%20strips%20the%20scheme%20and%20path%20but%20keeps%20the%20port%2C%20so%20a%20URL%20like%20%60https%3A%2F%2Fapi.example.com%3A8443%2Fv1%60%20produces%20%60api.example.com%3A8443%60.%20The%20field%20and%20the%20display%20label%20both%20say%20%22host%22%2C%20which%20normally%20means%20the%20hostname%20without%20a%20port.%20This%20is%20not%20a%20security%20concern%20since%20ports%20are%20not%20sensitive%2C%20but%20it%20is%20a%20naming%20mismatch%20that%20could%20confuse%20users%20reading%20the%20error%20message%20%28%22base%20URL%20host%3A%20api.example.com%3A8443%22%20looks%20odd%29.%20Consider%20stripping%20the%20port%20or%20renaming%20to%20%22base%20URL%20authority%22.%0A%0A%60%60%60suggestion%0Afn%20base_url_host%28base_url%3A%20%26str%29%20-%3E%20Option%3CString%3E%20%7B%0A%20%20%20%20let%20base_url%20%3D%20non_empty_trimmed%28base_url%29%3F%3B%0A%20%20%20%20let%20without_scheme%20%3D%20base_url%0A%20%20%20%20%20%20%20%20.split_once%28%22%3A%2F%2F%22%29%0A%20%20%20%20%20%20%20%20.map_or%28base_url%2C%20%7C%28_%2C%20rest%29%7C%20rest%29%3B%0A%20%20%20%20let%20authority%20%3D%20without_scheme.split%28'%2F'%29.next%28%29.unwrap_or%28without_scheme%29%3B%0A%20%20%20%20let%20host_with_port%20%3D%20authority%0A%20%20%20%20%20%20%20%20.rsplit_once%28'%40'%29%0A%20%20%20%20%20%20%20%20.map_or%28authority%2C%20%7C%28_%2C%20host%29%7C%20host%29%3B%0A%20%20%20%20%2F%2F%20Strip%20port%20so%20the%20label%20%22base%20URL%20host%22%20is%20accurate.%0A%20%20%20%20let%20host%20%3D%20host_with_port%0A%20%20%20%20%20%20%20%20.rsplit_once%28'%3A'%29%0A%20%20%20%20%20%20%20%20.map_or%28host_with_port%2C%20%7C%28host%2C%20_%29%7C%20host%29%3B%0A%20%20%20%20non_empty_trimmed%28host%29.map%28str%3A%3Ato_string%29%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Ftui%2Fsrc%2Fllm_client%2Fmod.rs%3A225-232%0A%60classify_api_key_prefix%60%20calls%20%60trim_start%28%29%60%20before%20checking%20for%20the%20%60tp-%60%20prefix%2C%20but%20%60public_key_prefix%60%20%28called%20by%20%60redacted_key_fingerprint%60%20on%20the%20same%20value%29%20does%20not%20trim%20at%20all.%20Both%20functions%20receive%20a%20value%20already%20stripped%20by%20%60non_empty_trimmed%60%2C%20so%20there%20is%20no%20observable%20difference%20%E2%80%94%20but%20the%20inconsistency%20is%20mildly%20confusing.%20Either%20both%20should%20rely%20on%20the%20pre-trimmed%20input%20or%20neither%20should.%0A%0A%60%60%60suggestion%0A%23%5Bmust_use%5D%0Apub%20fn%20classify_api_key_prefix%28api_key%3A%20%26str%29%20-%3E%20%26'static%20str%20%7B%0A%20%20%20%20if%20api_key.starts_with%28%22tp-%22%29%20%7B%0A%20%20%20%20%20%20%20%20%22Xiaomi%20MiMo%20Token%20Plan%20key%22%0A%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%22API%20key%22%0A%20%20%20%20%7D%0A%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Ftui%2Fsrc%2Fllm_client%2Fmod.rs%3A489-492%0A%60from_http_response_with_auth_context%60%20is%20%60pub%60%20but%20does%20not%20document%20that%20the%20caller%20is%20responsible%20for%20redacting%20API%20key%20material%20from%20%60body%60%20before%20passing%20it%20in.%20The%20peer%20method%20%60from_http_response_with_request_context%60%20does%20this%20automatically%20%E2%80%94%20but%20a%20future%20caller%20of%20the%20lower-level%20method%20who%20passes%20an%20unredacted%20response%20body%20%28e.g.%20one%20that%20contains%20a%20reflected%20key%20in%20the%20error%20text%29%20would%20silently%20expose%20the%20raw%20key%20in%20every%20rendered%20error%20message%2C%20which%20is%20exactly%20the%20leak%20this%20PR%20was%20designed%20to%20prevent.%20A%20doc%20note%20makes%20the%20contract%20explicit.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Constructs%20an%20%60LlmError%60%20from%20HTTP%20status%20code%20and%20response%20body%2C%20with%0A%20%20%20%20%2F%2F%2F%20optional%20structured%20details%20for%20authentication%20failures.%0A%20%20%20%20%2F%2F%2F%0A%20%20%20%20%2F%2F%2F%20%23%20Security%20note%0A%20%20%20%20%2F%2F%2F%20%60body%60%20is%20stored%20verbatim%20in%20the%20error%20message.%20Callers%20must%20ensure%20any%0A%20%20%20%20%2F%2F%2F%20API%20key%20material%20has%20been%20removed%20from%20it%20before%20calling%20this%20method.%0A%20%20%20%20%2F%2F%2F%20Prefer%20%5B%60Self%3A%3Afrom_http_response_with_request_context%60%5D%20when%20the%20raw%0A%20%20%20%20%2F%2F%2F%20API%20key%20is%20available%20%E2%80%94%20it%20performs%20redaction%20automatically.%0A%20%20%20%20%23%5Bmust_use%5D%0A%20%20%20%20pub%20fn%20from_http_response_with_auth_context%28%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Ftui%2Fsrc%2Fllm_client%2Fmod.rs%3A239-249%0A%60base_url_host%60%20strips%20the%20scheme%20and%20path%20but%20keeps%20the%20port%2C%20so%20a%20URL%20like%20%60https%3A%2F%2Fapi.example.com%3A8443%2Fv1%60%20produces%20%60api.example.com%3A8443%60.%20The%20field%20and%20the%20display%20label%20both%20say%20%22host%22%2C%20which%20normally%20means%20the%20hostname%20without%20a%20port.%20This%20is%20not%20a%20security%20concern%20since%20ports%20are%20not%20sensitive%2C%20but%20it%20is%20a%20naming%20mismatch%20that%20could%20confuse%20users%20reading%20the%20error%20message%20%28%22base%20URL%20host%3A%20api.example.com%3A8443%22%20looks%20odd%29.%20Consider%20stripping%20the%20port%20or%20renaming%20to%20%22base%20URL%20authority%22.%0A%0A%60%60%60suggestion%0Afn%20base_url_host%28base_url%3A%20%26str%29%20-%3E%20Option%3CString%3E%20%7B%0A%20%20%20%20let%20base_url%20%3D%20non_empty_trimmed%28base_url%29%3F%3B%0A%20%20%20%20let%20without_scheme%20%3D%20base_url%0A%20%20%20%20%20%20%20%20.split_once%28%22%3A%2F%2F%22%29%0A%20%20%20%20%20%20%20%20.map_or%28base_url%2C%20%7C%28_%2C%20rest%29%7C%20rest%29%3B%0A%20%20%20%20let%20authority%20%3D%20without_scheme.split%28'%2F'%29.next%28%29.unwrap_or%28without_scheme%29%3B%0A%20%20%20%20let%20host_with_port%20%3D%20authority%0A%20%20%20%20%20%20%20%20.rsplit_once%28'%40'%29%0A%20%20%20%20%20%20%20%20.map_or%28authority%2C%20%7C%28_%2C%20host%29%7C%20host%29%3B%0A%20%20%20%20%2F%2F%20Strip%20port%20so%20the%20label%20%22base%20URL%20host%22%20is%20accurate.%0A%20%20%20%20let%20host%20%3D%20host_with_port%0A%20%20%20%20%20%20%20%20.rsplit_once%28'%3A'%29%0A%20%20%20%20%20%20%20%20.map_or%28host_with_port%2C%20%7C%28host%2C%20_%29%7C%20host%29%3B%0A%20%20%20%20non_empty_trimmed%28host%29.map%28str%3A%3Ato_string%29%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Ftui%2Fsrc%2Fllm_client%2Fmod.rs%3A225-232%0A%60classify_api_key_prefix%60%20calls%20%60trim_start%28%29%60%20before%20checking%20for%20the%20%60tp-%60%20prefix%2C%20but%20%60public_key_prefix%60%20%28called%20by%20%60redacted_key_fingerprint%60%20on%20the%20same%20value%29%20does%20not%20trim%20at%20all.%20Both%20functions%20receive%20a%20value%20already%20stripped%20by%20%60non_empty_trimmed%60%2C%20so%20there%20is%20no%20observable%20difference%20%E2%80%94%20but%20the%20inconsistency%20is%20mildly%20confusing.%20Either%20both%20should%20rely%20on%20the%20pre-trimmed%20input%20or%20neither%20should.%0A%0A%60%60%60suggestion%0A%23%5Bmust_use%5D%0Apub%20fn%20classify_api_key_prefix%28api_key%3A%20%26str%29%20-%3E%20%26'static%20str%20%7B%0A%20%20%20%20if%20api_key.starts_with%28%22tp-%22%29%20%7B%0A%20%20%20%20%20%20%20%20%22Xiaomi%20MiMo%20Token%20Plan%20key%22%0A%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%22API%20key%22%0A%20%20%20%20%7D%0A%7D%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2792&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Ftui%2Fsrc%2Fllm_client%2Fmod.rs%3A489-492%0A%60from_http_response_with_auth_context%60%20is%20%60pub%60%20but%20does%20not%20document%20that%20the%20caller%20is%20responsible%20for%20redacting%20API%20key%20material%20from%20%60body%60%20before%20passing%20it%20in.%20The%20peer%20method%20%60from_http_response_with_request_context%60%20does%20this%20automatically%20%E2%80%94%20but%20a%20future%20caller%20of%20the%20lower-level%20method%20who%20passes%20an%20unredacted%20response%20body%20%28e.g.%20one%20that%20contains%20a%20reflected%20key%20in%20the%20error%20text%29%20would%20silently%20expose%20the%20raw%20key%20in%20every%20rendered%20error%20message%2C%20which%20is%20exactly%20the%20leak%20this%20PR%20was%20designed%20to%20prevent.%20A%20doc%20note%20makes%20the%20contract%20explicit.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Constructs%20an%20%60LlmError%60%20from%20HTTP%20status%20code%20and%20response%20body%2C%20with%0A%20%20%20%20%2F%2F%2F%20optional%20structured%20details%20for%20authentication%20failures.%0A%20%20%20%20%2F%2F%2F%0A%20%20%20%20%2F%2F%2F%20%23%20Security%20note%0A%20%20%20%20%2F%2F%2F%20%60body%60%20is%20stored%20verbatim%20in%20the%20error%20message.%20Callers%20must%20ensure%20any%0A%20%20%20%20%2F%2F%2F%20API%20key%20material%20has%20been%20removed%20from%20it%20before%20calling%20this%20method.%0A%20%20%20%20%2F%2F%2F%20Prefer%20%5B%60Self%3A%3Afrom_http_response_with_request_context%60%5D%20when%20the%20raw%0A%20%20%20%20%2F%2F%2F%20API%20key%20is%20available%20%E2%80%94%20it%20performs%20redaction%20automatically.%0A%20%20%20%20%23%5Bmust_use%5D%0A%20%20%20%20pub%20fn%20from_http_response_with_auth_context%28%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Ftui%2Fsrc%2Fllm_client%2Fmod.rs%3A239-249%0A%60base_url_host%60%20strips%20the%20scheme%20and%20path%20but%20keeps%20the%20port%2C%20so%20a%20URL%20like%20%60https%3A%2F%2Fapi.example.com%3A8443%2Fv1%60%20produces%20%60api.example.com%3A8443%60.%20The%20field%20and%20the%20display%20label%20both%20say%20%22host%22%2C%20which%20normally%20means%20the%20hostname%20without%20a%20port.%20This%20is%20not%20a%20security%20concern%20since%20ports%20are%20not%20sensitive%2C%20but%20it%20is%20a%20naming%20mismatch%20that%20could%20confuse%20users%20reading%20the%20error%20message%20%28%22base%20URL%20host%3A%20api.example.com%3A8443%22%20looks%20odd%29.%20Consider%20stripping%20the%20port%20or%20renaming%20to%20%22base%20URL%20authority%22.%0A%0A%60%60%60suggestion%0Afn%20base_url_host%28base_url%3A%20%26str%29%20-%3E%20Option%3CString%3E%20%7B%0A%20%20%20%20let%20base_url%20%3D%20non_empty_trimmed%28base_url%29%3F%3B%0A%20%20%20%20let%20without_scheme%20%3D%20base_url%0A%20%20%20%20%20%20%20%20.split_once%28%22%3A%2F%2F%22%29%0A%20%20%20%20%20%20%20%20.map_or%28base_url%2C%20%7C%28_%2C%20rest%29%7C%20rest%29%3B%0A%20%20%20%20let%20authority%20%3D%20without_scheme.split%28'%2F'%29.next%28%29.unwrap_or%28without_scheme%29%3B%0A%20%20%20%20let%20host_with_port%20%3D%20authority%0A%20%20%20%20%20%20%20%20.rsplit_once%28'%40'%29%0A%20%20%20%20%20%20%20%20.map_or%28authority%2C%20%7C%28_%2C%20host%29%7C%20host%29%3B%0A%20%20%20%20%2F%2F%20Strip%20port%20so%20the%20label%20%22base%20URL%20host%22%20is%20accurate.%0A%20%20%20%20let%20host%20%3D%20host_with_port%0A%20%20%20%20%20%20%20%20.rsplit_once%28'%3A'%29%0A%20%20%20%20%20%20%20%20.map_or%28host_with_port%2C%20%7C%28host%2C%20_%29%7C%20host%29%3B%0A%20%20%20%20non_empty_trimmed%28host%29.map%28str%3A%3Ato_string%29%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Ftui%2Fsrc%2Fllm_client%2Fmod.rs%3A225-232%0A%60classify_api_key_prefix%60%20calls%20%60trim_start%28%29%60%20before%20checking%20for%20the%20%60tp-%60%20prefix%2C%20but%20%60public_key_prefix%60%20%28called%20by%20%60redacted_key_fingerprint%60%20on%20the%20same%20value%29%20does%20not%20trim%20at%20all.%20Both%20functions%20receive%20a%20value%20already%20stripped%20by%20%60non_empty_trimmed%60%2C%20so%20there%20is%20no%20observable%20difference%20%E2%80%94%20but%20the%20inconsistency%20is%20mildly%20confusing.%20Either%20both%20should%20rely%20on%20the%20pre-trimmed%20input%20or%20neither%20should.%0A%0A%60%60%60suggestion%0A%23%5Bmust_use%5D%0Apub%20fn%20classify_api_key_prefix%28api_key%3A%20%26str%29%20-%3E%20%26'static%20str%20%7B%0A%20%20%20%20if%20api_key.starts_with%28%22tp-%22%29%20%7B%0A%20%20%20%20%20%20%20%20%22Xiaomi%20MiMo%20Token%20Plan%20key%22%0A%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%22API%20key%22%0A%20%20%20%20%7D%0A%7D%0A%60%60%60%0A%0A&pr=2792&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(tui): enrich auth errors with provid..."](https://github.com/hmbown/codewhale/commit/d9e919d95a649c005c49781bafc66a7542dc8914) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35848175)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->