### PR TITLE
feat(tui): add Hugging Face env aliases

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -248,7 +248,7 @@ max_subagents = 10 # optional (1-20)
 #   SGLang:    SGLANG_BASE_URL, SGLANG_MODEL, optional SGLANG_API_KEY
 #   vLLM:      VLLM_BASE_URL, VLLM_MODEL, optional VLLM_API_KEY
 #   Ollama:    OLLAMA_BASE_URL, OLLAMA_MODEL, optional OLLAMA_API_KEY
-#   Hugging Face: HUGGINGFACE_API_KEY (or HF_TOKEN), HUGGINGFACE_BASE_URL, HUGGINGFACE_MODEL
+#   Hugging Face: HUGGINGFACE_API_KEY (or HF_TOKEN), HUGGINGFACE_BASE_URL (or HF_BASE_URL), HUGGINGFACE_MODEL (or HF_MODEL)
 #
 # Custom DeepSeek-compatible APIs usually do not need a new provider table:
 # set `provider = "deepseek"` and override [providers.deepseek].base_url/model.
@@ -385,6 +385,8 @@ max_subagents = 10 # optional (1-20)
 # model = "deepseek-coder:1.3b"             # or any local Ollama tag
 
 # Hugging Face Inference Providers (https://huggingface.co/docs/api-inference)
+# Env var aliases: HUGGINGFACE_API_KEY / HF_TOKEN, HUGGINGFACE_BASE_URL / HF_BASE_URL,
+#                  HUGGINGFACE_MODEL / HF_MODEL
 [providers.huggingface]
 # api_key = "YOUR_HF_TOKEN"
 # base_url = "https://router.huggingface.co/v1"

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -3526,7 +3526,8 @@ fn apply_env_overrides(config: &mut Config) {
             .base_url = Some(value);
     }
     if matches!(config.api_provider(), ApiProvider::Huggingface)
-        && let Ok(value) = std::env::var("HUGGINGFACE_BASE_URL")
+        && let Ok(value) =
+            std::env::var("HUGGINGFACE_BASE_URL").or_else(|_| std::env::var("HF_BASE_URL"))
         && !value.trim().is_empty()
     {
         config
@@ -3739,7 +3740,7 @@ fn apply_env_overrides(config: &mut Config) {
             .model = Some(value);
     }
     if matches!(config.api_provider(), ApiProvider::Huggingface)
-        && let Ok(value) = std::env::var("HUGGINGFACE_MODEL")
+        && let Ok(value) = std::env::var("HUGGINGFACE_MODEL").or_else(|_| std::env::var("HF_MODEL"))
         && !value.trim().is_empty()
     {
         config
@@ -5931,7 +5932,9 @@ mod tests {
         huggingface_api_key: Option<OsString>,
         huggingface_token: Option<OsString>,
         huggingface_base_url: Option<OsString>,
+        hf_base_url: Option<OsString>,
         huggingface_model: Option<OsString>,
+        hf_model: Option<OsString>,
     }
 
     impl EnvGuard {
@@ -6028,7 +6031,9 @@ mod tests {
             let huggingface_api_key_prev = env::var_os("HUGGINGFACE_API_KEY");
             let huggingface_token_prev = env::var_os("HF_TOKEN");
             let huggingface_base_url_prev = env::var_os("HUGGINGFACE_BASE_URL");
+            let hf_base_url_prev = env::var_os("HF_BASE_URL");
             let huggingface_model_prev = env::var_os("HUGGINGFACE_MODEL");
+            let hf_model_prev = env::var_os("HF_MODEL");
             // Safety: test-only environment mutation guarded by a global mutex.
             unsafe {
                 env::set_var("HOME", &home_str);
@@ -6120,7 +6125,9 @@ mod tests {
                 env::remove_var("HUGGINGFACE_API_KEY");
                 env::remove_var("HF_TOKEN");
                 env::remove_var("HUGGINGFACE_BASE_URL");
+                env::remove_var("HF_BASE_URL");
                 env::remove_var("HUGGINGFACE_MODEL");
+                env::remove_var("HF_MODEL");
             }
             Self {
                 home: home_prev,
@@ -6212,7 +6219,9 @@ mod tests {
                 huggingface_api_key: huggingface_api_key_prev,
                 huggingface_token: huggingface_token_prev,
                 huggingface_base_url: huggingface_base_url_prev,
+                hf_base_url: hf_base_url_prev,
                 huggingface_model: huggingface_model_prev,
+                hf_model: hf_model_prev,
             }
         }
     }
@@ -6322,7 +6331,9 @@ mod tests {
                 Self::restore_var("HUGGINGFACE_API_KEY", self.huggingface_api_key.take());
                 Self::restore_var("HF_TOKEN", self.huggingface_token.take());
                 Self::restore_var("HUGGINGFACE_BASE_URL", self.huggingface_base_url.take());
+                Self::restore_var("HF_BASE_URL", self.hf_base_url.take());
                 Self::restore_var("HUGGINGFACE_MODEL", self.huggingface_model.take());
+                Self::restore_var("HF_MODEL", self.hf_model.take());
             }
         }
     }
@@ -10349,21 +10360,44 @@ model = "deepseek-ai/deepseek-v4-pro"
             std::process::id(),
             nanos
         ));
-        fs::create_dir_all(&temp_root)?;
-        let _guard = EnvGuard::new(&temp_root);
 
-        unsafe {
-            env::set_var("CODEWHALE_PROVIDER", "huggingface");
-            env::set_var("HUGGINGFACE_API_KEY", "hf-env-key");
-            env::set_var("HUGGINGFACE_BASE_URL", "https://custom-hf.example/v1");
-            env::set_var("HUGGINGFACE_MODEL", "meta-llama/Llama-3-70B");
+        {
+            let long_form_root = temp_root.join("long-form");
+            fs::create_dir_all(&long_form_root)?;
+            let _guard = EnvGuard::new(&long_form_root);
+
+            unsafe {
+                env::set_var("CODEWHALE_PROVIDER", "huggingface");
+                env::set_var("HUGGINGFACE_API_KEY", "hf-env-key");
+                env::set_var("HUGGINGFACE_BASE_URL", "https://custom-hf.example/v1");
+                env::set_var("HUGGINGFACE_MODEL", "meta-llama/Llama-3-70B");
+            }
+
+            let config = Config::load(None, None)?;
+            assert_eq!(config.api_provider(), ApiProvider::Huggingface);
+            assert_eq!(config.deepseek_api_key()?, "hf-env-key");
+            assert_eq!(config.deepseek_base_url(), "https://custom-hf.example/v1");
+            assert_eq!(config.default_model(), "meta-llama/Llama-3-70B");
         }
 
-        let config = Config::load(None, None)?;
-        assert_eq!(config.api_provider(), ApiProvider::Huggingface);
-        assert_eq!(config.deepseek_api_key()?, "hf-env-key");
-        assert_eq!(config.deepseek_base_url(), "https://custom-hf.example/v1");
-        assert_eq!(config.default_model(), "meta-llama/Llama-3-70B");
+        {
+            let short_form_root = temp_root.join("short-form");
+            fs::create_dir_all(&short_form_root)?;
+            let _guard = EnvGuard::new(&short_form_root);
+
+            unsafe {
+                env::set_var("CODEWHALE_PROVIDER", "huggingface");
+                env::set_var("HF_TOKEN", "hf-env-key");
+                env::set_var("HF_BASE_URL", "https://custom-hf.example/v1");
+                env::set_var("HF_MODEL", "meta-llama/Llama-3-70B");
+            }
+
+            let config = Config::load(None, None)?;
+            assert_eq!(config.api_provider(), ApiProvider::Huggingface);
+            assert_eq!(config.deepseek_api_key()?, "hf-env-key");
+            assert_eq!(config.deepseek_base_url(), "https://custom-hf.example/v1");
+            assert_eq!(config.default_model(), "meta-llama/Llama-3-70B");
+        }
         Ok(())
     }
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -441,6 +441,9 @@ Remaining variables:
 - `NOVITA_BASE_URL`
 - `FIREWORKS_API_KEY`
 - `FIREWORKS_BASE_URL`
+- `HUGGINGFACE_API_KEY` or `HF_TOKEN` (`HF_TOKEN` is a fallback alias accepted when provider is `huggingface`)
+- `HUGGINGFACE_BASE_URL` or `HF_BASE_URL`
+- `HUGGINGFACE_MODEL` or `HF_MODEL`
 - `SILICONFLOW_API_KEY`
 - `SILICONFLOW_BASE_URL`
 - `SILICONFLOW_MODEL`


### PR DESCRIPTION
Harvests PR #2780 by @hongqitai for the v0.9 stewardship branch.

Credit
- PR author: @hongqitai

Changes
- Adds `HF_BASE_URL` as the short fallback alias for `HUGGINGFACE_BASE_URL` when the active provider is `huggingface`.
- Adds `HF_MODEL` as the short fallback alias for `HUGGINGFACE_MODEL` when the active provider is `huggingface`.
- Keeps `HF_TOKEN` documented as the existing API-key fallback alias.
- Updates the sample config and configuration docs with the Hugging Face alias set.

Verification
- `cargo test -p codewhale-tui --locked huggingface_env_overrides_key_base_url_and_model --all-features -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-features --locked -- -D warnings`
- `./scripts/release/check-versions.sh`
- `git diff --cached --check`
- `git diff --check`
- `python3 scripts/check-coauthor-trailers.py --range origin/codex/v0.9.0-stewardship..HEAD --check-authors`
