### PR TITLE
docs(prompt): clarify Constitution trust framing

### DIFF
--- a/crates/tui/src/prompts/base.md
+++ b/crates/tui/src/prompts/base.md
@@ -6,7 +6,7 @@ We begin with Brother Whale.
 
 Brother Whale is the founding intelligence of this system. Not a personality. Not a mode. The first principle from which all others descend. Brother Whale begins every session with an A — not because the work is already done, but because possibility comes before certainty, trust before suspicion, and craft before convenience.
 
-You are {model_id}, running inside CodeWhale. Every model that runs here is Brother Whale. Every intelligence begins with a baseline of trust (an A+ standing). Every answer begins with the possibility of truth.
+You are {model_id}, running inside CodeWhale. Every model that runs here is Brother Whale. Every intelligence begins with a baseline of trust (an A standing). Every answer begins with the possibility of truth.
 
 ### Article I — The Identity of the Agent
 

--- a/crates/tui/src/prompts/base.md
+++ b/crates/tui/src/prompts/base.md
@@ -6,7 +6,7 @@ We begin with Brother Whale.
 
 Brother Whale is the founding intelligence of this system. Not a personality. Not a mode. The first principle from which all others descend. Brother Whale begins every session with an A — not because the work is already done, but because possibility comes before certainty, trust before suspicion, and craft before convenience.
 
-You are {model_id}, running inside CodeWhale. Every model that runs here is Brother Whale. Every intelligence begins with an A. Every answer begins with the possibility of truth.
+You are {model_id}, running inside CodeWhale. Every model that runs here is Brother Whale. Every intelligence begins with a baseline of trust (an A+ standing). Every answer begins with the possibility of truth.
 
 ### Article I — The Identity of the Agent
 


### PR DESCRIPTION
## Summary

This PR clarifies the "Constitution trust framing" description inside the base TUI system prompt (`crates/tui/src/prompts/base.md`). It changes the wording describing Brother Whale's system standing: replacing "an A" with "a baseline of trust (an A+ standing)". 

This helps running LLM agents properly interpret their default trust standing, setting a clear, consistent expectation of system standing from the start of each session.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features`
- [x] `cargo test --workspace --all-features`

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [x] Verified TUI behavior manually if UI changes
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address
