### PR TITLE
🧪 Add test for ToolError::permission_denied

### DIFF
--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -559,4 +559,17 @@ mod tests {
             "Failed to validate input: missing required field 'path'"
         );
     }
+
+    #[test]
+    fn tool_error_permission_denied_creates_correct_variant() {
+        let err = ToolError::permission_denied("unauthorized user");
+        assert!(matches!(
+            err,
+            ToolError::PermissionDenied { .. }
+        ));
+        assert_eq!(
+            err.to_string(),
+            "Failed to authorize tool execution: unauthorized user"
+        );
+    }
 }


### PR DESCRIPTION
🎯 **What:** Added missing unit test for `ToolError::permission_denied` in `crates/tools/src/lib.rs`.
📊 **Coverage:** Now tests the constructor output and `Display` representation of the `ToolError::PermissionDenied` variant.
✨ **Result:** Improved test coverage for tool error variants, providing confidence against regressions in error string formats.

---
*PR created automatically by Jules for task [631744388609734625](https://jules.google.com/task/631744388609734625) started by @Hmbown*