### PR TITLE
release: v0.8.58

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,82 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.58] - 2026-06-11
+
+### Added
+
+- **Native Anthropic provider.** A dedicated Messages API adapter
+  (`/v1/messages` with `x-api-key` auth) replaces OpenAI-dialect shims for
+  Claude models: adaptive thinking with `output_config.effort` shaping,
+  prompt-cache breakpoints (capped at 4, earliest dropped), signed-thinking
+  replay via `signature_delta`, normalized cache-hit/miss usage telemetry,
+  and SSE error envelopes. `claude-opus-4-8`, `claude-sonnet-4-6`, and
+  `claude-haiku-4-5` join the model registry; configure with
+  `ANTHROPIC_API_KEY` (#3014).
+- **Hooks v2.** `tool_call_before` hooks can now return a JSON decision —
+  `{"decision": "allow"|"deny"|"ask", "reason", "updatedInput",
+  "additionalContext"}` — with deny > ask > allow precedence across multiple
+  hooks, last-writer-wins input rewriting, and concatenated context. Exit
+  code 2 remains a legacy hard deny. Hooks support glob matchers and
+  project-local `.codewhale/hooks.toml` (#3026).
+- **Clickable sidebar.** Background-job rows show/cancel on click, the
+  Ctrl+K hint row runs `/jobs cancel-all`, and agent rows open `/subagents`;
+  row actions are built in the same pass as the rendered lines so a click
+  can never target the wrong job (#3028).
+- OSC 8 out-of-band hyperlink infrastructure with per-region open/close
+  sequences that survive partial redraws (#3029).
+- `codewhale exec` gains `--allowed-tools`, `--disallowed-tools` (deny wins),
+  `--max-turns`, and `--append-system-prompt` (#3027).
+- Constitution prompt source: YAML source-of-truth plus Python renderer for
+  the system prompt, with the active prompt now served from
+  `constitution.md` (#3015, renderer reconciliation still tracked).
+- Agent-task issue template, labels, and runner protocol (#3021); remote
+  smoke-test droplet loop hardening — gh CLI, swapfile, agent sessions
+  (#3022).
+
+### Changed
+
+- **Sub-agent routing is provider-aware.** DeepSeek ids are no longer
+  hardcoded into model validation; routing works from per-provider
+  big/cheap candidates, the network router is skipped when a provider has
+  no cheap tier, and spawn-time model requests are validated against the
+  active provider (#3018).
+- Model-specific facts in the system prompt (context window, sub-agent
+  pricing, thinking notes, architecture characteristics) are now templated
+  per-model instead of hardcoded DeepSeek V4 claims, in both `base.md` and
+  `constitution.md` (#3025).
+- Provider capability lookups for Moonshot/OpenAI/Atlascloud resolve from
+  per-model registry rows (bare and vendor-prefixed ids) instead of
+  hardcoded 64K-era floors (#3023).
+- Reasoning-effort now reaches Atlascloud (DeepSeek dialect), Moonshot
+  (`thinking` enable/disable), and Ollama (`think` param) (#3024); Moonshot/
+  Kimi models joined the reasoning-content provider and model gates (#3016).
+- Transcript polish: compact tool-call cells without boilerplate (#3031),
+  internal turn/agent ids hidden behind stable labels (#3030), and Ctrl+B
+  now backgrounds the running foreground shell directly instead of opening
+  a menu (#3032).
+- The Tasks sidebar separates "Model reasoning" from "Background commands",
+  and `auth list` reports the same active-credential source as
+  `auth status` for openai-codex.
+
+### Fixed
+
+- **TUI freeze under sub-agent load.** Rapid `AgentProgress` events
+  saturated the render loop and starved terminal input; progress-driven
+  repaints are now throttled to one per 100ms (#3033).
+- **Hooks on Windows.** Hook commands were passed to `cmd /C` through
+  CRT-style argument quoting, which injected literal `\"` sequences that
+  cmd.exe never unescapes — JSON decisions could not parse. Commands now
+  reach cmd.exe verbatim via `raw_arg`.
+- Codex Responses: assistant tool results are converted to
+  `function_call_output` items (multi-turn tool calling previously broke),
+  tool schemas are sanitized for the Responses API, and `maximum` effort
+  maps to `xhigh` (#3019, #3017 — both partially; retry/backoff and
+  per-tool strict mode remain open).
+- Better tool-denial and provider error messages harvested from PR #2933
+  (#3020).
+
+
 ## [0.8.57] - 2026-06-10
 
 ### Added
@@ -1636,7 +1712,8 @@ overflow report and `/theme` picker edge-wrapping patch in #1814.
 
 Older releases (v0.8.39 and earlier) are archived in [docs/CHANGELOG_ARCHIVE.md](docs/CHANGELOG_ARCHIVE.md).
 
-[Unreleased]: https://github.com/Hmbown/CodeWhale/compare/v0.8.57...HEAD
+[Unreleased]: https://github.com/Hmbown/CodeWhale/compare/v0.8.58...HEAD
+[0.8.58]: https://github.com/Hmbown/CodeWhale/compare/v0.8.57...v0.8.58
 [0.8.57]: https://github.com/Hmbown/CodeWhale/compare/v0.8.56...v0.8.57
 [0.8.56]: https://github.com/Hmbown/CodeWhale/compare/v0.8.55...v0.8.56
 [0.8.55]: https://github.com/Hmbown/CodeWhale/compare/v0.8.54...v0.8.55

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -771,7 +771,7 @@ checksum = "e9b18233253483ce2f65329a24072ec414db782531bdbb7d0bbc4bd2ce6b7e21"
 
 [[package]]
 name = "codewhale-agent"
-version = "0.8.57"
+version = "0.8.58"
 dependencies = [
  "codewhale-config",
  "serde",
@@ -779,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-app-server"
-version = "0.8.57"
+version = "0.8.58"
 dependencies = [
  "anyhow",
  "axum",
@@ -806,7 +806,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-cli"
-version = "0.8.57"
+version = "0.8.58"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-config"
-version = "0.8.57"
+version = "0.8.58"
 dependencies = [
  "anyhow",
  "codewhale-execpolicy",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-core"
-version = "0.8.57"
+version = "0.8.58"
 dependencies = [
  "anyhow",
  "chrono",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-execpolicy"
-version = "0.8.57"
+version = "0.8.58"
 dependencies = [
  "anyhow",
  "codewhale-protocol",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-hooks"
-version = "0.8.57"
+version = "0.8.58"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-mcp"
-version = "0.8.57"
+version = "0.8.58"
 dependencies = [
  "anyhow",
  "serde",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-protocol"
-version = "0.8.57"
+version = "0.8.58"
 dependencies = [
  "serde",
  "serde_json",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-release"
-version = "0.8.57"
+version = "0.8.58"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-secrets"
-version = "0.8.57"
+version = "0.8.58"
 dependencies = [
  "dirs",
  "keyring",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-state"
-version = "0.8.57"
+version = "0.8.58"
 dependencies = [
  "anyhow",
  "chrono",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-tools"
-version = "0.8.57"
+version = "0.8.58"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-tui"
-version = "0.8.57"
+version = "0.8.58"
 dependencies = [
  "anyhow",
  "arboard",
@@ -1027,11 +1027,11 @@ dependencies = [
 
 [[package]]
 name = "codewhale-tui-core"
-version = "0.8.57"
+version = "0.8.58"
 
 [[package]]
 name = "codewhale-whaleflow"
-version = "0.8.57"
+version = "0.8.58"
 dependencies = [
  "anyhow",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ default-members = ["crates/cli", "crates/app-server", "crates/tui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.8.57"
+version = "0.8.58"
 edition = "2024"
 # Rust 1.88 stabilized `let_chains` in `if`/`while` conditions, which the
 # codebase relies on extensively. Cargo enforces this so users on older

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -43,8 +43,8 @@ codewhale --model auto
 # https://github.com/Hmbown/CodeWhale/releases
 
 # GitHub に安定して到達できない場合は CNB mirror を使えます:
-cargo install --git https://cnb.cool/codewhale.net/codewhale --tag v0.8.57 codewhale-cli --locked --force
-cargo install --git https://cnb.cool/codewhale.net/codewhale --tag v0.8.57 codewhale-tui --locked --force
+cargo install --git https://cnb.cool/codewhale.net/codewhale --tag v0.8.58 codewhale-cli --locked --force
+cargo install --git https://cnb.cool/codewhale.net/codewhale --tag v0.8.58 codewhale-tui --locked --force
 
 # 旧 Homebrew 互換。formula はまだ deepseek-tui 名を使います。
 brew tap Hmbown/deepseek-tui

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ Other install paths are supported:
 # https://github.com/Hmbown/CodeWhale/releases
 
 # CNB mirror path for users who cannot reliably reach GitHub:
-cargo install --git https://cnb.cool/codewhale.net/codewhale --tag v0.8.57 codewhale-cli --locked --force
-cargo install --git https://cnb.cool/codewhale.net/codewhale --tag v0.8.57 codewhale-tui --locked --force
+cargo install --git https://cnb.cool/codewhale.net/codewhale --tag v0.8.58 codewhale-cli --locked --force
+cargo install --git https://cnb.cool/codewhale.net/codewhale --tag v0.8.58 codewhale-tui --locked --force
 
 # Legacy Homebrew compatibility while the formula is renamed
 brew tap Hmbown/deepseek-tui

--- a/README.vi.md
+++ b/README.vi.md
@@ -43,8 +43,8 @@ Các đường khác:
 # https://github.com/Hmbown/CodeWhale/releases
 
 # Nếu GitHub không ổn định, dùng CNB mirror:
-cargo install --git https://cnb.cool/codewhale.net/codewhale --tag v0.8.57 codewhale-cli --locked --force
-cargo install --git https://cnb.cool/codewhale.net/codewhale --tag v0.8.57 codewhale-tui --locked --force
+cargo install --git https://cnb.cool/codewhale.net/codewhale --tag v0.8.58 codewhale-cli --locked --force
+cargo install --git https://cnb.cool/codewhale.net/codewhale --tag v0.8.58 codewhale-tui --locked --force
 
 # Homebrew legacy trong lúc formula vẫn dùng tên deepseek-tui
 brew tap Hmbown/deepseek-tui

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -43,8 +43,8 @@ codewhale --model auto
 # https://github.com/Hmbown/CodeWhale/releases
 
 # 如果 GitHub 访问不稳定，可以使用 CNB 镜像：
-cargo install --git https://cnb.cool/codewhale.net/codewhale --tag v0.8.57 codewhale-cli --locked --force
-cargo install --git https://cnb.cool/codewhale.net/codewhale --tag v0.8.57 codewhale-tui --locked --force
+cargo install --git https://cnb.cool/codewhale.net/codewhale --tag v0.8.58 codewhale-cli --locked --force
+cargo install --git https://cnb.cool/codewhale.net/codewhale --tag v0.8.58 codewhale-tui --locked --force
 
 # 旧 Homebrew 兼容路径，formula 仍使用 deepseek-tui 名称
 brew tap Hmbown/deepseek-tui

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -7,5 +7,5 @@ repository.workspace = true
 description = "Model/provider registry and fallback strategy for DeepSeek workspace architecture"
 
 [dependencies]
-codewhale-config = { path = "../config", version = "0.8.57" }
+codewhale-config = { path = "../config", version = "0.8.58" }
 serde.workspace = true

--- a/crates/app-server/Cargo.toml
+++ b/crates/app-server/Cargo.toml
@@ -10,15 +10,15 @@ description = "Codex-style app-server transport for DeepSeek workspace architect
 anyhow.workspace = true
 axum.workspace = true
 clap.workspace = true
-codewhale-agent = { path = "../agent", version = "0.8.57" }
-codewhale-config = { path = "../config", version = "0.8.57" }
-codewhale-core = { path = "../core", version = "0.8.57" }
-codewhale-execpolicy = { path = "../execpolicy", version = "0.8.57" }
-codewhale-hooks = { path = "../hooks", version = "0.8.57" }
-codewhale-mcp = { path = "../mcp", version = "0.8.57" }
-codewhale-protocol = { path = "../protocol", version = "0.8.57" }
-codewhale-state = { path = "../state", version = "0.8.57" }
-codewhale-tools = { path = "../tools", version = "0.8.57" }
+codewhale-agent = { path = "../agent", version = "0.8.58" }
+codewhale-config = { path = "../config", version = "0.8.58" }
+codewhale-core = { path = "../core", version = "0.8.58" }
+codewhale-execpolicy = { path = "../execpolicy", version = "0.8.58" }
+codewhale-hooks = { path = "../hooks", version = "0.8.58" }
+codewhale-mcp = { path = "../mcp", version = "0.8.58" }
+codewhale-protocol = { path = "../protocol", version = "0.8.58" }
+codewhale-state = { path = "../state", version = "0.8.58" }
+codewhale-tools = { path = "../tools", version = "0.8.58" }
 serde.workspace = true
 serde_json.workspace = true
 rustls.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -19,14 +19,14 @@ path = "src/bin/codew_legacy_shim.rs"
 anyhow.workspace = true
 clap.workspace = true
 clap_complete.workspace = true
-codewhale-agent = { path = "../agent", version = "0.8.57" }
-codewhale-app-server = { path = "../app-server", version = "0.8.57" }
-codewhale-config = { path = "../config", version = "0.8.57" }
-codewhale-execpolicy = { path = "../execpolicy", version = "0.8.57" }
-codewhale-mcp = { path = "../mcp", version = "0.8.57" }
-codewhale-release = { path = "../release", version = "0.8.57" }
-codewhale-secrets = { path = "../secrets", version = "0.8.57" }
-codewhale-state = { path = "../state", version = "0.8.57" }
+codewhale-agent = { path = "../agent", version = "0.8.58" }
+codewhale-app-server = { path = "../app-server", version = "0.8.58" }
+codewhale-config = { path = "../config", version = "0.8.58" }
+codewhale-execpolicy = { path = "../execpolicy", version = "0.8.58" }
+codewhale-mcp = { path = "../mcp", version = "0.8.58" }
+codewhale-release = { path = "../release", version = "0.8.58" }
+codewhale-secrets = { path = "../secrets", version = "0.8.58" }
+codewhale-state = { path = "../state", version = "0.8.58" }
 chrono.workspace = true
 dirs.workspace = true
 serde.workspace = true

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -8,8 +8,8 @@ description = "Config schema and precedence model for DeepSeek workspace archite
 
 [dependencies]
 anyhow.workspace = true
-codewhale-execpolicy = { path = "../execpolicy", version = "0.8.57" }
-codewhale-secrets = { path = "../secrets", version = "0.8.57" }
+codewhale-execpolicy = { path = "../execpolicy", version = "0.8.58" }
+codewhale-secrets = { path = "../secrets", version = "0.8.58" }
 dirs.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -9,14 +9,14 @@ description = "Core runtime boundaries for DeepSeek workspace architecture"
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true
-codewhale-agent = { path = "../agent", version = "0.8.57" }
-codewhale-config = { path = "../config", version = "0.8.57" }
-codewhale-execpolicy = { path = "../execpolicy", version = "0.8.57" }
-codewhale-hooks = { path = "../hooks", version = "0.8.57" }
-codewhale-mcp = { path = "../mcp", version = "0.8.57" }
-codewhale-protocol = { path = "../protocol", version = "0.8.57" }
-codewhale-state = { path = "../state", version = "0.8.57" }
-codewhale-tools = { path = "../tools", version = "0.8.57" }
+codewhale-agent = { path = "../agent", version = "0.8.58" }
+codewhale-config = { path = "../config", version = "0.8.58" }
+codewhale-execpolicy = { path = "../execpolicy", version = "0.8.58" }
+codewhale-hooks = { path = "../hooks", version = "0.8.58" }
+codewhale-mcp = { path = "../mcp", version = "0.8.58" }
+codewhale-protocol = { path = "../protocol", version = "0.8.58" }
+codewhale-state = { path = "../state", version = "0.8.58" }
+codewhale-tools = { path = "../tools", version = "0.8.58" }
 serde_json.workspace = true
 tracing.workspace = true
 uuid.workspace = true

--- a/crates/execpolicy/Cargo.toml
+++ b/crates/execpolicy/Cargo.toml
@@ -8,5 +8,5 @@ description = "Execution policy and approval model parity for DeepSeek workspace
 
 [dependencies]
 anyhow.workspace = true
-codewhale-protocol = { path = "../protocol", version = "0.8.57" }
+codewhale-protocol = { path = "../protocol", version = "0.8.58" }
 serde.workspace = true

--- a/crates/hooks/Cargo.toml
+++ b/crates/hooks/Cargo.toml
@@ -10,7 +10,7 @@ description = "Hook dispatch and notifications parity for DeepSeek workspace arc
 anyhow.workspace = true
 async-trait.workspace = true
 chrono.workspace = true
-codewhale-protocol = { path = "../protocol", version = "0.8.57" }
+codewhale-protocol = { path = "../protocol", version = "0.8.58" }
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -9,7 +9,7 @@ description = "Tool invocation lifecycle, schema validation, and scheduler paral
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
-codewhale-protocol = { path = "../protocol", version = "0.8.57" }
+codewhale-protocol = { path = "../protocol", version = "0.8.58" }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -7,6 +7,82 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.58] - 2026-06-11
+
+### Added
+
+- **Native Anthropic provider.** A dedicated Messages API adapter
+  (`/v1/messages` with `x-api-key` auth) replaces OpenAI-dialect shims for
+  Claude models: adaptive thinking with `output_config.effort` shaping,
+  prompt-cache breakpoints (capped at 4, earliest dropped), signed-thinking
+  replay via `signature_delta`, normalized cache-hit/miss usage telemetry,
+  and SSE error envelopes. `claude-opus-4-8`, `claude-sonnet-4-6`, and
+  `claude-haiku-4-5` join the model registry; configure with
+  `ANTHROPIC_API_KEY` (#3014).
+- **Hooks v2.** `tool_call_before` hooks can now return a JSON decision —
+  `{"decision": "allow"|"deny"|"ask", "reason", "updatedInput",
+  "additionalContext"}` — with deny > ask > allow precedence across multiple
+  hooks, last-writer-wins input rewriting, and concatenated context. Exit
+  code 2 remains a legacy hard deny. Hooks support glob matchers and
+  project-local `.codewhale/hooks.toml` (#3026).
+- **Clickable sidebar.** Background-job rows show/cancel on click, the
+  Ctrl+K hint row runs `/jobs cancel-all`, and agent rows open `/subagents`;
+  row actions are built in the same pass as the rendered lines so a click
+  can never target the wrong job (#3028).
+- OSC 8 out-of-band hyperlink infrastructure with per-region open/close
+  sequences that survive partial redraws (#3029).
+- `codewhale exec` gains `--allowed-tools`, `--disallowed-tools` (deny wins),
+  `--max-turns`, and `--append-system-prompt` (#3027).
+- Constitution prompt source: YAML source-of-truth plus Python renderer for
+  the system prompt, with the active prompt now served from
+  `constitution.md` (#3015, renderer reconciliation still tracked).
+- Agent-task issue template, labels, and runner protocol (#3021); remote
+  smoke-test droplet loop hardening — gh CLI, swapfile, agent sessions
+  (#3022).
+
+### Changed
+
+- **Sub-agent routing is provider-aware.** DeepSeek ids are no longer
+  hardcoded into model validation; routing works from per-provider
+  big/cheap candidates, the network router is skipped when a provider has
+  no cheap tier, and spawn-time model requests are validated against the
+  active provider (#3018).
+- Model-specific facts in the system prompt (context window, sub-agent
+  pricing, thinking notes, architecture characteristics) are now templated
+  per-model instead of hardcoded DeepSeek V4 claims, in both `base.md` and
+  `constitution.md` (#3025).
+- Provider capability lookups for Moonshot/OpenAI/Atlascloud resolve from
+  per-model registry rows (bare and vendor-prefixed ids) instead of
+  hardcoded 64K-era floors (#3023).
+- Reasoning-effort now reaches Atlascloud (DeepSeek dialect), Moonshot
+  (`thinking` enable/disable), and Ollama (`think` param) (#3024); Moonshot/
+  Kimi models joined the reasoning-content provider and model gates (#3016).
+- Transcript polish: compact tool-call cells without boilerplate (#3031),
+  internal turn/agent ids hidden behind stable labels (#3030), and Ctrl+B
+  now backgrounds the running foreground shell directly instead of opening
+  a menu (#3032).
+- The Tasks sidebar separates "Model reasoning" from "Background commands",
+  and `auth list` reports the same active-credential source as
+  `auth status` for openai-codex.
+
+### Fixed
+
+- **TUI freeze under sub-agent load.** Rapid `AgentProgress` events
+  saturated the render loop and starved terminal input; progress-driven
+  repaints are now throttled to one per 100ms (#3033).
+- **Hooks on Windows.** Hook commands were passed to `cmd /C` through
+  CRT-style argument quoting, which injected literal `\"` sequences that
+  cmd.exe never unescapes — JSON decisions could not parse. Commands now
+  reach cmd.exe verbatim via `raw_arg`.
+- Codex Responses: assistant tool results are converted to
+  `function_call_output` items (multi-turn tool calling previously broke),
+  tool schemas are sanitized for the Responses API, and `maximum` effort
+  maps to `xhigh` (#3019, #3017 — both partially; retry/backoff and
+  per-tool strict mode remain open).
+- Better tool-denial and provider error messages harvested from PR #2933
+  (#3020).
+
+
 ## [0.8.57] - 2026-06-10
 
 ### Added
@@ -1191,75 +1267,6 @@ and continuing contributors **@reidliu41**, **@cyq1017**, **@idling11**,
   @saieswar237, @sximelon, @nanookclaw, @Sskift, @xin1104, @mrluanma,
   @Lellansin, and @zhuangbiaowei, while preserving the existing @jeoor
   acknowledgement in the consolidated list.
-
-## [0.8.44] - 2026-05-24
-
-### Added
-
-- **`codew` convenience alias.** `codew` is a short-form command that silently
-  forwards to `codewhale`. Six fewer keystrokes, same binary. Ships with the
-  Rust `codewhale-cli` crate and the npm `codewhale` package (#2013).
-- **Session picker inline rename.** Press `r` in the session picker (Ctrl+R)
-  to rename the selected session inline. Type the new title, Enter to confirm,
-  Esc to cancel (#1600).
-- **Plan detail display.** The \"Plan Confirmation\" modal now shows the plan
-  explanation and step list from `update_plan` so you can review what was
-  proposed before accepting (#834).
-- **Agent team UX.** Delegate cards in the transcript now show human-readable
-  roles (scout, builder, reviewer, verifier, executor) and the completion
-  summary instead of raw `agent_xxx` IDs (#1981).
-- **`--continue` / `-c` CLI flag.** `codewhale --continue` resumes your most
-  recent interactive session for the current workspace.
-
-### Changed
-
-- **App state migrates to `~/.codewhale/`.** New installs write product-owned
-  state (config, sessions, tasks, skills, logs, etc.) under `~/.codewhale/`.
-  `~/.deepseek/` continues to work as a compatibility fallback — no data loss,
-  no forced migration. `CODEWHALE_HOME` and `CODEWHALE_CONFIG_PATH` env vars
-  are now supported alongside existing `DEEPSEEK_*` vars (#2011).
-- **Project config overlay prefers `.codewhale/config.toml`** before
-  `.deepseek/config.toml`. Both are read; the CodeWhale root takes precedence.
-- **Doctor reports active state root** and whether legacy `~/.deepseek/`
-  state is also present.
-- **README contributor acknowledgements are current for this release.**
-  Thanks @jeoor, @LING71671, and @ousamabenyounes for the fixes and reports
-  now reflected in the public credits.
-- **Harvested-contribution credit audit completed.** The README Thanks list now
-  includes previously missed community helpers whose code, reports, or review
-  notes were already credited in older changelog entries but not in the public
-  contributor surface: @mvanhorn, @krisclarkdev, @tdccccc, @LittleBlacky,
-  @AnaheimEX, @THatch26, @alvin1, @knqiufan, @IIzzaya, @duanchao-lab,
-  @imkingjh999, @eng2007, @chennest, @kunpeng-ai-lab, @asdfg314284230,
-  @maker316, @lalala-233, @muyuliyan, @czf0718, @MeAiRobot, @tiger-dog,
-  @MMMarcinho, @lucaszhu-hue, @sandofree, @zhuangbiaowei, @NorethSea,
-  @Jianfengwu2024, @Fire-dtx, @oooyuy92, @qinxianyuzou, @tyouter,
-  @xulongzhe, @YaYII, @47Cid, and @JafarAkhondali.
-- **Harvest guidance now requires GitHub-visible attribution.** Maintainer
-  harvests should preserve the original commit author where possible or add
-  `Co-authored-by` trailers from the original PR commits, in addition to the
-  existing `Harvested from PR #N by @handle` trailer and changelog credit.
-- **Enter now steers when busy-waiting.** When the model is busy but not
-  actively streaming (waiting on tool results, sub-agents, or shell
-  commands), pressing Enter tries to steer your message into the current
-  turn instead of silently queueing it. During active streaming, Enter
-  still queues to avoid interrupting in-flight reasoning (#2009).
-
-### Fixed
-
-- **`/save` no longer creates repo-local `session_*.json`.** Default saves
-  now go to the managed sessions directory instead of the current workspace.
-  Explicit `/save path/to/file.json` exports still work as before (#2010).
-- **Boot-time session prune** caps managed sessions at 50 on every startup,
-  preventing unbounded growth of `~/.codewhale/sessions/`.
-- **Checkpoint path resolution** no longer hardcodes `~/.deepseek/` — uses
-  the resolved session directory instead.
-- **Plain startup no longer auto-opens the session picker.** `codewhale` and
-  `codew` start in a fresh composer again even when saved sessions exist.
-  Use `/sessions`, Ctrl+R, `--resume`, or `--continue` when you want to resume.
-- **Work sidebar now refreshes immediately** after `checklist_write`,
-  `checklist_update`, and `update_plan` tool calls, matching the existing
-  `todo_write` behavior instead of relying on the 2.5s periodic poll (#1787).
 
 ---
 

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -20,11 +20,11 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0.100"
-codewhale-config = { path = "../config", version = "0.8.57" }
-codewhale-protocol = { path = "../protocol", version = "0.8.57" }
-codewhale-release = { path = "../release", version = "0.8.57" }
-codewhale-secrets = { path = "../secrets", version = "0.8.57" }
-codewhale-tools = { path = "../tools", version = "0.8.57" }
+codewhale-config = { path = "../config", version = "0.8.58" }
+codewhale-protocol = { path = "../protocol", version = "0.8.58" }
+codewhale-release = { path = "../release", version = "0.8.58" }
+codewhale-secrets = { path = "../secrets", version = "0.8.58" }
+codewhale-tools = { path = "../tools", version = "0.8.58" }
 schemaui = { version = "0.12.0", default-features = false, optional = true }
 async-stream = "0.3.6"
 async-trait = "0.1"

--- a/npm/codewhale/package.json
+++ b/npm/codewhale/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codewhale",
-  "version": "0.8.57",
-  "codewhaleBinaryVersion": "0.8.57",
+  "version": "0.8.58",
+  "codewhaleBinaryVersion": "0.8.58",
   "description": "Install and run CodeWhale, the agentic terminal for open-source and open-weight coding models, from GitHub release artifacts.",
   "author": "Hmbown",
   "license": "MIT",

--- a/web/lib/facts.generated.ts
+++ b/web/lib/facts.generated.ts
@@ -18,8 +18,8 @@ export interface RepoFacts {
 }
 
 export const FACTS: RepoFacts = {
-  "generatedAt": "2026-06-10T06:46:48.026Z",
-  "version": "0.8.57",
+  "generatedAt": "2026-06-11T05:54:56.679Z",
+  "version": "0.8.58",
   "crates": [
     "agent",
     "app-server",


### PR DESCRIPTION
Release bump for v0.8.58 after the milestone merge train (#3034–#3050, #3054 — all merged, main CI green at `ce39b111` on all three platforms).

Produced by `./scripts/release/prepare-release.sh 0.8.58` plus the `## [0.8.58]` CHANGELOG entry: workspace + crate dependency pins, npm wrapper version + `codewhaleBinaryVersion`, README install-tag examples, `Cargo.lock`, regenerated `crates/tui/CHANGELOG.md` slice and `web/lib/facts.generated.ts`.

Preflight (all green locally):
- `./scripts/release/check-versions.sh` — workspace=0.8.58, npm=0.8.58, lockfile in sync
- `cargo fmt --all -- --check`, `cargo check --workspace --all-targets --locked`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-features --locked` — green except the 12 documented container-environment git-signing/metaso tests (passing in CI)
- `cargo build --release --locked -p codewhale-cli -p codewhale-tui` — binaries report `0.8.58`
- `node scripts/release/npm-wrapper-smoke.js` — passed with local assets
- `./scripts/release/publish-crates.sh dry-run` — exit 0

Merging this fires `auto-tag.yml` → `v0.8.58` → `release.yml`.

https://claude.ai/code/session_018zaP8vUfTAsrE38L6h6fw5

---
_Generated by [Claude Code](https://claude.ai/code/session_018zaP8vUfTAsrE38L6h6fw5)_