### PR TITLE
fix(cli): allow Volcengine provider in TUI dispatcher

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1605,6 +1605,7 @@ fn build_tui_command(
             | ProviderKind::Openai
             | ProviderKind::Atlascloud
             | ProviderKind::WanjieArk
+            | ProviderKind::Volcengine
             | ProviderKind::Openrouter
             | ProviderKind::XiaomiMimo
             | ProviderKind::Novita
@@ -1617,7 +1618,7 @@ fn build_tui_command(
             | ProviderKind::Ollama
     ) {
         bail!(
-            "The interactive TUI supports DeepSeek, NVIDIA NIM, OpenAI-compatible, AtlasCloud, Wanjie Ark, OpenRouter, Xiaomi MiMo, Novita, Fireworks, SiliconFlow, Arcee AI, Moonshot/Kimi, SGLang, vLLM, and Ollama providers. Remove --provider {} or use `codewhale model ...` for provider registry inspection.",
+            "The interactive TUI supports DeepSeek, NVIDIA NIM, OpenAI-compatible, AtlasCloud, Wanjie Ark, Volcengine Ark, OpenRouter, Xiaomi MiMo, Novita, Fireworks, SiliconFlow, Arcee AI, Moonshot/Kimi, SGLang, vLLM, and Ollama providers. Remove --provider {} or use `codewhale model ...` for provider registry inspection.",
             resolved_runtime.provider.as_str()
         );
     }
@@ -3123,6 +3124,70 @@ mod tests {
             Some("keyring")
         );
         assert_eq!(command_env(&cmd, "DEEPSEEK_AUTH_MODE"), None);
+    }
+
+    #[test]
+    fn build_tui_command_allows_volcengine_and_forwards_ark_keys() {
+        let _lock = env_lock();
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let custom = dir
+            .path()
+            .join(format!("custom-tui{}", std::env::consts::EXE_SUFFIX));
+        std::fs::write(&custom, b"").unwrap();
+        let custom_str = custom.to_string_lossy().into_owned();
+        let _bin = ScopedEnvVar::set("DEEPSEEK_TUI_BIN", &custom_str);
+
+        let cli = parse_ok(&[
+            "codewhale",
+            "--provider",
+            "volcengine",
+            "--model",
+            "DeepSeek-V4-Pro",
+            "--workspace",
+            "/tmp/codewhale-workspace",
+        ]);
+        let resolved = ResolvedRuntimeOptions {
+            provider: ProviderKind::Volcengine,
+            model: "DeepSeek-V4-Pro".to_string(),
+            api_key: Some("resolved-ark-key".to_string()),
+            api_key_source: Some(RuntimeApiKeySource::Keyring),
+            base_url: "https://ark.cn-beijing.volces.com/api/coding/v3".to_string(),
+            auth_mode: Some("api_key".to_string()),
+            insecure_skip_tls_verify: false,
+            output_mode: None,
+            log_level: None,
+            telemetry: false,
+            approval_policy: None,
+            sandbox_mode: None,
+            yolo: None,
+            http_headers: std::collections::BTreeMap::new(),
+        };
+
+        let cmd = build_tui_command(&cli, &resolved, Vec::new()).expect("command");
+        assert_eq!(
+            command_env(&cmd, "DEEPSEEK_PROVIDER").as_deref(),
+            Some("volcengine")
+        );
+        assert_eq!(
+            command_env(&cmd, "DEEPSEEK_MODEL").as_deref(),
+            Some("DeepSeek-V4-Pro")
+        );
+        assert_eq!(
+            command_env(&cmd, "DEEPSEEK_API_KEY").as_deref(),
+            Some("resolved-ark-key")
+        );
+        assert_eq!(
+            command_env(&cmd, "VOLCENGINE_API_KEY").as_deref(),
+            Some("resolved-ark-key")
+        );
+        assert_eq!(
+            command_env(&cmd, "VOLCENGINE_ARK_API_KEY").as_deref(),
+            Some("resolved-ark-key")
+        );
+        assert_eq!(
+            command_env(&cmd, "ARK_API_KEY").as_deref(),
+            Some("resolved-ark-key")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- allow the CLI dispatcher to launch the interactive TUI with the Volcengine provider
- update the unsupported-provider error message to list Volcengine Ark
- add regression coverage that Volcengine forwards Ark-compatible API key env vars to the TUI

## Test Plan
- cargo fmt --check
- cargo test -p codewhale-cli volcengine -- --nocapture
- cargo test -p codewhale-cli