### PR TITLE
fix(tui): name allow_shell blocker for shell tools

### DIFF
--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -3244,6 +3244,10 @@ fn missing_shell_tool_error_message_names_allow_shell_gate() {
     ] {
         let message = missing_tool_error_message(tool_name, &catalog);
         assert!(message.contains("not available in the current tool catalog"));
+        assert!(
+            message.contains("allow_shell = false"),
+            "{tool_name}: {message}"
+        );
         assert!(message.contains("allow_shell"), "{tool_name}: {message}");
         assert!(
             message.contains("/config allow_shell true"),
@@ -3272,6 +3276,7 @@ fn missing_shell_tool_error_message_keeps_allow_shell_hint_with_suggestions() {
 
     assert!(message.contains("Did you mean:"));
     assert!(message.contains("exec"));
+    assert!(message.contains("allow_shell = false"));
     assert!(message.contains("allow_shell"));
     assert!(message.contains("/config allow_shell true"));
     assert!(message.contains("--save"));

--- a/crates/tui/src/core/engine/tool_catalog.rs
+++ b/crates/tui/src/core/engine/tool_catalog.rs
@@ -544,7 +544,8 @@ pub(super) fn missing_tool_error_message(tool_name: &str, catalog: &[Tool]) -> S
 }
 
 fn shell_tool_allow_shell_hint() -> &'static str {
-    "Shell tools require top-level `allow_shell = true`. \
+    "Shell tools are disabled because top-level `allow_shell = false`; \
+     they require `allow_shell = true`. \
      In Agent mode, run `/config allow_shell true` for this session or add `--save` \
      for future sessions; the next turn will expose shell with approval gating"
 }


### PR DESCRIPTION
## Summary

- Clarify the missing-tool diagnostic for shell tools when `allow_shell` is disabled.
- Keep the existing `/config allow_shell true` and `--save` guidance, but name the current `allow_shell = false` blocker directly.
- Add regression coverage for both exact shell-tool names and suggestion-based missing-tool output.

## Verification

- `CARGO_TARGET_DIR=/tmp/codewhale-2657-final-target cargo test -p codewhale-tui missing_shell_tool_error_message -j1`
- `cargo fmt --check`
- `git diff --check HEAD^..HEAD`
