### PR TITLE
fix(exec): resolve --model auto via DEEPSEEK_MODEL env and reorder ExecArgs

### DIFF
--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -307,14 +307,6 @@ Plain `codewhale exec` is a one-shot model response. Use `--auto` for
 non-interactive filesystem/shell tool use.
 ")]
 struct ExecArgs {
-    /// Prompt to send to the model
-    #[arg(
-        value_name = "PROMPT",
-        required = true,
-        trailing_var_arg = true,
-        allow_hyphen_values = true
-    )]
-    prompt: Vec<String>,
     /// Override model for this run
     #[arg(long)]
     model: Option<String>,
@@ -349,6 +341,14 @@ struct ExecArgs {
     /// Extra text appended to the system prompt for this run.
     #[arg(long)]
     append_system_prompt: Option<String>,
+    /// Prompt to send to the model
+    #[arg(
+        value_name = "PROMPT",
+        required = true,
+        trailing_var_arg = true,
+        allow_hyphen_values = true
+    )]
+    prompt: Vec<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
@@ -460,11 +460,22 @@ fn join_prompt_parts(parts: &[String]) -> String {
 }
 
 fn resolve_exec_model(config: &Config, explicit_model: Option<&str>) -> String {
-    explicit_model
+    // The CLI dispatcher forwards --model via CODEWHALE_MODEL env var.
+    // ExecArgs.prompt has trailing_var_arg=true so --model is eaten as
+    // prompt text; prefer the env var when the explicit arg is absent.
+    if let Some(model) = explicit_model
         .map(str::trim)
-        .filter(|model| !model.is_empty())
-        .map(ToOwned::to_owned)
-        .unwrap_or_else(|| config.default_model())
+        .filter(|m| !m.is_empty())
+    {
+        return model.to_owned();
+    }
+    if let Ok(env_model) = std::env::var("DEEPSEEK_MODEL") {
+        let trimmed = env_model.trim();
+        if !trimmed.is_empty() {
+            return trimmed.to_owned();
+        }
+    }
+    config.default_model()
 }
 
 fn top_level_prompt_initial_input(parts: &[String]) -> Option<tui::InitialInput> {

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -463,10 +463,7 @@ fn resolve_exec_model(config: &Config, explicit_model: Option<&str>) -> String {
     // The CLI dispatcher forwards --model via CODEWHALE_MODEL env var.
     // ExecArgs.prompt has trailing_var_arg=true so --model is eaten as
     // prompt text; prefer the env var when the explicit arg is absent.
-    if let Some(model) = explicit_model
-        .map(str::trim)
-        .filter(|m| !m.is_empty())
-    {
+    if let Some(model) = explicit_model.map(str::trim).filter(|m| !m.is_empty()) {
         return model.to_owned();
     }
     if let Ok(env_model) = std::env::var("DEEPSEEK_MODEL") {


### PR DESCRIPTION
## Summary

`codewhale exec --model auto` never triggers auto-routing because `ExecArgs.prompt` has `trailing_var_arg=true`, which causes clap to consume `--model auto` as prompt text. The model falls back to `config.default_model()` (e.g. `deepseek-reasoner` for wanjie-ark).

## Root cause

Two issues:

1. **Field ordering**: `prompt` field appears before named args in `ExecArgs`, so clap parses it first and `trailing_var_arg` eats everything after it.

2. **Missing env fallback**: The CLI dispatcher (`codewhale` binary) forwards `--model` via `DEEPSEEK_MODEL` env var to the TUI binary, but `resolve_exec_model` doesn't read it.

## Fix

1. Move `prompt` to the end of `ExecArgs` so named args are parsed first (improves help output and partial parsing).

2. In `resolve_exec_model`, fall back to `DEEPSEEK_MODEL` env var when the explicit arg is absent.

## Verification

Tested with a local proxy capturing actual API requests to Volcengine Ark Agent Plan:

```
codewhale exec --model auto '只回复 OK'
→ model=deepseek-v4-flash ✅

codewhale exec --model auto '请帮我分析架构并实现重构方案...'
→ model=deepseek-v4-pro ✅
```

Without this fix, both requests would use `deepseek-reasoner` (the provider default), and `--model auto` would be silently ignored.