### PR TITLE
docs(release): close v0.9 credit rollback gates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,7 +159,7 @@ jobs:
             target: x86_64-pc-windows-msvc
             binary: codewhale-tui.exe
             artifact_name: codewhale-tui-windows-x64.exe
-          # --- deepseek (legacy dispatcher shim; removed in v0.9.0) ---
+          # --- deepseek (legacy dispatcher shim; compatibility-only) ---
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             binary: deepseek
@@ -180,7 +180,7 @@ jobs:
             target: x86_64-pc-windows-msvc
             binary: deepseek.exe
             artifact_name: deepseek-windows-x64.exe
-          # --- deepseek-tui (legacy TUI shim; removed in v0.9.0) ---
+          # --- deepseek-tui (legacy TUI shim; compatibility-only) ---
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             binary: deepseek-tui
@@ -538,8 +538,9 @@ jobs:
             printf '%s  %s\n' "${hash}" "${base}" >> "${manifest}"
           done < <(find artifacts -type f ! -path 'artifacts/checksums/*' -print0 | sort -z)
           # Legacy alias manifest so v0.8.40 `deepseek update` clients can
-          # still find a manifest by their hardcoded name. Same content; will
-          # be removed once the legacy shim binaries are retired in v0.9.0.
+          # still find a manifest by their hardcoded name. Same content as the
+          # canonical manifest; retire it only with an explicit release-infra
+          # cutover that also removes the legacy shim artifacts.
           cp "${manifest}" "artifacts/checksums/deepseek-artifacts-sha256.txt"
           cat "${manifest}"
       - uses: softprops/action-gh-release@v1
@@ -548,13 +549,11 @@ jobs:
           files: artifacts/*/*
           prerelease: false
           body: |
-            > This release renames the project to **CodeWhale**. The legacy
-            > `deepseek` and `deepseek-tui` binaries continue to ship as
-            > compatibility-only deprecation shims during v0.8.x; they print a
-            > one-line warning and forward to `codewhale` / `codewhale-tui`.
-            > They will be removed in v0.9.0. The legacy npm package
-            > `deepseek-tui` is deprecated and receives no further releases.
-            > See `docs/REBRAND.md` for the full migration story.
+            > **CodeWhale** is the canonical project, command, npm package, and
+            > release-asset name. The legacy npm package `deepseek-tui` is
+            > deprecated and receives no further releases. Users coming from
+            > v0.8.x legacy `deepseek` / `deepseek-tui` names should migrate
+            > with `docs/REBRAND.md`.
 
             ## Install
 
@@ -575,7 +574,7 @@ jobs:
               ghcr.io/hmbown/codewhale:${{ needs.resolve.outputs.tag }}
             ```
 
-            The image ships the `codewhale` dispatcher and `codewhale-tui` runtime (plus the legacy `deepseek` / `deepseek-tui` shims during the transition). The `latest` tag is also updated on release.
+            The image ships the `codewhale` dispatcher and `codewhale-tui` runtime. The `latest` tag is also updated on release.
 
             ### Cargo (Linux / macOS)
 
@@ -615,7 +614,7 @@ jobs:
 
             The **portable** Windows archive skips the install script — extract and run from any directory. The NSIS installer is currently unsigned and may trigger Windows SmartScreen until a signing certificate is wired into the release pipeline.
 
-            Individual binaries are also attached below for scripting and the npm wrapper. Legacy `deepseek-*` and `deepseek-tui-*` assets are compatibility-only deprecation shims for v0.8.x so that existing `deepseek update` invocations on v0.8.40 keep working; they forward to the canonical binaries. The legacy npm package `deepseek-tui` is deprecated and is not republished.
+            Individual binaries are also attached below for scripting and the npm wrapper. The legacy npm package `deepseek-tui` is deprecated and is not republished. For migration from v0.8.x legacy binary names, see `docs/REBRAND.md`.
 
             ### Verify (recommended)
 
@@ -634,6 +633,16 @@ jobs:
             ```
 
             The legacy `deepseek-artifacts-sha256.txt` is also attached for backward compatibility and contains the same hashes as the canonical manifest.
+
+            ## Contributors
+
+            Thanks to @sximelon, @cyq1017, @Artenx, @LHqweasd, @wywsoor,
+            @HUQIANTAO, @xyuai, @gaord, @shenjackyuanjie, @idling11,
+            @h3c-hexin, @AresNing, @tdccccc, @qiyuanlicn, @bevis-wong,
+            @shuxiangxuebiancheng, @hongqitai, @NASLXTO, @wuxixing,
+            @linzhiqin2003, @merchloubna70-dot, @puneetdixit200, @mvanhorn,
+            @Implementist, @jrcjrcc, and @punkcanyang for reports, PRs,
+            reviews, reproductions, and harvested work that shaped v0.9.0.
 
             ## Changelog
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -405,7 +405,10 @@ underscore-server-name fix and Xiaomi MiMo pricing (#2747, #2744, #2750, #2731)
 and **@puneetdixit200** for independently diagnosing and fixing the same MCP
 underscore issue (#2746, #2744), **@mvanhorn** for the hydrated deferred-tool
 render fix (#2757, #2648), and **@xyuai** for the Xiaomi MiMo Token Plan region
-documentation (#2756, #2735).
+documentation (#2756, #2735). Additional thanks to **@Implementist** for Plan
+prompt scrolling, wrapping, and display-width fixes, **@jrcjrcc** for the
+Windows sub-agent completion render-width fix, and **@punkcanyang** for the
+original `/init` implementation harvested through #2771/#2745.
 
 ## [0.8.53] - 2026-06-03
 

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -405,7 +405,10 @@ underscore-server-name fix and Xiaomi MiMo pricing (#2747, #2744, #2750, #2731)
 and **@puneetdixit200** for independently diagnosing and fixing the same MCP
 underscore issue (#2746, #2744), **@mvanhorn** for the hydrated deferred-tool
 render fix (#2757, #2648), and **@xyuai** for the Xiaomi MiMo Token Plan region
-documentation (#2756, #2735).
+documentation (#2756, #2735). Additional thanks to **@Implementist** for Plan
+prompt scrolling, wrapping, and display-width fixes, **@jrcjrcc** for the
+Windows sub-agent completion render-width fix, and **@punkcanyang** for the
+original `/init` implementation harvested through #2771/#2745.
 
 ## [0.8.53] - 2026-06-03
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -287,6 +287,38 @@ curl -L -o /tmp/codewhale-artifacts-sha256.txt \
 
 (Use `shasum -a 256 -c` instead of `sha256sum` on macOS.)
 
+### Roll back to a previous release
+
+If a new release is bad on your machine, install the last known-good version
+explicitly. Replace `X.Y.Z` with the version you want to restore.
+
+```bash
+# npm wrapper, including the matching GitHub release binaries
+npm install -g codewhale@X.Y.Z
+
+# Cargo install path; both crates are required
+cargo install codewhale-cli --version X.Y.Z --locked --force
+cargo install codewhale-tui --version X.Y.Z --locked --force
+```
+
+For manual installs, download both binaries or the platform archive from the
+exact release tag and verify the matching checksum manifest from that same tag:
+
+```bash
+# individual binaries
+curl -L -o codewhale-artifacts-sha256.txt \
+  https://github.com/Hmbown/CodeWhale/releases/download/vX.Y.Z/codewhale-artifacts-sha256.txt
+
+# platform archives
+curl -L -o codewhale-bundles-sha256.txt \
+  https://github.com/Hmbown/CodeWhale/releases/download/vX.Y.Z/codewhale-bundles-sha256.txt
+```
+
+Inside a CodeWhale workspace, `/restore list [N]` lists side-git file snapshots
+and `/restore <N>` restores files from the chosen snapshot. That workspace
+rollback does not change your installed binary version and does not rewrite
+conversation history.
+
 ### Windows Scoop
 
 The `codewhale` package is listed in Scoop's main bucket:

--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -205,6 +205,18 @@ remote add cnb …`, then `git push cnb vX.Y.Z`).
 
 ## Recovery and Rollback
 
+- User-facing rollback:
+  - npm: `npm install -g codewhale@X.Y.Z`
+  - Cargo: `cargo install codewhale-cli --version X.Y.Z --locked --force`
+    and `cargo install codewhale-tui --version X.Y.Z --locked --force`
+  - manual assets: download binaries or the platform archive plus the matching
+    `codewhale-artifacts-sha256.txt` or `codewhale-bundles-sha256.txt`
+    manifest from `https://github.com/Hmbown/CodeWhale/releases/tag/vX.Y.Z`
+  - workspace files: use `/restore list [N]` and `/restore <N>` for side-git
+    snapshots; this does not change the installed binary version or rewrite
+    conversation history
+  - keep [docs/INSTALL.md](INSTALL.md#roll-back-to-a-previous-release) in sync
+    with these commands
 - Crates publish partially:
   - rerun `./scripts/release/publish-crates.sh publish`
   - already-published crate versions will be skipped

--- a/docs/V0_9_0_RELEASE_ACCEPTANCE.md
+++ b/docs/V0_9_0_RELEASE_ACCEPTANCE.md
@@ -24,11 +24,11 @@ config source, result, and follow-up issue or PR.
 
 | Gate | Owner | Ship/defer decision | Evidence |
 | --- | --- | --- | --- |
-| DeepSeek V4 direct provider smoke | provider steward | ship |  |
-| Xiaomi MiMo token-plan and pay-as-you-go config smoke | provider steward | ship |  |
-| Arcee Trinity Thinking route smoke or explicit defer | provider steward | decide |  |
+| DeepSeek V4 direct provider smoke | provider steward | manual smoke required before tag | No dated live DeepSeek V4 direct-provider smoke has been recorded on this matrix yet. Static routing/model support exists, but release stewards must add date, OS, provider/model, command, redacted config source, and result before tagging if v0.9 release notes claim live DeepSeek V4 readiness. |
+| Xiaomi MiMo token-plan and pay-as-you-go config smoke | provider steward | ship config evidence / require live smoke before tag if claiming provider availability | Config coverage exercises token-plan and pay-as-you-go env behavior in `crates/config/src/lib.rs` (`xiaomi_mimo_env_token_plan_mode_uses_token_plan_key_and_endpoint`, `xiaomi_mimo_env_pay_as_you_go_mode_prefers_standard_key`) and mirrors the TUI config path in `crates/tui/src/config.rs`; `docs/PROVIDERS.md` documents Token Plan regions and pay-as-you-go mode. This is config evidence only, not a live Xiaomi call. |
+| Arcee Trinity Thinking route smoke or explicit defer | provider steward | defer live smoke / ship static route metadata | Static provider/model metadata exists in `docs/PROVIDERS.md`, `crates/agent/src/lib.rs`, and `crates/tui/src/config.rs`, but no live Arcee credential smoke has been recorded. Do not claim live Arcee route readiness in v0.9 release notes unless a dated manual smoke is added. |
 | Hugging Face provider route and MCP concept helpers ship; native Hub search/passports are deferred | model-lab steward | ship foundation / defer native search-passport runtime | `ProviderKind::Huggingface`, env aliases, picker/docs, and `/hf concepts` / `/hf mcp status` distinguish the chat provider route from Hugging Face MCP and explicit Hub tooling. `docs/PROVIDERS.md` states native Hub HTTP search/passport picker metadata are not shipped behavior in this checkout; #2705/#2707/#2712 remain open for native Model Lab work. |
-| OpenRouter, Novita, Fireworks, and Volcengine env behavior smoke | provider steward | ship |  |
+| OpenRouter, Novita, Fireworks, and Volcengine env behavior smoke | provider steward | ship config evidence / require live smoke before claiming live route coverage | Env/config tests cover OpenRouter, Novita, Fireworks, and Volcengine key/base-url/model override behavior in `crates/config/src/lib.rs`; TUI provider defaults and Volcengine env override are covered in `crates/tui/src/config.rs`, and `docs/PROVIDERS.md` documents the env/default behavior. This is env behavior evidence only, not live provider traffic. |
 | Provider registry drift check covers aliases/default env keys | provider steward | ship | #2820 (`5d491bc68`) added the metadata-only provider registry and `scripts/check-provider-registry.py`; verification included `python3 scripts/check-provider-registry.py` and `cargo test -p codewhale-config provider_ -- --nocapture`. |
 | Provider-scoped TLS skip-verify remains default-off and doctor-visible | security steward | ship | #2834 (`190e9f35e`, `6269cb91f`) landed provider-scoped TLS skip verify with default-off config, doctor warnings, docs, and CLI/runtime option tests. |
 
@@ -36,11 +36,11 @@ config source, result, and follow-up issue or PR.
 
 | Gate | Owner | Ship/defer decision | Evidence |
 | --- | --- | --- | --- |
-| Windows input/render smoke or documented manual verification | runtime steward | ship |  |
-| macOS and Linux TUI startup smoke | runtime steward | ship |  |
-| Large-repo startup smoke | runtime steward | ship |  |
-| Sub-agent timeout/completion smoke | subagent steward | ship |  |
-| Long-running command live-state smoke | runtime steward | ship |  |
+| Windows input/render smoke or documented manual verification | runtime steward | manual smoke required before tag | No dated Windows input/render smoke has been recorded on this matrix yet. Unit/shell-dispatcher tests are not a substitute for Windows ConPTY/manual input verification. |
+| macOS and Linux TUI startup smoke | runtime steward | manual smoke required before tag | Unix PTY tests cover startup/composer basics on Unix-like hosts, but exact-head macOS CI/manual startup evidence and Linux release-startup smoke must still be recorded before tagging. |
+| Large-repo startup smoke | runtime steward | defer full smoke / ship bounded-context mitigation evidence | Bounded project-context tests and changelog evidence cover the mitigation slice, but live large-workspace reports #697 and #1827 remain open. Do not close those issues or claim a full large-repo startup smoke without a dated manual run. |
+| Sub-agent timeout/completion smoke | subagent steward | ship timeout/completion slice | `docs/SUBAGENTS.md` documents per-step timeout and heartbeat behavior; `crates/tui/src/tools/subagent/tests.rs` covers `api_timeout_preserves_checkpoint_and_agent_eval_continues_from_it`, parent completion ordering, and timeout propagation. Broader hung-agent issues #1806/#2614 remain open. |
+| Long-running command live-state smoke | runtime steward | defer root-cause live-state smoke / ship shell-routing tests | Shell tests cover timeout/background/wait/cancel behavior and `shell_job_routing.rs` distinguishes live from stale process state, but #1786 remains open for shell PID/task-flow hangs and premature LIVE-state exit. |
 | Runtime API remains token-protected for GUI clients | GUI steward | ship | #2811/#2814 documented and consumed the existing runtime token flow from the official VS Code extension; #2822 (`bb8835812`) added `GET /v1/snapshots` behind the same runtime API token middleware. |
 | Snapshot/restore surfaces are read-only unless mutation semantics are tested | GUI steward | ship | #2822 (`bb8835812`) and #2828 (`293643e27`) expose restore points as read-only listing/Agent View metadata only; #2808 restore/retry/patch-undo mutation endpoints remain unmerged pending atomicity tests. |
 
@@ -80,17 +80,19 @@ config source, result, and follow-up issue or PR.
 | Gate | Owner | Ship/defer decision | Evidence |
 | --- | --- | --- | --- |
 | README, configuration docs, provider docs, and changelog agree | docs steward | ship | #2845 (`e22a7da53`) aligned README/config example/changelogs with the HarnessProfile cutline and removed stale `V0_9_0_EXECUTION_MAP` links. |
-| Breaking changes, deprecations, and deferred v0.9 gates are listed in release notes | release steward | ship |  |
-| Upgrade steps exist for users coming from `deepseek-tui` | docs steward | ship |  |
-| Rollback steps exist for npm wrapper, Cargo install, and side-git restore | release steward | ship |  |
-| Live GitHub Release body has its own contributor/credit section | release steward | ship |  |
-| Contributors/reporters/helpers from harvested PRs and linked issues are credited | release steward | ship |  |
+| Breaking changes, deprecations, and deferred v0.9 gates are listed in release notes | release steward | ship | Changelog and this matrix list deferred Model Lab/Hugging Face native Hub work, `codebase_search`, remote workbench runtime, WhaleFlow live runtime execution, HarnessProfile runtime selection, large-repo startup smoke, long-running command live-state smoke, and Arcee live smoke. `.github/workflows/release.yml` release-body text avoids stale v0.8.x-only shim wording and keeps CodeWhale as the canonical package/asset name. |
+| Upgrade steps exist for users coming from `deepseek-tui` | docs steward | ship | `docs/REBRAND.md` documents npm/Cargo migration commands, legacy state fallback, binary/package/asset naming, and the v0.9.0 compatibility cutline. |
+| Rollback steps exist for npm wrapper, Cargo install, and side-git restore | release steward | ship | `docs/INSTALL.md#roll-back-to-a-previous-release` and `docs/RELEASE_RUNBOOK.md#recovery-and-rollback` document pinned npm rollback, pinned Cargo rollback for both crates, exact-tag manual asset restore with checksums, and side-git `/restore list [N]` / `/restore <N>` workspace rollback. |
+| Live GitHub Release body has its own contributor/credit section | release steward | post-tag/pre-npm gate | `.github/workflows/release.yml` now creates a dedicated `## Contributors` release-body section with v0.9 contributor, reporter, helper, and harvested-PR credits. The live v0.9.0 Release does not exist yet, so this remains a release-time verification gate before npm publish or completion. |
+| Contributors/reporters/helpers from harvested PRs and linked issues are credited | release steward | ship local changelog / verify live body at release time | Changelog credits include harvested PR authors, issue reporters/helpers, and external/co-authored work including @Implementist, @jrcjrcc, and @punkcanyang. `python3 scripts/check-coauthor-trailers.py --author-map .github/AUTHOR_MAP --range origin/main..HEAD --check-authors` remains the local co-author-map gate; live release-body credits are covered by the row above. |
 
 ## Before Tagging
 
 - [ ] Every `ship` row has evidence.
 - [ ] Every `decide` row is changed to either `ship` with evidence or `defer`
       with an owner and linked follow-up.
+- [ ] Every `manual smoke required` row has dated smoke evidence, or is changed
+      to an explicit defer decision with an owner and linked follow-up.
 - [ ] Draft integration PR CI is green on the exact commit that will be tagged.
 - [ ] The release prompt points new agents to this matrix before any tag,
       publish, or GitHub Release action.


### PR DESCRIPTION
## Summary
- add explicit npm/Cargo/manual asset/side-git rollback instructions for v0.9 release readiness
- add v0.9 contributor credits to changelogs and the generated GitHub Release body
- mark provider/platform acceptance rows honestly as config evidence, manual smoke gates, or explicit defers instead of empty ship rows
- keep the release workflow body aligned with current legacy-shim artifact behavior while leaving actual shim removal as a separate release-infra cutover

## Verification
- git diff --check
- cmp -s CHANGELOG.md crates/tui/CHANGELOG.md
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "yaml-ok"'\n- ./scripts/release/check-versions.sh\n- ./scripts/release/check-ohos-deps.sh\n- python3 scripts/check-coauthor-trailers.py --author-map .github/AUTHOR_MAP --range origin/main..HEAD --check-authors\n\n## Credit\nCredits @Implementist, @jrcjrcc, and @punkcanyang for v0.9 work that was present in history/harvest trails but missing from the current Unreleased contributor paragraph.