### PR TITLE
fix(tui): expose external URL opener on unsupported targets

### DIFF
--- a/.github/AUTHOR_MAP
+++ b/.github/AUTHOR_MAP
@@ -74,6 +74,9 @@ xrnc@outlook.com = elowen53 <88364845+elowen53@users.noreply.github.com>
 CrepuscularIRIS = CrepuscularIRIS <126939795+CrepuscularIRIS@users.noreply.github.com>
 chnjames = chnjames <44110547+chnjames@users.noreply.github.com>
 ChaceLyee2101 = ChaceLyee2101 <95995339+ChaceLyee2101@users.noreply.github.com>
+ci4ic4 = ci4ic4 <6495973+ci4ic4@users.noreply.github.com>
+Chavdar Ivanov = ci4ic4 <6495973+ci4ic4@users.noreply.github.com>
+ci4ic4@gmail.com = ci4ic4 <6495973+ci4ic4@users.noreply.github.com>
 AresNing = AresNing <49557311+AresNing@users.noreply.github.com>
 
 shenjackyuanjie = shenjackyuanjie <54507071+shenjackyuanjie@users.noreply.github.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Browser-opening actions now compile on non-desktop targets by delegating the
+  unsupported-platform error to the shared URL opener instead of hiding the TUI
+  wrapper behind a narrower macOS/Linux/Windows cfg. Thanks @ci4ic4 for the
+  NetBSD/pkgsrc packaging report and fix (#2789).
 - MCP tool routing now preserves server names that contain underscores.
   `parse_prefixed_name` matches the qualified `mcp_<server>_<tool>` name against
   the set of registered server names and prefers the longest match, so tools on

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -161,6 +161,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Browser-opening actions now compile on non-desktop targets by delegating the
+  unsupported-platform error to the shared URL opener instead of hiding the TUI
+  wrapper behind a narrower macOS/Linux/Windows cfg. Thanks @ci4ic4 for the
+  NetBSD/pkgsrc packaging report and fix (#2789).
 - MCP tool routing now preserves server names that contain underscores.
   `parse_prefixed_name` matches the qualified `mcp_<server>_<tool>` name against
   the set of registered server names and prefers the longest match, so tools on

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -6093,7 +6093,6 @@ async fn apply_command_result(
 #[cfg(test)]
 use std::process::{Command, Stdio};
 
-#[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
 fn open_external_url(url: &str) -> Result<()> {
     crate::utils::open_url(url)
 }


### PR DESCRIPTION
## Summary
- harvest #2789's non-desktop compile fix
- make `open_external_url` available on every target so the unconditional `AppAction::OpenExternalUrl` arm compiles
- keep unsupported-platform behavior delegated to `crate::utils::open_url`
- add @ci4ic4 to `.github/AUTHOR_MAP` and credit the NetBSD/pkgsrc packaging report

## Credit
Harvested from PR #2789 by @ci4ic4.
Found while packaging CodeWhale 0.8.53 for pkgsrc on NetBSD.

## Testing
- `cargo test -p codewhale-tui --locked open_url -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/release/check-versions.sh`
- `python3 scripts/check-coauthor-trailers.py --range origin/codex/v0.9.0-stewardship..HEAD --check-authors`