### PR TITLE
feat(cache): slim runtime_prompt to minimal tag, move policy descriptions to system prompt

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -1245,16 +1245,8 @@ impl Engine {
                     let _ = self.tx_event.send(Event::AgentList { agents }).await;
                 }
                 Op::ChangeMode { mode } => {
-                    let previous_mode = self.current_mode;
                     self.current_mode = mode;
                     self.emit_session_updated().await;
-                    // Notify the agent that the mode has changed so it can re-evaluate
-                    // any operations that were blocked by the previous mode's policy.
-                    if previous_mode != mode {
-                        let msg = Self::mode_change_runtime_message(previous_mode, mode);
-                        self.session.add_message(msg);
-                        self.emit_session_updated().await;
-                    }
                     let _ = self
                         .tx_event
                         .send(Event::status(format!(
@@ -1412,47 +1404,6 @@ impl Engine {
                 workspace: self.session.workspace.clone(),
             })
             .await;
-    }
-
-    /// Build a runtime event message notifying the agent that the operating mode has changed.
-    /// This lets the agent re-evaluate any operations that were blocked by the previous mode.
-    fn mode_change_runtime_message(previous_mode: AppMode, new_mode: AppMode) -> Message {
-        let (policy_note, re_eval_hint) = match new_mode {
-            AppMode::Yolo => (
-                "all operations run automatically without requiring user approval",
-                "Re-evaluate any previously blocked write, patch, or shell operations \
-                 — they are now auto-approved.",
-            ),
-            AppMode::Agent => (
-                "read-only operations run silently; writes, patches, and shell \
-                 commands require user approval",
-                "Any operations you ran automatically under YOLO mode now require \
-                 explicit user approval before executing.",
-            ),
-            AppMode::Plan => (
-                "all writes and patches are blocked; shell and code execution are unavailable",
-                "Any previously planned operations that require writes or shell access \
-                 must wait until the mode changes back to Agent or YOLO.",
-            ),
-        };
-        Message {
-            role: "user".to_string(),
-            content: vec![ContentBlock::Text {
-                text: format!(
-                    "<codewhale:runtime_event kind=\"mode_change\" visibility=\"internal\">\n\
-This is an internal runtime event, not user input. The operating mode has changed \
-from {previous} mode to {new} mode.\n\n\
-In {new} mode: {policy}\n\n\
-{re_eval}\n\
-</codewhale:runtime_event>",
-                    previous = previous_mode.description(),
-                    new = new_mode.description(),
-                    policy = policy_note,
-                    re_eval = re_eval_hint,
-                ),
-                cache_control: None,
-            }],
-        }
     }
 
     async fn add_session_message(&mut self, message: Message) {
@@ -2692,51 +2643,34 @@ fn agent_approval_mode_for_turn(
     }
 }
 
-fn mode_prompt_marker(mode: AppMode) -> String {
+/// Produce a minimal runtime-policy tag for the per-turn transient user message.
+///
+/// All mode and approval policy descriptions live in the frozen system-prompt
+/// prefix (`render_runtime_policy_reference()`). This tag is a pointer — the
+/// model looks up the corresponding rules from the system prompt.  Reduces
+/// per-request overhead from ~500 tokens to ~12 tokens.
+fn runtime_prompt_text(mode: AppMode, approval_mode: crate::tui::approval::ApprovalMode) -> String {
+    let mode_str = mode_prompt_marker_value(mode);
+    let approval_str = approval_prompt_marker_value(approval_mode);
     format!(
-        "<mode_prompt mode=\"{}\">",
-        match mode {
-            AppMode::Agent => "agent",
-            AppMode::Plan => "plan",
-            AppMode::Yolo => "yolo",
-        }
+        "<runtime_prompt visibility=\"internal\" mode=\"{mode_str}\" approval=\"{approval_str}\"/>"
     )
 }
 
-fn approval_prompt_marker(approval_mode: crate::tui::approval::ApprovalMode) -> String {
-    format!(
-        "<approval_policy policy=\"{}\">",
-        match approval_mode {
-            crate::tui::approval::ApprovalMode::Auto => "auto",
-            crate::tui::approval::ApprovalMode::Suggest => "suggest",
-            crate::tui::approval::ApprovalMode::Never => "never",
-        }
-    )
-}
-
-fn mode_prompt_text(mode: AppMode) -> &'static str {
+fn mode_prompt_marker_value(mode: AppMode) -> &'static str {
     match mode {
-        AppMode::Agent => prompts::AGENT_MODE,
-        AppMode::Plan => prompts::PLAN_MODE,
-        AppMode::Yolo => prompts::YOLO_MODE,
+        AppMode::Agent => "agent",
+        AppMode::Plan => "plan",
+        AppMode::Yolo => "yolo",
     }
 }
 
-fn runtime_prompt_text(mode: AppMode, approval_mode: crate::tui::approval::ApprovalMode) -> String {
-    let marker = mode_prompt_marker(mode);
-    let mode_text = mode_prompt_text(mode).trim();
-    let taxonomy = prompts::render_core_tool_taxonomy_block(mode);
-    let approval_marker = approval_prompt_marker(approval_mode);
-    let approval_text = prompts::approval_prompt_for_mode(mode, approval_mode).trim();
-    format!(
-        "<runtime_prompt visibility=\"internal\">\n\
-This is runtime control metadata for the current request, not user input. \
-Apply it to the next assistant response and tool calls. It supersedes any \
-earlier mode or approval metadata in the transcript.\n\n\
-{marker}\n{taxonomy}\n{mode_text}\n</mode_prompt>\n\n\
-{approval_marker}\n{approval_text}\n</approval_policy>\n\
-</runtime_prompt>"
-    )
+fn approval_prompt_marker_value(approval_mode: crate::tui::approval::ApprovalMode) -> &'static str {
+    match approval_mode {
+        crate::tui::approval::ApprovalMode::Auto => "auto",
+        crate::tui::approval::ApprovalMode::Suggest => "suggest",
+        crate::tui::approval::ApprovalMode::Never => "never",
+    }
 }
 
 /// Spawn the engine in a background task

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -2650,27 +2650,19 @@ fn agent_approval_mode_for_turn(
 /// model looks up the corresponding rules from the system prompt.  Reduces
 /// per-request overhead from ~500 tokens to ~12 tokens.
 fn runtime_prompt_text(mode: AppMode, approval_mode: crate::tui::approval::ApprovalMode) -> String {
-    let mode_str = mode_prompt_marker_value(mode);
-    let approval_str = approval_prompt_marker_value(approval_mode);
-    format!(
-        "<runtime_prompt visibility=\"internal\" mode=\"{mode_str}\" approval=\"{approval_str}\"/>"
-    )
-}
-
-fn mode_prompt_marker_value(mode: AppMode) -> &'static str {
-    match mode {
+    let mode_str = match mode {
         AppMode::Agent => "agent",
         AppMode::Plan => "plan",
         AppMode::Yolo => "yolo",
-    }
-}
-
-fn approval_prompt_marker_value(approval_mode: crate::tui::approval::ApprovalMode) -> &'static str {
-    match approval_mode {
+    };
+    let approval_str = match approval_mode {
         crate::tui::approval::ApprovalMode::Auto => "auto",
         crate::tui::approval::ApprovalMode::Suggest => "suggest",
         crate::tui::approval::ApprovalMode::Never => "never",
-    }
+    };
+    format!(
+        "<runtime_prompt visibility=\"internal\" mode=\"{mode_str}\" approval=\"{approval_str}\"/>"
+    )
 }
 
 /// Spawn the engine in a background task

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -2378,7 +2378,10 @@ fn turn_metadata_mode_updates_with_change_mode_op() {
 }
 
 #[test]
-fn mode_change_op_updates_current_mode_and_emits_session_updated() {
+fn current_mode_field_assignment_takes_effect_synchronously() {
+    // Basic unit-level invariant: the current_mode field mutates as expected.
+    // Op::ChangeMode dispatch is exercised by the integration test
+    // change_mode_op_updates_current_mode_and_emits_status.
     let tmp = tempdir().expect("tempdir");
     let config = EngineConfig {
         workspace: tmp.path().to_path_buf(),
@@ -2388,9 +2391,6 @@ fn mode_change_op_updates_current_mode_and_emits_session_updated() {
     let (mut engine, _handle) = Engine::new(config, &Config::default());
     assert_eq!(engine.current_mode, AppMode::Agent);
 
-    // Op::ChangeMode updates current_mode synchronously.
-    // The per-turn <runtime_prompt> tag carries the current mode in every
-    // request — no separate mode_change runtime event is needed.
     engine.current_mode = AppMode::Yolo;
     assert_eq!(engine.current_mode, AppMode::Yolo);
 }

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -1852,9 +1852,22 @@ async fn change_mode_op_updates_current_mode_and_emits_status() {
         .await
         .expect("session update after mode switch")
         .expect("event");
+    let Event::SessionUpdated { messages, .. } = session_updated else {
+        panic!(
+            "should emit SessionUpdated after mode change, got: {session_updated:?}"
+        );
+    };
     assert!(
-        matches!(session_updated, Event::SessionUpdated { .. }),
-        "should emit SessionUpdated after mode change, got: {session_updated:?}"
+        messages.iter().all(|message| {
+            message.content.iter().all(|block| {
+                !matches!(
+                    block,
+                    ContentBlock::Text { text, .. }
+                        if text.contains("<runtime_prompt")
+                )
+            })
+        }),
+        "runtime prompt tags must not be persisted into session messages after mode change"
     );
 
     // Also expect a status event
@@ -2379,9 +2392,10 @@ fn turn_metadata_mode_updates_with_change_mode_op() {
 
 #[test]
 fn current_mode_field_assignment_takes_effect_synchronously() {
-    // Basic unit-level invariant: the current_mode field mutates as expected.
-    // Op::ChangeMode dispatch is exercised by the integration test
-    // change_mode_op_updates_current_mode_and_emits_status.
+    // Basic unit-level invariant: the current_mode field mutates as expected
+    // and the per-turn <runtime_prompt> tag reflects the current mode.
+    // Op::ChangeMode dispatch through the run loop is exercised by the
+    // integration test change_mode_op_updates_current_mode_and_emits_status.
     let tmp = tempdir().expect("tempdir");
     let config = EngineConfig {
         workspace: tmp.path().to_path_buf(),
@@ -2391,8 +2405,39 @@ fn current_mode_field_assignment_takes_effect_synchronously() {
     let (mut engine, _handle) = Engine::new(config, &Config::default());
     assert_eq!(engine.current_mode, AppMode::Agent);
 
+    // Verify runtime tag in Agent mode
+    let agent_messages = engine.messages_with_turn_metadata();
+    let agent_tag = agent_messages.last().expect("runtime tag message");
+    let ContentBlock::Text { text: agent_text, .. } =
+        agent_tag.content.first().expect("text block")
+    else {
+        panic!("expected text runtime tag in Agent mode");
+    };
+    assert!(
+        agent_text.contains("mode=\"agent\""),
+        "Agent mode should produce runtime tag with mode=\"agent\", got: {agent_text}"
+    );
+
+    // Switch to YOLO
     engine.current_mode = AppMode::Yolo;
     assert_eq!(engine.current_mode, AppMode::Yolo);
+
+    // Verify runtime tag reflects the YOLO mode with auto approval
+    let yolo_messages = engine.messages_with_turn_metadata();
+    let yolo_tag = yolo_messages.last().expect("runtime tag message");
+    let ContentBlock::Text { text: yolo_text, .. } =
+        yolo_tag.content.first().expect("text block")
+    else {
+        panic!("expected text runtime tag in YOLO mode");
+    };
+    assert!(
+        yolo_text.contains("mode=\"yolo\""),
+        "YOLO mode should produce runtime tag with mode=\"yolo\", got: {yolo_text}"
+    );
+    assert!(
+        yolo_text.contains("approval=\"auto\""),
+        "YOLO mode should project auto approval in runtime tag, got: {yolo_text}"
+    );
 }
 
 #[test]

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -1748,11 +1748,11 @@ async fn change_mode_refreshes_session_prompt_and_updates_session() {
                 !matches!(
                     block,
                     ContentBlock::Text { text, .. }
-                        if text.contains("<mode_prompt") || text.contains("<approval_policy")
+                        if text.contains("<runtime_prompt")
                 )
             })
         }),
-        "mode/approval prompts should be request-time metadata, not session history"
+        "runtime prompt tags should be request-time metadata, not session history"
     );
 }
 
@@ -1819,15 +1819,15 @@ fn runtime_prompt_is_projected_without_persisting_to_session_messages() {
         panic!("expected text runtime prompt");
     };
     assert!(text.contains("<runtime_prompt"));
-    assert!(text.contains("<mode_prompt mode=\"plan\">"));
+    assert!(text.contains("mode=\"plan\""));
     assert!(
-        text.contains("<approval_policy policy=\"never\">"),
+        text.contains("approval=\"never\""),
         "Plan mode should project its fixed never-approval policy: {text}"
     );
 }
 
 #[tokio::test]
-async fn change_mode_op_injects_runtime_event_into_session_messages() {
+async fn change_mode_op_updates_current_mode_and_emits_status() {
     let tmp = tempdir().expect("tempdir");
     let config = EngineConfig {
         workspace: tmp.path().to_path_buf(),
@@ -1837,7 +1837,6 @@ async fn change_mode_op_injects_runtime_event_into_session_messages() {
     let (engine, handle) = Engine::new(config, &Config::default());
 
     let run = tokio::spawn(engine.run());
-    // Switch from default Agent → YOLO
     handle
         .send(Op::ChangeMode {
             mode: AppMode::Yolo,
@@ -1845,40 +1844,30 @@ async fn change_mode_op_injects_runtime_event_into_session_messages() {
         .await
         .expect("send change mode");
 
-    // Collect session-updated events until we see the injected message
-    let messages = {
-        let mut rx = handle.rx_event.write().await;
-        loop {
-            let event = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
-                .await
-                .expect("session update after mode switch")
-                .expect("event");
-            if let Event::SessionUpdated { messages, .. } = event {
-                // The last message should be our runtime event
-                if let Some(last) = messages.last()
-                    && let ContentBlock::Text { text, .. } =
-                        last.content.first().expect("text block")
-                    && text.contains("kind=\"mode_change\"")
-                {
-                    break messages;
-                }
-            }
-        }
-    };
-    run.abort();
+    // Expect a SessionUpdated event confirming the mode change (the
+    // per-turn <runtime_prompt> tag carries the mode in every request,
+    // so no separate persistence of a mode_change runtime event is needed).
+    let mut rx = handle.rx_event.write().await;
+    let session_updated = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+        .await
+        .expect("session update after mode switch")
+        .expect("event");
+    assert!(
+        matches!(session_updated, Event::SessionUpdated { .. }),
+        "should emit SessionUpdated after mode change, got: {session_updated:?}"
+    );
 
-    let last = messages.last().expect("at least one message");
-    let ContentBlock::Text { text, .. } = last.content.first().expect("text block") else {
-        panic!("expected text block");
-    };
+    // Also expect a status event
+    let status = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+        .await
+        .expect("status after mode switch")
+        .expect("event");
     assert!(
-        text.contains("Agent mode") && text.contains("YOLO mode"),
-        "should contain both previous and new mode: {text}"
+        matches!(status, Event::Status { .. }),
+        "should emit Status after mode change, got: {status:?}"
     );
-    assert!(
-        text.contains("Re-evaluate"),
-        "should tell agent to re-evaluate: {text}"
-    );
+
+    run.abort();
 }
 
 #[test]
@@ -2389,30 +2378,21 @@ fn turn_metadata_mode_updates_with_change_mode_op() {
 }
 
 #[test]
-fn mode_change_runtime_message_format() {
-    let msg = Engine::mode_change_runtime_message(AppMode::Agent, AppMode::Yolo);
-
-    assert_eq!(msg.role, "user");
-    let ContentBlock::Text { text, .. } = msg.content.first().expect("text block") else {
-        panic!("expected text block");
+fn mode_change_op_updates_current_mode_and_emits_session_updated() {
+    let tmp = tempdir().expect("tempdir");
+    let config = EngineConfig {
+        workspace: tmp.path().to_path_buf(),
+        model: "deepseek-v4-pro".to_string(),
+        ..Default::default()
     };
+    let (mut engine, _handle) = Engine::new(config, &Config::default());
+    assert_eq!(engine.current_mode, AppMode::Agent);
 
-    assert!(
-        text.contains("codewhale:runtime_event"),
-        "should be a runtime event message"
-    );
-    assert!(
-        text.contains("kind=\"mode_change\""),
-        "should have mode_change kind"
-    );
-    assert!(
-        text.contains("Agent mode") && text.contains("YOLO mode"),
-        "should mention both previous and new mode: {text}"
-    );
-    assert!(
-        text.contains("Re-evaluate"),
-        "should tell agent to re-evaluate blocked operations: {text}"
-    );
+    // Op::ChangeMode updates current_mode synchronously.
+    // The per-turn <runtime_prompt> tag carries the current mode in every
+    // request — no separate mode_change runtime event is needed.
+    engine.current_mode = AppMode::Yolo;
+    assert_eq!(engine.current_mode, AppMode::Yolo);
 }
 
 #[test]

--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -816,15 +816,6 @@ pub(crate) fn render_core_tool_taxonomy_body(mode: AppMode) -> String {
     sentences.join(" ")
 }
 
-/// Render the full taxonomy block **with** a `## Core Tool Taxonomy` heading.
-/// Kept for backward-compatibility with existing callers (tests, diagnostics).
-pub(crate) fn render_core_tool_taxonomy_block(mode: AppMode) -> String {
-    format!(
-        "## Core Tool Taxonomy\n\n{}",
-        render_core_tool_taxonomy_body(mode)
-    )
-}
-
 fn core_taxonomy_tools_for_mode(mode: AppMode) -> Vec<&'static str> {
     let core_tools = crate::core::engine::default_active_native_tool_names();
     core_tools
@@ -1606,7 +1597,7 @@ mod tests {
 
     #[test]
     fn plan_prompt_taxonomy_omits_run_tests() {
-        let taxonomy = render_core_tool_taxonomy_block(AppMode::Plan);
+        let taxonomy = render_core_tool_taxonomy_body(AppMode::Plan);
         // Plan taxonomy should omit execution tools (verified at the source).
         assert!(
             taxonomy.contains("for discovery") && taxonomy.contains("for git inspection"),
@@ -2056,7 +2047,7 @@ mod tests {
             "base prompt must not contain static CJK priming tokens"
         );
         for mode in [AppMode::Agent, AppMode::Plan, AppMode::Yolo] {
-            let taxonomy = render_core_tool_taxonomy_block(mode);
+            let taxonomy = render_core_tool_taxonomy_body(mode);
             assert!(
                 !contains_cjk(&taxonomy),
                 "tool taxonomy must not contain static CJK priming tokens: {taxonomy:?}"

--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -719,6 +719,12 @@ fn default_approval_mode_for_mode(mode: AppMode) -> ApprovalMode {
 /// producing a broken heading hierarchy (## under ####).
 fn taxonomy_body(mode: AppMode) -> String {
     let block = render_core_tool_taxonomy_block(mode);
+    debug_assert!(
+        block.starts_with("## Core Tool Taxonomy\n\n"),
+        "render_core_tool_taxonomy_block format changed — \
+         taxonomy_body expects `## Core Tool Taxonomy\\n\\n` prefix; \
+         update the prefix or the assertion"
+    );
     block
         .strip_prefix("## Core Tool Taxonomy\n\n")
         .unwrap_or(&block)
@@ -748,19 +754,19 @@ pub(crate) fn render_runtime_policy_reference() -> String {
 
     out.push_str("#### agent\n\n");
     out.push_str(&taxonomy_agent);
-    out.push('\n');
+    out.push_str("\n\n");
     out.push_str(AGENT_MODE.trim());
     out.push_str("\n\n");
 
     out.push_str("#### plan\n\n");
     out.push_str(&taxonomy_plan);
-    out.push('\n');
+    out.push_str("\n\n");
     out.push_str(PLAN_MODE.trim());
     out.push_str("\n\n");
 
     out.push_str("#### yolo\n\n");
     out.push_str(&taxonomy_yolo);
-    out.push('\n');
+    out.push_str("\n\n");
     out.push_str(YOLO_MODE.trim());
     out.push_str("\n\n");
 

--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -1580,8 +1580,10 @@ mod tests {
             Personality::Calm,
             "deepseek-v4-pro",
         );
-        // The generated "## Core Tool Taxonomy" block now travels in the
-        // request-time <mode_prompt> metadata rather than being prepended here.
+        // The core tool taxonomy (grep_files / git_status / run_tests hints)
+        // is no longer prepended as a standalone "## Core Tool Taxonomy" block.
+        // It now lives inside the "## Runtime Policy Reference" section of the
+        // system prompt, scoped under each mode sub-heading.
         // (The "## Toolbox" section from the Constitutional preamble remains.)
         assert!(!prompt.contains("## Core Tool Taxonomy"));
         assert!(prompt.contains("You are deepseek-v4-pro"));
@@ -1602,8 +1604,9 @@ mod tests {
             "Plan taxonomy must not mention run_tests, run_verifiers, or exec_shell"
         );
         // The taxonomy block is rendered correctly but no longer inlined
-        // into the base system prompt — it travels in request-time
-        // <mode_prompt> metadata instead.
+        // into the base system prompt — it lives inside the
+        // "## Runtime Policy Reference" section of the system prompt,
+        // scoped under each mode sub-heading.
     }
 
     #[test]
@@ -1642,6 +1645,65 @@ mod tests {
         assert!(
             text.contains("The Constitution of CodeWhale (Articles I-VII) governs your behavior"),
             "authority recap must reference the Constitution"
+        );
+    }
+
+    #[test]
+    fn runtime_policy_reference_is_included_in_full_prompt() {
+        let tmp = tempdir().expect("tempdir");
+        let text = match system_prompt_for_mode_with_context_skills_session_and_approval(
+            AppMode::Agent,
+            tmp.path(),
+            None,
+            None,
+            None,
+            PromptSessionContext::default(),
+        ) {
+            SystemPrompt::Text(text) => text,
+            SystemPrompt::Blocks(_) => panic!("expected text system prompt"),
+        };
+
+        assert!(
+            text.contains("## Runtime Policy Reference"),
+            "full system prompt must contain the Runtime Policy Reference lookup table"
+        );
+        assert!(
+            text.contains(
+                "<runtime_prompt visibility=\"internal\" mode=\"<mode>\" approval=\"<approval>\"/>"
+            ),
+            "Runtime Policy Reference must explain the per-turn tag format"
+        );
+        assert!(
+            text.contains("### Modes"),
+            "Runtime Policy Reference must contain the Modes section"
+        );
+        assert!(
+            text.contains("#### agent"),
+            "Runtime Policy Reference must document Agent mode"
+        );
+        assert!(
+            text.contains("#### plan"),
+            "Runtime Policy Reference must document Plan mode"
+        );
+        assert!(
+            text.contains("#### yolo"),
+            "Runtime Policy Reference must document YOLO mode"
+        );
+        assert!(
+            text.contains("### Approval Policies"),
+            "Runtime Policy Reference must contain the Approval Policies section"
+        );
+        assert!(
+            text.contains("#### auto"),
+            "Runtime Policy Reference must document auto approval"
+        );
+        assert!(
+            text.contains("#### suggest"),
+            "Runtime Policy Reference must document suggest approval"
+        );
+        assert!(
+            text.contains("#### never"),
+            "Runtime Policy Reference must document never approval"
         );
     }
 

--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -701,14 +701,6 @@ impl Personality {
 
 // ── Composition ───────────────────────────────────────────────────────
 
-fn mode_prompt(mode: AppMode) -> &'static str {
-    match mode {
-        AppMode::Agent => AGENT_MODE,
-        AppMode::Yolo => YOLO_MODE,
-        AppMode::Plan => PLAN_MODE,
-    }
-}
-
 fn default_approval_mode_for_mode(mode: AppMode) -> ApprovalMode {
     match mode {
         AppMode::Agent => ApprovalMode::Suggest,
@@ -717,16 +709,76 @@ fn default_approval_mode_for_mode(mode: AppMode) -> ApprovalMode {
     }
 }
 
-pub(crate) fn approval_prompt_for_mode(mode: AppMode, approval_mode: ApprovalMode) -> &'static str {
-    match mode {
-        AppMode::Yolo => AUTO_APPROVAL,
-        AppMode::Plan => NEVER_APPROVAL,
-        AppMode::Agent => match approval_mode {
-            ApprovalMode::Auto => AUTO_APPROVAL,
-            ApprovalMode::Suggest => SUGGEST_APPROVAL,
-            ApprovalMode::Never => NEVER_APPROVAL,
-        },
-    }
+/// Generate a static reference block containing all mode and approval policy
+/// descriptions. This lives in the frozen system-prompt prefix (sent once per
+/// session) so the per-turn `<runtime_prompt>` tag can be a minimal pointer
+/// (`<runtime_prompt mode="yolo" approval="auto"/>`) instead of repeating the
+/// full policy text on every API request.
+/// Extract the body of a taxonomy block (strip the `## Core Tool Taxonomy`
+/// heading) so it can be nested under a mode-specific sub-heading without
+/// producing a broken heading hierarchy (## under ####).
+fn taxonomy_body(mode: AppMode) -> String {
+    let block = render_core_tool_taxonomy_block(mode);
+    block
+        .strip_prefix("## Core Tool Taxonomy\n\n")
+        .unwrap_or(&block)
+        .to_string()
+}
+
+pub(crate) fn render_runtime_policy_reference() -> String {
+    let taxonomy_agent = taxonomy_body(AppMode::Agent);
+    let taxonomy_plan = taxonomy_body(AppMode::Plan);
+    let taxonomy_yolo = taxonomy_body(AppMode::Yolo);
+
+    let mut out = String::with_capacity(8192);
+    out.push_str("## Runtime Policy Reference\n\n");
+
+    // Protocol explanation — how the per-turn tag maps to this reference.
+    out.push_str(
+        "Each turn, the latest message in the transcript will contain a \
+         `<runtime_prompt>` tag that specifies the currently active mode and \
+         approval policy. When you see this tag, look up the corresponding \
+         rules below and apply them for the current turn.\n\n\
+         The tag format is:\n\
+         `<runtime_prompt visibility=\"internal\" mode=\"<mode>\" approval=\"<approval>\"/>`\n\n",
+    );
+
+    // ── Mode reference ─────────────────────────────────────────────────
+    out.push_str("### Modes\n\n");
+
+    out.push_str("#### agent\n\n");
+    out.push_str(&taxonomy_agent);
+    out.push('\n');
+    out.push_str(AGENT_MODE.trim());
+    out.push_str("\n\n");
+
+    out.push_str("#### plan\n\n");
+    out.push_str(&taxonomy_plan);
+    out.push('\n');
+    out.push_str(PLAN_MODE.trim());
+    out.push_str("\n\n");
+
+    out.push_str("#### yolo\n\n");
+    out.push_str(&taxonomy_yolo);
+    out.push('\n');
+    out.push_str(YOLO_MODE.trim());
+    out.push_str("\n\n");
+
+    // ── Approval policy reference ──────────────────────────────────────
+    out.push_str("### Approval Policies\n\n");
+
+    out.push_str("#### auto\n\n");
+    out.push_str(AUTO_APPROVAL.trim());
+    out.push_str("\n\n");
+
+    out.push_str("#### suggest\n\n");
+    out.push_str(SUGGEST_APPROVAL.trim());
+    out.push_str("\n\n");
+
+    out.push_str("#### never\n\n");
+    out.push_str(NEVER_APPROVAL.trim());
+
+    out
 }
 
 /// Compose the full system prompt in deterministic order:
@@ -1164,6 +1216,13 @@ pub fn system_prompt_for_mode_with_context_skills_session_and_approval(
     //    when writing `.codewhale/handoff.md` on exit / `/compact`.
     full_prompt.push_str("\n\n");
     full_prompt.push_str(COMPACT_TEMPLATE);
+
+    // 5a. Runtime policy reference — all mode and approval policy descriptions
+    //     live here in the frozen prefix so the per-turn <runtime_prompt> tag
+    //     can be a minimal pointer instead of repeating the full policy text
+    //     on every API request (up to ~500 tokens saved per turn).
+    full_prompt.push_str("\n\n");
+    full_prompt.push_str(&render_runtime_policy_reference());
 
     // ── Volatile-content boundary ─────────────────────────────────────────
     // Everything below drifts mid-session and busts the prefix cache for

--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -714,27 +714,10 @@ fn default_approval_mode_for_mode(mode: AppMode) -> ApprovalMode {
 /// session) so the per-turn `<runtime_prompt>` tag can be a minimal pointer
 /// (`<runtime_prompt mode="yolo" approval="auto"/>`) instead of repeating the
 /// full policy text on every API request.
-/// Extract the body of a taxonomy block (strip the `## Core Tool Taxonomy`
-/// heading) so it can be nested under a mode-specific sub-heading without
-/// producing a broken heading hierarchy (## under ####).
-fn taxonomy_body(mode: AppMode) -> String {
-    let block = render_core_tool_taxonomy_block(mode);
-    debug_assert!(
-        block.starts_with("## Core Tool Taxonomy\n\n"),
-        "render_core_tool_taxonomy_block format changed — \
-         taxonomy_body expects `## Core Tool Taxonomy\\n\\n` prefix; \
-         update the prefix or the assertion"
-    );
-    block
-        .strip_prefix("## Core Tool Taxonomy\n\n")
-        .unwrap_or(&block)
-        .to_string()
-}
-
 pub(crate) fn render_runtime_policy_reference() -> String {
-    let taxonomy_agent = taxonomy_body(AppMode::Agent);
-    let taxonomy_plan = taxonomy_body(AppMode::Plan);
-    let taxonomy_yolo = taxonomy_body(AppMode::Yolo);
+    let taxonomy_agent = render_core_tool_taxonomy_body(AppMode::Agent);
+    let taxonomy_plan = render_core_tool_taxonomy_body(AppMode::Plan);
+    let taxonomy_yolo = render_core_tool_taxonomy_body(AppMode::Yolo);
 
     let mut out = String::with_capacity(8192);
     out.push_str("## Runtime Policy Reference\n\n");
@@ -809,7 +792,10 @@ const TOOL_TAXONOMY_DISCOVERY: &[&str] = &["grep_files", "file_search"];
 const TOOL_TAXONOMY_GIT: &[&str] = &["git_status", "git_diff"];
 const TOOL_TAXONOMY_VERIFICATION: &[&str] = &["run_tests", "run_verifiers"];
 
-pub(crate) fn render_core_tool_taxonomy_block(mode: AppMode) -> String {
+/// Return the core tool taxonomy body **without** a markdown heading.
+/// Suitable for embedding under a mode-specific sub-heading in the
+/// Runtime Policy Reference without producing a broken heading hierarchy.
+pub(crate) fn render_core_tool_taxonomy_body(mode: AppMode) -> String {
     let core_tools = core_taxonomy_tools_for_mode(mode);
     let mut sentences = Vec::new();
 
@@ -827,7 +813,16 @@ pub(crate) fn render_core_tool_taxonomy_block(mode: AppMode) -> String {
         !sentences.is_empty(),
         "core tool taxonomy has no active tool groups"
     );
-    format!("## Core Tool Taxonomy\n\n{}", sentences.join(" "))
+    sentences.join(" ")
+}
+
+/// Render the full taxonomy block **with** a `## Core Tool Taxonomy` heading.
+/// Kept for backward-compatibility with existing callers (tests, diagnostics).
+pub(crate) fn render_core_tool_taxonomy_block(mode: AppMode) -> String {
+    format!(
+        "## Core Tool Taxonomy\n\n{}",
+        render_core_tool_taxonomy_body(mode)
+    )
 }
 
 fn core_taxonomy_tools_for_mode(mode: AppMode) -> Vec<&'static str> {

--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -701,14 +701,6 @@ impl Personality {
 
 // ── Composition ───────────────────────────────────────────────────────
 
-fn default_approval_mode_for_mode(mode: AppMode) -> ApprovalMode {
-    match mode {
-        AppMode::Agent => ApprovalMode::Suggest,
-        AppMode::Yolo => ApprovalMode::Auto,
-        AppMode::Plan => ApprovalMode::Never,
-    }
-}
-
 /// Generate a static reference block containing all mode and approval policy
 /// descriptions. This lives in the frozen system-prompt prefix (sent once per
 /// session) so the per-turn `<runtime_prompt>` tag can be a minimal pointer

--- a/crates/tui/src/prompts/approvals/auto.md
+++ b/crates/tui/src/prompts/approvals/auto.md
@@ -1,4 +1,4 @@
-## Approval Policy: Auto — Tier 2 (Statute)
+##### Approval Policy: Auto — Tier 2 (Statute)
 
 All tool calls are pre-approved. You will not see approval prompts — your actions execute immediately.
 

--- a/crates/tui/src/prompts/approvals/never.md
+++ b/crates/tui/src/prompts/approvals/never.md
@@ -1,4 +1,4 @@
-## Approval Policy: Never — Tier 2 (Statute)
+##### Approval Policy: Never — Tier 2 (Statute)
 
 All write operations are blocked. You can read, search, and investigate, but you cannot modify the workspace.
 

--- a/crates/tui/src/prompts/approvals/suggest.md
+++ b/crates/tui/src/prompts/approvals/suggest.md
@@ -1,4 +1,4 @@
-## Approval Policy: Suggest — Tier 2 (Statute)
+##### Approval Policy: Suggest — Tier 2 (Statute)
 
 Read-only operations run silently. Write operations (file edits, patches, shell execution, sub-agent spawns, CSV batches) require user approval before executing.
 

--- a/crates/tui/src/prompts/modes/agent.md
+++ b/crates/tui/src/prompts/modes/agent.md
@@ -12,7 +12,7 @@ For simple writes, state the direct edit and proceed through the normal approval
 
 For multi-step initiatives, keep `checklist_write` current. Add `update_plan` only for genuinely useful strategy.
 
-##### Efficient Approvals
+###### Efficient Approvals
 
 When your plan includes multiple writes, present them together:
 1. Show `checklist_write` with all write steps listed so the user sees the full scope
@@ -21,7 +21,7 @@ When your plan includes multiple writes, present them together:
 
 Don't sequence approvals one at a time — the user wants context, not interruption. A clear plan with visible checklist items gets approved faster than a series of surprise approval prompts.
 
-##### Session Longevity
+###### Session Longevity
 
 Long sessions accumulate context. To stay fast:
 - Open sub-agent sessions for independent work instead of doing everything sequentially

--- a/crates/tui/src/prompts/modes/agent.md
+++ b/crates/tui/src/prompts/modes/agent.md
@@ -1,4 +1,4 @@
-## Mode: Agent
+##### Mode: Agent
 
 You are running in Agent mode — autonomous task execution with tool access.
 
@@ -12,7 +12,7 @@ For simple writes, state the direct edit and proceed through the normal approval
 
 For multi-step initiatives, keep `checklist_write` current. Add `update_plan` only for genuinely useful strategy.
 
-## Efficient Approvals
+##### Efficient Approvals
 
 When your plan includes multiple writes, present them together:
 1. Show `checklist_write` with all write steps listed so the user sees the full scope
@@ -21,7 +21,7 @@ When your plan includes multiple writes, present them together:
 
 Don't sequence approvals one at a time — the user wants context, not interruption. A clear plan with visible checklist items gets approved faster than a series of surprise approval prompts.
 
-## Session Longevity
+##### Session Longevity
 
 Long sessions accumulate context. To stay fast:
 - Open sub-agent sessions for independent work instead of doing everything sequentially

--- a/crates/tui/src/prompts/modes/plan.md
+++ b/crates/tui/src/prompts/modes/plan.md
@@ -1,4 +1,4 @@
-## Mode: Plan
+##### Mode: Plan
 
 You are running in Plan mode — design before implementing.
 

--- a/crates/tui/src/prompts/modes/yolo.md
+++ b/crates/tui/src/prompts/modes/yolo.md
@@ -1,4 +1,4 @@
-## Mode: YOLO
+##### Mode: YOLO
 
 You are running in YOLO mode — full autonomy, all actions pre-approved.
 


### PR DESCRIPTION
## Summary / 概要

> **Builds on #2801** / **基于 #2801**（merged / 已合并）

#2801 moved mode/approval policy descriptions out of the byte-stable system prompt into a per-turn `<runtime_prompt>` transient message. While it solved the prefix-cache invalidation problem, it introduced a recurring cost: the full policy text (~500 tokens) was repeated on **every API request** — including tool-call continuations within the same turn.

This PR restructures the information architecture: **static policy descriptions now live in the frozen system-prompt prefix** (sent once per session, cache-hit thereafter), and only a **minimal tag** is sent per turn.

#2801 将 mode/approval 策略描述从稳定的 system prompt 中移出，改为 per-turn transient message。虽然解决了 prefix-cache 失效问题，但引入了新成本：完整策略文本（~500 tokens）在**每个 API 请求**都重复发送，包括同一 turn 内的 tool-call 续轮。

本 PR 重构信息架构：**静态策略描述放入 frozen system-prompt prefix**（每 session 发送一次，后续请求全部 cache hit），每 turn 只发送最小 tag。

---

## Scope / 范围

- **Add `render_runtime_policy_reference()`** — a static reference block containing all mode + approval policy descriptions, plus a tag-interpretation protocol. / 新增 `render_runtime_policy_reference()`，生成包含所有 mode + approval 策略描述的静态参考块，附带 tag 解释协议。
- **Insert the reference into the system prompt** above the volatile-content boundary (frozen prefix region). / 将 reference 插入 system prompt 的 volatile-content boundary 之上（frozen prefix 区域）。
- **Simplify `runtime_prompt_text()`** from ~500-token XML block to ~16-token self-closing tag: `<runtime_prompt visibility="internal" mode="yolo" approval="auto"/>`. / 将 `runtime_prompt_text()` 从 ~500-token XML 块简化为 ~16-token 自闭合标签。
- **Fix markdown heading hierarchy** in 6 `.md` files (`##` → `#####`) so they nest correctly under `####` in the reference section. / 修正 6 个 `.md` 文件的标题层次 (`##` → `#####`)，确保在 reference 章节中正确嵌套。
- **Remove unused legacy functions**: `mode_prompt()`, `approval_prompt_for_mode()`, `mode_change_runtime_message()`. / 删除不再使用的遗留函数。
- **Simplify `Op::ChangeMode`** — no longer persists a separate mode_change event; the next turn tag carries the current mode. / 简化 `Op::ChangeMode`，不再持久化额外的 mode_change 事件，下一轮 tag 即携带当前 mode。
- **Update & rename affected tests** (2 tests rewritten, 5 assertions updated). / 更新并重命名受影响的测试（2 个测试重写，5 处断言更新）。

---

## Not in this slice / 不涉及

- **Policy content is byte-identical**; only heading levels changed. / 策略内容本身未修改，仅标题层次变更。
- **Tag-interpretation protocol unchanged** — already established in the system prompt reference section. / 不修改 tag 解释协议，已通过 system prompt 中的参考章节确立。
- **A/B testing model behavior** with the new tag format — follow-up work. / 新 tag 格式的 A/B 测试属于后续工作。

---

## Tradeoff / 权衡

| Dimension / 维度 | Before (post-#2801) / 旧 | After (this PR) / 新 |
|-----------|------------------------|-------------------|
| System prompt size / 系统提示体积 | ~8,000 tokens | ~9,325 tokens |
| _— one-time miss cost / 首次请求 miss_ | ~8,000 | ~9,325 (+1,325) |
| _— subsequent cache-hit / 后续 cache-hit_ | ~800 (~10%) | ~932 (~10%) |
| Per-request runtime tag / 每轮标签 | ~487 tokens (miss every time / 每次 miss) | ~16 tokens (miss every time / 每次 miss) |
| 10-turn session / 10 轮会话 (60 API calls) | 8,000 + 60×487 = **37,220** miss | 9,325 + 60×16 = **10,285** miss |
| Saving / 节省 | — | **26,935 tokens (72%)** |
| Break-even / 回本点 | — | **3 API calls / 3 次 API 调用** |
| Model behavior / 模型行为 | Sees full policy every turn / 每轮显式看到完整策略 | Looks up policy from system prompt reference / 从 reference 查表 |

**Core tradeoff**: system prompt grows by 1,325 tokens (one-time miss) in exchange for saving 471 tokens per API call. Net positive after 3 API calls. The model shifts from receiving explicit policy text every turn to looking up rules by tag — the reference section includes an explicit protocol instruction. Structural correctness is verified by tests; production behavioral stability needs follow-up observation.

**核心权衡**：system prompt 膨胀 1,325 tokens（仅首次 miss），换取每轮节省 471 tokens。3 次 API 调用后净正收益。模型从"每轮显式接收策略描述"改为"按 tag 查表"——参考章节中有明确的协议指引。结构性正确性已由测试验证；生产行为稳定性需要后续观测。

---

## Builds on / 基于

- #2687 — first prototype, closed / 第一个原型，已关闭
- #2801 (`feat(cache): project mode prompts per request`) — merged predecessor that established the per-turn `<runtime_prompt>` architecture / 已合并的前置 PR，确立了 per-turn `<runtime_prompt>` 架构

---

## Validation / 验证

```
cargo fmt --all                                   # ✅ passed / 通过
cargo clippy -p codewhale-tui -- -D warnings       # ✅ passed (0 warnings)
cargo test -p codewhale-tui -- runtime_prompt mode_change  # ✅ 9 passed, 0 failed
cargo check -p codewhale-tui                       # ✅ passed / 通过
```

Files changed / 改动文件: 9 files, +143 / −170 lines

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR restructures the runtime-policy information architecture by moving all mode and approval-policy descriptions from a per-turn `<runtime_prompt>` XML block (~500 tokens, re-sent on every API call) into a static `## Runtime Policy Reference` section in the frozen system-prompt prefix, and replacing the per-turn block with a minimal self-closing tag (~16 tokens). The change saves roughly 72% of per-session miss tokens (break-even at 3 API calls) at the cost of a one-time +1,325 token system-prompt miss.

- **`render_runtime_policy_reference()`** added to `prompts.rs` — generates a lookup table listing all three modes and all three approval policies; inserted at step 5a of the frozen-prefix composition pipeline so it is byte-stable across turns.
- **`runtime_prompt_text()`** in `engine.rs` simplified to `<runtime_prompt visibility="internal" mode="…" approval="…"/>`, removing `mode_change_runtime_message` and the associated per-mode re-evaluation hints from `Op::ChangeMode`.
- **Six `.md` files** had heading levels adjusted (`##` → `#####` / `######`) to nest correctly under the `####`-level subsections in the reference block; two tests were rewritten and five assertions updated to match the new tag format.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The structural refactor is self-consistent: approval-mode constraints (YOLO→auto, Plan→never) are still enforced by `approval_mode_for()` before `runtime_prompt_text()` is called, and the reference block is always present in the full system prompt used by the engine.

All changed code paths are covered by the updated tests. The removed `mode_change_runtime_message` was a behavioral notification, not a structural safety check, and its removal is explicitly acknowledged as a follow-up observation item. No data-loss or session-corruption paths were identified.

crates/tui/src/core/engine/tests.rs — the two rewritten test functions have some weaknesses in assertion coverage for the mode-change path, as noted in inline comments.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/prompts.rs | Core architectural change: adds render_runtime_policy_reference() (all mode+approval descriptions as static lookup table in system prompt), renames render_core_tool_taxonomy_block → render_core_tool_taxonomy_body (no longer emits its own heading), removes mode_prompt/approval_prompt_for_mode/default_approval_mode_for_mode helpers. Reference is inserted at step 5a of the frozen-prefix composition pipeline. |
| crates/tui/src/core/engine.rs | runtime_prompt_text() slimmed from ~500-token XML block to a ~16-token self-closing tag; Op::ChangeMode no longer injects a mode_change runtime event into session history; mode_prompt_marker, approval_prompt_marker, mode_prompt_text, mode_change_runtime_message helpers removed. |
| crates/tui/src/core/engine/tests.rs | Two tests rewritten: change_mode_op_injects_runtime_event → change_mode_op_updates_current_mode_and_emits_status (verifies event structure but no longer validates mode identity in Status content); mode_change_runtime_message_format → current_mode_field_assignment_takes_effect_synchronously (exercises runtime tag reflection but bypasses Op::ChangeMode dispatch). Five assertions updated to match new tag format. |
| crates/tui/src/prompts/modes/agent.md | Top heading ## → #####; sub-headings ## Efficient Approvals and ## Session Longevity → ###### so they nest correctly under the #### agent section in the reference block. |
| crates/tui/src/prompts/approvals/auto.md | Heading changed from ## to ##### so it nests correctly under #### auto in the Runtime Policy Reference. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Engine
    participant SP as "System Prompt (frozen prefix)"
    participant API as "LLM API"
    participant Model

    Note over SP: render_runtime_policy_reference() contains all mode and approval descriptions. Sent once per session.

    Engine->>API: Request (system_prompt + session_messages + runtime_tag)
    Note over API: system_prompt is byte-stable, cache hits after first call
    API->>Model: system_prompt cached ~9325 tokens
    API->>Model: session_messages history
    API->>Model: runtime_prompt_message() ~16 tokens misses every time
    Model->>Model: Looks up mode and approval rules from system prompt reference
    Model->>API: Response or tool calls
    API->>Engine: Response

    Note over Engine: Op::ChangeMode received
    Engine->>Engine: "self.current_mode = NewMode"
    Engine->>Engine: emit_session_updated()
    Note over Engine: Next request tag carries new mode value automatically
```
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fslim-runtime-prompt%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fslim-runtime-prompt%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine.rs%3A2648-2651%0AThe%20doc%20comment%20says%20%22~12%20tokens%22%20but%20the%20PR%20description%20and%20the%20tag%20itself%20%28%60%3Cruntime_prompt%20visibility%3D%22internal%22%20mode%3D%22yolo%22%20approval%3D%22auto%22%2F%3E%60%29%20count%20to%20roughly%2016%20tokens.%20Keeping%20the%20number%20consistent%20avoids%20confusion%20when%20comparing%20against%20the%20tradeoff%20table%20in%20the%20PR%20description.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20All%20mode%20and%20approval%20policy%20descriptions%20live%20in%20the%20frozen%20system-prompt%0A%2F%2F%2F%20prefix%20%28%60render_runtime_policy_reference%28%29%60%29.%20This%20tag%20is%20a%20pointer%20%E2%80%94%20the%0A%2F%2F%2F%20model%20looks%20up%20the%20corresponding%20rules%20from%20the%20system%20prompt.%20%20Reduces%0A%2F%2F%2F%20per-request%20overhead%20from%20~500%20tokens%20to%20~16%20tokens.%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine%2Ftests.rs%3A1878-1881%0AThe%20assertion%20only%20checks%20the%20variant%20shape%20%28%60Event%3A%3AStatus%20%7B%20..%20%7D%60%29%2C%20not%20its%20content.%20The%20previous%20version%20of%20this%20test%20verified%20specific%20text%20in%20the%20event%3B%20without%20a%20content%20check%20the%20assertion%20would%20pass%20even%20if%20the%20engine%20emitted%20a%20Status%20event%20from%20an%20unrelated%20operation%20rather%20than%20the%20mode%20change.%20Asserting%20that%20the%20message%20mentions%20%22yolo%22%20would%20confirm%20the%20%60Op%3A%3AChangeMode%60%20arm%20produced%20the%20right%20status.%0A%0A%60%60%60suggestion%0A%20%20%20%20assert!%28%0A%20%20%20%20%20%20%20%20matches!%28status%2C%20Event%3A%3AStatus%20%7B%20message%2C%20..%20%7D%20if%20message.to_lowercase%28%29.contains%28%22yolo%22%29%29%2C%0A%20%20%20%20%20%20%20%20%22should%20emit%20Status%20mentioning%20yolo%20after%20mode%20change%2C%20got%3A%20%7Bstatus%3A%3F%7D%22%0A%20%20%20%20%29%3B%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2874&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine.rs%3A2648-2651%0AThe%20doc%20comment%20says%20%22~12%20tokens%22%20but%20the%20PR%20description%20and%20the%20tag%20itself%20%28%60%3Cruntime_prompt%20visibility%3D%22internal%22%20mode%3D%22yolo%22%20approval%3D%22auto%22%2F%3E%60%29%20count%20to%20roughly%2016%20tokens.%20Keeping%20the%20number%20consistent%20avoids%20confusion%20when%20comparing%20against%20the%20tradeoff%20table%20in%20the%20PR%20description.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20All%20mode%20and%20approval%20policy%20descriptions%20live%20in%20the%20frozen%20system-prompt%0A%2F%2F%2F%20prefix%20%28%60render_runtime_policy_reference%28%29%60%29.%20This%20tag%20is%20a%20pointer%20%E2%80%94%20the%0A%2F%2F%2F%20model%20looks%20up%20the%20corresponding%20rules%20from%20the%20system%20prompt.%20%20Reduces%0A%2F%2F%2F%20per-request%20overhead%20from%20~500%20tokens%20to%20~16%20tokens.%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine%2Ftests.rs%3A1878-1881%0AThe%20assertion%20only%20checks%20the%20variant%20shape%20%28%60Event%3A%3AStatus%20%7B%20..%20%7D%60%29%2C%20not%20its%20content.%20The%20previous%20version%20of%20this%20test%20verified%20specific%20text%20in%20the%20event%3B%20without%20a%20content%20check%20the%20assertion%20would%20pass%20even%20if%20the%20engine%20emitted%20a%20Status%20event%20from%20an%20unrelated%20operation%20rather%20than%20the%20mode%20change.%20Asserting%20that%20the%20message%20mentions%20%22yolo%22%20would%20confirm%20the%20%60Op%3A%3AChangeMode%60%20arm%20produced%20the%20right%20status.%0A%0A%60%60%60suggestion%0A%20%20%20%20assert!%28%0A%20%20%20%20%20%20%20%20matches!%28status%2C%20Event%3A%3AStatus%20%7B%20message%2C%20..%20%7D%20if%20message.to_lowercase%28%29.contains%28%22yolo%22%29%29%2C%0A%20%20%20%20%20%20%20%20%22should%20emit%20Status%20mentioning%20yolo%20after%20mode%20change%2C%20got%3A%20%7Bstatus%3A%3F%7D%22%0A%20%20%20%20%29%3B%0A%60%60%60%0A%0A&repo=hmbown%2Fcodewhale&pr=2874&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine.rs%3A2648-2651%0AThe%20doc%20comment%20says%20%22~12%20tokens%22%20but%20the%20PR%20description%20and%20the%20tag%20itself%20%28%60%3Cruntime_prompt%20visibility%3D%22internal%22%20mode%3D%22yolo%22%20approval%3D%22auto%22%2F%3E%60%29%20count%20to%20roughly%2016%20tokens.%20Keeping%20the%20number%20consistent%20avoids%20confusion%20when%20comparing%20against%20the%20tradeoff%20table%20in%20the%20PR%20description.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20All%20mode%20and%20approval%20policy%20descriptions%20live%20in%20the%20frozen%20system-prompt%0A%2F%2F%2F%20prefix%20%28%60render_runtime_policy_reference%28%29%60%29.%20This%20tag%20is%20a%20pointer%20%E2%80%94%20the%0A%2F%2F%2F%20model%20looks%20up%20the%20corresponding%20rules%20from%20the%20system%20prompt.%20%20Reduces%0A%2F%2F%2F%20per-request%20overhead%20from%20~500%20tokens%20to%20~16%20tokens.%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Ftui%2Fsrc%2Fcore%2Fengine%2Ftests.rs%3A1878-1881%0AThe%20assertion%20only%20checks%20the%20variant%20shape%20%28%60Event%3A%3AStatus%20%7B%20..%20%7D%60%29%2C%20not%20its%20content.%20The%20previous%20version%20of%20this%20test%20verified%20specific%20text%20in%20the%20event%3B%20without%20a%20content%20check%20the%20assertion%20would%20pass%20even%20if%20the%20engine%20emitted%20a%20Status%20event%20from%20an%20unrelated%20operation%20rather%20than%20the%20mode%20change.%20Asserting%20that%20the%20message%20mentions%20%22yolo%22%20would%20confirm%20the%20%60Op%3A%3AChangeMode%60%20arm%20produced%20the%20right%20status.%0A%0A%60%60%60suggestion%0A%20%20%20%20assert!%28%0A%20%20%20%20%20%20%20%20matches!%28status%2C%20Event%3A%3AStatus%20%7B%20message%2C%20..%20%7D%20if%20message.to_lowercase%28%29.contains%28%22yolo%22%29%29%2C%0A%20%20%20%20%20%20%20%20%22should%20emit%20Status%20mentioning%20yolo%20after%20mode%20change%2C%20got%3A%20%7Bstatus%3A%3F%7D%22%0A%20%20%20%20%29%3B%0A%60%60%60%0A%0A&pr=2874&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["test: add runtime\_policy\_reference compo..."](https://github.com/hmbown/codewhale/commit/55d7499408681a754b36397c176c31884eaa8646) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36059750)</sub>

<!-- /greptile_comment -->