### PR TITLE
i18n: localize Cmd command output messages (15 MessageIds)

### DIFF
--- a/crates/tui/src/commands/config.rs
+++ b/crates/tui/src/commands/config.rs
@@ -12,7 +12,7 @@ use crate::config_persistence::{
     persist_tui_integer_key,
 };
 use crate::config_ui::{ConfigUiMode, parse_mode};
-use crate::localization::resolve_locale;
+use crate::localization::{MessageId, resolve_locale, tr};
 use crate::settings::Settings;
 use crate::tui::app::{
     App, AppAction, AppMode, OnboardingState, ReasoningEffort, SidebarFocus, VimMode,
@@ -969,20 +969,18 @@ pub fn trust(app: &mut App, arg: Option<&str>) -> CommandResult {
         "" | "status" | "list" => trust_status(&workspace, app, sub == "list"),
         "on" | "enable" | "yes" | "y" => {
             app.trust_mode = true;
-            CommandResult::message(
-                "Workspace trust mode enabled — agent file tools can now read/write any path. \
-                 Use `/trust off` to revert; prefer `/trust add <path>` for a narrower opt-in.",
-            )
+            CommandResult::message(tr(app.ui_locale, MessageId::CmdTrustEnabled))
         }
         "off" | "disable" | "no" | "n" => {
             app.trust_mode = false;
-            CommandResult::message("Workspace trust mode disabled.")
+            CommandResult::message(tr(app.ui_locale, MessageId::CmdTrustDisabled))
         }
         "add" => trust_add(&workspace, rest),
         "remove" | "rm" | "del" | "delete" => trust_remove(&workspace, rest),
-        other => CommandResult::error(format!(
-            "Unknown /trust action `{other}`. Use `/trust`, `/trust on|off`, `/trust add <path>`, or `/trust remove <path>`."
-        )),
+        other => CommandResult::error_localized(
+            app.ui_locale,
+            tr(app.ui_locale, MessageId::CmdTrustUnknownAction).replace("{action}", other),
+        ),
     }
 }
 
@@ -1072,27 +1070,24 @@ pub fn lsp_command(app: &mut App, arg: Option<&str>) -> CommandResult {
     // Access lsp_manager config through the App's engine handle
     let current_enabled = app.lsp_enabled;
 
+    let locale = app.ui_locale;
     match raw {
         "" | "status" => {
             let status = if current_enabled { "on" } else { "off" };
-            CommandResult::message(format!(
-                "LSP diagnostics are currently **{status}**.\n\n\
-                 Use `/lsp on` to enable or `/lsp off` to disable inline diagnostics after file edits."
-            ))
+            CommandResult::message(tr(locale, MessageId::CmdLspStatus).replace("{status}", status))
         }
         "on" | "enable" | "1" | "true" => {
             app.lsp_enabled = true;
-            CommandResult::message(
-                "LSP diagnostics enabled — file edit results will include compiler errors and warnings when available.",
-            )
+            CommandResult::message(tr(locale, MessageId::CmdLspEnabled))
         }
         "off" | "disable" | "0" | "false" => {
             app.lsp_enabled = false;
-            CommandResult::message("LSP diagnostics disabled.")
+            CommandResult::message(tr(locale, MessageId::CmdLspDisabled))
         }
-        other => CommandResult::error(format!(
-            "Unknown /lsp argument `{other}`. Use `/lsp on`, `/lsp off`, or `/lsp status`."
-        )),
+        other => CommandResult::error_localized(
+            locale,
+            tr(locale, MessageId::CmdLspUnknownArg).replace("{arg}", other),
+        ),
     }
 }
 
@@ -1102,6 +1097,7 @@ pub fn lsp_command(app: &mut App, arg: Option<&str>) -> CommandResult {
 /// `codewhale auth clear --provider <id>` and
 /// `codewhale auth set --provider <id>`.
 pub fn logout(app: &mut App) -> CommandResult {
+    let locale = app.ui_locale;
     let provider_name = app.api_provider.as_str();
     match clear_active_provider_api_key(provider_name) {
         Ok(()) => {
@@ -1109,12 +1105,16 @@ pub fn logout(app: &mut App) -> CommandResult {
             app.onboarding_needs_api_key = true;
             app.api_key_input.clear();
             app.api_key_cursor = 0;
-            CommandResult::message(format!(
-                "Cleared API key for {provider_name}. \
-                 Use `codewhale auth clear --provider <id>` to clear a different provider."
-            ))
+            CommandResult::message(
+                tr(locale, MessageId::CmdLogoutSuccess).replace("{provider}", provider_name),
+            )
         }
-        Err(e) => CommandResult::error(format!("Failed to clear API key for {provider_name}: {e}")),
+        Err(e) => CommandResult::error_localized(
+            locale,
+            tr(locale, MessageId::CmdLogoutFailed)
+                .replace("{provider}", provider_name)
+                .replace("{error}", &e.to_string()),
+        ),
     }
 }
 
@@ -1122,6 +1122,7 @@ pub fn logout(app: &mut App) -> CommandResult {
 mod tests {
     use super::*;
     use crate::config::Config;
+    use crate::localization::Locale;
     use crate::test_support::lock_test_env;
     use crate::tui::app::{App, TuiOptions};
     use crate::tui::approval::ApprovalMode;
@@ -1251,6 +1252,7 @@ mod tests {
         app.auto_model = false;
         app.api_provider = crate::config::ApiProvider::Deepseek;
         app.model_ids_passthrough = false;
+        app.ui_locale = Locale::En;
         app
     }
 
@@ -1892,7 +1894,7 @@ mod tests {
         app.trust_mode = false;
         let result = trust(&mut app, Some("on"));
         let msg = result.message.expect("message");
-        assert!(msg.contains("Workspace trust mode enabled"));
+        assert!(msg.contains(tr(Locale::En, MessageId::CmdTrustEnabled)));
         assert!(app.trust_mode);
     }
 

--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -94,6 +94,19 @@ impl CommandResult {
             is_error: true,
         }
     }
+
+    /// Create an error message result with a localized "Error:" prefix
+    pub fn error_localized(locale: Locale, msg: impl Into<String>) -> Self {
+        Self {
+            message: Some(format!(
+                "{} {}",
+                tr(locale, MessageId::CmdErrorPrefix),
+                msg.into()
+            )),
+            action: None,
+            is_error: true,
+        }
+    }
 }
 
 /// Command metadata for help and autocomplete.

--- a/crates/tui/src/commands/queue.rs
+++ b/crates/tui/src/commands/queue.rs
@@ -31,7 +31,7 @@ fn list_queue(app: &mut App) -> CommandResult {
     let queued = app.queued_message_count();
 
     if let Some(draft) = app.queued_draft.as_ref() {
-        lines.push("Editing queued message:".to_string());
+        lines.push(tr(locale, MessageId::CmdEditingQueuedDraft).to_string());
         lines.push(format!("- {}", truncate_preview(&draft.display)));
     }
 

--- a/crates/tui/src/commands/task.rs
+++ b/crates/tui/src/commands/task.rs
@@ -1,10 +1,11 @@
 //! Task commands: add/list/show/cancel
 
+use crate::localization::{MessageId, tr};
 use crate::tui::app::{App, AppAction};
 
 use super::CommandResult;
 
-pub fn task(_app: &mut App, args: Option<&str>) -> CommandResult {
+pub fn task(app: &mut App, args: Option<&str>) -> CommandResult {
     let raw = args.unwrap_or("").trim();
     if raw.is_empty() || raw.eq_ignore_ascii_case("list") {
         return CommandResult::action(AppAction::TaskList);
@@ -14,10 +15,14 @@ pub fn task(_app: &mut App, args: Option<&str>) -> CommandResult {
     let action = parts.next().unwrap_or("").to_ascii_lowercase();
     let remainder = parts.next().map(str::trim).filter(|s| !s.is_empty());
 
+    let locale = app.ui_locale;
     match action.as_str() {
         "add" => {
             let Some(prompt) = remainder else {
-                return CommandResult::error("Usage: /task add <prompt>");
+                return CommandResult::error_localized(
+                    locale,
+                    tr(locale, MessageId::CmdTaskUsageAdd),
+                );
             };
             CommandResult::action(AppAction::TaskAdd {
                 prompt: prompt.to_string(),
@@ -26,17 +31,23 @@ pub fn task(_app: &mut App, args: Option<&str>) -> CommandResult {
         "list" => CommandResult::action(AppAction::TaskList),
         "show" => {
             let Some(id) = remainder else {
-                return CommandResult::error("Usage: /task show <id>");
+                return CommandResult::error_localized(
+                    locale,
+                    tr(locale, MessageId::CmdTaskUsageShow),
+                );
             };
             CommandResult::action(AppAction::TaskShow { id: id.to_string() })
         }
         "cancel" | "stop" => {
             let Some(id) = remainder else {
-                return CommandResult::error("Usage: /task cancel <id>");
+                return CommandResult::error_localized(
+                    locale,
+                    tr(locale, MessageId::CmdTaskUsageCancel),
+                );
             };
             CommandResult::action(AppAction::TaskCancel { id: id.to_string() })
         }
-        _ => CommandResult::error("Usage: /task [add <prompt>|list|show <id>|cancel <id>]"),
+        _ => CommandResult::error_localized(locale, tr(locale, MessageId::CmdTaskUsageGeneral)),
     }
 }
 

--- a/crates/tui/src/localization.rs
+++ b/crates/tui/src/localization.rs
@@ -550,6 +550,22 @@ pub enum MessageId {
     CtxInspChangesByTurn,
     CtxInspStablePrefixOnly,
     CtxInspCacheTip,
+    // Cmd command output.
+    CmdErrorPrefix,
+    CmdTaskUsageAdd,
+    CmdTaskUsageShow,
+    CmdTaskUsageCancel,
+    CmdTaskUsageGeneral,
+    CmdTrustEnabled,
+    CmdTrustDisabled,
+    CmdTrustUnknownAction,
+    CmdLspStatus,
+    CmdLspEnabled,
+    CmdLspDisabled,
+    CmdLspUnknownArg,
+    CmdLogoutSuccess,
+    CmdLogoutFailed,
+    CmdEditingQueuedDraft,
 }
 
 #[allow(dead_code)]
@@ -874,6 +890,21 @@ pub const ALL_MESSAGE_IDS: &[MessageId] = &[
     MessageId::CtxInspChangesByTurn,
     MessageId::CtxInspStablePrefixOnly,
     MessageId::CtxInspCacheTip,
+    MessageId::CmdErrorPrefix,
+    MessageId::CmdTaskUsageAdd,
+    MessageId::CmdTaskUsageShow,
+    MessageId::CmdTaskUsageCancel,
+    MessageId::CmdTaskUsageGeneral,
+    MessageId::CmdTrustEnabled,
+    MessageId::CmdTrustDisabled,
+    MessageId::CmdTrustUnknownAction,
+    MessageId::CmdLspStatus,
+    MessageId::CmdLspEnabled,
+    MessageId::CmdLspDisabled,
+    MessageId::CmdLspUnknownArg,
+    MessageId::CmdLogoutSuccess,
+    MessageId::CmdLogoutFailed,
+    MessageId::CmdEditingQueuedDraft,
 ];
 
 pub fn tr(locale: Locale, id: MessageId) -> &'static str {
@@ -1509,6 +1540,34 @@ fn english(id: MessageId) -> &'static str {
             "Tip: Stable prefix blocks are DeepSeek V4 prefix-cache eligible. \
             Volatile working-set changes break the cache only for the tail."
         }
+        // Cmd command output.
+        MessageId::CmdErrorPrefix => "Error:",
+        MessageId::CmdTaskUsageAdd => "Usage: /task add <prompt>",
+        MessageId::CmdTaskUsageShow => "Usage: /task show <id>",
+        MessageId::CmdTaskUsageCancel => "Usage: /task cancel <id>",
+        MessageId::CmdTaskUsageGeneral => "Usage: /task [add <prompt>|list|show <id>|cancel <id>]",
+        MessageId::CmdTrustEnabled => {
+            "Workspace trust mode enabled — agent file tools can now read/write any path. Use /trust off to revert; prefer /trust add <path> for a narrower opt-in."
+        }
+        MessageId::CmdTrustDisabled => "Workspace trust mode disabled.",
+        MessageId::CmdTrustUnknownAction => {
+            "Unknown /trust action `{action}`. Use `/trust`, `/trust on|off`, `/trust add <path>`, or `/trust remove <path>`."
+        }
+        MessageId::CmdLspStatus => {
+            "LSP diagnostics are currently **{status}**.\n\nUse `/lsp on` to enable or `/lsp off` to disable inline diagnostics after file edits."
+        }
+        MessageId::CmdLspEnabled => {
+            "LSP diagnostics enabled — file edit results will include compiler errors and warnings when available."
+        }
+        MessageId::CmdLspDisabled => "LSP diagnostics disabled.",
+        MessageId::CmdLspUnknownArg => {
+            "Unknown /lsp argument `{arg}`. Use `/lsp on`, `/lsp off`, or `/lsp status`."
+        }
+        MessageId::CmdLogoutSuccess => {
+            "Cleared API key for {provider}. Use `codewhale auth clear --provider <id>` to clear a different provider."
+        }
+        MessageId::CmdLogoutFailed => "Failed to clear API key for {provider}: {error}",
+        MessageId::CmdEditingQueuedDraft => "Editing queued message:",
     }
 }
 
@@ -2009,6 +2068,36 @@ fn vietnamese(id: MessageId) -> Option<&'static str> {
         MessageId::CtxInspCacheTip => {
             "Gợi ý: Các khối ổn định đủ điều kiện cho bộ nhớ đệm tiền tố DeepSeek V4. Thay đổi vùng làm việc chỉ phá vỡ bộ nhớ đệm ở phần cuối."
         }
+        // Cmd command output.
+        MessageId::CmdErrorPrefix => "Lỗi:",
+        MessageId::CmdTaskUsageAdd => "Cách dùng: /task add <lời_nhắc>",
+        MessageId::CmdTaskUsageShow => "Cách dùng: /task show <id>",
+        MessageId::CmdTaskUsageCancel => "Cách dùng: /task cancel <id>",
+        MessageId::CmdTaskUsageGeneral => {
+            "Cách dùng: /task [add <lời_nhắc>|list|show <id>|cancel <id>]"
+        }
+        MessageId::CmdTrustEnabled => {
+            "Đã bật chế độ tin cậy không gian làm việc — công cụ tệp của tác nhân có thể đọc/ghi mọi đường dẫn. Dùng /trust off để hoàn tác; ưu tiên /trust add <path> để chọn phạm vi hẹp hơn."
+        }
+        MessageId::CmdTrustDisabled => "Chế độ tin cậy không gian làm việc đã tắt.",
+        MessageId::CmdTrustUnknownAction => {
+            "Hành động /trust không xác định `{action}`. Dùng `/trust`, `/trust on|off`, `/trust add <path>`, hoặc `/trust remove <path>`."
+        }
+        MessageId::CmdLspStatus => {
+            "Chẩn đoán LSP hiện đang **{status}**.\n\nDùng `/lsp on` để bật hoặc `/lsp off` để tắt chẩn đoán nội dòng sau khi chỉnh sửa tệp."
+        }
+        MessageId::CmdLspEnabled => {
+            "Đã bật chẩn đoán LSP — kết quả chỉnh sửa tệp sẽ bao gồm lỗi và cảnh báo trình biên dịch khi có."
+        }
+        MessageId::CmdLspDisabled => "Đã tắt chẩn đoán LSP.",
+        MessageId::CmdLspUnknownArg => {
+            "Đối số /lsp không xác định `{arg}`. Dùng `/lsp on`, `/lsp off`, hoặc `/lsp status`."
+        }
+        MessageId::CmdLogoutSuccess => {
+            "Đã xóa khóa API cho {provider}. Dùng `codewhale auth clear --provider <id>` để xóa nhà cung cấp khác."
+        }
+        MessageId::CmdLogoutFailed => "Không thể xóa khóa API cho {provider}: {error}",
+        MessageId::CmdEditingQueuedDraft => "Đang chỉnh sửa tin nhắn đã xếp hàng:",
     })
 }
 
@@ -2073,6 +2162,32 @@ fn traditional_chinese(id: MessageId) -> Option<&'static str> {
         MessageId::CtxInspCacheTip => {
             "提示：穩定前綴區塊符合 DeepSeek V4 前綴快取條件。易變工作集的更改僅會破壞快取尾部。"
         }
+        // Cmd command output.
+        MessageId::CmdErrorPrefix => "錯誤：",
+        MessageId::CmdTaskUsageAdd => "用法：/task add <提示>",
+        MessageId::CmdTaskUsageShow => "用法：/task show <id>",
+        MessageId::CmdTaskUsageCancel => "用法：/task cancel <id>",
+        MessageId::CmdTaskUsageGeneral => "用法：/task [add <提示>|list|show <id>|cancel <id>]",
+        MessageId::CmdTrustEnabled => {
+            "已啟用工作區信任模式 — 代理檔案工具現在可讀寫任何路徑。使用 /trust off 恢復；建議使用 /trust add <path> 進行更精確的授權。"
+        }
+        MessageId::CmdTrustDisabled => "工作區信任模式已停用。",
+        MessageId::CmdTrustUnknownAction => {
+            "未知的 /trust 操作 `{action}`。請使用 `/trust`、`/trust on|off`、`/trust add <path>` 或 `/trust remove <path>`。"
+        }
+        MessageId::CmdLspStatus => {
+            "LSP 診斷目前為 **{status}**。\n\n使用 `/lsp on` 啟用或 `/lsp off` 停用檔案編輯後的內嵌診斷。"
+        }
+        MessageId::CmdLspEnabled => "LSP 診斷已啟用 — 檔案編輯結果將包含編譯器錯誤和警告（如有）。",
+        MessageId::CmdLspDisabled => "LSP 診斷已停用。",
+        MessageId::CmdLspUnknownArg => {
+            "未知的 /lsp 參數 `{arg}`。請使用 `/lsp on`、`/lsp off` 或 `/lsp status`。"
+        }
+        MessageId::CmdLogoutSuccess => {
+            "已清除 {provider} 的 API 金鑰。使用 `codewhale auth clear --provider <id>` 清除其他提供者的金鑰。"
+        }
+        MessageId::CmdLogoutFailed => "清除 {provider} 的 API 金鑰失敗：{error}",
+        MessageId::CmdEditingQueuedDraft => "正在編輯佇列中的訊息：",
         other => chinese_simplified(other)?,
     })
 }
@@ -2536,6 +2651,36 @@ fn japanese(id: MessageId) -> Option<&'static str> {
         MessageId::CtxInspCacheTip => {
             "ヒント：安定プレフィックスブロックはDeepSeek V4プレフィックスキャッシュの対象です。揮発性ワーキングセットの変更は末尾のキャッシュのみを破壊します。"
         }
+        // Cmd command output.
+        MessageId::CmdErrorPrefix => "エラー：",
+        MessageId::CmdTaskUsageAdd => "使い方：/task add <プロンプト>",
+        MessageId::CmdTaskUsageShow => "使い方：/task show <id>",
+        MessageId::CmdTaskUsageCancel => "使い方：/task cancel <id>",
+        MessageId::CmdTaskUsageGeneral => {
+            "使い方：/task [add <プロンプト>|list|show <id>|cancel <id>]"
+        }
+        MessageId::CmdTrustEnabled => {
+            "ワークスペース信頼モードが有効になりました — エージェントファイルツールがすべてのパスを読み書きできます。元に戻すには /trust off。より狭い範囲の許可には /trust add <path> をお勧めします。"
+        }
+        MessageId::CmdTrustDisabled => "ワークスペース信頼モードが無効になりました。",
+        MessageId::CmdTrustUnknownAction => {
+            "不明な /trust アクション `{action}`。`/trust`、`/trust on|off`、`/trust add <path>`、または `/trust remove <path>` を使用してください。"
+        }
+        MessageId::CmdLspStatus => {
+            "LSP診断は現在 **{status}** です。\n\nファイル編集後のインライン診断を有効にするには `/lsp on`、無効にするには `/lsp off` を使用してください。"
+        }
+        MessageId::CmdLspEnabled => {
+            "LSP診断が有効になりました — ファイル編集結果にコンパイラのエラーや警告が含まれます。"
+        }
+        MessageId::CmdLspDisabled => "LSP診断が無効になりました。",
+        MessageId::CmdLspUnknownArg => {
+            "不明な /lsp 引数 `{arg}`。`/lsp on`、`/lsp off`、または `/lsp status` を使用してください。"
+        }
+        MessageId::CmdLogoutSuccess => {
+            "{provider} のAPIキーを消去しました。別のプロバイダーを消去するには `codewhale auth clear --provider <id>` を使用してください。"
+        }
+        MessageId::CmdLogoutFailed => "{provider} のAPIキーの消去に失敗しました：{error}",
+        MessageId::CmdEditingQueuedDraft => "キューされたメッセージを編集中：",
     })
 }
 
@@ -2940,6 +3085,32 @@ fn chinese_simplified(id: MessageId) -> Option<&'static str> {
         MessageId::CtxInspCacheTip => {
             "提示：稳定前缀区块符合 DeepSeek V4 前缀缓存条件。易变工作集的更改仅会破坏缓存尾部。"
         }
+        // Cmd command output.
+        MessageId::CmdErrorPrefix => "错误：",
+        MessageId::CmdTaskUsageAdd => "用法：/task add <提示>",
+        MessageId::CmdTaskUsageShow => "用法：/task show <id>",
+        MessageId::CmdTaskUsageCancel => "用法：/task cancel <id>",
+        MessageId::CmdTaskUsageGeneral => "用法：/task [add <提示>|list|show <id>|cancel <id>]",
+        MessageId::CmdTrustEnabled => {
+            "工作区信任模式已启用 — 代理文件工具现在可以读写任何路径。使用 /trust off 恢复；建议使用 /trust add <path> 进行更精确的授权。"
+        }
+        MessageId::CmdTrustDisabled => "工作区信任模式已禁用。",
+        MessageId::CmdTrustUnknownAction => {
+            "未知的 /trust 操作 `{action}`。请使用 `/trust`、`/trust on|off`、`/trust add <path>` 或 `/trust remove <path>`。"
+        }
+        MessageId::CmdLspStatus => {
+            "LSP 诊断当前为 **{status}**。\n\n使用 `/lsp on` 启用或 `/lsp off` 禁用文件编辑后的内联诊断。"
+        }
+        MessageId::CmdLspEnabled => "LSP 诊断已启用 — 文件编辑结果将包含编译器错误和警告（如有）。",
+        MessageId::CmdLspDisabled => "LSP 诊断已禁用。",
+        MessageId::CmdLspUnknownArg => {
+            "未知的 /lsp 参数 `{arg}`。请使用 `/lsp on`、`/lsp off` 或 `/lsp status`。"
+        }
+        MessageId::CmdLogoutSuccess => {
+            "已清除 {provider} 的 API 密钥。使用 `codewhale auth clear --provider <id>` 清除其他提供者的密钥。"
+        }
+        MessageId::CmdLogoutFailed => "清除 {provider} 的 API 密钥失败：{error}",
+        MessageId::CmdEditingQueuedDraft => "正在编辑队列中的消息：",
     })
 }
 
@@ -3426,6 +3597,34 @@ fn portuguese_brazil(id: MessageId) -> Option<&'static str> {
         MessageId::CtxInspCacheTip => {
             "Dica: Blocos de prefixo estável são elegíveis para cache de prefixo DeepSeek V4. Alterações no conjunto de trabalho volátil quebram o cache apenas no final."
         }
+        // Cmd command output.
+        MessageId::CmdErrorPrefix => "Erro:",
+        MessageId::CmdTaskUsageAdd => "Uso: /task add <prompt>",
+        MessageId::CmdTaskUsageShow => "Uso: /task show <id>",
+        MessageId::CmdTaskUsageCancel => "Uso: /task cancel <id>",
+        MessageId::CmdTaskUsageGeneral => "Uso: /task [add <prompt>|list|show <id>|cancel <id>]",
+        MessageId::CmdTrustEnabled => {
+            "Modo de confiança do workspace ativado — as ferramentas de arquivo do agente podem ler/escrever qualquer caminho. Use /trust off para reverter; prefira /trust add <path> para uma permissão mais restrita."
+        }
+        MessageId::CmdTrustDisabled => "Modo de confiança do workspace desativado.",
+        MessageId::CmdTrustUnknownAction => {
+            "Ação /trust desconhecida `{action}`. Use `/trust`, `/trust on|off`, `/trust add <path>`, ou `/trust remove <path>`."
+        }
+        MessageId::CmdLspStatus => {
+            "O diagnóstico LSP está atualmente **{status}**.\n\nUse `/lsp on` para ativar ou `/lsp off` para desativar o diagnóstico inline após edições de arquivo."
+        }
+        MessageId::CmdLspEnabled => {
+            "Diagnóstico LSP ativado — os resultados de edição de arquivo incluirão erros e avisos do compilador quando disponíveis."
+        }
+        MessageId::CmdLspDisabled => "Diagnóstico LSP desativado.",
+        MessageId::CmdLspUnknownArg => {
+            "Argumento /lsp desconhecido `{arg}`. Use `/lsp on`, `/lsp off`, ou `/lsp status`."
+        }
+        MessageId::CmdLogoutSuccess => {
+            "Chave de API limpa para {provider}. Use `codewhale auth clear --provider <id>` para limpar um provedor diferente."
+        }
+        MessageId::CmdLogoutFailed => "Falha ao limpar chave de API para {provider}: {error}",
+        MessageId::CmdEditingQueuedDraft => "Editando mensagem enfileirada:",
     })
 }
 
@@ -3922,6 +4121,34 @@ fn spanish_latin_america(id: MessageId) -> Option<&'static str> {
         MessageId::CtxInspCacheTip => {
             "Consejo: Los bloques de prefijo estable son elegibles para caché de prefijo DeepSeek V4. Los cambios en el conjunto de trabajo volátil solo rompen la caché al final."
         }
+        // Cmd command output.
+        MessageId::CmdErrorPrefix => "Error:",
+        MessageId::CmdTaskUsageAdd => "Uso: /task add <prompt>",
+        MessageId::CmdTaskUsageShow => "Uso: /task show <id>",
+        MessageId::CmdTaskUsageCancel => "Uso: /task cancel <id>",
+        MessageId::CmdTaskUsageGeneral => "Uso: /task [add <prompt>|list|show <id>|cancel <id>]",
+        MessageId::CmdTrustEnabled => {
+            "Modo de confianza del workspace activado — las herramientas de archivo del agente pueden leer/escribir cualquier ruta. Usa /trust off para revertir; prefiere /trust add <path> para una autorización más restringida."
+        }
+        MessageId::CmdTrustDisabled => "Modo de confianza del workspace desactivado.",
+        MessageId::CmdTrustUnknownAction => {
+            "Acción /trust desconocida `{action}`. Usa `/trust`, `/trust on|off`, `/trust add <path>`, o `/trust remove <path>`."
+        }
+        MessageId::CmdLspStatus => {
+            "El diagnóstico LSP está actualmente **{status}**.\n\nUsa `/lsp on` para activar o `/lsp off` para desactivar el diagnóstico inline después de ediciones de archivo."
+        }
+        MessageId::CmdLspEnabled => {
+            "Diagnóstico LSP activado — los resultados de edición de archivo incluirán errores y advertencias del compilador cuando estén disponibles."
+        }
+        MessageId::CmdLspDisabled => "Diagnóstico LSP desactivado.",
+        MessageId::CmdLspUnknownArg => {
+            "Argumento /lsp desconocido `{arg}`. Usa `/lsp on`, `/lsp off`, o `/lsp status`."
+        }
+        MessageId::CmdLogoutSuccess => {
+            "Clave de API borrada para {provider}. Usa `codewhale auth clear --provider <id>` para borrar un proveedor diferente."
+        }
+        MessageId::CmdLogoutFailed => "Error al borrar la clave de API para {provider}: {error}",
+        MessageId::CmdEditingQueuedDraft => "Editando mensaje en cola:",
     })
 }
 


### PR DESCRIPTION
Localize all Cmd* command output messages across 7 shipped locales.

### What's covered
- **CmdErrorPrefix** — localized "Error:" prefix via `CommandResult::error_localized()`
- **CmdTaskUsage{Add,Show,Cancel,General}** — /task usage hints
- **CmdTrust{Enabled,Disabled,UnknownAction}** — /trust status messages
- **CmdLsp{Status,Enabled,Disabled,UnknownArg}** — /lsp diagnostics messages
- **CmdLogout{Success,Failed}** — /logout messages
- **CmdEditingQueuedDraft** — queue list header for active draft

### Changes
- `localization.rs`: 15 new MessageIds + translations in all 7 locales
- `commands/mod.rs`: new `CommandResult::error_localized()` with localized error prefix
- `commands/task.rs`: all usage error messages via `tr()`
- `commands/config.rs`: trust/lsp/logout messages via `tr()`
- `commands/queue.rs`: editing-queued-message header via `tr()`

### Testing
- 4338 tests pass, 1 pre-existing flaky MCP SSE test failure
- clippy clean with `-D warnings`
- `cargo fmt --all --check` clean