### PR TITLE
fix(SSE): accept SSE data lines without space after colon

### DIFF
--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -1536,6 +1536,12 @@ mod anthropic;
 mod chat;
 mod responses;
 
+/// Strip the SSE `data:` field prefix and its optional leading space.
+fn extract_sse_data_value(line: &str) -> Option<&str> {
+    line.strip_prefix("data:")
+        .map(|v| v.strip_prefix(' ').unwrap_or(v))
+}
+
 pub(crate) use chat::{CacheWarmupKey, PromptInspection};
 
 pub(crate) fn inspect_prompt_for_request(request: &MessageRequest) -> PromptInspection {
@@ -3891,5 +3897,33 @@ mod tests {
             api_url_with_suffix("https://api.deepseek.com", "chat/completions", None),
             "https://api.deepseek.com/v1/chat/completions"
         );
+    }
+
+    #[test]
+    fn extract_sse_data_value_with_space() {
+        assert_eq!(
+            extract_sse_data_value("data: {\"ok\":true}"),
+            Some("{\"ok\":true}")
+        );
+    }
+
+    #[test]
+    fn extract_sse_data_value_without_space() {
+        assert_eq!(
+            extract_sse_data_value("data:{\"ok\":true}"),
+            Some("{\"ok\":true}")
+        );
+    }
+
+    #[test]
+    fn extract_sse_data_value_done_marker() {
+        assert_eq!(extract_sse_data_value("data: [DONE]"), Some("[DONE]"));
+        assert_eq!(extract_sse_data_value("data:[DONE]"), Some("[DONE]"));
+    }
+
+    #[test]
+    fn extract_sse_data_value_non_data_line() {
+        assert_eq!(extract_sse_data_value("event: message"), None);
+        assert_eq!(extract_sse_data_value(": heartbeat"), None);
     }
 }

--- a/crates/tui/src/client/anthropic.rs
+++ b/crates/tui/src/client/anthropic.rs
@@ -205,7 +205,7 @@ impl DeepSeekClient {
 
                     // `event:` lines are redundant (the data payload carries
                     // `type`) and comment/heartbeat lines are ignorable.
-                    let Some(data) = line.strip_prefix("data: ") else {
+                    let Some(data) = super::extract_sse_data_value(&line) else {
                         continue;
                     };
 

--- a/crates/tui/src/client/chat.rs
+++ b/crates/tui/src/client/chat.rs
@@ -437,7 +437,7 @@ impl DeepSeekClient {
                         continue;
                     }
 
-                    if let Some(data) = line.strip_prefix("data: ") {
+                    if let Some(data) = super::extract_sse_data_value(&line) {
                         line_buf.push_str(data);
                     }
                     // Ignore other SSE fields (event:, id:, retry:)

--- a/crates/tui/src/client/responses.rs
+++ b/crates/tui/src/client/responses.rs
@@ -167,7 +167,7 @@ impl DeepSeekClient {
                         continue;
                     }
 
-                    if let Some(data) = line.strip_prefix("data: ") {
+                    if let Some(data) = super::extract_sse_data_value(&line) {
                         if data == "[DONE]" {
                             done = true;
                             break;


### PR DESCRIPTION
## Summary
Per the SSE spec (https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation), the space after the colon is optional. Providers are allowed to omit it, but the parser only matched `"data: "`, silently dropping all chunks and producing empty output when a provider sends `data:{...}`.

Extract `extract_sse_data_value()` to handle both `data: ` and `data:` uniformly across all three SSE stream parsers (chat, responses, anthropic).

## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address
