### PR TITLE
docs(release): mark deferred v0.9 acceptance gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   profiles/status display must precede evidence stores, promotion gates, or any
   automatic Harness Creator, with DeepSeek, MiMo, Arcee, and generic/HF/local
   posture expectations called out separately (#2728).
+  Hugging Face / Model Lab and `codebase_search` release gates now explicitly
+  ship only the provider/MCP/docs/design foundation in v0.9; native Hub search,
+  model passports, Spaces/Jobs workflows, eval/export surfaces, and runtime
+  `codebase_search` registration remain deferred (#2705, #2680, #2727).
+  Remote workbench acceptance is also marked docs/setup-only for v0.9 so release
+  notes do not imply a shipped VM or Telegram bridge runtime (#2724).
   Release-facing HarnessProfile docs now match the current implementation:
   v0.9 ships the typed schema/config foundation and defers runtime resolver,
   telemetry, seed-profile selection, and status-display behavior until later

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -99,6 +99,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   profiles/status display must precede evidence stores, promotion gates, or any
   automatic Harness Creator, with DeepSeek, MiMo, Arcee, and generic/HF/local
   posture expectations called out separately (#2728).
+  Hugging Face / Model Lab and `codebase_search` release gates now explicitly
+  ship only the provider/MCP/docs/design foundation in v0.9; native Hub search,
+  model passports, Spaces/Jobs workflows, eval/export surfaces, and runtime
+  `codebase_search` registration remain deferred (#2705, #2680, #2727).
+  Remote workbench acceptance is also marked docs/setup-only for v0.9 so release
+  notes do not imply a shipped VM or Telegram bridge runtime (#2724).
   Release-facing HarnessProfile docs now match the current implementation:
   v0.9 ships the typed schema/config foundation and defers runtime resolver,
   telemetry, seed-profile selection, and status-display behavior until later

--- a/docs/MODEL_LAB.md
+++ b/docs/MODEL_LAB.md
@@ -15,10 +15,10 @@ implemented today.
 - DeepSeek is the first-class default provider today, with `deepseek-v4-pro`,
   `deepseek-v4-flash`, streaming thinking blocks, Fin routing, `DEEPSEEK_*`
   environment variables, and `~/.deepseek` config compatibility.
-- OpenRouter, Novita, Fireworks, NVIDIA NIM, AtlasCloud, Wanjie Ark, generic
-  OpenAI-compatible endpoints, SGLang, vLLM, and Ollama are supported provider
-  paths where their IDs appear in `/provider`, `codewhale --provider`, or
-  `codewhale models`.
+- OpenRouter, Novita, Fireworks, NVIDIA NIM, AtlasCloud, Wanjie Ark, Hugging
+  Face Inference Providers, generic OpenAI-compatible endpoints, SGLang, vLLM,
+  and Ollama are supported provider paths where their IDs appear in
+  `/provider`, `codewhale --provider`, or `codewhale models`.
 - Model auto-routing chooses a concrete DeepSeek model and thinking level per
   turn. It is not a TUI mode.
 - Fin is the fast `deepseek-v4-flash` thinking-off path for routing,
@@ -29,9 +29,11 @@ implemented today.
 
 ## Not Implemented Yet
 
-- A native Hugging Face provider or Hub browser.
-- Built-in Hugging Face model card, dataset, adapter, safetensors, or Jobs
-  workflows.
+- A native Hugging Face Hub browser, model passport picker, or direct Hub search
+  workflow. The OpenAI-compatible Hugging Face Inference Providers route is
+  implemented separately as a chat provider.
+- Built-in Hugging Face model card, dataset, adapter, safetensors, Spaces, or
+  Jobs workflows.
 - Native Unsloth, NeMo, or Arcee integrations.
 - A dedicated Model Lab UI tab.
 - Built-in benchmark suites, eval leaderboards, hosted observability, or
@@ -62,13 +64,13 @@ Planned scope:
 - Hub API auth and model discovery.
 - Model cards, licenses, tags, safetensors metadata, adapters, and dataset
   links surfaced in a terminal-friendly way.
-- Inference Providers as explicit provider choices when the user configures
-  them.
+- Native Hub browser and model-passport metadata on top of the already separate
+  Hugging Face Inference Providers chat route.
 - Hugging Face Jobs as an optional remote execution path for user-approved
   experiments.
 
-Non-goal for now: claiming a native Hugging Face provider exists before it is
-implemented in code.
+Non-goal for now: claiming native Hub search, model passports, Spaces/Jobs, or
+Model Lab UI exists before those surfaces are implemented in code.
 
 ## Unsloth Workset
 

--- a/docs/V0_9_0_RELEASE_ACCEPTANCE.md
+++ b/docs/V0_9_0_RELEASE_ACCEPTANCE.md
@@ -27,7 +27,7 @@ config source, result, and follow-up issue or PR.
 | DeepSeek V4 direct provider smoke | provider steward | ship |  |
 | Xiaomi MiMo token-plan and pay-as-you-go config smoke | provider steward | ship |  |
 | Arcee Trinity Thinking route smoke or explicit defer | provider steward | decide |  |
-| Hugging Face route/search/passport smoke or explicit defer | model-lab steward | decide |  |
+| Hugging Face provider route and MCP concept helpers ship; native Hub search/passports are deferred | model-lab steward | ship foundation / defer native search-passport runtime | `ProviderKind::Huggingface`, env aliases, picker/docs, and `/hf concepts` / `/hf mcp status` distinguish the chat provider route from Hugging Face MCP and explicit Hub tooling. `docs/PROVIDERS.md` states native Hub HTTP search/passport picker metadata are not shipped behavior in this checkout; #2705/#2707/#2712 remain open for native Model Lab work. |
 | OpenRouter, Novita, Fireworks, and Volcengine env behavior smoke | provider steward | ship |  |
 | Provider registry drift check covers aliases/default env keys | provider steward | ship | #2820 (`5d491bc68`) added the metadata-only provider registry and `scripts/check-provider-registry.py`; verification included `python3 scripts/check-provider-registry.py` and `cargo test -p codewhale-config provider_ -- --nocapture`. |
 | Provider-scoped TLS skip-verify remains default-off and doctor-visible | security steward | ship | #2834 (`190e9f35e`, `6269cb91f`) landed provider-scoped TLS skip verify with default-off config, doctor warnings, docs, and CLI/runtime option tests. |
@@ -61,19 +61,19 @@ config source, result, and follow-up issue or PR.
 | --- | --- | --- | --- |
 | WhaleFlow typed IR, mock executor, replay, TeacherReview, StudentReplay, and cutline docs are tested | WhaleFlow steward | ship | #2821/#2824/#2831/#2833/#2839/#2840/#2841 plus focused local `cargo test -p codewhale-whaleflow --locked`; #2670 closed after `cargo test -p codewhale-whaleflow starlark --locked` passed 7/7 on current stewardship head. The `rlm_cache_change.star` dogfood workflow now has recorded mock-trace replay coverage, including a missing-record divergence check. |
 | Live `workflow_run`, worktree application, provider calls, and TraceStore writes are deferred until cancellation/replay/atomicity semantics pass | WhaleFlow steward | defer | #2669 and #2679 remain open for live runtime execution, provider calls, TraceStore writes, Arcee/student replay, and CLI/TUI workflow mode; current v0.9 branch ships mock executor/replay foundations only. |
-| Model Lab / Hugging Face MVP is included or deferred with release-note wording | model-lab steward | decide |  |
+| Model Lab / Hugging Face MVP is included or deferred with release-note wording | model-lab steward | ship provider/MCP docs foundation / defer native Model Lab MVP | v0.9 ships the Hugging Face chat-provider route, provider docs, and `/hf` concept/MCP status helpers only. Native Hub search, model passports, Spaces/Jobs workflows, and Model Lab eval/export surfaces remain deferred to #2705/#2707/#2710/#2712/#2727. |
 | HarnessProfile runtime MVP is deferred; schema/resolver foundation ships with release-note wording | harness steward | ship foundation / defer runtime | #2844 (`efbcc681a`) documents the cutline; `HarnessPosture` / `HarnessProfile` config schema and strict validation are present; a pure resolver matches provider/model routes without changing runtime behavior; seed-profile runtime selection, telemetry, and status display remain follow-up work. |
-| `codebase_search` MVP is included or deferred with release-note wording | search steward | decide |  |
+| `codebase_search` MVP is included or deferred with release-note wording | search steward | defer runtime / ship design doc | `docs/CODEBASE_SEARCH_DESIGN.md` is explicitly doc-only and says no catalog code ships in this cycle; runtime tool registration, index/eval fixtures, and search implementation remain deferred to #2680. |
 | External memory remains explicit/optional per `WHALEFLOW_EXTERNAL_MEMORY.md` | memory steward | ship | #2842 (`a7052751e`) added the external-memory cutline: optional/explicit workflow node/plugin only, visible state/owner/storage/scope, and no hidden default context substrate. |
 
 ## Remote Workbench
 
 | Gate | Owner | Ship/defer decision | Evidence |
 | --- | --- | --- | --- |
-| Remote workbench is marked included, experimental, or deferred | remote steward | decide |  |
-| If included: VM install smoke passes | remote steward | decide |  |
-| If included: Telegram bridge smoke passes | remote steward | decide |  |
-| If deferred: release notes avoid implying remote workbench availability | remote steward | decide |  |
+| Remote workbench is marked included, experimental, or deferred | remote steward | defer runtime / ship setup docs only | `docs/REMOTE_VM_US.md`, `docs/REMOTE_SETUP_DESIGN.md`, and `docs/TENCENT_LIGHTHOUSE_HK.md` document possible VM/Telegram/Lark setup patterns, but no v0.9 remote workbench runtime is included. |
+| If included: VM install smoke passes | remote steward | defer | Not applicable while remote workbench runtime is deferred; no v0.9 VM install smoke is required before tagging. |
+| If included: Telegram bridge smoke passes | remote steward | defer | Not applicable while remote workbench runtime is deferred; Telegram bridge docs remain design/setup guidance only. |
+| If deferred: release notes avoid implying remote workbench availability | remote steward | ship | Acceptance matrix and changelog wording must say setup/design docs only, not a shipped remote workbench feature. |
 
 ## Docs, Migration, And Rollback
 


### PR DESCRIPTION
## Summary
- mark Hugging Face / Model Lab as provider/MCP/docs foundation only for v0.9, with native Hub search/passports/Spaces/Jobs/eval/export deferred
- mark `codebase_search` as design-doc-only for v0.9, with runtime tool/index/eval work deferred
- mark remote workbench as setup/design docs only, so release notes do not imply a shipped VM or Telegram bridge runtime
- mirror the defer decisions in the changelog

Refs #2729, #2727, #2705, #2680, and #2724.

## Verification
- `cargo test -p codewhale-tui hf --locked`
- `git diff --check`
- `cmp -s CHANGELOG.md crates/tui/CHANGELOG.md`
- `./scripts/release/check-versions.sh`
- `./scripts/release/check-ohos-deps.sh`
