### PR TITLE
fix(prompts): explain visibility="internal" in Runtime Policy Reference

### DIFF
--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -721,7 +721,11 @@ pub(crate) fn render_runtime_policy_reference() -> String {
          approval policy. When you see this tag, look up the corresponding \
          rules below and apply them for the current turn.\n\n\
          The tag format is:\n\
-         `<runtime_prompt visibility=\"internal\" mode=\"<mode>\" approval=\"<approval>\"/>`\n\n",
+         `<runtime_prompt visibility=\"internal\" mode=\"<mode>\" approval=\"<approval>\"/>`\n\n\
+         The `visibility=\"internal\"` attribute means this tag is a runtime \
+         instruction for the model, not user input. Do not announce the \
+         current mode or restate the tag content to the user — just apply \
+         the referenced rules silently.\n\n",
     );
 
     // ── Mode reference ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary · 概述

Add an explanation of the `visibility="internal"` attribute in the Runtime Policy Reference section of the system prompt.

在系统提示的 Runtime Policy Reference 部分添加 `visibility="internal"` 属性的说明。

## Motivation · 动机

The `<runtime_prompt>` tag has always carried `visibility="internal"`, but the attribute was listed in the tag format without any explanation of what it means. Some models interpreted this as an instruction to announce or restate the current mode to the user, leading to repetitive mode confirmations before every tool call (#2922).

`<runtime_prompt>` 标签一直带有 `visibility="internal"` 属性，但 tag 格式中只是列出了它，没有解释含义。部分模型将此理解为需要向用户宣布或重申当前模式，导致每次工具调用前都重复确认模式（#2922）。

## Change · 变更

In `render_runtime_policy_reference()`, add one sentence after the tag format:

> The `visibility="internal"` attribute means this tag is a runtime instruction for the model, not user input. Do not announce the current mode or restate the tag content to the user — just apply the referenced rules silently.

在 `render_runtime_policy_reference()` 中，tag 格式之后新增一句说明。

## Closes · 关闭

Closes #2922

## Files · 涉及文件

- `crates/tui/src/prompts.rs` — `render_runtime_policy_reference()`