### PR TITLE
fix(tui): surface subagent branch status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Sub-agent shell completions now refresh the workspace branch/status chip
+  immediately, and `/subagents` plus the Agents sidebar show each sub-agent's
+  current workspace branch when it is running in a child worktree.
 - Authentication failures now include redacted request context such as provider,
   base URL authority, model, key source, key type, and key fingerprint, making
   stale provider, endpoint, or API-key state diagnosable without exposing the

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -182,6 +182,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Sub-agent shell completions now refresh the workspace branch/status chip
+  immediately, and `/subagents` plus the Agents sidebar show each sub-agent's
+  current workspace branch when it is running in a child worktree.
 - Authentication failures now include redacted request context such as provider,
   base URL authority, model, key source, key type, and key fingerprint, making
   stale provider, endpoint, or API-key state diagnosable without exposing the

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -27,6 +27,7 @@ use uuid::Uuid;
 use crate::client::DeepSeekClient;
 use crate::config::MAX_SUBAGENTS;
 use crate::core::events::Event;
+use crate::dependencies::{ExternalTool, Git};
 use crate::llm_client::LlmClient;
 use crate::models::{ContentBlock, Message, MessageRequest, MessageResponse, SystemPrompt, Tool};
 use crate::tools::handle::VarHandle;
@@ -585,6 +586,10 @@ pub struct SubAgentResult {
     pub agent_id: String,
     pub context_mode: String,
     pub fork_context: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace: Option<PathBuf>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub git_branch: Option<String>,
     pub agent_type: SubAgentType,
     pub assignment: SubAgentAssignment,
     #[serde(default)]
@@ -607,6 +612,29 @@ pub struct SubAgentResult {
 
 fn is_false(b: &bool) -> bool {
     !*b
+}
+
+fn current_git_branch(workspace: &Path) -> Option<String> {
+    let branch = run_git(workspace, &["rev-parse", "--abbrev-ref", "HEAD"])?;
+    let branch = branch.trim();
+    if branch.is_empty() {
+        return None;
+    }
+    if branch != "HEAD" {
+        return Some(branch.to_string());
+    }
+
+    let short_hash = run_git(workspace, &["rev-parse", "--short", "HEAD"])?;
+    let short_hash = short_hash.trim();
+    (!short_hash.is_empty()).then(|| format!("detached:{short_hash}"))
+}
+
+fn run_git(workspace: &Path, args: &[&str]) -> Option<String> {
+    let output = Git::output(args, workspace).ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).to_string())
 }
 
 #[derive(Debug, Clone, Default)]
@@ -715,6 +743,8 @@ struct PersistedSubAgent {
     session_name: Option<String>,
     #[serde(default)]
     fork_context: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    workspace: Option<PathBuf>,
     agent_type: SubAgentType,
     prompt: String,
     assignment: SubAgentAssignment,
@@ -1064,6 +1094,7 @@ pub struct SubAgent {
     /// against the manager's `current_session_boot_id` to classify the
     /// agent as in-session vs prior-session at list time.
     pub session_boot_id: String,
+    pub workspace: PathBuf,
     input_tx: Option<mpsc::UnboundedSender<SubAgentInput>>,
     task_handle: Option<JoinHandle<()>>,
 }
@@ -1081,6 +1112,7 @@ impl SubAgent {
         nickname: Option<String>,
         allowed_tools: Option<Vec<String>>,
         input_tx: mpsc::UnboundedSender<SubAgentInput>,
+        workspace: PathBuf,
         session_boot_id: String,
     ) -> Self {
         let session_name = id.clone();
@@ -1103,6 +1135,7 @@ impl SubAgent {
             last_activity_at: started_at,
             allowed_tools,
             session_boot_id,
+            workspace,
             input_tx: Some(input_tx),
             task_handle: None,
         }
@@ -1116,6 +1149,8 @@ impl SubAgent {
             agent_id: self.id.clone(),
             context_mode: if self.fork_context { "forked" } else { "fresh" }.to_string(),
             fork_context: self.fork_context,
+            workspace: Some(self.workspace.clone()),
+            git_branch: current_git_branch(&self.workspace),
             agent_type: self.agent_type.clone(),
             assignment: self.assignment.clone(),
             model: self.model.clone(),
@@ -1213,6 +1248,7 @@ impl SubAgentManager {
                 id: agent.id.clone(),
                 session_name: Some(agent.session_name.clone()),
                 fork_context: agent.fork_context,
+                workspace: Some(agent.workspace.clone()),
                 agent_type: agent.agent_type.clone(),
                 prompt: agent.prompt.clone(),
                 assignment: agent.assignment.clone(),
@@ -1289,6 +1325,9 @@ impl SubAgentManager {
                     .filter(|name| !name.trim().is_empty())
                     .unwrap_or_else(|| persisted.id.clone()),
                 fork_context: persisted.fork_context,
+                workspace: persisted
+                    .workspace
+                    .unwrap_or_else(|| self.workspace.clone()),
                 agent_type: persisted.agent_type,
                 prompt: persisted.prompt,
                 assignment: persisted.assignment,
@@ -1443,6 +1482,7 @@ impl SubAgentManager {
             nickname,
             tools.clone(),
             input_tx,
+            runtime.context.workspace.clone(),
             self.current_session_boot_id.clone(),
         );
         if let Some(name) = options
@@ -4152,6 +4192,8 @@ async fn run_subagent(
                 }
                 .to_string(),
                 fork_context: fork_context_enabled,
+                workspace: Some(runtime.context.workspace.clone()),
+                git_branch: current_git_branch(&runtime.context.workspace),
                 agent_type: agent_type.clone(),
                 assignment: assignment.clone(),
                 model: runtime.model.clone(),
@@ -4254,6 +4296,8 @@ async fn run_subagent(
                     agent_id: agent_id.clone(),
                     context_mode: if fork_context_enabled { "forked" } else { "fresh" }.to_string(),
                     fork_context: fork_context_enabled,
+                    workspace: Some(runtime.context.workspace.clone()),
+                    git_branch: current_git_branch(&runtime.context.workspace),
                     agent_type: agent_type.clone(),
                     assignment: assignment.clone(),
                     model: runtime.model.clone(),
@@ -4350,6 +4394,8 @@ async fn run_subagent(
                                     agent_id: agent_id.clone(),
                                     context_mode: if fork_context_enabled { "forked" } else { "fresh" }.to_string(),
                                     fork_context: fork_context_enabled,
+                                    workspace: Some(runtime.context.workspace.clone()),
+                                    git_branch: current_git_branch(&runtime.context.workspace),
                                     agent_type: agent_type.clone(),
                                     assignment: assignment.clone(),
                                     model: runtime.model.clone(),
@@ -4596,6 +4642,8 @@ async fn run_subagent(
         }
         .to_string(),
         fork_context: fork_context_enabled,
+        workspace: Some(runtime.context.workspace.clone()),
+        git_branch: current_git_branch(&runtime.context.workspace),
         agent_type,
         assignment,
         model: runtime.model.clone(),

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use axum::{Json, Router, routing::post};
+use std::process::Command;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use tempfile::tempdir;
 
@@ -13,6 +14,8 @@ fn make_snapshot(status: SubAgentStatus) -> SubAgentResult {
         agent_id: "agent_test".to_string(),
         context_mode: "fresh".to_string(),
         fork_context: false,
+        workspace: None,
+        git_branch: None,
         agent_type: SubAgentType::General,
         assignment: make_assignment(),
         model: "deepseek-v4-flash".to_string(),
@@ -24,6 +27,58 @@ fn make_snapshot(status: SubAgentStatus) -> SubAgentResult {
         duration_ms: 0,
         from_prior_session: false,
     }
+}
+
+fn init_subagent_git_repo() -> tempfile::TempDir {
+    let dir = tempdir().expect("tempdir");
+
+    let init = Command::new("git")
+        .arg("init")
+        .current_dir(dir.path())
+        .output()
+        .expect("git init should run");
+    assert!(
+        init.status.success(),
+        "git init failed: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    let commit = Command::new("git")
+        .args([
+            "-c",
+            "user.name=codewhale Tests",
+            "-c",
+            "user.email=tests@example.com",
+            "-c",
+            "commit.gpgsign=false",
+            "commit",
+            "--allow-empty",
+            "-m",
+            "init",
+        ])
+        .current_dir(dir.path())
+        .output()
+        .expect("git commit should run");
+    assert!(
+        commit.status.success(),
+        "git commit failed: {}",
+        String::from_utf8_lossy(&commit.stderr)
+    );
+
+    dir
+}
+
+fn git(repo: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .expect("git command should run");
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 }
 
 fn text_message(role: &str, text: &str) -> Message {
@@ -1110,6 +1165,7 @@ async fn test_wait_for_result_reports_timeout_when_still_running() {
         Some("Blue".to_string()),
         Some(vec!["read_file".to_string()]),
         input_tx,
+        PathBuf::from("."),
         "boot_test".to_string(),
     );
     let agent_id = agent.id.clone();
@@ -1142,6 +1198,7 @@ async fn agent_eval_on_completed_session_returns_full_projection_not_running_err
         Some("Blue".to_string()),
         Some(vec!["read_file".to_string()]),
         input_tx,
+        PathBuf::from("."),
         "boot_test".to_string(),
     );
     let full_output = "Per-issue analysis:\n".to_string() + &"detail line\n".repeat(400);
@@ -1197,6 +1254,7 @@ async fn agent_eval_resolves_session_via_agent_name_alias() {
         Some("Blue".to_string()),
         Some(vec!["read_file".to_string()]),
         input_tx,
+        PathBuf::from("."),
         "boot_test".to_string(),
     );
     agent.session_name = "researcher".to_string();
@@ -1237,13 +1295,14 @@ async fn api_timeout_preserves_checkpoint_and_agent_eval_continues_from_it() {
         Some("Blue".to_string()),
         Some(vec![]),
         task_input_tx,
+        tmp.path().to_path_buf(),
         "boot_test".to_string(),
     );
     manager.write().await.agents.insert(agent_id.clone(), agent);
 
     let (client, calls, bodies) =
         delayed_chat_client(Duration::from_millis(80), "resumed answer").await;
-    let mut runtime = stub_runtime().with_step_api_timeout(Duration::from_millis(10));
+    let mut runtime = stub_runtime().with_step_api_timeout(Duration::from_millis(50));
     runtime.client = client;
     runtime.manager = Arc::clone(&manager);
     runtime.context = ToolContext::new(tmp.path());
@@ -1293,6 +1352,17 @@ async fn api_timeout_preserves_checkpoint_and_agent_eval_continues_from_it() {
             .any(|message| message_text(message).contains("Inspect checkpoint behavior")),
         "checkpoint should preserve local child prompt: {checkpoint:?}"
     );
+
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            if calls.load(Ordering::SeqCst) >= 1 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("first timed-out API attempt should reach the test server");
 
     let ctx = runtime.context.clone();
     let tool = AgentEvalTool::new(Arc::clone(&manager));
@@ -1371,6 +1441,7 @@ async fn spawn_duplicate_session_name_error_names_conflicting_agent() {
         Some("Blue".to_string()),
         Some(vec!["read_file".to_string()]),
         input_tx,
+        PathBuf::from("."),
         "boot_test".to_string(),
     );
     existing.session_name = "researcher".to_string();
@@ -1422,6 +1493,7 @@ async fn test_running_count_counts_only_agents_with_live_task_handles() {
         Some("Blue".to_string()),
         Some(vec!["read_file".to_string()]),
         input_tx,
+        PathBuf::from("."),
         "boot_test".to_string(),
     );
     agent.status = SubAgentStatus::Running;
@@ -1454,6 +1526,7 @@ fn test_running_count_ignores_running_status_without_task_handle() {
         Some("Blue".to_string()),
         Some(vec!["read_file".to_string()]),
         input_tx,
+        PathBuf::from("."),
         "boot_test".to_string(),
     );
     agent.status = SubAgentStatus::Running;
@@ -1475,6 +1548,7 @@ async fn test_running_count_counts_running_agents_until_status_reconciles() {
         Some("Blue".to_string()),
         Some(vec!["read_file".to_string()]),
         input_tx,
+        PathBuf::from("."),
         "boot_test".to_string(),
     );
     agent.status = SubAgentStatus::Running;
@@ -1502,6 +1576,7 @@ async fn cleanup_auto_cancels_stale_running_agent_and_releases_slot() {
         Some("Blue".to_string()),
         Some(vec!["read_file".to_string()]),
         input_tx,
+        PathBuf::from("."),
         "boot_test".to_string(),
     );
     agent.task_handle = Some(tokio::spawn(async {
@@ -1546,6 +1621,7 @@ async fn cleanup_keeps_recent_running_agent() {
         Some("Blue".to_string()),
         Some(vec!["read_file".to_string()]),
         input_tx,
+        PathBuf::from("."),
         "boot_test".to_string(),
     );
     agent.last_activity_at = Instant::now();
@@ -1583,6 +1659,7 @@ async fn touch_refreshes_stale_running_agent_heartbeat() {
         Some("Blue".to_string()),
         Some(vec!["read_file".to_string()]),
         input_tx,
+        PathBuf::from("."),
         "boot_test".to_string(),
     );
     agent.task_handle = Some(tokio::spawn(async {
@@ -1617,6 +1694,7 @@ fn test_assign_updates_running_agent_and_sends_message() {
         Some("Blue".to_string()),
         Some(vec!["read_file".to_string()]),
         input_tx,
+        PathBuf::from("."),
         "boot_test".to_string(),
     );
     let agent_id = agent.id.clone();
@@ -1655,6 +1733,7 @@ fn test_assign_rejects_message_for_non_running_agent() {
         Some("Blue".to_string()),
         Some(vec!["read_file".to_string()]),
         input_tx,
+        PathBuf::from("."),
         "boot_test".to_string(),
     );
     agent.status = SubAgentStatus::Completed;
@@ -1680,6 +1759,7 @@ fn test_assign_updates_non_running_metadata_without_message() {
         Some("Blue".to_string()),
         Some(vec!["read_file".to_string()]),
         input_tx,
+        PathBuf::from("."),
         "boot_test".to_string(),
     );
     agent.status = SubAgentStatus::Completed;
@@ -1716,6 +1796,7 @@ fn test_persist_and_reload_marks_running_agent_as_interrupted() {
         Some("Blue".to_string()),
         Some(vec!["read_file".to_string()]),
         input_tx,
+        PathBuf::from("."),
         "boot_test".to_string(),
     );
     let running_id = running.id.clone();
@@ -1752,6 +1833,7 @@ fn persist_and_reload_preserves_checkpoint_for_interrupted_running_agent() {
         Some("Blue".to_string()),
         Some(vec!["read_file".to_string()]),
         input_tx,
+        PathBuf::from("."),
         "boot_test".to_string(),
     );
     running.checkpoint = Some(make_checkpoint(
@@ -2573,6 +2655,7 @@ fn insert_prior_session_agent(
         None,
         None,
         input_tx,
+        manager.workspace.clone(),
         boot_id.to_string(),
     );
     agent.status = status;
@@ -2632,6 +2715,38 @@ fn list_filtered_drops_prior_session_terminals_by_default() {
         .find(|s| s.agent_id == "current_running")
         .unwrap();
     assert!(!current.from_prior_session);
+}
+
+#[test]
+fn list_snapshots_refresh_git_branch_from_agent_workspace() {
+    let repo = init_subagent_git_repo();
+    git(repo.path(), &["checkout", "-b", "feature/agent-old"]);
+
+    let mut manager = SubAgentManager::new(repo.path().to_path_buf(), 5);
+    let current_boot = manager.session_boot_id().to_string();
+    insert_prior_session_agent(
+        &mut manager,
+        "current_running",
+        SubAgentStatus::Running,
+        &current_boot,
+    );
+
+    let listed = manager.list_filtered(false);
+    let agent = listed
+        .iter()
+        .find(|agent| agent.agent_id == "current_running")
+        .expect("current agent should be listed");
+    assert_eq!(agent.git_branch.as_deref(), Some("feature/agent-old"));
+    assert_eq!(agent.workspace.as_deref(), Some(repo.path()));
+
+    git(repo.path(), &["checkout", "-b", "feature/agent-new"]);
+
+    let refreshed = manager.list_filtered(false);
+    let agent = refreshed
+        .iter()
+        .find(|agent| agent.agent_id == "current_running")
+        .expect("current agent should still be listed");
+    assert_eq!(agent.git_branch.as_deref(), Some("feature/agent-new"));
 }
 
 #[test]
@@ -2850,6 +2965,7 @@ async fn run_subagent_task_emits_parent_completion_before_terminal_update() {
         None,
         None,
         task_input_tx,
+        PathBuf::from("."),
         "boot_test".to_string(),
     );
     agent.status = SubAgentStatus::Running;

--- a/crates/tui/src/tui/sidebar.rs
+++ b/crates/tui/src/tui/sidebar.rs
@@ -1797,6 +1797,7 @@ pub struct SidebarAgentRow {
     pub name: String,
     pub role: String,
     pub status: String,
+    pub git_branch: Option<String>,
     pub progress: Option<String>,
     pub steps_taken: u32,
     pub duration_ms: Option<u64>,
@@ -1838,6 +1839,7 @@ fn sidebar_agent_rows(app: &App) -> Vec<SidebarAgentRow> {
                 name: agent.nickname.clone().unwrap_or_else(|| agent.name.clone()),
                 role: agent.agent_type.as_str().to_string(),
                 status: subagent_status_text(&agent.status).to_string(),
+                git_branch: agent.git_branch.clone(),
                 progress,
                 steps_taken: agent.steps_taken,
                 duration_ms: Some(agent.duration_ms),
@@ -1859,6 +1861,7 @@ fn sidebar_agent_rows(app: &App) -> Vec<SidebarAgentRow> {
                 name: id.clone(),
                 role: "agent".to_string(),
                 status: "running".to_string(),
+                git_branch: None,
                 progress: Some(progress.clone()),
                 steps_taken: 0,
                 duration_ms: app.agent_activity_started_at.map(|started| {
@@ -1967,6 +1970,9 @@ pub fn subagent_panel_lines(
         if row.steps_taken > 0 {
             detail_parts.push(format!("{} step(s)", row.steps_taken));
         }
+        if let Some(branch) = row.git_branch.as_deref() {
+            detail_parts.push(format!("branch {branch}"));
+        }
         if let Some(duration) = row.duration_ms {
             detail_parts.push(format_duration_ms(duration));
         }
@@ -2059,6 +2065,9 @@ fn subagent_panel_hover_texts(
         detail_parts.push(row.id.clone());
         if row.steps_taken > 0 {
             detail_parts.push(format!("{} step(s)", row.steps_taken));
+        }
+        if let Some(branch) = row.git_branch.as_deref() {
+            detail_parts.push(format!("branch {branch}"));
         }
         if let Some(duration) = row.duration_ms {
             detail_parts.push(format_duration_ms(duration));
@@ -3216,6 +3225,7 @@ mod tests {
                 name: "check-docs-mcp".to_string(),
                 role: "explore".to_string(),
                 status: "running".to_string(),
+                git_branch: Some("feature/docs".to_string()),
                 progress: Some("step 2/3: running tool 'read_file'".to_string()),
                 steps_taken: 2,
                 duration_ms: Some(22_000),
@@ -3225,6 +3235,7 @@ mod tests {
                 name: "check-install-docs".to_string(),
                 role: "general".to_string(),
                 status: "done".to_string(),
+                git_branch: None,
                 progress: Some("SUMMARY: docs checked".to_string()),
                 steps_taken: 5,
                 duration_ms: Some(21_000),
@@ -3466,6 +3477,7 @@ mod tests {
             name: "sidebar-detail-worker-with-long-name".to_string(),
             role: "worker".to_string(),
             status: "running".to_string(),
+            git_branch: Some("codex/sidebar-hover".to_string()),
             progress: Some(long_progress.to_string()),
             steps_taken: 9,
             duration_ms: Some(12_345),

--- a/crates/tui/src/tui/subagent_routing.rs
+++ b/crates/tui/src/tui/subagent_routing.rs
@@ -7,9 +7,11 @@ use crate::tools::subagent::{MailboxMessage, SubAgentResult, SubAgentStatus};
 use crate::tui::app::{App, AppMode, TaskPanelEntry};
 use crate::tui::history::{HistoryCell, SubAgentCell, summarize_tool_output};
 use crate::tui::pager::PagerView;
+use crate::tui::tool_routing::refreshes_workspace_context_on_completion;
 use crate::tui::widgets::agent_card::{
     AgentLifecycle, DelegateCard, FanoutCard, apply_to_delegate, apply_to_fanout,
 };
+use crate::tui::workspace_context;
 
 pub(super) fn running_agent_count(app: &App) -> usize {
     let mut ids: std::collections::HashSet<&str> =
@@ -88,6 +90,14 @@ pub(super) fn sort_subagents_in_place(agents: &mut [SubAgentResult]) {
     });
 }
 
+pub(super) fn subagent_message_refreshes_workspace_context(message: &MailboxMessage) -> bool {
+    matches!(
+        message,
+        MailboxMessage::ToolCallCompleted { tool_name, .. }
+            if refreshes_workspace_context_on_completion(tool_name)
+    )
+}
+
 /// Route a `MailboxMessage` envelope to the matching in-transcript card,
 /// allocating a `DelegateCard` or `FanoutCard` on first sight (issue #128).
 pub(super) fn handle_subagent_mailbox(app: &mut App, seq: u64, message: &MailboxMessage) {
@@ -106,6 +116,9 @@ pub(super) fn handle_subagent_mailbox(app: &mut App, seq: u64, message: &Mailbox
     // is special — it always belongs to the active fanout card if one
     // exists; otherwise it seeds a new one.
     let agent_id = message.agent_id().to_string();
+    if subagent_message_refreshes_workspace_context(message) {
+        workspace_context::refresh_now(app, Instant::now());
+    }
 
     if matches!(message, MailboxMessage::ChildSpawned { .. })
         && let Some(idx) = app.last_fanout_card_index

--- a/crates/tui/src/tui/tool_routing.rs
+++ b/crates/tui/src/tui/tool_routing.rs
@@ -864,7 +864,7 @@ fn is_exec_tool(name: &str) -> bool {
     )
 }
 
-fn refreshes_workspace_context_on_completion(name: &str) -> bool {
+pub(super) fn refreshes_workspace_context_on_completion(name: &str) -> bool {
     matches!(
         name,
         "exec_shell"

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -99,7 +99,8 @@ use crate::tui::shell_job_routing::{
 use crate::tui::streaming_thinking;
 use crate::tui::subagent_routing::{
     format_task_list, handle_subagent_mailbox, open_task_pager, reconcile_subagent_activity_state,
-    running_agent_count, sort_subagents_in_place, task_mode_label, task_summary_to_panel_entry,
+    running_agent_count, sort_subagents_in_place, subagent_message_refreshes_workspace_context,
+    task_mode_label, task_summary_to_panel_entry,
 };
 #[cfg(test)]
 use crate::tui::tool_routing::exploring_label;
@@ -2244,7 +2245,12 @@ async fn run_event_loop(
                         // full list available via /agents command.
                     }
                     EngineEvent::SubAgentMailbox { seq, message } => {
+                        let should_refresh_subagents =
+                            subagent_message_refreshes_workspace_context(&message);
                         handle_subagent_mailbox(app, seq, &message);
+                        if should_refresh_subagents {
+                            let _ = engine_handle.send(Op::ListSubAgents).await;
+                        }
                         transcript_batch_updated = true;
                     }
                     EngineEvent::ApprovalRequired {

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -3103,6 +3103,8 @@ fn make_subagent(
         agent_id: id.to_string(),
         context_mode: "fresh".to_string(),
         fork_context: false,
+        workspace: None,
+        git_branch: None,
         agent_type: crate::tools::subagent::SubAgentType::General,
         assignment: crate::tools::subagent::SubAgentAssignment {
             objective: format!("objective-{id}"),
@@ -4641,6 +4643,74 @@ fn completed_task_shell_wait_refreshes_workspace_context_before_ttl() {
         .expect("task shell completion should refresh context");
     assert!(
         refreshed.contains("feature/task-new"),
+        "expected refreshed branch in {refreshed:?}"
+    );
+}
+
+#[test]
+fn completed_subagent_shell_tool_refreshes_workspace_context_before_ttl() {
+    let repo = init_git_repo();
+    let checkout = Command::new("git")
+        .args(["checkout", "-b", "feature/subagent-old"])
+        .current_dir(repo.path())
+        .output()
+        .expect("git checkout should run");
+    assert!(
+        checkout.status.success(),
+        "git checkout failed: {}",
+        String::from_utf8_lossy(&checkout.stderr)
+    );
+
+    let mut app = create_test_app();
+    app.workspace = repo.path().to_path_buf();
+
+    let start = Instant::now();
+    crate::tui::workspace_context::refresh_if_needed(&mut app, start, true);
+    let initial = app
+        .workspace_context
+        .clone()
+        .expect("initial refresh should populate context");
+    assert!(
+        initial.contains("feature/subagent-old"),
+        "expected initial branch in {initial:?}"
+    );
+
+    let checkout = Command::new("git")
+        .args(["checkout", "-b", "feature/subagent-new"])
+        .current_dir(repo.path())
+        .output()
+        .expect("git checkout should run");
+    assert!(
+        checkout.status.success(),
+        "git checkout failed: {}",
+        String::from_utf8_lossy(&checkout.stderr)
+    );
+
+    let before_ttl = start + Duration::from_secs(crate::tui::workspace_context::REFRESH_SECS - 1);
+    crate::tui::workspace_context::refresh_if_needed(&mut app, before_ttl, true);
+    assert_eq!(
+        app.workspace_context.as_deref(),
+        Some(initial.as_str()),
+        "normal refresh should still respect the TTL"
+    );
+
+    handle_subagent_mailbox(
+        &mut app,
+        42,
+        &crate::tools::subagent::MailboxMessage::ToolCallCompleted {
+            agent_id: "agent_branch".to_string(),
+            tool_name: "exec_shell".to_string(),
+            step: 1,
+            ok: true,
+        },
+    );
+
+    let refreshed = app
+        .workspace_context
+        .as_deref()
+        .expect("subagent shell completion should refresh context");
+    assert!(
+        refreshed.contains("feature/subagent-new"),
         "expected refreshed branch in {refreshed:?}"
     );
 }

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -1777,6 +1777,8 @@ fn live_subagent_result(
         agent_id: agent_id.to_string(),
         context_mode: "fresh".to_string(),
         fork_context: false,
+        workspace: None,
+        git_branch: None,
         agent_type,
         assignment: SubAgentAssignment {
             objective: summarize_tool_output(objective),
@@ -2075,6 +2077,25 @@ fn append_subagent_group(
             ]));
         }
 
+        if let Some(branch) = agent.git_branch.as_deref() {
+            let workspace = agent
+                .workspace
+                .as_deref()
+                .and_then(|path| path.file_name())
+                .and_then(|name| name.to_str())
+                .filter(|name| !name.is_empty());
+            let mut branch_detail = format!("branch {branch}");
+            if let Some(workspace) = workspace {
+                branch_detail.push_str(&format!(" @ {workspace}"));
+            }
+            let max_len = content_width.saturating_sub(14);
+            let branch_detail = truncate_view_text(&branch_detail, max_len);
+            lines.push(Line::from(vec![
+                Span::styled("    git: ", Style::default().fg(palette::TEXT_MUTED)),
+                Span::styled(branch_detail, Style::default().fg(palette::DEEPSEEK_SKY)),
+            ]));
+        }
+
         let max_len = content_width.saturating_sub(18);
         let objective = truncate_view_text(&agent.assignment.objective, max_len);
         lines.push(Line::from(vec![
@@ -2276,6 +2297,8 @@ mod tests {
             agent_id: id.to_string(),
             context_mode: "fresh".to_string(),
             fork_context: false,
+            workspace: None,
+            git_branch: None,
             agent_type: SubAgentType::Explore,
             assignment: SubAgentAssignment {
                 objective: "read the docs".to_string(),


### PR DESCRIPTION
## Summary

- Refresh the parent workspace branch/status chip when a sub-agent finishes a shell-like tool call.
- Add workspace and current git branch metadata to sub-agent snapshots, including `agent_list`, `/subagents`, and the Agents sidebar.
- Persist sub-agent workspace paths so reloaded state can still describe where an agent was working.

## Verification

- `cargo test -p codewhale-tui --locked --bin codewhale-tui completed_subagent_shell_tool_refreshes_workspace_context_before_ttl -- --nocapture`
- `cargo test -p codewhale-tui --locked --bin codewhale-tui list_snapshots_refresh_git_branch_from_agent_workspace -- --nocapture`
- `cargo test -p codewhale-tui --locked --bin codewhale-tui subagent -- --nocapture`
- `cargo test -p codewhale-tui --locked --bin codewhale-tui workspace_context -- --nocapture`
- `cargo clippy -p codewhale-tui --locked --all-targets --all-features -- -D warnings`
- `./scripts/release/check-versions.sh`
- `git diff --check`
- `cargo fmt --all -- --check`
- `python3 scripts/check-coauthor-trailers.py --range origin/codex/v0.9.0-stewardship..HEAD --check-authors`
