### PR TITLE
🧪 Test `ToolCall::execution_subject` in `codewhale-tools`

### DIFF
--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -559,4 +559,54 @@ mod tests {
             "Failed to validate input: missing required field 'path'"
         );
     }
+
+    #[test]
+    fn tool_call_execution_subject_local_shell_with_cwd() {
+        let call = ToolCall {
+            name: "shell".to_string(),
+            payload: ToolPayload::LocalShell {
+                params: codewhale_protocol::LocalShellParams {
+                    command: "ls -l".to_string(),
+                    cwd: Some("/custom/dir".to_string()),
+                    timeout_ms: None,
+                },
+            },
+            source: ToolCallSource::Direct,
+            raw_tool_call_id: None,
+        };
+        let subject = call.execution_subject("/fallback/dir");
+        assert_eq!(subject, ("ls -l".to_string(), "/custom/dir".to_string(), "shell"));
+    }
+
+    #[test]
+    fn tool_call_execution_subject_local_shell_without_cwd() {
+        let call = ToolCall {
+            name: "shell".to_string(),
+            payload: ToolPayload::LocalShell {
+                params: codewhale_protocol::LocalShellParams {
+                    command: "echo hello".to_string(),
+                    cwd: None,
+                    timeout_ms: None,
+                },
+            },
+            source: ToolCallSource::Direct,
+            raw_tool_call_id: None,
+        };
+        let subject = call.execution_subject("/fallback/dir");
+        assert_eq!(subject, ("echo hello".to_string(), "/fallback/dir".to_string(), "shell"));
+    }
+
+    #[test]
+    fn tool_call_execution_subject_non_shell() {
+        let call = ToolCall {
+            name: "my_tool".to_string(),
+            payload: ToolPayload::Function {
+                arguments: "{}".to_string(),
+            },
+            source: ToolCallSource::Direct,
+            raw_tool_call_id: None,
+        };
+        let subject = call.execution_subject("/fallback/dir");
+        assert_eq!(subject, ("my_tool".to_string(), "/fallback/dir".to_string(), "tool"));
+    }
 }


### PR DESCRIPTION
🎯 **What:** The `ToolCall::execution_subject` method was lacking unit test coverage to ensure its derivation of execution subjects based on `ToolPayload` kinds returned the correct tuples.
📊 **Coverage:** The test suite now encompasses:
- `ToolPayload::LocalShell` where `cwd` is explicitly provided.
- `ToolPayload::LocalShell` where `cwd` is missing and should use the fallback.
- `ToolPayload::Function` representing a normal tool payload lacking a shell execution wrapper.
✨ **Result:** Enhanced test reliability guaranteeing that modifications or expansions to `ToolPayload` types safely resolve execution tracking contexts and directories.

---
*PR created automatically by Jules for task [14270420329080243344](https://jules.google.com/task/14270420329080243344) started by @Hmbown*