### PR TITLE
🧹 Remove unused `has_open_entries` in slop_ledger

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -2488,13 +2488,7 @@ impl Engine {
 
         let loaded = crate::slop_ledger::SlopLedger::load()
             .ok()
-            .and_then(|ledger| {
-                if ledger.has_open_entries() {
-                    ledger.completion_gate_summary()
-                } else {
-                    None
-                }
-            });
+            .and_then(|ledger| ledger.completion_gate_summary());
         self.slop_ledger_gate_cache = Some((modified, loaded.clone()));
         loaded
     }

--- a/crates/tui/src/slop_ledger.rs
+++ b/crates/tui/src/slop_ledger.rs
@@ -970,23 +970,6 @@ fn redact_exported_text(text: &mut String) {
 }
 
 impl SlopLedger {
-    /// Completion-gate / verifier hook: returns `true` when there are
-    /// unresolved slop entries (status `Open` or `InProgress`) that the
-    /// agent should review before claiming the task is done.
-    ///
-    /// Tools and engine hooks can call this on claim-of-done to surface
-    /// architectural residue the agent may have overlooked.
-    #[allow(dead_code)]
-    #[must_use]
-    pub fn has_open_entries(&self) -> bool {
-        self.entries.iter().any(|e| {
-            matches!(
-                e.status,
-                SlopEntryStatus::Open | SlopEntryStatus::InProgress
-            )
-        })
-    }
-
     /// Return a concise completion-gate summary suitable for a verifier
     /// sub-agent or the claim-of-done prompt. Returns `None` when all
     /// entries are resolved — the caller can then treat the gate as "pass".

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -2031,7 +2031,6 @@ async fn run_event_loop(
                             // done (#2127). This runs autonomously — no tool call
                             // required — so the agent can't forget to check.
                             if let Ok(ledger) = crate::slop_ledger::SlopLedger::load()
-                                && ledger.has_open_entries()
                                 && let Some(gate_msg) = ledger.completion_gate_summary()
                             {
                                 let short = gate_msg.lines().nth(4).unwrap_or("review before done");


### PR DESCRIPTION
🎯 **What:** Removed the `has_open_entries` function from `crates/tui/src/slop_ledger.rs` and simplified its call sites.
💡 **Why:** The function was unused dead code in practice because `completion_gate_summary()` performs the exact same check internally before returning anything. Using `completion_gate_summary` directly is simpler and removes redundancy.
✅ **Verification:** Verified by running `cargo check`, `cargo fmt --check`, `cargo clippy`, and `cargo test slop_ledger` - all checks passed successfully.
✨ **Result:** Improved code maintainability by deleting a redundant function and making code shorter and simpler.

---
*PR created automatically by Jules for task [5836367800244141658](https://jules.google.com/task/5836367800244141658) started by @Hmbown*