### PR TITLE
docs: credit VS Code plugin request trail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,10 +43,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   local runtime attach checks, status bar state, and a CodeWhale runtime status
   view. This answers the VS Code GUI lane without exposing chat webviews,
   Agent View, inline edits, or retry/undo runtime endpoints yet (#461, #462,
-  #480, #2580). Thanks @AiurArtanis for the Agent View prompt, @lbcheng888 for
-  the earlier scaffold, and @BigBenLabs, @lzx1545642258, @yangdaowan,
-  @mangdehuang, @VerrPower, @hejia-v, and @ygzhang-cn for the GUI/VS Code
-  demand and validation trail.
+  #480, #1584, #2580). Thanks @AiurArtanis for the Agent View prompt,
+  @lbcheng888 for the earlier scaffold, and @BigBenLabs, @lzx1545642258,
+  @yangdaowan, @mangdehuang, @VerrPower, @hejia-v, @nasus9527, and @ygzhang-cn
+  for the GUI/VS Code demand and validation trail.
 - Added `POST /v1/sessions` for runtime clients to save a completed thread as a
   managed session. The endpoint preserves thread title/model/mode/workspace
   metadata, maps missing threads to 404, and returns 409 instead of snapshotting

--- a/README.md
+++ b/README.md
@@ -644,10 +644,11 @@ Current v0.9 track credits:
 - **[aboimpinto](https://github.com/aboimpinto)** — sidebar command polish and
   pausable custom-command lifecycle direction harvested into the v0.9 track
   (#2788, #2732)
-- **[lbcheng888](https://github.com/lbcheng888)** and
-  **[AiurArtanis](https://github.com/AiurArtanis)** — VS Code extension
-  scaffold direction and Agent View request that shaped the official Phase 0
-  extension (#1022, #2580)
+- **[lbcheng888](https://github.com/lbcheng888)**,
+  **[AiurArtanis](https://github.com/AiurArtanis)**, and
+  **[nasus9527](https://github.com/nasus9527)** — VS Code extension scaffold
+  direction, Agent View request, and IDE plugin request that shaped the
+  official Phase 0 extension (#1022, #1584, #2580)
 - **[HUQIANTAO](https://github.com/HUQIANTAO)** — `web_run` cache-state
   lock-splitting, turn-metadata prefix-cache stability, and project-context
   cache work (#2502, #2517, #2636)

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -43,10 +43,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   local runtime attach checks, status bar state, and a CodeWhale runtime status
   view. This answers the VS Code GUI lane without exposing chat webviews,
   Agent View, inline edits, or retry/undo runtime endpoints yet (#461, #462,
-  #480, #2580). Thanks @AiurArtanis for the Agent View prompt, @lbcheng888 for
-  the earlier scaffold, and @BigBenLabs, @lzx1545642258, @yangdaowan,
-  @mangdehuang, @VerrPower, @hejia-v, and @ygzhang-cn for the GUI/VS Code
-  demand and validation trail.
+  #480, #1584, #2580). Thanks @AiurArtanis for the Agent View prompt,
+  @lbcheng888 for the earlier scaffold, and @BigBenLabs, @lzx1545642258,
+  @yangdaowan, @mangdehuang, @VerrPower, @hejia-v, @nasus9527, and @ygzhang-cn
+  for the GUI/VS Code demand and validation trail.
 - Added `POST /v1/sessions` for runtime clients to save a completed thread as a
   managed session. The endpoint preserves thread title/model/mode/workspace
   metadata, maps missing threads to 404, and returns 409 instead of snapshotting


### PR DESCRIPTION
## Summary
- add #1584 / @nasus9527 to the v0.9 VS Code extension demand trail
- keep root and TUI changelogs in sync
- polish the active README v0.9 contributor credit row for the Phase 0 extension

## Verification
- `cmp -s CHANGELOG.md crates/tui/CHANGELOG.md`
- `./scripts/release/check-versions.sh`
- `git diff --check`