### PR TITLE
🧪 Test ReleaseChannel::label

### DIFF
--- a/crates/release/src/lib.rs
+++ b/crates/release/src/lib.rs
@@ -350,6 +350,21 @@ mod tests {
     use super::*;
 
     #[test]
+    fn release_channel_from_beta_flag() {
+        assert_eq!(ReleaseChannel::from_beta_flag(true), ReleaseChannel::Beta);
+        assert_eq!(
+            ReleaseChannel::from_beta_flag(false),
+            ReleaseChannel::Stable
+        );
+    }
+
+    #[test]
+    fn release_channel_label() {
+        assert_eq!(ReleaseChannel::Stable.label(), "stable");
+        assert_eq!(ReleaseChannel::Beta.label(), "beta");
+    }
+
+    #[test]
     fn cnb_release_base_url_includes_tag_directory() {
         assert_eq!(
             cnb_release_base_url("0.8.47"),


### PR DESCRIPTION
🎯 **What:** Adds missing test coverage for `ReleaseChannel::from_beta_flag` and `ReleaseChannel::label` in `crates/release/src/lib.rs`.
📊 **Coverage:** Covers both `Stable` and `Beta` variants for both functions.
✨ **Result:** Increased test coverage and confidence in `ReleaseChannel` functionality.

---
*PR created automatically by Jules for task [11415620575576534827](https://jules.google.com/task/11415620575576534827) started by @Hmbown*