### PR TITLE
fix(tui): classify stream decode failures as network errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -310,6 +310,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Stream/body decode failures such as `Stream read error: error decoding
+  response body` are now classified as recoverable network interruptions
+  instead of generic internal errors, keeping the transcript and triage metadata
+  aligned with the existing stream retry path (#2847). Thanks
+  @qamranmushtaq-collab for the Windows/npx DeepSeek report.
 - The TUI footer, `/status`, `/mcp` manager, and command-palette MCP entries
   now count trusted workspace-local `.codewhale/mcp.json` servers together with
   the global MCP config, matching `codewhale mcp list` for merged global +

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -310,6 +310,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Stream/body decode failures such as `Stream read error: error decoding
+  response body` are now classified as recoverable network interruptions
+  instead of generic internal errors, keeping the transcript and triage metadata
+  aligned with the existing stream retry path (#2847). Thanks
+  @qamranmushtaq-collab for the Windows/npx DeepSeek report.
 - The TUI footer, `/status`, `/mcp` manager, and command-palette MCP entries
   now count trusted workspace-local `.codewhale/mcp.json` servers together with
   the global MCP config, matching `codewhale mcp list` for merged global +

--- a/crates/tui/src/error_taxonomy.rs
+++ b/crates/tui/src/error_taxonomy.rs
@@ -342,6 +342,10 @@ pub fn classify_error_message(message: &str) -> ErrorCategory {
     if lower.contains("network")
         || lower.contains("connection")
         || lower.contains("dns")
+        || lower.contains("stream read error")
+        || lower.contains("error decoding response body")
+        || lower.contains("chunk decode error")
+        || lower.contains("body decode")
         || lower.contains("temporarily unavailable")
         || lower.contains(" 502 ")
         || lower.contains(" 503 ")
@@ -546,6 +550,22 @@ mod tests {
             classify("request timed out after 30s"),
             ErrorCategory::Timeout
         );
+    }
+
+    #[test]
+    fn network_catches_stream_body_decode_failures() {
+        for msg in [
+            "Warn Stream read error: error decoding response body",
+            "Stream read error: error decoding response body",
+            "chunk decode error",
+            "provider body decode failed mid-stream",
+        ] {
+            assert_eq!(
+                classify(msg),
+                ErrorCategory::Network,
+                "expected Network for `{msg}`",
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- classify `Stream read error: error decoding response body`, chunk decode, and body decode failures as recoverable network interruptions instead of generic internal errors
- add focused taxonomy coverage for the exact #2847 phrasing
- credit @qamranmushtaq-collab in the changelog for the Windows/npx DeepSeek report

Refs #2847. This does not close the issue: it improves the error category/triage metadata around the reported failure while we still need reporter details to confirm the underlying Windows/npx/provider reproduction.

## Verification
- `cargo test -p codewhale-tui error_taxonomy::tests --locked`
- `git diff --check`
- `cmp -s CHANGELOG.md crates/tui/CHANGELOG.md`
- `./scripts/release/check-versions.sh`
- `./scripts/release/check-ohos-deps.sh`
