### PR TITLE
🧹 Refactor walk_for_completions to use SearchContext

### DIFF
--- a/crates/tui/src/working_set.rs
+++ b/crates/tui/src/working_set.rs
@@ -35,6 +35,14 @@ pub struct Workspace {
     completion_walk_depth: Option<usize>,
 }
 
+struct SearchContext<'a> {
+    needle: &'a str,
+    limit: usize,
+    prefix_hits: &'a mut Vec<String>,
+    substring_hits: &'a mut Vec<String>,
+    seen: &'a mut HashSet<PathBuf>,
+}
+
 impl Workspace {
     /// Construct a workspace anchored at `root`, capturing the process CWD as
     /// the secondary resolution pass. Convenience entry point intended for
@@ -220,51 +228,28 @@ impl Workspace {
         // Walk the recorded cwd first when it diverges from the workspace
         // root, so cwd-relative entries appear ahead of duplicates surfaced by
         // the workspace walk.
+        let mut ctx = SearchContext {
+            needle: &needle,
+            limit,
+            prefix_hits: &mut prefix_hits,
+            substring_hits: &mut substring_hits,
+            seen: &mut seen,
+        };
+
         let cwd_diverges = self
             .cwd
             .as_deref()
             .map(|c| c != self.root.as_path())
             .unwrap_or(false);
         if cwd_diverges && let Some(cwd) = self.cwd.as_deref() {
-            walk_for_completions(
-                cwd,
-                cwd,
-                &needle,
-                limit,
-                &mut prefix_hits,
-                &mut substring_hits,
-                &mut seen,
-                self.completion_walk_depth,
-            );
-            add_local_reference_completions(
-                cwd,
-                cwd,
-                &needle,
-                limit,
-                &mut prefix_hits,
-                &mut substring_hits,
-                &mut seen,
-                self.completion_walk_depth,
-            );
+            walk_for_completions(cwd, cwd, &mut ctx, self.completion_walk_depth);
+            add_local_reference_completions(cwd, cwd, &mut ctx, self.completion_walk_depth);
         }
-        walk_for_completions(
-            &self.root,
-            &self.root,
-            &needle,
-            limit,
-            &mut prefix_hits,
-            &mut substring_hits,
-            &mut seen,
-            self.completion_walk_depth,
-        );
+        walk_for_completions(&self.root, &self.root, &mut ctx, self.completion_walk_depth);
         add_local_reference_completions(
             &self.root,
             &self.root,
-            &needle,
-            limit,
-            &mut prefix_hits,
-            &mut substring_hits,
-            &mut seen,
+            &mut ctx,
             self.completion_walk_depth,
         );
 
@@ -402,15 +387,10 @@ fn discovery_walk_builder(root: &Path, max_depth: Option<usize>) -> WalkBuilder 
 /// Walk the AI-tool dot-directories (`.deepseek/`, `.cursor/`, `.claude/`,
 /// `.agents/`) with gitignore disabled so their contents are discoverable
 /// even when the project's `.gitignore` / `.ignore` excludes them.
-#[allow(clippy::too_many_arguments)]
 fn walk_always_discoverable_dirs(
     walk_root: &Path,
     display_root: &Path,
-    needle: &str,
-    limit: usize,
-    prefix_hits: &mut Vec<String>,
-    substring_hits: &mut Vec<String>,
-    seen: &mut HashSet<PathBuf>,
+    ctx: &mut SearchContext<'_>,
     max_depth: Option<usize>,
 ) {
     for dir_name in DISCOVERY_ALWAYS_DIRS {
@@ -428,7 +408,7 @@ fn walk_always_discoverable_dirs(
             builder.max_depth(Some(depth.saturating_sub(1)));
         }
         for entry in builder.build().flatten() {
-            if prefix_hits.len() + substring_hits.len() >= limit {
+            if ctx.prefix_hits.len() + ctx.substring_hits.len() >= ctx.limit {
                 break;
             }
             let path = entry.path();
@@ -445,7 +425,7 @@ fn walk_always_discoverable_dirs(
                 continue;
             }
             let abs = path.to_path_buf();
-            if !seen.insert(abs) {
+            if !ctx.seen.insert(abs) {
                 continue;
             }
             let is_dir = entry.file_type().is_some_and(|ft| ft.is_dir());
@@ -455,30 +435,25 @@ fn walk_always_discoverable_dirs(
                 rel_str.clone()
             };
             let lower = candidate.to_lowercase();
-            if needle.is_empty() || lower.starts_with(needle) {
-                prefix_hits.push(candidate);
-            } else if lower.contains(needle) {
-                substring_hits.push(candidate);
+            if ctx.needle.is_empty() || lower.starts_with(ctx.needle) {
+                ctx.prefix_hits.push(candidate);
+            } else if lower.contains(ctx.needle) {
+                ctx.substring_hits.push(candidate);
             }
         }
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 fn walk_for_completions(
     walk_root: &Path,
     display_root: &Path,
-    needle: &str,
-    limit: usize,
-    prefix_hits: &mut Vec<String>,
-    substring_hits: &mut Vec<String>,
-    seen: &mut HashSet<PathBuf>,
+    ctx: &mut SearchContext<'_>,
     max_depth: Option<usize>,
 ) {
     let builder = discovery_walk_builder(walk_root, max_depth);
 
     for entry in builder.build().flatten() {
-        if prefix_hits.len() + substring_hits.len() >= limit {
+        if ctx.prefix_hits.len() + ctx.substring_hits.len() >= ctx.limit {
             break;
         }
         let path = entry.path();
@@ -492,7 +467,7 @@ fn walk_for_completions(
         // Dedup across the (cwd, workspace) double-walk by absolute path; we
         // want the cwd-relative display when both walks see the same file.
         let abs = path.to_path_buf();
-        if !seen.insert(abs) {
+        if !ctx.seen.insert(abs) {
             continue;
         }
         let is_dir = entry.file_type().is_some_and(|ft| ft.is_dir());
@@ -502,60 +477,46 @@ fn walk_for_completions(
             rel_str.clone()
         };
         let lower = candidate.to_lowercase();
-        if needle.is_empty() || lower.starts_with(needle) {
-            prefix_hits.push(candidate);
-        } else if lower.contains(needle) {
-            substring_hits.push(candidate);
+        if ctx.needle.is_empty() || lower.starts_with(ctx.needle) {
+            ctx.prefix_hits.push(candidate);
+        } else if lower.contains(ctx.needle) {
+            ctx.substring_hits.push(candidate);
         }
     }
 
     // Also walk the AI-tool dot-directories with gitignore disabled so
     // `.deepseek/`, `.cursor/`, etc. are always discoverable.
-    walk_always_discoverable_dirs(
-        walk_root,
-        display_root,
-        needle,
-        limit,
-        prefix_hits,
-        substring_hits,
-        seen,
-        max_depth,
-    );
+    walk_always_discoverable_dirs(walk_root, display_root, ctx, max_depth);
 }
 
 const LOCAL_REFERENCE_SCAN_LIMIT: usize = 4096;
 
-#[allow(clippy::too_many_arguments)]
 fn add_local_reference_completions(
     root: &Path,
     display_root: &Path,
-    needle: &str,
-    limit: usize,
-    prefix_hits: &mut Vec<String>,
-    substring_hits: &mut Vec<String>,
-    seen: &mut HashSet<PathBuf>,
+    ctx: &mut SearchContext<'_>,
     max_depth: Option<usize>,
 ) {
-    if !should_try_local_reference_completion(needle) {
+    if !should_try_local_reference_completion(ctx.needle) {
         return;
     }
 
     for path in local_reference_paths(root, LOCAL_REFERENCE_SCAN_LIMIT, max_depth) {
-        if prefix_hits.len() + substring_hits.len() >= limit {
+        if ctx.prefix_hits.len() + ctx.substring_hits.len() >= ctx.limit {
             break;
         }
         let Ok(rel) = path.strip_prefix(display_root) else {
             continue;
         };
         let rel_str = rel.to_string_lossy().replace('\\', "/");
-        if rel_str.is_empty() || !seen.insert(path.clone()) {
+        if rel_str.is_empty() || !ctx.seen.insert(path.clone()) {
             continue;
         }
         let lower = rel_str.to_lowercase();
-        if needle.is_empty() || lower.starts_with(needle) {
-            prefix_hits.push(rel_str);
-        } else if lower.contains(needle) {
-            substring_hits.push(rel_str);
+        if ctx.needle.is_empty() || lower.starts_with(ctx.needle) {
+            ctx.prefix_hits.push(rel_str);
+        } else if lower.contains(ctx.needle) {
+            ctx.substring_hits.push(rel_str);
         }
     }
 }


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was "High Complexity: Too Many Arguments in `walk_for_completions`". This was resolved by creating a `SearchContext` struct that groups the 5 related search state parameters and passing it by mutable reference instead.
  💡 **Why:** How this improves maintainability: The functions `walk_for_completions`, `walk_always_discoverable_dirs`, and `add_local_reference_completions` each took 8 arguments. Grouping 5 of these related search-state arguments into a single struct greatly reduces signature complexity and allows for the removal of the `#[allow(clippy::too_many_arguments)]` pragma.
  ✅ **Verification:** I successfully confirmed that the changes did not break the functionality by ensuring that the codebase compiled warning-free with `cargo check` and `cargo clippy`, formatted correctly using `cargo fmt`, and passed all the tests related to `working_set` and `codewhale-tui`.
  ✨ **Result:** The signatures are now simpler, easier to read, and `clippy` exceptions have been cleanly removed, leaving the project in a slightly healthier state.

---
*PR created automatically by Jules for task [18290017424165256247](https://jules.google.com/task/18290017424165256247) started by @Hmbown*