### PR TITLE
🧪 Add test for `update_network_fallback_hint`

### DIFF
--- a/crates/release/src/lib.rs
+++ b/crates/release/src/lib.rs
@@ -433,4 +433,22 @@ mod tests {
             "unexpected error: {err:#}"
         );
     }
+
+    #[test]
+    fn update_network_fallback_hint_contains_constants() {
+        let hint = update_network_fallback_hint();
+        assert!(hint.contains(CNB_REPO_URL), "Hint missing CNB_REPO_URL");
+        assert!(
+            hint.contains(RELEASE_BASE_URL_ENV),
+            "Hint missing RELEASE_BASE_URL_ENV"
+        );
+        assert!(
+            hint.contains(UPDATE_VERSION_ENV),
+            "Hint missing UPDATE_VERSION_ENV"
+        );
+        assert!(
+            hint.contains(CHECKSUM_MANIFEST_ASSET),
+            "Hint missing CHECKSUM_MANIFEST_ASSET"
+        );
+    }
 }


### PR DESCRIPTION
🎯 **What:** Adds a test for `update_network_fallback_hint` to ensure that it correctly constructs the fallback string with the appropriate URLs and environment variable names.
📊 **Coverage:** Tests that the human-readable network fallback hint includes `CNB_REPO_URL`, `RELEASE_BASE_URL_ENV`, `UPDATE_VERSION_ENV`, and `CHECKSUM_MANIFEST_ASSET`.
✨ **Result:** Improved test coverage for `crates/release` preventing accidental removal or mutation of these necessary instructions.

---
*PR created automatically by Jules for task [5052621160596173963](https://jules.google.com/task/5052621160596173963) started by @Hmbown*