### PR TITLE
🧪 [testing] tests for fetchFeed in github.ts

### DIFF
--- a/web/lib/github.test.ts
+++ b/web/lib/github.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { lastPageFromLink, relativeTime } from "./github";
+import { lastPageFromLink, relativeTime, fetchFeed } from "./github";
 
 // We test the pure helper functions directly.
 // The async fetch functions require mocking the global fetch.
@@ -80,5 +80,140 @@ describe("lastPageFromLink", () => {
   it("returns undefined for invalid URL format", () => {
     const link = "not-a-valid-link-header; rel=last";
     expect(lastPageFromLink(link)).toBeUndefined();
+  });
+});
+
+
+// ── fetchFeed ────────────────────────────────────────────────────────
+
+describe("fetchFeed", () => {
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    global.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.clearAllMocks();
+  });
+
+  const mockIssue = {
+    number: 1,
+    title: "Test Issue",
+    html_url: "https://github.com/Hmbown/CodeWhale/issues/1",
+    state: "open",
+    user: { login: "tester", avatar_url: "https://avatars.githubusercontent.com/u/1?v=4" },
+    created_at: "2026-06-01T10:00:00Z",
+    updated_at: "2026-06-01T11:00:00Z",
+    comments: 0,
+    labels: [{ name: "bug", color: "d73a4a" }],
+    body: "This is a test issue",
+  };
+
+  const mockPullRequestFromIssues = {
+    ...mockIssue,
+    number: 2,
+    title: "Test PR in Issues",
+    pull_request: { url: "..." },
+    updated_at: "2026-06-01T11:30:00Z",
+  };
+
+  const mockPullRequest = {
+    number: 3,
+    title: "Test PR",
+    html_url: "https://github.com/Hmbown/CodeWhale/pull/3",
+    state: "open",
+    user: { login: "pr-tester", avatar_url: "https://avatars.githubusercontent.com/u/2?v=4" },
+    created_at: "2026-06-01T09:00:00Z",
+    updated_at: "2026-06-01T10:30:00Z",
+    comments: 2,
+    labels: [],
+    body: "This is a test PR",
+    merged_at: null,
+    draft: false,
+  };
+
+  it("fetches and combines issues and pull requests correctly", async () => {
+    const mockIssuesResponse = [mockIssue, mockPullRequestFromIssues];
+    const mockPullsResponse = [
+      mockPullRequest,
+      { ...mockPullRequest, number: 4, state: "closed", merged_at: "2026-06-01T10:00:00Z", updated_at: "2026-06-01T12:00:00Z" },
+      { ...mockPullRequest, number: 5, draft: true, updated_at: "2026-06-01T12:30:00Z" }
+    ];
+
+    vi.mocked(global.fetch).mockImplementation(async (url) => {
+      if (typeof url === "string" && url.includes("/issues")) {
+        return { ok: true, json: async () => mockIssuesResponse } as Response;
+      }
+      if (typeof url === "string" && url.includes("/pulls")) {
+        return { ok: true, json: async () => mockPullsResponse } as Response;
+      }
+      return { ok: false } as Response;
+    });
+
+    const feed = await fetchFeed();
+
+    expect(feed.length).toBe(4); // 1 issue + 3 PRs (mockPullRequestFromIssues is filtered)
+
+    // Check sorting (descending by updatedAt)
+    expect(feed[0].number).toBe(5); // 12:30
+    expect(feed[1].number).toBe(4); // 12:00
+    expect(feed[2].number).toBe(1); // 11:00
+    expect(feed[3].number).toBe(3); // 10:30
+
+    // Check mapping
+    const mergedPr = feed.find(f => f.number === 4);
+    expect(mergedPr?.state).toBe("merged");
+
+    const draftPr = feed.find(f => f.number === 5);
+    expect(draftPr?.state).toBe("draft");
+
+    const issue = feed.find(f => f.number === 1);
+    expect(issue?.kind).toBe("issue");
+  });
+
+  it("handles GitHub API errors gracefully", async () => {
+    vi.mocked(global.fetch).mockResolvedValue({ ok: false } as Response);
+
+    const feed = await fetchFeed();
+    expect(feed).toEqual([]);
+  });
+
+  it("passes the correct headers and token to fetch", async () => {
+    vi.mocked(global.fetch).mockResolvedValue({ ok: true, json: async () => [] } as Response);
+
+    await fetchFeed("test-token");
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+
+    const issuesCall = vi.mocked(global.fetch).mock.calls[0];
+    const pullsCall = vi.mocked(global.fetch).mock.calls[1];
+
+    expect(issuesCall[1]?.headers).toHaveProperty("Authorization", "Bearer test-token");
+    expect(pullsCall[1]?.headers).toHaveProperty("Authorization", "Bearer test-token");
+  });
+
+  it("limits the returned items based on the limit parameter", async () => {
+    // Generate 40 items
+    const mockIssuesResponse = Array.from({ length: 40 }).map((_, i) => ({
+      ...mockIssue,
+      number: i + 1,
+      updated_at: `2026-06-01T11:${i < 10 ? '0' + i : i}:00Z`,
+    }));
+
+    vi.mocked(global.fetch).mockImplementation(async (url) => {
+      if (typeof url === "string" && url.includes("/issues")) {
+        return { ok: true, json: async () => mockIssuesResponse } as Response;
+      }
+      if (typeof url === "string" && url.includes("/pulls")) {
+        return { ok: true, json: async () => [] } as Response;
+      }
+      return { ok: false } as Response;
+    });
+
+    const feed = await fetchFeed(undefined, 25);
+    expect(feed.length).toBe(25);
   });
 });


### PR DESCRIPTION
🎯 **What:** The testing gap in `web/lib/github.ts` for the `fetchFeed` function has been addressed. The function gathers and processes feed items from GitHub issues and pull requests, handling filters, sorts, mapping, error logic, limits, and authorization. 

📊 **Coverage:** The new tests now cover:
- Correctly gathering issues and pull requests, filtering out duplicates, mapping to proper issue states (`draft`, `merged`), and sorting descending by `updatedAt`.
- Error handling strategies if the GitHub APIs fail.
- Propagation of headers like `Authorization` with passed tokens.
- Output limiting behaviors as per the given `limit` argument.

✨ **Result:** Test coverage for `github.ts` has significantly increased, ensuring confident refactoring and functionality maintenance moving forward.

---
*PR created automatically by Jules for task [13749334664405087754](https://jules.google.com/task/13749334664405087754) started by @Hmbown*