### PR TITLE
fix(tui): prevent AltGr from swallowing @/#/$/!/%/ characters in composer

### DIFF
--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -2873,29 +2873,35 @@ async fn run_event_loop(
                     apply_alt_4_shortcut(app, key.modifiers);
                     continue;
                 }
-                KeyCode::Char('!') if key.modifiers.contains(KeyModifiers::ALT) => {
+                // Sidebar focus via Alt+! / Alt+@ / Alt+# / Alt+$ / Alt+%)
+                // AltGr on European keyboards emits Ctrl+Alt on Windows, so
+                // exclude Ctrl to avoid swallowing AltGr-typed characters
+                // like @ (AltGr+0 on French AZERTY) and # (AltGr+3). This
+                // matches the has_ctrl_or_alt / is_altgr philosophy in
+                // key_hint.rs: treat Ctrl+Alt as AltGr, not a shortcut.
+                KeyCode::Char('!') if key.modifiers.contains(KeyModifiers::ALT) && !key.modifiers.contains(KeyModifiers::CONTROL) => {
                     app.set_sidebar_focus(SidebarFocus::Work);
                     app.status_message = Some("Sidebar focus: work".to_string());
                     continue;
                 }
-                KeyCode::Char('@') if key.modifiers.contains(KeyModifiers::ALT) => {
+                KeyCode::Char('@') if key.modifiers.contains(KeyModifiers::ALT) && !key.modifiers.contains(KeyModifiers::CONTROL) => {
                     app.set_sidebar_focus(SidebarFocus::Tasks);
                     app.status_message = Some("Sidebar focus: tasks".to_string());
                     continue;
                 }
-                KeyCode::Char('#') if key.modifiers.contains(KeyModifiers::ALT) => {
+                KeyCode::Char('#') if key.modifiers.contains(KeyModifiers::ALT) && !key.modifiers.contains(KeyModifiers::CONTROL) => {
                     app.set_sidebar_focus(SidebarFocus::Agents);
                     app.status_message = Some("Sidebar focus: agents".to_string());
                     continue;
                 }
                 KeyCode::Char('$') | KeyCode::Char('%')
-                    if key.modifiers.contains(KeyModifiers::ALT) =>
+                    if key.modifiers.contains(KeyModifiers::ALT) && !key.modifiers.contains(KeyModifiers::CONTROL) =>
                 {
                     app.set_sidebar_focus(SidebarFocus::Context);
                     app.status_message = Some("Sidebar focus: context".to_string());
                     continue;
                 }
-                KeyCode::Char(')') if key.modifiers.contains(KeyModifiers::ALT) => {
+                KeyCode::Char(')') if key.modifiers.contains(KeyModifiers::ALT) && !key.modifiers.contains(KeyModifiers::CONTROL) => {
                     app.set_sidebar_focus(SidebarFocus::Auto);
                     app.status_message = Some("Sidebar focus: auto".to_string());
                     continue;

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -2879,29 +2879,42 @@ async fn run_event_loop(
                 // like @ (AltGr+0 on French AZERTY) and # (AltGr+3). This
                 // matches the has_ctrl_or_alt / is_altgr philosophy in
                 // key_hint.rs: treat Ctrl+Alt as AltGr, not a shortcut.
-                KeyCode::Char('!') if key.modifiers.contains(KeyModifiers::ALT) && !key.modifiers.contains(KeyModifiers::CONTROL) => {
+                KeyCode::Char('!')
+                    if key.modifiers.contains(KeyModifiers::ALT)
+                        && !key.modifiers.contains(KeyModifiers::CONTROL) =>
+                {
                     app.set_sidebar_focus(SidebarFocus::Work);
                     app.status_message = Some("Sidebar focus: work".to_string());
                     continue;
                 }
-                KeyCode::Char('@') if key.modifiers.contains(KeyModifiers::ALT) && !key.modifiers.contains(KeyModifiers::CONTROL) => {
+                KeyCode::Char('@')
+                    if key.modifiers.contains(KeyModifiers::ALT)
+                        && !key.modifiers.contains(KeyModifiers::CONTROL) =>
+                {
                     app.set_sidebar_focus(SidebarFocus::Tasks);
                     app.status_message = Some("Sidebar focus: tasks".to_string());
                     continue;
                 }
-                KeyCode::Char('#') if key.modifiers.contains(KeyModifiers::ALT) && !key.modifiers.contains(KeyModifiers::CONTROL) => {
+                KeyCode::Char('#')
+                    if key.modifiers.contains(KeyModifiers::ALT)
+                        && !key.modifiers.contains(KeyModifiers::CONTROL) =>
+                {
                     app.set_sidebar_focus(SidebarFocus::Agents);
                     app.status_message = Some("Sidebar focus: agents".to_string());
                     continue;
                 }
                 KeyCode::Char('$') | KeyCode::Char('%')
-                    if key.modifiers.contains(KeyModifiers::ALT) && !key.modifiers.contains(KeyModifiers::CONTROL) =>
+                    if key.modifiers.contains(KeyModifiers::ALT)
+                        && !key.modifiers.contains(KeyModifiers::CONTROL) =>
                 {
                     app.set_sidebar_focus(SidebarFocus::Context);
                     app.status_message = Some("Sidebar focus: context".to_string());
                     continue;
                 }
-                KeyCode::Char(')') if key.modifiers.contains(KeyModifiers::ALT) && !key.modifiers.contains(KeyModifiers::CONTROL) => {
+                KeyCode::Char(')')
+                    if key.modifiers.contains(KeyModifiers::ALT)
+                        && !key.modifiers.contains(KeyModifiers::CONTROL) =>
+                {
                     app.set_sidebar_focus(SidebarFocus::Auto);
                     app.status_message = Some("Sidebar focus: auto".to_string());
                     continue;


### PR DESCRIPTION
## Problem

On Windows, `AltGr` is delivered as `Ctrl+Alt` by crossterm. European keyboard layouts use AltGr to type common characters:
- French AZERTY: `@` = `AltGr+0`, `#` = `AltGr+3`
- German QWERTZ: `@` = `AltGr+Q`
- UK QWERTY: `#` = `AltGr+3`

The sidebar-focus shortcuts (`Alt+@`, `Alt+!`, `Alt+#`, `Alt+$`, `Alt+%)`, `Alt+)`) were matching on `key.modifiers.contains(KeyModifiers::ALT)` alone — so when a European user pressed AltGr to type `@`, the TUI interpreted it as the `Alt+@` sidebar shortcut and focused the sidebar instead of inserting the character.

Closes #2863.

## Fix

Added `&& !key.modifiers.contains(KeyModifiers::CONTROL)` to five sidebar-focus shortcut guards (`!`, `@`, `#`, `$/%`, `)`). When AltGr produces `Ctrl+Alt+char`, the shortcut no longer fires and the character falls through to the `KeyCode::Char(c)` catch-all, which inserts it as text.

This is consistent with the existing codebase philosophy in `key_hint.rs`, where `has_ctrl_or_alt()` and `is_altgr()` already treat `Ctrl+Alt` as AltGr on Windows — trading the rare ability to bind `Ctrl+Alt+<char>` shortcuts for not swallowing European keyboard input.

## Testing

- **Existing behavior preserved**: `Alt+@` (without Ctrl) still focuses the Tasks sidebar on all platforms.
- **AltGr fix**: `Ctrl+Alt+@` (AltGr+0 on French AZERTY) now inserts `@` as text instead of triggering the sidebar shortcut.
- The `Alt+0` / `Ctrl+Alt+0` shortcut is untouched — `apply_alt_0_shortcut` already handles Ctrl internally, and `AltGr+0` on French AZERTY produces `@` (not `0`), so it doesn't conflict.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where European keyboard users on Windows could not type `@`, `#`, `$`, `!`, or `)` in the composer because AltGr (delivered as `Ctrl+Alt` by crossterm) was incorrectly matching the sidebar-focus shortcuts. The fix adds `&& !key.modifiers.contains(KeyModifiers::CONTROL)` to five match guards so that `Ctrl+Alt+<char>` events fall through to the `KeyCode::Char(c)` catch-all and are inserted as text.

- **Five sidebar shortcuts patched** (`!`, `@`, `#`, `$/%`, `)`): adding `!CONTROL` to each guard prevents AltGr-produced characters from triggering focus changes on Windows while leaving plain `Alt+<char>` shortcuts fully intact.
- **Catch-all path confirmed safe**: `KeyCode::Char(c) => { app.insert_char(c); }` at the end of the match has no modifier guard, so the rejected `Ctrl+Alt+@` event is correctly handed off to character insertion.
- **Adjacent shortcuts unaffected**: `Alt+0` and `Alt+1/2/3/4` already inspect or delegate `KeyModifiers::CONTROL` internally and are not touched by this change.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal, targeted guard addition with no regressions on the happy path.

The five changed guards each gain one additional condition that rejects events carrying both ALT and CONTROL. The downstream catch-all has no modifier guard, so rejected events are correctly routed to character insertion. Adjacent shortcuts already handle or delegate CONTROL internally and are untouched. The tradeoff that Ctrl+Alt+char no longer fires sidebar shortcuts on any platform is explicitly documented in both the PR description and the inline comment.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/ui.rs | Five sidebar-focus match guards updated to exclude Ctrl, preventing AltGr characters from being swallowed; the change is surgical and the fall-through to insert_char is verified correct. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Key Event received] --> B{Char is one of ! @ # $ percent close-paren}
    B -- no --> C[Other key handlers]
    B -- yes --> D{ALT modifier present?}
    D -- no --> E[Char catch-all: app.insert_char]
    D -- yes --> F{CONTROL modifier also present? Ctrl+Alt = AltGr on Windows}
    F -- yes --> E
    F -- no --> G[set_sidebar_focus and update status_message]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["style(tui): format AltGr sidebar shortcu..."](https://github.com/hmbown/codewhale/commit/700a36edf11b69eb37177b04e74b268f00150079) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36015358)</sub>

<!-- /greptile_comment -->