### PR TITLE
test(tui): satisfy all-targets clippy map_or lint

### DIFF
--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -7379,7 +7379,7 @@ async fn provider_switch_auth_error_restores_previous_provider_and_model() {
     assert!(
         app.status_message
             .as_deref()
-            .map_or(true, |status| !status.contains("Provider switch failed")),
+            .is_none_or(|status| !status.contains("Provider switch failed")),
         "status message is set by the async event loop after engine respawn"
     );
 }


### PR DESCRIPTION
## Summary
- replaces a test-only `map_or(true, ...)` assertion with `is_none_or(...)`
- unblocks the stricter all-targets clippy release-preflight path without changing runtime behavior

## Verification
- `cargo clippy -p codewhale-tui --locked --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/release/check-versions.sh`
