### PR TITLE
chore: allowlist AdityaVG13 for v0.9 stewardship

### DIFF
--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -43,6 +43,7 @@ all:sximelon
 all:Sskift
 all:New2Niu
 all:shenjackyuanjie
+all:AdityaVG13
 all:mvanhorn
 all:MengZ-super
 all:membphis


### PR DESCRIPTION
## Summary
- add @AdityaVG13 to the contribution-gate allowlist for recurring v0.9 stewardship work

## Stewardship notes
@AdityaVG13 is already mapped in `.github/AUTHOR_MAP` and credited in the changelog/README for the WhaleFlow #2482/#2486 draft and cost-tracking direction harvested into the maintained v0.9 WhaleFlow foundation. This keeps the dry-run contribution-gate allowlist aligned with the contributor credit record.

## Verification
- `git diff --check`
- `./scripts/release/check-versions.sh`
- `cmp -s CHANGELOG.md crates/tui/CHANGELOG.md && echo changelogs-match`

No release, tag, publish, or artifact changes.
