### PR TITLE
🧪 Add test for ToolError::not_available

### DIFF
--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -559,4 +559,14 @@ mod tests {
             "Failed to validate input: missing required field 'path'"
         );
     }
+
+    #[test]
+    fn test_tool_error_not_available() {
+        let err = ToolError::not_available("custom tool not found");
+        assert!(matches!(err, ToolError::NotAvailable { .. }));
+        assert_eq!(
+            err.to_string(),
+            "Failed to locate tool: custom tool not found"
+        );
+    }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was that `ToolError::not_available` constructor was not tested.
📊 **Coverage:** The scenarios now tested are the correct instantiation of the `ToolError::NotAvailable` variant and the correctness of its formatting as a displayable string.
✨ **Result:** The improvement in test coverage increases confidence in the correctness of `ToolError` variants in `crates/tools`.

---
*PR created automatically by Jules for task [8448943810185998891](https://jules.google.com/task/8448943810185998891) started by @Hmbown*