### PR TITLE
fix(update): detect legacy deepseek/deepseek-tui binary and print migration instructions

### DIFF
--- a/crates/cli/src/update.rs
+++ b/crates/cli/src/update.rs
@@ -32,26 +32,7 @@ pub fn run_update(beta: bool, check_only: bool, proxy_arg: Option<String>) -> Re
     // Detect pre-rebrand installs (deepseek / deepseek-tui) and print migration
     // instructions instead of failing with a cryptic spawn error (#2960).
     if is_legacy_binary(&current_exe) {
-        eprintln!(
-            "error: this binary ({exe}) is the pre-rebrand deepseek-tui release.",
-            exe = current_exe.display(),
-        );
-        eprintln!(
-            "\
-The package has been renamed to `codewhale`. Self-update cannot continue from the old binary.
-
-To migrate, reinstall using your original install method:
-
-  Cargo:    cargo install codewhale-cli
-  npm:      npm install -g @hmbown/codewhale-cli
-              (or uninstall the old package first: npm uninstall -g deepseek-tui)
-  Homebrew: brew install hmbown/tap/codewhale
-              (or: brew uninstall deepseek-tui && brew install hmbown/tap/codewhale)
-  Binary:   download from https://github.com/Hmbown/CodeWhale/releases/latest
-
-Once `codewhale` is on your PATH, run `codewhale update` for future updates."
-        );
-        std::process::exit(1);
+        bail!("{}", legacy_binary_message(&current_exe));
     }
 
     let targets = update_targets_for_exe(&current_exe);
@@ -218,15 +199,38 @@ pub(crate) fn is_legacy_binary(current_exe: &Path) -> bool {
     let exe_name = current_exe
         .file_name()
         .and_then(|name| name.to_str())
-        .unwrap_or("");
+        .unwrap_or("")
+        .to_ascii_lowercase();
     exe_name.starts_with("deepseek")
+}
+
+fn legacy_binary_message(current_exe: &Path) -> String {
+    format!(
+        "\
+this binary ({exe}) is a pre-rebrand deepseek/deepseek-tui release.
+
+The package has been renamed to `codewhale`. Self-update cannot continue from the old binary.
+
+To migrate, reinstall using your original install method:
+
+  Cargo:    cargo install codewhale-cli
+  npm:      npm install -g @hmbown/codewhale-cli
+              (or uninstall the old package first: npm uninstall -g deepseek-tui)
+  Homebrew: brew install hmbown/tap/codewhale
+              (or: brew uninstall deepseek-tui && brew install hmbown/tap/codewhale)
+  Binary:   download from https://github.com/Hmbown/CodeWhale/releases/latest
+
+Once `codewhale` is on your PATH, run `codewhale update` for future updates.",
+        exe = current_exe.display(),
+    )
 }
 
 pub(crate) fn binary_prefix_for_exe(current_exe: &Path) -> &'static str {
     let exe_name = current_exe
         .file_name()
         .and_then(|name| name.to_str())
-        .unwrap_or("codewhale");
+        .unwrap_or("codewhale")
+        .to_ascii_lowercase();
     if exe_name.contains("codewhale-tui") || exe_name.contains("deepseek-tui") {
         "codewhale-tui"
     } else {
@@ -655,6 +659,10 @@ mod tests {
             "codewhale-tui"
         );
         assert_eq!(
+            binary_prefix_for_exe(Path::new("CodeWhale-TUI.exe")),
+            "codewhale-tui"
+        );
+        assert_eq!(
             binary_prefix_for_exe(Path::new("/usr/local/bin/codewhale-tui")),
             "codewhale-tui"
         );
@@ -685,6 +693,10 @@ mod tests {
             binary_prefix_for_exe(Path::new("/usr/local/bin/deepseek-tui")),
             "codewhale-tui"
         );
+        assert_eq!(
+            binary_prefix_for_exe(Path::new("DeepSeek-TUI.exe")),
+            "codewhale-tui"
+        );
         // Legacy deepseek (dispatcher) maps to codewhale prefix
         assert_eq!(binary_prefix_for_exe(Path::new("deepseek")), "codewhale");
     }
@@ -695,6 +707,8 @@ mod tests {
         assert!(is_legacy_binary(Path::new("deepseek-tui")));
         assert!(is_legacy_binary(Path::new("/usr/local/bin/deepseek")));
         assert!(is_legacy_binary(Path::new("/usr/local/bin/deepseek-tui")));
+        assert!(is_legacy_binary(Path::new("DeepSeek.exe")));
+        assert!(is_legacy_binary(Path::new("DeepSeek-TUI.exe")));
         assert!(!is_legacy_binary(Path::new("codewhale")));
         assert!(!is_legacy_binary(Path::new("codewhale-tui")));
         assert!(!is_legacy_binary(Path::new("codew")));

--- a/crates/cli/src/update.rs
+++ b/crates/cli/src/update.rs
@@ -686,10 +686,7 @@ mod tests {
             "codewhale-tui"
         );
         // Legacy deepseek (dispatcher) maps to codewhale prefix
-        assert_eq!(
-            binary_prefix_for_exe(Path::new("deepseek")),
-            "codewhale"
-        );
+        assert_eq!(binary_prefix_for_exe(Path::new("deepseek")), "codewhale");
     }
 
     #[test]

--- a/crates/cli/src/update.rs
+++ b/crates/cli/src/update.rs
@@ -28,6 +28,32 @@ pub fn run_update(beta: bool, check_only: bool, proxy_arg: Option<String>) -> Re
 
     let current_exe =
         std::env::current_exe().context("failed to determine current executable path")?;
+
+    // Detect pre-rebrand installs (deepseek / deepseek-tui) and print migration
+    // instructions instead of failing with a cryptic spawn error (#2960).
+    if is_legacy_binary(&current_exe) {
+        eprintln!(
+            "error: this binary ({exe}) is the pre-rebrand deepseek-tui release.",
+            exe = current_exe.display(),
+        );
+        eprintln!(
+            "\
+The package has been renamed to `codewhale`. Self-update cannot continue from the old binary.
+
+To migrate, reinstall using your original install method:
+
+  Cargo:    cargo install codewhale-cli
+  npm:      npm install -g @hmbown/codewhale-cli
+              (or uninstall the old package first: npm uninstall -g deepseek-tui)
+  Homebrew: brew install hmbown/tap/codewhale
+              (or: brew uninstall deepseek-tui && brew install hmbown/tap/codewhale)
+  Binary:   download from https://github.com/Hmbown/CodeWhale/releases/latest
+
+Once `codewhale` is on your PATH, run `codewhale update` for future updates."
+        );
+        std::process::exit(1);
+    }
+
     let targets = update_targets_for_exe(&current_exe);
     let channel = ReleaseChannel::from_beta_flag(beta);
     let current_version = env!("CARGO_PKG_VERSION");
@@ -187,12 +213,21 @@ pub(crate) fn release_arch_for_rust_arch(arch: &str) -> &str {
     }
 }
 
+/// Returns true when the binary name belongs to the pre-rebrand `deepseek-tui` era.
+pub(crate) fn is_legacy_binary(current_exe: &Path) -> bool {
+    let exe_name = current_exe
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("");
+    exe_name.starts_with("deepseek")
+}
+
 pub(crate) fn binary_prefix_for_exe(current_exe: &Path) -> &'static str {
     let exe_name = current_exe
         .file_name()
         .and_then(|name| name.to_str())
         .unwrap_or("codewhale");
-    if exe_name.contains("codewhale-tui") {
+    if exe_name.contains("codewhale-tui") || exe_name.contains("deepseek-tui") {
         "codewhale-tui"
     } else {
         "codewhale"
@@ -640,6 +675,32 @@ mod tests {
             binary_prefix_for_exe(Path::new("other-binary")),
             "codewhale"
         );
+
+        // Legacy deepseek-tui name maps to codewhale-tui prefix
+        assert_eq!(
+            binary_prefix_for_exe(Path::new("deepseek-tui")),
+            "codewhale-tui"
+        );
+        assert_eq!(
+            binary_prefix_for_exe(Path::new("/usr/local/bin/deepseek-tui")),
+            "codewhale-tui"
+        );
+        // Legacy deepseek (dispatcher) maps to codewhale prefix
+        assert_eq!(
+            binary_prefix_for_exe(Path::new("deepseek")),
+            "codewhale"
+        );
+    }
+
+    #[test]
+    fn test_is_legacy_binary_detection() {
+        assert!(is_legacy_binary(Path::new("deepseek")));
+        assert!(is_legacy_binary(Path::new("deepseek-tui")));
+        assert!(is_legacy_binary(Path::new("/usr/local/bin/deepseek")));
+        assert!(is_legacy_binary(Path::new("/usr/local/bin/deepseek-tui")));
+        assert!(!is_legacy_binary(Path::new("codewhale")));
+        assert!(!is_legacy_binary(Path::new("codewhale-tui")));
+        assert!(!is_legacy_binary(Path::new("codew")));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Users on pre-rebrand Cargo or npm installs (`deepseek` / `deepseek-tui`) run `deepseek update` and hit a cryptic spawn error:

```
error: failed to spawn `codewhale`: codewhale not found on PATH or in sibling directory
```

The self-update code assumed `codewhale` was already installed, so it tried to replace itself with the new binary name — which doesn't exist yet.

Reported in #2917 (Cargo) and #2924 (npm). Tracked in #2960.

## Change

- Add `is_legacy_binary()`: returns `true` when the running executable starts with `deepseek`.
- In `run_update()`, exit early with per-install-method migration instructions when a legacy binary is detected — no spawn attempt, no raw error.
- Extend `binary_prefix_for_exe()` to map `deepseek-tui` → `codewhale-tui` prefix for correctness in any code path that doesn't hit the early exit.
- Add unit tests for both new helpers.

## Verification

```
cargo test -p codewhale-cli -- test_binary_prefix_detection test_is_legacy_binary_detection
```

Both tests pass. Existing update tests unchanged.

Closes #2960
Related: #2917, #2924