### PR TITLE
fix: client response handling and desktop tray icon safety (5 bugs)

### DIFF
--- a/crates/desktop/src/tray.rs
+++ b/crates/desktop/src/tray.rs
@@ -9,7 +9,7 @@ pub fn setup(app: &App) -> Result<(), Box<dyn std::error::Error>> {
     let icon = app
         .default_window_icon()
         .ok_or("Application window icon not found")?;
-    let _tray = TrayIconBuilder::new()
+    let tray = TrayIconBuilder::new()
         .icon(icon.clone())
         .tooltip("CodeWhale Desktop")
         .on_tray_icon_event(|tray, event| {
@@ -27,6 +27,10 @@ pub fn setup(app: &App) -> Result<(), Box<dyn std::error::Error>> {
             }
         })
         .build(app)?;
+
+    // Store the tray icon in Tauri's managed state to keep it alive.
+    // In Tauri v2, dropping the TrayIcon removes it from the system tray.
+    app.manage(tray);
 
     Ok(())
 }

--- a/crates/desktop/src/tray.rs
+++ b/crates/desktop/src/tray.rs
@@ -1,0 +1,32 @@
+//! System tray setup.
+
+use tauri::{
+    App, Manager,
+    tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
+};
+
+pub fn setup(app: &App) -> Result<(), Box<dyn std::error::Error>> {
+    let icon = app
+        .default_window_icon()
+        .ok_or("Application window icon not found")?;
+    let _tray = TrayIconBuilder::new()
+        .icon(icon.clone())
+        .tooltip("CodeWhale Desktop")
+        .on_tray_icon_event(|tray, event| {
+            if let TrayIconEvent::Click {
+                button: MouseButton::Left,
+                button_state: MouseButtonState::Up,
+                ..
+            } = event
+            {
+                let app = tray.app_handle();
+                if let Some(window) = app.get_webview_window("main") {
+                    let _ = window.show();
+                    let _ = window.set_focus();
+                }
+            }
+        })
+        .build(app)?;
+
+    Ok(())
+}

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -852,7 +852,10 @@ impl DeepSeekClient {
             anyhow::bail!("Speech synthesis failed: HTTP {status}: {error_text}");
         }
 
-        let response_text = response.text().await.unwrap_or_default();
+        let response_text = response
+            .text()
+            .await
+            .context("Failed to read speech synthesis response body")?;
         let payload: Value = serde_json::from_str(&response_text)
             .context("Failed to parse speech synthesis response JSON")?;
         let (audio_bytes, transcript) = parse_speech_audio_response(&payload)?;
@@ -904,6 +907,8 @@ impl DeepSeekClient {
         let probe = self.http_client.get(health_url).send().await;
         match probe {
             Ok(resp) if resp.status().is_success() => {
+                // Consume the response body so the connection can be returned to the pool.
+                let _ = resp.text().await;
                 self.mark_request_success().await;
                 logging::info("Recovery probe succeeded");
             }
@@ -1021,6 +1026,8 @@ impl LlmClient for DeepSeekClient {
         let response = self.http_client.get(health_url).send().await;
         match response {
             Ok(resp) if resp.status().is_success() => {
+                // Consume the response body so the connection can be returned to the pool.
+                let _ = resp.text().await;
                 self.mark_request_success().await;
                 Ok(true)
             }
@@ -1360,7 +1367,10 @@ impl DeepSeekClient {
             );
             anyhow::bail!("FIM API error: HTTP {status}: {error_text}");
         }
-        let response_text = response.text().await.unwrap_or_default();
+        let response_text = response
+            .text()
+            .await
+            .context("Failed to read FIM API response body")?;
         let value: serde_json::Value =
             serde_json::from_str(&response_text).context("Failed to parse FIM API response")?;
         let text = value


### PR DESCRIPTION
## Summary

Fixes 5 client and desktop application bugs related to HTTP connection pool management and Tauri component lifecycle.

## Bugs Fixed

### Connection Pool Management

1. **`health_check` not consuming response body** (`client.rs:1018-1038`)
   - On success, the response body is never consumed. With HTTP/1.1 keep-alive or HTTP/2 multiplexing, the connection cannot be returned to the pool until the body is read.
   - **Fix**: Add `resp.text().await` to consume the body.

2. **`maybe_probe_recovery` not consuming response body** (`client.rs:908-922`)
   - Same issue as health_check.
   - **Fix**: Add `resp.text().await`.

3. **`synthesize_speech` response body read error** (`client.rs:855`)
   - `unwrap_or_default()` converts connection drops to empty string, causing misleading JSON parse error.
   - **Fix**: Replace with `.context()?` error propagation.

4. **`fim_completion` response body read error** (`client.rs:1368`)
   - Same pattern as synthesize_speech.
   - **Fix**: Replace with `.context()?` error propagation.

### Tauri Desktop

5. **TrayIcon dropped immediately after setup** (`desktop/tray.rs:10`)
   - In Tauri v2, dropping the `TrayIcon` instance removes it from the system tray. The local variable goes out of scope at the end of `setup()`.
   - **Fix**: Use `app.manage(tray)` to transfer ownership to Tauri's managed state, keeping the icon alive for the application's lifetime.
