### PR TITLE
🧪 Add test for ToolError::invalid_input

### DIFF
--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -559,4 +559,13 @@ mod tests {
             "Failed to validate input: missing required field 'path'"
         );
     }
+
+    #[test]
+    fn tool_error_invalid_input_creates_correct_variant() {
+        let err = ToolError::invalid_input("test invalid message");
+        match err {
+            ToolError::InvalidInput { message } => assert_eq!(message, "test invalid message"),
+            _ => panic!("Expected ToolError::InvalidInput, got {:?}", err),
+        }
+    }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of unit tests for the `ToolError::invalid_input` constructor in `crates/tools/src/lib.rs`.
📊 **Coverage:** The test ensures that `invalid_input` produces the correct `ToolError::InvalidInput` enum variant with the provided message payload.
✨ **Result:** Increased test coverage for tool error construction, ensuring no regressions in fundamental error types used throughout the tools crate.

---
*PR created automatically by Jules for task [1334347659824431821](https://jules.google.com/task/1334347659824431821) started by @Hmbown*