### PR TITLE
🧪 Add test for ToolError::execution_failed

### DIFF
--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -559,4 +559,14 @@ mod tests {
             "Failed to validate input: missing required field 'path'"
         );
     }
+
+    #[test]
+    fn test_tool_error_execution_failed() {
+        let err = ToolError::execution_failed("process crashed");
+        assert!(matches!(err, ToolError::ExecutionFailed { ref message } if message == "process crashed"));
+        assert_eq!(
+            err.to_string(),
+            "Failed to execute tool: process crashed"
+        );
+    }
 }


### PR DESCRIPTION
🎯 **What:** Added a unit test for the `ToolError::execution_failed` constructor.
📊 **Coverage:** The test checks that the returned variant is `ExecutionFailed` and verifies the string formatting for the `Display` trait.
✨ **Result:** Enhanced test coverage for the tool errors and prevented regressions in its behavior.

---
*PR created automatically by Jules for task [164910515851892921](https://jules.google.com/task/164910515851892921) started by @Hmbown*