### PR TITLE
docs: align Hugging Face provider docs, errors, and tests with shipped route

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -248,7 +248,8 @@ max_subagents = 10 # optional (1-20)
 #   SGLang:    SGLANG_BASE_URL, SGLANG_MODEL, optional SGLANG_API_KEY
 #   vLLM:      VLLM_BASE_URL, VLLM_MODEL, optional VLLM_API_KEY
 #   Ollama:    OLLAMA_BASE_URL, OLLAMA_MODEL, optional OLLAMA_API_KEY
-#   Hugging Face: HUGGINGFACE_API_KEY (or HF_TOKEN), HUGGINGFACE_BASE_URL, HUGGINGFACE_MODEL
+#   Hugging Face: HUGGINGFACE_API_KEY (or HF_TOKEN), HUGGINGFACE_BASE_URL (or HF_BASE_URL),
+#                 HUGGINGFACE_MODEL (or HF_MODEL)
 #
 # Custom DeepSeek-compatible APIs usually do not need a new provider table:
 # set `provider = "deepseek"` and override [providers.deepseek].base_url/model.
@@ -385,6 +386,7 @@ max_subagents = 10 # optional (1-20)
 # model = "deepseek-coder:1.3b"             # or any local Ollama tag
 
 # Hugging Face Inference Providers (https://huggingface.co/docs/api-inference)
+# Provider aliases: huggingface, hugging-face, hugging_face, hf
 [providers.huggingface]
 # api_key = "YOUR_HF_TOKEN"
 # base_url = "https://router.huggingface.co/v1"

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -132,6 +132,39 @@ pub enum ProviderKind {
 
 impl ProviderKind {
     #[must_use]
+    pub fn all() -> &'static [Self] {
+        &[
+            Self::Deepseek,
+            Self::NvidiaNim,
+            Self::Openai,
+            Self::Atlascloud,
+            Self::WanjieArk,
+            Self::Volcengine,
+            Self::Openrouter,
+            Self::XiaomiMimo,
+            Self::Novita,
+            Self::Fireworks,
+            Self::Siliconflow,
+            Self::SiliconflowCN,
+            Self::Arcee,
+            Self::Moonshot,
+            Self::Sglang,
+            Self::Vllm,
+            Self::Ollama,
+            Self::Huggingface,
+        ]
+    }
+
+    #[must_use]
+    pub fn names_hint() -> String {
+        Self::all()
+            .iter()
+            .map(|provider| provider.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+
+    #[must_use]
     pub fn as_str(self) -> &'static str {
         match self {
             Self::Deepseek => "deepseek",
@@ -698,8 +731,12 @@ impl ConfigToml {
     pub fn set_value(&mut self, key: &str, value: &str) -> Result<()> {
         match key {
             "provider" => {
-                self.provider = ProviderKind::parse(value)
-                    .with_context(|| format!("unknown provider '{value}'"))?;
+                self.provider = ProviderKind::parse(value).with_context(|| {
+                    format!(
+                        "unknown provider '{value}': expected {}",
+                        ProviderKind::names_hint()
+                    )
+                })?;
             }
             "api_key" => self.api_key = Some(value.to_string()),
             "base_url" => self.base_url = Some(value.to_string()),
@@ -1418,7 +1455,7 @@ impl ConfigToml {
         } else if let Some(value) = from_file.clone().filter(|v| !v.trim().is_empty()) {
             (Some(value), Some(RuntimeApiKeySource::ConfigFile))
         } else if should_skip_secret_store_for_provider(provider, &base_url, auth_mode.as_deref()) {
-            match codewhale_secrets::env_for(provider.as_str()) {
+            match env_api_key_for_provider(provider) {
                 Some(value) => (Some(value), Some(RuntimeApiKeySource::Env)),
                 None => (None, None),
             }
@@ -1431,7 +1468,10 @@ impl ConfigToml {
                     };
                     (Some(value), Some(source))
                 }
-                None => (None, None),
+                None => match env_api_key_for_provider(provider) {
+                    Some(value) => (Some(value), Some(RuntimeApiKeySource::Env)),
+                    None => (None, None),
+                },
             }
         };
 
@@ -1907,6 +1947,17 @@ fn should_skip_secret_store_for_provider(
         provider,
         ProviderKind::Sglang | ProviderKind::Vllm | ProviderKind::Ollama
     ) || base_url_uses_local_host(base_url)
+}
+
+fn env_api_key_for_provider(provider: ProviderKind) -> Option<String> {
+    if provider == ProviderKind::Huggingface {
+        return std::env::var("HUGGINGFACE_API_KEY")
+            .or_else(|_| std::env::var("HF_TOKEN"))
+            .ok()
+            .filter(|value| !value.trim().is_empty());
+    }
+
+    codewhale_secrets::env_for(provider.as_str())
 }
 
 fn auth_mode_requires_api_key(auth_mode: Option<&str>) -> bool {
@@ -2855,6 +2906,12 @@ mod tests {
         vllm_base_url: Option<OsString>,
         ollama_api_key: Option<OsString>,
         ollama_base_url: Option<OsString>,
+        huggingface_api_key: Option<OsString>,
+        huggingface_token: Option<OsString>,
+        huggingface_base_url: Option<OsString>,
+        hf_base_url: Option<OsString>,
+        huggingface_model: Option<OsString>,
+        hf_model: Option<OsString>,
         codewhale_provider: Option<OsString>,
         codewhale_model: Option<OsString>,
         codewhale_base_url: Option<OsString>,
@@ -2928,6 +2985,12 @@ mod tests {
                 vllm_base_url: env::var_os("VLLM_BASE_URL"),
                 ollama_api_key: env::var_os("OLLAMA_API_KEY"),
                 ollama_base_url: env::var_os("OLLAMA_BASE_URL"),
+                huggingface_api_key: env::var_os("HUGGINGFACE_API_KEY"),
+                huggingface_token: env::var_os("HF_TOKEN"),
+                huggingface_base_url: env::var_os("HUGGINGFACE_BASE_URL"),
+                hf_base_url: env::var_os("HF_BASE_URL"),
+                huggingface_model: env::var_os("HUGGINGFACE_MODEL"),
+                hf_model: env::var_os("HF_MODEL"),
             };
             // Safety: test-only environment mutation guarded by a module mutex.
             unsafe {
@@ -2996,6 +3059,12 @@ mod tests {
                 env::remove_var("VLLM_BASE_URL");
                 env::remove_var("OLLAMA_API_KEY");
                 env::remove_var("OLLAMA_BASE_URL");
+                env::remove_var("HUGGINGFACE_API_KEY");
+                env::remove_var("HF_TOKEN");
+                env::remove_var("HUGGINGFACE_BASE_URL");
+                env::remove_var("HF_BASE_URL");
+                env::remove_var("HUGGINGFACE_MODEL");
+                env::remove_var("HF_MODEL");
             }
             guard
         }
@@ -3084,6 +3153,12 @@ mod tests {
                 Self::restore_var("VLLM_BASE_URL", self.vllm_base_url.take());
                 Self::restore_var("OLLAMA_API_KEY", self.ollama_api_key.take());
                 Self::restore_var("OLLAMA_BASE_URL", self.ollama_base_url.take());
+                Self::restore_var("HUGGINGFACE_API_KEY", self.huggingface_api_key.take());
+                Self::restore_var("HF_TOKEN", self.huggingface_token.take());
+                Self::restore_var("HUGGINGFACE_BASE_URL", self.huggingface_base_url.take());
+                Self::restore_var("HF_BASE_URL", self.hf_base_url.take());
+                Self::restore_var("HUGGINGFACE_MODEL", self.huggingface_model.take());
+                Self::restore_var("HF_MODEL", self.hf_model.take());
             }
         }
     }
@@ -3987,6 +4062,13 @@ unix_socket_path = "/tmp/cw-hooks.sock"
             ProviderKind::parse("ark_wanjie"),
             Some(ProviderKind::WanjieArk)
         );
+        for alias in ["huggingface", "hugging-face", "hugging_face", "hf"] {
+            assert_eq!(ProviderKind::parse(alias), Some(ProviderKind::Huggingface));
+
+            let parsed: ConfigToml =
+                toml::from_str(&format!("provider = \"{alias}\"")).expect("huggingface alias");
+            assert_eq!(parsed.provider, ProviderKind::Huggingface);
+        }
 
         let parsed: ConfigToml =
             toml::from_str("provider = \"ark-wanjie\"").expect("wanjie provider alias");
@@ -3995,6 +4077,17 @@ unix_socket_path = "/tmp/cw-hooks.sock"
         let parsed: ConfigToml =
             toml::from_str("provider = \"silicon-flow\"").expect("siliconflow provider alias");
         assert_eq!(parsed.provider, ProviderKind::Siliconflow);
+    }
+
+    #[test]
+    fn unknown_provider_error_lists_huggingface() {
+        let mut config = ConfigToml::default();
+        let err = config
+            .set_value("provider", "not-a-provider")
+            .expect_err("unknown provider should fail");
+        let message = err.to_string();
+        assert!(message.contains("unknown provider 'not-a-provider'"));
+        assert!(message.contains("huggingface"));
     }
 
     #[test]
@@ -4685,6 +4778,51 @@ model = "mimo-v2.5-pro"
         assert_eq!(resolved.api_key.as_deref(), Some("arcee-file-key"));
         assert_eq!(resolved.base_url, DEFAULT_ARCEE_BASE_URL);
         assert_eq!(resolved.model, ARCEE_TRINITY_LARGE_PREVIEW_MODEL);
+    }
+
+    #[test]
+    fn huggingface_env_precedence_prefers_documented_names() {
+        let _lock = env_lock();
+        let _env = EnvGuard::without_deepseek_runtime_overrides();
+        // Safety: test-only environment mutation guarded by a module mutex.
+        unsafe {
+            env::set_var("CODEWHALE_PROVIDER", "hf");
+            env::set_var("HUGGINGFACE_API_KEY", "hf-full-key");
+            env::set_var("HF_TOKEN", "hf-token-fallback");
+            env::set_var("HUGGINGFACE_BASE_URL", "https://hf-full.example/v1");
+            env::set_var("HF_BASE_URL", "https://hf-short.example/v1");
+            env::set_var("HUGGINGFACE_MODEL", "org/full-model");
+            env::set_var("HF_MODEL", "org/short-model");
+        }
+
+        let resolved =
+            ConfigToml::default().resolve_runtime_options(&CliRuntimeOverrides::default());
+
+        assert_eq!(resolved.provider, ProviderKind::Huggingface);
+        assert_eq!(resolved.api_key.as_deref(), Some("hf-full-key"));
+        assert_eq!(resolved.base_url, "https://hf-full.example/v1");
+        assert_eq!(resolved.model, "org/full-model");
+    }
+
+    #[test]
+    fn huggingface_short_env_fallbacks_resolve_when_primary_names_are_absent() {
+        let _lock = env_lock();
+        let _env = EnvGuard::without_deepseek_runtime_overrides();
+        // Safety: test-only environment mutation guarded by a module mutex.
+        unsafe {
+            env::set_var("CODEWHALE_PROVIDER", "huggingface");
+            env::set_var("HF_TOKEN", "hf-token-fallback");
+            env::set_var("HF_BASE_URL", "https://hf-short.example/v1");
+            env::set_var("HF_MODEL", "org/short-model");
+        }
+
+        let resolved =
+            ConfigToml::default().resolve_runtime_options(&CliRuntimeOverrides::default());
+
+        assert_eq!(resolved.provider, ProviderKind::Huggingface);
+        assert_eq!(resolved.api_key.as_deref(), Some("hf-token-fallback"));
+        assert_eq!(resolved.base_url, "https://hf-short.example/v1");
+        assert_eq!(resolved.model, "org/short-model");
     }
 
     #[test]

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1952,9 +1952,13 @@ fn should_skip_secret_store_for_provider(
 fn env_api_key_for_provider(provider: ProviderKind) -> Option<String> {
     if provider == ProviderKind::Huggingface {
         return std::env::var("HUGGINGFACE_API_KEY")
-            .or_else(|_| std::env::var("HF_TOKEN"))
             .ok()
-            .filter(|value| !value.trim().is_empty());
+            .filter(|value| !value.trim().is_empty())
+            .or_else(|| {
+                std::env::var("HF_TOKEN")
+                    .ok()
+                    .filter(|value| !value.trim().is_empty())
+            });
     }
 
     codewhale_secrets::env_for(provider.as_str())
@@ -4823,6 +4827,24 @@ model = "mimo-v2.5-pro"
         assert_eq!(resolved.api_key.as_deref(), Some("hf-token-fallback"));
         assert_eq!(resolved.base_url, "https://hf-short.example/v1");
         assert_eq!(resolved.model, "org/short-model");
+    }
+
+    #[test]
+    fn huggingface_token_fallback_resolves_when_primary_api_key_is_blank() {
+        let _lock = env_lock();
+        let _env = EnvGuard::without_deepseek_runtime_overrides();
+        // Safety: test-only environment mutation guarded by a module mutex.
+        unsafe {
+            env::set_var("CODEWHALE_PROVIDER", "huggingface");
+            env::set_var("HUGGINGFACE_API_KEY", " ");
+            env::set_var("HF_TOKEN", "hf-token-fallback");
+        }
+
+        let resolved =
+            ConfigToml::default().resolve_runtime_options(&CliRuntimeOverrides::default());
+
+        assert_eq!(resolved.provider, ProviderKind::Huggingface);
+        assert_eq!(resolved.api_key.as_deref(), Some("hf-token-fallback"));
     }
 
     #[test]

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -3461,7 +3461,8 @@ fn apply_env_overrides(config: &mut Config) {
             .base_url = Some(value);
     }
     if matches!(config.api_provider(), ApiProvider::Huggingface)
-        && let Ok(value) = std::env::var("HUGGINGFACE_BASE_URL")
+        && let Ok(value) =
+            std::env::var("HUGGINGFACE_BASE_URL").or_else(|_| std::env::var("HF_BASE_URL"))
         && !value.trim().is_empty()
     {
         config
@@ -3674,7 +3675,7 @@ fn apply_env_overrides(config: &mut Config) {
             .model = Some(value);
     }
     if matches!(config.api_provider(), ApiProvider::Huggingface)
-        && let Ok(value) = std::env::var("HUGGINGFACE_MODEL")
+        && let Ok(value) = std::env::var("HUGGINGFACE_MODEL").or_else(|_| std::env::var("HF_MODEL"))
         && !value.trim().is_empty()
     {
         config
@@ -5763,7 +5764,9 @@ mod tests {
         huggingface_api_key: Option<OsString>,
         huggingface_token: Option<OsString>,
         huggingface_base_url: Option<OsString>,
+        hf_base_url: Option<OsString>,
         huggingface_model: Option<OsString>,
+        hf_model: Option<OsString>,
     }
 
     impl EnvGuard {
@@ -5860,7 +5863,9 @@ mod tests {
             let huggingface_api_key_prev = env::var_os("HUGGINGFACE_API_KEY");
             let huggingface_token_prev = env::var_os("HF_TOKEN");
             let huggingface_base_url_prev = env::var_os("HUGGINGFACE_BASE_URL");
+            let hf_base_url_prev = env::var_os("HF_BASE_URL");
             let huggingface_model_prev = env::var_os("HUGGINGFACE_MODEL");
+            let hf_model_prev = env::var_os("HF_MODEL");
             // Safety: test-only environment mutation guarded by a global mutex.
             unsafe {
                 env::set_var("HOME", &home_str);
@@ -5952,7 +5957,9 @@ mod tests {
                 env::remove_var("HUGGINGFACE_API_KEY");
                 env::remove_var("HF_TOKEN");
                 env::remove_var("HUGGINGFACE_BASE_URL");
+                env::remove_var("HF_BASE_URL");
                 env::remove_var("HUGGINGFACE_MODEL");
+                env::remove_var("HF_MODEL");
             }
             Self {
                 home: home_prev,
@@ -6044,7 +6051,9 @@ mod tests {
                 huggingface_api_key: huggingface_api_key_prev,
                 huggingface_token: huggingface_token_prev,
                 huggingface_base_url: huggingface_base_url_prev,
+                hf_base_url: hf_base_url_prev,
                 huggingface_model: huggingface_model_prev,
+                hf_model: hf_model_prev,
             }
         }
     }
@@ -6154,7 +6163,9 @@ mod tests {
                 Self::restore_var("HUGGINGFACE_API_KEY", self.huggingface_api_key.take());
                 Self::restore_var("HF_TOKEN", self.huggingface_token.take());
                 Self::restore_var("HUGGINGFACE_BASE_URL", self.huggingface_base_url.take());
+                Self::restore_var("HF_BASE_URL", self.hf_base_url.take());
                 Self::restore_var("HUGGINGFACE_MODEL", self.huggingface_model.take());
+                Self::restore_var("HF_MODEL", self.hf_model.take());
             }
         }
     }
@@ -10039,6 +10050,25 @@ model = "deepseek-ai/deepseek-v4-pro"
     }
 
     #[test]
+    fn huggingface_provider_aliases_parse() {
+        for alias in ["huggingface", "hugging-face", "hugging_face", "hf"] {
+            assert_eq!(ApiProvider::parse(alias), Some(ApiProvider::Huggingface));
+        }
+    }
+
+    #[test]
+    fn invalid_provider_error_lists_huggingface() {
+        let config = Config {
+            provider: Some("not-a-provider".to_string()),
+            ..Default::default()
+        };
+        let err = config.validate().expect_err("unknown provider should fail");
+        let message = err.to_string();
+        assert!(message.contains("Invalid provider 'not-a-provider'"));
+        assert!(message.contains("huggingface"));
+    }
+
+    #[test]
     fn huggingface_provider_uses_direct_defaults() -> Result<()> {
         let _lock = lock_test_env();
         let nanos = SystemTime::now()
@@ -10093,6 +10123,35 @@ model = "deepseek-ai/deepseek-v4-pro"
     }
 
     #[test]
+    fn huggingface_missing_key_error_mentions_env_fallbacks() -> Result<()> {
+        let _lock = lock_test_env();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let temp_root = env::temp_dir().join(format!(
+            "codewhale-tui-huggingface-missing-key-test-{}-{}",
+            std::process::id(),
+            nanos
+        ));
+        fs::create_dir_all(&temp_root)?;
+        let _guard = EnvGuard::new(&temp_root);
+
+        let config = Config {
+            provider: Some("huggingface".to_string()),
+            ..Default::default()
+        };
+
+        config.validate()?;
+        let err = config.deepseek_api_key().expect_err("missing key");
+        let message = err.to_string();
+        assert!(message.contains("Hugging Face API key not found"));
+        assert!(message.contains("HUGGINGFACE_API_KEY"));
+        assert!(message.contains("HF_TOKEN"));
+        Ok(())
+    }
+
+    #[test]
     fn huggingface_env_overrides_key_base_url_and_model() -> Result<()> {
         let _lock = lock_test_env();
         let nanos = SystemTime::now()
@@ -10110,8 +10169,11 @@ model = "deepseek-ai/deepseek-v4-pro"
         unsafe {
             env::set_var("CODEWHALE_PROVIDER", "huggingface");
             env::set_var("HUGGINGFACE_API_KEY", "hf-env-key");
+            env::set_var("HF_TOKEN", "hf-token-fallback");
             env::set_var("HUGGINGFACE_BASE_URL", "https://custom-hf.example/v1");
+            env::set_var("HF_BASE_URL", "https://fallback-hf.example/v1");
             env::set_var("HUGGINGFACE_MODEL", "meta-llama/Llama-3-70B");
+            env::set_var("HF_MODEL", "fallback/model");
         }
 
         let config = Config::load(None, None)?;
@@ -10119,6 +10181,36 @@ model = "deepseek-ai/deepseek-v4-pro"
         assert_eq!(config.deepseek_api_key()?, "hf-env-key");
         assert_eq!(config.deepseek_base_url(), "https://custom-hf.example/v1");
         assert_eq!(config.default_model(), "meta-llama/Llama-3-70B");
+        Ok(())
+    }
+
+    #[test]
+    fn huggingface_short_env_fallbacks_configure_route() -> Result<()> {
+        let _lock = lock_test_env();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let temp_root = env::temp_dir().join(format!(
+            "codewhale-tui-huggingface-short-env-test-{}-{}",
+            std::process::id(),
+            nanos
+        ));
+        fs::create_dir_all(&temp_root)?;
+        let _guard = EnvGuard::new(&temp_root);
+
+        unsafe {
+            env::set_var("CODEWHALE_PROVIDER", "hf");
+            env::set_var("HF_TOKEN", "hf-token-value");
+            env::set_var("HF_BASE_URL", "https://short-hf.example/v1");
+            env::set_var("HF_MODEL", "org/short-model");
+        }
+
+        let config = Config::load(None, None)?;
+        assert_eq!(config.api_provider(), ApiProvider::Huggingface);
+        assert_eq!(config.deepseek_api_key()?, "hf-token-value");
+        assert_eq!(config.deepseek_base_url(), "https://short-hf.example/v1");
+        assert_eq!(config.default_model(), "org/short-model");
         Ok(())
     }
 }

--- a/docs/MODEL_LAB.md
+++ b/docs/MODEL_LAB.md
@@ -7,8 +7,7 @@ those models become discoverable, evaluable, routable, servable, and exportable
 without weakening the current terminal-agent contract: local workspace control,
 explicit provider auth, approval gates, and clear privacy boundaries.
 
-This document is roadmap language. It does not mean every workset below is
-implemented today.
+This document is roadmap language. Some worksets below are roadmap-only.
 
 ## Implemented Today
 
@@ -19,6 +18,10 @@ implemented today.
   OpenAI-compatible endpoints, SGLang, vLLM, and Ollama are supported provider
   paths where their IDs appear in `/provider`, `codewhale --provider`, or
   `codewhale models`.
+- Hugging Face Inference Providers are available through the
+  OpenAI-compatible router at `https://router.huggingface.co/v1`. Select the
+  route with `huggingface`, `hugging-face`, `hugging_face`, or `hf`; configure
+  `HUGGINGFACE_API_KEY` or `HF_TOKEN` for auth.
 - Model auto-routing chooses a concrete DeepSeek model and thinking level per
   turn. It is not a TUI mode.
 - Fin is the fast `deepseek-v4-flash` thinking-off path for routing,
@@ -27,11 +30,10 @@ implemented today.
 - Self-hosted OpenAI-compatible endpoints can be used through SGLang, vLLM,
   Ollama, or the generic `openai` provider configuration.
 
-## Not Implemented Yet
+## Still Planned
 
-- A native Hugging Face provider or Hub browser.
-- Built-in Hugging Face model card, dataset, adapter, safetensors, or Jobs
-  workflows.
+- Hugging Face Hub browsing, upload/export, model card, dataset, adapter,
+  safetensors, or Jobs workflows.
 - Native Unsloth, NeMo, or Arcee integrations.
 - A dedicated Model Lab UI tab.
 - Built-in benchmark suites, eval leaderboards, hosted observability, or
@@ -57,18 +59,24 @@ describe a model as available before CodeWhale can actually route to it.
 
 ## Hugging Face Workset
 
+Implemented today:
+
+- Hugging Face Inference Providers as an explicit OpenAI-compatible router
+  provider, selected with `huggingface`, `hugging-face`, `hugging_face`, or
+  `hf`.
+- Model IDs are sent to the router exactly as selected, including
+  org-prefixed Hugging Face model IDs.
+
 Planned scope:
 
 - Hub API auth and model discovery.
 - Model cards, licenses, tags, safetensors metadata, adapters, and dataset
   links surfaced in a terminal-friendly way.
-- Inference Providers as explicit provider choices when the user configures
-  them.
 - Hugging Face Jobs as an optional remote execution path for user-approved
   experiments.
 
-Non-goal for now: claiming a native Hugging Face provider exists before it is
-implemented in code.
+Non-goal for now: treating the router route as Hub browsing/export, or
+inferring Hub upload/export auth from the inference-provider API key.
 
 ## Unsloth Workset
 
@@ -138,8 +146,9 @@ Planned scope:
 - Local files, prompts, transcripts, traces, model outputs, eval results,
   adapters, datasets, and checkpoints should remain local unless the user
   explicitly chooses a provider or export destination.
-- Provider auth must remain explicit. `DEEPSEEK_*`, OpenRouter, Hugging Face,
-  and self-hosted credentials should not be inferred from unrelated config.
+- Provider auth must remain explicit. `DEEPSEEK_*`, OpenRouter,
+  `HUGGINGFACE_API_KEY` / `HF_TOKEN`, and self-hosted credentials should not be
+  inferred from unrelated config.
 - Exportable artifacts should include provenance: source model, provider,
   route, tool policy, eval inputs, and redaction status.
 - Public sharing, hosted telemetry, sponsorship badges, and external branding

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -44,6 +44,11 @@ Use any of these surfaces to select a provider:
 as legacy aliases for `deepseek`. They do not select a different official host;
 DeepSeek uses the same official API host worldwide.
 
+`huggingface`, `hugging-face`, `hugging_face`, and `hf` all select the
+Hugging Face Inference Providers route. This is the OpenAI-compatible router
+path for chat/inference, not Hub browsing, model-card inspection, uploads, or
+artifact export.
+
 Fresh shared config writes to `~/.codewhale/config.toml`. Existing
 `~/.deepseek/config.toml` files are still read for compatibility.
 
@@ -128,7 +133,7 @@ endpoint.
 | `sglang` | `[providers.sglang]` | Optional `SGLANG_API_KEY` | `SGLANG_BASE_URL`; default `http://localhost:30000/v1` | `deepseek-ai/DeepSeek-V4-Pro`, `deepseek-ai/DeepSeek-V4-Flash` | Self-hosted OpenAI-compatible route. Localhost deployments commonly omit auth. `SGLANG_MODEL` is accepted. |
 | `vllm` | `[providers.vllm]` | Optional `VLLM_API_KEY` | `VLLM_BASE_URL`; default `http://localhost:8000/v1` | `deepseek-ai/DeepSeek-V4-Pro`, `deepseek-ai/DeepSeek-V4-Flash` | Self-hosted vLLM OpenAI-compatible route. Localhost deployments commonly omit auth. `VLLM_MODEL` is accepted. |
 | `ollama` | `[providers.ollama]` | Optional `OLLAMA_API_KEY` | `OLLAMA_BASE_URL`; default `http://localhost:11434/v1` | `deepseek-coder:1.3b`; provider-hinted custom tags pass through | Self-hosted Ollama OpenAI-compatible route. Localhost deployments commonly omit auth. `OLLAMA_MODEL` is accepted. |
-| `huggingface` | `[providers.huggingface]` | `HUGGINGFACE_API_KEY`, `HF_TOKEN` | `HUGGINGFACE_BASE_URL`; default `https://router.huggingface.co/v1` | `deepseek-ai/DeepSeek-V4-Pro`, `deepseek-ai/DeepSeek-V4-Flash` | Hugging Face Inference Providers OpenAI-compatible route. Org-prefixed model IDs pass through. |
+| `huggingface` | `[providers.huggingface]` | `HUGGINGFACE_API_KEY`, `HF_TOKEN` | `HUGGINGFACE_BASE_URL`, `HF_BASE_URL`; default `https://router.huggingface.co/v1` | `deepseek-ai/DeepSeek-V4-Pro`, `deepseek-ai/DeepSeek-V4-Flash` | Hugging Face Inference Providers OpenAI-compatible router route. Accepted aliases: `huggingface`, `hugging-face`, `hugging_face`, `hf`. Org-prefixed model IDs pass through. `HUGGINGFACE_MODEL` and `HF_MODEL` are accepted. Hub browsing/export are separate future features. |
 
 ### Xiaomi MiMo Notes
 
@@ -222,6 +227,18 @@ Tool-call support is tracked separately by the static `ModelRegistry` and by
 the endpoint's ability to accept OpenAI-compatible `tools` payloads. A custom
 OpenAI-compatible or local endpoint can still reject tool calls even if
 CodeWhale can send the schema.
+
+### Hugging Face Inference Providers Notes
+
+The shipped Hugging Face route targets the OpenAI-compatible Inference Providers
+router at `https://router.huggingface.co/v1`. Configure auth with
+`HUGGINGFACE_API_KEY` first, or `HF_TOKEN` as a fallback. Configure the endpoint
+with `HUGGINGFACE_BASE_URL` first, or `HF_BASE_URL` as a fallback; configure the
+model with `HUGGINGFACE_MODEL` first, or `HF_MODEL` as a fallback.
+
+This route does not imply Hub browsing, model-card metadata, dataset access,
+Jobs, uploads, or export. Those remain explicit Model Lab work items so
+provider auth and artifact movement stay separate.
 
 ### When a Local Model Prints Tool JSON
 

--- a/scripts/check-provider-registry.py
+++ b/scripts/check-provider-registry.py
@@ -30,6 +30,10 @@ API_PROVIDER_ONLY_IDS = {"deepseek-cn"}
 SHARED_PROVIDER_TABLES = {
     "siliconflow-CN": "siliconflow",
 }
+HUGGINGFACE_ALIASES = {"huggingface", "hugging-face", "hugging_face", "hf"}
+HUGGINGFACE_API_KEY_ENV_ORDER = ["HUGGINGFACE_API_KEY", "HF_TOKEN"]
+HUGGINGFACE_BASE_URL_ENV_ORDER = ["HUGGINGFACE_BASE_URL", "HF_BASE_URL"]
+HUGGINGFACE_MODEL_ENV_ORDER = ["HUGGINGFACE_MODEL", "HF_MODEL"]
 
 
 def read(path: Path) -> str:
@@ -66,6 +70,23 @@ def extract_match_block(
             if depth == 0:
                 return source[brace_start + 1 : index]
     raise ValueError(f"could not parse match block after {signature!r}")
+
+
+def parse_aliases_for_variant(source: str, enum_name: str, variant: str, context: str) -> set[str]:
+    impl_start = require_index(source, f"impl {enum_name}", context)
+    block = extract_match_block(
+        source,
+        "pub fn parse(value: &str) -> Option<Self>",
+        context,
+        impl_start,
+    )
+    match_arm = re.search(
+        rf'((?:"[^"]+"\s*\|\s*)*"[^"]+")\s*=>\s*Some\(Self::{variant}\)',
+        block,
+    )
+    if not match_arm:
+        raise ValueError(f"{context}: missing parse arm for {variant}")
+    return set(re.findall(r'"([^"]+)"', match_arm.group(1)))
 
 
 def provider_kind_ids(config_rs: str) -> dict[str, str]:
@@ -198,6 +219,76 @@ def report_provider_enum_drift(
     return errors
 
 
+def report_huggingface_coverage(
+    config_rs: str, tui_config_rs: str, providers_md: str
+) -> list[str]:
+    errors = []
+
+    config_aliases = parse_aliases_for_variant(
+        config_rs, "ProviderKind", "Huggingface", "crates/config/src/lib.rs"
+    )
+    tui_aliases = parse_aliases_for_variant(
+        tui_config_rs, "ApiProvider", "Huggingface", "crates/tui/src/config.rs"
+    )
+    errors += report_set(
+        "ProviderKind Hugging Face aliases",
+        HUGGINGFACE_ALIASES,
+        config_aliases & HUGGINGFACE_ALIASES,
+    )
+    errors += report_set(
+        "ApiProvider Hugging Face aliases",
+        HUGGINGFACE_ALIASES,
+        tui_aliases & HUGGINGFACE_ALIASES,
+    )
+
+    inline_source = re.sub(r"```.*?```", "", providers_md, flags=re.DOTALL)
+    code_spans = set(re.findall(r"`([^`]+)`", inline_source))
+    errors += report_set(
+        "documented Hugging Face aliases",
+        HUGGINGFACE_ALIASES,
+        code_spans & HUGGINGFACE_ALIASES,
+    )
+
+    for label, env_order in [
+        ("Hugging Face API key env precedence", HUGGINGFACE_API_KEY_ENV_ORDER),
+        ("Hugging Face base URL env precedence", HUGGINGFACE_BASE_URL_ENV_ORDER),
+        ("Hugging Face model env precedence", HUGGINGFACE_MODEL_ENV_ORDER),
+    ]:
+        errors += report_env_lookup_order(
+            label, config_rs, env_order, "crates/config/src/lib.rs"
+        )
+        errors += report_env_lookup_order(
+            label, tui_config_rs, env_order, "crates/tui/src/config.rs"
+        )
+        errors += report_string_order(label, providers_md, env_order, "docs/PROVIDERS.md")
+
+    return errors
+
+
+def report_env_lookup_order(
+    label: str, source: str, expected_order: list[str], context: str
+) -> list[str]:
+    lookup_needles = [f'std::env::var("{name}")' for name in expected_order]
+    return report_string_order(label, source, lookup_needles, context)
+
+
+def report_string_order(
+    label: str, source: str, expected_order: list[str], context: str
+) -> list[str]:
+    positions = []
+    for needle in expected_order:
+        index = source.find(needle)
+        if index == -1:
+            return [f"{label} missing {needle!r} in {context}"]
+        positions.append(index)
+    if positions != sorted(positions):
+        return [
+            f"{label} has wrong order in {context}: expected "
+            + " before ".join(expected_order)
+        ]
+    return []
+
+
 def provider_table_name(provider_id: str) -> str:
     return SHARED_PROVIDER_TABLES.get(provider_id, provider_id.replace("-", "_"))
 
@@ -216,6 +307,7 @@ def main() -> int:
 
         errors: list[str] = []
         errors += report_provider_enum_drift(canonical_ids, live_api_provider_ids)
+        errors += report_huggingface_coverage(config_rs, tui_config_rs, providers_md)
         errors += report_set(
             "shipped provider rows",
             canonical_ids,


### PR DESCRIPTION
## Summary

Aligns the Hugging Face provider surface with the shipped route, per the polish list in #2706: documented env aliases now actually resolve (`HUGGINGFACE_API_KEY` primary, `HF_TOKEN` fallback, blank-primary handled so the fallback still fires), provider errors list `huggingface` among known providers, `config.example.toml` and `docs/PROVIDERS.md` / `docs/MODEL_LAB.md` match the code, and a new `scripts/check-provider-registry.py` drift check keeps the registry, docs, and example config from diverging again. TUI env handling in `crates/tui/src/config.rs` mirrors the config-crate resolution so both paths agree.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features`
- [x] `cargo test --workspace --all-features` (one unrelated TUI test flaked in a single run and passed on re-run; the huggingface tests passed in every run)

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [x] Verified TUI behavior manually if UI changes (N/A: no rendered UI change; env resolution only)

Fixes #2706

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR aligns the Hugging Face provider surface — env var resolution, error messages, docs, example config, and the drift-check script — with the route that was already shipped. The code changes are small and targeted: two new env-var fallbacks in the TUI path (`HF_BASE_URL`, `HF_MODEL`), a new `env_api_key_for_provider` helper in the config crate that correctly prioritises `HUGGINGFACE_API_KEY` over `HF_TOKEN` (including blank-primary handling), and an expanded `check-provider-registry.py` that keeps aliases and env-var order in sync across both crates and docs.

- **Config crate** — adds `ProviderKind::all()` / `names_hint()` for richer "unknown provider" errors, and `env_api_key_for_provider()` so the `HUGGINGFACE_API_KEY` → `HF_TOKEN` fallback chain fires in both the "skip secret store" and "secret store returned nothing" paths.
- **TUI crate** — extends `apply_env_overrides` with `HF_BASE_URL` and `HF_MODEL` fallbacks to mirror the config-crate resolution; five new tests cover aliases, error text, short-name fallbacks, and combined-env precedence.
- **Docs / example config** — `PROVIDERS.md`, `MODEL_LAB.md`, and `config.example.toml` now document all four aliases, both base-URL env names, both model env names, and correctly place the HF inference-providers route in the "Implemented Today" section.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; all three resolution paths (config crate skip-secret-store, config crate secret-store fallback, TUI deepseek_api_key) now agree on HUGGINGFACE_API_KEY → HF_TOKEN priority, blank-primary handling is correct, and the new tests exercise the key scenarios end-to-end.

The functional changes are small and well-tested. The one structural concern is that ProviderKind::all() is a manually maintained list — a future enum variant added without updating it would silently disappear from error-message hints without any compiler warning. The drift-check script also has a first-occurrence limitation that could let an out-of-order resolution path go undetected. Neither issue affects current correctness.

crates/config/src/lib.rs — specifically the new ProviderKind::all() list, which must be kept in sync with the enum manually.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/config/src/lib.rs | Adds ProviderKind::all() + names_hint() for richer error messages, env_api_key_for_provider() for HUGGINGFACE_API_KEY/HF_TOKEN priority logic, and a fallback secrets path; tests cover blank-primary, short-name fallbacks, and full-name precedence. all() is manually maintained with no compile-time exhaustiveness guard. |
| crates/tui/src/config.rs | Adds HF_BASE_URL and HF_MODEL fallbacks in apply_env_overrides to mirror the config-crate resolution; updates test EnvGuard to save/restore those new vars; adds five new Hugging Face tests covering aliases, error messages, short-name fallbacks, and combined overrides. |
| scripts/check-provider-registry.py | Adds report_huggingface_coverage() which checks alias parity across ProviderKind/ApiProvider/docs, and report_env_lookup_order() which verifies HUGGINGFACE_API_KEY/HF_TOKEN ordering using source.find() (first occurrence); this approach can miss ordering violations in newly added code paths if an earlier correct-order site still exists in the file. |
| docs/PROVIDERS.md | Adds huggingface aliases note, updates table row to document HF_BASE_URL and HF_MODEL fallbacks, adds dedicated Hugging Face Inference Providers Notes section with correct precedence order; aligns with shipped code. |
| docs/MODEL_LAB.md | Moves Hugging Face inference route to Implemented Today list, restructures the HF workset section to separate shipped vs planned scope, and removes the stale native HF provider disclaimer. |
| config.example.toml | Updates HF env var comments to document HF_BASE_URL and HF_MODEL fallbacks; adds alias list comment above [providers.huggingface] table. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User sets provider to huggingface / hf / hugging-face / hugging_face] --> B[ProviderKind::parse / ApiProvider::parse]
    B --> C{Recognized?}
    C -- No --> D[Error: unknown provider expected deepseek ... huggingface]
    C -- Yes --> E[Resolve API key]
    E --> F{CLI flag set?}
    F -- Yes --> G[Use CLI key]
    F -- No --> H{Config file has api_key?}
    H -- Yes --> I[Use config file key]
    H -- No --> J{Skip secret store?}
    J -- Yes --> K[env_api_key_for_provider]
    J -- No --> L[secrets.resolve_with_source huggingface]
    L -- Found --> M[Return value]
    L -- None --> K
    K --> N{HUGGINGFACE_API_KEY set and non-blank?}
    N -- Yes --> O[Use HUGGINGFACE_API_KEY]
    N -- No --> P{HF_TOKEN set and non-blank?}
    P -- Yes --> Q[Use HF_TOKEN]
    P -- No --> R[Error: Hugging Face API key not found]
    subgraph TUI apply_env_overrides
    S[HUGGINGFACE_BASE_URL set?] -->|Yes| T[Use HUGGINGFACE_BASE_URL]
    S -->|No| U[HF_BASE_URL set?]
    U -->|Yes| V[Use HF_BASE_URL]
    U -->|No| W[Use default router.huggingface.co/v1]
    X[HUGGINGFACE_MODEL set?] -->|Yes| Y[Use HUGGINGFACE_MODEL]
    X -->|No| Z[HF_MODEL set?]
    Z -->|Yes| AA[Use HF_MODEL]
    Z -->|No| AB[Use default model]
    end
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `scripts/check-provider-registry.py`, line 682-696 ([link](https://github.com/hmbown/codewhale/blob/89cb6c55c81c7d8cc0c07816f215f5d00fe2d414/scripts/check-provider-registry.py#L682-L696)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> `report_string_order` anchors on the **first occurrence** of each needle via `str.find()`. In `crates/tui/src/config.rs` the correct-priority occurrence of `std::env::var("HUGGINGFACE_API_KEY")` (line ~2506) and `std::env::var("HF_TOKEN")` (line ~2511) appear before any of the `HF_TOKEN`-only "is auth present?" checks later in the file. So the ordering check passes today. However, if a new resolution code path is added that consults `HF_TOKEN` before `HUGGINGFACE_API_KEY`, the check would still pass because `find()` returns the first (correctly ordered) site and ignores the new one. Tightening the check to scan within the specific resolution function would make the drift guard more reliable.

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2F2706-huggingface-provider-polish%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F2706-huggingface-provider-polish%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fcheck-provider-registry.py%0ALine%3A%20682-696%0A%0AComment%3A%0A%60report_string_order%60%20anchors%20on%20the%20**first%20occurrence**%20of%20each%20needle%20via%20%60str.find%28%29%60.%20In%20%60crates%2Ftui%2Fsrc%2Fconfig.rs%60%20the%20correct-priority%20occurrence%20of%20%60std%3A%3Aenv%3A%3Avar%28%22HUGGINGFACE_API_KEY%22%29%60%20%28line%20~2506%29%20and%20%60std%3A%3Aenv%3A%3Avar%28%22HF_TOKEN%22%29%60%20%28line%20~2511%29%20appear%20before%20any%20of%20the%20%60HF_TOKEN%60-only%20%22is%20auth%20present%3F%22%20checks%20later%20in%20the%20file.%20So%20the%20ordering%20check%20passes%20today.%20However%2C%20if%20a%20new%20resolution%20code%20path%20is%20added%20that%20consults%20%60HF_TOKEN%60%20before%20%60HUGGINGFACE_API_KEY%60%2C%20the%20check%20would%20still%20pass%20because%20%60find%28%29%60%20returns%20the%20first%20%28correctly%20ordered%29%20site%20and%20ignores%20the%20new%20one.%20Tightening%20the%20check%20to%20scan%20within%20the%20specific%20resolution%20function%20would%20make%20the%20drift%20guard%20more%20reliable.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2879&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fcheck-provider-registry.py%0ALine%3A%20682-696%0A%0AComment%3A%0A%60report_string_order%60%20anchors%20on%20the%20**first%20occurrence**%20of%20each%20needle%20via%20%60str.find%28%29%60.%20In%20%60crates%2Ftui%2Fsrc%2Fconfig.rs%60%20the%20correct-priority%20occurrence%20of%20%60std%3A%3Aenv%3A%3Avar%28%22HUGGINGFACE_API_KEY%22%29%60%20%28line%20~2506%29%20and%20%60std%3A%3Aenv%3A%3Avar%28%22HF_TOKEN%22%29%60%20%28line%20~2511%29%20appear%20before%20any%20of%20the%20%60HF_TOKEN%60-only%20%22is%20auth%20present%3F%22%20checks%20later%20in%20the%20file.%20So%20the%20ordering%20check%20passes%20today.%20However%2C%20if%20a%20new%20resolution%20code%20path%20is%20added%20that%20consults%20%60HF_TOKEN%60%20before%20%60HUGGINGFACE_API_KEY%60%2C%20the%20check%20would%20still%20pass%20because%20%60find%28%29%60%20returns%20the%20first%20%28correctly%20ordered%29%20site%20and%20ignores%20the%20new%20one.%20Tightening%20the%20check%20to%20scan%20within%20the%20specific%20resolution%20function%20would%20make%20the%20drift%20guard%20more%20reliable.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2879&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fcheck-provider-registry.py%0ALine%3A%20682-696%0A%0AComment%3A%0A%60report_string_order%60%20anchors%20on%20the%20**first%20occurrence**%20of%20each%20needle%20via%20%60str.find%28%29%60.%20In%20%60crates%2Ftui%2Fsrc%2Fconfig.rs%60%20the%20correct-priority%20occurrence%20of%20%60std%3A%3Aenv%3A%3Avar%28%22HUGGINGFACE_API_KEY%22%29%60%20%28line%20~2506%29%20and%20%60std%3A%3Aenv%3A%3Avar%28%22HF_TOKEN%22%29%60%20%28line%20~2511%29%20appear%20before%20any%20of%20the%20%60HF_TOKEN%60-only%20%22is%20auth%20present%3F%22%20checks%20later%20in%20the%20file.%20So%20the%20ordering%20check%20passes%20today.%20However%2C%20if%20a%20new%20resolution%20code%20path%20is%20added%20that%20consults%20%60HF_TOKEN%60%20before%20%60HUGGINGFACE_API_KEY%60%2C%20the%20check%20would%20still%20pass%20because%20%60find%28%29%60%20returns%20the%20first%20%28correctly%20ordered%29%20site%20and%20ignores%20the%20new%20one.%20Tightening%20the%20check%20to%20scan%20within%20the%20specific%20resolution%20function%20would%20make%20the%20drift%20guard%20more%20reliable.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2879&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22fix%2F2706-huggingface-provider-polish%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F2706-huggingface-provider-polish%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Fconfig%2Fsrc%2Flib.rs%3A134-156%0A%60ProviderKind%3A%3Aall%28%29%60%20is%20a%20manually%20maintained%20list%20with%20no%20compile-time%20guarantee%20that%20it%20matches%20the%20enum's%20variants.%20If%20a%20new%20variant%20is%20added%20to%20%60ProviderKind%60%20but%20forgotten%20here%2C%20it%20will%20silently%20disappear%20from%20error-message%20hints.%20Consider%20using%20a%20crate%20like%20%60strum%60%20with%20%60%23%5Bderive%28EnumIter%29%5D%60%2C%20or%20at%20minimum%20a%20compile-time%20%60const%60%20array%20alongside%20the%20enum%20so%20the%20mismatch%20is%20caught%20at%20build%20time.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%20NOTE%3A%20Keep%20this%20list%20in%20sync%20with%20the%20ProviderKind%20enum.%20There%20is%20no%0A%20%20%20%20%2F%2F%20compile-time%20check%3B%20adding%20a%20variant%20without%20updating%20this%20array%20will%0A%20%20%20%20%2F%2F%20silently%20omit%20it%20from%20error-message%20hints%20produced%20by%20names_hint%28%29.%0A%20%20%20%20%23%5Bmust_use%5D%0A%20%20%20%20pub%20fn%20all%28%29%20-%3E%20%26'static%20%5BSelf%5D%20%7B%0A%20%20%20%20%20%20%20%20%26%5B%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3ADeepseek%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3ANvidiaNim%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3AOpenai%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3AAtlascloud%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3AWanjieArk%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3AVolcengine%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3AOpenrouter%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3AXiaomiMimo%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3ANovita%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3AFireworks%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3ASiliconflow%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3ASiliconflowCN%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3AArcee%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3AMoonshot%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3ASglang%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3AVllm%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3AOllama%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3AHuggingface%2C%0A%20%20%20%20%20%20%20%20%5D%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fcheck-provider-registry.py%3A682-696%0A%60report_string_order%60%20anchors%20on%20the%20**first%20occurrence**%20of%20each%20needle%20via%20%60str.find%28%29%60.%20In%20%60crates%2Ftui%2Fsrc%2Fconfig.rs%60%20the%20correct-priority%20occurrence%20of%20%60std%3A%3Aenv%3A%3Avar%28%22HUGGINGFACE_API_KEY%22%29%60%20%28line%20~2506%29%20and%20%60std%3A%3Aenv%3A%3Avar%28%22HF_TOKEN%22%29%60%20%28line%20~2511%29%20appear%20before%20any%20of%20the%20%60HF_TOKEN%60-only%20%22is%20auth%20present%3F%22%20checks%20later%20in%20the%20file.%20So%20the%20ordering%20check%20passes%20today.%20However%2C%20if%20a%20new%20resolution%20code%20path%20is%20added%20that%20consults%20%60HF_TOKEN%60%20before%20%60HUGGINGFACE_API_KEY%60%2C%20the%20check%20would%20still%20pass%20because%20%60find%28%29%60%20returns%20the%20first%20%28correctly%20ordered%29%20site%20and%20ignores%20the%20new%20one.%20Tightening%20the%20check%20to%20scan%20within%20the%20specific%20resolution%20function%20would%20make%20the%20drift%20guard%20more%20reliable.%0A%0A&repo=hmbown%2Fcodewhale&pr=2879&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Fconfig%2Fsrc%2Flib.rs%3A134-156%0A%60ProviderKind%3A%3Aall%28%29%60%20is%20a%20manually%20maintained%20list%20with%20no%20compile-time%20guarantee%20that%20it%20matches%20the%20enum's%20variants.%20If%20a%20new%20variant%20is%20added%20to%20%60ProviderKind%60%20but%20forgotten%20here%2C%20it%20will%20silently%20disappear%20from%20error-message%20hints.%20Consider%20using%20a%20crate%20like%20%60strum%60%20with%20%60%23%5Bderive%28EnumIter%29%5D%60%2C%20or%20at%20minimum%20a%20compile-time%20%60const%60%20array%20alongside%20the%20enum%20so%20the%20mismatch%20is%20caught%20at%20build%20time.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%20NOTE%3A%20Keep%20this%20list%20in%20sync%20with%20the%20ProviderKind%20enum.%20There%20is%20no%0A%20%20%20%20%2F%2F%20compile-time%20check%3B%20adding%20a%20variant%20without%20updating%20this%20array%20will%0A%20%20%20%20%2F%2F%20silently%20omit%20it%20from%20error-message%20hints%20produced%20by%20names_hint%28%29.%0A%20%20%20%20%23%5Bmust_use%5D%0A%20%20%20%20pub%20fn%20all%28%29%20-%3E%20%26'static%20%5BSelf%5D%20%7B%0A%20%20%20%20%20%20%20%20%26%5B%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3ADeepseek%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3ANvidiaNim%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3AOpenai%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3AAtlascloud%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3AWanjieArk%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3AVolcengine%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3AOpenrouter%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3AXiaomiMimo%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3ANovita%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3AFireworks%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3ASiliconflow%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3ASiliconflowCN%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3AArcee%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3AMoonshot%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3ASglang%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3AVllm%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3AOllama%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3AHuggingface%2C%0A%20%20%20%20%20%20%20%20%5D%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fcheck-provider-registry.py%3A682-696%0A%60report_string_order%60%20anchors%20on%20the%20**first%20occurrence**%20of%20each%20needle%20via%20%60str.find%28%29%60.%20In%20%60crates%2Ftui%2Fsrc%2Fconfig.rs%60%20the%20correct-priority%20occurrence%20of%20%60std%3A%3Aenv%3A%3Avar%28%22HUGGINGFACE_API_KEY%22%29%60%20%28line%20~2506%29%20and%20%60std%3A%3Aenv%3A%3Avar%28%22HF_TOKEN%22%29%60%20%28line%20~2511%29%20appear%20before%20any%20of%20the%20%60HF_TOKEN%60-only%20%22is%20auth%20present%3F%22%20checks%20later%20in%20the%20file.%20So%20the%20ordering%20check%20passes%20today.%20However%2C%20if%20a%20new%20resolution%20code%20path%20is%20added%20that%20consults%20%60HF_TOKEN%60%20before%20%60HUGGINGFACE_API_KEY%60%2C%20the%20check%20would%20still%20pass%20because%20%60find%28%29%60%20returns%20the%20first%20%28correctly%20ordered%29%20site%20and%20ignores%20the%20new%20one.%20Tightening%20the%20check%20to%20scan%20within%20the%20specific%20resolution%20function%20would%20make%20the%20drift%20guard%20more%20reliable.%0A%0A&repo=hmbown%2Fcodewhale&pr=2879&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Fconfig%2Fsrc%2Flib.rs%3A134-156%0A%60ProviderKind%3A%3Aall%28%29%60%20is%20a%20manually%20maintained%20list%20with%20no%20compile-time%20guarantee%20that%20it%20matches%20the%20enum's%20variants.%20If%20a%20new%20variant%20is%20added%20to%20%60ProviderKind%60%20but%20forgotten%20here%2C%20it%20will%20silently%20disappear%20from%20error-message%20hints.%20Consider%20using%20a%20crate%20like%20%60strum%60%20with%20%60%23%5Bderive%28EnumIter%29%5D%60%2C%20or%20at%20minimum%20a%20compile-time%20%60const%60%20array%20alongside%20the%20enum%20so%20the%20mismatch%20is%20caught%20at%20build%20time.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%20NOTE%3A%20Keep%20this%20list%20in%20sync%20with%20the%20ProviderKind%20enum.%20There%20is%20no%0A%20%20%20%20%2F%2F%20compile-time%20check%3B%20adding%20a%20variant%20without%20updating%20this%20array%20will%0A%20%20%20%20%2F%2F%20silently%20omit%20it%20from%20error-message%20hints%20produced%20by%20names_hint%28%29.%0A%20%20%20%20%23%5Bmust_use%5D%0A%20%20%20%20pub%20fn%20all%28%29%20-%3E%20%26'static%20%5BSelf%5D%20%7B%0A%20%20%20%20%20%20%20%20%26%5B%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3ADeepseek%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3ANvidiaNim%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3AOpenai%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3AAtlascloud%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3AWanjieArk%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3AVolcengine%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3AOpenrouter%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3AXiaomiMimo%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3ANovita%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3AFireworks%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3ASiliconflow%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3ASiliconflowCN%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3AArcee%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3AMoonshot%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3ASglang%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3AVllm%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3AOllama%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Self%3A%3AHuggingface%2C%0A%20%20%20%20%20%20%20%20%5D%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fcheck-provider-registry.py%3A682-696%0A%60report_string_order%60%20anchors%20on%20the%20**first%20occurrence**%20of%20each%20needle%20via%20%60str.find%28%29%60.%20In%20%60crates%2Ftui%2Fsrc%2Fconfig.rs%60%20the%20correct-priority%20occurrence%20of%20%60std%3A%3Aenv%3A%3Avar%28%22HUGGINGFACE_API_KEY%22%29%60%20%28line%20~2506%29%20and%20%60std%3A%3Aenv%3A%3Avar%28%22HF_TOKEN%22%29%60%20%28line%20~2511%29%20appear%20before%20any%20of%20the%20%60HF_TOKEN%60-only%20%22is%20auth%20present%3F%22%20checks%20later%20in%20the%20file.%20So%20the%20ordering%20check%20passes%20today.%20However%2C%20if%20a%20new%20resolution%20code%20path%20is%20added%20that%20consults%20%60HF_TOKEN%60%20before%20%60HUGGINGFACE_API_KEY%60%2C%20the%20check%20would%20still%20pass%20because%20%60find%28%29%60%20returns%20the%20first%20%28correctly%20ordered%29%20site%20and%20ignores%20the%20new%20one.%20Tightening%20the%20check%20to%20scan%20within%20the%20specific%20resolution%20function%20would%20make%20the%20drift%20guard%20more%20reliable.%0A%0A&pr=2879&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix: address self-review findings"](https://github.com/hmbown/codewhale/commit/89cb6c55c81c7d8cc0c07816f215f5d00fe2d414) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36069307)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->