### PR TITLE
feat(execpolicy): wire ask-only permissions into runtime

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -146,9 +146,9 @@ approval_policy = "on-request" # on-request | untrusted | never
 sandbox_mode = "workspace-write" # read-only | workspace-write | danger-full-access | external-sandbox
 
 # Typed permission rules live in a sibling `permissions.toml` file, not in
-# config.toml. This schema slice is ask-only and is parsed for follow-up
-# approval-flow wiring; allow/deny records and UI persistence are intentionally
-# out of scope here.
+# config.toml. This shape is ask-only and feeds the execution policy engine;
+# allow/deny records, glob expansion, and UI persistence are intentionally out
+# of scope here.
 #
 # Example ~/.codewhale/permissions.toml:
 #

--- a/crates/app-server/src/lib.rs
+++ b/crates/app-server/src/lib.rs
@@ -12,7 +12,6 @@ use axum::{Json, Router};
 use codewhale_agent::ModelRegistry;
 use codewhale_config::{CliRuntimeOverrides, ConfigStore};
 use codewhale_core::Runtime;
-use codewhale_execpolicy::ExecPolicyEngine;
 use codewhale_hooks::{HookDispatcher, JsonlHookSink, StdoutHookSink, UnixSocketHookSink};
 use codewhale_mcp::McpManager;
 use codewhale_protocol::{
@@ -314,6 +313,7 @@ async fn app_handler(
 fn build_state(config_path: Option<PathBuf>, auth_token: Option<String>) -> Result<AppState> {
     let store = ConfigStore::load(config_path.clone())?;
     let config = store.config.clone();
+    let exec_policy = store.exec_policy_engine();
     let registry = ModelRegistry::default();
 
     let state_db_path = config_path
@@ -344,7 +344,7 @@ fn build_state(config_path: Option<PathBuf>, auth_token: Option<String>) -> Resu
         state_store,
         Arc::new(ToolRegistry::default()),
         Arc::new(McpManager::default()),
-        ExecPolicyEngine::new(Vec::new(), Vec::new()),
+        exec_policy,
         hooks,
     );
 
@@ -1048,6 +1048,43 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn build_state_loads_permissions_into_runtime_policy() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let config_path = tmp.path().join("config.toml");
+        fs::write(&config_path, "api_key = \"sk-deepseek-secret\"\n").expect("write config");
+        fs::write(
+            tmp.path().join("permissions.toml"),
+            r#"
+            [[rules]]
+            tool = "exec_shell"
+            command = "cargo test"
+            "#,
+        )
+        .expect("write permissions");
+
+        let state = build_state(Some(config_path), None).expect("state");
+        let runtime = state.runtime.lock().await;
+        let decision = runtime
+            .exec_policy
+            .check(codewhale_execpolicy::ExecPolicyContext {
+                command: "cargo test --workspace",
+                cwd: "/workspace",
+                tool: Some("exec_shell"),
+                path: None,
+                ask_for_approval: codewhale_execpolicy::AskForApproval::UnlessTrusted,
+                sandbox_mode: Some("workspace-write"),
+            })
+            .expect("policy check");
+
+        assert!(decision.allow);
+        assert!(decision.requires_approval);
+        assert_eq!(
+            decision.matched_rule.as_deref(),
+            Some("tool=exec_shell command=cargo test")
+        );
+    }
+
     #[test]
     fn non_loopback_bind_without_auth_fails_fast() {
         let options = AppServerOptions {
@@ -1067,7 +1104,10 @@ mod tests {
 
     #[tokio::test]
     async fn stdio_transport_keeps_raw_config_get_for_legacy_clients() {
-        let state = build_state(None, None).expect("state");
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let config_path = tmp.path().join("config.toml");
+        fs::write(&config_path, "").expect("write config");
+        let state = build_state(Some(config_path), None).expect("state");
         {
             let mut cfg = state.config.write().await;
             cfg.api_key = Some("sk-deepseek-secret".to_string());

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -7,6 +7,7 @@ use std::sync::OnceLock;
 
 use anyhow::{Context, Result, bail};
 pub use codewhale_execpolicy::ToolAskRule;
+use codewhale_execpolicy::{ExecPolicyEngine, Ruleset};
 use codewhale_secrets::SecretSource;
 pub use codewhale_secrets::Secrets;
 use serde::{Deserialize, Serialize};
@@ -256,6 +257,11 @@ impl PermissionsToml {
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.rules.is_empty()
+    }
+
+    #[must_use]
+    pub fn ruleset(&self) -> Ruleset {
+        Ruleset::user(Vec::new(), Vec::new()).with_ask_rules(self.rules.clone())
     }
 }
 
@@ -2098,6 +2104,15 @@ impl ConfigStore {
     pub fn permissions_path(&self) -> PathBuf {
         permissions_path_for_config_path(&self.path)
     }
+
+    #[must_use]
+    pub fn exec_policy_engine(&self) -> ExecPolicyEngine {
+        if self.permissions.is_empty() {
+            ExecPolicyEngine::new(Vec::new(), Vec::new())
+        } else {
+            ExecPolicyEngine::with_rulesets(vec![self.permissions.ruleset()])
+        }
+    }
 }
 
 /// Process-wide default [`Secrets`] façade. The first caller wins; the
@@ -2787,6 +2802,54 @@ mod tests {
         assert_eq!(
             store.permissions().rules.as_slice(),
             &[ToolAskRule::exec_shell("cargo check")]
+        );
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn config_store_exec_policy_engine_uses_sibling_permissions() {
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "codewhale-permissions-engine-{}-{unique}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&dir).expect("mkdir");
+        let config_path = dir.join(CONFIG_FILE_NAME);
+        fs::write(&config_path, "model = \"deepseek-v4-flash\"\n").expect("write config");
+        fs::write(
+            dir.join(PERMISSIONS_FILE_NAME),
+            r#"
+            [[rules]]
+            tool = "exec_shell"
+            command = "cargo test"
+            "#,
+        )
+        .expect("write permissions");
+
+        let store = ConfigStore::load(Some(config_path)).expect("load config store");
+        let decision = store
+            .exec_policy_engine()
+            .check(codewhale_execpolicy::ExecPolicyContext {
+                command: "cargo test --workspace",
+                cwd: "/workspace",
+                tool: Some("exec_shell"),
+                path: None,
+                ask_for_approval: codewhale_execpolicy::AskForApproval::UnlessTrusted,
+                sandbox_mode: Some("workspace-write"),
+            })
+            .expect("policy check");
+
+        assert!(decision.allow);
+        assert!(decision.requires_approval);
+        assert_eq!(
+            decision.matched_rule.as_deref(),
+            Some("tool=exec_shell command=cargo test")
         );
 
         let _ = fs::remove_dir_all(dir);

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1095,11 +1095,12 @@ impl Runtime {
             ToolPayload::LocalShell { .. } => "exec_shell",
             _ => call.name.as_str(),
         };
+        let policy_path = permission_path_for_call(&call);
         let decision = self.exec_policy.check(ExecPolicyContext {
             command: &command,
             cwd: &policy_cwd,
             tool: Some(policy_tool),
-            path: None,
+            path: policy_path.as_deref(),
             ask_for_approval: approval_mode,
             sandbox_mode: None,
         })?;
@@ -1500,6 +1501,24 @@ fn preview_from_initial_history(initial_history: &InitialHistory) -> String {
     }
 }
 
+fn permission_path_for_call(call: &ToolCall) -> Option<String> {
+    match &call.payload {
+        ToolPayload::Function { arguments } => serde_json::from_str::<Value>(arguments)
+            .ok()
+            .and_then(|value| {
+                value
+                    .get("path")
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+            }),
+        ToolPayload::Mcp { raw_arguments, .. } => raw_arguments
+            .get("path")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        ToolPayload::Custom { .. } | ToolPayload::LocalShell { .. } => None,
+    }
+}
+
 fn truncate_preview(value: &str) -> String {
     value.chars().take(120).collect()
 }
@@ -1806,8 +1825,64 @@ fn job_state_status_to_runtime(status: JobStateStatus) -> JobStatus {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use codewhale_tools::ToolCallSource;
 
     // ── JobManager: lifecycle ──────────────────────────────────────────
+
+    #[test]
+    fn permission_path_for_call_extracts_function_path_argument() {
+        let call = ToolCall {
+            name: "read_file".to_string(),
+            payload: ToolPayload::Function {
+                arguments: json!({ "path": "README.md" }).to_string(),
+            },
+            source: ToolCallSource::Direct,
+            raw_tool_call_id: None,
+        };
+
+        assert_eq!(
+            permission_path_for_call(&call).as_deref(),
+            Some("README.md")
+        );
+    }
+
+    #[test]
+    fn permission_path_for_call_extracts_mcp_path_argument() {
+        let call = ToolCall {
+            name: "mcp_fs_read".to_string(),
+            payload: ToolPayload::Mcp {
+                server: "fs".to_string(),
+                tool: "read".to_string(),
+                raw_arguments: json!({ "path": "secrets/token.txt" }),
+                raw_tool_call_id: None,
+            },
+            source: ToolCallSource::Direct,
+            raw_tool_call_id: None,
+        };
+
+        assert_eq!(
+            permission_path_for_call(&call).as_deref(),
+            Some("secrets/token.txt")
+        );
+    }
+
+    #[test]
+    fn permission_path_for_call_ignores_shell_payload() {
+        let call = ToolCall {
+            name: "exec_shell".to_string(),
+            payload: ToolPayload::LocalShell {
+                params: codewhale_protocol::LocalShellParams {
+                    command: "cargo test".to_string(),
+                    cwd: None,
+                    timeout_ms: None,
+                },
+            },
+            source: ToolCallSource::Direct,
+            raw_tool_call_id: None,
+        };
+
+        assert_eq!(permission_path_for_call(&call), None);
+    }
 
     #[test]
     fn enqueue_creates_queued_job_with_zero_progress() {

--- a/crates/execpolicy/src/lib.rs
+++ b/crates/execpolicy/src/lib.rs
@@ -313,21 +313,26 @@ impl ExecPolicyEngine {
 
         self.rulesets
             .iter()
-            .flat_map(|ruleset| ruleset.ask_rules.iter())
-            .filter(|rule| rule.tool == tool)
-            .filter(|rule| match rule.command.as_deref() {
+            .flat_map(|ruleset| {
+                ruleset
+                    .ask_rules
+                    .iter()
+                    .map(move |rule| (ruleset.layer, rule))
+            })
+            .filter(|(_, rule)| rule.tool == tool)
+            .filter(|(_, rule)| match rule.command.as_deref() {
                 Some(command) => self.arity_dict.allow_rule_matches(command, ctx.command),
                 None => true,
             })
-            .filter(|rule| match (rule.path.as_deref(), ctx.path) {
+            .filter(|(_, rule)| match (rule.path.as_deref(), ctx.path) {
                 (Some(pattern), Some(path)) => {
                     normalize_path_value(pattern) == normalize_path_value(path)
                 }
                 (Some(_), None) => false,
                 (None, _) => true,
             })
-            .max_by_key(|rule| ask_rule_specificity(rule))
-            .cloned()
+            .max_by_key(|(layer, rule)| (*layer, ask_rule_specificity(rule)))
+            .map(|(_, rule)| rule.clone())
     }
 
     /// Records an approval key for the current session so subsequent checks skip approval.
@@ -373,9 +378,11 @@ impl ExecPolicyEngine {
 
         let ask_rule = self.matching_ask_rule(&ctx);
 
+        let mut matched_ask_rule = None;
         let requirement = match &ctx.ask_for_approval {
             AskForApproval::Never => {
                 if let Some(rule) = &ask_rule {
+                    matched_ask_rule = Some(rule.label());
                     ExecApprovalRequirement::Forbidden {
                         reason: format!(
                             "Typed ask rule '{}' requires approval, but approval policy is never.",
@@ -389,6 +396,20 @@ impl ExecPolicyEngine {
                     }
                 }
             }
+            AskForApproval::Reject { rules, .. } if *rules => ExecApprovalRequirement::Forbidden {
+                reason: "Policy is configured to reject rule-exceptions.".to_string(),
+            },
+            _ if let Some(rule) = &ask_rule => {
+                matched_ask_rule = Some(rule.label());
+                ExecApprovalRequirement::NeedsApproval {
+                    reason: format!("Typed ask rule '{}' requires approval.", rule.label()),
+                    proposed_execpolicy_amendment: None,
+                    proposed_network_policy_amendments: vec![NetworkPolicyAmendment {
+                        host: ctx.cwd.to_string(),
+                        action: NetworkPolicyRuleAction::Allow,
+                    }],
+                }
+            }
             AskForApproval::UnlessTrusted if is_trusted => ExecApprovalRequirement::Skip {
                 bypass_sandbox: false,
                 proposed_execpolicy_amendment: None,
@@ -396,9 +417,6 @@ impl ExecPolicyEngine {
             AskForApproval::OnFailure => ExecApprovalRequirement::Skip {
                 bypass_sandbox: false,
                 proposed_execpolicy_amendment: None,
-            },
-            AskForApproval::Reject { rules, .. } if *rules => ExecApprovalRequirement::Forbidden {
-                reason: "Policy is configured to reject rule-exceptions.".to_string(),
             },
             _ => ExecApprovalRequirement::NeedsApproval {
                 reason: if is_trusted {
@@ -424,12 +442,6 @@ impl ExecPolicyEngine {
             ExecApprovalRequirement::Skip { .. } => (true, false),
             ExecApprovalRequirement::NeedsApproval { .. } => (true, true),
             ExecApprovalRequirement::Forbidden { .. } => (false, false),
-        };
-
-        let matched_ask_rule = if matches!(&ctx.ask_for_approval, AskForApproval::Never) {
-            ask_rule.map(|rule| rule.label())
-        } else {
-            None
         };
 
         Ok(ExecPolicyDecision {
@@ -629,7 +641,7 @@ mod tests {
     }
 
     #[test]
-    fn typed_ask_rule_is_ignored_outside_never_mode_for_now() {
+    fn typed_ask_rule_requires_approval_under_unless_trusted() {
         let engine = ExecPolicyEngine::with_rulesets(vec![
             Ruleset::user(vec![], vec![])
                 .with_ask_rules(vec![ToolAskRule::exec_shell("cargo test")]),
@@ -641,18 +653,40 @@ mod tests {
 
         assert!(decision.allow);
         assert!(decision.requires_approval);
-        assert_eq!(decision.matched_rule, None);
+        assert_eq!(
+            decision.matched_rule.as_deref(),
+            Some("tool=exec_shell command=cargo test")
+        );
         match decision.requirement {
             ExecApprovalRequirement::NeedsApproval {
-                proposed_execpolicy_amendment: Some(amendment),
+                proposed_execpolicy_amendment,
                 ..
-            } => assert_eq!(amendment.prefixes, vec!["cargo"]),
-            other => panic!("expected unchanged approval behavior, got {other:?}"),
+            } => assert_eq!(proposed_execpolicy_amendment, None),
+            other => panic!("expected typed ask approval, got {other:?}"),
         }
     }
 
     #[test]
-    fn typed_ask_rule_does_not_change_allow_deny_precedence() {
+    fn typed_ask_rule_requires_approval_under_on_failure() {
+        let engine = ExecPolicyEngine::with_rulesets(vec![
+            Ruleset::user(vec![], vec![])
+                .with_ask_rules(vec![ToolAskRule::exec_shell("cargo test")]),
+        ]);
+
+        let decision = engine
+            .check(ctx("cargo test --workspace", AskForApproval::OnFailure))
+            .unwrap();
+
+        assert!(decision.allow);
+        assert!(decision.requires_approval);
+        assert_eq!(
+            decision.reason(),
+            "Typed ask rule 'tool=exec_shell command=cargo test' requires approval."
+        );
+    }
+
+    #[test]
+    fn typed_ask_rule_overrides_trusted_but_not_deny() {
         let engine = ExecPolicyEngine::with_rulesets(vec![
             Ruleset::user(
                 vec!["cargo test".to_string()],
@@ -665,8 +699,11 @@ mod tests {
             .check(ctx("cargo test --workspace", AskForApproval::UnlessTrusted))
             .unwrap();
         assert!(trusted.allow);
-        assert!(!trusted.requires_approval);
-        assert_eq!(trusted.matched_rule.as_deref(), Some("cargo test"));
+        assert!(trusted.requires_approval);
+        assert_eq!(
+            trusted.matched_rule.as_deref(),
+            Some("tool=exec_shell command=cargo test")
+        );
 
         let denied = engine
             .check(ctx("cargo test --danger", AskForApproval::Never))
@@ -677,6 +714,56 @@ mod tests {
         assert_eq!(
             denied.reason(),
             "Command blocked by denied prefix rule 'cargo test --danger'"
+        );
+    }
+
+    #[test]
+    fn typed_ask_rule_prefers_higher_layer_before_specificity() {
+        let engine = ExecPolicyEngine::with_rulesets(vec![
+            Ruleset::agent(vec![], vec![])
+                .with_ask_rules(vec![ToolAskRule::exec_shell("cargo test --workspace")]),
+            Ruleset::user(vec![], vec![])
+                .with_ask_rules(vec![ToolAskRule::exec_shell("cargo test")]),
+        ]);
+
+        let decision = engine
+            .check(ctx(
+                "cargo test --workspace --all-features",
+                AskForApproval::UnlessTrusted,
+            ))
+            .unwrap();
+
+        assert!(decision.requires_approval);
+        assert_eq!(
+            decision.matched_rule.as_deref(),
+            Some("tool=exec_shell command=cargo test")
+        );
+    }
+
+    #[test]
+    fn reject_rules_mode_still_forbids_matching_ask_rule() {
+        let engine = ExecPolicyEngine::with_rulesets(vec![
+            Ruleset::user(vec![], vec![])
+                .with_ask_rules(vec![ToolAskRule::exec_shell("cargo test")]),
+        ]);
+
+        let decision = engine
+            .check(ctx(
+                "cargo test --workspace",
+                AskForApproval::Reject {
+                    sandbox_approval: false,
+                    rules: true,
+                    mcp_elicitations: false,
+                },
+            ))
+            .unwrap();
+
+        assert!(!decision.allow);
+        assert!(!decision.requires_approval);
+        assert_eq!(decision.matched_rule, None);
+        assert_eq!(
+            decision.reason(),
+            "Policy is configured to reject rule-exceptions."
         );
     }
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -759,8 +759,10 @@ If you are upgrading from older releases:
   records loaded next to `config.toml`, for example
   `~/.codewhale/permissions.toml`. This schema foundation accepts
   `[[rules]]` entries with `tool` plus optional `command` or `path` fields.
-  It intentionally does not accept typed allow/deny records or provide approval
-  UI persistence yet.
+  Loaded rules feed the execution policy engine and force approval in approval
+  modes that can ask; under `approval_policy = "never"`, matching ask rules are
+  rejected because no prompt can be shown. This intentionally does not accept
+  typed allow/deny records, glob expansion, or approval UI persistence yet.
 - `managed_config_path` (string, optional): managed config file loaded after user/env config.
 - `requirements_path` (string, optional): requirements file used to enforce allowed approval/sandbox values.
 - `max_subagents` (int, optional): defaults to `10` and is clamped to `1..=20`.


### PR DESCRIPTION
## Summary

Builds on the harvested ask-only `permissions.toml` schema/loading work from #2404 (`3df018994` plus maintainer follow-up `69cff9375`) and wires typed ask permission records into the runtime execution policy path.

This keeps the next slice intentionally narrow: ask-only rules are now executable policy input, while typed allow/deny behavior and approval UI persistence remain out of scope.

## What changed

- Convert loaded `PermissionsToml` records into a user-layer `ExecPolicyEngine`.
- Use the loaded exec policy engine when building app-server runtime state.
- Make typed ask rules require approval in approval modes that can prompt.
- Treat matching ask rules as forbidden under `approval_policy = "never"`.
- Preserve deny priority and make ask rules override trusted-prefix auto-skip.
- Pass simple `path` fields from function/MCP tool payloads into `ExecPolicyContext`.
- Add tests for runtime wiring, ask/trust/deny precedence, reject behavior, and path extraction.

## Non-goals

- No typed allow/deny records.
- No approval UI persistence.
- No glob expansion.
- No patch/diff path extraction.

Related discussion:
- #1186
- #2242 

## Validation

- `cargo fmt --all`
- `cargo test -p codewhale-execpolicy --all-features`
- `cargo test -p codewhale-config --all-features`
- `cargo test -p codewhale-core --all-features`
- `cargo test -p codewhale-app-server --all-features`
- `cargo clippy -p codewhale-execpolicy -p codewhale-config -p codewhale-core -p codewhale-app-server --all-targets --all-features -- -D warnings`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR wires ask-only permission rules (loaded from `permissions.toml`) into the runtime execution policy path. Typed ask rules now force approval in all promptable approval modes and are forbidden under `approval_policy = "never"`, overriding trusted-prefix auto-skip.

- **`ExecPolicyEngine` match arm reordering**: ask rules now intercept all approval modes (not just `Never`), with `Reject { rules: true }` checked first and `UnlessTrusted`/`OnFailure` auto-skip arms now only reachable when no ask rule matches.
- **Layer-priority selection for ask rules**: `max_by_key((layer, specificity))` means a less-specific user-layer rule will beat a more-specific agent-layer rule — intentional per the added test but worth being aware of.
- **`permission_path_for_call`**: extracts the `path` argument from `Function`/`MCP` payloads for path-based ask-rule matching; `Custom` and `LocalShell` payloads return `None`.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The runtime wiring and match-arm reordering are correct overall, but the ask-rule approval branch produces a NetworkPolicyAmendment whose host field is populated with a filesystem path — an invalid network host — which would surface as a malformed or confusing approval prompt, particularly for file-access tools.

The match-arm reordering, layer-priority selection, and config-to-engine bridging all look correct and are well-tested. The concrete defect is in the new ask-rule NeedsApproval arm: it copies the existing pattern of using ctx.cwd as the NetworkPolicyAmendment host, but applies it to all ask-rule matches including file-access tools where a cwd path can never be a valid network host. The test suite verifies proposed_execpolicy_amendment using .. to ignore other fields, so the bad network amendment goes uncaught.

crates/execpolicy/src/lib.rs — the NeedsApproval arm for ask rules (lines ~402–412) needs the proposed_network_policy_amendments corrected or removed.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/execpolicy/src/lib.rs | Core logic refactored to wire ask rules into runtime: match arm reordering now makes ask rules trigger approval in all approval modes (not just Never), layer priority correctly uses max_by_key(layer, specificity). The new ask-rule NeedsApproval arm incorrectly uses ctx.cwd as a NetworkPolicyAmendment host — a filesystem path, not a network host. |
| crates/config/src/lib.rs | Adds PermissionsToml::ruleset() and ConfigStore::exec_policy_engine(), cleanly bridging the loaded permissions into the execpolicy layer. The branch on is_empty() to pick the legacy constructor is a minor inconsistency but functionally equivalent. |
| crates/app-server/src/lib.rs | Replaces empty ExecPolicyEngine::new() with store.exec_policy_engine() wiring the loaded permissions into runtime state. Integration test correctly exercises the full policy-check path. |
| crates/core/src/lib.rs | Adds permission_path_for_call() to extract the path argument from Function/MCP payloads and passes it into ExecPolicyContext. Logic is straightforward and tested; silently ignoring malformed JSON arguments is a safe fallback. |
| config.example.toml | Doc comment updated to reflect that loaded ask rules now feed the execution policy engine. Wording matches the actual behavior. |
| docs/CONFIGURATION.md | Documentation updated to describe the new ask-rule runtime behavior (approval in promptable modes, forbidden under approval_policy=never). Accurate and concise. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[invoke_tool called] --> B[permission_path_for_call\nextract path from args]
    B --> C[exec_policy.check\nExecPolicyContext]
    C --> D{deny prefix\nmatch?}
    D -- yes --> E[Forbidden\nmatched_rule = deny prefix]
    D -- no --> F{matching\nask rule?}
    F -- no --> G{AskForApproval mode}
    F -- yes --> H{AskForApproval::Never?}
    H -- yes --> I[Forbidden\nmatched_rule = ask rule label]
    H -- no --> J{Reject rules=true?}
    J -- yes --> K[Forbidden\nmatched_rule = None]
    J -- no --> L[NeedsApproval\nmatched_rule = ask rule label]
    G --> M{Never?}
    M -- yes --> N[Skip]
    G --> O{Reject rules=true?}
    O -- yes --> P[Forbidden]
    G --> Q{UnlessTrusted + trusted?}
    Q -- yes --> R[Skip]
    G --> S{OnFailure?}
    S -- yes --> T[Skip]
    G --> U[NeedsApproval]
```
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fpermissions-ask-engine-wiring%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fpermissions-ask-engine-wiring%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Fexecpolicy%2Fsrc%2Flib.rs%3A402-412%0A**Filesystem%20path%20used%20as%20network%20policy%20host**%0A%0A%60ctx.cwd%60%20is%20a%20filesystem%20directory%20%28e.g.%2C%20%60%2Fworkspace%60%29%2C%20but%20%60NetworkPolicyAmendment.host%60%20is%20documented%20as%20a%20network%20host.%20For%20file-access%20ask%20rules%20%28e.g.%2C%20%60edit_file%60%20with%20a%20%60path%60%20field%29%2C%20this%20proposes%20an%20amendment%20to%20allow%20the%20network%20host%20%60%2Fworkspace%60%2C%20which%20is%20syntactically%20invalid%20and%20would%20be%20presented%20to%20the%20user%20as%20a%20confusing%20or%20broken%20approval%20prompt.%20The%20pre-existing%20%60_%60%20fallback%20also%20does%20this%2C%20but%20the%20ask-rule%20branch%20is%20new%20and%20can%20now%20be%20reached%20by%20non-shell%20tools.%20The%20%60proposed_network_policy_amendments%60%20field%20should%20either%20be%20empty%20%28%60vec!%5B%5D%60%29%20for%20ask-rule%20matches%2C%20or%20populated%20with%20an%20actual%20resolved%20hostname%20extracted%20from%20the%20tool%20context.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Fexecpolicy%2Fsrc%2Flib.rs%3A399-401%0A**%60matched_rule%60%20is%20silently%20%60None%60%20when%20%60Reject%20%7B%20rules%3A%20true%20%7D%60%20wins%20over%20a%20matching%20ask%20rule**%0A%0AThe%20%60Reject%20%7B%20rules%2C%20..%20%7D%20if%20*rules%60%20arm%20fires%20before%20the%20ask-rule%20arm%2C%20so%20%60matched_ask_rule%60%20is%20never%20set.%20The%20resulting%20%60ExecPolicyDecision%60%20exposes%20%60matched_rule%3A%20None%60%20even%20though%20a%20typed%20ask%20rule%20was%20the%20semantic%20cause%20of%20the%20rejection.%20This%20makes%20it%20harder%20to%20diagnose%20why%20a%20command%20was%20blocked.%20The%20test%20%60reject_rules_mode_still_forbids_matching_ask_rule%60%20explicitly%20asserts%20this%20behavior%2C%20but%20consider%20whether%20users%20should%20see%20the%20matching%20rule%20label%20for%20debuggability.%0A%0A&repo=hmbown%2Fcodewhale&pr=2885&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Fexecpolicy%2Fsrc%2Flib.rs%3A402-412%0A**Filesystem%20path%20used%20as%20network%20policy%20host**%0A%0A%60ctx.cwd%60%20is%20a%20filesystem%20directory%20%28e.g.%2C%20%60%2Fworkspace%60%29%2C%20but%20%60NetworkPolicyAmendment.host%60%20is%20documented%20as%20a%20network%20host.%20For%20file-access%20ask%20rules%20%28e.g.%2C%20%60edit_file%60%20with%20a%20%60path%60%20field%29%2C%20this%20proposes%20an%20amendment%20to%20allow%20the%20network%20host%20%60%2Fworkspace%60%2C%20which%20is%20syntactically%20invalid%20and%20would%20be%20presented%20to%20the%20user%20as%20a%20confusing%20or%20broken%20approval%20prompt.%20The%20pre-existing%20%60_%60%20fallback%20also%20does%20this%2C%20but%20the%20ask-rule%20branch%20is%20new%20and%20can%20now%20be%20reached%20by%20non-shell%20tools.%20The%20%60proposed_network_policy_amendments%60%20field%20should%20either%20be%20empty%20%28%60vec!%5B%5D%60%29%20for%20ask-rule%20matches%2C%20or%20populated%20with%20an%20actual%20resolved%20hostname%20extracted%20from%20the%20tool%20context.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Fexecpolicy%2Fsrc%2Flib.rs%3A399-401%0A**%60matched_rule%60%20is%20silently%20%60None%60%20when%20%60Reject%20%7B%20rules%3A%20true%20%7D%60%20wins%20over%20a%20matching%20ask%20rule**%0A%0AThe%20%60Reject%20%7B%20rules%2C%20..%20%7D%20if%20*rules%60%20arm%20fires%20before%20the%20ask-rule%20arm%2C%20so%20%60matched_ask_rule%60%20is%20never%20set.%20The%20resulting%20%60ExecPolicyDecision%60%20exposes%20%60matched_rule%3A%20None%60%20even%20though%20a%20typed%20ask%20rule%20was%20the%20semantic%20cause%20of%20the%20rejection.%20This%20makes%20it%20harder%20to%20diagnose%20why%20a%20command%20was%20blocked.%20The%20test%20%60reject_rules_mode_still_forbids_matching_ask_rule%60%20explicitly%20asserts%20this%20behavior%2C%20but%20consider%20whether%20users%20should%20see%20the%20matching%20rule%20label%20for%20debuggability.%0A%0A&repo=hmbown%2Fcodewhale&pr=2885&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Fexecpolicy%2Fsrc%2Flib.rs%3A402-412%0A**Filesystem%20path%20used%20as%20network%20policy%20host**%0A%0A%60ctx.cwd%60%20is%20a%20filesystem%20directory%20%28e.g.%2C%20%60%2Fworkspace%60%29%2C%20but%20%60NetworkPolicyAmendment.host%60%20is%20documented%20as%20a%20network%20host.%20For%20file-access%20ask%20rules%20%28e.g.%2C%20%60edit_file%60%20with%20a%20%60path%60%20field%29%2C%20this%20proposes%20an%20amendment%20to%20allow%20the%20network%20host%20%60%2Fworkspace%60%2C%20which%20is%20syntactically%20invalid%20and%20would%20be%20presented%20to%20the%20user%20as%20a%20confusing%20or%20broken%20approval%20prompt.%20The%20pre-existing%20%60_%60%20fallback%20also%20does%20this%2C%20but%20the%20ask-rule%20branch%20is%20new%20and%20can%20now%20be%20reached%20by%20non-shell%20tools.%20The%20%60proposed_network_policy_amendments%60%20field%20should%20either%20be%20empty%20%28%60vec!%5B%5D%60%29%20for%20ask-rule%20matches%2C%20or%20populated%20with%20an%20actual%20resolved%20hostname%20extracted%20from%20the%20tool%20context.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Fexecpolicy%2Fsrc%2Flib.rs%3A399-401%0A**%60matched_rule%60%20is%20silently%20%60None%60%20when%20%60Reject%20%7B%20rules%3A%20true%20%7D%60%20wins%20over%20a%20matching%20ask%20rule**%0A%0AThe%20%60Reject%20%7B%20rules%2C%20..%20%7D%20if%20*rules%60%20arm%20fires%20before%20the%20ask-rule%20arm%2C%20so%20%60matched_ask_rule%60%20is%20never%20set.%20The%20resulting%20%60ExecPolicyDecision%60%20exposes%20%60matched_rule%3A%20None%60%20even%20though%20a%20typed%20ask%20rule%20was%20the%20semantic%20cause%20of%20the%20rejection.%20This%20makes%20it%20harder%20to%20diagnose%20why%20a%20command%20was%20blocked.%20The%20test%20%60reject_rules_mode_still_forbids_matching_ask_rule%60%20explicitly%20asserts%20this%20behavior%2C%20but%20consider%20whether%20users%20should%20see%20the%20matching%20rule%20label%20for%20debuggability.%0A%0A&pr=2885&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(execpolicy): wire typed ask permiss..."](https://github.com/hmbown/codewhale/commit/a03a936e122d98d8ad10b37b458109ff277bd915) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36074724)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->