### PR TITLE
🧪 [Testing] Add tests for from_beta_flag in ReleaseChannel

### DIFF
--- a/crates/release/src/lib.rs
+++ b/crates/release/src/lib.rs
@@ -350,6 +350,12 @@ mod tests {
     use super::*;
 
     #[test]
+    fn from_beta_flag_returns_correct_channel() {
+        assert_eq!(ReleaseChannel::from_beta_flag(true), ReleaseChannel::Beta);
+        assert_eq!(ReleaseChannel::from_beta_flag(false), ReleaseChannel::Stable);
+    }
+
+    #[test]
     fn cnb_release_base_url_includes_tag_directory() {
         assert_eq!(
             cnb_release_base_url("0.8.47"),


### PR DESCRIPTION
🎯 **What:** Testing gap addressed for `ReleaseChannel::from_beta_flag` function located at `crates/release/src/lib.rs`.
📊 **Coverage:** Tests `from_beta_flag` method on `ReleaseChannel` handling of boolean inputs mapping to stable or beta enums.
✨ **Result:** Improved test coverage by establishing correct behaviors for this utility function, providing greater confidence against regressions.

---
*PR created automatically by Jules for task [9522929121744389036](https://jules.google.com/task/9522929121744389036) started by @Hmbown*