### PR TITLE
  feat(config): add hotbar slot persistence

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -89,6 +89,26 @@ check_for_updates = true
 # update_uri = "https://internal.mirror.example/codewhale/releases/latest"
 
 # ─────────────────────────────────────────────────────────────────────────────────
+# Hotbar slots (#2061 / #2064)
+# ─────────────────────────────────────────────────────────────────────────────────
+# Optional 1-8 sidebar hotbar bindings. When no [[hotbar]] tables are present,
+# the TUI uses built-in defaults:
+#   1 voice.toggle      2 session.compact   3 mode.plan        4 mode.agent
+#   5 mode.yolo         6 palette.open      7 sidebar.toggle   8 trust.toggle
+#
+# Invalid slots are skipped with a warning, duplicate slots use the last entry,
+# and unknown actions are preserved so the UI can show a disabled placeholder.
+#
+# [[hotbar]]
+# slot = 1
+# label = "voice"
+# action = "voice.toggle"
+#
+# [[hotbar]]
+# slot = 2
+# action = "session.compact"
+
+# ─────────────────────────────────────────────────────────────────────────────────
 # Paths
 # ─────────────────────────────────────────────────────────────────────────────────
 # New installs write product state under ~/.codewhale/. Existing ~/.deepseek/

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod provider;
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
 use std::fs;
 #[cfg(unix)]
 use std::io::Write;
@@ -539,6 +540,10 @@ pub struct ConfigToml {
     /// v0.9 slices; this is the durable config data model.
     #[serde(default)]
     pub harness_profiles: Vec<HarnessProfile>,
+    /// Optional 1-8 hotbar slot bindings (#2064). When absent, the TUI falls
+    /// back to the built-in default slots.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hotbar: Option<Vec<HotbarBindingToml>>,
     /// App-server hook sink configuration. Kept separate from the TUI
     /// lifecycle `[hooks]` table so config rewrites preserve existing hooks.
     #[serde(default)]
@@ -562,6 +567,16 @@ impl ConfigToml {
         self.harness_profiles
             .iter()
             .find(|profile| profile.matches_route(provider_route, model))
+    }
+
+    /// Resolve durable hotbar config into normalized 1-8 slot bindings.
+    ///
+    /// `known_action_ids` is supplied by the TUI action registry in later
+    /// slices. Unknown actions are preserved so the UI can render a disabled
+    /// `?` cell instead of silently deleting user config.
+    #[must_use]
+    pub fn resolve_hotbar_bindings(&self, known_action_ids: &[&str]) -> HotbarConfigResolution {
+        resolve_hotbar_bindings(self.hotbar.as_deref(), known_action_ids)
     }
 }
 
@@ -614,6 +629,148 @@ fn wildcard_chars_match(pattern: &[char], value: &[char]) -> bool {
 pub struct ProviderChain {
     providers: Vec<ProviderKind>,
     position: usize,
+}
+
+pub const HOTBAR_SLOT_COUNT: u8 = 8;
+
+pub const DEFAULT_HOTBAR_ACTIONS: [&str; HOTBAR_SLOT_COUNT as usize] = [
+    "voice.toggle",
+    "session.compact",
+    "mode.plan",
+    "mode.agent",
+    "mode.yolo",
+    "palette.open",
+    "sidebar.toggle",
+    "trust.toggle",
+];
+
+/// On-disk schema for one `[[hotbar]]` table.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct HotbarBindingToml {
+    pub slot: u8,
+    pub action: String,
+    #[serde(default)]
+    pub label: Option<String>,
+}
+
+/// Validated hotbar binding used by future render/dispatch layers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HotbarBinding {
+    pub slot: u8,
+    pub action: String,
+    pub label: Option<String>,
+}
+
+/// Non-fatal hotbar config issue. Invalid slots are skipped; duplicate slots
+/// use the last binding; unknown actions are kept for UI feedback.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HotbarConfigWarning {
+    SlotOutOfRange {
+        slot: u8,
+        action: String,
+    },
+    DuplicateSlot {
+        slot: u8,
+        previous_action: String,
+        replacement_action: String,
+    },
+    UnknownAction {
+        slot: u8,
+        action: String,
+    },
+}
+
+impl fmt::Display for HotbarConfigWarning {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::SlotOutOfRange { slot, action } => write!(
+                f,
+                "hotbar slot {slot} for action '{action}' is outside 1-{HOTBAR_SLOT_COUNT}; skipped"
+            ),
+            Self::DuplicateSlot {
+                slot,
+                previous_action,
+                replacement_action,
+            } => write!(
+                f,
+                "hotbar slot {slot} was bound to '{previous_action}' more than once; using '{replacement_action}'"
+            ),
+            Self::UnknownAction { slot, action } => write!(
+                f,
+                "hotbar slot {slot} references unknown action '{action}'; keeping binding"
+            ),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HotbarConfigResolution {
+    pub bindings: Vec<HotbarBinding>,
+    pub warnings: Vec<HotbarConfigWarning>,
+}
+
+#[must_use]
+pub fn default_hotbar_bindings() -> Vec<HotbarBinding> {
+    DEFAULT_HOTBAR_ACTIONS
+        .iter()
+        .enumerate()
+        .map(|(idx, action)| HotbarBinding {
+            slot: u8::try_from(idx + 1).expect("default hotbar slot fits in u8"),
+            action: (*action).to_string(),
+            label: None,
+        })
+        .collect()
+}
+
+#[must_use]
+pub fn resolve_hotbar_bindings(
+    configured: Option<&[HotbarBindingToml]>,
+    known_action_ids: &[&str],
+) -> HotbarConfigResolution {
+    let known = known_action_ids.iter().copied().collect::<BTreeSet<&str>>();
+    let mut warnings = Vec::new();
+
+    let source = match configured {
+        Some(bindings) => bindings
+            .iter()
+            .map(|binding| HotbarBinding {
+                slot: binding.slot,
+                action: binding.action.clone(),
+                label: binding.label.clone(),
+            })
+            .collect::<Vec<_>>(),
+        None => default_hotbar_bindings(),
+    };
+
+    let mut by_slot: BTreeMap<u8, HotbarBinding> = BTreeMap::new();
+    for binding in source {
+        if !(1..=HOTBAR_SLOT_COUNT).contains(&binding.slot) {
+            warnings.push(HotbarConfigWarning::SlotOutOfRange {
+                slot: binding.slot,
+                action: binding.action,
+            });
+            continue;
+        }
+        if !known.is_empty() && !known.contains(binding.action.as_str()) {
+            warnings.push(HotbarConfigWarning::UnknownAction {
+                slot: binding.slot,
+                action: binding.action.clone(),
+            });
+        }
+        if let Some(previous) = by_slot.insert(binding.slot, binding.clone()) {
+            warnings.push(HotbarConfigWarning::DuplicateSlot {
+                slot: binding.slot,
+                previous_action: previous.action,
+                replacement_action: binding.action,
+            });
+        }
+    }
+
+    HotbarConfigResolution {
+        bindings: by_slot.into_values().collect(),
+        warnings,
+    }
 }
 
 impl ProviderChain {
@@ -3174,6 +3331,132 @@ mod tests {
         .expect_err("permissions.toml should be ask-only in this slice");
 
         assert!(err.message().contains("unknown field"));
+    }
+
+    #[test]
+    fn hotbar_defaults_when_config_is_absent() {
+        let config = ConfigToml::default();
+
+        let resolved = config.resolve_hotbar_bindings(&DEFAULT_HOTBAR_ACTIONS);
+
+        assert_eq!(resolved.warnings, Vec::new());
+        assert_eq!(resolved.bindings, default_hotbar_bindings());
+        assert_eq!(
+            resolved
+                .bindings
+                .iter()
+                .map(|binding| (binding.slot, binding.action.as_str()))
+                .collect::<Vec<_>>(),
+            vec![
+                (1, "voice.toggle"),
+                (2, "session.compact"),
+                (3, "mode.plan"),
+                (4, "mode.agent"),
+                (5, "mode.yolo"),
+                (6, "palette.open"),
+                (7, "sidebar.toggle"),
+                (8, "trust.toggle"),
+            ]
+        );
+    }
+
+    #[test]
+    fn hotbar_tables_parse_and_round_trip() {
+        let config: ConfigToml = toml::from_str(
+            r#"
+[[hotbar]]
+slot = 1
+label = "Plan"
+action = "mode.plan"
+
+[[hotbar]]
+slot = 2
+action = "session.compact"
+"#,
+        )
+        .expect("parse hotbar tables");
+
+        let resolved = config.resolve_hotbar_bindings(&["mode.plan", "session.compact"]);
+
+        assert_eq!(
+            resolved.bindings,
+            vec![
+                HotbarBinding {
+                    slot: 1,
+                    action: "mode.plan".to_string(),
+                    label: Some("Plan".to_string()),
+                },
+                HotbarBinding {
+                    slot: 2,
+                    action: "session.compact".to_string(),
+                    label: None,
+                },
+            ]
+        );
+        assert_eq!(resolved.warnings, Vec::new());
+
+        let serialized = toml::to_string_pretty(&config).expect("serialize config");
+        let round_tripped: ConfigToml =
+            toml::from_str(&serialized).expect("deserialize serialized config");
+        assert_eq!(round_tripped.hotbar, config.hotbar);
+    }
+
+    #[test]
+    fn hotbar_validation_warns_without_dropping_unknown_actions() {
+        let config: ConfigToml = toml::from_str(
+            r#"
+[[hotbar]]
+slot = 0
+action = "mode.plan"
+
+[[hotbar]]
+slot = 2
+action = "mode.plan"
+
+[[hotbar]]
+slot = 2
+action = "custom.action"
+
+[[hotbar]]
+slot = 9
+action = "mode.agent"
+"#,
+        )
+        .expect("parse hotbar tables");
+
+        let resolved = config.resolve_hotbar_bindings(&["mode.plan", "mode.agent"]);
+
+        assert_eq!(
+            resolved.bindings,
+            vec![HotbarBinding {
+                slot: 2,
+                action: "custom.action".to_string(),
+                label: None,
+            }]
+        );
+        assert_eq!(
+            resolved.warnings,
+            vec![
+                HotbarConfigWarning::SlotOutOfRange {
+                    slot: 0,
+                    action: "mode.plan".to_string(),
+                },
+                HotbarConfigWarning::UnknownAction {
+                    slot: 2,
+                    action: "custom.action".to_string(),
+                },
+                HotbarConfigWarning::DuplicateSlot {
+                    slot: 2,
+                    previous_action: "mode.plan".to_string(),
+                    replacement_action: "custom.action".to_string(),
+                },
+                HotbarConfigWarning::SlotOutOfRange {
+                    slot: 9,
+                    action: "mode.agent".to_string(),
+                },
+            ]
+        );
+        assert!(resolved.warnings[1].to_string().contains("keeping binding"));
     }
 
     #[test]

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -1656,6 +1656,11 @@ pub struct Config {
     #[serde(default)]
     pub auto: Option<AutoConfig>,
 
+    /// Optional 1-8 hotbar slot bindings (#2064). When absent, future hotbar
+    /// UI slices use the built-in defaults from `codewhale_config`.
+    #[serde(default)]
+    pub hotbar: Option<Vec<codewhale_config::HotbarBindingToml>>,
+
     /// Startup update-check behavior. When absent, the TUI keeps the default
     /// fire-and-forget latest-release check.
     #[serde(default)]
@@ -2916,6 +2921,15 @@ impl Config {
     #[must_use]
     pub fn update_config(&self) -> UpdateConfig {
         self.update.clone().unwrap_or_default()
+    }
+
+    /// Resolve durable hotbar bindings for future render/dispatch layers.
+    #[must_use]
+    pub fn resolve_hotbar_bindings(
+        &self,
+        known_action_ids: &[&str],
+    ) -> codewhale_config::HotbarConfigResolution {
+        codewhale_config::resolve_hotbar_bindings(self.hotbar.as_deref(), known_action_ids)
     }
 
     /// Resolve enabled features from defaults and config entries.
@@ -4495,6 +4509,7 @@ fn merge_config(base: Config, override_cfg: Config) -> Config {
         memory: override_cfg.memory.or(base.memory),
         speech: override_cfg.speech.or(base.speech),
         auto: override_cfg.auto.or(base.auto),
+        hotbar: override_cfg.hotbar.or(base.hotbar),
         update: override_cfg.update.or(base.update),
         lsp: override_cfg.lsp.or(base.lsp),
         context: ContextConfig {
@@ -5645,6 +5660,39 @@ mod tests {
         // A parsed config from the correct placement actually enables shell.
         let parsed: ConfigFile = toml::from_str(ok).expect("parse top-level config");
         assert!(parsed.base.allow_shell());
+    }
+
+    #[test]
+    fn tui_config_parses_hotbar_bindings() {
+        let raw = r#"
+[[hotbar]]
+slot = 1
+label = "Plan"
+action = "mode.plan"
+
+[[hotbar]]
+slot = 2
+action = "session.compact"
+"#;
+        let parsed: ConfigFile = toml::from_str(raw).expect("parse hotbar config");
+
+        let resolved = parsed
+            .base
+            .resolve_hotbar_bindings(&["mode.plan", "session.compact"]);
+
+        assert_eq!(resolved.warnings, Vec::new());
+        assert_eq!(
+            resolved
+                .bindings
+                .iter()
+                .map(|binding| (
+                    binding.slot,
+                    binding.action.as_str(),
+                    binding.label.as_deref()
+                ))
+                .collect::<Vec<_>>(),
+            vec![(1, "mode.plan", Some("Plan")), (2, "session.compact", None),]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

  Adds the config/schema foundation for the Hotbar tracking work.

  This implements `[[hotbar]]` persistence for slots 1-8 so later UI and key-dispatch slices can render and trigger user-
  configured hotbar actions instead of hardcoding slot bindings.

Refs #2064
Part of #2061

  ## Scope

  - Add `[[hotbar]]` config parsing for:
    - `slot`
    - `action`
    - optional `label`
  - Add default bindings when no `[[hotbar]]` table is configured.
  - Validate bindings safely:
    - out-of-range slots are skipped with a warning
    - duplicate slots use the last binding with a warning
    - unknown actions are preserved with a warning for future UI feedback
  - Wire the same schema into the TUI runtime config.
  - Document the example config in `config.example.toml`.

## Testing

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds the config/schema foundation for hotbar slot persistence: a new `[[hotbar]]` TOML array-of-tables that maps slots 1–8 to action IDs, with validation that skips out-of-range slots, warns on duplicates (last wins), and preserves unknown actions for future UI feedback. The same schema is mirrored into the TUI runtime `Config` and wired into `merge_config`.

- **Core logic** (`crates/config/src/lib.rs`): new `HotbarBindingToml`, `HotbarBinding`, `HotbarConfigWarning`, and `HotbarConfigResolution` types, `resolve_hotbar_bindings` free function, `default_hotbar_bindings` returning the 8 built-in defaults, all guarded by three tests covering defaults, TOML round-trip, and edge-case validation.
- **TUI wiring** (`crates/tui/src/config.rs`): mirrors the `hotbar` field into `Config`, delegates `resolve_hotbar_bindings` to `codewhale_config`, and adds the field to `merge_config` with all-or-nothing `Option::or` semantics (any override with even one slot fully replaces the base config's hotbar).
- **Docs** (`config.example.toml`): two commented-out `[[hotbar]]` examples with the full default slot list described in the header comment.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the new hotbar config path is additive and feature-flagged by absence — existing users see no change until they add [[hotbar]] tables.

The implementation is well-structured with thorough tests. The only substantive concern is that merge_config uses all-or-nothing Option::or for hotbar, meaning a project-level config with a single slot silently discards all global hotbar bindings. The UnknownAction warning message can also be misleading when the entry is the earlier of two duplicate-slot entries and gets overwritten. Neither issue affects correctness of the resolved bindings, only observability and merge-time ergonomics.

crates/config/src/lib.rs (warning message clarity) and crates/tui/src/config.rs (all-or-nothing merge semantics, missing skip_serializing_if)
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/config/src/lib.rs | Adds HotbarBindingToml, HotbarBinding, HotbarConfigWarning, HotbarConfigResolution types plus resolve_hotbar_bindings and default_hotbar_bindings helpers; wires hotbar into ConfigToml; three new unit tests cover defaults, round-trip, and validation edge cases. Warning message for DuplicateSlot is grammatically awkward, and UnknownAction's "keeping binding" phrasing can be misleading when the entry is subsequently overwritten. |
| crates/tui/src/config.rs | Mirrors the hotbar field and resolve_hotbar_bindings method from codewhale_config into the TUI Config struct; adds the field to merge_config with all-or-nothing Option::or semantics. Missing skip_serializing_if = "Option::is_none" is an inconsistency with the core config type. |
| config.example.toml | Documents the new [[hotbar]] table with two commented-out examples covering slot, label, and action; accurately reflects the 1-8 slot range and built-in defaults listed in the header comment. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["User TOML config\n[[hotbar]] tables"] -->|"serde deserialize"| B["Option<Vec<HotbarBindingToml>>"]
    B -->|"None"| C["default_hotbar_bindings()\nslots 1-8 with built-in actions"]
    B -->|"Some(entries)"| D["Iterate entries"]
    C --> E["BTreeMap<u8, HotbarBinding>"]
    D --> F{"slot in 1..=8?"}
    F -->|"No"| G["SlotOutOfRange warning\nskip entry"]
    F -->|"Yes"| H{"action in\nknown_action_ids?"}
    H -->|"No (and known non-empty)"| I["UnknownAction warning\nkeep entry"]
    H -->|"Yes"| J["insert into BTreeMap"]
    I --> J
    J --> K{"slot already\nin map?"}
    K -->|"Yes"| L["DuplicateSlot warning\nlast entry wins"]
    K -->|"No"| M["entry stored"]
    L --> M
    E --> N["BTreeMap::into_values()\n(sorted by slot)"]
    M --> N
    N --> O["HotbarConfigResolution\n{ bindings, warnings }"]
```
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fhotbar-config%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fhotbar-config%22.%0A%0AFix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Acrates%2Fconfig%2Fsrc%2Flib.rs%3A695-702%0A**Misleading%20%22keeping%20binding%22%20when%20entry%20is%20overwritten%20by%20a%20duplicate**%0A%0AThe%20%60UnknownAction%60%20warning%20fires%20before%20the%20duplicate-slot%20check%2C%20so%20the%20message%20says%20%22keeping%20binding%22%20even%20in%20the%20scenario%20where%20the%20unknown-action%20entry%20is%20the%20*earlier*%20of%20two%20identical%20slots%20and%20therefore%20gets%20discarded%20by%20the%20last-wins%20logic.%20A%20user%20who%20configures%20slot%202%20with%20%60custom.action%60%20%28unknown%29%20first%20and%20%60mode.plan%60%20%28known%29%20second%20will%20see%20%22keeping%20binding%22%20for%20%60custom.action%60%2C%20yet%20%60custom.action%60%20won't%20appear%20in%20the%20final%20resolved%20bindings%20%E2%80%94%20only%20the%20later%20%60DuplicateSlot%60%20warning%20explains%20the%20loss.%20Consider%20rewording%20to%20%22not%20rejecting%20binding%22%20or%20%22binding%20preserved%20unless%20overwritten%22%20to%20avoid%20implying%20a%20guarantee%20about%20the%20final%20resolved%20state.%0A%0A%23%23%23%20Issue%202%20of%204%0Acrates%2Fconfig%2Fsrc%2Flib.rs%3A697%0AThe%20%60DuplicateSlot%60%20message%20reads%20%22was%20bound%20to%20'%7Bprevious_action%7D'%20more%20than%20once%22%20which%20is%20grammatically%20ambiguous%20%E2%80%94%20it%20sounds%20like%20%60previous_action%60%20was%20bound%20repeatedly%20rather%20than%20the%20*slot*%20being%20reassigned.%20A%20clearer%20phrasing%20would%20be%20%22already%20bound%20to%20'%7Bprevious_action%7D'%3B%20replaced%20by%20'%7Breplacement_action%7D'%22.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22hotbar%20slot%20%7Bslot%7D%20already%20bound%20to%20'%7Bprevious_action%7D'%3B%20replaced%20by%20'%7Breplacement_action%7D'%22%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Acrates%2Ftui%2Fsrc%2Fconfig.rs%3A1659-1662%0A**%60skip_serializing_if%60%20missing%20on%20TUI%20hotbar%20field**%0A%0A%60ConfigToml.hotbar%60%20uses%20%60%23%5Bserde%28default%2C%20skip_serializing_if%20%3D%20%22Option%3A%3Ais_none%22%29%5D%60%2C%20but%20the%20mirroring%20%60Config.hotbar%60%20field%20here%20only%20has%20%60%23%5Bserde%28default%29%5D%60.%20If%20a%20TUI%20%60Config%60%20is%20ever%20round-tripped%20through%20%60toml%3A%3Ato_string%60%2C%20the%20%60None%60%20case%20may%20serialize%20as%20an%20explicit%20null%2Fempty%20entry%20depending%20on%20the%20TOML%20serializer%20version%2C%20adding%20noise%20to%20written%20config%20files.%20Adding%20%60skip_serializing_if%20%3D%20%22Option%3A%3Ais_none%22%60%20keeps%20parity%20with%20the%20%60codewhale_config%60%20type.%0A%0A%23%23%23%20Issue%204%20of%204%0Acrates%2Ftui%2Fsrc%2Fconfig.rs%3A4512%0A**All-or-nothing%20hotbar%20merge%20discards%20base%20slots%20silently**%0A%0A%60override_cfg.hotbar.or%28base.hotbar%29%60%20means%20any%20project%2Fworkspace%20config%20that%20defines%20even%20a%20single%20%60%5B%5Bhotbar%5D%5D%60%20entry%20completely%20discards%20the%20user's%20global%20hotbar%20bindings.%20For%20layered%20configs%20this%20may%20be%20surprising%20%E2%80%94%20a%20user%20who%20sets%20%60trust.toggle%60%20on%20slot%208%20globally%20will%20lose%20it%20entirely%20if%20a%20project%20config%20ships%20even%20one%20hotbar%20entry.%20There's%20no%20per-slot%20merging.%20This%20follows%20the%20same%20pattern%20as%20other%20%60Option%60%20config%20fields%2C%20but%20given%20that%20hotbar%20bindings%20feel%20user-personal%2C%20it%20may%20be%20worth%20a%20comment%20explaining%20the%20intentional%20all-or-nothing%20semantics.%0A%0A&repo=hmbown%2Fcodewhale&pr=2873&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Acrates%2Fconfig%2Fsrc%2Flib.rs%3A695-702%0A**Misleading%20%22keeping%20binding%22%20when%20entry%20is%20overwritten%20by%20a%20duplicate**%0A%0AThe%20%60UnknownAction%60%20warning%20fires%20before%20the%20duplicate-slot%20check%2C%20so%20the%20message%20says%20%22keeping%20binding%22%20even%20in%20the%20scenario%20where%20the%20unknown-action%20entry%20is%20the%20*earlier*%20of%20two%20identical%20slots%20and%20therefore%20gets%20discarded%20by%20the%20last-wins%20logic.%20A%20user%20who%20configures%20slot%202%20with%20%60custom.action%60%20%28unknown%29%20first%20and%20%60mode.plan%60%20%28known%29%20second%20will%20see%20%22keeping%20binding%22%20for%20%60custom.action%60%2C%20yet%20%60custom.action%60%20won't%20appear%20in%20the%20final%20resolved%20bindings%20%E2%80%94%20only%20the%20later%20%60DuplicateSlot%60%20warning%20explains%20the%20loss.%20Consider%20rewording%20to%20%22not%20rejecting%20binding%22%20or%20%22binding%20preserved%20unless%20overwritten%22%20to%20avoid%20implying%20a%20guarantee%20about%20the%20final%20resolved%20state.%0A%0A%23%23%23%20Issue%202%20of%204%0Acrates%2Fconfig%2Fsrc%2Flib.rs%3A697%0AThe%20%60DuplicateSlot%60%20message%20reads%20%22was%20bound%20to%20'%7Bprevious_action%7D'%20more%20than%20once%22%20which%20is%20grammatically%20ambiguous%20%E2%80%94%20it%20sounds%20like%20%60previous_action%60%20was%20bound%20repeatedly%20rather%20than%20the%20*slot*%20being%20reassigned.%20A%20clearer%20phrasing%20would%20be%20%22already%20bound%20to%20'%7Bprevious_action%7D'%3B%20replaced%20by%20'%7Breplacement_action%7D'%22.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22hotbar%20slot%20%7Bslot%7D%20already%20bound%20to%20'%7Bprevious_action%7D'%3B%20replaced%20by%20'%7Breplacement_action%7D'%22%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Acrates%2Ftui%2Fsrc%2Fconfig.rs%3A1659-1662%0A**%60skip_serializing_if%60%20missing%20on%20TUI%20hotbar%20field**%0A%0A%60ConfigToml.hotbar%60%20uses%20%60%23%5Bserde%28default%2C%20skip_serializing_if%20%3D%20%22Option%3A%3Ais_none%22%29%5D%60%2C%20but%20the%20mirroring%20%60Config.hotbar%60%20field%20here%20only%20has%20%60%23%5Bserde%28default%29%5D%60.%20If%20a%20TUI%20%60Config%60%20is%20ever%20round-tripped%20through%20%60toml%3A%3Ato_string%60%2C%20the%20%60None%60%20case%20may%20serialize%20as%20an%20explicit%20null%2Fempty%20entry%20depending%20on%20the%20TOML%20serializer%20version%2C%20adding%20noise%20to%20written%20config%20files.%20Adding%20%60skip_serializing_if%20%3D%20%22Option%3A%3Ais_none%22%60%20keeps%20parity%20with%20the%20%60codewhale_config%60%20type.%0A%0A%23%23%23%20Issue%204%20of%204%0Acrates%2Ftui%2Fsrc%2Fconfig.rs%3A4512%0A**All-or-nothing%20hotbar%20merge%20discards%20base%20slots%20silently**%0A%0A%60override_cfg.hotbar.or%28base.hotbar%29%60%20means%20any%20project%2Fworkspace%20config%20that%20defines%20even%20a%20single%20%60%5B%5Bhotbar%5D%5D%60%20entry%20completely%20discards%20the%20user's%20global%20hotbar%20bindings.%20For%20layered%20configs%20this%20may%20be%20surprising%20%E2%80%94%20a%20user%20who%20sets%20%60trust.toggle%60%20on%20slot%208%20globally%20will%20lose%20it%20entirely%20if%20a%20project%20config%20ships%20even%20one%20hotbar%20entry.%20There's%20no%20per-slot%20merging.%20This%20follows%20the%20same%20pattern%20as%20other%20%60Option%60%20config%20fields%2C%20but%20given%20that%20hotbar%20bindings%20feel%20user-personal%2C%20it%20may%20be%20worth%20a%20comment%20explaining%20the%20intentional%20all-or-nothing%20semantics.%0A%0A&repo=hmbown%2Fcodewhale&pr=2873&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Acrates%2Fconfig%2Fsrc%2Flib.rs%3A695-702%0A**Misleading%20%22keeping%20binding%22%20when%20entry%20is%20overwritten%20by%20a%20duplicate**%0A%0AThe%20%60UnknownAction%60%20warning%20fires%20before%20the%20duplicate-slot%20check%2C%20so%20the%20message%20says%20%22keeping%20binding%22%20even%20in%20the%20scenario%20where%20the%20unknown-action%20entry%20is%20the%20*earlier*%20of%20two%20identical%20slots%20and%20therefore%20gets%20discarded%20by%20the%20last-wins%20logic.%20A%20user%20who%20configures%20slot%202%20with%20%60custom.action%60%20%28unknown%29%20first%20and%20%60mode.plan%60%20%28known%29%20second%20will%20see%20%22keeping%20binding%22%20for%20%60custom.action%60%2C%20yet%20%60custom.action%60%20won't%20appear%20in%20the%20final%20resolved%20bindings%20%E2%80%94%20only%20the%20later%20%60DuplicateSlot%60%20warning%20explains%20the%20loss.%20Consider%20rewording%20to%20%22not%20rejecting%20binding%22%20or%20%22binding%20preserved%20unless%20overwritten%22%20to%20avoid%20implying%20a%20guarantee%20about%20the%20final%20resolved%20state.%0A%0A%23%23%23%20Issue%202%20of%204%0Acrates%2Fconfig%2Fsrc%2Flib.rs%3A697%0AThe%20%60DuplicateSlot%60%20message%20reads%20%22was%20bound%20to%20'%7Bprevious_action%7D'%20more%20than%20once%22%20which%20is%20grammatically%20ambiguous%20%E2%80%94%20it%20sounds%20like%20%60previous_action%60%20was%20bound%20repeatedly%20rather%20than%20the%20*slot*%20being%20reassigned.%20A%20clearer%20phrasing%20would%20be%20%22already%20bound%20to%20'%7Bprevious_action%7D'%3B%20replaced%20by%20'%7Breplacement_action%7D'%22.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22hotbar%20slot%20%7Bslot%7D%20already%20bound%20to%20'%7Bprevious_action%7D'%3B%20replaced%20by%20'%7Breplacement_action%7D'%22%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Acrates%2Ftui%2Fsrc%2Fconfig.rs%3A1659-1662%0A**%60skip_serializing_if%60%20missing%20on%20TUI%20hotbar%20field**%0A%0A%60ConfigToml.hotbar%60%20uses%20%60%23%5Bserde%28default%2C%20skip_serializing_if%20%3D%20%22Option%3A%3Ais_none%22%29%5D%60%2C%20but%20the%20mirroring%20%60Config.hotbar%60%20field%20here%20only%20has%20%60%23%5Bserde%28default%29%5D%60.%20If%20a%20TUI%20%60Config%60%20is%20ever%20round-tripped%20through%20%60toml%3A%3Ato_string%60%2C%20the%20%60None%60%20case%20may%20serialize%20as%20an%20explicit%20null%2Fempty%20entry%20depending%20on%20the%20TOML%20serializer%20version%2C%20adding%20noise%20to%20written%20config%20files.%20Adding%20%60skip_serializing_if%20%3D%20%22Option%3A%3Ais_none%22%60%20keeps%20parity%20with%20the%20%60codewhale_config%60%20type.%0A%0A%23%23%23%20Issue%204%20of%204%0Acrates%2Ftui%2Fsrc%2Fconfig.rs%3A4512%0A**All-or-nothing%20hotbar%20merge%20discards%20base%20slots%20silently**%0A%0A%60override_cfg.hotbar.or%28base.hotbar%29%60%20means%20any%20project%2Fworkspace%20config%20that%20defines%20even%20a%20single%20%60%5B%5Bhotbar%5D%5D%60%20entry%20completely%20discards%20the%20user's%20global%20hotbar%20bindings.%20For%20layered%20configs%20this%20may%20be%20surprising%20%E2%80%94%20a%20user%20who%20sets%20%60trust.toggle%60%20on%20slot%208%20globally%20will%20lose%20it%20entirely%20if%20a%20project%20config%20ships%20even%20one%20hotbar%20entry.%20There's%20no%20per-slot%20merging.%20This%20follows%20the%20same%20pattern%20as%20other%20%60Option%60%20config%20fields%2C%20but%20given%20that%20hotbar%20bindings%20feel%20user-personal%2C%20it%20may%20be%20worth%20a%20comment%20explaining%20the%20intentional%20all-or-nothing%20semantics.%0A%0A&pr=2873&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(config): add hotbar slot persistenc..."](https://github.com/hmbown/codewhale/commit/00407b5bf85e3d440b5655f9917d2e46a78ff8ff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36059148)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->