### PR TITLE
fix(tui): compact tool-call transcript rendering — suppress boilerplate

### DIFF
--- a/crates/tui/src/tui/history.rs
+++ b/crates/tui/src/tui/history.rs
@@ -961,7 +961,12 @@ impl ExecCell {
                     Style::default().fg(palette::TEXT_MUTED),
                     width,
                 ));
-            } else if self.status != ToolStatus::Running {
+            } else if self.status != ToolStatus::Running
+                && mode == RenderMode::Transcript
+            {
+                // #3031: Suppress "(no output)" in compact/Live mode;
+                // the success header is enough signal. Transcript still
+                // records it for exports/clipboard/pager.
                 lines.push(Line::from(Span::styled(
                     "  (no output)",
                     Style::default().fg(palette::TEXT_MUTED).italic(),
@@ -970,13 +975,17 @@ impl ExecCell {
         }
 
         if let Some(duration_ms) = self.duration_ms {
-            let seconds = f64::from(u32::try_from(duration_ms).unwrap_or(u32::MAX)) / 1000.0;
-            lines.extend(render_compact_kv(
-                "time",
-                &format!("{seconds:.2}s"),
-                Style::default().fg(palette::TEXT_DIM),
-                width,
-            ));
+            // #3031: Suppress sub-second timing in compact mode.
+            // Transcript mode always shows exact timing.
+            if mode == RenderMode::Transcript || duration_ms >= 1000 {
+                let seconds = f64::from(u32::try_from(duration_ms).unwrap_or(u32::MAX)) / 1000.0;
+                lines.extend(render_compact_kv(
+                    "time",
+                    &format!("{seconds:.2}s"),
+                    Style::default().fg(palette::TEXT_DIM),
+                    width,
+                ));
+            }
         }
 
         wrap_card_rail(lines)
@@ -2840,10 +2849,15 @@ fn render_preserved_output_mode(
 ) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
     if output.trim().is_empty() {
-        lines.push(Line::from(Span::styled(
-            "  (no output)",
-            Style::default().fg(palette::TEXT_MUTED).italic(),
-        )));
+        // #3031: In compact/Live mode, suppress "(no output)" — the tool
+        // header already carries the success/failure status.  Transcript
+        // mode still records it for exports/clipboard/pager.
+        if mode == RenderMode::Transcript {
+            lines.push(Line::from(Span::styled(
+                "  (no output)",
+                Style::default().fg(palette::TEXT_MUTED).italic(),
+            )));
+        }
         return lines;
     }
 

--- a/crates/tui/src/tui/history.rs
+++ b/crates/tui/src/tui/history.rs
@@ -961,9 +961,7 @@ impl ExecCell {
                     Style::default().fg(palette::TEXT_MUTED),
                     width,
                 ));
-            } else if self.status != ToolStatus::Running
-                && mode == RenderMode::Transcript
-            {
+            } else if self.status != ToolStatus::Running && mode == RenderMode::Transcript {
                 // #3031: Suppress "(no output)" in compact/Live mode;
                 // the success header is enough signal. Transcript still
                 // records it for exports/clipboard/pager.

--- a/crates/tui/src/tui/tool_routing.rs
+++ b/crates/tui/src/tui/tool_routing.rs
@@ -449,6 +449,19 @@ fn record_spillover_artifact_if_any(
         ));
 }
 
+/// #3031: shell/tasks tools embed the literal `"(no output)"` into successful
+/// `ToolResult` content (the model-facing transcript needs a non-empty tool
+/// result). Treat it as no output on the TUI side so the compact-mode
+/// suppression gate in `history.rs` actually fires; the raw content remains
+/// available through the tool-detail store.
+fn visible_tool_output(content: &str) -> Option<String> {
+    if content.trim() == "(no output)" {
+        None
+    } else {
+        Some(content.to_string())
+    }
+}
+
 pub(super) fn handle_tool_call_complete(
     app: &mut App,
     id: &str,
@@ -549,9 +562,11 @@ pub(super) fn handle_tool_call_complete(
                         .and_then(|m| m.get("duration_ms"))
                         .and_then(serde_json::Value::as_u64);
                     if status != ToolStatus::Running && exec.interaction.is_none() {
-                        exec.output = Some(tool_result.content.clone());
-                        exec.output_summary =
-                            Some(super::history::summarize_tool_output(&tool_result.content));
+                        exec.output = visible_tool_output(&tool_result.content);
+                        exec.output_summary = exec
+                            .output
+                            .as_deref()
+                            .map(super::history::summarize_tool_output);
                         exec.live_output = None;
                     } else if status == ToolStatus::Running
                         && exec.interaction.is_none()
@@ -642,8 +657,9 @@ pub(super) fn handle_tool_call_complete(
                 generic.status = status;
                 match result.as_ref() {
                     Ok(tool_result) => {
-                        generic.output = Some(tool_result.content.clone());
-                        generic.output_summary = Some(summarize_tool_output(&tool_result.content));
+                        generic.output = visible_tool_output(&tool_result.content);
+                        generic.output_summary =
+                            generic.output.as_deref().map(summarize_tool_output);
                         generic.is_diff = output_looks_like_diff(&tool_result.content);
                     }
                     Err(err) => {
@@ -1272,5 +1288,65 @@ mod tests {
         assert_eq!(snapshot.items.len(), 1);
         assert_eq!(snapshot.items[0].step, "render all fields");
         assert_eq!(snapshot.items[0].status, StepStatus::Pending);
+    }
+
+    // ── #3031: "(no output)" placeholder must not defeat compact rendering ─
+
+    #[test]
+    fn visible_tool_output_maps_no_output_placeholder_to_none() {
+        assert_eq!(visible_tool_output("(no output)"), None);
+        assert_eq!(visible_tool_output("  (no output)\n"), None);
+    }
+
+    #[test]
+    fn visible_tool_output_preserves_real_content() {
+        assert_eq!(
+            visible_tool_output("compiled 3 crates").as_deref(),
+            Some("compiled 3 crates")
+        );
+        // Output that merely CONTAINS the placeholder is real output.
+        assert_eq!(
+            visible_tool_output("step 1: (no output) — continuing").as_deref(),
+            Some("step 1: (no output) — continuing")
+        );
+        assert_eq!(visible_tool_output("").as_deref(), Some(""));
+    }
+
+    #[test]
+    fn exec_cell_without_output_suppresses_placeholder_in_live_mode() {
+        use crate::tui::history::{ExecCell, ExecSource, ToolCell, ToolStatus};
+
+        let cell = ToolCell::Exec(ExecCell {
+            command: "true".to_string(),
+            status: ToolStatus::Success,
+            output: None,
+            live_output: None,
+            shell_task_id: None,
+            started_at: None,
+            duration_ms: Some(120),
+            source: ExecSource::Assistant,
+            interaction: None,
+            output_summary: None,
+        });
+
+        let live: String = cell
+            .lines(80)
+            .iter()
+            .flat_map(|line| line.spans.iter().map(|s| s.content.to_string()))
+            .collect();
+        assert!(
+            !live.contains("(no output)"),
+            "Live mode must suppress the placeholder: {live:?}"
+        );
+
+        let transcript: String = cell
+            .transcript_lines(80)
+            .iter()
+            .flat_map(|line| line.spans.iter().map(|s| s.content.to_string()))
+            .collect();
+        assert!(
+            transcript.contains("(no output)"),
+            "Transcript mode still records the placeholder: {transcript:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Refs #3031 (partial — see descope note below).

Reduces low-value detail in the default compact/Live transcript view:

- **ExecCell**: suppress "(no output)" line — the success/failure header already conveys the outcome
- **ExecCell**: suppress sub-second timing — calls under 1s show no timing line; >=1s still shown
- **render_preserved_output_mode**: suppress "(no output)" for empty output in Live mode
- **tool_routing**: map the literal `"(no output)"` placeholder that
  `exec_shell`/`tasks` embed in successful `ToolResult` content to `None`
  for `ExecCell.output` / `GenericToolCell.output`. Without this, the
  dominant real-world path (completed `exec_shell` calls) never hit the
  empty-output gate and Live mode still rendered `output: (no output)`.
  The raw content remains in the tool-detail store.

Full detail (complete command, full output, exact timing) remains available in
Transcript mode — used by the pager, clipboard export, and Alt+V detail view.

## Changes

| Change | Before | After |
|---|---|---|
| Empty output | `  (no output)` line always shown | Suppressed in Live; Transcript keeps it |
| `"(no output)"` placeholder content | rendered as real output (`output: (no output)`) | mapped to no-output at routing layer; same suppression applies |
| Sub-second timing | `  time 0.32s` always shown | Suppressed in Live for <1s; Transcript shows always |
| render_preserved_output_mode | `  (no output)` for empty output | Suppressed in Live; Transcript keeps it |

## Verification
- `cargo check` with `-Dwarnings` — clean
- New tests: `visible_tool_output_*` (placeholder→None mapping, real
  content preserved, contains-placeholder content preserved),
  `exec_cell_without_output_suppresses_placeholder_in_live_mode`
  (Live suppresses, Transcript keeps)
- `cargo fmt --all -- --check` — clean

## Descoped from #3031 (keep the issue open)

This PR intentionally covers only the boilerplate-suppression slice.
Still open from the issue's acceptance criteria:

- one-line collapsed tool cells
- ~60-char command truncation in collapsed cells
- auto-expand on error
- `tool_cell_style` config knob
- summary-generator tests for the above