### PR TITLE
fix: error handling — log instead of silently swallowing errors (11 bugs)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -890,6 +890,7 @@ dependencies = [
  "codewhale-state",
  "codewhale-tools",
  "serde_json",
+ "tracing",
  "uuid",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -831,6 +831,7 @@ dependencies = [
  "tokio",
  "tower",
  "tower-http",
+ "tracing",
  "uuid",
 ]
 

--- a/crates/app-server/Cargo.toml
+++ b/crates/app-server/Cargo.toml
@@ -23,6 +23,7 @@ serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 tower-http.workspace = true
+tracing.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]

--- a/crates/app-server/src/lib.rs
+++ b/crates/app-server/src/lib.rs
@@ -879,7 +879,9 @@ async fn process_app_request(
             let message = result.err().map(|e| e.to_string());
             let snapshot = cfg.clone();
             drop(cfg);
-            let _ = persist_config(state, snapshot).await;
+            if let Err(e) = persist_config(state, snapshot).await {
+                tracing::error!("Failed to persist config after set: {e}");
+            }
             AppResponse {
                 ok,
                 data: json!({ "key": key, "value": value, "error": message }),
@@ -893,7 +895,9 @@ async fn process_app_request(
             let message = result.err().map(|e| e.to_string());
             let snapshot = cfg.clone();
             drop(cfg);
-            let _ = persist_config(state, snapshot).await;
+            if let Err(e) = persist_config(state, snapshot).await {
+                tracing::error!("Failed to persist config after unset: {e}");
+            }
             AppResponse {
                 ok,
                 data: json!({ "key": key, "error": message }),

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1590,10 +1590,7 @@ pub fn load_project_config(workspace: &Path) -> Option<ConfigToml> {
             match toml::from_str(&raw) {
                 Ok(config) => return Some(config),
                 Err(e) => {
-                    tracing::warn!(
-                        "Failed to parse project config {}: {e}",
-                        path.display()
-                    );
+                    tracing::warn!("Failed to parse project config {}: {e}", path.display());
                     return None;
                 }
             }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1587,7 +1587,16 @@ pub fn load_project_config(workspace: &Path) -> Option<ConfigToml> {
         if path.exists()
             && let Ok(raw) = fs::read_to_string(&path)
         {
-            return toml::from_str(&raw).ok();
+            match toml::from_str(&raw) {
+                Ok(config) => return Some(config),
+                Err(e) => {
+                    tracing::warn!(
+                        "Failed to parse project config {}: {e}",
+                        path.display()
+                    );
+                    return None;
+                }
+            }
         }
     }
     None
@@ -2509,15 +2518,33 @@ impl EnvRuntimeOverrides {
             log_level: std::env::var("DEEPSEEK_LOG_LEVEL").ok(),
             telemetry: std::env::var("DEEPSEEK_TELEMETRY")
                 .ok()
-                .and_then(|v| parse_bool(&v).ok()),
+                .and_then(|v| match parse_bool(&v) {
+                    Ok(b) => Some(b),
+                    Err(_) => {
+                        tracing::warn!("Invalid DEEPSEEK_TELEMETRY value '{v}', expected true/false");
+                        None
+                    }
+                }),
             approval_policy: std::env::var("DEEPSEEK_APPROVAL_POLICY").ok(),
             sandbox_mode: std::env::var("DEEPSEEK_SANDBOX_MODE").ok(),
             yolo: std::env::var("DEEPSEEK_YOLO")
                 .ok()
-                .and_then(|v| parse_bool(&v).ok()),
+                .and_then(|v| match parse_bool(&v) {
+                    Ok(b) => Some(b),
+                    Err(_) => {
+                        tracing::warn!("Invalid DEEPSEEK_YOLO value '{v}', expected true/false");
+                        None
+                    }
+                }),
             http_headers: std::env::var("DEEPSEEK_HTTP_HEADERS")
                 .ok()
-                .and_then(|value| parse_http_headers(&value).ok())
+                .and_then(|value| match parse_http_headers(&value) {
+                    Ok(h) => Some(h),
+                    Err(_) => {
+                        tracing::warn!("Invalid DEEPSEEK_HTTP_HEADERS value, expected format: header1=val1,header2=val2");
+                        None
+                    }
+                })
                 .filter(|headers| !headers.is_empty()),
             deepseek_base_url: std::env::var("CODEWHALE_BASE_URL")
                 .or_else(|_| std::env::var("DEEPSEEK_BASE_URL"))

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -18,4 +18,5 @@ codewhale-protocol = { path = "../protocol", version = "0.8.53" }
 codewhale-state = { path = "../state", version = "0.8.53" }
 codewhale-tools = { path = "../tools", version = "0.8.53" }
 serde_json.workspace = true
+tracing.workspace = true
 uuid.workspace = true

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -748,7 +748,9 @@ impl Runtime {
         hooks: HookDispatcher,
     ) -> Self {
         let mut jobs = JobManager::default();
-        let _ = jobs.load_from_store(&state);
+        if let Err(e) = jobs.load_from_store(&state) {
+            tracing::warn!("Failed to load job store, starting with empty job list: {e}");
+        }
         Self {
             config,
             model_registry,

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -1708,18 +1708,19 @@ In {new} mode: {policy}\n\n\
                     } else {
                         None
                     };
-                    let Some(subagent_runtime) = runtime else {
+                    if let Some(subagent_runtime) = runtime {
+                        Some(
+                            builder
+                                .with_subagent_tools(
+                                    self.subagent_manager.clone(),
+                                    subagent_runtime,
+                                )
+                                .build(tool_context),
+                        )
+                    } else {
                         tracing::warn!("Sub-agents enabled but no API client available, falling back to basic tool set");
-                        return Some(builder.build(tool_context));
-                    };
-                    Some(
-                        builder
-                            .with_subagent_tools(
-                                self.subagent_manager.clone(),
-                                subagent_runtime,
-                            )
-                            .build(tool_context),
-                    )
+                        Some(builder.build(tool_context))
+                    }
                 } else {
                     Some(builder.build(tool_context))
                 }
@@ -2537,9 +2538,9 @@ fn goal_objective_for_prompt(
     match goal_state.lock() {
         Ok(state) => {
             if let Some(objective) = state.objective() {
-                if state.is_active() {
-                    return Some(objective.to_string());
-                }
+                // Preserve original behavior: return None (not fallback) when
+                // objective exists but goal is inactive.
+                return state.is_active().then(|| objective.to_string());
             }
         }
         Err(err) => tracing::warn!("goal state lock poisoned while building prompt: {err}"),

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -1718,7 +1718,9 @@ In {new} mode: {policy}\n\n\
                                 .build(tool_context),
                         )
                     } else {
-                        tracing::warn!("Sub-agents enabled but no API client available, falling back to basic tool set");
+                        tracing::warn!(
+                            "Sub-agents enabled but no API client available, falling back to basic tool set"
+                        );
                         Some(builder.build(tool_context))
                     }
                 } else {

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -1708,11 +1708,15 @@ In {new} mode: {policy}\n\n\
                     } else {
                         None
                     };
+                    let Some(subagent_runtime) = runtime else {
+                        tracing::warn!("Sub-agents enabled but no API client available, falling back to basic tool set");
+                        return Some(builder.build(tool_context));
+                    };
                     Some(
                         builder
                             .with_subagent_tools(
                                 self.subagent_manager.clone(),
-                                runtime.expect("sub-agent runtime should exist with active client"),
+                                subagent_runtime,
                             )
                             .build(tool_context),
                     )
@@ -2220,7 +2224,7 @@ In {new} mode: {policy}\n\n\
         let pool = match self.ensure_mcp_pool().await {
             Ok(pool) => pool,
             Err(err) => {
-                let _ = self.tx_event.send(Event::status(err.to_string())).await;
+                let _ = self.tx_event.send(Event::status(format!("{err:#}"))).await;
                 return Vec::new();
             }
         };
@@ -2532,13 +2536,10 @@ fn goal_objective_for_prompt(
 ) -> Option<String> {
     match goal_state.lock() {
         Ok(state) => {
-            if state.objective().is_some() {
-                return state.is_active().then(|| {
-                    state
-                        .objective()
-                        .expect("checked goal objective")
-                        .to_string()
-                });
+            if let Some(objective) = state.objective() {
+                if state.is_active() {
+                    return Some(objective.to_string());
+                }
             }
         }
         Err(err) => tracing::warn!("goal state lock poisoned while building prompt: {err}"),

--- a/crates/tui/src/core/engine/tool_execution.rs
+++ b/crates/tui/src/core/engine/tool_execution.rs
@@ -133,7 +133,10 @@ pub(super) fn emit_tool_audit(event: serde_json::Value) {
     let path = PathBuf::from(path);
     if let Some(parent) = path.parent() {
         if let Err(e) = std::fs::create_dir_all(parent) {
-            tracing::error!("Failed to create audit log directory {}: {e}", parent.display());
+            tracing::error!(
+                "Failed to create audit log directory {}: {e}",
+                parent.display()
+            );
             return;
         }
     }

--- a/crates/tui/src/core/engine/tool_execution.rs
+++ b/crates/tui/src/core/engine/tool_execution.rs
@@ -125,14 +125,27 @@ pub(super) fn emit_tool_audit(event: serde_json::Value) {
     };
     let line = match serde_json::to_string(&event) {
         Ok(line) => line,
-        Err(_) => return,
+        Err(e) => {
+            tracing::error!("Failed to serialize tool audit event: {e}");
+            return;
+        }
     };
     let path = PathBuf::from(path);
     if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            tracing::error!("Failed to create audit log directory {}: {e}", parent.display());
+            return;
+        }
     }
-    if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(path) {
-        let _ = writeln!(file, "{line}");
+    match OpenOptions::new().create(true).append(true).open(&path) {
+        Ok(mut file) => {
+            if let Err(e) = writeln!(file, "{line}") {
+                tracing::error!("Failed to write to audit log {}: {e}", path.display());
+            }
+        }
+        Err(e) => {
+            tracing::error!("Failed to open audit log {}: {e}", path.display());
+        }
     }
 }
 

--- a/crates/tui/src/core/engine/tool_execution.rs
+++ b/crates/tui/src/core/engine/tool_execution.rs
@@ -131,14 +131,14 @@ pub(super) fn emit_tool_audit(event: serde_json::Value) {
         }
     };
     let path = PathBuf::from(path);
-    if let Some(parent) = path.parent() {
-        if let Err(e) = std::fs::create_dir_all(parent) {
-            tracing::error!(
-                "Failed to create audit log directory {}: {e}",
-                parent.display()
-            );
-            return;
-        }
+    if let Some(parent) = path.parent()
+        && let Err(e) = std::fs::create_dir_all(parent)
+    {
+        tracing::error!(
+            "Failed to create audit log directory {}: {e}",
+            parent.display()
+        );
+        return;
     }
     match OpenOptions::new().create(true).append(true).open(&path) {
         Ok(mut file) => {

--- a/crates/tui/src/mcp.rs
+++ b/crates/tui/src/mcp.rs
@@ -2191,7 +2191,9 @@ impl McpPool {
 
         let errors = self.connect_all().await;
         for (server, err) in errors {
-            tracing::warn!("Failed to connect MCP server '{server}' for resource templates: {err:#}");
+            tracing::warn!(
+                "Failed to connect MCP server '{server}' for resource templates: {err:#}"
+            );
         }
         let mut items = Vec::new();
         for (server, conn) in &self.connections {

--- a/crates/tui/src/mcp.rs
+++ b/crates/tui/src/mcp.rs
@@ -2004,11 +2004,11 @@ impl McpPool {
     /// Get or create a connection to a server
     pub async fn get_or_connect(&mut self, server_name: &str) -> Result<&mut McpConnection> {
         // Lazy auto-reload (#1267 part 2): cheap mtime-then-hash check before
-        // each connection lookup. Errors from the reload check (stat failure,
-        // partial config parse) are swallowed here so a transient FS hiccup
-        // can't take down the whole tool dispatch — the user still gets the
-        // existing connection to respond to.
-        let _ = self.reload_if_config_changed().await;
+        // each connection lookup. Transient FS errors are logged but not
+        // propagated so a brief hiccup can't take down the whole tool dispatch.
+        if let Err(e) = self.reload_if_config_changed().await {
+            tracing::warn!("MCP config reload check failed: {e:#}");
+        }
 
         let is_ready = self
             .connections
@@ -2148,7 +2148,10 @@ impl McpPool {
             return Ok(resources);
         }
 
-        let _ = self.connect_all().await;
+        let errors = self.connect_all().await;
+        for (server, err) in errors {
+            tracing::warn!("Failed to connect MCP server '{server}' for resources: {err:#}");
+        }
         let mut items = Vec::new();
         for (server, conn) in &self.connections {
             for resource in conn.resources() {
@@ -2186,7 +2189,10 @@ impl McpPool {
             return Ok(templates);
         }
 
-        let _ = self.connect_all().await;
+        let errors = self.connect_all().await;
+        for (server, err) in errors {
+            tracing::warn!("Failed to connect MCP server '{server}' for resource templates: {err:#}");
+        }
         let mut items = Vec::new();
         for (server, conn) in &self.connections {
             for template in conn.resource_templates() {

--- a/crates/tui/src/runtime_log.rs
+++ b/crates/tui/src/runtime_log.rs
@@ -176,7 +176,10 @@ pub fn init() -> Result<TuiLogGuard> {
     #[cfg(windows)]
     let (saved_stderr_handle, redirected_stderr_handle) = match redirect_stderr_to(&file) {
         Ok((saved, dup)) => (Some(saved), Some(dup)),
-        Err(_) => (None, None),
+        Err(e) => {
+            tracing::warn!("Failed to redirect stderr to log file: {e}");
+            (None, None)
+        }
     };
 
     Ok(TuiLogGuard {

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -825,7 +825,10 @@ impl RuntimeThreadManager {
     ) -> bool {
         let sender = match self.pending_approvals.lock() {
             Ok(mut map) => map.remove(approval_id),
-            Err(_) => return false,
+            Err(e) => {
+                tracing::error!("pending_approvals mutex poisoned: {e}");
+                return false;
+            }
         };
         match sender {
             Some(tx) => tx.send(decision).is_ok(),


### PR DESCRIPTION
## Summary

Fixes 11 error handling bugs where errors were silently discarded via `let _ =`, `Err(_)`, `.ok()`, or `.to_string()`, preventing users from diagnosing failures and masking data loss.

## Bugs Fixed

### Silent Error Discards

1. **`persist_config` errors discarded** (`app-server/lib.rs:882,896`)
   - After ConfigSet/ConfigUnset, disk write failure returns success to the user. Change is lost on restart.
   - **Fix**: Log `tracing::error!` on persistence failure.

2. **Job store load error discarded** (`core/lib.rs:751`)
   - Corrupted store silently starts with empty job list, losing all history.
   - **Fix**: Log `tracing::warn!` on load failure.

3. **Config parse failure returns `None`** (`config/lib.rs:1590`)
   - `toml::from_str().ok()` makes "malformed config" indistinguishable from "no config file".
   - **Fix**: Log `tracing::warn!` with the parse error before returning `None`.

4. **MCP `connect_all` errors discarded** (`mcp.rs:2151,2189`)
   - Failed server connections produce incomplete resource list with no indication.
   - **Fix**: Log `tracing::warn!` for each failed server.

5. **Error chain stripped in engine status** (`core/engine.rs:2221`)
   - `err.to_string()` loses the anyhow error chain. Line 2234 already uses `{err:#}` correctly.
   - **Fix**: Use `format!("{err:#}")` for consistency.

6. **Tool audit log failures all discarded** (`tool_execution.rs:122-136`)
   - Serialization, directory creation, file open, and write errors are all silently dropped.
   - **Fix**: Log each failure type with `tracing::error!`.

7. **Env var invalid values silently ignored** (`config/lib.rs:2519-2530`)
   - `DEEPSEEK_YOLO=TRUE` (wrong case) or `DEEPSEEK_TELEMETRY=maybe` treated as unset.
   - **Fix**: Log `tracing::warn!` on parse failure.

8. **MCP config reload errors completely silent** (`mcp.rs:2011`)
   - User edits MCP config expecting changes to take effect, but parse error is ignored.
   - **Fix**: Log `tracing::warn!` instead of `let _ =`.

### Logic Errors

9. **`expect()` on sub-agent runtime** (`core/engine.rs:1713`)
   - Panics if sub-agents enabled but no API client configured. Uses `let-else` with `return` which causes compilation errors.
   - **Fix**: Use `if let Some` with fallback to basic tool set.

10. **`expect()` on goal objective** (`core/engine.rs:2536`)
    - Fragile check-then-expect pattern. Refactored code changes semantics when goal is inactive.
    - **Fix**: Use `state.is_active().then(|| objective.to_string())` to preserve original behavior.

11. **Windows stderr redirect error discarded** (`runtime_log.rs:179`)
    - **Fix**: Log `tracing::warn!` on redirect failure.
