### PR TITLE
docs(release): resolve v0.9 UI acceptance cutline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,7 +120,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   replay contracts are tested. The `rlm_cache_change.star` dogfood workflow can
   now be replayed from recorded mock leaf/control records, and missing dogfood
   records produce `ReplayDiverged` instead of falling back to live execution
-  (#2679).
+  (#2679). The UI/workflow UX rows now also distinguish shipped transcript
+  tool-run collapse, sidebar detail popovers, and PlanArtifact review/handoff
+  evidence from the deferred first-look/home redesign (#2692, #2694, #2691,
+  #2713).
   Thanks @AdityaVG13 for the WhaleFlow draft and cost-tracking direction.
 - Added a state-store v2 schema migration for WhaleFlow trace tables covering
   workflow, branch, leaf, control-node, and teacher-candidate runs. The

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -120,7 +120,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   replay contracts are tested. The `rlm_cache_change.star` dogfood workflow can
   now be replayed from recorded mock leaf/control records, and missing dogfood
   records produce `ReplayDiverged` instead of falling back to live execution
-  (#2679).
+  (#2679). The UI/workflow UX rows now also distinguish shipped transcript
+  tool-run collapse, sidebar detail popovers, and PlanArtifact review/handoff
+  evidence from the deferred first-look/home redesign (#2692, #2694, #2691,
+  #2713).
   Thanks @AdityaVG13 for the WhaleFlow draft and cost-tracking direction.
 - Added a state-store v2 schema migration for WhaleFlow trace tables covering
   workflow, branch, leaf, control-node, and teacher-candidate runs. The

--- a/docs/V0_9_0_RELEASE_ACCEPTANCE.md
+++ b/docs/V0_9_0_RELEASE_ACCEPTANCE.md
@@ -48,11 +48,11 @@ config source, result, and follow-up issue or PR.
 
 | Gate | Owner | Ship/defer decision | Evidence |
 | --- | --- | --- | --- |
-| First-look screen included or explicitly deferred | UX steward | decide |  |
+| First-look screen included or explicitly deferred | UX steward | defer v0.9 redesign / keep existing onboarding | The existing onboarding welcome remains covered by `first_run_user_always_starts_at_welcome`; the opinionated v0.9 first-look/home redesign remains deferred to #2713 so release notes should not imply a new home screen. |
 | Slash picker readability smoke | UX steward | ship |  |
-| Transcript tool-collapse smoke or explicit defer | UX steward | decide |  |
-| Sidebar detail popovers smoke or explicit defer | UX steward | decide |  |
-| Plan review/handoff artifact smoke | Plan steward | ship |  |
+| Transcript tool-collapse smoke or explicit defer | UX steward | ship | #2776 (`c76ec4752`) landed dense successful tool-run collapse with guardrails for failed/running/shell/patch/review/diff cells; focused widget coverage includes `chat_widget_collapses_dense_tool_runs_by_default`, `chat_widget_expands_dense_tool_runs_on_demand`, and `chat_widget_expanded_mode_leaves_dense_tool_runs_visible`. |
+| Sidebar detail popovers smoke or explicit defer | UX steward | ship | #2778 (`3cb49233e`) added row-level hover metadata and wrapping detail popovers for truncated Work/Tasks/Agents rows; #2806 (`19f5c7aa6`) preserved current sub-agent progress in the sidebar hover text. Focused coverage includes `sidebar_hover_rows_mark_source_text_diff_as_truncated` and `subagent_hover_text_preserves_full_agent_id_and_progress`. |
+| Plan review/handoff artifact smoke | Plan steward | ship | #2770 (`7ac8063b6`) added rich PlanArtifact sections through the transcript/Plan prompt path; focused coverage includes `plan_update_cell_renders_rich_artifact_metadata` and `plan_prompt_renders_rich_plan_artifact_sections`. |
 | VS Code Agent View branch/workspace visibility smoke | GUI steward | ship | #2825 (`1bacaf763`) added `workspace` / `branch` metadata to `/v1/threads/summary`; #2832 (`50b773f1d`) added read-only auto-refresh so branch/workspace changes can appear without manual refresh. |
 
 ## v0.9.0 Feature Gates


### PR DESCRIPTION
## Summary
- resolves the v0.9 acceptance matrix UI/workflow UX decide rows
- records shipped evidence for transcript tool-run collapse, sidebar detail popovers, and PlanArtifact review/handoff
- explicitly defers the opinionated v0.9 first-look/home redesign while preserving the existing onboarding welcome

## Verification
- `cargo test -p codewhale-tui chat_widget_collapses_dense_tool_runs_by_default --locked`
- `cargo test -p codewhale-tui chat_widget_expands_dense_tool_runs_on_demand --locked`
- `cargo test -p codewhale-tui sidebar_hover --locked`
- `cargo test -p codewhale-tui subagent_hover_text_preserves_full_agent_id_and_progress --locked`
- `cargo test -p codewhale-tui plan_prompt_renders_rich_plan_artifact_sections --locked`
- `cargo test -p codewhale-tui plan_update_cell_renders_rich_artifact_metadata --locked`
- `cargo test -p codewhale-tui first_run_user_always_starts_at_welcome --locked`
- `git diff --check`
- `cmp -s CHANGELOG.md crates/tui/CHANGELOG.md`
- `./scripts/release/check-versions.sh`
- `./scripts/release/check-ohos-deps.sh`

## Credit
Preserves the already-landed contributor trail for #2692/#2694/#2691/#2713 while making the release cutline explicit.