### PR TITLE
fix(cli): add missing verbosity field to ResolvedRuntimeOptions tests

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -3865,6 +3865,7 @@ mod tests {
             approval_policy: None,
             sandbox_mode: None,
             yolo: None,
+            verbosity: None,
             http_headers: std::collections::BTreeMap::new(),
         };
         let err = build_tui_command(&cli, &options, vec![]).unwrap_err();
@@ -3900,6 +3901,7 @@ mod tests {
             approval_policy: None,
             sandbox_mode: None,
             yolo: None,
+            verbosity: None,
             http_headers: std::collections::BTreeMap::new(),
         };
         let err = build_tui_command(&cli, &options, vec![]).unwrap_err();
@@ -3938,6 +3940,7 @@ mod tests {
             approval_policy: None,
             sandbox_mode: None,
             yolo: None,
+            verbosity: None,
             http_headers: std::collections::BTreeMap::new(),
         };
         let cmd = build_tui_command(&cli, &options, vec![]).expect("should graceful fallback");


### PR DESCRIPTION
Fixes a compile error in codewhale-cli tests caused by the new verbosity field in ResolvedRuntimeOptions. Unblocks CI for all open PRs.