### PR TITLE
⚡ Optimize thread fetching in list_threads_summary

### DIFF
--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -1193,13 +1193,17 @@ async fn list_threads_summary(
         .await
         .map_err(|e| ApiError::internal(e.to_string()))?;
 
-    let mut summaries = Vec::new();
-    for thread in threads {
-        let detail = state
+    let detail_futures = threads.iter().map(|thread| async {
+        state
             .runtime_threads
             .get_thread_detail(&thread.id)
             .await
-            .map_err(map_thread_err)?;
+            .map_err(map_thread_err)
+    });
+    let details = futures_util::future::try_join_all(detail_futures).await?;
+
+    let mut summaries = Vec::new();
+    for (thread, detail) in threads.into_iter().zip(details.into_iter()) {
         let latest_turn = detail.turns.last();
         let latest_status =
             latest_turn.map(|turn| format!("{:?}", turn.status).to_ascii_lowercase());


### PR DESCRIPTION
💡 **What:** Replaced the sequential iteration over threads for fetching `get_thread_detail` in `list_threads_summary` with concurrent execution via `futures_util::future::try_join_all()`.

🎯 **Why:** To improve API latency when listing threads, particularly when many threads are returned. Previously, it processed the N state lookups and I/O awaits sequentially. Doing this concurrently scales linearly and yields O(1) latency scaled by network/IO conditions for N threads.

📊 **Measured Improvement:** No direct baseline was collected with a test framework since generating meaningful benchmarking conditions (numerous local threads populated in state database) would require complex scaffolding outside the scope of this improvement. However, structurally changing N sequential network/local DB lookups to concurrent operations guarantees performance bounds scaling proportional to the thread limit (up to 500 records), preventing severe N+1 request latency degradation when large thread collections are displayed to users.

---
*PR created automatically by Jules for task [7608052014730580245](https://jules.google.com/task/7608052014730580245) started by @Hmbown*