### PR TITLE
🧪 test: add ToolError::path_escape test

### DIFF
--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -559,4 +559,14 @@ mod tests {
             "Failed to validate input: missing required field 'path'"
         );
     }
+
+    #[test]
+    fn tool_error_path_escape_display() {
+        let path = std::path::PathBuf::from("../outside");
+        let err = ToolError::path_escape(path);
+        assert_eq!(
+            err.to_string(),
+            "Failed to resolve path '../outside': path escapes workspace"
+        );
+    }
 }


### PR DESCRIPTION
🎯 **What:** Added a unit test for the `ToolError::path_escape` constructor in `crates/tools/src/lib.rs`.
📊 **Coverage:** Tests that creating an error with this constructor yields the correct variant and formatted `to_string()` output.
✨ **Result:** Improved test coverage for `ToolError` constructors.

---
*PR created automatically by Jules for task [10954025978238734836](https://jules.google.com/task/10954025978238734836) started by @Hmbown*