### PR TITLE
🧪 Add test for ToolResult::success

### DIFF
--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -522,6 +522,16 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_tool_result_success() {
+        let content = "operation completed successfully";
+        let result = ToolResult::success(content);
+
+        assert!(result.success);
+        assert_eq!(result.content, content);
+        assert!(result.metadata.is_none());
+    }
+
+    #[test]
     fn tool_result_json_round_trips_content() {
         let result = ToolResult::json(&json!({"ok": true})).expect("json");
         assert!(result.success);


### PR DESCRIPTION
🎯 **What:** Added a test for the `ToolResult::success` constructor in `crates/tools/src/lib.rs`.
📊 **Coverage:** Ensures that the `ToolResult::success` method correctly sets up its internal state (`success=true`, exact content match, and `metadata=None`).
✨ **Result:** Improved test coverage for `ToolResult` utility methods, providing confidence in its correct initialization.

---
*PR created automatically by Jules for task [6643528892316758319](https://jules.google.com/task/6643528892316758319) started by @Hmbown*