### PR TITLE
[doc] fix the README.md format

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,9 @@ CodeWhale supports three Arcee models:
 | `trinity-mini` | ❌ No | 128,000 tokens | 4,096 tokens | Faster, cost-effective tasks |
 
 **Note:** The `trinity-large-thinking` model supports reasoning (thinking mode) and can handle very large contexts, making it ideal for complex programming tasks. The other models do not support reasoning but offer larger context windows than many other providers.
+
+```bash
+# Arcee
 codewhale auth set --provider arcee --api-key "YOUR_ARCEE_API_KEY"
 codewhale --provider arcee --model trinity-large-thinking
 codewhale --provider arcee --model trinity-large-preview


### PR DESCRIPTION
## Summary

<img width="957" height="750" alt="image" src="https://github.com/user-attachments/assets/613b2c6c-473c-4bcd-9b0b-3b2d599cf69d" />


## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a formatting issue in `README.md` where the Arcee provider CLI commands were rendered as plain text instead of inside a fenced bash code block.

- Inserts a blank line, a ` ```bash ` fence opener, and a `# Arcee` section comment immediately before the Arcee `codewhale auth set` commands, matching the style used for all other provider sections (Xiaomi MiMo, Novita, Fireworks, etc.) in the same block.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change that corrects missing code-fence markup; no logic, config, or runtime behavior is affected.

The change is three lines of Markdown — a blank line, a ```bash opener, and a comment — that make the Arcee command examples render consistently with every other provider block in the same file. There is no risk of regressions.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Adds missing ```bash opening and `# Arcee` section comment so the Arcee CLI commands are rendered as a fenced code block instead of bare text. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[README.md Arcee Section] --> B{Before PR}
    A --> C{After PR}
    B --> D[Note text - plain text Arcee commands - no code block]
    C --> E[Note text - backtick-bash fence - # Arcee comment - formatted Arcee commands]
    E --> F[Consistent with other provider sections in same block]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix the README.md format"](https://github.com/hmbown/codewhale/commit/9ceb9db1a401a4754a4a0c9a5003db40f4273a83) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36061668)</sub>

<!-- /greptile_comment -->