### PR TITLE
🧪 Add tests for release_base_url_from_env

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -914,6 +914,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "serial_test",
 ]
 
 [[package]]
@@ -4621,6 +4622,31 @@ dependencies = [
  "cfg-if",
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/crates/release/Cargo.toml
+++ b/crates/release/Cargo.toml
@@ -12,3 +12,6 @@ reqwest = { workspace = true, features = ["blocking"] }
 semver.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+
+[dev-dependencies]
+serial_test = "3.1.1"

--- a/crates/release/src/lib.rs
+++ b/crates/release/src/lib.rs
@@ -434,3 +434,114 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+mod env_tests {
+    use super::*;
+    use serial_test::serial;
+
+    fn clear_all_envs() {
+        unsafe {
+            std::env::remove_var(RELEASE_BASE_URL_ENV);
+            std::env::remove_var(LEGACY_RELEASE_BASE_URL_ENV);
+            std::env::remove_var(DEEPSEEK_RELEASE_BASE_URL_ENV);
+            std::env::remove_var(CNB_MIRROR_ENV);
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn returns_none_when_no_vars_set() {
+        clear_all_envs();
+        assert_eq!(release_base_url_from_env("1.0.0"), None);
+    }
+
+    #[test]
+    #[serial]
+    fn prefers_primary_release_base_url() {
+        clear_all_envs();
+        unsafe {
+            std::env::set_var(RELEASE_BASE_URL_ENV, "https://primary.example.com");
+            std::env::set_var(LEGACY_RELEASE_BASE_URL_ENV, "https://legacy.example.com");
+        }
+        assert_eq!(
+            release_base_url_from_env("1.0.0"),
+            Some("https://primary.example.com".to_string())
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn falls_back_to_legacy_vars() {
+        clear_all_envs();
+        unsafe {
+            std::env::set_var(LEGACY_RELEASE_BASE_URL_ENV, "https://legacy.example.com");
+            std::env::set_var(DEEPSEEK_RELEASE_BASE_URL_ENV, "https://deepseek.example.com");
+        }
+        assert_eq!(
+            release_base_url_from_env("1.0.0"),
+            Some("https://legacy.example.com".to_string())
+        );
+
+        clear_all_envs();
+        unsafe {
+            std::env::set_var(DEEPSEEK_RELEASE_BASE_URL_ENV, "https://deepseek.example.com");
+        }
+        assert_eq!(
+            release_base_url_from_env("1.0.0"),
+            Some("https://deepseek.example.com".to_string())
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn trims_whitespace_from_env_vars() {
+        clear_all_envs();
+        unsafe {
+            std::env::set_var(RELEASE_BASE_URL_ENV, "  https://spaced.example.com  \n");
+        }
+        assert_eq!(
+            release_base_url_from_env("1.0.0"),
+            Some("https://spaced.example.com".to_string())
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn ignores_empty_or_whitespace_only_vars() {
+        clear_all_envs();
+        unsafe {
+            std::env::set_var(RELEASE_BASE_URL_ENV, "   ");
+            std::env::set_var(LEGACY_RELEASE_BASE_URL_ENV, "");
+            std::env::set_var(DEEPSEEK_RELEASE_BASE_URL_ENV, "\n");
+        }
+        assert_eq!(release_base_url_from_env("1.0.0"), None);
+    }
+
+    #[test]
+    #[serial]
+    fn falls_back_to_cnb_mirror() {
+        clear_all_envs();
+        unsafe {
+            std::env::set_var(CNB_MIRROR_ENV, "1");
+        }
+        assert_eq!(
+            release_base_url_from_env("v1.2.3"),
+            Some("https://cnb.cool/Hmbown/CodeWhale/-/releases/v1.2.3".to_string())
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn explicit_url_overrides_cnb_mirror() {
+        clear_all_envs();
+        unsafe {
+            std::env::set_var(RELEASE_BASE_URL_ENV, "https://explicit.example.com");
+            std::env::set_var(CNB_MIRROR_ENV, "1");
+        }
+        assert_eq!(
+            release_base_url_from_env("1.0.0"),
+            Some("https://explicit.example.com".to_string())
+        );
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap for `release_base_url_from_env` in `crates/release/src/lib.rs` has been addressed. The function relies heavily on environment variables, making it tricky to test safely in concurrent test suites.
📊 **Coverage:** A new suite of test scenarios was added using `serial_test` and `unsafe` environment mutations to test:
- Falling back appropriately when variables are not set.
- Prioritizing `CODEWHALE_RELEASE_BASE_URL` over legacy variables.
- Using `CODEWHALE_USE_CNB_MIRROR` correctly.
- Trimming whitespace and ignoring empty string variables.
✨ **Result:** Enhanced test coverage guarantees deterministic resolution of release URL environments without flakiness.

---
*PR created automatically by Jules for task [202203644642355664](https://jules.google.com/task/202203644642355664) started by @Hmbown*