### PR TITLE
fix(tui): normalize macOS SUPER (Cmd) to CONTROL for keyboard shortcuts (#2938)

### DIFF
--- a/crates/tui/src/tui/composer_ui.rs
+++ b/crates/tui/src/tui/composer_ui.rs
@@ -121,6 +121,23 @@ pub(crate) fn is_word_cursor_modifier(modifiers: KeyModifiers) -> bool {
     modifiers.contains(KeyModifiers::CONTROL) || modifiers.contains(KeyModifiers::ALT)
 }
 
+/// On macOS, map `SUPER` (Cmd ⌘) to `CONTROL` when `CONTROL` is not already
+/// set, so that terminal emulators that don't pass Ctrl faithfully still work.
+/// On all other platforms this is a no-op.
+#[cfg(target_os = "macos")]
+pub(crate) fn normalize_macos_modifiers(modifiers: KeyModifiers) -> KeyModifiers {
+    if modifiers.contains(KeyModifiers::SUPER) && !modifiers.contains(KeyModifiers::CONTROL) {
+        modifiers | KeyModifiers::CONTROL
+    } else {
+        modifiers
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn normalize_macos_modifiers(modifiers: KeyModifiers) -> KeyModifiers {
+    modifiers
+}
+
 pub(crate) fn handle_composer_alt_word_motion_key(app: &mut App, key: KeyEvent) -> bool {
     if !key.modifiers.contains(KeyModifiers::ALT) || key.modifiers.contains(KeyModifiers::CONTROL) {
         return false;

--- a/crates/tui/src/tui/composer_ui.rs
+++ b/crates/tui/src/tui/composer_ui.rs
@@ -126,8 +126,11 @@ pub(crate) fn is_word_cursor_modifier(modifiers: KeyModifiers) -> bool {
 /// On all other platforms this is a no-op.
 #[cfg(target_os = "macos")]
 pub(crate) fn normalize_macos_modifiers(modifiers: KeyModifiers) -> KeyModifiers {
-    if modifiers.contains(KeyModifiers::SUPER) && !modifiers.contains(KeyModifiers::CONTROL) {
-        modifiers | KeyModifiers::CONTROL
+    // Strip SUPER and add CONTROL so that exact modifier equality checks
+    // (e.g. `modifiers == KeyModifiers::CONTROL` in Ctrl+S stashing) work
+    // correctly after normalization.
+    if modifiers.contains(KeyModifiers::SUPER) {
+        (modifiers - KeyModifiers::SUPER) | KeyModifiers::CONTROL
     } else {
         modifiers
     }

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -2972,13 +2972,20 @@ async fn run_event_loop(
             // User interaction — clear the ✅ completion marker from the title.
             crate::tui::notifications::reset_title_on_interaction();
 
-            let Event::Key(key) = evt else {
+            let Event::Key(mut key) = evt else {
                 continue;
             };
 
             if key.kind != KeyEventKind::Press {
                 continue;
             }
+
+            // Normalize macOS modifiers: map SUPER (Cmd) to CONTROL so that
+            // keyboard shortcuts work consistently across terminal emulators
+            // (Terminal.app, iTerm2, Kitty, etc.) that may report different
+            // modifier flags (#2938).
+            let mapped = crate::tui::composer_ui::normalize_macos_modifiers(key.modifiers);
+            key.modifiers = mapped;
 
             // Decision card keyboard routing (v0.8.43 truth-surface).
             // When a card is active, number keys 1-9 select options,

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -301,19 +301,19 @@ fn word_cursor_modifier_accepts_control_and_alt() {
 #[test]
 fn normalize_macos_modifiers_maps_super_to_control() {
     use crate::tui::composer_ui::normalize_macos_modifiers;
-    // SUPER (Cmd) without CONTROL should gain CONTROL.
+    // SUPER (Cmd) without CONTROL should gain CONTROL and lose SUPER.
     let normalized = normalize_macos_modifiers(KeyModifiers::SUPER);
     assert!(normalized.contains(KeyModifiers::CONTROL));
-    assert!(normalized.contains(KeyModifiers::SUPER));
+    assert!(!normalized.contains(KeyModifiers::SUPER));
 }
 
 #[test]
 fn normalize_macos_modifiers_preserves_existing_control() {
     use crate::tui::composer_ui::normalize_macos_modifiers;
-    // CONTROL already set — shouldn't be removed.
+    // CONTROL already set — SUPER should be removed.
     let normalized = normalize_macos_modifiers(KeyModifiers::CONTROL | KeyModifiers::SUPER);
     assert!(normalized.contains(KeyModifiers::CONTROL));
-    assert!(normalized.contains(KeyModifiers::SUPER));
+    assert!(!normalized.contains(KeyModifiers::SUPER));
 }
 
 #[test]

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -299,6 +299,33 @@ fn word_cursor_modifier_accepts_control_and_alt() {
 }
 
 #[test]
+fn normalize_macos_modifiers_maps_super_to_control() {
+    use crate::tui::composer_ui::normalize_macos_modifiers;
+    // SUPER (Cmd) without CONTROL should gain CONTROL.
+    let normalized = normalize_macos_modifiers(KeyModifiers::SUPER);
+    assert!(normalized.contains(KeyModifiers::CONTROL));
+    assert!(normalized.contains(KeyModifiers::SUPER));
+}
+
+#[test]
+fn normalize_macos_modifiers_preserves_existing_control() {
+    use crate::tui::composer_ui::normalize_macos_modifiers;
+    // CONTROL already set — shouldn't be removed.
+    let normalized = normalize_macos_modifiers(KeyModifiers::CONTROL | KeyModifiers::SUPER);
+    assert!(normalized.contains(KeyModifiers::CONTROL));
+    assert!(normalized.contains(KeyModifiers::SUPER));
+}
+
+#[test]
+fn normalize_macos_modifiers_leaves_alt_unchanged() {
+    use crate::tui::composer_ui::normalize_macos_modifiers;
+    let normalized = normalize_macos_modifiers(KeyModifiers::ALT);
+    // On non-macOS this is a no-op; on macOS ALT stays unchanged.
+    assert!(normalized.contains(KeyModifiers::ALT));
+    assert!(!normalized.contains(KeyModifiers::SUPER));
+}
+
+#[test]
 fn alt_f_and_alt_b_move_by_word_without_inserting_text() {
     let mut app = create_test_app();
     app.input = "alpha beta gamma".to_string();

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -298,6 +298,7 @@ fn word_cursor_modifier_accepts_control_and_alt() {
     assert!(!is_word_cursor_modifier(KeyModifiers::SHIFT));
 }
 
+#[cfg(target_os = "macos")]
 #[test]
 fn normalize_macos_modifiers_maps_super_to_control() {
     use crate::tui::composer_ui::normalize_macos_modifiers;
@@ -307,6 +308,7 @@ fn normalize_macos_modifiers_maps_super_to_control() {
     assert!(!normalized.contains(KeyModifiers::SUPER));
 }
 
+#[cfg(target_os = "macos")]
 #[test]
 fn normalize_macos_modifiers_preserves_existing_control() {
     use crate::tui::composer_ui::normalize_macos_modifiers;


### PR DESCRIPTION
On macOS, terminal emulators may report Cmd (SUPER) instead of Ctrl (CONTROL) for keyboard shortcuts, depending on the terminal app and its configuration. This caused Ctrl+B, Ctrl+Alt+2, and other shortcuts to be inconsistent.

Fix:
- Add normalize_macos_modifiers() in composer_ui.rs
- On macOS: map SUPER to CONTROL when CONTROL is not already set
- On other platforms: no-op
- Apply normalization at the key event entry point in ui.rs

Tests:
- normalize_macos_modifiers_maps_super_to_control
- normalize_macos_modifiers_preserves_existing_control
- normalize_macos_modifiers_leaves_alt_unchanged

Close https://github.com/Hmbown/CodeWhale/issues/2938
## Summary

## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address
