### PR TITLE
docs(harness): define profile cutline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   A dedicated v0.9.0 release acceptance matrix now tracks provider, runtime,
   UI, WhaleFlow, Model Lab, remote-workbench, docs, rollback, and credit gates
   that must be checked or explicitly deferred before tagging (#2729).
+  HarnessProfile docs now pin the v0.9.0 order: posture/schema/resolver/seed
+  profiles/status display must precede evidence stores, promotion gates, or any
+  automatic Harness Creator, with DeepSeek, MiMo, Arcee, and generic/HF/local
+  posture expectations called out separately (#2728).
   Thanks @AdityaVG13 for the WhaleFlow draft and cost-tracking direction.
 - Added a state-store v2 schema migration for WhaleFlow trace tables covering
   workflow, branch, leaf, control-node, and teacher-candidate runs. The

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ areas:
 | Project context stability | Bounded project-context packs and generated instructions keep large/noisy repositories from turning the first turn into an unbounded filesystem walk. |
 | HarmonyOS / OHOS | The lane carries safe OpenHarmony setup, OHOS platform guards, self-update disablement on OHOS, and target gating for PTY and Starlark execpolicy paths. Full OHOS target builds still require a host with the OpenHarmony native SDK configured. |
 | Nix and Starlark compatibility | Dependency stewardship keeps OHOS builds from pulling incompatible Nix-chain crates through PTY or Starlark paths where those features are gated. |
-| HarnessProfile | The branch carries the typed `HarnessPosture` / `HarnessProfile` config data model and strict schema validation. Provider/model posture selection, prompt/tool/runtime behavior, telemetry, and docs remain follow-up work. |
+| HarnessProfile | The branch carries the typed `HarnessPosture` / `HarnessProfile` config data model, strict schema validation, and a documented [profile cutline](docs/HARNESS_PROFILE_CUTLINE.md). Provider/model posture resolution, prompt/tool/runtime behavior, telemetry, and status display remain follow-up work. |
 | Contributor stewardship | Harvested PRs stay credited, contributor identity mapping is machine-readable, and community gates remain dry-run and human-toned while the branch is reviewed. |
 | WhaleFlow | Typed branch/leaf workflows, deterministic replay, pod-style workflow monitoring, provider/model posture, and evidence-backed profile evolution remain the larger v0.9 workbench goal. |
 

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -95,6 +95,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   A dedicated v0.9.0 release acceptance matrix now tracks provider, runtime,
   UI, WhaleFlow, Model Lab, remote-workbench, docs, rollback, and credit gates
   that must be checked or explicitly deferred before tagging (#2729).
+  HarnessProfile docs now pin the v0.9.0 order: posture/schema/resolver/seed
+  profiles/status display must precede evidence stores, promotion gates, or any
+  automatic Harness Creator, with DeepSeek, MiMo, Arcee, and generic/HF/local
+  posture expectations called out separately (#2728).
   Thanks @AdityaVG13 for the WhaleFlow draft and cost-tracking direction.
 - Added a state-store v2 schema migration for WhaleFlow trace tables covering
   workflow, branch, leaf, control-node, and teacher-candidate runs. The

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -401,6 +401,8 @@ safety_posture = "standard"        # standard | strict | permissive
 Unknown posture names or unknown keys inside a harness profile fail config
 deserialization instead of silently becoming `custom`. That is intentional:
 once runtime wiring consumes these profiles, a typo should be visible.
+The v0.9 implementation order and automatic-creator boundary are documented in
+[`HARNESS_PROFILE_CUTLINE.md`](HARNESS_PROFILE_CUTLINE.md).
 
 ## Environment Variables
 

--- a/docs/HARNESS_PROFILE_CUTLINE.md
+++ b/docs/HARNESS_PROFILE_CUTLINE.md
@@ -1,0 +1,77 @@
+# Harness Profile Cutline
+
+This note defines the v0.9.0 order for HarnessProfile work. The automatic
+Harness Creator must not run before the profile schema, resolver, seed
+profiles, and user-visible status surfaces are explicit and tested.
+
+## Decision
+
+For v0.9.0, CodeWhale should treat harness profiles as typed policy data first.
+Automatic profile evolution is deferred until replay evidence, candidate
+manifests, and promotion gates exist.
+
+The first implementation lane stops at:
+
+1. `HarnessPosture` enum and policy knobs.
+2. `HarnessProfile` schema and registry.
+3. Deterministic profile resolver.
+4. Seed profiles for common model families.
+5. Repo constitution overlay input.
+6. Status/UX display of the resolved provider, model, profile, and repo law.
+
+Only after those surfaces are visible and tested should CodeWhale add evidence
+stores, candidate manifests, promotion gates, or an agentic Harness Creator.
+
+## Required Seed Profiles
+
+| Model family | Intended posture | Notes |
+| --- | --- | --- |
+| DeepSeek V4 Pro / Flash | cache-heavy | Preserve prefix stability and large-context continuity. |
+| Xiaomi MiMo v2.5 Pro / Flash | cache-heavy | Similar long-context/cache posture, but route and auth remain distinct from DeepSeek. |
+| Arcee Trinity Thinking | cache-heavy or explicit Arcee profile | Direct Arcee IDs such as `trinity-large-thinking` must not be hidden behind OpenRouter aliases. |
+| Hugging Face / local / open-weight routes | lean | Prefer smaller context packs, stricter tool surfaces, and subagent-oriented decomposition. |
+| Generic OpenAI-compatible gateways | standard unless matched | Do not infer provider-specific posture from a bare endpoint alone. |
+
+Provider route, endpoint, model id, HarnessProfile, and repo constitution must be
+separately visible. A profile resolver may choose a profile, but it must not
+silently change provider auth, base URLs, model IDs, tool allowlists, or repo
+permissions.
+
+## Repo Constitution Boundary
+
+`.codewhale/constitution.json` is local repo law, not another provider profile.
+The resolver may read it as an input after project trust checks, but profile
+selection must show both:
+
+- the model-facing posture, such as `cache-heavy` or `lean`;
+- the repo-law source, such as `.codewhale/constitution.json` or none.
+
+## Automatic Evolution Boundary
+
+AHE/GEPA-style profile evolution is future work. It can be referenced as
+inspiration only after the text distinguishes these stages:
+
+1. candidate proposal from recorded evidence;
+2. replay/eval against a weaker or constrained student;
+3. promotion-gate decision with required tests and policy checks;
+4. inspectable overlay update or rollback.
+
+No v0.9.0 harness profile should be silently promoted, mutated, or written to a
+cached-main overlay by the schema/resolver/display lane.
+
+## Smoke Evidence Needed Before Release
+
+Before v0.9.0 ships with HarnessProfile behavior beyond schema parsing, the
+acceptance matrix should record evidence for:
+
+- DeepSeek V4 resolving to a cache-heavy profile;
+- Xiaomi MiMo resolving to a cache-heavy profile without sharing DeepSeek auth;
+- Arcee direct `trinity-large-thinking` resolving through the direct `arcee`
+  route, not the OpenRouter `arcee-ai/trinity-large-thinking` alias;
+- a generic/HF/local model resolving to a lean or standard profile;
+- the TUI or runtime status surface showing provider, model, profile, and repo
+  constitution separately;
+- no automatic profile mutation during normal Agent or WhaleFlow runs.
+
+Until that evidence exists, release notes should call HarnessProfile a typed
+schema/config foundation rather than an automatic harness creator.


### PR DESCRIPTION
## Summary
- add `docs/HARNESS_PROFILE_CUTLINE.md` for #2728
- document that posture/schema/resolver/seed profiles/status display must precede evidence stores, promotion gates, or automatic Harness Creator work
- call out DeepSeek, Xiaomi MiMo, direct Arcee, and generic/HF/local posture expectations separately
- link the cutline from README and configuration docs, with mirrored changelog wording

## Stewardship boundary
Docs-only. This does not implement the resolver, seed profiles, status display, profile mutation, evidence store, or automatic Harness Creator. #2728 should stay open until resolver/status tests and smoke evidence exist.

## Verification
- git diff --check
- ./scripts/release/check-versions.sh