### PR TITLE
i18n: localize mode-picker messages

### DIFF
--- a/crates/tui/src/localization.rs
+++ b/crates/tui/src/localization.rs
@@ -2038,7 +2038,7 @@ fn vietnamese(id: MessageId) -> Option<&'static str> {
         MessageId::ModePickerInstruction => "Chọn cách CodeWhale vận hành:",
         MessageId::ModePickerAgentHint => "Thực thi bình thường với phê duyệt",
         MessageId::ModePickerPlanHint => "Lập kế hoạch trước khi thực thi",
-        MessageId::ModePickerYoloHint => "Tự động phê duyệt; bật shell",
+        MessageId::ModePickerYoloHint => "Tự động duyệt; bật shell",
         MessageId::ModePickerFooterMove => "di chuyển ",
         MessageId::ModePickerFooterSelect => "chọn ",
         MessageId::ModePickerFooterCancel => "hủy ",
@@ -3487,10 +3487,10 @@ fn portuguese_brazil(id: MessageId) -> Option<&'static str> {
         MessageId::ModePickerInstruction => "Escolha como o CodeWhale deve operar:",
         MessageId::ModePickerAgentHint => "Execução normal com aprovações",
         MessageId::ModePickerPlanHint => "Planejar antes de executar",
-        MessageId::ModePickerYoloHint => "Aprovação automática; shell ativado",
+        MessageId::ModePickerYoloHint => "Auto-aprovar; shell ativo",
         MessageId::ModePickerFooterMove => "mover ",
-        MessageId::ModePickerFooterSelect => "selecionar ",
-        MessageId::ModePickerFooterCancel => "cancelar ",
+        MessageId::ModePickerFooterSelect => "escolher ",
+        MessageId::ModePickerFooterCancel => "sair ",
     })
 }
 
@@ -3991,10 +3991,10 @@ fn spanish_latin_america(id: MessageId) -> Option<&'static str> {
         MessageId::ModePickerInstruction => "Elige cómo debe operar CodeWhale:",
         MessageId::ModePickerAgentHint => "Ejecución normal con aprobaciones",
         MessageId::ModePickerPlanHint => "Planificar antes de ejecutar",
-        MessageId::ModePickerYoloHint => "Aprobación automática; shell habilitado",
+        MessageId::ModePickerYoloHint => "Auto-aprobar; shell activo",
         MessageId::ModePickerFooterMove => "mover ",
-        MessageId::ModePickerFooterSelect => "seleccionar ",
-        MessageId::ModePickerFooterCancel => "cancelar ",
+        MessageId::ModePickerFooterSelect => "elegir ",
+        MessageId::ModePickerFooterCancel => "volver ",
     })
 }
 

--- a/crates/tui/src/localization.rs
+++ b/crates/tui/src/localization.rs
@@ -550,6 +550,15 @@ pub enum MessageId {
     CtxInspChangesByTurn,
     CtxInspStablePrefixOnly,
     CtxInspCacheTip,
+    // Mode picker.
+    ModePickerTitle,
+    ModePickerInstruction,
+    ModePickerAgentHint,
+    ModePickerPlanHint,
+    ModePickerYoloHint,
+    ModePickerFooterMove,
+    ModePickerFooterSelect,
+    ModePickerFooterCancel,
 }
 
 #[allow(dead_code)]
@@ -874,6 +883,14 @@ pub const ALL_MESSAGE_IDS: &[MessageId] = &[
     MessageId::CtxInspChangesByTurn,
     MessageId::CtxInspStablePrefixOnly,
     MessageId::CtxInspCacheTip,
+    MessageId::ModePickerTitle,
+    MessageId::ModePickerInstruction,
+    MessageId::ModePickerAgentHint,
+    MessageId::ModePickerPlanHint,
+    MessageId::ModePickerYoloHint,
+    MessageId::ModePickerFooterMove,
+    MessageId::ModePickerFooterSelect,
+    MessageId::ModePickerFooterCancel,
 ];
 
 pub fn tr(locale: Locale, id: MessageId) -> &'static str {
@@ -1509,6 +1526,14 @@ fn english(id: MessageId) -> &'static str {
             "Tip: Stable prefix blocks are DeepSeek V4 prefix-cache eligible. \
             Volatile working-set changes break the cache only for the tail."
         }
+        MessageId::ModePickerTitle => " Mode ",
+        MessageId::ModePickerInstruction => "Choose how CodeWhale should operate:",
+        MessageId::ModePickerAgentHint => "Normal execution with approvals",
+        MessageId::ModePickerPlanHint => "Plan first before execution",
+        MessageId::ModePickerYoloHint => "Auto-approve; shell enabled",
+        MessageId::ModePickerFooterMove => "move ",
+        MessageId::ModePickerFooterSelect => "select ",
+        MessageId::ModePickerFooterCancel => "cancel ",
     }
 }
 
@@ -2009,6 +2034,14 @@ fn vietnamese(id: MessageId) -> Option<&'static str> {
         MessageId::CtxInspCacheTip => {
             "Gợi ý: Các khối ổn định đủ điều kiện cho bộ nhớ đệm tiền tố DeepSeek V4. Thay đổi vùng làm việc chỉ phá vỡ bộ nhớ đệm ở phần cuối."
         }
+        MessageId::ModePickerTitle => " Chế độ ",
+        MessageId::ModePickerInstruction => "Chọn cách CodeWhale vận hành:",
+        MessageId::ModePickerAgentHint => "Thực thi bình thường với phê duyệt",
+        MessageId::ModePickerPlanHint => "Lập kế hoạch trước khi thực thi",
+        MessageId::ModePickerYoloHint => "Tự động phê duyệt; bật shell",
+        MessageId::ModePickerFooterMove => "di chuyển ",
+        MessageId::ModePickerFooterSelect => "chọn ",
+        MessageId::ModePickerFooterCancel => "hủy ",
     })
 }
 
@@ -2073,6 +2106,14 @@ fn traditional_chinese(id: MessageId) -> Option<&'static str> {
         MessageId::CtxInspCacheTip => {
             "提示：穩定前綴區塊符合 DeepSeek V4 前綴快取條件。易變工作集的更改僅會破壞快取尾部。"
         }
+        MessageId::ModePickerTitle => " 模式 ",
+        MessageId::ModePickerInstruction => "選擇 CodeWhale 的運作方式：",
+        MessageId::ModePickerAgentHint => "一般執行，需經核准",
+        MessageId::ModePickerPlanHint => "先規劃再執行",
+        MessageId::ModePickerYoloHint => "自動核准；啟用 Shell",
+        MessageId::ModePickerFooterMove => "移動 ",
+        MessageId::ModePickerFooterSelect => "選擇 ",
+        MessageId::ModePickerFooterCancel => "取消 ",
         other => chinese_simplified(other)?,
     })
 }
@@ -2536,6 +2577,14 @@ fn japanese(id: MessageId) -> Option<&'static str> {
         MessageId::CtxInspCacheTip => {
             "ヒント：安定プレフィックスブロックはDeepSeek V4プレフィックスキャッシュの対象です。揮発性ワーキングセットの変更は末尾のキャッシュのみを破壊します。"
         }
+        MessageId::ModePickerTitle => " モード ",
+        MessageId::ModePickerInstruction => "CodeWhale の動作モードを選択：",
+        MessageId::ModePickerAgentHint => "承認付きの通常実行",
+        MessageId::ModePickerPlanHint => "実行前に計画を立てる",
+        MessageId::ModePickerYoloHint => "自動承認；シェル有効",
+        MessageId::ModePickerFooterMove => "移動 ",
+        MessageId::ModePickerFooterSelect => "選択 ",
+        MessageId::ModePickerFooterCancel => "キャンセル ",
     })
 }
 
@@ -2940,6 +2989,14 @@ fn chinese_simplified(id: MessageId) -> Option<&'static str> {
         MessageId::CtxInspCacheTip => {
             "提示：稳定前缀区块符合 DeepSeek V4 前缀缓存条件。易变工作集的更改仅会破坏缓存尾部。"
         }
+        MessageId::ModePickerTitle => " 模式 ",
+        MessageId::ModePickerInstruction => "选择 CodeWhale 的运行方式：",
+        MessageId::ModePickerAgentHint => "正常执行，需要批准",
+        MessageId::ModePickerPlanHint => "先计划再执行",
+        MessageId::ModePickerYoloHint => "自动批准；启用 Shell",
+        MessageId::ModePickerFooterMove => "移动 ",
+        MessageId::ModePickerFooterSelect => "选择 ",
+        MessageId::ModePickerFooterCancel => "取消 ",
     })
 }
 
@@ -3426,6 +3483,14 @@ fn portuguese_brazil(id: MessageId) -> Option<&'static str> {
         MessageId::CtxInspCacheTip => {
             "Dica: Blocos de prefixo estável são elegíveis para cache de prefixo DeepSeek V4. Alterações no conjunto de trabalho volátil quebram o cache apenas no final."
         }
+        MessageId::ModePickerTitle => " Modo ",
+        MessageId::ModePickerInstruction => "Escolha como o CodeWhale deve operar:",
+        MessageId::ModePickerAgentHint => "Execução normal com aprovações",
+        MessageId::ModePickerPlanHint => "Planejar antes de executar",
+        MessageId::ModePickerYoloHint => "Aprovação automática; shell ativado",
+        MessageId::ModePickerFooterMove => "mover ",
+        MessageId::ModePickerFooterSelect => "selecionar ",
+        MessageId::ModePickerFooterCancel => "cancelar ",
     })
 }
 
@@ -3922,6 +3987,14 @@ fn spanish_latin_america(id: MessageId) -> Option<&'static str> {
         MessageId::CtxInspCacheTip => {
             "Consejo: Los bloques de prefijo estable son elegibles para caché de prefijo DeepSeek V4. Los cambios en el conjunto de trabajo volátil solo rompen la caché al final."
         }
+        MessageId::ModePickerTitle => " Modo ",
+        MessageId::ModePickerInstruction => "Elige cómo debe operar CodeWhale:",
+        MessageId::ModePickerAgentHint => "Ejecución normal con aprobaciones",
+        MessageId::ModePickerPlanHint => "Planificar antes de ejecutar",
+        MessageId::ModePickerYoloHint => "Aprobación automática; shell habilitado",
+        MessageId::ModePickerFooterMove => "mover ",
+        MessageId::ModePickerFooterSelect => "seleccionar ",
+        MessageId::ModePickerFooterCancel => "cancelar ",
     })
 }
 

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -6254,6 +6254,7 @@ async fn apply_command_result(
                     app.view_stack
                         .push(crate::tui::views::mode_picker::ModePickerView::new(
                             app.mode,
+                            app.ui_locale,
                         ));
                 }
             }

--- a/crates/tui/src/tui/views/mode_picker.rs
+++ b/crates/tui/src/tui/views/mode_picker.rs
@@ -1,5 +1,3 @@
-//! `/mode` picker for Agent / Plan / YOLO.
-
 use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::{
     buffer::Buffer,
@@ -9,6 +7,7 @@ use ratatui::{
     widgets::{Block, Borders, Clear, Padding, Paragraph, Widget},
 };
 
+use crate::localization::{Locale, MessageId, tr};
 use crate::palette;
 use crate::tui::app::AppMode;
 use crate::tui::views::{ModalKind, ModalView, ViewAction, ViewEvent};
@@ -17,43 +16,44 @@ use crate::tui::views::{ModalKind, ModalView, ViewAction, ViewEvent};
 struct ModeRow {
     mode: AppMode,
     number: char,
-    name: &'static str,
-    hint: &'static str,
 }
 
 const MODE_ROWS: &[ModeRow] = &[
     ModeRow {
         mode: AppMode::Agent,
         number: '1',
-        name: "Agent",
-        hint: "Normal execution with approvals",
     },
     ModeRow {
         mode: AppMode::Plan,
         number: '2',
-        name: "Plan",
-        hint: "Plan first before execution",
     },
     ModeRow {
         mode: AppMode::Yolo,
         number: '3',
-        name: "YOLO",
-        hint: "Auto-approve; shell enabled",
     },
 ];
 
+fn mode_hint(mode: AppMode, locale: Locale) -> &'static str {
+    match mode {
+        AppMode::Agent => tr(locale, MessageId::ModePickerAgentHint),
+        AppMode::Plan => tr(locale, MessageId::ModePickerPlanHint),
+        AppMode::Yolo => tr(locale, MessageId::ModePickerYoloHint),
+    }
+}
+
 pub struct ModePickerView {
     cursor: usize,
+    locale: Locale,
 }
 
 impl ModePickerView {
     #[must_use]
-    pub fn new(current: AppMode) -> Self {
+    pub fn new(current: AppMode, locale: Locale) -> Self {
         let cursor = MODE_ROWS
             .iter()
             .position(|row| row.mode == current)
             .unwrap_or(0);
-        Self { cursor }
+        Self { cursor, locale }
     }
 
     fn selected_mode(&self) -> AppMode {
@@ -126,18 +126,18 @@ impl ModalView for ModePickerView {
 
         let block = Block::default()
             .title(Line::from(Span::styled(
-                " Mode ",
+                tr(self.locale, MessageId::ModePickerTitle),
                 Style::default()
                     .fg(palette::DEEPSEEK_SKY)
                     .add_modifier(Modifier::BOLD),
             )))
             .title_bottom(Line::from(vec![
                 Span::styled(" Up/Down ", Style::default().fg(palette::TEXT_MUTED)),
-                Span::raw("move "),
+                Span::raw(tr(self.locale, MessageId::ModePickerFooterMove)),
                 Span::styled(" Enter ", Style::default().fg(palette::TEXT_MUTED)),
-                Span::raw("select "),
+                Span::raw(tr(self.locale, MessageId::ModePickerFooterSelect)),
                 Span::styled(" Esc ", Style::default().fg(palette::TEXT_MUTED)),
-                Span::raw("cancel "),
+                Span::raw(tr(self.locale, MessageId::ModePickerFooterCancel)),
             ]))
             .borders(Borders::ALL)
             .border_style(Style::default().fg(palette::BORDER_COLOR))
@@ -149,7 +149,7 @@ impl ModalView for ModePickerView {
 
         let mut lines = Vec::with_capacity(MODE_ROWS.len() + 1);
         lines.push(Line::from(Span::styled(
-            "Choose how CodeWhale should operate:",
+            tr(self.locale, MessageId::ModePickerInstruction),
             Style::default().fg(palette::TEXT_MUTED),
         )));
 
@@ -172,12 +172,16 @@ impl ModalView for ModePickerView {
             };
             let pointer = if is_cursor { ">" } else { " " };
 
+            let name = match row.mode {
+                AppMode::Agent => "Agent",
+                AppMode::Plan => "Plan",
+                AppMode::Yolo => "YOLO",
+            };
+            let hint = mode_hint(row.mode, self.locale);
+
             lines.push(Line::from(vec![
-                Span::styled(
-                    format!("{pointer} {}. {:<7}", row.number, row.name),
-                    row_style,
-                ),
-                Span::styled(row.hint, hint_style),
+                Span::styled(format!("{pointer} {}. {:<7}", row.number, name), row_style),
+                Span::styled(hint, hint_style),
             ]));
         }
 
@@ -192,13 +196,13 @@ mod tests {
 
     #[test]
     fn opens_on_current_mode() {
-        let view = ModePickerView::new(AppMode::Plan);
+        let view = ModePickerView::new(AppMode::Plan, Locale::En);
         assert_eq!(view.selected_mode(), AppMode::Plan);
     }
 
     #[test]
     fn enter_emits_selected_mode() {
-        let mut view = ModePickerView::new(AppMode::Agent);
+        let mut view = ModePickerView::new(AppMode::Agent, Locale::En);
         view.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
         let action = view.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
         match action {
@@ -211,7 +215,7 @@ mod tests {
 
     #[test]
     fn number_keys_select_modes() {
-        let mut view = ModePickerView::new(AppMode::Agent);
+        let mut view = ModePickerView::new(AppMode::Agent, Locale::En);
         let action = view.handle_key(KeyEvent::new(KeyCode::Char('3'), KeyModifiers::NONE));
         match action {
             ViewAction::EmitAndClose(ViewEvent::ModeSelected { mode }) => {


### PR DESCRIPTION
## Summary

Localize the mode-picker modal (8 MessageIds) across all 7 shipped locales.

### Strings
- `ModePickerTitle` — `" Mode "`
- `ModePickerInstruction` — `"Choose how CodeWhale should operate:"`
- `ModePickerAgentHint` — `"Normal execution with approvals"`
- `ModePickerPlanHint` — `"Plan first before execution"`
- `ModePickerYoloHint` — `"Auto-approve; shell enabled"`
- `ModePickerFooterMove` — `"move "`
- `ModePickerFooterSelect` — `"select "`
- `ModePickerFooterCancel` — `"cancel "`

### Infrastructure
- Added `locale: Locale` field to `ModePickerView`
- Threaded locale from `AppAction::OpenModePicker` in `ui.rs`
- Mode names (Agent/Plan/YOLO) kept English per convention

### Verification
- 3 mode-picker tests pass
- 8 localization tests pass
- `cargo clippy`: clean
- `cargo fmt --all --check`: clean