### PR TITLE
🧪 Add tests for optional_str missing value behavior

### DIFF
--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -541,6 +541,27 @@ mod tests {
     }
 
     #[test]
+    fn optional_str_behavior() {
+        let input = json!({
+            "valid": "string_value",
+            "number": 42,
+            "null_value": null
+        });
+
+        // Happy path
+        assert_eq!(optional_str(&input, "valid"), Some("string_value"));
+
+        // Missing field
+        assert_eq!(optional_str(&input, "missing"), None);
+
+        // Wrong type
+        assert_eq!(optional_str(&input, "number"), None);
+
+        // Null value
+        assert_eq!(optional_str(&input, "null_value"), None);
+    }
+
+    #[test]
     fn required_str_reports_provided_fields_on_missing_required_field() {
         let input = json!({"path": "src/lib.rs", "content": "new body"});
         let err = required_str(&input, "replace").expect_err("replace is missing");


### PR DESCRIPTION
🎯 **What:** This PR adds a missing test for the `optional_str` function in `crates/tools/src/lib.rs`.
📊 **Coverage:** The new test `optional_str_behavior` verifies the extraction logic when given a valid string, a missing field, an invalid type (number), and a null value.
✨ **Result:** Improved test coverage and reliability for JSON input parsing within the tool framework.

---
*PR created automatically by Jules for task [7156451692135699724](https://jules.google.com/task/7156451692135699724) started by @Hmbown*