### PR TITLE
🧪 Add unit test for ToolError::missing_field constructor

### DIFF
--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -559,4 +559,10 @@ mod tests {
             "Failed to validate input: missing required field 'path'"
         );
     }
+
+    #[test]
+    fn tool_error_missing_field_constructor() {
+        let err = ToolError::missing_field("my_field");
+        assert!(matches!(err, ToolError::MissingField { field } if field == "my_field"));
+    }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR addresses the lack of test coverage for the `ToolError::missing_field` variant constructor in `crates/tools/src/lib.rs`.

📊 **Coverage:** What scenarios are now tested
A new unit test `tool_error_missing_field_constructor` was added to verify that calling the `missing_field` constructor correctly builds the `ToolError::MissingField` enum variant with the provided string payload.

✨ **Result:** The improvement in test coverage
Increased test coverage for `ToolError` helper constructors, ensuring refactoring safety.

---
*PR created automatically by Jules for task [9709596818144160378](https://jules.google.com/task/9709596818144160378) started by @Hmbown*