### PR TITLE
feat(config): prefer dispatcher-provided API key over saved root key when source is cli

### DIFF
--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -2518,6 +2518,20 @@ impl Config {
         // 0. DeepSeek compatibility slot. The legacy top-level `api_key`
         // belongs to DeepSeek only; provider-specific keys below must win for
         // NIM/OpenRouter/etc. so a stale DeepSeek key is not sent elsewhere.
+        //
+        // However, when the CLI dispatcher forwards an explicit `--api-key`
+        // through `DEEPSEEK_API_KEY` with the dispatcher source marker, that
+        // intentional override must win over the saved root key. This is
+        // essential for DeepSeek-compatible subscription endpoints where the
+        // user runs something like:
+        //   codewhale --provider deepseek --api-key ark-... --base-url ... --model auto
+        if matches!(provider, ApiProvider::Deepseek | ApiProvider::DeepseekCN)
+            && std::env::var("DEEPSEEK_API_KEY_SOURCE").as_deref() == Ok("cli")
+            && let Some(env_key) = codewhale_secrets::env_for("deepseek")
+            && !env_key.trim().is_empty()
+        {
+            return Ok(env_key);
+        }
         if matches!(provider, ApiProvider::Deepseek | ApiProvider::DeepseekCN)
             && let Some(configured) = self.api_key.as_ref()
             && !configured.trim().is_empty()
@@ -7002,7 +7016,7 @@ action = "session.compact"
         // Env var path.
         let env_cfg = Config::default();
         unsafe {
-            std::env::set_var("DEEPSEEK_API_KEY", "sk-test-from-env");
+            std::env::set_var("DEEPSEEK_API_KEY", "env-key");
         }
         assert!(
             has_api_key(&env_cfg),
@@ -7010,6 +7024,31 @@ action = "session.compact"
         );
         unsafe {
             std::env::remove_var("DEEPSEEK_API_KEY");
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn deepseek_dispatcher_env_key_overrides_config_key() -> Result<()> {
+        let _lock = lock_test_env();
+        let prev_source = std::env::var_os("DEEPSEEK_API_KEY_SOURCE");
+        unsafe {
+            std::env::set_var("DEEPSEEK_API_KEY", "ark-dispatcher-key");
+            std::env::set_var("DEEPSEEK_API_KEY_SOURCE", "cli");
+        }
+        let config = Config {
+            api_key: Some("saved-deepseek-key".to_string()),
+            ..Default::default()
+        };
+
+        assert_eq!(config.deepseek_api_key()?, "ark-dispatcher-key");
+
+        unsafe {
+            std::env::remove_var("DEEPSEEK_API_KEY");
+            match prev_source {
+                Some(value) => std::env::set_var("DEEPSEEK_API_KEY_SOURCE", value),
+                None => std::env::remove_var("DEEPSEEK_API_KEY_SOURCE"),
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary
When the CLI dispatcher launches the interactive TUI with an explicit `--api-key` argument (e.g. for a DeepSeek-compatible subscription endpoint like Volcengine Ark), the environment variable `DEEPSEEK_API_KEY` carries the intended key together with a dispatcher source marker. Previously the saved root `api_key` in config.toml always won over this env override for the DeepSeek provider, blocking the standard Completions API path from working with third-party endpoints.

This PR adds a short-circuit check at priority 0 in `Config::deepseek_api_key()` that returns the env key when the dispatcher sent it explicitly, keeping full backward compatibility for normal config-file or keyring paths.

## Test Plan
- New unit test: `deepseek_dispatcher_env_key_overrides_config_key`
- `cargo test -p codewhale-tui --bin codewhale-tui deepseek_dispatcher_env -- --nocapture`
- `cargo test -p codewhale-tui --bin codewhale-tui deepseek_api_key` — 5 tests pass
- `cargo build -p codewhale-cli -p codewhale-tui`
- Real smoke test with built binaries:
  ```bash
  codewhale --provider deepseek \
    --base-url https://ark.cn-beijing.volces.com/api/plan/v3 \
    --api-key <ark-key> \
    --model deepseek-v4-flash \
    exec '只回复 OK'
  # Output: OK.
  ```

Note: full `cargo test -p codewhale-tui --bin codewhale-tui -- --quiet` currently has 9 unrelated `project_context` failures in this environment caused by `/tmp/.deepseek/instructions.md` global-context path pollution; the new config tests and real smoke test pass.
