### PR TITLE
feat(model): complete Qwen 3.6 Plus support with dedicated tests (#2908)

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -5883,6 +5883,41 @@ mode = "token-plan-usa"
     }
 
     #[test]
+    #[test]
+    fn qwen3_6_plus_resolves_to_canonical_on_openrouter() {
+        let _lock = env_lock();
+        let _env = EnvGuard::without_deepseek_runtime_overrides();
+        let config = ConfigToml {
+            provider: ProviderKind::Openrouter,
+            ..ConfigToml::default()
+        };
+
+        let resolved = config.resolve_runtime_options(&CliRuntimeOverrides {
+            model: Some("qwen3.6-plus".to_string()),
+            ..CliRuntimeOverrides::default()
+        });
+
+        assert_eq!(resolved.provider, ProviderKind::Openrouter);
+        assert_eq!(resolved.model, OPENROUTER_QWEN_3_6_PLUS_MODEL);
+    }
+
+    #[test]
+    fn qwen3_6_plus_alias_qwen_dash_resolves() {
+        let _lock = env_lock();
+        let _env = EnvGuard::without_deepseek_runtime_overrides();
+        let config = ConfigToml {
+            provider: ProviderKind::Openrouter,
+            ..ConfigToml::default()
+        };
+
+        let resolved = config.resolve_runtime_options(&CliRuntimeOverrides {
+            model: Some("qwen-3.6-plus".to_string()),
+            ..CliRuntimeOverrides::default()
+        });
+
+        assert_eq!(resolved.model, OPENROUTER_QWEN_3_6_PLUS_MODEL);
+    }
+
     fn openrouter_provider_normalizes_recent_large_model_aliases() {
         let _lock = env_lock();
         let _env = EnvGuard::without_deepseek_runtime_overrides();

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -5883,7 +5883,6 @@ mode = "token-plan-usa"
     }
 
     #[test]
-    #[test]
     fn qwen3_6_plus_resolves_to_canonical_on_openrouter() {
         let _lock = env_lock();
         let _env = EnvGuard::without_deepseek_runtime_overrides();
@@ -5918,6 +5917,7 @@ mode = "token-plan-usa"
         assert_eq!(resolved.model, OPENROUTER_QWEN_3_6_PLUS_MODEL);
     }
 
+    #[test]
     fn openrouter_provider_normalizes_recent_large_model_aliases() {
         let _lock = env_lock();
         let _env = EnvGuard::without_deepseek_runtime_overrides();


### PR DESCRIPTION
Qwen 3.6 Plus already had full catalog/resolver/picker support. Add dedicated provider-hinted resolution tests to close the remaining gap.

Close https://github.com/Hmbown/CodeWhale/issues/2908

- Add qwen3_6_plus_resolves_to_canonical_on_openrouter test
- Add qwen3_6_plus_alias_qwen_dash_resolves test
- Both verify /model qwen3.6-plus resolves to qwen/qwen3.6-plus on OpenRouter

## Summary

## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address
