### PR TITLE
🧪 Add unit tests for resolve_release_query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -914,6 +914,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "serial_test",
 ]
 
 [[package]]
@@ -4621,6 +4622,31 @@ dependencies = [
  "cfg-if",
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/crates/release/Cargo.toml
+++ b/crates/release/Cargo.toml
@@ -12,3 +12,6 @@ reqwest = { workspace = true, features = ["blocking"] }
 semver.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+
+[dev-dependencies]
+serial_test = "3.5.0"

--- a/crates/release/src/lib.rs
+++ b/crates/release/src/lib.rs
@@ -348,6 +348,154 @@ fn version_is_beta(version: &semver::Version) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
+
+    fn clear_env() {
+        unsafe {
+            std::env::remove_var(RELEASE_BASE_URL_ENV);
+            std::env::remove_var(LEGACY_RELEASE_BASE_URL_ENV);
+            std::env::remove_var(DEEPSEEK_RELEASE_BASE_URL_ENV);
+            std::env::remove_var(CNB_MIRROR_ENV);
+            std::env::remove_var(UPDATE_VERSION_ENV);
+            std::env::remove_var(LEGACY_UPDATE_VERSION_ENV);
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_release_query_default() {
+        clear_env();
+
+        let query_stable = resolve_release_query(ReleaseChannel::Stable);
+        assert_eq!(
+            query_stable,
+            ReleaseQuery::GitHubLatest {
+                url: LATEST_RELEASE_URL
+            }
+        );
+
+        let query_beta = resolve_release_query(ReleaseChannel::Beta);
+        assert_eq!(
+            query_beta,
+            ReleaseQuery::GitHubReleaseList {
+                url: RELEASES_URL
+            }
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_release_query_mirror_env() {
+        clear_env();
+        unsafe {
+            std::env::set_var(RELEASE_BASE_URL_ENV, "https://example.com/mirror");
+        }
+
+        let query = resolve_release_query(ReleaseChannel::Stable);
+        let default_version = env!("CARGO_PKG_VERSION");
+        assert_eq!(
+            query,
+            ReleaseQuery::Mirror {
+                base_url: "https://example.com/mirror".to_string(),
+                version: default_version.to_string()
+            }
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_release_query_mirror_legacy_env() {
+        clear_env();
+        unsafe {
+            std::env::set_var(LEGACY_RELEASE_BASE_URL_ENV, "https://legacy.com/mirror");
+        }
+
+        let query = resolve_release_query(ReleaseChannel::Stable);
+        let default_version = env!("CARGO_PKG_VERSION");
+        assert_eq!(
+            query,
+            ReleaseQuery::Mirror {
+                base_url: "https://legacy.com/mirror".to_string(),
+                version: default_version.to_string()
+            }
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_release_query_mirror_deepseek_env() {
+        clear_env();
+        unsafe {
+            std::env::set_var(DEEPSEEK_RELEASE_BASE_URL_ENV, "https://deepseek.com/mirror");
+        }
+
+        let query = resolve_release_query(ReleaseChannel::Stable);
+        let default_version = env!("CARGO_PKG_VERSION");
+        assert_eq!(
+            query,
+            ReleaseQuery::Mirror {
+                base_url: "https://deepseek.com/mirror".to_string(),
+                version: default_version.to_string()
+            }
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_release_query_cnb_mirror() {
+        clear_env();
+        unsafe {
+            std::env::set_var(CNB_MIRROR_ENV, "1");
+        }
+
+        let query = resolve_release_query(ReleaseChannel::Stable);
+        let default_version = env!("CARGO_PKG_VERSION");
+        assert_eq!(
+            query,
+            ReleaseQuery::Mirror {
+                base_url: cnb_release_base_url(default_version),
+                version: default_version.to_string()
+            }
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_release_query_pinned_version() {
+        clear_env();
+        unsafe {
+            std::env::set_var(RELEASE_BASE_URL_ENV, "https://example.com/mirror");
+            std::env::set_var(UPDATE_VERSION_ENV, "v1.2.3");
+        }
+
+        let query = resolve_release_query(ReleaseChannel::Stable);
+        assert_eq!(
+            query,
+            ReleaseQuery::Mirror {
+                base_url: "https://example.com/mirror".to_string(),
+                version: "1.2.3".to_string()
+            }
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_release_query_legacy_pinned_version() {
+        clear_env();
+        unsafe {
+            std::env::set_var(RELEASE_BASE_URL_ENV, "https://example.com/mirror");
+            std::env::set_var(LEGACY_UPDATE_VERSION_ENV, "v1.2.3-legacy");
+        }
+
+        let query = resolve_release_query(ReleaseChannel::Stable);
+        assert_eq!(
+            query,
+            ReleaseQuery::Mirror {
+                base_url: "https://example.com/mirror".to_string(),
+                version: "1.2.3-legacy".to_string()
+            }
+        );
+    }
 
     #[test]
     fn cnb_release_base_url_includes_tag_directory() {


### PR DESCRIPTION
🎯 **What:** Added tests to cover the `resolve_release_query` function in `crates/release/src/lib.rs` which previously lacked unit test coverage. Since this function relies on environment variables, testing required safe state manipulation to prevent test flakiness.

📊 **Coverage:** 
The tests now cover:
- Default behavior without environment variables for `Stable` and `Beta` channels.
- Override behavior when `RELEASE_BASE_URL_ENV` (and legacy variants) are set.
- Override behavior when `CNB_MIRROR_ENV` is set.
- Combined behavior when both a mirror base URL and an update pinned version are specified via environment variables.

✨ **Result:** Improved test coverage for core release channel logic. Test execution uses `#[serial]` to prevent data races during environment variable access.

---
*PR created automatically by Jules for task [5235319121031014900](https://jules.google.com/task/5235319121031014900) started by @Hmbown*