### PR TITLE
🧪 Add tests for mirror_asset_url

### DIFF
--- a/crates/release/src/lib.rs
+++ b/crates/release/src/lib.rs
@@ -433,4 +433,24 @@ mod tests {
             "unexpected error: {err:#}"
         );
     }
+
+    #[test]
+    fn mirror_asset_url_formats_correctly() {
+        assert_eq!(
+            mirror_asset_url("https://example.com/assets", "file.zip"),
+            "https://example.com/assets/file.zip"
+        );
+        assert_eq!(
+            mirror_asset_url("https://example.com/assets/", "file.zip"),
+            "https://example.com/assets/file.zip"
+        );
+        assert_eq!(
+            mirror_asset_url("https://example.com/assets//", "file.zip"),
+            "https://example.com/assets/file.zip"
+        );
+        assert_eq!(
+            mirror_asset_url("", "file.zip"),
+            "/file.zip"
+        );
+    }
 }


### PR DESCRIPTION
🎯 **What:** Added tests for the `mirror_asset_url` function in `crates/release/src/lib.rs`.
📊 **Coverage:** The test checks various base URL formats including those with no trailing slash, single trailing slash, multiple trailing slashes, and an empty base URL string to properly validate formatting logic.
✨ **Result:** Improved test coverage, ensuring `mirror_asset_url` consistently correctly concatenates base URLs and asset filenames.

---
*PR created automatically by Jules for task [7836179193206692074](https://jules.google.com/task/7836179193206692074) started by @Hmbown*