### PR TITLE
docs(release): fill v0.9 acceptance evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   verified slices. `config.example.toml` includes a commented dormant
   harness-profile example, and README links point at the real acceptance matrix
   and HarnessProfile cutline docs.
+  The release acceptance matrix now records evidence for already-landed gates:
+  provider-registry drift checks, provider-scoped TLS skip verify, read-only
+  GUI runtime/restore-point surfaces, VS Code Agent View branch visibility,
+  WhaleFlow mock/runtime foundations, explicit external-memory boundaries, and
+  docs alignment. Live workflow execution, provider calls, TraceStore writes,
+  and mutation-oriented GUI endpoints remain deferred until their atomicity and
+  replay contracts are tested.
   Thanks @AdityaVG13 for the WhaleFlow draft and cost-tracking direction.
 - Added a state-store v2 schema migration for WhaleFlow trace tables covering
   workflow, branch, leaf, control-node, and teacher-candidate runs. The

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -105,6 +105,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   verified slices. `config.example.toml` includes a commented dormant
   harness-profile example, and README links point at the real acceptance matrix
   and HarnessProfile cutline docs.
+  The release acceptance matrix now records evidence for already-landed gates:
+  provider-registry drift checks, provider-scoped TLS skip verify, read-only
+  GUI runtime/restore-point surfaces, VS Code Agent View branch visibility,
+  WhaleFlow mock/runtime foundations, explicit external-memory boundaries, and
+  docs alignment. Live workflow execution, provider calls, TraceStore writes,
+  and mutation-oriented GUI endpoints remain deferred until their atomicity and
+  replay contracts are tested.
   Thanks @AdityaVG13 for the WhaleFlow draft and cost-tracking direction.
 - Added a state-store v2 schema migration for WhaleFlow trace tables covering
   workflow, branch, leaf, control-node, and teacher-candidate runs. The

--- a/docs/V0_9_0_RELEASE_ACCEPTANCE.md
+++ b/docs/V0_9_0_RELEASE_ACCEPTANCE.md
@@ -14,8 +14,8 @@ config source, result, and follow-up issue or PR.
 | `cargo check --workspace --all-targets --locked` | release steward | ship |  |
 | `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` | release steward | ship |  |
 | `cargo test --workspace --all-features --locked` | release steward | ship |  |
-| `./scripts/release/check-versions.sh` | release steward | ship |  |
-| `./scripts/release/check-ohos-deps.sh` | release steward | ship |  |
+| `./scripts/release/check-versions.sh` | release steward | ship | Passed locally during #2845 (`e22a7da53`) and remains part of the PR-local release gate for each stewardship slice. |
+| `./scripts/release/check-ohos-deps.sh` | release steward | ship | Passed locally during #2845 (`e22a7da53`); OHOS dependency graph stayed compatible for `codewhale-tui` on `aarch64-unknown-linux-ohos`. |
 | `./scripts/release/publish-crates.sh dry-run` | release steward | ship |  |
 | `node scripts/release/npm-wrapper-smoke.js` after release build | release steward | ship |  |
 | GitHub release asset verification before npm publish | release steward | ship |  |
@@ -29,8 +29,8 @@ config source, result, and follow-up issue or PR.
 | Arcee Trinity Thinking route smoke or explicit defer | provider steward | decide |  |
 | Hugging Face route/search/passport smoke or explicit defer | model-lab steward | decide |  |
 | OpenRouter, Novita, Fireworks, and Volcengine env behavior smoke | provider steward | ship |  |
-| Provider registry drift check covers aliases/default env keys | provider steward | ship |  |
-| Provider-scoped TLS skip-verify remains default-off and doctor-visible | security steward | ship |  |
+| Provider registry drift check covers aliases/default env keys | provider steward | ship | #2820 (`5d491bc68`) added the metadata-only provider registry and `scripts/check-provider-registry.py`; verification included `python3 scripts/check-provider-registry.py` and `cargo test -p codewhale-config provider_ -- --nocapture`. |
+| Provider-scoped TLS skip-verify remains default-off and doctor-visible | security steward | ship | #2834 (`190e9f35e`, `6269cb91f`) landed provider-scoped TLS skip verify with default-off config, doctor warnings, docs, and CLI/runtime option tests. |
 
 ## Runtime Stability
 
@@ -41,8 +41,8 @@ config source, result, and follow-up issue or PR.
 | Large-repo startup smoke | runtime steward | ship |  |
 | Sub-agent timeout/completion smoke | subagent steward | ship |  |
 | Long-running command live-state smoke | runtime steward | ship |  |
-| Runtime API remains token-protected for GUI clients | GUI steward | ship |  |
-| Snapshot/restore surfaces are read-only unless mutation semantics are tested | GUI steward | ship |  |
+| Runtime API remains token-protected for GUI clients | GUI steward | ship | #2811/#2814 documented and consumed the existing runtime token flow from the official VS Code extension; #2822 (`bb8835812`) added `GET /v1/snapshots` behind the same runtime API token middleware. |
+| Snapshot/restore surfaces are read-only unless mutation semantics are tested | GUI steward | ship | #2822 (`bb8835812`) and #2828 (`293643e27`) expose restore points as read-only listing/Agent View metadata only; #2808 restore/retry/patch-undo mutation endpoints remain unmerged pending atomicity tests. |
 
 ## UI And Workflow UX
 
@@ -53,18 +53,18 @@ config source, result, and follow-up issue or PR.
 | Transcript tool-collapse smoke or explicit defer | UX steward | decide |  |
 | Sidebar detail popovers smoke or explicit defer | UX steward | decide |  |
 | Plan review/handoff artifact smoke | Plan steward | ship |  |
-| VS Code Agent View branch/workspace visibility smoke | GUI steward | ship |  |
+| VS Code Agent View branch/workspace visibility smoke | GUI steward | ship | #2825 (`1bacaf763`) added `workspace` / `branch` metadata to `/v1/threads/summary`; #2832 (`50b773f1d`) added read-only auto-refresh so branch/workspace changes can appear without manual refresh. |
 
 ## v0.9.0 Feature Gates
 
 | Gate | Owner | Ship/defer decision | Evidence |
 | --- | --- | --- | --- |
-| WhaleFlow typed IR, mock executor, replay, TeacherReview, StudentReplay, and cutline docs are tested | WhaleFlow steward | ship |  |
-| Live `workflow_run`, worktree application, provider calls, and TraceStore writes are included only if cancellation/replay/atomicity semantics pass | WhaleFlow steward | decide |  |
+| WhaleFlow typed IR, mock executor, replay, TeacherReview, StudentReplay, and cutline docs are tested | WhaleFlow steward | ship | #2821/#2824/#2831/#2833/#2839/#2840/#2841 plus focused local `cargo test -p codewhale-whaleflow --locked`; #2670 closed after `cargo test -p codewhale-whaleflow starlark --locked` passed 7/7 on current stewardship head. |
+| Live `workflow_run`, worktree application, provider calls, and TraceStore writes are deferred until cancellation/replay/atomicity semantics pass | WhaleFlow steward | defer | #2669 and #2679 remain open for live runtime execution, provider calls, TraceStore writes, Arcee/student replay, and CLI/TUI workflow mode; current v0.9 branch ships mock executor/replay foundations only. |
 | Model Lab / Hugging Face MVP is included or deferred with release-note wording | model-lab steward | decide |  |
 | HarnessProfile runtime MVP is deferred; schema/config foundation ships with release-note wording | harness steward | ship foundation / defer runtime | #2844 (`efbcc681a`) documents the cutline; `HarnessPosture` / `HarnessProfile` config schema and strict validation are present; resolver, seed-profile runtime selection, telemetry, and status display remain follow-up work. |
 | `codebase_search` MVP is included or deferred with release-note wording | search steward | decide |  |
-| External memory remains explicit/optional per `WHALEFLOW_EXTERNAL_MEMORY.md` | memory steward | ship |  |
+| External memory remains explicit/optional per `WHALEFLOW_EXTERNAL_MEMORY.md` | memory steward | ship | #2842 (`a7052751e`) added the external-memory cutline: optional/explicit workflow node/plugin only, visible state/owner/storage/scope, and no hidden default context substrate. |
 
 ## Remote Workbench
 
@@ -79,7 +79,7 @@ config source, result, and follow-up issue or PR.
 
 | Gate | Owner | Ship/defer decision | Evidence |
 | --- | --- | --- | --- |
-| README, configuration docs, provider docs, and changelog agree | docs steward | ship |  |
+| README, configuration docs, provider docs, and changelog agree | docs steward | ship | #2845 (`e22a7da53`) aligned README/config example/changelogs with the HarnessProfile cutline and removed stale `V0_9_0_EXECUTION_MAP` links. |
 | Breaking changes, deprecations, and deferred v0.9 gates are listed in release notes | release steward | ship |  |
 | Upgrade steps exist for users coming from `deepseek-tui` | docs steward | ship |  |
 | Rollback steps exist for npm wrapper, Cargo install, and side-git restore | release steward | ship |  |


### PR DESCRIPTION
## Summary\n- fill release acceptance evidence for already-landed v0.9 gates\n- mark live workflow/provider/TraceStore runtime execution as deferred rather than undecided\n- record supporting PR/commit anchors for provider registry, TLS skip-verify, read-only GUI runtime surfaces, VS Code branch visibility, WhaleFlow foundations, external memory, and docs alignment\n\n## Stewardship notes\n- This is docs-only and does not claim new runtime behavior.\n- Mutation-oriented GUI endpoints from #2808 remain unmerged pending atomicity tests.\n- Live workflow_run/provider-call/TraceStore writes remain tracked in #2669 and #2679.\n\n## Verification\n- cmp -s CHANGELOG.md crates/tui/CHANGELOG.md && echo changelogs-match\n- git diff --check\n- ./scripts/release/check-versions.sh\n- ./scripts/release/check-ohos-deps.sh\n- gh pr view sanity check for referenced PRs #2820/#2821/#2822/#2824/#2825/#2828/#2831/#2833/#2834/#2839/#2840/#2841/#2842/#2845