### PR TITLE
fix(cache): set temp spillover root in cache_inspect test to survive nix sandbox

### DIFF
--- a/crates/tui/src/commands/debug.rs
+++ b/crates/tui/src/commands/debug.rs
@@ -1183,6 +1183,22 @@ mod tests {
         let _spill_guard = crate::tools::truncate::TEST_SPILLOVER_GUARD
             .lock()
             .unwrap_or_else(|err| err.into_inner());
+        // Set a temporary spillover root so wire-dedup can persist
+        // SHA-addressed tool-result files without depending on a
+        // writable $HOME (nix sandboxes have a read-only home tree).
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _restore = {
+            let prior = crate::tools::truncate::set_test_spillover_root(Some(
+                tmp.path().join(".deepseek").join("tool_outputs"),
+            ));
+            struct Restore(Option<std::path::PathBuf>);
+            impl Drop for Restore {
+                fn drop(&mut self) {
+                    crate::tools::truncate::set_test_spillover_root(self.0.take());
+                }
+            }
+            Restore(prior)
+        };
         let mut app = create_test_app();
         let long_output = format!("{}{}", "A".repeat(7_000), "Z".repeat(7_000));
         app.api_messages.push(Message {


### PR DESCRIPTION
## Summary

Fix the flaky `cache_inspect_displays_tool_result_budget_metadata` test that fails in nix build sandboxes.

## Root cause

nix sandboxes have a read-only home tree. The test relied on a writable `$HOME/.codewhale/tool_outputs/` for tool-result wire-dedup persistence. The first tool-result SHA spillover write failed silently, the dedup hash table was never populated, and the second identical tool result was not marked deduplicated.

## Fix

Set `TEST_SPILLOVER_ROOT` to a tempdir inside the test, matching the existing `with_tool_result_sha_spillover_root` pattern in `chat.rs`.

## Scope

Only test code (`#[cfg(test)]`). No production code paths affected.

## Validation

```
cargo test -p codewhale-tui -- commands::debug::tests::cache_inspect_displays_tool_result_budget_metadata --exact
```

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a flaky test (`cache_inspect_displays_tool_result_budget_metadata`) that silently failed in nix build sandboxes because the test was trying to write SHA-addressed spillover files to `$HOME/.codewhale/tool_outputs/`, which is read-only in nix sandbox environments.

- Adds a `tempfile::tempdir()` spillover root override inside the test, using the same `set_test_spillover_root` + RAII `Restore` guard pattern that already exists in `crates/tui/src/tui/ui/tests.rs:1477–1487`.
- The fix is entirely test-scoped (`#[cfg(test)]`); no production code paths are affected.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is confined to test code and uses an established, well-tested RAII pattern already present in the codebase.

The fix is a straightforward test-only addition that mirrors the identical set_test_spillover_root + Restore guard idiom already used in ui/tests.rs. Drop order is correct (_restore before tmp), the mutex guard prevents parallel tests from racing on the global root, and no production paths are touched.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tui/src/commands/debug.rs | Adds a temporary spillover root override to cache_inspect_displays_tool_result_budget_metadata using the established set_test_spillover_root + RAII Restore pattern; change is test-only and correct. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Test as cache_inspect_displays_tool_result_budget_metadata
    participant Guard as TEST_SPILLOVER_GUARD
    participant Root as TEST_SPILLOVER_ROOT
    participant TmpDir as tempfile::tempdir()
    participant Spillover as spillover_root()

    Test->>Guard: lock() — serialize against other root-overriding tests
    Test->>TmpDir: tempdir() — create writable scratch directory
    Test->>Root: set_test_spillover_root(tmp/.deepseek/tool_outputs) → returns prior
    Note over Test,Root: Restore(prior) held as _restore

    Test->>Spillover: called by wire-dedup on first tool result
    Spillover-->>Root: reads TEST_SPILLOVER_ROOT → tmp path
    Spillover-->>Test: returns writable tmp path (not $HOME)

    Test->>Spillover: called by wire-dedup on second tool result
    Spillover-->>Root: reads TEST_SPILLOVER_ROOT → same tmp path
    Note over Test: dedup finds SHA file → deduplicated=true ✓

    Note over Test: test assertions pass
    Test->>Root: _restore drops → set_test_spillover_root(prior)
    Test->>TmpDir: tmp drops → tempdir deleted
    Test->>Guard: _spill_guard drops → mutex released
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cache): set temp spillover root in c..."](https://github.com/hmbown/codewhale/commit/256f34c62143215b533965a7f1cb1e9c49de3c07) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36062357)</sub>

<!-- /greptile_comment -->