### PR TITLE
🔒 Fix command injection in hooks by switching to direct execution

### DIFF
--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -2902,7 +2902,11 @@ mod tests {
     fn hook_gate_denies_with_exit_code_2() {
         use crate::hooks::{Hook, HookContext, HookEvent, HookExecutor, HooksConfig};
 
-        let deny_cmd = if cfg!(windows) { "exit /b 2" } else { "exit 2" };
+        let deny_cmd = if cfg!(windows) {
+            "cmd /c \"exit /b 2\""
+        } else {
+            "sh -c \"exit 2\""
+        };
         let config = HooksConfig {
             enabled: true,
             hooks: vec![Hook::new(HookEvent::ToolCallBefore, deny_cmd)],
@@ -2922,7 +2926,11 @@ mod tests {
     fn hook_gate_allows_with_exit_code_0() {
         use crate::hooks::{Hook, HookContext, HookEvent, HookExecutor, HooksConfig};
 
-        let allow_cmd = if cfg!(windows) { "exit /b 0" } else { "exit 0" };
+        let allow_cmd = if cfg!(windows) {
+            "cmd /c \"exit /b 0\""
+        } else {
+            "sh -c \"exit 0\""
+        };
         let config = HooksConfig {
             enabled: true,
             hooks: vec![Hook::new(HookEvent::ToolCallBefore, allow_cmd)],
@@ -2943,7 +2951,11 @@ mod tests {
     fn hook_gate_failure_exit_code_1_is_not_denial() {
         use crate::hooks::{Hook, HookContext, HookEvent, HookExecutor, HooksConfig};
 
-        let fail_cmd = if cfg!(windows) { "exit /b 1" } else { "exit 1" };
+        let fail_cmd = if cfg!(windows) {
+            "cmd /c \"exit /b 1\""
+        } else {
+            "sh -c \"exit 1\""
+        };
         let config = HooksConfig {
             enabled: true,
             hooks: vec![Hook::new(HookEvent::ToolCallBefore, fail_cmd)],
@@ -2981,9 +2993,9 @@ mod tests {
         use crate::hooks::{Hook, HookContext, HookEvent, HookExecutor, HooksConfig};
 
         let deny_cmd = if cfg!(windows) {
-            "echo Tool blocked by security policy & exit /b 2"
+            "cmd /c \"echo Tool blocked by security policy & exit /b 2\""
         } else {
-            "echo 'Tool blocked by security policy' && exit 2"
+            "sh -c \"echo 'Tool blocked by security policy' && exit 2\""
         };
         let config = HooksConfig {
             enabled: true,
@@ -3100,9 +3112,9 @@ mod tests {
         use crate::hooks::{Hook, HookContext, HookEvent, HookExecutor, HooksConfig};
 
         let deny_cmd = if cfg!(windows) {
-            r#"echo {"decision":"deny","reason":"blocked by project policy"}"#
+            r#"cmd /c "echo {"decision":"deny","reason":"blocked by project policy"}""#
         } else {
-            r#"echo '{"decision":"deny","reason":"blocked by project policy"}'"#
+            r#"sh -c "echo '{\"decision\":\"deny\",\"reason\":\"blocked by project policy\"}'""#
         };
         let config = HooksConfig {
             enabled: true,
@@ -3126,9 +3138,9 @@ mod tests {
         use crate::hooks::{Hook, HookContext, HookEvent, HookExecutor, HooksConfig};
 
         let ask_cmd = if cfg!(windows) {
-            r#"echo {"decision":"ask"}"#
+            r#"cmd /c "echo {"decision":"ask"}""#
         } else {
-            r#"echo '{"decision":"ask"}'"#
+            r#"sh -c "echo '{\"decision\":\"ask\"}'""#
         };
         let config = HooksConfig {
             enabled: true,

--- a/crates/tui/src/hooks.rs
+++ b/crates/tui/src/hooks.rs
@@ -117,7 +117,7 @@ pub struct Hook {
     /// The event that triggers this hook
     pub event: HookEvent,
 
-    /// Shell command to execute (platform shell: `sh -c` on Unix, `cmd /C` on Windows)
+    /// Command to execute (parsed with shlex to avoid shell injection vulnerabilities)
     pub command: String,
 
     /// Optional condition for when this hook should run
@@ -623,22 +623,17 @@ pub struct HookExecutor {
 }
 
 impl HookExecutor {
-    fn build_shell_command(command: &str) -> Command {
-        #[cfg(windows)]
-        {
-            use std::os::windows::process::CommandExt as _;
-            let mut cmd = Command::new("cmd");
-            // raw_arg: cmd.exe does not parse the CRT-style \" escapes that
-            // Command::arg would insert, so pass the command line verbatim.
-            cmd.arg("/C").raw_arg(command);
-            cmd
+    fn build_shell_command(command: &str) -> Option<Command> {
+        // We use shlex on all platforms to parse the command string securely without a shell.
+        // This ensures cross-platform consistency and eliminates shell injection risks.
+        // Note: On Windows, paths with backslashes should be quoted or use forward slashes.
+        let tokens = shlex::split(command)?;
+        if tokens.is_empty() {
+            return None;
         }
-        #[cfg(not(windows))]
-        {
-            let mut cmd = Command::new("sh");
-            cmd.arg("-c").arg(command);
-            cmd
-        }
+        let mut cmd = Command::new(&tokens[0]);
+        cmd.args(&tokens[1..]);
+        Some(cmd)
     }
 
     /// Create a new `HookExecutor` with configuration
@@ -1086,7 +1081,20 @@ impl HookExecutor {
             }
         };
 
-        let mut command = Self::build_shell_command(&hook.command);
+        let mut command = match Self::build_shell_command(&hook.command) {
+            Some(cmd) => cmd,
+            None => {
+                return HookResult {
+                    name: hook.name.clone(),
+                    success: false,
+                    exit_code: None,
+                    stdout: String::new(),
+                    stderr: String::new(),
+                    duration: started.elapsed(),
+                    error: Some(format!("Failed to parse hook command: {}", hook.command)),
+                };
+            }
+        };
         command
             .current_dir(&working_dir)
             .envs(env_vars)
@@ -1207,7 +1215,9 @@ impl HookExecutor {
 
         // Spawn in a detached thread (fire-and-forget hook execution).
         std::thread::spawn(move || {
-            let mut command = HookExecutor::build_shell_command(&cmd);
+            let Some(mut command) = HookExecutor::build_shell_command(&cmd) else {
+                return;
+            };
             command
                 .current_dir(&wd)
                 .envs(&env)

--- a/test_shlex_json.rs
+++ b/test_shlex_json.rs
@@ -1,0 +1,5 @@
+fn main() {
+    let raw = r#"sh -c "echo '{\"decision\":\"deny\"}'""#;
+    let tokens = shlex::split(raw).unwrap();
+    println!("{:?}", tokens);
+}


### PR DESCRIPTION
This PR resolves a security vulnerability where hook commands were passed directly to a system shell (`sh -c` on Unix, `cmd /C` on Windows). Because these strings were passed unparsed, they allowed unintended shell metacharacter expansion and execution.

We migrated the `build_shell_command` logic to utilize the `shlex` crate. This tokenizes the configured `command` string into arguments safely, bypassing the shell completely and using `std::process::Command` directly with positional arguments. This change has been made uniformly for all platforms to guarantee consistent, strict quoting and tokenization behaviors across Unix and Windows environments. Tests covering hook payload formatting were updated to use shell abstractions internally where needed to retain behavior under direct execution.

---
*PR created automatically by Jules for task [18378925457158465128](https://jules.google.com/task/18378925457158465128) started by @Hmbown*