### PR TITLE
test(config): isolate provider chain runtime resolution

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -5394,6 +5394,8 @@ fallback_providers = ["deepseek", "openrouter"]
 
     #[test]
     fn fallback_providers_do_not_change_runtime_resolution() {
+        let _lock = env_lock();
+        let _env = EnvGuard::without_deepseek_runtime_overrides();
         let config = ConfigToml {
             provider: ProviderKind::NvidiaNim,
             fallback_providers: vec![ProviderKind::Deepseek],


### PR DESCRIPTION
## Summary
- fix the Windows-only CI failure from #2762 after #2779
- guard the dormant provider fallback runtime-resolution test with the existing env mutex and EnvGuard
- keep the assertion unchanged: `fallback_providers` must not change the selected runtime provider

## Testing
- `cargo test -p codewhale-config --locked fallback_providers_do_not_change_runtime_resolution -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/release/check-versions.sh`