### PR TITLE
fix(tui): list saved models from all providers in /model picker

### DIFF
--- a/crates/tui/src/tui/model_picker.rs
+++ b/crates/tui/src/tui/model_picker.rs
@@ -385,6 +385,36 @@ fn picker_model_rows_for_app(app: &App) -> Vec<ModelPickerRow> {
         );
     }
 
+    // Surface models saved under *other* providers in config (#2596). The
+    // active provider's list comes first; cross-provider saved models follow as
+    // a clearly labelled tail so a custom model that has never been selected on
+    // the current provider is still reachable. Selecting one switches provider
+    // on apply via `resolved_provider` / `build_event`. Rows are sorted by
+    // provider key so ordering stays deterministic regardless of map iteration.
+    let mut other_provider_models: Vec<(&String, &String)> = app
+        .provider_models
+        .iter()
+        .filter(|(key, _)| ApiProvider::parse(key) != Some(app.api_provider))
+        .collect();
+    other_provider_models.sort_by(|(a, _), (b, _)| a.cmp(b));
+    for (key, model) in other_provider_models {
+        let Some(provider) = ApiProvider::parse(key) else {
+            // Unknown provider key — we cannot switch to it, so skip rather
+            // than offer a row that would fail to apply.
+            continue;
+        };
+        let model = model.trim();
+        if model.is_empty() {
+            continue;
+        }
+        push_model_row(
+            &mut rows,
+            model.to_string(),
+            Some(provider),
+            format!("{} saved", provider.display_name()),
+        );
+    }
+
     rows
 }
 
@@ -855,7 +885,9 @@ mod tests {
     }
 
     #[test]
-    fn picker_hides_saved_models_from_other_providers() {
+    fn picker_lists_saved_models_from_other_providers() {
+        // #2596: custom models saved under a non-active provider must be
+        // reachable from the picker, after the active provider's own models.
         let (mut app, _lock) = create_test_app();
         app.api_provider = crate::config::ApiProvider::XiaomiMimo;
         app.model = "mimo-v2.5-pro".to_string();
@@ -868,10 +900,53 @@ mod tests {
         let view = ModelPickerView::new(&app);
         let model_ids = view.visible_model_ids();
 
+        // Active provider's own model stays present (and ahead of the tail).
         assert!(model_ids.contains(&"mimo-v2.5-pro"));
-        assert!(!model_ids.contains(&"deepseek-v4-pro"));
-        assert!(!model_ids.contains(&"kimi-k2.6"));
+        // Cross-provider saved models are now visible.
+        assert!(model_ids.contains(&"deepseek-v4-pro"));
+        assert!(model_ids.contains(&"kimi-k2.6"));
         assert!(!view.show_custom_model_row);
+
+        // Each cross-provider row carries its own provider so applying it
+        // switches CodeWhale to that provider (verified via build_event below).
+        let deepseek_row = view
+            .visible_model_rows()
+            .iter()
+            .find(|row| row.id == "deepseek-v4-pro")
+            .expect("deepseek-v4-pro row present");
+        assert_eq!(
+            deepseek_row.provider,
+            Some(crate::config::ApiProvider::Deepseek)
+        );
+
+        // Active-provider model must appear before any cross-provider tail row.
+        let active_idx = model_ids
+            .iter()
+            .position(|id| *id == "mimo-v2.5-pro")
+            .expect("active model index");
+        let cross_idx = model_ids
+            .iter()
+            .position(|id| *id == "kimi-k2.6")
+            .expect("cross-provider model index");
+        assert!(
+            active_idx < cross_idx,
+            "active provider models should precede cross-provider tail"
+        );
+    }
+
+    #[test]
+    fn picker_skips_unknown_provider_saved_models() {
+        // A config key that maps to no known provider cannot be applied, so it
+        // must not produce a picker row (#2596).
+        let (mut app, _lock) = create_test_app();
+        app.api_provider = crate::config::ApiProvider::XiaomiMimo;
+        app.model = "mimo-v2.5-pro".to_string();
+        app.auto_model = false;
+        app.provider_models
+            .insert("totally-unknown".to_string(), "ghost-model".to_string());
+
+        let view = ModelPickerView::new(&app);
+        assert!(!view.visible_model_ids().contains(&"ghost-model"));
     }
 
     #[test]

--- a/crates/tui/src/tui/model_picker.rs
+++ b/crates/tui/src/tui/model_picker.rs
@@ -391,18 +391,19 @@ fn picker_model_rows_for_app(app: &App) -> Vec<ModelPickerRow> {
     // the current provider is still reachable. Selecting one switches provider
     // on apply via `resolved_provider` / `build_event`. Rows are sorted by
     // provider key so ordering stays deterministic regardless of map iteration.
-    let mut other_provider_models: Vec<(&String, &String)> = app
+    // Parse each provider key once: drop unknown keys (cannot be applied) and
+    // the active provider (already listed above) in a single pass. `key` is
+    // kept only to keep ordering deterministic via the sort below.
+    let mut other_provider_models: Vec<(&String, ApiProvider, &String)> = app
         .provider_models
         .iter()
-        .filter(|(key, _)| ApiProvider::parse(key) != Some(app.api_provider))
+        .filter_map(|(key, model)| {
+            let provider = ApiProvider::parse(key)?;
+            (provider != app.api_provider).then_some((key, provider, model))
+        })
         .collect();
-    other_provider_models.sort_by(|(a, _), (b, _)| a.cmp(b));
-    for (key, model) in other_provider_models {
-        let Some(provider) = ApiProvider::parse(key) else {
-            // Unknown provider key — we cannot switch to it, so skip rather
-            // than offer a row that would fail to apply.
-            continue;
-        };
+    other_provider_models.sort_by(|(a, ..), (b, ..)| a.cmp(b));
+    for (_key, provider, model) in other_provider_models {
         let model = model.trim();
         if model.is_empty() {
             continue;

--- a/crates/tui/src/tui/model_picker.rs
+++ b/crates/tui/src/tui/model_picker.rs
@@ -402,7 +402,7 @@ fn picker_model_rows_for_app(app: &App) -> Vec<ModelPickerRow> {
             (provider != app.api_provider).then_some((key, provider, model))
         })
         .collect();
-    other_provider_models.sort_by(|(a, ..), (b, ..)| a.cmp(b));
+    other_provider_models.sort_by_key(|(a, ..)| *a);
     for (_key, provider, model) in other_provider_models {
         let model = model.trim();
         if model.is_empty() {


### PR DESCRIPTION
## Summary

- The `/model` picker only listed the active provider's models plus that provider's saved model, so a custom model saved under a *different* provider in config (e.g. `kimi-k2.6` under `moonshot` while the active provider is `deepseek`) was invisible in the picker — even though `/model kimi-k2.6` typed directly resolves and the model runs.
- `picker_model_rows_for_app` now appends cross-provider saved models from `provider_models` as a clearly labelled tail (`<Provider> saved`) after the active provider's list. The active provider's models still come first.
- Selecting a cross-provider row switches CodeWhale to that provider on apply, reusing the existing `resolved_provider` / `build_event` path (no new apply logic). Config keys that map to no known provider are skipped since they cannot be applied.

Fixes #2596.

## Design note

`picker_hides_saved_models_from_other_providers` previously asserted these models stay hidden. That test is repurposed into `picker_lists_saved_models_from_other_providers` to reflect the issue's requested behaviour (Option C — keep the active list first, add a labelled cross-provider tail). The apply path already supported a row carrying its own provider, so this only changes what rows are built, not how they apply.

## Test verification (RED -> GREEN)

New/updated test: `picker_lists_saved_models_from_other_providers`.

RED (prod fix reverted, cross-provider loop removed):
```
test tui::model_picker::tests::picker_lists_saved_models_from_other_providers ... FAILED
panicked at crates/tui/src/tui/model_picker.rs: assert model_ids.contains("deepseek-v4-pro")
test result: FAILED. 28 passed; 1 failed
```

GREEN (fix applied):
```
test tui::model_picker::tests::picker_lists_saved_models_from_other_providers ... ok
test tui::model_picker::tests::picker_skips_unknown_provider_saved_models ... ok
test result: ok. 29 passed; 0 failed
```

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features`
- [x] `cargo test --workspace --all-features` — 4608 passed, 0 failed (baseline 4607; +1 new test, no regressions)

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [x] Verified TUI behavior manually if UI changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Makes cross-provider saved models visible in the `/model` picker by appending them as a labelled tail after the active provider's list, and switches the provider on apply via the existing `resolved_provider` / `build_event` path.

- `picker_model_rows_for_app` now iterates `provider_models`, parses each key with `ApiProvider::parse`, skips the active provider and unknown keys, sorts the remainder deterministically by config key, and pushes one labelled row per entry.
- `picker_hides_saved_models_from_other_providers` is repurposed into `picker_lists_saved_models_from_other_providers` with assertions for ordering, row-level provider attribution, and provider-switch on apply; a new `picker_skips_unknown_provider_saved_models` test covers the filter-out path.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the apply path is unchanged and all existing tests pass with one new test converted from failing to green.

The change is contained to row-building logic with no modification to how events are emitted or applied. There is one untested edge case: when the user's active model was set via a direct /model command to a cross-provider ID rather than through the picker, that model now appears both as a labelled tail row and as the current (custom) row — a cosmetic duplication that does not cause incorrect behaviour but could confuse users.

crates/tui/src/tui/model_picker.rs — specifically the ModelPickerView::new selection logic and the interaction between show_custom_model_row and the new cross-provider tail rows.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/tui/model_picker.rs | Adds a cross-provider saved-model tail to the picker row list, sorts it deterministically by config key, filters out unknown providers, and updates tests to assert the new behaviour. The core fix is correct; a minor edge case exists where the model can appear twice if set via direct command rather than the picker. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[picker_model_rows_for_app] --> B[Push auto row]
    B --> C[Push active provider known models]
    C --> D{Active provider saved model exists?}
    D -- Yes --> E[Push Active-Provider saved row]
    D -- No --> F
    E --> F[Iterate all provider_models entries]
    F --> G{ApiProvider::parse succeeds?}
    G -- No unknown key --> H[Skip entry]
    G -- Yes --> I{Same as active provider?}
    I -- Yes --> H
    I -- No --> J[Collect cross-provider entry]
    J --> K[Sort by config key string]
    K --> L{model string empty after trim?}
    L -- Yes --> H
    L -- No --> M[Push Provider-saved row with provider set]
    M --> N[Return rows]
    H --> N
```
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2Fissue-2596%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fissue-2596%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fmodel_picker.rs%3A71-78%0A**Cross-provider%20model%20shown%20twice%20when%20set%20via%20direct%20command**%0A%0AThe%20%60selected_model_idx%60%20search%20%28line%2071%E2%80%9374%29%20matches%20only%20rows%20whose%20%60provider%60%20is%20%60None%60%20%28auto%29%20or%20equal%20to%20%60app.api_provider%60.%20Cross-provider%20rows%20added%20by%20the%20new%20tail%20loop%20never%20satisfy%20%60row.provider%20%3D%3D%20Some%28app.api_provider%29%60%2C%20so%20when%20%60app.model%60%20was%20set%20to%20a%20cross-provider%20model%20through%20a%20direct%20%60%2Fmodel%20%3Cid%3E%60%20command%20%28not%20via%20the%20picker%29%2C%20%60selected_model_idx%60%20stays%20%60None%60%2C%20%60show_custom_model_row%60%20becomes%20%60true%60%2C%20and%20the%20model%20ends%20up%20appearing%20twice%3A%20once%20as%20a%20labelled%20%22X%20saved%22%20tail%20row%20and%20once%20as%20the%20%22current%20%28custom%29%22%20row%20at%20the%20bottom.%20The%20PR%20description%20specifically%20mentions%20this%20path%20%28%22even%20though%20%60%2Fmodel%20kimi-k2.6%60%20typed%20directly%20resolves%20and%20the%20model%20runs%22%29%2C%20so%20the%20scenario%20is%20realistic.%20The%20fix%20would%20be%20to%20let%20the%20search%20also%20accept%20a%20cross-provider%20match%2C%20or%20to%20suppress%20%60show_custom_model_row%60%20when%20the%20model%20is%20already%20present%20as%20any%20tail%20row.%0A%0ANo%20test%20exercises%20the%20case%20where%20%60app.model%60%20equals%20a%20cross-provider%20saved%20model%20while%20%60api_provider%60%20is%20still%20the%20original%20provider.%0A%0A&repo=hmbown%2Fcodewhale&pr=2869&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fmodel_picker.rs%3A71-78%0A**Cross-provider%20model%20shown%20twice%20when%20set%20via%20direct%20command**%0A%0AThe%20%60selected_model_idx%60%20search%20%28line%2071%E2%80%9374%29%20matches%20only%20rows%20whose%20%60provider%60%20is%20%60None%60%20%28auto%29%20or%20equal%20to%20%60app.api_provider%60.%20Cross-provider%20rows%20added%20by%20the%20new%20tail%20loop%20never%20satisfy%20%60row.provider%20%3D%3D%20Some%28app.api_provider%29%60%2C%20so%20when%20%60app.model%60%20was%20set%20to%20a%20cross-provider%20model%20through%20a%20direct%20%60%2Fmodel%20%3Cid%3E%60%20command%20%28not%20via%20the%20picker%29%2C%20%60selected_model_idx%60%20stays%20%60None%60%2C%20%60show_custom_model_row%60%20becomes%20%60true%60%2C%20and%20the%20model%20ends%20up%20appearing%20twice%3A%20once%20as%20a%20labelled%20%22X%20saved%22%20tail%20row%20and%20once%20as%20the%20%22current%20%28custom%29%22%20row%20at%20the%20bottom.%20The%20PR%20description%20specifically%20mentions%20this%20path%20%28%22even%20though%20%60%2Fmodel%20kimi-k2.6%60%20typed%20directly%20resolves%20and%20the%20model%20runs%22%29%2C%20so%20the%20scenario%20is%20realistic.%20The%20fix%20would%20be%20to%20let%20the%20search%20also%20accept%20a%20cross-provider%20match%2C%20or%20to%20suppress%20%60show_custom_model_row%60%20when%20the%20model%20is%20already%20present%20as%20any%20tail%20row.%0A%0ANo%20test%20exercises%20the%20case%20where%20%60app.model%60%20equals%20a%20cross-provider%20saved%20model%20while%20%60api_provider%60%20is%20still%20the%20original%20provider.%0A%0A&repo=hmbown%2Fcodewhale&pr=2869&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftui%2Fsrc%2Ftui%2Fmodel_picker.rs%3A71-78%0A**Cross-provider%20model%20shown%20twice%20when%20set%20via%20direct%20command**%0A%0AThe%20%60selected_model_idx%60%20search%20%28line%2071%E2%80%9374%29%20matches%20only%20rows%20whose%20%60provider%60%20is%20%60None%60%20%28auto%29%20or%20equal%20to%20%60app.api_provider%60.%20Cross-provider%20rows%20added%20by%20the%20new%20tail%20loop%20never%20satisfy%20%60row.provider%20%3D%3D%20Some%28app.api_provider%29%60%2C%20so%20when%20%60app.model%60%20was%20set%20to%20a%20cross-provider%20model%20through%20a%20direct%20%60%2Fmodel%20%3Cid%3E%60%20command%20%28not%20via%20the%20picker%29%2C%20%60selected_model_idx%60%20stays%20%60None%60%2C%20%60show_custom_model_row%60%20becomes%20%60true%60%2C%20and%20the%20model%20ends%20up%20appearing%20twice%3A%20once%20as%20a%20labelled%20%22X%20saved%22%20tail%20row%20and%20once%20as%20the%20%22current%20%28custom%29%22%20row%20at%20the%20bottom.%20The%20PR%20description%20specifically%20mentions%20this%20path%20%28%22even%20though%20%60%2Fmodel%20kimi-k2.6%60%20typed%20directly%20resolves%20and%20the%20model%20runs%22%29%2C%20so%20the%20scenario%20is%20realistic.%20The%20fix%20would%20be%20to%20let%20the%20search%20also%20accept%20a%20cross-provider%20match%2C%20or%20to%20suppress%20%60show_custom_model_row%60%20when%20the%20model%20is%20already%20present%20as%20any%20tail%20row.%0A%0ANo%20test%20exercises%20the%20case%20where%20%60app.model%60%20equals%20a%20cross-provider%20saved%20model%20while%20%60api_provider%60%20is%20still%20the%20original%20provider.%0A%0A&pr=2869&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["fix(tui): use sort\_by\_key to satisfy cli..."](https://github.com/hmbown/codewhale/commit/97f6e0b2e5f9ed12c4e08c63ec655e4753483588) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36039335)</sub>

<!-- /greptile_comment -->