### PR TITLE
docs: map contribution gate implementation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,6 +189,15 @@ The allowlist is scoped:
 - `issue:username` allows issues.
 - `all:username` allows both.
 
+The implementation lives in a few reviewable pieces:
+
+| Gate piece | Source |
+| --- | --- |
+| Pull request gate | `.github/workflows/pr-gate.yml` |
+| Issue gate | `.github/workflows/issue-gate.yml` |
+| Maintainer approval flow | `.github/workflows/approve-contributor.yml` |
+| Scoped allowlist | `.github/APPROVED_CONTRIBUTORS` |
+
 A maintainer can approve someone by commenting `/lgtm` on a pull request for PR
 access, or `/lgtmi` on an issue for issue access. The exact bare commands
 `lgtm` and `lgtmi` are also accepted for compatibility, but the prefixed forms


### PR DESCRIPTION
Summary:
- Add a compact implementation map for the contribution gate docs.
- Link the documented gate pieces to the PR gate, issue gate, approval workflow, and scoped allowlist files.

Scope:
- Docs only; no workflow behavior changes.

Issues:
- Helps with #2890 by making the current implementation evidence explicit in CONTRIBUTING.md.

Validation:
- Verified #2890 is open before coding.
- Searched open PRs for a direct duplicate of the contribution gate allowlist follow-up and found none.
- Ran git diff --check.
- cargo fmt/clippy/test were not run because cargo is not available in this local environment; this change only touches CONTRIBUTING.md.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a small reference table to the contribution gate section of `CONTRIBUTING.md`, mapping each gate piece to its source file. All four referenced paths (`.github/workflows/pr-gate.yml`, `issue-gate.yml`, `approve-contributor.yml`, and `.github/APPROVED_CONTRIBUTORS`) exist in the repository.

- Inserts a Markdown table under the allowlist scoping rules pointing readers to the PR gate, issue gate, approval workflow, and allowlist files.
- No workflow behavior is changed; the diff touches only documentation prose.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Docs-only change that adds a reference table; no code or workflow behavior is modified.

The four file paths in the new table all resolve to real files in the repository, the surrounding prose is unchanged, and nothing executable is touched. The change does exactly what it says.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| CONTRIBUTING.md | Adds a four-row reference table linking the documented contribution gate to its actual workflow files; all four referenced paths exist in the repository. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[External Contributor opens PR or Issue] --> B{Gate workflow fires}
    B --> C[pr-gate.yml\n.github/workflows/pr-gate.yml]
    B --> D[issue-gate.yml\n.github/workflows/issue-gate.yml]
    C --> E{Contributor in\nAPPROVED_CONTRIBUTORS?}
    D --> E
    E -- Yes --> F[Contribution remains open]
    E -- No --> G[Dry-run: thank-you comment\nEnforce: close]
    G --> H[Maintainer comments /lgtm or /lgtmi]
    H --> I[approve-contributor.yml\n.github/workflows/approve-contributor.yml]
    I --> J[Opens allowlist-update PR\n.github/APPROVED_CONTRIBUTORS]
    J --> K[Maintainer merges allowlist PR]
    K --> F
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: map contribution gate implementati..."](https://github.com/hmbown/codewhale/commit/9e0a987eb56c52f02d5091ea22d7d2f3f63c784d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36154761)</sub>

<!-- /greptile_comment -->