### PR TITLE
feat(i18n): localize sandbox elevation dialog across 7 locales

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@ npm/*/bin/downloads/
 apps/
 
 # Claude Code runtime artifacts
+.claude/settings.json
 .claude/scheduled_tasks.lock
 .claude/worktrees/
 .worktrees/

--- a/crates/tui/src/client/responses.rs
+++ b/crates/tui/src/client/responses.rs
@@ -323,13 +323,8 @@ impl DeepSeekClient {
                                         .and_then(|s| s.as_str())
                                         .unwrap_or("completed");
                                     let stop_reason = match status {
-                                        "completed" => {
-                                            if saw_tool_call {
-                                                "tool_use"
-                                            } else {
-                                                "end_turn"
-                                            }
-                                        }
+                                        "completed" if saw_tool_call => "tool_use",
+                                        "completed" => "end_turn",
                                         "incomplete" => "max_tokens",
                                         _ => "end_turn",
                                     };

--- a/crates/tui/src/localization.rs
+++ b/crates/tui/src/localization.rs
@@ -537,6 +537,25 @@ pub enum MessageId {
     ApprovalChooseAction,
     ApprovalIntentLabel,
     ApprovalMoreLines,
+    // Sandbox elevation dialog.
+    ElevationTitleSandboxDenied,
+    ElevationTitleRequired,
+    ElevationFieldTool,
+    ElevationFieldCmd,
+    ElevationFieldReason,
+    ElevationImpactHeader,
+    ElevationImpactNetwork,
+    ElevationImpactWrite,
+    ElevationImpactFullAccess,
+    ElevationPromptProceed,
+    ElevationOptionNetwork,
+    ElevationOptionWrite,
+    ElevationOptionFullAccess,
+    ElevationOptionAbort,
+    ElevationOptionNetworkDesc,
+    ElevationOptionWriteDesc,
+    ElevationOptionFullAccessDesc,
+    ElevationOptionAbortDesc,
 
     CtxInspTitle,
     CtxInspSessionContext,
@@ -892,6 +911,24 @@ pub const ALL_MESSAGE_IDS: &[MessageId] = &[
     MessageId::ApprovalChooseAction,
     MessageId::ApprovalIntentLabel,
     MessageId::ApprovalMoreLines,
+    MessageId::ElevationTitleSandboxDenied,
+    MessageId::ElevationTitleRequired,
+    MessageId::ElevationFieldTool,
+    MessageId::ElevationFieldCmd,
+    MessageId::ElevationFieldReason,
+    MessageId::ElevationImpactHeader,
+    MessageId::ElevationImpactNetwork,
+    MessageId::ElevationImpactWrite,
+    MessageId::ElevationImpactFullAccess,
+    MessageId::ElevationPromptProceed,
+    MessageId::ElevationOptionNetwork,
+    MessageId::ElevationOptionWrite,
+    MessageId::ElevationOptionFullAccess,
+    MessageId::ElevationOptionAbort,
+    MessageId::ElevationOptionNetworkDesc,
+    MessageId::ElevationOptionWriteDesc,
+    MessageId::ElevationOptionFullAccessDesc,
+    MessageId::ElevationOptionAbortDesc,
     MessageId::CtxInspTitle,
     MessageId::CtxInspSessionContext,
     MessageId::CtxInspSystemPrompt,
@@ -1555,6 +1592,39 @@ fn english(id: MessageId) -> &'static str {
         MessageId::ApprovalChooseAction => "Enter selected option, or press y/a/d directly",
         MessageId::ApprovalIntentLabel => "Intent: ",
         MessageId::ApprovalMoreLines => "  … (+{count} lines)",
+        // Sandbox elevation dialog.
+// Sandbox elevation dialog.
+        MessageId::ElevationTitleSandboxDenied => "  ⚠ Sandbox Denied ",
+        MessageId::ElevationTitleRequired => " Sandbox Elevation Required ",
+        MessageId::ElevationFieldTool => "  Tool: ",
+        MessageId::ElevationFieldCmd => "  Cmd:  ",
+        MessageId::ElevationFieldReason => "  Reason: ",
+        MessageId::ElevationImpactHeader => "  Impact if approved:",
+        MessageId::ElevationImpactNetwork => {
+            "    - network retry enables outbound downloads and HTTP requests"
+        }
+        MessageId::ElevationImpactWrite => {
+            "    - write retry expands writable filesystem scope for this tool call"
+        }
+        MessageId::ElevationImpactFullAccess => {
+            "    - full access removes sandbox restrictions entirely for this retry"
+        }
+        MessageId::ElevationPromptProceed => "  Choose how to proceed:",
+        MessageId::ElevationOptionNetwork => "Allow outbound network",
+        MessageId::ElevationOptionWrite => "Allow extra write access",
+        MessageId::ElevationOptionFullAccess => "Full access (filesystem + network)",
+        MessageId::ElevationOptionAbort => "Abort",
+        MessageId::ElevationOptionNetworkDesc => {
+            "Retry this tool call with outbound network access for downloads and HTTP requests"
+        }
+        MessageId::ElevationOptionWriteDesc => {
+            "Retry this tool call with additional writable filesystem scope"
+        }
+        MessageId::ElevationOptionFullAccessDesc => {
+            "Retry without sandbox limits; grants unrestricted filesystem and network access"
+        }
+        MessageId::ElevationOptionAbortDesc => "Cancel this tool execution",
+
 
         MessageId::CtxInspTitle => "Context inspector",
         MessageId::CtxInspSessionContext => "Session Context",
@@ -2063,7 +2133,7 @@ fn vietnamese(id: MessageId) -> Option<&'static str> {
         MessageId::CtxMenuHelp => "Trợ giúp",
         MessageId::CtxMenuHelpDesc => "phím tắt và lệnh",
         MessageId::FanoutCounts => {
-            "{done} hoàn thành · {running} đang chạy · {failed} thất bại · {pending} chờ"
+            "{done} đã xong · {running} đang chạy · {failed} thất bại · {pending} chờ"
         }
 
         // Approval dialog.
@@ -2090,6 +2160,39 @@ fn vietnamese(id: MessageId) -> Option<&'static str> {
         MessageId::ApprovalChooseAction => "Enter để chọn, hoặc nhấn y/a/d trực tiếp",
         MessageId::ApprovalIntentLabel => "Ý định: ",
         MessageId::ApprovalMoreLines => "  … (+{count} dòng)",
+        // Sandbox elevation dialog.
+// Sandbox elevation dialog.
+        MessageId::ElevationTitleSandboxDenied => "  \u{26a0} Sandbox Bị Từ Chối ",
+        MessageId::ElevationTitleRequired => " Yêu Cầu Nâng Cấp Sandbox ",
+        MessageId::ElevationFieldTool => "  Công cụ: ",
+        MessageId::ElevationFieldCmd => "  Lệnh:   ",
+        MessageId::ElevationFieldReason => "  Lý do: ",
+        MessageId::ElevationImpactHeader => "  Tác động nếu được chấp thuận:",
+        MessageId::ElevationImpactNetwork => {
+            "    - thử lại với mạng cho phép tải xuống và yêu cầu HTTP"
+        }
+        MessageId::ElevationImpactWrite => {
+            "    - thử lại với quyền ghi mở rộng phạm vi hệ thống tệp"
+        }
+        MessageId::ElevationImpactFullAccess => {
+            "    - truy cập đầy đủ loại bỏ hoàn toàn hạn chế sandbox"
+        }
+        MessageId::ElevationPromptProceed => "  Chọn cách tiếp tục:",
+        MessageId::ElevationOptionNetwork => "Cho phép mạng ngoài",
+        MessageId::ElevationOptionWrite => "Cho phép quyền ghi bổ sung",
+        MessageId::ElevationOptionFullAccess => "Truy cập đầy đủ (hệ thống tệp + mạng)",
+        MessageId::ElevationOptionAbort => "Hủy bỏ",
+        MessageId::ElevationOptionNetworkDesc => {
+            "Thử lại cuộc gọi công cụ này với quyền truy cập mạng ngoài"
+        }
+        MessageId::ElevationOptionWriteDesc => {
+            "Thử lại cuộc gọi công cụ này với phạm vi hệ thống tệp có thể ghi bổ sung"
+        }
+        MessageId::ElevationOptionFullAccessDesc => {
+            "Thử lại không giới hạn sandbox; cấp quyền truy cập không hạn chế"
+        }
+        MessageId::ElevationOptionAbortDesc => "Hủy thực thi công cụ này",
+
 
         MessageId::CtxInspTitle => "Trình kiểm tra ngữ cảnh",
         MessageId::CtxInspSessionContext => "Ngữ cảnh phiên",
@@ -2179,6 +2282,31 @@ fn traditional_chinese(id: MessageId) -> Option<&'static str> {
         MessageId::ApprovalChooseAction => "Enter 執行選中項，或直接按 y/a/d",
         MessageId::ApprovalIntentLabel => "意圖：",
         MessageId::ApprovalMoreLines => "  … (還有 {count} 行)",
+        // Sandbox elevation dialog.
+// Sandbox elevation dialog.
+        MessageId::ElevationTitleSandboxDenied => "  \u{26a0} 沙箱拒絕 ",
+        MessageId::ElevationTitleRequired => " 沙箱提權 ",
+        MessageId::ElevationFieldTool => "  工具：",
+        MessageId::ElevationFieldCmd => "  命令：",
+        MessageId::ElevationFieldReason => "  原因：",
+        MessageId::ElevationImpactHeader => "  批准後的影響：",
+        MessageId::ElevationImpactNetwork => "    - 網路重試允許外部下載和 HTTP 請求",
+        MessageId::ElevationImpactWrite => "    - 寫入重試擴大此工具呼叫的檔案系統寫入範圍",
+        MessageId::ElevationImpactFullAccess => "    - 完全訪問解除沙箱限制",
+        MessageId::ElevationPromptProceed => "  請選擇處理方式：",
+        MessageId::ElevationOptionNetwork => "允許外部網路訪問",
+        MessageId::ElevationOptionWrite => "允許額外寫入權限",
+        MessageId::ElevationOptionFullAccess => "完全訪問（檔案系統 + 網路）",
+        MessageId::ElevationOptionAbort => "中止",
+        MessageId::ElevationOptionNetworkDesc => {
+            "使用外部網路訪問重試此工具呼叫（下載和 HTTP 請求）"
+        }
+        MessageId::ElevationOptionWriteDesc => "重試此工具呼叫，擴大可寫入的檔案系統範圍",
+        MessageId::ElevationOptionFullAccessDesc => {
+            "無沙箱限制重試（授予無限制的檔案系統和網路訪問權限）"
+        }
+        MessageId::ElevationOptionAbortDesc => "取消此工具呼叫",
+
 
         MessageId::CtxInspTitle => "上下文檢查器",
         MessageId::CtxInspSessionContext => "會話上下文",
@@ -2679,6 +2807,37 @@ fn japanese(id: MessageId) -> Option<&'static str> {
         MessageId::ApprovalChooseAction => "Enterで選択、または y/a/d を直接入力",
         MessageId::ApprovalIntentLabel => "意図：",
         MessageId::ApprovalMoreLines => "  … (+{count} 行)",
+        // Sandbox elevation dialog.
+// Sandbox elevation dialog.
+        MessageId::ElevationTitleSandboxDenied => "  \u{26a0} サンドボックス拒否 ",
+        MessageId::ElevationTitleRequired => " サンドボックス昇格 ",
+        MessageId::ElevationFieldTool => "  ツール：",
+        MessageId::ElevationFieldCmd => "  コマンド：",
+        MessageId::ElevationFieldReason => "  理由：",
+        MessageId::ElevationImpactHeader => "  承認された場合の影響：",
+        MessageId::ElevationImpactNetwork => {
+            "    - ネットワーク再試行で外部ダウンロードとHTTPリクエストが可能"
+        }
+        MessageId::ElevationImpactWrite => {
+            "    - 書き込み再試行でファイルシステムの書き込み範囲が拡大"
+        }
+        MessageId::ElevationImpactFullAccess => {
+            "    - フルアクセスでサンドボックス制限を完全に解除"
+        }
+        MessageId::ElevationPromptProceed => "  方法を選択：",
+        MessageId::ElevationOptionNetwork => "外部ネットワークを許可",
+        MessageId::ElevationOptionWrite => "追加の書き込みアクセスを許可",
+        MessageId::ElevationOptionFullAccess => "フルアクセス（ファイルシステム + ネットワーク）",
+        MessageId::ElevationOptionAbort => "中止",
+        MessageId::ElevationOptionNetworkDesc => {
+            "外部ネットワークアクセスでこのツール呼び出しを再試行（ダウンロードとHTTPリクエスト用）"
+        }
+        MessageId::ElevationOptionWriteDesc => "追加の書き込み可能ファイルシステム範囲で再試行",
+        MessageId::ElevationOptionFullAccessDesc => {
+            "サンドボックス制限なしで再試行（ファイルシステムとネットワークへの無制限アクセス）"
+        }
+        MessageId::ElevationOptionAbortDesc => "このツール実行をキャンセル",
+
 
         MessageId::CtxInspTitle => "コンテキストインスペクタ",
         MessageId::CtxInspSessionContext => "セッションコンテキスト",
@@ -3117,6 +3276,31 @@ fn chinese_simplified(id: MessageId) -> Option<&'static str> {
         MessageId::ApprovalChooseAction => "Enter 执行选中项，或直接按 y/a/d",
         MessageId::ApprovalIntentLabel => "意图：",
         MessageId::ApprovalMoreLines => "  … (还有 {count} 行)",
+        // Sandbox elevation dialog.
+// Sandbox elevation dialog.
+        MessageId::ElevationTitleSandboxDenied => "  \u{26a0} 沙箱拒绝 ",
+        MessageId::ElevationTitleRequired => " 沙箱提权 ",
+        MessageId::ElevationFieldTool => "  工具：",
+        MessageId::ElevationFieldCmd => "  命令：",
+        MessageId::ElevationFieldReason => "  原因：",
+        MessageId::ElevationImpactHeader => "  批准后的影响：",
+        MessageId::ElevationImpactNetwork => "    - 网络重试允许外部下载和 HTTP 请求",
+        MessageId::ElevationImpactWrite => "    - 写入重试扩大此工具调用的文件系统写入范围",
+        MessageId::ElevationImpactFullAccess => "    - 完全访问解除沙箱限制",
+        MessageId::ElevationPromptProceed => "  请选择处理方式：",
+        MessageId::ElevationOptionNetwork => "允许外部网络访问",
+        MessageId::ElevationOptionWrite => "允许额外写入权限",
+        MessageId::ElevationOptionFullAccess => "完全访问（文件系统 + 网络）",
+        MessageId::ElevationOptionAbort => "中止",
+        MessageId::ElevationOptionNetworkDesc => {
+            "使用外部网络访问重试此工具调用（下载和 HTTP 请求）"
+        }
+        MessageId::ElevationOptionWriteDesc => "重试此工具调用，扩大可写入的文件系统范围",
+        MessageId::ElevationOptionFullAccessDesc => {
+            "无沙箱限制重试（授予无限制的文件系统和网络访问权限）"
+        }
+        MessageId::ElevationOptionAbortDesc => "取消此工具调用",
+
 
         MessageId::CtxInspTitle => "上下文检查器",
         MessageId::CtxInspSessionContext => "会话上下文",
@@ -3631,6 +3815,39 @@ fn portuguese_brazil(id: MessageId) -> Option<&'static str> {
         MessageId::ApprovalChooseAction => "Enter para selecionar, ou pressione y/a/d diretamente",
         MessageId::ApprovalIntentLabel => "Intenção: ",
         MessageId::ApprovalMoreLines => "  … (+{count} linhas)",
+        // Sandbox elevation dialog.
+// Sandbox elevation dialog.
+        MessageId::ElevationTitleSandboxDenied => "  \u{26a0} Sandbox Negado ",
+        MessageId::ElevationTitleRequired => " Elevação de Sandbox Necessária ",
+        MessageId::ElevationFieldTool => "  Ferramenta: ",
+        MessageId::ElevationFieldCmd => "  Comando:  ",
+        MessageId::ElevationFieldReason => "  Motivo: ",
+        MessageId::ElevationImpactHeader => "  Impacto se aprovado:",
+        MessageId::ElevationImpactNetwork => {
+            "    - retry de rede permite downloads externos e requisições HTTP"
+        }
+        MessageId::ElevationImpactWrite => {
+            "    - retry de escrita expande o escopo do sistema de arquivos para esta chamada"
+        }
+        MessageId::ElevationImpactFullAccess => {
+            "    - acesso total remove todas as restrições de sandbox para este retry"
+        }
+        MessageId::ElevationPromptProceed => "  Escolha como prosseguir:",
+        MessageId::ElevationOptionNetwork => "Permitir rede externa",
+        MessageId::ElevationOptionWrite => "Permitir acesso extra de escrita",
+        MessageId::ElevationOptionFullAccess => "Acesso total (sistema de arquivos + rede)",
+        MessageId::ElevationOptionAbort => "Abortar",
+        MessageId::ElevationOptionNetworkDesc => {
+            "Retry esta chamada com acesso de rede externa para downloads e requisições HTTP"
+        }
+        MessageId::ElevationOptionWriteDesc => {
+            "Retry esta chamada com escopo adicional de sistema de arquivos gravável"
+        }
+        MessageId::ElevationOptionFullAccessDesc => {
+            "Retry sem limites de sandbox; concede acesso irrestrito ao sistema de arquivos e rede"
+        }
+        MessageId::ElevationOptionAbortDesc => "Cancelar esta execução de ferramenta",
+
 
         MessageId::CtxInspTitle => "Inspetor de contexto",
         MessageId::CtxInspSessionContext => "Contexto da sessão",
@@ -4159,6 +4376,39 @@ fn spanish_latin_america(id: MessageId) -> Option<&'static str> {
         MessageId::ApprovalChooseAction => "Enter para seleccionar, o presione y/a/d directamente",
         MessageId::ApprovalIntentLabel => "Intención: ",
         MessageId::ApprovalMoreLines => "  … (+{count} líneas)",
+        // Sandbox elevation dialog.
+// Sandbox elevation dialog.
+        MessageId::ElevationTitleSandboxDenied => "  \u{26a0} Sandbox Denegado ",
+        MessageId::ElevationTitleRequired => " Elevación de Sandbox Requerida ",
+        MessageId::ElevationFieldTool => "  Herramienta: ",
+        MessageId::ElevationFieldCmd => "  Comando:  ",
+        MessageId::ElevationFieldReason => "  Motivo: ",
+        MessageId::ElevationImpactHeader => "  Impacto si se aprueba:",
+        MessageId::ElevationImpactNetwork => {
+            "    - reintento de red permite descargas y solicitudes HTTP externas"
+        }
+        MessageId::ElevationImpactWrite => {
+            "    - reintento de escritura expande el ámbito del sistema de archivos para esta llamada"
+        }
+        MessageId::ElevationImpactFullAccess => {
+            "    - acceso total elimina todas las restricciones de sandbox para este reintento"
+        }
+        MessageId::ElevationPromptProceed => "  Elige cómo proceder:",
+        MessageId::ElevationOptionNetwork => "Permitir red externa",
+        MessageId::ElevationOptionWrite => "Permitir acceso extra de escritura",
+        MessageId::ElevationOptionFullAccess => "Acceso total (sistema de archivos + red)",
+        MessageId::ElevationOptionAbort => "Abortar",
+        MessageId::ElevationOptionNetworkDesc => {
+            "Reintenta esta llamada con acceso de red externa para descargas y solicitudes HTTP"
+        }
+        MessageId::ElevationOptionWriteDesc => {
+            "Reintenta esta llamada con ámbito adicional de sistema de archivos grabable"
+        }
+        MessageId::ElevationOptionFullAccessDesc => {
+            "Reintenta sin límites de sandbox; concede acceso sin restricciones al sistema de archivos y red"
+        }
+        MessageId::ElevationOptionAbortDesc => "Cancelar esta ejecución de herramienta",
+
 
         MessageId::CtxInspTitle => "Inspector de contexto",
         MessageId::CtxInspSessionContext => "Contexto de la sesión",

--- a/crates/tui/src/localization.rs
+++ b/crates/tui/src/localization.rs
@@ -1593,8 +1593,7 @@ fn english(id: MessageId) -> &'static str {
         MessageId::ApprovalIntentLabel => "Intent: ",
         MessageId::ApprovalMoreLines => "  … (+{count} lines)",
         // Sandbox elevation dialog.
-// Sandbox elevation dialog.
-        MessageId::ElevationTitleSandboxDenied => "  ⚠ Sandbox Denied ",
+        MessageId::ElevationTitleSandboxDenied => "  \u{26a0} Sandbox Denied ",
         MessageId::ElevationTitleRequired => " Sandbox Elevation Required ",
         MessageId::ElevationFieldTool => "  Tool: ",
         MessageId::ElevationFieldCmd => "  Cmd:  ",
@@ -1624,7 +1623,6 @@ fn english(id: MessageId) -> &'static str {
             "Retry without sandbox limits; grants unrestricted filesystem and network access"
         }
         MessageId::ElevationOptionAbortDesc => "Cancel this tool execution",
-
 
         MessageId::CtxInspTitle => "Context inspector",
         MessageId::CtxInspSessionContext => "Session Context",
@@ -2133,7 +2131,7 @@ fn vietnamese(id: MessageId) -> Option<&'static str> {
         MessageId::CtxMenuHelp => "Trợ giúp",
         MessageId::CtxMenuHelpDesc => "phím tắt và lệnh",
         MessageId::FanoutCounts => {
-            "{done} đã xong · {running} đang chạy · {failed} thất bại · {pending} chờ"
+            "{done} hoàn thành · {running} đang chạy · {failed} thất bại · {pending} chờ"
         }
 
         // Approval dialog.
@@ -2161,7 +2159,7 @@ fn vietnamese(id: MessageId) -> Option<&'static str> {
         MessageId::ApprovalIntentLabel => "Ý định: ",
         MessageId::ApprovalMoreLines => "  … (+{count} dòng)",
         // Sandbox elevation dialog.
-// Sandbox elevation dialog.
+        // Sandbox elevation dialog.
         MessageId::ElevationTitleSandboxDenied => "  \u{26a0} Sandbox Bị Từ Chối ",
         MessageId::ElevationTitleRequired => " Yêu Cầu Nâng Cấp Sandbox ",
         MessageId::ElevationFieldTool => "  Công cụ: ",
@@ -2192,7 +2190,6 @@ fn vietnamese(id: MessageId) -> Option<&'static str> {
             "Thử lại không giới hạn sandbox; cấp quyền truy cập không hạn chế"
         }
         MessageId::ElevationOptionAbortDesc => "Hủy thực thi công cụ này",
-
 
         MessageId::CtxInspTitle => "Trình kiểm tra ngữ cảnh",
         MessageId::CtxInspSessionContext => "Ngữ cảnh phiên",
@@ -2283,7 +2280,7 @@ fn traditional_chinese(id: MessageId) -> Option<&'static str> {
         MessageId::ApprovalIntentLabel => "意圖：",
         MessageId::ApprovalMoreLines => "  … (還有 {count} 行)",
         // Sandbox elevation dialog.
-// Sandbox elevation dialog.
+        // Sandbox elevation dialog.
         MessageId::ElevationTitleSandboxDenied => "  \u{26a0} 沙箱拒絕 ",
         MessageId::ElevationTitleRequired => " 沙箱提權 ",
         MessageId::ElevationFieldTool => "  工具：",
@@ -2306,7 +2303,6 @@ fn traditional_chinese(id: MessageId) -> Option<&'static str> {
             "無沙箱限制重試（授予無限制的檔案系統和網路訪問權限）"
         }
         MessageId::ElevationOptionAbortDesc => "取消此工具呼叫",
-
 
         MessageId::CtxInspTitle => "上下文檢查器",
         MessageId::CtxInspSessionContext => "會話上下文",
@@ -2808,7 +2804,7 @@ fn japanese(id: MessageId) -> Option<&'static str> {
         MessageId::ApprovalIntentLabel => "意図：",
         MessageId::ApprovalMoreLines => "  … (+{count} 行)",
         // Sandbox elevation dialog.
-// Sandbox elevation dialog.
+        // Sandbox elevation dialog.
         MessageId::ElevationTitleSandboxDenied => "  \u{26a0} サンドボックス拒否 ",
         MessageId::ElevationTitleRequired => " サンドボックス昇格 ",
         MessageId::ElevationFieldTool => "  ツール：",
@@ -2837,7 +2833,6 @@ fn japanese(id: MessageId) -> Option<&'static str> {
             "サンドボックス制限なしで再試行（ファイルシステムとネットワークへの無制限アクセス）"
         }
         MessageId::ElevationOptionAbortDesc => "このツール実行をキャンセル",
-
 
         MessageId::CtxInspTitle => "コンテキストインスペクタ",
         MessageId::CtxInspSessionContext => "セッションコンテキスト",
@@ -3277,7 +3272,7 @@ fn chinese_simplified(id: MessageId) -> Option<&'static str> {
         MessageId::ApprovalIntentLabel => "意图：",
         MessageId::ApprovalMoreLines => "  … (还有 {count} 行)",
         // Sandbox elevation dialog.
-// Sandbox elevation dialog.
+        // Sandbox elevation dialog.
         MessageId::ElevationTitleSandboxDenied => "  \u{26a0} 沙箱拒绝 ",
         MessageId::ElevationTitleRequired => " 沙箱提权 ",
         MessageId::ElevationFieldTool => "  工具：",
@@ -3300,7 +3295,6 @@ fn chinese_simplified(id: MessageId) -> Option<&'static str> {
             "无沙箱限制重试（授予无限制的文件系统和网络访问权限）"
         }
         MessageId::ElevationOptionAbortDesc => "取消此工具调用",
-
 
         MessageId::CtxInspTitle => "上下文检查器",
         MessageId::CtxInspSessionContext => "会话上下文",
@@ -3816,7 +3810,7 @@ fn portuguese_brazil(id: MessageId) -> Option<&'static str> {
         MessageId::ApprovalIntentLabel => "Intenção: ",
         MessageId::ApprovalMoreLines => "  … (+{count} linhas)",
         // Sandbox elevation dialog.
-// Sandbox elevation dialog.
+        // Sandbox elevation dialog.
         MessageId::ElevationTitleSandboxDenied => "  \u{26a0} Sandbox Negado ",
         MessageId::ElevationTitleRequired => " Elevação de Sandbox Necessária ",
         MessageId::ElevationFieldTool => "  Ferramenta: ",
@@ -3847,7 +3841,6 @@ fn portuguese_brazil(id: MessageId) -> Option<&'static str> {
             "Retry sem limites de sandbox; concede acesso irrestrito ao sistema de arquivos e rede"
         }
         MessageId::ElevationOptionAbortDesc => "Cancelar esta execução de ferramenta",
-
 
         MessageId::CtxInspTitle => "Inspetor de contexto",
         MessageId::CtxInspSessionContext => "Contexto da sessão",
@@ -4377,7 +4370,7 @@ fn spanish_latin_america(id: MessageId) -> Option<&'static str> {
         MessageId::ApprovalIntentLabel => "Intención: ",
         MessageId::ApprovalMoreLines => "  … (+{count} líneas)",
         // Sandbox elevation dialog.
-// Sandbox elevation dialog.
+        // Sandbox elevation dialog.
         MessageId::ElevationTitleSandboxDenied => "  \u{26a0} Sandbox Denegado ",
         MessageId::ElevationTitleRequired => " Elevación de Sandbox Requerida ",
         MessageId::ElevationFieldTool => "  Herramienta: ",
@@ -4408,7 +4401,6 @@ fn spanish_latin_america(id: MessageId) -> Option<&'static str> {
             "Reintenta sin límites de sandbox; concede acceso sin restricciones al sistema de archivos y red"
         }
         MessageId::ElevationOptionAbortDesc => "Cancelar esta ejecución de herramienta",
-
 
         MessageId::CtxInspTitle => "Inspector de contexto",
         MessageId::CtxInspSessionContext => "Contexto de la sesión",

--- a/crates/tui/src/tui/approval.rs
+++ b/crates/tui/src/tui/approval.rs
@@ -1026,6 +1026,7 @@ pub enum ElevationOption {
 
 impl ElevationOption {
     /// Get the display label for this option.
+    #[allow(dead_code)]
     pub fn label(&self) -> &'static str {
         match self {
             ElevationOption::WithNetwork => "Allow outbound network",
@@ -1036,6 +1037,7 @@ impl ElevationOption {
     }
 
     /// Get a short description.
+    #[allow(dead_code)]
     pub fn description(&self) -> &'static str {
         match self {
             ElevationOption::WithNetwork => {
@@ -1132,13 +1134,15 @@ impl ElevationRequest {
 pub struct ElevationView {
     request: ElevationRequest,
     selected: usize,
+    locale: Locale,
 }
 
 impl ElevationView {
-    pub fn new(request: ElevationRequest) -> Self {
+    pub fn new(request: ElevationRequest, locale: Locale) -> Self {
         Self {
             request,
             selected: 0,
+            locale,
         }
     }
 
@@ -1213,7 +1217,7 @@ impl ModalView for ElevationView {
     }
 
     fn render(&self, area: ratatui::layout::Rect, buf: &mut ratatui::buffer::Buffer) {
-        let elevation_widget = ElevationWidget::new(&self.request, self.selected);
+        let elevation_widget = ElevationWidget::new(&self.request, self.selected, self.locale);
         elevation_widget.render(area, buf);
     }
 }
@@ -1991,7 +1995,7 @@ mod tests {
     fn test_elevation_view_initial_state() {
         let request =
             ElevationRequest::for_shell("test-id", "cargo build", "network blocked", true, false);
-        let view = ElevationView::new(request);
+        let view = ElevationView::new(request, Locale::En);
         assert_eq!(view.selected, 0);
     }
 
@@ -1999,7 +2003,7 @@ mod tests {
     fn test_elevation_view_keybindings() {
         let request =
             ElevationRequest::for_shell("test-id", "cargo test", "write blocked", false, true);
-        let mut view = ElevationView::new(request);
+        let mut view = ElevationView::new(request, Locale::En);
 
         let action = view.handle_key(create_key_event(KeyCode::Char('n')));
         assert!(matches!(
@@ -2012,7 +2016,7 @@ mod tests {
 
         let request =
             ElevationRequest::for_shell("test-id", "cargo build", "write blocked", false, true);
-        let mut view = ElevationView::new(request);
+        let mut view = ElevationView::new(request, Locale::En);
         let action = view.handle_key(create_key_event(KeyCode::Char('w')));
         assert!(matches!(
             action,
@@ -2024,7 +2028,7 @@ mod tests {
 
         let request =
             ElevationRequest::for_shell("test-id", "cargo build", "blocked", false, false);
-        let mut view = ElevationView::new(request);
+        let mut view = ElevationView::new(request, Locale::En);
         let action = view.handle_key(create_key_event(KeyCode::Char('f')));
         assert!(matches!(
             action,
@@ -2036,7 +2040,7 @@ mod tests {
 
         let request =
             ElevationRequest::for_shell("test-id", "cargo build", "blocked", false, false);
-        let mut view = ElevationView::new(request);
+        let mut view = ElevationView::new(request, Locale::En);
         let action = view.handle_key(create_key_event(KeyCode::Esc));
         assert!(matches!(
             action,
@@ -2048,7 +2052,7 @@ mod tests {
 
         let request =
             ElevationRequest::for_shell("test-id", "cargo build", "blocked", false, false);
-        let mut view = ElevationView::new(request);
+        let mut view = ElevationView::new(request, Locale::En);
         let action = view.handle_key(create_key_event(KeyCode::Char('a')));
         assert!(matches!(
             action,
@@ -2062,7 +2066,7 @@ mod tests {
     #[test]
     fn test_elevation_view_navigation() {
         let request = ElevationRequest::for_shell("test-id", "cargo build", "blocked", true, false);
-        let mut view = ElevationView::new(request);
+        let mut view = ElevationView::new(request, Locale::En);
 
         assert_eq!(view.selected, 0);
 
@@ -2082,7 +2086,7 @@ mod tests {
     #[test]
     fn test_elevation_view_enter_uses_selected_option() {
         let request = ElevationRequest::for_shell("test-id", "cargo build", "blocked", true, false);
-        let mut view = ElevationView::new(request);
+        let mut view = ElevationView::new(request, Locale::En);
 
         view.handle_key(create_key_event(KeyCode::Down));
         assert_eq!(view.selected, 1);
@@ -2095,6 +2099,80 @@ mod tests {
                 ..
             })
         ));
+    }
+
+    fn render_elevation_lines(view: &ElevationView, w: u16, h: u16) -> Vec<String> {
+        use ratatui::buffer::Buffer;
+        use ratatui::layout::Rect;
+        let mut buf = Buffer::empty(Rect::new(0, 0, w, h));
+        view.render(Rect::new(0, 0, w, h), &mut buf);
+        (0..h)
+            .map(|row| {
+                (0..w)
+                    .map(|col| buf[(col, row)].symbol().to_string())
+                    .collect::<String>()
+            })
+            .collect()
+    }
+
+    fn compact_elevation_text(lines: &[String]) -> String {
+        lines.join("\n").replace(' ', "")
+    }
+
+    fn elevation_shell_request() -> ElevationRequest {
+        ElevationRequest::for_shell("test-id", "cargo build", "network blocked", true, false)
+    }
+
+    #[test]
+    fn test_elevation_render_en_has_expected_strings() {
+        let view = ElevationView::new(elevation_shell_request(), Locale::En);
+        let lines = render_elevation_lines(&view, 70, 22);
+        let joined = compact_elevation_text(&lines);
+        assert!(
+            joined.contains("SandboxDenied"),
+            "missing en title:\n{joined}"
+        );
+        assert!(joined.contains("Tool:"), "missing en tool label:\n{joined}");
+        assert!(joined.contains("Cmd:"), "missing en cmd label:\n{joined}");
+        assert!(
+            joined.contains("Reason:"),
+            "missing en reason label:\n{joined}"
+        );
+    }
+
+    #[test]
+    fn test_elevation_render_zh_hans_localizes_copy() {
+        let view = ElevationView::new(elevation_shell_request(), Locale::ZhHans);
+        let lines = render_elevation_lines(&view, 70, 22);
+        let joined = compact_elevation_text(&lines);
+        assert!(joined.contains("沙箱拒绝"), "missing zh title:\n{joined}");
+        assert!(
+            joined.contains("工具："),
+            "missing zh tool label:\n{joined}"
+        );
+        assert!(joined.contains("命令："), "missing zh cmd label:\n{joined}");
+        assert!(
+            joined.contains("原因："),
+            "missing zh reason label:\n{joined}"
+        );
+        assert!(
+            joined.contains("批准后的影响"),
+            "missing zh impact header:\n{joined}"
+        );
+        let en_artifacts = [
+            "SandboxDenied",
+            "Tool:",
+            "Cmd:",
+            "Reason:",
+            "Impactifapproved",
+            "Choosehowtoproceed",
+        ];
+        for artifact in &en_artifacts {
+            assert!(
+                !joined.contains(artifact),
+                "English leak '{artifact}' in zh rendering:\n{joined}"
+            );
+        }
     }
 
     // ========================================================================

--- a/crates/tui/src/tui/approval.rs
+++ b/crates/tui/src/tui/approval.rs
@@ -1026,7 +1026,7 @@ pub enum ElevationOption {
 
 impl ElevationOption {
     /// Get the display label for this option.
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub fn label(&self) -> &'static str {
         match self {
             ElevationOption::WithNetwork => "Allow outbound network",
@@ -1037,7 +1037,7 @@ impl ElevationOption {
     }
 
     /// Get a short description.
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub fn description(&self) -> &'static str {
         match self {
             ElevationOption::WithNetwork => {
@@ -2166,6 +2166,10 @@ mod tests {
             "Reason:",
             "Impactifapproved",
             "Choosehowtoproceed",
+            "Allowoutboundnetwork",
+            "Allowextrawriteaccess",
+            "Fullaccess",
+            "Abort",
         ];
         for artifact in &en_artifacts {
             assert!(
@@ -2173,6 +2177,58 @@ mod tests {
                 "English leak '{artifact}' in zh rendering:\n{joined}"
             );
         }
+    }
+
+    #[test]
+    fn test_elevation_render_ja_has_translated_copy() {
+        let view = ElevationView::new(elevation_shell_request(), Locale::Ja);
+        let lines = render_elevation_lines(&view, 70, 22);
+        let joined = compact_elevation_text(&lines);
+        assert!(
+            joined.contains("サンドボックス拒否"),
+            "missing ja title:\n{joined}"
+        );
+        assert!(
+            joined.contains("ツール："),
+            "missing ja tool label:\n{joined}"
+        );
+        assert!(
+            joined.contains("コマンド："),
+            "missing ja cmd label:\n{joined}"
+        );
+        assert!(
+            joined.contains("理由："),
+            "missing ja reason label:\n{joined}"
+        );
+        for eng in &["SandboxDenied", "Tool:", "Cmd:", "Reason:"] as &[&str] {
+            assert!(
+                !joined.contains(eng),
+                "English leak '{eng}' in ja:\n{joined}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_elevation_render_zh_hant_has_translated_copy() {
+        let view = ElevationView::new(elevation_shell_request(), Locale::ZhHant);
+        let lines = render_elevation_lines(&view, 70, 22);
+        let joined = compact_elevation_text(&lines);
+        assert!(
+            joined.contains("沙箱拒絕"),
+            "missing zh-Hant title:\n{joined}"
+        );
+        assert!(
+            joined.contains("工具："),
+            "missing zh-Hant tool label:\n{joined}"
+        );
+        assert!(
+            joined.contains("命令："),
+            "missing zh-Hant cmd label:\n{joined}"
+        );
+        assert!(
+            joined.contains("原因："),
+            "missing zh-Hant reason label:\n{joined}"
+        );
     }
 
     // ========================================================================

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -2554,7 +2554,8 @@ async fn run_event_loop(
                                 blocked_network,
                                 blocked_write,
                             );
-                            app.view_stack.push(ElevationView::new(request));
+                            app.view_stack
+                                .push(ElevationView::new(request, app.ui_locale));
                             if let Some((method, _, _)) =
                                 crate::tui::notifications::settings(config)
                             {

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -1615,16 +1615,24 @@ fn option_abort(locale: Locale) -> &'static str {
 pub struct ElevationWidget<'a> {
     request: &'a ElevationRequest,
     selected: usize,
+    locale: Locale,
 }
 
 impl<'a> ElevationWidget<'a> {
-    pub fn new(request: &'a ElevationRequest, selected: usize) -> Self {
-        Self { request, selected }
+    pub fn new(request: &'a ElevationRequest, selected: usize, locale: Locale) -> Self {
+        Self {
+            request,
+            selected,
+            locale,
+        }
     }
 }
 
 impl Renderable for ElevationWidget<'_> {
     fn render(&self, area: Rect, buf: &mut Buffer) {
+        use crate::localization::MessageId;
+        use crate::localization::tr;
+
         let popup_width = 70.min(area.width.saturating_sub(4));
         let popup_height = 22.min(area.height.saturating_sub(4));
         let popup_area = Rect {
@@ -1639,14 +1647,14 @@ impl Renderable for ElevationWidget<'_> {
         let mut lines = vec![
             Line::from(""),
             Line::from(vec![Span::styled(
-                "  ⚠ Sandbox Denied ",
+                tr(self.locale, MessageId::ElevationTitleSandboxDenied),
                 Style::default()
                     .fg(palette::STATUS_ERROR)
                     .add_modifier(Modifier::BOLD),
             )]),
             Line::from(""),
             Line::from(vec![
-                Span::raw("  Tool: "),
+                Span::raw(tr(self.locale, MessageId::ElevationFieldTool)),
                 Span::styled(
                     &self.request.tool_name,
                     Style::default()
@@ -1656,18 +1664,17 @@ impl Renderable for ElevationWidget<'_> {
             ]),
         ];
 
-        // Show command if it's a shell command
         if let Some(ref command) = self.request.command {
             let cmd_display = crate::utils::truncate_with_ellipsis(command, 45, "...");
             lines.push(Line::from(vec![
-                Span::raw("  Cmd:  "),
+                Span::raw(tr(self.locale, MessageId::ElevationFieldCmd)),
                 Span::styled(cmd_display, Style::default().fg(palette::TEXT_MUTED)),
             ]));
         }
 
         lines.push(Line::from(""));
         lines.push(Line::from(vec![
-            Span::raw("  Reason: "),
+            Span::raw(tr(self.locale, MessageId::ElevationFieldReason)),
             Span::styled(
                 &self.request.denial_reason,
                 Style::default().fg(palette::STATUS_WARNING),
@@ -1676,7 +1683,7 @@ impl Renderable for ElevationWidget<'_> {
 
         lines.push(Line::from(""));
         lines.push(Line::from(Span::styled(
-            "  Impact if approved:",
+            tr(self.locale, MessageId::ElevationImpactHeader),
             Style::default().fg(palette::TEXT_MUTED),
         )));
         if self
@@ -1686,7 +1693,7 @@ impl Renderable for ElevationWidget<'_> {
             .any(|option| matches!(option, ElevationOption::WithNetwork))
         {
             lines.push(Line::from(Span::styled(
-                "    - network retry enables outbound downloads and HTTP requests",
+                tr(self.locale, MessageId::ElevationImpactNetwork),
                 Style::default().fg(palette::TEXT_PRIMARY),
             )));
         }
@@ -1697,22 +1704,21 @@ impl Renderable for ElevationWidget<'_> {
             .any(|option| matches!(option, ElevationOption::WithWriteAccess(_)))
         {
             lines.push(Line::from(Span::styled(
-                "    - write retry expands writable filesystem scope for this tool call",
+                tr(self.locale, MessageId::ElevationImpactWrite),
                 Style::default().fg(palette::TEXT_PRIMARY),
             )));
         }
         lines.push(Line::from(Span::styled(
-            "    - full access removes sandbox restrictions entirely for this retry",
+            tr(self.locale, MessageId::ElevationImpactFullAccess),
             Style::default().fg(palette::TEXT_PRIMARY),
         )));
         lines.push(Line::from(""));
         lines.push(Line::from(Span::styled(
-            "  Choose how to proceed:",
+            tr(self.locale, MessageId::ElevationPromptProceed),
             Style::default().fg(palette::TEXT_MUTED),
         )));
         lines.push(Line::from(""));
 
-        // Render options
         for (i, option) in self.request.options.iter().enumerate() {
             let is_selected = i == self.selected;
             let style = if is_selected {
@@ -1723,11 +1729,27 @@ impl Renderable for ElevationWidget<'_> {
                 Style::default()
             };
 
-            let key = match option {
-                ElevationOption::WithNetwork => "n",
-                ElevationOption::WithWriteAccess(_) => "w",
-                ElevationOption::FullAccess => "f",
-                ElevationOption::Abort => "a",
+            let (key, label_id, desc_id) = match option {
+                ElevationOption::WithNetwork => (
+                    "n",
+                    MessageId::ElevationOptionNetwork,
+                    MessageId::ElevationOptionNetworkDesc,
+                ),
+                ElevationOption::WithWriteAccess(_) => (
+                    "w",
+                    MessageId::ElevationOptionWrite,
+                    MessageId::ElevationOptionWriteDesc,
+                ),
+                ElevationOption::FullAccess => (
+                    "f",
+                    MessageId::ElevationOptionFullAccess,
+                    MessageId::ElevationOptionFullAccessDesc,
+                ),
+                ElevationOption::Abort => (
+                    "a",
+                    MessageId::ElevationOptionAbort,
+                    MessageId::ElevationOptionAbortDesc,
+                ),
             };
 
             let label_color = match option {
@@ -1742,18 +1764,18 @@ impl Renderable for ElevationWidget<'_> {
                     format!("[{key}] "),
                     Style::default().fg(palette::STATUS_SUCCESS),
                 ),
-                Span::styled(option.label(), style.fg(label_color)),
+                Span::styled(tr(self.locale, label_id), style.fg(label_color)),
             ]));
             lines.push(Line::from(vec![
                 Span::raw("      "),
                 Span::styled(
-                    option.description(),
+                    tr(self.locale, desc_id),
                     Style::default().fg(palette::TEXT_MUTED),
                 ),
             ]));
         }
 
-        let title = " Sandbox Elevation Required ";
+        let title = tr(self.locale, MessageId::ElevationTitleRequired);
         let block = Block::default()
             .title(title)
             .borders(Borders::ALL)


### PR DESCRIPTION
Migrates the sandbox elevation dialog (`ElevationWidget`/`ElevationView`) from hardcoded English strings to `MessageId`-based translations covering all 7 shipped locales (En, Ja, ZhHans, ZhHant, PtBr, Es419, Vi).

**Changes**
- `localization.rs`: 18 new `MessageId` variants for elevation titles, field labels, impact copy, option labels/descriptions — all 7 locale translations
- `widgets/mod.rs`: replaced all hardcoded English strings in `ElevationWidget::render()` with `tr()` calls; added `locale` field
- `approval.rs`: `ElevationView::new(request, locale)` with locale field, passes to widget
- `ui.rs`: passes `app.ui_locale` to `ElevationView::new()`

**Verification**
- `cargo check` — 0 warnings
- `cargo test -- elevation` — 13/13 pass (including zh locale + English leak detection)
- `cargo test -- approval` — 96/96 pass
- `cargo test -- localization` — 8/8 pass
- `cargo fmt` — clean

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Migrates the sandbox elevation dialog from hardcoded English strings to the existing `MessageId`/`tr()` localization system, covering all 7 shipped locales consistently.

- **`localization.rs`**: Adds 18 new `MessageId` variants (titles, field labels, impact lines, option labels/descriptions) with translations in En, Ja, ZhHans, ZhHant, PtBr, Es419, and Vi; each non-English locale uses an exhaustive `Some(match …)` block so a missing translation is a compile error.
- **`widgets/mod.rs` / `approval.rs` / `ui.rs`**: `ElevationWidget` and `ElevationView` gain a `locale: Locale` field; `app.ui_locale` is wired in at the one call-site; `label()` / `description()` are narrowed to `#[cfg(test)]`.
- New render smoke-tests cover En, ZhHans, Ja, and ZhHant with English-leak assertions; previously flagged coverage gaps for PtBr, Es419, and Vi remain open.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is purely additive (new MessageIds + tr() call-sites) with no behavioral changes to sandbox policy decisions, key bindings, or event routing.

The localization wiring is mechanical and low-risk: each non-English locale function uses an exhaustive match so a missing translation is a compile error rather than a silent fallback gap. The tr() fallback chain guarantees English output even if a locale entry is somehow absent at runtime. No logic, auth boundaries, or data paths are touched.

No files require special attention.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/tui/src/localization.rs | Adds 18 new MessageId variants for the elevation dialog and corresponding translations in all 7 locales; all variants registered in ALL_MESSAGE_IDS; each non-English locale uses an exhaustive Some(match) block, so missing entries would be a compile error. |
| crates/tui/src/tui/approval.rs | ElevationView gains a locale field threaded through new(); label() and description() restricted to #[cfg(test)]; new render smoke-tests for En, ZhHans, Ja, and ZhHant added. |
| crates/tui/src/tui/widgets/mod.rs | ElevationWidget gains a locale field; all hardcoded English strings replaced with tr() calls using the new MessageIds; pre-existing approval-widget helpers (option_abort etc.) are unaffected and still used. |
| crates/tui/src/tui/ui.rs | Single call-site updated to pass app.ui_locale to ElevationView::new(); Locale is Copy so no ownership issue. |
| .gitignore | Adds .claude/settings.json to gitignore alongside the existing .claude/ runtime artifact entries. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as ui.rs (run_event_loop)
    participant AV as ElevationView (approval.rs)
    participant EW as ElevationWidget (widgets/mod.rs)
    participant LOC as tr() / localization.rs

    UI->>AV: ElevationView::new(request, app.ui_locale)
    AV->>EW: "ElevationWidget::new(&request, selected, locale)"
    EW->>LOC: tr(locale, ElevationTitleSandboxDenied)
    LOC-->>EW: "&'static str (locale-specific or En fallback)"
    EW->>LOC: tr(locale, ElevationFieldTool / Cmd / Reason)
    LOC-->>EW: "&'static str"
    EW->>LOC: tr(locale, ElevationOptionNetwork / Write / FullAccess / Abort)
    LOC-->>EW: "&'static str"
    EW-->>AV: rendered ratatui Buffer
    AV-->>UI: displayed dialog
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `crates/tui/src/tui/approval.rs`, line 718-743 ([link](https://github.com/hmbown/codewhale/blob/56fd9195819a97a0649317a1b7c49ad01cc93d91/crates/tui/src/tui/approval.rs#L718-L743)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Hardcoded English methods left alive as maintenance traps**

   `label()` and `description()` now return hardcoded English strings identical to the English locale translations in `localization.rs`, but are no longer called by the widget. Rather than being removed, they're silenced with `#[allow(dead_code)]`. If any future call site (CLI output, accessibility layer, snapshot test, or log message) uses these methods instead of `tr()`, it will silently produce English-only output for all locales. The `#[allow(dead_code)]` suppression hides the signal that would otherwise prompt a developer to investigate why these exist alongside the `tr()` path.

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fi18n-elevation%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fi18n-elevation%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fapproval.rs%0ALine%3A%20718-743%0A%0AComment%3A%0A**Hardcoded%20English%20methods%20left%20alive%20as%20maintenance%20traps**%0A%0A%60label%28%29%60%20and%20%60description%28%29%60%20now%20return%20hardcoded%20English%20strings%20identical%20to%20the%20English%20locale%20translations%20in%20%60localization.rs%60%2C%20but%20are%20no%20longer%20called%20by%20the%20widget.%20Rather%20than%20being%20removed%2C%20they're%20silenced%20with%20%60%23%5Ballow%28dead_code%29%5D%60.%20If%20any%20future%20call%20site%20%28CLI%20output%2C%20accessibility%20layer%2C%20snapshot%20test%2C%20or%20log%20message%29%20uses%20these%20methods%20instead%20of%20%60tr%28%29%60%2C%20it%20will%20silently%20produce%20English-only%20output%20for%20all%20locales.%20The%20%60%23%5Ballow%28dead_code%29%5D%60%20suppression%20hides%20the%20signal%20that%20would%20otherwise%20prompt%20a%20developer%20to%20investigate%20why%20these%20exist%20alongside%20the%20%60tr%28%29%60%20path.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2892&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fapproval.rs%0ALine%3A%20718-743%0A%0AComment%3A%0A**Hardcoded%20English%20methods%20left%20alive%20as%20maintenance%20traps**%0A%0A%60label%28%29%60%20and%20%60description%28%29%60%20now%20return%20hardcoded%20English%20strings%20identical%20to%20the%20English%20locale%20translations%20in%20%60localization.rs%60%2C%20but%20are%20no%20longer%20called%20by%20the%20widget.%20Rather%20than%20being%20removed%2C%20they're%20silenced%20with%20%60%23%5Ballow%28dead_code%29%5D%60.%20If%20any%20future%20call%20site%20%28CLI%20output%2C%20accessibility%20layer%2C%20snapshot%20test%2C%20or%20log%20message%29%20uses%20these%20methods%20instead%20of%20%60tr%28%29%60%2C%20it%20will%20silently%20produce%20English-only%20output%20for%20all%20locales.%20The%20%60%23%5Ballow%28dead_code%29%5D%60%20suppression%20hides%20the%20signal%20that%20would%20otherwise%20prompt%20a%20developer%20to%20investigate%20why%20these%20exist%20alongside%20the%20%60tr%28%29%60%20path.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2892&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fapproval.rs%0ALine%3A%20718-743%0A%0AComment%3A%0A**Hardcoded%20English%20methods%20left%20alive%20as%20maintenance%20traps**%0A%0A%60label%28%29%60%20and%20%60description%28%29%60%20now%20return%20hardcoded%20English%20strings%20identical%20to%20the%20English%20locale%20translations%20in%20%60localization.rs%60%2C%20but%20are%20no%20longer%20called%20by%20the%20widget.%20Rather%20than%20being%20removed%2C%20they're%20silenced%20with%20%60%23%5Ballow%28dead_code%29%5D%60.%20If%20any%20future%20call%20site%20%28CLI%20output%2C%20accessibility%20layer%2C%20snapshot%20test%2C%20or%20log%20message%29%20uses%20these%20methods%20instead%20of%20%60tr%28%29%60%2C%20it%20will%20silently%20produce%20English-only%20output%20for%20all%20locales.%20The%20%60%23%5Ballow%28dead_code%29%5D%60%20suppression%20hides%20the%20signal%20that%20would%20otherwise%20prompt%20a%20developer%20to%20investigate%20why%20these%20exist%20alongside%20the%20%60tr%28%29%60%20path.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2892&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

2. `crates/tui/src/tui/approval.rs`, line 1461-1511 ([link](https://github.com/hmbown/codewhale/blob/56fd9195819a97a0649317a1b7c49ad01cc93d91/crates/tui/src/tui/approval.rs#L1461-L1511)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Locale test coverage limited to En and ZhHans; option-label English leaks untested**

   The new render tests cover English and Simplified Chinese, but the five remaining locales (Ja, ZhHant, PtBr, Es419, Vi) have no render smoke-test. Additionally, the `en_artifacts` leak list in `test_elevation_render_zh_hans_localizes_copy` checks structural labels but omits option-label leaks like `"Allowoutboundnetwork"`, `"Fullaccess"`, `"Allowextrawriteaccess"`, and `"Abort"` — so an untranslated option label would pass the test undetected.

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hmbown%2Fcodewhale%22%20on%20the%20existing%20branch%20%22feat%2Fi18n-elevation%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fi18n-elevation%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fapproval.rs%0ALine%3A%201461-1511%0A%0AComment%3A%0A**Locale%20test%20coverage%20limited%20to%20En%20and%20ZhHans%3B%20option-label%20English%20leaks%20untested**%0A%0AThe%20new%20render%20tests%20cover%20English%20and%20Simplified%20Chinese%2C%20but%20the%20five%20remaining%20locales%20%28Ja%2C%20ZhHant%2C%20PtBr%2C%20Es419%2C%20Vi%29%20have%20no%20render%20smoke-test.%20Additionally%2C%20the%20%60en_artifacts%60%20leak%20list%20in%20%60test_elevation_render_zh_hans_localizes_copy%60%20checks%20structural%20labels%20but%20omits%20option-label%20leaks%20like%20%60%22Allowoutboundnetwork%22%60%2C%20%60%22Fullaccess%22%60%2C%20%60%22Allowextrawriteaccess%22%60%2C%20and%20%60%22Abort%22%60%20%E2%80%94%20so%20an%20untranslated%20option%20label%20would%20pass%20the%20test%20undetected.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2892&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fapproval.rs%0ALine%3A%201461-1511%0A%0AComment%3A%0A**Locale%20test%20coverage%20limited%20to%20En%20and%20ZhHans%3B%20option-label%20English%20leaks%20untested**%0A%0AThe%20new%20render%20tests%20cover%20English%20and%20Simplified%20Chinese%2C%20but%20the%20five%20remaining%20locales%20%28Ja%2C%20ZhHant%2C%20PtBr%2C%20Es419%2C%20Vi%29%20have%20no%20render%20smoke-test.%20Additionally%2C%20the%20%60en_artifacts%60%20leak%20list%20in%20%60test_elevation_render_zh_hans_localizes_copy%60%20checks%20structural%20labels%20but%20omits%20option-label%20leaks%20like%20%60%22Allowoutboundnetwork%22%60%2C%20%60%22Fullaccess%22%60%2C%20%60%22Allowextrawriteaccess%22%60%2C%20and%20%60%22Abort%22%60%20%E2%80%94%20so%20an%20untranslated%20option%20label%20would%20pass%20the%20test%20undetected.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=hmbown%2Fcodewhale&pr=2892&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftui%2Fsrc%2Ftui%2Fapproval.rs%0ALine%3A%201461-1511%0A%0AComment%3A%0A**Locale%20test%20coverage%20limited%20to%20En%20and%20ZhHans%3B%20option-label%20English%20leaks%20untested**%0A%0AThe%20new%20render%20tests%20cover%20English%20and%20Simplified%20Chinese%2C%20but%20the%20five%20remaining%20locales%20%28Ja%2C%20ZhHant%2C%20PtBr%2C%20Es419%2C%20Vi%29%20have%20no%20render%20smoke-test.%20Additionally%2C%20the%20%60en_artifacts%60%20leak%20list%20in%20%60test_elevation_render_zh_hans_localizes_copy%60%20checks%20structural%20labels%20but%20omits%20option-label%20leaks%20like%20%60%22Allowoutboundnetwork%22%60%2C%20%60%22Fullaccess%22%60%2C%20%60%22Allowextrawriteaccess%22%60%2C%20and%20%60%22Abort%22%60%20%E2%80%94%20so%20an%20untranslated%20option%20label%20would%20pass%20the%20test%20undetected.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2892&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix: address review feedback - cfg(test)..."](https://github.com/hmbown/codewhale/commit/0e4dbc56338183904fc322f0d3b13a1c2d57e7e3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36128518)</sub>

<!-- /greptile_comment -->