### PR TITLE
docs(harness): align v0.9 profile acceptance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   profiles/status display must precede evidence stores, promotion gates, or any
   automatic Harness Creator, with DeepSeek, MiMo, Arcee, and generic/HF/local
   posture expectations called out separately (#2728).
+  Release-facing HarnessProfile docs now match the current implementation:
+  v0.9 ships the typed schema/config foundation and defers runtime resolver,
+  telemetry, seed-profile selection, and status-display behavior until later
+  verified slices. `config.example.toml` includes a commented dormant
+  harness-profile example, and README links point at the real acceptance matrix
+  and HarnessProfile cutline docs.
   Thanks @AdityaVG13 for the WhaleFlow draft and cost-tracking direction.
 - Added a state-store v2 schema migration for WhaleFlow trace tables covering
   workflow, branch, leaf, control-node, and teacher-candidate runs. The

--- a/README.md
+++ b/README.md
@@ -57,8 +57,10 @@ areas:
 | Contributor stewardship | Harvested PRs stay credited, contributor identity mapping is machine-readable, and community gates remain dry-run and human-toned while the branch is reviewed. |
 | WhaleFlow | Typed branch/leaf workflows, deterministic replay, pod-style workflow monitoring, provider/model posture, and evidence-backed profile evolution remain the larger v0.9 workbench goal. |
 
-The current execution map lives in
-[docs/V0_9_0_EXECUTION_MAP.md](docs/V0_9_0_EXECUTION_MAP.md).
+The current release acceptance matrix lives in
+[docs/V0_9_0_RELEASE_ACCEPTANCE.md](docs/V0_9_0_RELEASE_ACCEPTANCE.md), with
+the HarnessProfile runtime boundary documented in
+[docs/HARNESS_PROFILE_CUTLINE.md](docs/HARNESS_PROFILE_CUTLINE.md).
 
 ## Release Status
 
@@ -606,7 +608,8 @@ without recreating skills the user deliberately deleted.
 | [RELEASE_RUNBOOK.md](docs/RELEASE_RUNBOOK.md) | Release process |
 | [LOCALIZATION.md](docs/LOCALIZATION.md) | UI locale matrix & switching |
 | [OPERATIONS_RUNBOOK.md](docs/OPERATIONS_RUNBOOK.md) | Ops & recovery |
-| [V0_9_0_EXECUTION_MAP.md](docs/V0_9_0_EXECUTION_MAP.md) | v0.9.0 issue lanes, PR harvest state, and release gates |
+| [V0_9_0_RELEASE_ACCEPTANCE.md](docs/V0_9_0_RELEASE_ACCEPTANCE.md) | v0.9.0 pre-tag acceptance matrix and release gates |
+| [HARNESS_PROFILE_CUTLINE.md](docs/HARNESS_PROFILE_CUTLINE.md) | HarnessProfile schema, resolver, and runtime boundary for v0.9 |
 | [2574-provider-fallback-chain.md](docs/rfcs/2574-provider-fallback-chain.md) | Provider fallback chain RFC |
 
 Full Changelog: [CHANGELOG.md](CHANGELOG.md).

--- a/config.example.toml
+++ b/config.example.toml
@@ -606,6 +606,26 @@ deepseek_v4_flash_prior = 4.2
 fallback_default_prior = 3.8
 
 # ─────────────────────────────────────────────────────────────────────────────────
+# Harness Profiles (preview schema; runtime resolver follows in later v0.9 slices)
+# ─────────────────────────────────────────────────────────────────────────────────
+# Harness profiles let future CodeWhale runtime slices select model-specific prompt,
+# context, tool, and subagent posture. v0.9 currently parses and validates this
+# schema, but normal Agent and WhaleFlow runs do not silently promote or mutate
+# behavior from these profiles yet.
+#
+# [[harness_profiles]]
+# provider_route = "deepseek"
+# model_pattern = "deepseek-v4.*"
+#
+# [harness_profiles.posture]
+# kind = "cache-heavy"          # standard | cache-heavy | lean | custom
+# max_subagents = 10            # 0 means runtime default
+# prefer_codebase_search = false
+# compaction_strategy = "prefix-cache" # default | prefix-cache | aggressive
+# tool_surface = "full"              # full | read-only | auto
+# safety_posture = "standard"        # standard | strict | permissive
+
+# ─────────────────────────────────────────────────────────────────────────────────
 # Profile Example (for multiple environments)
 # ─────────────────────────────────────────────────────────────────────────────────
 # Select a profile with `deepseek --profile <name>` or `DEEPSEEK_PROFILE=<name>`.

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -99,6 +99,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   profiles/status display must precede evidence stores, promotion gates, or any
   automatic Harness Creator, with DeepSeek, MiMo, Arcee, and generic/HF/local
   posture expectations called out separately (#2728).
+  Release-facing HarnessProfile docs now match the current implementation:
+  v0.9 ships the typed schema/config foundation and defers runtime resolver,
+  telemetry, seed-profile selection, and status-display behavior until later
+  verified slices. `config.example.toml` includes a commented dormant
+  harness-profile example, and README links point at the real acceptance matrix
+  and HarnessProfile cutline docs.
   Thanks @AdityaVG13 for the WhaleFlow draft and cost-tracking direction.
 - Added a state-store v2 schema migration for WhaleFlow trace tables covering
   workflow, branch, leaf, control-node, and teacher-candidate runs. The

--- a/docs/V0_9_0_RELEASE_ACCEPTANCE.md
+++ b/docs/V0_9_0_RELEASE_ACCEPTANCE.md
@@ -62,7 +62,7 @@ config source, result, and follow-up issue or PR.
 | WhaleFlow typed IR, mock executor, replay, TeacherReview, StudentReplay, and cutline docs are tested | WhaleFlow steward | ship |  |
 | Live `workflow_run`, worktree application, provider calls, and TraceStore writes are included only if cancellation/replay/atomicity semantics pass | WhaleFlow steward | decide |  |
 | Model Lab / Hugging Face MVP is included or deferred with release-note wording | model-lab steward | decide |  |
-| HarnessProfile MVP is included or deferred with release-note wording | harness steward | decide |  |
+| HarnessProfile runtime MVP is deferred; schema/config foundation ships with release-note wording | harness steward | ship foundation / defer runtime | #2844 (`efbcc681a`) documents the cutline; `HarnessPosture` / `HarnessProfile` config schema and strict validation are present; resolver, seed-profile runtime selection, telemetry, and status display remain follow-up work. |
 | `codebase_search` MVP is included or deferred with release-note wording | search steward | decide |  |
 | External memory remains explicit/optional per `WHALEFLOW_EXTERNAL_MEMORY.md` | memory steward | ship |  |
 


### PR DESCRIPTION
## Summary\n- mark the HarnessProfile v0.9 gate as schema/config foundation shipped, with runtime resolver/display deferred\n- add a commented dormant harness profile example to config.example.toml\n- replace stale README links to the missing execution-map doc with the release acceptance matrix and harness cutline docs\n\n## Stewardship notes\n- Follows the #2844 cutline: no claim that runtime provider/model posture resolution, telemetry, seed profile selection, or status display is active yet.\n- Keeps #2728 open for resolver tests, seed profiles, Arcee evidence, and status surface follow-up.\n\n## Verification\n- git diff --check\n- ./scripts/release/check-versions.sh\n- ./scripts/release/check-ohos-deps.sh\n- rg -n "V0_9_0_EXECUTION_MAP" README.md docs CHANGELOG.md crates/tui/CHANGELOG.md || true